### PR TITLE
fix(server): target invite links at an explicit APP_PUBLIC_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ BETTER_AUTH_INSECURE_COOKIES=false
 # `strict` — let it default by removing this line in a prod env.
 BETTER_AUTH_RATE_LIMIT=loose
 ALLOWED_ORIGINS=https://batuda.localhost
+# Canonical public app origin for the links the server mints (invitations).
+# Must be one of ALLOWED_ORIGINS — boot fails otherwise.
+APP_PUBLIC_URL=https://batuda.localhost
 
 # CRM email provider. **Required, no default** — the developer must
 # explicitly choose. Allowed values: local-inbox.

--- a/.env.example.github
+++ b/.env.example.github
@@ -107,6 +107,9 @@ RESEARCH_API_KEY_LLM=...
 # Better Auth + CORS
 BETTER_AUTH_BASE_URL=https://api.batuda.co
 ALLOWED_ORIGINS=https://batuda.co,https://engranatge.com
+# Canonical public app origin for server-minted links (invitations). Must be
+# one of ALLOWED_ORIGINS; name the product these invites belong to explicitly.
+APP_PUBLIC_URL=https://batuda.co
 
 # Cloudflare R2 endpoint + bucket
 STORAGE_ENDPOINT=https://<account>.r2.cloudflarestorage.com

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -121,6 +121,7 @@ jobs:
                 -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
                 -e BETTER_AUTH_BASE_URL="${{ vars.BETTER_AUTH_BASE_URL }}" \
                 -e ALLOWED_ORIGINS="${{ vars.ALLOWED_ORIGINS }}" \
+                -e APP_PUBLIC_URL="${{ vars.APP_PUBLIC_URL }}" \
                 -e STORAGE_ENDPOINT="${{ vars.STORAGE_ENDPOINT }}" \
                 -e STORAGE_REGION="${{ vars.STORAGE_REGION }}" \
                 -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
@@ -181,6 +182,7 @@ jobs:
                 -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
                 -e BETTER_AUTH_BASE_URL="${{ vars.BETTER_AUTH_BASE_URL }}" \
                 -e ALLOWED_ORIGINS="${{ vars.ALLOWED_ORIGINS }}" \
+                -e APP_PUBLIC_URL="${{ vars.APP_PUBLIC_URL }}" \
                 -e STORAGE_ENDPOINT="${{ vars.STORAGE_ENDPOINT }}" \
                 -e STORAGE_REGION="${{ vars.STORAGE_REGION }}" \
                 -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -16,7 +16,7 @@ import { buildBetterAuthConfig } from '@batuda/auth'
 import { setPasswordRoute } from '../plugins/set-password-route'
 import { TransactionalEmailProvider } from '../services/transactional-email-provider'
 import { TransactionalEmailProviderLive } from '../services/transactional-email-provider-live'
