### PR TITLE
feat(server): record task transitions on the company timeline

### DIFF
--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -14,17 +14,18 @@ import { TaskService } from '../services/tasks'
 type TaskRow = {
 	readonly id: string
 	readonly status: string
-	readonly updated_at: string
-	readonly completed_at: string | null
+	readonly updatedAt: string
+	readonly completedAt: string | null
 }
 
 // Optimistic-concurrency gate for PATCH /tasks/:id. Compare the row's
 // current `updated_at` ISO against the client's `If-Match` header; any
 // drift returns 409 so the UI can resurface the fresh row instead of
-// silently overwriting an agent's edit.
+// silently overwriting an agent's edit. Result columns arrive camelCase
+// (PgClient transformResultNames), so read `updatedAt`, not `updated_at`.
 const requireFresh = (row: TaskRow, ifMatch: string | undefined) => {
 	if (!ifMatch) return Effect.void
-	const current = new Date(row.updated_at).toISOString()
+	const current = new Date(row.updatedAt).toISOString()
 	if (current === ifMatch) return Effect.void
 	return Effect.fail(
 		new Conflict({
@@ -204,13 +205,24 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 				}),
 			)
 			.handle('snooze', _ =>
-				taskService.snooze(_.params.id, DateTime.toDateUtc(_.payload.until)),
+				Effect.gen(function* () {
+					const { userId, isAgent } = yield* SessionContext
+					return yield* taskService.snooze(
+						_.params.id,
+						DateTime.toDateUtc(_.payload.until),
+						{ id: userId, kind: isAgent ? 'agent' : 'user' },
+					)
+				}),
 			)
 			.handle('reschedule', _ =>
-				taskService.reschedule(
-					_.params.id,
-					_.payload.dueAt ? DateTime.toDateUtc(_.payload.dueAt) : null,
-				),
+				Effect.gen(function* () {
+					const { userId, isAgent } = yield* SessionContext
+					return yield* taskService.reschedule(
+						_.params.id,
+						_.payload.dueAt ? DateTime.toDateUtc(_.payload.dueAt) : null,
+						{ id: userId, kind: isAgent ? 'agent' : 'user' },
+					)
+				}),
 			)
 			.handle('bulkComplete', _ =>
 				Effect.gen(function* () {

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -358,7 +358,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 				),
 
 			snooze_task: params =>
-				taskService.snooze(params.id, new Date(params.until)).pipe(
+				taskService.snooze(params.id, new Date(params.until), AGENT_ACTOR).pipe(
 					Effect.catchTag('NotFound', () => Effect.succeed(null)),
 					Effect.orDie,
 				),
@@ -368,6 +368,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 					.reschedule(
 						params.id,
 						params.due_at === null ? null : new Date(params.due_at),
+						AGENT_ACTOR,
 					)
 					.pipe(
 						Effect.catchTag('NotFound', () => Effect.succeed(null)),

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -22,6 +22,7 @@ import { CurrentOrg } from '@batuda/controllers'
 
 import { PgLive } from '../db/client'
 import { type TaskFilters, type TaskPage, TaskService } from './tasks'
+import { TimelineActivityService } from './timeline-activity'
 
 const DATABASE_URL =
 	process.env['DATABASE_URL'] ??
@@ -59,7 +60,17 @@ beforeAll(async () => {
 }, 30_000)
 
 afterAll(async () => {
-	// Run as connection owner (no role switch) so RLS doesn't gate cleanup.
+	// Run as the connecting superuser (no role switch) so RLS doesn't gate
+	// cleanup. timeline_activity has no FK to tasks, so clear it and the
+	// task_events trail by the fixture title before the tasks themselves.
+	await pool.query(
+		`DELETE FROM timeline_activity WHERE entity_type = 'task' AND entity_id IN (SELECT id FROM tasks WHERE title = $1)`,
+		[FIXTURE_TITLE],
+	)
+	await pool.query(
+		`DELETE FROM task_events WHERE task_id IN (SELECT id FROM tasks WHERE title = $1)`,
+		[FIXTURE_TITLE],
+	)
 	await pool.query(`DELETE FROM tasks WHERE title = $1`, [FIXTURE_TITLE])
 	await pool.end()
 })
@@ -84,7 +95,12 @@ const createWith = (
 			name: 'fixture',
 			slug: 'fixture',
 		}),
-	).pipe(Layer.provideMerge(PgLive))
+	).pipe(
+		// TaskService now records onto the timeline, so it needs
+		// TimelineActivityService; both resolve their SqlClient from PgLive.
+		Layer.provideMerge(TimelineActivityService.layer),
+		Layer.provideMerge(PgLive),
+	)
 
 	return Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
@@ -178,7 +194,12 @@ const listWith = (org: string, filters: TaskFilters) => {
 	const deps = Layer.mergeAll(
 		TaskService.layer,
 		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
-	).pipe(Layer.provideMerge(PgLive))
+	).pipe(
+		// TaskService now records onto the timeline, so it needs
+		// TimelineActivityService; both resolve their SqlClient from PgLive.
+		Layer.provideMerge(TimelineActivityService.layer),
+		Layer.provideMerge(PgLive),
+	)
 	const page: TaskPage = { sort: 'due', limit: 100, offset: 0 }
 
 	return Effect.gen(function* () {
@@ -269,7 +290,12 @@ const attempt = (
 	const deps = Layer.mergeAll(
 		TaskService.layer,
 		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
-	).pipe(Layer.provideMerge(PgLive))
+	).pipe(
+		// TaskService now records onto the timeline, so it needs
+		// TimelineActivityService; both resolve their SqlClient from PgLive.
+		Layer.provideMerge(TimelineActivityService.layer),
+		Layer.provideMerge(PgLive),
+	)
 
 	return Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
@@ -332,7 +358,10 @@ describe('TaskService transitions', () => {
 				tallerOrgId,
 				Effect.gen(function* () {
 					const tasks = yield* TaskService
-					return yield* tasks.snooze(id, new Date(Date.now() - 60_000))
+					return yield* tasks.snooze(id, new Date(Date.now() - 60_000), {
+						id: null,
+						kind: 'user',
+					})
 				}),
 			)
 
@@ -404,6 +433,98 @@ describe('TaskService task_events', () => {
 			expect(events.rows[1]?.change).toEqual({ status: ['open', 'done'] })
 			expect(events.rows[1]?.actor_kind).toBe('agent')
 			// [apps/server/src/services/tasks.ts — recordEvent]
+		} finally {
+			client.release()
+		}
+	})
+})
+
+describe('TaskService timeline activity', () => {
+	it('should record task_created then task_completed on the company timeline', async () => {
+		// GIVEN a freshly created company-less task (create records TaskCreated)
+		const created = (await createWith(tallerOrgId, tallerOrgId, {
+			type: 'follow_up',
+			title: FIXTURE_TITLE,
+			status: 'open',
+		})) as ReadonlyArray<{ id: string }>
+		const taskId = created[0]?.id
+		if (!taskId) throw new Error('fixture task was not created')
+
+		// WHEN it is completed through the service
+		await attempt(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.complete(taskId, { id: null, kind: 'agent' })
+			}),
+		)
+
+		// THEN both activities land on the timeline for the task, with a null
+		// company_id — company-less tasks still appear
+		// [apps/server/src/services/tasks.ts — timeline.record on create + complete]
+		const activities = await pool.query<{
+			kind: string
+			company_id: string | null
+		}>(
+			`SELECT kind, company_id FROM timeline_activity
+			 WHERE entity_type = 'task' AND entity_id = $1::uuid
+			 ORDER BY occurred_at ASC`,
+			[taskId],
+		)
+		expect(activities.rows.map(r => r.kind)).toEqual([
+			'task_created',
+			'task_completed',
+		])
+		expect(activities.rows[0]?.company_id).toBeNull()
+	})
+})
+
+describe('TaskService snooze/reschedule events', () => {
+	it('should append a field-diff event for snooze and for reschedule', async () => {
+		// GIVEN an open task
+		const id = await seedTask({ status: 'open' })
+
+		// WHEN it is snoozed to the future then rescheduled, as an agent
+		await attempt(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.snooze(id, new Date(Date.now() + 3_600_000), {
+					id: null,
+					kind: 'agent',
+				})
+			}),
+		)
+		await attempt(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.reschedule(id, new Date(Date.now() + 7_200_000), {
+					id: null,
+					kind: 'agent',
+				})
+			}),
+		)
+
+		// THEN both transitions appended events — previously snooze and
+		// reschedule wrote nothing to the undo trail
+		// [apps/server/src/services/tasks.ts — recordTaskUpdate on snooze/reschedule]
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			await client.query('SET LOCAL ROLE app_user')
+			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+				tallerOrgId,
+			])
+			const events = await client.query<{ change: Record<string, unknown> }>(
+				`SELECT change FROM task_events WHERE task_id = $1 ORDER BY at ASC`,
+				[id],
+			)
+			await client.query('ROLLBACK')
+
+			const keys = events.rows.flatMap(r => Object.keys(r.change))
+			expect(keys).toContain('snoozedUntil')
+			expect(keys).toContain('dueAt')
 		} finally {
 			client.release()
 		}

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -4,6 +4,13 @@ import { SqlClient } from 'effect/unstable/sql'
 
 import { BadRequest, Conflict, CurrentOrg, NotFound } from '@batuda/controllers'
 
