### PR TITLE
refactor(server): move task get/update/bulkComplete onto TaskService

### DIFF
--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -2,37 +2,9 @@ import { DateTime, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import { SqlClient } from 'effect/unstable/sql'
 
-import {
-	BatudaApi,
-	Conflict,
-	NotFound,
-	SessionContext,
-} from '@batuda/controllers'
+import { BatudaApi, NotFound, SessionContext } from '@batuda/controllers'
 
 import { TaskService } from '../services/tasks'
-
-type TaskRow = {
-	readonly id: string
-	readonly status: string
-	readonly updatedAt: string
-	readonly completedAt: string | null
-}
-
-// Optimistic-concurrency gate for PATCH /tasks/:id. Compare the row's
-// current `updated_at` ISO against the client's `If-Match` header; any
-// drift returns 409 so the UI can resurface the fresh row instead of
-// silently overwriting an agent's edit. Result columns arrive camelCase
-// (PgClient transformResultNames), so read `updatedAt`, not `updated_at`.
-const requireFresh = (row: TaskRow, ifMatch: string | undefined) => {
-	if (!ifMatch) return Effect.void
-	const current = new Date(row.updatedAt).toISOString()
-	if (current === ifMatch) return Effect.void
-	return Effect.fail(
-		new Conflict({
-			message: `stale_write — current updated_at ${current} !== If-Match ${ifMatch}`,
-		}),
-	)
-}
 
 export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 	Effect.gen(function* () {
@@ -69,20 +41,7 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 					)
 				}).pipe(Effect.orDie),
 			)
-			.handle('get', _ =>
-				Effect.gen(function* () {
-					const rows = yield* sql<TaskRow>`
-						SELECT * FROM tasks WHERE id = ${_.params.id} LIMIT 1
-					`
-					if (rows.length === 0)
-						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					return rows[0]
-				}).pipe(
-					Effect.catch(e =>
-						e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
-					),
-				),
-			)
+			.handle('get', _ => taskService.get(_.params.id))
 			.handle('create', _ =>
 				Effect.gen(function* () {
 					const { userId: actorId, isAgent } = yield* SessionContext
@@ -122,60 +81,36 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 			)
 			.handle('update', _ =>
 				Effect.gen(function* () {
-					const current = yield* sql<TaskRow>`
-						SELECT * FROM tasks WHERE id = ${_.params.id} LIMIT 1
-					`
-					const row = current[0]
-					if (!row)
-						return yield* new NotFound({ entity: 'task', id: _.params.id })
-					yield* requireFresh(row, _.headers['if-match'])
-
-					const updates: Record<string, unknown> = {}
-					if (_.payload.title !== undefined) updates['title'] = _.payload.title
-					if (_.payload.notes !== undefined) updates['notes'] = _.payload.notes
-					if (_.payload.status !== undefined)
-						updates['status'] = _.payload.status
-					if (_.payload.priority !== undefined)
-						updates['priority'] = _.payload.priority
-					if (_.payload.assigneeId !== undefined)
-						updates['assignee_id'] = _.payload.assigneeId
-					if (_.payload.dueAt !== undefined)
-						updates['due_at'] = _.payload.dueAt
-							? DateTime.toDateUtc(_.payload.dueAt)
-							: null
-					if (_.payload.snoozedUntil !== undefined)
-						updates['snoozed_until'] = _.payload.snoozedUntil
-							? DateTime.toDateUtc(_.payload.snoozedUntil)
-							: null
-					if (_.payload.companyId !== undefined)
-						updates['company_id'] = _.payload.companyId
-					if (_.payload.contactId !== undefined)
-						updates['contact_id'] = _.payload.contactId
-					if (_.payload.metadata !== undefined)
-						updates['metadata'] = _.payload.metadata
-
-					// Keep the invariant: status='done' ⇔ completed_at IS NOT NULL.
-					// The DB CHECK would reject violations anyway, but updating
-					// `completed_at` here means clients don't have to know about it.
-					if (_.payload.status !== undefined) {
-						updates['completed_at'] =
-							_.payload.status === 'done' ? new Date() : null
-					}
-					updates['updated_at'] = new Date()
-					updates['actor_id'] = (yield* SessionContext).userId
-
-					const updated = yield* sql`
-						UPDATE tasks SET ${sql.update(updates)}
-						WHERE id = ${_.params.id} RETURNING *
-					`
-					return updated[0]
-				}).pipe(
-					Effect.catch(e =>
-						e._tag === 'NotFound' || e._tag === 'Conflict'
-							? Effect.fail(e)
-							: Effect.die(e),
-					),
-				),
+					const { userId, isAgent } = yield* SessionContext
+					return yield* taskService.update(
+						_.params.id,
+						{
+							title: _.payload.title,
+							notes: _.payload.notes,
+							status: _.payload.status,
+							priority: _.payload.priority,
+							assigneeId: _.payload.assigneeId,
+							// undefined leaves the column untouched; explicit null clears it.
+							dueAt:
+								_.payload.dueAt !== undefined
+									? _.payload.dueAt
+										? DateTime.toDateUtc(_.payload.dueAt)
+										: null
+									: undefined,
+							snoozedUntil:
+								_.payload.snoozedUntil !== undefined
+									? _.payload.snoozedUntil
+										? DateTime.toDateUtc(_.payload.snoozedUntil)
+										: null
+									: undefined,
+							companyId: _.payload.companyId,
+							contactId: _.payload.contactId,
+							metadata: _.payload.metadata,
+						},
+						{ id: userId, kind: isAgent ? 'agent' : 'user' },
+						_.headers['if-match'],
+					)
+				}),
 			)
 			.handle('complete', _ =>
 				Effect.gen(function* () {
@@ -224,24 +159,10 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 					)
 				}),
 			)
