### PR TITLE
feat: add org-owned API keys for AI/MCP sessions

### DIFF
--- a/apps/server/src/handlers/api-keys.ts
+++ b/apps/server/src/handlers/api-keys.ts
@@ -1,0 +1,73 @@
+import { Effect } from 'effect'
+import { HttpApiBuilder } from 'effect/unstable/httpapi'
+
+import { BatudaApi, CurrentOrg, SessionContext } from '@batuda/controllers'
+
+import { ApiKeyService } from '../services/api-keys'
+
+const SECONDS_PER_DAY = 86_400
+
+// Org-owned API key management. Full CRUD for any member of the active org
+// (OrgMiddleware resolves it and 403s when none is set). Every op runs through
+// ApiKeyService, which uses Better Auth's owner pool — so the request's
+// app_user scope from OrgMiddleware never touches the `apikey` table.
+export const ApiKeysLive = HttpApiBuilder.group(
+	BatudaApi,
+	'apiKeys',
+	handlers =>
+		Effect.gen(function* () {
+			const apiKeyService = yield* ApiKeyService
+			return handlers
+				.handle('create', _ =>
+					Effect.gen(function* () {
+						const org = yield* CurrentOrg
+						const { userId } = yield* SessionContext
+						const created = yield* apiKeyService.create(org.id, {
+							name: _.payload.name,
+							expiresIn:
+								_.payload.expiresInDays !== undefined
+									? _.payload.expiresInDays * SECONDS_PER_DAY
+									: undefined,
+						})
+						// Audit without the secret — `key` is never logged.
+						yield* Effect.logInfo('API key created').pipe(
+							Effect.annotateLogs({
+								event: 'apikey.created',
+								orgId: org.id,
+								actorUserId: userId,
+								keyId: created.id,
+								name: created.name,
+							}),
+						)
+						return created
+					}),
+				)
+				.handle('list', _ =>
+					Effect.gen(function* () {
+						const org = yield* CurrentOrg
+						return yield* apiKeyService.list(org.id)
+					}),
+				)
+				.handle('get', _ =>
+					Effect.gen(function* () {
+						const org = yield* CurrentOrg
+						return yield* apiKeyService.get(org.id, _.params.id)
+					}),
+				)
+				.handle('delete', _ =>
+					Effect.gen(function* () {
+						const org = yield* CurrentOrg
+						const { userId } = yield* SessionContext
+						yield* apiKeyService.delete(org.id, _.params.id)
+						yield* Effect.logInfo('API key deleted').pipe(
+							Effect.annotateLogs({
+								event: 'apikey.deleted',
+								orgId: org.id,
+								actorUserId: userId,
+								keyId: _.params.id,
+							}),
+						)
+					}),
+				)
+		}),
+)

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -197,7 +197,9 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 							})
 						},
 					}),
