### PR TITLE
feat: per-worktree shared-stack dev environments for parallel sessions

### DIFF
--- a/.claude/hooks/worktree-down.sh
+++ b/.claude/hooks/worktree-down.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# WorktreeRemove hook — drop this worktree's Postgres database and MinIO bucket
+# from the shared stack just before its directory is deleted, so those resources
+# don't leak. Side-effect only: WorktreeRemove cannot block removal, so this
+# always exits 0, even on error.
+set -uo pipefail
+
+payload="$(cat)"
+# Record each removal so the event's (currently undocumented) shape stays
+# auditable and the worktree path field can be confirmed from real runs.
+printf '%s\n' "$payload" \
+	>>"${CLAUDE_PROJECT_DIR:-.}/.claude/worktree-remove.log" 2>/dev/null || true
+
+# The event carries the worktree's absolute path, but the field name isn't
+# published — prefer the documented-style key, then fall back to any string in
+# the payload that points under .claude/worktrees/.
+wt="$(jq -r '.worktree_path // .worktreePath // .path // empty' <<<"$payload" 2>/dev/null)"
+if [ -z "$wt" ] || [ ! -d "$wt" ]; then
+	wt="$(jq -r '[.. | strings] | map(select(test("/\\.claude/worktrees/"))) | .[0] // empty' <<<"$payload" 2>/dev/null)"
+fi
+[ -n "$wt" ] && [ -d "$wt" ] || exit 0
+
+# Mirror the CLI's slug: branch name with a leading `worktree-` dropped,
+# lowercased, non-alphanumerics collapsed to `-`, capped at 24 chars. The
+# database swaps `-` for `_` (Postgres identifiers); the bucket keeps `-`.
+branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
+slug="$(printf '%s' "${branch#worktree-}" | tr '[:upper:]' '[:lower:]' \
+	| sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-24)"
+[ -n "$slug" ] || exit 0
+db="batuda_${slug//-/_}"
+bucket="batuda-assets-${slug}"
+
+docker exec batuda-db psql -U batuda -d postgres \
+	-c "DROP DATABASE IF EXISTS ${db} WITH (FORCE)" >/dev/null 2>&1 || true
+docker run --rm --network batuda_default --entrypoint /bin/sh minio/mc:latest \
+	-c "mc alias set local http://storage:9000 batuda batuda-secret >/dev/null 2>&1 && mc rb --force local/${bucket}" \
+	>/dev/null 2>&1 || true
+exit 0

--- a/.claude/hooks/worktree-up.sh
+++ b/.claude/hooks/worktree-up.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SessionStart hook — when a session begins in a linked worktree that hasn't been
+# provisioned yet, install deps and create its database + bucket in the shared
+# stack so the dev server just works. Runs once per worktree (skips once its
+# database exists), and never blocks the session: on failure it says how to finish
+# by hand and still exits 0. The slow install/up output goes to a log, not the session.
+set -uo pipefail
+
+# Act only inside a linked git worktree. The main checkout's git dir equals the
+# shared common dir; a linked worktree's git dir sits under it, so they differ.
+gitdir="$(git rev-parse --path-format=absolute --absolute-git-dir 2>/dev/null)" || exit 0
+common="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || exit 0
+[ -n "$gitdir" ] && [ "$gitdir" != "$common" ] || exit 0
+
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# Already provisioned if this worktree's database exists in the shared Postgres.
+# Mirror the CLI's slug (branch, drop a leading `worktree-`, lowercase, non-alnum
+# → `-`, cap 24; the database swaps `-` for `_`). Best-effort: if the stack is down
+# or docker is missing the probe is empty and we (re-)provision below.
+branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
+slug="$(printf '%s' "${branch#worktree-}" | tr '[:upper:]' '[:lower:]' \
+	| sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-24)"
+db="batuda_${slug//-/_}"
+exists="$(docker exec batuda-db psql -U batuda -d postgres -tAc \
+	"SELECT 1 FROM pg_database WHERE datname='$db'" 2>/dev/null | tr -d '[:space:]')"
+[ "$exists" = "1" ] && exit 0
+
+cd "$root" || exit 0
+log="$root/.claude/worktree-up.log"
+if pnpm install >"$log" 2>&1 && pnpm cli worktree up >>"$log" 2>&1; then
+	printf '%s\n' "Provisioned this worktree's database + bucket (pnpm cli worktree up). Run \`pnpm dev\` to serve it; full log at .claude/worktree-up.log."
+else
+	printf '%s\n' "Could not auto-provision this worktree (see .claude/worktree-up.log). Start Docker/OrbStack, then run: pnpm install && pnpm cli worktree up"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,16 @@
 		]
 	},
 	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-up.sh"
+					}
+				]
+			}
+		],
 		"PreToolUse": [
 			{
 				"matcher": "Edit",
@@ -116,6 +126,16 @@
 					{
 						"type": "command",
 						"command": "cd /Users/guillem/programacio/codi/autonom/batuda && git diff --name-only HEAD 2>/dev/null | grep -qE '\\.(ts|tsx)$' && echo '{\"systemMessage\": \"TypeScript files changed. Run: pnpm check-types\"}' || true"
+					}
+				]
+			}
+		],
+		"WorktreeRemove": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-down.sh"
 					}
 				]
 			}

--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -62,8 +62,8 @@ After pre-flight, check these in order. Stop when the cause is found.
 - All `RESEARCH_PROVIDER_*` vars set (server crashes without them; use `stub` for local dev)
 - `RESEARCH_PROVIDER_LLM` set (no auto-default; use `stub`)
 - All `RESEARCH_DEFAULT_*` and `RESEARCH_MAX_*` budget/concurrency vars set
