### PR TITLE
feat(server): match email search against per-message FTS

### DIFF
--- a/apps/server/src/db/migrations/0004_email_fts.ts
+++ b/apps/server/src/db/migrations/0004_email_fts.ts
@@ -1,0 +1,31 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Adds a denormalized FTS column on email_messages so the listThreads
+// search filter stops matching against email_thread_links.subject (only
+// the first message's subject) and instead matches subject + preview +
+// body per message. setweight A/B/C primes the column for future ranking.
+//
+// `'simple'` text-search config: no stemming, language-agnostic for a
+// polyglot inbox. Skips `unaccent()` because it is STABLE, which Postgres
+// rejects in GENERATED ALWAYS STORED — accent-folding would need an
+// IMMUTABLE SQL wrapper added later.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		ALTER TABLE email_messages
+			ADD COLUMN IF NOT EXISTS search_vector tsvector
+			GENERATED ALWAYS AS (
+				setweight(to_tsvector('simple', coalesce(subject, '')),      'A') ||
+				setweight(to_tsvector('simple', coalesce(text_preview, '')), 'B') ||
+				setweight(to_tsvector('simple', coalesce(text_body, '')),    'C')
+			) STORED
+	`
+
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS idx_email_messages_search_vector
+			ON email_messages USING GIN (search_vector)
+	`
+})

