### PR TITLE
feat: support app-specific passwords for 2FA mailboxes

### DIFF
--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -87,6 +87,11 @@ msgstr "{0} empreses amb filtres aplicats"
 msgid "{0} msgs"
 msgstr "{0} missatges"
 
+#. placeholder {0}: selectedPreset.name
+#: src/routes/emails/inboxes.tsx:881
+msgid "{0} no longer allows password sign-in for mail apps, so it can't be connected here yet — it needs an OAuth sign-in. Pick another provider or use Generic IMAP."
+msgstr "{0} ja no permet iniciar la sessió amb contrasenya a les aplicacions de correu, així que de moment no es pot connectar aquí: necessita un inici de sessió OAuth. Tria un altre proveïdor o fes servir IMAP genèric."
+
 #. placeholder {0}: failedIds.length
 #: src/routes/emails/index.tsx:494
 #: src/routes/emails/index.tsx:526
@@ -142,6 +147,10 @@ msgstr "1 fil"
 msgid "1 thread selected"
 msgstr "1 fil seleccionat"
 
+#: src/routes/emails/inboxes.tsx:467
+msgid "2FA accounts need an app-specific password."
+msgstr "Els comptes amb verificació en dos passos necessiten una contrasenya d'aplicació."
+
 #: src/components/instructions/template-editor-dialog.tsx:139
 msgid "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
 msgstr "Una etiqueta curta. Si vols, comença-la amb un [tag] com ara [research] per agrupar plantilles relacionades; els claudàtors només formen part del nom."
@@ -167,11 +176,11 @@ msgstr "Accés"
 msgid "across {0} providers"
 msgstr "en {0} proveïdors"
 
-#: src/routes/emails/inboxes.tsx:418
+#: src/routes/emails/inboxes.tsx:428
 msgid "Actions"
 msgstr "Accions"
 
-#: src/routes/emails/inboxes.tsx:416
+#: src/routes/emails/inboxes.tsx:426
 msgid "Active"
 msgstr "Activa"
 
@@ -266,8 +275,8 @@ msgstr "Admin"
 msgid "After approving, manage which org each one acts in here."
 msgstr "Després d'aprovar-lo, gestiona aquí en quina organització actua cadascun."
 
-#: src/routes/emails/inboxes.tsx:461
-#: src/routes/emails/inboxes.tsx:1003
+#: src/routes/emails/inboxes.tsx:488
+#: src/routes/emails/inboxes.tsx:1067
 msgid "Agent"
 msgstr "Agent"
 
@@ -349,7 +358,7 @@ msgstr "adjunt"
 msgid "Audit log"
 msgstr "Registre d'auditoria"
 
-#: src/routes/emails/inboxes.tsx:450
+#: src/routes/emails/inboxes.tsx:460
 msgid "Auth failed"
 msgstr "Error d'autenticació"
 
@@ -361,7 +370,7 @@ msgstr "Torna al compte"
 msgid "Back to companies"
 msgstr "Tornar a empreses"
 
-#: src/routes/emails/inboxes.tsx:307
+#: src/routes/emails/inboxes.tsx:317
 msgid "Back to emails"
 msgstr "Torna als correus"
 
@@ -490,8 +499,8 @@ msgstr "Crides"
 #: src/components/instructions/template-editor-dialog.tsx:178
 #: src/components/interactions/quick-capture-dialog.tsx:400
 #: src/components/research/research-dialog.tsx:271
-#: src/routes/emails/inboxes.tsx:1065
-#: src/routes/emails/inboxes.tsx:1463
+#: src/routes/emails/inboxes.tsx:1129
+#: src/routes/emails/inboxes.tsx:1542
 #: src/routes/settings/api-keys/index.tsx:424
 #: src/routes/tasks/index.tsx:743
 msgid "Cancel"
@@ -519,7 +528,7 @@ msgstr "Canvio d'opinió — vull posar contrasenya"
 msgid "Change password"
 msgstr "Canvia la contrasenya"
 
-#: src/routes/emails/inboxes.tsx:943
+#: src/routes/emails/inboxes.tsx:1007
 msgid "Change password (re-probes the connection)"
 msgstr "Canvia la contrasenya (reprova la connexió)"
 
@@ -557,7 +566,7 @@ msgstr "Comprova que la sessió sigui vàlida o torna-ho a provar."
 msgid "Check that your session is valid or try again."
 msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
 
-#: src/routes/emails/inboxes.tsx:390
+#: src/routes/emails/inboxes.tsx:400
 msgid "Check the session or try again."
 msgstr "Comprova la sessió o torna-ho a provar."
 
@@ -570,8 +579,8 @@ msgstr "Mira la safata d'entrada"
 msgid "Choose organization"
 msgstr "Tria una organització"
 
-#: src/routes/emails/inboxes.tsx:355
-#: src/routes/emails/inboxes.tsx:356
+#: src/routes/emails/inboxes.tsx:365
+#: src/routes/emails/inboxes.tsx:366
 msgid "Choose primary inbox"
 msgstr "Tria la bústia principal"
 
@@ -607,8 +616,8 @@ msgstr "Client"
 #: src/components/research/research-dialog.tsx:159
 #: src/routes/calendar/index.tsx:367
 #: src/routes/emails/$threadId.tsx:353
-#: src/routes/emails/inboxes.tsx:795
-#: src/routes/emails/inboxes.tsx:1346
+#: src/routes/emails/inboxes.tsx:835
+#: src/routes/emails/inboxes.tsx:1425
 #: src/routes/emails/index.tsx:732
 msgid "Close"
 msgstr "Tanca"
@@ -711,17 +720,17 @@ msgstr "Connecta eines d'IA"
 msgid "Connect AI tools over MCP"
 msgstr "Connecta eines d'IA amb MCP"
 
-#: src/routes/emails/inboxes.tsx:452
+#: src/routes/emails/inboxes.tsx:462
 msgid "Connect failed"
 msgstr "Connexió fallida"
 
-#: src/routes/emails/inboxes.tsx:311
+#: src/routes/emails/inboxes.tsx:321
 msgid "Connect IMAP/SMTP mailboxes and choose your primary sender."
 msgstr "Connecta bústies IMAP/SMTP i tria el remitent principal."
 
-#: src/routes/emails/inboxes.tsx:321
-#: src/routes/emails/inboxes.tsx:405
-#: src/routes/emails/inboxes.tsx:791
+#: src/routes/emails/inboxes.tsx:331
+#: src/routes/emails/inboxes.tsx:415
+#: src/routes/emails/inboxes.tsx:831
 msgid "Connect mailbox"
 msgstr "Connecta una bústia"
 
@@ -729,11 +738,11 @@ msgstr "Connecta una bústia"
 msgid "Connect to Batuda?"
 msgstr "Connectar a Batuda?"
 
-#: src/routes/emails/inboxes.tsx:396
+#: src/routes/emails/inboxes.tsx:406
 msgid "Connect your IMAP/SMTP mailbox to start sending and receiving email."
 msgstr "Connecta la teva bústia IMAP/SMTP per començar a enviar i rebre correu."
 
-#: src/routes/emails/inboxes.tsx:448
+#: src/routes/emails/inboxes.tsx:458
 msgid "Connected"
 msgstr "Connectada"
 
@@ -746,7 +755,7 @@ msgstr "Connectat {0}"
 msgid "Connecting…"
 msgstr "Connectant…"
 
-#: src/routes/emails/inboxes.tsx:248
+#: src/routes/emails/inboxes.tsx:258
 msgid "Connection tested"
 msgstr "Connexió provada"
 
@@ -771,7 +780,7 @@ msgstr "Contactes"
 msgid "Contacts found"
 msgstr "Contactes trobats"
 
-#: src/routes/emails/inboxes.tsx:1433
+#: src/routes/emails/inboxes.tsx:1512
 msgid "Content"
 msgstr "Contingut"
 
@@ -821,7 +830,7 @@ msgstr "No s'''ha pogut esborrar la supressió"
 msgid "Could not complete the connection. Please try again."
 msgstr "No s'ha pogut completar la connexió. Torna-ho a provar."
 
-#: src/routes/emails/inboxes.tsx:556
+#: src/routes/emails/inboxes.tsx:583
 msgid "Could not create the inbox. Check transport or credentials."
 msgstr "No s'ha pogut crear la bústia. Revisa el transport o les credencials."
 
@@ -837,7 +846,7 @@ msgstr "No s'ha pogut eliminar la clau. Torna-ho a provar."
 msgid "Could not load companies"
 msgstr "No s'han pogut carregar les empreses"
 
-#: src/routes/emails/inboxes.tsx:389
+#: src/routes/emails/inboxes.tsx:399
 msgid "Could not load inboxes"
 msgstr "No s'han pogut carregar les safates"
 
@@ -878,7 +887,7 @@ msgid "Could not publish the page. Please try again."
 msgstr "No s'ha pogut publicar la pàgina. Torna-ho a provar."
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:242
+#: src/routes/emails/inboxes.tsx:252
 msgid "Could not reach {0}."
 msgstr "No s'ha pogut arribar a {0}."
 
@@ -890,7 +899,7 @@ msgstr "No s'ha pogut eliminar {email}. Torna-ho a provar."
 msgid "Could not save"
 msgstr "No s'ha pogut desar"
 
-#: src/routes/emails/inboxes.tsx:574
+#: src/routes/emails/inboxes.tsx:601
 msgid "Could not save the inbox."
 msgstr "No s'ha pogut desar la safata."
 
@@ -911,11 +920,11 @@ msgstr "No s'''ha pogut enviar la invitació. Torna-ho a provar."
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "No s'ha pogut enviar l'enllaç. Torna-ho a provar d'aquí uns segons."
 
-#: src/routes/emails/inboxes.tsx:286
+#: src/routes/emails/inboxes.tsx:296
 msgid "Could not set primary inbox"
 msgstr "No s'ha pogut establir la bústia principal"
 
-#: src/routes/emails/inboxes.tsx:226
+#: src/routes/emails/inboxes.tsx:236
 msgid "Could not set the default inbox."
 msgstr "No s'ha pogut establir la safata per defecte."
 
@@ -931,7 +940,7 @@ msgstr "No s'ha pogut iniciar la recerca. Torna-ho a provar."
 msgid "Could not switch organization. Please try again."
 msgstr "No s'ha pogut canviar d'organització. Torna-ho a provar."
 
-#: src/routes/emails/inboxes.tsx:205
+#: src/routes/emails/inboxes.tsx:215
 msgid "Could not toggle the inbox state."
 msgstr "No s'ha pogut canviar l'estat de la safata."
 
@@ -985,11 +994,11 @@ msgstr "No s'ha pogut enviar"
 msgid "Couldn't update your preference. Try again."
 msgstr "No he pogut desar la teva preferència. Prova-ho de nou."
 
-#: src/routes/emails/inboxes.tsx:1475
+#: src/routes/emails/inboxes.tsx:1554
 msgid "Create"
 msgstr "Crea"
 
-#: src/routes/emails/inboxes.tsx:1359
+#: src/routes/emails/inboxes.tsx:1438
 msgid "Create a footer to append to outgoing emails from this inbox."
 msgstr "Crea un peu de pàgina per afegir als correus sortints d'aquesta bústia."
 
@@ -1017,7 +1026,12 @@ msgstr "Crea una clau d'API"
 msgid "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
 msgstr "Crea una clau d'API i enganxa el fragment de la teva eina — substituint <0>YOUR_API_KEY</0> per la clau. La clau actua en aquesta organització."
 
-#: src/routes/emails/inboxes.tsx:1253
+#: src/routes/emails/inboxes.tsx:476
+#: src/routes/emails/inboxes.tsx:895
+msgid "Create an app password →"
+msgstr "Crea una contrasenya d'aplicació →"
+
+#: src/routes/emails/inboxes.tsx:1332
 msgid "Create failed"
 msgstr "Error en crear"
 
@@ -1025,7 +1039,7 @@ msgstr "Error en crear"
 msgid "Create follow-up task"
 msgstr "Crea una tasca de seguiment"
 
-#: src/routes/emails/inboxes.tsx:1411
+#: src/routes/emails/inboxes.tsx:1490
 msgid "Create footer"
 msgstr "Crea peu de pàgina"
 
@@ -1034,7 +1048,7 @@ msgid "Create key"
 msgstr "Crea la clau"
 
 #: src/routes/emails/$threadId.tsx:498
-#: src/routes/emails/inboxes.tsx:417
+#: src/routes/emails/inboxes.tsx:427
 msgid "Created"
 msgstr "Creada"
 
@@ -1087,25 +1101,25 @@ msgstr "Rebutja"
 msgid "Decline {0}"
 msgstr "Rebutja {0}"
 
-#: src/routes/emails/inboxes.tsx:415
-#: src/routes/emails/inboxes.tsx:1368
+#: src/routes/emails/inboxes.tsx:425
+#: src/routes/emails/inboxes.tsx:1447
 msgid "Default"
 msgstr "Per defecte"
 
-#: src/routes/emails/inboxes.tsx:473
+#: src/routes/emails/inboxes.tsx:500
 msgid "Default inbox"
 msgstr "Safata per defecte"
 
-#: src/routes/emails/inboxes.tsx:930
+#: src/routes/emails/inboxes.tsx:994
 msgid "Defaults to the email address."
 msgstr "Per defecte, l'adreça electrònica."
 
-#: src/routes/emails/inboxes.tsx:1025
+#: src/routes/emails/inboxes.tsx:1089
 msgid "Defaults to you when omitted."
 msgstr "Per defecte ets tu si s'omet."
 
 #: src/components/instructions/template-delete-confirm.tsx:51
-#: src/routes/emails/inboxes.tsx:1395
+#: src/routes/emails/inboxes.tsx:1474
 #: src/routes/settings/api-keys/index.tsx:329
 msgid "Delete"
 msgstr "Elimina"
@@ -1116,8 +1130,8 @@ msgstr "Elimina"
 msgid "Delete {0}"
 msgstr "Elimina {0}"
 
-#: src/routes/emails/inboxes.tsx:266
-#: src/routes/emails/inboxes.tsx:1303
+#: src/routes/emails/inboxes.tsx:276
+#: src/routes/emails/inboxes.tsx:1382
 #: src/routes/settings/api-keys/index.tsx:162
 #: src/routes/settings/organization/templates.tsx:249
 #: src/routes/settings/profile/templates.tsx:130
