### PR TITLE
fix: trust portless's assigned port so local dev sign-in works out of the box

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ API_KEY_RATE_LIMIT_WINDOW_SECONDS=60
 # trusts each git worktree's auto-prefixed origin (`<branch>.batuda.localhost`)
 # so a worktree dev stack works with no per-worktree edits. Wildcards are
 # accepted only under `.localhost` (real-domain wildcards are rejected at boot).
+# No port here on purpose: portless falls back to a non-privileged port (e.g.
+# :1355) when it can't bind 443, and the server folds that exact origin
+# (`https://batuda.localhost:1355`) in from PORTLESS_URL at boot — so a fresh
+# `pnpm dev` signs in out of the box whatever port portless grabbed.
 ALLOWED_ORIGINS=https://batuda.localhost,https://*.batuda.localhost
 # Canonical public app origin for the links the server mints (invitations).
 # Must be one of ALLOWED_ORIGINS — boot fails otherwise.

--- a/apps/internal/playwright.config.ts
+++ b/apps/internal/playwright.config.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
 import { defineConfig, devices } from '@playwright/test'
 
 // Golden-path E2E suite. Hits the running dev stack at
@@ -17,10 +21,25 @@ import { defineConfig, devices } from '@playwright/test'
 // when the next flow's testids land — don't pre-write tests for
 // selectors that don't exist yet.
 
-// Default targets the portless dev URL on :443 (its documented default).
-// Override with E2E_BASE_URL when running against a non-default port,
-// staging, or CI.
-const BASE_URL = process.env['E2E_BASE_URL'] ?? 'https://batuda.localhost'
+// E2E_BASE_URL wins (CI / staging / an explicit port). Otherwise target the
+// portless dev origin: portless can't bind 443 without root, so it falls back to
+// a non-privileged port and records it in ~/.portless/proxy.port — read that so
+// `pnpm test:e2e` hits the same origin the browser does, with no manual export.
+// Fall back to the bare host (portless on its 443 default, or no portless) when
+// the file is absent.
+const portlessPortSuffix = (() => {
+	try {
+		const port = readFileSync(
+			join(homedir(), '.portless', 'proxy.port'),
+			'utf8',
+		).trim()
+		return port && port !== '443' ? `:${port}` : ''
+	} catch {
+		return ''
+	}
+})()
+const BASE_URL =
+	process.env['E2E_BASE_URL'] ?? `https://batuda.localhost${portlessPortSuffix}`
 
 const STORAGE_STATE = 'tests/e2e/.auth/alice.json'
 

--- a/apps/internal/tests/e2e/sign-in.test.ts
+++ b/apps/internal/tests/e2e/sign-in.test.ts
@@ -75,10 +75,12 @@ test.describe('sign-in', () => {
 			await page.getByTestId('login-submit').click()
 
 			// THEN the URL becomes / (NOT //evil.example/) — the open-redirect
-			// vector is closed
+			// vector is closed. The host must be batuda.localhost; the optional
+			// port tolerates portless's non-443 dev port without weakening the
+			// check that an evil host is rejected.
 			// [routes/login.tsx:20-22 — isSafeReturnTo rejects protocol-relative]
 			await page.waitForURL(/\/$/)
-			await expect(page).toHaveURL(/^https:\/\/batuda\.localhost\/$/)
+			await expect(page).toHaveURL(/^https:\/\/batuda\.localhost(:\d+)?\/$/)
 			await expect(page.getByTestId('login-form')).toHaveCount(0)
 		})
 	})

--- a/apps/internal/vite.config.ts
+++ b/apps/internal/vite.config.ts
@@ -32,9 +32,10 @@ const here = dirname(fileURLToPath(import.meta.url))
 //   1. `INTERNAL_API_URL` — explicit override.
 //   2. Derived from `PORTLESS_URL` (set by `portless run`) when the
 //      Vite dev server is itself on `*.batuda.localhost`. This makes
