### PR TITLE
Harden MCP OAuth: RLS backstop on the OAuth tables + DCR cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ BETTER_AUTH_RATE_LIMIT=loose
 # MCP clients don't re-authorize mid-session while developing. Production
 # defaults short (a few minutes) — let it default by removing this line.
 OAUTH_ACCESS_TOKEN_TTL_SECONDS=86400
+# Days before an OAuth client with no consent is garbage-collected. Long here so
+# a client you register while testing isn't swept; production defaults short.
+OAUTH_CLIENT_GC_DAYS=365
 ALLOWED_ORIGINS=https://batuda.localhost
 # Canonical public app origin for the links the server mints (invitations).
 # Must be one of ALLOWED_ORIGINS — boot fails otherwise.

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -194,7 +194,7 @@ msgstr "Admin"
 msgid "Agent"
 msgstr "Agent"
 
-#: src/routes/settings/mcp/connections.tsx:113
+#: src/routes/settings/mcp/connections.tsx:114
 msgid "AI assistants you've connected over MCP. Choose which organization each one acts in."
 msgstr "Assistents d'IA que has connectat per MCP. Tria en quina organització actua cadascun."
 
@@ -296,7 +296,7 @@ msgid "Back to organization"
 msgstr "Tornar a l'organització"
 
 #: src/routes/settings/api-keys/index.tsx:187
-#: src/routes/settings/mcp/connections.tsx:100
+#: src/routes/settings/mcp/connections.tsx:101
 msgid "Back to settings"
 msgstr "Torna a la configuració"
 
@@ -465,7 +465,7 @@ msgstr "Comprova la sessió o torna-ho a provar."
 msgid "Check your inbox"
 msgstr "Mira la safata d'entrada"
 
-#: src/routes/settings/mcp/connections.tsx:175
+#: src/routes/settings/mcp/connections.tsx:181
 msgid "Choose organization"
 msgstr "Tria una organització"
 
@@ -620,7 +620,7 @@ msgid "Connected"
 msgstr "Connectada"
 
 #. placeholder {0}: formatDate(row.createdAt)
-#: src/routes/settings/mcp/connections.tsx:148
+#: src/routes/settings/mcp/connections.tsx:149
 msgid "Connected {0}"
 msgstr "Connectat {0}"
 
@@ -730,7 +730,7 @@ msgstr "No s'ha pogut carregar aquesta execució."
 msgid "Could not load threads"
 msgstr "No s'han pogut carregar els fils"
 
-#: src/routes/settings/mcp/connections.tsx:130
+#: src/routes/settings/mcp/connections.tsx:131
 msgid "Could not load your connections. Refresh to try again."
 msgstr "No s'han pogut carregar les connexions. Actualitza per tornar-ho a provar."
 
@@ -804,7 +804,7 @@ msgstr "No s'ha pogut canviar d'organització. Torna-ho a provar."
 msgid "Could not toggle the inbox state."
 msgstr "No s'ha pogut canviar l'estat de la safata."
 
-#: src/routes/settings/mcp/connections.tsx:89
+#: src/routes/settings/mcp/connections.tsx:90
 msgid "Could not update"
 msgstr "No s'ha pogut actualitzar"
 
@@ -1451,7 +1451,7 @@ msgstr "Carregant l'execució…"
 #: src/components/companies/upcoming-meetings-card.tsx:57
 #: src/components/shared/loading-spinner.tsx:23
 #: src/routes/settings/api-keys/index.tsx:266
-#: src/routes/settings/mcp/connections.tsx:126
+#: src/routes/settings/mcp/connections.tsx:127
 #: src/routes/settings/organization/index.tsx:52
 #: src/routes/settings/organization/members.tsx:113
 msgid "Loading…"
@@ -1572,7 +1572,7 @@ msgstr "Resum de mercat"
 msgid "Maturity"
 msgstr "Maduresa"
 
-#: src/routes/settings/mcp/connections.tsx:110
+#: src/routes/settings/mcp/connections.tsx:111
 msgid "MCP connections"
 msgstr "Connexions MCP"
 
@@ -1727,7 +1727,7 @@ msgstr "Encara no hi ha empreses"
 msgid "No connection to the server. Try again in a few seconds."
 msgstr "Sense connexió al servidor. Torna-ho a provar d'aquí a uns segons."
 
-#: src/routes/settings/mcp/connections.tsx:136
+#: src/routes/settings/mcp/connections.tsx:137
 msgid "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
 msgstr "Encara no hi ha connexions. Afegeix aquest servidor al teu assistent d'IA i autoritza'l; després apareixerà aquí."
 
@@ -1973,11 +1973,11 @@ msgid "Organization"
 msgstr "Organització"
 
 #. placeholder {0}: row.name ?? t`Unnamed client`
-#: src/routes/settings/mcp/connections.tsx:171
+#: src/routes/settings/mcp/connections.tsx:177
 msgid "Organization for {0}"
 msgstr "Organització per a {0}"
 
-#: src/routes/settings/mcp/connections.tsx:81
+#: src/routes/settings/mcp/connections.tsx:82
 msgid "Organization updated"
 msgstr "Organització actualitzada"
 
@@ -2492,6 +2492,15 @@ msgstr "Selecciona el fil {0}"
 msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 msgstr "Triar un preestablit omple els paràmetres IMAP i SMTP — encara els pots editar."
 
+#: src/routes/settings/mcp/connections.tsx:154
+msgid "Self-reported name"
+msgstr "Nom autodeclarat"
+
+#. placeholder {0}: row.redirectHost
+#: src/routes/settings/mcp/connections.tsx:153
+msgid "Self-reported name · sends you to {0}"
+msgstr "Nom autodeclarat · t'envia a {0}"
+
 #: src/components/emails/compose-form.tsx:534
 msgid "Send"
 msgstr "Envia"
