### PR TITLE
refactor(server): scope research fan-out as a system actor

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -11,7 +11,7 @@ import { HttpApiBuilder, HttpApiScalar, OpenApi } from 'effect/unstable/httpapi'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { BookingProviderLive, IcsParserLive } from '@batuda/calendar'
-import { BatudaApi, CurrentOrg } from '@batuda/controllers'
+import { BatudaApi } from '@batuda/controllers'
 import { ParticipantMatcher } from '@batuda/email/participant-matcher'
 import {
 	makeResearchLlmLive,
@@ -45,7 +45,7 @@ import { EnvVars } from './lib/env'
 import { LoggerLive } from './lib/logger'
 import { OtlpObservability } from './lib/observability'
 import { McpHttpLive } from './mcp/http'
-import { OrgMiddlewareLive } from './middleware/org'
+import { OrgMiddlewareLive, resolveSystemOrg } from './middleware/org'
 import { SessionMiddlewareLive } from './middleware/session'
 import { CalendarService } from './services/calendar'
 import { CompanyService } from './services/companies'
@@ -107,9 +107,10 @@ const TIMELINE_STATUS_FOR_EVENT: Record<
 
 // ResearchEventSink runs out-of-band of an HTTP request — research runs
 // are kicked off by users but progress events fire later, sometimes from
-// background fibres. Recover the active org from the research_run row and
-// provide CurrentOrg manually so org-scoped fan-out (webhooks, timeline)
-// can reach the right tables.
+// background fibres. Recover the org (and originating user) from the
+// research_run row and enter app_user scope via resolveSystemOrg, so the
+// org-scoped fan-out (webhooks, timeline) writes under RLS like a request
+// instead of relying on the owner connection's bypass.
 const ResearchEventSinkLive = Layer.effect(
 	ResearchEventSink,
 	Effect.gen(function* () {
@@ -128,44 +129,58 @@ const ResearchEventSinkLive = Layer.effect(
 					}
 					const rows = yield* sql<{
 						organizationId: string
+						createdBy: string | null
 						query: string
 						briefMd: string | null
 					}>`
-						SELECT organization_id, query, brief_md
+						SELECT organization_id, created_by, query, brief_md
 						FROM research_runs
 						WHERE id = ${researchId} LIMIT 1
 					`
 					const [run] = rows
 					if (!run) return
-					const orgScope: { id: string; name: string; slug: string } = {
-						id: run.organizationId,
-						name: '',
-						slug: '',
-					}
-					yield* webhooks
-						.fire(event, payload)
-						.pipe(Effect.provideService(CurrentOrg, orgScope))
 					const status = TIMELINE_STATUS_FOR_EVENT[event] ?? null
-					if (!status) return
-					const linkRows = yield* sql<{ subjectId: string }>`
-						SELECT subject_id FROM research_links
-						WHERE research_id = ${researchId}
-						  AND subject_table = 'companies'
-						  AND link_kind = 'input'
-						LIMIT 1
-					`
-					const companyId = linkRows[0]?.subjectId ?? null
-					yield* timeline
-						.record(
-							new ResearchRunCompleted({
-								researchRunId: researchId,
-								companyId,
-								summary: run.briefMd ?? run.query,
-								status,
-								occurredAt: new Date(),
-							}),
-						)
-						.pipe(Effect.provideService(CurrentOrg, orgScope))
+
+					// Fan out as the system actor: load the real org and enter
+					// app_user scope so the timeline write passes RLS like a
+					// request would, instead of leaning on the owner connection's
+					// bypass. webhooks.fire forks its own delivery, so it rides
+					// CurrentOrg (now a real name/slug) but escapes the per-tx GUC.
+					yield* resolveSystemOrg(sql, run.organizationId, {
+						userId: run.createdBy ?? undefined,
+					})(
+						Effect.gen(function* () {
+							yield* webhooks.fire(event, payload)
+							if (!status) return
+							const linkRows = yield* sql<{ subjectId: string }>`
+								SELECT subject_id FROM research_links
+								WHERE research_id = ${researchId}
+								  AND subject_table = 'companies'
+								  AND link_kind = 'input'
+								LIMIT 1
+							`
+							yield* timeline.record(
+								new ResearchRunCompleted({
+									researchRunId: researchId,
+									companyId: linkRows[0]?.subjectId ?? null,
+									summary: run.briefMd ?? run.query,
+									status,
+									occurredAt: new Date(),
+								}),
+							)
+						}),
+					).pipe(
+						// Org deleted between run completion and fan-out: skip
+						// rather than crash, mirroring the missing-run return above.
+						Effect.catchTag('SystemOrgNotFound', e =>
+							Effect.logWarning('research fan-out skipped: org not found').pipe(
+								Effect.annotateLogs({
+									event: 'research.fanout.unknown_org',
+									orgId: e.orgId,
+								}),
+							),
+						),
+					)
 				}).pipe(Effect.orDie),
 		})
 	}),

