### PR TITLE
feat(instructions): let a user default stack extend the org default

### DIFF
--- a/apps/server/src/db/migrations/0011_stack_composition.ts
+++ b/apps/server/src/db/migrations/0011_stack_composition.ts
@@ -1,0 +1,23 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// A user's default instruction stack can either REPLACE the org default (the
+// original behavior) or EXTEND it — resolving as the live org default followed
+// by the user's own additions. `composition` records which. It is meaningful
+// only for a user-owned stack; the org default is always the base, so its value
+// is ignored. Existing stacks default to 'replace', preserving today's
+// resolution.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		ALTER TABLE agent_default_stacks
+			ADD COLUMN composition text NOT NULL DEFAULT 'replace'
+	`
+	yield* sql`
+		ALTER TABLE agent_default_stacks
+			ADD CONSTRAINT agent_default_stacks_composition_valid
+			CHECK (composition IN ('replace', 'extend'))
+	`
+})

--- a/apps/server/src/services/resolve-instructions.integration.test.ts
+++ b/apps/server/src/services/resolve-instructions.integration.test.ts
@@ -25,11 +25,16 @@ const ORG = `ri-org-${randomUUID()}`
 const U1 = `ri-u1-${randomUUID()}`
 const U2 = `ri-u2-${randomUUID()}`
 const U3 = `ri-u3-${randomUUID()}`
+const E1 = `ri-e1-${randomUUID()}`
+const E2 = `ri-e2-${randomUUID()}`
+const E4 = `ri-e4-${randomUUID()}`
 const ORG_OBJ = { id: ORG, name: 'ri', slug: 'ri' }
 
 let orgTemplate = ''
 let userTemplate = ''
 let u2Personal = ''
+let e1Template = ''
+let e2Template = ''
 
 const runRoot = <A>(
 	eff: Effect.Effect<A, unknown, SqlClient.SqlClient>,
@@ -94,7 +99,40 @@ beforeAll(async () => {
 					yield* sql`
 						INSERT INTO agent_default_stack_items (organization_id, stack_id, template_id, position)
 						VALUES (${ORG}, ${us[0]?.id ?? ''}, ${user}, 0)`
-					return { org, user, u2: u2[0]?.id ?? '' }
+					// E1 extends the org default with one personal addition (delta = [e1]).
+					const e1t = yield* sql<{ id: string }>`
+							INSERT INTO instruction_templates (organization_id, owner_user_id, name, body, created_by)
+							VALUES (${ORG}, ${E1}, 'E1', 'e1 body', ${E1}) RETURNING id`
+					const e1s = yield* sql<{ id: string }>`
+							INSERT INTO agent_default_stacks (organization_id, owner_user_id, agent, composition)
+							VALUES (${ORG}, ${E1}, 'research', 'extend') RETURNING id`
+					yield* sql`
+							INSERT INTO agent_default_stack_items (organization_id, stack_id, template_id, position)
+							VALUES (${ORG}, ${e1s[0]?.id ?? ''}, ${e1t[0]?.id ?? ''}, 0)`
+					// E2 extends but re-lists the org template ahead of its own (dedup case).
+					const e2t = yield* sql<{ id: string }>`
+							INSERT INTO instruction_templates (organization_id, owner_user_id, name, body, created_by)
+							VALUES (${ORG}, ${E2}, 'E2', 'e2 body', ${E2}) RETURNING id`
+					const e2s = yield* sql<{ id: string }>`
+							INSERT INTO agent_default_stacks (organization_id, owner_user_id, agent, composition)
+							VALUES (${ORG}, ${E2}, 'research', 'extend') RETURNING id`
+					yield* sql`
+							INSERT INTO agent_default_stack_items (organization_id, stack_id, template_id, position)
+							VALUES (${ORG}, ${e2s[0]?.id ?? ''}, ${org}, 0)`
+					yield* sql`
+							INSERT INTO agent_default_stack_items (organization_id, stack_id, template_id, position)
+							VALUES (${ORG}, ${e2s[0]?.id ?? ''}, ${e2t[0]?.id ?? ''}, 1)`
+					// E4 has an extend stack with no additions of its own (empty delta).
+					yield* sql`
+							INSERT INTO agent_default_stacks (organization_id, owner_user_id, agent, composition)
+							VALUES (${ORG}, ${E4}, 'research', 'extend')`
+					return {
+						org,
+						user,
+						u2: u2[0]?.id ?? '',
+						e1: e1t[0]?.id ?? '',
+						e2: e2t[0]?.id ?? '',
+					}
 				}),
 			)
 		}),
@@ -102,6 +140,8 @@ beforeAll(async () => {
 	orgTemplate = ids.org
 	userTemplate = ids.user
 	u2Personal = ids.u2
+	e1Template = ids.e1
+	e2Template = ids.e2
 }, 60_000)
 
 afterAll(async () => {
@@ -214,6 +254,69 @@ describe('resolveInstructions (live RLS)', () => {
 			// THEN the fingerprint changes (and the edited body resolves)
 			expect(after.fingerprint).not.toBe(before.fingerprint)
 			expect(after.segments).toEqual(['edited body'])
+		})
+	})
+
+	describe('when a user stack extends the org default', () => {
+		it('should resolve the org default first, then the user additions', async () => {
+			// GIVEN E1 has an extend stack that adds one personal template
+			const result = await resolveAs(E1)
+			// THEN the live org default leads and the addition follows
+			expect(result.source).toBe('user')
+			expect(result.templateIds).toEqual([orgTemplate, e1Template])
+			expect(result.segments).toEqual(['org body', 'e1 body'])
+		})
+
+		it('should keep the org template in its slot when the delta re-lists it', async () => {
+			// GIVEN E2's extend delta re-lists the org template ahead of its own
+			const result = await resolveAs(E2)
+			// THEN the org template keeps its lead slot and the duplicate is dropped
+			expect(result.source).toBe('user')
+			expect(result.templateIds).toEqual([orgTemplate, e2Template])
+			expect(result.segments).toEqual(['org body', 'e2 body'])
+		})
+
+		it('should resolve to the org default alone when the extend delta is empty', async () => {
+			// GIVEN E4 has an extend stack with no additions of its own
+			const result = await resolveAs(E4)
+			// THEN only the live org default resolves; the source stays the user stack
+			expect(result.source).toBe('user')
+			expect(result.templateIds).toEqual([orgTemplate])
+			expect(result.segments).toEqual(['org body'])
+		})
+
+		it('should be bypassed entirely by a per-run override', async () => {
+			// GIVEN E1 (an extend user) passes an explicit override
+			const result = await resolveAs(E1, [e1Template])
+			// THEN the override wins and the org default is not composed in
+			expect(result.source).toBe('override')
+			expect(result.templateIds).toEqual([e1Template])
+			expect(result.segments).toEqual(['e1 body'])
+		})
+
+		// Runs last: it edits the shared org template to prove the org base is live.
+		it('should track a live edit to the org default it extends', async () => {
+			// GIVEN E1's extend resolution layers on the org default
+			const before = await resolveAs(E1)
+			// WHEN the org default's template is edited
+			await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					yield* sql.withTransaction(
+						Effect.gen(function* () {
+							yield* sql`SET LOCAL ROLE app_service`
+							yield* sql`
+								UPDATE instruction_templates
+								SET body = 'edited org body', updated_at = now() + interval '1 second'
+								WHERE id = ${orgTemplate}`
+						}),
+					)
+				}),
+			)
+			const after = await resolveAs(E1)
+			// THEN E1's fingerprint changes and the edited org body resolves in the org slot
+			expect(after.fingerprint).not.toBe(before.fingerprint)
+			expect(after.segments).toEqual(['edited org body', 'e1 body'])
 		})
 	})
 })

--- a/packages/instructions/src/resolver.test.ts
+++ b/packages/instructions/src/resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	assembleSegments,
+	dedupeKeepFirst,
 	personalTemplatesInOrgStack,
 	pickStackSource,
 } from './resolver'
@@ -127,6 +128,45 @@ describe('personalTemplatesInOrgStack', () => {
 			// GIVEN an empty org stack [resolver.ts:46]
 			// THEN there is nothing to reject
 			expect(personalTemplatesInOrgStack([])).toEqual([])
+		})
+	})
+})
+
+describe('dedupeKeepFirst', () => {
+	describe('when an id repeats later in the list', () => {
+		it('should keep the first occurrence and preserve order', () => {
+			// GIVEN a list with a later duplicate [resolver.ts:dedupeKeepFirst]
+			// THEN the first position is kept and the duplicate dropped
+			expect(dedupeKeepFirst(['a', 'b', 'a', 'c'])).toEqual(['a', 'b', 'c'])
+		})
+	})
+
+	describe('when a user addition repeats an org template (the extend case)', () => {
+		it('should keep the template in its earlier org position', () => {
+			// GIVEN the org default ids followed by the user's additions, one of
+			// which is already in the org block [resolver.ts:dedupeKeepFirst]
+			const orgIds = ['org-1', 'org-2']
+			const userAdditions = ['org-2', 'mine']
+			// THEN org-2 keeps its org position and the user's duplicate is dropped
+			expect(dedupeKeepFirst([...orgIds, ...userAdditions])).toEqual([
+				'org-1',
+				'org-2',
+				'mine',
+			])
+		})
+	})
+
+	describe('when there are no duplicates', () => {
+		it('should return the ids unchanged', () => {
+			// GIVEN all-distinct ids [resolver.ts:dedupeKeepFirst]
+			expect(dedupeKeepFirst(['a', 'b', 'c'])).toEqual(['a', 'b', 'c'])
+		})
+	})
+
+	describe('when the list is empty', () => {
+		it('should return an empty list', () => {
+			// GIVEN no ids [resolver.ts:dedupeKeepFirst]
+			expect(dedupeKeepFirst([])).toEqual([])
 		})
 	})
 })

--- a/packages/instructions/src/resolver.ts
+++ b/packages/instructions/src/resolver.ts
@@ -35,6 +35,26 @@ export const assembleSegments = (
 ): ReadonlyArray<string> =>
 	templates.map(t => t.body.trim()).filter(body => body.length > 0)
 
+// A user's default stack either replaces the org default or extends it (the org
+// default, live, followed by the user's own additions).
+export type StackComposition = 'replace' | 'extend'
+
+// Keep the first occurrence of each id, preserving order. When an "extend" user
+// stack is appended after the org default, a template already in the org block
+// keeps its earlier position and the later duplicate is dropped.
+export const dedupeKeepFirst = (
+	ids: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+	const seen = new Set<string>()
+	const out: Array<string> = []
+	for (const id of ids) {
+		if (seen.has(id)) continue
+		seen.add(id)
+		out.push(id)
+	}
+	return out
+}
+
 // An org default stack (owner null) may reference only org-owned templates. A
 // personal template inside an org stack is hidden by RLS from other members and
 // would be silently dropped from their resolved prompt, so it must be rejected
@@ -70,6 +90,7 @@ export interface ResolvedInstructions {
 interface StackRow {
 	readonly id: string
 	readonly ownerUserId: string | null
+	readonly composition: StackComposition
 }
 
 interface TemplateRow {
@@ -112,7 +133,7 @@ export const resolveInstructions = (
 		const stacks = yield* override.length > 0
 			? Effect.succeed<ReadonlyArray<StackRow>>([])
 			: sql<StackRow>`
