### PR TITLE
TaskService consolidation: org_id fix, reconciled transitions, task_events

### DIFF
--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -1,6 +1,5 @@
 import { DateTime, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
-import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
@@ -42,42 +41,32 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 		return handlers
 			.handle('list', _ =>
 				Effect.gen(function* () {
-					const conditions: Array<Statement.Fragment> = []
-					if (_.query.companyId)
-						conditions.push(sql`company_id = ${_.query.companyId}`)
-					if (_.query.contactId)
-						conditions.push(sql`contact_id = ${_.query.contactId}`)
-					if (_.query.assigneeId)
-						conditions.push(sql`assignee_id = ${_.query.assigneeId}`)
-					if (_.query.status) conditions.push(sql`status = ${_.query.status}`)
-					if (_.query.priority)
-						conditions.push(sql`priority = ${_.query.priority}`)
-					if (_.query.source) conditions.push(sql`source = ${_.query.source}`)
-					if (_.query.dueFrom)
-						conditions.push(sql`due_at >= ${_.query.dueFrom}`)
-					if (_.query.dueTo) conditions.push(sql`due_at <= ${_.query.dueTo}`)
-					if (_.query.overdueOnly === 'true')
-						conditions.push(sql`due_at < now() AND status = 'open'`)
-					if (_.query.includeSnoozed !== 'true')
-						conditions.push(
-							sql`(snoozed_until IS NULL OR snoozed_until <= now())`,
-						)
-					if (_.query.search)
-						conditions.push(sql`title ILIKE ${`%${_.query.search}%`}`)
-					if (_.query.completed === 'true')
-						conditions.push(sql`status = 'done'`)
-					else if (_.query.completed === 'false')
-						conditions.push(sql`status NOT IN ('done', 'cancelled')`)
-
-					const limit = _.query.limit ?? 50
-					const offset = _.query.offset ?? 0
-
-					return yield* sql`
-						SELECT * FROM tasks
-						${conditions.length > 0 ? sql`WHERE ${sql.and(conditions)}` : sql``}
-						ORDER BY COALESCE(due_at, created_at) DESC
-						LIMIT ${limit} OFFSET ${offset}
-					`
+					return yield* taskService.list(
+						{
+							companyId: _.query.companyId,
+							contactId: _.query.contactId,
+							assigneeId: _.query.assigneeId,
+							status: _.query.status,
+							priority: _.query.priority,
+							source: _.query.source,
+							dueAfter: _.query.dueFrom,
+							dueBefore: _.query.dueTo,
+							overdueOnly: _.query.overdueOnly === 'true',
+							includeSnoozed: _.query.includeSnoozed === 'true',
+							completed:
+								_.query.completed === 'true'
+									? true
+									: _.query.completed === 'false'
+										? false
+										: undefined,
+							search: _.query.search,
+						},
+						{
+							sort: 'recent',
+							limit: _.query.limit ?? 50,
+							offset: _.query.offset ?? 0,
+						},
+					)
 				}).pipe(Effect.orDie),
 			)
 			.handle('get', _ =>

--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -84,27 +84,32 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 			)
 			.handle('create', _ =>
 				Effect.gen(function* () {
-					const { userId: actorId } = yield* SessionContext
-					const rows = yield* taskService.create({
-						company_id: _.payload.companyId ?? null,
-						contact_id: _.payload.contactId ?? null,
-						type: _.payload.type,
-						title: _.payload.title,
-						notes: _.payload.notes ?? null,
-						status: _.payload.status ?? 'open',
-						source: _.payload.source ?? 'user',
-						priority: _.payload.priority ?? 'normal',
-						assignee_id: _.payload.assigneeId ?? actorId,
-						actor_id: actorId,
-						due_at: _.payload.dueAt
-							? DateTime.toDateUtc(_.payload.dueAt)
-							: null,
-						linked_interaction_id: _.payload.linkedInteractionId ?? null,
-						linked_calendar_event_id: _.payload.linkedCalendarEventId ?? null,
-						linked_thread_link_id: _.payload.linkedThreadLinkId ?? null,
-						linked_proposal_id: _.payload.linkedProposalId ?? null,
-						metadata: _.payload.metadata ?? null,
-					})
+					const { userId: actorId, isAgent } = yield* SessionContext
+					const rows = yield* taskService.create(
+						{
+							company_id: _.payload.companyId ?? null,
+							contact_id: _.payload.contactId ?? null,
+							type: _.payload.type,
+							title: _.payload.title,
+							notes: _.payload.notes ?? null,
+							status: _.payload.status ?? 'open',
+							source: _.payload.source ?? 'user',
+							priority: _.payload.priority ?? 'normal',
+							assignee_id: _.payload.assigneeId ?? actorId,
+							// The tasks column; the audit actor for task_events is the
+							// second argument below.
+							actor_id: actorId,
+							due_at: _.payload.dueAt
+								? DateTime.toDateUtc(_.payload.dueAt)
+								: null,
+							linked_interaction_id: _.payload.linkedInteractionId ?? null,
+							linked_calendar_event_id: _.payload.linkedCalendarEventId ?? null,
+							linked_thread_link_id: _.payload.linkedThreadLinkId ?? null,
+							linked_proposal_id: _.payload.linkedProposalId ?? null,
+							metadata: _.payload.metadata ?? null,
+						},
+						{ id: actorId, kind: isAgent ? 'agent' : 'user' },
+					)
 					yield* Effect.logInfo('Task created').pipe(
 						Effect.annotateLogs({
 							event: 'task.created',
@@ -171,9 +176,33 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 					),
 				),
 			)
-			.handle('complete', _ => taskService.complete(_.params.id))
-			.handle('reopen', _ => taskService.reopen(_.params.id))
-			.handle('cancel', _ => taskService.cancel(_.params.id))
+			.handle('complete', _ =>
+				Effect.gen(function* () {
+					const { userId, isAgent } = yield* SessionContext
+					return yield* taskService.complete(_.params.id, {
+						id: userId,
+						kind: isAgent ? 'agent' : 'user',
+					})
+				}),
+			)
+			.handle('reopen', _ =>
+				Effect.gen(function* () {
+					const { userId, isAgent } = yield* SessionContext
+					return yield* taskService.reopen(_.params.id, {
+						id: userId,
+						kind: isAgent ? 'agent' : 'user',
+					})
+				}),
+			)
+			.handle('cancel', _ =>
+				Effect.gen(function* () {
+					const { userId, isAgent } = yield* SessionContext
+					return yield* taskService.cancel(_.params.id, {
+						id: userId,
+						kind: isAgent ? 'agent' : 'user',
+					})
+				}),
+			)
 			.handle('snooze', _ =>
 				taskService.snooze(_.params.id, DateTime.toDateUtc(_.payload.until)),
 			)

--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -3,7 +3,6 @@ import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
-	BadRequest,
 	BatudaApi,
 	Conflict,
 	NotFound,
@@ -172,108 +171,16 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 					),
 				),
 			)
-			.handle('complete', _ =>
-				Effect.gen(function* () {
-					const rows = yield* sql<TaskRow>`
-						UPDATE tasks SET
-							status = 'done',
-							completed_at = COALESCE(completed_at, now()),
-							updated_at = now()
-						WHERE id = ${_.params.id} RETURNING *
-					`
-					if (rows.length === 0)
-						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					return rows[0]
-				}).pipe(
-					Effect.catch(e =>
-						e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
-					),
-				),
-			)
-			.handle('reopen', _ =>
-				Effect.gen(function* () {
-					const rows = yield* sql<TaskRow>`
-						UPDATE tasks SET
-							status = 'open',
-							completed_at = NULL,
-							updated_at = now()
-						WHERE id = ${_.params.id} RETURNING *
-					`
-					if (rows.length === 0)
-						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					return rows[0]
-				}).pipe(
-					Effect.catch(e =>
-						e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
-					),
-				),
-			)
-			.handle('cancel', _ =>
-				Effect.gen(function* () {
-					const current = yield* sql<TaskRow>`
-						SELECT * FROM tasks WHERE id = ${_.params.id} LIMIT 1
-					`
-					const existing = current[0]
-					if (!existing)
-						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					if (existing.status === 'done')
-						return yield* new Conflict({ message: 'cannot_cancel_done_task' })
-					const rows = yield* sql`
-						UPDATE tasks SET
-							status = 'cancelled',
-							completed_at = NULL,
-							updated_at = now()
-						WHERE id = ${_.params.id} RETURNING *
-					`
-					return rows[0]
-				}).pipe(
-					Effect.catch(e =>
-						e._tag === 'NotFound' || e._tag === 'Conflict'
-							? Effect.fail(e)
-							: Effect.die(e),
-					),
-				),
-			)
+			.handle('complete', _ => taskService.complete(_.params.id))
+			.handle('reopen', _ => taskService.reopen(_.params.id))
+			.handle('cancel', _ => taskService.cancel(_.params.id))
 			.handle('snooze', _ =>
-				Effect.gen(function* () {
-					const until = DateTime.toDateUtc(_.payload.until)
-					if (until.getTime() <= Date.now())
-						return yield* new BadRequest({ message: 'until_must_be_future' })
-					const rows = yield* sql<TaskRow>`
-						UPDATE tasks SET
-							snoozed_until = ${until},
-							updated_at = now()
-						WHERE id = ${_.params.id} RETURNING *
-					`
-					if (rows.length === 0)
-						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					return rows[0]
-				}).pipe(
-					Effect.catch(e =>
-						e._tag === 'NotFound' || e._tag === 'BadRequest'
-							? Effect.fail(e)
-							: Effect.die(e),
-					),
-				),
+				taskService.snooze(_.params.id, DateTime.toDateUtc(_.payload.until)),
 			)
 			.handle('reschedule', _ =>
-				Effect.gen(function* () {
-					const dueAt = _.payload.dueAt
-						? DateTime.toDateUtc(_.payload.dueAt)
-						: null
-					const rows = yield* sql<TaskRow>`
-						UPDATE tasks SET
-							due_at = ${dueAt},
-							updated_at = now()
-						WHERE id = ${_.params.id} RETURNING *
-					`
-					if (rows.length === 0)
-						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					return rows[0]
-				}).pipe(
-					Effect.catch(e =>
-						e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
-					),
+				taskService.reschedule(
+					_.params.id,
+					_.payload.dueAt ? DateTime.toDateUtc(_.payload.dueAt) : null,
 				),
 			)
 			.handle('bulkComplete', _ =>

--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -11,6 +11,8 @@ import {
 	SessionContext,
 } from '@batuda/controllers'
 
+import { TaskService } from '../services/tasks'
+
 type TaskRow = {
 	readonly id: string
 	readonly status: string
@@ -36,6 +38,7 @@ const requireFresh = (row: TaskRow, ifMatch: string | undefined) => {
 export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
+		const taskService = yield* TaskService
 		return handlers
 			.handle('list', _ =>
 				Effect.gen(function* () {
@@ -94,28 +97,26 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 			.handle('create', _ =>
 				Effect.gen(function* () {
 					const { userId: actorId } = yield* SessionContext
-					const rows = yield* sql`
-						INSERT INTO tasks ${sql.insert({
-							company_id: _.payload.companyId ?? null,
-							contact_id: _.payload.contactId ?? null,
-							type: _.payload.type,
-							title: _.payload.title,
-							notes: _.payload.notes ?? null,
-							status: _.payload.status ?? 'open',
-							source: _.payload.source ?? 'user',
-							priority: _.payload.priority ?? 'normal',
-							assignee_id: _.payload.assigneeId ?? actorId,
-							actor_id: actorId,
-							due_at: _.payload.dueAt
-								? DateTime.toDateUtc(_.payload.dueAt)
-								: null,
-							linked_interaction_id: _.payload.linkedInteractionId ?? null,
-							linked_calendar_event_id: _.payload.linkedCalendarEventId ?? null,
-							linked_thread_link_id: _.payload.linkedThreadLinkId ?? null,
-							linked_proposal_id: _.payload.linkedProposalId ?? null,
-							metadata: _.payload.metadata ?? null,
-						})} RETURNING *
-					`
+					const rows = yield* taskService.create({
+						company_id: _.payload.companyId ?? null,
+						contact_id: _.payload.contactId ?? null,
+						type: _.payload.type,
+						title: _.payload.title,
+						notes: _.payload.notes ?? null,
+						status: _.payload.status ?? 'open',
+						source: _.payload.source ?? 'user',
+						priority: _.payload.priority ?? 'normal',
+						assignee_id: _.payload.assigneeId ?? actorId,
+						actor_id: actorId,
+						due_at: _.payload.dueAt
+							? DateTime.toDateUtc(_.payload.dueAt)
+							: null,
+						linked_interaction_id: _.payload.linkedInteractionId ?? null,
+						linked_calendar_event_id: _.payload.linkedCalendarEventId ?? null,
+						linked_thread_link_id: _.payload.linkedThreadLinkId ?? null,
+						linked_proposal_id: _.payload.linkedProposalId ?? null,
+						metadata: _.payload.metadata ?? null,
+					})
 					yield* Effect.logInfo('Task created').pipe(
 						Effect.annotateLogs({
 							event: 'task.created',
@@ -130,9 +131,9 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 					const current = yield* sql<TaskRow>`
 						SELECT * FROM tasks WHERE id = ${_.params.id} LIMIT 1
 					`
-					if (current.length === 0)
+					const row = current[0]
+					if (!row)
 						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					const row = current[0]!
 					yield* requireFresh(row, _.headers['if-match'])
 
 					const updates: Record<string, unknown> = {}
@@ -223,9 +224,10 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 					const current = yield* sql<TaskRow>`
 						SELECT * FROM tasks WHERE id = ${_.params.id} LIMIT 1
 					`
-					if (current.length === 0)
+					const existing = current[0]
+					if (!existing)
 						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					if (current[0]!.status === 'done')
+					if (existing.status === 'done')
 						return yield* new Conflict({ message: 'cannot_cancel_done_task' })
 					const rows = yield* sql`
 						UPDATE tasks SET

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -63,6 +63,7 @@ import { PipelineService } from './services/pipeline'
 import { RecordingService } from './services/recordings'
 import { ResearchBlobStorageLive } from './services/research-blob-storage'
 import { S3StorageProviderLive } from './services/s3-storage-provider'
+import { TaskService } from './services/tasks'
 import {
 	ResearchRunCompleted,
 	TimelineActivityService,
@@ -172,6 +173,7 @@ const ResearchEventSinkLive = Layer.effect(
 
 const ServicesLive = Layer.mergeAll(
 	CompanyService.layer,
+	TaskService.layer,
 	PipelineService.layer,
 	PageService.layer,
 	EmailService.layer,

--- a/apps/server/src/mcp-stdio.ts
+++ b/apps/server/src/mcp-stdio.ts
@@ -19,11 +19,13 @@ import { PageService } from './services/pages'
 import { PipelineService } from './services/pipeline'
 import { RecordingService } from './services/recordings'
 import { S3StorageProviderLive } from './services/s3-storage-provider'
+import { TaskService } from './services/tasks'
 import { TimelineActivityService } from './services/timeline-activity'
 import { WebhookService } from './services/webhooks'
 
 const ServicesLive = Layer.mergeAll(
 	CompanyService.layer,
+	TaskService.layer,
 	PipelineService.layer,
 	PageService.layer,
 	EmailService.layer,

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -6,6 +6,10 @@ import { CurrentOrg } from '@batuda/controllers'
 
 import { TaskService } from '../../services/tasks'
 
+// MCP writes are agent-driven; task_events records actor_kind='agent' with no
+// individual user id.
+const AGENT_ACTOR = { id: null, kind: 'agent' as const }
+
 // ── Shared literals ──────────────────────────────────────────────
 // The shapes here mirror the CHECK constraints in 0001_initial.ts.
 // Keeping them as exported Schema.Literals rather than free-form
@@ -227,25 +231,28 @@ export const TaskHandlersLive = TaskTools.toLayer(
 		return {
 			create_task: params =>
 				Effect.gen(function* () {
-					const rows = yield* taskService.create({
-						title: params.title,
-						type: params.type,
-						companyId: params.company_id ?? null,
-						contactId: params.contact_id ?? null,
-						notes: params.notes ?? null,
-						dueAt: asDate(params.due_at ?? null),
-						priority: params.priority ?? 'normal',
-						source: params.source ?? 'agent',
-						assigneeId: params.assignee_id ?? null,
-						linkedInteractionId: params.linked_interaction_id ?? null,
-						linkedCalendarEventId: params.linked_calendar_event_id ?? null,
-						linkedThreadLinkId: params.linked_thread_link_id ?? null,
-						linkedProposalId: params.linked_proposal_id ?? null,
-						metadata:
-							params.metadata !== undefined && params.metadata !== null
-								? JSON.stringify(params.metadata)
-								: null,
-					})
+					const rows = yield* taskService.create(
+						{
+							title: params.title,
+							type: params.type,
+							companyId: params.company_id ?? null,
+							contactId: params.contact_id ?? null,
+							notes: params.notes ?? null,
+							dueAt: asDate(params.due_at ?? null),
+							priority: params.priority ?? 'normal',
+							source: params.source ?? 'agent',
+							assigneeId: params.assignee_id ?? null,
+							linkedInteractionId: params.linked_interaction_id ?? null,
+							linkedCalendarEventId: params.linked_calendar_event_id ?? null,
+							linkedThreadLinkId: params.linked_thread_link_id ?? null,
+							linkedProposalId: params.linked_proposal_id ?? null,
+							metadata:
+								params.metadata !== undefined && params.metadata !== null
+									? JSON.stringify(params.metadata)
+									: null,
+						},
+						AGENT_ACTOR,
+					)
 					return rows[0]
 				}).pipe(Effect.orDie),
 
@@ -333,19 +340,19 @@ export const TaskHandlersLive = TaskTools.toLayer(
 				}).pipe(Effect.orDie),
 
 			complete_task: ({ id }) =>
-				taskService.complete(id).pipe(
+				taskService.complete(id, AGENT_ACTOR).pipe(
 					Effect.catchTag('NotFound', () => Effect.succeed(null)),
 					Effect.orDie,
 				),
 
 			reopen_task: ({ id }) =>
-				taskService.reopen(id).pipe(
+				taskService.reopen(id, AGENT_ACTOR).pipe(
 					Effect.catchTag('NotFound', () => Effect.succeed(null)),
 					Effect.orDie,
 				),
 
 			cancel_task: ({ id }) =>
-				taskService.cancel(id).pipe(
+				taskService.cancel(id, AGENT_ACTOR).pipe(
 					Effect.catchTag('NotFound', () => Effect.succeed(null)),
 					Effect.orDie,
 				),

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -3,6 +3,10 @@ import { Tool, Toolkit } from 'effect/unstable/ai'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
+import { CurrentOrg } from '@batuda/controllers'
+
+import { TaskService } from '../../services/tasks'
+
 // ── Shared literals ──────────────────────────────────────────────
 // The shapes here mirror the CHECK constraints in 0001_initial.ts.
 // Keeping them as exported Schema.Literals rather than free-form
@@ -49,6 +53,7 @@ const CreateTask = Tool.make('create_task', {
 		metadata: Schema.optional(Schema.NullOr(Schema.Unknown)),
 	}),
 	success: Schema.Unknown,
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Create Task')
 	.annotate(Tool.Destructive, false)
@@ -211,6 +216,7 @@ const asDate = (v: string | null | undefined): Date | null | undefined =>
 export const TaskHandlersLive = TaskTools.toLayer(
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
+		const taskService = yield* TaskService
 
 		const buildFilters = (params: {
 			readonly company_id?: string | undefined
@@ -252,7 +258,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 		return {
 			create_task: params =>
 				Effect.gen(function* () {
-					const rows = yield* sql`INSERT INTO tasks ${sql.insert({
+					const rows = yield* taskService.create({
 						title: params.title,
 						type: params.type,
 						companyId: params.company_id ?? null,
@@ -270,7 +276,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 							params.metadata !== undefined && params.metadata !== null
 								? JSON.stringify(params.metadata)
 								: null,
-					})} RETURNING *`
+					})
 					return rows[0]
 				}).pipe(Effect.orDie),
 

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -140,6 +140,7 @@ const CompleteTask = Tool.make('complete_task', {
 		'Mark a task as done (status=done, completed_at=now()). Idempotent — a second call on an already-done task is a no-op.',
 	parameters: Schema.Struct({ id: Schema.String }),
 	success: Schema.Unknown,
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Complete Task')
 	.annotate(Tool.Destructive, false)
@@ -151,6 +152,7 @@ const ReopenTask = Tool.make('reopen_task', {
 		'Re-open a done or cancelled task (status=open, completed_at=NULL). Idempotent — re-opening an already-open task leaves the row alone.',
 	parameters: Schema.Struct({ id: Schema.String }),
 	success: Schema.Unknown,
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Reopen Task')
 	.annotate(Tool.Destructive, false)
@@ -162,6 +164,7 @@ const CancelTask = Tool.make('cancel_task', {
 		'Cancel an open or in-progress task (status=cancelled). Rejects tasks whose status is already done. Use reopen_task first if you need to cancel a completed task.',
 	parameters: Schema.Struct({ id: Schema.String }),
 	success: Schema.Unknown,
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Cancel Task')
 	.annotate(Tool.Destructive, false)
@@ -169,12 +172,13 @@ const CancelTask = Tool.make('cancel_task', {
 
 const SnoozeTask = Tool.make('snooze_task', {
 	description:
-		'Hide a task from the active queue until `until` (ISO 8601 datetime). The row stays at status=open; list_tasks with include_snoozed=false filters it out while the timer is still in the future.',
+		'Hide a task from the active queue until `until` (ISO 8601 datetime). The row stays at status=open; list_tasks with include_snoozed=false filters it out while the timer is still in the future. `until` must be a future timestamp.',
 	parameters: Schema.Struct({
 		id: Schema.String,
 		until: Schema.String,
 	}),
 	success: Schema.Unknown,
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Snooze Task')
 	.annotate(Tool.Destructive, false)
@@ -188,6 +192,7 @@ const RescheduleTask = Tool.make('reschedule_task', {
 		due_at: Schema.NullOr(Schema.String),
 	}),
 	success: Schema.Unknown,
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Reschedule Task')
 	.annotate(Tool.Destructive, false)
@@ -328,68 +333,39 @@ export const TaskHandlersLive = TaskTools.toLayer(
 				}).pipe(Effect.orDie),
 
 			complete_task: ({ id }) =>
-				Effect.gen(function* () {
-					const rows = yield* sql`
-						UPDATE tasks SET
-							status = 'done',
-							completed_at = COALESCE(completed_at, now()),
-							updated_at = now()
-						WHERE id = ${id}
-						RETURNING *
-					`
-					return rows[0]
-				}).pipe(Effect.orDie),
+				taskService.complete(id).pipe(
+					Effect.catchTag('NotFound', () => Effect.succeed(null)),
+					Effect.orDie,
+				),
 
 			reopen_task: ({ id }) =>
-				Effect.gen(function* () {
-					const rows = yield* sql`
-						UPDATE tasks SET
-							status = 'open',
-							completed_at = NULL,
-							updated_at = now()
-						WHERE id = ${id}
-						RETURNING *
-					`
-					return rows[0]
-				}).pipe(Effect.orDie),
+				taskService.reopen(id).pipe(
+					Effect.catchTag('NotFound', () => Effect.succeed(null)),
+					Effect.orDie,
+				),
 
 			cancel_task: ({ id }) =>
-				Effect.gen(function* () {
-					const rows = yield* sql`
-						UPDATE tasks SET
-							status = 'cancelled',
-							updated_at = now()
-						WHERE id = ${id} AND status <> 'done'
-						RETURNING *
-					`
-					return rows[0]
-				}).pipe(Effect.orDie),
+				taskService.cancel(id).pipe(
+					Effect.catchTag('NotFound', () => Effect.succeed(null)),
+					Effect.orDie,
+				),
 
 			snooze_task: params =>
-				Effect.gen(function* () {
-					const until = new Date(params.until)
-					const rows = yield* sql`
-						UPDATE tasks SET
-							snoozed_until = ${until},
-							updated_at = now()
-						WHERE id = ${params.id}
-						RETURNING *
-					`
-					return rows[0]
-				}).pipe(Effect.orDie),
+				taskService.snooze(params.id, new Date(params.until)).pipe(
+					Effect.catchTag('NotFound', () => Effect.succeed(null)),
+					Effect.orDie,
+				),
 
 			reschedule_task: params =>
-				Effect.gen(function* () {
-					const due = params.due_at === null ? null : new Date(params.due_at)
-					const rows = yield* sql`
-						UPDATE tasks SET
-							due_at = ${due},
-							updated_at = now()
-						WHERE id = ${params.id}
-						RETURNING *
-					`
-					return rows[0]
-				}).pipe(Effect.orDie),
+				taskService
+					.reschedule(
+						params.id,
+						params.due_at === null ? null : new Date(params.due_at),
+					)
+					.pipe(
+						Effect.catchTag('NotFound', () => Effect.succeed(null)),
+						Effect.orDie,
+					),
 		}
 	}),
 )

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -1,6 +1,5 @@
 import { Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
-import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
@@ -63,7 +62,7 @@ const CreateTask = Tool.make('create_task', {
 
 const ListTasks = Tool.make('list_tasks', {
 	description:
-		'List tasks with filters. `completed` is a legacy convenience flag mapped to status=done. Prefer status/statuses/overdue_only/include_snoozed for richer queries. Results sort by due_at ASC NULLS LAST, then created_at ASC. Default limit 25.',
+		'List tasks with filters. `completed=true` maps to status=done; `completed=false` returns open work (excludes done AND cancelled). Prefer status/statuses/overdue_only/include_snoozed for richer queries. Results sort by due_at ASC NULLS LAST, then created_at ASC. Default limit 25.',
 	parameters: Schema.Struct({
 		company_id: Schema.optional(Schema.String),
 		contact_id: Schema.optional(Schema.String),
@@ -81,6 +80,7 @@ const ListTasks = Tool.make('list_tasks', {
 		offset: Schema.optional(Schema.Number),
 	}),
 	success: Schema.Array(Schema.Unknown),
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'List Tasks')
 	.annotate(Tool.Readonly, true)
@@ -101,6 +101,7 @@ const SearchTasks = Tool.make('search_tasks', {
 		limit: Schema.optional(Schema.Number),
 	}),
 	success: Schema.Array(Schema.Unknown),
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Search Tasks')
 	.annotate(Tool.Readonly, true)
@@ -205,10 +206,10 @@ export const TaskTools = Toolkit.make(
 )
 
 // ── Handlers ─────────────────────────────────────────────────────
-// Every read builds a Fragment[] to avoid string concatenation in the
-// SQL layer. Writes stay small on purpose — the DB CHECK constraints
-// enforce the status/completed_at invariant so the handler does not
-// need to rehash it.
+// Reads delegate to TaskService.list so filter semantics stay identical
+// to the HTTP transport. Writes stay small on purpose — the DB CHECK
+// constraints enforce the status/completed_at invariant so the handler
+// does not need to rehash it.
 
 const asDate = (v: string | null | undefined): Date | null | undefined =>
 	v === null ? null : v === undefined ? undefined : new Date(v)
@@ -217,43 +218,6 @@ export const TaskHandlersLive = TaskTools.toLayer(
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
 		const taskService = yield* TaskService
-
-		const buildFilters = (params: {
-			readonly company_id?: string | undefined
-			readonly contact_id?: string | undefined
-			readonly status?: string | undefined
-			readonly statuses?: ReadonlyArray<string> | undefined
-			readonly priority?: string | undefined
-			readonly source?: string | undefined
-			readonly assignee_id?: string | undefined
-			readonly due_before?: string | undefined
-			readonly due_after?: string | undefined
-			readonly overdue_only?: boolean | undefined
-			readonly include_snoozed?: boolean | undefined
-			readonly completed?: boolean | undefined
-		}): Array<Statement.Fragment> => {
-			const c: Array<Statement.Fragment> = []
-			if (params.company_id) c.push(sql`company_id = ${params.company_id}`)
-			if (params.contact_id) c.push(sql`contact_id = ${params.contact_id}`)
-			if (params.status) c.push(sql`status = ${params.status}`)
-			if (params.statuses && params.statuses.length > 0)
-				c.push(sql`status IN ${sql.in([...params.statuses])}`)
-			if (params.priority) c.push(sql`priority = ${params.priority}`)
-			if (params.source) c.push(sql`source = ${params.source}`)
-			if (params.assignee_id) c.push(sql`assignee_id = ${params.assignee_id}`)
-			if (params.due_before)
-				c.push(sql`due_at <= ${new Date(params.due_before)}`)
-			if (params.due_after) c.push(sql`due_at >= ${new Date(params.due_after)}`)
-			if (params.overdue_only === true)
-				c.push(sql`due_at < now() AND status = 'open'`)
-			// Default: hide currently-snoozed rows. Pass include_snoozed=true
-			// to see them (e.g., for the snoozed-tab in the inbox).
-			if (params.include_snoozed !== true)
-				c.push(sql`(snoozed_until IS NULL OR snoozed_until <= now())`)
-			if (params.completed === true) c.push(sql`status = 'done'`)
-			if (params.completed === false) c.push(sql`status <> 'done'`)
-			return c
-		}
 
 		return {
 			create_task: params =>
@@ -281,31 +245,45 @@ export const TaskHandlersLive = TaskTools.toLayer(
 				}).pipe(Effect.orDie),
 
 			list_tasks: params =>
-				Effect.gen(function* () {
-					const conditions = buildFilters(params)
-					const limit = params.limit ?? 25
-					const offset = params.offset ?? 0
-					return yield* sql`
-						SELECT * FROM tasks
-						${conditions.length > 0 ? sql`WHERE ${sql.and(conditions)}` : sql``}
-						ORDER BY due_at ASC NULLS LAST, created_at ASC
-						LIMIT ${limit} OFFSET ${offset}
-					`
-				}).pipe(Effect.orDie),
+				taskService
+					.list(
+						{
+							companyId: params.company_id,
+							contactId: params.contact_id,
+							assigneeId: params.assignee_id,
+							status: params.status,
+							statuses: params.statuses,
+							priority: params.priority,
+							source: params.source,
+							dueAfter: params.due_after,
+							dueBefore: params.due_before,
+							overdueOnly: params.overdue_only,
+							includeSnoozed: params.include_snoozed,
+							completed: params.completed,
+						},
+						{
+							sort: 'due',
+							limit: params.limit ?? 25,
+							offset: params.offset ?? 0,
+						},
+					)
+					.pipe(Effect.orDie),
 
 			search_tasks: params =>
-				Effect.gen(function* () {
-					const conditions = buildFilters(params)
-					const needle = `%${params.query.replace(/[\\%_]/g, m => '\\' + m)}%`
-					conditions.push(sql`(title ILIKE ${needle} OR notes ILIKE ${needle})`)
-					const limit = params.limit ?? 25
-					return yield* sql`
-						SELECT * FROM tasks
-						WHERE ${sql.and(conditions)}
-						ORDER BY due_at ASC NULLS LAST, created_at ASC
-						LIMIT ${limit}
-					`
-				}).pipe(Effect.orDie),
+				taskService
+					.list(
+						{
+							companyId: params.company_id,
+							assigneeId: params.assignee_id,
+							status: params.status,
+							source: params.source,
+							overdueOnly: params.overdue_only,
+							includeSnoozed: params.include_snoozed,
+							search: params.query,
+						},
+						{ sort: 'due', limit: params.limit ?? 25, offset: 0 },
+					)
+					.pipe(Effect.orDie),
 
 			update_task: params =>
 				Effect.gen(function* () {

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -259,6 +259,108 @@ describe('TaskService.list', () => {
 	})
 })
 
+// Runs a TaskService method as app_user and reports the failure tag (or null
+// on success) — lets the transition guards assert their tagged errors without
+// unwrapping Effect causes.
+const attempt = (
+	org: string,
+	body: Effect.Effect<unknown, unknown, CurrentOrg | TaskService>,
+): Promise<{ failedWith: string | null }> => {
+	const deps = Layer.mergeAll(
+		TaskService.layer,
+		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+	).pipe(Layer.provideMerge(PgLive))
+
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${org}, true)`
+				return yield* body.pipe(
+					Effect.match({
+						onFailure: e => ({
+							failedWith: (e as { _tag?: string })._tag ?? 'error',
+						}),
+						onSuccess: () => ({ failedWith: null as string | null }),
+					}),
+				)
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.runPromise)
+}
+
+const seedTask = async (data: Record<string, unknown>): Promise<string> => {
+	const rows = (await createWith(tallerOrgId, tallerOrgId, {
+		type: 'follow_up',
+		title: FIXTURE_TITLE,
+		...data,
+	})) as ReadonlyArray<{ id: string }>
+	const row = rows[0]
+	if (!row) throw new Error('fixture task was not created')
+	return row.id
+}
+
+describe('TaskService transitions', () => {
+	describe('cancel', () => {
+		it('should reject cancelling a task that is already done', async () => {
+			// GIVEN a done task
+			const id = await seedTask({ status: 'done', completedAt: new Date() })
+
+			// WHEN cancelling it
+			const result = await attempt(
+				tallerOrgId,
+				Effect.gen(function* () {
+					const tasks = yield* TaskService
+					return yield* tasks.cancel(id)
+				}),
+			)
+
+			// THEN it is rejected with Conflict (reopen it first to cancel)
+			expect(result.failedWith).toBe('Conflict')
+			// [apps/server/src/services/tasks.ts — cancel done-guard]
+		})
+	})
+
+	describe('snooze', () => {
+		it('should reject a snooze timer in the past', async () => {
+			// GIVEN an open task
+			const id = await seedTask({ status: 'open' })
+
+			// WHEN snoozing it to a past timestamp
+			const result = await attempt(
+				tallerOrgId,
+				Effect.gen(function* () {
+					const tasks = yield* TaskService
+					return yield* tasks.snooze(id, new Date(Date.now() - 60_000))
+				}),
+			)
+
+			// THEN it is rejected with BadRequest
+			expect(result.failedWith).toBe('BadRequest')
+			// [apps/server/src/services/tasks.ts — snooze future guard]
+		})
+	})
+
+	describe('complete', () => {
+		it('should report NotFound for a missing task id', async () => {
+			// GIVEN an id that does not exist
+			// WHEN completing it
+			const result = await attempt(
+				tallerOrgId,
+				Effect.gen(function* () {
+					const tasks = yield* TaskService
+					return yield* tasks.complete(randomUUID())
+				}),
+			)
+
+			// THEN it fails with NotFound
+			expect(result.failedWith).toBe('NotFound')
+			// [apps/server/src/services/tasks.ts — complete NotFound]
+		})
+	})
+})
+
 describe('tasks organization_id contract', () => {
 	const asAppUser = async <T>(
 		org: string,

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -11,6 +11,8 @@
 process.env['DATABASE_URL'] ??=
 	'postgresql://batuda:batuda@localhost:5433/batuda'
 
+import { randomUUID } from 'node:crypto'
+
 import { Effect, Layer } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import pg from 'pg'
@@ -19,7 +21,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { CurrentOrg } from '@batuda/controllers'
 
 import { PgLive } from '../db/client'
-import { TaskService } from './tasks'
+import { type TaskFilters, type TaskPage, TaskService } from './tasks'
 
 const DATABASE_URL =
 	process.env['DATABASE_URL'] ??
@@ -66,7 +68,15 @@ afterAll(async () => {
 // and CurrentOrg = `currentOrg` — the role + GUC OrgMiddleware establishes
 // per request — so org_isolation engages exactly as in production. The
 // transaction commits on success; afterAll removes the fixture rows.
-const createWith = (gucOrg: string, currentOrg: string) => {
+const createWith = (
+	gucOrg: string,
+	currentOrg: string,
+	data: Record<string, unknown> = {
+		type: 'follow_up',
+		title: FIXTURE_TITLE,
+		status: 'open',
+	},
+) => {
 	const deps = Layer.mergeAll(
 		TaskService.layer,
 		Layer.succeed(CurrentOrg, {
@@ -83,11 +93,7 @@ const createWith = (gucOrg: string, currentOrg: string) => {
 			Effect.gen(function* () {
 				yield* sql`SET LOCAL ROLE app_user`
 				yield* sql`SELECT set_config('app.current_org_id', ${gucOrg}, true)`
-				return yield* tasks.create({
-					type: 'follow_up',
-					title: FIXTURE_TITLE,
-					status: 'open',
-				})
+				return yield* tasks.create(data)
 			}),
 		)
 	}).pipe(Effect.provide(deps), Effect.runPromise)
@@ -164,6 +170,91 @@ describe('TaskService.create', () => {
 			expect(tallerVisible.length).toBeGreaterThan(0)
 			expect(restaurantVisible).toHaveLength(0)
 			// [apps/server/src/db/migrations/0001_initial.ts — org_isolation_tasks USING]
+		})
+	})
+})
+
+const listWith = (org: string, filters: TaskFilters) => {
+	const deps = Layer.mergeAll(
+		TaskService.layer,
+		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+	).pipe(Layer.provideMerge(PgLive))
+	const page: TaskPage = { sort: 'due', limit: 100, offset: 0 }
+
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const tasks = yield* TaskService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${org}, true)`
+				return yield* tasks.list(filters, page)
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.runPromise)
+}
+
+describe('TaskService.list', () => {
+	describe('when filtering by completed status', () => {
+		it('should treat completed=false as open work, excluding done AND cancelled', async () => {
+			// GIVEN one open, one done, and one cancelled task for a unique assignee
+			const assignee = `list-fixture-${randomUUID()}`
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: FIXTURE_TITLE,
+				status: 'open',
+				assigneeId: assignee,
+			})
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: FIXTURE_TITLE,
+				status: 'done',
+				completedAt: new Date(),
+				assigneeId: assignee,
+			})
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: FIXTURE_TITLE,
+				status: 'cancelled',
+				assigneeId: assignee,
+			})
+
+			// WHEN listing that assignee's open work
+			const rows = (await listWith(tallerOrgId, {
+				assigneeId: assignee,
+				completed: false,
+			})) as ReadonlyArray<{ status: string }>
+
+			// THEN only the open task returns — a cancelled task is not "open work"
+			expect(rows.map(r => r.status)).toEqual(['open'])
+			// [apps/server/src/services/tasks.ts — completed=false → NOT IN ('done','cancelled')]
+		})
+
+		it('should map completed=true to status=done', async () => {
+			// GIVEN an open and a done task for a unique assignee
+			const assignee = `list-fixture-${randomUUID()}`
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: FIXTURE_TITLE,
+				status: 'open',
+				assigneeId: assignee,
+			})
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: FIXTURE_TITLE,
+				status: 'done',
+				completedAt: new Date(),
+				assigneeId: assignee,
+			})
+
+			// WHEN listing completed tasks for that assignee
+			const rows = (await listWith(tallerOrgId, {
+				assigneeId: assignee,
+				completed: true,
+			})) as ReadonlyArray<{ status: string }>
+
+			// THEN only the done task returns
+			expect(rows.map(r => r.status)).toEqual(['done'])
 		})
 	})
 })

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -1,0 +1,206 @@
+// Integration test for TaskService.create. Verifies the service stamps the
+// active org's id on insert — the regression guard for the bug where the
+// HTTP handler and MCP tool both omitted organization_id (TEXT NOT NULL,
+// no DB default), so every create failed the not-null / org_isolation RLS
+// WITH CHECK under role app_user. Also pins the RLS facets the stamp
+// relies on: cross-org writes are rejected and created rows stay isolated.
+//
+// Prereq: `pnpm cli services up` (Postgres on $DATABASE_URL) and seeded
+// `taller` + `restaurant` orgs (`pnpm cli db reset && pnpm cli seed`).
+
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../db/client'
+import { TaskService } from './tasks'
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+const TALLER_SLUG = 'taller'
+const RESTAURANT_SLUG = 'restaurant'
+const FIXTURE_TITLE = 'taskservice-create-fixture'
+
+let pool: pg.Pool
+let tallerOrgId: string
+let restaurantOrgId: string
+
+const orgIdBySlug = async (slug: string): Promise<string> => {
+	const rows = await pool.query<{ id: string }>(
+		`SELECT id FROM organization WHERE slug = $1 LIMIT 1`,
+		[slug],
+	)
+	const id = rows.rows[0]?.id
+	if (!id) {
+		throw new Error(
+			`${slug} org missing — run 'pnpm cli db reset && pnpm cli seed' before this test`,
+		)
+	}
+	return id
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	// `SET LOCAL ROLE app_user` (below) needs the connecting user to be a
+	// member of app_user — idempotent on already-granted dev containers.
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	tallerOrgId = await orgIdBySlug(TALLER_SLUG)
+	restaurantOrgId = await orgIdBySlug(RESTAURANT_SLUG)
+}, 30_000)
+
+afterAll(async () => {
+	// Run as connection owner (no role switch) so RLS doesn't gate cleanup.
+	await pool.query(`DELETE FROM tasks WHERE title = $1`, [FIXTURE_TITLE])
+	await pool.end()
+})
+
+// Runs TaskService.create as role app_user with app.current_org_id = `gucOrg`
+// and CurrentOrg = `currentOrg` — the role + GUC OrgMiddleware establishes
+// per request — so org_isolation engages exactly as in production. The
+// transaction commits on success; afterAll removes the fixture rows.
+const createWith = (gucOrg: string, currentOrg: string) => {
+	const deps = Layer.mergeAll(
+		TaskService.layer,
+		Layer.succeed(CurrentOrg, {
+			id: currentOrg,
+			name: 'fixture',
+			slug: 'fixture',
+		}),
+	).pipe(Layer.provideMerge(PgLive))
+
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const tasks = yield* TaskService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${gucOrg}, true)`
+				return yield* tasks.create({
+					type: 'follow_up',
+					title: FIXTURE_TITLE,
+					status: 'open',
+				})
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.runPromise)
+}
+
+// Reads task ids carrying the fixture title visible under `org`'s GUC.
+const visibleTaskIds = async (org: string): Promise<ReadonlyArray<string>> => {
+	const client = await pool.connect()
+	try {
+		await client.query('BEGIN')
+		await client.query('SET LOCAL ROLE app_user')
+		await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+			org,
+		])
+		const rows = await client.query<{ id: string }>(
+			`SELECT id FROM tasks WHERE title = $1`,
+			[FIXTURE_TITLE],
+		)
+		await client.query('ROLLBACK')
+		return rows.rows.map(r => r.id)
+	} finally {
+		client.release()
+	}
+}
+
+describe('TaskService.create', () => {
+	describe('when invoked as app_user with a matching active org', () => {
+		it('should stamp organization_id from CurrentOrg', async () => {
+			// GIVEN role=app_user pinned to the taller org
+			// WHEN a company-less task is created through the service
+			const rows = (await createWith(
+				tallerOrgId,
+				tallerOrgId,
+			)) as ReadonlyArray<{
+				id: string
+				organizationId: string
+				companyId: string | null
+				title: string
+			}>
+
+			// THEN the persisted row carries the active org id
+			expect(rows[0]?.organizationId).toBe(tallerOrgId)
+			// AND the company-less task persisted with a null company_id
+			expect(rows[0]?.companyId).toBeNull()
+			expect(rows[0]?.title).toBe(FIXTURE_TITLE)
+			// [apps/server/src/services/tasks.ts — sql.insert organizationId]
+		})
+	})
+
+	describe('when CurrentOrg disagrees with the active-org GUC', () => {
+		it('should be rejected by org_isolation (cannot forge a cross-org task)', async () => {
+			// GIVEN role=app_user pinned to taller but CurrentOrg = restaurant
+			// WHEN create stamps the restaurant org while the GUC says taller
+			const create = createWith(tallerOrgId, restaurantOrgId)
+
+			// THEN the WITH CHECK predicate rejects the insert
+			await expect(create).rejects.toThrow()
+			// AND no restaurant-org fixture row leaked into taller's space
+			expect(await visibleTaskIds(restaurantOrgId)).toHaveLength(0)
+			// [apps/server/src/db/migrations/0001_initial.ts — org_isolation_tasks WITH CHECK]
+		})
+	})
+
+	describe('when a created task is read under a different org', () => {
+		it('should be visible to its own org and hidden from another', async () => {
+			// GIVEN a task created under the taller org
+			await createWith(tallerOrgId, tallerOrgId)
+
+			// WHEN reading the fixture under each org's GUC
+			const tallerVisible = await visibleTaskIds(tallerOrgId)
+			const restaurantVisible = await visibleTaskIds(restaurantOrgId)
+
+			// THEN taller sees it and restaurant does not (org_isolation USING)
+			expect(tallerVisible.length).toBeGreaterThan(0)
+			expect(restaurantVisible).toHaveLength(0)
+			// [apps/server/src/db/migrations/0001_initial.ts — org_isolation_tasks USING]
+		})
+	})
+})
+
+describe('tasks organization_id contract', () => {
+	const asAppUser = async <T>(
+		org: string,
+		fn: (client: pg.PoolClient) => Promise<T>,
+	): Promise<T> => {
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			await client.query('SET LOCAL ROLE app_user')
+			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+				org,
+			])
+			const result = await fn(client)
+			await client.query('ROLLBACK')
+			return result
+		} finally {
+			client.release()
+		}
+	}
+
+	describe('when a task is inserted without organization_id', () => {
+		it('should be rejected under role app_user', () =>
+			asAppUser(tallerOrgId, async client => {
+				// GIVEN role=app_user pinned to the taller org
+				// WHEN inserting a task that omits organization_id (the pre-fix shape)
+				const insert = client.query(
+					`INSERT INTO tasks (type, title, status) VALUES ('follow_up', $1, 'open')`,
+					[FIXTURE_TITLE],
+				)
+
+				// THEN Postgres rejects it — not-null + org_isolation WITH CHECK
+				await expect(insert).rejects.toThrow()
+				// [apps/server/src/db/migrations/0001_initial.ts:387 — organization_id NOT NULL + WITH CHECK]
+			}))
+	})
+})

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -93,7 +93,7 @@ const createWith = (
 			Effect.gen(function* () {
 				yield* sql`SET LOCAL ROLE app_user`
 				yield* sql`SELECT set_config('app.current_org_id', ${gucOrg}, true)`
-				return yield* tasks.create(data)
+				return yield* tasks.create(data, { id: null, kind: 'user' })
 			}),
 		)
 	}).pipe(Effect.provide(deps), Effect.runPromise)
@@ -312,7 +312,7 @@ describe('TaskService transitions', () => {
 				tallerOrgId,
 				Effect.gen(function* () {
 					const tasks = yield* TaskService
-					return yield* tasks.cancel(id)
+					return yield* tasks.cancel(id, { id: null, kind: 'user' })
 				}),
 			)
 
@@ -350,7 +350,7 @@ describe('TaskService transitions', () => {
 				tallerOrgId,
 				Effect.gen(function* () {
 					const tasks = yield* TaskService
-					return yield* tasks.complete(randomUUID())
+					return yield* tasks.complete(randomUUID(), { id: null, kind: 'user' })
 				}),
 			)
 
@@ -358,6 +358,55 @@ describe('TaskService transitions', () => {
 			expect(result.failedWith).toBe('NotFound')
 			// [apps/server/src/services/tasks.ts — complete NotFound]
 		})
+	})
+})
+
+describe('TaskService task_events', () => {
+	it('should record a created event and a status-change event for a task', async () => {
+		// GIVEN a freshly created task (createWith records it as a 'user' actor)
+		const created = (await createWith(tallerOrgId, tallerOrgId, {
+			type: 'follow_up',
+			title: FIXTURE_TITLE,
+			status: 'open',
+		})) as ReadonlyArray<{ id: string }>
+		const taskId = created[0]?.id
+		if (!taskId) throw new Error('fixture task was not created')
+
+		// WHEN it is completed through the service as an agent
+		await attempt(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.complete(taskId, { id: null, kind: 'agent' })
+			}),
+		)
+
+		// THEN both events are on the audit trail GET /tasks/:id/events reads
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			await client.query('SET LOCAL ROLE app_user')
+			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+				tallerOrgId,
+			])
+			const events = await client.query<{
+				change: unknown
+				actor_kind: string
+			}>(
+				`SELECT change, actor_kind FROM task_events WHERE task_id = $1 ORDER BY at ASC`,
+				[taskId],
+			)
+			await client.query('ROLLBACK')
+
+			expect(events.rows).toHaveLength(2)
+			expect(events.rows[0]?.change).toEqual({ kind: 'created' })
+			expect(events.rows[0]?.actor_kind).toBe('user')
+			expect(events.rows[1]?.change).toEqual({ status: ['open', 'done'] })
+			expect(events.rows[1]?.actor_kind).toBe('agent')
+			// [apps/server/src/services/tasks.ts — recordEvent]
+		} finally {
+			client.release()
+		}
 	})
 })
 

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -2,7 +2,7 @@ import { Effect, Layer, ServiceMap } from 'effect'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { CurrentOrg } from '@batuda/controllers'
+import { BadRequest, Conflict, CurrentOrg, NotFound } from '@batuda/controllers'
 
 export interface TaskFilters {
 	readonly companyId?: string | undefined
@@ -106,6 +106,97 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 							ORDER BY ${order}
 							LIMIT ${page.limit} OFFSET ${page.offset}
 						`
+					}),
+
+				complete: (id: string) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const rows = yield* sql<{ id: string }>`
+							UPDATE tasks SET
+								status = 'done',
+								completed_at = COALESCE(completed_at, now()),
+								updated_at = now()
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							RETURNING *
+						`.pipe(Effect.orDie)
+						const row = rows[0]
+						if (!row) return yield* new NotFound({ entity: 'task', id })
+						return row
+					}),
+
+				reopen: (id: string) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const rows = yield* sql<{ id: string }>`
+							UPDATE tasks SET
+								status = 'open',
+								completed_at = NULL,
+								updated_at = now()
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							RETURNING *
+						`.pipe(Effect.orDie)
+						const row = rows[0]
+						if (!row) return yield* new NotFound({ entity: 'task', id })
+						return row
+					}),
+
+				cancel: (id: string) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const current = yield* sql<{ status: string }>`
+							SELECT status FROM tasks
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`.pipe(Effect.orDie)
+						const existing = current[0]
+						if (!existing) return yield* new NotFound({ entity: 'task', id })
+						// A done task can't be cancelled — reopen it first. Enforced on
+						// both transports; the MCP tool previously no-op'd silently.
+						if (existing.status === 'done')
+							return yield* new Conflict({ message: 'cannot_cancel_done_task' })
+						// Clearing completed_at keeps the done ⇔ completed_at invariant:
+						// only status='done' may carry one (tasks_completed_at_matches_status).
+						const rows = yield* sql<{ id: string }>`
+							UPDATE tasks SET
+								status = 'cancelled',
+								completed_at = NULL,
+								updated_at = now()
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							RETURNING *
+						`.pipe(Effect.orDie)
+						const row = rows[0]
+						if (!row) return yield* new NotFound({ entity: 'task', id })
+						return row
+					}),
+
+				snooze: (id: string, until: Date) =>
+					Effect.gen(function* () {
+						// Reject past timers on both transports — a snooze into the past
+						// would resurface the task immediately.
+						if (until.getTime() <= Date.now())
+							return yield* new BadRequest({ message: 'until_must_be_future' })
+						const currentOrg = yield* CurrentOrg
+						const rows = yield* sql<{ id: string }>`
+							UPDATE tasks SET snoozed_until = ${until}, updated_at = now()
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							RETURNING *
+						`.pipe(Effect.orDie)
+						const row = rows[0]
+						if (!row) return yield* new NotFound({ entity: 'task', id })
+						return row
+					}),
+
+				reschedule: (id: string, dueAt: Date | null) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const rows = yield* sql<{ id: string }>`
+							UPDATE tasks SET due_at = ${dueAt}, updated_at = now()
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							RETURNING *
+						`.pipe(Effect.orDie)
+						const row = rows[0]
+						if (!row) return yield* new NotFound({ entity: 'task', id })
+						return row
 					}),
 			}
 		}),

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -30,6 +30,14 @@ export interface TaskPage {
 	readonly offset: number
 }
 
+// Who performed a write, recorded on the task_events audit trail. `kind`
+// satisfies the actor_kind NOT NULL check; `id` is null for agent-driven MCP
+// writes, which carry no individual user.
+export interface TaskActor {
+	readonly id: string | null
+	readonly kind: 'user' | 'agent'
+}
+
 // Persistence shared by the HTTP `tasks` handler and the MCP task toolkit.
 // Writes funnel through here so the `organization_id` stamp lives in one
 // place: the column is NOT NULL with no DB default, and the org_isolation
@@ -85,11 +93,38 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 				return conditions
 			}
 
+			// Append-only audit row consumed by the tasks-inbox undo drawer
+			// (`apps/internal` reads it via GET /tasks/:id/events). `change` is a
+			// field diff (`{ field: [old, new] }`) or `{ kind: 'created' }`.
+			const recordEvent = (
+				orgId: string,
+				taskId: string,
+				actor: TaskActor,
+				change: Record<string, unknown>,
+			) =>
+				sql`INSERT INTO task_events ${sql.insert({
+					organizationId: orgId,
+					taskId,
+					actorId: actor.id,
+					actorKind: actor.kind,
+					change: JSON.stringify(change),
+				})}`.pipe(Effect.orDie, Effect.asVoid)
+
 			return {
-				create: (data: Record<string, unknown>) =>
+				create: (data: Record<string, unknown>, actor: TaskActor) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						return yield* sql`INSERT INTO tasks ${sql.insert({ ...data, organizationId: currentOrg.id })} RETURNING *`
+						const rows = yield* sql<{
+							id: string
+						}>`INSERT INTO tasks ${sql.insert({ ...data, organizationId: currentOrg.id })} RETURNING *`.pipe(
+							Effect.orDie,
+						)
+						const row = rows[0]
+						if (row)
+							yield* recordEvent(currentOrg.id, row.id, actor, {
+								kind: 'created',
+							})
+						return rows
 					}),
 
 				list: (filters: TaskFilters, page: TaskPage) =>
@@ -108,9 +143,16 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`
 					}),
 
-				complete: (id: string) =>
+				complete: (id: string, actor: TaskActor) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						const before = yield* sql<{ status: string }>`
+							SELECT status FROM tasks
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`.pipe(Effect.orDie)
+						const prior = before[0]
+						if (!prior) return yield* new NotFound({ entity: 'task', id })
 						const rows = yield* sql<{ id: string }>`
 							UPDATE tasks SET
 								status = 'done',
@@ -121,12 +163,22 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`.pipe(Effect.orDie)
 						const row = rows[0]
 						if (!row) return yield* new NotFound({ entity: 'task', id })
+						yield* recordEvent(currentOrg.id, id, actor, {
+							status: [prior.status, 'done'],
+						})
 						return row
 					}),
 
