### PR TITLE
Connect MCP clients over OAuth: consent + connections UI

### DIFF
--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -123,6 +123,10 @@ msgstr "Accepta"
 msgid "Accepting the invitation…"
 msgstr "Acceptant la invitació…"
 
+#: src/routes/oauth/consent.tsx:128
+msgid "Access"
+msgstr "Accés"
+
 #. placeholder {0}: provider.length
 #: src/routes/settings/organization/spend.tsx:162
 msgid "across {0} providers"
@@ -190,6 +194,10 @@ msgstr "Admin"
 msgid "Agent"
 msgstr "Agent"
 
+#: src/routes/settings/mcp/connections.tsx:113
+msgid "AI assistants you've connected over MCP. Choose which organization each one acts in."
+msgstr "Assistents d'IA que has connectat per MCP. Tria en quina organització actua cadascun."
+
 #: src/routes/companies/index.tsx:277
 #: src/routes/emails/index.tsx:623
 msgid "All"
@@ -212,16 +220,24 @@ msgstr "Tot el temps"
 msgid "All under control"
 msgstr "Tot sota control"
 
+#: src/routes/oauth/consent.tsx:163
+msgid "Allow"
+msgstr "Permet"
+
 #: src/components/research/findings/shared.tsx:179
 msgid "Already in CRM"
 msgstr "Ja al CRM"
+
+#: src/routes/oauth/consent.tsx:114
+msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
+msgstr "Un assistent d'IA vol connectar-se al teu compte de Batuda per MCP i actuar en nom teu. Aprova només els assistents en qui confiïs."
 
 #: src/routes/settings/api-keys/index.tsx:395
 msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 msgstr "Qualsevol agent que faci servir \"{confirmLabel}\" deixarà de funcionar. Això no es pot desfer."
 
 #: src/routes/settings/api-keys/index.tsx:197
-#: src/routes/settings/profile/index.tsx:114
+#: src/routes/settings/profile/index.tsx:121
 msgid "API keys"
 msgstr "Claus d'API"
 
@@ -280,6 +296,7 @@ msgid "Back to organization"
 msgstr "Tornar a l'organització"
 
 #: src/routes/settings/api-keys/index.tsx:187
+#: src/routes/settings/mcp/connections.tsx:100
 msgid "Back to settings"
 msgstr "Torna a la configuració"
 
@@ -301,7 +318,7 @@ msgstr "Batuda — un CRM multi-inquilí per a petites agències."
 msgid "Batuda home"
 msgstr "Inici de Batuda"
 
-#: src/routes/login.tsx:404
+#: src/routes/login.tsx:443
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda és només amb invitació. Demana accés a l'equip d'Engranatge."
 
@@ -391,17 +408,21 @@ msgstr "Cancel·la"
 msgid "Cancel upload"
 msgstr "Cancel·la la pujada"
 
+#: src/routes/oauth/consent.tsx:152
+msgid "Cancelling…"
+msgstr "Cancel·lant…"
+
 #: src/components/emails/compose-form.tsx:429
 #: src/routes/emails/$threadId.tsx:595
 msgid "Cc"
 msgstr "Cc"
 
-#: src/routes/settings/profile/index.tsx:350
+#: src/routes/settings/profile/index.tsx:366
 msgid "Change my mind — set a password anyway"
 msgstr "Canvio d'opinió — vull posar contrasenya"
 
-#: src/routes/settings/profile/index.tsx:410
-#: src/routes/settings/profile/index.tsx:497
+#: src/routes/settings/profile/index.tsx:426
+#: src/routes/settings/profile/index.tsx:513
 msgid "Change password"
 msgstr "Canvia la contrasenya"
 
@@ -440,9 +461,13 @@ msgid "Check the session or try again."
 msgstr "Comprova la sessió o torna-ho a provar."
 
 #: src/routes/forgot-password.tsx:69
-#: src/routes/login.tsx:442
+#: src/routes/login.tsx:481
 msgid "Check your inbox"
 msgstr "Mira la safata d'entrada"
+
+#: src/routes/settings/mcp/connections.tsx:175
+msgid "Choose organization"
+msgstr "Tria una organització"
 
 #: src/routes/emails/inboxes.tsx:350
 #: src/routes/emails/inboxes.tsx:351
@@ -468,6 +493,7 @@ msgstr "Clicat"
 
 #: src/components/shared/status-badge.tsx:33
 #: src/routes/companies/$slug.tsx:445
+#: src/routes/oauth/consent.tsx:121
 msgid "Client"
 msgstr "Client"
 
@@ -581,6 +607,10 @@ msgstr "Connecta bústies IMAP/SMTP i tria el remitent principal."
 msgid "Connect mailbox"
 msgstr "Connecta una bústia"
 
+#: src/routes/oauth/consent.tsx:111
+msgid "Connect to Batuda?"
+msgstr "Connectar a Batuda?"
+
 #: src/routes/emails/inboxes.tsx:391
 msgid "Connect your IMAP/SMTP mailbox to start sending and receiving email."
 msgstr "Connecta la teva bústia IMAP/SMTP per començar a enviar i rebre correu."
@@ -589,9 +619,22 @@ msgstr "Connecta la teva bústia IMAP/SMTP per començar a enviar i rebre correu
 msgid "Connected"
 msgstr "Connectada"
 
+#. placeholder {0}: formatDate(row.createdAt)
+#: src/routes/settings/mcp/connections.tsx:148
+msgid "Connected {0}"
+msgstr "Connectat {0}"
+
+#: src/routes/oauth/consent.tsx:163
+msgid "Connecting…"
+msgstr "Connectant…"
+
 #: src/routes/emails/inboxes.tsx:248
 msgid "Connection tested"
 msgstr "Connexió provada"
+
+#: src/routes/settings/profile/index.tsx:130
+msgid "Connections"
+msgstr "Connexions"
 
 #: src/components/research/research-dialog.tsx:46
 msgid "Contact discovery"
@@ -647,6 +690,10 @@ msgstr "Copia la teva clau ara"
 msgid "Could not clear suppression"
 msgstr "No s'''ha pogut esborrar la supressió"
 
+#: src/routes/oauth/consent.tsx:68
+msgid "Could not complete the connection. Please try again."
+msgstr "No s'ha pogut completar la connexió. Torna-ho a provar."
+
 #: src/routes/emails/inboxes.tsx:546
 msgid "Could not create the inbox. Check transport or credentials."
 msgstr "No s'ha pogut crear la bústia. Revisa el transport o les credencials."
@@ -682,6 +729,10 @@ msgstr "No s'ha pogut carregar aquesta execució."
 #: src/routes/emails/index.tsx:783
 msgid "Could not load threads"
 msgstr "No s'han pogut carregar els fils"
+
+#: src/routes/settings/mcp/connections.tsx:130
+msgid "Could not load your connections. Refresh to try again."
+msgstr "No s'han pogut carregar les connexions. Actualitza per tornar-ho a provar."
 
 #: src/routes/settings/api-keys/index.tsx:270
 msgid "Could not load your keys. Refresh to try again."
@@ -725,7 +776,7 @@ msgid "Could not send the invitation. Please try again."
 msgstr "No s'''ha pogut enviar la invitació. Torna-ho a provar."
 
 #: src/routes/forgot-password.tsx:123
-#: src/routes/login.tsx:137
+#: src/routes/login.tsx:151
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "No s'ha pogut enviar l'enllaç. Torna-ho a provar d'aquí uns segons."
 
@@ -737,7 +788,7 @@ msgstr "No s'ha pogut establir la bústia principal"
 msgid "Could not set the default inbox."
 msgstr "No s'ha pogut establir la safata per defecte."
 
-#: src/routes/login.tsx:136
+#: src/routes/login.tsx:149
 msgid "Could not sign in. Check your email and password."
 msgstr "No s'ha pogut iniciar sessió. Comprova el correu i la contrasenya."
 
@@ -753,7 +804,11 @@ msgstr "No s'ha pogut canviar d'organització. Torna-ho a provar."
 msgid "Could not toggle the inbox state."
 msgstr "No s'ha pogut canviar l'estat de la safata."
 
-#: src/routes/settings/profile/index.tsx:355
+#: src/routes/settings/mcp/connections.tsx:89
+msgid "Could not update"
+msgstr "No s'ha pogut actualitzar"
+
+#: src/routes/settings/profile/index.tsx:371
 msgid "Couldn't update your preference. Try again."
 msgstr "No he pogut desar la teva preferència. Prova-ho de nou."
 
@@ -811,11 +866,11 @@ msgstr "Creada per agent"
 msgid "Creating…"
 msgstr "Creant…"
 
-#: src/routes/settings/profile/index.tsx:424
+#: src/routes/settings/profile/index.tsx:440
 msgid "Current password"
 msgstr "Contrasenya actual"
 
-#: src/routes/settings/profile/index.tsx:474
+#: src/routes/settings/profile/index.tsx:490
 msgid "Current password is incorrect."
 msgstr "La contrasenya actual no és correcta."
 
@@ -900,6 +955,10 @@ msgstr "Eliminant…"
 #: src/routes/emails/$threadId.tsx:675
 msgid "Delivered"
 msgstr "Lliurat"
+
+#: src/routes/oauth/consent.tsx:152
+msgid "Deny"
+msgstr "Denega"
 
 #: src/components/interactions/quick-capture-dialog.tsx:256
 msgid "Direction"
@@ -1005,7 +1064,7 @@ msgstr "Editor"
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
 #: src/routes/forgot-password.tsx:109
-#: src/routes/login.tsx:339
+#: src/routes/login.tsx:378
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Correu"
@@ -1022,11 +1081,11 @@ msgstr "Esborranys de correu"
 msgid "Email is dead-letter"
 msgstr "El correu electrònic és no entregable"
 
-#: src/routes/login.tsx:388
+#: src/routes/login.tsx:427
 msgid "Email me a sign-in link"
 msgstr "Envia'm un enllaç per correu"
 
-#: src/routes/login.tsx:134
+#: src/routes/login.tsx:147
 msgid "Email or password is incorrect."
 msgstr "El correu o la contrasenya no són correctes."
 
@@ -1047,7 +1106,7 @@ msgstr "Els emails, trucades, documents i propostes apareixeran aquí a mesura q
 msgid "Enrichment"
 msgstr "Enriquiment"
 
-#: src/routes/login.tsx:139
+#: src/routes/login.tsx:153
 msgid "Enter a valid email above first."
 msgstr "Primer escriu un correu vàlid a sobre."
 
@@ -1139,7 +1198,7 @@ msgstr "El proveïdor l'ha marcat com a brossa. El cos es mostra només per revi
 msgid "Footers — {0}"
 msgstr "Peus de pàgina — {0}"
 
-#: src/routes/login.tsx:395
+#: src/routes/login.tsx:434
 msgid "Forgot password?"
 msgstr "Has oblidat la contrasenya?"
 
@@ -1170,6 +1229,10 @@ msgstr "Pantalla completa"
 #: src/routes/settings/api-keys/index.tsx:111
 msgid "Give the key a name so you can recognize it later."
 msgstr "Posa un nom a la clau perquè la puguis reconèixer més endavant."
+
+#: src/routes/oauth/consent.tsx:96
+msgid "Go to connections"
+msgstr "Ves a connexions"
 
 #: src/routes/reset-password.tsx:173
 msgid "Go to sign in"
@@ -1206,7 +1269,7 @@ msgstr "Humà"
 msgid "I prefer passwordless"
 msgstr "Prefereixo sense contrasenya"
 
-#: src/routes/settings/profile/index.tsx:312
+#: src/routes/settings/profile/index.tsx:328
 msgid "I prefer passwordless — don't ask me again"
 msgstr "Prefereixo sense contrasenya — no m'ho tornis a preguntar"
 
@@ -1301,7 +1364,7 @@ msgstr "Convida un membre"
 msgid "Invite a new member"
 msgstr "Convida un nou membre"
 
-#: src/routes/login.tsx:449
+#: src/routes/login.tsx:488
 msgid "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 msgstr "Caduca en {MAGIC_LINK_EXPIRY_MINUTES} minuts. No el veus? Mira el correu brossa."
 
