### PR TITLE
cicd(deploy): keep lefthook disabled across prepare-script changes

### DIFF
--- a/apps/mail-worker/Dockerfile
+++ b/apps/mail-worker/Dockerfile
@@ -13,8 +13,9 @@ RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 COPY ./package.json ./pnpm-lock.yaml ./pnpm-workspace.yaml ./tsconfig.base.json ./
 COPY ./turbo.json ./
 
-# Disable lefthook in Docker build (no git available)
-RUN sed -i 's/"prepare": "lefthook install"/"prepare": ""/' package.json
+# Disable lefthook in the Docker build (no git here); match any prepare value so a
+# later prepare-script change can't silently slip past and break the build.
+RUN sed -i 's/"prepare": "[^"]*"/"prepare": ""/' package.json
 
 # Copy the full workspace so the turbo filter has the complete graph.
 # @batuda/mail-worker transitively depends on auth, calendar, controllers,

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -13,8 +13,9 @@ RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 COPY ./package.json ./pnpm-lock.yaml ./pnpm-workspace.yaml ./tsconfig.base.json ./
 COPY ./turbo.json ./
 
-# Disable lefthook in Docker build (no git available)
-RUN sed -i 's/"prepare": "lefthook install"/"prepare": ""/' package.json
+# Disable lefthook in the Docker build (no git here); match any prepare value so a
+# later prepare-script change can't silently slip past and break the build.
+RUN sed -i 's/"prepare": "[^"]*"/"prepare": ""/' package.json
 
 # Copy the full workspace so the turbo filter has the complete graph.
 # @batuda/server transitively depends on auth, calendar, controllers,


### PR DESCRIPTION
## What

Fixes the KraftCloud deploy build for `server` and `mail-worker`. Their Dockerfiles disable lefthook (the build container has no `git`) with a sed pinned to the literal `"lefthook install"`. Commit `a2c1ac2831` changed the prepare script to `"lefthook install --force"`, so the sed stopped matching, lefthook ran during `pnpm install --frozen-lockfile`, and the build failed on missing `git` — which broke the `server-v2026.6.15` deploy.

## The fix

- Wildcard sed (`"prepare": "[^"]*"` → `""`) strips whatever the prepare script is, so it stays disabled across future prepare-script changes. `--ignore-scripts` is not an option — the build needs the `sharp` / `workerd` / `esbuild` postinstalls.

## Impact

- Deploy/build only (`cicd`); no runtime or app-behavior change.
- `internal` is unaffected — it has no Dockerfile and builds on the GitHub runner (git present), then `wrangler deploy`s.
- After this merges, `server` re-releases as `2026.6.15-1` to actually deploy; `mail-worker` is fixed pre-emptively (not released here).

## Verification

- Simulated the new sed against the current `package.json`: `"prepare": "lefthook install --force"` → `"prepare": ""`.
- CI does not build the Docker image, so the real validation is the KraftCloud deploy on the server re-release.
