### PR TITLE
Stamp organization_id on documents and calendar create handlers

### DIFF
--- a/apps/server/src/handlers/calendar-create-internal-event.integration.test.ts
+++ b/apps/server/src/handlers/calendar-create-internal-event.integration.test.ts
@@ -1,0 +1,154 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to
+// the docker-compose service so the suite runs without a loaded .env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// SQL-contract test for the calendar_events INSERT that
+// `apps/server/src/handlers/calendar.ts` runs from
+// `handle('createInternalEvent', ...)`. The MCP tool path
+// (create_internal_block → CalendarService.createInternalBlock) already
+// stamps organization_id from CurrentOrg, so it's not in scope here —
+// only the HTTP handler bypassed the service and wrote SQL directly.
+//
+// Mirrors the post-fix shape (organization_id stamped from CurrentOrg)
+// using raw `pg` with `app.current_org_id` set on the session, so the
+// org_isolation_calendar_events RLS policy engages exactly as it does
+// at runtime. Also pins the pre-fix shape as a failure case so a future
+// hand-edit that drops the column from the INSERT immediately fails
+// the suite.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+describe('calendar_events INSERT — RLS contract (internal events)', () => {
+	let pool: pg.Pool
+	let orgId: string
+	const seededEventIds: string[] = []
+
+	beforeAll(async () => {
+		pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+		await pool.query('GRANT app_user TO CURRENT_USER')
+
+		const orgs = await pool.query<{ id: string }>(
+			`SELECT id FROM organization WHERE slug = $1 LIMIT 1`,
+			['taller'],
+		)
+		const oid = orgs.rows[0]?.id
+		if (!oid) {
+			throw new Error(
+				"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
+			)
+		}
+		orgId = oid
+	})
+
+	afterAll(async () => {
+		for (const id of seededEventIds) {
+			await pool.query(`DELETE FROM calendar_events WHERE id = $1::uuid`, [id])
+		}
+		await pool.end()
+	})
+
+	const withOrgScope = async <T>(
+		body: (client: pg.PoolClient) => Promise<T>,
+	): Promise<T> => {
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			await client.query('SET LOCAL ROLE app_user')
+			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+				orgId,
+			])
+			const result = await body(client)
+			await client.query('COMMIT')
+			return result
+		} catch (err) {
+			await client.query('ROLLBACK')
+			throw err
+		} finally {
+			client.release()
+		}
+	}
+
+	describe('when the createInternalEvent INSERT includes organization_id', () => {
+		it('should pass the org_isolation_calendar_events WITH CHECK clause as app_user', async () => {
+			// GIVEN app.current_org_id = taller.id and SET ROLE app_user
+			// WHEN INSERT INTO calendar_events runs with organization_id=taller.id
+			//      (mirrors handlers/calendar.ts createInternalEvent post-fix shape)
+			// THEN the policy approves the row
+			// [handlers/calendar.ts — createInternalEvent INSERT shape]
+			const id = randomUUID()
+			seededEventIds.push(id)
+			const icalUid = `internal-${randomUUID()}@calendar.batuda`
+
+			const inserted = await withOrgScope(async client => {
+				const result = await client.query<{
+					id: string
+					organization_id: string
+					source: string
+				}>(
+					`INSERT INTO calendar_events (
+						id,
+						organization_id,
+						source, provider, ical_uid, ical_sequence,
+						start_at, end_at, status,
+						title, location_type, organizer_email
+					) VALUES (
+						$1::uuid,
+						$2,
+						'internal', 'internal', $3, 0,
+						now(), now() + interval '30 minutes', 'confirmed',
+						'Test Block', 'none', 'organizer@example.com'
+					)
+					RETURNING id, organization_id, source`,
+					[id, orgId, icalUid],
+				)
+				return result.rows[0]
+			})
+
+			expect(inserted?.id).toBe(id)
+			expect(inserted?.organization_id).toBe(orgId)
+			expect(inserted?.source).toBe('internal')
+		})
+	})
+
+	describe('when the INSERT omits organization_id (the pre-fix shape)', () => {
+		it('should fail because the column is NOT NULL', async () => {
+			// GIVEN the pre-fix INSERT — no organization_id column in the list
+			// WHEN it runs as app_user with app.current_org_id set
+			// THEN the INSERT fails because organization_id is NOT NULL with no default
+			// [handlers/calendar.ts (pre-fix) — createInternalEvent omitted org_id]
+			const id = randomUUID()
+			const icalUid = `internal-${randomUUID()}@calendar.batuda`
+
+			await expect(
+				withOrgScope(async client => {
+					await client.query(
+						`INSERT INTO calendar_events (
+							id,
+							source, provider, ical_uid, ical_sequence,
+							start_at, end_at, status,
+							title, location_type, organizer_email
+						) VALUES (
+							$1::uuid,
+							'internal', 'internal', $2, 0,
+							now(), now() + interval '30 minutes', 'confirmed',
+							'Bug Repro', 'none', 'organizer@example.com'
+						)`,
+						[id, icalUid],
+					)
+				}),
+			).rejects.toThrow(
+				/null value in column "organization_id"|row.level security/i,
+			)
+		})
+	})
+})

