### PR TITLE
feat: attribute MCP API keys to their creating member

### DIFF
--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -244,11 +244,11 @@ msgstr "Ja al CRM"
 msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
 msgstr "Un assistent d'IA vol connectar-se al teu compte de Batuda per MCP i actuar en nom teu. Aprova només els assistents en qui confiïs."
 
-#: src/routes/settings/api-keys/index.tsx:398
+#: src/routes/settings/api-keys/index.tsx:409
 msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 msgstr "Qualsevol agent que faci servir \"{confirmLabel}\" deixarà de funcionar. Això no es pot desfer."
 
-#: src/routes/settings/api-keys/index.tsx:197
+#: src/routes/settings/api-keys/index.tsx:201
 #: src/routes/settings/profile/index.tsx:122
 msgid "API keys"
 msgstr "Claus d'API"
@@ -307,7 +307,7 @@ msgstr "Torna a la safata"
 msgid "Back to organization"
 msgstr "Tornar a l'organització"
 
-#: src/routes/settings/api-keys/index.tsx:187
+#: src/routes/settings/api-keys/index.tsx:191
 #: src/routes/settings/mcp/connections.tsx:101
 #: src/routes/settings/mcp/index.tsx:107
 msgid "Back to settings"
@@ -372,6 +372,10 @@ msgstr "Resum breu (opcional)"
 msgid "Bulk thread actions"
 msgstr "Accions massives de fils"
 
+#: src/routes/settings/api-keys/index.tsx:302
+msgid "by {creatorName}"
+msgstr "per {creatorName}"
+
 #: src/routes/settings/organization/spend.tsx:168
 msgid "By provider"
 msgstr "Per proveïdor"
@@ -412,7 +416,7 @@ msgstr "Crides"
 #: src/components/research/research-dialog.tsx:221
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
-#: src/routes/settings/api-keys/index.tsx:413
+#: src/routes/settings/api-keys/index.tsx:424
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -703,8 +707,8 @@ msgstr "Converses"
 msgid "Coordinates saved from the geocoder."
 msgstr "Coordenades desades del geocodificador."
 
-#: src/routes/settings/api-keys/index.tsx:358
-#: src/routes/settings/api-keys/index.tsx:361
+#: src/routes/settings/api-keys/index.tsx:369
+#: src/routes/settings/api-keys/index.tsx:372
 msgid "Copied"
 msgstr "Copiada"
 
@@ -712,7 +716,7 @@ msgstr "Copiada"
 msgid "Copied {label}"
 msgstr "S'ha copiat {label}"
 
-#: src/routes/settings/api-keys/index.tsx:358
+#: src/routes/settings/api-keys/index.tsx:369
 msgid "Copy"
 msgstr "Copia"
 
@@ -720,7 +724,7 @@ msgstr "Copia"
 msgid "Copy {label}"
 msgstr "Copia {label}"
 
-#: src/routes/settings/api-keys/index.tsx:171
+#: src/routes/settings/api-keys/index.tsx:175
 msgid "Copy failed"
 msgstr "No s'ha pogut copiar"
 
@@ -728,7 +732,7 @@ msgstr "No s'ha pogut copiar"
 msgid "Copy slug"
 msgstr "Copia el slug"
 
-#: src/routes/settings/api-keys/index.tsx:337
+#: src/routes/settings/api-keys/index.tsx:348
 msgid "Copy your key now"
 msgstr "Copia la teva clau ara"
 
@@ -744,11 +748,11 @@ msgstr "No s'ha pogut completar la connexió. Torna-ho a provar."
 msgid "Could not create the inbox. Check transport or credentials."
 msgstr "No s'ha pogut crear la bústia. Revisa el transport o les credencials."
 
-#: src/routes/settings/api-keys/index.tsx:138
+#: src/routes/settings/api-keys/index.tsx:142
 msgid "Could not create the key. Please try again."
 msgstr "No s'ha pogut crear la clau. Torna-ho a provar."
 
-#: src/routes/settings/api-keys/index.tsx:159
+#: src/routes/settings/api-keys/index.tsx:163
 msgid "Could not delete the key. Please try again."
 msgstr "No s'ha pogut eliminar la clau. Torna-ho a provar."
 
@@ -780,7 +784,7 @@ msgstr "No s'han pogut carregar els fils"
 msgid "Could not load your connections. Refresh to try again."
 msgstr "No s'han pogut carregar les connexions. Actualitza per tornar-ho a provar."
 
-#: src/routes/settings/api-keys/index.tsx:270
+#: src/routes/settings/api-keys/index.tsx:274
 msgid "Could not load your keys. Refresh to try again."
 msgstr "No s'han pogut carregar les teves claus. Actualitza per tornar-ho a provar."
 
@@ -870,7 +874,7 @@ msgstr "Crea"
 msgid "Create a footer to append to outgoing emails from this inbox."
 msgstr "Crea un peu de pàgina per afegir als correus sortints d'aquesta bústia."
 
-#: src/routes/settings/api-keys/index.tsx:209
+#: src/routes/settings/api-keys/index.tsx:213
 msgid "Create a key"
 msgstr "Crea una clau"
 
@@ -902,7 +906,7 @@ msgstr "Crea una tasca de seguiment"
 msgid "Create footer"
 msgstr "Crea peu de pàgina"
 
-#: src/routes/settings/api-keys/index.tsx:254
+#: src/routes/settings/api-keys/index.tsx:258
 msgid "Create key"
 msgstr "Crea la clau"
 
@@ -912,7 +916,7 @@ msgid "Created"
 msgstr "Creada"
 
 #. placeholder {0}: formatDate(row.createdAt)
-#: src/routes/settings/api-keys/index.tsx:292
+#: src/routes/settings/api-keys/index.tsx:298
 msgid "Created {0}"
 msgstr "Creada el {0}"
 
@@ -920,7 +924,7 @@ msgstr "Creada el {0}"
 msgid "Created by agent"
 msgstr "Creada per agent"
 
-#: src/routes/settings/api-keys/index.tsx:254
+#: src/routes/settings/api-keys/index.tsx:258
 msgid "Creating…"
 msgstr "Creant…"
 
@@ -973,13 +977,13 @@ msgid "Defaults to you when omitted."
 msgstr "Per defecte ets tu si s'omet."
 
 #: src/routes/emails/inboxes.tsx:1385
-#: src/routes/settings/api-keys/index.tsx:318
+#: src/routes/settings/api-keys/index.tsx:329
 msgid "Delete"
 msgstr "Elimina"
 
 #: src/routes/emails/inboxes.tsx:266
 #: src/routes/emails/inboxes.tsx:1293
-#: src/routes/settings/api-keys/index.tsx:158
+#: src/routes/settings/api-keys/index.tsx:162
 msgid "Delete failed"
 msgstr "Error en eliminar"
 
@@ -993,7 +997,7 @@ msgstr "Suprimeix la bústia {0}"
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
 msgstr "Suprimir la bústia {0}? Els missatges desats es mantenen; la connexió s'atura."
 
-#: src/routes/settings/api-keys/index.tsx:428
+#: src/routes/settings/api-keys/index.tsx:439
 msgid "Delete key"
 msgstr "Elimina la clau"
 
@@ -1001,12 +1005,12 @@ msgstr "Elimina la clau"
 msgid "Delete this footer? This cannot be undone."
 msgstr "Eliminar aquest peu de pàgina? Aquesta acció no es pot desfer."
 