+import {
+	TaskCompleted,
+	TaskCreated,
+	TaskUpdated,
+	TimelineActivityService,
+} from './timeline-activity'
+
 export interface TaskFilters {
 	readonly companyId?: string | undefined
 	readonly contactId?: string | undefined
@@ -38,6 +45,18 @@ export interface TaskActor {
 	readonly kind: 'user' | 'agent'
 }
 
+// Columns read back from a write to build the timeline event. Result names
+// are camelCase (PgClient transformResultNames), so this mirrors the row as
+// returned, not the snake_case columns.
+interface TaskRow {
+	readonly id: string
+	readonly organizationId: string
+	readonly companyId: string | null
+	readonly contactId: string | null
+	readonly title: string
+	readonly type: string
+}
+
 // Persistence shared by the HTTP `tasks` handler and the MCP task toolkit.
 // Writes funnel through here so the `organization_id` stamp lives in one
 // place: the column is NOT NULL with no DB default, and the org_isolation
@@ -49,6 +68,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 	{
 		make: Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
+			const timeline = yield* TimelineActivityService
 
 			const conditionsFor = (
 				orgId: string,
@@ -110,20 +130,58 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 					change: JSON.stringify(change),
 				})}`.pipe(Effect.orDie, Effect.asVoid)
 
+			// Both stores for a non-create transition: the task_events undo trail
+			// AND the company-timeline activity row. Kept together so a new
+			// transition can't write one and forget the other. `record` maps a
+			// `status → done` change to a task_completed activity; other diffs land
+			// as task_updated.
+			const recordTaskUpdate = (
+				orgId: string,
+				row: TaskRow,
+				actor: TaskActor,
+				change: Record<string, readonly [unknown, unknown]>,
+			) =>
+				Effect.gen(function* () {
+					yield* recordEvent(orgId, row.id, actor, change)
+					yield* timeline.record(
+						new TaskUpdated({
+							taskId: row.id,
+							companyId: row.companyId,
+							contactId: row.contactId,
+							change,
+							actorUserId: actor.id,
+							actorKind: actor.kind,
+							occurredAt: new Date(),
+						}),
+					)
+				})
+
 			return {
 				create: (data: Record<string, unknown>, actor: TaskActor) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const rows = yield* sql<{
-							id: string
-						}>`INSERT INTO tasks ${sql.insert({ ...data, organizationId: currentOrg.id })} RETURNING *`.pipe(
-							Effect.orDie,
-						)
+						const rows =
+							yield* sql<TaskRow>`INSERT INTO tasks ${sql.insert({ ...data, organizationId: currentOrg.id })} RETURNING *`.pipe(
+								Effect.orDie,
+							)
 						const row = rows[0]
-						if (row)
+						if (row) {
 							yield* recordEvent(currentOrg.id, row.id, actor, {
 								kind: 'created',
 							})
+							yield* timeline.record(
+								new TaskCreated({
+									taskId: row.id,
+									companyId: row.companyId,
+									contactId: row.contactId,
+									title: row.title,
+									taskType: row.type,
+									actorUserId: actor.id,
+									actorKind: actor.kind,
+									occurredAt: new Date(),
+								}),
+							)
+						}
 						return rows
 					}),
 
@@ -153,7 +211,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`.pipe(Effect.orDie)
 						const prior = before[0]
 						if (!prior) return yield* new NotFound({ entity: 'task', id })
