### PR TITLE
feat(internal): add accessible copy button and reorder MCP help page

### DIFF
--- a/apps/internal/src/components/primitives/pri-copy-button.tsx
+++ b/apps/internal/src/components/primitives/pri-copy-button.tsx
@@ -1,0 +1,88 @@
+import { useLingui } from '@lingui/react/macro'
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { usePriToast } from '@batuda/ui/pri'
+
+export function PriCopyButton({
+	text,
+	label,
+	className,
+	testId,
+}: {
+	readonly text: string
+	readonly label: string
+	readonly className?: string
+	readonly testId?: string
+}) {
+	const { t } = useLingui()
+	const toastManager = usePriToast()
+	const [copied, setCopied] = useState(false)
+
+	const onCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(text)
+			setCopied(true)
+			// Revert the check icon back to the copy icon shortly after.
+			setTimeout(() => setCopied(false), 1500)
+		} catch {
+			toastManager.add({
+				title: t`Couldn't copy`,
+				description: t`Select the text and copy it manually.`,
+				type: 'error',
+			})
+		}
+	}
+
+	return (
+		<>
+			<Button
+				type='button'
+				className={className}
+				data-testid={testId}
+				aria-label={t`Copy ${label}`}
+				onClick={() => void onCopy()}
+			>
+				{copied ? (
+					<Check size={14} aria-hidden />
+				) : (
+					<Copy size={14} aria-hidden />
+				)}
+			</Button>
+			{/* Announces the copy to screen readers; the icon swap is silent to them. */}
+			<SrOnly role='status' aria-live='polite'>
+				{copied ? t`Copied ${label}` : ''}
+			</SrOnly>
+		</>
+	)
+}
+
+const Button = styled.button.withConfig({ displayName: 'PriCopyButton' })`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	color: var(--color-on-surface-variant);
+
+	&:hover {
+		color: var(--color-primary);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+const SrOnly = styled.span.withConfig({ displayName: 'PriCopySrOnly' })`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+`

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -86,11 +86,11 @@ msgstr "{who} va escriure:"
 msgid "+{remaining} more"
 msgstr "+{remaining} més"
 
-#: src/routes/settings/mcp/index.tsx:247
+#: src/routes/settings/mcp/index.tsx:149
 msgid "<0>ChatGPT:</0> Settings → Connectors → turn on Developer mode → add the URL above and choose OAuth. (Plus, Pro, Business, Enterprise, or Edu.)"
 msgstr "<0>ChatGPT:</0> Configuració → Connectors → activa el mode desenvolupador → afegeix l'URL de dalt i tria OAuth. (Plus, Pro, Business, Enterprise o Edu.)"
 
-#: src/routes/settings/mcp/index.tsx:254
+#: src/routes/settings/mcp/index.tsx:156
 msgid "<0>Claude.ai:</0> Settings → Connectors → Add custom connector → paste the URL above."
 msgstr "<0>Claude.ai:</0> Configuració → Connectors → Afegeix un connector personalitzat → enganxa l'URL de dalt."
 
@@ -197,7 +197,7 @@ msgstr "Adreça"
 msgid "Admin"
 msgstr "Admin"
 
-#: src/routes/settings/mcp/index.tsx:262
+#: src/routes/settings/mcp/index.tsx:164
 msgid "After approving, manage which org each one acts in here."
 msgstr "Després d'aprovar-lo, gestiona aquí en quina organització actua cadascun."
 
@@ -244,7 +244,7 @@ msgstr "Ja al CRM"
 msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
 msgstr "Un assistent d'IA vol connectar-se al teu compte de Batuda per MCP i actuar en nom teu. Aprova només els assistents en qui confiïs."
 
-#: src/routes/settings/api-keys/index.tsx:395
+#: src/routes/settings/api-keys/index.tsx:398
 msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 msgstr "Qualsevol agent que faci servir \"{confirmLabel}\" deixarà de funcionar. Això no es pot desfer."
 
@@ -309,7 +309,7 @@ msgstr "Tornar a l'organització"
 
 #: src/routes/settings/api-keys/index.tsx:187
 #: src/routes/settings/mcp/connections.tsx:101
-#: src/routes/settings/mcp/index.tsx:133
+#: src/routes/settings/mcp/index.tsx:107
 msgid "Back to settings"
 msgstr "Torna a la configuració"
 
@@ -412,7 +412,7 @@ msgstr "Crides"
 #: src/components/research/research-dialog.tsx:221
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
-#: src/routes/settings/api-keys/index.tsx:410
+#: src/routes/settings/api-keys/index.tsx:413
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -459,11 +459,11 @@ msgstr "S'han desat els canvis."
 msgid "Channel"
 msgstr "Canal"
 
-#: src/routes/settings/mcp/index.tsx:217
+#: src/routes/settings/mcp/index.tsx:130
 msgid "Chat interfaces (OAuth)"
 msgstr "Interfícies de xat (OAuth)"
 
-#: src/routes/settings/mcp/index.tsx:220
+#: src/routes/settings/mcp/index.tsx:133
 msgid "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
 msgstr "ChatGPT i Claude.ai no poden enviar una clau, així que es connecten amb OAuth. Afegeix aquest servidor per URL, aprova'l i apareixerà a les teves connexions."
 
@@ -495,7 +495,7 @@ msgstr "Tria una organització"
 msgid "Choose primary inbox"
 msgstr "Tria la bústia principal"
 
-#: src/routes/settings/mcp/index.tsx:203
+#: src/routes/settings/mcp/index.tsx:216
 msgid "Claude Desktop can't reach a remote server directly, so this bridges through <0>mcp-remote</0> (needs Node installed). Or add it as an OAuth connector instead."
 msgstr "Claude Desktop no es pot connectar directament a un servidor remot, així que això fa de pont amb <0>mcp-remote</0> (cal tenir Node instal·lat). O afegeix-lo com a connector OAuth."
 
@@ -550,6 +550,10 @@ msgstr "Tancat"
 #: src/components/shared/status-badge.tsx:45
 msgid "Closed — won or lost"
 msgstr "Tancat — guanyat o perdut"
+
+#: src/routes/settings/mcp/index.tsx:175
+msgid "Coding tools (API key)"
+msgstr "Eines de programació (clau API)"
 
 #: src/components/shared/status-badge.tsx:39
 msgid "Cold lead — no contact yet"
@@ -622,7 +626,7 @@ msgstr "Conclusió o compromís (opcional)"
 msgid "Connect AI tools"
 msgstr "Connecta eines d'IA"
 
-#: src/routes/settings/mcp/index.tsx:143
+#: src/routes/settings/mcp/index.tsx:117
 msgid "Connect AI tools over MCP"
 msgstr "Connecta eines d'IA amb MCP"
 
@@ -700,16 +704,21 @@ msgid "Coordinates saved from the geocoder."
 msgstr "Coordenades desades del geocodificador."
 
 #: src/routes/settings/api-keys/index.tsx:358
+#: src/routes/settings/api-keys/index.tsx:361
 msgid "Copied"
 msgstr "Copiada"
 
-#: src/routes/settings/mcp/index.tsx:131
-msgid "Copied {copiedLabel}"
-msgstr "Copiat {copiedLabel}"
+#: src/components/primitives/pri-copy-button.tsx:55
+msgid "Copied {label}"
+msgstr "S'ha copiat {label}"
 
 #: src/routes/settings/api-keys/index.tsx:358
 msgid "Copy"
 msgstr "Copia"
+
+#: src/components/primitives/pri-copy-button.tsx:44
+msgid "Copy {label}"
+msgstr "Copia {label}"
 
 #: src/routes/settings/api-keys/index.tsx:171
 msgid "Copy failed"
@@ -718,15 +727,6 @@ msgstr "No s'ha pogut copiar"
 #: src/components/shared/company-card.tsx:125
 msgid "Copy slug"
 msgstr "Copia el slug"
-
-#. placeholder {0}: client.label
-#: src/routes/settings/mcp/index.tsx:183
-msgid "Copy the {0} config"
-msgstr "Copia la configuració de {0}"
-
-#: src/routes/settings/mcp/index.tsx:234
-msgid "Copy the server URL"
-msgstr "Copia l'URL del servidor"
 
 #: src/routes/settings/api-keys/index.tsx:337
 msgid "Copy your key now"
@@ -854,7 +854,7 @@ msgstr "No s'ha pogut canviar l'estat de la safata."
 msgid "Could not update"
 msgstr "No s'ha pogut actualitzar"
 
-#: src/routes/settings/mcp/index.tsx:121
+#: src/components/primitives/pri-copy-button.tsx:31
 msgid "Couldn't copy"
 msgstr "No s'ha pogut copiar"
 
@@ -882,11 +882,11 @@ msgstr "Crea una pàgina d'aterratge per a un prospecte des del detall d'una emp
 msgid "Create a prospect landing page to share with this company."
 msgstr "Crea una pàgina d'aterratge per a un prospecte per compartir amb aquesta empresa."
 
-#: src/routes/settings/mcp/index.tsx:164
+#: src/routes/settings/mcp/index.tsx:184
 msgid "Create an API key"
 msgstr "Crea una clau d'API"
 
-#: src/routes/settings/mcp/index.tsx:158
+#: src/routes/settings/mcp/index.tsx:178
 msgid "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
 msgstr "Crea una clau d'API i enganxa el fragment de la teva eina — substituint <0>YOUR_API_KEY</0> per la clau. La clau actua en aquesta organització."
 
@@ -993,7 +993,7 @@ msgstr "Suprimeix la bústia {0}"
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
 msgstr "Suprimir la bústia {0}? Els missatges desats es mantenen; la connexió s'atura."
 
-#: src/routes/settings/api-keys/index.tsx:425
+#: src/routes/settings/api-keys/index.tsx:428
 msgid "Delete key"
 msgstr "Elimina la clau"
 
@@ -1001,12 +1001,12 @@ msgstr "Elimina la clau"
 msgid "Delete this footer? This cannot be undone."
 msgstr "Eliminar aquest peu de pàgina? Aquesta acció no es pot desfer."
 
-#: src/routes/settings/api-keys/index.tsx:392
+#: src/routes/settings/api-keys/index.tsx:395
 msgid "Delete this key?"
 msgstr "Vols eliminar aquesta clau?"
 
 #: src/routes/settings/api-keys/index.tsx:318
-#: src/routes/settings/api-keys/index.tsx:425
+#: src/routes/settings/api-keys/index.tsx:428
 msgid "Deleting…"
 msgstr "Eliminant…"
 
@@ -1017,10 +1017,6 @@ msgstr "Lliurat"
 #: src/routes/oauth/consent.tsx:152
 msgid "Deny"
 msgstr "Denega"
-
-#: src/routes/settings/mcp/index.tsx:155
-msgid "Dev tools (API key)"
-msgstr "Eines de desenvolupament (clau d'API)"
 
 #: src/components/interactions/quick-capture-dialog.tsx:256
 msgid "Direction"
@@ -1051,7 +1047,7 @@ msgstr "Document"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/routes/settings/api-keys/index.tsx:370
+#: src/routes/settings/api-keys/index.tsx:373
 msgid "Done"
 msgstr "Fet"
 
@@ -1288,9 +1284,9 @@ msgstr "Del webhook"
 msgid "Full screen"
 msgstr "Pantalla completa"
 
-#: src/routes/settings/mcp/index.tsx:146
-msgid "Give an AI assistant access to this organization's CRM. Dev tools use an API key; chat interfaces connect over OAuth."
-msgstr "Dona accés al CRM d'aquesta organització a un assistent d'IA. Les eines de desenvolupament usen una clau d'API; les interfícies de xat es connecten amb OAuth."
+#: src/routes/settings/mcp/index.tsx:120
+msgid "Give an AI assistant access to this organization's CRM. Chat apps like ChatGPT and Claude.ai connect over OAuth; coding tools use an API key."
+msgstr "Dona a un assistent d'IA accés al CRM d'aquesta organització. Les aplicacions de xat com ChatGPT i Claude.ai es connecten amb OAuth; les eines de programació fan servir una clau API."
 
 #: src/routes/settings/api-keys/index.tsx:111
 msgid "Give the key a name so you can recognize it later."
@@ -2549,7 +2545,7 @@ msgstr "Tria una safata…"
 msgid "Select the key and copy it manually."
 msgstr "Selecciona la clau i copia-la manualment."
 
-#: src/routes/settings/mcp/index.tsx:122
+#: src/components/primitives/pri-copy-button.tsx:32
 msgid "Select the text and copy it manually."
 msgstr "Selecciona el text i copia'l manualment."
 
@@ -2610,7 +2606,7 @@ msgstr "Enviant…"
 msgid "Sent"
 msgstr "Enviat"
 
-#: src/routes/settings/mcp/index.tsx:235
+#: src/routes/settings/mcp/index.tsx:144
 msgid "server URL"
 msgstr "l'URL del servidor"
 
@@ -2638,7 +2634,7 @@ msgstr "Posa contrasenya"
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
 #: src/routes/settings/mcp/connections.tsx:104
-#: src/routes/settings/mcp/index.tsx:136
+#: src/routes/settings/mcp/index.tsx:110
 #: src/routes/settings/profile/index.tsx:109
 msgid "Settings"
 msgstr "Configuració"
@@ -3129,7 +3125,7 @@ msgstr "Pujant…"
 msgid "Use {0} as primary"
 msgstr "Fes servir {0} com a principal"
 
-#: src/routes/settings/mcp/index.tsx:195
+#: src/routes/settings/mcp/index.tsx:208
 msgid "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."
 msgstr "Usa <0>httpUrl</0>, no <1>url</1> — <2>url</2> sol selecciona el transport SSE antic."
 
@@ -3279,7 +3275,7 @@ msgid "Your Batuda workbench identity."
 msgstr "La teva identitat al banc de Batuda."
 
 #: src/routes/settings/mcp/connections.tsx:123
-#: src/routes/settings/mcp/index.tsx:266
+#: src/routes/settings/mcp/index.tsx:168
 msgid "Your connections"
 msgstr "Les teves connexions"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -86,11 +86,11 @@ msgstr "{who} wrote:"
 msgid "+{remaining} more"
 msgstr "+{remaining} more"
 
-#: src/routes/settings/mcp/index.tsx:247
+#: src/routes/settings/mcp/index.tsx:149
 msgid "<0>ChatGPT:</0> Settings → Connectors → turn on Developer mode → add the URL above and choose OAuth. (Plus, Pro, Business, Enterprise, or Edu.)"
 msgstr "<0>ChatGPT:</0> Settings → Connectors → turn on Developer mode → add the URL above and choose OAuth. (Plus, Pro, Business, Enterprise, or Edu.)"
 
-#: src/routes/settings/mcp/index.tsx:254
+#: src/routes/settings/mcp/index.tsx:156
 msgid "<0>Claude.ai:</0> Settings → Connectors → Add custom connector → paste the URL above."
 msgstr "<0>Claude.ai:</0> Settings → Connectors → Add custom connector → paste the URL above."
 
@@ -197,7 +197,7 @@ msgstr "Address"
 msgid "Admin"
 msgstr "Admin"
 
-#: src/routes/settings/mcp/index.tsx:262
+#: src/routes/settings/mcp/index.tsx:164
 msgid "After approving, manage which org each one acts in here."
 msgstr "After approving, manage which org each one acts in here."
 
@@ -244,7 +244,7 @@ msgstr "Already in CRM"
 msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
 msgstr "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
 
-#: src/routes/settings/api-keys/index.tsx:395
+#: src/routes/settings/api-keys/index.tsx:398
 msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 msgstr "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 
@@ -309,7 +309,7 @@ msgstr "Back to organization"
 
 #: src/routes/settings/api-keys/index.tsx:187
 #: src/routes/settings/mcp/connections.tsx:101
-#: src/routes/settings/mcp/index.tsx:133
+#: src/routes/settings/mcp/index.tsx:107
 msgid "Back to settings"
 msgstr "Back to settings"
 
@@ -412,7 +412,7 @@ msgstr "Calls"
 #: src/components/research/research-dialog.tsx:221
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
-#: src/routes/settings/api-keys/index.tsx:410
+#: src/routes/settings/api-keys/index.tsx:413
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel"
@@ -459,11 +459,11 @@ msgstr "Changes have been saved."
 msgid "Channel"
 msgstr "Channel"
 
-#: src/routes/settings/mcp/index.tsx:217
+#: src/routes/settings/mcp/index.tsx:130
 msgid "Chat interfaces (OAuth)"
 msgstr "Chat interfaces (OAuth)"
 
-#: src/routes/settings/mcp/index.tsx:220
+#: src/routes/settings/mcp/index.tsx:133
 msgid "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
 msgstr "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
 
@@ -495,7 +495,7 @@ msgstr "Choose organization"
 msgid "Choose primary inbox"
 msgstr "Choose primary inbox"
 
-#: src/routes/settings/mcp/index.tsx:203
+#: src/routes/settings/mcp/index.tsx:216
 msgid "Claude Desktop can't reach a remote server directly, so this bridges through <0>mcp-remote</0> (needs Node installed). Or add it as an OAuth connector instead."
 msgstr "Claude Desktop can't reach a remote server directly, so this bridges through <0>mcp-remote</0> (needs Node installed). Or add it as an OAuth connector instead."
 
@@ -550,6 +550,10 @@ msgstr "Closed"
 #: src/components/shared/status-badge.tsx:45
 msgid "Closed — won or lost"
 msgstr "Closed — won or lost"
+
+#: src/routes/settings/mcp/index.tsx:175
+msgid "Coding tools (API key)"
+msgstr "Coding tools (API key)"
 
 #: src/components/shared/status-badge.tsx:39
 msgid "Cold lead — no contact yet"
@@ -622,7 +626,7 @@ msgstr "Conclusion or commitment (optional)"
 msgid "Connect AI tools"
 msgstr "Connect AI tools"
 
-#: src/routes/settings/mcp/index.tsx:143
+#: src/routes/settings/mcp/index.tsx:117
 msgid "Connect AI tools over MCP"
 msgstr "Connect AI tools over MCP"
 
@@ -700,16 +704,21 @@ msgid "Coordinates saved from the geocoder."
 msgstr "Coordinates saved from the geocoder."
 
 #: src/routes/settings/api-keys/index.tsx:358
+#: src/routes/settings/api-keys/index.tsx:361
 msgid "Copied"
 msgstr "Copied"
 
-#: src/routes/settings/mcp/index.tsx:131
-msgid "Copied {copiedLabel}"
-msgstr "Copied {copiedLabel}"
+#: src/components/primitives/pri-copy-button.tsx:55
+msgid "Copied {label}"
+msgstr "Copied {label}"
 
 #: src/routes/settings/api-keys/index.tsx:358
 msgid "Copy"
 msgstr "Copy"
+
+#: src/components/primitives/pri-copy-button.tsx:44
+msgid "Copy {label}"
+msgstr "Copy {label}"
 
 #: src/routes/settings/api-keys/index.tsx:171
 msgid "Copy failed"
@@ -718,15 +727,6 @@ msgstr "Copy failed"
 #: src/components/shared/company-card.tsx:125
 msgid "Copy slug"
 msgstr "Copy slug"
-
-#. placeholder {0}: client.label
-#: src/routes/settings/mcp/index.tsx:183
-msgid "Copy the {0} config"
-msgstr "Copy the {0} config"
-
-#: src/routes/settings/mcp/index.tsx:234
-msgid "Copy the server URL"
-msgstr "Copy the server URL"
 
 #: src/routes/settings/api-keys/index.tsx:337
 msgid "Copy your key now"
@@ -854,7 +854,7 @@ msgstr "Could not toggle the inbox state."
 msgid "Could not update"
 msgstr "Could not update"
 
-#: src/routes/settings/mcp/index.tsx:121
+#: src/components/primitives/pri-copy-button.tsx:31
 msgid "Couldn't copy"
 msgstr "Couldn't copy"
 
@@ -882,11 +882,11 @@ msgstr "Create a prospect landing page from a company detail view or via the MCP
 msgid "Create a prospect landing page to share with this company."
 msgstr "Create a prospect landing page to share with this company."
 
-#: src/routes/settings/mcp/index.tsx:164
+#: src/routes/settings/mcp/index.tsx:184
 msgid "Create an API key"
 msgstr "Create an API key"
 
-#: src/routes/settings/mcp/index.tsx:158
+#: src/routes/settings/mcp/index.tsx:178
 msgid "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
 msgstr "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
 
@@ -993,7 +993,7 @@ msgstr "Delete inbox {0}"
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
 msgstr "Delete inbox {0}? Stored messages stay; the connection stops."
 
-#: src/routes/settings/api-keys/index.tsx:425
+#: src/routes/settings/api-keys/index.tsx:428
 msgid "Delete key"
 msgstr "Delete key"
 
@@ -1001,12 +1001,12 @@ msgstr "Delete key"
 msgid "Delete this footer? This cannot be undone."
 msgstr "Delete this footer? This cannot be undone."
 
-#: src/routes/settings/api-keys/index.tsx:392
+#: src/routes/settings/api-keys/index.tsx:395
 msgid "Delete this key?"
 msgstr "Delete this key?"
 
 #: src/routes/settings/api-keys/index.tsx:318
-#: src/routes/settings/api-keys/index.tsx:425
+#: src/routes/settings/api-keys/index.tsx:428
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1017,10 +1017,6 @@ msgstr "Delivered"
 #: src/routes/oauth/consent.tsx:152
 msgid "Deny"
 msgstr "Deny"
-
-#: src/routes/settings/mcp/index.tsx:155
-msgid "Dev tools (API key)"
-msgstr "Dev tools (API key)"
 
 #: src/components/interactions/quick-capture-dialog.tsx:256
 msgid "Direction"
@@ -1051,7 +1047,7 @@ msgstr "Document"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/routes/settings/api-keys/index.tsx:370
+#: src/routes/settings/api-keys/index.tsx:373
 msgid "Done"
 msgstr "Done"
 
@@ -1288,9 +1284,9 @@ msgstr "From webhook"
 msgid "Full screen"
 msgstr "Full screen"
 
-#: src/routes/settings/mcp/index.tsx:146
-msgid "Give an AI assistant access to this organization's CRM. Dev tools use an API key; chat interfaces connect over OAuth."
-msgstr "Give an AI assistant access to this organization's CRM. Dev tools use an API key; chat interfaces connect over OAuth."
+#: src/routes/settings/mcp/index.tsx:120
+msgid "Give an AI assistant access to this organization's CRM. Chat apps like ChatGPT and Claude.ai connect over OAuth; coding tools use an API key."
+msgstr "Give an AI assistant access to this organization's CRM. Chat apps like ChatGPT and Claude.ai connect over OAuth; coding tools use an API key."
 
 #: src/routes/settings/api-keys/index.tsx:111
 msgid "Give the key a name so you can recognize it later."
@@ -2549,7 +2545,7 @@ msgstr "Select inbox…"
 msgid "Select the key and copy it manually."
 msgstr "Select the key and copy it manually."
 
-#: src/routes/settings/mcp/index.tsx:122
+#: src/components/primitives/pri-copy-button.tsx:32
 msgid "Select the text and copy it manually."
 msgstr "Select the text and copy it manually."
 
@@ -2610,7 +2606,7 @@ msgstr "Sending…"
 msgid "Sent"
 msgstr "Sent"
 
-#: src/routes/settings/mcp/index.tsx:235
+#: src/routes/settings/mcp/index.tsx:144
 msgid "server URL"
 msgstr "server URL"
 
@@ -2638,7 +2634,7 @@ msgstr "Set password"
 #: src/routes/pages/$id.tsx:290
 #: src/routes/settings/api-keys/index.tsx:190
 #: src/routes/settings/mcp/connections.tsx:104
-#: src/routes/settings/mcp/index.tsx:136
+#: src/routes/settings/mcp/index.tsx:110
 #: src/routes/settings/profile/index.tsx:109
 msgid "Settings"
 msgstr "Settings"
@@ -3129,7 +3125,7 @@ msgstr "Uploading…"
 msgid "Use {0} as primary"
 msgstr "Use {0} as primary"
 
-#: src/routes/settings/mcp/index.tsx:195
+#: src/routes/settings/mcp/index.tsx:208
 msgid "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."
 msgstr "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."
 
@@ -3279,7 +3275,7 @@ msgid "Your Batuda workbench identity."
 msgstr "Your Batuda workbench identity."
 
 #: src/routes/settings/mcp/connections.tsx:123
-#: src/routes/settings/mcp/index.tsx:266
+#: src/routes/settings/mcp/index.tsx:168
 msgid "Your connections"
 msgstr "Your connections"
 

--- a/apps/internal/src/routes/settings/api-keys/index.tsx
+++ b/apps/internal/src/routes/settings/api-keys/index.tsx
@@ -357,6 +357,9 @@ function ApiKeysPage() {
 								<Copy size={14} aria-hidden />
 								<span>{copied ? t`Copied` : t`Copy`}</span>
 							</PriButton>
+							<SrOnly role='status' aria-live='polite'>
+								{copied ? t`Copied` : ''}
+							</SrOnly>
 						</SecretBox>
 						<RevealActions>
 							<PriDialog.Close
@@ -668,6 +671,18 @@ const SecretBox = styled.div.withConfig({ displayName: 'ApiKeysSecretBox' })`
 	align-items: stretch;
 	gap: var(--space-sm);
 	flex-wrap: wrap;
