### PR TITLE
feat: add research agent with providers, budget, and MCP tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "cmd=$(jq -r '.tool_input.command'); if echo \"$cmd\" | grep -qE 'git push.*(--force|-f)'; then echo '{\"decision\": \"block\", \"reason\": \"Force push is destructive. Use --force-with-lease or ask the user first.\"}'; else echo '{\"decision\": \"approve\"}'; fi",
+						"command": "cmd=$(jq -r '.tool_input.command'); if echo \"$cmd\" | grep -qE 'git push.*(--force-with-lease)'; then echo '{\"decision\": \"approve\"}'; elif echo \"$cmd\" | grep -qE 'git push.*(--force|-f)'; then echo '{\"decision\": \"block\", \"reason\": \"Force push is destructive. Use --force-with-lease or ask the user first.\"}'; else echo '{\"decision\": \"approve\"}'; fi",
 						"if": "Bash(git push*)"
 					}
 				]

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,29 @@ STORAGE_BUCKET=engranatge-recordings
 # Transcription provider (speech-to-text)
 TRANSCRIPTION_API_KEY=
 
+# ── Research capability providers (§18 of docs/backend-research.md) ──
+# Each is required, no auto/fallback. Boot fails if unset.
+# Local dev defaults to stub (zero cost, deterministic fake data).
+RESEARCH_SEARCH_PROVIDER=stub
+RESEARCH_SCRAPE_PROVIDER=stub
+RESEARCH_EXTRACT_PROVIDER=stub
+RESEARCH_DISCOVER_PROVIDER=stub
+RESEARCH_REGISTRY_PROVIDER_ES=stub
+RESEARCH_REPORT_PROVIDER_ES=stub
+
+# Provider API keys (only needed for the selected providers above)
+# FIRECRAWL_API_KEY=fc-...
+# BRAVE_SEARCH_API_KEY=BSA...
+# EINFORMA_API_KEY=...
+
+# ── Research LLM inference (for agent loop) ────────────────────────────
+# stub = deterministic fake output, zero cost. For real LLM locally,
+# use groq with a free-tier key and qwen/qwen3-32b.
+RESEARCH_LLM_PROVIDER=stub
+# RESEARCH_LLM_MODEL=qwen/qwen3-32b
+# RESEARCH_LLM_API_KEY=gsk_...
+# RESEARCH_LLM_BASE_URL=
+
 # Server
 PORT=3010
 NODE_ENV=development

--- a/.env.example.github
+++ b/.env.example.github
@@ -63,3 +63,23 @@ STORAGE_BUCKET=engranatge-recordings                        # [env-var]
 
 # Email provider runtime layer
 EMAIL_PROVIDER=agentmail                                    # [env-var]
+
+# ── Research Capability Providers ───────────────────────────────────────
+# Required, no defaults — boot fails if unset.
+RESEARCH_SEARCH_PROVIDER=brave                              # [env-var]
+RESEARCH_SCRAPE_PROVIDER=firecrawl                          # [env-var]
+RESEARCH_EXTRACT_PROVIDER=firecrawl                         # [env-var]
+RESEARCH_DISCOVER_PROVIDER=firecrawl                        # [env-var]
+RESEARCH_REGISTRY_PROVIDER_ES=librebor                      # [env-var]
+RESEARCH_REPORT_PROVIDER_ES=none                            # [env-var]
+
+# Provider API keys (only needed for the providers selected above)
+BRAVE_SEARCH_API_KEY=BSA...                                 # [env-secret]
+FIRECRAWL_API_KEY=fc-...                                    # [env-secret]
+# EINFORMA_API_KEY=                                         # [env-secret] (when report=einforma)
+
+# ── Research LLM Inference ─────────────────────────────────────────────
+RESEARCH_LLM_PROVIDER=nebius                                # [env-var]
+RESEARCH_LLM_MODEL=Qwen/Qwen3-32B                          # [env-var]
+RESEARCH_LLM_API_KEY=...                                    # [env-secret]
+# RESEARCH_LLM_BASE_URL=                                    # [env-var] (only for custom provider)

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -118,6 +118,17 @@ jobs:
                 -e EMAIL_API_KEY="${{ secrets.EMAIL_API_KEY }}" \
                 -e EMAIL_WEBHOOK_SECRET="${{ secrets.EMAIL_WEBHOOK_SECRET }}" \
                 -e EMAIL_PROVIDER="${{ vars.EMAIL_PROVIDER }}" \
+                -e RESEARCH_SEARCH_PROVIDER="${{ vars.RESEARCH_SEARCH_PROVIDER }}" \
+                -e RESEARCH_SCRAPE_PROVIDER="${{ vars.RESEARCH_SCRAPE_PROVIDER }}" \
+                -e RESEARCH_EXTRACT_PROVIDER="${{ vars.RESEARCH_EXTRACT_PROVIDER }}" \
+                -e RESEARCH_DISCOVER_PROVIDER="${{ vars.RESEARCH_DISCOVER_PROVIDER }}" \
+                -e RESEARCH_REGISTRY_PROVIDER_ES="${{ vars.RESEARCH_REGISTRY_PROVIDER_ES }}" \
+                -e RESEARCH_REPORT_PROVIDER_ES="${{ vars.RESEARCH_REPORT_PROVIDER_ES }}" \
+                -e BRAVE_SEARCH_API_KEY="${{ secrets.BRAVE_SEARCH_API_KEY }}" \
+                -e FIRECRAWL_API_KEY="${{ secrets.FIRECRAWL_API_KEY }}" \
+                -e RESEARCH_LLM_PROVIDER="${{ vars.RESEARCH_LLM_PROVIDER }}" \
+                -e RESEARCH_LLM_MODEL="${{ vars.RESEARCH_LLM_MODEL }}" \
+                -e RESEARCH_LLM_API_KEY="${{ secrets.RESEARCH_LLM_API_KEY }}" \
                 .
             else
               kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
@@ -140,6 +151,17 @@ jobs:
                 -e EMAIL_API_KEY="${{ secrets.EMAIL_API_KEY }}" \
                 -e EMAIL_WEBHOOK_SECRET="${{ secrets.EMAIL_WEBHOOK_SECRET }}" \
                 -e EMAIL_PROVIDER="${{ vars.EMAIL_PROVIDER }}" \
+                -e RESEARCH_SEARCH_PROVIDER="${{ vars.RESEARCH_SEARCH_PROVIDER }}" \
+                -e RESEARCH_SCRAPE_PROVIDER="${{ vars.RESEARCH_SCRAPE_PROVIDER }}" \
+                -e RESEARCH_EXTRACT_PROVIDER="${{ vars.RESEARCH_EXTRACT_PROVIDER }}" \
+                -e RESEARCH_DISCOVER_PROVIDER="${{ vars.RESEARCH_DISCOVER_PROVIDER }}" \
+                -e RESEARCH_REGISTRY_PROVIDER_ES="${{ vars.RESEARCH_REGISTRY_PROVIDER_ES }}" \
+                -e RESEARCH_REPORT_PROVIDER_ES="${{ vars.RESEARCH_REPORT_PROVIDER_ES }}" \
+                -e BRAVE_SEARCH_API_KEY="${{ secrets.BRAVE_SEARCH_API_KEY }}" \
+                -e FIRECRAWL_API_KEY="${{ secrets.FIRECRAWL_API_KEY }}" \
+                -e RESEARCH_LLM_PROVIDER="${{ vars.RESEARCH_LLM_PROVIDER }}" \
+                -e RESEARCH_LLM_MODEL="${{ vars.RESEARCH_LLM_MODEL }}" \
+                -e RESEARCH_LLM_API_KEY="${{ secrets.RESEARCH_LLM_API_KEY }}" \
                 .
             fi
 

--- a/apps/cli/src/commands/seed.ts
+++ b/apps/cli/src/commands/seed.ts
@@ -136,23 +136,23 @@ const COMPANIES = [
 		nextAction: 'Presentar proposta automatització',
 	},
 	{
-		slug: 'botiga-la-rambla',
-		name: 'Botiga La Rambla',
+		slug: 'bright-lane-boutique',
+		name: 'Bright Lane Boutique',
 		status: 'meeting',
 		industry: 'retail',
 		sizeRange: '1-5',
 		region: 'cat',
-		location: 'Igualada',
+		location: 'Barcelona',
 		source: 'instagram',
 		priority: 2,
-		email: 'hola@botigalarambla.cat',
+		email: 'hello@brightlane.cat',
 		phone: '+34 938 777 222',
-		instagram: '@botigalarambla',
+		instagram: '@brightlanebcn',
 		productsFit: ['ecommerce-local', 'web-starter'],
-		tags: ['moda', 'anoia'],
-		painPoints: 'Volen vendre online però no saben per on començar.',
+		tags: ['fashion', 'barcelona'],
+		painPoints: 'Want to sell online but unsure where to start.',
 		currentTools: 'Instagram direct',
-		nextAction: 'Reunió demo ecommerce',
+		nextAction: 'Schedule ecommerce demo',
 	},
 	{
 		slug: 'electricitat-del-valles',
@@ -189,8 +189,8 @@ const COMPANIES = [
 		tags: ['obrador', 'berguedà'],
 	},
 	{
-		slug: 'transport-maresme',
-		name: 'Transport Maresme SL',
+		slug: 'coastal-freight',
+		name: 'Coastal Freight SL',
 		status: 'responded',
 		industry: 'transport',
 		sizeRange: '11-25',
@@ -198,14 +198,14 @@ const COMPANIES = [
 		location: 'Mataró',
 		source: 'exa',
 		priority: 2,
-		website: 'https://transportmaresme.com',
-		email: 'logistica@transportmaresme.com',
+		website: 'https://coastalfreight.es',
+		email: 'ops@coastalfreight.es',
 		phone: '+34 937 888 999',
 		productsFit: ['automatitzacions'],
-		tags: ['logística', 'maresme'],
-		painPoints: 'Albarans en paper, difícil traçabilitat.',
+		tags: ['logistics', 'maresme'],
+		painPoints: 'Paper-based delivery notes, hard to trace shipments.',
 		currentTools: 'Paper + fax',
-		nextAction: 'Trucada de seguiment',
+		nextAction: 'Follow-up call',
 	},
 	{
 		slug: 'hostal-pirineu',
@@ -228,8 +228,8 @@ const COMPANIES = [
 		nextAction: 'Demo sistema de reserves',
 	},
 	{
-		slug: 'fruites-valencia',
-		name: 'Fruites València',
+		slug: 'distribuciones-martinez',
+		name: 'Distribuciones Martínez',
 		status: 'contacted',
 		industry: 'distribució',
 		sizeRange: '26-50',
@@ -237,17 +237,17 @@ const COMPANIES = [
 		location: 'Alzira',
 		source: 'manual',
 		priority: 2,
-		website: 'https://fruitesvalencia.es',
-		email: 'vendes@fruitesvalencia.es',
+		website: 'https://dismartinez.es',
+		email: 'ventas@dismartinez.es',
 		phone: '+34 962 441 555',
 		productsFit: ['automatitzacions', 'ecommerce-local'],
 		tags: ['agroalimentari', 'ribera'],
-		painPoints: 'Comandes per telèfon, fulls de ruta manuals.',
+		painPoints: 'Pedidos por teléfono, hojas de ruta manuales.',
 		currentTools: 'WhatsApp + Excel',
 	},
 	{
-		slug: 'disseny-eixample',
-		name: 'Disseny Eixample',
+		slug: 'park-stone-design',
+		name: 'Park & Stone Design',
 		status: 'dead',
 		industry: 'serveis',
 		sizeRange: '1-5',
@@ -255,11 +255,11 @@ const COMPANIES = [
 		location: 'Barcelona',
 		source: 'linkedin',
 		priority: 3,
-		email: 'hola@dissenyeixample.com',
-		instagram: '@dissenyeixample',
+		email: 'hello@parkstonedesign.com',
+		instagram: '@parkstonedesign',
 		productsFit: ['web-starter'],
-		tags: ['disseny', 'barcelona'],
-		painPoints: 'Ja tenien proveïdor web.',
+		tags: ['design', 'barcelona'],
+		painPoints: 'Already had a web provider.',
 	},
 	{
 		slug: 'ceramiques-emporda',
@@ -327,12 +327,12 @@ const getPresetData = (
 			emailStatusReason: 'Permanent/General',
 		},
 		{
-			companyId: companyMap.get('botiga-la-rambla')!,
-			name: 'Laia Font',
-			role: 'Propietària',
+			companyId: companyMap.get('bright-lane-boutique')!,
+			name: 'Sarah Mitchell',
+			role: 'Owner',
 			isDecisionMaker: true,
-			email: 'hola@botigalarambla.cat',
-			instagram: '@laiafont',
+			email: 'hello@brightlane.cat',
+			instagram: '@sarahm_bcn',
 		},
 		{
 			companyId: companyMap.get('hostal-pirineu')!,
@@ -343,11 +343,11 @@ const getPresetData = (
 			phone: '+34 674 551 234',
 		},
 		{
-			companyId: companyMap.get('transport-maresme')!,
-			name: 'Ramon Vidal',
-			role: 'Cap de Logística',
+			companyId: companyMap.get('coastal-freight')!,
+			name: 'Tom Parker',
+			role: 'Head of Logistics',
 			isDecisionMaker: false,
-			email: 'logistica@transportmaresme.com',
+			email: 'ops@coastalfreight.es',
 			phone: '+34 637 888 999',
 		},
 	]
@@ -405,17 +405,16 @@ const getPresetData = (
 			nextAction: 'Reunió presencial a la fàbrica',
 		},
 		{
-			companyId: companyMap.get('botiga-la-rambla')!,
-			contactId: contactMap.get('Laia Font'),
+			companyId: companyMap.get('bright-lane-boutique')!,
+			contactId: contactMap.get('Sarah Mitchell'),
 			date: new Date('2026-03-20'),
 			channel: 'instagram',
 			direction: 'inbound',
 			type: 'cold',
-			subject: 'DM per Instagram',
-			summary:
-				'Laia ens va escriure per Instagram preguntant per botigues online.',
+			subject: 'Instagram DM',
+			summary: 'Sarah reached out on Instagram asking about online shops.',
 			outcome: 'interested',
-			nextAction: 'Programar demo ecommerce',
+			nextAction: 'Schedule ecommerce demo',
 		},
 		{
 			companyId: companyMap.get('hostal-pirineu')!,
@@ -432,17 +431,17 @@ const getPresetData = (
 			nextAction: 'Preparar demo online',
 		},
 		{
-			companyId: companyMap.get('transport-maresme')!,
-			contactId: contactMap.get('Ramon Vidal'),
+			companyId: companyMap.get('coastal-freight')!,
+			contactId: contactMap.get('Tom Parker'),
 			date: new Date('2026-03-25'),
 			channel: 'phone',
 			direction: 'inbound',
 			type: 'cold',
-			subject: 'Trucada entrant',
+			subject: 'Inbound call',
 			summary:
-				"Ramon ens va trucar després de veure'ns a un directori. Interessat en digitalitzar albarans.",
+				'Tom called after finding us in a directory. Interested in digitising delivery notes.',
 			outcome: 'responded',
-			nextAction: 'Enviar info automatitzacions',
+			nextAction: 'Send automation info pack',
 		},
 	]
 
@@ -456,11 +455,11 @@ const getPresetData = (
 			dueAt: new Date('2026-04-05'),
 		},
 		{
-			companyId: companyMap.get('botiga-la-rambla')!,
-			contactId: contactMap.get('Laia Font'),
+			companyId: companyMap.get('bright-lane-boutique')!,
+			contactId: contactMap.get('Sarah Mitchell'),
 			type: 'call',
-			title: 'Demo ecommerce per videocall',
-			notes: 'Mostrar plantilla retail + integració Instagram Shop.',
+			title: 'Ecommerce demo videocall',
+			notes: 'Show retail template + Instagram Shop integration.',
 			dueAt: new Date('2026-04-03'),
 		},
 		{
@@ -472,11 +471,11 @@ const getPresetData = (
 			dueAt: new Date('2026-04-02'),
 		},
 		{
-			companyId: companyMap.get('transport-maresme')!,
-			contactId: contactMap.get('Ramon Vidal'),
+			companyId: companyMap.get('coastal-freight')!,
+			contactId: contactMap.get('Tom Parker'),
 			type: 'email',
-			title: 'Enviar informació automatitzacions',
-			notes: "PDF amb casos d'ús logística + preus.",
+			title: 'Send automation info pack',
+			notes: 'PDF with logistics use cases + pricing.',
 			dueAt: new Date('2026-04-01'),
 		},
 		{
@@ -534,7 +533,7 @@ const getPresetData = (
 export const seedReset = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient
 	yield* Effect.logInfo('Truncating CRM tables...')
-	yield* sql`TRUNCATE companies, products, pages CASCADE`
+	yield* sql`TRUNCATE companies, products, pages, research_runs, sources, user_research_policy, provider_quotas, provider_usage CASCADE`
 })
 
 // ── Seed auth ─────────────────────────────────────────────
@@ -687,6 +686,28 @@ export const seed = (preset: Preset) =>
 		}
 		if (insertedTasks.length > 3) {
 			yield* Effect.logInfo(`  ... and ${insertedTasks.length - 3} more`)
+		}
+
+		// 6. Research policy
+		yield* Effect.logInfo('Seeding research policy...')
+		const [testUser] = yield* sql<{
+			id: string
+		}>`SELECT id FROM "user" WHERE email = ${TEST_USER.email} LIMIT 1`
+		if (testUser) {
+			yield* sql`INSERT INTO user_research_policy ${sql.insert([
+				{
+					userId: testUser.id,
+					budgetCents: 100,
+					paidBudgetCents: 500,
+					autoApprovePaidCents: 200,
+					paidMonthlyCapCents: 2000,
+				},
+			])} ON CONFLICT (user_id) DO NOTHING`
+			yield* Effect.logInfo(`  policy: user ${testUser.id}`)
+		} else {
+			yield* Effect.logInfo(
+				'  (skipped — auth user not found, run seed auth first)',
+			)
 		}
 
 		// Full preset extras
@@ -872,6 +893,7 @@ export const seed = (preset: Preset) =>
 			contacts: insertedContacts.length,
 			interactions: insertedInteractions.length,
 			tasks: insertedTasks.length,
+			researchPolicy: testUser ? 1 : 0,
 			documents: preset === 'full' ? 4 : 0,
 			proposals: preset === 'full' ? 2 : 0,
 			pages: preset === 'full' ? 2 : 0,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,7 @@
 		"@engranatge/auth": "workspace:*",
 		"@engranatge/controllers": "workspace:*",
 		"@engranatge/domain": "workspace:*",
+		"@engranatge/research": "workspace:*",
 		"agentmail": "^0.4.18",
 		"better-auth": "^1.5.6",
 		"effect": "4.0.0-beta.43",

--- a/apps/server/src/db/migrations/0003_research.ts
+++ b/apps/server/src/db/migrations/0003_research.ts
@@ -1,0 +1,172 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	// ── Subject row additions ──
+	yield* Effect.all([
+		sql`ALTER TABLE companies ADD COLUMN IF NOT EXISTS version int NOT NULL DEFAULT 0`,
+		sql`ALTER TABLE companies ADD COLUMN IF NOT EXISTS deleted_at timestamptz`,
+		sql`ALTER TABLE contacts ADD COLUMN IF NOT EXISTS version int NOT NULL DEFAULT 0`,
+		sql`ALTER TABLE contacts ADD COLUMN IF NOT EXISTS deleted_at timestamptz`,
+	])
+
+	// ── Core: research_runs ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS research_runs (
+			id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			parent_id               uuid REFERENCES research_runs(id) ON DELETE CASCADE,
+			kind                    text NOT NULL CHECK (kind IN ('leaf','group','followup')) DEFAULT 'leaf',
+
+			query                   text NOT NULL,
+			mode                    text NOT NULL DEFAULT 'deep',
+			schema_name             text,
+
+			status                  text NOT NULL CHECK (status IN ('queued','running','succeeded','failed','cancelled','deleted')),
+			context                 jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+			findings                jsonb NOT NULL DEFAULT '{}'::jsonb,
+			brief_md                text,
+
+			budget_cents            int NOT NULL DEFAULT 0,
+			paid_budget_cents       int NOT NULL DEFAULT 0,
+			cost_cents              int NOT NULL DEFAULT 0,
+			paid_cost_cents         int NOT NULL DEFAULT 0,
+			cost_breakdown          jsonb NOT NULL DEFAULT '{}'::jsonb,
+			quota_breakdown         jsonb NOT NULL DEFAULT '{}'::jsonb,
+			tokens_in               int NOT NULL DEFAULT 0,
+			tokens_out              int NOT NULL DEFAULT 0,
+			paid_policy             jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+			idempotency_key         text UNIQUE,
+			created_by              text NOT NULL,
+			created_at              timestamptz NOT NULL DEFAULT now(),
+			started_at              timestamptz,
+			completed_at            timestamptz,
+			updated_at              timestamptz NOT NULL DEFAULT now(),
+
+			tool_log                jsonb NOT NULL DEFAULT '[]'::jsonb
+		)
+	`
+
+	yield* Effect.all([
+		sql`CREATE INDEX IF NOT EXISTS research_runs_status_idx ON research_runs(status) WHERE status IN ('queued','running')`,
+		sql`CREATE INDEX IF NOT EXISTS research_runs_parent_idx ON research_runs(parent_id)`,
+		sql`CREATE INDEX IF NOT EXISTS research_runs_created_by_idx ON research_runs(created_by)`,
+	])
+
+	// ── Sources (globally deduped by url_hash) ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS sources (
+			id                text PRIMARY KEY,
+			kind              text NOT NULL CHECK (kind IN ('web','registry','archive','report')),
+			provider          text NOT NULL,
+			url               text NOT NULL,
+			url_hash          text NOT NULL UNIQUE,
+			domain            text NOT NULL,
+			title             text,
+			author            text,
+			published_at      timestamptz,
+			language          text,
+			first_fetched_at  timestamptz NOT NULL DEFAULT now(),
+			last_fetched_at   timestamptz NOT NULL DEFAULT now(),
+			content_hash      text NOT NULL,
+			content_ref       text
+		)
+	`
+
+	yield* sql`CREATE INDEX IF NOT EXISTS sources_domain_idx ON sources(domain)`
+
+	// ── Many-to-many: research_runs <-> sources ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS research_run_sources (
+			research_id  uuid NOT NULL REFERENCES research_runs(id) ON DELETE CASCADE,
+			source_id    text NOT NULL REFERENCES sources(id),
+			local_ref    text NOT NULL,
+			fetched_at   timestamptz NOT NULL DEFAULT now(),
+			cost_cents   int NOT NULL DEFAULT 0,
+			PRIMARY KEY (research_id, source_id)
+		)
+	`
+
+	// ── Polymorphic link: run <-> subject row ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS research_links (
+			research_id    uuid NOT NULL REFERENCES research_runs(id) ON DELETE CASCADE,
+			subject_table  text NOT NULL CHECK (subject_table IN ('companies','contacts')),
+			subject_id     uuid NOT NULL,
+			link_kind      text NOT NULL CHECK (link_kind IN ('input','finding')),
+			created_at     timestamptz NOT NULL DEFAULT now(),
+			PRIMARY KEY (research_id, subject_table, subject_id)
+		)
+	`
+
+	yield* sql`CREATE INDEX IF NOT EXISTS research_links_subject_idx ON research_links(subject_table, subject_id)`
+
+	// ── Paid-spend audit log ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS research_paid_spend (
+			id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			research_id      uuid NOT NULL REFERENCES research_runs(id) ON DELETE CASCADE,
+			user_id          text NOT NULL,
+			provider         text NOT NULL,
+			tool             text NOT NULL,
+			idempotency_key  text NOT NULL UNIQUE,
+			amount_cents     int NOT NULL,
+			quota_units      int,
+			quota_unit       text,
+			args             jsonb NOT NULL,
+			result_hash      text,
+			result_data      jsonb,
+			source_id        text REFERENCES sources(id),
+			auto_approved    boolean NOT NULL,
+			approved_by      text,
+			at               timestamptz NOT NULL DEFAULT now()
+		)
+	`
+
+	yield* sql`CREATE INDEX IF NOT EXISTS research_paid_spend_user_at_idx ON research_paid_spend(user_id, at DESC)`
+
+	// ── User-level spending policy ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS user_research_policy (
+			user_id                    text PRIMARY KEY,
+			budget_cents               int NOT NULL DEFAULT 100,
+			paid_budget_cents          int NOT NULL DEFAULT 500,
+			auto_approve_paid_cents    int NOT NULL DEFAULT 200,
+			paid_monthly_cap_cents     int NOT NULL DEFAULT 2000,
+			updated_at                 timestamptz NOT NULL DEFAULT now()
+		)
+	`
+
+	// ── Provider quota config ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS provider_quotas (
+			user_id          text NOT NULL,
+			provider         text NOT NULL,
+			billing_model    text NOT NULL CHECK (billing_model IN ('monthly_plan', 'pay_per_call')),
+			sync_mode        text NOT NULL CHECK (sync_mode IN ('api', 'manual')) DEFAULT 'manual',
+			quota_total      int NOT NULL,
+			quota_unit       text NOT NULL,
+			period_months    int NOT NULL DEFAULT 1,
+			period_anchor    date,
+			cents_per_unit   int NOT NULL DEFAULT 0,
+			warn_at_pct      int NOT NULL DEFAULT 80,
+			last_synced_at   timestamptz,
+			updated_at       timestamptz NOT NULL DEFAULT now(),
+			PRIMARY KEY (user_id, provider)
+		)
+	`
+
+	// ── Provider usage counter ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS provider_usage (
+			user_id          text NOT NULL,
+			provider         text NOT NULL,
+			period_start     date NOT NULL,
+			units_consumed   int NOT NULL DEFAULT 0,
+			PRIMARY KEY (user_id, provider, period_start)
+		)
+	`
+})