-//      a worktree at `feature-x.batuda.localhost` proxy to its
-//      matching API at `feature-x.api.batuda.localhost` with no per-
-//      worktree env file.
+//      a worktree at `feature-x.batuda.localhost:<port>` proxy to its
+//      matching API at `feature-x.api.batuda.localhost:<port>` — the
+//      same port portless bound (it falls back to a non-privileged port
+//      like :1355 when it can't bind 443) — with no per-worktree env file.
 //   3. Default `https://api.batuda.localhost` for the main checkout.
 const portlessUrl = process.env['PORTLESS_URL']
 const derivedApiTarget = (() => {
@@ -42,9 +43,13 @@ const derivedApiTarget = (() => {
 	const marker = 'batuda.localhost'
 	try {
 		const url = new URL(portlessUrl)
-		if (!url.host.endsWith(marker)) return null
-		const apiHost = url.host.replace(marker, `api.${marker}`)
-		return `${url.protocol}//${apiHost}`
+		if (!url.hostname.endsWith(marker)) return null
+		const apiHost = url.hostname.replace(marker, `api.${marker}`)
+		// Keep portless's bound port (e.g. :1355) so the proxy reaches the API
+		// portless actually serves, and pin https since portless fronts these
+		// hosts with TLS. The default :443 is left off the host.
+		const portSuffix = url.port && url.port !== '443' ? `:${url.port}` : ''
+		return `https://${apiHost}${portSuffix}`
 	} catch {
 		return null
 	}

--- a/apps/server/src/lib/env.test.ts
+++ b/apps/server/src/lib/env.test.ts
@@ -4,6 +4,7 @@ import {
 	buildInvitationCallbackURL,
 	findPublicUrlNotAllowed,
 	findUnsafeWildcardOrigin,
+	mergeWorktreeOrigin,
 } from './env.js'
 
 // Locks in the safety guard that refuses to boot when ALLOWED_ORIGINS
@@ -161,6 +162,74 @@ describe('findPublicUrlNotAllowed', () => {
 			])
 			expect(message).not.toBeNull()
 			expect(message).toContain('APP_PUBLIC_URL')
+		})
+	})
+})
+
+// portless can't bind 443 without privileges, so it falls back to a port like
+// :1355 and the browser's Origin becomes `https://batuda.localhost:1355`. That
+// port is absent from the static ALLOWED_ORIGINS, so the derived app origin must
+// be folded in or every sign-in 403s — the out-of-the-box dev failure this guards.
+describe('mergeWorktreeOrigin', () => {
+	describe('when a worktree app origin is given', () => {
+		it('should prepend the derived port-carrying origin to the trusted list', () => {
+			// GIVEN the static origins (no port) and the portless-derived origin
+			// WHEN they are merged
+			// THEN the ported origin leads the list so CORS + Better-Auth trust it
+			// [lib/env.ts — prepend branch]
+			expect(
+				mergeWorktreeOrigin(
+					['https://batuda.localhost', 'https://*.batuda.localhost'],
+					'https://batuda.localhost:1355',
+				),
+			).toEqual([
+				'https://batuda.localhost:1355',
+				'https://batuda.localhost',
+				'https://*.batuda.localhost',
+			])
+		})
+
+		it('should let the merged list pass the APP_PUBLIC_URL boot check', () => {
+			// GIVEN APP_PUBLIC_URL is the derived ported origin (set the same way in
+			//   EnvVars), absent from the static list
+			// WHEN the merged list is fed to the boot check
+			// THEN it passes — the merge is what keeps boot from failing on the port
+			// [lib/env.ts — mergeWorktreeOrigin feeds findPublicUrlNotAllowed]
+			const appPublicUrl = 'https://batuda.localhost:1355'
+			const merged = mergeWorktreeOrigin(
+				['https://batuda.localhost', 'https://*.batuda.localhost'],
+				appPublicUrl,
+			)
+			expect(findPublicUrlNotAllowed(appPublicUrl, merged)).toBeNull()
+		})
+
+		it('should not duplicate an origin already present in the list', () => {
+			// GIVEN the derived origin already listed literally (portless on 443, no
+			//   port, collapses onto the static entry)
+			// WHEN they are merged
+			// THEN the list is returned unchanged — no duplicate trusted origin
+			// [lib/env.ts — includes() short-circuit]
+			expect(
+				mergeWorktreeOrigin(
+					['https://batuda.localhost', 'https://*.batuda.localhost'],
+					'https://batuda.localhost',
+				),
+			).toEqual(['https://batuda.localhost', 'https://*.batuda.localhost'])
+		})
+	})
+
+	describe('when there is no worktree origin (production)', () => {
+		it('should return the env list unchanged', () => {
+			// GIVEN null (deriveWorktreeOrigins returns null off *.batuda.localhost)
+			// WHEN merged
+			// THEN the explicitly-configured production origins win untouched
+			// [lib/env.ts — null short-circuit]
+			expect(
+				mergeWorktreeOrigin(
+					['https://batuda.co', 'https://engranatge.com'],
+					null,
+				),
+			).toEqual(['https://batuda.co', 'https://engranatge.com'])
 		})
 	})
 })

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -62,6 +62,23 @@ export function findPublicUrlNotAllowed(
 	)
 }
 
