### PR TITLE
cicd: harden workflows with least-privilege tokens and pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: CI only reads the repo. No token write scope.
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Lint, Build, Type Check, Test
@@ -16,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -74,7 +78,7 @@ jobs:
 
       - name: Create Neon branch
         id: neon-branch
-        uses: neondatabase/create-branch-action@v6
+        uses: neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c # 6.3.1
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch_name: ci-${{ github.run_id }}-${{ github.run_attempt }}
@@ -141,7 +145,7 @@ jobs:
       # never created (e.g. earlier step failed).
       - name: Delete Neon branch
         if: always() && steps.neon-branch.outcome == 'success'
-        uses: neondatabase/delete-branch-action@v3
+        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3.2.1
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch: ci-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -10,6 +10,11 @@ concurrency:
   group: deploy-mail-worker
   cancel-in-progress: false
 
+# Least privilege: deploy authenticates to KraftCloud via secrets, not the
+# GitHub token. It only needs to read the repo.
+permissions:
+  contents: read
+
 env:
   KRAFTCLOUD_METRO: fra
   # Pinned to the same kraft CLI version as deploy_server.yml. Bump
@@ -25,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prepare files for KraftCloud
         run: |
@@ -34,7 +39,7 @@ jobs:
 
       - name: Cache KraftCloud CLI
         id: kraft-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: kraft.deb
           key: kraft-cli-${{ env.KRAFT_VERSION }}
@@ -105,7 +110,7 @@ jobs:
           fi
 
       - name: Deploy to KraftCloud
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
         with:

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -10,6 +10,11 @@ concurrency:
   group: deploy-server
   cancel-in-progress: false
 
+# Least privilege: deploy authenticates to KraftCloud via secrets, not the
+# GitHub token. It only needs to read the repo.
+permissions:
+  contents: read
+
 env:
   KRAFTCLOUD_METRO: fra
   # Pinned to a known-good kraft CLI version. UKC's API caps the
@@ -30,13 +35,13 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -63,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prepare files for KraftCloud
         run: |
@@ -72,7 +77,7 @@ jobs:
 
       - name: Cache KraftCloud CLI
         id: kraft-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: kraft.deb
           key: kraft-cli-${{ env.KRAFT_VERSION }}
@@ -156,7 +161,7 @@ jobs:
           fi
 
       - name: Deploy to KraftCloud
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
         with:
@@ -245,4 +250,12 @@ jobs:
         run: |
           sleep 5
           kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance list | grep batuda-server || true
-          curl --retry 5 --retry-delay 5 --retry-all-errors -sf https://api.batuda.co/health && echo "Health check passed" || echo "::warning::Health check failed"
+          # Gate the deploy on /health actually serving. curl already retries
+          # to absorb cold-boot latency; fail the job if it never comes up so a
+          # broken release doesn't pass with only a warning.
+          if curl --retry 5 --retry-delay 5 --retry-all-errors -sf https://api.batuda.co/health -o /dev/null; then
+            echo "Health check passed"
+          else
+            echo "::error::Health check failed after deploy"
+            exit 1
+          fi

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -10,6 +10,11 @@ concurrency:
   group: deploy-web
   cancel-in-progress: false
 
+# Least privilege: deploy authenticates to Cloudflare via secrets, not the
+# GitHub token. It only needs to read the repo.
+permissions:
+  contents: read
+
 env:
   # Baked into the Vite client + SSR bundles via `import.meta.env.VITE_SERVER_URL`
   # and into the worker's API proxy targets. Build-time only.
@@ -25,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -53,13 +58,24 @@ jobs:
       # managed out-of-band (CF dashboard / API), so a deploy never touches
       # the production domain binding.
       - name: Deploy
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: apps/internal
           command: deploy
 
+      # Gate the deploy on the site actually serving. Retry to absorb edge
+      # propagation latency; fail the job if it never comes up so a broken
+      # release doesn't pass silently.
       - name: Verify deployment
         run: |
-          sleep 5
-          curl -sSf https://batuda.co -o /dev/null && echo "Site is accessible" || echo "::warning::Site not accessible"
+          for attempt in 1 2 3 4 5; do
+            if curl -sSf https://batuda.co -o /dev/null; then
+              echo "Site is accessible (attempt $attempt)"
+              exit 0
+            fi
+            echo "Not up yet (attempt $attempt); retrying in 5s…"
+            sleep 5
+          done
+          echo "::error::Site not accessible after deploy"
+          exit 1