@@ -1126,12 +1140,12 @@ msgid "Delete failed"
 msgstr "Error en eliminar"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:537
+#: src/routes/emails/inboxes.tsx:564
 msgid "Delete inbox {0}"
 msgstr "Suprimeix la bústia {0}"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:260
+#: src/routes/emails/inboxes.tsx:270
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
 msgstr "Suprimir la bústia {0}? Els missatges desats es mantenen; la connexió s'atura."
 
@@ -1139,7 +1153,7 @@ msgstr "Suprimir la bústia {0}? Els missatges desats es mantenen; la connexió 
 msgid "Delete key"
 msgstr "Elimina la clau"
 
-#: src/routes/emails/inboxes.tsx:1296
+#: src/routes/emails/inboxes.tsx:1375
 msgid "Delete this footer? This cannot be undone."
 msgstr "Eliminar aquest peu de pàgina? Aquesta acció no es pot desfer."
 
@@ -1173,7 +1187,7 @@ msgstr "Denega"
 msgid "Direction"
 msgstr "Direcció"
 
-#: src/routes/emails/inboxes.tsx:453
+#: src/routes/emails/inboxes.tsx:463
 #: src/routes/settings/api-keys/index.tsx:314
 msgid "Disabled"
 msgstr "Desactivada"
@@ -1186,7 +1200,7 @@ msgstr "Descarta"
 msgid "Discovery"
 msgstr "Descoberta"
 
-#: src/routes/emails/inboxes.tsx:855
+#: src/routes/emails/inboxes.tsx:919
 msgid "Display name"
 msgstr "Nom a mostrar"
 
@@ -1241,15 +1255,15 @@ msgstr "p. ex. [research] Espanya prospecció d'hostaleria"
 msgid "e.g. Claude Desktop"
 msgstr "p. ex. Claude Desktop"
 
-#: src/routes/emails/inboxes.tsx:1429
+#: src/routes/emails/inboxes.tsx:1508
 msgid "e.g. Company signature"
 msgstr "p. ex. Signatura de l'empresa"
 
-#: src/routes/emails/inboxes.tsx:861
+#: src/routes/emails/inboxes.tsx:925
 msgid "e.g. Sales — Acme"
 msgstr "p. ex. Vendes — Acme"
 
-#: src/routes/emails/inboxes.tsx:1386
+#: src/routes/emails/inboxes.tsx:1465
 msgid "Edit"
 msgstr "Edita"
 
@@ -1267,12 +1281,12 @@ msgstr "Edita {label}"
 msgid "Edit due date"
 msgstr "Edita la data de venciment"
 
-#: src/routes/emails/inboxes.tsx:791
+#: src/routes/emails/inboxes.tsx:831
 msgid "Edit inbox"
 msgstr "Edita la safata"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:528
+#: src/routes/emails/inboxes.tsx:555
 msgid "Edit inbox {0}"
 msgstr "Edita la safata {0}"
 
@@ -1295,14 +1309,14 @@ msgstr "Editor"
 #: src/components/research/findings/contact-discovery-view.tsx:74
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:860
-#: src/routes/emails/inboxes.tsx:412
+#: src/routes/emails/inboxes.tsx:422
 #: src/routes/forgot-password.tsx:109
 #: src/routes/login.tsx:378
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Correu"
 
-#: src/routes/emails/inboxes.tsx:842
+#: src/routes/emails/inboxes.tsx:906
 msgid "Email address"
 msgstr "Adreça electrònica"
 
@@ -1431,7 +1445,7 @@ msgid "Flagged as spam by the provider. The body is shown for review only."
 msgstr "El proveïdor l'ha marcat com a brossa. El cos es mostra només per revisar-lo."
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:1343
+#: src/routes/emails/inboxes.tsx:1422
 msgid "Footers — {0}"
 msgstr "Peus de pàgina — {0}"
 
@@ -1483,6 +1497,10 @@ msgstr "Ves a connexions"
 msgid "Go to sign in"
 msgstr "Ves a iniciar sessió"
 
+#: src/routes/emails/inboxes.tsx:885
+msgid "Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password."
+msgstr "Tens la verificació en dos passos activada? Fes servir una contrasenya d'aplicació del proveïdor aquí sota, no la teva contrasenya d'inici de sessió habitual."
+
 #: src/routes/accept-invitation.$id.tsx:170
 msgid "Heading to the dashboard…"
 msgstr "Anant al tauler…"
@@ -1509,8 +1527,8 @@ msgstr "Prioritat alta"
 msgid "How your default uses the org default"
 msgstr "Com es relaciona el teu valor per defecte amb el de l'organització"
 
-#: src/routes/emails/inboxes.tsx:459
-#: src/routes/emails/inboxes.tsx:997
+#: src/routes/emails/inboxes.tsx:486
+#: src/routes/emails/inboxes.tsx:1061
 msgid "Human"
 msgstr "Humà"
 
@@ -1526,16 +1544,16 @@ msgstr "Prefereixo sense contrasenya — no m'ho tornis a preguntar"
 msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 msgstr "Si <0>{submittedEmail}</0> està registrat, t'arribarà un enllaç per restablir la contrasenya. L'enllaç caduca en 1 hora."
 
-#: src/routes/emails/inboxes.tsx:867
+#: src/routes/emails/inboxes.tsx:931
 msgid "IMAP host"
 msgstr "Servidor IMAP"
 
-#: src/routes/emails/inboxes.tsx:877
+#: src/routes/emails/inboxes.tsx:941
 msgid "IMAP port"
 msgstr "Port IMAP"
 
-#: src/routes/emails/inboxes.tsx:886
-#: src/routes/emails/inboxes.tsx:890
+#: src/routes/emails/inboxes.tsx:950
+#: src/routes/emails/inboxes.tsx:954
 msgid "IMAP security"
 msgstr "Seguretat IMAP"
 
@@ -1567,19 +1585,19 @@ msgstr "Missatge entrant de {0}"
 msgid "Inbox"
 msgstr "Safata"
 
-#: src/routes/emails/inboxes.tsx:562
+#: src/routes/emails/inboxes.tsx:589
 msgid "Inbox connected"
 msgstr "Bústia connectada"
 
-#: src/routes/emails/inboxes.tsx:310
+#: src/routes/emails/inboxes.tsx:320
 msgid "Inbox management"
 msgstr "Gestió de safates"
 
-#: src/routes/emails/inboxes.tsx:274
+#: src/routes/emails/inboxes.tsx:284
 msgid "Inbox removed"
 msgstr "Bústia eliminada"
 
-#: src/routes/emails/inboxes.tsx:579
+#: src/routes/emails/inboxes.tsx:606
 msgid "Inbox updated"
 msgstr "Safata actualitzada"
 
@@ -1724,7 +1742,7 @@ msgstr "Carregant l'execució…"
 msgid "Loading…"
 msgstr "Carregant…"
 
-#: src/routes/emails/inboxes.tsx:410
+#: src/routes/emails/inboxes.tsx:420
 msgid "Local inboxes"
 msgstr "Safates locals"
 
@@ -1779,7 +1797,7 @@ msgid "Low priority"
 msgstr "Prioritat baixa"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:521
+#: src/routes/emails/inboxes.tsx:548
 msgid "Manage footers for {0}"
 msgstr "Gestiona els peus de pàgina de {0}"
 
@@ -1809,11 +1827,11 @@ msgstr "Marca «{0}» com a completada"
 msgid "Mark \"{0}\" as pending"
 msgstr "Marca «{0}» com a pendent"
 
-#: src/routes/emails/inboxes.tsx:491
+#: src/routes/emails/inboxes.tsx:518
 msgid "Mark active"
 msgstr "Marca com a activa"
 
-#: src/routes/emails/inboxes.tsx:473
+#: src/routes/emails/inboxes.tsx:500
 msgid "Mark as default"
 msgstr "Marca com a per defecte"
 
@@ -1821,7 +1839,7 @@ msgstr "Marca com a per defecte"
 msgid "Mark contacted"
 msgstr "Marca com a contactat"
 
-#: src/routes/emails/inboxes.tsx:491
+#: src/routes/emails/inboxes.tsx:518
 msgid "Mark inactive"
 msgstr "Marca com a inactiva"
 
@@ -1905,7 +1923,7 @@ msgid "Minimize"
 msgstr "Minimitza"
 
 #: src/components/instructions/template-editor-dialog.tsx:127
-#: src/routes/emails/inboxes.tsx:1423
+#: src/routes/emails/inboxes.tsx:1502
 #: src/routes/settings/api-keys/index.tsx:219
 msgid "Name"
 msgstr "Nom"
@@ -1944,7 +1962,7 @@ msgstr "Nova plantilla d'organització"
 msgid "New password"
 msgstr "Contrasenya nova"
 
-#: src/routes/emails/inboxes.tsx:952
+#: src/routes/emails/inboxes.tsx:1016
 msgid "New password or app-password"
 msgstr "Contrasenya nova o d'aplicació"
 
@@ -2056,7 +2074,7 @@ msgstr "sense data de venciment"
 msgid "No due date"
 msgstr "Sense data de venciment"
 
-#: src/routes/emails/inboxes.tsx:1358
+#: src/routes/emails/inboxes.tsx:1437
 msgid "No footers"
 msgstr "Sense peus de pàgina"
 
@@ -2064,7 +2082,7 @@ msgstr "Sense peus de pàgina"
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "Cap empresa d'alta prioritat sense seguiment programat"
 
-#: src/routes/emails/inboxes.tsx:395
+#: src/routes/emails/inboxes.tsx:405
 msgid "No inboxes yet"
 msgstr "Encara no hi ha safates"
 
@@ -2113,7 +2131,7 @@ msgstr "No hi ha crides de pagament en aquest interval."
 msgid "No presets available."
 msgstr "No hi ha plantilles predefinides disponibles."
 
-#: src/routes/emails/inboxes.tsx:329
+#: src/routes/emails/inboxes.tsx:339
 msgid "No primary inbox set."
 msgstr "No hi ha cap bústia principal."
 
@@ -2365,7 +2383,7 @@ msgstr "Resum"
 msgid "Owner"
 msgstr "Propietari"
 
-#: src/routes/emails/inboxes.tsx:1019
+#: src/routes/emails/inboxes.tsx:1083
 msgid "Owner user ID"
 msgstr "ID d'usuari propietari"
 
@@ -2413,7 +2431,7 @@ msgstr "Punts febles"
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/routes/emails/inboxes.tsx:953
+#: src/routes/emails/inboxes.tsx:1017
 msgid "Password or app-password"
 msgstr "Contrasenya o contrasenya d'aplicació"
 
@@ -2467,7 +2485,7 @@ msgstr "Tria una contrasenya nova. Els altres dispositius es desconnectaran."
 msgid "Pick a password you'll remember. Minimum 8 characters."
 msgstr "Tria una contrasenya que recordis. Mínim 8 caràcters."
 
-#: src/routes/emails/inboxes.tsx:813
+#: src/routes/emails/inboxes.tsx:853
 msgid "Pick a provider"
 msgstr "Tria un proveïdor"
 
@@ -2475,7 +2493,7 @@ msgstr "Tria un proveïdor"
 msgid "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
 msgstr "Tria una organització al selector de la barra superior, o tanca la sessió i torna a entrar. Després d'un reset recent de la base de dades de dev, les sessions existents poden apuntar a identificadors d'organització que el reset ha esborrat."
 
-#: src/routes/emails/inboxes.tsx:330
+#: src/routes/emails/inboxes.tsx:340
 msgid "Pick one to use as your default sender."
 msgstr "Tria'n una com a remitent per defecte."
 
@@ -2488,7 +2506,7 @@ msgstr "Tria les plantilles per fer servir només en aquesta recerca. Deixa-ho b
 msgid "Pipeline"
 msgstr "Pipeline"
 
-#: src/routes/emails/inboxes.tsx:1130
+#: src/routes/emails/inboxes.tsx:1194
 msgid "Plain"
 msgstr "Sense xifrar"
 
@@ -2513,7 +2531,7 @@ msgstr "Vista prèvia"
 msgid "Previous"
 msgstr "Anterior"
 
-#: src/routes/emails/inboxes.tsx:293
+#: src/routes/emails/inboxes.tsx:303
 msgid "Primary inbox set"
 msgstr "Bústia principal establerta"
 
@@ -2525,15 +2543,15 @@ msgstr "Navegació principal"
 msgid "Priority"
 msgstr "Prioritat"
 
-#: src/routes/emails/inboxes.tsx:437
+#: src/routes/emails/inboxes.tsx:447
 msgid "Private"
 msgstr "Privada"
 
-#: src/routes/emails/inboxes.tsx:1049
+#: src/routes/emails/inboxes.tsx:1113
 msgid "Private — hide threads from other members"
 msgstr "Privada — amaga els fils a la resta de membres"
 
-#: src/routes/emails/inboxes.tsx:436
+#: src/routes/emails/inboxes.tsx:446
 msgid "Private inbox"
 msgstr "Bústia privada"
 
@@ -2582,8 +2600,8 @@ msgstr "Escàner de prospectes"
 msgid "Prospects"
 msgstr "Prospectes"
 
-#: src/routes/emails/inboxes.tsx:805
-#: src/routes/emails/inboxes.tsx:812
+#: src/routes/emails/inboxes.tsx:845
+#: src/routes/emails/inboxes.tsx:852
 msgid "Provider preset"
 msgstr "Preestablit del proveïdor"
 
@@ -2608,9 +2626,9 @@ msgstr "Publicada"
 msgid "Publishing…"
 msgstr "Publicant…"
 
-#: src/routes/emails/inboxes.tsx:414
-#: src/routes/emails/inboxes.tsx:967
-#: src/routes/emails/inboxes.tsx:980
+#: src/routes/emails/inboxes.tsx:424
+#: src/routes/emails/inboxes.tsx:1031
+#: src/routes/emails/inboxes.tsx:1044
 msgid "Purpose"
 msgstr "Propòsit"
 
@@ -2643,7 +2661,7 @@ msgstr "Canvis recents"
 msgid "Recipient marked as spam"
 msgstr "El destinatari ha marcat el missatge com a brossa"
 
-#: src/routes/emails/inboxes.tsx:249
+#: src/routes/emails/inboxes.tsx:259
 msgid "Refreshing inbox status…"
 msgstr "Actualitzant l'estat de la bústia…"
 
