### PR TITLE
refactor(server): unify org-scope entry behind enterOrgScope

### DIFF
--- a/apps/server/src/handlers/webhooks-calcom.integration.test.ts
+++ b/apps/server/src/handlers/webhooks-calcom.integration.test.ts
@@ -12,10 +12,10 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { CurrentOrg } from '@batuda/controllers'
 
 import { PgLive } from '../db/client.js'
-import { provideOrg } from '../middleware/org.js'
+import { enterOrgScope } from '../middleware/org.js'
 import { OrgResolution } from '../services/org-resolution.js'
 
-// Function-level integration test for the org-resolution + provideOrg
+// Function-level integration test for the org-resolution + enterOrgScope
 // pipeline that webhooks-calcom.ts wires up (lines ~140-170 of the
 // handler). The full HTTP path (signature verification, schema decode,
 // dispatch through CalendarService) is exercised by the running dev
@@ -24,7 +24,7 @@ import { OrgResolution } from '../services/org-resolution.js'
 //
 //   1. resolveOrgForCalcomWebhook(payload) returns the matching org for
 //      a known cal.com booking.
-//   2. provideOrg(org)(effect) makes CurrentOrg AND `app.current_org_id`
+//   2. enterOrgScope({ org })(effect) makes CurrentOrg AND `app.current_org_id`
 //      reach the inner effect — so any SQL the CalendarService runs
 //      passes RLS as `app_user`.
 //
@@ -118,7 +118,7 @@ const cleanupFixtureInbox = Effect.gen(function* () {
 	yield* sql`DELETE FROM inboxes WHERE email = ${FIXTURE_INBOX_EMAIL}`
 })
 
