### PR TITLE
cicd: skip integration phase on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,26 @@ jobs:
       - name: Test (unit)
         run: pnpm test
 
+      # The integration phase (ephemeral Neon branch, MinIO, seed, and the
+      # integration suite) only runs on pull requests. A merge into main
+      # arrives here as a `push` event whose content the PR already
+      # exercised against an identical branch, so re-running it would just
+      # spin up a second Neon branch for no extra signal. The post-merge
+      # push still runs the fast lint/build/type-check/unit steps above as
+      # a green-checkmark on main.
+      #
       # Spin up an ephemeral Neon branch for the integration phase.
       # Outputs are job-scoped + secret-marked per Neon's docs, so
       # migrations + seed + integration tests all live in this job.
       # expires_at is a safety net: if the runner is killed before the
       # delete step runs, Neon auto-cleans the branch after 6 h.
       - name: Compute Neon branch expiry (6h)
+        if: github.event_name == 'pull_request'
         id: neon-expiry
         run: echo "iso=$(date -u -d '+6 hours' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Create Neon branch
+        if: github.event_name == 'pull_request'
         id: neon-branch
         uses: neondatabase/create-branch-action@v6
         with:
@@ -74,6 +84,7 @@ jobs:
           role: neondb_owner
 
       - name: Apply migrations to CI branch
+        if: github.event_name == 'pull_request'
         env:
           DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
         run: pnpm db:migrate
@@ -84,6 +95,7 @@ jobs:
       # bucket; `--wait` blocks until both services are healthy or, in
       # storage-init's case, have exited 0.
       - name: Start MinIO via docker compose
+        if: github.event_name == 'pull_request'
         run: docker compose -f docker/docker-compose.yml up -d --wait storage storage-init
 
       # Seed fixtures (notably the `taller` / `restaurant` orgs) that
@@ -92,6 +104,7 @@ jobs:
       # end-of-run. STORAGE_* points at the MinIO container started
       # above; the seedDemoEmails stage PUTs raw RFC822 bytes there.
       - name: Seed CI branch
+        if: github.event_name == 'pull_request'
         env:
           DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
           BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci
@@ -111,6 +124,7 @@ jobs:
       # files. The proper fix (per-test transactions in multi-org) is
       # tracked as a follow-up CI-perf slice.
       - name: Test (integration)
+        if: github.event_name == 'pull_request'
         env:
           DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
           BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci


### PR DESCRIPTION
## What

CI config (`.github/workflows/ci.yml`). A merge into `main` re-triggers the same `ci` job: the PR validates the branch on the `pull_request` event, then the merge fires `push: branches [main]` and runs it all again. The expensive half of that second run — spinning up an ephemeral Neon branch, MinIO, seeding, and the integration suite — re-validates content the PR already exercised, for no extra signal.

## Changes

- Gated the integration phase (compute expiry, create Neon branch, apply migrations, start MinIO, seed, integration test) to `pull_request` events via `if: github.event_name == 'pull_request'`.
- The post-merge `push: main` run now stops after the fast phase (lint / build / type-check / unit), still producing a green check on `main`.

## Impact

- **CI cost / behavior only** — no app code touched. Every merge to `main` now skips one ephemeral Neon branch + the integration suite.
- The post-merge fast phase is intentionally kept: with rebase/squash merges the commit landing on `main` is a new SHA the PR never tested as-is, so lint/build/type-check/unit still verify the real `main` commit.
- The Neon **delete** step is unchanged — it already guards on `steps.neon-branch.outcome == 'success'`, so when the create step is skipped (outcome `skipped`) cleanup correctly no-ops. No orphaned branches.
- PR runs are completely unaffected.

## Review guide

- The whole change is six `if:` lines plus one explanatory comment. The only thing worth checking is that no integration step references an output of a skipped step without a guard — they don't: every step consuming `steps.neon-branch.outputs.*` carries the same `if`, and the delete step's existing `outcome == 'success'` guard covers the skip case.

## Verification

- `ruby -ryaml` parse of the workflow: valid.
- Pre-commit hooks ran on commit: `check-deps`, `check-types`, `lint`, `test` all green.
- Not runnable locally (GitHub Actions config); the `push: main` path will be exercised on this PR's own merge.