--- a/apps/server/src/handlers/research.ts
+++ b/apps/server/src/handlers/research.ts
@@ -1,0 +1,246 @@
+import { Effect, Stream } from 'effect'
+import { HttpApiBuilder } from 'effect/unstable/httpapi'
+
+import { ForjaApi, NotFound, SessionContext } from '@engranatge/controllers'
+import {
+	type CreateResearchInput,
+	ResearchService,
+	type SystemDefaults,
+} from '@engranatge/research'
+
+import { EnvVars } from '../lib/env'
+
+export const ResearchLive = HttpApiBuilder.group(
+	ForjaApi,
+	'research',
+	handlers =>
+		Effect.gen(function* () {
+			const svc = yield* ResearchService
+			const env = yield* EnvVars
+
+			const systemDefaults: SystemDefaults = {
+				budgetCents: env.RESEARCH_DEFAULT_BUDGET_CENTS,
+				paidBudgetCents: env.RESEARCH_DEFAULT_PAID_BUDGET_CENTS,
+				autoApprovePaidCents: env.RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS,
+				paidMonthlyCapCents: env.RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS,
+				hardCeiling: env.RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS,
+			}
+
+			return handlers
+				.handle('create', _ =>
+					Effect.gen(function* () {
+						const { userId } = yield* SessionContext
+						const input: CreateResearchInput = {
+							query: _.payload.query,
+							mode: _.payload.mode,
+							context: _.payload.context as CreateResearchInput['context'],
+							schemaName: _.payload.schema_name,
+							budgetCents: _.payload.budget_cents,
+							paidBudgetCents: _.payload.paid_budget_cents,
+							autoApprovePaidCents: _.payload.auto_approve_paid_cents,
+							confirm: _.payload.confirm,
+						}
+						return yield* svc.create(userId, input, systemDefaults)
+					}).pipe(Effect.orDie),
+				)
+				.handle('list', _ =>
+					Effect.gen(function* () {
+						const { userId } = yield* SessionContext
+						return yield* svc.list({
+							createdBy: _.query.created_by ?? userId,
+							status: _.query.status,
+							subjectTable: _.query.subject_table,
+							subjectId: _.query.subject_id,
+							since: _.query.since,
+							limit: _.query.limit,
+							offset: _.query.offset,
+						})
+					}).pipe(Effect.orDie),
+				)
+				.handle('get', _ =>
+					Effect.gen(function* () {
+						const run = yield* svc.get(_.params.id)
+						if (!run)
+							return yield* new NotFound({
+								entity: 'research',
+								id: _.params.id,
+							})
+						return run
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
+				)
+				.handle('events', _ =>
+					Effect.gen(function* () {
+						// Check the run exists
+						const run = yield* svc.get(_.params.id)
+						if (!run)
+							return yield* new NotFound({
+								entity: 'research',
+								id: _.params.id,
+							})
+
+						const status = (run as { status: string }).status
+
+						// If already terminal, return final state immediately
+						if (
+							['succeeded', 'failed', 'cancelled', 'deleted'].includes(status)
+						) {
+							return {
+								status,
+								events: [
+									{
+										type: `run.${status}`,
+										researchId: _.params.id,
+										timestamp:
+											(run as { completedAt: string | null }).completedAt ??
+											new Date().toISOString(),
+										data: {},
+									},
+								],
+								done: true,
+							}
+						}
+
+						// Long-poll: subscribe and collect events for up to 30s
+						const stream = yield* svc.subscribe(_.params.id)
+						if (!stream) {
+							// No active PubSub — run may have completed between check and subscribe
+							return { status, events: [], done: false }
+						}
+
+						const events: unknown[] = []
+						yield* stream.pipe(
+							Stream.takeUntil(
+								evt =>
+									evt.type === 'run.succeeded' ||
+									evt.type === 'run.failed' ||
+									evt.type === 'run.cancelled',
+							),
+							Stream.tap(evt =>
+								Effect.sync(() => {
+									events.push(evt)
+								}),
+							),
+							Stream.runDrain,
+							Effect.timeout('30 seconds'),
+							Effect.catch(() => Effect.void),
+						)
+
+						return {
+							status:
+								events.length > 0
+									? (
+											events[events.length - 1] as { type: string }
+										).type.replace('run.', '')
+									: status,
+							events,
+							done: events.some(e =>
+								['run.succeeded', 'run.failed', 'run.cancelled'].includes(
+									(e as { type: string }).type,
+								),
+							),
+						}
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
+				)
+				.handle('cancel', _ =>
+					Effect.gen(function* () {
+						yield* svc.cancel(_.params.id)
+						return { status: 'cancelled' }
+					}).pipe(Effect.orDie),
+				)
+				.handle('attach', _ =>
+					Effect.gen(function* () {
+						yield* svc.attach(
+							_.params.id,
+							_.payload.subject_table,
+							_.payload.subject_id,
+						)
+						return { status: 'attached' }
+					}).pipe(Effect.orDie),
+				)
+				.handle('delete', _ =>
+					Effect.gen(function* () {
+						yield* svc.softDelete(_.params.id)
+						return { status: 'deleted' }
+					}).pipe(Effect.orDie),
+				)
+				.handle('bySubject', _ =>
+					svc.bySubject(_.params.table, _.params.subjectId).pipe(Effect.orDie),
+				)
+				.handle('approvePaidAction', _ =>
+					// Follow-up run mechanic — creates a new
+					// kind='followup' run with the approved action.
+					// Placeholder for now.
+					Effect.succeed({
+						status: 'approved',
+						followup_run_id: null,
+					}),
+				)
+				.handle('skipPaidAction', _ =>
+					Effect.succeed({
+						status: 'skipped',
+					}),
+				)
+				.handle('listProposedUpdates', _ =>
+					Effect.gen(function* () {
+						const run = yield* svc.get(_.params.id)
+						if (!run)
+							return yield* new NotFound({
+								entity: 'research',
+								id: _.params.id,
+							})
+						const findings = (run as { findings: unknown }).findings as {
+							proposed_updates?: unknown[]
+						}
+						return findings?.proposed_updates ?? []
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
+				)
+				.handle('applyProposedUpdate', _ =>
+					// Fires the domain update endpoint with OCC.
+					// Placeholder for now.
+					Effect.succeed({ status: 'applied' }),
+				)
+				.handle('rejectProposedUpdate', _ =>
+					Effect.succeed({ status: 'rejected' }),
+				)
+				.handle('getPolicy', _ =>
+					Effect.gen(function* () {
+						const { userId } = yield* SessionContext
+						const policy = yield* svc.getPolicy(userId)
+						return (
+							policy ?? {
+								budget_cents: systemDefaults.budgetCents,
+								paid_budget_cents: systemDefaults.paidBudgetCents,
+								auto_approve_paid_cents: systemDefaults.autoApprovePaidCents,
+								paid_monthly_cap_cents: systemDefaults.paidMonthlyCapCents,
+							}
+						)
+					}).pipe(Effect.orDie),
+				)
+				.handle('updatePolicy', _ =>
+					Effect.gen(function* () {
+						const { userId } = yield* SessionContext
+						return yield* svc.updatePolicy(userId, {
+							budgetCents: _.payload.budget_cents,
+							paidBudgetCents: _.payload.paid_budget_cents,
+							autoApprovePaidCents: _.payload.auto_approve_paid_cents,
+							paidMonthlyCapCents: _.payload.paid_monthly_cap_cents,
+						})
+					}).pipe(
+						Effect.map(rows => rows[0]),
+						Effect.orDie,
+					),
+				)
+		}),
+)

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -48,6 +48,86 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 			'EMAIL_PROVIDER',
 		)
 
+		// ── Research capability providers ──
+		// Each is explicit, no `auto` or fallback. Boot fails if unset.
+		const RESEARCH_SEARCH_PROVIDER = yield* Config.schema(
+			Schema.Literals(['stub', 'brave', 'firecrawl']),
+			'RESEARCH_SEARCH_PROVIDER',
+		)
+		const RESEARCH_SCRAPE_PROVIDER = yield* Config.schema(
+			Schema.Literals(['stub', 'firecrawl', 'local']),
+			'RESEARCH_SCRAPE_PROVIDER',
+		)
+		const RESEARCH_EXTRACT_PROVIDER = yield* Config.schema(
+			Schema.Literals(['stub', 'firecrawl', 'local']),
+			'RESEARCH_EXTRACT_PROVIDER',
+		)
+		const RESEARCH_DISCOVER_PROVIDER = yield* Config.schema(
+			Schema.Literals(['stub', 'firecrawl', 'anthropic', 'none']),
+			'RESEARCH_DISCOVER_PROVIDER',
+		)
+		const RESEARCH_REGISTRY_PROVIDER_ES = yield* Config.schema(
+			Schema.Literals(['stub', 'librebor', 'none']),
+			'RESEARCH_REGISTRY_PROVIDER_ES',
+		)
+		const RESEARCH_REPORT_PROVIDER_ES = yield* Config.schema(
+			Schema.Literals(['stub', 'einforma', 'none']),
+			'RESEARCH_REPORT_PROVIDER_ES',
+		)
+
+		// Budget defaults (system-level)
+		const RESEARCH_DEFAULT_BUDGET_CENTS = yield* Config.int(
+			'RESEARCH_DEFAULT_BUDGET_CENTS',
+		).pipe(Config.withDefault(100))
+		const RESEARCH_DEFAULT_PAID_BUDGET_CENTS = yield* Config.int(
+			'RESEARCH_DEFAULT_PAID_BUDGET_CENTS',
+		).pipe(Config.withDefault(500))
+		const RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS = yield* Config.int(
+			'RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS',
+		).pipe(Config.withDefault(200))
+		const RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS = yield* Config.int(
+			'RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS',
+		).pipe(Config.withDefault(2000))
+		const RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS = yield* Config.int(
+			'RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS',
+		).pipe(Config.withDefault(10000))
+
+		// Concurrency and safety
+		const RESEARCH_MAX_CONCURRENT_FIBERS_PER_USER = yield* Config.int(
+			'RESEARCH_MAX_CONCURRENT_FIBERS_PER_USER',
+		).pipe(Config.withDefault(3))
+		const RESEARCH_MAX_CONCURRENCY_FANOUT = yield* Config.int(
+			'RESEARCH_MAX_CONCURRENCY_FANOUT',
+		).pipe(Config.withDefault(3))
+		const RESEARCH_CONFIRM_THRESHOLD_FANOUT = yield* Config.int(
+			'RESEARCH_CONFIRM_THRESHOLD_FANOUT',
+		).pipe(Config.withDefault(10))
+
+		// Provider API keys (optional — only needed for selected providers)
+		const FIRECRAWL_API_KEY = yield* Config.option(
+			Config.redacted('FIRECRAWL_API_KEY'),
+		)
+		const BRAVE_SEARCH_API_KEY = yield* Config.option(
+			Config.redacted('BRAVE_SEARCH_API_KEY'),
+		)
+		const EINFORMA_API_KEY = yield* Config.option(
+			Config.redacted('EINFORMA_API_KEY'),
+		)
+
+		// LLM inference provider (for research agent loop)
+		const RESEARCH_LLM_PROVIDER = yield* Config.string(
+			'RESEARCH_LLM_PROVIDER',
+		).pipe(Config.withDefault('stub'))
+		const RESEARCH_LLM_MODEL = yield* Config.option(
+			Config.string('RESEARCH_LLM_MODEL'),
+		)
+		const RESEARCH_LLM_API_KEY = yield* Config.option(
+			Config.redacted('RESEARCH_LLM_API_KEY'),
+		)
+		const RESEARCH_LLM_BASE_URL = yield* Config.option(
+			Config.string('RESEARCH_LLM_BASE_URL'),
+		)
+
 		return {
 			DATABASE_URL,
 			PORT,
@@ -65,6 +145,27 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 			EMAIL_API_KEY,
 			EMAIL_WEBHOOK_SECRET,
 			EMAIL_PROVIDER,
+			RESEARCH_SEARCH_PROVIDER,
+			RESEARCH_SCRAPE_PROVIDER,
+			RESEARCH_EXTRACT_PROVIDER,
+			RESEARCH_DISCOVER_PROVIDER,
+			RESEARCH_REGISTRY_PROVIDER_ES,
+			RESEARCH_REPORT_PROVIDER_ES,
+			RESEARCH_DEFAULT_BUDGET_CENTS,
+			RESEARCH_DEFAULT_PAID_BUDGET_CENTS,
+			RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS,
+			RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS,
+			RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS,
+			RESEARCH_MAX_CONCURRENT_FIBERS_PER_USER,
+			RESEARCH_MAX_CONCURRENCY_FANOUT,
+			RESEARCH_CONFIRM_THRESHOLD_FANOUT,
+			FIRECRAWL_API_KEY,
+			BRAVE_SEARCH_API_KEY,
+			EINFORMA_API_KEY,
+			RESEARCH_LLM_PROVIDER,
+			RESEARCH_LLM_MODEL,
+			RESEARCH_LLM_API_KEY,
+			RESEARCH_LLM_BASE_URL,
 		} as const
 	}),
 }) {

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -10,6 +10,12 @@ import {
 import { HttpApiBuilder, HttpApiScalar, OpenApi } from 'effect/unstable/httpapi'
 
 import { ForjaApi } from '@engranatge/controllers'
+import {
+	makeResearchLlmLive,
+	makeResearchProvidersLive,
+	ResearchEventSink,
+	ResearchService,
+} from '@engranatge/research'
 
 import { PgLive } from './db/client'
 import { AgentMailWebhookLive } from './handlers/agentmail-webhook'
@@ -24,6 +30,7 @@ import { PagesLive } from './handlers/pages'
 import { ProductsLive } from './handlers/products'
 import { ProposalsLive } from './handlers/proposals'
 import { RecordingsLive } from './handlers/recordings'
+import { ResearchLive } from './handlers/research'
 import { TasksLive } from './handlers/tasks'
 import { WebhooksLive } from './handlers/webhooks'
 import { Auth } from './lib/auth'
@@ -57,7 +64,19 @@ const ApiLive = HttpApiBuilder.layer(ForjaApi).pipe(
 		EmailLive,
 		AgentMailWebhookLive,
 		RecordingsLive,
+		ResearchLive,
 	]),
+)
+
+// Wire research event sink → WebhookService
+const ResearchEventSinkLive = Layer.effect(
+	ResearchEventSink,
+	Effect.gen(function* () {
+		const webhooks = yield* WebhookService
+		return ResearchEventSink.of({
+			fire: (event, payload) => webhooks.fire(event, payload),
+		})
+	}),
 )
 
 const ServicesLive = Layer.mergeAll(
@@ -66,7 +85,11 @@ const ServicesLive = Layer.mergeAll(
 	PageService.layer,
 	EmailService.layer,
 	RecordingService.layer,
-).pipe(Layer.provideMerge(WebhookService.layer))
+	ResearchService.layer,
+).pipe(
+	Layer.provideMerge(ResearchEventSinkLive),
+	Layer.provideMerge(WebhookService.layer),
+)
 
 const ServerLive = Layer.unwrap(
 	Effect.gen(function* () {
@@ -180,6 +203,8 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(ServicesLive),
 	Layer.provide(EmailProviderLive),
 	Layer.provide(S3StorageProviderLive),
+	Layer.provide(makeResearchProvidersLive),
+	Layer.provide(makeResearchLlmLive),
 	Layer.provide(SessionMiddlewareLive),
 	Layer.provide(Auth.layer),
 	Layer.provide(EnvVars.layer),

--- a/apps/server/src/mcp/prompts/research-designer.ts
+++ b/apps/server/src/mcp/prompts/research-designer.ts
@@ -1,0 +1,38 @@
+import { Effect, Schema } from 'effect'
+import { McpServer } from 'effect/unstable/ai'
+
+import { schemaRegistry } from '@engranatge/research'
+
+import { LangParam, langDirective } from './_lang'
+
+export const ResearchDesignerPrompt = McpServer.prompt({
+	name: 'research-designer',
+	description:
+		'Help a user design a research query: choose a schema, set budget, phrase the question.',
+	parameters: {
+		topic: Schema.String,
+		lang: LangParam,
+	},
+	content: ({ topic, lang }) =>
+		Effect.gen(function* () {
+			const schemaNames = Object.keys(schemaRegistry)
+
+			return `${langDirective(lang)}
+
+You are helping design a research query for the Forja CRM research engine.
+
+**Topic:** ${topic}
+
+**Available schemas:**
+${schemaNames.map(name => `- \`${name}\``).join('\n')}
+
+Guide the user through:
+1. **Query phrasing** — write a clear, specific research query that will guide the AI agent
+2. **Schema selection** — which output schema fits best? Explain the trade-offs
+3. **Context** — should this be anchored to existing CRM rows? If so, which?
+4. **Budget** — estimate the likely cost tier (free registry, cheap web scraping, or paid reports)
+5. **Hints** — suggest language, recency, and location hints if relevant
+
+Output a ready-to-use JSON body for \`POST /research\`.`
+		}),
+})

--- a/apps/server/src/mcp/resources/research.ts
+++ b/apps/server/src/mcp/resources/research.ts
@@ -1,0 +1,21 @@
+import { Effect, Schema } from 'effect'
+import { McpSchema, McpServer } from 'effect/unstable/ai'
+
+import { ResearchService } from '@engranatge/research'
+
+const idParam = McpSchema.param('id', Schema.String)
+
+export const ResearchResource = McpServer.resource`forja://research/${idParam}`(
+	{
+		name: 'Research Run',
+		description:
+			'Full research run with findings, brief, sources, and tool log.',
+		mimeType: 'application/json',
+		audience: ['assistant'],
+		content: Effect.fn(function* (_uri, id) {
+			const svc = yield* ResearchService
+			const run = yield* svc.get(id)
+			return JSON.stringify(run, null, 2)
+		}),
+	},
+)

--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -5,9 +5,11 @@ import { CompanyResearchPrompt } from './prompts/company-research'
 import { DailyBriefingPrompt } from './prompts/daily-briefing'
 import { InteractionFollowUpPrompt } from './prompts/interaction-follow-up'
 import { ProposalDraftPrompt } from './prompts/proposal-draft'
+import { ResearchDesignerPrompt } from './prompts/research-designer'
 import { CompanyResource } from './resources/company'
 import { DocumentResource } from './resources/document'
 import { PipelineResource } from './resources/pipeline'
+import { ResearchResource } from './resources/research'
 import { CompanyHandlersLive, CompanyTools } from './tools/companies'
 import { ContactHandlersLive, ContactTools } from './tools/contacts'
 import { DocumentHandlersLive, DocumentTools } from './tools/documents'
@@ -16,6 +18,7 @@ import { InteractionHandlersLive, InteractionTools } from './tools/interactions'
 import { PageHandlersLive, PageTools } from './tools/pages'
 import { PipelineHandlersLive, PipelineTools } from './tools/pipeline'
 import { RecordingHandlersLive, RecordingTools } from './tools/recordings'
+import { ResearchMcpHandlersLive, ResearchMcpTools } from './tools/research-mcp'
 import { TaskHandlersLive, TaskTools } from './tools/tasks'
 
 export const McpToolsLive = Layer.mergeAll(
@@ -28,13 +31,16 @@ export const McpToolsLive = Layer.mergeAll(
 	McpServer.toolkit(PipelineTools),
 	McpServer.toolkit(EmailTools),
 	McpServer.toolkit(RecordingTools),
+	McpServer.toolkit(ResearchMcpTools),
 	CompanyResource,
 	PipelineResource,
 	DocumentResource,
+	ResearchResource,
 	CompanyResearchPrompt,
 	DailyBriefingPrompt,
 	ProposalDraftPrompt,
 	InteractionFollowUpPrompt,
+	ResearchDesignerPrompt,
 ).pipe(
 	Layer.provide(CompanyHandlersLive),
 	Layer.provide(ContactHandlersLive),
@@ -45,4 +51,5 @@ export const McpToolsLive = Layer.mergeAll(
 	Layer.provide(PipelineHandlersLive),
 	Layer.provide(EmailHandlersLive),
 	Layer.provide(RecordingHandlersLive),
+	Layer.provide(ResearchMcpHandlersLive),
 )

--- a/apps/server/src/mcp/tools/research-crm.ts
+++ b/apps/server/src/mcp/tools/research-crm.ts
@@ -1,0 +1,54 @@
+import { Effect, Schema } from 'effect'
+import { Tool, Toolkit } from 'effect/unstable/ai'
+
+import { CompanyService } from '../../services/companies'
+
+// ── crm_lookup ──
+// With `id`: get a single row. With `query`: search by name/fields.
+// Replaces separate search_companies + get_company + search_contacts + get_contact.
+
+const CrmLookup = Tool.make('crm_lookup', {
+	description:
+		"Look up existing CRM data. With 'id': get a single row. With 'query': search by name/fields. Use this to check if an entity already exists in the CRM before proposing new data.",
+	parameters: Schema.Struct({
+		table: Schema.Literals(['companies', 'contacts']),
+		query: Schema.optional(Schema.String),
+		id: Schema.optional(Schema.String),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'CRM Lookup')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+// ── Toolkit + handlers ──
+
+export const ResearchCrmTools = Toolkit.make(CrmLookup)
+
+export const ResearchCrmHandlersLive = ResearchCrmTools.toLayer(
+	Effect.gen(function* () {
+		const companies = yield* CompanyService
+
+		return {
+			crm_lookup: params =>
+				Effect.gen(function* () {
+					if (params.table === 'companies') {
+						if (params.id) {
+							return yield* companies
+								.findById(params.id)
+								.pipe(Effect.catchTag('NotFound', () => Effect.succeed(null)))
+						}
+						return yield* companies.search({
+							query: params.query,
+							limit: 10,
+						})
+					}
+					// contacts table — uses same SQL pattern
+					// For now, delegate to a direct SQL query since
+					// ContactService doesn't exist as a standalone service yet
+					return []
+				}).pipe(Effect.orDie),
+		}
+	}),
+)

--- a/apps/server/src/mcp/tools/research-mcp.ts
+++ b/apps/server/src/mcp/tools/research-mcp.ts
@@ -1,0 +1,137 @@
+import { Effect, Schema } from 'effect'
+import { Tool, Toolkit } from 'effect/unstable/ai'
+
+import { ResearchService, type SystemDefaults } from '@engranatge/research'
+
+import { EnvVars } from '../../lib/env'
+
+// ── start_research (async) ──
+
+const StartResearch = Tool.make('start_research', {
+	description:
+		'Start a research run. Returns an ID immediately — use get_research to poll for results. Best for long-running research where you want to do other work while waiting.',
+	parameters: Schema.Struct({
+		query: Schema.String,
+		context: Schema.optional(Schema.Unknown),
+		schema_name: Schema.optional(Schema.String),
+	}),
+	success: Schema.Struct({
+		id: Schema.String,
+		status: Schema.String,
+	}),
+})
+	.annotate(Tool.Title, 'Start Research')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+// ── get_research ──
+
+const GetResearch = Tool.make('get_research', {
+	description:
+		'Get the current state of a research run. Returns status, findings (if complete), cost, and sources.',
+	parameters: Schema.Struct({
+		id: Schema.String,
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Get Research')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+// ── research_sync (blocking) ──
+
+const ResearchSync = Tool.make('research_sync', {
+	description:
+		'Run research to completion and return full findings inline. Blocks until done or timeout. Best for short research that fits in a single tool call.',
+	parameters: Schema.Struct({
+		query: Schema.String,
+		context: Schema.optional(Schema.Unknown),
+		schema_name: Schema.optional(Schema.String),
+		max_wait_seconds: Schema.optional(Schema.Number),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Research (Sync)')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+// ── Toolkit + handlers ──
+
+export const ResearchMcpTools = Toolkit.make(
+	StartResearch,
+	GetResearch,
+	ResearchSync,
+)
+
+export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
+	Effect.gen(function* () {
+		const svc = yield* ResearchService
+		const env = yield* EnvVars
+
+		const systemDefaults: SystemDefaults = {
+			budgetCents: env.RESEARCH_DEFAULT_BUDGET_CENTS,
+			paidBudgetCents: env.RESEARCH_DEFAULT_PAID_BUDGET_CENTS,
+			autoApprovePaidCents: env.RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS,
+			paidMonthlyCapCents: env.RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS,
+			hardCeiling: env.RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS,
+		}
+
+		return {
+			start_research: params =>
+				Effect.gen(function* () {
+					// MCP calls use a system user for now
+					const userId = 'mcp-system'
+					const result = yield* svc.create(
+						userId,
+						{
+							query: params.query,
+							context: params.context as any,
+							schemaName: params.schema_name,
+						},
+						systemDefaults,
+					)
+					return result
+				}).pipe(Effect.orDie),
+
+			get_research: params =>
+				Effect.gen(function* () {
+					const run = yield* svc.get(params.id)
+					return run ?? { error: 'not found' }
+				}).pipe(Effect.orDie),
+
+			research_sync: params =>
+				Effect.gen(function* () {
+					const userId = 'mcp-system'
+					const { id } = yield* svc.create(
+						userId,
+						{
+							query: params.query,
+							context: params.context as any,
+							schemaName: params.schema_name,
+						},
+						systemDefaults,
+					)
+
+					// Poll until the run reaches a terminal status or we exceed
+					// the caller's timeout (default 2 minutes).
+					const maxWaitMs = (params.max_wait_seconds ?? 120) * 1000
+					const startedAt = Date.now()
+
+					let run = yield* svc.get(id)
+					while (
+						run &&
+						['queued', 'running'].includes(
+							(run as { status: string }).status,
+						) &&
+						Date.now() - startedAt < maxWaitMs
+					) {
+						yield* Effect.sleep('2 seconds')
+						run = yield* svc.get(id)
+					}
+
+					return run ?? { error: 'not found' }
+				}).pipe(Effect.orDie),
+		}
+	}),
+)

--- a/apps/server/src/mcp/tools/research-registry.ts
+++ b/apps/server/src/mcp/tools/research-registry.ts
@@ -1,0 +1,78 @@
+import { Effect, Schema } from 'effect'
+import { Tool, Toolkit } from 'effect/unstable/ai'
+
+import {
+	Budget,
+	ProviderQuota,
+	RegistryRouter,
+	ReportRouter,
+} from '@engranatge/research'
+
+// ── lookup_registry ──
+// One tool, two backends. depth='basic' → free registry (libreBORME).
+// depth='financials'|'full' → paid report (einforma), gated by budget.
+
+const LookupRegistry = Tool.make('lookup_registry', {
+	description:
+		"Look up a company in the official registry. With depth='basic' (default): free, returns legal name, NIF, capital, directors from libreBORME. With depth='financials' or 'full': paid report from einforma with detailed financials and risk scores. Always try basic first.",
+	parameters: Schema.Struct({
+		country: Schema.Literal('ES'),
+		query: Schema.optional(Schema.String),
+		tax_id: Schema.optional(Schema.String),
+		depth: Schema.optional(Schema.Literals(['basic', 'financials', 'full'])),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Lookup Registry')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+// ── Toolkit + handlers ──
+
+export const ResearchRegistryTools = Toolkit.make(LookupRegistry)
+
+export const ResearchRegistryHandlersLive = ResearchRegistryTools.toLayer(
+	Effect.gen(function* () {
+		const registry = yield* RegistryRouter
+		const report = yield* ReportRouter
+		const quota = yield* ProviderQuota
+		const budget = yield* Budget
+
+		return {
+			lookup_registry: params =>
+				Effect.gen(function* () {
+					const depth = params.depth ?? 'basic'
+
+					if (depth === 'basic') {
+						// Free registry (libreBORME) — no budget gate needed.
+						const result = yield* registry.lookup({
+							country: params.country,
+							query: params.query,
+							taxId: params.tax_id,
+						})
+						return result
+					}
+
+					// Paid report path — requires tax_id to identify the company.
+					if (!params.tax_id) {
+						return {
+							error: 'tax_id is required for financials/full depth',
+						}
+					}
+
+					// Einforma charges ~3 EUR per report. The budget gate prevents
+					// accidental spend; the LLM should try depth='basic' first.
+					yield* quota.check('einforma', 1)
+					yield* budget.chargePaid('einforma', 300)
+					const result = yield* report.report({
+						country: params.country,
+						taxId: params.tax_id,
+						depth,
+					})
+					yield* quota.consume('einforma', result.units)
+					return result
+				}).pipe(Effect.orDie),
+		}
+	}),
+)

--- a/apps/server/src/mcp/tools/research-sink.ts
+++ b/apps/server/src/mcp/tools/research-sink.ts
@@ -1,0 +1,178 @@
+import { Effect, Schema } from 'effect'
+import { Tool, Toolkit } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+
+import { ResearchRunContext } from '@engranatge/research'
+
+// ── propose_update ──
+// Writes to research_runs.findings.proposed_updates[], NEVER mutates domain rows.
+
+const ProposeUpdate = Tool.make('propose_update', {
+	description:
+		'Propose a field update for a CRM row. This does NOT modify the row — it records the proposal for human review. Always include citations for every proposed change.',
+	parameters: Schema.Struct({
+		subject_table: Schema.Literals(['companies', 'contacts']),
+		subject_id: Schema.String,
+		expected_version: Schema.Number,
+		fields: Schema.Unknown,
+		reason: Schema.String,
+		citations: Schema.Array(
+			Schema.Struct({
+				source_id: Schema.String,
+				quote: Schema.optional(Schema.String),
+			}),
+		),
+	}),
+	success: Schema.Struct({
+		status: Schema.String,
+	}),
+})
+	.annotate(Tool.Title, 'Propose Update')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+// ── attach_finding ──
+// Writes to research_links with link_kind='finding'. Idempotent.
+
+const AttachFinding = Tool.make('attach_finding', {
+	description:
+		"Link a CRM row to this research run as a finding. Use kind='already_in_db' for rows that match the query, 'discovered' for new entities, 'related' for tangential connections.",
+	parameters: Schema.Struct({
+		subject_table: Schema.Literals(['companies', 'contacts']),
+		subject_id: Schema.String,
+		kind: Schema.Literals(['already_in_db', 'discovered', 'related']),
+	}),
+	success: Schema.Struct({
+		status: Schema.String,
+	}),
+})
+	.annotate(Tool.Title, 'Attach Finding')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.Idempotent, true)
+	.annotate(Tool.OpenWorld, false)
+
+// ── propose_paid_action ──
+// Records the proposal and returns immediately. Human approves after the run.
+
+const ProposePaidAction = Tool.make('propose_paid_action', {
+	description:
+		'Propose a paid tool call that requires human approval. Call this instead of the paid tool directly when you receive an ApprovalRequired error. The research continues without the paid data — the human can approve after the run.',
+	parameters: Schema.Struct({
+		tool: Schema.String,
+		args: Schema.Unknown,
+		estimated_cents: Schema.Number,
+		reason: Schema.String,
+	}),
+	success: Schema.Struct({
+		status: Schema.String,
+	}),
+})
+	.annotate(Tool.Title, 'Propose Paid Action')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+// ── Toolkit + handlers ──
+
+export const ResearchSinkTools = Toolkit.make(
+	ProposeUpdate,
+	AttachFinding,
+	ProposePaidAction,
+)
+
+export const ResearchSinkHandlersLive = ResearchSinkTools.toLayer(
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const { researchId } = yield* ResearchRunContext
+
+		return {
+			propose_update: params =>
+				Effect.gen(function* () {
+					// Append to research_runs.findings.proposed_updates[]
+					yield* sql`
+						UPDATE research_runs
+						SET findings = jsonb_set(
+							findings,
+							'{proposed_updates}',
+							COALESCE(findings->'proposed_updates', '[]'::jsonb)
+								|| ${JSON.stringify([
+									{
+										subject_table: params.subject_table,
+										subject_id: params.subject_id,
+										expected_version: params.expected_version,
+										fields: params.fields,
+										reason: params.reason,
+										citations: params.citations,
+										status: 'pending',
+									},
+								])}::jsonb
+						),
+						updated_at = now()
+						WHERE id = ${researchId}
+					`
+
+					yield* Effect.logInfo('propose_update recorded').pipe(
+						Effect.annotateLogs({
+							research_id: researchId,
+							subject_table: params.subject_table,
+							subject_id: params.subject_id,
+						}),
+					)
+					return { status: 'proposed' }
+				}).pipe(Effect.orDie),
+
+			attach_finding: params =>
+				Effect.gen(function* () {
+					// Insert into research_links (idempotent)
+					yield* sql`
+						INSERT INTO research_links (research_id, subject_table, subject_id, link_kind)
+						VALUES (${researchId}, ${params.subject_table}, ${params.subject_id}, 'finding')
+						ON CONFLICT DO NOTHING
+					`
+
+					yield* Effect.logInfo('attach_finding recorded').pipe(
+						Effect.annotateLogs({
+							research_id: researchId,
+							subject_table: params.subject_table,
+							subject_id: params.subject_id,
+							kind: params.kind,
+						}),
+					)
+					return { status: 'attached' }
+				}).pipe(Effect.orDie),
+
+			propose_paid_action: params =>
+				Effect.gen(function* () {
+					// Append to research_runs.findings.pending_paid_actions[]
+					yield* sql`
+						UPDATE research_runs
+						SET findings = jsonb_set(
+							findings,
+							'{pending_paid_actions}',
+							COALESCE(findings->'pending_paid_actions', '[]'::jsonb)
+								|| ${JSON.stringify([
+									{
+										id: crypto.randomUUID(),
+										tool: params.tool,
+										args: params.args,
+										estimated_cents: params.estimated_cents,
+										reason: params.reason,
+										status: 'pending',
+									},
+								])}::jsonb
+						),
+						updated_at = now()
+						WHERE id = ${researchId}
+					`
+
+					yield* Effect.logInfo('propose_paid_action recorded').pipe(
+						Effect.annotateLogs({
+							research_id: researchId,
+							tool: params.tool,
+							estimated_cents: params.estimated_cents,
+						}),
+					)
+					return { status: 'proposed' }
+				}).pipe(Effect.orDie),
+		}
+	}),
+)

--- a/apps/server/src/mcp/tools/research-web.ts
+++ b/apps/server/src/mcp/tools/research-web.ts
@@ -1,0 +1,137 @@
+import { Effect, Schema } from 'effect'
+import { Tool, Toolkit } from 'effect/unstable/ai'
+
+import {
+	Budget,
+	DiscoverProvider,
+	ExtractProvider,
+	ProviderQuota,
+	ScrapeProvider,
+	SearchProvider,
+} from '@engranatge/research'
+
+// ── web_search ──
+
+const WebSearch = Tool.make('web_search', {
+	description:
+		'Search the web. Returns a list of URLs with titles and snippets. Use this as the first step to find information on a topic.',
+	parameters: Schema.Struct({
+		query: Schema.String,
+		limit: Schema.optional(Schema.Number),
+		recency_days: Schema.optional(Schema.Number),
+		location: Schema.optional(Schema.String),
+		languages: Schema.optional(Schema.Array(Schema.String)),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Web Search')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+// ── web_read ──
+
+const WebRead = Tool.make('web_read', {
+	description:
+		'Fetch a URL as markdown. Optionally pass a JSON schema to extract structured data instead of raw markdown. Use this to read the content of a page found via web_search.',
+	parameters: Schema.Struct({
+		url: Schema.String,
+		schema: Schema.optional(Schema.Unknown),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Web Read')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+// ── web_discover ──
+
+const WebDiscover = Tool.make('web_discover', {
+	description:
+		'Autonomous browsing: follows links, reasons over pages, returns findings. Expensive — only use when web_search + web_read cannot answer the question.',
+	parameters: Schema.Struct({
+		prompt: Schema.String,
+		urls: Schema.optional(Schema.Array(Schema.String)),
+		max_cost_cents: Schema.optional(Schema.Number),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Web Discover')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+// ── Toolkit + handlers ──
+
+export const ResearchWebTools = Toolkit.make(WebSearch, WebRead, WebDiscover)
+
+export const ResearchWebHandlersLive = ResearchWebTools.toLayer(
+	Effect.gen(function* () {
+		const search = yield* SearchProvider
+		const scrape = yield* ScrapeProvider
+		const extract = yield* ExtractProvider
+		const discover = yield* DiscoverProvider
+		const quota = yield* ProviderQuota
+		const budget = yield* Budget
+
+		return {
+			web_search: params =>
+				Effect.gen(function* () {
+					// Flow: quota check → budget charge → provider call → quota consume.
+					yield* quota.check('search', 1)
+					yield* budget.chargeCheap('search', 1) // 1 cent per search query
+					const result = yield* search.search({
+						query: params.query,
+						limit: params.limit,
+						recency: params.recency_days
+							? { days: params.recency_days }
+							: undefined,
+						location: params.location,
+						languages: params.languages ? [...params.languages] : undefined,
+					})
+					yield* quota.consume('search', result.units)
+					return result
+				}).pipe(Effect.orDie),
+
+			web_read: params =>
+				Effect.gen(function* () {
+					if (params.schema) {
+						// Structured extract costs 2x a plain scrape because the
+						// provider runs LLM inference to match the schema.
+						yield* quota.check('extract', 1)
+						yield* budget.chargeCheap('extract', 2)
+						const raw = yield* extract.extract({
+							url: params.url,
+							schema: params.schema as Schema.Top,
+						})
+						yield* quota.consume('extract', 1)
+						return raw
+					}
+					yield* quota.check('scrape', 1)
+					yield* budget.chargeCheap('scrape', 1) // 1 cent per page
+					const page = yield* scrape.scrape({
+						url: params.url,
+						formats: ['markdown'],
+					})
+					yield* quota.consume('scrape', page.units)
+					return page
+				}).pipe(Effect.orDie),
+
+			web_discover: params =>
+				Effect.gen(function* () {
+					// Autonomous browsing is expensive: charges 5 cents
+					// upfront because it spawns its own multi-page session.
+					yield* quota.check('discover', 5)
+					yield* budget.chargeCheap('discover', 5)
+					const result = yield* discover.discover({
+						prompt: params.prompt,
+						urls: params.urls ? [...params.urls] : undefined,
+						maxCostCents: params.max_cost_cents,
+					})
+					yield* quota.consume('discover', result.units)
+					return result
+				}).pipe(Effect.orDie),
+		}
+	}),
+)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,19 @@
 └─────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────┐
+│  Research providers (packages/research infrastructure)           │
+│  Selected at boot via RESEARCH_*_PROVIDER env vars               │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │ Brave Search │  │  Firecrawl   │  │  libreBORME/einforma │  │
+│  │  (web search)│  │ (scrape/ext) │  │  (ES registries)     │  │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘  │
+│  ┌──────────────────────────────────────────────────────────┐   ���
+│  │  LLM inference (Groq, Nebius, Fireworks, Together, etc.) │   │
+│  │  via @effect/ai-openai-compat (OpenAI-compatible API)    │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
 │  External automations                                            │
 │  ┌──────────────┐  ┌──────────────┐                            │
 │  │     n8n      │  │    Zapier    │  ← authenticate via API key │
@@ -117,6 +130,16 @@ Bounded context for authentication. Owns the Better-Auth config builder plus a s
 - `infrastructure/` — `buildBetterAuthConfig` (shared config builder), `makeBetterAuthAdapter` (pg + `betterAuth()` instance implementing the ports), scoped `acquirePgPool`
 
 The shared builder is why CLI-minted API keys validate against the running server: any drift in plugin list, prefix scheme, or rate-limit shape would break the apiKey plugin's verification path.
+
+### `packages/research`
+
+Bounded context for company research. Owns the research agent loop, provider port interfaces, budget/quota services, output schemas, and infrastructure implementations. Layered as:
+
+- `domain/` — tagged errors (`ProviderError`, `BudgetExceeded`, `MonthlyCapExceeded`, `QuotaExhausted`, `ApprovalRequired`) + value types (`SearchResult`, `ScrapedPage`, `DiscoverResult`, `RegistryRecord`, `CompanyReport`, etc.)
+- `application/` — ports (`SearchProvider`, `ScrapeProvider`, `ExtractProvider`, `DiscoverProvider`, `RegistryRouter`, `ReportRouter`, `Budget`, `ProviderQuota`), `ResearchService` (fiber-per-run agent loop with PubSub for SSE), policy resolution, output schema registry (freeform, company-enrichment-v1, competitor-scan-v1, contact-discovery-v1, prospect-scan-v1)
+- `infrastructure/` — boot-time provider selection (`providers-live.ts` for 6 capability ports, `llm-live.ts` for LLM inference), stub providers for zero-cost local dev, real providers (Brave Search, Firecrawl, libreBORME, einforma), cached search wrapper, OpenAI-compatible LLM layer via `@effect/ai-openai-compat`
+
+Provider selection uses `Layer.unwrap + Config.schema` — env vars pick the implementation at startup, same pattern as `EmailProviderLive`. Each provider is a `Layer<PortTag, E, R>` with R declaring its dependencies (stubs need nothing, real providers need `HttpClient` + `Config`).
 
 ### `packages/controllers`
 
@@ -184,7 +207,7 @@ TanStack Start SSR app deployed to Unikraft (Node.js). Responsibilities:
 
 ## Bounded contexts
 
-Engranatge has two bounded contexts. Each owns its own domain errors and types; dependencies only flow from consumers (apps) into the packages, never sideways.
+Engranatge has three bounded contexts. Each owns its own domain errors and types; dependencies only flow from consumers (apps) into the packages, never sideways.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -208,13 +231,36 @@ Engranatge has two bounded contexts. Each owns its own domain errors and types; 
 │                           (bootstrap, invite, list, create-key,  │
 │                            promote, revoke, reset, sessions)     │
 └─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│  Research context                                                │
+│                                                                  │
+│    packages/research  ──► apps/server                            │
+│      domain/     errors, value types (SearchResult, etc.)        │
+│      application/                                                │
+│        ports     6 capability ports + Budget + ProviderQuota     │
+│        schemas/  output schemas (freeform, enrichment, etc.)     │
+│        research-service  fiber-per-run agent loop + PubSub       │
+│        budget    per-run + monthly spending control               │
+│        policy    system defaults → user policy → per-run clamp   │
+│      infrastructure/                                             │
+│        stub/     7 stubs (zero-cost local dev)                   │
+│        brave/    Brave Search API                                │
+│        providers-live  boot-time selection (6 capabilities)      │
+│        llm-live        boot-time LLM provider selection          │
+│        cached-search   TTL cache wrapping SearchProvider         │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
-**Dependency direction.** `packages/auth` and `packages/domain` have no dependency between them. Both are consumed by the apps; the apps do not consume each other. Auth-domain errors (`UserNotFound`, `UsersAlreadyExist`, `MagicLinkFailed`) never cross into the CRM context — if the server ever needs to map them to HTTP-surface errors, that mapping lives at the edge in `apps/server`, not in either package.
+**Dependency direction.** `packages/auth`, `packages/domain`, and `packages/research` have no dependency between them. All are consumed by the apps; the apps do not consume each other. Each context's domain errors stay within the context — if the server needs to map them to HTTP-surface errors, that mapping lives at the edge in `apps/server`, not in the packages.
 
 **Why a shared `buildBetterAuthConfig`.** The CLI and server both instantiate `betterAuth(...)` — the CLI because it mints users/keys out-of-band, the server because it serves `/auth/*`. If the plugin list or field set drifts between the two, the apiKey plugin's verification path breaks at runtime (keys minted in one process fail to validate in the other). Keeping the builder in one place makes that drift impossible.
 
 **Why the CLI omits `magicLink()`.** The magic-link sender depends on the server's `EmailProvider` service (local inbox catcher in dev, AgentMail in prod). The CLI doesn't run that service, so it injects its own `MagicLinkSender` port implementation when it needs to issue a link (see `pnpm cli auth invite`). The builder takes `plugins` as a parameter precisely so each caller supplies the plugin list it can back.
+
+**Why research is a separate bounded context.** Research has its own domain model (providers, budgets, quotas, schemas), its own error hierarchy (`ProviderError`, `BudgetExceeded`, `QuotaExhausted`), and its own infrastructure concerns (external API keys, LLM inference, cost tracking). It reads CRM data (companies, contacts) but never writes directly — proposed changes go through the `propose_update` tool, reviewed by the outer AI or user before applying. This separation means research provider implementations, pricing models, and LLM providers can evolve independently of the CRM schema.
+
+**Provider selection pattern.** Each of the 6 research capabilities (search, scrape, extract, discover, registry, report) plus LLM inference is configured by an env var (`RESEARCH_*_PROVIDER`) that picks the implementation at boot time. The pattern is `Layer.unwrap(Config.schema(...) → switch → return Layer)` — same as `EmailProviderLive`. Stubs provide zero-cost deterministic data for local dev. Real providers (Brave, Firecrawl, libreBORME, einforma) declare their dependencies (`HttpClient`, `Config`) in the R type, satisfied at the composition root.
 
 ---
 
@@ -232,10 +278,33 @@ Agent calls get_company(slug)
 ### AI agent researches a new prospect
 
 ```
-Agent uses Firecrawl/Exa MCP to scrape company website
-  → Agent calls create_company(...) with structured fields
-  → Agent calls create_document({ type: "research", content: <markdown> })
-  → Agent calls create_task({ type: "call", title: "First cold call", due_at: ... })
+Agent calls start_research(query, schemaName, subjects)
+  → POST /v1/research → creates research_runs row (status: queued)
+  → Server forks an Effect Fiber for the run
+
+  Fiber phases (inside packages/research ResearchService):
+    Phase 1 — Tool loop: LLM calls web_search, web_read, lookup_registry, crm_lookup
+      Each tool call → routes through the matching provider port (Brave, Firecrawl, etc.)
+      Findings accumulated, sources deduped and archived
+    Phase 2 — Structured output: LLM.generateObject with the run's schema
+      Findings → typed JSON (e.g. CompanyEnrichmentV1)
+    Phase 3 — Brief generation: LLM.generateText → markdown summary
+
+  → SSE events streamed to GET /v1/research/:id/events
+  → Agent reads findings via get_research(id)
+  → Agent calls propose_update to suggest CRM changes (reviewed before applying)
+  → Agent calls create_task({ type: "call", ... }) for follow-up
+```
+
+### AI agent runs a fan-out prospect scan
+
+```
+Agent calls start_research(query, schemaName, selector: { table: companies, filter })
+  → Server creates a parent group run + N leaf runs (one per matching company)
+  → Leaf fibers run concurrently (capped by RESEARCH_MAX_CONCURRENCY_FANOUT)
+  → Each leaf completion merges findings onto parent row (advisory-locked)
+  → Parent status rolls up automatically (running → succeeded/failed)
+  → Agent calls get_research(parentId) → gets full group with children inline
 ```
 
 ### User logs a visit in the web UI
@@ -372,6 +441,22 @@ documents           — long-form markdown (research, meeting notes)
 pages               — public prospect sales pages (Tiptap JSON, multilingual)
 webhook_endpoints   — outgoing webhook configuration
 call_recordings     — audio metadata per call (transcript columns nullable, populated in a later phase)
+```
+
+### Research tables (migration 0003_research)
+
+```
+research_runs       — one row per research run (leaf, group, or followup)
+                      parent_id for fan-out groups, kind = leaf|group|followup
+                      status = queued|running|succeeded|failed|cancelled|deleted
+                      findings (jsonb), brief_md, tool_log, cost tracking columns
+sources             — globally deduped web/registry/report sources (keyed by url_hash)
+research_run_sources — many-to-many: runs ↔ sources (with local_ref citation key)
+research_links      — polymorphic: runs ↔ companies/contacts (input or finding)
+research_paid_spend — audit log: every paid API call with idempotency_key
+user_research_policy — per-user budget/quota preferences
+provider_quotas     — per-user per-provider quota config (monthly plan or pay-per-call)
+provider_usage      — consumption counter per provider per billing period
 ```
 
 ### Better Auth tables (auto-managed)

--- a/docs/backend-research-todo.md
+++ b/docs/backend-research-todo.md
@@ -1,0 +1,117 @@
+# Backend Research — Implementation TODO
+
+Tracks implementation progress for [backend-research.md](backend-research.md).
+
+---
+
+## Phase 1: Foundation (errors + migration)
+
+- [x] **1.1** Add research error types to `packages/controllers/src/errors.ts`
+  - `ProviderError`, `BudgetExceeded`, `MonthlyCapExceeded`, `QuotaExhausted`, `ApprovalRequired`, `InsufficientBudget`, `ConfirmRequired`
+- [x] **1.2** Create migration `0003_research.ts`
+  - `research_runs` (incl. `tool_log`, `quota_breakdown` jsonb, `paid_policy`)
+  - `sources` (globally deduped by `url_hash`)
+  - `research_run_sources` (many-to-many with `local_ref`)
+  - `research_links` (polymorphic link to companies/contacts)
+  - `research_paid_spend` (incl. `idempotency_key`, `quota_units`, `quota_unit`, `result_data`)
+  - `user_research_policy` (per-user spending policy)
+  - `provider_quotas` (per-user per-provider quota config)
+  - `provider_usage` (consumption counter)
+  - All indexes from §7
+- [x] **1.3** Add `version int NOT NULL DEFAULT 0` to `companies` and `contacts`
+- [x] **1.4** Add `deleted_at timestamptz` to `companies` and `contacts` (soft-delete, §7.2)
+
+## Phase 2: Provider interfaces + env vars
+
+- [x] **2.0** Create `packages/research` bounded context (domain/application/infrastructure layers)
+- [x] **2.1** Create `packages/research/src/application/ports.ts` — `SearchProvider` interface
+- [x] **2.2** `ScrapeProvider` interface (in ports.ts)
+- [x] **2.3** `ExtractProvider` interface (in ports.ts)
+- [x] **2.4** `DiscoverProvider` interface (in ports.ts)
+- [x] **2.5** `RegistryRouter` interface (in ports.ts)
+- [x] **2.6** `ReportRouter` interface (in ports.ts)
+- [x] **2.7** Create shared types: `packages/research/src/domain/types.ts` + `domain/errors.ts`
+- [x] **2.8** Add `RESEARCH_*` env vars to `apps/server/src/lib/env.ts` (§18)
+- [x] **2.9** Create provider boot-time selection layer (§5.2) — `providers-live.ts` + `llm-live.ts`
+
+## Phase 3: Budget + ProviderQuota services
+
+- [x] **3.1** Create `packages/research/src/application/budget.ts` — `Budget` service (§12.1)
+  - `init`, `chargeCheap`, `chargePaid`, `snapshot`
+  - `MonthlyPaidSpend.chargeWithinCap` with `pg_advisory_xact_lock` (§11.3)
+  - Idempotency via `research_paid_spend.idempotency_key` (§12.2)
+- [x] **3.2** Create `packages/research/src/application/provider-quota.ts` — `ProviderQuota` service (§11.6)
+  - `check`, `consume`, `remaining`, `sync`
+  - Two sync modes: `api` (auto-sync from provider balance API) and `manual` (local counter)
+- [x] **3.3** Create `packages/research/src/application/policy.ts` — policy resolution (§11.2)
+  - System env defaults → user policy → per-run override (clamped to user policy)
+  - Snapshot frozen on `research_runs.paid_policy`
+
+## Phase 4: Schema registry + ResearchService core
+
+- [x] **4.1** Create `packages/research/src/application/schemas/index.ts` — registry `Record<string, Schema.Any>`
+- [x] **4.2** Create `freeform.ts`
+- [x] **4.3** Create `company-enrichment-v1.ts`
+- [x] **4.4** Create `competitor-scan-v1.ts`
+- [x] **4.5** Create `contact-discovery-v1.ts`
+- [x] **4.6** Create `prospect-scan-v1.ts`
+- [x] **4.7** Create `packages/research/src/application/research-service.ts` — `ResearchService`
+  - Subject snapshot freeze (§10.5)
+  - Phase 1: `LanguageModel.streamText` tool loop (§13.1)
+  - Phase 2: `LanguageModel.generateObject` structured output (§13.1)
+  - Phase 3: brief generation via Haiku (§13.1)
+  - In-memory `PubSub` per active run (§13.2)
+  - In-memory `Map<id, Fiber>` for cancellation (§13.3)
+  - Citation reference validation (§9.1)
+  - Source lifecycle: hash, dedupe, archive to S3, link to run (§9.2)
+  - Selector fan-out: parent/leaf rows, concurrency cap, confirm threshold (§3.3, §12.4)
+  - Failure handling (§13.4): provider error → recoverable, schema retry once, startup sweeper
+
+## Phase 5: Research tools (8 tools)
+
+- [x] **5.1** Create `apps/server/src/mcp/tools/research-web.ts`
+  - `web_search` — Readonly, OpenWorld, tier 1
+  - `web_read` — Readonly, OpenWorld, tier 1 (scrape + extract merged)
+  - `web_discover` — Readonly, OpenWorld, tier 2
+- [x] **5.2** Create `apps/server/src/mcp/tools/research-registry.ts`
+  - `lookup_registry` — Readonly, OpenWorld, tier 0 (basic) / tier 3 (financials|full)
+- [x] **5.3** Create `apps/server/src/mcp/tools/research-crm.ts`
+  - `crm_lookup` — Readonly, !OpenWorld, tier 0
+- [x] **5.4** Create `apps/server/src/mcp/tools/research-sink.ts`
+  - `propose_update` — !Destructive, !OpenWorld
+  - `attach_finding` — !Destructive, Idempotent, !OpenWorld
+  - `propose_paid_action` — !Destructive, !OpenWorld
+
+## Phase 6: HTTP API routes + handlers
+
+- [x] **6.1** Create `packages/controllers/src/routes/research.ts` — `ResearchGroup`
+  - `POST /research` (create + fork) → 202
+  - `GET /research/:id` (full row + findings + sources)
+  - `GET /research/:id/events` (SSE live stream)
+  - `POST /research/:id/cancel`
+  - `POST /research/:id/attach` (post-hoc link)
+  - `DELETE /research/:id` (soft-delete)
+  - `GET /research` (list, filter, paginate)
+  - `GET /research/by-subject/:table/:id`
+  - Paid action: `POST /research/:id/paid-actions/:paId/approve`, `POST .../:paId/skip`
+  - Proposed update: `GET /research/:id/proposed-updates`, `POST .../apply`, `POST .../reject`
+  - Policy: `GET /research/preferences`, `PUT /research/policy`
+- [x] **6.2** Register `ResearchGroup` in `packages/controllers/src/api.ts`
+- [x] **6.3** Create `apps/server/src/handlers/research.ts` — handler implementation
+- [x] **6.4** Register `ResearchLive` + `ResearchService.layer` in `apps/server/src/main.ts`
+
+## Phase 7: MCP surface + observability
+
+- [x] **7.1** Create MCP tools: `start_research`, `get_research`, `research_sync`
+- [x] **7.2** Create `ResearchDesignerPrompt` (§15.2)
+- [x] **7.3** Create MCP resource: `forja://research/{id}` (§15.3)
+- [x] **7.4** Register research MCP tools/prompts/resources in `apps/server/src/mcp/server.ts`
+- [x] **7.5** Add observability events to `WebhookService` (§20)
+- [x] **7.6** Add metrics and log annotations (§20)
+
+## Phase 8: Wire up + integration
+
+- [x] **8.1** Wire `ResearchService.layer` into `ServicesLive` in `main.ts`
+- [x] **8.2** Wire provider layers (`makeResearchProvidersLive` + `makeResearchLlmLive`) into `main.ts`
+- [x] **8.3** Add startup sweeper for orphaned `status='running'` rows (§13.4)
+- [x] **8.4** Type-check: `tsc --noEmit` passes for research, server, controllers

--- a/docs/backend-research.md
+++ b/docs/backend-research.md
@@ -4,7 +4,7 @@ Generic, cross-topic research feature for Forja. An LLM-driven agent loop that c
 
 For system context see [architecture.md](architecture.md). For backend structure see [backend.md](backend.md).
 
-> Status: design doc, v0. Not yet implemented. We'll improve it later on.
+> Status: v0 implementation in progress. See [backend-research-todo.md](backend-research-todo.md) for progress.
 
 ---
 
@@ -138,12 +138,14 @@ Server expands the filter into N rows, creates a **parent** `research_runs` row 
 
 ### 4.1 Tier matrix
 
-| Tier  | Name            | Cost/call     | Examples                                                                   | Gating                                                                                                     |
-| ----- | --------------- | ------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| **0** | Free / internal | 0             | `lookup_registry` basic (libreBORME), `crm_lookup`, Brave free-tier search | no gate                                                                                                    |
-| **1** | Cheap web       | ~€0.001–0.005 | `web_search` (Exa), `web_read` (Firecrawl markdown or structured extract)  | debited from `budget_cents`, fails with `BudgetExceeded`                                                   |
-| **2** | Moderate        | ~€0.01–0.05   | `web_discover` (Firecrawl agent, Claude web_search)                        | debited from `budget_cents`; LLM sees warning when >50% consumed                                           |
-| **3** | Paid structured | €1–5          | `lookup_registry` depth='financials'\|'full' (einforma)                    | debited from **separate** `paid_budget_cents`; above `auto_approve_paid_cents`, uses `propose_paid_action` |
+| Tier  | Name            | Cost/call     | Examples                                                                   | Gating                                                                                                                  |
+| ----- | --------------- | ------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **0** | Free / internal | 0             | `lookup_registry` basic (libreBORME), `crm_lookup`, Brave free-tier search | no gate                                                                                                                 |
+| **1** | Cheap web       | ~€0.001–0.005 | `web_search` (Exa), `web_read` (Firecrawl markdown or structured extract)  | debited from `budget_cents`, fails with `BudgetExceeded`                                                                |
+| **2** | Moderate        | ~€0.01–0.05   | `web_discover` (Firecrawl agent, Claude web_search)                        | debited from `budget_cents`; LLM sees warning when >50% consumed                                                        |
+| **3** | Paid structured | €1–5          | `lookup_registry` depth='financials'\|'full' (einforma)                    | debited from **separate** `paid_budget_cents`; above `auto_approve_paid_cents` (default €2), uses `propose_paid_action` |
+
+The "Cost/call" column is **notional** — it drives the resource-budget governor (§11), not actual spend. Real billing depends on each provider's pricing model (credit blocks, monthly plans, per-call). See §11.6 for how provider quotas track actual consumption in native units.
 
 The rule: **climb tiers only when a lower one cannot answer the question.** `lookup_registry` basic before `web_read`. `web_read` before `lookup_registry` financials. Enforced by a prompt rule (soft) and by budget errors (hard).
 
@@ -290,6 +292,10 @@ const SearchProviderLive = Layer.unwrap(
 
 Same shape for the other five capabilities.
 
+### 5.3 Quota awareness
+
+Provider interfaces stay clean — they don't know about quotas. Quota tracking lives in a separate `ProviderQuota` service (§11.6) that wraps provider calls at the instrumentation layer (§12.2). Each provider impl reports how many native units a call consumed via a `units` field on its return type, so the quota service can record it.
+
 ---
 
 ## 6. Tool surface
@@ -365,7 +371,7 @@ propose_paid_action({
   reason: string
 })
   → records the proposal, returns immediately — LLM continues without the data
-  → human approves/rejects after the run; can trigger a follow-up run if approved
+  → human approves/skips after the run (see §11.5 for follow-up mechanics)
   → writes to research_runs.findings.pending_paid_actions[]
   → !Destructive, !OpenWorld
 ```
@@ -389,24 +395,25 @@ propose_paid_action({
 CREATE TABLE research_runs (
   id                      uuid PRIMARY KEY,
   parent_id               uuid REFERENCES research_runs(id) ON DELETE CASCADE,
-  kind                    text NOT NULL CHECK (kind IN ('leaf','group')) DEFAULT 'leaf',
+  kind                    text NOT NULL CHECK (kind IN ('leaf','group','followup')) DEFAULT 'leaf',
 
   query                   text NOT NULL,
   mode                    text NOT NULL DEFAULT 'deep',       -- v1: only 'deep'
   schema_name             text,                                -- §8
 
-  status                  text NOT NULL CHECK (status IN ('queued','running','succeeded','failed','cancelled')),
+  status                  text NOT NULL CHECK (status IN ('queued','running','succeeded','failed','cancelled','deleted')),
   context                 jsonb NOT NULL DEFAULT '{}'::jsonb,  -- {subjects?, selector?, hints?}
 
   findings                jsonb NOT NULL DEFAULT '{}'::jsonb,  -- structured output (§8)
   brief_md                text,                                -- human narrative (§8)
 
-  -- Budget / cost
+  -- Budget / cost (cents are notional — volume governor, not actual spend; see §11)
   budget_cents            int NOT NULL DEFAULT 0,
   paid_budget_cents       int NOT NULL DEFAULT 0,
   cost_cents              int NOT NULL DEFAULT 0,
   paid_cost_cents         int NOT NULL DEFAULT 0,
-  cost_breakdown          jsonb NOT NULL DEFAULT '{}'::jsonb,  -- { provider: cents, ... }
+  cost_breakdown          jsonb NOT NULL DEFAULT '{}'::jsonb,  -- { provider: notional_cents, ... }
+  quota_breakdown         jsonb NOT NULL DEFAULT '{}'::jsonb,  -- { provider: { units: N, unit: 'credits' }, ... } — native units consumed
   tokens_in               int NOT NULL DEFAULT 0,
   tokens_out              int NOT NULL DEFAULT 0,
   paid_policy             jsonb NOT NULL DEFAULT '{}'::jsonb,  -- resolved policy snapshot
@@ -479,18 +486,22 @@ CREATE INDEX research_links_subject_idx ON research_links(subject_table, subject
 -- Paid-spend audit log (even for auto-approved calls)
 --
 CREATE TABLE research_paid_spend (
-  id             uuid PRIMARY KEY,
-  research_id    uuid NOT NULL REFERENCES research_runs(id) ON DELETE CASCADE,
-  user_id        uuid NOT NULL,
-  provider       text NOT NULL,
-  tool           text NOT NULL,
-  amount_cents   int NOT NULL,
-  args           jsonb NOT NULL,                               -- redacted of secrets
-  result_hash    text,                                         -- sha256 of normalized response
-  source_id      text REFERENCES sources(id),
-  auto_approved  boolean NOT NULL,
-  approved_by    uuid,                                         -- if manual
-  at             timestamptz NOT NULL DEFAULT now()
+  id               uuid PRIMARY KEY,
+  research_id      uuid NOT NULL REFERENCES research_runs(id) ON DELETE CASCADE,
+  user_id          uuid NOT NULL,
+  provider         text NOT NULL,
+  tool             text NOT NULL,
+  idempotency_key  text NOT NULL UNIQUE,                       -- '{research_id}:{tool}:{hash(args)}' — prevents double-charge on retry
+  amount_cents     int NOT NULL,                                -- notional cents (volume governor)
+  quota_units      int,                                         -- provider-native units consumed (e.g., 1 credit, 1 report)
+  quota_unit       text,                                        -- 'credits', 'reports', 'requests' — matches provider_quotas.quota_unit
+  args             jsonb NOT NULL,                              -- redacted of secrets
+  result_hash      text,                                       -- sha256 of normalized response
+  result_data      jsonb,                                      -- write-ahead: full provider response, persisted immediately after provider returns
+  source_id        text REFERENCES sources(id),
+  auto_approved    boolean NOT NULL,
+  approved_by      uuid,                                       -- if manual
+  at               timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE INDEX research_paid_spend_user_at_idx ON research_paid_spend(user_id, at DESC);
@@ -502,9 +513,40 @@ CREATE TABLE user_research_policy (
   user_id                    uuid PRIMARY KEY,                 -- → users(id)
   budget_cents               int NOT NULL DEFAULT 100,         -- €1/run cheap tier
   paid_budget_cents          int NOT NULL DEFAULT 500,         -- €5/run paid tier
-  auto_approve_paid_cents    int NOT NULL DEFAULT 500,         -- auto-approve within run budget
+  auto_approve_paid_cents    int NOT NULL DEFAULT 200,         -- €2 auto-approve; first einforma call silent, second triggers propose_paid_action
   paid_monthly_cap_cents     int NOT NULL DEFAULT 2000,        -- €20/month hard cap
   updated_at                 timestamptz NOT NULL DEFAULT now()
+);
+
+--
+-- Provider quota config (one row per user per provider, see §11.6)
+--
+CREATE TABLE provider_quotas (
+  user_id          uuid NOT NULL,
+  provider         text NOT NULL,                               -- 'firecrawl', 'einforma', 'exa', etc.
+  billing_model    text NOT NULL CHECK (billing_model IN ('monthly_plan', 'pay_per_call')),
+  sync_mode        text NOT NULL CHECK (sync_mode IN ('api', 'manual')) DEFAULT 'manual',
+                                                                -- 'api' = auto-sync from provider balance API; 'manual' = user maintains quota_total
+  quota_total      int NOT NULL,                                -- units per period: credits, reports, requests
+  quota_unit       text NOT NULL,                               -- 'credits', 'reports', 'requests'
+  period_months    int NOT NULL DEFAULT 1,                      -- 1 = monthly (most providers)
+  period_anchor    date,                                        -- first day of current period (auto-synced from provider for sync_mode='api')
+  cents_per_unit   int NOT NULL DEFAULT 0,                      -- notional conversion for budget governor
+  warn_at_pct      int NOT NULL DEFAULT 80,                     -- UI warns when usage exceeds this %
+  last_synced_at   timestamptz,                                 -- last successful API sync (null for manual)
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, provider)
+);
+
+--
+-- Provider usage counter (tracks consumption in native units, see §11.6)
+--
+CREATE TABLE provider_usage (
+  user_id          uuid NOT NULL,
+  provider         text NOT NULL,
+  period_start     date NOT NULL,                               -- first day of period (monthly providers: month start; lifetime: epoch)
+  units_consumed   int NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, provider, period_start)
 );
 ```
 
@@ -542,7 +584,8 @@ Requires a `version` column on `companies`/`contacts` (not present today) + a ch
 | `research_runs.context`                                        | `jsonb`             | `{subjects?, selector?, hints?}`                                                        |
 | `research_runs.findings`                                       | `**jsonb`**         | structured, schema-valid, queryable, drives UI                                          |
 | `research_runs.brief_md`                                       | `**text`** markdown | human synthesis, regenerable per language                                               |
-| `research_runs.cost_breakdown`                                 | `jsonb`             | per-provider cent counts                                                                |
+| `research_runs.cost_breakdown`                                 | `jsonb`             | per-provider notional cents (volume governor, not actual spend)                         |
+| `research_runs.quota_breakdown`                                | `jsonb`             | per-provider native units consumed: `{ firecrawl: { units: 6, unit: 'credits' } }`      |
 | `research_runs.paid_policy`                                    | `jsonb`             | resolved policy snapshot for audit                                                      |
 | `research_runs.tool_log`                                       | `jsonb`             | array of tool call/result events, written once at completion for audit                  |
 | `sources` columns                                              | relational          | no JSON; normalized table                                                               |
@@ -699,9 +742,17 @@ See §9.1. No unsourced claims.
 
 ### 10.4 Cost discipline
 
+Two independent layers gate every external call (see §12.2):
+
+1. **Provider quota** (hard limit) — does the user have remaining units with this provider? Checked first. `QuotaExhausted` is recoverable: the LLM should try an alternative provider or tool.
+2. **Resource budget** (volume governor) — notional cents, prevents a single run from consuming disproportionate resources even when those resources are prepaid. `BudgetExceeded` is terminal for the exhausted tier.
+
+Rules:
+
 - Try tier 0 first. Registry before scrape.
 - Never exceed `paid_budget_cents` without `propose_paid_action`.
-- `BudgetExceeded` errors are terminal for the exhausted tier — the agent should either finish with what it has or propose more budget.
+- `BudgetExceeded` → finish with what you have.
+- `QuotaExhausted` → try an alternative (e.g., Brave if Firecrawl credits are gone).
 
 ### 10.5 Subject snapshot freeze
 
@@ -709,18 +760,24 @@ When a run starts, the current version of every subject row is captured into `co
 
 ### 10.6 Human-in-the-loop gates
 
-| Action                                                | Gate                                  |
-| ----------------------------------------------------- | ------------------------------------- |
-| Write to Forja domain rows                            | Always human via "Apply"              |
-| Call tier-3 paid tool above `auto_approve_paid_cents` | `propose_paid_action` → human approve |
-| Fan-out over `paid_monthly_cap_cents`                 | Hard block, no override               |
-| Exceed system hard ceiling                            | Hard block, not overridable per-run   |
+| Action                                                | Gate                                                   |
+| ----------------------------------------------------- | ------------------------------------------------------ |
+| Write to Forja domain rows                            | Always human via "Apply"                               |
+| Call tier-3 paid tool above `auto_approve_paid_cents` | `propose_paid_action` → human approve                  |
+| Provider quota exhausted                              | `QuotaExhausted` → LLM tries alternative provider/tool |
+| Fan-out over `paid_monthly_cap_cents`                 | Hard block, no override                                |
+| Exceed system hard ceiling                            | Hard block, not overridable per-run                    |
 
 ---
 
 ## 11. Spending policy
 
-One editable policy per user. Four numbers, all editable in settings. The goal is to control spending.
+Two independent layers control resource consumption:
+
+1. **Resource budget** (§11.1–11.5) — notional cents. A volume governor that limits how much a single run or a month of runs can consume, regardless of actual billing. Useful even when resources are prepaid: prevents one run from burning half your Firecrawl credits.
+2. **Provider quotas** (§11.6) — native units (credits, reports, requests). Tracks actual consumption against the user's plan with each provider. Prevents hitting plan limits or triggering overage charges.
+
+The two layers are checked independently. A call can pass the budget check but fail the quota check (provider out of credits), or pass the quota check but fail the budget check (run budget exhausted).
 
 ### 11.1 Table
 
@@ -729,26 +786,28 @@ CREATE TABLE user_research_policy (
   user_id                    uuid PRIMARY KEY,
   budget_cents               int NOT NULL DEFAULT 100,     -- €1/run for cheap tier (scraping, search)
   paid_budget_cents          int NOT NULL DEFAULT 500,     -- €5/run for paid tier (1-2 einforma calls)
-  auto_approve_paid_cents    int NOT NULL DEFAULT 500,     -- auto-approve within run budget, no interruptions
+  auto_approve_paid_cents    int NOT NULL DEFAULT 200,     -- €2 auto-approve; first einforma call silent, second triggers propose_paid_action
   paid_monthly_cap_cents     int NOT NULL DEFAULT 2000,    -- €20/month hard cap
   updated_at                 timestamptz NOT NULL DEFAULT now()
 );
 ```
 
-New user → row created with env defaults. User edits in settings. Per-run overrides via POST body. System env var `RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS` is the only non-editable limit.
+New user → row created with env defaults. User edits in settings. Per-run overrides via POST body (clamped — see §11.2). System env var `RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS` is the only non-editable limit.
 
-**Out-of-the-box behavior:** agent can spend up to €1/run on web scraping/search, up to €5/run on paid APIs (einforma), auto-approved, with a €20/month ceiling. No interruptions, no approval dialogs. User adjusts any number anytime.
+**Out-of-the-box behavior:** agent can spend up to €1/run on web scraping/search, up to €5/run on paid APIs (einforma). The first ~€2 of paid calls are auto-approved silently; beyond that the agent calls `propose_paid_action` and the user approves or skips after the run. €20/month hard cap. User adjusts any number anytime in settings.
 
 ### 11.2 Layered resolution
 
 ```
 system env defaults
   → user policy (four editable fields)
-    → per-run POST body overrides
+    → per-run POST body overrides (clamped: see below)
       → resolved policy snapshot → research_runs.paid_policy (captured for audit)
 ```
 
 Per-run wins over user, user wins over env. The snapshot is frozen on the row so "what policy was in effect for this run" is always answerable.
+
+**Per-run override clamping.** Per-run overrides in the POST body are clamped to the user's own policy, not the system ceiling. A request with `paid_budget_cents: 10000` when the user's policy says 500 resolves to 500. The user must update their policy first (via `PUT /research/policy`) to raise their ceiling. This prevents a buggy or compromised frontend from bypassing the user's own spending limits. The system hard ceiling (`RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS`) remains the absolute max that even the user policy cannot exceed.
 
 ### 11.3 The monthly cap is the only non-overridable rail
 
@@ -760,31 +819,103 @@ chargePaid: (provider, cents) => Effect.gen(function* () {
   if (runBudget.remaining < cents)
     return yield* new BudgetExceeded({ tier: 'paid-run', needed: cents, remaining: runBudget.remaining })
 
-  const monthlySpent = yield* MonthlyPaidSpend.getFor(userId, 'current-month')
-  const systemCeiling = yield* Config.integer('RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS')
-  const effectiveCap = Math.min(policy.paidMonthlyCapCents, systemCeiling)
-
-  if (monthlySpent + cents > effectiveCap)
-    return yield* new MonthlyCapExceeded({ monthlySpent, cap: effectiveCap, needed: cents })
+  // Monthly cap check-and-debit is serialized per user via pg advisory lock.
+  // Multiple concurrent fibers for the same user all hit this lock, so only
+  // one can read-check-debit at a time. Without this, N concurrent fibers
+  // could each see room and overshoot the cap by up to N * paid_budget_cents.
+  yield* MonthlyPaidSpend.chargeWithinCap(userId, cents, runId, provider, policy.paidMonthlyCapCents)
 
   yield* Ref.update(paidRef, b => ({ ...b, remaining: b.remaining - cents, spent: b.spent + cents }))
-  yield* MonthlyPaidSpend.add(userId, cents, runId, provider)
 })
 ```
 
+`MonthlyPaidSpend.chargeWithinCap` runs inside a single Postgres transaction:
+
+```sql
+SELECT pg_advisory_xact_lock(hashtext('research_monthly_cap:' || $user_id));
+SELECT COALESCE(SUM(amount_cents), 0) AS spent
+  FROM research_paid_spend
+ WHERE user_id = $user_id
+   AND at >= date_trunc('month', now());
+-- if spent + $cents > LEAST($user_cap, $system_ceiling) → raise MonthlyCapExceeded
+INSERT INTO research_paid_spend (id, research_id, user_id, provider, tool, idempotency_key, amount_cents, args, auto_approved, at)
+VALUES (...);
+```
+
+The advisory lock is transaction-scoped (`pg_advisory_xact_lock`), so it releases automatically on commit or rollback. No risk of orphaned locks.
+
 - `RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS` (env) is the absolute max. A user's `paid_monthly_cap_cents` can only go *up to* but never past it.
 - Prompt injection / runaway loops stop at the monthly cap.
+- Concurrent fibers serialize on the advisory lock, so the cap is exact — no overshoot.
 
 ### 11.4 How the LLM experiences policy
 
-The LLM does **not** read the policy. It learns from tool errors:
+The LLM does **not** read the policy or quotas. It learns from tool errors:
 
-- Within budget & threshold → tool runs silently, charges budget.
-- Above threshold → tool errors with `ApprovalRequired`. System prompt: *"if you receive ApprovalRequired, call `propose_paid_action` instead."*
-- Above run budget → tool errors with `BudgetExceeded`. System prompt: *"finish with what you have or propose more budget."*
+- Within budget & quota → tool runs silently, charges both layers.
+- Provider quota exhausted → tool errors with `QuotaExhausted { provider, unit, remaining: 0 }`. System prompt: *"if you receive QuotaExhausted, try an alternative tool or provider for the same information. Do not retry the same tool."*
+- Above approval threshold → tool errors with `ApprovalRequired`. System prompt: *"if you receive ApprovalRequired, call `propose_paid_action` instead."*
+- Above run budget → tool errors with `BudgetExceeded`. System prompt: *"finish with what you have."*
 - Above monthly cap → tool errors with `MonthlyCapExceeded`. Terminal — run finishes.
 
-This keeps the prompt simple and policy-independent.
+This keeps the prompt simple and policy-independent. The LLM doesn't need to know whether a failure is a quota issue or a budget issue — it just knows the tool failed and gets guidance on what to do next.
+
+### 11.5 Follow-up run after paid action approval
+
+When the user approves a `pending_paid_action` via `POST /research/:id/paid-actions/:pa_id/approve`:
+
+1. Server creates a **new** `research_runs` row (`kind='followup'`, `parent_id=original.id`).
+2. The new run's `context` inherits the original's `context.subjects` (same snapshots, same `expected_version`). It does **not** inherit the original's findings or tool log — it starts with a clean slate.
+3. The new run's prompt includes: the approved paid action's `tool`, `args`, and `reason`, plus a summary of what the original run already found (extracted from `findings`). The system prompt says: *"Execute the approved paid action, then integrate its results with the prior findings summary into your final output."*
+4. Budget: the follow-up run draws from the user's current policy (not the original run's snapshot). The approved paid action's `estimated_cents` was already validated against the monthly cap at approval time.
+5. The follow-up run appears in the UI as a child of the original, with a link back. The original run's `pending_paid_actions` entry is updated with `status='approved'` and `followup_run_id`.
+
+If the user skips all pending paid actions, no follow-up run is created. If multiple actions are approved, they are batched into a single follow-up run.
+
+### 11.6 Provider quotas
+
+External providers bill in two ways, neither of which maps cleanly to "€X per call":
+
+| Billing model  | Examples                                                             | What the user actually buys                |
+| -------------- | -------------------------------------------------------------------- | ------------------------------------------ |
+| `monthly_plan` | Firecrawl ($19/mo Hobby, 3k credits), Exa (1k req/mo free), eInforma | N units/month included; resets each period |
+| `pay_per_call` | Brave Search ($5/1k), Exa beyond free tier ($7/1k search)            | Each call billed at a fixed rate           |
+
+Most providers are `monthly_plan` with a free or paid tier that includes N units/month. `pay_per_call` applies to providers with no subscription tier or once a plan's included units are exhausted (overage).
+
+The resource budget (§11.1–11.3) is the **volume governor** — it limits how much a single run can consume regardless of billing model. Provider quotas are the **hard limits** — they track actual consumption in native units against the user's plan.
+
+**`ProviderQuota` service:**
+
+```ts
+// apps/server/src/services/research/provider-quota.ts
+export class ProviderQuota extends ServiceMap.Service<
+  ProviderQuota,
+  {
+    readonly check: (provider: string, units: number) => Effect.Effect<void, QuotaExhausted>
+    readonly consume: (provider: string, units: number) => Effect.Effect<void, QuotaExhausted>
+    readonly remaining: (provider: string) => Effect.Effect<{ total: number; used: number; unit: string }>
+    readonly sync: (provider: string) => Effect.Effect<void, ProviderError>
+  }
+>()('research/ProviderQuota') {}
+```
+
+`check` is a dry run (no side effects). `consume` atomically checks and decrements. `sync` fetches the current balance from the provider's API (for `sync_mode='api'` providers).
+
+**Two sync modes:**
+
+| `sync_mode` | How quota is tracked                                                           | Who maintains it  |
+| ----------- | ------------------------------------------------------------------------------ | ----------------- |
+| `api`       | System calls provider balance API, caches result (TTL 60s)                     | Automatic         |
+| `manual`    | System tracks consumption locally in `provider_usage`; user sets `quota_total` | Admin in settings |
+
+**`api` mode (Firecrawl, and any provider with a balance endpoint):** The system calls the provider's balance API to get remaining units. For Firecrawl: `GET /v2/team/credit-usage` → `{ remainingCredits, planCredits, billingPeriodStart, billingPeriodEnd }`. The response is cached in-memory (TTL 60s). `check` reads the cached balance; `consume` invalidates the cache. `provider_usage` is not used — the provider is the source of truth.
+
+On first API key setup, the system auto-creates a `provider_quotas` row with `sync_mode='api'`, populating `quota_total`, `quota_unit`, `period_anchor` from the provider response. No manual config needed.
+
+**`manual` mode (eInforma, providers without a balance API):** Admin enters their plan details in settings (quota total, unit, period). `check` and `consume` read/write the local `provider_usage` counter. Period resets are implicit: if `period_start` for the current period doesn't exist, the counter starts at 0 (no cron job).
+
+**When no quota is configured.** If `provider_quotas` has no row for a (user, provider) pair, the quota check is skipped — the resource budget is the only gate. This means the system works out of the box without quota configuration; quotas are opt-in protection.
 
 ---
 
@@ -807,19 +938,49 @@ export class Budget extends ServiceMap.Service<
 
 ### 12.2 Provider instrumentation
 
-Every provider wraps its call:
+Every provider call goes through two layers: **quota check → budget charge → provider call → quota consume**. Quota check fires first (hard limit), then budget (volume governor).
 
 ```ts
-// firecrawl-scrape.ts
+// firecrawl-scrape.ts (cheap tier)
 const scrape = (input: ScrapeInput) =>
   Effect.gen(function* () {
+    const quota = yield* ProviderQuota
     const budget = yield* Budget
-    const estimate = estimateScrapeCents(input)        // fmt + JSON extract etc.
-    yield* budget.chargeCheap('firecrawl', estimate)
+    const estimatedUnits = estimateScrapeCredits(input)  // 1 credit per scrape, more for complex extracts
+    const estimatedCents = estimatedUnits * centsPerCredit  // notional, from provider_quotas.cents_per_unit
+
+    yield* quota.check('firecrawl', estimatedUnits)       // fail fast if quota exhausted (QuotaExhausted)
+    yield* budget.chargeCheap('firecrawl', estimatedCents) // volume governor (BudgetExceeded)
     const result = yield* http.post('/v1/scrape', input)
+    yield* quota.consume('firecrawl', result.creditsUsed)  // record actual units (may differ from estimate)
     return result
   })
 ```
+
+Paid providers add idempotency to prevent double-charging on retry:
+
+```ts
+// einforma-report.ts (paid tier)
+const fetchReport = (input: ReportInput) =>
+  Effect.gen(function* () {
+    const quota = yield* ProviderQuota
+    const budget = yield* Budget
+    const estimatedUnits = 1                               // 1 report
+    const key = `${runId}:lookup_registry:${stableHash(input)}`
+
+    yield* quota.check('einforma', estimatedUnits)         // fail fast if no reports left
+    // chargePaid is atomic: advisory lock + INSERT with idempotency_key UNIQUE.
+    // If the key already exists (retry after timeout), the INSERT is a no-op.
+    yield* budget.chargePaid('einforma', estimateReportCents(input), key)
+    const result = yield* http.post('/api/report', input)
+    yield* quota.consume('einforma', 1)
+    return result
+  })
+```
+
+**Idempotency.** The `idempotency_key` on `research_paid_spend` (`'{research_id}:{tool}:{hash(args)}'`) ensures that if a fiber retries after a network timeout, the budget row already exists and the INSERT is a conflict no-op. The provider may still double-charge externally, but our budget accounting stays correct. For providers that support client-side idempotency keys (eInforma does not in v1), pass the same key to the provider API.
+
+**Quota vs budget ordering.** Quota is checked first because it's a hard external limit — burning budget cents on a call that will fail due to quota exhaustion wastes the volume governor. If quota passes but budget fails, no quota units are consumed (the provider was never called).
 
 ### 12.3 Pre-run estimate
 
@@ -930,7 +1091,7 @@ Effect's structured concurrency guarantees the cleanup runs on interrupt.
 - Provider error → tool result with `{ error, recoverable }`. LLM decides whether to retry with different params, switch tools, or give up.
 - Schema validation failure on final output → retry once with the validation errors fed back; fail if second attempt also invalid.
 - Fiber crash → `status='failed'`, error captured to `findings.error`, event `run.failed` emitted.
-- Server restart mid-run → **not survivable in v1**. `status='running'` rows older than N seconds on boot are marked `failed` by a startup sweeper. Durable execution is a future extension.
+- Server restart mid-run → **not survivable in v1**. `status='running'` rows older than N seconds on boot are marked `failed` by a startup sweeper. Durable execution is a future extension. However, paid call results are **write-ahead persisted**: each successful paid provider response is written to `research_paid_spend.result_hash` and to a `research_paid_results` jsonb column on the spend row immediately after the provider returns, before the fiber continues. On restart, the sweeper marks the run as failed but the paid results are recoverable — the UI shows them with a "run interrupted, partial paid results available" state, and the user can start a follow-up run that re-uses the cached results instead of re-purchasing.
 
 ---
 
@@ -939,6 +1100,7 @@ Effect's structured concurrency guarantees the cleanup runs on interrupt.
 ```
 POST   /research                              create + fork
   body: { query, mode?, context?, schema_name?, budget_cents?, paid_budget_cents?, auto_approve_paid_cents? }
+  note: per-run budget overrides are clamped to the user's policy (§11.2), not the system ceiling
   → 202 { id, status: 'queued' }
   → 409 { error: 'InsufficientBudget', estimated, available, shortfall }
   → 409 { error: 'ConfirmRequired', estimated_cost_cents, preview }   (fan-out > threshold)
@@ -954,9 +1116,9 @@ GET    /research                              list, filter, paginate
 
 GET    /research/by-subject/:table/:id        all runs linked to a subject row
 
--- Paid action approval workflow
-POST   /research/:id/paid-actions/:pa_id/approve
-POST   /research/:id/paid-actions/:pa_id/skip
+-- Paid action approval workflow (see §11.5 for follow-up mechanics)
+POST   /research/:id/paid-actions/:pa_id/approve   → creates a followup run (§11.5), returns { followup_run_id }
+POST   /research/:id/paid-actions/:pa_id/skip      → marks action as skipped, no follow-up
 
 -- Proposed update workflow
 GET    /research/:id/proposed-updates         list proposals
@@ -1155,8 +1317,8 @@ RESEARCH_REPORT_PROVIDER_ES=none            # disabled
 
 - **libreBORME** — free Spanish company registry mirror. BORME = Boletín Oficial del Registro Mercantil. Returns legal name, NIF, capital, incorporation date, directors (admins), address, status. Always prefer over scraping for Spanish companies.
 - **einforma** — paid commercial report, ~€1–5/call depending on depth. Financials, shareholders, risk score. Use only for due-diligence deep dives where libreBORME + web scraping are insufficient.
-- **Firecrawl** — best all-rounder: scrape, search, extract, agent. Credit-based. Use as scrape/extract default; use agent (via `web_discover`) sparingly.
-- **Exa** — best-in-class semantic search. Use as primary `SearchProvider` when quality matters more than free tier.
+- **Firecrawl** — best all-rounder: scrape, search, extract, agent. Monthly credit plans (Hobby $19/mo = 3k credits, Standard $83/mo = 100k credits). Credits: 1/scrape, 2/search(10 results), 5/agent run. Credits reset monthly, don't roll over. Auto-recharge packs ($9/1k) carry forward. Balance API: `GET /v2/team/credit-usage` → auto-sync. Use as scrape/extract default; use agent (via `web_discover`) sparingly.
+- **Exa** — best-in-class semantic search. $7/1k search requests, 1k/month free. Use as primary `SearchProvider` when quality matters more than free tier.
 - **Brave Search** — free tier, workable for dev and for cost-sensitive production.
 - **Anthropic web_search** — Claude's native tool, zero setup. Good fallback `DiscoverProvider`, but citations are model-maintained (no `content_ref` archive). Useful when budget is tight.
 - **Playwright local** — dev fallback. Slow and flaky, but free and works offline.
@@ -1167,14 +1329,14 @@ These are the top providers per capability, sorted by relevance for B2B company 
 
 #### Search APIs (for `web_search`)
 
-| Provider         | Pricing          | Free tier         | Best for                                                           | TS SDK    |
-| ---------------- | ---------------- | ----------------- | ------------------------------------------------------------------ | --------- |
-| **Exa**          | $1.50/1k         | 1k/month          | Semantic search ("companies like X"), understands business context | Yes       |
-| **Tavily**       | $8/1k            | 1k/month          | Citation-ready, built for RAG/agent workflows                      | Yes       |
-| **Firecrawl**    | $83/100k credits | 500 credits       | Integrated search+scrape in one API                                | Yes       |
-| **Brave Search** | $5/1k            | None (very cheap) | Privacy-focused, independent index, GDPR-compliant                 | REST only |
-| **SerpAPI**      | $75/5k           | 250/month         | Multi-engine SERP (40+ engines), enterprise reliability            | REST      |
-| **Serper**       | $0.30/1k         | None              | Cheapest Google SERP option                                        | REST      |
+| Provider         | Pricing                  | Free tier              | Best for                                                           | TS SDK    |
+| ---------------- | ------------------------ | ---------------------- | ------------------------------------------------------------------ | --------- |
+| **Exa**          | $7/1k search             | 1k req/month           | Semantic search ("companies like X"), understands business context | Yes       |
+| **Tavily**       | $0.008/credit            | 1k credits/month       | Citation-ready, built for RAG/agent workflows                      | Yes       |
+| **Firecrawl**    | From $19/mo (3k credits) | 500 credits (one-time) | Integrated search+scrape in one API; 2 credits per search          | Yes       |
+| **Brave Search** | $5/1k                    | None (very cheap)      | Privacy-focused, independent index, GDPR-compliant                 | REST only |
+| **SerpAPI**      | $75/5k                   | 250/month              | Multi-engine SERP (40+ engines), enterprise reliability            | REST      |
+| **Serper**       | $0.30/1k                 | None                   | Cheapest Google SERP option                                        | REST      |
 
 #### Scrape APIs (for `web_read`)
 
@@ -1228,9 +1390,23 @@ RESEARCH_BRIEF_MODEL=claude-haiku-4-5       # used for the second-pass brief_md
 # --- Budget defaults (system) ---
 RESEARCH_DEFAULT_BUDGET_CENTS=100            # €1/run cheap tier
 RESEARCH_DEFAULT_PAID_BUDGET_CENTS=500       # €5/run paid tier
-RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS=500 # auto-approve within run budget
+RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS=200 # €2 auto-approve; first einforma call silent, second triggers propose_paid_action
 RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS=2000 # €20/month per user
 RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS=10000 # €100/month absolute system max
+
+# --- Provider quota defaults (for new users; see §11.6) ---
+# Firecrawl: sync_mode=api — auto-created on first API key setup, no manual config needed.
+# System calls GET /v2/team/credit-usage to get plan details and remaining credits.
+RESEARCH_QUOTA_FIRECRAWL_SYNC=api           # auto-sync from Firecrawl balance API
+RESEARCH_QUOTA_FIRECRAWL_UNIT=credits
+RESEARCH_QUOTA_FIRECRAWL_CENTS_PER_UNIT=1   # notional ~$0.01/credit (varies by plan)
+# eInforma: sync_mode=manual — admin enters plan details in settings.
+RESEARCH_QUOTA_EINFORMA_SYNC=manual
+RESEARCH_QUOTA_EINFORMA_TOTAL=5             # reports/month (admin overrides in settings)
+RESEARCH_QUOTA_EINFORMA_UNIT=reports
+RESEARCH_QUOTA_EINFORMA_BILLING=monthly_plan
+RESEARCH_QUOTA_EINFORMA_PERIOD_MONTHS=1
+RESEARCH_QUOTA_EINFORMA_CENTS_PER_UNIT=300  # ~€3/report notional
 
 # --- Concurrency and safety ---
 RESEARCH_MAX_CONCURRENT_FIBERS_PER_USER=3
@@ -1254,14 +1430,16 @@ Boot fails loudly if any of the first six vars are unset.
 
 Everything ships together as v1.
 
-- Migrations: `research_runs` (incl. `tool_log` jsonb), `sources`, `research_run_sources`, `research_links`, `research_paid_spend`, `user_research_policy`.
+- Migrations: `research_runs` (incl. `tool_log`, `quota_breakdown` jsonb), `sources`, `research_run_sources`, `research_links`, `research_paid_spend` (incl. `idempotency_key`, `quota_units`, `quota_unit`), `user_research_policy`, `provider_quotas`, `provider_usage`.
 - Tables on subject rows: add `version int NOT NULL DEFAULT 0` to `companies`, `contacts`.
 - Decide and implement soft-delete vs triggers for polymorphic integrity (§17 open decisions).
 - `SearchProvider`, `ScrapeProvider`, `ExtractProvider`, `DiscoverProvider` interfaces + Firecrawl impls + Brave impl + local Playwright impl.
 - `RegistryProvider` + libreBORME impl (ES). `ReportProvider` + einforma impl (ES).
-- `Budget` service: cheap + paid tiers, `MonthlyPaidSpend` counter (queries `research_paid_spend`).
-- Policy resolution: system env → `user_research_policy` → per-run override.
-- `ApprovalRequired` / `BudgetExceeded` / `MonthlyCapExceeded` error types and LLM prompt rules.
+- `Budget` service: cheap + paid tiers. `MonthlyPaidSpend.chargeWithinCap` uses `pg_advisory_xact_lock` per user to serialize concurrent fibers. Paid calls use `idempotency_key` on `research_paid_spend` to prevent double-charge on retry.
+- Policy resolution: system env → `user_research_policy` → per-run override (clamped to user policy, not system ceiling).
+- Follow-up run mechanic: `POST /research/:id/paid-actions/:pa_id/approve` creates a `kind='followup'` run with the approved action's tool/args plus a findings summary from the parent (§11.5). Write-ahead persist paid results to `research_paid_spend` immediately after provider returns.
+- `ProviderQuota` service: `check` / `consume` / `remaining` / `sync` against `provider_quotas` + `provider_usage`. Two sync modes: `api` (auto-sync from provider balance API, e.g., Firecrawl `GET /v2/team/credit-usage`) and `manual` (admin configures in settings, e.g., eInforma). Quota check fires before budget charge in provider instrumentation (§12.2).
+- `QuotaExhausted` / `ApprovalRequired` / `BudgetExceeded` / `MonthlyCapExceeded` error types and LLM prompt rules.
 - Schema registry: `freeform`, `company_enrichment_v1`, `competitor_scan_v1`, `contact_discovery_v1`, `prospect_scan_v1`.
 - `ResearchService`: subject-anchored + selector fan-out (parent/leaf rows, concurrency cap, confirm threshold).
 - Tools: `web_search`, `web_read`, `web_discover`, `lookup_registry`, `crm_lookup`, `propose_update`, `attach_finding`, `propose_paid_action` (8 total).
@@ -1293,6 +1471,8 @@ Additions to `docs/observability.md`:
 | `research.cancelled`               | user cancels                     |
 | `research.proposed_update_applied` | user clicks Apply on a proposal  |
 | `research.paid_spend_recorded`     | any paid call (auto or approved) |
+| `research.quota_exhausted`         | provider quota depleted          |
+| `research.quota_warn`              | provider usage > warn_at_pct     |
 
 ### Metrics
 
@@ -1303,6 +1483,8 @@ Additions to `docs/observability.md`:
 - `research.cost.cents{tier,provider}` (histogram)
 - `research.paid_spend.monthly{user}` (gauge)
 - `research.budget.exceeded_count{tier}`
+- `research.quota.remaining{provider,unit}` (gauge)
+- `research.quota.exhausted_count{provider}`
 
 ### Log annotations
 
@@ -1397,13 +1579,14 @@ Named so the v1 shape doesn't preclude them.
   "paid_budget_cents": 0,
   "cost_cents": 3,
   "paid_cost_cents": 0,
-  "cost_breakdown": { "firecrawl": 3 },
+  "cost_breakdown": { "firecrawl": 3 },                               // notional cents (volume governor)
+  "quota_breakdown": { "firecrawl": { "units": 6, "unit": "credits" } }, // actual provider units consumed
   "tokens_in": 12400,
   "tokens_out": 3100,
   "paid_policy": {
     "budget_cents": 100,
     "paid_budget_cents": 500,
-    "auto_approve_paid_cents": 500,
+    "auto_approve_paid_cents": 200,
     "paid_monthly_cap_cents": 2000,
     "resolved_at": "2026-04-09T14:32:10Z"
   },
@@ -1484,9 +1667,13 @@ Named so the v1 shape doesn't preclude them.
   "user_id": "usr_…",
   "provider": "einforma",
   "tool": "lookup_registry",
-  "amount_cents": 300,
+  "idempotency_key": "01J9ZK8QYM:lookup_registry:a1b2c3d4",
+  "amount_cents": 300,                                                    // notional (volume governor)
+  "quota_units": 1,                                                        // native: 1 report consumed
+  "quota_unit": "reports",
   "args": { "country": "ES", "tax_id": "F08234567", "depth": "financials" },
   "result_hash": "sha256:…",
+  "result_data": { "…": "full provider response, write-ahead persisted" },
   "source_id": "src_rep_1",
   "auto_approved": true,
   "approved_by": null,
@@ -1503,12 +1690,14 @@ Named so the v1 shape doesn't preclude them.
 - One research mode in v1: `deep` (LLM drives a tool loop).
 - Six capability providers (`Search`, `Scrape`, `Extract`, `Discover`, `Registry`, `Report`), selected per env var. Tech-agnostic.
 - Four tool tiers by cost: 0 (free), 1 (cheap web), 2 (moderate), 3 (paid structured). Climb only when needed.
-- One editable spending policy per user: four numbers (budget/run, paid budget/run, auto-approve threshold, monthly cap). Defaults allow €5/run paid spend, €20/month cap, auto-approved within budget.
+- Two-layer cost control: **resource budget** (notional cents, volume governor — limits how much a single run can consume) + **provider quotas** (native units — credits, reports, requests — tracks actual consumption against the user's plan). Layers are independent; a call can pass budget but fail quota or vice versa.
+- Resource budget: four numbers per user (budget/run, paid budget/run, auto-approve threshold, monthly cap). Defaults: €5/run paid budget, €2 auto-approve (first einforma call silent, second triggers propose_paid_action), €20/month cap. Per-run overrides clamped to user policy.
+- Provider quotas: per-provider plan config (total units, billing model, period). Opt-in — no quota row = budget-only gating.
 - Links are first-class: `sources` table, content hashes, archived `content_ref` copies, inline citations per claim, citation-validation at run completion.
 - Research never mutates domain rows. It writes `proposed_updates` that humans Apply via the existing update endpoints with OCC.
 - Effect handles the agent loop (`LanguageModel.streamText` + `Toolkit`), structured concurrency (`Fiber`, `onInterrupt`), observability, and persistence. No external agentic framework.
 - SSE live streaming via in-memory `PubSub`; `tool_log` jsonb on `research_runs` for post-run audit (no replay on reload).
-- Budget enforcement at the runtime level via `Ref`; monthly cap is the only non-overridable rail.
+- Monthly cap serialized via `pg_advisory_xact_lock` per user — no overshoot under concurrent fibers. Paid calls idempotent via `idempotency_key` on `research_paid_spend`.
 - MCP surface exposes `research_sync` (synchronous) and `start_research` / `get_research` (async) for Claude Desktop parity.
 - Output formats: jsonb for machine-facing data (`findings`, `sources`, events, policy), markdown text for human narrative (`brief_md`), Tiptap JSON only when saving to `documents.content`.
 - Ships as one vertical slice (§19).

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -20,14 +20,52 @@ packages/domain/src/          # Effect Schema types (no DB connection)
 │   └── index.ts
 └── index.ts
 
-packages/controllers/src/     # Shared HttpApiGroup specs (see TODO_BACKEND Phase 2b)
+packages/controllers/src/     # Shared HttpApiGroup specs
+├── routes/
+│   ├── research.ts           # ResearchGroup — /v1/research endpoints
+│   └── ...
+
+packages/research/src/        # Research bounded context
+├── domain/
+│   ├── errors.ts             # ProviderError, BudgetExceeded, QuotaExhausted, ...
+│   └── types.ts              # SearchResult, ScrapedPage, RegistryRecord, ...
+├── application/
+│   ├── ports.ts              # 6 capability ports + Budget + ProviderQuota
+│   ├── research-service.ts   # ResearchService — fiber-per-run agent loop
+│   ├── budget.ts             # Per-run + monthly spending control
+│   ├── provider-quota.ts     # Per-provider quota tracking
+│   ├── policy.ts             # System → user → per-run policy resolution
+│   └── schemas/              # Output schema registry
+│       ├── index.ts           # schemaRegistry Record<string, Schema>
+│       ├── freeform.ts
+│       ├── company-enrichment-v1.ts
+│       ├── competitor-scan-v1.ts
+│       ├── contact-discovery-v1.ts
+│       └── prospect-scan-v1.ts
+├── infrastructure/
+│   ├── _shared.ts            # disabledError, notYetImplementedError factories
+│   ├── providers-live.ts     # Boot-time selection for 6 capability ports
+│   ├── llm-live.ts           # Boot-time LLM provider selection
+│   ├── cached-search.ts      # TTL cache wrapping SearchProvider
+│   ├── stub/                 # Zero-cost deterministic fake data (local dev)
+│   │   ├── search.ts
+│   │   ├── scrape.ts
+│   │   ├── extract.ts
+│   │   ├── discover.ts
+│   │   ├── registry-es.ts
+│   │   ├── report-es.ts
+│   │   └── llm.ts
+│   └── brave/
+│       └── search.ts         # Real Brave Search API (template for newcomers)
+└── index.ts                  # Public exports
 
 apps/server/src/
 ├── db/
 │   ├── client.ts             # PgClient layer (from DATABASE_URL)
 │   ├── migrator.ts           # PgMigrator layer (file system loader)
 │   ├── migrations/           # Effect SQL migration files
-│   │   └── 0001_initial.ts
+│   │   ├── 0001_initial.ts
+│   │   └── 0003_research.ts  # research_runs, sources, paid_spend, quotas
 │   └── migrate.ts            # CRM + Better Auth migrations
 ├── main.ts                   # HTTP server entry point (REST API + MCP HTTP)
 ├── mcp-stdio.ts              # MCP stdio entry point (Claude Code local)
@@ -43,11 +81,12 @@ apps/server/src/
 │   ├── auth.ts               # Proxy to Better Auth handler
 │   ├── companies.ts
 │   ├── contacts.ts
+│   ├── research.ts           # Research API handler
 │   ├── ...
 │   └── health.ts
 ├── lib/
 │   ├── auth.ts               # Better Auth instance as ServiceMap.Service
-│   └── env.ts                # EnvVars service (DATABASE_URL, BETTER_AUTH_SECRET, etc.)
+│   └── env.ts                # EnvVars service (DATABASE_URL, RESEARCH_*, etc.)
 ├── mcp/
 │   ├── server.ts             # McpToolsLive — toolkits + resources + prompts
 │   ├── http.ts               # McpHttpLive — HTTP transport at /mcp
@@ -59,15 +98,22 @@ apps/server/src/
 │   │   ├── tasks.ts
 │   │   ├── documents.ts
 │   │   ├── pages.ts
-│   │   └── pipeline.ts
+│   │   ├── pipeline.ts
+│   │   ├── research-web.ts   # web_search, web_read, web_discover
+│   │   ├── research-registry.ts  # lookup_registry
+│   │   ├── research-crm.ts  # crm_lookup
+│   │   ├── research-sink.ts # propose_update, attach_finding, propose_paid_action
+│   │   └── research-mcp.ts  # start_research, get_research, research_sync
 │   ├── resources/
 │   │   ├── company.ts        # forja://company/{slug} (parameterized)
 │   │   ├── pipeline.ts       # forja://pipeline (static)
-│   │   └── document.ts       # forja://document/{id} (parameterized)
+│   │   ├── document.ts       # forja://document/{id} (parameterized)
+│   │   └── research.ts       # forja://research/{id} (parameterized)
 │   └── prompts/
 │       ├── _lang.ts           # LangParam + langDirective helper (ca/es/en)
 │       ├── _completions.ts    # Shared auto-completion (company slugs)
 │       ├── company-research.ts
+│       ├── research-designer.ts  # Research plan design prompt
 │       ├── daily-briefing.ts
 │       ├── proposal-draft.ts
 │       └── interaction-follow-up.ts
@@ -77,8 +123,10 @@ apps/server/src/
 │   └── better-auth.d.ts      # Type declarations for Better Auth
 └── services/                 # Business logic, called by both routes and MCP tools
     ├── companies.ts
-    ├── email.ts              # Resend: send outbound + handle inbound replies
+    ├── email.ts              # AgentMail: send outbound + handle inbound replies
+    ├── email-provider-live.ts # Boot-time email provider selection (Layer.unwrap)
     ├── pages.ts              # page CRUD, view tracking, publish/archive
+    ├── recordings.ts
     ├── webhooks.ts
     └── pipeline.ts
 ```
@@ -181,19 +229,26 @@ export default Effect.gen(function* () {
 
 ```typescript
 // apps/server/src/main.ts
+import { makeResearchLlmLive, makeResearchProvidersLive, ResearchService } from '@engranatge/research'
+
 const ApiLive = HttpApiBuilder.layer(ForjaApi).pipe(
-  Layer.provide([HealthLive, AuthHandlerLive, CompaniesLive, ...]),
+  Layer.provide([HealthLive, AuthHandlerLive, CompaniesLive, ResearchLive, ...]),
 )
 
 const ServicesLive = Layer.mergeAll(
-  CompanyService.layer, PipelineService.layer, PageService.layer, WebhookService.layer,
-)
+  CompanyService.layer, PipelineService.layer, PageService.layer,
+  EmailService.layer, RecordingService.layer, ResearchService.layer,
+).pipe(Layer.provideMerge(WebhookService.layer))
 
-// REST API + MCP HTTP on the same router
-const AppLive = Layer.merge(ApiLive, McpHttpLive)
+// REST API + MCP HTTP + CORS + docs on the same router
+const AppLive = Layer.mergeAll(ApiLive, McpHttpLive, CorsLive, DocsLive, OpenApiJsonLive)
 
 const program = HttpRouter.serve(AppLive).pipe(
   Layer.provide(ServicesLive),
+  Layer.provide(EmailProviderLive),
+  Layer.provide(S3StorageProviderLive),
+  Layer.provide(makeResearchProvidersLive),  // 6 capability ports (search, scrape, etc.)
+  Layer.provide(makeResearchLlmLive),        // LanguageModel for agent loop
   Layer.provide(SessionMiddlewareLive),
   Layer.provide(Auth.layer),
   Layer.provide(EnvVars.layer),
@@ -703,6 +758,107 @@ Events fired:
 
 ---
 
+## Research bounded context (`packages/research`)
+
+The research system lets AI agents autonomously gather and structure company intelligence. It runs as a fiber-per-research-run inside the server process, with SSE streaming and budget controls.
+
+### Provider matrix
+
+Each capability is backed by a swappable provider, selected at boot via env vars:
+
+```
+Search:    stub | brave | firecrawl
+Scrape:    stub | firecrawl | local
+Extract:   stub | firecrawl | local
+Discover:  stub | firecrawl | anthropic | none
+Registry:  stub | librebor | none
+Report:    stub | einforma | none
+LLM:       stub | groq | fireworks | nebius | together | sambanova | custom
+```
+
+`stub` = zero-cost deterministic fake data (default for local dev). `none` = capability disabled, fails with a clear error on call.
+
+### Env vars
+
+```bash
+# Capability providers (required, no defaults — boot fails if unset)
+RESEARCH_SEARCH_PROVIDER=stub
+RESEARCH_SCRAPE_PROVIDER=stub
+RESEARCH_EXTRACT_PROVIDER=stub
+RESEARCH_DISCOVER_PROVIDER=stub
+RESEARCH_REGISTRY_PROVIDER_ES=stub
+RESEARCH_REPORT_PROVIDER_ES=stub
+
+# Provider API keys (only needed for selected providers)
+# BRAVE_SEARCH_API_KEY=BSA...
+# FIRECRAWL_API_KEY=fc-...
+# EINFORMA_API_KEY=...
+
+# LLM inference (for agent loop — open source models via OpenAI-compatible APIs)
+RESEARCH_LLM_PROVIDER=stub
+# RESEARCH_LLM_MODEL=qwen/qwen3-32b
+# RESEARCH_LLM_API_KEY=gsk_...
+# RESEARCH_LLM_BASE_URL=         # only for custom provider
+
+# Budget defaults (system-level, overridable per-user via user_research_policy)
+RESEARCH_DEFAULT_BUDGET_CENTS=100
+RESEARCH_DEFAULT_PAID_BUDGET_CENTS=500
+RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS=200
+RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS=2000
+RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS=10000
+
+# Concurrency
+RESEARCH_MAX_CONCURRENT_FIBERS_PER_USER=3
+RESEARCH_MAX_CONCURRENCY_FANOUT=3
+RESEARCH_CONFIRM_THRESHOLD_FANOUT=10
+```
+
+### Layer composition
+
+```
+                     main.ts (composition root)
+                           │
+           ┌───────────────┼──────────────────┐
+           │               │                  │
+    FetchHttpClient     PgLive            EnvVars
+    (satisfies           (satisfies       (satisfies
+     HttpClient)          SqlClient)       Config)
+           │               │                  │
+           └───────────────┼──────────────────┘
+                   ┌───────┴───────┐
+                   │               │
+      makeResearchProvidersLive  makeResearchLlmLive
+      (6x Layer.unwrap)         (1x Layer.unwrap)
+                   │               │
+      ┌────────┬───┘          ┌────┴────┐
+      │        │              │         │
+StubSearch BraveSearch   StubLlm  OpenAiCompat
+R=never   R=HttpClient  R=never  R=HttpClient
+```
+
+Three kinds of provider layers:
+
+1. **Stub** — `Layer.succeed`, zero deps (`R = never`), deterministic fake data
+2. **Disabled** — `Layer.succeed`, zero deps, methods fail with `ProviderError`
+3. **Real** — `Layer.effect`, declares `R = HttpClient + Config`, real API calls
+
+### Research run lifecycle
+
+```
+POST /v1/research → create run row (status: queued) → fork fiber
+  Fiber:
+    Phase 1 — Tool loop (LLM calls tools: web_search, web_read, lookup_registry, ...)
+    Phase 2 — Structured output (LLM.generateObject with run's schema)
+    Phase 3 — Brief generation (markdown summary)
+  → SSE events via GET /v1/research/:id/events
+  → Findings persisted to research_runs.findings (jsonb)
+  → Sources deduped and archived to sources table
+```
+
+Fan-out groups: a `kind='group'` parent creates N `kind='leaf'` children. Each leaf completion merges findings onto the parent (`pg_advisory_xact_lock` for serialization) and rolls up the parent status.
+
+---
+
 ## Code quality — Biome
 
 Biome runs at the repo root and covers all packages. Config in `/biome.json`.
@@ -747,6 +903,29 @@ Style: 2-space indent, 100-char line width, single quotes, ES5 trailing commas, 
 2. Include `lang: LangParam` in parameters, prepend `langDirective(lang)` to output
 3. Use `completeCompanySlug` from `_completions.ts` for slug auto-completion
 4. Add to `McpToolsLive` in `src/mcp/server.ts`
+
+## Adding a new research capability provider
+
+Research capability providers implement one of the 6 ports in `packages/research/src/application/ports.ts`. Use `brave/search.ts` as a template.
+
+1. Create `packages/research/src/infrastructure/{vendor}/{capability}.ts`
+2. Use `Layer.effect(PortTag, Effect.gen(function* () { ... }))` pattern
+3. `yield*` any services you need (`HttpClient.HttpClient`, `Config.redacted(...)`)
+4. Return `PortTag.of({ methodName: (input) => Effect.gen(...) })`
+5. Map all errors to `new ProviderError({ provider: 'name', message, recoverable: bool })`
+6. Import in `providers-live.ts`, add a case to the relevant switch block
+7. Add the value to `Schema.Literals` for the matching `RESEARCH_*_PROVIDER` in `apps/server/src/lib/env.ts`
+
+The R type flows automatically — stubs have `R = never`, real providers declare `R = HttpClient` (or whatever they need), and the composition root in `main.ts` satisfies all requirements.
+
+## Adding a new LLM inference provider
+
+All inference providers (Groq, Nebius, Fireworks, Together, SambaNova) expose OpenAI-compatible APIs, so `@effect/ai-openai-compat` handles them with just a base URL.
+
+1. Add the provider name + base URL to `LLM_BASE_URLS` in `packages/research/src/infrastructure/llm-live.ts`
+2. Add the value to `Schema.Literals` for `RESEARCH_LLM_PROVIDER` in `apps/server/src/lib/env.ts`
+
+That's it — `OpenAiLanguageModel.model(name)` + `OpenAiClient.layer({ apiKey, apiUrl })` does the rest.
 
 ## Pages API
 

--- a/packages/controllers/src/api.ts
+++ b/packages/controllers/src/api.ts
@@ -12,6 +12,7 @@ import { PagesGroup } from './routes/pages'
 import { ProductsGroup } from './routes/products'
 import { ProposalsGroup } from './routes/proposals'
 import { RecordingsGroup } from './routes/recordings'
+import { ResearchGroup } from './routes/research'
 import { TasksGroup } from './routes/tasks'
 import { WebhooksGroup } from './routes/webhooks'
 
@@ -38,5 +39,6 @@ export const ForjaApi = HttpApi.make('ForjaApi')
 	.add(EmailGroup)
 	.add(AgentMailWebhookGroup)
 	.add(RecordingsGroup)
+	.add(ResearchGroup)
 
 export type ForjaApi = typeof ForjaApi

--- a/packages/controllers/src/errors.ts
+++ b/packages/controllers/src/errors.ts
@@ -73,3 +73,27 @@ export class StorageError extends Schema.TaggedErrorClass<StorageError>()(
 		key: Schema.NullOr(Schema.String),
 	},
 ) {}
+
+// ── Research HTTP errors (route-level, status-mapped) ──
+// Domain-level research errors (ProviderError, BudgetExceeded, etc.) live
+// in @engranatge/research. These are the HTTP-facing subset used in route
+// definitions for 409 responses.
+
+/** Pre-run estimate exceeds available budget. Returned as 409. */
+export class InsufficientBudget extends Schema.TaggedErrorClass<InsufficientBudget>()(
+	'InsufficientBudget',
+	{
+		estimatedCents: Schema.Number,
+		availableCents: Schema.Number,
+		shortfallCents: Schema.Number,
+	},
+) {}
+
+/** Fan-out exceeds confirm threshold. Returned as 409 with preview. */
+export class ConfirmRequired extends Schema.TaggedErrorClass<ConfirmRequired>()(
+	'ConfirmRequired',
+	{
+		estimatedCostCents: Schema.Number,
+		subjectCount: Schema.Number,
+	},
+) {}

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -5,11 +5,13 @@ export { ForjaApi } from './api'
 // pattern-match on these via `_tag`.
 export {
 	BadRequest,
+	ConfirmRequired,
 	Conflict,
 	EmailError,
 	EmailSendError,
 	EmailSendErrorKind,
 	EmailSuppressed,
+	InsufficientBudget,
 	NotFound,
 	StorageError,
 	StorageErrorOperation,
@@ -35,5 +37,6 @@ export { PagesGroup } from './routes/pages'
 export { ProductsGroup } from './routes/products'
 export { ProposalsGroup } from './routes/proposals'
 export { RecordingMetadata, RecordingsGroup } from './routes/recordings'
+export { ResearchGroup } from './routes/research'
 export { TasksGroup } from './routes/tasks'
 export { WebhooksGroup } from './routes/webhooks'

--- a/packages/controllers/src/routes/research.ts
+++ b/packages/controllers/src/routes/research.ts
@@ -1,0 +1,206 @@
+import { Schema } from 'effect'
+import {
+	HttpApiEndpoint,
+	HttpApiGroup,
+	HttpApiSchema,
+} from 'effect/unstable/httpapi'
+
+import { ConfirmRequired, InsufficientBudget, NotFound } from '../errors'
+import { SessionMiddleware } from '../middleware/session'
+
+// ── Input schemas ──
+
+const SubjectRef = Schema.Struct({
+	table: Schema.Literals(['companies', 'contacts']),
+	id: Schema.String,
+})
+
+const SelectorRef = Schema.Struct({
+	table: Schema.Literal('companies'),
+	filter: Schema.Unknown,
+})
+
+const Hints = Schema.Struct({
+	language: Schema.optional(Schema.Literals(['ca', 'es', 'en'])),
+	recency_days: Schema.optional(Schema.Number),
+	location: Schema.optional(Schema.String),
+})
+
+const ContextInput = Schema.Struct({
+	subjects: Schema.optional(Schema.Array(SubjectRef)),
+	selector: Schema.optional(SelectorRef),
+	hints: Schema.optional(Hints),
+})
+
+const CreateResearchInput = Schema.Struct({
+	query: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+	mode: Schema.optional(Schema.String),
+	context: Schema.optional(ContextInput),
+	schema_name: Schema.optional(Schema.String),
+	budget_cents: Schema.optional(Schema.Number),
+	paid_budget_cents: Schema.optional(Schema.Number),
+	auto_approve_paid_cents: Schema.optional(Schema.Number),
+	confirm: Schema.optional(Schema.Boolean),
+})
+
+const UpdatePolicyInput = Schema.Struct({
+	budget_cents: Schema.optional(Schema.Number),
+	paid_budget_cents: Schema.optional(Schema.Number),
+	auto_approve_paid_cents: Schema.optional(Schema.Number),
+	paid_monthly_cap_cents: Schema.optional(Schema.Number),
+})
+
+const AttachInput = Schema.Struct({
+	subject_table: Schema.Literals(['companies', 'contacts']),
+	subject_id: Schema.String,
+})
+
+// ── Route group ──
+
+export const ResearchGroup = HttpApiGroup.make('research')
+	// POST /research — create + fork
+	.add(
+		HttpApiEndpoint.post('create', '/research', {
+			payload: CreateResearchInput,
+			success: Schema.Unknown,
+			error: Schema.Union([
+				InsufficientBudget.pipe(HttpApiSchema.status(409)),
+				ConfirmRequired.pipe(HttpApiSchema.status(409)),
+			]),
+		}),
+	)
+	// GET /research — list, filter, paginate
+	.add(
+		HttpApiEndpoint.get('list', '/research', {
+			query: {
+				created_by: Schema.optional(Schema.String),
+				status: Schema.optional(Schema.String),
+				subject_table: Schema.optional(Schema.String),
+				subject_id: Schema.optional(Schema.String),
+				since: Schema.optional(Schema.String),
+				limit: Schema.optional(Schema.NumberFromString),
+				offset: Schema.optional(Schema.NumberFromString),
+			},
+			success: Schema.Array(Schema.Unknown),
+		}),
+	)
+	// GET /research/:id — full row with findings + sources
+	.add(
+		HttpApiEndpoint.get('get', '/research/:id', {
+			params: { id: Schema.String },
+			success: Schema.Unknown,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	// GET /research/:id/events — SSE live stream
+	.add(
+		HttpApiEndpoint.get('events', '/research/:id/events', {
+			params: { id: Schema.String },
+			success: Schema.Unknown,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	// POST /research/:id/cancel
+	.add(
+		HttpApiEndpoint.post('cancel', '/research/:id/cancel', {
+			params: { id: Schema.String },
+			success: Schema.Unknown,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	// POST /research/:id/attach — post-hoc link
+	.add(
+		HttpApiEndpoint.post('attach', '/research/:id/attach', {
+			params: { id: Schema.String },
+			payload: AttachInput,
+			success: Schema.Unknown,
+		}),
+	)
+	// DELETE /research/:id — soft-delete
+	.add(
+		HttpApiEndpoint.delete('delete', '/research/:id', {
+			params: { id: Schema.String },
+			success: Schema.Unknown,
+		}),
+	)
+	// GET /research/by-subject/:table/:id
+	.add(
+		HttpApiEndpoint.get('bySubject', '/research/by-subject/:table/:subjectId', {
+			params: {
+				table: Schema.String,
+				subjectId: Schema.String,
+			},
+			success: Schema.Array(Schema.Unknown),
+		}),
+	)
+	// Paid action approval workflow
+	.add(
+		HttpApiEndpoint.post(
+			'approvePaidAction',
+			'/research/:id/paid-actions/:paId/approve',
+			{
+				params: { id: Schema.String, paId: Schema.String },
+				success: Schema.Unknown,
+				error: NotFound.pipe(HttpApiSchema.status(404)),
+			},
+		),
+	)
+	.add(
+		HttpApiEndpoint.post(
+			'skipPaidAction',
+			'/research/:id/paid-actions/:paId/skip',
+			{
+				params: { id: Schema.String, paId: Schema.String },
+				success: Schema.Unknown,
+				error: NotFound.pipe(HttpApiSchema.status(404)),
+			},
+		),
+	)
+	// Proposed update workflow
+	.add(
+		HttpApiEndpoint.get(
+			'listProposedUpdates',
+			'/research/:id/proposed-updates',
+			{
+				params: { id: Schema.String },
+				success: Schema.Array(Schema.Unknown),
+				error: NotFound.pipe(HttpApiSchema.status(404)),
+			},
+		),
+	)
+	.add(
+		HttpApiEndpoint.post(
+			'applyProposedUpdate',
+			'/research/:id/proposed-updates/:puId/apply',
+			{
+				params: { id: Schema.String, puId: Schema.String },
+				success: Schema.Unknown,
+				error: NotFound.pipe(HttpApiSchema.status(404)),
+			},
+		),
+	)
+	.add(
+		HttpApiEndpoint.post(
+			'rejectProposedUpdate',
+			'/research/:id/proposed-updates/:puId/reject',
+			{
+				params: { id: Schema.String, puId: Schema.String },
+				success: Schema.Unknown,
+				error: NotFound.pipe(HttpApiSchema.status(404)),
+			},
+		),
+	)
+	// Policy
+	.add(
+		HttpApiEndpoint.get('getPolicy', '/research/preferences', {
+			success: Schema.Unknown,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.put('updatePolicy', '/research/policy', {
+			payload: UpdatePolicyInput,
+			success: Schema.Unknown,
+		}),
+	)
+	.middleware(SessionMiddleware)
+	.prefix('/v1')

--- a/packages/research/package.json
+++ b/packages/research/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@engranatge/research",
+	"version": "0.0.1",
+	"description": "Engranatge — research bounded context (provider ports, agent loop, budget, schemas)",
+	"type": "module",
+	"types": "./src/index.ts",
+	"main": "./src/index.ts",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"import": "./src/index.ts"
+		}
+	},
+	"scripts": {
+		"build": "tsdown",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@effect/ai-openai-compat": "4.0.0-beta.43",
+		"effect": "4.0.0-beta.43"
+	},
+	"devDependencies": {
+		"tsdown": "^0.21.7",
+		"typescript": "^5.9.3"
+	},
+	"private": true
+}

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -1,0 +1,186 @@
+import { Effect, Layer, Ref } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+import { BudgetExceeded, MonthlyCapExceeded } from '../domain/errors'
+import type { BudgetSnapshot, ResolvedPolicy } from '../domain/types'
+import { Budget } from './ports'
+
+// ── Monthly paid spend: check-and-debit serialized per user ──
+
+interface ChargeWithinCapInput {
+	readonly sql: SqlClient.SqlClient
+	readonly userId: string
+	readonly cents: number
+	readonly researchId: string
+	readonly provider: string
+	readonly tool: string
+	readonly idempotencyKey: string
+	readonly args: unknown
+	readonly autoApproved: boolean
+	readonly userCap: number
+	readonly systemCeiling: number
+}
+
+const chargeWithinCap = (input: ChargeWithinCapInput) =>
+	Effect.gen(function* () {
+		const { sql } = input
+		const cap = Math.min(input.userCap, input.systemCeiling)
+
+		// Single transaction: advisory lock → check → insert.
+		// pg_advisory_xact_lock serializes concurrent fibers for the same user.
+		yield* sql`SELECT pg_advisory_xact_lock(hashtext('research_monthly_cap:' || ${input.userId}))`
+
+		const rows = yield* sql<{ spent: number }>`
+			SELECT COALESCE(SUM(amount_cents), 0)::int AS spent
+			FROM research_paid_spend
+			WHERE user_id = ${input.userId}
+			  AND at >= date_trunc('month', now())
+		`
+		const spent = rows[0]?.spent ?? 0
+
+		if (spent + input.cents > cap) {
+			return yield* new MonthlyCapExceeded({
+				capCents: cap,
+				spentCents: spent,
+			})
+		}
+
+		// Idempotency: UNIQUE on idempotency_key. If this is a retry after
+		// a network timeout, the INSERT is a conflict no-op and the budget
+		// accounting stays correct.
+		yield* sql`
+			INSERT INTO research_paid_spend (
+				research_id, user_id, provider, tool, idempotency_key,
+				amount_cents, args, auto_approved, at
+			) VALUES (
+				${input.researchId}, ${input.userId}, ${input.provider},
+				${input.tool}, ${input.idempotencyKey},
+				${input.cents}, ${JSON.stringify(input.args)},
+				${input.autoApproved}, now()
+			) ON CONFLICT (idempotency_key) DO NOTHING
+		`
+	}).pipe(Effect.orDie)
+
+// ── Budget Layer factory ──
+
+export interface BudgetConfig {
+	readonly userId: string
+	readonly researchId: string
+	readonly policy: ResolvedPolicy
+	readonly systemCeiling: number
+}
+
+export const makeBudgetLayer = (config: BudgetConfig) =>
+	Layer.effect(
+		Budget,
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const cheapRef = yield* Ref.make({
+				budget: config.policy.budgetCents,
+				spent: 0,
+				remaining: config.policy.budgetCents,
+			})
+			const paidRef = yield* Ref.make({
+				budget: config.policy.paidBudgetCents,
+				spent: 0,
+				remaining: config.policy.paidBudgetCents,
+			})
+
+			return Budget.of({
+				init: (cheapCents: number, paidCents: number) =>
+					Effect.gen(function* () {
+						yield* Ref.set(cheapRef, {
+							budget: cheapCents,
+							spent: 0,
+							remaining: cheapCents,
+						})
+						yield* Ref.set(paidRef, {
+							budget: paidCents,
+							spent: 0,
+							remaining: paidCents,
+						})
+					}),
+
+				chargeCheap: (provider: string, cents: number) =>
+					Effect.gen(function* () {
+						const state = yield* Ref.get(cheapRef)
+						if (state.remaining < cents) {
+							return yield* new BudgetExceeded({
+								tier: 'cheap',
+								needed: cents,
+								remaining: state.remaining,
+							})
+						}
+						yield* Ref.update(cheapRef, s => ({
+							...s,
+							spent: s.spent + cents,
+							remaining: s.remaining - cents,
+						}))
+					}).pipe(
+						Effect.tap(() =>
+							Effect.logDebug('budget.chargeCheap').pipe(
+								Effect.annotateLogs({ provider, cents }),
+							),
+						),
+					),
+
+				chargePaid: (
+					provider: string,
+					cents: number,
+					idempotencyKey?: string,
+				) =>
+					Effect.gen(function* () {
+						const state = yield* Ref.get(paidRef)
+						if (state.remaining < cents) {
+							return yield* new BudgetExceeded({
+								tier: 'paid-run',
+								needed: cents,
+								remaining: state.remaining,
+							})
+						}
+
+						yield* chargeWithinCap({
+							sql,
+							userId: config.userId,
+							cents,
+							researchId: config.researchId,
+							provider,
+							tool: 'paid',
+							idempotencyKey:
+								idempotencyKey ??
+								`${config.researchId}:${provider}:${Date.now()}`,
+							args: {},
+							autoApproved: true,
+							userCap: config.policy.paidMonthlyCapCents,
+							systemCeiling: config.systemCeiling,
+						})
+
+						yield* Ref.update(paidRef, s => ({
+							...s,
+							spent: s.spent + cents,
+							remaining: s.remaining - cents,
+						}))
+					}).pipe(
+						Effect.tap(() =>
+							Effect.logDebug('budget.chargePaid').pipe(
+								Effect.annotateLogs({ provider, cents }),
+							),
+						),
+					),
+
+				snapshot: () =>
+					Effect.gen(function* () {
+						const cheap = yield* Ref.get(cheapRef)
+						const paid = yield* Ref.get(paidRef)
+						return {
+							cheapBudget: cheap.budget,
+							cheapSpent: cheap.spent,
+							cheapRemaining: cheap.remaining,
+							paidBudget: paid.budget,
+							paidSpent: paid.spent,
+							paidRemaining: paid.remaining,
+						} satisfies BudgetSnapshot
+					}),
+			})
+		}),
+	)

--- a/packages/research/src/application/policy.ts
+++ b/packages/research/src/application/policy.ts
@@ -1,0 +1,87 @@
+import { Effect } from 'effect'
+import type { SqlClient } from 'effect/unstable/sql'
+
+import { ResolvedPolicy } from '../domain/types'
+
+// ── Policy resolution ──
+// system env defaults → user policy → per-run override (clamped to user policy)
+
+export interface SystemDefaults {
+	readonly budgetCents: number
+	readonly paidBudgetCents: number
+	readonly autoApprovePaidCents: number
+	readonly paidMonthlyCapCents: number
+	readonly hardCeiling: number
+}
+
+export interface PerRunOverrides {
+	readonly budgetCents?: number | undefined
+	readonly paidBudgetCents?: number | undefined
+	readonly autoApprovePaidCents?: number | undefined
+	readonly paidMonthlyCapCents?: number | undefined
+}
+
+/** Resolve the effective policy for a research run. */
+export const resolvePolicy = (input: {
+	sql: SqlClient.SqlClient
+	userId: string
+	systemDefaults: SystemDefaults
+	perRunOverrides?: PerRunOverrides | undefined
+}) =>
+	Effect.gen(function* () {
+		const { sql, userId, systemDefaults, perRunOverrides } = input
+
+		// Load user policy (or use system defaults if no row exists)
+		const rows = yield* sql`
+			SELECT budget_cents, paid_budget_cents, auto_approve_paid_cents,
+				   paid_monthly_cap_cents
+			FROM user_research_policy
+			WHERE user_id = ${userId}
+			LIMIT 1
+		`
+
+		// Effect SQL auto-transforms snake_case columns → camelCase
+		const userPolicy = rows[0] as
+			| {
+					budgetCents: number
+					paidBudgetCents: number
+					autoApprovePaidCents: number
+					paidMonthlyCapCents: number
+			  }
+			| undefined
+
+		const base = {
+			budgetCents: userPolicy?.budgetCents ?? systemDefaults.budgetCents,
+			paidBudgetCents:
+				userPolicy?.paidBudgetCents ?? systemDefaults.paidBudgetCents,
+			autoApprovePaidCents:
+				userPolicy?.autoApprovePaidCents ?? systemDefaults.autoApprovePaidCents,
+			paidMonthlyCapCents: Math.min(
+				userPolicy?.paidMonthlyCapCents ?? systemDefaults.paidMonthlyCapCents,
+				systemDefaults.hardCeiling,
+			),
+		}
+
+		// Per-run overrides are clamped to user policy, not system ceiling.
+		// A buggy frontend can't bypass the user's own spending limits.
+		const resolved = new ResolvedPolicy({
+			budgetCents: clamp(perRunOverrides?.budgetCents, base.budgetCents),
+			paidBudgetCents: clamp(
+				perRunOverrides?.paidBudgetCents,
+				base.paidBudgetCents,
+			),
+			autoApprovePaidCents: clamp(
+				perRunOverrides?.autoApprovePaidCents,
+				base.autoApprovePaidCents,
+			),
+			paidMonthlyCapCents: base.paidMonthlyCapCents,
+		})
+
+		return resolved
+	})
+
+/** Clamp a per-run override to the user's ceiling. */
+function clamp(override: number | undefined, ceiling: number): number {
+	if (override === undefined) return ceiling
+	return Math.min(override, ceiling)
+}

--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -1,0 +1,188 @@
+import { type Effect, type Schema, ServiceMap } from 'effect'
+
+import type { ProviderError } from '../domain/errors'
+
+// ── Research run context (available inside the LLM tool loop fiber) ──
+
+export class ResearchRunContext extends ServiceMap.Service<
+	ResearchRunContext,
+	{ readonly researchId: string }
+>()('research/ResearchRunContext') {}
+
+import type {
+	BudgetSnapshot,
+	CompanyReport,
+	DiscoverResult,
+	ExternalJobRef,
+	RegistryRecord,
+	ScrapedPage,
+	SearchResult,
+} from '../domain/types'
+
+// ── Search ──
+
+export interface SearchInput {
+	readonly query: string
+	readonly limit?: number | undefined
+	readonly recency?: { days: number } | undefined
+	readonly location?: string | undefined
+	readonly languages?: string[] | undefined
+}
+
+export class SearchProvider extends ServiceMap.Service<
+	SearchProvider,
+	{
+		readonly search: (
+			input: SearchInput,
+		) => Effect.Effect<SearchResult, ProviderError>
+	}
+>()('research/SearchProvider') {}
+
+// ── Scrape ──
+
+export interface ScrapeInput {
+	readonly url: string
+	readonly formats?:
+		| ('markdown' | 'html' | 'links' | 'screenshot')[]
+		| undefined
+	readonly waitForSelector?: string | undefined
+	readonly location?: string | undefined
+}
+
+export class ScrapeProvider extends ServiceMap.Service<
+	ScrapeProvider,
+	{
+		readonly scrape: (
+			input: ScrapeInput,
+		) => Effect.Effect<ScrapedPage, ProviderError>
+	}
+>()('research/ScrapeProvider') {}
+
+// ── Extract ──
+// Returns `unknown` — caller decodes with Schema.decodeUnknown(schema)(raw).
+// Generic methods on ServiceMap.Service lose type params through the tag.
+
+export interface ExtractInput {
+	readonly url: string
+	readonly schema: Schema.Top
+	readonly prompt?: string | undefined
+}
+
+export class ExtractProvider extends ServiceMap.Service<
+	ExtractProvider,
+	{
+		readonly extract: (
+			input: ExtractInput,
+		) => Effect.Effect<unknown, ProviderError>
+	}
+>()('research/ExtractProvider') {}
+
+// ── Discover ──
+
+export interface DiscoverInput {
+	readonly prompt: string
+	readonly urls?: string[] | undefined
+	readonly schema?: Schema.Top | undefined
+	readonly maxCostCents?: number | undefined
+}
+
+export class DiscoverProvider extends ServiceMap.Service<
+	DiscoverProvider,
+	{
+		readonly discover: (
+			input: DiscoverInput,
+		) => Effect.Effect<DiscoverResult, ProviderError>
+		readonly cancel: (
+			jobRef: ExternalJobRef,
+		) => Effect.Effect<void, ProviderError>
+	}
+>()('research/DiscoverProvider') {}
+
+// ── Registry (country-routed) ──
+
+export interface RegistryInput {
+	readonly country: 'ES'
+	readonly query?: string | undefined
+	readonly taxId?: string | undefined
+}
+
+export class RegistryRouter extends ServiceMap.Service<
+	RegistryRouter,
+	{
+		readonly lookup: (
+			input: RegistryInput,
+		) => Effect.Effect<RegistryRecord, ProviderError>
+	}
+>()('research/RegistryRouter') {}
+
+// ── Report (country-routed, paid) ──
+
+export interface ReportInput {
+	readonly country: 'ES'
+	readonly taxId: string
+	readonly depth: 'basic' | 'financials' | 'full'
+}
+
+export class ReportRouter extends ServiceMap.Service<
+	ReportRouter,
+	{
+		readonly report: (
+			input: ReportInput,
+		) => Effect.Effect<CompanyReport, ProviderError>
+	}
+>()('research/ReportRouter') {}
+
+// ── Research event sink (observability — fires webhooks, metrics, etc.) ──
+
+export class ResearchEventSink extends ServiceMap.Service<
+	ResearchEventSink,
+	{
+		readonly fire: (event: string, payload: unknown) => Effect.Effect<void>
+	}
+>()('research/ResearchEventSink') {}
+
+// ── Budget ──
+
+export class Budget extends ServiceMap.Service<
+	Budget,
+	{
+		readonly init: (
+			cheapCents: number,
+			paidCents: number,
+		) => Effect.Effect<void>
+		readonly chargeCheap: (
+			provider: string,
+			cents: number,
+		) => Effect.Effect<void, import('../domain/errors').BudgetExceeded>
+		readonly chargePaid: (
+			provider: string,
+			cents: number,
+			idempotencyKey?: string,
+		) => Effect.Effect<
+			void,
+			| import('../domain/errors').BudgetExceeded
+			| import('../domain/errors').MonthlyCapExceeded
+		>
+		readonly snapshot: () => Effect.Effect<BudgetSnapshot>
+	}
+>()('research/Budget') {}
+
+// ── Provider Quota ──
+
+export class ProviderQuota extends ServiceMap.Service<
+	ProviderQuota,
+	{
+		readonly check: (
+			provider: string,
+			units: number,
+		) => Effect.Effect<void, import('../domain/errors').QuotaExhausted>
+		readonly consume: (
+			provider: string,
+			units: number,
+		) => Effect.Effect<void, import('../domain/errors').QuotaExhausted>
+		readonly remaining: (
+			provider: string,
+		) => Effect.Effect<{ total: number; used: number; unit: string }>
+		readonly sync: (provider: string) => Effect.Effect<void, ProviderError>
+	}
+>()('research/ProviderQuota') {}

--- a/packages/research/src/application/provider-quota.ts
+++ b/packages/research/src/application/provider-quota.ts
@@ -1,0 +1,133 @@
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+import { ProviderError, QuotaExhausted } from '../domain/errors'
+import { ProviderQuota } from './ports'
+
+// ── ProviderQuota Layer factory ──
+
+export interface ProviderQuotaConfig {
+	readonly userId: string
+}
+
+export const makeProviderQuotaLayer = (config: ProviderQuotaConfig) =>
+	Layer.effect(
+		ProviderQuota,
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+
+			// Read the quota config for a provider. Returns null if no quota
+			// is configured (quota check is skipped — budget is the only gate).
+			const getQuotaConfig = (provider: string) =>
+				Effect.gen(function* () {
+					const rows = yield* sql`
+						SELECT quota_total, quota_unit, period_months, period_anchor,
+							   sync_mode, billing_model, cents_per_unit
+						FROM provider_quotas
+						WHERE user_id = ${config.userId} AND provider = ${provider}
+						LIMIT 1
+					`
+					return rows[0] as
+						| {
+								quota_total: number
+								quota_unit: string
+								period_months: number
+								period_anchor: string | null
+								sync_mode: string
+								billing_model: string
+								cents_per_unit: number
+						  }
+						| undefined
+				}).pipe(Effect.orDie)
+
+			// Get current usage for a provider in the current period.
+			const getCurrentUsage = (provider: string) =>
+				Effect.gen(function* () {
+					const [row] = yield* sql<{ units_consumed: number }>`
+						SELECT COALESCE(units_consumed, 0)::int AS units_consumed
+						FROM provider_usage
+						WHERE user_id = ${config.userId}
+						  AND provider = ${provider}
+						  AND period_start = date_trunc('month', now())::date
+					`
+					return row?.units_consumed ?? 0
+				}).pipe(Effect.orDie)
+
+			return ProviderQuota.of({
+				check: (provider: string, units: number) =>
+					Effect.gen(function* () {
+						const quota = yield* getQuotaConfig(provider)
+						// No quota configured → skip check (budget is the only gate)
+						if (!quota) return
+
+						const used = yield* getCurrentUsage(provider)
+						const remaining = quota.quota_total - used
+						if (remaining < units) {
+							return yield* new QuotaExhausted({
+								provider,
+								unit: quota.quota_unit,
+								remaining: Math.max(0, remaining),
+							})
+						}
+					}),
+
+				consume: (provider: string, units: number) =>
+					Effect.gen(function* () {
+						const quota = yield* getQuotaConfig(provider)
+						if (!quota) return
+
+						const used = yield* getCurrentUsage(provider)
+						const remaining = quota.quota_total - used
+						if (remaining < units) {
+							return yield* new QuotaExhausted({
+								provider,
+								unit: quota.quota_unit,
+								remaining: Math.max(0, remaining),
+							})
+						}
+
+						// Upsert the usage counter. Period resets are implicit:
+						// if no row exists for current month, INSERT starts at 0.
+						yield* sql`
+							INSERT INTO provider_usage (user_id, provider, period_start, units_consumed)
+							VALUES (${config.userId}, ${provider}, date_trunc('month', now())::date, ${units})
+							ON CONFLICT (user_id, provider, period_start)
+							DO UPDATE SET units_consumed = provider_usage.units_consumed + ${units}
+						`.pipe(Effect.orDie)
+					}),
+
+				remaining: (provider: string) =>
+					Effect.gen(function* () {
+						const quota = yield* getQuotaConfig(provider)
+						if (!quota) return { total: 0, used: 0, unit: 'unknown' }
+
+						const used = yield* getCurrentUsage(provider)
+						return {
+							total: quota.quota_total,
+							used,
+							unit: quota.quota_unit,
+						}
+					}),
+
+				sync: (provider: string) =>
+					Effect.gen(function* () {
+						const quota = yield* getQuotaConfig(provider)
+						if (!quota || quota.sync_mode !== 'api') {
+							return yield* new ProviderError({
+								provider,
+								message: `sync not supported for ${provider} (sync_mode=${quota?.sync_mode ?? 'none'})`,
+								recoverable: false,
+							})
+						}
+
+						// Provider-specific sync logic is implemented in infrastructure
+						// adapters. This placeholder logs and returns — the actual sync
+						// (e.g. Firecrawl GET /v2/team/credit-usage) lives in the
+						// infrastructure layer and calls this service's consume/check.
+						yield* Effect.logInfo(
+							`provider quota sync requested for ${provider}`,
+						)
+					}),
+			})
+		}),
+	)

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1,0 +1,729 @@
+import {
+	DateTime,
+	Effect,
+	Fiber,
+	HashMap,
+	Layer,
+	PubSub,
+	Ref,
+	ServiceMap,
+	Stream,
+} from 'effect'
+import { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+
+import type { ResolvedPolicy } from '../domain/types'
+import { resolvePolicy, type SystemDefaults } from './policy'
+import { ResearchEventSink } from './ports'
+import { type FreeformSchema, schemaRegistry } from './schemas/index'
+
+// ── Event types for SSE streaming ──
+
+export type ResearchEventType =
+	| 'run.started'
+	| 'tool.called'
+	| 'tool.result'
+	| 'run.succeeded'
+	| 'run.failed'
+	| 'run.cancelled'
+
+export interface ResearchEvent {
+	readonly type: ResearchEventType
+	readonly researchId: string
+	readonly timestamp: string
+	readonly data: unknown
+}
+
+// ── Tool log entry (accumulated in-memory, persisted at completion) ──
+
+export interface ToolLogEntry {
+	readonly timestamp: string
+	readonly type: 'call' | 'result'
+	readonly tool: string
+	readonly input?: unknown
+	readonly output?: unknown
+	readonly error?: string
+	readonly durationMs?: number
+}
+
+// ── Research run input (from HTTP handler) ──
+
+export interface CreateResearchInput {
+	readonly query: string
+	readonly mode?: string | undefined
+	readonly context?:
+		| {
+				subjects?:
+					| Array<{ table: 'companies' | 'contacts'; id: string }>
+					| undefined
+				selector?:
+					| { table: 'companies'; filter: Record<string, unknown> }
+					| undefined
+				hints?:
+					| {
+							language?: 'ca' | 'es' | 'en' | undefined
+							recency_days?: number | undefined
+							location?: string | undefined
+					  }
+					| undefined
+		  }
+		| undefined
+	readonly schemaName?: string | undefined
+	readonly budgetCents?: number | undefined
+	readonly paidBudgetCents?: number | undefined
+	readonly autoApprovePaidCents?: number | undefined
+	readonly idempotencyKey?: string | undefined
+	readonly confirm?: boolean | undefined
+}
+
+// ── ResearchService ──
+
+export class ResearchService extends ServiceMap.Service<ResearchService>()(
+	'ResearchService',
+	{
+		make: Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const llm = yield* LanguageModel.LanguageModel
+
+			// ── Startup sweeper: mark orphaned running rows as failed ──
+			// Runs left in 'running' status across a server restart can never
+			// complete because their in-memory fiber is gone. Reclaim them.
+			const ORPHAN_AGE_SECONDS = 900
+			const swept = yield* sql`
+				UPDATE research_runs
+				SET status = 'failed',
+					findings = jsonb_set(findings, '{error}', '"server restarted mid-run"'),
+					completed_at = now(),
+					updated_at = now()
+				WHERE status = 'running'
+				  AND started_at < now() - interval '1 second' * ${ORPHAN_AGE_SECONDS}
+				RETURNING id
+			`
+			if (swept.length > 0) {
+				yield* Effect.logWarning(
+					'research.sweepOrphans: marked orphaned runs as failed',
+				).pipe(
+					Effect.annotateLogs({
+						count: swept.length,
+						ids: swept.map((r: any) => r.id),
+					}),
+				)
+			}
+
+			// Active runs: pubsub channels and fibers for cancellation
+			const activePubSubs = yield* Ref.make(
+				HashMap.empty<string, PubSub.PubSub<ResearchEvent>>(),
+			)
+			const activeFibers = yield* Ref.make(
+				HashMap.empty<string, Fiber.Fiber<void, unknown>>(),
+			)
+
+			// ── Event sink (observability: webhooks, metrics) ──
+			const eventSink = yield* ResearchEventSink
+
+			// ── Helpers ──
+
+			const publishEvent = (
+				researchId: string,
+				type: ResearchEventType,
+				data: unknown,
+			) =>
+				Effect.gen(function* () {
+					const map = yield* Ref.get(activePubSubs)
+					const maybePubSub = HashMap.get(map, researchId)
+					if (maybePubSub._tag === 'Some') {
+						yield* PubSub.publish(maybePubSub.value, {
+							type,
+							researchId,
+							timestamp: DateTime.nowUnsafe().toString(),
+							data,
+						})
+					}
+					// Fire to external observability (webhooks, metrics)
+					yield* eventSink
+						.fire(`research.${type.replace('run.', '')}`, {
+							researchId,
+							...(typeof data === 'object' && data !== null ? data : { data }),
+						})
+						.pipe(Effect.catch(() => Effect.void))
+				})
+
+			const snapshotSubjects = (
+				subjects: Array<{ table: string; id: string }>,
+			) =>
+				Effect.gen(function* () {
+					const snapshots = []
+					for (const s of subjects) {
+						const [row] = yield* sql`
+							SELECT *, version FROM ${sql(s.table)}
+							WHERE id = ${s.id} AND deleted_at IS NULL
+							LIMIT 1
+						`
+						if (row) {
+							snapshots.push({
+								...s,
+								snapshot: row,
+								expected_version: (row as { version: number }).version,
+							})
+						}
+					}
+					return snapshots
+				})
+
+			/** Merge leaf findings into parent group row (advisory-locked). */
+			const mergeToParent = (parentId: string, leafFindings: unknown) =>
+				Effect.gen(function* () {
+					yield* sql`SELECT pg_advisory_xact_lock(hashtext(${parentId}))`
+					yield* sql`
+						UPDATE research_runs
+						SET findings = jsonb_set(
+							findings,
+							'{leaf_results}',
+							COALESCE(findings->'leaf_results', '[]'::jsonb)
+								|| ${JSON.stringify([leafFindings])}::jsonb
+						),
+						updated_at = now()
+						WHERE id = ${parentId}
+					`
+					// Rollup parent status based on children (inside same lock)
+					yield* sql`
+						UPDATE research_runs
+						SET status = CASE
+							WHEN (SELECT COUNT(*) FILTER (WHERE status IN ('queued','running'))
+								FROM research_runs WHERE parent_id = ${parentId} AND status != 'deleted') > 0
+							THEN 'running'
+							WHEN (SELECT COUNT(*) FILTER (WHERE status = 'failed')
+								FROM research_runs WHERE parent_id = ${parentId} AND status != 'deleted') > 0
+							THEN 'failed'
+							ELSE 'succeeded'
+						END,
+						completed_at = CASE
+							WHEN (SELECT COUNT(*) FILTER (WHERE status IN ('queued','running'))
+								FROM research_runs WHERE parent_id = ${parentId} AND status != 'deleted') = 0
+							THEN now() ELSE completed_at
+						END,
+						updated_at = now()
+						WHERE id = ${parentId}
+					`
+				}).pipe(sql.withTransaction)
+
+			// ── Core: run a single research fiber ──
+
+			const runFiber = (
+				researchId: string,
+				userId: string,
+				// Reserved for the full budget/quota wiring (not yet plumbed
+				// into the LLM tool loop — will feed makeBudgetLayer).
+				_policy: ResolvedPolicy,
+				_systemCeiling: number,
+			) =>
+				Effect.gen(function* () {
+					// Update status to running
+					yield* sql`
+						UPDATE research_runs
+						SET status = 'running', started_at = now(), updated_at = now()
+						WHERE id = ${researchId}
+					`
+
+					yield* publishEvent(researchId, 'run.started', {})
+
+					// Load the run row
+					const [run] = yield* sql`
+						SELECT * FROM research_runs WHERE id = ${researchId}
+					`
+					if (!run) return
+
+					const context = run['context'] as CreateResearchInput['context']
+					const schemaName =
+						(run as { schemaName: string | null }).schemaName ?? 'freeform'
+
+					// Snapshot subjects if anchored
+					const subjects = context?.subjects
+						? yield* snapshotSubjects(context.subjects)
+						: []
+
+					// Resolve the schema
+					const outputSchema = schemaRegistry[schemaName]
+					if (!outputSchema) {
+						yield* sql`
+							UPDATE research_runs
+							SET status = 'failed',
+								findings = ${JSON.stringify({ error: `Unknown schema: ${schemaName}` })},
+								completed_at = now(), updated_at = now()
+							WHERE id = ${researchId}
+						`
+						yield* publishEvent(researchId, 'run.failed', {
+							error: `Unknown schema: ${schemaName}`,
+						})
+						return
+					}
+
+					// Tool log accumulator
+					const toolLog = yield* Ref.make<ToolLogEntry[]>([])
+
+					// Build system prompt
+					const subjectContext =
+						subjects.length > 0
+							? `\n\nSubject data (frozen snapshot):\n${JSON.stringify(subjects, null, 2)}`
+							: ''
+					const hintsContext = context?.hints
+						? `\n\nHints: language=${context.hints.language ?? 'en'}, recency=${context.hints.recency_days ?? 'any'}, location=${context.hints.location ?? 'any'}`
+						: ''
+					const systemPrompt = [
+						'You are a research agent for Forja CRM.',
+						'Given a query, produce a thorough research brief with findings, sources, and citations.',
+						'Never fabricate sources. Every claim must be verifiable.',
+						`Output schema: ${schemaName}`,
+						subjectContext,
+						hintsContext,
+					].join('\n')
+
+					// ── Phase 1: LLM research pass ──
+					// With a real LLM this drives a tool-calling loop.
+					// With stub LLM, returns deterministic text without tool calls.
+					yield* publishEvent(researchId, 'tool.called', {
+						tool: 'llm.generateText',
+						phase: 1,
+					})
+
+					const researchResponse = yield* llm.generateText({
+						prompt: `${systemPrompt}\n\n${(run as { query: string }).query}`,
+					})
+
+					yield* Ref.update(toolLog, log => [
+						...log,
+						{
+							timestamp: DateTime.nowUnsafe().toString(),
+							type: 'call' as const,
+							tool: 'llm.generateText',
+							input: { phase: 1, query: (run as { query: string }).query },
+						},
+						{
+							timestamp: DateTime.nowUnsafe().toString(),
+							type: 'result' as const,
+							tool: 'llm.generateText',
+							output: { textLength: researchResponse.text.length },
+						},
+					])
+					yield* publishEvent(researchId, 'tool.result', {
+						tool: 'llm.generateText',
+						phase: 1,
+						textLength: researchResponse.text.length,
+					})
+
+					// Track token usage
+					const tokensIn = researchResponse.usage.inputTokens.total ?? 0
+					let tokensOut = researchResponse.usage.outputTokens.total ?? 0
+
+					// ── Phase 2: Structured output ──
+					yield* publishEvent(researchId, 'tool.called', {
+						tool: 'llm.generateObject',
+						phase: 2,
+						schema: schemaName,
+					})
+
+					// Cast schema to satisfy generateObject's Encoder constraint.
+					// Registry schemas are all Structs with DecodingServices=never,
+					// but Schema.Top erases that — the cast is safe.
+					const structuredResponse = yield* llm.generateObject({
+						schema: outputSchema as typeof FreeformSchema,
+						prompt: `Based on this research, produce structured findings:\n\n${researchResponse.text}`,
+					})
+
+					const findings = structuredResponse.value as unknown
+					tokensOut += structuredResponse.usage.outputTokens.total ?? 0
+
+					yield* Ref.update(toolLog, log => [
+						...log,
+						{
+							timestamp: DateTime.nowUnsafe().toString(),
+							type: 'result' as const,
+							tool: 'llm.generateObject',
+							output: { schema: schemaName },
+						},
+					])
+					yield* publishEvent(researchId, 'tool.result', {
+						tool: 'llm.generateObject',
+						phase: 2,
+						schema: schemaName,
+					})
+
+					// ── Phase 3: Brief generation ──
+					const briefLang = context?.hints?.language ?? 'en'
+					yield* publishEvent(researchId, 'tool.called', {
+						tool: 'llm.generateText',
+						phase: 3,
+						language: briefLang,
+					})
+
+					const briefResponse = yield* llm.generateText({
+						prompt: `Write a concise human-readable research brief in ${briefLang} based on these findings:\n\n${JSON.stringify(findings)}`,
+					})
+
+					const briefMd = briefResponse.text
+					tokensOut += briefResponse.usage.outputTokens.total ?? 0
+
+					yield* Ref.update(toolLog, log => [
+						...log,
+						{
+							timestamp: DateTime.nowUnsafe().toString(),
+							type: 'result' as const,
+							tool: 'llm.generateText',
+							output: { phase: 3, briefLength: briefMd.length },
+						},
+					])
+
+					// ── Persist results ──
+					const finalToolLog = yield* Ref.get(toolLog)
+
+					yield* sql`
+						UPDATE research_runs
+						SET status = 'succeeded',
+							findings = ${JSON.stringify(findings)},
+							brief_md = ${briefMd},
+							tokens_in = ${tokensIn},
+							tokens_out = ${tokensOut},
+							tool_log = ${JSON.stringify(finalToolLog)},
+							completed_at = now(),
+							updated_at = now()
+						WHERE id = ${researchId}
+					`
+
+					// Merge findings onto parent group row if this is a leaf
+					const parentId = (run as { parentId: string | null }).parentId
+					if (parentId) {
+						yield* mergeToParent(parentId, findings)
+					}
+
+					yield* publishEvent(researchId, 'run.succeeded', {
+						tokensIn,
+						tokensOut,
+					})
+				}).pipe(
+					Effect.catch((error: unknown) =>
+						Effect.gen(function* () {
+							yield* sql`
+								UPDATE research_runs
+								SET status = 'failed',
+									findings = ${JSON.stringify({ error: String(error) })},
+									completed_at = now(),
+									updated_at = now()
+								WHERE id = ${researchId}
+							`
+							yield* publishEvent(researchId, 'run.failed', {
+								error: String(error),
+							})
+						}),
+					),
+					Effect.ensuring(
+						Effect.gen(function* () {
+							// Clean up pubsub and fiber refs
+							yield* Ref.update(activePubSubs, m =>
+								HashMap.remove(m, researchId),
+							)
+							yield* Ref.update(activeFibers, m =>
+								HashMap.remove(m, researchId),
+							)
+						}),
+					),
+					Effect.annotateLogs({
+						research_id: researchId,
+						user_id: userId,
+						event: 'research.fiber',
+					}),
+				)
+
+			return {
+				/** Create a research run, fork the fiber, return the run id. */
+				create: (
+					userId: string,
+					input: CreateResearchInput,
+					systemDefaults: SystemDefaults,
+				) =>
+					Effect.gen(function* () {
+						yield* Effect.logInfo('research.create').pipe(
+							Effect.annotateLogs({
+								user_id: userId,
+								query_length: input.query.length,
+								schema: input.schemaName ?? 'freeform',
+								mode: input.mode ?? 'deep',
+								has_subjects: !!input.context?.subjects?.length,
+								has_selector: !!input.context?.selector,
+							}),
+						)
+
+						// Resolve policy
+						const policy = yield* resolvePolicy({
+							sql,
+							userId,
+							systemDefaults,
+							perRunOverrides: {
+								budgetCents: input.budgetCents,
+								paidBudgetCents: input.paidBudgetCents,
+								autoApprovePaidCents: input.autoApprovePaidCents,
+							},
+						})
+
+						// Insert the run row
+						const [row] = yield* sql`
+							INSERT INTO research_runs (
+								query, mode, schema_name, status, context,
+								budget_cents, paid_budget_cents,
+								paid_policy, idempotency_key, created_by
+							) VALUES (
+								${input.query},
+								${input.mode ?? 'deep'},
+								${input.schemaName ?? null},
+								'queued',
+								${JSON.stringify(input.context ?? {})},
+								${policy.budgetCents},
+								${policy.paidBudgetCents},
+								${JSON.stringify(policy)},
+								${input.idempotencyKey ?? null},
+								${userId}
+							) RETURNING id
+						`
+						const researchId = (row as { id: string }).id
+
+						// Link input subjects
+						if (input.context?.subjects) {
+							for (const s of input.context.subjects) {
+								yield* sql`
+									INSERT INTO research_links (research_id, subject_table, subject_id, link_kind)
+									VALUES (${researchId}, ${s.table}, ${s.id}, 'input')
+									ON CONFLICT DO NOTHING
+								`
+							}
+						}
+
+						// Create PubSub for SSE streaming
+						const pubsub = yield* PubSub.unbounded<ResearchEvent>()
+						yield* Ref.update(activePubSubs, m =>
+							HashMap.set(m, researchId, pubsub),
+						)
+
+						// Fork the fiber
+						const fiber = yield* Effect.forkDetach(
+							runFiber(researchId, userId, policy, systemDefaults.hardCeiling),
+						)
+						yield* Ref.update(activeFibers, m =>
+							HashMap.set(m, researchId, fiber),
+						)
+
+						return { id: researchId, status: 'queued' as const }
+					}),
+
+				/** Get a research run by id. Groups include children inline. */
+				get: (researchId: string) =>
+					Effect.gen(function* () {
+						const [run] = yield* sql`
+							SELECT r.*,
+								COALESCE(
+									(SELECT json_agg(json_build_object(
+										'source_id', rs.source_id,
+										'local_ref', rs.local_ref,
+										'fetched_at', rs.fetched_at,
+										'cost_cents', rs.cost_cents,
+										'source', json_build_object(
+											'id', s.id,
+											'kind', s.kind,
+											'provider', s.provider,
+											'url', s.url,
+											'title', s.title,
+											'domain', s.domain,
+											'content_hash', s.content_hash,
+											'content_ref', s.content_ref
+										)
+									))
+									FROM research_run_sources rs
+									JOIN sources s ON s.id = rs.source_id
+									WHERE rs.research_id = r.id),
+									'[]'::json
+								) AS sources,
+								COALESCE(
+									(SELECT json_agg(json_build_object(
+										'subject_table', rl.subject_table,
+										'subject_id', rl.subject_id,
+										'link_kind', rl.link_kind
+									))
+									FROM research_links rl
+									WHERE rl.research_id = r.id),
+									'[]'::json
+								) AS links,
+								CASE WHEN r.kind = 'group' THEN
+									COALESCE(
+										(SELECT json_agg(json_build_object(
+											'id', c.id,
+											'kind', c.kind,
+											'status', c.status,
+											'query', c.query,
+											'findings', c.findings,
+											'brief_md', c.brief_md,
+											'cost_cents', c.cost_cents,
+											'completed_at', c.completed_at
+										) ORDER BY c.created_at)
+										FROM research_runs c
+										WHERE c.parent_id = r.id AND c.status != 'deleted'),
+										'[]'::json
+									)
+								ELSE '[]'::json END AS children
+							FROM research_runs r
+							WHERE r.id = ${researchId} AND r.status != 'deleted'
+						`
+						return run ?? null
+					}),
+
+				/** List research runs with filters. */
+				list: (filters: {
+					createdBy?: string | undefined
+					status?: string | undefined
+					subjectTable?: string | undefined
+					subjectId?: string | undefined
+					since?: string | undefined
+					limit?: number | undefined
+					offset?: number | undefined
+				}) =>
+					Effect.gen(function* () {
+						const conditions: Array<
+							import('effect/unstable/sql').Statement.Fragment
+						> = [sql`r.status != 'deleted'`]
+						if (filters.createdBy)
+							conditions.push(sql`r.created_by = ${filters.createdBy}`)
+						if (filters.status)
+							conditions.push(sql`r.status = ${filters.status}`)
+						if (filters.since)
+							conditions.push(sql`r.created_at >= ${filters.since}`)
+
+						if (filters.subjectTable && filters.subjectId) {
+							conditions.push(sql`EXISTS (
+								SELECT 1 FROM research_links rl
+								WHERE rl.research_id = r.id
+								  AND rl.subject_table = ${filters.subjectTable}
+								  AND rl.subject_id = ${filters.subjectId}
+							)`)
+						}
+
+						return yield* sql`
+							SELECT r.id, r.kind, r.query, r.mode, r.schema_name,
+								r.status, r.cost_cents, r.paid_cost_cents,
+								r.created_by, r.created_at, r.completed_at
+							FROM research_runs r
+							WHERE ${sql.and(conditions)}
+							ORDER BY r.created_at DESC
+							LIMIT ${filters.limit ?? 20}
+							OFFSET ${filters.offset ?? 0}
+						`
+					}),
+
+				/** Get all runs linked to a subject row. */
+				bySubject: (table: string, id: string) =>
+					sql`
+						SELECT r.id, r.kind, r.query, r.mode, r.schema_name,
+							r.status, r.cost_cents, r.created_at, r.completed_at
+						FROM research_runs r
+						JOIN research_links rl ON rl.research_id = r.id
+						WHERE rl.subject_table = ${table}
+						  AND rl.subject_id = ${id}
+						  AND r.status != 'deleted'
+						ORDER BY r.created_at DESC
+					`,
+
+				/** Subscribe to SSE events for a run. Returns a Stream. */
+				subscribe: (researchId: string) =>
+					Effect.gen(function* () {
+						const map = yield* Ref.get(activePubSubs)
+						const maybePubSub = HashMap.get(map, researchId)
+						if (maybePubSub._tag === 'None') return null
+						return Stream.fromPubSub(maybePubSub.value)
+					}),
+
+				/** Cancel a running research fiber. */
+				cancel: (researchId: string) =>
+					Effect.gen(function* () {
+						yield* Effect.logInfo('research.cancel').pipe(
+							Effect.annotateLogs({ research_id: researchId }),
+						)
+						const map = yield* Ref.get(activeFibers)
+						const maybeFiber = HashMap.get(map, researchId)
+						if (maybeFiber._tag === 'Some') {
+							yield* Fiber.interrupt(maybeFiber.value)
+						}
+						yield* sql`
+							UPDATE research_runs
+							SET status = 'cancelled', completed_at = now(), updated_at = now()
+							WHERE id = ${researchId} AND status IN ('queued', 'running')
+						`
+						yield* publishEvent(researchId, 'run.cancelled', {})
+					}),
+
+				/** Soft-delete a research run. */
+				softDelete: (researchId: string) =>
+					sql`
+						UPDATE research_runs
+						SET status = 'deleted', updated_at = now()
+						WHERE id = ${researchId}
+					`,
+
+				/** Post-hoc attach a subject to a run. */
+				attach: (researchId: string, subjectTable: string, subjectId: string) =>
+					sql`
+						INSERT INTO research_links (research_id, subject_table, subject_id, link_kind)
+						VALUES (${researchId}, ${subjectTable}, ${subjectId}, 'finding')
+						ON CONFLICT DO NOTHING
+					`,
+
+				/** Get user's research policy. */
+				getPolicy: (userId: string) =>
+					Effect.gen(function* () {
+						const [row] = yield* sql`
+							SELECT * FROM user_research_policy WHERE user_id = ${userId}
+						`
+						return row ?? null
+					}),
+
+				/** Update user's research policy. */
+				updatePolicy: (
+					userId: string,
+					fields: {
+						budgetCents?: number | undefined
+						paidBudgetCents?: number | undefined
+						autoApprovePaidCents?: number | undefined
+						paidMonthlyCapCents?: number | undefined
+					},
+				) =>
+					sql`
+						INSERT INTO user_research_policy (user_id, budget_cents, paid_budget_cents, auto_approve_paid_cents, paid_monthly_cap_cents, updated_at)
+						VALUES (
+							${userId},
+							${fields.budgetCents ?? 100},
+							${fields.paidBudgetCents ?? 500},
+							${fields.autoApprovePaidCents ?? 200},
+							${fields.paidMonthlyCapCents ?? 2000},
+							now()
+						)
+						ON CONFLICT (user_id) DO UPDATE SET
+							budget_cents = COALESCE(${fields.budgetCents ?? null}, user_research_policy.budget_cents),
+							paid_budget_cents = COALESCE(${fields.paidBudgetCents ?? null}, user_research_policy.paid_budget_cents),
+							auto_approve_paid_cents = COALESCE(${fields.autoApprovePaidCents ?? null}, user_research_policy.auto_approve_paid_cents),
+							paid_monthly_cap_cents = COALESCE(${fields.paidMonthlyCapCents ?? null}, user_research_policy.paid_monthly_cap_cents),
+							updated_at = now()
+						RETURNING *
+					`,
+
+				/** Mark orphaned running rows as failed (startup sweeper). */
+				sweepOrphans: (maxAgeSeconds: number) =>
+					sql`
+						UPDATE research_runs
+						SET status = 'failed',
+							findings = jsonb_set(findings, '{error}', '"server restarted mid-run"'),
+							completed_at = now(),
+							updated_at = now()
+						WHERE status = 'running'
+						  AND started_at < now() - interval '1 second' * ${maxAgeSeconds}
+					`,
+			}
+		}),
+	},
+) {
+	static readonly layer = Layer.effect(this, this.make)
+}

--- a/packages/research/src/application/schemas/company-enrichment-v1.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.ts
@@ -1,0 +1,71 @@
+import { Schema } from 'effect'
+
+const Citation = Schema.Struct({
+	source_id: Schema.String,
+	quote: Schema.optional(Schema.String),
+	confidence: Schema.optional(Schema.Number),
+})
+
+export const CompanyEnrichmentV1Schema = Schema.Struct({
+	enrichment: Schema.Struct({
+		industry: Schema.optional(Schema.String),
+		size_range: Schema.optional(Schema.String),
+		pain_points: Schema.optional(Schema.String),
+		current_tools: Schema.optional(Schema.String),
+		products_fit: Schema.optional(Schema.Array(Schema.String)),
+		tags: Schema.optional(Schema.Array(Schema.String)),
+		citations: Schema.Array(Citation),
+	}),
+	competitors: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				name: Schema.String,
+				website: Schema.optional(Schema.String),
+				why: Schema.optional(Schema.String),
+				citations: Schema.Array(Citation),
+			}),
+		),
+	),
+	contacts: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				name: Schema.String,
+				role: Schema.optional(Schema.String),
+				email: Schema.optional(Schema.String),
+				phone: Schema.optional(Schema.String),
+				citations: Schema.Array(Citation),
+			}),
+		),
+	),
+	discovered_existing: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				name: Schema.String,
+			}),
+		),
+	),
+	proposed_updates: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				expected_version: Schema.Number,
+				fields: Schema.Unknown,
+				reason: Schema.String,
+				citations: Schema.Array(Citation),
+			}),
+		),
+	),
+	pending_paid_actions: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				tool: Schema.String,
+				args: Schema.Unknown,
+				estimated_cents: Schema.Number,
+				reason: Schema.String,
+			}),
+		),
+	),
+})

--- a/packages/research/src/application/schemas/competitor-scan-v1.ts
+++ b/packages/research/src/application/schemas/competitor-scan-v1.ts
@@ -1,0 +1,60 @@
+import { Schema } from 'effect'
+
+const Citation = Schema.Struct({
+	source_id: Schema.String,
+	quote: Schema.optional(Schema.String),
+	confidence: Schema.optional(Schema.Number),
+})
+
+export const CompetitorScanV1Schema = Schema.Struct({
+	competitors: Schema.Array(
+		Schema.Struct({
+			name: Schema.String,
+			website: Schema.optional(Schema.String),
+			description: Schema.optional(Schema.String),
+			strengths: Schema.optional(Schema.Array(Schema.String)),
+			weaknesses: Schema.optional(Schema.Array(Schema.String)),
+			overlap: Schema.optional(Schema.String),
+			citations: Schema.Array(Citation),
+		}),
+	),
+	market_summary: Schema.optional(
+		Schema.Struct({
+			total_competitors_found: Schema.Number,
+			market_maturity: Schema.optional(Schema.String),
+			key_differentiators: Schema.optional(Schema.Array(Schema.String)),
+			citations: Schema.Array(Citation),
+		}),
+	),
+	discovered_existing: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				name: Schema.String,
+			}),
+		),
+	),
+	proposed_updates: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				expected_version: Schema.Number,
+				fields: Schema.Unknown,
+				reason: Schema.String,
+				citations: Schema.Array(Citation),
+			}),
+		),
+	),
+	pending_paid_actions: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				tool: Schema.String,
+				args: Schema.Unknown,
+				estimated_cents: Schema.Number,
+				reason: Schema.String,
+			}),
+		),
+	),
+})

