### PR TITLE
feat: ship mail-worker as a releasable + deployable target

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
 	"respectGitignore": false,
-	"model": "claude-opus-4-7",
 	"permissions": {
 		"allow": [
 			"Bash(curl -s* https://*batuda.localhost/*)",
@@ -20,6 +19,7 @@
 			"Bash(agent-browser --help)"
 		]
 	},
+	"model": "claude-opus-4-7",
 	"hooks": {
 		"PreToolUse": [
 			{
@@ -124,6 +124,8 @@
 	"enabledPlugins": {
 		"frontend-design@claude-plugins-official": true,
 		"readability-improver@ai-standards": true,
-		"test-bdd@ai-standards": true
+		"test-bdd@ai-standards": true,
+		"unikraft@ai-standards": true,
+		"a11y-accessibility-reviewer@ai-standards": true
 	}
 }

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: This skill should be used when the user asks to "release", "deploy", "ship", "create a new version", "release server", "release internal", "release ui", "release all", or mentions CalVer versioning. Handles interactive release workflow for Batuda targets (server, internal, ui, or all) with independent CalVer versioning, GitHub tag-based deploys/publishes, and post-release verification.
+description: This skill should be used when the user asks to "release", "deploy", "ship", "create a new version", "release server", "release internal", "release ui", "release mail-worker", "release all", or mentions CalVer versioning. Handles interactive release workflow for Batuda targets (server, internal, ui, mail-worker, or all) with independent CalVer versioning, GitHub tag-based deploys/publishes, and post-release verification.
 allowed-tools: Bash(git:*) Bash(pnpm:*) Bash(gh:*) Bash(kraft:*) Bash(curl:*) Bash(npm:*) Read AskUserQuestion
 ---
 
@@ -21,14 +21,15 @@ If any check fails, inform the developer and stop.
 
 ## Step 2: Determine Which Target to Release
 
-If the user passed an argument (e.g. `/release server`, `/release ui`, `/release all`), use it directly — skip the question. Accepted values: `server`, `internal`, `ui`, `all`.
+If the user passed an argument (e.g. `/release server`, `/release ui`, `/release all`), use it directly — skip the question. Accepted values: `server`, `internal`, `ui`, `mail-worker`, `all`.
 
 Otherwise, use `AskUserQuestion`:
 
 - **Server** — API at api.batuda.co (`server-v*` tag → auto-deploys)
 - **Internal** — Batuda web at batuda.co (`internal-v*` tag → auto-deploys; tag prefix kept while the app folder is `apps/internal/`)
 - **UI** — `@batuda/ui` shared package (`ui-v*` tag → auto-publishes to npm)
-- **All** — Server first, then Internal, then UI
+- **Mail-worker** — IMAP IDLE + SMTP-aware worker (`mail-worker-v*` tag → auto-deploys to KraftCloud as a background instance, no public endpoint)
+- **All** — Server first, then Internal, then UI, then Mail-worker
 
 ## Step 3: Check Commits Exist
 
@@ -44,6 +45,10 @@ git rev-list <tag>..HEAD --count -- apps/internal packages/
 # UI
 git describe --tags --match='ui-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || echo "no-tag"
 git rev-list <tag>..HEAD --count -- packages/ui
+
+# Mail-worker
+git describe --tags --match='mail-worker-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || echo "no-tag"
+git rev-list <tag>..HEAD --count -- apps/mail-worker packages/
 ```
 
 If 0 commits, ask if they want to force with `--no-git.requireCommits`.
@@ -51,27 +56,27 @@ If 0 commits, ask if they want to force with `--no-git.requireCommits`.
 ## Step 4: Dry Run
 
 ```bash
-pnpm release:server:dry   # or release:internal:dry / release:ui:dry
+pnpm release:server:dry   # or release:internal:dry / release:ui:dry / release:mail-worker:dry
 ```
 
 Show the expected version and changelog. Ask for confirmation.
 
 ## Step 4.5: Apply DB Migrations (if schema changed)
 
-Only for `server` or `all` releases. Check whether migration files changed since the last server tag:
+Only for `server` or `all` releases (mail-worker reads/writes existing schema; no migrations live under `apps/mail-worker/`). Check whether migration files changed since the last server tag:
 
 ```bash
 last_tag=$(git describe --tags --match='server-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null)
 git diff --name-only "$last_tag"..HEAD -- apps/server/src/db/migrations/
 ```
 
-If non-empty **and** a production DB is provisioned, run migrations against the direct (non-pooled) NeonDB URL from your machine before tagging:
+If non-empty, run migrations against the direct (non-pooled) NeonDB URL from your machine before tagging:
 
 ```bash
 DATABASE_URL="<neon-direct-url>" pnpm db:migrate
 ```
 
-The deploy workflow does not run migrations — deploying new server code against an unmigrated schema will crash on boot. Skip this step until Phase 2 of `docs/TODO_DEPLOYMENT.md` is done (prod DB not yet provisioned).
+The deploy workflow does not run migrations — deploying new server code against an unmigrated schema will crash on boot.
 
 ## Step 5: Execute Release
 
@@ -79,9 +84,10 @@ The deploy workflow does not run migrations — deploying new server code agains
 GITHUB_TOKEN=$(gh auth token) pnpm release:server --ci
 GITHUB_TOKEN=$(gh auth token) pnpm release:internal --ci
 GITHUB_TOKEN=$(gh auth token) pnpm release:ui --ci
+GITHUB_TOKEN=$(gh auth token) pnpm release:mail-worker --ci
 ```
 
-**Note:** Deploy triggers automatically on tag push via GitHub workflows. For `ui`, the `ui-v*` tag triggers `publish-ui.yml` which builds `packages/ui/dist` and publishes to npm with provenance via npm **Trusted Publishing (OIDC)** — no `NPM_TOKEN` secret. The trusted publisher is configured at https://www.npmjs.com/package/@batuda/ui/access (repo: `guillempuche/batuda`, workflow: `publish-ui.yml`). Same-day patches land as `YYYY.M.D-N` (a semver prerelease), so the workflow passes `--tag latest` to keep them as the default install target. JSR is not used — it does not allow non-JS/TS files and the UI package ships `tokens.css` / `tailwind.css`.
+**Note:** Deploy triggers automatically on tag push via GitHub workflows. For `ui`, the `ui-v*` tag triggers `publish-ui.yml` which builds `packages/ui/dist` and publishes to npm with provenance via npm **Trusted Publishing (OIDC)** — no `NPM_TOKEN` secret. The trusted publisher is configured at https://www.npmjs.com/package/@batuda/ui/access (repo: `guillempuche/batuda`, workflow: `publish-ui.yml`). Same-day patches land as `YYYY.M.D-N` (a semver prerelease), so the workflow passes `--tag latest` to keep them as the default install target. JSR is not used — it does not allow non-JS/TS files and the UI package ships `tokens.css` / `tailwind.css`. For `mail-worker`, the `mail-worker-v*` tag triggers `deploy_mail_worker.yml` which builds the worker image and `kraft cloud deploy`s it to a no-public-port service on KraftCloud.
 
 ## Step 6: Watch Deployment
 
@@ -101,6 +107,11 @@ gh run watch
 # UI
 sleep 5
 gh run list --workflow=publish-ui.yml --limit 1
+gh run watch
+
+# Mail-worker
+sleep 5
+gh run list --workflow=deploy_mail_worker.yml --limit 1
 gh run watch
 ```
 
@@ -128,6 +139,15 @@ kraft cloud --metro fra service get batuda-web
 npm view @batuda/ui version     # latest on npm
 ```
 
+**Mail-worker:**
+
+```bash
+kraft cloud --metro fra instance list | grep batuda-mail-worker
+kraft cloud --metro fra instance logs batuda-mail-worker --tail 50 | grep "IDLE established"
+```
+
+No `curl /health` — the mail-worker has no HTTP listener.
+
 ## Config Reference
 
 ```
@@ -135,6 +155,7 @@ npm view @batuda/ui version     # latest on npm
 .release-it.server.cjs             # Server: extends base, tag server-v*
 .release-it.internal.cjs           # Internal: extends base, tag internal-v*
 .release-it.ui.cjs                 # UI: extends base, tag ui-v*
+.release-it.mail-worker.cjs        # Mail-worker: extends base, tag mail-worker-v*
 scripts/release-calver-plugin.cjs  # CalVer version computation
 scripts/release-utils.cjs          # Workspace dependency path resolver
 ```
@@ -146,6 +167,7 @@ release-it only considers commits that touch relevant paths (computed by `script
 - **Server:** `apps/server` + all `workspace:*` dependencies
 - **Internal:** `apps/internal` + all `workspace:*` dependencies
 - **UI:** `packages/ui` (leaf — no workspace deps of its own)
+- **Mail-worker:** `apps/mail-worker` + all `workspace:*` dependencies
 
 A change to `packages/ui/` counts for any app that depends on it.
 

--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -1,0 +1,115 @@
+name: Deploy Mail-worker
+
+on:
+  push:
+    tags:
+      - "mail-worker-v*"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-mail-worker
+  cancel-in-progress: false
+
+env:
+  KRAFTCLOUD_METRO: fra
+  # Pinned to the same kraft CLI version as deploy_server.yml. Bump
+  # both together after a dry-run on one target.
+  KRAFT_VERSION: v0.12.10
+
+jobs:
+  deploy:
+    name: Deploy to KraftCloud
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare files for KraftCloud
+        run: |
+          cp apps/mail-worker/Kraftfile Kraftfile
+          cp apps/mail-worker/Dockerfile Dockerfile
+
+      - name: Cache KraftCloud CLI
+        id: kraft-cache
+        uses: actions/cache@v5
+        with:
+          path: kraft.deb
+          key: kraft-cli-${{ env.KRAFT_VERSION }}
+
+      - name: Download KraftCloud CLI
+        if: steps.kraft-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sSfL "https://github.com/unikraft/kraftkit/releases/download/${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION#v}_linux_amd64.deb" -o kraft.deb
+
+      - name: Install KraftCloud CLI
+        run: |
+          sudo dpkg -i kraft.deb
+          which kraft
+
+      - name: Extract version from tag
+        id: meta
+        run: |
+          if [[ "$GITHUB_REF_NAME" == mail-worker-v* ]]; then
+            echo "version=${GITHUB_REF_NAME#mail-worker-v}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(node -p "require('./apps/mail-worker/package.json').version")" >> $GITHUB_OUTPUT
+          fi
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      # Background worker — no public HTTP endpoint, so no service. Use a
+      # stable instance name (`batuda-mail-worker`) mirroring the
+      # batuda-server / batuda-web naming so ops commands target a
+      # predictable identity. The IMAP IDLE connections drop on any
+      # restart and the worker's claim-and-reconnect loop re-establishes
+      # them, so a ~5s gap between delete + recreate is acceptable.
+      - name: Delete previous instance (idempotent)
+        env:
+          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
+        run: |
+          kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance remove batuda-mail-worker 2>&1 | grep -v "not found" || true
+
+      - name: Deploy to KraftCloud
+        uses: nick-fields/retry@v4
+        env:
+          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          # -M 2048 mirrors server's footprint; mail-worker's deploy tree
+          # (aws-sdk + imapflow + mailparser + pg + effect) is comparable.
+          # --timeout 10s is mandatory: UKC caps per-RPC timeouts at
+          # 10000ms; kraft's 60s default is rejected with HTTP 400.
+          # --scale-to-zero off matches the Kraftfile label and keeps the
+          # IDLE-holding worker always-warm.
+          command: |
+            kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
+              --timeout 10s \
+              --name batuda-mail-worker \
+              -M 2048 \
+              --scale-to-zero off \
+              -e NODE_ENV=production \
+              -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
+              -e GIT_SHA="${{ github.sha }}" \
+              -e REGION="${{ env.KRAFTCLOUD_METRO }}" \
+              -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
+              -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
+              -e STORAGE_ENDPOINT="${{ vars.STORAGE_ENDPOINT }}" \
+              -e STORAGE_REGION="${{ vars.STORAGE_REGION }}" \
+              -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
+              -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
+              -e STORAGE_BUCKET="${{ vars.STORAGE_BUCKET }}" \
+              .
+
+      - name: Verify deployment
+        env:
+          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
+        run: |
+          sleep 5
+          kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance get batuda-mail-worker
+          # claimAvailableInboxes runs every 5 s, so an IDLE-established
+          # log line should appear within ~10 s if any inbox is provisioned.
+          kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance logs batuda-mail-worker --tail 100 || echo "::warning::No logs yet"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
           - server
           - internal
           - ui
+          - mail-worker
           - all
       dry_run:
         description: "Dry run (preview without creating release)"
@@ -65,5 +66,13 @@ jobs:
       - name: Release UI
         if: inputs.app == 'ui' || inputs.app == 'all'
         run: pnpm release:ui --ci ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Mail-worker runs last in `all` so a failing API-side release
+      # doesn't leave a half-promoted worker stack.
+      - name: Release Mail-worker
+        if: inputs.app == 'mail-worker' || inputs.app == 'all'
+        run: pnpm release:mail-worker --ci ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-it.mail-worker.cjs
+++ b/.release-it.mail-worker.cjs
@@ -1,0 +1,42 @@
+const {
+	getCommitPathsArray,
+	changelogPreset,
+	changelogHeader,
+} = require('./scripts/release-utils.cjs')
+
+module.exports = {
+	extends: './.release-it.base.json',
+	git: {
+		commitsPath: 'apps/mail-worker',
+		commitMessage: 'cicd(release): mail-worker v${version}',
+		tagAnnotation: 'Mail-worker Release v${version}',
+		tagMatch: 'mail-worker-v[0-9]*.[0-9]*.[0-9]*',
+		tagName: 'mail-worker-v${version}',
+	},
+	github: {
+		releaseName: 'Mail-worker v${version}',
+	},
+	hooks: {
+		'after:release': "echo '✅ Released mail-worker v${version}'",
+	},
+	npm: false,
+	plugins: {
+		'./scripts/release-calver-plugin.cjs': {},
+		'@release-it/bumper': {
+			in: 'apps/mail-worker/package.json',
+			out: 'apps/mail-worker/package.json',
+		},
+		'@release-it/conventional-changelog': {
+			gitRawCommitsOpts: {
+				path: getCommitPathsArray('apps/mail-worker'),
+			},
+			header: changelogHeader,
+			ignoreRecommendedBump: true,
+			infile: 'apps/mail-worker/CHANGELOG.md',
+			preset: changelogPreset,
+			writerOpts: {
+				headerPartial: '## {{date}} ({{currentTag}})\n',
+			},
+		},
+	},
+}

--- a/apps/mail-worker/CHANGELOG.md
+++ b/apps/mail-worker/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/apps/mail-worker/Dockerfile
+++ b/apps/mail-worker/Dockerfile
@@ -1,0 +1,51 @@
+# Stage 1 — build
+FROM node:24-alpine AS build
+
+# Disable parallel IPv4/IPv6 — required for Unikraft's network stack
+ENV NODE_OPTIONS=--no-network-family-autoselection
+
+WORKDIR /repo
+
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
+
+# Copy workspace manifests first for layer caching
+COPY ./package.json ./pnpm-lock.yaml ./pnpm-workspace.yaml ./tsconfig.base.json ./
+COPY ./turbo.json ./
+
+# Disable lefthook in Docker build (no git available)
+RUN sed -i 's/"prepare": "lefthook install"/"prepare": ""/' package.json
+
+# Copy the full workspace so the turbo filter has the complete graph.
+# @batuda/mail-worker transitively depends on auth, calendar, controllers,
+# domain, email, research, ui — turbo's `^build` resolves them all.
+COPY ./apps ./apps
+COPY ./packages ./packages
+
+RUN --mount=type=cache,target=/root/.pnpm-store \
+    CI=true pnpm install --frozen-lockfile
+
+RUN DO_NOT_TRACK=1 TURBO_TELEMETRY_DISABLED=1 \
+    pnpm turbo run build --filter=@batuda/mail-worker
+
+# Produce a self-contained deploy tree (app dist + flattened prod
+# node_modules). tsdown externalizes `dependencies` by default, so the
+# runtime image needs real node_modules — bundling alone is not enough.
+RUN pnpm deploy --filter=@batuda/mail-worker --prod /deploy
+
+# Stage 2 — runtime (production-only, no devDependencies or source)
+FROM node:24-alpine
+
+ENV NODE_OPTIONS=--no-network-family-autoselection
+ENV NODE_ENV=production
+
+# Run as non-root for security
+RUN addgroup -g 1001 -S app && adduser -u 1001 -S app -G app
+
+WORKDIR /app
+
+COPY --from=build --chown=app:app /deploy /app
+
+USER app
+
+CMD ["node", "dist/main.mjs"]

--- a/apps/mail-worker/Kraftfile
+++ b/apps/mail-worker/Kraftfile
@@ -1,0 +1,16 @@
+spec: v0.6
+
+name: batuda-mail-worker
+
+runtime: node:latest
+
+labels:
+  # Scale-to-zero is OFF: mail-worker holds long-lived IMAP IDLE
+  # connections per inbox. A scale-to-zero suspend would drop those
+  # connections every idle window and lose IDLE notifications between
+  # wake-ups; the worker's claim/reconnect loop is built for crash
+  # recovery, not for re-establishing connections every few minutes.
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
+
+rootfs: ./Dockerfile
+cmd: ["/usr/bin/node", "/app/dist/main.mjs"]

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
 		"release:server": "release-it --config .release-it.server.cjs",
 		"release:internal": "release-it --config .release-it.internal.cjs",
 		"release:ui": "release-it --config .release-it.ui.cjs",
+		"release:mail-worker": "release-it --config .release-it.mail-worker.cjs",
 		"release:server:dry": "release-it --config .release-it.server.cjs --dry-run",
 		"release:internal:dry": "release-it --config .release-it.internal.cjs --dry-run",
 		"release:ui:dry": "release-it --config .release-it.ui.cjs --dry-run",
+		"release:mail-worker:dry": "release-it --config .release-it.mail-worker.cjs --dry-run",
 		"______ Setup ______": "",
 		"prepare": "lefthook install",
 		"setup": "pnpm cli -- setup"


### PR DESCRIPTION
## Summary
- **Deploy artifacts**: `apps/mail-worker/{Dockerfile,Kraftfile}` + `.github/workflows/deploy_mail_worker.yml`. Background instance pattern (no service, no public endpoint) with a stable name `batuda-mail-worker` mirroring the `batuda-server` / `batuda-web` convention. Delete-then-create on each deploy (~5s gap; the worker's claim+reconnect loop tolerates restarts the same way IMAP IDLE drops are handled today).
- **Release pipeline**: `.release-it.mail-worker.cjs` mirrors the per-target shape of the existing `server` / `internal` / `ui` configs (same CalVer plugin, same base config, distinct `commitsPath` / `tagName` / `CHANGELOG`). Root `package.json` gets `release:mail-worker` + `release:mail-worker:dry`. The `Release` workflow dispatcher adds a `mail-worker` choice and runs the new target **last** in `all`-mode releases so a failing API release doesn't promote a half-built worker stack.
- **Skill update**: `/release` skill learns the new target — Steps 2-7 + Config Reference + Commit Path Tracking all get mail-worker stanzas. Also dropped a stale Step 4.5 note about "prod DB not yet provisioned" (it has been, since 2026-05-11).
- **Plugin tracking** (bundled): `.claude/settings.json` records the recently installed `unikraft` and `a11y-accessibility-reviewer` plugins. Plugin installer also reformatted the file (tabs → 2-space indent); the substantive delta is three new `enabledPlugins` entries.

## Known caveats / follow-ups
- `apps/mail-worker/package.json:15` still declares `@batuda/server` as an unused workspace dep. `getCommitPathsArray('apps/mail-worker')` walks into `apps/server`, so a server-only commit could trip a no-op mail-worker release. Slice 4 drops the unused dep when `ParticipantMatcher` moves to `packages/email`.
- `kraft cloud deploy --name X` errors on conflict, so the workflow has a delete-then-create idempotency step. Tradeoff: ~5s downtime per deploy (acceptable for an IDLE worker that reconnects after any restart) in exchange for a stable, predictable instance name.

## Test plan
- [x] `pnpm test` and `pnpm test:integration` continue passing locally (slice 3 doesn't touch test infra).
- [x] `node -e ".release-it.mail-worker.cjs"` parses cleanly; `release-utils.cjs::getCommitPathsArray('apps/mail-worker')` returns a sensible workspace dep set.
- [ ] CI on this PR (unit + integration) passes both phases.
- [ ] First real `mail-worker-v*` tag deploys cleanly. If `kraft cloud deploy --name batuda-mail-worker` errors with anything other than "instance already exists", iterate.