### PR TITLE
feat(internal): drive inbox dialogs from URL search params

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -114,6 +114,44 @@ Magic-link emails (from invite flow) are tagged with `labels: magic-link` in fro
 
 If no emails appear, verify `EMAIL_PROVIDER=local-inbox` in `.env` and check `apps/server/server.log` for `"email provider: local-inbox"`.
 
+## Running a worktree dev stack
+
+To run the app from a git worktree (e.g. to verify a branch live) **alongside** the
+main checkout's stack, without conflict.
+
+**How it works:** portless auto-prefixes the git branch name, so you use the
+**same** dev names and portless namespaces them by worktree. From a worktree on
+branch `<branch>`, `--name batuda` serves at `<branch>.batuda.localhost` and
+`--name api.batuda` at `<branch>.api.batuda.localhost`. The web auto-derives its
+API origin from its own host, so the pair just works. portless injects `PORT`
+(overriding `.env`), so there is no port clash with the main stack. Docker
+Postgres/MinIO are shared (same data).
+
+Setup (run binaries directly — `pnpm` scripts fail in worktrees on the lefthook
+`prepare` hook: `core.hooksPath is set locally`):
+
+```bash
+# 1. Copy the .env from the main checkout — no edits needed. ALLOWED_ORIGINS
+#    ships a `*.batuda.localhost` wildcard that trusts the worktree origin, and
+#    the auth cookie domain collapses to `batuda.localhost` (shared), so login
+#    works as-is. (Older .env missing the wildcard: append `,https://*.batuda.localhost`.)
+#    Caveat: APP_PUBLIC_URL/BETTER_AUTH_BASE_URL stay at the main host, so
+#    invite/MCP-issuer links point at the main app — fine for normal testing.
+cp ../../.env ./.env
+
+# 2. Build @batuda/ui — the SERVER (node/tsx) resolves its `default`/dist export.
+#    (vite dev alone doesn't need this: the web uses the `development`/src export.)
+./node_modules/.bin/turbo run build --filter=@batuda/ui
+
+# 3. Start server (from apps/server) and web (from apps/internal), in background:
+../../node_modules/.bin/portless run --name api.batuda node --watch --env-file=../../.env --import tsx src/main.ts
+../../node_modules/.bin/portless run --name batuda vite dev
+```
+
+Verify: `curl -sk https://<branch>.api.batuda.localhost/health` and drive
+`agent-browser` against `https://<branch>.batuda.localhost`. The branch is
+`git branch --show-current`.
+
 ## CLI commands reference
 
 | Command                    | Purpose                                    |

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,11 @@ OAUTH_CLIENT_GC_DAYS=365
 API_KEY_RATE_LIMIT_ENABLED=false
 API_KEY_RATE_LIMIT_MAX=600
 API_KEY_RATE_LIMIT_WINDOW_SECONDS=60
-ALLOWED_ORIGINS=https://batuda.localhost
+# The literal trusts the main dev origin; the `*.batuda.localhost` wildcard
+# trusts each git worktree's auto-prefixed origin (`<branch>.batuda.localhost`)
+# so a worktree dev stack works with no per-worktree edits. Wildcards are
+# accepted only under `.localhost` (real-domain wildcards are rejected at boot).
+ALLOWED_ORIGINS=https://batuda.localhost,https://*.batuda.localhost
 # Canonical public app origin for the links the server mints (invitations).
 # Must be one of ALLOWED_ORIGINS — boot fails otherwise.
 APP_PUBLIC_URL=https://batuda.localhost

--- a/apps/internal/package.json
+++ b/apps/internal/package.json
@@ -7,6 +7,7 @@
 		"dev": "portless run --name batuda vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test": "vitest run",
 		"check-types": "pnpm routes:generate && tsc --noEmit && tsc --noEmit -p tsconfig.node.json",
 		"routes:generate": "node scripts/generate-routes.mjs",
 		"test:e2e": "playwright test",

--- a/apps/internal/src/atoms/inbox-draft-atoms.ts
+++ b/apps/internal/src/atoms/inbox-draft-atoms.ts
@@ -1,0 +1,52 @@
+import { Atom } from 'effect/unstable/reactivity'
+
+/**
+ * In-progress draft for the "Connect mailbox" form, kept in a global atom so a
+ * half-filled form survives closing the dialog and navigating away. The value
+ * lives in the per-mount registry (see `<RegistryProvider>` in __root.tsx), so
+ * a hard refresh starts fresh; the create handler also resets it on success.
+ *
+ * The mailbox password is deliberately NOT part of this draft — the secret
+ * never enters the atom (nor the URL). It stays in the form's local state and
+ * is read only on submit.
+ *
+ * The string-literal unions mirror the inbox domain; they're duplicated here
+ * (rather than imported from the route) to keep this atom free of UI imports.
+ */
+
+type InboxPurpose = 'human' | 'agent' | 'shared'
+type TransportSecurity = 'tls' | 'starttls' | 'plain'
+
+export type InboxDraft = {
+	readonly email: string
+	readonly displayName: string
+	readonly purpose: InboxPurpose
+	readonly ownerUserId: string
+	readonly isDefault: boolean
+	readonly isPrivate: boolean
+	readonly imapHost: string
+	readonly imapPort: number
+	readonly imapSecurity: TransportSecurity
+	readonly smtpHost: string
+	readonly smtpPort: number
+	readonly smtpSecurity: TransportSecurity
+	readonly username: string
+}
+
+export const emptyInboxDraft: InboxDraft = {
+	email: '',
+	displayName: '',
+	purpose: 'human',
+	ownerUserId: '',
+	isDefault: false,
+	isPrivate: false,
+	imapHost: '',
+	imapPort: 993,
+	imapSecurity: 'tls',
+	smtpHost: '',
+	smtpPort: 465,
+	smtpSecurity: 'tls',
+	username: '',
+}
+
+export const inboxDraftAtom = Atom.make<InboxDraft>(emptyInboxDraft)

