### PR TITLE
fix(server): provide HttpClient at the layer stack root

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -177,7 +177,7 @@ const ServicesLive = Layer.mergeAll(
 	EmailService.layer,
 	RecordingService.layer,
 	ResearchService.layer,
-	Geocoder.layer.pipe(Layer.provide(FetchHttpClient.layer)),
+	Geocoder.layer,
 	// daemonLayer outputs `never` so a downstream `provideMerge` would
 	// skip building it (nothing requires it). Listing it inside `mergeAll`
 	// forces the build, which fires the side-effect that forks the probe.
@@ -241,7 +241,7 @@ const AppLive = Layer.mergeAll(
 
 const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(ServicesLive),
-	Layer.provide(BookingProviderLive.pipe(Layer.provide(FetchHttpClient.layer))),
+	Layer.provide(BookingProviderLive),
 	Layer.provide(IcsParserLive),
 	Layer.provide(EmailProviderLive),
 	Layer.provide(researchToolkitLayer),
@@ -252,6 +252,10 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(OrgMiddlewareLive),
 	Layer.provide(SessionMiddlewareLive),
 	Layer.provide(Auth.layer),
+	// Provided once at the bottom of the stack so every layer above (booking,
+	// brave search, calcom, geocoder, inbox-health-probe, …) can pick up
+	// `HttpClient.HttpClient` from a single shared fetch.
+	Layer.provide(FetchHttpClient.layer),
 	Layer.provide(EnvVars.layer),
 	Layer.provide(PgLive),
 	Layer.provideMerge(ServerLive),


### PR DESCRIPTION
## Summary

The first prod boot succeeded all Effect layer init (transactional email, research stubs, brave search, calendar stub, inbox health probe), then Node crashed ~60s later with `Service not found: effect/HttpClient`.

## Root cause

Only `BookingProviderLive` and `Geocoder.layer` had `FetchHttpClient.layer` wrapped around them in `apps/server/src/main.ts`. Other services that need `HttpClient.HttpClient` at runtime — brave search, calcom callbacks via the booking provider's outer handlers, future HTTP services — inherited from the program stack, where HttpClient wasn't provided. The first runtime call from one of those services tripped the missing-service error.

## Fix

Single `Layer.provide(FetchHttpClient.layer)` near the bottom of the program stack (between `Auth.layer` and `EnvVars.layer`). Every layer above can pick up `HttpClient.HttpClient` from one shared fetch. Removed the now-redundant inline `.pipe(Layer.provide(FetchHttpClient.layer))` on `BookingProviderLive` and `Geocoder.layer`.

## Test plan

- [ ] CI green
- [ ] After merge: re-trigger `deploy_server.yml`. Server boots + stays running past 60s. `/health` → 200.