-				reopen: (id: string) =>
+				reopen: (id: string, actor: TaskActor) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						const before = yield* sql<{ status: string }>`
+							SELECT status FROM tasks
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`.pipe(Effect.orDie)
+						const prior = before[0]
+						if (!prior) return yield* new NotFound({ entity: 'task', id })
 						const rows = yield* sql<{ id: string }>`
 							UPDATE tasks SET
 								status = 'open',
@@ -137,10 +189,13 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`.pipe(Effect.orDie)
 						const row = rows[0]
 						if (!row) return yield* new NotFound({ entity: 'task', id })
+						yield* recordEvent(currentOrg.id, id, actor, {
+							status: [prior.status, 'open'],
+						})
 						return row
 					}),
 
-				cancel: (id: string) =>
+				cancel: (id: string, actor: TaskActor) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
 						const current = yield* sql<{ status: string }>`
@@ -166,6 +221,9 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`.pipe(Effect.orDie)
 						const row = rows[0]
 						if (!row) return yield* new NotFound({ entity: 'task', id })
+						yield* recordEvent(currentOrg.id, id, actor, {
+							status: [existing.status, 'cancelled'],
+						})
 						return row
 					}),
 

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -1,0 +1,28 @@
+import { Effect, Layer, ServiceMap } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+// Persistence shared by the HTTP `tasks` handler and the MCP task toolkit.
+// Both write paths funnel through here so the `organization_id` stamp lives
+// in one place: the column is NOT NULL with no DB default, and the
+// org_isolation RLS policy's WITH CHECK rejects any row whose
+// organization_id doesn't match the active org GUC.
+export class TaskService extends ServiceMap.Service<TaskService>()(
+	'TaskService',
+	{
+		make: Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+
+			return {
+				create: (data: Record<string, unknown>) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						return yield* sql`INSERT INTO tasks ${sql.insert({ ...data, organizationId: currentOrg.id })} RETURNING *`
+					}),
+			}
+		}),
+	},
+) {
+	static readonly layer = Layer.effect(this, this.make)
+}

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -1,24 +1,111 @@
 import { Effect, Layer, ServiceMap } from 'effect'
