### PR TITLE
fix(server): grant app_user/app_service membership WITH SET TRUE

### DIFF
--- a/apps/server/src/db/migrations/0002_role_set_option.ts
+++ b/apps/server/src/db/migrations/0002_role_set_option.ts
@@ -1,0 +1,26 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Postgres 16+ split role membership into separate ADMIN / INHERIT / SET
+// flags. The `CREATE ROLE` auto-grant in 0001_initial.ts hands the creator
+// (here, the DATABASE_URL owner) ADMIN but NOT SET, so `SET LOCAL ROLE
+// app_user` / `app_service` is denied at runtime — OrgMiddleware, the
+// inbox-health-probe, and the calcom webhook handler all trip on it.
+//
+// 0001_initial.ts now issues the same GRANTs inline after CREATE ROLE, so
+// fresh databases never hit this. This migration exists to fix the
+// already-deployed Neon DB that was created against the older 0001.
+//
+// Idempotent: re-running `GRANT … WITH SET TRUE` against an already-set
+// membership is a no-op.
+//
+// Keep `INHERIT FALSE`: the DATABASE_URL owner must NOT inherit
+// `app_user`'s RLS-bound visibility by default. Code switches explicitly
+// per transaction so the boundary stays auditable.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`GRANT app_user TO CURRENT_USER WITH ADMIN TRUE, INHERIT FALSE, SET TRUE`
+	yield* sql`GRANT app_service TO CURRENT_USER WITH ADMIN TRUE, INHERIT FALSE, SET TRUE`
+})


### PR DESCRIPTION
## Summary

Adds `0002_role_set_option.ts` to fix the production Neon DB where `SET LOCAL ROLE app_user`/`app_service` is denied at runtime.

## Root cause

Postgres 16+ split role membership into separate `ADMIN`/`INHERIT`/`SET` options. When `0001_initial.ts` runs `CREATE ROLE app_user`/`app_service`, the auto-grant gives the creator (the DATABASE_URL owner) `ADMIN TRUE, INHERIT FALSE, SET FALSE`. The `SET FALSE` half is exactly what blocks `SET LOCAL ROLE …`.

Verified via Neon MCP:
```sql
SELECT role.rolname, am.set_option
FROM pg_auth_members am
JOIN pg_roles role ON role.oid = am.roleid
WHERE role.rolname IN ('app_user','app_service');
-- both: set_option = false
```

## Impact today

- `inbox-health-probe` trips every 15 min in prod: `permission denied to set role "app_service"`.
- `OrgMiddleware` would trip identically on any org-scoped HTTP request — `/health` bypasses it, so we haven't surfaced the request-path failure yet.

## Fix

`0002_role_set_option.ts`:
```ts
GRANT app_user    TO CURRENT_USER WITH ADMIN TRUE, INHERIT FALSE, SET TRUE
GRANT app_service TO CURRENT_USER WITH ADMIN TRUE, INHERIT FALSE, SET TRUE
```

- `SET TRUE`: the actual fix — allows `SET LOCAL ROLE` to switch from the DATABASE_URL owner.
- `INHERIT FALSE`: deliberate; the DATABASE_URL owner must NOT silently inherit `app_user`'s RLS-gated visibility. Every role switch stays explicit per transaction.
- `ADMIN TRUE`: preserves the ability to manage these roles.

Idempotent — re-running against a membership that already has SET TRUE is a no-op.

## Apply

After merge, locally (with `.env.cloud` containing the direct Neon URL):
```sh
pnpm cli --env cloud db migrate
```

The migrator records `0002_role_set_option` in `effect_sql_migrations`. Fresh deploys run both 0001 and 0002 in sequence; outcome identical to a database that only ran the updated 0001.

## Verify

After migrate, via Neon MCP / psql:
```sql
SELECT role.rolname, am.set_option
FROM pg_auth_members am
JOIN pg_roles role ON role.oid = am.roleid
WHERE role.rolname IN ('app_user','app_service');
-- both: set_option = true
```

inbox-health-probe stops logging "permission denied" on its next tick.

## Test plan

- [ ] CI green
- [ ] After merge: run `pnpm cli --env cloud db migrate`, confirm `set_option=true` for both roles via MCP
- [ ] Tail prod logs 15 min later, confirm no "permission denied" entries