### PR TITLE
refactor(server): drop the redundant ALLOWED_ORIGINS wildcard

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -23,15 +23,20 @@ Run these checks for each target app. Report results before deeper debugging.
 
 ### Portless proxy
 
-All dev URLs route through portless (web at `batuda.localhost`, API at `api.batuda.localhost`). If both apps fail with connection errors, check the proxy first before investigating individual apps.
+All dev URLs route through the portless proxy (web at `batuda.localhost`, API at `api.batuda.localhost`) on whatever port it bound — 443 when it can, otherwise a non-privileged fallback like `:1355`. Grab that port once and reuse it below (the internal app/server ports are portless-assigned, so `lsof -i :3010` finds nothing):
+
+```bash
+P=$(cat ~/.portless/proxy.port 2>/dev/null || echo 443)       # the portless proxy port
+WEB=https://batuda.localhost$([ "$P" = 443 ] || echo ":$P")   # the web origin (drops :443)
+```
+
+If both apps fail with connection errors, check the proxy first: `portless list` shows the registered routes and the local port each proxies to.
 
 ### Server (`api.batuda.localhost`)
 
 ```bash
-curl -sk https://api.batuda.localhost/health 2>/dev/null && echo "OK" || echo "DOWN"
-# If DOWN:
-lsof -i :3010 -sTCP:LISTEN 2>/dev/null | head -5
-# Start: pnpm dev:server
+curl -sk https://api.batuda.localhost:$P/health 2>/dev/null && echo "OK" || echo "DOWN"
+# If DOWN: `portless list` (is api.batuda registered?), then start: pnpm dev:server
 ```
 
 Check the persistent log file at `apps/server/server.log` (survives `node --watch` reloads). Grep for:
@@ -44,13 +49,11 @@ Check the persistent log file at `apps/server/server.log` (survives `node --watc
 ### Web / Internal (`batuda.localhost`)
 
 ```bash
-curl -sk https://batuda.localhost/ 2>/dev/null | head -20 && echo "OK" || echo "DOWN"
-# If DOWN:
-lsof -i :3000 -sTCP:LISTEN 2>/dev/null | head -5
-# Start: pnpm dev:internal
+curl -sk $WEB/ 2>/dev/null | head -20 && echo "OK" || echo "DOWN"
+# If DOWN: `portless list` (is batuda registered?), then start: pnpm dev:internal
 ```
 
-Verify `apps/internal/.env` contains `VITE_SERVER_URL=https://api.batuda.localhost`. Without it, client-side API calls fall back to `http://localhost:3010` which breaks under portless.
+In dev the client derives its API origin from the page (`<host>.api.batuda.localhost`), so `VITE_SERVER_URL` is prod-only — not needed locally. If `/v1/*` data won't load, confirm the page is open on the URL `pnpm dev` printed (with portless's port), not a bare `https://batuda.localhost`.
 
 ## Common issues
 
@@ -62,7 +65,7 @@ After pre-flight, check these in order. Stop when the cause is found.
 - All `RESEARCH_PROVIDER_*` vars set (server crashes without them; use `stub` for local dev)
 - `RESEARCH_PROVIDER_LLM` set (no auto-default; use `stub`)
 - All `RESEARCH_DEFAULT_*` and `RESEARCH_MAX_*` budget/concurrency vars set