@@ -2799,8 +2817,8 @@ msgid "Sales context"
 msgstr "Context comercial"
 
 #: src/components/instructions/template-editor-dialog.tsx:173
-#: src/routes/emails/inboxes.tsx:1071
-#: src/routes/emails/inboxes.tsx:1476
+#: src/routes/emails/inboxes.tsx:1135
+#: src/routes/emails/inboxes.tsx:1555
 #: src/routes/pages/$id.tsx:271
 msgid "Save"
 msgstr "Desa"
@@ -2831,7 +2849,7 @@ msgstr "Desa el valor per defecte de l'organització"
 
 #: src/components/emails/compose-form.tsx:547
 #: src/components/instructions/template-editor-dialog.tsx:173
-#: src/routes/emails/inboxes.tsx:1473
+#: src/routes/emails/inboxes.tsx:1552
 #: src/routes/pages/$id.tsx:271
 #: src/routes/reset-password.tsx:242
 #: src/routes/settings/profile/index.tsx:334
@@ -2880,7 +2898,7 @@ msgstr "Selecciona el text i copia'l manualment."
 msgid "Select thread {0}"
 msgstr "Selecciona el fil {0}"
 
-#: src/routes/emails/inboxes.tsx:837
+#: src/routes/emails/inboxes.tsx:877
 msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 msgstr "Triar un preestablit omple els paràmetres IMAP i SMTP — encara els pots editar."
 
@@ -2952,7 +2970,7 @@ msgstr "Posa una contrasenya"
 msgid "Set a password so you don't have to check your email next time."
 msgstr "Posa una contrasenya per no haver de mirar el correu la pròxima vegada."
 
-#: src/routes/emails/inboxes.tsx:1378
+#: src/routes/emails/inboxes.tsx:1457
 msgid "Set as default"
 msgstr "Estableix com a predeterminat"
 
@@ -2973,12 +2991,16 @@ msgstr "Configura <0>plantilles d'instruccions</0> reutilitzables per guiar cada
 msgid "Settings"
 msgstr "Configuració"
 
+#: src/routes/emails/inboxes.tsx:896
+msgid "Setup guide →"
+msgstr "Guia de configuració →"
+
 #: src/components/research/run-detail.tsx:181
 msgid "Shaped by"
 msgstr "Modelat per"
 
-#: src/routes/emails/inboxes.tsx:462
-#: src/routes/emails/inboxes.tsx:1009
+#: src/routes/emails/inboxes.tsx:489
+#: src/routes/emails/inboxes.tsx:1073
 msgid "Shared"
 msgstr "Compartida"
 
@@ -3063,16 +3085,16 @@ msgstr "Mida"
 msgid "Slug"
 msgstr "Slug"
 
-#: src/routes/emails/inboxes.tsx:895
+#: src/routes/emails/inboxes.tsx:959
 msgid "SMTP host"
 msgstr "Servidor SMTP"
 
-#: src/routes/emails/inboxes.tsx:905
+#: src/routes/emails/inboxes.tsx:969
 msgid "SMTP port"
 msgstr "Port SMTP"
 
-#: src/routes/emails/inboxes.tsx:914
-#: src/routes/emails/inboxes.tsx:918
+#: src/routes/emails/inboxes.tsx:978
+#: src/routes/emails/inboxes.tsx:982
 msgid "SMTP security"
 msgstr "Seguretat SMTP"
 
@@ -3139,12 +3161,12 @@ msgstr "Plantilles predefinides per començar"
 msgid "Starting…"
 msgstr "Iniciant…"
 
-#: src/routes/emails/inboxes.tsx:1124
+#: src/routes/emails/inboxes.tsx:1188
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
 #: src/routes/calendar/index.tsx:279
-#: src/routes/emails/inboxes.tsx:413
+#: src/routes/emails/inboxes.tsx:423
 #: src/routes/pages/index.tsx:147
 #: src/routes/tasks/index.tsx:695
 msgid "Status"
@@ -3159,7 +3181,7 @@ msgstr "Ha fallat l'actualització d'estat"
 msgid "Still in use"
 msgstr "Encara s'utilitza"
 
-#: src/routes/emails/inboxes.tsx:960
+#: src/routes/emails/inboxes.tsx:1024
 msgid "Stored encrypted with AES-256-GCM."
 msgstr "Es desa xifrada amb AES-256-GCM."
 
@@ -3227,20 +3249,20 @@ msgstr "Plantilles"
 msgid "Tentative"
 msgstr "Provisional"
 
-#: src/routes/emails/inboxes.tsx:1072
+#: src/routes/emails/inboxes.tsx:1136
 msgid "Test & connect"
 msgstr "Prova i connecta"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:514
+#: src/routes/emails/inboxes.tsx:541
 msgid "Test connection for {0}"
 msgstr "Prova la connexió de {0}"
 
-#: src/routes/emails/inboxes.tsx:241
+#: src/routes/emails/inboxes.tsx:251
 msgid "Test failed"
 msgstr "Prova fallida"
 
-#: src/routes/emails/inboxes.tsx:1069
+#: src/routes/emails/inboxes.tsx:1133
 msgid "Testing connection…"
 msgstr "Provant la connexió…"
 
@@ -3289,7 +3311,7 @@ msgstr "La invitació pot haver caducat o ja s'''ha utilitzat."
 msgid "The invitee gets a 48-hour link. They can accept it once."
 msgstr "El convidat rep un enllaç de 48 hores. Pot acceptar-lo una sola vegada."
 
-#: src/routes/emails/inboxes.tsx:563
+#: src/routes/emails/inboxes.tsx:590
 msgid "The mailbox is ready."
 msgstr "La bústia està a punt."
 
@@ -3415,7 +3437,7 @@ msgstr "Cronologia"
 msgid "Title"
 msgstr "Títol"
 
-#: src/routes/emails/inboxes.tsx:1118
+#: src/routes/emails/inboxes.tsx:1182
 msgid "TLS"
 msgstr "TLS"
 
@@ -3493,10 +3515,10 @@ msgstr "Clau sense títol"
 msgid "Upcoming meetings"
 msgstr "Reunions properes"
 
-#: src/routes/emails/inboxes.tsx:204
-#: src/routes/emails/inboxes.tsx:225
-#: src/routes/emails/inboxes.tsx:1270
-#: src/routes/emails/inboxes.tsx:1322
+#: src/routes/emails/inboxes.tsx:214
+#: src/routes/emails/inboxes.tsx:235
+#: src/routes/emails/inboxes.tsx:1349
+#: src/routes/emails/inboxes.tsx:1401
 msgid "Update failed"
 msgstr "Ha fallat l'actualització"
 
@@ -3509,7 +3531,7 @@ msgid "Uploading…"
 msgstr "Pujant…"
 
 #. placeholder {0}: primarySuggestions[0]?.email ?? ''
-#: src/routes/emails/inboxes.tsx:344
+#: src/routes/emails/inboxes.tsx:354
 msgid "Use {0} as primary"
 msgstr "Fes servir {0} com a principal"
 
@@ -3521,11 +3543,11 @@ msgstr "Usa <0>httpUrl</0>, no <1>url</1> — <2>url</2> sol selecciona el trans
 msgid "Use a different email"
 msgstr "Fes servir un altre correu"
 
-#: src/routes/emails/inboxes.tsx:1454
+#: src/routes/emails/inboxes.tsx:1533
 msgid "Use as default footer"
 msgstr "Utilitza com a peu de pàgina predeterminat"
 
-#: src/routes/emails/inboxes.tsx:1037
+#: src/routes/emails/inboxes.tsx:1101
 msgid "Use as default for this purpose"
 msgstr "Usa com a per defecte per a aquest propòsit"
 
@@ -3537,7 +3559,7 @@ msgstr "Fes servir contrasenya"
 msgid "Use the org default"
 msgstr "Utilitza el valor per defecte de l'organització"
 
-#: src/routes/emails/inboxes.tsx:924
+#: src/routes/emails/inboxes.tsx:988
 msgid "Username"
 msgstr "Nom d'usuari"
 
@@ -3626,7 +3648,7 @@ msgstr "Qui"
 msgid "Workshop floor — live counters on the bench."
 msgstr "Planta del taller — comptadors en viu al banc."
 
-#: src/routes/emails/inboxes.tsx:1443
+#: src/routes/emails/inboxes.tsx:1522
 msgid "Write footer…"
 msgstr "Escriu el peu de pàgina…"
 
@@ -3662,7 +3684,7 @@ msgstr "Ja ets membre de {orgName}."
 msgid "You're now a member."
 msgstr "Ja ets membre."
 
-#: src/routes/emails/inboxes.tsx:848
+#: src/routes/emails/inboxes.tsx:912
 msgid "you@example.com"
 msgstr "tu@exemple.com"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -87,6 +87,11 @@ msgstr "{0} companies with filters applied"
 msgid "{0} msgs"
 msgstr "{0} msgs"
 
+#. placeholder {0}: selectedPreset.name
+#: src/routes/emails/inboxes.tsx:881
+msgid "{0} no longer allows password sign-in for mail apps, so it can't be connected here yet — it needs an OAuth sign-in. Pick another provider or use Generic IMAP."
+msgstr "{0} no longer allows password sign-in for mail apps, so it can't be connected here yet — it needs an OAuth sign-in. Pick another provider or use Generic IMAP."
+
 #. placeholder {0}: failedIds.length
 #: src/routes/emails/index.tsx:494
 #: src/routes/emails/index.tsx:526
@@ -142,6 +147,10 @@ msgstr "1 thread"
 msgid "1 thread selected"
 msgstr "1 thread selected"
 
+#: src/routes/emails/inboxes.tsx:467
+msgid "2FA accounts need an app-specific password."
+msgstr "2FA accounts need an app-specific password."
+
 #: src/components/instructions/template-editor-dialog.tsx:139
 msgid "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
 msgstr "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
@@ -167,11 +176,11 @@ msgstr "Access"
 msgid "across {0} providers"
 msgstr "across {0} providers"
 
-#: src/routes/emails/inboxes.tsx:418
+#: src/routes/emails/inboxes.tsx:428
 msgid "Actions"
 msgstr "Actions"
 
-#: src/routes/emails/inboxes.tsx:416
+#: src/routes/emails/inboxes.tsx:426
 msgid "Active"
 msgstr "Active"
 
@@ -266,8 +275,8 @@ msgstr "Admin"
 msgid "After approving, manage which org each one acts in here."
 msgstr "After approving, manage which org each one acts in here."
 
-#: src/routes/emails/inboxes.tsx:461
-#: src/routes/emails/inboxes.tsx:1003
+#: src/routes/emails/inboxes.tsx:488
+#: src/routes/emails/inboxes.tsx:1067
 msgid "Agent"
 msgstr "Agent"
 
@@ -349,7 +358,7 @@ msgstr "attachment"
 msgid "Audit log"
 msgstr "Audit log"
 
-#: src/routes/emails/inboxes.tsx:450
+#: src/routes/emails/inboxes.tsx:460
 msgid "Auth failed"
 msgstr "Auth failed"
 
@@ -361,7 +370,7 @@ msgstr "Back to account"
 msgid "Back to companies"
 msgstr "Back to companies"
 
-#: src/routes/emails/inboxes.tsx:307
+#: src/routes/emails/inboxes.tsx:317
 msgid "Back to emails"
 msgstr "Back to emails"
 
@@ -490,8 +499,8 @@ msgstr "Calls"
 #: src/components/instructions/template-editor-dialog.tsx:178
 #: src/components/interactions/quick-capture-dialog.tsx:400
 #: src/components/research/research-dialog.tsx:271
-#: src/routes/emails/inboxes.tsx:1065
-#: src/routes/emails/inboxes.tsx:1463
+#: src/routes/emails/inboxes.tsx:1129
+#: src/routes/emails/inboxes.tsx:1542
 #: src/routes/settings/api-keys/index.tsx:424
 #: src/routes/tasks/index.tsx:743
 msgid "Cancel"
@@ -519,7 +528,7 @@ msgstr "Change my mind — set a password anyway"
 msgid "Change password"
 msgstr "Change password"
 
-#: src/routes/emails/inboxes.tsx:943
+#: src/routes/emails/inboxes.tsx:1007
 msgid "Change password (re-probes the connection)"
 msgstr "Change password (re-probes the connection)"
 
@@ -557,7 +566,7 @@ msgstr "Check that the session is valid or try again."
 msgid "Check that your session is valid or try again."
 msgstr "Check that your session is valid or try again."
 
-#: src/routes/emails/inboxes.tsx:390
+#: src/routes/emails/inboxes.tsx:400
 msgid "Check the session or try again."
 msgstr "Check the session or try again."
 
@@ -570,8 +579,8 @@ msgstr "Check your inbox"
 msgid "Choose organization"
 msgstr "Choose organization"
 
-#: src/routes/emails/inboxes.tsx:355
-#: src/routes/emails/inboxes.tsx:356
+#: src/routes/emails/inboxes.tsx:365
+#: src/routes/emails/inboxes.tsx:366
 msgid "Choose primary inbox"
 msgstr "Choose primary inbox"
 
@@ -607,8 +616,8 @@ msgstr "Client"
 #: src/components/research/research-dialog.tsx:159
 #: src/routes/calendar/index.tsx:367
 #: src/routes/emails/$threadId.tsx:353
-#: src/routes/emails/inboxes.tsx:795
-#: src/routes/emails/inboxes.tsx:1346
+#: src/routes/emails/inboxes.tsx:835
+#: src/routes/emails/inboxes.tsx:1425
 #: src/routes/emails/index.tsx:732
 msgid "Close"
 msgstr "Close"
@@ -711,17 +720,17 @@ msgstr "Connect AI tools"
 msgid "Connect AI tools over MCP"
 msgstr "Connect AI tools over MCP"
 
-#: src/routes/emails/inboxes.tsx:452
+#: src/routes/emails/inboxes.tsx:462
 msgid "Connect failed"
 msgstr "Connect failed"
 
-#: src/routes/emails/inboxes.tsx:311
+#: src/routes/emails/inboxes.tsx:321
 msgid "Connect IMAP/SMTP mailboxes and choose your primary sender."
 msgstr "Connect IMAP/SMTP mailboxes and choose your primary sender."
 
