### PR TITLE
Harden research MCP input validation and lifecycle guards

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,6 @@
 			"Edit(.claude/skills/**)"
 		]
 	},
-	"model": "claude-opus-4-7",
 	"hooks": {
 		"PreToolUse": [
 			{

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,12 @@
 {
 	"mcpServers": {
+		"batuda": {
+			"type": "http",
+			"url": "https://api.batuda.co/mcp",
+			"headers": {
+				"x-api-key": "${BATUDA_API_KEY}"
+			}
+		},
 		"cloudflare-api": {
 			"type": "http",
 			"url": "https://mcp.cloudflare.com/mcp"

--- a/apps/server/src/handlers/research.ts
+++ b/apps/server/src/handlers/research.ts
@@ -164,21 +164,44 @@ export const ResearchLive = HttpApiBuilder.group(
 				)
 				.handle('cancel', _ =>
 					Effect.gen(function* () {
-						yield* svc.cancel(_.params.id)
+						const res = yield* svc.cancel(_.params.id)
+						if (res.outcome === 'not_found')
+							return yield* new NotFound({
+								entity: 'research',
+								id: _.params.id,
+							})
 						return { status: 'cancelled' }
-					}).pipe(Effect.orDie),
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
 				)
 				.handle('attach', _ =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						yield* svc.attach(
+						const res = yield* svc.attach(
 							currentOrg.id,
 							_.params.id,
 							_.payload.subject_table,
 							_.payload.subject_id,
 						)
+						if (res.outcome === 'subject_not_found')
+							return yield* new NotFound({
+								entity: _.payload.subject_table,
+								id: _.payload.subject_id,
+							})
+						if (res.outcome === 'run_not_found')
+							return yield* new NotFound({
+								entity: 'research',
+								id: _.params.id,
+							})
 						return { status: 'attached' }
-					}).pipe(Effect.orDie),
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
 				)
 				.handle('delete', _ =>
 					Effect.gen(function* () {

--- a/apps/server/src/mcp/tools/_research-shared.test.ts
+++ b/apps/server/src/mcp/tools/_research-shared.test.ts
@@ -1,0 +1,140 @@
+import { Cause, Effect, Exit, Schema } from 'effect'
+import { SqlError } from 'effect/unstable/sql'
+import { describe, expect, it } from 'vitest'
+
+import {
+	ResearchQuery,
+	redactDbErrors,
+	SchemaNameParam,
+	Uuid,
+} from './_research-shared'
+
+// True when the value passes the schema's validation (refinement checks included).
+const accepts = (schema: Schema.Codec<unknown>, value: unknown): boolean =>
+	Schema.is(schema)(value)
+
+const A_UUID = '550e8400-e29b-41d4-a716-446655440000'
+
+describe('Uuid', () => {
+	describe('when the value is a well-formed UUID', () => {
+		it('should accept it', () => {
+			// GIVEN a canonical UUID
+			// THEN it decodes
+			expect(accepts(Uuid, A_UUID)).toBe(true)
+		})
+	})
+
+	describe('when the value is an uppercase UUID', () => {
+		it('should accept it, matching how Postgres parses either case', () => {
+			// GIVEN a UUID in uppercase
+			// THEN it still passes (Postgres accepts it too)
+			expect(accepts(Uuid, A_UUID.toUpperCase())).toBe(true)
+		})
+	})
+
+	describe('when the value is not a UUID', () => {
+		it('should reject a malformed id before it can reach SQL', () => {
+			// GIVEN ids Postgres would reject as an invalid uuid cast
+			// THEN each is refused at the boundary, so no raw SqlError leaks
+			expect(accepts(Uuid, 'abc-not-a-uuid')).toBe(false)
+			expect(accepts(Uuid, '')).toBe(false)
+			expect(accepts(Uuid, '123')).toBe(false)
+		})
+	})
+})
+
+describe('ResearchQuery', () => {
+	describe('when the query is present and reasonably sized', () => {
+		it('should accept it', () => {
+			// GIVEN a normal prompt
+			// THEN it decodes
+			expect(accepts(ResearchQuery, 'Investiga Factorial')).toBe(true)
+		})
+	})
+
+	describe('when the query is empty', () => {
+		it('should reject it so no empty run is created', () => {
+			// GIVEN an empty string
+			// THEN it is refused
+			expect(accepts(ResearchQuery, '')).toBe(false)
+		})
+	})
+
+	describe('when the query length is at the boundary', () => {
+		it('should accept input exactly at the 8000-char cap', () => {
+			// GIVEN a prompt at the cap
+			// THEN it still decodes
+			expect(accepts(ResearchQuery, 'x'.repeat(8000))).toBe(true)
+		})
+
+		it('should reject oversized input that would waste provider spend', () => {
+			// GIVEN a prompt one char past the cap
+			// THEN it is refused
+			expect(accepts(ResearchQuery, 'x'.repeat(8001))).toBe(false)
+		})
+	})
+})
+
+describe('SchemaNameParam', () => {
+	describe('when the name is in the closed set', () => {
+		it('should accept every registered schema name', () => {
+			// GIVEN each schema the server can resolve
+			// THEN all decode
+			for (const name of [
+				'freeform',
+				'company_enrichment_v1',
+				'competitor_scan_v1',
+				'contact_discovery_v1',
+				'prospect_scan_v1',
+			]) {
+				expect(accepts(SchemaNameParam, name)).toBe(true)
+			}
+		})
+	})
+
+	describe('when the name is unknown', () => {
+		it('should reject it up front instead of creating a doomed run', () => {
+			// GIVEN a schema name the registry does not define
+			// THEN it is refused at the boundary
+			expect(accepts(SchemaNameParam, 'bogus_schema_v9')).toBe(false)
+		})
+	})
+})
+
+describe('redactDbErrors', () => {
+	const sqlError = () =>
+		new SqlError.SqlError({
+			reason: new SqlError.UnknownError({
+				cause: 'boom',
+				message: 'SELECT secret FROM users',
+			}),
+		})
+
+	describe('when the wrapped effect fails with a SqlError', () => {
+		it('should collapse it to a redacted defect that hides the driver error', () => {
+			// GIVEN an effect failing with a SqlError carrying the raw statement
+			const exit = Effect.runSyncExit(redactDbErrors(Effect.fail(sqlError())))
+
+			// THEN the result is a defect with a generic message, and neither the
+			// SQL statement nor the SqlError tag survives in the rendered cause
+			expect(Exit.isFailure(exit)).toBe(true)
+			if (Exit.isFailure(exit)) {
+				const rendered = Cause.pretty(exit.cause)
+				expect(rendered).toContain('internal error')
+				expect(rendered).not.toContain('SELECT secret')
+				expect(rendered).not.toContain('SqlError')
+			}
+		})
+	})
+
+	describe('when the wrapped effect succeeds', () => {
+		it('should pass the value through untouched', () => {
+			// GIVEN a successful effect
+			const exit = Effect.runSyncExit(redactDbErrors(Effect.succeed('ok')))
+
+			// THEN the success is preserved
+			expect(Exit.isSuccess(exit)).toBe(true)
+			if (Exit.isSuccess(exit)) expect(exit.value).toBe('ok')
+		})
+	})
+})

--- a/apps/server/src/mcp/tools/_research-shared.ts
+++ b/apps/server/src/mcp/tools/_research-shared.ts
@@ -1,0 +1,32 @@
+import { Effect, Schema } from 'effect'
+import type { SqlError } from 'effect/unstable/sql'
+
+import { SchemaNameSchema } from '@batuda/research'
+
+// A UUID-shaped identifier, validated at the MCP parameter boundary. Rejecting
+// a malformed id here means it never reaches SQL as an invalid uuid cast, which
+// would otherwise surface a raw Postgres error to the caller.
+export const Uuid = Schema.String.check(Schema.isUUID())
+
+// schema_name constrained to the server's closed set, so an unknown name is
+// rejected up front instead of creating a run that only fails at phase 0.
+export const SchemaNameParam = SchemaNameSchema
+
+// A research query: present and length-bounded. Stops empty prompts from
+// creating junk runs and caps oversized input that would otherwise waste spend
+// once real providers are wired in.
+export const ResearchQuery = Schema.String.check(
+	Schema.isMinLength(1),
+	Schema.isMaxLength(8000),
+)
+
+// Swap an infrastructure SqlError for a redacted defect so the MCP layer returns
+// a generic message instead of dumping the Postgres driver error — statement,
+// connection details, driver stack — to the client. The lifecycle/service calls
+// behind these tools fail only with SqlError, so we collapse it to a defect (like
+// the prior `Effect.orDie`). A string defect (not `new Error`) keeps even our own
+// source path out of the rendered cause.
+export const redactDbErrors = <A, R>(
+	effect: Effect.Effect<A, SqlError.SqlError, R>,
+): Effect.Effect<A, never, R> =>
+	effect.pipe(Effect.catchTag('SqlError', () => Effect.die('internal error')))

--- a/apps/server/src/mcp/tools/research-lifecycle.ts
+++ b/apps/server/src/mcp/tools/research-lifecycle.ts
@@ -4,6 +4,8 @@ import { Tool, Toolkit } from 'effect/unstable/ai'
 import { CurrentOrg, SessionContext } from '@batuda/controllers'
 import { ResearchService } from '@batuda/research'
 
+import { redactDbErrors, Uuid } from './_research-shared'
+
 const REQUEST_DEPENDENCIES = [SessionContext, CurrentOrg]
 
 const Decision = Schema.Literals(['approve', 'skip'])
@@ -17,7 +19,7 @@ const ListResearch = Tool.make('list_research', {
 		created_by: Schema.optional(Schema.String),
 		status: Schema.optional(Schema.String),
 		subject_table: Schema.optional(Schema.String),
-		subject_id: Schema.optional(Schema.String),
+		subject_id: Schema.optional(Uuid),
 		since: Schema.optional(Schema.String),
 		limit: Schema.optional(Schema.Number),
 		offset: Schema.optional(Schema.Number),
@@ -34,11 +36,12 @@ const CancelResearch = Tool.make('cancel_research', {
 	description:
 		'Interrupt a queued or running research run. Already-cancelled runs are left as-is.',
 	parameters: Schema.Struct({
-		id: Schema.String,
+		id: Uuid,
 	}),
-	success: Schema.Struct({
-		status: Schema.Literal('cancelled'),
-	}),
+	success: Schema.Union([
+		Schema.Struct({ status: Schema.Literal('cancelled') }),
+		Schema.Struct({ error: Schema.Literal('not_found') }),
+	]),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'Cancel Research')
@@ -52,11 +55,14 @@ const AttachResearch = Tool.make('attach_research', {
 	parameters: Schema.Struct({
 		id: Schema.String,
 		subject_table: Schema.Literals(['companies', 'contacts']),
-		subject_id: Schema.String,
+		subject_id: Uuid,
 	}),
-	success: Schema.Struct({
-		status: Schema.Literal('attached'),
-	}),
+	success: Schema.Union([
+		Schema.Struct({ status: Schema.Literal('attached') }),
+		Schema.Struct({
+			error: Schema.Literals(['subject_not_found', 'run_not_found']),
+		}),
+	]),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'Attach Research')
@@ -68,7 +74,7 @@ const DeleteResearch = Tool.make('delete_research', {
 	description:
 		'Soft-delete a research run (sets status=deleted; the row stays for audit but stops appearing in list_research). Requires user approval before execution.',
 	parameters: Schema.Struct({
-		id: Schema.String,
+		id: Uuid,
 	}),
 	success: Schema.Struct({
 		status: Schema.Literal('deleted'),
@@ -196,23 +202,31 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 						limit: filters.limit,
 						offset: filters.offset,
 					})
-					.pipe(Effect.orDie),
+					.pipe(redactDbErrors),
 			cancel_research: ({ id }) =>
 				Effect.gen(function* () {
-					yield* svc.cancel(id)
+					const res = yield* svc.cancel(id)
+					if (res.outcome === 'not_found')
+						return { error: 'not_found' as const }
 					return { status: 'cancelled' as const }
-				}).pipe(Effect.orDie),
+				}).pipe(redactDbErrors),
 			attach_research: ({ id, subject_table, subject_id }) =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
-					yield* svc.attach(currentOrg.id, id, subject_table, subject_id)
-					return { status: 'attached' as const }
-				}).pipe(Effect.orDie),
+					const res = yield* svc.attach(
+						currentOrg.id,
+						id,
+						subject_table,
+						subject_id,
+					)
+					if (res.outcome === 'attached') return { status: 'attached' as const }
+					return { error: res.outcome }
+				}).pipe(redactDbErrors),
 			delete_research: ({ id }) =>
 				Effect.gen(function* () {
 					yield* svc.softDelete(id)
 					return { status: 'deleted' as const }
-				}).pipe(Effect.orDie),
+				}).pipe(redactDbErrors),
 			resolve_research_paid_action: ({ decision }) =>
 				// Placeholder: returns the resolution shape but the follow-up
 				// run that performs the paid call is not yet wired, so no DB
@@ -230,7 +244,7 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 						proposed_updates?: unknown[]
 					} | null
 					return findings?.proposed_updates ?? []
-				}).pipe(Effect.orDie),
+				}).pipe(redactDbErrors),
 			resolve_research_proposed_update: ({ decision }) =>
 				// Placeholder: the OCC-protected CRM write that would land on
 				// apply is not yet wired, so this returns the resolution
@@ -255,7 +269,7 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 							paidMonthlyCapCents: params.paid_monthly_cap_cents,
 						})
 						.pipe(Effect.map(rows => rows[0]))