-import { EnvVars } from './env'
+import { buildInvitationCallbackURL, EnvVars } from './env'
 
 export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 	make: Effect.gen(function* () {
@@ -134,15 +134,12 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 							// endpoint then redirects to that resolved URL — so a
 							// `/accept-invitation/...` relative path would land on
 							// `https://api.batuda.localhost/...` which the
-							// frontend can't serve. Use the first trusted origin
-							// (the public-facing app URL) as the prefix.
-							const frontendOrigin = env.ALLOWED_ORIGINS[0]
-							if (!frontendOrigin) {
-								throw new Error(
-									'No ALLOWED_ORIGINS configured; cannot build invitation callbackURL.',
-								)
-							}
-							const callbackURL = `${frontendOrigin.replace(/\/$/, '')}/accept-invitation/${data.id}`
+							// frontend can't serve. APP_PUBLIC_URL is the canonical
+							// app origin, validated ∈ ALLOWED_ORIGINS at boot.
+							const callbackURL = buildInvitationCallbackURL(
+								env.APP_PUBLIC_URL,
+								data.id,
+							)
 
 							if (!authHandle) {
 								throw new Error(

--- a/apps/server/src/lib/env.test.ts
+++ b/apps/server/src/lib/env.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { findUnsafeWildcardOrigin } from './env.js'
+import {
+	buildInvitationCallbackURL,
+	findPublicUrlNotAllowed,
+	findUnsafeWildcardOrigin,
+} from './env.js'
 
 // Locks in the safety guard that refuses to boot when ALLOWED_ORIGINS
 // includes a wildcard pattern whose suffix is *not* `.localhost`. Without
@@ -70,6 +74,77 @@ describe('findUnsafeWildcardOrigin', () => {
 			expect(
 				findUnsafeWildcardOrigin(['https://*.localhost.attacker.com']),
 			).toBe('https://*.localhost.attacker.com')
+		})
+	})
+})
+
+// The invitation callback URL is built from APP_PUBLIC_URL, not
+// ALLOWED_ORIGINS[0] — so reordering the trusted-origins list can't silently
+// retarget invite links. These lock the host the link points at.
+describe('buildInvitationCallbackURL', () => {
+	describe('with a public URL and an invitation id', () => {
+		it('should build an absolute accept-invitation URL', () => {
+			// GIVEN the canonical app origin and an invitation id
+			// WHEN the callback URL is built
+			// THEN it is <origin>/accept-invitation/<id>
+			// [lib/env.ts — buildInvitationCallbackURL]
+			expect(buildInvitationCallbackURL('https://batuda.co', 'inv-1')).toBe(
+				'https://batuda.co/accept-invitation/inv-1',
+			)
+		})
+
+		it('should trim a trailing slash on the origin', () => {
+			// GIVEN a public URL with a trailing slash
+			// WHEN the callback URL is built
+			// THEN the slash is collapsed so the path isn't doubled
+			// [lib/env.ts — replace(/\/$/, '')]
+			expect(buildInvitationCallbackURL('https://batuda.co/', 'inv-2')).toBe(
+				'https://batuda.co/accept-invitation/inv-2',
+			)
+		})
+
+		it('should target the given origin regardless of any origins order', () => {
+			// GIVEN the builder takes the origin directly (not ALLOWED_ORIGINS[0])
+			// WHEN called with a second-listed product origin
+			// THEN the link targets exactly that origin — reordering can't move it
+			// [lib/env.ts — origin is a parameter, not positional]
+			expect(buildInvitationCallbackURL('https://app.batuda.co', 'inv-3')).toBe(
+				'https://app.batuda.co/accept-invitation/inv-3',
+			)
+		})
+	})
+})
+
+// APP_PUBLIC_URL must be one of ALLOWED_ORIGINS or the server refuses to boot,
+// so an invite can't point at a host the app doesn't actually trust.
+describe('findPublicUrlNotAllowed', () => {
+	describe('when the public URL is one of the allowed origins', () => {
+		it('should return null', () => {
+			// GIVEN APP_PUBLIC_URL listed in ALLOWED_ORIGINS
+			// WHEN the validator runs
+			// THEN it passes (null)
+			// [lib/env.ts — includes() short-circuit]
+			expect(
+				findPublicUrlNotAllowed('https://batuda.co', [
+					'https://admin.batuda.co',
+					'https://batuda.co',
+				]),
+			).toBeNull()
+		})
+	})
+
+	describe('when the public URL is not an allowed origin', () => {
+		it('should return a message so boot fails', () => {
+			// GIVEN APP_PUBLIC_URL absent from ALLOWED_ORIGINS
+			// WHEN the validator runs
+			// THEN it returns a non-null message that EnvVars turns into a boot
+			//   ConfigError
+			// [lib/env.ts — non-membership branch]
+			const message = findPublicUrlNotAllowed('https://evil.example', [
+				'https://batuda.co',
+			])
+			expect(message).not.toBeNull()
+			expect(message).toContain('APP_PUBLIC_URL')
 		})
 	})
 })

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -28,6 +28,35 @@ export function findUnsafeWildcardOrigin(
 	return null
 }
 
+/**
+ * Builds the absolute accept-invitation URL Better Auth redirects to after a
+ * magic-link verify. Takes the public origin explicitly so it can't drift
+ * with ALLOWED_ORIGINS ordering — reordering that list never retargets an
+ * invite link at the wrong product.
+ */
+export function buildInvitationCallbackURL(
+	publicUrl: string,
+	invitationId: string,
+): string {
+	return `${publicUrl.replace(/\/$/, '')}/accept-invitation/${invitationId}`
+}
+
+/**
+ * Returns an explanatory message if `publicUrl` is not one of
+ * `allowedOrigins`, else `null`. APP_PUBLIC_URL must be a trusted origin so
+ * the links the server mints can't point at a host it won't serve.
+ */
+export function findPublicUrlNotAllowed(
+	publicUrl: string,
+	allowedOrigins: ReadonlyArray<string>,
+): string | null {
+	if (allowedOrigins.includes(publicUrl)) return null
+	return (
+		`APP_PUBLIC_URL "${publicUrl}" is not one of ALLOWED_ORIGINS ` +
+		`[${allowedOrigins.join(', ')}]. List it there so the app trusts it.`
+	)
+}
+
 export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 	make: Effect.gen(function* () {
 		const DATABASE_URL = yield* Config.redacted('DATABASE_URL')
@@ -81,6 +110,24 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 				return Effect.succeed(patterns)
 			}),
 		)
+
+		// Canonical public origin for the links the server mints (invitation
+		// callback URLs). Required, no default — like BETTER_AUTH_BASE_URL — and
+		// validated to be one of ALLOWED_ORIGINS so an invite can't point at an
+		// origin the app doesn't trust. Decoupled from ALLOWED_ORIGINS ordering
+		// on purpose: reordering that list no longer moves invite links.
+		const APP_PUBLIC_URL = yield* Config.string('APP_PUBLIC_URL')
+		const publicUrlError = findPublicUrlNotAllowed(
+			APP_PUBLIC_URL,
+			ALLOWED_ORIGINS,
+		)
+		if (publicUrlError !== null) {
+			return yield* Effect.fail(
+				new Config.ConfigError(
+					new ConfigProvider.SourceError({ message: publicUrlError }),
+				),
+			)
+		}
 
 		// S3-compatible object storage. Same code path serves MinIO (local
 		// dev) and Cloudflare R2 (prod) — only the endpoint/credentials
