### PR TITLE
fix: derive worktree host and slug from the branch basename

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -117,9 +117,10 @@ If no emails appear, verify `EMAIL_PROVIDER=local-inbox` in `.env` and check `ap
 ## Running a worktree dev stack
 
 Each git worktree gets its own dev data inside the **one shared** Docker stack — its
-own Postgres database (`batuda_<branch>`) and MinIO bucket (`batuda-assets-<branch>`),
-**not** a stack per worktree. portless serves it at `<branch>.batuda.localhost` (web)
-and `<branch>.api.batuda.localhost` (server), namespaced by branch so there's no clash
+own Postgres database (`batuda_<slug>`) and MinIO bucket (`batuda-assets-<slug>`),
+**not** a stack per worktree. portless serves it at `<label>.batuda.localhost` (web)
+and `<label>.api.batuda.localhost` (server), where `<label>`/`<slug>` is the branch's
+last path segment (so `ui/foo` → `foo.batuda.localhost`), so there's no clash
 with the main checkout. See the `/worktrees` skill for the full model.
 
 ```bash
@@ -136,9 +137,10 @@ pnpm cli worktree down      # drop this worktree's DB + bucket
 pnpm cli worktree prune     # reap DBs/buckets of worktrees that no longer exist
 ```
 
-Verify: `curl -sk https://<branch>.api.batuda.localhost/health` and drive
-`agent-browser` against `https://<branch>.batuda.localhost` (`<branch>` =
-`git branch --show-current`). The server derives its own auth/app origins from
+Verify: `curl -sk https://<label>.api.batuda.localhost/health` and drive
+`agent-browser` against `https://<label>.batuda.localhost` (use the host
+`pnpm cli worktree doctor` prints — portless takes the branch's last path segment).
+The server derives its own auth/app origins from
 `PORTLESS_URL`, so login, API calls, and minted links (invitations, auth redirects)
 all target the worktree's host automatically — no per-worktree `.env` edits. If the
 server won't boot with an `APP_PUBLIC_URL … not one of ALLOWED_ORIGINS` error, the

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -44,7 +44,7 @@ gh pr view --json number,state,isDraft 2>/dev/null || echo "no PR yet"
 
 Type-checks and unit tests are **not** enough — they have passed on changes that produced wrong behavior at runtime. Run the changed path against the live local stack and confirm the user-visible behavior. If the stack is unhealthy, run `/debug-apps` first.
 
-**In a git worktree** (the recommended setup): provision its own stack with `pnpm cli worktree up` (not `services up`), then `pnpm dev`, and target the worktree's own host — `https://<branch>.batuda.localhost` (web) / `https://<branch>.api.batuda.localhost` (api), where `<branch>` = `git branch --show-current` — everywhere this step (and the screenshot commands below) say `batuda.localhost`. The server, login, and minted links all work at that host automatically. See `/worktrees`.
+**In a git worktree** (the recommended setup): provision its own stack with `pnpm cli worktree up` (not `services up`), then `pnpm dev`, and target the worktree's own host — `https://<label>.batuda.localhost` (web) / `https://<label>.api.batuda.localhost` (api), where `<label>` is the host `pnpm cli worktree doctor` prints (portless takes the branch's **last path segment**, so `ui/foo` → `foo.batuda.localhost`) — everywhere this step (and the screenshot commands below) say `batuda.localhost`. The server, login, and minted links all work at that host automatically. See `/worktrees`.
 
 - **CLI** — run the actual command (`pnpm cli seed`, `pnpm cli doctor`, …) and inspect output / DB state.
 - **Server** — hit the endpoint (curl or via the running app), check the response and `apps/server/server.log`.

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -16,14 +16,17 @@ everything — **3 containers total, regardless of how many worktrees you have**
 is a *logical tenant* inside it:
 
 - its own Postgres **database** `batuda_<slug>` and MinIO **bucket** `batuda-assets-<slug>`,