-describe('webhook org-resolution + provideOrg pipeline', () => {
+describe('webhook org-resolution + enterOrgScope pipeline', () => {
 	let orgIds: OrgIds
 	const seededEvents: string[] = []
 
@@ -150,12 +150,12 @@ describe('webhook org-resolution + provideOrg pipeline', () => {
 		it('should provide CurrentOrg AND set app.current_org_id for downstream SQL', async () => {
 			// GIVEN a calendar_events row with provider=calcom + source=booking in taller
 			// WHEN resolveOrgForCalcomWebhook(payload) returns taller AND
-			//      provideOrg(taller) wraps an inner effect that yields CurrentOrg
-			//      and reads current_setting('app.current_org_id')
+			//      enterOrgScope({ org }) wraps an inner effect that yields
+			//      CurrentOrg and reads current_setting('app.current_org_id')
 			// THEN the inner effect sees CurrentOrg.id === taller.id
 			//      AND current_setting === taller.id
 			// [webhooks-calcom.ts:135-174 — handler chain]
-			// [middleware/org.ts:64-90 — provideOrg]
+			// [middleware/org.ts — enterOrgScope]
 			const eventId = randomUUID()
 			const icalUid = `webhook-test-${eventId}`
 			seededEvents.push(eventId)
@@ -188,8 +188,9 @@ describe('webhook org-resolution + provideOrg pipeline', () => {
 						iCalUID: icalUid,
 					} as never)
 
-					// Then run the inner effect through provideOrg.
-					return yield* provideOrg(org)(inner)
+					// Then run the inner effect through enterOrgScope.
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org })(inner)
 				}).pipe(
 					Effect.provide(OrgResolution.layer),
 					Effect.provide(PgLive),
@@ -210,13 +211,13 @@ describe('webhook org-resolution + provideOrg pipeline', () => {
 		})
 	})
 
-	describe("when provideOrg's inner effect runs as app_user against an org-scoped table", () => {
+	describe("when enterOrgScope's inner effect runs as app_user against an org-scoped table", () => {
 		it('should pass the org_isolation RLS WITH CHECK clause', async () => {
-			// GIVEN provideOrg(taller) has set app.current_org_id and SET ROLE app_user
+			// GIVEN enterOrgScope({ org }) has set app.current_org_id and SET ROLE app_user
 			// WHEN the inner effect INSERTs a row that includes organization_id = taller.id
 			// THEN the org_isolation_calendar_events policy approves the write
 			//      AND the row is queryable from inside the same tx
-			// [middleware/org.ts:75-79 — SET LOCAL ROLE app_user]
+			// [middleware/org.ts — enterOrgScope: SET LOCAL ROLE app_user]
 			// [migrations/0001_initial.ts — org_isolation_calendar_events policy]
 			const eventId = randomUUID()
 			const icalUid = `rls-test-${eventId}`
@@ -258,7 +259,8 @@ describe('webhook org-resolution + provideOrg pipeline', () => {
 							organizer: { email: FIXTURE_INBOX_EMAIL },
 						} as never)
 						.pipe(Effect.orDie)
-					return yield* provideOrg(org)(inner)
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org })(inner)
 				}).pipe(
 					Effect.provide(OrgResolution.layer),
 					Effect.provide(PgLive),

--- a/apps/server/src/handlers/webhooks-calcom.ts
+++ b/apps/server/src/handlers/webhooks-calcom.ts
@@ -3,10 +3,11 @@ import { createHmac, timingSafeEqual } from 'node:crypto'
 import { Config, Effect, Exit, Option, Redacted } from 'effect'
 import { HttpServerResponse } from 'effect/unstable/http'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
+import { SqlClient } from 'effect/unstable/sql'
 
 import { BatudaApi } from '@batuda/controllers'
 
-import { provideOrg } from '../middleware/org'
+import { enterOrgScope } from '../middleware/org'
 import {
 	CalendarService,
 	decodeCalcomWebhookEnvelope,
@@ -33,6 +34,7 @@ export const CalcomWebhookLive = HttpApiBuilder.group(
 		Effect.gen(function* () {
 			const svc = yield* CalendarService
 			const orgRes = yield* OrgResolution
+			const sql = yield* SqlClient.SqlClient
 			// Optional at boot so the server still starts when cal.com is not
 			// configured yet; individual webhook requests fail with 503 until
 			// the secret lands. This matches the rest of the stack's
@@ -138,7 +140,7 @@ export const CalcomWebhookLive = HttpApiBuilder.group(
 					// Resolve the org from the payload BEFORE dispatching: every
 					// SQL write inside `handleCalcomWebhook` (timeline.record,
 					// task INSERTs, calendar_events upserts) yields CurrentOrg
-					// and runs inside provideOrg's RLS-scoped tx.
+					// and runs inside enterOrgScope's RLS-scoped tx.
 					const orgScopeExit = yield* orgRes
 						.resolveOrgForCalcomWebhook(envelope.payload)
 						.pipe(Effect.exit)
@@ -164,7 +166,7 @@ export const CalcomWebhookLive = HttpApiBuilder.group(
 
 					yield* svc
 						.handleCalcomWebhook(envelope)
-						.pipe(provideOrg(orgScopeExit.value), Effect.orDie)
+						.pipe(enterOrgScope(sql, { org: orgScopeExit.value }))
 					return HttpServerResponse.jsonUnsafe({ ok: true })
 				}),
 			)

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -244,7 +244,7 @@ const AppLive = Layer.mergeAll(
 )
 
 // `CurrentOrg` is request-scoped — provided per request by OrgMiddleware
-// (HTTP), McpAuthMiddleware (MCP tools), `provideOrg` (cal.com webhook),
+// (HTTP), McpAuthMiddleware (MCP tools), `enterOrgScope` (cal.com webhook),
 // and inline `Effect.provideService` calls in ResearchEventSinkLive. It
 // surfaces in the program's R only because Tool.make declares
 // `dependencies: [CurrentOrg]` for typing.

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -12,7 +12,7 @@ import { SqlClient } from 'effect/unstable/sql'
 import { SessionContext } from '@batuda/controllers'
 
 import { Auth } from '../lib/auth'
-import { CurrentOrg } from './current-org'
+import { enterOrgScope } from '../middleware/org'
 import { CurrentUser } from './current-user'
 import { McpToolsLive } from './server'
 
@@ -67,6 +67,8 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					)
 				}
 
+				// Org lookup faults die as a defect, mirroring the HTTP path —
+				// an infra failure here isn't a JSON-RPC protocol error.
 				const orgRows = yield* sql<{
 					id: string
 					name: string
@@ -76,7 +78,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					FROM "organization"
 					WHERE id = ${activeOrgId}
 					LIMIT 1
-				`
+				`.pipe(Effect.orDie)
 				const org = orgRows[0]
 				if (!org) {
 					return yield* HttpServerResponse.json(
@@ -92,38 +94,27 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					)
 				}
 
-				// Same per-request transaction wrapper as OrgMiddlewareLive: SET
-				// LOCAL ROLE app_user + the two GUCs live for exactly the
-				// request's scope so the MCP tool sees RLS-scoped reads.
-				return yield* sql.withTransaction(
-					Effect.gen(function* () {
-						yield* sql`SET LOCAL ROLE app_user`
-						yield* sql`SELECT set_config('app.current_org_id', ${org.id}, true)`
-						yield* sql`SELECT set_config('app.current_user_id', ${result.user.id}, true)`
-						return yield* httpEffect.pipe(
-							Effect.provideService(CurrentUser, {
-								userId: result.user.id,
-								email: result.user.email,
-								name: result.user.name ?? 'Unknown',
-								isAgent: result.user.isAgent === true,
-							}),
-							// SessionContext mirrors CurrentUser using the controllers-
-							// package tag so service-layer code that consumes
-							// SessionContext (e.g. EmailService) works identically across
-							// HTTP and MCP transports.
-							Effect.provideService(SessionContext, {
-								userId: result.user.id,
-								email: result.user.email,
-								name: result.user.name ?? undefined,
-								isAgent: result.user.isAgent === true,
-							}),
-							Effect.provideService(CurrentOrg, {
-								id: org.id,
-								name: org.name,
-								slug: org.slug,
-							}),
-						)
+				// Enter the org scope via the shared combinator (role + both
+				// GUCs + CurrentOrg in one tx, faults die) so the MCP tool sees
+				// the same RLS-scoped reads as the HTTP path. CurrentUser and
+				// SessionContext are MCP-only, provided on top.
+				return yield* httpEffect.pipe(
+					Effect.provideService(CurrentUser, {
+						userId: result.user.id,
+						email: result.user.email,
+						name: result.user.name ?? 'Unknown',
+						isAgent: result.user.isAgent === true,
 					}),
+					// SessionContext mirrors CurrentUser using the controllers-
+					// package tag so service-layer code that consumes SessionContext
+					// (e.g. EmailService) works identically across HTTP and MCP.
+					Effect.provideService(SessionContext, {
+						userId: result.user.id,
+						email: result.user.email,
+						name: result.user.name ?? undefined,
+						isAgent: result.user.isAgent === true,
+					}),
+					enterOrgScope(sql, { org, userId: result.user.id }),
 				)
 			})
 	}),

--- a/apps/server/src/middleware/enter-org-scope.integration.test.ts
+++ b/apps/server/src/middleware/enter-org-scope.integration.test.ts
@@ -1,0 +1,210 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// docker-compose service so the suite runs without a loaded .env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from './org.js'
+
+// enterOrgScope is the single combinator the HTTP org middleware, the MCP
+// auth middleware, and the cal.com webhook all route their tx-tail through.
+// These pin the contract that must not drift between them: role app_user +
+// the org GUC always, the user GUC only when a user is present (never an
+// empty string), and that the user GUC actually drives user-scoped RLS.
+
+interface Org {
+	id: string
+	name: string
+	slug: string
+}
+
+interface ScopeReading {
+	currentOrgId: string
+	currentOrgSlug: string
+	role: string | null
+	orgGuc: string | null
+	userGuc: string | null
+}
+
+// Read the active role + both GUCs + CurrentOrg from inside the scope. Runs
+// on enterOrgScope's pinned tx connection, so it observes what the combinator
+// set there.
+const readScope: Effect.Effect<
+	ScopeReading,
+	never,
+	CurrentOrg | SqlClient.SqlClient
+> = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+	const org = yield* CurrentOrg
+	const rows = yield* sql<{
+		role: string
+		orgGuc: string | null
+		userGuc: string | null
+	}>`
+			SELECT current_user AS role,
+			       current_setting('app.current_org_id', true) AS "orgGuc",
+			       current_setting('app.current_user_id', true) AS "userGuc"
+		`.pipe(Effect.orDie)
+	return {
+		currentOrgId: org.id,
+		currentOrgSlug: org.slug,
+		role: rows[0]?.role ?? null,
+		orgGuc: rows[0]?.orgGuc ?? null,
+		userGuc: rows[0]?.userGuc ?? null,
+	}
+})
+
+// Count user_research_policy rows visible under the active scope. The 0003
+// user-isolation policy filters these to current_setting('app.current_user_id').
+const countVisiblePolicies: Effect.Effect<number, never, SqlClient.SqlClient> =
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const rows = yield* sql<{ n: number }>`
+			SELECT count(*)::int AS n FROM user_research_policy
+		`.pipe(Effect.orDie)
+		return rows[0]?.n ?? 0
+	})
+
+const ctx = {} as { org: Org }
+const seededUsers: string[] = []
+
+beforeAll(async () => {
+	ctx.org = await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<Org>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const found = rows[0]
+			if (!found) {
+				throw new Error(
+					"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			return found
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<Org, never, never>,
+	)
+}, 60_000)
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql.withTransaction(
+				Effect.gen(function* () {
+					yield* sql`SET LOCAL ROLE app_service`
+					for (const userId of seededUsers)
+						yield* sql`DELETE FROM user_research_policy WHERE user_id = ${userId}`
+				}),
+			)
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('enterOrgScope', () => {
+	describe('when a user is present', () => {
+		it('should run as app_user with both the org and user GUCs set', async () => {
+			// GIVEN an org and a user id
+			// WHEN enterOrgScope(sql, { org, userId }) wraps an effect that reads
+			//      current_user + both GUCs
+			// THEN the role is app_user, both GUCs hold their ids, and CurrentOrg
+			//      is the org
+			// [middleware/org.ts — enterOrgScope: SET LOCAL ROLE + set_config x2]
+			const userId = `usr-${randomUUID()}`
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org: ctx.org, userId })(readScope)
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					ScopeReading,
+					never,
+					never
+				>,
+			)
+			expect(result.role).toBe('app_user')
+			expect(result.orgGuc).toBe(ctx.org.id)
+			expect(result.userGuc).toBe(userId)
+			expect(result.currentOrgId).toBe(ctx.org.id)
+			expect(result.currentOrgSlug).toBe(ctx.org.slug)
+		})
+	})
+
+	describe('when no user is present (webhook path)', () => {
+		it('should set the org GUC only and leave the user GUC unset', async () => {
+			// GIVEN an org and no user id
+			// WHEN enterOrgScope(sql, { org }) wraps the reader
+			// THEN the org GUC is set, but the user GUC reads NULL — not an empty
+			//      string a future user-scoped policy could match
+			// [middleware/org.ts — userId omitted ⇒ user GUC skipped]
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org: ctx.org })(readScope)
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					ScopeReading,
+					never,
+					never
+				>,
+			)
+			expect(result.role).toBe('app_user')
+			expect(result.orgGuc).toBe(ctx.org.id)
+			expect(result.userGuc).toBeNull()
+		})
+	})
+
+	describe('when the user GUC backs a user-scoped RLS table', () => {
+		it('should expose only the scoped user rows', async () => {
+			// GIVEN a user_research_policy row seeded for userA only
+			// WHEN the table is read under enterOrgScope for userA then userB
+			// THEN userA sees its row and userB sees none — the user GUC drives
+			//      the 0003 user-isolation policy
+			// [migrations/0003_user_scoped_rls.ts — user_isolation_user_research_policy]
+			const userA = `urp-${randomUUID()}`
+			const userB = `urp-${randomUUID()}`
+			seededUsers.push(userA, userB)
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					// app_service (BYPASSRLS) seeds across the FORCE policy.
+					yield* sql.withTransaction(
+						Effect.gen(function* () {
+							yield* sql`SET LOCAL ROLE app_service`
+							yield* sql`INSERT INTO user_research_policy (user_id) VALUES (${userA})`
+						}),
+					)
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+			)
+
+			const [asA, asB] = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					const a = yield* enterOrgScope(sql, {
+						org: ctx.org,
+						userId: userA,
+					})(countVisiblePolicies)
+					const b = yield* enterOrgScope(sql, {
+						org: ctx.org,
+						userId: userB,
+					})(countVisiblePolicies)
+					return [a, b] as const
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					readonly [number, number],
+					never,
+					never
+				>,
+			)
+
+			expect(asA).toBe(1)
+			expect(asB).toBe(0)
+		})
+	})
+})

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -20,37 +20,46 @@ interface OrgRow {
 }
 
 /**
- * Run an effect with `CurrentOrg` provided AND the matching
- * `app.current_org_id` GUC set on the connection. Both values must match —
- * RLS would catch drift but the cost of debugging "row level security
- * denied" is high, so they're stitched together here.
+ * Enter the per-request org scope on the SQL connection, then run `effect`
+ * inside it. In one transaction: `SET LOCAL ROLE app_user`, set the
+ * `app.current_org_id` GUC (and `app.current_user_id` when a user is
+ * present), and provide `CurrentOrg`. The role + GUCs release on
+ * COMMIT/ROLLBACK with the transaction's scope, so they follow the request
+ * exactly. Effect's SqlClient nests handler-side `withTransaction` calls as
+ * savepoints, and `SET LOCAL` releases alongside the per-tx Scope, so the
+ * GUC scope tracks the request scope. SQL faults die as a defect, keeping
+ * callers' error unions free of `SqlError`.
  *
- * For HTTP routes the same dance lives inline inside `OrgMiddlewareLive`
- * (closed over its own `sql` binding); this exported helper exists so
- * non-HTTP entry points (webhook handlers, MCP tools, future cron jobs)
- * can reuse the contract without re-deriving it.
+ * The HTTP org middleware, the MCP auth middleware, and the cal.com webhook
+ * all route their tx-tail through here so the role + GUC contract can't
+ * drift between transports; each keeps its own session prologue and error
+ * rendering on top.
+ *
+ * `userId` is optional: the webhook acts for an org with no signed-in user,
+ * so the user GUC is left unset rather than written as an empty string — an
+ * empty string reads back as `''` (not NULL) and could match an empty-keyed
+ * row under a future user-scoped policy.
  */