+import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
 
+export interface TaskFilters {
+	readonly companyId?: string | undefined
+	readonly contactId?: string | undefined
+	readonly assigneeId?: string | undefined
+	readonly status?: string | undefined
+	readonly statuses?: ReadonlyArray<string> | undefined
+	readonly priority?: string | undefined
+	readonly source?: string | undefined
+	readonly dueAfter?: string | undefined
+	readonly dueBefore?: string | undefined
+	readonly overdueOnly?: boolean | undefined
+	readonly includeSnoozed?: boolean | undefined
+	readonly completed?: boolean | undefined
+	readonly search?: string | undefined
+}
+
+// `recent` surfaces newest-first for the web inbox; `due` surfaces the most
+// overdue first for an agent picking the next thing to act on.
+export type TaskSort = 'recent' | 'due'
+
+export interface TaskPage {
+	readonly sort: TaskSort
+	readonly limit: number
+	readonly offset: number
+}
+
 // Persistence shared by the HTTP `tasks` handler and the MCP task toolkit.
-// Both write paths funnel through here so the `organization_id` stamp lives
-// in one place: the column is NOT NULL with no DB default, and the
-// org_isolation RLS policy's WITH CHECK rejects any row whose
-// organization_id doesn't match the active org GUC.
+// Writes funnel through here so the `organization_id` stamp lives in one
+// place: the column is NOT NULL with no DB default, and the org_isolation
+// RLS policy's WITH CHECK rejects a row whose organization_id doesn't match
+// the active org GUC. Reads share one filter builder so `completed`/snooze
+// semantics can't drift between the two transports.
 export class TaskService extends ServiceMap.Service<TaskService>()(
 	'TaskService',
 	{
 		make: Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
 
+			const conditionsFor = (
+				orgId: string,
+				filters: TaskFilters,
+			): Array<Statement.Fragment> => {
+				const conditions: Array<Statement.Fragment> = [
+					sql`organization_id = ${orgId}`,
+				]
+				if (filters.companyId)
+					conditions.push(sql`company_id = ${filters.companyId}`)
+				if (filters.contactId)
+					conditions.push(sql`contact_id = ${filters.contactId}`)
+				if (filters.assigneeId)
+					conditions.push(sql`assignee_id = ${filters.assigneeId}`)
+				if (filters.status) conditions.push(sql`status = ${filters.status}`)
+				if (filters.statuses && filters.statuses.length > 0)
+					conditions.push(sql`status IN ${sql.in([...filters.statuses])}`)
+				if (filters.priority)
+					conditions.push(sql`priority = ${filters.priority}`)
+				if (filters.source) conditions.push(sql`source = ${filters.source}`)
+				if (filters.dueAfter)
+					conditions.push(sql`due_at >= ${filters.dueAfter}`)
+				if (filters.dueBefore)
+					conditions.push(sql`due_at <= ${filters.dueBefore}`)
+				if (filters.overdueOnly)
+					conditions.push(sql`due_at < now() AND status = 'open'`)
+				// Snoozed rows hide by default; includeSnoozed surfaces them.
+				if (filters.includeSnoozed !== true)
+					conditions.push(
+						sql`(snoozed_until IS NULL OR snoozed_until <= now())`,
+					)
+				// `completed=false` excludes cancelled as well as done — a cancelled
+				// task is not open work. Shared by both transports so the meaning of
+				// the flag can't drift.
+				if (filters.completed === true) conditions.push(sql`status = 'done'`)
+				if (filters.completed === false)
+					conditions.push(sql`status NOT IN ('done', 'cancelled')`)
+				if (filters.search) {
+					const needle = `%${filters.search.replace(/[\\%_]/g, match => `\\${match}`)}%`
+					conditions.push(sql`(title ILIKE ${needle} OR notes ILIKE ${needle})`)
+				}
+				return conditions
+			}
+
 			return {
 				create: (data: Record<string, unknown>) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
 						return yield* sql`INSERT INTO tasks ${sql.insert({ ...data, organizationId: currentOrg.id })} RETURNING *`
+					}),
+
+				list: (filters: TaskFilters, page: TaskPage) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const conditions = conditionsFor(currentOrg.id, filters)
+						const order =
+							page.sort === 'recent'
+								? sql`COALESCE(due_at, created_at) DESC`
+								: sql`due_at ASC NULLS LAST, created_at ASC`
+						return yield* sql`
+							SELECT * FROM tasks
+							WHERE ${sql.and(conditions)}
+							ORDER BY ${order}
+							LIMIT ${page.limit} OFFSET ${page.offset}
+						`
 					}),
 			}
 		}),