@@ -1335,7 +1398,7 @@ msgstr "Idioma"
 
 #: src/components/profile/language-select.tsx:34
 #: src/routes/pages/$id.tsx:311
-#: src/routes/settings/profile/index.tsx:142
+#: src/routes/settings/profile/index.tsx:158
 msgid "Language"
 msgstr "Idioma"
 
@@ -1388,6 +1451,7 @@ msgstr "Carregant l'execució…"
 #: src/components/companies/upcoming-meetings-card.tsx:57
 #: src/components/shared/loading-spinner.tsx:23
 #: src/routes/settings/api-keys/index.tsx:266
+#: src/routes/settings/mcp/connections.tsx:126
 #: src/routes/settings/organization/index.tsx:52
 #: src/routes/settings/organization/members.tsx:113
 msgid "Loading…"
@@ -1508,6 +1572,10 @@ msgstr "Resum de mercat"
 msgid "Maturity"
 msgstr "Maduresa"
 
+#: src/routes/settings/mcp/connections.tsx:110
+msgid "MCP connections"
+msgstr "Connexions MCP"
+
 #: src/routes/companies/$slug.tsx:454
 msgid "Medium"
 msgstr "Mitjana"
@@ -1585,8 +1653,8 @@ msgid "Never expires"
 msgstr "No caduca mai"
 
 #: src/routes/reset-password.tsx:193
-#: src/routes/settings/profile/index.tsx:252
-#: src/routes/settings/profile/index.tsx:436
+#: src/routes/settings/profile/index.tsx:268
+#: src/routes/settings/profile/index.tsx:452
 msgid "New password"
 msgstr "Contrasenya nova"
 
@@ -1651,12 +1719,17 @@ msgstr "Encara no hi ha empreses"
 
 #: src/components/layout/org-switcher.tsx:62
 #: src/routes/accept-invitation.$id.tsx:98
-#: src/routes/login.tsx:138
+#: src/routes/login.tsx:152
+#: src/routes/oauth/consent.tsx:71
 #: src/routes/settings/organization/invite.tsx:77
 #: src/routes/settings/organization/members.tsx:81
-#: src/routes/settings/profile/index.tsx:82
+#: src/routes/settings/profile/index.tsx:89
 msgid "No connection to the server. Try again in a few seconds."
 msgstr "Sense connexió al servidor. Torna-ho a provar d'aquí a uns segons."
+
+#: src/routes/settings/mcp/connections.tsx:136
+msgid "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
+msgstr "Encara no hi ha connexions. Afegeix aquest servidor al teu assistent d'IA i autoritza'l; després apareixerà aquí."
 
 #: src/components/companies/cadence-card.tsx:56
 msgid "No contact yet."
@@ -1802,6 +1875,10 @@ msgstr "Nota"
 msgid "Nothing changed yet."
 msgstr "Encara no ha canviat res."
 
+#: src/routes/oauth/consent.tsx:80
+msgid "Nothing to authorize"
+msgstr "Res a autoritzar"
+
 #: src/routes/settings/organization/spend.tsx:227
 msgid "Nothing to show in this range."
 msgstr "Res a mostrar en aquest interval."
@@ -1825,7 +1902,7 @@ msgid "Open"
 msgstr "Obert"
 
 #. placeholder {0}: provider.label
-#: src/routes/login.tsx:482
+#: src/routes/login.tsx:521
 msgid "Open {0}"
 msgstr "Obre {0}"
 
@@ -1891,9 +1968,18 @@ msgstr "Obert"
 #: src/routes/settings/organization/index.tsx:42
 #: src/routes/settings/organization/invite.tsx:91
 #: src/routes/settings/organization/members.tsx:95
-#: src/routes/settings/profile/index.tsx:108
+#: src/routes/settings/profile/index.tsx:115
 msgid "Organization"
 msgstr "Organització"
+
+#. placeholder {0}: row.name ?? t`Unnamed client`
+#: src/routes/settings/mcp/connections.tsx:171
+msgid "Organization for {0}"
+msgstr "Organització per a {0}"
+
+#: src/routes/settings/mcp/connections.tsx:81
+msgid "Organization updated"
+msgstr "Organització actualitzada"
 
 #: src/components/layout/org-switcher.tsx:107
 msgid "Organizations"
@@ -1985,7 +2071,7 @@ msgstr "Indicadors de dolor"
 msgid "Pain points"
 msgstr "Punts febles"
 
-#: src/routes/login.tsx:354
+#: src/routes/login.tsx:393
 msgid "Password"
 msgstr "Contrasenya"
 
@@ -1997,17 +2083,17 @@ msgstr "Contrasenya o contrasenya d'aplicació"
 msgid "Password updated"
 msgstr "Contrasenya actualitzada"
 
-#: src/routes/settings/profile/index.tsx:484
+#: src/routes/settings/profile/index.tsx:500
 msgid "Password updated."
 msgstr "Contrasenya actualitzada."
 
-#: src/routes/settings/profile/index.tsx:338
+#: src/routes/settings/profile/index.tsx:354
 msgid "Passwordless sign-in only"
 msgstr "Només inici de sessió sense contrasenya"
 
 #: src/routes/reset-password.tsx:221
-#: src/routes/settings/profile/index.tsx:278
-#: src/routes/settings/profile/index.tsx:462
+#: src/routes/settings/profile/index.tsx:294
+#: src/routes/settings/profile/index.tsx:478
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "La contrasenya ha de tenir com a mínim {MIN_PASSWORD_LENGTH} caràcters."
 
@@ -2035,7 +2121,7 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Telèfon"
 
-#: src/routes/settings/profile/index.tsx:413
+#: src/routes/settings/profile/index.tsx:429
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Tria una contrasenya nova. Els altres dispositius es desconnectaran."
 
@@ -2107,7 +2193,7 @@ msgid "Products fit"
 msgstr "Encaix de productes"
 
 #: src/routes/companies/$slug.tsx:1082
-#: src/routes/settings/profile/index.tsx:94
+#: src/routes/settings/profile/index.tsx:101
 msgid "Profile"
 msgstr "Perfil"
 
@@ -2245,8 +2331,8 @@ msgid "Reopen thread"
 msgstr "Reobre el fil"
 
 #: src/routes/reset-password.tsx:207
-#: src/routes/settings/profile/index.tsx:265
-#: src/routes/settings/profile/index.tsx:449
+#: src/routes/settings/profile/index.tsx:281
+#: src/routes/settings/profile/index.tsx:465
 msgid "Repeat new password"
 msgstr "Repeteix la contrasenya nova"
 
@@ -2272,11 +2358,11 @@ msgstr "Recerca"
 msgid "Research run"
 msgstr "Recerca"
 
-#: src/routes/login.tsx:464
+#: src/routes/login.tsx:503
 msgid "Resend in"
 msgstr "Torna a enviar en"
 
-#: src/routes/login.tsx:470
+#: src/routes/login.tsx:509
 msgid "Resend link"
 msgstr "Torna a enviar l'enllaç"
 
@@ -2352,7 +2438,7 @@ msgstr "Ha fallat el desament"
 msgid "Save new password"
 msgstr "Desa la nova contrasenya"
 
-#: src/routes/settings/profile/index.tsx:303
+#: src/routes/settings/profile/index.tsx:319
 msgid "Save password"
 msgstr "Desa la contrasenya"
 
@@ -2360,8 +2446,8 @@ msgstr "Desa la contrasenya"
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
 #: src/routes/reset-password.tsx:242
-#: src/routes/settings/profile/index.tsx:301
-#: src/routes/settings/profile/index.tsx:495
+#: src/routes/settings/profile/index.tsx:317
+#: src/routes/settings/profile/index.tsx:511
 msgid "Saving…"
 msgstr "Desant…"
 
@@ -2436,7 +2522,7 @@ msgstr "Envia l'enllaç"
 
 #: src/components/emails/compose-form.tsx:534
 #: src/routes/forgot-password.tsx:134
-#: src/routes/login.tsx:387
+#: src/routes/login.tsx:426
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
 msgstr "Enviant…"
@@ -2449,7 +2535,7 @@ msgstr "Enviat"
 msgid "Set a new password"
 msgstr "Posa una contrasenya nova"
 
-#: src/routes/settings/profile/index.tsx:241
+#: src/routes/settings/profile/index.tsx:257
 msgid "Set a password"
 msgstr "Posa una contrasenya"
 
@@ -2468,7 +2554,8 @@ msgstr "Posa contrasenya"
 #: src/components/layout/nav-items.ts:81
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
-#: src/routes/settings/profile/index.tsx:101
+#: src/routes/settings/mcp/connections.tsx:103
+#: src/routes/settings/profile/index.tsx:108
 msgid "Settings"
 msgstr "Configuració"
 
@@ -2503,7 +2590,7 @@ msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Mostrant {firstRow}–{lastRow} de {total}"
 
 #: src/routes/accept-invitation.$id.tsx:129
-#: src/routes/login.tsx:376
+#: src/routes/login.tsx:415
 msgid "Sign in"
 msgstr "Inicia sessió"
 
@@ -2511,7 +2598,7 @@ msgstr "Inicia sessió"
 msgid "Sign in to accept this invitation"
 msgstr "Inicia sessió per acceptar aquesta invitació"
 
-#: src/routes/login.tsx:329
+#: src/routes/login.tsx:368
 msgid "Sign in to continue"
 msgstr "Inicia sessió per continuar"
 
@@ -2519,19 +2606,19 @@ msgstr "Inicia sessió per continuar"
 msgid "Sign in with your new password. Other devices will need to sign in again too."
 msgstr "Inicia sessió amb la contrasenya nova. Els altres dispositius també hauran de tornar a iniciar sessió."
 
-#: src/routes/settings/profile/index.tsx:161
+#: src/routes/settings/profile/index.tsx:177
 msgid "Sign out"
 msgstr "Tanca sessió"
 
-#: src/routes/settings/profile/index.tsx:76
+#: src/routes/settings/profile/index.tsx:83
 msgid "Sign-out failed. Please try again."
 msgstr "No s'ha pogut tancar la sessió. Torna-ho a provar."
 
-#: src/routes/login.tsx:376
+#: src/routes/login.tsx:415
 msgid "Signing in…"
 msgstr "Iniciant sessió…"
 
-#: src/routes/settings/profile/index.tsx:161
+#: src/routes/settings/profile/index.tsx:177
 msgid "Signing out…"
 msgstr "Tancant sessió…"
 
@@ -2571,9 +2658,13 @@ msgstr "Posposades"
 msgid "someone"
 msgstr "algú"
 
+#: src/routes/oauth/consent.tsx:56
+msgid "Something went wrong. Start the connection again from your assistant."
+msgstr "Alguna cosa ha anat malament. Torna a iniciar la connexió des del teu assistent."
+
 #: src/routes/reset-password.tsx:233
-#: src/routes/settings/profile/index.tsx:290
-#: src/routes/settings/profile/index.tsx:479
+#: src/routes/settings/profile/index.tsx:306
+#: src/routes/settings/profile/index.tsx:495
 msgid "Something went wrong. Try again."
 msgstr "Alguna cosa ha fallat. Prova-ho de nou."
 
@@ -2697,11 +2788,15 @@ msgstr "Prova fallida"
 msgid "Testing connection…"
 msgstr "Provant la connexió…"
 
-#: src/routes/login.tsx:141
+#: src/routes/login.tsx:150
+msgid "That connection request expired. Start it again from your AI assistant."
+msgstr "Aquesta sol·licitud de connexió ha caducat. Torna a iniciar-la des del teu assistent d'IA."
+
+#: src/routes/login.tsx:155
 msgid "That link expired. Request a fresh one below."
 msgstr "L'enllaç ha caducat. Demana'n un de nou a sota."
 
-#: src/routes/login.tsx:142
+#: src/routes/login.tsx:156
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "L'enllaç ja no és vàlid. Demana'n un de nou a sota."
 