-#: src/routes/settings/api-keys/index.tsx:395
+#: src/routes/settings/api-keys/index.tsx:406
 msgid "Delete this key?"
 msgstr "Vols eliminar aquesta clau?"
 
-#: src/routes/settings/api-keys/index.tsx:318
-#: src/routes/settings/api-keys/index.tsx:428
+#: src/routes/settings/api-keys/index.tsx:329
+#: src/routes/settings/api-keys/index.tsx:439
 msgid "Deleting…"
 msgstr "Eliminant…"
 
@@ -1023,7 +1027,7 @@ msgid "Direction"
 msgstr "Direcció"
 
 #: src/routes/emails/inboxes.tsx:443
-#: src/routes/settings/api-keys/index.tsx:303
+#: src/routes/settings/api-keys/index.tsx:314
 msgid "Disabled"
 msgstr "Desactivada"
 
@@ -1047,7 +1051,7 @@ msgstr "Document"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/routes/settings/api-keys/index.tsx:373
+#: src/routes/settings/api-keys/index.tsx:384
 msgid "Done"
 msgstr "Fet"
 
@@ -1072,7 +1076,7 @@ msgstr "Data de venciment"
 msgid "Duration (min)"
 msgstr "Durada (min)"
 
-#: src/routes/settings/api-keys/index.tsx:222
+#: src/routes/settings/api-keys/index.tsx:226
 msgid "e.g. Claude Desktop"
 msgstr "p. ex. Claude Desktop"
 
@@ -1185,15 +1189,15 @@ msgid "Expand"
 msgstr "Desplega"
 
 #. placeholder {0}: formatDate(row.expiresAt)
-#: src/routes/settings/api-keys/index.tsx:296
+#: src/routes/settings/api-keys/index.tsx:307
 msgid "Expires {0}"
 msgstr "Caduca el {0}"
 
-#: src/routes/settings/api-keys/index.tsx:228
+#: src/routes/settings/api-keys/index.tsx:232
 msgid "Expires in (days)"
 msgstr "Caduca d'aquí a (dies)"
 
-#: src/routes/settings/api-keys/index.tsx:118
+#: src/routes/settings/api-keys/index.tsx:122
 msgid "Expiry must be a number of days greater than zero."
 msgstr "La caducitat ha de ser un nombre de dies més gran que zero."
 
@@ -1288,7 +1292,7 @@ msgstr "Pantalla completa"
 msgid "Give an AI assistant access to this organization's CRM. Chat apps like ChatGPT and Claude.ai connect over OAuth; coding tools use an API key."
 msgstr "Dona a un assistent d'IA accés al CRM d'aquesta organització. Les aplicacions de xat com ChatGPT i Claude.ai es connecten amb OAuth; les eines de programació fan servir una clau API."
 
-#: src/routes/settings/api-keys/index.tsx:111
+#: src/routes/settings/api-keys/index.tsx:115
 msgid "Give the key a name so you can recognize it later."
 msgstr "Posa un nom a la clau perquè la puguis reconèixer més endavant."
 
@@ -1442,7 +1446,7 @@ msgstr "Uneix-te a la videotrucada"
 msgid "Key"
 msgstr "Clau"
 
-#: src/routes/settings/api-keys/index.tsx:150
+#: src/routes/settings/api-keys/index.tsx:154
 msgid "Key deleted"
 msgstr "Clau eliminada"
 
@@ -1450,7 +1454,7 @@ msgstr "Clau eliminada"
 msgid "Key differentiators"
 msgstr "Diferenciadors clau"
 
-#: src/routes/settings/api-keys/index.tsx:200
+#: src/routes/settings/api-keys/index.tsx:204
 msgid "Keys let AI agents and MCP clients act on behalf of this organization."
 msgstr "Les claus permeten que els agents d'IA i els clients MCP actuïn en nom d'aquesta organització."
 
@@ -1512,7 +1516,7 @@ msgstr "Carregant l'execució…"
 
 #: src/components/companies/upcoming-meetings-card.tsx:57
 #: src/components/shared/loading-spinner.tsx:23
-#: src/routes/settings/api-keys/index.tsx:266
+#: src/routes/settings/api-keys/index.tsx:270
 #: src/routes/settings/mcp/connections.tsx:127
 #: src/routes/settings/organization/index.tsx:52
 #: src/routes/settings/organization/members.tsx:113
@@ -1687,7 +1691,7 @@ msgid "Minimize"
 msgstr "Minimitza"
 
 #: src/routes/emails/inboxes.tsx:1413
-#: src/routes/settings/api-keys/index.tsx:215
+#: src/routes/settings/api-keys/index.tsx:219
 msgid "Name"
 msgstr "Nom"
 
@@ -1706,11 +1710,11 @@ msgstr "Necessita atenció"
 msgid "never"
 msgstr "mai"
 
-#: src/routes/settings/api-keys/index.tsx:236
+#: src/routes/settings/api-keys/index.tsx:240
 msgid "Never"
 msgstr "Mai"
 
-#: src/routes/settings/api-keys/index.tsx:298
+#: src/routes/settings/api-keys/index.tsx:309
 msgid "Never expires"
 msgstr "No caduca mai"
 
@@ -1839,7 +1843,7 @@ msgstr "Cap empresa d'alta prioritat sense seguiment programat"
 msgid "No inboxes yet"
 msgstr "Encara no hi ha safates"
 
-#: src/routes/settings/api-keys/index.tsx:274
+#: src/routes/settings/api-keys/index.tsx:278
 msgid "No keys yet. Create one above to connect an agent."
 msgstr "Encara no tens cap clau. Crea'n una a dalt per connectar un agent."
 
@@ -2541,7 +2545,7 @@ msgstr "Selecciona tots els fils d'aquesta pàgina"
 msgid "Select inbox…"
 msgstr "Tria una safata…"
 
-#: src/routes/settings/api-keys/index.tsx:172
+#: src/routes/settings/api-keys/index.tsx:176
 msgid "Select the key and copy it manually."
 msgstr "Selecciona la clau i copia-la manualment."
 
@@ -2632,7 +2636,7 @@ msgstr "Posa contrasenya"
 
 #: src/components/layout/nav-items.ts:81
 #: src/routes/pages/$id.tsx:290
-#: src/routes/settings/api-keys/index.tsx:190
+#: src/routes/settings/api-keys/index.tsx:194
 #: src/routes/settings/mcp/connections.tsx:104
 #: src/routes/settings/mcp/index.tsx:110
 #: src/routes/settings/profile/index.tsx:109
@@ -2884,7 +2888,7 @@ msgstr "L'enllaç ja no és vàlid. Demana'n un de nou a sota."
 msgid "The 20 most recently edited open tasks. Click one to reopen it."
 msgstr "Les 20 tasques obertes editades més recentment. Fes-hi clic per reobrir-ne una."
 
-#: src/routes/settings/api-keys/index.tsx:151
+#: src/routes/settings/api-keys/index.tsx:155
 msgid "The API key can no longer be used."
 msgstr "La clau d'API ja no es pot fer servir."
 
@@ -2981,7 +2985,7 @@ msgstr "Aquesta invitació ja no és vàlida."
 msgid "This invitation link is no longer valid. It may have already been used."
 msgstr "Aquest enllaç de la invitació ja no és vàlid. Pot haver-se utilitzat."
 
-#: src/routes/settings/api-keys/index.tsx:340
+#: src/routes/settings/api-keys/index.tsx:351
 msgid "This is the only time the full key is shown. Store it somewhere safe — I can't show it again."
 msgstr "Aquest és l'únic moment en què es mostra la clau sencera. Desa-la en un lloc segur — no te la puc tornar a mostrar."
 