@@ -156,6 +203,7 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 			BETTER_AUTH_INSECURE_COOKIES,
 			BETTER_AUTH_RATE_LIMIT,
 			ALLOWED_ORIGINS,
+			APP_PUBLIC_URL,
 			STORAGE_ENDPOINT,
 			STORAGE_REGION,
 			STORAGE_ACCESS_KEY_ID,

--- a/apps/server/src/main.boot.test.ts
+++ b/apps/server/src/main.boot.test.ts
@@ -24,8 +24,9 @@ const PORT = 34_040
 const env = {
 	NODE_ENV: 'production',
 	PORT: String(PORT),
-	// Local dev fixtures from `pnpm cli services up`.
-	DATABASE_URL: 'postgres://batuda:batuda-secret@localhost:5433/batuda',
+	// Local dev fixtures from `pnpm cli services up` (docker-compose sets
+	// POSTGRES_PASSWORD=batuda).
+	DATABASE_URL: 'postgres://batuda:batuda@localhost:5433/batuda',
 	STORAGE_ENDPOINT: 'http://localhost:9000',
 	STORAGE_REGION: 'auto',
 	STORAGE_ACCESS_KEY_ID: 'batuda',
@@ -34,7 +35,10 @@ const env = {
 	// Boot-time tags must be set; the actual auth flow isn't exercised.
 	BETTER_AUTH_SECRET: '00000000000000000000000000000000',
 	BETTER_AUTH_BASE_URL: `http://localhost:${PORT}`,
-	ALLOWED_ORIGINS: '',
+	// APP_PUBLIC_URL is required and validated ∈ ALLOWED_ORIGINS at boot, so
+	// these must be a consistent pair (was ALLOWED_ORIGINS='').
+	ALLOWED_ORIGINS: `http://localhost:${PORT}`,
+	APP_PUBLIC_URL: `http://localhost:${PORT}`,
 	EMAIL_CREDENTIAL_KEY: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
 	EMAIL_PROVIDER: 'local-inbox',
 	EMAIL_PROVIDER_TRANSACTIONAL: 'local',


### PR DESCRIPTION
## What & why

The invitation `callbackURL` was built from `ALLOWED_ORIGINS[0]` (`lib/auth.ts`). Production ships two product origins (`batuda.co`, `engranatge.com`), so reordering that list would silently point invite links at the wrong product. This is the only positional consumer — CORS uses set-membership. This adds an explicit, boot-validated `APP_PUBLIC_URL` and routes invite links through it, so ordering no longer matters.

## Changes

- **`lib/env.ts`**: new `APP_PUBLIC_URL` — required (no default, like `BETTER_AUTH_BASE_URL`) and validated to be one of `ALLOWED_ORIGINS` at boot (fails with a `Config.ConfigError`). Two pure helpers: `buildInvitationCallbackURL(publicUrl, invitationId)` and `findPublicUrlNotAllowed(publicUrl, allowedOrigins)`.
- **`lib/auth.ts`**: the invitation `callbackURL` now uses `buildInvitationCallbackURL(env.APP_PUBLIC_URL, data.id)`; removed the dead empty-origin guard.
- **Config**: declared `APP_PUBLIC_URL` in `.env.example` / `.env.example.github` (=`https://batuda.co`) and both deploy blocks of `.github/workflows/deploy_server.yml`. Not needed in `apps/cli` / `apps/internal` / `.env.example.cloud`.
- **`main.boot.test.ts`**: set `ALLOWED_ORIGINS` + `APP_PUBLIC_URL` to a consistent pair (was `ALLOWED_ORIGINS=''`). Also fixed a stale `DATABASE_URL` password (`batuda-secret` → `batuda`; docker-compose uses `batuda`) that was independently breaking the boot test.

## ⚠️ Required before next deploy

The deploy workflow now passes `${{ vars.APP_PUBLIC_URL }}`. The GitHub **production** environment variable must exist or boot will fail on the required var:

```
gh variable set APP_PUBLIC_URL --env production --body "https://batuda.co"
```

(Local dev: add `APP_PUBLIC_URL=https://batuda.localhost` to your `.env`.)

## Tests

- `env.test.ts`: `buildInvitationCallbackURL` builds from the given origin, trims a trailing slash, and is order-independent by construction; `findPublicUrlNotAllowed` passes when the URL is listed and returns a message (→ boot fail) when it isn't.
- Boot test now passes 3/3 with the required `APP_PUBLIC_URL`.

## Verification

- `check-types` + unit `test` + `build` (turbo): 30/30.
- Boot test (`pnpm --filter @batuda/server test:boot`): 3/3.
- Full server integration suite: 13 files / 99 tests.

Part of the architecture-remediation series (PR-F).