### PR TITLE
feat(server): rate-limit org API keys and return 429 when exceeded

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ OAUTH_ACCESS_TOKEN_TTL_SECONDS=86400
 # Days before an OAuth client with no consent is garbage-collected. Long here so
 # a client you register while testing isn't swept; production defaults short.
 OAUTH_CLIENT_GC_DAYS=365
+# Per-key rate limit for org-scoped API keys (what AI/MCP clients call /mcp
+# with). Disabled here so local MCP testing — many tool calls per turn —
+# isn't throttled; production defaults enabled at 600 requests / 60s. Tune
+# with API_KEY_RATE_LIMIT_MAX / API_KEY_RATE_LIMIT_WINDOW_SECONDS.
+API_KEY_RATE_LIMIT_ENABLED=false
 ALLOWED_ORIGINS=https://batuda.localhost
 # Canonical public app origin for the links the server mints (invitations).
 # Must be one of ALLOWED_ORIGINS — boot fails otherwise.

--- a/apps/server/src/lib/cors.ts
+++ b/apps/server/src/lib/cors.ts
@@ -63,7 +63,7 @@ export const CorsLive = Layer.unwrap(
 				// Required: browser only attaches the session cookie with
 				// credentials:'include' + a specific origin (not *).
 				credentials: true,
-				exposedHeaders: ['content-length', 'content-type'],
+				exposedHeaders: ['content-length', 'content-type', 'retry-after'],
 				maxAge: 86400, // 24 h — preflight cache; browsers cap at this anyway.
 			}),
 			{ global: true },

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -99,6 +99,22 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		const OAUTH_CLIENT_GC_DAYS = yield* Config.int('OAUTH_CLIENT_GC_DAYS').pipe(
 			Config.withDefault(7),
 		)
+		// Per-key rate limit for org-scoped API keys — the credential AI/MCP
+		// clients call /mcp with. Enabled in prod so a leaked or runaway key
+		// can't hammer the API unthrottled; dev sets ENABLED=false so local MCP
+		// testing (which fans out many tool calls per turn) never hits a false
+		// rejection. MAX requests per WINDOW_SECONDS, stamped on each key at
+		// creation. Defaults are generous (600/60s ≈ 10 req/s) — they bound
+		// abuse, not normal use; tune per environment.
+		const API_KEY_RATE_LIMIT_ENABLED = yield* Config.boolean(
+			'API_KEY_RATE_LIMIT_ENABLED',
+		).pipe(Config.withDefault(true))
+		const API_KEY_RATE_LIMIT_MAX = yield* Config.int(
+			'API_KEY_RATE_LIMIT_MAX',
+		).pipe(Config.withDefault(600))
+		const API_KEY_RATE_LIMIT_WINDOW_SECONDS = yield* Config.int(
+			'API_KEY_RATE_LIMIT_WINDOW_SECONDS',
+		).pipe(Config.withDefault(60))
 		// Comma-separated list of trusted origins (e.g.
 		// `https://batuda.localhost`). Each entry is either a literal
 		// origin matched exactly or a wildcard-subdomain pattern
@@ -220,6 +236,9 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 			BETTER_AUTH_RATE_LIMIT,
 			OAUTH_ACCESS_TOKEN_TTL_SECONDS,
 			OAUTH_CLIENT_GC_DAYS,
+			API_KEY_RATE_LIMIT_ENABLED,
+			API_KEY_RATE_LIMIT_MAX,
+			API_KEY_RATE_LIMIT_WINDOW_SECONDS,
 			ALLOWED_ORIGINS,
 			APP_PUBLIC_URL,
 			STORAGE_ENDPOINT,

--- a/apps/server/src/mcp/api-key-auth.integration.test.ts
+++ b/apps/server/src/mcp/api-key-auth.integration.test.ts
@@ -50,6 +50,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { PgLive } from '../db/client'
 import { Auth } from '../lib/auth'
+import { EnvVars } from '../lib/env'
 import { enterOrgScope } from '../middleware/org'
 import { ApiKeyService } from '../services/api-keys'
 