@@ -2554,7 +2563,7 @@ msgstr "Posa contrasenya"
 #: src/components/layout/nav-items.ts:81
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
-#: src/routes/settings/mcp/connections.tsx:103
+#: src/routes/settings/mcp/connections.tsx:104
 #: src/routes/settings/profile/index.tsx:108
 msgid "Settings"
 msgstr "Configuració"
@@ -2885,7 +2894,7 @@ msgstr "L'espai de treball on viuen les dades del CRM."
 msgid "They replied — keep the thread warm"
 msgstr "Ha respost — manté el fil calent"
 
-#: src/routes/settings/mcp/connections.tsx:82
+#: src/routes/settings/mcp/connections.tsx:83
 msgid "This connection now acts in the chosen organization."
 msgstr "Aquesta connexió ara actua en l'organització triada."
 
@@ -3006,8 +3015,8 @@ msgstr "Usuari desconegut"
 msgid "Unlinked"
 msgstr "Sense enllaçar"
 
-#: src/routes/settings/mcp/connections.tsx:146
-#: src/routes/settings/mcp/connections.tsx:171
+#: src/routes/settings/mcp/connections.tsx:147
+#: src/routes/settings/mcp/connections.tsx:177
 msgid "Unnamed client"
 msgstr "Client sense nom"
 
@@ -3166,7 +3175,7 @@ msgstr "No tens permís per veure aquesta pàgina."
 msgid "You got in from a link in your email."
 msgstr "Has entrat des d'un enllaç al teu correu."
 
-#: src/routes/settings/mcp/connections.tsx:90
+#: src/routes/settings/mcp/connections.tsx:91
 msgid "You may not be a member of that organization. Try again."
 msgstr "Potser no ets membre d'aquesta organització. Torna-ho a provar."
 
@@ -3190,7 +3199,7 @@ msgstr "tu@exemple.com"
 msgid "Your Batuda workbench identity."
 msgstr "La teva identitat al banc de Batuda."
 
-#: src/routes/settings/mcp/connections.tsx:122
+#: src/routes/settings/mcp/connections.tsx:123
 msgid "Your connections"
 msgstr "Les teves connexions"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -194,7 +194,7 @@ msgstr "Admin"
 msgid "Agent"
 msgstr "Agent"
 
-#: src/routes/settings/mcp/connections.tsx:113
+#: src/routes/settings/mcp/connections.tsx:114
 msgid "AI assistants you've connected over MCP. Choose which organization each one acts in."
 msgstr "AI assistants you've connected over MCP. Choose which organization each one acts in."
 
@@ -296,7 +296,7 @@ msgid "Back to organization"
 msgstr "Back to organization"
 
 #: src/routes/settings/api-keys/index.tsx:187
-#: src/routes/settings/mcp/connections.tsx:100
+#: src/routes/settings/mcp/connections.tsx:101
 msgid "Back to settings"
 msgstr "Back to settings"
 
@@ -465,7 +465,7 @@ msgstr "Check the session or try again."
 msgid "Check your inbox"
 msgstr "Check your inbox"
 
-#: src/routes/settings/mcp/connections.tsx:175
+#: src/routes/settings/mcp/connections.tsx:181
 msgid "Choose organization"
 msgstr "Choose organization"
 
@@ -620,7 +620,7 @@ msgid "Connected"
 msgstr "Connected"
 
 #. placeholder {0}: formatDate(row.createdAt)
-#: src/routes/settings/mcp/connections.tsx:148
+#: src/routes/settings/mcp/connections.tsx:149
 msgid "Connected {0}"
 msgstr "Connected {0}"
 
@@ -730,7 +730,7 @@ msgstr "Could not load this run."
 msgid "Could not load threads"
 msgstr "Could not load threads"
 
-#: src/routes/settings/mcp/connections.tsx:130
+#: src/routes/settings/mcp/connections.tsx:131
 msgid "Could not load your connections. Refresh to try again."
 msgstr "Could not load your connections. Refresh to try again."
 
@@ -804,7 +804,7 @@ msgstr "Could not switch organization. Please try again."
 msgid "Could not toggle the inbox state."
 msgstr "Could not toggle the inbox state."
 
-#: src/routes/settings/mcp/connections.tsx:89
+#: src/routes/settings/mcp/connections.tsx:90
 msgid "Could not update"
 msgstr "Could not update"
 
@@ -1451,7 +1451,7 @@ msgstr "Loading run…"
 #: src/components/companies/upcoming-meetings-card.tsx:57
 #: src/components/shared/loading-spinner.tsx:23
 #: src/routes/settings/api-keys/index.tsx:266
-#: src/routes/settings/mcp/connections.tsx:126
+#: src/routes/settings/mcp/connections.tsx:127
 #: src/routes/settings/organization/index.tsx:52
 #: src/routes/settings/organization/members.tsx:113
 msgid "Loading…"
@@ -1572,7 +1572,7 @@ msgstr "Market summary"
 msgid "Maturity"
 msgstr "Maturity"
 
-#: src/routes/settings/mcp/connections.tsx:110
+#: src/routes/settings/mcp/connections.tsx:111
 msgid "MCP connections"
 msgstr "MCP connections"
 
@@ -1727,7 +1727,7 @@ msgstr "No companies yet"
 msgid "No connection to the server. Try again in a few seconds."
 msgstr "No connection to the server. Try again in a few seconds."
 
-#: src/routes/settings/mcp/connections.tsx:136
+#: src/routes/settings/mcp/connections.tsx:137
 msgid "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
 msgstr "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
 
@@ -1973,11 +1973,11 @@ msgid "Organization"
 msgstr "Organization"
 
 #. placeholder {0}: row.name ?? t`Unnamed client`
-#: src/routes/settings/mcp/connections.tsx:171
+#: src/routes/settings/mcp/connections.tsx:177
 msgid "Organization for {0}"
 msgstr "Organization for {0}"
 