@@ -3095,7 +3099,7 @@ msgstr "Client sense nom"
 msgid "Untitled"
 msgstr "Sense títol"
 
-#: src/routes/settings/api-keys/index.tsx:279
+#: src/routes/settings/api-keys/index.tsx:283
 msgid "Untitled key"
 msgstr "Clau sense títol"
 
@@ -3283,6 +3287,6 @@ msgstr "Les teves connexions"
 msgid "Your email isn't verified yet. Use the magic link instead."
 msgstr "El correu encara no està verificat. Fes servir l'enllaç de sessió."
 
-#: src/routes/settings/api-keys/index.tsx:262
+#: src/routes/settings/api-keys/index.tsx:266
 msgid "Your keys"
 msgstr "Les teves claus"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -244,11 +244,11 @@ msgstr "Already in CRM"
 msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
 msgstr "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
 
-#: src/routes/settings/api-keys/index.tsx:398
+#: src/routes/settings/api-keys/index.tsx:409
 msgid "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 msgstr "Any agent using \"{confirmLabel}\" will stop working. This can't be undone."
 
-#: src/routes/settings/api-keys/index.tsx:197
+#: src/routes/settings/api-keys/index.tsx:201
 #: src/routes/settings/profile/index.tsx:122
 msgid "API keys"
 msgstr "API keys"
@@ -307,7 +307,7 @@ msgstr "Back to inbox"
 msgid "Back to organization"
 msgstr "Back to organization"
 
-#: src/routes/settings/api-keys/index.tsx:187
+#: src/routes/settings/api-keys/index.tsx:191
 #: src/routes/settings/mcp/connections.tsx:101
 #: src/routes/settings/mcp/index.tsx:107
 msgid "Back to settings"
@@ -372,6 +372,10 @@ msgstr "Brief summary (optional)"
 msgid "Bulk thread actions"
 msgstr "Bulk thread actions"
 
+#: src/routes/settings/api-keys/index.tsx:302
+msgid "by {creatorName}"
+msgstr "by {creatorName}"
+
 #: src/routes/settings/organization/spend.tsx:168
 msgid "By provider"
 msgstr "By provider"
@@ -412,7 +416,7 @@ msgstr "Calls"
 #: src/components/research/research-dialog.tsx:221
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
-#: src/routes/settings/api-keys/index.tsx:413
+#: src/routes/settings/api-keys/index.tsx:424
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel"
@@ -703,8 +707,8 @@ msgstr "Conversations"
 msgid "Coordinates saved from the geocoder."
 msgstr "Coordinates saved from the geocoder."
 
-#: src/routes/settings/api-keys/index.tsx:358
-#: src/routes/settings/api-keys/index.tsx:361
+#: src/routes/settings/api-keys/index.tsx:369
+#: src/routes/settings/api-keys/index.tsx:372
 msgid "Copied"
 msgstr "Copied"
 
@@ -712,7 +716,7 @@ msgstr "Copied"
 msgid "Copied {label}"
 msgstr "Copied {label}"
 
-#: src/routes/settings/api-keys/index.tsx:358
+#: src/routes/settings/api-keys/index.tsx:369
 msgid "Copy"
 msgstr "Copy"
 
@@ -720,7 +724,7 @@ msgstr "Copy"
 msgid "Copy {label}"
 msgstr "Copy {label}"
 
-#: src/routes/settings/api-keys/index.tsx:171
+#: src/routes/settings/api-keys/index.tsx:175
 msgid "Copy failed"
 msgstr "Copy failed"
 
@@ -728,7 +732,7 @@ msgstr "Copy failed"
 msgid "Copy slug"
 msgstr "Copy slug"
 
-#: src/routes/settings/api-keys/index.tsx:337
+#: src/routes/settings/api-keys/index.tsx:348
 msgid "Copy your key now"
 msgstr "Copy your key now"
 
@@ -744,11 +748,11 @@ msgstr "Could not complete the connection. Please try again."
 msgid "Could not create the inbox. Check transport or credentials."
 msgstr "Could not create the inbox. Check transport or credentials."
 
-#: src/routes/settings/api-keys/index.tsx:138
+#: src/routes/settings/api-keys/index.tsx:142
 msgid "Could not create the key. Please try again."
 msgstr "Could not create the key. Please try again."
 
-#: src/routes/settings/api-keys/index.tsx:159
+#: src/routes/settings/api-keys/index.tsx:163
 msgid "Could not delete the key. Please try again."
 msgstr "Could not delete the key. Please try again."
 
@@ -780,7 +784,7 @@ msgstr "Could not load threads"
 msgid "Could not load your connections. Refresh to try again."
 msgstr "Could not load your connections. Refresh to try again."
 
-#: src/routes/settings/api-keys/index.tsx:270
+#: src/routes/settings/api-keys/index.tsx:274
 msgid "Could not load your keys. Refresh to try again."
 msgstr "Could not load your keys. Refresh to try again."
 
@@ -870,7 +874,7 @@ msgstr "Create"
 msgid "Create a footer to append to outgoing emails from this inbox."
 msgstr "Create a footer to append to outgoing emails from this inbox."
 
-#: src/routes/settings/api-keys/index.tsx:209
+#: src/routes/settings/api-keys/index.tsx:213
 msgid "Create a key"
 msgstr "Create a key"
 
@@ -902,7 +906,7 @@ msgstr "Create follow-up task"
 msgid "Create footer"
 msgstr "Create footer"
 
-#: src/routes/settings/api-keys/index.tsx:254
+#: src/routes/settings/api-keys/index.tsx:258
 msgid "Create key"
 msgstr "Create key"
 
@@ -912,7 +916,7 @@ msgid "Created"
 msgstr "Created"
 
 #. placeholder {0}: formatDate(row.createdAt)
-#: src/routes/settings/api-keys/index.tsx:292
+#: src/routes/settings/api-keys/index.tsx:298
 msgid "Created {0}"
 msgstr "Created {0}"
 
@@ -920,7 +924,7 @@ msgstr "Created {0}"
 msgid "Created by agent"
 msgstr "Created by agent"
 
-#: src/routes/settings/api-keys/index.tsx:254
+#: src/routes/settings/api-keys/index.tsx:258
 msgid "Creating…"
 msgstr "Creating…"
 
@@ -973,13 +977,13 @@ msgid "Defaults to you when omitted."
 msgstr "Defaults to you when omitted."
 
 #: src/routes/emails/inboxes.tsx:1385
-#: src/routes/settings/api-keys/index.tsx:318
+#: src/routes/settings/api-keys/index.tsx:329
 msgid "Delete"
 msgstr "Delete"
 
 #: src/routes/emails/inboxes.tsx:266
 #: src/routes/emails/inboxes.tsx:1293
-#: src/routes/settings/api-keys/index.tsx:158
+#: src/routes/settings/api-keys/index.tsx:162
 msgid "Delete failed"
 msgstr "Delete failed"
 
@@ -993,7 +997,7 @@ msgstr "Delete inbox {0}"
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
 msgstr "Delete inbox {0}? Stored messages stay; the connection stops."
 
-#: src/routes/settings/api-keys/index.tsx:428
+#: src/routes/settings/api-keys/index.tsx:439
 msgid "Delete key"
 msgstr "Delete key"
 
