### PR TITLE
chore: add an uploader for PR screenshots and recordings

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -76,7 +76,7 @@ agent-browser open https://batuda.localhost/<route>
 agent-browser screenshot /tmp/pr-<feature>-mobile.png
 ```
 
-**Recording** (native WebM, no ffmpeg; preserves login state when started from the current page — see vercel-labs/agent-browser#116). Record at the viewport that matters for the flow; record both sizes only if the flow itself differs by size:
+**Recording** (native WebM — the uploader transcodes it to a compact MP4, so capture stays simple; preserves login state when started from the current page — see vercel-labs/agent-browser#116). Record at the viewport that matters, and keep it tight — set up state *before* `record start`, then perform only the steps that show the change; record both sizes only if the flow itself differs by size:
 
 ```bash
 agent-browser set device "iPhone 16 Pro"               # or: set viewport 1440 900
@@ -190,31 +190,18 @@ These are the things a human reviewer of *this* system must act on or verify and
 
 If a change touches none of these, say so briefly rather than leaving the reviewer guessing.
 
-### Embedding media (public repo)
+### Embedding media
 
-`guillempuche/batuda` is public, so raw URLs render inline. Keep the feature diff clean by hosting media on a dedicated, never-merged `pr-media` branch instead of committing it into the change. Do it from a throwaway worktree so the feature worktree is untouched:
+Media goes **with the PR** — never on a side branch. Two paths:
 
-```bash
-MEDIA=$(mktemp -d)
-# reuse the branch if it exists, otherwise create it orphaned
-git worktree add -B pr-media "$MEDIA" origin/pr-media 2>/dev/null \
-  || { git worktree add --detach "$MEDIA" && git -C "$MEDIA" switch --orphan pr-media; }
-mkdir -p "$MEDIA/<branch>"
-cp /tmp/pr-<feature>*.png /tmp/pr-<feature>.webm "$MEDIA/<branch>/"
-git -C "$MEDIA" add . && git -C "$MEDIA" commit -m "chore: pr media for <branch>"
-git -C "$MEDIA" push -u origin pr-media
-git worktree remove "$MEDIA"
-```
+**Automated (agent, no human) — the shared media bucket.** `scripts/gh-pr-media.sh <pr#> <file>…` syncs each capture to the team's public `github-media` bucket over S3 (provider-agnostic, via the `aws` CLI), keyed `<repo>/pr-<n>/<file>`, and prints the markdown — an image embed or a `<video>` tag — to drop into the body with `gh pr edit`. It compacts as it uploads — PNG/JPEG screenshots become WebP, WebM/MOV recordings a downscaled MP4 — so you hand it raw captures and the embed stays small (a UI shot drops ~8× vs PNG). Re-running for a PR **replaces** its media (new files uploaded, then stale objects under the PR's folder deleted), so updated screenshots/recordings don't pile up. This is what lets `/pr` run end-to-end on any teammate's laptop, with no stray branch and no manual drag.
 