-					apiKey({ enableSessionForAPIKeys: true }),
+					// enableMetadata: org-owned keys carry { organizationId } so the
+					// MCP path resolves the org from the key (BADREQUEST otherwise).
+					apiKey({ enableSessionForAPIKeys: true, enableMetadata: true }),
 					setPasswordRoute(),
 					magicLink({
 						// Closes the silent-signup hole on /sign-in/magic-link.
@@ -257,7 +259,10 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 		)
 		authHandle = instance as unknown as typeof authHandle
 
-		return { instance } as const
+		// `pool` connects as the DB owner (never SET ROLE app_user), so it is
+		// the only path that can read/write the `apikey` table — app_user has
+		// no grants on it (migrations/0005). API-key management uses it.
+		return { instance, pool } as const
 	}),
 }) {
 	static readonly layer = Layer.effect(this, this.make).pipe(

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -22,6 +22,7 @@ import {
 } from '@batuda/research'
 
 import { PgLive } from './db/client'
+import { ApiKeysLive } from './handlers/api-keys'
 import { AuthHandlerLive } from './handlers/auth'
 import { CalendarLive } from './handlers/calendar'
 import { CompaniesLive } from './handlers/companies'
@@ -47,6 +48,7 @@ import { OtlpObservability } from './lib/observability'
 import { McpHttpLive } from './mcp/http'
 import { OrgMiddlewareLive, resolveSystemOrg } from './middleware/org'
 import { SessionMiddlewareLive } from './middleware/session'
+import { ApiKeyService } from './services/api-keys'
 import { CalendarService } from './services/calendar'
 import { CompanyService } from './services/companies'
 import { CredentialCrypto } from './services/credential-crypto'
@@ -74,6 +76,7 @@ const ApiLive = HttpApiBuilder.layer(BatudaApi).pipe(
 	Layer.provide([
 		HealthLive,
 		AuthHandlerLive,
+		ApiKeysLive,
 		CompaniesLive,
 		ContactsLive,
 		InteractionsLive,
@@ -187,6 +190,7 @@ const ResearchEventSinkLive = Layer.effect(
 )
 
 const ServicesLive = Layer.mergeAll(
+	ApiKeyService.layer,
 	CompanyService.layer,
 	TaskService.layer,
 	PipelineService.layer,

--- a/apps/server/src/services/api-keys.integration.test.ts
+++ b/apps/server/src/services/api-keys.integration.test.ts
@@ -1,0 +1,281 @@
+// ApiKeyService runs against the real `Auth` layer (a Better Auth instance +
+// its owner pool), so the full env must be present before the layer builds.
+// Mirrors apps/server/src/main.boot.test.ts's env block.
+const env: Record<string, string> = {
+	NODE_ENV: 'test',
+	DATABASE_URL: 'postgres://batuda:batuda@localhost:5433/batuda',
+	BETTER_AUTH_SECRET: '00000000000000000000000000000000',
+	BETTER_AUTH_BASE_URL: 'http://localhost:3010',
+	ALLOWED_ORIGINS: 'http://localhost:3010',
+	APP_PUBLIC_URL: 'http://localhost:3010',
+	STORAGE_ENDPOINT: 'http://localhost:9000',
+	STORAGE_REGION: 'auto',
+	STORAGE_ACCESS_KEY_ID: 'batuda',
+	STORAGE_SECRET_ACCESS_KEY: 'batuda-secret',
+	STORAGE_BUCKET: 'batuda-assets',
+	EMAIL_PROVIDER: 'local-inbox',
+	EMAIL_CREDENTIAL_KEY: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+	EMAIL_PROVIDER_TRANSACTIONAL: 'local',
+	GEOCODER_PROVIDER: 'nominatim',
+	RESEARCH_PROVIDER_SEARCH: 'stub',
+	RESEARCH_PROVIDER_SCRAPE: 'stub',
+	RESEARCH_PROVIDER_EXTRACT: 'stub',
+	RESEARCH_PROVIDER_DISCOVER: 'stub',
+	RESEARCH_PROVIDER_REGISTRY_ES: 'stub',
+	RESEARCH_PROVIDER_REPORT_ES: 'none',
+	RESEARCH_LLM_AGENT_PROVIDERS: 'stub',
+	RESEARCH_LLM_EXTRACT_PROVIDERS: 'stub',
+	RESEARCH_LLM_WRITER_PROVIDERS: 'stub',
+	RESEARCH_DEFAULT_BUDGET_CENTS: '100',
+	RESEARCH_DEFAULT_PAID_BUDGET_CENTS: '500',
+	RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS: '200',
+	RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS: '2000',
+	RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS: '10000',
+	RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL: '3',
+	RESEARCH_MAX_CONCURRENCY_FANOUT: '3',
+	RESEARCH_CONFIRM_THRESHOLD_FANOUT: '10',
+}
+for (const [k, v] of Object.entries(env)) process.env[k] ??= v
+
+import { type Config, Effect, Layer, ManagedRuntime } from 'effect'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { Auth } from '../lib/auth'
+import { ApiKeyService } from './api-keys'
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+// Per-org agent users this feature mints; cleaned up by this exact pattern.
+const AGENT_EMAIL_LIKE = 'agent+%@keys.batuda.internal'
+
+let pool: pg.Pool
+let runtime: ManagedRuntime.ManagedRuntime<ApiKeyService, Config.ConfigError>
+let tallerOrgId: string
+let restaurantOrgId: string
+
+const orgIdBySlug = async (slug: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		'SELECT id FROM organization WHERE slug = $1 LIMIT 1',
+		[slug],
+	)
+	const id = r.rows[0]?.id
+	if (!id)
+		throw new Error(
+			`${slug} org missing — run 'pnpm cli db reset && pnpm cli seed'`,
+		)
+	return id
+}
+
+const cleanup = async () => {
+	await pool.query(
+		`DELETE FROM apikey WHERE "referenceId" IN (SELECT id FROM "user" WHERE email LIKE $1)`,
+		[AGENT_EMAIL_LIKE],
+	)
+	await pool.query('DELETE FROM "user" WHERE email LIKE $1', [AGENT_EMAIL_LIKE])
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	tallerOrgId = await orgIdBySlug('taller')
+	restaurantOrgId = await orgIdBySlug('restaurant')
+	await cleanup()
+	runtime = ManagedRuntime.make(Layer.provide(ApiKeyService.layer, Auth.layer))
+}, 60_000)
+
+afterAll(async () => {
+	await cleanup()
+	await runtime.dispose()
+	await pool.end()
+})
+
+const create = (orgId: string, name: string, expiresIn?: number) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ApiKeyService
+			return yield* svc.create(orgId, { name, expiresIn })
+		}),
+	)
+
+const list = (orgId: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ApiKeyService
+			return yield* svc.list(orgId)
+		}),
+	)
+
+const getOutcome = (orgId: string, keyId: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ApiKeyService
+			return yield* svc.get(orgId, keyId).pipe(
+				Effect.match({
+					onFailure: e => ({ tag: e._tag }),
+					onSuccess: row => ({ tag: 'ok' as const, row }),
+				}),
+			)
+		}),
+	)
+
+const deleteOutcome = (orgId: string, keyId: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ApiKeyService
+			return yield* svc.delete(orgId, keyId).pipe(
+				Effect.match({
+					onFailure: e => e._tag,
+					onSuccess: () => 'ok' as const,
+				}),
+			)
+		}),
+	)
+
+const apikeyRow = async (id: string) => {
+	const r = await pool.query<{
+		referenceId: string
+		metadata: unknown
+		rateLimitEnabled: boolean
+	}>(
+		'SELECT "referenceId", metadata, "rateLimitEnabled" FROM apikey WHERE id = $1',
+		[id],
+	)
+	return r.rows[0]
+}
+
+const agentCount = async (orgId: string) => {
+	const r = await pool.query<{ n: number }>(
+		'SELECT count(*)::int AS n FROM "user" WHERE lower(email) = lower($1)',
+		[`agent+${orgId}@keys.batuda.internal`],
+	)
+	return r.rows[0]?.n ?? 0
+}
+
+describe('ApiKeyService.create', () => {
+	describe('for a member of the active org', () => {
+		it('should mint a one-time key stamped with the org and no rate limit', async () => {
+			// GIVEN a create for the taller org
+			// WHEN the service mints a key
+			const created = await create(tallerOrgId, 'ci-create')
+
+			// THEN the plaintext key is returned once, and the row carries the org
+			// in metadata, is owned by the org's agent user, and has no rate limit
+			expect(created.key.length).toBeGreaterThan(0)
+			const row = await apikeyRow(created.id)
+			// Better Auth stores metadata as a JSON string column.
+			const meta =
+				typeof row?.metadata === 'string'
+					? (JSON.parse(row.metadata) as unknown)
+					: row?.metadata
+			expect(meta).toMatchObject({ organizationId: tallerOrgId })
+			expect(row?.rateLimitEnabled).toBe(false)
+			const agentR = await pool.query<{ id: string }>(
+				'SELECT id FROM "user" WHERE lower(email) = lower($1)',
+				[`agent+${tallerOrgId}@keys.batuda.internal`],
+			)
+			expect(row?.referenceId).toBe(agentR.rows[0]?.id)
+		})
+	})
+
+	describe('when keys already exist for the org', () => {
+		it('should reuse the single per-org agent user', async () => {
+			// GIVEN two creates for the same org
+			await create(tallerOrgId, 'ci-agent-a')
+			await create(tallerOrgId, 'ci-agent-b')
+			// THEN exactly one agent user backs them
+			expect(await agentCount(tallerOrgId)).toBe(1)
+		})
+	})
+
+	describe('with and without a TTL', () => {
+		it('should set expiresAt only when expiresIn is given', async () => {
+			// GIVEN one key with a 7-day TTL and one without
+			const withTtl = await create(tallerOrgId, 'ci-ttl', 7 * 86_400)
+			const noTtl = await create(tallerOrgId, 'ci-no-ttl')
+			// THEN expiresAt reflects the choice
+			expect(withTtl.expiresAt).not.toBeNull()
+			expect(noTtl.expiresAt).toBeNull()
+		})
+	})
+})
+
+describe('ApiKeyService.list', () => {
+	it("should return only the org's enabled keys, redacted, isolated by org", async () => {
+		// GIVEN a key in taller
+		const created = await create(tallerOrgId, 'ci-list')
+
+		// WHEN listing taller vs restaurant
+		const tallerKeys = await list(tallerOrgId)
+		const restaurantKeys = await list(restaurantOrgId)
+
+		// THEN taller sees its key (without the secret) and restaurant does not
+		const found = tallerKeys.find(k => k.id === created.id)
+		expect(found).toBeDefined()
+		expect(found).not.toHaveProperty('key')
+		expect(restaurantKeys.some(k => k.id === created.id)).toBe(false)
+	})
+
+	describe('for an org that never created a key', () => {
+		it('should return [] and mint no agent user', async () => {
+			// GIVEN restaurant has created no keys this run
+			// WHEN listing
+			const keys = await list(restaurantOrgId)
+			// THEN it is empty and no agent user was provisioned by the read
+			expect(keys).toHaveLength(0)
+			expect(await agentCount(restaurantOrgId)).toBe(0)
+		})
+	})
+})
+
+describe('ApiKeyService.get', () => {
+	it('should return the redacted key for its own org', async () => {
+		// GIVEN a taller key
+		const created = await create(tallerOrgId, 'ci-get')
+		// WHEN fetched under taller
+		const outcome = await getOutcome(tallerOrgId, created.id)
+		// THEN it returns the row without the secret
+		expect(outcome.tag).toBe('ok')
+		if (outcome.tag === 'ok') expect(outcome.row).not.toHaveProperty('key')
+	})
+
+	describe('cross-org and unknown ids', () => {
+		it('should report NotFound', async () => {
+			// GIVEN a taller key
+			const created = await create(tallerOrgId, 'ci-get-x')
+			// WHEN fetched under restaurant, or with a bogus id under taller
+			// THEN both are NotFound (no cross-org read)
+			expect((await getOutcome(restaurantOrgId, created.id)).tag).toBe(
+				'NotFound',
+			)
+			expect((await getOutcome(tallerOrgId, 'does-not-exist')).tag).toBe(
+				'NotFound',
+			)
+		})
+	})
+})
+
+describe('ApiKeyService.delete', () => {
+	it("should hard-delete the org's key so it leaves the list", async () => {
+		// GIVEN a taller key
+		const created = await create(tallerOrgId, 'ci-del')
+		// WHEN deleted under taller
+		const outcome = await deleteOutcome(tallerOrgId, created.id)
+		// THEN it succeeds, the row is gone, and the list excludes it
+		expect(outcome).toBe('ok')
+		expect(await apikeyRow(created.id)).toBeUndefined()
+		expect((await list(tallerOrgId)).some(k => k.id === created.id)).toBe(false)
+	})
+
+	describe('cross-org and unknown ids', () => {
+		it('should report NotFound and not delete', async () => {
+			// GIVEN a taller key
+			const created = await create(tallerOrgId, 'ci-del-x')
+			// WHEN deleting it under restaurant, or a bogus id under taller
+			// THEN NotFound, and the taller key is untouched
+			expect(await deleteOutcome(restaurantOrgId, created.id)).toBe('NotFound')
+			expect(await deleteOutcome(tallerOrgId, 'does-not-exist')).toBe(
+				'NotFound',
+			)
+			expect(await apikeyRow(created.id)).toBeDefined()
+		})
+	})
+})

