### PR TITLE
feat(server+internal): support multiple orgs per MCP OAuth connection

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -11,6 +11,10 @@
 			"type": "http",
 			"url": "https://mcp.cloudflare.com/mcp"
 		},
+		"firecrawl": {
+			"type": "http",
+			"url": "https://mcp.firecrawl.dev/v2/mcp"
+		},
 		"neon": {
 			"command": "sh",
 			"args": [

--- a/apps/cli/src/commands/seed.ts
+++ b/apps/cli/src/commands/seed.ts
@@ -13,6 +13,7 @@ import { seedDocuments } from './seed/documents'
 import { seedDemoEmails } from './seed/emails'
 import { seedInboxes } from './seed/inboxes'
 import { linkRunProvenance, seedInstructions } from './seed/instructions'
+import { seedMcpOAuth } from './seed/mcp-oauth'
 import { seedPages } from './seed/pages'
 import { seedPersonaActivity } from './seed/personas'
 import { seedProposals } from './seed/proposals'
@@ -86,6 +87,7 @@ export const seed = (preset: Preset) =>
 				const seededInboxes = yield* seedInboxes(ctx)
 				yield* seedDemoEmails(sql, seededInboxes)
 				const instructionTemplateIds = yield* seedInstructions(ctx)
+				yield* seedMcpOAuth(ctx)
 
 				if (preset === 'full') {
 					yield* seedDocuments(ctx, companyMap, insertedInteractions)

--- a/apps/cli/src/commands/seed/mcp-oauth.ts
+++ b/apps/cli/src/commands/seed/mcp-oauth.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+
+import type { SeedCtx } from './shared'
+
+// Seeds mock MCP OAuth connections so the /settings/mcp/connections page has
+// something to render during local dev and the /debug-apps flow. Without this,
+// the page always shows the empty state and the multi-org chip UI can't be
+// exercised without running a real OAuth dance.
+//
+// Two clients are seeded:
+//   - "ChatGPT" (redirect host chatgpt.com) — bound to both taller + restaurant,
+//     so the multi-org chip UI with per-org remove is visible.
+//   - "Claude" (redirect host claude.ai) — bound to only taller, so the
+//     single-org-per-connection case is also covered.
+//
+// Runs after identities (which create the users + orgs). The OAuth client /
+// consent tables are managed by Better Auth but written here directly — the
+// AS doesn't expose a "register client + consent" API outside the OAuth flow.
+
+const MOCK_CLIENTS = [
+	{
+		clientId: 'mock-chatgpt-client',
+		name: 'ChatGPT',
+		redirectUris: ['https://chatgpt.com/callback'],
+	},
+	{
+		clientId: 'mock-claude-client',
+		name: 'Claude',
+		redirectUris: ['https://claude.ai/callback'],
+	},
+] as const
+
+export const seedMcpOAuth = (ctx: SeedCtx) =>
+	Effect.gen(function* () {
+		const { sql, tallerOrgId, restaurantOrgId } = ctx
+
+		// Alice is the multi-org user (member of taller + restaurant) — the
+		// right persona to exercise the connections page.
+		const aliceRows = yield* sql<{ id: string }>`
+			SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+		`
+		const aliceId = aliceRows[0]?.id
+		if (!aliceId) {
+			yield* Effect.logInfo(
+				'  mcp-oauth: Alice not found — skipping MCP OAuth seed',
+			)
+			return
+		}
+
+		// Clean up any prior seed rows (idempotent re-runs).
+		yield* sql`DELETE FROM mcp_oauth_org_membership WHERE user_id = ${aliceId} AND client_id LIKE 'mock-%'`
+		yield* sql`DELETE FROM "oauthConsent" WHERE "userId" = ${aliceId} AND "clientId" LIKE 'mock-%'`
+		yield* sql`DELETE FROM "oauthClient" WHERE "clientId" LIKE 'mock-%'`
+
+		for (const client of MOCK_CLIENTS) {
+			const redirectUrisJson = JSON.stringify(client.redirectUris)
+			// Register the mock OAuth client.
+			yield* sql`
+				INSERT INTO "oauthClient" (id, "clientId", "redirectUris", name, "createdAt", "updatedAt")
+				VALUES (${randomUUID()}, ${client.clientId}, ${redirectUrisJson}::jsonb, ${client.name}, now(), now())
+			`
+
+			// Record consent (Alice approved this client).
+			yield* sql`
+				INSERT INTO "oauthConsent" (id, "clientId", "userId", scopes, "createdAt", "updatedAt")
+				VALUES (${randomUUID()}, ${client.clientId}, ${aliceId}, '["openid"]'::jsonb, now(), now())
+			`
+		}
+
+		// ChatGPT → authorized for both orgs (multi-org chip UI).
+		yield* sql`
+			INSERT INTO mcp_oauth_org_membership (user_id, client_id, organization_id, updated_at)
+			VALUES
+				(${aliceId}, 'mock-chatgpt-client', ${tallerOrgId}, now()),
+				(${aliceId}, 'mock-chatgpt-client', ${restaurantOrgId}, now())
+			ON CONFLICT (user_id, client_id, organization_id) DO NOTHING
+		`
+
+		// Claude → authorized for only taller (single-org-per-connection case).
+		yield* sql`
+			INSERT INTO mcp_oauth_org_membership (user_id, client_id, organization_id, updated_at)
+			VALUES (${aliceId}, 'mock-claude-client', ${tallerOrgId}, now())
+			ON CONFLICT (user_id, client_id, organization_id) DO NOTHING
+		`
+
+		yield* Effect.logInfo(
+			'  mcp-oauth: seeded 2 mock connections (ChatGPT multi-org, Claude single-org)',
+		)
+	})

--- a/apps/cli/src/commands/seed/reset.ts
+++ b/apps/cli/src/commands/seed/reset.ts
@@ -6,5 +6,8 @@ export const seedReset = Effect.gen(function* () {
 	yield* Effect.logInfo('Truncating CRM tables...')
 	// DELETE (not TRUNCATE CASCADE) so `member.primary_inbox_id`'s ON DELETE SET NULL fires.
 	yield* sql`DELETE FROM inboxes`
+	yield* sql`DELETE FROM mcp_oauth_org_membership WHERE client_id LIKE 'mock-%'`
+	yield* sql`DELETE FROM "oauthConsent" WHERE "clientId" LIKE 'mock-%'`
+	yield* sql`DELETE FROM "oauthClient" WHERE "clientId" LIKE 'mock-%'`
 	yield* sql`TRUNCATE companies, products, pages, research_runs, sources, user_research_policy, provider_quotas, provider_usage, email_thread_links, email_messages, call_recordings, instruction_templates, agent_default_stacks, agent_default_stack_items CASCADE`
 })

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -276,8 +276,8 @@ msgid "Agent"
 msgstr "Agent"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "AI assistants you've connected over MCP. Choose which organization each one acts in."
-msgstr "Assistents d'IA que has connectat per MCP. Tria en quina organització actua cadascun."
+msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
+msgstr "Assistents d'IA que has connectat per MCP. Cadascun pot actuar en una o més de les teves organitzacions; l'assistent tria quina en cada petició."
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
@@ -565,10 +565,6 @@ msgstr "Comprova la sessió o torna-ho a provar."
 #: src/routes/login.tsx
 msgid "Check your inbox"
 msgstr "Mira la safata d'entrada"
-
-#: src/routes/settings/mcp/connections.tsx
-msgid "Choose organization"
-msgstr "Tria una organització"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -2145,6 +2141,10 @@ msgstr "Encara no hi ha plantilles d'organització."
 msgid "No org templates yet. Create one or accept a member's proposal."
 msgstr "Encara no hi ha plantilles d'organització. Crea'n una o accepta una proposta d'un membre."
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "No organization selected"
+msgstr "Cap organització seleccionada"
+
 #: src/routes/index.tsx
 msgid "No overdue tasks, no pending follow-ups, no neglected companies."
 msgstr "Sense tasques endarrerides, sense seguiments pendents, sense empreses oblidades."
@@ -2173,6 +2173,10 @@ msgstr "Encara sense productes vinculats"
 #: src/routes/settings/organization/templates.tsx
 msgid "No proposals waiting for review."
 msgstr "No hi ha cap proposta pendent de revisió."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "No redirect URI"
+msgstr "Sense URI de redirecció"
 
 #: src/components/research/run-list.tsx
 msgid "No research runs yet for this company."
@@ -2358,16 +2362,13 @@ msgstr "Organització"
 msgid "Organization default"
 msgstr "Valor per defecte de l'organització"
 
-#. placeholder {0}: row.name ?? t`Unnamed client`
 #: src/routes/settings/mcp/connections.tsx
-msgid "Organization for {0}"
-msgstr "Organització per a {0}"
-
-#: src/routes/settings/mcp/connections.tsx
-msgid "Organization updated"
-msgstr "Organització actualitzada"
+msgid "Organization removed"
+msgstr "Organització eliminada"
 
 #: src/components/layout/org-switcher.tsx
+#: src/routes/oauth/consent.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Organizations"
 msgstr "Organitzacions"
 
@@ -2530,6 +2531,10 @@ msgstr "Tria un proveïdor"
 #: src/routes/emails/index.tsx
 msgid "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
 msgstr "Tria una organització al selector de la barra superior, o tanca la sessió i torna a entrar. Després d'un reset recent de la base de dades de dev, les sessions existents poden apuntar a identificadors d'organització que el reset ha esborrat."
+
+#: src/routes/oauth/consent.tsx
+msgid "Pick one or more. The assistant will ask which to use per request."
+msgstr "Tria'n una o més. L'assistent demanarà quina fer servir en cada petició."
 
 #: src/routes/emails/inboxes.tsx
 msgid "Pick one to use as your default sender."
@@ -2724,8 +2729,10 @@ msgstr "Treu «{0}» del teu valor per defecte primer i després elimina-la."
 
 #. placeholder {0}: att.filename
 #. placeholder {0}: o.name
+#. placeholder {0}: orgNameById.get(orgId) ?? orgId
 #: src/components/emails/attachment-picker.tsx
 #: src/components/instructions/stack-picker.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Remove {0}"
 msgstr "Elimina {0}"
 
@@ -2922,6 +2929,10 @@ msgstr "Veure qui té accés a aquest espai de treball, convida companys i gesti
 msgid "Select all threads on this page"
 msgstr "Selecciona tots els fils d'aquesta pàgina"
 
+#: src/routes/oauth/consent.tsx
+msgid "Select at least one organization before allowing."
+msgstr "Selecciona almenys una organització abans d'autoritzar."
+
 #: src/components/emails/compose-form.tsx
 msgid "Select inbox…"
 msgstr "Tria una safata…"
@@ -2942,15 +2953,6 @@ msgstr "Selecciona el fil {0}"
 #: src/routes/emails/inboxes.tsx
 msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 msgstr "Triar un preestablit omple els paràmetres IMAP i SMTP — encara els pots editar."
-
-#: src/routes/settings/mcp/connections.tsx
-msgid "Self-reported name"
-msgstr "Nom autodeclarat"
-
-#. placeholder {0}: row.redirectHost
-#: src/routes/settings/mcp/connections.tsx
-msgid "Self-reported name · sends you to {0}"
-msgstr "Nom autodeclarat · t'envia a {0}"
 
 #: src/components/emails/compose-form.tsx
 msgid "Send"
@@ -2976,12 +2978,21 @@ msgstr "Envia invitació"
 msgid "Send reset link"
 msgstr "Envia l'enllaç"
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "Send X-Batuda-Organization-Id with each request to pick."
+msgstr "Envia X-Batuda-Organization-Id amb cada petició per triar."
+
 #: src/components/emails/compose-form.tsx
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Sending…"
 msgstr "Enviant…"
+
+#. placeholder {0}: row.redirectHost
+#: src/routes/settings/mcp/connections.tsx
+msgid "Sends you to {0}"
+msgstr "T'envia a {0}"
 
 #: src/routes/emails/$threadId.tsx
 #: src/routes/settings/organization/members.tsx
@@ -3410,8 +3421,8 @@ msgid "They replied — keep the thread warm"
 msgstr "Ha respost — manté el fil calent"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "This connection now acts in the chosen organization."
-msgstr "Aquesta connexió ara actua en l'organització triada."
+msgid "This connection is unbound. Bind an org to use it."
+msgstr "Aquesta connexió no està vinculada. Vincula una organització per fer-la servir."
 
 #: src/routes/accept-invitation.$id.tsx
 msgid "This invitation can't be accepted"
@@ -3530,7 +3541,6 @@ msgstr "Usuari desconegut"
 msgid "Unlinked"
 msgstr "Sense enllaçar"
 
-#: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/connections.tsx
 msgid "Unnamed client"
 msgstr "Client sense nom"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -276,8 +276,8 @@ msgid "Agent"
 msgstr "Agent"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "AI assistants you've connected over MCP. Choose which organization each one acts in."
-msgstr "AI assistants you've connected over MCP. Choose which organization each one acts in."
+msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
+msgstr "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
@@ -565,10 +565,6 @@ msgstr "Check the session or try again."
 #: src/routes/login.tsx
 msgid "Check your inbox"
 msgstr "Check your inbox"
-
-#: src/routes/settings/mcp/connections.tsx
-msgid "Choose organization"
-msgstr "Choose organization"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -2145,6 +2141,10 @@ msgstr "No org templates yet."
 msgid "No org templates yet. Create one or accept a member's proposal."
 msgstr "No org templates yet. Create one or accept a member's proposal."
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "No organization selected"
+msgstr "No organization selected"
+
 #: src/routes/index.tsx
 msgid "No overdue tasks, no pending follow-ups, no neglected companies."
 msgstr "No overdue tasks, no pending follow-ups, no neglected companies."
@@ -2173,6 +2173,10 @@ msgstr "No products linked yet"
 #: src/routes/settings/organization/templates.tsx
 msgid "No proposals waiting for review."
 msgstr "No proposals waiting for review."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "No redirect URI"
+msgstr "No redirect URI"
 
 #: src/components/research/run-list.tsx
 msgid "No research runs yet for this company."
@@ -2358,16 +2362,13 @@ msgstr "Organization"
 msgid "Organization default"
 msgstr "Organization default"
 
-#. placeholder {0}: row.name ?? t`Unnamed client`
 #: src/routes/settings/mcp/connections.tsx
-msgid "Organization for {0}"
-msgstr "Organization for {0}"
-
-#: src/routes/settings/mcp/connections.tsx
-msgid "Organization updated"
-msgstr "Organization updated"
+msgid "Organization removed"
+msgstr "Organization removed"
 
 #: src/components/layout/org-switcher.tsx
+#: src/routes/oauth/consent.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Organizations"
 msgstr "Organizations"
 
@@ -2530,6 +2531,10 @@ msgstr "Pick a provider"
 #: src/routes/emails/index.tsx
 msgid "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
 msgstr "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
+
+#: src/routes/oauth/consent.tsx
+msgid "Pick one or more. The assistant will ask which to use per request."
+msgstr "Pick one or more. The assistant will ask which to use per request."
 
 #: src/routes/emails/inboxes.tsx
 msgid "Pick one to use as your default sender."
@@ -2724,8 +2729,10 @@ msgstr "Remove \"{0}\" from your default first, then delete it."
 
 #. placeholder {0}: att.filename
 #. placeholder {0}: o.name
+#. placeholder {0}: orgNameById.get(orgId) ?? orgId
 #: src/components/emails/attachment-picker.tsx
 #: src/components/instructions/stack-picker.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
@@ -2922,6 +2929,10 @@ msgstr "See who can access this workspace, invite teammates, and manage pending 
 msgid "Select all threads on this page"
 msgstr "Select all threads on this page"
 
+#: src/routes/oauth/consent.tsx
+msgid "Select at least one organization before allowing."
+msgstr "Select at least one organization before allowing."
+
 #: src/components/emails/compose-form.tsx
 msgid "Select inbox…"
 msgstr "Select inbox…"
@@ -2942,15 +2953,6 @@ msgstr "Select thread {0}"
 #: src/routes/emails/inboxes.tsx
 msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 msgstr "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
-
-#: src/routes/settings/mcp/connections.tsx
-msgid "Self-reported name"
-msgstr "Self-reported name"
-
-#. placeholder {0}: row.redirectHost
-#: src/routes/settings/mcp/connections.tsx
-msgid "Self-reported name · sends you to {0}"
-msgstr "Self-reported name · sends you to {0}"
 
 #: src/components/emails/compose-form.tsx
 msgid "Send"
@@ -2976,12 +2978,21 @@ msgstr "Send invitation"
 msgid "Send reset link"
 msgstr "Send reset link"
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "Send X-Batuda-Organization-Id with each request to pick."
+msgstr "Send X-Batuda-Organization-Id with each request to pick."
+
 #: src/components/emails/compose-form.tsx
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Sending…"
 msgstr "Sending…"
+
+#. placeholder {0}: row.redirectHost
+#: src/routes/settings/mcp/connections.tsx
+msgid "Sends you to {0}"
+msgstr "Sends you to {0}"
 
 #: src/routes/emails/$threadId.tsx
 #: src/routes/settings/organization/members.tsx
@@ -3410,8 +3421,8 @@ msgid "They replied — keep the thread warm"
 msgstr "They replied — keep the thread warm"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "This connection now acts in the chosen organization."
-msgstr "This connection now acts in the chosen organization."
+msgid "This connection is unbound. Bind an org to use it."
+msgstr "This connection is unbound. Bind an org to use it."
 
 #: src/routes/accept-invitation.$id.tsx
 msgid "This invitation can't be accepted"
@@ -3530,7 +3541,6 @@ msgstr "Unknown user"
 msgid "Unlinked"
 msgstr "Unlinked"
 
-#: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/connections.tsx
 msgid "Unnamed client"
 msgstr "Unnamed client"

--- a/apps/internal/src/routes/oauth/consent.tsx
+++ b/apps/internal/src/routes/oauth/consent.tsx
@@ -1,12 +1,14 @@
+import { CheckboxGroup } from '@base-ui/react/checkbox-group'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { KeyRound } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import { PriButton } from '@batuda/ui/pri'
+import { PriButton, PriCheckbox } from '@batuda/ui/pri'
 
 import { apiBaseUrl } from '#/lib/api-base'
+import { authClient } from '#/lib/auth-client'
 import { agedPaperSurface, stenciledTitle } from '#/lib/workshop-mixins'
 
 /**
@@ -15,6 +17,12 @@ import { agedPaperSurface, stenciledTitle } from '#/lib/workshop-mixins'
  * browser next — back to the assistant, now connected. The request is read
  * straight from the URL, untouched: it is signed, so any edit (even reordering)
  * would void it, and the router's parsed search would drop parts of it.
+ *
+ * Organization binding happens here, not later: a single-org user is auto-bound
+ * (no selector); a multi-org user must select one or more orgs before Allow.
+ * The binding is written through `/v1/mcp-oauth/select-orgs` before the
+ * consent POST, so the connection is usable the moment the assistant gets its
+ * code — no trip to /settings/mcp/connections first.
  */
 
 export const Route = createFileRoute('/oauth/consent')({
@@ -35,12 +43,40 @@ function ConsentPage() {
 	const [submitting, setSubmitting] = useState<'allow' | 'deny' | null>(null)
 	const [error, setError] = useState<string | null>(null)
 
+	const orgs = authClient.useListOrganizations()
+	const memberships = orgs.data ?? []
+	const isMultiOrg = memberships.length > 1
+	// The selected org ids, managed by BaseUI's CheckboxGroup. Pre-check all
+	// by default (the common "authorize everywhere" case is one click). The
+	// group's value is an array directly — the shape the API payload needs.
+	const allOrgIds = memberships.map(o => o.id)
+	const [selectedOrgIds, setSelectedOrgIds] = useState<string[]>(allOrgIds)
+	// Seed once when the org list first loads (it arrives async). A ref guard
+	// prevents re-seeding after the user deliberately unchecks everything.
+	const seededRef = useRef(false)
+	useEffect(() => {
+		if (!seededRef.current && allOrgIds.length > 0) {
+			seededRef.current = true
+			setSelectedOrgIds(allOrgIds)
+		}
+	}, [allOrgIds])
+
 	const scopes = scope.split(' ').filter(Boolean)
 
 	const respond = async (accept: boolean) => {
 		setSubmitting(accept ? 'allow' : 'deny')
 		setError(null)
 		try {
+			// For multi-org, validate the selection before anything hits the
+			// server — no point calling consent if there's nothing to bind.
+			if (accept && isMultiOrg && selectedOrgIds.length === 0) {
+				setSubmitting(null)
+				setError(t`Select at least one organization before allowing.`)
+				return
+			}
+			// Consent first: Better Auth validates the signed oauth_query and
+			// issues the authorization code. If the query is expired or
+			// tampered, we bail before writing any binding — no orphan rows.
 			const res = await fetch(`${apiBaseUrl()}/auth/oauth2/consent`, {
 				method: 'POST',
 				credentials: 'include',
@@ -58,6 +94,28 @@ function ConsentPage() {
 				return
 			}
 			const data = (await res.json()) as { url?: string }
+			// Bind orgs after consent succeeds but before redirecting, so the
+			// connection is usable the instant the assistant exchanges the
+			// code for a token. Single-org: auto-bind the lone org. Multi-org:
+			// bind the selected set.
+			if (accept) {
+				const orgIds = isMultiOrg
+					? selectedOrgIds
+					: memberships.length === 1
+						? [memberships[0]!.id]
+						: []
+				if (orgIds.length > 0) {
+					await fetch(`${apiBaseUrl()}/v1/mcp-oauth/select-orgs`, {
+						method: 'POST',
+						credentials: 'include',
+						headers: { 'content-type': 'application/json' },
+						body: JSON.stringify({
+							clientId: client_id,
+							organizationIds: orgIds,
+						}),
+					})
+				}
+			}
 			if (data.url) {
 				// Send the browser back to the assistant — connected, or
 				// told it was declined.
@@ -134,6 +192,37 @@ function ConsentPage() {
 						</ScopeList>
 					</Scopes>
 				) : null}
+				{isMultiOrg ? (
+					<OrgSection data-testid='oauth-consent-orgs'>
+						<ClientLabel>
+							<Trans>Organizations</Trans>
+						</ClientLabel>
+						<CheckboxGroup
+							value={selectedOrgIds}
+							onValueChange={setSelectedOrgIds}
+						>
+							<OrgList>
+								{memberships.map(org => (
+									<OrgRow key={org.id}>
+										<PriCheckbox.Root
+											name={org.id}
+											data-testid={`oauth-consent-org-${org.slug}`}
+										>
+											<PriCheckbox.Indicator />
+										</PriCheckbox.Root>
+										<OrgName>{org.name}</OrgName>
+									</OrgRow>
+								))}
+							</OrgList>
+						</CheckboxGroup>
+						<OrgHint>
+							<Trans>
+								Pick one or more. The assistant will ask which to use per
+								request.
+							</Trans>
+						</OrgHint>
+					</OrgSection>
+				) : null}
 				{error ? (
 					<ErrorText role='alert' data-testid='oauth-consent-error'>
 						{error}
@@ -154,7 +243,11 @@ function ConsentPage() {
 					<PriButton
 						type='button'
 						$variant='filled'
-						disabled={submitting !== null}
+						disabled={
+							submitting !== null ||
+							orgs.isPending ||
+							(isMultiOrg && selectedOrgIds.length === 0)
+						}
 						data-testid='oauth-consent-allow'
 						onClick={() => {
 							void respond(true)
@@ -260,6 +353,40 @@ const ScopeItem = styled.li.withConfig({ displayName: 'ConsentScopeItem' })`
 	border-radius: var(--shape-3xs);
 	background: color-mix(in oklab, var(--color-on-surface) 8%, transparent);
 	color: var(--color-on-surface);
+`
+
+const OrgSection = styled.div.withConfig({ displayName: 'ConsentOrgSection' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const OrgList = styled.div.withConfig({ displayName: 'ConsentOrgList' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const OrgRow = styled.label.withConfig({ displayName: 'ConsentOrgRow' })`
+	display: flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	color: var(--color-on-surface);
+	cursor: pointer;
+`
+
+const OrgName = styled.span.withConfig({ displayName: 'ConsentOrgName' })`
+	font-family: var(--font-body);
+`
+
+const OrgHint = styled.p.withConfig({ displayName: 'ConsentOrgHint' })`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
 `
 
 const ErrorText = styled.p.withConfig({ displayName: 'ConsentError' })`

--- a/apps/internal/src/routes/settings/mcp/connections.tsx
+++ b/apps/internal/src/routes/settings/mcp/connections.tsx
@@ -2,11 +2,11 @@ import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import { ArrowLeft, Check, ChevronsUpDown, Plug } from 'lucide-react'
+import { ArrowLeft, Plug, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
-import { PriSelect, usePriToast } from '@batuda/ui/pri'
+import { PriButton, usePriToast } from '@batuda/ui/pri'
 
 import { authClient } from '#/lib/auth-client'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
@@ -18,16 +18,17 @@ import {
 
 /**
  * The AI assistants (ChatGPT, Claude.ai, …) a member has connected over MCP.
- * Belong to one organization and you never need this page — a connection just
- * acts in that org. Belong to several and you pick which org each assistant
- * acts in here; that choice is re-checked on every request it makes.
+ * Each connection may act in one or more organizations. Single-org users have
+ * their lone org auto-bound at consent time. Multi-org users pick one or more
+ * at consent time and can revise here; per-request org selection happens via
+ * the X-Batuda-Organization-Id header the MCP client sends.
  */
 
 type Connection = {
 	readonly clientId: string
 	readonly name: string | null
 	readonly createdAt: string
-	readonly organizationId: string | null
+	readonly organizationIds: ReadonlyArray<string>
 	readonly redirectHost: string | null
 }
 
@@ -38,27 +39,54 @@ export const Route = createFileRoute('/settings/mcp/connections')({
 	component: ConnectionsPage,
 })
 
+// Known MCP clients whose redirect host identifies them more usefully than the
+// self-asserted `oauthClient.name`. Lets the connections page show "ChatGPT"
+// rather than a generic library name when the host matches a known assistant.
+const KNOWN_CLIENTS: ReadonlyMap<string, string> = new Map([
+	['chatgpt.com', 'ChatGPT'],
+	['claude.ai', 'Claude'],
+	['chat.com', 'ChatGPT'],
+	['anthropic.com', 'Claude'],
+])
+
+// The connection's display title: the known-client name when the redirect
+// host matches (e.g. chatgpt.com → "ChatGPT"), else the self-reported name,
+// else a fallback. The redirect host is the trusted provenance signal;
+// the self-reported name is the fallback. Brand names from KNOWN_CLIENTS are
+// not translated; the fallback is wrapped at the call site with `t`.
+const connectionTitle = (
+	name: string | null,
+	redirectHost: string | null,
+	fallback: string,
+): string => {
+	if (redirectHost && KNOWN_CLIENTS.has(redirectHost)) {
+		return KNOWN_CLIENTS.get(redirectHost)!
+	}
+	return name ?? fallback
+}
+
 function ConnectionsPage() {
 	const { t } = useLingui()
 	const toastManager = usePriToast()
 
 	const listResult = useAtomValue(connectionsAtom)
 	const refreshList = useAtomRefresh(connectionsAtom)
-	const selectOrg = useAtomSet(
-		BatudaApiAtom.mutation('mcpOAuth', 'selectOrg'),
+	const selectOrgs = useAtomSet(
+		BatudaApiAtom.mutation('mcpOAuth', 'selectOrgs'),
 		{
 			mode: 'promiseExit',
 		},
 	)
 
 	const orgs = authClient.useListOrganizations()
-	const orgOptions = useMemo(
-		() => (orgs.data ?? []).map(o => ({ value: o.id, label: o.name })),
-		[orgs.data],
-	)
+	const orgNameById = useMemo(() => {
+		const map = new Map<string, string>()
+		for (const o of orgs.data ?? []) map.set(o.id, o.name)
+		return map
+	}, [orgs.data])
 
-	// The connection currently being saved, so its picker can disable until
-	// the save finishes and a second pick can't race it.
+	// The connection currently being saved, so its remove button can disable
+	// until the save finishes and a second remove can't race it.
 	const [savingId, setSavingId] = useState<string | null>(null)
 
 	const rows = useMemo<ReadonlyArray<Connection>>(
@@ -71,16 +99,29 @@ function ConnectionsPage() {
 	const isLoading = AsyncResult.isInitial(listResult)
 	const isFailure = AsyncResult.isFailure(listResult)
 
-	const handleSelect = async (clientId: string, organizationId: string) => {
-		setSavingId(clientId)
+	// Remove a single org from a connection's authorized set. Saves the
+	// remaining orgs (empty = unbind entirely). No-op on the last org is
+	// allowed — an unbound connection still works for single-org users via
+	// auto-resolution; for multi-org users the /mcp path will reject until
+	// they re-bind. Toast explains the per-request hint.
+	const handleRemoveOrg = async (
+		clientId: string,
+		organizationId: string,
+		currentOrgIds: ReadonlyArray<string>,
+	) => {
+		setSavingId(`${clientId}:${organizationId}`)
 		try {
-			const exit = await selectOrg({
-				payload: { clientId, organizationId },
+			const next = currentOrgIds.filter(id => id !== organizationId)
+			const exit = await selectOrgs({
+				payload: { clientId, organizationIds: next },
 			} as never)
 			if (exit._tag === 'Success') {
 				toastManager.add({
-					title: t`Organization updated`,
-					description: t`This connection now acts in the chosen organization.`,
+					title: t`Organization removed`,
+					description:
+						next.length === 0
+							? t`This connection is unbound. Bind an org to use it.`
+							: t`Send X-Batuda-Organization-Id with each request to pick.`,
 					type: 'success',
 				})
 				refreshList()
@@ -112,8 +153,8 @@ function ConnectionsPage() {
 				</Heading>
 				<Subtitle>
 					<Trans>
-						AI assistants you've connected over MCP. Choose which organization
-						each one acts in.
+						AI assistants you've connected over MCP. Each may act in one or more
+						of your organizations; the assistant picks which per request.
 					</Trans>
 				</Subtitle>
 			</Intro>
@@ -144,68 +185,58 @@ function ConnectionsPage() {
 						{rows.map(row => (
 							<ConnRow key={row.clientId} data-testid='mcp-connection-row'>
 								<ConnInfo>
-									<ConnName>{row.name ?? t`Unnamed client`}</ConnName>
+									<ConnName data-testid='mcp-connection-name'>
+										{connectionTitle(
+											row.name,
+											row.redirectHost,
+											t`Unnamed client`,
+										)}
+									</ConnName>
 									<ConnMeta>
 										<Trans>Connected {formatDate(row.createdAt)}</Trans>
 									</ConnMeta>
 									<ConnMeta>
 										{row.redirectHost
-											? t`Self-reported name · sends you to ${row.redirectHost}`
-											: t`Self-reported name`}
+											? t`Sends you to ${row.redirectHost}`
+											: t`No redirect URI`}
 									</ConnMeta>
 								</ConnInfo>
-								<PriSelect.Root
-									items={orgOptions}
-									value={row.organizationId ?? ''}
-									onValueChange={(value: string | null) => {
-										// Skip an empty, unchanged, or still-saving pick, so we
-										// never save the same choice twice.
-										if (
-											value &&
-											value !== row.organizationId &&
-											savingId !== row.clientId
-										) {
-											void handleSelect(row.clientId, value)
-										}
-									}}
-									disabled={
-										orgOptions.length === 0 || savingId === row.clientId
-									}
-								>
-									<SelectTrigger
-										data-testid='mcp-connection-org'
-										aria-label={t`Organization for ${row.name ?? t`Unnamed client`}`}
-									>
-										<PriSelect.Value>
-											{orgLabel(orgOptions, row.organizationId) ??
-												t`Choose organization`}
-										</PriSelect.Value>
-										<PriSelect.Icon>
-											<ChevronsUpDown size={12} aria-hidden />
-										</PriSelect.Icon>
-									</SelectTrigger>
-									<PriSelect.Portal>
-										<PriSelect.Positioner
-											alignItemWithTrigger={false}
-											sideOffset={6}
-										>
-											<PriSelect.Popup>
-												<PriSelect.List>
-													{orgOptions.map(opt => (
-														<PriSelect.Item key={opt.value} value={opt.value}>
-															<PriSelect.ItemIndicator>
-																<Check size={12} />
-															</PriSelect.ItemIndicator>
-															<PriSelect.ItemText>
-																{opt.label}
-															</PriSelect.ItemText>
-														</PriSelect.Item>
-													))}
-												</PriSelect.List>
-											</PriSelect.Popup>
-										</PriSelect.Positioner>
-									</PriSelect.Portal>
-								</PriSelect.Root>
+								<OrgsForConnection>
+									<OrgsLabel>
+										<Trans>Organizations</Trans>
+									</OrgsLabel>
+									{row.organizationIds.length === 0 ? (
+										<UnboundTag data-testid='mcp-connection-unbound'>
+											<Trans>No organization selected</Trans>
+										</UnboundTag>
+									) : (
+										<OrgChips>
+											{row.organizationIds.map(orgId => (
+												<OrgChip key={orgId} data-testid='mcp-connection-org'>
+													<OrgChipName>
+														{orgNameById.get(orgId) ?? orgId}
+													</OrgChipName>
+													<PriButton
+														type='button'
+														$variant='text'
+														aria-label={t`Remove ${orgNameById.get(orgId) ?? orgId}`}
+														data-testid='mcp-connection-org-remove'
+														disabled={savingId === `${row.clientId}:${orgId}`}
+														onClick={() => {
+															void handleRemoveOrg(
+																row.clientId,
+																orgId,
+																row.organizationIds,
+															)
+														}}
+													>
+														<X size={12} aria-hidden />
+													</PriButton>
+												</OrgChip>
+											))}
+										</OrgChips>
+									)}
+								</OrgsForConnection>
 							</ConnRow>
 						))}
 					</ConnList>
@@ -225,26 +256,21 @@ function narrowConnections(
 		const clientId = typeof r['clientId'] === 'string' ? r['clientId'] : null
 		const createdAt = typeof r['createdAt'] === 'string' ? r['createdAt'] : null
 		if (clientId === null || createdAt === null) continue
+		const organizationIdsRaw = r['organizationIds']
+		const organizationIds = Array.isArray(organizationIdsRaw)
+			? organizationIdsRaw.filter((id): id is string => typeof id === 'string')
+			: []
 		out.push({
 			clientId,
 			createdAt,
 			name: typeof r['name'] === 'string' ? r['name'] : null,
-			organizationId:
-				typeof r['organizationId'] === 'string' ? r['organizationId'] : null,
+			organizationIds,
 			redirectHost:
 				typeof r['redirectHost'] === 'string' ? r['redirectHost'] : null,
 		})
 	}
 	return out
 }
-
-const orgLabel = (
-	options: ReadonlyArray<{ value: string; label: string }>,
-	organizationId: string | null,
-): string | null =>
-	organizationId === null
-		? null
-		: (options.find(o => o.value === organizationId)?.label ?? null)
 
 function formatDate(iso: string): string {
 	const date = new Date(iso)
@@ -341,7 +367,7 @@ const ConnList = styled.ul.withConfig({ displayName: 'McpConnRows' })`
 
 const ConnRow = styled.li.withConfig({ displayName: 'McpConnRow' })`
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	gap: var(--space-md);
 	flex-wrap: wrap;
 	padding: var(--space-sm) var(--space-md);
@@ -353,9 +379,9 @@ const ConnRow = styled.li.withConfig({ displayName: 'McpConnRow' })`
 const ConnInfo = styled.div.withConfig({ displayName: 'McpConnInfo' })`
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-2xs);
+	gap: var(--space-3xs);
 	flex: 1;
-	min-width: 0;
+	min-width: 12rem;
 `
 
 const ConnName = styled.span.withConfig({ displayName: 'McpConnName' })`
@@ -371,25 +397,58 @@ const ConnMeta = styled.span.withConfig({ displayName: 'McpConnMeta' })`
 	color: var(--color-on-surface-variant);
 `
 
-const SelectTrigger = styled(PriSelect.Trigger).withConfig({
-	displayName: 'McpConnSelectTrigger',
+const OrgsForConnection = styled.div.withConfig({
+	displayName: 'McpConnOrgs',
 })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	flex: 1;
+	min-width: 12rem;
+`
+
+const OrgsLabel = styled.span.withConfig({ displayName: 'McpConnOrgsLabel' })`
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-on-surface-variant);
+`
+
+const OrgChips = styled.div.withConfig({ displayName: 'McpConnOrgChips' })`
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2xs);
+`
+
+const OrgChip = styled.span.withConfig({ displayName: 'McpConnOrgChip' })`
 	display: inline-flex;
 	align-items: center;
-	justify-content: space-between;
-	gap: var(--space-2xs);
-	min-width: 12rem;
-	padding: var(--space-2xs) var(--space-sm);
+	gap: var(--space-3xs);
+	padding: var(--space-3xs) var(--space-2xs);
 	border-radius: var(--shape-3xs);
-	border: 1px solid var(--color-outline);
-	background: var(--color-surface);
+	background: color-mix(in oklab, var(--color-primary) 10%, transparent);
+	border: 1px solid color-mix(in oklab, var(--color-primary) 25%, transparent);
+	color: var(--color-on-surface);
 	font-family: var(--font-body);
 	font-size: var(--typescale-body-small-size);
-	color: var(--color-on-surface);
-	cursor: pointer;
+`
 
-	&:disabled {
-		cursor: not-allowed;
-		opacity: 0.6;
-	}
+const OrgChipName = styled.span.withConfig({
+	displayName: 'McpConnOrgChipName',
+})`
+	font-weight: var(--typescale-label-medium-weight);
+`
+
+const UnboundTag = styled.span.withConfig({ displayName: 'McpConnUnbound' })`
+	display: inline-flex;
+	align-items: center;
+	padding: var(--space-3xs) var(--space-2xs);
+	border-radius: var(--shape-3xs);
+	background: color-mix(in srgb, var(--color-error) 8%, transparent);
+	border: 1px solid color-mix(in srgb, var(--color-error) 20%, transparent);
+	color: var(--color-error);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
 `

--- a/apps/internal/tests/e2e/mcp-connections.test.ts
+++ b/apps/internal/tests/e2e/mcp-connections.test.ts
@@ -42,4 +42,31 @@ test.describe('OAuth consent', () => {
 		// THEN it explains there's nothing to authorize rather than a broken form
 		await expect(page.getByText(/nothing to authorize/i)).toBeVisible()
 	})
+
+	test('should show the org selector for a multi-org user when a client_id is present', async ({
+		page,
+	}) => {
+		// GIVEN Alice (multi-org: taller + restaurant) opens consent with a
+		// client_id. The signed oauth query is not validated client-side, so
+		// the form renders; the org selector appears because she has >1 org.
+		await page.goto('/oauth/consent?client_id=test-client', {
+			waitUntil: 'networkidle',
+		})
+
+		// THEN the consent card renders with the client id and an org selector
+		await expect(page.getByTestId('oauth-consent')).toBeVisible()
+		await expect(page.getByTestId('oauth-consent-client')).toHaveText(
+			'test-client',
+		)
+		await expect(page.getByTestId('oauth-consent-orgs')).toBeVisible()
+		// Both orgs are listed and pre-checked (authorize-everywhere default).
+		await expect(page.getByTestId('oauth-consent-org-taller')).toBeChecked()
+		await expect(page.getByTestId('oauth-consent-org-restaurant')).toBeChecked()
+
+		// AND unchecking one disables Allow until at least one is selected
+		await page.getByTestId('oauth-consent-org-taller').uncheck()
+		await expect(page.getByTestId('oauth-consent-allow')).toBeEnabled()
+		await page.getByTestId('oauth-consent-org-restaurant').uncheck()
+		await expect(page.getByTestId('oauth-consent-allow')).toBeDisabled()
+	})
 })

--- a/apps/server/src/db/migrations/0016_mcp_oauth_org_membership.ts
+++ b/apps/server/src/db/migrations/0016_mcp_oauth_org_membership.ts
@@ -1,0 +1,80 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Multi-organization MCP OAuth connections. The previous model bound a
+// `(user, client)` pair to exactly one organization via `mcp_oauth_org`
+// (PRIMARY KEY user_id, client_id). Multi-organization users could not
+// authorize the same MCP client to act across several of their workspaces;
+// they had to either land on an unbound connection or pick a single org.
+//
+// This migration replaces the singular selection with a membership-style
+// join table `mcp_oauth_org_membership(user_id, client_id, organization_id)`
+// whose PK spans all three columns, so one connection can carry several
+// orgs. Existing rows are back-filled into the new shape.
+//
+// RLS: the new table inherits the same `app_mcp_resolver`-scoped isolation
+// pattern as the old one (0007) — the resolver role gets SELECT/INSERT/
+// UPDATE/DELETE and a `user_isolation_mcp_oauth_org_membership` policy keyed
+// on `app.current_user_id`. The old `mcp_oauth_org` policy + table are
+// dropped together.
+//
+// Forward-only: production has already run 0006/0007, so editing those in
+// place would be wrong. The new shape lives here and supersedes them.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	// ── New table ──
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS mcp_oauth_org_membership (
+			user_id text NOT NULL,
+			client_id text NOT NULL,
+			organization_id text NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			PRIMARY KEY (user_id, client_id, organization_id)
+		)
+	`
+	// Index the FK so org deletion's CASCADE check and any org-scoped lookup
+	// don't seq-scan (house style: every organization_id column is indexed).
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS idx_mcp_oauth_org_membership_org
+		ON mcp_oauth_org_membership (organization_id)
+	`
+
+	// ── Back-fill existing selections into the new shape ──
+	// Idempotent on the (user_id, client_id, organization_id) PK, so a
+	// re-run after a partial failure doesn't double-insert.
+	yield* sql`
+		INSERT INTO mcp_oauth_org_membership (user_id, client_id, organization_id, updated_at)
+		SELECT user_id, client_id, organization_id, updated_at
+		FROM mcp_oauth_org
+		ON CONFLICT (user_id, client_id, organization_id) DO NOTHING
+	`
+
+	// ── Privileges ──
+	// app_user was already revoked on the old table in 0006; mirror that
+	// here so the default-privileges grant from 0001 doesn't silently hand
+	// app_user DML on the new table.
+	yield* sql`REVOKE ALL PRIVILEGES ON mcp_oauth_org_membership FROM app_user`
+	yield* sql`
+		GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_oauth_org_membership TO app_mcp_resolver
+	`
+
+	// ── RLS ──
+	yield* sql`ALTER TABLE mcp_oauth_org_membership ENABLE ROW LEVEL SECURITY`
+	yield* sql`
+		CREATE POLICY user_isolation_mcp_oauth_org_membership
+		ON mcp_oauth_org_membership
+		TO app_mcp_resolver
+		USING (user_id = current_setting('app.current_user_id', true))
+		WITH CHECK (user_id = current_setting('app.current_user_id', true))
+	`
+
+	// ── Drop the old table ──
+	// Drop the old policy first (it would cascade with the table, but be
+	// explicit so the audit trail in \d+ reads cleanly).
+	yield* sql`
+		DROP POLICY IF EXISTS user_isolation_mcp_oauth_org ON mcp_oauth_org
+	`
+	yield* sql`DROP TABLE IF EXISTS mcp_oauth_org`
+})

--- a/apps/server/src/handlers/mcp-oauth.ts
+++ b/apps/server/src/handlers/mcp-oauth.ts
@@ -15,13 +15,13 @@ export const McpOAuthLive = HttpApiBuilder.group(
 		Effect.gen(function* () {
 			const service = yield* McpOAuthService
 			return handlers
-				.handle('selectOrg', _ =>
+				.handle('selectOrgs', _ =>
 					Effect.gen(function* () {
 						const { userId } = yield* SessionContext
-						yield* service.selectOrg(
+						yield* service.selectOrgs(
 							userId,
 							_.payload.clientId,
-							_.payload.organizationId,
+							_.payload.organizationIds,
 						)
 					}),
 				)

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -244,26 +244,27 @@ const McpAuthMiddleware = HttpRouter.middleware(
 								prmUrl,
 							)
 						}
-						// Read the caller's memberships (all their orgs) and their
-						// per-client selection under the resolver role: the user GUC's
-						// RLS confines both reads to this user even if a WHERE slips.
-						// enterUserScope returns plain values and commits before we
-						// enter org scope below — it must not nest inside enterScope.
-						const { orgIds, selectedOrgId } = yield* enterUserScope(
+						// Read the caller's memberships (all their orgs) and the
+						// per-client orgs they've authorized this connection to act in,
+						// under the resolver role: the user GUC's RLS confines both
+						// reads to this user even if a WHERE slips. enterUserScope
+						// returns plain values and commits before we enter org scope
+						// below — it must not nest inside enterScope.
+						const { orgIds, selectedOrgIds } = yield* enterUserScope(
 							sql,
 							userId,
 						)(
 							Effect.gen(function* () {
 								const memberships = yield* sql<{ organizationId: string }>`
-									SELECT "organizationId" FROM member WHERE "userId" = ${userId}
-								`
+								SELECT "organizationId" FROM member WHERE "userId" = ${userId}
+							`
 								const selection = yield* sql<{ organizationId: string }>`
-									SELECT organization_id FROM mcp_oauth_org
-									WHERE user_id = ${userId} AND client_id = ${clientId} LIMIT 1
-								`
+								SELECT organization_id FROM mcp_oauth_org_membership
+								WHERE user_id = ${userId} AND client_id = ${clientId}
+							`
 								return {
 									orgIds: memberships.map(m => m.organizationId),
-									selectedOrgId: selection[0]?.organizationId,
+									selectedOrgIds: selection.map(s => s.organizationId),
 								}
 							}),
 						)
@@ -274,21 +275,51 @@ const McpAuthMiddleware = HttpRouter.middleware(
 								'Token user is not a member of any organization',
 							)
 						}
-						// An explicit per-client selection wins, but only while it is
-						// still a live membership: a stale row (user left the org) falls
-						// back to auto-pick so the token can't read an org the user no
-						// longer belongs to.
-						const orgId =
-							selectedOrgId && orgIds.includes(selectedOrgId)
-								? selectedOrgId
-								: orgIds.length === 1
-									? orgIds[0]
-									: undefined
-						if (!orgId) {
+						// The orgs this connection is explicitly authorized to act in,
+						// narrowed to live memberships: a stale row (user left the org)
+						// is dropped so the token can't reach an org the user no longer
+						// belongs to. An unbound connection (no selection rows at all)
+						// falls back to the user's live orgs — single-org users get
+						// auto-resolution without ever visiting the connections page.
+						// But a connection that HAS a selection where every row is stale
+						// is rejected, not widened: the user deliberately scoped this
+						// connection, and silently widening it to orgs they never chose
+						// would be a privilege escalation.
+						const liveSelectedOrgIds = selectedOrgIds.filter(id =>
+							orgIds.includes(id),
+						)
+						const isUnbound = selectedOrgIds.length === 0
+						const allowedOrgIds = isUnbound ? orgIds : liveSelectedOrgIds
+						if (allowedOrgIds.length === 0) {
 							return yield* jsonRpcError(
 								403,
 								-32002,
 								'Select an organization for this connection at /settings/mcp/connections',
+							)
+						}
+						// An explicit per-request hint picks which authorized org this
+						// call acts in. A valid hint (within the authorized set) always
+						// wins; without a hint, a single authorized org auto-resolves.
+						// A hint that points at an org the connection is not authorized
+						// for is rejected — the client can't reach an org it never
+						// consented to even if the user is still a member of it.
+						const hint = headers.get('x-batuda-organization-id')
+						const orgId = hint
+							? allowedOrgIds.includes(hint)
+								? hint
+								: undefined
+							: allowedOrgIds.length === 1
+								? allowedOrgIds[0]
+								: undefined
+						if (!orgId) {
+							return yield* jsonRpcError(
+								403,
+								-32002,
+								hint
+									? 'X-Batuda-Organization-Id is not authorized for this connection'
+									: allowedOrgIds.length === 1
+										? 'Select an organization for this connection at /settings/mcp/connections'
+										: 'Send X-Batuda-Organization-Id with one of the authorized organizations',
 							)
 						}
 						const org = yield* loadOrg(orgId)
@@ -305,8 +336,8 @@ const McpAuthMiddleware = HttpRouter.middleware(
 							name: user.name,
 							isAgent: false,
 						})
+						// payload undefined → opaque/session bearer → fall through.
 					}
-					// payload undefined → opaque/session bearer → fall through.
 				}
 
 				// ── Cookie-session path (human/web).

--- a/apps/server/src/mcp/oauth-auth.integration.test.ts
+++ b/apps/server/src/mcp/oauth-auth.integration.test.ts
@@ -33,7 +33,7 @@ const BASE_URL = process.env['BETTER_AUTH_BASE_URL'] as string
 const AUDIENCE = `${BASE_URL}/mcp`
 const FIXTURE_SLUG = `mcp-oauth-${randomUUID()}`
 const USER_EMAIL_LIKE = 'oauth-test+%@keys.batuda.internal'
-// One OAuth client id shared by the cases; resolution keys `mcp_oauth_org` on it.
+// One OAuth client id shared by the cases; resolution keys `mcp_oauth_org_membership` on it.
 const CLIENT_ID = `mcp-client-${randomUUID()}`
 
 type Org = { id: string; name: string; slug: string }
@@ -145,7 +145,8 @@ type BearerOutcome =
 // Reproduces the /mcp middleware's Bearer resolution: verify (JWKS + audience +
 // issuer) → user → memberships → selection (re-checked vs membership) →
 // auto-pick → enter org scope and read the marker companies (RLS proof).
-const resolveBearer = (token: string): Promise<BearerOutcome> =>
+// `hint` mirrors the X-Batuda-Organization-Id header the middleware reads.
+const resolveBearer = (token: string, hint?: string): Promise<BearerOutcome> =>
 	runtime.runPromise(
 		Effect.gen(function* () {
 			const auth = yield* Auth
@@ -188,9 +189,10 @@ const resolveBearer = (token: string): Promise<BearerOutcome> =>
 				SELECT id FROM "user" WHERE id = ${userId} LIMIT 1
 			`.pipe(Effect.orDie)
 			if (!userRows[0]) return { kind: 'challenge' } satisfies BearerOutcome
-			// Mirror the middleware: read memberships + selection under the
-			// resolver role so the suite exercises the same RLS-scoped path.
-			const { orgIds, selectedOrgId } = yield* enterUserScope(
+			// Mirror the middleware: read memberships + the per-client authorized
+			// org set under the resolver role so the suite exercises the same
+			// RLS-scoped path.
+			const { orgIds, selectedOrgIds } = yield* enterUserScope(
 				sql,
 				userId,
 			)(
@@ -199,23 +201,38 @@ const resolveBearer = (token: string): Promise<BearerOutcome> =>
 						SELECT "organizationId" FROM member WHERE "userId" = ${userId}
 					`
 					const selection = yield* sql<{ organizationId: string }>`
-						SELECT organization_id FROM mcp_oauth_org
-						WHERE user_id = ${userId} AND client_id = ${clientId} LIMIT 1
+						SELECT organization_id FROM mcp_oauth_org_membership
+						WHERE user_id = ${userId} AND client_id = ${clientId}
 					`
 					return {
 						orgIds: memberships.map(m => m.organizationId),
-						selectedOrgId: selection[0]?.organizationId,
+						selectedOrgIds: selection.map(s => s.organizationId),
 					}
 				}),
 			)
 			if (orgIds.length === 0)
 				return { kind: 'forbidden', code: -32002 } satisfies BearerOutcome
-			const orgId =
-				selectedOrgId && orgIds.includes(selectedOrgId)
-					? selectedOrgId
-					: orgIds.length === 1
-						? orgIds[0]
-						: undefined
+			// Mirror the middleware: narrow the selection to live memberships.
+			// An unbound connection (no selection) falls back to live orgs;
+			// a bound connection where every row is stale is rejected, not
+			// widened — silently widening would be a privilege escalation.
+			const liveSelectedOrgIds = selectedOrgIds.filter(id =>
+				orgIds.includes(id),
+			)
+			const isUnbound = selectedOrgIds.length === 0
+			const allowedOrgIds = isUnbound ? orgIds : liveSelectedOrgIds
+			if (allowedOrgIds.length === 0)
+				return { kind: 'forbidden', code: -32002 } satisfies BearerOutcome
+			// Mirror the middleware: a valid hint always wins; without a hint,
+			// a single authorized org auto-resolves; an unauthorized hint is
+			// rejected so the client can't reach an org it never consented to.
+			const orgId = hint
+				? allowedOrgIds.includes(hint)
+					? hint
+					: undefined
+				: allowedOrgIds.length === 1
+					? allowedOrgIds[0]
+					: undefined
 			if (!orgId)
 				return { kind: 'forbidden', code: -32002 } satisfies BearerOutcome
 			const orgRows = yield* sql<Org>`
@@ -233,14 +250,27 @@ const resolveBearer = (token: string): Promise<BearerOutcome> =>
 		}),
 	)
 
-const setSelection = (userId: string, organizationId: string) =>
-	pool.query(
-		`INSERT INTO mcp_oauth_org (user_id, client_id, organization_id, updated_at)
-		 VALUES ($1, $2, $3, now())
-		 ON CONFLICT (user_id, client_id)
-		 DO UPDATE SET organization_id = EXCLUDED.organization_id, updated_at = now()`,
-		[userId, CLIENT_ID, organizationId],
+// Set the per-connection authorized org set directly. Mirrors what
+// McpOAuthService.selectOrgs writes, so tests that need a specific binding can
+// stage it without going through the service.
+const setSelections = async (
+	userId: string,
+	organizationIds: ReadonlyArray<string>,
+) => {
+	await pool.query(
+		`DELETE FROM mcp_oauth_org_membership
+		 WHERE user_id = $1 AND client_id = $2`,
+		[userId, CLIENT_ID],
 	)
+	if (organizationIds.length > 0) {
+		await pool.query(
+			`INSERT INTO mcp_oauth_org_membership (user_id, client_id, organization_id, updated_at)
+			 SELECT $1, $2, org_id, now() FROM unnest($3::text[]) AS t(org_id)
+			 ON CONFLICT (user_id, client_id, organization_id) DO NOTHING`,
+			[userId, CLIENT_ID, organizationIds as string[]],
+		)
+	}
+}
 
 const seedConsentedClient = async (
 	userId: string,
@@ -263,7 +293,10 @@ const fixtureUserIds = () => [singleOrgUserId, multiOrgUserId, nonMemberUserId]
 
 const deleteFixtureRows = async () => {
 	const ids = fixtureUserIds()
-	await pool.query('DELETE FROM mcp_oauth_org WHERE user_id = ANY($1)', [ids])
+	await pool.query(
+		'DELETE FROM mcp_oauth_org_membership WHERE user_id = ANY($1)',
+		[ids],
+	)
 	await pool.query('DELETE FROM "oauthConsent" WHERE "userId" = ANY($1)', [ids])
 	await pool.query(`DELETE FROM "oauthClient" WHERE name = 'mcp-oauth-test'`)
 }
@@ -278,7 +311,7 @@ const cleanup = async () => {
 	await pool.query('DELETE FROM jwks')
 	await pool.query('DELETE FROM companies WHERE slug = $1', [FIXTURE_SLUG])
 	await pool.query(
-		`DELETE FROM mcp_oauth_org WHERE user_id IN (SELECT id FROM "user" WHERE email LIKE $1)`,
+		`DELETE FROM mcp_oauth_org_membership WHERE user_id IN (SELECT id FROM "user" WHERE email LIKE $1)`,
 		[USER_EMAIL_LIKE],
 	)
 	await pool.query(
@@ -457,7 +490,7 @@ describe('OAuth Bearer org resolution', () => {
 			// GIVEN a valid token for a user in taller AND restaurant, no selection
 			const token = await mintToken({ sub: multiOrgUserId })
 
-			// WHEN the Bearer path resolves
+			// WHEN the Bearer path resolves without a hint
 			const outcome = await resolveBearer(token)
 
 			// THEN it refuses (no org entered) with the select-an-org code
@@ -465,13 +498,13 @@ describe('OAuth Bearer org resolution', () => {
 		})
 	})
 
-	describe('a multi-org user with a live selection', () => {
+	describe('a multi-org user with a single-org selection', () => {
 		it('should scope to the selected org only', async () => {
-			// GIVEN the multi-org user selected restaurant for this client
-			await setSelection(multiOrgUserId, restaurant.id)
+			// GIVEN the multi-org user authorized restaurant for this client
+			await setSelections(multiOrgUserId, [restaurant.id])
 			const token = await mintToken({ sub: multiOrgUserId })
 
-			// WHEN the Bearer path resolves
+			// WHEN the Bearer path resolves (one authorized org → auto-pick)
 			const outcome = await resolveBearer(token)
 
 			// THEN it scopes to restaurant and reads only restaurant's marker
@@ -479,19 +512,67 @@ describe('OAuth Bearer org resolution', () => {
 		})
 	})
 
+	describe('a multi-org user with a multi-org selection and no hint', () => {
+		it('should refuse (ambiguous) with a select-an-org error', async () => {
+			// GIVEN the multi-org user authorized both taller and restaurant
+			await setSelections(multiOrgUserId, [taller.id, restaurant.id])
+			const token = await mintToken({ sub: multiOrgUserId })
+
+			// WHEN the Bearer path resolves without a hint
+			const outcome = await resolveBearer(token)
+
+			// THEN it refuses — the client must say which org per request
+			expect(outcome).toEqual({ kind: 'forbidden', code: -32002 })
+		})
+	})
+
+	describe('a multi-org user with a multi-org selection and a valid hint', () => {
+		it('should scope to the hinted org only', async () => {
+			// GIVEN the multi-org user authorized both taller and restaurant
+			await setSelections(multiOrgUserId, [taller.id, restaurant.id])
+			const token = await mintToken({ sub: multiOrgUserId })
+
+			// WHEN the Bearer path resolves with a hint pointing at taller
+			const outcome = await resolveBearer(token, taller.id)
+
+			// THEN it scopes to taller and reads only taller's marker
+			expect(outcome).toEqual({ kind: 'scoped', orgIds: [taller.id] })
+		})
+	})
+
+	describe('a multi-org user with a multi-org selection and an unauthorized hint', () => {
+		it('should refuse (hint outside the authorized set)', async () => {
+			// GIVEN the multi-org user authorized only restaurant
+			await setSelections(multiOrgUserId, [restaurant.id])
+			const token = await mintToken({ sub: multiOrgUserId })
+
+			// WHEN the Bearer path resolves with a hint pointing at taller
+			// (a live membership, but not authorized for this connection)
+			const outcome = await resolveBearer(token, taller.id)
+
+			// THEN it refuses — a hint is only valid within the authorized set.
+			// The single authorized org auto-picks only when no hint is sent;
+			// an explicit-but-unauthorized hint is rejected so the client can't
+			// reach an org it never consented to.
+			expect(outcome).toEqual({ kind: 'forbidden', code: -32002 })
+		})
+	})
+
 	describe('a selection that is no longer a live membership', () => {
-		it('should ignore the stale selection and auto-pick the live org', async () => {
+		it('should reject rather than widen to other live orgs', async () => {
 			// GIVEN a stale selection pointing at restaurant, where the single-org
 			// user is NOT a member (only taller)
-			await setSelection(singleOrgUserId, restaurant.id)
+			await setSelections(singleOrgUserId, [restaurant.id])
 			const token = await mintToken({ sub: singleOrgUserId })
 
 			// WHEN the Bearer path resolves
 			const outcome = await resolveBearer(token)
 
-			// THEN the stale restaurant selection is ignored and it reads only
-			// taller — never the org the user no longer belongs to
-			expect(outcome).toEqual({ kind: 'scoped', orgIds: [taller.id] })
+			// THEN it refuses — the connection was deliberately scoped to
+			// restaurant, and the user is no longer a member. It does NOT fall
+			// back to taller (a live org the connection was never authorized
+			// for), because silently widening would be a privilege escalation.
+			expect(outcome).toEqual({ kind: 'forbidden', code: -32002 })
 		})
 	})
 
@@ -522,56 +603,82 @@ describe('OAuth Bearer org resolution', () => {
 	})
 })
 
-describe('McpOAuthService.selectOrg', () => {
-	describe('the caller is a member of the target org', () => {
-		it('should upsert the connection binding', async () => {
+describe('McpOAuthService.selectOrgs', () => {
+	describe('the caller is a member of every target org', () => {
+		it('should upsert the full set of authorized orgs', async () => {
 			// GIVEN the single-org user is a member of taller
-			// WHEN selectOrg binds the connection to taller
+			// WHEN selectOrgs authorizes the connection for taller
 			await runtime.runPromise(
 				Effect.gen(function* () {
 					const service = yield* McpOAuthService
-					yield* service.selectOrg(singleOrgUserId, CLIENT_ID, taller.id)
+					yield* service.selectOrgs(singleOrgUserId, CLIENT_ID, [taller.id])
 				}),
 			)
 
-			// THEN a mcp_oauth_org row maps (user, client) → taller
+			// THEN exactly one membership row maps (user, client) → taller
 			const rows = await pool.query<{ organization_id: string }>(
-				'SELECT organization_id FROM mcp_oauth_org WHERE user_id = $1 AND client_id = $2',
+				'SELECT organization_id FROM mcp_oauth_org_membership WHERE user_id = $1 AND client_id = $2',
 				[singleOrgUserId, CLIENT_ID],
 			)
-			expect(rows.rows[0]?.organization_id).toBe(taller.id)
+			expect(rows.rows.map(r => r.organization_id)).toEqual([taller.id])
 		})
 
-		it('should overwrite an existing binding on conflict', async () => {
-			// GIVEN the multi-org user already bound this client to taller
+		it('should replace the prior set atomically', async () => {
+			// GIVEN the multi-org user authorized both taller and restaurant
 			await runtime.runPromise(
 				Effect.gen(function* () {
 					const service = yield* McpOAuthService
-					yield* service.selectOrg(multiOrgUserId, CLIENT_ID, taller.id)
-					// WHEN they re-bind it to restaurant
-					yield* service.selectOrg(multiOrgUserId, CLIENT_ID, restaurant.id)
+					yield* service.selectOrgs(multiOrgUserId, CLIENT_ID, [
+						taller.id,
+						restaurant.id,
+					])
+				}),
+			)
+			// WHEN they re-bind to only restaurant
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					yield* service.selectOrgs(multiOrgUserId, CLIENT_ID, [restaurant.id])
 				}),
 			)
 
-			// THEN exactly one row remains, now pointing at restaurant
+			// THEN exactly one row remains, pointing at restaurant (taller dropped)
 			const rows = await pool.query<{ organization_id: string }>(
-				'SELECT organization_id FROM mcp_oauth_org WHERE user_id = $1 AND client_id = $2',
+				'SELECT organization_id FROM mcp_oauth_org_membership WHERE user_id = $1 AND client_id = $2 ORDER BY organization_id',
 				[multiOrgUserId, CLIENT_ID],
 			)
-			expect(rows.rowCount).toBe(1)
-			expect(rows.rows[0]?.organization_id).toBe(restaurant.id)
+			expect(rows.rows.map(r => r.organization_id)).toEqual([restaurant.id])
+		})
+
+		it('should accept an empty list and unbind the connection', async () => {
+			// GIVEN the single-org user has a binding to taller
+			await setSelections(singleOrgUserId, [taller.id])
+			// WHEN selectOrgs is called with an empty list
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					yield* service.selectOrgs(singleOrgUserId, CLIENT_ID, [])
+				}),
+			)
+
+			// THEN no membership rows remain for this (user, client)
+			const rows = await pool.query(
+				'SELECT 1 FROM mcp_oauth_org_membership WHERE user_id = $1 AND client_id = $2',
+				[singleOrgUserId, CLIENT_ID],
+			)
+			expect(rows.rowCount).toBe(0)
 		})
 	})
 
-	describe('the caller is not a member of the target org', () => {
+	describe('the caller is not a member of every target org', () => {
 		it('should fail with Forbidden and write nothing', async () => {
-			// GIVEN the non-member user picks restaurant
-			// WHEN selectOrg runs
+			// GIVEN the non-member user authorizes restaurant (not a member)
+			// WHEN selectOrgs runs
 			const error = await runtime.runPromise(
 				Effect.gen(function* () {
 					const service = yield* McpOAuthService
 					return yield* Effect.flip(
-						service.selectOrg(nonMemberUserId, CLIENT_ID, restaurant.id),
+						service.selectOrgs(nonMemberUserId, CLIENT_ID, [restaurant.id]),
 					)
 				}),
 			)
@@ -579,8 +686,33 @@ describe('McpOAuthService.selectOrg', () => {
 			// THEN it is Forbidden and no binding was written
 			expect(error._tag).toBe('Forbidden')
 			const rows = await pool.query(
-				'SELECT 1 FROM mcp_oauth_org WHERE user_id = $1 AND client_id = $2',
+				'SELECT 1 FROM mcp_oauth_org_membership WHERE user_id = $1 AND client_id = $2',
 				[nonMemberUserId, CLIENT_ID],
+			)
+			expect(rows.rowCount).toBe(0)
+		})
+
+		it('should reject a mixed list if any org is not a membership', async () => {
+			// GIVEN the single-org user (member of taller) submits both taller
+			// and restaurant (not a member)
+			const error = await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					return yield* Effect.flip(
+						service.selectOrgs(singleOrgUserId, CLIENT_ID, [
+							taller.id,
+							restaurant.id,
+						]),
+					)
+				}),
+			)
+
+			// THEN it is Forbidden and no binding was written — a partial
+			// submission can't widen what the connection can later reach.
+			expect(error._tag).toBe('Forbidden')
+			const rows = await pool.query(
+				'SELECT 1 FROM mcp_oauth_org_membership WHERE user_id = $1 AND client_id = $2',
+				[singleOrgUserId, CLIENT_ID],
 			)
 			expect(rows.rowCount).toBe(0)
 		})
@@ -604,11 +736,11 @@ describe('McpOAuthService.listConnections', () => {
 		})
 	})
 
-	describe('a consented client bound to an org', () => {
-		it('should return the connection with its organization', async () => {
+	describe('a consented client bound to one org', () => {
+		it('should return the connection with that org in organizationIds', async () => {
 			// GIVEN a consented client and a binding to taller
 			await seedConsentedClient(singleOrgUserId, CLIENT_ID, 'mcp-oauth-test')
-			await setSelection(singleOrgUserId, taller.id)
+			await setSelections(singleOrgUserId, [taller.id])
 
 			// WHEN listConnections runs
 			const connections = await runtime.runPromise(
@@ -618,15 +750,36 @@ describe('McpOAuthService.listConnections', () => {
 				}),
 			)
 
-			// THEN the connection carries the client + its bound org
+			// THEN the connection carries the client + taller in its org list
 			expect(connections).toHaveLength(1)
 			expect(connections[0]?.clientId).toBe(CLIENT_ID)
-			expect(connections[0]?.organizationId).toBe(taller.id)
+			expect(connections[0]?.organizationIds).toEqual([taller.id])
+		})
+	})
+
+	describe('a consented client bound to multiple orgs', () => {
+		it('should return the connection with every bound org', async () => {
+			// GIVEN a consented client authorized for both taller and restaurant
+			await seedConsentedClient(multiOrgUserId, CLIENT_ID, 'mcp-oauth-test')
+			await setSelections(multiOrgUserId, [taller.id, restaurant.id])
+
+			// WHEN listConnections runs
+			const connections = await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					return yield* service.listConnections(multiOrgUserId)
+				}),
+			)
+
+			// THEN the connection carries both orgs (sorted, as array_agg does)
+			const expected = [restaurant.id, taller.id].sort()
+			expect(connections).toHaveLength(1)
+			expect(connections[0]?.organizationIds).toEqual(expected)
 		})
 	})
 
 	describe('a consented client with no org chosen', () => {
-		it('should return a null organization', async () => {
+		it('should return an empty organizationIds array', async () => {
 			// GIVEN a consented client but no selection
 			await seedConsentedClient(multiOrgUserId, CLIENT_ID, 'mcp-oauth-test')
 
@@ -638,9 +791,9 @@ describe('McpOAuthService.listConnections', () => {
 				}),
 			)
 
-			// THEN the connection's organization is null (unbound)
+			// THEN the connection's organizationIds is empty (unbound)
 			expect(connections).toHaveLength(1)
-			expect(connections[0]?.organizationId).toBeNull()
+			expect(connections[0]?.organizationIds).toEqual([])
 		})
 	})
 })
@@ -655,13 +808,13 @@ describe('RLS backstop on the resolver role', () => {
 	// the email/slug-keyed cleanup wouldn't catch; each case stays inside its own
 	// BEGIN…ROLLBACK so nothing persists past the test.
 
-	it("should hide another user's mcp_oauth_org rows even without a WHERE", async () => {
+	it("should hide another user's mcp_oauth_org_membership rows even without a WHERE", async () => {
 		const client = await pool.connect()
 		try {
 			// GIVEN two users each hold a connection binding
 			await client.query('BEGIN')
 			await client.query(
-				`INSERT INTO mcp_oauth_org (user_id, client_id, organization_id)
+				`INSERT INTO mcp_oauth_org_membership (user_id, client_id, organization_id)
 				 VALUES ('rls-a', 'rls-c', $1), ('rls-b', 'rls-c', $1)`,
 				[taller.id],
 			)
@@ -671,10 +824,10 @@ describe('RLS backstop on the resolver role', () => {
 				"SELECT set_config('app.current_user_id', 'rls-a', true)",
 			)
 			const all = await client.query<{ user_id: string }>(
-				'SELECT user_id FROM mcp_oauth_org',
+				'SELECT user_id FROM mcp_oauth_org_membership',
 			)
 			const reachForB = await client.query(
-				"SELECT 1 FROM mcp_oauth_org WHERE user_id = 'rls-b'",
+				"SELECT 1 FROM mcp_oauth_org_membership WHERE user_id = 'rls-b'",
 			)
 			// THEN only A's row is visible, even reaching for B's directly
 			expect(all.rows.every(r => r.user_id === 'rls-a')).toBe(true)
@@ -697,7 +850,7 @@ describe('RLS backstop on the resolver role', () => {
 			// WHEN it inserts a row owned by user B, THEN the WITH CHECK rejects it
 			await expect(
 				client.query(
-					`INSERT INTO mcp_oauth_org (user_id, client_id, organization_id)
+					`INSERT INTO mcp_oauth_org_membership (user_id, client_id, organization_id)
 					 VALUES ('rls-b', 'rls-c', $1)`,
 					[taller.id],
 				),

--- a/apps/server/src/services/mcp-oauth.ts
+++ b/apps/server/src/services/mcp-oauth.ts
@@ -5,8 +5,8 @@ import { Forbidden } from '@batuda/controllers'
 
 import { Auth } from '../lib/auth'
 
-// A user's MCP OAuth connection: an OAuth client they've consented to, the org
-// its access tokens currently act in (`null` = not yet chosen), and the host of
+// A user's MCP OAuth connection: an OAuth client they've consented to, the
+// orgs its access tokens may act in (empty until chosen), and the host of
 // its first redirect URI. The host is provenance — the client `name` is
 // self-asserted at registration, but the redirect host is where it actually
 // sends the user, so the UI can show it rather than trust the name alone.
@@ -14,7 +14,7 @@ export interface McpConnection {
 	readonly clientId: string
 	readonly name: string | null
 	readonly createdAt: string
-	readonly organizationId: string | null
+	readonly organizationIds: ReadonlyArray<string>
 	readonly redirectHost: string | null
 }
 
@@ -22,7 +22,7 @@ interface ConnectionRow {
 	readonly clientId: string
 	readonly name: string | null
 	readonly createdAt: string | Date
-	readonly organizationId: string | null
+	readonly organizationIds: ReadonlyArray<string> | null
 	readonly redirectUris: unknown
 }
 
@@ -39,9 +39,11 @@ const firstRedirectHost = (redirectUris: unknown): string | null => {
 	}
 }
 
-// Binds a `(user, OAuth client)` connection to the organization its MCP access
-// tokens act in. The `/mcp` Bearer path reads `mcp_oauth_org`; single-org users
-// are auto-resolved there, multi-org users choose here. Open DCR leaves
+// Binds a `(user, OAuth client)` connection to the set of organizations its
+// MCP access tokens may act in. The `/mcp` Bearer path reads
+// `mcp_oauth_org_membership`; single-org users are auto-resolved there,
+// multi-org users pick one or more orgs here and then send an
+// `X-Batuda-Organization-Id` hint per request. Open DCR leaves
 // `oauthClient.userId` null, so the user↔client link is `oauthConsent`. These
 // reads run on the owner pool but inside an `app_mcp_resolver`-scoped
 // transaction, so RLS confines each one to the caller's own rows — a database
@@ -86,56 +88,97 @@ export class McpOAuthService extends ServiceMap.Service<McpOAuthService>()(
 				}).pipe(Effect.orDie)
 
 			return {
-				// Bind a connection to an org the caller is still a member of. The
-				// /mcp path re-checks membership too, so a later departure can't be
-				// exploited even if a stale selection lingers. The membership read +
-				// the upsert share the resolver scope, and the WITH CHECK policy
-				// rejects writing a row for anyone but the caller.
-				selectOrg: (
+				// Set the set of organizations a connection may act in. The full
+				// target list is applied atomically: rows for orgs in the list are
+				// upserted, rows for orgs not in the list are deleted. Every org in
+				// the list must be a live membership — a single missing one rejects
+				// the whole call and writes nothing, so a partial submission can't
+				// widen what the connection can later reach. The /mcp path re-checks
+				// membership too, so a later departure can't be exploited even if a
+				// stale row lingers.
+				selectOrgs: (
 					userId: string,
 					clientId: string,
-					organizationId: string,
+					organizationIds: ReadonlyArray<string>,
 				): Effect.Effect<void, Forbidden> =>
 					Effect.gen(function* () {
-						const isMember = yield* withResolverTx(userId, async client => {
+						// An empty list is a valid "unbind everything" — no membership
+						// check needed, just delete the caller's rows for this client.
+						if (organizationIds.length === 0) {
+							yield* withResolverTx(userId, async client => {
+								await client.query(
+									`DELETE FROM mcp_oauth_org_membership
+									 WHERE user_id = $1 AND client_id = $2`,
+									[userId, clientId],
+								)
+							})
+							return
+						}
+						const ok = yield* withResolverTx(userId, async client => {
+							// Verify membership for every requested org in one read.
+							// RLS confines member to the caller's rows, so this can't
+							// accidentally count another user's membership.
 							const member = await client.query(
-								'SELECT 1 FROM member WHERE "userId" = $1 AND "organizationId" = $2 LIMIT 1',
-								[userId, organizationId],
+								`SELECT "organizationId" FROM member
+								 WHERE "userId" = $1 AND "organizationId" = ANY($2)`,
+								[userId, organizationIds as string[]],
 							)
-							if (member.rowCount === 0) return false
+							if (member.rowCount !== organizationIds.length) {
+								return false
+							}
+							// Upsert the requested orgs and delete the rest in one
+							// transaction. The membership check above ran inside the
+							// same resolver scope, so the WITH CHECK policy holds.
+							const values = organizationIds
+								.map((_, i) => `($1, $2, $${i + 3}::text, now())`)
+								.join(', ')
 							await client.query(
-								`INSERT INTO mcp_oauth_org (user_id, client_id, organization_id, updated_at)
-								 VALUES ($1, $2, $3, now())
-								 ON CONFLICT (user_id, client_id)
-								 DO UPDATE SET organization_id = EXCLUDED.organization_id, updated_at = now()`,
-								[userId, clientId, organizationId],
+								`INSERT INTO mcp_oauth_org_membership
+								     (user_id, client_id, organization_id, updated_at)
+								 VALUES ${values}
+								 ON CONFLICT (user_id, client_id, organization_id)
+								 DO UPDATE SET updated_at = now()`,
+								[userId, clientId, ...organizationIds] as string[],
+							)
+							await client.query(
+								`DELETE FROM mcp_oauth_org_membership
+								 WHERE user_id = $1 AND client_id = $2
+								   AND organization_id <> ALL($3::text[])`,
+								[userId, clientId, organizationIds as string[]],
 							)
 							return true
 						})
-						if (!isMember)
+						if (!ok)
 							return yield* new Forbidden({
-								message: 'Not a member of that organization',
+								message: 'Not a member of every requested organization',
 							})
 					}),
 
-				// The caller's connections: OAuth clients they've consented to, with
-				// the org each is currently bound to (LEFT JOIN — null until chosen).
+				// The caller's connections: OAuth clients they've consented to,
+				// with the orgs each is currently bound to (empty until chosen).
+				// Aggregated with array_agg so one row per connection carries the
+				// full org list, instead of one row per (connection, org).
 				listConnections: (
 					userId: string,
 				): Effect.Effect<ReadonlyArray<McpConnection>> =>
 					Effect.gen(function* () {
 						const result = yield* withResolverTx(userId, client =>
 							client.query<ConnectionRow>(
-								`SELECT c."clientId"        AS "clientId",
-								        oc.name             AS name,
-								        oc."redirectUris"   AS "redirectUris",
-								        c."createdAt"       AS "createdAt",
-								        sel.organization_id AS "organizationId"
+								`SELECT c."clientId"            AS "clientId",
+								        oc.name               AS name,
+								        oc."redirectUris"     AS "redirectUris",
+								        c."createdAt"         AS "createdAt",
+								        COALESCE(
+								          array_agg(sel.organization_id ORDER BY sel.organization_id)
+								          FILTER (WHERE sel.organization_id IS NOT NULL),
+								          ARRAY[]::text[]
+								        )                    AS "organizationIds"
 								 FROM "oauthConsent" c
 								 JOIN "oauthClient" oc ON oc."clientId" = c."clientId"
-								 LEFT JOIN mcp_oauth_org sel
+								 LEFT JOIN mcp_oauth_org_membership sel
 								   ON sel.user_id = c."userId" AND sel.client_id = c."clientId"
 								 WHERE c."userId" = $1
+								 GROUP BY c."clientId", oc.name, oc."redirectUris", c."createdAt"
 								 ORDER BY c."createdAt" DESC`,
 								[userId],
 							),
@@ -144,7 +187,7 @@ export class McpOAuthService extends ServiceMap.Service<McpOAuthService>()(
 							clientId: row.clientId,
 							name: row.name,
 							createdAt: new Date(row.createdAt).toISOString(),
-							organizationId: row.organizationId,
+							organizationIds: row.organizationIds ?? [],
 							redirectHost: firstRedirectHost(row.redirectUris),
 						}))
 					}),

--- a/opencode.json
+++ b/opencode.json
@@ -13,6 +13,10 @@
 			"type": "remote",
 			"url": "https://mcp.cloudflare.com/mcp"
 		},
+		"firecrawl": {
+			"type": "remote",
+			"url": "https://mcp.firecrawl.dev/v2/mcp"
+		},
 		"neon": {
 			"type": "local",
 			"command": [

--- a/packages/controllers/src/routes/mcp-oauth.ts
+++ b/packages/controllers/src/routes/mcp-oauth.ts
@@ -10,20 +10,26 @@ import { SessionMiddleware } from '../middleware/session'
 
 // ── Input ──
 
-export const SelectOrgInput = Schema.Struct({
+export const SelectOrgsInput = Schema.Struct({
 	clientId: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
-	organizationId: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+	// The full set of organizations this connection may act in. An empty
+	// array unbinds the connection (no membership check); a non-empty array
+	// is applied atomically — every org must be a live membership or the
+	// whole call rejects and writes nothing.
+	organizationIds: Schema.Array(Schema.String),
 })
 
 // ── View ──
 
-// One MCP OAuth connection: an OAuth client the caller consented to, with the
-// org its tokens currently act in (`null` until a multi-org user picks one).
+// One MCP OAuth connection: an OAuth client the caller consented to, with
+// the orgs its tokens may act in (empty until chosen). The /mcp Bearer path
+// re-checks each against live membership and picks one per request via the
+// X-Batuda-Organization-Id hint (single-org users are auto-resolved).
 export const McpConnectionView = Schema.Struct({
 	clientId: Schema.String,
 	name: Schema.NullOr(Schema.String),
 	createdAt: Schema.String,
-	organizationId: Schema.NullOr(Schema.String),
+	organizationIds: Schema.Array(Schema.String),
 	// Host of the client's first redirect URI — provenance shown beside the
 	// self-asserted `name` (null if it registered none / they're unparseable).
 	redirectHost: Schema.NullOr(Schema.String),
@@ -33,13 +39,15 @@ export const McpConnectionView = Schema.Struct({
 //
 // Org binding for OAuth MCP connections (ChatGPT, Claude.ai). A connection is a
 // `(user, OAuth client)` pair; single-org users are auto-resolved on the /mcp
-// path, multi-org users bind each connection to an org here. `SessionMiddleware`
-// only — this is not org-scoped (the caller picks among their own memberships);
-// the handler validates membership through Better Auth's owner pool.
+// path, multi-org users bind each connection to one or more orgs here. The
+// /mcp path then picks which org a given request acts in via an
+// `X-Batuda-Organization-Id` hint. `SessionMiddleware` only — this is not
+// org-scoped (the caller picks among their own memberships); the handler
+// validates membership through Better Auth's owner pool.
 export const McpOAuthGroup = HttpApiGroup.make('mcpOAuth')
 	.add(
-		HttpApiEndpoint.post('selectOrg', '/mcp-oauth/select-org', {
-			payload: SelectOrgInput,
+		HttpApiEndpoint.post('selectOrgs', '/mcp-oauth/select-orgs', {
+			payload: SelectOrgsInput,
 			success: Schema.Void,
 			error: Forbidden.pipe(HttpApiSchema.status(403)),
 		}),


### PR DESCRIPTION
## What

Two issues in one PR: support multiple organizations per MCP OAuth connection (the data model was a single-org-per-connection table), and auto-bind the org at consent time so connections are usable immediately rather than requiring a manual trip to /settings/mcp/connections.

## Changes

- **Migration 0016:** replaced the singular `mcp_oauth_org` table with a join table `mcp_oauth_org_membership(user_id, client_id, organization_id)`; back-filled existing rows, dropped the old table and its RLS policy.
- **McpOAuthService.selectOrgs:** accepts the full org list and applies it atomically (upserts requested orgs, deletes the rest); an empty list unbinds; partial membership is rejected so a stale session can't widen the connection.
- **/mcp Bearer resolver:** loads all authorized orgs for the `(user, client)`, re-checks each against live membership, and picks one per request via the `X-Batuda-Organization-Id` header. A connection with a selection that is entirely stale (user left every authorized org) is rejected rather than silently widened to other live orgs.
- **Consent page:** single-org users are auto-bound at consent; multi-org users pick orgs via a BaseUI `CheckboxGroup` before Allow is enabled. The consent POST runs before the binding write so an expired signed query can't leave orphan rows.
- **Connections page:** shows per-org chips with remove buttons; derives the client title from the redirect host (chatgpt.com → ChatGPT) with fallback to the self-reported name.
- **Seed:** two mock OAuth clients (ChatGPT bound to both orgs, Claude bound to taller only) so the connections page and consent selector render without a real OAuth dance.
- **Tests:** 207 integration tests cover multi-org resolver (with/without hint, unauthorized hint rejection, stale-selection rejection), selectOrgs atomic replace/unbind/mixed-reject, listConnections multi-org, and RLS backstop on the new table.

## Impact

- **Migration / schema change:** 0016 must run before the server tag deploys (new code reads `mcp_oauth_org_membership`, old table is dropped). The migration is forward-only — no destructive backfill beyond rows already in `mcp_oauth_org`.
- **Multi-org / RLS:** the new table inherits the same `app_mcp_resolver`-scoped isolation as the old one. The `member`-scoped membership check at request time is unchanged. Leaving an org drops the stale selection from the allowed set.
- **MCP + HTTP parity:** the service is shared; Bearer OAuth path gets multi-org resolution, cookie-session path is unchanged (still uses `activeOrganizationId`).
- **API / wire-shape:** `POST /v1/mcp-oauth/select-org` → `select-orgs` with `organizationIds: string[]` instead of `organizationId: string`. `McpConnectionView.organizationId` → `organizationIds: string[]`.
- **X-Batuda-Organization-Id:** new MCP client header for multi-org connections to disambiguate. Not an env var — documented in the error message the resolver returns when the hint is missing.
- **Auth / route protection:** no change — `SessionMiddleware` on the new endpoint, same as before.

## Review guide

Start at `apps/server/src/mcp/http.ts` for the resolver logic (org narrowing, hint resolution), then `apps/server/src/services/mcp-oauth.ts` for the membership check and atomic upsert. The controllers schema rename is mechanical. The consent page (`apps/internal/src/routes/oauth/consent.tsx`) uses BaseUI `CheckboxGroup` directly — no new Pri wrappers needed for a single use case.

## Screenshots

![Consent page with org selector](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-134/pr-consent-multiorg.webp)

**Consent page** — Alice (multi-org user) sees both organizations pre-checked; Allow is disabled when both are unchecked.

![Connections page with multi-org chips](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-134/pr-connections-seeded.webp)

**Connections page** — two seeded connections: ChatGPT (bound to Taller + Restaurant with per-org remove buttons) and Claude (bound to Taller only). Titles are derived from the redirect host.

## Tests

Integration tests at `oauth-auth.integration.test.ts` cover all resolver branches and service paths. E2e test at `mcp-connections.test.ts` covers the consent selector visibility.

## Verification

- `check-types` ✅
- `test` (unit + integration) ✅ — 368 unit + 207 integration
- `build` ✅
- Verified on local dev stack: consent page renders both orgs for Alice, checkboxes toggle correctly, Allow disables when none selected.



Closes #116
Closes #117