-- `ALLOWED_ORIGINS=https://batuda.localhost` — only the web origin (the API is same-origin to itself, so it does not appear in its own allowlist). No wildcards, every new cross-origin caller has to be listed explicitly
-- `BETTER_AUTH_BASE_URL=https://api.batuda.localhost`
+- `ALLOWED_ORIGINS` — the web origin(s): `https://batuda.localhost` plus the `https://*.batuda.localhost` wildcard that trusts each worktree's `<branch>.batuda.localhost`. Production origins must be listed explicitly (a wildcard whose suffix isn't `.localhost` is rejected at boot)
+- `BETTER_AUTH_BASE_URL=https://api.batuda.localhost` (in a worktree the server derives this + `APP_PUBLIC_URL` from `PORTLESS_URL`, so they point at the worktree's own host)
 - `EMAIL_PROVIDER` set explicitly (use `local-inbox` for dev)
 - Run `pnpm cli doctor` for a full automated environment health check
 
@@ -73,7 +73,7 @@ Local dev depends on two Docker containers defined in `docker/docker-compose.yml
 
 | Service     | Container        | Port(s)                               |
 | ----------- | ---------------- | ------------------------------------- |
-| Postgres 17 | `batuda-db`      | `5433:5432`                           |
+| Postgres 18 | `batuda-db`      | `5433:5432`                           |
 | MinIO (S3)  | `batuda-storage` | `9000` (S3 API), `9001` (web console) |
 
 ```bash
@@ -116,57 +116,54 @@ If no emails appear, verify `EMAIL_PROVIDER=local-inbox` in `.env` and check `ap
 
 ## Running a worktree dev stack
 
-To run the app from a git worktree (e.g. to verify a branch live) **alongside** the
-main checkout's stack, without conflict.
-
-**How it works:** portless auto-prefixes the git branch name, so you use the
-**same** dev names and portless namespaces them by worktree. From a worktree on
-branch `<branch>`, `--name batuda` serves at `<branch>.batuda.localhost` and
-`--name api.batuda` at `<branch>.api.batuda.localhost`. The web auto-derives its
-API origin from its own host, so the pair just works. portless injects `PORT`
-(overriding `.env`), so there is no port clash with the main stack. Docker
-Postgres/MinIO are shared (same data).
-
-Setup (run binaries directly — `pnpm` scripts fail in worktrees on the lefthook
-`prepare` hook: `core.hooksPath is set locally`):
+Each git worktree gets its own dev data inside the **one shared** Docker stack — its
+own Postgres database (`batuda_<branch>`) and MinIO bucket (`batuda-assets-<branch>`),
+**not** a stack per worktree. portless serves it at `<branch>.batuda.localhost` (web)
+and `<branch>.api.batuda.localhost` (server), namespaced by branch so there's no clash
+with the main checkout. See the `/worktrees` skill for the full model.
 
 ```bash
-# 1. Copy the .env from the main checkout — no edits needed. ALLOWED_ORIGINS
-#    ships a `*.batuda.localhost` wildcard that trusts the worktree origin, and
-#    the auth cookie domain collapses to `batuda.localhost` (shared), so login
-#    works as-is. (Older .env missing the wildcard: append `,https://*.batuda.localhost`.)
-#    Caveat: APP_PUBLIC_URL/BETTER_AUTH_BASE_URL stay at the main host, so
-#    invite/MCP-issuer links point at the main app — fine for normal testing.
-cp ../../.env ./.env
+# Provision this worktree: creates its DB + bucket, writes .env, migrates + seeds.
+# Auto-runs once on session start (skips once the DB exists); re-running re-seeds.
+pnpm cli worktree up
 
-# 2. Build @batuda/ui — the SERVER (node/tsx) resolves its `default`/dist export.
-#    (vite dev alone doesn't need this: the web uses the `development`/src export.)
-./node_modules/.bin/turbo run build --filter=@batuda/ui
+# Run the stack — portless injects PORT/PORTLESS_URL per service, no clash with main.
+pnpm dev
 
-# 3. Start server (from apps/server) and web (from apps/internal), in background:
-../../node_modules/.bin/portless run --name api.batuda node --watch --env-file=../../.env --import tsx src/main.ts
-../../node_modules/.bin/portless run --name batuda vite dev
+pnpm cli worktree ls        # every worktree + its DB + provisioned state + URL
+pnpm cli worktree doctor    # this worktree: stack, DB, migrations, bucket, URL
+pnpm cli worktree down      # drop this worktree's DB + bucket
+pnpm cli worktree prune     # reap DBs/buckets of worktrees that no longer exist
 ```
 
 Verify: `curl -sk https://<branch>.api.batuda.localhost/health` and drive
-`agent-browser` against `https://<branch>.batuda.localhost`. The branch is
-`git branch --show-current`.
+`agent-browser` against `https://<branch>.batuda.localhost` (`<branch>` =
+`git branch --show-current`). The server derives its own auth/app origins from
+`PORTLESS_URL`, so login, API calls, and minted links (invitations, auth redirects)
+all target the worktree's host automatically — no per-worktree `.env` edits. If the
+server won't boot with an `APP_PUBLIC_URL … not one of ALLOWED_ORIGINS` error, the
+main `.env` is missing the `https://*.batuda.localhost` wildcard — add it there.
 
 ## CLI commands reference
 
-| Command                    | Purpose                                    |
-| -------------------------- | ------------------------------------------ |
-| `pnpm cli doctor`          | Full environment health check              |
-| `pnpm cli setup`           | Copy `.env` files from examples            |
-| `pnpm cli seed`            | Truncate + insert seed data (idempotent)   |
-| `pnpm cli seed --preset X` | `minimal` or `full` preset (default: full) |
-| `pnpm cli data [entity]`   | List seeded mock data (overview or rows)   |
-| `pnpm cli db migrate`      | Run pending migrations                     |
-| `pnpm cli db reset`        | Truncate + migrate + seed (clean slate)    |
-| `pnpm cli services up`     | Start Docker Postgres + MinIO              |
-| `pnpm cli services down`   | Stop Docker services                       |
-| `pnpm cli services status` | Show Docker container status               |
-| `pnpm cli:tui`             | Interactive TUI (same commands)            |
+| Command                    | Purpose                                        |
+| -------------------------- | ---------------------------------------------- |
+| `pnpm cli doctor`          | Full environment health check                  |
+| `pnpm cli setup`           | Copy `.env` files from examples                |
+| `pnpm cli seed`            | Truncate + insert seed data (idempotent)       |
+| `pnpm cli seed --preset X` | `minimal` or `full` preset (default: full)     |
+| `pnpm cli data [entity]`   | List seeded mock data (overview or rows)       |
+| `pnpm cli db migrate`      | Run pending migrations                         |
+| `pnpm cli db reset`        | Truncate + migrate + seed (clean slate)        |
+| `pnpm cli services up`     | Start Docker Postgres + MinIO                  |
+| `pnpm cli services down`   | Stop Docker services                           |
+| `pnpm cli services status` | Show Docker container status                   |
+| `pnpm cli worktree up`     | Provision this worktree's DB + bucket (+ seed) |
+| `pnpm cli worktree ls`     | List all worktrees + DB / URL / provisioned    |
+| `pnpm cli worktree doctor` | Diagnose the current worktree's data layer     |
+| `pnpm cli worktree down`   | Drop this worktree's DB + bucket               |
+| `pnpm cli worktree prune`  | Reap orphaned worktree DBs + buckets           |
+| `pnpm cli:tui`             | Interactive TUI (same commands)                |
 
 ## Browser debugging
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -44,6 +44,8 @@ gh pr view --json number,state,isDraft 2>/dev/null || echo "no PR yet"
 
 Type-checks and unit tests are **not** enough — they have passed on changes that produced wrong behavior at runtime. Run the changed path against the live local stack and confirm the user-visible behavior. If the stack is unhealthy, run `/debug-apps` first.
 
+**In a git worktree** (the recommended setup): provision its own stack with `pnpm cli worktree up` (not `services up`), then `pnpm dev`, and target the worktree's own host — `https://<branch>.batuda.localhost` (web) / `https://<branch>.api.batuda.localhost` (api), where `<branch>` = `git branch --show-current` — everywhere this step (and the screenshot commands below) say `batuda.localhost`. The server, login, and minted links all work at that host automatically. See `/worktrees`.
+
 - **CLI** — run the actual command (`pnpm cli seed`, `pnpm cli doctor`, …) and inspect output / DB state.
 - **Server** — hit the endpoint (curl or via the running app), check the response and `apps/server/server.log`.
 - **UI** — drive the page and confirm the rendered state (see below).

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: worktrees
+description: This skill should be used when working with git worktrees for parallel Claude/dev sessions on Batuda — creating, provisioning, running, listing/diagnosing, or tearing down a worktree's dev stack, or cleaning up orphaned data. Covers the shared-services model (one Docker stack; each worktree gets its own Postgres database + MinIO bucket), the `pnpm cli worktree` commands, lifecycle hooks, and per-worktree CORS/portless.
+allowed-tools: Bash(pnpm:*) Bash(git:*) Bash(docker:*) Read
+---
+
+# Worktrees on Batuda
+
+Run many sessions at once, each in its own git worktree, **without** running a Docker
+stack per worktree.
+
+## The model
+
+One **shared** Docker stack (the `batuda` compose project: Postgres, MinIO, Mailpit) backs
+everything — **3 containers total, regardless of how many worktrees you have**. A worktree
+is a *logical tenant* inside it:
+
+- its own Postgres **database** `batuda_<slug>` and MinIO **bucket** `batuda-assets-<slug>`,
+  where `<slug>` is the branch lowercased with a leading `worktree-` dropped, non-alphanumerics
+  → `-`, capped at 24 chars (the database swaps `-` → `_`) — so branch `worktree-feature-x` gives
+  `batuda_feature_x` / `batuda-assets-feature-x`, which is what `ls`/`doctor` print,
+- a generated `.env` pointing `DATABASE_URL` / `STORAGE_BUCKET` at them; everything else
+  (shared endpoints, secrets) is inherited from the main checkout's `.env`.
+
+portless gives each worktree its own URLs by **raw** branch — web `https://<branch>.batuda.localhost`,
+server `https://<branch>.api.batuda.localhost` — so two worktrees' `pnpm dev` never collide.
+
+## Where worktrees live
+
+`.claude/worktrees/<name>` (gitignored). Create one with
+`git worktree add .claude/worktrees/<name> -b <branch>` (works anywhere), or — on a Claude Code
+build with worktree support — `claude --worktree <name>` (branch `worktree-<name>`), which also
+fires the auto-provision/teardown hooks below.
+
+## Lifecycle
+
+1. **Create** — `claude --worktree foo`, or `git worktree add`.
+2. **Provision** — auto on first session start (the `SessionStart` hook runs
+   `pnpm install && pnpm cli worktree up`, then skips once the worktree's database exists). Or
+   run `pnpm cli worktree up` yourself: it ensures the shared stack is up, creates the DB +
+   bucket, writes `.env`, and migrates + seeds (re-running re-seeds — see Caveats).
+3. **Run** — `pnpm dev` → portless serves `https://<branch>.batuda.localhost`.
+4. **Inspect** — `pnpm cli worktree ls` (every worktree + its DB/URL/provisioned state),
+   `pnpm cli worktree doctor` (deep health of the current one).
+5. **Tear down** — auto when **Claude** removes the worktree (the `WorktreeRemove` hook drops
+   the DB + bucket). Or `pnpm cli worktree down`.
+
+## Commands (`pnpm cli worktree …`; run `--help` for flags)
+
+| command  | does                                                                |
+| -------- | ------------------------------------------------------------------- |
+| `up`     | provision this worktree: DB + bucket, then migrate + seed           |
+| `down`   | drop this worktree's DB + bucket (shared stack untouched)           |
+| `ls`     | table of every worktree + database + provisioned (✓) + URL          |
+| `doctor` | health of the current worktree (stack, DB, migrations, bucket, URL) |
+| `prune`  | reap DBs + buckets of worktrees that no longer exist                |
+
+## Caveats
+
+- **`git worktree remove` does NOT auto-tear-down** — the `WorktreeRemove` hook only fires when
+  *Claude* removes the worktree. After a manual `git worktree remove`, the DB + bucket leak; run
+  `pnpm cli worktree down` first, or `pnpm cli worktree prune` later to reap orphans.
+- **`pnpm cli worktree up` re-seeds** (`--preset minimal`) every run, so re-running it resets the
+  worktree's seed data — don't re-run it on a worktree whose data you've hand-edited.
+- **`pnpm cli services down` from a worktree** stops the *shared* stack (every worktree + main),
+  so it refuses unless run from the main checkout or given `--force`. To remove just your
+  worktree's data, use `worktree down`.
+- The shared Postgres caps connections at 200 — plenty for ~20 parallel dev servers.
+
+## CORS / auth (works per worktree, no per-worktree env)
+
+CORS trusts `https://*.batuda.localhost` (wildcard), the session cookie spans `batuda.localhost`,
+and the **server derives its own canonical origins from `PORTLESS_URL`** — so login, API calls,
+and minted links (invitations, auth redirects) all target the *worktree's* host automatically.
+Each worktree's own database keeps sessions/data isolated.

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -27,6 +27,13 @@ import { emailInject } from './commands/email'
 import { seed, seedIdentities } from './commands/seed'
 import { servicesDown, servicesStatus, servicesUp } from './commands/services'
 import { appendEnvKeys, resetEnvFile, setup } from './commands/setup'
+import {
+	worktreeDoctor,
+	worktreeDown,
+	worktreeLs,
+	worktreePrune,
+	worktreeUp,
+} from './commands/worktree'
 import { withDb } from './db'
 import { loadEnv } from './lib/load-env'
 import { recoveryHint } from './lib/recovery-hint'
@@ -489,27 +496,118 @@ const servicesUpCommand = Command.make('up', {}, () =>
 		yield* Effect.logInfo('Starting services...')
 		yield* servicesUp
 	}),
-).pipe(Command.withDescription('Start local Docker services'))
+).pipe(Command.withDescription('Start the shared Docker services'))
 