-#: src/routes/emails/inboxes.tsx:321
-#: src/routes/emails/inboxes.tsx:405
-#: src/routes/emails/inboxes.tsx:791
+#: src/routes/emails/inboxes.tsx:331
+#: src/routes/emails/inboxes.tsx:415
+#: src/routes/emails/inboxes.tsx:831
 msgid "Connect mailbox"
 msgstr "Connect mailbox"
 
@@ -729,11 +738,11 @@ msgstr "Connect mailbox"
 msgid "Connect to Batuda?"
 msgstr "Connect to Batuda?"
 
-#: src/routes/emails/inboxes.tsx:396
+#: src/routes/emails/inboxes.tsx:406
 msgid "Connect your IMAP/SMTP mailbox to start sending and receiving email."
 msgstr "Connect your IMAP/SMTP mailbox to start sending and receiving email."
 
-#: src/routes/emails/inboxes.tsx:448
+#: src/routes/emails/inboxes.tsx:458
 msgid "Connected"
 msgstr "Connected"
 
@@ -746,7 +755,7 @@ msgstr "Connected {0}"
 msgid "Connecting…"
 msgstr "Connecting…"
 
-#: src/routes/emails/inboxes.tsx:248
+#: src/routes/emails/inboxes.tsx:258
 msgid "Connection tested"
 msgstr "Connection tested"
 
@@ -771,7 +780,7 @@ msgstr "Contacts"
 msgid "Contacts found"
 msgstr "Contacts found"
 
-#: src/routes/emails/inboxes.tsx:1433
+#: src/routes/emails/inboxes.tsx:1512
 msgid "Content"
 msgstr "Content"
 
@@ -821,7 +830,7 @@ msgstr "Could not clear suppression"
 msgid "Could not complete the connection. Please try again."
 msgstr "Could not complete the connection. Please try again."
 
-#: src/routes/emails/inboxes.tsx:556
+#: src/routes/emails/inboxes.tsx:583
 msgid "Could not create the inbox. Check transport or credentials."
 msgstr "Could not create the inbox. Check transport or credentials."
 
@@ -837,7 +846,7 @@ msgstr "Could not delete the key. Please try again."
 msgid "Could not load companies"
 msgstr "Could not load companies"
 
-#: src/routes/emails/inboxes.tsx:389
+#: src/routes/emails/inboxes.tsx:399
 msgid "Could not load inboxes"
 msgstr "Could not load inboxes"
 
@@ -878,7 +887,7 @@ msgid "Could not publish the page. Please try again."
 msgstr "Could not publish the page. Please try again."
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:242
+#: src/routes/emails/inboxes.tsx:252
 msgid "Could not reach {0}."
 msgstr "Could not reach {0}."
 
@@ -890,7 +899,7 @@ msgstr "Could not remove {email}. Please try again."
 msgid "Could not save"
 msgstr "Could not save"
 
-#: src/routes/emails/inboxes.tsx:574
+#: src/routes/emails/inboxes.tsx:601
 msgid "Could not save the inbox."
 msgstr "Could not save the inbox."
 
@@ -911,11 +920,11 @@ msgstr "Could not send the invitation. Please try again."
 msgid "Could not send the link. Try again in a few seconds."
 msgstr "Could not send the link. Try again in a few seconds."
 
-#: src/routes/emails/inboxes.tsx:286
+#: src/routes/emails/inboxes.tsx:296
 msgid "Could not set primary inbox"
 msgstr "Could not set primary inbox"
 
-#: src/routes/emails/inboxes.tsx:226
+#: src/routes/emails/inboxes.tsx:236
 msgid "Could not set the default inbox."
 msgstr "Could not set the default inbox."
 
@@ -931,7 +940,7 @@ msgstr "Could not start the research run. Please try again."
 msgid "Could not switch organization. Please try again."
 msgstr "Could not switch organization. Please try again."
 
-#: src/routes/emails/inboxes.tsx:205
+#: src/routes/emails/inboxes.tsx:215
 msgid "Could not toggle the inbox state."
 msgstr "Could not toggle the inbox state."
 
@@ -985,11 +994,11 @@ msgstr "Couldn't send it"
 msgid "Couldn't update your preference. Try again."
 msgstr "Couldn't update your preference. Try again."
 
-#: src/routes/emails/inboxes.tsx:1475
+#: src/routes/emails/inboxes.tsx:1554
 msgid "Create"
 msgstr "Create"
 
-#: src/routes/emails/inboxes.tsx:1359
+#: src/routes/emails/inboxes.tsx:1438
 msgid "Create a footer to append to outgoing emails from this inbox."
 msgstr "Create a footer to append to outgoing emails from this inbox."
 
@@ -1017,7 +1026,12 @@ msgstr "Create an API key"
 msgid "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
 msgstr "Create an API key, then paste the snippet for your tool — replacing <0>YOUR_API_KEY</0> with it. The key acts in this organization."
 
-#: src/routes/emails/inboxes.tsx:1253
+#: src/routes/emails/inboxes.tsx:476
+#: src/routes/emails/inboxes.tsx:895
+msgid "Create an app password →"
+msgstr "Create an app password →"
+
+#: src/routes/emails/inboxes.tsx:1332
 msgid "Create failed"
 msgstr "Create failed"
 
@@ -1025,7 +1039,7 @@ msgstr "Create failed"
 msgid "Create follow-up task"
 msgstr "Create follow-up task"
 
-#: src/routes/emails/inboxes.tsx:1411
+#: src/routes/emails/inboxes.tsx:1490
 msgid "Create footer"
 msgstr "Create footer"
 
@@ -1034,7 +1048,7 @@ msgid "Create key"
 msgstr "Create key"
 
 #: src/routes/emails/$threadId.tsx:498
-#: src/routes/emails/inboxes.tsx:417
+#: src/routes/emails/inboxes.tsx:427
 msgid "Created"
 msgstr "Created"
 
@@ -1087,25 +1101,25 @@ msgstr "Decline"
 msgid "Decline {0}"
 msgstr "Decline {0}"
 
-#: src/routes/emails/inboxes.tsx:415
-#: src/routes/emails/inboxes.tsx:1368
+#: src/routes/emails/inboxes.tsx:425
+#: src/routes/emails/inboxes.tsx:1447
 msgid "Default"
 msgstr "Default"
 
-#: src/routes/emails/inboxes.tsx:473
+#: src/routes/emails/inboxes.tsx:500
 msgid "Default inbox"
 msgstr "Default inbox"
 
-#: src/routes/emails/inboxes.tsx:930
+#: src/routes/emails/inboxes.tsx:994
 msgid "Defaults to the email address."
 msgstr "Defaults to the email address."
 
-#: src/routes/emails/inboxes.tsx:1025
+#: src/routes/emails/inboxes.tsx:1089
 msgid "Defaults to you when omitted."
 msgstr "Defaults to you when omitted."
 
 #: src/components/instructions/template-delete-confirm.tsx:51
-#: src/routes/emails/inboxes.tsx:1395
+#: src/routes/emails/inboxes.tsx:1474
 #: src/routes/settings/api-keys/index.tsx:329
 msgid "Delete"
 msgstr "Delete"
@@ -1116,8 +1130,8 @@ msgstr "Delete"
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
-#: src/routes/emails/inboxes.tsx:266
-#: src/routes/emails/inboxes.tsx:1303
+#: src/routes/emails/inboxes.tsx:276
+#: src/routes/emails/inboxes.tsx:1382
 #: src/routes/settings/api-keys/index.tsx:162
 #: src/routes/settings/organization/templates.tsx:249
 #: src/routes/settings/profile/templates.tsx:130
@@ -1126,12 +1140,12 @@ msgid "Delete failed"
 msgstr "Delete failed"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:537
+#: src/routes/emails/inboxes.tsx:564
 msgid "Delete inbox {0}"
 msgstr "Delete inbox {0}"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:260
+#: src/routes/emails/inboxes.tsx:270
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
 msgstr "Delete inbox {0}? Stored messages stay; the connection stops."
 
@@ -1139,7 +1153,7 @@ msgstr "Delete inbox {0}? Stored messages stay; the connection stops."
 msgid "Delete key"
 msgstr "Delete key"
 
-#: src/routes/emails/inboxes.tsx:1296
+#: src/routes/emails/inboxes.tsx:1375
 msgid "Delete this footer? This cannot be undone."
 msgstr "Delete this footer? This cannot be undone."
 
@@ -1173,7 +1187,7 @@ msgstr "Deny"
 msgid "Direction"
 msgstr "Direction"
 
-#: src/routes/emails/inboxes.tsx:453
+#: src/routes/emails/inboxes.tsx:463
 #: src/routes/settings/api-keys/index.tsx:314
 msgid "Disabled"
 msgstr "Disabled"
@@ -1186,7 +1200,7 @@ msgstr "Discard"
 msgid "Discovery"
 msgstr "Discovery"
 
-#: src/routes/emails/inboxes.tsx:855
+#: src/routes/emails/inboxes.tsx:919
 msgid "Display name"
 msgstr "Display name"
 
@@ -1241,15 +1255,15 @@ msgstr "e.g. [research] Spain hospitality sourcing"
 msgid "e.g. Claude Desktop"
 msgstr "e.g. Claude Desktop"
 
-#: src/routes/emails/inboxes.tsx:1429
+#: src/routes/emails/inboxes.tsx:1508
 msgid "e.g. Company signature"
 msgstr "e.g. Company signature"
 
-#: src/routes/emails/inboxes.tsx:861
+#: src/routes/emails/inboxes.tsx:925
 msgid "e.g. Sales — Acme"
 msgstr "e.g. Sales — Acme"
 
-#: src/routes/emails/inboxes.tsx:1386
+#: src/routes/emails/inboxes.tsx:1465
 msgid "Edit"
 msgstr "Edit"
 
@@ -1267,12 +1281,12 @@ msgstr "Edit {label}"
 msgid "Edit due date"
 msgstr "Edit due date"
 
-#: src/routes/emails/inboxes.tsx:791
+#: src/routes/emails/inboxes.tsx:831
 msgid "Edit inbox"
 msgstr "Edit inbox"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:528
+#: src/routes/emails/inboxes.tsx:555
 msgid "Edit inbox {0}"
 msgstr "Edit inbox {0}"
 
@@ -1295,14 +1309,14 @@ msgstr "Editor"
 #: src/components/research/findings/contact-discovery-view.tsx:74
 #: src/components/shared/channel-icon.tsx:63
 #: src/routes/companies/$slug.tsx:860
-#: src/routes/emails/inboxes.tsx:412
+#: src/routes/emails/inboxes.tsx:422
 #: src/routes/forgot-password.tsx:109
 #: src/routes/login.tsx:378
 #: src/routes/settings/organization/invite.tsx:137
 msgid "Email"
 msgstr "Email"
 
-#: src/routes/emails/inboxes.tsx:842
+#: src/routes/emails/inboxes.tsx:906
 msgid "Email address"
 msgstr "Email address"
 
@@ -1431,7 +1445,7 @@ msgid "Flagged as spam by the provider. The body is shown for review only."
 msgstr "Flagged as spam by the provider. The body is shown for review only."
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:1343
+#: src/routes/emails/inboxes.tsx:1422
 msgid "Footers — {0}"
 msgstr "Footers — {0}"
 
@@ -1483,6 +1497,10 @@ msgstr "Go to connections"
 msgid "Go to sign in"
 msgstr "Go to sign in"
 
+#: src/routes/emails/inboxes.tsx:885
+msgid "Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password."
+msgstr "Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password."
+
 #: src/routes/accept-invitation.$id.tsx:170
 msgid "Heading to the dashboard…"
 msgstr "Heading to the dashboard…"
@@ -1509,8 +1527,8 @@ msgstr "High priority"
 msgid "How your default uses the org default"
 msgstr "How your default uses the org default"
 
-#: src/routes/emails/inboxes.tsx:459
-#: src/routes/emails/inboxes.tsx:997
+#: src/routes/emails/inboxes.tsx:486
+#: src/routes/emails/inboxes.tsx:1061
 msgid "Human"
 msgstr "Human"
 
@@ -1526,16 +1544,16 @@ msgstr "I prefer passwordless — don't ask me again"
 msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 msgstr "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 
-#: src/routes/emails/inboxes.tsx:867
+#: src/routes/emails/inboxes.tsx:931
 msgid "IMAP host"
 msgstr "IMAP host"
 
-#: src/routes/emails/inboxes.tsx:877
+#: src/routes/emails/inboxes.tsx:941
 msgid "IMAP port"
 msgstr "IMAP port"
 
-#: src/routes/emails/inboxes.tsx:886
-#: src/routes/emails/inboxes.tsx:890
+#: src/routes/emails/inboxes.tsx:950
+#: src/routes/emails/inboxes.tsx:954
 msgid "IMAP security"
 msgstr "IMAP security"
 
@@ -1567,19 +1585,19 @@ msgstr "Inbound message from {0}"
 msgid "Inbox"
 msgstr "Inbox"
 
-#: src/routes/emails/inboxes.tsx:562
+#: src/routes/emails/inboxes.tsx:589
 msgid "Inbox connected"
 msgstr "Inbox connected"
 
-#: src/routes/emails/inboxes.tsx:310
+#: src/routes/emails/inboxes.tsx:320
 msgid "Inbox management"
 msgstr "Inbox management"
 
-#: src/routes/emails/inboxes.tsx:274
+#: src/routes/emails/inboxes.tsx:284
 msgid "Inbox removed"
 msgstr "Inbox removed"
 
-#: src/routes/emails/inboxes.tsx:579
+#: src/routes/emails/inboxes.tsx:606
 msgid "Inbox updated"
 msgstr "Inbox updated"
 
@@ -1724,7 +1742,7 @@ msgstr "Loading run…"
 msgid "Loading…"
 msgstr "Loading…"
 
-#: src/routes/emails/inboxes.tsx:410
+#: src/routes/emails/inboxes.tsx:420
 msgid "Local inboxes"
 msgstr "Local inboxes"
 
@@ -1779,7 +1797,7 @@ msgid "Low priority"
 msgstr "Low priority"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:521
+#: src/routes/emails/inboxes.tsx:548
 msgid "Manage footers for {0}"
 msgstr "Manage footers for {0}"
 