@@ -2762,11 +2857,11 @@ msgstr "Potser el fil s'ha arxivat al proveïdor o l'enllaç és obsolet."
 msgid "The token expired or was already used. Request a fresh link."
 msgstr "El token ha caducat o ja s'ha fet servir. Demana un enllaç nou."
 
-#: src/routes/settings/profile/index.tsx:469
+#: src/routes/settings/profile/index.tsx:485
 msgid "The two new password fields don't match."
 msgstr "Les dues contrasenyes noves no coincideixen."
 
-#: src/routes/settings/profile/index.tsx:285
+#: src/routes/settings/profile/index.tsx:301
 msgid "The two password fields don't match."
 msgstr "Les dues contrasenyes no coincideixen."
 
@@ -2789,6 +2884,10 @@ msgstr "L'espai de treball on viuen les dades del CRM."
 #: src/components/shared/status-badge.tsx:41
 msgid "They replied — keep the thread warm"
 msgstr "Ha respost — manté el fil calent"
+
+#: src/routes/settings/mcp/connections.tsx:82
+msgid "This connection now acts in the chosen organization."
+msgstr "Aquesta connexió ara actua en l'organització triada."
 
 #: src/routes/accept-invitation.$id.tsx:193
 msgid "This invitation can't be accepted"
@@ -2814,6 +2913,10 @@ msgstr "Aquest enllaç ja no és vàlid"
 #: src/routes/settings/organization/spend.tsx:134
 msgid "This month"
 msgstr "Aquest mes"
+
+#: src/routes/oauth/consent.tsx:83
+msgid "This page opens when an AI assistant asks to connect. Start the connection from your assistant."
+msgstr "Aquesta pàgina s'obre quan un assistent d'IA demana connectar-se. Inicia la connexió des del teu assistent."
 
 #: src/routes/index.tsx:420
 #: src/routes/tasks/index.tsx:474
@@ -2858,7 +2961,7 @@ msgstr "Per a"
 msgid "Today"
 msgstr "Avui"
 
-#: src/routes/login.tsx:133
+#: src/routes/login.tsx:146
 msgid "Too many attempts. Try again in a minute."
 msgstr "Massa intents. Torna-ho a provar d'aquí un minut."
 
@@ -2895,13 +2998,18 @@ msgstr "desconegut"
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: src/routes/settings/profile/index.tsx:87
+#: src/routes/settings/profile/index.tsx:94
 msgid "Unknown user"
 msgstr "Usuari desconegut"
 
 #: src/routes/emails/$threadId.tsx:475
 msgid "Unlinked"
 msgstr "Sense enllaçar"
+
+#: src/routes/settings/mcp/connections.tsx:146
+#: src/routes/settings/mcp/connections.tsx:171
+msgid "Unnamed client"
+msgstr "Client sense nom"
 
 #: src/routes/emails/index.tsx:1397
 msgid "Untitled"
@@ -2937,7 +3045,7 @@ msgstr "Pujant…"
 msgid "Use {0} as primary"
 msgstr "Fes servir {0} com a principal"
 
-#: src/routes/login.tsx:492
+#: src/routes/login.tsx:531
 msgid "Use a different email"
 msgstr "Fes servir un altre correu"
 
@@ -2949,7 +3057,7 @@ msgstr "Utilitza com a peu de pàgina predeterminat"
 msgid "Use as default for this purpose"
 msgstr "Usa com a per defecte per a aquest propòsit"
 
-#: src/routes/login.tsx:499
+#: src/routes/login.tsx:538
 msgid "Use password instead"
 msgstr "Fes servir contrasenya"
 
@@ -2974,15 +3082,15 @@ msgstr "Visites"
 msgid "Visit"
 msgstr "Visita"
 
-#: src/routes/login.tsx:143
+#: src/routes/login.tsx:157
 msgid "We couldn't sign you in via that link. Try again."
 msgstr "No s'ha pogut iniciar sessió amb aquest enllaç. Torna-ho a provar."
 
-#: src/routes/login.tsx:140
+#: src/routes/login.tsx:154
 msgid "We don't recognize that email. Ask an admin to invite you."
 msgstr "No reconeixem aquest correu. Demana a un administrador que t'inviti."
 
-#: src/routes/login.tsx:445
+#: src/routes/login.tsx:484
 msgid "We sent a sign-in link to"
 msgstr "S'ha enviat un enllaç d'inici de sessió a"
 
@@ -3046,7 +3154,7 @@ msgstr "Escriu el peu de pàgina…"
 msgid "Write your message…"
 msgstr "Escriu el teu missatge…"
 
-#: src/routes/settings/profile/index.tsx:244
+#: src/routes/settings/profile/index.tsx:260
 msgid "You currently sign in from email links. Add a password to skip checking your email next time."
 msgstr "Ara mateix entres des d'enllaços al correu. Afegeix una contrasenya per no haver de mirar el correu la pròxima vegada."
 
@@ -3058,7 +3166,11 @@ msgstr "No tens permís per veure aquesta pàgina."
 msgid "You got in from a link in your email."
 msgstr "Has entrat des d'un enllaç al teu correu."
 
-#: src/routes/settings/profile/index.tsx:341
+#: src/routes/settings/mcp/connections.tsx:90
+msgid "You may not be a member of that organization. Try again."
+msgstr "Potser no ets membre d'aquesta organització. Torna-ho a provar."
+
+#: src/routes/settings/profile/index.tsx:357
 msgid "You sign in from email links. I won't bring it up again."
 msgstr "Entres des d'enllaços al correu. No t'ho tornaré a esmentar."
 
@@ -3074,11 +3186,15 @@ msgstr "Ja ets membre."
 msgid "you@example.com"
 msgstr "tu@exemple.com"
 
-#: src/routes/settings/profile/index.tsx:97
+#: src/routes/settings/profile/index.tsx:104
 msgid "Your Batuda workbench identity."
 msgstr "La teva identitat al banc de Batuda."
 
-#: src/routes/login.tsx:135
+#: src/routes/settings/mcp/connections.tsx:122
+msgid "Your connections"
+msgstr "Les teves connexions"
+
+#: src/routes/login.tsx:148
 msgid "Your email isn't verified yet. Use the magic link instead."
 msgstr "El correu encara no està verificat. Fes servir l'enllaç de sessió."
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -123,6 +123,10 @@ msgstr "Accept"
 msgid "Accepting the invitation…"
 msgstr "Accepting the invitation…"
 
+#: src/routes/oauth/consent.tsx:128
+msgid "Access"
+msgstr "Access"
+
 #. placeholder {0}: provider.length
 #: src/routes/settings/organization/spend.tsx:162
 msgid "across {0} providers"
@@ -190,6 +194,10 @@ msgstr "Admin"
 msgid "Agent"
 msgstr "Agent"
 
+#: src/routes/settings/mcp/connections.tsx:113
+msgid "AI assistants you've connected over MCP. Choose which organization each one acts in."
+msgstr "AI assistants you've connected over MCP. Choose which organization each one acts in."
+
 #: src/routes/companies/index.tsx:277
 #: src/routes/emails/index.tsx:623
 msgid "All"
@@ -212,16 +220,24 @@ msgstr "All time"
 msgid "All under control"
 msgstr "All under control"
 
+#: src/routes/oauth/consent.tsx:163
+msgid "Allow"
+msgstr "Allow"
+
 #: src/components/research/findings/shared.tsx:179
 msgid "Already in CRM"
 msgstr "Already in CRM"
+
+#: src/routes/oauth/consent.tsx:114
+msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
+msgstr "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
 
 #: src/routes/settings/api-keys/index.tsx:395
 msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 msgstr "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 
 #: src/routes/settings/api-keys/index.tsx:197
-#: src/routes/settings/profile/index.tsx:114
+#: src/routes/settings/profile/index.tsx:121
 msgid "API keys"
 msgstr "API keys"
 
@@ -280,6 +296,7 @@ msgid "Back to organization"
 msgstr "Back to organization"
 
 #: src/routes/settings/api-keys/index.tsx:187
+#: src/routes/settings/mcp/connections.tsx:100
 msgid "Back to settings"
 msgstr "Back to settings"
 
@@ -301,7 +318,7 @@ msgstr "Batuda — a multi-tenant CRM for small agencies."
 msgid "Batuda home"
 msgstr "Batuda home"
 
-#: src/routes/login.tsx:404
+#: src/routes/login.tsx:443
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda is invite-only. Request access from the Engranatge team."
 
@@ -391,17 +408,21 @@ msgstr "Cancel"
 msgid "Cancel upload"
 msgstr "Cancel upload"
 
+#: src/routes/oauth/consent.tsx:152
+msgid "Cancelling…"
+msgstr "Cancelling…"
+
 #: src/components/emails/compose-form.tsx:429
 #: src/routes/emails/$threadId.tsx:595
 msgid "Cc"
 msgstr "Cc"
 
-#: src/routes/settings/profile/index.tsx:350
+#: src/routes/settings/profile/index.tsx:366
 msgid "Change my mind — set a password anyway"
 msgstr "Change my mind — set a password anyway"
 
-#: src/routes/settings/profile/index.tsx:410
-#: src/routes/settings/profile/index.tsx:497
+#: src/routes/settings/profile/index.tsx:426
+#: src/routes/settings/profile/index.tsx:513
 msgid "Change password"
 msgstr "Change password"
 
@@ -440,9 +461,13 @@ msgid "Check the session or try again."
 msgstr "Check the session or try again."
 
 #: src/routes/forgot-password.tsx:69
-#: src/routes/login.tsx:442
+#: src/routes/login.tsx:481
 msgid "Check your inbox"
 msgstr "Check your inbox"
+
+#: src/routes/settings/mcp/connections.tsx:175
+msgid "Choose organization"
+msgstr "Choose organization"
 
 #: src/routes/emails/inboxes.tsx:350
 #: src/routes/emails/inboxes.tsx:351
@@ -468,6 +493,7 @@ msgstr "Clicked"
 
 #: src/components/shared/status-badge.tsx:33
 #: src/routes/companies/$slug.tsx:445
+#: src/routes/oauth/consent.tsx:121
 msgid "Client"
 msgstr "Client"
 
@@ -581,6 +607,10 @@ msgstr "Connect IMAP/SMTP mailboxes and choose your primary sender."
 msgid "Connect mailbox"
 msgstr "Connect mailbox"
 
+#: src/routes/oauth/consent.tsx:111
+msgid "Connect to Batuda?"
+msgstr "Connect to Batuda?"
+
 #: src/routes/emails/inboxes.tsx:391
 msgid "Connect your IMAP/SMTP mailbox to start sending and receiving email."
 msgstr "Connect your IMAP/SMTP mailbox to start sending and receiving email."
@@ -589,9 +619,22 @@ msgstr "Connect your IMAP/SMTP mailbox to start sending and receiving email."
 msgid "Connected"
 msgstr "Connected"
 
+#. placeholder {0}: formatDate(row.createdAt)
+#: src/routes/settings/mcp/connections.tsx:148
+msgid "Connected {0}"
+msgstr "Connected {0}"
+
+#: src/routes/oauth/consent.tsx:163
+msgid "Connecting…"
+msgstr "Connecting…"
+
 #: src/routes/emails/inboxes.tsx:248
 msgid "Connection tested"
 msgstr "Connection tested"
+
+#: src/routes/settings/profile/index.tsx:130
+msgid "Connections"
+msgstr "Connections"
 
 #: src/components/research/research-dialog.tsx:46
 msgid "Contact discovery"
@@ -647,6 +690,10 @@ msgstr "Copy your key now"
 msgid "Could not clear suppression"
 msgstr "Could not clear suppression"
 
+#: src/routes/oauth/consent.tsx:68
+msgid "Could not complete the connection. Please try again."
+msgstr "Could not complete the connection. Please try again."
+
 #: src/routes/emails/inboxes.tsx:546
 msgid "Could not create the inbox. Check transport or credentials."
 msgstr "Could not create the inbox. Check transport or credentials."
@@ -682,6 +729,10 @@ msgstr "Could not load this run."
 #: src/routes/emails/index.tsx:783
 msgid "Could not load threads"
 msgstr "Could not load threads"
