### PR TITLE
Add the MCP setup help page: copy-paste configs + OAuth connect

### DIFF
--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -86,6 +86,14 @@ msgstr "{who} va escriure:"
 msgid "+{remaining} more"
 msgstr "+{remaining} més"
 
+#: src/routes/settings/mcp/index.tsx:247
+msgid "<0>ChatGPT:</0> Settings → Connectors → turn on Developer mode → add the URL above and choose OAuth. (Plus, Pro, Business, Enterprise, or Edu.)"
+msgstr "<0>ChatGPT:</0> Configuració → Connectors → activa el mode desenvolupador → afegeix l'URL de dalt i tria OAuth. (Plus, Pro, Business, Enterprise o Edu.)"
+
+#: src/routes/settings/mcp/index.tsx:254
+msgid "<0>Claude.ai:</0> Settings → Connectors → Add custom connector → paste the URL above."
+msgstr "<0>Claude.ai:</0> Configuració → Connectors → Afegeix un connector personalitzat → enganxa l'URL de dalt."
+
 #: src/components/companies/calendar-tab.tsx:64
 #: src/components/companies/upcoming-meetings-card.tsx:97
 msgid "1 attendee"
@@ -189,6 +197,10 @@ msgstr "Adreça"
 msgid "Admin"
 msgstr "Admin"
 
+#: src/routes/settings/mcp/index.tsx:262
+msgid "After approving, manage which org each one acts in here."
+msgstr "Després d'aprovar-lo, gestiona aquí en quina organització actua cadascun."
+
 #: src/routes/emails/inboxes.tsx:451
 #: src/routes/emails/inboxes.tsx:993
 msgid "Agent"
@@ -237,7 +249,7 @@ msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undon
 msgstr "Qualsevol agent que faci servir \"{confirmLabel}\" deixarà de funcionar. Això no es pot desfer."
 
 #: src/routes/settings/api-keys/index.tsx:197
-#: src/routes/settings/profile/index.tsx:121
+#: src/routes/settings/profile/index.tsx:122
 msgid "API keys"
 msgstr "Claus d'API"
 
@@ -297,6 +309,7 @@ msgstr "Tornar a l'organització"
 
 #: src/routes/settings/api-keys/index.tsx:187
 #: src/routes/settings/mcp/connections.tsx:101
+#: src/routes/settings/mcp/index.tsx:133
 msgid "Back to settings"
 msgstr "Torna a la configuració"
 
@@ -417,12 +430,12 @@ msgstr "Cancel·lant…"
 msgid "Cc"
 msgstr "Cc"
 
-#: src/routes/settings/profile/index.tsx:366
+#: src/routes/settings/profile/index.tsx:373
 msgid "Change my mind — set a password anyway"
 msgstr "Canvio d'opinió — vull posar contrasenya"
 
-#: src/routes/settings/profile/index.tsx:426
-#: src/routes/settings/profile/index.tsx:513
+#: src/routes/settings/profile/index.tsx:433
+#: src/routes/settings/profile/index.tsx:520
 msgid "Change password"
 msgstr "Canvia la contrasenya"
 
@@ -445,6 +458,14 @@ msgstr "S'han desat els canvis."
 #: src/components/interactions/quick-capture-dialog.tsx:232
 msgid "Channel"
 msgstr "Canal"
+
+#: src/routes/settings/mcp/index.tsx:217
+msgid "Chat interfaces (OAuth)"
+msgstr "Interfícies de xat (OAuth)"
+
+#: src/routes/settings/mcp/index.tsx:220
+msgid "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
+msgstr "ChatGPT i Claude.ai no poden enviar una clau, així que es connecten amb OAuth. Afegeix aquest servidor per URL, aprova'l i apareixerà a les teves connexions."
 
 #: src/routes/companies/$slug.tsx:333
 #: src/routes/emails/index.tsx:784
@@ -473,6 +494,10 @@ msgstr "Tria una organització"
 #: src/routes/emails/inboxes.tsx:351
 msgid "Choose primary inbox"
 msgstr "Tria la bústia principal"
+
+#: src/routes/settings/mcp/index.tsx:203
+msgid "Claude Desktop can't reach a remote server directly, so this bridges through <0>mcp-remote</0> (needs Node installed). Or add it as an OAuth connector instead."
+msgstr "Claude Desktop no es pot connectar directament a un servidor remot, així que això fa de pont amb <0>mcp-remote</0> (cal tenir Node instal·lat). O afegeix-lo com a connector OAuth."
 
 #: src/components/shared/task-item.tsx:292
 #: src/routes/companies/$slug.tsx:1045
@@ -593,6 +618,14 @@ msgstr "Redacta"
 msgid "Conclusion or commitment (optional)"
 msgstr "Conclusió o compromís (opcional)"
 
+#: src/routes/settings/profile/index.tsx:128
+msgid "Connect AI tools"
+msgstr "Connecta eines d'IA"
+
+#: src/routes/settings/mcp/index.tsx:143
+msgid "Connect AI tools over MCP"
+msgstr "Connecta eines d'IA amb MCP"
+
 #: src/routes/emails/inboxes.tsx:442
 msgid "Connect failed"
 msgstr "Connexió fallida"
@@ -632,7 +665,7 @@ msgstr "Connectant…"
 msgid "Connection tested"
 msgstr "Connexió provada"
 
-#: src/routes/settings/profile/index.tsx:130
+#: src/routes/settings/profile/index.tsx:137
 msgid "Connections"
 msgstr "Connexions"
 
@@ -670,6 +703,10 @@ msgstr "Coordenades desades del geocodificador."
 msgid "Copied"
 msgstr "Copiada"
 
+#: src/routes/settings/mcp/index.tsx:131
+msgid "Copied {copiedLabel}"
+msgstr "Copiat {copiedLabel}"
+
 #: src/routes/settings/api-keys/index.tsx:358
 msgid "Copy"
 msgstr "Copia"
@@ -681,6 +718,15 @@ msgstr "No s'ha pogut copiar"
 #: src/components/shared/company-card.tsx:125
 msgid "Copy slug"
 msgstr "Copia el slug"
+
+#. placeholder {0}: client.label
+#: src/routes/settings/mcp/index.tsx:183
+msgid "Copy the {0} config"
+msgstr "Copia la configuració de {0}"
+
+#: src/routes/settings/mcp/index.tsx:234
+msgid "Copy the server URL"
+msgstr "Copia l'URL del servidor"
 
 #: src/routes/settings/api-keys/index.tsx:337
 msgid "Copy your key now"
@@ -808,7 +854,11 @@ msgstr "No s'ha pogut canviar l'estat de la safata."
 msgid "Could not update"
 msgstr "No s'ha pogut actualitzar"
 
-#: src/routes/settings/profile/index.tsx:371
+#: src/routes/settings/mcp/index.tsx:121
+msgid "Couldn't copy"
+msgstr "No s'ha pogut copiar"
+
+#: src/routes/settings/profile/index.tsx:378
 msgid "Couldn't update your preference. Try again."
 msgstr "No he pogut desar la teva preferència. Prova-ho de nou."
 
@@ -831,6 +881,14 @@ msgstr "Crea una pàgina d'aterratge per a un prospecte des del detall d'una emp
 #: src/routes/companies/$slug.tsx:1118
 msgid "Create a prospect landing page to share with this company."
 msgstr "Crea una pàgina d'aterratge per a un prospecte per compartir amb aquesta empresa."
