### PR TITLE
feat: set/change password from /profile

### DIFF
--- a/apps/internal/src/components/profile/set-password-nudge.tsx
+++ b/apps/internal/src/components/profile/set-password-nudge.tsx
@@ -1,0 +1,262 @@
+import { Trans } from '@lingui/react/macro'
+import { useNavigate } from '@tanstack/react-router'
+import { KeyRound, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+import { PriButton } from '@batuda/ui/pri'
+
+import {
+	fetchSecurityState,
+	type SecurityState,
+	setPasswordOptOut,
+} from '#/lib/security-state'
+import {
+	agedPaperSurface,
+	brushedMetalBezel,
+	maskingTapeCorner,
+	stenciledTitle,
+} from '#/lib/workshop-mixins'
+
+const DISMISS_STORAGE_KEY = 'batuda.set-password-nudge-dismissed'
+
+interface DismissEntry {
+	readonly userKey: string
+	readonly until: number
+}
+
+/**
+ * Reminds passwordless users they can bind a password without forcing it.
+ * Three escape paths so the prompt never overstays its welcome:
+ *   - "Set password" routes to /profile (where the form lives).
+ *   - "I prefer passwordless" persists a server-side opt-out — silences
+ *     the nudge on every device.
+ *   - "Maybe later" stores a local 24h dismissal — quieter, auto-expires.
+ *
+ * Renders nothing during SSR so the localStorage read can't trigger a
+ * hydration mismatch.
+ */
+export function SetPasswordNudge() {
+	const navigate = useNavigate()
+	const [state, setState] = useState<SecurityState | null>(null)
+	const [dismissedLocally, setDismissedLocally] = useState(false)
+	const [busy, setBusy] = useState(false)
+
+	useEffect(() => {
+		let active = true
+		void (async () => {
+			const result = await fetchSecurityState(undefined)
+			if (!active) return
+			setState(result)
+			if (result && !result.hasPassword && !result.passwordOptOut) {
+				setDismissedLocally(isLocallyDismissed())
+			}
+		})()
+		return () => {
+			active = false
+		}
+	}, [])
+
+	if (!state) return null
+	if (state.hasPassword || state.passwordOptOut) return null
+	if (dismissedLocally) return null
+
+	const handleSetPassword = async () => {
+		await navigate({ to: '/profile' })
+	}
+
+	const handleOptOut = async () => {
+		setBusy(true)
+		const ok = await setPasswordOptOut(true)
+		setBusy(false)
+		if (ok) {
+			setState({ ...state, passwordOptOut: true })
+		}
+	}
+
+	const handleDismiss = () => {
+		persistLocalDismiss()
+		setDismissedLocally(true)
+	}
+
+	return (
+		<Banner role='status' data-testid='set-password-nudge'>
+			<Tape aria-hidden />
+			<Bezel aria-hidden>
+				<KeyRound size={18} />
+			</Bezel>
+			<BannerCopy>
+				<BannerTitle>
+					<Trans>You got in from a link in your email.</Trans>
+				</BannerTitle>
+				<BannerBody>
+					<Trans>
+						Set a password so you don't have to check your email next time.
+					</Trans>
+				</BannerBody>
+			</BannerCopy>
+			<BannerActions>
+				<PriButton
+					type='button'
+					$variant='filled'
+					onClick={handleSetPassword}
+					disabled={busy}
+					data-testid='set-password-nudge-go'
+				>
+					<Trans>Set password</Trans>
+				</PriButton>
+				<TextButton
+					type='button'
+					onClick={handleOptOut}
+					disabled={busy}
+					data-testid='set-password-nudge-opt-out'
+				>
+					<Trans>I prefer passwordless</Trans>
+				</TextButton>
+				<DismissButton
+					type='button'
+					onClick={handleDismiss}
+					aria-label='Dismiss'
+					data-testid='set-password-nudge-dismiss'
+				>
+					<X size={16} />
+				</DismissButton>
+			</BannerActions>
+		</Banner>
+	)
+}
+
+function isLocallyDismissed(): boolean {
+	if (typeof window === 'undefined') return false
+	try {
+		const raw = window.localStorage.getItem(DISMISS_STORAGE_KEY)
+		if (!raw) return false
+		const parsed = JSON.parse(raw) as Partial<DismissEntry>
+		if (typeof parsed.until !== 'number') return false
+		return parsed.until > Date.now()
+	} catch {
+		return false
+	}
+}
+
+function persistLocalDismiss(): void {
+	if (typeof window === 'undefined') return
+	const entry: DismissEntry = {
+		userKey: 'current',
+		until: Date.now() + 24 * 60 * 60 * 1000,
+	}
+	try {
+		window.localStorage.setItem(DISMISS_STORAGE_KEY, JSON.stringify(entry))
+	} catch {
+		// Ignore quota or privacy-mode errors; nudge will reappear after reload.
+	}
+}
+
+const Banner = styled.section.withConfig({
+	displayName: 'SetPasswordNudge',
+})`
+	${agedPaperSurface}
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: var(--space-md);
+	padding: var(--space-md) var(--space-lg);
+	flex-wrap: wrap;
+	color: var(--color-on-surface);
+`
+
+const Tape = styled.span.withConfig({ displayName: 'SetPasswordNudgeTape' })`
+	${maskingTapeCorner}
+`
+
+const Bezel = styled.span.withConfig({ displayName: 'SetPasswordNudgeBezel' })`
+	${brushedMetalBezel}
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: 50%;
+	color: var(--color-on-surface);
+	flex-shrink: 0;
+`
+
+const BannerCopy = styled.div.withConfig({
+	displayName: 'SetPasswordNudgeCopy',
+})`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+	flex: 1 1 240px;
+	min-width: 240px;
+`
+
+const BannerTitle = styled.p.withConfig({
+	displayName: 'SetPasswordNudgeTitle',
+})`
+	${stenciledTitle}
+	margin: 0;
+	font-size: var(--typescale-title-small-size);
+	line-height: var(--typescale-title-small-line);
+`
+
+const BannerBody = styled.p.withConfig({
+	displayName: 'SetPasswordNudgeBody',
+})`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	line-height: var(--typescale-body-medium-line);
+	color: var(--color-on-surface-variant);
+	font-style: italic;
+`
+
+const BannerActions = styled.div.withConfig({
+	displayName: 'SetPasswordNudgeActions',
+})`
+	display: flex;
+	align-items: center;
+	gap: var(--space-sm);
+	flex-wrap: wrap;
+`
+
+const TextButton = styled.button.withConfig({
+	displayName: 'SetPasswordNudgeTextButton',
+})`
+	background: none;
+	border: none;
+	padding: var(--space-2xs) 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	cursor: pointer;
+	text-decoration: underline;
+
+	&:hover:not(:disabled) {
+		color: var(--color-on-surface);
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+`
+
+const DismissButton = styled.button.withConfig({
+	displayName: 'SetPasswordNudgeDismissButton',
+})`
+	background: none;
+	border: none;
+	padding: var(--space-2xs);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--color-on-surface-variant);
+	cursor: pointer;
+	border-radius: var(--shape-2xs);
+
+	&:hover {
+		color: var(--color-on-surface);
+		background: color-mix(in srgb, var(--color-on-surface) 8%, transparent);
+	}
+`

--- a/apps/internal/src/lib/security-state.ts
+++ b/apps/internal/src/lib/security-state.ts
@@ -1,0 +1,139 @@
+import { apiBaseUrl } from './api-base'
+
+/**
+ * Composes Better Auth's `/auth/get-session` and `/auth/list-accounts`
+ * into the two booleans the profile card and nudge banner render against.
+ * No custom server route: `passwordOptOut` rides on the user payload as
+ * a `user.additionalFields` column, and `hasPassword` is derived from
+ * the credential row in `/auth/list-accounts`.
+ *
+ * SSR branching mirrors `fetchSession`: server callers pass an explicit
+ * `Cookie` header (loaders can't read `document.cookie`); browser callers
+ * pass `undefined` and rely on `credentials: 'include'`.
+ */
+
+const AUTH_COOKIE_PATTERN = /^(?:__Secure-|__Host-)?batuda[._-]/
+
+function filterAuthCookies(header: string): string {
+	return header
+		.split(';')
+		.map(cookie => cookie.trim())
+		.filter(cookie => {
+			const eq = cookie.indexOf('=')
+			const name = eq === -1 ? cookie : cookie.slice(0, eq)
+			return AUTH_COOKIE_PATTERN.test(name)
+		})
+		.join('; ')
+}
+
+export interface SecurityState {
+	readonly hasPassword: boolean
+	readonly passwordOptOut: boolean
+}
+
+interface AccountSummary {
+	readonly providerId?: unknown
+}
+
+export async function fetchSecurityState(
+	cookieHeader: string | undefined,
+): Promise<SecurityState | null> {
+	const base = apiBaseUrl()
+	if (typeof window === 'undefined' && !base) return null
+	const headers: Record<string, string> = { accept: 'application/json' }
+	if (cookieHeader) {
+		const filtered = filterAuthCookies(cookieHeader)
+		if (filtered) headers['cookie'] = filtered
+	}
+	try {
+		const [sessionRes, accountsRes] = await Promise.all([
+			fetch(`${base}/auth/get-session`, {
+				method: 'GET',
+				headers,
+				credentials: 'include',
+			}),
+			fetch(`${base}/auth/list-accounts`, {
+				method: 'GET',
+				headers,
+				credentials: 'include',
+			}),
+		])
+		if (!sessionRes.ok || !accountsRes.ok) return null
+		const sessionBody = (await sessionRes.json()) as unknown
+		if (
+			!sessionBody ||
+			typeof sessionBody !== 'object' ||
+			!('user' in sessionBody)
+		) {
+			return null
+		}
+		const user = (sessionBody as { user?: { passwordOptOut?: unknown } }).user
+		if (!user || typeof user !== 'object') return null
+
+		const accountsBody = (await accountsRes.json()) as unknown
+		if (!Array.isArray(accountsBody)) return null
+		const hasPassword = (accountsBody as AccountSummary[]).some(
+			account => account.providerId === 'credential',
+		)
+		return {
+			hasPassword,
+			passwordOptOut: user.passwordOptOut === true,
+		}
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Flip the `passwordOptOut` flag on the current user. `/auth/update-user`
+ * refreshes the session cookie's cached user record in the same response,
+ * so the next `fetchSession` sees the new value with no separate invalidation.
+ */
+export async function setPasswordOptOut(optOut: boolean): Promise<boolean> {
+	const base = apiBaseUrl()
+	const res = await fetch(`${base}/auth/update-user`, {
+		method: 'POST',
+		credentials: 'include',
+		headers: {
+			'content-type': 'application/json',
+			accept: 'application/json',
+		},
+		body: JSON.stringify({ passwordOptOut: optOut }),
+	})
+	return res.ok
+}
+
+export interface SetPasswordResult {
+	readonly ok: boolean
+	readonly code?: string
+}
+
+/**
+ * Bind a first password for the current session. Returns a code-keyed
+ * result (mirroring Better Auth's `{ code, message }` body) so the caller
+ * can render a locale-stable error without parsing the human message.
+ */
+export async function setFirstPassword(
+	newPassword: string,
+): Promise<SetPasswordResult> {
+	const base = apiBaseUrl()
+	const res = await fetch(`${base}/auth/set-password`, {
+		method: 'POST',
+		credentials: 'include',
+		headers: {
+			'content-type': 'application/json',
+			accept: 'application/json',
+		},
+		body: JSON.stringify({ newPassword }),
+	})
+	if (res.ok) return { ok: true }
+	try {
+		const body = (await res.json()) as { code?: unknown }
+		if (typeof body.code === 'string') {
+			return { ok: false, code: body.code }
+		}
+		return { ok: false }
+	} catch {
+		return { ok: false }
+	}
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -380,8 +380,8 @@ msgstr "Cc"
 msgid "Change my mind — set a password anyway"
 msgstr "Canvio d'opinió — vull posar contrasenya"
 
-#: src/routes/profile/index.tsx:381
-#: src/routes/profile/index.tsx:468
+#: src/routes/profile/index.tsx:387
+#: src/routes/profile/index.tsx:474
 msgid "Change password"
 msgstr "Canvia la contrasenya"
 
@@ -744,11 +744,11 @@ msgstr "Creada"
 msgid "Created by agent"
 msgstr "Creada per agent"
 
-#: src/routes/profile/index.tsx:395
+#: src/routes/profile/index.tsx:401
 msgid "Current password"
 msgstr "Contrasenya actual"
 
-#: src/routes/profile/index.tsx:445
+#: src/routes/profile/index.tsx:451
 msgid "Current password is incorrect."
 msgstr "La contrasenya actual no és correcta."
 
@@ -1446,7 +1446,7 @@ msgid "never"
 msgstr "mai"
 
 #: src/routes/profile/index.tsx:229
-#: src/routes/profile/index.tsx:407
+#: src/routes/profile/index.tsx:413
 msgid "New password"
 msgstr "Contrasenya nova"
 
@@ -1844,7 +1844,7 @@ msgstr "Contrasenya"
 msgid "Password or app-password"
 msgstr "Contrasenya o contrasenya d'aplicació"
 
-#: src/routes/profile/index.tsx:455
+#: src/routes/profile/index.tsx:461
 msgid "Password updated."
 msgstr "Contrasenya actualitzada."
 
@@ -1853,7 +1853,7 @@ msgid "Passwordless sign-in only"
 msgstr "Només inici de sessió sense contrasenya"
 
 #: src/routes/profile/index.tsx:255
-#: src/routes/profile/index.tsx:433
+#: src/routes/profile/index.tsx:439
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "La contrasenya ha de tenir com a mínim {MIN_PASSWORD_LENGTH} caràcters."
 
@@ -1881,7 +1881,7 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Telèfon"
 
-#: src/routes/profile/index.tsx:384
+#: src/routes/profile/index.tsx:390
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Tria una contrasenya nova. Els altres dispositius es desconnectaran."
 
@@ -2088,7 +2088,7 @@ msgid "Reopen thread"
 msgstr "Reobre el fil"
 
 #: src/routes/profile/index.tsx:242
-#: src/routes/profile/index.tsx:420
+#: src/routes/profile/index.tsx:426
 msgid "Repeat new password"
 msgstr "Repeteix la contrasenya nova"
 
@@ -2185,7 +2185,7 @@ msgstr "Desa la contrasenya"
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
 #: src/routes/profile/index.tsx:278
-#: src/routes/profile/index.tsx:466
+#: src/routes/profile/index.tsx:472
 msgid "Saving…"
 msgstr "Desant…"
 
@@ -2376,7 +2376,7 @@ msgid "someone"
 msgstr "algú"
 
 #: src/routes/profile/index.tsx:267
-#: src/routes/profile/index.tsx:450
+#: src/routes/profile/index.tsx:456
 msgid "Something went wrong. Try again."
 msgstr "Alguna cosa ha fallat. Prova-ho de nou."
 
@@ -2557,7 +2557,7 @@ msgstr "El fil existeix però el proveïdor no ha retornat cap missatge."
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "Potser el fil s'ha arxivat al proveïdor o l'enllaç és obsolet."
 
-#: src/routes/profile/index.tsx:440
+#: src/routes/profile/index.tsx:446
 msgid "The two new password fields don't match."
 msgstr "Les dues contrasenyes noves no coincideixen."
 

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -140,7 +140,7 @@ msgstr "Activa"
 msgid "Active client"
 msgstr "Client actiu"
 
-#: src/routes/index.tsx:269
+#: src/routes/index.tsx:272
 msgid "Active companies"
 msgstr "Empreses actives"
 
@@ -208,7 +208,7 @@ msgstr "Tots els estats"
 msgid "All time"
 msgstr "Tot el temps"
 
-#: src/routes/index.tsx:300
+#: src/routes/index.tsx:303
 msgid "All under control"
 msgstr "Tot sota control"
 
@@ -282,7 +282,7 @@ msgstr "Batuda — un CRM multi-inquilí per a petites agències."
 msgid "Batuda home"
 msgstr "Inici de Batuda"
 
-#: src/routes/login.tsx:389
+#: src/routes/login.tsx:392
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda és només amb invitació. Demana accés a l'equip d'Engranatge."
 
@@ -376,6 +376,15 @@ msgstr "Cancel·la la pujada"
 msgid "Cc"
 msgstr "Cc"
 
+#: src/routes/profile/index.tsx:327
+msgid "Change my mind — set a password anyway"
+msgstr "Canvio d'opinió — vull posar contrasenya"
+
+#: src/routes/profile/index.tsx:381
+#: src/routes/profile/index.tsx:468
+msgid "Change password"
+msgstr "Canvia la contrasenya"
+
 #: src/routes/emails/inboxes.tsx:933
 msgid "Change password (re-probes the connection)"
 msgstr "Canvia la contrasenya (reprova la connexió)"
@@ -410,7 +419,7 @@ msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
 msgid "Check the session or try again."
 msgstr "Comprova la sessió o torna-ho a provar."
 
-#: src/routes/login.tsx:427
+#: src/routes/login.tsx:430
 msgid "Check your inbox"
 msgstr "Mira la safata d'entrada"
 
@@ -496,9 +505,9 @@ msgstr "Empreses"
 #: src/components/interactions/quick-capture-dialog.tsx:209
 #: src/routes/emails/$threadId.tsx:427
 #: src/routes/emails/$threadId.tsx:467
-#: src/routes/index.tsx:315
-#: src/routes/index.tsx:392
-#: src/routes/index.tsx:432
+#: src/routes/index.tsx:318
+#: src/routes/index.tsx:395
+#: src/routes/index.tsx:435
 msgid "Company"
 msgstr "Empresa"
 
@@ -694,6 +703,10 @@ msgstr "No s'ha pogut canviar d'organització. Torna-ho a provar."
 msgid "Could not toggle the inbox state."
 msgstr "No s'ha pogut canviar l'estat de la safata."
 
+#: src/routes/profile/index.tsx:332
+msgid "Couldn't update your preference. Try again."
+msgstr "No he pogut desar la teva preferència. Prova-ho de nou."
+
 #: src/routes/emails/inboxes.tsx:1465
 msgid "Create"
 msgstr "Crea"
@@ -730,6 +743,14 @@ msgstr "Creada"
 #: src/components/shared/task-item.tsx:336
 msgid "Created by agent"
 msgstr "Creada per agent"
+
+#: src/routes/profile/index.tsx:395
+msgid "Current password"
+msgstr "Contrasenya actual"
+
+#: src/routes/profile/index.tsx:445
+msgid "Current password is incorrect."
+msgstr "La contrasenya actual no és correcta."
 
 #: src/components/companies/about-section.tsx:100
 #: src/components/research/findings/company-enrichment-view.tsx:82
@@ -892,7 +913,7 @@ msgstr "Editor"
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
-#: src/routes/login.tsx:331
+#: src/routes/login.tsx:334
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Correu"
@@ -909,7 +930,7 @@ msgstr "Esborranys de correu"
 msgid "Email is dead-letter"
 msgstr "El correu electrònic és no entregable"
 
-#: src/routes/login.tsx:380
+#: src/routes/login.tsx:383
 msgid "Email me a sign-in link"
 msgstr "Envia'm un enllaç per correu"
 
@@ -1055,7 +1076,7 @@ msgstr "Alta"
 
 #: src/components/shared/priority-dot.tsx:47
 #: src/components/shared/task-item.tsx:309
-#: src/routes/index.tsx:459
+#: src/routes/index.tsx:462
 msgid "High priority"
 msgstr "Prioritat alta"
 
@@ -1063,6 +1084,14 @@ msgstr "Prioritat alta"
 #: src/routes/emails/inboxes.tsx:987
 msgid "Human"
 msgstr "Humà"
+
+#: src/components/profile/set-password-nudge.tsx:114
+msgid "I prefer passwordless"
+msgstr "Prefereixo sense contrasenya"
+
+#: src/routes/profile/index.tsx:289
+msgid "I prefer passwordless — don't ask me again"
+msgstr "Prefereixo sense contrasenya — no m'ho tornis a preguntar"
 
 #: src/routes/emails/inboxes.tsx:857
 msgid "IMAP host"
@@ -1151,7 +1180,7 @@ msgstr "Convida un membre"
 msgid "Invite a new member"
 msgstr "Convida un nou membre"
 
-#: src/routes/login.tsx:434
+#: src/routes/login.tsx:437
 msgid "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 msgstr "Caduca en {MAGIC_LINK_EXPIRY_MINUTES} minuts. No el veus? Mira el correu brossa."
 
@@ -1177,7 +1206,7 @@ msgstr "Idioma"
 
 #: src/components/profile/language-select.tsx:34
 #: src/routes/pages/$id.tsx:311
-#: src/routes/profile/index.tsx:121
+#: src/routes/profile/index.tsx:119
 msgid "Language"
 msgstr "Idioma"
 
@@ -1405,7 +1434,7 @@ msgstr "Nom"
 msgid "name@example.com, another@example.com"
 msgstr "nom@exemple.cat, altre@exemple.cat"
 
-#: src/routes/index.tsx:289
+#: src/routes/index.tsx:292
 msgid "Needs attention"
 msgstr "Necessita atenció"
 
@@ -1415,6 +1444,11 @@ msgstr "Necessita atenció"
 #: src/routes/companies/$slug.tsx:828
 msgid "never"
 msgstr "mai"
+
+#: src/routes/profile/index.tsx:229
+#: src/routes/profile/index.tsx:407
+msgid "New password"
+msgstr "Contrasenya nova"
 
 #: src/routes/emails/inboxes.tsx:942
 msgid "New password or app-password"
@@ -1522,7 +1556,7 @@ msgstr "Sense data de venciment"
 msgid "No footers"
 msgstr "Sense peus de pàgina"
 
-#: src/routes/index.tsx:462
+#: src/routes/index.tsx:465
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "Cap empresa d'alta prioritat sense seguiment programat"
 
@@ -1546,7 +1580,7 @@ msgstr "No hi ha missatges en aquest fil"
 msgid "No open tasks."
 msgstr "Cap tasca oberta."
 
-#: src/routes/index.tsx:301
+#: src/routes/index.tsx:304
 msgid "No overdue tasks, no pending follow-ups, no neglected companies."
 msgstr "Sense tasques endarrerides, sense seguiments pendents, sense empreses oblidades."
 
@@ -1584,7 +1618,7 @@ msgstr "No hi ha troballes estructurades."
 msgid "No tags yet"
 msgstr "Encara sense etiquetes"
 
-#: src/routes/index.tsx:379
+#: src/routes/index.tsx:382
 msgid "No tasks for today"
 msgstr "Cap tasca per a avui"
 
@@ -1596,7 +1630,7 @@ msgstr "Cap fil coincideix amb els filtres"
 msgid "No threads yet"
 msgstr "Encara no hi ha fils"
 
-#: src/routes/index.tsx:419
+#: src/routes/index.tsx:422
 msgid "No upcoming due dates"
 msgstr "Sense venciments propers"
 
@@ -1643,7 +1677,7 @@ msgid "Open"
 msgstr "Obert"
 
 #. placeholder {0}: provider.label
-#: src/routes/login.tsx:467
+#: src/routes/login.tsx:470
 msgid "Open {0}"
 msgstr "Obre {0}"
 
@@ -1686,7 +1720,7 @@ msgid "Open task details"
 msgstr "Obre els detalls de la tasca"
 
 #: src/components/companies/open-tasks-card.tsx:39
-#: src/routes/index.tsx:270
+#: src/routes/index.tsx:273
 msgid "Open tasks"
 msgstr "Tasques obertes"
 
@@ -1739,7 +1773,7 @@ msgstr "Resultat"
 msgid "Outcome: {0}"
 msgstr "Resultat: {0}"
 
-#: src/routes/index.tsx:271
+#: src/routes/index.tsx:274
 #: src/routes/tasks/index.tsx:446
 #: src/routes/tasks/index.tsx:466
 msgid "Overdue"
@@ -1802,13 +1836,26 @@ msgstr "Indicadors de dolor"
 msgid "Pain points"
 msgstr "Punts febles"
 
-#: src/routes/login.tsx:346
+#: src/routes/login.tsx:349
 msgid "Password"
 msgstr "Contrasenya"
 
 #: src/routes/emails/inboxes.tsx:943
 msgid "Password or app-password"
 msgstr "Contrasenya o contrasenya d'aplicació"
+
+#: src/routes/profile/index.tsx:455
+msgid "Password updated."
+msgstr "Contrasenya actualitzada."
+
+#: src/routes/profile/index.tsx:315
+msgid "Passwordless sign-in only"
+msgstr "Només inici de sessió sense contrasenya"
+
+#: src/routes/profile/index.tsx:255
+#: src/routes/profile/index.tsx:433
+msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
+msgstr "La contrasenya ha de tenir com a mínim {MIN_PASSWORD_LENGTH} caràcters."
 
 #: src/components/research/findings/shared.tsx:143
 msgid "Pending paid actions"
@@ -1834,6 +1881,10 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Telèfon"
 
+#: src/routes/profile/index.tsx:384
+msgid "Pick a new password. Other signed-in devices will be signed out."
+msgstr "Tria una contrasenya nova. Els altres dispositius es desconnectaran."
+
 #: src/routes/emails/inboxes.tsx:803
 msgid "Pick a provider"
 msgstr "Tria un proveïdor"
@@ -1847,7 +1898,7 @@ msgid "Pick one to use as your default sender."
 msgstr "Tria'n una com a remitent per defecte."
 
 #: src/components/layout/nav-items.ts:38
-#: src/routes/index.tsx:261
+#: src/routes/index.tsx:262
 msgid "Pipeline"
 msgstr "Pipeline"
 
@@ -1899,7 +1950,7 @@ msgstr "Encaix de productes"
 
 #: src/components/layout/nav-items.ts:81
 #: src/routes/companies/$slug.tsx:1082
-#: src/routes/profile/index.tsx:91
+#: src/routes/profile/index.tsx:89
 msgid "Profile"
 msgstr "Perfil"
 
@@ -2036,6 +2087,11 @@ msgstr "Reobre"
 msgid "Reopen thread"
 msgstr "Reobre el fil"
 
+#: src/routes/profile/index.tsx:242
+#: src/routes/profile/index.tsx:420
+msgid "Repeat new password"
+msgstr "Repeteix la contrasenya nova"
+
 #: src/routes/emails/$threadId.tsx:403
 msgid "Reply"
 msgstr "Respon"
@@ -2053,11 +2109,11 @@ msgstr "Recerca"
 msgid "Research run"
 msgstr "Recerca"
 
-#: src/routes/login.tsx:449
+#: src/routes/login.tsx:452
 msgid "Resend in"
 msgstr "Torna a enviar en"
 
-#: src/routes/login.tsx:455
+#: src/routes/login.tsx:458
 msgid "Resend link"
 msgstr "Torna a enviar l'enllaç"
 
@@ -2121,9 +2177,15 @@ msgstr "Desa"
 msgid "Save failed"
 msgstr "Ha fallat el desament"
 
+#: src/routes/profile/index.tsx:280
+msgid "Save password"
+msgstr "Desa la contrasenya"
+
 #: src/components/emails/compose-form.tsx:547
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
+#: src/routes/profile/index.tsx:278
+#: src/routes/profile/index.tsx:466
 msgid "Saving…"
 msgstr "Desant…"
 
@@ -2189,7 +2251,7 @@ msgid "Send invitation"
 msgstr "Envia invitació"
 
 #: src/components/emails/compose-form.tsx:534
-#: src/routes/login.tsx:379
+#: src/routes/login.tsx:382
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
 msgstr "Enviant…"
@@ -2198,9 +2260,21 @@ msgstr "Enviant…"
 msgid "Sent"
 msgstr "Enviat"
 
+#: src/routes/profile/index.tsx:218
+msgid "Set a password"
+msgstr "Posa una contrasenya"
+
+#: src/components/profile/set-password-nudge.tsx:93
+msgid "Set a password so you don't have to check your email next time."
+msgstr "Posa una contrasenya per no haver de mirar el correu la pròxima vegada."
+
 #: src/routes/emails/inboxes.tsx:1368
 msgid "Set as default"
 msgstr "Estableix com a predeterminat"
+
+#: src/components/profile/set-password-nudge.tsx:106
+msgid "Set password"
+msgstr "Posa contrasenya"
 
 #: src/routes/pages/$id.tsx:290
 msgid "Settings"
@@ -2237,7 +2311,7 @@ msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Mostrant {firstRow}–{lastRow} de {total}"
 
 #: src/routes/accept-invitation.$id.tsx:129
-#: src/routes/login.tsx:368
+#: src/routes/login.tsx:371
 msgid "Sign in"
 msgstr "Inicia sessió"
 
@@ -2245,11 +2319,11 @@ msgstr "Inicia sessió"
 msgid "Sign in to accept this invitation"
 msgstr "Inicia sessió per acceptar aquesta invitació"
 
-#: src/routes/login.tsx:321
+#: src/routes/login.tsx:324
 msgid "Sign in to continue"
 msgstr "Inicia sessió per continuar"
 
-#: src/routes/profile/index.tsx:136
+#: src/routes/profile/index.tsx:138
 msgid "Sign out"
 msgstr "Tanca sessió"
 
@@ -2257,11 +2331,11 @@ msgstr "Tanca sessió"
 msgid "Sign-out failed. Please try again."
 msgstr "No s'ha pogut tancar la sessió. Torna-ho a provar."
 
-#: src/routes/login.tsx:368
+#: src/routes/login.tsx:371
 msgid "Signing in…"
 msgstr "Iniciant sessió…"
 
-#: src/routes/profile/index.tsx:136
+#: src/routes/profile/index.tsx:138
 msgid "Signing out…"
 msgstr "Tancant sessió…"
 
@@ -2300,6 +2374,11 @@ msgstr "Posposades"
 #: src/routes/emails/$threadId.tsx:260
 msgid "someone"
 msgstr "algú"
+
+#: src/routes/profile/index.tsx:267
+#: src/routes/profile/index.tsx:450
+msgid "Something went wrong. Try again."
+msgstr "Alguna cosa ha fallat. Prova-ho de nou."
 
 #: src/components/companies/about-section.tsx:82
 #: src/routes/calendar/index.tsx:273
@@ -2478,6 +2557,14 @@ msgstr "El fil existeix però el proveïdor no ha retornat cap missatge."
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "Potser el fil s'ha arxivat al proveïdor o l'enllaç és obsolet."
 
+#: src/routes/profile/index.tsx:440
+msgid "The two new password fields don't match."
+msgstr "Les dues contrasenyes noves no coincideixen."
+
+#: src/routes/profile/index.tsx:262
+msgid "The two password fields don't match."
+msgstr "Les dues contrasenyes no coincideixen."
+
 #: src/routes/tasks/index.tsx:440
 msgid "The workshop ledger — tear off one strip at a time."
 msgstr "El llibre del taller — arrenca-n'hi una tira cada vegada."
@@ -2510,7 +2597,7 @@ msgstr "Aquest enllaç de la invitació ja no és vàlid. Pot haver-se utilitzat
 msgid "This month"
 msgstr "Aquest mes"
 
-#: src/routes/index.tsx:417
+#: src/routes/index.tsx:420
 #: src/routes/tasks/index.tsx:474
 msgid "This week"
 msgstr "Aquesta setmana"
@@ -2548,7 +2635,7 @@ msgstr "TLS"
 msgid "To"
 msgstr "Per a"
 
-#: src/routes/index.tsx:377
+#: src/routes/index.tsx:380
 #: src/routes/tasks/index.tsx:458
 msgid "Today"
 msgstr "Avui"
@@ -2586,7 +2673,7 @@ msgstr "desconegut"
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: src/routes/profile/index.tsx:84
+#: src/routes/profile/index.tsx:82
 msgid "Unknown user"
 msgstr "Usuari desconegut"
 
@@ -2624,7 +2711,7 @@ msgstr "Pujant…"
 msgid "Use {0} as primary"
 msgstr "Fes servir {0} com a principal"
 
-#: src/routes/login.tsx:477
+#: src/routes/login.tsx:480
 msgid "Use a different email"
 msgstr "Fes servir un altre correu"
 
@@ -2636,7 +2723,7 @@ msgstr "Utilitza com a peu de pàgina predeterminat"
 msgid "Use as default for this purpose"
 msgstr "Usa com a per defecte per a aquest propòsit"
 
-#: src/routes/login.tsx:484
+#: src/routes/login.tsx:487
 msgid "Use password instead"
 msgstr "Fes servir contrasenya"
 
@@ -2669,7 +2756,7 @@ msgstr "No s'ha pogut iniciar sessió amb aquest enllaç. Torna-ho a provar."
 msgid "We don't recognize that email. Ask an admin to invite you."
 msgstr "No reconeixem aquest correu. Demana a un administrador que t'inviti."
 
-#: src/routes/login.tsx:430
+#: src/routes/login.tsx:433
 msgid "We sent a sign-in link to"
 msgstr "S'ha enviat un enllaç d'inici de sessió a"
 
@@ -2721,7 +2808,7 @@ msgstr "On"
 msgid "Who"
 msgstr "Qui"
 
-#: src/routes/index.tsx:264
+#: src/routes/index.tsx:265
 msgid "Workshop floor — live counters on the bench."
 msgstr "Planta del taller — comptadors en viu al banc."
 
@@ -2733,9 +2820,21 @@ msgstr "Escriu el peu de pàgina…"
 msgid "Write your message…"
 msgstr "Escriu el teu missatge…"
 
+#: src/routes/profile/index.tsx:221
+msgid "You currently sign in from email links. Add a password to skip checking your email next time."
+msgstr "Ara mateix entres des d'enllaços al correu. Afegeix una contrasenya per no haver de mirar el correu la pròxima vegada."
+
 #: src/routes/settings/organization/spend.tsx:99
 msgid "You don't have permission to see this page."
 msgstr "No tens permís per veure aquesta pàgina."
+
+#: src/components/profile/set-password-nudge.tsx:90
+msgid "You got in from a link in your email."
+msgstr "Has entrat des d'un enllaç al teu correu."
+
+#: src/routes/profile/index.tsx:318
+msgid "You sign in from email links. I won't bring it up again."
+msgstr "Entres des d'enllaços al correu. No t'ho tornaré a esmentar."
 
 #: src/routes/accept-invitation.$id.tsx:166
 msgid "You're now a member of {orgName}."
@@ -2749,7 +2848,7 @@ msgstr "Ja ets membre."
 msgid "you@example.com"
 msgstr "tu@exemple.com"
 
-#: src/routes/profile/index.tsx:94
+#: src/routes/profile/index.tsx:92
 msgid "Your Batuda workbench identity."
 msgstr "La teva identitat al banc de Batuda."
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -140,7 +140,7 @@ msgstr "Active"
 msgid "Active client"
 msgstr "Active client"
 
-#: src/routes/index.tsx:269
+#: src/routes/index.tsx:272
 msgid "Active companies"
 msgstr "Active companies"
 
@@ -208,7 +208,7 @@ msgstr "All statuses"
 msgid "All time"
 msgstr "All time"
 
-#: src/routes/index.tsx:300
+#: src/routes/index.tsx:303
 msgid "All under control"
 msgstr "All under control"
 
@@ -282,7 +282,7 @@ msgstr "Batuda — a multi-tenant CRM for small agencies."
 msgid "Batuda home"
 msgstr "Batuda home"
 
-#: src/routes/login.tsx:389
+#: src/routes/login.tsx:392
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda is invite-only. Request access from the Engranatge team."
 
@@ -376,6 +376,15 @@ msgstr "Cancel upload"
 msgid "Cc"
 msgstr "Cc"
 
+#: src/routes/profile/index.tsx:327
+msgid "Change my mind — set a password anyway"
+msgstr "Change my mind — set a password anyway"
+
+#: src/routes/profile/index.tsx:381
+#: src/routes/profile/index.tsx:468
+msgid "Change password"
+msgstr "Change password"
+
 #: src/routes/emails/inboxes.tsx:933
 msgid "Change password (re-probes the connection)"
 msgstr "Change password (re-probes the connection)"
@@ -410,7 +419,7 @@ msgstr "Check that your session is valid or try again."
 msgid "Check the session or try again."
 msgstr "Check the session or try again."
 
-#: src/routes/login.tsx:427
+#: src/routes/login.tsx:430
 msgid "Check your inbox"
 msgstr "Check your inbox"
 
@@ -496,9 +505,9 @@ msgstr "Companies"
 #: src/components/interactions/quick-capture-dialog.tsx:209
 #: src/routes/emails/$threadId.tsx:427
 #: src/routes/emails/$threadId.tsx:467
-#: src/routes/index.tsx:315
-#: src/routes/index.tsx:392
-#: src/routes/index.tsx:432
+#: src/routes/index.tsx:318
+#: src/routes/index.tsx:395
+#: src/routes/index.tsx:435
 msgid "Company"
 msgstr "Company"
 
@@ -694,6 +703,10 @@ msgstr "Could not switch organization. Please try again."
 msgid "Could not toggle the inbox state."
 msgstr "Could not toggle the inbox state."
 
+#: src/routes/profile/index.tsx:332
+msgid "Couldn't update your preference. Try again."
+msgstr "Couldn't update your preference. Try again."
+
 #: src/routes/emails/inboxes.tsx:1465
 msgid "Create"
 msgstr "Create"
@@ -730,6 +743,14 @@ msgstr "Created"
 #: src/components/shared/task-item.tsx:336
 msgid "Created by agent"
 msgstr "Created by agent"
+
+#: src/routes/profile/index.tsx:395
+msgid "Current password"
+msgstr "Current password"
+
+#: src/routes/profile/index.tsx:445
+msgid "Current password is incorrect."
+msgstr "Current password is incorrect."
 
 #: src/components/companies/about-section.tsx:100
 #: src/components/research/findings/company-enrichment-view.tsx:82
@@ -892,7 +913,7 @@ msgstr "Editor"
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
-#: src/routes/login.tsx:331
+#: src/routes/login.tsx:334
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Email"
@@ -909,7 +930,7 @@ msgstr "Email drafts"
 msgid "Email is dead-letter"
 msgstr "Email is dead-letter"
 
-#: src/routes/login.tsx:380
+#: src/routes/login.tsx:383
 msgid "Email me a sign-in link"
 msgstr "Email me a sign-in link"
 
@@ -1055,7 +1076,7 @@ msgstr "High"
 
 #: src/components/shared/priority-dot.tsx:47
 #: src/components/shared/task-item.tsx:309
-#: src/routes/index.tsx:459
+#: src/routes/index.tsx:462
 msgid "High priority"
 msgstr "High priority"
 
@@ -1063,6 +1084,14 @@ msgstr "High priority"
 #: src/routes/emails/inboxes.tsx:987
 msgid "Human"
 msgstr "Human"
+
+#: src/components/profile/set-password-nudge.tsx:114
+msgid "I prefer passwordless"
+msgstr "I prefer passwordless"
+
+#: src/routes/profile/index.tsx:289
+msgid "I prefer passwordless — don't ask me again"
+msgstr "I prefer passwordless — don't ask me again"
 
 #: src/routes/emails/inboxes.tsx:857
 msgid "IMAP host"
@@ -1151,7 +1180,7 @@ msgstr "Invite a member"
 msgid "Invite a new member"
 msgstr "Invite a new member"
 
-#: src/routes/login.tsx:434
+#: src/routes/login.tsx:437
 msgid "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 msgstr "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 
@@ -1177,7 +1206,7 @@ msgstr "Lang"
 
 #: src/components/profile/language-select.tsx:34
 #: src/routes/pages/$id.tsx:311
-#: src/routes/profile/index.tsx:121
+#: src/routes/profile/index.tsx:119
 msgid "Language"
 msgstr "Language"
 
@@ -1405,7 +1434,7 @@ msgstr "Name"
 msgid "name@example.com, another@example.com"
 msgstr "name@example.com, another@example.com"
 
-#: src/routes/index.tsx:289
+#: src/routes/index.tsx:292
 msgid "Needs attention"
 msgstr "Needs attention"
 
@@ -1415,6 +1444,11 @@ msgstr "Needs attention"
 #: src/routes/companies/$slug.tsx:828
 msgid "never"
 msgstr "never"
+
+#: src/routes/profile/index.tsx:229
+#: src/routes/profile/index.tsx:407
+msgid "New password"
+msgstr "New password"
 
 #: src/routes/emails/inboxes.tsx:942
 msgid "New password or app-password"
@@ -1522,7 +1556,7 @@ msgstr "No due date"
 msgid "No footers"
 msgstr "No footers"
 
-#: src/routes/index.tsx:462
+#: src/routes/index.tsx:465
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "No high-priority companies without a scheduled follow-up"
 
@@ -1546,7 +1580,7 @@ msgstr "No messages in this thread"
 msgid "No open tasks."
 msgstr "No open tasks."
 
-#: src/routes/index.tsx:301
+#: src/routes/index.tsx:304
 msgid "No overdue tasks, no pending follow-ups, no neglected companies."
 msgstr "No overdue tasks, no pending follow-ups, no neglected companies."
 
@@ -1584,7 +1618,7 @@ msgstr "No structured findings."
 msgid "No tags yet"
 msgstr "No tags yet"
 
-#: src/routes/index.tsx:379
+#: src/routes/index.tsx:382
 msgid "No tasks for today"
 msgstr "No tasks for today"
 
@@ -1596,7 +1630,7 @@ msgstr "No threads match the filters"
 msgid "No threads yet"
 msgstr "No threads yet"
 
-#: src/routes/index.tsx:419
+#: src/routes/index.tsx:422
 msgid "No upcoming due dates"
 msgstr "No upcoming due dates"
 
@@ -1643,7 +1677,7 @@ msgid "Open"
 msgstr "Open"
 
 #. placeholder {0}: provider.label
-#: src/routes/login.tsx:467
+#: src/routes/login.tsx:470
 msgid "Open {0}"
 msgstr "Open {0}"
 
@@ -1686,7 +1720,7 @@ msgid "Open task details"
 msgstr "Open task details"
 
 #: src/components/companies/open-tasks-card.tsx:39
-#: src/routes/index.tsx:270
+#: src/routes/index.tsx:273
 msgid "Open tasks"
 msgstr "Open tasks"
 
@@ -1739,7 +1773,7 @@ msgstr "Outcome"
 msgid "Outcome: {0}"
 msgstr "Outcome: {0}"
 
-#: src/routes/index.tsx:271
+#: src/routes/index.tsx:274
 #: src/routes/tasks/index.tsx:446
 #: src/routes/tasks/index.tsx:466
 msgid "Overdue"
@@ -1802,13 +1836,26 @@ msgstr "Pain indicators"
 msgid "Pain points"
 msgstr "Pain points"
 
-#: src/routes/login.tsx:346
+#: src/routes/login.tsx:349
 msgid "Password"
 msgstr "Password"
 
 #: src/routes/emails/inboxes.tsx:943
 msgid "Password or app-password"
 msgstr "Password or app-password"
+
+#: src/routes/profile/index.tsx:455
+msgid "Password updated."
+msgstr "Password updated."
+
+#: src/routes/profile/index.tsx:315
+msgid "Passwordless sign-in only"
+msgstr "Passwordless sign-in only"
+
+#: src/routes/profile/index.tsx:255
+#: src/routes/profile/index.tsx:433
+msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
+msgstr "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 
 #: src/components/research/findings/shared.tsx:143
 msgid "Pending paid actions"
@@ -1834,6 +1881,10 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Phone"
 
+#: src/routes/profile/index.tsx:384
+msgid "Pick a new password. Other signed-in devices will be signed out."
+msgstr "Pick a new password. Other signed-in devices will be signed out."
+
 #: src/routes/emails/inboxes.tsx:803
 msgid "Pick a provider"
 msgstr "Pick a provider"
@@ -1847,7 +1898,7 @@ msgid "Pick one to use as your default sender."
 msgstr "Pick one to use as your default sender."
 
 #: src/components/layout/nav-items.ts:38
-#: src/routes/index.tsx:261
+#: src/routes/index.tsx:262
 msgid "Pipeline"
 msgstr "Pipeline"
 
@@ -1899,7 +1950,7 @@ msgstr "Products fit"
 
 #: src/components/layout/nav-items.ts:81
 #: src/routes/companies/$slug.tsx:1082
-#: src/routes/profile/index.tsx:91
+#: src/routes/profile/index.tsx:89
 msgid "Profile"
 msgstr "Profile"
 
@@ -2036,6 +2087,11 @@ msgstr "Reopen"
 msgid "Reopen thread"
 msgstr "Reopen thread"
 
+#: src/routes/profile/index.tsx:242
+#: src/routes/profile/index.tsx:420
+msgid "Repeat new password"
+msgstr "Repeat new password"
+
 #: src/routes/emails/$threadId.tsx:403
 msgid "Reply"
 msgstr "Reply"
@@ -2053,11 +2109,11 @@ msgstr "Research"
 msgid "Research run"
 msgstr "Research run"
 
-#: src/routes/login.tsx:449
+#: src/routes/login.tsx:452
 msgid "Resend in"
 msgstr "Resend in"
 
-#: src/routes/login.tsx:455
+#: src/routes/login.tsx:458
 msgid "Resend link"
 msgstr "Resend link"
 
@@ -2121,9 +2177,15 @@ msgstr "Save"
 msgid "Save failed"
 msgstr "Save failed"
 
+#: src/routes/profile/index.tsx:280
+msgid "Save password"
+msgstr "Save password"
+
 #: src/components/emails/compose-form.tsx:547
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
+#: src/routes/profile/index.tsx:278
+#: src/routes/profile/index.tsx:466
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2189,7 +2251,7 @@ msgid "Send invitation"
 msgstr "Send invitation"
 
 #: src/components/emails/compose-form.tsx:534
-#: src/routes/login.tsx:379
+#: src/routes/login.tsx:382
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
 msgstr "Sending…"
@@ -2198,9 +2260,21 @@ msgstr "Sending…"
 msgid "Sent"
 msgstr "Sent"
 
+#: src/routes/profile/index.tsx:218
+msgid "Set a password"
+msgstr "Set a password"
+
+#: src/components/profile/set-password-nudge.tsx:93
+msgid "Set a password so you don't have to check your email next time."
+msgstr "Set a password so you don't have to check your email next time."
+
 #: src/routes/emails/inboxes.tsx:1368
 msgid "Set as default"
 msgstr "Set as default"
+
+#: src/components/profile/set-password-nudge.tsx:106
+msgid "Set password"
+msgstr "Set password"
 
 #: src/routes/pages/$id.tsx:290
 msgid "Settings"
@@ -2237,7 +2311,7 @@ msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Showing {firstRow}–{lastRow} of {total}"
 
 #: src/routes/accept-invitation.$id.tsx:129
-#: src/routes/login.tsx:368
+#: src/routes/login.tsx:371
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -2245,11 +2319,11 @@ msgstr "Sign in"
 msgid "Sign in to accept this invitation"
 msgstr "Sign in to accept this invitation"
 
-#: src/routes/login.tsx:321
+#: src/routes/login.tsx:324
 msgid "Sign in to continue"
 msgstr "Sign in to continue"
 
-#: src/routes/profile/index.tsx:136
+#: src/routes/profile/index.tsx:138
 msgid "Sign out"
 msgstr "Sign out"
 
@@ -2257,11 +2331,11 @@ msgstr "Sign out"
 msgid "Sign-out failed. Please try again."
 msgstr "Sign-out failed. Please try again."
 
-#: src/routes/login.tsx:368
+#: src/routes/login.tsx:371
 msgid "Signing in…"
 msgstr "Signing in…"
 
-#: src/routes/profile/index.tsx:136
+#: src/routes/profile/index.tsx:138
 msgid "Signing out…"
 msgstr "Signing out…"
 
@@ -2300,6 +2374,11 @@ msgstr "Snoozed"
 #: src/routes/emails/$threadId.tsx:260
 msgid "someone"
 msgstr "someone"
+
+#: src/routes/profile/index.tsx:267
+#: src/routes/profile/index.tsx:450
+msgid "Something went wrong. Try again."
+msgstr "Something went wrong. Try again."
 
 #: src/components/companies/about-section.tsx:82
 #: src/routes/calendar/index.tsx:273
@@ -2478,6 +2557,14 @@ msgstr "The thread exists but the provider returned no messages."
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "The thread may have been archived upstream or the link is stale."
 
+#: src/routes/profile/index.tsx:440
+msgid "The two new password fields don't match."
+msgstr "The two new password fields don't match."
+
+#: src/routes/profile/index.tsx:262
+msgid "The two password fields don't match."
+msgstr "The two password fields don't match."
+
 #: src/routes/tasks/index.tsx:440
 msgid "The workshop ledger — tear off one strip at a time."
 msgstr "The workshop ledger — tear off one strip at a time."
@@ -2510,7 +2597,7 @@ msgstr "This invitation link is no longer valid. It may have already been used."
 msgid "This month"
 msgstr "This month"
 
-#: src/routes/index.tsx:417
+#: src/routes/index.tsx:420
 #: src/routes/tasks/index.tsx:474
 msgid "This week"
 msgstr "This week"
@@ -2548,7 +2635,7 @@ msgstr "TLS"
 msgid "To"
 msgstr "To"
 
-#: src/routes/index.tsx:377
+#: src/routes/index.tsx:380
 #: src/routes/tasks/index.tsx:458
 msgid "Today"
 msgstr "Today"
@@ -2586,7 +2673,7 @@ msgstr "unknown"
 msgid "Unknown"
 msgstr "Unknown"
 
-#: src/routes/profile/index.tsx:84
+#: src/routes/profile/index.tsx:82
 msgid "Unknown user"
 msgstr "Unknown user"
 
@@ -2624,7 +2711,7 @@ msgstr "Uploading…"
 msgid "Use {0} as primary"
 msgstr "Use {0} as primary"
 
-#: src/routes/login.tsx:477
+#: src/routes/login.tsx:480
 msgid "Use a different email"
 msgstr "Use a different email"
 
@@ -2636,7 +2723,7 @@ msgstr "Use as default footer"
 msgid "Use as default for this purpose"
 msgstr "Use as default for this purpose"
 
-#: src/routes/login.tsx:484
+#: src/routes/login.tsx:487
 msgid "Use password instead"
 msgstr "Use password instead"
 
@@ -2669,7 +2756,7 @@ msgstr "We couldn't sign you in via that link. Try again."
 msgid "We don't recognize that email. Ask an admin to invite you."
 msgstr "We don't recognize that email. Ask an admin to invite you."
 
-#: src/routes/login.tsx:430
+#: src/routes/login.tsx:433
 msgid "We sent a sign-in link to"
 msgstr "We sent a sign-in link to"
 
@@ -2721,7 +2808,7 @@ msgstr "Where"
 msgid "Who"
 msgstr "Who"
 
-#: src/routes/index.tsx:264
+#: src/routes/index.tsx:265
 msgid "Workshop floor — live counters on the bench."
 msgstr "Workshop floor — live counters on the bench."
 
@@ -2733,9 +2820,21 @@ msgstr "Write footer…"
 msgid "Write your message…"
 msgstr "Write your message…"
 
+#: src/routes/profile/index.tsx:221
+msgid "You currently sign in from email links. Add a password to skip checking your email next time."
+msgstr "You currently sign in from email links. Add a password to skip checking your email next time."
+
 #: src/routes/settings/organization/spend.tsx:99
 msgid "You don't have permission to see this page."
 msgstr "You don't have permission to see this page."
+
+#: src/components/profile/set-password-nudge.tsx:90
+msgid "You got in from a link in your email."
+msgstr "You got in from a link in your email."
+
+#: src/routes/profile/index.tsx:318
+msgid "You sign in from email links. I won't bring it up again."
+msgstr "You sign in from email links. I won't bring it up again."
 
 #: src/routes/accept-invitation.$id.tsx:166
 msgid "You're now a member of {orgName}."
@@ -2749,7 +2848,7 @@ msgstr "You're now a member."
 msgid "you@example.com"
 msgstr "you@example.com"
 
-#: src/routes/profile/index.tsx:94
+#: src/routes/profile/index.tsx:92
 msgid "Your Batuda workbench identity."
 msgstr "Your Batuda workbench identity."
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -380,8 +380,8 @@ msgstr "Cc"
 msgid "Change my mind — set a password anyway"
 msgstr "Change my mind — set a password anyway"
 
-#: src/routes/profile/index.tsx:381
-#: src/routes/profile/index.tsx:468
+#: src/routes/profile/index.tsx:387
+#: src/routes/profile/index.tsx:474
 msgid "Change password"
 msgstr "Change password"
 
@@ -744,11 +744,11 @@ msgstr "Created"
 msgid "Created by agent"
 msgstr "Created by agent"
 
-#: src/routes/profile/index.tsx:395
+#: src/routes/profile/index.tsx:401
 msgid "Current password"
 msgstr "Current password"
 
-#: src/routes/profile/index.tsx:445
+#: src/routes/profile/index.tsx:451
 msgid "Current password is incorrect."
 msgstr "Current password is incorrect."
 
@@ -1446,7 +1446,7 @@ msgid "never"
 msgstr "never"
 
 #: src/routes/profile/index.tsx:229
-#: src/routes/profile/index.tsx:407
+#: src/routes/profile/index.tsx:413
 msgid "New password"
 msgstr "New password"
 
@@ -1844,7 +1844,7 @@ msgstr "Password"
 msgid "Password or app-password"
 msgstr "Password or app-password"
 
-#: src/routes/profile/index.tsx:455
+#: src/routes/profile/index.tsx:461
 msgid "Password updated."
 msgstr "Password updated."
 
@@ -1853,7 +1853,7 @@ msgid "Passwordless sign-in only"
 msgstr "Passwordless sign-in only"
 
 #: src/routes/profile/index.tsx:255
-#: src/routes/profile/index.tsx:433
+#: src/routes/profile/index.tsx:439
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 
@@ -1881,7 +1881,7 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Phone"
 
-#: src/routes/profile/index.tsx:384
+#: src/routes/profile/index.tsx:390
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Pick a new password. Other signed-in devices will be signed out."
 
@@ -2088,7 +2088,7 @@ msgid "Reopen thread"
 msgstr "Reopen thread"
 
 #: src/routes/profile/index.tsx:242
-#: src/routes/profile/index.tsx:420
+#: src/routes/profile/index.tsx:426
 msgid "Repeat new password"
 msgstr "Repeat new password"
 
@@ -2185,7 +2185,7 @@ msgstr "Save password"
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
 #: src/routes/profile/index.tsx:278
-#: src/routes/profile/index.tsx:466
+#: src/routes/profile/index.tsx:472
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2376,7 +2376,7 @@ msgid "someone"
 msgstr "someone"
 
 #: src/routes/profile/index.tsx:267
-#: src/routes/profile/index.tsx:450
+#: src/routes/profile/index.tsx:456
 msgid "Something went wrong. Try again."
 msgstr "Something went wrong. Try again."
 
@@ -2557,7 +2557,7 @@ msgstr "The thread exists but the provider returned no messages."
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "The thread may have been archived upstream or the link is stale."
 
-#: src/routes/profile/index.tsx:440
+#: src/routes/profile/index.tsx:446
 msgid "The two new password fields don't match."
 msgstr "The two new password fields don't match."
 

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
 import { companiesListAtom, openTasksAtom } from '#/atoms/pipeline-atoms'
+import { SetPasswordNudge } from '#/components/profile/set-password-nudge'
 import { CompanyCard } from '#/components/shared/company-card'
 import { EmptyState } from '#/components/shared/empty-state'
 import { KpiCounter } from '#/components/shared/kpi-counter'
@@ -264,6 +265,8 @@ function PipelinePage() {
 					<Trans>Workshop floor — live counters on the bench.</Trans>
 				</Subtitle>
 			</Intro>
+
+			<SetPasswordNudge />
 
 			<KpiRow>
 				<KpiCounter value={companies.length} label={t`Active companies`} />

--- a/apps/internal/src/routes/profile/index.tsx
+++ b/apps/internal/src/routes/profile/index.tsx
@@ -1,13 +1,21 @@
 import { Trans, useLingui } from '@lingui/react/macro'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router'
 import { LogOut, Mail, UserCircle2 } from 'lucide-react'
-import { useActionState } from 'react'
+import { useActionState, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { PriButton } from '@batuda/ui/pri'
 
+import { PriPasswordInput } from '#/components/primitives/pri-password-input'
 import { LanguageSelect } from '#/components/profile/language-select'
 import { apiBaseUrl } from '#/lib/api-base'
+import { authClient } from '#/lib/auth-client'
+import {
+	fetchSecurityState,
+	type SecurityState,
+	setFirstPassword,
+	setPasswordOptOut,
+} from '#/lib/security-state'
 import { getServerCookieHeader } from '#/lib/server-cookie'
 import { fetchSession, type SessionUser } from '#/lib/session-check'
 import {
@@ -16,16 +24,7 @@ import {
 	stenciledTitle,
 } from '#/lib/workshop-mixins'
 
-/**
- * Profile page.
- *
- * Loads the current session via `fetchSession` (same helper the root
- * guard uses) so the route renders the signed-in user's name + email.
- * The sign-out button POSTs to Better-Auth's `/auth/sign-out` endpoint
- * and then client-navigates to `/login` — the root guard won't let us
- * stay on `/profile` once the cookie is gone, so the redirect is both
- * correctness and UX.
- */
+const MIN_PASSWORD_LENGTH = 8
 
 export const Route = createFileRoute('/profile/')({
 	loader: async () => {
@@ -33,8 +32,11 @@ export const Route = createFileRoute('/profile/')({
 		if (import.meta.env.SSR) {
 			cookieHeader = (await getServerCookieHeader()) ?? undefined
 		}
-		const user = await fetchSession(cookieHeader)
-		return { user }
+		const [user, securityState] = await Promise.all([
+			fetchSession(cookieHeader),
+			fetchSecurityState(cookieHeader),
+		])
+		return { user, securityState }
 	},
 	head: () => ({ meta: [{ title: 'Profile — Batuda' }] }),
 	component: ProfilePage,
@@ -44,42 +46,38 @@ interface SignOutState {
 	readonly error: string | null
 }
 
-const INITIAL_STATE: SignOutState = { error: null }
+const INITIAL_SIGN_OUT_STATE: SignOutState = { error: null }
 
 function ProfilePage() {
 	const { t } = useLingui()
-	const { user } = Route.useLoaderData() as { user: SessionUser | null }
+	const { user, securityState } = Route.useLoaderData() as {
+		user: SessionUser | null
+		securityState: SecurityState | null
+	}
 	const navigate = useNavigate()
 
-	// React 19 form action mirrors login.tsx — React queues the submit
-	// even before hydration completes, so a click during the hydration
-	// gap is dispatched safely instead of falling through to a native
-	// form submit.
-	const [state, formAction, isPending] = useActionState<SignOutState, FormData>(
-		async () => {
-			try {
-				const res = await fetch(`${apiBaseUrl()}/auth/sign-out`, {
-					method: 'POST',
-					credentials: 'include',
-					headers: { 'content-type': 'application/json' },
-					// Better Auth's sign-out parses the body as JSON; send an
-					// empty object rather than no body so the parser doesn't
-					// throw SyntaxError on an empty string.
-					body: '{}',
-				})
-				if (!res.ok) {
-					return { error: t`Sign-out failed. Please try again.` }
-				}
-				await navigate({ to: '/login' })
-				return { error: null }
-			} catch {
-				return {
-					error: t`No connection to the server. Try again in a few seconds.`,
-				}
+	const [signOutState, signOutAction, isSigningOut] = useActionState<
+		SignOutState,
+		FormData
+	>(async () => {
+		try {
+			const res = await fetch(`${apiBaseUrl()}/auth/sign-out`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'content-type': 'application/json' },
+				body: '{}',
+			})
+			if (!res.ok) {
+				return { error: t`Sign-out failed. Please try again.` }
 			}
-		},
-		INITIAL_STATE,
-	)
+			await navigate({ to: '/login' })
+			return { error: null }
+		} catch {
+			return {
+				error: t`No connection to the server. Try again in a few seconds.`,
+			}
+		}
+	}, INITIAL_SIGN_OUT_STATE)
 
 	const displayName = user?.name ?? user?.email ?? t`Unknown user`
 	const initial = displayName.charAt(0).toUpperCase() || 'U'
@@ -123,20 +121,362 @@ function ProfilePage() {
 				<LanguageSelect />
 			</LanguageRow>
 
-			{state.error ? <ErrorText role='alert'>{state.error}</ErrorText> : null}
+			{securityState ? <PasswordCard state={securityState} /> : null}
 
-			<SignOutForm action={formAction}>
+			{signOutState.error ? (
+				<ErrorText role='alert'>{signOutState.error}</ErrorText>
+			) : null}
+
+			<SignOutForm action={signOutAction}>
 				<PriButton
 					type='submit'
 					$variant='filled'
 					data-testid='profile-signout'
-					disabled={isPending}
+					disabled={isSigningOut}
 				>
 					<LogOut size={16} />
-					<span>{isPending ? t`Signing out…` : t`Sign out`}</span>
+					<span>{isSigningOut ? t`Signing out…` : t`Sign out`}</span>
 				</PriButton>
 			</SignOutForm>
 		</Page>
+	)
+}
+
+interface PasswordCardProps {
+	readonly state: SecurityState
+}
+
+function PasswordCard({ state }: PasswordCardProps) {
+	if (state.hasPassword) {
+		return <ChangePasswordCard />
+	}
+	if (state.passwordOptOut) {
+		return <OptedOutCard />
+	}
+	return <SetPasswordCard />
+}
+
+function SetPasswordCard() {
+	const router = useRouter()
+	const [status, setStatus] = useState<
+		| 'idle'
+		| 'submitting'
+		| 'mismatch'
+		| 'too-short'
+		| 'already-set'
+		| 'error'
+		| 'opting-out'
+	>('idle')
+
+	// Inputs stay DOM-owned and are read via FormData on submit: BaseUI's
+	// FieldControl wires its own `onValueChange`, so a React `value`+`onChange`
+	// pair would never update and the field would appear empty.
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault()
+		const form = new FormData(event.currentTarget)
+		const newPassword = String(form.get('newPassword') ?? '')
+		const confirmPassword = String(form.get('newPasswordConfirm') ?? '')
+		if (newPassword.length < MIN_PASSWORD_LENGTH) {
+			setStatus('too-short')
+			return
+		}
+		if (newPassword !== confirmPassword) {
+			setStatus('mismatch')
+			return
+		}
+		setStatus('submitting')
+		const result = await setFirstPassword(newPassword)
+		if (!result.ok) {
+			// PASSWORD_ALREADY_SET fires when another tab beat us to it.
+			// Re-render the loader so the card flips to the change form.
+			if (result.code === 'PASSWORD_ALREADY_SET') {
+				setStatus('already-set')
+				await router.invalidate()
+				return
+			}
+			setStatus('error')
+			return
+		}
+		setStatus('idle')
+		await router.invalidate()
+	}
+
+	const handleOptOut = async () => {
+		setStatus('opting-out')
+		const ok = await setPasswordOptOut(true)
+		if (!ok) {
+			setStatus('error')
+			return
+		}
+		setStatus('idle')
+		await router.invalidate()
+	}
+
+	return (
+		<SecurityCard data-testid='profile-password-card'>
+			<SecurityCardHeading>
+				<Trans>Set a password</Trans>
+			</SecurityCardHeading>
+			<SecurityCardBody>
+				<Trans>
+					You currently sign in from email links. Add a password to skip
+					checking your email next time.
+				</Trans>
+			</SecurityCardBody>
+			<PasswordForm onSubmit={handleSubmit} data-testid='set-password-form'>
+				<FieldRow>
+					<FieldLabel htmlFor='set-password-new'>
+						<Trans>New password</Trans>
+					</FieldLabel>
+					<PriPasswordInput
+						id='set-password-new'
+						name='newPassword'
+						autoComplete='new-password'
+						required
+						minLength={MIN_PASSWORD_LENGTH}
+						data-testid='set-password-new'
+					/>
+				</FieldRow>
+				<FieldRow>
+					<FieldLabel htmlFor='set-password-confirm'>
+						<Trans>Repeat new password</Trans>
+					</FieldLabel>
+					<PriPasswordInput
+						id='set-password-confirm'
+						name='newPasswordConfirm'
+						autoComplete='new-password'
+						required
+						minLength={MIN_PASSWORD_LENGTH}
+						data-testid='set-password-confirm'
+					/>
+				</FieldRow>
+				{status === 'too-short' ? (
+					<StatusText role='alert' data-testid='set-password-error'>
+						<Trans>
+							Passwords need at least {MIN_PASSWORD_LENGTH} characters.
+						</Trans>
+					</StatusText>
+				) : null}
+				{status === 'mismatch' ? (
+					<StatusText role='alert' data-testid='set-password-error'>
+						<Trans>The two password fields don't match.</Trans>
+					</StatusText>
+				) : null}
+				{status === 'error' ? (
+					<StatusText role='alert' data-testid='set-password-error'>
+						<Trans>Something went wrong. Try again.</Trans>
+					</StatusText>
+				) : null}
+				<ActionsRow>
+					<PriButton
+						type='submit'
+						$variant='filled'
+						disabled={status === 'submitting' || status === 'opting-out'}
+						data-testid='set-password-submit'
+					>
+						{status === 'submitting' ? (
+							<Trans>Saving…</Trans>
+						) : (
+							<Trans>Save password</Trans>
+						)}
+					</PriButton>
+					<TextButton
+						type='button'
+						onClick={handleOptOut}
+						disabled={status === 'submitting' || status === 'opting-out'}
+						data-testid='passwordless-only-toggle'
+					>
+						<Trans>I prefer passwordless — don't ask me again</Trans>
+					</TextButton>
+				</ActionsRow>
+			</PasswordForm>
+		</SecurityCard>
+	)
+}
+
+function OptedOutCard() {
+	const router = useRouter()
+	const [status, setStatus] = useState<'idle' | 'undoing' | 'error'>('idle')
+
+	const handleUndo = async () => {
+		setStatus('undoing')
+		const ok = await setPasswordOptOut(false)
+		if (!ok) {
+			setStatus('error')
+			return
+		}
+		setStatus('idle')
+		await router.invalidate()
+	}
+
+	return (
+		<SecurityCard data-testid='profile-password-card-opted-out'>
+			<SecurityCardHeading>
+				<Trans>Passwordless sign-in only</Trans>
+			</SecurityCardHeading>
+			<SecurityCardBody>
+				<Trans>You sign in from email links. I won't bring it up again.</Trans>
+			</SecurityCardBody>
+			<ActionsRow>
+				<TextButton
+					type='button'
+					onClick={handleUndo}
+					disabled={status === 'undoing'}
+					data-testid='passwordless-only-undo'
+				>
+					<Trans>Change my mind — set a password anyway</Trans>
+				</TextButton>
+			</ActionsRow>
+			{status === 'error' ? (
+				<StatusText role='alert' data-testid='set-password-error'>
+					<Trans>Couldn't update your preference. Try again.</Trans>
+				</StatusText>
+			) : null}
+		</SecurityCard>
+	)
+}
+
+function ChangePasswordCard() {
+	const formRef = useRef<HTMLFormElement | null>(null)
+	const [status, setStatus] = useState<
+		| 'idle'
+		| 'submitting'
+		| 'mismatch'
+		| 'too-short'
+		| 'wrong-current'
+		| 'error'
+		| 'success'
+	>('idle')
+
+	// Uncontrolled inputs; see SetPasswordCard for the rationale
+	// (BaseUI FieldControl owns onChange, so React controlled state
+	// never updates from typing).
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault()
+		const form = new FormData(event.currentTarget)
+		const currentPassword = String(form.get('currentPassword') ?? '')
+		const newPassword = String(form.get('newPassword') ?? '')
+		const confirmPassword = String(form.get('newPasswordConfirm') ?? '')
+		if (newPassword.length < MIN_PASSWORD_LENGTH) {
+			setStatus('too-short')
+			return
+		}
+		if (newPassword !== confirmPassword) {
+			setStatus('mismatch')
+			return
+		}
+		setStatus('submitting')
+		const { error } = await authClient.changePassword({
+			currentPassword,
+			newPassword,
+			revokeOtherSessions: true,
+		})
+		if (error) {
+			// `changePassword` returns INVALID_PASSWORD when the current password
+			// doesn't match — code stays stable across locale, message doesn't.
+			setStatus(error.code === 'INVALID_PASSWORD' ? 'wrong-current' : 'error')
+			return
+		}
+		formRef.current?.reset()
+		setStatus('success')
+	}
+
+	return (
+		<SecurityCard data-testid='profile-password-card'>
+			<SecurityCardHeading>
+				<Trans>Change password</Trans>
+			</SecurityCardHeading>
+			<SecurityCardBody>
+				<Trans>
+					Pick a new password. Other signed-in devices will be signed out.
+				</Trans>
+			</SecurityCardBody>
+			<PasswordForm
+				ref={formRef}
+				onSubmit={handleSubmit}
+				data-testid='change-password-form'
+			>
+				<FieldRow>
+					<FieldLabel htmlFor='change-password-current'>
+						<Trans>Current password</Trans>
+					</FieldLabel>
+					<PriPasswordInput
+						id='change-password-current'
+						name='currentPassword'
+						autoComplete='current-password'
+						required
+						data-testid='change-password-current'
+					/>
+				</FieldRow>
+				<FieldRow>
+					<FieldLabel htmlFor='change-password-new'>
+						<Trans>New password</Trans>
+					</FieldLabel>
+					<PriPasswordInput
+						id='change-password-new'
+						name='newPassword'
+						autoComplete='new-password'
+						required
+						minLength={MIN_PASSWORD_LENGTH}
+						data-testid='change-password-new'
+					/>
+				</FieldRow>
+				<FieldRow>
+					<FieldLabel htmlFor='change-password-confirm'>
+						<Trans>Repeat new password</Trans>
+					</FieldLabel>
+					<PriPasswordInput
+						id='change-password-confirm'
+						name='newPasswordConfirm'
+						autoComplete='new-password'
+						required
+						minLength={MIN_PASSWORD_LENGTH}
+						data-testid='change-password-confirm'
+					/>
+				</FieldRow>
+				{status === 'too-short' ? (
+					<StatusText role='alert' data-testid='change-password-error'>
+						<Trans>
+							Passwords need at least {MIN_PASSWORD_LENGTH} characters.
+						</Trans>
+					</StatusText>
+				) : null}
+				{status === 'mismatch' ? (
+					<StatusText role='alert' data-testid='change-password-error'>
+						<Trans>The two new password fields don't match.</Trans>
+					</StatusText>
+				) : null}
+				{status === 'wrong-current' ? (
+					<StatusText role='alert' data-testid='change-password-error'>
+						<Trans>Current password is incorrect.</Trans>
+					</StatusText>
+				) : null}
+				{status === 'error' ? (
+					<StatusText role='alert' data-testid='change-password-error'>
+						<Trans>Something went wrong. Try again.</Trans>
+					</StatusText>
+				) : null}
+				{status === 'success' ? (
+					<SuccessText role='status' data-testid='change-password-success'>
+						<Trans>Password updated.</Trans>
+					</SuccessText>
+				) : null}
+				<ActionsRow>
+					<PriButton
+						type='submit'
+						$variant='filled'
+						disabled={status === 'submitting'}
+						data-testid='change-password-submit'
+					>
+						{status === 'submitting' ? (
+							<Trans>Saving…</Trans>
+						) : (
+							<Trans>Change password</Trans>
+						)}
+					</PriButton>
+				</ActionsRow>
+			</PasswordForm>
+		</SecurityCard>
 	)
 }
 
@@ -272,6 +612,109 @@ const LanguageRowLabel = styled.span.withConfig({
 	font-size: var(--typescale-label-large-size);
 	line-height: var(--typescale-label-large-line);
 	letter-spacing: 0.08em;
+`
+
+const SecurityCard = styled.section.withConfig({
+	displayName: 'ProfileSecurityCard',
+})`
+	${brushedMetalPlate}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+	padding: var(--space-md);
+	border-radius: var(--shape-2xs);
+`
+
+const SecurityCardHeading = styled.h3.withConfig({
+	displayName: 'ProfileSecurityHeading',
+})`
+	${stenciledTitle}
+	font-size: var(--typescale-title-medium-size);
+	line-height: var(--typescale-title-medium-line);
+	margin: 0;
+`
+
+const SecurityCardBody = styled.p.withConfig({
+	displayName: 'ProfileSecurityBody',
+})`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	line-height: var(--typescale-body-small-line);
+	color: var(--color-on-surface-variant);
+`
+
+const PasswordForm = styled.form.withConfig({
+	displayName: 'ProfilePasswordForm',
+})`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+`
+
+const FieldRow = styled.div.withConfig({ displayName: 'ProfileFieldRow' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const FieldLabel = styled.label.withConfig({
+	displayName: 'ProfileFieldLabel',
+})`
+	font-family: var(--font-body);
+	font-size: var(--typescale-label-medium-size);
+	line-height: var(--typescale-label-medium-line);
+	color: var(--color-on-surface-variant);
+`
+
+const ActionsRow = styled.div.withConfig({ displayName: 'ProfileActionsRow' })`
+	display: flex;
+	align-items: center;
+	gap: var(--space-md);
+	flex-wrap: wrap;
+`
+
+const TextButton = styled.button.withConfig({
+	displayName: 'ProfileTextButton',
+})`
+	background: none;
+	border: none;
+	padding: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	cursor: pointer;
+	text-decoration: underline;
+
+	&:hover:not(:disabled) {
+		color: var(--color-on-surface);
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+`
+
+const StatusText = styled.p.withConfig({ displayName: 'ProfileStatusText' })`
+	margin: 0;
+	padding: var(--space-2xs) var(--space-sm);
+	border-left: 3px solid var(--color-error);
+	background: color-mix(in srgb, var(--color-error) 6%, transparent);
+	color: var(--color-error);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+`
+
+const SuccessText = styled.p.withConfig({ displayName: 'ProfileSuccessText' })`
+	margin: 0;
+	padding: var(--space-2xs) var(--space-sm);
+	border-left: 3px solid var(--color-primary);
+	background: color-mix(in srgb, var(--color-primary) 6%, transparent);
+	color: var(--color-primary);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
 `
 
 const ErrorText = styled.p.withConfig({ displayName: 'ProfileError' })`

--- a/apps/internal/tests/e2e/profile-password.test.ts
+++ b/apps/internal/tests/e2e/profile-password.test.ts
@@ -1,0 +1,265 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
+// End-to-end set/change password from /profile. The flow under test:
+//
+//   1. Alice invites a fresh user → org plugin's sendInvitationEmail
+//      pre-creates them without a password and ships a magic-link
+//      sign-in URL to apps/server/.dev-inbox/.
+//   2. A fresh browser context opens the URL: BA's magic-link verify
+//      signs the new user in. Their `account` table has no credential
+//      row, so `fetchSecurityState` derives `hasPassword: false`.
+//   3. /profile renders the "Set a password" form (the three-state card's
+//      `!hasPassword && !passwordOptOut` branch).
+//   4. Submitting the form hits POST /auth/set-password (the thin BA
+//      plugin route at apps/server/src/plugins/set-password-route.ts).
+//   5. After router.invalidate(), the card flips to "Change password"
+//      because the loader re-fetches hasPassword and gets true.
+//   6. The opt-out path POSTs { passwordOptOut: true } to
+//      /auth/update-user — the card collapses to the passwordless-only
+//      confirmed state with an undo affordance.
+//
+// Selectors and branches verified against:
+//   apps/internal/src/routes/profile/index.tsx
+//   apps/server/src/plugins/set-password-route.ts
+//   apps/internal/src/lib/security-state.ts
+
+const INBOX_DIR = join(process.cwd(), '..', 'server', '.dev-inbox')
+
+const NEW_PASSWORD = 'first-real-password-1234'
+
+interface InvitationMail {
+	readonly file: string
+	readonly url: string
+}
+
+// Polls .dev-inbox/ for an `invitation`-labelled .md whose filename
+// contains the recipient slug, then extracts the magic-link URL. Same
+// pattern as invite.test.ts:44-89 — the file appears asynchronously
+// after the API responds.
+async function pollInvitationMail(
+	recipient: string,
+	timeoutMs: number,
+): Promise<InvitationMail> {
+	const slug = recipient.split('@')[0]!
+	const deadline = Date.now() + timeoutMs
+	let lastErr: unknown
+	while (Date.now() < deadline) {
+		try {
+			const files = await readdir(INBOX_DIR)
+			const match = files
+				.filter(name => name.includes(slug) && name.endsWith('.md'))
+				.sort()
+				.pop()
+			if (match) {
+				const body = await readFile(join(INBOX_DIR, match), 'utf8')
+				if (!body.includes('labels:') || !body.includes('invitation')) {
+					await new Promise(r => {
+						setTimeout(r, 200)
+					})
+					continue
+				}
+				const urlMatch = body.match(
+					/https?:\/\/[^\s]*\/auth\/magic-link\/verify[^\s]*/,
+				)
+				if (urlMatch) return { file: match, url: urlMatch[0] }
+			}
+		} catch (e) {
+			lastErr = e
+		}
+		await new Promise(r => {
+			setTimeout(r, 200)
+		})
+	}
+	throw new Error(
+		`invitation .md for ${recipient} did not appear within ${timeoutMs}ms (last error: ${String(lastErr)})`,
+	)
+}
+
+// Mints a fresh passwordless user via the invitation flow and returns a
+// BrowserContext + Page authenticated as that user. Two contexts are
+// required: Alice's session sends the invite, and a separate context
+// follows the magic link so we end up authed as the invitee, not Alice.
+async function bootPasswordlessInvitee(
+	alicePage: Page,
+	browser: import('@playwright/test').Browser,
+	emailHint: string,
+): Promise<{
+	email: string
+	context: BrowserContext
+	page: Page
+}> {
+	const email = `${emailHint}-${Date.now()}@example.com`
+
+	await alicePage.goto('/settings/organization/invite', {
+		waitUntil: 'networkidle',
+	})
+	await alicePage.getByTestId('invite-email').fill(email)
+	await alicePage.getByTestId('invite-role').selectOption('member')
+	await alicePage.getByTestId('invite-submit').click()
+	await expect(alicePage.getByTestId('invite-success')).toBeVisible({
+		timeout: 10_000,
+	})
+
+	const mail = await pollInvitationMail(email, 5_000)
+	const inviteeContext = await browser.newContext({ ignoreHTTPSErrors: true })
+	const inviteePage = await inviteeContext.newPage()
+	await inviteePage.goto(mail.url, { waitUntil: 'networkidle' })
+	await expect(
+		inviteePage.getByTestId('accept-invitation-success'),
+	).toBeVisible({ timeout: 15_000 })
+
+	return { email, context: inviteeContext, page: inviteePage }
+}
+
+test.describe('setting a first password from /profile', () => {
+	test.beforeEach(async ({ page }) => {
+		// Sibling tests may have flipped Alice's active org; reset before
+		// each scenario so /settings/organization/invite resolves to taller.
+		await page.goto('/', { waitUntil: 'commit' })
+		await setActiveOrgBySlug(page, 'taller')
+	})
+
+	test.describe('when a passwordless user opens /profile', () => {
+		test('should render the set-password form, accept a new password, and flip to change-password', async ({
+			page,
+			browser,
+		}) => {
+			// GIVEN a freshly invited user with no credential row
+			//   [profile/index.tsx — `!hasPassword && !passwordOptOut` branch]
+			const bob = await bootPasswordlessInvitee(page, browser, 'pwd-set')
+
+			// WHEN Bob opens /profile
+			await bob.page.goto('/profile', { waitUntil: 'networkidle' })
+
+			// THEN the set-password form should render — not the change-password
+			// form, and not the opted-out confirmed state.
+			await expect(bob.page.getByTestId('set-password-form')).toBeVisible({
+				timeout: 10_000,
+			})
+			await expect(bob.page.getByTestId('change-password-form')).toHaveCount(0)
+			await expect(
+				bob.page.getByTestId('profile-password-card-opted-out'),
+			).toHaveCount(0)
+
+			// WHEN Bob fills both password fields and submits
+			//   [set-password-route.ts — credential row written branch]
+			await bob.page.getByTestId('set-password-new').fill(NEW_PASSWORD)
+			await bob.page.getByTestId('set-password-confirm').fill(NEW_PASSWORD)
+
+			// Diagnostic: confirm fill() actually landed in the DOM input
+			// (the form reads via FormData on submit, not React state).
+			const newInputValue = await bob.page
+				.getByTestId('set-password-new')
+				.inputValue()
+			expect(
+				newInputValue,
+				'fill() should have written into the password input',
+			).toBe(NEW_PASSWORD)
+
+			// Capture the set-password response so we can diagnose 401/200.
+			const setPasswordResponse = bob.page.waitForResponse(
+				resp =>
+					resp.url().includes('/auth/set-password') &&
+					resp.request().method() === 'POST',
+				{ timeout: 5_000 },
+			)
+			await bob.page.getByTestId('set-password-submit').click()
+			const resp = await setPasswordResponse
+			expect(
+				resp.status(),
+				`POST /auth/set-password returned ${resp.status()} — body=${await resp.text()}`,
+			).toBe(200)
+
+			// THEN the loader re-invalidates and the card flips to the
+			// change-password form (proving the credential row now exists).
+			await expect(bob.page.getByTestId('change-password-form')).toBeVisible({
+				timeout: 10_000,
+			})
+			await expect(bob.page.getByTestId('set-password-form')).toHaveCount(0)
+
+			await bob.context.close()
+		})
+	})
+
+	test.describe('when a passwordless user opts out from the profile card', () => {
+		test('should swap to the passwordless-only confirmed state and offer an undo', async ({
+			page,
+			browser,
+		}) => {
+			// GIVEN a passwordless invitee on /profile
+			//   [profile/index.tsx — `passwordless-only-toggle` button]
+			const bob = await bootPasswordlessInvitee(page, browser, 'pwd-optout')
+			await bob.page.goto('/profile', { waitUntil: 'networkidle' })
+			await expect(bob.page.getByTestId('set-password-form')).toBeVisible({
+				timeout: 10_000,
+			})
+
+			// WHEN Bob clicks "I prefer passwordless"
+			//   [security-state.ts — setPasswordOptOut(true)]
+			await bob.page.getByTestId('passwordless-only-toggle').click()
+
+			// THEN the opted-out card replaces the set-password form.
+			await expect(
+				bob.page.getByTestId('profile-password-card-opted-out'),
+			).toBeVisible({ timeout: 10_000 })
+			await expect(bob.page.getByTestId('set-password-form')).toHaveCount(0)
+
+			// WHEN Bob undoes via the "Change my mind" link
+			//   [security-state.ts — setPasswordOptOut(false)]
+			await bob.page.getByTestId('passwordless-only-undo').click()
+
+			// THEN the set-password form returns, proving the flag flipped
+			// back and the loader re-fetched.
+			await expect(bob.page.getByTestId('set-password-form')).toBeVisible({
+				timeout: 10_000,
+			})
+			await expect(
+				bob.page.getByTestId('profile-password-card-opted-out'),
+			).toHaveCount(0)
+
+			await bob.context.close()
+		})
+	})
+
+	test.describe('when a password user (Alice) opens /profile', () => {
+		test('should render the change-password form and reject a wrong current password', async ({
+			page,
+		}) => {
+			// GIVEN Alice, who already has a credential row from the seed
+			//   [profile/index.tsx — `hasPassword === true` branch]
+			await page.goto('/profile', { waitUntil: 'networkidle' })
+
+			// THEN the change-password form should render, not the set form.
+			await expect(page.getByTestId('change-password-form')).toBeVisible({
+				timeout: 10_000,
+			})
+			await expect(page.getByTestId('set-password-form')).toHaveCount(0)
+
+			// WHEN Alice submits with a wrong current password
+			//   [profile/index.tsx — `INVALID_PASSWORD` branch on changePassword]
+			await page
+				.getByTestId('change-password-current')
+				.fill('this-is-not-her-current-password')
+			await page
+				.getByTestId('change-password-new')
+				.fill('would-be-the-new-password-123')
+			await page
+				.getByTestId('change-password-confirm')
+				.fill('would-be-the-new-password-123')
+			await page.getByTestId('change-password-submit').click()
+
+			// THEN the wrong-current error region surfaces. We do NOT proceed
+			// to actually change Alice's password — sibling tests rely on the
+			// seed credentials for auth.setup. Cleaning that up across the
+			// suite is out of scope for this test.
+			await expect(page.getByTestId('change-password-error')).toBeVisible({
+				timeout: 10_000,
+			})
+		})
+	})
+})

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -26,6 +26,11 @@ const authMigrate = Effect.promise(async () => {
 					required: false,
 					defaultValue: false,
 				},
+				passwordOptOut: {
+					type: 'boolean',
+					required: false,
+					defaultValue: false,
+				},
 			},
 		},
 		// `organization()` here so Better Auth's CLI generates the

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -13,6 +13,7 @@ import pg from 'pg'
 
 import { buildBetterAuthConfig } from '@batuda/auth'
 
+import { setPasswordRoute } from '../plugins/set-password-route'
 import { TransactionalEmailProvider } from '../services/transactional-email-provider'
 import { TransactionalEmailProviderLive } from '../services/transactional-email-provider-live'
 import { EnvVars } from './env'
@@ -186,6 +187,7 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 						},
 					}),
 					apiKey({ enableSessionForAPIKeys: true }),
+					setPasswordRoute(),
 					magicLink({
 						// Closes the silent-signup hole on /sign-in/magic-link.
 						// The invitation flow and CLI invite commands pre-create

--- a/apps/server/src/plugins/set-password-route.test.ts
+++ b/apps/server/src/plugins/set-password-route.test.ts
@@ -1,0 +1,197 @@
+import { betterAuth } from 'better-auth'
+import { APIError } from 'better-auth/api'
+import { admin, organization } from 'better-auth/plugins'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { buildBetterAuthConfig } from '@batuda/auth'
+
+import { setPasswordRoute } from './set-password-route'
+
+// Real Postgres on $DATABASE_URL — every email is prefixed so afterAll's
+// scoped DELETE leaves the dev seed alone.
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+const BETTER_AUTH_SECRET = process.env['BETTER_AUTH_SECRET'] ?? 'test-secret'
+
+const TEST_EMAIL_PREFIX = 'auth-it-setpwd-'
+
+const sharedPool = new pg.Pool({ connectionString: DATABASE_URL })
+
+const buildInstance = () =>
+	betterAuth(
+		buildBetterAuthConfig({
+			env: {
+				secret: BETTER_AUTH_SECRET,
+				baseURL: 'http://localhost:3010',
+				useSecureCookies: false,
+				trustedOrigins: [],
+			},
+			pool: sharedPool,
+			// `admin` exposes createUser (public sign-up is disabled);
+			// `organization` is required by the shared config's
+			// session.create.before hook that auto-picks the active org.
+			plugins: [admin(), organization(), setPasswordRoute()],
+		}),
+	)
+
+type AuthInstance = ReturnType<typeof buildInstance>
+
+const createUser = async (
+	auth: AuthInstance,
+	label: string,
+): Promise<{ email: string; password: string }> => {
+	const email = `${TEST_EMAIL_PREFIX}${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`
+	const password = 'seed-password-1234'
+	await auth.api.createUser({
+		body: { email, name: label, password },
+	})
+	return { email, password }
+}
+
+const signInAndGetCookie = async (
+	auth: AuthInstance,
+	email: string,
+	password: string,
+): Promise<string> => {
+	const result = await auth.api.signInEmail({
+		returnHeaders: true,
+		body: { email, password },
+	})
+	const cookie = result.headers.getSetCookie()[0]
+	if (!cookie) throw new Error('signInEmail did not Set-Cookie')
+	return cookie
+}
+
+const stripCredentialRow = async (email: string): Promise<void> => {
+	await sharedPool.query(
+		`DELETE FROM "account"
+		 WHERE "userId" = (SELECT id FROM "user" WHERE email = $1 LIMIT 1)
+		   AND "providerId" = 'credential'`,
+		[email],
+	)
+}
+
+afterAll(async () => {
+	await sharedPool.query(
+		`DELETE FROM "account" WHERE "userId" IN (SELECT id FROM "user" WHERE email LIKE $1)`,
+		[`${TEST_EMAIL_PREFIX}%`],
+	)
+	await sharedPool.query(
+		`DELETE FROM "session" WHERE "userId" IN (SELECT id FROM "user" WHERE email LIKE $1)`,
+		[`${TEST_EMAIL_PREFIX}%`],
+	)
+	await sharedPool.query(`DELETE FROM "user" WHERE email LIKE $1`, [
+		`${TEST_EMAIL_PREFIX}%`,
+	])
+	await sharedPool.end()
+})
+
+describe('POST /auth/set-password — passwordless user binds a first credential', () => {
+	let auth: AuthInstance
+	beforeAll(() => {
+		auth = buildInstance()
+	})
+
+	describe('given a session for a passwordless user', () => {
+		it('should write a credential row that signs in with the new password', async () => {
+			// [set-password-route.ts:42 — no-credential-row branch]
+			// GIVEN a user invited passwordless (we sign in via the throwaway
+			// password and immediately strip the credential row, mirroring the
+			// post-invite state at auth.ts:167)
+			const { email, password } = await createUser(auth, 'fresh')
+			const cookie = await signInAndGetCookie(auth, email, password)
+			await stripCredentialRow(email)
+			const newPassword = 'first-real-password-1234'
+
+			// WHEN /auth/set-password is called
+			const result = await auth.api.setPassword({
+				headers: { cookie },
+				body: { newPassword },
+			})
+
+			// THEN status:true is returned and the new credential signs in.
+			expect(result).toEqual({ status: true })
+			const reSignIn = await auth.api.signInEmail({
+				returnHeaders: true,
+				body: { email, password: newPassword },
+			})
+			expect(reSignIn.headers.getSetCookie()[0]).toBeTruthy()
+		})
+	})
+})
+
+describe('POST /auth/set-password — already-set guard', () => {
+	let auth: AuthInstance
+	beforeAll(() => {
+		auth = buildInstance()
+	})
+
+	describe('given a user who already has a credential row', () => {
+		it('should reject with PASSWORD_ALREADY_SET', async () => {
+			// [set-password-route.ts:54 — credential-row-exists branch]
+			// GIVEN a user with the seed password still in place (no strip)
+			const { email, password } = await createUser(auth, 'has')
+			const cookie = await signInAndGetCookie(auth, email, password)
+
+			// WHEN /auth/set-password is called
+			// THEN the route rejects to avoid overwriting an existing credential.
+			await expect(
+				auth.api.setPassword({
+					headers: { cookie },
+					body: { newPassword: 'a-different-password-9999' },
+				}),
+			).rejects.toBeInstanceOf(APIError)
+		})
+	})
+})
+
+describe('POST /auth/set-password — input validation', () => {
+	let auth: AuthInstance
+	beforeAll(() => {
+		auth = buildInstance()
+	})
+
+	describe('given a 7-character password (Better Auth minimum is 8)', () => {
+		it('should reject with PASSWORD_TOO_SHORT', async () => {
+			// [set-password-route.ts:38 — length floor]
+			// GIVEN a passwordless user
+			const { email, password } = await createUser(auth, 'short')
+			const cookie = await signInAndGetCookie(auth, email, password)
+			await stripCredentialRow(email)
+
+			// WHEN a short password is submitted
+			// THEN the route rejects before touching the DB.
+			await expect(
+				auth.api.setPassword({
+					headers: { cookie },
+					body: { newPassword: '1234567' },
+				}),
+			).rejects.toBeInstanceOf(APIError)
+		})
+	})
+})
+
+describe('POST /auth/set-password — without a session', () => {
+	let auth: AuthInstance
+	beforeAll(() => {
+		auth = buildInstance()
+	})
+
+	describe('when no cookie is sent', () => {
+		it('should reject with UNAUTHORIZED before the handler runs', async () => {
+			// [set-password-route.ts:34 — sensitiveSessionMiddleware gate]
+			// GIVEN no cookie
+			// WHEN /auth/set-password is invoked
+			// THEN the middleware rejects before any password hash runs.
+			await expect(
+				auth.api.setPassword({
+					headers: {},
+					body: { newPassword: 'doesnt-matter-1234' },
+				}),
+			).rejects.toBeInstanceOf(APIError)
+		})
+	})
+})

--- a/apps/server/src/plugins/set-password-route.ts
+++ b/apps/server/src/plugins/set-password-route.ts
@@ -1,0 +1,75 @@
+import { BASE_ERROR_CODES } from '@better-auth/core/error'
+import type { BetterAuthPlugin } from 'better-auth'
+import {
+	APIError,
+	createAuthEndpoint,
+	sensitiveSessionMiddleware,
+} from 'better-auth/api'
+import * as z from 'zod'
+
+/**
+ * Better Auth's built-in `setPassword` is a path-less admin escape hatch —
+ * `authClient.setPassword` is not generated and `/auth/change-password`
+ * refuses to set a first password by design. Without this route a
+ * passwordless invitee has no way to bind their own credential row.
+ *
+ * Mounted at `POST /auth/set-password`. `sensitiveSessionMiddleware` forces
+ * a fresh DB lookup so a cached cookie can't be replayed. Mirrors the core
+ * implementation at docs/repos/better-auth/.../api/routes/update-user.ts:316,
+ * including the `PASSWORD_ALREADY_SET` guard.
+ */
+export const setPasswordRoute = () => {
+	return {
+		id: 'set-password-route',
+		endpoints: {
+			setPassword: createAuthEndpoint(
+				'/set-password',
+				{
+					method: 'POST',
+					body: z.object({
+						newPassword: z.string(),
+					}),
+					use: [sensitiveSessionMiddleware],
+				},
+				async ctx => {
+					const { newPassword } = ctx.body
+					const session = ctx.context.session
+					const minLength = ctx.context.password.config.minPasswordLength
+					const maxLength = ctx.context.password.config.maxPasswordLength
+					if (newPassword.length < minLength) {
+						throw APIError.from(
+							'BAD_REQUEST',
+							BASE_ERROR_CODES.PASSWORD_TOO_SHORT,
+						)
+					}
+					if (newPassword.length > maxLength) {
+						throw APIError.from(
+							'BAD_REQUEST',
+							BASE_ERROR_CODES.PASSWORD_TOO_LONG,
+						)
+					}
+					const accounts = await ctx.context.internalAdapter.findAccounts(
+						session.user.id,
+					)
+					const credential = accounts.find(
+						account => account.providerId === 'credential' && account.password,
+					)
+					if (credential) {
+						throw APIError.from(
+							'BAD_REQUEST',
+							BASE_ERROR_CODES.PASSWORD_ALREADY_SET,
+						)
+					}
+					const passwordHash = await ctx.context.password.hash(newPassword)
+					await ctx.context.internalAdapter.linkAccount({
+						userId: session.user.id,
+						providerId: 'credential',
+						accountId: session.user.id,
+						password: passwordHash,
+					})
+					return ctx.json({ status: true })
+				},
+			),
+		},
+	} satisfies BetterAuthPlugin
+}

--- a/packages/auth/src/infrastructure/build-better-auth-config.ts
+++ b/packages/auth/src/infrastructure/build-better-auth-config.ts
@@ -90,6 +90,13 @@ export const buildBetterAuthConfig = <Plugins extends BetterAuthPlugin[]>(
 					required: false,
 					defaultValue: false,
 				},
+				// User has chosen to stay passwordless; gates the "set a password"
+				// nudge so we stop asking. Toggled via `/auth/update-user`.
+				passwordOptOut: {
+					type: 'boolean' as const,
+					required: false,
+					defaultValue: false,
+				},
 			},
 		},
 		session: {


### PR DESCRIPTION
## Summary

Lets users transition between passwordless and password authentication without leaving the app. Three surfaces:

- **`/profile` password card** — three states (set first password, change existing password, opted-out confirmed). Built on Better Auth's native `/auth/list-accounts` + `/auth/get-session` for state derivation; new `set-password-route` plugin for the first-time bind.
- **Dashboard nudge** — banner on `/` that reminds passwordless users they can bind a password, with three exit doors (Set password, I prefer passwordless, Maybe later — 24h local dismiss).
- **Opt-out is cross-device.** `passwordOptOut` is a `user.additionalFields` column flipped via Better Auth's native `/auth/update-user`; no custom endpoint.

## Why this approach

Better Auth ships almost everything we need natively (`changePassword`, `update-user`, `list-accounts`, `get-session` with additional fields). The one gap is the **set first password** flow — BA's core `setPassword` is a path-less, server-only escape hatch with no client SDK exposure. So this PR adds a single thin plugin route at `POST /auth/set-password` that mirrors BA's own implementation (gated by `sensitiveSessionMiddleware`, rejects `PASSWORD_ALREADY_SET`).

## Notes for reviewers

- **Inputs are uncontrolled** in the password card. BaseUI's `FieldControl` owns its own `onChange` and exposes `onValueChange` instead; controlled `value` + React `onChange` silently drops Playwright `fill()` updates. Memory `feedback_password_input_uncontrolled` documents this — applies to `PriPasswordInput` specifically, not `PriInput` callers in general (probed; production controlled inputs work fine).
- **Copy avoids "magic link" jargon.** Local SMB users (Batuda's target) see "from a link in your email" everywhere. Catalan translations match.
- **Sequenced after PR #24** (drop throwaway-password workaround). Builds on it: invitees are natively passwordless, the `set-password` route gives them the in-app form to bind a credential.

## Test plan

- [x] Server vitest — set-password-route covers passwordless→credential, PASSWORD_ALREADY_SET race, length floor, no-session 401.
- [x] Server vitest — `auth.test.ts` regression (admin createUser without password → no credential row; with → row).
- [x] Internal e2e — `profile-password.test.ts` covers the set/opt-out/change paths with a two-context Bob fixture; 3× consecutive runs passed.
- [x] Workspace `pnpm -w check-types && pnpm -w test` green.
- [x] i18n catalogs: 656 total, 0 missing (en/ca).