### PR TITLE
In-pipeline prod migrations, explicit config, and Infisical foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Secret scan (secretlint)
+        run: pnpm lint-secrets
+
       - name: Check (Biome + dprint)
         run: pnpm check
 
@@ -111,6 +114,8 @@ jobs:
           STORAGE_ACCESS_KEY_ID: batuda
           STORAGE_SECRET_ACCESS_KEY: batuda-secret
           STORAGE_BUCKET: batuda-assets
+          EMAIL_PROVIDER: local-inbox
+          GEOCODER_PROVIDER: nominatim
         run: pnpm cli seed
 
       # --concurrency=1 forces the workspaces' test:integration tasks to

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -21,8 +21,42 @@ env:
   KRAFT_VERSION: v0.12.10
 
 jobs:
+  # Run pending migrations before the rolling deploy; they must be
+  # backward-compatible with the still-running version (docs/runbooks.md).
+  migrate:
+    name: Migrate prod database
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply migrations
+        # Migrations need a SEPARATE connection from the runtime DATABASE_URL:
+        # the schema owner `neondb_owner` (the runtime `app_service` role can't
+        # run the DDL + REVOKE/GRANT the migrations issue), over the direct
+        # (unpooled) endpoint (the pooler breaks migration locks). migrate.ts
+        # refuses a pooled host outright.
+        env:
+          DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
+        run: pnpm db:migrate
+
   deploy:
     name: Deploy to KraftCloud
+    needs: migrate
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,4 @@
+{
+	"workspaceId": "6bd2f291-890f-4b19-9a7e-002044e059d1",
+	"defaultEnvironment": "prod"
+}

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -72,11 +72,52 @@ const authMigrate = Effect.promise(async () => {
 	await pool.end()
 })
 