-#: src/routes/settings/mcp/connections.tsx:81
+#: src/routes/settings/mcp/connections.tsx:82
 msgid "Organization updated"
 msgstr "Organization updated"
 
@@ -2492,6 +2492,15 @@ msgstr "Select thread {0}"
 msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 msgstr "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 
+#: src/routes/settings/mcp/connections.tsx:154
+msgid "Self-reported name"
+msgstr "Self-reported name"
+
+#. placeholder {0}: row.redirectHost
+#: src/routes/settings/mcp/connections.tsx:153
+msgid "Self-reported name · sends you to {0}"
+msgstr "Self-reported name · sends you to {0}"
+
 #: src/components/emails/compose-form.tsx:534
 msgid "Send"
 msgstr "Send"
@@ -2554,7 +2563,7 @@ msgstr "Set password"
 #: src/components/layout/nav-items.ts:81
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
-#: src/routes/settings/mcp/connections.tsx:103
+#: src/routes/settings/mcp/connections.tsx:104
 #: src/routes/settings/profile/index.tsx:108
 msgid "Settings"
 msgstr "Settings"
@@ -2885,7 +2894,7 @@ msgstr "The workspace your CRM data lives in."
 msgid "They replied — keep the thread warm"
 msgstr "They replied — keep the thread warm"
 
-#: src/routes/settings/mcp/connections.tsx:82
+#: src/routes/settings/mcp/connections.tsx:83
 msgid "This connection now acts in the chosen organization."
 msgstr "This connection now acts in the chosen organization."
 
@@ -3006,8 +3015,8 @@ msgstr "Unknown user"
 msgid "Unlinked"
 msgstr "Unlinked"
 
-#: src/routes/settings/mcp/connections.tsx:146
-#: src/routes/settings/mcp/connections.tsx:171
+#: src/routes/settings/mcp/connections.tsx:147
+#: src/routes/settings/mcp/connections.tsx:177
 msgid "Unnamed client"
 msgstr "Unnamed client"
 
@@ -3166,7 +3175,7 @@ msgstr "You don't have permission to see this page."
 msgid "You got in from a link in your email."
 msgstr "You got in from a link in your email."
 
-#: src/routes/settings/mcp/connections.tsx:90
+#: src/routes/settings/mcp/connections.tsx:91
 msgid "You may not be a member of that organization. Try again."
 msgstr "You may not be a member of that organization. Try again."
 
@@ -3190,7 +3199,7 @@ msgstr "you@example.com"
 msgid "Your Batuda workbench identity."
 msgstr "Your Batuda workbench identity."
 
-#: src/routes/settings/mcp/connections.tsx:122
+#: src/routes/settings/mcp/connections.tsx:123
 msgid "Your connections"
 msgstr "Your connections"
 

--- a/apps/internal/src/routes/settings/mcp/connections.tsx
+++ b/apps/internal/src/routes/settings/mcp/connections.tsx
@@ -28,6 +28,7 @@ type Connection = {
 	readonly name: string | null
 	readonly createdAt: string
 	readonly organizationId: string | null
+	readonly redirectHost: string | null
 }
 
 const connectionsAtom = BatudaApiAtom.query('mcpOAuth', 'listConnections', {})
@@ -147,6 +148,11 @@ function ConnectionsPage() {
 									<ConnMeta>
 										<Trans>Connected {formatDate(row.createdAt)}</Trans>
 									</ConnMeta>
+									<ConnMeta>
+										{row.redirectHost
+											? t`Self-reported name · sends you to ${row.redirectHost}`
+											: t`Self-reported name`}
+									</ConnMeta>
 								</ConnInfo>
 								<PriSelect.Root
 									items={orgOptions}
@@ -225,6 +231,8 @@ function narrowConnections(
 			name: typeof r['name'] === 'string' ? r['name'] : null,
 			organizationId:
 				typeof r['organizationId'] === 'string' ? r['organizationId'] : null,
+			redirectHost:
+				typeof r['redirectHost'] === 'string' ? r['redirectHost'] : null,
 		})
 	}
 	return out