-const servicesDownCommand = Command.make('down', {}, () =>
-	Effect.gen(function* () {
-		yield* Effect.logInfo('Stopping services...')
-		yield* servicesDown
-	}),
-).pipe(Command.withDescription('Stop local Docker services'))
+const servicesDownCommand = Command.make(
+	'down',
+	{
+		force: Flag.boolean('force').pipe(
+			Flag.withDescription(
+				'Stop the shared stack even from inside a worktree (affects every worktree)',
+			),
+			Flag.withDefault(false),
+		),
+	},
+	({ force }) =>
+		Effect.gen(function* () {
+			yield* Effect.logInfo('Stopping services...')
+			yield* servicesDown(force)
+		}),
+).pipe(
+	Command.withDescription(
+		'Stop the shared Docker services (affects all worktrees)',
+	),
+)
 
 const servicesStatusCommand = Command.make(
 	'status',
 	{},
 	() => servicesStatus,
-).pipe(Command.withDescription('Show Docker services status'))
+).pipe(Command.withDescription('Show shared Docker services status'))
 
 const servicesCommand = Command.make('services').pipe(
-	Command.withDescription('Manage local Docker services'),
+	Command.withDescription(
+		'Manage the one shared Docker stack (Postgres, MinIO, Mailpit) all worktrees use',
+	),
 	Command.withSubcommands([
 		servicesUpCommand,
 		servicesDownCommand,
 		servicesStatusCommand,
+	]),
+)
+
+// ── Worktree ───────────────────────────────────────────────
+
+const worktreeUpCommand = Command.make('up', {}, () => worktreeUp).pipe(
+	Command.withShortDescription(
+		'Provision this worktree (database + bucket + seed)',
+	),
+	Command.withDescription(
+		'Provision this worktree inside the shared stack: create its own Postgres ' +
+			'database (batuda_<branch>) and MinIO bucket, write its .env, then migrate ' +
+			'and seed. Idempotent, and auto-runs on session start.',
+	),
+)
+
+const worktreeDownCommand = Command.make('down', {}, () => worktreeDown).pipe(
+	Command.withShortDescription('Drop this worktree’s database + bucket'),
+	Command.withDescription(
+		'Drop this worktree’s Postgres database and MinIO bucket from the shared ' +
+			'stack. The shared containers and every other worktree are left untouched.',
+	),
+)
+
+const worktreePruneCommand = Command.make(
+	'prune',
+	{},
+	() => worktreePrune,
+).pipe(
+	Command.withShortDescription('Remove orphaned worktree databases + buckets'),
+	Command.withDescription(
+		'Drop databases and buckets left behind by worktrees that no longer exist ' +
+			'(removed with `git worktree remove`, crashed sessions, non-interactive ' +
+			'runs). The main checkout and every live worktree are kept.',
+	),
+)
+
+const worktreeLsCommand = Command.make('ls', {}, () => worktreeLs).pipe(
+	Command.withShortDescription(
+		'List all worktrees + their database/bucket/URL',
+	),
+	Command.withDescription(
+		'Show every git worktree with its Postgres database, whether it is ' +
+			'provisioned (✓), and its portless URL — the at-a-glance map for ' +
+			'juggling parallel sessions.',
+	),
+)
+
+const worktreeDoctorCommand = Command.make(
+	'doctor',
+	{},
+	() => worktreeDoctor,
+).pipe(
+	Command.withShortDescription('Diagnose this worktree’s data layer'),
+	Command.withDescription(
+		'Check the current worktree’s health: shared stack reachable, its database ' +
+			'exists + migrated, its bucket exists, and the portless URL it serves.',
+	),
+)
+
+const worktreeCommand = Command.make('worktree').pipe(
+	Command.withShortDescription('Per-worktree dev data on the shared stack'),
+	Command.withDescription(
+		'Give each git worktree its own Postgres database + MinIO bucket inside the ' +
+			'one shared Docker stack — low-RAM isolation for parallel sessions. ' +
+			'Auto-provisioned on session start; `up` (re)provisions, `down` removes ' +
+			'this worktree, `prune` reaps orphans, `ls` maps them, `doctor` ' +
+			'diagnoses. Example: `pnpm cli worktree up`.',
+	),
+	Command.withSubcommands([
+		worktreeUpCommand,
+		worktreeDownCommand,
+		worktreePruneCommand,
+		worktreeLsCommand,
+		worktreeDoctorCommand,
 	]),
 )
 
@@ -657,6 +755,7 @@ export const batuda = Command.make('batuda').pipe(
 		dataCommand,
 		authCommand,
 		servicesCommand,
+		worktreeCommand,
 		calendarCommand,
 		emailCommand,
 	]),

--- a/apps/cli/src/commands/services.ts
+++ b/apps/cli/src/commands/services.ts
@@ -5,11 +5,12 @@ import { SqlClient } from 'effect/unstable/sql'
 
 import { PgLive } from '../db'
 import { exec, ROOT } from '../shell'
+import { isLinkedWorktree } from './worktree'
 
 const COMPOSE_FILE = resolve(ROOT, 'docker/docker-compose.yml')
 
 const compose = (...args: string[]) =>