-				}).pipe(Effect.orDie),
+				}).pipe(redactDbErrors),
 			get_research_spend: ({ range, group_by }) =>
 				svc
 					.spend({
@@ -264,7 +278,7 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 						...(range !== undefined && { range }),
 						...(group_by !== undefined && { groupBy: group_by }),
 					})
-					.pipe(Effect.orDie),
+					.pipe(redactDbErrors),
 		}
 	}),
 )

--- a/apps/server/src/mcp/tools/research-mcp.ts
+++ b/apps/server/src/mcp/tools/research-mcp.ts
@@ -9,6 +9,12 @@ import {
 } from '@batuda/research'
 
 import { EnvVars } from '../../lib/env'
+import {
+	ResearchQuery,
+	redactDbErrors,
+	SchemaNameParam,
+	Uuid,
+} from './_research-shared'
 
 const REQUEST_DEPENDENCIES = [CurrentOrg]
 
@@ -18,9 +24,9 @@ const StartResearch = Tool.make('start_research', {
 	description:
 		'Start a research run. Returns an ID immediately — use get_research to poll for results. Best for long-running research where you want to do other work while waiting.',
 	parameters: Schema.Struct({
-		query: Schema.String,
+		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
-		schema_name: Schema.optional(Schema.String),
+		schema_name: Schema.optional(SchemaNameParam),
 	}),
 	success: Schema.Struct({
 		id: Schema.String,
@@ -38,7 +44,7 @@ const GetResearch = Tool.make('get_research', {
 	description:
 		'Get the current state of a research run. Returns status, findings (if complete), cost, and sources.',
 	parameters: Schema.Struct({
-		id: Schema.String,
+		id: Uuid,
 	}),
 	success: Schema.Unknown,
 	dependencies: REQUEST_DEPENDENCIES,
@@ -54,9 +60,9 @@ const ResearchSync = Tool.make('research_sync', {
 	description:
 		'Run research to completion and return full findings inline. Blocks until done or timeout. Best for short research that fits in a single tool call.',
 	parameters: Schema.Struct({
-		query: Schema.String,
+		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
-		schema_name: Schema.optional(Schema.String),
+		schema_name: Schema.optional(SchemaNameParam),
 		max_wait_seconds: Schema.optional(Schema.Number),
 	}),
 	success: Schema.Unknown,
@@ -104,13 +110,13 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 						systemDefaults,
 					)
 					return result
-				}).pipe(Effect.orDie),
+				}).pipe(redactDbErrors),
 
 			get_research: params =>
 				Effect.gen(function* () {
 					const run = yield* svc.get(params.id)
 					return run ?? { error: 'not found' }
-				}).pipe(Effect.orDie),
+				}).pipe(redactDbErrors),
 
 			research_sync: params =>
 				Effect.gen(function* () {
@@ -145,7 +151,7 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 					}
 
 					return run ?? { error: 'not found' }
-				}).pipe(Effect.orDie),
+				}).pipe(redactDbErrors),
 		}
 	}),
 )