--- a/apps/server/src/db/migrations/0007_mcp_oauth_user_rls.ts
+++ b/apps/server/src/db/migrations/0007_mcp_oauth_user_rls.ts
@@ -1,0 +1,70 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// A database backstop for the per-user OAuth data the connections page and the
+// /mcp org-resolution read: a hand-written `WHERE userId = …` is the only thing
+// keeping one member from seeing another's connections, with nothing under it.
+//
+// `app_mcp_resolver` is a dedicated NOLOGIN role those reads run as (the owner
+// pool bypasses RLS, so the reads have to switch into a constrained role for a
+// policy to bite). It's kept separate from `app_user` on purpose: these
+// policies key on the current user, and `app_user`'s membership reads elsewhere
+// are keyed on the active org — mixing them would widen what `app_user` sees
+// across the whole app. PUBLIC has no table access (revoked in 0001), so the
+// role is granted schema usage and exactly the privileges it needs.
+//
+// What enforces the isolation is running the reads as the non-superuser
+// `app_mcp_resolver` role, which these policies bind. Better Auth keeps issuing
+// tokens and recording consent through its owner connection, which bypasses RLS
+// untouched. RLS is ENABLEd (not FORCEd) — FORCE would only matter for a
+// non-superuser table owner, which the connection role isn't.
+// Each policy compares against `app.current_user_id`, set just before the reads;
+// if it's unset the comparison matches no rows, so a read that forgets to enter
+// the scope fails closed rather than leaking.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		DO $$
+		BEGIN
+			IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'app_mcp_resolver') THEN
+				CREATE ROLE app_mcp_resolver NOLOGIN;
+			END IF;
+		END
+		$$
+	`
+	// PG 16 only permits `SET LOCAL ROLE` into a role granted WITH SET (see 0002).
+	yield* sql`GRANT app_mcp_resolver TO CURRENT_USER WITH SET TRUE`
+	yield* sql`GRANT USAGE ON SCHEMA public TO app_mcp_resolver`
+
+	yield* sql`GRANT SELECT ON "oauthConsent" TO app_mcp_resolver`
+	yield* sql`GRANT SELECT ON "oauthClient" TO app_mcp_resolver`
+	yield* sql`GRANT SELECT ON member TO app_mcp_resolver`
+	yield* sql`GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_oauth_org TO app_mcp_resolver`
+
+	yield* sql`ALTER TABLE "oauthConsent" ENABLE ROW LEVEL SECURITY`
+	yield* sql`
+		CREATE POLICY user_isolation_oauth_consent ON "oauthConsent"
+			TO app_mcp_resolver
+			USING ("userId" = current_setting('app.current_user_id', true))
+	`
+
+	yield* sql`ALTER TABLE mcp_oauth_org ENABLE ROW LEVEL SECURITY`
+	yield* sql`
+		CREATE POLICY user_isolation_mcp_oauth_org ON mcp_oauth_org
+			TO app_mcp_resolver
+			USING (user_id = current_setting('app.current_user_id', true))
+			WITH CHECK (user_id = current_setting('app.current_user_id', true))
+	`
+
+	// `member` already has RLS (0005, org-scoped for app_user). Add a user-scoped
+	// policy for the resolver so it reads all of the caller's memberships across
+	// orgs when picking the org a token acts in. Policies are per-role, so this
+	// leaves app_user's org-scoped policy untouched.
+	yield* sql`
+		CREATE POLICY user_isolation_member_resolver ON member
+			TO app_mcp_resolver
+			USING ("userId" = current_setting('app.current_user_id', true))
+	`
+})

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -15,6 +15,7 @@ import pg from 'pg'
 
 import { buildBetterAuthConfig } from '@batuda/auth'
 
+import { oauthClientGc } from '../plugins/oauth-client-gc'
 import { setPasswordRoute } from '../plugins/set-password-route'
 import { TransactionalEmailProvider } from '../services/transactional-email-provider'
 import { TransactionalEmailProviderLive } from '../services/transactional-email-provider-live'
@@ -233,6 +234,9 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 						validAudiences: [`${env.BETTER_AUTH_BASE_URL}/mcp`],
 					}),
 					setPasswordRoute(),
+					// Garbage-collects abandoned open-DCR clients after each
+					// registration (see env OAUTH_CLIENT_GC_DAYS).
+					oauthClientGc(pool, env.OAUTH_CLIENT_GC_DAYS),
 					magicLink({
 						// Closes the silent-signup hole on /sign-in/magic-link.
 						// The invitation flow and CLI invite commands pre-create

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -92,6 +92,13 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		const OAUTH_ACCESS_TOKEN_TTL_SECONDS = yield* Config.int(
 			'OAUTH_ACCESS_TOKEN_TTL_SECONDS',
 		).pipe(Config.withDefault(900))
+		// Anyone can register an OAuth client (open Dynamic Client Registration),
+		// so abandoned ones get garbage-collected after each registration: a
+		// client older than this many days with no consent is deleted. Short in
+		// prod; dev sets it long so a client registered while testing survives.
+		const OAUTH_CLIENT_GC_DAYS = yield* Config.int('OAUTH_CLIENT_GC_DAYS').pipe(
+			Config.withDefault(7),
+		)
 		// Comma-separated list of trusted origins (e.g.
 		// `https://batuda.localhost`). Each entry is either a literal
 		// origin matched exactly or a wildcard-subdomain pattern
@@ -212,6 +219,7 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 			BETTER_AUTH_INSECURE_COOKIES,
 			BETTER_AUTH_RATE_LIMIT,
 			OAUTH_ACCESS_TOKEN_TTL_SECONDS,
+			OAUTH_CLIENT_GC_DAYS,
 			ALLOWED_ORIGINS,
 			APP_PUBLIC_URL,
 			STORAGE_ENDPOINT,

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -14,7 +14,7 @@ import { SessionContext } from '@batuda/controllers'
 
 import { Auth } from '../lib/auth'
 import { EnvVars } from '../lib/env'
-import { enterOrgScope } from '../middleware/org'
+import { enterOrgScope, enterUserScope } from '../middleware/org'
 import { CurrentUser } from './current-user'
 import { McpToolsLive } from './server'
 
@@ -205,12 +205,29 @@ const McpAuthMiddleware = HttpRouter.middleware(
 								prmUrl,
 							)
 						}
