### PR TITLE
refactor: drop throwaway-password workaround in invitation paths

### DIFF
--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -193,11 +193,10 @@ describe('buildBetterAuthConfig customRules — magic-link routes in loose mode'
 	})
 })
 
-describe('credential-row strip helper (matches sendInvitationEmail bug fold-in)', () => {
-	// The strip DELETE is closure-bound inside the org plugin's
-	// sendInvitationEmail callback (auth.ts:167) and reaching it through
-	// the public API needs an authed inviter session — end-to-end coverage
-	// lives in apps/internal/tests/e2e. Here we exercise the SQL itself.
+describe('admin createUser respects an omitted password', () => {
+	// Pins the Better Auth contract that callers (web invitation flow,
+	// CLI `users.createPasswordless`) lean on: no `password` => no
+	// `account` row, so invitees start passwordless.
 
 	const buildInstance = () =>
 		betterAuth(
@@ -232,70 +231,48 @@ describe('credential-row strip helper (matches sendInvitationEmail bug fold-in)'
 		return Number(result.rows[0]?.count ?? '0')
 	}
 
-	const stripCredentialRow = async (email: string): Promise<void> => {
-		await sharedPool.query(
-			`DELETE FROM "account"
-			 WHERE "userId" = (SELECT id FROM "user" WHERE email = $1 LIMIT 1)
-			   AND "providerId" = 'credential'`,
-			[email],
-		)
-	}
-
-	beforeAll(() => {
-		// No truncate — afterAll at file scope cleans this test's own rows
-		// by `auth-it-` email prefix so the dev seed stays untouched.
-	})
-
-	describe('when the invite path just created the user', () => {
-		it('should remove the throwaway credential row so the invitee starts passwordless', async () => {
-			// [auth.ts:167 — wasCreated=true branch]
-			// GIVEN a freshly created invitee carrying the throwaway password
-			// that sendInvitationEmail mints at auth.ts:146.
+	describe('when password is omitted', () => {
+		it('should create the user without a credential row', async () => {
+			// [better-auth/dist/plugins/admin/routes.mjs:170 — `if (ctx.body.password)` gate is false]
+			// GIVEN a fresh invitee email and an instance with the admin plugin
 			const auth = buildInstance()
-			const inviteeEmail = `${TEST_EMAIL_PREFIX}wascreated-${Date.now()}@example.com`
+			const inviteeEmail = `${TEST_EMAIL_PREFIX}nopwd-${Date.now()}@example.com`
+
+			// WHEN createUser is called with no password field
 			await auth.api.createUser({
 				body: {
 					email: inviteeEmail,
-					name: 'Was Created',
-					password: `invite-fake-id-${Date.now()}-pending`,
+					name: 'No Password',
 				},
 			})
-			expect(
-				await countCredentialRows(inviteeEmail),
-				'createUser must write a credential row for the strip to remove',
-			).toBe(1)
 
-			// WHEN the strip runs
-			await stripCredentialRow(inviteeEmail)
-
-			// THEN the credential row is gone but the user row survives —
-			// magic-link verify reads the user row only.
-			expect(await countCredentialRows(inviteeEmail)).toBe(0)
+			// THEN the user row is written but the credential row is skipped —
+			// magic-link verify reads `findUserByEmail` so the user can sign in.
 			expect(await countUserRows(inviteeEmail)).toBe(1)
+			expect(await countCredentialRows(inviteeEmail)).toBe(0)
 		})
 	})
 
-	describe('when the invite path encountered an existing user', () => {
-		it('should leave the existing credential row untouched (no data loss)', async () => {
-			// [auth.ts:162 — wasCreated=false branch]
-			// GIVEN an existing user with a real password (second-org invite
-			// path resolves to USER_ALREADY_EXISTS at auth.ts:156).
+	describe('when password is provided', () => {
+		it('should write a credential row alongside the user', async () => {
+			// [better-auth/dist/plugins/admin/routes.mjs:170 — `if (ctx.body.password)` gate is true]
+			// GIVEN an email and a real password (matches the second-org
+			// invite path: the user already has a password from a prior org).
 			const auth = buildInstance()
-			const existingUserEmail = `${TEST_EMAIL_PREFIX}existing-${Date.now()}@example.com`
+			const userEmail = `${TEST_EMAIL_PREFIX}haspwd-${Date.now()}@example.com`
+
+			// WHEN createUser is called with a password
 			await auth.api.createUser({
 				body: {
-					email: existingUserEmail,
-					name: 'Existing',
+					email: userEmail,
+					name: 'Has Password',
 					password: 'their-own-real-password-1234',
 				},
 			})
-			expect(await countCredentialRows(existingUserEmail)).toBe(1)
 
-			// WHEN the invite path skips the strip (no call here on purpose —
-			// production gates the DELETE on `wasCreated`).
-
-			// THEN the real password row is preserved.
-			expect(await countCredentialRows(existingUserEmail)).toBe(1)
+			// THEN both rows exist — confirms `password` is the only switch.
+			expect(await countUserRows(userEmail)).toBe(1)
+			expect(await countCredentialRows(userEmail)).toBe(1)
 		})
 	})
 })

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -48,7 +48,8 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 							body: {
 								email: string
 								name: string
-								password: string
+								// Optional: omitting leaves the invitee passwordless.
+								password?: string
 							}
 							headers?: Headers
 						}) => Promise<unknown>
@@ -134,20 +135,19 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 								)
 							}
 							// Pre-create the invitee because magic-link verify refuses
-							// to create users while `disableSignUp` is on. Existing
-							// users (second-org invitations) fall through with
-							// wasCreated=false so we never strip a real password.
-							let wasCreated = false
+							// to create users while `disableSignUp` is on. Omitting
+							// `password` keeps invitees passwordless — admin createUser
+							// only writes a credential row when one is provided.
+							// Second-org invitations fall through the catch arm:
+							// `USER_ALREADY_EXISTS` is non-fatal here.
 							try {
 								await authHandle.api.createUser({
 									body: {
 										email: data.email,
 										name: data.email.split('@')[0] ?? data.email,
-										password: `invite-${data.id}-${Date.now()}-pending`,
 									},
 									headers: request?.headers ?? new Headers(),
 								})
-								wasCreated = true
 							} catch (cause) {
 								// Match by code, not message — locale shifts would
 								// silently break a substring predicate.
@@ -158,18 +158,6 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 								) {
 									throw cause
 								}
-							}
-							if (wasCreated) {
-								// Strip the throwaway credential row before the
-								// magic link is minted so no `/sign-in/email`
-								// window exists on the password we just stored.
-								// Magic-link verify reads the user row only.
-								await pool.query(
-									`DELETE FROM "account"
-									 WHERE "userId" = (SELECT id FROM "user" WHERE email = $1 LIMIT 1)
-									   AND "providerId" = 'credential'`,
-									[data.email],
-								)
 							}
 							// Mint a magic-link sign-in URL. The URL is delivered
 							// to *our* sendMagicLink callback below; we route it to

--- a/packages/auth/src/infrastructure/better-auth-adapter.ts
+++ b/packages/auth/src/infrastructure/better-auth-adapter.ts
@@ -270,14 +270,15 @@ export const makeBetterAuthAdapter = (
 				),
 			),
 
-		createPasswordless: (input: NewUserInput) => {
-			const throwaway = `bootstrap-${Math.random().toString(36).slice(2)}-${Date.now()}`
-			return Effect.tryPromise({
+		createPasswordless: (input: NewUserInput) =>
+			// Better Auth's admin createUser gates credential creation on a
+			// truthy `password` field — omit it and no `account` row is
+			// written. See admin/routes.ts `if (ctx.body.password)`.
+			Effect.tryPromise({
 				try: () =>
 					instance.api.createUser({
 						body: {
 							email: input.email,
-							password: throwaway,
 							name: input.name,
 							role: input.role,
 						},
@@ -303,17 +304,9 @@ export const makeBetterAuthAdapter = (
 							}),
 						)
 					}
-					return Effect.tryPromise({
-						try: () =>
-							pool.query(
-								'DELETE FROM "account" WHERE "userId" = $1 AND "providerId" = $2',
-								[row.id, 'credential'],
-							),
-						catch: queryError,
-					}).pipe(Effect.map(() => toUser(row)))
+					return Effect.succeed(toUser(row))
 				}),
-			)
-		},
+			),
 
 		setRole: (email: string, role: Role) =>
 			Effect.tryPromise({


### PR DESCRIPTION
## Summary

- Both invitation paths (web org plugin + CLI passwordless adapter) used to write a throwaway password then `DELETE` the credential row. Better Auth's admin `createUser` already gates credential creation on `if (ctx.body.password)`, so omitting the field gives the same end state with one fewer SQL write per invite.
- Replaced the dance with bare `createUser` calls in `apps/server/src/lib/auth.ts` (`sendInvitationEmail`) and `packages/auth/src/infrastructure/better-auth-adapter.ts` (`users.createPasswordless`).
- Refactored the `auth.test.ts` strip-helper block into `describe('admin createUser respects an omitted password')` with two contexts pinning the BA invariant the new path relies on: omitted password → no credential row; provided password → credential row. The previous block exercised the workaround's DELETE, which no longer exists.

## Plan reference

Follows `drop-throwaway-invite-password-native-passwordless-create.md`.

## What this does NOT do

- **No backfill of legacy phantom credential rows.** Users invited before PR #1's strip fix landed may still have credential rows with the old `invite-${id}-${ts}-pending` plaintext recipe. The exploit surface is narrow (requires a leaked invitation ID *without* the magic-link token, plus bypassing `/sign-in/email` rate-limits) — fix it as a one-off ops query per environment if it turns out to matter.
- **No revert of PR #1's commit 2.** Its history stays; this PR just removes the workaround it added.

## Test plan

- [x] `pnpm vitest run` in `apps/server/` — 110 tests pass, including the 2-context refactored block.
- [x] `pnpm vitest run` in `packages/auth/` — 7 tests pass.
- [x] `pnpm --filter @batuda/internal test:e2e invite.test.ts --workers 1` — invite round-trip passes.
- [x] `pnpm --filter @batuda/internal test:e2e sign-in-magic-link.test.ts --workers 1` — 4/4 pass.
- [x] `pnpm -w check-types` — clean.
- [x] `pnpm -w build` — clean.
- [x] CLI manual smoke: `pnpm cli auth invite-admin --email refactor-smoke@example.com ...` then `psql` confirms `0` credential rows for the new user.