@@ -1809,11 +1827,11 @@ msgstr "Mark \"{0}\" as complete"
 msgid "Mark \"{0}\" as pending"
 msgstr "Mark \"{0}\" as pending"
 
-#: src/routes/emails/inboxes.tsx:491
+#: src/routes/emails/inboxes.tsx:518
 msgid "Mark active"
 msgstr "Mark active"
 
-#: src/routes/emails/inboxes.tsx:473
+#: src/routes/emails/inboxes.tsx:500
 msgid "Mark as default"
 msgstr "Mark as default"
 
@@ -1821,7 +1839,7 @@ msgstr "Mark as default"
 msgid "Mark contacted"
 msgstr "Mark contacted"
 
-#: src/routes/emails/inboxes.tsx:491
+#: src/routes/emails/inboxes.tsx:518
 msgid "Mark inactive"
 msgstr "Mark inactive"
 
@@ -1905,7 +1923,7 @@ msgid "Minimize"
 msgstr "Minimize"
 
 #: src/components/instructions/template-editor-dialog.tsx:127
-#: src/routes/emails/inboxes.tsx:1423
+#: src/routes/emails/inboxes.tsx:1502
 #: src/routes/settings/api-keys/index.tsx:219
 msgid "Name"
 msgstr "Name"
@@ -1944,7 +1962,7 @@ msgstr "New org template"
 msgid "New password"
 msgstr "New password"
 
-#: src/routes/emails/inboxes.tsx:952
+#: src/routes/emails/inboxes.tsx:1016
 msgid "New password or app-password"
 msgstr "New password or app-password"
 
@@ -2056,7 +2074,7 @@ msgstr "no due date"
 msgid "No due date"
 msgstr "No due date"
 
-#: src/routes/emails/inboxes.tsx:1358
+#: src/routes/emails/inboxes.tsx:1437
 msgid "No footers"
 msgstr "No footers"
 
@@ -2064,7 +2082,7 @@ msgstr "No footers"
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "No high-priority companies without a scheduled follow-up"
 
-#: src/routes/emails/inboxes.tsx:395
+#: src/routes/emails/inboxes.tsx:405
 msgid "No inboxes yet"
 msgstr "No inboxes yet"
 
@@ -2113,7 +2131,7 @@ msgstr "No paid calls in this range."
 msgid "No presets available."
 msgstr "No presets available."
 
-#: src/routes/emails/inboxes.tsx:329
+#: src/routes/emails/inboxes.tsx:339
 msgid "No primary inbox set."
 msgstr "No primary inbox set."
 
@@ -2365,7 +2383,7 @@ msgstr "Overview"
 msgid "Owner"
 msgstr "Owner"
 
-#: src/routes/emails/inboxes.tsx:1019
+#: src/routes/emails/inboxes.tsx:1083
 msgid "Owner user ID"
 msgstr "Owner user ID"
 
@@ -2413,7 +2431,7 @@ msgstr "Pain points"
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/emails/inboxes.tsx:953
+#: src/routes/emails/inboxes.tsx:1017
 msgid "Password or app-password"
 msgstr "Password or app-password"
 
@@ -2467,7 +2485,7 @@ msgstr "Pick a new password. Other signed-in devices will be signed out."
 msgid "Pick a password you'll remember. Minimum 8 characters."
 msgstr "Pick a password you'll remember. Minimum 8 characters."
 
-#: src/routes/emails/inboxes.tsx:813
+#: src/routes/emails/inboxes.tsx:853
 msgid "Pick a provider"
 msgstr "Pick a provider"
 
@@ -2475,7 +2493,7 @@ msgstr "Pick a provider"
 msgid "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
 msgstr "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
 
-#: src/routes/emails/inboxes.tsx:330
+#: src/routes/emails/inboxes.tsx:340
 msgid "Pick one to use as your default sender."
 msgstr "Pick one to use as your default sender."
 
@@ -2488,7 +2506,7 @@ msgstr "Pick templates to use just for this run. Leave empty to use your default
 msgid "Pipeline"
 msgstr "Pipeline"
 
-#: src/routes/emails/inboxes.tsx:1130
+#: src/routes/emails/inboxes.tsx:1194
 msgid "Plain"
 msgstr "Plain"
 
@@ -2513,7 +2531,7 @@ msgstr "Preview"
 msgid "Previous"
 msgstr "Previous"
 
-#: src/routes/emails/inboxes.tsx:293
+#: src/routes/emails/inboxes.tsx:303
 msgid "Primary inbox set"
 msgstr "Primary inbox set"
 
@@ -2525,15 +2543,15 @@ msgstr "Primary navigation"
 msgid "Priority"
 msgstr "Priority"
 
-#: src/routes/emails/inboxes.tsx:437
+#: src/routes/emails/inboxes.tsx:447
 msgid "Private"
 msgstr "Private"
 
-#: src/routes/emails/inboxes.tsx:1049
+#: src/routes/emails/inboxes.tsx:1113
 msgid "Private — hide threads from other members"
 msgstr "Private — hide threads from other members"
 
-#: src/routes/emails/inboxes.tsx:436
+#: src/routes/emails/inboxes.tsx:446
 msgid "Private inbox"
 msgstr "Private inbox"
 
@@ -2582,8 +2600,8 @@ msgstr "Prospect scan"
 msgid "Prospects"
 msgstr "Prospects"
 
-#: src/routes/emails/inboxes.tsx:805
-#: src/routes/emails/inboxes.tsx:812
+#: src/routes/emails/inboxes.tsx:845
+#: src/routes/emails/inboxes.tsx:852
 msgid "Provider preset"
 msgstr "Provider preset"
 
@@ -2608,9 +2626,9 @@ msgstr "Published"
 msgid "Publishing…"
 msgstr "Publishing…"
 
-#: src/routes/emails/inboxes.tsx:414
-#: src/routes/emails/inboxes.tsx:967
-#: src/routes/emails/inboxes.tsx:980
+#: src/routes/emails/inboxes.tsx:424
+#: src/routes/emails/inboxes.tsx:1031
+#: src/routes/emails/inboxes.tsx:1044
 msgid "Purpose"
 msgstr "Purpose"
 
@@ -2643,7 +2661,7 @@ msgstr "Recent changes"
 msgid "Recipient marked as spam"
 msgstr "Recipient marked as spam"
 
-#: src/routes/emails/inboxes.tsx:249
+#: src/routes/emails/inboxes.tsx:259
 msgid "Refreshing inbox status…"
 msgstr "Refreshing inbox status…"
 
@@ -2799,8 +2817,8 @@ msgid "Sales context"
 msgstr "Sales context"
 
 #: src/components/instructions/template-editor-dialog.tsx:173
-#: src/routes/emails/inboxes.tsx:1071
-#: src/routes/emails/inboxes.tsx:1476
+#: src/routes/emails/inboxes.tsx:1135
+#: src/routes/emails/inboxes.tsx:1555
 #: src/routes/pages/$id.tsx:271
 msgid "Save"
 msgstr "Save"
@@ -2831,7 +2849,7 @@ msgstr "Save the org default"
 
 #: src/components/emails/compose-form.tsx:547
 #: src/components/instructions/template-editor-dialog.tsx:173
-#: src/routes/emails/inboxes.tsx:1473
+#: src/routes/emails/inboxes.tsx:1552
 #: src/routes/pages/$id.tsx:271
 #: src/routes/reset-password.tsx:242
 #: src/routes/settings/profile/index.tsx:334
@@ -2880,7 +2898,7 @@ msgstr "Select the text and copy it manually."
 msgid "Select thread {0}"
 msgstr "Select thread {0}"
 
-#: src/routes/emails/inboxes.tsx:837
+#: src/routes/emails/inboxes.tsx:877
 msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 msgstr "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 
@@ -2952,7 +2970,7 @@ msgstr "Set a password"
 msgid "Set a password so you don't have to check your email next time."
 msgstr "Set a password so you don't have to check your email next time."
 
-#: src/routes/emails/inboxes.tsx:1378
+#: src/routes/emails/inboxes.tsx:1457
 msgid "Set as default"
 msgstr "Set as default"
 
@@ -2973,12 +2991,16 @@ msgstr "Set up reusable <0>instruction templates</0> to guide every run."
 msgid "Settings"
 msgstr "Settings"
 
+#: src/routes/emails/inboxes.tsx:896
+msgid "Setup guide →"
+msgstr "Setup guide →"
+
 #: src/components/research/run-detail.tsx:181
 msgid "Shaped by"
 msgstr "Shaped by"
 
-#: src/routes/emails/inboxes.tsx:462
-#: src/routes/emails/inboxes.tsx:1009
+#: src/routes/emails/inboxes.tsx:489
+#: src/routes/emails/inboxes.tsx:1073
 msgid "Shared"
 msgstr "Shared"
 
@@ -3063,16 +3085,16 @@ msgstr "Size"
 msgid "Slug"
 msgstr "Slug"
 
-#: src/routes/emails/inboxes.tsx:895
+#: src/routes/emails/inboxes.tsx:959
 msgid "SMTP host"
 msgstr "SMTP host"
 
-#: src/routes/emails/inboxes.tsx:905
+#: src/routes/emails/inboxes.tsx:969
 msgid "SMTP port"
 msgstr "SMTP port"
 
-#: src/routes/emails/inboxes.tsx:914
-#: src/routes/emails/inboxes.tsx:918
+#: src/routes/emails/inboxes.tsx:978
+#: src/routes/emails/inboxes.tsx:982
 msgid "SMTP security"
 msgstr "SMTP security"
 
@@ -3139,12 +3161,12 @@ msgstr "Starter presets"
 msgid "Starting…"
 msgstr "Starting…"
 
-#: src/routes/emails/inboxes.tsx:1124
+#: src/routes/emails/inboxes.tsx:1188
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
 #: src/routes/calendar/index.tsx:279
-#: src/routes/emails/inboxes.tsx:413
+#: src/routes/emails/inboxes.tsx:423
 #: src/routes/pages/index.tsx:147
 #: src/routes/tasks/index.tsx:695
 msgid "Status"
@@ -3159,7 +3181,7 @@ msgstr "Status update failed"
 msgid "Still in use"
 msgstr "Still in use"
 
-#: src/routes/emails/inboxes.tsx:960
+#: src/routes/emails/inboxes.tsx:1024
 msgid "Stored encrypted with AES-256-GCM."
 msgstr "Stored encrypted with AES-256-GCM."
 
@@ -3227,20 +3249,20 @@ msgstr "Templates"
 msgid "Tentative"
 msgstr "Tentative"
 
-#: src/routes/emails/inboxes.tsx:1072
+#: src/routes/emails/inboxes.tsx:1136
 msgid "Test & connect"
 msgstr "Test & connect"
 
 #. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx:514
+#: src/routes/emails/inboxes.tsx:541
 msgid "Test connection for {0}"
 msgstr "Test connection for {0}"
 
-#: src/routes/emails/inboxes.tsx:241
+#: src/routes/emails/inboxes.tsx:251
 msgid "Test failed"
 msgstr "Test failed"
 
-#: src/routes/emails/inboxes.tsx:1069
+#: src/routes/emails/inboxes.tsx:1133
 msgid "Testing connection…"
 msgstr "Testing connection…"
 
@@ -3289,7 +3311,7 @@ msgstr "The invitation may have expired or already been used."
 msgid "The invitee gets a 48-hour link. They can accept it once."
 msgstr "The invitee gets a 48-hour link. They can accept it once."
 
-#: src/routes/emails/inboxes.tsx:563
+#: src/routes/emails/inboxes.tsx:590
 msgid "The mailbox is ready."
 msgstr "The mailbox is ready."
 
@@ -3415,7 +3437,7 @@ msgstr "Timeline"
 msgid "Title"
 msgstr "Title"
 
-#: src/routes/emails/inboxes.tsx:1118
+#: src/routes/emails/inboxes.tsx:1182
 msgid "TLS"
 msgstr "TLS"
 
@@ -3493,10 +3515,10 @@ msgstr "Untitled key"
 msgid "Upcoming meetings"
 msgstr "Upcoming meetings"
 
-#: src/routes/emails/inboxes.tsx:204
-#: src/routes/emails/inboxes.tsx:225
-#: src/routes/emails/inboxes.tsx:1270
-#: src/routes/emails/inboxes.tsx:1322
+#: src/routes/emails/inboxes.tsx:214
+#: src/routes/emails/inboxes.tsx:235
+#: src/routes/emails/inboxes.tsx:1349
+#: src/routes/emails/inboxes.tsx:1401
 msgid "Update failed"
 msgstr "Update failed"
 
@@ -3509,7 +3531,7 @@ msgid "Uploading…"
 msgstr "Uploading…"
 
 #. placeholder {0}: primarySuggestions[0]?.email ?? ''
-#: src/routes/emails/inboxes.tsx:344
+#: src/routes/emails/inboxes.tsx:354
 msgid "Use {0} as primary"
 msgstr "Use {0} as primary"
 
@@ -3521,11 +3543,11 @@ msgstr "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old 
 msgid "Use a different email"
 msgstr "Use a different email"
 
-#: src/routes/emails/inboxes.tsx:1454
+#: src/routes/emails/inboxes.tsx:1533
 msgid "Use as default footer"
 msgstr "Use as default footer"
 
-#: src/routes/emails/inboxes.tsx:1037
+#: src/routes/emails/inboxes.tsx:1101
 msgid "Use as default for this purpose"
 msgstr "Use as default for this purpose"
 
@@ -3537,7 +3559,7 @@ msgstr "Use password instead"
 msgid "Use the org default"
 msgstr "Use the org default"
 
-#: src/routes/emails/inboxes.tsx:924
+#: src/routes/emails/inboxes.tsx:988
 msgid "Username"
 msgstr "Username"
 
@@ -3626,7 +3648,7 @@ msgstr "Who"
 msgid "Workshop floor — live counters on the bench."
 msgstr "Workshop floor — live counters on the bench."
 
-#: src/routes/emails/inboxes.tsx:1443
+#: src/routes/emails/inboxes.tsx:1522
 msgid "Write footer…"
 msgstr "Write footer…"
 
@@ -3662,7 +3684,7 @@ msgstr "You're now a member of {orgName}."
 msgid "You're now a member."
 msgstr "You're now a member."
 
