### PR TITLE
chore: hoist pnpm node_modules to fix Unikraft CPIO boot

### DIFF
--- a/apps/internal/tsconfig.json
+++ b/apps/internal/tsconfig.json
@@ -10,7 +10,9 @@
 		},
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
-		"noEmit": true
+		"noEmit": true,
+		"declaration": false,
+		"declarationMap": false
 	},
 	"include": ["src", "vite.config.ts"],
 	"exclude": ["node_modules", "dist", ".output"]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,11 @@ packages:
 # `injectWorkspacePackages` leaves peerless workspace deps as unresolved symlinks under `pnpm deploy`.
 forceLegacyDeploy: true
 
+# Flat node_modules. pnpm's default `.pnpm/<peer-deps-hash>/` paths exceed
+# Unikraft's libukcpio buffer (~256 chars) and crash the unikernel at boot
+# with `Failed to extract CPIO to /: -2`.
+nodeLinker: hoisted
+
 # Trusted install scripts; install fails on any unlisted dep with build scripts.
 allowBuilds:
   '@swc/core': true


### PR DESCRIPTION
## Summary

Unblocks the deploy that crashed at unikernel boot with `Failed to extract CPIO to /: -2` (libukcpio rejected a 265-char path under pnpm's virtual store).

## Root cause

pnpm v9+ encodes peer-dep resolution into virtual-store directory names (`@tanstack+router-plugin@1.167.12_@tanstack+react-router@1.168.10_react-dom@19.2.4_react_80a0f0f9ef7320034a642f553d648904` — ~130 chars). Stack a real filename + `dist/cjs/.../foo.cjs.map` tail and Unikraft's CPIO filename buffer overflows. `@tanstack/router-plugin` here is transitive via `@tanstack/react-router` → `@batuda/controllers`.

## Fix

`nodeLinker: hoisted` in `pnpm-workspace.yaml` flattens `node_modules` to the classic layout — deps land directly under `node_modules/<dep>/`, capping path length at 134 chars in the built image.

## Collateral

Hoisted layout exposes TS2742 in `apps/internal/src/lib/auth-client.ts` (better-auth's `createAuthClient()` returns an inferred type that references private `.d.mts` subpaths the bundler can't name portably under the new path layout). Added `declaration: false` + `declarationMap: false` to `apps/internal/tsconfig.json` — semantically correct since the app already has `noEmit: true` and never publishes type declarations.

## Trade-off

Looser local module isolation — workspace code can resolve packages they didn't declare in their own `package.json`. Acceptable here:
- No internal phantom-dep bugs to protect against
- `check-types` + `build` catch missing-dep issues at compile time
- Strict isolation can be reinstated later by bundling all deps into `dist/main.mjs` (the C option from the earlier triage)

## Verification

- `pnpm install` clean under hoisted (1288 deps, flat layout)
- `pnpm check-types` 11/11 green
- `pnpm build` 11/11 green
- `docker build apps/server/Dockerfile` builds clean
- Max path in resulting image: **134 chars** (was 265)

## Test plan

- [ ] CI green
- [ ] After merge: re-trigger `deploy_server.yml`, instance boots clean (no CPIO error), `/health` → 200