+
+#: src/routes/settings/mcp/index.tsx:164
+msgid "Create an API key"
+msgstr "Crea una clau d'API"
+
+#: src/routes/settings/mcp/index.tsx:158
+msgid "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
+msgstr "Crea una clau d'API i enganxa el fragment de la teva eina — substituint <0>YOUR_API_KEY</0> per la clau. La clau actua en aquesta organització."
 
 #: src/routes/emails/inboxes.tsx:1243
 msgid "Create failed"
@@ -866,11 +924,11 @@ msgstr "Creada per agent"
 msgid "Creating…"
 msgstr "Creant…"
 
-#: src/routes/settings/profile/index.tsx:440
+#: src/routes/settings/profile/index.tsx:447
 msgid "Current password"
 msgstr "Contrasenya actual"
 
-#: src/routes/settings/profile/index.tsx:490
+#: src/routes/settings/profile/index.tsx:497
 msgid "Current password is incorrect."
 msgstr "La contrasenya actual no és correcta."
 
@@ -959,6 +1017,10 @@ msgstr "Lliurat"
 #: src/routes/oauth/consent.tsx:152
 msgid "Deny"
 msgstr "Denega"
+
+#: src/routes/settings/mcp/index.tsx:155
+msgid "Dev tools (API key)"
+msgstr "Eines de desenvolupament (clau d'API)"
 
 #: src/components/interactions/quick-capture-dialog.tsx:256
 msgid "Direction"
@@ -1226,6 +1288,10 @@ msgstr "Del webhook"
 msgid "Full screen"
 msgstr "Pantalla completa"
 
+#: src/routes/settings/mcp/index.tsx:146
+msgid "Give an AI assistant access to this organization's CRM. Dev tools use an API key; chat interfaces connect over OAuth."
+msgstr "Dona accés al CRM d'aquesta organització a un assistent d'IA. Les eines de desenvolupament usen una clau d'API; les interfícies de xat es connecten amb OAuth."
+
 #: src/routes/settings/api-keys/index.tsx:111
 msgid "Give the key a name so you can recognize it later."
 msgstr "Posa un nom a la clau perquè la puguis reconèixer més endavant."
@@ -1269,7 +1335,7 @@ msgstr "Humà"
 msgid "I prefer passwordless"
 msgstr "Prefereixo sense contrasenya"
 
-#: src/routes/settings/profile/index.tsx:328
+#: src/routes/settings/profile/index.tsx:335
 msgid "I prefer passwordless — don't ask me again"
 msgstr "Prefereixo sense contrasenya — no m'ho tornis a preguntar"
 
@@ -1398,7 +1464,7 @@ msgstr "Idioma"
 
 #: src/components/profile/language-select.tsx:34
 #: src/routes/pages/$id.tsx:311
-#: src/routes/settings/profile/index.tsx:158
+#: src/routes/settings/profile/index.tsx:165
 msgid "Language"
 msgstr "Idioma"
 
@@ -1653,8 +1719,8 @@ msgid "Never expires"
 msgstr "No caduca mai"
 
 #: src/routes/reset-password.tsx:193
-#: src/routes/settings/profile/index.tsx:268
-#: src/routes/settings/profile/index.tsx:452
+#: src/routes/settings/profile/index.tsx:275
+#: src/routes/settings/profile/index.tsx:459
 msgid "New password"
 msgstr "Contrasenya nova"
 
@@ -1723,7 +1789,7 @@ msgstr "Encara no hi ha empreses"
 #: src/routes/oauth/consent.tsx:71
 #: src/routes/settings/organization/invite.tsx:77
 #: src/routes/settings/organization/members.tsx:81
-#: src/routes/settings/profile/index.tsx:89
+#: src/routes/settings/profile/index.tsx:90
 msgid "No connection to the server. Try again in a few seconds."
 msgstr "Sense connexió al servidor. Torna-ho a provar d'aquí a uns segons."
 
@@ -1968,7 +2034,7 @@ msgstr "Obert"
 #: src/routes/settings/organization/index.tsx:42
 #: src/routes/settings/organization/invite.tsx:91
 #: src/routes/settings/organization/members.tsx:95
-#: src/routes/settings/profile/index.tsx:115
+#: src/routes/settings/profile/index.tsx:116
 msgid "Organization"
 msgstr "Organització"
 
@@ -2083,17 +2149,17 @@ msgstr "Contrasenya o contrasenya d'aplicació"
 msgid "Password updated"
 msgstr "Contrasenya actualitzada"
 
-#: src/routes/settings/profile/index.tsx:500
+#: src/routes/settings/profile/index.tsx:507
 msgid "Password updated."
 msgstr "Contrasenya actualitzada."
 
-#: src/routes/settings/profile/index.tsx:354
+#: src/routes/settings/profile/index.tsx:361
 msgid "Passwordless sign-in only"
 msgstr "Només inici de sessió sense contrasenya"
 
 #: src/routes/reset-password.tsx:221
-#: src/routes/settings/profile/index.tsx:294
-#: src/routes/settings/profile/index.tsx:478
+#: src/routes/settings/profile/index.tsx:301
+#: src/routes/settings/profile/index.tsx:485
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "La contrasenya ha de tenir com a mínim {MIN_PASSWORD_LENGTH} caràcters."
 
@@ -2121,7 +2187,7 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Telèfon"
 
-#: src/routes/settings/profile/index.tsx:429
+#: src/routes/settings/profile/index.tsx:436
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Tria una contrasenya nova. Els altres dispositius es desconnectaran."
 
@@ -2193,7 +2259,7 @@ msgid "Products fit"
 msgstr "Encaix de productes"
 
 #: src/routes/companies/$slug.tsx:1082
-#: src/routes/settings/profile/index.tsx:101
+#: src/routes/settings/profile/index.tsx:102
 msgid "Profile"
 msgstr "Perfil"
 
@@ -2331,8 +2397,8 @@ msgid "Reopen thread"
 msgstr "Reobre el fil"
 
 #: src/routes/reset-password.tsx:207
-#: src/routes/settings/profile/index.tsx:281
-#: src/routes/settings/profile/index.tsx:465
+#: src/routes/settings/profile/index.tsx:288
+#: src/routes/settings/profile/index.tsx:472
 msgid "Repeat new password"
 msgstr "Repeteix la contrasenya nova"
 
@@ -2438,7 +2504,7 @@ msgstr "Ha fallat el desament"
 msgid "Save new password"
 msgstr "Desa la nova contrasenya"
 
-#: src/routes/settings/profile/index.tsx:319
+#: src/routes/settings/profile/index.tsx:326
 msgid "Save password"
 msgstr "Desa la contrasenya"
 
@@ -2446,8 +2512,8 @@ msgstr "Desa la contrasenya"
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
 #: src/routes/reset-password.tsx:242
-#: src/routes/settings/profile/index.tsx:317
-#: src/routes/settings/profile/index.tsx:511
+#: src/routes/settings/profile/index.tsx:324
+#: src/routes/settings/profile/index.tsx:518
 msgid "Saving…"
 msgstr "Desant…"
 
@@ -2482,6 +2548,10 @@ msgstr "Tria una safata…"
 #: src/routes/settings/api-keys/index.tsx:172
 msgid "Select the key and copy it manually."
 msgstr "Selecciona la clau i copia-la manualment."
+
+#: src/routes/settings/mcp/index.tsx:122
+msgid "Select the text and copy it manually."
+msgstr "Selecciona el text i copia'l manualment."
 
 #. placeholder {0}: row.original.subject ?? '(no subject)'
 #: src/routes/emails/index.tsx:965
@@ -2540,11 +2610,15 @@ msgstr "Enviant…"
 msgid "Sent"
 msgstr "Enviat"
 