--- a/packages/controllers/src/routes/research.ts
+++ b/packages/controllers/src/routes/research.ts
@@ -115,6 +115,7 @@ export const ResearchGroup = HttpApiGroup.make('research')
 			params: { id: Schema.String },
 			payload: AttachInput,
 			success: Schema.Unknown,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
 		}),
 	)
 	// DELETE /research/:id — soft-delete

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -2,6 +2,9 @@ import { Cause } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
+	attachOutcome,
+	cancelOutcome,
+	clampPagination,
 	computeResearchCacheKey,
 	normalizeResearchQuery,
 	researchCacheTtlDaysFor,
@@ -214,6 +217,114 @@ describe('shouldMarkRunFailed', () => {
 	})
 })
 
+describe('clampPagination', () => {
+	describe('when no limit or offset is given', () => {
+		it('should fall back to the default page size and a zero offset', () => {
+			// GIVEN no pagination filters
+			// WHEN clamping
+			const { limit, offset } = clampPagination(undefined, undefined)
+
+			// THEN the prior query defaults stand
+			expect(limit).toBe(20)
+			expect(offset).toBe(0)
+		})
+	})
+
+	describe('when the limit is below the floor', () => {
+		it('should raise a negative or zero limit to 1 so SQL never sees LIMIT < 1', () => {
+			// GIVEN limits Postgres would reject as `LIMIT -1` / `LIMIT 0`
+			// THEN they are floored at the minimum of 1
+			expect(clampPagination(-1, 0).limit).toBe(1)
+			expect(clampPagination(0, 0).limit).toBe(1)
+		})
+	})
+
+	describe('when the limit is above the ceiling', () => {
+		it('should cap an oversized limit at 100 so one call cannot pull the whole table', () => {
+			// GIVEN an absurdly large limit
+			// THEN it is capped at the page-size ceiling
+			expect(clampPagination(10_000_000, 0).limit).toBe(100)
+		})
+	})
+
+	describe('when the limit is within range', () => {
+		it('should pass a sensible page size through unchanged', () => {
+			// GIVEN a limit inside [1, 100]
+			// THEN it is preserved
+			expect(clampPagination(50, 0).limit).toBe(50)
+		})
+	})
+
+	describe('when the offset is negative', () => {
+		it('should floor it at 0, since a negative OFFSET is meaningless', () => {
+			// GIVEN a negative offset
+			// THEN it is floored to 0
+			expect(clampPagination(20, -5).offset).toBe(0)
+		})
+	})
+
+	describe('when the offset is a valid position', () => {
+		it('should pass it through unchanged', () => {
+			// GIVEN a non-negative offset
+			// THEN it is preserved
+			expect(clampPagination(20, 40).offset).toBe(40)
+		})
+	})
+})
+
+describe('cancelOutcome', () => {
+	describe('when a queued/running row flipped to cancelled', () => {
+		it('should report a real cancellation', () => {
+			// GIVEN the UPDATE … RETURNING matched a row
+			// THEN the run was genuinely cancelled
+			expect(cancelOutcome(true, true)).toBe('cancelled')
+		})
+	})
+
+	describe('when nothing flipped but the run exists', () => {
+		it('should report it as already in a terminal state', () => {
+			// GIVEN no row flipped, but the run is present (already finished)
+			// THEN cancelling is a no-op on a terminal run
+			expect(cancelOutcome(false, true)).toBe('already_terminal')
+		})
+	})
+
+	describe('when nothing flipped and the run is absent', () => {
+		it('should report not_found instead of a false success', () => {
+			// GIVEN no row flipped and no run with that id
+			// THEN the caller learns it does not exist (the F7 bug)
+			expect(cancelOutcome(false, false)).toBe('not_found')
+		})
+	})
+})
+
+describe('attachOutcome', () => {
+	describe('when the subject does not exist', () => {
+		it('should refuse at the subject, preventing an orphan link', () => {
+			// GIVEN no company/contact with that id (the F3 bug)
+			// THEN the attach is rejected before the run is even considered
+			expect(attachOutcome(false, false)).toBe('subject_not_found')
+			expect(attachOutcome(false, true)).toBe('subject_not_found')
+		})
+	})
+
+	describe('when the subject exists but the run does not', () => {
+		it('should report the run as not found', () => {
+			// GIVEN a real subject but no such run
+			// THEN the attach is rejected at the run
+			expect(attachOutcome(true, false)).toBe('run_not_found')
+		})
+	})
+
+	describe('when both the subject and run exist', () => {
+		it('should attach the link', () => {
+			// GIVEN both rows present
+			// THEN the link may be written
+			expect(attachOutcome(true, true)).toBe('attached')
+		})
+	})
+})
+
 // ── Fiber-level behaviors (integration) ──
 // These exercise runFiber against stub providers + real Postgres. They require
 // `pnpm cli services up`, the 0001 migration applied, and the three tier-LLM