-export const provideOrg =
-	(org: {
-		readonly id: string
-		readonly name: string
-		readonly slug: string
-	}) =>
-	<A, E, R>(effect: Effect.Effect<A, E, R | CurrentOrg>) =>
-		Effect.gen(function* () {
-			const sql = yield* SqlClient.SqlClient
-			return yield* sql.withTransaction(
+export const enterOrgScope =
+	(
+		// Passed in (not pulled from context) so the wrapped effect's R stays
+		// free of SqlClient — the HTTP middleware boundary only admits the
+		// services it provides. Every caller already holds a layer-level binding.
+		sql: SqlClient.SqlClient,
+		scope: { readonly org: OrgRow; readonly userId?: string | undefined },
+	) =>
+	<A, E, R>(effect: Effect.Effect<A, E, R>) =>
+		sql
+			.withTransaction(
 				Effect.gen(function* () {
 					yield* sql`SET LOCAL ROLE app_user`
-					yield* sql`SELECT set_config('app.current_org_id', ${org.id}, true)`
-					return yield* Effect.provideService(effect, CurrentOrg, org)
+					yield* sql`SELECT set_config('app.current_org_id', ${scope.org.id}, true)`
+					if (scope.userId !== undefined)
+						yield* sql`SELECT set_config('app.current_user_id', ${scope.userId}, true)`
+					return yield* Effect.provideService(effect, CurrentOrg, scope.org)
 				}),
 			)
-		}) as Effect.Effect<
-			A,
-			E | import('effect/unstable/sql').SqlError.SqlError,
-			Exclude<R, CurrentOrg> | SqlClient.SqlClient
-		>
+			.pipe(Effect.orDie) as Effect.Effect<A, never, Exclude<R, CurrentOrg>>
 
 /**
  * Implementing Layer for the `OrgMiddleware` Tag declared in
@@ -66,16 +75,8 @@ export const provideOrg =
  *   3. Reject with `Forbidden` if the session has no `activeOrganizationId`.
  *   4. Look up the organization row by id — slug + name are read alongside
  *      so route handlers can build org-scoped URLs without a second query.
- *   5. Open a transaction and `SET LOCAL ROLE app_user` + `SELECT
- *      set_config('app.current_org_id', <id>, true)` so RLS policies engage
- *      for the rest of the handler. Effect's SqlClient cleanly nests handler-
- *      side `withTransaction` calls as savepoints (per
- *      `docs/repos/effect/packages/effect/src/unstable/sql/SqlClient.ts:205-209`),
- *      and `SET LOCAL` releases on COMMIT/ROLLBACK alongside the per-tx
- *      Scope close (line 244), so the GUC scope follows the request scope
- *      exactly. Pattern mirrors the mail-worker's per-batch wrapper at
- *      `apps/mail-worker/src/ingest.ts:49-74`.
- *   6. Provide `CurrentOrg` to downstream handlers.
+ *   5. Hand off to `enterOrgScope` — role + both GUCs + `CurrentOrg` inside
+ *      one transaction; see its doc for the savepoint/scope mechanics.
  */
 export const OrgMiddlewareLive = Layer.effect(
 	OrgMiddleware,
@@ -132,28 +133,14 @@ export const OrgMiddlewareLive = Layer.effect(
 					})
 				}
 
