### PR TITLE
cicd: wire go-live keys, guard migrations, gate prod schema changes

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -61,22 +61,18 @@ pnpm release:server:dry   # or release:internal:dry / release:ui:dry / release:m
 
 Show the expected version and changelog. Ask for confirmation.
 
-## Step 4.5: Apply DB Migrations (if schema changed)
+## Step 4.5: DB migrations — verify, don't run
 
-Only for `server` or `all` releases (mail-worker reads/writes existing schema; no migrations live under `apps/mail-worker/`). Check whether migration files changed since the last server tag:
+**Never run prod migrations from your machine.** The `Deploy Server` workflow's `migrate` job applies them against the prod database (the schema-owner `neondb_owner` role over the direct/unpooled endpoint) immediately before the rolling `kraft cloud deploy`, gated by a required reviewer on the `production-db` GitHub environment. There is intentionally no `db:migrate:prod`. Full rationale: `docs/runbooks.md` → *Applying database migrations*.
+
+Your job at release time is to confirm the pending migrations are **safe for a rolling deploy**, not to apply them. See what changed since the last server tag:
 
 ```bash
 last_tag=$(git describe --tags --match='server-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null)
 git diff --name-only "$last_tag"..HEAD -- apps/server/src/db/migrations/
 ```
 
-If non-empty, run migrations against the direct (non-pooled) NeonDB URL from your machine before tagging:
-
-```bash
-DATABASE_URL="<neon-direct-url>" pnpm db:migrate
-```
-
-The deploy workflow does not run migrations — deploying new server code against an unmigrated schema will crash on boot.
+Each migration must be **backward-compatible with the still-running version** (expand-contract): the old instance keeps serving during the rollout, so dropping/renaming a column it still reads breaks it mid-deploy. CI already enforces this — `scripts/check-migration-safety.mjs` fails any PR that adds a non-backward-compatible migration unless it carries an `expand-contract:` marker — so a clean PR has already passed the gate. Drop the old shape only in a **later** release, once no running version reads it.
 
 ## Step 5: Execute Release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
+      # A prod deploy is a rolling update — the old instance keeps serving while
+      # the new one boots — so a migration that drops/renames a column the old
+      # version still reads breaks it mid-rollout. Fail a PR that adds a
+      # non-backward-compatible migration unless it carries an `expand-contract:`
+      # marker (docs/runbooks.md). Runs before install — needs only git + node.
+      - name: Migration safety (expand-contract)
+        run: |
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          node scripts/check-migration-safety.mjs "origin/$GITHUB_BASE_REF"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -32,7 +32,10 @@ jobs:
     name: Migrate prod database
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: production
+    # `production-db` gates only this migrate job with a required reviewer —
+    # routine deploys (the `deploy` job, web, mail-worker) stay un-gated. Its
+    # MIGRATION_DATABASE_URL secret must be set on this environment.
+    environment: production-db
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -146,6 +149,9 @@ jobs:
             -e RESEARCH_API_KEY_SCRAPE="${{ secrets.RESEARCH_API_KEY_SCRAPE }}"
             -e RESEARCH_API_KEY_EXTRACT="${{ secrets.RESEARCH_API_KEY_EXTRACT }}"
             -e RESEARCH_API_KEY_REGISTRY_ES="${{ secrets.RESEARCH_API_KEY_REGISTRY_ES }}"
+            -e RESEARCH_API_KEY_ENRICH="${{ secrets.RESEARCH_API_KEY_ENRICH }}"
+            -e RESEARCH_API_KEY_VERIFY="${{ secrets.RESEARCH_API_KEY_VERIFY }}"
+            -e RESEARCH_API_KEY_REGISTRY_GB="${{ secrets.RESEARCH_API_KEY_REGISTRY_GB }}"
           )
           BYTES=$(printf '%s' "${E_ARGS[*]}" | wc -c | tr -d ' ')
           FLAGS=0
@@ -226,6 +232,9 @@ jobs:
                 -e RESEARCH_API_KEY_SCRAPE="${{ secrets.RESEARCH_API_KEY_SCRAPE }}" \
                 -e RESEARCH_API_KEY_EXTRACT="${{ secrets.RESEARCH_API_KEY_EXTRACT }}" \
                 -e RESEARCH_API_KEY_REGISTRY_ES="${{ secrets.RESEARCH_API_KEY_REGISTRY_ES }}" \
+                -e RESEARCH_API_KEY_ENRICH="${{ secrets.RESEARCH_API_KEY_ENRICH }}" \
+                -e RESEARCH_API_KEY_VERIFY="${{ secrets.RESEARCH_API_KEY_VERIFY }}" \
+                -e RESEARCH_API_KEY_REGISTRY_GB="${{ secrets.RESEARCH_API_KEY_REGISTRY_GB }}" \
                 .
             }
             if [ "${{ steps.service-check.outputs.exists }}" = "true" ]; then

