### PR TITLE
refactor(server): drop unsafe cast in runMain, type-check program R

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -239,6 +239,24 @@ const AppLive = Layer.mergeAll(
 	OpenApiJsonLive,
 )
 
+// `CurrentOrg` is request-scoped: real call sites override it via
+// OrgMiddleware (HTTP), McpAuthMiddleware (MCP tools), `provideOrg`
+// (cal.com webhook), or the inline `Effect.provideService` calls in
+// ResearchEventSinkLive. Non-org-scoped endpoints (/docs, /openapi.json,
+// MCP transport plumbing) and a few service method signatures still
+// surface `CurrentOrg` in the program's R, so we satisfy the type
+// statically here with a layer that dies loudly if anyone reads the tag
+// outside a request scope — surfacing the leak as a Defect rather than
+// silently masking it with a cast.
+const CurrentOrgFallbackLive = Layer.effect(
+	CurrentOrg,
+	Effect.die(
+		new Error(
+			'CurrentOrg accessed outside a request scope — reach it via OrgMiddleware, McpAuthMiddleware, provideOrg, or an explicit Effect.provideService(CurrentOrg, …).',
+		),
+	),
+)
+
 const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(ServicesLive),
 	Layer.provide(BookingProviderLive),
@@ -251,6 +269,7 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(S3StorageProviderLive),
 	Layer.provide(OrgMiddlewareLive),
 	Layer.provide(SessionMiddlewareLive),
+	Layer.provide(CurrentOrgFallbackLive),
 	Layer.provide(Auth.layer),
 	// Provided once at the bottom of the stack so every layer above (booking,
 	// brave search, calcom, geocoder, inbox-health-probe, …) can pick up
@@ -264,4 +283,4 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.launch,
 )
 
-NodeRuntime.runMain(program as unknown as Effect.Effect<void, unknown, never>)
+NodeRuntime.runMain(program)


### PR DESCRIPTION
## Summary

Removes `apps/server/src/main.ts:267`'s `NodeRuntime.runMain(program as unknown as Effect.Effect<void, unknown, never>)` cast. The cast was masking a real type-leak — TypeScript would have rejected the call without it. The same shape would have hidden the FetchHttpClient regression that crashed our first prod boot (PR #13).

## Root cause of the leak

`OrgMiddleware`'s `HttpApiMiddleware.Service<…, { provides: CurrentOrg }>` only discharges the requirement on endpoints attached via `.middleware(OrgMiddleware)`. The cal.com webhook group, `/docs`, `/openapi.json`, MCP transport plumbing, and a few service method signatures (`WebhookService.fire`, `TimelineActivityService.record`) still surface `CurrentOrg` in the program's `R`. Every real call site provides it dynamically (OrgMiddleware, McpAuthMiddleware, `provideOrg`, the two inline `Effect.provideService` calls in `ResearchEventSinkLive`), but the static type system can't see those dynamic provisions.

## Fix

Two changes in `apps/server/src/main.ts`:

1. Drop the cast — `runMain(program)` now consumes the typed effect directly. Any future "forgot to provide a layer" becomes a CI-blocking compile error.

2. Add `CurrentOrgFallbackLive` — a layer that fails with `Effect.die(...)` if anyone reads `CurrentOrg` outside a request scope. Provided once at the program root; every real call site shadows it. Runtime behaviour unchanged for the request path, but any future accidental read surfaces as a labelled Defect instead of silently being masked.

```ts
const CurrentOrgFallbackLive = Layer.effect(
  CurrentOrg,
  Effect.die(new Error('CurrentOrg accessed outside a request scope — …')),
)
```

## Verification

- `pnpm --filter @batuda/server check-types` green
- `pnpm --filter @batuda/server build` clean (dist/main.mjs 91 KB unchanged)
- Smoke-checked the layer order — `CurrentOrgFallbackLive` is provided AFTER `OrgMiddlewareLive` and `SessionMiddlewareLive` so they can override per-request

## Memory link

Honours `[[feedback_type_safety]]` ("no `any`/`@ts-expect-error`") — replaces the `as unknown as` (a type assertion that lies) with a real layer.

## Test plan

- [ ] CI green
- [ ] After merge: server keeps booting normally; any `CurrentOrg` read leak in the future surfaces in logs as `"CurrentOrg accessed outside a request scope — …"`

Follow-up (PR-A2): boot test that exercises this exact invariant at runtime.