### PR TITLE
cicd(deploy): server env hygiene before first prod boot

### DIFF
--- a/.env.example.github
+++ b/.env.example.github
@@ -2,142 +2,140 @@
 # GitHub Secrets & Variables — Batuda
 # ============================================================================
 #
-# Reference for what needs to be configured in the GitHub repo dashboard.
-# This file is NOT loaded by any workflow — it exists only as documentation.
+# Reference for what to configure in the GitHub repo dashboard. This file is
+# NOT loaded by any workflow — it's documentation.
 #
-# Locations:
-#   [env-secret]   → Settings > Environments > production > Environment secrets
-#   [env-var]      → Settings > Environments > production > Environment variables
+# Layout: two blocks below for easy copy-paste into the dashboard.
+#   1. SECRETS    → Settings > Environments > production > Environment secrets
+#   2. VARIABLES  → Settings > Environments > production > Environment variables
 #
-# Environment: all deploy workflows use the "production" environment.
-# Create it at: Settings > Environments > New environment > "production"
+# All deploy workflows use the `production` environment. Create it at
+# Settings > Environments > New environment > "production". GITHUB_TOKEN is
+# provided automatically by GitHub Actions — no manual setup.
 #
-# GITHUB_TOKEN is provided automatically by GitHub Actions — no manual setup.
+# Service names (batuda-server, batuda-web, engranatge-marketing) are inlined
+# in the deploy workflows; each workflow probes `kraft cloud service get` and
+# switches between `--service` (rolling update) and `--name -d -p` (first-time
+# create), so no service-name variable is needed.
 #
 # ============================================================================
 
 
-# ── KraftCloud Infrastructure ───────────────────────────────────────────────
-# Used by: deploy_server, deploy_web, deploy_marketing
+# ============================================================================
+# SECRETS — Settings > Environments > production > Environment secrets
+# ============================================================================
 
-# KraftCloud API token for deploying unikernels.
-# Obtain from: https://console.kraft.cloud → API tokens
-KRAFTCLOUD_TOKEN=kc_...                                     # [env-secret]
+# KraftCloud API token. Used by all three deploy workflows.
+# Obtain: https://console.kraft.cloud → API tokens
+KRAFTCLOUD_TOKEN=kc_...
 
-# Service names are inlined in the deploy workflows (batuda-server,
-# batuda-web, engranatge-marketing). Each workflow probes
-# `kraft cloud service get` at runtime and switches between
-# `--service` (rolling update) and `--name -d -p` (first-time create),
-# so no service-name variable is needed.
+# NeonDB pooled connection string.
+# Format: postgres://user:pass@ep-xxx-pooler.aws.neon.tech/batuda?sslmode=require
+DATABASE_URL=postgres://...
 
+# Better Auth session signing key (32-byte hex).
+# Generate: node -e "console.log(crypto.randomBytes(32).toString('hex'))"
+BETTER_AUTH_SECRET=
 
-# ── Server Runtime Env — Secrets ────────────────────────────────────────────
-# Passed to KraftCloud instance via -e flags in deploy_server.yml.
+# AES-256-GCM master key for per-inbox IMAP/SMTP credential encryption (32
+# bytes BASE64, not hex). Boot derives per-inbox subkeys via HKDF; rotating
+# this breaks every encrypted inbox row, so save it in a password manager
+# before pasting into GitHub.
+# Generate: node -e "console.log(crypto.randomBytes(32).toString('base64'))"
+EMAIL_CREDENTIAL_KEY=
 
-# NeonDB connection string (postgres://user:pass@ep-xxx.aws.neon.tech/batuda?sslmode=require)
-DATABASE_URL=postgres://...                                 # [env-secret]
-
-# Random secret for Better Auth session signing (min 32 chars)
-# Generate with: node -e "console.log(crypto.randomBytes(32).toString('hex'))"
-BETTER_AUTH_SECRET=                                         # [env-secret]
-
-# S3-compatible object storage credentials (Cloudflare R2 in production)
-STORAGE_ACCESS_KEY_ID=                                      # [env-secret]
-STORAGE_SECRET_ACCESS_KEY=                                  # [env-secret]
-
-# Per-inbox IMAP/SMTP credential encryption key (AES-256-GCM master, 32 bytes
-# base64). Boot derives per-inbox subkeys via HKDF; rotating this key breaks
-# every encrypted inbox row, so save it in a password manager before pasting
-# into GitHub. Generate:
-#   node -e "console.log(crypto.randomBytes(32).toString('base64'))"
-EMAIL_CREDENTIAL_KEY=                                       # [env-secret]
+# Cloudflare R2 access credentials (S3-compatible).
+STORAGE_ACCESS_KEY_ID=
+STORAGE_SECRET_ACCESS_KEY=
 
 # Resend API key for system transactional email (magic links, invitations).
-# Required when EMAIL_PROVIDER_TRANSACTIONAL=resend (see Variables below).
-EMAIL_API_KEY_TRANSACTIONAL=re_...                          # [env-secret]
+# Required when EMAIL_PROVIDER_TRANSACTIONAL=resend (see Variables).
+EMAIL_API_KEY_TRANSACTIONAL=re_...
 
 # Cal.com integration. CALENDAR_API_KEY is read at boot by the calcom adapter
 # (packages/calendar/src/infrastructure/calcom-live.ts); CALENDAR_WEBHOOK_SECRET
-# is optional but required for the /webhooks/calcom signature check.
-CALENDAR_API_KEY=cal_...                                    # [env-secret]
-CALENDAR_WEBHOOK_SECRET=                                    # [env-secret]
+# is read by the /webhooks/calcom signature check.
+CALENDAR_API_KEY=cal_...
+CALENDAR_WEBHOOK_SECRET=
+
+# Research provider keys. Parallel grammar: one var per capability slot. If a
+# vendor serves multiple capabilities, paste the same value in each var.
+# Slot 1 = unsuffixed; slot N = _2, _3, … (only set when the corresponding
+# _PROVIDER_ list has ≥2 entries).
+RESEARCH_API_KEY_SEARCH=BSA...
+RESEARCH_API_KEY_SCRAPE=fc-...
+RESEARCH_API_KEY_EXTRACT=fc-...
+RESEARCH_API_KEY_DISCOVER=fc-...
+RESEARCH_API_KEY_LLM=...
+# RESEARCH_API_KEY_REGISTRY_ES=    # when registry=librebor adds a paid tier
+# RESEARCH_API_KEY_REPORT_ES=      # when report=einforma
+# RESEARCH_API_KEY_SEARCH_2=       # slot 2 — only if SEARCH list has ≥2 vendors
 
 
-# ── Server Runtime Env — Variables ──────────────────────────────────────────
-# Non-sensitive configuration passed to KraftCloud instance via -e flags.
+# ============================================================================
+# VARIABLES — Settings > Environments > production > Environment variables
+# ============================================================================
 
-BETTER_AUTH_BASE_URL=https://api.batuda.co             # [env-var]
-ALLOWED_ORIGINS=https://batuda.co,https://engranatge.com  # [env-var]
+# Better Auth + CORS
+BETTER_AUTH_BASE_URL=https://api.batuda.co
+ALLOWED_ORIGINS=https://batuda.co,https://engranatge.com
 