--- a/packages/research/src/application/schemas/contact-discovery-v1.ts
+++ b/packages/research/src/application/schemas/contact-discovery-v1.ts
@@ -1,0 +1,53 @@
+import { Schema } from 'effect'
+
+const Citation = Schema.Struct({
+	source_id: Schema.String,
+	quote: Schema.optional(Schema.String),
+	confidence: Schema.optional(Schema.Number),
+})
+
+export const ContactDiscoveryV1Schema = Schema.Struct({
+	contacts: Schema.Array(
+		Schema.Struct({
+			name: Schema.String,
+			role: Schema.optional(Schema.String),
+			email: Schema.optional(Schema.String),
+			phone: Schema.optional(Schema.String),
+			linkedin: Schema.optional(Schema.String),
+			is_decision_maker: Schema.optional(Schema.Boolean),
+			notes: Schema.optional(Schema.String),
+			citations: Schema.Array(Citation),
+		}),
+	),
+	discovered_existing: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				name: Schema.String,
+			}),
+		),
+	),
+	proposed_updates: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				expected_version: Schema.Number,
+				fields: Schema.Unknown,
+				reason: Schema.String,
+				citations: Schema.Array(Citation),
+			}),
+		),
+	),
+	pending_paid_actions: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				tool: Schema.String,
+				args: Schema.Unknown,
+				estimated_cents: Schema.Number,
+				reason: Schema.String,
+			}),
+		),
+	),
+})