-				// Run the rest of the request inside a transaction so SET LOCAL
-				// ROLE + the two GUCs (org id + user id) live for exactly the
-				// request's scope and release on COMMIT/ROLLBACK. SqlError
-				// surfaces as a die so the middleware's declared error union
-				// stays { Unauthorized | Forbidden }. `app.current_user_id`
-				// is set alongside `app.current_org_id` so future per-user
-				// RLS policies (e.g. on `member` to scope membership reads
-				// by self) don't need a second middleware change.
-				return yield* sql
-					.withTransaction(
-						Effect.gen(function* () {
-							yield* sql`SET LOCAL ROLE app_user`
-							yield* sql`SELECT set_config('app.current_org_id', ${row.id}, true)`
-							yield* sql`SELECT set_config('app.current_user_id', ${result.user.id}, true)`
-							return yield* Effect.provideService(effect, CurrentOrg, {
-								id: row.id,
-								name: row.name,
-								slug: row.slug,
-							})
-						}),
-					)
-					.pipe(Effect.orDie)
+				// Enter the org scope (role + both GUCs + CurrentOrg) for the
+				// rest of the request via the shared combinator, keeping the
+				// HTTP and MCP transports in lockstep. The user GUC backs
+				// future per-user RLS (e.g. scoping membership reads to self).
+				return yield* enterOrgScope(sql, {
+					org: row,
+					userId: result.user.id,
+				})(effect)
 			})
 	}),
 ).pipe(Layer.provide(Auth.layer))