### PR DESCRIPTION
## What

Consolidates task persistence into a shared `TaskService` (used by both the HTTP API and the MCP toolkit), fixing several correctness issues surfaced during an architecture review. Part of the architecture-remediation plan (PR-D).

Five focused commits:

- **fix (P0):** task creation omitted the `NOT NULL` `organization_id` (no DB default), so every create failed the org_isolation RLS `WITH CHECK` under role `app_user`. Now stamped from `CurrentOrg` in one place.
- **fix:** `completed=false` now means open work — excludes done **and** cancelled — on both transports. The MCP tool previously kept cancelled tasks in the not-completed set.
- **refactor:** `create`/`list`/`search` plus the transition verbs (`complete`/`reopen`/`cancel`/`snooze`/`reschedule`) moved onto `TaskService`; the HTTP handlers and MCP tools are thin delegations sharing one filter builder + one set of invariants.
- **fix:** MCP `cancel` of a done task and `snooze` into the past now fail (matching the HTTP API) instead of silently no-op'ing.
- **feat:** `task_events` are recorded on create + status transitions, so `GET /tasks/:id/events` and the tasks-inbox undo drawer surface history instead of the always-empty list they returned before.

## Tests

- 10 integration cases for `TaskService` — org_id stamping, cross-org `WITH CHECK` rejection, read isolation, `completed` semantics, transition guards (cancel-of-done, snooze-past, NotFound), and `task_events` change-shape + `actor_kind`.
- Gates green: `check-types` (11 packages), unit tests, `build`, and the full integration suite (12 files / 87 tests).

## Deferred follow-ups

- `TimelineActivityService.record()` so tasks appear on the company timeline (the other half of the events work).
- `task_events` for `snooze`/`reschedule`.
- Move `update`/`get`/`bulkComplete` onto `TaskService` (`update` carries the If-Match optimistic-concurrency path).