### PR TITLE
refactor(server): Effect code-quality sweep (DateTime, no bare any, config)

### DIFF
--- a/apps/server/src/handlers/companies.ts
+++ b/apps/server/src/handlers/companies.ts
@@ -37,12 +37,12 @@ export const CompaniesLive = HttpApiBuilder.group(
 					),
 				)
 				.handle('create', _ =>
-					svc.create(_.payload as any).pipe(
+					svc.create(_.payload).pipe(
 						Effect.tap(r =>
 							Effect.logInfo('Company created').pipe(
 								Effect.annotateLogs({
 									event: 'company.created',
-									slug: (r as any)[0]?.slug,
+									slug: r[0]?.['slug'],
 								}),
 							),
 						),
@@ -51,7 +51,7 @@ export const CompaniesLive = HttpApiBuilder.group(
 					),
 				)
 				.handle('update', _ =>
-					svc.update(_.params.id, _.payload as any).pipe(
+					svc.update(_.params.id, _.payload).pipe(
 						Effect.tap(() =>
 							Effect.logInfo('Company updated').pipe(
 								Effect.annotateLogs({

--- a/apps/server/src/handlers/contacts.ts
+++ b/apps/server/src/handlers/contacts.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect'
+import { DateTime, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
@@ -36,7 +36,7 @@ export const ContactsLive = HttpApiBuilder.group(
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						const rows = yield* sql`
-							UPDATE contacts SET ${sql.update({ ...(_.payload as any), updatedAt: new Date() }, ['id'])}
+							UPDATE contacts SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						yield* Effect.logInfo('Contact updated').pipe(

--- a/apps/server/src/handlers/contacts.ts
+++ b/apps/server/src/handlers/contacts.ts
@@ -23,11 +23,11 @@ export const ContactsLive = HttpApiBuilder.group(
 				.handle('create', _ =>
 					Effect.gen(function* () {
 						const rows =
-							yield* sql`INSERT INTO contacts ${sql.insert(_.payload as any)} RETURNING *`
+							yield* sql`INSERT INTO contacts ${sql.insert(_.payload)} RETURNING *`
 						yield* Effect.logInfo('Contact created').pipe(
 							Effect.annotateLogs({
 								event: 'contact.created',
-								companyId: (_.payload as any).companyId,
+								companyId: _.payload.companyId,
 							}),
 						)
 						return rows[0]
@@ -36,7 +36,7 @@ export const ContactsLive = HttpApiBuilder.group(
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						const rows = yield* sql`
-							UPDATE contacts SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
+							UPDATE contacts SET ${sql.update({ ..._.payload, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						yield* Effect.logInfo('Contact updated').pipe(

--- a/apps/server/src/handlers/documents.ts
+++ b/apps/server/src/handlers/documents.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect'
+import { DateTime, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
@@ -69,7 +69,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 								contactId: null,
 								title: created.title ?? payload.type,
 								actorUserId: null,
-								occurredAt: new Date(),
+								occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 							}),
 						)
 						yield* Effect.logInfo('Document created').pipe(
@@ -87,7 +87,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						const rows = yield* sql`
-							UPDATE documents SET ${sql.update({ ...(_.payload as any), updatedAt: new Date() }, ['id'])}
+							UPDATE documents SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						yield* Effect.logInfo('Document updated').pipe(

--- a/apps/server/src/handlers/documents.ts
+++ b/apps/server/src/handlers/documents.ts
@@ -87,7 +87,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						const rows = yield* sql`
-							UPDATE documents SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
+							UPDATE documents SET ${sql.update({ ..._.payload, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						yield* Effect.logInfo('Document updated').pipe(

--- a/apps/server/src/handlers/interactions.ts
+++ b/apps/server/src/handlers/interactions.ts
@@ -51,7 +51,7 @@ export const InteractionsLive = HttpApiBuilder.group(
 
 						const occurredAt = payload.date
 							? DateTime.toDateUtc(payload.date)
-							: new Date()
+							: DateTime.toDateUtc(DateTime.nowUnsafe())
 						const nextActionAt = payload.nextActionAt
 							? new Date(payload.nextActionAt)
 							: null
@@ -85,7 +85,7 @@ export const InteractionsLive = HttpApiBuilder.group(
 
 						if (payload.nextAction || payload.nextActionAt) {
 							const companyUpdate: Record<string, unknown> = {
-								updatedAt: new Date(),
+								updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 							}
 							if (payload.nextAction)
 								companyUpdate['nextAction'] = payload.nextAction

--- a/apps/server/src/handlers/products.ts
+++ b/apps/server/src/handlers/products.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect'
+import { DateTime, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -29,7 +29,7 @@ export const ProductsLive = HttpApiBuilder.group(
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						const rows = yield* sql`
-							UPDATE products SET ${sql.update({ ...(_.payload as any), updatedAt: new Date() }, ['id'])}
+							UPDATE products SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						yield* Effect.logInfo('Product updated').pipe(

--- a/apps/server/src/handlers/products.ts
+++ b/apps/server/src/handlers/products.ts
@@ -19,7 +19,7 @@ export const ProductsLive = HttpApiBuilder.group(
 				.handle('create', _ =>
 					Effect.gen(function* () {
 						const rows =
-							yield* sql`INSERT INTO products ${sql.insert(_.payload as any)} RETURNING *`
+							yield* sql`INSERT INTO products ${sql.insert(_.payload)} RETURNING *`
 						yield* Effect.logInfo('Product created').pipe(
 							Effect.annotateLogs({ event: 'product.created' }),
 						)
@@ -29,7 +29,7 @@ export const ProductsLive = HttpApiBuilder.group(
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						const rows = yield* sql`
-							UPDATE products SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
+							UPDATE products SET ${sql.update({ ..._.payload, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						yield* Effect.logInfo('Product updated').pipe(

--- a/apps/server/src/handlers/proposals.ts
+++ b/apps/server/src/handlers/proposals.ts
@@ -37,11 +37,11 @@ export const ProposalsLive = HttpApiBuilder.group(
 				.handle('create', _ =>
 					Effect.gen(function* () {
 						const rows =
-							yield* sql`INSERT INTO proposals ${sql.insert(_.payload as any)} RETURNING *`
+							yield* sql`INSERT INTO proposals ${sql.insert(_.payload)} RETURNING *`
 						yield* Effect.logInfo('Proposal created').pipe(
 							Effect.annotateLogs({
 								event: 'proposal.created',
-								companyId: (_.payload as any).companyId,
+								companyId: _.payload.companyId,
 							}),
 						)
 						return rows[0]
@@ -62,7 +62,7 @@ export const ProposalsLive = HttpApiBuilder.group(
 						const before = existing[0]
 
 						const rows = yield* sql`
-							UPDATE proposals SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
+							UPDATE proposals SET ${sql.update({ ..._.payload, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 

--- a/apps/server/src/handlers/proposals.ts
+++ b/apps/server/src/handlers/proposals.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect'
+import { DateTime, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
@@ -62,7 +62,7 @@ export const ProposalsLive = HttpApiBuilder.group(
 						const before = existing[0]
 
 						const rows = yield* sql`
-							UPDATE proposals SET ${sql.update({ ...(_.payload as any), updatedAt: new Date() }, ['id'])}
+							UPDATE proposals SET ${sql.update({ ...(_.payload as any), updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) }, ['id'])}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 
@@ -76,7 +76,7 @@ export const ProposalsLive = HttpApiBuilder.group(
 									companyId: before.companyId,
 									contactId: before.contactId,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 						}

--- a/apps/server/src/handlers/research.ts
+++ b/apps/server/src/handlers/research.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from 'effect'
+import { DateTime, Effect, Stream } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
 import {
@@ -109,7 +109,7 @@ export const ResearchLive = HttpApiBuilder.group(
 										researchId: _.params.id,
 										timestamp:
 											(run as { completedAt: string | null }).completedAt ??
-											new Date().toISOString(),
+											DateTime.formatIso(DateTime.nowUnsafe()),
 										data: {},
 									},
 								],

--- a/apps/server/src/handlers/webhooks.ts
+++ b/apps/server/src/handlers/webhooks.ts
@@ -19,7 +19,7 @@ export const WebhooksLive = HttpApiBuilder.group(
 				)
 				.handle('create', _ =>
 					Effect.gen(function* () {
-						const rows = yield* svc.create(_.payload as any)
+						const rows = yield* svc.create(_.payload)
 						yield* Effect.logInfo('Webhook endpoint created').pipe(
 							Effect.annotateLogs({ event: 'webhook.created' }),
 						)
@@ -28,7 +28,7 @@ export const WebhooksLive = HttpApiBuilder.group(
 				)
 				.handle('update', _ =>
 					Effect.gen(function* () {
-						const rows = yield* svc.update(_.params.id, _.payload as any)
+						const rows = yield* svc.update(_.params.id, _.payload)
 						return rows[0]
 					}).pipe(Effect.orDie),
 				)

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http'
 
 import { NodeHttpServer, NodeRuntime } from '@effect/platform-node'
-import { Config, Effect, Layer } from 'effect'
+import { Config, DateTime, Effect, Layer } from 'effect'
 import {
 	FetchHttpClient,
 	HttpRouter,
@@ -172,7 +172,7 @@ const ResearchEventSinkLive = Layer.effect(
 									companyId: linkRows[0]?.subjectId ?? null,
 									summary: run.briefMd ?? run.query,
 									status,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 						}),

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -165,12 +165,12 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 				),
 			create_company: params =>
 				Effect.gen(function* () {
-					const rows = yield* service.create(params as any)
+					const rows = yield* service.create(params)
 					return rows[0]
 				}).pipe(Effect.orDie),
 			update_company: ({ id, ...fields }) =>
 				Effect.gen(function* () {
-					const rows = yield* service.update(id, fields as any)
+					const rows = yield* service.update(id, fields)
 					return rows[0]
 				}).pipe(Effect.orDie),
 			geocode_company: ({ id }) =>

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from 'effect'
+import { DateTime, Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -77,7 +77,7 @@ export const ContactHandlersLive = ContactTools.toLayer(
 				Effect.gen(function* () {
 					const data: Record<string, unknown> = {
 						...fields,
-						updatedAt: new Date(),
+						updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 					}
 					const rows =
 						yield* sql`UPDATE contacts SET ${sql.update(data, ['id'])} WHERE id = ${id} RETURNING *`

--- a/apps/server/src/mcp/tools/documents.ts
+++ b/apps/server/src/mcp/tools/documents.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from 'effect'
+import { DateTime, Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -121,7 +121,7 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 							contactId: null,
 							title: created.title ?? params.type,
 							actorUserId: null,
-							occurredAt: new Date(),
+							occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 						}),
 					)
 					const full =
@@ -132,7 +132,7 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 				Effect.gen(function* () {
 					const data: Record<string, unknown> = {
 						...fields,
-						updatedAt: new Date(),
+						updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 					}
 					const rows =
 						yield* sql`UPDATE documents SET ${sql.update(data, ['id'])} WHERE id = ${id} RETURNING *`

--- a/apps/server/src/mcp/tools/interactions.ts
+++ b/apps/server/src/mcp/tools/interactions.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from 'effect'
+import { DateTime, Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -66,7 +66,7 @@ export const InteractionHandlersLive = InteractionTools.toLayer(
 		return {
 			log_interaction: params =>
 				Effect.gen(function* () {
-					const occurredAt = new Date()
+					const occurredAt = DateTime.toDateUtc(DateTime.nowUnsafe())
 					const nextActionAt = params.next_action_at
 						? new Date(params.next_action_at)
 						: null
@@ -100,7 +100,7 @@ export const InteractionHandlersLive = InteractionTools.toLayer(
 
 					if (params.next_action || nextActionAt) {
 						const companyUpdate: Record<string, unknown> = {
-							updatedAt: new Date(),
+							updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 						}
 						if (params.next_action)
 							companyUpdate['nextAction'] = params.next_action

--- a/apps/server/src/mcp/tools/research-mcp.ts
+++ b/apps/server/src/mcp/tools/research-mcp.ts
@@ -2,7 +2,11 @@ import { Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { ResearchService, type SystemDefaults } from '@batuda/research'
+import {
+	type CreateResearchInput,
+	ResearchService,
+	type SystemDefaults,
+} from '@batuda/research'
 
 import { EnvVars } from '../../lib/env'
 
@@ -107,7 +111,7 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 						orgId,
 						{
 							query: params.query,
-							context: params.context as any,
+							context: params.context as CreateResearchInput['context'],
 							schemaName: params.schema_name,
 						},
 						systemDefaults,
@@ -130,7 +134,7 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 						orgId,
 						{
 							query: params.query,
-							context: params.context as any,
+							context: params.context as CreateResearchInput['context'],
 							schemaName: params.schema_name,
 						},
 						systemDefaults,

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from 'effect'
+import { DateTime, Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -330,7 +330,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 							yield* sql`SELECT * FROM tasks WHERE id = ${params.id}`
 						return existing[0]
 					}
-					fields['updated_at'] = new Date()
+					fields['updated_at'] = DateTime.toDateUtc(DateTime.nowUnsafe())
 					const rows = yield* sql`
 						UPDATE tasks SET ${sql.update(fields)}
 						WHERE id = ${params.id}

--- a/apps/server/src/services/calendar.ts
+++ b/apps/server/src/services/calendar.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Layer, Schema, ServiceMap } from 'effect'
+import { Data, DateTime, Effect, Layer, Schema, ServiceMap } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
@@ -517,7 +517,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									startAt,
 									endAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 						}
@@ -557,7 +557,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 								startAt,
 								endAt,
 								actorUserId: null,
-								occurredAt: new Date(),
+								occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 							}),
 						)
 					}),
@@ -592,7 +592,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 								contactId: target.contactId,
 								cancelledStartAt: target.startAt,
 								actorUserId: null,
-								occurredAt: new Date(),
+								occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 							}),
 						)
 
@@ -731,7 +731,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 										companyId: row.companyId,
 										contactId: row.contactId,
 										actorUserId: null,
-										occurredAt: new Date(),
+										occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 									}),
 								)
 							}
@@ -809,7 +809,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									contactId: inserted.contactId,
 									cancelledStartAt: inserted.startAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							results.cancelled += 1
@@ -826,7 +826,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									startAt: inserted.startAt,
 									endAt: inserted.endAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							results.updated += 1
@@ -841,7 +841,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									startAt: inserted.startAt,
 									endAt: inserted.endAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							results.created += 1
@@ -934,7 +934,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									startAt: args.startAt,
 									endAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							return row
@@ -988,7 +988,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									startAt: args.newStartAt,
 									endAt: newEndAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							return { ...existing, startAt: args.newStartAt, endAt: newEndAt }
@@ -1030,7 +1030,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									contactId: existing.contactId,
 									cancelledStartAt: existing.startAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							return { ...existing, status: 'cancelled' as const }
@@ -1149,7 +1149,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									companyId: existing.companyId,
 									contactId: existing.contactId,
 									actorUserId: args.actorUserId,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							return {
@@ -1241,7 +1241,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 									startAt: args.startAt,
 									endAt: args.endAt,
 									actorUserId: null,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 							return row
@@ -1291,7 +1291,9 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 					// RFC 5545 §3.8.7.2: every VEVENT MUST carry a DTSTAMP
 					// (creation time of the ICS in UTC). Without it strict
 					// parsers (Outlook, Exchange) reject the envelope.
-					const dtStamp = formatIcsDate(new Date())
+					const dtStamp = formatIcsDate(
+						DateTime.toDateUtc(DateTime.nowUnsafe()),
+					)
 					const ics = [
 						'BEGIN:VCALENDAR',
 						'VERSION:2.0',

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, ServiceMap } from 'effect'
+import { DateTime, Effect, Layer, ServiceMap } from 'effect'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -91,7 +91,7 @@ export class CompanyService extends ServiceMap.Service<CompanyService>()(
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
 						return yield* sql`
-							UPDATE companies SET ${sql.update({ ...data, updatedAt: new Date() })}
+							UPDATE companies SET ${sql.update({ ...data, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${id} AND organization_id = ${currentOrg.id}
 							RETURNING *
 						`

--- a/apps/server/src/services/email-attachment-staging.ts
+++ b/apps/server/src/services/email-attachment-staging.ts
@@ -438,6 +438,7 @@ export class EmailAttachmentStaging extends ServiceMap.Service<EmailAttachmentSt
 	static readonly layer = Layer.effect(this, this.make)
 
 	// 5-min cadence stays well under the 1-hour TTL so a missed tick can't leak orphans past expiry.
+	// Outputs no service (`effectDiscard`), so it must be listed in `mergeAll` — a `provideMerge` skips it.
 	static readonly sweepDaemonLayer = Layer.effectDiscard(
 		Effect.gen(function* () {
 			const staging = yield* EmailAttachmentStaging

--- a/apps/server/src/services/email-draft-store.ts
+++ b/apps/server/src/services/email-draft-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-import { Effect, Layer, ServiceMap } from 'effect'
+import { DateTime, Effect, Layer, ServiceMap } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg, NotFound } from '@batuda/controllers'
@@ -134,7 +134,9 @@ export class DraftStore extends ServiceMap.Service<DraftStore>()('DraftStore', {
 		const update = (draftId: string, input: UpdateDraftInput) =>
 			Effect.gen(function* () {
 				const currentOrg = yield* CurrentOrg
-				const patch: Record<string, unknown> = { updatedAt: new Date() }
+				const patch: Record<string, unknown> = {
+					updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
+				}
 				if (input.to !== undefined) patch['toAddresses'] = input.to
 				if (input.cc !== undefined) patch['ccAddresses'] = input.cc
 				if (input.bcc !== undefined) patch['bccAddresses'] = input.bcc

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-import { Data, Effect, Layer, Schedule, ServiceMap } from 'effect'
+import { Data, DateTime, Effect, Layer, Schedule, ServiceMap } from 'effect'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -646,7 +646,7 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 								`
 							}
 
-							const sentAt = new Date()
+							const sentAt = DateTime.toDateUtc(DateTime.nowUnsafe())
 							const emailRows = yield* sql<{ id: string }>`
 								INSERT INTO email_messages ${sql.insert({
 									organizationId: currentOrg.id,
@@ -1680,7 +1680,7 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 								passwordTag: encrypted.tag,
 								grantStatus: probe.status,
 								grantLastError: probe.detail,
-								grantLastSeenAt: new Date(),
+								grantLastSeenAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								folderState: '{}',
 							})}
 							RETURNING ${selectInboxColumns}

--- a/apps/server/src/services/inbox-health-probe.ts
+++ b/apps/server/src/services/inbox-health-probe.ts
@@ -121,7 +121,9 @@ export class InboxHealthProbe extends ServiceMap.Service<InboxHealthProbe>()(
 	static readonly layer = Layer.effect(this, this.make)
 
 	// Forks the recurring loop on boot. Separate from `layer` so tests can
-	// drive `tick` directly without paying for a daemon.
+	// drive `tick` directly without paying for a daemon. Outputs no service
+	// (`effectDiscard`), so it must be listed in `mergeAll` — a `provideMerge`
+	// would skip building it and the probe would never start.
 	static readonly daemonLayer = Layer.effectDiscard(
 		Effect.gen(function* () {
 			const probe = yield* InboxHealthProbe

--- a/apps/server/src/services/local-inbox-provider.ts
+++ b/apps/server/src/services/local-inbox-provider.ts
@@ -4,7 +4,7 @@ import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { Readable } from 'node:stream'
 
-import { Effect, Layer } from 'effect'
+import { DateTime, Effect, Layer } from 'effect'
 
 import { EmailError, EmailSendError } from '@batuda/controllers'
 
@@ -173,7 +173,7 @@ const parseFrontmatter = (raw: string): MessageRecord => {
 		.filter((a): a is StoredAttachment => a !== null)
 
 	return {
-		sentAt: asString('sentAt', new Date().toISOString()),
+		sentAt: asString('sentAt', DateTime.formatIso(DateTime.nowUnsafe())),
 		messageId: asString('messageId'),
 		threadId: asString('threadId'),
 		from: asString('from', DEV_INBOX_EMAIL),
@@ -424,7 +424,7 @@ export const LocalInboxProviderLive = Layer.effect(
 			params: SendParams,
 		): Effect.Effect<SendResult, EmailSendError> =>
 			Effect.gen(function* () {
-				const sentAt = new Date()
+				const sentAt = DateTime.toDateUtc(DateTime.nowUnsafe())
 				const messageId = `msg_local_${randomUUID()}`
 				const threadId = `thr_local_${randomUUID()}`
 				const recipients = Array.isArray(params.to) ? params.to : [params.to]
@@ -482,7 +482,7 @@ export const LocalInboxProviderLive = Layer.effect(
 				const subject = original?.record.subject
 					? `Re: ${original.record.subject.replace(/^Re:\s*/i, '')}`
 					: 'Re: (local-inbox)'
-				const sentAt = new Date()
+				const sentAt = DateTime.toDateUtc(DateTime.nowUnsafe())
 				const newMessageId = `msg_local_${randomUUID()}`
 				const recipients = params.to
 					? Array.isArray(params.to)

--- a/apps/server/src/services/local-transactional-provider.ts
+++ b/apps/server/src/services/local-transactional-provider.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
-import { Effect, Layer } from 'effect'
+import { DateTime, Effect, Layer } from 'effect'
 
 import { EmailSendError } from '@batuda/controllers'
 
@@ -97,7 +97,7 @@ export const LocalTransactionalProviderLive = Layer.effect(
 		}): Effect.Effect<void, EmailSendError> =>
 			Effect.gen(function* () {
 				yield* ensureInboxDir
-				const sentAt = new Date()
+				const sentAt = DateTime.toDateUtc(DateTime.nowUnsafe())
 				const messageId = `msg_local_${randomUUID()}`
 				const threadId = `thr_local_${randomUUID()}`
 				const stamp = filenameStamp(sentAt)

--- a/apps/server/src/services/pages.ts
+++ b/apps/server/src/services/pages.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Schema, ServiceMap } from 'effect'
+import { DateTime, Effect, Layer, Schema, ServiceMap } from 'effect'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient, type SqlError } from 'effect/unstable/sql'
 
@@ -146,7 +146,7 @@ export class PageService extends ServiceMap.Service<PageService>()(
 				create,
 
 				update: (id: string, data: Record<string, unknown>) =>
-					sql`UPDATE pages SET ${sql.update({ ...data, updatedAt: new Date() })} WHERE id = ${id} RETURNING *`,
+					sql`UPDATE pages SET ${sql.update({ ...data, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })} WHERE id = ${id} RETURNING *`,
 
 				publish: (id: string) =>
 					sql`UPDATE pages SET status = 'published', published_at = now(), updated_at = now() WHERE id = ${id} RETURNING *`,

--- a/apps/server/src/services/pipeline.ts
+++ b/apps/server/src/services/pipeline.ts
@@ -17,7 +17,7 @@ export class PipelineService extends ServiceMap.Service<PipelineService>()(
 							t.company_id, c.name as company_name, c.slug as company_slug
 						FROM tasks t
 						INNER JOIN companies c ON t.company_id = c.id
-						WHERE t.completed_at IS NULL AND t.due_at < ${new Date()}
+						WHERE t.completed_at IS NULL AND t.due_at < now()
 						ORDER BY t.due_at
 						LIMIT ${limit}
 					`,
@@ -37,7 +37,7 @@ export class PipelineService extends ServiceMap.Service<PipelineService>()(
 						const overdueCompanies = yield* sql`
 							SELECT id, slug, name, next_action, next_action_at
 							FROM companies
-							WHERE next_action_at < ${new Date()}
+							WHERE next_action_at < now()
 								AND status NOT IN ('closed', 'dead')
 							ORDER BY next_action_at
 							LIMIT ${limit}
@@ -57,7 +57,7 @@ export class PipelineService extends ServiceMap.Service<PipelineService>()(
 							count: number
 						}>`
 							SELECT count(*)::int as count FROM tasks
-							WHERE completed_at IS NULL AND due_at < ${new Date()}
+							WHERE completed_at IS NULL AND due_at < now()
 						`
 
 						const companiesWithoutNextAction = yield* sql<{

--- a/apps/server/src/services/recordings.ts
+++ b/apps/server/src/services/recordings.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-import { Effect, Layer, ServiceMap } from 'effect'
+import { DateTime, Effect, Layer, ServiceMap } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { BadRequest, Conflict, CurrentOrg, NotFound } from '@batuda/controllers'
@@ -135,7 +135,7 @@ export class RecordingService extends ServiceMap.Service<RecordingService>()(
 								contactId = params.contactId ?? null
 							}
 
-							const recordedAt = new Date()
+							const recordedAt = DateTime.toDateUtc(DateTime.nowUnsafe())
 							const activityResult = yield* timeline.record(
 								new InteractionLogged({
 									companyId,

--- a/apps/server/src/services/s3-storage-provider.ts
+++ b/apps/server/src/services/s3-storage-provider.ts
@@ -6,10 +6,11 @@ import {
 	S3Client,
 } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
-import { Config, Effect, Layer, Redacted } from 'effect'
+import { Effect, Layer, Redacted } from 'effect'
 
 import { StorageError } from '@batuda/controllers'
 
+import { EnvVars } from '../lib/env.js'
 import {
 	type HeadResult,
 	type PutParams,
@@ -22,11 +23,12 @@ const errorMessage = (e: unknown): string =>
 export const S3StorageProviderLive = Layer.effect(
 	StorageProvider,
 	Effect.gen(function* () {
-		const endpoint = yield* Config.string('STORAGE_ENDPOINT')
-		const region = yield* Config.string('STORAGE_REGION')
-		const accessKeyId = yield* Config.string('STORAGE_ACCESS_KEY_ID')
-		const secretAccessKey = yield* Config.redacted('STORAGE_SECRET_ACCESS_KEY')
-		const bucket = yield* Config.string('STORAGE_BUCKET')
+		const env = yield* EnvVars
+		const endpoint = env.STORAGE_ENDPOINT
+		const region = env.STORAGE_REGION
+		const accessKeyId = env.STORAGE_ACCESS_KEY_ID
+		const secretAccessKey = env.STORAGE_SECRET_ACCESS_KEY
+		const bucket = env.STORAGE_BUCKET
 
 		// `forcePathStyle: true` keeps a single code path working for both
 		// MinIO (which only speaks path-style: `http://host/bucket/key`) and

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, ServiceMap } from 'effect'
+import { DateTime, Effect, Layer, ServiceMap } from 'effect'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -167,7 +167,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 							change,
 							actorUserId: actor.id,
 							actorKind: actor.kind,
-							occurredAt: new Date(),
+							occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 						}),
 					)
 				})
@@ -194,7 +194,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 									taskType: row.type,
 									actorUserId: actor.id,
 									actorKind: actor.kind,
-									occurredAt: new Date(),
+									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
 						}
@@ -247,7 +247,7 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 								contactId: row.contactId,
 								actorUserId: actor.id,
 								actorKind: actor.kind,
-								occurredAt: new Date(),
+								occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 							}),
 						)
 						return row
@@ -424,8 +424,10 @@ export class TaskService extends ServiceMap.Service<TaskService>()(
 						// have to manage completed_at (the DB CHECK enforces it anyway).
 						if (input.status !== undefined)
 							updates['completed_at'] =
-								input.status === 'done' ? new Date() : null
-						updates['updated_at'] = new Date()
+								input.status === 'done'
+									? DateTime.toDateUtc(DateTime.nowUnsafe())
+									: null
+						updates['updated_at'] = DateTime.toDateUtc(DateTime.nowUnsafe())
 						updates['actor_id'] = actor.id
 
 						const updated = yield* sql`

--- a/apps/server/src/services/timeline-activity.ts
+++ b/apps/server/src/services/timeline-activity.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Layer, ServiceMap } from 'effect'
+import { Data, DateTime, Effect, Layer, ServiceMap } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
@@ -172,7 +172,7 @@ const isPast = (at: Date, now: Date) => at.getTime() <= now.getTime()
 
 export const denormColumnFor = (
 	event: TimelineEvent,
-	now: Date = new Date(),
+	now: Date = DateTime.toDateUtc(DateTime.nowUnsafe()),
 ): DenormColumn | null => {
 	switch (event._tag) {
 		case 'EmailSent':

--- a/apps/server/src/services/webhooks.ts
+++ b/apps/server/src/services/webhooks.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto'
 
-import { Effect, Layer, ServiceMap } from 'effect'
+import { DateTime, Effect, Layer, ServiceMap } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
@@ -61,7 +61,7 @@ export class WebhookService extends ServiceMap.Service<WebhookService>()(
 											body: JSON.stringify({
 												event,
 												payload,
-												timestamp: new Date().toISOString(),
+												timestamp: DateTime.formatIso(DateTime.nowUnsafe()),
 											}),
 										}),
 									catch: e =>


### PR DESCRIPTION
## What

Effect code-quality sweep (3 commits, all `refactor(server)`):

1. **`new Date()` → `DateTime`/`now()`** (~50 sites). Pipeline overdue/next-action checks compare against SQL `now()` (server-side, no JS↔DB clock split); every other server-time value uses `DateTime.toDateUtc(DateTime.nowUnsafe())`, and ISO-string timestamps use `DateTime.formatIso`. The full sweep (incl. the `occurredAt`/`sentAt` domain-object sites across calendar/email/tasks).
2. **Drop `as any`** — no bare `any` left in server source. Reducible casts typed properly (payload field access, service args, result-row index access); vestigial `sql.update(…, ['id'])` omit-args removed (route `id` is a param, never in the typed body); the one genuine agent-boundary cast (research-mcp freeform `context`) narrowed to `CreateResearchInput['context']`.
3. **Centralize storage config + clarify daemons** — S3 provider reads `STORAGE_*` from `EnvVars` (single source) instead of re-reading `Config`; documented the `never`-output `effectDiscard` daemon layers (must be in `mergeAll`, not `provideMerge`).

## Why

Follows the project's DateTime rule (`now()`/`DateTime` over raw `new Date()`) and type-safety rule (no `any`), and removes the `STORAGE_*` config duplication. All behavior-preserving — `DateTime.toDateUtc(DateTime.nowUnsafe())` ≡ `new Date()`, and `now()` is the same instant evaluated server-side.

## Test plan

- [x] `check-types`
- [x] integration **143/143**
- [x] unit **60/60**
- [x] `build` (validates the S3→EnvVars layer wiring)
- [x] boot **6/6**

Follow-up to the env-required PR (#54). Scope note: this is the broad cleanup chosen over the narrower option — every `new Date()` site converted, not just the SQL-write ones.
