### PR TITLE
feat(server): authenticate MCP sessions with org API keys

### DIFF
--- a/apps/server/src/mcp/api-key-auth.integration.test.ts
+++ b/apps/server/src/mcp/api-key-auth.integration.test.ts
@@ -1,0 +1,217 @@
+// Pins how the /mcp middleware resolves an org API key: key → org's agent +
+// org (from the key's metadata) → scoped session, the org isolation that
+// yields, and the fail-closed rejections. The JSON-RPC envelope wiring is
+// covered by the boot test.
+//
+// The full env must be set before the Auth layer builds.
+const env: Record<string, string> = {
+	NODE_ENV: 'test',
+	DATABASE_URL: 'postgres://batuda:batuda@localhost:5433/batuda',
+	BETTER_AUTH_SECRET: '00000000000000000000000000000000',
+	BETTER_AUTH_BASE_URL: 'http://localhost:3010',
+	ALLOWED_ORIGINS: 'http://localhost:3010',
+	APP_PUBLIC_URL: 'http://localhost:3010',
+	STORAGE_ENDPOINT: 'http://localhost:9000',
+	STORAGE_REGION: 'auto',
+	STORAGE_ACCESS_KEY_ID: 'batuda',
+	STORAGE_SECRET_ACCESS_KEY: 'batuda-secret',
+	STORAGE_BUCKET: 'batuda-assets',
+	EMAIL_PROVIDER: 'local-inbox',
+	EMAIL_CREDENTIAL_KEY: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+	EMAIL_PROVIDER_TRANSACTIONAL: 'local',
+	GEOCODER_PROVIDER: 'nominatim',
+	RESEARCH_PROVIDER_SEARCH: 'stub',
+	RESEARCH_PROVIDER_SCRAPE: 'stub',
+	RESEARCH_PROVIDER_EXTRACT: 'stub',
+	RESEARCH_PROVIDER_DISCOVER: 'stub',
+	RESEARCH_PROVIDER_REGISTRY_ES: 'stub',
+	RESEARCH_PROVIDER_REPORT_ES: 'none',
+	RESEARCH_LLM_AGENT_PROVIDERS: 'stub',
+	RESEARCH_LLM_EXTRACT_PROVIDERS: 'stub',
+	RESEARCH_LLM_WRITER_PROVIDERS: 'stub',
+	RESEARCH_DEFAULT_BUDGET_CENTS: '100',
+	RESEARCH_DEFAULT_PAID_BUDGET_CENTS: '500',
+	RESEARCH_DEFAULT_AUTO_APPROVE_PAID_CENTS: '200',
+	RESEARCH_DEFAULT_PAID_MONTHLY_CAP_CENTS: '2000',
+	RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS: '10000',
+	RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL: '3',
+	RESEARCH_MAX_CONCURRENCY_FANOUT: '3',
+	RESEARCH_CONFIRM_THRESHOLD_FANOUT: '10',
+}
+for (const [k, v] of Object.entries(env)) process.env[k] ??= v
+
+import { randomUUID } from 'node:crypto'
+
+import type { PgClient } from '@effect/sql-pg'
+import { type Config, Effect, Layer, ManagedRuntime } from 'effect'
+import { SqlClient, type SqlError } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { Auth } from '../lib/auth'
+import { enterOrgScope } from '../middleware/org'
+import { ApiKeyService } from '../services/api-keys'
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+const AGENT_EMAIL_LIKE = 'agent+%@keys.batuda.internal'
+const FIXTURE_SLUG = `mcp-keyauth-${randomUUID()}`
+
+type Org = { id: string; name: string; slug: string }
+
+let pool: pg.Pool
+let runtime: ManagedRuntime.ManagedRuntime<
+	ApiKeyService | Auth | SqlClient.SqlClient | PgClient.PgClient,
+	Config.ConfigError | SqlError.SqlError
+>
+let taller: Org
+let restaurant: Org
+
+const orgBySlug = async (slug: string): Promise<Org> => {
+	const result = await pool.query<Org>(
+		'SELECT id, name, slug FROM organization WHERE slug = $1 LIMIT 1',
+		[slug],
+	)
+	const row = result.rows[0]
+	if (!row)
+		throw new Error(
+			`${slug} org missing — run 'pnpm cli db reset && pnpm cli seed'`,
+		)
+	return row
+}
+
+// One marker company per org, so a scoped read can prove isolation.
+const seedCompany = async (orgId: string) => {
+	await pool.query(
+		`INSERT INTO companies (organization_id, slug, name) VALUES ($1, $2, $2)`,
+		[orgId, FIXTURE_SLUG],
+	)
+}
+
+const cleanup = async () => {
+	await pool.query('DELETE FROM companies WHERE slug = $1', [FIXTURE_SLUG])
+	await pool.query(
+		`DELETE FROM apikey WHERE "referenceId" IN (SELECT id FROM "user" WHERE email LIKE $1)`,
+		[AGENT_EMAIL_LIKE],
+	)
+	await pool.query('DELETE FROM "user" WHERE email LIKE $1', [AGENT_EMAIL_LIKE])
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	taller = await orgBySlug('taller')
+	restaurant = await orgBySlug('restaurant')
+	await cleanup()
+	await seedCompany(taller.id)
+	await seedCompany(restaurant.id)
+	runtime = ManagedRuntime.make(
+		Layer.provideMerge(ApiKeyService.layer, Layer.mergeAll(Auth.layer, PgLive)),
+	)
+}, 60_000)
+
+afterAll(async () => {
+	await cleanup()
+	await runtime.dispose()
+	await pool.end()
+})
+
+// Mints a key (ApiKeyService), verifies it (the middleware's first step), then
+// — for a valid org key — resolves the org from metadata and runs `body`
+// inside enterOrgScope as the agent, exactly as the /mcp middleware would.
+interface ResolveResult {
+	readonly valid: boolean
+	readonly orgId: string | null
+	readonly referenceId: string | null
+}
+
+const verify = (key: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const { instance } = yield* Auth
+			const verified = yield* Effect.promise(() =>
+				instance.api.verifyApiKey({ body: { key } }),
+			)
+			const orgId = verified.valid
+				? ((verified.key?.metadata as { organizationId?: string } | null)
+						?.organizationId ?? null)
+				: null
+			return {
+				valid: verified.valid,
+				orgId,
+				referenceId: verified.key?.referenceId ?? null,
+			} satisfies ResolveResult
+		}),
+	)
+
+describe('MCP API-key auth resolution', () => {
+	describe('a valid org key', () => {
+		it('should resolve to its org + agent and scope reads to that org', async () => {
+			// GIVEN a key minted for the taller org
+			const created = await runtime.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ApiKeyService
+					return yield* svc.create(taller.id, { name: 'mcp-key' })
+				}),
+			)
+
+			// WHEN the key is verified (the middleware's resolution step)
+			const resolved = await verify(created.key)
+
+			// THEN it is valid and carries taller's org id + the org's agent user
+			expect(resolved.valid).toBe(true)
+			expect(resolved.orgId).toBe(taller.id)
+			const agent = await pool.query<{ id: string }>(
+				'SELECT id FROM "user" WHERE lower(email) = lower($1)',
+				[`agent+${taller.id}@keys.batuda.internal`],
+			)
+			expect(resolved.referenceId).toBe(agent.rows[0]?.id)
+
+			// AND entering that scope as the agent reads only taller's marker
+			// company, never restaurant's (RLS isolation)
+			// Result columns are camelCase (PgClient transformResultNames).
+			const orgIds = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, {
+						org: taller,
+						userId: resolved.referenceId ?? '',
+					})(
+						Effect.gen(function* () {
+							const rows = yield* sql<{ organizationId: string }>`
+								SELECT organization_id FROM companies WHERE slug = ${FIXTURE_SLUG}
+							`
+							return rows.map(r => r.organizationId)
+						}),
+					)
+				}),
+			)
+			expect(orgIds).toEqual([taller.id])
+		})
+	})
+
+	describe('invalid, unknown, or revoked keys', () => {
+		it('should be rejected (valid:false), failing closed', async () => {
+			// GIVEN a garbage key and a minted-then-deleted key
+			const garbage = await verify('batuda_not-a-real-key')
+
+			const created = await runtime.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ApiKeyService
+					return yield* svc.create(taller.id, { name: 'mcp-revoke' })
+				}),
+			)
+			const id = created.id
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ApiKeyService
+					return yield* svc.delete(taller.id, id)
+				}),
+			)
+			const revoked = await verify(created.key)
+
+			// THEN neither verifies
+			expect(garbage.valid).toBe(false)
+			expect(revoked.valid).toBe(false)
+		})
+	})
+})

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -16,10 +16,24 @@ import { enterOrgScope } from '../middleware/org'
 import { CurrentUser } from './current-user'
 import { McpToolsLive } from './server'
 
