### PR TITLE
feat: confine API keys to the MCP path

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -53,6 +53,8 @@ Type-checks and unit tests are **not** enough — they have passed on changes th
 
 When the change touches the web UI (`apps/internal`, `packages/ui`), attach visual proof so the reviewer sees it without running the branch. Drive the app with `agent-browser` — full command reference in `.claude/skills/debug-apps/references/agent-browser.md`. First make sure the stack is up and seeded (`/debug-apps`; `pnpm cli seed --preset minimal`) and log in if the route is gated.
 
+**Default to capturing — screenshots are on by default for every UI PR; capture them without asking.** The only case where skipping is even on the table is a change whose visual result is self-evident from the diff alone — a token value, a one-word copy edit, a renamed label — something any human understands by reading the code. Even then, don't decide for the user: **`AskUserQuestion`** whether to capture or skip, and follow their answer. Never skip silently. "The stack is slow to start" is not a reason to skip; if it genuinely won't come up, surface that and ask rather than burying a note in the PR body.
+
 **Screenshot, recording, or both — pick by what changed:**
 
 - **Screenshot** — a *state*: new/changed layout, copy, color, a field, an empty / loading / error state. One still per distinct state. This is the default; prefer it when a single frame tells the story.
@@ -169,7 +171,7 @@ Match recent PRs (`gh pr view 67 --json body`, `gh pr view 64 --json body`). Inc
 - `## Changes` (or `## The fix` for a bug) — the substantive changes as bullets describing **intent**, not file lists. The diff already shows the files.
 - `## Impact` — the blast radius (see checklist below). The single most valuable section for this codebase, because the surfaces are decoupled and the diff doesn't reveal the ripple. Omit only if genuinely none apply.
 - `## Review guide` — how to review this fast: where to look first, the riskiest part and why, any decision I made that you might overrule, and anything I couldn't fully verify (e.g. Snyk unavailable). Mark generated or mechanical parts as skip-able. This is where the self-review (Step 3) surfaces what it couldn't resolve.
-- `## Screenshots` / `## Demo` — for UI PRs (embedding below).
+- `## Screenshots` / `## Demo` — **mandatory for UI PRs**: embed the media, or — only for a self-evident change the user approved skipping — one line `> Screenshots skipped (approved): <reason>`. Neither present = an incomplete PR; there is no silent third option. (Embedding below.)
 - `## Tests` — what's covered (unit / integration), when notable.
 - `## Verification` — only what you **actually ran** (verify-before-assert): the gates you executed (`check-types` / `test` / `build`) and the live-stack or UI check you actually performed. Never write "all tests pass" you didn't run — an unverified claim here is worse than saying nothing.
 - `## Deferred` — follow-ups intentionally not in this PR.

--- a/apps/cli/src/commands/seed/identities.ts
+++ b/apps/cli/src/commands/seed/identities.ts
@@ -72,7 +72,7 @@ export const seedIdentities = Effect.gen(function* () {
 					},
 				}),
 				organization(),
-				apiKey({ enableSessionForAPIKeys: true }),
+				apiKey({ enableSessionForAPIKeys: false }),
 			],
 		}),
 	)

