### PR TITLE
test(server): fix oauth-auth integration tests (stale JWKS from prod clone)

### DIFF
--- a/apps/server/src/mcp/oauth-auth.integration.test.ts
+++ b/apps/server/src/mcp/oauth-auth.integration.test.ts
@@ -269,6 +269,13 @@ const deleteFixtureRows = async () => {
 }
 
 const cleanup = async () => {
+	// The JWKS signing key is stored encrypted with BETTER_AUTH_SECRET. CI clones
+	// its database from a parent whose key was encrypted with a different secret,
+	// so this run can't decrypt it — and Better Auth reuses a still-valid key
+	// rather than regenerating one. Clear it so the first sign mints a fresh key
+	// with this run's secret. Safe: the suite is sequential (fileParallelism:false)
+	// and this is the only file that signs JWTs.
+	await pool.query('DELETE FROM jwks')
 	await pool.query('DELETE FROM companies WHERE slug = $1', [FIXTURE_SLUG])
 	await pool.query(
 		`DELETE FROM mcp_oauth_org WHERE user_id IN (SELECT id FROM "user" WHERE email LIKE $1)`,

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,43 @@
+# Runbooks
+
+Operational procedures for production. Add a new section per procedure.
+
+## Rotating `BETTER_AUTH_SECRET`
+
+`BETTER_AUTH_SECRET` does double duty: it signs sessions/cookies **and** it
+encrypts the JWKS private key Better Auth uses to sign OAuth / MCP / web-chat
+access tokens. Because of that second role you **cannot rotate the secret on
+its own** — the stored signing key was encrypted with the *old* secret, and
+Better Auth keeps trying to decrypt it with the new one and fails
+(`BetterAuthError: Failed to decrypt private key`), so every token sign breaks
+until the key is cleared. It does **not** self-heal: a still-valid key is
+reused, never regenerated (mechanism in
+`docs/repos/better-auth/packages/better-auth/src/plugins/jwt/sign.ts`; tracked
+in issue #59).
+
+### Procedure (do these together, during low traffic)
+
+1. **Update the secret** in the production environment (deploy secret /
+   KraftCloud env), then deploy.
+2. **Clear the JWKS** so a fresh signing key is minted with the new secret on
+   the next request — run against the production database (Neon console / psql):
+   ```sql
+   DELETE FROM jwks;
+   ```
+3. **Verify**: exercise an endpoint that signs a token (or run the
+   `oauth-auth` integration tests) — no "Failed to decrypt" errors.
+
+### Impact to expect
+
+- Clearing `jwks` invalidates the old signing key, so **access tokens signed
+  with it stop verifying** until clients refresh. The prod access-token TTL is
+  short (`OAUTH_ACCESS_TOKEN_TTL_SECONDS`, 900s), so the window is small —
+  still, prefer a quiet moment.
+- Sessions/cookies signed with the old secret also invalidate (users re-login).
+
+### Avoiding the coupling later (optional)
+
+- Set the jwt plugin's `rotationInterval` so keys expire and regenerate on a
+  schedule, or
+- weigh `jwks.disablePrivateKeyEncryption` — removes the secret↔key coupling
+  but stores the signing private key **unencrypted** in the DB.


### PR DESCRIPTION
Fixes the 10 failing `src/mcp/oauth-auth.integration.test.ts` tests — a pre-existing red on `main` (failing since ~2026-05-29), unrelated to the crash-resilience PR.

## Root cause
Better Auth `1.6.x` stores the JWKS **private key encrypted with `BETTER_AUTH_SECRET`** (default-on; older versions stored it plaintext). On every sign it decrypts the *latest* key with the current secret and only regenerates a missing/expired key — a stale key encrypted with a different secret is reused and the decrypt throws (`sign.ts:124`), never self-healing.

CI creates each ephemeral integration branch with `parent = production` (confirmed via Neon), so it **clones production's `jwks` row** (encrypted with production's secret), while the run uses the test secret from `applyTestEnv()`. Every `signJWT` then fails with *"Failed to decrypt private key"*, so all 10 token-minting tests fail; the non-token tests pass.

## Fix
Clear the `jwks` table in the integration test's `cleanup()` so Better Auth mints a fresh key with the run's own secret. Test-only (no production code change); it deletes only on the ephemeral CI clone, never production. Safe because the integration suite is sequential (`fileParallelism: false`) and this is the only file that signs JWTs.

## Verification
CI (this PR) runs the integration suite against a fresh ephemeral Neon branch — the exact environment that was failing.

## Follow-up (separate)
Production would hit the same error if `BETTER_AUTH_SECRET` were ever rotated without clearing `jwks` — tracked as an ops/runbook item, not part of this fix.
