### PR TITLE
feat: AI instruction templates — foundation (resolver + schema)

### DIFF
--- a/apps/server/src/db/migrations/0008_instruction_templates.ts
+++ b/apps/server/src/db/migrations/0008_instruction_templates.ts
@@ -1,0 +1,213 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// AI instruction templates: a surface-neutral library of named prompt blocks,
+// owned by the org (owner_user_id NULL) or a user, that any agent composes into
+// its system prompt — plus per-(scope, agent) default stacks, an ordered list
+// of templates resolved at run time.
+//
+// RLS is asymmetric by design. Reads are RLS-enforced: a member sees
+// org-owned templates + their own, never another member's personal ones. Writes
+// are constrained only to the org at the DB level — row ownership, the admin
+// gate on org-owned rows (Better-Auth member.role, which Postgres RLS can't
+// read), and ownership transfer are all enforced in the application service.
+// FORCE ROW LEVEL SECURITY applies the policies to the table owner too;
+// app_service (BYPASSRLS) bypasses them for worker/cron paths. New tables
+// inherit app_user/app_service DML grants via the ALTER DEFAULT PRIVILEGES set
+// in 0001, so no GRANT statements are needed here.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	// ── instruction_templates ──────────────────────────────────────────────
+	// `agent`-agnostic: a template is just text and can be stacked by any agent.
+	// `updated_at` feeds the resolution fingerprint; the service bumps it on
+	// every body edit so an edited template never serves a stale cached run.
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS instruction_templates (
+			id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			organization_id   text NOT NULL,
+			owner_user_id     text,
+			name              text NOT NULL,
+			body              text NOT NULL,
+			source_preset_id  text,
+			created_by        text NOT NULL,
+			created_at        timestamptz NOT NULL DEFAULT now(),
+			updated_at        timestamptz NOT NULL DEFAULT now()
+		)
+	`
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS instruction_templates_org_owner_idx
+			ON instruction_templates (organization_id, owner_user_id)
+	`
+	yield* sql`ALTER TABLE instruction_templates ENABLE ROW LEVEL SECURITY`
+	yield* sql`ALTER TABLE instruction_templates FORCE ROW LEVEL SECURITY`
+	// Read: org-owned + own only (a member never sees another member's personal
+	// templates).
+	yield* sql`
+		CREATE POLICY read_instruction_templates ON instruction_templates
+			FOR SELECT TO app_user
+			USING (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+	`
+	// Create: own or org-owned (the org-owned case is admin-gated in the app).
+	yield* sql`
+		CREATE POLICY insert_instruction_templates ON instruction_templates
+			FOR INSERT TO app_user
+			WITH CHECK (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+	`
+	// Update: may target own/org-owned rows; the new owner only has to stay in
+	// the org, so the app can transfer ownership (donate to org, hand to another
+	// member) — RLS can't model that since it can't read member.role.
+	yield* sql`
+		CREATE POLICY update_instruction_templates ON instruction_templates
+			FOR UPDATE TO app_user
+			USING (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+			WITH CHECK (organization_id = current_setting('app.current_org_id', true))
+	`
+	// Delete: own/org-owned only (FK RESTRICT below still blocks in-use ones).
+	yield* sql`
+		CREATE POLICY delete_instruction_templates ON instruction_templates
+			FOR DELETE TO app_user
+			USING (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+	`
+
+	// ── agent_default_stacks ────────────────────────────────────────────────
+	// One default stack per (org, agent) and per (org, user, agent). owner NULL =
+	// the org default; set = a user's own, which replaces the org default for
+	// them. Stacks are not transferable (only templates are), so writes can be
+	// owner-restricted on both sides.
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS agent_default_stacks (
+			id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			organization_id  text NOT NULL,
+			owner_user_id    text,
+			agent            text NOT NULL,
+			created_at       timestamptz NOT NULL DEFAULT now(),
+			updated_at       timestamptz NOT NULL DEFAULT now()
+		)
+	`
+	yield* sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS agent_default_stacks_org_default_uidx
+			ON agent_default_stacks (organization_id, agent)
+			WHERE owner_user_id IS NULL
+	`
+	yield* sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS agent_default_stacks_user_default_uidx
+			ON agent_default_stacks (organization_id, owner_user_id, agent)
+			WHERE owner_user_id IS NOT NULL
+	`
+	yield* sql`ALTER TABLE agent_default_stacks ENABLE ROW LEVEL SECURITY`
+	yield* sql`ALTER TABLE agent_default_stacks FORCE ROW LEVEL SECURITY`
+	yield* sql`
+		CREATE POLICY read_agent_default_stacks ON agent_default_stacks
+			FOR SELECT TO app_user
+			USING (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+	`
+	yield* sql`
+		CREATE POLICY insert_agent_default_stacks ON agent_default_stacks
+			FOR INSERT TO app_user
+			WITH CHECK (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+	`
+	yield* sql`
+		CREATE POLICY update_agent_default_stacks ON agent_default_stacks
+			FOR UPDATE TO app_user
+			USING (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+			WITH CHECK (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+	`
+	yield* sql`
+		CREATE POLICY delete_agent_default_stacks ON agent_default_stacks
+			FOR DELETE TO app_user
+			USING (
+				organization_id = current_setting('app.current_org_id', true)
+				AND (
+					owner_user_id IS NULL
+					OR owner_user_id = current_setting('app.current_user_id', true)
+				)
+			)
+	`
+
+	// ── agent_default_stack_items ──────────────────────────────────────────
+	// Ordered references inside a stack. A child table (not a jsonb array) so
+	// ordering stays clean and a template can't be deleted while any stack still
+	// references it (FK ON DELETE RESTRICT — reassign first). organization_id is
+	// denormalised for a plain org-isolation policy; the items are only orderings
+	// of opaque ids, so org-wide read is acceptable (the parent stack row and the
+	// template bodies stay protected by their own owner-restricted policies).
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS agent_default_stack_items (
+			id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			organization_id  text NOT NULL,
+			stack_id         uuid NOT NULL REFERENCES agent_default_stacks(id) ON DELETE CASCADE,
+			template_id      uuid NOT NULL REFERENCES instruction_templates(id) ON DELETE RESTRICT,
+			position         int NOT NULL
+		)
+	`
+	yield* sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS agent_default_stack_items_position_uidx
+			ON agent_default_stack_items (stack_id, position)
+	`
+	yield* sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS agent_default_stack_items_template_uidx
+			ON agent_default_stack_items (stack_id, template_id)
+	`
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS agent_default_stack_items_template_idx
+			ON agent_default_stack_items (template_id)
+	`
+	yield* sql`ALTER TABLE agent_default_stack_items ENABLE ROW LEVEL SECURITY`
+	yield* sql`ALTER TABLE agent_default_stack_items FORCE ROW LEVEL SECURITY`
+	yield* sql`
+		CREATE POLICY org_isolation_agent_default_stack_items ON agent_default_stack_items
+			FOR ALL TO app_user
+			USING (organization_id = current_setting('app.current_org_id', true))
+			WITH CHECK (organization_id = current_setting('app.current_org_id', true))
+	`
+})

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@batuda/instructions",
+	"version": "0.0.1",
+	"description": "Batuda — AI instruction templates (org + user library, per-agent default stacks, resolver, preset catalog)",
+	"type": "module",
+	"types": "./src/index.ts",
+	"main": "./src/index.ts",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"import": "./src/index.ts"
+		}
+	},
+	"scripts": {
+		"build": "tsdown",
+		"check-types": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"effect": "4.0.0-beta.43"
+	},
+	"devDependencies": {
+		"@types/node": "^22.15.0",
+		"tsdown": "^0.21.7",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.4"
+	},
+	"private": true
+}

--- a/packages/instructions/src/domain.ts
+++ b/packages/instructions/src/domain.ts
@@ -1,0 +1,45 @@
+import { Schema } from 'effect'
+
+// The code-defined set of AI agents that compose instruction templates into
+// their prompt. Research today; email/chat/outreach later. Kept as a string
+// set (not a DB enum) so adding an agent is a code change, never a migration —
+// the same convention research uses for its schema_name registry.
+export const agents = ['research'] as const
+
+export type Agent = (typeof agents)[number]
+
+// The same closed set as an Effect Schema, so HTTP/MCP boundaries can validate
+// an `agent` param with one import instead of re-deriving the literal union.
+export const AgentSchema = Schema.Literals(agents)
+
+// A named, reusable block of instruction text, owned by the org
+// (`ownerUserId` null) or a user. Just text — no baked schema or hints — so the
+// same template can shape any agent that stacks it.
+export interface InstructionTemplate {
+	readonly id: string
+	readonly organizationId: string
+	readonly ownerUserId: string | null
+	readonly name: string
+	readonly body: string
+	readonly sourcePresetId: string | null
+	readonly createdBy: string
+	readonly updatedAt: string
+}
+
+// A per-(scope, agent) ordered default stack. `ownerUserId` null = the org
+// default (admin-managed); set = a user's own, which replaces the org default
+// for that user.
+export interface AgentDefaultStack {
+	readonly id: string
+	readonly organizationId: string
+	readonly ownerUserId: string | null
+	readonly agent: Agent
+}
+
+// One ordered reference inside a stack. `position` is the add-order; the
+// resolver reads a stack's items by ascending position.
+export interface StackItem {
+	readonly stackId: string
+	readonly templateId: string
+	readonly position: number
+}

--- a/packages/instructions/src/fingerprint.test.ts
+++ b/packages/instructions/src/fingerprint.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { fingerprintTemplates } from './fingerprint'
+
+describe('fingerprintTemplates', () => {
+	describe('when the same templates resolve in the same order', () => {
+		it('should produce a stable fingerprint so an unchanged stack keeps hitting the cache', () => {
+			// GIVEN two identical ordered resolutions [fingerprint.ts:13]
+			const a = fingerprintTemplates([
+				{ id: 't1', updatedAt: '100' },
+				{ id: 't2', updatedAt: '200' },
+			])
+			const b = fingerprintTemplates([
+				{ id: 't1', updatedAt: '100' },
+				{ id: 't2', updatedAt: '200' },
+			])
+			// THEN they fingerprint identically
+			expect(a).toBe(b)
+		})
+	})
+
+	describe('when a template is edited', () => {
+		it('should change the fingerprint so the edited template never serves a stale run', () => {
+			// GIVEN the same template id with a bumped updated_at [fingerprint.ts:13]
+			const before = fingerprintTemplates([{ id: 't1', updatedAt: '100' }])
+			const after = fingerprintTemplates([{ id: 't1', updatedAt: '101' }])
+			// THEN the fingerprint changes
+			expect(after).not.toBe(before)
+		})
+	})
+
+	describe('when the stack is reordered', () => {
+		it('should change the fingerprint because order changes the assembled prompt', () => {
+			// GIVEN the same two templates in opposite orders [fingerprint.ts:13]
+			const ab = fingerprintTemplates([
+				{ id: 't1', updatedAt: '100' },
+				{ id: 't2', updatedAt: '200' },
+			])
+			const ba = fingerprintTemplates([
+				{ id: 't2', updatedAt: '200' },
+				{ id: 't1', updatedAt: '100' },
+			])
+			// THEN order is significant
+			expect(ab).not.toBe(ba)
+		})
+	})
+
+	describe('when membership changes', () => {
+		it('should change the fingerprint when a template is added to the stack', () => {
+			// GIVEN one template, then the same plus a second [fingerprint.ts:13]
+			const one = fingerprintTemplates([{ id: 't1', updatedAt: '100' }])
+			const two = fingerprintTemplates([
+				{ id: 't1', updatedAt: '100' },
+				{ id: 't2', updatedAt: '200' },
+			])
+			// THEN the fingerprint changes
+			expect(two).not.toBe(one)
+		})
+	})
+
+	describe('when no templates resolve', () => {
+		it('should return a fixed sha-256 that re-warms existing keys exactly once', () => {
+			// GIVEN the empty resolution [fingerprint.ts:13]
+			const empty1 = fingerprintTemplates([])
+			const empty2 = fingerprintTemplates([])
+			// THEN it is a stable 64-hex-char digest — folding it into the cache key
+			// is a single one-time change, not per-run churn
+			expect(empty1).toBe(empty2)
+			expect(empty1).toMatch(/^[0-9a-f]{64}$/)
+		})
+	})
+
+	describe('when ids or timestamps would concatenate ambiguously', () => {
+		it('should keep distinct resolutions distinct across the field delimiters', () => {
+			// GIVEN two resolutions whose naive concatenation would collide but whose
+			// delimited encoding does not [fingerprint.ts:13]
+			const a = fingerprintTemplates([
+				{ id: 't1', updatedAt: '1' },
+				{ id: 't2', updatedAt: '2' },
+			])
+			const b = fingerprintTemplates([
+				{ id: 't1', updatedAt: '1@t2' },
+				{ id: '', updatedAt: '2' },
+			])
+			// THEN they fingerprint differently
+			expect(a).not.toBe(b)
+		})
+	})
+})

--- a/packages/instructions/src/fingerprint.ts
+++ b/packages/instructions/src/fingerprint.ts
@@ -1,0 +1,17 @@
+import { createHash } from 'node:crypto'
+
+// A stable content fingerprint of the ordered templates that shaped a prompt,
+// keyed on each template's id + last-updated time in resolution order. Editing
+// a template's body (which bumps its `updated_at`), swapping the stack, or
+// reordering it all change the fingerprint — and therefore the research cache
+// key — so an edited template never serves a stale cached run, while an
+// unchanged stack keeps hitting the cache.
+//
+// The empty case (no templates resolved) hashes to a fixed value; folding that
+// into existing cache keys re-warms them exactly once, then they stabilise.
+export const fingerprintTemplates = (
+	templates: ReadonlyArray<{ readonly id: string; readonly updatedAt: string }>,
+): string => {
+	const canonical = templates.map(t => `${t.id}@${t.updatedAt}`).join('|')
+	return createHash('sha256').update(canonical).digest('hex')
+}

--- a/packages/instructions/src/index.ts
+++ b/packages/instructions/src/index.ts
@@ -1,0 +1,26 @@
+// AI instruction templates — a surface-neutral library of named prompt blocks
+// (org + user owned) and per-agent default stacks. An agent resolves an ordered
+// stack into prompt segments + a cache fingerprint at run time. The tables' DDL
+// lives with the app's migrations, not here; this package owns the logic.
+
+export type {
+	Agent,
+	AgentDefaultStack,
+	InstructionTemplate,
+	StackItem,
+} from './domain'
+export { AgentSchema, agents } from './domain'
+export { fingerprintTemplates } from './fingerprint'
+export type { InstructionPreset } from './presets'
+export { instructionPresets, presetById, presetsForAgent } from './presets'
+export type {
+	ResolvedInstructions,
+	ResolveInstructionsArgs,
+	StackSource,
+} from './resolver'
+export {
+	assembleSegments,
+	personalTemplatesInOrgStack,
+	pickStackSource,
+	resolveInstructions,
+} from './resolver'

--- a/packages/instructions/src/presets.test.ts
+++ b/packages/instructions/src/presets.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { agents } from './domain'
+import { instructionPresets, presetById, presetsForAgent } from './presets'
+
+describe('instructionPresets', () => {
+	describe('when the catalog is loaded', () => {
+		it('should have unique preset ids', () => {
+			// GIVEN every preset id [presets.ts:16]
+			const ids = instructionPresets.map(p => p.id)
+			// THEN none collide (an import records source_preset_id by it)
+			expect(new Set(ids).size).toBe(ids.length)
+		})
+
+		it('should give every preset a non-empty name and body', () => {
+			// GIVEN each catalog entry [presets.ts:16]
+			for (const preset of instructionPresets) {
+				// THEN it carries real, importable text
+				expect(preset.name.trim().length).toBeGreaterThan(0)
+				expect(preset.body.trim().length).toBeGreaterThan(0)
+			}
+		})
+
+		it('should only reference known agents', () => {
+			// GIVEN each catalog entry [presets.ts:16]
+			for (const preset of instructionPresets) {
+				// THEN its agent is in the code-defined set
+				expect([...agents]).toContain(preset.agent)
+			}
+		})
+	})
+})
+
+describe('presetById', () => {
+	describe('when the id exists', () => {
+		it('should round-trip the catalog entry', () => {
+			// GIVEN the first catalog entry [presets.ts:54]
+			const first = instructionPresets[0]
+			expect(first).toBeDefined()
+			// THEN looking it up by id returns the same entry
+			if (first) expect(presetById(first.id)).toEqual(first)
+		})
+	})
+
+	describe('when the id is unknown', () => {
+		it('should return undefined', () => {
+			// GIVEN an id no preset uses [presets.ts:54]
+			// THEN the lookup misses cleanly
+			expect(presetById('does-not-exist')).toBeUndefined()
+		})
+	})
+})
+
+describe('presetsForAgent', () => {
+	describe('when an agent has presets', () => {
+		it('should return only presets for the requested agent', () => {
+			// GIVEN the research agent [presets.ts:57]
+			const research = presetsForAgent('research')
+			// THEN every returned preset targets research, and there is at least one
+			expect(research.length).toBeGreaterThan(0)
+			expect(research.every(p => p.agent === 'research')).toBe(true)
+		})
+	})
+})

--- a/packages/instructions/src/presets.ts
+++ b/packages/instructions/src/presets.ts
@@ -1,0 +1,56 @@
+import type { Agent } from './domain'
+
+// A Batuda-authored instruction template the user can import into their org or
+// personal library. Importing copies the body into an `instruction_templates`
+// row (recording `source_preset_id`); the catalog itself is code — versioned
+// with the app, never user-edited — and can seed an org default stack.
+export interface InstructionPreset {
+	readonly id: string
+	readonly name: string
+	readonly agent: Agent
+	readonly body: string
+}
+
+export const instructionPresets: ReadonlyArray<InstructionPreset> = [
+	{
+		id: 'research-icp-qualification',
+		name: '[research] ICP qualification',
+		agent: 'research',
+		body: [
+			'When researching a company, always assess fit against the ideal customer profile:',
+			"- Note the company's size, sector, and apparent buying stage.",
+			'- Call out concrete signals of need for the offering, and any disqualifiers.',
+			'- End with a one-line verdict — strong fit, possible fit, or poor fit — and the single most important reason.',
+		].join('\n'),
+	},
+	{
+		id: 'research-spain-market',
+		name: '[research] Spain market sourcing',
+		agent: 'research',
+		body: [
+			'Prioritise primary Spanish-language sources for companies based in Spain:',
+			"- Prefer official registries, the company's own site, and reputable local press over aggregators.",
+			'- Capture the legal name and any trading names, plus the province or city.',
+			'- Keep figures in their original currency and note the date they refer to.',
+		].join('\n'),
+	},
+	{
+		id: 'research-concise-brief',
+		name: '[research] Concise brief',
+		agent: 'research',
+		body: [
+			'Write the brief to be skimmed in under a minute:',
+			'- Lead with the conclusion, then the few facts that support it.',
+			'- Use short sentences and plain words; avoid filler and hedging.',
+			'- Omit anything you could not verify from a source.',
+		].join('\n'),
+	},
+]
+
+export const presetById = (id: string): InstructionPreset | undefined =>
+	instructionPresets.find(preset => preset.id === id)
+
+export const presetsForAgent = (
+	agent: Agent,
+): ReadonlyArray<InstructionPreset> =>
+	instructionPresets.filter(preset => preset.agent === agent)

--- a/packages/instructions/src/resolver.test.ts
+++ b/packages/instructions/src/resolver.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	assembleSegments,
+	personalTemplatesInOrgStack,
+	pickStackSource,
+} from './resolver'
+
+describe('pickStackSource', () => {
+	describe('when a per-run override is present', () => {
+		it('should choose the override even when both defaults exist', () => {
+			// GIVEN an override alongside a user and an org stack [resolver.ts:16]
+			const source = pickStackSource({
+				hasOverride: true,
+				hasUserStack: true,
+				hasOrgStack: true,
+			})
+			// THEN the override wins
+			expect(source).toBe('override')
+		})
+	})
+
+	describe('when there is no override but the user has their own stack', () => {
+		it('should choose the user stack over the org default', () => {
+			// GIVEN a user stack and an org default [resolver.ts:16]
+			const source = pickStackSource({
+				hasOverride: false,
+				hasUserStack: true,
+				hasOrgStack: true,
+			})
+			// THEN the user's own default replaces the org default
+			expect(source).toBe('user')
+		})
+	})
+
+	describe('when only the org default exists', () => {
+		it('should fall back to the org stack', () => {
+			// GIVEN only an org default [resolver.ts:16]
+			const source = pickStackSource({
+				hasOverride: false,
+				hasUserStack: false,
+				hasOrgStack: true,
+			})
+			// THEN the org stack is used
+			expect(source).toBe('org')
+		})
+	})
+
+	describe('when nothing applies', () => {
+		it('should resolve to none so the run uses only the built-in prompt', () => {
+			// GIVEN no override, no user stack, no org stack [resolver.ts:16]
+			const source = pickStackSource({
+				hasOverride: false,
+				hasUserStack: false,
+				hasOrgStack: false,
+			})
+			// THEN nothing is layered in
+			expect(source).toBe('none')
+		})
+	})
+})
+
+describe('assembleSegments', () => {
+	describe('when templates carry content', () => {
+		it('should keep one trimmed segment per template in stack order', () => {
+			// GIVEN two non-empty bodies with surrounding whitespace [resolver.ts:33]
+			const segments = assembleSegments([
+				{ body: '  sell to hotels  ' },
+				{ body: 'be terse' },
+			])
+			// THEN they become trimmed, ordered segments
+			expect(segments).toEqual(['sell to hotels', 'be terse'])
+		})
+	})
+
+	describe('when a body is blank or whitespace-only', () => {
+		it('should drop it so no empty segment reaches the prompt', () => {
+			// GIVEN a mix of real and blank bodies [resolver.ts:33]
+			const segments = assembleSegments([
+				{ body: 'keep' },
+				{ body: '   ' },
+				{ body: '' },
+			])
+			// THEN only the real one survives
+			expect(segments).toEqual(['keep'])
+		})
+	})
+
+	describe('when there are no templates', () => {
+		it('should return an empty list', () => {
+			// GIVEN no templates [resolver.ts:33]
+			// THEN there are no segments
+			expect(assembleSegments([])).toEqual([])
+		})
+	})
+})
+
+describe('personalTemplatesInOrgStack', () => {
+	describe('when an org stack references only org-owned templates', () => {
+		it('should report no offenders', () => {
+			// GIVEN an org stack of org-owned templates [resolver.ts:46]
+			const offenders = personalTemplatesInOrgStack([
+				{ templateId: 'a', ownerUserId: null },
+				{ templateId: 'b', ownerUserId: null },
+			])
+			// THEN the stack is valid
+			expect(offenders).toEqual([])
+		})
+	})
+
+	describe('when an org stack references personal templates', () => {
+		it('should flag the personal ids RLS would silently hide from other members', () => {
+			// GIVEN an org stack mixing an org template with two members' personal
+			// templates [resolver.ts:46]
+			const offenders = personalTemplatesInOrgStack([
+				{ templateId: 'org-1', ownerUserId: null },
+				{ templateId: 'mine', ownerUserId: 'user_42' },
+				{ templateId: 'theirs', ownerUserId: 'user_99' },
+			])
+			// THEN both personal templates are flagged, so the write is rejected
+			expect(offenders).toEqual(['mine', 'theirs'])
+		})
+	})
+
+	describe('when the stack is empty', () => {
+		it('should report no offenders', () => {
+			// GIVEN an empty org stack [resolver.ts:46]
+			// THEN there is nothing to reject
+			expect(personalTemplatesInOrgStack([])).toEqual([])
+		})
+	})
+})

--- a/packages/instructions/src/resolver.ts
+++ b/packages/instructions/src/resolver.ts
@@ -1,0 +1,164 @@
+import { Effect } from 'effect'
+import type { SqlError } from 'effect/unstable/sql'
+import { SqlClient } from 'effect/unstable/sql'
+
+import type { Agent } from './domain'
+import { fingerprintTemplates } from './fingerprint'
+
+// ── Pure resolution helpers (unit-tested) ─────────────────────────────────
+
+// The stack that applies to a run, in precedence order:
+//   per-run override  >  the user's own default stack  >  the org default
+// A user's own default replaces the org's (no merge); an explicit per-run pick
+// replaces both. `none` means no templates applied — the run uses only the
+// surface's own built-in prompt.
+export type StackSource = 'override' | 'user' | 'org' | 'none'
+
+export const pickStackSource = (args: {
+	readonly hasOverride: boolean
+	readonly hasUserStack: boolean
+	readonly hasOrgStack: boolean
+}): StackSource =>
+	args.hasOverride
+		? 'override'
+		: args.hasUserStack
+			? 'user'
+			: args.hasOrgStack
+				? 'org'
+				: 'none'
+
+// Turn the resolved templates into ordered prompt segments — one trimmed
+// segment per template body, in stack order. Blank bodies are dropped so an
+// empty template can't emit a dangling segment downstream.
+export const assembleSegments = (
+	templates: ReadonlyArray<{ readonly body: string }>,
+): ReadonlyArray<string> =>
+	templates.map(t => t.body.trim()).filter(body => body.length > 0)
+
+// An org default stack (owner null) may reference only org-owned templates. A
+// personal template inside an org stack is hidden by RLS from other members and
+// would be silently dropped from their resolved prompt, so it must be rejected
+// when the stack is written. Returns the offending (personal) template ids.
+export const personalTemplatesInOrgStack = (
+	items: ReadonlyArray<{
+		readonly templateId: string
+		readonly ownerUserId: string | null
+	}>,
+): ReadonlyArray<string> =>
+	items.filter(item => item.ownerUserId !== null).map(item => item.templateId)
+
+// ── DB resolution (exercised end-to-end when research is wired) ────────────
+
+export interface ResolveInstructionsArgs {
+	readonly organizationId: string
+	readonly userId: string
+	readonly agent: Agent
+	readonly overrideTemplateIds?: ReadonlyArray<string> | undefined
+}
+
+export interface ResolvedInstructions {
+	readonly segments: ReadonlyArray<string>
+	readonly fingerprint: string
+	readonly templateIds: ReadonlyArray<string>
+	readonly source: StackSource
+}
+
+interface StackRow {
+	readonly id: string
+	readonly owner_user_id: string | null
+}
+
+interface TemplateRow {
+	readonly id: string
+	readonly body: string
+	readonly updated_at: string
+}
+
+const readStackTemplateIds = (
+	sql: SqlClient.SqlClient,
+	stackId: string,
+): Effect.Effect<ReadonlyArray<string>, SqlError.SqlError> =>
+	Effect.map(
+		sql<{ template_id: string }>`
+			SELECT template_id
+			FROM agent_default_stack_items
+			WHERE stack_id = ${stackId}
+			ORDER BY position ASC
+		`,
+		rows => rows.map(row => row.template_id),
+	)
+
+// Resolve the effective instruction prompt for one agent run. Must run inside
+// the request transaction: it reads through RLS, so the org/user GUCs have to
+// be set. (Research's run fiber is forked outside the tx — which is exactly why
+// resolution happens here and the result is threaded in.)
+export const resolveInstructions = (
+	args: ResolveInstructionsArgs,
+): Effect.Effect<
+	ResolvedInstructions,
+	SqlError.SqlError,
+	SqlClient.SqlClient
+> =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const override = args.overrideTemplateIds ?? []
+
+		// Candidate default stacks visible to this actor: their own + the org's.
+		// Skipped entirely when a per-run override is given.
+		const stacks = yield* override.length > 0
+			? Effect.succeed<ReadonlyArray<StackRow>>([])
+			: sql<StackRow>`
+					SELECT id, owner_user_id
+					FROM agent_default_stacks
+					WHERE organization_id = ${args.organizationId}
+						AND agent = ${args.agent}
+						AND (owner_user_id = ${args.userId} OR owner_user_id IS NULL)
+				`
+		const userStack = stacks.find(s => s.owner_user_id === args.userId)
+		const orgStack = stacks.find(s => s.owner_user_id === null)
+
+		const source = pickStackSource({
+			hasOverride: override.length > 0,
+			hasUserStack: userStack !== undefined,
+			hasOrgStack: orgStack !== undefined,
+		})
+		const chosenStack =
+			source === 'user' ? userStack : source === 'org' ? orgStack : undefined
+
+		const orderedIds = yield* source === 'override'
+			? Effect.succeed<ReadonlyArray<string>>(override)
+			: chosenStack
+				? readStackTemplateIds(sql, chosenStack.id)
+				: Effect.succeed<ReadonlyArray<string>>([])
+
+		if (orderedIds.length === 0) {
+			return {
+				segments: [],
+				fingerprint: fingerprintTemplates([]),
+				templateIds: [],
+				source,
+			}
+		}
+
+		// RLS silently drops any id the actor can't read (e.g. another member's
+		// personal template named in a per-run override) — they never reach the
+		// prompt and never enter the fingerprint.
+		const rows = yield* sql<TemplateRow>`
+			SELECT id, body, EXTRACT(EPOCH FROM updated_at)::text AS updated_at
+			FROM instruction_templates
+			WHERE id IN ${sql.in([...orderedIds])}
+		`
+		const byId = new Map(rows.map(row => [row.id, row]))
+		const ordered = orderedIds
+			.map(id => byId.get(id))
+			.filter((row): row is TemplateRow => row !== undefined)
+
+		return {
+			segments: assembleSegments(ordered),
+			fingerprint: fingerprintTemplates(
+				ordered.map(row => ({ id: row.id, updatedAt: row.updated_at })),
+			),
+			templateIds: ordered.map(row => row.id),
+			source,
+		}
+	})

--- a/packages/instructions/tsconfig.json
+++ b/packages/instructions/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/instructions/vitest.config.ts
+++ b/packages/instructions/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		include: ['src/**/*.test.ts'],
+		environment: 'node',
+		globals: false,
+		testTimeout: 30_000,
+	},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,6 +596,25 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@22.19.15)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/instructions:
+    dependencies:
+      effect:
+        specifier: 4.0.0-beta.43
+        version: 4.0.0-beta.43
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.15
+      tsdown:
+        specifier: ^0.21.7
+        version: 0.21.7(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.15)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/research:
     dependencies:
       '@effect/ai-openai-compat':


### PR DESCRIPTION
## What

Slice 1 of the AI instruction-templates feature: a surface-neutral library of named instruction templates (org- or user-owned) plus per-agent ordered "default stacks", with the resolver and database schema. Nothing consumes it yet — that's slice 2 (wire research).

## Changes

- **`packages/instructions`** (new, depends only on `effect`): resolver, fingerprint, preset catalog, domain types. Resolves a run's effective stack — per-run override, else the user's own default, else the org's — into ordered prompt segments plus a cache fingerprint that changes when a template is edited, swapped, or reordered.
- **Migration `0008`**: `instruction_templates`, `agent_default_stacks`, `agent_default_stack_items`. Asymmetric RLS — reads are owner-restricted (a member sees org-owned + their own, never another member's personal templates); writes only have to stay in-org so the service owns ownership, the admin gate, and transfers (Postgres RLS can't read `member.role`). `ON DELETE RESTRICT` blocks deleting a template that any stack still references.

## Verification

- `check-types`, **22 unit tests** (resolution precedence, fingerprint behaviour, org-stack rejects personal templates), and `build` pass.
- The migration was applied by the real migrator to an ephemeral copy of the production DB and inspected: RLS enabled + forced on all three tables, per-command policies present, the asymmetric update policy confirmed, FK delete actions and partial unique indexes correct.

## Not in this PR (next slices)

- Slice 2 — wire research: app-layer resolution as the attributed user, thread `{ segments, fingerprint }` into `create()`, build the Effect `Prompt`, fold in `research_cache` org-isolation.
- Slice 3 — management API (CRUD / defaults / transfer / presets + the admin gate).
- Slice 4 — UI.
