### PR TITLE
Crash-resilience: process guards + restart, imapflow listener, bounded caches, webhook & research-sink fixes

### DIFF
--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -85,12 +85,17 @@ jobs:
           # 10000ms; kraft's 60s default is rejected with HTTP 400.
           # --scale-to-zero off matches the Kraftfile label and keeps the
           # IDLE-holding worker always-warm.
+          # --restart on-failure: if the worker crashes (non-zero exit), the
+          # platform starts a fresh one instead of leaving it dead but still
+          # listed as "running" and processing no mail. A clean shutdown
+          # (exit 0) is left alone. Pairs with the crash-guards in main.ts.
           command: |
             kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
               --timeout 10s \
               --name batuda-mail-worker \
               -M 2048 \
               --scale-to-zero off \
+              --restart on-failure \
               -e NODE_ENV=production \
               -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
               -e GIT_SHA="${{ github.sha }}" \

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -92,6 +92,10 @@ jobs:
           #     timeout note below); 30s tripped HTTP 400 and aborted the
           #     rollout. Node + DB pool warm-up fits in 5s on the cold
           #     unikernel path because connection-pool init is lazy.
+          #   --restart on-failure: if the process crashes (non-zero exit) the
+          #     platform starts a fresh instance, instead of leaving a dead-but-
+          #     "running" box that serves nothing. A clean shutdown (exit 0) is
+          #     left alone. Pairs with the process crash-guards in main.ts.
           #   -M 2048: pnpm v11 hoisted-mode `pnpm deploy --prod` under legacy
           #     deploy doesn't prune to apps/server's runtime deps — /deploy
           #     ends up with the workspace's full install tree (~303 MB).
@@ -108,6 +112,7 @@ jobs:
             if [ "${{ steps.service-check.outputs.exists }}" = "true" ]; then
               kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
                 --timeout 10s \
+                --restart on-failure \
                 --service batuda-server \
                 --rollout remove_sequential \
                 --rollout-wait 5s \
@@ -180,6 +185,7 @@ jobs:
                 80:443/http+redirect
               kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
                 --timeout 10s \
+                --restart on-failure \
                 --service batuda-server \
                 -M 2048 \
                 -e NODE_ENV=production \

--- a/apps/mail-worker/src/crash-guards.ts
+++ b/apps/mail-worker/src/crash-guards.ts
@@ -1,0 +1,53 @@
+import { DateTime } from 'effect'
+
+const describe = (value: unknown): unknown =>
+	value instanceof Error
+		? { name: value.name, message: value.message, stack: value.stack }
+		: String(value)
+
+const logFatal = (message: string, fields: Record<string, unknown>): void => {
+	// Use the plain console here, not the app's logger: the program is already
+	// crashing, so we keep logging dead-simple. The line is still structured
+	// (JSON) so our log tools can read it like the rest.
+	console.error(
+		JSON.stringify({
+			level: 'FATAL',
+			message,
+			timestamp: DateTime.formatIso(DateTime.nowUnsafe()),
+			...fields,
+		}),
+	)
+}
+
+/**
+ * Safety net for rare, low-level errors that slip past the app's normal error
+ * handling — for example a database or email connection failing at an awkward
+ * moment. Left unhandled, the program would stop *silently*: still listed as
+ * "running" but answering nothing (the kind of failure that previously took the
+ * site down). Instead we record the error and exit, so the hosting platform's
+ * automatic "restart on failure" rule brings it back in a clean state.
+ *
+ * Call once, at startup. These handlers must never throw.
+ */
+export const installCrashGuards = (): void => {
+	process.on('uncaughtException', (error, origin) => {
+		try {
+			logFatal('uncaughtException — exiting for restart', {
+				origin,
+				error: describe(error),
+			})
+		} finally {
+			process.exit(1)
+		}
+	})
+
+	process.on('unhandledRejection', reason => {
+		try {
+			logFatal('unhandledRejection — exiting for restart', {
+				reason: describe(reason),
+			})
+		} finally {
+			process.exit(1)
+		}
+	})
+}