-			.handle('bulkComplete', _ =>
-				Effect.gen(function* () {
-					const rows = yield* sql`
-						UPDATE tasks SET
-							status = 'done',
-							completed_at = COALESCE(completed_at, now()),
-							updated_at = now()
-						WHERE id IN ${sql.in(_.payload.ids)} RETURNING id
-					`
-					return {
-						completed: rows.length,
-						ids: rows.map(r => (r as { id: string }).id),
-					}
-				}).pipe(Effect.orDie),
-			)
+			.handle('bulkComplete', _ => taskService.bulkComplete(_.payload.ids))
 			.handle('events', _ =>
 				Effect.gen(function* () {
-					const exists = yield* sql<TaskRow>`
+					const exists = yield* sql`
 						SELECT id FROM tasks WHERE id = ${_.params.id} LIMIT 1
 					`
 					if (exists.length === 0)

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -327,6 +327,32 @@ const seedTask = async (data: Record<string, unknown>): Promise<string> => {
 	return row.id
 }
 
+// Runs a method under role app_user + the org GUC and returns its value
+// (failures die). Use `attempt` instead when asserting a tagged failure.
+const runScoped = <A>(
+	org: string,
+	body: Effect.Effect<A, unknown, CurrentOrg | TaskService>,
+): Promise<A> => {
+	const deps = Layer.mergeAll(
+		TaskService.layer,
+		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+	).pipe(
+		Layer.provideMerge(TimelineActivityService.layer),
+		Layer.provideMerge(PgLive),
+	)
+
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${org}, true)`
+				return yield* body
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+}
+
 describe('TaskService transitions', () => {
 	describe('cancel', () => {
 		it('should reject cancelling a task that is already done', async () => {
@@ -528,6 +554,121 @@ describe('TaskService snooze/reschedule events', () => {
 		} finally {
 			client.release()
 		}
+	})
+})
+
+describe('TaskService.get', () => {
+	it('should return the task for its own org', async () => {
+		// GIVEN a seeded task
+		const id = await seedTask({ status: 'open' })
+
+		// WHEN fetched through the service under that org
+		const row = (await runScoped(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.get(id)
+			}),
+		)) as { id: string }
+
+		// THEN it returns the row
+		expect(row.id).toBe(id)
+		// [apps/server/src/services/tasks.ts — get]
+	})
+
+	it('should report NotFound for a missing id', async () => {
+		// GIVEN an id that does not exist
+		// WHEN fetched
+		const result = await attempt(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.get(randomUUID())
+			}),
+		)
+
+		// THEN it fails with NotFound
+		expect(result.failedWith).toBe('NotFound')
+		// [apps/server/src/services/tasks.ts — get NotFound]
+	})
+})
+
+describe('TaskService.update', () => {
+	it('should apply a field change without an If-Match', async () => {
+		// GIVEN an open task
+		const id = await seedTask({ status: 'open' })
+
+		// WHEN its notes are updated through the service (title stays the
+		// fixture so afterAll still cleans it up)
+		await runScoped(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.update(
+					id,
+					{ notes: 'consolidation-test-note' },
+					{ id: null, kind: 'user' },
+				)
+			}),
+		)
+
+		// THEN the committed row reflects the change
+		const after = await pool.query<{ notes: string | null }>(
+			`SELECT notes FROM tasks WHERE id = $1`,
+			[id],
+		)
+		expect(after.rows[0]?.notes).toBe('consolidation-test-note')
+		// [apps/server/src/services/tasks.ts — update]
+	})
+
+	it('should reject a stale If-Match with Conflict', async () => {
+		// GIVEN an open task
+		const id = await seedTask({ status: 'open' })
+
+		// WHEN updated with an If-Match that can't match the row's updated_at
+		const result = await attempt(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.update(
+					id,
+					{ title: FIXTURE_TITLE },
+					{ id: null, kind: 'user' },
+					'1970-01-01T00:00:00.000Z',
+				)
+			}),
+		)
+
+		// THEN it fails Conflict — and the freshness check read `updatedAt`
+		// (camelCase) without throwing on a missing `updated_at` column
+		expect(result.failedWith).toBe('Conflict')
+		// [apps/server/src/services/tasks.ts — update If-Match gate]
+	})
+})
+
+describe('TaskService.bulkComplete', () => {
+	it('should complete the given tasks and report the count', async () => {
+		// GIVEN two open tasks
+		const a = await seedTask({ status: 'open' })
+		const b = await seedTask({ status: 'open' })
+
+		// WHEN bulk-completed through the service
+		const result = (await runScoped(
+			tallerOrgId,
+			Effect.gen(function* () {
+				const tasks = yield* TaskService
+				return yield* tasks.bulkComplete([a, b])
+			}),
+		)) as { completed: number; ids: ReadonlyArray<string> }
+
+		// THEN both are reported and persisted as done
+		expect(result.completed).toBe(2)
+		const statuses = await pool.query<{ status: string }>(
+			`SELECT status FROM tasks WHERE id = ANY($1)`,
+			[[a, b]],
+		)
+		expect(statuses.rows.map(r => r.status)).toEqual(['done', 'done'])
+		// [apps/server/src/services/tasks.ts — bulkComplete]
 	})
 })
 

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -45,6 +45,22 @@ export interface TaskActor {
 	readonly kind: 'user' | 'agent'
 }
 