@@ -231,5 +342,20 @@ describe('research fiber (integration)', () => {
 	)
 	it.todo(
 		'should short-circuit identical create() calls via research_cache (kind=cache_hit, cost_cents=0)',
+	)
+})
+
+// ── Lifecycle guards (integration) ──
+// Exercise the not-found / existence checks against real Postgres. Scaffolded
+// so the BDD intent stays visible — wire fixtures in the integration harness.
+describe('research lifecycle (integration)', () => {
+	it.todo(
+		'should report outcome=not_found when cancelling a run id with no queued/running row',
+	)
+	it.todo(
+		'should report outcome=already_terminal when cancelling a run that already finished',
+	)
+	it.todo(
+		'should refuse to attach a run to a company or contact that does not exist, writing no research_links row',
 	)
 })

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -68,6 +68,43 @@ export const schemaVersionFor = (schemaName: string): number => {
 	return match ? Number(match[1]) : 1
 }
 
+// Clamp list pagination so out-of-range input can't reach SQL: a negative limit
+// makes Postgres reject `LIMIT -1`, an unbounded one would pull the whole table,
+// and a negative offset is meaningless. Defaults match the prior query.
+export const clampPagination = (
+	limit: number | undefined,
+	offset: number | undefined,
+): { readonly limit: number; readonly offset: number } => {
+	// `Schema.Number` also admits NaN/Infinity/floats, which would reach SQL as
+	// `LIMIT NaN` / `LIMIT 2.5`; coerce to a finite integer (or the default) first.
+	const toInt = (n: number | undefined, fallback: number): number =>
+		n !== undefined && Number.isFinite(n) ? Math.trunc(n) : fallback
+	return {
+		limit: Math.min(Math.max(toInt(limit, 20), 1), 100),
+		offset: Math.max(toInt(offset, 0), 0),
+	}
+}
+
+// Outcome of a cancel attempt, decided from whether a queued/running row
+// actually flipped to cancelled and whether the run exists at all.
+export const cancelOutcome = (
+	flipped: boolean,
+	exists: boolean,
+): 'cancelled' | 'already_terminal' | 'not_found' =>
+	flipped ? 'cancelled' : exists ? 'already_terminal' : 'not_found'
+
+// Outcome of an attach attempt: the subject must exist before the run, and both
+// before the link is written.
+export const attachOutcome = (
+	subjectExists: boolean,
+	runExists: boolean,
+): 'subject_not_found' | 'run_not_found' | 'attached' =>
+	!subjectExists
+		? 'subject_not_found'
+		: !runExists
+			? 'run_not_found'
+			: 'attached'
+
 /**
  * Research-run cache TTL policy. Structured schemas are stable (the schema
  * itself is the invalidation knob via `schemaVersion`); freeform briefs stay
@@ -944,6 +981,12 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							)`)
 						}
 
+						// Clamp pagination before it reaches SQL (see clampPagination).
+						const { limit, offset } = clampPagination(
+							filters.limit,
+							filters.offset,
+						)
+
 						return yield* sql`
 							SELECT r.id, r.kind, r.query, r.mode, r.schema_name,
 								r.status, r.cost_cents, r.paid_cost_cents,
@@ -951,8 +994,8 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							FROM research_runs r
 							WHERE ${sql.and(conditions)}
 							ORDER BY r.created_at DESC
-							LIMIT ${filters.limit ?? 20}
-							OFFSET ${filters.offset ?? 0}
+							LIMIT ${limit}
+							OFFSET ${offset}
 						`
 					}),
 
@@ -1028,12 +1071,28 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						if (maybeFiber._tag === 'Some') {
 							yield* Fiber.interrupt(maybeFiber.value)
 						}
-						yield* sql`
+						// RETURNING tells us whether a queued/running row actually
+						// flipped, so the caller can tell a real cancel apart from a
+						// no-op on a missing or already-finished run.
+						const [cancelled] = yield* sql<{ id: string }>`
 							UPDATE research_runs
 							SET status = 'cancelled', completed_at = now(), updated_at = now()
 							WHERE id = ${researchId} AND status IN ('queued', 'running')
+							RETURNING id
 						`
-						yield* publishEvent(researchId, 'run.cancelled', {})
+						const flipped = cancelled !== undefined
+						if (flipped) {
+							yield* publishEvent(researchId, 'run.cancelled', {})
+							return { outcome: cancelOutcome(true, true) }
+						}
+						// Nothing flipped: tell an already-finished run apart from one
+						// that doesn't exist at all.
+						const [existing] = yield* sql<{ id: string }>`
+							SELECT id FROM research_runs
+							WHERE id = ${researchId} AND status != 'deleted'
+							LIMIT 1
+						`
+						return { outcome: cancelOutcome(false, existing !== undefined) }
 					}),
 
 				/** Soft-delete a research run. */