--- a/apps/mail-worker/src/inbox-session.test.ts
+++ b/apps/mail-worker/src/inbox-session.test.ts
@@ -1,0 +1,101 @@
+import { EventEmitter } from 'node:events'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { onImapClientError } from './inbox-session.js'
+
+// Spy on console.warn so the handler's single JSON line is captured, not printed.
+const captureWarn = () =>
+	vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+const loggedPayload = (
+	warn: ReturnType<typeof captureWarn>,
+): Record<string, unknown> => JSON.parse(String(warn.mock.calls[0]?.[0]))
+
+describe('onImapClientError', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe('when the client emits an Error with the listener attached', () => {
+		it('should swallow the error without throwing', () => {
+			// GIVEN an emitter wired exactly like the ImapFlow client
+			// [inbox-session.ts — client.on('error', onImapClientError(claimed.id))]
+			captureWarn()
+			const client = new EventEmitter()
+			client.on('error', onImapClientError('inbox_123'))
+
+			// WHEN a socket-style error fires mid-session
+			const emit = () => client.emit('error', new Error('socket hang up'))
+
+			// THEN it does not throw (without a listener Node would crash here)
+			expect(emit).not.toThrow()
+		})
+
+		it('should log one WARN entry naming the inbox and the error message', () => {
+			// GIVEN the wired emitter
+			const warn = captureWarn()
+			const client = new EventEmitter()
+			client.on('error', onImapClientError('inbox_123'))
+
+			// WHEN it emits an Error
+			client.emit('error', new Error('socket hang up'))
+
+			// THEN exactly one structured WARN line is written
+			// AND it carries the inbox id and the error's message
+			expect(warn).toHaveBeenCalledOnce()
+			expect(loggedPayload(warn)).toMatchObject({
+				level: 'WARN',
+				inboxId: 'inbox_123',
+				error: 'socket hang up',
+			})
+		})
+	})
+
+	describe('when the emitted value is not an Error instance', () => {
+		it('should still swallow it and stringify the value', () => {
+			// GIVEN a non-Error payload — some providers surface a bare code/string
+			// [inbox-session.ts — `error instanceof Error ? … : String(error)`]
+			const warn = captureWarn()
+			const client = new EventEmitter()
+			client.on('error', onImapClientError('inbox_456'))
+
+			// WHEN a non-Error value is emitted
+			const emit = () => client.emit('error', 'ECONNRESET')
+
+			// THEN it does not throw, and the stringified value is logged
+			expect(emit).not.toThrow()
+			expect(loggedPayload(warn)).toMatchObject({
+				inboxId: 'inbox_456',
+				error: 'ECONNRESET',
+			})
+		})
+
+		it('should not throw on a null payload', () => {
+			// GIVEN a null payload (the degenerate non-Error case)
+			const warn = captureWarn()
+			const client = new EventEmitter()
+			client.on('error', onImapClientError('inbox_789'))
+
+			// WHEN null is emitted
+			const emit = () => client.emit('error', null)
+
+			// THEN it still swallows and records 'null', never throwing
+			expect(emit).not.toThrow()
+			expect(loggedPayload(warn)).toMatchObject({ error: 'null' })
+		})
+	})
+
+	describe('when no error listener is attached', () => {
+		it('should throw on emit, proving the listener is load-bearing', () => {
+			// GIVEN a bare emitter with no 'error' listener (the pre-fix state)
+			const client = new EventEmitter()
+
+			// WHEN it emits 'error'
+			const emit = () => client.emit('error', new Error('socket hang up'))
+
+			// THEN Node rethrows — which, without our listener, crashes the worker
+			expect(emit).toThrow('socket hang up')
+		})
+	})
+})

--- a/apps/mail-worker/src/inbox-session.ts
+++ b/apps/mail-worker/src/inbox-session.ts
@@ -13,6 +13,23 @@ import {
 	recordFolderHead,
 } from './folder-sync.js'
 
+// When the email connection drops, the IMAP library reports it as an 'error'
+// event from outside our normal flow. With no listener, that crashes the whole
+// worker — taking down every mailbox it watches, not just this one. So we
+// listen and just record it; the worker's retry loop reconnects on its own.
+export const onImapClientError =
+	(inboxId: string) =>
+	(error: unknown): void => {
+		console.warn(
+			JSON.stringify({
+				level: 'WARN',
+				message: 'imap client error (will reconnect)',
+				inboxId,
+				error: error instanceof Error ? error.message : String(error),
+			}),
+		)
+	}
+
 // Folders we monitor per inbox. Most providers have INBOX + Sent;
 // Gmail's "All Mail" duplicates everything (covered by IMAP \All
 // special-use), so we skip it. Outbound rows we APPEND to "Sent" still