--- a/apps/internal/src/context/quick-capture-context.tsx
+++ b/apps/internal/src/context/quick-capture-context.tsx
@@ -8,6 +8,15 @@ import {
 } from 'react'
 
 /**
+ * Boundary note: page-scoped dialogs (e.g. the inbox dialogs in
+ * routes/emails/inboxes.tsx) live in the `?dlg=` URL param so they are
+ * deep-linkable and the back button closes them. Quick Capture stays a
+ * React context instead: it is the one app-global dialog (opens from
+ * anywhere via Shift+I), and its imperative `onSubmitted` pre-fill callback
+ * below cannot be serialised into a URL.
+ */
+
+/**
  * Shape of the "pre-fill" payload callers pass when they want the Quick
  * Capture dialog to open with a company (and optionally a contact) already
  * selected. If `undefined` the dialog opens empty — the user picks the

--- a/apps/internal/src/lib/dlg-search.test.ts
+++ b/apps/internal/src/lib/dlg-search.test.ts
@@ -1,0 +1,100 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
+import { validateSearchWith } from '#/lib/search-schema'
+
+// A representative route vocabulary: one dialog that opens on its own and two
+// that target a row. This mirrors how routes/emails/inboxes.tsx declares its
+// dialogs, so the decode behaviour asserted here is the real route contract.
+const dlg = Schema.Union([
+	dlgNoId('create'),
+	dlgWithId('edit'),
+	dlgWithId('footers'),
+])
+
+// `validateSearch` receives the already-parsed search object (TanStack turns
+// the nested JSON back into JS before calling it), so we decode plain objects.
+const decode = validateSearchWith({ dlg })
+const decodeWithSibling = validateSearchWith({
+	dlg,
+	companyId: Schema.NonEmptyString,
+})
+
+describe('dialog search-param vocabulary [dlg-search.ts]', () => {
+	describe('when the param is a recognised dialog with no target', () => {
+		it('should decode to that dialog', () => {
+			// GIVEN ?dlg={kind:'create'} (post-parse object)
+			// WHEN validated by the route [search-schema.ts:15 validateSearchWith]
+			// THEN the create dialog is recognised
+			expect(decode({ dlg: { kind: 'create' } })).toEqual({
+				dlg: { kind: 'create' },
+			})
+		})
+	})
+
+	describe('when the param targets a row with a non-empty id', () => {
+		it('should decode kind and id together', () => {
+			// GIVEN ?dlg={kind:'edit',id:'inbox-42'}
+			// WHEN validated
+			// THEN both fields round-trip [dlg-search.ts:18 dlgWithId]
+			expect(decode({ dlg: { kind: 'edit', id: 'inbox-42' } })).toEqual({
+				dlg: { kind: 'edit', id: 'inbox-42' },
+			})
+		})
+	})
+
+	describe('when the kind is outside the route vocabulary', () => {
+		it('should drop dlg so the dialog stays closed', () => {
+			// GIVEN a kind this route never declared (e.g. pasted from another page)
+			// WHEN validated
+			// THEN dlg is omitted — the scope gate keeps the dialog closed
+			expect(decode({ dlg: { kind: 'bogus' } })).toEqual({})
+			expect(decode({ dlg: { kind: 'bogus' } }).dlg).toBeUndefined()
+		})
+	})
+
+	describe('when an entity dialog is missing its id', () => {
+		it('should reject it and stay closed', () => {
+			// GIVEN an edit/footers variant with no id, or an empty id
+			// WHEN validated [dlg-search.ts:18 dlgWithId requires NonEmptyString]
+			// THEN dlg is dropped rather than opening a dialog with no target
+			expect(decode({ dlg: { kind: 'edit' } })).toEqual({})
+			expect(decode({ dlg: { kind: 'edit', id: '' } })).toEqual({})
+		})
+	})
+
+	describe('when dlg is malformed next to a valid sibling param', () => {
+		it('should keep the sibling and drop only dlg', () => {
+			// GIVEN ?dlg=<bad>&companyId=c1
+			// WHEN validated [search-schema.ts:7 per-field tolerance]
+			// THEN companyId survives even though dlg failed
+			expect(
+				decodeWithSibling({ dlg: { kind: 'bogus' }, companyId: 'c1' }),
+			).toEqual({ companyId: 'c1' })
+		})
+	})
+
+	describe('when there is no dlg param at all', () => {
+		it('should produce no dialog', () => {
+			// GIVEN a URL with no ?dlg=
+			// WHEN validated
+			// THEN the result carries no dialog
+			expect(decode({})).toEqual({})
+		})
+	})
+
+	describe('when following a deep link with a url-encoded dialog', () => {
+		it('should round-trip the structured value', () => {
+			// GIVEN a shared link ?dlg=<url-encoded JSON>
+			const encoded =
+				'%7B%22kind%22%3A%22edit%22%2C%22id%22%3A%22inbox-42%22%7D'
+			// WHEN the browser decodes + parses it the way TanStack does
+			const parsed: unknown = JSON.parse(decodeURIComponent(encoded))
+			// THEN validateSearch recovers the typed dialog
+			expect(decode({ dlg: parsed })).toEqual({
+				dlg: { kind: 'edit', id: 'inbox-42' },
+			})
+		})
+	})
+})

--- a/apps/internal/src/lib/dlg-search.ts
+++ b/apps/internal/src/lib/dlg-search.ts
@@ -1,0 +1,24 @@
+import { Schema } from 'effect'
+
+/**
+ * Building blocks for a route's dialog vocabulary, stored in the `?dlg=`
+ * search param.
+ *
+ * A dialog is identified in the URL by a small object — `{ kind }` for a
+ * dialog that opens on its own, or `{ kind, id }` for one that targets a row.
+ * TanStack already turns the nested search object back into JS before
+ * `validateSearch` runs, so each route validates `dlg` as a plain
+ * `Schema.Union` of these structs (see `routes/emails/inboxes.tsx`).
+ *
+ * Because each route lists only the kinds it owns, a `?dlg=` value a route
+ * doesn't recognise fails to decode and the dialog simply stays closed — a
+ * page can only open the dialogs it declares.
+ */
+
+/** A dialog that targets a specific row: its `id` must be present and non-empty. */
+export const dlgWithId = <const K extends string>(kind: K) =>
+	Schema.Struct({ kind: Schema.Literal(kind), id: Schema.NonEmptyString })
+
+/** A dialog that opens without a target row. */
+export const dlgNoId = <const K extends string>(kind: K) =>
+	Schema.Struct({ kind: Schema.Literal(kind) })

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -1,6 +1,12 @@
-import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
+import {
+	useAtom,
+	useAtomRefresh,
+	useAtomSet,
+	useAtomValue,
+} from '@effect/atom-react'
 import { useLingui } from '@lingui/react/macro'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useLocation } from '@tanstack/react-router'