+#: src/routes/settings/mcp/index.tsx:235
+msgid "server URL"
+msgstr "l'URL del servidor"
+
 #: src/routes/reset-password.tsx:185
 msgid "Set a new password"
 msgstr "Posa una contrasenya nova"
 
-#: src/routes/settings/profile/index.tsx:257
+#: src/routes/settings/profile/index.tsx:264
 msgid "Set a password"
 msgstr "Posa una contrasenya"
 
@@ -2564,7 +2638,8 @@ msgstr "Posa contrasenya"
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
 #: src/routes/settings/mcp/connections.tsx:104
-#: src/routes/settings/profile/index.tsx:108
+#: src/routes/settings/mcp/index.tsx:136
+#: src/routes/settings/profile/index.tsx:109
 msgid "Settings"
 msgstr "Configuració"
 
@@ -2615,11 +2690,11 @@ msgstr "Inicia sessió per continuar"
 msgid "Sign in with your new password. Other devices will need to sign in again too."
 msgstr "Inicia sessió amb la contrasenya nova. Els altres dispositius també hauran de tornar a iniciar sessió."
 
-#: src/routes/settings/profile/index.tsx:177
+#: src/routes/settings/profile/index.tsx:184
 msgid "Sign out"
 msgstr "Tanca sessió"
 
-#: src/routes/settings/profile/index.tsx:83
+#: src/routes/settings/profile/index.tsx:84
 msgid "Sign-out failed. Please try again."
 msgstr "No s'ha pogut tancar la sessió. Torna-ho a provar."
 
@@ -2627,7 +2702,7 @@ msgstr "No s'ha pogut tancar la sessió. Torna-ho a provar."
 msgid "Signing in…"
 msgstr "Iniciant sessió…"
 
-#: src/routes/settings/profile/index.tsx:177
+#: src/routes/settings/profile/index.tsx:184
 msgid "Signing out…"
 msgstr "Tancant sessió…"
 
@@ -2672,8 +2747,8 @@ msgid "Something went wrong. Start the connection again from your assistant."
 msgstr "Alguna cosa ha anat malament. Torna a iniciar la connexió des del teu assistent."
 
 #: src/routes/reset-password.tsx:233
-#: src/routes/settings/profile/index.tsx:306
-#: src/routes/settings/profile/index.tsx:495
+#: src/routes/settings/profile/index.tsx:313
+#: src/routes/settings/profile/index.tsx:502
 msgid "Something went wrong. Try again."
 msgstr "Alguna cosa ha fallat. Prova-ho de nou."
 
@@ -2866,11 +2941,11 @@ msgstr "Potser el fil s'ha arxivat al proveïdor o l'enllaç és obsolet."
 msgid "The token expired or was already used. Request a fresh link."
 msgstr "El token ha caducat o ja s'ha fet servir. Demana un enllaç nou."
 
-#: src/routes/settings/profile/index.tsx:485
+#: src/routes/settings/profile/index.tsx:492
 msgid "The two new password fields don't match."
 msgstr "Les dues contrasenyes noves no coincideixen."
 
-#: src/routes/settings/profile/index.tsx:301
+#: src/routes/settings/profile/index.tsx:308
 msgid "The two password fields don't match."
 msgstr "Les dues contrasenyes no coincideixen."
 
@@ -3007,7 +3082,7 @@ msgstr "desconegut"
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: src/routes/settings/profile/index.tsx:94
+#: src/routes/settings/profile/index.tsx:95
 msgid "Unknown user"
 msgstr "Usuari desconegut"
 
@@ -3053,6 +3128,10 @@ msgstr "Pujant…"
 #: src/routes/emails/inboxes.tsx:339
 msgid "Use {0} as primary"
 msgstr "Fes servir {0} com a principal"
+
+#: src/routes/settings/mcp/index.tsx:195
+msgid "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."
+msgstr "Usa <0>httpUrl</0>, no <1>url</1> — <2>url</2> sol selecciona el transport SSE antic."
 
 #: src/routes/login.tsx:531
 msgid "Use a different email"
@@ -3163,7 +3242,7 @@ msgstr "Escriu el peu de pàgina…"
 msgid "Write your message…"
 msgstr "Escriu el teu missatge…"
 
-#: src/routes/settings/profile/index.tsx:260
+#: src/routes/settings/profile/index.tsx:267
 msgid "You currently sign in from email links. Add a password to skip checking your email next time."
 msgstr "Ara mateix entres des d'enllaços al correu. Afegeix una contrasenya per no haver de mirar el correu la pròxima vegada."
 
@@ -3179,7 +3258,7 @@ msgstr "Has entrat des d'un enllaç al teu correu."
 msgid "You may not be a member of that organization. Try again."
 msgstr "Potser no ets membre d'aquesta organització. Torna-ho a provar."
 
-#: src/routes/settings/profile/index.tsx:357
+#: src/routes/settings/profile/index.tsx:364
 msgid "You sign in from email links. I won't bring it up again."
 msgstr "Entres des d'enllaços al correu. No t'ho tornaré a esmentar."
 
@@ -3195,11 +3274,12 @@ msgstr "Ja ets membre."
 msgid "you@example.com"
 msgstr "tu@exemple.com"
 
-#: src/routes/settings/profile/index.tsx:104
+#: src/routes/settings/profile/index.tsx:105
 msgid "Your Batuda workbench identity."
 msgstr "La teva identitat al banc de Batuda."
 
 #: src/routes/settings/mcp/connections.tsx:123
+#: src/routes/settings/mcp/index.tsx:266
 msgid "Your connections"
 msgstr "Les teves connexions"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -86,6 +86,14 @@ msgstr "{who} wrote:"
 msgid "+{remaining} more"
 msgstr "+{remaining} more"
 
+#: src/routes/settings/mcp/index.tsx:247
+msgid "<0>ChatGPT:</0> Settings → Connectors → turn on Developer mode → add the URL above and choose OAuth. (Plus, Pro, Business, Enterprise, or Edu.)"
+msgstr "<0>ChatGPT:</0> Settings → Connectors → turn on Developer mode → add the URL above and choose OAuth. (Plus, Pro, Business, Enterprise, or Edu.)"
+
+#: src/routes/settings/mcp/index.tsx:254
+msgid "<0>Claude.ai:</0> Settings → Connectors → Add custom connector → paste the URL above."
+msgstr "<0>Claude.ai:</0> Settings → Connectors → Add custom connector → paste the URL above."
+
 #: src/components/companies/calendar-tab.tsx:64
 #: src/components/companies/upcoming-meetings-card.tsx:97
 msgid "1 attendee"
@@ -189,6 +197,10 @@ msgstr "Address"
 msgid "Admin"
 msgstr "Admin"
 
+#: src/routes/settings/mcp/index.tsx:262
+msgid "After approving, manage which org each one acts in here."
+msgstr "After approving, manage which org each one acts in here."
+
 #: src/routes/emails/inboxes.tsx:451
 #: src/routes/emails/inboxes.tsx:993
 msgid "Agent"
@@ -237,7 +249,7 @@ msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undon
 msgstr "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 
 #: src/routes/settings/api-keys/index.tsx:197
-#: src/routes/settings/profile/index.tsx:121
+#: src/routes/settings/profile/index.tsx:122
 msgid "API keys"
 msgstr "API keys"
 
@@ -297,6 +309,7 @@ msgstr "Back to organization"
 
 #: src/routes/settings/api-keys/index.tsx:187
 #: src/routes/settings/mcp/connections.tsx:101