@@ -157,6 +174,8 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 			// so the connection breaks idle slightly before the server would.
 			maxIdleTime: env.EMAIL_WORKER_IDLE_TIMEOUT_SEC * 1000,
 		})
+
+		client.on('error', onImapClientError(claimed.id))
 
 		// EXPUNGE arrives over IDLE. The listener runs outside any Effect
 		// scope so we can't issue SQL from it directly — instead we

--- a/apps/mail-worker/src/main.ts
+++ b/apps/mail-worker/src/main.ts
@@ -4,6 +4,7 @@ import { Effect, type Fiber, Layer, Ref, Schedule } from 'effect'
 import { ParticipantMatcher } from '@batuda/email/participant-matcher'
 
 import { type ClaimedInbox, claimAvailableInboxes } from './claim.js'
+import { installCrashGuards } from './crash-guards.js'
 import { PgLive } from './db.js'
 import { CredentialDecryptor } from './decrypt.js'
 import { WorkerEnvVars } from './env.js'
@@ -98,5 +99,10 @@ const Live = Layer.mergeAll(
 	Layer.provideMerge(PgLive),
 	Layer.provideMerge(WorkerEnvVars.layer),
 )
+
+// Turn on the crash safety net before the worker starts: a rare low-level error
+// (e.g. a dropped email connection) must be logged and the worker auto-restarted,
+// not left silently dead — which would stop it watching every mailbox.
+installCrashGuards()
 
 NodeRuntime.runMain(Effect.scoped(program).pipe(Effect.provide(Live)))

--- a/apps/server/src/handlers/calendar.ts
+++ b/apps/server/src/handlers/calendar.ts
@@ -1,4 +1,4 @@
-import { DateTime, Effect } from 'effect'
+import { Cache, DateTime, Duration, Effect, Option } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
@@ -26,16 +26,6 @@ type EventRow = {
 	readonly source: 'booking' | 'email' | 'internal'
 }
 
-// Hard-coded 60s availability cache per `(eventTypeId, from, to)`. A
-// request that arrives inside the window replays the prior slot list
-// so the Batuda booking picker doesn't fan out N parallel calls into
-// the provider when the user clicks around. The entry is invalidated
-// by a booking webhook fan-out; in between, the provider's own edge
-// staleness is already bounded.
-const slotCache = new Map<
-	string,
-	{ readonly expiresAt: number; readonly slots: ReadonlyArray<unknown> }
->()
 const cacheKey = (eventTypeId: string, from: string, to: string) =>
 	`${eventTypeId}|${from}|${to}`
 