-						// Every current membership — the owner role bypasses member RLS
-						// before scope, so this sees all of the user's orgs.
-						const memberships = yield* sql<{ organizationId: string }>`
-							SELECT "organizationId" FROM member WHERE "userId" = ${userId}
-						`.pipe(Effect.orDie)
-						const orgIds = memberships.map(m => m.organizationId)
+						// Read the caller's memberships (all their orgs) and their
+						// per-client selection under the resolver role: the user GUC's
+						// RLS confines both reads to this user even if a WHERE slips.
+						// enterUserScope returns plain values and commits before we
+						// enter org scope below — it must not nest inside enterScope.
+						const { orgIds, selectedOrgId } = yield* enterUserScope(
+							sql,
+							userId,
+						)(
+							Effect.gen(function* () {
+								const memberships = yield* sql<{ organizationId: string }>`
+									SELECT "organizationId" FROM member WHERE "userId" = ${userId}
+								`
+								const selection = yield* sql<{ organizationId: string }>`
+									SELECT organization_id FROM mcp_oauth_org
+									WHERE user_id = ${userId} AND client_id = ${clientId} LIMIT 1
+								`
+								return {
+									orgIds: memberships.map(m => m.organizationId),
+									selectedOrgId: selection[0]?.organizationId,
+								}
+							}),
+						)
 						if (orgIds.length === 0) {
 							return yield* jsonRpcError(
 								403,
@@ -222,11 +239,6 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						// still a live membership: a stale row (user left the org) falls
 						// back to auto-pick so the token can't read an org the user no
 						// longer belongs to.
-						const selection = yield* sql<{ organizationId: string }>`
-							SELECT organization_id FROM mcp_oauth_org
-							WHERE user_id = ${userId} AND client_id = ${clientId} LIMIT 1
-						`.pipe(Effect.orDie)
-						const selectedOrgId = selection[0]?.organizationId
 						const orgId =
 							selectedOrgId && orgIds.includes(selectedOrgId)
 								? selectedOrgId

--- a/apps/server/src/mcp/oauth-auth.integration.test.ts
+++ b/apps/server/src/mcp/oauth-auth.integration.test.ts
@@ -58,6 +58,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { PgLive } from '../db/client'
 import { Auth } from '../lib/auth'
 import { enterOrgScope, enterUserScope } from '../middleware/org'
+import { gcAbandonedClients } from '../plugins/oauth-client-gc'
 import { McpOAuthService } from '../services/mcp-oauth'
 
 const DATABASE_URL = process.env['DATABASE_URL'] as string
@@ -752,6 +753,49 @@ describe('RLS backstop on the resolver role', () => {
 		} finally {
 			await client.query('ROLLBACK')
 			client.release()
+		}
+	})
+})
+
+describe('abandoned OAuth client GC', () => {
+	it('should delete only never-consented clients past the grace window', async () => {
+		const old = `gc-old-${randomUUID()}`
+		const recent = `gc-recent-${randomUUID()}`
+		const consented = `gc-consented-${randomUUID()}`
+		try {
+			// GIVEN an old + a recent never-consented client, and an old consented one
+			await pool.query(
+				`INSERT INTO "oauthClient" (id, "clientId", "redirectUris", name, "createdAt")
+				 VALUES ($1, $1, '[]'::jsonb, 'gc', '2000-01-01'),
+				        ($2, $2, '[]'::jsonb, 'gc', now()),
+				        ($3, $3, '[]'::jsonb, 'gc', '2000-01-01')`,
+				[old, recent, consented],
+			)
+			await pool.query(
+				`INSERT INTO "oauthConsent" (id, "clientId", "userId", scopes, "createdAt", "updatedAt")
+				 VALUES ($1, $2, $3, '["openid"]'::jsonb, now(), now())`,
+				[randomUUID(), consented, singleOrgUserId],
+			)
+			// WHEN the GC runs with a 7-day grace window
+			const deleted = await gcAbandonedClients(pool, 7)
+			// THEN only the old never-consented client is gone
+			const rows = await pool.query<{ clientId: string }>(
+				'SELECT "clientId" FROM "oauthClient" WHERE "clientId" = ANY($1)',
+				[[old, recent, consented]],
+			)
+			const ids = rows.rows.map(r => r.clientId)
+			expect(deleted).toBeGreaterThanOrEqual(1)
+			expect(ids).not.toContain(old)
+			expect(ids).toContain(recent)
+			expect(ids).toContain(consented)
+		} finally {
+			await pool.query(
+				'DELETE FROM "oauthConsent" WHERE "clientId" = ANY($1)',
+				[[old, recent, consented]],
+			)
+			await pool.query('DELETE FROM "oauthClient" WHERE "clientId" = ANY($1)', [
+				[old, recent, consented],
+			])
 		}
 	})
 })

--- a/apps/server/src/mcp/oauth-auth.integration.test.ts
+++ b/apps/server/src/mcp/oauth-auth.integration.test.ts
@@ -57,7 +57,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import { PgLive } from '../db/client'
 import { Auth } from '../lib/auth'
-import { enterOrgScope } from '../middleware/org'
+import { enterOrgScope, enterUserScope } from '../middleware/org'
 import { McpOAuthService } from '../services/mcp-oauth'
 
 const DATABASE_URL = process.env['DATABASE_URL'] as string
