### PR TITLE
fix(server): bundle @batuda/* workspace deps + bump unikernel memory

### DIFF
--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -92,10 +92,12 @@ jobs:
           #     timeout note below); 30s tripped HTTP 400 and aborted the
           #     rollout. Node + DB pool warm-up fits in 5s on the cold
           #     unikernel path because connection-pool init is lazy.
-          #   -M 1024: 512 MiB caused CPIO extraction to run out of space
-          #     on the marketing unikernel; matching 1024 here for the
-          #     server's larger runtime footprint (DB driver, R2 SDK,
-          #     IMAP/SMTP client).
+          #   -M 2048: pnpm v11 hoisted-mode `pnpm deploy --prod` under legacy
+          #     deploy doesn't prune to apps/server's runtime deps — /deploy
+          #     ends up with the workspace's full install tree (~303 MB).
+          #     1024 ran out of initrd RAM extracting the CPIO. 2048 fits.
+          #     Slimming the image is tracked as a follow-up; bumping memory
+          #     unblocks the first prod boot today.
           #   --timeout 10s is mandatory: kraft's default per-RPC timeout
           #     is 60s, but UKC's API caps it at 10000ms and rejects
           #     anything higher with HTTP 400 ("Timeout value must be in
@@ -109,7 +111,7 @@ jobs:
                 --service batuda-server \
                 --rollout remove_sequential \
                 --rollout-wait 5s \
-                -M 1024 \
+                -M 2048 \
                 -e NODE_ENV=production \
                 -e PORT=3000 \
                 -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
@@ -166,7 +168,7 @@ jobs:
               kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
                 --timeout 10s \
                 --service batuda-server \
-                -M 1024 \
+                -M 2048 \
                 -e NODE_ENV=production \
                 -e PORT=3000 \
                 -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "portless run --name api.batuda node --watch --env-file=../../.env --import tsx src/main.ts",
 		"dev:mcp": "node --env-file=../../.env --import tsx src/mcp-stdio.ts",
-		"build": "tsdown src/main.ts src/mcp-stdio.ts src/db/migrate.ts",
+		"build": "tsdown",
 		"check-types": "tsc --noEmit",
 		"start": "node dist/main.mjs",
 		"migrate": "node --env-file=../../.env --import tsx src/db/migrate.ts",

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+// Bundle the `@batuda/*` workspace packages into the server bundle. Their
+// package.json files point `main`/`import` at `./src/index.ts` (raw TS) for
+// local-dev consumption via tsx/Vite, which Node.js can't load at runtime.
+// Inlining them at build time keeps the runtime image free of workspace
+// `node_modules/@batuda/*` entries entirely, while leaving npm dependencies
+// (effect, pg, AWS SDK, ...) external as before.
+export default defineConfig({
+	entry: ['src/main.ts', 'src/mcp-stdio.ts', 'src/db/migrate.ts'],
+	format: 'esm',
+	noExternal: [/^@batuda\//],
+})


### PR DESCRIPTION
## Summary

Two coupled fixes to make the first prod boot succeed:

1. **Bundle `@batuda/*` workspace deps into apps/server's dist.** Their `package.json` files all point `main`/`import` at `./src/index.ts` (raw TS for local dev via tsx/Vite), which Node.js can't load at runtime — boot crashes with `ERR_UNKNOWN_FILE_EXTENSION ".ts"` on the first import of e.g. `@batuda/calendar`.
2. **Bump unikernel memory `-M 1024` → `-M 2048`** so the (still-bloated) deploy image fits the initrd RAM.

## Why bundling (not fixing 6 package.json files)

The `main`/`import` → `./src/index.ts` pattern is intentional for local-dev — every workspace package is consumed as raw TS by tsx (server) and Vite (internal/marketing). Switching all 6 to `./dist/index.mjs` would also require:
- Adding a `development` condition so local dev still resolves to src
- Adding tsdown configs for the packages with subpath exports (`@batuda/email` has 6 subpath entries that don't have dist outputs today)

Bundling is one file (`apps/server/tsdown.config.ts`), one config knob (`noExternal: [/^@batuda\//]`). The workspace TS gets inlined into `dist/main.mjs`. No `node_modules/@batuda/*` lookup at runtime. Local dev path is unchanged.

## Why the memory bump

pnpm v11 hoisted-mode `pnpm deploy --prod` under `forceLegacyDeploy: true` doesn't prune the output tree — `/deploy` ends up with the workspace's full installed `node_modules` (~303 MB), including dev tools like vite/vitest/prettier that the server never loads. The unikernel boots successfully under 2048 MiB but ran out of initrd RAM at 1024 MiB extracting the CPIO. Slimming the image is tracked as a follow-up (`pnpm deploy` filter is the wrong tool here — likely needs a separate `npm install --omit=dev` step against the bundled `dist/main.mjs`).

## Verification

- `pnpm --filter @batuda/server build` → `dist/main.mjs` 91 KB with workspace deps inlined (total dist 2.62 MB).
- `node apps/server/dist/main.mjs` boots locally without the .ts extension error (fails at DB auth with fake password, as expected).
- `docker build apps/server/Dockerfile` clean, image 430 MB.
- Manual `kraft cloud deploy --service batuda-server -M 2048` of an earlier failing image already proven to boot (567 ms).

## Test plan

- [ ] CI green
- [ ] After merge: re-trigger `deploy_server.yml`. Instance boots cleanly with `-M 2048`, no CPIO error, no `.ts` extension error. `/health` → 200.