--- a/apps/server/src/middleware/enter-org-scope.integration.test.ts
+++ b/apps/server/src/middleware/enter-org-scope.integration.test.ts
@@ -12,7 +12,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { CurrentOrg } from '@batuda/controllers'
 
 import { PgLive } from '../db/client.js'
-import { enterOrgScope } from './org.js'
+import { enterOrgScope, resolveSystemOrg } from './org.js'
 
 // enterOrgScope is the single combinator the HTTP org middleware, the MCP
 // auth middleware, and the cal.com webhook all route their tx-tail through.
@@ -205,6 +205,77 @@ describe('enterOrgScope', () => {
 
 			expect(asA).toBe(1)
 			expect(asB).toBe(0)
+		})
+	})
+})
+
+// resolveSystemOrg layers a real org load + fail-closed guard on top of
+// enterOrgScope, for system actors (the research event sink) that have an org
+// id but no request. The org isolation itself is enterOrgScope's job (covered
+// above); these cover what resolveSystemOrg adds.
+describe('resolveSystemOrg', () => {
+	describe('when the org exists', () => {
+		it('should load the real org and run as app_user with both GUCs', async () => {
+			// GIVEN an existing org id and an on-behalf-of user
+			// WHEN resolveSystemOrg(sql, orgId, { userId }) wraps the reader
+			// THEN CurrentOrg carries the real slug (not an empty string), the
+			//      role is app_user, and both GUCs are set
+			// [middleware/org.ts — resolveSystemOrg: load org then enterOrgScope]
+			const userId = `sys-${randomUUID()}`
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* resolveSystemOrg(sql, ctx.org.id, { userId })(readScope)
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					ScopeReading,
+					never,
+					never
+				>,
+			)
+			expect(result.role).toBe('app_user')
+			expect(result.orgGuc).toBe(ctx.org.id)
+			expect(result.userGuc).toBe(userId)
+			expect(result.currentOrgId).toBe(ctx.org.id)
+			expect(result.currentOrgSlug).toBe(ctx.org.slug)
+			expect(result.currentOrgSlug.length).toBeGreaterThan(0)
+		})
+	})
+
+	describe('when the org does not exist', () => {
+		it('should fail with SystemOrgNotFound without running the effect', async () => {
+			// GIVEN an org id with no organization row
+			// WHEN resolveSystemOrg wraps an effect that would flip a sentinel
+			// THEN it fails SystemOrgNotFound and the inner effect never ran, so
+			//      no partial role/GUC scope was applied
+			// [middleware/org.ts — resolveSystemOrg: missing org fails pre-scope]
+			let ran = false
+			// catchTag only fires for SystemOrgNotFound, so a 'fail-closed'
+			// outcome also asserts the error tag; any other failure propagates.
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* resolveSystemOrg(
+						sql,
+						'org-does-not-exist',
+						{},
+					)(
+						Effect.sync(() => {
+							ran = true
+							return 'ran' as const
+						}),
+					).pipe(
+						Effect.catchTag('SystemOrgNotFound', () =>
+							Effect.succeed('fail-closed' as const),
+						),
+					)
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					'ran' | 'fail-closed',
+					never,
+					never
+				>,
+			)
+			expect(ran).toBe(false)
+			expect(outcome).toBe('fail-closed')
 		})
 	})
 })

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -1,6 +1,6 @@
 import { NodeHttpServerRequest } from '@effect/platform-node'
 import { fromNodeHeaders } from 'better-auth/node'
-import { Effect, Layer } from 'effect'
+import { Data, Effect, Layer } from 'effect'
 import { HttpServerRequest } from 'effect/unstable/http'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -60,6 +60,40 @@ export const enterOrgScope =
 				}),
 			)
 			.pipe(Effect.orDie) as Effect.Effect<A, never, Exclude<R, CurrentOrg>>