@@ -220,17 +220,28 @@ const resolveBearer = (token: string): Promise<BearerOutcome> =>
 				SELECT id FROM "user" WHERE id = ${userId} LIMIT 1
 			`.pipe(Effect.orDie)
 			if (!userRows[0]) return { kind: 'challenge' } satisfies BearerOutcome
-			const memberships = yield* sql<{ organizationId: string }>`
-				SELECT "organizationId" FROM member WHERE "userId" = ${userId}
-			`.pipe(Effect.orDie)
-			const orgIds = memberships.map(m => m.organizationId)
+			// Mirror the middleware: read memberships + selection under the
+			// resolver role so the suite exercises the same RLS-scoped path.
+			const { orgIds, selectedOrgId } = yield* enterUserScope(
+				sql,
+				userId,
+			)(
+				Effect.gen(function* () {
+					const memberships = yield* sql<{ organizationId: string }>`
+						SELECT "organizationId" FROM member WHERE "userId" = ${userId}
+					`
+					const selection = yield* sql<{ organizationId: string }>`
+						SELECT organization_id FROM mcp_oauth_org
+						WHERE user_id = ${userId} AND client_id = ${clientId} LIMIT 1
+					`
+					return {
+						orgIds: memberships.map(m => m.organizationId),
+						selectedOrgId: selection[0]?.organizationId,
+					}
+				}),
+			)
 			if (orgIds.length === 0)
 				return { kind: 'forbidden', code: -32002 } satisfies BearerOutcome
-			const selection = yield* sql<{ organizationId: string }>`
-				SELECT organization_id FROM mcp_oauth_org
-				WHERE user_id = ${userId} AND client_id = ${clientId} LIMIT 1
-			`.pipe(Effect.orDie)
-			const selectedOrgId = selection[0]?.organizationId
 			const orgId =
 				selectedOrgId && orgIds.includes(selectedOrgId)
 					? selectedOrgId
@@ -656,5 +667,91 @@ describe('McpOAuthService.listConnections', () => {
 			expect(connections).toHaveLength(1)
 			expect(connections[0]?.organizationId).toBeNull()
 		})
+	})
+})
+
+describe('RLS backstop on the resolver role', () => {
+	// The connections and /mcp reads run as app_mcp_resolver with the caller's id
+	// in app.current_user_id. These prove the policies isolate by user at the
+	// database — the guarantee behind the explicit WHERE in McpOAuthService and
+	// the /mcp resolution, should a future edit ever drop it.
+	//
+	// The `rls-a`/`rls-b` (users) + `rls-c` (client) rows are synthetic ids that
+	// the email/slug-keyed cleanup wouldn't catch; each case stays inside its own
+	// BEGIN…ROLLBACK so nothing persists past the test.
+
+	it("should hide another user's mcp_oauth_org rows even without a WHERE", async () => {
+		const client = await pool.connect()
+		try {
+			// GIVEN two users each hold a connection binding
+			await client.query('BEGIN')
+			await client.query(
+				`INSERT INTO mcp_oauth_org (user_id, client_id, organization_id)
+				 VALUES ('rls-a', 'rls-c', $1), ('rls-b', 'rls-c', $1)`,
+				[taller.id],
+			)
+			// WHEN the resolver reads as user A
+			await client.query('SET LOCAL ROLE app_mcp_resolver')
+			await client.query(
+				"SELECT set_config('app.current_user_id', 'rls-a', true)",
+			)
+			const all = await client.query<{ user_id: string }>(
+				'SELECT user_id FROM mcp_oauth_org',
+			)
+			const reachForB = await client.query(
+				"SELECT 1 FROM mcp_oauth_org WHERE user_id = 'rls-b'",
+			)
+			// THEN only A's row is visible, even reaching for B's directly
+			expect(all.rows.every(r => r.user_id === 'rls-a')).toBe(true)
+			expect(reachForB.rowCount).toBe(0)
+		} finally {
+			await client.query('ROLLBACK')
+			client.release()
+		}
+	})
+
+	it('should reject writing a row for another user', async () => {
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			// GIVEN the resolver scoped to user A
+			await client.query('SET LOCAL ROLE app_mcp_resolver')
+			await client.query(
+				"SELECT set_config('app.current_user_id', 'rls-a', true)",
+			)
+			// WHEN it inserts a row owned by user B, THEN the WITH CHECK rejects it
+			await expect(
+				client.query(
+					`INSERT INTO mcp_oauth_org (user_id, client_id, organization_id)
+					 VALUES ('rls-b', 'rls-c', $1)`,
+					[taller.id],
+				),
+			).rejects.toThrow(/row-level security/i)
+		} finally {
+			await client.query('ROLLBACK')
+			client.release()
+		}
+	})
+
+	it("should expose only the current user's memberships", async () => {
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			// GIVEN the seeded member table spans several users
+			// WHEN the resolver reads member as the single-org user
+			await client.query('SET LOCAL ROLE app_mcp_resolver')
+			await client.query("SELECT set_config('app.current_user_id', $1, true)", [
+				singleOrgUserId,
+			])
+			const rows = await client.query<{ userId: string }>(
+				'SELECT "userId" FROM member',
+			)
+			// THEN every visible membership is that user's own
+			expect(rows.rowCount).toBeGreaterThan(0)
+			expect(rows.rows.every(r => r.userId === singleOrgUserId)).toBe(true)
+		} finally {
+			await client.query('ROLLBACK')
+			client.release()
+		}
 	})
 })

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -61,6 +61,36 @@ export const enterOrgScope =
 			)
 			.pipe(Effect.orDie) as Effect.Effect<A, never, Exclude<R, CurrentOrg>>
 
+/**
+ * Enter a per-user scope for reads that span a user's orgs before any single
+ * org is chosen — their MCP connections, and the memberships the /mcp path
+ * scans to resolve which org a token acts in. In one transaction: `SET LOCAL
+ * ROLE app_mcp_resolver`, set the `app.current_user_id` GUC, run `effect`,
+ * commit. The resolver's RLS policies match that GUC, so the reads can't see
+ * another user's rows even if a `WHERE` is wrong.
+ *
+ * Use it to RETURN plain values (e.g. the resolved org id), then enter the org
+ * scope separately. Do NOT nest it inside `enterOrgScope`: SqlClient nests
+ * `withTransaction` as savepoints, so a nested `SET LOCAL ROLE` would not
+ * revert cleanly and the resolver role would bleed into the org-scoped work.
+ *
+ * `userId` is required — unlike `enterOrgScope`'s optional user GUC. An unset
+ * GUC reads back as `''`, which matches no rows and rejects inserts, so there
+ * is no system-actor path through here.
+ */
+export const enterUserScope =
+	(sql: SqlClient.SqlClient, userId: string) =>
+	<A, E, R>(effect: Effect.Effect<A, E, R>) =>
+		sql
+			.withTransaction(
+				Effect.gen(function* () {
+					yield* sql`SET LOCAL ROLE app_mcp_resolver`
+					yield* sql`SELECT set_config('app.current_user_id', ${userId}, true)`
+					return yield* effect
+				}),
+			)
+			.pipe(Effect.orDie) as Effect.Effect<A, never, R>
+
 // Raised when a system-actor scope can't resolve its org — e.g. the org was
 // deleted between a research run completing and its fan-out firing. A distinct
 // tag lets callers skip the work rather than crash.

--- a/apps/server/src/plugins/oauth-client-gc.ts
+++ b/apps/server/src/plugins/oauth-client-gc.ts
@@ -1,0 +1,52 @@
+import type { BetterAuthPlugin } from 'better-auth'
+import { createAuthMiddleware } from 'better-auth/api'
+import type { Pool } from 'pg'
+
+/**
+ * Open Dynamic Client Registration lets anyone register an OAuth client
+ * unauthenticated, so clients no user ever consents to would pile up. After
+ * each registration, delete clients older than `gcDays` that still have no
+ * consent — bounding the table opportunistically, without a separate job.
+ *
+ * Deleting only never-consented clients past a grace window can't touch a
+ * client a user is mid-authorizing (its row is recent) or one already in use
+ * (it has a consent row). Production keeps `gcDays` short; dev sets it long so
+ * a client registered while testing isn't swept away.
+ */
+export const gcAbandonedClients = async (
+	pool: Pool,
+	gcDays: number,
+): Promise<number> => {
+	// Clamp ≥ 0: a negative window lands in the future and would sweep
+	// recently-registered, not-yet-consented clients.
+	const days = Math.max(0, gcDays)
+	const result = await pool.query(
+		`DELETE FROM "oauthClient"
+		 WHERE "createdAt" < now() - ($1 || ' days')::interval
+		   AND NOT EXISTS (
+		     SELECT 1 FROM "oauthConsent"
+		     WHERE "oauthConsent"."clientId" = "oauthClient"."clientId"
+		   )`,
+		[String(days)],
+	)
+	return result.rowCount ?? 0
+}
+
+export const oauthClientGc = (
+	pool: Pool,
+	gcDays: number,
+): BetterAuthPlugin => ({
+	id: 'oauth-client-gc',
+	hooks: {
+		after: [
+			{
+				matcher: ctx => ctx.path === '/oauth2/register',
+				// Best-effort: a cleanup failure must never fail the registration
+				// the user is in the middle of, so the error is swallowed.
+				handler: createAuthMiddleware(async () => {
+					await gcAbandonedClients(pool, gcDays).catch(() => {})
+				}),
+			},
+		],
+	},
+})

--- a/apps/server/src/services/mcp-oauth.ts
+++ b/apps/server/src/services/mcp-oauth.ts
@@ -1,4 +1,5 @@
 import { Effect, Layer, ServiceMap } from 'effect'
+import type { PoolClient } from 'pg'
 
 import { Forbidden } from '@batuda/controllers'
 
@@ -22,45 +23,81 @@ interface ConnectionRow {
 
 // Binds a `(user, OAuth client)` connection to the organization its MCP access
 // tokens act in. The `/mcp` Bearer path reads `mcp_oauth_org`; single-org users
-// are auto-resolved there, multi-org users choose here. All access goes through
-// Better Auth's owner pool — `app_user` has no grants on these tables
-// (migrations/0006) — and open DCR leaves `oauthClient.userId` null, so the
-// user↔client link is `oauthConsent`.
+// are auto-resolved there, multi-org users choose here. Open DCR leaves
+// `oauthClient.userId` null, so the user↔client link is `oauthConsent`. These
+// reads run on the owner pool but inside an `app_mcp_resolver`-scoped
+// transaction, so RLS confines each one to the caller's own rows — a database
+// backstop behind the explicit `WHERE userId`, in case a future edit drops it.
 export class McpOAuthService extends ServiceMap.Service<McpOAuthService>()(
 	'McpOAuthService',
 	{
 		make: Effect.gen(function* () {
 			const auth = yield* Auth
 
+			// Run `fn` in one transaction on the owner pool, scoped to the
+			// app_mcp_resolver role with this user's id in `app.current_user_id`.
+			// The role's RLS policies key on that GUC, so a query that forgets or
+			// botches its `WHERE userId` still can't read or write another user's
+			// rows. Infra faults die as defects, keeping callers' error unions clean.
+			const withResolverTx = <A>(
+				userId: string,
+				fn: (client: PoolClient) => Promise<A>,
+			): Effect.Effect<A> =>
+				Effect.tryPromise(async () => {
+					const client = await auth.pool.connect()
+					try {
+						await client.query('BEGIN')
+						await client.query('SET LOCAL ROLE app_mcp_resolver')
+						await client.query(
+							"SELECT set_config('app.current_user_id', $1, true)",
+							[userId],
+						)
+						try {
+							const result = await fn(client)
+							await client.query('COMMIT')
+							return result
+						} catch (error) {
+							// Preserve the original failure — a ROLLBACK on a dead
+							// connection can throw and would otherwise mask the cause.
+							await client.query('ROLLBACK').catch(() => {})
+							throw error
+						}
+					} finally {
+						client.release()
+					}
+				}).pipe(Effect.orDie)
+
 			return {
 				// Bind a connection to an org the caller is still a member of. The
 				// /mcp path re-checks membership too, so a later departure can't be
-				// exploited even if a stale selection lingers.
+				// exploited even if a stale selection lingers. The membership read +
+				// the upsert share the resolver scope, and the WITH CHECK policy
+				// rejects writing a row for anyone but the caller.
 				selectOrg: (
 					userId: string,
 					clientId: string,
 					organizationId: string,
 				): Effect.Effect<void, Forbidden> =>
 					Effect.gen(function* () {
-						const member = yield* Effect.tryPromise(() =>
-							auth.pool.query(
+						const isMember = yield* withResolverTx(userId, async client => {
+							const member = await client.query(
 								'SELECT 1 FROM member WHERE "userId" = $1 AND "organizationId" = $2 LIMIT 1',
 								[userId, organizationId],
-							),
-						).pipe(Effect.orDie)
-						if (member.rowCount === 0)
-							return yield* new Forbidden({
-								message: 'Not a member of that organization',
-							})
-						yield* Effect.tryPromise(() =>
-							auth.pool.query(
+							)
+							if (member.rowCount === 0) return false
+							await client.query(
 								`INSERT INTO mcp_oauth_org (user_id, client_id, organization_id, updated_at)
 								 VALUES ($1, $2, $3, now())
 								 ON CONFLICT (user_id, client_id)
 								 DO UPDATE SET organization_id = EXCLUDED.organization_id, updated_at = now()`,
 								[userId, clientId, organizationId],
-							),
-						).pipe(Effect.orDie)
+							)
+							return true
+						})
+						if (!isMember)
+							return yield* new Forbidden({
+								message: 'Not a member of that organization',
+							})
 					}),
 
 				// The caller's connections: OAuth clients they've consented to, with
@@ -69,8 +106,8 @@ export class McpOAuthService extends ServiceMap.Service<McpOAuthService>()(
 					userId: string,
 				): Effect.Effect<ReadonlyArray<McpConnection>> =>
 					Effect.gen(function* () {
-						const result = yield* Effect.tryPromise(() =>
-							auth.pool.query<ConnectionRow>(
+						const result = yield* withResolverTx(userId, client =>
+							client.query<ConnectionRow>(
 								`SELECT c."clientId"        AS "clientId",
 								        oc.name             AS name,
 								        c."createdAt"       AS "createdAt",
