### PR TITLE
feat(cli): add worktree done command

### DIFF
--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -45,10 +45,57 @@ fires the auto-provision/teardown hooks below.
 3. **Run** — `pnpm dev` → portless serves `https://<label>.batuda.localhost` (the branch's last path segment).
 4. **Inspect** — `pnpm cli worktree ls` (every worktree + its DB/URL/provisioned state),
    `pnpm cli worktree doctor` (deep health of the current one).
-5. **Tear down** — auto when **Claude** removes the worktree (the `WorktreeRemove` hook drops
-   the DB + bucket). Or `pnpm cli worktree down` — it drops the database + bucket recorded in
-   this worktree's `.env` (not re-derived from the live branch), so it stays correct even after
-   the branch is switched, e.g. by a PR merge (see Caveats).
+5. **Tear down / finish** — after the PR merges, run `pnpm cli worktree done` once to drop the data, remove the linked worktree, and clean up the local branch. For manual teardown run `pnpm cli worktree down` (DB + bucket only) and then `git worktree remove`. Auto when **Claude** removes the worktree (the `WorktreeRemove` hook drops the DB + bucket).
+
+## Post-merge / branch cleanup
+
+After the PR is merged:
+
+```bash
+pnpm cli worktree done
+```
+
+This one command detects whether it is running inside a linked worktree or the main checkout and does the safe cleanup:
+
+- linked worktree: drops DB + bucket, removes the worktree directory, checks out `main`, pulls, and deletes the local branch if it still exists.
+- main checkout: checks out `main`, pulls, and deletes the local feature branch.
+
+It refuses if the working tree is dirty; pass `--stash` to safely stash uncommitted changes and pop them on `main`, or `--force` to discard them.
+
+### What if the local branch still has changes?
+
+- **Uncommitted changes**: `worktree done` stops by default. Use `pnpm cli worktree done --stash` to stash them before cleanup and pop the stash on `main`. Alternatively, stash manually (`git stash`) and run `worktree done`, then `git stash pop` on `main`.
+- **Committed changes after a rebase-merge**: the local branch may no longer be an ancestor of `main` because the merge rewrote commits. `git branch -d` then reports "not fully merged". This is expected — the PR code is already on `main` with new hashes. Use `pnpm cli worktree done --force` (or `git branch -D <branch>`) after confirming you do not need the old local commits.
+- **Linked worktree with changes**: the worktree directory is removed, so any uncommitted changes inside it are lost unless stashed or committed first. Prefer `pnpm cli worktree done --stash`.
+
+### Manual fallback (tools without the CLI)
+
+If the tool cannot run `pnpm cli worktree done`, fall back to the manual sequences below.
+
+#### Main checkout
+
+```bash
+gh pr merge <branch> --rebase --delete-branch
+# then locally
+git checkout main
+git pull --prune
+git branch -d <branch>
+```
+
+If `git branch -d` complains the branch is not fully merged, confirm the PR is merged upstream and the local branch has been rebased/squashed, then use `git branch -D <branch>`.
+
+#### Linked worktree
+
+```bash
+cd .claude/worktrees/<name>
+gh pr merge --rebase --delete-branch   # GitHub checks main into this directory
+pnpm cli worktree down                 # drop this worktree's DB + bucket
+git worktree remove .claude/worktrees/<name>
+cd /path/to/main/checkout
+git pull --prune
+```
+
+If the directory was removed manually before `worktree down`, run `pnpm cli worktree prune` from the main checkout to find and drop the orphaned database + bucket.
 
 ## Commands (`pnpm cli worktree …`; run `--help` for flags)
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -29,6 +29,7 @@ import { servicesDown, servicesStatus, servicesUp } from './commands/services'
 import { appendEnvKeys, resetEnvFile, setup } from './commands/setup'
 import {
 	worktreeDoctor,
+	worktreeDone,
 	worktreeDown,
 	worktreeLs,
 	worktreePrune,
@@ -557,6 +558,33 @@ const worktreeDownCommand = Command.make('down', {}, () => worktreeDown).pipe(
 	),
 )
 
+const worktreeDoneCommand = Command.make(
+	'done',
+	{
+		force: Flag.boolean('force').pipe(
+			Flag.withDescription(
+				'Ignore a dirty working tree and force branch/worktree removal',
+			),
+			Flag.withDefault(false),
+		),
+		stash: Flag.boolean('stash').pipe(
+			Flag.withDescription(
+				'Stash uncommitted changes before cleanup, then pop them on main',
+			),
+			Flag.withDefault(false),
+		),
+	},
+	({ force, stash }) => worktreeDone({ force, stash }),
+).pipe(
+	Command.withShortDescription('Finish a feature branch / linked worktree'),
+	Command.withDescription(
+		'Clean up after a merged PR: drop the worktree data, remove a linked ' +
+			'worktree directory, and delete the local feature branch. From the main ' +
+			'checkout it just checks out main, pulls, and deletes the branch. ' +
+			'Fails if the working tree is dirty unless --stash or --force is passed.',
+	),
+)
+
 const worktreePruneCommand = Command.make(
 	'prune',
 	{
@@ -616,6 +644,7 @@ const worktreeCommand = Command.make('worktree').pipe(
 	Command.withSubcommands([
 		worktreeUpCommand,
 		worktreeDownCommand,
+		worktreeDoneCommand,
 		worktreePruneCommand,
 		worktreeLsCommand,
 		worktreeDoctorCommand,

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -109,6 +109,22 @@ export const isLinkedWorktree = Effect.gen(function* () {
 	return gitDir !== resolve(main, '.git')
 })
 
+const workingTreeClean = execSilent('git', 'status', '--porcelain').pipe(
+	Effect.map(out => out.trim() === ''),
+)
+
+const branchExists = (branch: string) =>
+	execSilent(
+		'git',
+		'show-ref',
+		'--verify',
+		'--quiet',
+		`refs/heads/${branch}`,
+	).pipe(
+		Effect.map(() => true),
+		Effect.catch(() => Effect.succeed(false)),
+	)
+
 const branchName = execSilent('git', 'rev-parse', '--abbrev-ref', 'HEAD')
 
 const slugForCurrentWorktree = branchName.pipe(Effect.map(slugForBranch))
@@ -418,6 +434,89 @@ export const worktreeDown = Effect.gen(function* () {
 	)
 	yield* Console.log(`✓ Removed ${db} and ${bucket} (shared stack untouched).`)
 })
+
+export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
+	Effect.gen(function* () {
+		const { force, stash } = options
+		let didStash = false
+		const clean = yield* workingTreeClean
+
+		if (!clean) {
+			if (stash) {
+				yield* exec('git', 'stash', 'push', '-u', '-m', 'batuda-worktree-done')
+				didStash = true
+				yield* Console.log('✓ Stashed uncommitted changes')
+			} else if (!force) {
+				return yield* Effect.fail(
+					new Error(
+						'Working tree is not clean. Stash with --stash, commit manually, or pass --force to discard.',
+					),
+				)
+			}
+		}
+
+		const linked = yield* isLinkedWorktree
+		const mainRoot = yield* mainCheckoutRoot()
+
+		if (linked) {
+			const branch = yield* branchName
+			const worktreePath = resolve(
+				yield* execSilent('git', 'rev-parse', '--show-toplevel'),
+			)
+			yield* Console.log(
+				`Finishing linked worktree ${worktreePath} (branch ${branch})...`,
+			)
+
+			yield* worktreeDown
+
+			// Move to the main checkout before deleting the worktree directory,
+			// otherwise subsequent git commands would run from a deleted cwd.
+			process.chdir(mainRoot)
+			const removeArgs = force
+				? ['worktree', 'remove', '--force', worktreePath]
+				: ['worktree', 'remove', worktreePath]
+			yield* execIn(mainRoot, 'git', ...removeArgs)
+			yield* Console.log('✓ Removed linked worktree directory')
+
+			yield* execIn(mainRoot, 'git', 'checkout', 'main')
+			yield* execIn(mainRoot, 'git', 'pull', '--prune')
+
+			if (yield* branchExists(branch)) {
+				const deleteArgs = force
+					? ['branch', '-D', branch]
+					: ['branch', '-d', branch]
+				yield* execIn(mainRoot, 'git', ...deleteArgs)
+				yield* Console.log(`✓ Deleted local branch ${branch}`)
+			}
+		} else {
+			const branch = yield* branchName
+			if (branch === 'main') {
+				return yield* Effect.fail(
+					new Error(
+						'Already on the main branch. Run this from a feature branch or linked worktree.',
+					),
+				)
+			}
+			yield* Console.log(`Finishing feature branch ${branch}...`)
+			yield* exec('git', 'checkout', 'main')
+			yield* exec('git', 'pull', '--prune')
+
+			if (yield* branchExists(branch)) {
+				const deleteArgs = force
+					? ['branch', '-D', branch]
+					: ['branch', '-d', branch]
+				yield* exec('git', ...deleteArgs)
+				yield* Console.log(`✓ Deleted local branch ${branch}`)
+			}
+		}
+
+		yield* Console.log('✓ Done')
+
+		if (didStash) {
+			yield* exec('git', 'stash', 'pop')
+			yield* Console.log('✓ Popped stash')
+		}
+	})
 
 // Dry-run by default: list the orphans and stop. `--yes` is required to drop,
 // so prune can never silently delete data — and because ownership is read from


### PR DESCRIPTION
## What

Add `pnpm cli worktree done`, a single cleanup command for finishing a feature branch or linked worktree after its PR merges. It replaces the manual git sequence the worktrees skill previously documented, reducing the chance of AI or human errors around branch names, cwd, and worktree removal order.

## Changes

- Added `worktreeDone` in `apps/cli/src/commands/worktree.ts`.
  - Detects main checkout vs linked worktree and runs the appropriate cleanup.
  - `--stash` stashes uncommitted changes before cleanup and pops them on `main`.
  - `--force` forces branch/worktree removal for rebase-merged branches that are no longer ancestors of `main`.
- Registered the `done` subcommand in `apps/cli/src/cli.ts`.
- Updated the worktrees skill to document the new command, `--stash`, `--force`, and rebase-merge behavior.

## Impact

- No schema, API, auth, or deploy changes.
- Affects only local dev workflow and AI skill instructions.
- The existing `worktree up/down/ls/doctor/prune` commands are unchanged.

## Review guide

- Start with `apps/cli/src/commands/worktree.ts` `worktreeDone` to see the branching logic.
- The `--stash` flow was tested end-to-end in the current session by finishing the already-merged `feat/mcp-multi-org-bindings` branch.

## Verification

- `pnpm check-types` ✅
- `pnpm --filter @batuda/cli build` ✅
- `pnpm lint` ✅
- `pnpm test` (ran by pre-push hook) ✅
- Ran `pnpm cli worktree done --stash --force` locally to finish a merged branch with uncommitted changes ✅