@@ -1001,12 +1005,12 @@ msgstr "Delete key"
 msgid "Delete this footer? This cannot be undone."
 msgstr "Delete this footer? This cannot be undone."
 
-#: src/routes/settings/api-keys/index.tsx:395
+#: src/routes/settings/api-keys/index.tsx:406
 msgid "Delete this key?"
 msgstr "Delete this key?"
 
-#: src/routes/settings/api-keys/index.tsx:318
-#: src/routes/settings/api-keys/index.tsx:428
+#: src/routes/settings/api-keys/index.tsx:329
+#: src/routes/settings/api-keys/index.tsx:439
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1023,7 +1027,7 @@ msgid "Direction"
 msgstr "Direction"
 
 #: src/routes/emails/inboxes.tsx:443
-#: src/routes/settings/api-keys/index.tsx:303
+#: src/routes/settings/api-keys/index.tsx:314
 msgid "Disabled"
 msgstr "Disabled"
 
@@ -1047,7 +1051,7 @@ msgstr "Document"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/routes/settings/api-keys/index.tsx:373
+#: src/routes/settings/api-keys/index.tsx:384
 msgid "Done"
 msgstr "Done"
 
@@ -1072,7 +1076,7 @@ msgstr "Due date"
 msgid "Duration (min)"
 msgstr "Duration (min)"
 
-#: src/routes/settings/api-keys/index.tsx:222
+#: src/routes/settings/api-keys/index.tsx:226
 msgid "e.g. Claude Desktop"
 msgstr "e.g. Claude Desktop"
 
@@ -1185,15 +1189,15 @@ msgid "Expand"
 msgstr "Expand"
 
 #. placeholder {0}: formatDate(row.expiresAt)
-#: src/routes/settings/api-keys/index.tsx:296
+#: src/routes/settings/api-keys/index.tsx:307
 msgid "Expires {0}"
 msgstr "Expires {0}"
 
-#: src/routes/settings/api-keys/index.tsx:228
+#: src/routes/settings/api-keys/index.tsx:232
 msgid "Expires in (days)"
 msgstr "Expires in (days)"
 
-#: src/routes/settings/api-keys/index.tsx:118
+#: src/routes/settings/api-keys/index.tsx:122
 msgid "Expiry must be a number of days greater than zero."
 msgstr "Expiry must be a number of days greater than zero."
 
@@ -1288,7 +1292,7 @@ msgstr "Full screen"
 msgid "Give an AI assistant access to this organization's CRM. Chat apps like ChatGPT and Claude.ai connect over OAuth; coding tools use an API key."
 msgstr "Give an AI assistant access to this organization's CRM. Chat apps like ChatGPT and Claude.ai connect over OAuth; coding tools use an API key."
 
-#: src/routes/settings/api-keys/index.tsx:111
+#: src/routes/settings/api-keys/index.tsx:115
 msgid "Give the key a name so you can recognize it later."
 msgstr "Give the key a name so you can recognize it later."
 
@@ -1442,7 +1446,7 @@ msgstr "Join video call"
 msgid "Key"
 msgstr "Key"
 
-#: src/routes/settings/api-keys/index.tsx:150
+#: src/routes/settings/api-keys/index.tsx:154
 msgid "Key deleted"
 msgstr "Key deleted"
 
@@ -1450,7 +1454,7 @@ msgstr "Key deleted"
 msgid "Key differentiators"
 msgstr "Key differentiators"
 
-#: src/routes/settings/api-keys/index.tsx:200
+#: src/routes/settings/api-keys/index.tsx:204
 msgid "Keys let AI agents and MCP clients act on behalf of this organization."
 msgstr "Keys let AI agents and MCP clients act on behalf of this organization."
 
@@ -1512,7 +1516,7 @@ msgstr "Loading run…"
 
 #: src/components/companies/upcoming-meetings-card.tsx:57
 #: src/components/shared/loading-spinner.tsx:23
-#: src/routes/settings/api-keys/index.tsx:266
+#: src/routes/settings/api-keys/index.tsx:270
 #: src/routes/settings/mcp/connections.tsx:127
 #: src/routes/settings/organization/index.tsx:52
 #: src/routes/settings/organization/members.tsx:113
@@ -1687,7 +1691,7 @@ msgid "Minimize"
 msgstr "Minimize"
 
 #: src/routes/emails/inboxes.tsx:1413
-#: src/routes/settings/api-keys/index.tsx:215
+#: src/routes/settings/api-keys/index.tsx:219
 msgid "Name"
 msgstr "Name"
 
@@ -1706,11 +1710,11 @@ msgstr "Needs attention"
 msgid "never"
 msgstr "never"
 
-#: src/routes/settings/api-keys/index.tsx:236
+#: src/routes/settings/api-keys/index.tsx:240
 msgid "Never"
 msgstr "Never"
 
-#: src/routes/settings/api-keys/index.tsx:298
+#: src/routes/settings/api-keys/index.tsx:309
 msgid "Never expires"
 msgstr "Never expires"
 
@@ -1839,7 +1843,7 @@ msgstr "No high-priority companies without a scheduled follow-up"
 msgid "No inboxes yet"
 msgstr "No inboxes yet"
 
-#: src/routes/settings/api-keys/index.tsx:274
+#: src/routes/settings/api-keys/index.tsx:278
 msgid "No keys yet. Create one above to connect an agent."
 msgstr "No keys yet. Create one above to connect an agent."
 
@@ -2541,7 +2545,7 @@ msgstr "Select all threads on this page"
 msgid "Select inbox…"
 msgstr "Select inbox…"
 
-#: src/routes/settings/api-keys/index.tsx:172
+#: src/routes/settings/api-keys/index.tsx:176
 msgid "Select the key and copy it manually."
 msgstr "Select the key and copy it manually."
 
@@ -2632,7 +2636,7 @@ msgstr "Set password"
 
 #: src/components/layout/nav-items.ts:81
 #: src/routes/pages/$id.tsx:290
-#: src/routes/settings/api-keys/index.tsx:190
+#: src/routes/settings/api-keys/index.tsx:194
 #: src/routes/settings/mcp/connections.tsx:104
 #: src/routes/settings/mcp/index.tsx:110
 #: src/routes/settings/profile/index.tsx:109
@@ -2884,7 +2888,7 @@ msgstr "That link is no longer valid. Request a fresh one below."
 msgid "The 20 most recently edited open tasks. Click one to reopen it."
 msgstr "The 20 most recently edited open tasks. Click one to reopen it."
 
-#: src/routes/settings/api-keys/index.tsx:151
+#: src/routes/settings/api-keys/index.tsx:155
 msgid "The API key can no longer be used."
 msgstr "The API key can no longer be used."
 
@@ -2981,7 +2985,7 @@ msgstr "This invitation is no longer valid."
 msgid "This invitation link is no longer valid. It may have already been used."
 msgstr "This invitation link is no longer valid. It may have already been used."
 
-#: src/routes/settings/api-keys/index.tsx:340
+#: src/routes/settings/api-keys/index.tsx:351
 msgid "This is the only time the full key is shown. Store it somewhere safe — I can't show it again."
 msgstr "This is the only time the full key is shown. Store it somewhere safe — I can't show it again."
 
@@ -3095,7 +3099,7 @@ msgstr "Unnamed client"
 msgid "Untitled"
 msgstr "Untitled"
 
-#: src/routes/settings/api-keys/index.tsx:279
+#: src/routes/settings/api-keys/index.tsx:283
 msgid "Untitled key"
 msgstr "Untitled key"
 
