### PR TITLE
fix(internal): resolve @batuda/ui to source via 'development' condition

### DIFF
--- a/apps/internal/vite.config.ts
+++ b/apps/internal/vite.config.ts
@@ -122,7 +122,20 @@ const config = defineConfig({
 		// `.default` property — Nitro's prebuild then emits
 		// `const { __extends } = tslib.default` which throws at SSR
 		// time because tslib's ESM has named exports, not a default.
-		conditions: ['module', 'import', 'default'],
+		//
+		// `development` is first so workspace packages with a
+		// `"development"` export key (e.g. `@batuda/ui`) resolve to
+		// their TS source in dev, not the pre-built `dist/`. Without
+		// it Vite picks `import` → `dist/index.mjs`, which tsdown ships
+		// without `@swc/plugin-styled-components` componentIds; the SSR
+		// pipeline's `noExternal` still re-runs the SWC plugin and adds
+		// IDs, while the client loads dist as-is. The classnames then
+		// diverge (`pri-input__PriInput-sc-{hash}-0` vs `PriInput-{hash}`)
+		// and React 19 bails hydration on every affected subtree —
+		// magic-link button onClick stops attaching, sign-in form
+		// submits get dropped, etc. Symmetric source load + symmetric
+		// transform fixes the mismatch at the root.
+		conditions: ['development', 'module', 'import', 'default'],
 	},
 	ssr: {
 		// Bundle through Vite for SSR so the React-using deps go through
@@ -136,7 +149,7 @@ const config = defineConfig({
 			'@base-ui/react',
 			'@base-ui/utils',
 		],
-		resolve: { conditions: ['module', 'import', 'default'] },
+		resolve: { conditions: ['development', 'module', 'import', 'default'] },
 	},
 	plugins: [
 		tanstackStart(),


### PR DESCRIPTION
## Summary

The e2e sign-in suite has been intermittently failing because React 19 silently bailed hydration on every styled-components subtree from `@batuda/ui` — event handlers on `PriInput` / `PriButton` / `PriToast.Viewport` etc. never attached, so click events on the magic-link trigger went nowhere and the test timed out waiting for the inbox panel.

## Root cause

`@batuda/ui`'s `package.json` exports `"development": "./src/..."` and `"import": "./dist/index.mjs"`. The pre-built `dist/` is produced by `tsdown` (no styled-components transform), while `src/` gets the `@swc/plugin-styled-components` treatment when bundled.

`apps/internal/vite.config.ts` explicitly set `resolve.conditions = ['module', 'import', 'default']` to fix an unrelated tslib issue. That **dropped Vite's built-in `'development'` condition**, so `@batuda/ui` resolved to `dist/` for both pipelines. But:

- **SSR** has `noExternal: ['@batuda/ui']`, which re-runs the full plugin chain over `dist/` and adds `componentId: 'sc-16c965fa-0'` ⇒ classname `pri-input__PriInput-sc-16c965fa-0 ewhMDn`.
- **Client** loads `dist/` as a normal workspace dep with no transform ⇒ classname `PriInput-iuSRNt kIxOqF` (styled-components runtime fallback).

Two different classnames for the same component ⇒ React 19 declares hydration mismatch on the affected subtree ⇒ event handlers don't bind. The trace shows the click reaches the DOM but `requestMagicLink` never runs (no POST to `/auth/sign-in/magic-link`).

## Fix

Prepend `'development'` to both `resolve.conditions` and `ssr.resolve.conditions`. `@batuda/ui` now resolves to its TS source in both pipelines, both run the SWC plugin, classnames match, hydration succeeds.

Other deps don't expose a `development` key, so the resolution falls through unchanged for them. The tslib fix is preserved (still no `'node'` condition).

## Test plan

- [x] `pnpm --filter @batuda/internal check-types` — green
- [x] `curl https://batuda.localhost/login` SSR HTML has `pri-input__PriInput-sc-16c965fa-0` (unchanged)
- [x] Vite-served `@batuda/ui/pri/pri-input.tsx` shows the SWC plugin output with `componentId: 'sc-16c965fa-0'` (now also on the client)
- [x] **`pnpm exec playwright test sign-in.test.ts sign-in-magic-link --project=unauth` — 9/9 pass × 3 consecutive runs** (was 0/9 → 8/9 → flaky before this PR; now stable)

## Secondary finding (no fix needed)

A cold/invalidated Vite `optimizeDeps` cache causes a mid-test page reload when Vite discovers new dependencies during navigation (`✨ optimized dependencies changed. reloading`). That can manifest as an additional false-positive flake on the very first test run after a `node_modules/.vite` wipe. Subsequent runs are stable because the cache is warm. Worth knowing but not addressable in vite.config.