-- `ALLOWED_ORIGINS` — the web origin(s): `https://batuda.localhost` plus the `https://*.batuda.localhost` wildcard that trusts each worktree's `<branch>.batuda.localhost`. Production origins must be listed explicitly (a wildcard whose suffix isn't `.localhost` is rejected at boot)
+- `ALLOWED_ORIGINS` — literal web origins, comma-separated (dev: `https://batuda.localhost`); no wildcards (any `*` fails boot). A worktree's `<branch>.batuda.localhost` origin is derived from `PORTLESS_URL` and merged in automatically — no entry needed. Details: `docs/backend.md` → Cross-origin policy
 - `BETTER_AUTH_BASE_URL=https://api.batuda.localhost` (in a worktree the server derives this + `APP_PUBLIC_URL` from `PORTLESS_URL`, so they point at the worktree's own host)
 - `EMAIL_PROVIDER` set explicitly (use `local-inbox` for dev)
 - Run `pnpm cli doctor` for a full automated environment health check
@@ -95,8 +98,8 @@ pnpm cli db reset     # truncate + migrate + seed (nuclear option)
 
 Auth spans server + internal. Both must be running.
 
-1. Verify CORS preflight: `curl -sk -X OPTIONS -H "Origin: https://batuda.localhost" -H "Access-Control-Request-Method: POST" https://api.batuda.localhost/auth/sign-in/email -D - -o /dev/null 2>&1 | grep -i 'access-control'`
-2. Verify session endpoint: `curl -sk https://api.batuda.localhost/auth/get-session`
+1. Verify CORS preflight (`$P`/`$WEB` from the pre-flight): `curl -sk -X OPTIONS -H "Origin: $WEB" -H "Access-Control-Request-Method: POST" https://api.batuda.localhost:$P/auth/sign-in/email -D - -o /dev/null 2>&1 | grep -i 'access-control'`
+2. Verify session endpoint: `curl -sk https://api.batuda.localhost:$P/auth/get-session`
 3. Check `apps/server/server.log` for `http.url="/auth/sign-in/email"` and its status
 4. Verify seed user exists: `pnpm cli seed --preset minimal` (idempotent)
 5. **Active org:** logging in does not set an active organization. If org-scoped pages (companies, emails, templates…) render "Couldn't load … Refresh to try again." and the switcher shows "NO ACTIVE ORGANIZATION", select one: `agent-browser find testid "org-switcher" click` then `find testid "org-switcher-option-<slug>" click` (Better Auth `setActive` + reload). The available `<slug>`s are the `org-switcher-option-*` entries in the open switcher's snapshot — one per membership, or run `pnpm cli data members`.
@@ -137,14 +140,15 @@ pnpm cli worktree down      # drop this worktree's DB + bucket
 pnpm cli worktree prune     # reap DBs/buckets of worktrees that no longer exist
 ```
 
-Verify: `curl -sk https://<label>.api.batuda.localhost/health` and drive
-`agent-browser` against `https://<label>.batuda.localhost` (use the host
-`pnpm cli worktree doctor` prints — portless takes the branch's last path segment).
+Verify: `curl -sk https://<label>.api.batuda.localhost:$P/health` and drive
+`agent-browser` against `https://<label>.batuda.localhost` (use the full URL
+`pnpm cli worktree doctor` prints — host plus portless's port).
 The server derives its own auth/app origins from
 `PORTLESS_URL`, so login, API calls, and minted links (invitations, auth redirects)
 all target the worktree's host automatically — no per-worktree `.env` edits. If the
-server won't boot with an `APP_PUBLIC_URL … not one of ALLOWED_ORIGINS` error, the
-main `.env` is missing the `https://*.batuda.localhost` wildcard — add it there.
+server won't boot with `ALLOWED_ORIGINS does not accept wildcard patterns`, a `.env`
+(main or worktree) still lists `https://*.batuda.localhost` — remove it; the worktree
+origin is derived from `PORTLESS_URL`, no wildcard needed.
 
 ## CLI commands reference
 
@@ -176,7 +180,7 @@ For the full command reference (login flow, navigation, interaction, network ins
 Quick login test:
 
 ```bash
-agent-browser open https://batuda.localhost/login
+agent-browser open "$WEB/login"                               # $WEB from the pre-flight
 agent-browser fill "input[name='email']" "admin@taller.cat"
 agent-browser fill "input[name='password']" "batuda-dev-2026"
 agent-browser click "button[type='submit']"

--- a/.claude/skills/debug-apps/references/agent-browser.md
+++ b/.claude/skills/debug-apps/references/agent-browser.md
@@ -2,6 +2,8 @@
 
 Playwright-based CLI for testing apps as a real user. Already installed in this environment.
 
+> **Dev URLs carry portless's port.** portless binds 443 when it can, otherwise a fallback like `:1355`. The `https://batuda.localhost/…` examples below omit it — substitute the URL `pnpm dev` printed (e.g. `https://batuda.localhost:1355/…`), or prefix with `$(cat ~/.portless/proxy.port)`.
+
 ## Dev login credentials
 
 Created by `pnpm cli seed` (any preset). Defined in `apps/cli/src/commands/seed.ts`:

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -72,7 +72,13 @@ fires the auto-provision/teardown hooks below.
 
 ## CORS / auth (works per worktree, no per-worktree env)
 
-CORS trusts `https://*.batuda.localhost` (wildcard), the session cookie spans `batuda.localhost`,
-and the **server derives its own canonical origins from `PORTLESS_URL`** — so login, API calls,
-and minted links (invitations, auth redirects) all target the *worktree's* host automatically.
-Each worktree's own database keeps sessions/data isolated.
+The **server derives its canonical origins from `PORTLESS_URL`** and merges the worktree's
+`<label>.batuda.localhost:<port>` origin into the trusted set; the session cookie spans
+`batuda.localhost`; and the client derives its `<label>.api.batuda.localhost` API host the same
+way — so login, `/v1` data, API calls, and minted links (invitations, auth redirects) all target
+the *worktree's* host automatically. `ALLOWED_ORIGINS` is literal-only (no `*.batuda.localhost`
+wildcard). Each worktree's own database keeps sessions/data isolated.
+
+A worktree whose `.env` lists `https://*.batuda.localhost` won't boot — `ALLOWED_ORIGINS` is
+literal-only, so remove that line (or re-run `pnpm cli worktree up` to regenerate the `.env`,
+which re-seeds — see Caveats).

--- a/.env.example
+++ b/.env.example
@@ -28,15 +28,14 @@ OAUTH_CLIENT_GC_DAYS=365
 API_KEY_RATE_LIMIT_ENABLED=false
 API_KEY_RATE_LIMIT_MAX=600
 API_KEY_RATE_LIMIT_WINDOW_SECONDS=60
-# The literal trusts the main dev origin; the `*.batuda.localhost` wildcard
-# trusts each git worktree's auto-prefixed origin (`<branch>.batuda.localhost`)
-# so a worktree dev stack works with no per-worktree edits. Wildcards are
-# accepted only under `.localhost` (real-domain wildcards are rejected at boot).
-# No port here on purpose: portless falls back to a non-privileged port (e.g.
-# :1355) when it can't bind 443, and the server folds that exact origin
-# (`https://batuda.localhost:1355`) in from PORTLESS_URL at boot — so a fresh
-# `pnpm dev` signs in out of the box whatever port portless grabbed.
-ALLOWED_ORIGINS=https://batuda.localhost,https://*.batuda.localhost
+# Trusted origins, each listed literally (no wildcards — a `*.host` entry fails
+# boot). A git worktree's branch-prefixed origin (`<branch>.batuda.localhost`)
+# is derived from PORTLESS_URL and merged in at boot, so a worktree dev stack
+# works with no per-worktree edit. No port here on purpose: portless falls back
+# to a non-privileged port (e.g. :1355) when it can't bind 443, and the server
+# folds that exact origin (`https://batuda.localhost:1355`) in from PORTLESS_URL
+# — so a fresh `pnpm dev` signs in out of the box whatever port portless grabbed.
+ALLOWED_ORIGINS=https://batuda.localhost
 # Canonical public app origin for the links the server mints (invitations).
 # Must be one of ALLOWED_ORIGINS — boot fails otherwise.
 APP_PUBLIC_URL=https://batuda.localhost

--- a/apps/server/src/lib/cors.test.ts
+++ b/apps/server/src/lib/cors.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import { matchOrigin } from './cors.js'
 
-// Locks in the wildcard-subdomain rule used by ALLOWED_ORIGINS so the
-// dev-time worktree workflow (portless prepends a branch subdomain to
-// the configured route) keeps working without per-branch env tweaks,
-// and so a typo in the matcher can't accidentally widen what passes
-// CORS in production.
+// Locks in the exact-origin matching ALLOWED_ORIGINS uses (literal origins only,
+// no wildcards). A dev worktree's branch-prefixed origin is derived from
+// PORTLESS_URL and merged into the list, so CORS and the boot check judge every
+// origin the same way — by exact equality, including the port.
 
 describe('matchOrigin', () => {
 	describe('with no origin (same-origin request)', () => {
@@ -15,26 +14,30 @@ describe('matchOrigin', () => {
 			// WHEN the matcher runs
 			// THEN it returns false — the middleware only enforces CORS on
 			//   cross-origin calls, so the request still goes through
-			// [lib/cors.ts:28 — `typeof origin !== 'string'` guard]
+			// [lib/origin-match.ts — undefined-origin guard]
 			expect(matchOrigin(undefined, 'https://batuda.localhost')).toBe(false)
 		})
 	})
 
-	describe('with a literal origin pattern', () => {
+	describe('with a matching origin', () => {
 		it('should match the exact origin', () => {
-			// GIVEN a literal pattern equal to the candidate origin
+			// GIVEN a pattern equal to the candidate origin
 			// WHEN the matcher runs
 			// THEN it returns true
-			// [lib/cors.ts:25 — `origin === pattern` short-circuit]
+			// [lib/origin-match.ts — origin === pattern]
 			expect(
 				matchOrigin('https://batuda.localhost', 'https://batuda.localhost'),
 			).toBe(true)
 		})
+	})
 
-		it('should reject any other origin', () => {
-			// GIVEN a literal pattern
-			// WHEN a non-equal origin is checked
-			// THEN it returns false
+	describe('with a non-matching origin', () => {
+		it('should reject a subdomain of the pattern host', () => {
+			// GIVEN a subdomain of the pattern's host
+			// WHEN the matcher runs
+			// THEN it returns false — without wildcards a subdomain is trusted only
+			//   when listed (or derived + merged) literally
+			// [lib/origin-match.ts — exact match, no subdomain widening]
 			expect(
 				matchOrigin(
 					'https://other.batuda.localhost',
@@ -42,53 +45,17 @@ describe('matchOrigin', () => {
 				),
 			).toBe(false)
 		})
-	})
 
-	describe('with a wildcard subdomain pattern', () => {
-		const PATTERN = 'https://*.batuda.localhost'
-
-		it('should match a single-label subdomain under the suffix', () => {
-			// GIVEN `https://*.batuda.localhost`
-			// WHEN a worktree route like `https://feature-x.batuda.localhost` checks
-			// THEN it is allowed
-			// [lib/cors.ts:34 — single-label wildcard branch]
-			expect(matchOrigin('https://feature-x.batuda.localhost', PATTERN)).toBe(
-				true,
-			)
-		})
-
-		it('should reject the bare suffix host without a subdomain', () => {
-			// GIVEN `https://*.batuda.localhost`
-			// WHEN the bare suffix host is checked
-			// THEN it is not matched (literal listing covers that case)
-			// [lib/cors.ts:39 — empty-sub guard]
-			expect(matchOrigin('https://batuda.localhost', PATTERN)).toBe(false)
-		})
-
-		it('should reject multi-label subdomains', () => {
-			// GIVEN `https://*.batuda.localhost`
-			// WHEN a deeper subdomain like `a.b.batuda.localhost` checks
-			// THEN it is rejected so a leaked DNS record can't satisfy the wildcard
-			// [lib/cors.ts:43 — single-label invariant]
-			expect(matchOrigin('https://a.b.batuda.localhost', PATTERN)).toBe(false)
-		})
-
-		it('should reject mismatched protocols', () => {
-			// GIVEN `https://*.batuda.localhost`
-			// WHEN an http origin checks
-			// THEN it is rejected
-			// [lib/cors.ts:35 — protocol prefix guard]
-			expect(matchOrigin('http://x.batuda.localhost', PATTERN)).toBe(false)
-		})
-
-		it('should reject an attacker-controlled suffix collision', () => {
-			// GIVEN `https://*.batuda.localhost`
-			// WHEN an origin uses the suffix as a *prefix* of its own host
-			//   (e.g. `evil.batuda.localhost.attacker.com`)
-			// THEN it is rejected — wildcard endsWith uses a literal `.suffix`
-			// [lib/cors.ts:38 — `.${suffix}` boundary]
+		it('should reject a port mismatch', () => {
+			// GIVEN the same host on a different port
+			// WHEN the matcher runs
+			// THEN it returns false — an origin includes its port
+			// [lib/origin-match.ts — exact match includes the port]
 			expect(
-				matchOrigin('https://evil.batuda.localhost.attacker.com', PATTERN),
+				matchOrigin(
+					'https://batuda.localhost:1355',
+					'https://batuda.localhost',
+				),
 			).toBe(false)
 		})
 	})

--- a/apps/server/src/lib/cors.ts
+++ b/apps/server/src/lib/cors.ts
@@ -9,9 +9,9 @@ export { matchOrigin }
 
 export const CorsLive = Layer.unwrap(
 	Effect.gen(function* () {
-		// Reads the already-validated ALLOWED_ORIGINS list from EnvVars so
-		// any wildcard-pattern audit (see env.ts) applies here too. Same
-		// array is reused as Better-Auth `trustedOrigins` in lib/auth.ts.
+		// Reads the already-validated ALLOWED_ORIGINS list from EnvVars (the
+		// same literal origins, see env.ts). Same array is reused as Better-Auth
+		// `trustedOrigins` in lib/auth.ts.
 		const env = yield* EnvVars
 		const allowedOrigins = env.ALLOWED_ORIGINS
 

--- a/apps/server/src/lib/env.test.ts
+++ b/apps/server/src/lib/env.test.ts
@@ -3,78 +3,83 @@ import { describe, expect, it } from 'vitest'
 import {
 	buildInvitationCallbackURL,
 	findPublicUrlNotAllowed,
-	findUnsafeWildcardOrigin,
+	findWildcardOrigin,
 	mergeWorktreeOrigin,
 } from './env.js'
 
-// Locks in the safety guard that refuses to boot when ALLOWED_ORIGINS
-// includes a wildcard pattern whose suffix is *not* `.localhost`. Without
-// this rule, a typo or copy-paste error in production env could grant
-// CORS + Better-Auth trust to every subdomain of an externally-resolvable
-// apex (e.g. `https://*.example.com`).
+// Locks in the boot guard that refuses any ALLOWED_ORIGINS entry containing a
+// `*`. Wildcards aren't a valid origin shape — a worktree's branch-prefixed
+// origin is derived from PORTLESS_URL and merged in literally — so a stray
+// `*.host` (dev or a production `*.example.com`) is a config mistake that must
+// fail boot, not silently never match.
 
-describe('findUnsafeWildcardOrigin', () => {
-	describe('with no wildcard patterns', () => {
+describe('findWildcardOrigin', () => {
+	describe('with only literal origins', () => {
 		it('should return null', () => {
 			// GIVEN a list of literal origins
 			// WHEN the validator runs
 			// THEN no offender is reported
-			// [lib/env.ts — first short-circuit branch]
+			// [lib/env.ts — no `*` found]
 			expect(
-				findUnsafeWildcardOrigin([
+				findWildcardOrigin([
 					'https://batuda.localhost',
 					'https://crm.example.com',
 				]),
 			).toBeNull()
 		})
+
+		it('should return null for an empty list', () => {
+			// GIVEN no configured origins
+			// WHEN the validator runs
+			// THEN null (nothing to reject)
+			// [lib/env.ts — empty loop]
+			expect(findWildcardOrigin([])).toBeNull()
+		})
 	})
 
 	describe('with a wildcard under .localhost', () => {
-		it('should accept worktree-friendly localhost wildcards', () => {
-			// GIVEN a wildcard pattern under .localhost
+		it('should report it so boot fails', () => {
+			// GIVEN a dev-style `*.batuda.localhost` wildcard
 			// WHEN the validator runs
-			// THEN no offender is reported (dev worktree subdomains are safe
-			//   because .localhost is not externally resolvable)
-			// [lib/env.ts — endsWith('.localhost') branch]
+			// THEN it is reported — wildcards are rejected even under .localhost; the
+			//   worktree origin is derived from PORTLESS_URL and merged in literally
+			// [lib/env.ts — pattern.includes('*')]
 			expect(
-				findUnsafeWildcardOrigin([
+				findWildcardOrigin([
 					'https://batuda.localhost',
 					'https://*.batuda.localhost',
 				]),
-			).toBeNull()
-		})
-
-		it('should accept the bare localhost suffix', () => {
-			// GIVEN `https://*.localhost`
-			// WHEN the validator runs
-			// THEN it is accepted
-			// [lib/env.ts — `suffix === 'localhost'` short-circuit]
-			expect(findUnsafeWildcardOrigin(['https://*.localhost'])).toBeNull()
+			).toBe('https://*.batuda.localhost')
 		})
 	})
 
-	describe('with a wildcard outside .localhost', () => {
-		it('should report the offending production-style pattern', () => {
-			// GIVEN a wildcard pattern under a routable apex
+	describe('with a wildcard under a routable apex', () => {
+		it('should report the production-style pattern', () => {
+			// GIVEN a `*.example.com` wildcard
 			// WHEN the validator runs
-			// THEN it returns the offending pattern so boot fails loudly
-			// [lib/env.ts — `return pattern` branch]
+			// THEN it is reported so a broad subdomain-trust hole never ships
+			// [lib/env.ts — pattern.includes('*')]
 			expect(
-				findUnsafeWildcardOrigin([
+				findWildcardOrigin([
 					'https://batuda.localhost',
 					'https://*.example.com',
 				]),
 			).toBe('https://*.example.com')
 		})
+	})
 
-		it('should reject sneaky `.localhost.attacker.com` suffixes', () => {
-			// GIVEN a wildcard whose suffix only superficially mentions localhost
+	describe('with several wildcards', () => {
+		it('should report the first one found', () => {
+			// GIVEN more than one wildcard entry
 			// WHEN the validator runs
-			// THEN it is rejected because the suffix doesn't end in `.localhost`
-			// [lib/env.ts — endsWith vs contains]
+			// THEN the first is returned (boot fails on it; order is the env order)
+			// [lib/env.ts — returns on first match]
 			expect(
-				findUnsafeWildcardOrigin(['https://*.localhost.attacker.com']),
-			).toBe('https://*.localhost.attacker.com')
+				findWildcardOrigin([
+					'https://*.batuda.localhost',
+					'https://*.example.com',
+				]),
+			).toBe('https://*.batuda.localhost')
 		})
 	})
 })
@@ -116,16 +121,17 @@ describe('buildInvitationCallbackURL', () => {
 	})
 })
 
-// APP_PUBLIC_URL must be trusted by ALLOWED_ORIGINS (literal or wildcard) or the
-// server refuses to boot, so an invite can't point at a host the app doesn't
-// actually trust. Wildcard matching lets a portless-derived worktree origin pass.
+// APP_PUBLIC_URL must be one of ALLOWED_ORIGINS (matched exactly) or the server
+// refuses to boot, so an invite can't point at a host the app doesn't trust. A
+// portless-derived worktree origin passes because it was merged into the list
+// literally — there is no wildcard widening.
 describe('findPublicUrlNotAllowed', () => {
 	describe('when the public URL is one of the allowed origins', () => {
 		it('should return null', () => {
 			// GIVEN APP_PUBLIC_URL listed literally in ALLOWED_ORIGINS
 			// WHEN the validator runs
 			// THEN it passes (null)
-			// [lib/env.ts — matchOrigin literal branch]
+			// [lib/env.ts — exact-match member]
 			expect(
 				findPublicUrlNotAllowed('https://batuda.co', [
 					'https://admin.batuda.co',
@@ -135,18 +141,33 @@ describe('findPublicUrlNotAllowed', () => {
 		})
 	})
 
-	describe('when the public URL matches an allowed wildcard origin', () => {
-		it('should return null', () => {
-			// GIVEN a derived worktree origin and a `*.batuda.localhost` wildcard
+	describe('when the public URL is a derived worktree origin in the list', () => {
+		it('should return null because it was merged in literally', () => {
+			// GIVEN a derived worktree origin (with its port) listed literally — the
+			//   shape mergeWorktreeOrigin produces in EnvVars
 			// WHEN the validator runs
-			// THEN the wildcard accepts it (the literal isn't listed)
-			// [lib/env.ts — matchOrigin wildcard branch]
+			// THEN it passes by exact match, not via any wildcard
+			// [lib/env.ts — exact-match member]
 			expect(
-				findPublicUrlNotAllowed('https://feature-x.batuda.localhost', [
+				findPublicUrlNotAllowed('https://feature-x.batuda.localhost:1355', [
+					'https://feature-x.batuda.localhost:1355',
 					'https://batuda.localhost',
-					'https://*.batuda.localhost',
 				]),
 			).toBeNull()
+		})
+	})
+
+	describe('when the public URL is a subdomain that is not listed', () => {
+		it('should return a message — no wildcard widens trust to it', () => {
+			// GIVEN a subdomain of a listed host, but not itself listed
+			// WHEN the validator runs
+			// THEN it is rejected — only exact origins pass, no `*.host` widening
+			// [lib/env.ts — non-membership branch]
+			const message = findPublicUrlNotAllowed(
+				'https://other.batuda.localhost',
+				['https://batuda.localhost'],
+			)
+			expect(message).not.toBeNull()
 		})
 	})
 
@@ -179,14 +200,10 @@ describe('mergeWorktreeOrigin', () => {
 			// [lib/env.ts — prepend branch]
 			expect(
 				mergeWorktreeOrigin(
-					['https://batuda.localhost', 'https://*.batuda.localhost'],
+					['https://batuda.localhost'],
 					'https://batuda.localhost:1355',
 				),
-			).toEqual([
-				'https://batuda.localhost:1355',
-				'https://batuda.localhost',
-				'https://*.batuda.localhost',
-			])
+			).toEqual(['https://batuda.localhost:1355', 'https://batuda.localhost'])
 		})
 
 		it('should let the merged list pass the APP_PUBLIC_URL boot check', () => {
@@ -197,7 +214,7 @@ describe('mergeWorktreeOrigin', () => {
 			// [lib/env.ts — mergeWorktreeOrigin feeds findPublicUrlNotAllowed]
 			const appPublicUrl = 'https://batuda.localhost:1355'
 			const merged = mergeWorktreeOrigin(
-				['https://batuda.localhost', 'https://*.batuda.localhost'],
+				['https://batuda.localhost'],
 				appPublicUrl,
 			)
 			expect(findPublicUrlNotAllowed(appPublicUrl, merged)).toBeNull()
@@ -211,16 +228,16 @@ describe('mergeWorktreeOrigin', () => {
 			// [lib/env.ts — includes() short-circuit]
 			expect(
 				mergeWorktreeOrigin(
-					['https://batuda.localhost', 'https://*.batuda.localhost'],
+					['https://batuda.localhost'],
 					'https://batuda.localhost',
 				),
-			).toEqual(['https://batuda.localhost', 'https://*.batuda.localhost'])
+			).toEqual(['https://batuda.localhost'])
 		})
 	})
 
 	describe('when there is no worktree origin (production)', () => {
 		it('should return the env list unchanged', () => {
-			// GIVEN null (deriveWorktreeOrigins returns null off *.batuda.localhost)
+			// GIVEN null (deriveWorktreeOrigins returns null off a batuda.localhost host)
 			// WHEN merged
 			// THEN the explicitly-configured production origins win untouched
 			// [lib/env.ts — null short-circuit]

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -11,22 +11,18 @@ import { matchOrigin } from './origin-match'
 import { deriveWorktreeOrigins } from './portless-origins'
 
 /**
- * Returns the first ALLOWED_ORIGINS pattern that uses a wildcard
- * subdomain whose suffix is NOT under `.localhost`, or `null` if every
- * pattern is safe. Production origins must be listed explicitly so a
- * misconfigured deploy can't grant CORS + Better-Auth trust to every
- * subdomain of an externally-resolvable apex.
+ * Returns the first ALLOWED_ORIGINS pattern that contains a `*` wildcard, or
+ * `null` if every pattern is a literal origin. ALLOWED_ORIGINS holds literal
+ * origins only: each is trusted explicitly, and a dev worktree's branch-prefixed
+ * origin is derived from `PORTLESS_URL` and merged in. A `*.host` entry is a
+ * config mistake — boot fails loudly rather than silently never matching (and a
+ * prod deploy can't grant trust to every subdomain of a routable apex).
  */
-export function findUnsafeWildcardOrigin(
+export function findWildcardOrigin(
 	patterns: ReadonlyArray<string>,
 ): string | null {
 	for (const pattern of patterns) {
-		const wildcardAt = pattern.indexOf('://*.')
-		if (wildcardAt === -1) continue
-		const suffix = pattern.slice(wildcardAt + '://*.'.length)
-		if (suffix === 'localhost') continue
-		if (suffix.endsWith('.localhost')) continue
-		return pattern
+		if (pattern.includes('*')) return pattern
 	}
 	return null
 }
@@ -47,9 +43,10 @@ export function buildInvitationCallbackURL(
 /**
  * Returns an explanatory message if `publicUrl` is not trusted by
  * `allowedOrigins`, else `null`. APP_PUBLIC_URL must be a trusted origin so the
- * links the server mints can't point at a host it won't serve. Matched with the
- * same wildcard rules as CORS, so a derived worktree origin
- * (`<branch>.batuda.localhost`) is accepted by the `*.batuda.localhost` wildcard.
+ * links the server mints can't point at a host it won't serve. Matched the same
+ * way as CORS (exact origin), so a derived worktree origin
+ * (`<branch>.batuda.localhost:<port>`) passes because it was merged into
+ * ALLOWED_ORIGINS, not via any wildcard.
  */
 export function findPublicUrlNotAllowed(
 	publicUrl: string,
@@ -65,8 +62,8 @@ export function findPublicUrlNotAllowed(
 /**
  * Folds a portless dev worktree's derived app origin into the trusted-origins
  * list. The browser's real Origin carries the port portless bound (e.g. :1355
- * when it can't bind 443); without this neither the literal nor the wildcard in
- * ALLOWED_ORIGINS matches it, so CORS and Better-Auth reject sign-in with 403.
+ * when it can't bind 443); without this the literal in ALLOWED_ORIGINS doesn't
+ * match it, so CORS and Better-Auth reject sign-in with 403.
  * Prepended and de-duplicated so the APP_PUBLIC_URL boot check accepts it too.
  * Returns the list unchanged off a worktree (production), where env values win.
  */
@@ -91,8 +88,8 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		// In a dev worktree portless sets PORTLESS_URL to this worktree's own api
 		// host (`<branch>.api.batuda.localhost`); derive the matching origins so the
 		// server's canonical base and the links it mints use the worktree's host,
-		// not the main checkout's. Null off `*.batuda.localhost` (prod), where the
-		// explicit env values below win. Mirrors apps/internal/vite.config.ts.
+		// not the main checkout's. Null off a `batuda.localhost` host (prod), where
+		// the explicit env values below win. Mirrors apps/internal/vite.config.ts.
 		const PORTLESS_URL = yield* Config.string('PORTLESS_URL').pipe(
 			Config.withDefault(''),
 		)
@@ -141,25 +138,25 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		const API_KEY_RATE_LIMIT_WINDOW_SECONDS = yield* Config.int(
 			'API_KEY_RATE_LIMIT_WINDOW_SECONDS',
 		)
-		// Comma-separated list of trusted origins (e.g.
-		// `https://batuda.localhost`). Each entry is either a literal
-		// origin matched exactly or a wildcard-subdomain pattern
-		// `https://*.host`. Wildcards are accepted only when the suffix
-		// ends in `.localhost` — production hosts (`*.example.com`) are
-		// rejected at boot to avoid shipping a broad subdomain-trust hole.
-		// Same array is reused as Better-Auth `trustedOrigins`.
+		// Comma-separated list of trusted origins, each a literal origin
+		// (`https://batuda.localhost` / `https://host:port`) matched exactly.
+		// Wildcards are not supported: a dev worktree's branch-prefixed origin
+		// is derived from PORTLESS_URL and merged in below, so every trusted
+		// origin is listed explicitly. A `*.host` entry fails boot rather than
+		// silently never matching. Same array is reused as Better-Auth
+		// `trustedOrigins`.
 		const allowedOriginsFromEnv = yield* Config.string('ALLOWED_ORIGINS').pipe(
 			Config.map(s => (s ? s.split(',').map(o => o.trim()) : [])),
 			Config.mapOrFail(patterns => {
-				const offending = findUnsafeWildcardOrigin(patterns)
+				const offending = findWildcardOrigin(patterns)
 				if (offending !== null) {
 					return Effect.fail(
 						new Config.ConfigError(
 							new ConfigProvider.SourceError({
 								message:
-									`ALLOWED_ORIGINS rejects wildcard pattern "${offending}": ` +
-									'wildcard subdomains are only allowed under .localhost. ' +
-									'List each production origin explicitly.',
+									`ALLOWED_ORIGINS does not accept wildcard patterns (got "${offending}"). ` +
+									'List each origin literally; a dev worktree derives its own origin ' +
+									'from PORTLESS_URL.',
 							}),
 						),
 					)

--- a/apps/server/src/lib/origin-match.ts
+++ b/apps/server/src/lib/origin-match.ts
@@ -1,20 +1,13 @@
 /**
- * Origin matching for ALLOWED_ORIGINS. Each pattern is either a literal
- * origin (`https://host` / `https://host:port`) matched exactly, or a
- * wildcard-subdomain pattern (`https://*.host`) that matches any single
- * additional subdomain segment under `host`.
- *
- * Wildcards are scoped to subdomains only — the protocol and the suffix
- * after `*.` must match literally — so `https://*.batuda.localhost`
- * accepts `https://worktree-foo.batuda.localhost` but never
- * `https://attacker.com` or `https://evil.batuda.localhost.attacker.com`.
- * Listing every allowed origin explicitly is still preferred in
- * production; the wildcard exists so dev worktrees (e.g. portless
- * branch-prefixed routes) don't need a fresh ALLOWED_ORIGINS entry per
- * branch.
+ * Exact-match check for ALLOWED_ORIGINS. Every pattern is a literal origin
+ * (`https://host` / `https://host:port`) compared verbatim — there are no
+ * wildcard patterns. A dev worktree's branch-prefixed origin is trusted by
+ * deriving it from `PORTLESS_URL` and merging it into ALLOWED_ORIGINS (see
+ * lib/env.ts), so every trusted origin is listed explicitly rather than via a
+ * broad `*.host` subdomain grant.
  *
  * Shared by the CORS middleware (lib/cors.ts) and the APP_PUBLIC_URL boot
- * check (lib/env.ts), so both judge a derived worktree origin the same way.
+ * check (lib/env.ts), so both judge an origin the same way.
  */
 export const matchOrigin = (
 	origin: string | undefined,
@@ -24,19 +17,5 @@ export const matchOrigin = (
 	// middleware passes `undefined` here. Treat that as no-match — the
 	// browser only enforces CORS on cross-origin requests anyway.
 	if (typeof origin !== 'string') return false
-	if (origin === pattern) return true
-	const wildcardPrefix = '://*.'
-	const wildcardAt = pattern.indexOf(wildcardPrefix)
-	if (wildcardAt === -1) return false
-	const protocol = pattern.slice(0, wildcardAt + 3) // includes "://"
-	const suffix = pattern.slice(wildcardAt + wildcardPrefix.length) // host after "*."
-	if (!origin.startsWith(protocol)) return false
-	const host = origin.slice(protocol.length)
-	if (!host.endsWith(`.${suffix}`)) return false
-	const sub = host.slice(0, host.length - suffix.length - 1)
-	if (sub.length === 0) return false
-	if (sub.includes('/')) return false
-	// Wildcard matches a single label so `a.b.host` doesn't accidentally
-	// satisfy `*.host`. Multi-segment wildcards would need their own pattern.
-	return !sub.includes('.')
+	return origin === pattern
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -415,7 +415,7 @@ The `batuda.co/*` Workers Route is bound out-of-band, not by the deploy.
 
 ### Tenant marketing sites
 
-Each tenant deploys its own public site from its own repo. The first tenant is Engranatge: its marketing repo (`engranatge-marketing`) deploys to KraftCloud (service `engranatge-marketing` → `engranatge.com`). No coupling to this repo except the server's CORS allow-list (`ALLOWED_ORIGINS` includes the tool origin `https://batuda.co` and each tenant origin, e.g. `https://engranatge.com`).
+Each tenant deploys its own public site from its own repo. The first tenant is Engranatge: its marketing repo (`engranatge-marketing`) deploys to KraftCloud (service `engranatge-marketing` → `engranatge.com`). No coupling to this repo except the server's CORS allow-list — `ALLOWED_ORIGINS` lists the tool origin `https://batuda.co` and each tenant origin (e.g. `https://engranatge.com`) as literal entries (see [backend.md → Cross-origin policy](backend.md#cross-origin-policy)).
 
 The server runs on Unikraft (stateless Node.js, scales to zero when idle); the web app runs on Cloudflare Workers (SSR at the edge).
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -604,7 +604,7 @@ npx @modelcontextprotocol/inspector -- pnpm --filter @batuda/server dev:mcp
 echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{"elicitation":{}},"clientInfo":{"name":"test","version":"0.1"}}}' | pnpm --filter @batuda/server dev:mcp
 
 # HTTP endpoint
-curl -X POST http://localhost:3010/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}'
+curl -X POST -k https://api.batuda.localhost:$(cat ~/.portless/proxy.port 2>/dev/null || echo 443)/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}'
 
 # Claude Code — .mcp.json already configures the batuda stdio server
 ```
@@ -627,7 +627,7 @@ Key files:
 
 ### Cross-origin policy
 
-The Batuda web app lives on `:3000`, this API on `:3010`, and the tenant marketing site on `:3001` — every request is cross-origin. CORS is wired as a global `HttpRouter.middleware` in `src/main.ts` via `HttpMiddleware.cors({ allowedOrigins, credentials: true, ... })`, with `allowedOrigins` read from `ALLOWED_ORIGINS` env (comma-separated) and falling back to `http://localhost:3000,http://localhost:3001` in dev. The same env var is fed to Better-Auth as `trustedOrigins` in `src/lib/auth.ts` so both layers agree on what's legitimate. `credentials: true` is required for the browser to attach the `batuda.session_token` cookie on fetch calls that use `credentials: 'include'`.
+The web app and the API are different origins. In dev, portless serves the app at `https://batuda.localhost` and the API at `https://api.batuda.localhost` — binding 443 when it can, otherwise a non-privileged port like `:1355`, which it prints on startup; in prod the app (Cloudflare Workers, `batuda.co`) and API (Unikraft, `api.batuda.co`) split the same way. The browser fetches `/auth/*` same-origin (the Vite dev proxy / Worker forwards them to the API, so the session cookie lands on the app host) and `/v1/*` cross-origin to the API host. CORS is a global `HttpRouter.middleware` in `src/main.ts` via `HttpMiddleware.cors({ allowedOrigins, credentials: true, ... })`; `allowedOrigins` comes from the **required** `ALLOWED_ORIGINS` env — comma-separated **literal** origins matched exactly, with no wildcards (any `*` fails boot) and no dev fallback (boot fails if unset). The same array is fed to Better-Auth as `trustedOrigins` (`src/lib/auth.ts`) so CORS and CSRF agree, and `credentials: true` lets the browser attach the `__Secure-batuda.session_token` cookie on `credentials: 'include'` fetches. A git-worktree dev stack needs no per-worktree origin config: the server derives the worktree's `<branch>.batuda.localhost` origin from `PORTLESS_URL` and merges it into the trusted set (see the `worktrees` skill).
 
 ### Invite-only signup
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,15 +122,15 @@ pnpm dev:server
 pnpm dev:internal
 ```
 
-Dev URLs use portless `*.localhost` hostnames (no `/etc/hosts` edit needed on modern macOS/Linux):
+Dev URLs use portless `*.localhost` hostnames (no `/etc/hosts` edit needed on modern macOS/Linux). portless binds 443 when it can, otherwise a non-privileged port (e.g. `:1355`) — so **open the exact URL the dev server prints on startup** (it carries that port; the hosts below omit it):
 
-- API: [https://api.batuda.localhost](https://api.batuda.localhost)
-- API docs (Scalar): [https://api.batuda.localhost/docs](https://api.batuda.localhost/docs)
-- Batuda web app: [https://batuda.localhost](https://batuda.localhost)
+- API: `https://api.batuda.localhost`
+- API docs (Scalar): `https://api.batuda.localhost/docs`
+- Batuda web app: `https://batuda.localhost`
 
 Each tenant runs its own public marketing site from a separate repo (e.g. the Engranatge tenant uses `engranatge-marketing`). Run the tenant's own `pnpm dev` if you need the full loop against a local CRM.
 
-Log in at `/sign-in` with the admin credentials you set in Step 5.
+Log in at `/login` with the admin credentials you set in Step 5.
 
 ---
 


### PR DESCRIPTION
## What

Removes the `https://*.batuda.localhost` wildcard from `ALLOWED_ORIGINS` — a follow-up to #126/#127. The wildcard predated per-worktree origin derivation: now the server derives a worktree's branch-prefixed origin from `PORTLESS_URL` and merges it into the trusted set literally, so the wildcard granted nothing on portless's non-443 port and only widened subdomain trust on 443. Surface: `server` origin/CORS/CSRF trust.

## Changes

- `origin-match.ts` — `matchOrigin` is exact-match only (the wildcard-subdomain branch is gone).
- `env.ts` — `findUnsafeWildcardOrigin` → `findWildcardOrigin`: any `*` in `ALLOWED_ORIGINS` is a hard boot error (subsumes the old suffix-confusion guard).
- `.env.example` — `ALLOWED_ORIGINS=https://batuda.localhost` (no wildcard).
- worktrees skill — CORS note corrected (derivation + merge, literal-only).

## Impact

- **Breaking (dev), by design — clean break, no shim.** A `*.host` entry in `ALLOWED_ORIGINS` now fails boot. **Existing `.env` files carry it**: the root `.env` and every pre-existing worktree `.env` (e.g. `inline-invitations`) list `https://*.batuda.localhost` and must drop that line (or re-run `pnpm cli worktree up` to regenerate) before the server boots. Contributors do the same one-line edit once.
- **Security: trust is tightened.** Only exact origins are trusted (plus each worktree's own derived origin). The broad `*.batuda.localhost` subdomain grant — which would trust *any* subdomain on a portless-on-443 setup — is gone.
- **Prod unchanged.** Production `ALLOWED_ORIGINS` was always literal (`deploy_web.yml` / `.env.example.github`); no deploy coordination needed. Worktrees keep working via the derived merge (verified below).

## Tests

- `findWildcardOrigin`: literal-only → null, empty → null, `.localhost` wildcard → reported, routable wildcard → reported, first-of-several → reported.
- `matchOrigin`: undefined-origin → false, exact match → true, subdomain → false, **port mismatch → false**.
- `findPublicUrlNotAllowed`: derived worktree origin passes by exact match (merged), an unlisted subdomain is rejected (no widening).

## Verification

- Gates green: `check-types` (12/12), `test` (18/18), `build` (12/12).
- **Real server test** (booted the server with a worktree-style `PORTLESS_URL`, wildcard removed):

| Scenario | Result |
|---|---|
| wildcard in `ALLOWED_ORIGINS` | **boot fails** with the literal-only message |
| `feature-x.batuda.localhost:1355` (worktree's own, derived+merged) | **200** — trusted without the wildcard |
| `other-branch.batuda.localhost:1355` (a different worktree) | **403** — no broad subdomain trust |
| `evil.batuda.localhost:1355` | **403** |
| `batuda.localhost` (listed literally) | **200** |

The worktree origin-trust mechanism (what this PR changes) is exercised directly; the client/cookie flow is unchanged from #126/#127.

## Review guide

- Start at `origin-match.ts` (now `origin === pattern` + the undefined-origin guard) and `env.ts` `findWildcardOrigin`. The per-worktree trust rides `mergeWorktreeOrigin` (unchanged), not the wildcard.
- The deliberate breaking change is the boot guard — see Impact. Confirm the clean-break framing matches your intent.

Follow-up to #126 and #127.


## Docs (folded in)

Origin/CORS docs corrected for the current portless + literal-origin model, with one canonical explanation cross-referenced (not duplicated):

- **`docs/backend.md` → Cross-origin policy** — rewritten as the canonical reference (portless dev origins incl. the non-443 port, literal-only `ALLOWED_ORIGINS`, per-worktree `PORTLESS_URL` derivation + merge, no wildcard, no dev fallback). The stale `:3000/:3010/:3001` model and the non-existent `localhost:3000` fallback are gone.
- **`docs/architecture.md`** — cross-references the above instead of restating it.
- **`docs/getting-started.md`** — dev URLs point at the portless-printed URL (may carry a port); `/sign-in` → `/login`.
- **`.claude/skills/debug-apps`** — fixed an *actively wrong* instruction (it told you to **add** `*.batuda.localhost` to `.env` on a boot error — that now fails boot; corrected to **remove** it); `VITE_SERVER_URL` noted as prod-only (dev derives the client API origin from the page).

_Deferred:_ `debug-apps`/`backend.md` still carry pre-portless **port-model diagnostics** (`lsof -i :3010/:3000`, no-port `curl` URLs) — a separate cleanup, not origin/wildcard-related.
