### PR TITLE
fix(cli): resolve worktree data from .env, not the live branch

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -559,14 +559,25 @@ const worktreeDownCommand = Command.make('down', {}, () => worktreeDown).pipe(
 
 const worktreePruneCommand = Command.make(
 	'prune',
-	{},
-	() => worktreePrune,
+	{
+		yes: Flag.boolean('yes').pipe(
+			Flag.withDescription(
+				'Actually drop the orphans (without it, prune only lists them)',
+			),
+			Flag.withDefault(false),
+		),
+	},
+	({ yes }) => worktreePrune(yes),
 ).pipe(
-	Command.withShortDescription('Remove orphaned worktree databases + buckets'),
+	Command.withShortDescription(
+		'List (or, with --yes, drop) orphaned worktree data',
+	),
 	Command.withDescription(
-		'Drop databases and buckets left behind by worktrees that no longer exist ' +
+		'Find databases and buckets left behind by worktrees that no longer exist ' +
 			'(removed with `git worktree remove`, crashed sessions, non-interactive ' +
-			'runs). The main checkout and every live worktree are kept.',
+			'runs). Lists them by default; pass `--yes` to drop. Ownership is read ' +
+			'from each live worktree’s .env, so the main checkout and every live ' +
+			'worktree — even one whose branch was swapped — are kept.',
 	),
 )
 

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -61,6 +61,31 @@ const slugForBranch = (branch: string) =>
 const dbName = (slug: string) => `batuda_${slug.replace(/-/g, '_')}`
 const bucketName = (slug: string) => `batuda-assets-${slug}`
 
+// A worktree's real database + bucket, read from the `.env` it generated at
+// provision time. That file is the stable record of what `up` actually created;
+// the live branch is not, because `gh pr merge --delete-branch` checks `main`
+// out into the worktree after a merge — re-deriving a slug from the branch then
+// targets the wrong data (or the main checkout's). `down`/`doctor`/`ls`/`prune`
+// therefore key off the `.env`; only the portless URL still follows the branch
+// (portless does route by the live branch).
+const identityFromEnv = (
+	envPath: string,
+): { db: string; bucket: string } | null => {
+	if (!existsSync(envPath)) return null
+	const body = readFileSync(envPath, 'utf-8')
+	const url = body.match(/^DATABASE_URL=(.+)$/m)?.[1]?.trim()
+	const bucket = body.match(/^STORAGE_BUCKET=(.+)$/m)?.[1]?.trim()
+	// Last path segment of the DB URL, with any `?sslmode=…` query stripped.
+	const db = url?.match(/\/([^/?]+)(?:\?|$)/)?.[1]
+	return db && bucket ? { db, bucket } : null
+}
+
+// Guard for destructive ops: only a suffixed `batuda_<slug>` / `batuda-assets-<slug>`
+// pair belongs to a worktree. The main checkout's bare `batuda` / `batuda-assets`
+// must never be dropped, so anything without the suffix is refused.
+const isWorktreeOwned = (db: string, bucket: string) =>
+	db.startsWith('batuda_') && bucket.startsWith('batuda-assets-')
+
 // The shared `.git` is identical from any worktree, so its parent is the main
 // checkout — where the real .env (the values to inherit) lives.
 const mainCheckoutRoot = () =>
@@ -172,27 +197,29 @@ const ensureSharedStack = dockerFail(
 )
 
 // CREATE/DROP DATABASE can't run from inside the target database, so every call
-// goes through the shared db container's `postgres` maintenance database.
-const databaseExists = (slug: string) =>
+// goes through the shared db container's `postgres` maintenance database. These
+// take the resolved database NAME (not a slug): `up` derives it from the branch
+// slug, while `down`/`prune` read it from the worktree's `.env`.
+const databaseExists = (db: string) =>
 	execSilent(
-		`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${dbName(slug)}'"`,
+		`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${db}'"`,
 	).pipe(Effect.map(out => out.trim() === '1'))
 
-const createDatabase = (slug: string) =>
+const createDatabase = (db: string) =>
 	Effect.gen(function* () {
-		if (yield* databaseExists(slug)) return
+		if (yield* databaseExists(db)) return
 		yield* dockerFail(
 			exec(
-				`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -c "CREATE DATABASE ${dbName(slug)}"`,
+				`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -c "CREATE DATABASE ${db}"`,
 			),
 		)
 	})
 
 // WITH (FORCE) (PG13+) terminates any open sessions so the drop can't hang.
-const dropDatabase = (slug: string) =>
+const dropDatabase = (db: string) =>
 	dockerFail(
 		exec(
-			`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -c "DROP DATABASE IF EXISTS ${dbName(slug)} WITH (FORCE)"`,
+			`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -c "DROP DATABASE IF EXISTS ${db} WITH (FORCE)"`,
 		),
 	)
 
@@ -210,21 +237,27 @@ const mcCapture = (command: string) => execSilent(mcScript(command))
 const settle = <A, E, R>(self: Effect.Effect<A, E, R>) =>
 	self.pipe(Effect.retry(Schedule.spaced('2 seconds').pipe(Schedule.take(5))))
 
-// `git worktree list` includes the main checkout; deriving each branch's slug the
-// same way the up path does means a live worktree's data is never swept.
-const liveWorktreeSlugs = execSilent(
+// Each live worktree's real database + bucket, read from its generated `.env`.
+// Keyed off `.env`, not the branch, so a live worktree whose branch was swapped
+// (gh checking `main` out into it after a merge) is still recognised as owning
+// its data — otherwise prune would reap a live worktree's database.
+const liveOwnedResources = execSilent(
 	'git',
 	'worktree',
 	'list',
 	'--porcelain',
 ).pipe(
 	Effect.map(out => {
-		const slugs = new Set<string>()
-		for (const line of out.split('\n')) {
-			const m = line.match(/^branch refs\/heads\/(.+)$/)
-			if (m?.[1]) slugs.add(slugForBranch(m[1]))
+		const dbs = new Set<string>()
+		const buckets = new Set<string>()
+		for (const entry of parseWorktrees(out)) {
+			const id = identityFromEnv(resolve(entry.path, '.env'))
+			if (id) {
+				dbs.add(id.db)
+				buckets.add(id.bucket)
+			}
 		}
-		return slugs
+		return { dbs, buckets }
 	}),
 )
 
@@ -255,25 +288,15 @@ const listBuckets = mcCapture('mc ls local --json').pipe(
 	),
 )
 
-// Pure: from the databases + buckets that exist and the slugs of currently
-// checked-out worktrees, return the slugs whose data no live worktree owns. The
-// main checkout's `batuda` database / `batuda-assets` bucket lack the suffix, so
-// they're never matched.
-const findOrphanSlugs = (
-	dbNames: readonly string[],
-	bucketNames: readonly string[],
-	liveSlugs: ReadonlySet<string>,
-): string[] => {
-	const fromDbs = dbNames
-		.filter(n => n.startsWith('batuda_'))
-		.map(n => n.slice('batuda_'.length).replace(/_/g, '-'))
-	const fromBuckets = bucketNames
-		.filter(n => n.startsWith('batuda-assets-'))
-		.map(n => n.slice('batuda-assets-'.length))
-	const slugs = new Set([...fromDbs, ...fromBuckets])
-	// Drop empty slugs so a bare `batuda_` / `batuda-assets-` (e.g. main) is never swept.
-	return [...slugs].filter(s => s.length > 0 && !liveSlugs.has(s))
-}
+// Existing suffixed resources that no live worktree owns. The bare `batuda` /
+// `batuda-assets` (the main checkout) don't carry the `_`/`-` suffix the prefix
+// requires, so they can never be selected.
+const findOrphans = (
+	existing: readonly string[],
+	owned: ReadonlySet<string>,
+	prefix: string,
+): string[] =>
+	existing.filter(name => name.startsWith(prefix) && !owned.has(name))
 
 // True only when the shared Postgres answers — the cheapest "is the stack up?"
 // probe. Any docker/connection error folds into `false`.
@@ -335,7 +358,7 @@ export const worktreeUp = Effect.gen(function* () {
 	yield* Effect.logInfo(
 		`Provisioning database ${dbName(slug)} + bucket ${bucketName(slug)}…`,
 	)
-	yield* settle(createDatabase(slug))
+	yield* settle(createDatabase(dbName(slug)))
 	yield* settle(mc(`mc mb --ignore-existing local/${bucketName(slug)}`))
 
 	yield* writeWorktreeEnv(main, slug)
@@ -368,44 +391,77 @@ export const worktreeDown = Effect.gen(function* () {
 			new Error('Not in a worktree — refusing to drop the shared database.'),
 		)
 	}
-	const slug = yield* slugForCurrentWorktree
-	yield* Effect.logInfo(
-		`Dropping database ${dbName(slug)} + bucket ${bucketName(slug)}…`,
-	)
-	yield* dropDatabase(slug)
-	// The bucket may already be gone (or never created) — don't fail teardown on it.
-	yield* mc(`mc rb --force local/${bucketName(slug)}`).pipe(
-		Effect.catch(() => Effect.void),
-	)
-	yield* Console.log(
-		`✓ Removed ${dbName(slug)} and ${bucketName(slug)} (shared stack untouched).`,
-	)
-})
-
-export const worktreePrune = Effect.gen(function* () {
-	const dbNames = yield* listDatabases
-	const bucketNames = yield* listBuckets
-	const liveSlugs = yield* liveWorktreeSlugs
-	const orphans = findOrphanSlugs(dbNames, bucketNames, liveSlugs)
-
-	if (orphans.length === 0) {
-		yield* Console.log('No orphaned worktree data — nothing to prune.')
-		return
-	}
-
-	yield* Effect.logInfo(
-		`Pruning ${orphans.length} orphaned worktree(s): ${orphans.join(', ')}…`,
-	)
-	for (const slug of orphans) {
-		yield* dropDatabase(slug)
-		yield* mc(`mc rb --force local/${bucketName(slug)}`).pipe(
-			Effect.catch(() => Effect.void),
+	// Read the data this worktree actually provisioned from its `.env`, never the
+	// live branch — after a `gh pr merge --delete-branch` the branch is `main`,
+	// so a branch-derived slug would miss the real database (or hit main's).
+	const identity = identityFromEnv(resolve(ROOT, '.env'))
+	if (!identity) {
+		return yield* Effect.fail(
+			new Error(
+				'No provisioned .env here — nothing to drop. Run `pnpm cli worktree up` first, or it was already torn down.',
+			),
 		)
 	}
-	yield* Console.log(
-		`✓ Pruned ${orphans.length} orphaned worktree(s): ${orphans.join(', ')}.`,
+	const { db, bucket } = identity
+	if (!isWorktreeOwned(db, bucket)) {
+		return yield* Effect.fail(
+			new Error(
+				`This worktree's .env points at ${db} / ${bucket}, which look like the main checkout's shared data — refusing to drop. The worktree overrides were never written.`,
+			),
+		)
+	}
+	yield* Effect.logInfo(`Dropping database ${db} + bucket ${bucket}…`)
+	yield* dropDatabase(db)
+	// The bucket may already be gone (or never created) — don't fail teardown on it.
+	yield* mc(`mc rb --force local/${bucket}`).pipe(
+		Effect.catch(() => Effect.void),
 	)
+	yield* Console.log(`✓ Removed ${db} and ${bucket} (shared stack untouched).`)
 })
+
+// Dry-run by default: list the orphans and stop. `--yes` is required to drop,
+// so prune can never silently delete data — and because ownership is read from
+// each live worktree's `.env`, a worktree whose branch was swapped is never
+// mistaken for an orphan.
+export const worktreePrune = (apply: boolean) =>
+	Effect.gen(function* () {
+		const owned = yield* liveOwnedResources
+		const orphanDbs = findOrphans(yield* listDatabases, owned.dbs, 'batuda_')
+		const orphanBuckets = findOrphans(
+			yield* listBuckets,
+			owned.buckets,
+			'batuda-assets-',
+		)
+
+		if (orphanDbs.length === 0 && orphanBuckets.length === 0) {
+			yield* Console.log('No orphaned worktree data — nothing to prune.')
+			return
+		}
+
+		yield* Console.log('')
+		yield* Console.log('Orphaned worktree data (no live worktree owns it):')
+		for (const db of orphanDbs) yield* Console.log(`  database  ${db}`)
+		for (const bucket of orphanBuckets)
+			yield* Console.log(`  bucket    ${bucket}`)
+		yield* Console.log('')
+
+		if (!apply) {
+			yield* Console.log(
+				'Dry run — re-run with `--yes` to drop the above. (The main `batuda` / `batuda-assets` are never listed.)',
+			)
+			return
+		}
+
+		for (const db of orphanDbs) yield* dropDatabase(db)
+		for (const bucket of orphanBuckets) {
+			yield* mc(`mc rb --force local/${bucket}`).pipe(
+				Effect.catch(() => Effect.void),
+			)
+		}
+		yield* Console.log(
+			`✓ Pruned ${orphanDbs.length} database(s) + ${orphanBuckets.length} bucket(s).`,
+		)
+	})
 
 export const worktreeLs = Effect.gen(function* () {
 	const porcelain = yield* execSilent('git', 'worktree', 'list', '--porcelain')
@@ -415,13 +471,15 @@ export const worktreeLs = Effect.gen(function* () {
 
 	const rows = parseWorktrees(porcelain).map(e => {
 		// The main checkout owns the unsuffixed `batuda` database/bucket; every
-		// linked worktree owns its `batuda_<slug>` / `batuda-assets-<slug>` pair.
+		// linked worktree owns whatever its `.env` records — read that rather than
+		// re-derive from the branch, which drifts once gh checks out main.
 		const isMain = resolve(e.path) === resolve(main)
 		const branch = e.branch ?? '(detached)'
-		const slug = e.branch ? slugForBranch(e.branch) : ''
-		const db = isMain ? 'batuda' : dbName(slug)
-		const bucket = isMain ? 'batuda-assets' : bucketName(slug)
-		const provisioned = dbs.has(db) && buckets.has(bucket)
+		const identity = isMain ? null : identityFromEnv(resolve(e.path, '.env'))
+		const db = isMain ? 'batuda' : (identity?.db ?? '—')
+		const bucket = isMain ? 'batuda-assets' : identity?.bucket
+		const provisioned =
+			bucket !== undefined && dbs.has(db) && buckets.has(bucket)
 		const url = isMain
 			? 'https://batuda.localhost'
 			: e.branch
@@ -468,33 +526,42 @@ export const worktreeDoctor = Effect.gen(function* () {
 			detail: 'main checkout — uses the shared `batuda` database',
 		})
 	} else {
-		const slug = yield* slugForCurrentWorktree
-		const db = dbName(slug)
-		const dbOk = stackOk ? yield* databaseExists(slug) : false
-		checks.push({
-			ok: dbOk,
-			name: 'database',
-			detail: dbOk ? db : `${db} missing — run \`pnpm cli worktree up\``,
-		})
+		// Identity from the worktree's own `.env` — the branch is unreliable after
+		// a merge swaps it to main.
+		const identity = identityFromEnv(resolve(ROOT, '.env'))
+		if (!identity) {
+			checks.push({
+				ok: false,
+				name: 'database',
+				detail: 'no .env — run `pnpm cli worktree up`',
+			})
+		} else {
+			const { db, bucket } = identity
+			const dbOk = stackOk ? yield* databaseExists(db) : false
+			checks.push({
+				ok: dbOk,
+				name: 'database',
+				detail: dbOk ? db : `${db} missing — run \`pnpm cli worktree up\``,
+			})
 
-		const tables = dbOk ? yield* tableCount(db) : 0
-		checks.push({
-			ok: tables > 0,
-			name: 'migrations',
-			detail:
-				tables > 0 ? `${tables} tables` : 'none — run `pnpm cli worktree up`',
-		})
+			const tables = dbOk ? yield* tableCount(db) : 0
+			checks.push({
+				ok: tables > 0,
+				name: 'migrations',
+				detail:
+					tables > 0 ? `${tables} tables` : 'none — run `pnpm cli worktree up`',
+			})
 
-		const bucket = bucketName(slug)
-		let bucketOk = false
-		if (stackOk) bucketOk = new Set(yield* listBuckets).has(bucket)
-		checks.push({
-			ok: bucketOk,
-			name: 'bucket',
-			detail: bucketOk
-				? bucket
-				: `${bucket} missing — run \`pnpm cli worktree up\``,
-		})
+			let bucketOk = false
+			if (stackOk) bucketOk = new Set(yield* listBuckets).has(bucket)
+			checks.push({
+				ok: bucketOk,
+				name: 'bucket',
+				detail: bucketOk
+					? bucket
+					: `${bucket} missing — run \`pnpm cli worktree up\``,
+			})
+		}
 
 		const branch = yield* branchName
 		checks.push({


### PR DESCRIPTION
## What

A data-safety fix for `pnpm cli worktree` teardown. It manifested while cleaning up the last DX worktree: `worktree down` dropped `batuda_main` (a no-op) and **left the worktree's real `batuda_dx_parity` database orphaned**, and `prune` would have reaped a *live* worktree's data. Root cause: `down`/`doctor`/`ls`/`prune` derived a worktree's identity (→ which DB + bucket) from the **current branch's last path segment** — a mutable input. `gh pr merge --delete-branch` checks `main` out into the worktree after a merge, so the branch-derived slug stops matching the data the worktree actually provisioned. This happens on **every** worktree PR merge.

## The fix

- **Identity comes from the worktree's generated `.env`, not the branch.** `up` writes `DATABASE_URL=…/batuda_<slug>` + `STORAGE_BUCKET=batuda-assets-<slug>` at provision time — the stable record of what it created. `down`/`doctor`/`ls`/`prune` now read those; only the portless URL still follows the branch (portless does route by the live branch). `down` additionally **refuses** if the `.env` resolves to the main checkout's bare `batuda` / `batuda-assets`.
- **`prune` is dry-run by default, `--yes` to drop**, and computes ownership from each *live* worktree's `.env` — so a live worktree whose branch was swapped is recognised as owning its data and never reaped. No more silent mass-deletion.

No backward compatibility kept (pre-prod): the branch-derived `findOrphanSlugs` / `liveWorktreeSlugs` are gone, and `prune` now requires `--yes` to act.

## Impact

- **CLI-only.** No server/schema/migration/env. Behavior shifts: `prune` no longer drops anything without `--yes` (lists by default); `down`/`doctor`/`ls` report the `.env`'s real DB/bucket even when the branch has drifted.
- The `prune --yes` contract is now genuinely destructive-on-demand; the dry-run default is the safety.

## Review guide

- `worktree.ts`: `identityFromEnv` (the `.env` parse — last path segment of `DATABASE_URL`, `STORAGE_BUCKET`) is the linchpin; `isWorktreeOwned` is the guard that protects the main checkout's bare names; `liveOwnedResources` + `findOrphans` drive the safe prune.
- `down` and `doctor` read the *current* worktree's `.env` (`ROOT/.env`); `ls` and `prune` read *each* worktree's `.env` (`<path>/.env`).
- No unit test: `apps/cli` has no test harness (the repo's "no CLI tests" convention), so this is verified by exercising the real commands end-to-end (below) — which covers the docker/psql/git path a unit test can't.

## Verification

Provisioned a worktree (`cli/worktree-identity` → `batuda_worktree_identity`), then **swapped its branch** to simulate the post-merge `gh` checkout, and exercised every command:

```
# doctor after the branch swap — data still from .env, URL follows the branch
  ✓ database      batuda_worktree_identity
  ✓ bucket        batuda-assets-worktree-identity
  ✓ url           https://swapped-branch-test.batuda.localhost (run `pnpm dev`)

# prune (dry run) — lists a synthetic orphan, NOT the live (branch-swapped) worktree or main
Orphaned worktree data (no live worktree owns it):
  database  batuda_stale_orphan
Dry run — re-run with `--yes` to drop the above. (The main `batuda` / `batuda-assets` are never listed.)

# down on the swapped branch — drops the .env's DB, not a branch-derived name
Dropping database batuda_worktree_identity + bucket batuda-assets-worktree-identity…
✓ Removed batuda_worktree_identity and batuda-assets-worktree-identity (shared stack untouched).
```

`batuda` (main) stayed intact throughout. Gates: `pnpm -w check-types` 12/12 ✓ · `pnpm -w build` 12/12 ✓ · Biome ✓.

## Deferred

None.