@@ -46,6 +36,26 @@ export const CalendarLive = HttpApiBuilder.group(
 		Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
 			const provider = yield* BookingProvider
+
+			// Remembers the available times we just looked up so the booking
+			// picker stays fast while someone clicks around, instead of asking
+			// the calendar provider again and again. We keep the 500 most recent
+			// answers and forget each one after a minute, so this memory can't
+			// grow forever.
+			const slotCache = yield* Cache.make<
+				string,
+				ReadonlyArray<unknown>,
+				never,
+				never
+			>({
+				capacity: 500,
+				timeToLive: Duration.seconds(60),
+				// We always store answers ourselves; we never ask this cache to
+				// fetch one for us, so reaching here means something went wrong.
+				lookup: () =>
+					Effect.die('calendar slotCache lookup invoked — expected set-only'),
+			})
+
 			return handlers
 				.handle('listEventTypes', _ =>
 					Effect.gen(function* () {
@@ -213,8 +223,8 @@ export const CalendarLive = HttpApiBuilder.group(
 								message: 'unknown_event_type_or_not_synced',
 							})
 						const key = cacheKey(_.query.eventTypeId, _.query.from, _.query.to)
-						const cached = slotCache.get(key)
-						if (cached && cached.expiresAt > Date.now()) return cached.slots
+						const cached = yield* Cache.getOption(slotCache, key)
+						if (Option.isSome(cached)) return cached.value
 
 						const slots = yield* provider
 							.findSlots({
@@ -230,10 +240,7 @@ export const CalendarLive = HttpApiBuilder.group(
 									Effect.die('provider_failed'),
 								),
 							)
-						slotCache.set(key, {
-							slots,
-							expiresAt: Date.now() + 60_000,
-						})
+						yield* Cache.set(slotCache, key, slots)
 						return slots
 					}).pipe(
 						Effect.catch(e =>

--- a/apps/server/src/lib/crash-guards.test.ts
+++ b/apps/server/src/lib/crash-guards.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { installCrashGuards } from './crash-guards'
+
+type ProcessSignal = 'uncaughtException' | 'unhandledRejection'
+type ProcessListener = (...args: ReadonlyArray<unknown>) => void
+
+const GUARDED_SIGNALS: ReadonlyArray<ProcessSignal> = [
+	'uncaughtException',
+	'unhandledRejection',
+]
+
+// Use the general event-emitter type here: the stricter process-specific
+// typings won't accept a value that could be either of our two events.
+const emitter: NodeJS.EventEmitter = process
+
+const listenersFor = (signal: ProcessSignal): ReadonlyArray<ProcessListener> =>
+	emitter.listeners(signal) as unknown as ReadonlyArray<ProcessListener>
+
+describe('installCrashGuards', () => {
+	// The handlers attach to the global `process` and call process.exit when they
+	// fire, so each test snapshots the listeners that already exist and removes
+	// only the ones it adds — and never emits the events.
+	const baseline = new Map<ProcessSignal, ReadonlyArray<ProcessListener>>()
+
+	beforeEach(() => {
+		for (const signal of GUARDED_SIGNALS)
+			baseline.set(signal, listenersFor(signal))
+	})
+
+	afterEach(() => {
+		for (const signal of GUARDED_SIGNALS) {
+			const keep = new Set(baseline.get(signal))
+			for (const listener of listenersFor(signal)) {
+				if (!keep.has(listener)) emitter.removeListener(signal, listener)
+			}
+		}
+	})
+
+	describe('when installed', () => {
+		it('should register one uncaughtException handler', () => {
+			// GIVEN the uncaughtException listeners present before install
+			// [crash-guards.ts — process.on('uncaughtException')]
+			const before = process.listenerCount('uncaughtException')
+
+			// WHEN the crash guards are installed
+			installCrashGuards()
+
+			// THEN exactly one handler has been added
+			expect(process.listenerCount('uncaughtException')).toBe(before + 1)
+		})
+
+		it('should register one unhandledRejection handler', () => {
+			// GIVEN the unhandledRejection listeners present before install
+			// [crash-guards.ts — process.on('unhandledRejection')]
+			const before = process.listenerCount('unhandledRejection')
+
+			// WHEN the crash guards are installed
+			installCrashGuards()
+
+			// THEN exactly one handler has been added
+			expect(process.listenerCount('unhandledRejection')).toBe(before + 1)
+		})
+	})
+})

--- a/apps/server/src/lib/crash-guards.ts
+++ b/apps/server/src/lib/crash-guards.ts
@@ -1,0 +1,53 @@
+import { DateTime } from 'effect'
+
+const describe = (value: unknown): unknown =>
+	value instanceof Error
+		? { name: value.name, message: value.message, stack: value.stack }
+		: String(value)
+
+const logFatal = (message: string, fields: Record<string, unknown>): void => {
+	// Use the plain console here, not the app's logger: the program is already
+	// crashing, so we keep logging dead-simple. The line is still structured
+	// (JSON) so our log tools can read it like the rest.
+	console.error(
+		JSON.stringify({
+			level: 'FATAL',
+			message,
+			timestamp: DateTime.formatIso(DateTime.nowUnsafe()),
+			...fields,
+		}),
+	)
+}
+
+/**
+ * Safety net for rare, low-level errors that slip past the app's normal error
+ * handling — for example a database or email connection failing at an awkward
+ * moment. Left unhandled, the program would stop *silently*: still listed as
+ * "running" but answering nothing (the kind of failure that previously took the
+ * site down). Instead we record the error and exit, so the hosting platform's
+ * automatic "restart on failure" rule brings it back in a clean state.
+ *
+ * Call once, at startup. These handlers must never throw.
+ */
+export const installCrashGuards = (): void => {
+	process.on('uncaughtException', (error, origin) => {
+		try {
+			logFatal('uncaughtException — exiting for restart', {
+				origin,
+				error: describe(error),
+			})
+		} finally {
+			process.exit(1)
+		}
+	})
+
+	process.on('unhandledRejection', reason => {
+		try {
+			logFatal('unhandledRejection — exiting for restart', {
+				reason: describe(reason),
+			})
+		} finally {
+			process.exit(1)
+		}
+	})
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -43,6 +43,7 @@ import { WebhooksLive } from './handlers/webhooks'
 import { CalcomWebhookLive } from './handlers/webhooks-calcom'
 import { Auth } from './lib/auth'
 import { CorsLive } from './lib/cors'
+import { installCrashGuards } from './lib/crash-guards'
 import { EnvVars } from './lib/env'
 import { LoggerLive } from './lib/logger'
 import { OtlpObservability } from './lib/observability'
@@ -313,5 +314,10 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(OtlpObservability),
 	Layer.launch,
 )
+
+// Turn on the crash safety net before the server starts, so a rare low-level
+// error gets logged and the process auto-restarted instead of dying silently.
+// See crash-guards.ts.
+installCrashGuards()
 
 NodeRuntime.runMain(program as unknown as Effect.Effect<void, unknown, never>)

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http'
 
 import { NodeHttpServer, NodeRuntime } from '@effect/platform-node'
-import { Config, DateTime, Effect, Layer } from 'effect'
+import { Cause, Config, DateTime, Effect, Layer } from 'effect'
 import {
 	FetchHttpClient,
 	HttpRouter,
@@ -189,7 +189,22 @@ const ResearchEventSinkLive = Layer.effect(
 							),
 						),
 					)
-				}).pipe(Effect.orDie),
+				}).pipe(
+					// The event sink is fire-and-forget telemetry. A transient DB
+					// error here must NOT kill the research run, so log and move on;
+					// only a genuine cancellation/shutdown (a pure interrupt) is let
+					// through.
+					Effect.catchCause(cause =>
+						Cause.hasInterruptsOnly(cause)
+							? Effect.interrupt
+							: Effect.logWarning('research event-sink fan-out failed').pipe(
+									Effect.annotateLogs({
+										event: 'research.fanout.failed',
+										cause: Cause.pretty(cause),
+									}),
+								),
+					),
+				),
 		})
 	}),
 )

