### PR TITLE
feat: expose instruction transfer and donation lifecycle over MCP

### DIFF
--- a/apps/server/src/db/migrations/0014_instruction_template_transfer_fn.ts
+++ b/apps/server/src/db/migrations/0014_instruction_template_transfer_fn.ts
@@ -1,0 +1,69 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Reassigning a personal instruction template to another member can't happen in
+// the member's own access scope: the per-user read policy
+// (owner_user_id IS NULL OR = the current user) hides the resulting row from
+// them, and the row-level security rules refuse to write a row you can't see.
+// This function runs the single ownership change with elevated rights, but
+// re-checks the rules itself first — the caller must own the template in the
+// active org, and the target must be a live member of that same org — so the
+// elevation can never move a template across users or orgs even if a caller's
+// own checks are wrong. Only the request role may run it; the search path is
+// pinned empty and every object fully qualified, the standard hardening so the
+// body can't be tricked into running through a same-named impostor object.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		CREATE OR REPLACE FUNCTION public.transfer_instruction_template(
+			p_template_id uuid,
+			p_target_user_id text
+		) RETURNS SETOF public.instruction_templates
+		LANGUAGE plpgsql
+		SECURITY DEFINER
+		SET search_path = ''
+		AS $$
+		DECLARE
+			v_actor text := current_setting('app.current_user_id', true);
+			v_org   text := current_setting('app.current_org_id', true);
+		BEGIN
+			IF v_actor IS NULL OR v_actor = '' OR v_org IS NULL OR v_org = '' THEN
+				RAISE EXCEPTION 'instruction template transfer requires an active org and user scope';
+			END IF;
+
+			IF NOT EXISTS (
+				SELECT 1 FROM public.member
+				WHERE "userId" = p_target_user_id AND "organizationId" = v_org
+			) THEN
+				RAISE EXCEPTION 'instruction template transfer target is not a member of the active org';
+			END IF;
+
+			RETURN QUERY
+				WITH updated AS (
+					UPDATE public.instruction_templates
+					SET owner_user_id = p_target_user_id, updated_at = now()
+					WHERE id = p_template_id
+						AND organization_id = v_org
+						AND owner_user_id = v_actor
+					RETURNING *
+				)
+				SELECT * FROM updated;
+		END;
+		$$
+	`
+
+	// Lock execution to the request role while the migration role still owns the
+	// function — these are owner-only changes.
+	yield* sql`REVOKE EXECUTE ON FUNCTION public.transfer_instruction_template(uuid, text) FROM PUBLIC`
+	yield* sql`GRANT EXECUTE ON FUNCTION public.transfer_instruction_template(uuid, text) TO app_user`
+
+	// The function must run as app_service (BYPASSRLS) so its definer rights can
+	// write the new owner. Handing ownership over needs app_service to hold CREATE
+	// on the schema for that one step, so grant it just long enough to make the
+	// transfer, then take it back to keep app_service at least privilege.
+	yield* sql`GRANT CREATE ON SCHEMA public TO app_service`
+	yield* sql`ALTER FUNCTION public.transfer_instruction_template(uuid, text) OWNER TO app_service`
+	yield* sql`REVOKE CREATE ON SCHEMA public FROM app_service`
+})

--- a/apps/server/src/mcp/tools/_annotations.test.ts
+++ b/apps/server/src/mcp/tools/_annotations.test.ts
@@ -11,6 +11,7 @@ import { CompanyTools } from './companies'
 import { ContactTools } from './contacts'
 import { DocumentTools } from './documents'
 import { EmailTools } from './email'
+import { InstructionsMcpTools } from './instructions-mcp'
 import { InteractionTools } from './interactions'
 import { PageTools } from './pages'
 import { PipelineTools } from './pipeline'
@@ -32,6 +33,7 @@ const TOOLKITS = {
 	ContactTools,
 	DocumentTools,
 	EmailTools,
+	InstructionsMcpTools,
 	InteractionTools,
 	PageTools,
 	PipelineTools,

--- a/apps/server/src/mcp/tools/instructions-mcp.integration.test.ts
+++ b/apps/server/src/mcp/tools/instructions-mcp.integration.test.ts
@@ -1,0 +1,367 @@
+// Exercises the instruction MCP tools end-to-end against a real Postgres:
+// transfer (template ownership) and the donation lifecycle (propose → list →
+// accept/reject), driven through the real toolkit handlers the way a `tools/call`
+// would, inside the same org RLS scope (`enterOrgScope`) the /mcp middleware
+// applies. Asserts both the discriminated `{ outcome }` bodies and the resulting
+// DB state. Uses the seeded `taller` org: its `owner` acts as the admin gate, its
+// plain `member` as the proposer / transfer target. Requires $DATABASE_URL.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { Tool } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { SessionContext } from '@batuda/controllers'
+import type { Donation } from '@batuda/instructions'
+
+import { PgLive } from '../../db/client'
+import { EnvVars } from '../../lib/env'
+import { enterOrgScope } from '../../middleware/org'
+import type {
+	CreateOutcome,
+	DonateOutcome,
+	ResolveDonationOutcome,
+	TransferOutcome,
+} from '../../services/instructions'
+import { InstructionsService } from '../../services/instructions'
+import { applyTestEnv } from '../../test-env'
+import {
+	InstructionsMcpHandlersLive,
+	InstructionsMcpTools,
+} from './instructions-mcp'
+
+// Config has no defaults; set the required env before any layer reads it.
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+// Namespaces every row this suite creates so cleanup never touches seed data.
+const MARKER = `mcp-verify-${randomUUID()}-`
+
+type Org = { id: string; name: string; slug: string }
+type Tools = typeof InstructionsMcpTools.tools
+
+// The handlers are provided per call against the transaction-scoped SqlClient
+// `enterOrgScope` opens, so the service's queries see the request's role + GUCs
+// exactly as they do behind the live /mcp middleware.
+const HandlersLayer = InstructionsMcpHandlersLive.pipe(
+	Layer.provide(InstructionsService.layer),
+)
+const makeRuntime = () =>
+	ManagedRuntime.make(PgLive.pipe(Layer.provide(EnvVars.layer)))
+
+let pool: pg.Pool
+let runtime: ReturnType<typeof makeRuntime>
+let taller: Org
+let ownerId: string
+let memberId: string
+
+const orgBySlug = async (slug: string): Promise<Org> => {
+	const result = await pool.query<Org>(
+		'SELECT id, name, slug FROM organization WHERE slug = $1 LIMIT 1',
+		[slug],
+	)
+	const row = result.rows[0]
+	if (!row)
+		throw new Error(
+			`${slug} org missing — run 'pnpm cli db reset && pnpm cli seed'`,
+		)
+	return row
+}
+
+const memberWithRole = async (orgId: string, role: string): Promise<string> => {
+	const r = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 AND role = $2 LIMIT 1',
+		[orgId, role],
+	)
+	const id = r.rows[0]?.userId
+	if (!id) throw new Error(`taller has no ${role} member — run 'pnpm cli seed'`)
+	return id
+}
+
+const cleanup = async () => {
+	await pool.query(
+		'DELETE FROM instruction_template_donations WHERE name LIKE $1',
+		[`${MARKER}%`],
+	)
+	await pool.query('DELETE FROM instruction_templates WHERE name LIKE $1', [
+		`${MARKER}%`,
+	])
+}
+
+// Invokes a tool the way the MCP server does: validate params, run the handler,
+// collect its single result — all inside the actor's org RLS scope.
+const callTool = (
+	actorId: string,
+	name: keyof Tools & string,
+	params: Tool.Parameters<Tools[keyof Tools]>,
+): Promise<unknown> =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org: taller, userId: actorId })(
+				Effect.gen(function* () {
+					const toolkit = yield* InstructionsMcpTools
+					const stream = yield* toolkit.handle(name, params)
+					const [first] = yield* Stream.runCollect(stream)
+					return first?.result as unknown
+				}).pipe(
+					Effect.provideService(SessionContext, {
+						userId: actorId,
+						email: `${actorId}@verify.local`,
+						name: undefined,
+						isAgent: true,
+					}),
+					Effect.provide(HandlersLayer),
+				),
+			)
+		}),
+	)
+
+// Creates a personal template owned by `actorId`, returning its id.
+const createPersonalTemplate = async (
+	actorId: string,
+	label: string,
+): Promise<string> => {
+	const created = (await callTool(actorId, 'manage_instruction_template', {
+		action: 'create',
+		name: `${MARKER}${label}`,
+		body: 'verification body',
+		scope: 'personal',
+	})) as CreateOutcome
+	if (created.outcome !== 'created')
+		throw new Error(`create failed: ${JSON.stringify(created)}`)
+	return created.template.id
+}
+
+// Calls the privileged transfer function directly in the actor's app_user scope,
+// bypassing the service's own checks, to prove the function re-enforces them.
+const callTransferFn = (
+	actorId: string,
+	templateId: string,
+	targetUserId: string,
+): Promise<ReadonlyArray<{ owner_user_id: string | null }>> =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org: taller, userId: actorId })(
+				sql<{ owner_user_id: string | null }>`
+					SELECT owner_user_id
+					FROM transfer_instruction_template(${templateId}, ${targetUserId})
+				`,
+			)
+		}),
+	)
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	taller = await orgBySlug('taller')
+	ownerId = await memberWithRole(taller.id, 'owner')
+	memberId = await memberWithRole(taller.id, 'member')
+	await cleanup()
+	runtime = makeRuntime()
+}, 60_000)
+
+afterAll(async () => {
+	await cleanup()
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('MCP instruction tools against live Postgres', () => {
+	describe('when a member transfers a personal template', () => {
+		it('should flip ownership to the target member', async () => {
+			// GIVEN the member owns a personal template
+			const id = await createPersonalTemplate(memberId, 'transfer')
+
+			// WHEN the member transfers it to the owner
+			const moved = (await callTool(memberId, 'manage_instruction_template', {
+				action: 'transfer',
+				id,
+				target_user_id: ownerId,
+			})) as TransferOutcome
+
+			// THEN the outcome is transferred and the row's owner flips
+			// [instructions-mcp.ts manage_instruction_template:transfer]
+			expect(moved.outcome).toBe('transferred')
+			const row = await pool.query<{ owner_user_id: string }>(
+				'SELECT owner_user_id FROM instruction_templates WHERE id = $1',
+				[id],
+			)
+			expect(row.rows[0]?.owner_user_id).toBe(ownerId)
+		})
+
+		it('should reject a transfer that omits the target', async () => {
+			// GIVEN a personal template
+			const id = await createPersonalTemplate(memberId, 'transfer-bad')
+
+			// WHEN transfer is called without target_user_id
+			const res = await callTool(memberId, 'manage_instruction_template', {
+				action: 'transfer',
+				id,
+			})
+
+			// THEN the handler reports the missing parameter, untouched
+			// [instructions-mcp.ts manage_instruction_template:transfer guard]
+			expect(res).toMatchObject({
+				error: expect.stringContaining('target_user_id'),
+			})
+		})
+	})
+
+	describe('when a member donates a template the org reviews', () => {
+		it('should let an admin accept it into a fresh org template', async () => {
+			// GIVEN the member proposes a personal template to the org
+			const templateId = await createPersonalTemplate(memberId, 'donate-accept')
+			const proposed = (await callTool(
+				memberId,
+				'manage_instruction_donation',
+				{
+					action: 'propose',
+					template_id: templateId,
+				},
+			)) as DonateOutcome
+			if (proposed.outcome !== 'proposed')
+				throw new Error(`propose failed: ${JSON.stringify(proposed)}`)
+			const donationId = proposed.donation.id
+
+			// WHEN the owner lists pending donations
+			// [instructions-mcp.ts manage_instruction_donation:list]
+			const pending = (await callTool(ownerId, 'manage_instruction_donation', {
+				action: 'list',
+				status: 'pending',
+			})) as ReadonlyArray<Donation>
+			expect(pending.some(d => d.id === donationId)).toBe(true)
+
+			// AND the owner accepts it
+			const accepted = (await callTool(ownerId, 'manage_instruction_donation', {
+				action: 'accept',
+				id: donationId,
+			})) as ResolveDonationOutcome
+
+			// THEN a fresh org-owned template is created and the donation closes
+			// [instructions-mcp.ts manage_instruction_donation:accept]
+			if (accepted.outcome !== 'accepted')
+				throw new Error(`accept failed: ${JSON.stringify(accepted)}`)
+			const orgTemplate = await pool.query<{ owner_user_id: string | null }>(
+				'SELECT owner_user_id FROM instruction_templates WHERE id = $1',
+				[accepted.template.id],
+			)
+			expect(orgTemplate.rows[0]?.owner_user_id).toBeNull()
+			const donation = await pool.query<{ status: string }>(
+				'SELECT status FROM instruction_template_donations WHERE id = $1',
+				[donationId],
+			)
+			expect(donation.rows[0]?.status).toBe('accepted')
+		})
+
+		it('should let an admin reject a pending donation', async () => {
+			// GIVEN a pending donation
+			const templateId = await createPersonalTemplate(memberId, 'donate-reject')
+			const proposed = (await callTool(
+				memberId,
+				'manage_instruction_donation',
+				{
+					action: 'propose',
+					template_id: templateId,
+				},
+			)) as DonateOutcome
+			if (proposed.outcome !== 'proposed')
+				throw new Error(`propose failed: ${JSON.stringify(proposed)}`)
+
+			// WHEN the owner rejects it
+			const rejected = (await callTool(ownerId, 'manage_instruction_donation', {
+				action: 'reject',
+				id: proposed.donation.id,
+			})) as ResolveDonationOutcome
+
+			// THEN the proposal closes as rejected
+			// [instructions-mcp.ts manage_instruction_donation:reject]
+			expect(rejected.outcome).toBe('rejected')
+			const donation = await pool.query<{ status: string }>(
+				'SELECT status FROM instruction_template_donations WHERE id = $1',
+				[proposed.donation.id],
+			)
+			expect(donation.rows[0]?.status).toBe('rejected')
+		})
+
+		it('should forbid a non-admin from accepting', async () => {
+			// GIVEN a pending donation
+			const templateId = await createPersonalTemplate(memberId, 'donate-forbid')
+			const proposed = (await callTool(
+				memberId,
+				'manage_instruction_donation',
+				{
+					action: 'propose',
+					template_id: templateId,
+				},
+			)) as DonateOutcome
+			if (proposed.outcome !== 'proposed')
+				throw new Error(`propose failed: ${JSON.stringify(proposed)}`)
+
+			// WHEN the plain member tries to accept it
+			const res = (await callTool(memberId, 'manage_instruction_donation', {
+				action: 'accept',
+				id: proposed.donation.id,
+			})) as ResolveDonationOutcome
+
+			// THEN the admin gate forbids it and the donation stays pending
+			// [instructions-mcp.ts manage_instruction_donation:accept admin gate]
+			expect(res.outcome).toBe('forbidden')
+			const donation = await pool.query<{ status: string }>(
+				'SELECT status FROM instruction_template_donations WHERE id = $1',
+				[proposed.donation.id],
+			)
+			expect(donation.rows[0]?.status).toBe('pending')
+		})
+
+		it('should reject a propose that omits the template', async () => {
+			// WHEN propose is called without template_id
+			const res = await callTool(memberId, 'manage_instruction_donation', {
+				action: 'propose',
+			})
+
+			// THEN the handler reports the missing parameter
+			// [instructions-mcp.ts manage_instruction_donation:propose guard]
+			expect(res).toMatchObject({
+				error: expect.stringContaining('template_id'),
+			})
+		})
+	})
+
+	// The transfer function self-elevates (BYPASSRLS), so it re-checks the rules
+	// the service checks above. These call it directly, past the service, to prove
+	// the elevation can't be abused even if a caller's checks were wrong.
+	describe('when the transfer function is called past the service checks', () => {
+		it('should refuse to move a template the caller does not own', async () => {
+			// GIVEN a template owned by the admin
+			const adminTemplate = await createPersonalTemplate(ownerId, 'fn-owned')
+
+			// WHEN the plain member invokes the function for it directly
+			const rows = await callTransferFn(memberId, adminTemplate, memberId)
+
+			// THEN the in-DB ownership guard yields no row and the owner is untouched
+			// [0014_instruction_template_transfer_fn.ts — owner_user_id = v_actor guard]
+			expect(rows).toHaveLength(0)
+			const check = await pool.query<{ owner_user_id: string }>(
+				'SELECT owner_user_id FROM instruction_templates WHERE id = $1',
+				[adminTemplate],
+			)
+			expect(check.rows[0]?.owner_user_id).toBe(ownerId)
+		})
+
+		it('should reject a target who is not a member of the org', async () => {
+			// GIVEN a template the member owns
+			const id = await createPersonalTemplate(memberId, 'fn-nonmember')
+
+			// WHEN the function is called with a non-member target
+			const attempt = callTransferFn(memberId, id, 'not-a-member-user-id')
+
+			// THEN the in-DB membership guard raises rather than transferring
+			// [0014_instruction_template_transfer_fn.ts — membership EXISTS guard]
+			await expect(attempt).rejects.toThrow()
+		})
+	})
+})

--- a/apps/server/src/mcp/tools/instructions-mcp.ts
+++ b/apps/server/src/mcp/tools/instructions-mcp.ts
@@ -18,13 +18,14 @@ const Scope = Schema.Literals(['personal', 'org'])
 
 const ManageTemplate = Tool.make('manage_instruction_template', {
 	description:
-		'List, create, update, or delete instruction templates for the active org. scope=org targets an org-owned template (admin only); scope=personal targets your own. Editing an org template as a non-admin forks a personal copy.',
+		'List, create, update, delete, or transfer instruction templates for the active org. scope=org targets an org-owned template (admin only); scope=personal targets your own. Editing an org template as a non-admin forks a personal copy. transfer hands a personal template you own to another member (target_user_id).',
 	parameters: Schema.Struct({
-		action: Schema.Literals(['list', 'create', 'update', 'delete']),
+		action: Schema.Literals(['list', 'create', 'update', 'delete', 'transfer']),
 		id: Schema.optional(Uuid),
 		name: Schema.optional(Schema.String),
 		body: Schema.optional(Schema.String),
 		scope: Schema.optional(Scope),
+		target_user_id: Schema.optional(Schema.String),
 	}),
 	success: Schema.Unknown,
 	dependencies: REQUEST_DEPENDENCIES,
@@ -63,10 +64,28 @@ const ManageDefaultStack = Tool.make('manage_instruction_default_stack', {
 	.annotate(Tool.Title, 'Manage Instruction Default Stack')
 	.annotate(Tool.OpenWorld, false)
 
+const ManageDonation = Tool.make('manage_instruction_donation', {
+	description:
+		'Donate a personal instruction template to the org for shared use, or review pending donations. propose submits a personal template you own (template_id) for admin review; list returns donations (optionally filtered by status); accept (admin only) creates a fresh org template from the proposal; reject (admin only) closes it. Accepting reads only the snapshot taken when the donation was proposed, never the proposer’s still-personal template.',
+	parameters: Schema.Struct({
+		action: Schema.Literals(['propose', 'list', 'accept', 'reject']),
+		template_id: Schema.optional(Uuid),
+		id: Schema.optional(Uuid),
+		status: Schema.optional(
+			Schema.Literals(['pending', 'accepted', 'rejected']),
+		),
+	}),
+	success: Schema.Unknown,
+	dependencies: REQUEST_DEPENDENCIES,
+})
+	.annotate(Tool.Title, 'Manage Instruction Donations')
+	.annotate(Tool.OpenWorld, false)
+
 export const InstructionsMcpTools = Toolkit.make(
 	ManageTemplate,
 	ManagePreset,
 	ManageDefaultStack,
+	ManageDonation,
 )
 
 export const InstructionsMcpHandlersLive = InstructionsMcpTools.toLayer(
@@ -115,6 +134,17 @@ export const InstructionsMcpHandlersLive = InstructionsMcpTools.toLayer(
 							if (params.id === undefined)
 								return { error: 'id is required to delete' }
 							return yield* run(svc.remove(userId, params.id))
+						case 'transfer':
+							if (
+								params.id === undefined ||
+								params.target_user_id === undefined
+							)
+								return {
+									error: 'id and target_user_id are required to transfer',
+								}
+							return yield* run(
+								svc.transfer(org.id, userId, params.id, params.target_user_id),
+							)
 					}
 				}),
 
@@ -159,6 +189,28 @@ export const InstructionsMcpHandlersLive = InstructionsMcpTools.toLayer(
 											params.composition ?? 'replace',
 										),
 							)
+					}
+				}),
+
+			manage_instruction_donation: params =>
+				Effect.gen(function* () {
+					const org = yield* CurrentOrg
+					const { userId } = yield* SessionContext
+					switch (params.action) {
+						case 'list':
+							return yield* run(svc.listDonations(params.status))
+						case 'propose':
+							if (params.template_id === undefined)
+								return { error: 'template_id is required to propose' }
+							return yield* run(svc.propose(org.id, userId, params.template_id))
+						case 'accept':
+							if (params.id === undefined)
+								return { error: 'id is required to accept' }
+							return yield* run(svc.accept(userId, params.id))
+						case 'reject':
+							if (params.id === undefined)
+								return { error: 'id is required to reject' }
+							return yield* run(svc.reject(userId, params.id))
 					}
 				}),
 		}

--- a/packages/instructions/src/management.ts
+++ b/packages/instructions/src/management.ts
@@ -136,8 +136,12 @@ export const forkTemplate = (
 		})
 	})
 
-// Hand a template to another member. RLS lets the owner target their own row and
-// only requires the new owner to stay in-org, so the app validates the target.
+// Hand a template to another member in the same org. A member can't make this
+// change directly: once the new owner is set, the per-user read policy hides the
+// row from the member, and the table refuses to write a row they can no longer
+// see. So the ownership change runs through a privileged database function that
+// re-checks ownership and target membership before reassigning. It returns the
+// updated row on success, or no row when the caller doesn't own the template.
 export const transferTemplateToUser = (
 	id: string,
 	targetUserId: string,
@@ -145,10 +149,8 @@ export const transferTemplateToUser = (
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
 		const rows = yield* sql<TemplateRow>`