-#: src/routes/emails/inboxes.tsx:848
+#: src/routes/emails/inboxes.tsx:912
 msgid "you@example.com"
 msgstr "you@example.com"
 

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -89,6 +89,8 @@ type ProviderPreset = {
 	readonly smtpPort: number
 	readonly smtpSecurity: TransportSecurity
 	readonly helpUrl: string
+	readonly appPasswordUrl: string
+	readonly passwordAuthSupported: boolean
 }
 
 async function loadInboxesOnServer(): Promise<ReadonlyArray<unknown>> {
@@ -153,6 +155,14 @@ function InboxesPage() {
 				? narrowInboxRows(inboxesResult.value)
 				: [],
 		[inboxesResult],
+	)
+	const presetsResult = useAtomValue(providerPresetsAtom)
+	const presets = useMemo<ReadonlyArray<ProviderPreset>>(
+		() =>
+			AsyncResult.isSuccess(presetsResult)
+				? narrowPresets(presetsResult.value)
+				: [],
+		[presetsResult],
 	)
 	const isLoading = AsyncResult.isInitial(inboxesResult)
 	const isFailure = AsyncResult.isFailure(inboxesResult)
@@ -452,6 +462,23 @@ function InboxesPage() {
 												? t`Connect failed`
 												: t`Disabled`}
 								</StatusBadge>
+								{row.grantStatus === 'auth_failed' && (
+									<AuthHint>
+										{t`2FA accounts need an app-specific password.`}
+										{authPasswordUrlFor(presets, row.imapHost) !== '' && (
+											<>
+												{' '}
+												<PresetLink
+													href={authPasswordUrlFor(presets, row.imapHost)}
+													target='_blank'
+													rel='noreferrer noopener'
+												>
+													{t`Create an app password →`}
+												</PresetLink>
+											</>
+										)}
+									</AuthHint>
+								)}
 							</CellStatus>
 							<CellPurpose role='cell'>
 								<PurposeBadge $purpose={row.purpose}>
@@ -711,6 +738,18 @@ function InboxFormDialog({
 		[presets],
 	)
 
+	// Derived from the chosen preset: powers the 2FA app-password hint and
+	// blocks submit for providers that no longer accept password sign-in.
+	const selectedPreset = useMemo(
+		() => presets.find(p => p.name === presetName) ?? null,
+		[presets, presetName],
+	)
+	const providerUnsupported =
+		selectedPreset !== null && !selectedPreset.passwordAuthSupported
+	const appPasswordUrl = selectedPreset?.appPasswordUrl ?? ''
+	const setupUrl =
+		appPasswordUrl !== '' ? appPasswordUrl : (selectedPreset?.helpUrl ?? '')
+
 	const usernameForSubmit = username !== '' ? username : email
 
 	// Create requires email + transport + credentials. Edit lets the user
@@ -719,6 +758,7 @@ function InboxFormDialog({
 	// the user opted into changing it.
 	const canSubmit =
 		!submitting &&
+		!providerUnsupported &&
 		(editing !== null
 			? email !== ''
 			: email !== '' &&
@@ -835,6 +875,30 @@ function InboxFormDialog({
 									</PriSelect.Portal>
 								</PriSelect.Root>
 								<Hint>{t`Selecting a preset fills IMAP and SMTP defaults — you can still edit them.`}</Hint>
+								{selectedPreset !== null &&
+									(providerUnsupported ? (
+										<Warning role='alert'>
+											{t`${selectedPreset.name} no longer allows password sign-in for mail apps, so it can't be connected here yet — it needs an OAuth sign-in. Pick another provider or use Generic IMAP.`}
+										</Warning>
+									) : (
+										<Hint>
+											{t`Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password.`}
+											{setupUrl !== '' && (
+												<>
+													{' '}
+													<PresetLink
+														href={setupUrl}
+														target='_blank'
+														rel='noreferrer noopener'
+													>
+														{appPasswordUrl !== ''
+															? t`Create an app password →`
+															: t`Setup guide →`}
+													</PresetLink>
+												</>
+											)}
+										</Hint>
+									))}
 							</Field>
 						)}
 
@@ -1136,6 +1200,18 @@ function SecuritySelect({
 	)
 }
 
+// App-password page for the provider matching an inbox's IMAP host, or '' when
+// the host isn't a known preset. Points an auth-failed inbox (usually a 2FA
+// account missing its app password) at the right place to create one.
+function authPasswordUrlFor(
+	presets: ReadonlyArray<ProviderPreset>,
+	imapHost: string,
+): string {
+	if (imapHost === '') return ''
+	const preset = presets.find(p => p.imapHost === imapHost)
+	return preset?.appPasswordUrl ?? ''
+}
+
 function narrowPresets(raw: unknown): ReadonlyArray<ProviderPreset> {
 	if (!Array.isArray(raw)) return []
 	const out: Array<ProviderPreset> = []
@@ -1166,6 +1242,9 @@ function narrowPresets(raw: unknown): ReadonlyArray<ProviderPreset> {
 			smtpPort: r['smtpPort'],
 			smtpSecurity: smtpSec,
 			helpUrl: typeof r['helpUrl'] === 'string' ? r['helpUrl'] : '',
+			appPasswordUrl:
+				typeof r['appPasswordUrl'] === 'string' ? r['appPasswordUrl'] : '',
+			passwordAuthSupported: r['passwordAuthSupported'] !== false,
 		})
 	}
 	return out
@@ -1861,6 +1940,26 @@ const Hint = styled.p.withConfig({ displayName: 'InboxFormHint' })`
 	font-size: var(--typescale-label-small-size);
 	color: var(--color-on-surface-variant);
 	font-style: italic;
+`
+
+const PresetLink = styled.a.withConfig({ displayName: 'InboxFormPresetLink' })`
+	color: var(--color-primary);
+	font-style: normal;
+	text-decoration: underline;
+`
+
+const Warning = styled.p.withConfig({ displayName: 'InboxFormWarning' })`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-error);
+`
+
+const AuthHint = styled.p.withConfig({ displayName: 'InboxesAuthHint' })`
+	margin: var(--space-2xs) 0 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-on-surface-variant);
 `
 
 const CellDefault = styled.div.withConfig({

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -311,7 +311,7 @@ const ListEmailInboxes = Tool.make('list_email_inboxes', {
 
 const ListEmailProviderPresets = Tool.make('list_email_provider_presets', {
 	description:
-		'List the built-in mailbox presets (Infomaniak, Fastmail, Gmail Workspace, Microsoft 365, Proton Bridge, Generic IMAP). Each entry pre-fills IMAP and SMTP host/port/security so create_email_inbox callers only need to add credentials. Static — safe to cache.',
+		'List the built-in mailbox presets (Infomaniak, Fastmail, iCloud Mail, Yahoo Mail, Gmail Workspace, Microsoft 365, Proton Bridge, Generic IMAP). Each entry pre-fills IMAP and SMTP host/port/security, plus appPasswordUrl (where the user generates an app-specific password for a 2FA account) and passwordAuthSupported (false for Gmail and Microsoft 365, which no longer allow password sign-in and need OAuth). create_email_inbox callers only need to add credentials. Static — safe to cache.',
 	parameters: Schema.Struct({}),
 	success: Schema.Array(Schema.Unknown),
 })
@@ -342,7 +342,7 @@ const GetEmailInboxStatus = Tool.make('get_email_inbox_status', {
 
 const CreateEmailInbox = Tool.make('create_email_inbox', {
 	description:
-		'Connect a new mailbox to the calling member. Requires full IMAP + SMTP transport details (use list_email_provider_presets to pre-fill these for known providers) and a password / app-password — Batuda is a generic IMAP/SMTP client, not a hosted mail provider. Credentials are encrypted at rest. `purpose=human` defaults ownership to the caller; `purpose=shared` clears any owner_user_id and rejects is_private=true. Setting is_default atomically clears the previous default in the same (owner, purpose) bucket.',
+		'Connect a new mailbox to the calling member. Requires full IMAP + SMTP transport details (use list_email_provider_presets to pre-fill these for known providers) and a password / app-password — Batuda is a generic IMAP/SMTP client, not a hosted mail provider. If the account has two-factor authentication enabled, its normal login password is rejected: the user must generate a provider app-specific password (see appPasswordUrl on the matching preset) and pass that instead. Gmail and Microsoft 365 no longer allow password sign-in at all (passwordAuthSupported=false) and will fail until an OAuth connector exists. Credentials are encrypted at rest. `purpose=human` defaults ownership to the caller; `purpose=shared` clears any owner_user_id and rejects is_private=true. Setting is_default atomically clears the previous default in the same (owner, purpose) bucket.',
 	parameters: Schema.Struct({
 		email: Schema.String,
 		password: Schema.String,
@@ -396,7 +396,7 @@ const UpdateEmailInbox = Tool.make('update_email_inbox', {
 
 const TestEmailInbox = Tool.make('test_email_inbox', {
 	description:
-		'Refresh the connection heartbeat for an inbox. The mail-transport slice will perform a real IMAP LOGIN + SMTP EHLO probe; until then this only stamps grant_last_seen_at so the UI can confirm the inbox row still resolves in this org. Returns the updated inbox row.',
+		'Re-probe a stored inbox: decrypts the saved credentials and runs a real IMAP LOGIN + SMTP check against the configured hosts, then updates grant_status / grant_last_error / grant_last_seen_at and returns the refreshed inbox row. Use after changing a password (for example switching to an app-specific password) to confirm the mailbox now connects.',
 	parameters: Schema.Struct({
 		id: Schema.String,
 	}),

--- a/apps/server/src/services/email-inbox-update.integration.test.ts
+++ b/apps/server/src/services/email-inbox-update.integration.test.ts
@@ -1,0 +1,464 @@
+// PgLive reads DATABASE_URL at layer-build time (no default). Set it so the
+// suite runs without a loaded .env, matching the other integration tests.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+	CurrentOrg,
+	GrantAuthFailed,
+	SessionContext,
+} from '@batuda/controllers'
+
+import { PgLive } from '../db/client.js'
+import { CalendarService } from './calendar.js'
+import {
+	CredentialCrypto,
+	decryptWithKey,
+	encryptWithKey,
+} from './credential-crypto.js'
+import { EmailService } from './email.js'
+import { EmailAttachmentStaging } from './email-attachment-staging.js'
+import { DraftStore } from './email-draft-store.js'
+import { EmailProvider } from './email-provider.js'
+import { type DecryptedCreds, MailTransport } from './mail-transport.js'
+import { StorageProvider } from './storage-provider.js'
+import { TimelineActivityService } from './timeline-activity.js'
+
+// Real Postgres + real SqlClient + stubbed MailTransport/CredentialCrypto. The
+// contract under test is updateInbox's re-probe: a credential or transport
+// change must run a fresh probe and persist the real outcome, while a
+// metadata-only edit must not probe at all. The cipher round-trip and the live
+// IMAP/SMTP probe are owned by their own suites.
+
+const TEST_ORG = 'inbox-update-test-org'
+const TEST_USER = 'inbox-update-test-user'
+
+const stubTransport = (
+	probe: (creds: DecryptedCreds) => Effect.Effect<void, unknown>,
+) =>
+	Layer.succeed(MailTransport, {
+		probe,
+		send: () => Effect.die('send not used in this test'),
+		appendToSent: () => Effect.die('appendToSent not used in this test'),
+	} as never)
+
+const stubCrypto = Layer.succeed(CredentialCrypto, {
+	encryptPassword: () => ({
+		ciphertext: new Uint8Array([0]),
+		nonce: new Uint8Array([0]),
+		tag: new Uint8Array([0]),
+	}),
+	decryptPassword: () => 'stubbed-password',
+} as never)
+
+// updateInbox/reprobeInbox only touch sql, crypto, transport and CurrentOrg.
+// The other EmailService dependencies are captured at construction but never
+// called on this path, so empty stubs are enough to build the layer.
+const serviceLayer = (
+	probe: (creds: DecryptedCreds) => Effect.Effect<void, unknown>,
+) =>
+	EmailService.layer.pipe(
+		Layer.provide([
+			stubCrypto,
+			stubTransport(probe),
+			Layer.succeed(EmailProvider, {} as never),
+			Layer.succeed(TimelineActivityService, {} as never),
+			Layer.succeed(EmailAttachmentStaging, {} as never),
+			Layer.succeed(DraftStore, {} as never),
+			Layer.succeed(CalendarService, {} as never),
+			Layer.succeed(StorageProvider, {} as never),
+		]),
+		Layer.provide(PgLive),
+	)
+
+const orgContext = Layer.succeed(CurrentOrg, { id: TEST_ORG } as never)
+const sessionContext = Layer.succeed(SessionContext, {
+	userId: TEST_USER,
+} as never)
+
+interface GrantRow {
+	readonly grantStatus: string
+	readonly grantLastError: string | null
+	readonly displayName: string | null
+}
+
+describe('EmailService.updateInbox re-probe', () => {
+	let inboxId: string
+
+	const seedInbox = Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const placeholder = new Uint8Array([0])
+		const rows = yield* sql<{ id: string }>`
+			INSERT INTO inboxes (
+				organization_id, email, display_name, purpose, owner_user_id,
+				imap_host, imap_port, imap_security,
+				smtp_host, smtp_port, smtp_security,
+				username, password_ciphertext, password_nonce, password_tag,
+				active, grant_status
+			) VALUES (
+				${TEST_ORG}, 'update@test.local', 'Baseline', 'human', ${TEST_USER},
+				'imap.test.local', 993, 'tls',
+				'smtp.test.local', 587, 'starttls',
+				'update@test.local', ${placeholder}, ${placeholder}, ${placeholder},
+				true, 'connected'
+			)
+			RETURNING id
+		`
+		return rows[0]!.id
+	})
+
+	const resetRow = (id: string) =>
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`
+				UPDATE inboxes
+				SET grant_status = 'connected',
+				    grant_last_error = NULL,
+				    display_name = 'Baseline'
+				WHERE id = ${id}
+			`
+		})
+
+	const readGrant = (id: string) =>
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<GrantRow>`
+				SELECT grant_status AS "grantStatus",
+				       grant_last_error AS "grantLastError",
+				       display_name AS "displayName"
+				FROM inboxes WHERE id = ${id}
+			`
+			return rows[0]
+		})
+
+	beforeAll(async () => {
+		inboxId = await Effect.runPromise(
+			seedInbox.pipe(Effect.provide(PgLive)) as Effect.Effect<
+				string,
+				never,
+				never
+			>,
+		)
+	})
+
+	afterAll(async () => {
+		if (inboxId) {
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					yield* sql`DELETE FROM inboxes WHERE id = ${inboxId}`
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+			)
+		}
+	})
+
+	beforeEach(async () => {
+		await Effect.runPromise(
+			resetRow(inboxId).pipe(Effect.provide(PgLive)) as Effect.Effect<
+				void,
+				never,
+				never
+			>,
+		)
+	})
+
+	describe('when the password changes and the probe fails to authenticate', () => {
+		it('should persist auth_failed with the upstream detail', async () => {
+			// [email.ts:1956 — updateInbox: credentialsChanged → reprobeInbox(id)]
+			// GIVEN a probe that rejects the new credentials
+			const detail = 'NO Invalid login or password'
+
+			// WHEN the password is updated
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.updateInbox(inboxId, { password: 'app-pw-wrong' })
+				}).pipe(
+					Effect.provide(
+						serviceLayer(creds =>
+							Effect.fail(
+								new GrantAuthFailed({ inboxId: creds.inboxId, detail }),
+							),
+						),
+					),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+				) as Effect.Effect<void, never, never>,
+			)
+
+			// THEN the row reflects the real probe outcome, not an optimistic
+			// connected
+			const grant = await Effect.runPromise(
+				readGrant(inboxId).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					GrantRow | undefined,
+					never,
+					never
+				>,
+			)
+			expect(grant?.grantStatus).toBe('auth_failed')
+			expect(grant?.grantLastError).toBe(detail)
+		})
+	})
+
+	describe('when the password changes and the probe succeeds', () => {
+		it('should persist connected and clear the previous error', async () => {
+			// [email.ts:466 — reprobeInbox writes connected and clears grant_last_error]
+			// GIVEN the row was previously failing
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					yield* sql`UPDATE inboxes SET grant_status = 'auth_failed', grant_last_error = 'stale' WHERE id = ${inboxId}`
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+			)
+
+			// WHEN the user pastes a working app password
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.updateInbox(inboxId, { password: 'app-pw-good' })
+				}).pipe(
+					Effect.provide(serviceLayer(() => Effect.void)),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+				) as Effect.Effect<void, never, never>,
+			)
+
+			// THEN the inbox recovers to connected with no error
+			const grant = await Effect.runPromise(
+				readGrant(inboxId).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					GrantRow | undefined,
+					never,
+					never
+				>,
+			)
+			expect(grant?.grantStatus).toBe('connected')
+			expect(grant?.grantLastError).toBeNull()
+		})
+	})
+
+	describe('when only metadata changes', () => {
+		it('should not probe and should leave grant_status untouched', async () => {
+			// [email.ts:1912 — credentialsChanged is false, so no reprobe on a metadata-only edit]
+			// GIVEN the row is connected and a probe that fails loudly if called
+			// WHEN only the display name is edited
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.updateInbox(inboxId, { displayName: 'Renamed' })
+				}).pipe(
+					Effect.provide(
+						serviceLayer(() =>
+							Effect.die('probe must not run for a metadata-only edit'),
+						),
+					),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+				) as Effect.Effect<void, never, never>,
+			)
+
+			// THEN the name changed but the grant state is untouched
+			const grant = await Effect.runPromise(
+				readGrant(inboxId).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					GrantRow | undefined,
+					never,
+					never
+				>,
+			)
+			expect(grant?.displayName).toBe('Renamed')
+			expect(grant?.grantStatus).toBe('connected')
+		})
+	})
+})
+
+describe('EmailService.listProviderPresets', () => {
+	describe('when read through the service', () => {
+		it('should expose appPasswordUrl and passwordAuthSupported, with Gmail/M365 unsupported', async () => {
+			// [email.ts:1649 — listProviderPresets returns PROVIDER_PRESETS]
+			// GIVEN the built-in preset list
+			// WHEN it is read through the service
+			const presets = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.listProviderPresets()
+				}).pipe(Effect.provide(serviceLayer(() => Effect.void)), Effect.orDie),
+			)
+
+			// THEN every entry carries the two hint fields with the right types
+			for (const preset of presets) {
+				expect(typeof preset.appPasswordUrl).toBe('string')
+				expect(typeof preset.passwordAuthSupported).toBe('boolean')
+			}
+
+			const byName = (name: string) => presets.find(p => p.name === name)
+
+			// AND the two OAuth-only providers are flagged unsupported
+			expect(byName('Gmail Workspace')?.passwordAuthSupported).toBe(false)
+			expect(byName('Microsoft 365')?.passwordAuthSupported).toBe(false)
+
+			// AND app-password providers are supported with a creation link
+			expect(byName('Infomaniak')?.passwordAuthSupported).toBe(true)
+			expect(byName('Infomaniak')?.appPasswordUrl).toContain('infomaniak.com')
+			expect(byName('iCloud Mail')?.appPasswordUrl).toContain('apple.com')
+			expect(byName('Yahoo Mail')?.appPasswordUrl).toContain('yahoo.com')
+		})
+	})
+})
+
+describe('EmailService.updateInbox re-probe — real credential round-trip', () => {
+	// Real AES-GCM round-trip (HKDF subkey per inbox id); only the network
+	// probe is stubbed, and it captures the credentials it receives. This proves
+	// the part the stubbed-crypto suite above cannot see: that the password the
+	// caller passes is encrypted, stored, re-read and decrypted back to the
+	// exact value handed to the probe.
+	const TEST_KEY = Buffer.alloc(32, 7)
+	const ORIGINAL_PW = 'original-app-pw'
+
+	const realCrypto = Layer.succeed(CredentialCrypto, {
+		encryptPassword: (input: { inboxId: string; plain: string }) =>
+			encryptWithKey(TEST_KEY, input),
+		decryptPassword: (input: {
+			inboxId: string
+			ciphertext: Uint8Array
+			nonce: Uint8Array
+			tag: Uint8Array
+		}) => decryptWithKey(TEST_KEY, input),
+	} as never)
+
+	const probeCalls: Array<DecryptedCreds> = []
+	const capturingTransport = Layer.succeed(MailTransport, {
+		probe: (creds: DecryptedCreds) => {
+			probeCalls.push(creds)
+			return Effect.void
+		},
+		send: () => Effect.die('send not used in this test'),
+		appendToSent: () => Effect.die('appendToSent not used in this test'),
+	} as never)
+
+	const realServiceLayer = EmailService.layer.pipe(
+		Layer.provide([
+			realCrypto,
+			capturingTransport,
+			Layer.succeed(EmailProvider, {} as never),
+			Layer.succeed(TimelineActivityService, {} as never),
+			Layer.succeed(EmailAttachmentStaging, {} as never),
+			Layer.succeed(DraftStore, {} as never),
+			Layer.succeed(CalendarService, {} as never),
+			Layer.succeed(StorageProvider, {} as never),
+		]),
+		Layer.provide(PgLive),
+	)
+
+	const inboxId = randomUUID()
+
+	const seedOriginal = Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const enc = encryptWithKey(TEST_KEY, { inboxId, plain: ORIGINAL_PW })
+		yield* sql`
+			UPDATE inboxes
+			SET password_ciphertext = ${enc.ciphertext},
+			    password_nonce = ${enc.nonce},
+			    password_tag = ${enc.tag},
+			    imap_host = 'imap.test.local',
+			    grant_status = 'connected',
+			    grant_last_error = NULL
+			WHERE id = ${inboxId}
+		`
+	})
+
+	beforeAll(async () => {
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				const enc = encryptWithKey(TEST_KEY, { inboxId, plain: ORIGINAL_PW })
+				yield* sql`
+					INSERT INTO inboxes (
+						id, organization_id, email, display_name, purpose, owner_user_id,
+						imap_host, imap_port, imap_security,
+						smtp_host, smtp_port, smtp_security,
+						username, password_ciphertext, password_nonce, password_tag,
+						active, grant_status
+					) VALUES (
+						${inboxId}, ${TEST_ORG}, 'roundtrip@test.local', 'Roundtrip', 'human', ${TEST_USER},
+						'imap.test.local', 993, 'tls',
+						'smtp.test.local', 587, 'starttls',
+						'roundtrip@test.local', ${enc.ciphertext}, ${enc.nonce}, ${enc.tag},
+						true, 'connected'
+					)
+				`
+			}).pipe(Effect.provide(PgLive), Effect.orDie),
+		)
+	})
+
+	afterAll(async () => {
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				yield* sql`DELETE FROM inboxes WHERE id = ${inboxId}`
+			}).pipe(Effect.provide(PgLive), Effect.orDie),
+		)
+	})
+
+	beforeEach(async () => {
+		await Effect.runPromise(
+			seedOriginal.pipe(Effect.provide(PgLive), Effect.orDie),
+		)
+		probeCalls.length = 0
+	})
+
+	describe('when the password is rotated', () => {
+		it('should probe with the newly entered password', async () => {
+			// [email.ts:1956 — reprobeInbox re-reads and decrypts the freshly stored ciphertext]
+			// GIVEN a working inbox
+			// WHEN the password is changed to a fresh app password
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.updateInbox(inboxId, { password: 'rotated-app-pw' })
+				}).pipe(
+					Effect.provide(realServiceLayer),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+					Effect.orDie,
+				),
+			)
+
+			// THEN the probe received exactly the new password — proving the
+			// encrypt → store → re-read → decrypt chain on the update path
+			expect(probeCalls).toHaveLength(1)
+			expect(probeCalls[0]?.password).toBe('rotated-app-pw')
+		})
+	})
+
+	describe('when only the transport changes', () => {
+		it('should probe with the decrypted stored password and the new host', async () => {
+			// [email.ts:1912 — transport change triggers reprobe with the decrypted stored password]
+			// GIVEN the stored password is left unchanged
+			// WHEN only the IMAP host is edited
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.updateInbox(inboxId, {
+						imapHost: 'imap.rotated.example',
+					})
+				}).pipe(
+					Effect.provide(realServiceLayer),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+					Effect.orDie,
+				),
+			)
+
+			// THEN the probe used the decrypted stored password against the new
+			// host
+			expect(probeCalls).toHaveLength(1)
+			expect(probeCalls[0]?.password).toBe(ORIGINAL_PW)
+			expect(probeCalls[0]?.imapHost).toBe('imap.rotated.example')
+		})
+	})
+})

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -256,30 +256,16 @@ const projectAttachmentsForWire = <T extends Record<string, unknown>>(
 	return { ...row, attachments: projected }
 }
 