+
+#: src/routes/settings/mcp/connections.tsx:130
+msgid "Could not load your connections. Refresh to try again."
+msgstr "Could not load your connections. Refresh to try again."
 
 #: src/routes/settings/api-keys/index.tsx:270
 msgid "Could not load your keys. Refresh to try again."
@@ -725,7 +776,7 @@ msgid "Could not send the invitation. Please try again."
 msgstr "Could not send the invitation. Please try again."
 
 #: src/routes/forgot-password.tsx:123
-#: src/routes/login.tsx:137
+#: src/routes/login.tsx:151
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "Could not send the link. Try again in a few seconds."
 
@@ -737,7 +788,7 @@ msgstr "Could not set primary inbox"
 msgid "Could not set the default inbox."
 msgstr "Could not set the default inbox."
 
-#: src/routes/login.tsx:136
+#: src/routes/login.tsx:149
 msgid "Could not sign in. Check your email and password."
 msgstr "Could not sign in. Check your email and password."
 
@@ -753,7 +804,11 @@ msgstr "Could not switch organization. Please try again."
 msgid "Could not toggle the inbox state."
 msgstr "Could not toggle the inbox state."
 
-#: src/routes/settings/profile/index.tsx:355
+#: src/routes/settings/mcp/connections.tsx:89
+msgid "Could not update"
+msgstr "Could not update"
+
+#: src/routes/settings/profile/index.tsx:371
 msgid "Couldn't update your preference. Try again."
 msgstr "Couldn't update your preference. Try again."
 
@@ -811,11 +866,11 @@ msgstr "Created by agent"
 msgid "Creating…"
 msgstr "Creating…"
 
-#: src/routes/settings/profile/index.tsx:424
+#: src/routes/settings/profile/index.tsx:440
 msgid "Current password"
 msgstr "Current password"
 
-#: src/routes/settings/profile/index.tsx:474
+#: src/routes/settings/profile/index.tsx:490
 msgid "Current password is incorrect."
 msgstr "Current password is incorrect."
 
@@ -900,6 +955,10 @@ msgstr "Deleting…"
 #: src/routes/emails/$threadId.tsx:675
 msgid "Delivered"
 msgstr "Delivered"
+
+#: src/routes/oauth/consent.tsx:152
+msgid "Deny"
+msgstr "Deny"
 
 #: src/components/interactions/quick-capture-dialog.tsx:256
 msgid "Direction"
@@ -1005,7 +1064,7 @@ msgstr "Editor"
 #: src/routes/companies/$slug.tsx:854
 #: src/routes/emails/inboxes.tsx:402
 #: src/routes/forgot-password.tsx:109
-#: src/routes/login.tsx:339
+#: src/routes/login.tsx:378
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Email"
@@ -1022,11 +1081,11 @@ msgstr "Email drafts"
 msgid "Email is dead-letter"
 msgstr "Email is dead-letter"
 
-#: src/routes/login.tsx:388
+#: src/routes/login.tsx:427
 msgid "Email me a sign-in link"
 msgstr "Email me a sign-in link"
 
-#: src/routes/login.tsx:134
+#: src/routes/login.tsx:147
 msgid "Email or password is incorrect."
 msgstr "Email or password is incorrect."
 
@@ -1047,7 +1106,7 @@ msgstr "Emails, calls, documents, and proposals will appear here as they happen.
 msgid "Enrichment"
 msgstr "Enrichment"
 
-#: src/routes/login.tsx:139
+#: src/routes/login.tsx:153
 msgid "Enter a valid email above first."
 msgstr "Enter a valid email above first."
 
@@ -1139,7 +1198,7 @@ msgstr "Flagged as spam by the provider. The body is shown for review only."
 msgid "Footers — {0}"
 msgstr "Footers — {0}"
 
-#: src/routes/login.tsx:395
+#: src/routes/login.tsx:434
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
@@ -1170,6 +1229,10 @@ msgstr "Full screen"
 #: src/routes/settings/api-keys/index.tsx:111
 msgid "Give the key a name so you can recognize it later."
 msgstr "Give the key a name so you can recognize it later."
+
+#: src/routes/oauth/consent.tsx:96
+msgid "Go to connections"
+msgstr "Go to connections"
 
 #: src/routes/reset-password.tsx:173
 msgid "Go to sign in"
@@ -1206,7 +1269,7 @@ msgstr "Human"
 msgid "I prefer passwordless"
 msgstr "I prefer passwordless"
 
-#: src/routes/settings/profile/index.tsx:312
+#: src/routes/settings/profile/index.tsx:328
 msgid "I prefer passwordless — don't ask me again"
 msgstr "I prefer passwordless — don't ask me again"
 
@@ -1301,7 +1364,7 @@ msgstr "Invite a member"
 msgid "Invite a new member"
 msgstr "Invite a new member"
 
-#: src/routes/login.tsx:449
+#: src/routes/login.tsx:488
 msgid "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 msgstr "It expires in {MAGIC_LINK_EXPIRY_MINUTES} minutes. Not seeing it? Check spam."
 
@@ -1335,7 +1398,7 @@ msgstr "Lang"
 
 #: src/components/profile/language-select.tsx:34
 #: src/routes/pages/$id.tsx:311
-#: src/routes/settings/profile/index.tsx:142
+#: src/routes/settings/profile/index.tsx:158
 msgid "Language"
 msgstr "Language"
 
@@ -1388,6 +1451,7 @@ msgstr "Loading run…"
 #: src/components/companies/upcoming-meetings-card.tsx:57
 #: src/components/shared/loading-spinner.tsx:23
 #: src/routes/settings/api-keys/index.tsx:266
+#: src/routes/settings/mcp/connections.tsx:126
 #: src/routes/settings/organization/index.tsx:52
 #: src/routes/settings/organization/members.tsx:113
 msgid "Loading…"
@@ -1508,6 +1572,10 @@ msgstr "Market summary"
 msgid "Maturity"
 msgstr "Maturity"
 
+#: src/routes/settings/mcp/connections.tsx:110
+msgid "MCP connections"
+msgstr "MCP connections"
+
 #: src/routes/companies/$slug.tsx:454
 msgid "Medium"
 msgstr "Medium"
@@ -1585,8 +1653,8 @@ msgid "Never expires"
 msgstr "Never expires"
 
 #: src/routes/reset-password.tsx:193
-#: src/routes/settings/profile/index.tsx:252
-#: src/routes/settings/profile/index.tsx:436
+#: src/routes/settings/profile/index.tsx:268
+#: src/routes/settings/profile/index.tsx:452
 msgid "New password"
 msgstr "New password"
 
@@ -1651,12 +1719,17 @@ msgstr "No companies yet"
 
 #: src/components/layout/org-switcher.tsx:62
 #: src/routes/accept-invitation.$id.tsx:98
-#: src/routes/login.tsx:138
+#: src/routes/login.tsx:152
+#: src/routes/oauth/consent.tsx:71
 #: src/routes/settings/organization/invite.tsx:77
 #: src/routes/settings/organization/members.tsx:81
-#: src/routes/settings/profile/index.tsx:82
+#: src/routes/settings/profile/index.tsx:89
 msgid "No connection to the server. Try again in a few seconds."
 msgstr "No connection to the server. Try again in a few seconds."
+
+#: src/routes/settings/mcp/connections.tsx:136
+msgid "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
+msgstr "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
 
 #: src/components/companies/cadence-card.tsx:56
 msgid "No contact yet."
@@ -1802,6 +1875,10 @@ msgstr "Note"
 msgid "Nothing changed yet."
 msgstr "Nothing changed yet."
 
+#: src/routes/oauth/consent.tsx:80
+msgid "Nothing to authorize"
+msgstr "Nothing to authorize"
+
 #: src/routes/settings/organization/spend.tsx:227
 msgid "Nothing to show in this range."
 msgstr "Nothing to show in this range."
@@ -1825,7 +1902,7 @@ msgid "Open"
 msgstr "Open"
 
 #. placeholder {0}: provider.label
-#: src/routes/login.tsx:482
+#: src/routes/login.tsx:521
 msgid "Open {0}"
 msgstr "Open {0}"
 
@@ -1891,9 +1968,18 @@ msgstr "Opened"
 #: src/routes/settings/organization/index.tsx:42
 #: src/routes/settings/organization/invite.tsx:91
 #: src/routes/settings/organization/members.tsx:95
-#: src/routes/settings/profile/index.tsx:108
+#: src/routes/settings/profile/index.tsx:115
 msgid "Organization"
 msgstr "Organization"
+
+#. placeholder {0}: row.name ?? t`Unnamed client`
+#: src/routes/settings/mcp/connections.tsx:171
+msgid "Organization for {0}"
+msgstr "Organization for {0}"
+
+#: src/routes/settings/mcp/connections.tsx:81
+msgid "Organization updated"
+msgstr "Organization updated"
 
 #: src/components/layout/org-switcher.tsx:107
 msgid "Organizations"
@@ -1985,7 +2071,7 @@ msgstr "Pain indicators"
 msgid "Pain points"
 msgstr "Pain points"
 
-#: src/routes/login.tsx:354
+#: src/routes/login.tsx:393
 msgid "Password"
 msgstr "Password"
 
@@ -1997,17 +2083,17 @@ msgstr "Password or app-password"
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/routes/settings/profile/index.tsx:484
+#: src/routes/settings/profile/index.tsx:500
 msgid "Password updated."
 msgstr "Password updated."
 
-#: src/routes/settings/profile/index.tsx:338
+#: src/routes/settings/profile/index.tsx:354
 msgid "Passwordless sign-in only"
 msgstr "Passwordless sign-in only"
 
 #: src/routes/reset-password.tsx:221
-#: src/routes/settings/profile/index.tsx:278
-#: src/routes/settings/profile/index.tsx:462
+#: src/routes/settings/profile/index.tsx:294
+#: src/routes/settings/profile/index.tsx:478
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 
@@ -2035,7 +2121,7 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Phone"
 
-#: src/routes/settings/profile/index.tsx:413
+#: src/routes/settings/profile/index.tsx:429
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Pick a new password. Other signed-in devices will be signed out."
 
@@ -2107,7 +2193,7 @@ msgid "Products fit"
 msgstr "Products fit"
 
 #: src/routes/companies/$slug.tsx:1082
-#: src/routes/settings/profile/index.tsx:94
+#: src/routes/settings/profile/index.tsx:101
 msgid "Profile"
 msgstr "Profile"
 
@@ -2245,8 +2331,8 @@ msgid "Reopen thread"
 msgstr "Reopen thread"
 
 #: src/routes/reset-password.tsx:207
-#: src/routes/settings/profile/index.tsx:265
-#: src/routes/settings/profile/index.tsx:449
+#: src/routes/settings/profile/index.tsx:281
+#: src/routes/settings/profile/index.tsx:465
 msgid "Repeat new password"
 msgstr "Repeat new password"
 
@@ -2272,11 +2358,11 @@ msgstr "Research"
 msgid "Research run"
 msgstr "Research run"
 
-#: src/routes/login.tsx:464
+#: src/routes/login.tsx:503
 msgid "Resend in"
 msgstr "Resend in"
 
-#: src/routes/login.tsx:470
+#: src/routes/login.tsx:509
 msgid "Resend link"
 msgstr "Resend link"
 
@@ -2352,7 +2438,7 @@ msgstr "Save failed"
 msgid "Save new password"
 msgstr "Save new password"
 
-#: src/routes/settings/profile/index.tsx:303
+#: src/routes/settings/profile/index.tsx:319
 msgid "Save password"
 msgstr "Save password"
 
@@ -2360,8 +2446,8 @@ msgstr "Save password"
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
 #: src/routes/reset-password.tsx:242
-#: src/routes/settings/profile/index.tsx:301
-#: src/routes/settings/profile/index.tsx:495
+#: src/routes/settings/profile/index.tsx:317
+#: src/routes/settings/profile/index.tsx:511
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2436,7 +2522,7 @@ msgstr "Send reset link"
 
 #: src/components/emails/compose-form.tsx:534
 #: src/routes/forgot-password.tsx:134
