### PR TITLE
ai(mcp): switch neon server to local stdio + NEON_API_KEY

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,8 +5,11 @@
 			"url": "https://mcp.cloudflare.com/mcp"
 		},
 		"neon": {
-			"type": "http",
-			"url": "https://mcp.neon.tech/mcp"
+			"command": "sh",
+			"args": [
+				"-c",
+				"exec npx -y @neondatabase/mcp-server-neon start \"$NEON_API_KEY\""
+			]
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Switches the Neon MCP entry in `.mcp.json` from the HTTP/OAuth endpoint (`https://mcp.neon.tech/mcp`) to a local stdio server spawned via `npx -y @neondatabase/mcp-server-neon`, authenticated by `\$NEON_API_KEY`.

## Why

The OAuth-based HTTP variant dropped mid-session today and blocked the auth flow — couldn't be reconnected without a full /mcp dialog cycle. The stdio + long-lived `NEON_API_KEY` path is what Neon documents for non-interactive use and is more reliable for autonomous flows.

## Side effect

Anyone using this repo's MCP integration now needs `NEON_API_KEY` exported in their shell. The `sh -c` wrapper expands the env var inline, so an unset value spawns npx with an empty arg and the server fails at startup. Follow-up: document this in the dev-setup section of the README / getting-started.

## Test plan

- [ ] Pull this branch locally, set `NEON_API_KEY=…` in shell, reload MCP — verify Neon tools list (`list_projects`, `describe_project`, etc.) is available.
- [ ] CI green (`.mcp.json` is not loaded at build time, so no functional impact on test suite).