-# Cloudflare R2 endpoint and bucket
-STORAGE_ENDPOINT=https://<account>.r2.cloudflarestorage.com # [env-var]
-STORAGE_REGION=auto                                         # [env-var]
-STORAGE_BUCKET=batuda-assets                                # [env-var]
+# Cloudflare R2 endpoint + bucket
+STORAGE_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+STORAGE_REGION=auto
+STORAGE_BUCKET=batuda-assets
 
 # CRM email provider (BYO IMAP/SMTP). Boot fails on unknown values.
-EMAIL_PROVIDER=local-inbox                                  # [env-var]
+EMAIL_PROVIDER=local-inbox
 
 # System transactional email (magic links / invitations). Cloud uses Resend.
-EMAIL_PROVIDER_TRANSACTIONAL=resend                         # [env-var]
-EMAIL_FROM_TRANSACTIONAL=Batuda <noreply@batuda.co>         # [env-var]
+EMAIL_PROVIDER_TRANSACTIONAL=resend
+EMAIL_FROM_TRANSACTIONAL=Batuda <noreply@batuda.co>
 
 # Cal.com booking provider selector. Boot reads this in
-# packages/calendar/src/infrastructure/live.ts; 'calcom' requires CALENDAR_API_KEY.
-CALENDAR_PROVIDER=calcom                                    # [env-var]
+# packages/calendar/src/infrastructure/live.ts; 'calcom' requires
+# CALENDAR_API_KEY in the Secrets block above.
+CALENDAR_PROVIDER=calcom
 
 # Geocoder (Where panel → lat/lng lookups)
-GEOCODER_PROVIDER=nominatim                                 # [env-var]
+GEOCODER_PROVIDER=nominatim
 
-# ── Research Providers ─────────────────────────────────────────────────
-# Role-first, vendor-neutral. Comma-list accepted: first value = primary,
-# rest = fallback order on ProviderError. Registry/report are per-country
-# (ISO-3166-1 alpha-2 suffix). Boot fails on unset / unknown vendors.
-RESEARCH_PROVIDER_SEARCH=brave                              # [env-var]
-RESEARCH_PROVIDER_SCRAPE=firecrawl                          # [env-var]
-RESEARCH_PROVIDER_EXTRACT=firecrawl                         # [env-var]
-RESEARCH_PROVIDER_DISCOVER=firecrawl                        # [env-var]
-RESEARCH_PROVIDER_REGISTRY_ES=librebor                      # [env-var]
-RESEARCH_PROVIDER_REPORT_ES=none                            # [env-var]
-RESEARCH_PROVIDER_LLM=nebius                                # [env-var]
-
-# API keys (parallel grammar). If one vendor serves multiple capabilities,
-# paste the same value in each var. Slot 1 = unsuffixed; slot N = `_2`,
-# `_3`, … — only needed when the corresponding _PROVIDER_ list has ≥2 entries.
-RESEARCH_API_KEY_SEARCH=BSA...                              # [env-secret]
-RESEARCH_API_KEY_SCRAPE=fc-...                              # [env-secret]
-RESEARCH_API_KEY_EXTRACT=fc-...                             # [env-secret]
-RESEARCH_API_KEY_DISCOVER=fc-...                            # [env-secret]
-# RESEARCH_API_KEY_REGISTRY_ES=                             # [env-secret] (when registry=librebor has a paid tier)
-# RESEARCH_API_KEY_REPORT_ES=                               # [env-secret] (when report=einforma)
-RESEARCH_API_KEY_LLM=...                                    # [env-secret]
-# RESEARCH_API_KEY_SEARCH_2=                                # [env-secret] (slot 2 — only if SEARCH list has ≥2 vendors)
+# Research providers. Role-first, vendor-neutral. Comma-list accepted: first
+# value = primary, rest = fallback order on ProviderError. Registry/report
+# are per-country (ISO-3166-1 alpha-2 suffix). Boot fails on unset/unknown.
+RESEARCH_PROVIDER_SEARCH=brave
+RESEARCH_PROVIDER_SCRAPE=firecrawl
+RESEARCH_PROVIDER_EXTRACT=firecrawl
+RESEARCH_PROVIDER_DISCOVER=firecrawl
+RESEARCH_PROVIDER_REGISTRY_ES=librebor
+RESEARCH_PROVIDER_REPORT_ES=none
+RESEARCH_PROVIDER_LLM=nebius
 
 # LLM-specific (only when RESEARCH_PROVIDER_LLM != stub)
-RESEARCH_MODEL_LLM=Qwen/Qwen3-32B                           # [env-var]
-# RESEARCH_BASE_URL_LLM=                                    # [env-var] (only for custom provider)
+RESEARCH_MODEL_LLM=Qwen/Qwen3-32B
+# RESEARCH_BASE_URL_LLM=    # only for custom provider
 
-# ── Research Budgets & Concurrency ─────────────────────────────────────
-RESEARCH_DEFAULT_BUDGET_CENTS=100                           # [env-var]
-RESEARCH_DEFAULT_PAID_BUDGET_CENTS=500                      # [env-var]
-RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS=200                # [env-var]
-RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS=2000                # [env-var]
-RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS=10000               # [env-var]
-RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL=3                      # [env-var]
-RESEARCH_MAX_CONCURRENCY_FANOUT=3                           # [env-var]
-RESEARCH_CONFIRM_THRESHOLD_FANOUT=10                        # [env-var]
+# Research budgets + concurrency
+RESEARCH_DEFAULT_BUDGET_CENTS=100
+RESEARCH_DEFAULT_PAID_BUDGET_CENTS=500
+RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS=200
+RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS=2000
+RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS=10000
+RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL=3
+RESEARCH_MAX_CONCURRENCY_FANOUT=3
+RESEARCH_CONFIRM_THRESHOLD_FANOUT=10
 
-
-# ── Optional knobs (defaults exist in code) ────────────────────────────────
+# ── Optional knobs (defaults exist in code) ─────────────────────────────────
 # Uncomment + set only if the default is wrong for production.
 
-# MIN_LOG_LEVEL=Info                                        # [env-var] (Effect log level; default 'Info')
-# CALENDAR_BASE_URL=https://api.cal.com/v2                  # [env-var] (override for Cal.com staging)
-# PORTLESS_URL=                                             # [env-var] (dev-only tunnel URL surfaced to logs)
-# OTEL_EXPORTER_OTLP_ENDPOINT=                              # [env-var] (OpenTelemetry exporter; off when empty)
-# OTEL_EXPORTER_OTLP_HEADERS=                               # [env-var] (e.g. authorization=Bearer ...)
+# MIN_LOG_LEVEL=Info                          # Effect log level; default 'Info'
+# CALENDAR_BASE_URL=https://api.cal.com/v2    # override for Cal.com staging
+# PORTLESS_URL=                               # dev-only tunnel URL surfaced to logs
+# OTEL_EXPORTER_OTLP_ENDPOINT=                # OpenTelemetry exporter; off when empty
+# OTEL_EXPORTER_OTLP_HEADERS=                 # e.g. authorization=Bearer ...
 
 # mcp-stdio context pinning (apps/server/src/mcp-stdio.ts) — only for the
 # local stdio MCP entrypoint, never set in the production server unikernel.
