### PR TITLE
feat(instructions): set and read stack composition via the API and MCP

### DIFF
--- a/apps/server/src/handlers/instructions.ts
+++ b/apps/server/src/handlers/instructions.ts
@@ -93,6 +93,7 @@ export const InstructionsLive = HttpApiBuilder.group(
 							userId,
 							agent,
 							_.payload.template_ids,
+							_.payload.composition ?? 'replace',
 						)
 					}),
 				)

--- a/apps/server/src/mcp/tools/instructions-mcp.ts
+++ b/apps/server/src/mcp/tools/instructions-mcp.ts
@@ -49,12 +49,13 @@ const ManagePreset = Tool.make('manage_instruction_preset', {
 
 const ManageDefaultStack = Tool.make('manage_instruction_default_stack', {
 	description:
-		'Get, set, or clear the default instruction stack for an agent. scope=org sets the org default (admin only); scope=personal sets your own; clear removes your own so you inherit the org default.',
+		'Get, set, or clear the default instruction stack for an agent. scope=org sets the org default (admin only); scope=personal sets your own; clear removes your own so you inherit the org default. composition=extend (personal scope) layers your templates on the live org default instead of replacing it.',
 	parameters: Schema.Struct({
 		action: Schema.Literals(['get', 'set', 'clear']),
 		agent: Schema.String,
 		scope: Schema.optional(Scope),
 		template_ids: Schema.optional(Schema.Array(Uuid)),
+		composition: Schema.optional(Schema.Literals(['replace', 'extend'])),
 	}),
 	success: Schema.Unknown,
 	dependencies: REQUEST_DEPENDENCIES,
@@ -155,6 +156,7 @@ export const InstructionsMcpHandlersLive = InstructionsMcpTools.toLayer(
 											userId,
 											agent,
 											params.template_ids,
+											params.composition ?? 'replace',
 										),
 							)
 					}

--- a/apps/server/src/services/instructions.ts
+++ b/apps/server/src/services/instructions.ts
@@ -21,6 +21,7 @@ import {
 	presetsForAgent,
 	proposeDonation,
 	rejectDonation,
+	type StackComposition,
 	type StackView,
 	setDefaultStack,
 	transferTemplateToUser,
@@ -256,6 +257,7 @@ export class InstructionsService extends ServiceMap.Service<InstructionsService>
 					userId: string,
 					agent: Agent,
 					templateIds: ReadonlyArray<string>,
+					composition: StackComposition,
 				): Effect.Effect<SetStackOutcome, never, SqlClient.SqlClient> =>
 					Effect.gen(function* () {
 						const result = yield* setDefaultStack({
@@ -263,6 +265,7 @@ export class InstructionsService extends ServiceMap.Service<InstructionsService>
 							ownerUserId: userId,
 							agent,
 							templateIds,
+							composition,
 						})
 						return result.ok
 							? { outcome: 'set' as const, stackId: result.stackId }
@@ -291,6 +294,8 @@ export class InstructionsService extends ServiceMap.Service<InstructionsService>
 							ownerUserId: null,
 							agent,
 							templateIds,
+							// The org default is always the base of any extend.
+							composition: 'replace',
 						})
 						return result.ok
 							? { outcome: 'set' as const, stackId: result.stackId }

--- a/apps/server/src/services/resolve-instructions.integration.test.ts
+++ b/apps/server/src/services/resolve-instructions.integration.test.ts
@@ -16,7 +16,12 @@ import { Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { resolveInstructions } from '@batuda/instructions'
+import {
+	clearUserDefaultStack,
+	getDefaultStacks,
+	resolveInstructions,
+	setDefaultStack,
+} from '@batuda/instructions'
 
 import { PgLive } from '../db/client.js'
 import { enterOrgScope } from '../middleware/org.js'
@@ -317,6 +322,76 @@ describe('resolveInstructions (live RLS)', () => {
 			// THEN E1's fingerprint changes and the edited org body resolves in the org slot
 			expect(after.fingerprint).not.toBe(before.fingerprint)
 			expect(after.segments).toEqual(['edited org body', 'e1 body'])
+		})
+	})
+
+	describe('default-stack composition (set, then read it back)', () => {
+		const setStackFor = (
+			userId: string,
+			composition: 'replace' | 'extend',
+			templateIds: ReadonlyArray<string>,
+		) =>
+			runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org: ORG_OBJ, userId })(
+						setDefaultStack({
+							organizationId: ORG,
+							ownerUserId: userId,
+							agent: 'research',
+							templateIds,
+							composition,
+						}),
+					)
+				}),
+			)
+		const readStacks = (userId: string) =>
+			runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org: ORG_OBJ, userId })(
+						getDefaultStacks(ORG, userId, 'research'),
+					)
+				}),
+			)
+
+		it('should persist composition=extend and read it back with its items', async () => {
+			// GIVEN a fresh user saves an extend stack over the org template
+			const me = `ri-s1-${randomUUID()}`
+			const result = await setStackFor(me, 'extend', [orgTemplate])
+			expect(result.ok).toBe(true)
+			// THEN reading it back reports extend + the stored items
+			const stacks = await readStacks(me)
+			expect(stacks.user?.composition).toBe('extend')
+			expect(stacks.user?.templateIds).toEqual([orgTemplate])
+		})
+
+		it('should overwrite the composition when an existing stack is re-saved', async () => {
+			// GIVEN a user's stack is extend, then re-saved as replace
+			const me = `ri-s2-${randomUUID()}`
+			await setStackFor(me, 'extend', [orgTemplate])
+			await setStackFor(me, 'replace', [orgTemplate])
+			// THEN the upsert UPDATE wrote the new composition
+			const stacks = await readStacks(me)
+			expect(stacks.user?.composition).toBe('replace')
+		})
+
+		it('should leave no user stack after it is cleared', async () => {
+			// GIVEN a user with an extend stack
+			const me = `ri-s3-${randomUUID()}`
+			await setStackFor(me, 'extend', [orgTemplate])
+			// WHEN it is cleared
+			await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org: ORG_OBJ, userId: me })(
+						clearUserDefaultStack(ORG, me, 'research'),
+					)
+				}),
+			)
+			// THEN they inherit the org default again (no user stack)
+			const stacks = await readStacks(me)
+			expect(stacks.user).toBeNull()
 		})
 	})
 })