-						const rows = yield* sql<{ id: string }>`
+						const rows = yield* sql<TaskRow>`
 							UPDATE tasks SET
 								status = 'done',
 								completed_at = COALESCE(completed_at, now()),
@@ -166,6 +224,16 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						yield* recordEvent(currentOrg.id, id, actor, {
 							status: [prior.status, 'done'],
 						})
+						yield* timeline.record(
+							new TaskCompleted({
+								taskId: id,
+								companyId: row.companyId,
+								contactId: row.contactId,
+								actorUserId: actor.id,
+								actorKind: actor.kind,
+								occurredAt: new Date(),
+							}),
+						)
 						return row
 					}),
 
@@ -179,7 +247,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`.pipe(Effect.orDie)
 						const prior = before[0]
 						if (!prior) return yield* new NotFound({ entity: 'task', id })
-						const rows = yield* sql<{ id: string }>`
+						const rows = yield* sql<TaskRow>`
 							UPDATE tasks SET
 								status = 'open',
 								completed_at = NULL,
@@ -189,7 +257,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`.pipe(Effect.orDie)
 						const row = rows[0]
 						if (!row) return yield* new NotFound({ entity: 'task', id })
-						yield* recordEvent(currentOrg.id, id, actor, {
+						yield* recordTaskUpdate(currentOrg.id, row, actor, {
 							status: [prior.status, 'open'],
 						})
 						return row
@@ -211,7 +279,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 							return yield* new Conflict({ message: 'cannot_cancel_done_task' })
 						// Clearing completed_at keeps the done ⇔ completed_at invariant:
 						// only status='done' may carry one (tasks_completed_at_matches_status).
-						const rows = yield* sql<{ id: string }>`
+						const rows = yield* sql<TaskRow>`
 							UPDATE tasks SET
 								status = 'cancelled',
 								completed_at = NULL,
@@ -221,39 +289,59 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						`.pipe(Effect.orDie)
 						const row = rows[0]
 						if (!row) return yield* new NotFound({ entity: 'task', id })
-						yield* recordEvent(currentOrg.id, id, actor, {
+						yield* recordTaskUpdate(currentOrg.id, row, actor, {
 							status: [existing.status, 'cancelled'],
 						})
 						return row
 					}),
 
-				snooze: (id: string, until: Date) =>
+				snooze: (id: string, until: Date, actor: TaskActor) =>
 					Effect.gen(function* () {
 						// Reject past timers on both transports — a snooze into the past
 						// would resurface the task immediately.
 						if (until.getTime() <= Date.now())
 							return yield* new BadRequest({ message: 'until_must_be_future' })
 						const currentOrg = yield* CurrentOrg
-						const rows = yield* sql<{ id: string }>`
+						const before = yield* sql<{ snoozedUntil: string | null }>`
+							SELECT snoozed_until FROM tasks
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`.pipe(Effect.orDie)
+						const prior = before[0]
+						if (!prior) return yield* new NotFound({ entity: 'task', id })
+						const rows = yield* sql<TaskRow>`
 							UPDATE tasks SET snoozed_until = ${until}, updated_at = now()
 							WHERE id = ${id} AND organization_id = ${currentOrg.id}
 							RETURNING *
 						`.pipe(Effect.orDie)
 						const row = rows[0]
 						if (!row) return yield* new NotFound({ entity: 'task', id })
+						yield* recordTaskUpdate(currentOrg.id, row, actor, {
+							snoozedUntil: [prior.snoozedUntil, until],
+						})
 						return row
 					}),
 