+`
+
+const SrOnly = styled.span.withConfig({ displayName: 'ApiKeysSrOnly' })`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 `
 
 const SecretValue = styled.code.withConfig({

--- a/apps/internal/src/routes/settings/mcp/index.tsx
+++ b/apps/internal/src/routes/settings/mcp/index.tsx
@@ -1,11 +1,9 @@
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { ArrowLeft, Check, Copy, Plug } from 'lucide-react'
-import { useState } from 'react'
+import { ArrowLeft, Plug } from 'lucide-react'
 import styled from 'styled-components'
 
-import { usePriToast } from '@batuda/ui/pri'
-
+import { PriCopyButton } from '#/components/primitives/pri-copy-button'
 import { apiBaseUrl } from '#/lib/api-base'
 import {
 	brushedMetalPlate,
@@ -14,11 +12,12 @@ import {
 } from '#/lib/workshop-mixins'
 
 /**
- * Help page for connecting an AI tool to this org over MCP. Two paths: dev
- * tools paste a config snippet with an API key; chat interfaces (ChatGPT,
- * Claude.ai) can't carry a key, so they add the server by URL and approve it
- * over OAuth. Every snippet embeds the live server URL, so it's correct for
- * whichever environment the page is served from.
+ * Help page for connecting an AI tool to this org over MCP. Chat interfaces
+ * (ChatGPT, Claude.ai) come first since most people reach for those — they
+ * can't carry a key, so they add the server by URL and approve it over OAuth.
+ * Coding tools come last: they paste a config snippet with an API key. Every
+ * snippet embeds the live server URL, so it's correct for whichever environment
+ * the page is served from.
  */
 
 export const Route = createFileRoute('/settings/mcp/')({
@@ -26,9 +25,9 @@ export const Route = createFileRoute('/settings/mcp/')({
 	component: McpSetupPage,
 })
 
-// The config snippet for each file-config tool, given the live MCP URL. Tool
-// names, file paths, and the snippets themselves are not translated (brands,
-// paths, code); only the surrounding guidance is.
+// The config snippet for each coding tool, given the live MCP URL. Tool names,
+// file paths, and the snippets themselves are not translated (brands, paths,
+// code); only the surrounding guidance is.
 type HeaderClient = {
 	readonly id: string
 	readonly label: string
@@ -101,35 +100,10 @@ const HEADER_CLIENTS: ReadonlyArray<HeaderClient> = [
 
 function McpSetupPage() {
 	const { t } = useLingui()
-	const toastManager = usePriToast()
-	const [copiedId, setCopiedId] = useState<string | null>(null)
-	const [copiedLabel, setCopiedLabel] = useState('')
 	const mcpUrl = `${apiBaseUrl()}/mcp`
-
-	const copy = async (id: string, text: string, label: string) => {
-		try {
-			await navigator.clipboard.writeText(text)
-			setCopiedId(id)
-			// Drives a polite live region so the copy is announced, not just shown.
-			setCopiedLabel(label)
-			setTimeout(
-				() => setCopiedId(current => (current === id ? null : current)),
-				1500,
-			)
-		} catch {
-			toastManager.add({
-				title: t`Couldn't copy`,
-				description: t`Select the text and copy it manually.`,
-				type: 'error',
-			})
-		}
-	}
 
 	return (
 		<Page>
-			<Announce role='status' aria-live='polite'>
-				{copiedId ? t`Copied ${copiedLabel}` : ''}
-			</Announce>
 			<BackLink to='/settings' aria-label={t`Back to settings`}>
 				<ArrowLeft size={14} aria-hidden />
 				<span>
@@ -144,73 +118,12 @@ function McpSetupPage() {
 				</Heading>
 				<Subtitle>
 					<Trans>
-						Give an AI assistant access to this organization's CRM. Dev tools
-						use an API key; chat interfaces connect over OAuth.
+						Give an AI assistant access to this organization's CRM. Chat apps
+						like ChatGPT and Claude.ai connect over OAuth; coding tools use an
+						API key.
 					</Trans>
 				</Subtitle>
 			</Intro>
-
-			<Section>
-				<SectionTitle>
-					<Trans>Dev tools (API key)</Trans>
-				</SectionTitle>
-				<SectionLead>
-					<Trans>
-						Create an API key, then paste the snippet for your tool — replacing{' '}
-						<Mono>YOUR_API_KEY</Mono> with it. The key acts in this
-						organization.
-					</Trans>{' '}
-					<Link to='/settings/api-keys'>
-						<Trans>Create an API key</Trans>
-					</Link>
-				</SectionLead>
-
-				{HEADER_CLIENTS.map(client => {
-					const snippet = client.snippet(mcpUrl)
-					return (
-						<ClientBlock key={client.id}>
-							<BlockHead>
-								<ClientName>{client.label}</ClientName>
-								<Where>{client.where}</Where>
-							</BlockHead>
-							<CodeWrap>
-								<Pre>
-									<code>{snippet}</code>
-								</Pre>
-								<CopyButton
-									type='button'
-									data-testid={`mcp-copy-${client.id}`}
-									aria-label={t`Copy the ${client.label} config`}
-									onClick={() => void copy(client.id, snippet, client.label)}
-								>
-									{copiedId === client.id ? (
-										<Check size={14} aria-hidden />
-									) : (
-										<Copy size={14} aria-hidden />
-									)}
-								</CopyButton>
-							</CodeWrap>
-							{client.id === 'gemini' ? (
-								<Note>
-									<Trans>
-										Use <Mono>httpUrl</Mono>, not <Mono>url</Mono> — plain{' '}
-										<Mono>url</Mono> selects the old SSE transport.
-									</Trans>
-								</Note>
-							) : null}
-							{client.id === 'claude-desktop' ? (
-								<Note>
-									<Trans>
-										Claude Desktop can't reach a remote server directly, so this
-										bridges through <Mono>mcp-remote</Mono> (needs Node
-										installed). Or add it as an OAuth connector instead.
-									</Trans>
-								</Note>
-							) : null}
-						</ClientBlock>
-					)
-				})}
-			</Section>
 
 			<Section>
 				<SectionTitle>
@@ -228,18 +141,7 @@ function McpSetupPage() {
 					<Pre>
 						<code>{mcpUrl}</code>
 					</Pre>
-					<CopyButton
-						type='button'
-						data-testid='mcp-copy-url'
-						aria-label={t`Copy the server URL`}
-						onClick={() => void copy('url', mcpUrl, t`server URL`)}
-					>
-						{copiedId === 'url' ? (
-							<Check size={14} aria-hidden />
-						) : (
-							<Copy size={14} aria-hidden />
-						)}
-					</CopyButton>
+					<CopyBtn text={mcpUrl} label={t`server URL`} testId='mcp-copy-url' />
 				</UrlRow>
 
 				<Steps>
@@ -267,6 +169,61 @@ function McpSetupPage() {
 					</Link>
 				</SectionLead>
 			</Section>
+
+			<Section>
+				<SectionTitle>
+					<Trans>Coding tools (API key)</Trans>
+				</SectionTitle>
+				<SectionLead>
+					<Trans>
+						Create an API key, then paste the snippet for your tool — replacing{' '}
+						<Mono>YOUR_API_KEY</Mono> with it. The key acts in this
+						organization.
+					</Trans>{' '}
+					<Link to='/settings/api-keys'>
+						<Trans>Create an API key</Trans>
+					</Link>
+				</SectionLead>
+
+				{HEADER_CLIENTS.map(client => {
+					const snippet = client.snippet(mcpUrl)
+					return (
+						<ClientBlock key={client.id}>
+							<BlockHead>
+								<ClientName>{client.label}</ClientName>
+								<Where>{client.where}</Where>
+							</BlockHead>
+							<CodeWrap>
+								<Pre>
+									<code>{snippet}</code>
+								</Pre>
+								<CopyBtn
+									text={snippet}
+									label={client.label}
+									testId={`mcp-copy-${client.id}`}
+								/>
+							</CodeWrap>
+							{client.id === 'gemini' ? (
+								<Note>
+									<Trans>
+										Use <Mono>httpUrl</Mono>, not <Mono>url</Mono> — plain{' '}
+										<Mono>url</Mono> selects the old SSE transport.
+									</Trans>
+								</Note>
+							) : null}
+							{client.id === 'claude-desktop' ? (
+								<Note>
+									<Trans>
+										Claude Desktop can't reach a remote server directly, so this
+										bridges through <Mono>mcp-remote</Mono> (needs Node
+										installed). Or add it as an OAuth connector instead.
+									</Trans>
+								</Note>
+							) : null}
+						</ClientBlock>
+					)
+				})}
+			</Section>
 		</Page>
 	)
 }
@@ -275,20 +232,6 @@ const Page = styled.div.withConfig({ displayName: 'McpSetupPage' })`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-lg);
-`
-
-// Off-screen but in the accessibility tree: a polite live region that announces
-// a successful copy, which is otherwise only the icon swapping to a check.
-const Announce = styled.span`
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
 `
 
 const BackLink = styled(Link).withConfig({ displayName: 'McpSetupBackLink' })`
@@ -422,37 +365,18 @@ const Pre = styled.pre.withConfig({ displayName: 'McpSetupPre' })`
 	white-space: pre;
 `
 
-const CopyButton = styled.button.withConfig({ displayName: 'McpSetupCopy' })`
+// The shared PriCopyButton positioned into the code block's corner.
+const CopyBtn = styled(PriCopyButton).withConfig({
+	displayName: 'McpSetupCopy',
+})`
 	position: absolute;
 	top: var(--space-2xs);
 	right: var(--space-2xs);
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: var(--shape-3xs);
 	border: 1px solid var(--color-outline);
 	background: var(--color-surface);
-	color: var(--color-on-surface-variant);
-	cursor: pointer;
-
-	&:hover {
-		color: var(--color-primary);
-	}
-
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
-	}
-`
-
-const Note = styled.p.withConfig({ displayName: 'McpSetupNote' })`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-small-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-	margin: 0;
 `
 
 const UrlRow = styled.div.withConfig({ displayName: 'McpSetupUrlRow' })`
@@ -481,4 +405,12 @@ const Mono = styled.code.withConfig({ displayName: 'McpSetupMono' })`
 	padding: 0 var(--space-3xs);
 	border-radius: var(--shape-3xs);
 	background: color-mix(in oklab, var(--color-on-surface) 8%, transparent);
+`
+
+const Note = styled.p.withConfig({ displayName: 'McpSetupNote' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	line-height: var(--typescale-body-small-line);
+	color: var(--color-on-surface-variant);
+	margin: 0;
 `

--- a/apps/internal/tests/e2e/mcp-setup.test.ts
+++ b/apps/internal/tests/e2e/mcp-setup.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test'
+
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
+// The /settings/mcp help page: reachable from the settings nav, lists the chat
+// interfaces (OAuth) first and the coding tools (API key) last, and gives every
+// snippet a copy button. The clipboard write + screen-reader announce are
+// unit-level concerns of PriCopyButton; this covers routing, render, and order.
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/', { waitUntil: 'commit' })
+	await setActiveOrgBySlug(page, 'taller')
+})
+
+test.describe('settings — connect AI tools (MCP)', () => {
+	test('should reach the help page from the settings nav and render its sections', async ({
+		page,
+	}) => {
+		// GIVEN the Settings hub, which lands on the profile page
+		await page.goto('/settings', { waitUntil: 'networkidle' })
+		await expect(page).toHaveURL(/\/settings\/profile$/)
+
+		// WHEN she follows the Connect AI tools link
+		await page.getByTestId('settings-nav-mcp-setup').click()
+
+		// THEN the help page loads with its heading and snippet copy buttons
+		await expect(page).toHaveURL(/\/settings\/mcp\/?$/)
+		await expect(
+			page.getByRole('heading', { name: /connect ai tools over mcp/i }),
+		).toBeVisible()
+		await expect(page.getByTestId('mcp-copy-url')).toBeVisible()
+		await expect(page.getByTestId('mcp-copy-claude-code')).toBeVisible()
+	})
+
+	test('should list the chat interfaces before the coding tools', async ({
+		page,
+	}) => {
+		// GIVEN the help page
+		await page.goto('/settings/mcp', { waitUntil: 'networkidle' })
+
+		// WHEN its section titles are read top to bottom
+		const titles = await page
+			.getByRole('heading', { level: 3 })
+			.allTextContents()
+
+		// THEN the popular chat interfaces come first and the coding tools last
+		const chatIndex = titles.findIndex(title => /chat interfaces/i.test(title))
+		const codingIndex = titles.findIndex(title => /coding tools/i.test(title))
+		expect(chatIndex).toBeGreaterThanOrEqual(0)
+		expect(codingIndex).toBeGreaterThan(chatIndex)
+	})
+})