--- a/apps/server/src/lib/auth.integration.test.ts
+++ b/apps/server/src/lib/auth.integration.test.ts
@@ -29,6 +29,11 @@ const sharedPool = new pg.Pool({ connectionString: DATABASE_URL })
 
 afterAll(async () => {
 	// Remove only the rows we wrote so the seed survives for sibling tests.
+	// API keys reference the user, so clear them before the user rows.
+	await sharedPool.query(
+		`DELETE FROM apikey WHERE "referenceId" IN (SELECT id FROM "user" WHERE email LIKE $1)`,
+		[`${TEST_EMAIL_PREFIX}%`],
+	)
 	await sharedPool.query(
 		`DELETE FROM "account" WHERE "userId" IN (SELECT id FROM "user" WHERE email LIKE $1)`,
 		[`${TEST_EMAIL_PREFIX}%`],
@@ -37,6 +42,70 @@ afterAll(async () => {
 		`${TEST_EMAIL_PREFIX}%`,
 	])
 	await sharedPool.end()
+})
+
+describe('API key session confinement', () => {
+	// Build the instance like the server (auth.ts): a key must never become a
+	// login session. Its only consumer is the MCP path, which checks it with
+	// verifyApiKey — so a leaked key can't be replayed against the cookie-gated
+	// REST API that reads getSession.
+	const buildInstance = () =>
+		betterAuth(
+			buildBetterAuthConfig({
+				env: {
+					secret: BETTER_AUTH_SECRET,
+					baseURL: 'http://localhost:3010',
+					useSecureCookies: false,
+					trustedOrigins: [],
+				},
+				pool: sharedPool,
+				plugins: [
+					openAPI(),
+					bearer(),
+					admin(),
+					organization(),
+					apiKey({ enableSessionForAPIKeys: false }),
+				],
+			}),
+		)
+
+	describe('when an x-api-key is presented to getSession', () => {
+		it('should not resolve a session, yet stay valid for verifyApiKey', async () => {
+			// GIVEN a user holding a valid API key
+			const auth = buildInstance()
+			const email = `${TEST_EMAIL_PREFIX}confine-${Date.now()}@example.com`
+			await auth.api.createUser({
+				body: {
+					email,
+					name: 'Key Confine',
+					password: 'temp-confine-password-1234',
+				},
+			})
+			const lookup = await sharedPool.query<{ id: string }>(
+				'SELECT id FROM "user" WHERE email = $1 LIMIT 1',
+				[email],
+			)
+			const userId = lookup.rows[0]!.id
+			const created = await auth.api.createApiKey({
+				body: { userId, name: 'confinement-probe' },
+			})
+
+			// WHEN getSession sees only that key in the x-api-key header
+			const session = await auth.api.getSession({
+				headers: new Headers({ 'x-api-key': created.key }),
+			})
+
+			// THEN no session is minted — the key cannot authenticate the
+			// session-gated REST API.
+			expect(session).toBeNull()
+
+			// AND the key still verifies on its intended MCP path.
+			const verified = await auth.api.verifyApiKey({
+				body: { key: created.key },
+			})
+			expect(verified.valid).toBe(true)
+		})
+	})
 })
 
 describe('magic-link plugin existence pre-check on sendMagicLink', () => {
@@ -63,7 +132,7 @@ describe('magic-link plugin existence pre-check on sendMagicLink', () => {
 					bearer(),
 					admin(),
 					organization(),
-					apiKey({ enableSessionForAPIKeys: true }),
+					apiKey({ enableSessionForAPIKeys: false }),
 					magicLink({
 						disableSignUp: true,
 						// Mirrors auth.ts:206 — silent no-op for unknown emails

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -202,7 +202,11 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 					}),
 					// enableMetadata: org-owned keys carry { organizationId } so the
 					// MCP path resolves the org from the key (BADREQUEST otherwise).
-					apiKey({ enableSessionForAPIKeys: true, enableMetadata: true }),
+					// enableSessionForAPIKeys is off on purpose: a key authenticates
+					// only the MCP path (checked there with verifyApiKey), never as a
+					// login session on the cookie-gated REST API — so a leaked key
+					// can't be replayed beyond /mcp.
+					apiKey({ enableSessionForAPIKeys: false, enableMetadata: true }),
 					// OAuth 2.1 Authorization Server for web chat MCP clients
 					// (ChatGPT, Claude.ai) that can't send the `x-api-key` header.
 					// `oauthProvider` issues JWT access tokens whose `aud` is the

--- a/apps/server/src/services/multi-org-isolation.integration.test.ts
+++ b/apps/server/src/services/multi-org-isolation.integration.test.ts
@@ -117,7 +117,7 @@ const buildTestAuth = (pool: pg.Pool) =>
 				bearer(),
 				admin(),
 				organization(),
-				apiKey({ enableSessionForAPIKeys: true }),
+				apiKey({ enableSessionForAPIKeys: false }),
 				magicLink({ sendMagicLink: async () => {} }),
 			],
 		}),

--- a/packages/auth/src/infrastructure/better-auth-adapter.ts
+++ b/packages/auth/src/infrastructure/better-auth-adapter.ts
@@ -194,7 +194,7 @@ export const makeBetterAuthAdapter = (
 				// CLI mirrors the server's plugin set so adapter-issued sessions
 				// and API keys carry the same plugin shape as runtime requests.
 				organization(),
-				apiKeyPlugin({ enableSessionForAPIKeys: true }),
+				apiKeyPlugin({ enableSessionForAPIKeys: false }),
 				magicLinkPlugin({
 					sendMagicLink: data =>
 						resolvedSender({

--- a/packages/ui/src/pri/pri-select.tsx
+++ b/packages/ui/src/pri/pri-select.tsx
@@ -67,6 +67,9 @@ const PriPopup = styled(Select.Popup).withConfig({
 	displayName: 'PriSelectPopup',
 })`
 	position: relative;
+	/* Match the popup to at least the trigger width so options never look narrower than the selector. */
+	min-width: var(--anchor-width);
+	box-sizing: border-box;
 	background-color: var(--color-metal);
 	background-image:
 		var(--texture-brushed-metal),


### PR DESCRIPTION
## What

Security hardening in **Auth** (`apps/server`). The `x-api-key` credential that AI/MCP clients use now authenticates **only** the MCP transport — it's verified there with `verifyApiKey` and is no longer accepted as a login session on the cookie-gated REST API. Previously `enableSessionForAPIKeys: true` let a key resolve a session at every `getSession` site (the whole REST API); the only thing stopping it was the per-org agent user having no org membership — an implicit, fragile boundary. This makes the confinement explicit and enforced, so a leaked MCP key can't be replayed beyond `/mcp`.

Two unrelated changes ride along at my request — see Changes.

## Changes

- **Confine API keys to `/mcp`** — `enableSessionForAPIKeys: false` in the server Better Auth config, the shared CLI adapter, and the dev seed (all three mirror one plugin set). The `/mcp` key path is untouched — it calls `verifyApiKey` directly, independent of the flag.
- A regression test (`API key session confinement`) asserts an `x-api-key` yields no `getSession` session yet still validates via `verifyApiKey`; the two integration-test config mirrors now match prod.
- _(rider — `ai(skills)`)_ Make PR screenshots the default for UI changes in the `pr` skill.
- _(rider — `fix(ui)`)_ The select popup takes `min-width: var(--anchor-width)` so options never render narrower than the trigger.

## Impact

- **Auth / route protection:** the intended consumer (`/mcp`) keeps working unchanged. Keys are no longer a valid credential on the REST API's session path (`middleware/session.ts`, `middleware/org.ts`). No exploitable behavior change today (the agent user has no membership) — the boundary is now explicit rather than incidental.
- **Multi-org / MCP:** no change to org scoping or which Postgres role runs — the MCP path still enters `app_user` scope as the key's creator.
- No schema, env-var, or wire-shape changes.

## Review guide

- Start at `apps/server/src/lib/auth.ts` — the one security-relevant flip; the CLI adapter and dev seed only mirror it.
- The new test in `auth.integration.test.ts` is the regression guard.
- This touches auth (a security boundary). I read both credential paths (`x-api-key` + OAuth) in depth beforehand; this change only *removes* surface. **Snyk wasn't available** in my environment, so it wasn't run.
- The two riders are independent and low-risk; the UI one has a screenshot below.

## Screenshots

The status `PriSelect` open on a company page — the popup now takes the trigger's width (`min-width: var(--anchor-width)`), so options never render narrower than the selector.

![pr-priselect-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-90/pr-priselect-desktop.webp)

![pr-priselect-popup.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-90/pr-priselect-popup.webp)

## Tests

- New integration test `API key session confinement` (auth.integration).
- Updated the multi-org-isolation + auth.integration config mirrors to match prod.

## Verification

- `pnpm -w check-types` — green (12/12).
- `pnpm -w test` — green (server 252 tests; 18/18 tasks).
- `pnpm -w build` — green (12/12).
- Integration suites `auth.integration`, `multi-org-isolation`, `mcp/api-key-auth` — 52 pass, including the new confinement test.
- Drove the live local stack: logged in, opened a company's status `PriSelect`, captured the popup (above).
