### PR TITLE
fix(server): emit object-typed inputSchema for no-arg MCP tools

### DIFF
--- a/apps/server/src/mcp/tools/_annotations.test.ts
+++ b/apps/server/src/mcp/tools/_annotations.test.ts
@@ -84,6 +84,24 @@ describe('MCP tool annotation coverage', () => {
 						).toBe(true)
 					})
 
+					it('should expose an object-typed inputSchema', () => {
+						// GIVEN a tool registered in the toolkit
+						// WHEN generating its MCP inputSchema (the same call the
+						//      server makes when answering tools/list)
+						// THEN the JSON Schema root is type "object" — clients hide
+						//      every tool in the list when one breaks this rule, and
+						//      an empty Schema.Struct({}) produces a typeless root, so
+						//      no-arg tools must leave parameters off entirely
+						// [tools/${toolkitName} — inputSchema root-type invariant]
+						const inputSchema = Tool.getJsonSchema(tool) as {
+							type?: unknown
+						}
+						expect(
+							inputSchema.type,
+							`${toolName} inputSchema root must be type:"object"; drop empty Schema.Struct({}) (omit parameters instead)`,
+						).toBe('object')
+					})
+
 					if (READ_ONLY_NAME.test(toolName)) {
 						it('should declare Tool.Readonly = true', () => {
 							// GIVEN a tool whose name matches a read-only convention

--- a/apps/server/src/mcp/tools/calendar.ts
+++ b/apps/server/src/mcp/tools/calendar.ts
@@ -224,7 +224,6 @@ const CreateInternalBlock = Tool.make('create_internal_block', {
 const SyncEventTypes = Tool.make('sync_event_types', {
 	description:
 		'Pull the latest event-type list from the calendar provider (title, duration_minutes, locations) and update local rows by (provider, provider_event_type_id). Safe to call on every boot + on demand; title/duration changes show up without a redeploy.',
-	parameters: Schema.Struct({}),
 	success: Schema.Struct({ synced: Schema.Number }),
 })
 	.annotate(Tool.Title, 'Sync Event Types')

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -312,7 +312,6 @@ const ListEmailInboxes = Tool.make('list_email_inboxes', {
 const ListEmailProviderPresets = Tool.make('list_email_provider_presets', {
 	description:
 		'List the built-in mailbox presets (Infomaniak, Fastmail, iCloud Mail, Yahoo Mail, Gmail Workspace, Microsoft 365, Proton Bridge, Generic IMAP). Each entry pre-fills IMAP and SMTP host/port/security, plus appPasswordUrl (where the user generates an app-specific password for a 2FA account) and passwordAuthSupported (false for Gmail and Microsoft 365, which no longer allow password sign-in and need OAuth). create_email_inbox callers only need to add credentials. Static — safe to cache.',
-	parameters: Schema.Struct({}),
 	success: Schema.Array(Schema.Unknown),
 })
 	.annotate(Tool.Title, 'List Email Provider Presets')
@@ -323,7 +322,6 @@ const ListEmailProviderPresets = Tool.make('list_email_provider_presets', {
 const GetEmailInboxStatus = Tool.make('get_email_inbox_status', {
 	description:
 		'Return the calling member’s primary inbox in the active organization, if any. Use before send_email/create_email_draft to confirm the user has a default inbox set; if hasDefault=false the UI should prompt them to connect a mailbox first.',
-	parameters: Schema.Struct({}),
 	success: Schema.Struct({
 		hasDefault: Schema.Boolean,
 		primary: Schema.NullOr(

--- a/apps/server/src/mcp/tools/products.ts
+++ b/apps/server/src/mcp/tools/products.ts
@@ -9,7 +9,6 @@ const REQUEST_DEPENDENCIES = [CurrentOrg]
 const ListProducts = Tool.make('list_products', {
 	description:
 		'List products in the organization. Returns id, slug, name, type, status, default_price, price_type, target_industries, metadata, created_at.',
-	parameters: Schema.Struct({}),
 	success: Schema.Array(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })


### PR DESCRIPTION
## What

The CRM MCP server (`apps/server`) advertises its tools to clients via `tools/list`. Four no-arg tools declared `parameters: Schema.Struct({})`, and in Effect `4.0.0-beta.43` an *empty* struct serializes to a typeless `{ "anyOf": [{ "type": "object" }, { "type": "array" }] }` root. The MCP spec requires every tool's `inputSchema` root to be `type: "object"`, so spec-compliant clients (Claude Desktop, claude.ai) reject the **entire** `tools/list` when any one tool violates it — the connection succeeds but exposes **zero** tools. Dropping the empty struct lets those tools fall back to Effect's `EmptyParams`, which serializes to a valid `{ "type": "object" }`.

## The fix

- Removed `parameters: Schema.Struct({})` from the four no-arg tools — `list_products`, `list_email_provider_presets`, `get_email_inbox_status`, `sync_event_types`. With `parameters` omitted they default to `EmptyParams` (`Record(String, Never)`), which serializes to `{ "type": "object", "additionalProperties": false }`. Their handlers already took no arguments, so behavior is unchanged — this matches the existing `get_pipeline`, which already omits `parameters`.
- Added a registry invariant to the existing `_annotations.test.ts` net asserting every tool's `inputSchema` root is `type: "object"` — covering the whole class (any non-object root), not just empty structs.

## Impact

- **MCP transport only.** This changes what `tools/list` advertises for four tools. No shared service logic changed, so the HTTP/controller surface is unaffected — these are `Tool.make` schema definitions, not `packages/controllers` contracts.
- No migration, no RLS / Postgres-role change, no new env vars, no wire-shape change to `packages/domain` / `packages/controllers`.
- **Needs a `server` release to reach prod** — production is still serving the broken schemas until the `server` tag ships. The four handlers are unchanged, so there is no behavioral risk on deploy.

## Review guide

- Start at the four one-line deletions — each removes an empty `Schema.Struct({})` so the tool inherits the valid default. The only question worth checking is "do these handlers read params?" — they are all `() => …`, confirmed, so omitting `parameters` is safe.
- The test block in `_annotations.test.ts` is the durable guard; the rest of that file is unchanged.
- Root cause is Effect's deliberate JSON Schema mapping for an empty object-type (`internal/schema/representation.ts:468` returns the typeless `anyOf`), and the server passes the schema through unvalidated (`McpSchema` types `inputSchema` as `Schema.Any`) — so the fix has to live at the tool definition, not the transport.

## Tests

- Unit: new `inputSchema` root-type invariant in `apps/server/src/mcp/tools/_annotations.test.ts`, parameterized over every tool in every toolkit. I confirmed it bites by temporarily reintroducing `Schema.Struct({})` (the test went red: "expected undefined to be 'object'"), then restored the fix.

## Verification

Ran locally in a worktree:

- `pnpm -w check-types` → green (12/12)
- `pnpm --filter @batuda/server test` (fast unit suite, excludes integration/boot) → 366 passed
- `pnpm --filter @batuda/server build` → green
- Serialized all tools via `Tool.getJsonSchema` (the exact function the server calls at `McpServer.ts:617`): 0 non-object roots after the fix.

Not run locally: the full integration/e2e suite and the other packages' builds (CI covers these), and a live OAuth-gated `tools/list` round-trip — the changed path is pure schema generation, which I exercised directly against the real tool definitions.