+#: src/routes/settings/mcp/index.tsx:133
 msgid "Back to settings"
 msgstr "Back to settings"
 
@@ -417,12 +430,12 @@ msgstr "Cancelling…"
 msgid "Cc"
 msgstr "Cc"
 
-#: src/routes/settings/profile/index.tsx:366
+#: src/routes/settings/profile/index.tsx:373
 msgid "Change my mind — set a password anyway"
 msgstr "Change my mind — set a password anyway"
 
-#: src/routes/settings/profile/index.tsx:426
-#: src/routes/settings/profile/index.tsx:513
+#: src/routes/settings/profile/index.tsx:433
+#: src/routes/settings/profile/index.tsx:520
 msgid "Change password"
 msgstr "Change password"
 
@@ -445,6 +458,14 @@ msgstr "Changes have been saved."
 #: src/components/interactions/quick-capture-dialog.tsx:232
 msgid "Channel"
 msgstr "Channel"
+
+#: src/routes/settings/mcp/index.tsx:217
+msgid "Chat interfaces (OAuth)"
+msgstr "Chat interfaces (OAuth)"
+
+#: src/routes/settings/mcp/index.tsx:220
+msgid "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
+msgstr "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
 
 #: src/routes/companies/$slug.tsx:333
 #: src/routes/emails/index.tsx:784
@@ -473,6 +494,10 @@ msgstr "Choose organization"
 #: src/routes/emails/inboxes.tsx:351
 msgid "Choose primary inbox"
 msgstr "Choose primary inbox"
+
+#: src/routes/settings/mcp/index.tsx:203
+msgid "Claude Desktop can't reach a remote server directly, so this bridges through <0>mcp-remote</0> (needs Node installed). Or add it as an OAuth connector instead."
+msgstr "Claude Desktop can't reach a remote server directly, so this bridges through <0>mcp-remote</0> (needs Node installed). Or add it as an OAuth connector instead."
 
 #: src/components/shared/task-item.tsx:292
 #: src/routes/companies/$slug.tsx:1045
@@ -593,6 +618,14 @@ msgstr "Compose"
 msgid "Conclusion or commitment (optional)"
 msgstr "Conclusion or commitment (optional)"
 
+#: src/routes/settings/profile/index.tsx:128
+msgid "Connect AI tools"
+msgstr "Connect AI tools"
+
+#: src/routes/settings/mcp/index.tsx:143
+msgid "Connect AI tools over MCP"
+msgstr "Connect AI tools over MCP"
+
 #: src/routes/emails/inboxes.tsx:442
 msgid "Connect failed"
 msgstr "Connect failed"
@@ -632,7 +665,7 @@ msgstr "Connecting…"
 msgid "Connection tested"
 msgstr "Connection tested"
 
-#: src/routes/settings/profile/index.tsx:130
+#: src/routes/settings/profile/index.tsx:137
 msgid "Connections"
 msgstr "Connections"
 
@@ -670,6 +703,10 @@ msgstr "Coordinates saved from the geocoder."
 msgid "Copied"
 msgstr "Copied"
 
+#: src/routes/settings/mcp/index.tsx:131
+msgid "Copied {copiedLabel}"
+msgstr "Copied {copiedLabel}"
+
 #: src/routes/settings/api-keys/index.tsx:358
 msgid "Copy"
 msgstr "Copy"
@@ -681,6 +718,15 @@ msgstr "Copy failed"
 #: src/components/shared/company-card.tsx:125
 msgid "Copy slug"
 msgstr "Copy slug"
+
+#. placeholder {0}: client.label
+#: src/routes/settings/mcp/index.tsx:183
+msgid "Copy the {0} config"
+msgstr "Copy the {0} config"
+
+#: src/routes/settings/mcp/index.tsx:234
+msgid "Copy the server URL"
+msgstr "Copy the server URL"
 
 #: src/routes/settings/api-keys/index.tsx:337
 msgid "Copy your key now"
@@ -808,7 +854,11 @@ msgstr "Could not toggle the inbox state."
 msgid "Could not update"
 msgstr "Could not update"
 
-#: src/routes/settings/profile/index.tsx:371
+#: src/routes/settings/mcp/index.tsx:121
+msgid "Couldn't copy"
+msgstr "Couldn't copy"
+
+#: src/routes/settings/profile/index.tsx:378
 msgid "Couldn't update your preference. Try again."
 msgstr "Couldn't update your preference. Try again."
 
@@ -831,6 +881,14 @@ msgstr "Create a prospect landing page from a company detail view or via the MCP
 #: src/routes/companies/$slug.tsx:1118
 msgid "Create a prospect landing page to share with this company."
 msgstr "Create a prospect landing page to share with this company."
+
+#: src/routes/settings/mcp/index.tsx:164
+msgid "Create an API key"
+msgstr "Create an API key"
+
+#: src/routes/settings/mcp/index.tsx:158
+msgid "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
+msgstr "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
 
 #: src/routes/emails/inboxes.tsx:1243
 msgid "Create failed"
@@ -866,11 +924,11 @@ msgstr "Created by agent"
 msgid "Creating…"
 msgstr "Creating…"
 
-#: src/routes/settings/profile/index.tsx:440
+#: src/routes/settings/profile/index.tsx:447
 msgid "Current password"
 msgstr "Current password"
 
-#: src/routes/settings/profile/index.tsx:490
+#: src/routes/settings/profile/index.tsx:497
 msgid "Current password is incorrect."
 msgstr "Current password is incorrect."
 
@@ -959,6 +1017,10 @@ msgstr "Delivered"
 #: src/routes/oauth/consent.tsx:152
 msgid "Deny"
 msgstr "Deny"
+
+#: src/routes/settings/mcp/index.tsx:155
+msgid "Dev tools (API key)"
+msgstr "Dev tools (API key)"
 
 #: src/components/interactions/quick-capture-dialog.tsx:256
 msgid "Direction"
@@ -1226,6 +1288,10 @@ msgstr "From webhook"
 msgid "Full screen"
 msgstr "Full screen"
 
+#: src/routes/settings/mcp/index.tsx:146
+msgid "Give an AI assistant access to this organization's CRM. Dev tools use an API key; chat interfaces connect over OAuth."
+msgstr "Give an AI assistant access to this organization's CRM. Dev tools use an API key; chat interfaces connect over OAuth."
+
 #: src/routes/settings/api-keys/index.tsx:111
 msgid "Give the key a name so you can recognize it later."
 msgstr "Give the key a name so you can recognize it later."
@@ -1269,7 +1335,7 @@ msgstr "Human"
 msgid "I prefer passwordless"
 msgstr "I prefer passwordless"
 
-#: src/routes/settings/profile/index.tsx:328
+#: src/routes/settings/profile/index.tsx:335
 msgid "I prefer passwordless — don't ask me again"
 msgstr "I prefer passwordless — don't ask me again"
 
@@ -1398,7 +1464,7 @@ msgstr "Lang"
 
 #: src/components/profile/language-select.tsx:34
 #: src/routes/pages/$id.tsx:311
-#: src/routes/settings/profile/index.tsx:158
+#: src/routes/settings/profile/index.tsx:165
 msgid "Language"
 msgstr "Language"
 
@@ -1653,8 +1719,8 @@ msgid "Never expires"
 msgstr "Never expires"
 
 #: src/routes/reset-password.tsx:193
-#: src/routes/settings/profile/index.tsx:268
-#: src/routes/settings/profile/index.tsx:452
+#: src/routes/settings/profile/index.tsx:275
+#: src/routes/settings/profile/index.tsx:459
 msgid "New password"
 msgstr "New password"
 
