### PR TITLE
feat(server): SMTP retry + scheduled orphan sweep

### DIFF
--- a/apps/server/src/handlers/email.ts
+++ b/apps/server/src/handlers/email.ts
@@ -72,6 +72,7 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 							// 409s; collapse internal errors to die().
 							Effect.catchTag('EmailError', e => Effect.die(e)),
 							Effect.catchTag('SqlError', e => Effect.die(e)),
+							Effect.catchTag('SmtpSendFailed', e => Effect.die(e)),
 						),
 				)
 				.handle('reply', _ =>
@@ -94,6 +95,7 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 						.pipe(
 							Effect.catchTag('EmailError', e => Effect.die(e)),
 							Effect.catchTag('SqlError', e => Effect.die(e)),
+							Effect.catchTag('SmtpSendFailed', e => Effect.die(e)),
 						),
 				)
 				.handle('listThreads', _ =>
@@ -353,6 +355,7 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 							GrantUnavailable: e => Effect.die(e),
 							BadRequest: e => Effect.die(e),
 							SqlError: e => Effect.die(e),
+							SmtpSendFailed: e => Effect.die(e),
 						}),
 					),
 				)

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -182,6 +182,8 @@ const ServicesLive = Layer.mergeAll(
 	// skip building it (nothing requires it). Listing it inside `mergeAll`
 	// forces the build, which fires the side-effect that forks the probe.
 	InboxHealthProbe.daemonLayer.pipe(Layer.provide(InboxHealthProbe.layer)),
+	// Same `never`-output trick; EmailAttachmentStaging is supplied via the `provideMerge` below.
+	EmailAttachmentStaging.sweepDaemonLayer,
 ).pipe(
 	// CalendarService sits below EmailService because EmailService's
 	// inbound-webhook path delegates text/calendar parts to it. Keep

--- a/apps/server/src/services/email-attachment-staging.ts
+++ b/apps/server/src/services/email-attachment-staging.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import path from 'node:path'
 
-import { DateTime, Effect, Layer, ServiceMap } from 'effect'
+import { DateTime, Effect, Layer, Schedule, ServiceMap } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { BadRequest, CurrentOrg } from '@batuda/controllers'
@@ -436,6 +436,22 @@ export class EmailAttachmentStaging extends ServiceMap.Service<EmailAttachmentSt
 	},
 ) {
 	static readonly layer = Layer.effect(this, this.make)
+
+	// 5-min cadence stays well under the 1-hour TTL so a missed tick can't leak orphans past expiry.
+	static readonly sweepDaemonLayer = Layer.effectDiscard(
+		Effect.gen(function* () {
+			const staging = yield* EmailAttachmentStaging
+			yield* Effect.logInfo('email staging sweep: every 5 minutes')
+			yield* staging.sweepExpired().pipe(
+				Effect.tapError(error =>
+					Effect.logError('email staging sweep failed', error),
+				),
+				Effect.ignore,
+				Effect.repeat(Schedule.spaced('5 minutes')),
+				Effect.forkScoped,
+			)
+		}),
+	)
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/apps/server/src/services/email-send-retry.test.ts
+++ b/apps/server/src/services/email-send-retry.test.ts
@@ -1,0 +1,113 @@
+import { Cause, Effect, Exit, Fiber, Ref } from 'effect'
+import { TestClock } from 'effect/testing'
+import { describe, expect, it } from 'vitest'
+
+import { retrySmtpSend, type SmtpSendFailed } from './email'
+
+const extractFailure = <E>(cause: Cause.Cause<E>): E | null => {
+	let found: E | null = null
+	for (const reason of cause.reasons) {
+		if (Cause.isFailReason(reason)) {
+			found = reason.error
+			break
+		}
+	}
+	return found
+}
+
+// The retry policy is `Schedule.exponential('1 second', 2)` ⊓ `recurs(3)`,
+// so the back-off pattern is 1s → 2s → 4s. TestClock lets us advance time
+// deterministically without waiting ~7s in real seconds.
+
+describe('retrySmtpSend', () => {
+	describe('when SMTP fails transiently then recovers', () => {
+		it('should resolve with the eventual success and call the underlying send 3 times', () =>
+			Effect.gen(function* () {
+				// GIVEN a transport that fails twice then succeeds
+				const calls = yield* Ref.make(0)
+				const send = Effect.gen(function* () {
+					const n = yield* Ref.updateAndGet(calls, c => c + 1)
+					if (n < 3) return yield* Effect.fail(new Error('ECONNRESET'))
+					return { messageId: 'ok-1' }
+				})
+
+				// WHEN the retry-wrapped send is forked and the clock advances
+				// through the 1s + 2s back-off windows
+				const fiber = yield* Effect.forkChild(retrySmtpSend(send, 'inbox-test'))
+				yield* TestClock.adjust('1 second')
+				yield* TestClock.adjust('2 seconds')
+
+				// THEN the program resolves with the success value
+				const result = yield* Fiber.join(fiber)
+				expect(result.messageId).toBe('ok-1')
+
+				// AND the underlying send was called exactly 3 times
+				expect(yield* Ref.get(calls)).toBe(3)
+				// [apps/server/src/services/email.ts — smtpRetrySchedule recurs(3) bound]
+			}).pipe(
+				Effect.scoped,
+				Effect.provide(TestClock.layer()),
+				Effect.runPromise,
+			))
+	})
+
+	describe('when SMTP fails on every attempt', () => {
+		it('should surface SmtpSendFailed after exhausting the 3-retry budget', () =>
+			Effect.gen(function* () {
+				// GIVEN a transport that always fails with the same wire error
+				const calls = yield* Ref.make(0)
+				const send = Effect.gen(function* () {
+					yield* Ref.update(calls, c => c + 1)
+					return yield* Effect.fail(new Error('SMTP 421 too many connections'))
+				})
+
+				// WHEN the retry-wrapped send is forked and the clock advances
+				// past every back-off window (1s + 2s + 4s = 7s)
+				const fiber = yield* Effect.forkChild(
+					Effect.exit(retrySmtpSend(send, 'inbox-test')),
+				)
+				yield* TestClock.adjust('10 seconds')
+
+				// THEN the fiber exits with a typed SmtpSendFailed failure
+				const exit = yield* Fiber.join(fiber)
+				expect(Exit.isFailure(exit)).toBe(true)
+				const failure = Exit.isFailure(exit) ? extractFailure(exit.cause) : null
+				expect(failure?._tag).toBe('SmtpSendFailed')
+				expect((failure as SmtpSendFailed).inboxId).toBe('inbox-test')
+
+				// AND the underlying send was called 4 times (1 initial + 3 retries)
+				expect(yield* Ref.get(calls)).toBe(4)
+				// [apps/server/src/services/email.ts — retrySmtpSend mapError → SmtpSendFailed]
+			}).pipe(
+				Effect.scoped,
+				Effect.provide(TestClock.layer()),
+				Effect.runPromise,
+			))
+	})
+
+	describe('when send succeeds on the first attempt', () => {
+		it('should call the transport exactly once and never sleep', () =>
+			Effect.gen(function* () {
+				// GIVEN a transport that succeeds immediately
+				const calls = yield* Ref.make(0)
+				const send = Effect.gen(function* () {
+					yield* Ref.update(calls, c => c + 1)
+					return { messageId: 'happy-path' }
+				})
+
+				// WHEN the retry-wrapped send runs without any clock advance
+				const result = yield* retrySmtpSend(send, 'inbox-test')
+
+				// THEN it resolves immediately with the happy-path messageId
+				expect(result.messageId).toBe('happy-path')
+
+				// AND no retry fired
+				expect(yield* Ref.get(calls)).toBe(1)
+				// [apps/server/src/services/email.ts — retrySmtpSend happy path]
+			}).pipe(
+				Effect.scoped,
+				Effect.provide(TestClock.layer()),
+				Effect.runPromise,
+			))
+	})
+})

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-import { Effect, Layer, ServiceMap } from 'effect'
+import { Data, Effect, Layer, Schedule, ServiceMap } from 'effect'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -40,6 +40,27 @@ import type {
 import { MailTransport } from './mail-transport.js'
 import { StorageProvider } from './storage-provider.js'
 import { EmailSent, TimelineActivityService } from './timeline-activity.js'
+
+// Typed tag so the handler can die deliberately and the staging sweep
+// claims the orphaned attachment objects instead of leaking on a 500.
+export class SmtpSendFailed extends Data.TaggedError('SmtpSendFailed')<{
+	readonly cause: unknown
+	readonly inboxId: string
+}> {}
+
+// 1 + 3 retries spaced 1s/2s/4s → ~7s worst case before surfacing.
+export const smtpRetrySchedule = Schedule.exponential('1 second', 2).pipe(
+	Schedule.bothLeft(Schedule.recurs(3)),
+)
+
+export const retrySmtpSend = <A, E>(
+	send: Effect.Effect<A, E>,
+	inboxId: string,
+): Effect.Effect<A, SmtpSendFailed> =>
+	send.pipe(
+		Effect.retry(smtpRetrySchedule),
+		Effect.mapError(cause => new SmtpSendFailed({ cause, inboxId })),
+	)
 
 // PgClient.transformResultNames in apps/server/src/db/client.ts converts
 // snake_case columns to camelCase on read, so every row type in this file
@@ -538,10 +559,17 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 			const dispatchOutbound = (
 				inbox: InboxRow,
 				message: OutboundMessage,
-			): Effect.Effect<{ messageId: string; rawRef: string }, never, never> =>
+			): Effect.Effect<
+				{ messageId: string; rawRef: string },
+				SmtpSendFailed,
+				never
+			> =>
 				Effect.gen(function* () {
 					const creds = yield* loadDecryptedCreds(inbox)
-					const sent = yield* transport.send(creds, message).pipe(Effect.orDie)
+					const sent = yield* retrySmtpSend(
+						transport.send(creds, message),
+						inbox.id,
+					)
 					const messageId = sent.messageId
 					const key = sentRawKey(inbox.organizationId, inbox.id, messageId)
 					yield* storage


### PR DESCRIPTION
## Summary

Slice 5 of the operational-readiness plan. Outbound email sends now survive transient SMTP failures, and the existing `EmailAttachmentStaging.sweepExpired()` finally has a caller so orphaned pre-uploaded objects don't accumulate.

- `transport.send(creds, message)` was wrapped in `Effect.orDie`, so any wire hiccup killed the request fiber, returned a 500, and left the pre-uploaded attachment objects behind (`markSentAndCleanup` never ran). A bounded `Schedule.exponential('1 second', 2)` ⊓ `recurs(3)` retry absorbs transient failures; persistent failures surface as a typed `SmtpSendFailed` tag that the 3 handlers (`send`, `reply`, `sendDraft`) explicitly `Effect.die` so the runtime can still log the cause but the request gets a clean 500 instead of an unhandled defect.
- `EmailAttachmentStaging.sweepDaemonLayer` forks a 5-minute `Schedule.spaced` tick that calls `sweepExpired()`. Five minutes is well below the 1-hour TTL, so a missed tick is harmless, but tight enough that the worst-case orphan window is bounded.
- Together: a request that exhausts the retry budget surfaces `SmtpSendFailed`, the response dies cleanly, and the sweep reclaims the staged objects within ≤5 min instead of leaking until the next operator pass.

## Test plan

- [x] `pnpm --filter @batuda/server test` — 55 → 58 tests pass, including the new `email-send-retry.test.ts` (`TestClock` drives the 1s/2s/4s windows deterministically).
- [x] `pnpm check-types` — clean across the workspace.
- [x] `pnpm --filter @batuda/server build` — succeeds.
- [ ] Once merged + deployed: kill the SMTP transport mid-send (e.g. `iptables` drop or a deliberate `nodemailer` mis-config), observe the 1s/2s/4s retry pattern in logs, confirm the request 500s cleanly, then watch `email_attachment_staging` shrink on the next 5-min tick.