### PR TITLE
feat(internal): allow resending a pending invitation

### DIFF
--- a/apps/internal/src/routes/settings/organization/members.tsx
+++ b/apps/internal/src/routes/settings/organization/members.tsx
@@ -143,11 +143,14 @@ function MembersPage() {
 			const result = await authClient.organization.inviteMember({
 				email: trimmed,
 				role: inviteRole,
+				// Let people re-invite someone who hasn't accepted yet: reuse
+				// the open invitation (the link already in their inbox keeps
+				// working) instead of erroring on the second try.
+				resend: true,
 			})
 			if (result.error) {
-				// BA returns INVITER_NOT_FOUND, USER_ALREADY_INVITED_TO_THIS_
-				// ORGANIZATION, USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION,
-				// etc. The message is human-readable enough to surface inline.
+				// Remaining errors (already a member, no inviter, etc.) come
+				// back with a human-readable message, so we show it as-is.
 				setInviteError(
 					result.error.message ??
 						t`Could not send the invitation. Please try again.`,


### PR DESCRIPTION
## What

When an admin invites someone who already has a pending invitation, the form returned a "user already invited" error. This passes `resend: true` to Better Auth's `inviteMember` in the inline invite panel — the server reuses the existing open invitation (the link in the recipient's inbox keeps working) rather than rejecting the second submit.

Lives in the `internal` app / Organization members page (`settings/organization/members.tsx`).

## Changes

- Pass `resend: true` to `authClient.organization.inviteMember` in the new-invite panel so a second submit for an already-invited address succeeds instead of erroring.
- Update the error-handling comment to reflect what errors can still come back (already a member, no inviter).

## Impact

No schema change, no migration, no new env vars, no MCP surface, no RLS/auth touch. Change is fully contained in `apps/internal`. The dedicated resend button already used `resend: true`; this aligns the initial invite submit with the same behaviour.

## Review guide

`resend: true` is a documented Better Auth option (see `docs/repos/better-auth/packages/better-auth/src/plugins/organization/routes/crud-invites.ts` and the `describe("resend invitation should reuse existing")` test suite). No logic lives on our side; the only risk is that the option was misidentified — verified against the vendored source before opening.

> Screenshots skipped (approved): the invite panel is visually identical before and after; the change is a single API flag with no rendering effect.

## Verification

`check-types`, `test`, and `build` all pass. Pre-push hook ran tests and secrets scan — both green.