-	exec('docker', 'compose', '-f', COMPOSE_FILE, ...args).pipe(
+	exec('docker', 'compose', '-p', 'batuda', '-f', COMPOSE_FILE, ...args).pipe(
 		Effect.catch(() =>
 			Effect.fail(
 				new Error('Docker command failed. Is Docker/OrbStack running?'),
@@ -20,7 +21,7 @@ const compose = (...args: string[]) =>
 /**
  * After `docker compose up -d`, the DB container needs a moment to
  * accept connections. Retry up to 4 times (1 s apart) then give up
- * silently -- the user can always run `pnpm cli doctor` separately.
+ * silently — the user can always run `pnpm cli doctor` separately.
  */
 const checkMigrations = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient
@@ -53,7 +54,20 @@ export const servicesUp = compose('up', '-d').pipe(
 	Effect.andThen(printServiceUrls),
 )
 
-export const servicesDown = compose('down')
+// Stopping the one shared stack disrupts every worktree and the main checkout, so
+// refuse from inside a linked worktree unless explicitly forced — point at the
+// per-worktree teardown instead.
+export const servicesDown = (force: boolean) =>
+	Effect.gen(function* () {
+		if (!force && (yield* isLinkedWorktree)) {
+			return yield* Effect.fail(
+				new Error(
+					'`services down` stops the shared stack used by every worktree. Run it from the main checkout, use `pnpm cli worktree down` to remove just this worktree, or pass --force.',
+				),
+			)
+		}
+		yield* compose('down')
+	})
 
 export const servicesStatus = compose('ps').pipe(
 	Effect.andThen(printServiceUrls),

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -1,0 +1,488 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+import { Console, Effect, Schedule } from 'effect'
+
+import { exec, execIn, execSilent, ROOT } from '../shell'
+import { dbMigrate } from './db'
+
+// The whole machine runs ONE shared Docker stack (the `batuda` compose project).
+// A linked worktree is not its own stack — it's a logical tenant inside the shared
+// one: its own Postgres database and its own MinIO bucket, with a `.env` pointing
+// at them. portless already separates the app servers per branch; this separates
+// the data each branch reads/writes, at a fraction of the RAM of a stack-per-worktree.
+
+const BASE = resolve(ROOT, 'docker/docker-compose.yml')
+const SHARED_PROJECT = 'batuda'
+const DB_CONTAINER = 'batuda-db'
+const PG_USER = 'batuda'
+// Compose names the default network `<project>_default`.
+const STORAGE_NETWORK = `${SHARED_PROJECT}_default`
+
+// Docker-safe slug (lowercase, [a-z0-9-]) derived from the worktree's branch.
+const slugify = (s: string) =>
+	s
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, 24)
+
+// Postgres identifiers can't contain hyphens unquoted, so the database name uses
+// underscores; S3 bucket names can't contain underscores, so the bucket keeps
+// hyphens. Both derive from the one slug so they stay paired per worktree.
+const dbName = (slug: string) => `batuda_${slug.replace(/-/g, '_')}`
+const bucketName = (slug: string) => `batuda-assets-${slug}`
+
+// The shared `.git` is identical from any worktree, so its parent is the main
+// checkout — where the real .env (the values to inherit) lives.
+const mainCheckoutRoot = () =>
+	execSilent(
+		'git',
+		'rev-parse',
+		'--path-format=absolute',
+		'--git-common-dir',
+	).pipe(Effect.map(dirname))
+
+export const isLinkedWorktree = Effect.gen(function* () {
+	const gitDir = yield* execSilent(
+		'git',
+		'rev-parse',
+		'--path-format=absolute',
+		'--absolute-git-dir',
+	)
+	const main = yield* mainCheckoutRoot()
+	// In the main checkout gitDir is `<main>/.git`; in a linked worktree it is
+	// `<main>/.git/worktrees/<name>`, so it sits below the common `.git`.
+	return gitDir !== resolve(main, '.git')
+})
+
+const branchName = execSilent('git', 'rev-parse', '--abbrev-ref', 'HEAD')
+
+const slugForCurrentWorktree = branchName.pipe(
+	Effect.map(b => slugify(b.replace(/^worktree-/, ''))),
+)
+
+// Only the worktree's own database and bucket differ from main; the shared
+// endpoints (Postgres host/port, MinIO, Mailpit) are inherited as-is.
+const envOverrides = (slug: string): Record<string, string> => ({
+	DATABASE_URL: `postgresql://batuda:batuda@localhost:5433/${dbName(slug)}`,
+	STORAGE_BUCKET: bucketName(slug),
+})
+
+// Rewrite matching keys in a .env body, appending any that weren't present, so the
+// worktree inherits every other value from the main checkout's file.
+const mergeEnv = (base: string, overrides: Record<string, string>): string => {
+	const remaining = new Set(Object.keys(overrides))
+	const lines = base.split('\n').map(line => {
+		const match = line.match(/^([A-Z0-9_]+)=/)
+		const key = match?.[1]
+		if (key && key in overrides) {
+			remaining.delete(key)
+			return `${key}=${overrides[key]}`
+		}
+		return line
+	})
+	for (const key of remaining) lines.push(`${key}=${overrides[key]}`)
+	return lines.join('\n')
+}
+
+// Read the main checkout's .env (the source of every shared value), apply the
+// worktree overrides, and write the worktree's copy. Both apps/server (root .env)
+// and the CLI (apps/cli/.env) need the DB url, so write both.
+const writeWorktreeEnv = (mainRoot: string, slug: string) =>
+	Effect.gen(function* () {
+		const overrides = envOverrides(slug)
+		const targets: Array<{
+			from: string
+			to: string
+			keys?: readonly string[]
+		}> = [
+			{ from: resolve(mainRoot, '.env'), to: resolve(ROOT, '.env') },
+			{
+				from: resolve(mainRoot, 'apps/cli/.env'),
+				to: resolve(ROOT, 'apps/cli/.env'),
+				keys: ['DATABASE_URL'],
+			},
+		]
+		for (const t of targets) {
+			if (!existsSync(t.from)) {
+				return yield* Effect.fail(
+					new Error(
+						`No ${t.from} in the main checkout — run \`pnpm cli setup\` there first.`,
+					),
+				)
+			}
+			const base = readFileSync(t.from, 'utf-8')
+			const subset = t.keys
+				? Object.fromEntries(
+						t.keys.flatMap(k => {
+							const v = overrides[k]
+							return v === undefined ? [] : [[k, v] as const]
+						}),
+					)
+				: overrides
+			yield* Effect.promise(() => writeFile(t.to, mergeEnv(base, subset)))
+		}
+	})
+
+const dockerFail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+	self.pipe(
+		Effect.catch(() =>
+			Effect.fail(
+				new Error('Docker command failed. Is Docker/OrbStack running?'),
+			),
+		),
+	)
+
+// `exec` runs through a shell that concatenates its args WITHOUT quoting, so a
+// multi-word argument (a SQL statement, a `sh -c` script) would be word-split.
+// Each docker command below is therefore passed as one already-quoted command
+// string. Interpolated values are all from a `[a-z0-9_-]` slug, so quoting them
+// is safe.
+
+// Start the one shared stack if it isn't already up (idempotent).
+const ensureSharedStack = dockerFail(
+	exec(`docker compose -p ${SHARED_PROJECT} -f "${BASE}" up -d`),
+)
+
+// CREATE/DROP DATABASE can't run from inside the target database, so every call
+// goes through the shared db container's `postgres` maintenance database.
+const databaseExists = (slug: string) =>
+	execSilent(
+		`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${dbName(slug)}'"`,
+	).pipe(Effect.map(out => out.trim() === '1'))
+
+const createDatabase = (slug: string) =>
+	Effect.gen(function* () {
+		if (yield* databaseExists(slug)) return
+		yield* dockerFail(
+			exec(
+				`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -c "CREATE DATABASE ${dbName(slug)}"`,
+			),
+		)
+	})
+
+// WITH (FORCE) (PG13+) terminates any open sessions so the drop can't hang.
+const dropDatabase = (slug: string) =>
+	dockerFail(
+		exec(
+			`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -c "DROP DATABASE IF EXISTS ${dbName(slug)} WITH (FORCE)"`,
+		),
+	)
+
+// The minio/mc image's entrypoint is `mc` itself, so override it with a shell
+// (as the storage-init sidecar does) to set the alias then run one command,
+// reaching the shared MinIO over the compose network.
+const mcScript = (command: string) =>
+	`docker run --rm --network ${STORAGE_NETWORK} --entrypoint /bin/sh minio/mc:latest -c "mc alias set local http://storage:9000 batuda batuda-secret >/dev/null 2>&1 && ${command}"`
+
+const mc = (command: string) => dockerFail(exec(mcScript(command)))
+const mcCapture = (command: string) => execSilent(mcScript(command))
+
+// The shared containers may have only just started, so give Postgres/MinIO a few
+// seconds to accept connections before the create succeeds.
+const settle = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+	self.pipe(Effect.retry(Schedule.spaced('2 seconds').pipe(Schedule.take(5))))
+
+// `git worktree list` includes the main checkout; slugifying every branch the
+// same way the up path does means a live worktree's data is never swept.
+const liveWorktreeSlugs = execSilent(
+	'git',
+	'worktree',
+	'list',
+	'--porcelain',
+).pipe(
+	Effect.map(out => {
+		const slugs = new Set<string>()
+		for (const line of out.split('\n')) {
+			const m = line.match(/^branch refs\/heads\/(.+)$/)
+			if (m?.[1]) slugs.add(slugify(m[1].replace(/^worktree-/, '')))
+		}
+		return slugs
+	}),
+)
+
+const listDatabases = execSilent(
+	`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'batuda%'"`,
+).pipe(
+	Effect.map(out =>
+		out
+			.split('\n')
+			.map(s => s.trim())
+			.filter(Boolean),
+	),
+)
+
+const listBuckets = mcCapture('mc ls local --json').pipe(
+	Effect.map(out =>
+		out
+			.split('\n')
+			.filter(Boolean)
+			.flatMap(line => {
+				try {
+					const key = (JSON.parse(line) as { key?: string }).key
+					return key ? [key.replace(/\/$/, '')] : []
+				} catch {
+					return []
+				}
+			}),
+	),
+)
+
+// Pure: from the databases + buckets that exist and the slugs of currently
+// checked-out worktrees, return the slugs whose data no live worktree owns. The
+// main checkout's `batuda` database / `batuda-assets` bucket lack the suffix, so
+// they're never matched.
+const findOrphanSlugs = (
+	dbNames: readonly string[],
+	bucketNames: readonly string[],
+	liveSlugs: ReadonlySet<string>,
+): string[] => {
+	const fromDbs = dbNames
+		.filter(n => n.startsWith('batuda_'))
+		.map(n => n.slice('batuda_'.length).replace(/_/g, '-'))
+	const fromBuckets = bucketNames
+		.filter(n => n.startsWith('batuda-assets-'))
+		.map(n => n.slice('batuda-assets-'.length))
+	const slugs = new Set([...fromDbs, ...fromBuckets])
+	// Drop empty slugs so a bare `batuda_` / `batuda-assets-` (e.g. main) is never swept.
+	return [...slugs].filter(s => s.length > 0 && !liveSlugs.has(s))
+}
+
+// True only when the shared Postgres answers — the cheapest "is the stack up?"
+// probe. Any docker/connection error folds into `false`.
+const stackReachable = execSilent(
+	`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -tAc "SELECT 1"`,
+).pipe(
+	Effect.map(out => out.trim() === '1'),
+	Effect.catch(() => Effect.succeed(false)),
+)
+
+// How many public tables a database has — 0 means it exists but isn't migrated.
+const tableCount = (db: string) =>
+	execSilent(
+		`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d ${db} -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE'"`,
+	).pipe(
+		Effect.map(out => Number(out.trim()) || 0),
+		Effect.catch(() => Effect.succeed(0)),
+	)
+
+// Parse `git worktree list --porcelain` into one entry per worktree; `branch` is
+// null for a detached HEAD (which the provisioning flow never targets).
+const parseWorktrees = (
+	porcelain: string,
+): Array<{ path: string; branch: string | null }> => {
+	const entries: Array<{ path: string; branch: string | null }> = []
+	let path = ''
+	let branch: string | null = null
+	const flush = () => {
+		if (path) entries.push({ path, branch })
+		path = ''
+		branch = null
+	}
+	for (const line of porcelain.split('\n')) {
+		if (line.startsWith('worktree ')) {
+			flush()
+			path = line.slice('worktree '.length)
+		} else if (line.startsWith('branch refs/heads/')) {
+			branch = line.slice('branch refs/heads/'.length)
+		}
+	}
+	flush()
+	return entries
+}
+
+export const worktreeUp = Effect.gen(function* () {
+	if (!(yield* isLinkedWorktree)) {
+		return yield* Effect.fail(
+			new Error(
+				'Not in a worktree. Use `pnpm cli services up` for the main checkout’s shared stack.',
+			),
+		)
+	}
+	const main = yield* mainCheckoutRoot()
+	const slug = yield* slugForCurrentWorktree
+
+	yield* Effect.logInfo('Ensuring the shared stack is up…')
+	yield* ensureSharedStack
+
+	yield* Effect.logInfo(
+		`Provisioning database ${dbName(slug)} + bucket ${bucketName(slug)}…`,
+	)
+	yield* settle(createDatabase(slug))
+	yield* settle(mc(`mc mb --ignore-existing local/${bucketName(slug)}`))
+
+	yield* writeWorktreeEnv(main, slug)
+	// Make the just-written values visible to this process + every subprocess
+	// (migrate/seed) it spawns, so they target this worktree's database, not main's.
+	for (const [k, v] of Object.entries(envOverrides(slug))) process.env[k] = v
+
+	yield* Effect.logInfo('Running migrations…')
+	yield* settle(dbMigrate)
+	yield* Effect.logInfo('Seeding…')
+	yield* execIn(ROOT, 'pnpm', 'cli', 'seed', '--preset', 'minimal')
+
+	const branch = yield* branchName
+	yield* Console.log(
+		[
+			'',
+			'✓ Worktree ready inside the shared stack',
+			`  Database:  ${dbName(slug)}  (postgresql://batuda:batuda@localhost:5433/${dbName(slug)})`,
+			`  Bucket:    ${bucketName(slug)}  (MinIO http://localhost:9001, batuda / batuda-secret)`,
+			'  Mailpit:   http://localhost:8025  (shared across worktrees)',
+			`  Run \`pnpm dev\` → portless serves https://${branch}.batuda.localhost`,
+			'',
+		].join('\n'),
+	)
+})
+
+export const worktreeDown = Effect.gen(function* () {
+	if (!(yield* isLinkedWorktree)) {
+		return yield* Effect.fail(
+			new Error('Not in a worktree — refusing to drop the shared database.'),
+		)
+	}
+	const slug = yield* slugForCurrentWorktree
+	yield* Effect.logInfo(
+		`Dropping database ${dbName(slug)} + bucket ${bucketName(slug)}…`,
+	)
+	yield* dropDatabase(slug)
+	// The bucket may already be gone (or never created) — don't fail teardown on it.
+	yield* mc(`mc rb --force local/${bucketName(slug)}`).pipe(
+		Effect.catch(() => Effect.void),
+	)
+	yield* Console.log(
+		`✓ Removed ${dbName(slug)} and ${bucketName(slug)} (shared stack untouched).`,
+	)
+})
+
+export const worktreePrune = Effect.gen(function* () {
+	const dbNames = yield* listDatabases
+	const bucketNames = yield* listBuckets
+	const liveSlugs = yield* liveWorktreeSlugs
+	const orphans = findOrphanSlugs(dbNames, bucketNames, liveSlugs)
+
+	if (orphans.length === 0) {
+		yield* Console.log('No orphaned worktree data — nothing to prune.')
+		return
+	}
+
+	yield* Effect.logInfo(
+		`Pruning ${orphans.length} orphaned worktree(s): ${orphans.join(', ')}…`,
+	)
+	for (const slug of orphans) {
+		yield* dropDatabase(slug)
+		yield* mc(`mc rb --force local/${bucketName(slug)}`).pipe(
+			Effect.catch(() => Effect.void),
+		)
+	}
+	yield* Console.log(
+		`✓ Pruned ${orphans.length} orphaned worktree(s): ${orphans.join(', ')}.`,
+	)
+})
+
+export const worktreeLs = Effect.gen(function* () {
+	const porcelain = yield* execSilent('git', 'worktree', 'list', '--porcelain')
+	const main = yield* mainCheckoutRoot()
+	const dbs = new Set(yield* listDatabases)
+	const buckets = new Set(yield* listBuckets)
+
+	const rows = parseWorktrees(porcelain).map(e => {
+		// The main checkout owns the unsuffixed `batuda` database/bucket; every
+		// linked worktree owns its `batuda_<slug>` / `batuda-assets-<slug>` pair.
+		const isMain = resolve(e.path) === resolve(main)
+		const branch = e.branch ?? '(detached)'
+		const slug = e.branch ? slugify(e.branch.replace(/^worktree-/, '')) : ''
+		const db = isMain ? 'batuda' : dbName(slug)
+		const bucket = isMain ? 'batuda-assets' : bucketName(slug)
+		const provisioned = dbs.has(db) && buckets.has(bucket)
+		const url = isMain
+			? 'https://batuda.localhost'
+			: e.branch
+				? `https://${e.branch}.batuda.localhost`
+				: '—'
+		return { branch, db, url, provisioned }
+	})
+
+	const branchWidth = Math.max(
+		...rows.map(r => r.branch.length),
+		'BRANCH'.length,
+	)
+	const dbWidth = Math.max(...rows.map(r => r.db.length), 'DATABASE'.length)
+	yield* Console.log('')
+	yield* Console.log(
+		`  ${'BRANCH'.padEnd(branchWidth)}  ${'DATABASE'.padEnd(dbWidth)}  URL`,
+	)
+	for (const r of rows) {
+		// ✓ = its database + bucket both exist; · = not provisioned yet.
+		const mark = r.provisioned ? '✓' : '·'
+		yield* Console.log(
+			`${mark} ${r.branch.padEnd(branchWidth)}  ${r.db.padEnd(dbWidth)}  ${r.url}`,
+		)
+	}
+	yield* Console.log('')
+})
+
+export const worktreeDoctor = Effect.gen(function* () {
+	const checks: Array<{ ok: boolean; name: string; detail: string }> = []
+
+	const stackOk = yield* stackReachable
+	checks.push({
+		ok: stackOk,
+		name: 'shared stack',
+		detail: stackOk
+			? 'Postgres reachable (batuda-db)'
+			: 'down — run `pnpm cli services up`',
+	})
+
+	if (!(yield* isLinkedWorktree)) {
+		checks.push({
+			ok: true,
+			name: 'worktree',
+			detail: 'main checkout — uses the shared `batuda` database',
+		})
+	} else {
+		const slug = yield* slugForCurrentWorktree
+		const db = dbName(slug)
+		const dbOk = stackOk ? yield* databaseExists(slug) : false
+		checks.push({
+			ok: dbOk,
+			name: 'database',
+			detail: dbOk ? db : `${db} missing — run \`pnpm cli worktree up\``,
+		})
+
+		const tables = dbOk ? yield* tableCount(db) : 0
+		checks.push({
+			ok: tables > 0,
+			name: 'migrations',
+			detail:
+				tables > 0 ? `${tables} tables` : 'none — run `pnpm cli worktree up`',
+		})
+
+		const bucket = bucketName(slug)
+		let bucketOk = false
+		if (stackOk) bucketOk = new Set(yield* listBuckets).has(bucket)
+		checks.push({
+			ok: bucketOk,
+			name: 'bucket',
+			detail: bucketOk
+				? bucket
+				: `${bucket} missing — run \`pnpm cli worktree up\``,
+		})
+
+		const branch = yield* branchName
+		checks.push({
+			ok: true,
+			name: 'url',
+			detail: `https://${branch}.batuda.localhost (run \`pnpm dev\`)`,
+		})
+	}
+
+	const w = Math.max(...checks.map(c => c.name.length))
+	yield* Console.log('')
+	for (const c of checks) {
+		yield* Console.log(`  ${c.ok ? '✓' : '✗'} ${c.name.padEnd(w)}  ${c.detail}`)
+	}
+	yield* Console.log('')
+})

--- a/apps/server/src/lib/cors.ts
+++ b/apps/server/src/lib/cors.ts
@@ -2,46 +2,10 @@ import { Effect, Layer } from 'effect'
 import { HttpMiddleware, HttpRouter } from 'effect/unstable/http'
 
 import { EnvVars } from './env'
+import { matchOrigin } from './origin-match'
 
-/**
- * Origin matching for ALLOWED_ORIGINS. Each pattern is either a literal
- * origin (`https://host` / `https://host:port`) matched exactly, or a
- * wildcard-subdomain pattern (`https://*.host`) that matches any single
- * additional subdomain segment under `host`.
- *
- * Wildcards are scoped to subdomains only — the protocol and the suffix
- * after `*.` must match literally — so `https://*.batuda.localhost`
- * accepts `https://worktree-foo.batuda.localhost` but never
- * `https://attacker.com` or `https://evil.batuda.localhost.attacker.com`.
- * Listing every allowed origin explicitly is still preferred in
- * production; the wildcard exists so dev worktrees (e.g. portless
- * branch-prefixed routes) don't need a fresh ALLOWED_ORIGINS entry per
- * branch.
- */
-export const matchOrigin = (
-	origin: string | undefined,
-	pattern: string,
-): boolean => {
-	// Same-origin requests don't carry an Origin header so the CORS
-	// middleware passes `undefined` here. Treat that as no-match — the
-	// browser only enforces CORS on cross-origin requests anyway.
-	if (typeof origin !== 'string') return false
-	if (origin === pattern) return true
-	const wildcardPrefix = '://*.'
-	const wildcardAt = pattern.indexOf(wildcardPrefix)
-	if (wildcardAt === -1) return false
-	const protocol = pattern.slice(0, wildcardAt + 3) // includes "://"
-	const suffix = pattern.slice(wildcardAt + wildcardPrefix.length) // host after "*."
-	if (!origin.startsWith(protocol)) return false
-	const host = origin.slice(protocol.length)
-	if (!host.endsWith(`.${suffix}`)) return false
-	const sub = host.slice(0, host.length - suffix.length - 1)
-	if (sub.length === 0) return false
-	if (sub.includes('/')) return false
-	// Wildcard matches a single label so `a.b.host` doesn't accidentally
-	// satisfy `*.host`. Multi-segment wildcards would need their own pattern.
-	return !sub.includes('.')
-}
+// Re-exported so existing importers (e.g. lib/cors.test.ts) keep their path.
+export { matchOrigin }
 
 export const CorsLive = Layer.unwrap(
 	Effect.gen(function* () {

--- a/apps/server/src/lib/env.test.ts
+++ b/apps/server/src/lib/env.test.ts
@@ -115,19 +115,35 @@ describe('buildInvitationCallbackURL', () => {
 	})
 })
 
-// APP_PUBLIC_URL must be one of ALLOWED_ORIGINS or the server refuses to boot,
-// so an invite can't point at a host the app doesn't actually trust.
+// APP_PUBLIC_URL must be trusted by ALLOWED_ORIGINS (literal or wildcard) or the
+// server refuses to boot, so an invite can't point at a host the app doesn't
+// actually trust. Wildcard matching lets a portless-derived worktree origin pass.
 describe('findPublicUrlNotAllowed', () => {
 	describe('when the public URL is one of the allowed origins', () => {
 		it('should return null', () => {
-			// GIVEN APP_PUBLIC_URL listed in ALLOWED_ORIGINS
+			// GIVEN APP_PUBLIC_URL listed literally in ALLOWED_ORIGINS
 			// WHEN the validator runs
 			// THEN it passes (null)
-			// [lib/env.ts — includes() short-circuit]
+			// [lib/env.ts — matchOrigin literal branch]
 			expect(
 				findPublicUrlNotAllowed('https://batuda.co', [
 					'https://admin.batuda.co',
 					'https://batuda.co',
+				]),
+			).toBeNull()
+		})
+	})
+
+	describe('when the public URL matches an allowed wildcard origin', () => {
+		it('should return null', () => {
+			// GIVEN a derived worktree origin and a `*.batuda.localhost` wildcard
+			// WHEN the validator runs
+			// THEN the wildcard accepts it (the literal isn't listed)
+			// [lib/env.ts — matchOrigin wildcard branch]
+			expect(
+				findPublicUrlNotAllowed('https://feature-x.batuda.localhost', [
+					'https://batuda.localhost',
+					'https://*.batuda.localhost',
 				]),
 			).toBeNull()
 		})

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -7,6 +7,9 @@ import {
 	ServiceMap,
 } from 'effect'
 
+import { matchOrigin } from './origin-match'
+import { deriveWorktreeOrigins } from './portless-origins'
+
 /**
  * Returns the first ALLOWED_ORIGINS pattern that uses a wildcard
  * subdomain whose suffix is NOT under `.localhost`, or `null` if every
@@ -42,15 +45,17 @@ export function buildInvitationCallbackURL(
 }
 
 /**
- * Returns an explanatory message if `publicUrl` is not one of
- * `allowedOrigins`, else `null`. APP_PUBLIC_URL must be a trusted origin so
- * the links the server mints can't point at a host it won't serve.
+ * Returns an explanatory message if `publicUrl` is not trusted by
+ * `allowedOrigins`, else `null`. APP_PUBLIC_URL must be a trusted origin so the
+ * links the server mints can't point at a host it won't serve. Matched with the
+ * same wildcard rules as CORS, so a derived worktree origin
+ * (`<branch>.batuda.localhost`) is accepted by the `*.batuda.localhost` wildcard.
  */
 export function findPublicUrlNotAllowed(
 	publicUrl: string,
 	allowedOrigins: ReadonlyArray<string>,
 ): string | null {
-	if (allowedOrigins.includes(publicUrl)) return null
+	if (allowedOrigins.some(p => matchOrigin(publicUrl, p))) return null
 	return (
 		`APP_PUBLIC_URL "${publicUrl}" is not one of ALLOWED_ORIGINS ` +
 		`[${allowedOrigins.join(', ')}]. List it there so the app trusts it.`
@@ -65,9 +70,23 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		const MIN_LOG_LEVEL = yield* Config.string('MIN_LOG_LEVEL')
 
 		const BETTER_AUTH_SECRET = yield* Config.redacted('BETTER_AUTH_SECRET')
-		// Required (no default): cookie-domain derivation depends on this,
-		// so a missing value in prod would ship broken auth silently.
-		const BETTER_AUTH_BASE_URL = yield* Config.string('BETTER_AUTH_BASE_URL')
+
+		// In a dev worktree portless sets PORTLESS_URL to this worktree's own api
+		// host (`<branch>.api.batuda.localhost`); derive the matching origins so the
+		// server's canonical base and the links it mints use the worktree's host,
+		// not the main checkout's. Null off `*.batuda.localhost` (prod), where the
+		// explicit env values below win. Mirrors apps/internal/vite.config.ts.
+		const PORTLESS_URL = yield* Config.string('PORTLESS_URL').pipe(
+			Config.withDefault(''),
+		)
+		const worktreeOrigins = deriveWorktreeOrigins(PORTLESS_URL)
+
+		// Required (no default): cookie-domain derivation depends on this, so a
+		// missing value in prod would ship broken auth silently. In a worktree the
+		// portless-derived api origin overrides it.
+		const BETTER_AUTH_BASE_URL =
+			worktreeOrigins?.apiOrigin ??
+			(yield* Config.string('BETTER_AUTH_BASE_URL'))
 		const BETTER_AUTH_INSECURE_COOKIES = yield* Config.boolean(
 			'BETTER_AUTH_INSECURE_COOKIES',
 		)
@@ -137,7 +156,8 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		// validated to be one of ALLOWED_ORIGINS so an invite can't point at an
 		// origin the app doesn't trust. Decoupled from ALLOWED_ORIGINS ordering
 		// on purpose: reordering that list no longer moves invite links.
-		const APP_PUBLIC_URL = yield* Config.string('APP_PUBLIC_URL')
+		const APP_PUBLIC_URL =
+			worktreeOrigins?.appOrigin ?? (yield* Config.string('APP_PUBLIC_URL'))
 		const publicUrlError = findPublicUrlNotAllowed(
 			APP_PUBLIC_URL,
 			ALLOWED_ORIGINS,

--- a/apps/server/src/lib/origin-match.ts
+++ b/apps/server/src/lib/origin-match.ts
@@ -1,0 +1,42 @@
+/**
+ * Origin matching for ALLOWED_ORIGINS. Each pattern is either a literal
+ * origin (`https://host` / `https://host:port`) matched exactly, or a
+ * wildcard-subdomain pattern (`https://*.host`) that matches any single
+ * additional subdomain segment under `host`.
+ *
+ * Wildcards are scoped to subdomains only — the protocol and the suffix
+ * after `*.` must match literally — so `https://*.batuda.localhost`
+ * accepts `https://worktree-foo.batuda.localhost` but never
+ * `https://attacker.com` or `https://evil.batuda.localhost.attacker.com`.
+ * Listing every allowed origin explicitly is still preferred in
+ * production; the wildcard exists so dev worktrees (e.g. portless
+ * branch-prefixed routes) don't need a fresh ALLOWED_ORIGINS entry per
+ * branch.
+ *
+ * Shared by the CORS middleware (lib/cors.ts) and the APP_PUBLIC_URL boot
+ * check (lib/env.ts), so both judge a derived worktree origin the same way.
+ */
+export const matchOrigin = (
+	origin: string | undefined,
+	pattern: string,
+): boolean => {
+	// Same-origin requests don't carry an Origin header so the CORS
+	// middleware passes `undefined` here. Treat that as no-match — the
+	// browser only enforces CORS on cross-origin requests anyway.
+	if (typeof origin !== 'string') return false
+	if (origin === pattern) return true
+	const wildcardPrefix = '://*.'
+	const wildcardAt = pattern.indexOf(wildcardPrefix)
+	if (wildcardAt === -1) return false
+	const protocol = pattern.slice(0, wildcardAt + 3) // includes "://"
+	const suffix = pattern.slice(wildcardAt + wildcardPrefix.length) // host after "*."
+	if (!origin.startsWith(protocol)) return false
+	const host = origin.slice(protocol.length)
+	if (!host.endsWith(`.${suffix}`)) return false
+	const sub = host.slice(0, host.length - suffix.length - 1)
+	if (sub.length === 0) return false
+	if (sub.includes('/')) return false
+	// Wildcard matches a single label so `a.b.host` doesn't accidentally
+	// satisfy `*.host`. Multi-segment wildcards would need their own pattern.
+	return !sub.includes('.')
+}

--- a/apps/server/src/lib/portless-origins.test.ts
+++ b/apps/server/src/lib/portless-origins.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveWorktreeOrigins } from './portless-origins.js'
+
+// portless injects PORTLESS_URL as the server's own host. In a worktree that is
+// `<branch>.api.batuda.localhost`; deriving the paired app origin lets the server
+// mint links + cookies for the worktree instead of the main checkout. Off the
+// `*.batuda.localhost` marker (production) it returns null so the static env wins.
+
+describe('deriveWorktreeOrigins', () => {
+	describe('when PORTLESS_URL is a worktree api host', () => {
+		it('should derive the worktree api + app origins', () => {
+			// GIVEN a branch-prefixed portless api host
+			// WHEN origins are derived
+			// THEN api keeps the host and app drops the `api.` label
+			// [lib/portless-origins.ts — appHost replace]
+			expect(
+				deriveWorktreeOrigins('https://feature-x.api.batuda.localhost'),
+			).toEqual({
+				apiOrigin: 'https://feature-x.api.batuda.localhost',
+				appOrigin: 'https://feature-x.batuda.localhost',
+			})
+		})
+
+		it('should pin https + drop the port for the real portless format', () => {
+			// GIVEN portless's actual PORTLESS_URL (http scheme, :443 port)
+			// WHEN origins are derived
+			// THEN the scheme is pinned to https and the port dropped, so they match
+			//   the `https://*.batuda.localhost` CORS wildcard the server trusts
+			// [lib/portless-origins.ts — https pin]
+			expect(
+				deriveWorktreeOrigins('http://feature-x.api.batuda.localhost:443'),
+			).toEqual({
+				apiOrigin: 'https://feature-x.api.batuda.localhost',
+				appOrigin: 'https://feature-x.batuda.localhost',
+			})
+		})
+	})
+
+	describe('when PORTLESS_URL is the main checkout api host', () => {
+		it('should derive the bare app origin', () => {
+			// GIVEN the unprefixed api host
+			// WHEN origins are derived
+			// THEN the app origin collapses to the bare marker
+			// [lib/portless-origins.ts — api.<marker> → <marker>]
+			expect(deriveWorktreeOrigins('https://api.batuda.localhost')).toEqual({
+				apiOrigin: 'https://api.batuda.localhost',
+				appOrigin: 'https://batuda.localhost',
+			})
+		})
+	})
+
+	describe('when PORTLESS_URL is not a batuda.localhost host', () => {
+		it('should return null so production keeps its env origins', () => {
+			// GIVEN a production-style host
+			// WHEN origins are derived
+			// THEN null — the caller falls back to the configured env values
+			// [lib/portless-origins.ts — endsWith(DEV_MARKER) guard]
+			expect(deriveWorktreeOrigins('https://api.batuda.co')).toBeNull()
+		})
+	})
+
+	describe('when PORTLESS_URL is empty, undefined, or invalid', () => {
+		it('should return null for an empty string', () => {
+			// GIVEN no PORTLESS_URL (portless not in the loop)
+			// WHEN origins are derived
+			// THEN null
+			// [lib/portless-origins.ts — falsy guard]
+			expect(deriveWorktreeOrigins('')).toBeNull()
+		})
+
+		it('should return null for undefined', () => {
+			// GIVEN undefined
+			// WHEN origins are derived
+			// THEN null
+			// [lib/portless-origins.ts — falsy guard]
+			expect(deriveWorktreeOrigins(undefined)).toBeNull()
+		})
+
+		it('should return null for an unparseable URL rather than throwing', () => {
+			// GIVEN a malformed value
+			// WHEN origins are derived
+			// THEN null
+			// [lib/portless-origins.ts — try/catch]
+			expect(deriveWorktreeOrigins('not a url')).toBeNull()
+		})
+	})
+})

--- a/apps/server/src/lib/portless-origins.ts
+++ b/apps/server/src/lib/portless-origins.ts
@@ -1,0 +1,36 @@
+// The dev hostname marker portless prefixes the git branch onto. Off this marker
+// (e.g. production hosts) there is no worktree to derive, so callers fall back to
+// the static env values.
+const DEV_MARKER = 'batuda.localhost'
+
+/**
+ * Derive a worktree's own origins from the PORTLESS_URL portless injects into the
+ * server process. The server runs at `<branch>.api.batuda.localhost`, paired with
+ * an app at `<branch>.batuda.localhost`. Returns null when PORTLESS_URL is absent
+ * or not a `*.batuda.localhost` host, so production keeps its configured origins.
+ *
+ * This is the inverse of the web's derivation in apps/internal/vite.config.ts,
+ * which inserts `api.` before the marker to point the app at its server.
+ */
+export const deriveWorktreeOrigins = (
+	portlessUrl: string | undefined,
+): { apiOrigin: string; appOrigin: string } | null => {
+	if (!portlessUrl) return null
+	let apiHost: string
+	try {
+		apiHost = new URL(portlessUrl).hostname
+	} catch {
+		return null
+	}
+	if (!apiHost.endsWith(DEV_MARKER)) return null
+	// `<branch>.api.batuda.localhost` → `<branch>.batuda.localhost` (and the main
+	// checkout's `api.batuda.localhost` → `batuda.localhost`).
+	const appHost = apiHost.replace(`api.${DEV_MARKER}`, DEV_MARKER)
+	// portless serves these dev hosts over HTTPS but reports PORTLESS_URL as
+	// `http://…:443`; the browser origin that CORS + cookies must match is always
+	// https, so pin the scheme (and drop the port by using the hostname).
+	return {
+		apiOrigin: `https://${apiHost}`,
+		appOrigin: `https://${appHost}`,
+	}
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   db:
     container_name: batuda-db
     image: postgres:18-alpine
+    # One shared Postgres backs every worktree (each gets its own database), so
+    # raise the ceiling for all those concurrent dev-server pools.
+    command: postgres -c max_connections=200
     ports:
       - "5433:5432"
     environment:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"release:ui:dry": "release-it --config .release-it.ui.cjs --dry-run",
 		"release:mail-worker:dry": "release-it --config .release-it.mail-worker.cjs --dry-run",
 		"______ Setup ______": "",
-		"prepare": "lefthook install",
+		"prepare": "lefthook install --force",
 		"setup": "pnpm cli -- setup"
 	},
 	"devDependencies": {

--- a/scripts/gh-pr-media.sh
+++ b/scripts/gh-pr-media.sh
@@ -33,10 +33,19 @@
 set -euo pipefail
 
 # Teammate-local config (gitignored), if present — values come from the vault.
+# It lives only in the main checkout, never in a linked worktree, so when run
+# from a worktree fall back to the main checkout's copy via the shared git dir.
 # set -a auto-exports everything the file defines, so the aws CLI below sees it.
-[ -f .env.pr-media ] && {
+env_file=""
+if [ -f .env.pr-media ]; then
+	env_file=.env.pr-media
+elif main_git="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" && [ -n "$main_git" ]; then
+	candidate="$(dirname "$main_git")/.env.pr-media"
+	[ -f "$candidate" ] && env_file="$candidate"
+fi
+[ -n "$env_file" ] && {
 	set -a
-	. ./.env.pr-media
+	. "$env_file"
 	set +a
 }
 


### PR DESCRIPTION
## What

Run many Claude/dev sessions at once, each in its own git worktree, with **low RAM**. The dev stack assumed a single checkout — one Postgres/MinIO/Mailpit, one `.env`, a `services`/`db` CLI bound to that one stack — and worktrees couldn't even `pnpm install`/commit (the `prepare` hook aborted on a set `core.hooksPath`). This makes each worktree a **logical tenant inside one shared Docker stack**: its own Postgres database (`batuda_<branch>`) + MinIO bucket, provisioned and torn down automatically. **3 containers regardless of how many worktrees.** portless already separates the app servers per branch; this separates the data each branch reads/writes. Surfaces: `cli`, `server`, plus the worktree lifecycle hooks/skills.

## Changes

- **Unblock install/commit in worktrees** — `prepare` runs `lefthook install --force`, so a set `core.hooksPath` no longer aborts the `pnpm install` that pnpm's deps check + the pre-commit hook run.
- **`pnpm cli worktree up|down|ls|doctor|prune`** — `up` creates the worktree's database + bucket in the shared stack, writes a port-matched `.env`, then migrates + seeds; `down` drops them; `prune` reaps orphans (worktrees removed with `git worktree remove`/crashes); `ls` maps every worktree, `doctor` diagnoses the current one.
- **Multi-session-safe `services`** — now manages the single shared stack and refuses `services down` from inside a worktree (it'd stop the stack every worktree + main share) unless `--force`. Postgres `max_connections` → 200.
- **Per-worktree server↔web** — the server derives `BETTER_AUTH_BASE_URL` + `APP_PUBLIC_URL` from `PORTLESS_URL` (pinned `https`), so login, API calls, and minted links (invitations, auth redirects) all target the worktree's own host; the `APP_PUBLIC_URL` boot check is now wildcard-aware.
- **PR-media from a worktree** — `gh-pr-media.sh` falls back to the main checkout's gitignored `.env.pr-media` via the shared git dir.
- **Lifecycle hooks** — `SessionStart` auto-provisions a worktree on first entry (skips once its DB exists); `WorktreeRemove` drops its DB + bucket on removal.
- **Docs** — a `worktrees` skill; `debug-apps` and `pr` made worktree-aware.

## Impact

- **Postgres** — one shared server now hosts N worktree databases (`max_connections` 200). **No schema/migration change.**
- **CORS / auth** — `ALLOWED_ORIGINS` keeps the `https://*.batuda.localhost` wildcard; the server's canonical origins are environment-derived in dev only (null off the `*.batuda.localhost` marker, so **production is unchanged** — `PORTLESS_URL` is dev-only). Session cookie still spans `batuda.localhost`.
- **CLI** — `services`/`worktree` behave differently inside a worktree (guarded `services down`); main checkout unchanged.

## Verified

- `worktree up/down/ls/doctor/prune` dogfooded; **three worktrees coexisting in one 3-container stack**, main checkout untouched.
- Live server in a worktree: boots clean (derived `https` origins pass the wildcard check), `/health` 200, CORS preflight from the worktree origin returns it + `credentials: true`, a foreign origin is rejected. The e2e caught + fixed a real boot bug (portless reports `PORTLESS_URL=http://…:443`, so the derivation now pins `https`).
- Lifecycle hooks: `SessionStart` provisions then skips once the DB exists (no re-seed loop); `WorktreeRemove` drops the DB + bucket.
- Gates: `pnpm install` → `check-types` + `test` (259 server tests, incl. new portless/origin tests) → `build`, all green (test + secretlint also run on push).

## Review guide

- Start at `apps/cli/src/commands/worktree.ts` (the engine) and `apps/server/src/lib/portless-origins.ts` (the origin derivation).
- Riskiest bits: the docker shell-quoting in `worktree.ts` — each docker command is passed as **one pre-quoted string** because the shell `exec` concatenates args unquoted; interpolated values are all `[a-z0-9_-]` slugs, so it's injection-safe. And the `services down` worktree guard (a worktree must never stop the shared stack).
- No CLI unit tests (repo convention — `apps/cli` has no test setup); verified by dogfooding. The pure helpers `deriveWorktreeOrigins` and `findPublicUrlNotAllowed` (wildcard) are unit-tested.
- `ai`/`ai(skills)` commits are docs + hooks; skip-able for logic review.

## Deferred

Shared-services is the only mode (the isolated-container approach was reworked out before merge). Not here: template-DB snapshot for faster provisioning, idle-stack reaping, and a `WorktreeCreate` auto-create hook (it *replaces* git's worktree creation and aborts on any non-zero exit — a stopped Docker daemon would block making worktrees, too risky). Security-audit follow-ups are tracked in #92.