+import { Option, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import {
 	Check,
@@ -14,7 +20,7 @@ import {
 	Trash2,
 	X,
 } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { EmailEditor } from '@batuda/email/editor'
@@ -41,10 +47,17 @@ import {
 	updateFooterAtom,
 	updateInboxAtom,
 } from '#/atoms/emails-atoms'
+import {
+	emptyInboxDraft,
+	type InboxDraft,
+	inboxDraftAtom,
+} from '#/atoms/inbox-draft-atoms'
 import { EmptyState } from '#/components/shared/empty-state'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { SkeletonRows } from '#/components/shared/skeleton-row'
 import { dehydrateAtom } from '#/lib/atom-hydration'
+import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
+import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
 import {
 	agedPaperRow,
@@ -106,7 +119,20 @@ async function loadInboxesOnServer(): Promise<ReadonlyArray<unknown>> {
 	return Effect.runPromise(program)
 }
 
+// Which dialog is open lives in the `?dlg=` URL param so dialogs are
+// deep-linkable and the back button closes them. This route owns exactly three
+// dialogs; a `?dlg=` value outside this set fails to decode and stays closed.
+// `dlg` is intentionally not a loaderDep — opening a dialog never refetches.
+const inboxDlgSchema = Schema.Union([
+	dlgNoId('create'),
+	dlgWithId('edit'),
+	dlgWithId('footers'),
+])
+type InboxDlg = Schema.Schema.Type<typeof inboxDlgSchema>
+const decodeInboxDlg = Schema.decodeUnknownOption(inboxDlgSchema)
+
 export const Route = createFileRoute('/emails/inboxes')({
+	validateSearch: validateSearchWith({ dlg: inboxDlgSchema }),
 	loader: async () => {
 		if (!import.meta.env.SSR) return { dehydrated: [] as const }
 		try {
@@ -125,11 +151,43 @@ export const Route = createFileRoute('/emails/inboxes')({
 	component: InboxesPage,
 })
 
-type DialogMode =
-	| { readonly kind: 'closed' }
-	| { readonly kind: 'create' }
-	| { readonly kind: 'edit'; readonly row: InboxRow }
-	| { readonly kind: 'footers'; readonly row: InboxRow }
+// Open pushes a history entry (so Back closes the dialog); close drops `dlg`
+// with replace (so Back doesn't reopen it).
+//
+// `dlg` is read from the live URL rather than this route's validated search:
+// a programmatic navigate that removes the last search param updates the URL
+// but leaves the route match's validated search stale (only a real back/forward
+// re-resolves it), so the dialog wouldn't close. The URL always reflects the
+// truth, so we decode it through the same schema here — keeping the scope gate
+// (an unknown `dlg` decodes to nothing) without casts.
+function useInboxDlg() {
+	const rawDlg = useLocation({ select: l => l.search?.dlg })
+	const dlg = useMemo(
+		() => Option.getOrUndefined(decodeInboxDlg(rawDlg)),
+		[rawDlg],
+	)
+	const navigate = Route.useNavigate()
+	const open = useCallback(
+		(next: InboxDlg) => {
+			void navigate({
+				to: '/emails/inboxes',
+				search: prev => ({ ...prev, dlg: next }),
+			})
+		},
+		[navigate],
+	)
+	const close = useCallback(() => {
+		if (dlg === undefined) return
+		// Drop the `dlg` key entirely (rather than blank it) so the param
+		// disappears from the address bar and the URL goes back to clean.
+		void navigate({
+			to: '/emails/inboxes',
+			search: ({ dlg: _, ...rest }) => rest,
+			replace: true,
+		})
+	}, [navigate, dlg])
+	return { dlg, open, close }
+}
 
 function InboxesPage() {
 	const { t } = useLingui()
@@ -147,7 +205,7 @@ function InboxesPage() {
 		mode: 'promiseExit',
 	})
 
-	const [dialog, setDialog] = useState<DialogMode>({ kind: 'closed' })
+	const { dlg, open, close } = useInboxDlg()
 
 	const rows = useMemo<ReadonlyArray<InboxRow>>(
 		() =>
@@ -166,6 +224,20 @@ function InboxesPage() {
 	)
 	const isLoading = AsyncResult.isInitial(inboxesResult)
 	const isFailure = AsyncResult.isFailure(inboxesResult)
+	const listSettled =
+		AsyncResult.isSuccess(inboxesResult) || AsyncResult.isFailure(inboxesResult)
+
+	// Edit/footers dialogs carry only the row id in the URL; resolve the row
+	// from the loaded list. A deep link to a row that no longer exists closes
+	// itself once the list has loaded.
+	const targetRow = useMemo(() => {
+		if (dlg === undefined || dlg.kind === 'create') return null
+		return rows.find(row => row.id === dlg.id) ?? null
+	}, [dlg, rows])
+	useEffect(() => {
+		if (dlg === undefined || dlg.kind === 'create') return
+		if (listSettled && targetRow === null) close()
+	}, [dlg, listSettled, targetRow, close])
 
 	// hasDefault is the only signal we need from inboxStatus to drive the
 	// banner; the picker walks the inbox list itself.
@@ -190,18 +262,15 @@ function InboxesPage() {
 	)
 	const showPrimaryBanner = !hasPrimary && primarySuggestions.length > 0
 
-	const openCreate = useCallback(() => {
-		setDialog({ kind: 'create' })
-	}, [])
-	const openEdit = useCallback((row: InboxRow) => {
-		setDialog({ kind: 'edit', row })
-	}, [])
-	const openFooters = useCallback((row: InboxRow) => {
-		setDialog({ kind: 'footers', row })
-	}, [])
-	const closeDialog = useCallback(() => {
-		setDialog({ kind: 'closed' })
-	}, [])
+	const openCreate = useCallback(() => open({ kind: 'create' }), [open])
+	const openEdit = useCallback(
+		(row: InboxRow) => open({ kind: 'edit', id: row.id }),
+		[open],
+	)
+	const openFooters = useCallback(
+		(row: InboxRow) => open({ kind: 'footers', id: row.id }),
+		[open],
+	)
 
 	const toggleActive = useCallback(
 		async (row: InboxRow) => {
@@ -571,50 +640,93 @@ function InboxesPage() {
 				</InboxesTable>
 			)}
 
-			{(dialog.kind === 'create' || dialog.kind === 'edit') && (
-				<InboxFormDialog
-					mode={dialog}
-					onClose={closeDialog}
-					onCreate={async input => {
-						const exit = await createInbox({ payload: input } as never)
-						if (exit._tag !== 'Success') {
-							return {
-								ok: false,
-								error: t`Could not create the inbox. Check transport or credentials.`,
+			{dlg !== undefined &&
+				(dlg.kind === 'create' ||
+					(dlg.kind === 'edit' && targetRow !== null)) && (
+					<InboxFormDialog
+						key={dlg.kind === 'edit' ? `edit:${dlg.id}` : 'create'}
+						editing={dlg.kind === 'edit' ? targetRow : null}
+						onClose={close}
+						onCreate={async input => {
+							const exit = await createInbox({ payload: input } as never)
+							if (exit._tag !== 'Success') {
+								return {
+									ok: false,
+									error: t`Could not create the inbox. Check transport or credentials.`,
+								}
 							}
-						}
-						refreshInboxes()
-						refreshInboxStatus()
-						toastManager.add({
-							title: t`Inbox connected`,
-							description: t`The mailbox is ready.`,
-							type: 'success',
-						})
-						return { ok: true }
-					}}
-					onUpdate={async (id, patch) => {
-						const exit = await updateInbox({
-							params: { id },
-							payload: patch,
-						})
-						if (exit._tag !== 'Success') {
-							return { ok: false, error: t`Could not save the inbox.` }
-						}
-						refreshInboxes()
-						refreshInboxStatus()
-						toastManager.add({
-							title: t`Inbox updated`,
-							type: 'success',
-						})
-						return { ok: true }
-					}}
+							refreshInboxes()
+							refreshInboxStatus()
+							toastManager.add({
+								title: t`Inbox connected`,
+								description: t`The mailbox is ready.`,
+								type: 'success',
+							})
+							return { ok: true }
+						}}
+						onUpdate={async (id, patch) => {
+							const exit = await updateInbox({
+								params: { id },
+								payload: patch,
+							})
+							if (exit._tag !== 'Success') {
+								return { ok: false, error: t`Could not save the inbox.` }
+							}
+							refreshInboxes()
+							refreshInboxStatus()
+							toastManager.add({
+								title: t`Inbox updated`,
+								type: 'success',
+							})
+							return { ok: true }
+						}}
+					/>
+				)}
+
+			{dlg?.kind === 'footers' && targetRow !== null && (
+				<FooterManageDialog
+					key={`footers:${targetRow.id}`}
+					row={targetRow}
+					onClose={close}
 				/>
 			)}
 
-			{dialog.kind === 'footers' && (
-				<FooterManageDialog row={dialog.row} onClose={closeDialog} />
-			)}
+			{dlg !== undefined &&
+				dlg.kind !== 'create' &&
+				targetRow === null &&
+				!listSettled && <DialogPending onClose={close} />}
 		</Page>
+	)
+}
+
+// Shown briefly when a deep link names a row (?dlg={kind:'edit',id}) before the
+// inbox list has loaded, so the dialog doesn't flash empty or closed.
+function DialogPending({ onClose }: { readonly onClose: () => void }) {
+	const { t } = useLingui()
+	return (
+		<PriDialog.Root
+			open
+			onOpenChange={(next: boolean) => {
+				if (!next) onClose()
+			}}
+		>
+			<PriDialog.Portal>
+				<PriDialog.Backdrop />
+				<PriDialog.Popup>
+					<DialogHeader>
+						<PriDialog.Title>{t`Loading…`}</PriDialog.Title>
+						<PriDialog.Close
+							render={props => (
+								<CloseButton type='button' aria-label={t`Close`} {...props}>
+									<X size={16} aria-hidden />
+								</CloseButton>
+							)}
+						/>
+					</DialogHeader>
+					<SkeletonRows count={3} height='2rem' />
+				</PriDialog.Popup>
+			</PriDialog.Portal>
+		</PriDialog.Root>
 	)
 }
 
@@ -667,13 +779,33 @@ type UpdatePayload = {
 	readonly password?: string
 }
 
+// Seed the edit form from a row. Password is intentionally omitted — it is
+// never read back, only set when the user opts to change it.
+function rowToDraft(row: InboxRow): InboxDraft {
+	return {
+		email: row.email,
+		displayName: row.displayName ?? '',
+		purpose: row.purpose,
+		ownerUserId: row.ownerUserId ?? '',
+		isDefault: row.isDefault,
+		isPrivate: row.isPrivate,
+		imapHost: row.imapHost,
+		imapPort: row.imapPort,
+		imapSecurity: row.imapSecurity,
+		smtpHost: row.smtpHost,
+		smtpPort: row.smtpPort,
+		smtpSecurity: row.smtpSecurity,
+		username: row.username,
+	}
+}
+
 function InboxFormDialog({
-	mode,
+	editing,
 	onClose,
 	onCreate,
 	onUpdate,
 }: {
-	readonly mode: DialogMode
+	readonly editing: InboxRow | null
 	readonly onClose: () => void
 	readonly onCreate: (input: CreatePayload) => Promise<MutationResult>
 	readonly onUpdate: (
@@ -682,7 +814,7 @@ function InboxFormDialog({
 	) => Promise<MutationResult>
 }) {
 	const { t } = useLingui()
-	const editing = mode.kind === 'edit' ? mode.row : null
+	const isCreate = editing === null
 
 	const presetsResult = useAtomValue(providerPresetsAtom)
 	const presets = useMemo<ReadonlyArray<ProviderPreset>>(
@@ -693,28 +825,25 @@ function InboxFormDialog({
 		[presetsResult],
 	)
 
+	// Create keeps its draft in a global atom so a half-filled form survives
+	// closing the dialog and navigating away; edit uses local state seeded from
+	// the row. Both share the InboxDraft shape, so the form binds to one `draft`
+	// regardless of mode. The password is never part of the draft.
+	const [createDraft, setCreateDraft] = useAtom(inboxDraftAtom)
+	const [editDraft, setEditDraft] = useState<InboxDraft>(() =>
+		editing !== null ? rowToDraft(editing) : emptyInboxDraft,
+	)
+	const draft = isCreate ? createDraft : editDraft
+	const patchDraft = useCallback(
+		(partial: Partial<InboxDraft>) => {
+			if (isCreate) setCreateDraft(prev => ({ ...prev, ...partial }))
+			else setEditDraft(prev => ({ ...prev, ...partial }))
+		},
+		[isCreate, setCreateDraft],
+	)
+
 	// Preset name selected in the dropdown — '' means none / custom.
 	const [presetName, setPresetName] = useState<string>('')
-	const [email, setEmail] = useState(editing?.email ?? '')
-	const [displayName, setDisplayName] = useState(editing?.displayName ?? '')
-	const [purpose, setPurpose] = useState<InboxPurpose>(
-		editing?.purpose ?? 'human',
-	)
-	const [ownerUserId, setOwnerUserId] = useState(editing?.ownerUserId ?? '')
-	const [isDefault, setIsDefault] = useState(editing?.isDefault ?? false)
-	const [isPrivate, setIsPrivate] = useState(editing?.isPrivate ?? false)
-
-	const [imapHost, setImapHost] = useState(editing?.imapHost ?? '')
-	const [imapPort, setImapPort] = useState<number>(editing?.imapPort ?? 993)
-	const [imapSecurity, setImapSecurity] = useState<TransportSecurity>(
-		editing?.imapSecurity ?? 'tls',
-	)
-	const [smtpHost, setSmtpHost] = useState(editing?.smtpHost ?? '')
-	const [smtpPort, setSmtpPort] = useState<number>(editing?.smtpPort ?? 465)
-	const [smtpSecurity, setSmtpSecurity] = useState<TransportSecurity>(
-		editing?.smtpSecurity ?? 'tls',
-	)
-	const [username, setUsername] = useState(editing?.username ?? '')
 	const [password, setPassword] = useState('')
 	// In edit mode the password field is empty and only sent when the
 	// user types a new one, so existing credentials aren't blanked.
@@ -728,14 +857,16 @@ function InboxFormDialog({
 			setPresetName(name)
 			const preset = presets.find(p => p.name === name)
 			if (preset === undefined) return
-			setImapHost(preset.imapHost)
-			setImapPort(preset.imapPort)
-			setImapSecurity(preset.imapSecurity)
-			setSmtpHost(preset.smtpHost)
-			setSmtpPort(preset.smtpPort)
-			setSmtpSecurity(preset.smtpSecurity)
+			patchDraft({
+				imapHost: preset.imapHost,
+				imapPort: preset.imapPort,
+				imapSecurity: preset.imapSecurity,
+				smtpHost: preset.smtpHost,
+				smtpPort: preset.smtpPort,
+				smtpSecurity: preset.smtpSecurity,
+			})
 		},
-		[presets],
+		[presets, patchDraft],
 	)
 
 	// Derived from the chosen preset: powers the 2FA app-password hint and
@@ -750,7 +881,7 @@ function InboxFormDialog({
 	const setupUrl =
 		appPasswordUrl !== '' ? appPasswordUrl : (selectedPreset?.helpUrl ?? '')
 
-	const usernameForSubmit = username !== '' ? username : email
+	const usernameForSubmit = draft.username !== '' ? draft.username : draft.email
 
 	// Create requires email + transport + credentials. Edit lets the user
 	// patch any subset; we always send the full transport so the server's
@@ -760,10 +891,10 @@ function InboxFormDialog({
 		!submitting &&
 		!providerUnsupported &&
 		(editing !== null
-			? email !== ''
-			: email !== '' &&
-				imapHost !== '' &&
-				smtpHost !== '' &&
+			? draft.email !== ''
+			: draft.email !== '' &&
+				draft.imapHost !== '' &&
+				draft.smtpHost !== '' &&
 				password !== '' &&
 				usernameForSubmit !== '')
 
@@ -776,39 +907,45 @@ function InboxFormDialog({
 		const result =
 			editing !== null
 				? await onUpdate(editing.id, {
-						displayName: displayName === '' ? null : displayName,
-						purpose,
+						displayName: draft.displayName === '' ? null : draft.displayName,
+						purpose: draft.purpose,
 						ownerUserId:
-							purpose === 'human' && ownerUserId !== '' ? ownerUserId : null,
-						isDefault,
-						isPrivate,
-						imapHost,
-						imapPort,
-						imapSecurity,
-						smtpHost,
-						smtpPort,
-						smtpSecurity,
+							draft.purpose === 'human' && draft.ownerUserId !== ''
+								? draft.ownerUserId
+								: null,
+						isDefault: draft.isDefault,
+						isPrivate: draft.isPrivate,
+						imapHost: draft.imapHost,
+						imapPort: draft.imapPort,
+						imapSecurity: draft.imapSecurity,
+						smtpHost: draft.smtpHost,
+						smtpPort: draft.smtpPort,
+						smtpSecurity: draft.smtpSecurity,
 						username: usernameForSubmit,
 						...(changeCredentials && password !== '' && { password }),
 					})
 				: await onCreate({
-						email,
-						...(displayName !== '' && { displayName }),
-						purpose,
-						...(purpose === 'human' && ownerUserId !== '' && { ownerUserId }),
-						...(isDefault && { isDefault: true }),
-						...(isPrivate && { isPrivate: true }),
-						imapHost,
-						imapPort,
-						imapSecurity,
-						smtpHost,
-						smtpPort,
-						smtpSecurity,
+						email: draft.email,
+						...(draft.displayName !== '' && { displayName: draft.displayName }),
+						purpose: draft.purpose,
+						...(draft.purpose === 'human' &&
+							draft.ownerUserId !== '' && { ownerUserId: draft.ownerUserId }),
+						...(draft.isDefault && { isDefault: true }),
+						...(draft.isPrivate && { isPrivate: true }),
+						imapHost: draft.imapHost,
+						imapPort: draft.imapPort,
+						imapSecurity: draft.imapSecurity,
+						smtpHost: draft.smtpHost,
+						smtpPort: draft.smtpPort,
+						smtpSecurity: draft.smtpSecurity,
 						username: usernameForSubmit,
 						password,
 					})
 
 		if (result.ok) {
+			// Clear the persisted create draft only after a successful connect;
+			// closing or navigating away keeps it.
+			if (isCreate) setCreateDraft(emptyInboxDraft)
 			onClose()
 			return
 		}
@@ -818,7 +955,7 @@ function InboxFormDialog({
 
 	return (
 		<PriDialog.Root
-			open={mode.kind !== 'closed'}
+			open
 			onOpenChange={(next: boolean) => {
 				if (!next) onClose()
 			}}
@@ -907,8 +1044,8 @@ function InboxFormDialog({
 							<PriInput
 								id='ix-email'
 								type='email'
-								value={email}
-								onChange={e => setEmail(e.target.value)}
+								value={draft.email}
+								onChange={e => patchDraft({ email: e.target.value })}
 								placeholder={t`you@example.com`}
 								required
 								disabled={editing !== null}
@@ -920,8 +1057,8 @@ function InboxFormDialog({
 							<PriInput
 								id='ix-display'
 								type='text'
-								value={displayName}
-								onChange={e => setDisplayName(e.target.value)}
+								value={draft.displayName}
+								onChange={e => patchDraft({ displayName: e.target.value })}
 								placeholder={t`e.g. Sales — Acme`}
 							/>
 						</Field>
@@ -932,8 +1069,8 @@ function InboxFormDialog({
 								<PriInput
 									id='ix-imap-host'
 									type='text'
-									value={imapHost}
-									onChange={e => setImapHost(e.target.value)}
+									value={draft.imapHost}
+									onChange={e => patchDraft({ imapHost: e.target.value })}
 									placeholder='imap.example.com'
 								/>
 							</Field>
@@ -942,15 +1079,17 @@ function InboxFormDialog({
 								<PriInput
 									id='ix-imap-port'
 									type='number'
-									value={imapPort}
-									onChange={e => setImapPort(parseInt(e.target.value, 10) || 0)}
+									value={draft.imapPort}
+									onChange={e =>
+										patchDraft({ imapPort: parseInt(e.target.value, 10) || 0 })
+									}
 								/>
 							</Field>
 							<Field>
 								<Label>{t`IMAP security`}</Label>
 								<SecuritySelect
-									value={imapSecurity}
-									onChange={setImapSecurity}
+									value={draft.imapSecurity}
+									onChange={next => patchDraft({ imapSecurity: next })}
 									ariaLabel={t`IMAP security`}
 								/>
 							</Field>
@@ -960,8 +1099,8 @@ function InboxFormDialog({
 								<PriInput
 									id='ix-smtp-host'
 									type='text'
-									value={smtpHost}
-									onChange={e => setSmtpHost(e.target.value)}
+									value={draft.smtpHost}
+									onChange={e => patchDraft({ smtpHost: e.target.value })}
 									placeholder='smtp.example.com'
 								/>
 							</Field>
@@ -970,15 +1109,17 @@ function InboxFormDialog({
 								<PriInput
 									id='ix-smtp-port'
 									type='number'
-									value={smtpPort}
-									onChange={e => setSmtpPort(parseInt(e.target.value, 10) || 0)}
+									value={draft.smtpPort}
+									onChange={e =>
+										patchDraft({ smtpPort: parseInt(e.target.value, 10) || 0 })
+									}
 								/>
 							</Field>
 							<Field>
 								<Label>{t`SMTP security`}</Label>
 								<SecuritySelect
-									value={smtpSecurity}
-									onChange={setSmtpSecurity}
+									value={draft.smtpSecurity}
+									onChange={next => patchDraft({ smtpSecurity: next })}
 									ariaLabel={t`SMTP security`}
 								/>
 							</Field>
@@ -989,8 +1130,8 @@ function InboxFormDialog({
 							<PriInput
 								id='ix-username'
 								type='text'
-								value={username}
-								onChange={e => setUsername(e.target.value)}
+								value={draft.username}
+								onChange={e => patchDraft({ username: e.target.value })}
 								placeholder={t`Defaults to the email address.`}
 							/>
 						</Field>
@@ -1030,14 +1171,14 @@ function InboxFormDialog({
 						<Field>
 							<Label>{t`Purpose`}</Label>
 							<PriSelect.Root
-								value={purpose}
+								value={draft.purpose}
 								onValueChange={value => {
 									if (
 										value === 'human' ||
 										value === 'agent' ||
 										value === 'shared'
 									) {
-										setPurpose(value)
+										patchDraft({ purpose: value })
 									}
 								}}
 							>
@@ -1078,14 +1219,14 @@ function InboxFormDialog({
 							</PriSelect.Root>
 						</Field>
 
-						{purpose === 'human' && (
+						{draft.purpose === 'human' && (
 							<Field>
 								<Label htmlFor='ix-owner'>{t`Owner user ID`}</Label>
 								<PriInput
 									id='ix-owner'
 									type='text'
-									value={ownerUserId}
-									onChange={e => setOwnerUserId(e.target.value)}
+									value={draft.ownerUserId}
+									onChange={e => patchDraft({ ownerUserId: e.target.value })}
 									placeholder={t`Defaults to you when omitted.`}
 								/>
 							</Field>
@@ -1095,19 +1236,19 @@ function InboxFormDialog({
 							<input
 								id='ix-default'
 								type='checkbox'
-								checked={isDefault}
-								onChange={e => setIsDefault(e.target.checked)}
+								checked={draft.isDefault}
+								onChange={e => patchDraft({ isDefault: e.target.checked })}
 							/>
 							<label htmlFor='ix-default'>{t`Use as default for this purpose`}</label>
 						</CheckboxRow>
 
-						{purpose !== 'shared' && (
+						{draft.purpose !== 'shared' && (
 							<CheckboxRow>
 								<input
 									id='ix-private'
 									type='checkbox'
-									checked={isPrivate}
-									onChange={e => setIsPrivate(e.target.checked)}
+									checked={draft.isPrivate}
+									onChange={e => patchDraft({ isPrivate: e.target.checked })}
 								/>
 								<label htmlFor='ix-private'>
 									{t`Private — hide threads from other members`}

--- a/apps/internal/src/routes/emails/index.tsx
+++ b/apps/internal/src/routes/emails/index.tsx
@@ -5,7 +5,7 @@ import {
 	useAtomValue,
 } from '@effect/atom-react'
 import { useLingui } from '@lingui/react/macro'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import {
 	type ColumnDef,
 	type ColumnSizingState,
@@ -37,6 +37,7 @@ import {
 	Mail,
 	Pencil,
 	PencilLine,
+	Plus,
 	Search,
 	X,
 } from 'lucide-react'
@@ -560,6 +561,25 @@ function EmailsIndexPage() {
 					<Subtitle>{total === 1 ? t`1 thread` : t`${total} threads`}</Subtitle>
 				</IntroText>
 				<IntroActions>
+					{/*
+					 * Cross-route dialog opener: a real <Link> (cmd/middle-clickable,
+					 * shareable) that lands on /emails/inboxes with the connect dialog
+					 * already open via the `?dlg=` param. Back returns here.
+					 */}
+					<PriButton
+						$variant='outlined'
+						data-testid='emails-connect-mailbox'
+						render={props => (
+							<Link
+								to='/emails/inboxes'
+								search={{ dlg: { kind: 'create' } }}
+								{...props}
+							/>
+						)}
+					>
+						<Plus size={14} aria-hidden />
+						<span>{t`Connect mailbox`}</span>
+					</PriButton>
 					<PriButton
 						type='button'
 						$variant='outlined'

--- a/apps/internal/vitest.config.ts
+++ b/apps/internal/vitest.config.ts
@@ -1,0 +1,21 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+const here = fileURLToPath(new URL('.', import.meta.url))
+
+// Standalone from vite.config.ts on purpose: unit tests cover pure logic
+// (schema/search helpers) and don't need the app's SSR/Lingui/styled plugins.
+// Only the `#/` path alias is mirrored so `#/lib/*` imports resolve.
+export default defineConfig({
+	resolve: {
+		alias: [{ find: /^#\//, replacement: `${resolve(here, 'src')}/` }],
+	},
+	test: {
+		include: ['src/**/*.test.ts'],
+		environment: 'node',
+		globals: false,
+		testTimeout: 30_000,
+	},
+})


### PR DESCRIPTION
## What

Inbox dialogs (connect / edit mailbox, manage footers) in the internal CRM (`apps/internal`, email/inbox surface) now live in the URL via a `?dlg=` search param instead of local component state. They're deep-linkable and shareable, the browser back button closes them, and a half-filled "Connect mailbox" form survives closing and navigating away. A small reusable core (`lib/dlg-search.ts`) makes the pattern available to other routes, scoped so a route only opens the dialogs it declares.

This branch also carries the dev-stack ergonomics that let me verify the change from a git worktree (a `*.batuda.localhost` CORS wildcard + a `/debug-apps` worktree section).

## Changes

- Added a reusable `?dlg=` vocabulary (`dlgWithId`/`dlgNoId`); a value a route doesn't declare decodes to nothing, so the dialog stays closed (the scope gate).
- Moved the inbox create/edit/footers dialogs onto `?dlg=` — deep-linkable, back-button closes, and a stale deep-link id self-closes once the list loads.
- Kept the half-filled connect form in a global atom: survives close + navigation, cleared only on refresh or a successful connect. The mailbox password is never in the atom or the URL.
- Added a cross-route "Connect mailbox" link from the emails list; left Quick Capture context-based (no owning route; its imperative prefill callback can't live in a URL).
- Dev ergonomics: trusted worktree origins via a `*.batuda.localhost` CORS wildcard in the dev template, and documented the worktree dev-stack setup in the `debug-apps` skill.

## Impact

- **CORS (dev only):** `.env.example` gains a `*.batuda.localhost` wildcard in `ALLOWED_ORIGINS`. Dev template only — production sets its own explicit `ALLOWED_ORIGINS` (no wildcard), and the existing boot-guard already rejects any wildcard not under `.localhost`, so prod is unaffected.
- **CI test step:** `apps/internal` gains a vitest harness (it had none) + a `test` script, so `turbo test` now runs unit tests there.
- No schema/migration, no RLS / multi-org change, no API / wire-shape change (reuses the existing inbox create/update payloads), no MCP/HTTP service change, no new required env var, no auth-boundary change.

## Review guide

- **Riskiest bit — `useInboxDlg` in `inboxes.tsx`:** it reads `dlg` from `useLocation` (then re-decodes via the schema), *not* the route's validated search. Reason: a programmatic navigate that drops the last search param updates the URL but leaves TanStack's validated *match* search stale (only back/forward re-resolves it), so the dialog wouldn't close. The live URL is always correct; decoding it preserves the scope gate. This is the one spot to scrutinise.
- **Decisions you might overrule:** (1) the `useLocation` workaround above vs. waiting on a router-level fix; (2) grouping the skill doc + `.env.example` into one `chore` commit (mixes an `ai(skills)` file with config).
- **Re-baselined** onto the just-merged 2FA app-password work; the single `inboxes.tsx` conflict was integrated — kept the 2FA preset / app-password hints, used my draft-based `usernameForSubmit`.
- **Not run:** `snyk_code_scan` (tool unavailable in my session — flagging per the security policy); the a11y agent (dialog a11y is Base UI's `PriDialog`, unchanged — only the open/close mechanism changed). Say the word if you want either run.
- **Skip-able:** `vitest.config.ts` (boilerplate), the `quick-capture-context.tsx` change (comment only).

## Demo

Open → type → close clears the dialog → reopen keeps the draft:

<video controls src="https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-89/pr-dialogs.mp4"></video>

The connect-mailbox dialog (with the merged 2FA "Pick a provider" preset):

![pr-dialog-open.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-89/pr-dialog-open.webp)

## Tests

- Unit — `lib/dlg-search.test.ts`, 7 cases on the decode contract: a recognised dialog decodes; an out-of-vocabulary kind and a missing/empty id both decode to nothing (the scope gate); a malformed `dlg` doesn't drop sibling params; a deep-link round-trips.
- e2e — driven manually (see Verification).

## Verification

Ran locally via the tool binaries directly (`pnpm` is blocked in my environment by a local `core.hooksPath` quirk, so the `pnpm -w` gates + full workspace build run in CI):

- `tsc --noEmit` (both `apps/internal` projects): clean.
- `vitest run` (the new test): 7/7.
- `biome check`: clean.
- `vite build` (`apps/internal`): clean.
- Live e2e on a worktree stack (logged in, real API + DB): cross-route open, Escape + hardware-Back close, draft persists on close / clears on refresh, edit opens seeded from the row, footers open, deep-link to a real id, stale-id self-close, and an out-of-vocabulary kind staying closed — all pass. The merged 2FA app-password hints still render in the form.

## Deferred

- The other dialogs (template editor/delete, research, quick-capture) aren't migrated — the shared core makes that a follow-up.
- A `PriSelect` popup-width fix is staged separately in the main checkout (unrelated to this PR).
