### PR TITLE
feat(cli): env-file visibility in doctor + CLI/TUI parity fixes

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -203,6 +203,7 @@ Media goes **with the PR** — never on a side branch. Two paths:
 
 - One-time per-laptop config (gitignored `.env.pr-media`, copied from `.env.example.pr-media`, filled from the team vault): `GITHUB_MEDIA_S3_ENDPOINT` + `GITHUB_MEDIA_S3_ACCESS_KEY_ID` + `GITHUB_MEDIA_S3_SECRET_ACCESS_KEY` + `GITHUB_MEDIA_PUBLIC_BASE` (the bucket's public r2.dev/custom URL — public access is required, since GitHub fetches the media unauthenticated). Namespaced `GITHUB_MEDIA_S3_*` so they never collide with the backend `STORAGE_*` or a teammate's `AWS_*`; the script maps them to `AWS_*` for the one subprocess. The `aws`, `cwebp`, and `ffmpeg` CLIs come from the nix dev shell (`flake.nix`), so `nix develop` / direnv covers it. Bucket + script are shared; only the keys are per-person.
 - If a var is missing the script exits naming it; fall back to the manual path.
+- **Worktree gotcha:** `.env.pr-media` is gitignored, so it exists only in the main checkout — a worktree never has it. From a worktree session, run `gh-pr-media.sh` from the main checkout (or source the config from there); don't conclude the automated path is unavailable just because the file is missing in the worktree. `pnpm cli doctor` lists this file's status to make the gap visible.
 
 **Manual (human) — GitHub user-attachments.** Drag the file into the PR description in the web UI; GitHub mints a `user-attachments` URL bound to the PR (a `.webm` becomes an inline player). Use this when no R2 token is set up — leave a `> _Drag the <thing> in here._` placeholder in the body so the spot is obvious.
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -669,11 +669,18 @@ const emailInjectCommand = Command.make(
 	{
 		to: Flag.string('to').pipe(
 			Flag.withDescription('Recipient address (must match a seeded inbox)'),
+			Flag.withFallbackPrompt(
+				Prompt.text({ message: 'To (a seeded inbox address):' }),
+			),
 		),
 		from: Flag.string('from').pipe(
 			Flag.withDescription('Sender address (any value works locally)'),
+			Flag.withFallbackPrompt(Prompt.text({ message: 'From:' })),
 		),
-		subject: Flag.string('subject').pipe(Flag.withDescription('Subject line')),
+		subject: Flag.string('subject').pipe(
+			Flag.withDescription('Subject line'),
+			Flag.withFallbackPrompt(Prompt.text({ message: 'Subject:' })),
+		),
 		text: Flag.string('text').pipe(
 			Flag.withDescription('Plain-text body'),
 			Flag.optional,
@@ -727,13 +734,35 @@ const emailCommand = Command.make('email').pipe(
 // definition here (rather than in a separate `cli-tree.ts`) avoids splitting
 // the file just to share one const; the `isMain` guard below makes import
 // safe by deferring `runMain` until cli.ts is the entry script.
+// The TUI runs a leaf with no argv, so an entity picker only appears if the
+// argument itself prompts. Gate that prompt on an interactive stdin: the TUI
+// and a bare interactive `data` get the picker, while piped / non-TTY callers
+// (CI, scripts, agents) fall straight to the overview instead of blocking on a
+// prompt nothing will ever answer. `optional` stays outermost either way, so a
+// provided `data <entity>` skips the prompt and Esc lands on the overview.
+const dataEntityArg = (() => {
+	const base = Argument.choice('entity', ENTITY_NAMES).pipe(
+		Argument.withDescription(
+			'Seeded entity to list; omit (or Esc the prompt) for an overview',
+		),
+	)
+	return process.stdin.isTTY
+		? base.pipe(
+				Argument.withFallbackPrompt(
+					Prompt.select({
+						message: 'Which entity? (Esc for the overview)',
+						choices: ENTITY_NAMES.map(name => ({ title: name, value: name })),
+					}),
+				),
+				Argument.optional,
+			)
+		: base.pipe(Argument.optional)
+})()
+
 const dataCommand = Command.make(
 	'data',
 	{
-		entity: Argument.choice('entity', ENTITY_NAMES).pipe(
-			Argument.withDescription('Seeded entity to list; omit for an overview'),
-			Argument.optional,
-		),
+		entity: dataEntityArg,
 		json: Flag.boolean('json').pipe(
 			Flag.withDescription('Print JSON instead of a table'),
 			Flag.withDefault(false),

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,6 +1,6 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { request } from 'node:https'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { Config, Effect } from 'effect'
 import type { ChildProcessSpawner } from 'effect/unstable/process'
@@ -30,6 +30,88 @@ interface Check {
 const ok = (detail: string) => ({ status: 'ok' as const, detail })
 const warn = (detail: string) => ({ status: 'warn' as const, detail })
 const fail = (detail: string) => ({ status: 'fail' as const, detail })
+
+// Worktrees only carry tracked files, so gitignored configs (`.env`,
+// `.env.pr-media`, …) live in the main checkout and never get copied in.
+// `worktree up` writes a worktree's own root `.env`, but the rest are absent
+// by design — the hint points there instead of crying "missing".
+const IN_WORKTREE = resolve(ROOT).includes(`${join('.claude', 'worktrees')}`)
+
+const envKeys = (content: string): Set<string> => {
+	const keys = new Set<string>()
+	for (const line of content.split('\n')) {
+		const trimmed = line.trim()
+		if (!trimmed || trimmed.startsWith('#')) continue
+		const eq = trimmed.indexOf('=')
+		if (eq !== -1) keys.add(trimmed.slice(0, eq))
+	}
+	return keys
+}
+
+// Every fillable `.env.example*` at the repo root or one level into
+// `apps/`/`packages/`. `.env.example` (and `apps/<x>/.env.example`) are
+// required — `setup` syncs them. Variants like `.env.example.pr-media` are
+// opt-in, per-workflow configs `setup` deliberately skips, so the only place to
+// learn they exist is here. A variant counts only if its header declares a
+// `Copy to \`.env.x\`` target; reference-only files (e.g. `.env.example.github`,
+// which documents GitHub-dashboard secrets and is never loaded) are skipped.
+const findEnvExamples = (): string[] => {
+	const results: string[] = []
+	for (const entry of readdirSync(ROOT)) {
+		if (entry === '.env.example') {
+			results.push(entry)
+		} else if (entry.startsWith('.env.example.')) {
+			const header = readFileSync(resolve(ROOT, entry), 'utf8')
+			if (header.includes('Copy to `')) results.push(entry)
+		}
+	}
+	for (const workspace of ['apps', 'packages']) {
+		const dir = resolve(ROOT, workspace)
+		if (!existsSync(dir)) continue
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (!entry.isDirectory()) continue
+			const rel = join(workspace, entry.name, '.env.example')
+			if (existsSync(resolve(ROOT, rel))) results.push(rel)
+		}
+	}
+	return results
+}
+
+const envFileCheck = (example: string): Check => {
+	// `.env.example` → `.env`; `.env.example.cloud` → `.env.cloud`.
+	const target = example.replace('.example', '')
+	const optional = !example.endsWith('.env.example')
+	return {
+		name: target,
+		run: Effect.sync(() => {
+			const targetPath = resolve(ROOT, target)
+			if (!existsSync(targetPath)) {
+				// In a worktree only the generated root `.env` is present; the rest
+				// are gitignored and intentionally not copied, so this isn't a fault.
+				if (IN_WORKTREE) {
+					return warn(
+						'lives in the main checkout (gitignored — not copied here)',
+					)
+				}
+				if (optional) {
+					return warn(
+						`optional, not set → \`cp ${example} ${target}\` and fill`,
+					)
+				}
+				return fail('missing → run `pnpm cli setup`')
+			}
+			const targetKeys = envKeys(readFileSync(targetPath, 'utf8'))
+			const missing = [
+				...envKeys(readFileSync(resolve(ROOT, example), 'utf8')),
+			].filter(key => !targetKeys.has(key))
+			return missing.length > 0
+				? warn(
+						`${missing.length} key(s) missing → \`pnpm cli setup --update\` (or fill by hand)`,
+					)
+				: ok('configured')
+		}),
+	}
+}
 
 const fileCheck = (rel: string, label: string): Check => ({
 	name: label,
@@ -282,8 +364,7 @@ const cloudAuthUrlCheck: Check = {
 }
 
 const localChecks: Check[] = [
-	fileCheck('.env', '.env file'),
-	fileCheck('apps/cli/.env', 'apps/cli/.env file'),
+	...findEnvExamples().map(envFileCheck),
 	emailCredentialKeyCheck,
 	dockerCheck,
 	composeCheck,


### PR DESCRIPTION
## What

Three small DX improvements to the `cli` surface, answering "does anything tell me which `.env` files to fill, and do the CLI and TUI actually have parity?" — both gaps I hit while shipping #130.

The `pnpm cli` exposes the same command tree as a flag-driven CLI (`cli.ts`) and an auto-discovered interactive TUI (`tui.ts`). Parity is structural — the TUI walks the CLI tree and prompts for any leaf flag that declares `withFallbackPrompt` — so the audit was about finding the inputs that *didn't* declare one (broken in the TUI) and giving `doctor` a way to surface env-file state.

## Changes

- **`doctor` reports env-file status.** It now self-discovers every fillable `.env.example*` (root + `apps/*`/`packages/*`) and reports each target as `configured` / `N key(s) missing` / `not set`, with the right next step (required → `pnpm cli setup`; opt-in like `.env.pr-media` → `cp … && fill`). Reference-only templates that declare no copy target (`.env.example.github`, "NOT loaded by any workflow") are skipped, and inside a worktree it points at the main checkout instead of a false "missing" — gitignored configs are never copied in.
- **`email inject` works in the TUI.** `--to/--from/--subject` were required flags with no prompt, so the auto-discovered TUI menu ran the command and it errored on the spot. Added fallback prompts; passing the flags on the CLI still skips them.
- **`data <entity>` is pickable in the TUI.** The entity argument now offers an interactive picker instead of always jumping to the overview — gated on an interactive stdin so piped / non-TTY callers (CI, scripts, agents) still get the overview rather than blocking on a prompt nothing answers.
- **`/pr` skill note:** the PR-media uploader's config is gitignored, so a worktree never has it — run the script from the main checkout instead of concluding the automated path is unavailable.

## Impact

- **CLI behavior shifts (no data/schema/server/env/RLS touched):** `doctor`'s local output gains an env-files block (replacing the two hard-coded `.env` existence lines); a *bare interactive* `pnpm cli data` now shows a picker (Esc → overview) instead of jumping straight to the overview — non-interactive `data` / `data --json` / `data <entity>` are unchanged. `email inject` with all flags is unchanged.
- Frontend/server untouched; `cli` only. No migrations, no new env vars.

## Review guide

- Start in `doctor.ts` (`findEnvExamples` + `envFileCheck`) — the env-file logic. The `Copy to \`` header check is the heuristic that distinguishes a fillable config from a reference doc; if a future variant author forgets that phrase it'll be skipped (called out so it's a conscious convention).
- `cli.ts`: the `data` entity is gated on `process.stdin.isTTY` so the prompt never blocks a non-TTY caller — a decision you might want to revisit (the alternative, always-prompt, hangs piped `data`).
- No `cli` unit tests (per the repo convention — CLI commands are verified by running them; underlying services are tested separately).

## Verification

Ran in a worktree against the live shared stack:

- `doctor` env-files block (worktree view — shows the worktree-aware hint):

```
  ✓ .env                  configured
  ! .env.cloud            lives in the main checkout (gitignored — not copied here)
  ! .env.pr-media         lives in the main checkout (gitignored — not copied here)
  ✓ apps/cli/.env         configured
  ! apps/internal/.env    lives in the main checkout (gitignored — not copied here)
```

  In the main checkout these read `configured` / `N key(s) missing` / `optional, not set → cp …`.
- `email inject` — CLI with flags injects without prompting; flagless run now prompts for To/From/Subject (the path the TUI takes).
- `data` — `data companies` lists rows; bare `data` and `data --json` over a non-TTY return the overview without hanging; interactive/TUI gets the picker.
- Gates: `pnpm -w check-types` 12/12 ✓ · `pnpm -w build` 12/12 ✓ · Biome ✓.

## Deferred

None.