-Then reference the raw URLs in the body:
+- One-time per-laptop config (gitignored `.env.pr-media`, copied from `.env.example.pr-media`, filled from the team vault): `GITHUB_MEDIA_S3_ENDPOINT` + `GITHUB_MEDIA_S3_ACCESS_KEY_ID` + `GITHUB_MEDIA_S3_SECRET_ACCESS_KEY` + `GITHUB_MEDIA_PUBLIC_BASE` (the bucket's public r2.dev/custom URL — public access is required, since GitHub fetches the media unauthenticated). Namespaced `GITHUB_MEDIA_S3_*` so they never collide with the backend `STORAGE_*` or a teammate's `AWS_*`; the script maps them to `AWS_*` for the one subprocess. The `aws`, `cwebp`, and `ffmpeg` CLIs come from the nix dev shell (`flake.nix`), so `nix develop` / direnv covers it. Bucket + script are shared; only the keys are per-person.
+- If a var is missing the script exits naming it; fall back to the manual path.
 
-```markdown
-![<caption>](https://raw.githubusercontent.com/guillempuche/batuda/pr-media/<branch>/pr-<feature>-desktop.png)
+**Manual (human) — GitHub user-attachments.** Drag the file into the PR description in the web UI; GitHub mints a `user-attachments` URL bound to the PR (a `.webm` becomes an inline player). Use this when no R2 token is set up — leave a `> _Drag the <thing> in here._` placeholder in the body so the spot is obvious.
 
-<video controls src="https://raw.githubusercontent.com/guillempuche/batuda/pr-media/<branch>/pr-<feature>.webm"></video>
-```
-
-Fallback: dragging files into the PR body via the GitHub web UI mints `user-attachments` URLs that render natively (a player for `.webm`) — use that if a browser surface is available and you'd rather not push media.
+**Never** create a `pr-media` (or any media) branch — it clutters the repo with a branch nobody asked for, and surprises like that erode trust even when they work.
 
 ## Step 8 — Review loop
 

--- a/.env.example.pr-media
+++ b/.env.example.pr-media
@@ -1,0 +1,28 @@
+# ============================================================================
+# PR media uploader (scripts/gh-pr-media.sh) — teammate-local, never committed
+# ============================================================================
+#
+# Copy to `.env.pr-media` (gitignored, auto-sourced by the script) and fill from
+# the team secrets manager — the vault is the source of truth.
+#
+# Provider-agnostic S3: the shared bucket happens to live on R2, but nothing
+# here names a vendor. Namespaced GITHUB_MEDIA_S3_* so they never collide with
+# the backend STORAGE_* vars or a teammate's own AWS_*.
+# ============================================================================
+
+# S3 endpoint + credentials for the shared media bucket. Make an S3 API token
+# with Object Read & Write (e.g. dash.cloudflare.com -> R2 -> Manage R2 API
+# Tokens). The endpoint encodes your account + jurisdiction — an EU bucket looks
+# like https://<account>.eu.r2.cloudflarestorage.com.
+GITHUB_MEDIA_S3_ENDPOINT=https://<account>.eu.r2.cloudflarestorage.com
+GITHUB_MEDIA_S3_ACCESS_KEY_ID=
+GITHUB_MEDIA_S3_SECRET_ACCESS_KEY=
+GITHUB_MEDIA_S3_BUCKET=github-media
+# Leave as "auto" for R2 — the jurisdiction is in the endpoint above, not here.
+# (R2 rejects a real region like "eu"; valid values are auto/weur/eeur/enam/….)
+GITHUB_MEDIA_S3_REGION=auto
+
+# Public read base. The bucket must have public access on (an r2.dev URL or a
+# custom domain) — GitHub fetches embedded media unauthenticated, so the private
+# S3 endpoint above will NOT render.
+GITHUB_MEDIA_PUBLIC_BASE=https://pub-<hash>.r2.dev

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ apps/*/playwright-report/
 .env.local
 .env.*.local
 .env.cloud
+.env.pr-media
 apps/*/.env.cloud
 
 # Local secrets — never commit (TLS keys, dev tokens, etc.)

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,22 @@
             # so `wrangler login`, `wrangler deploy`, `wrangler dev` work
             # without each contributor having to `pnpm exec wrangler …`.
             pkgs.wrangler
+            # AWS CLI (v2). Used by scripts/gh-pr-media.sh to upload PR
+            # screenshots/recordings to the shared media bucket over S3
+            # (provider-agnostic — the bucket happens to live on R2). Installed
+            # via nix so `/pr` media upload works on every contributor's laptop
+            # with no manual install.
+            pkgs.awscli2
+            # ffmpeg — compresses /pr screen recordings before upload.
+            # agent-browser records full-resolution WebM with no quality knob,
+            # so a few desktop seconds is several MB; ffmpeg downscales, drops
+            # the frame rate, and transcodes to a compact MP4. Installed via nix
+            # so the /pr media flow is identical on every contributor's laptop.
+            pkgs.ffmpeg
+            # libwebp — provides `cwebp`, which the /pr uploader uses to convert
+            # PNG/JPEG screenshots to WebP (crisp UI text, ~8x smaller). Paired
+            # with ffmpeg so scripts/gh-pr-media.sh can compact every capture.
+            pkgs.libwebp
             # Local OpenTelemetry receiver + TUI viewer.
             # Listens on :4317 (gRPC) and :4318 (OTLP/HTTP JSON).
             # Point OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
@@ -35,6 +51,9 @@
             echo "Node:     $(node --version)"
             echo "pnpm:     $(pnpm --version)"
             echo "wrangler: $(wrangler --version 2>/dev/null || echo 'available')"
+            echo "aws:      $(aws --version 2>/dev/null || echo 'available')"
+            echo "ffmpeg:   $(ffmpeg -version 2>/dev/null | head -1 | cut -d' ' -f3)"
+            echo "cwebp:    $(cwebp -version 2>/dev/null | head -1)"
             echo "otel-tui: $(otel-tui --version 2>/dev/null || echo 'available')"
           '';
         };