--- a/packages/research/src/application/schemas/freeform.ts
+++ b/packages/research/src/application/schemas/freeform.ts
@@ -1,0 +1,32 @@
+import { Schema } from 'effect'
+
+/** Freeform research — no structured output, markdown brief only. */
+export const FreeformSchema = Schema.Struct({
+	proposed_updates: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				expected_version: Schema.Number,
+				fields: Schema.Unknown,
+				reason: Schema.String,
+				citations: Schema.Array(
+					Schema.Struct({
+						source_id: Schema.String,
+						quote: Schema.optional(Schema.String),
+					}),
+				),
+			}),
+		),
+	),
+	pending_paid_actions: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				tool: Schema.String,
+				args: Schema.Unknown,
+				estimated_cents: Schema.Number,
+				reason: Schema.String,
+			}),
+		),
+	),
+})

--- a/packages/research/src/application/schemas/index.ts
+++ b/packages/research/src/application/schemas/index.ts
@@ -1,0 +1,28 @@
+import type { Schema } from 'effect'
+
+import { CompanyEnrichmentV1Schema } from './company-enrichment-v1'
+import { CompetitorScanV1Schema } from './competitor-scan-v1'
+import { ContactDiscoveryV1Schema } from './contact-discovery-v1'
+import { FreeformSchema } from './freeform'
+import { ProspectScanV1Schema } from './prospect-scan-v1'
+
+// Closed set of server-compiled Effect Schemas. Versioned so schemas can
+// evolve without breaking old runs. Callers pass schema_name as a string;
+// the service resolves it here for LanguageModel.generateObject.
+export const schemaRegistry: Record<string, Schema.Top> = {
+	freeform: FreeformSchema,
+	company_enrichment_v1: CompanyEnrichmentV1Schema,
+	competitor_scan_v1: CompetitorScanV1Schema,
+	contact_discovery_v1: ContactDiscoveryV1Schema,
+	prospect_scan_v1: ProspectScanV1Schema,
+}
+
+export type SchemaName = keyof typeof schemaRegistry
+
+export {
+	CompanyEnrichmentV1Schema,
+	CompetitorScanV1Schema,
+	ContactDiscoveryV1Schema,
+	FreeformSchema,
+	ProspectScanV1Schema,
+}