--- a/apps/server/src/services/email-search.integration.test.ts
+++ b/apps/server/src/services/email-search.integration.test.ts
@@ -1,0 +1,247 @@
+// Live-DB integration test for the email FTS rewrite. Verifies that the
+// generated tsvector + GIN index on email_messages let listThreads
+// match against subject + preview + body per message, and that the
+// participants subquery catches sender/recipient hits.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable on
+// $DATABASE_URL, and `pnpm cli db migrate` so 0004_email_fts has run.
+
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+const ORG_ID = `test-org-${randomUUID()}`
+const ACME_DOMAIN = `acme-${randomUUID()}.example`
+
+let pool: pg.Pool
+let inboxId: string
+let bodyOnlyThreadId: string
+let subjectOnlyThreadId: string
+let recipientOnlyThreadId: string
+let accentedThreadId: string
+
+// Mirrors the FTS WHERE branch in apps/server/src/services/email.ts:listThreads.
+// Returns the matched thread_link ids for `q` scoped to ORG_ID.
+const searchThreads = async (q: string): Promise<string[]> => {
+	const rows = await pool.query<{ id: string }>(
+		`
+		SELECT tl.id
+		FROM email_thread_links tl
+		WHERE tl.organization_id = $1
+		  AND (
+		    EXISTS (
+		      SELECT 1 FROM email_messages em
+		      WHERE em.organization_id = tl.organization_id
+		        AND (em.message_id = tl.external_thread_id
+		             OR tl.external_thread_id = ANY(em."references"))
+		        AND em.search_vector @@ plainto_tsquery('simple', $2)
+		    )
+		    OR EXISTS (
+		      SELECT 1 FROM email_messages em2
+		      JOIN message_participants mp ON mp.email_message_id = em2.id
+		      WHERE em2.organization_id = tl.organization_id
+		        AND (em2.message_id = tl.external_thread_id
+		             OR tl.external_thread_id = ANY(em2."references"))
+		        AND mp.email_address ILIKE $3
+		    )
+		  )
+		`,
+		[ORG_ID, q, `%${q}%`],
+	)
+	return rows.rows.map(r => r.id)
+}
+
+const insertThreadWithMessage = async (args: {
+	externalThreadId: string
+	subject: string | null
+	textPreview: string | null
+	textBody: string | null
+	recipient?: string | undefined
+}): Promise<string> => {
+	const link = await pool.query<{ id: string }>(
+		`INSERT INTO email_thread_links (organization_id, external_thread_id, inbox_id, subject)
+		 VALUES ($1, $2, $3, $4) RETURNING id`,
+		[ORG_ID, args.externalThreadId, inboxId, args.subject],
+	)
+	const linkRow = link.rows[0]
+	if (!linkRow) throw new Error('failed to insert thread link')
+
+	const msg = await pool.query<{ id: string }>(
+		`INSERT INTO email_messages
+		 (organization_id, inbox_id, message_id, direction, folder, raw_rfc822_ref,
+		  subject, text_preview, text_body, status, imap_uid, imap_uidvalidity)
+		 VALUES ($1, $2, $3, 'inbound', 'INBOX', 'sentinel',
+		         $4, $5, $6, 'normal', $7, 100)
+		 RETURNING id`,
+		[
+			ORG_ID,
+			inboxId,
+			args.externalThreadId,
+			args.subject,
+			args.textPreview,
+			args.textBody,
+			Math.floor(Math.random() * 1_000_000_000),
+		],
+	)
+	const msgRow = msg.rows[0]
+	if (!msgRow) throw new Error('failed to insert email message')
+
+	if (args.recipient) {
+		await pool.query(
+			`INSERT INTO message_participants (email_message_id, email_address, role)
+			 VALUES ($1, $2, 'to')`,
+			[msgRow.id, args.recipient],
+		)
+	}
+
+	return linkRow.id
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+
+	const inboxResult = await pool.query<{ id: string }>(
+		`INSERT INTO inboxes
+		 (organization_id, owner_user_id, email, purpose,
+		  imap_host, imap_port, imap_security,
+		  smtp_host, smtp_port, smtp_security,
+		  username, password_ciphertext, password_nonce, password_tag)
+		 VALUES ($1, $2, $3, 'human',
+		         'imap.example.com', 993, 'tls',
+		         'smtp.example.com', 465, 'tls',
+		         $3, '\\x00'::bytea, '\\x00'::bytea, '\\x00'::bytea)
+		 RETURNING id`,
+		[ORG_ID, `test-user-${randomUUID()}`, `inbox@${ACME_DOMAIN}`],
+	)
+	const inboxRow = inboxResult.rows[0]
+	if (!inboxRow) throw new Error('failed to insert test inbox')
+	inboxId = inboxRow.id
+
+	bodyOnlyThreadId = await insertThreadWithMessage({
+		externalThreadId: `<body-${randomUUID()}@${ACME_DOMAIN}>`,
+		subject: 'Hi',
+		textPreview: 'opening line',
+		textBody: 'please find the invoice attached',
+	})
+
+	subjectOnlyThreadId = await insertThreadWithMessage({
+		externalThreadId: `<subject-${randomUUID()}@${ACME_DOMAIN}>`,
+		subject: 'Project kickoff Monday',
+		textPreview: null,
+		textBody: 'see calendar',
+	})
+
+	recipientOnlyThreadId = await insertThreadWithMessage({
+		externalThreadId: `<recipient-${randomUUID()}@${ACME_DOMAIN}>`,
+		subject: 'just hello',
+		textPreview: null,
+		textBody: 'plain body',
+		recipient: 'partner@example.com',
+	})
+
+	accentedThreadId = await insertThreadWithMessage({
+		externalThreadId: `<accent-${randomUUID()}@${ACME_DOMAIN}>`,
+		subject: "cançó d'aquesta nit",
+		textPreview: null,
+		textBody: 'lyrics',
+	})
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(
+		`DELETE FROM message_participants WHERE email_message_id IN (SELECT id FROM email_messages WHERE organization_id = $1)`,
+		[ORG_ID],
+	)
+	await pool.query(`DELETE FROM email_messages WHERE organization_id = $1`, [
+		ORG_ID,
+	])
+	await pool.query(
+		`DELETE FROM email_thread_links WHERE organization_id = $1`,
+		[ORG_ID],
+	)
+	await pool.query(`DELETE FROM inboxes WHERE organization_id = $1`, [ORG_ID])
+	await pool.end()
+})
+
+describe('email search — full-text', () => {
+	describe('when the query matches a word only present in the body', () => {
+		it('should return the thread even though the subject does not match', async () => {
+			// GIVEN a thread whose only mention of "invoice" is in the body
+			// WHEN we search for "invoice"
+			const ids = await searchThreads('invoice')
+
+			// THEN the body-only thread is returned
+			expect(ids).toContain(bodyOnlyThreadId)
+			// [apps/server/src/services/email.ts — em.search_vector @@ plainto_tsquery]
+		})
+	})
+
+	describe('when the query matches the subject only', () => {
+		it('should return the thread via the subject weight', async () => {
+			// GIVEN a thread whose subject contains "kickoff" but the body does not
+			// WHEN we search for "kickoff"
+			const ids = await searchThreads('kickoff')
+
+			// THEN the subject-only thread is returned
+			expect(ids).toContain(subjectOnlyThreadId)
+			// [apps/server/src/db/migrations/0004_email_fts.ts — setweight(subject, 'A')]
+		})
+	})
+
+	describe('when the query matches a recipient email address', () => {
+		it('should return the thread via the participants subquery', async () => {
+			// GIVEN a thread whose recipient is "partner@example.com" and whose
+			// body/subject do NOT mention that string
+			// WHEN we search for "partner@example"
+			const ids = await searchThreads('partner@example')
+
+			// THEN the thread is returned via the EXISTS message_participants branch
+			expect(ids).toContain(recipientOnlyThreadId)
+			// [apps/server/src/services/email.ts — EXISTS message_participants ILIKE]
+		})
+	})
+
+	describe('when the query is the exact accented form of a subject', () => {
+		it('should match the accented thread', async () => {
+			// GIVEN a thread whose subject contains "cançó"
+			// WHEN we search for the exact accented form
+			const ids = await searchThreads('cançó')
+
+			// THEN the accented thread is returned
+			expect(ids).toContain(accentedThreadId)
+			// [apps/server/src/db/migrations/0004_email_fts.ts — to_tsvector('simple') keeps accents]
+		})
+	})
+
+	describe('when the query is the unaccented form of an accented subject', () => {
+		it('should not match (accent-folding deferred)', async () => {
+			// GIVEN the same thread above; tsvector keeps accents because
+			// unaccent() is STABLE, not IMMUTABLE
+			// WHEN we search for "canco" (no accent)
+			const ids = await searchThreads('canco')
+
+			// THEN the accented thread is NOT returned — folding is a follow-up
+			expect(ids).not.toContain(accentedThreadId)
+			// [apps/server/src/db/migrations/0004_email_fts.ts — no unaccent wrapper yet]
+		})
+	})
+
+	describe('when the query matches nothing', () => {
+		it('should return zero rows', async () => {
+			// GIVEN no thread mentions "zzz-no-match"
+			// WHEN we search for it
+			const ids = await searchThreads('zzz-no-match')
+
+			// THEN the result is empty
+			expect(ids).toHaveLength(0)
+		})
+	})
+})

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -1304,8 +1304,31 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						if (filters?.purpose)
 							conditions.push(sql`i.purpose = ${filters.purpose}`)
 						if (filters?.query) {
-							const pattern = `%${filters.query.toLowerCase()}%`
-							conditions.push(sql`lower(tl.subject) LIKE ${pattern}`)
+							const trimmedQuery = filters.query.trim()
+							if (trimmedQuery.length > 0) {
+								// FTS over each message's subject + preview + body; the
+								// separate participants subquery catches sender/recipient
+								// hits, which the tsvector deliberately omits (unbounded
+								// recipient sets would force a tsvector rebuild on every
+								// reply).
+								conditions.push(sql`(
+									EXISTS (
+										SELECT 1 FROM email_messages em
+										WHERE em.organization_id = tl.organization_id
+										  AND (em.message_id = tl.external_thread_id
+										       OR tl.external_thread_id = ANY(em."references"))
+										  AND em.search_vector @@ plainto_tsquery('simple', ${trimmedQuery})
+									)
+									OR EXISTS (
+										SELECT 1 FROM email_messages em2
+										JOIN message_participants mp ON mp.email_message_id = em2.id
+										WHERE em2.organization_id = tl.organization_id
+										  AND (em2.message_id = tl.external_thread_id
+										       OR tl.external_thread_id = ANY(em2."references"))
+										  AND mp.email_address ILIKE ${`%${trimmedQuery}%`}
+									)
+								)`)
+							}
 						}
 
 						const whereClause = sql`WHERE ${sql.and(conditions)}`