@@ -1048,14 +1107,52 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 				attach: (
 					organizationId: string,
 					researchId: string,
-					subjectTable: string,
+					subjectTable: 'companies' | 'contacts',
 					subjectId: string,
 				) =>
-					sql`
-						INSERT INTO research_links (organization_id, research_id, subject_table, subject_id, link_kind)
-						VALUES (${organizationId}, ${researchId}, ${subjectTable}, ${subjectId}, 'finding')
-						ON CONFLICT DO NOTHING
-					`,
+					Effect.gen(function* () {
+						// Guard against orphan links: the subject row must exist and
+						// belong to this org before we record the link. Branch on the
+						// (enum-constrained) table so its name is always a literal,
+						// never interpolated into the statement.
+						const subjectLookup =
+							subjectTable === 'companies'
+								? sql<{ id: string }>`
+									SELECT id FROM companies
+									WHERE id = ${subjectId}
+									  AND organization_id = ${organizationId}
+									  AND deleted_at IS NULL
+									LIMIT 1
+								`
+								: sql<{ id: string }>`
+									SELECT id FROM contacts
+									WHERE id = ${subjectId}
+									  AND organization_id = ${organizationId}
+									  AND deleted_at IS NULL
+									LIMIT 1
+								`
+						const [subject] = yield* subjectLookup
+						// Skip the run lookup when the subject is already missing.
+						if (!subject) return { outcome: attachOutcome(false, false) }
+
+						// The run must exist under this org as well.
+						const [run] = yield* sql<{ id: string }>`
+							SELECT id FROM research_runs
+							WHERE id = ${researchId}
+							  AND organization_id = ${organizationId}
+							  AND status != 'deleted'
+							LIMIT 1
+						`
+						const outcome = attachOutcome(true, run !== undefined)
+						if (outcome === 'attached') {
+							yield* sql`
+								INSERT INTO research_links (organization_id, research_id, subject_table, subject_id, link_kind)
+								VALUES (${organizationId}, ${researchId}, ${subjectTable}, ${subjectId}, 'finding')
+								ON CONFLICT DO NOTHING
+							`
+						}
+						return { outcome }
+					}),
 
 				/** Get user's research policy. */
 				getPolicy: (userId: string) =>

