### PR TITLE
fix(internal): repair dev attachment downloads and stabilize email e2e

### DIFF
--- a/apps/internal/src/lib/email-attachments.ts
+++ b/apps/internal/src/lib/email-attachments.ts
@@ -54,7 +54,19 @@ export function downloadUrlFor(
 	messageId: string,
 	attachmentId: string,
 ): string {
-	return `${apiBaseUrl()}/v1/email/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}/download`
+	// This URL is baked into an <a href> during SSR, so it must be one the
+	// browser can reach with its session cookie. In dev that means relative:
+	// apiBaseUrl()'s dev-SSR value is the 127.0.0.1 loopback, which would ship
+	// in the HTML and 401 (the browser can't send the Secure cookie there); a
+	// relative path resolves against the page origin instead, whose /v1/* the
+	// Vite dev proxy forwards to the API. In prod apiBaseUrl() is the real API
+	// origin, so the link goes straight there cross-origin like every other
+	// call — no extra hop through the SSR Worker.
+	const base =
+		typeof import.meta !== 'undefined' && import.meta.env?.DEV
+			? ''
+			: apiBaseUrl()
+	return `${base}/v1/email/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}/download`
 }
 
 export function formatBytes(bytes: number): string {

--- a/apps/internal/tests/e2e/helpers/mail-catcher.ts
+++ b/apps/internal/tests/e2e/helpers/mail-catcher.ts
@@ -16,8 +16,11 @@ export interface CatcherMessage {
 }
 
 // Decoded view for the few assertions that need the parsed body/attachments.
+// `Html` is the decoded text/html part — assert formatting against this, not
+// the raw RFC822, whose quoted-printable soft-wraps split long style tags.
 interface ParsedMessage {
 	readonly Text: string
+	readonly Html: string
 	readonly Attachments: ReadonlyArray<{
 		readonly FileName: string
 		readonly ContentType: string
@@ -104,6 +107,7 @@ export async function getMessage(
 	const parsed = await simpleParser(message.mimeMessage)
 	return {
 		Text: parsed.text ?? '',
+		Html: parsed.html || '',
 		Attachments: parsed.attachments.map(a => ({
 			FileName: a.filename ?? '',
 			ContentType: a.contentType,

--- a/apps/internal/tests/e2e/rich-compose.test.ts
+++ b/apps/internal/tests/e2e/rich-compose.test.ts
@@ -4,19 +4,20 @@ import { expect, test } from '@playwright/test'
 
 import {
 	clearCatcher,
+	getMessage,
 	getRawMessage,
 	waitForMessage,
 } from './helpers/mail-catcher'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
-// Rich-compose path. The Tiptap editor inside the compose form is
-// driven through its bubble menu — selecting text exposes Bold,
-// Bullet List, and Link buttons. We trigger formatting via keyboard
-// shortcuts (Cmd+B / Cmd+Shift+8 / Cmd+K-style flow) because the
-// upstream `@react-email/editor` bubble menu DOM is not stable enough
-// for testid-style hooks. The wire-side assertion is what proves the
-// formatting survived: the raw RFC822 must contain `<strong>`, `<ul>`,
-// `<li>`, and an `<a href` tag.
+// Rich-compose path. The Tiptap editor's bubble-menu controls carry no
+// stable testids, so formatting is applied the way a user would: the
+// "- " Markdown rule starts a bullet list, and a double-click word
+// selection plus the stock Cmd+B keymap bolds a word. The proof is
+// wire-side: the decoded text/html part the recipient receives, where the
+// brand renderer emits inline-styled spans — a font-weight span for bold,
+// and <ul>/<li> whose rows wrap their text in <span> — not <strong> or
+// bare list tags.
 //
 // Selectors verified against:
 //   apps/internal/src/components/emails/compose-form.tsx
@@ -47,7 +48,7 @@ test.describe('compose with rich formatting', () => {
 	})
 
 	test.describe('when the user composes with bold + a bullet list', () => {
-		test('should send an HTML body that carries <strong>, <ul>, and <li> on the wire', async ({
+		test('should send an HTML body where bold and a bullet list survive on the wire', async ({
 			page,
 		}) => {
 			const testId = `rich-${Date.now()}`
@@ -62,24 +63,36 @@ test.describe('compose with rich formatting', () => {
 
 			const editor = editorOf(page)
 			await editor.click()
-			// Bold word via Cmd+B (Tiptap's stock keymap)
+			// Build the body: a first line, then a bullet list. The "- "
+			// Markdown input rule fires on typed text and is reliable headless.
+			await editor.pressSequentially('Hello world')
+			await page.keyboard.press('Enter')
+			await editor.pressSequentially('- one')
+			await page.keyboard.press('Enter')
+			await editor.pressSequentially('two')
+			// Bold "Hello" by selecting the word — double-click is a reliable
+			// browser primitive — then toggling Tiptap's stock Cmd+B. Toggling
+			// bold on an empty caret (stored marks) does not survive the typing
+			// that follows in headless Chromium.
+			await editor
+				.locator('p')
+				.filter({ hasText: 'Hello world' })
+				.first()
+				.dblclick({ position: { x: 8, y: 10 } })
 			await page.keyboard.press('Meta+b')
-			await editor.pressSequentially('Hello')
-			await page.keyboard.press('Meta+b')
-			await editor.pressSequentially(' world\n')
-			// Bullet list via the standard Tiptap Markdown shortcut
-			await editor.pressSequentially('- one\n')
-			await editor.pressSequentially('two\n')
 
 			await expect(page.getByTestId('compose-send')).toBeEnabled()
 			await page.getByTestId('compose-send').click()
 
-			// THEN the raw RFC822 carries the formatting on the html part
+			// THEN the decoded html part carries the formatting. The brand
+			// renderer emits inline-styled spans, not <strong> or bare <ul>:
+			// bold is a font-weight span, list rows wrap their text in <span>.
 			const summary = await waitForMessage(recipient)
-			const raw = getRawMessage(summary)
-			expect(raw).toMatch(/<strong>Hello<\/strong>/i)
-			expect(raw).toMatch(/<ul>/i)
-			expect(raw).toMatch(/<li>/i)
+			const html = (await getMessage(summary)).Html
+			expect(html).toMatch(/<span style="font-weight:\s*700">Hello<\/span>/i)
+			expect(html).toMatch(/<ul[^>]*>/i)
+			expect(html).toMatch(/<li[^>]*><span>one<\/span>/i)
+			expect(html).toMatch(/<li[^>]*><span>two<\/span>/i)
 		})
 	})
 

--- a/apps/internal/tests/e2e/send-email.test.ts
+++ b/apps/internal/tests/e2e/send-email.test.ts
@@ -132,8 +132,14 @@ test.describe('compose and send via the mail catcher', () => {
 			// GIVEN Alice opens compose from Pep Casals' company so SuppressionGuard
 			// has a companyId to query against
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
+			// Wait for hydration so the click lands on the wired action, and give
+			// the compose dialog room to mount on a cold dev bundle (mirrors the
+			// attachment spec's rationale).
+			await expect(page.getByTestId('action-compose-email')).toBeEnabled()
 			await page.getByTestId('action-compose-email').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await expect(page.getByTestId('compose-form')).toBeVisible({
+				timeout: 15_000,
+			})
 
 			// WHEN Alice puts the suppressed contact in `to`
 			await page.getByTestId('compose-to').fill(SUPPRESSED_EMAIL)


### PR DESCRIPTION
## What

Fixes the three pre-existing e2e flakes in `apps/internal`'s email suite. One of the three turned out to be a **real dev/worktree bug**, not a flaky test.

## Changes

- **fix: inbound attachment downloads in dev/worktrees.** The attachment chip's `href` was built with `apiBaseUrl()`, whose dev-SSR value is the `127.0.0.1` loopback. That absolute URL got baked into the server-rendered `<a href>`, so the browser couldn't send the Secure session cookie to it — every inbound attachment download `401`'d in local dev and worktrees (for real users, not only the test). The link is now relative in dev, resolving against the page origin whose `/v1/*` Vite forwards to the API. **Prod is unchanged**: there `apiBaseUrl()` is the real API origin, so links still go straight to the API.
- **test: rich-compose.** Bold is applied via a real double-click word selection + Cmd+B (an empty-caret stored mark didn't survive the typing that follows in headless Chromium), and the wire assertions now match the renderer's *actual* output — an inline `font-weight` span and styled `<ul>`/`<li>`, read from the decoded html part instead of raw quoted-printable (whose soft-wraps split long style tags).
- **test: send-email.** Waits for the compose action to hydrate before clicking, with a longer dialog mount timeout.

## Impact

- **No prod behavior change.** The download-URL fix only alters the dev/worktree branch; a prod build compiles to the same direct-to-API URL as before (build-verified).
- No schema/migration, RLS/`organization_id`, wire-shape, auth-boundary, or env-var changes.
- `api-base.ts` is untouched — the fix reuses the existing `apiBaseUrl()` for the prod value.

## Review guide

- The only src change is `downloadUrlFor` in `email-attachments.ts`; the dev/prod branch is the one thing to scrutinize. Key assumption: `/v1/*` is forwarded to the API in dev (Vite `server.proxy`) and prod (the Worker), both confirmed in source. Relative is intentionally dev-only; prod stays absolute.
- The two test changes are mechanical (interaction + assertion shape).

## Tests

- `inbound-attachment` (M4 + M8), `rich-compose` (bold + plain), `send-email` (suppressed) — all green.

## Verification

Ran against the live local stack:
- Gates green: `check`, `check-deps`, `check-types`, `test` (18 tasks), `build` (12 tasks).
- The 3 target specs pass; full suite 76 passed.
- **Live browser download** (real session as `admin@taller.cat`, org taller, M4 thread in the running app): the chip's `href` is now relative (`/v1/email/…/download`), and fetching it returned `200`, `content-type: image/png`, `content-disposition: attachment; filename="photo.png"`, 67 bytes.

## Screenshots

No visual change — the attachment chip renders identically; the fix is the link's target (loopback → relative). The live-download result above is the functional proof (thread capture available on request).

## Deferred

- Two **pre-existing, unrelated** e2e failures, out of scope: `thread-render` (expects 2 message cards but the seed/threading now yields 5) and `api-keys` (minted-key row visibility). Both fail identically in isolation on a fresh seed, on surfaces this PR doesn't touch.
- Minor Lingui catalog drift on `main` (stale source-line references in the `emails/index.tsx` / `inboxes.tsx` `.po` entries — no string changes) surfaced by the pre-commit extract; left for the i18n flow.
