### PR TITLE
ai(skills): document .env-based worktree teardown + safe prune

### DIFF
--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -46,29 +46,42 @@ fires the auto-provision/teardown hooks below.
 4. **Inspect** — `pnpm cli worktree ls` (every worktree + its DB/URL/provisioned state),
    `pnpm cli worktree doctor` (deep health of the current one).
 5. **Tear down** — auto when **Claude** removes the worktree (the `WorktreeRemove` hook drops
-   the DB + bucket). Or `pnpm cli worktree down`.
+   the DB + bucket). Or `pnpm cli worktree down` — it drops the database + bucket recorded in
+   this worktree's `.env` (not re-derived from the live branch), so it stays correct even after
+   the branch is switched, e.g. by a PR merge (see Caveats).
 
 ## Commands (`pnpm cli worktree …`; run `--help` for flags)
 
-| command  | does                                                                |
-| -------- | ------------------------------------------------------------------- |
-| `up`     | provision this worktree: DB + bucket, then migrate + seed           |
-| `down`   | drop this worktree's DB + bucket (shared stack untouched)           |
-| `ls`     | table of every worktree + database + provisioned (✓) + URL          |
-| `doctor` | health of the current worktree (stack, DB, migrations, bucket, URL) |
-| `prune`  | reap DBs + buckets of worktrees that no longer exist                |
+| command  | does                                                                   |
+| -------- | ---------------------------------------------------------------------- |
+| `up`     | provision this worktree: DB + bucket, then migrate + seed              |
+| `down`   | drop this worktree's DB + bucket (shared stack untouched)              |
+| `ls`     | table of every worktree + database + provisioned (✓) + URL             |
+| `doctor` | health of the current worktree (stack, DB, migrations, bucket, URL)    |
+| `prune`  | list orphaned DBs + buckets (worktrees that are gone); `--yes` to drop |
 
 ## Caveats
 
 - **`git worktree remove` does NOT auto-tear-down** — the `WorktreeRemove` hook only fires when
   *Claude* removes the worktree. After a manual `git worktree remove`, the DB + bucket leak; run
-  `pnpm cli worktree down` first, or `pnpm cli worktree prune` later to reap orphans.
+  `pnpm cli worktree down` **first**, or `pnpm cli worktree prune` later. `prune` only *lists*
+  orphans by default (pass `--yes` to drop) and keys ownership off each live worktree's `.env`,
+  so it never reaps a live worktree — even one whose branch was switched.
+- **Merging a worktree's PR switches its branch.** `gh pr merge --delete-branch` checks `main`
+  out into the worktree (the PR branch is gone). `down`/`doctor`/`ls`/`prune` read this worktree's
+  identity from its `.env`, not the live branch, so teardown stays correct — but the portless
+  **URL** then follows the new branch. Run `pnpm cli worktree down` before removing the dir.
 - **`pnpm cli worktree up` re-seeds** (`--preset minimal`) every run, so re-running it resets the
   worktree's seed data — don't re-run it on a worktree whose data you've hand-edited.
 - **`pnpm cli services down` from a worktree** stops the *shared* stack (every worktree + main),
   so it refuses unless run from the main checkout or given `--force`. To remove just your
   worktree's data, use `worktree down`.
 - The shared Postgres caps connections at 200 — plenty for ~20 parallel dev servers.
+- **New worktree, no HTTPS?** If `https://<label>.batuda.localhost` gives `ERR_CONNECTION_CLOSED`
+  (the proxy serves no cert for the nested host), check `~/.portless/ca.srl` — a past `sudo` run
+  can leave it root-owned, which silently fails cert *signing* for every new host (the generated
+  `host-certs/<host>.pem` lands 0 bytes). The `.portless` dir is yours, so `rm ~/.portless/ca.srl`,
+  then restart this worktree's `pnpm dev` to re-mint the cert.
 
 ## CORS / auth (works per worktree, no per-worktree env)
 


### PR DESCRIPTION
## What

Updates the `/worktrees` skill to match the worktree-tooling fix that just landed (#132) and capture two gotchas I hit this session.

## Changes

- **Teardown is `.env`-based.** Documented that `down`/`doctor`/`ls`/`prune` read each worktree's identity from its generated `.env`, not the live branch — so teardown stays correct after `gh pr merge --delete-branch` swaps the branch to `main`.
- **`prune` is safe.** Noted it lists orphans by default and needs `--yes` to drop, and never reaps a live worktree (even one whose branch was switched).
- **New caveat: PR merge switches the branch.** Explains the `gh`-checks-out-`main` behaviour and that the portless URL follows the new branch.
- **New troubleshooting note: no HTTPS on a fresh worktree.** The root-owned `~/.portless/ca.srl` that silently fails cert signing (0-byte cert) → `ERR_CONNECTION_CLOSED`, and the one-line fix.

## Impact

Docs only (`.claude/skills/worktrees/SKILL.md`). No code.

## Verification

Prose review; the behaviours described are exactly what I verified against the real CLI in #132 (branch-swap across `down`/`doctor`/`ls`/`prune`).