--- a/biome.json
+++ b/biome.json
@@ -127,6 +127,16 @@
 					}
 				}
 			}
+		},
+		{
+			"includes": ["scripts/*.mjs"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
 		}
 	]
 }

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -32,7 +32,7 @@ Where migrations run depends on the environment, and the boundary is deliberate.
 
 **Local / worktree** — `pnpm db:migrate` runs against your local stack, with `DATABASE_URL` from `.env`. It echoes its target first — e.g. `Migration target: "batuda_feature_x" on localhost (local)` — so you can see which database you are about to touch.
 
-**Production** — migrations run **in the deploy pipeline, never from a laptop**: the `Deploy Server` workflow applies them against the prod database immediately before `kraft cloud deploy`. There is intentionally no `db:migrate:prod` script.
+**Production** — migrations run **in the deploy pipeline, never from a laptop**: the `Deploy Server` workflow applies them against the prod database immediately before `kraft cloud deploy`. There is intentionally no `db:migrate:prod` script. A required reviewer on the `production-db` GitHub environment gates the `migrate` job specifically, so it pauses for a one-click approval before any prod schema change lands — a final human checkpoint. Routine deploys (web, mail-worker, the server `deploy` job) are not gated. `MIGRATION_DATABASE_URL` lives on `production-db`.
 
 ### Connection: schema owner, direct endpoint
 
@@ -46,6 +46,8 @@ CI gets the same shape for free — its Neon branch is created with `role: neond
 ### Rolling-deploy compatibility
 
 The deploy is a rolling update — the old instance keeps serving while the new one boots — so each migration must stay **backward-compatible with the running version**. Add the new shape now (a nullable/defaulted column, a new table) and drop or tighten the old shape in a **later** release; renaming or dropping a column the live version still reads breaks requests mid-rollout.
+
+CI enforces this on every PR: `scripts/check-migration-safety.mjs` fails when a newly added migration drops/renames a column, drops a table, truncates, or adds a `NOT NULL` column without a default — unless the file opts in with an `// expand-contract: <reason>` marker. The marker is the deliberate escape hatch for a change that's safe despite the rule (the old reader shipped a release ago, or pre-production with no live instance to break) — it forces you to write down *why* rather than dropping silently.
 
 ### Rehearsing and re-running
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"db:up": "docker compose -f docker/docker-compose.yml up -d",
 		"db:down": "docker compose -f docker/docker-compose.yml down",
 		"db:migrate": "pnpm --filter @batuda/server run migrate",
+		"check-migrations": "node scripts/check-migration-safety.mjs",
 		"______ Release ______": "",
 		"release:server": "release-it --config .release-it.server.cjs",
 		"release:internal": "release-it --config .release-it.internal.cjs",

--- a/scripts/check-migration-safety.mjs
+++ b/scripts/check-migration-safety.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Enforces the expand-contract migration discipline (docs/runbooks.md). The prod
+// deploy is a ROLLING update: the old instance keeps serving while the new one
+// boots, so each migration must stay backward-compatible with the still-running
+// version. Dropping or renaming a column the live version still reads breaks its
+// requests mid-rollout.
+//
+// This scans migration files ADDED in the PR (vs the base ref) for
+// non-backward-compatible DDL and fails unless the file opts in with an explicit
+// marker comment documenting why it's deliberate:
+//
+//   // expand-contract: <why the old shape is safe to drop in this same deploy>
+//
+// Usage: node scripts/check-migration-safety.mjs [baseRef]   (default: origin/main)
+
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+const MIGRATIONS_DIR = 'apps/server/src/db/migrations/'
+const baseRef = process.argv[2] ?? 'origin/main'
+
+// DDL that is not safe under a rolling deploy (the old instance breaks).
+const DESTRUCTIVE = [
+	['DROP COLUMN', /\bDROP\s+COLUMN\b/i],
+	['DROP TABLE', /\bDROP\s+TABLE\b/i],
+	['TRUNCATE', /\bTRUNCATE\b/i],
+	['RENAME COLUMN', /\bRENAME\s+COLUMN\b/i],
+	['RENAME TO', /\bRENAME\s+TO\b/i],
+	['DROP CONSTRAINT', /\bDROP\s+CONSTRAINT\b/i],
+	// A required column with no default rejects the old instance's inserts, which don't fill it in.
+	[
+		'DROP NOT NULL→NOT NULL add',
+		/ADD\s+COLUMN\b[^;]*\bNOT\s+NULL\b(?![^;]*DEFAULT)/i,
+	],
+]
+const MARKER = /expand-contract:/i
+
+// Two-dot diff: compares the base and HEAD trees directly, so it needs no
+// merge-base history — works under CI's shallow checkout.
+const added = execSync(
+	`git diff --name-only --diff-filter=A ${baseRef}..HEAD -- ${MIGRATIONS_DIR}`,
+	{ encoding: 'utf8' },
+)
+	.trim()
+	.split('\n')
+	.filter(Boolean)
+
+if (added.length === 0) {
+	console.log('✓ migration safety: no new migrations in this change')
+	process.exit(0)
+}
+
+let failed = false
+for (const file of added) {
+	const sql = readFileSync(file, 'utf8')
+	const hits = DESTRUCTIVE.filter(([, re]) => re.test(sql)).map(
+		([name]) => name,
+	)
+	if (hits.length === 0) {
+		console.log(`✓ ${file} — backward-compatible`)
+		continue
+	}
+	if (MARKER.test(sql)) {
+		console.log(
+			`✓ ${file} — non-backward-compatible but marked expand-contract (deliberate): ${hits.join(', ')}`,
+		)
+		continue
+	}
+	failed = true
+	console.error(
+		`✗ ${file} — non-backward-compatible DDL with no \`expand-contract:\` marker: ${hits.join(', ')}`,
+	)
+}
+
+if (failed) {
+	console.error(
+		'\nThese changes break the still-running instance during the rolling deploy.\n' +
+			'Split them into expand (add the new shape now) + contract (drop the old shape\n' +
+			'in a LATER release) — see docs/runbooks.md. If the old shape is genuinely unused\n' +
+			'(pre-prod, or the last reader shipped a release ago), opt in with a marker:\n' +
+			'    // expand-contract: <why the old shape is safe to drop now>\n',
+	)
+	process.exit(1)
+}
+console.log('\n✓ migration safety check passed')