--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"


### PR DESCRIPTION
## What

Hardens all six GitHub Actions workflows (`ci`, `deploy_web`, `deploy_server`, `deploy_mail_worker`, `release`, `publish-ui`) against three risks: over-scoped workflow tokens, mutable third-party action tags, and post-deploy checks that pass even when the release isn't serving. This is ship-time CI/CD config only — no app code, no runtime behavior changes. It mirrors the same hardening already applied to the marketing repo (engranatge).

## Changes

- **Least-privilege tokens** — added `permissions: contents: read` to `ci`, `deploy_web`, `deploy_server`, and `deploy_mail_worker`, so none runs with a write-scoped `GITHUB_TOKEN`. `release` keeps `contents: write` (it pushes tags/commits) and `publish-ui` keeps `contents: read` + `id-token: write` (npm provenance) — both already correct, left as-is.
- **SHA-pinned every action** — replaced mutable `@vN` tags with full commit SHAs across all six workflows, including the new `migrate` job in `deploy_server` that landed on main while this was in flight. A version comment (`# v6.0.3`) preserves readability. Pins: checkout v6.0.3, setup-node v6.4.0, pnpm/action-setup v5.0.0, wrangler-action v4.0.0, cache v5.1.0, nick-fields/retry v4.0.0, neon create-branch 6.3.1, neon delete-branch v3.2.1.
- **Gated the deploy verify** — `deploy_web` and `deploy_server` previously passed even when the post-deploy `curl` to the live site / `/health` failed (it only emitted `::warning::`). Both now retry to absorb propagation/cold-boot latency and then `exit 1`, so a release that doesn't actually serve fails the job. `deploy_mail_worker` is unchanged: it has no HTTP endpoint, and its `kraft instance get` already exits non-zero if the worker is missing — the meaningful signal is already gated.

## Impact

- No schema, RLS, env-var, API-shape, or auth changes. Nothing about how the deployed apps run changes.
- The deploy/release/publish jobs still authenticate via their existing secrets (Cloudflare / KraftCloud / npm OIDC), not the GitHub token — narrowing the token to read-only removes an unused privilege without touching those paths.
- Pinning is functionally identical to the tags it replaces; SHAs were resolved from the same major versions already in use, so behavior is unchanged. Future action upgrades now require an explicit SHA bump (intended).
- The gated verify changes deploy **pass/fail behavior**: a deploy whose site/health check never comes up now reports red instead of green. This is the intended effect — it surfaces broken releases — but it means a flaky edge/cold-boot beyond the retry window would now fail the job rather than warn. The retry windows (web: 5×5s; server: curl `--retry 5 --retry-delay 5`) match what the old steps already waited through.

## Review guide

- Most of the diff is mechanical: a `permissions` block per file and `@tag` → `@sha # tag` swaps. The riskiest mechanical thing is a bad SHA — each was resolved live via `gh api repos/<owner>/<repo>/commits/<tag>` and the comment is the matching semver tag.
- The one **behavioral** change is the gated verify in `deploy_web` / `deploy_server` (the `Verify deployment` steps) — worth a closer look since it changes when a deploy is marked failed. `deploy_mail_worker` was intentionally left as-is (rationale in Changes).
- `release.yml` and `publish-ui.yml` intentionally keep their existing `permissions` (write / id-token) — those are required and were not downgraded.

## Verification

- All six files pass a YAML parse (`ruby -ryaml`).
- No unpinned `@vN`/`@branch` refs remain (grep across `.github/workflows/`).
- lefthook pre-commit ran clean on the commit (`check-deps`, `check-types`, `format-packages`, `lint`).
- The repo's `check-types`/`test`/`build` gates were not run for this change: it touches zero TS/app code, so they exercise main, not this diff. The meaningful validation is YAML validity + SHA correctness above. CI on this PR runs the full suite regardless.
- The gated-verify shell logic was reviewed by reading, not executed against a live deploy (it only runs inside the deploy workflows). The retry-then-`exit 1` structure mirrors the marketing repo's verified version.
