### PR TITLE
fix(internal): derive the dev client API origin on portless's port

### DIFF
--- a/apps/internal/.env.example
+++ b/apps/internal/.env.example
@@ -1,13 +1,9 @@
-# Public API base URL for Better Auth + /v1/* fetches.
+# Absolute API origin the browser fetches /v1/* from.
 #
-# In dev this lives on the API portless subdomain. The browser does NOT
-# fetch this URL directly: Vite proxies same-origin `/auth/*` requests to
-# this target so the session cookie lands on `batuda.localhost` instead
-# of `api.batuda.localhost` (cross-subdomain cookies under `localhost`
-# are refused by RFC 6761-aware browsers, which broke reload-after-login
-# until the proxy was added). SSR still fetches this URL absolutely to
-# forward the incoming Cookie header to the API.
-#
-# In prod (real TLD), the browser DOES fetch this URL directly — the
-# parent-domain cookie flows fine across subdomains.
-VITE_SERVER_URL=https://api.batuda.localhost
+# PROD ONLY — injected into the client + SSR bundles at build time
+# (.github/workflows/deploy_web.yml sets it to https://api.batuda.co). In dev
+# the app derives the API origin from the page instead, so it follows whatever
+# port portless bound (e.g. :1355 when it can't bind 443) and each worktree
+# talks to its own API with no per-worktree edit. Leave this unset locally;
+# set it only to point a dev build at a fixed remote API.
+# VITE_SERVER_URL=https://api.batuda.co

--- a/apps/internal/src/lib/batuda-api-atom.test.ts
+++ b/apps/internal/src/lib/batuda-api-atom.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildDevApiOrigin } from '#/lib/batuda-api-atom'
+
+// buildDevApiOrigin is the pure core of the cross-origin API host the data
+// atoms fetch /v1/* from in dev. portless can't bind 443 without root, so it
+// falls back to a port like :1355 and the page origin carries it — the derived
+// API origin must carry the same port or every client-side data call lands on
+// an unreachable :443 host.
+
+describe('buildDevApiOrigin', () => {
+	describe('on the main dev checkout', () => {
+		it('should insert the api host and keep the port portless bound', () => {
+			// GIVEN the page on batuda.localhost at portless's :1355
+			// WHEN the API origin is derived
+			// THEN it points at the api subdomain on the same port
+			// [lib/batuda-api-atom.ts — apiHost + port kept]
+			expect(buildDevApiOrigin('batuda.localhost', '1355', 'https:')).toBe(
+				'https://api.batuda.localhost:1355',
+			)
+		})
+	})
+
+	describe('in a worktree', () => {
+		it('should map the branch subdomain to its matching api host', () => {
+			// GIVEN a worktree page host
+			// WHEN derived
+			// THEN api. is inserted before the marker and the port kept
+			// [lib/batuda-api-atom.ts — apiHost replace]
+			expect(
+				buildDevApiOrigin('feature-x.batuda.localhost', '1355', 'https:'),
+			).toBe('https://feature-x.api.batuda.localhost:1355')
+		})
+
+		it('should derive for a multi-label subdomain too', () => {
+			// GIVEN a host with more than one label under the marker
+			// WHEN derived
+			// THEN api. is still inserted before the marker (label count agnostic,
+			//   unlike the server-side single-label trust matcher)
+			// [lib/batuda-api-atom.ts — apiHost replace]
+			expect(buildDevApiOrigin('a.b.batuda.localhost', '1355', 'https:')).toBe(
+				'https://a.b.api.batuda.localhost:1355',
+			)
+		})
+	})
+
+	describe('when portless is on the default 443', () => {
+		it('should drop the port the browser omits from its origin', () => {
+			// GIVEN portless bound 443 (an explicit :443, or no port at all)
+			// WHEN derived
+			// THEN no port suffix, matching the portless-on-443 browser origin
+			// [lib/batuda-api-atom.ts — port dropped]
+			expect(buildDevApiOrigin('batuda.localhost', '443', 'https:')).toBe(
+				'https://api.batuda.localhost',
+			)
+			expect(buildDevApiOrigin('batuda.localhost', '', 'https:')).toBe(
+				'https://api.batuda.localhost',
+			)
+		})
+	})
+
+	describe('when the page itself is served over http', () => {
+		it('should honor the page scheme rather than pin https', () => {
+			// GIVEN an http page (window.location.protocol is authoritative here,
+			//   unlike the server which pins https because PORTLESS_URL lies)
+			// WHEN derived
+			// THEN the API origin uses the same scheme the page loaded with
+			// [lib/batuda-api-atom.ts — protocol passthrough]
+			expect(buildDevApiOrigin('batuda.localhost', '1355', 'http:')).toBe(
+				'http://api.batuda.localhost:1355',
+			)
+		})
+	})
+
+	describe('off a dev host (production)', () => {
+		it('should return null so VITE_SERVER_URL wins', () => {
+			// GIVEN a production page host
+			// WHEN derived
+			// THEN null — the bundle's VITE_SERVER_URL is the API origin instead
+			// [lib/batuda-api-atom.ts — label-boundary guard]
+			expect(buildDevApiOrigin('app.batuda.co', '', 'https:')).toBeNull()
+		})
+
+		it('should reject a lookalike that only suffix-matches the marker', () => {
+			// GIVEN hosts ending in the marker text but not on a label boundary
+			// WHEN derived
+			// THEN null — least trust: no self-derived origin off a bare endsWith
+			// [lib/batuda-api-atom.ts — label-boundary guard]
+			expect(
+				buildDevApiOrigin('xbatuda.localhost', '1355', 'https:'),
+			).toBeNull()
+			expect(
+				buildDevApiOrigin('batuda.localhost.evil.com', '', 'https:'),
+			).toBeNull()
+		})
+	})
+})

