### PR TITLE
feat: wire instruction templates into research + cache org-isolation

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,7 @@
 		"@batuda/controllers": "workspace:*",
 		"@batuda/domain": "workspace:*",
 		"@batuda/email": "workspace:*",
+		"@batuda/instructions": "workspace:*",
 		"@batuda/research": "workspace:*",
 		"@batuda/ui": "workspace:*",
 		"@types/mailparser": "^3.4.6",

--- a/apps/server/src/db/migrations/0009_research_cache_org_isolation.ts
+++ b/apps/server/src/db/migrations/0009_research_cache_org_isolation.ts
@@ -1,0 +1,36 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// research_cache had no organization_id and used key_hash as its sole primary
+// key, so two organizations whose runs hashed to the same key collided — the
+// second write overwrote the first row, and a cross-org cache hit could surface
+// another organization's result. Scope the cache per organization: add
+// organization_id, key on (organization_id, key_hash), and apply the same
+// org-isolation RLS as research_runs — request-scope reads (app_user) are
+// filtered by the org GUC, while privileged writes set organization_id
+// explicitly. Existing rows carry no org, so they're truncated; research_cache
+// is a pure cache and re-warms on the next miss.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`TRUNCATE research_cache`
+	yield* sql`ALTER TABLE research_cache ADD COLUMN organization_id text NOT NULL`
+	yield* sql`ALTER TABLE research_cache DROP CONSTRAINT research_cache_pkey`
+	yield* sql`ALTER TABLE research_cache ADD PRIMARY KEY (organization_id, key_hash)`
+
+	yield* sql`DROP INDEX IF EXISTS research_cache_user_expires_idx`
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS research_cache_org_user_expires_idx
+			ON research_cache (organization_id, user_id, expires_at)
+	`
+
+	yield* sql`ALTER TABLE research_cache ENABLE ROW LEVEL SECURITY`
+	yield* sql`ALTER TABLE research_cache FORCE ROW LEVEL SECURITY`
+	yield* sql`
+		CREATE POLICY org_isolation_research_cache ON research_cache
+			TO app_user
+			USING (organization_id = current_setting('app.current_org_id', true))
+			WITH CHECK (organization_id = current_setting('app.current_org_id', true))
+	`
+})

--- a/apps/server/src/handlers/research.ts
+++ b/apps/server/src/handlers/research.ts
@@ -7,6 +7,7 @@ import {
 	NotFound,
 	SessionContext,
 } from '@batuda/controllers'
+import { resolveInstructions } from '@batuda/instructions'
 import {
 	type CreateResearchInput,
 	ResearchService,
@@ -46,11 +47,18 @@ export const ResearchLive = HttpApiBuilder.group(
 							autoApprovePaidCents: _.payload.auto_approve_paid_cents,
 							confirm: _.payload.confirm,
 						}
+						const instructions = yield* resolveInstructions({
+							organizationId: currentOrg.id,
+							userId,
+							agent: 'research',
+							overrideTemplateIds: _.payload.template_ids,
+						})
 						return yield* svc.create(
 							userId,
 							currentOrg.id,
 							input,
 							systemDefaults,
+							instructions,
 						)
 					}).pipe(Effect.orDie),
 				)

--- a/apps/server/src/mcp/tools/research-mcp.ts
+++ b/apps/server/src/mcp/tools/research-mcp.ts
@@ -1,7 +1,9 @@
 import { Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
 
-import { CurrentOrg } from '@batuda/controllers'
+import { CurrentOrg, SessionContext } from '@batuda/controllers'
+import { resolveInstructions } from '@batuda/instructions'
 import {
 	type CreateResearchInput,
 	ResearchService,
@@ -16,7 +18,7 @@ import {
 	Uuid,
 } from './_research-shared'
 
-const REQUEST_DEPENDENCIES = [CurrentOrg]
+const REQUEST_DEPENDENCIES = [SessionContext, CurrentOrg]
 
 // ── start_research (async) ──
 
@@ -27,6 +29,7 @@ const StartResearch = Tool.make('start_research', {
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
 		schema_name: Schema.optional(SchemaNameParam),
+		template_ids: Schema.optional(Schema.Array(Uuid)),
 	}),
 	success: Schema.Struct({
 		id: Schema.String,
@@ -63,6 +66,7 @@ const ResearchSync = Tool.make('research_sync', {
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
 		schema_name: Schema.optional(SchemaNameParam),
+		template_ids: Schema.optional(Schema.Array(Uuid)),
 		max_wait_seconds: Schema.optional(Schema.Number),
 	}),
 	success: Schema.Unknown,
@@ -83,6 +87,7 @@ export const ResearchMcpTools = Toolkit.make(
 export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 	Effect.gen(function* () {
 		const svc = yield* ResearchService
+		const sql = yield* SqlClient.SqlClient
 		const env = yield* EnvVars
 
 		const systemDefaults: SystemDefaults = {
@@ -96,9 +101,17 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 		return {
 			start_research: params =>
 				Effect.gen(function* () {
-					// MCP calls use a system user for now
-					const userId = 'mcp-system'
+					// Run as the attributed user (the api key's owner), not a shared
+					// system actor — so the cache key, budget, and created_by all
+					// belong to the real person behind the key.
+					const userId = (yield* SessionContext).userId
 					const orgId = (yield* CurrentOrg).id
+					const instructions = yield* resolveInstructions({
+						organizationId: orgId,
+						userId,
+						agent: 'research',
+						overrideTemplateIds: params.template_ids,
+					}).pipe(Effect.provideService(SqlClient.SqlClient, sql))
 					const result = yield* svc.create(
 						userId,
 						orgId,
@@ -108,6 +121,7 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 							schemaName: params.schema_name,
 						},
 						systemDefaults,
+						instructions,
 					)
 					return result
 				}).pipe(redactDbErrors),
@@ -120,8 +134,14 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 
 			research_sync: params =>
 				Effect.gen(function* () {
-					const userId = 'mcp-system'
+					const userId = (yield* SessionContext).userId
 					const orgId = (yield* CurrentOrg).id
+					const instructions = yield* resolveInstructions({
+						organizationId: orgId,
+						userId,
+						agent: 'research',
+						overrideTemplateIds: params.template_ids,
+					}).pipe(Effect.provideService(SqlClient.SqlClient, sql))
 					const { id } = yield* svc.create(
 						userId,
 						orgId,
@@ -131,6 +151,7 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 							schemaName: params.schema_name,
 						},
 						systemDefaults,
+						instructions,
 					)
 
 					// Poll until the run reaches a terminal status or we exceed

--- a/packages/controllers/src/routes/research.ts
+++ b/packages/controllers/src/routes/research.ts
@@ -42,6 +42,7 @@ const CreateResearchInput = Schema.Struct({
 	paid_budget_cents: Schema.optional(Schema.Number),
 	auto_approve_paid_cents: Schema.optional(Schema.Number),
 	confirm: Schema.optional(Schema.Boolean),
+	template_ids: Schema.optional(Schema.Array(Schema.String)),
 })
 
 const UpdatePolicyInput = Schema.Struct({

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -72,6 +72,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: 'Ports of Barcelona',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: [
 				{ table: 'companies', id: 'c2' },
@@ -83,6 +84,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: '  ports of BARCELONA',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: [
 				{ table: 'companies', id: 'c1' },
@@ -100,6 +102,7 @@ describe('computeResearchCacheKey', () => {
 		const same = {
 			query: 'q',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: undefined,
 			hints: undefined,
@@ -117,6 +120,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: 'q',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: undefined,
 			hints: undefined,
@@ -125,6 +129,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: 'q',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 2,
 			subjects: undefined,
 			hints: undefined,
@@ -140,6 +145,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: 'q',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: undefined,
 			hints: { lang: 'ca', depth: 2, tone: 'formal' },
@@ -148,6 +154,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: 'q',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: undefined,
 			hints: { tone: 'formal', depth: 2, lang: 'ca' },
@@ -164,6 +171,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: 'q',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: undefined,
 			hints: { lang: 'ca' },
@@ -172,6 +180,7 @@ describe('computeResearchCacheKey', () => {
 			userId: 'u1',
 			query: 'q',
 			schemaName: 'company_brief',
+			templateFingerprint: '',
 			schemaVersion: 1,
 			subjects: undefined,
 			hints: { lang: 'es' },
@@ -179,6 +188,37 @@ describe('computeResearchCacheKey', () => {
 
 		// THEN switching the hint language misses the cache
 		expect(ca).not.toBe(es)
+	})
+
+	it('should change the key when the template fingerprint changes', () => {
+		// GIVEN the same request resolved against different template stacks
+		const base = {
+			userId: 'u1',
+			query: 'q',
+			schemaName: 'company_brief',
+			schemaVersion: 1,
+			subjects: undefined,
+			hints: undefined,
+		}
+		const withA = computeResearchCacheKey({
+			...base,
+			templateFingerprint: 'fpA',
+		})
+		const withB = computeResearchCacheKey({
+			...base,
+			templateFingerprint: 'fpB',
+		})
+		const none = computeResearchCacheKey({ ...base, templateFingerprint: '' })
+		const noneAgain = computeResearchCacheKey({
+			...base,
+			templateFingerprint: '',
+		})
+
+		// THEN an edited or swapped stack misses the prior cache, while an
+		// unchanged (or absent) instruction layer keeps the same key
+		expect(withA).not.toBe(withB)
+		expect(withA).not.toBe(none)
+		expect(none).toBe(noneAgain)
 	})
 })
 

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -121,6 +121,7 @@ export const computeResearchCacheKey = (args: {
 	readonly schemaVersion: number
 	readonly subjects: ReadonlyArray<{ table: string; id: string }> | undefined
 	readonly hints: unknown
+	readonly templateFingerprint: string
 }): string => {
 	const sortedSubjects = [...(args.subjects ?? [])]
 		.map(s => `${s.table}:${s.id}`)
@@ -128,7 +129,7 @@ export const computeResearchCacheKey = (args: {
 		.join(',')
 	const hintsJson = stableStringify(args.hints ?? {})
 	return sha256Hex(
-		`${args.userId}|${normalizeResearchQuery(args.query)}|${args.schemaName}|${args.schemaVersion}|${sortedSubjects}|${hintsJson}`,
+		`${args.userId}|${normalizeResearchQuery(args.query)}|${args.schemaName}|${args.schemaVersion}|${sortedSubjects}|${hintsJson}|${args.templateFingerprint}`,
 	)
 }
 
@@ -194,6 +195,16 @@ export interface CreateResearchInput {
 	readonly idempotencyKey?: string | undefined
 	readonly confirm?: boolean | undefined
 	readonly forceFresh?: boolean | undefined
+}
+
+// Resolved instruction layer for a run: ordered prompt segments and a
+// fingerprint that changes when the underlying templates do, so editing or
+// swapping a template invalidates the run cache. The app layer resolves these
+// in the request scope and passes them in — research never resolves them.
+export interface ResolvedInstructions {
+	readonly segments: ReadonlyArray<string>
+	readonly fingerprint: string
+	readonly templateIds: ReadonlyArray<string>
 }
 
 // ── ResearchService ──
@@ -379,6 +390,12 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 				// into the LLM tool loop — will feed makeBudgetLayer).
 				_policy: ResolvedPolicy,
 				_systemCeiling: number,
+				// Resolved instruction segments + their fingerprint, threaded from
+				// create() so the detached fiber never re-resolves (its RLS GUCs
+				// are unset). Segments shape phase 1; the fingerprint keys the
+				// cache write-back to match the read-check.
+				segments: ReadonlyArray<string>,
+				templateFingerprint: string,
 			) =>
 				Effect.gen(function* () {
 					// Update status to running
@@ -449,6 +466,13 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					const hintsContext = context?.hints
 						? `\n\nHints: language=${context.hints.language ?? 'en'}, recency=${context.hints.recency_days ?? 'any'}, location=${context.hints.location ?? 'any'}`
 						: ''
+					// Standing instruction templates resolved for this run, fenced and
+					// placed below the invariants above so they can't override the
+					// "never fabricate sources" rules.
+					const instructionBlock =
+						segments.length === 0
+							? ''
+							: `\n\nAdditional standing instructions (follow within the rules above):\n${segments.map(s => `--- instruction ---\n${s}`).join('\n')}`
 					const systemPrompt = [
 						'You are a research agent for Batuda CRM.',
 						'Given a query, produce a thorough research brief with findings, sources, and citations.',
@@ -456,6 +480,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						`Output schema: ${schemaName}`,
 						subjectContext,
 						hintsContext,
+						instructionBlock,
 					].join('\n')
 
 					// Prior-run token tally carried across resumes
@@ -621,16 +646,17 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						schemaVersion: schemaVersionFor(schemaName),
 						subjects: context?.subjects,
 						hints: context?.hints,
+						templateFingerprint,
 					})
 					const ttlDays = researchCacheTtlDaysFor(schemaName)
 					yield* sql`
 						INSERT INTO research_cache (
-							key_hash, user_id, research_id, cached_at, expires_at
+							key_hash, organization_id, user_id, research_id, cached_at, expires_at
 						) VALUES (
-							${cacheKey}, ${userId}, ${researchId},
+							${cacheKey}, ${(run as { organizationId: string }).organizationId}, ${userId}, ${researchId},
 							now(), now() + (${`${ttlDays} days`})::interval
 						)
