### PR TITLE
feat(internal): make the inbox connections screen beginner-friendly

### DIFF
--- a/apps/internal/src/components/shared/empty-state.tsx
+++ b/apps/internal/src/components/shared/empty-state.tsx
@@ -21,7 +21,7 @@ export function EmptyState({
 }: {
 	icon?: ComponentType<{ size?: number | string; 'aria-hidden'?: boolean }>
 	title: string
-	description?: string
+	description?: ReactNode
 	action?: ReactNode
 }) {
 	return (
@@ -82,7 +82,7 @@ const Title = styled.p.withConfig({ displayName: 'EmptyStateTitle' })`
 	text-shadow: var(--text-shadow-emboss);
 `
 
-const Description = styled.p.withConfig({
+const Description = styled.div.withConfig({
 	displayName: 'EmptyStateDescription',
 })`
 	margin: 0;

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -143,10 +143,6 @@ msgstr "1 fil"
 msgid "1 thread selected"
 msgstr "1 fil seleccionat"
 
-#: src/routes/emails/inboxes.tsx
-msgid "2FA accounts need an app-specific password."
-msgstr "Els comptes amb verificació en dos passos necessiten una contrasenya d'aplicació."
-
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
 msgstr "Una etiqueta curta. Si vols, comença-la amb un [tag] com ara [research] per agrupar plantilles relacionades; els claudàtors només formen part del nom."
@@ -175,10 +171,6 @@ msgstr "en {0} proveïdors"
 #: src/routes/emails/inboxes.tsx
 msgid "Actions"
 msgstr "Accions"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Active"
-msgstr "Activa"
 
 #: src/components/shared/status-badge.tsx
 msgid "Active client"
@@ -254,6 +246,11 @@ msgstr "Afegeix a l'organització"
 msgid "Add to the org default"
 msgstr "Amplia el valor per defecte de l'organització"
 
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Added"
+msgstr "Afegit"
+
 #: src/routes/settings/organization/templates.tsx
 msgid "Added to the org"
 msgstr "Afegida a l'organització"
@@ -267,14 +264,21 @@ msgstr "Adreça"
 msgid "Admin"
 msgstr "Admin"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Advanced settings (IMAP / SMTP)"
+msgstr "Configuració avançada (IMAP / SMTP)"
+
 #: src/routes/settings/mcp/index.tsx
 msgid "After approving, manage which org each one acts in here."
 msgstr "Després d'aprovar-lo, gestiona aquí en quina organització actua cadascun."
 
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Agent"
 msgstr "Agent"
+
+#: src/routes/emails/inboxes.tsx
+msgid "AI agent"
+msgstr "Agent IA"
 
 #: src/routes/settings/mcp/connections.tsx
 msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
@@ -353,10 +357,6 @@ msgstr "adjunt"
 #: src/routes/tasks/index.tsx
 msgid "Audit log"
 msgstr "Registre d'auditoria"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Auth failed"
-msgstr "Error d'autenticació"
 
 #: src/routes/settings/profile/templates.tsx
 msgid "Back to account"
@@ -728,27 +728,26 @@ msgid "Connect AI tools over MCP"
 msgstr "Connecta eines d'IA amb MCP"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Connect failed"
-msgstr "Connexió fallida"
+#: src/routes/emails/inboxes.tsx
+msgid "Connect an email"
+msgstr "Connecta un correu"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Connect IMAP/SMTP mailboxes and choose your primary sender."
-msgstr "Connecta bústies IMAP/SMTP i tria el remitent principal."
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/index.tsx
 msgid "Connect mailbox"
 msgstr "Connecta una bústia"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Connect the email address you use with customers, so you can send and receive right here."
+msgstr "Connecta l'adreça de correu que fas servir amb els clients perquè puguis enviar i rebre des d'aquí."
 
 #: src/routes/oauth/consent.tsx
 msgid "Connect to Batuda?"
 msgstr "Connectar a Batuda?"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Connect your IMAP/SMTP mailbox to start sending and receiving email."
-msgstr "Connecta la teva bústia IMAP/SMTP per començar a enviar i rebre correu."
+msgid "Connect your email to get started"
+msgstr "Connecta el teu correu per començar"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Connected"
@@ -973,6 +972,10 @@ msgstr "No s'han pogut actualitzar els canals"
 msgid "Couldn't add it"
 msgstr "No s'ha pogut afegir"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Couldn't connect"
+msgstr "No s'ha pogut connectar"
+
 #: src/components/primitives/pri-copy-button.tsx
 msgid "Couldn't copy"
 msgstr "No s'ha pogut copiar"
@@ -1006,6 +1009,10 @@ msgstr "No s'ha pogut desar"
 #: src/routes/settings/profile/templates.tsx
 msgid "Couldn't send it"
 msgstr "No s'ha pogut enviar"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Couldn't sign in"
+msgstr "No s'ha pogut iniciar la sessió"
 
 #: src/routes/settings/profile/index.tsx
 msgid "Couldn't update your preference. Try again."
@@ -1050,7 +1057,7 @@ msgstr "Crea una contrasenya d'aplicació →"
 
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
-msgid "Create an app-specific password for {0}, opens in a new tab"
+msgid "Create an app password for {0}, opens in a new tab"
 msgstr "Crea una contrasenya d'aplicació per a {0}, s'obre en una pestanya nova"
 
 #: src/routes/emails/inboxes.tsx
@@ -1074,7 +1081,6 @@ msgid "Create key"
 msgstr "Crea la clau"
 
 #: src/routes/emails/$threadId.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Created"
 msgstr "Creada"
 
@@ -1128,13 +1134,8 @@ msgid "Decline {0}"
 msgstr "Rebutja {0}"
 
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Default"
 msgstr "Per defecte"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Default inbox"
-msgstr "Safata per defecte"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Defaults to the email address."
@@ -1164,11 +1165,6 @@ msgstr "Elimina {0}"
 #: src/routes/settings/profile/templates.tsx
 msgid "Delete failed"
 msgstr "Error en eliminar"
-
-#. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx
-msgid "Delete inbox {0}"
-msgstr "Suprimeix la bústia {0}"
 
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
@@ -1213,7 +1209,6 @@ msgstr "Denega"
 msgid "Direction"
 msgstr "Direcció"
 
-#: src/routes/emails/inboxes.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Disabled"
 msgstr "Desactivada"
@@ -1316,10 +1311,9 @@ msgstr "Edita la data de venciment"
 msgid "Edit inbox"
 msgstr "Edita la safata"
 
-#. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
-msgid "Edit inbox {0}"
-msgstr "Edita la safata {0}"
+msgid "Edit settings"
+msgstr "Edita la configuració"
 
 #: src/components/shared/task-item.tsx
 msgid "Edit task title"
@@ -1367,6 +1361,10 @@ msgstr "Envia'm un enllaç per correu"
 msgid "Email or password is incorrect."
 msgstr "El correu o la contrasenya no són correctes."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Email signature"
+msgstr "Signatura del correu"
+
 #: src/routes/companies/$slug.tsx
 msgid "Email via Batuda"
 msgstr "Correu via Batuda"
@@ -1391,6 +1389,10 @@ msgstr "Primer escriu un correu vàlid a sobre."
 #: src/routes/settings/organization/members.tsx
 msgid "Enter an email address."
 msgstr "Introdueix una adreça electrònica."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Enter your mail server settings below."
+msgstr "Introdueix la configuració del servidor de correu a sota."
 
 #: src/components/shared/channel-icon.tsx
 msgid "Event"
@@ -1536,13 +1538,13 @@ msgstr "Ves a connexions"
 msgid "Go to sign in"
 msgstr "Ves a iniciar sessió"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password."
-msgstr "Tens la verificació en dos passos activada? Fes servir una contrasenya d'aplicació del proveïdor aquí sota, no la teva contrasenya d'inici de sessió habitual."
-
 #: src/routes/accept-invitation.$id.tsx
 msgid "Heading to the dashboard…"
 msgstr "Anant al tauler…"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Hide advanced settings"
+msgstr "Amaga la configuració avançada"
 
 #: src/routes/emails/$threadId.tsx
 msgid "Hide Cc"
@@ -1567,7 +1569,6 @@ msgid "How your default uses the org default"
 msgstr "Com es relaciona el teu valor per defecte amb el de l'organització"
 
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Human"
 msgstr "Humà"
 
@@ -1579,9 +1580,17 @@ msgstr "Prefereixo sense contrasenya"
 msgid "I prefer passwordless — don't ask me again"
 msgstr "Prefereixo sense contrasenya — no m'ho tornis a preguntar"
 
+#: src/routes/emails/inboxes.tsx
+msgid "I'll fill in the technical settings for you — you just add your email and password."
+msgstr "Jo ompliré la configuració tècnica per tu; tu només has d'afegir el correu i la contrasenya."
+
 #: src/routes/forgot-password.tsx
 msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 msgstr "Si <0>{submittedEmail}</0> està registrat, t'arribarà un enllaç per restablir la contrasenya. L'enllaç caduca en 1 hora."
+
+#: src/routes/emails/inboxes.tsx
+msgid "If your account has two-factor authentication, use an app-specific password — not your normal login password."
+msgstr "Si el teu compte té verificació en dos passos, fes servir una contrasenya d'aplicació, no la contrasenya d'inici de sessió habitual."
 
 #: src/routes/emails/inboxes.tsx
 msgid "IMAP host"
@@ -1625,10 +1634,6 @@ msgid "Inbox connected"
 msgstr "Bústia connectada"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Inbox management"
-msgstr "Gestió de safates"
-
-#: src/routes/emails/inboxes.tsx
 msgid "Inbox removed"
 msgstr "Bústia eliminada"
 
@@ -1641,6 +1646,14 @@ msgstr "Safata actualitzada"
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Industry"
 msgstr "Sector"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Infomaniak needs a Mail app password created in your Mail service — not an account application password, and not your normal login password."
+msgstr "Infomaniak necessita una contrasenya d'aplicació de Mail creada al teu servei Mail; no la contrasenya d'aplicació del compte ni la contrasenya d'inici de sessió habitual."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Infomaniak needs a Mail app password created in your Mail service — not an account application password."
+msgstr "Infomaniak necessita una contrasenya d'aplicació de Mail creada al teu servei Mail, no una contrasenya d'aplicació del compte."
 
 #: src/components/shared/channel-icon.tsx
 msgid "Instagram"
@@ -1785,10 +1798,6 @@ msgstr "Carregant l'execució…"
 msgid "Loading…"
 msgstr "Carregant…"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Local inboxes"
-msgstr "Safates locals"
-
 #: src/components/companies/where-panel-client.client.tsx
 msgid "Locate this company"
 msgstr "Localitza aquesta empresa"
@@ -1839,6 +1848,11 @@ msgstr "Baixa"
 msgid "Low priority"
 msgstr "Prioritat baixa"
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "Make {0} the primary sender"
+msgstr "Fes que {0} sigui el remitent principal"
+
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Make primary"
 msgstr "Fes-lo principal"
@@ -1846,11 +1860,6 @@ msgstr "Fes-lo principal"
 #: src/routes/companies/$slug.tsx
 msgid "Manage channels"
 msgstr "Gestiona els canals"
-
-#. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx
-msgid "Manage footers for {0}"
-msgstr "Gestiona els peus de pàgina de {0}"
 
 #: src/routes/emails/index.tsx
 msgid "Manage inboxes"
@@ -1878,21 +1887,9 @@ msgstr "Marca «{0}» com a completada"
 msgid "Mark \"{0}\" as pending"
 msgstr "Marca «{0}» com a pendent"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Mark active"
-msgstr "Marca com a activa"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Mark as default"
-msgstr "Marca com a per defecte"
-
 #: src/components/shared/company-card.tsx
 msgid "Mark contacted"
 msgstr "Marca com a contactat"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Mark inactive"
-msgstr "Marca com a inactiva"
 
 #: src/routes/emails/index.tsx
 #: src/routes/emails/index.tsx
@@ -2143,10 +2140,6 @@ msgstr "Sense peus de pàgina"
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "Cap empresa d'alta prioritat sense seguiment programat"
 
-#: src/routes/emails/inboxes.tsx
-msgid "No inboxes yet"
-msgstr "Encara no hi ha safates"
-
 #: src/routes/settings/api-keys/index.tsx
 msgid "No keys yet. Create one above to connect an agent."
 msgstr "Encara no tens cap clau. Crea'n una a dalt per connectar un agent."
@@ -2288,6 +2281,10 @@ msgstr "Res a mostrar en aquest interval."
 #: src/routes/emails/$threadId.tsx
 msgid "On {date}, {who} wrote:"
 msgstr "El {date}, {who} va escriure:"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Once it's connected, I can send and receive email for you right here — no switching tabs."
+msgstr "Un cop connectat, puc enviar i rebre correu per tu des d'aquí, sense canviar de pestanya."
 
 #: src/routes/accept-invitation.$id.tsx
 msgid "One click to accept the invitation."
@@ -2518,6 +2515,19 @@ msgstr "Només inici de sessió sense contrasenya"
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "La contrasenya ha de tenir com a mínim {MIN_PASSWORD_LENGTH} caràcters."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Paste an app password — I'll show you where to get one"
+msgstr "Enganxa una contrasenya d'aplicació; jo et mostraré on aconseguir-ne una"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Pause syncing"
+msgstr "Atura la sincronització"
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Paused"
+msgstr "Aturat"
+
 #: src/routes/settings/organization/members.tsx
 msgid "Pending"
 msgstr "Pendent"
@@ -2540,6 +2550,7 @@ msgid "People with access to this workspace."
 msgstr "Persones amb accés a aquest espai de treball."
 
 #: src/routes/calendar/index.tsx
+#: src/routes/emails/inboxes.tsx
 #: src/routes/tasks/index.tsx
 #: src/routes/tasks/index.tsx
 msgid "Personal"
@@ -2578,6 +2589,10 @@ msgstr "Tria'n una com a remitent per defecte."
 msgid "Pick templates to use just for this run. Leave empty to use your default."
 msgstr "Tria les plantilles per fer servir només en aquesta recerca. Deixa-ho buit per utilitzar el valor per defecte."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Pick your email provider"
+msgstr "Tria el teu proveïdor de correu"
+
 #: src/components/layout/nav-items.ts
 #: src/routes/index.tsx
 msgid "Pipeline"
@@ -2606,6 +2621,12 @@ msgstr "Vista prèvia"
 #: src/routes/emails/index.tsx
 msgid "Previous"
 msgstr "Anterior"
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Primary"
+msgstr "Principal"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Primary inbox set"
@@ -2675,11 +2696,6 @@ msgstr "Escàner de prospectes"
 msgid "Prospects"
 msgstr "Prospectes"
 
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Provider preset"
-msgstr "Preestablit del proveïdor"
-
 #: src/routes/pages/$id.tsx
 msgid "Public URL"
 msgstr "URL pública"
@@ -2701,7 +2717,6 @@ msgstr "Publicada"
 msgid "Publishing…"
 msgstr "Publicant…"
 
-#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Purpose"
@@ -2746,6 +2761,7 @@ msgstr "Actualitzant l'estat de la bústia…"
 msgid "Region"
 msgstr "Regió"
 
+#: src/routes/emails/inboxes.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Remove"
 msgstr "Elimina"
@@ -2869,6 +2885,10 @@ msgstr "Reprèn esborranys ({0})"
 msgid "Resume drafting (1)"
 msgstr "Reprèn l'esborrany (1)"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Resume syncing"
+msgstr "Reprèn la sincronització"
+
 #: src/routes/settings/profile/templates.tsx
 msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 msgstr "Orientació reutilitzable i permanent que segueix el teu agent de recerca: què vens, a qui t'adreces, el to i en quines fonts confiar."
@@ -2986,10 +3006,6 @@ msgstr "Selecciona el text i copia'l manualment."
 #: src/routes/emails/index.tsx
 msgid "Select thread {0}"
 msgstr "Selecciona el fil {0}"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
-msgstr "Triar un preestablit omple els paràmetres IMAP i SMTP — encara els pots editar."
 
 #: src/components/emails/compose-form.tsx
 msgid "Send"
@@ -3239,6 +3255,10 @@ msgstr "Orientació permanent que el teu agent de recerca segueix en cada recerc
 msgid "Start"
 msgstr "Inicia"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Start sending and receiving"
+msgstr "Comença a enviar i rebre"
+
 #: src/components/research/research-dialog.tsx
 msgid "Starting…"
 msgstr "Iniciant…"
@@ -3248,6 +3268,7 @@ msgid "STARTTLS"
 msgstr "STARTTLS"
 
 #: src/routes/calendar/index.tsx
+#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/pages/index.tsx
 #: src/routes/tasks/index.tsx
@@ -3314,6 +3335,10 @@ msgstr "Tasques"
 msgid "Tax ID"
 msgstr "NIF"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Technical details"
+msgstr "Detalls tècnics"
+
 #: src/routes/pages/$id.tsx
 msgid "Template"
 msgstr "Plantilla"
@@ -3335,10 +3360,9 @@ msgstr "Provisional"
 msgid "Test & connect"
 msgstr "Prova i connecta"
 
-#. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
-msgid "Test connection for {0}"
-msgstr "Prova la connexió de {0}"
+msgid "Test connection"
+msgstr "Prova la connexió"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Test failed"
@@ -3642,6 +3666,15 @@ msgid "Use the org default"
 msgstr "Utilitza el valor per defecte de l'organització"
 
 #: src/routes/emails/inboxes.tsx
+msgid "Use your email provider's app-specific password — not your normal login password."
+msgstr "Fes servir la contrasenya d'aplicació del teu proveïdor de correu, no la contrasenya d'inici de sessió habitual."
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Used for"
+msgstr "S'utilitza per a"
+
+#: src/routes/emails/inboxes.tsx
 msgid "Username"
 msgstr "Nom d'usuari"
 
@@ -3722,6 +3755,11 @@ msgstr "On"
 msgid "Who"
 msgstr "Qui"
 
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Who's your email provider?"
+msgstr "Quin és el teu proveïdor de correu?"
+
 #: src/routes/settings/organization/members.tsx
 msgid "Working…"
 msgstr "Processant…"
@@ -3778,6 +3816,11 @@ msgstr "La teva identitat al banc de Batuda."
 #: src/routes/settings/mcp/index.tsx
 msgid "Your connections"
 msgstr "Les teves connexions"
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Your email connections"
+msgstr "Les teves connexions de correu"
 
 #: src/routes/login.tsx
 msgid "Your email isn't verified yet. Use the magic link instead."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -143,10 +143,6 @@ msgstr "1 thread"
 msgid "1 thread selected"
 msgstr "1 thread selected"
 
-#: src/routes/emails/inboxes.tsx
-msgid "2FA accounts need an app-specific password."
-msgstr "2FA accounts need an app-specific password."
-
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
 msgstr "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
@@ -175,10 +171,6 @@ msgstr "across {0} providers"
 #: src/routes/emails/inboxes.tsx
 msgid "Actions"
 msgstr "Actions"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Active"
-msgstr "Active"
 
 #: src/components/shared/status-badge.tsx
 msgid "Active client"
@@ -254,6 +246,11 @@ msgstr "Add to org"
 msgid "Add to the org default"
 msgstr "Add to the org default"
 
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Added"
+msgstr "Added"
+
 #: src/routes/settings/organization/templates.tsx
 msgid "Added to the org"
 msgstr "Added to the org"
@@ -267,14 +264,21 @@ msgstr "Address"
 msgid "Admin"
 msgstr "Admin"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Advanced settings (IMAP / SMTP)"
+msgstr "Advanced settings (IMAP / SMTP)"
+
 #: src/routes/settings/mcp/index.tsx
 msgid "After approving, manage which org each one acts in here."
 msgstr "After approving, manage which org each one acts in here."
 
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Agent"
 msgstr "Agent"
+
+#: src/routes/emails/inboxes.tsx
+msgid "AI agent"
+msgstr "AI agent"
 
 #: src/routes/settings/mcp/connections.tsx
 msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
@@ -353,10 +357,6 @@ msgstr "attachment"
 #: src/routes/tasks/index.tsx
 msgid "Audit log"
 msgstr "Audit log"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Auth failed"
-msgstr "Auth failed"
 
 #: src/routes/settings/profile/templates.tsx
 msgid "Back to account"
@@ -728,27 +728,26 @@ msgid "Connect AI tools over MCP"
 msgstr "Connect AI tools over MCP"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Connect failed"
-msgstr "Connect failed"
+#: src/routes/emails/inboxes.tsx
+msgid "Connect an email"
+msgstr "Connect an email"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Connect IMAP/SMTP mailboxes and choose your primary sender."
-msgstr "Connect IMAP/SMTP mailboxes and choose your primary sender."
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/index.tsx
 msgid "Connect mailbox"
 msgstr "Connect mailbox"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Connect the email address you use with customers, so you can send and receive right here."
+msgstr "Connect the email address you use with customers, so you can send and receive right here."
 
 #: src/routes/oauth/consent.tsx
 msgid "Connect to Batuda?"
 msgstr "Connect to Batuda?"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Connect your IMAP/SMTP mailbox to start sending and receiving email."
-msgstr "Connect your IMAP/SMTP mailbox to start sending and receiving email."
+msgid "Connect your email to get started"
+msgstr "Connect your email to get started"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Connected"
@@ -973,6 +972,10 @@ msgstr "Could not update channels"
 msgid "Couldn't add it"
 msgstr "Couldn't add it"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Couldn't connect"
+msgstr "Couldn't connect"
+
 #: src/components/primitives/pri-copy-button.tsx
 msgid "Couldn't copy"
 msgstr "Couldn't copy"
@@ -1006,6 +1009,10 @@ msgstr "Couldn't save"
 #: src/routes/settings/profile/templates.tsx
 msgid "Couldn't send it"
 msgstr "Couldn't send it"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Couldn't sign in"
+msgstr "Couldn't sign in"
 
 #: src/routes/settings/profile/index.tsx
 msgid "Couldn't update your preference. Try again."
@@ -1050,8 +1057,8 @@ msgstr "Create an app password →"
 
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
-msgid "Create an app-specific password for {0}, opens in a new tab"
-msgstr "Create an app-specific password for {0}, opens in a new tab"
+msgid "Create an app password for {0}, opens in a new tab"
+msgstr "Create an app password for {0}, opens in a new tab"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Create an app-specific password, opens in a new tab"
@@ -1074,7 +1081,6 @@ msgid "Create key"
 msgstr "Create key"
 
 #: src/routes/emails/$threadId.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Created"
 msgstr "Created"
 
@@ -1128,13 +1134,8 @@ msgid "Decline {0}"
 msgstr "Decline {0}"
 
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Default"
 msgstr "Default"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Default inbox"
-msgstr "Default inbox"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Defaults to the email address."
@@ -1164,11 +1165,6 @@ msgstr "Delete {0}"
 #: src/routes/settings/profile/templates.tsx
 msgid "Delete failed"
 msgstr "Delete failed"
-
-#. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx
-msgid "Delete inbox {0}"
-msgstr "Delete inbox {0}"
 
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
@@ -1213,7 +1209,6 @@ msgstr "Deny"
 msgid "Direction"
 msgstr "Direction"
 
-#: src/routes/emails/inboxes.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Disabled"
 msgstr "Disabled"
@@ -1316,10 +1311,9 @@ msgstr "Edit due date"
 msgid "Edit inbox"
 msgstr "Edit inbox"
 
-#. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
-msgid "Edit inbox {0}"
-msgstr "Edit inbox {0}"
+msgid "Edit settings"
+msgstr "Edit settings"
 
 #: src/components/shared/task-item.tsx
 msgid "Edit task title"
@@ -1367,6 +1361,10 @@ msgstr "Email me a sign-in link"
 msgid "Email or password is incorrect."
 msgstr "Email or password is incorrect."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Email signature"
+msgstr "Email signature"
+
 #: src/routes/companies/$slug.tsx
 msgid "Email via Batuda"
 msgstr "Email via Batuda"
@@ -1391,6 +1389,10 @@ msgstr "Enter a valid email above first."
 #: src/routes/settings/organization/members.tsx
 msgid "Enter an email address."
 msgstr "Enter an email address."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Enter your mail server settings below."
+msgstr "Enter your mail server settings below."
 
 #: src/components/shared/channel-icon.tsx
 msgid "Event"
@@ -1536,13 +1538,13 @@ msgstr "Go to connections"
 msgid "Go to sign in"
 msgstr "Go to sign in"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password."
-msgstr "Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password."
-
 #: src/routes/accept-invitation.$id.tsx
 msgid "Heading to the dashboard…"
 msgstr "Heading to the dashboard…"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Hide advanced settings"
+msgstr "Hide advanced settings"
 
 #: src/routes/emails/$threadId.tsx
 msgid "Hide Cc"
@@ -1567,7 +1569,6 @@ msgid "How your default uses the org default"
 msgstr "How your default uses the org default"
 
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Human"
 msgstr "Human"
 
@@ -1579,9 +1580,17 @@ msgstr "I prefer passwordless"
 msgid "I prefer passwordless — don't ask me again"
 msgstr "I prefer passwordless — don't ask me again"
 
+#: src/routes/emails/inboxes.tsx
+msgid "I'll fill in the technical settings for you — you just add your email and password."
+msgstr "I'll fill in the technical settings for you — you just add your email and password."
+
 #: src/routes/forgot-password.tsx
 msgid "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
 msgstr "If <0>{submittedEmail}</0> is registered, a reset link is on its way. The link expires in 1 hour."
+
+#: src/routes/emails/inboxes.tsx
+msgid "If your account has two-factor authentication, use an app-specific password — not your normal login password."
+msgstr "If your account has two-factor authentication, use an app-specific password — not your normal login password."
 
 #: src/routes/emails/inboxes.tsx
 msgid "IMAP host"
@@ -1625,10 +1634,6 @@ msgid "Inbox connected"
 msgstr "Inbox connected"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Inbox management"
-msgstr "Inbox management"
-
-#: src/routes/emails/inboxes.tsx
 msgid "Inbox removed"
 msgstr "Inbox removed"
 
@@ -1641,6 +1646,14 @@ msgstr "Inbox updated"
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Industry"
 msgstr "Industry"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Infomaniak needs a Mail app password created in your Mail service — not an account application password, and not your normal login password."
+msgstr "Infomaniak needs a Mail app password created in your Mail service — not an account application password, and not your normal login password."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Infomaniak needs a Mail app password created in your Mail service — not an account application password."
+msgstr "Infomaniak needs a Mail app password created in your Mail service — not an account application password."
 
 #: src/components/shared/channel-icon.tsx
 msgid "Instagram"
@@ -1785,10 +1798,6 @@ msgstr "Loading run…"
 msgid "Loading…"
 msgstr "Loading…"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Local inboxes"
-msgstr "Local inboxes"
-
 #: src/components/companies/where-panel-client.client.tsx
 msgid "Locate this company"
 msgstr "Locate this company"
@@ -1839,6 +1848,11 @@ msgstr "Low"
 msgid "Low priority"
 msgstr "Low priority"
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "Make {0} the primary sender"
+msgstr "Make {0} the primary sender"
+
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Make primary"
 msgstr "Make primary"
@@ -1846,11 +1860,6 @@ msgstr "Make primary"
 #: src/routes/companies/$slug.tsx
 msgid "Manage channels"
 msgstr "Manage channels"
-
-#. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx
-msgid "Manage footers for {0}"
-msgstr "Manage footers for {0}"
 
 #: src/routes/emails/index.tsx
 msgid "Manage inboxes"
@@ -1878,21 +1887,9 @@ msgstr "Mark \"{0}\" as complete"
 msgid "Mark \"{0}\" as pending"
 msgstr "Mark \"{0}\" as pending"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Mark active"
-msgstr "Mark active"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Mark as default"
-msgstr "Mark as default"
-
 #: src/components/shared/company-card.tsx
 msgid "Mark contacted"
 msgstr "Mark contacted"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Mark inactive"
-msgstr "Mark inactive"
 
 #: src/routes/emails/index.tsx
 #: src/routes/emails/index.tsx
@@ -2143,10 +2140,6 @@ msgstr "No footers"
 msgid "No high-priority companies without a scheduled follow-up"
 msgstr "No high-priority companies without a scheduled follow-up"
 
-#: src/routes/emails/inboxes.tsx
-msgid "No inboxes yet"
-msgstr "No inboxes yet"
-
 #: src/routes/settings/api-keys/index.tsx
 msgid "No keys yet. Create one above to connect an agent."
 msgstr "No keys yet. Create one above to connect an agent."
@@ -2288,6 +2281,10 @@ msgstr "Nothing to show in this range."
 #: src/routes/emails/$threadId.tsx
 msgid "On {date}, {who} wrote:"
 msgstr "On {date}, {who} wrote:"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Once it's connected, I can send and receive email for you right here — no switching tabs."
+msgstr "Once it's connected, I can send and receive email for you right here — no switching tabs."
 
 #: src/routes/accept-invitation.$id.tsx
 msgid "One click to accept the invitation."
@@ -2518,6 +2515,19 @@ msgstr "Passwordless sign-in only"
 msgid "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgstr "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Paste an app password — I'll show you where to get one"
+msgstr "Paste an app password — I'll show you where to get one"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Pause syncing"
+msgstr "Pause syncing"
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Paused"
+msgstr "Paused"
+
 #: src/routes/settings/organization/members.tsx
 msgid "Pending"
 msgstr "Pending"
@@ -2540,6 +2550,7 @@ msgid "People with access to this workspace."
 msgstr "People with access to this workspace."
 
 #: src/routes/calendar/index.tsx
+#: src/routes/emails/inboxes.tsx
 #: src/routes/tasks/index.tsx
 #: src/routes/tasks/index.tsx
 msgid "Personal"
@@ -2578,6 +2589,10 @@ msgstr "Pick one to use as your default sender."
 msgid "Pick templates to use just for this run. Leave empty to use your default."
 msgstr "Pick templates to use just for this run. Leave empty to use your default."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Pick your email provider"
+msgstr "Pick your email provider"
+
 #: src/components/layout/nav-items.ts
 #: src/routes/index.tsx
 msgid "Pipeline"
@@ -2606,6 +2621,12 @@ msgstr "Preview"
 #: src/routes/emails/index.tsx
 msgid "Previous"
 msgstr "Previous"
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Primary"
+msgstr "Primary"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Primary inbox set"
@@ -2675,11 +2696,6 @@ msgstr "Prospect scan"
 msgid "Prospects"
 msgstr "Prospects"
 
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Provider preset"
-msgstr "Provider preset"
-
 #: src/routes/pages/$id.tsx
 msgid "Public URL"
 msgstr "Public URL"
@@ -2701,7 +2717,6 @@ msgstr "Published"
 msgid "Publishing…"
 msgstr "Publishing…"
 
-#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Purpose"
@@ -2746,6 +2761,7 @@ msgstr "Refreshing inbox status…"
 msgid "Region"
 msgstr "Region"
 
+#: src/routes/emails/inboxes.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Remove"
 msgstr "Remove"
@@ -2869,6 +2885,10 @@ msgstr "Resume drafting ({0})"
 msgid "Resume drafting (1)"
 msgstr "Resume drafting (1)"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Resume syncing"
+msgstr "Resume syncing"
+
 #: src/routes/settings/profile/templates.tsx
 msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 msgstr "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
@@ -2986,10 +3006,6 @@ msgstr "Select the text and copy it manually."
 #: src/routes/emails/index.tsx
 msgid "Select thread {0}"
 msgstr "Select thread {0}"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
-msgstr "Selecting a preset fills IMAP and SMTP defaults — you can still edit them."
 
 #: src/components/emails/compose-form.tsx
 msgid "Send"
@@ -3239,6 +3255,10 @@ msgstr "Standing guidance your research agent follows on every run."
 msgid "Start"
 msgstr "Start"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Start sending and receiving"
+msgstr "Start sending and receiving"
+
 #: src/components/research/research-dialog.tsx
 msgid "Starting…"
 msgstr "Starting…"
@@ -3248,6 +3268,7 @@ msgid "STARTTLS"
 msgstr "STARTTLS"
 
 #: src/routes/calendar/index.tsx
+#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/pages/index.tsx
 #: src/routes/tasks/index.tsx
@@ -3314,6 +3335,10 @@ msgstr "Tasks"
 msgid "Tax ID"
 msgstr "Tax ID"
 
+#: src/routes/emails/inboxes.tsx
+msgid "Technical details"
+msgstr "Technical details"
+
 #: src/routes/pages/$id.tsx
 msgid "Template"
 msgstr "Template"
@@ -3335,10 +3360,9 @@ msgstr "Tentative"
 msgid "Test & connect"
 msgstr "Test & connect"
 
-#. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
-msgid "Test connection for {0}"
-msgstr "Test connection for {0}"
+msgid "Test connection"
+msgstr "Test connection"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Test failed"
@@ -3642,6 +3666,15 @@ msgid "Use the org default"
 msgstr "Use the org default"
 
 #: src/routes/emails/inboxes.tsx
+msgid "Use your email provider's app-specific password — not your normal login password."
+msgstr "Use your email provider's app-specific password — not your normal login password."
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Used for"
+msgstr "Used for"
+
+#: src/routes/emails/inboxes.tsx
 msgid "Username"
 msgstr "Username"
 
@@ -3722,6 +3755,11 @@ msgstr "Where"
 msgid "Who"
 msgstr "Who"
 
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Who's your email provider?"
+msgstr "Who's your email provider?"
+
 #: src/routes/settings/organization/members.tsx
 msgid "Working…"
 msgstr "Working…"
@@ -3778,6 +3816,11 @@ msgstr "Your Batuda workbench identity."
 #: src/routes/settings/mcp/index.tsx
 msgid "Your connections"
 msgstr "Your connections"
+
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "Your email connections"
+msgstr "Your email connections"
 
 #: src/routes/login.tsx
 msgid "Your email isn't verified yet. Use the magic link instead."

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -13,13 +13,16 @@ import {
 	ChevronLeft,
 	FileText,
 	Inbox as InboxIcon,
+	Pause,
 	Pencil,
+	Play,
 	Plus,
 	RefreshCw,
 	Star,
 	Trash2,
 	X,
 } from 'lucide-react'
+import type { ComponentType } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -30,6 +33,7 @@ import {
 	PriDialog,
 	PriInput,
 	PriSelect,
+	PriTooltip,
 	usePriToast,
 } from '@batuda/ui/pri'
 
@@ -69,6 +73,9 @@ import {
 type InboxPurpose = 'human' | 'agent' | 'shared'
 type TransportSecurity = 'tls' | 'starttls' | 'plain'
 type GrantStatus = 'connected' | 'auth_failed' | 'connect_failed' | 'disabled'
+// What the status pill shows. A paused inbox (active=false) reads "Paused"
+// regardless of its last sign-in result, so it gets its own tone.
+type StatusTone = GrantStatus | 'paused'
 
 type InboxRow = {
 	readonly id: string
@@ -386,8 +393,8 @@ function InboxesPage() {
 							<span>{t`Back to emails`}</span>
 						</Link>
 					</BackLink>
-					<Title>{t`Inbox management`}</Title>
-					<Subtitle>{t`Connect IMAP/SMTP mailboxes and choose your primary sender.`}</Subtitle>
+					<Title>{t`Your email connections`}</Title>
+					<Subtitle>{t`Connect the email address you use with customers, so you can send and receive right here.`}</Subtitle>
 				</IntroText>
 				<IntroActions>
 					<PriButton
@@ -397,7 +404,7 @@ function InboxesPage() {
 						onClick={openCreate}
 					>
 						<Plus size={14} aria-hidden />
-						<span>{t`Connect mailbox`}</span>
+						<span>{t`Connect an email`}</span>
 					</PriButton>
 				</IntroActions>
 			</Intro>
@@ -471,8 +478,17 @@ function InboxesPage() {
 			) : rows.length === 0 ? (
 				<EmptyState
 					icon={InboxIcon}
-					title={t`No inboxes yet`}
-					description={t`Connect your IMAP/SMTP mailbox to start sending and receiving email.`}
+					title={t`Connect your email to get started`}
+					description={
+						<EmptyHelp>
+							<p>{t`Once it's connected, I can send and receive email for you right here — no switching tabs.`}</p>
+							<ol>
+								<li>{t`Pick your email provider`}</li>
+								<li>{t`Paste an app password — I'll show you where to get one`}</li>
+								<li>{t`Start sending and receiving`}</li>
+							</ol>
+						</EmptyHelp>
+					}
 					action={
 						<PriButton
 							type='button'
@@ -481,163 +497,167 @@ function InboxesPage() {
 							onClick={openCreate}
 						>
 							<Plus size={14} aria-hidden />
-							<span>{t`Connect mailbox`}</span>
+							<span>{t`Connect an email`}</span>
 						</PriButton>
 					}
 				/>
 			) : (
-				<InboxesTable role='table' aria-label={t`Local inboxes`}>
+				<InboxesTable role='table' aria-label={t`Your email connections`}>
 					<TableHead role='row'>
 						<HeadCell role='columnheader'>{t`Email`}</HeadCell>
 						<HeadCell role='columnheader'>{t`Status`}</HeadCell>
-						<HeadCell role='columnheader'>{t`Purpose`}</HeadCell>
-						<HeadCell role='columnheader'>{t`Default`}</HeadCell>
-						<HeadCell role='columnheader'>{t`Active`}</HeadCell>
-						<HeadCell role='columnheader'>{t`Created`}</HeadCell>
+						<HeadCell role='columnheader'>{t`Used for`}</HeadCell>
+						<HeadCell role='columnheader'>{t`Primary`}</HeadCell>
+						<HeadCell role='columnheader'>{t`Added`}</HeadCell>
 						<HeadCell role='columnheader' aria-label={t`Actions`}>
 							{' '}
 						</HeadCell>
 					</TableHead>
-					{rows.map(row => (
-						<TableRow key={row.id} role='row' $inactive={!row.active}>
-							<CellEmail role='cell'>
-								<EmailAddress>{row.email}</EmailAddress>
-								<EmailMeta>
-									{row.displayName !== null && row.displayName !== '' ? (
-										<DisplayName>{row.displayName}</DisplayName>
-									) : null}
-									{row.imapHost !== '' && (
-										<HostName title={`IMAP ${row.imapHost}:${row.imapPort}`}>
-											{row.imapHost}
-										</HostName>
-									)}
-									{row.isPrivate && (
-										<PrivacyTag aria-label={t`Private inbox`}>
-											{t`Private`}
-										</PrivacyTag>
-									)}
-								</EmailMeta>
-							</CellEmail>
-							<CellStatus role='cell'>
-								<StatusBadge
-									$status={row.grantStatus}
-									title={row.grantLastError ?? ''}
-								>
-									{row.grantStatus === 'connected'
-										? t`Connected`
-										: row.grantStatus === 'auth_failed'
-											? t`Auth failed`
-											: row.grantStatus === 'connect_failed'
-												? t`Connect failed`
-												: t`Disabled`}
-								</StatusBadge>
-								{row.grantStatus === 'auth_failed' && (
-									<AuthHint>
-										{t`2FA accounts need an app-specific password.`}
-										{authPasswordUrlFor(presets, row.imapHost) !== '' && (
-											<>
-												{' '}
-												<PresetLink
-													href={authPasswordUrlFor(presets, row.imapHost)}
-													aria-label={t`Create an app-specific password for ${row.email}, opens in a new tab`}
-													target='_blank'
-													rel='noreferrer noopener'
-												>
-													{t`Create an app password →`}
-												</PresetLink>
-											</>
+					{rows.map(row => {
+						const providerName = providerNameFor(presets, row.imapHost)
+						const appPwUrl = authPasswordUrlFor(presets, row.imapHost)
+						// A paused (inactive) inbox isn't syncing, so that takes
+						// precedence over whatever its last sign-in result was.
+						const statusTone: StatusTone = !row.active
+							? 'paused'
+							: row.grantStatus
+						const statusLabel = !row.active
+							? t`Paused`
+							: row.grantStatus === 'connected'
+								? t`Connected`
+								: row.grantStatus === 'auth_failed'
+									? t`Couldn't sign in`
+									: row.grantStatus === 'connect_failed'
+										? t`Couldn't connect`
+										: t`Paused`
+						return (
+							<TableRow key={row.id} role='row' $inactive={!row.active}>
+								<CellEmail role='cell'>
+									<EmailAddress>{row.email}</EmailAddress>
+									<EmailMeta>
+										{row.displayName !== null && row.displayName !== '' ? (
+											<DisplayName>{row.displayName}</DisplayName>
+										) : null}
+										{providerName !== '' && (
+											<ProviderName
+												title={`IMAP ${row.imapHost}:${row.imapPort}`}
+											>
+												{providerName}
+											</ProviderName>
 										)}
-									</AuthHint>
-								)}
-							</CellStatus>
-							<CellPurpose role='cell'>
-								<PurposeBadge $purpose={row.purpose}>
-									{row.purpose === 'human'
-										? t`Human`
-										: row.purpose === 'agent'
-											? t`Agent`
-											: t`Shared`}
-								</PurposeBadge>
-							</CellPurpose>
-							<CellDefault role='cell'>
-								<IconToggle
-									type='button'
-									$active={row.isDefault}
-									onClick={() => {
-										void setDefault(row)
-									}}
-									aria-label={
-										row.isDefault ? t`Default inbox` : t`Mark as default`
-									}
-									aria-pressed={row.isDefault}
-								>
-									<Star
-										size={14}
-										aria-hidden
-										fill={row.isDefault ? 'currentColor' : 'none'}
-									/>
-								</IconToggle>
-							</CellDefault>
-							<CellActive role='cell'>
-								<IconToggle
-									type='button'
-									$active={row.active}
-									onClick={() => {
-										void toggleActive(row)
-									}}
-									aria-label={row.active ? t`Mark inactive` : t`Mark active`}
-									aria-pressed={row.active}
-								>
-									{row.active ? (
-										<Check size={14} aria-hidden />
-									) : (
-										<X size={14} aria-hidden />
+										{row.isPrivate && (
+											<PrivacyTag aria-label={t`Private inbox`}>
+												{t`Private`}
+											</PrivacyTag>
+										)}
+									</EmailMeta>
+								</CellEmail>
+								<CellStatus role='cell'>
+									<MobileCaption>{t`Status`}</MobileCaption>
+									<StatusBadge $status={statusTone}>{statusLabel}</StatusBadge>
+									{row.active && row.grantStatus === 'auth_failed' && (
+										<AuthHint>
+											{row.imapHost === 'mail.infomaniak.com'
+												? t`Infomaniak needs a Mail app password created in your Mail service — not an account application password.`
+												: t`Use your email provider's app-specific password — not your normal login password.`}
+											{appPwUrl !== '' && (
+												<>
+													{' '}
+													<PresetLink
+														href={appPwUrl}
+														aria-label={t`Create an app password for ${row.email}, opens in a new tab`}
+														target='_blank'
+														rel='noreferrer noopener'
+													>
+														{t`Create an app password →`}
+													</PresetLink>
+												</>
+											)}
+										</AuthHint>
 									)}
-								</IconToggle>
-							</CellActive>
-							<CellDate role='cell'>
-								{row.createdAt !== null ? (
-									<RelativeDate value={row.createdAt} />
-								) : (
-									<Muted>—</Muted>
-								)}
-							</CellDate>
-							<CellActions role='cell'>
-								<IconAction
-									type='button'
-									onClick={() => {
-										void handleTest(row)
-									}}
-									aria-label={t`Test connection for ${row.email}`}
-								>
-									<RefreshCw size={14} aria-hidden />
-								</IconAction>
-								<IconAction
-									type='button'
-									onClick={() => openFooters(row)}
-									aria-label={t`Manage footers for ${row.email}`}
-								>
-									<FileText size={14} aria-hidden />
-								</IconAction>
-								<IconAction
-									type='button'
-									onClick={() => openEdit(row)}
-									aria-label={t`Edit inbox ${row.email}`}
-								>
-									<Pencil size={14} aria-hidden />
-								</IconAction>
-								<IconAction
-									type='button'
-									onClick={() => {
-										void handleDelete(row)
-									}}
-									aria-label={t`Delete inbox ${row.email}`}
-								>
-									<Trash2 size={14} aria-hidden />
-								</IconAction>
-							</CellActions>
-						</TableRow>
-					))}
+									{row.grantLastError !== null && row.grantLastError !== '' && (
+										<TechDetails>
+											<summary>{t`Technical details`}</summary>
+											<code>{row.grantLastError}</code>
+										</TechDetails>
+									)}
+								</CellStatus>
+								<CellPurpose role='cell'>
+									<MobileCaption>{t`Used for`}</MobileCaption>
+									<PurposeBadge $purpose={row.purpose}>
+										{row.purpose === 'human'
+											? t`Personal`
+											: row.purpose === 'agent'
+												? t`AI agent`
+												: t`Shared`}
+									</PurposeBadge>
+								</CellPurpose>
+								<CellDefault role='cell'>
+									<MobileCaption>{t`Primary`}</MobileCaption>
+									{row.isDefault ? (
+										<PrimaryLabel>
+											<Star size={12} aria-hidden fill='currentColor' />
+											{t`Primary`}
+										</PrimaryLabel>
+									) : (
+										<IconToggle
+											type='button'
+											$active={false}
+											onClick={() => {
+												void setDefault(row)
+											}}
+											aria-label={t`Make ${row.email} the primary sender`}
+										>
+											<Star size={14} aria-hidden fill='none' />
+										</IconToggle>
+									)}
+								</CellDefault>
+								<CellDate role='cell'>
+									<MobileCaption>{t`Added`}</MobileCaption>
+									{row.createdAt !== null ? (
+										<RelativeDate value={row.createdAt} />
+									) : (
+										<Muted>—</Muted>
+									)}
+								</CellDate>
+								<CellActions role='cell'>
+									<PriTooltip.Provider delay={300}>
+										<ActionButton
+											icon={RefreshCw}
+											label={t`Test connection`}
+											onClick={() => {
+												void handleTest(row)
+											}}
+										/>
+										<ActionButton
+											icon={FileText}
+											label={t`Email signature`}
+											onClick={() => openFooters(row)}
+										/>
+										<ActionButton
+											icon={Pencil}
+											label={t`Edit settings`}
+											onClick={() => openEdit(row)}
+										/>
+										<ActionButton
+											icon={row.active ? Pause : Play}
+											label={row.active ? t`Pause syncing` : t`Resume syncing`}
+											onClick={() => {
+												void toggleActive(row)
+											}}
+										/>
+										<ActionButton
+											icon={Trash2}
+											label={t`Remove`}
+											onClick={() => {
+												void handleDelete(row)
+											}}
+										/>
+									</PriTooltip.Provider>
+								</CellActions>
+							</TableRow>
+						)
+					})}
 				</InboxesTable>
 			)}
 
@@ -888,6 +908,16 @@ function InboxFormDialog({
 			? 'ix-provider-2fa-hint'
 			: undefined
 
+	// IMAP/SMTP host/port hide inside a collapsible "Advanced settings" section
+	// so the common path is just provider + email + password. A chosen preset
+	// with no host (Generic / Other) forces it open, since the user must type
+	// the servers; before any provider is picked it stays collapsed.
+	const [showAdvanced, setShowAdvanced] = useState(editing !== null)
+	const needsManualHosts =
+		selectedPreset !== null &&
+		(draft.imapHost.trim() === '' || draft.smtpHost.trim() === '')
+	const advancedOpen = showAdvanced || needsManualHosts
+
 	const usernameForSubmit = draft.username !== '' ? draft.username : draft.email
 
 	// Create requires email + transport + credentials. Edit lets the user
@@ -986,7 +1016,7 @@ function InboxFormDialog({
 					<Form onSubmit={handleSubmit}>
 						{editing === null && presets.length > 0 && (
 							<Field>
-								<Label>{t`Provider preset`}</Label>
+								<Label>{t`Who's your email provider?`}</Label>
 								<PriSelect.Root
 									value={presetName}
 									onValueChange={value => {
@@ -994,7 +1024,7 @@ function InboxFormDialog({
 									}}
 								>
 									<PriSelect.Trigger
-										aria-label={t`Provider preset`}
+										aria-label={t`Who's your email provider?`}
 										aria-describedby={providerHintId}
 									>
 										<PriSelect.Value placeholder={t`Pick a provider`} />
@@ -1021,7 +1051,7 @@ function InboxFormDialog({
 										</PriSelect.Positioner>
 									</PriSelect.Portal>
 								</PriSelect.Root>
-								<Hint>{t`Selecting a preset fills IMAP and SMTP defaults — you can still edit them.`}</Hint>
+								<Hint>{t`I'll fill in the technical settings for you — you just add your email and password.`}</Hint>
 								{selectedPreset !== null &&
 									(providerUnsupported ? (
 										<Warning role='alert' id='ix-provider-warning'>
@@ -1029,7 +1059,9 @@ function InboxFormDialog({
 										</Warning>
 									) : (
 										<Hint id='ix-provider-2fa-hint'>
-											{t`Has two-factor authentication enabled? Use a provider app-specific password below, not your normal login password.`}
+											{selectedPreset.imapHost === 'mail.infomaniak.com'
+												? t`Infomaniak needs a Mail app password created in your Mail service — not an account application password, and not your normal login password.`
+												: t`If your account has two-factor authentication, use an app-specific password — not your normal login password.`}
 											{setupUrl !== '' && (
 												<>
 													{' '}
@@ -1078,67 +1110,86 @@ function InboxFormDialog({
 							/>
 						</Field>
 
-						<TransportGrid>
-							<Field>
-								<Label htmlFor='ix-imap-host'>{t`IMAP host`}</Label>
-								<PriInput
-									id='ix-imap-host'
-									type='text'
-									value={draft.imapHost}
-									onChange={e => patchDraft({ imapHost: e.target.value })}
-									placeholder='imap.example.com'
-								/>
-							</Field>
-							<Field>
-								<Label htmlFor='ix-imap-port'>{t`IMAP port`}</Label>
-								<PriInput
-									id='ix-imap-port'
-									type='number'
-									value={draft.imapPort}
-									onChange={e =>
-										patchDraft({ imapPort: parseInt(e.target.value, 10) || 0 })
-									}
-								/>
-							</Field>
-							<Field>
-								<Label>{t`IMAP security`}</Label>
-								<SecuritySelect
-									value={draft.imapSecurity}
-									onChange={next => patchDraft({ imapSecurity: next })}
-									ariaLabel={t`IMAP security`}
-								/>
-							</Field>
+						{needsManualHosts ? (
+							<Hint>{t`Enter your mail server settings below.`}</Hint>
+						) : (
+							<AdvancedToggle
+								type='button'
+								onClick={() => setShowAdvanced(v => !v)}
+								aria-expanded={advancedOpen}
+							>
+								{advancedOpen
+									? t`Hide advanced settings`
+									: t`Advanced settings (IMAP / SMTP)`}
+							</AdvancedToggle>
+						)}
+						{advancedOpen && (
+							<TransportGrid>
+								<Field>
+									<Label htmlFor='ix-imap-host'>{t`IMAP host`}</Label>
+									<PriInput
+										id='ix-imap-host'
+										type='text'
+										value={draft.imapHost}
+										onChange={e => patchDraft({ imapHost: e.target.value })}
+										placeholder='imap.example.com'
+									/>
+								</Field>
+								<Field>
+									<Label htmlFor='ix-imap-port'>{t`IMAP port`}</Label>
+									<PriInput
+										id='ix-imap-port'
+										type='number'
+										value={draft.imapPort}
+										onChange={e =>
+											patchDraft({
+												imapPort: parseInt(e.target.value, 10) || 0,
+											})
+										}
+									/>
+								</Field>
+								<Field>
+									<Label>{t`IMAP security`}</Label>
+									<SecuritySelect
+										value={draft.imapSecurity}
+										onChange={next => patchDraft({ imapSecurity: next })}
+										ariaLabel={t`IMAP security`}
+									/>
+								</Field>
 
-							<Field>
-								<Label htmlFor='ix-smtp-host'>{t`SMTP host`}</Label>
-								<PriInput
-									id='ix-smtp-host'
-									type='text'
-									value={draft.smtpHost}
-									onChange={e => patchDraft({ smtpHost: e.target.value })}
-									placeholder='smtp.example.com'
-								/>
-							</Field>
-							<Field>
-								<Label htmlFor='ix-smtp-port'>{t`SMTP port`}</Label>
-								<PriInput
-									id='ix-smtp-port'
-									type='number'
-									value={draft.smtpPort}
-									onChange={e =>
-										patchDraft({ smtpPort: parseInt(e.target.value, 10) || 0 })
-									}
-								/>
-							</Field>
-							<Field>
-								<Label>{t`SMTP security`}</Label>
-								<SecuritySelect
-									value={draft.smtpSecurity}
-									onChange={next => patchDraft({ smtpSecurity: next })}
-									ariaLabel={t`SMTP security`}
-								/>
-							</Field>
-						</TransportGrid>
+								<Field>
+									<Label htmlFor='ix-smtp-host'>{t`SMTP host`}</Label>
+									<PriInput
+										id='ix-smtp-host'
+										type='text'
+										value={draft.smtpHost}
+										onChange={e => patchDraft({ smtpHost: e.target.value })}
+										placeholder='smtp.example.com'
+									/>
+								</Field>
+								<Field>
+									<Label htmlFor='ix-smtp-port'>{t`SMTP port`}</Label>
+									<PriInput
+										id='ix-smtp-port'
+										type='number'
+										value={draft.smtpPort}
+										onChange={e =>
+											patchDraft({
+												smtpPort: parseInt(e.target.value, 10) || 0,
+											})
+										}
+									/>
+								</Field>
+								<Field>
+									<Label>{t`SMTP security`}</Label>
+									<SecuritySelect
+										value={draft.smtpSecurity}
+										onChange={next => patchDraft({ smtpSecurity: next })}
+										ariaLabel={t`SMTP security`}
+									/>
+								</Field>
+							</TransportGrid>
+						)}
 
 						<Field>
 							<Label htmlFor='ix-username'>{t`Username`}</Label>
@@ -1373,6 +1424,49 @@ function authPasswordUrlFor(
 	if (imapHost === '') return ''
 	const preset = presets.find(p => p.imapHost === imapHost)
 	return preset?.appPasswordUrl ?? ''
+}
+
+// Friendly provider name ("Infomaniak") for an inbox's IMAP host so the list
+// shows a recognisable label instead of a raw server hostname. Falls back to
+// the host itself for mailboxes that don't match a known preset.
+function providerNameFor(
+	presets: ReadonlyArray<ProviderPreset>,
+	imapHost: string,
+): string {
+	if (imapHost === '') return ''
+	const preset = presets.find(p => p.imapHost === imapHost)
+	return preset?.name ?? imapHost
+}
+
+// One row action: an icon button that shows its label as a tooltip on
+// pointer/keyboard, and as inline text on small screens where tooltips never
+// open on tap. The caller passes an already-translated label.
+function ActionButton({
+	icon: Icon,
+	label,
+	onClick,
+}: {
+	icon: ComponentType<{ size?: number; 'aria-hidden'?: boolean }>
+	label: string
+	onClick: () => void
+}) {
+	return (
+		<PriTooltip.Root>
+			<PriTooltip.Trigger
+				render={
+					<IconAction type='button' onClick={onClick} aria-label={label}>
+						<Icon size={14} aria-hidden />
+						<ActionLabel>{label}</ActionLabel>
+					</IconAction>
+				}
+			/>
+			<PriTooltip.Portal>
+				<PriTooltip.Positioner side='top' sideOffset={6}>
+					<PriTooltip.Popup>{label}</PriTooltip.Popup>
+				</PriTooltip.Positioner>
+			</PriTooltip.Portal>
+		</PriTooltip.Root>
+	)
 }
 
 function narrowPresets(raw: unknown): ReadonlyArray<ProviderPreset> {
@@ -1883,23 +1977,37 @@ const InboxesTable = styled.div.withConfig({ displayName: 'InboxesTable' })`
 	background: var(--color-paper-aged);
 `
 
+// Columns: email · status · used-for · primary · added · actions.
 const gridTemplate = css`
 	display: grid;
 	grid-template-columns:
 		minmax(0, 2fr)
-		8rem
+		minmax(8rem, 0.9fr)
+		7rem
 		6rem
-		4rem
-		4rem
-		minmax(0, 1fr)
-		8rem;
+		minmax(0, 0.8fr)
+		auto;
 	align-items: center;
 	gap: var(--space-sm);
 	padding: var(--space-sm) var(--space-md);
+`
+
+// On small screens the header row is hidden, so each value cell carries its
+// own column name as a caption above the value. Real text (not CSS generated
+// content) so a screen reader reads it as part of the cell.
+const MobileCaption = styled.span.withConfig({
+	displayName: 'InboxesMobileCaption',
+})`
+	display: none;
 
 	@media (max-width: 767px) {
-		grid-template-columns: 1fr auto;
-		gap: var(--space-2xs);
+		display: block;
+		margin-bottom: var(--space-3xs);
+		font-family: var(--font-display);
+		font-size: var(--typescale-label-small-size);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--color-on-surface-variant);
 	}
 `
 
@@ -1938,6 +2046,13 @@ const TableRow = styled.div.withConfig({
 	&:last-child {
 		border-bottom: none;
 	}
+
+	@media (max-width: 767px) {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		gap: var(--space-sm);
+	}
 `
 
 const CellEmail = styled.div.withConfig({ displayName: 'InboxesCellEmail' })`
@@ -1950,9 +2065,7 @@ const EmailAddress = styled.span.withConfig({ displayName: 'InboxesEmail' })`
 	font-family: var(--font-body);
 	font-weight: var(--font-weight-medium);
 	color: var(--color-on-surface);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	overflow-wrap: anywhere;
 `
 
 const DisplayName = styled.span.withConfig({
@@ -1970,7 +2083,12 @@ const CellPurpose = styled.div.withConfig({
 	displayName: 'InboxesCellPurpose',
 })``
 
-const CellStatus = styled.div.withConfig({ displayName: 'InboxesCellStatus' })``
+const CellStatus = styled.div.withConfig({ displayName: 'InboxesCellStatus' })`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--space-3xs);
+`
 
 const EmailMeta = styled.div.withConfig({ displayName: 'InboxesEmailMeta' })`
 	display: flex;
@@ -1980,8 +2098,10 @@ const EmailMeta = styled.div.withConfig({ displayName: 'InboxesEmailMeta' })`
 	min-width: 0;
 `
 
-const HostName = styled.span.withConfig({ displayName: 'InboxesHostName' })`
-	font-family: var(--font-mono, monospace);
+const ProviderName = styled.span.withConfig({
+	displayName: 'InboxesProviderName',
+})`
+	font-family: var(--font-body);
 	font-size: var(--typescale-label-small-size);
 	color: var(--color-on-surface-variant);
 	overflow: hidden;
@@ -2005,7 +2125,7 @@ const PrivacyTag = styled.span.withConfig({ displayName: 'InboxesPrivacyTag' })`
 const StatusBadge = styled.span.withConfig({
 	displayName: 'InboxesStatusBadge',
 	shouldForwardProp: prop => prop !== '$status',
-})<{ $status: GrantStatus }>`
+})<{ $status: StatusTone }>`
 	display: inline-flex;
 	align-items: center;
 	padding: 2px var(--space-2xs);
@@ -2015,12 +2135,11 @@ const StatusBadge = styled.span.withConfig({
 	font-weight: var(--font-weight-bold);
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
-	cursor: ${p => (p.$status !== 'connected' ? 'help' : 'default')};
 	${p =>
 		p.$status === 'connected'
 			? css`
 					background: color-mix(in oklab, #16a34a 14%, transparent);
-					color: color-mix(in oklab, #166534 80%, black);
+					color: #0f5c29;
 					border: 1px solid color-mix(in oklab, #16a34a 40%, transparent);
 				`
 			: p.$status === 'auth_failed'
@@ -2118,6 +2237,27 @@ const Warning = styled.p.withConfig({ displayName: 'InboxFormWarning' })`
 	color: var(--color-error);
 `
 
+const AdvancedToggle = styled.button.withConfig({
+	displayName: 'InboxFormAdvancedToggle',
+})`
+	align-self: flex-start;
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-primary);
+	text-decoration: underline;
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
 const AuthHint = styled.p.withConfig({ displayName: 'InboxesAuthHint' })`
 	margin: var(--space-2xs) 0 0;
 	font-family: var(--font-body);
@@ -2128,15 +2268,10 @@ const AuthHint = styled.p.withConfig({ displayName: 'InboxesAuthHint' })`
 const CellDefault = styled.div.withConfig({
 	displayName: 'InboxesCellDefault',
 })``
-const CellActive = styled.div.withConfig({ displayName: 'InboxesCellActive' })``
 const CellDate = styled.div.withConfig({ displayName: 'InboxesCellDate' })`
 	font-family: var(--font-display);
 	font-size: var(--typescale-label-small-size);
 	color: var(--color-on-surface-variant);
-
-	@media (max-width: 767px) {
-		display: none;
-	}
 `
 const CellActions = styled.div.withConfig({
 	displayName: 'InboxesCellActions',
@@ -2144,6 +2279,49 @@ const CellActions = styled.div.withConfig({
 	display: flex;
 	justify-content: flex-end;
 	gap: var(--space-3xs);
+
+	@media (max-width: 767px) {
+		flex-direction: column;
+		align-items: stretch;
+		justify-content: flex-start;
+		gap: var(--space-2xs);
+	}
+`
+
+const PrimaryLabel = styled.span.withConfig({
+	displayName: 'InboxesPrimaryLabel',
+})`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3xs);
+	color: var(--color-primary);
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+`
+
+const TechDetails = styled.details.withConfig({
+	displayName: 'InboxesTechDetails',
+})`
+	margin-top: var(--space-3xs);
+
+	> summary {
+		cursor: pointer;
+		font-family: var(--font-body);
+		font-size: var(--typescale-label-small-size);
+		color: var(--color-on-surface-variant);
+	}
+
+	> code {
+		display: block;
+		margin-top: var(--space-3xs);
+		font-family: var(--font-mono, monospace);
+		font-size: var(--typescale-label-small-size);
+		color: var(--color-on-surface-variant);
+		overflow-wrap: anywhere;
+	}
 `
 
 const PurposeBadge = styled.span.withConfig({
@@ -2223,20 +2401,44 @@ const IconAction = styled.button.withConfig({
 	height: 1.75rem;
 	padding: 0;
 	background: transparent;
-	border: 1px dashed var(--color-outline);
+	border: 1px solid var(--color-outline);
 	border-radius: var(--shape-2xs);
 	color: var(--color-on-surface-variant);
 	cursor: pointer;
+	transition:
+		color 160ms ease,
+		border-color 160ms ease;
 
 	&:hover:not(:disabled) {
 		color: var(--color-primary);
 		border-color: var(--color-primary);
-		border-style: solid;
 	}
 
 	&:focus-visible {
 		outline: none;
 		box-shadow: var(--glow-active);
+	}
+
+	/* On small screens the button carries a visible text label, so it grows
+	   to fit and left-aligns instead of staying an icon-only square. */
+	@media (max-width: 767px) {
+		width: auto;
+		height: auto;
+		justify-content: flex-start;
+		gap: var(--space-2xs);
+		padding: var(--space-2xs) var(--space-sm);
+	}
+`
+
+const ActionLabel = styled.span.withConfig({
+	displayName: 'InboxesActionLabel',
+})`
+	display: none;
+
+	@media (max-width: 767px) {
+		display: inline;
+		font-family: var(--font-body);
+		font-size: var(--typescale-label-medium-size);
 	}
 `
 
@@ -2244,6 +2446,30 @@ const Muted = styled.span.withConfig({ displayName: 'InboxesMuted' })`
 	color: var(--color-on-surface-variant);
 	font-style: italic;
 	opacity: 0.7;
+`
+
+const EmptyHelp = styled.div.withConfig({ displayName: 'InboxesEmptyHelp' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+	align-items: flex-start;
+	text-align: left;
+
+	> p {
+		margin: 0;
+	}
+
+	> ol {
+		margin: 0;
+		padding-left: var(--space-md);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2xs);
+	}
+
+	> ol > li {
+		font-style: normal;
+	}
 `
 
 const DialogHeader = styled.div.withConfig({

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -350,8 +350,12 @@ const PROVIDER_PRESETS = [
 		smtpPort: 465,
 		smtpSecurity: 'tls',
 		helpUrl: 'https://www.infomaniak.com/en/support/faq/2427',
+		// Infomaniak splits passwords in two: the account-level "application
+		// password" (FAQ 2855) only works for contacts/calendars, never IMAP.
+		// IMAP/SMTP needs a per-mailbox device password created in Mail Service
+		// (FAQ 1321) — point users there or they hit "Invalid login or password".
 		appPasswordUrl:
-			'https://www.infomaniak.com/en/support/faq/2855/manage-application-passwords',
+			'https://www.infomaniak.com/en/support/faq/1321/add-a-device-generate-app-specific-password-via-the-mail-app',
 		passwordAuthSupported: true,
 	},
 	{


### PR DESCRIPTION
## What

Reshapes the **inbox connections** screen (`apps/internal`, CRM/email surface — `/emails/inboxes`) so a non-technical founder can tell whether their email works and what to do when it doesn't. The old screen read like a sysadmin's connection table: protocols (`IMAP/SMTP`), status codes (`AUTH FAILED`), insider columns (`PURPOSE` / `DEFAULT` / `ACTIVE`), and unlabeled icon buttons. This was proven painful in practice — the `AUTH FAILED` hint ("2FA accounts need an app-specific password") was both jargon and *wrong* for Infomaniak: it pointed at the account application-password page (FAQ 2855), which doesn't work for IMAP; the right one is the Mail-service device password (FAQ 1321).

## Changes

- **Plain language over protocol.** "Inbox management" → "Your email connections"; dropped IMAP/SMTP from the intro; `AUTH FAILED` → "Couldn't sign in", etc.
- **Self-serve errors.** A failed sign-in now shows provider-specific guidance (e.g. the exact Infomaniak Mail-app-password gotcha) with the corrected link, and tucks the raw server error behind a "Technical details" disclosure instead of a hover-only tooltip.
- **Decoded columns.** "Used for" = Personal / AI agent / Shared; the standalone *Active* column is folded into Status (an off inbox reads "Paused"); the on/off control moves into the row menu as Pause/Resume; the default row shows a "Primary" label.
- **Labelled, touch-reachable actions.** Icon buttons get tooltips on pointer/keyboard and inline text labels on small screens (Base UI tooltips don't open on tap), with solid affordances instead of the dashed borders that read as disabled.
- **Real mobile layout.** Under 768px each row becomes a stacked card with a caption above each value, instead of unlabeled cells flowing into a 2-column grid.
- **Identity, not hostname.** The full email no longer truncates, and the row shows the provider name ("Infomaniak") rather than the mail server hostname.
- **Provider-first connect form.** Leads with "Who's your email provider?", auto-fills the transport, and hides IMAP/SMTP host/port behind an "Advanced settings" toggle (auto-opened only for Generic/Other).
- **Welcoming empty state** with a short "what happens next" list.
- Carries the **Infomaniak preset link fix** (FAQ 2855 → FAQ 1321) in `apps/server`.

## Impact

- **API / wire-shape:** none. No `packages/controllers` or `packages/domain` shape change; the inbox list and provider-preset responses are unchanged (the per-provider error hint is rendered client-side, keyed off the preset's `imapHost`, so it stays translatable).
- **i18n:** all new user-facing strings are wrapped in Lingui macros and translated to Catalan; `ca` catalog has 0 missing.
- **Migration / RLS / auth / env / CORS / webhooks:** none touched.
- **MCP + HTTP parity:** the server change is a single preset URL string in `PROVIDER_PRESETS`, so both the HTTP `listProviderPresets` and the MCP `list_email_provider_presets` surfaces get the corrected link automatically.

## Review guide

- Start in `apps/internal/src/routes/emails/inboxes.tsx` — the bulk of the change. The risk areas worth a look: the responsive switch (desktop grid vs `<768px` stacked cards via `cellLabel` + `data-label` captions) and the `ActionButton` (tooltip on pointer + inline label on touch, since tooltips never open on tap).
- The two `.po` catalogs are generated by `i18n:extract` plus hand-added Catalan — skim, don't scrutinize.
- One decision you might overrule: the per-provider error hint lives **client-side** (a translated string keyed by `imapHost`) rather than as a raw string on the server preset — because `apps/internal` requires every string to go through Lingui and the server value couldn't be translated. Easy to revisit if you'd rather carry it on the preset.
- a11y: ran the accessibility reviewer and fixed what it flagged in this surface — the "Connected" pill text contrast (now ≥4.5:1), the mobile column captions are real DOM text instead of CSS generated content (so screen readers read them), the one-way "Make primary" star no longer claims a bogus `aria-pressed` toggle state, and the icon-button border is more discoverable. One finding is **out of scope**: the app-wide `--glow-active` focus ring is below 3:1 and disappears in forced-colors mode — it's a shared token used everywhere, so fixing it belongs in its own pass, not a drive-by here (see Deferred).

## Screenshots

**Desktop — the connections list.** Plain status, "Used for" = Personal / AI agent, ★ Primary on the default row, the Active column merged into Status, full emails, and labelled row actions:

![pr-inboxes-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-151/pr-inboxes-desktop.webp)

**Mobile (iPhone) — stacked cards.** Each value carries a caption above it and the actions become full-width labelled buttons (touch-friendly, no hover-only tooltips):

![pr-inboxes-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-151/pr-inboxes-mobile.webp)

> The provider-first connect form and the tailored Infomaniak app-password hint (with the corrected FAQ-1321 link) were verified live but aren't re-captured here.

## Verification

- Gates run locally, all green: `pnpm -w check-types`, `pnpm -w test` (unit), `pnpm -w build`; `biome check`; `i18n:extract` (0 missing in `ca`).
- **Server integration suite was NOT run locally** — the worktree's integration test-DB global-setup (`scripts/integration-db-setup.ts`) didn't build the schema here ("organization does not exist" across all suites), an env gap unrelated to this diff (no server logic / SQL / schema changed). Relying on CI to run it.
- Drove the change against the live worktree stack (logged in, Taller Demo org), desktop + 430px mobile: confirmed the new header/columns, the merged Status, full email + provider name, the stacked mobile cards with labelled action buttons, and the provider-first connect form with advanced settings hidden — and that selecting **Infomaniak** renders the exact tailored device-password hint with the corrected link.
- Ran the `a11y-accessibility-reviewer` agent on the changed components.

## Deferred

- **App-wide focus indicator** (`--glow-active` in `packages/ui/src/tokens.css`): the focus ring is ~1.2:1 over paper and is removed in forced-colors mode, failing WCAG 2.4.11. It's the shared focus pattern for every interactive control in the app, so it deserves a dedicated token fix + a forced-colors snapshot test rather than touching it through this PR.
- The `list_email_inboxes` MCP tool returns a bare array as `structuredContent`, which the claude.ai MCP client rejects — separate, pre-existing bug, not in scope here.