--- a/apps/server/src/services/api-keys.ts
+++ b/apps/server/src/services/api-keys.ts
@@ -1,0 +1,207 @@
+import { Effect, Layer, ServiceMap } from 'effect'
+
+import { NotFound } from '@batuda/controllers'
+
+import { Auth } from '../lib/auth'
+
+// Returned once on create — `key` is the plaintext the caller must store now
+// (Better Auth hashes it on write, so it is unrecoverable afterward).
+export interface CreatedApiKey {
+	readonly id: string
+	readonly key: string
+	readonly name: string | null
+	readonly start: string | null
+	readonly prefix: string | null
+	readonly expiresAt: string | null
+	readonly createdAt: string
+}
+
+// List/get shape — never carries the secret, only the masked `start` prefix.
+export interface RedactedApiKey {
+	readonly id: string
+	readonly name: string | null
+	readonly start: string | null
+	readonly prefix: string | null
+	readonly expiresAt: string | null
+	readonly createdAt: string
+	readonly enabled: boolean
+}
+
+interface KeyRow {
+	readonly id: string
+	readonly name: string | null
+	readonly start: string | null
+	readonly prefix: string | null
+	readonly expiresAt: string | Date | null
+	readonly createdAt: string | Date
+	readonly enabled: boolean
+}
+
+const isoOrNull = (value: string | Date | null): string | null =>
+	value === null ? null : new Date(value).toISOString()
+
+const toRedacted = (row: KeyRow): RedactedApiKey => ({
+	id: row.id,
+	name: row.name,
+	start: row.start,
+	prefix: row.prefix,
+	expiresAt: isoOrNull(row.expiresAt),
+	createdAt: new Date(row.createdAt).toISOString(),
+	enabled: row.enabled,
+})
+
+const SELECT_COLS = 'id, name, start, prefix, "expiresAt", "createdAt", enabled'
+
+// API keys are owned by a per-org agent user (`isAgent`) and carry the org in
+// their Better Auth `metadata`; the MCP transport reads that to scope the
+// session. All `apikey`/agent-user access goes through Better Auth's owner
+// pool: `app_user` has no grants on the `apikey` table (migrations/0005), and
+// the table has no org column to RLS-scope — isolation is enforced here by the
+// per-org `referenceId` predicate on every query.
+export class ApiKeyService extends ServiceMap.Service<ApiKeyService>()(
+	'ApiKeyService',
+	{
+		make: Effect.gen(function* () {
+			const auth = yield* Auth
+
+			// One deterministic agent user per org. `.internal` is never a routable
+			// mailbox; the user is passwordless (no `password` → no account row) and
+			// `isAgent`, so it never surfaces in human sign-in/member flows.
+			const agentEmail = (orgId: string) =>
+				`agent+${orgId}@keys.batuda.internal`
+
+			// Resolve the org's agent user id without creating it — reads (list/get)
+			// and delete must not mint a phantom agent for an org that has no keys.
+			// Case-insensitive: Better Auth normalizes the stored email to lower
+			// case, while org ids (in the local part) are mixed-case.
+			const findAgentId = (orgId: string) =>
+				Effect.tryPromise(() =>
+					auth.pool.query<{ id: string }>(
+						'SELECT id FROM "user" WHERE lower(email) = lower($1) LIMIT 1',
+						[agentEmail(orgId)],
+					),
+				).pipe(
+					Effect.orDie,
+					Effect.map(r => r.rows[0]?.id ?? null),
+				)
+
+			const getOrCreateAgentId = (orgId: string) =>
+				Effect.gen(function* () {
+					const existing = yield* findAgentId(orgId)
+					if (existing) return existing
+					// Headerless admin createUser: no session/permission gate, and the
+					// `data` fields land on the user's additionalFields (isAgent).
+					// Ignore the result: a concurrent create (or a prior row) surfaces
+					// `USER_ALREADY_EXISTS`, and the re-select below is the source of
+					// truth either way — so two racing creates converge on one agent.
+					yield* Effect.tryPromise(() =>
+						auth.instance.api.createUser({
+							body: {
+								email: agentEmail(orgId),
+								name: `API agent (${orgId})`,
+								data: { isAgent: true },
+							},
+						}),
+					).pipe(Effect.ignore)
+					const created = yield* findAgentId(orgId)
+					if (!created)
+						return yield* Effect.die(
+							new Error(`agent user missing after create for org ${orgId}`),
+						)
+					return created
+				})
+
+			return {
+				create: (
+					orgId: string,
+					input: {
+						readonly name: string
+						readonly expiresIn?: number | undefined
+					},
+				): Effect.Effect<CreatedApiKey> =>
+					Effect.gen(function* () {
+						const agentId = yield* getOrCreateAgentId(orgId)
+						// No `headers`/`request` on purpose: `userId`, `metadata`, and
+						// `rateLimitEnabled` are server-only and rejected on a call that
+						// looks client-originated.
+						const result = yield* Effect.tryPromise(() =>
+							auth.instance.api.createApiKey({
+								body: {
+									userId: agentId,
+									name: input.name,
+									metadata: { organizationId: orgId },
+									rateLimitEnabled: false,
+									...(input.expiresIn !== undefined
+										? { expiresIn: input.expiresIn }
+										: {}),
+								},
+							}),
+						).pipe(Effect.orDie)
+						return {
+							id: result.id,
+							key: result.key,
+							name: result.name ?? null,
+							start: result.start ?? null,
+							prefix: result.prefix ?? null,
+							expiresAt: isoOrNull(result.expiresAt ?? null),
+							createdAt: new Date(result.createdAt).toISOString(),
+						}
+					}),
+
+				list: (orgId: string): Effect.Effect<ReadonlyArray<RedactedApiKey>> =>
+					Effect.gen(function* () {
+						const agentId = yield* findAgentId(orgId)
+						if (!agentId) return []
+						const rows = yield* Effect.tryPromise(() =>
+							auth.pool.query<KeyRow>(
+								`SELECT ${SELECT_COLS} FROM apikey
+								 WHERE "referenceId" = $1 AND enabled = true
+								   AND ("expiresAt" IS NULL OR "expiresAt" > now())
+								 ORDER BY "createdAt" DESC`,
+								[agentId],
+							),
+						).pipe(Effect.orDie)
+						return rows.rows.map(toRedacted)
+					}),
+
+				get: (
+					orgId: string,
+					keyId: string,
+				): Effect.Effect<RedactedApiKey, NotFound> =>
+					Effect.gen(function* () {
+						const agentId = yield* findAgentId(orgId)
+						if (!agentId)
+							return yield* new NotFound({ entity: 'apiKey', id: keyId })
+						const rows = yield* Effect.tryPromise(() =>
+							auth.pool.query<KeyRow>(
+								`SELECT ${SELECT_COLS} FROM apikey
+								 WHERE id = $1 AND "referenceId" = $2 LIMIT 1`,
+								[keyId, agentId],
+							),
+						).pipe(Effect.orDie)
+						const row = rows.rows[0]
+						if (!row)
+							return yield* new NotFound({ entity: 'apiKey', id: keyId })
+						return toRedacted(row)
+					}),
+
+				delete: (orgId: string, keyId: string): Effect.Effect<void, NotFound> =>
+					Effect.gen(function* () {
+						const agentId = yield* findAgentId(orgId)
+						if (!agentId)
+							return yield* new NotFound({ entity: 'apiKey', id: keyId })
+						const result = yield* Effect.tryPromise(() =>
+							auth.pool.query(
+								'DELETE FROM apikey WHERE id = $1 AND "referenceId" = $2',
+								[keyId, agentId],
+							),
+						).pipe(Effect.orDie)
+						if (result.rowCount === 0)
+							return yield* new NotFound({ entity: 'apiKey', id: keyId })
+					}),
+			}
+		}),
+	},
+) {
+	static readonly layer = Layer.effect(this, this.make)
+}