@@ -3283,6 +3287,6 @@ msgstr "Your connections"
 msgid "Your email isn't verified yet. Use the magic link instead."
 msgstr "Your email isn't verified yet. Use the magic link instead."
 
-#: src/routes/settings/api-keys/index.tsx:262
+#: src/routes/settings/api-keys/index.tsx:266
 msgid "Your keys"
 msgstr "Your keys"

--- a/apps/internal/src/routes/settings/api-keys/index.tsx
+++ b/apps/internal/src/routes/settings/api-keys/index.tsx
@@ -38,6 +38,10 @@ type ApiKeyRow = {
 	readonly expiresAt: string | null
 	readonly createdAt: string
 	readonly enabled: boolean
+	readonly createdBy: {
+		readonly name: string | null
+		readonly email: string
+	} | null
 }
 
 // The one-time create response — the only place the plaintext `key` exists.
@@ -278,6 +282,8 @@ function ApiKeysPage() {
 						{rows.map(row => {
 							const label = row.name ?? t`Untitled key`
 							const isDeleting = deletingId === row.id
+							const creatorName =
+								row.createdBy?.name ?? row.createdBy?.email ?? null
 							return (
 								<KeyRow key={row.id} data-testid='api-key-row'>
 									<KeyInfo>
@@ -291,6 +297,11 @@ function ApiKeysPage() {
 											<MetaItem>
 												<Trans>Created {formatDate(row.createdAt)}</Trans>
 											</MetaItem>
+											{creatorName ? (
+												<MetaItem data-testid='api-key-creator'>
+													<Trans>by {creatorName}</Trans>
+												</MetaItem>
+											) : null}
 											<MetaItem>
 												{row.expiresAt ? (
 													<Trans>Expires {formatDate(row.expiresAt)}</Trans>
@@ -452,9 +463,20 @@ function narrowKeys(rows: ReadonlyArray<unknown>): ReadonlyArray<ApiKeyRow> {
 			prefix: typeof r['prefix'] === 'string' ? r['prefix'] : null,
 			expiresAt: typeof r['expiresAt'] === 'string' ? r['expiresAt'] : null,
 			enabled: r['enabled'] !== false,
+			createdBy: narrowCreatedBy(r['createdBy']),
 		})
 	}
 	return out
+}
+
+function narrowCreatedBy(
+	value: unknown,
+): { readonly name: string | null; readonly email: string } | null {
+	if (!value || typeof value !== 'object') return null
+	const v = value as Record<string, unknown>
+	const email = typeof v['email'] === 'string' ? v['email'] : null
+	if (email === null) return null
+	return { name: typeof v['name'] === 'string' ? v['name'] : null, email }
 }
 
 function narrowCreated(value: unknown): CreatedApiKey | null {

--- a/apps/server/src/handlers/api-keys.ts
+++ b/apps/server/src/handlers/api-keys.ts
@@ -22,7 +22,7 @@ export const ApiKeysLive = HttpApiBuilder.group(
 					Effect.gen(function* () {
 						const org = yield* CurrentOrg
 						const { userId } = yield* SessionContext
-						const created = yield* apiKeyService.create(org.id, {
+						const created = yield* apiKeyService.create(org.id, userId, {
 							name: _.payload.name,
 							expiresIn:
 								_.payload.expiresInDays !== undefined

--- a/apps/server/src/mcp/api-key-auth.integration.test.ts
+++ b/apps/server/src/mcp/api-key-auth.integration.test.ts
@@ -1,7 +1,7 @@
-// Pins how the /mcp middleware resolves an org API key: key → org's agent +
-// org (from the key's metadata) → scoped session, the org isolation that
-// yields, and the fail-closed rejections. The JSON-RPC envelope wiring is
-// covered by the boot test.
+// Pins how the /mcp middleware resolves an org API key: key → its org + the
+// creating member (from the key's metadata) → a session scoped to that member,
+// the org isolation that yields, and the fail-closed rejections. The JSON-RPC
+// envelope wiring is covered by the boot test.
 //
 // The full env must be set before the Auth layer builds.
 const env: Record<string, string> = {
@@ -67,6 +67,7 @@ let runtime: ManagedRuntime.ManagedRuntime<
 >
 let taller: Org
 let restaurant: Org
+let tallerMemberId: string
 
 const orgBySlug = async (slug: string): Promise<Org> => {
 	const result = await pool.query<Org>(
@@ -79,6 +80,17 @@ const orgBySlug = async (slug: string): Promise<Org> => {
 			`${slug} org missing — run 'pnpm cli db reset && pnpm cli seed'`,
 		)
 	return row
+}
+
+// A real member of the org — the key creator a real /mcp key would carry.
+const memberIdOf = async (orgId: string): Promise<string> => {
+	const r = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 ORDER BY "userId" LIMIT 1',
+		[orgId],
+	)
+	const id = r.rows[0]?.userId
+	if (!id) throw new Error(`${orgId} has no members — run 'pnpm cli seed'`)
+	return id
 }
 
 // One marker company per org, so a scoped read can prove isolation.
@@ -102,6 +114,7 @@ beforeAll(async () => {
 	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
 	taller = await orgBySlug('taller')
 	restaurant = await orgBySlug('restaurant')
+	tallerMemberId = await memberIdOf(taller.id)
 	await cleanup()
 	await seedCompany(taller.id)
 	await seedCompany(restaurant.id)
@@ -119,9 +132,9 @@ afterAll(async () => {
 	await pool.end()
 })
 
-// Mints a key (ApiKeyService), verifies it (the middleware's first step), then
-// — for a valid org key — resolves the org from metadata and runs `body`
-// inside enterOrgScope as the agent, exactly as the /mcp middleware would.
+// Verifies a key the way the /mcp middleware does as its first step, surfacing
+// what the result carries (validity, org, the key's agent owner, rate-limit
+// error). Creator resolution is exercised separately via `resolveCreator`.
 interface ResolveResult {
 	readonly valid: boolean
 	readonly orgId: string | null
@@ -155,14 +168,42 @@ const verify = (key: string) =>
 		}),
 	)
 
+// Mirrors the /mcp middleware's creator resolution: verify, read the creator id
+// from the key's metadata, and confirm a live membership in the org. Returns the
+// creator's user id, or null when the key has no creator or the creator is not
+// (or no longer) a member.
+const resolveCreator = (orgId: string, key: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const { instance } = yield* Auth
+			const verified = yield* Effect.promise(() =>
+				instance.api.verifyApiKey({ body: { key } }),
+			)
+			if (!verified.valid || !verified.key) return null
+			const createdByUserId = (
+				verified.key.metadata as { createdByUserId?: string } | null
+			)?.createdByUserId
+			if (!createdByUserId) return null
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<{ id: string }>`
+				SELECT u.id FROM "user" u
+				JOIN member m ON m."userId" = u.id AND m."organizationId" = ${orgId}
+				WHERE u.id = ${createdByUserId} LIMIT 1
+			`
+			return rows[0]?.id ?? null
+		}),
+	)
+
 describe('MCP API-key auth resolution', () => {
 	describe('a valid org key', () => {
-		it('should resolve to its org + agent and scope reads to that org', async () => {
+		it('should attribute to the creating member and scope reads to its org', async () => {
 			// GIVEN a key minted for the taller org
 			const created = await runtime.runPromise(
 				Effect.gen(function* () {
 					const svc = yield* ApiKeyService
-					return yield* svc.create(taller.id, { name: 'mcp-key' })
+					return yield* svc.create(taller.id, tallerMemberId, {
+						name: 'mcp-key',
+					})
 				}),
 			)
 
@@ -177,8 +218,10 @@ describe('MCP API-key auth resolution', () => {
 				[`agent+${taller.id}@keys.batuda.internal`],
 			)
 			expect(resolved.referenceId).toBe(agent.rows[0]?.id)
+			// AND it attributes to the creating member, still a live member
+			expect(await resolveCreator(taller.id, created.key)).toBe(tallerMemberId)
 
-			// AND entering that scope as the agent reads only taller's marker
+			// AND entering that scope as the creating member reads only taller's marker
 			// company, never restaurant's (RLS isolation)
 			// Result columns are camelCase (PgClient transformResultNames).
 			const orgIds = await runtime.runPromise(
@@ -186,7 +229,7 @@ describe('MCP API-key auth resolution', () => {
 					const sql = yield* SqlClient.SqlClient
 					return yield* enterOrgScope(sql, {
 						org: taller,
-						userId: resolved.referenceId ?? '',
+						userId: tallerMemberId,
 					})(
 						Effect.gen(function* () {
 							const rows = yield* sql<{ organizationId: string }>`
@@ -209,7 +252,9 @@ describe('MCP API-key auth resolution', () => {
 			const created = await runtime.runPromise(
 				Effect.gen(function* () {
 					const svc = yield* ApiKeyService
-					return yield* svc.create(taller.id, { name: 'mcp-revoke' })
+					return yield* svc.create(taller.id, tallerMemberId, {
+						name: 'mcp-revoke',
+					})
 				}),
 			)
 			const id = created.id
@@ -233,7 +278,9 @@ describe('MCP API-key auth resolution', () => {
 			await runtime.runPromise(
 				Effect.gen(function* () {
 					const svc = yield* ApiKeyService
-					return yield* svc.create(taller.id, { name: 'mcp-rl-seed' })
+					return yield* svc.create(taller.id, tallerMemberId, {
+						name: 'mcp-rl-seed',
+					})
 				}),
 			)
 			const agentRow = await pool.query<{ id: string }>(
@@ -276,6 +323,62 @@ describe('MCP API-key auth resolution', () => {
 			expect(third.errorCode).toBe('RATE_LIMITED')
 			expect(typeof third.tryAgainIn).toBe('number')
 			expect(Math.ceil((third.tryAgainIn ?? 0) / 1000)).toBeGreaterThan(0)
+		})
+	})
+
+	describe('a key whose creator is no longer a member', () => {
+		it('should resolve no creator, so the middleware rejects it', async () => {
+			// GIVEN a taller key stamped with a creator id that has no taller
+			// membership (a member who has since left, or never belonged)
+			const exMemberId = randomUUID()
+			const created = await runtime.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ApiKeyService
+					return yield* svc.create(taller.id, exMemberId, {
+						name: 'mcp-ex-member',
+					})
+				}),
+			)
+			// WHEN resolving the creator against taller
+			// THEN no live membership → null (the middleware answers 403)
+			expect(await resolveCreator(taller.id, created.key)).toBeNull()
+		})
+	})
+
+	describe('a key with no creator in its metadata', () => {
+		it('should resolve no creator, so the middleware rejects it', async () => {
+			// GIVEN a key minted directly without a createdByUserId; there is no
+			// backward-compat fallback to the org agent
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ApiKeyService
+					return yield* svc.create(taller.id, tallerMemberId, {
+						name: 'mcp-nocreator-seed',
+					})
+				}),
+			)
+			const agentRow = await pool.query<{ id: string }>(
+				'SELECT id FROM "user" WHERE lower(email) = lower($1)',
+				[`agent+${taller.id}@keys.batuda.internal`],
+			)
+			const key = await runtime.runPromise(
+				Effect.gen(function* () {
+					const { instance } = yield* Auth
+					const created = yield* Effect.promise(() =>
+						instance.api.createApiKey({
+							body: {
+								userId: agentRow.rows[0]?.id as string,
+								name: 'mcp-nocreator',
+								metadata: { organizationId: taller.id },
+							},
+						}),
+					)
+					return created.key
+				}),
+			)
+			// WHEN resolving the creator
+			// THEN none (no createdByUserId) → null (the middleware answers 403)
+			expect(await resolveCreator(taller.id, key)).toBeNull()
 		})
 	})
 })

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -103,9 +103,10 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						enterOrgScope(sql, { org, userId: principal.userId }),
 					)
 
-				// ── API-key path (AI/MCP clients): the key resolves to its org's
-				// agent user (referenceId) and the org from metadata — no cookie
-				// session or activeOrganizationId is involved. Fail closed.
+				// ── API-key path (AI/MCP clients): the org and the creating member
+				// come from the key's metadata; the session acts as that member so
+				// actions attribute to them — no cookie or activeOrganizationId
+				// involved. Fail closed.
 				const apiKey = headers.get('x-api-key')
 				if (apiKey) {
 					const verified = yield* Effect.promise(() =>
@@ -135,34 +136,48 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						}
 						return yield* jsonRpcError(401, -32001, 'Invalid API key')
 					}
-					const orgId = (
-						verified.key.metadata as { organizationId?: string } | null
-					)?.organizationId
+					const meta = verified.key.metadata as {
+						organizationId?: string
+						createdByUserId?: string
+					} | null
+					const orgId = meta?.organizationId
 					if (!orgId) {
 						return yield* jsonRpcError(401, -32001, 'API key is not org-scoped')
 					}
+					// Required, never silently org-attributed: a key with no creator
+					// in its metadata is rejected outright.
+					const createdByUserId = meta?.createdByUserId
+					if (!createdByUserId) {
+						return yield* jsonRpcError(
+							403,
+							-32003,
+							'API key has no creator; recreate it',
+						)
+					}
 					const org = yield* loadOrg(orgId)
-					const agentRows = yield* sql<{
+					// Resolve the creator and confirm they are still a live member of the
+					// org: the key stops working once they leave.
+					const creatorRows = yield* sql<{
 						id: string
 						email: string
 						name: string | null
 					}>`
-						SELECT id, email, name FROM "user"
-						WHERE id = ${verified.key.referenceId} LIMIT 1
+						SELECT u.id, u.email, u.name FROM "user" u
+						JOIN member m ON m."userId" = u.id AND m."organizationId" = ${orgId}
+						WHERE u.id = ${createdByUserId} LIMIT 1
 					`.pipe(Effect.orDie)
-					const agent = agentRows[0]
-					// Org or agent user deleted out from under the key → fail closed.
-					if (!org || !agent) {
+					const creator = creatorRows[0]
+					if (!org || !creator) {
 						return yield* jsonRpcError(
 							403,
 							-32003,
-							'API key organization or agent is no longer available',
+							'API key creator is no longer a member of its organization',
 						)
 					}
 					return yield* enterScope(org, {
-						userId: agent.id,
-						email: agent.email,
-						name: agent.name,
+						userId: creator.id,
+						email: creator.email,
+						name: creator.name,
 						isAgent: true,
 					})
 				}

--- a/apps/server/src/services/api-keys.integration.test.ts
+++ b/apps/server/src/services/api-keys.integration.test.ts
@@ -54,6 +54,7 @@ let pool: pg.Pool
 let runtime: ManagedRuntime.ManagedRuntime<ApiKeyService, Config.ConfigError>
 let tallerOrgId: string
 let restaurantOrgId: string
+let tallerMemberId: string
 
 const orgIdBySlug = async (slug: string): Promise<string> => {
 	const r = await pool.query<{ id: string }>(
@@ -65,6 +66,17 @@ const orgIdBySlug = async (slug: string): Promise<string> => {
 		throw new Error(
 			`${slug} org missing — run 'pnpm cli db reset && pnpm cli seed'`,
 		)
+	return id
+}
+
+// A real member of the org, used as the key creator (stored in key metadata).
+const memberIdOf = async (orgId: string): Promise<string> => {
+	const r = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 ORDER BY "userId" LIMIT 1',
+		[orgId],
+	)
+	const id = r.rows[0]?.userId
+	if (!id) throw new Error(`${orgId} has no members — run 'pnpm cli seed'`)
 	return id
 }
 
@@ -80,6 +92,7 @@ beforeAll(async () => {
 	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
 	tallerOrgId = await orgIdBySlug('taller')
 	restaurantOrgId = await orgIdBySlug('restaurant')
+	tallerMemberId = await memberIdOf(tallerOrgId)
 	await cleanup()
 	runtime = ManagedRuntime.make(
 		Layer.provide(
@@ -95,11 +108,16 @@ afterAll(async () => {
 	await pool.end()
 })
 
-const create = (orgId: string, name: string, expiresIn?: number) =>
+const create = (
+	orgId: string,
+	name: string,
+	expiresIn?: number,
+	actorUserId = tallerMemberId,
+) =>
 	runtime.runPromise(
 		Effect.gen(function* () {
 			const svc = yield* ApiKeyService
-			return yield* svc.create(orgId, { name, expiresIn })
+			return yield* svc.create(orgId, actorUserId, { name, expiresIn })
 		}),
 	)
 
@@ -173,7 +191,10 @@ describe('ApiKeyService.create', () => {
 				typeof row?.metadata === 'string'
 					? (JSON.parse(row.metadata) as unknown)
 					: row?.metadata
-			expect(meta).toMatchObject({ organizationId: tallerOrgId })
+			expect(meta).toMatchObject({
+				organizationId: tallerOrgId,
+				createdByUserId: tallerMemberId,
+			})
 			expect(row?.rateLimitEnabled).toBe(true)
 			const agentR = await pool.query<{ id: string }>(
 				'SELECT id FROM "user" WHERE lower(email) = lower($1)',
@@ -218,6 +239,8 @@ describe('ApiKeyService.list', () => {
 		const found = tallerKeys.find(k => k.id === created.id)
 		expect(found).toBeDefined()
 		expect(found).not.toHaveProperty('key')
+		// list resolves the key's creator from its metadata
+		expect(found?.createdBy?.id).toBe(tallerMemberId)
 		expect(restaurantKeys.some(k => k.id === created.id)).toBe(false)
 	})
 

--- a/apps/server/src/services/api-keys.ts
+++ b/apps/server/src/services/api-keys.ts
@@ -17,6 +17,13 @@ export interface CreatedApiKey {
 	readonly createdAt: string
 }
 
+// Resolved creator of a key — the human whose session minted it.
+interface Creator {
+	readonly id: string
+	readonly name: string | null
+	readonly email: string
+}
+
 // List/get shape — never carries the secret, only the masked `start` prefix.
 export interface RedactedApiKey {
 	readonly id: string
@@ -26,6 +33,7 @@ export interface RedactedApiKey {
 	readonly expiresAt: string | null
 	readonly createdAt: string
 	readonly enabled: boolean
+	readonly createdBy: Creator | null
 }
 
 interface KeyRow {
@@ -36,12 +44,31 @@ interface KeyRow {
 	readonly expiresAt: string | Date | null
 	readonly createdAt: string | Date
 	readonly enabled: boolean
+	readonly metadata: string | null
 }
 
 const isoOrNull = (value: string | Date | null): string | null =>
 	value === null ? null : new Date(value).toISOString()
 
-const toRedacted = (row: KeyRow): RedactedApiKey => ({
+// Better Auth stores key metadata as a JSON string column; pull the creator id
+// back out, tolerating a double-encoded value.
+const parseCreatorId = (metadata: string | null): string | null => {
+	if (!metadata) return null
+	try {
+		let parsed: unknown = JSON.parse(metadata)
+		if (typeof parsed === 'string') parsed = JSON.parse(parsed)
+		return (
+			(parsed as { createdByUserId?: string } | null)?.createdByUserId ?? null
+		)
+	} catch {
+		return null
+	}
+}
+
+const toRedacted = (
+	row: KeyRow,
+	createdBy: Creator | null,
+): RedactedApiKey => ({
 	id: row.id,
 	name: row.name,
 	start: row.start,
@@ -49,9 +76,11 @@ const toRedacted = (row: KeyRow): RedactedApiKey => ({
 	expiresAt: isoOrNull(row.expiresAt),
 	createdAt: new Date(row.createdAt).toISOString(),
 	enabled: row.enabled,
+	createdBy,
 })
 
-const SELECT_COLS = 'id, name, start, prefix, "expiresAt", "createdAt", enabled'
+const SELECT_COLS =
+	'id, name, start, prefix, "expiresAt", "createdAt", enabled, metadata'
 
 // API keys are owned by a per-org agent user (`isAgent`) and carry the org in
 // their Better Auth `metadata`; the MCP transport reads that to scope the
@@ -113,9 +142,31 @@ export class ApiKeyService extends ServiceMap.Service<ApiKeyService>()(
 					return created
 				})
 
+			// Batch-resolve the human creators of a set of keys so a listing can
+			// label each key with who minted it — one query, not one per key.
+			const resolveCreators = (rows: ReadonlyArray<KeyRow>) =>
+				Effect.gen(function* () {
+					const ids = [
+						...new Set(
+							rows
+								.map(r => parseCreatorId(r.metadata))
+								.filter((id): id is string => id !== null),
+						),
+					]
+					if (ids.length === 0) return new Map<string, Creator>()
+					const users = yield* Effect.tryPromise(() =>
+						auth.pool.query<Creator>(
+							'SELECT id, name, email FROM "user" WHERE id = ANY($1)',
+							[ids],
+						),
+					).pipe(Effect.orDie)
+					return new Map(users.rows.map(u => [u.id, u] as const))
+				})
+
 			return {
 				create: (
 					orgId: string,
+					actorUserId: string,
 					input: {
 						readonly name: string
 						readonly expiresIn?: number | undefined
@@ -131,7 +182,10 @@ export class ApiKeyService extends ServiceMap.Service<ApiKeyService>()(
 								body: {
 									userId: agentId,
 									name: input.name,
-									metadata: { organizationId: orgId },
+									metadata: {
+										organizationId: orgId,
+										createdByUserId: actorUserId,
+									},
 									// Stamp the limit from config rather than inherit Better
 									// Auth's 10-req/day default, which a single MCP turn (many
 									// tool calls) would blow through.
@@ -173,7 +227,13 @@ export class ApiKeyService extends ServiceMap.Service<ApiKeyService>()(
 								[agentId],
 							),
 						).pipe(Effect.orDie)
-						return rows.rows.map(toRedacted)
+						const creators = yield* resolveCreators(rows.rows)
+						return rows.rows.map(row =>
+							toRedacted(
+								row,
+								creators.get(parseCreatorId(row.metadata) ?? '') ?? null,
+							),
+						)
 					}),
 
 				get: (
@@ -194,7 +254,11 @@ export class ApiKeyService extends ServiceMap.Service<ApiKeyService>()(
 						const row = rows.rows[0]
 						if (!row)
 							return yield* new NotFound({ entity: 'apiKey', id: keyId })
-						return toRedacted(row)
+						const creators = yield* resolveCreators([row])
+						return toRedacted(
+							row,
+							creators.get(parseCreatorId(row.metadata) ?? '') ?? null,
+						)
 					}),
 
 				delete: (orgId: string, keyId: string): Effect.Effect<void, NotFound> =>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -345,9 +345,9 @@ Company status updated to "client" via MCP or web
 
 ## Authentication (Better Auth)
 
-All auth is handled by [Better Auth](https://www.better-auth.com/) v1.5.6 with plugins: `openAPI`, `bearer`, `admin`, `apiKey`, `organization`, `magicLink`.
+All auth is handled by [Better Auth](https://www.better-auth.com/) v1.6.11 with plugins: `openAPI`, `bearer`, `admin`, `apiKey`, `organization`, `magicLink`, `jwt`, and `oauthProvider` (the OAuth 2.1 authorization server for web-chat MCP clients).
 
-**Multi-org scoping.** Every request resolves an `activeOrganizationId` from the session (or env var, for MCP stdio in dev). Middleware loads the matching `organization` row into a `CurrentOrg` ServiceMap service, then opens a transactional connection that runs `SET LOCAL app.current_org_id = $orgId` before any tenant-scoped reads/writes. Two Postgres roles enforce isolation: `app_user` (RLS enforced — HTTP + MCP path) and `app_service` (BYPASSRLS — mail worker + cron jobs that resolve org ownership explicitly per row).
+**Multi-org scoping.** Every request resolves an `activeOrganizationId` from the session (or env var, for MCP stdio in dev). Middleware loads the matching `organization` row into a `CurrentOrg` ServiceMap service, then opens a transactional connection that runs `SET LOCAL app.current_org_id = $orgId` before any tenant-scoped reads/writes. Three Postgres roles enforce isolation: `app_user` (RLS enforced — HTTP + MCP path), `app_service` (BYPASSRLS — mail worker + cron jobs that resolve org ownership explicitly per row), and `app_mcp_resolver` (a NOLOGIN role the MCP OAuth path switches into to read a caller's own memberships and consents under user-scoped RLS).
 
 **Two user types:**
 
@@ -364,13 +364,21 @@ All auth is handled by [Better Auth](https://www.better-auth.com/) v1.5.6 with p
 | `/mcp` (HTTP transport)                                     | Protected — HTTP middleware validates Better Auth session, provides `CurrentUser` |
 | MCP stdio                                                   | Trusted local process — static `CurrentUser`                                      |
 
-**API key flow for AI agents and external services (n8n, Zapier):**
+**API key flow.** Two kinds of `x-api-key` keys exist:
 
-1. Admin creates agent user: `POST /auth/admin/create-user`
-2. Admin creates API key: `POST /auth/api-key/create`
-3. Agent/service sends `x-api-key: sk_...` header
-4. `@better-auth/api-key` plugin with `enableSessionForAPIKeys: true` mocks a session
-5. `SessionMiddleware` validates uniformly via `auth.api.getSession()`
+- **Org-scoped keys** (the `/mcp` path) — any org member self-serves them under
+  `/settings/api-keys`. Each key is owned by the org's agent user but stamps its
+  creating member in metadata. On a `/mcp` call the key resolves to its org plus
+  that member — re-checking a live `member` row, so the key stops working once the
+  creator leaves the org — and the session acts as the member, so actions
+  attribute to the person. Keys carry a per-key rate limit (`API_KEY_RATE_LIMIT_*`,
+  enabled in prod); a throttled key gets `429` + `Retry-After`.
+- **User-owned keys** (admin / external integrations like n8n, Zapier) — minted
+  out-of-band against a specific user (`pnpm cli auth create-key` or
+  `POST /auth/api-key/create`). They carry no org metadata and serve `/auth/admin/*`
+  and webhook callers, not `/mcp`.
+
+Both are validated by `@better-auth/api-key` (`enableSessionForAPIKeys: true`); `SessionMiddleware` validates `/v1/*` uniformly via `auth.api.getSession()`.
 
 **MCP auth on behalf of user:**
 
@@ -459,7 +467,9 @@ user                — auth users (team members + AI agents, with isAgent field
 session             — active sessions; activeOrganizationId picks per-request tenant
 account             — auth provider accounts
 verification        — email verification tokens
-api_key             — hashed API keys (referenceId, configId, quotas, rate limits)
+api_key             — hashed API keys (referenceId, configId, quotas, per-key
+                      rate limits; metadata carries organizationId + createdByUserId
+                      for org-scoped /mcp keys)
 organization        — tenant root; users belong via member rows
 member              — (organization_id, user_id) plus primary_inbox_id additionalField
 invitation          — pending invites by email

--- a/packages/controllers/src/routes/api-keys.ts
+++ b/packages/controllers/src/routes/api-keys.ts
@@ -30,6 +30,13 @@ export const ApiKeyView = Schema.Struct({
 	expiresAt: Schema.NullOr(Schema.String),
 	createdAt: Schema.String,
 	enabled: Schema.Boolean,
+	createdBy: Schema.NullOr(
+		Schema.Struct({
+			id: Schema.String,
+			name: Schema.NullOr(Schema.String),
+			email: Schema.String,
+		}),
+	),
 })
 
 // Create response — the only place the plaintext `key` is ever returned.


### PR DESCRIPTION
## What

Makes org-scoped `/mcp` API keys **attribute to the member who created them** instead of a single shared per-org agent.

- **`services/api-keys.ts`** — `create()` stamps `createdByUserId` in the key's metadata; `list`/`get` resolve the creator (parse the JSON-string `metadata` in app, then one batched `WHERE id = ANY(...)` user lookup — no jsonb operator on the TEXT column); `createdBy` added to the redacted DTO.
- **`mcp/http.ts`** — the `x-api-key` branch reads `createdByUserId`, JOINs `member` to confirm a **live** org membership, and enters scope as that **human** (so `actor_user_id` on tasks/timeline records the person). Fails closed (`403`) when the creator is missing or no longer a member.
- **`handlers/api-keys.ts`** — threads the session `userId` into `create`.
- **`packages/controllers`** — `ApiKeyView.createdBy`.
- **`internal/.../api-keys/index.tsx`** — shows "Created by {name}" per row (Lingui en+ca).
- **`docs/architecture.md`** — §Authentication refresh (separate commit).

## Why

Every key in an org acted as the same agent user, so MCP-sourced actions were indistinguishable between members. Attributing to the real person makes the activity log meaningful and turns "creator left the org" into an automatic kill-switch (the per-call membership re-check, mirroring the OAuth path).

## No backward compatibility

Pre-production: every org-scoped key carries `createdByUserId`. A key minted before this change is **not** migrated — it's rejected at `/mcp` and must be recreated. No legacy org-agent fallback.

## Behavior change

Unassigned MCP-created tasks now auto-assign to the key's creator (was the shared agent) — an improvement; FK-safe via the membership re-check.

## Test plan

- [x] `check-types` (server + controllers + internal)
- [x] integration **143/143** — incl. attribution (key by member → principal is that member, not the agent), creator-not-a-member → `403`, missing-creator → `403`, `createdBy` resolution in `list`
- [x] unit **60/60**
- [x] builds (server, internal, controllers)
- [x] i18n 0 missing (en/ca)

Part 2 of 2 — follows the per-key rate-limit PR (#52, merged).
