### PR TITLE
fix(internal): restore mobile scroll and bottom-nav clearance

### DIFF
--- a/apps/internal/src/components/layout/blueprint-sheet.tsx
+++ b/apps/internal/src/components/layout/blueprint-sheet.tsx
@@ -10,6 +10,8 @@ import styled from 'styled-components'
 
 import { PriScrollArea } from '@batuda/ui/pri'
 
+import { useMediaQuery } from '#/lib/use-media-query'
+
 /**
  * Batuda blueprint sheet — aged technical-drawing paper with cross-hatch +
  * grid, tape strips at the top corners, and sticky rulers along the top
@@ -43,6 +45,10 @@ export function useBlueprintViewportRef(): ViewportRef {
 export function BlueprintSheet({ children }: { children: React.ReactNode }) {
 	const viewportRef = useRef<HTMLDivElement>(null)
 	const value = useMemo(() => viewportRef, [])
+	// Below 768px the page scrolls as a normal document (the body lock only
+	// applies at ≥768px), so the scroll area — which always owns its scroll — is
+	// mounted only on the locked-body layout. Phones get plain document scroll.
+	const isDesktopScroll = useMediaQuery('(min-width: 768px)', true)
 	const { scrollYProgress } = useScroll({ container: viewportRef })
 	// Parallel-rule effect: top ruler ticks drift horizontally as the user
 	// scrolls the sheet, so the drafting-table metaphor stays alive.
@@ -58,14 +64,20 @@ export function BlueprintSheet({ children }: { children: React.ReactNode }) {
 					<TopRuler style={{ backgroundPositionX: rulerShiftX }} />
 					<LeftRuler style={{ backgroundPositionY: rulerShiftY }} />
 					<Vignette />
-					<PriScrollArea.Root>
-						<PriScrollArea.Viewport ref={viewportRef}>
+					{isDesktopScroll ? (
+						<PriScrollArea.Root>
+							<PriScrollArea.Viewport ref={viewportRef}>
+								<Content>{children}</Content>
+							</PriScrollArea.Viewport>
+							<PriScrollArea.Scrollbar orientation='vertical'>
+								<PriScrollArea.Thumb />
+							</PriScrollArea.Scrollbar>
+						</PriScrollArea.Root>
+					) : (
+						<MobileViewport ref={viewportRef}>
 							<Content>{children}</Content>
-						</PriScrollArea.Viewport>
-						<PriScrollArea.Scrollbar orientation='vertical'>
-							<PriScrollArea.Thumb />
-						</PriScrollArea.Scrollbar>
-					</PriScrollArea.Root>
+						</MobileViewport>
+					)}
 				</Sheet>
 			</Wrapper>
 		</ViewportRefContext.Provider>
@@ -253,12 +265,18 @@ const Vignette = styled.div`
 	}
 `
 
+// Phones scroll the document, not an inner viewport. This wrapper holds no
+// scroll of its own (so the page scrolls naturally and a touch anywhere works),
+// and only exists to keep the ruler-parallax ref pointed at a mounted element.
+const MobileViewport = styled.div`
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+`
+
 const Content = styled.div`
 	padding: var(--space-lg) var(--space-md);
-	padding-bottom: calc(
-		var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px) +
-			var(--space-md)
-	);
+	padding-bottom: calc(var(--bottom-nav-space) + var(--space-md));
 	position: relative;
 	z-index: 2;
 

--- a/apps/internal/src/components/layout/bottom-nav.tsx
+++ b/apps/internal/src/components/layout/bottom-nav.tsx
@@ -54,7 +54,7 @@ const Bar = styled.nav.withConfig({ displayName: 'BottomNavBar' })`
 	justify-content: space-evenly;
 	padding: var(--space-xs) 0;
 	padding-bottom: calc(var(--space-xs) + env(safe-area-inset-bottom, 0px));
-	min-height: var(--bottom-nav-height);
+	min-height: var(--bottom-nav-space);
 
 	/* Glassy bar — tinted pegboard color with backdrop blur so the workshop
 	 * texture still bleeds through but text and icons remain legible. Matches

--- a/apps/internal/src/lib/use-media-query.ts
+++ b/apps/internal/src/lib/use-media-query.ts
@@ -1,0 +1,27 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
+/**
+ * SSR-safe media query. `useSyncExternalStore` keeps server and first client
+ * render in agreement (no hydration mismatch) and updates live as the viewport
+ * crosses the breakpoint.
+ *
+ * `serverDefault` is the value assumed during SSR, where `matchMedia` doesn't
+ * exist. Default to the value that renders the safer markup for your case —
+ * e.g. the desktop layout for a desktop-first app, so a wide first paint isn't
+ * briefly clipped before hydration.
+ */
+export function useMediaQuery(query: string, serverDefault = false): boolean {
+	const subscribe = useCallback(
+		(onChange: () => void) => {
+			const mql = window.matchMedia(query)
+			mql.addEventListener('change', onChange)
+			return () => mql.removeEventListener('change', onChange)
+		},
+		[query],
+	)
+	return useSyncExternalStore(
+		subscribe,
+		() => window.matchMedia(query).matches,
+		() => serverDefault,
+	)
+}

--- a/apps/internal/src/styles.css
+++ b/apps/internal/src/styles.css
@@ -6,6 +6,13 @@
 	 * bottom nav, fixed widths for the desktop side nav, or sticky top-bar
 	 * offsets reference these tokens. */
 	--bottom-nav-height: 4.5rem;
+	/* Total space a fixed bottom nav occupies: the bar plus the iOS safe-area
+	 * inset. Single source for both the nav's height and the content padding
+	 * that keeps pages clear of it. */
+	--bottom-nav-space: calc(
+		var(--bottom-nav-height) +
+		env(safe-area-inset-bottom, 0px)
+	);
 	--side-nav-width: 8rem; /* 128px — narrow pegboard: knob + label below */
 	--top-bar-height: 3.5rem;
 }


### PR DESCRIPTION
Two app-wide mobile layout fixes (independent of the instruction-templates work).

## Main content didn't scroll on phones

Below 768px the body isn't locked (document scroll, for pull-to-refresh), but `BlueprintSheet` still wrapped the page in a `PriScrollArea` whose viewport sized itself to its content and **swallowed the touch gesture** without moving — so a touch on the content did nothing.

BaseUI's `ScrollAreaViewport` hardcodes `overflow: scroll` **inline** with no opt-out prop (confirmed in `docs/repos/base-ui/.../ScrollAreaViewport.tsx:374`), so rather than fight it with `!important`, the scroll area is now **rendered only on the locked-body desktop layout** (via a small SSR-safe `useMediaQuery`). On phones the page scrolls as a plain document, so a touch anywhere moves it. The rulers/scrollbar are desktop-only chrome, so nothing is lost.

## Content hidden behind the fixed bottom nav

The bottom nav is `position: fixed`, so content runs under it. The reserved space and the nav's own height were computed separately and could drift. Both now derive from one **`--bottom-nav-space`** token (bar height + `safe-area-inset-bottom`), so notched devices reserve the right amount everywhere.

## Verified

- Mobile (390px, fresh mount): zero overflow traps in `main`, document scrolls (`scrollTop` moves), no motion error.
- Desktop path unchanged (scroll area still owns scroll under the locked body).
- `check-types` · Biome · `i18n-check` · `build` · unit suite all pass.