-# BATUDA_ACTIVE_ORG_ID=                                     # [env-var]
-# BATUDA_ACTIVE_ORG_NAME=                                   # [env-var]
-# BATUDA_ACTIVE_ORG_SLUG=                                   # [env-var]
+# BATUDA_ACTIVE_ORG_ID=
+# BATUDA_ACTIVE_ORG_NAME=
+# BATUDA_ACTIVE_ORG_SLUG=

--- a/.env.example.github
+++ b/.env.example.github
@@ -45,11 +45,22 @@ BETTER_AUTH_SECRET=                                         # [env-secret]
 STORAGE_ACCESS_KEY_ID=                                      # [env-secret]
 STORAGE_SECRET_ACCESS_KEY=                                  # [env-secret]
 
-# AgentMail API key and webhook verification.
-# EMAIL_WEBHOOK_SECRET comes from AgentMail dashboard → webhook settings;
-# format whsec_<base64>. Svix validates at boot — an invalid value crashes the server.
-EMAIL_API_KEY=am_...                                        # [env-secret]
-EMAIL_WEBHOOK_SECRET=whsec_...                              # [env-secret]
+# Per-inbox IMAP/SMTP credential encryption key (AES-256-GCM master, 32 bytes
+# base64). Boot derives per-inbox subkeys via HKDF; rotating this key breaks
+# every encrypted inbox row, so save it in a password manager before pasting
+# into GitHub. Generate:
+#   node -e "console.log(crypto.randomBytes(32).toString('base64'))"
+EMAIL_CREDENTIAL_KEY=                                       # [env-secret]
+
+# Resend API key for system transactional email (magic links, invitations).
+# Required when EMAIL_PROVIDER_TRANSACTIONAL=resend (see Variables below).
+EMAIL_API_KEY_TRANSACTIONAL=re_...                          # [env-secret]
+
+# Cal.com integration. CALENDAR_API_KEY is read at boot by the calcom adapter
+# (packages/calendar/src/infrastructure/calcom-live.ts); CALENDAR_WEBHOOK_SECRET
+# is optional but required for the /webhooks/calcom signature check.
+CALENDAR_API_KEY=cal_...                                    # [env-secret]
+CALENDAR_WEBHOOK_SECRET=                                    # [env-secret]
 
 
 # ── Server Runtime Env — Variables ──────────────────────────────────────────
@@ -69,7 +80,10 @@ EMAIL_PROVIDER=local-inbox                                  # [env-var]
 # System transactional email (magic links / invitations). Cloud uses Resend.
 EMAIL_PROVIDER_TRANSACTIONAL=resend                         # [env-var]
 EMAIL_FROM_TRANSACTIONAL=Batuda <noreply@batuda.co>         # [env-var]
-# EMAIL_API_KEY_TRANSACTIONAL is sensitive — set via secret manager.
+
+# Cal.com booking provider selector. Boot reads this in
+# packages/calendar/src/infrastructure/live.ts; 'calcom' requires CALENDAR_API_KEY.
+CALENDAR_PROVIDER=calcom                                    # [env-var]
 
 # Geocoder (Where panel → lat/lng lookups)
 GEOCODER_PROVIDER=nominatim                                 # [env-var]
@@ -111,3 +125,19 @@ RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS=10000               # [env-var]
 RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL=3                      # [env-var]
 RESEARCH_MAX_CONCURRENCY_FANOUT=3                           # [env-var]
 RESEARCH_CONFIRM_THRESHOLD_FANOUT=10                        # [env-var]
+
+
+# ── Optional knobs (defaults exist in code) ────────────────────────────────
+# Uncomment + set only if the default is wrong for production.
+
+# MIN_LOG_LEVEL=Info                                        # [env-var] (Effect log level; default 'Info')
+# CALENDAR_BASE_URL=https://api.cal.com/v2                  # [env-var] (override for Cal.com staging)
+# PORTLESS_URL=                                             # [env-var] (dev-only tunnel URL surfaced to logs)
+# OTEL_EXPORTER_OTLP_ENDPOINT=                              # [env-var] (OpenTelemetry exporter; off when empty)
+# OTEL_EXPORTER_OTLP_HEADERS=                               # [env-var] (e.g. authorization=Bearer ...)
+
+# mcp-stdio context pinning (apps/server/src/mcp-stdio.ts) — only for the
+# local stdio MCP entrypoint, never set in the production server unikernel.
+# BATUDA_ACTIVE_ORG_ID=                                     # [env-var]
+# BATUDA_ACTIVE_ORG_NAME=                                   # [env-var]
+# BATUDA_ACTIVE_ORG_SLUG=                                   # [env-var]

--- a/.env.example.github
+++ b/.env.example.github
@@ -52,9 +52,18 @@ STORAGE_SECRET_ACCESS_KEY=
 # Required when EMAIL_PROVIDER_TRANSACTIONAL=resend (see Variables).
 EMAIL_API_KEY_TRANSACTIONAL=re_...
 
-# Cal.com integration. CALENDAR_API_KEY is read at boot by the calcom adapter
-# (packages/calendar/src/infrastructure/calcom-live.ts); CALENDAR_WEBHOOK_SECRET
-# is read by the /webhooks/calcom signature check.
+# Cal.com integration. CALENDAR_API_KEY is read at boot by the calcom adapter;
+# CALENDAR_WEBHOOK_SECRET is the HMAC-SHA256 key for X-Cal-Signature-256 header
+# verification in /webhooks/calcom. Configure at cal.com → Settings → Developer
+# → Webhooks:
+#   - Subscriber URL: https://api.batuda.co/webhooks/calcom
+#   - Permission: team owner/admin via dashboard (programmatic path needs
+#     the WEBHOOK_WRITE OAuth scope; personal API keys inherit owner perms)
+#   - Subscribe to ALL triggers (Cal.com default). The server dispatches on
+#     these 6 (apps/server/src/services/calendar.ts:395-411) and 200-acks
+#     every other trigger as a no-op for forward-compat:
+#       BOOKING_CREATED, BOOKING_REQUESTED, BOOKING_RESCHEDULED,
+#       BOOKING_CANCELLED, BOOKING_REJECTED, MEETING_ENDED
 CALENDAR_API_KEY=cal_...
 CALENDAR_WEBHOOK_SECRET=
 
@@ -62,11 +71,21 @@ CALENDAR_WEBHOOK_SECRET=
 # vendor serves multiple capabilities, paste the same value in each var.
 # Slot 1 = unsuffixed; slot N = _2, _3, … (only set when the corresponding
 # _PROVIDER_ list has ≥2 entries).
+
+# Brave Search → api-dashboard.search.brave.com (free tier needs a card on file).
 RESEARCH_API_KEY_SEARCH=BSA...
+
+# Firecrawl → firecrawl.dev. One key powers all three Firecrawl capabilities —
+# paste the same `fc-…` value into SCRAPE / EXTRACT / DISCOVER.
 RESEARCH_API_KEY_SCRAPE=fc-...
 RESEARCH_API_KEY_EXTRACT=fc-...
 RESEARCH_API_KEY_DISCOVER=fc-...
+
+# Nebius AI Studio → studio.nebius.com → Settings → API Keys. RESEARCH_MODEL_LLM
+# must match a Studio model id verbatim (e.g. `Qwen/Qwen3-32B`); mismatch 404s
+# at first inference, not at boot.
 RESEARCH_API_KEY_LLM=...