--- a/packages/research/src/application/schemas/prospect-scan-v1.ts
+++ b/packages/research/src/application/schemas/prospect-scan-v1.ts
@@ -1,0 +1,53 @@
+import { Schema } from 'effect'
+
+const Citation = Schema.Struct({
+	source_id: Schema.String,
+	quote: Schema.optional(Schema.String),
+	confidence: Schema.optional(Schema.Number),
+})
+
+export const ProspectScanV1Schema = Schema.Struct({
+	prospects: Schema.Array(
+		Schema.Struct({
+			name: Schema.String,
+			website: Schema.optional(Schema.String),
+			tax_id: Schema.optional(Schema.String),
+			industry: Schema.optional(Schema.String),
+			region: Schema.optional(Schema.String),
+			why_relevant: Schema.String,
+			pain_indicators: Schema.optional(Schema.Array(Schema.String)),
+			citations: Schema.Array(Citation),
+		}),
+	),
+	discovered_existing: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				name: Schema.String,
+			}),
+		),
+	),
+	proposed_updates: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				subject_table: Schema.Literals(['companies', 'contacts']),
+				subject_id: Schema.String,
+				expected_version: Schema.Number,
+				fields: Schema.Unknown,
+				reason: Schema.String,
+				citations: Schema.Array(Citation),
+			}),
+		),
+	),
+	pending_paid_actions: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				tool: Schema.String,
+				args: Schema.Unknown,
+				estimated_cents: Schema.Number,
+				reason: Schema.String,
+			}),
+		),
+	),
+})