-					SELECT id, owner_user_id
+					SELECT id, owner_user_id, composition
 					FROM agent_default_stacks
 					WHERE organization_id = ${args.organizationId}
 						AND agent = ${args.agent}
@@ -129,11 +150,25 @@ export const resolveInstructions = (
 		const chosenStack =
 			source === 'user' ? userStack : source === 'org' ? orgStack : undefined
 
+		// An "extend" user stack resolves to the live org default followed by the
+		// user's own additions (deduped, with the org keeping its position).
+		// Every other case reads a single chosen stack, as before.
+		const isExtend = source === 'user' && userStack?.composition === 'extend'
 		const orderedIds = yield* source === 'override'
 			? Effect.succeed<ReadonlyArray<string>>(override)
-			: chosenStack
-				? readStackTemplateIds(sql, chosenStack.id)
-				: Effect.succeed<ReadonlyArray<string>>([])
+			: isExtend
+				? Effect.gen(function* () {
+						const orgIds = orgStack
+							? yield* readStackTemplateIds(sql, orgStack.id)
+							: []
+						const userIds = userStack
+							? yield* readStackTemplateIds(sql, userStack.id)
+							: []
+						return dedupeKeepFirst([...orgIds, ...userIds])
+					})
+				: chosenStack
+					? readStackTemplateIds(sql, chosenStack.id)
+					: Effect.succeed<ReadonlyArray<string>>([])
 
 		if (orderedIds.length === 0) {
 			return {


### PR DESCRIPTION
## What

Adds an `extend` mode to a user's default instruction stack (the Research/instructions context — `packages/instructions` + a migration in `apps/server`). Today a user's own default stack **replaces** the org default; this lets it **extend** the *live* org default instead — "org default + my additions" — so the user's runs keep following later org changes instead of forking a private copy.

This is the schema + resolver slice. The API/MCP (next PR) and the UI (top of the stack) build on it.

## Changes

- Migration `0011_stack_composition`: `agent_default_stacks.composition text NOT NULL DEFAULT 'replace'` + a CHECK (`'replace' | 'extend'`).
- Resolver: when a user stack is `extend`, resolution returns the live org default ⧺ the user's additions, **deduped keep-first** (the org template keeps its position); a per-run override still bypasses the stack entirely.
- `dedupeKeepFirst` helper + `StackComposition` type.

## Impact

- **Migration** — `0011` must run **before** the server tag (the deploy doesn't migrate). Additive column with a default; existing stacks stay `replace`, so no behavior change for them.
- No API surface in this slice (resolver-internal); no RLS / tenant-isolation change.

## Review guide

- The one load-bearing change is the `isExtend` branch in `resolver.ts` — confirm the order (org first, then additions) and the keep-first dedup. Everything else is the column + types.

## Tests

Integration (`resolve-instructions.integration.test.ts`, through RLS): extend compose, dedup, empty-delta, override-bypasses-extend, and liveness (editing the org default's last template reflects in the user's resolved stack).

## Verification

- Integration suite (resolve-instructions) — green.
- Migration applied locally via `pnpm cli db migrate`.