+/**
+ * Folds a portless dev worktree's derived app origin into the trusted-origins
+ * list. The browser's real Origin carries the port portless bound (e.g. :1355
+ * when it can't bind 443); without this neither the literal nor the wildcard in
+ * ALLOWED_ORIGINS matches it, so CORS and Better-Auth reject sign-in with 403.
+ * Prepended and de-duplicated so the APP_PUBLIC_URL boot check accepts it too.
+ * Returns the list unchanged off a worktree (production), where env values win.
+ */
+export function mergeWorktreeOrigin(
+	allowedOrigins: string[],
+	worktreeAppOrigin: string | null,
+): string[] {
+	if (worktreeAppOrigin === null) return allowedOrigins
+	if (allowedOrigins.includes(worktreeAppOrigin)) return allowedOrigins
+	return [worktreeAppOrigin, ...allowedOrigins]
+}
+
 export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 	make: Effect.gen(function* () {
 		const DATABASE_URL = yield* Config.redacted('DATABASE_URL')
@@ -131,7 +148,7 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		// ends in `.localhost` — production hosts (`*.example.com`) are
 		// rejected at boot to avoid shipping a broad subdomain-trust hole.
 		// Same array is reused as Better-Auth `trustedOrigins`.
-		const ALLOWED_ORIGINS = yield* Config.string('ALLOWED_ORIGINS').pipe(
+		const allowedOriginsFromEnv = yield* Config.string('ALLOWED_ORIGINS').pipe(
 			Config.map(s => (s ? s.split(',').map(o => o.trim()) : [])),
 			Config.mapOrFail(patterns => {
 				const offending = findUnsafeWildcardOrigin(patterns)
@@ -149,6 +166,16 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 				}
 				return Effect.succeed(patterns)
 			}),
+		)
+
+		// In a portless dev worktree the browser's real Origin carries the port
+		// portless bound (e.g. :1355 when it couldn't bind 443). Merge that derived
+		// app origin into the trusted list so CORS, Better-Auth trustedOrigins, and
+		// the APP_PUBLIC_URL boot check below all accept it — no per-machine
+		// ALLOWED_ORIGINS edit for whichever port portless grabbed.
+		const ALLOWED_ORIGINS = mergeWorktreeOrigin(
+			allowedOriginsFromEnv,
+			worktreeOrigins?.appOrigin ?? null,
 		)
 
 		// Canonical public origin for the links the server mints (invitation

--- a/apps/server/src/lib/portless-origins.test.ts
+++ b/apps/server/src/lib/portless-origins.test.ts
@@ -22,14 +22,42 @@ describe('deriveWorktreeOrigins', () => {
 			})
 		})
 