--- a/apps/server/src/handlers/calendar.ts
+++ b/apps/server/src/handlers/calendar.ts
@@ -8,6 +8,7 @@ import {
 	BadRequest,
 	BatudaApi,
 	Conflict,
+	CurrentOrg,
 	Forbidden,
 	NotFound,
 	SessionContext,
@@ -127,6 +128,7 @@ export const CalendarLive = HttpApiBuilder.group(
 				.handle('createInternalEvent', _ =>
 					Effect.gen(function* () {
 						const { email: organizerEmail } = yield* SessionContext
+						const currentOrg = yield* CurrentOrg
 						const startAt = DateTime.toDateUtc(_.payload.startAt)
 						const endAt = DateTime.toDateUtc(_.payload.endAt)
 						if (endAt.getTime() <= startAt.getTime())
@@ -137,6 +139,7 @@ export const CalendarLive = HttpApiBuilder.group(
 						const icalUid = `internal-${crypto.randomUUID()}@calendar.batuda`
 						const rows = yield* sql`
 							INSERT INTO calendar_events ${sql.insert({
+								organization_id: currentOrg.id,
 								source: 'internal',
 								provider: 'internal',
 								provider_booking_id: null,

--- a/apps/server/src/handlers/documents-create.integration.test.ts
+++ b/apps/server/src/handlers/documents-create.integration.test.ts
@@ -1,0 +1,158 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to
+// the docker-compose service so the suite runs without a loaded .env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// SQL-contract test for the documents INSERT that
+// `apps/server/src/handlers/documents.ts` and
+// `apps/server/src/mcp/tools/documents.ts` both run from their create
+// paths. Mirrors the post-fix shape (organization_id stamped from
+// CurrentOrg) using raw `pg` with `app.current_org_id` set on the
+// session, so the org_isolation_documents RLS policy engages exactly
+// as it does at runtime. Also pins the pre-fix shape as a failure
+// case so a future hand-edit that drops the column from the INSERT
+// immediately fails the suite.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+describe('documents INSERT — RLS contract', () => {
+	let pool: pg.Pool
+	let orgId: string
+	const seededDocumentIds: string[] = []
+	const seededCompanyIds: string[] = []
+
+	beforeAll(async () => {
+		pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+		await pool.query('GRANT app_user TO CURRENT_USER')
+
+		const orgs = await pool.query<{ id: string }>(
+			`SELECT id FROM organization WHERE slug = $1 LIMIT 1`,
+			['taller'],
+		)
+		const oid = orgs.rows[0]?.id
+		if (!oid) {
+			throw new Error(
+				"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
+			)
+		}
+		orgId = oid
+	})
+
+	afterAll(async () => {
+		for (const id of seededDocumentIds) {
+			await pool.query(`DELETE FROM documents WHERE id = $1::uuid`, [id])
+		}
+		for (const id of seededCompanyIds) {
+			await pool.query(`DELETE FROM companies WHERE id = $1::uuid`, [id])
+		}
+		await pool.end()
+	})
+
+	const withOrgScope = async <T>(
+		body: (client: pg.PoolClient) => Promise<T>,
+	): Promise<T> => {
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			await client.query('SET LOCAL ROLE app_user')
+			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+				orgId,
+			])
+			const result = await body(client)
+			await client.query('COMMIT')
+			return result
+		} catch (err) {
+			await client.query('ROLLBACK')
+			throw err
+		} finally {
+			client.release()
+		}
+	}
+
+	const seedCompany = async (client: pg.PoolClient): Promise<string> => {
+		const id = randomUUID()
+		const slug = `documents-test-${id}`
+		await client.query(
+			`INSERT INTO companies (id, organization_id, slug, name)
+			 VALUES ($1::uuid, $2, $3, 'Documents Test Co')`,
+			[id, orgId, slug],
+		)
+		seededCompanyIds.push(id)
+		return id
+	}
+
+	describe('when the create INSERT includes organization_id', () => {
+		it('should pass the org_isolation_documents WITH CHECK clause as app_user', async () => {
+			// GIVEN app.current_org_id = taller.id and SET ROLE app_user
+			// WHEN INSERT INTO documents runs with organization_id=taller.id
+			//      (mirrors handlers/documents.ts + tools/documents.ts post-fix shape)
+			// THEN the policy approves the row
+			// [handlers/documents.ts + tools/documents.ts — create handler INSERT shape]
+			const id = randomUUID()
+			seededDocumentIds.push(id)
+
+			const inserted = await withOrgScope(async client => {
+				const companyId = await seedCompany(client)
+				const result = await client.query<{
+					id: string
+					organization_id: string
+					type: string
+				}>(
+					`INSERT INTO documents (
+						id,
+						organization_id,
+						company_id, type, content
+					) VALUES (
+						$1::uuid,
+						$2,
+						$3::uuid, 'note', 'Test content'
+					)
+					RETURNING id, organization_id, type`,
+					[id, orgId, companyId],
+				)
+				return result.rows[0]
+			})
+
+			expect(inserted?.id).toBe(id)
+			expect(inserted?.organization_id).toBe(orgId)
+			expect(inserted?.type).toBe('note')
+		})
+	})
+
+	describe('when the INSERT omits organization_id (the pre-fix shape)', () => {
+		it('should fail because the column is NOT NULL', async () => {
+			// GIVEN the pre-fix INSERT — no organization_id column in the list
+			// WHEN it runs as app_user with app.current_org_id set
+			// THEN the INSERT fails because organization_id is NOT NULL with no default
+			// [handlers/documents.ts + tools/documents.ts (pre-fix) — INSERT omitted org_id]
+			const id = randomUUID()
+
+			await expect(
+				withOrgScope(async client => {
+					const companyId = await seedCompany(client)
+					await client.query(
+						`INSERT INTO documents (
+							id,
+							company_id, type, content
+						) VALUES (
+							$1::uuid,
+							$2::uuid, 'note', 'Bug Repro'
+						)`,
+						[id, companyId],
+					)
+				}),
+			).rejects.toThrow(
+				/null value in column "organization_id"|row.level security/i,
+			)
+		})
+	})
+})

--- a/apps/server/src/handlers/documents.ts
+++ b/apps/server/src/handlers/documents.ts
@@ -3,7 +3,7 @@ import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { BatudaApi, NotFound } from '@batuda/controllers'
+import { BatudaApi, CurrentOrg, NotFound } from '@batuda/controllers'
 
 import {
 	DocumentCreated,
@@ -46,6 +46,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 				)
 				.handle('create', _ =>
 					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
 						const payload = _.payload as {
 							companyId: string
 							interactionId?: string
@@ -54,7 +55,10 @@ export const DocumentsLive = HttpApiBuilder.group(
 							content: string
 						}
 						const rows = yield* sql<{ id: string; title: string | null }>`
-							INSERT INTO documents ${sql.insert(payload)} RETURNING id, title
+							INSERT INTO documents ${sql.insert({
+								...payload,
+								organizationId: currentOrg.id,
+							})} RETURNING id, title
 						`
 						const created = rows[0]
 						if (!created) {

--- a/apps/server/src/mcp/tools/documents.ts
+++ b/apps/server/src/mcp/tools/documents.ts
@@ -99,8 +99,10 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 				}).pipe(Effect.orDie),
 			create_document: params =>
 				Effect.gen(function* () {
+					const currentOrg = yield* CurrentOrg
 					const rows = yield* sql<{ id: string; title: string | null }>`
 						INSERT INTO documents ${sql.insert({
+							organizationId: currentOrg.id,
 							companyId: params.company_id,
 							interactionId: params.interaction_id,
 							type: params.type,


### PR DESCRIPTION
## Summary

Closes the two `organization_id` follow-ups deferred from PR #60. Same dormant bug pattern: HTTP create handlers were calling `sql.insert(_.payload)` without `organization_id`, and both target tables require it (NOT NULL + RLS `WITH CHECK`). Existing rows seeded via direct SQL hide the bug today; the first real caller would have returned 500.

2 commits, +323 LOC. Independent of PR #60.

## What's fixed

- **`apps/server/src/handlers/documents.ts`** and **`apps/server/src/mcp/tools/documents.ts`** — both `create` paths now stamp `organizationId` from `CurrentOrg`.
- **`apps/server/src/handlers/calendar.ts` `createInternalEvent`** — HTTP path now stamps `organization_id`. The MCP path (`create_internal_block` → `CalendarService.createInternalBlock`) was already correct because it goes through the service.

## Tests added

Two SQL-contract tests mirroring the products / proposals / contacts pattern from PR #60:

- `apps/server/src/handlers/documents-create.integration.test.ts`
- `apps/server/src/handlers/calendar-create-internal-event.integration.test.ts`

Each pins the post-fix INSERT shape under RLS and the pre-fix shape as a rejection.

## Test plan

- [x] `pnpm install` ✓
- [x] `pnpm check-types` ✓ (11/11)
- [x] `pnpm test` ✓ (15/15 unit + spec)
- [x] `pnpm build` ✓ (11/11)
- [x] `pnpm --filter @batuda/server test:integration documents-create calendar-create-internal-event` ✓ (4/4 SQL-contract tests)