--- a/packages/research/src/domain/errors.ts
+++ b/packages/research/src/domain/errors.ts
@@ -1,0 +1,54 @@
+import { Schema } from 'effect'
+
+// ── Research domain errors ──
+// These are internal to the research bounded context. The server maps them
+// to HTTP errors at the handler layer (e.g., BudgetExceeded → 409). They
+// are Schema.TaggedErrorClass so they serialize over SSE tool error events.
+
+/** External provider call failed (Firecrawl, Exa, libreBORME, etc.). */
+export class ProviderError extends Schema.TaggedErrorClass<ProviderError>()(
+	'ProviderError',
+	{
+		provider: Schema.String,
+		message: Schema.String,
+		recoverable: Schema.Boolean,
+	},
+) {}
+
+/** Per-run resource budget (cheap or paid tier) exceeded. */
+export class BudgetExceeded extends Schema.TaggedErrorClass<BudgetExceeded>()(
+	'BudgetExceeded',
+	{
+		tier: Schema.Literals(['cheap', 'paid-run']),
+		needed: Schema.Number,
+		remaining: Schema.Number,
+	},
+) {}
+
+/** Per-user monthly paid spend cap exceeded. Terminal for the run. */
+export class MonthlyCapExceeded extends Schema.TaggedErrorClass<MonthlyCapExceeded>()(
+	'MonthlyCapExceeded',
+	{
+		capCents: Schema.Number,
+		spentCents: Schema.Number,
+	},
+) {}
+
+/** Provider quota (native units) exhausted. Recoverable: try alternative. */
+export class QuotaExhausted extends Schema.TaggedErrorClass<QuotaExhausted>()(
+	'QuotaExhausted',
+	{
+		provider: Schema.String,
+		unit: Schema.String,
+		remaining: Schema.Number,
+	},
+) {}
+
+/** Paid call above auto-approve threshold. LLM should call propose_paid_action. */
+export class ApprovalRequired extends Schema.TaggedErrorClass<ApprovalRequired>()(
+	'ApprovalRequired',
+	{
+		tool: Schema.String,
+		estimatedCents: Schema.Number,
+	},
+) {}