+// Fields a PATCH can change. The caller decodes the wire payload into this
+// shape (dates already converted to Date); the service maps it to columns and
+// keeps the status ⇔ completed_at invariant.
+export interface TaskUpdateInput {
+	readonly title?: string | undefined
+	readonly notes?: string | null | undefined
+	readonly status?: string | undefined
+	readonly priority?: string | undefined
+	readonly assigneeId?: string | null | undefined
+	readonly dueAt?: Date | null | undefined
+	readonly snoozedUntil?: Date | null | undefined
+	readonly companyId?: string | null | undefined
+	readonly contactId?: string | null | undefined
+	readonly metadata?: unknown
+}
+
 // Columns read back from a write to build the timeline event. Result names
 // are camelCase (PgClient transformResultNames), so this mirrors the row as
 // returned, not the snake_case columns.
@@ -343,6 +359,97 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 							dueAt: [prior.dueAt, dueAt],
 						})
 						return row
+					}),
+
+				get: (id: string) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const rows = yield* sql`
+							SELECT * FROM tasks
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`.pipe(Effect.orDie)
+						const row = rows[0]
+						if (!row) return yield* new NotFound({ entity: 'task', id })
+						return row
+					}),
+
+				// Partial field update. `ifMatch` is the HTTP If-Match optimistic-
+				// concurrency gate (the row's prior `updated_at` ISO); MCP callers
+				// omit it. Free-form edits don't write the task_events/timeline trail
+				// the discrete transitions do.
+				update: (
+					id: string,
+					input: TaskUpdateInput,
+					actor: TaskActor,
+					ifMatch?: string,
+				) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const current = yield* sql<{ updatedAt: string }>`
+							SELECT updated_at FROM tasks
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`.pipe(Effect.orDie)
+						const prior = current[0]
+						if (!prior) return yield* new NotFound({ entity: 'task', id })
+						// Result columns are camelCase (transformResultNames), so the
+						// freshness check reads `updatedAt`, not `updated_at`.
+						if (ifMatch !== undefined) {
+							const fresh = new Date(prior.updatedAt).toISOString()
+							if (fresh !== ifMatch)
+								return yield* new Conflict({
+									message: `stale_write — current updated_at ${fresh} !== If-Match ${ifMatch}`,
+								})
+						}
+
+						const updates: Record<string, unknown> = {}
+						if (input.title !== undefined) updates['title'] = input.title
+						if (input.notes !== undefined) updates['notes'] = input.notes
+						if (input.status !== undefined) updates['status'] = input.status
+						if (input.priority !== undefined)
+							updates['priority'] = input.priority
+						if (input.assigneeId !== undefined)
+							updates['assignee_id'] = input.assigneeId
+						if (input.dueAt !== undefined) updates['due_at'] = input.dueAt
+						if (input.snoozedUntil !== undefined)
+							updates['snoozed_until'] = input.snoozedUntil
+						if (input.companyId !== undefined)
+							updates['company_id'] = input.companyId
+						if (input.contactId !== undefined)
+							updates['contact_id'] = input.contactId
+						if (input.metadata !== undefined)
+							updates['metadata'] = input.metadata
+						// Keep status='done' ⇔ completed_at IS NOT NULL so clients don't
+						// have to manage completed_at (the DB CHECK enforces it anyway).
+						if (input.status !== undefined)
+							updates['completed_at'] =
+								input.status === 'done' ? new Date() : null
+						updates['updated_at'] = new Date()
+						updates['actor_id'] = actor.id
+
+						const updated = yield* sql`
+							UPDATE tasks SET ${sql.update(updates)}
+							WHERE id = ${id} AND organization_id = ${currentOrg.id}
+							RETURNING *
+						`.pipe(Effect.orDie)
+						return updated[0]
+					}),
+
+				bulkComplete: (ids: ReadonlyArray<string>) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						if (ids.length === 0) return { completed: 0, ids: [] as string[] }
+						const rows = yield* sql<{ id: string }>`
+							UPDATE tasks SET
+								status = 'done',
+								completed_at = COALESCE(completed_at, now()),
+								updated_at = now()
+							WHERE id IN ${sql.in([...ids])}
+								AND organization_id = ${currentOrg.id}
+							RETURNING id
+						`.pipe(Effect.orDie)
+						return { completed: rows.length, ids: rows.map(r => r.id) }
 					}),
 			}
 		}),

