### PR TITLE
feat(ui): add fluid prose typescale for long-form reading

### DIFF
--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -124,6 +124,20 @@
 	--typescale-body-small-line: 1rem;
 	--typescale-body-small-tracking: 0.025rem;
 
+	/* Prose — long-form reading (marketing/content). Fluid sizes + generous
+	 * leading, distinct from the compact fixed Body scale used in dense UI. */
+	--typescale-prose-large-size: clamp(1rem, 0.96rem + 0.21vw, 1.125rem);
+	--typescale-prose-large-line: clamp(1.5rem, 1.44rem + 0.3vw, 1.75rem);
+	--typescale-prose-large-tracking: 0rem;
+
+	--typescale-prose-medium-size: clamp(0.9375rem, 0.9rem + 0.19vw, 1rem);
+	--typescale-prose-medium-line: clamp(1.4rem, 1.34rem + 0.28vw, 1.55rem);
+	--typescale-prose-medium-tracking: 0rem;
+
+	--typescale-prose-small-size: clamp(0.875rem, 0.85rem + 0.13vw, 0.9375rem);
+	--typescale-prose-small-line: clamp(1.3rem, 1.26rem + 0.2vw, 1.4rem);
+	--typescale-prose-small-tracking: 0rem;
+
 	/* Label */
 	--typescale-label-large-size: 0.875rem;
 	--typescale-label-large-line: 1.25rem;


### PR DESCRIPTION
## Summary

Adds a **prose** typescale to `@batuda/ui` for long-form reading copy (marketing/content), distinct from the Material `body` scale which stays compact and fixed for dense UI.

New tokens in `tokens.css` (`--typescale-prose-{large,medium,small}` · size/line/tracking):
- **Fluid sizes** (clamp), like display/headline: e.g. prose-large `16→18px`, prose-medium `15→16px`, prose-small `14→15px`.
- **Generous leading** (~1.5–1.6) tuned for reading, vs `body`'s tighter UI leading.

## Why a new role instead of changing `body`

`body` is consumed across the CRM (`apps/internal`) as compact, fixed UI text — making it fluid/larger would hurt density there. Long-form reading is a different role, so it gets its own scale. This change is **purely additive**: no existing token changes, so all current consumers (including the CRM) are unaffected.

## Scope

`tokens.css` only. The typescale is consumed as raw CSS variables (`var(--typescale-…)`), not via Tailwind `@theme` utilities or a typed registry, so no other wiring is needed. Built into `dist/tokens.css`; `tailwind.css` imports it.

## Consumer

The Engranatge marketing site will route its reading copy (story, subtitles, card descriptions) through `--typescale-prose-*` once this is published, replacing a local body-token override.