### PR TITLE
docs: fix broken issue links in ui changelog + guard commit bodies

### DIFF
--- a/.claude/skills/commits/SKILL.md
+++ b/.claude/skills/commits/SKILL.md
@@ -136,6 +136,7 @@ If ALL changed files match `ai` patterns → use `ai` type. If mixed with non-AI
 4. **AI-only changes**: When changes are exclusively AI-related (see AI Scope), always use `ai` type
 5. **No mechanical cleanup or implementation narration**: Don't mention consequences obvious from the primary change (removed unused imports, unwrapped single-child fragments, updated indentation), and don't describe how the diff achieves the change ("added a helper that maps X to Y" when the diff is the helper). Focus on intent / why, not mechanism
 6. **No tautology**: The subject must not repeat the type as a verb. The type already conveys the action — e.g., `fix: fix the login` → `fix: resolve login failure`, `refactor: refactor auth` → `refactor: simplify auth flow`
+7. **No bare `#` tokens in the body**: The changelog generator reads `#<token>` as a GitHub issue reference and renders it as a "closes" link, so a hex color or fragment becomes a broken issue link in the release notes — write `b05220 → 95400f`, not `#b05220 → #95400f`
 
 ## Body sizing
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* meet WCAG AA contrast and add ARIA to the mailbox connect form ([1326007](https://github.com/guillempuche/batuda/commit/1326007c3d3178d882dde6c4dd6d29d8b2896771)), closes [#b05220](https://github.com/guillempuche/batuda/issues/b05220) [#95400f](https://github.com/guillempuche/batuda/issues/95400f)
+* meet WCAG AA contrast and add ARIA to the mailbox connect form ([1326007](https://github.com/guillempuche/batuda/commit/1326007c3d3178d882dde6c4dd6d29d8b2896771))
 * **ui:** match select popup width to its trigger ([839ae9b](https://github.com/guillempuche/batuda/commit/839ae9b803cdb896ce5d2ad896e75dbabd0d66d5))
 
 ## 2026-05-17 (ui-v2026.5.17)


### PR DESCRIPTION
## What

The `ui-v2026.6.14` release notes and `packages/ui/CHANGELOG.md` linked two non-existent issues, `#b05220` and `#95400f`. Those are hex color codes from commit `1326007`'s body (`--color-primary #b05220 → #95400f`); conventional-changelog (release-it's notes generator) reads any `#<token>` as a GitHub issue reference and renders it as a "closes" link, so the hex colors became dead `…/issues/b05220` links.

The **published GitHub release notes** for `ui-v2026.6.14` were already corrected directly (out of band — they don't live in the repo). This PR fixes the committed changelog and prevents recurrence.

## Changes

- Removed the bogus `closes #b05220 #95400f` links from the v2026.6.14 changelog entry.
- Added rule 7 to the `/commits` skill: no bare `#` tokens in commit bodies (write `b05220 → 95400f`).

## Impact

- Docs/skills only — no code, build, or runtime effect.

## Verification

- `dprint check` clean on both files.
- Confirmed commit `1326007` is the only one carrying `#hex` tokens, so `ui-v2026.6.14` is the only affected release; its published notes are already fixed.