-  where `<slug>` is the branch lowercased with a leading `worktree-` dropped, non-alphanumerics
-  → `-`, capped at 24 chars (the database swaps `-` → `_`) — so branch `worktree-feature-x` gives
-  `batuda_feature_x` / `batuda-assets-feature-x`, which is what `ls`/`doctor` print,
+  where `<slug>` is the branch's **last path segment** lowercased, non-alphanumerics → `-`
+  (the database swaps `-` → `_`; a very long name gets a short hash suffix) — so branch
+  `ui/feature-x` gives `batuda_feature_x` / `batuda-assets-feature-x`, which is what
+  `ls`/`doctor` print,
 - a generated `.env` pointing `DATABASE_URL` / `STORAGE_BUCKET` at them; everything else
   (shared endpoints, secrets) is inherited from the main checkout's `.env`.
 
-portless gives each worktree its own URLs by **raw** branch — web `https://<branch>.batuda.localhost`,
-server `https://<branch>.api.batuda.localhost` — so two worktrees' `pnpm dev` never collide.
+portless serves each worktree on that same last-path-segment label — web
+`https://<label>.batuda.localhost`, server `https://<label>.api.batuda.localhost`, so
+`ui/feature-x` → `feature-x.batuda.localhost` and two worktrees' `pnpm dev` never collide.
+**Use the URL `pnpm cli worktree ls`/`doctor` prints** — don't build it from the branch by hand.
 
 ## Where worktrees live
 
@@ -39,7 +42,7 @@ fires the auto-provision/teardown hooks below.
    `pnpm install && pnpm cli worktree up`, then skips once the worktree's database exists). Or
    run `pnpm cli worktree up` yourself: it ensures the shared stack is up, creates the DB +
    bucket, writes `.env`, and migrates + seeds (re-running re-seeds — see Caveats).