### PR DESCRIPTION
## What

- **`PriCopyButton` primitive** (`apps/internal/src/components/primitives/`) — copies to the clipboard, swaps to a check icon, announces success through a visually-hidden polite live region, and carries the house focus ring. Callers position it with `styled()`.
- **`/settings/mcp` reordered** to lead with the chat connectors (ChatGPT, Claude.ai over OAuth) and end with the coding-tool API-key snippets, since the chat apps are the common entry point. Adopts `PriCopyButton`.
- **api-keys copy button** gains the same screen-reader announce.
- **Playwright e2e** (`mcp-setup.test.ts`): reachable from the settings nav, renders its sections, and chat interfaces sort before coding tools.
- en/ca i18n for the new strings.

## Why

The bare icon copy button was silent to assistive technology (no announcement on success) and skipped the house focus ring — WCAG 4.1.3 / 2.4.7. A shared primitive fixes both in one place and lets api-keys reuse it. The reorder reflects that most people connect from a chat UI, not a coding tool.

## Test plan

- [x] `biome check` — clean
- [x] `check-types` (apps/internal) — clean
- [x] `build` (apps/internal) — client + server bundles
- [x] `i18n:extract` — 0 missing (en/ca)
- [ ] Playwright `mcp-setup.test.ts` — runs on CI (needs the live stack)