--- a/apps/internal/src/lib/batuda-api-atom.ts
+++ b/apps/internal/src/lib/batuda-api-atom.ts
@@ -15,22 +15,45 @@ const BatudaHttpClientLive = FetchHttpClient.layer.pipe(
 	Layer.provide(Layer.succeed(FetchHttpClient.Fetch, credentialsFetch)),
 )
 
+const DEV_MARKER = 'batuda.localhost'
+
 /**
- * Derives the absolute API host. In production an explicit
- * `VITE_SERVER_URL` is required (built into the bundle). In dev on
- * `*.batuda.localhost` we fall back to a runtime derivation from
- * `window.location.host` so worktree subdomains (e.g.
- * `feature-x.batuda.localhost`) automatically talk to their matching
- * worktree API (`feature-x.api.batuda.localhost`) without a
- * per-worktree env file.
+ * Pure core of the dev API-origin derivation: given the page's location
+ * parts, build the matching cross-origin API host, or null off a
+ * `batuda.localhost` host (production). Split out from the `window` read so
+ * the host/port logic is unit-testable without a DOM.
+ *
+ * A worktree on `feature-x.batuda.localhost` talks to its matching API at
+ * `feature-x.api.batuda.localhost`, on whatever port portless bound.
+ */
+export function buildDevApiOrigin(
+	hostname: string,
+	port: string,
+	protocol: string,
+): string | null {
+	// Match on a label boundary so a lookalike host like `xbatuda.localhost`
+	// can't masquerade as a dev origin.
+	if (hostname !== DEV_MARKER && !hostname.endsWith(`.${DEV_MARKER}`)) {
+		return null
+	}
+	const apiHost = hostname.replace(DEV_MARKER, `api.${DEV_MARKER}`)
+	// Keep portless's port (e.g. :1355 when it can't bind 443) so the
+	// cross-origin /v1 calls reach the API portless actually serves; the
+	// browser omits the default :443 from the origin it sends.
+	const portSuffix = port && port !== '443' ? `:${port}` : ''
+	return `${protocol}//${apiHost}${portSuffix}`
+}
+
+/**
+ * In dev, derives the cross-origin API host from the page so a worktree
+ * automatically talks to its matching worktree API with no per-worktree env
+ * file. Returns null off a dev host (production), where `VITE_SERVER_URL`
+ * (built into the bundle) is the absolute API origin instead.
  */
 function deriveDevApiOrigin(): string | null {
 	if (typeof window === 'undefined') return null
-	const host = window.location.host
-	const marker = 'batuda.localhost'
-	if (!host.endsWith(marker)) return null
-	const apiHost = host.replace(marker, `api.${marker}`)
-	return `${window.location.protocol}//${apiHost}`
+	const { hostname, port, protocol } = window.location
+	return buildDevApiOrigin(hostname, port, protocol)
 }
 
 /**
@@ -59,9 +82,12 @@ export class BatudaApiAtom extends AtomHttpApi.Service<BatudaApiAtom>()(
 	{
 		api: BatudaApi,
 		httpClient: BatudaHttpClientLive,
+		// Dev derives the worktree's own API origin from the page (so it carries
+		// portless's port); `VITE_SERVER_URL` is the prod-only absolute origin
+		// baked into the bundle, used once the page is off a batuda.localhost host.
 		baseUrl:
-			import.meta.env['VITE_SERVER_URL'] ??
 			deriveDevApiOrigin() ??
+			import.meta.env['VITE_SERVER_URL'] ??
 			'https://api.batuda.localhost',
 	},
 ) {}


### PR DESCRIPTION
## What

Fixes client-side `/v1` data being broken in local dev on a non-443 portless — a follow-up to #126, in a module #126 didn't touch (`apps/internal`'s reactive data atoms). portless can't bind 443 without root, so it falls back to a port like `:1355`; client-side data calls were still targeting an unreachable `https://api.batuda.localhost:443`. SSR-rendered initial loads masked it, so it survived #126's sign-in/session E2E.

## The fix

- `batuda-api-atom.ts` derived the cross-origin API host by **stripping the port** (`host.endsWith('batuda.localhost')` is false once the host carries `:1355`) and was overridden anyway by a stale `VITE_SERVER_URL=https://api.batuda.localhost` dev default. Now it derives from the page **keeping the port** (with a label-boundary host guard so a lookalike like `xbatuda.localhost` can't self-derive), and the dev derivation wins over the prod-only `VITE_SERVER_URL`.
- Split the derivation into a pure `buildDevApiOrigin(hostname, port, protocol)` so the host/port logic is unit-testable without a DOM.
- `apps/internal/.env.example` now documents `VITE_SERVER_URL` as prod-only (injected by `deploy_web.yml`); dev derives the origin.

## Impact

- **Dev-only.** Prod is unchanged: the derivation returns null off a `batuda.localhost` host, so prod uses `VITE_SERVER_URL` (`https://api.batuda.co`, injected by `.github/workflows/deploy_web.yml`) exactly as before. No new env vars.
- Relies on #126 (the `ALLOWED_ORIGINS`/`trustedOrigins` `:1355` merge) for the cross-origin `/v1` preflight to pass — already on `main`.
- The same-origin `/auth` path (`api-base.ts`) is untouched.

## Review guide

- Core is `buildDevApiOrigin` in `batuda-api-atom.ts`; the one behavior change is the `baseUrl` reorder (dev derivation now precedes `VITE_SERVER_URL`). Everything else is the window-read wrapper + comments.

## Tests

- 7 unit cases for `buildDevApiOrigin`: port kept, `:443`/empty dropped, multi-label subdomain, protocol passthrough, production null, lookalike host rejected.

## Verification

- Gates green: `check-types` (12/12), internal `test` (14), `build` (12/12 — the bundle that ships this module).
- Live, real browser at `https://batuda.localhost:1355`: client cross-origin `OPTIONS /v1/companies → 204`, `GET /v1/companies → 200` after setting the active org, and `/companies` renders real data. Before the fix those calls targeted an unreachable `:443`.

Follow-up to #126.