-3. **Run** — `pnpm dev` → portless serves `https://<branch>.batuda.localhost`.
+3. **Run** — `pnpm dev` → portless serves `https://<label>.batuda.localhost` (the branch's last path segment).
 4. **Inspect** — `pnpm cli worktree ls` (every worktree + its DB/URL/provisioned state),
    `pnpm cli worktree doctor` (deep health of the current one).
 5. **Tear down** — auto when **Claude** removes the worktree (the `WorktreeRemove` hook drops

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
@@ -20,13 +21,39 @@ const PG_USER = 'batuda'
 // Compose names the default network `<project>_default`.
 const STORAGE_NETWORK = `${SHARED_PROJECT}_default`
 
-// Docker-safe slug (lowercase, [a-z0-9-]) derived from the worktree's branch.
-const slugify = (s: string) =>
-	s
+// portless routes each worktree by the branch's LAST path segment — `ui/foo` and a
+// plain `foo` both serve `foo.batuda.localhost` — lowercased to a DNS label, with a
+// short hash appended past 63 chars. We mirror that derivation exactly so the host
+// we print is the host portless serves, and we key this worktree's database +
+// bucket off the SAME label so the URL and the data behind it can't drift apart.
+const MAX_DNS_LABEL = 63
+// A bucket name caps at 63 chars and ours carries a `batuda-assets-` (14) prefix, so
+// the shared slug is bounded to 49 — also safe for the `batuda_` database prefix.
+const MAX_SLUG = 49
+
+const dnsLabel = (raw: string, max: number): string => {
+	const sane = raw
 		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/[^a-z0-9-]/g, '-')
+		.replace(/-{2,}/g, '-')
 		.replace(/^-+|-+$/g, '')
-		.slice(0, 24)
+	if (sane.length <= max) return sane
+	// Too long: keep a unique tail by appending a short hash. Trim by 7 to leave
+	// room for the 6-char hash plus the hyphen that joins it.
+	const hash = createHash('sha256').update(sane).digest('hex').slice(0, 6)
+	return `${sane.slice(0, max - 7).replace(/-+$/, '')}-${hash}`
+}
+
+const branchLabel = (branch: string) => branch.split('/').pop() ?? branch
+
+// The subdomain portless actually serves for this branch (capped at 63 as it does).
+const branchHost = (branch: string) =>
+	`${dnsLabel(branchLabel(branch), MAX_DNS_LABEL)}.batuda.localhost`
+
+// Names this worktree's database + bucket — the same label as the host, capped
+// tighter so both identifiers stay valid.
+const slugForBranch = (branch: string) =>
+	dnsLabel(branchLabel(branch), MAX_SLUG)
 
 // Postgres identifiers can't contain hyphens unquoted, so the database name uses
 // underscores; S3 bucket names can't contain underscores, so the bucket keeps
@@ -59,9 +86,7 @@ export const isLinkedWorktree = Effect.gen(function* () {
 
 const branchName = execSilent('git', 'rev-parse', '--abbrev-ref', 'HEAD')
 
-const slugForCurrentWorktree = branchName.pipe(
-	Effect.map(b => slugify(b.replace(/^worktree-/, ''))),
-)
+const slugForCurrentWorktree = branchName.pipe(Effect.map(slugForBranch))
 
 // Only the worktree's own database and bucket differ from main; the shared
 // endpoints (Postgres host/port, MinIO, Mailpit) are inherited as-is.
@@ -185,7 +210,7 @@ const mcCapture = (command: string) => execSilent(mcScript(command))
 const settle = <A, E, R>(self: Effect.Effect<A, E, R>) =>
 	self.pipe(Effect.retry(Schedule.spaced('2 seconds').pipe(Schedule.take(5))))
 
-// `git worktree list` includes the main checkout; slugifying every branch the
+// `git worktree list` includes the main checkout; deriving each branch's slug the
 // same way the up path does means a live worktree's data is never swept.
 const liveWorktreeSlugs = execSilent(
 	'git',
@@ -197,7 +222,7 @@ const liveWorktreeSlugs = execSilent(
 		const slugs = new Set<string>()
 		for (const line of out.split('\n')) {
 			const m = line.match(/^branch refs\/heads\/(.+)$/)
-			if (m?.[1]) slugs.add(slugify(m[1].replace(/^worktree-/, '')))
+			if (m?.[1]) slugs.add(slugForBranch(m[1]))
 		}
 		return slugs
 	}),
@@ -331,7 +356,7 @@ export const worktreeUp = Effect.gen(function* () {
 			`  Database:  ${dbName(slug)}  (postgresql://batuda:batuda@localhost:5433/${dbName(slug)})`,
 			`  Bucket:    ${bucketName(slug)}  (MinIO http://localhost:9001, batuda / batuda-secret)`,
 			'  Mailpit:   http://localhost:8025  (shared across worktrees)',
-			`  Run \`pnpm dev\` → portless serves https://${branch}.batuda.localhost`,
+			`  Run \`pnpm dev\` → portless serves https://${branchHost(branch)}`,
 			'',
 		].join('\n'),
 	)
@@ -393,14 +418,14 @@ export const worktreeLs = Effect.gen(function* () {
 		// linked worktree owns its `batuda_<slug>` / `batuda-assets-<slug>` pair.
 		const isMain = resolve(e.path) === resolve(main)
 		const branch = e.branch ?? '(detached)'
-		const slug = e.branch ? slugify(e.branch.replace(/^worktree-/, '')) : ''
+		const slug = e.branch ? slugForBranch(e.branch) : ''
 		const db = isMain ? 'batuda' : dbName(slug)
 		const bucket = isMain ? 'batuda-assets' : bucketName(slug)
 		const provisioned = dbs.has(db) && buckets.has(bucket)
 		const url = isMain
 			? 'https://batuda.localhost'
 			: e.branch
-				? `https://${e.branch}.batuda.localhost`
+				? `https://${branchHost(e.branch)}`
 				: '—'
 		return { branch, db, url, provisioned }
 	})
@@ -475,7 +500,7 @@ export const worktreeDoctor = Effect.gen(function* () {
 		checks.push({
 			ok: true,
 			name: 'url',
-			detail: `https://${branch}.batuda.localhost (run \`pnpm dev\`)`,
+			detail: `https://${branchHost(branch)} (run \`pnpm dev\`)`,
 		})
 	}
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,6 +134,20 @@ Log in at `/sign-in` with the admin credentials you set in Step 5.
 
 ---
 
+## (Optional) Parallel work in git worktrees
+
+Work on several branches at once without a second Docker stack: each git worktree is a *tenant* in the shared stack with its own database + bucket. The `/worktrees` skill has the full model; the short version:
+
+```bash
+git worktree add .claude/worktrees/<name> -b <branch>   # create
+pnpm cli worktree up                                     # its DB + bucket + .env, then migrate + seed
+pnpm dev                                                 # portless serves it on its own host
+pnpm cli worktree doctor                                 # prints that host + health
+pnpm cli worktree down                                   # drop its DB + bucket when done
+```
+
+portless serves the worktree at the branch's **last path segment** — `ui/foo` → `https://foo.batuda.localhost`. Use the URL `worktree doctor` prints rather than guessing it.
+
 ## Env targets: `--env local|cloud`
 
 Every CLI command accepts `--env local|cloud` (default `local`).
@@ -152,6 +166,8 @@ Cloud env requires `gh` authenticated locally (`gh auth status`). If `gh` is mis
 **Port 5433 already in use.** Another Postgres is bound to the default port. Either stop the other instance or change `POSTGRES_PORT` in `.env` and re-run `pnpm cli services up`.
 
 **TLS cert errors on `*.batuda.localhost`.** Dev servers use self-signed certs. Accept the cert once per hostname in your browser (API + web app = two prompts).
+
+**A worktree host won't load at all** (`ERR_CONNECTION_CLOSED`, no cert prompt). A long-running portless proxy can lack certs for worktree subdomains created after it started — restart the proxy so it re-mints them.
 
 **`pnpm cli auth bootstrap` says `UsersAlreadyExist`.** Someone already bootstrapped. If you don't know the credentials, run `pnpm cli auth reset-password --email <their-email>` to overwrite the password instead.
 


### PR DESCRIPTION
## What

Fixes the worktree dev tooling (`apps/cli` `worktree` commands) for branch names that aren't already a clean hostname — slashes, uppercase, punctuation. portless routes each worktree by the branch's **last path segment**, lowercased to a DNS label; the CLI was instead interpolating the **raw** branch into the host and deriving the DB/bucket slug a third, different way. For a branch like `ui/foo` it printed the unreachable `https://ui/foo.batuda.localhost` while portless actually served `foo.batuda.localhost`. Closes #93.

## The fix

- One derivation now mirrors portless's exactly (last path segment → lowercase → invalid chars to hyphens → hash-truncate past 63), used for both the printed URL and the per-worktree database/bucket slug, so the host the CLI prints is the host portless serves and it can't drift from its data.
- Corrected the three skills that documented the old "raw branch" rule (worktrees, debug-apps, pr) and added a worktrees section + a stale-proxy troubleshooting note to the getting-started guide.

## Impact

- **Dev-only tooling** — no schema/migration, wire-shape, auth/RLS, env, or MCP changes.
- **Slug derivation changed**, so a worktree provisioned under the old scheme (e.g. `batuda_ui_foo`) no longer matches its branch's new slug (`batuda_foo`); the old DB/bucket become orphans. `pnpm cli worktree prune` reaps them, or re-run `pnpm cli worktree up` to re-provision. Worktree data is ephemeral dev seed, so nothing of value is lost.

## Review guide

- The whole behavioral change is `apps/cli/src/commands/worktree.ts`; the rest is docs. Start at the new `dnsLabel` / `branchHost` / `slugForBranch` helpers.
- I verified the helpers against portless's own `branchToPrefix` / `sanitizeForHostname` / `truncateLabel` in `node_modules/portless` — same regexes, same 63-char cap, same 6-char sha256 suffix.
- Snyk: the `snyk_code_scan` tool isn't available in my session; this is dev CLI string-handling, not a security surface.

## Verification

Renamed the worktree branch through each edge case and compared the CLI's printed URL to portless's authoritative `portless get`:

| branch | portless serves | CLI prints | match |
| --- | --- | --- | --- |
| `myfeature` | `myfeature.batuda.localhost` | same | ✓ |
| `MyFeature` | `myfeature.batuda.localhost` | same | ✓ |
| `feat/Foo_Bar.v2` | `foo-bar-v2.batuda.localhost` | same | ✓ |
| `release/v1.2.3` | `v1-2-3.batuda.localhost` | same | ✓ |
| 70-char branch | `…excee-d29356.batuda.localhost` | same | ✓ |

Gates: `pnpm install` (no lockfile drift) → `check-types` (12/12) + `test` (18/18) → `build` (12/12), plus `dprint` clean on the docs. (No unit test — repo convention skips tests for `apps/cli`; verified behaviorally above.)