@@ -83,7 +120,7 @@ export class McpOAuthService extends ServiceMap.Service<McpOAuthService>()(
 								 ORDER BY c."createdAt" DESC`,
 								[userId],
 							),
-						).pipe(Effect.orDie)
+						)
 						return result.rows.map(row => ({
 							clientId: row.clientId,
 							name: row.name,

--- a/apps/server/src/services/mcp-oauth.ts
+++ b/apps/server/src/services/mcp-oauth.ts
@@ -5,13 +5,17 @@ import { Forbidden } from '@batuda/controllers'
 
 import { Auth } from '../lib/auth'
 
-// A user's MCP OAuth connection: an OAuth client they've consented to, plus the
-// organization its access tokens currently act in (`null` = not yet chosen).
+// A user's MCP OAuth connection: an OAuth client they've consented to, the org
+// its access tokens currently act in (`null` = not yet chosen), and the host of
+// its first redirect URI. The host is provenance — the client `name` is
+// self-asserted at registration, but the redirect host is where it actually
+// sends the user, so the UI can show it rather than trust the name alone.
 export interface McpConnection {
 	readonly clientId: string
 	readonly name: string | null
 	readonly createdAt: string
 	readonly organizationId: string | null
+	readonly redirectHost: string | null
 }
 
 interface ConnectionRow {
@@ -19,6 +23,20 @@ interface ConnectionRow {
 	readonly name: string | null
 	readonly createdAt: string | Date
 	readonly organizationId: string | null
+	readonly redirectUris: unknown
+}
+
+// The host of a client's first registered redirect URI, or null if it has none
+// / they're unparseable. Surfaced on the connections page as provenance.
+const firstRedirectHost = (redirectUris: unknown): string | null => {
+	const uris = Array.isArray(redirectUris) ? redirectUris : []
+	const first = uris.find((u): u is string => typeof u === 'string')
+	if (first === undefined) return null
+	try {
+		return new URL(first).host
+	} catch {
+		return null
+	}
 }
 
 // Binds a `(user, OAuth client)` connection to the organization its MCP access
@@ -110,6 +128,7 @@ export class McpOAuthService extends ServiceMap.Service<McpOAuthService>()(
 							client.query<ConnectionRow>(
 								`SELECT c."clientId"        AS "clientId",
 								        oc.name             AS name,
+								        oc."redirectUris"   AS "redirectUris",
 								        c."createdAt"       AS "createdAt",
 								        sel.organization_id AS "organizationId"
 								 FROM "oauthConsent" c
@@ -126,6 +145,7 @@ export class McpOAuthService extends ServiceMap.Service<McpOAuthService>()(
 							name: row.name,
 							createdAt: new Date(row.createdAt).toISOString(),
 							organizationId: row.organizationId,
+							redirectHost: firstRedirectHost(row.redirectUris),
 						}))
 					}),
 			}

