### PR TITLE
refactor(internal): consolidate the instruction-template pages

### DIFF
--- a/apps/internal/src/components/instructions/instruction-page-chrome.tsx
+++ b/apps/internal/src/components/instructions/instruction-page-chrome.tsx
@@ -1,0 +1,148 @@
+import { Link } from '@tanstack/react-router'
+import styled from 'styled-components'
+
+import {
+	brushedMetalPlate,
+	ruledLedgerRow,
+	rulerUnderRule,
+	stenciledTitle,
+} from '#/lib/workshop-mixins'
+
+// Shared page furniture for the instruction-template settings pages (the user
+// library and the org admin page). Both pages lay out the same workshop
+// surfaces — brushed-metal sections, a stencilled title, a ruled list of
+// template rows — so the chrome lives in one place to stay in step.
+
+export const Page = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
+`
+
+export const BackLink = styled(Link)`
+	display: inline-flex;
+	gap: var(--space-2xs);
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-medium-size);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-on-surface-variant);
+	text-decoration: none;
+
+	&:hover {
+		color: var(--color-on-surface);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+export const Intro = styled.div`
+	${rulerUnderRule}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	padding-bottom: var(--space-xs);
+`
+
+export const Heading = styled.h2`
+	${stenciledTitle}
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-size: var(--typescale-headline-large-size);
+	line-height: var(--typescale-headline-large-line);
+	margin: 0;
+`
+
+export const Subtitle = styled.p`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-large-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+	max-width: 46rem;
+`
+
+export const Section = styled.section`
+	${brushedMetalPlate}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+	padding: var(--space-md);
+	border-radius: var(--shape-2xs);
+`
+
+export const SectionHead = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-sm);
+`
+
+export const SectionTitle = styled.h3`
+	${stenciledTitle}
+	font-size: var(--typescale-title-medium-size);
+	line-height: var(--typescale-title-medium-line);
+	margin: 0;
+`
+
+export const TemplateList = styled.ul`
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+export const TemplateRowItem = styled.li`
+	${ruledLedgerRow}
+	display: flex;
+	align-items: center;
+	gap: var(--space-sm);
+	padding: var(--space-2xs) 0;
+`
+
+export const TemplateName = styled.span`
+	flex: 1 1 auto;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	color: var(--color-on-surface);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+`
+
+export const RowActions = styled.div`
+	display: inline-flex;
+	gap: var(--space-2xs);
+`
+
+export const Empty = styled.p`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+// Inline error notice for a failed load or save (pair with role='alert').
+export const Notice = styled.p`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-error);
+	padding: var(--space-2xs) var(--space-sm);
+	border-left: 3px solid var(--color-error);
+	background: color-mix(in srgb, var(--color-error) 6%, transparent);
+	margin: 0;
+`
+
+export const DialogActions = styled.div`
+	display: flex;
+	gap: var(--space-sm);
+	justify-content: flex-end;
+	margin-top: var(--space-md);
+`

--- a/apps/internal/src/components/instructions/instruction-shapes.ts
+++ b/apps/internal/src/components/instructions/instruction-shapes.ts
@@ -94,3 +94,19 @@ export function narrowPresets(value: unknown): ReadonlyArray<PresetShape> {
 	}
 	return out
 }
+
+// Pull the server's `{ outcome }` discriminant out of a mutation result.
+// promiseExit mutations resolve to a tagged Success/Failure result; only a
+// Success carries a value, and these endpoints return `Schema.Unknown` bodies
+// — so narrow the value rather than casting it to a made-up type. A failed
+// call, or a success without a recognisable outcome, both read as null.
+export function outcomeOf(exit: {
+	readonly _tag: string
+	readonly value?: unknown
+}): string | null {
+	if (exit._tag !== 'Success') return null
+	const value = exit.value
+	if (!value || typeof value !== 'object') return null
+	const outcome = (value as Record<string, unknown>)['outcome']
+	return typeof outcome === 'string' ? outcome : null
+}

--- a/apps/internal/src/components/instructions/template-delete-confirm.tsx
+++ b/apps/internal/src/components/instructions/template-delete-confirm.tsx
@@ -1,0 +1,65 @@
+import { Trans } from '@lingui/react/macro'
+import type { ReactNode } from 'react'
+
+import { PriButton, PriDialog } from '@batuda/ui/pri'
+
+import { DialogActions } from './instruction-page-chrome'
+
+// Delete-confirmation dialog shared by the personal and org template pages.
+// The plumbing is identical — a focus-trapped popup, a Delete button that
+// disables while the delete runs, and Cancel — so each page passes only its
+// own wording and a test id. The dialog stays open mid-delete so a row can't
+// disappear under a half-finished action.
+export function TemplateDeleteConfirm({
+	open,
+	deleting,
+	onConfirm,
+	onClose,
+	testId,
+	title,
+	description,
+}: {
+	readonly open: boolean
+	readonly deleting: boolean
+	readonly onConfirm: () => void
+	readonly onClose: () => void
+	readonly testId: string
+	readonly title: ReactNode
+	readonly description: ReactNode
+}) {
+	return (
+		<PriDialog.Root
+			open={open}
+			onOpenChange={(nextOpen: boolean) => {
+				if (!nextOpen && !deleting) onClose()
+			}}
+		>
+			<PriDialog.Portal>
+				<PriDialog.Backdrop />
+				<PriDialog.Popup data-testid={testId}>
+					<PriDialog.Title>{title}</PriDialog.Title>
+					<PriDialog.Description>{description}</PriDialog.Description>
+					<DialogActions>
+						{/* Confirm button gets its own selector so tests can click it apart from the popup. */}
+						<PriButton
+							type='button'
+							$variant='filled'
+							data-testid={`${testId}-button`}
+							disabled={deleting}
+							onClick={onConfirm}
+						>
+							{deleting ? <Trans>Deleting…</Trans> : <Trans>Delete</Trans>}
+						</PriButton>
+						<PriDialog.Close
+							render={props => (
+								<PriButton type='button' $variant='text' {...props}>
+									<Trans>Cancel</Trans>
+								</PriButton>
+							)}
+						/>
+					</DialogActions>
+				</PriDialog.Popup>
+			</PriDialog.Portal>
+		</PriDialog.Root>
+	)
+}

--- a/apps/internal/src/lib/api-base.ts
+++ b/apps/internal/src/lib/api-base.ts
@@ -1,3 +1,8 @@
+// `__INTERNAL_DEV_PORT__` is injected by vite.config's `define`: the dev
+// server's real port, baked in at config time. The dev SSR runtime (workerd)
+// can't read `process.env`, so the dev branch below uses this constant.
+declare const __INTERNAL_DEV_PORT__: string
+
 /**
  * Single source of truth for the URL the frontend uses to reach the API.
  *
@@ -17,11 +22,13 @@
  *   - **Client in prod** → `VITE_SERVER_URL` (absolute API origin). The
  *     browser fetches cross-origin and the parent-domain cookie flows
  *     via `credentials: 'include'`.
- *   - **SSR in dev** → `http://127.0.0.1:${PORT}` (the Vite dev server
- *     itself). Vite then proxies `/auth/*` and `/v1/*` to the API with
- *     `secure: false`. The SSR runtime never has to validate portless's
- *     self-signed cert chain. Defense in depth: TLS verification stays
- *     on globally; only the dev-only loopback proxy hop ignores it.
+ *   - **SSR in dev** → `http://127.0.0.1:${__INTERNAL_DEV_PORT__}` (the
+ *     Vite dev server itself — the port is baked in at config time because
+ *     the workerd SSR runtime can't read `process.env`). Vite then proxies
+ *     `/auth/*` and `/v1/*` to the API with `secure: false`. The SSR
+ *     runtime never has to validate portless's self-signed cert chain.
+ *     Defense in depth: TLS verification stays on globally; only the
+ *     dev-only loopback proxy hop ignores it.
  *   - **SSR in prod** → absolute `VITE_SERVER_URL`. No proxy, real TLS.
  */
 export function apiBaseUrl(): string {
@@ -32,9 +39,7 @@ export function apiBaseUrl(): string {
 	if (typeof import.meta === 'undefined') return fromEnv
 	if (import.meta.env.SSR) {
 		if (!import.meta.env.DEV) return fromEnv
-		const port =
-			(typeof process !== 'undefined' && process.env?.['PORT']) || '5173'
-		return `http://127.0.0.1:${port}`
+		return `http://127.0.0.1:${__INTERNAL_DEV_PORT__}`
 	}
 	if (import.meta.env.DEV) {
 		if (typeof window !== 'undefined') return window.location.origin

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -25,25 +25,25 @@ msgid "— Select a company —"
 msgstr "— Tria una empresa —"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:168
+#: src/routes/settings/profile/templates.tsx:166
 msgid "\"{0}\" is waiting for an admin to add it to the organization."
 msgstr "«{0}» espera que un administrador l'afegeixi a l'organització."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/organization/templates.tsx:539
+#: src/routes/settings/organization/templates.tsx:546
 msgid "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 msgstr "S'eliminarà «{0}» per a tothom de l'organització. Això no es pot desfer."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/profile/templates.tsx:331
+#: src/routes/settings/profile/templates.tsx:329
 msgid "\"{0}\" will be removed for good. This can't be undone."
 msgstr "S'eliminarà «{0}» per sempre. Això no es pot desfer."
 
-#: src/routes/settings/organization/templates.tsx:271
+#: src/routes/settings/organization/templates.tsx:329
 msgid "\"{name}\" is now an org template you can edit."
 msgstr "«{name}» ja és una plantilla de l'organització que pots editar."
 
-#: src/routes/settings/organization/templates.tsx:226
+#: src/routes/settings/organization/templates.tsx:290
 msgid "\"{name}\" is now an org template."
 msgstr "«{name}» ja és una plantilla de l'organització."
 
@@ -219,7 +219,7 @@ msgstr "Posa un nom i les instruccions abans de desar."
 msgid "Add a template"
 msgstr "Afegeix una plantilla"
 
-#: src/routes/settings/organization/templates.tsx:406
+#: src/routes/settings/organization/templates.tsx:415
 msgid "Add an org template first."
 msgstr "Afegeix primer una plantilla de l'organització."
 
@@ -243,12 +243,12 @@ msgstr "Afegeix tasca"
 msgid "Add the first decision-maker to keep track of who to reach."
 msgstr "Afegeix el primer responsable de decisió per saber a qui adreçar-te."
 
-#: src/routes/settings/organization/templates.tsx:456
+#: src/routes/settings/organization/templates.tsx:465
 msgid "Add to org"
 msgstr "Afegeix a l'organització"
 
-#: src/routes/settings/organization/templates.tsx:225
-#: src/routes/settings/organization/templates.tsx:270
+#: src/routes/settings/organization/templates.tsx:289
+#: src/routes/settings/organization/templates.tsx:328
 msgid "Added to the org"
 msgstr "Afegida a l'organització"
 
@@ -352,7 +352,7 @@ msgstr "Registre d'auditoria"
 msgid "Auth failed"
 msgstr "Error d'autenticació"
 
-#: src/routes/settings/profile/templates.tsx:185
+#: src/routes/settings/profile/templates.tsx:183
 msgid "Back to account"
 msgstr "Torna al compte"
 
@@ -372,7 +372,7 @@ msgstr "Torna a la safata"
 #: src/routes/settings/organization/invite.tsx:87
 #: src/routes/settings/organization/members.tsx:91
 #: src/routes/settings/organization/spend.tsx:111
-#: src/routes/settings/organization/templates.tsx:289
+#: src/routes/settings/organization/templates.tsx:102
 msgid "Back to organization"
 msgstr "Tornar a l'organització"
 
@@ -404,7 +404,7 @@ msgstr "Inici de Batuda"
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda és només amb invitació. Demana accés a l'equip d'Engranatge."
 
-#: src/routes/settings/organization/templates.tsx:481
+#: src/routes/settings/organization/templates.tsx:490
 msgid "Batuda-written templates you can drop into the org and edit."
 msgstr "Plantilles escrites per Batuda que pots afegir a l'organització i editar."
 
@@ -491,8 +491,8 @@ msgstr "Crides"
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
 #: src/routes/settings/api-keys/index.tsx:424
-#: src/routes/settings/organization/templates.tsx:559
-#: src/routes/settings/profile/templates.tsx:351
+#: src/routes/settings/organization/templates.tsx:566
+#: src/routes/settings/profile/templates.tsx:349
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -939,7 +939,7 @@ msgstr "No s'ha pogut canviar l'estat de la safata."
 msgid "Could not update"
 msgstr "No s'ha pogut actualitzar"
 
-#: src/routes/settings/organization/templates.tsx:234
+#: src/routes/settings/organization/templates.tsx:298
 msgid "Couldn't add it"
 msgstr "No s'ha pogut afegir"
 
@@ -947,37 +947,37 @@ msgstr "No s'ha pogut afegir"
 msgid "Couldn't copy"
 msgstr "No s'ha pogut copiar"
 
-#: src/routes/settings/organization/templates.tsx:251
+#: src/routes/settings/organization/templates.tsx:312
 msgid "Couldn't decline it"
 msgstr "No s'ha pogut rebutjar"
 
-#: src/routes/settings/organization/templates.tsx:180
-#: src/routes/settings/profile/templates.tsx:126
-#: src/routes/settings/profile/templates.tsx:146
+#: src/routes/settings/organization/templates.tsx:250
+#: src/routes/settings/profile/templates.tsx:127
+#: src/routes/settings/profile/templates.tsx:147
 msgid "Couldn't delete the template. Please try again."
 msgstr "No s'ha pogut eliminar la plantilla. Torna-ho a provar."
 
-#: src/routes/settings/organization/templates.tsx:278
+#: src/routes/settings/organization/templates.tsx:336
 msgid "Couldn't import it"
 msgstr "No s'ha pogut importar"
 
-#: src/routes/settings/organization/templates.tsx:400
+#: src/routes/settings/organization/templates.tsx:411
 msgid "Couldn't load the org default. Refresh to try again."
 msgstr "No s'ha pogut carregar el valor per defecte de l'organització. Actualitza per tornar-ho a provar."
 
-#: src/routes/settings/profile/templates.tsx:283
+#: src/routes/settings/profile/templates.tsx:281
 msgid "Couldn't load your default. Refresh to try again."
 msgstr "No s'ha pogut carregar el teu valor per defecte. Actualitza per tornar-ho a provar."
 
-#: src/routes/settings/profile/templates.tsx:220
+#: src/routes/settings/profile/templates.tsx:218
 msgid "Couldn't load your templates. Refresh to try again."
 msgstr "No s'han pogut carregar les teves plantilles. Actualitza per tornar-ho a provar."
 
-#: src/routes/settings/organization/templates.tsx:211
+#: src/routes/settings/organization/templates.tsx:278
 msgid "Couldn't save"
 msgstr "No s'ha pogut desar"
 
-#: src/routes/settings/profile/templates.tsx:174
+#: src/routes/settings/profile/templates.tsx:172
 msgid "Couldn't send it"
 msgstr "No s'ha pogut enviar"
 
@@ -1005,7 +1005,7 @@ msgstr "Crea una pàgina d'aterratge per a un prospecte des del detall d'una emp
 msgid "Create a prospect landing page to share with this company."
 msgstr "Crea una pàgina d'aterratge per a un prospecte per compartir amb aquesta empresa."
 
-#: src/routes/settings/profile/templates.tsx:291
+#: src/routes/settings/profile/templates.tsx:289
 msgid "Create a template above first, then pick which ones run by default."
 msgstr "Crea primer una plantilla a dalt i després tria quines s'executen per defecte."
 
@@ -1083,7 +1083,7 @@ msgid "Decline"
 msgstr "Rebutja"
 
 #. placeholder {0}: d.name
-#: src/routes/settings/organization/templates.tsx:460
+#: src/routes/settings/organization/templates.tsx:469
 msgid "Decline {0}"
 msgstr "Rebutja {0}"
 
@@ -1106,23 +1106,23 @@ msgstr "Per defecte ets tu si s'omet."
 
 #: src/routes/emails/inboxes.tsx:1385
 #: src/routes/settings/api-keys/index.tsx:329
-#: src/routes/settings/organization/templates.tsx:554
-#: src/routes/settings/profile/templates.tsx:346
+#: src/routes/settings/organization/templates.tsx:561
+#: src/routes/settings/profile/templates.tsx:344
 msgid "Delete"
 msgstr "Elimina"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:374
-#: src/routes/settings/profile/templates.tsx:265
+#: src/routes/settings/organization/templates.tsx:385
+#: src/routes/settings/profile/templates.tsx:263
 msgid "Delete {0}"
 msgstr "Elimina {0}"
 
 #: src/routes/emails/inboxes.tsx:266
 #: src/routes/emails/inboxes.tsx:1293
 #: src/routes/settings/api-keys/index.tsx:162
-#: src/routes/settings/organization/templates.tsx:179
-#: src/routes/settings/profile/templates.tsx:125
-#: src/routes/settings/profile/templates.tsx:145
+#: src/routes/settings/organization/templates.tsx:249
+#: src/routes/settings/profile/templates.tsx:126
+#: src/routes/settings/profile/templates.tsx:146
 msgid "Delete failed"
 msgstr "Error en eliminar"
 
@@ -1148,18 +1148,18 @@ msgstr "Eliminar aquest peu de pàgina? Aquesta acció no es pot desfer."
 msgid "Delete this key?"
 msgstr "Vols eliminar aquesta clau?"
 
-#: src/routes/settings/organization/templates.tsx:536
+#: src/routes/settings/organization/templates.tsx:543
 msgid "Delete this org template?"
 msgstr "Vols eliminar aquesta plantilla de l'organització?"
 
-#: src/routes/settings/profile/templates.tsx:328
+#: src/routes/settings/profile/templates.tsx:326
 msgid "Delete this template?"
 msgstr "Vols eliminar aquesta plantilla?"
 
 #: src/routes/settings/api-keys/index.tsx:329
 #: src/routes/settings/api-keys/index.tsx:439
-#: src/routes/settings/organization/templates.tsx:554
-#: src/routes/settings/profile/templates.tsx:346
+#: src/routes/settings/organization/templates.tsx:561
+#: src/routes/settings/profile/templates.tsx:344
 msgid "Deleting…"
 msgstr "Eliminant…"
 
@@ -1201,7 +1201,7 @@ msgid "Documents"
 msgstr "Documents"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:249
+#: src/routes/settings/profile/templates.tsx:247
 msgid "Donate {0} to your organization"
 msgstr "Dona {0} a la teva organització"
 
@@ -1251,8 +1251,8 @@ msgid "Edit"
 msgstr "Edita"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:367
-#: src/routes/settings/profile/templates.tsx:258
+#: src/routes/settings/organization/templates.tsx:378
+#: src/routes/settings/profile/templates.tsx:256
 msgid "Edit {0}"
 msgstr "Edita {0}"
 
@@ -1524,7 +1524,7 @@ msgstr "Port IMAP"
 msgid "IMAP security"
 msgstr "Seguretat IMAP"
 
-#: src/routes/settings/organization/templates.tsx:504
+#: src/routes/settings/organization/templates.tsx:513
 msgid "Import to org"
 msgstr "Importa a l'organització"
 
@@ -1580,7 +1580,7 @@ msgstr "Instagram"
 
 #: src/routes/settings/organization/index.tsx:141
 #: src/routes/settings/profile/index.tsx:147
-#: src/routes/settings/profile/templates.tsx:192
+#: src/routes/settings/profile/templates.tsx:190
 msgid "Instruction templates"
 msgstr "Plantilles d'instruccions"
 
@@ -1859,7 +1859,7 @@ msgstr "Reunions des de reserves, invitacions per correu i blocs interns."
 msgid "Member"
 msgstr "Membre"
 
-#: src/routes/settings/organization/templates.tsx:434
+#: src/routes/settings/organization/templates.tsx:443
 msgid "Member proposals"
 msgstr "Propostes dels membres"
 
@@ -1882,7 +1882,7 @@ msgstr "Meta"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/profile/templates.tsx:242
+#: src/routes/settings/profile/templates.tsx:240
 msgid "Mine"
 msgstr "Meva"
 
@@ -1937,7 +1937,7 @@ msgid "Never expires"
 msgstr "No caduca mai"
 
 #: src/components/instructions/template-editor-dialog.tsx:87
-#: src/routes/settings/organization/templates.tsx:345
+#: src/routes/settings/organization/templates.tsx:356
 msgid "New org template"
 msgstr "Nova plantilla d'organització"
 
@@ -1952,7 +1952,7 @@ msgid "New password or app-password"
 msgstr "Contrasenya nova o d'aplicació"
 
 #: src/components/instructions/template-editor-dialog.tsx:89
-#: src/routes/settings/profile/templates.tsx:214
+#: src/routes/settings/profile/templates.tsx:212
 msgid "New template"
 msgstr "Nova plantilla"
 
@@ -2091,11 +2091,11 @@ msgstr "No hi ha missatges en aquest fil"
 msgid "No open tasks."
 msgstr "Cap tasca oberta."
 
-#: src/routes/settings/organization/templates.tsx:327
+#: src/routes/settings/organization/templates.tsx:145
 msgid "No org templates yet."
 msgstr "Encara no hi ha plantilles d'organització."
 
-#: src/routes/settings/organization/templates.tsx:351
+#: src/routes/settings/organization/templates.tsx:362
 msgid "No org templates yet. Create one, import a preset, or accept a member's proposal."
 msgstr "Encara no hi ha plantilles d'organització. Crea'n una, importa una predefinida o accepta la proposta d'un membre."
 
@@ -2112,7 +2112,7 @@ msgstr "Encara no hi ha pàgines"
 msgid "No paid calls in this range."
 msgstr "No hi ha crides de pagament en aquest interval."
 
-#: src/routes/settings/organization/templates.tsx:487
+#: src/routes/settings/organization/templates.tsx:496
 msgid "No presets available."
 msgstr "No hi ha plantilles predefinides disponibles."
 
@@ -2124,7 +2124,7 @@ msgstr "No hi ha cap bústia principal."
 msgid "No products linked yet"
 msgstr "Encara sense productes vinculats"
 
-#: src/routes/settings/organization/templates.tsx:438
+#: src/routes/settings/organization/templates.tsx:447
 msgid "No proposals waiting for review."
 msgstr "No hi ha cap proposta pendent de revisió."
 
@@ -2153,7 +2153,7 @@ msgstr "Cap tasca per a avui"
 msgid "No templates added yet."
 msgstr "Encara no has afegit cap plantilla."
 
-#: src/routes/settings/profile/templates.tsx:224
+#: src/routes/settings/profile/templates.tsx:222
 msgid "No templates yet. Create one to start shaping your runs."
 msgstr "Encara no hi ha plantilles. Crea'n una per començar a guiar les teves recerques."
 
@@ -2285,21 +2285,21 @@ msgstr "Obert"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/organization/templates.tsx:320
-#: src/routes/settings/organization/templates.tsx:362
-#: src/routes/settings/profile/templates.tsx:240
+#: src/routes/settings/organization/templates.tsx:138
+#: src/routes/settings/organization/templates.tsx:373
+#: src/routes/settings/profile/templates.tsx:238
 msgid "Org"
 msgstr "Org"
 
-#: src/routes/settings/organization/templates.tsx:206
+#: src/routes/settings/organization/templates.tsx:273
 msgid "Org default saved"
 msgstr "Valor per defecte de l'organització desat"
 
-#: src/routes/settings/organization/templates.tsx:296
+#: src/routes/settings/organization/templates.tsx:109
 msgid "Org instruction templates"
 msgstr "Plantilles d'instruccions de l'organització"
 
-#: src/routes/settings/organization/templates.tsx:336
+#: src/routes/settings/organization/templates.tsx:347
 msgid "Org templates"
 msgstr "Plantilles de l'organització"
 
@@ -2310,7 +2310,7 @@ msgstr "Plantilles de l'organització"
 msgid "Organization"
 msgstr "Organització"
 
-#: src/routes/settings/organization/templates.tsx:390
+#: src/routes/settings/organization/templates.tsx:401
 msgid "Organization default"
 msgstr "Valor per defecte de l'organització"
 
@@ -2496,11 +2496,11 @@ msgstr "Pipeline"
 msgid "Plain"
 msgstr "Sense xifrar"
 
-#: src/routes/settings/organization/templates.tsx:212
-#: src/routes/settings/organization/templates.tsx:235
-#: src/routes/settings/organization/templates.tsx:252
 #: src/routes/settings/organization/templates.tsx:279
-#: src/routes/settings/profile/templates.tsx:175
+#: src/routes/settings/organization/templates.tsx:299
+#: src/routes/settings/organization/templates.tsx:313
+#: src/routes/settings/organization/templates.tsx:337
+#: src/routes/settings/profile/templates.tsx:173
 msgid "Please try again."
 msgstr "Torna-ho a provar."
 
@@ -2557,7 +2557,7 @@ msgstr "Perfil"
 msgid "Proposal"
 msgstr "Proposta"
 
-#: src/routes/settings/organization/templates.tsx:248
+#: src/routes/settings/organization/templates.tsx:309
 msgid "Proposal declined"
 msgstr "Proposta rebutjada"
 
@@ -2662,12 +2662,12 @@ msgid "Remove"
 msgstr "Elimina"
 
 #. placeholder {0}: target.name
-#: src/routes/settings/organization/templates.tsx:171
+#: src/routes/settings/organization/templates.tsx:241
 msgid "Remove \"{0}\" from the org default first, then delete it."
 msgstr "Treu «{0}» del valor per defecte de l'organització primer i després elimina-la."
 
 #. placeholder {0}: target.name
-#: src/routes/settings/profile/templates.tsx:137
+#: src/routes/settings/profile/templates.tsx:138
 msgid "Remove \"{0}\" from your default first, then delete it."
 msgstr "Treu «{0}» del teu valor per defecte primer i després elimina-la."
 
@@ -2771,7 +2771,7 @@ msgstr "Reprèn esborranys ({0})"
 msgid "Resume drafting (1)"
 msgstr "Reprèn l'esborrany (1)"
 
-#: src/routes/settings/profile/templates.tsx:195
+#: src/routes/settings/profile/templates.tsx:193
 msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 msgstr "Orientació reutilitzable i permanent que segueix el teu agent de recerca: què vens, a qui t'adreces, el to i en quines fonts confiar."
 
@@ -2826,7 +2826,7 @@ msgstr "Desa la nova contrasenya"
 msgid "Save password"
 msgstr "Desa la contrasenya"
 
-#: src/routes/settings/organization/templates.tsx:425
+#: src/routes/settings/organization/templates.tsx:434
 msgid "Save the org default"
 msgstr "Desa el valor per defecte de l'organització"
 
@@ -2933,7 +2933,7 @@ msgstr "Enviant…"
 msgid "Sent"
 msgstr "Enviat"
 
-#: src/routes/settings/profile/templates.tsx:167
+#: src/routes/settings/profile/templates.tsx:165
 msgid "Sent to your admins"
 msgstr "Enviada als administradors"
 
@@ -2983,7 +2983,7 @@ msgstr "Compartida"
 msgid "Shared guidance and the org research default."
 msgstr "Orientació compartida i la recerca per defecte de l'organització."
 
-#: src/routes/settings/organization/templates.tsx:299
+#: src/routes/settings/organization/templates.tsx:112
 msgid "Shared guidance every member's research agent can use, plus the organization's default."
 msgstr "Orientació compartida que pot fer servir l'agent de recerca de cada membre, més el valor per defecte de l'organització."
 
@@ -3128,7 +3128,7 @@ msgstr "Orientació permanent que el teu agent de recerca segueix en cada recerc
 msgid "Start"
 msgstr "Inicia"
 
-#: src/routes/settings/organization/templates.tsx:478
+#: src/routes/settings/organization/templates.tsx:487
 msgid "Starter presets"
 msgstr "Plantilles predefinides per començar"
 
@@ -3151,8 +3151,8 @@ msgstr "Estat"
 msgid "Status update failed"
 msgstr "Ha fallat l'actualització d'estat"
 
-#: src/routes/settings/organization/templates.tsx:170
-#: src/routes/settings/profile/templates.tsx:136
+#: src/routes/settings/organization/templates.tsx:240
+#: src/routes/settings/profile/templates.tsx:137
 msgid "Still in use"
 msgstr "Encara s'utilitza"
 
@@ -3211,12 +3211,12 @@ msgstr "NIF"
 msgid "Template"
 msgstr "Plantilla"
 
-#: src/routes/settings/organization/templates.tsx:186
-#: src/routes/settings/profile/templates.tsx:152
+#: src/routes/settings/organization/templates.tsx:256
+#: src/routes/settings/profile/templates.tsx:153
 msgid "Template deleted"
 msgstr "Plantilla eliminada"
 
-#: src/routes/settings/profile/templates.tsx:205
+#: src/routes/settings/profile/templates.tsx:203
 msgid "Templates"
 msgstr "Plantilles"
 
@@ -3338,7 +3338,7 @@ msgstr "L'espai de treball on viuen les dades del CRM."
 msgid "These come from your organization. Saving keeps your own copy, so your runs stop following later changes to the org default."
 msgstr "Aquestes vénen de la teva organització. Si les deses, en guardes una còpia pròpia i les teves recerques deixen de seguir els canvis posteriors del valor per defecte de l'organització."
 
-#: src/routes/settings/organization/templates.tsx:393
+#: src/routes/settings/organization/templates.tsx:404
 msgid "These templates run for every member who hasn't set their own — in order. Only org templates can go here."
 msgstr "Aquestes plantilles s'apliquen, en ordre, a cada membre que no n'hagi triat de pròpies. Aquí només hi poden anar plantilles de l'organització."
 
@@ -3680,7 +3680,7 @@ msgstr "El correu encara no està verificat. Fes servir l'enllaç de sessió."
 msgid "Your keys"
 msgstr "Les teves claus"
 
-#: src/routes/settings/organization/templates.tsx:309
+#: src/routes/settings/organization/templates.tsx:127
 msgid "Your organization's admins manage these templates. You can use any of them in your own default or per run."
 msgstr "Els administradors de la teva organització gestionen aquestes plantilles. En pots fer servir qualsevol al teu valor per defecte o en cada recerca."
 
@@ -3689,6 +3689,6 @@ msgid "Your own"
 msgstr "Pròpia"
 
 #: src/components/instructions/default-stack-editor.tsx:63
-#: src/routes/settings/profile/templates.tsx:288
+#: src/routes/settings/profile/templates.tsx:286
 msgid "Your research default"
 msgstr "La teva recerca per defecte"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -25,25 +25,25 @@ msgid "— Select a company —"
 msgstr "— Tria una empresa —"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:156
+#: src/routes/settings/profile/templates.tsx:168
 msgid "\"{0}\" is waiting for an admin to add it to the organization."
 msgstr "«{0}» espera que un administrador l'afegeixi a l'organització."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/organization/templates.tsx:527
+#: src/routes/settings/organization/templates.tsx:539
 msgid "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 msgstr "S'eliminarà «{0}» per a tothom de l'organització. Això no es pot desfer."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/profile/templates.tsx:319
+#: src/routes/settings/profile/templates.tsx:331
 msgid "\"{0}\" will be removed for good. This can't be undone."
 msgstr "S'eliminarà «{0}» per sempre. Això no es pot desfer."
 
-#: src/routes/settings/organization/templates.tsx:259
+#: src/routes/settings/organization/templates.tsx:271
 msgid "\"{name}\" is now an org template you can edit."
 msgstr "«{name}» ja és una plantilla de l'organització que pots editar."
 
-#: src/routes/settings/organization/templates.tsx:214
+#: src/routes/settings/organization/templates.tsx:226
 msgid "\"{name}\" is now an org template."
 msgstr "«{name}» ja és una plantilla de l'organització."
 
@@ -219,7 +219,7 @@ msgstr "Posa un nom i les instruccions abans de desar."
 msgid "Add a template"
 msgstr "Afegeix una plantilla"
 
-#: src/routes/settings/organization/templates.tsx:394
+#: src/routes/settings/organization/templates.tsx:406
 msgid "Add an org template first."
 msgstr "Afegeix primer una plantilla de l'organització."
 
@@ -243,12 +243,12 @@ msgstr "Afegeix tasca"
 msgid "Add the first decision-maker to keep track of who to reach."
 msgstr "Afegeix el primer responsable de decisió per saber a qui adreçar-te."
 
-#: src/routes/settings/organization/templates.tsx:444
+#: src/routes/settings/organization/templates.tsx:456
 msgid "Add to org"
 msgstr "Afegeix a l'organització"
 
-#: src/routes/settings/organization/templates.tsx:213
-#: src/routes/settings/organization/templates.tsx:258
+#: src/routes/settings/organization/templates.tsx:225
+#: src/routes/settings/organization/templates.tsx:270
 msgid "Added to the org"
 msgstr "Afegida a l'organització"
 
@@ -352,7 +352,7 @@ msgstr "Registre d'auditoria"
 msgid "Auth failed"
 msgstr "Error d'autenticació"
 
-#: src/routes/settings/profile/templates.tsx:173
+#: src/routes/settings/profile/templates.tsx:185
 msgid "Back to account"
 msgstr "Torna al compte"
 
@@ -372,7 +372,7 @@ msgstr "Torna a la safata"
 #: src/routes/settings/organization/invite.tsx:87
 #: src/routes/settings/organization/members.tsx:91
 #: src/routes/settings/organization/spend.tsx:111
-#: src/routes/settings/organization/templates.tsx:277
+#: src/routes/settings/organization/templates.tsx:289
 msgid "Back to organization"
 msgstr "Tornar a l'organització"
 
@@ -404,7 +404,7 @@ msgstr "Inici de Batuda"
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda és només amb invitació. Demana accés a l'equip d'Engranatge."
 
-#: src/routes/settings/organization/templates.tsx:469
+#: src/routes/settings/organization/templates.tsx:481
 msgid "Batuda-written templates you can drop into the org and edit."
 msgstr "Plantilles escrites per Batuda que pots afegir a l'organització i editar."
 
@@ -491,8 +491,8 @@ msgstr "Crides"
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
 #: src/routes/settings/api-keys/index.tsx:424
-#: src/routes/settings/organization/templates.tsx:547
-#: src/routes/settings/profile/templates.tsx:339
+#: src/routes/settings/organization/templates.tsx:559
+#: src/routes/settings/profile/templates.tsx:351
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -939,7 +939,7 @@ msgstr "No s'ha pogut canviar l'estat de la safata."
 msgid "Could not update"
 msgstr "No s'ha pogut actualitzar"
 
-#: src/routes/settings/organization/templates.tsx:222
+#: src/routes/settings/organization/templates.tsx:234
 msgid "Couldn't add it"
 msgstr "No s'ha pogut afegir"
 
@@ -947,37 +947,37 @@ msgstr "No s'ha pogut afegir"
 msgid "Couldn't copy"
 msgstr "No s'ha pogut copiar"
 
-#: src/routes/settings/organization/templates.tsx:239
+#: src/routes/settings/organization/templates.tsx:251
 msgid "Couldn't decline it"
 msgstr "No s'ha pogut rebutjar"
 
-#: src/routes/settings/organization/templates.tsx:168
-#: src/routes/settings/profile/templates.tsx:114
-#: src/routes/settings/profile/templates.tsx:134
+#: src/routes/settings/organization/templates.tsx:180
+#: src/routes/settings/profile/templates.tsx:126
+#: src/routes/settings/profile/templates.tsx:146
 msgid "Couldn't delete the template. Please try again."
 msgstr "No s'ha pogut eliminar la plantilla. Torna-ho a provar."
 
-#: src/routes/settings/organization/templates.tsx:266
+#: src/routes/settings/organization/templates.tsx:278
 msgid "Couldn't import it"
 msgstr "No s'ha pogut importar"
 
-#: src/routes/settings/organization/templates.tsx:388
+#: src/routes/settings/organization/templates.tsx:400
 msgid "Couldn't load the org default. Refresh to try again."
 msgstr "No s'ha pogut carregar el valor per defecte de l'organització. Actualitza per tornar-ho a provar."
 
-#: src/routes/settings/profile/templates.tsx:271
+#: src/routes/settings/profile/templates.tsx:283
 msgid "Couldn't load your default. Refresh to try again."
 msgstr "No s'ha pogut carregar el teu valor per defecte. Actualitza per tornar-ho a provar."
 
-#: src/routes/settings/profile/templates.tsx:208
+#: src/routes/settings/profile/templates.tsx:220
 msgid "Couldn't load your templates. Refresh to try again."
 msgstr "No s'han pogut carregar les teves plantilles. Actualitza per tornar-ho a provar."
 
-#: src/routes/settings/organization/templates.tsx:199
+#: src/routes/settings/organization/templates.tsx:211
 msgid "Couldn't save"
 msgstr "No s'ha pogut desar"
 
-#: src/routes/settings/profile/templates.tsx:162
+#: src/routes/settings/profile/templates.tsx:174
 msgid "Couldn't send it"
 msgstr "No s'ha pogut enviar"
 
@@ -1005,7 +1005,7 @@ msgstr "Crea una pàgina d'aterratge per a un prospecte des del detall d'una emp
 msgid "Create a prospect landing page to share with this company."
 msgstr "Crea una pàgina d'aterratge per a un prospecte per compartir amb aquesta empresa."
 
-#: src/routes/settings/profile/templates.tsx:279
+#: src/routes/settings/profile/templates.tsx:291
 msgid "Create a template above first, then pick which ones run by default."
 msgstr "Crea primer una plantilla a dalt i després tria quines s'executen per defecte."
 
@@ -1083,7 +1083,7 @@ msgid "Decline"
 msgstr "Rebutja"
 
 #. placeholder {0}: d.name
-#: src/routes/settings/organization/templates.tsx:448
+#: src/routes/settings/organization/templates.tsx:460
 msgid "Decline {0}"
 msgstr "Rebutja {0}"
 
@@ -1106,23 +1106,23 @@ msgstr "Per defecte ets tu si s'omet."
 
 #: src/routes/emails/inboxes.tsx:1385
 #: src/routes/settings/api-keys/index.tsx:329
-#: src/routes/settings/organization/templates.tsx:542
-#: src/routes/settings/profile/templates.tsx:334
+#: src/routes/settings/organization/templates.tsx:554
+#: src/routes/settings/profile/templates.tsx:346
 msgid "Delete"
 msgstr "Elimina"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:362
-#: src/routes/settings/profile/templates.tsx:253
+#: src/routes/settings/organization/templates.tsx:374
+#: src/routes/settings/profile/templates.tsx:265
 msgid "Delete {0}"
 msgstr "Elimina {0}"
 
 #: src/routes/emails/inboxes.tsx:266
 #: src/routes/emails/inboxes.tsx:1293
 #: src/routes/settings/api-keys/index.tsx:162
-#: src/routes/settings/organization/templates.tsx:167
-#: src/routes/settings/profile/templates.tsx:113
-#: src/routes/settings/profile/templates.tsx:133
+#: src/routes/settings/organization/templates.tsx:179
+#: src/routes/settings/profile/templates.tsx:125
+#: src/routes/settings/profile/templates.tsx:145
 msgid "Delete failed"
 msgstr "Error en eliminar"
 
@@ -1148,18 +1148,18 @@ msgstr "Eliminar aquest peu de pàgina? Aquesta acció no es pot desfer."
 msgid "Delete this key?"
 msgstr "Vols eliminar aquesta clau?"
 
-#: src/routes/settings/organization/templates.tsx:524
+#: src/routes/settings/organization/templates.tsx:536
 msgid "Delete this org template?"
 msgstr "Vols eliminar aquesta plantilla de l'organització?"
 
-#: src/routes/settings/profile/templates.tsx:316
+#: src/routes/settings/profile/templates.tsx:328
 msgid "Delete this template?"
 msgstr "Vols eliminar aquesta plantilla?"
 
 #: src/routes/settings/api-keys/index.tsx:329
 #: src/routes/settings/api-keys/index.tsx:439
-#: src/routes/settings/organization/templates.tsx:542
-#: src/routes/settings/profile/templates.tsx:334
+#: src/routes/settings/organization/templates.tsx:554
+#: src/routes/settings/profile/templates.tsx:346
 msgid "Deleting…"
 msgstr "Eliminant…"
 
@@ -1201,7 +1201,7 @@ msgid "Documents"
 msgstr "Documents"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:237
+#: src/routes/settings/profile/templates.tsx:249
 msgid "Donate {0} to your organization"
 msgstr "Dona {0} a la teva organització"
 
@@ -1251,8 +1251,8 @@ msgid "Edit"
 msgstr "Edita"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:355
-#: src/routes/settings/profile/templates.tsx:246
+#: src/routes/settings/organization/templates.tsx:367
+#: src/routes/settings/profile/templates.tsx:258
 msgid "Edit {0}"
 msgstr "Edita {0}"
 
@@ -1524,7 +1524,7 @@ msgstr "Port IMAP"
 msgid "IMAP security"
 msgstr "Seguretat IMAP"
 
-#: src/routes/settings/organization/templates.tsx:492
+#: src/routes/settings/organization/templates.tsx:504
 msgid "Import to org"
 msgstr "Importa a l'organització"
 
@@ -1580,7 +1580,7 @@ msgstr "Instagram"
 
 #: src/routes/settings/organization/index.tsx:141
 #: src/routes/settings/profile/index.tsx:147
-#: src/routes/settings/profile/templates.tsx:180
+#: src/routes/settings/profile/templates.tsx:192
 msgid "Instruction templates"
 msgstr "Plantilles d'instruccions"
 
@@ -1859,7 +1859,7 @@ msgstr "Reunions des de reserves, invitacions per correu i blocs interns."
 msgid "Member"
 msgstr "Membre"
 
-#: src/routes/settings/organization/templates.tsx:422
+#: src/routes/settings/organization/templates.tsx:434
 msgid "Member proposals"
 msgstr "Propostes dels membres"
 
@@ -1882,7 +1882,7 @@ msgstr "Meta"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/profile/templates.tsx:230
+#: src/routes/settings/profile/templates.tsx:242
 msgid "Mine"
 msgstr "Meva"
 
@@ -1937,7 +1937,7 @@ msgid "Never expires"
 msgstr "No caduca mai"
 
 #: src/components/instructions/template-editor-dialog.tsx:87
-#: src/routes/settings/organization/templates.tsx:333
+#: src/routes/settings/organization/templates.tsx:345
 msgid "New org template"
 msgstr "Nova plantilla d'organització"
 
@@ -1952,7 +1952,7 @@ msgid "New password or app-password"
 msgstr "Contrasenya nova o d'aplicació"
 
 #: src/components/instructions/template-editor-dialog.tsx:89
-#: src/routes/settings/profile/templates.tsx:202
+#: src/routes/settings/profile/templates.tsx:214
 msgid "New template"
 msgstr "Nova plantilla"
 
@@ -2091,11 +2091,11 @@ msgstr "No hi ha missatges en aquest fil"
 msgid "No open tasks."
 msgstr "Cap tasca oberta."
 
-#: src/routes/settings/organization/templates.tsx:315
+#: src/routes/settings/organization/templates.tsx:327
 msgid "No org templates yet."
 msgstr "Encara no hi ha plantilles d'organització."
 
-#: src/routes/settings/organization/templates.tsx:339
+#: src/routes/settings/organization/templates.tsx:351
 msgid "No org templates yet. Create one, import a preset, or accept a member's proposal."
 msgstr "Encara no hi ha plantilles d'organització. Crea'n una, importa una predefinida o accepta la proposta d'un membre."
 
@@ -2112,7 +2112,7 @@ msgstr "Encara no hi ha pàgines"
 msgid "No paid calls in this range."
 msgstr "No hi ha crides de pagament en aquest interval."
 
-#: src/routes/settings/organization/templates.tsx:475
+#: src/routes/settings/organization/templates.tsx:487
 msgid "No presets available."
 msgstr "No hi ha plantilles predefinides disponibles."
 
@@ -2124,7 +2124,7 @@ msgstr "No hi ha cap bústia principal."
 msgid "No products linked yet"
 msgstr "Encara sense productes vinculats"
 
-#: src/routes/settings/organization/templates.tsx:426
+#: src/routes/settings/organization/templates.tsx:438
 msgid "No proposals waiting for review."
 msgstr "No hi ha cap proposta pendent de revisió."
 
@@ -2153,7 +2153,7 @@ msgstr "Cap tasca per a avui"
 msgid "No templates added yet."
 msgstr "Encara no has afegit cap plantilla."
 
-#: src/routes/settings/profile/templates.tsx:212
+#: src/routes/settings/profile/templates.tsx:224
 msgid "No templates yet. Create one to start shaping your runs."
 msgstr "Encara no hi ha plantilles. Crea'n una per començar a guiar les teves recerques."
 
@@ -2285,21 +2285,21 @@ msgstr "Obert"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/organization/templates.tsx:308
-#: src/routes/settings/organization/templates.tsx:350
-#: src/routes/settings/profile/templates.tsx:228
+#: src/routes/settings/organization/templates.tsx:320
+#: src/routes/settings/organization/templates.tsx:362
+#: src/routes/settings/profile/templates.tsx:240
 msgid "Org"
 msgstr "Org"
 
-#: src/routes/settings/organization/templates.tsx:194
+#: src/routes/settings/organization/templates.tsx:206
 msgid "Org default saved"
 msgstr "Valor per defecte de l'organització desat"
 
-#: src/routes/settings/organization/templates.tsx:284
+#: src/routes/settings/organization/templates.tsx:296
 msgid "Org instruction templates"
 msgstr "Plantilles d'instruccions de l'organització"
 
-#: src/routes/settings/organization/templates.tsx:324
+#: src/routes/settings/organization/templates.tsx:336
 msgid "Org templates"
 msgstr "Plantilles de l'organització"
 
@@ -2310,7 +2310,7 @@ msgstr "Plantilles de l'organització"
 msgid "Organization"
 msgstr "Organització"
 
-#: src/routes/settings/organization/templates.tsx:378
+#: src/routes/settings/organization/templates.tsx:390
 msgid "Organization default"
 msgstr "Valor per defecte de l'organització"
 
@@ -2496,11 +2496,11 @@ msgstr "Pipeline"
 msgid "Plain"
 msgstr "Sense xifrar"
 
-#: src/routes/settings/organization/templates.tsx:200
-#: src/routes/settings/organization/templates.tsx:223
-#: src/routes/settings/organization/templates.tsx:240
-#: src/routes/settings/organization/templates.tsx:267
-#: src/routes/settings/profile/templates.tsx:163
+#: src/routes/settings/organization/templates.tsx:212
+#: src/routes/settings/organization/templates.tsx:235
+#: src/routes/settings/organization/templates.tsx:252
+#: src/routes/settings/organization/templates.tsx:279
+#: src/routes/settings/profile/templates.tsx:175
 msgid "Please try again."
 msgstr "Torna-ho a provar."
 
@@ -2557,7 +2557,7 @@ msgstr "Perfil"
 msgid "Proposal"
 msgstr "Proposta"
 
-#: src/routes/settings/organization/templates.tsx:236
+#: src/routes/settings/organization/templates.tsx:248
 msgid "Proposal declined"
 msgstr "Proposta rebutjada"
 
@@ -2662,12 +2662,12 @@ msgid "Remove"
 msgstr "Elimina"
 
 #. placeholder {0}: target.name
-#: src/routes/settings/organization/templates.tsx:159
+#: src/routes/settings/organization/templates.tsx:171
 msgid "Remove \"{0}\" from the org default first, then delete it."
 msgstr "Treu «{0}» del valor per defecte de l'organització primer i després elimina-la."
 
 #. placeholder {0}: target.name
-#: src/routes/settings/profile/templates.tsx:125
+#: src/routes/settings/profile/templates.tsx:137
 msgid "Remove \"{0}\" from your default first, then delete it."
 msgstr "Treu «{0}» del teu valor per defecte primer i després elimina-la."
 
@@ -2771,7 +2771,7 @@ msgstr "Reprèn esborranys ({0})"
 msgid "Resume drafting (1)"
 msgstr "Reprèn l'esborrany (1)"
 
-#: src/routes/settings/profile/templates.tsx:183
+#: src/routes/settings/profile/templates.tsx:195
 msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 msgstr "Orientació reutilitzable i permanent que segueix el teu agent de recerca: què vens, a qui t'adreces, el to i en quines fonts confiar."
 
@@ -2826,7 +2826,7 @@ msgstr "Desa la nova contrasenya"
 msgid "Save password"
 msgstr "Desa la contrasenya"
 
-#: src/routes/settings/organization/templates.tsx:413
+#: src/routes/settings/organization/templates.tsx:425
 msgid "Save the org default"
 msgstr "Desa el valor per defecte de l'organització"
 
@@ -2933,7 +2933,7 @@ msgstr "Enviant…"
 msgid "Sent"
 msgstr "Enviat"
 
-#: src/routes/settings/profile/templates.tsx:155
+#: src/routes/settings/profile/templates.tsx:167
 msgid "Sent to your admins"
 msgstr "Enviada als administradors"
 
@@ -2983,7 +2983,7 @@ msgstr "Compartida"
 msgid "Shared guidance and the org research default."
 msgstr "Orientació compartida i la recerca per defecte de l'organització."
 
-#: src/routes/settings/organization/templates.tsx:287
+#: src/routes/settings/organization/templates.tsx:299
 msgid "Shared guidance every member's research agent can use, plus the organization's default."
 msgstr "Orientació compartida que pot fer servir l'agent de recerca de cada membre, més el valor per defecte de l'organització."
 
@@ -3128,7 +3128,7 @@ msgstr "Orientació permanent que el teu agent de recerca segueix en cada recerc
 msgid "Start"
 msgstr "Inicia"
 
-#: src/routes/settings/organization/templates.tsx:466
+#: src/routes/settings/organization/templates.tsx:478
 msgid "Starter presets"
 msgstr "Plantilles predefinides per començar"
 
@@ -3151,8 +3151,8 @@ msgstr "Estat"
 msgid "Status update failed"
 msgstr "Ha fallat l'actualització d'estat"
 
-#: src/routes/settings/organization/templates.tsx:158
-#: src/routes/settings/profile/templates.tsx:124
+#: src/routes/settings/organization/templates.tsx:170
+#: src/routes/settings/profile/templates.tsx:136
 msgid "Still in use"
 msgstr "Encara s'utilitza"
 
@@ -3211,12 +3211,12 @@ msgstr "NIF"
 msgid "Template"
 msgstr "Plantilla"
 
-#: src/routes/settings/organization/templates.tsx:174
-#: src/routes/settings/profile/templates.tsx:140
+#: src/routes/settings/organization/templates.tsx:186
+#: src/routes/settings/profile/templates.tsx:152
 msgid "Template deleted"
 msgstr "Plantilla eliminada"
 
-#: src/routes/settings/profile/templates.tsx:193
+#: src/routes/settings/profile/templates.tsx:205
 msgid "Templates"
 msgstr "Plantilles"
 
@@ -3338,7 +3338,7 @@ msgstr "L'espai de treball on viuen les dades del CRM."
 msgid "These come from your organization. Saving keeps your own copy, so your runs stop following later changes to the org default."
 msgstr "Aquestes vénen de la teva organització. Si les deses, en guardes una còpia pròpia i les teves recerques deixen de seguir els canvis posteriors del valor per defecte de l'organització."
 
-#: src/routes/settings/organization/templates.tsx:381
+#: src/routes/settings/organization/templates.tsx:393
 msgid "These templates run for every member who hasn't set their own — in order. Only org templates can go here."
 msgstr "Aquestes plantilles s'apliquen, en ordre, a cada membre que no n'hagi triat de pròpies. Aquí només hi poden anar plantilles de l'organització."
 
@@ -3680,7 +3680,7 @@ msgstr "El correu encara no està verificat. Fes servir l'enllaç de sessió."
 msgid "Your keys"
 msgstr "Les teves claus"
 
-#: src/routes/settings/organization/templates.tsx:297
+#: src/routes/settings/organization/templates.tsx:309
 msgid "Your organization's admins manage these templates. You can use any of them in your own default or per run."
 msgstr "Els administradors de la teva organització gestionen aquestes plantilles. En pots fer servir qualsevol al teu valor per defecte o en cada recerca."
 
@@ -3689,6 +3689,6 @@ msgid "Your own"
 msgstr "Pròpia"
 
 #: src/components/instructions/default-stack-editor.tsx:63
-#: src/routes/settings/profile/templates.tsx:276
+#: src/routes/settings/profile/templates.tsx:288
 msgid "Your research default"
 msgstr "La teva recerca per defecte"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -30,12 +30,12 @@ msgid "\"{0}\" is waiting for an admin to add it to the organization."
 msgstr "«{0}» espera que un administrador l'afegeixi a l'organització."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/organization/templates.tsx:546
+#: src/routes/settings/organization/templates.tsx:543
 msgid "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 msgstr "S'eliminarà «{0}» per a tothom de l'organització. Això no es pot desfer."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/profile/templates.tsx:329
+#: src/routes/settings/profile/templates.tsx:326
 msgid "\"{0}\" will be removed for good. This can't be undone."
 msgstr "S'eliminarà «{0}» per sempre. Això no es pot desfer."
 
@@ -485,14 +485,13 @@ msgstr "Truca al telèfon"
 msgid "Calls"
 msgstr "Crides"
 
+#: src/components/instructions/template-delete-confirm.tsx:56
 #: src/components/instructions/template-editor-dialog.tsx:178
 #: src/components/interactions/quick-capture-dialog.tsx:400
 #: src/components/research/research-dialog.tsx:271
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
 #: src/routes/settings/api-keys/index.tsx:424
-#: src/routes/settings/organization/templates.tsx:566
-#: src/routes/settings/profile/templates.tsx:349
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -1104,10 +1103,9 @@ msgstr "Per defecte, l'adreça electrònica."
 msgid "Defaults to you when omitted."
 msgstr "Per defecte ets tu si s'omet."
 
+#: src/components/instructions/template-delete-confirm.tsx:51
 #: src/routes/emails/inboxes.tsx:1385
 #: src/routes/settings/api-keys/index.tsx:329
-#: src/routes/settings/organization/templates.tsx:561
-#: src/routes/settings/profile/templates.tsx:344
 msgid "Delete"
 msgstr "Elimina"
 
@@ -1148,18 +1146,17 @@ msgstr "Eliminar aquest peu de pàgina? Aquesta acció no es pot desfer."
 msgid "Delete this key?"
 msgstr "Vols eliminar aquesta clau?"
 
-#: src/routes/settings/organization/templates.tsx:543
+#: src/routes/settings/organization/templates.tsx:541
 msgid "Delete this org template?"
 msgstr "Vols eliminar aquesta plantilla de l'organització?"
 
-#: src/routes/settings/profile/templates.tsx:326
+#: src/routes/settings/profile/templates.tsx:324
 msgid "Delete this template?"
 msgstr "Vols eliminar aquesta plantilla?"
 
+#: src/components/instructions/template-delete-confirm.tsx:51
 #: src/routes/settings/api-keys/index.tsx:329
 #: src/routes/settings/api-keys/index.tsx:439
-#: src/routes/settings/organization/templates.tsx:561
-#: src/routes/settings/profile/templates.tsx:344
 msgid "Deleting…"
 msgstr "Eliminant…"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -25,25 +25,25 @@ msgid "— Select a company —"
 msgstr "— Select a company —"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:168
+#: src/routes/settings/profile/templates.tsx:166
 msgid "\"{0}\" is waiting for an admin to add it to the organization."
 msgstr "\"{0}\" is waiting for an admin to add it to the organization."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/organization/templates.tsx:539
+#: src/routes/settings/organization/templates.tsx:546
 msgid "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 msgstr "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/profile/templates.tsx:331
+#: src/routes/settings/profile/templates.tsx:329
 msgid "\"{0}\" will be removed for good. This can't be undone."
 msgstr "\"{0}\" will be removed for good. This can't be undone."
 
-#: src/routes/settings/organization/templates.tsx:271
+#: src/routes/settings/organization/templates.tsx:329
 msgid "\"{name}\" is now an org template you can edit."
 msgstr "\"{name}\" is now an org template you can edit."
 
-#: src/routes/settings/organization/templates.tsx:226
+#: src/routes/settings/organization/templates.tsx:290
 msgid "\"{name}\" is now an org template."
 msgstr "\"{name}\" is now an org template."
 
@@ -219,7 +219,7 @@ msgstr "Add a name and instructions before saving."
 msgid "Add a template"
 msgstr "Add a template"
 
-#: src/routes/settings/organization/templates.tsx:406
+#: src/routes/settings/organization/templates.tsx:415
 msgid "Add an org template first."
 msgstr "Add an org template first."
 
@@ -243,12 +243,12 @@ msgstr "Add task"
 msgid "Add the first decision-maker to keep track of who to reach."
 msgstr "Add the first decision-maker to keep track of who to reach."
 
-#: src/routes/settings/organization/templates.tsx:456
+#: src/routes/settings/organization/templates.tsx:465
 msgid "Add to org"
 msgstr "Add to org"
 
-#: src/routes/settings/organization/templates.tsx:225
-#: src/routes/settings/organization/templates.tsx:270
+#: src/routes/settings/organization/templates.tsx:289
+#: src/routes/settings/organization/templates.tsx:328
 msgid "Added to the org"
 msgstr "Added to the org"
 
@@ -352,7 +352,7 @@ msgstr "Audit log"
 msgid "Auth failed"
 msgstr "Auth failed"
 
-#: src/routes/settings/profile/templates.tsx:185
+#: src/routes/settings/profile/templates.tsx:183
 msgid "Back to account"
 msgstr "Back to account"
 
@@ -372,7 +372,7 @@ msgstr "Back to inbox"
 #: src/routes/settings/organization/invite.tsx:87
 #: src/routes/settings/organization/members.tsx:91
 #: src/routes/settings/organization/spend.tsx:111
-#: src/routes/settings/organization/templates.tsx:289
+#: src/routes/settings/organization/templates.tsx:102
 msgid "Back to organization"
 msgstr "Back to organization"
 
@@ -404,7 +404,7 @@ msgstr "Batuda home"
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda is invite-only. Request access from the Engranatge team."
 
-#: src/routes/settings/organization/templates.tsx:481
+#: src/routes/settings/organization/templates.tsx:490
 msgid "Batuda-written templates you can drop into the org and edit."
 msgstr "Batuda-written templates you can drop into the org and edit."
 
@@ -491,8 +491,8 @@ msgstr "Calls"
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
 #: src/routes/settings/api-keys/index.tsx:424
-#: src/routes/settings/organization/templates.tsx:559
-#: src/routes/settings/profile/templates.tsx:351
+#: src/routes/settings/organization/templates.tsx:566
+#: src/routes/settings/profile/templates.tsx:349
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel"
@@ -939,7 +939,7 @@ msgstr "Could not toggle the inbox state."
 msgid "Could not update"
 msgstr "Could not update"
 
-#: src/routes/settings/organization/templates.tsx:234
+#: src/routes/settings/organization/templates.tsx:298
 msgid "Couldn't add it"
 msgstr "Couldn't add it"
 
@@ -947,37 +947,37 @@ msgstr "Couldn't add it"
 msgid "Couldn't copy"
 msgstr "Couldn't copy"
 
-#: src/routes/settings/organization/templates.tsx:251
+#: src/routes/settings/organization/templates.tsx:312
 msgid "Couldn't decline it"
 msgstr "Couldn't decline it"
 
-#: src/routes/settings/organization/templates.tsx:180
-#: src/routes/settings/profile/templates.tsx:126
-#: src/routes/settings/profile/templates.tsx:146
+#: src/routes/settings/organization/templates.tsx:250
+#: src/routes/settings/profile/templates.tsx:127
+#: src/routes/settings/profile/templates.tsx:147
 msgid "Couldn't delete the template. Please try again."
 msgstr "Couldn't delete the template. Please try again."
 
-#: src/routes/settings/organization/templates.tsx:278
+#: src/routes/settings/organization/templates.tsx:336
 msgid "Couldn't import it"
 msgstr "Couldn't import it"
 
-#: src/routes/settings/organization/templates.tsx:400
+#: src/routes/settings/organization/templates.tsx:411
 msgid "Couldn't load the org default. Refresh to try again."
 msgstr "Couldn't load the org default. Refresh to try again."
 
-#: src/routes/settings/profile/templates.tsx:283
+#: src/routes/settings/profile/templates.tsx:281
 msgid "Couldn't load your default. Refresh to try again."
 msgstr "Couldn't load your default. Refresh to try again."
 
-#: src/routes/settings/profile/templates.tsx:220
+#: src/routes/settings/profile/templates.tsx:218
 msgid "Couldn't load your templates. Refresh to try again."
 msgstr "Couldn't load your templates. Refresh to try again."
 
-#: src/routes/settings/organization/templates.tsx:211
+#: src/routes/settings/organization/templates.tsx:278
 msgid "Couldn't save"
 msgstr "Couldn't save"
 
-#: src/routes/settings/profile/templates.tsx:174
+#: src/routes/settings/profile/templates.tsx:172
 msgid "Couldn't send it"
 msgstr "Couldn't send it"
 
@@ -1005,7 +1005,7 @@ msgstr "Create a prospect landing page from a company detail view or via the MCP
 msgid "Create a prospect landing page to share with this company."
 msgstr "Create a prospect landing page to share with this company."
 
-#: src/routes/settings/profile/templates.tsx:291
+#: src/routes/settings/profile/templates.tsx:289
 msgid "Create a template above first, then pick which ones run by default."
 msgstr "Create a template above first, then pick which ones run by default."
 
@@ -1083,7 +1083,7 @@ msgid "Decline"
 msgstr "Decline"
 
 #. placeholder {0}: d.name
-#: src/routes/settings/organization/templates.tsx:460
+#: src/routes/settings/organization/templates.tsx:469
 msgid "Decline {0}"
 msgstr "Decline {0}"
 
@@ -1106,23 +1106,23 @@ msgstr "Defaults to you when omitted."
 
 #: src/routes/emails/inboxes.tsx:1385
 #: src/routes/settings/api-keys/index.tsx:329
-#: src/routes/settings/organization/templates.tsx:554
-#: src/routes/settings/profile/templates.tsx:346
+#: src/routes/settings/organization/templates.tsx:561
+#: src/routes/settings/profile/templates.tsx:344
 msgid "Delete"
 msgstr "Delete"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:374
-#: src/routes/settings/profile/templates.tsx:265
+#: src/routes/settings/organization/templates.tsx:385
+#: src/routes/settings/profile/templates.tsx:263
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
 #: src/routes/emails/inboxes.tsx:266
 #: src/routes/emails/inboxes.tsx:1293
 #: src/routes/settings/api-keys/index.tsx:162
-#: src/routes/settings/organization/templates.tsx:179
-#: src/routes/settings/profile/templates.tsx:125
-#: src/routes/settings/profile/templates.tsx:145
+#: src/routes/settings/organization/templates.tsx:249
+#: src/routes/settings/profile/templates.tsx:126
+#: src/routes/settings/profile/templates.tsx:146
 msgid "Delete failed"
 msgstr "Delete failed"
 
@@ -1148,18 +1148,18 @@ msgstr "Delete this footer? This cannot be undone."
 msgid "Delete this key?"
 msgstr "Delete this key?"
 
-#: src/routes/settings/organization/templates.tsx:536
+#: src/routes/settings/organization/templates.tsx:543
 msgid "Delete this org template?"
 msgstr "Delete this org template?"
 
-#: src/routes/settings/profile/templates.tsx:328
+#: src/routes/settings/profile/templates.tsx:326
 msgid "Delete this template?"
 msgstr "Delete this template?"
 
 #: src/routes/settings/api-keys/index.tsx:329
 #: src/routes/settings/api-keys/index.tsx:439
-#: src/routes/settings/organization/templates.tsx:554
-#: src/routes/settings/profile/templates.tsx:346
+#: src/routes/settings/organization/templates.tsx:561
+#: src/routes/settings/profile/templates.tsx:344
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1201,7 +1201,7 @@ msgid "Documents"
 msgstr "Documents"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:249
+#: src/routes/settings/profile/templates.tsx:247
 msgid "Donate {0} to your organization"
 msgstr "Donate {0} to your organization"
 
@@ -1251,8 +1251,8 @@ msgid "Edit"
 msgstr "Edit"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:367
-#: src/routes/settings/profile/templates.tsx:258
+#: src/routes/settings/organization/templates.tsx:378
+#: src/routes/settings/profile/templates.tsx:256
 msgid "Edit {0}"
 msgstr "Edit {0}"
 
@@ -1524,7 +1524,7 @@ msgstr "IMAP port"
 msgid "IMAP security"
 msgstr "IMAP security"
 
-#: src/routes/settings/organization/templates.tsx:504
+#: src/routes/settings/organization/templates.tsx:513
 msgid "Import to org"
 msgstr "Import to org"
 
@@ -1580,7 +1580,7 @@ msgstr "Instagram"
 
 #: src/routes/settings/organization/index.tsx:141
 #: src/routes/settings/profile/index.tsx:147
-#: src/routes/settings/profile/templates.tsx:192
+#: src/routes/settings/profile/templates.tsx:190
 msgid "Instruction templates"
 msgstr "Instruction templates"
 
@@ -1859,7 +1859,7 @@ msgstr "Meetings from bookings, email invitations, and internal blocks."
 msgid "Member"
 msgstr "Member"
 
-#: src/routes/settings/organization/templates.tsx:434
+#: src/routes/settings/organization/templates.tsx:443
 msgid "Member proposals"
 msgstr "Member proposals"
 
@@ -1882,7 +1882,7 @@ msgstr "Meta"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/profile/templates.tsx:242
+#: src/routes/settings/profile/templates.tsx:240
 msgid "Mine"
 msgstr "Mine"
 
@@ -1937,7 +1937,7 @@ msgid "Never expires"
 msgstr "Never expires"
 
 #: src/components/instructions/template-editor-dialog.tsx:87
-#: src/routes/settings/organization/templates.tsx:345
+#: src/routes/settings/organization/templates.tsx:356
 msgid "New org template"
 msgstr "New org template"
 
@@ -1952,7 +1952,7 @@ msgid "New password or app-password"
 msgstr "New password or app-password"
 
 #: src/components/instructions/template-editor-dialog.tsx:89
-#: src/routes/settings/profile/templates.tsx:214
+#: src/routes/settings/profile/templates.tsx:212
 msgid "New template"
 msgstr "New template"
 
@@ -2091,11 +2091,11 @@ msgstr "No messages in this thread"
 msgid "No open tasks."
 msgstr "No open tasks."
 
-#: src/routes/settings/organization/templates.tsx:327
+#: src/routes/settings/organization/templates.tsx:145
 msgid "No org templates yet."
 msgstr "No org templates yet."
 
-#: src/routes/settings/organization/templates.tsx:351
+#: src/routes/settings/organization/templates.tsx:362
 msgid "No org templates yet. Create one, import a preset, or accept a member's proposal."
 msgstr "No org templates yet. Create one, import a preset, or accept a member's proposal."
 
@@ -2112,7 +2112,7 @@ msgstr "No pages yet"
 msgid "No paid calls in this range."
 msgstr "No paid calls in this range."
 
-#: src/routes/settings/organization/templates.tsx:487
+#: src/routes/settings/organization/templates.tsx:496
 msgid "No presets available."
 msgstr "No presets available."
 
@@ -2124,7 +2124,7 @@ msgstr "No primary inbox set."
 msgid "No products linked yet"
 msgstr "No products linked yet"
 
-#: src/routes/settings/organization/templates.tsx:438
+#: src/routes/settings/organization/templates.tsx:447
 msgid "No proposals waiting for review."
 msgstr "No proposals waiting for review."
 
@@ -2153,7 +2153,7 @@ msgstr "No tasks for today"
 msgid "No templates added yet."
 msgstr "No templates added yet."
 
-#: src/routes/settings/profile/templates.tsx:224
+#: src/routes/settings/profile/templates.tsx:222
 msgid "No templates yet. Create one to start shaping your runs."
 msgstr "No templates yet. Create one to start shaping your runs."
 
@@ -2285,21 +2285,21 @@ msgstr "Opened"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/organization/templates.tsx:320
-#: src/routes/settings/organization/templates.tsx:362
-#: src/routes/settings/profile/templates.tsx:240
+#: src/routes/settings/organization/templates.tsx:138
+#: src/routes/settings/organization/templates.tsx:373
+#: src/routes/settings/profile/templates.tsx:238
 msgid "Org"
 msgstr "Org"
 
-#: src/routes/settings/organization/templates.tsx:206
+#: src/routes/settings/organization/templates.tsx:273
 msgid "Org default saved"
 msgstr "Org default saved"
 
-#: src/routes/settings/organization/templates.tsx:296
+#: src/routes/settings/organization/templates.tsx:109
 msgid "Org instruction templates"
 msgstr "Org instruction templates"
 
-#: src/routes/settings/organization/templates.tsx:336
+#: src/routes/settings/organization/templates.tsx:347
 msgid "Org templates"
 msgstr "Org templates"
 
@@ -2310,7 +2310,7 @@ msgstr "Org templates"
 msgid "Organization"
 msgstr "Organization"
 
-#: src/routes/settings/organization/templates.tsx:390
+#: src/routes/settings/organization/templates.tsx:401
 msgid "Organization default"
 msgstr "Organization default"
 
@@ -2496,11 +2496,11 @@ msgstr "Pipeline"
 msgid "Plain"
 msgstr "Plain"
 
-#: src/routes/settings/organization/templates.tsx:212
-#: src/routes/settings/organization/templates.tsx:235
-#: src/routes/settings/organization/templates.tsx:252
 #: src/routes/settings/organization/templates.tsx:279
-#: src/routes/settings/profile/templates.tsx:175
+#: src/routes/settings/organization/templates.tsx:299
+#: src/routes/settings/organization/templates.tsx:313
+#: src/routes/settings/organization/templates.tsx:337
+#: src/routes/settings/profile/templates.tsx:173
 msgid "Please try again."
 msgstr "Please try again."
 
@@ -2557,7 +2557,7 @@ msgstr "Profile"
 msgid "Proposal"
 msgstr "Proposal"
 
-#: src/routes/settings/organization/templates.tsx:248
+#: src/routes/settings/organization/templates.tsx:309
 msgid "Proposal declined"
 msgstr "Proposal declined"
 
@@ -2662,12 +2662,12 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: target.name
-#: src/routes/settings/organization/templates.tsx:171
+#: src/routes/settings/organization/templates.tsx:241
 msgid "Remove \"{0}\" from the org default first, then delete it."
 msgstr "Remove \"{0}\" from the org default first, then delete it."
 
 #. placeholder {0}: target.name
-#: src/routes/settings/profile/templates.tsx:137
+#: src/routes/settings/profile/templates.tsx:138
 msgid "Remove \"{0}\" from your default first, then delete it."
 msgstr "Remove \"{0}\" from your default first, then delete it."
 
@@ -2771,7 +2771,7 @@ msgstr "Resume drafting ({0})"
 msgid "Resume drafting (1)"
 msgstr "Resume drafting (1)"
 
-#: src/routes/settings/profile/templates.tsx:195
+#: src/routes/settings/profile/templates.tsx:193
 msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 msgstr "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 
@@ -2826,7 +2826,7 @@ msgstr "Save new password"
 msgid "Save password"
 msgstr "Save password"
 
-#: src/routes/settings/organization/templates.tsx:425
+#: src/routes/settings/organization/templates.tsx:434
 msgid "Save the org default"
 msgstr "Save the org default"
 
@@ -2933,7 +2933,7 @@ msgstr "Sending…"
 msgid "Sent"
 msgstr "Sent"
 
-#: src/routes/settings/profile/templates.tsx:167
+#: src/routes/settings/profile/templates.tsx:165
 msgid "Sent to your admins"
 msgstr "Sent to your admins"
 
@@ -2983,7 +2983,7 @@ msgstr "Shared"
 msgid "Shared guidance and the org research default."
 msgstr "Shared guidance and the org research default."
 
-#: src/routes/settings/organization/templates.tsx:299
+#: src/routes/settings/organization/templates.tsx:112
 msgid "Shared guidance every member's research agent can use, plus the organization's default."
 msgstr "Shared guidance every member's research agent can use, plus the organization's default."
 
@@ -3128,7 +3128,7 @@ msgstr "Standing guidance your research agent follows on every run."
 msgid "Start"
 msgstr "Start"
 
-#: src/routes/settings/organization/templates.tsx:478
+#: src/routes/settings/organization/templates.tsx:487
 msgid "Starter presets"
 msgstr "Starter presets"
 
@@ -3151,8 +3151,8 @@ msgstr "Status"
 msgid "Status update failed"
 msgstr "Status update failed"
 
-#: src/routes/settings/organization/templates.tsx:170
-#: src/routes/settings/profile/templates.tsx:136
+#: src/routes/settings/organization/templates.tsx:240
+#: src/routes/settings/profile/templates.tsx:137
 msgid "Still in use"
 msgstr "Still in use"
 
@@ -3211,12 +3211,12 @@ msgstr "Tax ID"
 msgid "Template"
 msgstr "Template"
 
-#: src/routes/settings/organization/templates.tsx:186
-#: src/routes/settings/profile/templates.tsx:152
+#: src/routes/settings/organization/templates.tsx:256
+#: src/routes/settings/profile/templates.tsx:153
 msgid "Template deleted"
 msgstr "Template deleted"
 
-#: src/routes/settings/profile/templates.tsx:205
+#: src/routes/settings/profile/templates.tsx:203
 msgid "Templates"
 msgstr "Templates"
 
@@ -3338,7 +3338,7 @@ msgstr "The workspace your CRM data lives in."
 msgid "These come from your organization. Saving keeps your own copy, so your runs stop following later changes to the org default."
 msgstr "These come from your organization. Saving keeps your own copy, so your runs stop following later changes to the org default."
 
-#: src/routes/settings/organization/templates.tsx:393
+#: src/routes/settings/organization/templates.tsx:404
 msgid "These templates run for every member who hasn't set their own — in order. Only org templates can go here."
 msgstr "These templates run for every member who hasn't set their own — in order. Only org templates can go here."
 
@@ -3680,7 +3680,7 @@ msgstr "Your email isn't verified yet. Use the magic link instead."
 msgid "Your keys"
 msgstr "Your keys"
 
-#: src/routes/settings/organization/templates.tsx:309
+#: src/routes/settings/organization/templates.tsx:127
 msgid "Your organization's admins manage these templates. You can use any of them in your own default or per run."
 msgstr "Your organization's admins manage these templates. You can use any of them in your own default or per run."
 
@@ -3689,6 +3689,6 @@ msgid "Your own"
 msgstr "Your own"
 
 #: src/components/instructions/default-stack-editor.tsx:63
-#: src/routes/settings/profile/templates.tsx:288
+#: src/routes/settings/profile/templates.tsx:286
 msgid "Your research default"
 msgstr "Your research default"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -25,25 +25,25 @@ msgid "— Select a company —"
 msgstr "— Select a company —"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:156
+#: src/routes/settings/profile/templates.tsx:168
 msgid "\"{0}\" is waiting for an admin to add it to the organization."
 msgstr "\"{0}\" is waiting for an admin to add it to the organization."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/organization/templates.tsx:527
+#: src/routes/settings/organization/templates.tsx:539
 msgid "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 msgstr "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/profile/templates.tsx:319
+#: src/routes/settings/profile/templates.tsx:331
 msgid "\"{0}\" will be removed for good. This can't be undone."
 msgstr "\"{0}\" will be removed for good. This can't be undone."
 
-#: src/routes/settings/organization/templates.tsx:259
+#: src/routes/settings/organization/templates.tsx:271
 msgid "\"{name}\" is now an org template you can edit."
 msgstr "\"{name}\" is now an org template you can edit."
 
-#: src/routes/settings/organization/templates.tsx:214
+#: src/routes/settings/organization/templates.tsx:226
 msgid "\"{name}\" is now an org template."
 msgstr "\"{name}\" is now an org template."
 
@@ -219,7 +219,7 @@ msgstr "Add a name and instructions before saving."
 msgid "Add a template"
 msgstr "Add a template"
 
-#: src/routes/settings/organization/templates.tsx:394
+#: src/routes/settings/organization/templates.tsx:406
 msgid "Add an org template first."
 msgstr "Add an org template first."
 
@@ -243,12 +243,12 @@ msgstr "Add task"
 msgid "Add the first decision-maker to keep track of who to reach."
 msgstr "Add the first decision-maker to keep track of who to reach."
 
-#: src/routes/settings/organization/templates.tsx:444
+#: src/routes/settings/organization/templates.tsx:456
 msgid "Add to org"
 msgstr "Add to org"
 
-#: src/routes/settings/organization/templates.tsx:213
-#: src/routes/settings/organization/templates.tsx:258
+#: src/routes/settings/organization/templates.tsx:225
+#: src/routes/settings/organization/templates.tsx:270
 msgid "Added to the org"
 msgstr "Added to the org"
 
@@ -352,7 +352,7 @@ msgstr "Audit log"
 msgid "Auth failed"
 msgstr "Auth failed"
 
-#: src/routes/settings/profile/templates.tsx:173
+#: src/routes/settings/profile/templates.tsx:185
 msgid "Back to account"
 msgstr "Back to account"
 
@@ -372,7 +372,7 @@ msgstr "Back to inbox"
 #: src/routes/settings/organization/invite.tsx:87
 #: src/routes/settings/organization/members.tsx:91
 #: src/routes/settings/organization/spend.tsx:111
-#: src/routes/settings/organization/templates.tsx:277
+#: src/routes/settings/organization/templates.tsx:289
 msgid "Back to organization"
 msgstr "Back to organization"
 
@@ -404,7 +404,7 @@ msgstr "Batuda home"
 msgid "Batuda is invite-only. Request access from the Engranatge team."
 msgstr "Batuda is invite-only. Request access from the Engranatge team."
 
-#: src/routes/settings/organization/templates.tsx:469
+#: src/routes/settings/organization/templates.tsx:481
 msgid "Batuda-written templates you can drop into the org and edit."
 msgstr "Batuda-written templates you can drop into the org and edit."
 
@@ -491,8 +491,8 @@ msgstr "Calls"
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
 #: src/routes/settings/api-keys/index.tsx:424
-#: src/routes/settings/organization/templates.tsx:547
-#: src/routes/settings/profile/templates.tsx:339
+#: src/routes/settings/organization/templates.tsx:559
+#: src/routes/settings/profile/templates.tsx:351
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel"
@@ -939,7 +939,7 @@ msgstr "Could not toggle the inbox state."
 msgid "Could not update"
 msgstr "Could not update"
 
-#: src/routes/settings/organization/templates.tsx:222
+#: src/routes/settings/organization/templates.tsx:234
 msgid "Couldn't add it"
 msgstr "Couldn't add it"
 
@@ -947,37 +947,37 @@ msgstr "Couldn't add it"
 msgid "Couldn't copy"
 msgstr "Couldn't copy"
 
-#: src/routes/settings/organization/templates.tsx:239
+#: src/routes/settings/organization/templates.tsx:251
 msgid "Couldn't decline it"
 msgstr "Couldn't decline it"
 
-#: src/routes/settings/organization/templates.tsx:168
-#: src/routes/settings/profile/templates.tsx:114
-#: src/routes/settings/profile/templates.tsx:134
+#: src/routes/settings/organization/templates.tsx:180
+#: src/routes/settings/profile/templates.tsx:126
+#: src/routes/settings/profile/templates.tsx:146
 msgid "Couldn't delete the template. Please try again."
 msgstr "Couldn't delete the template. Please try again."
 
-#: src/routes/settings/organization/templates.tsx:266
+#: src/routes/settings/organization/templates.tsx:278
 msgid "Couldn't import it"
 msgstr "Couldn't import it"
 
-#: src/routes/settings/organization/templates.tsx:388
+#: src/routes/settings/organization/templates.tsx:400
 msgid "Couldn't load the org default. Refresh to try again."
 msgstr "Couldn't load the org default. Refresh to try again."
 
-#: src/routes/settings/profile/templates.tsx:271
+#: src/routes/settings/profile/templates.tsx:283
 msgid "Couldn't load your default. Refresh to try again."
 msgstr "Couldn't load your default. Refresh to try again."
 
-#: src/routes/settings/profile/templates.tsx:208
+#: src/routes/settings/profile/templates.tsx:220
 msgid "Couldn't load your templates. Refresh to try again."
 msgstr "Couldn't load your templates. Refresh to try again."
 
-#: src/routes/settings/organization/templates.tsx:199
+#: src/routes/settings/organization/templates.tsx:211
 msgid "Couldn't save"
 msgstr "Couldn't save"
 
-#: src/routes/settings/profile/templates.tsx:162
+#: src/routes/settings/profile/templates.tsx:174
 msgid "Couldn't send it"
 msgstr "Couldn't send it"
 
@@ -1005,7 +1005,7 @@ msgstr "Create a prospect landing page from a company detail view or via the MCP
 msgid "Create a prospect landing page to share with this company."
 msgstr "Create a prospect landing page to share with this company."
 
-#: src/routes/settings/profile/templates.tsx:279
+#: src/routes/settings/profile/templates.tsx:291
 msgid "Create a template above first, then pick which ones run by default."
 msgstr "Create a template above first, then pick which ones run by default."
 
@@ -1083,7 +1083,7 @@ msgid "Decline"
 msgstr "Decline"
 
 #. placeholder {0}: d.name
-#: src/routes/settings/organization/templates.tsx:448
+#: src/routes/settings/organization/templates.tsx:460
 msgid "Decline {0}"
 msgstr "Decline {0}"
 
@@ -1106,23 +1106,23 @@ msgstr "Defaults to you when omitted."
 
 #: src/routes/emails/inboxes.tsx:1385
 #: src/routes/settings/api-keys/index.tsx:329
-#: src/routes/settings/organization/templates.tsx:542
-#: src/routes/settings/profile/templates.tsx:334
+#: src/routes/settings/organization/templates.tsx:554
+#: src/routes/settings/profile/templates.tsx:346
 msgid "Delete"
 msgstr "Delete"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:362
-#: src/routes/settings/profile/templates.tsx:253
+#: src/routes/settings/organization/templates.tsx:374
+#: src/routes/settings/profile/templates.tsx:265
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
 #: src/routes/emails/inboxes.tsx:266
 #: src/routes/emails/inboxes.tsx:1293
 #: src/routes/settings/api-keys/index.tsx:162
-#: src/routes/settings/organization/templates.tsx:167
-#: src/routes/settings/profile/templates.tsx:113
-#: src/routes/settings/profile/templates.tsx:133
+#: src/routes/settings/organization/templates.tsx:179
+#: src/routes/settings/profile/templates.tsx:125
+#: src/routes/settings/profile/templates.tsx:145
 msgid "Delete failed"
 msgstr "Delete failed"
 
@@ -1148,18 +1148,18 @@ msgstr "Delete this footer? This cannot be undone."
 msgid "Delete this key?"
 msgstr "Delete this key?"
 
-#: src/routes/settings/organization/templates.tsx:524
+#: src/routes/settings/organization/templates.tsx:536
 msgid "Delete this org template?"
 msgstr "Delete this org template?"
 
-#: src/routes/settings/profile/templates.tsx:316
+#: src/routes/settings/profile/templates.tsx:328
 msgid "Delete this template?"
 msgstr "Delete this template?"
 
 #: src/routes/settings/api-keys/index.tsx:329
 #: src/routes/settings/api-keys/index.tsx:439
-#: src/routes/settings/organization/templates.tsx:542
-#: src/routes/settings/profile/templates.tsx:334
+#: src/routes/settings/organization/templates.tsx:554
+#: src/routes/settings/profile/templates.tsx:346
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1201,7 +1201,7 @@ msgid "Documents"
 msgstr "Documents"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/profile/templates.tsx:237
+#: src/routes/settings/profile/templates.tsx:249
 msgid "Donate {0} to your organization"
 msgstr "Donate {0} to your organization"
 
@@ -1251,8 +1251,8 @@ msgid "Edit"
 msgstr "Edit"
 
 #. placeholder {0}: row.name
-#: src/routes/settings/organization/templates.tsx:355
-#: src/routes/settings/profile/templates.tsx:246
+#: src/routes/settings/organization/templates.tsx:367
+#: src/routes/settings/profile/templates.tsx:258
 msgid "Edit {0}"
 msgstr "Edit {0}"
 
@@ -1524,7 +1524,7 @@ msgstr "IMAP port"
 msgid "IMAP security"
 msgstr "IMAP security"
 
-#: src/routes/settings/organization/templates.tsx:492
+#: src/routes/settings/organization/templates.tsx:504
 msgid "Import to org"
 msgstr "Import to org"
 
@@ -1580,7 +1580,7 @@ msgstr "Instagram"
 
 #: src/routes/settings/organization/index.tsx:141
 #: src/routes/settings/profile/index.tsx:147
-#: src/routes/settings/profile/templates.tsx:180
+#: src/routes/settings/profile/templates.tsx:192
 msgid "Instruction templates"
 msgstr "Instruction templates"
 
@@ -1859,7 +1859,7 @@ msgstr "Meetings from bookings, email invitations, and internal blocks."
 msgid "Member"
 msgstr "Member"
 
-#: src/routes/settings/organization/templates.tsx:422
+#: src/routes/settings/organization/templates.tsx:434
 msgid "Member proposals"
 msgstr "Member proposals"
 
@@ -1882,7 +1882,7 @@ msgstr "Meta"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/profile/templates.tsx:230
+#: src/routes/settings/profile/templates.tsx:242
 msgid "Mine"
 msgstr "Mine"
 
@@ -1937,7 +1937,7 @@ msgid "Never expires"
 msgstr "Never expires"
 
 #: src/components/instructions/template-editor-dialog.tsx:87
-#: src/routes/settings/organization/templates.tsx:333
+#: src/routes/settings/organization/templates.tsx:345
 msgid "New org template"
 msgstr "New org template"
 
@@ -1952,7 +1952,7 @@ msgid "New password or app-password"
 msgstr "New password or app-password"
 
 #: src/components/instructions/template-editor-dialog.tsx:89
-#: src/routes/settings/profile/templates.tsx:202
+#: src/routes/settings/profile/templates.tsx:214
 msgid "New template"
 msgstr "New template"
 
@@ -2091,11 +2091,11 @@ msgstr "No messages in this thread"
 msgid "No open tasks."
 msgstr "No open tasks."
 
-#: src/routes/settings/organization/templates.tsx:315
+#: src/routes/settings/organization/templates.tsx:327
 msgid "No org templates yet."
 msgstr "No org templates yet."
 
-#: src/routes/settings/organization/templates.tsx:339
+#: src/routes/settings/organization/templates.tsx:351
 msgid "No org templates yet. Create one, import a preset, or accept a member's proposal."
 msgstr "No org templates yet. Create one, import a preset, or accept a member's proposal."
 
@@ -2112,7 +2112,7 @@ msgstr "No pages yet"
 msgid "No paid calls in this range."
 msgstr "No paid calls in this range."
 
-#: src/routes/settings/organization/templates.tsx:475
+#: src/routes/settings/organization/templates.tsx:487
 msgid "No presets available."
 msgstr "No presets available."
 
@@ -2124,7 +2124,7 @@ msgstr "No primary inbox set."
 msgid "No products linked yet"
 msgstr "No products linked yet"
 
-#: src/routes/settings/organization/templates.tsx:426
+#: src/routes/settings/organization/templates.tsx:438
 msgid "No proposals waiting for review."
 msgstr "No proposals waiting for review."
 
@@ -2153,7 +2153,7 @@ msgstr "No tasks for today"
 msgid "No templates added yet."
 msgstr "No templates added yet."
 
-#: src/routes/settings/profile/templates.tsx:212
+#: src/routes/settings/profile/templates.tsx:224
 msgid "No templates yet. Create one to start shaping your runs."
 msgstr "No templates yet. Create one to start shaping your runs."
 
@@ -2285,21 +2285,21 @@ msgstr "Opened"
 
 #: src/components/instructions/stack-picker.tsx:108
 #: src/components/instructions/stack-picker.tsx:159
-#: src/routes/settings/organization/templates.tsx:308
-#: src/routes/settings/organization/templates.tsx:350
-#: src/routes/settings/profile/templates.tsx:228
+#: src/routes/settings/organization/templates.tsx:320
+#: src/routes/settings/organization/templates.tsx:362
+#: src/routes/settings/profile/templates.tsx:240
 msgid "Org"
 msgstr "Org"
 
-#: src/routes/settings/organization/templates.tsx:194
+#: src/routes/settings/organization/templates.tsx:206
 msgid "Org default saved"
 msgstr "Org default saved"
 
-#: src/routes/settings/organization/templates.tsx:284
+#: src/routes/settings/organization/templates.tsx:296
 msgid "Org instruction templates"
 msgstr "Org instruction templates"
 
-#: src/routes/settings/organization/templates.tsx:324
+#: src/routes/settings/organization/templates.tsx:336
 msgid "Org templates"
 msgstr "Org templates"
 
@@ -2310,7 +2310,7 @@ msgstr "Org templates"
 msgid "Organization"
 msgstr "Organization"
 
-#: src/routes/settings/organization/templates.tsx:378
+#: src/routes/settings/organization/templates.tsx:390
 msgid "Organization default"
 msgstr "Organization default"
 
@@ -2496,11 +2496,11 @@ msgstr "Pipeline"
 msgid "Plain"
 msgstr "Plain"
 
-#: src/routes/settings/organization/templates.tsx:200
-#: src/routes/settings/organization/templates.tsx:223
-#: src/routes/settings/organization/templates.tsx:240
-#: src/routes/settings/organization/templates.tsx:267
-#: src/routes/settings/profile/templates.tsx:163
+#: src/routes/settings/organization/templates.tsx:212
+#: src/routes/settings/organization/templates.tsx:235
+#: src/routes/settings/organization/templates.tsx:252
+#: src/routes/settings/organization/templates.tsx:279
+#: src/routes/settings/profile/templates.tsx:175
 msgid "Please try again."
 msgstr "Please try again."
 
@@ -2557,7 +2557,7 @@ msgstr "Profile"
 msgid "Proposal"
 msgstr "Proposal"
 
-#: src/routes/settings/organization/templates.tsx:236
+#: src/routes/settings/organization/templates.tsx:248
 msgid "Proposal declined"
 msgstr "Proposal declined"
 
@@ -2662,12 +2662,12 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: target.name
-#: src/routes/settings/organization/templates.tsx:159
+#: src/routes/settings/organization/templates.tsx:171
 msgid "Remove \"{0}\" from the org default first, then delete it."
 msgstr "Remove \"{0}\" from the org default first, then delete it."
 
 #. placeholder {0}: target.name
-#: src/routes/settings/profile/templates.tsx:125
+#: src/routes/settings/profile/templates.tsx:137
 msgid "Remove \"{0}\" from your default first, then delete it."
 msgstr "Remove \"{0}\" from your default first, then delete it."
 
@@ -2771,7 +2771,7 @@ msgstr "Resume drafting ({0})"
 msgid "Resume drafting (1)"
 msgstr "Resume drafting (1)"
 
-#: src/routes/settings/profile/templates.tsx:183
+#: src/routes/settings/profile/templates.tsx:195
 msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 msgstr "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 
@@ -2826,7 +2826,7 @@ msgstr "Save new password"
 msgid "Save password"
 msgstr "Save password"
 
-#: src/routes/settings/organization/templates.tsx:413
+#: src/routes/settings/organization/templates.tsx:425
 msgid "Save the org default"
 msgstr "Save the org default"
 
@@ -2933,7 +2933,7 @@ msgstr "Sending…"
 msgid "Sent"
 msgstr "Sent"
 
-#: src/routes/settings/profile/templates.tsx:155
+#: src/routes/settings/profile/templates.tsx:167
 msgid "Sent to your admins"
 msgstr "Sent to your admins"
 
@@ -2983,7 +2983,7 @@ msgstr "Shared"
 msgid "Shared guidance and the org research default."
 msgstr "Shared guidance and the org research default."
 
-#: src/routes/settings/organization/templates.tsx:287
+#: src/routes/settings/organization/templates.tsx:299
 msgid "Shared guidance every member's research agent can use, plus the organization's default."
 msgstr "Shared guidance every member's research agent can use, plus the organization's default."
 
@@ -3128,7 +3128,7 @@ msgstr "Standing guidance your research agent follows on every run."
 msgid "Start"
 msgstr "Start"
 
-#: src/routes/settings/organization/templates.tsx:466
+#: src/routes/settings/organization/templates.tsx:478
 msgid "Starter presets"
 msgstr "Starter presets"
 
@@ -3151,8 +3151,8 @@ msgstr "Status"
 msgid "Status update failed"
 msgstr "Status update failed"
 
-#: src/routes/settings/organization/templates.tsx:158
-#: src/routes/settings/profile/templates.tsx:124
+#: src/routes/settings/organization/templates.tsx:170
+#: src/routes/settings/profile/templates.tsx:136
 msgid "Still in use"
 msgstr "Still in use"
 
@@ -3211,12 +3211,12 @@ msgstr "Tax ID"
 msgid "Template"
 msgstr "Template"
 
-#: src/routes/settings/organization/templates.tsx:174
-#: src/routes/settings/profile/templates.tsx:140
+#: src/routes/settings/organization/templates.tsx:186
+#: src/routes/settings/profile/templates.tsx:152
 msgid "Template deleted"
 msgstr "Template deleted"
 
-#: src/routes/settings/profile/templates.tsx:193
+#: src/routes/settings/profile/templates.tsx:205
 msgid "Templates"
 msgstr "Templates"
 
@@ -3338,7 +3338,7 @@ msgstr "The workspace your CRM data lives in."
 msgid "These come from your organization. Saving keeps your own copy, so your runs stop following later changes to the org default."
 msgstr "These come from your organization. Saving keeps your own copy, so your runs stop following later changes to the org default."
 
-#: src/routes/settings/organization/templates.tsx:381
+#: src/routes/settings/organization/templates.tsx:393
 msgid "These templates run for every member who hasn't set their own — in order. Only org templates can go here."
 msgstr "These templates run for every member who hasn't set their own — in order. Only org templates can go here."
 
@@ -3680,7 +3680,7 @@ msgstr "Your email isn't verified yet. Use the magic link instead."
 msgid "Your keys"
 msgstr "Your keys"
 
-#: src/routes/settings/organization/templates.tsx:297
+#: src/routes/settings/organization/templates.tsx:309
 msgid "Your organization's admins manage these templates. You can use any of them in your own default or per run."
 msgstr "Your organization's admins manage these templates. You can use any of them in your own default or per run."
 
@@ -3689,6 +3689,6 @@ msgid "Your own"
 msgstr "Your own"
 
 #: src/components/instructions/default-stack-editor.tsx:63
-#: src/routes/settings/profile/templates.tsx:276
+#: src/routes/settings/profile/templates.tsx:288
 msgid "Your research default"
 msgstr "Your research default"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -30,12 +30,12 @@ msgid "\"{0}\" is waiting for an admin to add it to the organization."
 msgstr "\"{0}\" is waiting for an admin to add it to the organization."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/organization/templates.tsx:546
+#: src/routes/settings/organization/templates.tsx:543
 msgid "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 msgstr "\"{0}\" will be removed for everyone in the organization. This can't be undone."
 
 #. placeholder {0}: confirmTarget?.name ?? ''
-#: src/routes/settings/profile/templates.tsx:329
+#: src/routes/settings/profile/templates.tsx:326
 msgid "\"{0}\" will be removed for good. This can't be undone."
 msgstr "\"{0}\" will be removed for good. This can't be undone."
 
@@ -485,14 +485,13 @@ msgstr "Call phone"
 msgid "Calls"
 msgstr "Calls"
 
+#: src/components/instructions/template-delete-confirm.tsx:56
 #: src/components/instructions/template-editor-dialog.tsx:178
 #: src/components/interactions/quick-capture-dialog.tsx:400
 #: src/components/research/research-dialog.tsx:271
 #: src/routes/emails/inboxes.tsx:1055
 #: src/routes/emails/inboxes.tsx:1453
 #: src/routes/settings/api-keys/index.tsx:424
-#: src/routes/settings/organization/templates.tsx:566
-#: src/routes/settings/profile/templates.tsx:349
 #: src/routes/tasks/index.tsx:718
 msgid "Cancel"
 msgstr "Cancel"
@@ -1104,10 +1103,9 @@ msgstr "Defaults to the email address."
 msgid "Defaults to you when omitted."
 msgstr "Defaults to you when omitted."
 
+#: src/components/instructions/template-delete-confirm.tsx:51
 #: src/routes/emails/inboxes.tsx:1385
 #: src/routes/settings/api-keys/index.tsx:329
-#: src/routes/settings/organization/templates.tsx:561
-#: src/routes/settings/profile/templates.tsx:344
 msgid "Delete"
 msgstr "Delete"
 
@@ -1148,18 +1146,17 @@ msgstr "Delete this footer? This cannot be undone."
 msgid "Delete this key?"
 msgstr "Delete this key?"
 
-#: src/routes/settings/organization/templates.tsx:543
+#: src/routes/settings/organization/templates.tsx:541
 msgid "Delete this org template?"
 msgstr "Delete this org template?"
 
-#: src/routes/settings/profile/templates.tsx:326
+#: src/routes/settings/profile/templates.tsx:324
 msgid "Delete this template?"
 msgstr "Delete this template?"
 
+#: src/components/instructions/template-delete-confirm.tsx:51
 #: src/routes/settings/api-keys/index.tsx:329
 #: src/routes/settings/api-keys/index.tsx:439
-#: src/routes/settings/organization/templates.tsx:561
-#: src/routes/settings/profile/templates.tsx:344
 msgid "Deleting…"
 msgstr "Deleting…"
 

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -76,14 +76,96 @@ export const Route = createFileRoute('/settings/organization/templates')({
 })
 
 function OrgTemplatesPage() {
-	const { t } = useLingui()
-	const toast = usePriToast()
 	const activeMember = authClient.useActiveMember()
 	const role = activeMember.data?.role ?? null
 	const isAdmin = role === 'owner' || role === 'admin'
 
 	const templatesResult = useAtomValue(instructionTemplatesAtom)
 	const refreshTemplates = useAtomRefresh(instructionTemplatesAtom)
+
+	// Org-owned templates are the ones with no personal owner.
+	const orgTemplates = useMemo<ReadonlyArray<TemplateShape>>(
+		() =>
+			AsyncResult.isSuccess(templatesResult)
+				? narrowTemplates(templatesResult.value).filter(
+						x => x.ownerUserId === null,
+					)
+				: [],
+		[templatesResult],
+	)
+
+	return (
+		<Page>
+			<BackLink to='/settings/organization'>
+				<ArrowLeft size={14} aria-hidden />
+				<span>
+					<Trans>Back to organization</Trans>
+				</span>
+			</BackLink>
+
+			<Intro>
+				<Heading>
+					<ScrollText size={20} aria-hidden />
+					<Trans>Org instruction templates</Trans>
+				</Heading>
+				<Subtitle>
+					<Trans>
+						Shared guidance every member's research agent can use, plus the
+						organization's default.
+					</Trans>
+				</Subtitle>
+			</Intro>
+
+			{isAdmin ? (
+				<OrgTemplateAdmin
+					orgTemplates={orgTemplates}
+					refreshTemplates={refreshTemplates}
+				/>
+			) : (
+				<Section>
+					<Hint role='note'>
+						<Trans>
+							Your organization's admins manage these templates. You can use any
+							of them in your own default or per run.
+						</Trans>
+					</Hint>
+					{orgTemplates.length > 0 ? (
+						<TemplateList>
+							{orgTemplates.map(row => (
+								<TemplateRowItem key={row.id} data-testid='org-template-row'>
+									<TemplateName>{row.name}</TemplateName>
+									<OwnerBadge>
+										<Trans>Org</Trans>
+									</OwnerBadge>
+								</TemplateRowItem>
+							))}
+						</TemplateList>
+					) : (
+						<Empty>
+							<Trans>No org templates yet.</Trans>
+						</Empty>
+					)}
+				</Section>
+			)}
+		</Page>
+	)
+}
+
+// The admin half of the org templates page: managing org templates, the org
+// default stack, the donation review queue, and preset import. It's mounted
+// only for owners/admins, so its donation, preset, and stack queries never
+// fire for a regular member — who can't act on that data anyway, since every
+// org write is admin-gated on the server.
+function OrgTemplateAdmin({
+	orgTemplates,
+	refreshTemplates,
+}: {
+	readonly orgTemplates: ReadonlyArray<TemplateShape>
+	readonly refreshTemplates: () => void
+}) {
+	const { t } = useLingui()
+	const toast = usePriToast()
+
 	const donationsResult = useAtomValue(instructionDonationsAtom)
 	const refreshDonations = useAtomRefresh(instructionDonationsAtom)
 	const presetsResult = useAtomValue(instructionPresetsAtom)
@@ -97,16 +179,6 @@ function OrgTemplatesPage() {
 	const rejectDonation = useAtomSet(rejectDonationAtom, { mode: 'promiseExit' })
 	const importPreset = useAtomSet(importPresetAtom, { mode: 'promiseExit' })
 
-	// Org-owned templates are the ones with no personal owner.
-	const orgTemplates = useMemo<ReadonlyArray<TemplateShape>>(
-		() =>
-			AsyncResult.isSuccess(templatesResult)
-				? narrowTemplates(templatesResult.value).filter(
-						x => x.ownerUserId === null,
-					)
-				: [],
-		[templatesResult],
-	)
 	const pendingDonations = useMemo(
 		() =>
 			AsyncResult.isSuccess(donationsResult)
@@ -268,236 +340,185 @@ function OrgTemplatesPage() {
 	}
 
 	return (
-		<Page>
-			<BackLink to='/settings/organization'>
-				<ArrowLeft size={14} aria-hidden />
-				<span>
-					<Trans>Back to organization</Trans>
-				</span>
-			</BackLink>
+		<>
+			<Section>
+				<SectionHead>
+					<SectionTitle>
+						<Trans>Org templates</Trans>
+					</SectionTitle>
+					<PriButton
+						type='button'
+						$variant='filled'
+						data-testid='org-templates-new'
+						onClick={openCreate}
+					>
+						<Plus size={16} aria-hidden />
+						<Trans>New org template</Trans>
+					</PriButton>
+				</SectionHead>
 
-			<Intro>
-				<Heading>
-					<ScrollText size={20} aria-hidden />
-					<Trans>Org instruction templates</Trans>
-				</Heading>
-				<Subtitle>
-					<Trans>
-						Shared guidance every member's research agent can use, plus the
-						organization's default.
-					</Trans>
-				</Subtitle>
-			</Intro>
-
-			{!isAdmin ? (
-				<Section>
-					<Hint role='note'>
+				{orgTemplates.length === 0 ? (
+					<Empty>
 						<Trans>
-							Your organization's admins manage these templates. You can use any
-							of them in your own default or per run.
+							No org templates yet. Create one, import a preset, or accept a
+							member's proposal.
 						</Trans>
-					</Hint>
-					{orgTemplates.length > 0 ? (
-						<TemplateList>
-							{orgTemplates.map(row => (
-								<TemplateRowItem key={row.id} data-testid='org-template-row'>
-									<TemplateName>{row.name}</TemplateName>
-									<OwnerBadge>
-										<Trans>Org</Trans>
-									</OwnerBadge>
-								</TemplateRowItem>
-							))}
-						</TemplateList>
-					) : (
-						<Empty>
-							<Trans>No org templates yet.</Trans>
-						</Empty>
-					)}
-				</Section>
-			) : (
-				<>
-					<Section>
-						<SectionHead>
-							<SectionTitle>
-								<Trans>Org templates</Trans>
-							</SectionTitle>
+					</Empty>
+				) : (
+					<TemplateList>
+						{orgTemplates.map(row => (
+							<TemplateRowItem key={row.id} data-testid='org-template-row'>
+								<TemplateName>{row.name}</TemplateName>
+								<OwnerBadge>
+									<Trans>Org</Trans>
+								</OwnerBadge>
+								<RowActions>
+									<InstructionIconButton
+										type='button'
+										aria-label={t`Edit ${row.name}`}
+										onClick={() => openEdit(row)}
+									>
+										<Pencil size={14} aria-hidden />
+									</InstructionIconButton>
+									<InstructionIconButton
+										type='button'
+										aria-label={t`Delete ${row.name}`}
+										onClick={() =>
+											setConfirmTarget({ id: row.id, name: row.name })
+										}
+									>
+										<Trash2 size={14} aria-hidden />
+									</InstructionIconButton>
+								</RowActions>
+							</TemplateRowItem>
+						))}
+					</TemplateList>
+				)}
+			</Section>
+
+			<Section data-testid='org-default-stack'>
+				<SectionTitle>
+					<Trans>Organization default</Trans>
+				</SectionTitle>
+				<Hint>
+					<Trans>
+						These templates run for every member who hasn't set their own — in
+						order. Only org templates can go here.
+					</Trans>
+				</Hint>
+				{stacksFailed ? (
+					<Notice role='alert'>
+						<Trans>Couldn't load the org default. Refresh to try again.</Trans>
+					</Notice>
+				) : orgTemplates.length === 0 ? (
+					<Empty>
+						<Trans>Add an org template first.</Trans>
+					</Empty>
+				) : (
+					<>
+						<StackPicker
+							options={stackOptions}
+							selectedIds={effectiveStack}
+							onChange={setStackIds}
+						/>
+						<Actions>
 							<PriButton
 								type='button'
 								$variant='filled'
-								data-testid='org-templates-new'
-								onClick={openCreate}
+								data-testid='org-default-save'
+								disabled={savingStack || effectiveStack.length === 0}
+								onClick={() => {
+									void saveStack()
+								}}
 							>
-								<Plus size={16} aria-hidden />
-								<Trans>New org template</Trans>
+								<Trans>Save the org default</Trans>
 							</PriButton>
-						</SectionHead>
+						</Actions>
+					</>
+				)}
+			</Section>
 
-						{orgTemplates.length === 0 ? (
-							<Empty>
-								<Trans>
-									No org templates yet. Create one, import a preset, or accept a
-									member's proposal.
-								</Trans>
-							</Empty>
-						) : (
-							<TemplateList>
-								{orgTemplates.map(row => (
-									<TemplateRowItem key={row.id} data-testid='org-template-row'>
-										<TemplateName>{row.name}</TemplateName>
-										<OwnerBadge>
-											<Trans>Org</Trans>
-										</OwnerBadge>
-										<RowActions>
-											<InstructionIconButton
-												type='button'
-												aria-label={t`Edit ${row.name}`}
-												onClick={() => openEdit(row)}
-											>
-												<Pencil size={14} aria-hidden />
-											</InstructionIconButton>
-											<InstructionIconButton
-												type='button'
-												aria-label={t`Delete ${row.name}`}
-												onClick={() =>
-													setConfirmTarget({ id: row.id, name: row.name })
-												}
-											>
-												<Trash2 size={14} aria-hidden />
-											</InstructionIconButton>
-										</RowActions>
-									</TemplateRowItem>
-								))}
-							</TemplateList>
-						)}
-					</Section>
+			<Section>
+				<SectionTitle>
+					<Trans>Member proposals</Trans>
+				</SectionTitle>
+				{pendingDonations.length === 0 ? (
+					<Empty>
+						<Trans>No proposals waiting for review.</Trans>
+					</Empty>
+				) : (
+					<ReviewList>
+						{pendingDonations.map(d => (
+							<ReviewItem key={d.id} data-testid='donation-row'>
+								<ReviewHead>
+									<TemplateName>{d.name}</TemplateName>
+									<ReviewActions>
+										<PriButton
+											type='button'
+											$variant='filled'
+											data-testid='donation-accept'
+											onClick={() => {
+												void accept(d.id, d.name)
+											}}
+										>
+											<Check size={14} aria-hidden />
+											<Trans>Add to org</Trans>
+										</PriButton>
+										<InstructionIconButton
+											type='button'
+											aria-label={t`Decline ${d.name}`}
+											onClick={() => {
+												void reject(d.id)
+											}}
+										>
+											<X size={14} aria-hidden />
+										</InstructionIconButton>
+									</ReviewActions>
+								</ReviewHead>
+								<BodyPreview>{preview(d.body)}</BodyPreview>
+							</ReviewItem>
+						))}
+					</ReviewList>
+				)}
+			</Section>
 
-					<Section data-testid='org-default-stack'>
-						<SectionTitle>
-							<Trans>Organization default</Trans>
-						</SectionTitle>
-						<Hint>
-							<Trans>
-								These templates run for every member who hasn't set their own —
-								in order. Only org templates can go here.
-							</Trans>
-						</Hint>
-						{stacksFailed ? (
-							<Notice role='alert'>
-								<Trans>
-									Couldn't load the org default. Refresh to try again.
-								</Trans>
-							</Notice>
-						) : orgTemplates.length === 0 ? (
-							<Empty>
-								<Trans>Add an org template first.</Trans>
-							</Empty>
-						) : (
-							<>
-								<StackPicker
-									options={stackOptions}
-									selectedIds={effectiveStack}
-									onChange={setStackIds}
-								/>
-								<Actions>
+			<Section>
+				<SectionTitle>
+					<Trans>Starter presets</Trans>
+				</SectionTitle>
+				<Hint>
+					<Trans>
+						Batuda-written templates you can drop into the org and edit.
+					</Trans>
+				</Hint>
+				{presets.length === 0 ? (
+					<Empty>
+						<Trans>No presets available.</Trans>
+					</Empty>
+				) : (
+					<ReviewList>
+						{presets.map(p => (
+							<ReviewItem key={p.id} data-testid='preset-row'>
+								<ReviewHead>
+									<TemplateName>{p.name}</TemplateName>
 									<PriButton
 										type='button'
-										$variant='filled'
-										data-testid='org-default-save'
-										disabled={savingStack || effectiveStack.length === 0}
+										$variant='outlined'
+										data-testid='preset-import'
 										onClick={() => {
-											void saveStack()
+											void importToOrg(p.id, p.name)
 										}}
 									>
-										<Trans>Save the org default</Trans>
+										<Download size={14} aria-hidden />
+										<Trans>Import to org</Trans>
 									</PriButton>
-								</Actions>
-							</>
-						)}
-					</Section>
-
-					<Section>
-						<SectionTitle>
-							<Trans>Member proposals</Trans>
-						</SectionTitle>
-						{pendingDonations.length === 0 ? (
-							<Empty>
-								<Trans>No proposals waiting for review.</Trans>
-							</Empty>
-						) : (
-							<ReviewList>
-								{pendingDonations.map(d => (
-									<ReviewItem key={d.id} data-testid='donation-row'>
-										<ReviewHead>
-											<TemplateName>{d.name}</TemplateName>
-											<ReviewActions>
-												<PriButton
-													type='button'
-													$variant='filled'
-													data-testid='donation-accept'
-													onClick={() => {
-														void accept(d.id, d.name)
-													}}
-												>
-													<Check size={14} aria-hidden />
-													<Trans>Add to org</Trans>
-												</PriButton>
-												<InstructionIconButton
-													type='button'
-													aria-label={t`Decline ${d.name}`}
-													onClick={() => {
-														void reject(d.id)
-													}}
-												>
-													<X size={14} aria-hidden />
-												</InstructionIconButton>
-											</ReviewActions>
-										</ReviewHead>
-										<BodyPreview>{preview(d.body)}</BodyPreview>
-									</ReviewItem>
-								))}
-							</ReviewList>
-						)}
-					</Section>
-
-					<Section>
-						<SectionTitle>
-							<Trans>Starter presets</Trans>
-						</SectionTitle>
-						<Hint>
-							<Trans>
-								Batuda-written templates you can drop into the org and edit.
-							</Trans>
-						</Hint>
-						{presets.length === 0 ? (
-							<Empty>
-								<Trans>No presets available.</Trans>
-							</Empty>
-						) : (
-							<ReviewList>
-								{presets.map(p => (
-									<ReviewItem key={p.id} data-testid='preset-row'>
-										<ReviewHead>
-											<TemplateName>{p.name}</TemplateName>
-											<PriButton
-												type='button'
-												$variant='outlined'
-												data-testid='preset-import'
-												onClick={() => {
-													void importToOrg(p.id, p.name)
-												}}
-											>
-												<Download size={14} aria-hidden />
-												<Trans>Import to org</Trans>
-											</PriButton>
-										</ReviewHead>
-										<BodyPreview>{preview(p.body)}</BodyPreview>
-									</ReviewItem>
-								))}
-							</ReviewList>
-						)}
-					</Section>
-				</>
-			)}
+								</ReviewHead>
+								<BodyPreview>{preview(p.body)}</BodyPreview>
+							</ReviewItem>
+						))}
+					</ReviewList>
+				)}
+			</Section>
 
 			<TemplateEditorDialog
 				open={dialogOpen}
@@ -550,7 +571,7 @@ function OrgTemplatesPage() {
 					</PriDialog.Popup>
 				</PriDialog.Portal>
 			</PriDialog.Root>
-		</Page>
+		</>
 	)
 }
 

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -1,6 +1,6 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import {
 	ArrowLeft,
@@ -33,6 +33,23 @@ import {
 	OwnerBadge,
 } from '#/components/instructions/instruction-chrome'
 import {
+	BackLink,
+	DialogActions,
+	Empty,
+	Heading,
+	Intro,
+	Notice,
+	Page,
+	RowActions,
+	Section,
+	SectionHead,
+	SectionTitle,
+	Subtitle,
+	TemplateList,
+	TemplateName,
+	TemplateRowItem,
+} from '#/components/instructions/instruction-page-chrome'
+import {
 	narrowDonations,
 	narrowPresets,
 	narrowStackIds,
@@ -48,12 +65,7 @@ import {
 	TemplateEditorDialog,
 } from '#/components/instructions/template-editor-dialog'
 import { authClient } from '#/lib/auth-client'
-import {
-	brushedMetalPlate,
-	ruledLedgerRow,
-	rulerUnderRule,
-	stenciledTitle,
-} from '#/lib/workshop-mixins'
+import { ruledLedgerRow } from '#/lib/workshop-mixins'
 
 const AGENT = 'research'
 
@@ -293,12 +305,12 @@ function OrgTemplatesPage() {
 
 			{!isAdmin ? (
 				<Section>
-					<Notice role='note'>
+					<Hint role='note'>
 						<Trans>
 							Your organization's admins manage these templates. You can use any
 							of them in your own default or per run.
 						</Trans>
-					</Notice>
+					</Hint>
 					{orgTemplates.length > 0 ? (
 						<TemplateList>
 							{orgTemplates.map(row => (
@@ -373,7 +385,7 @@ function OrgTemplatesPage() {
 						)}
 					</Section>
 
-					<Card data-testid='org-default-stack'>
+					<Section data-testid='org-default-stack'>
 						<SectionTitle>
 							<Trans>Organization default</Trans>
 						</SectionTitle>
@@ -415,7 +427,7 @@ function OrgTemplatesPage() {
 								</Actions>
 							</>
 						)}
-					</Card>
+					</Section>
 
 					<Section>
 						<SectionTitle>
@@ -561,128 +573,11 @@ function preview(body: string): string {
 	return flat.length > 140 ? `${flat.slice(0, 140)}…` : flat
 }
 
-const Page = styled.div`
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-lg);
-`
-
-const BackLink = styled(Link)`
-	display: inline-flex;
-	gap: var(--space-2xs);
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-medium-size);
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	color: var(--color-on-surface-variant);
-	text-decoration: none;
-
-	&:hover {
-		color: var(--color-on-surface);
-	}
-
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
-	}
-`
-
-const Intro = styled.div`
-	${rulerUnderRule}
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-2xs);
-	padding-bottom: var(--space-xs);
-`
-
-const Heading = styled.h2`
-	${stenciledTitle}
-	display: inline-flex;
-	align-items: center;
-	gap: var(--space-2xs);
-	font-size: var(--typescale-headline-large-size);
-	line-height: var(--typescale-headline-large-line);
-	margin: 0;
-`
-
-const Subtitle = styled.p`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-large-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-	margin: 0;
-	max-width: 46rem;
-`
-
-const Section = styled.section`
-	${brushedMetalPlate}
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-sm);
-	padding: var(--space-md);
-	border-radius: var(--shape-2xs);
-`
-
-const Card = styled.section`
-	${brushedMetalPlate}
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-sm);
-	padding: var(--space-md);
-	border-radius: var(--shape-2xs);
-`
-
-const SectionHead = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: var(--space-sm);
-`
-
-const SectionTitle = styled.h3`
-	${stenciledTitle}
-	font-size: var(--typescale-title-medium-size);
-	line-height: var(--typescale-title-medium-line);
-	margin: 0;
-`
-
 const Hint = styled.p`
 	font-family: var(--font-body);
 	font-size: var(--typescale-body-small-size);
 	color: var(--color-on-surface-variant);
 	margin: 0;
-`
-
-const TemplateList = styled.ul`
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-2xs);
-`
-
-const TemplateRowItem = styled.li`
-	${ruledLedgerRow}
-	display: flex;
-	align-items: center;
-	gap: var(--space-sm);
-	padding: var(--space-2xs) 0;
-`
-
-const TemplateName = styled.span`
-	flex: 1 1 auto;
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-medium-size);
-	color: var(--color-on-surface);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-`
-
-const RowActions = styled.div`
-	display: inline-flex;
-	gap: var(--space-2xs);
 `
 
 const ReviewList = styled.ul`
@@ -725,26 +620,4 @@ const BodyPreview = styled.p`
 const Actions = styled.div`
 	display: flex;
 	gap: var(--space-sm);
-`
-
-const Empty = styled.p`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-medium-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-	margin: 0;
-`
-
-const Notice = styled.p`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-small-size);
-	color: var(--color-on-surface-variant);
-	margin: 0;
-`
-
-const DialogActions = styled.div`
-	display: flex;
-	gap: var(--space-sm);
-	justify-content: flex-end;
-	margin-top: var(--space-md);
 `

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -15,7 +15,7 @@ import {
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
-import { PriButton, PriDialog, usePriToast } from '@batuda/ui/pri'
+import { PriButton, usePriToast } from '@batuda/ui/pri'
 
 import {
 	acceptDonationAtom,
@@ -34,7 +34,6 @@ import {
 } from '#/components/instructions/instruction-chrome'
 import {
 	BackLink,
-	DialogActions,
 	Empty,
 	Heading,
 	Intro,
@@ -61,6 +60,7 @@ import {
 	type StackOption,
 	StackPicker,
 } from '#/components/instructions/stack-picker'
+import { TemplateDeleteConfirm } from '#/components/instructions/template-delete-confirm'
 import {
 	type TemplateDraft,
 	TemplateEditorDialog,
@@ -530,47 +530,22 @@ function OrgTemplateAdmin({
 				}}
 			/>
 
-			<PriDialog.Root
+			<TemplateDeleteConfirm
 				open={confirmTarget !== null}
-				onOpenChange={(nextOpen: boolean) => {
-					if (!nextOpen && !deleting) setConfirmTarget(null)
+				deleting={deleting}
+				onConfirm={() => {
+					void confirmDelete()
 				}}
-			>
-				<PriDialog.Portal>
-					<PriDialog.Backdrop />
-					<PriDialog.Popup data-testid='org-template-delete-confirm'>
-						<PriDialog.Title>
-							<Trans>Delete this org template?</Trans>
-						</PriDialog.Title>
-						<PriDialog.Description>
-							<Trans>
-								"{confirmTarget?.name ?? ''}" will be removed for everyone in
-								the organization. This can't be undone.
-							</Trans>
-						</PriDialog.Description>
-						<DialogActions>
-							<PriButton
-								type='button'
-								$variant='filled'
-								data-testid='org-template-delete-confirm-button'
-								disabled={deleting}
-								onClick={() => {
-									void confirmDelete()
-								}}
-							>
-								{deleting ? <Trans>Deleting…</Trans> : <Trans>Delete</Trans>}
-							</PriButton>
-							<PriDialog.Close
-								render={props => (
-									<PriButton type='button' $variant='text' {...props}>
-										<Trans>Cancel</Trans>
-									</PriButton>
-								)}
-							/>
-						</DialogActions>
-					</PriDialog.Popup>
-				</PriDialog.Portal>
-			</PriDialog.Root>
+				onClose={() => setConfirmTarget(null)}
+				testId='org-template-delete-confirm'
+				title={<Trans>Delete this org template?</Trans>}
+				description={
+					<Trans>
+						"{confirmTarget?.name ?? ''}" will be removed for everyone in the
+						organization. This can't be undone.
+					</Trans>
+				}
+			/>
 		</>
 	)
 }

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -54,6 +54,7 @@ import {
 	narrowPresets,
 	narrowStackIds,
 	narrowTemplates,
+	outcomeOf,
 	type TemplateShape,
 } from '#/components/instructions/instruction-shapes'
 import {
@@ -161,10 +162,7 @@ function OrgTemplatesPage() {
 		const exit = await deleteTemplate({ params: { id: target.id } } as never)
 		setDeleting(false)
 		setConfirmTarget(null)
-		const outcome =
-			exit._tag === 'Success'
-				? (exit.value as { outcome?: string } | null)?.outcome
-				: null
+		const outcome = outcomeOf(exit)
 		if (outcome === 'in_use') {
 			toast.add({
 				title: t`Still in use`,
@@ -198,10 +196,7 @@ function OrgTemplatesPage() {
 			payload: { template_ids: ids },
 		} as never)
 		setSavingStack(false)
-		const outcome =
-			exit._tag === 'Success'
-				? (exit.value as { outcome?: string } | null)?.outcome
-				: null
+		const outcome = outcomeOf(exit)
 		if (outcome === 'set') {
 			toast.add({ title: t`Org default saved`, type: 'success' })
 			refreshStacks()
@@ -216,10 +211,7 @@ function OrgTemplatesPage() {
 
 	const accept = async (id: string, name: string) => {
 		const exit = await acceptDonation({ params: { id } } as never)
-		const outcome =
-			exit._tag === 'Success'
-				? (exit.value as { outcome?: string } | null)?.outcome
-				: null
+		const outcome = outcomeOf(exit)
 		if (outcome === 'accepted') {
 			toast.add({
 				title: t`Added to the org`,
@@ -240,10 +232,7 @@ function OrgTemplatesPage() {
 
 	const reject = async (id: string) => {
 		const exit = await rejectDonation({ params: { id } } as never)
-		const outcome =
-			exit._tag === 'Success'
-				? (exit.value as { outcome?: string } | null)?.outcome
-				: null
+		const outcome = outcomeOf(exit)
 		if (outcome === 'rejected') {
 			toast.add({ title: t`Proposal declined`, type: 'success' })
 		} else {
@@ -261,10 +250,7 @@ function OrgTemplatesPage() {
 			params: { presetId },
 			payload: { scope: 'org' },
 		} as never)
-		const outcome =
-			exit._tag === 'Success'
-				? (exit.value as { outcome?: string } | null)?.outcome
-				: null
+		const outcome = outcomeOf(exit)
 		if (outcome === 'imported') {
 			toast.add({
 				title: t`Added to the org`,

--- a/apps/internal/src/routes/settings/profile/templates.tsx
+++ b/apps/internal/src/routes/settings/profile/templates.tsx
@@ -1,6 +1,6 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { ArrowLeft, Gift, Pencil, Plus, ScrollText, Trash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
@@ -20,6 +20,23 @@ import {
 	OwnerBadge,
 } from '#/components/instructions/instruction-chrome'
 import {
+	BackLink,
+	DialogActions,
+	Empty,
+	Heading,
+	Intro,
+	Notice,
+	Page,
+	RowActions,
+	Section,
+	SectionHead,
+	SectionTitle,
+	Subtitle,
+	TemplateList,
+	TemplateName,
+	TemplateRowItem,
+} from '#/components/instructions/instruction-page-chrome'
+import {
 	narrowStackIds,
 	narrowTemplates,
 	type TemplateShape,
@@ -30,12 +47,7 @@ import {
 	TemplateEditorDialog,
 } from '#/components/instructions/template-editor-dialog'
 import { authClient } from '#/lib/auth-client'
-import {
-	brushedMetalPlate,
-	ruledLedgerRow,
-	rulerUnderRule,
-	stenciledTitle,
-} from '#/lib/workshop-mixins'
+import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
 const AGENT = 'research'
 
@@ -348,132 +360,6 @@ function TemplatesPage() {
 	)
 }
 
-const Page = styled.div`
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-lg);
-`
-
-const BackLink = styled(Link)`
-	display: inline-flex;
-	gap: var(--space-2xs);
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-medium-size);
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	color: var(--color-on-surface-variant);
-	text-decoration: none;
-
-	&:hover {
-		color: var(--color-on-surface);
-	}
-
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
-	}
-`
-
-const Intro = styled.div`
-	${rulerUnderRule}
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-2xs);
-	padding-bottom: var(--space-xs);
-`
-
-const Heading = styled.h2`
-	${stenciledTitle}
-	display: inline-flex;
-	align-items: center;
-	gap: var(--space-2xs);
-	font-size: var(--typescale-headline-large-size);
-	line-height: var(--typescale-headline-large-line);
-	margin: 0;
-`
-
-const Subtitle = styled.p`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-large-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-	margin: 0;
-	max-width: 46rem;
-`
-
-const Section = styled.section`
-	${brushedMetalPlate}
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-sm);
-	padding: var(--space-md);
-	border-radius: var(--shape-2xs);
-`
-
-const SectionHead = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: var(--space-sm);
-`
-
-const SectionTitle = styled.h3`
-	${stenciledTitle}
-	font-size: var(--typescale-title-medium-size);
-	line-height: var(--typescale-title-medium-line);
-	margin: 0;
-`
-
-const TemplateList = styled.ul`
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-2xs);
-`
-
-const TemplateRowItem = styled.li`
-	${ruledLedgerRow}
-	display: flex;
-	align-items: center;
-	gap: var(--space-sm);
-	padding: var(--space-2xs) 0;
-`
-
-const TemplateName = styled.span`
-	flex: 1 1 auto;
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-medium-size);
-	color: var(--color-on-surface);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-`
-
-const RowActions = styled.div`
-	display: inline-flex;
-	gap: var(--space-2xs);
-`
-
-const Empty = styled.p`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-medium-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-	margin: 0;
-`
-
-const Notice = styled.p`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-small-size);
-	color: var(--color-error);
-	padding: var(--space-2xs) var(--space-sm);
-	border-left: 3px solid var(--color-error);
-	background: color-mix(in srgb, var(--color-error) 6%, transparent);
-	margin: 0;
-`
-
 const EmptyDefault = styled.section`
 	${brushedMetalPlate}
 	display: flex;
@@ -488,11 +374,4 @@ const EmptyDefaultTitle = styled.h3`
 	font-size: var(--typescale-title-medium-size);
 	line-height: var(--typescale-title-medium-line);
 	margin: 0;
-`
-
-const DialogActions = styled.div`
-	display: flex;
-	gap: var(--space-sm);
-	justify-content: flex-end;
-	margin-top: var(--space-md);
 `

--- a/apps/internal/src/routes/settings/profile/templates.tsx
+++ b/apps/internal/src/routes/settings/profile/templates.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft, Gift, Pencil, Plus, ScrollText, Trash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
-import { PriButton, PriDialog, usePriToast } from '@batuda/ui/pri'
+import { PriButton, usePriToast } from '@batuda/ui/pri'
 
 import {
 	defaultStacksAtom,
@@ -21,7 +21,6 @@ import {
 } from '#/components/instructions/instruction-chrome'
 import {
 	BackLink,
-	DialogActions,
 	Empty,
 	Heading,
 	Intro,
@@ -43,6 +42,7 @@ import {
 	type TemplateShape,
 } from '#/components/instructions/instruction-shapes'
 import type { StackOption } from '#/components/instructions/stack-picker'
+import { TemplateDeleteConfirm } from '#/components/instructions/template-delete-confirm'
 import {
 	type TemplateDraft,
 	TemplateEditorDialog,
@@ -313,47 +313,22 @@ function TemplatesPage() {
 				}}
 			/>
 
-			<PriDialog.Root
+			<TemplateDeleteConfirm
 				open={confirmTarget !== null}
-				onOpenChange={(nextOpen: boolean) => {
-					if (!nextOpen && !deleting) setConfirmTarget(null)
+				deleting={deleting}
+				onConfirm={() => {
+					void confirmDelete()
 				}}
-			>
-				<PriDialog.Portal>
-					<PriDialog.Backdrop />
-					<PriDialog.Popup data-testid='template-delete-confirm'>
-						<PriDialog.Title>
-							<Trans>Delete this template?</Trans>
-						</PriDialog.Title>
-						<PriDialog.Description>
-							<Trans>
-								"{confirmTarget?.name ?? ''}" will be removed for good. This
-								can't be undone.
-							</Trans>
-						</PriDialog.Description>
-						<DialogActions>
-							<PriButton
-								type='button'
-								$variant='filled'
-								data-testid='template-delete-confirm-button'
-								disabled={deleting}
-								onClick={() => {
-									void confirmDelete()
-								}}
-							>
-								{deleting ? <Trans>Deleting…</Trans> : <Trans>Delete</Trans>}
-							</PriButton>
-							<PriDialog.Close
-								render={props => (
-									<PriButton type='button' $variant='text' {...props}>
-										<Trans>Cancel</Trans>
-									</PriButton>
-								)}
-							/>
-						</DialogActions>
-					</PriDialog.Popup>
-				</PriDialog.Portal>
-			</PriDialog.Root>
+				onClose={() => setConfirmTarget(null)}
+				testId='template-delete-confirm'
+				title={<Trans>Delete this template?</Trans>}
+				description={
+					<Trans>
+						"{confirmTarget?.name ?? ''}" will be removed for good. This can't
+						be undone.
+					</Trans>
+				}
+			/>
 		</Page>
 	)
 }

--- a/apps/internal/src/routes/settings/profile/templates.tsx
+++ b/apps/internal/src/routes/settings/profile/templates.tsx
@@ -39,6 +39,7 @@ import {
 import {
 	narrowStackIds,
 	narrowTemplates,
+	outcomeOf,
 	type TemplateShape,
 } from '#/components/instructions/instruction-shapes'
 import type { StackOption } from '#/components/instructions/stack-picker'
@@ -128,7 +129,7 @@ function TemplatesPage() {
 			})
 			return
 		}
-		const outcome = (exit.value as { outcome?: string } | null)?.outcome
+		const outcome = outcomeOf(exit)
 		// A template still referenced by a default stack is blocked server-side;
 		// surface why instead of letting the row silently reappear.
 		if (outcome === 'in_use') {
@@ -158,10 +159,7 @@ function TemplatesPage() {
 	// becomes an org-owned template everyone can use.
 	const donate = async (row: TemplateShape) => {
 		const exit = await donateTemplate({ params: { id: row.id } } as never)
-		const outcome =
-			exit._tag === 'Success'
-				? (exit.value as { outcome?: string } | null)?.outcome
-				: null
+		const outcome = outcomeOf(exit)
 		if (outcome === 'proposed') {
 			toast.add({
 				title: t`Sent to your admins`,

--- a/apps/internal/vite.config.ts
+++ b/apps/internal/vite.config.ts
@@ -79,101 +79,123 @@ const devProxy = {
 	'/docs': apiProxy,
 }
 
-const config = defineConfig({
-	server: {
-		proxy: devProxy,
-	},
-	resolve: {
-		tsconfigPaths: true,
-		// The CJS shim does `require("react")` and creates a duplicate
-		// React via Node's CJS cache; SSR's hooks dispatcher lives on
-		// the ESM React, so any external-store hook call throws
-		// "Invalid hook call". React 19 has `useSyncExternalStore`
-		// natively, but aliasing straight to bare `'react'` breaks
-		// dev SSR because the alias keeps React in-graph (bypassing
-		// externalization) and `react/index.js` is CJS, which Vite's
-		// dev module-runner can't execute. The local ESM shims
-		// re-export from `react` so both dev and build land on a
-		// single instance.
-		alias: [
-			{
-				find: /^use-sync-external-store\/shim\/with-selector$/,
-				replacement: resolve(
-					here,
-					'src/lib/use-sync-external-store-shim-with-selector.ts',
-				),
-			},
-			{
-				find: /^use-sync-external-store\/shim$/,
-				replacement: resolve(here, 'src/lib/use-sync-external-store-shim.ts'),
-			},
-			{
-				find: /^use-sync-external-store\/shim\/index$/,
-				replacement: resolve(here, 'src/lib/use-sync-external-store-shim.ts'),
-			},
-			{
-				find: /^use-sync-external-store\/shim\/index\.js$/,
-				replacement: resolve(here, 'src/lib/use-sync-external-store-shim.ts'),
-			},
-		],
-		dedupe: ['react', 'react-dom', '@base-ui/react', '@base-ui/utils'],
-		// Drop the default 'node' condition so tslib (and any other
-		// dual-pkg dep that styled-components pulls in) resolves to its
-		// ESM build. With 'node' first, Vite/Nitro picks the CJS entry
-		// and the interop wrapper exposes `__extends` only via a
-		// `.default` property — Nitro's prebuild then emits
-		// `const { __extends } = tslib.default` which throws at SSR
-		// time because tslib's ESM has named exports, not a default.
-		//
-		// `development` is first so workspace packages with a
-		// `"development"` export key (e.g. `@batuda/ui`) resolve to
-		// their TS source in dev, not the pre-built `dist/`. Without
-		// it Vite picks `import` → `dist/index.mjs`, which tsdown ships
-		// without `@swc/plugin-styled-components` componentIds; the SSR
-		// pipeline's `noExternal` still re-runs the SWC plugin and adds
-		// IDs, while the client loads dist as-is. The classnames then
-		// diverge (`pri-input__PriInput-sc-{hash}-0` vs `PriInput-{hash}`)
-		// and React 19 bails hydration on every affected subtree —
-		// magic-link button onClick stops attaching, sign-in form
-		// submits get dropped, etc. Symmetric source load + symmetric
-		// transform fixes the mismatch at the root.
-		conditions: ['development', 'module', 'import', 'default'],
-	},
-	ssr: {
-		// Bundle through Vite for SSR so the React-using deps go through
-		// the same dedupe + conditions as the rest of the SSR graph;
-		// otherwise Vite externalizes them and Node's resolver picks a
-		// different React/tslib instance and SSR throws on hook calls
-		// or `__extends` is undefined.
-		noExternal: [
-			'styled-components',
-			'@batuda/ui',
-			'@base-ui/react',
-			'@base-ui/utils',
-		],
-		resolve: { conditions: ['development', 'module', 'import', 'default'] },
-	},
-	plugins: [
-		tailwindcss(),
-		cloudflare({ viteEnvironment: { name: 'ssr' } }),
-		tanstackStart(),
-		viteReact({
-			plugins: [
-				['@lingui/swc-plugin', {}],
-				[
-					'@swc/plugin-styled-components',
-					{
-						displayName: true,
-						ssr: true,
-						fileName: true,
-						pure: false,
-						transpileTemplateLiterals: true,
-					},
-				],
+const config = defineConfig(({ command }) => {
+	// The dev SSR runtime is workerd (the Cloudflare plugin below), which
+	// can't read this Node process's env — so the SSR session check has no
+	// way to learn the dev server's port to call back through. portless
+	// launches us as `PORT=<n> vite dev --port <n> --strictPort`, so the real
+	// port is known here at config time; bake it into the bundle. Require it
+	// rather than guessing a default: a wrong port surfaces as a silent
+	// /login bounce on every authed hard-load, not a clear error.
+	if (command === 'serve' && !process.env['PORT']) {
+		throw new Error(
+			'PORT is not set. Start the dev server with `pnpm dev` (portless ' +
+				'assigns and exports PORT). Without it the SSR session check ' +
+				"can't reach the dev server, so every authed page hard-load " +
+				'bounces to /login.',
+		)
+	}
+	return {
+		define: {
+			// Read only in the dev-SSR branch of api-base; the consuming branch
+			// is dead-code-eliminated in prod builds, so the value is unused there.
+			__INTERNAL_DEV_PORT__: JSON.stringify(process.env['PORT'] ?? '0'),
+		},
+		server: {
+			proxy: devProxy,
+		},
+		resolve: {
+			tsconfigPaths: true,
+			// The CJS shim does `require("react")` and creates a duplicate
+			// React via Node's CJS cache; SSR's hooks dispatcher lives on
+			// the ESM React, so any external-store hook call throws
+			// "Invalid hook call". React 19 has `useSyncExternalStore`
+			// natively, but aliasing straight to bare `'react'` breaks
+			// dev SSR because the alias keeps React in-graph (bypassing
+			// externalization) and `react/index.js` is CJS, which Vite's
+			// dev module-runner can't execute. The local ESM shims
+			// re-export from `react` so both dev and build land on a
+			// single instance.
+			alias: [
+				{
+					find: /^use-sync-external-store\/shim\/with-selector$/,
+					replacement: resolve(
+						here,
+						'src/lib/use-sync-external-store-shim-with-selector.ts',
+					),
+				},
+				{
+					find: /^use-sync-external-store\/shim$/,
+					replacement: resolve(here, 'src/lib/use-sync-external-store-shim.ts'),
+				},
+				{
+					find: /^use-sync-external-store\/shim\/index$/,
+					replacement: resolve(here, 'src/lib/use-sync-external-store-shim.ts'),
+				},
+				{
+					find: /^use-sync-external-store\/shim\/index\.js$/,
+					replacement: resolve(here, 'src/lib/use-sync-external-store-shim.ts'),
+				},
 			],
-		}),
-		lingui(),
-	],
+			dedupe: ['react', 'react-dom', '@base-ui/react', '@base-ui/utils'],
+			// Drop the default 'node' condition so tslib (and any other
+			// dual-pkg dep that styled-components pulls in) resolves to its
+			// ESM build. With 'node' first, Vite/Nitro picks the CJS entry
+			// and the interop wrapper exposes `__extends` only via a
+			// `.default` property — Nitro's prebuild then emits
+			// `const { __extends } = tslib.default` which throws at SSR
+			// time because tslib's ESM has named exports, not a default.
+			//
+			// `development` is first so workspace packages with a
+			// `"development"` export key (e.g. `@batuda/ui`) resolve to
+			// their TS source in dev, not the pre-built `dist/`. Without
+			// it Vite picks `import` → `dist/index.mjs`, which tsdown ships
+			// without `@swc/plugin-styled-components` componentIds; the SSR
+			// pipeline's `noExternal` still re-runs the SWC plugin and adds
+			// IDs, while the client loads dist as-is. The classnames then
+			// diverge (`pri-input__PriInput-sc-{hash}-0` vs `PriInput-{hash}`)
+			// and React 19 bails hydration on every affected subtree —
+			// magic-link button onClick stops attaching, sign-in form
+			// submits get dropped, etc. Symmetric source load + symmetric
+			// transform fixes the mismatch at the root.
+			conditions: ['development', 'module', 'import', 'default'],
+		},
+		ssr: {
+			// Bundle through Vite for SSR so the React-using deps go through
+			// the same dedupe + conditions as the rest of the SSR graph;
+			// otherwise Vite externalizes them and Node's resolver picks a
+			// different React/tslib instance and SSR throws on hook calls
+			// or `__extends` is undefined.
+			noExternal: [
+				'styled-components',
+				'@batuda/ui',
+				'@base-ui/react',
+				'@base-ui/utils',
+			],
+			resolve: { conditions: ['development', 'module', 'import', 'default'] },
+		},
+		plugins: [
+			tailwindcss(),
+			cloudflare({ viteEnvironment: { name: 'ssr' } }),
+			tanstackStart(),
+			viteReact({
+				plugins: [
+					['@lingui/swc-plugin', {}],
+					[
+						'@swc/plugin-styled-components',
+						{
+							displayName: true,
+							ssr: true,
+							fileName: true,
+							pure: false,
+							transpileTemplateLiterals: true,
+						},
+					],
+				],
+			}),
+			lingui(),
+		],
+	}
 })
 
 export default config


### PR DESCRIPTION
Follow-up to the code review on the org-admin page (#71). Extends the original "shared chrome" refactor with the deferred dedup follow-ups (now browser-verifiable), plus a standalone dev-infra fix that unblocked that verification.

## Refactor — the chrome work + follow-ups

- **Shared page chrome** *(original commit)* — the 14 byte-identical styled components → `instruction-page-chrome.tsx`; unified `Notice`; collapsed the org `Card` into `Section`.
- **`outcomeOf(exit)` helper** — replaces a repeated `(exit.value as { outcome? })?.outcome` block, dropping 7 unsafe `as` casts across both pages.
- **Admin-only child component** — the org page's donation/preset/stack queries now mount only for admins, so a regular member's browser no longer fetches review data it can't act on (every org write is admin-gated server-side).
- **Shared `TemplateDeleteConfirm`** — the org and profile pages duplicated the same confirm dialog; now one component, each page passing only its own wording + test id.
- **i18n** — `#:` source-line refs refreshed to match the moved code (Catalan stays complete).

## Bundled dev-infra fix

**`fix(internal): stop authed hard-loads bouncing to /login in dev`** — the dev SSR runtime is workerd (Cloudflare vite plugin), which can't read the Node process's `PORT`; `apiBaseUrl()` fell back to a stale hardcoded port, so every authed hard-navigation (and the org switcher's `window.location.assign` reload) bounced to `/login`, even with a valid session cookie. The real port is now injected at Vite config time via `define`, and the config throws in dev `serve` when `PORT` is unset instead of silently defaulting.

Unrelated to the chrome work — it's what unblocked the `:443` browser verification. It stays a clean standalone commit on a `--rebase` merge; if you `--squash` this PR, pull it out first.

## Verified

`check-types` / Biome / `i18n-check` green on every commit. Browser-walked on the `:443` portless stack: the org admin page renders all four sections (admin-gated, non-admin fallback intact), the scope-aware create dialog, and **create → list → delete** (through the shared dialog) — seed left clean.

## Deliberately not done

A **scope-aware `DefaultStackEditor`** for the inlined org default. The user editor (inherit-from-org / fork / clear) and the org editor (the base everyone inherits) share only "a `StackPicker` + a save button"; merging them would thread a `scope` prop through divergent logic and copy and make both harder to read — a dedup that costs clarity.