### PR DESCRIPTION
## Summary

Slice 6 of the operational-readiness plan. The email search filter in `listThreads` was matching against `email_thread_links.subject`, which only tracks the first message's subject — body matches, mutated subjects (`Re:`, `Fwd:`), and recipient hits never showed up.

- New migration `0004_email_fts.ts` adds `email_messages.search_vector tsvector GENERATED ALWAYS AS (setweight(subject,'A') || setweight(text_preview,'B') || setweight(text_body,'C')) STORED` plus a GIN index. `'simple'` text-search config keeps the column language-agnostic for the polyglot inbox; `unaccent()` is deliberately left out because it is `STABLE` and Postgres rejects it in generated columns — accent-folding is a follow-up.
- `listThreads` now combines two `EXISTS` subqueries: one over `email_messages.search_vector` for body/subject/preview hits, and one over `message_participants.email_address ILIKE` for sender/recipient hits. Recipients stay out of the tsvector because an unbounded recipient set would force a reindex on every reply.
- The two together fix the long-standing "I know this email exists but search can't find it" papercut.

## Test plan

- [x] `pnpm cli db migrate` applies cleanly against the local dev DB; `\d email_messages` shows the generated column and `pg_indexes` lists `idx_email_messages_search_vector`.
- [x] `pnpm --filter @batuda/server test:integration` — 77 → 83 tests pass, including the new `email-search.integration.test.ts` (6 BDD-shaped scenarios: body-only, subject-only, recipient-only, accented exact, accented unfolded, no-match).
- [x] `pnpm --filter @batuda/server test` — 55 unit tests still pass.
- [x] `pnpm check-types` clean across the workspace.
- [x] `pnpm --filter @batuda/server build` succeeds.
- [ ] Once merged + deployed: search for a body-only term in a real prod inbox → previously invisible message appears; `EXPLAIN ANALYZE` confirms `Bitmap Index Scan on idx_email_messages_search_vector`.