### PR TITLE
feat(observability): export every server and mail-worker error to Honeycomb

### DIFF
--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -91,6 +91,7 @@ jobs:
             -e SERVICE_VERSION="${{ steps.meta.outputs.version }}"
             -e GIT_SHA="${{ github.sha }}"
             -e REGION="${{ env.KRAFTCLOUD_METRO }}"
+            -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-mail-worker"
             -e DATABASE_URL="${{ secrets.DATABASE_URL }}"
             -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}"
             -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}"
@@ -138,6 +139,7 @@ jobs:
               -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
               -e GIT_SHA="${{ github.sha }}" \
               -e REGION="${{ env.KRAFTCLOUD_METRO }}" \
+              -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-mail-worker" \
               -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
               -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
               -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -134,6 +134,7 @@ jobs:
             -e SERVICE_VERSION="${{ steps.meta.outputs.version }}"
             -e GIT_SHA="${{ github.sha }}"
             -e REGION="${{ env.KRAFTCLOUD_METRO }}"
+            -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-server"
             -e DATABASE_URL="${{ secrets.DATABASE_URL }}"
             -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}"
             -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}"
@@ -217,6 +218,7 @@ jobs:
                 -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
                 -e GIT_SHA="${{ github.sha }}" \
                 -e REGION="${{ env.KRAFTCLOUD_METRO }}" \
+                -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-server" \
                 -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
                 -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
                 -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \

--- a/apps/mail-worker/package.json
+++ b/apps/mail-worker/package.json
@@ -15,6 +15,7 @@
 		"@batuda/controllers": "workspace:*",
 		"@batuda/domain": "workspace:*",
 		"@batuda/email": "workspace:*",
+		"@batuda/observability": "workspace:*",
 		"@effect/platform-node": "4.0.0-beta.43",
 		"@effect/sql-pg": "4.0.0-beta.43",
 		"effect": "4.0.0-beta.43",

--- a/apps/mail-worker/src/main.ts
+++ b/apps/mail-worker/src/main.ts
@@ -1,7 +1,8 @@
 import { NodeRuntime } from '@effect/platform-node'
-import { Effect, type Fiber, Layer, Ref, Schedule } from 'effect'
+import { DateTime, Effect, type Fiber, Layer, Ref, Schedule } from 'effect'
 
 import { ParticipantMatcher } from '@batuda/email/participant-matcher'
+import { makeOtlpObservability } from '@batuda/observability'
 
 import { type ClaimedInbox, claimAvailableInboxes } from './claim.js'
 import { installCrashGuards } from './crash-guards.js'