--- a/apps/server/src/services/calendar.ts
+++ b/apps/server/src/services/calendar.ts
@@ -1,4 +1,14 @@
-import { Data, DateTime, Effect, Layer, Schema, ServiceMap } from 'effect'
+import {
+	Cache,
+	Data,
+	DateTime,
+	Duration,
+	Effect,
+	Layer,
+	Option,
+	Schema,
+	ServiceMap,
+} from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
@@ -158,12 +168,24 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 			const timeline = yield* TimelineActivityService
 			const participantMatcher = yield* ParticipantMatcher
 
-			// Hot-path cache for slot queries so repeated callers within the
-			// TTL don't fan out parallel provider calls for the same window.
-			const slotCache = new Map<
+			// Remembers the available times we just looked up so that people
+			// asking for the same dates at once get a quick answer, instead of
+			// each request going out to the calendar provider separately. We keep
+			// the 500 most recent answers and forget each one after a short while,
+			// so this memory can't grow forever.
+			const slotCache = yield* Cache.make<
 				string,
-				{ readonly expiresAt: number; readonly slots: ReadonlyArray<Slot> }
-			>()
+				ReadonlyArray<Slot>,
+				never,
+				never
+			>({
+				capacity: 500,
+				timeToLive: Duration.millis(AVAILABILITY_CACHE_TTL_MS),
+				// We always store answers ourselves; we never ask this cache to
+				// fetch one for us, so reaching here means something went wrong.
+				lookup: () =>
+					Effect.die('calendar slotCache lookup invoked — expected set-only'),
+			})
 
 			const cacheKey = (
 				providerEventTypeId: string,
@@ -1337,8 +1359,8 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 						args.from,
 						args.to,
 					)