@@ -1723,7 +1789,7 @@ msgstr "No companies yet"
 #: src/routes/oauth/consent.tsx:71
 #: src/routes/settings/organization/invite.tsx:77
 #: src/routes/settings/organization/members.tsx:81
-#: src/routes/settings/profile/index.tsx:89
+#: src/routes/settings/profile/index.tsx:90
 msgid "No connection to the server. Try again in a few seconds."
 msgstr "No connection to the server. Try again in a few seconds."
 
@@ -1968,7 +2034,7 @@ msgstr "Opened"
 #: src/routes/settings/organization/index.tsx:42
 #: src/routes/settings/organization/invite.tsx:91
 #: src/routes/settings/organization/members.tsx:95
-#: src/routes/settings/profile/index.tsx:115
+#: src/routes/settings/profile/index.tsx:116
 msgid "Organization"
 msgstr "Organization"
 
@@ -2083,17 +2149,17 @@ msgstr "Password or app-password"
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/routes/settings/profile/index.tsx:500
+#: src/routes/settings/profile/index.tsx:507
 msgid "Password updated."
 msgstr "Password updated."
 
-#: src/routes/settings/profile/index.tsx:354
+#: src/routes/settings/profile/index.tsx:361
 msgid "Passwordless sign-in only"
 msgstr "Passwordless sign-in only"
 
 #: src/routes/reset-password.tsx:221
-#: src/routes/settings/profile/index.tsx:294
-#: src/routes/settings/profile/index.tsx:478
+#: src/routes/settings/profile/index.tsx:301
+#: src/routes/settings/profile/index.tsx:485
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 
@@ -2121,7 +2187,7 @@ msgstr "Personal"
 msgid "Phone"
 msgstr "Phone"
 
-#: src/routes/settings/profile/index.tsx:429
+#: src/routes/settings/profile/index.tsx:436
 msgid "Pick a new password. Other signed-in devices will be signed out."
 msgstr "Pick a new password. Other signed-in devices will be signed out."
 
@@ -2193,7 +2259,7 @@ msgid "Products fit"
 msgstr "Products fit"
 
 #: src/routes/companies/$slug.tsx:1082
-#: src/routes/settings/profile/index.tsx:101
+#: src/routes/settings/profile/index.tsx:102
 msgid "Profile"
 msgstr "Profile"
 
@@ -2331,8 +2397,8 @@ msgid "Reopen thread"
 msgstr "Reopen thread"
 
 #: src/routes/reset-password.tsx:207
-#: src/routes/settings/profile/index.tsx:281
-#: src/routes/settings/profile/index.tsx:465
+#: src/routes/settings/profile/index.tsx:288
+#: src/routes/settings/profile/index.tsx:472
 msgid "Repeat new password"
 msgstr "Repeat new password"
 
@@ -2438,7 +2504,7 @@ msgstr "Save failed"
 msgid "Save new password"
 msgstr "Save new password"
 
-#: src/routes/settings/profile/index.tsx:319
+#: src/routes/settings/profile/index.tsx:326
 msgid "Save password"
 msgstr "Save password"
 
@@ -2446,8 +2512,8 @@ msgstr "Save password"
 #: src/routes/emails/inboxes.tsx:1463
 #: src/routes/pages/$id.tsx:268
 #: src/routes/reset-password.tsx:242
-#: src/routes/settings/profile/index.tsx:317
-#: src/routes/settings/profile/index.tsx:511
+#: src/routes/settings/profile/index.tsx:324
+#: src/routes/settings/profile/index.tsx:518
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2482,6 +2548,10 @@ msgstr "Select inbox…"
 #: src/routes/settings/api-keys/index.tsx:172
 msgid "Select the key and copy it manually."
 msgstr "Select the key and copy it manually."
+
+#: src/routes/settings/mcp/index.tsx:122
+msgid "Select the text and copy it manually."
+msgstr "Select the text and copy it manually."
 
 #. placeholder {0}: row.original.subject ?? '(no subject)'
 #: src/routes/emails/index.tsx:965
@@ -2540,11 +2610,15 @@ msgstr "Sending…"
 msgid "Sent"
 msgstr "Sent"
 
+#: src/routes/settings/mcp/index.tsx:235
+msgid "server URL"
+msgstr "server URL"
+
 #: src/routes/reset-password.tsx:185
 msgid "Set a new password"
 msgstr "Set a new password"
 
-#: src/routes/settings/profile/index.tsx:257
+#: src/routes/settings/profile/index.tsx:264
 msgid "Set a password"
 msgstr "Set a password"
 
@@ -2564,7 +2638,8 @@ msgstr "Set password"
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
 #: src/routes/settings/mcp/connections.tsx:104
-#: src/routes/settings/profile/index.tsx:108
+#: src/routes/settings/mcp/index.tsx:136
+#: src/routes/settings/profile/index.tsx:109
 msgid "Settings"
 msgstr "Settings"
 
@@ -2615,11 +2690,11 @@ msgstr "Sign in to continue"
 msgid "Sign in with your new password. Other devices will need to sign in again too."
 msgstr "Sign in with your new password. Other devices will need to sign in again too."
 
-#: src/routes/settings/profile/index.tsx:177
+#: src/routes/settings/profile/index.tsx:184
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/routes/settings/profile/index.tsx:83
+#: src/routes/settings/profile/index.tsx:84
 msgid "Sign-out failed. Please try again."
 msgstr "Sign-out failed. Please try again."
 
@@ -2627,7 +2702,7 @@ msgstr "Sign-out failed. Please try again."
 msgid "Signing in…"
 msgstr "Signing in…"
 
-#: src/routes/settings/profile/index.tsx:177
+#: src/routes/settings/profile/index.tsx:184
 msgid "Signing out…"
 msgstr "Signing out…"
 
@@ -2672,8 +2747,8 @@ msgid "Something went wrong. Start the connection again from your assistant."
 msgstr "Something went wrong. Start the connection again from your assistant."
 
 #: src/routes/reset-password.tsx:233
-#: src/routes/settings/profile/index.tsx:306
-#: src/routes/settings/profile/index.tsx:495
+#: src/routes/settings/profile/index.tsx:313
+#: src/routes/settings/profile/index.tsx:502
 msgid "Something went wrong. Try again."
 msgstr "Something went wrong. Try again."
 
@@ -2866,11 +2941,11 @@ msgstr "The thread may have been archived upstream or the link is stale."
 msgid "The token expired or was already used. Request a fresh link."
 msgstr "The token expired or was already used. Request a fresh link."
 
-#: src/routes/settings/profile/index.tsx:485
+#: src/routes/settings/profile/index.tsx:492
 msgid "The two new password fields don't match."
 msgstr "The two new password fields don't match."
 
-#: src/routes/settings/profile/index.tsx:301
+#: src/routes/settings/profile/index.tsx:308
 msgid "The two password fields don't match."
 msgstr "The two password fields don't match."
 
@@ -3007,7 +3082,7 @@ msgstr "unknown"
 msgid "Unknown"
 msgstr "Unknown"
 
-#: src/routes/settings/profile/index.tsx:94
+#: src/routes/settings/profile/index.tsx:95
 msgid "Unknown user"
 msgstr "Unknown user"
 
@@ -3053,6 +3128,10 @@ msgstr "Uploading…"
 #: src/routes/emails/inboxes.tsx:339
 msgid "Use {0} as primary"
 msgstr "Use {0} as primary"