+const jsonRpcError = (status: number, code: number, message: string) =>
+	HttpServerResponse.json(
+		{ jsonrpc: '2.0', id: null, error: { code, message } },
+		{ status },
+	)
+
 const McpAuthMiddleware = HttpRouter.middleware(
 	Effect.gen(function* () {
 		const { instance } = yield* Auth
 		const sql = yield* SqlClient.SqlClient
+
+		const loadOrg = (orgId: string) =>
+			sql<{ id: string; name: string; slug: string }>`
+				SELECT id, name, slug FROM "organization" WHERE id = ${orgId} LIMIT 1
+			`.pipe(
+				Effect.orDie,
+				Effect.map(rows => rows[0]),
+			)
 
 		return httpEffect =>
 			Effect.gen(function* () {
@@ -30,19 +44,86 @@ const McpAuthMiddleware = HttpRouter.middleware(
 
 				const incomingMessage = NodeHttpServerRequest.toIncomingMessage(req)
 				const headers = fromNodeHeaders(incomingMessage.headers)
+
+				// Shared tail: provide the principal (MCP-only CurrentUser +
+				// controllers-package SessionContext, so service-layer code works
+				// across transports) and enter the org's app_user scope.
+				const enterScope = (
+					org: { id: string; name: string; slug: string },
+					principal: {
+						readonly userId: string
+						readonly email: string
+						readonly name: string | null
+						readonly isAgent: boolean
+					},
+				) =>
+					httpEffect.pipe(
+						Effect.provideService(CurrentUser, {
+							userId: principal.userId,
+							email: principal.email,
+							name: principal.name ?? 'Unknown',
+							isAgent: principal.isAgent,
+						}),
+						Effect.provideService(SessionContext, {
+							userId: principal.userId,
+							email: principal.email,
+							name: principal.name ?? undefined,
+							isAgent: principal.isAgent,
+						}),
+						enterOrgScope(sql, { org, userId: principal.userId }),
+					)
+
+				// ── API-key path (AI/MCP clients): the key resolves to its org's
+				// agent user (referenceId) and the org from metadata — no cookie
+				// session or activeOrganizationId is involved. Fail closed.
+				const apiKey = headers.get('x-api-key')
+				if (apiKey) {
+					const verified = yield* Effect.promise(() =>
+						instance.api.verifyApiKey({ body: { key: apiKey } }),
+					)
+					// verifyApiKey returns valid:false for unknown/disabled/expired/
+					// rate-limited keys (it never throws for those).
+					if (!verified.valid || !verified.key) {
+						return yield* jsonRpcError(401, -32001, 'Invalid API key')
+					}
+					const orgId = (
+						verified.key.metadata as { organizationId?: string } | null
+					)?.organizationId
+					if (!orgId) {
+						return yield* jsonRpcError(401, -32001, 'API key is not org-scoped')
+					}
+					const org = yield* loadOrg(orgId)
+					const agentRows = yield* sql<{
+						id: string
+						email: string
+						name: string | null
+					}>`
+						SELECT id, email, name FROM "user"
+						WHERE id = ${verified.key.referenceId} LIMIT 1
+					`.pipe(Effect.orDie)
+					const agent = agentRows[0]
+					// Org or agent user deleted out from under the key → fail closed.
+					if (!org || !agent) {
+						return yield* jsonRpcError(
+							403,
+							-32003,
+							'API key organization or agent is no longer available',
+						)
+					}
+					return yield* enterScope(org, {
+						userId: agent.id,
+						email: agent.email,
+						name: agent.name,
+						isAgent: true,
+					})
+				}
+
+				// ── Cookie-session path (human/web).
 				const result = yield* Effect.promise(() =>
 					instance.api.getSession({ headers }),
 				)
-
 				if (!result) {
-					return yield* HttpServerResponse.json(
-						{
-							jsonrpc: '2.0',
-							id: null,
-							error: { code: -32001, message: 'Unauthorized' },
-						},
-						{ status: 401 },
-					)
+					return yield* jsonRpcError(401, -32001, 'Unauthorized')
 				}
 
 				// `activeOrganizationId` is contributed by the Better-Auth
@@ -53,69 +134,26 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					result.session as { activeOrganizationId?: string | null }
 				).activeOrganizationId
 				if (!activeOrgId) {
-					return yield* HttpServerResponse.json(
-						{
-							jsonrpc: '2.0',
-							id: null,
-							error: {
-								code: -32002,
-								message:
-									'No active organization on session — call /auth/organization/set-active first',
-							},
-						},
-						{ status: 403 },
+					return yield* jsonRpcError(
+						403,
+						-32002,
+						'No active organization on session — call /auth/organization/set-active first',
 					)
 				}
-
-				// Org lookup faults die as a defect, mirroring the HTTP path —
-				// an infra failure here isn't a JSON-RPC protocol error.
-				const orgRows = yield* sql<{
-					id: string
-					name: string
-					slug: string
-				}>`
-					SELECT id, name, slug
-					FROM "organization"
-					WHERE id = ${activeOrgId}
-					LIMIT 1
-				`.pipe(Effect.orDie)
-				const org = orgRows[0]
+				const org = yield* loadOrg(activeOrgId)
 				if (!org) {
-					return yield* HttpServerResponse.json(
-						{
-							jsonrpc: '2.0',
-							id: null,
-							error: {
-								code: -32003,
-								message: `Active organization ${activeOrgId} not found`,
-							},
-						},
-						{ status: 403 },
+					return yield* jsonRpcError(
+						403,
+						-32003,
+						`Active organization ${activeOrgId} not found`,
 					)
 				}
-
-				// Enter the org scope via the shared combinator (role + both
-				// GUCs + CurrentOrg in one tx, faults die) so the MCP tool sees
-				// the same RLS-scoped reads as the HTTP path. CurrentUser and
-				// SessionContext are MCP-only, provided on top.
-				return yield* httpEffect.pipe(
-					Effect.provideService(CurrentUser, {
-						userId: result.user.id,
-						email: result.user.email,
-						name: result.user.name ?? 'Unknown',
-						isAgent: result.user.isAgent === true,
-					}),
-					// SessionContext mirrors CurrentUser using the controllers-
-					// package tag so service-layer code that consumes SessionContext
-					// (e.g. EmailService) works identically across HTTP and MCP.
-					Effect.provideService(SessionContext, {
-						userId: result.user.id,
-						email: result.user.email,
-						name: result.user.name ?? undefined,
-						isAgent: result.user.isAgent === true,
-					}),
-					enterOrgScope(sql, { org, userId: result.user.id }),
-				)
+				return yield* enterScope(org, {
+					userId: result.user.id,
+					email: result.user.email,
+					name: result.user.name ?? null,
+					isAgent: result.user.isAgent === true,
+				})
 			})
 	}),
 	{ global: true },


### PR DESCRIPTION
Slice 2 of the org-owned API-keys feature — makes the keys minted in Slice 1 actually authenticate an AI/MCP session. (Slice 3 = the web management UI.)

## What

`apps/server/src/mcp/http.ts`: the `/mcp` auth middleware now branches on an `x-api-key` header.
- **Key path**: `verifyApiKey` → read the org from `key.metadata.organizationId` and the agent user from `key.referenceId` → load both → enter that org's `app_user` scope as the agent (`isAgent: true`). No cookie session or `activeOrganizationId` involved.
- **Cookie path**: unchanged (human/web).
- Refactor: shared `jsonRpcError` + `loadOrg` helpers and an `enterScope` tail used by both paths.

## Fail-closed

A JSON-RPC 401/403 (no partial scope) on: invalid/unknown key, disabled (revoked) key, expired key, a key with no `organizationId` in metadata, and a deleted org or agent user.

## Tests

`mcp/api-key-auth.integration.test.ts`: a minted key resolves to its org id + the org's agent user, and entering that scope reads **only** that org's marker company (RLS isolation, never the other org's); garbage and minted-then-revoked keys verify as invalid (fail closed). (The JSON-RPC envelope wiring is covered by the boot test.)

## Verification

- `check-types`, turbo 30/30, full server integration **119 tests** (+2 here), boot 3/3 (the middleware change still boots cleanly).

Part 2 of 3 (server → **MCP auth** → web).