-					const hit = slotCache.get(key)
-					if (hit && hit.expiresAt > Date.now()) return hit.slots
+					const hit = yield* Cache.getOption(slotCache, key)
+					if (Option.isSome(hit)) return hit.value
 					const slots = yield* provider
 						.findSlots({
 							providerEventTypeId: eventType.providerEventTypeId,
@@ -1350,10 +1372,7 @@ export class CalendarService extends ServiceMap.Service<CalendarService>()(
 								Effect.succeed<ReadonlyArray<Slot>>([]),
 							),
 						)
-					slotCache.set(key, {
-						slots,
-						expiresAt: Date.now() + AVAILABILITY_CACHE_TTL_MS,
-					})
+					yield* Cache.set(slotCache, key, slots)
 					return slots
 				})
 

--- a/apps/server/src/services/webhooks.test.ts
+++ b/apps/server/src/services/webhooks.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchingEndpoints, type WebhookEndpoint } from './webhooks'
+
+const endpoint = (
+	url: string,
+	events: ReadonlyArray<string>,
+): WebhookEndpoint => ({ url, secret: null, events })
+
+describe('matchingEndpoints', () => {
+	describe('when an endpoint subscribed to the event', () => {
+		it('should include it', () => {
+			// GIVEN an endpoint subscribed to the fired event
+			// [webhooks.ts — endpoints.filter(ep => ep.events.includes(event))]
+			const endpoints = [endpoint('https://a', ['recording.uploaded'])]
+
+			// WHEN matching that event
+			const result = matchingEndpoints(endpoints, 'recording.uploaded')
+
+			// THEN the endpoint is returned
+			expect(result).toEqual(endpoints)
+		})
+
+		it('should include an endpoint subscribed to several events', () => {
+			// GIVEN an endpoint subscribed to multiple events including the target
+			const ep = endpoint('https://a', [
+				'research.succeeded',
+				'recording.uploaded',
+			])
+
+			// WHEN matching one of them
+			const result = matchingEndpoints([ep], 'recording.uploaded')
+
+			// THEN it is returned
+			expect(result).toEqual([ep])
+		})
+	})
+
+	describe('when an endpoint is not subscribed to the event', () => {
+		it('should exclude an endpoint subscribed only to other events', () => {
+			// GIVEN an endpoint subscribed to a different event
+			const endpoints = [endpoint('https://a', ['research.succeeded'])]
+
+			// WHEN matching an unsubscribed event
+			const result = matchingEndpoints(endpoints, 'recording.uploaded')
+
+			// THEN nothing is returned
+			expect(result).toEqual([])
+		})
+
+		it('should exclude an endpoint with an empty subscription list', () => {
+			// GIVEN an endpoint subscribed to nothing — an empty events array
+			const endpoints = [endpoint('https://a', [])]
+
+			// WHEN matching any event
+			const result = matchingEndpoints(endpoints, 'recording.uploaded')
+
+			// THEN it is excluded
+			expect(result).toEqual([])
+		})
+	})
+
+	describe('when several endpoints have mixed subscriptions', () => {
+		it('should return only the subscribed ones, preserving order', () => {
+			// GIVEN three endpoints, two of them subscribed to the target event
+			const subscribedA = endpoint('https://a', ['recording.uploaded'])
+			const unsubscribed = endpoint('https://b', ['research.failed'])
+			const subscribedC = endpoint('https://c', ['x', 'recording.uploaded'])
+
+			// WHEN matching the event
+			const result = matchingEndpoints(
+				[subscribedA, unsubscribed, subscribedC],
+				'recording.uploaded',
+			)
+
+			// THEN only the subscribed endpoints come back, in input order
+			expect(result).toEqual([subscribedA, subscribedC])
+		})
+
+		it('should return empty for an empty endpoint list', () => {
+			// GIVEN no endpoints at all
+			// WHEN matching any event
+			const result = matchingEndpoints([], 'recording.uploaded')
+
+			// THEN the result is empty
+			expect(result).toEqual([])
+		})
+	})
+})

--- a/apps/server/src/services/webhooks.ts
+++ b/apps/server/src/services/webhooks.ts
@@ -12,6 +12,20 @@ const hmacSign = (secret: string | null, payload: unknown): string => {
 		.digest('hex')
 }
 