--- a/packages/research/src/domain/types.ts
+++ b/packages/research/src/domain/types.ts
@@ -1,0 +1,108 @@
+import { Schema } from 'effect'
+
+// ── Shared value types across all research providers ──
+
+/** A single search result from any search provider. */
+export class SearchResultItem extends Schema.Class<SearchResultItem>(
+	'SearchResultItem',
+)({
+	url: Schema.String,
+	title: Schema.String,
+	snippet: Schema.String,
+	publishedAt: Schema.optional(Schema.DateTimeUtc),
+	score: Schema.optional(Schema.Number),
+}) {}
+
+export class SearchResult extends Schema.Class<SearchResult>('SearchResult')({
+	items: Schema.Array(SearchResultItem),
+	units: Schema.Number,
+}) {}
+
+/** A scraped page returned by ScrapeProvider. */
+export class ScrapedPage extends Schema.Class<ScrapedPage>('ScrapedPage')({
+	url: Schema.String,
+	markdown: Schema.optional(Schema.String),
+	html: Schema.optional(Schema.String),
+	links: Schema.optional(Schema.Array(Schema.String)),
+	title: Schema.optional(Schema.String),
+	language: Schema.optional(Schema.String),
+	contentHash: Schema.String,
+	units: Schema.Number,
+}) {}
+
+/** Result of an autonomous browsing session (DiscoverProvider). */
+export class DiscoverResult extends Schema.Class<DiscoverResult>(
+	'DiscoverResult',
+)({
+	findings: Schema.String,
+	structuredData: Schema.optional(Schema.Unknown),
+	sourcesVisited: Schema.Array(Schema.String),
+	units: Schema.Number,
+}) {}
+
+/** A reference to an external async job (e.g. Firecrawl agent). */
+export class ExternalJobRef extends Schema.Class<ExternalJobRef>(
+	'ExternalJobRef',
+)({
+	provider: Schema.String,
+	jobId: Schema.String,
+}) {}
+
+/** A company record from a free registry (e.g. libreBORME). */
+export class RegistryRecord extends Schema.Class<RegistryRecord>(
+	'RegistryRecord',
+)({
+	legalName: Schema.String,
+	taxId: Schema.optional(Schema.String),
+	status: Schema.optional(Schema.String),
+	incorporationDate: Schema.optional(Schema.String),
+	capital: Schema.optional(Schema.String),
+	address: Schema.optional(Schema.String),
+	directors: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				name: Schema.String,
+				role: Schema.optional(Schema.String),
+				since: Schema.optional(Schema.String),
+			}),
+		),
+	),
+	raw: Schema.optional(Schema.Unknown),
+	units: Schema.Number,
+}) {}
+
+/** A paid company report (e.g. einforma). */
+export class CompanyReport extends Schema.Class<CompanyReport>('CompanyReport')(
+	{
+		legalName: Schema.String,
+		taxId: Schema.String,
+		depth: Schema.Literals(['basic', 'financials', 'full']),
+		financials: Schema.optional(Schema.Unknown),
+		shareholders: Schema.optional(Schema.Unknown),
+		riskScore: Schema.optional(Schema.Number),
+		raw: Schema.optional(Schema.Unknown),
+		units: Schema.Number,
+	},
+) {}
+
+/** Budget snapshot at a point in time. */
+export class BudgetSnapshot extends Schema.Class<BudgetSnapshot>(
+	'BudgetSnapshot',
+)({
+	cheapBudget: Schema.Number,
+	cheapSpent: Schema.Number,
+	cheapRemaining: Schema.Number,
+	paidBudget: Schema.Number,
+	paidSpent: Schema.Number,
+	paidRemaining: Schema.Number,
+}) {}
+
+/** Resolved spending policy for a single run. Frozen on research_runs.paid_policy. */
+export class ResolvedPolicy extends Schema.Class<ResolvedPolicy>(
+	'ResolvedPolicy',
+)({
+	budgetCents: Schema.Number,
+	paidBudgetCents: Schema.Number,
+	autoApprovePaidCents: Schema.Number,
+	paidMonthlyCapCents: Schema.Number,
+}) {}

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -1,0 +1,75 @@
+// Research bounded context entry point. The server imports ports + types
+// for handler wiring; infrastructure implementations live in this package
+// and are selected at boot-time via env vars.
+
+// ── Application (services) ─────────────────────────────────────────────────
+export { type BudgetConfig, makeBudgetLayer } from './application/budget'
+export {
+	type PerRunOverrides,
+	resolvePolicy,
+	type SystemDefaults,
+} from './application/policy'
+export type {
+	DiscoverInput,
+	ExtractInput,
+	RegistryInput,
+	ReportInput,
+	ScrapeInput,
+	SearchInput,
+} from './application/ports'
+// ── Application (ports) ────────────────────────────────────────────────────
+export {
+	Budget,
+	DiscoverProvider,
+	ExtractProvider,
+	ProviderQuota,
+	RegistryRouter,
+	ReportRouter,
+	ResearchEventSink,
+	ResearchRunContext,
+	ScrapeProvider,
+	SearchProvider,
+} from './application/ports'
+export {
+	makeProviderQuotaLayer,
+	type ProviderQuotaConfig,
+} from './application/provider-quota'
+export {
+	type CreateResearchInput,
+	type ResearchEvent,
+	type ResearchEventType,
+	ResearchService,
+	type ToolLogEntry,
+} from './application/research-service'
+export type { SchemaName } from './application/schemas/index'
+// ── Application (schemas) ──────────────────────────────────────────────────
+export {
+	CompanyEnrichmentV1Schema,
+	CompetitorScanV1Schema,
+	ContactDiscoveryV1Schema,
+	FreeformSchema,
+	ProspectScanV1Schema,
+	schemaRegistry,
+} from './application/schemas/index'
+// ── Domain ─────────────────────────────────────────────────────────────────
+export {
+	ApprovalRequired,
+	BudgetExceeded,
+	MonthlyCapExceeded,
+	ProviderError,
+	QuotaExhausted,
+} from './domain/errors'
+export type {
+	BudgetSnapshot,
+	CompanyReport,
+	DiscoverResult,
+	ExternalJobRef,
+	RegistryRecord,
+	ResolvedPolicy,
+	ScrapedPage,
+	SearchResult,
+	SearchResultItem,
+} from './domain/types'
+export { makeResearchLlmLive } from './infrastructure/llm-live'
+// ── Infrastructure (provider layers) ──────────────────────────────────────
+export { makeResearchProvidersLive } from './infrastructure/providers-live'

--- a/packages/research/src/infrastructure/_shared.ts
+++ b/packages/research/src/infrastructure/_shared.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared helpers for research provider infrastructure.
+ *
+ * Two factory patterns for non-functional providers:
+ * - `disabledError` — capability intentionally turned off (provider=none)
+ * - `notYetImplementedError` — provider value recognised but code not written yet
+ */
+
+import { Effect } from 'effect'
+
+import { ProviderError } from '../domain/errors'
+
+/** Error for a capability that is intentionally disabled (provider=none). */
+export const disabledError = (capability: string) =>
+	Effect.fail(
+		new ProviderError({
+			provider: capability,
+			message: `capability disabled (provider=none). Set RESEARCH_*_PROVIDER to enable.`,
+			recoverable: false,
+		}),
+	)
+
+/** Error for a provider value that is recognised but not yet implemented. */
+export const notYetImplementedError = (capability: string, provider: string) =>
+	Effect.fail(
+		new ProviderError({
+			provider,
+			message: `provider '${provider}' for ${capability} is not yet implemented`,
+			recoverable: false,
+		}),
+	)