+
 # RESEARCH_API_KEY_REGISTRY_ES=    # when registry=librebor adds a paid tier
 # RESEARCH_API_KEY_REPORT_ES=      # when report=einforma
 # RESEARCH_API_KEY_SEARCH_2=       # slot 2 — only if SEARCH list has ≥2 vendors

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -122,6 +122,14 @@ jobs:
                 -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
                 -e STORAGE_BUCKET="${{ vars.STORAGE_BUCKET }}" \
                 -e EMAIL_PROVIDER="${{ vars.EMAIL_PROVIDER }}" \
+                -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
+                -e EMAIL_PROVIDER_TRANSACTIONAL="${{ vars.EMAIL_PROVIDER_TRANSACTIONAL }}" \
+                -e EMAIL_API_KEY_TRANSACTIONAL="${{ secrets.EMAIL_API_KEY_TRANSACTIONAL }}" \
+                -e EMAIL_FROM_TRANSACTIONAL="${{ vars.EMAIL_FROM_TRANSACTIONAL }}" \
+                -e CALENDAR_PROVIDER="${{ vars.CALENDAR_PROVIDER }}" \
+                -e CALENDAR_API_KEY="${{ secrets.CALENDAR_API_KEY }}" \
+                -e CALENDAR_WEBHOOK_SECRET="${{ secrets.CALENDAR_WEBHOOK_SECRET }}" \
+                -e GEOCODER_PROVIDER="${{ vars.GEOCODER_PROVIDER }}" \
                 -e RESEARCH_PROVIDER_SEARCH="${{ vars.RESEARCH_PROVIDER_SEARCH }}" \
                 -e RESEARCH_PROVIDER_SCRAPE="${{ vars.RESEARCH_PROVIDER_SCRAPE }}" \
                 -e RESEARCH_PROVIDER_EXTRACT="${{ vars.RESEARCH_PROVIDER_EXTRACT }}" \
@@ -135,6 +143,14 @@ jobs:
                 -e RESEARCH_API_KEY_DISCOVER="${{ secrets.RESEARCH_API_KEY_DISCOVER }}" \
                 -e RESEARCH_API_KEY_LLM="${{ secrets.RESEARCH_API_KEY_LLM }}" \
                 -e RESEARCH_MODEL_LLM="${{ vars.RESEARCH_MODEL_LLM }}" \
+                -e RESEARCH_DEFAULT_BUDGET_CENTS="${{ vars.RESEARCH_DEFAULT_BUDGET_CENTS }}" \
+                -e RESEARCH_DEFAULT_PAID_BUDGET_CENTS="${{ vars.RESEARCH_DEFAULT_PAID_BUDGET_CENTS }}" \
+                -e RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS="${{ vars.RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS }}" \
+                -e RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS="${{ vars.RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS }}" \
+                -e RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS="${{ vars.RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS }}" \
+                -e RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL="${{ vars.RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL }}" \
+                -e RESEARCH_MAX_CONCURRENCY_FANOUT="${{ vars.RESEARCH_MAX_CONCURRENCY_FANOUT }}" \
+                -e RESEARCH_CONFIRM_THRESHOLD_FANOUT="${{ vars.RESEARCH_CONFIRM_THRESHOLD_FANOUT }}" \
                 .
             else
               # First-time: create an explicitly-named service, then attach
@@ -163,6 +179,14 @@ jobs:
                 -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
                 -e STORAGE_BUCKET="${{ vars.STORAGE_BUCKET }}" \
                 -e EMAIL_PROVIDER="${{ vars.EMAIL_PROVIDER }}" \
+                -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
+                -e EMAIL_PROVIDER_TRANSACTIONAL="${{ vars.EMAIL_PROVIDER_TRANSACTIONAL }}" \
+                -e EMAIL_API_KEY_TRANSACTIONAL="${{ secrets.EMAIL_API_KEY_TRANSACTIONAL }}" \
+                -e EMAIL_FROM_TRANSACTIONAL="${{ vars.EMAIL_FROM_TRANSACTIONAL }}" \
+                -e CALENDAR_PROVIDER="${{ vars.CALENDAR_PROVIDER }}" \
+                -e CALENDAR_API_KEY="${{ secrets.CALENDAR_API_KEY }}" \
+                -e CALENDAR_WEBHOOK_SECRET="${{ secrets.CALENDAR_WEBHOOK_SECRET }}" \
+                -e GEOCODER_PROVIDER="${{ vars.GEOCODER_PROVIDER }}" \
                 -e RESEARCH_PROVIDER_SEARCH="${{ vars.RESEARCH_PROVIDER_SEARCH }}" \
                 -e RESEARCH_PROVIDER_SCRAPE="${{ vars.RESEARCH_PROVIDER_SCRAPE }}" \
                 -e RESEARCH_PROVIDER_EXTRACT="${{ vars.RESEARCH_PROVIDER_EXTRACT }}" \
@@ -176,6 +200,14 @@ jobs:
                 -e RESEARCH_API_KEY_DISCOVER="${{ secrets.RESEARCH_API_KEY_DISCOVER }}" \
                 -e RESEARCH_API_KEY_LLM="${{ secrets.RESEARCH_API_KEY_LLM }}" \
                 -e RESEARCH_MODEL_LLM="${{ vars.RESEARCH_MODEL_LLM }}" \
+                -e RESEARCH_DEFAULT_BUDGET_CENTS="${{ vars.RESEARCH_DEFAULT_BUDGET_CENTS }}" \
+                -e RESEARCH_DEFAULT_PAID_BUDGET_CENTS="${{ vars.RESEARCH_DEFAULT_PAID_BUDGET_CENTS }}" \
+                -e RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS="${{ vars.RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS }}" \
+                -e RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS="${{ vars.RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS }}" \
+                -e RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS="${{ vars.RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS }}" \
+                -e RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL="${{ vars.RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL }}" \
+                -e RESEARCH_MAX_CONCURRENCY_FANOUT="${{ vars.RESEARCH_MAX_CONCURRENCY_FANOUT }}" \
+                -e RESEARCH_CONFIRM_THRESHOLD_FANOUT="${{ vars.RESEARCH_CONFIRM_THRESHOLD_FANOUT }}" \
                 .
             fi
 

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -121,8 +121,6 @@ jobs:
                 -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
                 -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
                 -e STORAGE_BUCKET="${{ vars.STORAGE_BUCKET }}" \
-                -e EMAIL_API_KEY="${{ secrets.EMAIL_API_KEY }}" \
-                -e EMAIL_WEBHOOK_SECRET="${{ secrets.EMAIL_WEBHOOK_SECRET }}" \
                 -e EMAIL_PROVIDER="${{ vars.EMAIL_PROVIDER }}" \
                 -e RESEARCH_PROVIDER_SEARCH="${{ vars.RESEARCH_PROVIDER_SEARCH }}" \
                 -e RESEARCH_PROVIDER_SCRAPE="${{ vars.RESEARCH_PROVIDER_SCRAPE }}" \
@@ -164,8 +162,6 @@ jobs:
                 -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
                 -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
                 -e STORAGE_BUCKET="${{ vars.STORAGE_BUCKET }}" \
