### PR TITLE
feat: forgot-password via email (slice 3)

### DIFF
--- a/apps/internal/playwright.config.ts
+++ b/apps/internal/playwright.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
 		// project. Includes the magic-link sign-in variant.
 		{
 			name: 'unauth',
-			testMatch: /sign-in(?:-magic-link)?\.test\.ts/,
+			testMatch: /(?:sign-in(?:-magic-link)?|forgot-password)\.test\.ts/,
 			use: { ...devices['Desktop Chrome'] },
 		},
 		// 3. Everything else gets Alice's cookie injected via
@@ -64,7 +64,7 @@ export default defineConfig({
 		{
 			name: 'authed',
 			testMatch: /.*\.test\.ts/,
-			testIgnore: /sign-in(?:-magic-link)?\.test\.ts/,
+			testIgnore: /(?:sign-in(?:-magic-link)?|forgot-password)\.test\.ts/,
 			use: {
 				...devices['Desktop Chrome'],
 				storageState: STORAGE_STATE,

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -270,6 +270,12 @@ msgstr "Torna a la safata"
 msgid "Back to organization"
 msgstr "Tornar a l'organització"
 
+#: src/routes/forgot-password.tsx:82
+#: src/routes/forgot-password.tsx:134
+#: src/routes/reset-password.tsx:82
+msgid "Back to sign in"
+msgstr "Torna a iniciar sessió"
+
 #: src/i18n/lingui.tsx:56
 msgid "Batuda"
 msgstr "Batuda"
@@ -282,7 +288,7 @@ msgstr "Batuda — un CRM multi-inquilí per a petites agències."
 msgid "Batuda home"
 msgstr "Inici de Batuda"
 
-#: src/routes/login.tsx:392
+#: src/routes/login.tsx:404
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda és només amb invitació. Demana accés a l'equip d'Engranatge."
 
@@ -419,7 +425,8 @@ msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
 msgid "Check the session or try again."
 msgstr "Comprova la sessió o torna-ho a provar."
 
-#: src/routes/login.tsx:430
+#: src/routes/forgot-password.tsx:65
+#: src/routes/login.tsx:442
 msgid "Check your inbox"
 msgstr "Mira la safata d'entrada"
 
@@ -675,7 +682,8 @@ msgstr "No s'ha pogut desar la pàgina. Torna-ho a provar."
 msgid "Could not send the invitation. Please try again."
 msgstr "No s'''ha pogut enviar la invitació. Torna-ho a provar."
 
-#: src/routes/login.tsx:132
+#: src/routes/forgot-password.tsx:119
+#: src/routes/login.tsx:137
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "No s'ha pogut enviar l'enllaç. Torna-ho a provar d'aquí uns segons."
 
@@ -687,7 +695,7 @@ msgstr "No s'ha pogut establir la bústia principal"
 msgid "Could not set the default inbox."
 msgstr "No s'ha pogut establir la safata per defecte."
 
-#: src/routes/login.tsx:131
+#: src/routes/login.tsx:136
 msgid "Could not sign in. Check your email and password."
 msgstr "No s'ha pogut iniciar sessió. Comprova el correu i la contrasenya."
 
@@ -913,7 +921,8 @@ msgstr "Editor"
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
-#: src/routes/login.tsx:334
+#: src/routes/forgot-password.tsx:105
+#: src/routes/login.tsx:339
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Correu"
@@ -930,11 +939,11 @@ msgstr "Esborranys de correu"
 msgid "Email is dead-letter"
 msgstr "El correu electrònic és no entregable"
 
-#: src/routes/login.tsx:383
+#: src/routes/login.tsx:388
 msgid "Email me a sign-in link"
 msgstr "Envia'm un enllaç per correu"
 
-#: src/routes/login.tsx:129
+#: src/routes/login.tsx:134
 msgid "Email or password is incorrect."
 msgstr "El correu o la contrasenya no són correctes."
 
@@ -955,7 +964,7 @@ msgstr "Els emails, trucades, documents i propostes apareixeran aquí a mesura q
 msgid "Enrichment"
 msgstr "Enriquiment"
 
-#: src/routes/login.tsx:134
+#: src/routes/login.tsx:139
 msgid "Enter a valid email above first."
 msgstr "Primer escriu un correu vàlid a sobre."
 
@@ -1034,6 +1043,10 @@ msgstr "El proveïdor l'ha marcat com a brossa. El cos es mostra només per revi
 msgid "Footers — {0}"
 msgstr "Peus de pàgina — {0}"
 
+#: src/routes/login.tsx:395
+msgid "Forgot password?"
+msgstr "Has oblidat la contrasenya?"
+
 #: src/components/research/research-dialog.tsx:31
 msgid "Freeform"
 msgstr "Lliure"
@@ -1057,6 +1070,10 @@ msgstr "Del webhook"
 #: src/components/emails/compose-window.tsx:69
 msgid "Full screen"
 msgstr "Pantalla completa"
+
+#: src/routes/reset-password.tsx:173
+msgid "Go to sign in"
+msgstr "Ves a iniciar sessió"
 
 #: src/routes/accept-invitation.$id.tsx:170
 msgid "Heading to the dashboard…"
@@ -1092,6 +1109,10 @@ msgstr "Prefereixo sense contrasenya"
 #: src/routes/profile/index.tsx:289
 msgid "I prefer passwordless — don't ask me again"
 msgstr "Prefereixo sense contrasenya — no m'ho tornis a preguntar"
+
+#: src/routes/forgot-password.tsx:68
+msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
+msgstr "Si <0>{submittedEmail}</0> està registrat, t'arribarà un enllaç per restablir la contrasenya. L'enllaç caduca en 1 hora."
 
 #: src/routes/emails/inboxes.tsx:857
 msgid "IMAP host"
@@ -1180,7 +1201,7 @@ msgstr "Convida un membre"
 msgid "Invite a new member"
 msgstr "Convida un nou membre"
 
-#: src/routes/login.tsx:437
+#: src/routes/login.tsx:449
 msgid "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 msgstr "Caduca en {MAGIC_LINK_EXPIRY_MINUTES} minuts. No el veus? Mira el correu brossa."
 
@@ -1447,6 +1468,7 @@ msgstr "mai"
 
 #: src/routes/profile/index.tsx:229
 #: src/routes/profile/index.tsx:413
+#: src/routes/reset-password.tsx:193
 msgid "New password"
 msgstr "Contrasenya nova"
 
@@ -1511,7 +1533,7 @@ msgstr "Encara no hi ha empreses"
 
 #: src/components/layout/org-switcher.tsx:62
 #: src/routes/accept-invitation.$id.tsx:98
-#: src/routes/login.tsx:133
+#: src/routes/login.tsx:138
 #: src/routes/profile/index.tsx:77
 #: src/routes/settings/organization/invite.tsx:77
 #: src/routes/settings/organization/members.tsx:81
@@ -1646,6 +1668,10 @@ msgstr "cap planificat"
 msgid "Normal priority"
 msgstr "Prioritat normal"
 
+#: src/routes/forgot-password.tsx:74
+msgid "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
+msgstr "No el veus? Mira la carpeta de correu brossa. Si estàs segur que el correu és correcte i no arriba mai, un administrador et pot ajudar."
+
 #: src/components/interactions/quick-capture-dialog.tsx:425
 msgid "Note"
 msgstr "Nota"
@@ -1677,7 +1703,7 @@ msgid "Open"
 msgstr "Obert"
 
 #. placeholder {0}: provider.label
-#: src/routes/login.tsx:470
+#: src/routes/login.tsx:482
 msgid "Open {0}"
 msgstr "Obre {0}"
 
@@ -1836,13 +1862,17 @@ msgstr "Indicadors de dolor"
 msgid "Pain points"
 msgstr "Punts febles"
 
-#: src/routes/login.tsx:349
+#: src/routes/login.tsx:354
 msgid "Password"
 msgstr "Contrasenya"
 
 #: src/routes/emails/inboxes.tsx:943
 msgid "Password or app-password"
 msgstr "Contrasenya o contrasenya d'aplicació"
+
+#: src/routes/reset-password.tsx:157
+msgid "Password updated"
+msgstr "Contrasenya actualitzada"
 
 #: src/routes/profile/index.tsx:461
 msgid "Password updated."
@@ -1854,6 +1884,7 @@ msgstr "Només inici de sessió sense contrasenya"
 
 #: src/routes/profile/index.tsx:255
 #: src/routes/profile/index.tsx:439
+#: src/routes/reset-password.tsx:221
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "La contrasenya ha de tenir com a mínim {MIN_PASSWORD_LENGTH} caràcters."
 
@@ -1884,6 +1915,10 @@ msgstr "Telèfon"
 #: src/routes/profile/index.tsx:390
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Tria una contrasenya nova. Els altres dispositius es desconnectaran."
+
+#: src/routes/reset-password.tsx:188
+msgid "Pick a password you'll remember. Minimum 8 characters."
+msgstr "Tria una contrasenya que recordis. Mínim 8 caràcters."
 
 #: src/routes/emails/inboxes.tsx:803
 msgid "Pick a provider"
@@ -2089,6 +2124,7 @@ msgstr "Reobre el fil"
 
 #: src/routes/profile/index.tsx:242
 #: src/routes/profile/index.tsx:426
+#: src/routes/reset-password.tsx:207
 msgid "Repeat new password"
 msgstr "Repeteix la contrasenya nova"
 
@@ -2100,6 +2136,11 @@ msgstr "Respon"
 msgid "Reply all"
 msgstr "Respon a tots"
 
+#: src/routes/reset-password.tsx:77
+#: src/routes/reset-password.tsx:140
+msgid "Request a new link"
+msgstr "Demana un enllaç nou"
+
 #: src/components/companies/research-summary-card.tsx:31
 #: src/components/shared/channel-icon.tsx:71
 msgid "Research"
@@ -2109,17 +2150,25 @@ msgstr "Recerca"
 msgid "Research run"
 msgstr "Recerca"
 
-#: src/routes/login.tsx:452
+#: src/routes/login.tsx:464
 msgid "Resend in"
 msgstr "Torna a enviar en"
 
-#: src/routes/login.tsx:458
+#: src/routes/login.tsx:470
 msgid "Resend link"
 msgstr "Torna a enviar l'enllaç"
 
 #: src/routes/emails/index.tsx:1361
 msgid "Reset"
 msgstr "Restableix"
+
+#: src/routes/reset-password.tsx:66
+msgid "Reset links expire after 1 hour and can only be used once. Ask for a new one and follow it within the hour."
+msgstr "Els enllaços per restablir caduquen en 1 hora i només es poden fer servir un cop. Demana'n un de nou i obre'l dins l'hora."
+
+#: src/routes/forgot-password.tsx:95
+msgid "Reset your password"
+msgstr "Restableix la contrasenya"
 
 #: src/routes/calendar/index.tsx:308
 msgid "Respond to the organizer"
@@ -2177,6 +2226,10 @@ msgstr "Desa"
 msgid "Save failed"
 msgstr "Ha fallat el desament"
 
+#: src/routes/reset-password.tsx:242
+msgid "Save new password"
+msgstr "Desa la nova contrasenya"
+
 #: src/routes/profile/index.tsx:280
 msgid "Save password"
 msgstr "Desa la contrasenya"
@@ -2186,6 +2239,7 @@ msgstr "Desa la contrasenya"
 #: src/routes/pages/$id.tsx:268
 #: src/routes/profile/index.tsx:278
 #: src/routes/profile/index.tsx:472
+#: src/routes/reset-password.tsx:242
 msgid "Saving…"
 msgstr "Desant…"
 
@@ -2250,8 +2304,13 @@ msgstr "Envia correu"
 msgid "Send invitation"
 msgstr "Envia invitació"
 
+#: src/routes/forgot-password.tsx:128
+msgid "Send reset link"
+msgstr "Envia l'enllaç"
+
 #: src/components/emails/compose-form.tsx:534
-#: src/routes/login.tsx:382
+#: src/routes/forgot-password.tsx:128
+#: src/routes/login.tsx:387
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
 msgstr "Enviant…"
@@ -2259,6 +2318,10 @@ msgstr "Enviant…"
 #: src/routes/emails/$threadId.tsx:683
 msgid "Sent"
 msgstr "Enviat"
+
+#: src/routes/reset-password.tsx:185
+msgid "Set a new password"
+msgstr "Posa una contrasenya nova"
 
 #: src/routes/profile/index.tsx:218
 msgid "Set a password"
@@ -2311,7 +2374,7 @@ msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Mostrant {firstRow}–{lastRow} de {total}"
 
 #: src/routes/accept-invitation.$id.tsx:129
-#: src/routes/login.tsx:371
+#: src/routes/login.tsx:376
 msgid "Sign in"
 msgstr "Inicia sessió"
 
@@ -2319,9 +2382,13 @@ msgstr "Inicia sessió"
 msgid "Sign in to accept this invitation"
 msgstr "Inicia sessió per acceptar aquesta invitació"
 
-#: src/routes/login.tsx:324
+#: src/routes/login.tsx:329
 msgid "Sign in to continue"
 msgstr "Inicia sessió per continuar"
+
+#: src/routes/reset-password.tsx:160
+msgid "Sign in with your new password. Other devices will need to sign in again too."
+msgstr "Inicia sessió amb la contrasenya nova. Els altres dispositius també hauran de tornar a iniciar sessió."
 
 #: src/routes/profile/index.tsx:138
 msgid "Sign out"
@@ -2331,7 +2398,7 @@ msgstr "Tanca sessió"
 msgid "Sign-out failed. Please try again."
 msgstr "No s'ha pogut tancar la sessió. Torna-ho a provar."
 
-#: src/routes/login.tsx:371
+#: src/routes/login.tsx:376
 msgid "Signing in…"
 msgstr "Iniciant sessió…"
 
@@ -2377,6 +2444,7 @@ msgstr "algú"
 
 #: src/routes/profile/index.tsx:267
 #: src/routes/profile/index.tsx:456
+#: src/routes/reset-password.tsx:233
 msgid "Something went wrong. Try again."
 msgstr "Alguna cosa ha fallat. Prova-ho de nou."
 
@@ -2500,11 +2568,11 @@ msgstr "Prova fallida"
 msgid "Testing connection…"
 msgstr "Provant la connexió…"
 
-#: src/routes/login.tsx:136
+#: src/routes/login.tsx:141
 msgid "That link expired. Request a fresh one below."
 msgstr "L'enllaç ha caducat. Demana'n un de nou a sota."
 
-#: src/routes/login.tsx:137
+#: src/routes/login.tsx:142
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "L'enllaç ja no és vàlid. Demana'n un de nou a sota."
 
@@ -2557,12 +2625,20 @@ msgstr "El fil existeix però el proveïdor no ha retornat cap missatge."
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "Potser el fil s'ha arxivat al proveïdor o l'enllaç és obsolet."
 
+#: src/routes/reset-password.tsx:130
+msgid "The token expired or was already used. Request a fresh link."
+msgstr "El token ha caducat o ja s'ha fet servir. Demana un enllaç nou."
+
 #: src/routes/profile/index.tsx:446
 msgid "The two new password fields don't match."
 msgstr "Les dues contrasenyes noves no coincideixen."
 
 #: src/routes/profile/index.tsx:262
 msgid "The two password fields don't match."
+msgstr "Les dues contrasenyes no coincideixen."
+
+#: src/routes/reset-password.tsx:228
+msgid "The two passwords don't match."
 msgstr "Les dues contrasenyes no coincideixen."
 
 #: src/routes/tasks/index.tsx:440
@@ -2592,6 +2668,11 @@ msgstr "Aquesta invitació ja no és vàlida."
 #: src/routes/accept-invitation.$id.tsx:57
 msgid "This invitation link is no longer valid. It may have already been used."
 msgstr "Aquest enllaç de la invitació ja no és vàlid. Pot haver-se utilitzat."
+
+#: src/routes/reset-password.tsx:63
+#: src/routes/reset-password.tsx:127
+msgid "This link is no longer valid"
+msgstr "Aquest enllaç ja no és vàlid"
 
 #: src/routes/settings/organization/spend.tsx:134
 msgid "This month"
@@ -2640,7 +2721,7 @@ msgstr "Per a"
 msgid "Today"
 msgstr "Avui"
 
-#: src/routes/login.tsx:128
+#: src/routes/login.tsx:133
 msgid "Too many attempts. Try again in a minute."
 msgstr "Massa intents. Torna-ho a provar d'aquí un minut."
 
@@ -2660,6 +2741,10 @@ msgstr "Tipus"
 #: src/components/shared/editable-field.tsx:320
 msgid "Type and press Enter"
 msgstr "Escriu i prem Retorn"
+
+#: src/routes/forgot-password.tsx:98
+msgid "Type the email you sign in with. We'll send a reset link."
+msgstr "Escriu el correu amb què inicies sessió. T'enviaré un enllaç per restablir-la."
 
 #: src/components/companies/calendar-tab.tsx:60
 #: src/components/companies/conversations-tab.tsx:166
@@ -2711,7 +2796,7 @@ msgstr "Pujant…"
 msgid "Use {0} as primary"
 msgstr "Fes servir {0} com a principal"
 
-#: src/routes/login.tsx:480
+#: src/routes/login.tsx:492
 msgid "Use a different email"
 msgstr "Fes servir un altre correu"
 
@@ -2723,7 +2808,7 @@ msgstr "Utilitza com a peu de pàgina predeterminat"
 msgid "Use as default for this purpose"
 msgstr "Usa com a per defecte per a aquest propòsit"
 
-#: src/routes/login.tsx:487
+#: src/routes/login.tsx:499
 msgid "Use password instead"
 msgstr "Fes servir contrasenya"
 
@@ -2748,15 +2833,15 @@ msgstr "Visites"
 msgid "Visit"
 msgstr "Visita"
 
-#: src/routes/login.tsx:138
+#: src/routes/login.tsx:143
 msgid "We couldn't sign you in via that link. Try again."
 msgstr "No s'ha pogut iniciar sessió amb aquest enllaç. Torna-ho a provar."
 
-#: src/routes/login.tsx:135
+#: src/routes/login.tsx:140
 msgid "We don't recognize that email. Ask an admin to invite you."
 msgstr "No reconeixem aquest correu. Demana a un administrador que t'inviti."
 
-#: src/routes/login.tsx:433
+#: src/routes/login.tsx:445
 msgid "We sent a sign-in link to"
 msgstr "S'ha enviat un enllaç d'inici de sessió a"
 
@@ -2852,6 +2937,6 @@ msgstr "tu@exemple.com"
 msgid "Your Batuda workbench identity."
 msgstr "La teva identitat al banc de Batuda."
 
-#: src/routes/login.tsx:130
+#: src/routes/login.tsx:135
 msgid "Your email isn't verified yet. Use the magic link instead."
 msgstr "El correu encara no està verificat. Fes servir l'enllaç de sessió."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -270,8 +270,8 @@ msgstr "Torna a la safata"
 msgid "Back to organization"
 msgstr "Tornar a l'organització"
 
-#: src/routes/forgot-password.tsx:82
-#: src/routes/forgot-password.tsx:134
+#: src/routes/forgot-password.tsx:86
+#: src/routes/forgot-password.tsx:140
 #: src/routes/reset-password.tsx:82
 msgid "Back to sign in"
 msgstr "Torna a iniciar sessió"
@@ -425,7 +425,7 @@ msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
 msgid "Check the session or try again."
 msgstr "Comprova la sessió o torna-ho a provar."
 
-#: src/routes/forgot-password.tsx:65
+#: src/routes/forgot-password.tsx:69
 #: src/routes/login.tsx:442
 msgid "Check your inbox"
 msgstr "Mira la safata d'entrada"
@@ -682,7 +682,7 @@ msgstr "No s'ha pogut desar la pàgina. Torna-ho a provar."
 msgid "Could not send the invitation. Please try again."
 msgstr "No s'''ha pogut enviar la invitació. Torna-ho a provar."
 
-#: src/routes/forgot-password.tsx:119
+#: src/routes/forgot-password.tsx:123
 #: src/routes/login.tsx:137
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "No s'ha pogut enviar l'enllaç. Torna-ho a provar d'aquí uns segons."
@@ -921,7 +921,7 @@ msgstr "Editor"
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
-#: src/routes/forgot-password.tsx:105
+#: src/routes/forgot-password.tsx:109
 #: src/routes/login.tsx:339
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
@@ -1110,7 +1110,7 @@ msgstr "Prefereixo sense contrasenya"
 msgid "I prefer passwordless — don't ask me again"
 msgstr "Prefereixo sense contrasenya — no m'ho tornis a preguntar"
 
-#: src/routes/forgot-password.tsx:68
+#: src/routes/forgot-password.tsx:72
 msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 msgstr "Si <0>{submittedEmail}</0> està registrat, t'arribarà un enllaç per restablir la contrasenya. L'enllaç caduca en 1 hora."
 
@@ -1668,7 +1668,7 @@ msgstr "cap planificat"
 msgid "Normal priority"
 msgstr "Prioritat normal"
 
-#: src/routes/forgot-password.tsx:74
+#: src/routes/forgot-password.tsx:78
 msgid "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
 msgstr "No el veus? Mira la carpeta de correu brossa. Si estàs segur que el correu és correcte i no arriba mai, un administrador et pot ajudar."
 
@@ -2166,7 +2166,7 @@ msgstr "Restableix"
 msgid "Reset links expire after 1 hour and can only be used once. Ask for a new one and follow it within the hour."
 msgstr "Els enllaços per restablir caduquen en 1 hora i només es poden fer servir un cop. Demana'n un de nou i obre'l dins l'hora."
 
-#: src/routes/forgot-password.tsx:95
+#: src/routes/forgot-password.tsx:99
 msgid "Reset your password"
 msgstr "Restableix la contrasenya"
 
@@ -2304,12 +2304,12 @@ msgstr "Envia correu"
 msgid "Send invitation"
 msgstr "Envia invitació"
 
-#: src/routes/forgot-password.tsx:128
+#: src/routes/forgot-password.tsx:134
 msgid "Send reset link"
 msgstr "Envia l'enllaç"
 
 #: src/components/emails/compose-form.tsx:534
-#: src/routes/forgot-password.tsx:128
+#: src/routes/forgot-password.tsx:134
 #: src/routes/login.tsx:387
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
@@ -2742,7 +2742,7 @@ msgstr "Tipus"
 msgid "Type and press Enter"
 msgstr "Escriu i prem Retorn"
 
-#: src/routes/forgot-password.tsx:98
+#: src/routes/forgot-password.tsx:102
 msgid "Type the email you sign in with. We'll send a reset link."
 msgstr "Escriu el correu amb què inicies sessió. T'enviaré un enllaç per restablir-la."
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -270,8 +270,8 @@ msgstr "Back to inbox"
 msgid "Back to organization"
 msgstr "Back to organization"
 
-#: src/routes/forgot-password.tsx:82
-#: src/routes/forgot-password.tsx:134
+#: src/routes/forgot-password.tsx:86
+#: src/routes/forgot-password.tsx:140
 #: src/routes/reset-password.tsx:82
 msgid "Back to sign in"
 msgstr "Back to sign in"
@@ -425,7 +425,7 @@ msgstr "Check that your session is valid or try again."
 msgid "Check the session or try again."
 msgstr "Check the session or try again."
 
-#: src/routes/forgot-password.tsx:65
+#: src/routes/forgot-password.tsx:69
 #: src/routes/login.tsx:442
 msgid "Check your inbox"
 msgstr "Check your inbox"
@@ -682,7 +682,7 @@ msgstr "Could not save the page. Please try again."
 msgid "Could not send the invitation. Please try again."
 msgstr "Could not send the invitation. Please try again."
 
-#: src/routes/forgot-password.tsx:119
+#: src/routes/forgot-password.tsx:123
 #: src/routes/login.tsx:137
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "Could not send the link. Try again in a few seconds."
@@ -921,7 +921,7 @@ msgstr "Editor"
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
-#: src/routes/forgot-password.tsx:105
+#: src/routes/forgot-password.tsx:109
 #: src/routes/login.tsx:339
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
@@ -1110,7 +1110,7 @@ msgstr "I prefer passwordless"
 msgid "I prefer passwordless — don't ask me again"
 msgstr "I prefer passwordless — don't ask me again"
 
-#: src/routes/forgot-password.tsx:68
+#: src/routes/forgot-password.tsx:72
 msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 msgstr "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 
@@ -1668,7 +1668,7 @@ msgstr "none scheduled"
 msgid "Normal priority"
 msgstr "Normal priority"
 
-#: src/routes/forgot-password.tsx:74
+#: src/routes/forgot-password.tsx:78
 msgid "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
 msgstr "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
 
@@ -2166,7 +2166,7 @@ msgstr "Reset"
 msgid "Reset links expire after 1 hour and can only be used once. Ask for a new one and follow it within the hour."
 msgstr "Reset links expire after 1 hour and can only be used once. Ask for a new one and follow it within the hour."
 
-#: src/routes/forgot-password.tsx:95
+#: src/routes/forgot-password.tsx:99
 msgid "Reset your password"
 msgstr "Reset your password"
 
@@ -2304,12 +2304,12 @@ msgstr "Send email"
 msgid "Send invitation"
 msgstr "Send invitation"
 
-#: src/routes/forgot-password.tsx:128
+#: src/routes/forgot-password.tsx:134
 msgid "Send reset link"
 msgstr "Send reset link"
 
 #: src/components/emails/compose-form.tsx:534
-#: src/routes/forgot-password.tsx:128
+#: src/routes/forgot-password.tsx:134
 #: src/routes/login.tsx:387
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
@@ -2742,7 +2742,7 @@ msgstr "Type"
 msgid "Type and press Enter"
 msgstr "Type and press Enter"
 
-#: src/routes/forgot-password.tsx:98
+#: src/routes/forgot-password.tsx:102
 msgid "Type the email you sign in with. We'll send a reset link."
 msgstr "Type the email you sign in with. We'll send a reset link."
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -270,6 +270,12 @@ msgstr "Back to inbox"
 msgid "Back to organization"
 msgstr "Back to organization"
 
+#: src/routes/forgot-password.tsx:82
+#: src/routes/forgot-password.tsx:134
+#: src/routes/reset-password.tsx:82
+msgid "Back to sign in"
+msgstr "Back to sign in"
+
 #: src/i18n/lingui.tsx:56
 msgid "Batuda"
 msgstr "Batuda"
@@ -282,7 +288,7 @@ msgstr "Batuda — a multi-tenant CRM for small agencies."
 msgid "Batuda home"
 msgstr "Batuda home"
 
-#: src/routes/login.tsx:392
+#: src/routes/login.tsx:404
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda is invite-only. Request access from the Engranatge team."
 
@@ -419,7 +425,8 @@ msgstr "Check that your session is valid or try again."
 msgid "Check the session or try again."
 msgstr "Check the session or try again."
 
-#: src/routes/login.tsx:430
+#: src/routes/forgot-password.tsx:65
+#: src/routes/login.tsx:442
 msgid "Check your inbox"
 msgstr "Check your inbox"
 
@@ -675,7 +682,8 @@ msgstr "Could not save the page. Please try again."
 msgid "Could not send the invitation. Please try again."
 msgstr "Could not send the invitation. Please try again."
 
-#: src/routes/login.tsx:132
+#: src/routes/forgot-password.tsx:119
+#: src/routes/login.tsx:137
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "Could not send the link. Try again in a few seconds."
 
@@ -687,7 +695,7 @@ msgstr "Could not set primary inbox"
 msgid "Could not set the default inbox."
 msgstr "Could not set the default inbox."
 
-#: src/routes/login.tsx:131
+#: src/routes/login.tsx:136
 msgid "Could not sign in. Check your email and password."
 msgstr "Could not sign in. Check your email and password."
 
@@ -913,7 +921,8 @@ msgstr "Editor"
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
-#: src/routes/login.tsx:334
+#: src/routes/forgot-password.tsx:105
+#: src/routes/login.tsx:339
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Email"
@@ -930,11 +939,11 @@ msgstr "Email drafts"
 msgid "Email is dead-letter"
 msgstr "Email is dead-letter"
 
-#: src/routes/login.tsx:383
+#: src/routes/login.tsx:388
 msgid "Email me a sign-in link"
 msgstr "Email me a sign-in link"
 
-#: src/routes/login.tsx:129
+#: src/routes/login.tsx:134
 msgid "Email or password is incorrect."
 msgstr "Email or password is incorrect."
 
@@ -955,7 +964,7 @@ msgstr "Emails, calls, documents, and proposals will appear here as they happen.
 msgid "Enrichment"
 msgstr "Enrichment"
 
-#: src/routes/login.tsx:134
+#: src/routes/login.tsx:139
 msgid "Enter a valid email above first."
 msgstr "Enter a valid email above first."
 
@@ -1034,6 +1043,10 @@ msgstr "Flagged as spam by the provider. The body is shown for review only."
 msgid "Footers — {0}"
 msgstr "Footers — {0}"
 
+#: src/routes/login.tsx:395
+msgid "Forgot password?"
+msgstr "Forgot password?"
+
 #: src/components/research/research-dialog.tsx:31
 msgid "Freeform"
 msgstr "Freeform"
@@ -1057,6 +1070,10 @@ msgstr "From webhook"
 #: src/components/emails/compose-window.tsx:69
 msgid "Full screen"
 msgstr "Full screen"
+
+#: src/routes/reset-password.tsx:173
+msgid "Go to sign in"
+msgstr "Go to sign in"
 
 #: src/routes/accept-invitation.$id.tsx:170
 msgid "Heading to the dashboard…"
@@ -1092,6 +1109,10 @@ msgstr "I prefer passwordless"
 #: src/routes/profile/index.tsx:289
 msgid "I prefer passwordless — don't ask me again"
 msgstr "I prefer passwordless — don't ask me again"
+
+#: src/routes/forgot-password.tsx:68
+msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
+msgstr "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 
 #: src/routes/emails/inboxes.tsx:857
 msgid "IMAP host"
@@ -1180,7 +1201,7 @@ msgstr "Invite a member"
 msgid "Invite a new member"
 msgstr "Invite a new member"
 
-#: src/routes/login.tsx:437
+#: src/routes/login.tsx:449
 msgid "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 msgstr "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 
@@ -1447,6 +1468,7 @@ msgstr "never"
 
 #: src/routes/profile/index.tsx:229
 #: src/routes/profile/index.tsx:413
+#: src/routes/reset-password.tsx:193
 msgid "New password"
 msgstr "New password"
 
@@ -1511,7 +1533,7 @@ msgstr "No companies yet"
 
 #: src/components/layout/org-switcher.tsx:62
 #: src/routes/accept-invitation.$id.tsx:98
-#: src/routes/login.tsx:133
+#: src/routes/login.tsx:138
 #: src/routes/profile/index.tsx:77
 #: src/routes/settings/organization/invite.tsx:77
 #: src/routes/settings/organization/members.tsx:81
@@ -1646,6 +1668,10 @@ msgstr "none scheduled"
 msgid "Normal priority"
 msgstr "Normal priority"
 
+#: src/routes/forgot-password.tsx:74
+msgid "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
+msgstr "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
+
 #: src/components/interactions/quick-capture-dialog.tsx:425
 msgid "Note"
 msgstr "Note"
@@ -1677,7 +1703,7 @@ msgid "Open"
 msgstr "Open"
 
 #. placeholder {0}: provider.label
-#: src/routes/login.tsx:470
+#: src/routes/login.tsx:482
 msgid "Open {0}"
 msgstr "Open {0}"
 
@@ -1836,13 +1862,17 @@ msgstr "Pain indicators"
 msgid "Pain points"
 msgstr "Pain points"
 
-#: src/routes/login.tsx:349
+#: src/routes/login.tsx:354
 msgid "Password"
 msgstr "Password"
 
 #: src/routes/emails/inboxes.tsx:943
 msgid "Password or app-password"
 msgstr "Password or app-password"
+
+#: src/routes/reset-password.tsx:157
+msgid "Password updated"
+msgstr "Password updated"
 
 #: src/routes/profile/index.tsx:461
 msgid "Password updated."
@@ -1854,6 +1884,7 @@ msgstr "Passwordless sign-in only"
 
 #: src/routes/profile/index.tsx:255
 #: src/routes/profile/index.tsx:439
+#: src/routes/reset-password.tsx:221
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 
@@ -1884,6 +1915,10 @@ msgstr "Phone"
 #: src/routes/profile/index.tsx:390
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Pick a new password. Other signed-in devices will be signed out."
+
+#: src/routes/reset-password.tsx:188
+msgid "Pick a password you'll remember. Minimum 8 characters."
+msgstr "Pick a password you'll remember. Minimum 8 characters."
 
 #: src/routes/emails/inboxes.tsx:803
 msgid "Pick a provider"
@@ -2089,6 +2124,7 @@ msgstr "Reopen thread"
 
 #: src/routes/profile/index.tsx:242
 #: src/routes/profile/index.tsx:426
+#: src/routes/reset-password.tsx:207
 msgid "Repeat new password"
 msgstr "Repeat new password"
 
@@ -2100,6 +2136,11 @@ msgstr "Reply"
 msgid "Reply all"
 msgstr "Reply all"
 
+#: src/routes/reset-password.tsx:77
+#: src/routes/reset-password.tsx:140
+msgid "Request a new link"
+msgstr "Request a new link"
+
 #: src/components/companies/research-summary-card.tsx:31
 #: src/components/shared/channel-icon.tsx:71
 msgid "Research"
@@ -2109,17 +2150,25 @@ msgstr "Research"
 msgid "Research run"
 msgstr "Research run"
 
-#: src/routes/login.tsx:452
+#: src/routes/login.tsx:464
 msgid "Resend in"
 msgstr "Resend in"
 
-#: src/routes/login.tsx:458
+#: src/routes/login.tsx:470
 msgid "Resend link"
 msgstr "Resend link"
 
 #: src/routes/emails/index.tsx:1361
 msgid "Reset"
 msgstr "Reset"
+
+#: src/routes/reset-password.tsx:66
+msgid "Reset links expire after 1 hour and can only be used once. Ask for a new one and follow it within the hour."
+msgstr "Reset links expire after 1 hour and can only be used once. Ask for a new one and follow it within the hour."
+
+#: src/routes/forgot-password.tsx:95
+msgid "Reset your password"
+msgstr "Reset your password"
 
 #: src/routes/calendar/index.tsx:308
 msgid "Respond to the organizer"
@@ -2177,6 +2226,10 @@ msgstr "Save"
 msgid "Save failed"
 msgstr "Save failed"
 
+#: src/routes/reset-password.tsx:242
+msgid "Save new password"
+msgstr "Save new password"
+
 #: src/routes/profile/index.tsx:280
 msgid "Save password"
 msgstr "Save password"
@@ -2186,6 +2239,7 @@ msgstr "Save password"
 #: src/routes/pages/$id.tsx:268
 #: src/routes/profile/index.tsx:278
 #: src/routes/profile/index.tsx:472
+#: src/routes/reset-password.tsx:242
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2250,8 +2304,13 @@ msgstr "Send email"
 msgid "Send invitation"
 msgstr "Send invitation"
 
+#: src/routes/forgot-password.tsx:128
+msgid "Send reset link"
+msgstr "Send reset link"
+
 #: src/components/emails/compose-form.tsx:534
-#: src/routes/login.tsx:382
+#: src/routes/forgot-password.tsx:128
+#: src/routes/login.tsx:387
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
 msgstr "Sending…"
@@ -2259,6 +2318,10 @@ msgstr "Sending…"
 #: src/routes/emails/$threadId.tsx:683
 msgid "Sent"
 msgstr "Sent"
+
+#: src/routes/reset-password.tsx:185
+msgid "Set a new password"
+msgstr "Set a new password"
 
 #: src/routes/profile/index.tsx:218
 msgid "Set a password"
@@ -2311,7 +2374,7 @@ msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Showing {firstRow}–{lastRow} of {total}"
 
 #: src/routes/accept-invitation.$id.tsx:129
-#: src/routes/login.tsx:371
+#: src/routes/login.tsx:376
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -2319,9 +2382,13 @@ msgstr "Sign in"
 msgid "Sign in to accept this invitation"
 msgstr "Sign in to accept this invitation"
 
-#: src/routes/login.tsx:324
+#: src/routes/login.tsx:329
 msgid "Sign in to continue"
 msgstr "Sign in to continue"
+
+#: src/routes/reset-password.tsx:160
+msgid "Sign in with your new password. Other devices will need to sign in again too."
+msgstr "Sign in with your new password. Other devices will need to sign in again too."
 
 #: src/routes/profile/index.tsx:138
 msgid "Sign out"
@@ -2331,7 +2398,7 @@ msgstr "Sign out"
 msgid "Sign-out failed. Please try again."
 msgstr "Sign-out failed. Please try again."
 
-#: src/routes/login.tsx:371
+#: src/routes/login.tsx:376
 msgid "Signing in…"
 msgstr "Signing in…"
 
@@ -2377,6 +2444,7 @@ msgstr "someone"
 
 #: src/routes/profile/index.tsx:267
 #: src/routes/profile/index.tsx:456
+#: src/routes/reset-password.tsx:233
 msgid "Something went wrong. Try again."
 msgstr "Something went wrong. Try again."
 
@@ -2500,11 +2568,11 @@ msgstr "Test failed"
 msgid "Testing connection…"
 msgstr "Testing connection…"
 
-#: src/routes/login.tsx:136
+#: src/routes/login.tsx:141
 msgid "That link expired. Request a fresh one below."
 msgstr "That link expired. Request a fresh one below."
 
-#: src/routes/login.tsx:137
+#: src/routes/login.tsx:142
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "That link is no longer valid. Request a fresh one below."
 
@@ -2557,6 +2625,10 @@ msgstr "The thread exists but the provider returned no messages."
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "The thread may have been archived upstream or the link is stale."
 
+#: src/routes/reset-password.tsx:130
+msgid "The token expired or was already used. Request a fresh link."
+msgstr "The token expired or was already used. Request a fresh link."
+
 #: src/routes/profile/index.tsx:446
 msgid "The two new password fields don't match."
 msgstr "The two new password fields don't match."
@@ -2564,6 +2636,10 @@ msgstr "The two new password fields don't match."
 #: src/routes/profile/index.tsx:262
 msgid "The two password fields don't match."
 msgstr "The two password fields don't match."
+
+#: src/routes/reset-password.tsx:228
+msgid "The two passwords don't match."
+msgstr "The two passwords don't match."
 
 #: src/routes/tasks/index.tsx:440
 msgid "The workshop ledger — tear off one strip at a time."
@@ -2592,6 +2668,11 @@ msgstr "This invitation is no longer valid."
 #: src/routes/accept-invitation.$id.tsx:57
 msgid "This invitation link is no longer valid. It may have already been used."
 msgstr "This invitation link is no longer valid. It may have already been used."
+
+#: src/routes/reset-password.tsx:63
+#: src/routes/reset-password.tsx:127
+msgid "This link is no longer valid"
+msgstr "This link is no longer valid"
 
 #: src/routes/settings/organization/spend.tsx:134
 msgid "This month"
@@ -2640,7 +2721,7 @@ msgstr "To"
 msgid "Today"
 msgstr "Today"
 
-#: src/routes/login.tsx:128
+#: src/routes/login.tsx:133
 msgid "Too many attempts. Try again in a minute."
 msgstr "Too many attempts. Try again in a minute."
 
@@ -2660,6 +2741,10 @@ msgstr "Type"
 #: src/components/shared/editable-field.tsx:320
 msgid "Type and press Enter"
 msgstr "Type and press Enter"
+
+#: src/routes/forgot-password.tsx:98
+msgid "Type the email you sign in with. We'll send a reset link."
+msgstr "Type the email you sign in with. We'll send a reset link."
 
 #: src/components/companies/calendar-tab.tsx:60
 #: src/components/companies/conversations-tab.tsx:166
@@ -2711,7 +2796,7 @@ msgstr "Uploading…"
 msgid "Use {0} as primary"
 msgstr "Use {0} as primary"
 
-#: src/routes/login.tsx:480
+#: src/routes/login.tsx:492
 msgid "Use a different email"
 msgstr "Use a different email"
 
@@ -2723,7 +2808,7 @@ msgstr "Use as default footer"
 msgid "Use as default for this purpose"
 msgstr "Use as default for this purpose"
 
-#: src/routes/login.tsx:487
+#: src/routes/login.tsx:499
 msgid "Use password instead"
 msgstr "Use password instead"
 
@@ -2748,15 +2833,15 @@ msgstr "Views"
 msgid "Visit"
 msgstr "Visit"
 
-#: src/routes/login.tsx:138
+#: src/routes/login.tsx:143
 msgid "We couldn't sign you in via that link. Try again."
 msgstr "We couldn't sign you in via that link. Try again."
 
-#: src/routes/login.tsx:135
+#: src/routes/login.tsx:140
 msgid "We don't recognize that email. Ask an admin to invite you."
 msgstr "We don't recognize that email. Ask an admin to invite you."
 
-#: src/routes/login.tsx:433
+#: src/routes/login.tsx:445
 msgid "We sent a sign-in link to"
 msgstr "We sent a sign-in link to"
 
@@ -2852,6 +2937,6 @@ msgstr "you@example.com"
 msgid "Your Batuda workbench identity."
 msgstr "Your Batuda workbench identity."
 
-#: src/routes/login.tsx:130
+#: src/routes/login.tsx:135
 msgid "Your email isn't verified yet. Use the magic link instead."
 msgstr "Your email isn't verified yet. Use the magic link instead."

--- a/apps/internal/src/routeTree.gen.ts
+++ b/apps/internal/src/routeTree.gen.ts
@@ -9,7 +9,9 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TasksIndexRouteImport } from './routes/tasks/index'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
@@ -28,9 +30,19 @@ import { Route as SettingsOrganizationSpendRouteImport } from './routes/settings
 import { Route as SettingsOrganizationMembersRouteImport } from './routes/settings/organization/members'
 import { Route as SettingsOrganizationInviteRouteImport } from './routes/settings/organization/invite'
 
+const ResetPasswordRoute = ResetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -125,7 +137,9 @@ const SettingsOrganizationInviteRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/accept-invitation/$id': typeof AcceptInvitationIdRoute
   '/companies/$slug': typeof CompaniesSlugRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
@@ -145,7 +159,9 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/accept-invitation/$id': typeof AcceptInvitationIdRoute
   '/companies/$slug': typeof CompaniesSlugRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
@@ -166,7 +182,9 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/accept-invitation/$id': typeof AcceptInvitationIdRoute
   '/companies/$slug': typeof CompaniesSlugRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
@@ -188,7 +206,9 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/accept-invitation/$id'
     | '/companies/$slug'
     | '/emails/$threadId'
@@ -208,7 +228,9 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/accept-invitation/$id'
     | '/companies/$slug'
     | '/emails/$threadId'
@@ -228,7 +250,9 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/accept-invitation/$id'
     | '/companies/$slug'
     | '/emails/$threadId'
@@ -249,7 +273,9 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
+  ResetPasswordRoute: typeof ResetPasswordRoute
   AcceptInvitationIdRoute: typeof AcceptInvitationIdRoute
   CompaniesSlugRoute: typeof CompaniesSlugRoute
   EmailsThreadIdRoute: typeof EmailsThreadIdRoute
@@ -270,11 +296,25 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/reset-password': {
+      id: '/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof ResetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/forgot-password': {
+      id: '/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof ForgotPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -401,7 +441,9 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
+  ResetPasswordRoute: ResetPasswordRoute,
   AcceptInvitationIdRoute: AcceptInvitationIdRoute,
   CompaniesSlugRoute: CompaniesSlugRoute,
   EmailsThreadIdRoute: EmailsThreadIdRoute,

--- a/apps/internal/src/routes/__root.tsx
+++ b/apps/internal/src/routes/__root.tsx
@@ -69,6 +69,8 @@ export const Route = createRootRoute({
 		// jankier than letting the page render its own message.
 		const isPublicPath =
 			location.pathname === '/login' ||
+			location.pathname === '/forgot-password' ||
+			location.pathname === '/reset-password' ||
 			location.pathname.startsWith('/accept-invitation/')
 		if (!isPublicPath) {
 			const user = await fetchSession(cookieHeader ?? undefined)
@@ -154,6 +156,8 @@ function RootComponent() {
 	// empty). Everything else runs inside the full authenticated shell.
 	const isAuthChrome =
 		location.pathname === '/login' ||
+		location.pathname === '/forgot-password' ||
+		location.pathname === '/reset-password' ||
 		location.pathname.startsWith('/accept-invitation/')
 
 	// Tell any stale `/login` tab (left on the "Check your inbox" panel

--- a/apps/internal/src/routes/forgot-password.tsx
+++ b/apps/internal/src/routes/forgot-password.tsx
@@ -1,0 +1,246 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { PriButton, PriInput } from '@batuda/ui/pri'
+
+import { authClient } from '#/lib/auth-client'
+import { stenciledTitle } from '#/lib/workshop-mixins'
+
+/**
+ * Email-based password reset request. The form POSTs the email to
+ * Better Auth's `/auth/request-password-reset` with a `redirectTo` set
+ * to the frontend's `/reset-password` route. BA returns an opaque success
+ * regardless of whether the email exists (anti-enumeration); we render
+ * the same "if this email is registered…" confirmation either way.
+ *
+ * The email lands in `apps/server/.dev-inbox/` with `labels: password-reset`
+ * in dev; in prod it ships via the configured transactional provider.
+ */
+
+export const Route = createFileRoute('/forgot-password')({
+	head: () => ({ meta: [{ title: 'Reset password — Batuda' }] }),
+	component: ForgotPasswordPage,
+})
+
+type Status = 'idle' | 'submitting' | 'sent' | 'error'
+
+function ForgotPasswordPage() {
+	const { t } = useLingui()
+	const [status, setStatus] = useState<Status>('idle')
+	const [submittedEmail, setSubmittedEmail] = useState('')
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault()
+		const form = new FormData(event.currentTarget)
+		const email = String(form.get('email') ?? '')
+			.trim()
+			.toLowerCase()
+		if (!email.includes('@')) {
+			setStatus('error')
+			return
+		}
+		setStatus('submitting')
+		const redirectTo = new URL(
+			'/reset-password',
+			window.location.origin,
+		).toString()
+		const result = await authClient.requestPasswordReset({ email, redirectTo })
+		if (result.error) {
+			setStatus('error')
+			return
+		}
+		setSubmittedEmail(email)
+		setStatus('sent')
+	}
+
+	if (status === 'sent') {
+		return (
+			<Page>
+				<Card
+					role='status'
+					aria-live='polite'
+					data-testid='forgot-password-sent'
+				>
+					<Brand>Batuda</Brand>
+					<Heading>
+						<Trans>Check your inbox</Trans>
+					</Heading>
+					<Body>
+						<Trans>
+							If <strong>{submittedEmail}</strong> is registered, a reset link
+							is on its way. The link expires in 1 hour.
+						</Trans>
+					</Body>
+					<Body>
+						<Trans>
+							Not seeing it? Check your spam folder. If you're sure the email is
+							right and it never arrives, an admin can help.
+						</Trans>
+					</Body>
+					<BackRow>
+						<BackLink to='/login'>
+							<ArrowLeft size={14} aria-hidden />
+							<Trans>Back to sign in</Trans>
+						</BackLink>
+					</BackRow>
+				</Card>
+			</Page>
+		)
+	}
+
+	return (
+		<Page>
+			<Card>
+				<Brand>Batuda</Brand>
+				<Heading>
+					<Trans>Reset your password</Trans>
+				</Heading>
+				<Body>
+					<Trans>
+						Type the email you sign in with. We'll send a reset link.
+					</Trans>
+				</Body>
+				<Form onSubmit={handleSubmit} data-testid='forgot-password-form'>
+					<Field>
+						<Label htmlFor='forgot-email'>
+							<Trans>Email</Trans>
+						</Label>
+						<PriInput
+							id='forgot-email'
+							name='email'
+							type='email'
+							autoComplete='email'
+							required
+							disabled={status === 'submitting'}
+							data-testid='forgot-password-email'
+						/>
+					</Field>
+					{status === 'error' ? (
+						<ErrorText role='alert' data-testid='forgot-password-error'>
+							<Trans>
+								Could not send the link. Try again in a few seconds.
+							</Trans>
+						</ErrorText>
+					) : null}
+					<PriButton
+						type='submit'
+						$variant='filled'
+						disabled={status === 'submitting'}
+						data-testid='forgot-password-submit'
+					>
+						{status === 'submitting' ? t`Sending…` : t`Send reset link`}
+					</PriButton>
+				</Form>
+				<BackRow>
+					<BackLink to='/login'>
+						<ArrowLeft size={14} aria-hidden />
+						<Trans>Back to sign in</Trans>
+					</BackLink>
+				</BackRow>
+			</Card>
+		</Page>
+	)
+}
+
+const Page = styled.div.withConfig({ displayName: 'ForgotPasswordPage' })`
+	min-height: 100dvh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--space-lg);
+	background-color: var(--color-surface);
+`
+
+const Card = styled.div.withConfig({ displayName: 'ForgotPasswordCard' })`
+	position: relative;
+	width: 100%;
+	max-width: 26rem;
+	padding: var(--space-xl);
+	background-color: var(--color-paper-aged);
+	border: 1px solid rgba(120, 95, 60, 0.45);
+	border-radius: var(--shape-2xs);
+	box-shadow:
+		var(--shadow-paper-inset),
+		0 6px 20px rgba(0, 0, 0, 0.18);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+`
+
+const Brand = styled.h1.withConfig({ displayName: 'ForgotPasswordBrand' })`
+	${stenciledTitle}
+	font-size: var(--typescale-display-small-size);
+	line-height: var(--typescale-display-small-line);
+	letter-spacing: 0.1em;
+	color: var(--color-primary);
+	margin: 0;
+`
+
+const Heading = styled.h2.withConfig({ displayName: 'ForgotPasswordHeading' })`
+	${stenciledTitle}
+	font-size: var(--typescale-headline-small-size);
+	line-height: var(--typescale-headline-small-line);
+	margin: 0;
+`
+
+const Body = styled.p.withConfig({ displayName: 'ForgotPasswordBody' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	line-height: var(--typescale-body-medium-line);
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const Form = styled.form.withConfig({ displayName: 'ForgotPasswordForm' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+`
+
+const Field = styled.div.withConfig({ displayName: 'ForgotPasswordField' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const Label = styled.label.withConfig({ displayName: 'ForgotPasswordLabel' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-label-medium-size);
+	color: var(--color-on-surface-variant);
+`
+
+const ErrorText = styled.p.withConfig({ displayName: 'ForgotPasswordError' })`
+	margin: 0;
+	padding: var(--space-2xs) var(--space-sm);
+	border-left: 3px solid var(--color-error);
+	background: color-mix(in srgb, var(--color-error) 6%, transparent);
+	color: var(--color-error);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+`
+
+const BackRow = styled.div.withConfig({ displayName: 'ForgotPasswordBackRow' })`
+	display: flex;
+	justify-content: center;
+`
+
+const BackLink = styled(Link).withConfig({
+	displayName: 'ForgotPasswordBackLink',
+})`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	text-decoration: none;
+
+	&:hover {
+		color: var(--color-on-surface);
+		text-decoration: underline;
+	}
+`

--- a/apps/internal/src/routes/login.tsx
+++ b/apps/internal/src/routes/login.tsx
@@ -1,6 +1,11 @@
 import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import {
+	createFileRoute,
+	Link,
+	redirect,
+	useNavigate,
+} from '@tanstack/react-router'
 import { Schema } from 'effect'
 import { useActionState, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -381,6 +386,13 @@ function LoginPage() {
 						{magicLinkStatus.kind === 'sending'
 							? t`Sending…`
 							: t`Email me a sign-in link`}
+					</MagicLinkTrigger>
+					<MagicLinkTrigger
+						as={Link}
+						to='/forgot-password'
+						data-testid='login-forgot-password'
+					>
+						<Trans>Forgot password?</Trans>
 					</MagicLinkTrigger>
 				</MagicLinkRow>
 				{magicLinkStatus.kind === 'error' ? (

--- a/apps/internal/src/routes/reset-password.tsx
+++ b/apps/internal/src/routes/reset-password.tsx
@@ -1,0 +1,350 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { PriButton } from '@batuda/ui/pri'
+
+import { PriPasswordInput } from '#/components/primitives/pri-password-input'
+import { authClient } from '#/lib/auth-client'
+import { stenciledTitle } from '#/lib/workshop-mixins'
+
+/**
+ * Landing page for the reset-password email link. Better Auth bounces
+ * the user from `${api}/auth/reset-password/:token?callbackURL=...` to
+ * this route with `?token=` (success) or `?error=INVALID_TOKEN` (expired
+ * or used). The form renders when a token is present; otherwise the
+ * page shows a recovery panel that points back at /forgot-password.
+ *
+ * Password inputs are uncontrolled and read via `FormData` because
+ * `PriPasswordInput` doesn't accept a controlled `value`.
+ */
+
+const MIN_PASSWORD_LENGTH = 8
+
+interface ResetSearch {
+	readonly token?: string
+	readonly error?: string
+}
+
+export const Route = createFileRoute('/reset-password')({
+	validateSearch: (search: Record<string, unknown>): ResetSearch => {
+		const result: { token?: string; error?: string } = {}
+		if (typeof search['token'] === 'string') result.token = search['token']
+		if (typeof search['error'] === 'string') result.error = search['error']
+		return result
+	},
+	head: () => ({ meta: [{ title: 'Set new password — Batuda' }] }),
+	component: ResetPasswordPage,
+})
+
+type Status =
+	| 'idle'
+	| 'submitting'
+	| 'too-short'
+	| 'mismatch'
+	| 'invalid-token'
+	| 'error'
+	| 'success'
+
+function ResetPasswordPage() {
+	const { t } = useLingui()
+	const navigate = useNavigate()
+	const search = Route.useSearch()
+	const [status, setStatus] = useState<Status>('idle')
+
+	if (search.error || !search.token) {
+		return (
+			<Page>
+				<Card data-testid='reset-password-token-error'>
+					<Brand>Batuda</Brand>
+					<Heading>
+						<Trans>This link is no longer valid</Trans>
+					</Heading>
+					<Body>
+						<Trans>
+							Reset links expire after 1 hour and can only be used once. Ask for
+							a new one and follow it within the hour.
+						</Trans>
+					</Body>
+					<PriButton
+						as={Link}
+						to='/forgot-password'
+						$variant='filled'
+						data-testid='reset-password-request-new'
+					>
+						<Trans>Request a new link</Trans>
+					</PriButton>
+					<BackRow>
+						<BackLink to='/login'>
+							<ArrowLeft size={14} aria-hidden />
+							<Trans>Back to sign in</Trans>
+						</BackLink>
+					</BackRow>
+				</Card>
+			</Page>
+		)
+	}
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault()
+		const form = new FormData(event.currentTarget)
+		const newPassword = String(form.get('newPassword') ?? '')
+		const confirm = String(form.get('newPasswordConfirm') ?? '')
+		if (newPassword.length < MIN_PASSWORD_LENGTH) {
+			setStatus('too-short')
+			return
+		}
+		if (newPassword !== confirm) {
+			setStatus('mismatch')
+			return
+		}
+		setStatus('submitting')
+		const result = await authClient.resetPassword({
+			newPassword,
+			token: search.token,
+		})
+		if (result.error) {
+			// BA returns INVALID_TOKEN for expired/used tokens — distinct
+			// state so the recovery copy points the user back at /forgot.
+			if (result.error.code === 'INVALID_TOKEN') {
+				setStatus('invalid-token')
+				return
+			}
+			setStatus('error')
+			return
+		}
+		setStatus('success')
+	}
+
+	if (status === 'invalid-token') {
+		return (
+			<Page>
+				<Card data-testid='reset-password-token-error'>
+					<Brand>Batuda</Brand>
+					<Heading>
+						<Trans>This link is no longer valid</Trans>
+					</Heading>
+					<Body>
+						<Trans>
+							The token expired or was already used. Request a fresh link.
+						</Trans>
+					</Body>
+					<PriButton
+						as={Link}
+						to='/forgot-password'
+						$variant='filled'
+						data-testid='reset-password-request-new'
+					>
+						<Trans>Request a new link</Trans>
+					</PriButton>
+				</Card>
+			</Page>
+		)
+	}
+
+	if (status === 'success') {
+		return (
+			<Page>
+				<Card
+					role='status'
+					aria-live='polite'
+					data-testid='reset-password-success'
+				>
+					<Brand>Batuda</Brand>
+					<Heading>
+						<Trans>Password updated</Trans>
+					</Heading>
+					<Body>
+						<Trans>
+							Sign in with your new password. Other devices will need to sign in
+							again too.
+						</Trans>
+					</Body>
+					<PriButton
+						type='button'
+						$variant='filled'
+						onClick={() => {
+							void navigate({ to: '/login' })
+						}}
+						data-testid='reset-password-go-login'
+					>
+						<Trans>Go to sign in</Trans>
+					</PriButton>
+				</Card>
+			</Page>
+		)
+	}
+
+	return (
+		<Page>
+			<Card>
+				<Brand>Batuda</Brand>
+				<Heading>
+					<Trans>Set a new password</Trans>
+				</Heading>
+				<Body>
+					<Trans>Pick a password you'll remember. Minimum 8 characters.</Trans>
+				</Body>
+				<Form onSubmit={handleSubmit} data-testid='reset-password-form'>
+					<Field>
+						<Label htmlFor='reset-new'>
+							<Trans>New password</Trans>
+						</Label>
+						<PriPasswordInput
+							id='reset-new'
+							name='newPassword'
+							autoComplete='new-password'
+							required
+							minLength={MIN_PASSWORD_LENGTH}
+							disabled={status === 'submitting'}
+							data-testid='reset-password-new'
+						/>
+					</Field>
+					<Field>
+						<Label htmlFor='reset-confirm'>
+							<Trans>Repeat new password</Trans>
+						</Label>
+						<PriPasswordInput
+							id='reset-confirm'
+							name='newPasswordConfirm'
+							autoComplete='new-password'
+							required
+							minLength={MIN_PASSWORD_LENGTH}
+							disabled={status === 'submitting'}
+							data-testid='reset-password-confirm'
+						/>
+					</Field>
+					{status === 'too-short' ? (
+						<ErrorText role='alert' data-testid='reset-password-error'>
+							<Trans>
+								Passwords need at least {MIN_PASSWORD_LENGTH} characters.
+							</Trans>
+						</ErrorText>
+					) : null}
+					{status === 'mismatch' ? (
+						<ErrorText role='alert' data-testid='reset-password-error'>
+							<Trans>The two passwords don't match.</Trans>
+						</ErrorText>
+					) : null}
+					{status === 'error' ? (
+						<ErrorText role='alert' data-testid='reset-password-error'>
+							<Trans>Something went wrong. Try again.</Trans>
+						</ErrorText>
+					) : null}
+					<PriButton
+						type='submit'
+						$variant='filled'
+						disabled={status === 'submitting'}
+						data-testid='reset-password-submit'
+					>
+						{status === 'submitting' ? t`Saving…` : t`Save new password`}
+					</PriButton>
+				</Form>
+			</Card>
+		</Page>
+	)
+}
+
+const Page = styled.div.withConfig({ displayName: 'ResetPasswordPage' })`
+	min-height: 100dvh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--space-lg);
+	background-color: var(--color-surface);
+`
+
+const Card = styled.div.withConfig({ displayName: 'ResetPasswordCard' })`
+	position: relative;
+	width: 100%;
+	max-width: 26rem;
+	padding: var(--space-xl);
+	background-color: var(--color-paper-aged);
+	border: 1px solid rgba(120, 95, 60, 0.45);
+	border-radius: var(--shape-2xs);
+	box-shadow:
+		var(--shadow-paper-inset),
+		0 6px 20px rgba(0, 0, 0, 0.18);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+`
+
+const Brand = styled.h1.withConfig({ displayName: 'ResetPasswordBrand' })`
+	${stenciledTitle}
+	font-size: var(--typescale-display-small-size);
+	line-height: var(--typescale-display-small-line);
+	letter-spacing: 0.1em;
+	color: var(--color-primary);
+	margin: 0;
+`
+
+const Heading = styled.h2.withConfig({ displayName: 'ResetPasswordHeading' })`
+	${stenciledTitle}
+	font-size: var(--typescale-headline-small-size);
+	line-height: var(--typescale-headline-small-line);
+	margin: 0;
+`
+
+const Body = styled.p.withConfig({ displayName: 'ResetPasswordBody' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	line-height: var(--typescale-body-medium-line);
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const Form = styled.form.withConfig({ displayName: 'ResetPasswordForm' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+`
+
+const Field = styled.div.withConfig({ displayName: 'ResetPasswordField' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const Label = styled.label.withConfig({ displayName: 'ResetPasswordLabel' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-label-medium-size);
+	color: var(--color-on-surface-variant);
+`
+
+const ErrorText = styled.p.withConfig({ displayName: 'ResetPasswordError' })`
+	margin: 0;
+	padding: var(--space-2xs) var(--space-sm);
+	border-left: 3px solid var(--color-error);
+	background: color-mix(in srgb, var(--color-error) 6%, transparent);
+	color: var(--color-error);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+`
+
+const BackRow = styled.div.withConfig({
+	displayName: 'ResetPasswordBackRow',
+})`
+	display: flex;
+	justify-content: center;
+`
+
+const BackLink = styled(Link).withConfig({
+	displayName: 'ResetPasswordBackLink',
+})`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	text-decoration: none;
+
+	&:hover {
+		color: var(--color-on-surface);
+		text-decoration: underline;
+	}
+`

--- a/apps/internal/tests/e2e/forgot-password.test.ts
+++ b/apps/internal/tests/e2e/forgot-password.test.ts
@@ -1,0 +1,214 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { expect, test } from '@playwright/test'
+
+// End-to-end forgot-password flow. The flow under test:
+//
+//   1. Visitor clicks "Forgot password?" on /login → lands on /forgot-password.
+//   2. Submits the email → frontend calls authClient.requestPasswordReset
+//      with redirectTo=`${origin}/reset-password`.
+//   3. Better Auth opaque-succeeds and writes a .md to .dev-inbox/
+//      with `labels: password-reset`. The .md carries a URL like
+//      ${apiHost}/auth/reset-password/${token}?callbackURL=${redirectTo}.
+//   4. Visitor opens that URL → BA's reset-password/:token callback
+//      origin-checks and redirects to `${redirectTo}?token=${token}`.
+//   5. /reset-password renders, the visitor types a new password,
+//      authClient.resetPassword({ newPassword, token }) updates the row.
+//   6. Sign-in with the new password succeeds.
+//
+// Selectors verified against:
+//   apps/internal/src/routes/forgot-password.tsx
+//   apps/internal/src/routes/reset-password.tsx
+//   apps/server/src/services/local-transactional-provider.ts (label key)
+
+const INBOX_DIR = join(process.cwd(), '..', 'server', '.dev-inbox')
+
+interface ResetMail {
+	readonly file: string
+	readonly url: string
+}
+
+// Polls .dev-inbox/ for a `password-reset`-labelled .md whose filename
+// contains the recipient slug, then extracts the reset URL. Same shape
+// as invite.test.ts's helper — the file appears asynchronously after
+// the API responds.
+async function pollResetMail(
+	recipient: string,
+	timeoutMs: number,
+): Promise<ResetMail> {
+	const slug = recipient.split('@')[0]!
+	const deadline = Date.now() + timeoutMs
+	let lastErr: unknown
+	while (Date.now() < deadline) {
+		try {
+			const files = await readdir(INBOX_DIR)
+			const match = files
+				.filter(name => name.includes(slug) && name.endsWith('.md'))
+				.sort()
+				.pop()
+			if (match) {
+				const body = await readFile(join(INBOX_DIR, match), 'utf8')
+				if (!body.includes('labels:') || !body.includes('password-reset')) {
+					await new Promise(r => {
+						setTimeout(r, 200)
+					})
+					continue
+				}
+				const urlMatch = body.match(
+					/https?:\/\/[^\s]*\/auth\/reset-password\/[^\s]*/,
+				)
+				if (urlMatch) return { file: match, url: urlMatch[0] }
+			}
+		} catch (e) {
+			lastErr = e
+		}
+		await new Promise(r => {
+			setTimeout(r, 200)
+		})
+	}
+	throw new Error(
+		`password-reset .md for ${recipient} did not appear within ${timeoutMs}ms (last error: ${String(lastErr)})`,
+	)
+}
+
+test.describe('forgot-password end-to-end', () => {
+	test.describe('when a registered user requests a reset', () => {
+		test('should email a link, accept a new password via /reset-password, and let her sign back in', async ({
+			page,
+		}) => {
+			// GIVEN Alice (admin@taller.cat is in the seed) opens /forgot-password
+			//   [forgot-password.tsx — form branch]
+			const recipient = 'admin@taller.cat'
+			const newPassword = `reset-pwd-${Date.now()}`
+
+			await page.goto('/forgot-password', { waitUntil: 'networkidle' })
+			await expect(page.getByTestId('forgot-password-form')).toBeVisible()
+
+			// WHEN she submits her email
+			await page.getByTestId('forgot-password-email').fill(recipient)
+			const requestResponse = page.waitForResponse(
+				resp =>
+					resp.url().includes('/auth/request-password-reset') &&
+					resp.request().method() === 'POST',
+				{ timeout: 5_000 },
+			)
+			await page.getByTestId('forgot-password-submit').click()
+			const reqRes = await requestResponse
+			expect(reqRes.status()).toBe(200)
+
+			// THEN the success panel renders (opaque, even on unknown email)
+			await expect(page.getByTestId('forgot-password-sent')).toBeVisible({
+				timeout: 10_000,
+			})
+
+			// AND a .md should land in .dev-inbox/ with the reset URL
+			//   [local-transactional-provider.ts — label: 'password-reset']
+			const mail = await pollResetMail(recipient, 5_000)
+			expect(mail.url).toContain('/auth/reset-password/')
+
+			// WHEN she opens the URL — BA bounces to /reset-password?token=...
+			//   [password.ts:152 — requestPasswordResetCallback redirect]
+			await page.goto(mail.url, { waitUntil: 'networkidle' })
+			await expect(page.getByTestId('reset-password-form')).toBeVisible({
+				timeout: 10_000,
+			})
+
+			// AND she submits a new password
+			//   [reset-password.tsx — submit branch]
+			await page.getByTestId('reset-password-new').fill(newPassword)
+			await page.getByTestId('reset-password-confirm').fill(newPassword)
+			const resetResponse = page.waitForResponse(
+				resp =>
+					resp.url().includes('/auth/reset-password') &&
+					resp.request().method() === 'POST',
+				{ timeout: 5_000 },
+			)
+			await page.getByTestId('reset-password-submit').click()
+			const resetRes = await resetResponse
+			expect(
+				resetRes.status(),
+				`POST /auth/reset-password returned ${resetRes.status()}`,
+			).toBe(200)
+
+			// THEN the success panel renders
+			await expect(page.getByTestId('reset-password-success')).toBeVisible({
+				timeout: 10_000,
+			})
+
+			// AND she can sign in with the new password.
+			await page.goto('/login', { waitUntil: 'networkidle' })
+			await page.getByTestId('login-email').fill(recipient)
+			await page.getByTestId('login-password').fill(newPassword)
+			await page.getByTestId('login-submit').click()
+			await page.waitForURL(/\/$/, { timeout: 10_000 })
+			await expect(page.getByTestId('login-form')).toHaveCount(0)
+
+			// Restore the seed password so auth.setup.ts's
+			// `batuda-dev-2026` keeps the rest of the suite green.
+			const restoreRes = await page.evaluate(
+				async ({ current, restore }) => {
+					const res = await fetch('/auth/change-password', {
+						method: 'POST',
+						credentials: 'include',
+						headers: { 'content-type': 'application/json' },
+						body: JSON.stringify({
+							currentPassword: current,
+							newPassword: restore,
+							revokeOtherSessions: false,
+						}),
+					})
+					return res.ok
+				},
+				{ current: newPassword, restore: 'batuda-dev-2026' },
+			)
+			expect(restoreRes, 'failed to restore Alice seed password').toBe(true)
+		})
+	})
+
+	test.describe('when an unregistered email is submitted', () => {
+		test('should still render the opaque "check your inbox" panel (no enumeration)', async ({
+			page,
+		}) => {
+			// GIVEN /forgot-password
+			//   [password.ts:104 — silent-success branch]
+			await page.goto('/forgot-password', { waitUntil: 'networkidle' })
+
+			// WHEN an email that is not in `user` is submitted
+			await page
+				.getByTestId('forgot-password-email')
+				.fill(`noone-${Date.now()}@example.invalid`)
+			const response = page.waitForResponse(
+				resp =>
+					resp.url().includes('/auth/request-password-reset') &&
+					resp.request().method() === 'POST',
+				{ timeout: 5_000 },
+			)
+			await page.getByTestId('forgot-password-submit').click()
+
+			// THEN the API still returns 200 and the same success panel renders
+			const res = await response
+			expect(res.status()).toBe(200)
+			await expect(page.getByTestId('forgot-password-sent')).toBeVisible({
+				timeout: 10_000,
+			})
+		})
+	})
+
+	test.describe('when the user lands on /reset-password without a token', () => {
+		test('should render the invalid-link recovery state with a CTA back to /forgot-password', async ({
+			page,
+		}) => {
+			// GIVEN no token (e.g. user copied a stale URL or hit the route directly)
+			//   [reset-password.tsx — missing-token branch]
+			await page.goto('/reset-password', { waitUntil: 'networkidle' })
+
+			// THEN the form should NOT render, the error state should
+			await expect(page.getByTestId('reset-password-form')).toHaveCount(0)
+			await expect(page.getByTestId('reset-password-token-error')).toBeVisible({
+				timeout: 10_000,
+			})
+			await expect(page.getByTestId('reset-password-request-new')).toBeVisible()
+		})
+	})
+})

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -76,6 +76,20 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 					rateLimit: env.BETTER_AUTH_RATE_LIMIT,
 				},
 				pool,
+				sendResetPassword: async data => {
+					// Mirror BA's default `resetPasswordTokenExpiresIn` (1h) and
+					// pass it through so the template can tell the recipient
+					// whether the link is still good.
+					const RESET_TOKEN_TTL_MS = 60 * 60 * 1000
+					const expiresAt = new Date(Date.now() + RESET_TOKEN_TTL_MS)
+					await Effect.runPromise(
+						transactional.sendResetPassword({
+							email: data.user.email,
+							url: data.url,
+							expiresAt,
+						}),
+					)
+				},
 				plugins: [
 					openAPI(),
 					bearer(),

--- a/apps/server/src/services/local-transactional-provider.ts
+++ b/apps/server/src/services/local-transactional-provider.ts
@@ -9,6 +9,7 @@ import { EmailSendError } from '@batuda/controllers'
 import {
 	type InvitationParams,
 	type MagicLinkParams,
+	type ResetPasswordParams,
 	TransactionalEmailProvider,
 } from './transactional-email-provider.js'
 
@@ -131,6 +132,25 @@ export const LocalTransactionalProviderLive = Layer.effect(
 				label: 'magic-link',
 			})
 
+		const sendResetPassword = (params: ResetPasswordParams) => {
+			const expiry = params.expiresAt.toISOString()
+			const bodyText = [
+				'Someone (hopefully you) asked to reset your Batuda password.',
+				'',
+				'Click the link below to choose a new one:',
+				'',
+				params.url,
+				'',
+				`This link expires at ${expiry}. If you didn't request a reset, you can ignore this email.`,
+			].join('\n')
+			return writeMd({
+				to: params.email,
+				subject: 'Reset your Batuda password',
+				bodyText,
+				label: 'password-reset',
+			})
+		}
+
 		const sendInvitation = (params: InvitationParams) => {
 			const expiry = params.expiresAt.toISOString()
 			const subject = `${params.inviterName} invited you to ${params.organizationName} on Batuda`
@@ -151,6 +171,6 @@ export const LocalTransactionalProviderLive = Layer.effect(
 			})
 		}
 
-		return { sendMagicLink, sendInvitation } as const
+		return { sendMagicLink, sendInvitation, sendResetPassword } as const
 	}),
 )

--- a/apps/server/src/services/resend-transactional-provider.ts
+++ b/apps/server/src/services/resend-transactional-provider.ts
@@ -5,6 +5,7 @@ import { EmailSendError } from '@batuda/controllers'
 import {
 	type InvitationParams,
 	type MagicLinkParams,
+	type ResetPasswordParams,
 	TransactionalEmailProvider,
 } from './transactional-email-provider.js'
 
@@ -71,8 +72,36 @@ const buildInvitationBody = (
 	}
 }
 
+const buildResetPasswordBody = (
+	params: ResetPasswordParams,
+	from: string,
+): ResendBody => {
+	const expiry = params.expiresAt.toISOString()
+	const url = escapeHtml(params.url)
+	return {
+		from,
+		to: [params.email],
+		subject: 'Reset your Batuda password',
+		text: [
+			'Someone (hopefully you) asked to reset your Batuda password.',
+			'',
+			'Click the link below to choose a new one:',
+			'',
+			params.url,
+			'',
+			`This link expires at ${expiry}. If you didn't request a reset, you can ignore this email.`,
+		].join('\n'),
+		html: [
+			'<p>Someone (hopefully you) asked to reset your Batuda password.</p>',
+			'<p>Click the link below to choose a new one:</p>',
+			`<p><a href="${url}">${url}</a></p>`,
+			`<p style="color:#666">This link expires at ${expiry}. If you didn't request a reset, you can ignore this email.</p>`,
+		].join(''),
+	}
+}
+
 // Sends via the Resend REST API. Raw `fetch` keeps this layer dependency-free
-// (no SDK transitives) — magic-link delivery is one POST, one JSON body.
+// (no SDK transitives) — every template is one POST, one JSON body.
 export const ResendTransactionalProviderLive = Layer.effect(
 	TransactionalEmailProvider,
 	Effect.gen(function* () {
@@ -127,6 +156,9 @@ export const ResendTransactionalProviderLive = Layer.effect(
 		const sendInvitation = (params: InvitationParams) =>
 			post(buildInvitationBody(params, from), params.email)
 
-		return { sendMagicLink, sendInvitation } as const
+		const sendResetPassword = (params: ResetPasswordParams) =>
+			post(buildResetPasswordBody(params, from), params.email)
+
+		return { sendMagicLink, sendInvitation, sendResetPassword } as const
 	}),
 )

--- a/apps/server/src/services/transactional-email-provider.test.ts
+++ b/apps/server/src/services/transactional-email-provider.test.ts
@@ -103,6 +103,52 @@ describe('TransactionalEmailProvider — Local (integration)', () => {
 		})
 	})
 
+	describe('sendResetPassword', () => {
+		describe('when called with valid params', () => {
+			it('should write a .md file with labels: password-reset and the expiry inline', async () => {
+				// GIVEN the local transactional provider
+				// AND a recipient unique to this run
+				const recipient = `it-resetpwd-${Date.now()}@example.com`
+				const expiresAt = new Date('2026-06-01T12:00:00Z')
+
+				// WHEN we send a reset-password email
+				await program(
+					Effect.gen(function* () {
+						const provider = yield* TransactionalEmailProvider
+						yield* provider.sendResetPassword({
+							email: recipient,
+							url: 'https://api.batuda.localhost/auth/reset-password/tok-1?callbackURL=https://batuda.localhost/reset-password',
+							expiresAt,
+						})
+					}),
+				)
+
+				// THEN a .md file should appear in the dev-inbox dir
+				//   [local-transactional-provider.ts — sendResetPassword writeMd branch]
+				const inbox = join(__dirname, '..', '..', '.dev-inbox')
+				const files = await readdir(inbox)
+				const match = files.find(name =>
+					name.includes(recipient.split('@')[0]!),
+				)
+				expect(
+					match,
+					'expected a file matching the recipient slug',
+				).toBeTruthy()
+
+				// AND the frontmatter should carry labels: ['password-reset']
+				const body = await readFile(join(inbox, match!), 'utf8')
+				expect(body).toMatch(/labels:\s*\n\s+- password-reset/)
+
+				// AND the body should include the URL + ISO expiry so the recipient
+				// knows whether the link is still good.
+				expect(body).toContain('/auth/reset-password/tok-1')
+				expect(body).toContain(expiresAt.toISOString())
+
+				await rm(join(inbox, match!), { force: true })
+			})
+		})
+	})
+
 	describe('sendMagicLink (regression — must still work after sendInvitation lands)', () => {
 		describe('when called with valid params', () => {
 			it('should write a .md file with labels: magic-link', async () => {
@@ -320,6 +366,44 @@ describe('TransactionalEmailProvider — Resend (unit, stubbed fetch)', () => {
 				if (exit._tag !== 'Failure') return
 				const error = failureFrom(exit.cause)
 				expect(error?.kind).toBe('unknown')
+			})
+		})
+
+		describe('sendResetPassword via Resend', () => {
+			it('should POST the reset-password template with the URL inline + ISO expiry', async () => {
+				// GIVEN the stub captures the request shape
+				//   [resend-transactional-provider.ts — sendResetPassword branch]
+				const captured: { url?: string; init?: RequestInit } = {}
+				const stub: typeof fetch = async (input, init) => {
+					captured.url = input.toString()
+					if (init) captured.init = init
+					return new Response('{}', { status: 200 })
+				}
+				const expiresAt = new Date('2026-06-01T12:00:00Z')
+
+				// WHEN we send a reset-password email
+				const exit = await runWith(
+					stub,
+					Effect.gen(function* () {
+						const provider = yield* TransactionalEmailProvider
+						yield* provider.sendResetPassword({
+							email: 'pwd-reset@example.com',
+							url: 'https://api.batuda.localhost/auth/reset-password/tok-1?callbackURL=https://batuda.localhost/reset-password',
+							expiresAt,
+						})
+					}),
+				)
+				expect(exit._tag, 'exit should be Success').toBe('Success')
+
+				// THEN the body carries the URL + recipient + escaped HTML link
+				expect(captured.url).toBe('https://api.resend.com/emails')
+				const body = JSON.parse(String(captured.init?.body))
+				expect(body.to).toEqual(['pwd-reset@example.com'])
+				expect(body.subject).toContain('Reset')
+				expect(body.text).toContain('/auth/reset-password/tok-1')
+				expect(body.text).toContain(expiresAt.toISOString())
+				expect(body.html).toContain('href="')
+				expect(body.html).toContain(expiresAt.toISOString())
 			})
 		})
 

--- a/apps/server/src/services/transactional-email-provider.ts
+++ b/apps/server/src/services/transactional-email-provider.ts
@@ -2,17 +2,28 @@ import { type Effect, ServiceMap } from 'effect'
 
 import type { EmailSendError } from '@batuda/controllers'
 
-// System-originated transactional email — magic links today, password
-// resets and invitation emails next. Kept separate from the BYO-mailbox
-// `EmailProvider` because the deployment shape, reliability requirements,
-// and operational tooling (DKIM/SPF on Batuda's domain vs the user's)
-// don't overlap. CRM mailbox outage = one user complaining; transactional
-// outage = nobody can log in.
+// System-originated transactional email — magic links, password resets,
+// and org invitations. Kept separate from the BYO-mailbox `EmailProvider`
+// because the deployment shape, reliability requirements, and operational
+// tooling (DKIM/SPF on Batuda's domain vs the user's) don't overlap. CRM
+// mailbox outage = one user complaining; transactional outage = nobody
+// can log in.
 
 export interface MagicLinkParams {
 	readonly email: string
 	readonly url: string
 	readonly token: string
+}
+
+// Reset-password URL bounces through BA's `/auth/reset-password/:token`
+// callback endpoint (origin-checked) which then redirects to the frontend
+// `/reset-password?token=...` page. `expiresAt` is BA's
+// `resetPasswordTokenExpiresIn` (default 1 hour) — the template surfaces
+// it so a returning user knows whether the link is still good.
+export interface ResetPasswordParams {
+	readonly email: string
+	readonly url: string
+	readonly expiresAt: Date
 }
 
 // Org invitation. `inviteUrl` is the magic-link URL minted by the BA
@@ -36,6 +47,9 @@ export class TransactionalEmailProvider extends ServiceMap.Service<
 		) => Effect.Effect<void, EmailSendError>
 		readonly sendInvitation: (
 			params: InvitationParams,
+		) => Effect.Effect<void, EmailSendError>
+		readonly sendResetPassword: (
+			params: ResetPasswordParams,
 		) => Effect.Effect<void, EmailSendError>
 	}
 >()('TransactionalEmailProvider') {}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -69,5 +69,6 @@ export {
 	type AuthEnv,
 	type BuildBetterAuthConfigInput,
 	buildBetterAuthConfig,
+	type SendResetPassword,
 } from './infrastructure/build-better-auth-config'
 export { acquirePgPool } from './infrastructure/pg-pool'

--- a/packages/auth/src/infrastructure/build-better-auth-config.ts
+++ b/packages/auth/src/infrastructure/build-better-auth-config.ts
@@ -19,12 +19,29 @@ export interface AuthEnv {
 	readonly rateLimit?: 'strict' | 'loose'
 }
 
+/**
+ * BA invokes `sendResetPassword({ user, url, token }, ctx.request)`. The
+ * `/request-password-reset` route silently succeeds for unknown emails
+ * (see docs/repos/better-auth/.../api/routes/password.ts:101-119), so
+ * by the time this callback fires the user is guaranteed to exist.
+ * CLI callers omit it — there is no recovery-email surface in the CLI.
+ */
+export type SendResetPassword = (
+	data: {
+		readonly user: { readonly email: string }
+		readonly url: string
+		readonly token: string
+	},
+	request?: Request,
+) => Promise<void>
+
 export interface BuildBetterAuthConfigInput<
 	Plugins extends BetterAuthPlugin[],
 > {
 	readonly env: AuthEnv
 	readonly pool: pg.Pool
 	readonly plugins: Plugins
+	readonly sendResetPassword?: SendResetPassword
 }
 
 /**
@@ -82,7 +99,16 @@ export const buildBetterAuthConfig = <Plugins extends BetterAuthPlugin[]>(
 			dialect: new PostgresDialect({ pool: input.pool }),
 			type: 'postgres' as const,
 		},
-		emailAndPassword: { enabled: true, disableSignUp: true }, // Invite-only: new users created via admin plugin, not public sign-up.
+		// Invite-only: new users created via admin plugin, not public sign-up.
+		// `sendResetPassword` is wired by the server only; the CLI omits it
+		// because there is no recovery-email surface in CLI flows.
+		emailAndPassword: {
+			enabled: true,
+			disableSignUp: true,
+			...(input.sendResetPassword
+				? { sendResetPassword: input.sendResetPassword }
+				: {}),
+		},
 		user: {
 			additionalFields: {
 				isAgent: {
@@ -156,6 +182,10 @@ export const buildBetterAuthConfig = <Plugins extends BetterAuthPlugin[]>(
 					// Production stays on the plugin default.
 					'/sign-in/magic-link': { window: 60, max: 200 },
 					'/magic-link/verify': { window: 60, max: 200 },
+					// Reset-password default is the global 100/min; the forgot-password
+					// e2e fires several requests back-to-back across the suite. Loose
+					// mode widens just this route; production stays on the global cap.
+					'/request-password-reset': { window: 60, max: 200 },
 					'/get-session': { window: 60, max: 1000 },
 					'/organization/set-active': { window: 60, max: 500 },
 				},


### PR DESCRIPTION
## Summary

Closes the third slice of the password+passwordless feature series (parent plan: `i-like-it-plan-misty-robin.md`). Adds a self-serve recovery path for users who lose their password.

The flow is **fully BA-native**: `POST /auth/request-password-reset` → email with `/auth/reset-password/:token?callbackURL=...` → BA's origin-checked callback redirects to `/reset-password?token=...` → frontend POSTs `authClient.resetPassword({newPassword, token})`. No custom plugin.

## What's in this PR

### Server side
- **Transactional provider** gains `sendResetPassword({email, url, expiresAt})` on the port + Local + Resend impls. Local writer uses `labels: password-reset` so the dev-inbox surface filters correctly.
- **`buildBetterAuthConfig`** accepts an optional `SendResetPassword` callback and forwards it into BA's `emailAndPassword.sendResetPassword`. Server bridges BA's `{user, url, token}` onto the provider's `{email, url, expiresAt}` and stamps a 1-hour TTL matching BA's `resetPasswordTokenExpiresIn` default. CLI omits the callback (no recovery email in CLI flows).
- **Loose-mode rate-limit** raises `/request-password-reset` from the global 100/min to 200/min so the e2e suite doesn't trip strict mode.
- **vitest extension** covers the Local impl's `.md` writer with `password-reset` label + the Resend impl's request body shape.

### Frontend
- **`/forgot-password`** — single-email-field form. Opaque success panel matches BA's anti-enumeration response shape (same render regardless of whether the email exists).
- **`/reset-password`** — three-state route: missing/invalid token → recovery CTA back to `/forgot-password`; new-password form (uncontrolled inputs + FormData, per `feedback_password_input_uncontrolled`); success state with a CTA back to `/login`.
- **`/login`** gains a "Forgot password?" link next to the magic-link affordance.
- **`__root.tsx` public-path gates** + the Playwright `unauth` project regex extended so unauth visitors can reach both routes.

### Tests
- **`forgot-password.test.ts`** (Playwright e2e) covers three scenarios — registered email round-trip, unregistered email opaque success, missing-token recovery state. The happy-path test restores Alice's seed password to keep `auth.setup.ts` green for sibling suites.

## Test plan

- [x] Server vitest — 9 tests in `transactional-email-provider.test.ts` covering Local + Resend for invitation + magic-link + sendResetPassword (regression + new).
- [x] Internal e2e — `forgot-password.test.ts` 3/3 pass.
- [x] Workspace `pnpm -w check-types` green.
- [x] Workspace `pnpm -w test` green (116 server tests).
- [x] Workspace `pnpm -w build` green.
- [x] i18n: 670 strings, 0 missing (en/ca).
- [x] Manual smoke against the running dev stack — request reset, click `.dev-inbox/.md` URL, set new password, sign in.

## Out of scope

- No 2FA / OTP / passkeys.
- No template differentiation by user role.
- No "reset request rate-limit per-user" beyond BA's global window — the standard origin-check + IP-window pair is enough at this scale.