+// Echo which database each run targets (flagging a local host) so a stray
+// `db:migrate` can't quietly hit the wrong one, and refuse a pooled endpoint
+// outright — migrating through the pooler half-applies and corrupts.
+const isLocalHost = (host: string): boolean =>
+	host === 'localhost' || host === '127.0.0.1' || host.endsWith('.localhost')
+
+// Neon's pooled endpoint (PgBouncer, transaction mode) drops the advisory
+// locks + cross-statement transactions the migrators hold, so migrating
+// through it half-applies. Runtime uses the pooled URL; migrations must use
+// the direct one (DATABASE_URL_UNPOOLED in prod, plain DATABASE_URL wherever
+// no pooler exists).
+const isPooledHost = (host: string): boolean =>
+	host.includes('-pooler') || host.includes('pgbouncer')
+
+const logMigrationTarget = Effect.gen(function* () {
+	const raw = process.env['DATABASE_URL']
+	if (!raw) return
+	let host = 'unknown'
+	let database = 'unknown'
+	try {
+		const url = new URL(raw)
+		host = url.hostname
+		database = url.pathname.replace(/^\//, '') || 'unknown'
+	} catch {
+		// a malformed URL is surfaced by the migration steps below
+	}
+	if (isPooledHost(host)) {
+		return yield* Effect.die(
+			new Error(
+				`Refusing to migrate through a pooled connection (${host}). Point ` +
+					`DATABASE_URL at the direct/unpooled endpoint — the pooler breaks ` +
+					`the locks and transactions migrations rely on.`,
+			),
+		)
+	}
+	yield* Effect.log(
+		`Migration target: "${database}" on ${host}${isLocalHost(host) ? ' (local)' : ''}`,
+	)
+})
+
 // Better Auth migrations run first so the CRM migration (0001_initial)
 // can reference Better Auth tables — specifically the FK from
 // member.primary_inbox_id → inboxes(id) needs the `member` table to
 // already exist when the ALTER TABLE fires.
 const program = Effect.gen(function* () {
+	yield* logMigrationTarget
 	yield* Effect.log('Running Better Auth migrations...')
 	yield* authMigrate
 	yield* Effect.log('Better Auth migrations complete')

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -213,7 +213,7 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		const EMAIL_PROVIDER = yield* Config.schema(
 			Schema.Literals(['local-inbox']),
 			'EMAIL_PROVIDER',
-		).pipe(Config.withDefault('local-inbox'))
+		)
 		// AES-256-GCM master key for encrypting per-inbox IMAP/SMTP
 		// credentials at rest. Base64-encoded 32 bytes. Per-inbox subkeys
 		// are derived via HKDF-SHA256 with the inbox id as `info`, so a
@@ -228,7 +228,7 @@ export class EnvVars extends ServiceMap.Service<EnvVars>()('EnvVars', {
 		const GEOCODER_PROVIDER = yield* Config.schema(
 			Schema.Literals(['nominatim']),
 			'GEOCODER_PROVIDER',
-		).pipe(Config.withDefault('nominatim'))
+		)
 
 		// Budget defaults (system-level)
 		const RESEARCH_DEFAULT_BUDGET_CENTS = yield* Config.int(

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -25,3 +25,28 @@ Operational procedures for production. Add a new section per procedure.
 
 - Set the jwt plugin's `rotationInterval` so keys expire and regenerate on a schedule, or
 - weigh `jwks.disablePrivateKeyEncryption` — removes the secret↔key coupling but stores the signing private key **unencrypted** in the DB.
+
+## Applying database migrations
+
+Where migrations run depends on the environment, and the boundary is deliberate.
+
+**Local / worktree** — `pnpm db:migrate` runs against your local stack, with `DATABASE_URL` from `.env`. It echoes its target first — e.g. `Migration target: "batuda_feature_x" on localhost (local)` — so you can see which database you are about to touch.
+
+**Production** — migrations run **in the deploy pipeline, never from a laptop**: the `Deploy Server` workflow applies them against the prod database immediately before `kraft cloud deploy`. There is intentionally no `db:migrate:prod` script.
+
+### Connection: schema owner, direct endpoint
+
+Migrations use a **different connection from the app runtime** on two axes, so they get their own secret (`MIGRATION_DATABASE_URL`) rather than reusing `DATABASE_URL`:
+
+- **Role `neondb_owner`**, not the runtime `app_service`. Migrations issue DDL plus `REVOKE`/`GRANT`/`ALTER DEFAULT PRIVILEGES` that wire RLS for `app_user` and `app_mcp_resolver` — only the schema owner may. `app_service` (BYPASSRLS) fails these with permission errors.
+- **Direct (unpooled) endpoint.** Neon's pooler is PgBouncer in transaction mode and drops the advisory locks + cross-statement transactions the migrators hold; `migrate.ts` refuses a pooled host outright.
+
+CI gets the same shape for free — its Neon branch is created with `role: neondb_owner` on the action's direct branch URL. Runtime (`DATABASE_URL`) stays `app_service` + pooled-capable; the server `SET LOCAL ROLE app_user` / `app_mcp_resolver` per request for RLS.
+
+### Rolling-deploy compatibility
+
+The deploy is a rolling update — the old instance keeps serving while the new one boots — so each migration must stay **backward-compatible with the running version**. Add the new shape now (a nullable/defaulted column, a new table) and drop or tighten the old shape in a **later** release; renaming or dropping a column the live version still reads breaks requests mid-rollout.
+
+### Rehearsing and re-running
+
+For a destructive or large change, rehearse on a Neon branch first (branch prod → apply → verify → let the pipeline run it on prod); CI already runs every migration on an ephemeral Neon branch per PR. The migrator is incremental — it records applied migrations and a re-run only applies the pending ones, so a re-run after a partial failure resumes safely.

--- a/flake.nix
+++ b/flake.nix
@@ -44,12 +44,18 @@
             # at it to inspect traces, logs, and metrics while developing.
             # Upstream: https://github.com/ymtdzzz/otel-tui
             pkgs.otel-tui
+            # Infisical CLI — prod secrets for cloud CLI ops (`--env cloud`) and
+            # the Infisical→GitHub secret sync. Pinned here so the core team has
+            # it without a manual install; local dev runs on `pnpm cli setup`
+            # defaults and never needs it.
+            pkgs.infisical
           ];
 
           shellHook = ''
             echo "Forja dev environment"
             echo "Node:     $(node --version)"
             echo "pnpm:     $(pnpm --version)"
+            echo "infisical:$(infisical --version 2>/dev/null || echo ' available')"
             echo "wrangler: $(wrangler --version 2>/dev/null || echo 'available')"
             echo "aws:      $(aws --version 2>/dev/null || echo 'available')"
             echo "ffmpeg:   $(ffmpeg -version 2>/dev/null | head -1 | cut -d' ' -f3)"

--- a/packages/research/src/infrastructure/llm-live.ts
+++ b/packages/research/src/infrastructure/llm-live.ts
@@ -75,9 +75,7 @@ const buildSlot = (
 		)
 		const baseUrl =
 			vendor === 'custom'
-				? yield* Config.string(keyForSlot(`${envPrefix}_BASE_URL`, slot)).pipe(
-						Config.withDefault('https://api.tokenfactory.nebius.com/v1'),
-					)
+				? yield* Config.string(keyForSlot(`${envPrefix}_BASE_URL`, slot))
 				: LLM_BASE_URLS[vendor]
 		const service = yield* OpenAiLanguageModel.make({ model }).pipe(
 			Effect.provide(
@@ -106,9 +104,7 @@ const buildTierLayer = <Self>(
 				return Layer.succeed(Tag)(stubLanguageModelService)
 			}
 
-			const model = yield* Config.string(`${envPrefix}_MODEL`).pipe(
-				Config.withDefault('Qwen/Qwen3-32B'),
-			)
+			const model = yield* Config.string(`${envPrefix}_MODEL`)
 			const slots = yield* Effect.forEach(vendors, (vendor, i) =>
 				buildSlot(vendor, envPrefix, i, model),
 			)


### PR DESCRIPTION
Repo-side of #137: moves prod DB migrations into the deploy pipeline, hardens config to fail loudly, and lays the Infisical foundation.

## What's here
- **In-pipeline prod migrations** — `deploy_server.yml` applies pending migrations before the rolling deploy (gated: a migration failure blocks the rollout), on a dedicated `MIGRATION_DATABASE_URL` (schema owner + direct — the `app_service` runtime role can't run the migrations' DDL/grants, and the pooler breaks their locks).
- **Migration target guard** — `migrate.ts` echoes the target DB (flagging local) and refuses a pooled endpoint outright.
- **Explicit config** — dropped now-redundant `withDefault`s (research LLM model/base URL, `EMAIL_PROVIDER`, `GEOCODER_PROVIDER`); `config.production.json` supplies them in prod, so a missing value fails loudly at boot.
- **Secret scan in CI** — `secretlint` step.
- **Infisical foundation** — CLI in the dev shell + `.infisical.json` linking the repo to the project.
- **Runbook** — database migrations + the owner/direct vs app_service/pooled connection split.

## Before the first deploy
Add a **`MIGRATION_DATABASE_URL`** secret = the **`neondb_owner`** role on the **direct** (non-`-pooler`) endpoint. Runtime `DATABASE_URL` stays `app_service`.

## Not in this PR (deferred)
- Infisical **Secret Sync** (console → GitHub Actions secrets) — console setup.
- Cloud-CLI `infisical run` refactor (drops `.env.cloud`) — separate follow-up PR.
- Retiring the redundant GitHub Variables — manual, post-verify.

Release of the apps is gated on this merging.
