### PR TITLE
fix(server): wrap MCP list-tool output in an object envelope

### DIFF
--- a/apps/server/src/mcp/tools/_annotations.test.ts
+++ b/apps/server/src/mcp/tools/_annotations.test.ts
@@ -102,6 +102,25 @@ describe('MCP tool annotation coverage', () => {
 						).toBe('object')
 					})
 
+					it('should not encode structured output as a bare array', () => {
+						// GIVEN a tool's success schema — Effect copies the encoded
+						//       value straight into the result's structuredContent
+						// WHEN converting that schema to JSON Schema
+						// THEN the root is not type:"array" — MCP requires
+						//      structuredContent to be a JSON object, so a strict
+						//      client rejects a bare-array result and hides the tool.
+						//      List tools must wrap rows in an object (_result.ts
+						//      ListResult → { items }).
+						// [tools/${toolkitName} — structured-output object invariant]
+						const outputSchema = Tool.getJsonSchemaFromSchema(
+							tool.successSchema,
+						) as { type?: unknown }
+						expect(
+							outputSchema.type,
+							`${toolName} success schema must not encode to a JSON array; wrap the list in an object (ListResult / { items })`,
+						).not.toBe('array')
+					})
+
 					if (READ_ONLY_NAME.test(toolName)) {
 						it('should declare Tool.Readonly = true', () => {
 							// GIVEN a tool whose name matches a read-only convention

--- a/apps/server/src/mcp/tools/_result.ts
+++ b/apps/server/src/mcp/tools/_result.ts
@@ -1,0 +1,14 @@
+import { Schema } from 'effect'
+
+// Many tools naturally return a list, but the MCP standard requires a tool's
+// structured output to be a JSON object — strict clients reject a bare array
+// and hide the tool. Wrapping each list as `{ items }` keeps the result valid.
+// Pair this schema with `toItems` on the handler's returned array.
+export const ListResult = (item: Schema.Top) =>
+	Schema.Struct({ items: Schema.Array(item) })
+
+export const toItems = <A>(
+	items: ReadonlyArray<A>,
+): { items: ReadonlyArray<A> } => ({
+	items,
+})

--- a/apps/server/src/mcp/tools/calendar.ts
+++ b/apps/server/src/mcp/tools/calendar.ts
@@ -9,6 +9,7 @@ import { CalendarService } from '../../services/calendar'
 import { dispatchForwardInvitation } from '../../services/calendar-forward-dispatch'
 import { dispatchRsvpReply } from '../../services/calendar-rsvp-dispatch'
 import { EmailService } from '../../services/email'
+import { ListResult, toItems } from './_result'
 
 // Per-request services the dispatcher tools depend on. The MCP HTTP middleware
 // (apps/server/src/mcp/http.ts) provides both alongside CurrentUser, so
@@ -38,7 +39,7 @@ const FindAvailability = Tool.make('find_availability', {
 		from: Schema.String,
 		to: Schema.String,
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'Find Availability')
@@ -122,7 +123,7 @@ const RsvpPendingInvitations = Tool.make('rsvp_pending_invitations', {
 		attendee_email: Schema.String,
 		limit: Schema.optional(Schema.Number),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Pending Invitations')
@@ -158,7 +159,7 @@ const ListUpcoming = Tool.make('list_upcoming_meetings', {
 		source: Schema.optional(Schema.Literals(['booking', 'email', 'internal'])),
 		limit: Schema.optional(Schema.Number),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Upcoming Meetings')
@@ -172,7 +173,7 @@ const ListEventTypes = Tool.make('list_event_types', {
 	parameters: Schema.Struct({
 		active: Schema.optional(Schema.Boolean),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Event Types')
@@ -261,7 +262,7 @@ export const CalendarHandlersLive = CalendarTools.toLayer(
 						from: new Date(params.from),
 						to: new Date(params.to),
 					})
-					.pipe(Effect.orDie),
+					.pipe(Effect.orDie, Effect.map(toItems)),
 			schedule_meeting: params =>
 				svc
 					.scheduleMeeting({
@@ -337,7 +338,7 @@ export const CalendarHandlersLive = CalendarTools.toLayer(
 						attendeeEmail: params.attendee_email,
 						limit: params.limit ?? 25,
 					})
-					.pipe(Effect.orDie),
+					.pipe(Effect.orDie, Effect.map(toItems)),
 			forward_invitation: params =>
 				dispatchForwardInvitation({
 					calendarEventId: params.calendar_event_id,
@@ -390,7 +391,7 @@ export const CalendarHandlersLive = CalendarTools.toLayer(
 						ORDER BY start_at ASC
 						LIMIT ${limit}
 					`
-				}).pipe(Effect.orDie),
+				}).pipe(Effect.orDie, Effect.map(toItems)),
 			list_event_types: params =>
 				Effect.gen(function* () {
 					const conditions: Array<Statement.Fragment> = []
@@ -401,7 +402,7 @@ export const CalendarHandlersLive = CalendarTools.toLayer(
 						${conditions.length > 0 ? sql`WHERE ${sql.and(conditions)}` : sql``}
 						ORDER BY slug
 					`
-				}).pipe(Effect.orDie),
+				}).pipe(Effect.orDie, Effect.map(toItems)),
 			get_calendar_event: ({ id }) =>
 				Effect.gen(function* () {
 					const rows =

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -10,6 +10,7 @@ import {
 	EmailAttachmentStaging,
 	type StagingRef,
 } from '../../services/email-attachment-staging'
+import { ListResult, toItems } from './_result'
 
 // Per-request services every email tool depends on. The MCP HTTP middleware
 // (apps/server/src/mcp/http.ts) provides both alongside CurrentUser, so
@@ -314,7 +315,7 @@ const ListEmailInboxes = Tool.make('list_email_inboxes', {
 		active: Schema.optional(Schema.Boolean),
 		owner_user_id: Schema.optional(Schema.String),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Email Inboxes')
@@ -325,7 +326,7 @@ const ListEmailInboxes = Tool.make('list_email_inboxes', {
 const ListEmailProviderPresets = Tool.make('list_email_provider_presets', {
 	description:
 		'List the built-in mailbox presets (Infomaniak, Fastmail, iCloud Mail, Yahoo Mail, Gmail Workspace, Microsoft 365, Proton Bridge, Generic IMAP). Each entry pre-fills IMAP and SMTP host/port/security, plus appPasswordUrl (where the user generates an app-specific password for a 2FA account) and passwordAuthSupported (false for Gmail and Microsoft 365, which no longer allow password sign-in and need OAuth). create_email_inbox callers only need to add credentials. Static — safe to cache.',
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 })
 	.annotate(Tool.Title, 'List Email Provider Presets')
 	.annotate(Tool.Readonly, true)
@@ -480,7 +481,7 @@ const ListEmailDrafts = Tool.make('list_email_drafts', {
 	parameters: Schema.Struct({
 		inbox_id: Schema.optional(Schema.String),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Email Drafts')
@@ -531,7 +532,7 @@ const ListInboxFooters = Tool.make('list_inbox_footers', {
 	parameters: Schema.Struct({
 		inbox_id: Schema.String,
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Inbox Footers')
@@ -895,14 +896,17 @@ export const EmailHandlersLive = EmailTools.toLayer(
 					Effect.orDie,
 				),
 			list_email_inboxes: params =>
-				svc.listLocalInboxes({
-					...(params.purpose !== undefined && { purpose: params.purpose }),
-					...(params.active !== undefined && { active: params.active }),
-					...(params.owner_user_id !== undefined && {
-						ownerUserId: params.owner_user_id,
-					}),
-				}),
-			list_email_provider_presets: () => svc.listProviderPresets(),
+				svc
+					.listLocalInboxes({
+						...(params.purpose !== undefined && { purpose: params.purpose }),
+						...(params.active !== undefined && { active: params.active }),
+						...(params.owner_user_id !== undefined && {
+							ownerUserId: params.owner_user_id,
+						}),
+					})
+					.pipe(Effect.map(toItems)),
+			list_email_provider_presets: () =>
+				svc.listProviderPresets().pipe(Effect.map(toItems)),
 			get_email_inbox_status: () => svc.inboxStatus(),
 			create_email_inbox: params =>
 				svc
@@ -1066,10 +1070,11 @@ export const EmailHandlersLive = EmailTools.toLayer(
 				}
 			},
 			list_email_drafts: params =>
-				svc.listDrafts(params.inbox_id).pipe(Effect.orDie),
+				svc.listDrafts(params.inbox_id).pipe(Effect.orDie, Effect.map(toItems)),
 			get_email_draft: ({ inbox_id, draft_id }) =>
 				svc.getDraft(inbox_id, draft_id).pipe(Effect.orDie),
-			list_inbox_footers: params => svc.listFooters(params.inbox_id),
+			list_inbox_footers: params =>
+				svc.listFooters(params.inbox_id).pipe(Effect.map(toItems)),
 			get_inbox_footer: ({ id }) => svc.getFooter(id).pipe(Effect.orDie),
 			manage_inbox_footer: params => {
 				switch (params.action) {

--- a/apps/server/src/mcp/tools/products.ts
+++ b/apps/server/src/mcp/tools/products.ts
@@ -4,12 +4,14 @@ import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
 
+import { ListResult, toItems } from './_result'
+
 const REQUEST_DEPENDENCIES = [CurrentOrg]
 
 const ListProducts = Tool.make('list_products', {
 	description:
 		'List products in the organization. Returns id, slug, name, type, status, default_price, price_type, target_industries, metadata, created_at.',
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Products')
@@ -73,6 +75,7 @@ export const ProductHandlersLive = ProductTools.toLayer(
 			list_products: () =>
 				sql`SELECT id, slug, name, type, status, default_price, price_type, target_industries, metadata, created_at FROM products ORDER BY created_at DESC`.pipe(
 					Effect.orDie,
+					Effect.map(toItems),
 				),
 			create_product: params =>
 				Effect.gen(function* () {

--- a/apps/server/src/mcp/tools/proposals.ts
+++ b/apps/server/src/mcp/tools/proposals.ts
@@ -8,6 +8,7 @@ import {
 	ProposalEvent,
 	TimelineActivityService,
 } from '../../services/timeline-activity'
+import { ListResult, toItems } from './_result'
 
 const REQUEST_DEPENDENCIES = [CurrentOrg]
 
@@ -25,7 +26,7 @@ const ListProposals = Tool.make('list_proposals', {
 	parameters: Schema.Struct({
 		company_id: Schema.optional(Schema.String),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Proposals')
@@ -91,7 +92,7 @@ export const ProposalHandlersLive = ProposalTools.toLayer(
 						return yield* sql`SELECT * FROM proposals WHERE company_id = ${company_id} ORDER BY created_at DESC`
 					}
 					return yield* sql`SELECT * FROM proposals ORDER BY created_at DESC`
-				}).pipe(Effect.orDie),
+				}).pipe(Effect.orDie, Effect.map(toItems)),
 			create_proposal: params =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg

--- a/apps/server/src/mcp/tools/research-lifecycle.ts
+++ b/apps/server/src/mcp/tools/research-lifecycle.ts
@@ -5,6 +5,7 @@ import { CurrentOrg, SessionContext } from '@batuda/controllers'
 import { ResearchService } from '@batuda/research'
 
 import { redactDbErrors, Uuid } from './_research-shared'
+import { ListResult, toItems } from './_result'
 
 const REQUEST_DEPENDENCIES = [SessionContext, CurrentOrg]
 
@@ -24,7 +25,7 @@ const ListResearch = Tool.make('list_research', {
 		limit: Schema.optional(Schema.Number),
 		offset: Schema.optional(Schema.Number),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'List Research')
@@ -111,7 +112,7 @@ const ListResearchProposedUpdates = Tool.make(
 		parameters: Schema.Struct({
 			id: Schema.String,
 		}),
-		success: Schema.Array(Schema.Unknown),
+		success: ListResult(Schema.Unknown),
 		dependencies: REQUEST_DEPENDENCIES,
 	},
 )
@@ -167,7 +168,7 @@ const GetResearchSpend = Tool.make('get_research_spend', {
 		range: Schema.optional(SpendRange),
 		group_by: Schema.optional(SpendGroupBy),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'Get Research Spend')
@@ -202,7 +203,7 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 						limit: filters.limit,
 						offset: filters.offset,
 					})
-					.pipe(redactDbErrors),
+					.pipe(redactDbErrors, Effect.map(toItems)),
 			cancel_research: ({ id }) =>
 				Effect.gen(function* () {
 					const res = yield* svc.cancel(id)
@@ -244,7 +245,7 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 						proposed_updates?: unknown[]
 					} | null
 					return findings?.proposed_updates ?? []
-				}).pipe(redactDbErrors),
+				}).pipe(redactDbErrors, Effect.map(toItems)),
 			resolve_research_proposed_update: ({ decision }) =>
 				// Placeholder: the OCC-protected CRM write that would land on
 				// apply is not yet wired, so this returns the resolution
@@ -278,7 +279,7 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 						...(range !== undefined && { range }),
 						...(group_by !== undefined && { groupBy: group_by }),
 					})
-					.pipe(redactDbErrors),
+					.pipe(redactDbErrors, Effect.map(toItems)),
 		}
 	}),
 )

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -5,6 +5,7 @@ import { SqlClient } from 'effect/unstable/sql'
 import { CurrentOrg } from '@batuda/controllers'
 
 import { TaskService } from '../../services/tasks'
+import { ListResult, toItems } from './_result'
 
 // MCP writes are agent-driven; task_events records actor_kind='agent' with no
 // individual user id.
@@ -83,7 +84,7 @@ const ListTasks = Tool.make('list_tasks', {
 		limit: Schema.optional(Schema.Number),
 		offset: Schema.optional(Schema.Number),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'List Tasks')
@@ -104,7 +105,7 @@ const SearchTasks = Tool.make('search_tasks', {
 		source: Schema.optional(TaskSource),
 		limit: Schema.optional(Schema.Number),
 	}),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Search Tasks')
@@ -224,7 +225,7 @@ const GetTaskEvents = Tool.make('get_task_events', {
 	description:
 		'List audit events recorded for a task (created/updated/completed/cancelled/snoozed/rescheduled). Returns up to the 100 most recent events sorted by occurrence time descending.',
 	parameters: Schema.Struct({ id: Schema.String }),
-	success: Schema.Array(Schema.Unknown),
+	success: ListResult(Schema.Unknown),
 	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Get Task Events')
@@ -311,7 +312,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 							offset: params.offset ?? 0,
 						},
 					)
-					.pipe(Effect.orDie),
+					.pipe(Effect.orDie, Effect.map(toItems)),
 
 			search_tasks: params =>
 				taskService
@@ -327,7 +328,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 						},
 						{ sort: 'due', limit: params.limit ?? 25, offset: 0 },
 					)
-					.pipe(Effect.orDie),
+					.pipe(Effect.orDie, Effect.map(toItems)),
 
 			update_task: params =>
 				Effect.gen(function* () {
@@ -398,7 +399,7 @@ export const TaskHandlersLive = TaskTools.toLayer(
 						SELECT * FROM task_events WHERE task_id = ${id}
 						ORDER BY at DESC LIMIT 100
 					`
-				}).pipe(Effect.orDie),
+				}).pipe(Effect.orDie, Effect.map(toItems)),
 
 			reopen_task: ({ id }) =>
 				taskService.reopen(id, AGENT_ACTOR).pipe(


### PR DESCRIPTION
## What

Fixes a contract bug in the MCP tool surface (`apps/server` — `src/mcp/tools`): **16 list-style tools were unusable through strict MCP clients** (including claude.ai). Each declared `success: Schema.Array(...)`, and Effect copies the encoded success value straight into the result's `structuredContent`. A bare array passed Effect's `typeof === "object"` guard (`McpServer.ts:648`) and shipped as a top-level array — but MCP requires `structuredContent` to be a JSON **object**, so the client rejects the whole call (`expected record, received array`) and hides the tool.

Reproduced live twice (`list_email_inboxes`, `list_email_provider_presets`); the other 14 fail identically — they were just the two exercised so far.

## The fix

A shared envelope helper (`_result.ts`): `ListResult(item)` → `Schema.Struct({ items: Schema.Array(item) })`, and `toItems` to wrap the handler's array. Each of the 16 tools now declares `success: ListResult(Schema.Unknown)` and returns `{ items: [...] }`. This makes the encoded structured output an object, which strict clients accept.

The 16 span `email` (4), `calendar` (4), `tasks` (3), `research-lifecycle` (3), `products` (1), `proposals` (1) — all list/collection tools an AI client routinely calls (`list_*` / `search_*` / `find_*`, plus `get_research_spend`, `rsvp_pending_invitations`, `get_task_events`).

## Impact

- **Wire-shape change (the thing to weigh):** these tools now return `{ items: [...] }` instead of a bare array, so consumers must read `.items`. Since the tools were *rejected* by strict clients before, there's no working consumer to regress — and it aligns with the existing `list_email_threads` / `list_email_messages` envelope convention.
- **MCP + HTTP parity:** these are MCP-only tools; the HTTP routes are separate and untouched.
- **No migration / RLS / auth / env / CORS / webhooks** touched. No dependency patching — the fix is entirely in batuda code.
- The compiler enforces the contract: because `success` is now a `Struct`, a handler that forgot to wrap its array would fail `check-types`.

## Review guide

- Start in `apps/server/src/mcp/tools/_result.ts` (the 8-line helper) — the rest is the same two-line edit repeated across 6 files (import + `ListResult(...)` + `Effect.map(toItems)`), mechanical and compiler-checked.
- The regression net is in `_annotations.test.ts` — a new invariant walks every tool in every toolkit and asserts its `success` schema does **not** encode to a JSON array (`type !== "array"`), so a future array-success tool can't land silently. I verified it *catches* the bug: reintroducing `Schema.Array` on one tool makes the test fail.

## Tests

- New invariant in `_annotations.test.ts` (rides with the logic): "should not encode structured output as a bare array", for all tools across all toolkits.
- Negative-tested: temporarily reverting one tool to `Schema.Array` fails the invariant; reverted.

## Verification

- Ran locally, all green: `pnpm --filter @batuda/server check-types`, `test` (487 unit), `build`; `biome check`.
- **Did NOT run the server integration suite locally** — this worktree wasn't provisioned, so the integration global-setup's `cli seed` step threw a `ConfigError` (missing env config) before any test executed. That's an environment gap unrelated to this diff (server-only code; no SQL/schema/handler-logic change beyond the output shape). Relying on CI to run it in its proper DB.
- I could not exercise the live MCP round-trip locally (the claude.ai MCP targets production); the static `structuredContent`-shape invariant is the regression guard, asserting exactly what the client enforces.