+
+#: src/routes/settings/mcp/index.tsx:195
+msgid "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."
+msgstr "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."
 
 #: src/routes/login.tsx:531
 msgid "Use a different email"
@@ -3163,7 +3242,7 @@ msgstr "Write footer…"
 msgid "Write your message…"
 msgstr "Write your message…"
 
-#: src/routes/settings/profile/index.tsx:260
+#: src/routes/settings/profile/index.tsx:267
 msgid "You currently sign in from email links. Add a password to skip checking your email next time."
 msgstr "You currently sign in from email links. Add a password to skip checking your email next time."
 
@@ -3179,7 +3258,7 @@ msgstr "You got in from a link in your email."
 msgid "You may not be a member of that organization. Try again."
 msgstr "You may not be a member of that organization. Try again."
 
-#: src/routes/settings/profile/index.tsx:357
+#: src/routes/settings/profile/index.tsx:364
 msgid "You sign in from email links. I won't bring it up again."
 msgstr "You sign in from email links. I won't bring it up again."
 
@@ -3195,11 +3274,12 @@ msgstr "You're now a member."
 msgid "you@example.com"
 msgstr "you@example.com"
 
-#: src/routes/settings/profile/index.tsx:104
+#: src/routes/settings/profile/index.tsx:105
 msgid "Your Batuda workbench identity."
 msgstr "Your Batuda workbench identity."
 
 #: src/routes/settings/mcp/connections.tsx:123
+#: src/routes/settings/mcp/index.tsx:266
 msgid "Your connections"
 msgstr "Your connections"
 

--- a/apps/internal/src/routeTree.gen.ts
+++ b/apps/internal/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as CompaniesSlugRouteImport } from './routes/companies/$slug'
 import { Route as AcceptInvitationIdRouteImport } from './routes/accept-invitation.$id'
 import { Route as SettingsProfileIndexRouteImport } from './routes/settings/profile/index'
 import { Route as SettingsOrganizationIndexRouteImport } from './routes/settings/organization/index'
+import { Route as SettingsMcpIndexRouteImport } from './routes/settings/mcp/index'
 import { Route as SettingsApiKeysIndexRouteImport } from './routes/settings/api-keys/index'
 import { Route as SettingsOrganizationSpendRouteImport } from './routes/settings/organization/spend'
 import { Route as SettingsOrganizationMembersRouteImport } from './routes/settings/organization/members'
@@ -136,6 +137,11 @@ const SettingsOrganizationIndexRoute =
     path: '/settings/organization/',
     getParentRoute: () => rootRouteImport,
   } as any)