--- a/scripts/gh-pr-media.sh
+++ b/scripts/gh-pr-media.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Compact a PR's screenshots/recordings and sync them to the shared media bucket
+# (default github-media), printing the markdown to embed in the PR body. Provider-
+# agnostic S3 (R2, MinIO, AWS, …) via the aws CLI, so nothing here names a vendor.
+# Works in any repo — the folder is the repo name (github-media/<repo>/).
+# No human in the loop.
+#
+# Compacts as it uploads, so you hand it the raw captures:
+#   • PNG / JPEG images  → WebP q80  (crisp UI text, ~8x smaller than PNG)
+#   • WebM / MOV videos  → MP4       (downscaled ≤1280 wide, 15 fps, no audio)
+#   • already-compact .webp / .mp4 / .gif / .svg → uploaded as-is
+#
+# Re-running for a PR REPLACES its media: new files are uploaded first, then any
+# stale object left under the PR's folder is deleted — so updated screenshots
+# and recordings don't pile up.
+#
+# Config (env, namespaced GITHUB_MEDIA_S3_* so it never collides with the backend
+# STORAGE_* or a teammate's own AWS_*). Source of truth = the team secrets
+# manager; locally fill `.env.pr-media` (gitignored, from `.env.example.pr-media`),
+# which this script auto-sources.
+#   GITHUB_MEDIA_S3_ENDPOINT          S3 endpoint, e.g. https://<acct>.eu.r2.cloudflarestorage.com
+#   GITHUB_MEDIA_S3_ACCESS_KEY_ID
+#   GITHUB_MEDIA_S3_SECRET_ACCESS_KEY
+#   GITHUB_MEDIA_PUBLIC_BASE          public read base (public access required), e.g. https://pub-<hash>.r2.dev
+#   GITHUB_MEDIA_S3_BUCKET            optional, default github-media
+#   GITHUB_MEDIA_S3_REGION            optional, default auto ("auto" for R2 — NOT a jurisdiction like "eu")
+#   AWS_CLI                           optional, default `aws` on PATH
+#
+# Tools: aws (upload) + cwebp & ffmpeg (compaction) — all from the nix dev shell.
+#
+# Usage: scripts/gh-pr-media.sh <pr-number> <file> [<file> ...]
+#   Emits one markdown line per file (image embed or <video> tag) on stdout.
+set -euo pipefail
+
+# Teammate-local config (gitignored), if present — values come from the vault.
+# set -a auto-exports everything the file defines, so the aws CLI below sees it.
+[ -f .env.pr-media ] && {
+	set -a
+	. ./.env.pr-media
+	set +a
+}
+
+awscli="${AWS_CLI:-aws}"
+command -v "$awscli" >/dev/null || {
+	echo "aws CLI not found — enter the nix dev shell (nix develop / direnv); flake.nix provides it" >&2
+	exit 127
+}
+
+bucket="${GITHUB_MEDIA_S3_BUCKET:-github-media}"
+region="${GITHUB_MEDIA_S3_REGION:-auto}"
+endpoint="${GITHUB_MEDIA_S3_ENDPOINT:?set GITHUB_MEDIA_S3_ENDPOINT to the S3 endpoint, e.g. https://<account>.eu.r2.cloudflarestorage.com}"
+base="${GITHUB_MEDIA_PUBLIC_BASE:?set GITHUB_MEDIA_PUBLIC_BASE to the public read base, e.g. https://pub-<hash>.r2.dev}"
+: "${GITHUB_MEDIA_S3_ACCESS_KEY_ID:?set GITHUB_MEDIA_S3_ACCESS_KEY_ID}"
+: "${GITHUB_MEDIA_S3_SECRET_ACCESS_KEY:?set GITHUB_MEDIA_S3_SECRET_ACCESS_KEY}"
+
+[ "$#" -ge 2 ] || {
+	echo "usage: $(basename "$0") <pr-number> <file>..." >&2
+	exit 2
+}
+pr="$1"
+shift
+slug="$(gh repo view --json name -q .name)" # repo name = the per-repo folder
+prefix="${slug}/pr-${pr}"
+
+# Converted files land here; removed on any exit.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# aws reads AWS_*; map our namespaced vars in for this process only, so the
+# backend STORAGE_* and any AWS_* the teammate has are untouched.
+export AWS_ACCESS_KEY_ID="$GITHUB_MEDIA_S3_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$GITHUB_MEDIA_S3_SECRET_ACCESS_KEY"
+export AWS_REGION="$region"
+s3api() { "$awscli" s3api "$@" --endpoint-url "$endpoint"; }
+
+lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+# Make a basename safe for an S3 key + public URL: spaces or odd characters would
+# break the markdown link and the stale-cleanup match below, so collapse anything
+# outside [A-Za-z0-9._-] to a dash (macOS screenshots come with spaces).
+safe_name() { printf '%s' "$1" | tr -cs 'A-Za-z0-9._-' '-'; }
+
+# The name a file is uploaded under: images become .webp, videos .mp4, anything
+# already compact keeps its name. Pure (no I/O) so the upload and emit passes agree.
+target_name() {
+	local base
+	base="$(safe_name "$(basename "$1")")"
+	case "$(lc "$base")" in
+	*.png | *.jpg | *.jpeg) echo "${base%.*}.webp" ;;
+	*.webm | *.mov) echo "${base%.*}.mp4" ;;
+	*) echo "$base" ;;
+	esac
+}
+
+mime() {
+	case "$(lc "$1")" in
+	*.png) echo image/png ;;
+	*.jpg | *.jpeg) echo image/jpeg ;;
+	*.gif) echo image/gif ;;
+	*.webp) echo image/webp ;;
+	*.svg) echo image/svg+xml ;;
+	*.webm) echo video/webm ;;
+	*.mp4) echo video/mp4 ;;
+	*) echo application/octet-stream ;;
+	esac
+}
+
+# Produce a compact local file to upload for $1 and echo its path. Images → WebP
+# (crisp UI text, far smaller than PNG); videos → a downscaled, 15-fps, silent MP4.
+# Files already in a compact format are uploaded untouched. Only the final path is
+# printed to stdout; the converters log to stderr, so the caller captures the path.
+prepare() {
+	local src="$1" out
+	out="${tmpdir}/$(target_name "$src")"
+	case "$(lc "$src")" in
+	*.png | *.jpg | *.jpeg)
+		command -v cwebp >/dev/null || {
+			echo "cwebp not found — enter the nix dev shell; flake.nix provides it" >&2
+			return 1
+		}
+		cwebp -quiet -q 80 "$src" -o "$out" || return 1
+		echo "$out"
+		;;
+	*.webm | *.mov)
+		command -v ffmpeg >/dev/null || {
+			echo "ffmpeg not found — enter the nix dev shell; flake.nix provides it" >&2
+			return 1
+		}
+		ffmpeg -y -loglevel error -i "$src" \
+			-vf "scale='min(1280,iw)':-2,fps=15" -c:v libx264 -crf 30 \
+			-preset veryfast -movflags +faststart -an "$out" || return 1
+		echo "$out"
+		;;
+	*) echo "$src" ;;
+	esac
+}
+
+# Fail before any upload if a path is wrong, so a bad arg never half-updates the PR.
+for f in "$@"; do
+	[ -f "$f" ] || {
+		echo "no such file: $f" >&2
+		exit 1
+	}
+done
+
+# 1) Compact + upload the new set first (a failure never leaves the PR with no media).
+keep=" "
+for f in "$@"; do
+	name="$(target_name "$f")"
+	key="${prefix}/${name}"
+	local_file="$(prepare "$f")" || exit 1
+	# content-type so .webp/.mp4 render inline; cache-control immutable since a
+	# given PR-media object never changes once posted.
+	s3api put-object --bucket "$bucket" --key "$key" --body "$local_file" \
+		--content-type "$(mime "$name")" \
+		--cache-control "public, max-age=31536000, immutable" >/dev/null || {
+		echo "upload failed: ${key}" >&2
+		exit 1
+	}
+	# Remember this object so the delete pass below knows not to remove it.
+	keep="${keep}${key} "
+done
+
+# 2) Delete anything still under the PR's folder that we didn't just upload —
+#    i.e. screenshots/recordings the PR no longer uses.
+existing="$(s3api list-objects-v2 --bucket "$bucket" --prefix "${prefix}/" \
+	--query 'Contents[].Key' --output text 2>/dev/null || true)"
+for k in $existing; do
+	[ "$k" = "None" ] && continue
+	# Is this object one we just uploaded? keep holds every uploaded key wrapped in
+	# spaces, so a space-padded match means "yes, leave it"; no match means stale.
+	case "$keep" in
+	*" $k "*) : ;; # just uploaded — keep
+	*) s3api delete-object --bucket "$bucket" --key "$k" >/dev/null ||
+		echo "warn: could not delete stale ${k}" >&2 ;;
+	esac
+done
+
+# 3) Emit the markdown for the current set.
+for f in "$@"; do
+	name="$(target_name "$f")"
+	url="${base%/}/${prefix}/${name}"
+	case "$(lc "$name")" in
+	*.mp4) printf '<video controls src="%s"></video>\n' "$url" ;;
+	*) printf '![%s](%s)\n' "$name" "$url" ;;
+	esac
+done


