### PR TITLE
ai(mcp): add the Honeycomb MCP server for Claude and opencode

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -15,6 +15,13 @@
 			"type": "http",
 			"url": "https://mcp.firecrawl.dev/v2/mcp"
 		},
+		"honeycomb": {
+			"type": "http",
+			"url": "https://mcp.honeycomb.io/mcp",
+			"headers": {
+				"Authorization": "Bearer ${HONEYCOMB_API_KEY}"
+			}
+		},
 		"neon": {
 			"command": "sh",
 			"args": [

--- a/opencode.json
+++ b/opencode.json
@@ -17,6 +17,14 @@
 			"type": "remote",
 			"url": "https://mcp.firecrawl.dev/v2/mcp"
 		},
+		"honeycomb": {
+			"type": "remote",
+			"url": "https://mcp.honeycomb.io/mcp",
+			"oauth": false,
+			"headers": {
+				"Authorization": "Bearer {env:HONEYCOMB_API_KEY}"
+			}
+		},
 		"neon": {
 			"type": "local",
 			"command": [


### PR DESCRIPTION
## What

Adds Honeycomb's hosted MCP server to both assistant configs (`.mcp.json` for Claude Code, `opencode.json` for opencode), so I can query Honeycomb — traces, logs, investigations — from the assistant. This is the read side that complements #153 (which sends telemetry *to* Honeycomb).

## Changes

- Added a `honeycomb` entry to both configs pointing at the hosted HTTP endpoint `https://mcp.honeycomb.io/mcp`, following the existing remote-MCP pattern (`type: http`/`remote` + env-var header expansion).
- Auth is `Authorization: Bearer ${HONEYCOMB_API_KEY}` — the key is read from the environment, so **no secret is committed**.

## Impact

- No code, no runtime behavior — assistant tooling config only.
- Requires a Honeycomb **Management API key** (read scope for MCP + Environments; write only to let the assistant create triggers/boards). Set `HONEYCOMB_API_KEY="<KEY_ID>:<SECRET_KEY>"` in the shell env that launches Claude Code / opencode (`.env` isn't auto-loaded for them).
- Only useful once OTLP export is live (#153 + the Honeycomb account), but harmless before then.

## Verification

- `.mcp.json` and `opencode.json` parse as valid JSON; pre-commit `check-types` + biome lint passed. Not exercised live (needs the Management API key).
