### PR TITLE
cicd(deploy): bump wrangler-action to v4

### DIFF
--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -53,7 +53,7 @@ jobs:
       # managed out-of-band (CF dashboard / API), so a deploy never touches
       # the production domain binding.
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: apps/internal


### PR DESCRIPTION
Bumps `cloudflare/wrangler-action` `@v3` → `@v4` (Node 20 → Node 24; `@v3` is deprecated on GitHub Actions from June 16, 2026).

The build already runs Wrangler 4 (via `@cloudflare/vite-plugin`), so v4's default Wrangler aligns and the action inputs (`apiToken`, `workingDirectory`, `command`) are unchanged.

Verified against the wrangler-action v4.0.0 changelog and Cloudflare's [Update v3 → v4 guide](https://developers.cloudflare.com/workers/wrangler/migration/update-v3-to-v4/): **no `wrangler.jsonc` change needed** — none of the keys removed in v4 (`legacy_assets`, `node_compat`, `usage_model`) are present, and we already use the `nodejs_compat` flag.