@@ -105,7 +106,10 @@ beforeAll(async () => {
 	await seedCompany(taller.id)
 	await seedCompany(restaurant.id)
 	runtime = ManagedRuntime.make(
-		Layer.provideMerge(ApiKeyService.layer, Layer.mergeAll(Auth.layer, PgLive)),
+		Layer.provideMerge(
+			ApiKeyService.layer,
+			Layer.mergeAll(Auth.layer, PgLive),
+		).pipe(Layer.provide(EnvVars.layer)),
 	)
 }, 60_000)
 
@@ -122,6 +126,8 @@ interface ResolveResult {
 	readonly valid: boolean
 	readonly orgId: string | null
 	readonly referenceId: string | null
+	readonly errorCode: string | null
+	readonly tryAgainIn: number | null
 }
 
 const verify = (key: string) =>
@@ -135,10 +141,16 @@ const verify = (key: string) =>
 				? ((verified.key?.metadata as { organizationId?: string } | null)
 						?.organizationId ?? null)
 				: null
+			const error = verified.error as {
+				code?: string
+				details?: { tryAgainIn?: number }
+			} | null
 			return {
 				valid: verified.valid,
 				orgId,
 				referenceId: verified.key?.referenceId ?? null,
+				errorCode: error?.code ?? null,
+				tryAgainIn: error?.details?.tryAgainIn ?? null,
 			} satisfies ResolveResult
 		}),
 	)
@@ -212,6 +224,58 @@ describe('MCP API-key auth resolution', () => {
 			// THEN neither verifies
 			expect(garbage.valid).toBe(false)
 			expect(revoked.valid).toBe(false)
+		})
+	})
+
+	describe('a rate-limited key', () => {
+		it('should fail closed with RATE_LIMITED and a retry hint once over its window', async () => {
+			// GIVEN taller's agent user (the owner every taller key references)
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ApiKeyService
+					return yield* svc.create(taller.id, { name: 'mcp-rl-seed' })
+				}),
+			)
+			const agentRow = await pool.query<{ id: string }>(
+				'SELECT id FROM "user" WHERE lower(email) = lower($1)',
+				[`agent+${taller.id}@keys.batuda.internal`],
+			)
+			const agentId = agentRow.rows[0]?.id as string
+
+			// AND a key for it capped at 2 requests in a long window (minted
+			// directly so the cap is small regardless of the env defaults)
+			const limitedKey = await runtime.runPromise(
+				Effect.gen(function* () {
+					const { instance } = yield* Auth
+					const created = yield* Effect.promise(() =>
+						instance.api.createApiKey({
+							body: {
+								userId: agentId,
+								name: 'mcp-rl',
+								metadata: { organizationId: taller.id },
+								rateLimitEnabled: true,
+								rateLimitMax: 2,
+								rateLimitTimeWindow: 60_000,
+							},
+						}),
+					)
+					return created.key
+				}),
+			)
+
+			// WHEN it is verified three times inside the window
+			const first = await verify(limitedKey)
+			const second = await verify(limitedKey)
+			const third = await verify(limitedKey)
+
+			// THEN the first two pass and the third is throttled with the code +
+			// retry hint the /mcp branch maps to a 429 + Retry-After
+			expect(first.valid).toBe(true)
+			expect(second.valid).toBe(true)
+			expect(third.valid).toBe(false)
+			expect(third.errorCode).toBe('RATE_LIMITED')
+			expect(typeof third.tryAgainIn).toBe('number')
+			expect(Math.ceil((third.tryAgainIn ?? 0) / 1000)).toBeGreaterThan(0)
 		})
 	})
 })

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -18,10 +18,15 @@ import { enterOrgScope, enterUserScope } from '../middleware/org'
 import { CurrentUser } from './current-user'
 import { McpToolsLive } from './server'
 
-const jsonRpcError = (status: number, code: number, message: string) =>
+const jsonRpcError = (
+	status: number,
+	code: number,
+	message: string,
+	headers?: Record<string, string>,
+) =>
 	HttpServerResponse.json(
 		{ jsonrpc: '2.0', id: null, error: { code, message } },
-		{ status },
+		{ status, ...(headers ? { headers } : {}) },
 	)
 
 // 401 that advertises the OAuth Authorization Server per RFC 9728: keeps the
