### PR TITLE
chore: drop dead stage_fixed on i18n-check lefthook step

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -30,10 +30,13 @@ pre-commit:
       # `i18n:check` in every workspace that defines it via pnpm's
       # `--if-present` filter — internal is the only web app here today, any
       # new web app tomorrow without editing this file.
+      #
+      # No `stage_fixed`: `i18n:check` is read-only (it verifies catalogs
+      # are in sync, never writes). Auto-amending .po would silently stage
+      # untranslated msgstr entries, which then ship as empty strings.
       glob: "apps/internal/**/*.{tsx,ts,po}"
       run: |
         pnpm -r --parallel --if-present run i18n:check
-      stage_fixed: true
 
 pre-push:
   commands:


### PR DESCRIPTION
## Summary

`pre-commit.commands.i18n-check.stage_fixed: true` had no effect — `i18n:check` runs `bash scripts/check-po-translations.sh .`, which is read-only. `stage_fixed` only does something when the hook command actually modifies files (the other entries that use it — `biome`, `syncpack`, `dprint` — all run with `--write`).

## Why not auto-extract instead

Catalog drift is semantic, not cosmetic. `lingui extract` would add untranslated `msgstr ""` entries for every non-default locale; auto-staging those into the commit ships empty strings to prod. The check-only pattern surfaces drift loudly so a human picks the translations.

## Test plan

- [x] `pre-commit` still runs `i18n:check` and fails the commit when catalogs drift (no behavior change — only the dead flag is gone).
- [x] Comment block explains the deliberate asymmetry vs the formatter steps.