### PR TITLE
ai(mcp): switch the Honeycomb MCP server to OAuth and the EU region

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -17,10 +17,7 @@
 		},
 		"honeycomb": {
 			"type": "http",
-			"url": "https://mcp.honeycomb.io/mcp",
-			"headers": {
-				"Authorization": "Bearer ${HONEYCOMB_API_KEY}"
-			}
+			"url": "https://mcp.eu1.honeycomb.io/mcp"
 		},
 		"neon": {
 			"command": "sh",

--- a/opencode.json
+++ b/opencode.json
@@ -19,11 +19,7 @@
 		},
 		"honeycomb": {
 			"type": "remote",
-			"url": "https://mcp.honeycomb.io/mcp",
-			"oauth": false,
-			"headers": {
-				"Authorization": "Bearer {env:HONEYCOMB_API_KEY}"
-			}
+			"url": "https://mcp.eu1.honeycomb.io/mcp"
 		},
 		"neon": {
 			"type": "local",


### PR DESCRIPTION
## What

Corrects the Honeycomb MCP entry from #154: it shipped with the **US** endpoint and an **API-key header**, but my Honeycomb is **EU** and OAuth is the cleaner auth path (no key to store; browser sign-in on first use).

## Changes

- `.mcp.json` (Claude Code) + `opencode.json`: point `honeycomb` at `https://mcp.eu1.honeycomb.io/mcp` and drop the `Authorization`/`${HONEYCOMB_API_KEY}` header so the client does OAuth. Verified working in Claude Code (`/mcp` → browser sign-in → EU env → read-only).
- opencode: no `oauth`/`headers` fields — per opencode docs it auto-detects the 401 and starts the OAuth flow (matches `cloudflare-api`/`firecrawl`).

## Impact

- AI tooling config only — no code, no runtime, no deploy. `HONEYCOMB_API_KEY` is no longer needed for MCP (the OTLP **ingest** key for export is separate and unaffected).

## Verification

- Both files valid JSON; Claude Code connects via OAuth. opencode not yet exercised (auto-OAuth on first connect).