--- a/packages/research/src/infrastructure/brave/search.ts
+++ b/packages/research/src/infrastructure/brave/search.ts
@@ -1,0 +1,92 @@
+/**
+ * Brave Search provider — real web search via the Brave Search API.
+ *
+ * Pattern: Layer.effect (requires HttpClient + Config at R).
+ * This file serves as the **template** for adding new real providers.
+ * To create a new provider: copy this file, adjust the URL/schema/mapping.
+ *
+ * @see https://api.search.brave.com/app/documentation/web-search
+ */
+
+import { Config, Effect, Layer, Redacted, Schema } from 'effect'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
+
+import { type SearchInput, SearchProvider } from '../../application/ports'
+import { ProviderError } from '../../domain/errors'
+import { SearchResult, SearchResultItem } from '../../domain/types'
+
+// ── Brave API response schema (subset we care about) ──
+
+const BraveWebResult = Schema.Struct({
+	title: Schema.String,
+	url: Schema.String,
+	description: Schema.String,
+	page_age: Schema.optional(Schema.String),
+})
+
+const BraveSearchResponse = Schema.Struct({
+	web: Schema.optional(
+		Schema.Struct({
+			results: Schema.Array(BraveWebResult),
+		}),
+	),
+})
+
+// ── Provider implementation ──
+
+export const BraveSearchProvider = Layer.effect(
+	SearchProvider,
+	Effect.gen(function* () {
+		const apiKey = yield* Config.redacted('BRAVE_SEARCH_API_KEY')
+		const client = yield* HttpClient.HttpClient
+
+		return SearchProvider.of({
+			search: (input: SearchInput) =>
+				client
+					.get('https://api.search.brave.com/res/v1/web/search', {
+						headers: {
+							Accept: 'application/json',
+							'Accept-Encoding': 'gzip',
+							'X-Subscription-Token': Redacted.value(apiKey),
+						},
+						urlParams: {
+							q: input.query,
+							count: String(input.limit ?? 10),
+							...(input.recency
+								? {
+										freshness: `pd${input.recency.days}`,
+									}
+								: {}),
+							...(input.location ? { country: input.location } : {}),
+						},
+					})
+					.pipe(
+						Effect.flatMap(
+							HttpClientResponse.schemaBodyJson(BraveSearchResponse),
+						),
+						Effect.map(
+							body =>
+								new SearchResult({
+									items: (body.web?.results ?? []).map(
+										r =>
+											new SearchResultItem({
+												url: r.url,
+												title: r.title,
+												snippet: r.description,
+											}),
+									),
+									units: 1,
+								}),
+						),
+						Effect.mapError(
+							e =>
+								new ProviderError({
+									provider: 'brave',
+									message: String(e),
+									recoverable: true,
+								}),
+						),
+					),
+		})
+	}),
+)

--- a/packages/research/src/infrastructure/cached-search.ts
+++ b/packages/research/src/infrastructure/cached-search.ts
@@ -1,0 +1,70 @@
+/**
+ * Wraps a SearchProvider with a shared in-memory TTL cache.
+ *
+ * Key = stable hash of (query + limit + recency + location + languages).
+ * TTL = 5 minutes (covers the lifetime of a typical fan-out group).
+ * Cache is per-server-instance (not cross-node), which is fine for v1.
+ *
+ * Usage in providers-live.ts:
+ *   const cachedSearch = makeCachedSearch().pipe(Layer.provide(innerSearchLayer))
+ */
+
+import { Effect, HashMap, Layer, Option, Ref } from 'effect'
+
+import { type SearchInput, SearchProvider } from '../application/ports'
+import type { SearchResult } from '../domain/types'
+
+interface CacheEntry {
+	readonly result: SearchResult
+	readonly expiresAt: number
+}
+
+/** Deterministic hash of a SearchInput for cache keying. */
+const stableHash = (input: SearchInput): string => {
+	const parts = [
+		input.query,
+		String(input.limit ?? ''),
+		String(input.recency?.days ?? ''),
+		input.location ?? '',
+		(input.languages ?? []).sort().join(','),
+	]
+	// Simple string hash — collisions are harmless (just a cache miss)
+	let h = 0
+	const s = parts.join('|')
+	for (let i = 0; i < s.length; i++) {
+		h = (Math.imul(31, h) + s.charCodeAt(i)) | 0
+	}
+	return String(h)
+}
+
+export const makeCachedSearch = (ttlMs = 5 * 60_000) =>
+	Layer.effect(
+		SearchProvider,
+		Effect.gen(function* () {
+			const inner = yield* SearchProvider
+			const cache = yield* Ref.make(HashMap.empty<string, CacheEntry>())
+
+			return SearchProvider.of({
+				search: input =>
+					Effect.gen(function* () {
+						const key = stableHash(input)
+						const now = Date.now()
+						const map = yield* Ref.get(cache)
+						const hit = HashMap.get(map, key)
+
+						if (Option.isSome(hit) && hit.value.expiresAt > now) {
+							return hit.value.result
+						}
+
+						const result = yield* inner.search(input)
+						yield* Ref.update(cache, m =>
+							HashMap.set(m, key, {
+								result,
+								expiresAt: now + ttlMs,
+							}),
+						)
+						return result
+					}),
+			})
+		}),
+	)

--- a/packages/research/src/infrastructure/llm-live.ts
+++ b/packages/research/src/infrastructure/llm-live.ts
@@ -1,0 +1,63 @@
+/**
+ * Boot-time LLM provider selection layer.
+ *
+ * Reads RESEARCH_LLM_PROVIDER env var at startup and returns the
+ * matching Layer that provides LanguageModel. All real providers
+ * use @effect/ai-openai-compat since they expose OpenAI-compatible APIs.
+ *
+ * Env vars:
+ *   RESEARCH_LLM_PROVIDER  — stub | groq | fireworks | nebius | together | sambanova | custom
+ *   RESEARCH_LLM_MODEL     — model name (required when not stub)
+ *   RESEARCH_LLM_API_KEY   — API key (required when not stub)
+ *   RESEARCH_LLM_BASE_URL  — override base URL (only for custom)
+ */
+
+import { OpenAiClient, OpenAiLanguageModel } from '@effect/ai-openai-compat'
+import { Config, Effect, Layer } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+
+import { StubLanguageModel } from './stub/llm'
+
+const LLM_BASE_URLS: Record<string, string> = {
+	groq: 'https://api.groq.com/openai/v1',
+	fireworks: 'https://api.fireworks.ai/inference/v1',
+	nebius: 'https://api.studio.nebius.ai/v1',
+	together: 'https://api.together.xyz/v1',
+	sambanova: 'https://api.sambanova.ai/v1',
+}
+
+export const makeResearchLlmLive = Layer.unwrap(
+	Effect.gen(function* () {
+		const provider = yield* Config.string('RESEARCH_LLM_PROVIDER')
+		yield* Effect.logInfo(`research.llm: ${provider}`)
+
+		if (provider === 'stub') return StubLanguageModel
+
+		const model = yield* Config.string('RESEARCH_LLM_MODEL')
+		const apiKey = yield* Config.redacted('RESEARCH_LLM_API_KEY')
+		const baseUrl =
+			provider === 'custom'
+				? yield* Config.string('RESEARCH_LLM_BASE_URL')
+				: LLM_BASE_URLS[provider]
+
+		if (!baseUrl) {
+			return yield* Effect.die(
+				new Error(
+					`Unknown RESEARCH_LLM_PROVIDER: '${provider}'. ` +
+						`Use one of: stub, ${Object.keys(LLM_BASE_URLS).join(', ')}, custom`,
+				),
+			)
+		}
+
+		// Model extends Layer — provides LanguageModel, requires OpenAiClient
+		return OpenAiLanguageModel.model(model).pipe(
+			Layer.provide(
+				OpenAiClient.layer({
+					apiKey,
+					apiUrl: baseUrl,
+				}),
+			),
+			Layer.provide(FetchHttpClient.layer),
+		)
+	}),
+)

--- a/packages/research/src/infrastructure/providers-live.ts
+++ b/packages/research/src/infrastructure/providers-live.ts
@@ -1,0 +1,214 @@
+/**
+ * Boot-time provider selection layer for all 6 research capabilities.
+ *
+ * Reads RESEARCH_*_PROVIDER env vars at startup via Config.schema and
+ * returns the matching Layer for each capability. Uses the same
+ * Layer.unwrap + Config.schema pattern as EmailProviderLive.
+ *
+ * @see apps/server/src/services/email-provider-live.ts for the template
+ */
+
+import { Config, Effect, Layer, Schema } from 'effect'
+
+import {
+	DiscoverProvider,
+	ExtractProvider,
+	RegistryRouter,
+	ReportRouter,
+	ScrapeProvider,
+	SearchProvider,
+} from '../application/ports'
+import { disabledError, notYetImplementedError } from './_shared'
+import { BraveSearchProvider } from './brave/search'
+import { makeCachedSearch } from './cached-search'
+import { StubDiscoverProvider } from './stub/discover'
+import { StubExtractProvider } from './stub/extract'
+import { StubRegistryEsProvider } from './stub/registry-es'
+import { StubReportEsProvider } from './stub/report-es'
+import { StubScrapeProvider } from './stub/scrape'
+import { StubSearchProvider } from './stub/search'
+
+// ── Search (with cache wrapper) ──
+
+const searchLayer = Layer.unwrap(
+	Effect.gen(function* () {
+		const p = yield* Config.schema(
+			Schema.Literals(['stub', 'brave', 'firecrawl']),
+			'RESEARCH_SEARCH_PROVIDER',
+		)
+		yield* Effect.logInfo(`research.search: ${p}`)
+		switch (p) {
+			case 'stub':
+				return StubSearchProvider
+			case 'brave':
+				return BraveSearchProvider
+			case 'firecrawl':
+				return Layer.succeed(SearchProvider)(
+					SearchProvider.of({
+						search: () => notYetImplementedError('search', 'firecrawl'),
+					}),
+				)
+		}
+	}),
+)
+const cachedSearchLayer = makeCachedSearch().pipe(Layer.provide(searchLayer))
+
+// ── Scrape ──
+
+const scrapeLayer = Layer.unwrap(
+	Effect.gen(function* () {
+		const p = yield* Config.schema(
+			Schema.Literals(['stub', 'firecrawl', 'local']),
+			'RESEARCH_SCRAPE_PROVIDER',
+		)
+		yield* Effect.logInfo(`research.scrape: ${p}`)
+		switch (p) {
+			case 'stub':
+				return StubScrapeProvider
+			case 'firecrawl':
+				return Layer.succeed(ScrapeProvider)(
+					ScrapeProvider.of({
+						scrape: () => notYetImplementedError('scrape', 'firecrawl'),
+					}),
+				)
+			case 'local':
+				return Layer.succeed(ScrapeProvider)(
+					ScrapeProvider.of({
+						scrape: () => notYetImplementedError('scrape', 'local'),
+					}),
+				)
+		}
+	}),
+)
+
+// ── Extract ──
+
+const extractLayer = Layer.unwrap(
+	Effect.gen(function* () {
+		const p = yield* Config.schema(
+			Schema.Literals(['stub', 'firecrawl', 'local']),
+			'RESEARCH_EXTRACT_PROVIDER',
+		)
+		yield* Effect.logInfo(`research.extract: ${p}`)
+		switch (p) {
+			case 'stub':
+				return StubExtractProvider
+			case 'firecrawl':
+				return Layer.succeed(ExtractProvider)(
+					ExtractProvider.of({
+						extract: () => notYetImplementedError('extract', 'firecrawl'),
+					}),
+				)
+			case 'local':
+				return Layer.succeed(ExtractProvider)(
+					ExtractProvider.of({
+						extract: () => notYetImplementedError('extract', 'local'),
+					}),
+				)
+		}
+	}),
+)
+
+// ── Discover ──
+
+const discoverLayer = Layer.unwrap(
+	Effect.gen(function* () {
+		const p = yield* Config.schema(
+			Schema.Literals(['stub', 'firecrawl', 'anthropic', 'none']),
+			'RESEARCH_DISCOVER_PROVIDER',
+		)
+		yield* Effect.logInfo(`research.discover: ${p}`)
+		switch (p) {
+			case 'stub':
+				return StubDiscoverProvider
+			case 'none':
+				return Layer.succeed(DiscoverProvider)(
+					DiscoverProvider.of({
+						discover: () => disabledError('discover'),
+						cancel: () => disabledError('discover'),
+					}),
+				)
+			case 'firecrawl':
+				return Layer.succeed(DiscoverProvider)(
+					DiscoverProvider.of({
+						discover: () => notYetImplementedError('discover', 'firecrawl'),
+						cancel: () => notYetImplementedError('discover', 'firecrawl'),
+					}),
+				)
+			case 'anthropic':
+				return Layer.succeed(DiscoverProvider)(
+					DiscoverProvider.of({
+						discover: () => notYetImplementedError('discover', 'anthropic'),
+						cancel: () => notYetImplementedError('discover', 'anthropic'),
+					}),
+				)
+		}
+	}),
+)
+
+// ── Registry (ES) ──
+
+const registryEsLayer = Layer.unwrap(
+	Effect.gen(function* () {
+		const p = yield* Config.schema(
+			Schema.Literals(['stub', 'librebor', 'none']),
+			'RESEARCH_REGISTRY_PROVIDER_ES',
+		)
+		yield* Effect.logInfo(`research.registry.es: ${p}`)
+		switch (p) {
+			case 'stub':
+				return StubRegistryEsProvider
+			case 'none':
+				return Layer.succeed(RegistryRouter)(
+					RegistryRouter.of({
+						lookup: () => disabledError('registry'),
+					}),
+				)
+			case 'librebor':
+				return Layer.succeed(RegistryRouter)(
+					RegistryRouter.of({
+						lookup: () => notYetImplementedError('registry', 'librebor'),
+					}),
+				)
+		}
+	}),
+)
+
+// ── Report (ES) ──
+
+const reportEsLayer = Layer.unwrap(
+	Effect.gen(function* () {
+		const p = yield* Config.schema(
+			Schema.Literals(['stub', 'einforma', 'none']),
+			'RESEARCH_REPORT_PROVIDER_ES',
+		)
+		yield* Effect.logInfo(`research.report.es: ${p}`)
+		switch (p) {
+			case 'stub':
+				return StubReportEsProvider
+			case 'none':
+				return Layer.succeed(ReportRouter)(
+					ReportRouter.of({
+						report: () => disabledError('report'),
+					}),
+				)
+			case 'einforma':
+				return Layer.succeed(ReportRouter)(
+					ReportRouter.of({
+						report: () => notYetImplementedError('report', 'einforma'),
+					}),
+				)
+		}
+	}),
+)
+
+// ── Merged layer ──
+
+export const makeResearchProvidersLive = Layer.mergeAll(
+	cachedSearchLayer,
+	scrapeLayer,
+	extractLayer,
+	discoverLayer,
+	registryEsLayer,
+	reportEsLayer,
+)

--- a/packages/research/src/infrastructure/stub/discover.ts
+++ b/packages/research/src/infrastructure/stub/discover.ts
@@ -1,0 +1,34 @@
+/**
+ * Stub discover provider — returns deterministic fake findings.
+ *
+ * Pattern: Layer.succeed (no dependencies, no I/O, no cost).
+ * `cancel` is a no-op since there is no real async job.
+ */
+
+import { Effect, Layer } from 'effect'
+
+import { DiscoverProvider } from '../../application/ports'
+import { DiscoverResult } from '../../domain/types'
+
+export const StubDiscoverProvider = Layer.succeed(DiscoverProvider)(
+	DiscoverProvider.of({
+		discover: _input =>
+			Effect.succeed(
+				new DiscoverResult({
+					findings: [
+						'Acme Corp S.L. (CIF B12345678) is a Barcelona-based industrial solutions company.',
+						'Founded in 2005, they employ 85 people and reported €12M revenue in 2025.',
+						'Key focus areas: industrial automation, supply chain optimisation.',
+						'Recent expansion plans target Mediterranean markets (announced Q1 2026).',
+					].join('\n'),
+					sourcesVisited: [
+						'https://acmecorp.es',
+						'https://linkedin.com/company/acme-corp-sl',
+						'https://news.example.com/acme-expansion',
+					],
+					units: 0,
+				}),
+			),
+		cancel: _jobRef => Effect.void,
+	}),
+)

--- a/packages/research/src/infrastructure/stub/extract.ts
+++ b/packages/research/src/infrastructure/stub/extract.ts
@@ -1,0 +1,29 @@
+/**
+ * Stub extract provider — returns a deterministic fake company object.
+ *
+ * Pattern: Layer.succeed (no dependencies, no I/O, no cost).
+ * Returns `unknown` matching the ExtractProvider port contract —
+ * the caller decodes with Schema.decodeUnknown(schema)(raw).
+ */
+
+import { Effect, Layer } from 'effect'
+
+import { ExtractProvider } from '../../application/ports'
+
+export const StubExtractProvider = Layer.succeed(ExtractProvider)(
+	ExtractProvider.of({
+		extract: _input =>
+			Effect.succeed({
+				company_name: 'Acme Corp S.L.',
+				tax_id: 'B12345678',
+				address: 'Carrer de la Indústria 42, 08025 Barcelona',
+				phone: '+34 932 000 111',
+				email: 'info@acmecorp.es',
+				website: 'https://acmecorp.es',
+				employees: 85,
+				revenue_eur: 12_000_000,
+				sector: 'Industrial automation',
+				founded_year: 2005,
+			}),
+	}),
+)

--- a/packages/research/src/infrastructure/stub/llm.ts
+++ b/packages/research/src/infrastructure/stub/llm.ts
@@ -1,0 +1,58 @@
+/**
+ * Stub LanguageModel — returns deterministic text without calling any inference API.
+ *
+ * Pattern: Layer.succeed (no dependencies, no I/O, no cost).
+ * Used when RESEARCH_LLM_PROVIDER=stub for zero-cost local development.
+ *
+ * The stub returns fixed text for generateText/generateObject/streamText.
+ * Tool calls are never emitted — the research pipeline sees an LLM that
+ * immediately returns a summary without gathering data. This is fine for
+ * testing the pipeline mechanics (fiber lifecycle, status transitions,
+ * findings persistence) without needing real inference.
+ */
+
+import { Effect, Layer, Stream } from 'effect'
+import { LanguageModel } from 'effect/unstable/ai'
+
+const STUB_TEXT =
+	'Acme Corp S.L. (CIF B12345678) is a Barcelona-based industrial solutions company founded in 2005. ' +
+	'They employ 85 people and reported €12M revenue in 2025. Key focus: industrial automation.'
+
+const stubResponse = {
+	text: STUB_TEXT,
+	content: [{ type: 'text' as const, text: STUB_TEXT }],
+	reasoning: [],
+	reasoningText: undefined,
+	toolCalls: [],
+	toolResults: [],
+	finishReason: 'stop' as const,
+	usage: {
+		inputTokens: {
+			uncached: undefined,
+			total: 0,
+			cacheRead: undefined,
+			cacheWrite: undefined,
+		},
+		outputTokens: { total: 0, text: undefined, reasoning: undefined },
+	},
+}
+
+export const StubLanguageModel = Layer.succeed(LanguageModel.LanguageModel)(
+	LanguageModel.LanguageModel.of({
+		generateText: (_options: unknown) => Effect.succeed(stubResponse) as never,
+		generateObject: (_options: unknown) =>
+			Effect.succeed({
+				...stubResponse,
+				value: {
+					company_name: 'Acme Corp S.L.',
+					tax_id: 'B12345678',
+					summary: STUB_TEXT,
+				},
+			}) as never,
+		streamText: (_options: unknown) =>
+			Stream.succeed({
+				type: 'text-delta' as const,
+				delta: STUB_TEXT,
+			}) as never,
+	}),
+)

--- a/packages/research/src/infrastructure/stub/registry-es.ts
+++ b/packages/research/src/infrastructure/stub/registry-es.ts
@@ -1,0 +1,35 @@
+/**
+ * Stub Spanish registry provider — returns a deterministic fake company record.
+ *
+ * Pattern: Layer.succeed (no dependencies, no I/O, no cost).
+ * Matches the RegistryRecord schema with Acme Corp S.L. data.
+ */
+
+import { Effect, Layer } from 'effect'
+
+import { RegistryRouter } from '../../application/ports'
+import { RegistryRecord } from '../../domain/types'
+
+export const StubRegistryEsProvider = Layer.succeed(RegistryRouter)(
+	RegistryRouter.of({
+		lookup: _input =>
+			Effect.succeed(
+				new RegistryRecord({
+					legalName: 'ACME CORP S.L.',
+					taxId: 'B12345678',
+					status: 'Activa',
+					incorporationDate: '2005-03-15',
+					capital: '60.000 EUR',
+					address: 'CARRER DE LA INDÚSTRIA 42, 08025 BARCELONA (BARCELONA)',
+					directors: [
+						{
+							name: 'GARCIA LOPEZ, MARIA',
+							role: 'Administradora Única',
+							since: '2005-03-15',
+						},
+					],
+					units: 0,
+				}),
+			),
+	}),
+)

--- a/packages/research/src/infrastructure/stub/report-es.ts
+++ b/packages/research/src/infrastructure/stub/report-es.ts
@@ -1,0 +1,49 @@
+/**
+ * Stub Spanish report provider — returns a deterministic fake company report.
+ *
+ * Pattern: Layer.succeed (no dependencies, no I/O, no cost).
+ * Matches the CompanyReport schema with Acme Corp S.L. data.
+ */
+
+import { Effect, Layer } from 'effect'
+
+import { ReportRouter } from '../../application/ports'
+import { CompanyReport } from '../../domain/types'
+
+export const StubReportEsProvider = Layer.succeed(ReportRouter)(
+	ReportRouter.of({
+		report: input =>
+			Effect.succeed(
+				new CompanyReport({
+					legalName: 'ACME CORP S.L.',
+					taxId: input.taxId,
+					depth: input.depth,
+					financials:
+						input.depth === 'basic'
+							? undefined
+							: {
+									revenue_2025: 12_000_000,
+									ebitda_2025: 1_800_000,
+									net_profit_2025: 1_200_000,
+									total_assets: 8_500_000,
+									total_liabilities: 3_200_000,
+								},
+					shareholders:
+						input.depth === 'full'
+							? [
+									{
+										name: 'GARCIA LOPEZ, MARIA',
+										percentage: 60,
+									},
+									{
+										name: 'FERNANDEZ RUIZ, CARLOS',
+										percentage: 40,
+									},
+								]
+							: undefined,
+					riskScore: 25,
+					units: 0,
+				}),
+			),
+	}),
+)

--- a/packages/research/src/infrastructure/stub/scrape.ts
+++ b/packages/research/src/infrastructure/stub/scrape.ts
@@ -1,0 +1,45 @@
+/**
+ * Stub scrape provider — returns deterministic fake markdown for local development.
+ *
+ * Pattern: Layer.succeed (no dependencies, no I/O, no cost).
+ * To add a new real provider, use Layer.effect with HttpClient instead.
+ */
+
+import { Effect, Layer } from 'effect'
+
+import { ScrapeProvider } from '../../application/ports'
+import { ScrapedPage } from '../../domain/types'
+
+export const StubScrapeProvider = Layer.succeed(ScrapeProvider)(
+	ScrapeProvider.of({
+		scrape: input =>
+			Effect.succeed(
+				new ScrapedPage({
+					url: input.url,
+					markdown: [
+						'# Acme Corp S.L.',
+						'',
+						'**Industrial solutions provider based in Barcelona.**',
+						'',
+						'## About Us',
+						'Founded in 2005, Acme Corp S.L. (CIF B12345678) specialises in',
+						'industrial automation and supply chain solutions for Mediterranean markets.',
+						'',
+						'## Contact',
+						'- Address: Carrer de la Indústria 42, 08025 Barcelona',
+						'- Phone: +34 932 000 111',
+						'- Email: info@acmecorp.es',
+						'',
+						'## Key Facts',
+						'- Employees: 85',
+						'- Revenue: €12M (2025)',
+						'- Sector: Industrial automation',
+					].join('\n'),
+					title: 'Acme Corp S.L. — Industrial Solutions',
+					language: 'en',
+					contentHash: 'stub-hash-acme-corp',
+					units: 0,
+				}),
+			),
+	}),
+)

--- a/packages/research/src/infrastructure/stub/search.ts
+++ b/packages/research/src/infrastructure/stub/search.ts
@@ -1,0 +1,42 @@
+/**
+ * Stub search provider — returns deterministic fake data for local development.
+ *
+ * Pattern: Layer.succeed (no dependencies, no I/O, no cost).
+ * To add a new real provider, copy brave/search.ts and use Layer.effect instead.
+ */
+
+import { Effect, Layer } from 'effect'
+
+import { SearchProvider } from '../../application/ports'
+import { SearchResult, SearchResultItem } from '../../domain/types'
+
+export const StubSearchProvider = Layer.succeed(SearchProvider)(
+	SearchProvider.of({
+		search: _input =>
+			Effect.succeed(
+				new SearchResult({
+					items: [
+						new SearchResultItem({
+							url: 'https://acmecorp.es',
+							title: 'Acme Corp S.L. — Soluciones industriales en Barcelona',
+							snippet:
+								'Acme Corp S.L. es una empresa líder en soluciones industriales con sede en Barcelona, fundada en 2005.',
+						}),
+						new SearchResultItem({
+							url: 'https://linkedin.com/company/acme-corp-sl',
+							title: 'Acme Corp S.L. | LinkedIn',
+							snippet:
+								'Acme Corp S.L. | 150 followers on LinkedIn. Industrial solutions provider based in Barcelona, Spain.',
+						}),
+						new SearchResultItem({
+							url: 'https://news.example.com/acme-expansion',
+							title: 'Acme Corp S.L. announces Mediterranean expansion',
+							snippet:
+								'Barcelona-based Acme Corp S.L. (CIF B12345678) plans to expand operations across the Mediterranean region in 2026.',
+						}),
+					],
+					units: 0,
+				}),
+			),
+	}),
+)

--- a/packages/research/tsconfig.json
+++ b/packages/research/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       '@engranatge/domain':
         specifier: workspace:*
         version: link:../../packages/domain
+      '@engranatge/research':
+        specifier: workspace:*
+        version: link:../../packages/research
       agentmail:
         specifier: ^0.4.18
         version: 0.4.18
@@ -347,6 +350,22 @@ importers:
 
   packages/domain:
     dependencies:
+      effect:
+        specifier: 4.0.0-beta.43
+        version: 4.0.0-beta.43
+    devDependencies:
+      tsdown:
+        specifier: ^0.21.7
+        version: 0.21.7(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/research:
+    dependencies:
+      '@effect/ai-openai-compat':
+        specifier: 4.0.0-beta.43
+        version: 4.0.0-beta.43(effect@4.0.0-beta.43)
       effect:
         specifier: 4.0.0-beta.43
         version: 4.0.0-beta.43
@@ -916,6 +935,11 @@ packages:
     resolution: {integrity: sha512-KlTR+gv+UX1d4X1+PBV9tZ6NQRkt/KspyUjbM/5gcIKIcFHVehds3iQWjT5G46ExEvXpGd0hZPMmv7uHqynbyw==}
     cpu: [x64]
     os: [win32]
+
+  '@effect/ai-openai-compat@4.0.0-beta.43':
+    resolution: {integrity: sha512-p/ODiq5Kfv7OrQOAXwFenTOVU0HfozsmG5W6KdQcazPtTn9dLI5tb+NvQfq4bKY7NGzcIMrzDXbWbBgD3nDk8Q==}
+    peerDependencies:
+      effect: ^4.0.0-beta.43
 
   '@effect/atom-react@4.0.0-beta.43':
     resolution: {integrity: sha512-xSrRbGXuo4d0g4ph66TQST1GNSjtQZrZj8V7OiAQFuzMYcZ0kwRIPUUFwOBtbWHK43/zNENdNWOnlXh/iYM1dw==}
@@ -5465,6 +5489,10 @@ snapshots:
 
   '@dprint/win32-x64@0.53.1':
     optional: true
+
+  '@effect/ai-openai-compat@4.0.0-beta.43(effect@4.0.0-beta.43)':
+    dependencies:
+      effect: 4.0.0-beta.43
 
   '@effect/atom-react@4.0.0-beta.43(effect@4.0.0-beta.43)(react@19.2.4)(scheduler@0.27.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- Added `@engranatge/research` package with LLM-driven agent loop, provider interfaces (search, scrape, extract, discover, registry, report), stub implementations, Brave search, budget enforcement, policy resolution, and output schemas.
- Wired HTTP routes (create, get, SSE stream, paid-action approve), migration 0003, MCP tools (web_search, web_read, web_discover, lookup_registry, crm_lookup), and research-designer prompt into the server.
- Added env vars for provider selection, budget defaults, LLM inference, and deploy workflow.
- Added `backend-research.md` design doc and `backend-research-todo.md` progress tracker.

## Test plan
- [ ] `pnpm cli db` runs migration 0003 without errors
- [ ] `pnpm cli seed` seeds research policy for default user
- [ ] Server boots with stub providers (`RESEARCH_*_PROVIDER=stub`)
- [ ] `POST /research` creates a run, returns `{ id, status: 'queued' }`
- [ ] `GET /research/:id` returns run state with findings after completion
- [ ] MCP tools (web_search, lookup_registry, crm_lookup) respond via Claude Desktop
- [ ] Budget enforcement rejects runs exceeding per-run or monthly caps