+const SettingsMcpIndexRoute = SettingsMcpIndexRouteImport.update({
+  id: '/settings/mcp/',
+  path: '/settings/mcp/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsApiKeysIndexRoute = SettingsApiKeysIndexRouteImport.update({
   id: '/settings/api-keys/',
   path: '/settings/api-keys/',
@@ -189,6 +195,7 @@ export interface FileRoutesByFullPath {
   '/settings/organization/members': typeof SettingsOrganizationMembersRoute
   '/settings/organization/spend': typeof SettingsOrganizationSpendRoute
   '/settings/api-keys/': typeof SettingsApiKeysIndexRoute
+  '/settings/mcp/': typeof SettingsMcpIndexRoute
   '/settings/organization/': typeof SettingsOrganizationIndexRoute
   '/settings/profile/': typeof SettingsProfileIndexRoute
 }
@@ -216,6 +223,7 @@ export interface FileRoutesByTo {
   '/settings/organization/members': typeof SettingsOrganizationMembersRoute
   '/settings/organization/spend': typeof SettingsOrganizationSpendRoute
   '/settings/api-keys': typeof SettingsApiKeysIndexRoute
+  '/settings/mcp': typeof SettingsMcpIndexRoute
   '/settings/organization': typeof SettingsOrganizationIndexRoute
   '/settings/profile': typeof SettingsProfileIndexRoute
 }
@@ -244,6 +252,7 @@ export interface FileRoutesById {
   '/settings/organization/members': typeof SettingsOrganizationMembersRoute
   '/settings/organization/spend': typeof SettingsOrganizationSpendRoute
   '/settings/api-keys/': typeof SettingsApiKeysIndexRoute
+  '/settings/mcp/': typeof SettingsMcpIndexRoute
   '/settings/organization/': typeof SettingsOrganizationIndexRoute
   '/settings/profile/': typeof SettingsProfileIndexRoute
 }
@@ -273,6 +282,7 @@ export interface FileRouteTypes {
     | '/settings/organization/members'
     | '/settings/organization/spend'
     | '/settings/api-keys/'
+    | '/settings/mcp/'
     | '/settings/organization/'
     | '/settings/profile/'
   fileRoutesByTo: FileRoutesByTo
@@ -300,6 +310,7 @@ export interface FileRouteTypes {
     | '/settings/organization/members'
     | '/settings/organization/spend'
     | '/settings/api-keys'
+    | '/settings/mcp'
     | '/settings/organization'
     | '/settings/profile'
   id:
@@ -327,6 +338,7 @@ export interface FileRouteTypes {
     | '/settings/organization/members'
     | '/settings/organization/spend'
     | '/settings/api-keys/'
+    | '/settings/mcp/'
     | '/settings/organization/'
     | '/settings/profile/'
   fileRoutesById: FileRoutesById
@@ -355,6 +367,7 @@ export interface RootRouteChildren {
   SettingsOrganizationMembersRoute: typeof SettingsOrganizationMembersRoute
   SettingsOrganizationSpendRoute: typeof SettingsOrganizationSpendRoute
   SettingsApiKeysIndexRoute: typeof SettingsApiKeysIndexRoute
+  SettingsMcpIndexRoute: typeof SettingsMcpIndexRoute
   SettingsOrganizationIndexRoute: typeof SettingsOrganizationIndexRoute
   SettingsProfileIndexRoute: typeof SettingsProfileIndexRoute
 }
@@ -501,6 +514,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsOrganizationIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/settings/mcp/': {
+      id: '/settings/mcp/'
+      path: '/settings/mcp'
+      fullPath: '/settings/mcp/'
+      preLoaderRoute: typeof SettingsMcpIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/settings/api-keys/': {
       id: '/settings/api-keys/'
       path: '/settings/api-keys'
@@ -563,6 +583,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsOrganizationMembersRoute: SettingsOrganizationMembersRoute,
   SettingsOrganizationSpendRoute: SettingsOrganizationSpendRoute,
   SettingsApiKeysIndexRoute: SettingsApiKeysIndexRoute,
+  SettingsMcpIndexRoute: SettingsMcpIndexRoute,
   SettingsOrganizationIndexRoute: SettingsOrganizationIndexRoute,
   SettingsProfileIndexRoute: SettingsProfileIndexRoute,
 }

--- a/apps/internal/src/routes/settings/mcp/index.tsx
+++ b/apps/internal/src/routes/settings/mcp/index.tsx
@@ -1,0 +1,484 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ArrowLeft, Check, Copy, Plug } from 'lucide-react'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { usePriToast } from '@batuda/ui/pri'
+
+import { apiBaseUrl } from '#/lib/api-base'
+import {
+	brushedMetalPlate,
+	rulerUnderRule,
+	stenciledTitle,
+} from '#/lib/workshop-mixins'
+
+/**
+ * Help page for connecting an AI tool to this org over MCP. Two paths: dev
+ * tools paste a config snippet with an API key; chat interfaces (ChatGPT,
+ * Claude.ai) can't carry a key, so they add the server by URL and approve it
+ * over OAuth. Every snippet embeds the live server URL, so it's correct for
+ * whichever environment the page is served from.
+ */
+
+export const Route = createFileRoute('/settings/mcp/')({
+	head: () => ({ meta: [{ title: 'Connect AI tools — Batuda' }] }),
+	component: McpSetupPage,
+})
+
+// The config snippet for each file-config tool, given the live MCP URL. Tool
+// names, file paths, and the snippets themselves are not translated (brands,
+// paths, code); only the surrounding guidance is.
+type HeaderClient = {
+	readonly id: string
+	readonly label: string
+	readonly where: string
+	readonly snippet: (mcpUrl: string) => string
+}
+
+const jsonBlock = (server: Record<string, unknown>, key = 'mcpServers') =>
+	JSON.stringify({ [key]: { batuda: server } }, null, 2)
+
+const HEADER_CLIENTS: ReadonlyArray<HeaderClient> = [
+	{
+		id: 'claude-code',
+		label: 'Claude Code',
+		where: 'Terminal',
+		snippet: url =>
+			`claude mcp add --transport http batuda ${url} \\\n  --header "x-api-key: YOUR_API_KEY"`,
+	},
+	{
+		id: 'cursor',
+		label: 'Cursor',
+		where: '~/.cursor/mcp.json',
+		snippet: url =>
+			jsonBlock({ url, headers: { 'x-api-key': 'YOUR_API_KEY' } }),
+	},
+	{
+		id: 'vscode',
+		label: 'VS Code (Copilot)',
+		where: '.vscode/mcp.json',
+		snippet: url =>
+			jsonBlock(
+				{ type: 'http', url, headers: { 'x-api-key': 'YOUR_API_KEY' } },
+				'servers',
+			),
+	},
+	{
+		id: 'windsurf',
+		label: 'Windsurf',
+		where: '~/.codeium/windsurf/mcp_config.json',
+		snippet: url =>
+			jsonBlock({ serverUrl: url, headers: { 'x-api-key': 'YOUR_API_KEY' } }),
+	},
+	{
+		id: 'codex',
+		label: 'Codex CLI',
+		where: '~/.codex/config.toml',
+		snippet: url =>
+			`[mcp_servers.batuda]\nurl = "${url}"\nhttp_headers = { "x-api-key" = "YOUR_API_KEY" }`,
+	},
+	{
+		id: 'gemini',
+		label: 'Gemini CLI',
+		where: '~/.gemini/settings.json',
+		snippet: url =>
+			jsonBlock({ httpUrl: url, headers: { 'x-api-key': 'YOUR_API_KEY' } }),
+	},
+	{
+		id: 'claude-desktop',
+		label: 'Claude Desktop',
+		where: 'claude_desktop_config.json',
+		snippet: url =>
+			jsonBlock({
+				command: 'npx',
+				// biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder mcp-remote resolves from the env block below, not a JS template.
+				args: ['-y', 'mcp-remote', url, '--header', 'x-api-key:${API_KEY}'],
+				env: { API_KEY: 'YOUR_API_KEY' },
+			}),
+	},
+]
+
+function McpSetupPage() {
+	const { t } = useLingui()
+	const toastManager = usePriToast()
+	const [copiedId, setCopiedId] = useState<string | null>(null)
+	const [copiedLabel, setCopiedLabel] = useState('')
+	const mcpUrl = `${apiBaseUrl()}/mcp`
+
+	const copy = async (id: string, text: string, label: string) => {
+		try {
+			await navigator.clipboard.writeText(text)
+			setCopiedId(id)
+			// Drives a polite live region so the copy is announced, not just shown.
+			setCopiedLabel(label)
+			setTimeout(
+				() => setCopiedId(current => (current === id ? null : current)),
+				1500,
+			)
+		} catch {
+			toastManager.add({
+				title: t`Couldn't copy`,
+				description: t`Select the text and copy it manually.`,
+				type: 'error',
+			})
+		}
+	}
+
+	return (
+		<Page>
+			<Announce role='status' aria-live='polite'>
+				{copiedId ? t`Copied ${copiedLabel}` : ''}
+			</Announce>
+			<BackLink to='/settings' aria-label={t`Back to settings`}>
+				<ArrowLeft size={14} aria-hidden />
+				<span>
+					<Trans>Settings</Trans>
+				</span>
+			</BackLink>
+
+			<Intro>
+				<Heading>
+					<Plug size={20} aria-hidden />
+					<Trans>Connect AI tools over MCP</Trans>
+				</Heading>
+				<Subtitle>
+					<Trans>
+						Give an AI assistant access to this organization's CRM. Dev tools
+						use an API key; chat interfaces connect over OAuth.
+					</Trans>
+				</Subtitle>
+			</Intro>
+
+			<Section>
+				<SectionTitle>
+					<Trans>Dev tools (API key)</Trans>
+				</SectionTitle>
+				<SectionLead>
+					<Trans>
+						Create an API key, then paste the snippet for your tool — replacing{' '}
+						<Mono>YOUR_API_KEY</Mono> with it. The key acts in this
+						organization.
+					</Trans>{' '}
+					<Link to='/settings/api-keys'>
+						<Trans>Create an API key</Trans>
+					</Link>
+				</SectionLead>
+
+				{HEADER_CLIENTS.map(client => {
+					const snippet = client.snippet(mcpUrl)
+					return (
+						<ClientBlock key={client.id}>
+							<BlockHead>
+								<ClientName>{client.label}</ClientName>
+								<Where>{client.where}</Where>
+							</BlockHead>
+							<CodeWrap>
+								<Pre>
+									<code>{snippet}</code>
+								</Pre>
+								<CopyButton
+									type='button'
+									data-testid={`mcp-copy-${client.id}`}
+									aria-label={t`Copy the ${client.label} config`}
+									onClick={() => void copy(client.id, snippet, client.label)}
+								>
+									{copiedId === client.id ? (
+										<Check size={14} aria-hidden />
+									) : (
+										<Copy size={14} aria-hidden />
+									)}
+								</CopyButton>
+							</CodeWrap>
+							{client.id === 'gemini' ? (
+								<Note>
+									<Trans>
+										Use <Mono>httpUrl</Mono>, not <Mono>url</Mono> — plain{' '}
+										<Mono>url</Mono> selects the old SSE transport.
+									</Trans>
+								</Note>
+							) : null}
+							{client.id === 'claude-desktop' ? (
+								<Note>
+									<Trans>
+										Claude Desktop can't reach a remote server directly, so this
+										bridges through <Mono>mcp-remote</Mono> (needs Node
+										installed). Or add it as an OAuth connector instead.
+									</Trans>
+								</Note>
+							) : null}
+						</ClientBlock>
+					)
+				})}
+			</Section>
+
+			<Section>
+				<SectionTitle>
+					<Trans>Chat interfaces (OAuth)</Trans>
+				</SectionTitle>
+				<SectionLead>
+					<Trans>
+						ChatGPT and Claude.ai can't send a key, so they connect over OAuth.
+						Add this server by URL, approve it, and it appears under your
+						connections.
+					</Trans>
+				</SectionLead>
+
+				<UrlRow>
+					<Pre>
+						<code>{mcpUrl}</code>
+					</Pre>
+					<CopyButton
+						type='button'
+						data-testid='mcp-copy-url'
+						aria-label={t`Copy the server URL`}
+						onClick={() => void copy('url', mcpUrl, t`server URL`)}
+					>
+						{copiedId === 'url' ? (
+							<Check size={14} aria-hidden />
+						) : (
+							<Copy size={14} aria-hidden />
+						)}
+					</CopyButton>
+				</UrlRow>
+
+				<Steps>
+					<li>
+						<Trans>
+							<Strong>ChatGPT:</Strong> Settings → Connectors → turn on
+							Developer mode → add the URL above and choose OAuth. (Plus, Pro,
+							Business, Enterprise, or Edu.)
+						</Trans>
+					</li>
+					<li>
+						<Trans>
+							<Strong>Claude.ai:</Strong> Settings → Connectors → Add custom
+							connector → paste the URL above.
+						</Trans>
+					</li>
+				</Steps>
+
+				<SectionLead>
+					<Trans>
+						After approving, manage which org each one acts in here.
+					</Trans>{' '}
+					<Link to='/settings/mcp/connections'>
+						<Trans>Your connections</Trans>
+					</Link>
+				</SectionLead>
+			</Section>
+		</Page>
+	)
+}
+
+const Page = styled.div.withConfig({ displayName: 'McpSetupPage' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
+`
+
+// Off-screen but in the accessibility tree: a polite live region that announces
+// a successful copy, which is otherwise only the icon swapping to a check.
+const Announce = styled.span`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+`
+
+const BackLink = styled(Link).withConfig({ displayName: 'McpSetupBackLink' })`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	text-decoration: none;
+	width: fit-content;
+	border-radius: var(--shape-3xs);
+
+	&:hover {
+		color: var(--color-primary);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+const Intro = styled.div.withConfig({ displayName: 'McpSetupIntro' })`
+	${rulerUnderRule}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	padding-bottom: var(--space-xs);
+`
+
+const Heading = styled.h2.withConfig({ displayName: 'McpSetupHeading' })`
+	${stenciledTitle}
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-size: var(--typescale-headline-large-size);
+	line-height: var(--typescale-headline-large-line);
+	margin: 0;
+`
+
+const Subtitle = styled.p.withConfig({ displayName: 'McpSetupSubtitle' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-large-size);
+	line-height: var(--typescale-body-large-line);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const Section = styled.section.withConfig({ displayName: 'McpSetupSection' })`
+	${brushedMetalPlate}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+	padding: var(--space-md);
+	border-radius: var(--shape-2xs);
+`
+
+const SectionTitle = styled.h3.withConfig({
+	displayName: 'McpSetupSectionTitle',
+})`
+	${stenciledTitle}
+	font-size: var(--typescale-title-medium-size);
+	line-height: var(--typescale-title-medium-line);
+	margin: 0;
+`
+
+const SectionLead = styled.p.withConfig({ displayName: 'McpSetupLead' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	line-height: var(--typescale-body-medium-line);
+	color: var(--color-on-surface-variant);
+	margin: 0;
+
+	a {
+		color: var(--color-primary);
+		border-radius: var(--shape-3xs);
+	}
+
+	a:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+		text-decoration: underline;
+	}
+`
+
+const ClientBlock = styled.div.withConfig({ displayName: 'McpSetupClient' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const BlockHead = styled.div.withConfig({ displayName: 'McpSetupBlockHead' })`
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--space-sm);
+	flex-wrap: wrap;
+`
+
+const ClientName = styled.span.withConfig({
+	displayName: 'McpSetupClientName',
+})`
+	${stenciledTitle}
+	font-size: var(--typescale-title-small-size);
+`
+
+const Where = styled.code.withConfig({ displayName: 'McpSetupWhere' })`
+	font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const CodeWrap = styled.div.withConfig({ displayName: 'McpSetupCodeWrap' })`
+	position: relative;
+`
+
+const Pre = styled.pre.withConfig({ displayName: 'McpSetupPre' })`
+	margin: 0;
+	padding: var(--space-sm);
+	padding-right: var(--space-xl);
+	border-radius: var(--shape-3xs);
+	background: color-mix(in oklab, var(--color-on-surface) 6%, transparent);
+	border: 1px solid color-mix(in oklab, var(--color-on-surface) 10%, transparent);
+	overflow-x: auto;
+	font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+	font-size: var(--typescale-body-small-size);
+	line-height: 1.5;
+	color: var(--color-on-surface);
+	white-space: pre;
+`
+
+const CopyButton = styled.button.withConfig({ displayName: 'McpSetupCopy' })`
+	position: absolute;
+	top: var(--space-2xs);
+	right: var(--space-2xs);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
+	border-radius: var(--shape-3xs);
+	border: 1px solid var(--color-outline);
+	background: var(--color-surface);
+	color: var(--color-on-surface-variant);
+	cursor: pointer;
+
+	&:hover {
+		color: var(--color-primary);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+const Note = styled.p.withConfig({ displayName: 'McpSetupNote' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const UrlRow = styled.div.withConfig({ displayName: 'McpSetupUrlRow' })`
+	position: relative;
+`
+
+const Steps = styled.ul.withConfig({ displayName: 'McpSetupSteps' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+	margin: 0;
+	padding-left: var(--space-md);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	line-height: var(--typescale-body-medium-line);
+	color: var(--color-on-surface);
+`
+
+const Strong = styled.strong.withConfig({ displayName: 'McpSetupStrong' })`
+	font-weight: 700;
+`
+
+const Mono = styled.code.withConfig({ displayName: 'McpSetupMono' })`
+	font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+	font-size: 0.92em;
+	padding: 0 var(--space-3xs);
+	border-radius: var(--shape-3xs);
+	background: color-mix(in oklab, var(--color-on-surface) 8%, transparent);
+`

--- a/apps/internal/src/routes/settings/profile/index.tsx
+++ b/apps/internal/src/routes/settings/profile/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tanstack/react-router'
 import {
 	Building2,
+	Cable,
 	KeyRound,
 	LogOut,
 	Mail,
@@ -119,6 +120,12 @@ function ProfilePage() {
 					<KeyRound size={16} aria-hidden />
 					<span>
 						<Trans>API keys</Trans>
+					</span>
+				</NavRow>
+				<NavRow to='/settings/mcp' data-testid='settings-nav-mcp-setup'>
+					<Cable size={16} aria-hidden />
+					<span>
+						<Trans>Connect AI tools</Trans>
 					</span>
 				</NavRow>
 				<NavRow


### PR DESCRIPTION
The original "help MCP section" ask — a `/settings/mcp` page users open to connect their AI tools, now that the OAuth backend, UI, and hardening are all shipped (PRs #46–#49).

## What's here
- **Dev tools (API key):** copy-paste config snippets for **Claude Code, Cursor, VS Code (Copilot), Windsurf, Codex CLI, Gemini CLI, and Claude Desktop** — each in its real config location, with the live server URL embedded and a `YOUR_API_KEY` placeholder. Per-tool gotchas noted (Gemini's `httpUrl`, Claude Desktop's `mcp-remote` bridge). Links to the API-keys page to mint a key.
- **Chat interfaces (OAuth):** the server URL + the connect steps for **ChatGPT** and **Claude.ai** (add by URL → approve), linking to the connections page to manage them.
- A "Connect AI tools" entry in the settings nav.

Configs were sourced from each tool's current official docs. The snippet URLs use `apiBaseUrl()`, so they're correct in every environment.

## Verification
`check-types` ✓ · `build` ✓ · i18n en+ca 0 missing. Readability pass + an a11y review applied: a polite live region announces copy success (WCAG 4.1.3) and the buttons/links carry the app's focus ring (2.4.7).

## Follow-up (noted, not in scope)
The a11y reviewer flagged the same copy-button pattern in `api-keys` and `mcp/connections` — a shared `CopyButton` primitive would fix all three at once.