--- a/packages/controllers/src/routes/instructions.ts
+++ b/packages/controllers/src/routes/instructions.ts
@@ -32,6 +32,9 @@ const TransferInput = Schema.Struct({ target_user_id: Schema.String })
 
 const SetStackInput = Schema.Struct({
 	template_ids: Schema.Array(Schema.String),
+	// Personal stacks only: 'extend' layers the templates on the live org
+	// default; absent/'replace' uses the stack alone. Ignored for org stacks.
+	composition: Schema.optional(Schema.Literals(['replace', 'extend'])),
 })
 
 const ImportPresetInput = Schema.Struct({ scope: Scope })

--- a/packages/instructions/src/index.ts
+++ b/packages/instructions/src/index.ts
@@ -48,6 +48,7 @@ export { instructionPresets, presetById, presetsForAgent } from './presets'
 export type {
 	ResolvedInstructions,
 	ResolveInstructionsArgs,
+	StackComposition,
 	StackSource,
 } from './resolver'
 export {

--- a/packages/instructions/src/management.ts
+++ b/packages/instructions/src/management.ts
@@ -4,6 +4,7 @@ import { SqlClient } from 'effect/unstable/sql'
 
 import type { Agent, InstructionTemplate } from './domain'
 import { classifyStackTemplates } from './management-logic'
+import type { StackComposition } from './resolver'
 
 // SQL-only management operations for instruction templates, default stacks, and
 // donations. They run as the request-scoped role, so RLS already limits what
@@ -176,6 +177,7 @@ export const deleteTemplate = (id: string): Eff<DeleteTemplateResult> =>
 export interface StackView {
 	readonly id: string
 	readonly templateIds: ReadonlyArray<string>
+	readonly composition: StackComposition
 }
 
 const loadStackItemIds = (
@@ -197,20 +199,29 @@ export const getDefaultStacks = (
 ): Eff<{ readonly org: StackView | null; readonly user: StackView | null }> =>
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
-		const stacks = yield* sql<{ id: string; ownerUserId: string | null }>`
-			SELECT id, owner_user_id FROM agent_default_stacks
+		const stacks = yield* sql<{
+			id: string
+			ownerUserId: string | null
+			composition: StackComposition
+		}>`
+			SELECT id, owner_user_id, composition FROM agent_default_stacks
 			WHERE organization_id = ${organizationId} AND agent = ${agent}
 				AND (owner_user_id = ${userId} OR owner_user_id IS NULL)
 		`
 		const orgRow = stacks.find(s => s.ownerUserId === null)
 		const userRow = stacks.find(s => s.ownerUserId === userId)
 		const org = orgRow
-			? { id: orgRow.id, templateIds: yield* loadStackItemIds(sql, orgRow.id) }
+			? {
+					id: orgRow.id,
+					templateIds: yield* loadStackItemIds(sql, orgRow.id),
+					composition: orgRow.composition,
+				}
 			: null
 		const user = userRow
 			? {
 					id: userRow.id,
 					templateIds: yield* loadStackItemIds(sql, userRow.id),
+					composition: userRow.composition,
 				}
 			: null
 		return { org, user }
@@ -222,6 +233,9 @@ export interface SetDefaultStackInput {
 	readonly ownerUserId: string | null
 	readonly agent: Agent
 	readonly templateIds: ReadonlyArray<string>
+	// 'extend' layers the items on the live org default; the org default is
+	// always the base, so it passes 'replace'.
+	readonly composition: StackComposition
 }
 
 export type SetDefaultStackResult =
@@ -279,11 +293,11 @@ export const setDefaultStack = (
 		if (existingRow) {
 			stackId = existingRow.id
 			yield* sql`DELETE FROM agent_default_stack_items WHERE stack_id = ${stackId}`
-			yield* sql`UPDATE agent_default_stacks SET updated_at = now() WHERE id = ${stackId}`
+			yield* sql`UPDATE agent_default_stacks SET composition = ${input.composition}, updated_at = now() WHERE id = ${stackId}`
 		} else {
 			const created = yield* sql<{ id: string }>`
-				INSERT INTO agent_default_stacks (organization_id, owner_user_id, agent)
-				VALUES (${input.organizationId}, ${input.ownerUserId}, ${input.agent})
+				INSERT INTO agent_default_stacks (organization_id, owner_user_id, agent, composition)
+				VALUES (${input.organizationId}, ${input.ownerUserId}, ${input.agent}, ${input.composition})
 				RETURNING id
 			`
 			const createdRow = created[0]


### PR DESCRIPTION
## What

Threads `composition` through the set/read path so a client — HTTP **or** MCP — can choose `extend` for a user's default stack. Builds on the resolver slice (base PR). Research/instructions context.

## Changes

- `getDefaultStacks` returns each stack's `composition`; `setDefaultStack` persists it.
- `setUserStack` takes a `composition` param; `setOrgStack` stays `replace` (org stacks don't extend — extend is a personal-scope concept).
- HTTP `SetStackInput` gains an **optional** `composition`; the handler defaults absent → `'replace'`.
- MCP `manage_instruction_default_stack` gains the same optional param, with a one-line description of extend.

## Impact

- **API / wire-shape** — `SetStackInput.composition` is optional, so additive and backward-compatible (existing callers keep replacing).
- **MCP + HTTP parity** — both surfaces get composition (shared service).
- No schema / RLS change (the column landed in the base PR).

## Review guide

- The threading is mechanical (controller → handler → service → management). The one judgment call: `setOrgStack` forces `replace`.

## Tests

Integration round-trip: set a stack with each composition and read it back; overwrite; clear.

## Verification

- Integration suite (instructions set/read) — green.