-// Vendor-neutral mailbox presets surfaced to the connect-mailbox UI. Adding a
-// new entry requires no code beyond appending to this list — fields are the
-// same shape as the createInbox payload.
+// Vendor-neutral mailbox presets for the connect-mailbox picker. The transport
+// fields mirror the createInbox payload; helpUrl, appPasswordUrl and
+// passwordAuthSupported are UI-only hints. Most providers accept an app-specific
+// password under two-factor authentication, and appPasswordUrl points to where
+// the user creates one. Gmail and Microsoft 365 are passwordAuthSupported=false:
+// they dropped password sign-in for mail clients and need an OAuth connection
+// the app does not offer yet, so the UI flags them when selected. Ordered by
+// rough global popularity (most common first), with Generic IMAP last as the
+// manual catch-all.
 const PROVIDER_PRESETS = [
-	{
-		name: 'Infomaniak',
-		imapHost: 'mail.infomaniak.com',
-		imapPort: 993,
-		imapSecurity: 'tls',
-		smtpHost: 'mail.infomaniak.com',
-		smtpPort: 465,
-		smtpSecurity: 'tls',
-		helpUrl: 'https://www.infomaniak.com/en/support/faq/2427',
-	},
-	{
-		name: 'Fastmail',
-		imapHost: 'imap.fastmail.com',
-		imapPort: 993,
-		imapSecurity: 'tls',
-		smtpHost: 'smtp.fastmail.com',
-		smtpPort: 465,
-		smtpSecurity: 'tls',
-		helpUrl: 'https://www.fastmail.help/hc/en-us/articles/1500000278342',
-	},
 	{
 		name: 'Gmail Workspace',
 		imapHost: 'imap.gmail.com',
@@ -289,6 +275,8 @@ const PROVIDER_PRESETS = [
 		smtpPort: 465,
 		smtpSecurity: 'tls',
 		helpUrl: 'https://support.google.com/mail/answer/7126229',
+		appPasswordUrl: '',
+		passwordAuthSupported: false,
 	},
 	{
 		name: 'Microsoft 365',
@@ -300,6 +288,32 @@ const PROVIDER_PRESETS = [
 		smtpSecurity: 'starttls',
 		helpUrl:
 			'https://support.microsoft.com/en-us/office/pop-imap-and-smtp-settings-8361e398-8af4-4e97-b147-6c6c4ac95353',
+		appPasswordUrl: '',
+		passwordAuthSupported: false,
+	},
+	{
+		name: 'iCloud Mail',
+		imapHost: 'imap.mail.me.com',
+		imapPort: 993,
+		imapSecurity: 'tls',
+		smtpHost: 'smtp.mail.me.com',
+		smtpPort: 587,
+		smtpSecurity: 'starttls',
+		helpUrl: '',
+		appPasswordUrl: 'https://support.apple.com/en-us/102654',
+		passwordAuthSupported: true,
+	},
+	{
+		name: 'Yahoo Mail',
+		imapHost: 'imap.mail.yahoo.com',
+		imapPort: 993,
+		imapSecurity: 'tls',
+		smtpHost: 'smtp.mail.yahoo.com',
+		smtpPort: 465,
+		smtpSecurity: 'tls',
+		helpUrl: '',
+		appPasswordUrl: 'https://help.yahoo.com/kb/SLN15241.html',
+		passwordAuthSupported: true,
 	},
 	{
 		name: 'Proton Bridge',
@@ -310,6 +324,34 @@ const PROVIDER_PRESETS = [
 		smtpPort: 1025,
 		smtpSecurity: 'starttls',
 		helpUrl: 'https://proton.me/support/protonmail-bridge-clients',
+		appPasswordUrl: '',
+		passwordAuthSupported: true,
+	},
+	{
+		name: 'Fastmail',
+		imapHost: 'imap.fastmail.com',
+		imapPort: 993,
+		imapSecurity: 'tls',
+		smtpHost: 'smtp.fastmail.com',
+		smtpPort: 465,
+		smtpSecurity: 'tls',
+		helpUrl: 'https://www.fastmail.help/hc/en-us/articles/1500000278342',
+		appPasswordUrl:
+			'https://www.fastmail.help/hc/en-us/articles/360058752854-App-passwords',
+		passwordAuthSupported: true,
+	},
+	{
+		name: 'Infomaniak',
+		imapHost: 'mail.infomaniak.com',
+		imapPort: 993,
+		imapSecurity: 'tls',
+		smtpHost: 'mail.infomaniak.com',
+		smtpPort: 465,
+		smtpSecurity: 'tls',
+		helpUrl: 'https://www.infomaniak.com/en/support/faq/2427',
+		appPasswordUrl:
+			'https://www.infomaniak.com/en/support/faq/2855/manage-application-passwords',
+		passwordAuthSupported: true,
 	},
 	{
 		name: 'Generic IMAP',
@@ -320,6 +362,8 @@ const PROVIDER_PRESETS = [
 		smtpPort: 587,
 		smtpSecurity: 'starttls',
 		helpUrl: '',
+		appPasswordUrl: '',
+		passwordAuthSupported: true,
 	},
 ] as const
 
@@ -412,6 +456,102 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						LIMIT 1
 					`.pipe(Effect.orDie)
 					return rows[0] ?? null
+				})
+
+			// Decrypt the stored credentials in-memory, run an IMAP LOGIN + SMTP
+			// verify against the configured hosts, and persist the outcome so the
+			// status badge reflects reality. Shared by testInbox (a manual
+			// re-test) and updateInbox (immediate feedback after a credential or
+			// transport change) so both report connect/auth failures identically.
+			const reprobeInbox = (id: string) =>
+				Effect.gen(function* () {
+					const currentOrg = yield* CurrentOrg
+
+					const credRows = yield* sql<{
+						imapHost: string
+						imapPort: number
+						imapSecurity: 'tls' | 'starttls' | 'plain'
+						smtpHost: string
+						smtpPort: number
+						smtpSecurity: 'tls' | 'starttls' | 'plain'
+						username: string
+						passwordCiphertext: Uint8Array
+						passwordNonce: Uint8Array
+						passwordTag: Uint8Array
+					}>`
+						SELECT
+							imap_host          AS "imapHost",
+							imap_port          AS "imapPort",
+							imap_security      AS "imapSecurity",
+							smtp_host          AS "smtpHost",
+							smtp_port          AS "smtpPort",
+							smtp_security      AS "smtpSecurity",
+							username,
+							password_ciphertext AS "passwordCiphertext",
+							password_nonce     AS "passwordNonce",
+							password_tag       AS "passwordTag"
+						FROM inboxes
+						WHERE id = ${id}
+						  AND organization_id = ${currentOrg.id}
+						LIMIT 1
+					`.pipe(Effect.orDie)
+					const cred = credRows[0]
+					if (!cred) {
+						return yield* new NotFound({ entity: 'Inbox', id })
+					}
+
+					const password = crypto.decryptPassword({
+						inboxId: id,
+						ciphertext: cred.passwordCiphertext,
+						nonce: cred.passwordNonce,
+						tag: cred.passwordTag,
+					})
+
+					const probe = yield* transport
+						.probe({
+							inboxId: id,
+							imapHost: cred.imapHost,
+							imapPort: cred.imapPort,
+							imapSecurity: cred.imapSecurity,
+							smtpHost: cred.smtpHost,
+							smtpPort: cred.smtpPort,
+							smtpSecurity: cred.smtpSecurity,
+							username: cred.username,
+							password,
+						})
+						.pipe(
+							Effect.match({
+								onSuccess: () =>
+									({
+										status: 'connected' as const,
+										detail: null as string | null,
+									}) as const,
+								onFailure: err =>
+									({
+										status:
+											err._tag === 'GrantAuthFailed'
+												? ('auth_failed' as const)
+												: ('connect_failed' as const),
+										detail: err.detail ?? null,
+									}) as const,
+							}),
+						)
+
+					const rows = yield* sql<InboxRow>`
+						UPDATE inboxes
+						SET
+							grant_status = ${probe.status},
+							grant_last_error = ${probe.detail},
+							grant_last_seen_at = now(),
+							updated_at = now()
+						WHERE id = ${id}
+						  AND organization_id = ${currentOrg.id}
+						RETURNING ${selectInboxColumns}
+					`
+					if (rows.length === 0) {
+						return yield* new NotFound({ entity: 'Inbox', id })
+					}
+					return rows[0]!
 				})
 
 			const resolveDefaultInboxForCurrentUser = () =>
@@ -1759,14 +1899,25 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 							sets.push(sql`password_ciphertext = ${encrypted.ciphertext}`)
 							sets.push(sql`password_nonce = ${encrypted.nonce}`)
 							sets.push(sql`password_tag = ${encrypted.tag}`)
-							// Reset the grant state so the worker re-probes on next tick.
-							sets.push(sql`grant_status = 'connected'`)
-							sets.push(sql`grant_last_error = NULL`)
 						}
 
 						if (sets.length === 0) {
 							return existing
 						}
+
+						// A credential or transport change is re-probed after the
+						// write so the returned row reflects the real connection
+						// state — createInbox probes up-front, and an edit that only
+						// touches metadata (e.g. display name) skips the probe.
+						const credentialsChanged =
+							patch.password !== undefined ||
+							patch.username !== undefined ||
+							patch.imapHost !== undefined ||
+							patch.imapPort !== undefined ||
+							patch.imapSecurity !== undefined ||
+							patch.smtpHost !== undefined ||
+							patch.smtpPort !== undefined ||
+							patch.smtpSecurity !== undefined
 
 						// Promoting to default requires clearing the prior default
 						// in the same (owner, purpose) bucket, mirroring createInbox.
@@ -1802,6 +1953,9 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						if (rows.length === 0) {
 							return yield* new NotFound({ entity: 'Inbox', id })
 						}
+						if (credentialsChanged) {
+							return yield* reprobeInbox(id)
+						}
 						return rows[0]!
 					}),
 
@@ -1825,100 +1979,9 @@ export class EmailService extends ServiceMap.Service<EmailService>()(
 						return rows[0]!
 					}),
 
-				// Re-probe stored credentials by decrypting in-memory and running
-				// IMAP LOGIN + SMTP verify against the configured hosts. The
-				// inbox row is updated with the probe outcome so the UI can
-				// refresh the status badge without reloading the entire list.
-				testInbox: (id: string) =>
-					Effect.gen(function* () {
-						const currentOrg = yield* CurrentOrg
-
-						const credRows = yield* sql<{
-							imapHost: string
-							imapPort: number
-							imapSecurity: 'tls' | 'starttls' | 'plain'
-							smtpHost: string
-							smtpPort: number
-							smtpSecurity: 'tls' | 'starttls' | 'plain'
-							username: string
-							passwordCiphertext: Uint8Array
-							passwordNonce: Uint8Array
-							passwordTag: Uint8Array
-						}>`
-							SELECT
-								imap_host          AS "imapHost",
-								imap_port          AS "imapPort",
-								imap_security      AS "imapSecurity",
-								smtp_host          AS "smtpHost",
-								smtp_port          AS "smtpPort",
-								smtp_security      AS "smtpSecurity",
-								username,
-								password_ciphertext AS "passwordCiphertext",
-								password_nonce     AS "passwordNonce",
-								password_tag       AS "passwordTag"
-							FROM inboxes
-							WHERE id = ${id}
-							  AND organization_id = ${currentOrg.id}
-							LIMIT 1
-						`.pipe(Effect.orDie)
-						const cred = credRows[0]
-						if (!cred) {
-							return yield* new NotFound({ entity: 'Inbox', id })
-						}
-
-						const password = crypto.decryptPassword({
-							inboxId: id,
-							ciphertext: cred.passwordCiphertext,
-							nonce: cred.passwordNonce,
-							tag: cred.passwordTag,
-						})
-
-						const probe = yield* transport
-							.probe({
-								inboxId: id,
-								imapHost: cred.imapHost,
-								imapPort: cred.imapPort,
-								imapSecurity: cred.imapSecurity,
-								smtpHost: cred.smtpHost,
-								smtpPort: cred.smtpPort,
-								smtpSecurity: cred.smtpSecurity,
-								username: cred.username,
-								password,
-							})
-							.pipe(
-								Effect.match({
-									onSuccess: () =>
-										({
-											status: 'connected' as const,
-											detail: null as string | null,
-										}) as const,
-									onFailure: err =>
-										({
-											status:
-												err._tag === 'GrantAuthFailed'
-													? ('auth_failed' as const)
-													: ('connect_failed' as const),
-											detail: err.detail ?? null,
-										}) as const,
-								}),
-							)
-
-						const rows = yield* sql<InboxRow>`
-							UPDATE inboxes
-							SET
-								grant_status = ${probe.status},
-								grant_last_error = ${probe.detail},
-								grant_last_seen_at = now(),
-								updated_at = now()
-							WHERE id = ${id}
-							  AND organization_id = ${currentOrg.id}
-							RETURNING ${selectInboxColumns}
-						`
-						if (rows.length === 0) {
-							return yield* new NotFound({ entity: 'Inbox', id })
-						}
-						return rows[0]!
-					}),
+				// Manual re-test of a stored mailbox — decrypt, probe, and write
+				// back the grant status. Shares reprobeInbox with updateInbox.
+				testInbox: (id: string) => reprobeInbox(id),
 
 				// Promotes a single inbox to `is_default=true` for the calling
 				// member. Validates ownership so a member cannot promote an


### PR DESCRIPTION
## What

Makes the **app-specific password** path first-class so a mailbox with two-factor authentication can actually connect over IMAP/SMTP — the universal, provider-agnostic way 2FA accounts authenticate (there is no protocol path for a 2FA code, and OAuth is per-provider, so it can never be "any provider"). Touches the CRM email surface across `server` (inbox service + MCP tools) and `internal` (connect-mailbox UI). No OAuth, no schema change.

This came out of a live failure: an Infomaniak inbox sat at `grant_status = auth_failed` ("Invalid login or password") because the account has 2FA and I'd entered the login password instead of an app password.

## Changes

- **Presets** now carry `appPasswordUrl` (where to create an app password) and `passwordAuthSupported`. Added **iCloud** and **Yahoo**; **Gmail Workspace** and **Microsoft 365** are flagged `passwordAuthSupported: false` (they dropped password sign-in for mail clients and need OAuth, which isn't offered yet). List ordered by rough global popularity, Generic IMAP last.
- **Editing an inbox now re-probes.** A password/transport change runs a real IMAP+SMTP probe and persists the true outcome instead of optimistically marking the inbox `connected` and leaving the worker to discover the failure later. Factored the existing `testInbox` decrypt→probe→writeback into a shared `reprobeInbox`.
- **MCP** `create_email_inbox` now tells agents to use an app password for 2FA accounts; the stale `test_email_inbox` description was corrected to describe the real probe.
- **Internal UI**: the connect-mailbox form shows an app-password hint with a "create one" link, and for OAuth-only providers shows a warning and disables submit; `auth_failed` inboxes in the list get the same hint. New strings in English + Catalan.

## Impact

- **MCP + HTTP parity** — `createInbox` / `updateInbox` / `testInbox` are shared services, so both transports get the re-probe and the corrected behavior.
- **Wire-shape (additive)** — `list_email_provider_presets` now returns `appPasswordUrl` + `passwordAuthSupported`. Additive fields consumed by the internal client; no breaking change.
- **No migration, no schema change, no new env vars, no RLS/auth boundary change.** The re-probe decrypts an *already-stored* credential with the existing per-inbox key — no new secret handling.
- **Gmail / Microsoft 365 stay unconnectable by password** — that's the provider's doing, not a regression; the UI now states it instead of letting users fail silently. An OAuth connector for those two is future work.

## Review guide

- Start at `apps/server/src/services/email.ts` → `reprobeInbox` and `updateInbox` (the only behavior change). Riskiest line: the re-probe re-reads the row and decrypts the *freshly stored* ciphertext — covered by a real-AES-GCM integration test that asserts the new password actually reaches the probe.
- Presets are static data; the UI additions are conditional hints/warnings — skim-able.
- **a11y**: I fixed announceability (the warning is now `role='alert'`) and made the list link self-describing. One **known residual I did not fix here**: `PresetLink` uses `var(--color-primary)`, which measures ~4.2:1 on the dialog's hard-coded `#f0e8d0` paper background — below AA 4.5:1. This is **systemic** (the primary token vs paper-aged affects existing links app-wide; `PriDialog` hard-codes the background), so I deliberately avoided a one-off color override — flagging for a design-token fix. Minor deferred: `aria-describedby` wiring on the provider `<select>` and an "opens in new tab" cue.
- **Snyk**: the `snyk_code_scan` MCP tool wasn't available in my session, so I couldn't run it. The change introduces no new untrusted-input parsing, SQL is parameterized, and crypto/auth are untouched.
- The compiled `messages.js` catalogs are intentionally untouched — `@lingui/vite-plugin` compiles `.po` at build; `i18n-check` passed.

## Tests

- New integration suite (real Postgres), `/test-bdd` shape with `[email.ts:line]` annotations:
  - `updateInbox` re-probe → `auth_failed` on bad creds, `connected` on good, and **no probe** on a metadata-only edit.
  - Real-AES-GCM round-trip → a rotated password, and a transport-only edit, each assert the exact credential handed to the probe.
  - `listProviderPresets` contract (fields present; Gmail/M365 unsupported).
- 252 existing server unit tests still green after the `reprobeInbox`/`testInbox` refactor.

## Verification

- Ran `turbo check-types` + `test` (252) + `build` — all green.
- Integration suite 6/6 against local Postgres (:5433).
- **Not run**: the live IMAP/SMTP probe against a real provider (needs a real app password) and browser screenshots (worktree dev-stack cost). The UI additions are conditional hints verified by the build + described above; happy to capture screenshots if you want them before merge.

## Deferred

- a11y contrast of `var(--color-primary)` on paper backgrounds (design-system token).
- `aria-describedby` on the provider select + "opens in new tab" link cue.
- OAuth connector for Gmail / Microsoft 365 (the only providers this path can't cover).