--- a/apps/server/src/services/timeline-activity.integration.test.ts
+++ b/apps/server/src/services/timeline-activity.integration.test.ts
@@ -1,0 +1,209 @@
+// Executes TimelineActivityService.record() against a real Postgres. The
+// company-cadence denorm is the one part the pure-helper unit tests can't
+// reach: last_*_at uses GREATEST (so a late, older event can't regress it),
+// while next_calendar_event_at recomputes from calendar_events (so it can
+// DECREASE — something GREATEST could never do).
+//
+// Prereq: `pnpm cli services up` and a seeded `taller` org.
+
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../db/client'
+import {
+	EmailSent,
+	MeetingCancelled,
+	MeetingScheduled,
+	TimelineActivityService,
+	type TimelineEvent,
+} from './timeline-activity'
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+const FIXTURE_SLUG = `cadence-${randomUUID()}`
+
+let pool: pg.Pool
+let tallerOrgId: string
+let companyId: string
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	const org = await pool.query<{ id: string }>(
+		`SELECT id FROM organization WHERE slug = 'taller' LIMIT 1`,
+	)
+	const id = org.rows[0]?.id
+	if (!id) {
+		throw new Error(
+			"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
+		)
+	}
+	tallerOrgId = id
+	const company = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name) VALUES ($1, $2, $2) RETURNING id`,
+		[tallerOrgId, FIXTURE_SLUG],
+	)
+	companyId = company.rows[0]!.id
+}, 30_000)
+
+afterAll(async () => {
+	// Superuser cleanup (no role switch) — bypasses RLS on the fixture rows.
+	await pool.query(`DELETE FROM timeline_activity WHERE company_id = $1`, [
+		companyId,
+	])
+	await pool.query(`DELETE FROM calendar_events WHERE company_id = $1`, [
+		companyId,
+	])
+	await pool.query(`DELETE FROM companies WHERE id = $1`, [companyId])
+	await pool.end()
+})
+
+// Records one event as role app_user scoped to the taller org — the same
+// role + GUC + CurrentOrg the request path establishes, so the cadence
+// UPDATEs pass RLS exactly as in production.
+const recordScoped = (event: TimelineEvent): Promise<unknown> => {
+	const deps = TimelineActivityService.layer.pipe(Layer.provideMerge(PgLive))
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const timeline = yield* TimelineActivityService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${tallerOrgId}, true)`
+				return yield* timeline.record(event).pipe(
+					Effect.provideService(CurrentOrg, {
+						id: tallerOrgId,
+						name: 'fixture',
+						slug: 'fixture',
+					}),
+				)
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+}
+
+const seedConfirmedMeeting = async (startAt: Date): Promise<string> => {
+	const id = randomUUID()
+	await pool.query(
+		`INSERT INTO calendar_events (
+			id, organization_id, company_id, source, provider, provider_booking_id,
+			ical_uid, ical_sequence, start_at, end_at, status, title,
+			location_type, organizer_email
+		) VALUES (
+			$1::uuid, $2, $3::uuid, 'booking', 'calcom', $4,
+			$5, 0, $6, $7, 'confirmed', 'Cadence test',
+			'video', 'organizer@taller.cat'
+		)`,
+		[
+			id,
+			tallerOrgId,
+			companyId,
+			`booking-${id}`,
+			`ical-${id}`,
+			startAt,
+			new Date(startAt.getTime() + 1_800_000),
+		],
+	)
+	return id
+}
+
+const companyCadence = async (): Promise<{
+	last_email_at: Date | null
+	next_calendar_event_at: Date | null
+}> => {
+	const rows = await pool.query<{
+		last_email_at: Date | null
+		next_calendar_event_at: Date | null
+	}>(
+		`SELECT last_email_at, next_calendar_event_at FROM companies WHERE id = $1`,
+		[companyId],
+	)
+	return rows.rows[0]!
+}
+
+describe('TimelineActivityService.record cadence denorm', () => {
+	describe('when emails are recorded out of order', () => {
+		it('should keep last_email_at at the newest (GREATEST, no regression)', async () => {
+			// GIVEN an email at T2 then a late-delivered email at an earlier T1
+			const t2 = new Date(Date.now() - 60_000)
+			const t1 = new Date(Date.now() - 3_600_000)
+			const email = (occurredAt: Date) =>
+				new EmailSent({
+					emailMessageId: randomUUID(),
+					companyId,
+					contactId: null,
+					subject: 'cadence',
+					summary: null,
+					actorUserId: null,
+					occurredAt,
+				})
+
+			// WHEN both are recorded, newest first
+			await recordScoped(email(t2))
+			await recordScoped(email(t1))
+
+			// THEN last_email_at still holds T2 — GREATEST ignored the older event
+			// [timeline-activity.ts — bumpCompany GREATEST(last_email_at, at)]
+			const cadence = await companyCadence()
+			expect(cadence.last_email_at?.toISOString()).toBe(t2.toISOString())
+		})
+	})
+
+	describe('when the only upcoming meeting is cancelled', () => {
+		it('should let next_calendar_event_at decrease (recompute from source)', async () => {
+			// GIVEN a confirmed future meeting recorded for the company
+			const startAt = new Date(Date.now() + 10 * 86_400_000)
+			const calId = await seedConfirmedMeeting(startAt)
+			await recordScoped(
+				new MeetingScheduled({
+					calendarEventId: calId,
+					companyId,
+					contactId: null,
+					source: 'booking',
+					title: 'Cadence test',
+					startAt,
+					endAt: new Date(startAt.getTime() + 1_800_000),
+					actorUserId: null,
+					occurredAt: new Date(),
+				}),
+			)
+			const scheduled = await companyCadence()
+			expect(scheduled.next_calendar_event_at?.toISOString()).toBe(
+				startAt.toISOString(),
+			)
+
+			// WHEN it is cancelled, leaving no confirmed future event
+			await pool.query(
+				`UPDATE calendar_events SET status = 'cancelled' WHERE id = $1::uuid`,
+				[calId],
+			)
+			await recordScoped(
+				new MeetingCancelled({
+					calendarEventId: calId,
+					companyId,
+					contactId: null,
+					cancelledStartAt: startAt,
+					actorUserId: null,
+					occurredAt: new Date(),
+				}),
+			)
+
+			// THEN next_calendar_event_at recomputes to NULL — a DECREASE that
+			// GREATEST could never produce
+			// [timeline-activity.ts — recomputeCompanyNextMeeting MIN(...)]
+			const cancelled = await companyCadence()
+			expect(cancelled.next_calendar_event_at).toBeNull()
+		})
+	})
+})