### PR DESCRIPTION
## What & why

The HTTP org middleware, the MCP auth middleware, and the cal.com webhook each hand-rolled the same "enter org scope" sequence: `SET LOCAL ROLE app_user`, set the `app.current_org_id` (and `app.current_user_id`) GUCs, open a transaction, provide `CurrentOrg`. Three copies meant the role + GUC contract could drift between transports. This extracts one combinator, `enterOrgScope(sql, { org, userId? })`, and routes all three through it. Each transport keeps its own session prologue and error rendering (HTTP tagged errors vs MCP JSON-RPC envelopes).

This is hardening, not a live-bug fix — the three copies were already in sync. It also closes two consistency gaps below.

## Changes

- **`middleware/org.ts`**: `provideOrg` → `enterOrgScope`. `sql` is passed in (not pulled from context) so the wrapped effect's `R` stays free of `SqlClient` — the HTTP middleware boundary only admits the services it provides. `OrgMiddlewareLive` routes its tx-tail through it.
- **`mcp/http.ts`**: the MCP auth middleware routes through `enterOrgScope`, and the org SELECT gains `.orDie` — so org-lookup and tx faults die as a defect like the HTTP path, instead of leaking `SqlError` into the JSON-RPC reply.
- **`handlers/webhooks-calcom.ts`**: the webhook calls `enterOrgScope(sql, { org })` with no `userId`. The user GUC is left **unset** (not written as an empty string, which would read back as `''` rather than NULL and could match an empty-keyed row under a future user-scoped policy).
- **`main.ts`**: comment reference updated.

## Tests

- New `enter-org-scope.integration.test.ts`: role `app_user` + both GUCs when a user is present; the org GUC alone (user GUC unset) without one; and the user GUC actually driving the `0003` user-scoped RLS on `user_research_policy` (visible for that user, empty for another).
- Migrated `webhooks-calcom.integration.test.ts` to the renamed combinator.

## Notes / deviations from plan

- `sql` is a parameter rather than context-resolved — required by the HTTP middleware `R` constraint (documented inline).
- Integration test only: the role+GUC contract is observable only against a real DB, and HTTP↔MCP parity is now structural (one shared combinator), so a mock-based unit test would be brittle and low-value.

## Verification

- `check-types` + unit `test` + `build` (turbo): 30/30.
- Full server integration suite: 13 files / 97 tests (+1 file, +3 tests here).

Part of the architecture-remediation series (PR-B).