--- a/packages/controllers/src/api.ts
+++ b/packages/controllers/src/api.ts
@@ -1,5 +1,6 @@
 import { HttpApi, OpenApi } from 'effect/unstable/httpapi'
 
+import { ApiKeysGroup } from './routes/api-keys'
 import { AuthGroup } from './routes/auth'
 import { CalcomWebhookGroup } from './routes/calcom-webhook'
 import { CalendarGroup } from './routes/calendar'
@@ -29,6 +30,7 @@ export const BatudaApi = HttpApi.make('BatudaApi')
 	)
 	.add(HealthGroup)
 	.add(AuthGroup)
+	.add(ApiKeysGroup)
 	.add(CompaniesGroup)
 	.add(ContactsGroup)
 	.add(InteractionsGroup)

--- a/packages/controllers/src/routes/api-keys.ts
+++ b/packages/controllers/src/routes/api-keys.ts
@@ -1,0 +1,81 @@
+import { Schema } from 'effect'
+import {
+	HttpApiEndpoint,
+	HttpApiGroup,
+	HttpApiSchema,
+} from 'effect/unstable/httpapi'
+
+import { NotFound } from '../errors'
+import { OrgMiddleware } from '../middleware/org'
+import { SessionMiddleware } from '../middleware/session'
+
+// ── Input ──
+
+export const CreateApiKeyInput = Schema.Struct({
+	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+	// Optional TTL in days; omitted ⇒ a non-expiring key.
+	expiresInDays: Schema.optional(
+		Schema.Number.pipe(Schema.check(Schema.isGreaterThan(0))),
+	),
+})
+
+// ── Views ──
+
+// Redacted — never carries the secret, only the masked `start` prefix BA stores.
+export const ApiKeyView = Schema.Struct({
+	id: Schema.String,
+	name: Schema.NullOr(Schema.String),
+	start: Schema.NullOr(Schema.String),
+	prefix: Schema.NullOr(Schema.String),
+	expiresAt: Schema.NullOr(Schema.String),
+	createdAt: Schema.String,
+	enabled: Schema.Boolean,
+})
+
+// Create response — the only place the plaintext `key` is ever returned.
+export const CreatedApiKeyView = Schema.Struct({
+	id: Schema.String,
+	key: Schema.String,
+	name: Schema.NullOr(Schema.String),
+	start: Schema.NullOr(Schema.String),
+	prefix: Schema.NullOr(Schema.String),
+	expiresAt: Schema.NullOr(Schema.String),
+	createdAt: Schema.String,
+})
+
+// ── Route group ──
+//
+// Org-owned API keys for AI/MCP sessions. Full CRUD open to any member of the
+// active org (consumer-responsible — no per-operation human/agent gating);
+// `OrgMiddleware` resolves the active member org (and 403s when none is set).
+// The key handlers act through Better Auth's owner pool, so the request's
+// app_user scope never touches the `apikey` table.
+export const ApiKeysGroup = HttpApiGroup.make('apiKeys')
+	.add(
+		HttpApiEndpoint.post('create', '/api-keys', {
+			payload: CreateApiKeyInput,
+			success: CreatedApiKeyView,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.get('list', '/api-keys', {
+			success: Schema.Array(ApiKeyView),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.get('get', '/api-keys/:id', {
+			params: { id: Schema.String },
+			success: ApiKeyView,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.delete('delete', '/api-keys/:id', {
+			params: { id: Schema.String },
+			success: Schema.Void,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	.middleware(SessionMiddleware)
+	.middleware(OrgMiddleware)
+	.prefix('/v1')


### PR DESCRIPTION
First slice of the org-owned API-keys feature (plan: org-owned, self-served, one-time read, no rate limit, per-org agent user, org from key metadata). This slice is the **server management surface**; MCP key auth (Slice 2) and the web UI (Slice 3) follow.

## What

- **`/v1/api-keys` CRUD** (`packages/controllers/src/routes/api-keys.ts`, `apps/server/src/handlers/api-keys.ts`): `create`, `list`, `get`, `delete`, behind `SessionMiddleware` + `OrgMiddleware`. Full CRUD for any member of the active org (consumer-responsible — no per-op human/agent gating); `OrgMiddleware` 403s when no org is active.
- **`ApiKeyService`** (`apps/server/src/services/api-keys.ts`): each org's keys are owned by a lazily-provisioned, idempotent **per-org agent user** (`isAgent`), and carry `{ organizationId }` in the key's Better Auth metadata (the hook Slice 2 reads to scope an MCP session). `create` → `auth.api.createApiKey({ body: { userId, metadata, rateLimitEnabled: false } })` (body-only — server-only props). `list`/`get`/`delete` run owner-pool SQL scoped by `referenceId = agentUserId`.
- **`lib/auth.ts`**: `apiKey` plugin gains `enableMetadata`; `Auth` now exposes its owner `pool`.

## Security

- All `apikey`/agent-user access goes through Better Auth's **owner pool** — `app_user` has no grant on the `apikey` table (PR-A / migration 0005), so the request's `app_user` scope never touches it.
- The plaintext `key` is returned **once** on create (BA hashes it), never logged; `list`/`get` are redacted (masked `start` prefix only).
- Every op is **org-scoped** by the per-org `referenceId` predicate — no cross-org read/delete (verified). Keys carry **no rate limit**.

## Tests

`services/api-keys.integration.test.ts` (live PG + the real `Auth` layer), edge cases: create stamps org + agent + no-rate-limit; agent-user idempotency across two creates; TTL on/off; list redaction + cross-org isolation + empty-org (no phantom agent); get redacted + cross-org/unknown → NotFound; delete hard + cross-org/unknown → NotFound.

## Verification

- `check-types` (controllers + server), turbo 30/30, full server integration **117 tests** (+9 here), boot 3/3.

Part 1 of 3 (server → MCP auth → web).