### PR DESCRIPTION
## What & why

Completes the PR-D thin-handler goal: every task persistence path now funnels through `TaskService`, and `record()`'s cadence denorm gets its first DB-level coverage (the documented PR-E gap).

## Changes

- **`services/tasks.ts`**: added `get(id)`, `update(id, input, actor, ifMatch?)`, and `bulkComplete(ids)`. The `If-Match` optimistic-concurrency gate moved into `update` as an **optional** param so MCP callers aren't forced through it; it reads `updatedAt` (results are camelCase). New `TaskUpdateInput` decode-then-map type. These are behavior-preserving moves — free-form `update`/`bulkComplete` still don't write the `task_events`/timeline trail that the discrete transitions do.
- **`handlers/tasks.ts`**: `get`/`update`/`bulkComplete` are now thin delegations; removed the inline `requireFresh` helper, the local `TaskRow` type, and the now-unused `Conflict` import (~110 fewer lines).

## Tests

- `tasks.integration.test.ts`: a `runScoped` helper + tests for `get` (returns / NotFound), `update` (applies a field; a stale `If-Match` → `Conflict` — which also proves the camelCase `updatedAt` read doesn't throw), and `bulkComplete` (count + persisted as done).
- **`timeline-activity.integration.test.ts` (new)**: runs `TimelineActivityService.record()` against Postgres for the first time — `last_email_at` holds the newest across out-of-order events (GREATEST), and `next_calendar_event_at` *decreases* to NULL when the only upcoming meeting is cancelled (recompute-from-source, which GREATEST can't do).

## Verification

- `check-types` + unit `test` + `build` (turbo): 30/30.
- Full server integration suite: 14 files / 108 tests (+7 here).

Finishes the deferred task-consolidation + `record()` test gap from PR-D/PR-E.