+
+// Raised when a system-actor scope can't resolve its org — e.g. the org was
+// deleted between a research run completing and its fan-out firing. A distinct
+// tag lets callers skip the work rather than crash.
+export class SystemOrgNotFound extends Data.TaggedError('SystemOrgNotFound')<{
+	readonly orgId: string
+}> {}
+
+/**
+ * Fail-closed org scope for system actors that run outside any request — the
+ * research event sink fires after the originating request has returned. Loads
+ * the real organization row by id (so `CurrentOrg` carries a true name/slug
+ * instead of empties), then enters app_user scope via `enterOrgScope`. A
+ * missing org fails with `SystemOrgNotFound` *before* the effect runs, so no
+ * partial scope (role/GUC) is ever applied.
+ *
+ * `userId` is the on-behalf-of user (e.g. the run's creator); omit it to set
+ * the org GUC alone.
+ */
+export const resolveSystemOrg =
+	(
+		sql: SqlClient.SqlClient,
+		orgId: string,
+		opts?: { readonly userId?: string | undefined },
+	) =>
+	<A, E, R>(effect: Effect.Effect<A, E, R>) =>
+		Effect.gen(function* () {
+			const rows = yield* sql<OrgRow>`
+				SELECT id, name, slug FROM "organization" WHERE id = ${orgId} LIMIT 1
+			`.pipe(Effect.orDie)
+			const org = rows[0]
+			if (!org) return yield* new SystemOrgNotFound({ orgId })
+			return yield* enterOrgScope(sql, { org, userId: opts?.userId })(effect)
+		})
 
 /**
  * Implementing Layer for the `OrgMiddleware` Tag declared in


### PR DESCRIPTION
## What & why

The research event sink fires after the originating HTTP request has returned (sometimes from a background fibre). It used to hand-build a `{ id, name: '', slug: '' }` `CurrentOrg` and run its webhooks + timeline fan-out on the **owner** connection — RLS bypassed, with an empty org name/slug. This adds a small primitive, `resolveSystemOrg(sql, orgId, { userId? })`, that loads the **real** organization row and enters `app_user` scope via `enterOrgScope` (PR-B). The sink routes its fan-out through it.

## Changes

- **`middleware/org.ts`**: new `resolveSystemOrg` + `SystemOrgNotFound`. It loads `id/name/slug` by org id, then delegates to `enterOrgScope`. A missing org fails with `SystemOrgNotFound` **before** the effect runs — fail-closed, no partial role/GUC scope applied. `userId` is the optional on-behalf-of user (the run's creator).
- **`main.ts` (`ResearchEventSinkLive`)**: recovers the org **and** `created_by` from the `research_run` row and runs the fan-out through `resolveSystemOrg`. Two intentional behavior shifts:
  - The timeline write now passes RLS as `app_user` scoped to the run's org (like a request), instead of relying on owner bypass; webhooks see a real org name/slug. (`record` stamps `organization_id` from `CurrentOrg`, so the WITH CHECK matches the GUC.)
  - A run whose org was deleted before fan-out now **fails closed** (caught, logged, skipped) instead of writing against a dangling org id.
- The mail-worker's empty-org `ParticipantMatcher` call is deliberately left untouched — it must stay `app_service`/BYPASSRLS.

## Tests

Added a `describe('resolveSystemOrg')` block to `enter-org-scope.integration.test.ts` (same module, same harness):
- existing org → loads the real slug (non-empty) and runs as `app_user` with both GUCs;
- missing org → fails `SystemOrgNotFound` without running the inner effect (no partial scope).

`webhooks.fire` is `forkDetach` + uses an explicit org predicate, so it rides `CurrentOrg` but escapes the per-tx GUC — its behavior is unchanged besides the now-real org name/slug.

## Notes / deviations from plan

- `resolveSystemOrg` tests live alongside `enterOrgScope` (same module/harness) rather than a separate `system-org-scope.integration.test.ts`, to avoid duplicating the harness.
- The `record`-as-`app_user` RLS write is transitively covered (enterOrgScope user-scoped RLS test + multi-org WITH CHECK tests); the full `TimelineActivityService.record()` DB test is tracked as a PR-D follow-up.

## Verification

- `check-types` + unit `test` + `build` (turbo): 30/30.
- Full server integration suite: 13 files / 99 tests (+2 here).

Part of the architecture-remediation series (PR-C).