+// Just the columns fire() reads; the query returns the whole row.
+export type WebhookEndpoint = {
+	readonly url: string
+	readonly secret: string | null
+	readonly events: ReadonlyArray<string>
+}
+
+// An endpoint is notified for an event only if it subscribed to that event.
+export const matchingEndpoints = (
+	endpoints: ReadonlyArray<WebhookEndpoint>,
+	event: string,
+): ReadonlyArray<WebhookEndpoint> =>
+	endpoints.filter(ep => ep.events.includes(event))
+
 export class WebhookService extends ServiceMap.Service<WebhookService>()(
 	'WebhookService',
 	{
@@ -25,15 +39,13 @@ export class WebhookService extends ServiceMap.Service<WebhookService>()(
 				fire: (event: string, payload: unknown) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const endpoints = yield* sql`
+						const endpoints = yield* sql<WebhookEndpoint>`
 							SELECT * FROM webhook_endpoints
 							WHERE is_active = true
 							  AND organization_id = ${currentOrg.id}
 						`
 
-						const matching = endpoints.filter((ep: any) =>
-							ep.events.includes(event),
-						)
+						const matching = matchingEndpoints(endpoints, event)
 
 						yield* Effect.logInfo('Webhook fan-out').pipe(
 							Effect.annotateLogs({
@@ -43,9 +55,13 @@ export class WebhookService extends ServiceMap.Service<WebhookService>()(
 							}),
 						)
 
+						// Send the webhooks in the background, but only after the lookup
+						// above has finished. The lookup has to run as part of the original
+						// request so it reads from the right place; sending it to the
+						// background too could make it run too late and read the wrong data.
 						yield* Effect.forEach(
 							matching,
-							(endpoint: any) =>
+							endpoint =>
 								Effect.tryPromise({
 									try: () =>
 										fetch(endpoint.url, {
@@ -79,8 +95,8 @@ export class WebhookService extends ServiceMap.Service<WebhookService>()(
 									),
 								),
 							{ concurrency: 'unbounded' },
-						)
-					}).pipe(Effect.forkDetach),
+						).pipe(Effect.forkDetach)
+					}),
 
 				list: () =>
 					Effect.gen(function* () {

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -1,3 +1,4 @@
+import { Cause } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -5,6 +6,7 @@ import {
 	normalizeResearchQuery,
 	researchCacheTtlDaysFor,
 	schemaVersionFor,
+	shouldMarkRunFailed,
 } from './research-service'
 
 describe('normalizeResearchQuery', () => {
@@ -174,6 +176,41 @@ describe('computeResearchCacheKey', () => {
 
 		// THEN switching the hint language misses the cache
 		expect(ca).not.toBe(es)
+	})
+})
+
+describe('shouldMarkRunFailed', () => {
+	describe('when the run ended with a typed failure', () => {
+		it('should mark the run failed', () => {
+			// GIVEN a Fail cause (an LLM or SQL error reaching the terminal handler)
+			// [research-service.ts — Effect.catchCause(cause => shouldMarkRunFailed(cause) ? …)]
+			const cause = Cause.fail(new Error('llm provider failed'))
+
+			// WHEN deciding whether to record the run as failed
+			// THEN it is recorded as failed
+			expect(shouldMarkRunFailed(cause)).toBe(true)
+		})
+	})
+
+	describe('when the run ended with a defect (an unexpected crash)', () => {
+		it('should mark the run failed', () => {
+			// GIVEN a Die cause (an unexpected throw, not a typed error)
+			const cause = Cause.die(new Error('boom'))
+
+			// THEN it is still recorded as failed
+			expect(shouldMarkRunFailed(cause)).toBe(true)
+		})
+	})
+
+	describe('when the run was interrupted (cancelled or shut down)', () => {
+		it('should not mark the run failed, so the cancellation status stands', () => {
+			// GIVEN a pure interrupt cause (cancel / graceful shutdown)
+			const cause = Cause.interrupt()
+
+			// WHEN deciding
+			// THEN the run is left alone — overwriting it with 'failed' would be wrong
+			expect(shouldMarkRunFailed(cause)).toBe(false)
+		})
 	})
 })
 

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 
 import {
+	Cause,
 	Config,
 	DateTime,
 	Effect,
@@ -25,6 +26,13 @@ import {
 } from './ports'
 import { type FreeformSchema, schemaRegistry } from './schemas/index'
 import { researchToolkit } from './tools'
+
+// A finished run is flipped to 'failed' for a real error or an unexpected
+// crash, but NOT when it was simply cancelled or shut down (a pure interrupt) —
+// that path sets its own status. So anything that isn't purely an interrupt
+// counts as a failure worth recording.
+export const shouldMarkRunFailed = (cause: Cause.Cause<unknown>): boolean =>
+	!Cause.hasInterruptsOnly(cause)
 
 const sha256Hex = (input: string): string =>
 	createHash('sha256').update(input).digest('hex')
@@ -260,12 +268,10 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						})
 					}
 					// Fire to external observability (webhooks, metrics)
-					yield* eventSink
-						.fire(`research.${type.replace('run.', '')}`, {
-							researchId,
-							...(typeof data === 'object' && data !== null ? data : { data }),
-						})
-						.pipe(Effect.catch(() => Effect.void))
+					yield* eventSink.fire(`research.${type.replace('run.', '')}`, {
+						researchId,
+						...(typeof data === 'object' && data !== null ? data : { data }),
+					})
 				})
 
 			const snapshotSubjects = (
@@ -605,21 +611,27 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						tokensOut,
 					})
 				}).pipe(
-					Effect.catch((error: unknown) =>
-						Effect.gen(function* () {
-							yield* sql`
-								UPDATE research_runs
-								SET status = 'failed',
-									findings = ${JSON.stringify({ error: String(error) })},
-									completed_at = now(),
-									updated_at = now()
-								WHERE id = ${researchId}
-							`
-							yield* publishEvent(researchId, 'run.failed', {
-								error: String(error),
+					Effect.catchCause(cause => {
+						if (shouldMarkRunFailed(cause)) {
+							return Effect.gen(function* () {
+								const detail = Cause.pretty(cause)
+								yield* sql`
+									UPDATE research_runs
+									SET status = 'failed',
+										findings = ${JSON.stringify({ error: detail })},
+										completed_at = now(),
+										updated_at = now()
+									WHERE id = ${researchId}
+								`
+								yield* publishEvent(researchId, 'run.failed', {
+									error: detail,
+								})
 							})
-						}),
-					),
+						}
+						// Pure interrupt (cancel/shutdown): propagate it; the cancel
+						// path sets the status itself, so don't overwrite it.
+						return Effect.interrupt
+					}),
 					Effect.ensuring(
 						Effect.gen(function* () {
 							// Without this shutdown, Stream.fromPubSub keeps the


### PR DESCRIPTION
Hardens the API server and mail-worker against the failure modes behind the 2026-05-26 multi-day outage (surfaced by a multi-agent crash audit + adversarial red-team). **batuda code only — no dependency patches.**

## Commits

1. **`feat`: process crash guards** — `installCrashGuards()` in both `main.ts` before `runMain`, catching out-of-fiber throws (the `@effect/sql-pg` pool callback, etc.) that `runMain` (SIGINT/SIGTERM only) would otherwise let crash silently. Logs + exits non-zero.
2. **`cicd(deploy)`: `--restart on-failure`** — both deploy workflows, so the guard's exit recovers instead of leaving a dead-but-"running" zombie (the outage root cause; current platform default is `never`).
3. **`fix(mail-worker)`: imapflow `error` listener** — a mid-IDLE socket/TLS error no longer crashes the whole worker (which would drop IDLE for every claimed inbox).
4. **`fix(server)`: bounded calendar caches** — the two unbounded slot-cache `Map`s become set-only Effect `Cache` (capacity 500 + 60s TTL), closing an auth-gated request-path OOM.
5. **`fix(server)`: webhook lookup off the detached fiber** — the endpoint `SELECT` runs on the request's own connection; only the HTTP delivery is backgrounded, so it can't query a released/reused connection.
6. **`fix`: research event-sink no longer strands runs** — `Effect.orDie` becomes `Effect.catchCause`; a transient DB blip during fan-out is logged (not fatal), defects mark the run `failed`, and a genuine cancel/shutdown still propagates.

## Verification

`pnpm install` → `check-types` (11 packages) + `test` (server 68, mail-worker 24, research 42 — all passing) + `build`, all green. Each behavior also runtime-verified: the guard logs+exits(1); the imapflow listener swallows an `'error'` on a real `ImapFlow`; the cache evicts at capacity; the research terminal handler marks-failed on a defect and re-raises a pure interrupt.

## Ops follow-up (at deploy)

The existing `batuda-server` instance still has restart policy `never`. Once this deploys `--restart on-failure` to the new instance, remove the stale one (`kraft cloud --metro fra instance remove …`) or let the next rollout age it out.