-		it('should pin https + drop the port for the real portless format', () => {
-			// GIVEN portless's actual PORTLESS_URL (http scheme, :443 port)
+		it('should keep the port portless assigned so it matches the browser origin', () => {
+			// GIVEN portless's real PORTLESS_URL — https with the non-443 port it
+			//   grabbed because it couldn't bind 443 (formatUrl renders https://host:1355)
 			// WHEN origins are derived
-			// THEN the scheme is pinned to https and the port dropped, so they match
-			//   the `https://*.batuda.localhost` CORS wildcard the server trusts
+			// THEN the :1355 port is preserved, so the derived app origin equals the
+			//   browser's Origin header and Better-Auth + CORS trust the sign-in
+			// [lib/portless-origins.ts — portSuffix kept]
+			expect(
+				deriveWorktreeOrigins('https://feature-x.api.batuda.localhost:1355'),
+			).toEqual({
+				apiOrigin: 'https://feature-x.api.batuda.localhost:1355',
+				appOrigin: 'https://feature-x.batuda.localhost:1355',
+			})
+		})
+
+		it('should pin https even when PORTLESS_URL reports an http scheme', () => {
+			// GIVEN an http-scheme PORTLESS_URL (older/non-TLS portless reporting)
+			// WHEN origins are derived
+			// THEN the scheme is pinned to https (the browser always loads these
+			//   hosts over TLS) while the port is still kept
 			// [lib/portless-origins.ts — https pin]
 			expect(
-				deriveWorktreeOrigins('http://feature-x.api.batuda.localhost:443'),
+				deriveWorktreeOrigins('http://feature-x.api.batuda.localhost:1355'),
+			).toEqual({
+				apiOrigin: 'https://feature-x.api.batuda.localhost:1355',
+				appOrigin: 'https://feature-x.batuda.localhost:1355',
+			})
+		})
+
+		it('should drop the default :443 the browser omits from its origin', () => {
+			// GIVEN portless bound the privileged 443 port (an explicit :443)
+			// WHEN origins are derived
+			// THEN the port is dropped, matching the portless-on-443 browser origin
+			// [lib/portless-origins.ts — :443 dropped]
+			expect(
+				deriveWorktreeOrigins('https://feature-x.api.batuda.localhost:443'),
 			).toEqual({
 				apiOrigin: 'https://feature-x.api.batuda.localhost',
 				appOrigin: 'https://feature-x.batuda.localhost',
@@ -55,8 +83,20 @@ describe('deriveWorktreeOrigins', () => {
 			// GIVEN a production-style host
 			// WHEN origins are derived
 			// THEN null — the caller falls back to the configured env values
-			// [lib/portless-origins.ts — endsWith(DEV_MARKER) guard]
+			// [lib/portless-origins.ts — label-boundary marker guard]
 			expect(deriveWorktreeOrigins('https://api.batuda.co')).toBeNull()
+		})
+
+		it('should reject a lookalike host that only suffix-matches the marker', () => {
+			// GIVEN a host that ends in the marker text but not on a label boundary
+			// WHEN origins are derived
+			// THEN null — least trust: `xbatuda.localhost` must not self-derive a
+			//   trusted origin off a bare endsWith() check
+			// [lib/portless-origins.ts — apiHost !== marker && endsWith('.' + marker)]
+			expect(deriveWorktreeOrigins('https://xbatuda.localhost')).toBeNull()
+			expect(
+				deriveWorktreeOrigins('https://api.batuda.localhost.evil.com'),
+			).toBeNull()
 		})
 	})
 

--- a/apps/server/src/lib/portless-origins.ts
+++ b/apps/server/src/lib/portless-origins.ts
@@ -16,21 +16,28 @@ export const deriveWorktreeOrigins = (
 	portlessUrl: string | undefined,
 ): { apiOrigin: string; appOrigin: string } | null => {
 	if (!portlessUrl) return null
-	let apiHost: string
+	let url: URL
 	try {
-		apiHost = new URL(portlessUrl).hostname
+		url = new URL(portlessUrl)
 	} catch {
 		return null
 	}
-	if (!apiHost.endsWith(DEV_MARKER)) return null
+	const apiHost = url.hostname
+	// Match on a label boundary, not a bare suffix: a lookalike host like
+	// `xbatuda.localhost` must not slip through and self-derive a trusted origin.
+	if (apiHost !== DEV_MARKER && !apiHost.endsWith(`.${DEV_MARKER}`)) return null
 	// `<branch>.api.batuda.localhost` → `<branch>.batuda.localhost` (and the main
 	// checkout's `api.batuda.localhost` → `batuda.localhost`).
 	const appHost = apiHost.replace(`api.${DEV_MARKER}`, DEV_MARKER)
-	// portless serves these dev hosts over HTTPS but reports PORTLESS_URL as
-	// `http://…:443`; the browser origin that CORS + cookies must match is always
-	// https, so pin the scheme (and drop the port by using the hostname).
+	// portless fronts these dev hosts with HTTPS, so pin the scheme whatever
+	// PORTLESS_URL reports. Keep the port portless actually bound: it falls back
+	// to a non-privileged port (e.g. :1355) when it can't bind 443, and the
+	// browser's Origin header carries that port — so the derived origin must too,
+	// or CORS + Better-Auth reject the sign-in. The default :443 is dropped
+	// because the browser omits it from the Origin.
+	const portSuffix = url.port && url.port !== '443' ? `:${url.port}` : ''
 	return {
-		apiOrigin: `https://${apiHost}`,
-		appOrigin: `https://${appHost}`,
+		apiOrigin: `https://${apiHost}${portSuffix}`,
+		appOrigin: `https://${appHost}${portSuffix}`,
 	}
 }


### PR DESCRIPTION
## What

Makes batuda's local dev sign-in work out of the box. Surface: **Auth origin trust** — `server` (the derived/trusted origins) plus `internal` (the Vite dev API proxy and the Playwright harness). `portless` can't bind privileged port 443 without root, so it falls back to a non-privileged port (e.g. `:1355`); the browser origin becomes `https://batuda.localhost:1355`, but the dev origin derivation stripped the port. Better Auth's origin matcher is port-sensitive and validates the `Origin` whenever a cookie is present (browsers always send one), so every sign-in returned `403 Invalid origin` on a fresh clone.

## The fix

- Keep portless's assigned port in the derived dev origins (drop only the default `:443`, which the browser omits), and fold the derived **app** origin into `ALLOWED_ORIGINS` so CORS, Better-Auth `trustedOrigins`, and the `APP_PUBLIC_URL` boot check all accept the real browser origin — no per-machine env edit.
- Tightened the dev-marker check to a label boundary, so a lookalike host like `xbatuda.localhost` can't self-derive a trusted origin (least-trust; came out of the security review).
- Point the Vite dev API proxy and the Playwright base URL at portless's actual port. The SSR hard-reload session check proxies through the same target, so the "reload-logs-you-out" path is fixed too.
- The security-sensitive `matchOrigin` is left unchanged — the merged exact literal covers ported origins via exact match, so a wrong port (`:9999`) still 403s.

## Impact

- **`ALLOWED_ORIGINS` / CORS — dev-only, no production change, no coordinated deploy.** The port-carrying origin is derived from `PORTLESS_URL` and gated on the non-routable `.localhost` TLD; production keeps its explicit literal origins (no derivation, no wildcard, `strict` rate limit, secure cookies). An adversarial review confirmed no value of `PORTLESS_URL` can broaden production trust — every derived origin stays under `.localhost`.
- No migration, no RLS / `organization_id` change, no MCP↔HTTP wire-shape change, no new env vars (`PORTLESS_URL` already existed and is dev-only), and no change to the prod auth / route-protection boundary.

## Review guide

- Start at `apps/server/src/lib/portless-origins.ts` (port kept, `:443` dropped, label-boundary guard) and `env.ts` `mergeWorktreeOrigin` (only the app origin is trusted, deduped, returns unchanged off a worktree).
- Riskiest part is the dev/prod boundary. I ran an adversarial security review — prod-injection of a stray `PORTLESS_URL`, port/parser confusion (`:0443`, userinfo, case, trailing dot, IP-literal), and the Better-Auth-vs-repo matcher divergence — and found **no path that broadens production trust; must-fix: none**. `snyk_code_scan` not run (tool unavailable in this environment).
- Full design + security analysis lives in #124.

## Tests

- Unit (`@batuda/server`): port preserved / `:443` dropped / https pinned / lookalike host rejected; `mergeWorktreeOrigin` prepend + dedup, and the merged list passing the `APP_PUBLIC_URL` boot check.
- Real-browser E2E (Playwright + Chromium): sign-in flows + session-persistence, including the SSR-hard-reload-while-authed path.

## Verification

- Gates run green: `pnpm install` (no lockfile drift), `check-types` (12/12), `test` (371 server tests + all packages), `build` (12/12 — including the `internal` SSR bundle that exercises `vite.config.ts`).
- Live: **12/12 real-browser E2E with zero manual config** — the Playwright config auto-derived `https://batuda.localhost:1355` from `~/.portless/proxy.port`. API matrix with a cookie present: trusted `:1355` → 200, untrusted origin and wrong port `:9999` → 403.
- No visual change (dev proxy + test config only), so no screenshots — the real-browser E2E is the behavioral proof.

## Deferred

- Evaluate removing the now-largely-redundant `https://*.batuda.localhost` wildcard from `ALLOWED_ORIGINS`, since each worktree derives its own exact origin.
- Reconcile the Better-Auth-vs-repo wildcard matcher divergence (multi-label vs single-label; dev-only).
- Harden `findUnsafeWildcardOrigin` against suffix-confusion (pre-existing defense-in-depth; prod config is already explicit).

Closes #124.