-			UPDATE instruction_templates
-			SET owner_user_id = ${targetUserId}, updated_at = now()
-			WHERE id = ${id}
-			RETURNING id, organization_id, owner_user_id, name, body, source_preset_id, created_by, updated_at::text AS updated_at
+			SELECT id, organization_id, owner_user_id, name, body, source_preset_id, created_by, updated_at::text AS updated_at
+			FROM transfer_instruction_template(${id}, ${targetUserId})
 		`
 		const row = rows[0]
 		return row ? toTemplate(row) : undefined


### PR DESCRIPTION
## What

I brought the instruction-template **MCP** surface to parity with the **HTTP** one, and fixed template **transfer**, which turned out to be RLS-broken on *both* transports. This lives in the instructions context — the surface-neutral `@batuda/instructions` package, the shared `InstructionsService`, and the two transports (`@batuda/controllers` HTTP routes + the `apps/server` MCP tools). The MCP surface already exposed templates, presets, and default stacks but omitted the donation lifecycle and transfer; this closes that gap.

## Changes

- Added a `manage_instruction_donation` MCP tool (`propose` / `list` / `accept` / `reject`) and a `transfer` action on `manage_instruction_template`, so an agent reaches the same instruction controls the web app does. Both delegate to the existing `InstructionsService` — no new business logic.
- Fixed template transfer. A member can't reassign a personal template in their own access scope: once the new owner is set, the per-user read policy hides the row and the table refuses to write a row the member can no longer see. Transfer now goes through a privileged `SECURITY DEFINER` database function that re-checks ownership and target membership before flipping the owner.
- Closed a pre-existing gap: the instruction toolkit was never covered by the MCP annotation regression test; it is now.

## Impact

- **Migration — must run before the server tag.** `0014_instruction_template_transfer_fn.ts` creates `transfer_instruction_template(...)`. The deploy doesn't auto-migrate, so apply it before the new server boots. Non-destructive (adds a function, no table/column change). No regression risk if ordering slips — the old transfer path already only ever 500'd.
- **Multi-org / RLS — a deliberate, narrow exception to "RLS-only".** The function is owned by `app_service` (BYPASSRLS), so it bypasses row-level security for one statement — the only way to express "reassign ownership to another user", which FORCE RLS structurally forbids from the actor's own scope. The privilege is fenced: EXECUTE revoked from PUBLIC and granted only to `app_user`; the body re-derives actor + org from the request GUCs (never from parameters) and constrains the UPDATE to `owner_user_id = actor AND organization_id = active-org`, with a target-membership check in the active org. It can't move a template across users or orgs even if a caller's checks are wrong. `search_path` is pinned empty with every object fully qualified.
- **MCP ↔ HTTP parity.** Both transports share `InstructionsService` and now `transferTemplateToUser`, so the transfer fix lands on *both* surfaces at once (HTTP's transfer was equally broken before). The new donation tool reaches parity with the donation routes HTTP already had.
- No new env vars, no wire-shape/API change, no auth-boundary change.

## Review guide

- Start at `apps/server/src/db/migrations/0014_instruction_template_transfer_fn.ts` — the only security-sensitive part. The thing to sanity-check: the in-function ownership + membership checks key off the GUCs (`app.current_user_id` / `app.current_org_id`), not the function arguments.
- **Decision you might overrule:** introducing a `SECURITY DEFINER` function at all, as a controlled exception to the otherwise RLS-only model. I picked it over (a) a mid-request `SET ROLE app_service` (weakest — BYPASSRLS active in-request with an unguarded statement) and (b) an accept-based transfer (most secure but a bigger consent-flow build). This keeps the elevation to one auditable, EXECUTE-gated, self-checking statement.
- `instructions-mcp.ts` and the `management.ts` one-liner are mechanical delegations — skim-able.
- I ran an adversarial security review of the function (cross-user, cross-org, search_path hijack, injection, BYPASSRLS leak, GUC spoofing, EXECUTE fail-open) — all safe. **Snyk was not available in my environment**, so `snyk_code_scan` was not run.

## Tests

- A live integration test drives the real MCP tool handlers against a seeded Postgres in the same org RLS scope the `/mcp` middleware uses: the donation lifecycle (propose → list → accept → reject), the admin gate (non-admin accept → forbidden), transfer (ownership flips), and both missing-parameter guards.
- Two cases call the transfer function directly, past the service checks, to prove its in-DB backstop fires: a non-owner gets no row; a non-member target raises.
- The instructions toolkit is now in the MCP annotation regression test.

## Verification

- Gates: `pnpm install` (no lockfile drift) → `check-types` (12/12) + `test` (17/17 tasks, 252 server unit tests) → `build` (12/12) — all green.
- Applied the migration via the real migrator (lands as `0014`, tracked) and ran the integration suite (8/8) against the seeded local Postgres.