-#: src/routes/login.tsx:387
+#: src/routes/login.tsx:426
 #: src/routes/settings/organization/invite.tsx:180
 msgid "Sending…"
 msgstr "Sending…"
@@ -2449,7 +2535,7 @@ msgstr "Sent"
 msgid "Set a new password"
 msgstr "Set a new password"
 
-#: src/routes/settings/profile/index.tsx:241
+#: src/routes/settings/profile/index.tsx:257
 msgid "Set a password"
 msgstr "Set a password"
 
@@ -2468,7 +2554,8 @@ msgstr "Set password"
 #: src/components/layout/nav-items.ts:81
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
-#: src/routes/settings/profile/index.tsx:101
+#: src/routes/settings/mcp/connections.tsx:103
+#: src/routes/settings/profile/index.tsx:108
 msgid "Settings"
 msgstr "Settings"
 
@@ -2503,7 +2590,7 @@ msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Showing {firstRow}–{lastRow} of {total}"
 
 #: src/routes/accept-invitation.$id.tsx:129
-#: src/routes/login.tsx:376
+#: src/routes/login.tsx:415
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -2511,7 +2598,7 @@ msgstr "Sign in"
 msgid "Sign in to accept this invitation"
 msgstr "Sign in to accept this invitation"
 
-#: src/routes/login.tsx:329
+#: src/routes/login.tsx:368
 msgid "Sign in to continue"
 msgstr "Sign in to continue"
 
@@ -2519,19 +2606,19 @@ msgstr "Sign in to continue"
 msgid "Sign in with your new password. Other devices will need to sign in again too."
 msgstr "Sign in with your new password. Other devices will need to sign in again too."
 
-#: src/routes/settings/profile/index.tsx:161
+#: src/routes/settings/profile/index.tsx:177
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/routes/settings/profile/index.tsx:76
+#: src/routes/settings/profile/index.tsx:83
 msgid "Sign-out failed. Please try again."
 msgstr "Sign-out failed. Please try again."
 
-#: src/routes/login.tsx:376
+#: src/routes/login.tsx:415
 msgid "Signing in…"
 msgstr "Signing in…"
 
-#: src/routes/settings/profile/index.tsx:161
+#: src/routes/settings/profile/index.tsx:177
 msgid "Signing out…"
 msgstr "Signing out…"
 
@@ -2571,9 +2658,13 @@ msgstr "Snoozed"
 msgid "someone"
 msgstr "someone"
 
+#: src/routes/oauth/consent.tsx:56
+msgid "Something went wrong. Start the connection again from your assistant."
+msgstr "Something went wrong. Start the connection again from your assistant."
+
 #: src/routes/reset-password.tsx:233
-#: src/routes/settings/profile/index.tsx:290
-#: src/routes/settings/profile/index.tsx:479
+#: src/routes/settings/profile/index.tsx:306
+#: src/routes/settings/profile/index.tsx:495
 msgid "Something went wrong. Try again."
 msgstr "Something went wrong. Try again."
 
@@ -2697,11 +2788,15 @@ msgstr "Test failed"
 msgid "Testing connection…"
 msgstr "Testing connection…"
 
-#: src/routes/login.tsx:141
+#: src/routes/login.tsx:150
+msgid "That connection request expired. Start it again from your AI assistant."
+msgstr "That connection request expired. Start it again from your AI assistant."
+
+#: src/routes/login.tsx:155
 msgid "That link expired. Request a fresh one below."
 msgstr "That link expired. Request a fresh one below."
 
-#: src/routes/login.tsx:142
+#: src/routes/login.tsx:156
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "That link is no longer valid. Request a fresh one below."
 
@@ -2762,11 +2857,11 @@ msgstr "The thread may have been archived upstream or the link is stale."
 msgid "The token expired or was already used. Request a fresh link."
 msgstr "The token expired or was already used. Request a fresh link."
 
-#: src/routes/settings/profile/index.tsx:469
+#: src/routes/settings/profile/index.tsx:485
 msgid "The two new password fields don't match."
 msgstr "The two new password fields don't match."
 
-#: src/routes/settings/profile/index.tsx:285
+#: src/routes/settings/profile/index.tsx:301
 msgid "The two password fields don't match."
 msgstr "The two password fields don't match."
 
@@ -2789,6 +2884,10 @@ msgstr "The workspace your CRM data lives in."
 #: src/components/shared/status-badge.tsx:41
 msgid "They replied — keep the thread warm"
 msgstr "They replied — keep the thread warm"
+
+#: src/routes/settings/mcp/connections.tsx:82
+msgid "This connection now acts in the chosen organization."
+msgstr "This connection now acts in the chosen organization."
 
 #: src/routes/accept-invitation.$id.tsx:193
 msgid "This invitation can't be accepted"
@@ -2814,6 +2913,10 @@ msgstr "This link is no longer valid"
 #: src/routes/settings/organization/spend.tsx:134
 msgid "This month"
 msgstr "This month"
+
+#: src/routes/oauth/consent.tsx:83
+msgid "This page opens when an AI assistant asks to connect. Start the connection from your assistant."
+msgstr "This page opens when an AI assistant asks to connect. Start the connection from your assistant."
 
 #: src/routes/index.tsx:420
 #: src/routes/tasks/index.tsx:474
@@ -2858,7 +2961,7 @@ msgstr "To"
 msgid "Today"
 msgstr "Today"
 
-#: src/routes/login.tsx:133
+#: src/routes/login.tsx:146
 msgid "Too many attempts. Try again in a minute."
 msgstr "Too many attempts. Try again in a minute."
 
@@ -2895,13 +2998,18 @@ msgstr "unknown"
 msgid "Unknown"
 msgstr "Unknown"
 
-#: src/routes/settings/profile/index.tsx:87
+#: src/routes/settings/profile/index.tsx:94
 msgid "Unknown user"
 msgstr "Unknown user"
 
 #: src/routes/emails/$threadId.tsx:475
 msgid "Unlinked"
 msgstr "Unlinked"
+
+#: src/routes/settings/mcp/connections.tsx:146
+#: src/routes/settings/mcp/connections.tsx:171
+msgid "Unnamed client"
+msgstr "Unnamed client"
 
 #: src/routes/emails/index.tsx:1397
 msgid "Untitled"
@@ -2937,7 +3045,7 @@ msgstr "Uploading…"
 msgid "Use {0} as primary"
 msgstr "Use {0} as primary"
 
-#: src/routes/login.tsx:492
+#: src/routes/login.tsx:531
 msgid "Use a different email"
 msgstr "Use a different email"
 
@@ -2949,7 +3057,7 @@ msgstr "Use as default footer"
 msgid "Use as default for this purpose"
 msgstr "Use as default for this purpose"
 
-#: src/routes/login.tsx:499
+#: src/routes/login.tsx:538
 msgid "Use password instead"
 msgstr "Use password instead"
 
@@ -2974,15 +3082,15 @@ msgstr "Views"
 msgid "Visit"
 msgstr "Visit"
 
-#: src/routes/login.tsx:143
+#: src/routes/login.tsx:157
 msgid "We couldn't sign you in via that link. Try again."
 msgstr "We couldn't sign you in via that link. Try again."
 
-#: src/routes/login.tsx:140
+#: src/routes/login.tsx:154
 msgid "We don't recognize that email. Ask an admin to invite you."
 msgstr "We don't recognize that email. Ask an admin to invite you."
 
-#: src/routes/login.tsx:445
+#: src/routes/login.tsx:484
 msgid "We sent a sign-in link to"
 msgstr "We sent a sign-in link to"
 
@@ -3046,7 +3154,7 @@ msgstr "Write footer…"
 msgid "Write your message…"
 msgstr "Write your message…"
 
-#: src/routes/settings/profile/index.tsx:244
+#: src/routes/settings/profile/index.tsx:260
 msgid "You currently sign in from email links. Add a password to skip checking your email next time."
 msgstr "You currently sign in from email links. Add a password to skip checking your email next time."
 
@@ -3058,7 +3166,11 @@ msgstr "You don't have permission to see this page."
 msgid "You got in from a link in your email."
 msgstr "You got in from a link in your email."
 
-#: src/routes/settings/profile/index.tsx:341
+#: src/routes/settings/mcp/connections.tsx:90
+msgid "You may not be a member of that organization. Try again."
+msgstr "You may not be a member of that organization. Try again."
+
+#: src/routes/settings/profile/index.tsx:357
 msgid "You sign in from email links. I won't bring it up again."
 msgstr "You sign in from email links. I won't bring it up again."
 
@@ -3074,11 +3186,15 @@ msgstr "You're now a member."
 msgid "you@example.com"
 msgstr "you@example.com"
 
-#: src/routes/settings/profile/index.tsx:97
+#: src/routes/settings/profile/index.tsx:104
 msgid "Your Batuda workbench identity."
 msgstr "Your Batuda workbench identity."
 
-#: src/routes/login.tsx:135
+#: src/routes/settings/mcp/connections.tsx:122
+msgid "Your connections"
+msgstr "Your connections"
+
+#: src/routes/login.tsx:148
 msgid "Your email isn't verified yet. Use the magic link instead."
 msgstr "Your email isn't verified yet. Use the magic link instead."
 

--- a/apps/internal/src/routeTree.gen.ts
+++ b/apps/internal/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as CompaniesIndexRouteImport } from './routes/companies/index'
 import { Route as CalendarIndexRouteImport } from './routes/calendar/index'
 import { Route as ResearchIdRouteImport } from './routes/research/$id'
 import { Route as PagesIdRouteImport } from './routes/pages/$id'
+import { Route as OauthConsentRouteImport } from './routes/oauth/consent'
 import { Route as EmailsInboxesRouteImport } from './routes/emails/inboxes'
 import { Route as EmailsThreadIdRouteImport } from './routes/emails/$threadId'
 import { Route as CompaniesSlugRouteImport } from './routes/companies/$slug'
@@ -32,6 +33,7 @@ import { Route as SettingsApiKeysIndexRouteImport } from './routes/settings/api-
 import { Route as SettingsOrganizationSpendRouteImport } from './routes/settings/organization/spend'
 import { Route as SettingsOrganizationMembersRouteImport } from './routes/settings/organization/members'
 import { Route as SettingsOrganizationInviteRouteImport } from './routes/settings/organization/invite'