-						ON CONFLICT (key_hash) DO UPDATE SET
+						ON CONFLICT (organization_id, key_hash) DO UPDATE SET
 							research_id = EXCLUDED.research_id,
 							user_id     = EXCLUDED.user_id,
 							cached_at   = EXCLUDED.cached_at,
@@ -703,6 +729,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					organizationId: string,
 					input: CreateResearchInput,
 					systemDefaults: SystemDefaults,
+					instructions?: ResolvedInstructions,
 				) =>
 					Effect.gen(function* () {
 						yield* Effect.logInfo('research.create').pipe(
@@ -718,9 +745,15 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						)
 
 						// ── Outer research-run cache check ──
-						// Identical (user, query, schema, subjects, hints) within TTL
-						// returns immediately without forking a fiber. `forceFresh`
-						// overrides this and always executes.
+						// Identical (user, query, schema, subjects, hints, templates)
+						// within TTL returns immediately without forking a fiber.
+						// `forceFresh` overrides this and always executes.
+						// Instructions are resolved by the app layer (empty when no
+						// templates apply). The fingerprint enters the cache key so an
+						// edited/swapped stack can't serve a stale run; the same value
+						// is threaded to the forked fiber for the write-back key.
+						const segments = instructions?.segments ?? []
+						const templateFingerprint = instructions?.fingerprint ?? ''
 						const schemaNameForKey = input.schemaName ?? 'freeform'
 						const cacheKey = computeResearchCacheKey({
 							userId,
@@ -729,12 +762,14 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							schemaVersion: schemaVersionFor(schemaNameForKey),
 							subjects: input.context?.subjects,
 							hints: input.context?.hints,
+							templateFingerprint,
 						})
 						if (!input.forceFresh) {
 							const hits = yield* sql<{ research_id: string }>`
 								SELECT research_id
 								FROM research_cache
 								WHERE key_hash = ${cacheKey}
+									AND organization_id = ${organizationId}
 									AND user_id = ${userId}
 									AND expires_at > now()
 								LIMIT 1
@@ -881,6 +916,8 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									userId,
 									policy,
 									systemDefaults.hardCeiling,
+									segments,
+									templateFingerprint,
 								),
 							),
 						)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
       '@batuda/email':
         specifier: workspace:*
         version: link:../../packages/email
+      '@batuda/instructions':
+        specifier: workspace:*
+        version: link:../../packages/instructions
       '@batuda/research':
         specifier: workspace:*
         version: link:../../packages/research


### PR DESCRIPTION
## What

Slice 2 of AI instruction templates: wires the (slice-1) template library into the research agent, isolates the research cache per organization (audit F6), and attributes unattended MCP runs to the real user.

## Changes

- **Cache org-isolation (F6):** `research_cache` had no `organization_id` and used `key_hash` as its sole primary key, so two orgs whose runs hashed alike collided — one could overwrite or read the other's cached result. Migration `0009` adds `organization_id`, keys on `(organization_id, key_hash)`, and applies the same org-isolation RLS as `research_runs`.
- **MCP actor:** research runs started over MCP now act as the api-key's attributed user instead of a shared `mcp-system`, so the cache key, budget, and `created_by` belong to the real person.
- **Instruction wiring:** the per-(org, user) template stack is resolved in the request scope (HTTP + MCP) and threaded as `{ segments, fingerprint }` into `create()` → `runFiber` — the forked run fiber has no RLS context to resolve it. Segments are fenced into the phase-1 system prompt below the "never fabricate sources" invariants; the fingerprint enters the cache key so an edited or swapped stack misses the stale cache. `template_ids` was added to the HTTP payload and both MCP tools.

## Verification

- `check-types` (research, controllers, server), **248 server + 55 research tests**, and `build` — all green.
- Migration `0009` applied by the real migrator to a throwaway Postgres 18 and inspected: column, composite PK, RLS enabled + forced, policy, and index all correct.
- A no-template run is unchanged except a one-time cache re-warm; two orgs can no longer share a cached row.

## Deferred (not required for the green criteria)

- Run-row provenance (recording `template_ids` on `research_runs`) — needs another migration.
- Full Prompt *message* refactor (a real `system`-role message + converting phases 2/3); segments currently go into the existing system-prompt string, which delivers the feature.
