### PR TITLE
ai(mcp): add vercel remote server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,6 +10,10 @@
 				"-c",
 				"exec npx -y @neondatabase/mcp-server-neon start \"$NEON_API_KEY\""
 			]
+		},
+		"vercel": {
+			"type": "http",
+			"url": "https://mcp.vercel.com"
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds Vercel's official remote MCP server to `.mcp.json` so Claude can manage Vercel projects, deployments, and env vars from inside this repo. Per https://vercel.com/docs/agent-resources/vercel-mcp, the only official transport is HTTP+OAuth at `https://mcp.vercel.com` — no stdio variant exists yet.

## Side note

The HTTP+OAuth pattern carries the same drop-mid-session risk that motivated PR #7's Neon switch (HTTP → stdio + `NEON_API_KEY`). If Vercel publishes a stdio-spawnable server, the natural follow-up is the same one-line config swap.

## Test plan

- [x] `.mcp.json` is config-only, not loaded at build time → existing CI is unaffected.
- [ ] After merge: reload MCP, run `/mcp`, authenticate with Vercel; verify the project list tool returns the active workspace.