@@ -106,9 +111,28 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					const verified = yield* Effect.promise(() =>
 						instance.api.verifyApiKey({ body: { key: apiKey } }),
 					)
-					// verifyApiKey returns valid:false for unknown/disabled/expired/
-					// rate-limited keys (it never throws for those).
 					if (!verified.valid || !verified.key) {
+						// A throttled key comes back with a distinct code (not a bad
+						// credential): answer 429 + Retry-After so the client backs off
+						// instead of treating it as an invalid credential.
+						const error = verified.error as {
+							code?: string
+							details?: { tryAgainIn?: number }
+						} | null
+						if (
+							error?.code === 'RATE_LIMITED' ||
+							error?.code === 'USAGE_EXCEEDED'
+						) {
+							const tryAgainIn = error.details?.tryAgainIn
+							return yield* jsonRpcError(
+								429,
+								-32001,
+								'API key rate limit exceeded',
+								typeof tryAgainIn === 'number'
+									? { 'retry-after': String(Math.ceil(tryAgainIn / 1000)) }
+									: undefined,
+							)
+						}
 						return yield* jsonRpcError(401, -32001, 'Invalid API key')
 					}
 					const orgId = (

--- a/apps/server/src/services/api-keys.integration.test.ts
+++ b/apps/server/src/services/api-keys.integration.test.ts
@@ -8,6 +8,7 @@ const env: Record<string, string> = {
 	BETTER_AUTH_BASE_URL: 'http://localhost:3010',
 	ALLOWED_ORIGINS: 'http://localhost:3010',
 	APP_PUBLIC_URL: 'http://localhost:3010',
+	API_KEY_RATE_LIMIT_ENABLED: 'true',
 	STORAGE_ENDPOINT: 'http://localhost:9000',
 	STORAGE_REGION: 'auto',
 	STORAGE_ACCESS_KEY_ID: 'batuda',
@@ -42,6 +43,7 @@ import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { Auth } from '../lib/auth'
+import { EnvVars } from '../lib/env'
 import { ApiKeyService } from './api-keys'
 
 const DATABASE_URL = process.env['DATABASE_URL'] as string
@@ -79,7 +81,12 @@ beforeAll(async () => {
 	tallerOrgId = await orgIdBySlug('taller')
 	restaurantOrgId = await orgIdBySlug('restaurant')
 	await cleanup()
-	runtime = ManagedRuntime.make(Layer.provide(ApiKeyService.layer, Auth.layer))
+	runtime = ManagedRuntime.make(
+		Layer.provide(
+			ApiKeyService.layer,
+			Layer.mergeAll(Auth.layer, EnvVars.layer),
+		),
+	)
 }, 60_000)
 
 afterAll(async () => {
@@ -152,13 +159,13 @@ const agentCount = async (orgId: string) => {
 
 describe('ApiKeyService.create', () => {
 	describe('for a member of the active org', () => {
-		it('should mint a one-time key stamped with the org and no rate limit', async () => {
+		it('should mint a one-time key stamped with the org, agent-owned, and rate-limited', async () => {
 			// GIVEN a create for the taller org
 			// WHEN the service mints a key
 			const created = await create(tallerOrgId, 'ci-create')
 
 			// THEN the plaintext key is returned once, and the row carries the org
-			// in metadata, is owned by the org's agent user, and has no rate limit
+			// in metadata, is owned by the org's agent user, and carries the limit
 			expect(created.key.length).toBeGreaterThan(0)
 			const row = await apikeyRow(created.id)
 			// Better Auth stores metadata as a JSON string column.
@@ -167,7 +174,7 @@ describe('ApiKeyService.create', () => {
 					? (JSON.parse(row.metadata) as unknown)
 					: row?.metadata
 			expect(meta).toMatchObject({ organizationId: tallerOrgId })
-			expect(row?.rateLimitEnabled).toBe(false)
+			expect(row?.rateLimitEnabled).toBe(true)
 			const agentR = await pool.query<{ id: string }>(
 				'SELECT id FROM "user" WHERE lower(email) = lower($1)',
 				[`agent+${tallerOrgId}@keys.batuda.internal`],

--- a/apps/server/src/services/api-keys.ts
+++ b/apps/server/src/services/api-keys.ts
@@ -3,6 +3,7 @@ import { Effect, Layer, ServiceMap } from 'effect'
 import { NotFound } from '@batuda/controllers'
 
 import { Auth } from '../lib/auth'
+import { EnvVars } from '../lib/env'
 
 // Returned once on create — `key` is the plaintext the caller must store now
 // (Better Auth hashes it on write, so it is unrecoverable afterward).
@@ -63,6 +64,7 @@ export class ApiKeyService extends ServiceMap.Service<ApiKeyService>()(
 	{
 		make: Effect.gen(function* () {
 			const auth = yield* Auth
+			const env = yield* EnvVars
 
 			// One deterministic agent user per org. `.internal` is never a routable
 			// mailbox; the user is passwordless (no `password` → no account row) and
@@ -130,7 +132,17 @@ export class ApiKeyService extends ServiceMap.Service<ApiKeyService>()(
 									userId: agentId,
 									name: input.name,
 									metadata: { organizationId: orgId },
-									rateLimitEnabled: false,
+									// Stamp the limit from config rather than inherit Better
+									// Auth's 10-req/day default, which a single MCP turn (many
+									// tool calls) would blow through.
+									rateLimitEnabled: env.API_KEY_RATE_LIMIT_ENABLED,
+									...(env.API_KEY_RATE_LIMIT_ENABLED
+										? {
+												rateLimitMax: env.API_KEY_RATE_LIMIT_MAX,
+												rateLimitTimeWindow:
+													env.API_KEY_RATE_LIMIT_WINDOW_SECONDS * 1000,
+											}
+										: {}),
 									...(input.expiresIn !== undefined
 										? { expiresIn: input.expiresIn }
 										: {}),


### PR DESCRIPTION
## What

Adds per-key rate limiting to **org-scoped API keys** (the credential AI/MCP clients call `/mcp` with) and maps a throttled key to a correct HTTP **429 + `Retry-After`**.

- **`env.ts`** — `API_KEY_RATE_LIMIT_ENABLED` (default `true`), `_MAX` (600), `_WINDOW_SECONDS` (60). Capability-named, explicit on/off gate (no NODE_ENV inference).
- **`.env.example`** — dev override `API_KEY_RATE_LIMIT_ENABLED=false` so local MCP testing (many tool calls per turn) isn't throttled.
- **`services/api-keys.ts`** — `create()` stamps explicit `rateLimitEnabled/Max/TimeWindow`. Explicit values are required: flipping the flag on without them would inherit Better Auth's **10-requests/day** default and brick clients.
- **`mcp/http.ts`** — `jsonRpcError` gains an optional headers param; the `x-api-key` branch answers **429 + `Retry-After`** for `RATE_LIMITED`/`USAGE_EXCEEDED` (Retry-After only when `tryAgainIn` is present), else the existing 401.
- **`cors.ts`** — exposes `retry-after` cross-origin.

## Why

A leaked or runaway org key could hit `/mcp` unthrottled with full org read+write. A per-key limit bounds the blast radius and contains misbehaving clients, and 429 + Retry-After tells a well-behaved client to back off instead of treating throttling as a bad credential.

## Scope / no backward compatibility

Targets only server-minted org-scoped keys (used at `/mcp`). The CLI/`packages/auth` key path (admin/external integrations) is untouched. Pre-production: limits apply to keys created from here on; existing test keys are recreated, not backfilled.

## Test plan

- [x] `check-types`
- [x] integration **141/141** (incl. new: 3× verify a max-2 key → `RATE_LIMITED` + numeric `tryAgainIn`)
- [x] unit **60/60**
- [x] `build`
- Manual (post-merge): `curl -i /mcp` with a key past its window → `429` + `Retry-After`.

Part 1 of 2 — per-user attribution (PR B) follows separately.