--- a/packages/controllers/src/routes/mcp-oauth.ts
+++ b/packages/controllers/src/routes/mcp-oauth.ts
@@ -24,6 +24,9 @@ export const McpConnectionView = Schema.Struct({
 	name: Schema.NullOr(Schema.String),
 	createdAt: Schema.String,
 	organizationId: Schema.NullOr(Schema.String),
+	// Host of the client's first redirect URI — provenance shown beside the
+	// self-asserted `name` (null if it registered none / they're unparseable).
+	redirectHost: Schema.NullOr(Schema.String),
 })
 
 // ── Route group ──


### PR DESCRIPTION
The final two findings from the adversarial review of the MCP OAuth implementation. Two commits.

## 1. RLS backstop on the OAuth tables (the headline finding)
The per-user OAuth data (`mcp_oauth_org`, `oauthConsent`, `member`) was read through the owner pool with only a hand-written `WHERE userId` between one member and another's connections — no database backstop. This adds a dedicated NOLOGIN `app_mcp_resolver` role with user-scoped RLS policies; the connections service (`selectOrg`/`listConnections`) and the `/mcp` org-resolution now read under it via a new `enterUserScope`, so a wrong `WHERE` can't cross users.

- ENABLE-not-FORCE: Better Auth keeps issuing tokens / recording consent through its owner connection, untouched. (The owner is a superuser, so what actually enforces isolation is running the reads as the non-superuser resolver role — not the ENABLE/FORCE choice.)
- Proven three ways: live psql proofs (read isolation, WITH-CHECK rejection, positive control), in-harness isolation tests, and the 139/139 regression suite (the existing replica now exercises the resolver path).

## 2. Clean up abandoned clients + connection provenance
- Open DCR clients that are never consented to are garbage-collected after each registration past a grace window (`OAUTH_CLIENT_GC_DAYS` — short in prod, long in dev); best-effort, can't fail a registration.
- The connections page shows each client's redirect host and marks the name self-reported, so a member judges a self-registered client by where it sends them — not just its chosen name.

## Verification
`check-types` ✓ · `build` ✓ · server integration **139/139** (incl. 3 new RLS-isolation cases + the GC test) · i18n en+ca 0 missing. Readability + adversarial correctness reviews passed ("ship as-is").