--- a/packages/research/src/application/schemas/index.ts
+++ b/packages/research/src/application/schemas/index.ts
@@ -1,4 +1,4 @@
-import type { Schema } from 'effect'
+import { Schema } from 'effect'
 
 import { CompanyEnrichmentV1Schema } from './company-enrichment-v1'
 import { CompetitorScanV1Schema } from './competitor-scan-v1'
@@ -18,6 +18,22 @@ export const schemaRegistry: Record<string, Schema.Top> = {
 }
 
 export type SchemaName = keyof typeof schemaRegistry
+
+// Runtime tuple of the registry's keys, so the API boundary can reject an
+// unknown schema_name up front instead of letting a doomed run be created.
+// Kept in sync with schemaRegistry above (a closed, rarely-changing set).
+export const schemaNames = [
+	'freeform',
+	'company_enrichment_v1',
+	'competitor_scan_v1',
+	'contact_discovery_v1',
+	'prospect_scan_v1',
+] as const
+
+// The same closed set as an Effect Schema, so HTTP/MCP boundaries can validate
+// schema_name with one import instead of re-deriving the literal union (which
+// widens to plain string when the tuple is read across a package boundary).
+export const SchemaNameSchema = Schema.Literals(schemaNames)
 
 export {
 	CompanyEnrichmentV1Schema,

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -53,6 +53,7 @@ export {
 	ContactDiscoveryV1Schema,
 	FreeformSchema,
 	ProspectScanV1Schema,
+	SchemaNameSchema,
 	schemaRegistry,
 } from './application/schemas/index'
 export { researchToolkit, researchToolkitLayer } from './application/tools'


### PR DESCRIPTION
## What

Hardens the research MCP tool surface against the input-validation, data-integrity, and error-handling bugs found while testing the live production deployment.

## Changes

- **Input validation** at the MCP parameter boundary: UUID-checked ids, `schema_name` restricted to the closed registry set, non-empty + length-capped query, and clamped pagination (finite-int, `[1,100]`). Malformed or oversized inputs are now rejected cleanly instead of reaching SQL (raw `SqlError` leak) or creating runs that only fail at phase 0.
- **Orphan-link prevention**: `attach` verifies the subject (company/contact) and the run exist under the org before writing a `research_links` row. Enforced in the service, so the MCP and HTTP callers both benefit.
- **Honest cancel**: `cancel` reports `not_found` / `already_terminal` instead of always returning `cancelled`.
- **Error redaction**: a transient `SqlError` collapses to a generic defect, so the Postgres driver error (statement, connection details) — and our own source path — no longer reach clients.

A small follow-up `ai:` commit registers the production batuda MCP server (env-var keyed) and unpins the Claude Code model.

## Verification

`check-types`, unit tests, and `build` all pass. New BDD coverage: validation schemas, pagination clamp, cancel/attach outcome logic, and the redaction security property. DB round-trips for attach/cancel remain `it.todo`, matching the repo's integration-test convention.

## Deferred

- **F1** intermittent 500 — originates in the shared `OrgMiddleware` (auth/org resolution), not research code; belongs with the crash-resilience backlog.
- **F9** Cloudflare WAF user-agent blocking — infrastructure/rule review, not code.