### PR DESCRIPTION
## What

A no-human uploader that hosts a PR's screenshots and recordings on a shared S3 bucket (`github-media`, on Cloudflare R2) and prints the markdown to embed — so `/pr` media renders inline with **no throwaway `pr-media` branch** and no manual drag. Repo tooling (the `/pr` workflow), not an app surface.

## Changes

- **`scripts/gh-pr-media.sh`** — compacts each capture on upload (PNG/JPEG → WebP, WebM/MOV → a downscaled MP4), syncs it under `<repo>/pr-<n>/`, prunes any stale object the PR no longer uses, and emits an image embed or `<video>` tag.
- **`flake.nix`** — adds `awscli2`, `ffmpeg`, `libwebp` (cwebp) to the dev shell, so the flow is identical on every laptop.
- **`.claude/skills/pr/SKILL.md`** — routes the media step through the uploader (captures stay raw; the tool compacts); drops the old `pr-media`-branch instructions.
- **`.env.example.pr-media`** + **`.gitignore`** — per-person S3 config template; the real `.env.pr-media` is gitignored.

## Impact

- **New dev-shell tools** — run `direnv reload` / re-enter `nix develop` to pick up `aws`/`cwebp`/`ffmpeg`.
- **Secrets** — per-person S3 keys live in a gitignored `.env.pr-media` (the vault is the source of truth); nothing secret is committed. Namespaced `GITHUB_MEDIA_S3_*` so they never collide with the backend `STORAGE_*` or a teammate's own `AWS_*`.
- **Bucket** — `github-media` must have public read (an r2.dev URL or a custom domain); GitHub fetches embedded media unauthenticated.
- No app / runtime / TypeScript / schema impact.

## Review guide

- The core is `scripts/gh-pr-media.sh` — `prepare()` / `target_name()` (convert-or-passthrough + the pure name map the upload and emit passes share) and the upload → stale-prune → emit passes. The flake / skill / env are wiring.
- TS gates are **N/A** — zero TypeScript changed (bash / nix / markdown / env only).
- **Snyk** isn't connected this session and bash isn't a Snyk Code language, so `snyk_code_scan` wasn't run.

## Verification

- **Real end-to-end** against the live bucket: a PNG screenshot uploaded as WebP renders at its public URL (`HTTP 200, image/webp`, **684 KB → 99 KB**); re-running pruned the stale `.png` (only the `.webp` remained); the ffmpeg transcode recipe validated on a synthetic clip.
- `bash -n` clean; pre-commit hook green (**check-types 12/12 cached**, check-deps / syncpack, lint); `pnpm install` clean; `pnpm -w build` 12/12.
- `test` left to CI (no TypeScript changed; the integration suite needs the live stack).