-                -e EMAIL_API_KEY="${{ secrets.EMAIL_API_KEY }}" \
-                -e EMAIL_WEBHOOK_SECRET="${{ secrets.EMAIL_WEBHOOK_SECRET }}" \
                 -e EMAIL_PROVIDER="${{ vars.EMAIL_PROVIDER }}" \
                 -e RESEARCH_PROVIDER_SEARCH="${{ vars.RESEARCH_PROVIDER_SEARCH }}" \
                 -e RESEARCH_PROVIDER_SCRAPE="${{ vars.RESEARCH_PROVIDER_SCRAPE }}" \

--- a/docs/TODO_DEPLOYMENT.md
+++ b/docs/TODO_DEPLOYMENT.md
@@ -90,22 +90,22 @@ mTLS support — verify with KraftCloud first.
 ## Phase 2 — Server (`apps/server` → `api.batuda.co`)
 
 > **PR shape — Slice 1 (env hygiene), 3 commits in one PR**, must merge **before** the production deploy.
-> Audit found 2 stale vars (`EMAIL_API_KEY`, `EMAIL_WEBHOOK_SECRET`) that the workflow still passes despite zero code readers (AgentMail leftovers), and **5 + 8 vars the code requires with no defaults** that neither the workflow nor `.env.example.github` declares — server boot crashes today on a fresh prod deploy. The PR fixes both.
+> Audit found 2 stale vars (`EMAIL_API_KEY`, `EMAIL_WEBHOOK_SECRET`) that the workflow still passes despite zero code readers (AgentMail leftovers), and **8 + 8 vars the code requires with no defaults** that neither the workflow nor `.env.example.github` declares — server boot crashes today on a fresh prod deploy. The PR fixes both. (Original audit said 5 + 8; the missing var was `CALENDAR_PROVIDER`, the boot selector for `BookingProviderLive` in `packages/calendar/src/infrastructure/live.ts`.)
 
 Commits in PR #1:
 
-- [ ] `ci(server): drop stale AgentMail env vars from deploy workflow`
-  - Strip `-e EMAIL_API_KEY=…` from update + first-create branches
-  - Strip `-e EMAIL_WEBHOOK_SECRET=…` from update + first-create branches
-- [ ] `ci(server): wire transactional-email + calendar + research-budget vars`
-  - Add `-e EMAIL_CREDENTIAL_KEY`, `-e EMAIL_API_KEY_TRANSACTIONAL`, `-e EMAIL_FROM_TRANSACTIONAL`, `-e CALENDAR_API_KEY`, `-e CALENDAR_WEBHOOK_SECRET`, `-e GEOCODER_PROVIDER`, `-e EMAIL_PROVIDER_TRANSACTIONAL` to both branches
-  - Add the 8 `-e RESEARCH_DEFAULT_*` / `RESEARCH_MAX_*` / `RESEARCH_CONFIRM_*` to both branches
-- [ ] `docs: align .env.example.github with code env reads`
-  - Strip `EMAIL_API_KEY` and `EMAIL_WEBHOOK_SECRET` lines (and AgentMail commentary)
-  - Replace `EMAIL_PROVIDER=agentmail` with `EMAIL_PROVIDER=local-inbox`
-  - Add the 5 newly-required entries with comments naming their consumer
-  - Add the 8 research-budget entries (some already present — verify)
-  - Add commented-out optional examples: `MIN_LOG_LEVEL`, `CALENDAR_BASE_URL`, `BATUDA_ACTIVE_ORG_*`, `PORTLESS_URL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`
+- [x] `cicd(deploy): drop stale AgentMail env vars from server deploy`
+  - Stripped `-e EMAIL_API_KEY=…` from update + first-create branches
+  - Stripped `-e EMAIL_WEBHOOK_SECRET=…` from update + first-create branches
+- [x] `cicd(deploy): wire transactional, calendar, and research-budget vars`
+  - Added `-e EMAIL_CREDENTIAL_KEY`, `-e EMAIL_API_KEY_TRANSACTIONAL`, `-e EMAIL_FROM_TRANSACTIONAL`, `-e EMAIL_PROVIDER_TRANSACTIONAL`, `-e CALENDAR_PROVIDER`, `-e CALENDAR_API_KEY`, `-e CALENDAR_WEBHOOK_SECRET`, `-e GEOCODER_PROVIDER` to both branches (8 vars — original audit missed `CALENDAR_PROVIDER`, also required at boot)
+  - Added the 8 `-e RESEARCH_DEFAULT_*` / `RESEARCH_MAX_*` / `RESEARCH_CONFIRM_*` to both branches
+- [x] `docs: align .env.example.github with code env reads`
+  - Stripped `EMAIL_API_KEY` and `EMAIL_WEBHOOK_SECRET` lines (and AgentMail commentary)
+  - `EMAIL_PROVIDER` was already `local-inbox`, no rename needed
+  - Added the 5 newly-required entries with comments naming their consumer (EMAIL_CREDENTIAL_KEY, EMAIL_API_KEY_TRANSACTIONAL, CALENDAR_PROVIDER, CALENDAR_API_KEY, CALENDAR_WEBHOOK_SECRET)
+  - Verified all 8 research-budget entries already present
+  - Added commented-out optional examples: `MIN_LOG_LEVEL`, `CALENDAR_BASE_URL`, `BATUDA_ACTIVE_ORG_*`, `PORTLESS_URL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`
 
 Already applied to `deploy_server.yml` (kraft timing knobs, separate from Slice 1):
 
