### PR TITLE
fix(server): drop CurrentOrgFallback to keep MCP request-scope intact

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -239,23 +239,26 @@ const AppLive = Layer.mergeAll(
 	OpenApiJsonLive,
 )
 
-// `CurrentOrg` is request-scoped: real call sites override it via
-// OrgMiddleware (HTTP), McpAuthMiddleware (MCP tools), `provideOrg`
-// (cal.com webhook), or the inline `Effect.provideService` calls in
-// ResearchEventSinkLive. Non-org-scoped endpoints (/docs, /openapi.json,
-// MCP transport plumbing) and a few service method signatures still
-// surface `CurrentOrg` in the program's R, so we satisfy the type
-// statically here with a layer that dies loudly if anyone reads the tag
-// outside a request scope — surfacing the leak as a Defect rather than
-// silently masking it with a cast.
-const CurrentOrgFallbackLive = Layer.effect(
-	CurrentOrg,
-	Effect.die(
-		new Error(
-			'CurrentOrg accessed outside a request scope — reach it via OrgMiddleware, McpAuthMiddleware, provideOrg, or an explicit Effect.provideService(CurrentOrg, …).',
-		),
-	),
-)
+// `CurrentOrg` is request-scoped — provided per request by OrgMiddleware
+// (HTTP), McpAuthMiddleware (MCP tools), `provideOrg` (cal.com webhook),
+// and inline `Effect.provideService` calls in ResearchEventSinkLive. It
+// surfaces in the program's R only because Tool.make declares
+// `dependencies: [CurrentOrg]` for typing.
+//
+// No root layer for it on purpose: `McpServer.toolkit(...)` snapshots the
+// service map at layer-build time (effect/src/unstable/ai/McpServer.ts:610)
+// and re-injects it per tool call via `Effect.provideContext`, where
+// `ServiceMap.merge` lets the snapshot OVERRIDE the request fiber. A
+// boot-time sentinel would clobber McpAuthMiddleware's real value and
+// return empty/foreign rows from every tool; leaving the tag absent at
+// boot keeps it out of the snapshot so the request value survives.
+//
+// The runMain cast type-erases the unsatisfied requirement. A
+// defect-throwing fallback would surface accidental out-of-scope reads
+// more loudly but crashes startup for the same snapshot reason. The
+// pattern stops being necessary when upstream defers `McpServer.toolkit`
+// capture to request time; `main.boot.test.ts:149-156` is the regression
+// guard (not in `pnpm test` today — run via `pnpm test:integration`).
 
 const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(ServicesLive),
@@ -269,7 +272,6 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(S3StorageProviderLive),
 	Layer.provide(OrgMiddlewareLive),
 	Layer.provide(SessionMiddlewareLive),
-	Layer.provide(CurrentOrgFallbackLive),
 	Layer.provide(Auth.layer),
 	// Provided once at the bottom of the stack so every layer above (booking,
 	// brave search, calcom, geocoder, inbox-health-probe, …) can pick up
@@ -283,4 +285,4 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.launch,
 )
 
-NodeRuntime.runMain(program)
+NodeRuntime.runMain(program as unknown as Effect.Effect<void, unknown, never>)


### PR DESCRIPTION
## Summary

Hotfix off `main`. `e8a7d80ec65` (Wed May 13) added a `Layer.effect(CurrentOrg, Effect.die(...))` fallback at the program root to surface accidental out-of-request-scope reads as Defects. The intent was sound — but the design collides with how `McpServer.toolkit(...)` registers tools.

## Root cause

`McpServer.toolkit(...)` snapshots the entire service map at layer-build time (`effect/src/unstable/ai/McpServer.ts:610`) and re-injects it per tool call via `Effect.provideContext`. `ServiceMap.merge` semantics mean the snapshot **overrides** the request fiber. With a boot-time CurrentOrg layer in scope:

- The defect-throwing variant fires during the toolkit's build → server crashes at boot.
- A sentinel like `Layer.succeed(CurrentOrg, { id: '__startup_stub__', ... })` lets boot succeed but ends up in the snapshot — every MCP tool call sees the stub instead of `McpAuthMiddleware`'s real `provideService(CurrentOrg, realOrg)`, returning empty/foreign rows.

Pre-`e8a7d80ec65` worked because the runMain cast left `CurrentOrg` absent from the layer scope entirely — the snapshot didn't contain it, and the request fiber's value survived.

## Fix

Drop the `CurrentOrgFallback` layer. Restore the cast at `NodeRuntime.runMain(program as unknown as Effect.Effect<void, unknown, never>)`. CurrentOrg shows up in the program's R only because `Tool.make` declares `dependencies: [CurrentOrg]` for typing; the cast type-erases that at the root. Every real call site (OrgMiddleware, McpAuthMiddleware, provideOrg, ResearchEventSinkLive's inline `Effect.provideService`) provides the tag per-request — unchanged.

Added a multi-paragraph comment above the cast explaining the trade-off, naming the upstream source line, and pointing future contributors at `main.boot.test.ts:149-156` as the regression guard.

## Trade-off

- **Lost**: defect-throwing fallback for accidental out-of-scope CurrentOrg reads.
- **Kept**: server boots; MCP tool calls actually use the request's CurrentOrg; type-check still requires every real call site to provide the tag.

The clean architectural alternative is for upstream `McpServer.toolkit` to defer service capture until request time. Until that lands, the cast is the pragmatic choice.

## Test plan

- [x] `pnpm --filter @batuda/server check-types` — green
- [x] `pnpm --filter @batuda/server exec vitest run` — 103/103 across 14 files
- [x] Dev stack boot: `pnpm dev:server` reaches `Listening on http://0.0.0.0:...`, `curl /health` → 200
- [x] **MCP smoke (verifies the fix end-to-end)**:
  - Signed in as Alice via `/auth/sign-in/email`, set active org via `/auth/organization/set-active { organizationSlug: 'taller' }`.
  - MCP `initialize` + `notifications/initialized` + `tools/call search_companies`.
  - Got 3 real Taller companies (Ferros Baix Llobregat, Cal Pep Fonda, Hostal del Pirineu).
  - Switched active org to `restaurant`, re-ran. Got exactly 1 result: Marisqueria del Port (Restaurant's only seeded company). No Taller leakage.
  - Confirms the per-request `CurrentOrg` from `McpAuthMiddleware` reaches the handler (not a snapshot stub).

## Follow-up

`apps/server/src/main.boot.test.ts:149-156` already asserts this exact regression but is documented as "Not wired into the default `pnpm test`" (line 11). Worth wiring into a separate CI job so the next attempt at this refactor catches it.