-				reschedule: (id: string, dueAt: Date | null) =>
+				reschedule: (id: string, dueAt: Date | null, actor: TaskActor) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const rows = yield* sql<{ id: string }>`
+						const before = yield* sql<{ dueAt: string | null }>`
+							SELECT due_at FROM tasks
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`.pipe(Effect.orDie)
+						const prior = before[0]
+						if (!prior) return yield* new NotFound({ entity: 'task', id })
+						const rows = yield* sql<TaskRow>`
 							UPDATE tasks SET due_at = ${dueAt}, updated_at = now()
 							WHERE id = ${id} AND organization_id = ${currentOrg.id}
 							RETURNING *
 						`.pipe(Effect.orDie)
 						const row = rows[0]
 						if (!row) return yield* new NotFound({ entity: 'task', id })
+						yield* recordTaskUpdate(currentOrg.id, row, actor, {
+							dueAt: [prior.dueAt, dueAt],
+						})
 						return row
 					}),
 			}


### PR DESCRIPTION
## What & why

`TaskService` wrote the `task_events` undo trail (create/complete/reopen/cancel) but never called `TimelineActivityService.record()` — so `TaskCreated`/`TaskUpdated`/`TaskCompleted` were defined and mapped yet never constructed, and tasks never showed on the company timeline alongside emails and calls. This wires the timeline in and completes the audit trail.

## Changes

- **`services/tasks.ts`**: `TaskService` now depends on `TimelineActivityService`. Each transition records a `timeline_activity` row — create → `TaskCreated`, complete → `TaskCompleted`, reopen/cancel/snooze/reschedule → `TaskUpdated`. A new `recordTaskUpdate` helper writes **both** the `task_events` undo row and the timeline activity together, so a future transition can't update one and forget the other. (Task events write only a `timeline_activity` row — no interaction/cadence side effects.)
- **`snooze`/`reschedule`** gained an `actor: TaskActor` param (+ a before-SELECT for the old value) so they append a field-diff `task_events` row; previously they wrote nothing to the undo trail. Threaded from `SessionContext` on HTTP, `AGENT_ACTOR` on MCP.
- **`handlers/tasks.ts`**: fixed a latent bug — `requireFresh` read `row.updated_at`, but results are camelCase (`updatedAt`, PgClient `transformResultNames`), so any `If-Match` request threw on `new Date(undefined)`. `TaskRow` corrected to camelCase.

## Tests

Extended `tasks.integration.test.ts` (provides `TimelineActivityService` to the layers; `afterAll` now clears `timeline_activity` + `task_events` for fixtures):
- a created-then-completed task lands `task_created` + `task_completed` on the timeline, with `company_id` NULL (company-less tasks still appear);
- `snooze` + `reschedule` append `snoozedUntil` / `dueAt` field-diff events.

These also execute `TimelineActivityService.record()` against a real DB for the first time (the prior gap).

## Remaining (tracked, not in this PR)

- Move `update`/`get`/`bulkComplete` off the inline handler onto `TaskService` (the original thin-handler goal).
- `record()` cadence tests for email/meeting events (out-of-order `last_*_at` via GREATEST; `next_calendar_event_at` decrease via recompute).

## Verification

- `check-types` + unit `test` + `build` (turbo): 30/30.
- Full server integration suite: 13 files / 101 tests (+2 here).

Follow-up to PR-D (the deferred task-timeline work).