### PR DESCRIPTION
## What

Hardens prod deploys around the #147 channels-only migration + go-live. Three CICD concerns, surfaced while preparing `/release server`:

1. **Go-live secret wiring (release blocker).** `config.production.json` (merged in #147) flips `ENRICH`/`VERIFY` → `hunter` and `REGISTRY_GB` → `companies-house`, so the server reads `RESEARCH_API_KEY_ENRICH/_VERIFY/_REGISTRY_GB` at boot. Infisical already syncs those into the `production` env secrets, but `deploy_server.yml` never *referenced* them in its `-e` block — so the next deploy would `ConfigError` and crash on boot. Added them (and to the cmdline size guard).
2. **Expand-contract CI guard.** A migration that drops/renames a column the still-running instance reads breaks it mid-rolling-deploy (`docs/runbooks.md`). `scripts/check-migration-safety.mjs` fails a PR adding such a migration unless it carries an `expand-contract:` marker. (`0018` would have been caught — verified.)
3. **Gated prod migrations.** The `migrate` job moved to a new `production-db` GitHub environment with a required reviewer, so prod schema changes pause for a one-click OK; routine deploys (web, mail-worker, the server `deploy` job) stay un-gated.

## Impact

- **Unblocks `/release server`** — the go-live keys now reach the unikernel. No code in the repo references Infisical; secrets flow Infisical → GitHub `production` secrets → `-e` args.
- **`production-db` env** is created with `guillempuche` as reviewer. ⚠️ **`MIGRATION_DATABASE_URL` must be present on `production-db`** (point the Infisical sync there, or add it once) — the `migrate` job reads it from that env now. Without it the migrate job fails.
- **New CI gate** on every PR (runs before install; git + node only). A deliberate destructive migration opts out with an `expand-contract:` comment.
- Deploy secrets still ride the kernel cmdline (`-e`); KraftCloud has **no** off-cmdline secret store (`--env-secret` / `kraft cloud secret` do not exist — verified against `kraft 0.12.13`). The size guard (40→43 flags) remains the backstop.

## Review guide

- Riskiest file: `deploy_server.yml` — the 3 new `-e` lines mirror the existing 18 exactly; the only structural change is the `migrate` job's `environment: production` → `production-db`.
- The guard (`scripts/check-migration-safety.mjs`) is a self-contained Node script; the regexes target unambiguous non-backward-compatible DDL, with the marker as the escape hatch.

## Verification

- `node scripts/check-migration-safety.mjs server-v2026.6.28` → `0017` passes, `0018` fails (the real destructive migration) — exit 1. With no new migrations → passes.
- Verified `--env-secret`/`kraft cloud secret` do **not** exist via the installed `kraft 0.12.13 --help` (the WebSearch summary that suggested them was wrong).
- `production-db` env + reviewer created (`gh api`, confirmed). check-types/biome green via pre-commit.

## Deferred

- Migrating all ~20 runtime secrets off the cmdline isn't possible today (no KraftCloud secret store); revisit if the platform adds one or the 50-flag ceiling nears.
