### PR TITLE
feat: server-backed email drafts, inbox footers, and inbox resolution fixes

### DIFF
--- a/apps/internal/src/atoms/emails-atoms.ts
+++ b/apps/internal/src/atoms/emails-atoms.ts
@@ -111,3 +111,31 @@ export const markThreadUnreadAtom = ForjaApiAtom.mutation(
 export const createInboxAtom = ForjaApiAtom.mutation('email', 'createInbox')
 export const updateInboxAtom = ForjaApiAtom.mutation('email', 'updateInbox')
 export const syncInboxesAtom = ForjaApiAtom.mutation('email', 'syncInboxes')
+
+// ── Drafts ──
+export const createDraftAtom = ForjaApiAtom.mutation('email', 'createDraft')
+export const updateDraftAtom = ForjaApiAtom.mutation('email', 'updateDraft')
+export const deleteDraftAtom = ForjaApiAtom.mutation('email', 'deleteDraft')
+export const sendDraftAtom = ForjaApiAtom.mutation('email', 'sendDraft')
+export const listDraftsAtom = ForjaApiAtom.query('email', 'listDrafts', {
+	query: {},
+})
+
+// ── Footers ──
+export const createFooterAtom = ForjaApiAtom.mutation('email', 'createFooter')
+export const updateFooterAtom = ForjaApiAtom.mutation('email', 'updateFooter')
+export const deleteFooterAtom = ForjaApiAtom.mutation('email', 'deleteFooter')
+
+const footerCache = new Map<string, ReturnType<typeof makeFooterAtom>>()
+function makeFooterAtom(inboxId: string) {
+	return ForjaApiAtom.query('email', 'listFooters', {
+		params: { inboxId },
+	})
+}
+export function footersAtomFor(inboxId: string) {
+	const existing = footerCache.get(inboxId)
+	if (existing !== undefined) return existing
+	const atom = makeFooterAtom(inboxId)
+	footerCache.set(inboxId, atom)
+	return atom
+}

--- a/apps/internal/src/components/emails/compose-dock.tsx
+++ b/apps/internal/src/components/emails/compose-dock.tsx
@@ -69,11 +69,11 @@ function MinimizedPill({ draft }: { readonly draft: Draft }) {
 
 function pillLabel(draft: Draft, t: ReturnType<typeof useLingui>['t']): string {
 	if (draft.mode === 'reply') {
-		const subject = draft.form.subject.trim()
+		const subject = draft.subject.trim()
 		if (subject !== '') return t`Reply: ${subject}`
 		return t`Reply`
 	}
-	const subject = draft.form.subject.trim()
+	const subject = draft.subject.trim()
 	if (subject !== '') return subject
 	return t`New message`
 }

--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -2,22 +2,25 @@ import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { useLingui } from '@lingui/react/macro'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { AlertTriangle, Plus, Send, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { PriButton, PriInput, PriSelect } from '@engranatge/ui/pri'
 
 import { contactsAtomFor } from '#/atoms/company-atoms'
 import {
+	createDraftAtom,
+	deleteDraftAtom,
 	emailsSearchAtom,
 	inboxesListAtom,
-	replyEmailAtom,
-	sendEmailAtom,
+	sendDraftAtom,
 	threadAtomFor,
+	updateDraftAtom,
 } from '#/atoms/emails-atoms'
 import { AttachmentPicker } from '#/components/emails/attachment-picker'
 import { EmailComposer } from '#/components/emails/email-composer'
 import { type Draft, useComposeEmail } from '#/context/compose-email-context'
+import type { StagedAttachment } from '#/lib/email-attachments'
 
 type InboxOption = {
 	readonly id: string
@@ -28,6 +31,17 @@ type InboxOption = {
 	readonly active: boolean
 }
 
+type DraftForm = {
+	inboxId: string | null
+	to: string
+	cc: string
+	bcc: string
+	subject: string
+	body: string
+	bodyHtml: string
+	attachments: ReadonlyArray<StagedAttachment>
+}
+
 type SendState = 'idle' | 'sending' | 'error'
 
 type SuppressedAddress = {
@@ -36,13 +50,17 @@ type SuppressedAddress = {
 	readonly reason: 'bounced' | 'complained'
 }
 
+const SAVE_DEBOUNCE_MS = 300
+
 export function ComposeForm({ draft }: { readonly draft: Draft }) {
 	const { t } = useLingui()
-	const { updateForm, close, markClean } = useComposeEmail()
+	const { close, updateMeta } = useComposeEmail()
 	const inboxesResult = useAtomValue(inboxesListAtom)
 
-	const send = useAtomSet(sendEmailAtom, { mode: 'promiseExit' })
-	const reply = useAtomSet(replyEmailAtom, { mode: 'promiseExit' })
+	const createDraft = useAtomSet(createDraftAtom, { mode: 'promiseExit' })
+	const updateDraft = useAtomSet(updateDraftAtom, { mode: 'promiseExit' })
+	const deleteDraft = useAtomSet(deleteDraftAtom, { mode: 'promiseExit' })
+	const sendDraft = useAtomSet(sendDraftAtom, { mode: 'promiseExit' })
 	const refreshList = useAtomRefresh(emailsSearchAtom({}))
 	const refreshThread = useAtomRefresh(
 		threadAtomFor(draft.threadId ?? '__unused__'),
@@ -56,20 +74,136 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		[inboxesResult],
 	)
 
-	// Lock the inbox in reply mode — replies must ship from the thread's
-	// inbox. For `new` drafts, fall back to the user's default human
-	// inbox if the form hasn't been touched.
-	const effectiveInboxId = useMemo(() => {
-		if (draft.form.inboxId !== null) return draft.form.inboxId
-		const fallback =
-			inboxes.find(i => i.purpose === 'human' && i.isDefault && i.active) ??
-			inboxes.find(i => i.purpose === 'human' && i.active)
-		return fallback?.id ?? null
-	}, [draft.form.inboxId, inboxes])
-
-	const [ccBccOpen, setCcBccOpen] = useState(
-		draft.form.cc.length > 0 || draft.form.bcc.length > 0,
+	const defaultInboxId = useMemo(
+		() =>
+			(
+				inboxes.find(i => i.purpose === 'human' && i.isDefault && i.active) ??
+				inboxes.find(i => i.purpose === 'human' && i.active)
+			)?.id ?? null,
+		[inboxes],
 	)
+
+	const [form, setForm] = useState<DraftForm>(() => ({
+		inboxId: draft.inboxId || null,
+		to: draft.to,
+		cc: '',
+		bcc: '',
+		subject: draft.subject,
+		body: '',
+		bodyHtml: '',
+		attachments: [],
+	}))
+
+	const effectiveInboxId = form.inboxId ?? defaultInboxId
+
+	const serverIdRef = useRef<string | null>(draft.serverId)
+	const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const mountedRef = useRef(true)
+	useEffect(
+		() => () => {
+			mountedRef.current = false
+		},
+		[],
+	)
+
+	// Create server draft on mount if none exists
+	useEffect(() => {
+		if (serverIdRef.current !== null) return
+		const inboxId = effectiveInboxId
+		if (inboxId === null) return
+
+		updateMeta(draft.id, { saving: true })
+
+		const params: Record<string, unknown> = { inboxId }
+		if (draft.to) params['to'] = draft.to
+		if (draft.subject) params['subject'] = draft.subject
+		if (draft.companyId) params['companyId'] = draft.companyId
+		if (draft.contactId) params['contactId'] = draft.contactId
+		if (draft.mode === 'reply') params['mode'] = 'reply'
+		if (draft.threadId) params['threadLinkId'] = draft.threadId
+
+		void createDraft({ payload: params } as never).then(exit => {
+			if (!mountedRef.current) return
+			if (exit._tag === 'Success') {
+				const result = exit.value as Record<string, unknown> | null
+				const serverId =
+					typeof result?.['draftId'] === 'string' ? result['draftId'] : null
+				serverIdRef.current = serverId
+				updateMeta(draft.id, { serverId, saving: false })
+			} else {
+				updateMeta(draft.id, { saving: false })
+			}
+		})
+	}, [
+		effectiveInboxId,
+		draft.id,
+		draft.to,
+		draft.subject,
+		draft.companyId,
+		draft.contactId,
+		draft.mode,
+		draft.threadId,
+		createDraft,
+		updateMeta,
+	])
+
+	const debouncedSave = useCallback(
+		(patch: Partial<DraftForm>) => {
+			if (saveTimerRef.current !== null) {
+				clearTimeout(saveTimerRef.current)
+			}
+			saveTimerRef.current = setTimeout(() => {
+				const serverId = serverIdRef.current
+				const inboxId = effectiveInboxId
+				if (serverId === null || inboxId === null) return
+
+				updateMeta(draft.id, { saving: true })
+				const payload: Record<string, unknown> = { inboxId }
+				if (patch.to !== undefined) payload['to'] = patch.to
+				if (patch.cc !== undefined) {
+					const list = splitAddresses(patch.cc)
+					if (list.length > 0) payload['cc'] = list
+				}
+				if (patch.bcc !== undefined) {
+					const list = splitAddresses(patch.bcc)
+					if (list.length > 0) payload['bcc'] = list
+				}
+				if (patch.subject !== undefined) payload['subject'] = patch.subject
+				if (patch.body !== undefined) payload['text'] = patch.body
+				if (patch.bodyHtml !== undefined) payload['html'] = patch.bodyHtml
+
+				void updateDraft({
+					params: { draftId: serverId },
+					payload,
+				} as never).then(() => {
+					if (mountedRef.current) {
+						updateMeta(draft.id, { saving: false })
+					}
+				})
+			}, SAVE_DEBOUNCE_MS)
+		},
+		[effectiveInboxId, draft.id, updateDraft, updateMeta],
+	)
+
+	useEffect(
+		() => () => {
+			if (saveTimerRef.current !== null) clearTimeout(saveTimerRef.current)
+		},
+		[],
+	)
+
+	const patchForm = useCallback(
+		(patch: Partial<DraftForm>) => {
+			setForm(prev => ({ ...prev, ...patch }))
+			if (patch.subject !== undefined)
+				updateMeta(draft.id, { subject: patch.subject })
+			if (patch.to !== undefined) updateMeta(draft.id, { to: patch.to })
+			debouncedSave(patch)
+		},
+		[draft.id, debouncedSave, updateMeta],
+	)
+
+	const [ccBccOpen, setCcBccOpen] = useState(false)
 	const [sendState, setSendState] = useState<SendState>('idle')
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
 	const [suppressed, setSuppressed] = useState<
@@ -78,101 +212,65 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 
 	const canSend = useMemo(() => {
 		if (sendState === 'sending') return false
-		if (draft.form.body.trim() === '') return false
+		if (form.body.trim() === '') return false
 		if (suppressed.length > 0) return false
+		if (serverIdRef.current === null) return false
 		if (draft.mode === 'reply') {
 			return draft.threadId !== undefined
 		}
 		if (effectiveInboxId === null) return false
-		if (draft.form.to.trim() === '') return false
+		if (form.to.trim() === '') return false
 		return true
-	}, [sendState, draft, effectiveInboxId, suppressed])
+	}, [sendState, form.body, form.to, suppressed, effectiveInboxId, draft])
 
 	const handleSend = useCallback(async () => {
+		const serverId = serverIdRef.current
+		if (serverId === null || effectiveInboxId === null) return
+
+		if (saveTimerRef.current !== null) {
+			clearTimeout(saveTimerRef.current)
+			saveTimerRef.current = null
+		}
+
 		setSendState('sending')
 		setErrorMessage(null)
 		try {
-			if (draft.mode === 'reply') {
-				if (draft.threadId === undefined) {
-					throw new Error('Reply draft missing threadId')
-				}
-				const cc = splitAddresses(draft.form.cc)
-				const bcc = splitAddresses(draft.form.bcc)
-				const attachments = draft.form.attachments.map(a => ({
-					stagingId: a.stagingId,
-				}))
-				await reply({
-					payload: {
-						threadId: draft.threadId,
-						text: draft.form.body,
-						...(draft.form.bodyHtml !== '' && { html: draft.form.bodyHtml }),
-						...(cc.length > 0 && { cc }),
-						...(bcc.length > 0 && { bcc }),
-						...(attachments.length > 0 && { attachments }),
-					},
-				})
-				refreshThread()
-			} else {
-				if (effectiveInboxId === null) {
-					throw new Error('Compose draft missing inboxId')
-				}
-				const toList = splitAddresses(draft.form.to)
-				if (toList.length === 0) {
-					throw new Error('At least one recipient required')
-				}
-				const firstTo = toList[0]
-				if (firstTo === undefined) {
-					throw new Error('At least one recipient required')
-				}
-				const to: string | ReadonlyArray<string> =
-					toList.length === 1 ? firstTo : toList
-				const cc = splitAddresses(draft.form.cc)
-				const bcc = splitAddresses(draft.form.bcc)
-				const attachments = draft.form.attachments.map(a => ({
-					stagingId: a.stagingId,
-				}))
-				await send({
-					payload: {
-						inboxId: effectiveInboxId,
-						to,
-						subject: draft.form.subject,
-						text: draft.form.body,
-						...(draft.form.bodyHtml !== '' && { html: draft.form.bodyHtml }),
-						companyId: draft.companyId ?? '',
-						...(draft.contactId !== undefined && {
-							contactId: draft.contactId,
-						}),
-						...(cc.length > 0 && { cc }),
-						...(bcc.length > 0 && { bcc }),
-						...(attachments.length > 0 && { attachments }),
-					},
-				})
+			const exit = await sendDraft({
+				params: { draftId: serverId },
+				payload: { inboxId: effectiveInboxId },
+			})
+			if (exit._tag !== 'Success') {
+				throw new Error('Send failed')
 			}
-			markClean(draft.id)
 			refreshList()
-			close(draft.id, { force: true })
+			if (draft.threadId) refreshThread()
+			close(draft.id)
 		} catch (error) {
 			setSendState('error')
 			setErrorMessage(
 				error instanceof Error ? error.message : 'Failed to send email',
 			)
-			return
 		}
-		setSendState('idle')
 	}, [
-		draft,
 		effectiveInboxId,
-		send,
-		reply,
+		sendDraft,
 		refreshList,
 		refreshThread,
-		markClean,
 		close,
+		draft.id,
+		draft.threadId,
 	])
 
-	const handleDiscard = useCallback(() => {
+	const handleDiscard = useCallback(async () => {
+		const serverId = serverIdRef.current
+		if (serverId !== null && effectiveInboxId !== null) {
+			await deleteDraft({
+				params: { draftId: serverId },
+				query: { inboxId: effectiveInboxId },
+			} as never)
+		}
 		close(draft.id)
-	}, [close, draft.id])
+	}, [effectiveInboxId, deleteDraft, close, draft.id])
 
 	const isReply = draft.mode === 'reply'
 
@@ -190,7 +288,7 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 					<PriSelect.Root
 						value={effectiveInboxId ?? ''}
 						onValueChange={value => {
-							updateForm(draft.id, { inboxId: value === '' ? null : value })
+							patchForm({ inboxId: value === '' ? null : value })
 						}}
 					>
 						<PriSelect.Trigger id={`inbox-${draft.id}`}>
@@ -223,10 +321,10 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 						id={`to-${draft.id}`}
 						data-testid='compose-to'
 						type='text'
-						value={draft.form.to}
+						value={form.to}
 						placeholder={t`name@example.com, another@example.com`}
 						onChange={event => {
-							updateForm(draft.id, { to: event.target.value })
+							patchForm({ to: event.target.value })
 						}}
 					/>
 				</Field>
@@ -249,10 +347,10 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 						<PriInput
 							id={`cc-${draft.id}`}
 							type='text'
-							value={draft.form.cc}
+							value={form.cc}
 							placeholder={t`Comma-separated`}
 							onChange={event => {
-								updateForm(draft.id, { cc: event.target.value })
+								patchForm({ cc: event.target.value })
 							}}
 						/>
 					</Field>
@@ -261,10 +359,10 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 						<PriInput
 							id={`bcc-${draft.id}`}
 							type='text'
-							value={draft.form.bcc}
+							value={form.bcc}
 							placeholder={t`Comma-separated`}
 							onChange={event => {
-								updateForm(draft.id, { bcc: event.target.value })
+								patchForm({ bcc: event.target.value })
 							}}
 						/>
 					</Field>
@@ -278,10 +376,10 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 						id={`subject-${draft.id}`}
 						data-testid='compose-subject'
 						type='text'
-						value={draft.form.subject}
+						value={form.subject}
 						placeholder={t`What is this about?`}
 						onChange={event => {
-							updateForm(draft.id, { subject: event.target.value })
+							patchForm({ subject: event.target.value })
 						}}
 					/>
 				</Field>
@@ -290,9 +388,9 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 			<BodyField>
 				<BodyLabel>{t`Message`}</BodyLabel>
 				<EmailComposer
-					initialHtml={draft.form.bodyHtml}
+					initialHtml={form.bodyHtml}
 					onChange={(html, text) => {
-						updateForm(draft.id, { body: text, bodyHtml: html })
+						patchForm({ body: text, bodyHtml: html })
 					}}
 					placeholder={t`Write your message…`}
 				/>
@@ -301,9 +399,9 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 			{draft.companyId !== undefined ? (
 				<SuppressionGuard
 					companyId={draft.companyId}
-					to={draft.form.to}
-					cc={draft.form.cc}
-					bcc={draft.form.bcc}
+					to={form.to}
+					cc={form.cc}
+					bcc={form.bcc}
 					onChange={setSuppressed}
 				/>
 			) : null}
@@ -334,9 +432,9 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 			) : null}
 
 			<AttachmentPicker
-				value={draft.form.attachments}
+				value={form.attachments}
 				onChange={next => {
-					updateForm(draft.id, { attachments: next })
+					patchForm({ attachments: next })
 				}}
 			/>
 
@@ -354,11 +452,14 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 					type='button'
 					$variant='text'
 					data-testid='compose-discard'
-					onClick={handleDiscard}
+					onClick={() => {
+						void handleDiscard()
+					}}
 				>
 					<X size={14} aria-hidden />
 					<span>{t`Discard`}</span>
 				</PriButton>
+				{draft.saving ? <SavingIndicator>{t`Saving…`}</SavingIndicator> : null}
 			</Footer>
 		</Form>
 	)
@@ -526,6 +627,18 @@ const Footer = styled.div.withConfig({ displayName: 'ComposeFooter' })`
 	gap: var(--space-xs);
 	padding-top: var(--space-xs);
 	border-top: 1px dashed var(--color-outline);
+`
+
+const SavingIndicator = styled.span.withConfig({
+	displayName: 'ComposeSaving',
+})`
+	margin-left: auto;
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-on-surface-variant);
+	opacity: 0.7;
 `
 
 const SuppressionBanner = styled.div.withConfig({

--- a/apps/internal/src/components/emails/compose-window.tsx
+++ b/apps/internal/src/components/emails/compose-window.tsx
@@ -93,18 +93,18 @@ export function ComposeWindow({ draft }: { readonly draft: Draft }) {
 
 function titleFor(draft: Draft, t: ReturnType<typeof useLingui>['t']): string {
 	if (draft.mode === 'reply') {
-		const subject = draft.form.subject.trim()
+		const subject = draft.subject.trim()
 		if (subject !== '') return t`Reply: ${subject}`
 		return t`Reply`
 	}
-	const subject = draft.form.subject.trim()
+	const subject = draft.subject.trim()
 	if (subject !== '') return subject
 	return t`New message`
 }
 
 function previewFor(draft: Draft): string | null {
 	if (draft.mode === 'reply') return null
-	const to = draft.form.to.trim()
+	const to = draft.to.trim()
 	if (to === '') return null
 	return to
 }

--- a/apps/internal/src/context/compose-email-context.tsx
+++ b/apps/internal/src/context/compose-email-context.tsx
@@ -4,42 +4,25 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from 'react'
 
-/**
- * Draft mode. `new` writes a fresh thread (requires inbox + to +
- * subject). `reply` replies into an existing thread (inbox + subject
- * are locked to the thread so the payload is smaller).
- */
 export type DraftMode = 'new' | 'reply'
-
-/** Window chrome state. Drafts move between these three. */
 export type DraftWindowState = 'open' | 'minimized' | 'fullscreen'
-
-import type { StagedAttachment } from '#/lib/email-attachments'
-
-/** Per-draft form fields. Reply drafts only write `body`, `cc`, `bcc`. */
-export type DraftForm = {
-	readonly inboxId: string | null
-	readonly to: string
-	readonly cc: string
-	readonly bcc: string
-	readonly subject: string
-	readonly body: string
-	readonly bodyHtml: string
-	readonly attachments: ReadonlyArray<StagedAttachment>
-}
 
 export type Draft = {
 	readonly id: string
+	readonly serverId: string | null
+	readonly inboxId: string
 	readonly mode: DraftMode
 	readonly windowState: DraftWindowState
-	readonly form: DraftForm
-	readonly dirty: boolean
+	readonly saving: boolean
 	readonly threadId?: string
 	readonly companyId?: string
 	readonly contactId?: string
+	readonly subject: string
+	readonly to: string
 }
 
 export type OpenComposeInput = {
@@ -56,62 +39,91 @@ export type OpenComposeInput = {
 	readonly bodyHtml?: string
 }
 
-const EMPTY_FORM: DraftForm = {
-	inboxId: null,
-	to: '',
-	cc: '',
-	bcc: '',
-	subject: '',
-	body: '',
-	bodyHtml: '',
-	attachments: [],
-}
-
 export type ComposeEmailContextValue = {
 	readonly drafts: ReadonlyArray<Draft>
 	readonly openCompose: (input: OpenComposeInput) => string
-	readonly close: (id: string, options?: { readonly force?: boolean }) => void
+	readonly close: (id: string) => void
 	readonly minimize: (id: string) => void
 	readonly restore: (id: string) => void
 	readonly toggleFullscreen: (id: string) => void
 	readonly focus: (id: string) => void
-	readonly updateForm: (id: string, patch: Partial<DraftForm>) => void
-	readonly markClean: (id: string) => void
+	readonly updateMeta: (
+		id: string,
+		patch: Partial<Pick<Draft, 'serverId' | 'saving' | 'subject' | 'to'>>,
+	) => void
 }
 
 const ComposeEmailContext = createContext<ComposeEmailContextValue | null>(null)
 
-/**
- * Draft state for the floating compose dock. Mounting the provider high
- * in the tree lets drafts survive route navigations. Drafts live only in
- * memory — closing a dirty draft prompts for confirmation, and a forced
- * close (used after a successful send) skips the prompt.
- */
+const SERVER_URL =
+	import.meta.env['VITE_SERVER_URL'] ?? 'https://api.engranatge.localhost'
+
 export function ComposeEmailProvider({
 	children,
 }: {
 	children: React.ReactNode
 }) {
 	const [drafts, setDrafts] = useState<ReadonlyArray<Draft>>([])
+	const recoveredRef = useRef(false)
+
+	useEffect(() => {
+		if (recoveredRef.current) return
+		recoveredRef.current = true
+		fetch(`${SERVER_URL}/v1/email/drafts`, { credentials: 'include' })
+			.then(res => (res.ok ? res.json() : []))
+			.then((serverDrafts: unknown) => {
+				if (!Array.isArray(serverDrafts)) return
+				setDrafts(prev => {
+					const existingServerIds = new Set(
+						prev.map(d => d.serverId).filter((s): s is string => s !== null),
+					)
+					const recovered: Draft[] = []
+					for (const raw of serverDrafts) {
+						if (!raw || typeof raw !== 'object') continue
+						const sd = raw as Record<string, unknown>
+						const draftId =
+							typeof sd['draftId'] === 'string' ? sd['draftId'] : null
+						if (draftId === null || existingServerIds.has(draftId)) continue
+						const clientId =
+							typeof sd['clientId'] === 'string' ? sd['clientId'] : undefined
+						const ctx = parseClientId(clientId)
+						const toRaw = sd['to']
+						recovered.push({
+							id: generateDraftId(),
+							serverId: draftId,
+							inboxId: typeof sd['inboxId'] === 'string' ? sd['inboxId'] : '',
+							mode: ctx.mode === 'reply' ? 'reply' : 'new',
+							windowState: 'minimized',
+							saving: false,
+							subject: typeof sd['subject'] === 'string' ? sd['subject'] : '',
+							to:
+								typeof toRaw === 'string'
+									? toRaw
+									: Array.isArray(toRaw)
+										? toRaw.join(', ')
+										: '',
+							...(ctx.companyId !== null && { companyId: ctx.companyId }),
+							...(ctx.contactId !== null && { contactId: ctx.contactId }),
+						})
+					}
+					if (recovered.length === 0) return prev
+					return [...prev, ...recovered]
+				})
+			})
+			.catch(() => {})
+	}, [])
 
 	const openCompose = useCallback((input: OpenComposeInput): string => {
 		const id = generateDraftId()
-		const base: DraftForm = {
-			...EMPTY_FORM,
-			...(input.inboxId !== undefined && { inboxId: input.inboxId }),
-			...(input.to !== undefined && { to: input.to }),
-			...(input.cc !== undefined && { cc: input.cc }),
-			...(input.bcc !== undefined && { bcc: input.bcc }),
-			...(input.subject !== undefined && { subject: input.subject }),
-			...(input.body !== undefined && { body: input.body }),
-			...(input.bodyHtml !== undefined && { bodyHtml: input.bodyHtml }),
-		}
 		const draft: Draft = {
 			id,
+			serverId: null,
+			inboxId: input.inboxId ?? '',
 			mode: input.mode,
 			windowState: 'open',
-			form: base,
-			dirty: false,
+			saving: false,
+			subject: input.subject ?? '',
+			to: input.to ?? '',
 			...(input.threadId !== undefined && { threadId: input.threadId }),
 			...(input.companyId !== undefined && { companyId: input.companyId }),
 			...(input.contactId !== undefined && { contactId: input.contactId }),
@@ -120,26 +132,15 @@ export function ComposeEmailProvider({
 		return id
 	}, [])
 
-	const close = useCallback(
-		(id: string, options?: { readonly force?: boolean }) => {
-			setDrafts(prev => {
-				const target = prev.find(d => d.id === id)
-				if (target === undefined) return prev
-				if (target.dirty && options?.force !== true) {
-					const ok = window.confirm(
-						'Discard this draft? Unsaved changes will be lost.',
-					)
-					if (!ok) return prev
-				}
-				return prev.filter(d => d.id !== id)
-			})
-		},
-		[],
-	)
+	const close = useCallback((id: string) => {
+		setDrafts(prev => prev.filter(d => d.id !== id))
+	}, [])
 
 	const minimize = useCallback((id: string) => {
 		setDrafts(prev =>
-			prev.map(d => (d.id === id ? { ...d, windowState: 'minimized' } : d)),
+			prev.map(d =>
+				d.id === id ? { ...d, windowState: 'minimized' as const } : d,
+			),
 		)
 	}, [])
 
@@ -148,7 +149,7 @@ export function ComposeEmailProvider({
 			const target = prev.find(d => d.id === id)
 			if (target === undefined) return prev
 			const rest = prev.filter(d => d.id !== id)
-			return [{ ...target, windowState: 'open' }, ...rest]
+			return [{ ...target, windowState: 'open' as const }, ...rest]
 		})
 	}, [])
 
@@ -159,7 +160,9 @@ export function ComposeEmailProvider({
 					? {
 							...d,
 							windowState:
-								d.windowState === 'fullscreen' ? 'open' : 'fullscreen',
+								d.windowState === 'fullscreen'
+									? ('open' as const)
+									: ('fullscreen' as const),
 						}
 					: d,
 			),
@@ -176,21 +179,16 @@ export function ComposeEmailProvider({
 		})
 	}, [])
 
-	const updateForm = useCallback((id: string, patch: Partial<DraftForm>) => {
-		setDrafts(prev =>
-			prev.map(d =>
-				d.id === id ? { ...d, form: { ...d.form, ...patch }, dirty: true } : d,
-			),
-		)
-	}, [])
+	const updateMeta = useCallback(
+		(
+			id: string,
+			patch: Partial<Pick<Draft, 'serverId' | 'saving' | 'subject' | 'to'>>,
+		) => {
+			setDrafts(prev => prev.map(d => (d.id === id ? { ...d, ...patch } : d)))
+		},
+		[],
+	)
 
-	const markClean = useCallback((id: string) => {
-		setDrafts(prev => prev.map(d => (d.id === id ? { ...d, dirty: false } : d)))
-	}, [])
-
-	// Global Shift+E shortcut for "new compose". Skipped when the user
-	// is typing in an input/textarea/contenteditable so it doesn't
-	// interrupt editing — matches the Shift+I pattern from Quick Capture.
 	useEffect(() => {
 		const handler = (event: KeyboardEvent) => {
 			if (!event.shiftKey) return
@@ -225,8 +223,7 @@ export function ComposeEmailProvider({
 			restore,
 			toggleFullscreen,
 			focus,
-			updateForm,
-			markClean,
+			updateMeta,
 		}),
 		[
 			drafts,
@@ -236,8 +233,7 @@ export function ComposeEmailProvider({
 			restore,
 			toggleFullscreen,
 			focus,
-			updateForm,
-			markClean,
+			updateMeta,
 		],
 	)
 
@@ -260,4 +256,28 @@ export function useComposeEmail(): ComposeEmailContextValue {
 
 function generateDraftId(): string {
 	return `draft-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`
+}
+
+function parseClientId(clientId: string | undefined): {
+	companyId: string | null
+	contactId: string | null
+	mode: string | null
+} {
+	const empty = { companyId: null, contactId: null, mode: null }
+	if (!clientId?.startsWith('forja:draft')) return empty
+	const result: {
+		companyId: string | null
+		contactId: string | null
+		mode: string | null
+	} = { ...empty }
+	for (const part of clientId.split(';')) {
+		const eq = part.indexOf('=')
+		if (eq === -1) continue
+		const key = part.slice(0, eq)
+		const val = part.slice(eq + 1)
+		if (key === 'companyId') result.companyId = val
+		else if (key === 'contactId') result.contactId = val
+		else if (key === 'mode') result.mode = val
+	}
+	return result
 }

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -16,13 +16,13 @@ msgstr ""
 #: src/routes/emails/$threadId.tsx:386
 #: src/routes/emails/$threadId.tsx:396
 #: src/routes/emails/$threadId.tsx:441
-#: src/routes/pages/index.tsx:177
+#: src/routes/pages/index.tsx:174
 msgid "—"
 msgstr "—"
 
 #: src/routes/companies/$slug.tsx:809
 msgid "— not set —"
-msgstr "— sense definir —"
+msgstr "— sense establir —"
 
 #: src/components/interactions/quick-capture-dialog.tsx:219
 msgid "— Select a company —"
@@ -34,7 +34,7 @@ msgstr "— Tria una empresa —"
 msgid "(no subject)"
 msgstr "(sense assumpte)"
 
-#: src/routes/emails/inboxes.tsx:432
+#: src/routes/emails/inboxes.tsx:454
 msgid "(provider assigns)"
 msgstr "(ho assigna el proveïdor)"
 
@@ -74,11 +74,11 @@ msgstr "1 fil"
 msgid "1 thread selected"
 msgstr "1 fil seleccionat"
 
-#: src/routes/emails/inboxes.tsx:252
+#: src/routes/emails/inboxes.tsx:263
 msgid "Actions"
 msgstr "Accions"
 
-#: src/routes/emails/inboxes.tsx:250
+#: src/routes/emails/inboxes.tsx:261
 msgid "Active"
 msgstr "Activa"
 
@@ -96,13 +96,13 @@ msgstr "Afegeix {label}"
 
 #: src/components/companies/where-panel.tsx:126
 msgid "Add a location on the Profile tab, then locate this company."
-msgstr "Afegeix una ubicació a la pestanya Perfil i després localitza aquesta empresa."
+msgstr "Afegeix una ubicació a la pestanya de perfil i després localitza aquesta empresa."
 
 #: src/components/emails/attachment-picker.tsx:107
 msgid "Add attachment"
 msgstr "Afegeix adjunt"
 
-#: src/components/emails/compose-form.tsx:243
+#: src/components/emails/compose-form.tsx:341
 msgid "Add Cc / Bcc"
 msgstr "Afegeix Cc / Bcc"
 
@@ -119,16 +119,16 @@ msgstr "Afegeix tasca"
 msgid "Add the first decision-maker to keep track of who to reach."
 msgstr "Afegeix el primer responsable de decisió per saber a qui adreçar-te."
 
-#: src/routes/emails/inboxes.tsx:149
+#: src/routes/emails/inboxes.tsx:160
 msgid "Added {added}, retired {retired}."
 msgstr "N'he afegit {added}, n'he retirat {retired}."
 
-#: src/routes/emails/inboxes.tsx:515
+#: src/routes/emails/inboxes.tsx:537
 msgid "Address:"
 msgstr "Adreça:"
 
-#: src/routes/emails/inboxes.tsx:269
-#: src/routes/emails/inboxes.tsx:568
+#: src/routes/emails/inboxes.tsx:280
+#: src/routes/emails/inboxes.tsx:590
 msgid "Agent"
 msgstr "Agent"
 
@@ -179,7 +179,7 @@ msgstr "Adjunta"
 msgid "attachment"
 msgstr "adjunt"
 
-#: src/routes/emails/inboxes.tsx:201
+#: src/routes/emails/inboxes.tsx:212
 msgid "Back to emails"
 msgstr "Torna als correus"
 
@@ -188,7 +188,7 @@ msgstr "Torna als correus"
 msgid "Back to inbox"
 msgstr "Torna a la safata"
 
-#: src/components/emails/compose-form.tsx:260
+#: src/components/emails/compose-form.tsx:358
 msgid "Bcc"
 msgstr "Bcc"
 
@@ -204,7 +204,7 @@ msgstr "Bloquejat pel proveïdor. El cos es mostra només per revisar-lo."
 msgid "Bold"
 msgstr "Negreta"
 
-#: src/components/emails/compose-form.tsx:322
+#: src/components/emails/compose-form.tsx:420
 msgid "bounced"
 msgstr "rebotat"
 
@@ -234,7 +234,8 @@ msgid "Call phone"
 msgstr "Truca al telèfon"
 
 #: src/components/interactions/quick-capture-dialog.tsx:400
-#: src/routes/emails/inboxes.tsx:616
+#: src/routes/emails/inboxes.tsx:638
+#: src/routes/emails/inboxes.tsx:945
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -242,7 +243,7 @@ msgstr "Cancel·la"
 msgid "Cancel upload"
 msgstr "Cancel·la la pujada"
 
-#: src/components/emails/compose-form.tsx:248
+#: src/components/emails/compose-form.tsx:346
 #: src/routes/emails/$threadId.tsx:543
 msgid "Cc"
 msgstr "Cc"
@@ -255,7 +256,7 @@ msgstr "Canvia la prioritat"
 msgid "Change status"
 msgstr "Canvia l'estat"
 
-#: src/routes/pages/$id.tsx:159
+#: src/routes/pages/$id.tsx:158
 msgid "Changes have been saved."
 msgstr "S'han desat els canvis."
 
@@ -265,7 +266,7 @@ msgstr "Canal"
 
 #: src/routes/companies/$slug.tsx:299
 #: src/routes/emails/index.tsx:734
-#: src/routes/pages/$id.tsx:114
+#: src/routes/pages/$id.tsx:113
 msgid "Check that the session is valid or try again."
 msgstr "Comprova que la sessió sigui vàlida o torna-ho a provar."
 
@@ -273,7 +274,7 @@ msgstr "Comprova que la sessió sigui vàlida o torna-ho a provar."
 msgid "Check that your session is valid or try again."
 msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
 
-#: src/routes/emails/inboxes.tsx:229
+#: src/routes/emails/inboxes.tsx:240
 msgid "Check the session or try again."
 msgstr "Comprova la sessió o torna-ho a provar."
 
@@ -299,7 +300,8 @@ msgstr "Client"
 
 #: src/components/interactions/quick-capture-dialog.tsx:188
 #: src/routes/emails/$threadId.tsx:315
-#: src/routes/emails/inboxes.tsx:484
+#: src/routes/emails/inboxes.tsx:506
+#: src/routes/emails/inboxes.tsx:830
 #: src/routes/emails/index.tsx:687
 msgid "Close"
 msgstr "Tanca"
@@ -332,8 +334,8 @@ msgstr "Bloc de codi"
 msgid "Cold lead — no contact yet"
 msgstr "Pista freda — encara sense contacte"
 
-#: src/components/emails/compose-form.tsx:253
-#: src/components/emails/compose-form.tsx:265
+#: src/components/emails/compose-form.tsx:351
+#: src/components/emails/compose-form.tsx:363
 msgid "Comma-separated"
 msgstr "Separats per comes"
 
@@ -353,7 +355,7 @@ msgstr "Empreses"
 msgid "Company"
 msgstr "Empresa"
 
-#: src/components/emails/compose-form.tsx:322
+#: src/components/emails/compose-form.tsx:420
 msgid "complained"
 msgstr "marcat com a brossa"
 
@@ -383,15 +385,19 @@ msgstr "Contactat"
 msgid "Contacts"
 msgstr "Contactes"
 
+#: src/routes/emails/inboxes.tsx:917
+msgid "Content"
+msgstr "Contingut"
+
 #: src/components/companies/where-panel.tsx:66
 msgid "Coordinates saved from the geocoder."
-msgstr "Coordenades desades des del geocodificador."
+msgstr "Coordenades desades del geocodificador."
 
 #: src/components/shared/company-card.tsx:125
 msgid "Copy slug"
 msgstr "Copia el slug"
 
-#: src/routes/emails/inboxes.tsx:348
+#: src/routes/emails/inboxes.tsx:366
 msgid "Could not create the inbox."
 msgstr "No s'ha pogut crear la safata."
 
@@ -399,7 +405,7 @@ msgstr "No s'ha pogut crear la safata."
 msgid "Could not load companies"
 msgstr "No s'han pogut carregar les empreses"
 
-#: src/routes/emails/inboxes.tsx:228
+#: src/routes/emails/inboxes.tsx:239
 msgid "Could not load inboxes"
 msgstr "No s'han pogut carregar les safates"
 
@@ -407,7 +413,7 @@ msgstr "No s'han pogut carregar les safates"
 msgid "Could not load this company"
 msgstr "No s'ha pogut carregar aquesta empresa"
 
-#: src/routes/pages/$id.tsx:113
+#: src/routes/pages/$id.tsx:112
 msgid "Could not load this page"
 msgstr "No s'ha pogut carregar aquesta pàgina"
 
@@ -423,11 +429,11 @@ msgstr "No s'ha pogut localitzar"
 msgid "Could not log the interaction. Please try again."
 msgstr "No s'ha pogut registrar la interacció. Torna-ho a provar."
 
-#: src/routes/pages/$id.tsx:189
+#: src/routes/pages/$id.tsx:188
 msgid "Could not publish the page. Please try again."
 msgstr "No s'ha pogut publicar la pàgina. Torna-ho a provar."
 
-#: src/routes/emails/inboxes.tsx:135
+#: src/routes/emails/inboxes.tsx:146
 msgid "Could not reach the email provider. Check logs."
 msgstr "No he pogut connectar amb el proveïdor de correu. Revisa els registres."
 
@@ -435,15 +441,15 @@ msgstr "No he pogut connectar amb el proveïdor de correu. Revisa els registres.
 msgid "Could not save"
 msgstr "No s'ha pogut desar"
 
-#: src/routes/emails/inboxes.tsx:365
+#: src/routes/emails/inboxes.tsx:383
 msgid "Could not save the inbox."
 msgstr "No s'ha pogut desar la safata."
 
-#: src/routes/pages/$id.tsx:166
+#: src/routes/pages/$id.tsx:165
 msgid "Could not save the page. Please try again."
 msgstr "No s'ha pogut desar la pàgina. Torna-ho a provar."
 
-#: src/routes/emails/inboxes.tsx:184
+#: src/routes/emails/inboxes.tsx:195
 msgid "Could not set the default inbox."
 msgstr "No s'ha pogut establir la safata per defecte."
 
@@ -451,13 +457,18 @@ msgstr "No s'ha pogut establir la safata per defecte."
 msgid "Could not sign in. Check your email and password."
 msgstr "No s'ha pogut iniciar sessió. Comprova el correu i la contrasenya."
 
-#: src/routes/emails/inboxes.tsx:164
+#: src/routes/emails/inboxes.tsx:175
 msgid "Could not toggle the inbox state."
 msgstr "No s'ha pogut canviar l'estat de la safata."
 
-#: src/routes/emails/inboxes.tsx:623
+#: src/routes/emails/inboxes.tsx:645
+#: src/routes/emails/inboxes.tsx:957
 msgid "Create"
 msgstr "Crea"
+
+#: src/routes/emails/inboxes.tsx:843
+msgid "Create a footer to append to outgoing emails from this inbox."
+msgstr "Crea un peu de pàgina per afegir als correus sortints d'aquesta bústia."
 
 #: src/routes/pages/index.tsx:141
 msgid "Create a prospect landing page from a company detail view or via the MCP tools."
@@ -467,18 +478,26 @@ msgstr "Crea una pàgina d'aterratge per a un prospecte des del detall d'una emp
 msgid "Create a prospect landing page to share with this company."
 msgstr "Crea una pàgina d'aterratge per a un prospecte per compartir amb aquesta empresa."
 
-#: src/routes/emails/inboxes.tsx:219
-#: src/routes/emails/inboxes.tsx:239
-#: src/routes/emails/inboxes.tsx:480
+#: src/routes/emails/inboxes.tsx:736
+msgid "Create failed"
+msgstr "Error en crear"
+
+#: src/routes/emails/inboxes.tsx:895
+msgid "Create footer"
+msgstr "Crea peu de pàgina"
+
+#: src/routes/emails/inboxes.tsx:230
+#: src/routes/emails/inboxes.tsx:250
+#: src/routes/emails/inboxes.tsx:502
 msgid "Create inbox"
 msgstr "Crea safata"
 
-#: src/routes/emails/inboxes.tsx:235
+#: src/routes/emails/inboxes.tsx:246
 msgid "Create one or run sync to pull mailboxes from the provider."
 msgstr "Crea'n una o sincronitza per portar les bústies del proveïdor."
 
 #: src/routes/emails/$threadId.tsx:449
-#: src/routes/emails/inboxes.tsx:251
+#: src/routes/emails/inboxes.tsx:262
 msgid "Created"
 msgstr "Creada"
 
@@ -499,13 +518,26 @@ msgstr "Descartat"
 msgid "Decision maker"
 msgstr "Responsable de decisió"
 
-#: src/routes/emails/inboxes.tsx:249
+#: src/routes/emails/inboxes.tsx:260
+#: src/routes/emails/inboxes.tsx:852
 msgid "Default"
 msgstr "Per defecte"
 
-#: src/routes/emails/inboxes.tsx:290
+#: src/routes/emails/inboxes.tsx:301
 msgid "Default inbox"
 msgstr "Safata per defecte"
+
+#: src/routes/emails/inboxes.tsx:879
+msgid "Delete"
+msgstr "Elimina"
+
+#: src/routes/emails/inboxes.tsx:787
+msgid "Delete failed"
+msgstr "Error en eliminar"
+
+#: src/routes/emails/inboxes.tsx:780
+msgid "Delete this footer? This cannot be undone."
+msgstr "Eliminar aquest peu de pàgina? Aquesta acció no es pot desfer."
 
 #: src/routes/emails/$threadId.tsx:621
 msgid "Delivered"
@@ -515,11 +547,11 @@ msgstr "Lliurat"
 msgid "Direction"
 msgstr "Direcció"
 
-#: src/components/emails/compose-form.tsx:360
+#: src/components/emails/compose-form.tsx:460
 msgid "Discard"
 msgstr "Descarta"
 
-#: src/routes/emails/inboxes.tsx:521
+#: src/routes/emails/inboxes.tsx:543
 msgid "Display name"
 msgstr "Nom a mostrar"
 
@@ -527,7 +559,7 @@ msgstr "Nom a mostrar"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/routes/emails/inboxes.tsx:505
+#: src/routes/emails/inboxes.tsx:527
 msgid "Domain"
 msgstr "Domini"
 
@@ -539,28 +571,36 @@ msgstr "Esborrany"
 msgid "Duration (min)"
 msgstr "Durada (min)"
 
-#: src/routes/emails/inboxes.tsx:511
+#: src/routes/emails/inboxes.tsx:913
+msgid "e.g. Company signature"
+msgstr "p. ex. Signatura de l'empresa"
+
+#: src/routes/emails/inboxes.tsx:533
 msgid "e.g. engranatge.com"
 msgstr "p. ex. engranatge.com"
 
-#: src/routes/emails/inboxes.tsx:501
+#: src/routes/emails/inboxes.tsx:523
 msgid "e.g. hola"
 msgstr "p. ex. hola"
 
-#: src/routes/emails/inboxes.tsx:527
+#: src/routes/emails/inboxes.tsx:549
 msgid "e.g. Hola — Engranatge"
 msgstr "p. ex. Hola — Engranatge"
+
+#: src/routes/emails/inboxes.tsx:870
+msgid "Edit"
+msgstr "Edita"
 
 #: src/components/shared/editable-field.tsx:141
 msgid "Edit {label}"
 msgstr "Edita {label}"
 
-#: src/routes/emails/inboxes.tsx:480
+#: src/routes/emails/inboxes.tsx:502
 msgid "Edit inbox"
 msgstr "Edita la safata"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:329
+#: src/routes/emails/inboxes.tsx:347
 msgid "Edit inbox {0}"
 msgstr "Edita la safata {0}"
 
@@ -568,14 +608,14 @@ msgstr "Edita la safata {0}"
 msgid "Edit link"
 msgstr "Edita l'enllaç"
 
-#: src/routes/pages/$id.tsx:254
+#: src/routes/pages/$id.tsx:253
 msgid "Editor"
 msgstr "Editor"
 
 #: src/components/interactions/quick-capture-dialog.tsx:424
 #: src/components/shared/channel-icon.tsx:51
 #: src/routes/companies/$slug.tsx:720
-#: src/routes/emails/inboxes.tsx:246
+#: src/routes/emails/inboxes.tsx:257
 #: src/routes/login.tsx:141
 msgid "Email"
 msgstr "Correu"
@@ -639,6 +679,11 @@ msgstr "Primer contacte enviat"
 msgid "Flagged as spam by the provider. The body is shown for review only."
 msgstr "El proveïdor l'ha marcat com a brossa. El cos es mostra només per revisar-lo."
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx:827
+msgid "Footers — {0}"
+msgstr "Peus de pàgina — {0}"
+
 #: src/i18n/lingui.tsx:56
 msgid "Forja — Engranatge CRM"
 msgstr "Forja — CRM d'Engranatge"
@@ -696,8 +741,8 @@ msgstr "Prioritat alta"
 msgid "Horizontal rule"
 msgstr "Línia horitzontal"
 
-#: src/routes/emails/inboxes.tsx:267
-#: src/routes/emails/inboxes.tsx:562
+#: src/routes/emails/inboxes.tsx:278
+#: src/routes/emails/inboxes.tsx:584
 msgid "Human"
 msgstr "Humà"
 
@@ -718,25 +763,25 @@ msgstr "Els correus entrants i sortints es fixaran en aquest tauler un cop exist
 msgid "Inbound message from {0}"
 msgstr "Missatge entrant de {0}"
 
-#: src/components/emails/compose-form.tsx:189
+#: src/components/emails/compose-form.tsx:287
 #: src/routes/emails/$threadId.tsx:390
 #: src/routes/emails/$threadId.tsx:430
 msgid "Inbox"
 msgstr "Safata"
 
-#: src/routes/emails/inboxes.tsx:353
+#: src/routes/emails/inboxes.tsx:371
 msgid "Inbox created"
 msgstr "Safata creada"
 
-#: src/routes/emails/inboxes.tsx:204
+#: src/routes/emails/inboxes.tsx:215
 msgid "Inbox management"
 msgstr "Gestió de safates"
 
-#: src/routes/emails/inboxes.tsx:369
+#: src/routes/emails/inboxes.tsx:387
 msgid "Inbox updated"
 msgstr "Safata actualitzada"
 
-#: src/routes/emails/inboxes.tsx:148
+#: src/routes/emails/inboxes.tsx:159
 msgid "Inboxes synced"
 msgstr "Safates sincronitzades"
 
@@ -765,7 +810,7 @@ msgid "Lang"
 msgstr "Idioma"
 
 #: src/components/profile/language-select.tsx:34
-#: src/routes/pages/$id.tsx:278
+#: src/routes/pages/$id.tsx:277
 #: src/routes/profile/index.tsx:111
 msgid "Language"
 msgstr "Idioma"
@@ -811,7 +856,7 @@ msgstr "Carregant empreses…"
 msgid "Loading…"
 msgstr "Carregant…"
 
-#: src/routes/emails/inboxes.tsx:244
+#: src/routes/emails/inboxes.tsx:255
 msgid "Local inboxes"
 msgstr "Safates locals"
 
@@ -858,11 +903,16 @@ msgstr "Baixa"
 msgid "Low priority"
 msgstr "Prioritat baixa"
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx:340
+msgid "Manage footers for {0}"
+msgstr "Gestiona els peus de pàgina de {0}"
+
 #: src/routes/emails/index.tsx:549
 msgid "Manage inboxes"
 msgstr "Gestiona les safates"
 
-#: src/routes/emails/inboxes.tsx:205
+#: src/routes/emails/inboxes.tsx:216
 msgid "Map provider mailboxes to purpose, owner, and defaults."
 msgstr "Associa les bústies del proveïdor a propòsit, propietari i valors per defecte."
 
@@ -876,11 +926,11 @@ msgstr "Marca «{0}» com a completada"
 msgid "Mark \"{0}\" as pending"
 msgstr "Marca «{0}» com a pendent"
 
-#: src/routes/emails/inboxes.tsx:308
+#: src/routes/emails/inboxes.tsx:319
 msgid "Mark active"
 msgstr "Marca com a activa"
 
-#: src/routes/emails/inboxes.tsx:290
+#: src/routes/emails/inboxes.tsx:301
 msgid "Mark as default"
 msgstr "Marca com a per defecte"
 
@@ -888,7 +938,7 @@ msgstr "Marca com a per defecte"
 msgid "Mark contacted"
 msgstr "Marca com a contactat"
 
-#: src/routes/emails/inboxes.tsx:308
+#: src/routes/emails/inboxes.tsx:319
 msgid "Mark inactive"
 msgstr "Marca com a inactiva"
 
@@ -920,7 +970,7 @@ msgstr "Reunió"
 msgid "Meeting booked"
 msgstr "Reunió programada"
 
-#: src/components/emails/compose-form.tsx:291
+#: src/components/emails/compose-form.tsx:389
 msgid "Message"
 msgstr "Missatge"
 
@@ -948,9 +998,13 @@ msgstr "missatges"
 msgid "Msgs"
 msgstr "Msgs"
 
-#: src/components/emails/compose-form.tsx:227
+#: src/routes/emails/inboxes.tsx:907
+msgid "Name"
+msgstr "Nom"
+
+#: src/components/emails/compose-form.tsx:325
 msgid "name@example.com, another@example.com"
-msgstr "nom@exemple.com, altre@exemple.com"
+msgstr "nom@exemple.cat, altre@exemple.cat"
 
 #: src/routes/index.tsx:288
 msgid "Needs attention"
@@ -997,7 +1051,7 @@ msgstr "Encara no hi ha contactes"
 
 #: src/components/companies/where-panel.tsx:118
 msgid "No coordinates yet. Locate this company to plot it on the map."
-msgstr "Encara no té coordenades. Localitza aquesta empresa per situar-la al mapa."
+msgstr "Encara sense coordenades. Localitza aquesta empresa per situar-la al mapa."
 
 #: src/components/shared/task-item.tsx:70
 msgid "no date"
@@ -1019,11 +1073,15 @@ msgstr "Sense data de venciment"
 msgid "No email threads yet"
 msgstr "Encara no hi ha fils de correu"
 
+#: src/routes/emails/inboxes.tsx:842
+msgid "No footers"
+msgstr "Sense peus de pàgina"
+
 #: src/routes/index.tsx:461
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "Cap empresa d'alta prioritat sense seguiment programat"
 
-#: src/routes/emails/inboxes.tsx:234
+#: src/routes/emails/inboxes.tsx:245
 msgid "No inboxes yet"
 msgstr "Encara no hi ha safates"
 
@@ -1050,11 +1108,11 @@ msgstr "Sense tasques pendents. És hora de celebrar-ho o de buscar nous prospec
 
 #: src/routes/companies/$slug.tsx:838
 msgid "No products linked yet"
-msgstr "Cap producte vinculat encara"
+msgstr "Encara sense productes vinculats"
 
 #: src/routes/companies/$slug.tsx:832
 msgid "No tags yet"
-msgstr "Cap etiqueta encara"
+msgstr "Encara sense etiquetes"
 
 #: src/routes/companies/$slug.tsx:969
 msgid "No tasks for this company"
@@ -1148,11 +1206,11 @@ msgstr "Resultat: {0}"
 msgid "Overdue"
 msgstr "Endarrerit"
 
-#: src/routes/emails/inboxes.tsx:248
+#: src/routes/emails/inboxes.tsx:259
 msgid "Owner"
 msgstr "Propietari"
 
-#: src/routes/emails/inboxes.tsx:584
+#: src/routes/emails/inboxes.tsx:606
 msgid "Owner user ID"
 msgstr "ID d'usuari propietari"
 
@@ -1160,21 +1218,21 @@ msgstr "ID d'usuari propietari"
 msgid "Page {page} of {totalPages}"
 msgstr "Pàgina {page} de {totalPages}"
 
-#: src/routes/pages/$id.tsx:181
+#: src/routes/pages/$id.tsx:180
 msgid "Page published"
 msgstr "Pàgina publicada"
 
-#: src/routes/pages/$id.tsx:158
+#: src/routes/pages/$id.tsx:157
 msgid "Page saved"
 msgstr "Pàgina desada"
 
-#: src/routes/pages/$id.tsx:210
+#: src/routes/pages/$id.tsx:209
 msgid "Page title"
 msgstr "Títol de la pàgina"
 
 #: src/components/layout/nav-items.ts:59
 #: src/routes/companies/$slug.tsx:764
-#: src/routes/pages/$id.tsx:204
+#: src/routes/pages/$id.tsx:203
 #: src/routes/pages/index.tsx:111
 msgid "Pages"
 msgstr "Pàgines"
@@ -1192,8 +1250,8 @@ msgstr "Contrasenya"
 msgid "Pipeline"
 msgstr "Pipeline"
 
-#: src/routes/pages/$id.tsx:222
-#: src/routes/pages/index.tsx:185
+#: src/routes/pages/$id.tsx:221
+#: src/routes/pages/index.tsx:182
 msgid "Preview"
 msgstr "Vista prèvia"
 
@@ -1211,7 +1269,7 @@ msgstr "Prioritat"
 
 #: src/routes/companies/$slug.tsx:835
 msgid "Products fit"
-msgstr "Productes encaixats"
+msgstr "Encaix de productes"
 
 #: src/components/layout/nav-items.ts:73
 #: src/routes/companies/$slug.tsx:746
@@ -1238,15 +1296,15 @@ msgstr "Les propostes, notes de reunió i adjunts apareixeran aquí."
 msgid "Prospect"
 msgstr "Prospecte"
 
-#: src/routes/pages/$id.tsx:297
+#: src/routes/pages/$id.tsx:296
 msgid "Public URL"
 msgstr "URL pública"
 
-#: src/routes/pages/$id.tsx:245
+#: src/routes/pages/$id.tsx:244
 msgid "Publish"
 msgstr "Publica"
 
-#: src/routes/pages/$id.tsx:188
+#: src/routes/pages/$id.tsx:187
 msgid "Publish failed"
 msgstr "Ha fallat la publicació"
 
@@ -1255,13 +1313,13 @@ msgstr "Ha fallat la publicació"
 msgid "Published"
 msgstr "Publicada"
 
-#: src/routes/pages/$id.tsx:245
+#: src/routes/pages/$id.tsx:244
 msgid "Publishing…"
 msgstr "Publicant…"
 
-#: src/routes/emails/inboxes.tsx:247
-#: src/routes/emails/inboxes.tsx:532
-#: src/routes/emails/inboxes.tsx:545
+#: src/routes/emails/inboxes.tsx:258
+#: src/routes/emails/inboxes.tsx:554
+#: src/routes/emails/inboxes.tsx:567
 msgid "Purpose"
 msgstr "Propòsit"
 
@@ -1324,17 +1382,20 @@ msgstr "Respost"
 msgid "Row actions"
 msgstr "Accions de la fila"
 
-#: src/routes/emails/inboxes.tsx:622
-#: src/routes/pages/$id.tsx:235
+#: src/routes/emails/inboxes.tsx:644
+#: src/routes/emails/inboxes.tsx:958
+#: src/routes/pages/$id.tsx:234
 msgid "Save"
 msgstr "Desa"
 
-#: src/routes/pages/$id.tsx:165
+#: src/routes/pages/$id.tsx:164
 msgid "Save failed"
 msgstr "Ha fallat el desament"
 
-#: src/routes/emails/inboxes.tsx:620
-#: src/routes/pages/$id.tsx:235
+#: src/components/emails/compose-form.tsx:462
+#: src/routes/emails/inboxes.tsx:642
+#: src/routes/emails/inboxes.tsx:955
+#: src/routes/pages/$id.tsx:234
 msgid "Saving…"
 msgstr "Desant…"
 
@@ -1358,7 +1419,7 @@ msgstr "Cerca fils"
 msgid "Select all threads on this page"
 msgstr "Selecciona tots els fils d'aquesta pàgina"
 
-#: src/components/emails/compose-form.tsx:197
+#: src/components/emails/compose-form.tsx:295
 msgid "Select inbox…"
 msgstr "Tria una safata…"
 
@@ -1367,11 +1428,11 @@ msgstr "Tria una safata…"
 msgid "Select thread {0}"
 msgstr "Selecciona el fil {0}"
 
-#: src/components/emails/compose-form.tsx:351
+#: src/components/emails/compose-form.tsx:449
 msgid "Send"
 msgstr "Envia"
 
-#: src/components/emails/compose-form.tsx:316
+#: src/components/emails/compose-form.tsx:414
 msgid "Send blocked: these recipients cannot receive email"
 msgstr "Enviament bloquejat: aquests destinataris no poden rebre correu"
 
@@ -1379,7 +1440,7 @@ msgstr "Enviament bloquejat: aquests destinataris no poden rebre correu"
 msgid "Send email"
 msgstr "Envia correu"
 
-#: src/components/emails/compose-form.tsx:351
+#: src/components/emails/compose-form.tsx:449
 msgid "Sending…"
 msgstr "Enviant…"
 
@@ -1387,12 +1448,16 @@ msgstr "Enviant…"
 msgid "Sent"
 msgstr "Enviat"
 
-#: src/routes/pages/$id.tsx:257
+#: src/routes/emails/inboxes.tsx:862
+msgid "Set as default"
+msgstr "Estableix com a predeterminat"
+
+#: src/routes/pages/$id.tsx:256
 msgid "Settings"
 msgstr "Configuració"
 
-#: src/routes/emails/inboxes.tsx:270
-#: src/routes/emails/inboxes.tsx:574
+#: src/routes/emails/inboxes.tsx:281
+#: src/routes/emails/inboxes.tsx:596
 msgid "Shared"
 msgstr "Compartida"
 
@@ -1437,7 +1502,7 @@ msgstr "Tancant sessió…"
 msgid "Size"
 msgstr "Mida"
 
-#: src/routes/pages/$id.tsx:272
+#: src/routes/pages/$id.tsx:271
 #: src/routes/pages/index.tsx:148
 msgid "Slug"
 msgstr "Slug"
@@ -1467,7 +1532,7 @@ msgstr "Ha fallat l'actualització d'estat"
 msgid "Strikethrough"
 msgstr "Ratllat"
 
-#: src/components/emails/compose-form.tsx:276
+#: src/components/emails/compose-form.tsx:374
 #: src/components/interactions/quick-capture-dialog.tsx:306
 #: src/routes/emails/index.tsx:779
 msgid "Subject"
@@ -1477,15 +1542,15 @@ msgstr "Assumpte"
 msgid "Summary"
 msgstr "Resum"
 
-#: src/routes/emails/inboxes.tsx:134
+#: src/routes/emails/inboxes.tsx:145
 msgid "Sync failed"
 msgstr "Ha fallat la sincronització"
 
-#: src/routes/emails/inboxes.tsx:215
+#: src/routes/emails/inboxes.tsx:226
 msgid "Sync now"
 msgstr "Sincronitza ara"
 
-#: src/routes/emails/inboxes.tsx:215
+#: src/routes/emails/inboxes.tsx:226
 msgid "Syncing…"
 msgstr "Sincronitzant…"
 
@@ -1500,19 +1565,19 @@ msgstr "Etiquetes"
 msgid "Tasks"
 msgstr "Tasques"
 
-#: src/routes/pages/$id.tsx:284
+#: src/routes/pages/$id.tsx:283
 msgid "Template"
 msgstr "Plantilla"
 
 #: src/components/companies/where-panel.tsx:73
 msgid "The geocoder did not return a match. Try editing the location field."
-msgstr "El geocodificador no ha tornat cap coincidència. Prova d'editar el camp d'ubicació."
+msgstr "El geocodificador no ha trobat cap coincidència. Prova d'editar el camp d'ubicació."
 
-#: src/routes/emails/inboxes.tsx:354
+#: src/routes/emails/inboxes.tsx:372
 msgid "The new inbox is ready."
 msgstr "La safata nova ja està a punt."
 
-#: src/routes/pages/$id.tsx:182
+#: src/routes/pages/$id.tsx:181
 msgid "The page is now live."
 msgstr "La pàgina ja està publicada."
 
@@ -1562,7 +1627,7 @@ msgstr "Cronologia"
 msgid "Title"
 msgstr "Títol"
 
-#: src/components/emails/compose-form.tsx:221
+#: src/components/emails/compose-form.tsx:319
 #: src/routes/emails/$threadId.tsx:520
 msgid "To"
 msgstr "Per a"
@@ -1583,7 +1648,7 @@ msgstr "Tipus"
 
 #: src/components/shared/editable-field.tsx:320
 msgid "Type and press Enter"
-msgstr "Escriu i prem Enter"
+msgstr "Escriu i prem Retorn"
 
 #: src/components/emails/email-composer.tsx:291
 msgid "Undo"
@@ -1601,8 +1666,10 @@ msgstr "Usuari desconegut"
 msgid "Unlinked"
 msgstr "Sense enllaçar"
 
-#: src/routes/emails/inboxes.tsx:163
-#: src/routes/emails/inboxes.tsx:183
+#: src/routes/emails/inboxes.tsx:174
+#: src/routes/emails/inboxes.tsx:194
+#: src/routes/emails/inboxes.tsx:754
+#: src/routes/emails/inboxes.tsx:806
 msgid "Update failed"
 msgstr "Ha fallat l'actualització"
 
@@ -1622,15 +1689,19 @@ msgstr "Pujant…"
 msgid "Use “Log interaction” above to record the first touch."
 msgstr "Fes servir «Registra interacció» a dalt per anotar el primer contacte."
 
-#: src/routes/emails/inboxes.tsx:602
+#: src/routes/emails/inboxes.tsx:936
+msgid "Use as default footer"
+msgstr "Utilitza com a peu de pàgina predeterminat"
+
+#: src/routes/emails/inboxes.tsx:624
 msgid "Use as default for this purpose"
 msgstr "Usa com a per defecte per a aquest propòsit"
 
-#: src/routes/emails/inboxes.tsx:495
+#: src/routes/emails/inboxes.tsx:517
 msgid "Username"
 msgstr "Nom d'usuari"
 
-#: src/routes/emails/inboxes.tsx:590
+#: src/routes/emails/inboxes.tsx:612
 msgid "UUID (optional)"
 msgstr "UUID (opcional)"
 
@@ -1638,7 +1709,7 @@ msgstr "UUID (opcional)"
 msgid "View thread"
 msgstr "Veure el fil"
 
-#: src/routes/pages/$id.tsx:290
+#: src/routes/pages/$id.tsx:289
 #: src/routes/pages/index.tsx:151
 msgid "Views"
 msgstr "Visites"
@@ -1651,7 +1722,7 @@ msgstr "Visita"
 msgid "What happened?"
 msgstr "Què ha passat?"
 
-#: src/components/emails/compose-form.tsx:282
+#: src/components/emails/compose-form.tsx:380
 msgid "What is this about?"
 msgstr "De què tracta?"
 
@@ -1672,7 +1743,11 @@ msgstr "On"
 msgid "Workshop floor — live counters on the bench."
 msgstr "Planta del taller — comptadors en viu al banc."
 
-#: src/components/emails/compose-form.tsx:297
+#: src/routes/emails/inboxes.tsx:925
+msgid "Write footer…"
+msgstr "Escriu el peu de pàgina…"
+
+#: src/components/emails/compose-form.tsx:395
 #: src/components/emails/email-composer.tsx:62
 msgid "Write your message…"
 msgstr "Escriu el teu missatge…"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -16,7 +16,7 @@ msgstr ""
 #: src/routes/emails/$threadId.tsx:386
 #: src/routes/emails/$threadId.tsx:396
 #: src/routes/emails/$threadId.tsx:441
-#: src/routes/pages/index.tsx:177
+#: src/routes/pages/index.tsx:174
 msgid "—"
 msgstr "—"
 
@@ -34,7 +34,7 @@ msgstr "— Select a company —"
 msgid "(no subject)"
 msgstr "(no subject)"
 
-#: src/routes/emails/inboxes.tsx:432
+#: src/routes/emails/inboxes.tsx:454
 msgid "(provider assigns)"
 msgstr "(provider assigns)"
 
@@ -74,11 +74,11 @@ msgstr "1 thread"
 msgid "1 thread selected"
 msgstr "1 thread selected"
 
-#: src/routes/emails/inboxes.tsx:252
+#: src/routes/emails/inboxes.tsx:263
 msgid "Actions"
 msgstr "Actions"
 
-#: src/routes/emails/inboxes.tsx:250
+#: src/routes/emails/inboxes.tsx:261
 msgid "Active"
 msgstr "Active"
 
@@ -102,7 +102,7 @@ msgstr "Add a location on the Profile tab, then locate this company."
 msgid "Add attachment"
 msgstr "Add attachment"
 
-#: src/components/emails/compose-form.tsx:243
+#: src/components/emails/compose-form.tsx:341
 msgid "Add Cc / Bcc"
 msgstr "Add Cc / Bcc"
 
@@ -119,16 +119,16 @@ msgstr "Add task"
 msgid "Add the first decision-maker to keep track of who to reach."
 msgstr "Add the first decision-maker to keep track of who to reach."
 
-#: src/routes/emails/inboxes.tsx:149
+#: src/routes/emails/inboxes.tsx:160
 msgid "Added {added}, retired {retired}."
 msgstr "Added {added}, retired {retired}."
 
-#: src/routes/emails/inboxes.tsx:515
+#: src/routes/emails/inboxes.tsx:537
 msgid "Address:"
 msgstr "Address:"
 
-#: src/routes/emails/inboxes.tsx:269
-#: src/routes/emails/inboxes.tsx:568
+#: src/routes/emails/inboxes.tsx:280
+#: src/routes/emails/inboxes.tsx:590
 msgid "Agent"
 msgstr "Agent"
 
@@ -179,7 +179,7 @@ msgstr "Attach"
 msgid "attachment"
 msgstr "attachment"
 
-#: src/routes/emails/inboxes.tsx:201
+#: src/routes/emails/inboxes.tsx:212
 msgid "Back to emails"
 msgstr "Back to emails"
 
@@ -188,7 +188,7 @@ msgstr "Back to emails"
 msgid "Back to inbox"
 msgstr "Back to inbox"
 
-#: src/components/emails/compose-form.tsx:260
+#: src/components/emails/compose-form.tsx:358
 msgid "Bcc"
 msgstr "Bcc"
 
@@ -204,7 +204,7 @@ msgstr "Blocked by the provider. The body is shown for review only."
 msgid "Bold"
 msgstr "Bold"
 
-#: src/components/emails/compose-form.tsx:322
+#: src/components/emails/compose-form.tsx:420
 msgid "bounced"
 msgstr "bounced"
 
@@ -234,7 +234,8 @@ msgid "Call phone"
 msgstr "Call phone"
 
 #: src/components/interactions/quick-capture-dialog.tsx:400
-#: src/routes/emails/inboxes.tsx:616
+#: src/routes/emails/inboxes.tsx:638
+#: src/routes/emails/inboxes.tsx:945
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -242,7 +243,7 @@ msgstr "Cancel"
 msgid "Cancel upload"
 msgstr "Cancel upload"
 
-#: src/components/emails/compose-form.tsx:248
+#: src/components/emails/compose-form.tsx:346
 #: src/routes/emails/$threadId.tsx:543
 msgid "Cc"
 msgstr "Cc"
@@ -255,7 +256,7 @@ msgstr "Change priority"
 msgid "Change status"
 msgstr "Change status"
 
-#: src/routes/pages/$id.tsx:159
+#: src/routes/pages/$id.tsx:158
 msgid "Changes have been saved."
 msgstr "Changes have been saved."
 
@@ -265,7 +266,7 @@ msgstr "Channel"
 
 #: src/routes/companies/$slug.tsx:299
 #: src/routes/emails/index.tsx:734
-#: src/routes/pages/$id.tsx:114
+#: src/routes/pages/$id.tsx:113
 msgid "Check that the session is valid or try again."
 msgstr "Check that the session is valid or try again."
 
@@ -273,7 +274,7 @@ msgstr "Check that the session is valid or try again."
 msgid "Check that your session is valid or try again."
 msgstr "Check that your session is valid or try again."
 
-#: src/routes/emails/inboxes.tsx:229
+#: src/routes/emails/inboxes.tsx:240
 msgid "Check the session or try again."
 msgstr "Check the session or try again."
 
@@ -299,7 +300,8 @@ msgstr "Client"
 
 #: src/components/interactions/quick-capture-dialog.tsx:188
 #: src/routes/emails/$threadId.tsx:315
-#: src/routes/emails/inboxes.tsx:484
+#: src/routes/emails/inboxes.tsx:506
+#: src/routes/emails/inboxes.tsx:830
 #: src/routes/emails/index.tsx:687
 msgid "Close"
 msgstr "Close"
@@ -332,8 +334,8 @@ msgstr "Code block"
 msgid "Cold lead — no contact yet"
 msgstr "Cold lead — no contact yet"
 
-#: src/components/emails/compose-form.tsx:253
-#: src/components/emails/compose-form.tsx:265
+#: src/components/emails/compose-form.tsx:351
+#: src/components/emails/compose-form.tsx:363
 msgid "Comma-separated"
 msgstr "Comma-separated"
 
@@ -353,7 +355,7 @@ msgstr "Companies"
 msgid "Company"
 msgstr "Company"
 
-#: src/components/emails/compose-form.tsx:322
+#: src/components/emails/compose-form.tsx:420
 msgid "complained"
 msgstr "complained"
 
@@ -383,6 +385,10 @@ msgstr "Contacted"
 msgid "Contacts"
 msgstr "Contacts"
 
+#: src/routes/emails/inboxes.tsx:917
+msgid "Content"
+msgstr "Content"
+
 #: src/components/companies/where-panel.tsx:66
 msgid "Coordinates saved from the geocoder."
 msgstr "Coordinates saved from the geocoder."
@@ -391,7 +397,7 @@ msgstr "Coordinates saved from the geocoder."
 msgid "Copy slug"
 msgstr "Copy slug"
 
-#: src/routes/emails/inboxes.tsx:348
+#: src/routes/emails/inboxes.tsx:366
 msgid "Could not create the inbox."
 msgstr "Could not create the inbox."
 
@@ -399,7 +405,7 @@ msgstr "Could not create the inbox."
 msgid "Could not load companies"
 msgstr "Could not load companies"
 
-#: src/routes/emails/inboxes.tsx:228
+#: src/routes/emails/inboxes.tsx:239
 msgid "Could not load inboxes"
 msgstr "Could not load inboxes"
 
@@ -407,7 +413,7 @@ msgstr "Could not load inboxes"
 msgid "Could not load this company"
 msgstr "Could not load this company"
 
-#: src/routes/pages/$id.tsx:113
+#: src/routes/pages/$id.tsx:112
 msgid "Could not load this page"
 msgstr "Could not load this page"
 
@@ -423,11 +429,11 @@ msgstr "Could not locate"
 msgid "Could not log the interaction. Please try again."
 msgstr "Could not log the interaction. Please try again."
 
-#: src/routes/pages/$id.tsx:189
+#: src/routes/pages/$id.tsx:188
 msgid "Could not publish the page. Please try again."
 msgstr "Could not publish the page. Please try again."
 
-#: src/routes/emails/inboxes.tsx:135
+#: src/routes/emails/inboxes.tsx:146
 msgid "Could not reach the email provider. Check logs."
 msgstr "Could not reach the email provider. Check logs."
 
@@ -435,15 +441,15 @@ msgstr "Could not reach the email provider. Check logs."
 msgid "Could not save"
 msgstr "Could not save"
 
-#: src/routes/emails/inboxes.tsx:365
+#: src/routes/emails/inboxes.tsx:383
 msgid "Could not save the inbox."
 msgstr "Could not save the inbox."
 
-#: src/routes/pages/$id.tsx:166
+#: src/routes/pages/$id.tsx:165
 msgid "Could not save the page. Please try again."
 msgstr "Could not save the page. Please try again."
 
-#: src/routes/emails/inboxes.tsx:184
+#: src/routes/emails/inboxes.tsx:195
 msgid "Could not set the default inbox."
 msgstr "Could not set the default inbox."
 
@@ -451,13 +457,18 @@ msgstr "Could not set the default inbox."
 msgid "Could not sign in. Check your email and password."
 msgstr "Could not sign in. Check your email and password."
 
-#: src/routes/emails/inboxes.tsx:164
+#: src/routes/emails/inboxes.tsx:175
 msgid "Could not toggle the inbox state."
 msgstr "Could not toggle the inbox state."
 
-#: src/routes/emails/inboxes.tsx:623
+#: src/routes/emails/inboxes.tsx:645
+#: src/routes/emails/inboxes.tsx:957
 msgid "Create"
 msgstr "Create"
+
+#: src/routes/emails/inboxes.tsx:843
+msgid "Create a footer to append to outgoing emails from this inbox."
+msgstr "Create a footer to append to outgoing emails from this inbox."
 
 #: src/routes/pages/index.tsx:141
 msgid "Create a prospect landing page from a company detail view or via the MCP tools."
@@ -467,18 +478,26 @@ msgstr "Create a prospect landing page from a company detail view or via the MCP
 msgid "Create a prospect landing page to share with this company."
 msgstr "Create a prospect landing page to share with this company."
 
-#: src/routes/emails/inboxes.tsx:219
-#: src/routes/emails/inboxes.tsx:239
-#: src/routes/emails/inboxes.tsx:480
+#: src/routes/emails/inboxes.tsx:736
+msgid "Create failed"
+msgstr "Create failed"
+
+#: src/routes/emails/inboxes.tsx:895
+msgid "Create footer"
+msgstr "Create footer"
+
+#: src/routes/emails/inboxes.tsx:230
+#: src/routes/emails/inboxes.tsx:250
+#: src/routes/emails/inboxes.tsx:502
 msgid "Create inbox"
 msgstr "Create inbox"
 
-#: src/routes/emails/inboxes.tsx:235
+#: src/routes/emails/inboxes.tsx:246
 msgid "Create one or run sync to pull mailboxes from the provider."
 msgstr "Create one or run sync to pull mailboxes from the provider."
 
 #: src/routes/emails/$threadId.tsx:449
-#: src/routes/emails/inboxes.tsx:251
+#: src/routes/emails/inboxes.tsx:262
 msgid "Created"
 msgstr "Created"
 
@@ -499,13 +518,26 @@ msgstr "Dead"
 msgid "Decision maker"
 msgstr "Decision maker"
 
-#: src/routes/emails/inboxes.tsx:249
+#: src/routes/emails/inboxes.tsx:260
+#: src/routes/emails/inboxes.tsx:852
 msgid "Default"
 msgstr "Default"
 
-#: src/routes/emails/inboxes.tsx:290
+#: src/routes/emails/inboxes.tsx:301
 msgid "Default inbox"
 msgstr "Default inbox"
+
+#: src/routes/emails/inboxes.tsx:879
+msgid "Delete"
+msgstr "Delete"
+
+#: src/routes/emails/inboxes.tsx:787
+msgid "Delete failed"
+msgstr "Delete failed"
+
+#: src/routes/emails/inboxes.tsx:780
+msgid "Delete this footer? This cannot be undone."
+msgstr "Delete this footer? This cannot be undone."
 
 #: src/routes/emails/$threadId.tsx:621
 msgid "Delivered"
@@ -515,11 +547,11 @@ msgstr "Delivered"
 msgid "Direction"
 msgstr "Direction"
 
-#: src/components/emails/compose-form.tsx:360
+#: src/components/emails/compose-form.tsx:460
 msgid "Discard"
 msgstr "Discard"
 
-#: src/routes/emails/inboxes.tsx:521
+#: src/routes/emails/inboxes.tsx:543
 msgid "Display name"
 msgstr "Display name"
 
@@ -527,7 +559,7 @@ msgstr "Display name"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/routes/emails/inboxes.tsx:505
+#: src/routes/emails/inboxes.tsx:527
 msgid "Domain"
 msgstr "Domain"
 
@@ -539,28 +571,36 @@ msgstr "Draft"
 msgid "Duration (min)"
 msgstr "Duration (min)"
 
-#: src/routes/emails/inboxes.tsx:511
+#: src/routes/emails/inboxes.tsx:913
+msgid "e.g. Company signature"
+msgstr "e.g. Company signature"
+
+#: src/routes/emails/inboxes.tsx:533
 msgid "e.g. engranatge.com"
 msgstr "e.g. engranatge.com"
 
-#: src/routes/emails/inboxes.tsx:501
+#: src/routes/emails/inboxes.tsx:523
 msgid "e.g. hola"
 msgstr "e.g. hola"
 
-#: src/routes/emails/inboxes.tsx:527
+#: src/routes/emails/inboxes.tsx:549
 msgid "e.g. Hola — Engranatge"
 msgstr "e.g. Hola — Engranatge"
+
+#: src/routes/emails/inboxes.tsx:870
+msgid "Edit"
+msgstr "Edit"
 
 #: src/components/shared/editable-field.tsx:141
 msgid "Edit {label}"
 msgstr "Edit {label}"
 
-#: src/routes/emails/inboxes.tsx:480
+#: src/routes/emails/inboxes.tsx:502
 msgid "Edit inbox"
 msgstr "Edit inbox"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:329
+#: src/routes/emails/inboxes.tsx:347
 msgid "Edit inbox {0}"
 msgstr "Edit inbox {0}"
 
@@ -568,14 +608,14 @@ msgstr "Edit inbox {0}"
 msgid "Edit link"
 msgstr "Edit link"
 
-#: src/routes/pages/$id.tsx:254
+#: src/routes/pages/$id.tsx:253
 msgid "Editor"
 msgstr "Editor"
 
 #: src/components/interactions/quick-capture-dialog.tsx:424
 #: src/components/shared/channel-icon.tsx:51
 #: src/routes/companies/$slug.tsx:720
-#: src/routes/emails/inboxes.tsx:246
+#: src/routes/emails/inboxes.tsx:257
 #: src/routes/login.tsx:141
 msgid "Email"
 msgstr "Email"
@@ -639,6 +679,11 @@ msgstr "First outreach sent"
 msgid "Flagged as spam by the provider. The body is shown for review only."
 msgstr "Flagged as spam by the provider. The body is shown for review only."
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx:827
+msgid "Footers — {0}"
+msgstr "Footers — {0}"
+
 #: src/i18n/lingui.tsx:56
 msgid "Forja — Engranatge CRM"
 msgstr "Forja — Engranatge CRM"
@@ -696,8 +741,8 @@ msgstr "High priority"
 msgid "Horizontal rule"
 msgstr "Horizontal rule"
 
-#: src/routes/emails/inboxes.tsx:267
-#: src/routes/emails/inboxes.tsx:562
+#: src/routes/emails/inboxes.tsx:278
+#: src/routes/emails/inboxes.tsx:584
 msgid "Human"
 msgstr "Human"
 
@@ -718,25 +763,25 @@ msgstr "Inbound and outbound emails will pin to this board once a thread exists.
 msgid "Inbound message from {0}"
 msgstr "Inbound message from {0}"
 
-#: src/components/emails/compose-form.tsx:189
+#: src/components/emails/compose-form.tsx:287
 #: src/routes/emails/$threadId.tsx:390
 #: src/routes/emails/$threadId.tsx:430
 msgid "Inbox"
 msgstr "Inbox"
 
-#: src/routes/emails/inboxes.tsx:353
+#: src/routes/emails/inboxes.tsx:371
 msgid "Inbox created"
 msgstr "Inbox created"
 
-#: src/routes/emails/inboxes.tsx:204
+#: src/routes/emails/inboxes.tsx:215
 msgid "Inbox management"
 msgstr "Inbox management"
 
-#: src/routes/emails/inboxes.tsx:369
+#: src/routes/emails/inboxes.tsx:387
 msgid "Inbox updated"
 msgstr "Inbox updated"
 
-#: src/routes/emails/inboxes.tsx:148
+#: src/routes/emails/inboxes.tsx:159
 msgid "Inboxes synced"
 msgstr "Inboxes synced"
 
@@ -765,7 +810,7 @@ msgid "Lang"
 msgstr "Lang"
 
 #: src/components/profile/language-select.tsx:34
-#: src/routes/pages/$id.tsx:278
+#: src/routes/pages/$id.tsx:277
 #: src/routes/profile/index.tsx:111
 msgid "Language"
 msgstr "Language"
@@ -811,7 +856,7 @@ msgstr "Loading companies…"
 msgid "Loading…"
 msgstr "Loading…"
 
-#: src/routes/emails/inboxes.tsx:244
+#: src/routes/emails/inboxes.tsx:255
 msgid "Local inboxes"
 msgstr "Local inboxes"
 
@@ -858,11 +903,16 @@ msgstr "Low"
 msgid "Low priority"
 msgstr "Low priority"
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx:340
+msgid "Manage footers for {0}"
+msgstr "Manage footers for {0}"
+
 #: src/routes/emails/index.tsx:549
 msgid "Manage inboxes"
 msgstr "Manage inboxes"
 
-#: src/routes/emails/inboxes.tsx:205
+#: src/routes/emails/inboxes.tsx:216
 msgid "Map provider mailboxes to purpose, owner, and defaults."
 msgstr "Map provider mailboxes to purpose, owner, and defaults."
 
@@ -876,11 +926,11 @@ msgstr "Mark \"{0}\" as complete"
 msgid "Mark \"{0}\" as pending"
 msgstr "Mark \"{0}\" as pending"
 
-#: src/routes/emails/inboxes.tsx:308
+#: src/routes/emails/inboxes.tsx:319
 msgid "Mark active"
 msgstr "Mark active"
 
-#: src/routes/emails/inboxes.tsx:290
+#: src/routes/emails/inboxes.tsx:301
 msgid "Mark as default"
 msgstr "Mark as default"
 
@@ -888,7 +938,7 @@ msgstr "Mark as default"
 msgid "Mark contacted"
 msgstr "Mark contacted"
 
-#: src/routes/emails/inboxes.tsx:308
+#: src/routes/emails/inboxes.tsx:319
 msgid "Mark inactive"
 msgstr "Mark inactive"
 
@@ -920,7 +970,7 @@ msgstr "Meeting"
 msgid "Meeting booked"
 msgstr "Meeting booked"
 
-#: src/components/emails/compose-form.tsx:291
+#: src/components/emails/compose-form.tsx:389
 msgid "Message"
 msgstr "Message"
 
@@ -948,7 +998,11 @@ msgstr "msgs"
 msgid "Msgs"
 msgstr "Msgs"
 
-#: src/components/emails/compose-form.tsx:227
+#: src/routes/emails/inboxes.tsx:907
+msgid "Name"
+msgstr "Name"
+
+#: src/components/emails/compose-form.tsx:325
 msgid "name@example.com, another@example.com"
 msgstr "name@example.com, another@example.com"
 
@@ -1019,11 +1073,15 @@ msgstr "No due date"
 msgid "No email threads yet"
 msgstr "No email threads yet"
 
+#: src/routes/emails/inboxes.tsx:842
+msgid "No footers"
+msgstr "No footers"
+
 #: src/routes/index.tsx:461
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "No high-priority companies without a scheduled follow-up"
 
-#: src/routes/emails/inboxes.tsx:234
+#: src/routes/emails/inboxes.tsx:245
 msgid "No inboxes yet"
 msgstr "No inboxes yet"
 
@@ -1148,11 +1206,11 @@ msgstr "Outcome: {0}"
 msgid "Overdue"
 msgstr "Overdue"
 
-#: src/routes/emails/inboxes.tsx:248
+#: src/routes/emails/inboxes.tsx:259
 msgid "Owner"
 msgstr "Owner"
 
-#: src/routes/emails/inboxes.tsx:584
+#: src/routes/emails/inboxes.tsx:606
 msgid "Owner user ID"
 msgstr "Owner user ID"
 
@@ -1160,21 +1218,21 @@ msgstr "Owner user ID"
 msgid "Page {page} of {totalPages}"
 msgstr "Page {page} of {totalPages}"
 
-#: src/routes/pages/$id.tsx:181
+#: src/routes/pages/$id.tsx:180
 msgid "Page published"
 msgstr "Page published"
 
-#: src/routes/pages/$id.tsx:158
+#: src/routes/pages/$id.tsx:157
 msgid "Page saved"
 msgstr "Page saved"
 
-#: src/routes/pages/$id.tsx:210
+#: src/routes/pages/$id.tsx:209
 msgid "Page title"
 msgstr "Page title"
 
 #: src/components/layout/nav-items.ts:59
 #: src/routes/companies/$slug.tsx:764
-#: src/routes/pages/$id.tsx:204
+#: src/routes/pages/$id.tsx:203
 #: src/routes/pages/index.tsx:111
 msgid "Pages"
 msgstr "Pages"
@@ -1192,8 +1250,8 @@ msgstr "Password"
 msgid "Pipeline"
 msgstr "Pipeline"
 
-#: src/routes/pages/$id.tsx:222
-#: src/routes/pages/index.tsx:185
+#: src/routes/pages/$id.tsx:221
+#: src/routes/pages/index.tsx:182
 msgid "Preview"
 msgstr "Preview"
 
@@ -1238,15 +1296,15 @@ msgstr "Proposals, meeting notes and attachments will show up here."
 msgid "Prospect"
 msgstr "Prospect"
 
-#: src/routes/pages/$id.tsx:297
+#: src/routes/pages/$id.tsx:296
 msgid "Public URL"
 msgstr "Public URL"
 
-#: src/routes/pages/$id.tsx:245
+#: src/routes/pages/$id.tsx:244
 msgid "Publish"
 msgstr "Publish"
 
-#: src/routes/pages/$id.tsx:188
+#: src/routes/pages/$id.tsx:187
 msgid "Publish failed"
 msgstr "Publish failed"
 
@@ -1255,13 +1313,13 @@ msgstr "Publish failed"
 msgid "Published"
 msgstr "Published"
 
-#: src/routes/pages/$id.tsx:245
+#: src/routes/pages/$id.tsx:244
 msgid "Publishing…"
 msgstr "Publishing…"
 
-#: src/routes/emails/inboxes.tsx:247
-#: src/routes/emails/inboxes.tsx:532
-#: src/routes/emails/inboxes.tsx:545
+#: src/routes/emails/inboxes.tsx:258
+#: src/routes/emails/inboxes.tsx:554
+#: src/routes/emails/inboxes.tsx:567
 msgid "Purpose"
 msgstr "Purpose"
 
@@ -1324,17 +1382,20 @@ msgstr "Responded"
 msgid "Row actions"
 msgstr "Row actions"
 
-#: src/routes/emails/inboxes.tsx:622
-#: src/routes/pages/$id.tsx:235
+#: src/routes/emails/inboxes.tsx:644
+#: src/routes/emails/inboxes.tsx:958
+#: src/routes/pages/$id.tsx:234
 msgid "Save"
 msgstr "Save"
 
-#: src/routes/pages/$id.tsx:165
+#: src/routes/pages/$id.tsx:164
 msgid "Save failed"
 msgstr "Save failed"
 
-#: src/routes/emails/inboxes.tsx:620
-#: src/routes/pages/$id.tsx:235
+#: src/components/emails/compose-form.tsx:462
+#: src/routes/emails/inboxes.tsx:642
+#: src/routes/emails/inboxes.tsx:955
+#: src/routes/pages/$id.tsx:234
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -1358,7 +1419,7 @@ msgstr "Search threads"
 msgid "Select all threads on this page"
 msgstr "Select all threads on this page"
 
-#: src/components/emails/compose-form.tsx:197
+#: src/components/emails/compose-form.tsx:295
 msgid "Select inbox…"
 msgstr "Select inbox…"
 
@@ -1367,11 +1428,11 @@ msgstr "Select inbox…"
 msgid "Select thread {0}"
 msgstr "Select thread {0}"
 
-#: src/components/emails/compose-form.tsx:351
+#: src/components/emails/compose-form.tsx:449
 msgid "Send"
 msgstr "Send"
 
-#: src/components/emails/compose-form.tsx:316
+#: src/components/emails/compose-form.tsx:414
 msgid "Send blocked: these recipients cannot receive email"
 msgstr "Send blocked: these recipients cannot receive email"
 
@@ -1379,7 +1440,7 @@ msgstr "Send blocked: these recipients cannot receive email"
 msgid "Send email"
 msgstr "Send email"
 
-#: src/components/emails/compose-form.tsx:351
+#: src/components/emails/compose-form.tsx:449
 msgid "Sending…"
 msgstr "Sending…"
 
@@ -1387,12 +1448,16 @@ msgstr "Sending…"
 msgid "Sent"
 msgstr "Sent"
 
-#: src/routes/pages/$id.tsx:257
+#: src/routes/emails/inboxes.tsx:862
+msgid "Set as default"
+msgstr "Set as default"
+
+#: src/routes/pages/$id.tsx:256
 msgid "Settings"
 msgstr "Settings"
 
-#: src/routes/emails/inboxes.tsx:270
-#: src/routes/emails/inboxes.tsx:574
+#: src/routes/emails/inboxes.tsx:281
+#: src/routes/emails/inboxes.tsx:596
 msgid "Shared"
 msgstr "Shared"
 
@@ -1437,7 +1502,7 @@ msgstr "Signing out…"
 msgid "Size"
 msgstr "Size"
 
-#: src/routes/pages/$id.tsx:272
+#: src/routes/pages/$id.tsx:271
 #: src/routes/pages/index.tsx:148
 msgid "Slug"
 msgstr "Slug"
@@ -1467,7 +1532,7 @@ msgstr "Status update failed"
 msgid "Strikethrough"
 msgstr "Strikethrough"
 
-#: src/components/emails/compose-form.tsx:276
+#: src/components/emails/compose-form.tsx:374
 #: src/components/interactions/quick-capture-dialog.tsx:306
 #: src/routes/emails/index.tsx:779
 msgid "Subject"
@@ -1477,15 +1542,15 @@ msgstr "Subject"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/routes/emails/inboxes.tsx:134
+#: src/routes/emails/inboxes.tsx:145
 msgid "Sync failed"
 msgstr "Sync failed"
 
-#: src/routes/emails/inboxes.tsx:215
+#: src/routes/emails/inboxes.tsx:226
 msgid "Sync now"
 msgstr "Sync now"
 
-#: src/routes/emails/inboxes.tsx:215
+#: src/routes/emails/inboxes.tsx:226
 msgid "Syncing…"
 msgstr "Syncing…"
 
@@ -1500,7 +1565,7 @@ msgstr "Tags"
 msgid "Tasks"
 msgstr "Tasks"
 
-#: src/routes/pages/$id.tsx:284
+#: src/routes/pages/$id.tsx:283
 msgid "Template"
 msgstr "Template"
 
@@ -1508,11 +1573,11 @@ msgstr "Template"
 msgid "The geocoder did not return a match. Try editing the location field."
 msgstr "The geocoder did not return a match. Try editing the location field."
 
-#: src/routes/emails/inboxes.tsx:354
+#: src/routes/emails/inboxes.tsx:372
 msgid "The new inbox is ready."
 msgstr "The new inbox is ready."
 
-#: src/routes/pages/$id.tsx:182
+#: src/routes/pages/$id.tsx:181
 msgid "The page is now live."
 msgstr "The page is now live."
 
@@ -1562,7 +1627,7 @@ msgstr "Timeline"
 msgid "Title"
 msgstr "Title"
 
-#: src/components/emails/compose-form.tsx:221
+#: src/components/emails/compose-form.tsx:319
 #: src/routes/emails/$threadId.tsx:520
 msgid "To"
 msgstr "To"
@@ -1601,8 +1666,10 @@ msgstr "Unknown user"
 msgid "Unlinked"
 msgstr "Unlinked"
 
-#: src/routes/emails/inboxes.tsx:163
-#: src/routes/emails/inboxes.tsx:183
+#: src/routes/emails/inboxes.tsx:174
+#: src/routes/emails/inboxes.tsx:194
+#: src/routes/emails/inboxes.tsx:754
+#: src/routes/emails/inboxes.tsx:806
 msgid "Update failed"
 msgstr "Update failed"
 
@@ -1622,15 +1689,19 @@ msgstr "Uploading…"
 msgid "Use “Log interaction” above to record the first touch."
 msgstr "Use “Log interaction” above to record the first touch."
 
-#: src/routes/emails/inboxes.tsx:602
+#: src/routes/emails/inboxes.tsx:936
+msgid "Use as default footer"
+msgstr "Use as default footer"
+
+#: src/routes/emails/inboxes.tsx:624
 msgid "Use as default for this purpose"
 msgstr "Use as default for this purpose"
 
-#: src/routes/emails/inboxes.tsx:495
+#: src/routes/emails/inboxes.tsx:517
 msgid "Username"
 msgstr "Username"
 
-#: src/routes/emails/inboxes.tsx:590
+#: src/routes/emails/inboxes.tsx:612
 msgid "UUID (optional)"
 msgstr "UUID (optional)"
 
@@ -1638,7 +1709,7 @@ msgstr "UUID (optional)"
 msgid "View thread"
 msgstr "View thread"
 
-#: src/routes/pages/$id.tsx:290
+#: src/routes/pages/$id.tsx:289
 #: src/routes/pages/index.tsx:151
 msgid "Views"
 msgstr "Views"
@@ -1651,7 +1722,7 @@ msgstr "Visit"
 msgid "What happened?"
 msgstr "What happened?"
 
-#: src/components/emails/compose-form.tsx:282
+#: src/components/emails/compose-form.tsx:380
 msgid "What is this about?"
 msgstr "What is this about?"
 
@@ -1672,7 +1743,11 @@ msgstr "Where"
 msgid "Workshop floor — live counters on the bench."
 msgstr "Workshop floor — live counters on the bench."
 
-#: src/components/emails/compose-form.tsx:297
+#: src/routes/emails/inboxes.tsx:925
+msgid "Write footer…"
+msgstr "Write footer…"
+
+#: src/components/emails/compose-form.tsx:395
 #: src/components/emails/email-composer.tsx:62
 msgid "Write your message…"
 msgstr "Write your message…"

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -5,11 +5,13 @@ import { AsyncResult } from 'effect/unstable/reactivity'
 import {
 	Check,
 	ChevronLeft,
+	FileText,
 	Inbox as InboxIcon,
 	Pencil,
 	Plus,
 	RefreshCw,
 	Star,
+	Trash2,
 	X,
 } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
@@ -24,11 +26,16 @@ import {
 } from '@engranatge/ui/pri'
 
 import {
+	createFooterAtom,
 	createInboxAtom,
+	deleteFooterAtom,
+	footersAtomFor,
 	inboxesListAtom,
 	syncInboxesAtom,
+	updateFooterAtom,
 	updateInboxAtom,
 } from '#/atoms/emails-atoms'
+import { EmailComposer } from '#/components/emails/email-composer'
 import { EmptyState } from '#/components/shared/empty-state'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { SkeletonRows } from '#/components/shared/skeleton-row'
@@ -91,6 +98,7 @@ type DialogMode =
 	| { readonly kind: 'closed' }
 	| { readonly kind: 'create' }
 	| { readonly kind: 'edit'; readonly row: InboxRow }
+	| { readonly kind: 'footers'; readonly row: InboxRow }
 
 function InboxesPage() {
 	const { t } = useLingui()
@@ -120,6 +128,9 @@ function InboxesPage() {
 	}, [])
 	const openEdit = useCallback((row: InboxRow) => {
 		setDialog({ kind: 'edit', row })
+	}, [])
+	const openFooters = useCallback((row: InboxRow) => {
+		setDialog({ kind: 'footers', row })
 	}, [])
 	const closeDialog = useCallback(() => {
 		setDialog({ kind: 'closed' })
@@ -325,6 +336,13 @@ function InboxesPage() {
 							<CellActions role='cell'>
 								<IconAction
 									type='button'
+									onClick={() => openFooters(row)}
+									aria-label={t`Manage footers for ${row.email}`}
+								>
+									<FileText size={14} aria-hidden />
+								</IconAction>
+								<IconAction
+									type='button'
 									onClick={() => openEdit(row)}
 									aria-label={t`Edit inbox ${row.email}`}
 								>
@@ -336,7 +354,7 @@ function InboxesPage() {
 				</InboxesTable>
 			)}
 
-			{dialog.kind !== 'closed' && (
+			{(dialog.kind === 'create' || dialog.kind === 'edit') && (
 				<InboxFormDialog
 					mode={dialog}
 					onClose={closeDialog}
@@ -372,6 +390,10 @@ function InboxesPage() {
 						return { ok: true }
 					}}
 				/>
+			)}
+
+			{dialog.kind === 'footers' && (
+				<FooterManageDialog row={dialog.row} onClose={closeDialog} />
 			)}
 		</Page>
 	)
@@ -630,6 +652,339 @@ function InboxFormDialog({
 	)
 }
 
+// ── Footer management dialog ────────────────────────────────────
+
+type FooterRow = {
+	readonly id: string
+	readonly name: string
+	readonly html: string
+	readonly textFallback: string
+	readonly isDefault: boolean
+}
+
+type FooterEditing =
+	| { readonly kind: 'none' }
+	| { readonly kind: 'create' }
+	| { readonly kind: 'edit'; readonly footer: FooterRow }
+
+function FooterManageDialog({
+	row,
+	onClose,
+}: {
+	readonly row: InboxRow
+	readonly onClose: () => void
+}) {
+	const { t } = useLingui()
+	const toastManager = usePriToast()
+	const footersResult = useAtomValue(footersAtomFor(row.id))
+	const refreshFooters = useAtomRefresh(footersAtomFor(row.id))
+
+	const createFooter = useAtomSet(createFooterAtom, { mode: 'promiseExit' })
+	const updateFooter = useAtomSet(updateFooterAtom, { mode: 'promiseExit' })
+	const deleteFooter = useAtomSet(deleteFooterAtom, { mode: 'promiseExit' })
+
+	const footers = useMemo<ReadonlyArray<FooterRow>>(
+		() =>
+			AsyncResult.isSuccess(footersResult)
+				? narrowFooterRows(footersResult.value)
+				: [],
+		[footersResult],
+	)
+
+	const [editing, setEditing] = useState<FooterEditing>({ kind: 'none' })
+	const [name, setName] = useState('')
+	const [html, setHtml] = useState('')
+	const [textFallback, setTextFallback] = useState('')
+	const [isDefault, setIsDefault] = useState(false)
+	const [submitting, setSubmitting] = useState(false)
+
+	const startCreate = useCallback(() => {
+		setName('')
+		setHtml('')
+		setTextFallback('')
+		setIsDefault(false)
+		setEditing({ kind: 'create' })
+	}, [])
+
+	const startEdit = useCallback((footer: FooterRow) => {
+		setName(footer.name)
+		setHtml(footer.html)
+		setTextFallback(footer.textFallback)
+		setIsDefault(footer.isDefault)
+		setEditing({ kind: 'edit', footer })
+	}, [])
+
+	const cancelEdit = useCallback(() => {
+		setEditing({ kind: 'none' })
+	}, [])
+
+	const handleSave = useCallback(async () => {
+		if (name.trim() === '' || html.trim() === '') return
+		setSubmitting(true)
+		if (editing.kind === 'create') {
+			const exit = await createFooter({
+				params: { inboxId: row.id },
+				payload: {
+					name,
+					html,
+					...(textFallback !== '' && { textFallback }),
+					...(isDefault && { isDefault: true }),
+				},
+			} as never)
+			if (exit._tag !== 'Success') {
+				toastManager.add({
+					title: t`Create failed`,
+					type: 'error',
+				})
+				setSubmitting(false)
+				return
+			}
+		} else if (editing.kind === 'edit') {
+			const exit = await updateFooter({
+				params: { id: editing.footer.id },
+				payload: {
+					name,
+					html,
+					textFallback,
+					isDefault,
+				},
+			} as never)
+			if (exit._tag !== 'Success') {
+				toastManager.add({
+					title: t`Update failed`,
+					type: 'error',
+				})
+				setSubmitting(false)
+				return
+			}
+		}
+		refreshFooters()
+		setEditing({ kind: 'none' })
+		setSubmitting(false)
+	}, [
+		editing,
+		name,
+		html,
+		textFallback,
+		isDefault,
+		row.id,
+		createFooter,
+		updateFooter,
+		refreshFooters,
+		toastManager,
+		t,
+	])
+
+	const handleDelete = useCallback(
+		async (footerId: string) => {
+			const ok = window.confirm(t`Delete this footer? This cannot be undone.`)
+			if (!ok) return
+			const exit = await deleteFooter({
+				params: { id: footerId },
+			} as never)
+			if (exit._tag !== 'Success') {
+				toastManager.add({
+					title: t`Delete failed`,
+					type: 'error',
+				})
+				return
+			}
+			refreshFooters()
+		},
+		[deleteFooter, refreshFooters, toastManager, t],
+	)
+
+	const handleSetDefault = useCallback(
+		async (footer: FooterRow) => {
+			if (footer.isDefault) return
+			const exit = await updateFooter({
+				params: { id: footer.id },
+				payload: { isDefault: true },
+			} as never)
+			if (exit._tag !== 'Success') {
+				toastManager.add({
+					title: t`Update failed`,
+					type: 'error',
+				})
+				return
+			}
+			refreshFooters()
+		},
+		[updateFooter, refreshFooters, toastManager, t],
+	)
+
+	return (
+		<PriDialog.Root
+			open
+			onOpenChange={(next: boolean) => {
+				if (!next) onClose()
+			}}
+		>
+			<PriDialog.Portal>
+				<PriDialog.Backdrop />
+				<PriDialog.Popup>
+					<DialogHeader>
+						<PriDialog.Title>{t`Footers — ${row.email}`}</PriDialog.Title>
+						<PriDialog.Close
+							render={props => (
+								<CloseButton type='button' aria-label={t`Close`} {...props}>
+									<X size={16} aria-hidden />
+								</CloseButton>
+							)}
+						/>
+					</DialogHeader>
+
+					{editing.kind === 'none' ? (
+						<FooterListView>
+							{footers.length === 0 ? (
+								<EmptyState
+									icon={FileText}
+									title={t`No footers`}
+									description={t`Create a footer to append to outgoing emails from this inbox.`}
+								/>
+							) : (
+								<FooterTable>
+									{footers.map(f => (
+										<FooterItem key={f.id}>
+											<FooterName>
+												{f.name}
+												{f.isDefault ? (
+													<DefaultTag>{t`Default`}</DefaultTag>
+												) : null}
+											</FooterName>
+											<FooterActions>
+												{!f.isDefault && (
+													<IconAction
+														type='button'
+														onClick={() => {
+															void handleSetDefault(f)
+														}}
+														aria-label={t`Set as default`}
+													>
+														<Star size={14} aria-hidden />
+													</IconAction>
+												)}
+												<IconAction
+													type='button'
+													onClick={() => startEdit(f)}
+													aria-label={t`Edit`}
+												>
+													<Pencil size={14} aria-hidden />
+												</IconAction>
+												<IconAction
+													type='button'
+													onClick={() => {
+														void handleDelete(f.id)
+													}}
+													aria-label={t`Delete`}
+												>
+													<Trash2 size={14} aria-hidden />
+												</IconAction>
+											</FooterActions>
+										</FooterItem>
+									))}
+								</FooterTable>
+							)}
+							<FooterDialogFooter>
+								<PriButton
+									type='button'
+									$variant='filled'
+									onClick={startCreate}
+								>
+									<Plus size={14} aria-hidden />
+									<span>{t`Create footer`}</span>
+								</PriButton>
+							</FooterDialogFooter>
+						</FooterListView>
+					) : (
+						<Form
+							onSubmit={e => {
+								e.preventDefault()
+								void handleSave()
+							}}
+						>
+							<Field>
+								<Label htmlFor='ftr-name'>{t`Name`}</Label>
+								<PriInput
+									id='ftr-name'
+									type='text'
+									value={name}
+									onChange={e => setName(e.target.value)}
+									placeholder={t`e.g. Company signature`}
+								/>
+							</Field>
+							<Field>
+								<Label>{t`Content`}</Label>
+								<FooterEditorWrap>
+									<EmailComposer
+										initialHtml={html}
+										onChange={(h, text) => {
+											setHtml(h)
+											setTextFallback(text)
+										}}
+										placeholder={t`Write footer…`}
+									/>
+								</FooterEditorWrap>
+							</Field>
+							<CheckboxRow>
+								<input
+									id='ftr-default'
+									type='checkbox'
+									checked={isDefault}
+									onChange={e => setIsDefault(e.target.checked)}
+								/>
+								<label htmlFor='ftr-default'>{t`Use as default footer`}</label>
+							</CheckboxRow>
+							<Footer>
+								<PriButton
+									type='button'
+									$variant='text'
+									onClick={cancelEdit}
+									disabled={submitting}
+								>
+									{t`Cancel`}
+								</PriButton>
+								<PriButton
+									type='submit'
+									$variant='filled'
+									disabled={
+										submitting || name.trim() === '' || html.trim() === ''
+									}
+								>
+									{submitting
+										? t`Saving…`
+										: editing.kind === 'create'
+											? t`Create`
+											: t`Save`}
+								</PriButton>
+							</Footer>
+						</Form>
+					)}
+				</PriDialog.Popup>
+			</PriDialog.Portal>
+		</PriDialog.Root>
+	)
+}
+
+function narrowFooterRows(raw: unknown): ReadonlyArray<FooterRow> {
+	if (!Array.isArray(raw)) return []
+	const out: FooterRow[] = []
+	for (const entry of raw) {
+		if (!entry || typeof entry !== 'object') continue
+		const r = entry as Record<string, unknown>
+		if (typeof r['id'] !== 'string') continue
+		out.push({
+			id: r['id'],
+			name: typeof r['name'] === 'string' ? r['name'] : '',
+			html: typeof r['html'] === 'string' ? r['html'] : '',
+			textFallback:
+				typeof r['textFallback'] === 'string' ? r['textFallback'] : '',
+			isDefault: r['isDefault'] === true,
+		})
+	}
+	return out
+}
+
 // ── Narrowing ────────────────────────────────────────────────────
 
 function narrowInboxRows(rows: unknown): ReadonlyArray<InboxRow> {
@@ -754,7 +1109,7 @@ const gridTemplate = css`
 		4rem
 		4rem
 		minmax(0, 1fr)
-		2.5rem;
+		5rem;
 	align-items: center;
 	gap: var(--space-sm);
 	padding: var(--space-sm) var(--space-md);
@@ -860,6 +1215,7 @@ const CellActions = styled.div.withConfig({
 })`
 	display: flex;
 	justify-content: flex-end;
+	gap: var(--space-3xs);
 `
 
 const PurposeBadge = styled.span.withConfig({
@@ -1050,4 +1406,78 @@ const Footer = styled.div.withConfig({ displayName: 'InboxFormFooter' })`
 	gap: var(--space-sm);
 	padding-top: var(--space-sm);
 	background-position: left top;
+`
+
+// ── Footer dialog styles ────────────────────────────────────────
+
+const FooterListView = styled.div.withConfig({
+	displayName: 'FooterListView',
+})`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+`
+
+const FooterTable = styled.div.withConfig({ displayName: 'FooterTable' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const FooterItem = styled.div.withConfig({ displayName: 'FooterItem' })`
+	${agedPaperRow}
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-sm);
+	padding: var(--space-sm) var(--space-md);
+	border: 1px solid var(--color-ledger-line);
+	border-radius: var(--shape-2xs);
+`
+
+const FooterName = styled.div.withConfig({ displayName: 'FooterName' })`
+	display: flex;
+	align-items: center;
+	gap: var(--space-xs);
+	font-family: var(--font-body);
+	font-weight: var(--font-weight-medium);
+	min-width: 0;
+`
+
+const DefaultTag = styled.span.withConfig({ displayName: 'FooterDefault' })`
+	display: inline-flex;
+	padding: 1px var(--space-2xs);
+	border-radius: var(--shape-2xs);
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	background: color-mix(in oklab, var(--color-primary) 16%, transparent);
+	color: color-mix(in oklab, var(--color-primary) 80%, black);
+	border: 1px solid
+		color-mix(in oklab, var(--color-primary) 45%, transparent);
+`
+
+const FooterActions = styled.div.withConfig({
+	displayName: 'FooterActions',
+})`
+	display: flex;
+	gap: var(--space-3xs);
+	flex: 0 0 auto;
+`
+
+const FooterDialogFooter = styled.div.withConfig({
+	displayName: 'FooterDialogFooter',
+})`
+	display: flex;
+	justify-content: flex-start;
+`
+
+const FooterEditorWrap = styled.div.withConfig({
+	displayName: 'FooterEditorWrap',
+})`
+	min-height: 120px;
+	border: 1px solid var(--color-ledger-line);
+	border-radius: var(--shape-2xs);
+	padding: var(--space-2xs);
 `

--- a/apps/server/src/db/migrations/0001_initial.ts
+++ b/apps/server/src/db/migrations/0001_initial.ts
@@ -239,6 +239,19 @@ export default Effect.gen(function* () {
 		)
 	`
 
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS inbox_footers (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			inbox_id UUID NOT NULL REFERENCES inboxes(id) ON DELETE CASCADE,
+			name TEXT NOT NULL,
+			html TEXT NOT NULL,
+			text_fallback TEXT NOT NULL DEFAULT '',
+			is_default BOOLEAN NOT NULL DEFAULT false,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		)
+	`
+
 	// ── Call recordings ──────────────────────────────────────────────
 	yield* sql`
 		CREATE TABLE IF NOT EXISTS call_recordings (
@@ -420,6 +433,10 @@ export default Effect.gen(function* () {
 		sql`CREATE INDEX IF NOT EXISTS idx_inboxes_purpose ON inboxes(purpose) WHERE active = true`,
 		sql`CREATE INDEX IF NOT EXISTS idx_inboxes_owner_user_id ON inboxes(owner_user_id) WHERE owner_user_id IS NOT NULL`,
 		sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_inboxes_single_default ON inboxes((1)) WHERE is_default = true`,
+
+		// inbox_footers
+		sql`CREATE INDEX IF NOT EXISTS idx_inbox_footers_inbox_id ON inbox_footers(inbox_id)`,
+		sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_footers_single_default ON inbox_footers(inbox_id) WHERE is_default = true`,
 
 		// call_recordings — partial index on the common "active" path.
 		sql`CREATE INDEX IF NOT EXISTS idx_call_recordings_active ON call_recordings(deleted_at) WHERE deleted_at IS NULL`,

--- a/apps/server/src/handlers/email.ts
+++ b/apps/server/src/handlers/email.ts
@@ -2,7 +2,7 @@ import { Effect, Stream } from 'effect'
 import { HttpServerResponse, Multipart } from 'effect/unstable/http'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
-import { type BadRequest, ForjaApi } from '@engranatge/controllers'
+import { BadRequest, ForjaApi } from '@engranatge/controllers'
 
 import { EmailService } from '../services/email'
 import { EmailAttachmentStaging } from '../services/email-attachment-staging'
@@ -21,286 +21,414 @@ export const EmailLive = HttpApiBuilder.group(ForjaApi, 'email', handlers =>
 			refs && refs.length > 0
 				? staging.resolve(refs.map(r => r.stagingId))
 				: Effect.succeed([])
-		return handlers
-			.handle('send', _ =>
-				Effect.gen(function* () {
-					const attachments = yield* resolveAttachments(_.payload.attachments)
-					return yield* svc.send(
-						_.payload.inboxId,
-						typeof _.payload.to === 'string' ? _.payload.to : [..._.payload.to],
-						_.payload.subject,
-						{
-							...(_.payload.text !== undefined && {
-								text: _.payload.text,
-							}),
-							...(_.payload.html !== undefined && {
-								html: _.payload.html,
-							}),
-						},
-						_.payload.companyId,
-						_.payload.contactId,
-						{
-							...(_.payload.cc !== undefined && { cc: [..._.payload.cc] }),
-							...(_.payload.bcc !== undefined && {
-								bcc: [..._.payload.bcc],
-							}),
-							...(_.payload.replyTo !== undefined && {
-								replyTo: _.payload.replyTo,
-							}),
-							...(attachments.length > 0 && { attachments }),
-						},
-					)
-				}).pipe(
-					// EmailSuppressed + BadRequest flow through the typed error channel.
-					// Anything else (EmailSendError, SqlError) becomes a defect.
-					Effect.catchTag('EmailSendError', e => Effect.die(e)),
-					Effect.catchTag('SqlError', e => Effect.die(e)),
-				),
-			)
-			.handle('reply', _ =>
-				Effect.gen(function* () {
-					const attachments = yield* resolveAttachments(_.payload.attachments)
-					return yield* svc.reply(
-						_.payload.threadId,
-						{
-							...(_.payload.text !== undefined && {
-								text: _.payload.text,
-							}),
-							...(_.payload.html !== undefined && {
-								html: _.payload.html,
-							}),
-						},
-						{
-							...(_.payload.cc !== undefined && { cc: [..._.payload.cc] }),
-							...(_.payload.bcc !== undefined && {
-								bcc: [..._.payload.bcc],
-							}),
-							...(attachments.length > 0 && { attachments }),
-						},
-					)
-				}).pipe(
-					Effect.catchTag('EmailSendError', e => Effect.die(e)),
-					Effect.catchTag('NotFound', e => Effect.die(e)),
-					Effect.catchTag('EmailError', e => Effect.die(e)),
-					Effect.catchTag('SqlError', e => Effect.die(e)),
-				),
-			)
-			.handle('listThreads', _ =>
-				svc.listThreads({
-					...(_.query.inboxId !== undefined && {
-						inboxId: _.query.inboxId,
-					}),
-					...(_.query.companyId !== undefined && {
-						companyId: _.query.companyId,
-					}),
-					...(_.query.status !== undefined && { status: _.query.status }),
-					...(_.query.purpose !== undefined && {
-						purpose: _.query.purpose,
-					}),
-					...(_.query.query !== undefined && { query: _.query.query }),
-					...(_.query.limit !== undefined && { limit: _.query.limit }),
-					...(_.query.offset !== undefined && { offset: _.query.offset }),
-				}),
-			)
-			.handle('getThread', _ =>
-				svc.getThread(_.params.threadId).pipe(Effect.orDie),
-			)
-			.handle('updateThreadStatus', _ =>
-				svc.updateThreadStatus(_.params.threadId, _.payload.status).pipe(
-					Effect.catchTag('NotFound', e => Effect.die(e)),
-					Effect.catchTag('SqlError', e => Effect.die(e)),
-					Effect.orDie,
-				),
-			)
-			.handle('markThreadRead', _ => svc.markThreadRead(_.params.threadId))
-			.handle('markThreadUnread', _ => svc.markThreadUnread(_.params.threadId))
-			.handle('listMessages', _ =>
-				svc.listMessages({
-					...(_.query.contactId !== undefined && {
-						contactId: _.query.contactId,
-					}),
-					...(_.query.companyId !== undefined && {
-						companyId: _.query.companyId,
-					}),
-					...(_.query.status !== undefined && {
-						status: _.query.status,
-					}),
-					...(_.query.limit !== undefined && {
-						limit: _.query.limit,
-					}),
-					...(_.query.offset !== undefined && {
-						offset: _.query.offset,
-					}),
-				}),
-			)
-			.handle('getMessage', _ =>
-				svc.getMessage(_.params.messageId).pipe(Effect.orDie),
-			)
-			.handle('listInboxes', _ =>
-				svc.listLocalInboxes({
-					...(_.query.purpose !== undefined && {
-						purpose: _.query.purpose,
-					}),
-					...(_.query.active !== undefined && {
-						active: _.query.active === 'true',
-					}),
-					...(_.query.ownerUserId !== undefined && {
-						ownerUserId: _.query.ownerUserId,
-					}),
-				}),
-			)
-			.handle('createInbox', _ =>
-				svc
-					.createInbox({
-						...(_.payload.username !== undefined && {
-							username: _.payload.username,
-						}),
-						...(_.payload.domain !== undefined && {
-							domain: _.payload.domain,
-						}),
-						...(_.payload.displayName !== undefined && {
-							displayName: _.payload.displayName,
-						}),
-						purpose: _.payload.purpose,
-						...(_.payload.ownerUserId !== undefined && {
-							ownerUserId: _.payload.ownerUserId,
-						}),
-						...(_.payload.isDefault !== undefined && {
-							isDefault: _.payload.isDefault,
-						}),
-					})
-					.pipe(
+		return (
+			handlers
+				.handle('send', _ =>
+					Effect.gen(function* () {
+						const attachments = yield* resolveAttachments(_.payload.attachments)
+						return yield* svc.send(
+							_.payload.inboxId,
+							typeof _.payload.to === 'string'
+								? _.payload.to
+								: [..._.payload.to],
+							_.payload.subject,
+							{
+								...(_.payload.text !== undefined && {
+									text: _.payload.text,
+								}),
+								...(_.payload.html !== undefined && {
+									html: _.payload.html,
+								}),
+							},
+							_.payload.companyId,
+							_.payload.contactId,
+							{
+								...(_.payload.cc !== undefined && { cc: [..._.payload.cc] }),
+								...(_.payload.bcc !== undefined && {
+									bcc: [..._.payload.bcc],
+								}),
+								...(_.payload.replyTo !== undefined && {
+									replyTo: _.payload.replyTo,
+								}),
+								...(attachments.length > 0 && { attachments }),
+								...(_.payload.skipFooter !== undefined && {
+									skipFooter: _.payload.skipFooter,
+								}),
+							},
+						)
+					}).pipe(
+						Effect.catchTag('EmailSendError', e => Effect.die(e)),
+						Effect.catchTag('SqlError', e => Effect.die(e)),
+					),
+				)
+				.handle('reply', _ =>
+					Effect.gen(function* () {
+						const attachments = yield* resolveAttachments(_.payload.attachments)
+						return yield* svc.reply(
+							_.payload.threadId,
+							{
+								...(_.payload.text !== undefined && {
+									text: _.payload.text,
+								}),
+								...(_.payload.html !== undefined && {
+									html: _.payload.html,
+								}),
+							},
+							{
+								...(_.payload.cc !== undefined && { cc: [..._.payload.cc] }),
+								...(_.payload.bcc !== undefined && {
+									bcc: [..._.payload.bcc],
+								}),
+								...(attachments.length > 0 && { attachments }),
+								...(_.payload.skipFooter !== undefined && {
+									skipFooter: _.payload.skipFooter,
+								}),
+							},
+						)
+					}).pipe(
+						Effect.catchTag('EmailSendError', e => Effect.die(e)),
+						Effect.catchTag('NotFound', e => Effect.die(e)),
 						Effect.catchTag('EmailError', e => Effect.die(e)),
 						Effect.catchTag('SqlError', e => Effect.die(e)),
 					),
-			)
-			.handle('updateInbox', _ =>
-				svc
-					.updateInbox(_.params.id, {
-						...(_.payload.displayName !== undefined && {
-							displayName: _.payload.displayName,
+				)
+				.handle('listThreads', _ =>
+					svc.listThreads({
+						...(_.query.inboxId !== undefined && {
+							inboxId: _.query.inboxId,
 						}),
-						...(_.payload.purpose !== undefined && {
-							purpose: _.payload.purpose,
+						...(_.query.companyId !== undefined && {
+							companyId: _.query.companyId,
 						}),
-						...(_.payload.ownerUserId !== undefined && {
-							ownerUserId: _.payload.ownerUserId,
+						...(_.query.status !== undefined && { status: _.query.status }),
+						...(_.query.purpose !== undefined && {
+							purpose: _.query.purpose,
 						}),
-						...(_.payload.isDefault !== undefined && {
-							isDefault: _.payload.isDefault,
-						}),
-						...(_.payload.active !== undefined && {
-							active: _.payload.active,
-						}),
-					})
-					.pipe(
+						...(_.query.query !== undefined && { query: _.query.query }),
+						...(_.query.limit !== undefined && { limit: _.query.limit }),
+						...(_.query.offset !== undefined && { offset: _.query.offset }),
+					}),
+				)
+				.handle('getThread', _ =>
+					svc.getThread(_.params.threadId).pipe(Effect.orDie),
+				)
+				.handle('updateThreadStatus', _ =>
+					svc.updateThreadStatus(_.params.threadId, _.payload.status).pipe(
 						Effect.catchTag('NotFound', e => Effect.die(e)),
 						Effect.catchTag('SqlError', e => Effect.die(e)),
-					),
-			)
-			.handle('syncInboxes', () => svc.syncInboxes())
-			.handleRaw(
-				'stageAttachment',
-				Effect.fnUntraced(function* ({ request }) {
-					let bytes: Uint8Array | undefined
-					let filename: string | undefined
-					let contentType: string | undefined
-
-					yield* request.multipartStream.pipe(
-						Stream.runForEach(part =>
-							Effect.gen(function* () {
-								if (Multipart.isFile(part) && part.key === 'file') {
-									bytes = yield* part.contentEffect
-									filename = part.name ?? 'attachment'
-									contentType = part.contentType
-								}
-							}),
-						),
 						Effect.orDie,
-					)
-
-					if (!bytes || !contentType) {
-						return HttpServerResponse.jsonUnsafe(
-							{
-								_tag: 'BadRequest',
-								message: 'Missing file part in multipart upload',
-							},
-							{ status: 400 },
-						)
-					}
-
-					const result = yield* staging
-						.stage({
-							bytes,
-							filename: filename ?? 'attachment',
-							contentType,
+					),
+				)
+				.handle('markThreadRead', _ => svc.markThreadRead(_.params.threadId))
+				.handle('markThreadUnread', _ =>
+					svc.markThreadUnread(_.params.threadId),
+				)
+				.handle('listMessages', _ =>
+					svc.listMessages({
+						...(_.query.contactId !== undefined && {
+							contactId: _.query.contactId,
+						}),
+						...(_.query.companyId !== undefined && {
+							companyId: _.query.companyId,
+						}),
+						...(_.query.status !== undefined && {
+							status: _.query.status,
+						}),
+						...(_.query.limit !== undefined && {
+							limit: _.query.limit,
+						}),
+						...(_.query.offset !== undefined && {
+							offset: _.query.offset,
+						}),
+					}),
+				)
+				.handle('getMessage', _ =>
+					svc.getMessage(_.params.messageId).pipe(Effect.orDie),
+				)
+				.handle('listInboxes', _ =>
+					svc.listLocalInboxes({
+						...(_.query.purpose !== undefined && {
+							purpose: _.query.purpose,
+						}),
+						...(_.query.active !== undefined && {
+							active: _.query.active === 'true',
+						}),
+						...(_.query.ownerUserId !== undefined && {
+							ownerUserId: _.query.ownerUserId,
+						}),
+					}),
+				)
+				.handle('createInbox', _ =>
+					svc
+						.createInbox({
+							...(_.payload.username !== undefined && {
+								username: _.payload.username,
+							}),
+							...(_.payload.domain !== undefined && {
+								domain: _.payload.domain,
+							}),
+							...(_.payload.displayName !== undefined && {
+								displayName: _.payload.displayName,
+							}),
+							purpose: _.payload.purpose,
+							...(_.payload.ownerUserId !== undefined && {
+								ownerUserId: _.payload.ownerUserId,
+							}),
+							...(_.payload.isDefault !== undefined && {
+								isDefault: _.payload.isDefault,
+							}),
 						})
 						.pipe(
-							Effect.catchTag('BadRequest', err =>
-								Effect.succeed(
-									HttpServerResponse.jsonUnsafe(
-										{ _tag: 'BadRequest', message: err.message },
-										{ status: 400 },
-									),
-								),
+							Effect.catchTag('EmailError', e => Effect.die(e)),
+							Effect.catchTag('SqlError', e => Effect.die(e)),
+						),
+				)
+				.handle('updateInbox', _ =>
+					svc
+						.updateInbox(_.params.id, {
+							...(_.payload.displayName !== undefined && {
+								displayName: _.payload.displayName,
+							}),
+							...(_.payload.purpose !== undefined && {
+								purpose: _.payload.purpose,
+							}),
+							...(_.payload.ownerUserId !== undefined && {
+								ownerUserId: _.payload.ownerUserId,
+							}),
+							...(_.payload.isDefault !== undefined && {
+								isDefault: _.payload.isDefault,
+							}),
+							...(_.payload.active !== undefined && {
+								active: _.payload.active,
+							}),
+						})
+						.pipe(
+							Effect.catchTag('NotFound', e => Effect.die(e)),
+							Effect.catchTag('SqlError', e => Effect.die(e)),
+						),
+				)
+				.handle('syncInboxes', () => svc.syncInboxes())
+				// ── Drafts ──
+				.handle('createDraft', _ =>
+					svc
+						.createDraft(
+							_.payload.inboxId,
+							{
+								...(_.payload.to !== undefined && {
+									to:
+										typeof _.payload.to === 'string'
+											? _.payload.to
+											: [..._.payload.to],
+								}),
+								...(_.payload.cc !== undefined && { cc: [..._.payload.cc] }),
+								...(_.payload.bcc !== undefined && { bcc: [..._.payload.bcc] }),
+								...(_.payload.subject !== undefined && {
+									subject: _.payload.subject,
+								}),
+								...(_.payload.text !== undefined && { text: _.payload.text }),
+								...(_.payload.html !== undefined && { html: _.payload.html }),
+								...(_.payload.inReplyTo !== undefined && {
+									inReplyTo: _.payload.inReplyTo,
+								}),
+							},
+							{
+								...(_.payload.companyId !== undefined && {
+									companyId: _.payload.companyId,
+								}),
+								...(_.payload.contactId !== undefined && {
+									contactId: _.payload.contactId,
+								}),
+								...(_.payload.mode !== undefined && { mode: _.payload.mode }),
+								...(_.payload.threadLinkId !== undefined && {
+									threadLinkId: _.payload.threadLinkId,
+								}),
+							},
+						)
+						.pipe(Effect.orDie),
+				)
+				.handle('listDrafts', _ =>
+					svc.listDrafts(_.query.inboxId).pipe(Effect.orDie),
+				)
+				.handle('getDraft', _ =>
+					svc.getDraft(_.query.inboxId, _.params.draftId).pipe(Effect.orDie),
+				)
+				.handle('updateDraft', _ =>
+					svc
+						.updateDraft(_.payload.inboxId, _.params.draftId, {
+							...(_.payload.to !== undefined && {
+								to:
+									typeof _.payload.to === 'string'
+										? _.payload.to
+										: [..._.payload.to],
+							}),
+							...(_.payload.cc !== undefined && { cc: [..._.payload.cc] }),
+							...(_.payload.bcc !== undefined && { bcc: [..._.payload.bcc] }),
+							...(_.payload.subject !== undefined && {
+								subject: _.payload.subject,
+							}),
+							...(_.payload.text !== undefined && { text: _.payload.text }),
+							...(_.payload.html !== undefined && { html: _.payload.html }),
+						})
+						.pipe(Effect.orDie),
+				)
+				.handle('deleteDraft', _ =>
+					svc.deleteDraft(_.query.inboxId, _.params.draftId).pipe(Effect.orDie),
+				)
+				.handle('sendDraft', _ =>
+					svc.sendDraft(_.payload.inboxId, _.params.draftId).pipe(
+						Effect.catchTag('EmailError', e =>
+							Effect.fail(new BadRequest({ message: e.message })),
+						),
+						Effect.catchTag('EmailSendError', e => Effect.die(e)),
+						Effect.catchTag('SqlError', e => Effect.die(e)),
+					),
+				)
+				// ── Footers ──
+				.handle('listFooters', _ =>
+					svc.listFooters(_.params.inboxId).pipe(Effect.orDie),
+				)
+				.handle('createFooter', _ =>
+					svc
+						.createFooter({
+							inboxId: _.params.inboxId,
+							name: _.payload.name,
+							html: _.payload.html,
+							...(_.payload.textFallback !== undefined && {
+								textFallback: _.payload.textFallback,
+							}),
+							...(_.payload.isDefault !== undefined && {
+								isDefault: _.payload.isDefault,
+							}),
+						})
+						.pipe(Effect.orDie),
+				)
+				.handle('getFooter', _ =>
+					svc.getFooter(_.params.id).pipe(
+						Effect.catchTag('NotFound', e => Effect.fail(e)),
+						Effect.catchTag('SqlError', e => Effect.die(e)),
+					),
+				)
+				.handle('updateFooter', _ =>
+					svc
+						.updateFooter(_.params.id, {
+							...(_.payload.name !== undefined && { name: _.payload.name }),
+							...(_.payload.html !== undefined && { html: _.payload.html }),
+							...(_.payload.textFallback !== undefined && {
+								textFallback: _.payload.textFallback,
+							}),
+							...(_.payload.isDefault !== undefined && {
+								isDefault: _.payload.isDefault,
+							}),
+						})
+						.pipe(
+							Effect.catchTag('NotFound', e => Effect.fail(e)),
+							Effect.catchTag('SqlError', e => Effect.die(e)),
+						),
+				)
+				.handle('deleteFooter', _ => svc.deleteFooter(_.params.id))
+				.handleRaw(
+					'stageAttachment',
+					Effect.fnUntraced(function* ({ request }) {
+						let bytes: Uint8Array | undefined
+						let filename: string | undefined
+						let contentType: string | undefined
+
+						yield* request.multipartStream.pipe(
+							Stream.runForEach(part =>
+								Effect.gen(function* () {
+									if (Multipart.isFile(part) && part.key === 'file') {
+										bytes = yield* part.contentEffect
+										filename = part.name ?? 'attachment'
+										contentType = part.contentType
+									}
+								}),
 							),
+							Effect.orDie,
 						)
 
-					if (
-						typeof result === 'object' &&
-						result !== null &&
-						'stagingId' in result
-					) {
-						return HttpServerResponse.jsonUnsafe(result)
-					}
-					return result
-				}),
-			)
-			.handleRaw(
-				'downloadAttachment',
-				Effect.fnUntraced(function* ({ params }) {
-					const piped = yield* svc
-						.streamAttachment(params.messageId, params.attachmentId)
-						.pipe(
-							Effect.catchTag('NotFound', err =>
-								Effect.succeed(
-									HttpServerResponse.jsonUnsafe(
-										{ _tag: 'NotFound', entity: err.entity, id: err.id },
-										{ status: 404 },
+						if (!bytes || !contentType) {
+							return HttpServerResponse.jsonUnsafe(
+								{
+									_tag: 'BadRequest',
+									message: 'Missing file part in multipart upload',
+								},
+								{ status: 400 },
+							)
+						}
+
+						const result = yield* staging
+							.stage({
+								bytes,
+								filename: filename ?? 'attachment',
+								contentType,
+							})
+							.pipe(
+								Effect.catchTag('BadRequest', err =>
+									Effect.succeed(
+										HttpServerResponse.jsonUnsafe(
+											{ _tag: 'BadRequest', message: err.message },
+											{ status: 400 },
+										),
 									),
 								),
-							),
-							Effect.catchTag('EmailError', err =>
-								Effect.succeed(
-									HttpServerResponse.jsonUnsafe(
-										{ _tag: 'EmailError', message: err.message },
-										{ status: 502 },
+							)
+
+						if (
+							typeof result === 'object' &&
+							result !== null &&
+							'stagingId' in result
+						) {
+							return HttpServerResponse.jsonUnsafe(result)
+						}
+						return result
+					}),
+				)
+				.handleRaw(
+					'downloadAttachment',
+					Effect.fnUntraced(function* ({ params }) {
+						const piped = yield* svc
+							.streamAttachment(params.messageId, params.attachmentId)
+							.pipe(
+								Effect.catchTag('NotFound', err =>
+									Effect.succeed(
+										HttpServerResponse.jsonUnsafe(
+											{ _tag: 'NotFound', entity: err.entity, id: err.id },
+											{ status: 404 },
+										),
 									),
 								),
-							),
-							Effect.catchTag('SqlError', e => Effect.die(e)),
-						)
-					// If `piped` is already an HTTP response (one of the catch arms)
-					// hand it back unchanged. Otherwise wrap the provider stream.
-					if (HttpServerResponse.isHttpServerResponse(piped)) {
-						return piped
-					}
-					const disposition = piped.filename
-						? `attachment; filename="${piped.filename.replace(/"/g, '')}"`
-						: 'attachment'
-					const body = Stream.fromReadableStream({
-						evaluate: () => piped.stream,
-						onError: e =>
-							new Error(
-								`attachment stream: ${e instanceof Error ? e.message : String(e)}`,
-							),
-					})
-					return HttpServerResponse.stream(body, {
-						contentType: piped.contentType,
-						...(piped.size !== undefined && { contentLength: piped.size }),
-						headers: { 'content-disposition': disposition },
-					})
-				}),
-			)
+								Effect.catchTag('EmailError', err =>
+									Effect.succeed(
+										HttpServerResponse.jsonUnsafe(
+											{ _tag: 'EmailError', message: err.message },
+											{ status: 502 },
+										),
+									),
+								),
+								Effect.catchTag('SqlError', e => Effect.die(e)),
+							)
+						// If `piped` is already an HTTP response (one of the catch arms)
+						// hand it back unchanged. Otherwise wrap the provider stream.
+						if (HttpServerResponse.isHttpServerResponse(piped)) {
+							return piped
+						}
+						const disposition = piped.filename
+							? `attachment; filename="${piped.filename.replace(/"/g, '')}"`
+							: 'attachment'
+						const body = Stream.fromReadableStream({
+							evaluate: () => piped.stream,
+							onError: e =>
+								new Error(
+									`attachment stream: ${e instanceof Error ? e.message : String(e)}`,
+								),
+						})
+						return HttpServerResponse.stream(body, {
+							contentType: piped.contentType,
+							...(piped.size !== undefined && { contentLength: piped.size }),
+							headers: { 'content-disposition': disposition },
+						})
+					}),
+				)
+		)
 	}),
 )

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -57,7 +57,7 @@ const InlineAttachment = Schema.Struct({
 
 const SendEmail = Tool.make('send_email', {
 	description:
-		'Send a new email from a specific inbox. Accepts a single recipient or array for To/Cc/Bcc. Attachments are inline base64 (filename + content_type + content_base64 + optional content_id for cid-referenced inline images). Creates a thread link and logs an outbound interaction. Returns {_tag:"sent"} on success or {_tag:"suppressed"} if a recipient is suppressed.',
+		'Send a new email from a specific inbox. Accepts a single recipient or array for To/Cc/Bcc. Attachments are inline base64 (filename + content_type + content_base64 + optional content_id for cid-referenced inline images). Creates a thread link and logs an outbound interaction. Returns {_tag:"sent"} on success or {_tag:"suppressed"} if a recipient is suppressed. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		inbox_id: Schema.String,
 		to: Recipients,
@@ -70,6 +70,7 @@ const SendEmail = Tool.make('send_email', {
 		company_id: Schema.String,
 		contact_id: Schema.optional(Schema.String),
 		attachments: Schema.optional(Schema.Array(InlineAttachment)),
+		skip_footer: Schema.optional(Schema.Boolean),
 	}),
 	success: SendEmailResult,
 })
@@ -79,7 +80,7 @@ const SendEmail = Tool.make('send_email', {
 
 const ReplyEmail = Tool.make('reply_email', {
 	description:
-		'Reply to the latest message in an existing email thread. Optional Cc/Bcc extend the thread. Attachments are inline base64 (filename + content_type + content_base64). Returns {_tag:"sent"} on success or {_tag:"suppressed"} if the recipient is suppressed.',
+		'Reply to the latest message in an existing email thread. Optional Cc/Bcc extend the thread. Attachments are inline base64 (filename + content_type + content_base64). Returns {_tag:"sent"} on success or {_tag:"suppressed"} if the recipient is suppressed. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		thread_id: Schema.String,
 		text: Schema.optional(Schema.String),
@@ -87,6 +88,7 @@ const ReplyEmail = Tool.make('reply_email', {
 		cc: Schema.optional(Schema.Array(Schema.String)),
 		bcc: Schema.optional(Schema.Array(Schema.String)),
 		attachments: Schema.optional(Schema.Array(InlineAttachment)),
+		skip_footer: Schema.optional(Schema.Boolean),
 	}),
 	success: SendEmailResult,
 })
@@ -259,6 +261,135 @@ const SyncEmailInboxes = Tool.make('sync_email_inboxes', {
 	.annotate(Tool.Destructive, false)
 	.annotate(Tool.OpenWorld, true)
 
+// ── Draft tools ─────────────────────────────────────────────────
+
+const CreateEmailDraft = Tool.make('create_email_draft', {
+	description:
+		'Create a draft email that a human can review in Forja before sending. The draft is stored on the provider (AgentMail) and shows up in the compose dock. Optionally set company_id/contact_id/mode to link to CRM context.',
+	parameters: Schema.Struct({
+		inbox_id: Schema.String,
+		to: Schema.optional(Recipients),
+		cc: Schema.optional(Schema.Array(Schema.String)),
+		bcc: Schema.optional(Schema.Array(Schema.String)),
+		subject: Schema.optional(Schema.String),
+		text: Schema.optional(Schema.String),
+		html: Schema.optional(Schema.String),
+		in_reply_to: Schema.optional(Schema.String),
+		company_id: Schema.optional(Schema.String),
+		contact_id: Schema.optional(Schema.String),
+		mode: Schema.optional(Schema.String),
+		thread_link_id: Schema.optional(Schema.String),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Create Email Draft')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+const UpdateEmailDraft = Tool.make('update_email_draft', {
+	description:
+		'Update fields on an existing draft. Pass only the fields you want to change.',
+	parameters: Schema.Struct({
+		inbox_id: Schema.String,
+		draft_id: Schema.String,
+		to: Schema.optional(Recipients),
+		cc: Schema.optional(Schema.Array(Schema.String)),
+		bcc: Schema.optional(Schema.Array(Schema.String)),
+		subject: Schema.optional(Schema.String),
+		text: Schema.optional(Schema.String),
+		html: Schema.optional(Schema.String),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Update Email Draft')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+const SendEmailDraft = Tool.make('send_email_draft', {
+	description:
+		'Send a previously created draft. This triggers the same thread-link/interaction/message recording pipeline as a direct send. Returns {_tag:"sent"} or {_tag:"suppressed"}.',
+	parameters: Schema.Struct({
+		inbox_id: Schema.String,
+		draft_id: Schema.String,
+	}),
+	success: SendEmailResult,
+})
+	.annotate(Tool.Title, 'Send Email Draft')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, true)
+
+const ListEmailDrafts = Tool.make('list_email_drafts', {
+	description:
+		'List drafts for a specific inbox. Returns draft metadata (no body). If inbox_id is omitted, lists across all active inboxes.',
+	parameters: Schema.Struct({
+		inbox_id: Schema.optional(Schema.String),
+	}),
+	success: Schema.Array(Schema.Unknown),
+})
+	.annotate(Tool.Title, 'List Email Drafts')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+// ── Footer tools ────────────────────────────────────────────────
+
+const ListInboxFooters = Tool.make('list_inbox_footers', {
+	description:
+		'List all footers configured for an inbox. The default footer is automatically appended to outbound emails unless skipFooter is set.',
+	parameters: Schema.Struct({
+		inbox_id: Schema.String,
+	}),
+	success: Schema.Array(Schema.Unknown),
+})
+	.annotate(Tool.Title, 'List Inbox Footers')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+const CreateInboxFooter = Tool.make('create_inbox_footer', {
+	description:
+		'Create an HTML footer for an inbox. If is_default is true, this becomes the footer automatically appended to outbound emails. Only one default per inbox is allowed.',
+	parameters: Schema.Struct({
+		inbox_id: Schema.String,
+		name: Schema.String,
+		html: Schema.String,
+		text_fallback: Schema.optional(Schema.String),
+		is_default: Schema.optional(Schema.Boolean),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Create Inbox Footer')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+const UpdateInboxFooter = Tool.make('update_inbox_footer', {
+	description:
+		'Update an existing inbox footer. Flipping is_default=true atomically clears the previous default for the same inbox.',
+	parameters: Schema.Struct({
+		id: Schema.String,
+		name: Schema.optional(Schema.String),
+		html: Schema.optional(Schema.String),
+		text_fallback: Schema.optional(Schema.String),
+		is_default: Schema.optional(Schema.Boolean),
+	}),
+	success: Schema.Unknown,
+})
+	.annotate(Tool.Title, 'Update Inbox Footer')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+const DeleteInboxFooter = Tool.make('delete_inbox_footer', {
+	description:
+		'Permanently delete an inbox footer. If the deleted footer was the default, no footer will be appended to future outbound emails until another is set as default.',
+	parameters: Schema.Struct({
+		id: Schema.String,
+	}),
+	success: Schema.Void,
+})
+	.annotate(Tool.Title, 'Delete Inbox Footer')
+	.annotate(Tool.Destructive, true)
+	.annotate(Tool.OpenWorld, false)
+
 export const EmailTools = Toolkit.make(
 	SendEmail,
 	ReplyEmail,
@@ -272,6 +403,14 @@ export const EmailTools = Toolkit.make(
 	CreateEmailInbox,
 	UpdateEmailInbox,
 	SyncEmailInboxes,
+	CreateEmailDraft,
+	UpdateEmailDraft,
+	SendEmailDraft,
+	ListEmailDrafts,
+	ListInboxFooters,
+	CreateInboxFooter,
+	UpdateInboxFooter,
+	DeleteInboxFooter,
 )
 
 export const EmailHandlersLive = EmailTools.toLayer(
@@ -298,6 +437,9 @@ export const EmailHandlersLive = EmailTools.toLayer(
 								replyTo: params.reply_to,
 							}),
 							...(attachments.length > 0 && { attachments }),
+							...(params.skip_footer !== undefined && {
+								skipFooter: params.skip_footer,
+							}),
 						},
 					)
 					.pipe(
@@ -330,6 +472,9 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							...(params.cc !== undefined && { cc: [...params.cc] }),
 							...(params.bcc !== undefined && { bcc: [...params.bcc] }),
 							...(attachments.length > 0 && { attachments }),
+							...(params.skip_footer !== undefined && {
+								skipFooter: params.skip_footer,
+							}),
 						},
 					)
 					.pipe(
@@ -453,6 +598,105 @@ export const EmailHandlersLive = EmailTools.toLayer(
 						Effect.orDie,
 					),
 			sync_email_inboxes: () => svc.syncInboxes(),
+			create_email_draft: params =>
+				svc
+					.createDraft(
+						params.inbox_id,
+						{
+							...(params.to !== undefined && {
+								to: typeof params.to === 'string' ? params.to : [...params.to],
+							}),
+							...(params.cc !== undefined && { cc: [...params.cc] }),
+							...(params.bcc !== undefined && { bcc: [...params.bcc] }),
+							...(params.subject !== undefined && {
+								subject: params.subject,
+							}),
+							...(params.text !== undefined && { text: params.text }),
+							...(params.html !== undefined && { html: params.html }),
+							...(params.in_reply_to !== undefined && {
+								inReplyTo: params.in_reply_to,
+							}),
+						},
+						{
+							...(params.company_id !== undefined && {
+								companyId: params.company_id,
+							}),
+							...(params.contact_id !== undefined && {
+								contactId: params.contact_id,
+							}),
+							...(params.mode !== undefined && { mode: params.mode }),
+							...(params.thread_link_id !== undefined && {
+								threadLinkId: params.thread_link_id,
+							}),
+						},
+					)
+					.pipe(Effect.orDie),
+			update_email_draft: params =>
+				svc
+					.updateDraft(params.inbox_id, params.draft_id, {
+						...(params.to !== undefined && {
+							to: typeof params.to === 'string' ? params.to : [...params.to],
+						}),
+						...(params.cc !== undefined && { cc: [...params.cc] }),
+						...(params.bcc !== undefined && { bcc: [...params.bcc] }),
+						...(params.subject !== undefined && {
+							subject: params.subject,
+						}),
+						...(params.text !== undefined && { text: params.text }),
+						...(params.html !== undefined && { html: params.html }),
+					})
+					.pipe(Effect.orDie),
+			send_email_draft: params =>
+				svc.sendDraft(params.inbox_id, params.draft_id).pipe(
+					Effect.map(r => ({
+						_tag: 'sent' as const,
+						messageId: r.messageId,
+						threadId: r.threadId,
+					})),
+					Effect.catchTag('EmailSuppressed', e =>
+						Effect.succeed({
+							_tag: 'suppressed' as const,
+							contactStatus: e.status,
+							recipient: e.recipient,
+							reason: e.reason,
+						}),
+					),
+					Effect.orDie,
+				),
+			list_email_drafts: params =>
+				svc.listDrafts(params.inbox_id).pipe(Effect.orDie),
+			list_inbox_footers: params => svc.listFooters(params.inbox_id),
+			create_inbox_footer: params =>
+				svc
+					.createFooter({
+						inboxId: params.inbox_id,
+						name: params.name,
+						html: params.html,
+						...(params.text_fallback !== undefined && {
+							textFallback: params.text_fallback,
+						}),
+						...(params.is_default !== undefined && {
+							isDefault: params.is_default,
+						}),
+					})
+					.pipe(Effect.orDie),
+			update_inbox_footer: params =>
+				svc
+					.updateFooter(params.id, {
+						...(params.name !== undefined && { name: params.name }),
+						...(params.html !== undefined && { html: params.html }),
+						...(params.text_fallback !== undefined && {
+							textFallback: params.text_fallback,
+						}),
+						...(params.is_default !== undefined && {
+							isDefault: params.is_default,
+						}),
+					})
+					.pipe(
+						Effect.catchTag('NotFound', e => Effect.die(e)),
+						Effect.orDie,
+					),
+			delete_inbox_footer: params => svc.deleteFooter(params.id),
 		}
 	}),
 )

--- a/apps/server/src/services/agentmail-provider.ts
+++ b/apps/server/src/services/agentmail-provider.ts
@@ -29,12 +29,15 @@ const firstRecipient = (to: string | string[]): string =>
 	Array.isArray(to) ? (to[0] ?? '') : to
 
 import {
+	type CreateDraftParams,
 	type CreateInboxParams,
 	EmailProvider,
 	type ListParams,
 	type MagicLinkParams,
 	type ProviderAttachmentMeta,
 	type ProviderAttachmentStream,
+	type ProviderDraft,
+	type ProviderDraftItem,
 	type ProviderInbox,
 	type ProviderMessage,
 	type ProviderMessageItem,
@@ -44,6 +47,7 @@ import {
 	type SendAttachmentInput,
 	type SendParams,
 	type SendResult,
+	type UpdateDraftParams,
 } from './email-provider.js'
 
 /** Strip keys whose value is `undefined` so exactOptionalPropertyTypes is satisfied. */
@@ -161,6 +165,72 @@ const mapInbox = (i: {
 	email: i.email,
 	displayName: i.displayName,
 	createdAt: i.createdAt,
+})
+
+const mapDraftItem = (d: {
+	inboxId: string
+	draftId: string
+	to?: string[]
+	cc?: string[]
+	bcc?: string[]
+	subject?: string
+	preview?: string
+	attachments?: {
+		attachmentId: string
+		filename?: string
+		size: number
+		contentType?: string
+		contentId?: string
+	}[]
+	inReplyTo?: string
+	sendStatus?: 'scheduled' | 'sending' | 'failed'
+	sendAt?: Date
+	updatedAt: Date
+	clientId?: string
+}): ProviderDraftItem => ({
+	draftId: d.draftId,
+	inboxId: d.inboxId,
+	clientId: d.clientId,
+	to: d.to,
+	cc: d.cc,
+	bcc: d.bcc,
+	subject: d.subject,
+	preview: d.preview,
+	attachments: d.attachments?.map(mapAttachment),
+	inReplyTo: d.inReplyTo,
+	sendStatus: d.sendStatus,
+	sendAt: d.sendAt,
+	updatedAt: d.updatedAt,
+})
+
+const mapDraft = (d: {
+	inboxId: string
+	draftId: string
+	to?: string[]
+	cc?: string[]
+	bcc?: string[]
+	subject?: string
+	preview?: string
+	text?: string
+	html?: string
+	attachments?: {
+		attachmentId: string
+		filename?: string
+		size: number
+		contentType?: string
+		contentId?: string
+	}[]
+	inReplyTo?: string
+	sendStatus?: 'scheduled' | 'sending' | 'failed'
+	sendAt?: Date
+	updatedAt: Date
+	createdAt: Date
+	clientId?: string
+}): ProviderDraft => ({
+	...mapDraftItem(d),
+	text: d.text,
+	html: d.html,
+	createdAt: d.createdAt,
 })
 
 export const AgentMailProviderLive = Layer.effect(
@@ -438,6 +508,119 @@ export const AgentMailProviderLive = Layer.effect(
 				})
 			})
 
+		const createDraft = (
+			inboxId: string,
+			params: CreateDraftParams,
+		): Effect.Effect<ProviderDraft, EmailError> =>
+			Effect.tryPromise({
+				try: () =>
+					client.inboxes.drafts.create(
+						inboxId,
+						compact({
+							to: params.to,
+							cc: params.cc,
+							bcc: params.bcc,
+							subject: params.subject,
+							text: params.text,
+							html: params.html,
+							attachments: params.attachments?.map(toAgentMailAttachment),
+							inReplyTo: params.inReplyTo,
+							clientId: params.clientId,
+						}),
+					),
+				catch: e =>
+					new EmailError({
+						message: e instanceof Error ? e.message : String(e),
+					}),
+			}).pipe(Effect.map(mapDraft))
+
+		const updateDraft = (
+			inboxId: string,
+			draftId: string,
+			params: UpdateDraftParams,
+		): Effect.Effect<ProviderDraft, EmailError> =>
+			Effect.tryPromise({
+				try: () =>
+					client.inboxes.drafts.update(
+						inboxId,
+						draftId,
+						compact({
+							to: params.to,
+							cc: params.cc,
+							bcc: params.bcc,
+							subject: params.subject,
+							text: params.text,
+							html: params.html,
+							sendAt: params.sendAt,
+						}),
+					),
+				catch: e =>
+					new EmailError({
+						message: e instanceof Error ? e.message : String(e),
+					}),
+			}).pipe(Effect.map(mapDraft))
+
+		const deleteDraft = (
+			inboxId: string,
+			draftId: string,
+		): Effect.Effect<void, EmailError> =>
+			Effect.tryPromise({
+				try: () => client.inboxes.drafts.delete(inboxId, draftId),
+				catch: e =>
+					new EmailError({
+						message: e instanceof Error ? e.message : String(e),
+					}),
+			}).pipe(Effect.asVoid)
+
+		const sendDraft = (
+			inboxId: string,
+			draftId: string,
+		): Effect.Effect<SendResult, EmailSendError> =>
+			Effect.tryPromise({
+				try: () => client.inboxes.drafts.send(inboxId, draftId, {}),
+				catch: e => {
+					const message = e instanceof Error ? e.message : String(e)
+					return new EmailSendError({
+						message,
+						kind: classifyAgentMailError(message),
+						recipient: null,
+					})
+				},
+			}).pipe(
+				Effect.map(r => ({ messageId: r.messageId, threadId: r.threadId })),
+			)
+
+		const listDrafts = (
+			inboxId: string,
+			params?: ListParams,
+		): Effect.Effect<ProviderDraftItem[], EmailError> =>
+			Effect.tryPromise({
+				try: () =>
+					client.inboxes.drafts.list(
+						inboxId,
+						compact({
+							limit: params?.limit,
+							pageToken: params?.pageToken,
+						}),
+					),
+				catch: e =>
+					new EmailError({
+						message: e instanceof Error ? e.message : String(e),
+					}),
+			}).pipe(Effect.map(r => r.drafts.map(mapDraftItem)))
+
+		const getDraft = (
+			inboxId: string,
+			draftId: string,
+		): Effect.Effect<ProviderDraft, EmailError> =>
+			Effect.tryPromise({
+				try: () => client.inboxes.drafts.get(inboxId, draftId),
+				catch: e =>
+					new EmailError({
+						message: e instanceof Error ? e.message : String(e),
+					}),
+			}).pipe(Effect.map(mapDraft))
+
 		return {
 			send,
 			reply,
@@ -450,6 +633,12 @@ export const AgentMailProviderLive = Layer.effect(
 			streamAttachment,
 			updateLabels,
 			sendMagicLink,
+			createDraft,
+			updateDraft,
+			deleteDraft,
+			sendDraft,
+			listDrafts,
+			getDraft,
 		} as const
 	}),
 )

--- a/apps/server/src/services/email-provider.ts
+++ b/apps/server/src/services/email-provider.ts
@@ -119,6 +119,52 @@ export interface MagicLinkParams {
 	readonly token: string
 }
 
+// ── Draft interfaces ──
+
+export interface CreateDraftParams {
+	readonly to?: string | string[] | undefined
+	readonly cc?: string | string[] | undefined
+	readonly bcc?: string | string[] | undefined
+	readonly subject?: string | undefined
+	readonly text?: string | undefined
+	readonly html?: string | undefined
+	readonly attachments?: readonly SendAttachmentInput[] | undefined
+	readonly inReplyTo?: string | undefined
+	readonly clientId?: string | undefined
+}
+
+export interface UpdateDraftParams {
+	readonly to?: string | string[] | undefined
+	readonly cc?: string | string[] | undefined
+	readonly bcc?: string | string[] | undefined
+	readonly subject?: string | undefined
+	readonly text?: string | undefined
+	readonly html?: string | undefined
+	readonly sendAt?: Date | undefined
+}
+
+export interface ProviderDraftItem {
+	readonly draftId: string
+	readonly inboxId: string
+	readonly clientId?: string | undefined
+	readonly to?: string[] | undefined
+	readonly cc?: string[] | undefined
+	readonly bcc?: string[] | undefined
+	readonly subject?: string | undefined
+	readonly preview?: string | undefined
+	readonly attachments?: readonly ProviderAttachmentMeta[] | undefined
+	readonly inReplyTo?: string | undefined
+	readonly sendStatus?: 'scheduled' | 'sending' | 'failed' | undefined
+	readonly sendAt?: Date | undefined
+	readonly updatedAt: Date
+}
+
+export interface ProviderDraft extends ProviderDraftItem {
+	readonly text?: string | undefined
+	readonly html?: string | undefined
+	readonly createdAt: Date
+}
+
 // ── Abstract provider tag ──
 
 export class EmailProvider extends ServiceMap.Service<
@@ -167,5 +213,30 @@ export class EmailProvider extends ServiceMap.Service<
 		readonly sendMagicLink: (
 			params: MagicLinkParams,
 		) => Effect.Effect<void, EmailSendError>
+		readonly createDraft: (
+			inboxId: string,
+			params: CreateDraftParams,
+		) => Effect.Effect<ProviderDraft, EmailError>
+		readonly updateDraft: (
+			inboxId: string,
+			draftId: string,
+			params: UpdateDraftParams,
+		) => Effect.Effect<ProviderDraft, EmailError>
+		readonly deleteDraft: (
+			inboxId: string,
+			draftId: string,
+		) => Effect.Effect<void, EmailError>
+		readonly sendDraft: (
+			inboxId: string,
+			draftId: string,
+		) => Effect.Effect<SendResult, EmailSendError>
+		readonly listDrafts: (
+			inboxId: string,
+			params?: ListParams,
+		) => Effect.Effect<ProviderDraftItem[], EmailError>
+		readonly getDraft: (
+			inboxId: string,
+			draftId: string,
+		) => Effect.Effect<ProviderDraft, EmailError>
 	}
 >()('EmailProvider') {}

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -5,7 +5,11 @@ import { SqlClient } from 'effect/unstable/sql'
 import { EmailError, EmailSuppressed, NotFound } from '@engranatge/controllers'
 import type { InboundClassification } from '@engranatge/domain'
 
-import type { SendAttachmentInput } from './email-provider.js'
+import type {
+	CreateDraftParams,
+	SendAttachmentInput,
+	UpdateDraftParams,
+} from './email-provider.js'
 import { EmailProvider } from './email-provider.js'
 import { WebhookService } from './webhooks.js'
 
@@ -19,6 +23,77 @@ type ContactSuppressionRow = {
 
 const firstRecipient = (to: string | string[]): string =>
 	Array.isArray(to) ? (to[0] ?? '') : to
+
+const encodeClientId = (ctx: {
+	companyId?: string
+	contactId?: string
+	mode?: string
+	threadLinkId?: string
+}): string => {
+	const parts = ['forja:draft']
+	if (ctx.companyId) parts.push(`companyId=${ctx.companyId}`)
+	if (ctx.contactId) parts.push(`contactId=${ctx.contactId}`)
+	if (ctx.mode) parts.push(`mode=${ctx.mode}`)
+	if (ctx.threadLinkId) parts.push(`threadLinkId=${ctx.threadLinkId}`)
+	return parts.join(';')
+}
+
+const parseClientId = (
+	clientId: string | undefined,
+): {
+	companyId: string | null
+	contactId: string | null
+	mode: string | null
+	threadLinkId: string | null
+} => {
+	const empty: {
+		companyId: string | null
+		contactId: string | null
+		mode: string | null
+		threadLinkId: string | null
+	} = {
+		companyId: null,
+		contactId: null,
+		mode: null,
+		threadLinkId: null,
+	}
+	if (!clientId?.startsWith('forja:draft')) return empty
+	const result = { ...empty }
+	for (const part of clientId.split(';')) {
+		const eq = part.indexOf('=')
+		if (eq === -1) continue
+		const key = part.slice(0, eq)
+		const val = part.slice(eq + 1)
+		if (key === 'companyId') result.companyId = val
+		else if (key === 'contactId') result.contactId = val
+		else if (key === 'mode') result.mode = val
+		else if (key === 'threadLinkId') result.threadLinkId = val
+	}
+	return result
+}
+
+const injectFooter = (
+	body: { text?: string; html?: string },
+	footer: { html: string; textFallback: string },
+): { text?: string; html?: string } => {
+	let html = body.html
+	if (html !== undefined) {
+		const closingBody = html.lastIndexOf('</body>')
+		if (closingBody !== -1) {
+			html = `${html.slice(0, closingBody)}<div>${footer.html}</div>${html.slice(closingBody)}`
+		} else {
+			html = `${html}<div>${footer.html}</div>`
+		}
+	}
+	let text = body.text
+	if (text !== undefined && footer.textFallback) {
+		text = `${text}\n\n${footer.textFallback}`
+	}
+	return {
+		...(text !== undefined && { text }),
+		...(html !== undefined && { html }),
+	}
+}
 
 export class EmailService extends ServiceMap.Service<EmailService>()(
 	'EmailService',
@@ -57,6 +132,106 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 					}
 				})
 
+			const resolveInbox = (inboxId: string) =>
+				sql<{ id: string; providerInboxId: string }>`
+					SELECT id, provider_inbox_id FROM inboxes
+					WHERE id = ${inboxId} LIMIT 1
+				`.pipe(
+					Effect.map(rows => rows[0] ?? null),
+					Effect.orDie,
+				)
+
+			const resolveLocalInboxId = (providerInboxId: string) =>
+				sql<{ id: string }>`
+					SELECT id FROM inboxes
+					WHERE provider_inbox_id = ${providerInboxId} LIMIT 1
+				`.pipe(
+					Effect.map(rows => rows[0]?.id ?? null),
+					Effect.orDie,
+				)
+
+			type FooterRow = { html: string; textFallback: string }
+			const resolveDefaultFooter = (localInboxId: string) =>
+				sql<FooterRow>`
+					SELECT html, text_fallback FROM inbox_footers
+					WHERE inbox_id = ${localInboxId} AND is_default = true
+					LIMIT 1
+				`.pipe(
+					Effect.map(rows => rows[0] ?? null),
+					Effect.orDie,
+				)
+
+			const recordOutbound = (args: {
+				result: { messageId: string; threadId: string }
+				providerInboxId: string
+				localInboxId: string | null
+				companyId: string | null
+				contactId: string | null
+				subject: string | null
+				to: string[]
+				cc: string[]
+				bcc: string[]
+				isNewThread: boolean
+			}) =>
+				Effect.gen(function* () {
+					if (args.isNewThread) {
+						yield* sql`
+							INSERT INTO email_thread_links ${sql.insert({
+								provider: providerName,
+								providerThreadId: args.result.threadId,
+								providerInboxId: args.providerInboxId,
+								inboxId: args.localInboxId,
+								companyId: args.companyId,
+								contactId: args.contactId,
+								subject: args.subject,
+								status: 'open',
+							})}
+						`
+					}
+
+					if (args.companyId) {
+						yield* sql`
+							INSERT INTO interactions ${sql.insert({
+								companyId: args.companyId,
+								contactId: args.contactId,
+								date: new Date(),
+								channel: 'email',
+								direction: 'outbound',
+								type: 'email',
+								subject: args.subject,
+								metadata: JSON.stringify({
+									providerThreadId: args.result.threadId,
+									providerMessageId: args.result.messageId,
+								}),
+							})}
+						`
+						yield* sql`
+							UPDATE companies
+							SET last_contacted_at = now(), updated_at = now()
+							WHERE id = ${args.companyId}
+						`
+					}
+
+					yield* sql`
+						INSERT INTO email_messages ${sql.insert({
+							provider: providerName,
+							providerMessageId: args.result.messageId,
+							providerThreadId: args.result.threadId,
+							providerInboxId: args.providerInboxId,
+							direction: 'outbound',
+							companyId: args.companyId,
+							contactId: args.contactId,
+							recipients: JSON.stringify({
+								to: args.to,
+								cc: args.cc,
+								bcc: args.bcc,
+							}),
+							status: 'sent',
+							statusUpdatedAt: new Date(),
+						})}
+					`
+				})
+
 			return {
 				send: (
 					inboxId: string,
@@ -70,6 +245,7 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						bcc?: string[] | undefined
 						replyTo?: string | undefined
 						attachments?: readonly SendAttachmentInput[] | undefined
+						skipFooter?: boolean | undefined
 					},
 				) =>
 					Effect.gen(function* () {
@@ -77,18 +253,26 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						const bcc = extras?.bcc ?? []
 						const attachments = extras?.attachments ?? []
 
+						const inbox = yield* resolveInbox(inboxId)
+						const providerInboxId = inbox?.providerInboxId ?? inboxId
+						const localInboxId = inbox?.id ?? null
+
 						if (contactId) {
 							yield* assertContactNotSuppressed(contactId, to)
 						}
 
-						// Self-heal the suppression cache if the provider rejects for a
-						// recipient we had not yet marked as bounced locally.
+						let finalBody = body
+						if (!extras?.skipFooter && localInboxId) {
+							const footer = yield* resolveDefaultFooter(localInboxId)
+							if (footer) finalBody = injectFooter(body, footer)
+						}
+
 						const result = yield* provider
-							.send(inboxId, {
+							.send(providerInboxId, {
 								to,
 								subject,
-								...(body.text !== undefined && { text: body.text }),
-								...(body.html !== undefined && { html: body.html }),
+								...(finalBody.text !== undefined && { text: finalBody.text }),
+								...(finalBody.html !== undefined && { html: finalBody.html }),
 								...(cc.length > 0 && { cc }),
 								...(bcc.length > 0 && { bcc }),
 								...(extras?.replyTo !== undefined && {
@@ -121,58 +305,18 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 								),
 							)
 
-						yield* sql`
-							INSERT INTO email_thread_links ${sql.insert({
-								provider: providerName,
-								providerThreadId: result.threadId,
-								providerInboxId: inboxId,
-								companyId,
-								contactId: contactId ?? null,
-								subject,
-								status: 'open',
-							})}
-						`
-
-						yield* sql`
-							INSERT INTO interactions ${sql.insert({
-								companyId,
-								contactId: contactId ?? null,
-								date: new Date(),
-								channel: 'email',
-								direction: 'outbound',
-								type: 'email',
-								subject,
-								metadata: JSON.stringify({
-									providerThreadId: result.threadId,
-									providerMessageId: result.messageId,
-								}),
-							})}
-						`
-
-						yield* sql`
-							UPDATE companies
-							SET last_contacted_at = now(), updated_at = now()
-							WHERE id = ${companyId}
-						`
-
-						yield* sql`
-							INSERT INTO email_messages ${sql.insert({
-								provider: providerName,
-								providerMessageId: result.messageId,
-								providerThreadId: result.threadId,
-								providerInboxId: inboxId,
-								direction: 'outbound',
-								companyId,
-								contactId: contactId ?? null,
-								recipients: JSON.stringify({
-									to: Array.isArray(to) ? to : [to],
-									cc,
-									bcc,
-								}),
-								status: 'sent',
-								statusUpdatedAt: new Date(),
-							})}
-						`
+						yield* recordOutbound({
+							result,
+							providerInboxId,
+							localInboxId,
+							companyId,
+							contactId: contactId ?? null,
+							subject,
+							to: Array.isArray(to) ? to : [to],
+							cc,
+							bcc,
+							isNewThread: true,
+						})
 
 						yield* Effect.logInfo('Email sent').pipe(
 							Effect.annotateLogs({
@@ -192,6 +336,7 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						cc?: string[] | undefined
 						bcc?: string[] | undefined
 						attachments?: readonly SendAttachmentInput[] | undefined
+						skipFooter?: boolean | undefined
 					},
 				) =>
 					Effect.gen(function* () {
@@ -211,6 +356,7 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						}
 						const link = links[0] as {
 							providerInboxId: string
+							inboxId: string | null
 							companyId: string | null
 							contactId: string | null
 						}
@@ -226,8 +372,6 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 							})
 						}
 
-						// When the last message is inbound, reply to its sender; when it's
-						// outbound, keep the original recipients.
 						const replyRecipients = lastMessage.from
 							? [lastMessage.from]
 							: lastMessage.to
@@ -236,10 +380,19 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 							yield* assertContactNotSuppressed(link.contactId, replyRecipients)
 						}
 
+						const localInboxId =
+							link.inboxId ?? (yield* resolveLocalInboxId(link.providerInboxId))
+
+						let finalBody = body
+						if (!extras?.skipFooter && localInboxId) {
+							const footer = yield* resolveDefaultFooter(localInboxId)
+							if (footer) finalBody = injectFooter(body, footer)
+						}
+
 						const result = yield* provider
 							.reply(link.providerInboxId, lastMessage.messageId, {
-								...(body.text !== undefined && { text: body.text }),
-								...(body.html !== undefined && { html: body.html }),
+								...(finalBody.text !== undefined && { text: finalBody.text }),
+								...(finalBody.html !== undefined && { html: finalBody.html }),
 								...(cc.length > 0 && { cc }),
 								...(bcc.length > 0 && { bcc }),
 								...(attachments.length > 0 && { attachments }),
@@ -270,48 +423,18 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 								),
 							)
 
-						if (link.companyId) {
-							yield* sql`
-								INSERT INTO interactions ${sql.insert({
-									companyId: link.companyId,
-									contactId: link.contactId,
-									date: new Date(),
-									channel: 'email',
-									direction: 'outbound',
-									type: 'email',
-									subject: thread.subject ?? null,
-									metadata: JSON.stringify({
-										providerThreadId,
-										providerMessageId: result.messageId,
-									}),
-								})}
-							`
-
-							yield* sql`
-								UPDATE companies
-								SET last_contacted_at = now(), updated_at = now()
-								WHERE id = ${link.companyId}
-							`
-						}
-
-						yield* sql`
-							INSERT INTO email_messages ${sql.insert({
-								provider: providerName,
-								providerMessageId: result.messageId,
-								providerThreadId,
-								providerInboxId: link.providerInboxId,
-								direction: 'outbound',
-								companyId: link.companyId,
-								contactId: link.contactId,
-								recipients: JSON.stringify({
-									to: replyRecipients,
-									cc,
-									bcc,
-								}),
-								status: 'sent',
-								statusUpdatedAt: new Date(),
-							})}
-						`
+						yield* recordOutbound({
+							result,
+							providerInboxId: link.providerInboxId,
+							localInboxId,
+							companyId: link.companyId,
+							contactId: link.contactId,
+							subject: thread.subject ?? null,
+							to: replyRecipients,
+							cc,
+							bcc,
+							isNewThread: false,
+						})
 
 						yield* Effect.logInfo('Email reply sent').pipe(
 							Effect.annotateLogs({
@@ -379,11 +502,16 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 								companyId = contact.companyId
 							}
 
+							const localInboxId = yield* resolveLocalInboxId(
+								payload.providerInboxId,
+							)
+
 							yield* sql`
 								INSERT INTO email_thread_links ${sql.insert({
 									provider: payload.provider,
 									providerThreadId: payload.providerThreadId,
 									providerInboxId: payload.providerInboxId,
+									inboxId: localInboxId,
 									companyId,
 									contactId,
 									subject: payload.subject ?? null,
@@ -1184,6 +1312,243 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						)
 						return { added, retired, total: upstream.length }
 					}).pipe(Effect.orDie),
+
+				// ── Drafts ──────────────────────────────────────────────────
+
+				createDraft: (
+					inboxId: string,
+					params: CreateDraftParams,
+					context?: {
+						companyId?: string
+						contactId?: string
+						mode?: string
+						threadLinkId?: string
+					},
+				) =>
+					Effect.gen(function* () {
+						const inbox = yield* resolveInbox(inboxId)
+						const providerInboxId = inbox?.providerInboxId ?? inboxId
+						const clientId = context ? encodeClientId(context) : undefined
+						return yield* provider.createDraft(providerInboxId, {
+							...params,
+							...(clientId !== undefined && { clientId }),
+						})
+					}),
+
+				updateDraft: (
+					inboxId: string,
+					draftId: string,
+					params: UpdateDraftParams,
+				) =>
+					Effect.gen(function* () {
+						const inbox = yield* resolveInbox(inboxId)
+						const providerInboxId = inbox?.providerInboxId ?? inboxId
+						return yield* provider.updateDraft(providerInboxId, draftId, params)
+					}),
+
+				deleteDraft: (inboxId: string, draftId: string) =>
+					Effect.gen(function* () {
+						const inbox = yield* resolveInbox(inboxId)
+						const providerInboxId = inbox?.providerInboxId ?? inboxId
+						yield* provider.deleteDraft(providerInboxId, draftId)
+					}),
+
+				getDraft: (inboxId: string, draftId: string) =>
+					Effect.gen(function* () {
+						const inbox = yield* resolveInbox(inboxId)
+						const providerInboxId = inbox?.providerInboxId ?? inboxId
+						return yield* provider.getDraft(providerInboxId, draftId)
+					}),
+
+				listDrafts: (inboxId?: string) =>
+					Effect.gen(function* () {
+						if (inboxId) {
+							const inbox = yield* resolveInbox(inboxId)
+							const providerInboxId = inbox?.providerInboxId ?? inboxId
+							return yield* provider.listDrafts(providerInboxId)
+						}
+						const inboxes = yield* sql<{
+							providerInboxId: string
+						}>`
+							SELECT provider_inbox_id FROM inboxes
+							WHERE active = true
+						`
+						const results = yield* Effect.all(
+							inboxes.map(i =>
+								provider
+									.listDrafts(i.providerInboxId)
+									.pipe(
+										Effect.catch(() =>
+											Effect.succeed(
+												[] as import('./email-provider.js').ProviderDraftItem[],
+											),
+										),
+									),
+							),
+						)
+						return results
+							.flat()
+							.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+					}).pipe(Effect.orDie),
+
+				sendDraft: (inboxId: string, draftId: string) =>
+					Effect.gen(function* () {
+						const inbox = yield* resolveInbox(inboxId)
+						const providerInboxId = inbox?.providerInboxId ?? inboxId
+						const localInboxId = inbox?.id ?? null
+
+						const draft = yield* provider.getDraft(providerInboxId, draftId)
+
+						const ctx = parseClientId(draft.clientId)
+
+						if (ctx.contactId) {
+							yield* assertContactNotSuppressed(ctx.contactId, draft.to ?? [])
+						}
+
+						const result = yield* provider.sendDraft(providerInboxId, draftId)
+
+						yield* recordOutbound({
+							result,
+							providerInboxId,
+							localInboxId,
+							companyId: ctx.companyId,
+							contactId: ctx.contactId,
+							subject: draft.subject ?? null,
+							to: draft.to ?? [],
+							cc: draft.cc ?? [],
+							bcc: draft.bcc ?? [],
+							isNewThread: ctx.mode !== 'reply',
+						})
+
+						yield* Effect.logInfo('Draft sent').pipe(
+							Effect.annotateLogs({
+								event: 'email.draft_sent',
+								draftId,
+								threadId: result.threadId,
+							}),
+						)
+
+						return result
+					}),
+
+				// ── Footers ─────────────────────────────────────────────────
+
+				listFooters: (inboxId: string) =>
+					sql`
+						SELECT * FROM inbox_footers
+						WHERE inbox_id = ${inboxId}
+						ORDER BY is_default DESC, name
+					`.pipe(Effect.orDie),
+
+				getFooter: (id: string) =>
+					Effect.gen(function* () {
+						const rows = yield* sql`
+							SELECT * FROM inbox_footers
+							WHERE id = ${id} LIMIT 1
+						`
+						if (rows.length === 0) {
+							return yield* new NotFound({
+								entity: 'InboxFooter',
+								id,
+							})
+						}
+						return rows[0]!
+					}),
+
+				createFooter: (input: {
+					inboxId: string
+					name: string
+					html: string
+					textFallback?: string
+					isDefault?: boolean
+				}) =>
+					Effect.gen(function* () {
+						if (input.isDefault) {
+							yield* sql`
+								UPDATE inbox_footers
+								SET is_default = false, updated_at = now()
+								WHERE inbox_id = ${input.inboxId} AND is_default = true
+							`
+						}
+						const rows = yield* sql`
+							INSERT INTO inbox_footers ${sql.insert({
+								inboxId: input.inboxId,
+								name: input.name,
+								html: input.html,
+								textFallback: input.textFallback ?? '',
+								isDefault: input.isDefault ?? false,
+							})}
+							RETURNING *
+						`
+						return rows[0]!
+					}),
+
+				updateFooter: (
+					id: string,
+					patch: {
+						name?: string
+						html?: string
+						textFallback?: string
+						isDefault?: boolean
+					},
+				) =>
+					Effect.gen(function* () {
+						if (patch.isDefault === true) {
+							const existing = yield* sql<{ inboxId: string }>`
+								SELECT inbox_id FROM inbox_footers
+								WHERE id = ${id} LIMIT 1
+							`
+							if (existing[0]) {
+								yield* sql`
+									UPDATE inbox_footers
+									SET is_default = false, updated_at = now()
+									WHERE inbox_id = ${existing[0].inboxId}
+									  AND is_default = true AND id <> ${id}
+								`
+							}
+						}
+						const sets: Array<Statement.Fragment> = []
+						if (patch.name !== undefined) sets.push(sql`name = ${patch.name}`)
+						if (patch.html !== undefined) sets.push(sql`html = ${patch.html}`)
+						if (patch.textFallback !== undefined)
+							sets.push(sql`text_fallback = ${patch.textFallback}`)
+						if (patch.isDefault !== undefined)
+							sets.push(sql`is_default = ${patch.isDefault}`)
+						if (sets.length === 0) {
+							return yield* Effect.gen(function* () {
+								const r = yield* sql`
+									SELECT * FROM inbox_footers WHERE id = ${id} LIMIT 1
+								`
+								if (r.length === 0) {
+									return yield* new NotFound({
+										entity: 'InboxFooter',
+										id,
+									})
+								}
+								return r[0]!
+							})
+						}
+						sets.push(sql`updated_at = now()`)
+						const rows = yield* sql`
+							UPDATE inbox_footers
+							SET ${sql.csv(sets)}
+							WHERE id = ${id}
+							RETURNING *
+						`
+						if (rows.length === 0) {
+							return yield* new NotFound({
+								entity: 'InboxFooter',
+								id,
+							})
+						}
+						return rows[0]!
+					}),
+
+				deleteFooter: (id: string) =>
+					sql`DELETE FROM inbox_footers WHERE id = ${id}`.pipe(
+						Effect.asVoid,
+						Effect.orDie,
+					),
 			}
 		}),
 	},

--- a/apps/server/src/services/local-inbox-provider.ts
+++ b/apps/server/src/services/local-inbox-provider.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises'
+import {
+	mkdir,
+	readdir,
+	readFile,
+	stat,
+	unlink,
+	writeFile,
+} from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { Readable } from 'node:stream'
 
@@ -9,12 +16,15 @@ import { Effect, Layer } from 'effect'
 import { EmailError, EmailSendError } from '@engranatge/controllers'
 
 import {
+	type CreateDraftParams,
 	type CreateInboxParams,
 	EmailProvider,
 	type ListParams,
 	type MagicLinkParams,
 	type ProviderAttachmentMeta,
 	type ProviderAttachmentStream,
+	type ProviderDraft,
+	type ProviderDraftItem,
 	type ProviderInbox,
 	type ProviderMessage,
 	type ProviderMessageItem,
@@ -24,6 +34,7 @@ import {
 	type SendAttachmentInput,
 	type SendParams,
 	type SendResult,
+	type UpdateDraftParams,
 } from './email-provider.js'
 
 // ── Synthetic dev inbox identity ──
@@ -42,6 +53,7 @@ const DEV_INBOX_CREATED_AT = new Date('2024-01-01T00:00:00Z')
 // started from (root, apps/server, ...). Using process.cwd() doubled the path
 // when running via `pnpm --filter @engranatge/server dev`.
 const INBOX_DIR = resolve(import.meta.dirname, '..', '..', '.dev-inbox')
+const DRAFTS_DIR = resolve(INBOX_DIR, 'drafts')
 const ATTACHMENTS_DIR = resolve(INBOX_DIR, 'attachments')
 
 // ── Filename + slug helpers ──
@@ -727,6 +739,261 @@ export const LocalInboxProviderLive = Layer.effect(
 				yield* writeRecord(rec, sentAt)
 			})
 
+		// ── Drafts ──
+
+		const ensureDraftsDir = Effect.tryPromise({
+			try: () => mkdir(DRAFTS_DIR, { recursive: true }),
+			catch: e =>
+				new EmailError({
+					message: `local-inbox: cannot create ${DRAFTS_DIR}: ${e instanceof Error ? e.message : String(e)}`,
+				}),
+		})
+
+		const draftFilename = (draftId: string) => `${draftId}.md`
+		const draftPath = (draftId: string) =>
+			resolve(DRAFTS_DIR, draftFilename(draftId))
+
+		const writeDraftFile = (draft: ProviderDraft) =>
+			Effect.gen(function* () {
+				yield* ensureDraftsDir
+				const to = draft.to ?? []
+				const cc = draft.cc ?? []
+				const bcc = draft.bcc ?? []
+				const fm = [
+					`draftId: ${draft.draftId}`,
+					`inboxId: ${draft.inboxId}`,
+					`to: ${formatList(to)}`,
+					`cc: ${formatList(cc)}`,
+					`bcc: ${formatList(bcc)}`,
+					`subject: ${draft.subject ?? ''}`,
+					`text: ${draft.text === undefined ? 'null' : draft.text}`,
+					`html: ${draft.html === undefined ? 'null' : draft.html}`,
+					...(draft.clientId ? [`clientId: ${draft.clientId}`] : []),
+					...(draft.inReplyTo ? [`inReplyTo: ${draft.inReplyTo}`] : []),
+					`updatedAt: ${draft.updatedAt.toISOString()}`,
+					`createdAt: ${draft.createdAt.toISOString()}`,
+				].join('\n')
+				const body = draft.text ?? draft.html ?? ''
+				const content = `---\n${fm}\n---\n\n${body}\n`
+				yield* Effect.tryPromise({
+					try: () => writeFile(draftPath(draft.draftId), content, 'utf8'),
+					catch: e =>
+						new EmailError({
+							message: `local-inbox: cannot write draft: ${e instanceof Error ? e.message : String(e)}`,
+						}),
+				})
+			})
+
+		const readDraftFile = (draftId: string) =>
+			Effect.tryPromise({
+				try: async () => {
+					const raw = await readFile(draftPath(draftId), 'utf8')
+					const match = FRONTMATTER_RE.exec(raw)
+					if (!match) throw new Error('missing frontmatter')
+					const fmText = match[1] ?? ''
+					const body = (match[2] ?? '').trimStart()
+					const fields: Record<string, string | string[]> = {}
+					const lines = fmText.split('\n')
+					let currentList: { key: string; items: string[] } | null = null
+					for (const line of lines) {
+						if (line.startsWith('  - ') && currentList) {
+							currentList.items.push(line.slice(4).trim())
+							continue
+						}
+						if (currentList) {
+							fields[currentList.key] = currentList.items
+							currentList = null
+						}
+						const colon = line.indexOf(':')
+						if (colon === -1) continue
+						const key = line.slice(0, colon).trim()
+						const value = line.slice(colon + 1).trim()
+						if (value === '') {
+							currentList = { key, items: [] }
+						} else if (value === '[]') {
+							fields[key] = []
+						} else {
+							fields[key] = value
+						}
+					}
+					if (currentList) fields[currentList.key] = currentList.items
+					const str = (k: string) => {
+						const v = fields[k]
+						return typeof v === 'string' && v !== 'null' ? v : undefined
+					}
+					const list = (k: string) => {
+						const v = fields[k]
+						return Array.isArray(v) && v.length > 0 ? v : undefined
+					}
+					return {
+						draftId: str('draftId') ?? draftId,
+						inboxId: str('inboxId') ?? DEV_INBOX_ID,
+						clientId: str('clientId'),
+						to: list('to'),
+						cc: list('cc'),
+						bcc: list('bcc'),
+						subject: str('subject'),
+						preview: body.slice(0, 140) || undefined,
+						text: str('text') ?? (body || undefined),
+						html: str('html'),
+						inReplyTo: str('inReplyTo'),
+						updatedAt: new Date(str('updatedAt') ?? Date.now()),
+						createdAt: new Date(str('createdAt') ?? Date.now()),
+					} satisfies ProviderDraft
+				},
+				catch: e =>
+					new EmailError({
+						message: `local-inbox: cannot read draft ${draftId}: ${e instanceof Error ? e.message : String(e)}`,
+					}),
+			})
+
+		const coerceList = (
+			v: string | string[] | undefined,
+		): string[] | undefined => {
+			if (v === undefined) return undefined
+			return Array.isArray(v) ? v : [v]
+		}
+
+		const createDraft = (
+			_inboxId: string,
+			params: CreateDraftParams,
+		): Effect.Effect<ProviderDraft, EmailError> =>
+			Effect.gen(function* () {
+				const now = new Date()
+				const draft: ProviderDraft = {
+					draftId: `draft_local_${randomUUID()}`,
+					inboxId: DEV_INBOX_ID,
+					clientId: params.clientId,
+					to: coerceList(params.to),
+					cc: coerceList(params.cc),
+					bcc: coerceList(params.bcc),
+					subject: params.subject,
+					text: params.text,
+					html: params.html,
+					inReplyTo: params.inReplyTo,
+					updatedAt: now,
+					createdAt: now,
+				}
+				yield* writeDraftFile(draft)
+				yield* Effect.logInfo(`local-inbox: created draft ${draft.draftId}`)
+				return draft
+			})
+
+		const updateDraft = (
+			_inboxId: string,
+			draftId: string,
+			params: UpdateDraftParams,
+		): Effect.Effect<ProviderDraft, EmailError> =>
+			Effect.gen(function* () {
+				const existing = yield* readDraftFile(draftId)
+				const updated: ProviderDraft = {
+					...existing,
+					to: params.to !== undefined ? coerceList(params.to) : existing.to,
+					cc: params.cc !== undefined ? coerceList(params.cc) : existing.cc,
+					bcc: params.bcc !== undefined ? coerceList(params.bcc) : existing.bcc,
+					subject: params.subject ?? existing.subject,
+					text: params.text ?? existing.text,
+					html: params.html ?? existing.html,
+					updatedAt: new Date(),
+				}
+				yield* writeDraftFile(updated)
+				return updated
+			})
+
+		const deleteDraft = (
+			_inboxId: string,
+			draftId: string,
+		): Effect.Effect<void, EmailError> =>
+			Effect.tryPromise({
+				try: () => unlink(draftPath(draftId)),
+				catch: e =>
+					new EmailError({
+						message: `local-inbox: cannot delete draft ${draftId}: ${e instanceof Error ? e.message : String(e)}`,
+					}),
+			}).pipe(Effect.asVoid)
+
+		const sendDraft = (
+			_inboxId: string,
+			draftId: string,
+		): Effect.Effect<SendResult, EmailSendError> =>
+			Effect.gen(function* () {
+				const draft = yield* readDraftFile(draftId).pipe(
+					Effect.mapError(
+						e =>
+							new EmailSendError({
+								message: e.message,
+								kind: 'unknown',
+								recipient: null,
+							}),
+					),
+				)
+				const sentAt = new Date()
+				const messageId = `msg_local_${randomUUID()}`
+				const threadId = `thr_local_${randomUUID()}`
+				const rec: MessageRecord = {
+					sentAt: sentAt.toISOString(),
+					messageId,
+					threadId,
+					from: DEV_INBOX_EMAIL,
+					to: draft.to ?? [],
+					cc: draft.cc ?? [],
+					bcc: draft.bcc ?? [],
+					replyTo: null,
+					subject: draft.subject ?? '(no subject)',
+					text: draft.text ?? null,
+					html: draft.html ?? null,
+					labels: [],
+					bodyText: draft.text ?? draft.html ?? '',
+					attachments: [],
+				}
+				yield* writeRecord(rec, sentAt)
+				yield* Effect.tryPromise({
+					try: () => unlink(draftPath(draftId)),
+					catch: () =>
+						new EmailSendError({
+							message: `local-inbox: cannot delete sent draft ${draftId}`,
+							kind: 'unknown',
+							recipient: null,
+						}),
+				})
+				yield* Effect.logInfo(
+					`local-inbox: sent draft ${draftId} as ${messageId}`,
+				)
+				return { messageId, threadId }
+			})
+
+		const listDrafts = (
+			_inboxId: string,
+			_params?: ListParams,
+		): Effect.Effect<ProviderDraftItem[], EmailError> =>
+			Effect.gen(function* () {
+				yield* ensureDraftsDir
+				const entries = yield* Effect.tryPromise({
+					try: () => readdir(DRAFTS_DIR),
+					catch: e =>
+						new EmailError({
+							message: `local-inbox: cannot read drafts dir: ${e instanceof Error ? e.message : String(e)}`,
+						}),
+				})
+				const mdFiles = entries.filter(n => n.endsWith('.md'))
+				const drafts: ProviderDraftItem[] = []
+				for (const f of mdFiles) {
+					const id = f.replace(/\.md$/, '')
+					const d = yield* readDraftFile(id).pipe(
+						Effect.catch(() => Effect.succeed(null as ProviderDraft | null)),
+					)
+					if (d) drafts.push(d)
+				}
+				return drafts.sort(
+					(a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+				)
+			})
+
+		const getDraft = (
+			_inboxId: string,
+			draftId: string,
+		): Effect.Effect<ProviderDraft, EmailError> => readDraftFile(draftId)
+
 		return {
 			send,
 			reply,
@@ -739,6 +1006,12 @@ export const LocalInboxProviderLive = Layer.effect(
 			streamAttachment,
 			updateLabels,
 			sendMagicLink,
+			createDraft,
+			updateDraft,
+			deleteDraft,
+			sendDraft,
+			listDrafts,
+			getDraft,
 		} as const
 	}),
 )

--- a/packages/controllers/src/routes/email.ts
+++ b/packages/controllers/src/routes/email.ts
@@ -37,6 +37,7 @@ export const EmailGroup = HttpApiGroup.make('email')
 				companyId: Schema.String,
 				contactId: Schema.optional(Schema.String),
 				attachments: Schema.optional(Schema.Array(SendAttachmentRef)),
+				skipFooter: Schema.optional(Schema.Boolean),
 			}),
 			success: Schema.Struct({
 				messageId: Schema.String,
@@ -57,6 +58,7 @@ export const EmailGroup = HttpApiGroup.make('email')
 				cc: Schema.optional(Schema.Array(Schema.String)),
 				bcc: Schema.optional(Schema.Array(Schema.String)),
 				attachments: Schema.optional(Schema.Array(SendAttachmentRef)),
+				skipFooter: Schema.optional(Schema.Boolean),
 			}),
 			success: Schema.Struct({
 				messageId: Schema.String,
@@ -210,6 +212,124 @@ export const EmailGroup = HttpApiGroup.make('email')
 				error: NotFound.pipe(HttpApiSchema.status(404)),
 			},
 		),
+	)
+	// ── Drafts ──
+	.add(
+		HttpApiEndpoint.post('createDraft', '/email/drafts', {
+			payload: Schema.Struct({
+				inboxId: Schema.String,
+				to: Schema.optional(Recipients),
+				cc: Schema.optional(Schema.Array(Schema.String)),
+				bcc: Schema.optional(Schema.Array(Schema.String)),
+				subject: Schema.optional(Schema.String),
+				text: Schema.optional(Schema.String),
+				html: Schema.optional(Schema.String),
+				inReplyTo: Schema.optional(Schema.String),
+				companyId: Schema.optional(Schema.String),
+				contactId: Schema.optional(Schema.String),
+				mode: Schema.optional(Schema.String),
+				threadLinkId: Schema.optional(Schema.String),
+			}),
+			success: Schema.Unknown,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.get('listDrafts', '/email/drafts', {
+			query: {
+				inboxId: Schema.optional(Schema.String),
+			},
+			success: Schema.Array(Schema.Unknown),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.get('getDraft', '/email/drafts/:draftId', {
+			params: { draftId: Schema.String },
+			query: { inboxId: Schema.String },
+			success: Schema.Unknown,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.patch('updateDraft', '/email/drafts/:draftId', {
+			params: { draftId: Schema.String },
+			payload: Schema.Struct({
+				inboxId: Schema.String,
+				to: Schema.optional(Recipients),
+				cc: Schema.optional(Schema.Array(Schema.String)),
+				bcc: Schema.optional(Schema.Array(Schema.String)),
+				subject: Schema.optional(Schema.String),
+				text: Schema.optional(Schema.String),
+				html: Schema.optional(Schema.String),
+			}),
+			success: Schema.Unknown,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.delete('deleteDraft', '/email/drafts/:draftId', {
+			params: { draftId: Schema.String },
+			query: { inboxId: Schema.String },
+			success: Schema.Void,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.post('sendDraft', '/email/drafts/:draftId/send', {
+			params: { draftId: Schema.String },
+			payload: Schema.Struct({
+				inboxId: Schema.String,
+			}),
+			success: Schema.Struct({
+				messageId: Schema.String,
+				threadId: Schema.String,
+			}),
+			error: Schema.Union([
+				EmailSuppressed.pipe(HttpApiSchema.status(409)),
+				BadRequest.pipe(HttpApiSchema.status(400)),
+			]),
+		}),
+	)
+	// ── Footers ──
+	.add(
+		HttpApiEndpoint.get('listFooters', '/email/inboxes/:inboxId/footers', {
+			params: { inboxId: Schema.String },
+			success: Schema.Array(Schema.Unknown),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.post('createFooter', '/email/inboxes/:inboxId/footers', {
+			params: { inboxId: Schema.String },
+			payload: Schema.Struct({
+				name: Schema.String,
+				html: Schema.String,
+				textFallback: Schema.optional(Schema.String),
+				isDefault: Schema.optional(Schema.Boolean),
+			}),
+			success: Schema.Unknown,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.get('getFooter', '/email/footers/:id', {
+			params: { id: Schema.String },
+			success: Schema.Unknown,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.patch('updateFooter', '/email/footers/:id', {
+			params: { id: Schema.String },
+			payload: Schema.Struct({
+				name: Schema.optional(Schema.String),
+				html: Schema.optional(Schema.String),
+				textFallback: Schema.optional(Schema.String),
+				isDefault: Schema.optional(Schema.Boolean),
+			}),
+			success: Schema.Unknown,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.delete('deleteFooter', '/email/footers/:id', {
+			params: { id: Schema.String },
+			success: Schema.Void,
+		}),
 	)
 	.middleware(SessionMiddleware)
 	.prefix('/v1')


### PR DESCRIPTION
## Summary

- **Bug fixes (A1/A2):** `email_thread_links.inbox_id` is now populated on send/webhook, and `send()` resolves local UUID → provider inbox ID before calling the provider.
- **Server-backed drafts (B1–B10):** Drafts are stored on the email provider (AgentMail / local dev) instead of React memory. Full CRUD via REST + MCP tools. Frontend compose context becomes a UI-state coordinator with debounced auto-save. Drafts survive page refresh and can be created by AI via MCP.
- **Inbox footers (C1–C5):** Per-inbox HTML footers with WYSIWYG editor (reuses Tiptap `EmailComposer`). One default footer per inbox auto-injected on send/reply, with `skipFooter` opt-out. Full CRUD via REST + MCP tools.

### Backend
- Extended `EmailProvider` interface with 6 draft methods, implemented in AgentMail and local providers
- Extracted `recordOutbound` helper from duplicated send/reply logic
- Added `resolveInbox` helper (local UUID ↔ provider inbox ID)
- Added `inbox_footers` table with partial unique index for single default
- 6 draft + 5 footer REST routes and handlers
- 4 draft + 4 footer MCP tools

### Frontend
- Rewrote `ComposeEmailContext` as UI-state coordinator (window state + server sync)
- Rewrote `ComposeForm` with local state + debounced server PATCH (300ms)
- Draft recovery on mount via `GET /v1/email/drafts`
- Footer management dialog on inbox settings page with create/edit/delete/set-default

## Test plan

- [ ] Create a draft in Forja → refresh → draft reappears (minimized)
- [ ] Edit draft fields → verify debounced save (saving indicator)
- [ ] Send draft → verify thread link, interaction, and message records
- [ ] Create draft via MCP tool → appears in Forja compose dock
- [ ] Discard draft → verify deletion on server
- [ ] Send email → verify `email_thread_links.inbox_id` is populated
- [ ] Send with AgentMail provider → verify correct provider inbox ID resolution
- [ ] Create two footers, set one as default → send email → footer HTML at bottom
- [ ] Send with `skipFooter: true` → no footer injected
- [ ] Delete default footer → sends work without footer