@@ -38,6 +39,22 @@ const program = Effect.gen(function* () {
 		new Map(),
 	)
 
+	// Liveness signal. A dead/crash-looping worker exports no telemetry, so a
+	// Honeycomb absence trigger watches for a gap in this event. The scan tick
+	// fires every 5s; throttle the heartbeat to ~1/min so it stays a cheap
+	// "still alive" pulse rather than per-tick noise. Starts at 0 so the first
+	// tick emits immediately (a boot heartbeat).
+	const HEARTBEAT_INTERVAL_MS = 60_000
+	const lastHeartbeatAt = yield* Ref.make(0)
+	const emitHeartbeat = Effect.gen(function* () {
+		const now = DateTime.toEpochMillis(DateTime.nowUnsafe())
+		if (now - (yield* Ref.get(lastHeartbeatAt)) < HEARTBEAT_INTERVAL_MS) return
+		yield* Ref.set(lastHeartbeatAt, now)
+		yield* Effect.logInfo('mail-worker heartbeat').pipe(
+			Effect.annotateLogs({ event: 'mail_worker.heartbeat' }),
+		)
+	})
+
 	const reapFinished = Effect.gen(function* () {
 		const current = yield* Ref.get(running)
 		const next = new Map(current)
@@ -52,6 +69,7 @@ const program = Effect.gen(function* () {
 	})
 
 	const tick: Effect.Effect<void, never, never> = Effect.gen(function* () {
+		yield* emitHeartbeat
 		yield* reapFinished
 		const claimed: readonly ClaimedInbox[] = yield* claimAvailableInboxes.pipe(
 			Effect.catchCause(cause =>
@@ -99,6 +117,12 @@ const Live = Layer.mergeAll(
 	// inbox claim/session queries run by `program`.
 	Layer.provideMerge(PgLive),
 	Layer.provideMerge(WorkerEnvVars.layer),
+	// Export traces, logs, and metrics to the batuda-mail-worker Honeycomb
+	// dataset when OTEL_EXPORTER_OTLP_ENDPOINT is set. Without this the worker's
+	// IMAP disconnects, credential failures, and session-fiber deaths die in the
+	// console ring-buffer. Sits above ConfigFileLive so it can read NODE_ENV +
+	// the OTEL_* settings; merges with the default console logger, not replacing it.
+	Layer.provide(makeOtlpObservability({ serviceName: 'batuda-mail-worker' })),
 	// Install the baked-file config values before the readers above resolve, so
 	// the env-var layer and the database client can read non-secret settings
 	// that no longer travel on the boot command line.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,6 +36,7 @@
 		"@batuda/domain": "workspace:*",
 		"@batuda/email": "workspace:*",
 		"@batuda/instructions": "workspace:*",
+		"@batuda/observability": "workspace:*",
 		"@batuda/research": "workspace:*",
 		"@batuda/ui": "workspace:*",
 		"@types/mailparser": "^3.4.6",

--- a/apps/server/src/handlers/auth.ts
+++ b/apps/server/src/handlers/auth.ts
@@ -31,6 +31,19 @@ const proxyToAuth = Effect.gen(function* () {
 	const fetchRequest = new Request(url, init)
 
 	const response = yield* Effect.promise(() => instance.handler(fetchRequest))
+
+	// The MCP OAuth-drop bug shows up as failures on the token endpoint, which
+	// Better Auth serves opaquely. Tag the request span with the grant outcome
+	// (response status) so a refresh failure is visible in Honeycomb without a
+	// console grep. The request body is already streamed to Better Auth, so
+	// grant_type isn't read here (would need teeing the stream).
+	if (url.pathname.endsWith('/oauth2/token')) {
+		yield* Effect.annotateCurrentSpan({
+			'auth.endpoint': 'oauth2/token',
+			'auth.token_response_status': response.status,
+		})
+	}
+
 	return HttpServerResponse.fromWeb(response)
 })
 

--- a/apps/server/src/handlers/health.ts
+++ b/apps/server/src/handlers/health.ts
@@ -2,8 +2,7 @@ import { Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
 import { BatudaApi } from '@batuda/controllers'
-
-import { buildMeta } from '../lib/build-meta'
+import { buildMeta } from '@batuda/observability'
 
 export const HealthLive = HttpApiBuilder.group(BatudaApi, 'health', handlers =>
 	Effect.succeed(

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -30,6 +30,55 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 			connectionString: Redacted.value(env.DATABASE_URL),
 		})
 
+		// Better Auth's `logger.log` and `onAPIError.onError` are plain callbacks
+		// that fire OUTSIDE the Effect fiber. Capture the layer's services here so
+		// those callbacks can fork log effects onto the real runtime — routing
+		// Better Auth's internal errors (adapter, OAuth/OIDC) through OTLP like
+		// every other log instead of leaving them console-only.
+		const services = yield* Effect.services<never>()
+		const forkLog = (effect: Effect.Effect<void, never, never>): void => {
+			Effect.runForkWith(services)(effect)
+		}
+		const betterAuthLogger: NonNullable<
+			Parameters<typeof buildBetterAuthConfig>[0]['logger']
+		> = {
+			// Capture warnings + errors. 'warn' is also Better Auth's own default
+			// level, so nothing it would normally surface is lost; info/debug are
+			// filtered out (a custom `log` replaces its console writer entirely).
+			level: 'warn',
+			log: (level, message, ...args) => {
+				forkLog(
+					(level === 'error'
+						? Effect.logError(message)
+						: Effect.logWarning(message)
+					).pipe(
+						Effect.annotateLogs({
+							event: 'auth.internal',
+							betterAuthLevel: level,
+							...(args.length > 0 ? { detail: args } : {}),
+						}),
+					),
+				)
+			},
+		}
+		const betterAuthOnAPIError: NonNullable<
+			Parameters<typeof buildBetterAuthConfig>[0]['onAPIError']
+		> = {
+			// Observe only — don't change Better Auth's response behaviour. Log the
+			// error message (not ctx: it holds headers/session) so OAuth/token
+			// failures are queryable instead of vanishing into the console buffer.
+			onError: error => {
+				forkLog(
+					Effect.logError('Better Auth API error').pipe(
+						Effect.annotateLogs({
+							event: 'auth.api_error',
+							error: error instanceof Error ? error.message : String(error),
+						}),
+					),
+				)
+			},
+		}
+
 		// The shared builder is the single source of truth for Batuda's
 		// Better-Auth config. CLI commands use the same builder with a
 		// narrower plugin list (no magicLink) so that API keys and sessions
@@ -79,6 +128,8 @@ export class Auth extends ServiceMap.Service<Auth>()('Auth', {
 					rateLimit: env.BETTER_AUTH_RATE_LIMIT,
 				},
 				pool,
+				logger: betterAuthLogger,
+				onAPIError: betterAuthOnAPIError,
 				sendResetPassword: async data => {
 					// Mirror BA's default `resetPasswordTokenExpiresIn` (1h) and
 					// pass it through so the template can tell the recipient

--- a/apps/server/src/lib/observability-middleware.test.ts
+++ b/apps/server/src/lib/observability-middleware.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { httpPathPattern } from './observability-middleware.js'
+
+// Locks in how request URLs are normalised before they become span attributes
+// and log fields: record ids collapse to :id so errors group by route, and the
+// query string / fragment are dropped so a secret in `?code=…` never leaks.
+
+describe('httpPathPattern', () => {
+	describe('when the url has no dynamic segment or query', () => {
+		it('should return the path unchanged', () => {
+			// GIVEN a static route
+			// WHEN normalised
+			// THEN it is returned as-is
+			// [httpPathPattern]
+			expect(httpPathPattern('/companies')).toBe('/companies')
+		})
+	})
+
+	describe('when the url embeds a uuid record id', () => {
+		it('should replace the uuid with :id', () => {
+			// GIVEN a route with a record uuid
+			// WHEN normalised
+			// THEN the uuid collapses to :id so errors group by route
+			// [UUID → :id]
+			expect(
+				httpPathPattern('/companies/3f2504e0-4f89-41d3-9a0c-0305e82c3301'),
+			).toBe('/companies/:id')
+		})
+
+		it('should replace every uuid when more than one appears', () => {
+			// GIVEN a nested route with two uuids
+			// WHEN normalised
+			// THEN both collapse to :id (global replace, case-insensitive)
+			// [UUID global flag]
+			expect(
+				httpPathPattern(
+					'/orgs/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/contacts/3f2504e0-4f89-41d3-9a0c-0305e82c3301',
+				),
+			).toBe('/orgs/:id/contacts/:id')
+		})
+	})
+
+	describe('when the url carries a query string', () => {
+		it('should drop the query so secrets never reach a span or log', () => {
+			// GIVEN an OAuth callback whose query holds a code
+			// WHEN normalised
+			// THEN only the path survives; the query (and any token in it) is gone
+			// [split('?')]
+			expect(httpPathPattern('/auth/callback?code=secret&state=xyz')).toBe(
+				'/auth/callback',
+			)
+		})
+	})
+
+	describe('when the url is a reset-password link (token in the path)', () => {
+		it('should collapse the token segment so it never reaches a log', () => {
+			// GIVEN a reset-password URL whose token rides in the path, not the query
+			// WHEN normalised
+			// THEN the token segment collapses to :token (a raw token in a log line
+			//   would be a single-use credential leak)
+			// [/auth/reset-password/ branch]
+			expect(
+				httpPathPattern('/auth/reset-password/eyJhbGciOi-secret-token'),
+			).toBe('/auth/reset-password/:token')
+		})
+	})
+
+	describe('when the url is a magic-link verify (token in the query)', () => {
+		it('should drop the token along with the query', () => {
+			// GIVEN a magic-link verify URL with the token in the query
+			// WHEN normalised
+			// THEN only the path survives; the token is gone
+			// [split('?')]
+			expect(
+				httpPathPattern('/auth/magic-link/verify?token=secret-magic-token'),
+			).toBe('/auth/magic-link/verify')
+		})
+	})
+
+	describe('when the url carries a fragment', () => {
+		it('should drop the fragment', () => {
+			// GIVEN a url with a hash fragment
+			// WHEN normalised
+			// THEN the fragment is dropped
+			// [split('#')]
+			expect(httpPathPattern('/pages/about#section')).toBe('/pages/about')
+		})
+	})
+})

--- a/apps/server/src/lib/observability-middleware.ts
+++ b/apps/server/src/lib/observability-middleware.ts
@@ -1,0 +1,86 @@
+import { Cause, Effect } from 'effect'
+import {
+	HttpMiddleware,
+	HttpRouter,
+	HttpServerRequest,
+} from 'effect/unstable/http'
+
+// Collapse record-identifying URL segments so errors group by route, not by
+// individual record. UUIDs → :id; the query string and fragment are dropped so
+// a token in `?code=…`/`?token=…` never lands in a span attribute or log line.
+const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+
+export const httpPathPattern = (url: string): string => {
+	const path = url.split('?')[0]?.split('#')[0] ?? url
+	// The reset-password token rides in the path itself (not a UUID), so collapse
+	// that whole segment — otherwise it would leak into the log line.
+	if (path.startsWith('/auth/reset-password/'))
+		return '/auth/reset-password/:token'
+	return path.replace(UUID, ':id')
+}
+
+/**
+ * Catch-all observability middleware. Annotates every request's span and logs
+ * with a stable id + route, emits one sanitized per-request completion log, and
+ * guarantees the full cause of any defect or 5xx is logged at error level — the
+ * last line of defence so no API error escapes unlogged (and therefore
+ * unexported once OTLP is on). Attached globally like `CorsLive`.
+ *
+ * It REPLACES Effect's built-in request logger, which is disabled at `serve`
+ * (`disableLogger: true`): that logger annotates `http.url` with the RAW request
+ * URL, so a magic-link/reset token in the URL would export verbatim to OTLP.
+ * This one logs the sanitized `http.path_pattern` instead.
+ *
+ * `OrgMiddleware` runs after this one and adds `org.id` to the same request
+ * span once the org resolves.
+ */
+export const ObservabilityLive = HttpRouter.middleware(
+	HttpMiddleware.make(app =>
+		Effect.gen(function* () {
+			const request = yield* HttpServerRequest.HttpServerRequest
+			// Reuse an upstream correlation id when the edge supplies one, else mint
+			// one so a single request's logs and span share a key.
+			const requestId = request.headers['x-request-id'] ?? crypto.randomUUID()
+			const pathPattern = httpPathPattern(request.url)
+			const context = {
+				'request.id': requestId,
+				'http.method': request.method,
+				'http.path_pattern': pathPattern,
+			}
+
+			yield* Effect.annotateCurrentSpan(context)
+
+			return yield* app.pipe(
+				// One completion log per request (replacing the disabled built-in one),
+				// at error level for a 5xx so it surfaces, info otherwise. The route is
+				// the sanitized path_pattern from `context` below — never the raw URL.
+				Effect.tap(response =>
+					response.status >= 500
+						? Effect.logError('HTTP server error response').pipe(
+								Effect.annotateLogs({
+									event: 'http.server_error',
+									'http.status': response.status,
+								}),
+							)
+						: Effect.logInfo('HTTP request completed').pipe(
+								Effect.annotateLogs({
+									event: 'http.request',
+									'http.status': response.status,
+								}),
+							),
+				),
+				// Defects (and any failure cause reaching here) carry the real stack;
+				// log the whole cause so it is queryable instead of dying in the
+				// console ring-buffer. A pure interrupt is a client disconnect or
+				// shutdown, NOT an error — skip it so it doesn't trip error alerts.
+				Effect.tapCause(cause =>
+					Cause.hasInterruptsOnly(cause)
+						? Effect.void
+						: Effect.logError(Cause.pretty(cause)),
+				),
+				Effect.annotateLogs(context),
+			)
+		}),
+	),
+	{ global: true },
+)

--- a/apps/server/src/lib/observability.ts
+++ b/apps/server/src/lib/observability.ts
@@ -1,78 +1,10 @@
-import { Config, Duration, Effect, Layer } from 'effect'
-import { FetchHttpClient } from 'effect/unstable/http'
-import { Otlp } from 'effect/unstable/observability'
-
-import { buildMeta } from './build-meta'
+import { makeOtlpObservability } from '@batuda/observability'
 
 /**
- * Parse OTLP headers from the standard comma-separated format.
- * Format: "key=value,key2=value2"
+ * OTLP observability layer for the API server. Exports traces, logs, and
+ * metrics to the `batuda-server` Honeycomb dataset when
+ * OTEL_EXPORTER_OTLP_ENDPOINT is set; otherwise a no-op (local dev).
  */
-const parseOtlpHeaders = (raw: string): Record<string, string> => {
-	const headers: Record<string, string> = {}
-	for (const pair of raw.split(',')) {
-		const idx = pair.indexOf('=')
-		if (idx > 0) {
-			headers[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim()
-		}
-	}
-	return headers
-}
-
-/**
- * OTLP observability layer — exports traces, logs, and metrics.
- *
- * Enabled only when OTEL_EXPORTER_OTLP_ENDPOINT is set.
- * When disabled (local dev), returns Layer.empty.
- *
- * Config:
- * - OTEL_EXPORTER_OTLP_ENDPOINT — base URL (e.g. https://api.honeycomb.io)
- * - OTEL_EXPORTER_OTLP_HEADERS — comma-separated key=value pairs
- * - NODE_ENV — deployment environment attribute
- */
-export const OtlpObservability = Layer.unwrap(
-	Effect.gen(function* () {
-		const baseUrl = yield* Config.string('OTEL_EXPORTER_OTLP_ENDPOINT').pipe(
-			Config.withDefault(''),
-		)
-		const headersRaw = yield* Config.string('OTEL_EXPORTER_OTLP_HEADERS').pipe(
-			Config.withDefault(''),
-		)
-		const environment = yield* Config.string('NODE_ENV')
-
-		if (!baseUrl) {
-			yield* Effect.logInfo(
-				'OTLP export disabled (no OTEL_EXPORTER_OTLP_ENDPOINT)',
-			)
-			return Layer.empty
-		}
-
-		yield* Effect.logInfo('OTLP export enabled').pipe(
-			Effect.annotateLogs({
-				endpoint: baseUrl,
-				version: buildMeta.version,
-				commit: buildMeta.commitShort,
-				region: buildMeta.region,
-				environment,
-			}),
-		)
-
-		return Otlp.layerJson({
-			baseUrl,
-			resource: {
-				serviceName: 'batuda-server',
-				serviceVersion: buildMeta.version,
-				attributes: {
-					'deployment.environment': environment,
-					'vcs.revision': buildMeta.commit,
-					'cloud.region': buildMeta.region,
-				},
-			},
-			headers: headersRaw ? parseOtlpHeaders(headersRaw) : undefined,
-			tracerExportInterval: Duration.seconds(5),
-			loggerExportInterval: Duration.seconds(1),
-			metricsExportInterval: Duration.seconds(60),
-			metricsTemporality: 'cumulative',
-		}).pipe(Layer.provide(FetchHttpClient.layer))
-	}),
-)
+export const OtlpObservability = makeOtlpObservability({
+	serviceName: 'batuda-server',
+})

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -4,6 +4,7 @@ import { NodeHttpServer, NodeRuntime } from '@effect/platform-node'
 import { Cause, Config, DateTime, Effect, Layer } from 'effect'
 import {
 	FetchHttpClient,
+	HttpMiddleware,
 	HttpRouter,
 	HttpServerResponse,
 } from 'effect/unstable/http'
@@ -50,6 +51,7 @@ import { installCrashGuards } from './lib/crash-guards'
 import { EnvVars } from './lib/env'
 import { LoggerLive } from './lib/logger'
 import { OtlpObservability } from './lib/observability'
+import { ObservabilityLive } from './lib/observability-middleware'
 import { WellKnownLive } from './lib/well-known'
 import { McpHttpLive } from './mcp/http'
 import { OrgMiddlewareLive, resolveSystemOrg } from './middleware/org'
@@ -282,10 +284,29 @@ const OpenApiJsonLive = HttpRouter.add(
 	HttpServerResponse.json(OpenApi.fromApi(BatudaApi)),
 )
 
+// Routes where tracing is suppressed. The tracer records `url.full`/`url.query`
+// UNREDACTED, so any route whose URL itself carries a secret must be exempt or
+// the token lands in Honeycomb: magic-link verify (token in query) and
+// reset-password (token in path). `/health` is exempt too — the uptime checker
+// polls it constantly and would otherwise drown the real traces. Matched on the
+// path alone so a query string (e.g. `/health?x=1`) doesn't slip through.
+const TracerDisabledLive = Layer.succeed(HttpMiddleware.TracerDisabledWhen)(
+	request => {
+		const path = request.url.split('?')[0] ?? request.url
+		return (
+			path === '/health' ||
+			path.startsWith('/auth/magic-link/verify') ||
+			path.startsWith('/auth/reset-password')
+		)
+	},
+)
+
 const AppLive = Layer.mergeAll(
 	ApiLive,
 	McpHttpLive,
 	CorsLive,
+	ObservabilityLive,
+	TracerDisabledLive,
 	DocsLive,
 	OpenApiJsonLive,
 	WellKnownLive,
@@ -312,7 +333,18 @@ const AppLive = Layer.mergeAll(
 // capture to request time; `main.boot.test.ts:149-156` is the regression
 // guard (not in `pnpm test` today — run via `pnpm test:integration`).
 
-const program = HttpRouter.serve(AppLive).pipe(
+// `HttpMiddleware.tracer` wraps the whole server chain in a per-request span so
+// traces export to OTLP and per-route span annotations (request id, org id, tool
+// name) have a span to attach to. `serve` already adds the request logger; this
+// adds the missing tracer. `/health` is exempted from tracing inside AppLive.
+const program = HttpRouter.serve(AppLive, {
+	middleware: HttpMiddleware.tracer,
+	// Disable Effect's built-in request logger: in this version it annotates
+	// `http.url` with the RAW request URL, so a magic-link/reset token in the URL
+	// would export verbatim to OTLP. ObservabilityLive emits a sanitized
+	// completion log (path_pattern, query stripped) in its place.
+	disableLogger: true,
+}).pipe(
 	Layer.provide(ServicesLive),
 	Layer.provide(BookingProviderLive),
 	Layer.provide(IcsParserLive),
@@ -332,8 +364,15 @@ const program = HttpRouter.serve(AppLive).pipe(
 	Layer.provide(EnvVars.layer),
 	Layer.provide(PgLive),
 	Layer.provideMerge(ServerLive),
-	Layer.provide(LoggerLive),
+	// OtlpObservability sits ABOVE LoggerLive so its OTLP logger merges ON TOP of
+	// LoggerLive's clean console+tracer+file set (OtlpLogger defaults to
+	// mergeWithExisting). The reverse order would let LoggerLive — which REPLACES
+	// the logger set — drop the OTLP logger, so non-span logs (detached fibers,
+	// boot, Better Auth callbacks) would never reach Honeycomb's /v1/logs. When
+	// OTLP is off, OtlpObservability is Layer.empty and LoggerLive's set shows
+	// through unchanged (no duplicated default logger).
 	Layer.provide(OtlpObservability),
+	Layer.provide(LoggerLive),
 	// Bottom of the stack so the baked-file ConfigProvider underlies every
 	// Config reader above it — including LoggerLive's MIN_LOG_LEVEL, which in
 	// prod lives only in the file, not on the cmdline. A higher placement would

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -29,6 +29,19 @@ const jsonRpcError = (
 		{ status, ...(headers ? { headers } : {}) },
 	)
 
+// MCP clients (ChatGPT, Claude.ai) surface an auth rejection as a silent retry
+// loop, not a visible error — so every 401/403 path logs why it fired. `reason`
+// is a fixed enum-like string (never a token or key) so the rejections are
+// queryable without leaking a credential.
+const rejectAuth = <A, E, R>(
+	reason: string,
+	response: Effect.Effect<A, E, R>,
+) =>
+	Effect.logWarning('MCP auth rejected').pipe(
+		Effect.annotateLogs({ event: 'mcp.auth.rejected', reason }),
+		Effect.andThen(response),
+	)
+
 // 401 that advertises the OAuth Authorization Server per RFC 9728: keeps the
 // JSON-RPC error body the MCP transport expects and points clients at the
 // protected-resource metadata. `Access-Control-Expose-Headers` lets a browser
@@ -79,6 +92,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 				// controllers-package SessionContext, so service-layer code works
 				// across transports) and enter the org's app_user scope.
 				const enterScope = (
+					authMethod: 'api_key' | 'oauth' | 'cookie',
 					org: { id: string; name: string; slug: string },
 					principal: {
 						readonly userId: string
@@ -87,20 +101,32 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						readonly isAgent: boolean
 					},
 				) =>
-					httpEffect.pipe(
-						Effect.provideService(CurrentUser, {
-							userId: principal.userId,
-							email: principal.email,
-							name: principal.name ?? 'Unknown',
-							isAgent: principal.isAgent,
-						}),
-						Effect.provideService(SessionContext, {
-							userId: principal.userId,
-							email: principal.email,
-							name: principal.name ?? undefined,
-							isAgent: principal.isAgent,
-						}),
-						enterOrgScope(sql, { org, userId: principal.userId }),
+					// Tag the request span with how the caller authenticated and the
+					// org it resolved to BEFORE running the tool — the tool-call context
+					// needed to debug an MCP "disconnection" (silent 401 loop) from
+					// Honeycomb alone, present even if the tool then fails.
+					Effect.annotateCurrentSpan({
+						'mcp.auth_method': authMethod,
+						'mcp.org_id': org.id,
+						'mcp.principal_is_agent': principal.isAgent,
+					}).pipe(
+						Effect.andThen(
+							httpEffect.pipe(
+								Effect.provideService(CurrentUser, {
+									userId: principal.userId,
+									email: principal.email,
+									name: principal.name ?? 'Unknown',
+									isAgent: principal.isAgent,
+								}),
+								Effect.provideService(SessionContext, {
+									userId: principal.userId,
+									email: principal.email,
+									name: principal.name ?? undefined,
+									isAgent: principal.isAgent,
+								}),
+								enterOrgScope(sql, { org, userId: principal.userId }),
+							),
+						),
 					)
 
 				// ── API-key path (AI/MCP clients): the org and the creating member
@@ -134,7 +160,10 @@ const McpAuthMiddleware = HttpRouter.middleware(
 									: undefined,
 							)
 						}
-						return yield* jsonRpcError(401, -32001, 'Invalid API key')
+						return yield* rejectAuth(
+							'invalid_api_key',
+							jsonRpcError(401, -32001, 'Invalid API key'),
+						)
 					}
 					const meta = verified.key.metadata as {
 						organizationId?: string
@@ -142,16 +171,18 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					} | null
 					const orgId = meta?.organizationId
 					if (!orgId) {
-						return yield* jsonRpcError(401, -32001, 'API key is not org-scoped')
+						return yield* rejectAuth(
+							'api_key_not_org_scoped',
+							jsonRpcError(401, -32001, 'API key is not org-scoped'),
+						)
 					}
 					// Required, never silently org-attributed: a key with no creator
 					// in its metadata is rejected outright.
 					const createdByUserId = meta?.createdByUserId
 					if (!createdByUserId) {
-						return yield* jsonRpcError(
-							403,
-							-32003,
-							'API key has no creator; recreate it',
+						return yield* rejectAuth(
+							'api_key_no_creator',
+							jsonRpcError(403, -32003, 'API key has no creator; recreate it'),
 						)
 					}
 					const org = yield* loadOrg(orgId)
@@ -168,13 +199,16 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					`.pipe(Effect.orDie)
 					const creator = creatorRows[0]
 					if (!org || !creator) {
-						return yield* jsonRpcError(
-							403,
-							-32003,
-							'API key creator is no longer a member of its organization',
+						return yield* rejectAuth(
+							'api_key_creator_not_member',
+							jsonRpcError(
+								403,
+								-32003,
+								'API key creator is no longer a member of its organization',
+							),
 						)
 					}
-					return yield* enterScope(org, {
+					return yield* enterScope('api_key', org, {
 						userId: creator.id,
 						email: creator.email,
 						name: creator.name,
@@ -216,10 +250,13 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						}),
 					)
 					if (!outcome.ok) {
-						return yield* bearerChallenge(
-							-32001,
-							'Invalid or expired access token',
-							prmUrl,
+						return yield* rejectAuth(
+							'invalid_or_expired_token',
+							bearerChallenge(
+								-32001,
+								'Invalid or expired access token',
+								prmUrl,
+							),
 						)
 					}
 					const payload = outcome.payload
@@ -238,10 +275,13 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						`.pipe(Effect.orDie)
 						const user = userRows[0]
 						if (!user) {
-							return yield* bearerChallenge(
-								-32003,
-								'Token user is no longer available',
-								prmUrl,
+							return yield* rejectAuth(
+								'token_user_unavailable',
+								bearerChallenge(
+									-32003,
+									'Token user is no longer available',
+									prmUrl,
+								),
 							)
 						}
 						// Read the caller's memberships (all their orgs) and the
@@ -269,10 +309,13 @@ const McpAuthMiddleware = HttpRouter.middleware(
 							}),
 						)
 						if (orgIds.length === 0) {
-							return yield* jsonRpcError(
-								403,
-								-32002,
-								'Token user is not a member of any organization',
+							return yield* rejectAuth(
+								'token_user_no_org',
+								jsonRpcError(
+									403,
+									-32002,
+									'Token user is not a member of any organization',
+								),
 							)
 						}
 						// The orgs this connection is explicitly authorized to act in,
@@ -291,10 +334,13 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						const isUnbound = selectedOrgIds.length === 0
 						const allowedOrgIds = isUnbound ? orgIds : liveSelectedOrgIds
 						if (allowedOrgIds.length === 0) {
-							return yield* jsonRpcError(
-								403,
-								-32002,
-								'Select an organization for this connection at /settings/mcp/connections',
+							return yield* rejectAuth(
+								'no_authorized_org',
+								jsonRpcError(
+									403,
+									-32002,
+									'Select an organization for this connection at /settings/mcp/connections',
+								),
 							)
 						}
 						// An explicit per-request hint picks which authorized org this
@@ -312,25 +358,27 @@ const McpAuthMiddleware = HttpRouter.middleware(
 								? allowedOrgIds[0]
 								: undefined
 						if (!orgId) {
-							return yield* jsonRpcError(
-								403,
-								-32002,
-								hint
-									? 'X-Batuda-Organization-Id is not authorized for this connection'
-									: allowedOrgIds.length === 1
-										? 'Select an organization for this connection at /settings/mcp/connections'
-										: 'Send X-Batuda-Organization-Id with one of the authorized organizations',
+							return yield* rejectAuth(
+								hint ? 'org_hint_not_authorized' : 'org_selection_required',
+								jsonRpcError(
+									403,
+									-32002,
+									hint
+										? 'X-Batuda-Organization-Id is not authorized for this connection'
+										: allowedOrgIds.length === 1
+											? 'Select an organization for this connection at /settings/mcp/connections'
+											: 'Send X-Batuda-Organization-Id with one of the authorized organizations',
+								),
 							)
 						}
 						const org = yield* loadOrg(orgId)
 						if (!org) {
-							return yield* jsonRpcError(
-								403,
-								-32003,
-								`Organization ${orgId} not found`,
+							return yield* rejectAuth(
+								'org_not_found',
+								jsonRpcError(403, -32003, `Organization ${orgId} not found`),
 							)
 						}
-						return yield* enterScope(org, {
+						return yield* enterScope('oauth', org, {
 							userId: user.id,
 							email: user.email,
 							name: user.name,
@@ -345,7 +393,10 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					instance.api.getSession({ headers }),
 				)
 				if (!result) {
-					return yield* bearerChallenge(-32001, 'Unauthorized', prmUrl)
+					return yield* rejectAuth(
+						'no_session',
+						bearerChallenge(-32001, 'Unauthorized', prmUrl),
+					)
 				}
 
 				// `activeOrganizationId` is contributed by the Better-Auth
@@ -356,21 +407,27 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					result.session as { activeOrganizationId?: string | null }
 				).activeOrganizationId
 				if (!activeOrgId) {
-					return yield* jsonRpcError(
-						403,
-						-32002,
-						'No active organization on session — call /auth/organization/set-active first',
+					return yield* rejectAuth(
+						'no_active_org',
+						jsonRpcError(
+							403,
+							-32002,
+							'No active organization on session — call /auth/organization/set-active first',
+						),
 					)
 				}
 				const org = yield* loadOrg(activeOrgId)
 				if (!org) {
-					return yield* jsonRpcError(
-						403,
-						-32003,
-						`Active organization ${activeOrgId} not found`,
+					return yield* rejectAuth(
+						'active_org_not_found',
+						jsonRpcError(
+							403,
+							-32003,
+							`Active organization ${activeOrgId} not found`,
+						),
 					)
 				}
-				return yield* enterScope(org, {
+				return yield* enterScope('cookie', org, {
 					userId: result.user.id,
 					email: result.user.email,
 					name: result.user.name ?? null,

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -197,6 +197,11 @@ export const OrgMiddlewareLive = Layer.effect(
 					})
 				}
 
+				// Tag the request span with the resolved org so errors and traces
+				// can be filtered to one tenant. ObservabilityMiddleware runs before
+				// this and already set request id + route on the same span.
+				yield* Effect.annotateCurrentSpan({ 'org.id': row.id })
+
 				// Enter the org scope (role + both GUCs + CurrentOrg) for the
 				// rest of the request via the shared combinator, keeping the
 				// HTTP and MCP transports in lockstep. The user GUC backs

--- a/apps/server/src/services/webhooks.ts
+++ b/apps/server/src/services/webhooks.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto'
 
-import { DateTime, Effect, Layer, ServiceMap } from 'effect'
+import { Cause, DateTime, Effect, Layer, ServiceMap } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
@@ -95,7 +95,25 @@ export class WebhookService extends ServiceMap.Service<WebhookService>()(
 									),
 								),
 							{ concurrency: 'unbounded' },
-						).pipe(Effect.forkDetach)
+						).pipe(
+							// The per-endpoint catch above handles delivery failures, but a
+							// DEFECT inside this detached fiber (a bug, not a fetch
+							// rejection) would otherwise vanish with no trace. Catch the
+							// whole cause so it's logged; let a genuine interrupt
+							// (shutdown/cancel) propagate. Mirrors the research event sink.
+							Effect.catchCause(cause =>
+								Cause.hasInterruptsOnly(cause)
+									? Effect.interrupt
+									: Effect.logError('Webhook fan-out failed').pipe(
+											Effect.annotateLogs({
+												event: 'webhook.fanout.failed',
+												webhookEvent: event,
+												cause: Cause.pretty(cause),
+											}),
+										),
+							),
+							Effect.forkDetach,
+						)
 					}),
 
 				list: () =>

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -539,67 +539,75 @@ Effect's `Otlp.layerJson` appends `/v1/traces`, `/v1/logs`, and `/v1/metrics` to
 
 ## Implementation Details
 
-### Server: Effect v4 Built-in OTLP
+### Shared OTLP layer: `@batuda/observability`
 
-Effect v4 includes OTLP export in `effect/unstable/observability` — no separate `@effect/opentelemetry` package needed:
-
-```typescript
-// apps/server/src/lib/observability.ts
-import { Otlp, OtlpTracer, OtlpLogger, OtlpMetrics, OtlpSerialization } from "effect/unstable/observability"
-import { FetchHttpClient } from "@effect/platform"
-import { Duration, Layer } from "effect"
-
-export const buildMeta = {
-  version: process.env.npm_package_version ?? process.env.SERVICE_VERSION ?? 'unknown',
-  commit: process.env.GIT_SHA ?? 'unknown',
-  commitShort: (process.env.GIT_SHA ?? 'unknown').slice(0, 7),
-  region: process.env.REGION ?? 'local',
-}
-
-// Combined layer — traces, logs, and metrics in one
-export const OtlpObservability = Otlp.layer({
-  baseUrl: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
-  resource: {
-    serviceName: 'batuda-server',
-    serviceVersion: buildMeta.version,
-    attributes: {
-      'deployment.environment': environment,
-      'vcs.revision': buildMeta.commit,
-      'cloud.region': buildMeta.region,
-    },
-  },
-  tracerExportInterval: Duration.seconds(5),
-  loggerExportInterval: Duration.seconds(1),
-  metricsExportInterval: Duration.seconds(60),
-  metricsTemporality: "cumulative",
-}).pipe(
-  Layer.provide(OtlpSerialization.layerJson),
-  Layer.provide(FetchHttpClient.layer)
-)
-```
-
-Individual layers are also available for granular control:
+Both processes (server, mail-worker) export through one tiny workspace package, `packages/observability`. It owns the build metadata (version/commit/region read from `process.env`) and a per-process exporter factory, `makeOtlpObservability({ serviceName })`. Effect v4 ships OTLP in `effect/unstable/observability` — no separate `@effect/opentelemetry` package, and the HTTP client comes from `effect/unstable/http`, not `@effect/platform`.
 
 ```typescript
-// Traces only
-OtlpTracer.layer({ url: "http://localhost:4318/v1/traces", resource, exportInterval: Duration.seconds(5) })
+// packages/observability/src/otlp.ts (shape — see the file for the full version)
+import { Config, Duration, Effect, Layer } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import { Otlp } from "effect/unstable/observability"
+import { buildMeta } from "./build-meta"
 
-// Logs only
-OtlpLogger.layer({ url: "http://localhost:4318/v1/logs", resource, exportInterval: Duration.seconds(1) })
-
-// Metrics only
-OtlpMetrics.layer({ url: "http://localhost:4318/v1/metrics", resource, temporality: "cumulative" })
+export const makeOtlpObservability = (options: { readonly serviceName: string }) =>
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const baseUrl = yield* Config.string("OTEL_EXPORTER_OTLP_ENDPOINT").pipe(Config.withDefault(""))
+      const headersRaw = yield* Config.string("OTEL_EXPORTER_OTLP_HEADERS").pipe(Config.withDefault(""))
+      const environment = yield* Config.string("NODE_ENV")
+      // The endpoint is the on/off switch: no endpoint → no export (local dev).
+      if (!baseUrl) return Layer.empty
+      return Otlp.layerJson({
+        baseUrl,
+        resource: {
+          serviceName: options.serviceName, // batuda-server | batuda-mail-worker
+          serviceVersion: buildMeta.version,
+          attributes: {
+            "deployment.environment": environment,
+            "deployment.id": `${buildMeta.version}-${buildMeta.commitShort}`,
+            "vcs.revision": buildMeta.commit,
+            "cloud.region": buildMeta.region,
+          },
+        },
+        headers: parseOtlpHeaders(headersRaw),
+        tracerExportInterval: Duration.seconds(5),
+        loggerExportInterval: Duration.seconds(1),
+        metricsExportInterval: Duration.seconds(60),
+        metricsTemporality: "cumulative",
+      }).pipe(Layer.provide(FetchHttpClient.layer))
+    }),
+  )
 ```
+
+`Otlp.layerJson` registers a tracer, a metrics reader, AND an OTLP logger; the logger's `mergeWithExisting` defaults to `true`, so it adds to whatever console logger the process already has rather than replacing it. The server provides it in `apps/server/src/lib/observability.ts` (`serviceName: 'batuda-server'`); the mail-worker provides it around its `Live` layer in `apps/mail-worker/src/main.ts` (`serviceName: 'batuda-mail-worker'`).
 
 **Configuration:**
 
-- `OTEL_EXPORTER_OTLP_HEADERS` — comma-separated key=value pairs (e.g. `x-honeycomb-team=KEY`)
-- `OTEL_EXPORTER_OTLP_ENDPOINT` — OTLP endpoint base URL
+- `OTEL_EXPORTER_OTLP_ENDPOINT` — OTLP endpoint base URL (`https://api.honeycomb.io`). Non-secret, so it lives in each app's `config.production.json` alongside the other endpoints (`STORAGE_ENDPOINT`, the LLM base URLs) — NOT a CI secret. **It is also the on/off switch**: unset → export disabled. It is deliberately left OUT of `config.production.json` until Honeycomb is set up, so OTLP stays dark by default; adding the one line (plus the secret below) is what turns it on. Locally it comes from `.env` (`http://localhost:4318` for otel-tui).
+- `OTEL_EXPORTER_OTLP_HEADERS` — comma-separated `key=value` pairs. This DOES carry a secret (the Honeycomb team key), so it stays a CI secret holding the team key only (`x-honeycomb-team=KEY`); each deploy workflow appends its own non-secret `,x-honeycomb-dataset=…` (see below).
 - `SERVICE_VERSION` — CalVer version (injected by CI)
 - `GIT_SHA` — full commit SHA (short SHA derived at runtime)
 - `REGION` — Unikraft metro / deployment region
 
-When headers are not set, export is disabled (local development).
+**Per-service datasets + the metrics-routing gotcha.** Traces auto-route to a Honeycomb dataset named after the resource `service.name`, so `batuda-server` and `batuda-mail-worker` separate on their own. Logs and metrics, however, route by the `x-honeycomb-dataset` header — so each deploy workflow appends `x-honeycomb-dataset=batuda-server` / `batuda-mail-worker` to the shared team-key secret. One Honeycomb API key (environment-scoped) is enough for both.
+
+### Catch-all error logging + request tracing
+
+`apps/server/src/lib/observability-middleware.ts` (`ObservabilityLive`) is a global router middleware — attached in `AppLive` exactly like `CorsLive`. Per request it annotates the span and logs with `request.id` (reusing an upstream `x-request-id` when present), `http.method`, and `http.path_pattern` (UUIDs → `:id`, query/fragment dropped so a token in `?code=…` never lands in a span or log). It then logs the **full cause** of any defect (`Effect.tapCause`) or 5xx response at error level — the last line of defence so no API error escapes unlogged. `OrgMiddleware` adds `org.id` to the same span once the org resolves.
+
+`HttpMiddleware.tracer` is added to the `serve` chain in `apps/server/src/main.ts` so every request gets a span (Effect's `serve` adds only the request logger by default). A `TracerDisabledWhen` predicate exempts a few routes: `/health` (the uptime checker polls it constantly and would drown the real traces) and the routes whose URL itself carries a secret — magic-link verify (token in the query) and reset-password (token in the path). This matters because the tracer records `url.full`/`url.query` **unredacted** (header values like `authorization`/`cookie`/`x-api-key` are redacted by default, but the URL is not), so tracing those routes would export a single-use token to Honeycomb.
+
+### Better Auth error bridge
+
+Better Auth runs its callbacks outside the Effect fiber, so its internal errors (adapter failures, OAuth/OIDC) would be console-only. `apps/server/src/lib/auth.ts` captures the layer's services and forwards Better Auth's `logger.log` (warn+error) and `onAPIError.onError` onto that runtime via `Effect.runForkWith`, so they export through OTLP like every other log.
+
+### Auth-sensitive spans (added per-surface, not blanket)
+
+Per the scoping below, spans are added only where the MCP-drop class of bug needs them, not across every endpoint:
+
+- MCP auth chokepoint (`apps/server/src/mcp/http.ts`) — the request span gets `mcp.auth_method` (`api_key`/`oauth`/`cookie`), `mcp.org_id`, and `mcp.principal_is_agent`. Every 401/403 path also logs a `mcp.auth.rejected` reason.
+- `/auth/oauth2/token` (`apps/server/src/handlers/auth.ts`) — the span gets `auth.token_response_status` (the grant outcome) when the proxied path is the token endpoint.
 
 ### Wide Events Pattern
 
@@ -610,7 +618,7 @@ const span = yield* Effect.currentSpan
 span.attribute('company.id', companyId)
 span.attribute('interaction.channel', channel)
 span.attribute('interaction.direction', direction)
-span.event('interaction.logged', DateTime.unsafeNow(), { outcome: "interested" })
+span.event('interaction.logged', DateTime.nowUnsafe(), { outcome: "interested" })
 ```
 
 This produces a single rich event with all business context — ideal for exploration in Honeycomb or similar tools.

--- a/packages/auth/src/infrastructure/build-better-auth-config.ts
+++ b/packages/auth/src/infrastructure/build-better-auth-config.ts
@@ -42,6 +42,17 @@ export interface BuildBetterAuthConfigInput<
 	readonly pool: pg.Pool
 	readonly plugins: Plugins
 	readonly sendResetPassword?: SendResetPassword
+	/**
+	 * Routes Better Auth's own internal logs (adapter failures, OAuth/OIDC
+	 * errors) somewhere queryable. The server forwards them into the Effect
+	 * logger; the CLI omits it and keeps Better Auth's console default.
+	 */
+	readonly logger?: BetterAuthOptions['logger']
+	/**
+	 * Observes every API-level error Better Auth raises. The server forwards
+	 * these to the Effect logger so OAuth/token failures aren't console-only.
+	 */
+	readonly onAPIError?: BetterAuthOptions['onAPIError']
 }
 
 /**
@@ -203,5 +214,8 @@ export const buildBetterAuthConfig = <Plugins extends BetterAuthPlugin[]>(
 				: {}), // Set on all cookies, not just cross-subdomain ones.
 		},
 		trustedOrigins: [...input.env.trustedOrigins],
+		// Observability hooks — only present when the caller (server) wires them.
+		...(input.logger ? { logger: input.logger } : {}),
+		...(input.onAPIError ? { onAPIError: input.onAPIError } : {}),
 	} satisfies BetterAuthOptions // Type-checks fields without widening the inferred literal shape.
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@batuda/observability",
+	"version": "0.0.1",
+	"description": "Batuda — shared OTLP observability layer (traces, logs, metrics) + build metadata",
+	"type": "module",
+	"types": "./src/index.ts",
+	"main": "./src/index.ts",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"import": "./src/index.ts"
+		}
+	},
+	"scripts": {
+		"build": "tsdown",
+		"check-types": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"effect": "4.0.0-beta.43"
+	},
+	"devDependencies": {
+		"@types/node": "^22.15.0",
+		"tsdown": "^0.21.7",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.4"
+	},
+	"private": true
+}

--- a/packages/observability/src/build-meta.ts
+++ b/packages/observability/src/build-meta.ts
@@ -1,6 +1,7 @@
 /**
  * Build metadata resolved once at startup.
- * Shared by the health endpoint and OTLP resource attributes.
+ * Shared by the server health endpoint and OTLP resource attributes across
+ * every process (server, mail-worker).
  *
  * Fallback chains:
  * - version: npm_package_version (pnpm dev) → SERVICE_VERSION (CI) → "unknown"

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,6 @@
+// Shared OTLP observability for every Batuda process. Owns the build metadata
+// (version/commit/region) surfaced on the health endpoint and the OTLP resource,
+// plus the per-process exporter layer factory.
+
+export { buildMeta } from './build-meta'
+export { makeOtlpObservability } from './otlp'

--- a/packages/observability/src/otlp.ts
+++ b/packages/observability/src/otlp.ts
@@ -1,0 +1,93 @@
+import { Config, Duration, Effect, Layer } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+import { Otlp } from 'effect/unstable/observability'
+
+import { buildMeta } from './build-meta'
+
+/**
+ * Parse OTLP headers from the standard comma-separated format.
+ * Format: "key=value,key2=value2"
+ */
+const parseOtlpHeaders = (raw: string): Record<string, string> => {
+	const headers: Record<string, string> = {}
+	for (const pair of raw.split(',')) {
+		const idx = pair.indexOf('=')
+		if (idx > 0) {
+			headers[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim()
+		}
+	}
+	return headers
+}
+
+/**
+ * OTLP observability layer for a single process — exports traces, logs, and
+ * metrics. `serviceName` distinguishes the emitting process in the backend
+ * (e.g. `batuda-server`, `batuda-mail-worker`); the Honeycomb dataset is chosen
+ * by the `x-honeycomb-dataset` value inside OTEL_EXPORTER_OTLP_HEADERS, not here.
+ *
+ * Enabled only when OTEL_EXPORTER_OTLP_ENDPOINT is set.
+ * When disabled (local dev), returns Layer.empty.
+ *
+ * Config:
+ * - OTEL_EXPORTER_OTLP_ENDPOINT — base URL (e.g. https://api.honeycomb.io)
+ * - OTEL_EXPORTER_OTLP_HEADERS — comma-separated key=value pairs
+ * - NODE_ENV — deployment environment attribute
+ */
+export const makeOtlpObservability = (options: {
+	readonly serviceName: string
+}) =>
+	Layer.unwrap(
+		Effect.gen(function* () {
+			const baseUrl = yield* Config.string('OTEL_EXPORTER_OTLP_ENDPOINT').pipe(
+				Config.withDefault(''),
+			)
+
+			if (!baseUrl) {
+				yield* Effect.logInfo(
+					'OTLP export disabled (no OTEL_EXPORTER_OTLP_ENDPOINT)',
+				)
+				return Layer.empty
+			}
+
+			// Read below the disable guard so a process with OTLP off (e.g. the
+			// mail-worker run locally, where NODE_ENV is optional) never needs these.
+			const headersRaw = yield* Config.string(
+				'OTEL_EXPORTER_OTLP_HEADERS',
+			).pipe(Config.withDefault(''))
+			const environment = yield* Config.string('NODE_ENV').pipe(
+				Config.withDefault('development'),
+			)
+
+			yield* Effect.logInfo('OTLP export enabled').pipe(
+				Effect.annotateLogs({
+					service: options.serviceName,
+					endpoint: baseUrl,
+					version: buildMeta.version,
+					commit: buildMeta.commitShort,
+					region: buildMeta.region,
+					environment,
+				}),
+			)
+
+			return Otlp.layerJson({
+				baseUrl,
+				resource: {
+					serviceName: options.serviceName,
+					serviceVersion: buildMeta.version,
+					attributes: {
+						'deployment.environment': environment,
+						// Identifies which build is live; UKC exposes no per-instance
+						// id, so the version+commit pair is the finest grain available.
+						'deployment.id': `${buildMeta.version}-${buildMeta.commitShort}`,
+						'vcs.revision': buildMeta.commit,
+						'cloud.region': buildMeta.region,
+					},
+				},
+				headers: headersRaw ? parseOtlpHeaders(headersRaw) : undefined,
+				tracerExportInterval: Duration.seconds(5),
+				loggerExportInterval: Duration.seconds(1),
+				metricsExportInterval: Duration.seconds(60),
+				metricsTemporality: 'cumulative',
+			}).pipe(Layer.provide(FetchHttpClient.layer))
+		}),
+	)

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/observability/vitest.config.ts
+++ b/packages/observability/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		include: ['src/**/*.test.ts'],
+		environment: 'node',
+		globals: false,
+		testTimeout: 30_000,
+	},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       '@batuda/email':
         specifier: workspace:*
         version: link:../../packages/email
+      '@batuda/observability':
+        specifier: workspace:*
+        version: link:../../packages/observability
       '@effect/platform-node':
         specifier: 4.0.0-beta.43
         version: 4.0.0-beta.43(effect@4.0.0-beta.43)(ioredis@5.10.1)
@@ -449,6 +452,9 @@ importers:
       '@batuda/instructions':
         specifier: workspace:*
         version: link:../../packages/instructions
+      '@batuda/observability':
+        specifier: workspace:*
+        version: link:../../packages/observability
       '@batuda/research':
         specifier: workspace:*
         version: link:../../packages/research
@@ -624,6 +630,25 @@ importers:
         version: 4.1.4(@types/node@22.19.15)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/instructions:
+    dependencies:
+      effect:
+        specifier: 4.0.0-beta.43
+        version: 4.0.0-beta.43
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.15
+      tsdown:
+        specifier: ^0.21.7
+        version: 0.21.7(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.15)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/observability:
     dependencies:
       effect:
         specifier: 4.0.0-beta.43


### PR DESCRIPTION
## What

Closes #87. Prod ran with OTLP export disabled, so there were **no exported errors** — only the ephemeral, unqueryable KraftCloud console ring-buffer. This is the code half of the issue: every error in the **server** and the **mail-worker** now reaches Honeycomb, and the MCP-drop class of bug (silent 401 loops) is debuggable from there alone. It spans the `server`, `mail-worker`, and a new shared `observability` package. The Honeycomb account/key, triggers, and external uptime check are Guillem's to set up (checklist at the bottom) — nothing here turns on until then.

## Changes

- **Shared `@batuda/observability` package** — moved the OTLP layer + build metadata out of the server so the **mail-worker** exports too (IMAP drops, credential failures, session-fiber deaths were dying on the console). Each process tags its own `service.name`; the mail-worker also emits a throttled heartbeat for a liveness alert.
- **Catch-all error logging + request tracing** — a global middleware logs the full cause of every defect/5xx with request context (`request.id`, sanitized `http.path_pattern`); enabled `HttpMiddleware.tracer` so spans export.
- **Plugged four console-only error categories** into the exporter: Better Auth internal/API errors, MCP auth rejections (each 401/403 now logs a reason + tags the span with auth method and org), the OAuth token-grant outcome, and defects in the detached webhook fan-out (`catch` → `catchCause`).
- **Secret-safe telemetry** — the built-in request logger recorded the raw URL and the tracer records `url.full`/`url.query`; both would have exported magic-link and reset-password **tokens** to Honeycomb. Disabled the built-in logger in favour of a sanitized path pattern, and exempted the token-bearing routes from tracing.

## Impact

- **New env vars** (boot-time, both processes): `OTEL_EXPORTER_OTLP_ENDPOINT` (the on/off switch — unset = export disabled) and `OTEL_EXPORTER_OTLP_HEADERS` (Honeycomb team key). Endpoint lives in `config.production.json` like the other endpoints; the header is a CI secret. **Left unset, so prod is unchanged until Guillem configures it.**
- **Auth / MCP**: only adds logging + span annotations on the auth and MCP paths — no change to auth decisions, responses, or redirects (verified Better Auth's `onAPIError` is observe-only and runs after redirect short-circuiting).
- **MCP + HTTP parity**: the catch-all middleware and the request tracer wrap the shared router, so both transports are covered; MCP tool calls additionally get an auth-context span.
- **Deploy coupling**: both deploy workflows now pass the headers secret; until it (and the endpoint) are set, the `-e` is a harmless empty value.
- **No migration, no schema change, no RLS/role change, no wire-shape change.**

## Review guide

- **Start with `apps/server/src/main.ts`** — the layer wiring is the load-bearing part: `OtlpObservability` is provided *above* `LoggerLive` so the OTLP logger merges onto (not replaces) the console set, and the tracer is added to `serve` with `disableLogger: true`.
- **Riskiest bit — the secret-leak fix** (`observability-middleware.ts` + the `TracerDisabledLive` predicate in `main.ts`). I verified with a local OTLP collector that magic-link/reset tokens and a bearer header produce **zero** matches in exported trace/log bodies. The route exemption is enumerated (magic-link verify, reset-password) — a future auth route that carries a secret in its URL must be added there; called out in `docs/observability.md`.
- **Decisions you might overrule**: (1) the OTLP **endpoint** is non-secret config in `config.production.json`, not a CI secret — consistent with `STORAGE_ENDPOINT`/the LLM base URLs, and it keeps export off-by-default. (2) Kept Better Auth's `onAPIError` hook even though it bypasses BA's own error categorization — errors are still captured via the logger bridge. (3) Per-tool and per-controller `withSpan` instrumentation is **deferred** (the issue de-scopes blanket spans); only the auth-sensitive paths got spans.
- **Skip-able**: `docs/observability.md` is a prose rewrite; the package extraction is a move (git shows it as a rename of `build-meta.ts`).
- I ran an adversarial self-review against the vendored Effect v4 source for the layer-ordering, tracer, and `runForkWith` correctness; Snyk was not run (tool not wired into this session).

## Tests

- Unit tests for the URL sanitizer (`httpPathPattern`) — UUID collapse, query/fragment stripping, the reset-password path-token and magic-link query-token cases that prevent the leak. The rest is layer wiring, exercised live (below).

## Verification

- `pnpm install` → `pnpm check-types` (13/13) + `pnpm test` (20/20; server 389) → `pnpm build` (13/13), all green on the rebased branch.
- **Live, against a local OTLP collector**: server + mail-worker boot with `OTLP export enabled`; **traces, logs, and metrics all export**; a forced MCP 401 logs `mcp.auth.rejected` with its reason; the mail-worker heartbeat fires.
- **Leak check**: hit `/auth/magic-link/verify?token=…`, `/auth/reset-password/<token>`, a bearer header, and `/health?x=secret` — grepped the exported OTLP bodies: **0** occurrences of any token.

## Deferred

- Per-MCP-tool and per-controller spans (issue de-scopes blanket spans — add lazily per debugging need).
- Everything needing Guillem's credentials — see below.

## Handoff to Guillem (turns this on — not in this PR)

1. Create a Honeycomb environment; get the API (team) key.
2. Add the GitHub secret `OTEL_EXPORTER_OTLP_HEADERS` = `x-honeycomb-team=<KEY>` (team key only — the workflow appends the per-service dataset).
3. Add `"OTEL_EXPORTER_OTLP_ENDPOINT": "https://api.honeycomb.io"` to `apps/server/config.production.json` **and** `apps/mail-worker/config.production.json`, then release both. Boot log should flip to `OTLP export enabled`.
4. Honeycomb triggers → email: any 5xx, any error-level event from either service, MCP 401 / token-grant spike, boot-loop (>3 `OTLP export enabled`/hr), mail-worker heartbeat absence (>5 min).
5. External uptime check on `GET https://api.batuda.co/health` (UptimeRobot or Cloudflare Health Checks — through the public hostname, not the UKC origin).
