### PR TITLE
ai: add opencode config with MCP servers, formatters, and guards plugin

### DIFF
--- a/.opencode/plugins/batuda-guards.js
+++ b/.opencode/plugins/batuda-guards.js
@@ -1,0 +1,79 @@
+export const BatudaGuards = async ({ client, $, directory }) => {
+	return {
+		'tool.execute.before': async (input, output) => {
+			const tool = input.tool
+			const args = output.args ?? {}
+
+			// ── write/edit guards ────────────────────────────────────────
+			if (tool === 'write' || tool === 'edit') {
+				const filePath = args.filePath ?? ''
+
+				// Block writes to migrations with invalid filename format.
+				// Edits to existing migrations ask via the permission config.
+				if (
+					tool === 'write' &&
+					filePath.includes('apps/server/src/db/migrations/')
+				) {
+					const filename = filePath.split('/').pop() ?? ''
+					if (!/^\d{4}_[a-z_]+\.ts$/.test(filename)) {
+						throw new Error(
+							'Migration must match NNNN_description.ts (e.g. 0002_add_contacts.ts)',
+						)
+					}
+				}
+
+				if (filePath.includes('apps/server/src/db/migrations/')) {
+					const ts = new Date().toISOString().replace('T', ' ').slice(0, 19)
+					await $`printf '[%s] %s\n' ${ts} ${filePath} >> ${directory}/.opencode/migration-audit.log`.nothrow()
+				}
+			}
+
+			// ── bash guards ──────────────────────────────────────────────
+			if (tool === 'bash') {
+				const cmd = args.command ?? ''
+				// Block bare --force/-f pushes; allow --force-with-lease.
+				if (
+					/git push/.test(cmd) &&
+					!/--force-with-lease/.test(cmd) &&
+					/(\s--force(\s|$)|\s-f(\s|$))/.test(cmd)
+				) {
+					throw new Error(
+						'Force push is destructive. Use --force-with-lease or ask the user first.',
+					)
+				}
+			}
+		},
+
+		// Injects the current branch into the system prompt every turn so
+		// the AI always knows which worktree / feature branch it is in.
+		'experimental.chat.system.transform': async (input, output) => {
+			const branch = await $`git -C ${directory} rev-parse --abbrev-ref HEAD`
+				.text()
+				.catch(() => null)
+			if (branch) {
+				output.system += `\n\n[Current git branch: ${branch.trim()}]`
+			}
+		},
+
+		// Re-injects critical rules after context compaction so the AI does
+		// not abandon planned workflows mid-session.
+		'experimental.session.compacting': async (input, output) => {
+			output.context.push(`## Critical rules (must be followed even after compaction)
+
+- **Never read .env files.** Use Config.string() / Config.redacted() in Effect code.
+- **Migration filenames:** apps/server/src/db/migrations/ files must match \`NNNN_description.ts\` (e.g. \`0003_add_contacts.ts\`). Never edit an existing migration; create a new one.
+- **After editing packages/domain/src/schema/:** check whether a new Effect SQL migration is needed.
+- **After editing apps/internal/src/ with Lingui macros** (<Trans>, useLingui, msg\`): run \`pnpm -F @batuda/internal i18n:extract\`, translate new msgids in non-en messages.po, then \`pnpm -F @batuda/internal i18n:check\` before ending the turn.
+- **Never force-push.** Use \`git push --force-with-lease\` or ask first.
+- **Dates:** prefer \`DateTime.nowUnsafe()\` + \`toDateUtc()\` / \`formatIso()\` and SQL \`now()\` over \`new Date()\`.
+- **Filenames:** kebab-case for all files including React components.
+- **Env vars:** name the capability, not the vendor (\`STORAGE_*\`, \`EMAIL_*\`, never \`R2_*\`, \`AGENTMAIL_*\`).`)
+		},
+
+		// Provision a linked worktree's database + bucket on session start.
+		// The script exits 0 in non-worktree contexts and on all error paths.
+		'session.created': async () => {
+			await $`${directory}/.claude/hooks/worktree-up.sh`.quiet().nothrow()
+		},
+	}
+}

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,46 @@
+{
+	"$schema": "https://opencode.ai/config.json",
+	"mcp": {
+		"batuda": {
+			"type": "remote",
+			"url": "https://api.batuda.co/mcp",
+			"oauth": false,
+			"headers": {
+				"x-api-key": "{env:BATUDA_API_KEY}"
+			}
+		},
+		"cloudflare-api": {
+			"type": "remote",
+			"url": "https://mcp.cloudflare.com/mcp"
+		},
+		"neon": {
+			"type": "local",
+			"command": [
+				"sh",
+				"-c",
+				"exec npx -y @neondatabase/mcp-server-neon start \"$NEON_API_KEY\""
+			]
+		}
+	},
+	"permission": {
+		"edit": {
+			"apps/server/src/db/migrations/0*.ts": "ask"
+		}
+	},
+	"formatter": {
+		"biome": {
+			"command": [
+				"biome",
+				"check",
+				"--write",
+				"--no-errors-on-unmatched",
+				"$FILE"
+			],
+			"extensions": [".ts", ".tsx", ".json"]
+		},
+		"dprint": {
+			"command": ["dprint", "fmt", "$FILE"],
+			"extensions": [".md"]
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds an opencode configuration to mirror the existing Claude Code setup in \`.claude/\`. The goal is to have parity between the two tools — same MCP servers, same post-edit formatting, and the same behavioural guards (migration filename enforcement, force-push block, worktree provisioning).

## Changes

- Wired batuda (remote, API key header), cloudflare-api (OAuth), and neon (local stdio) as MCP servers — same three as \`.mcp.json\`.
- Configured biome (\`check --write\`) and dprint as native opencode formatters, replacing what was a \`PostToolUse\` shell hook in Claude Code.
- Added \`.opencode/plugins/batuda-guards.js\`: blocks writes to migrations with bad filenames and force-pushes without \`--force-with-lease\`; audits migration writes to a log; injects the current git branch into the system prompt every turn; re-injects critical project rules (lingui extract, migration format, no \`.env\` reads, DateTime, kebab-case, env var naming) into context after compaction; runs \`worktree-up.sh\` on \`session.created\`.

## Impact

No impact on the running application. These files are read by opencode only — not by the server, CI, or any test suite. No new env vars, no schema changes, no deploy coupling.

The \`.opencode/plugins/\` directory is auto-loaded by opencode; no entry in \`opencode.json\` is needed to activate the plugin.

## Review guide

The only non-obvious design decision: soft reminders (lingui extract, domain schema migration check) that were \`systemMessage\` injections in Claude Code can't be fed back to the AI inline in opencode's current plugin API. They're in \`experimental.session.compacting\` instead — the AI sees them, but only at compaction time, not per-edit. Tracked in [anomalyco/opencode#27364](https://github.com/anomalyco/opencode/issues/27364).

\`WorktreeRemove\` teardown (\`worktree-down.sh\`) has no opencode lifecycle equivalent yet. Tracked in [anomalyco/opencode#15680](https://github.com/anomalyco/opencode/issues/15680).

## Verification

Pre-commit: biome + type-check (12 packages, all cache hit). Pre-push: full test suite green. Config-only change — no live-stack verification needed.