@@ -150,9 +150,9 @@ Already applied to `deploy_server.yml` (kraft timing knobs, separate from Slice 
   - [ ] Capture key → `RESEARCH_API_KEY_LLM`
   - [ ] Decide model → `RESEARCH_MODEL_LLM` (suggested: `Qwen/Qwen3-32B`)
 
-- [ ] **Self-generate locally** — random hex secrets
-  - [ ] `node -e "console.log(crypto.randomBytes(32).toString('hex'))"` → `BETTER_AUTH_SECRET`
-  - [ ] `node -e "console.log(crypto.randomBytes(32).toString('hex'))"` → `EMAIL_CREDENTIAL_KEY` (HKDF master for inbox credential AES-256-GCM; **rotation breaks every encrypted inbox row** — save in a password manager before pasting to GH)
+- [ ] **Self-generate locally** — random secrets
+  - [ ] `node -e "console.log(crypto.randomBytes(32).toString('hex'))"` → `BETTER_AUTH_SECRET` (hex)
+  - [ ] `node -e "console.log(crypto.randomBytes(32).toString('base64'))"` → `EMAIL_CREDENTIAL_KEY` (**base64**, not hex — `apps/server/src/services/credential-crypto.ts` decodes with `Buffer.from(..., 'base64')` and dies if the result is not exactly 32 bytes; HKDF master for inbox credential AES-256-GCM; **rotation breaks every encrypted inbox row** — save in a password manager before pasting to GH; must match the mail-worker value in Phase 3)
 
 ### Configure GitHub `production` environment
 
@@ -173,7 +173,7 @@ To add:
 
 - [ ] `DATABASE_URL` — pooled NeonDB URL
 - [ ] `BETTER_AUTH_SECRET` — generated hex
-- [ ] `EMAIL_CREDENTIAL_KEY` — generated hex (must match the value mail-worker will use in Phase 3)
+- [ ] `EMAIL_CREDENTIAL_KEY` — generated base64 (must match the value mail-worker will use in Phase 3)
 - [ ] `STORAGE_ACCESS_KEY_ID` — R2
 - [ ] `STORAGE_SECRET_ACCESS_KEY` — R2
 - [ ] `EMAIL_API_KEY_TRANSACTIONAL` — Resend (required because `EMAIL_PROVIDER_TRANSACTIONAL=resend`)
@@ -197,6 +197,7 @@ Quoted values to avoid shell quirks. To set:
 - [ ] `EMAIL_PROVIDER` = `"local-inbox"` (the BYO IMAP/SMTP per-inbox path; only literal accepted by `Schema.Literals` today — naming follow-up tracked separately)
 - [ ] `EMAIL_PROVIDER_TRANSACTIONAL` = `"resend"`
 - [ ] `EMAIL_FROM_TRANSACTIONAL` = `"Batuda <noreply@batuda.co>"`
+- [ ] `CALENDAR_PROVIDER` = `"calcom"` (boot selector in `packages/calendar/src/infrastructure/live.ts`)
 - [ ] `GEOCODER_PROVIDER` = `"nominatim"`
 - [ ] `RESEARCH_PROVIDER_SEARCH` = `"brave"`
 - [ ] `RESEARCH_PROVIDER_SCRAPE` = `"firecrawl"`

--- a/docs/TODO_DEPLOYMENT.md
+++ b/docs/TODO_DEPLOYMENT.md
@@ -171,50 +171,51 @@ Already present:
 
 To add:
 
-- [ ] `DATABASE_URL` — pooled NeonDB URL
-- [ ] `BETTER_AUTH_SECRET` — generated hex
-- [ ] `EMAIL_CREDENTIAL_KEY` — generated base64 (must match the value mail-worker will use in Phase 3)
-- [ ] `STORAGE_ACCESS_KEY_ID` — R2
-- [ ] `STORAGE_SECRET_ACCESS_KEY` — R2
-- [ ] `EMAIL_API_KEY_TRANSACTIONAL` — Resend (required because `EMAIL_PROVIDER_TRANSACTIONAL=resend`)
-- [ ] `CALENDAR_API_KEY` — Cal.com (required when Calendar layer mounts at boot)
-- [ ] `CALENDAR_WEBHOOK_SECRET` — Cal.com webhook
-- [ ] `RESEARCH_API_KEY_SEARCH` — Brave
-- [ ] `RESEARCH_API_KEY_SCRAPE` — Firecrawl
-- [ ] `RESEARCH_API_KEY_EXTRACT` — Firecrawl
-- [ ] `RESEARCH_API_KEY_DISCOVER` — Firecrawl
-- [ ] `RESEARCH_API_KEY_LLM` — Nebius (or chosen LLM)
+- [x] `DATABASE_URL` — pooled NeonDB URL (set via `gh secret set` 2026-05-11)
+- [x] `BETTER_AUTH_SECRET` — generated hex (set via dashboard 2026-05-11)
+- [x] `EMAIL_CREDENTIAL_KEY` — generated base64 (set via dashboard 2026-05-11; must match the value mail-worker will use in Phase 3)
+- [x] `STORAGE_ACCESS_KEY_ID` — R2 Account API token (Object Read & Write, scoped to `batuda-assets`; set 2026-05-12)
+- [x] `STORAGE_SECRET_ACCESS_KEY` — R2 Account API token (set 2026-05-12)
+- [x] `EMAIL_API_KEY_TRANSACTIONAL` — Resend (set via dashboard 2026-05-11)
+- [x] `CALENDAR_API_KEY` — Cal.com (set via dashboard 2026-05-11)
+- [x] `CALENDAR_WEBHOOK_SECRET` — Cal.com webhook HMAC key (set via dashboard 2026-05-11; same value on cal.com webhook config)
+- [x] `RESEARCH_API_KEY_SEARCH` — Brave (set via dashboard 2026-05-11)
+- [x] `RESEARCH_API_KEY_SCRAPE` — Firecrawl (set via dashboard 2026-05-11)
+- [x] `RESEARCH_API_KEY_EXTRACT` — Firecrawl (set via dashboard 2026-05-11)
+- [x] `RESEARCH_API_KEY_DISCOVER` — Firecrawl (set via dashboard 2026-05-11)
+- [x] `RESEARCH_API_KEY_LLM` — Nebius (set via dashboard 2026-05-12)
+- [x] `RESEARCH_API_KEY_REGISTRY_ES` — Librebor (set 2026-05-12; bonus — Librebor adapter is unimplemented today (`packages/research/src/infrastructure/providers-live.ts:160`), workflow does not pass the var yet, key sits unused until the adapter ships)
 
 #### Variables (`gh variable set <NAME> --env production -R guillempuche/batuda --body "<value>"`)
 
-Quoted values to avoid shell quirks. To set:
+Quoted values to avoid shell quirks. All 26 set 2026-05-11/12 (verified via `gh variable list --env production`):
 
-- [ ] `BETTER_AUTH_BASE_URL` = `"https://api.batuda.co"`
-- [ ] `ALLOWED_ORIGINS` = `"https://batuda.co,https://engranatge.com"` (add each tenant's marketing origin)
-- [ ] `STORAGE_ENDPOINT` = `"https://<account>.r2.cloudflarestorage.com"`
-- [ ] `STORAGE_REGION` = `"auto"`
-- [ ] `STORAGE_BUCKET` = `"batuda-assets"`
-- [ ] `EMAIL_PROVIDER` = `"local-inbox"` (the BYO IMAP/SMTP per-inbox path; only literal accepted by `Schema.Literals` today — naming follow-up tracked separately)
-- [ ] `EMAIL_PROVIDER_TRANSACTIONAL` = `"resend"`
-- [ ] `EMAIL_FROM_TRANSACTIONAL` = `"Batuda <noreply@batuda.co>"`
-- [ ] `CALENDAR_PROVIDER` = `"calcom"` (boot selector in `packages/calendar/src/infrastructure/live.ts`)
-- [ ] `GEOCODER_PROVIDER` = `"nominatim"`
-- [ ] `RESEARCH_PROVIDER_SEARCH` = `"brave"`
-- [ ] `RESEARCH_PROVIDER_SCRAPE` = `"firecrawl"`
-- [ ] `RESEARCH_PROVIDER_EXTRACT` = `"firecrawl"`
-- [ ] `RESEARCH_PROVIDER_DISCOVER` = `"firecrawl"`
-- [ ] `RESEARCH_PROVIDER_REGISTRY_ES` = `"librebor"`
-- [ ] `RESEARCH_PROVIDER_REPORT_ES` = `"none"`
-- [ ] `RESEARCH_PROVIDER_LLM` = `"nebius"`
-- [ ] `RESEARCH_MODEL_LLM` = `"Qwen/Qwen3-32B"`
-- [ ] `RESEARCH_DEFAULT_BUDGET_CENTS` = `"100"`
-- [ ] `RESEARCH_DEFAULT_PAID_BUDGET_CENTS` = `"500"`
-- [ ] `RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS` = `"200"`
-- [ ] `RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS` = `"2000"`
-- [ ] `RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS` = `"10000"`
-- [ ] `RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL` = `"3"`
-- [ ] `RESEARCH_MAX_CONCURRENCY_FANOUT` = `"3"`
-- [ ] `RESEARCH_CONFIRM_THRESHOLD_FANOUT` = `"10"`
+- [x] `BETTER_AUTH_BASE_URL` = `"https://api.batuda.co"`
+- [x] `ALLOWED_ORIGINS` = `"https://batuda.co,https://engranatge.com"` (add each tenant's marketing origin)
+- [x] `STORAGE_ENDPOINT` = `"https://<account-id>.eu.r2.cloudflarestorage.com"` (EU jurisdiction bucket → `.eu.` infix is mandatory; account-id is the hex string visible in the R2 bucket's "S3 API" field)
+- [x] `STORAGE_REGION` = `"auto"` (R2 ignores the AWS region; `auto` is the canonical value, `us-east-1`/empty also alias)
+- [x] `STORAGE_BUCKET` = `"batuda-assets"`
+- [x] `EMAIL_PROVIDER` = `"local-inbox"` (the BYO IMAP/SMTP per-inbox path; only literal accepted by `Schema.Literals` today — naming follow-up tracked separately)
+- [x] `EMAIL_PROVIDER_TRANSACTIONAL` = `"resend"`
+- [x] `EMAIL_FROM_TRANSACTIONAL` = `"Batuda <noreply@batuda.co>"`
+- [x] `CALENDAR_PROVIDER` = `"calcom"` (boot selector in `packages/calendar/src/infrastructure/live.ts`)
+- [x] `GEOCODER_PROVIDER` = `"nominatim"`
+- [x] `RESEARCH_PROVIDER_SEARCH` = `"brave"`
+- [x] `RESEARCH_PROVIDER_SCRAPE` = `"firecrawl"`
+- [x] `RESEARCH_PROVIDER_EXTRACT` = `"firecrawl"`
+- [x] `RESEARCH_PROVIDER_DISCOVER` = `"firecrawl"`
+- [x] `RESEARCH_PROVIDER_REGISTRY_ES` = `"librebor"`
+- [x] `RESEARCH_PROVIDER_REPORT_ES` = `"none"`
+- [x] `RESEARCH_PROVIDER_LLM` = `"nebius"`
+- [x] `RESEARCH_MODEL_LLM` = `"Qwen/Qwen3-32B"`
+- [x] `RESEARCH_DEFAULT_BUDGET_CENTS` = `"100"`
+- [x] `RESEARCH_DEFAULT_PAID_BUDGET_CENTS` = `"500"`
+- [x] `RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS` = `"200"`
+- [x] `RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS` = `"2000"`
+- [x] `RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS` = `"10000"`
+- [x] `RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL` = `"3"`
+- [x] `RESEARCH_MAX_CONCURRENCY_FANOUT` = `"3"`
+- [x] `RESEARCH_CONFIRM_THRESHOLD_FANOUT` = `"10"`
 
 ### DNS
 

--- a/docs/TODO_DEPLOYMENT.md
+++ b/docs/TODO_DEPLOYMENT.md
@@ -52,11 +52,11 @@ No runtime secrets needed; the workflow only reads `KRAFTCLOUD_TOKEN`.
 
 ### Deploy
 
-- [ ] Trigger workflow: `gh workflow run deploy_web.yml -R guillempuche/batuda`
-- [ ] Watch run: `gh run watch -R guillempuche/batuda`
-- [ ] Confirm LE cert issued: `kraft cloud --metro fra certificate list | grep batuda.co`
-- [ ] Confirm instance running: `kraft cloud --metro fra instance list | grep batuda-web`
-- [ ] Smoke test via Cloudflare edge: `curl -sI https://batuda.co | head -5`
+- [x] Trigger workflow: `gh workflow run deploy_web.yml -R guillempuche/batuda`
+- [x] Watch run: `gh run watch -R guillempuche/batuda`
+- [x] Confirm LE cert issued: `kraft cloud --metro fra certificate list | grep batuda.co` — `batuda.co-5nna3`, valid
+- [x] Confirm instance running: `kraft cloud --metro fra instance list | grep batuda-web` — `batuda-web-om2b1`, running
+- [x] Smoke test via Cloudflare edge: `curl -sI https://batuda.co | head -5` — HTTP/2 307 → `/login?returnTo=%2F` (Better Auth gating, no 525)
 
 ### Cloudflare SSL/TLS (do AFTER first successful deploy so LE cert exists)
 
@@ -64,7 +64,7 @@ No runtime secrets needed; the workflow only reads `KRAFTCLOUD_TOKEN`.
 - [x] SSL/TLS → Edge Certificates → **Always Use HTTPS** = on — verified `curl -sI http://batuda.co` returns `301 → https://batuda.co/`
 - [x] SSL/TLS → Edge Certificates → **Minimum TLS Version** = 1.2 — set in dashboard
 - [x] SSL/TLS → Edge Certificates → **TLS 1.3** = on — verified `openssl s_client -tls1_3` succeeds with `TLS_AES_256_GCM_SHA384`
-- [ ] Verify via Cloudflare edge: `curl -I https://batuda.co` (expect HTTP/2 200, no 525) — currently returns 404 (no origin deployed)
+- [x] Verify via Cloudflare edge: `curl -I https://batuda.co` (expect no 525) — returns HTTP/2 307 to `/login` (auth-gated, not 200 because every route requires session; goal of "TLS handshake succeeds end-to-end through CF edge" is met)
 - [ ] Verify SSL Labs grade A on `batuda.co` — gated on origin deploy
 
 ### (Deferred) Hardening — restrict origin to Cloudflare-only traffic
@@ -92,17 +92,24 @@ mTLS support — verify with KraftCloud first.
 > **PR shape — Slice 1 (env hygiene), 3 commits in one PR**, must merge **before** the production deploy.
 > Audit found 2 stale vars (`EMAIL_API_KEY`, `EMAIL_WEBHOOK_SECRET`) that the workflow still passes despite zero code readers (AgentMail leftovers), and **5 + 8 vars the code requires with no defaults** that neither the workflow nor `.env.example.github` declares — server boot crashes today on a fresh prod deploy. The PR fixes both.
 
-Commits:
+Commits in PR #1:
 
 - [ ] `ci(server): drop stale AgentMail env vars from deploy workflow`
+  - Strip `-e EMAIL_API_KEY=…` from update + first-create branches
+  - Strip `-e EMAIL_WEBHOOK_SECRET=…` from update + first-create branches
 - [ ] `ci(server): wire transactional-email + calendar + research-budget vars`
+  - Add `-e EMAIL_CREDENTIAL_KEY`, `-e EMAIL_API_KEY_TRANSACTIONAL`, `-e EMAIL_FROM_TRANSACTIONAL`, `-e CALENDAR_API_KEY`, `-e CALENDAR_WEBHOOK_SECRET`, `-e GEOCODER_PROVIDER`, `-e EMAIL_PROVIDER_TRANSACTIONAL` to both branches
+  - Add the 8 `-e RESEARCH_DEFAULT_*` / `RESEARCH_MAX_*` / `RESEARCH_CONFIRM_*` to both branches
 - [ ] `docs: align .env.example.github with code env reads`
+  - Strip `EMAIL_API_KEY` and `EMAIL_WEBHOOK_SECRET` lines (and AgentMail commentary)
+  - Replace `EMAIL_PROVIDER=agentmail` with `EMAIL_PROVIDER=local-inbox`
+  - Add the 5 newly-required entries with comments naming their consumer
+  - Add the 8 research-budget entries (some already present — verify)
+  - Add commented-out optional examples: `MIN_LOG_LEVEL`, `CALENDAR_BASE_URL`, `BATUDA_ACTIVE_ORG_*`, `PORTLESS_URL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`
 
-Already applied to `deploy_server.yml` (separate from Slice 1, no checkbox needed):
+Already applied to `deploy_server.yml` (kraft timing knobs, separate from Slice 1):
 
-- [x] Pin `KRAFT_VERSION: v0.12.10`
-- [x] Set `--timeout 10s` on both update + first-create branches
-- [x] Set `--rollout-wait 5s` on update branch
+- [x] `KRAFT_VERSION: v0.12.10` pinned + `--timeout 10s` on both branches + `--rollout-wait 5s` on update branch
 
 ### Provision external services
 
@@ -153,14 +160,14 @@ Reference: `.env.example.github`. All values land in the `production` environmen
 
 #### Secrets to delete (stale, AgentMail leftovers, zero code readers)
 
-- [ ] `gh secret delete EMAIL_API_KEY        --env production -R guillempuche/batuda`
-- [ ] `gh secret delete EMAIL_WEBHOOK_SECRET --env production -R guillempuche/batuda`
+- [x] `gh secret delete EMAIL_API_KEY` — already absent in `production` env (verified via `gh secret list`)
+- [x] `gh secret delete EMAIL_WEBHOOK_SECRET` — already absent in `production` env
 
 #### Secrets to set (`gh secret set <NAME> --env production -R guillempuche/batuda`)
 
-Already present (verify they exist):
+Already present:
 
-- [ ] `KRAFTCLOUD_TOKEN`
+- [x] `KRAFTCLOUD_TOKEN` — verified via `gh secret list --env production`
 
 To add:
 
@@ -169,8 +176,8 @@ To add:
 - [ ] `EMAIL_CREDENTIAL_KEY` — generated hex (must match the value mail-worker will use in Phase 3)
 - [ ] `STORAGE_ACCESS_KEY_ID` — R2
 - [ ] `STORAGE_SECRET_ACCESS_KEY` — R2
-- [ ] `EMAIL_API_KEY_TRANSACTIONAL` — Resend
-- [ ] `CALENDAR_API_KEY` — Cal.com
+- [ ] `EMAIL_API_KEY_TRANSACTIONAL` — Resend (required because `EMAIL_PROVIDER_TRANSACTIONAL=resend`)
+- [ ] `CALENDAR_API_KEY` — Cal.com (required when Calendar layer mounts at boot)
 - [ ] `CALENDAR_WEBHOOK_SECRET` — Cal.com webhook
 - [ ] `RESEARCH_API_KEY_SEARCH` — Brave
 - [ ] `RESEARCH_API_KEY_SCRAPE` — Firecrawl
@@ -207,32 +214,6 @@ Quoted values to avoid shell quirks. To set:
 - [ ] `RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL` = `"3"`
 - [ ] `RESEARCH_MAX_CONCURRENCY_FANOUT` = `"3"`
 - [ ] `RESEARCH_CONFIRM_THRESHOLD_FANOUT` = `"10"`
-
-### Update `deploy_server.yml` workflow (Slice 1, PR #1)
-
-The `-e` flag block is duplicated across the **update branch** and **first-create branch** of the deploy step. Every change must land in **both** copies.
-
-- [ ] Strip `-e EMAIL_API_KEY=…` from update branch
-- [ ] Strip `-e EMAIL_API_KEY=…` from first-create branch
-- [ ] Strip `-e EMAIL_WEBHOOK_SECRET=…` from update branch
-- [ ] Strip `-e EMAIL_WEBHOOK_SECRET=…` from first-create branch
-- [ ] Add `-e EMAIL_CREDENTIAL_KEY=…` to both branches
-- [ ] Add `-e EMAIL_API_KEY_TRANSACTIONAL=…` to both branches
-- [ ] Add `-e EMAIL_FROM_TRANSACTIONAL=…` to both branches
-- [ ] Add `-e CALENDAR_API_KEY=…` to both branches
-- [ ] Add `-e CALENDAR_WEBHOOK_SECRET=…` to both branches
-- [ ] Add `-e GEOCODER_PROVIDER=…` to both branches
-- [ ] Add `-e EMAIL_PROVIDER_TRANSACTIONAL=…` to both branches
-- [ ] Add the 8 `-e RESEARCH_DEFAULT_*` / `RESEARCH_MAX_*` / `RESEARCH_CONFIRM_*` to both branches
-
-### Update `.env.example.github` (Slice 1, PR #1)
-
-- [ ] Strip `EMAIL_API_KEY` and `EMAIL_WEBHOOK_SECRET` lines
-- [ ] Strip the AgentMail commentary on those lines
-- [ ] Replace `EMAIL_PROVIDER=agentmail` with `EMAIL_PROVIDER=local-inbox`
-- [ ] Add the 5 newly-required entries with comments naming their consumer
-- [ ] Add the 8 research budget entries (some already there — verify)
-- [ ] Add commented-out optional examples: `MIN_LOG_LEVEL`, `CALENDAR_BASE_URL`, `BATUDA_ACTIVE_ORG_*`, `PORTLESS_URL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`
 
 ### DNS
 


### PR DESCRIPTION
## Summary

- Strip stale AgentMail env vars (`EMAIL_API_KEY`, `EMAIL_WEBHOOK_SECRET`) from `deploy_server.yml` — both lost their code readers when BYO IMAP/SMTP landed.
- Wire the 16 env vars the server reads at boot with no default into the workflow's update + first-create branches (`EMAIL_CREDENTIAL_KEY`, `EMAIL_API_KEY_TRANSACTIONAL`, `EMAIL_FROM_TRANSACTIONAL`, `EMAIL_PROVIDER_TRANSACTIONAL`, `CALENDAR_PROVIDER`, `CALENDAR_API_KEY`, `CALENDAR_WEBHOOK_SECRET`, `GEOCODER_PROVIDER`, plus 8 `RESEARCH_DEFAULT_*` / `RESEARCH_MAX_*` / `RESEARCH_CONFIRM_*`). Without these the first prod deploy would `Config.ConfigError` before serving a request.
- Align `.env.example.github` with what `apps/server` + `packages/{calendar,research}` actually read; correct `EMAIL_CREDENTIAL_KEY` generation from hex → base64 in `TODO_DEPLOYMENT.md` (`credential-crypto.ts` decodes with `Buffer.from(..., 'base64')` and dies on a 64-byte hex string).

The original Slice 1 audit said 5 + 8 missing vars; the missing one was `CALENDAR_PROVIDER`, the boot selector for `BookingProviderLive` (`packages/calendar/src/infrastructure/live.ts:14`). Header in the TODO updated to 8 + 8.

## Test plan

- [ ] CI: `check-types` + `test` + `build` green (no app code touched, cache should replay).
- [ ] Manual: `grep -c '^                -e ' .github/workflows/deploy_server.yml` returns 28 on each branch (update + first-create), matching the boot env reads.
- [ ] After merge: run `gh variable set` + `gh secret set` per `docs/TODO_DEPLOYMENT.md` "Configure GitHub `production` environment", then `gh workflow run deploy_server.yml` and confirm `https://api.batuda.co/health` returns 200.