+import { Route as SettingsMcpConnectionsRouteImport } from './routes/settings/mcp/connections'
 
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
@@ -98,6 +100,11 @@ const PagesIdRoute = PagesIdRouteImport.update({
   path: '/pages/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OauthConsentRoute = OauthConsentRouteImport.update({
+  id: '/oauth/consent',
+  path: '/oauth/consent',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const EmailsInboxesRoute = EmailsInboxesRouteImport.update({
   id: '/emails/inboxes',
   path: '/emails/inboxes',
@@ -152,6 +159,11 @@ const SettingsOrganizationInviteRoute =
     path: '/settings/organization/invite',
     getParentRoute: () => rootRouteImport,
   } as any)
+const SettingsMcpConnectionsRoute = SettingsMcpConnectionsRouteImport.update({
+  id: '/settings/mcp/connections',
+  path: '/settings/mcp/connections',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -162,6 +174,7 @@ export interface FileRoutesByFullPath {
   '/companies/$slug': typeof CompaniesSlugRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
   '/emails/inboxes': typeof EmailsInboxesRoute
+  '/oauth/consent': typeof OauthConsentRoute
   '/pages/$id': typeof PagesIdRoute
   '/research/$id': typeof ResearchIdRoute
   '/calendar/': typeof CalendarIndexRoute
@@ -171,6 +184,7 @@ export interface FileRoutesByFullPath {
   '/profile/': typeof ProfileIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/tasks/': typeof TasksIndexRoute
+  '/settings/mcp/connections': typeof SettingsMcpConnectionsRoute
   '/settings/organization/invite': typeof SettingsOrganizationInviteRoute
   '/settings/organization/members': typeof SettingsOrganizationMembersRoute
   '/settings/organization/spend': typeof SettingsOrganizationSpendRoute
@@ -187,6 +201,7 @@ export interface FileRoutesByTo {
   '/companies/$slug': typeof CompaniesSlugRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
   '/emails/inboxes': typeof EmailsInboxesRoute
+  '/oauth/consent': typeof OauthConsentRoute
   '/pages/$id': typeof PagesIdRoute
   '/research/$id': typeof ResearchIdRoute
   '/calendar': typeof CalendarIndexRoute
@@ -196,6 +211,7 @@ export interface FileRoutesByTo {
   '/profile': typeof ProfileIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/tasks': typeof TasksIndexRoute
+  '/settings/mcp/connections': typeof SettingsMcpConnectionsRoute
   '/settings/organization/invite': typeof SettingsOrganizationInviteRoute
   '/settings/organization/members': typeof SettingsOrganizationMembersRoute
   '/settings/organization/spend': typeof SettingsOrganizationSpendRoute
@@ -213,6 +229,7 @@ export interface FileRoutesById {
   '/companies/$slug': typeof CompaniesSlugRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
   '/emails/inboxes': typeof EmailsInboxesRoute
+  '/oauth/consent': typeof OauthConsentRoute
   '/pages/$id': typeof PagesIdRoute
   '/research/$id': typeof ResearchIdRoute
   '/calendar/': typeof CalendarIndexRoute
@@ -222,6 +239,7 @@ export interface FileRoutesById {
   '/profile/': typeof ProfileIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/tasks/': typeof TasksIndexRoute
+  '/settings/mcp/connections': typeof SettingsMcpConnectionsRoute
   '/settings/organization/invite': typeof SettingsOrganizationInviteRoute
   '/settings/organization/members': typeof SettingsOrganizationMembersRoute
   '/settings/organization/spend': typeof SettingsOrganizationSpendRoute
@@ -240,6 +258,7 @@ export interface FileRouteTypes {
     | '/companies/$slug'
     | '/emails/$threadId'
     | '/emails/inboxes'
+    | '/oauth/consent'
     | '/pages/$id'
     | '/research/$id'
     | '/calendar/'
@@ -249,6 +268,7 @@ export interface FileRouteTypes {
     | '/profile/'
     | '/settings/'
     | '/tasks/'
+    | '/settings/mcp/connections'
     | '/settings/organization/invite'
     | '/settings/organization/members'
     | '/settings/organization/spend'
@@ -265,6 +285,7 @@ export interface FileRouteTypes {
     | '/companies/$slug'
     | '/emails/$threadId'
     | '/emails/inboxes'
+    | '/oauth/consent'
     | '/pages/$id'
     | '/research/$id'
     | '/calendar'
@@ -274,6 +295,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/settings'
     | '/tasks'
+    | '/settings/mcp/connections'
     | '/settings/organization/invite'
     | '/settings/organization/members'
     | '/settings/organization/spend'
@@ -290,6 +312,7 @@ export interface FileRouteTypes {
     | '/companies/$slug'
     | '/emails/$threadId'
     | '/emails/inboxes'
+    | '/oauth/consent'
     | '/pages/$id'
     | '/research/$id'
     | '/calendar/'
@@ -299,6 +322,7 @@ export interface FileRouteTypes {
     | '/profile/'
     | '/settings/'
     | '/tasks/'
+    | '/settings/mcp/connections'
     | '/settings/organization/invite'
     | '/settings/organization/members'
     | '/settings/organization/spend'
@@ -316,6 +340,7 @@ export interface RootRouteChildren {
   CompaniesSlugRoute: typeof CompaniesSlugRoute
   EmailsThreadIdRoute: typeof EmailsThreadIdRoute
   EmailsInboxesRoute: typeof EmailsInboxesRoute
+  OauthConsentRoute: typeof OauthConsentRoute
   PagesIdRoute: typeof PagesIdRoute
   ResearchIdRoute: typeof ResearchIdRoute
   CalendarIndexRoute: typeof CalendarIndexRoute
@@ -325,6 +350,7 @@ export interface RootRouteChildren {
   ProfileIndexRoute: typeof ProfileIndexRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
   TasksIndexRoute: typeof TasksIndexRoute
+  SettingsMcpConnectionsRoute: typeof SettingsMcpConnectionsRoute
   SettingsOrganizationInviteRoute: typeof SettingsOrganizationInviteRoute
   SettingsOrganizationMembersRoute: typeof SettingsOrganizationMembersRoute
   SettingsOrganizationSpendRoute: typeof SettingsOrganizationSpendRoute
@@ -426,6 +452,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PagesIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/oauth/consent': {
+      id: '/oauth/consent'
+      path: '/oauth/consent'
+      fullPath: '/oauth/consent'
+      preLoaderRoute: typeof OauthConsentRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/emails/inboxes': {
       id: '/emails/inboxes'
       path: '/emails/inboxes'
@@ -496,6 +529,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsOrganizationInviteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/settings/mcp/connections': {
+      id: '/settings/mcp/connections'
+      path: '/settings/mcp/connections'
+      fullPath: '/settings/mcp/connections'
+      preLoaderRoute: typeof SettingsMcpConnectionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -508,6 +548,7 @@ const rootRouteChildren: RootRouteChildren = {
   CompaniesSlugRoute: CompaniesSlugRoute,
   EmailsThreadIdRoute: EmailsThreadIdRoute,
   EmailsInboxesRoute: EmailsInboxesRoute,
+  OauthConsentRoute: OauthConsentRoute,
   PagesIdRoute: PagesIdRoute,
   ResearchIdRoute: ResearchIdRoute,
   CalendarIndexRoute: CalendarIndexRoute,
@@ -517,6 +558,7 @@ const rootRouteChildren: RootRouteChildren = {
   ProfileIndexRoute: ProfileIndexRoute,
   SettingsIndexRoute: SettingsIndexRoute,
   TasksIndexRoute: TasksIndexRoute,
+  SettingsMcpConnectionsRoute: SettingsMcpConnectionsRoute,
   SettingsOrganizationInviteRoute: SettingsOrganizationInviteRoute,
   SettingsOrganizationMembersRoute: SettingsOrganizationMembersRoute,
   SettingsOrganizationSpendRoute: SettingsOrganizationSpendRoute,

--- a/apps/internal/src/routes/__root.tsx
+++ b/apps/internal/src/routes/__root.tsx
@@ -158,7 +158,10 @@ function RootComponent() {
 		location.pathname === '/login' ||
 		location.pathname === '/forgot-password' ||
 		location.pathname === '/reset-password' ||
-		location.pathname.startsWith('/accept-invitation/')
+		location.pathname.startsWith('/accept-invitation/') ||
+		// The OAuth consent screen runs mid-flow (authed, but handing access to
+		// an MCP client) — render it focused, without the org-aware chrome.
+		location.pathname === '/oauth/consent'
 
 	// Tell any stale `/login` tab (left on the "Check your inbox" panel
 	// after a cross-tab magic-link verify) to navigate off. Listener lives

--- a/apps/internal/src/routes/login.tsx
+++ b/apps/internal/src/routes/login.tsx
@@ -33,6 +33,19 @@ function isSafeReturnTo(value: string): boolean {
 const safeReturnTo = (value: string | undefined): string =>
 	value && isSafeReturnTo(value) ? value : '/'
 
+/**
+ * The connection request in the URL when an AI assistant (ChatGPT, Claude.ai)
+ * sent the user here to sign in — otherwise empty. Read straight from the URL
+ * because it's signed, and the router's parsed search would drop the parts the
+ * signature covers. The `sig` marker tells a real request from a hand-typed URL.
+ */
+function pendingOAuthQuery(): string {
+	if (typeof window === 'undefined') return ''
+	const raw = window.location.search.replace(/^\?/, '')
+	const params = new URLSearchParams(raw)
+	return params.has('client_id') && params.has('sig') ? raw : ''
+}
+
 // Cross-tab sign-in coordination channel: when the magic-link verify
 // endpoint lands the user in a fresh tab, we broadcast so the original
 // `/login` tab can navigate off the stale "Check your inbox" panel.
@@ -134,6 +147,7 @@ const MESSAGES = {
 	invalidCredentials: msg`Email or password is incorrect.`,
 	emailNotVerified: msg`Your email isn't verified yet. Use the magic link instead.`,
 	passwordFallback: msg`Could not sign in. Check your email and password.`,
+	oauthRestart: msg`That connection request expired. Start it again from your AI assistant.`,
 	magicLinkFallback: msg`Could not send the link. Try again in a few seconds.`,
 	network: msg`No connection to the server. Try again in a few seconds.`,
 	enterValidEmail: msg`Enter a valid email above first.`,
@@ -167,15 +181,27 @@ function LoginPage() {
 		async (_previous, formData) => {
 			const email = normalizeEmail(String(formData.get('email') ?? ''))
 			const password = String(formData.get('password') ?? '')
+			// If an AI assistant sent the user here to connect, send its request
+			// along with the sign-in so the server can carry on once they're in.
+			const oauthQuery = pendingOAuthQuery()
 			try {
 				const response = await fetch(`${apiBaseUrl()}/auth/sign-in/email`, {
 					method: 'POST',
 					credentials: 'include',
 					headers: { 'content-type': 'application/json' },
-					body: JSON.stringify({ email, password }),
+					body: JSON.stringify(
+						oauthQuery
+							? { email, password, oauth_query: oauthQuery }
+							: { email, password },
+					),
 				})
 				if (!response.ok) {
 					const body = (await response.json().catch(() => null)) as ErrorBody
+					// The credentials were fine; the connection request itself
+					// lapsed. Send them back to the assistant, not to "wrong password".
+					if (oauthQuery && isOAuthQueryError(body)) {
+						return { error: t(MESSAGES.oauthRestart) }
+					}
 					const key = passwordErrorKey(body, response.status)
 					// Known codes have curated copy; unknowns defer to Better-Auth's
 					// already-localized `message` and only then to our generic string.
@@ -184,6 +210,19 @@ function LoginPage() {
 							? (body?.message ?? t(MESSAGES.passwordFallback))
 							: t(MESSAGES[key])
 					return { error }
+				}
+				// The server replies with where to send the browser next — the
+				// consent screen, or back to the assistant. Go there, not into
+				// the app.
+				if (oauthQuery) {
+					const body = (await response.json().catch(() => null)) as {
+						url?: string
+					} | null
+					if (body?.url) {
+						window.location.assign(body.url)
+						return { error: null }
+					}
+					// No next URL came back — they're signed in, so just enter the app.
 				}
 				// Success — cookie is on the response. Navigate to the
 				// originally requested URL (or `/`); the root's beforeLoad
@@ -509,7 +548,13 @@ function InboxView({
 // Shape of Better-Auth's error responses. The literal return-type unions on
 // the helpers below are load-bearing: they let the call-site narrow against
 // `MESSAGES` and let TS catch a missing key the moment one is added here.
-type ErrorBody = { code?: string; message?: string } | null
+type ErrorBody = { code?: string; message?: string; error?: string } | null
+
+// A forwarded authorize query that's expired or tampered fails sign-in with
+// this code (not a credential error), so the user can be pointed back to their
+// assistant instead of being told their password is wrong.
+const isOAuthQueryError = (body: ErrorBody): boolean =>
+	body?.error === 'invalid_signature' || body?.code === 'invalid_signature'
 
 // HTTP 429 short-circuits the body — Better-Auth's rate-limit response has
 // no `code`, so status has to be checked before `body.code`.

--- a/apps/internal/src/routes/oauth/consent.tsx
+++ b/apps/internal/src/routes/oauth/consent.tsx
@@ -1,0 +1,281 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { KeyRound } from 'lucide-react'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { PriButton } from '@batuda/ui/pri'
+
+import { apiBaseUrl } from '#/lib/api-base'
+import { agedPaperSurface, stenciledTitle } from '#/lib/workshop-mixins'
+
+/**
+ * Consent screen an AI assistant is sent to before it may connect. Approving
+ * sends the request back to the server, which replies with where to send the
+ * browser next — back to the assistant, now connected. The request is read
+ * straight from the URL, untouched: it is signed, so any edit (even reordering)
+ * would void it, and the router's parsed search would drop parts of it.
+ */
+
+export const Route = createFileRoute('/oauth/consent')({
+	validateSearch: (
+		search: Record<string, unknown>,
+	): { readonly client_id: string; readonly scope: string } => ({
+		client_id:
+			typeof search['client_id'] === 'string' ? search['client_id'] : '',
+		scope: typeof search['scope'] === 'string' ? search['scope'] : '',
+	}),
+	head: () => ({ meta: [{ title: 'Authorize — Batuda' }] }),
+	component: ConsentPage,
+})
+
+function ConsentPage() {
+	const { t } = useLingui()
+	const { client_id, scope } = Route.useSearch()
+	const [submitting, setSubmitting] = useState<'allow' | 'deny' | null>(null)
+	const [error, setError] = useState<string | null>(null)
+
+	const scopes = scope.split(' ').filter(Boolean)
+
+	const respond = async (accept: boolean) => {
+		setSubmitting(accept ? 'allow' : 'deny')
+		setError(null)
+		try {
+			const res = await fetch(`${apiBaseUrl()}/auth/oauth2/consent`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					accept,
+					oauth_query: window.location.search.replace(/^\?/, ''),
+				}),
+			})
+			if (!res.ok) {
+				setSubmitting(null)
+				setError(
+					t`Something went wrong. Start the connection again from your assistant.`,
+				)
+				return
+			}
+			const data = (await res.json()) as { url?: string }
+			if (data.url) {
+				// Send the browser back to the assistant — connected, or
+				// told it was declined.
+				window.location.assign(data.url)
+				return
+			}
+			setSubmitting(null)
+			setError(t`Could not complete the connection. Please try again.`)
+		} catch {
+			setSubmitting(null)
+			setError(t`No connection to the server. Try again in a few seconds.`)
+		}
+	}
+
+	if (!client_id) {
+		return (
+			<Page>
+				<Card>
+					<Title>
+						<Trans>Nothing to authorize</Trans>
+					</Title>
+					<Body>
+						<Trans>
+							This page opens when an AI assistant asks to connect. Start the
+							connection from your assistant.
+						</Trans>
+					</Body>
+					<Actions>
+						<PriButton
+							type='button'
+							$variant='text'
+							render={props => (
+								<Link to='/settings/mcp/connections' {...props} />
+							)}
+						>
+							<Trans>Go to connections</Trans>
+						</PriButton>
+					</Actions>
+				</Card>
+			</Page>
+		)
+	}
+
+	return (
+		<Page>
+			<Card data-testid='oauth-consent'>
+				<Bezel aria-hidden>
+					<KeyRound size={20} />
+				</Bezel>
+				<Title>
+					<Trans>Connect to Batuda?</Trans>
+				</Title>
+				<Body>
+					<Trans>
+						An AI assistant wants to connect to your Batuda account over MCP and
+						act on your behalf. Only approve assistants you trust.
+					</Trans>
+				</Body>
+				<Client>
+					<ClientLabel>
+						<Trans>Client</Trans>
+					</ClientLabel>
+					<ClientId data-testid='oauth-consent-client'>{client_id}</ClientId>
+				</Client>
+				{scopes.length > 0 ? (
+					<Scopes>
+						<ClientLabel>
+							<Trans>Access</Trans>
+						</ClientLabel>
+						<ScopeList>
+							{scopes.map(s => (
+								<ScopeItem key={s}>{s}</ScopeItem>
+							))}
+						</ScopeList>
+					</Scopes>
+				) : null}
+				{error ? (
+					<ErrorText role='alert' data-testid='oauth-consent-error'>
+						{error}
+					</ErrorText>
+				) : null}
+				<Actions>
+					<PriButton
+						type='button'
+						$variant='text'
+						disabled={submitting !== null}
+						data-testid='oauth-consent-deny'
+						onClick={() => {
+							void respond(false)
+						}}
+					>
+						{submitting === 'deny' ? t`Cancelling…` : t`Deny`}
+					</PriButton>
+					<PriButton
+						type='button'
+						$variant='filled'
+						disabled={submitting !== null}
+						data-testid='oauth-consent-allow'
+						onClick={() => {
+							void respond(true)
+						}}
+					>
+						{submitting === 'allow' ? t`Connecting…` : t`Allow`}
+					</PriButton>
+				</Actions>
+			</Card>
+		</Page>
+	)
+}
+
+const Page = styled.div.withConfig({ displayName: 'ConsentPage' })`
+	min-height: 100dvh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--space-lg);
+`
+
+const Card = styled.div.withConfig({ displayName: 'ConsentCard' })`
+	${agedPaperSurface}
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+	width: 100%;
+	max-width: 28rem;
+	padding: var(--space-xl);
+	border-radius: var(--shape-xs);
+	color: var(--color-on-surface);
+`
+
+const Bezel = styled.span.withConfig({ displayName: 'ConsentBezel' })`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: var(--shape-full);
+	background: color-mix(in oklab, var(--color-primary) 14%, transparent);
+	color: var(--color-primary);
+`
+
+const Title = styled.h1.withConfig({ displayName: 'ConsentTitle' })`
+	${stenciledTitle}
+	font-size: var(--typescale-headline-small-size);
+	line-height: var(--typescale-headline-small-line);
+	margin: 0;
+`
+
+const Body = styled.p.withConfig({ displayName: 'ConsentBody' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	line-height: var(--typescale-body-medium-line);
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const Client = styled.div.withConfig({ displayName: 'ConsentClient' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+`
+
+const ClientLabel = styled.span.withConfig({
+	displayName: 'ConsentClientLabel',
+})`
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-on-surface-variant);
+`
+
+const ClientId = styled.code.withConfig({ displayName: 'ConsentClientId' })`
+	font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface);
+	word-break: break-all;
+`
+
+const Scopes = styled.div.withConfig({ displayName: 'ConsentScopes' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const ScopeList = styled.ul.withConfig({ displayName: 'ConsentScopeList' })`
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2xs);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+`
+
+const ScopeItem = styled.li.withConfig({ displayName: 'ConsentScopeItem' })`
+	font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+	font-size: var(--typescale-label-small-size);
+	padding: var(--space-3xs) var(--space-2xs);
+	border-radius: var(--shape-3xs);
+	background: color-mix(in oklab, var(--color-on-surface) 8%, transparent);
+	color: var(--color-on-surface);
+`
+
+const ErrorText = styled.p.withConfig({ displayName: 'ConsentError' })`
+	margin: 0;
+	padding: var(--space-2xs) var(--space-sm);
+	border-left: 3px solid var(--color-error);
+	background: color-mix(in srgb, var(--color-error) 6%, transparent);
+	color: var(--color-error);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+`
+
+const Actions = styled.div.withConfig({ displayName: 'ConsentActions' })`
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--space-sm);
+	flex-wrap: wrap;
+`

--- a/apps/internal/src/routes/settings/mcp/connections.tsx
+++ b/apps/internal/src/routes/settings/mcp/connections.tsx
@@ -1,0 +1,387 @@
+import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { AsyncResult } from 'effect/unstable/reactivity'
+import { ArrowLeft, Check, ChevronsUpDown, Plug } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import styled from 'styled-components'
+
+import { PriSelect, usePriToast } from '@batuda/ui/pri'
+
+import { authClient } from '#/lib/auth-client'
+import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+import {
+	brushedMetalPlate,
+	rulerUnderRule,
+	stenciledTitle,
+} from '#/lib/workshop-mixins'
+
+/**
+ * The AI assistants (ChatGPT, Claude.ai, …) a member has connected over MCP.
+ * Belong to one organization and you never need this page — a connection just
+ * acts in that org. Belong to several and you pick which org each assistant
+ * acts in here; that choice is re-checked on every request it makes.
+ */
+
+type Connection = {
+	readonly clientId: string
+	readonly name: string | null
+	readonly createdAt: string
+	readonly organizationId: string | null
+}
+
+const connectionsAtom = BatudaApiAtom.query('mcpOAuth', 'listConnections', {})
+
+export const Route = createFileRoute('/settings/mcp/connections')({
+	head: () => ({ meta: [{ title: 'MCP connections — Batuda' }] }),
+	component: ConnectionsPage,
+})
+
+function ConnectionsPage() {
+	const { t } = useLingui()
+	const toastManager = usePriToast()
+
+	const listResult = useAtomValue(connectionsAtom)
+	const refreshList = useAtomRefresh(connectionsAtom)
+	const selectOrg = useAtomSet(
+		BatudaApiAtom.mutation('mcpOAuth', 'selectOrg'),
+		{
+			mode: 'promiseExit',
+		},
+	)
+
+	const orgs = authClient.useListOrganizations()
+	const orgOptions = useMemo(
+		() => (orgs.data ?? []).map(o => ({ value: o.id, label: o.name })),
+		[orgs.data],
+	)
+
+	// The connection currently being saved, so its picker can disable until
+	// the save finishes and a second pick can't race it.
+	const [savingId, setSavingId] = useState<string | null>(null)
+
+	const rows = useMemo<ReadonlyArray<Connection>>(
+		() =>
+			AsyncResult.isSuccess(listResult)
+				? narrowConnections(listResult.value)
+				: [],
+		[listResult],
+	)
+	const isLoading = AsyncResult.isInitial(listResult)
+	const isFailure = AsyncResult.isFailure(listResult)
+
+	const handleSelect = async (clientId: string, organizationId: string) => {
+		setSavingId(clientId)
+		try {
+			const exit = await selectOrg({
+				payload: { clientId, organizationId },
+			} as never)
+			if (exit._tag === 'Success') {
+				toastManager.add({
+					title: t`Organization updated`,
+					description: t`This connection now acts in the chosen organization.`,
+					type: 'success',
+				})
+				refreshList()
+				return
+			}
+			toastManager.add({
+				title: t`Could not update`,
+				description: t`You may not be a member of that organization. Try again.`,
+				type: 'error',
+			})
+		} finally {
+			setSavingId(null)
+		}
+	}
+
+	return (
+		<Page>
+			<BackLink to='/settings' aria-label={t`Back to settings`}>
+				<ArrowLeft size={14} aria-hidden />
+				<span>
+					<Trans>Settings</Trans>
+				</span>
+			</BackLink>
+
+			<Intro>
+				<Heading>
+					<Plug size={20} aria-hidden />
+					<Trans>MCP connections</Trans>
+				</Heading>
+				<Subtitle>
+					<Trans>
+						AI assistants you've connected over MCP. Choose which organization
+						each one acts in.
+					</Trans>
+				</Subtitle>
+			</Intro>
+
+			<ListSection>
+				<SectionTitle>
+					<Trans>Your connections</Trans>
+				</SectionTitle>
+				{isLoading ? (
+					<Empty>
+						<Trans>Loading…</Trans>
+					</Empty>
+				) : isFailure ? (
+					<Empty role='alert'>
+						<Trans>
+							Could not load your connections. Refresh to try again.
+						</Trans>
+					</Empty>
+				) : rows.length === 0 ? (
+					<Empty data-testid='mcp-connections-empty'>
+						<Trans>
+							No connections yet. Add this server in your AI assistant and
+							authorize it, then it appears here.
+						</Trans>
+					</Empty>
+				) : (
+					<ConnList>
+						{rows.map(row => (
+							<ConnRow key={row.clientId} data-testid='mcp-connection-row'>
+								<ConnInfo>
+									<ConnName>{row.name ?? t`Unnamed client`}</ConnName>
+									<ConnMeta>
+										<Trans>Connected {formatDate(row.createdAt)}</Trans>
+									</ConnMeta>
+								</ConnInfo>
+								<PriSelect.Root
+									items={orgOptions}
+									value={row.organizationId ?? ''}
+									onValueChange={(value: string | null) => {
+										// Skip an empty, unchanged, or still-saving pick, so we
+										// never save the same choice twice.
+										if (
+											value &&
+											value !== row.organizationId &&
+											savingId !== row.clientId
+										) {
+											void handleSelect(row.clientId, value)
+										}
+									}}
+									disabled={
+										orgOptions.length === 0 || savingId === row.clientId
+									}
+								>
+									<SelectTrigger
+										data-testid='mcp-connection-org'
+										aria-label={t`Organization for ${row.name ?? t`Unnamed client`}`}
+									>
+										<PriSelect.Value>
+											{orgLabel(orgOptions, row.organizationId) ??
+												t`Choose organization`}
+										</PriSelect.Value>
+										<PriSelect.Icon>
+											<ChevronsUpDown size={12} aria-hidden />
+										</PriSelect.Icon>
+									</SelectTrigger>
+									<PriSelect.Portal>
+										<PriSelect.Positioner
+											alignItemWithTrigger={false}
+											sideOffset={6}
+										>
+											<PriSelect.Popup>
+												<PriSelect.List>
+													{orgOptions.map(opt => (
+														<PriSelect.Item key={opt.value} value={opt.value}>
+															<PriSelect.ItemIndicator>
+																<Check size={12} />
+															</PriSelect.ItemIndicator>
+															<PriSelect.ItemText>
+																{opt.label}
+															</PriSelect.ItemText>
+														</PriSelect.Item>
+													))}
+												</PriSelect.List>
+											</PriSelect.Popup>
+										</PriSelect.Positioner>
+									</PriSelect.Portal>
+								</PriSelect.Root>
+							</ConnRow>
+						))}
+					</ConnList>
+				)}
+			</ListSection>
+		</Page>
+	)
+}
+
+function narrowConnections(
+	rows: ReadonlyArray<unknown>,
+): ReadonlyArray<Connection> {
+	const out: Array<Connection> = []
+	for (const row of rows) {
+		if (!row || typeof row !== 'object') continue
+		const r = row as Record<string, unknown>
+		const clientId = typeof r['clientId'] === 'string' ? r['clientId'] : null
+		const createdAt = typeof r['createdAt'] === 'string' ? r['createdAt'] : null
+		if (clientId === null || createdAt === null) continue
+		out.push({
+			clientId,
+			createdAt,
+			name: typeof r['name'] === 'string' ? r['name'] : null,
+			organizationId:
+				typeof r['organizationId'] === 'string' ? r['organizationId'] : null,
+		})
+	}
+	return out
+}
+
+const orgLabel = (
+	options: ReadonlyArray<{ value: string; label: string }>,
+	organizationId: string | null,
+): string | null =>
+	organizationId === null
+		? null
+		: (options.find(o => o.value === organizationId)?.label ?? null)
+
+function formatDate(iso: string): string {
+	const date = new Date(iso)
+	if (Number.isNaN(date.getTime())) return iso
+	return date.toLocaleDateString(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	})
+}
+
+const Page = styled.div.withConfig({ displayName: 'McpConnectionsPage' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
+`
+
+const BackLink = styled(Link).withConfig({ displayName: 'McpConnBackLink' })`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	text-decoration: none;
+	width: fit-content;
+
+	&:hover {
+		color: var(--color-primary);
+	}
+`
+
+const Intro = styled.div.withConfig({ displayName: 'McpConnIntro' })`
+	${rulerUnderRule}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	padding-bottom: var(--space-xs);
+`
+
+const Heading = styled.h2.withConfig({ displayName: 'McpConnHeading' })`
+	${stenciledTitle}
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-size: var(--typescale-headline-large-size);
+	line-height: var(--typescale-headline-large-line);
+	margin: 0;
+`
+
+const Subtitle = styled.p.withConfig({ displayName: 'McpConnSubtitle' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-large-size);
+	line-height: var(--typescale-body-large-line);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const ListSection = styled.section.withConfig({ displayName: 'McpConnList' })`
+	${brushedMetalPlate}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+	padding: var(--space-md);
+	border-radius: var(--shape-2xs);
+`
+
+const SectionTitle = styled.h3.withConfig({
+	displayName: 'McpConnSectionTitle',
+})`
+	${stenciledTitle}
+	font-size: var(--typescale-title-medium-size);
+	line-height: var(--typescale-title-medium-line);
+	margin: 0;
+`
+
+const Empty = styled.p.withConfig({ displayName: 'McpConnEmpty' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const ConnList = styled.ul.withConfig({ displayName: 'McpConnRows' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+`
+
+const ConnRow = styled.li.withConfig({ displayName: 'McpConnRow' })`
+	display: flex;
+	align-items: center;
+	gap: var(--space-md);
+	flex-wrap: wrap;
+	padding: var(--space-sm) var(--space-md);
+	border-radius: var(--shape-3xs);
+	background: color-mix(in oklab, var(--color-on-surface) 4%, transparent);
+	border: 1px solid color-mix(in oklab, var(--color-on-surface) 10%, transparent);
+`
+
+const ConnInfo = styled.div.withConfig({ displayName: 'McpConnInfo' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	flex: 1;
+	min-width: 0;
+`
+
+const ConnName = styled.span.withConfig({ displayName: 'McpConnName' })`
+	${stenciledTitle}
+	font-size: var(--typescale-title-small-size);
+	overflow: hidden;
+	text-overflow: ellipsis;
+`
+
+const ConnMeta = styled.span.withConfig({ displayName: 'McpConnMeta' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const SelectTrigger = styled(PriSelect.Trigger).withConfig({
+	displayName: 'McpConnSelectTrigger',
+})`
+	display: inline-flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-2xs);
+	min-width: 12rem;
+	padding: var(--space-2xs) var(--space-sm);
+	border-radius: var(--shape-3xs);
+	border: 1px solid var(--color-outline);
+	background: var(--color-surface);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface);
+	cursor: pointer;
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+`

--- a/apps/internal/src/routes/settings/profile/index.tsx
+++ b/apps/internal/src/routes/settings/profile/index.tsx
@@ -5,7 +5,14 @@ import {
 	useNavigate,
 	useRouter,
 } from '@tanstack/react-router'
-import { Building2, KeyRound, LogOut, Mail, UserCircle2 } from 'lucide-react'
+import {
+	Building2,
+	KeyRound,
+	LogOut,
+	Mail,
+	Plug,
+	UserCircle2,
+} from 'lucide-react'
 import { useActionState, useRef, useState } from 'react'
 import styled from 'styled-components'
 
@@ -112,6 +119,15 @@ function ProfilePage() {
 					<KeyRound size={16} aria-hidden />
 					<span>
 						<Trans>API keys</Trans>
+					</span>
+				</NavRow>
+				<NavRow
+					to='/settings/mcp/connections'
+					data-testid='settings-nav-mcp-connections'
+				>
+					<Plug size={16} aria-hidden />
+					<span>
+						<Trans>Connections</Trans>
 					</span>
 				</NavRow>
 			</SettingsNav>

--- a/apps/internal/src/start.ts
+++ b/apps/internal/src/start.ts
@@ -1,0 +1,21 @@
+import { createMiddleware, createStart } from '@tanstack/react-start'
+import { setResponseHeader } from '@tanstack/react-start/server'
+
+/**
+ * App-wide server setup. The one job here is to tell every browser never to
+ * show a Batuda page inside a frame on another site. That's the standard guard
+ * against clickjacking — a hidden frame that tricks a signed-in person into
+ * clicking something they can't see, such as the "Allow" on the connect screen.
+ * Nothing in Batuda is meant to be embedded anywhere, so framing is denied
+ * outright, on every page (the modern header plus the legacy one older
+ * browsers still honour).
+ */
+const denyFraming = createMiddleware().server(async ({ next }) => {
+	setResponseHeader('Content-Security-Policy', "frame-ancestors 'none'")
+	setResponseHeader('X-Frame-Options', 'DENY')
+	return next()
+})
+
+export const startInstance = createStart(() => ({
+	requestMiddleware: [denyFraming],
+}))

--- a/apps/internal/tests/e2e/mcp-connections.test.ts
+++ b/apps/internal/tests/e2e/mcp-connections.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
+// The MCP OAuth UI: the connections settings page (where a member binds each
+// authorized AI client to an org) and the consent screen. The full OAuth dance
+// (a real client → authorize → login → consent → token) needs a live OAuth
+// client, so this covers the routing + the unauthenticated/empty states; the
+// happy-path consent flow is validated against the dev stack manually.
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/', { waitUntil: 'commit' })
+	await setActiveOrgBySlug(page, 'taller')
+})
+
+test.describe('settings — MCP connections', () => {
+	test('should reach the connections page from the settings nav and show the empty state', async ({
+		page,
+	}) => {
+		// GIVEN the Settings hub, which lands on the profile page
+		await page.goto('/settings', { waitUntil: 'networkidle' })
+		await expect(page).toHaveURL(/\/settings\/profile$/)
+
+		// WHEN she follows the Connections link
+		await page.getByTestId('settings-nav-mcp-connections').click()
+
+		// THEN the connections page loads and shows the empty state (no clients
+		// authorized yet)
+		await expect(page).toHaveURL(/\/settings\/mcp\/connections$/)
+		await expect(page.getByTestId('mcp-connections-empty')).toBeVisible()
+	})
+})
+
+test.describe('OAuth consent', () => {
+	test('should show nothing-to-authorize when opened without an authorize request', async ({
+		page,
+	}) => {
+		// GIVEN the consent route opened directly (no signed authorize query)
+		// WHEN it renders for the signed-in user
+		await page.goto('/oauth/consent', { waitUntil: 'networkidle' })
+
+		// THEN it explains there's nothing to authorize rather than a broken form
+		await expect(page.getByText(/nothing to authorize/i)).toBeVisible()
+	})
+})

--- a/apps/internal/tests/e2e/security-headers.test.ts
+++ b/apps/internal/tests/e2e/security-headers.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test'
+
+// The app-wide frame-deny guard (src/start.ts) has to ride on every rendered
+// document, so no other site can frame a Batuda page and trick a signed-in
+// person into a click. The OAuth consent screen is the highest-value target —
+// assert there, on a route that renders standalone without an active org.
+
+test.describe('security headers', () => {
+	test('should forbid other sites from framing a rendered page', async ({
+		page,
+	}) => {
+		// GIVEN any rendered document (the consent screen, a prime clickjacking
+		// target)
+		// WHEN it loads
+		const response = await page.goto('/oauth/consent', { waitUntil: 'commit' })
+
+		// THEN the response refuses framing from anywhere, via both the new and old headers
+		const headers = response?.headers() ?? {}
+		expect(headers['content-security-policy']).toContain(
+			"frame-ancestors 'none'",
+		)
+		expect(headers['x-frame-options']).toBe('DENY')
+	})
+})


### PR DESCRIPTION
Slice 2 of MCP OAuth: the web UI that lets chat connectors (ChatGPT, Claude.ai) — which can't send `x-api-key` — connect over OAuth 2.1. Server-side OAuth (Slice 1) is already on main.

## What's here
- **Consent screen** (`/oauth/consent`) — where an assistant is sent to be approved before it can act on the user's behalf.
- **Connections page** (`/settings/mcp/connections`) — where a member of several orgs binds each assistant to the org it acts in (re-checked against live membership on every call; in-flight lock + per-row label for screen readers).
- **OAuth continuation in sign-in** — forwards the signed authorize request through `/login` so the flow resumes after sign-in; an expired request now points the user back to their assistant instead of reading as a wrong password.
- **App-wide clickjacking guard** — `frame-ancestors 'none'` + `X-Frame-Options: DENY` on every rendered page via a TanStack Start request middleware, protecting the one-click consent "Allow".

## Verification
- `check-types`, `build`, Biome, and i18n (en + ca, 0 missing) all green.
- Playwright covers the connections nav + empty states and the consent no-request state; `security-headers.test.ts` asserts the frame-deny headers (also runtime-verified against a live dev `/login`).
- The full OAuth handshake needs a real external client (ChatGPT/Claude.ai) and is verified manually against the dev stack.

## Follow-ups (from the adversarial design review)
A server-side hardening PR follows: pin token verification to EdDSA, environment-aware token TTL/limits (permissive in dev), bind each token to its organization, and a real-JWKS contract test — then RLS on the OAuth tables and dynamic-client caps.