### PR TITLE
feat(server): make instruction templates usable from MCP chat + web

### DIFF
--- a/apps/internal/package.json
+++ b/apps/internal/package.json
@@ -19,6 +19,7 @@
 		"@batuda/controllers": "workspace:*",
 		"@batuda/domain": "workspace:*",
 		"@batuda/email": "workspace:*",
+		"@batuda/instructions": "workspace:*",
 		"@batuda/research": "workspace:*",
 		"@batuda/ui": "workspace:*",
 		"@dnd-kit/core": "^6.3.1",

--- a/apps/internal/src/components/instructions/agent-selector.tsx
+++ b/apps/internal/src/components/instructions/agent-selector.tsx
@@ -1,0 +1,50 @@
+import { Trans } from '@lingui/react/macro'
+import type { ReactNode } from 'react'
+import styled from 'styled-components'
+
+import { type Agent, agents } from '@batuda/instructions/domain'
+import { PriToggleGroup } from '@batuda/ui/pri'
+
+// Instructions are per surface: each agent (research, email, …) keeps its own
+// default stack. This toggle picks which surface the default-stack section below
+// it configures. The surface list comes straight from the server's agent set, so
+// a new surface appears here with no extra wiring — only a label is needed.
+const AGENT_LABELS: Record<Agent, ReactNode> = {
+	research: <Trans>Research</Trans>,
+	email: <Trans>Email</Trans>,
+}
+
+export function AgentSelector({
+	agent,
+	onChange,
+	labelledBy,
+}: {
+	readonly agent: Agent
+	readonly onChange: (agent: Agent) => void
+	// Id of the visible heading that names this control, so a screen reader
+	// announces what the surface choice governs instead of two bare buttons.
+	readonly labelledBy: string
+}) {
+	return (
+		<Root
+			aria-labelledby={labelledBy}
+			value={[agent]}
+			onValueChange={(values: string[]) => {
+				const next = values[0]
+				if (next && (agents as ReadonlyArray<string>).includes(next)) {
+					onChange(next as Agent)
+				}
+			}}
+		>
+			{agents.map(value => (
+				<PriToggleGroup.Item key={value} value={value}>
+					{AGENT_LABELS[value]}
+				</PriToggleGroup.Item>
+			))}
+		</Root>
+	)
+}
+
+const Root = styled(PriToggleGroup.Root)`
+	align-self: flex-start;
+`

--- a/apps/internal/src/components/instructions/default-stack-editor.tsx
+++ b/apps/internal/src/components/instructions/default-stack-editor.tsx
@@ -91,7 +91,7 @@ export function DefaultStackEditor({
 		<Card data-testid='default-stack-editor'>
 			<Head>
 				<Title>
-					<Trans>Your research default</Trans>
+					<Trans>Your default</Trans>
 				</Title>
 				<Badge>
 					{inheriting ? (
@@ -105,8 +105,8 @@ export function DefaultStackEditor({
 			</Head>
 			<Hint>
 				<Trans>
-					These templates shape every research run, in order — unless you pick
-					different ones for a single run.
+					These templates shape every run, in order — unless you pick different
+					ones for a single run.
 				</Trans>
 			</Hint>
 

--- a/apps/internal/src/components/instructions/instruction-page-chrome.tsx
+++ b/apps/internal/src/components/instructions/instruction-page-chrome.tsx
@@ -80,6 +80,9 @@ export const SectionHead = styled.div`
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--space-sm);
+	/* On a narrow phone the title and its action (a button or the surface
+	   selector) drop to separate rows instead of crowding one line. */
+	flex-wrap: wrap;
 `
 
 export const SectionTitle = styled.h3`

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -1137,6 +1137,10 @@ msgstr "Rebutja {0}"
 msgid "Default"
 msgstr "Per defecte"
 
+#: src/routes/settings/profile/templates.tsx
+msgid "Default instructions"
+msgstr "Instruccions per defecte"
+
 #: src/routes/emails/inboxes.tsx
 msgid "Defaults to the email address."
 msgstr "Per defecte, l'adreça electrònica."
@@ -1329,6 +1333,7 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/companies/conversations-tab.tsx
+#: src/components/instructions/agent-selector.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
@@ -2835,6 +2840,7 @@ msgid "Request a new link"
 msgstr "Demana un enllaç nou"
 
 #: src/components/companies/research-summary-card.tsx
+#: src/components/instructions/agent-selector.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "Research"
 msgstr "Recerca"
@@ -2890,8 +2896,12 @@ msgid "Resume syncing"
 msgstr "Reprèn la sincronització"
 
 #: src/routes/settings/profile/templates.tsx
-msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
-msgstr "Orientació reutilitzable i permanent que segueix el teu agent de recerca: què vens, a qui t'adreces, el to i en quines fonts confiar."
+msgid "Reusable, standing guidance your agents follow — what you sell, who you target, tone, and which sources to trust."
+msgstr "Orientació reutilitzable i permanent que segueixen els teus agents: què vens, a qui t'adreces, el to i en quines fonts confiar."
+
+#: src/routes/settings/profile/templates.tsx
+#~ msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
+#~ msgstr "Orientació reutilitzable i permanent que segueix el teu agent de recerca: què vens, a qui t'adreces, el to i en quines fonts confiar."
 
 #: src/routes/settings/organization/members.tsx
 msgid "Role"
@@ -3111,8 +3121,12 @@ msgid "Shared guidance and the org research default."
 msgstr "Orientació compartida i la recerca per defecte de l'organització."
 
 #: src/routes/settings/organization/templates.tsx
-msgid "Shared guidance every member's research agent can use, plus the organization's default."
-msgstr "Orientació compartida que pot fer servir l'agent de recerca de cada membre, més el valor per defecte de l'organització."
+msgid "Shared guidance every member's agents can use, plus the organization's default."
+msgstr "Orientació compartida que poden fer servir els agents de cada membre, més el valor per defecte de l'organització."
+
+#: src/routes/settings/organization/templates.tsx
+#~ msgid "Shared guidance every member's research agent can use, plus the organization's default."
+#~ msgstr "Orientació compartida que pot fer servir l'agent de recerca de cada membre, més el valor per defecte de l'organització."
 
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "Shared with everyone in your organization — their research agent follows it on every run."
@@ -3475,8 +3489,12 @@ msgid "These templates run for every member who hasn't set their own — in orde
 msgstr "Aquestes plantilles s'apliquen, en ordre, a cada membre que no n'hagi triat de pròpies. Aquí només hi poden anar plantilles de l'organització."
 
 #: src/components/instructions/default-stack-editor.tsx
-msgid "These templates shape every research run, in order — unless you pick different ones for a single run."
-msgstr "Aquestes plantilles configuren cada recerca, en ordre, llevat que en triïs d'altres per a una recerca concreta."
+#~ msgid "These templates shape every research run, in order — unless you pick different ones for a single run."
+#~ msgstr "Aquestes plantilles configuren cada recerca, en ordre, llevat que en triïs d'altres per a una recerca concreta."
+
+#: src/components/instructions/default-stack-editor.tsx
+msgid "These templates shape every run, in order — unless you pick different ones for a single run."
+msgstr "Aquestes plantilles configuren cada execució, en ordre, llevat que en triïs d'altres per a una sola execució."
 
 #: src/components/shared/status-badge.tsx
 msgid "They replied — keep the thread warm"
@@ -3817,6 +3835,11 @@ msgstr "La teva identitat al banc de Batuda."
 msgid "Your connections"
 msgstr "Les teves connexions"
 
+#: src/components/instructions/default-stack-editor.tsx
+#: src/routes/settings/profile/templates.tsx
+msgid "Your default"
+msgstr "El teu valor per defecte"
+
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Your email connections"
@@ -3844,5 +3867,5 @@ msgstr "Pròpia"
 
 #: src/components/instructions/default-stack-editor.tsx
 #: src/routes/settings/profile/templates.tsx
-msgid "Your research default"
-msgstr "La teva recerca per defecte"
+#~ msgid "Your research default"
+#~ msgstr "La teva recerca per defecte"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -1137,6 +1137,10 @@ msgstr "Decline {0}"
 msgid "Default"
 msgstr "Default"
 
+#: src/routes/settings/profile/templates.tsx
+msgid "Default instructions"
+msgstr "Default instructions"
+
 #: src/routes/emails/inboxes.tsx
 msgid "Defaults to the email address."
 msgstr "Defaults to the email address."
@@ -1329,6 +1333,7 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/companies/conversations-tab.tsx
+#: src/components/instructions/agent-selector.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
@@ -2835,6 +2840,7 @@ msgid "Request a new link"
 msgstr "Request a new link"
 
 #: src/components/companies/research-summary-card.tsx
+#: src/components/instructions/agent-selector.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "Research"
 msgstr "Research"
@@ -2890,8 +2896,12 @@ msgid "Resume syncing"
 msgstr "Resume syncing"
 
 #: src/routes/settings/profile/templates.tsx
-msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
-msgstr "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
+msgid "Reusable, standing guidance your agents follow — what you sell, who you target, tone, and which sources to trust."
+msgstr "Reusable, standing guidance your agents follow — what you sell, who you target, tone, and which sources to trust."
+
+#: src/routes/settings/profile/templates.tsx
+#~ msgid "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
+#~ msgstr "Reusable, standing guidance your research agent follows — what you sell, who you target, tone, and which sources to trust."
 
 #: src/routes/settings/organization/members.tsx
 msgid "Role"
@@ -3111,8 +3121,12 @@ msgid "Shared guidance and the org research default."
 msgstr "Shared guidance and the org research default."
 
 #: src/routes/settings/organization/templates.tsx
-msgid "Shared guidance every member's research agent can use, plus the organization's default."
-msgstr "Shared guidance every member's research agent can use, plus the organization's default."
+msgid "Shared guidance every member's agents can use, plus the organization's default."
+msgstr "Shared guidance every member's agents can use, plus the organization's default."
+
+#: src/routes/settings/organization/templates.tsx
+#~ msgid "Shared guidance every member's research agent can use, plus the organization's default."
+#~ msgstr "Shared guidance every member's research agent can use, plus the organization's default."
 
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "Shared with everyone in your organization — their research agent follows it on every run."
@@ -3475,8 +3489,12 @@ msgid "These templates run for every member who hasn't set their own — in orde
 msgstr "These templates run for every member who hasn't set their own — in order. Only org templates can go here."
 
 #: src/components/instructions/default-stack-editor.tsx
-msgid "These templates shape every research run, in order — unless you pick different ones for a single run."
-msgstr "These templates shape every research run, in order — unless you pick different ones for a single run."
+#~ msgid "These templates shape every research run, in order — unless you pick different ones for a single run."
+#~ msgstr "These templates shape every research run, in order — unless you pick different ones for a single run."
+
+#: src/components/instructions/default-stack-editor.tsx
+msgid "These templates shape every run, in order — unless you pick different ones for a single run."
+msgstr "These templates shape every run, in order — unless you pick different ones for a single run."
 
 #: src/components/shared/status-badge.tsx
 msgid "They replied — keep the thread warm"
@@ -3817,6 +3835,11 @@ msgstr "Your Batuda workbench identity."
 msgid "Your connections"
 msgstr "Your connections"
 
+#: src/components/instructions/default-stack-editor.tsx
+#: src/routes/settings/profile/templates.tsx
+msgid "Your default"
+msgstr "Your default"
+
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Your email connections"
@@ -3844,5 +3867,5 @@ msgstr "Your own"
 
 #: src/components/instructions/default-stack-editor.tsx
 #: src/routes/settings/profile/templates.tsx
-msgid "Your research default"
-msgstr "Your research default"
+#~ msgid "Your research default"
+#~ msgstr "Your research default"

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -14,6 +14,7 @@ import {
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
+import type { Agent } from '@batuda/instructions/domain'
 import { PriButton, usePriToast } from '@batuda/ui/pri'
 
 import {
@@ -25,6 +26,7 @@ import {
 	rejectDonationAtom,
 	setOrgStackAtom,
 } from '#/atoms/instruction-atoms'
+import { AgentSelector } from '#/components/instructions/agent-selector'
 import {
 	InstructionIconButton,
 	OwnerBadge,
@@ -63,8 +65,6 @@ import {
 } from '#/components/instructions/template-editor-dialog'
 import { authClient } from '#/lib/auth-client'
 import { ruledLedgerRow } from '#/lib/workshop-mixins'
-
-const AGENT = 'research'
 
 export const Route = createFileRoute('/settings/organization/templates')({
 	head: () => ({ meta: [{ title: 'Org instruction templates — Batuda' }] }),
@@ -106,7 +106,7 @@ function OrgTemplatesPage() {
 				</Heading>
 				<Subtitle>
 					<Trans>
-						Shared guidance every member's research agent can use, plus the
+						Shared guidance every member's agents can use, plus the
 						organization's default.
 					</Trans>
 				</Subtitle>
@@ -162,9 +162,13 @@ function OrgTemplateAdmin({
 	const { t } = useLingui()
 	const toast = usePriToast()
 
+	// Instructions are per surface; this picks which surface's org default the
+	// section below edits. Org templates themselves are surface-neutral.
+	const [agent, setAgent] = useState<Agent>('research')
+
 	const donationsResult = useAtomValue(instructionDonationsAtom)
 	const refreshDonations = useAtomRefresh(instructionDonationsAtom)
-	const stacksAtom = useMemo(() => defaultStacksAtom(AGENT), [])
+	const stacksAtom = useMemo(() => defaultStacksAtom(agent), [agent])
 	const stacksResult = useAtomValue(stacksAtom)
 	const refreshStacks = useAtomRefresh(stacksAtom)
 
@@ -204,6 +208,13 @@ function OrgTemplateAdmin({
 	const [stackIds, setStackIds] = useState<ReadonlyArray<string> | null>(null)
 	const [savingStack, setSavingStack] = useState(false)
 	const effectiveStack = stackIds ?? orgStackIds ?? []
+
+	// Switching surface re-seeds the picker from that surface's saved org default,
+	// dropping any unsaved edits to the previous surface.
+	const selectAgent = (next: Agent) => {
+		setAgent(next)
+		setStackIds(null)
+	}
 
 	const openCreate = () => {
 		setEditing(null)
@@ -251,7 +262,7 @@ function OrgTemplateAdmin({
 		// dangling reference the server would only reject.
 		const ids = effectiveStack.filter(id => stackOptions.some(o => o.id === id))
 		const exit = await setOrgStack({
-			params: { agent: AGENT },
+			params: { agent },
 			payload: { template_ids: ids },
 		} as never)
 		setSavingStack(false)
@@ -361,9 +372,16 @@ function OrgTemplateAdmin({
 			</Section>
 
 			<Section data-testid='org-default-stack'>
-				<SectionTitle>
-					<Trans>Organization default</Trans>
-				</SectionTitle>
+				<SectionHead>
+					<SectionTitle id='org-default-surface'>
+						<Trans>Organization default</Trans>
+					</SectionTitle>
+					<AgentSelector
+						agent={agent}
+						onChange={selectAgent}
+						labelledBy='org-default-surface'
+					/>
+				</SectionHead>
 				<Hint>
 					<Trans>
 						These templates run for every member who hasn't set their own — in

--- a/apps/internal/src/routes/settings/profile/templates.tsx
+++ b/apps/internal/src/routes/settings/profile/templates.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Gift, Pencil, Plus, ScrollText, Trash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
+import type { Agent } from '@batuda/instructions/domain'
 import { PriButton, usePriToast } from '@batuda/ui/pri'
 
 import {
@@ -14,6 +15,7 @@ import {
 	donateTemplateAtom,
 	instructionTemplatesAtom,
 } from '#/atoms/instruction-atoms'
+import { AgentSelector } from '#/components/instructions/agent-selector'
 import { DefaultStackEditor } from '#/components/instructions/default-stack-editor'
 import {
 	InstructionIconButton,
@@ -51,8 +53,6 @@ import {
 import { authClient } from '#/lib/auth-client'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
-const AGENT = 'research'
-
 export const Route = createFileRoute('/settings/profile/templates')({
 	head: () => ({ meta: [{ title: 'Instruction templates — Batuda' }] }),
 	component: TemplatesPage,
@@ -64,9 +64,13 @@ function TemplatesPage() {
 	const session = authClient.useSession()
 	const myUserId = session.data?.user?.id ?? null
 
+	// Instructions are per surface; this picks which surface's default the editor
+	// below configures. Templates themselves are surface-neutral.
+	const [agent, setAgent] = useState<Agent>('research')
+
 	const templatesResult = useAtomValue(instructionTemplatesAtom)
 	const refreshTemplates = useAtomRefresh(instructionTemplatesAtom)
-	const stacksAtom = useMemo(() => defaultStacksAtom(AGENT), [])
+	const stacksAtom = useMemo(() => defaultStacksAtom(agent), [agent])
 	const stacksResult = useAtomValue(stacksAtom)
 	const refreshStacks = useAtomRefresh(stacksAtom)
 	const deleteTemplate = useAtomSet(deleteTemplateAtom, { mode: 'promiseExit' })
@@ -195,8 +199,8 @@ function TemplatesPage() {
 				</Heading>
 				<Subtitle>
 					<Trans>
-						Reusable, standing guidance your research agent follows — what you
-						sell, who you target, tone, and which sources to trust.
+						Reusable, standing guidance your agents follow — what you sell, who
+						you target, tone, and which sources to trust.
 					</Trans>
 				</Subtitle>
 			</Intro>
@@ -280,34 +284,47 @@ function TemplatesPage() {
 				)}
 			</Section>
 
-			{stacksFailed ? (
-				<Notice role='alert'>
-					<Trans>Couldn't load your default. Refresh to try again.</Trans>
-				</Notice>
-			) : templates.length === 0 ? (
-				<EmptyDefault>
-					<EmptyDefaultTitle>
-						<Trans>Your research default</Trans>
-					</EmptyDefaultTitle>
-					<Empty>
-						<Trans>
-							Create a template above first, then pick which ones run by
-							default.
-						</Trans>
-					</Empty>
-				</EmptyDefault>
-			) : (
-				<DefaultStackEditor
-					agent={AGENT}
-					options={options}
-					userStackIds={userStackIds}
-					orgStackIds={orgStackIds}
-					userComposition={userComposition}
-					onSaved={() => {
-						refreshStacks()
-					}}
-				/>
-			)}
+			<Section>
+				<SectionHead>
+					<SectionTitle id='profile-default-surface'>
+						<Trans>Default instructions</Trans>
+					</SectionTitle>
+					<AgentSelector
+						agent={agent}
+						onChange={setAgent}
+						labelledBy='profile-default-surface'
+					/>
+				</SectionHead>
+
+				{stacksFailed ? (
+					<Notice role='alert'>
+						<Trans>Couldn't load your default. Refresh to try again.</Trans>
+					</Notice>
+				) : templates.length === 0 ? (
+					<EmptyDefault>
+						<EmptyDefaultTitle>
+							<Trans>Your default</Trans>
+						</EmptyDefaultTitle>
+						<Empty>
+							<Trans>
+								Create a template above first, then pick which ones run by
+								default.
+							</Trans>
+						</Empty>
+					</EmptyDefault>
+				) : (
+					<DefaultStackEditor
+						agent={agent}
+						options={options}
+						userStackIds={userStackIds}
+						orgStackIds={orgStackIds}
+						userComposition={userComposition}
+						onSaved={() => {
+							refreshStacks()
+						}}
+					/>
+				)}
+			</Section>
 
 			<TemplateEditorDialog
 				open={dialogOpen}

--- a/apps/server/src/mcp/prompts/instructions.ts
+++ b/apps/server/src/mcp/prompts/instructions.ts
@@ -1,0 +1,103 @@
+import { Effect, Schema } from 'effect'
+import { McpServer } from 'effect/unstable/ai'
+
+import {
+	AgentSchema,
+	agents,
+	isUuidRef,
+	listTemplates,
+} from '@batuda/instructions'
+
+// User-controlled entry points (slash commands) for the instruction-template
+// feature — the protocol-standard home for human-invoked actions, distinct from
+// the model-controlled tools and the application-controlled menu resource.
+// `apply-instruction` resolves a named instruction and tells the AI to apply it
+// to the next agent action; `save-instruction` walks the AI through capturing a
+// standing preference with the existing management tools.
+
+const scopeLabel = (ownerUserId: string | null): 'org' | 'personal' =>
+	ownerUserId === null ? 'org' : 'personal'
+
+// ── apply-instruction ────────────────────────────────────────────────────────
+
+export const ApplyInstructionPrompt = McpServer.prompt({
+	name: 'apply-instruction',
+	description:
+		'Apply a saved instruction (by name or id) to the next research run or email. Resolves the instruction and directs the AI to use it.',
+	parameters: {
+		agent: Schema.String,
+		instruction: Schema.String,
+	},
+	completion: {
+		agent: (input: string) =>
+			Effect.succeed(agents.filter(a => a.startsWith(input))),
+		instruction: (input: string) =>
+			listTemplates().pipe(
+				Effect.map(rows =>
+					rows
+						.map(t => t.name)
+						.filter(name => name.toLowerCase().startsWith(input.toLowerCase())),
+				),
+				Effect.orElseSucceed(() => [] as Array<string>),
+			),
+	},
+	content: ({ agent, instruction }) =>
+		Effect.gen(function* () {
+			if (!Schema.is(AgentSchema)(agent)) {
+				return `Unknown agent "${agent}". Valid agents: ${agents.join(', ')}.`
+			}
+			const templates = yield* listTemplates().pipe(Effect.orDie)
+			// A ref is an id when it's UUID-shaped, otherwise a human name. RLS has
+			// already limited `templates` to the org's plus the caller's own, so a
+			// name that matches nothing here is one the user genuinely can't apply.
+			const matches = templates.filter(t =>
+				isUuidRef(instruction) ? t.id === instruction : t.name === instruction,
+			)
+			if (matches.length === 0) {
+				const available = templates.map(t => `"${t.name}"`).join(', ') || 'none'
+				return `No instruction "${instruction}" is available for ${agent}. Readable instructions: ${available}. Ask the user which they meant, or create it with manage_instruction_template.`
+			}
+			if (matches.length > 1) {
+				const candidates = matches
+					.map(t => `${scopeLabel(t.ownerUserId)} (id ${t.id})`)
+					.join('; ')
+				return `"${instruction}" matches more than one instruction: ${candidates}. Ask the user which one, then apply it by its id.`
+			}
+			const tpl = matches[0]
+			if (!tpl) return `No instruction "${instruction}" is available.`
+			const how =
+				agent === 'research'
+					? `call start_research or research_sync with instructions: ["${tpl.name}"] (or the id ${tpl.id}) so the run records and applies it`
+					: 'follow this instruction when you compose the email body'
+			return `Apply the "${tpl.name}" instruction (${scopeLabel(tpl.ownerUserId)}) to your next ${agent} action.
+
+Instruction:
+${tpl.body}
+
+To apply it, ${how}. If the user wants this on by default, use manage_instruction_default_stack.`
+		}),
+})
+
+// ── save-instruction ─────────────────────────────────────────────────────────
+
+export const SaveInstructionPrompt = McpServer.prompt({
+	name: 'save-instruction',
+	description:
+		'Save a standing preference the user expressed as a reusable instruction template (personal or org), using the existing management tools.',
+	parameters: {
+		name: Schema.String,
+		scope: Schema.Literals(['personal', 'org']),
+	},
+	completion: {
+		scope: (input: string) =>
+			Effect.succeed(
+				(['personal', 'org'] as const).filter(s => s.startsWith(input)),
+			),
+	},
+	content: ({ name, scope }) =>
+		Effect.succeed(`The user wants to save a standing instruction named "${name}" (${scope} scope).
+
+1. Capture the preference the user expressed in this conversation as the instruction body — concise and imperative (e.g. "Always open with the contact's first name").
+2. Create it: call manage_instruction_template with action "create", name "${name}", scope "${scope}", and that body. (scope "org" is admin-only and is rejected for non-admins — save it as "personal" instead if that happens.)
+3. Offer to apply it by default for an agent (research or email) with manage_instruction_default_stack action "set", or per call via the apply-instruction prompt.`),
+})

--- a/apps/server/src/mcp/resources/instructions.ts
+++ b/apps/server/src/mcp/resources/instructions.ts
@@ -1,0 +1,74 @@
+import { Effect, Schema } from 'effect'
+import { McpSchema, McpServer } from 'effect/unstable/ai'
+
+import { CurrentOrg, SessionContext } from '@batuda/controllers'
+import {
+	AgentSchema,
+	agents,
+	getDefaultStacks,
+	listTemplates,
+	resolveInstructions,
+} from '@batuda/instructions'
+
+const agentParam = McpSchema.param('agent', Schema.String)
+
+// A read-only menu of instruction templates plus the active default stack for an
+// agent, so a capable client can read the user's standing rules before composing
+// (research findings, an email body) without a tool round-trip. Reads run inside
+// the request's org scope, so templates and stacks are already RLS-scoped to this
+// org plus the caller's own. The agent param is validated against the code set
+// (research, email); an unknown agent returns the valid list rather than failing.
+export const InstructionsResource =
+	McpServer.resource`batuda://instructions/${agentParam}`({
+		name: 'Agent Instructions',
+		description:
+			'Instruction templates readable in this org plus the active default stack for an agent (research, email). Read before composing so output follows the user’s standing rules. For research, override per run with start_research/research_sync `instructions`; for email, follow these when composing. The apply-instruction and save-instruction prompts use and capture them.',
+		mimeType: 'application/json',
+		audience: ['assistant'],
+		completion: {
+			agent: (input: string) =>
+				Effect.succeed(agents.filter(a => a.startsWith(input))),
+		},
+		content: Effect.fn(function* (_uri, agentRaw) {
+			const agent = Schema.is(AgentSchema)(agentRaw) ? agentRaw : null
+			if (!agent) {
+				return JSON.stringify(
+					{ error: `unknown agent: ${agentRaw}`, agents: [...agents] },
+					null,
+					2,
+				)
+			}
+			const org = yield* CurrentOrg
+			const { userId } = yield* SessionContext
+			const templates = yield* listTemplates().pipe(Effect.orDie)
+			const stacks = yield* getDefaultStacks(org.id, userId, agent).pipe(
+				Effect.orDie,
+			)
+			// The effective instructions for a run with no override — what actually
+			// fires today, after the user-replaces-org precedence the resolver applies.
+			const active = yield* resolveInstructions({
+				organizationId: org.id,
+				userId,
+				agent,
+			}).pipe(Effect.orDie)
+			return JSON.stringify(
+				{
+					agent,
+					templates: templates.map(t => ({
+						id: t.id,
+						name: t.name,
+						scope: t.ownerUserId === null ? 'org' : 'personal',
+						body: t.body,
+					})),
+					default_stacks: stacks,
+					active: {
+						source: active.source,
+						names: active.templateNames,
+						segments: active.segments,
+					},
+				},
+				null,
+				2,
+			)
+		}),
+	})

--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -3,11 +3,16 @@ import { McpServer } from 'effect/unstable/ai'
 
 import { CompanyResearchPrompt } from './prompts/company-research'
 import { DailyBriefingPrompt } from './prompts/daily-briefing'
+import {
+	ApplyInstructionPrompt,
+	SaveInstructionPrompt,
+} from './prompts/instructions'
 import { InteractionFollowUpPrompt } from './prompts/interaction-follow-up'
 import { ProposalDraftPrompt } from './prompts/proposal-draft'
 import { ResearchDesignerPrompt } from './prompts/research-designer'
 import { CompanyResource } from './resources/company'
 import { DocumentResource } from './resources/document'
+import { InstructionsResource } from './resources/instructions'
 import { PipelineResource } from './resources/pipeline'
 import { ResearchResource } from './resources/research'
 import { TimelineResource } from './resources/timeline'
@@ -65,12 +70,15 @@ export const McpToolsLive = Layer.mergeAll(
 	PipelineResource,
 	DocumentResource,
 	ResearchResource,
+	InstructionsResource,
 	TimelineResource,
 	CompanyResearchPrompt,
 	DailyBriefingPrompt,
 	ProposalDraftPrompt,
 	InteractionFollowUpPrompt,
 	ResearchDesignerPrompt,
+	ApplyInstructionPrompt,
+	SaveInstructionPrompt,
 ).pipe(
 	Layer.provide(CompanyHandlersLive),
 	Layer.provide(ContactHandlersLive),

--- a/apps/server/src/mcp/tools/_instructions-shared.ts
+++ b/apps/server/src/mcp/tools/_instructions-shared.ts
@@ -1,0 +1,88 @@
+import { Effect, Schema } from 'effect'
+import type { SqlError } from 'effect/unstable/sql'
+import { SqlClient } from 'effect/unstable/sql'
+
+import {
+	type Agent,
+	type ResolvedInstructions,
+	type ResolveRefsResult,
+	resolveInstructionRefs,
+	resolveInstructions,
+} from '@batuda/instructions'
+
+// Per-run instruction-override surface for the agent-facing research MCP tools.
+// A caller names instruction templates by human name OR id; names resolve
+// server-side, scoped by RLS to the org's templates plus the caller's own. An
+// unresolved name returns a clarification the tool hands straight back instead of
+// acting, so the AI re-asks the human or retries with the exact id.
+
+// The override param: an array of template names or ids.
+export const InstructionsOverride = Schema.Array(Schema.String)
+
+const InstructionCandidate = Schema.Struct({
+	id: Schema.String,
+	name: Schema.String,
+	scope: Schema.Literals(['personal', 'org']),
+})
+
+// Returned in place of the normal result when a name can't be resolved. Shared
+// across tools so every surface reports collisions the same way.
+export const InstructionClarification = Schema.Struct({
+	_tag: Schema.Literal('instruction_clarification'),
+	message: Schema.String,
+	unknown: Schema.Array(Schema.String),
+	ambiguous: Schema.Array(
+		Schema.Struct({
+			query: Schema.String,
+			candidates: Schema.Array(InstructionCandidate),
+		}),
+	),
+})
+
+export const buildClarification = (
+	result: Extract<ResolveRefsResult, { readonly ok: false }>,
+) => ({
+	_tag: 'instruction_clarification' as const,
+	message:
+		'One or more instruction references could not be resolved, so nothing was done. For an unknown name, fix the spelling or create the template first; for an ambiguous name, pass the exact id from the listed candidates.',
+	unknown: result.unknown,
+	ambiguous: result.ambiguous,
+})
+
+export type OverrideResolution =
+	| { readonly ok: true; readonly instructions: ResolvedInstructions }
+	| {
+			readonly ok: false
+			readonly clarification: ReturnType<typeof buildClarification>
+	  }
+
+// Resolve a caller's override (names or ids) and then the effective instruction
+// stack for one agent run. Both reads go through RLS, so this must run inside the
+// request transaction (the captured `sql` is the request-scoped client). Returns
+// the resolved instructions, or a clarification to hand back when a name doesn't
+// resolve — in which case no stack is resolved and the caller should not act.
+export const resolveInstructionOverride = (args: {
+	readonly sql: SqlClient.SqlClient
+	readonly organizationId: string
+	readonly userId: string
+	readonly agent: Agent
+	readonly refs: ReadonlyArray<string>
+}): Effect.Effect<OverrideResolution, SqlError.SqlError> =>
+	Effect.gen(function* () {
+		const refResult = yield* resolveInstructionRefs(args.refs).pipe(
+			Effect.provideService(SqlClient.SqlClient, args.sql),
+		)
+		if (!refResult.ok) {
+			return {
+				ok: false as const,
+				clarification: buildClarification(refResult),
+			}
+		}
+		const instructions = yield* resolveInstructions({
+			organizationId: args.organizationId,
+			userId: args.userId,
+			agent: args.agent,
+			overrideTemplateIds: refResult.templateIds,
+		}).pipe(Effect.provideService(SqlClient.SqlClient, args.sql))
+		return { ok: true as const, instructions }
+	})

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -84,7 +84,7 @@ const AttachmentRef = Schema.Struct({
 
 const SendEmail = Tool.make('send_email', {
 	description:
-		'Send a new email. The body is a structured block tree (paragraph / heading / list / quote / divider / image) — not raw html/text. Omit inbox_id to use the calling member’s primary inbox in the active org. Attachments reference staging_ids returned by stage_email_attachment; set inline=true for cid-referenced inline images. Returns {_tag:"sent"} on success or {_tag:"suppressed"} if a recipient is suppressed. Set skip_footer=true to omit the inbox default footer.',
+		'Send a new email. The body is a structured block tree (paragraph / heading / list / quote / divider / image) — not raw html/text. Omit inbox_id to use the calling member’s primary inbox in the active org. Attachments reference staging_ids returned by stage_email_attachment; set inline=true for cid-referenced inline images. Before composing, read the member’s standing email instructions (writing style, sign-off, do/don’t rules) from the batuda://instructions/email resource and write the body to follow them. Returns {_tag:"sent"} on success or {_tag:"suppressed"} if a recipient is suppressed. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		inbox_id: Schema.optional(Schema.String),
 		to: Recipients,
@@ -108,7 +108,7 @@ const SendEmail = Tool.make('send_email', {
 
 const ReplyEmail = Tool.make('reply_email', {
 	description:
-		'Reply to the latest message in an existing email thread. Body is a structured block tree — if you want the parent quoted, emit a `quote` block wrapping sanitized parent blocks (you can read the parent via get_email_thread). Optional Cc/Bcc extend the thread. Attachments reference staging_ids from stage_email_attachment. Returns {_tag:"sent"} or {_tag:"suppressed"}. Set skip_footer=true to omit the inbox default footer.',
+		'Reply to the latest message in an existing email thread. Body is a structured block tree — if you want the parent quoted, emit a `quote` block wrapping sanitized parent blocks (you can read the parent via get_email_thread). Optional Cc/Bcc extend the thread. Attachments reference staging_ids from stage_email_attachment. Before composing, read the member’s standing email instructions from the batuda://instructions/email resource and write the reply to follow them. Returns {_tag:"sent"} or {_tag:"suppressed"}. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		thread_id: Schema.String,
 		body_json: EmailBlocks,

--- a/apps/server/src/mcp/tools/research-mcp.ts
+++ b/apps/server/src/mcp/tools/research-mcp.ts
@@ -3,7 +3,6 @@ import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg, SessionContext } from '@batuda/controllers'
-import { resolveInstructions } from '@batuda/instructions'
 import {
 	type CreateResearchInput,
 	ResearchService,
@@ -11,6 +10,11 @@ import {
 } from '@batuda/research'
 
 import { EnvVars } from '../../lib/env'
+import {
+	InstructionClarification,
+	InstructionsOverride,
+	resolveInstructionOverride,
+} from './_instructions-shared'
 import {
 	ResearchQuery,
 	redactDbErrors,
@@ -24,17 +28,22 @@ const REQUEST_DEPENDENCIES = [SessionContext, CurrentOrg]
 
 const StartResearch = Tool.make('start_research', {
 	description:
-		'Start a research run. Returns an ID immediately — use get_research to poll for results. Best for long-running research where you want to do other work while waiting.',
+		"Start a research run; returns {_tag:'started', id, status, applied_instructions} immediately — poll get_research for results. applied_instructions lists the instruction templates that shaped the run. The user's default research instructions apply automatically; pass `instructions` (template names or ids) to override them for this run. An unknown or ambiguous name returns {_tag:'instruction_clarification'} with candidates instead of starting. If the user states a new standing preference, save it with manage_instruction_template.",
 	parameters: Schema.Struct({
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
 		schema_name: Schema.optional(SchemaNameParam),
-		template_ids: Schema.optional(Schema.Array(Uuid)),
+		instructions: Schema.optional(InstructionsOverride),
 	}),
-	success: Schema.Struct({
-		id: Schema.String,
-		status: Schema.String,
-	}),
+	success: Schema.Union([
+		Schema.Struct({
+			_tag: Schema.Literal('started'),
+			id: Schema.String,
+			status: Schema.String,
+			applied_instructions: Schema.Array(Schema.String),
+		}),
+		InstructionClarification,
+	]),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'Start Research')
@@ -45,7 +54,7 @@ const StartResearch = Tool.make('start_research', {
 
 const GetResearch = Tool.make('get_research', {
 	description:
-		'Get the current state of a research run. Returns status, findings (if complete), cost, and sources.',
+		'Get the current state of a research run. Returns status, findings (if complete), cost, sources, and applied_instructions — the instruction templates that shaped the run.',
 	parameters: Schema.Struct({
 		id: Uuid,
 	}),
@@ -61,12 +70,12 @@ const GetResearch = Tool.make('get_research', {
 
 const ResearchSync = Tool.make('research_sync', {
 	description:
-		'Run research to completion and return full findings inline. Blocks until done or timeout. Best for short research that fits in a single tool call.',
+		"Run research to completion and return full findings inline (blocks until done or timeout); best for short research. The returned run includes applied_instructions — the instruction templates that shaped it. The user's default research instructions apply automatically; pass `instructions` (template names or ids) to override them for this run. An unknown or ambiguous name returns {_tag:'instruction_clarification'} with candidates instead of running.",
 	parameters: Schema.Struct({
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
 		schema_name: Schema.optional(SchemaNameParam),
-		template_ids: Schema.optional(Schema.Array(Uuid)),
+		instructions: Schema.optional(InstructionsOverride),
 		max_wait_seconds: Schema.optional(Schema.Number),
 	}),
 	success: Schema.Unknown,
@@ -84,6 +93,20 @@ export const ResearchMcpTools = Toolkit.make(
 	ResearchSync,
 )
 
+// Surface the instruction templates a run applied under one consistent field.
+// svc.get returns the persisted column as `templateNames` (PgClient camelCases
+// result keys); normalize it to applied_instructions so sync/poll callers read
+// the same shape start_research returns.
+const withAppliedInstructions = (run: unknown): unknown => {
+	if (run === null || typeof run !== 'object') return run
+	const row = run as Record<string, unknown>
+	const names = row['templateNames'] ?? row['template_names']
+	return {
+		...row,
+		applied_instructions: Array.isArray(names) ? names : [],
+	}
+}
+
 export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 	Effect.gen(function* () {
 		const svc = yield* ResearchService
@@ -98,6 +121,21 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 			hardCeiling: env.RESEARCH_MONTHLY_CAP_HARD_CEILING_CENTS,
 		}
 
+		// Resolve a per-run override (names or ids) to the effective instruction
+		// stack, or a clarification to hand straight back when a name can't resolve.
+		const resolveForRun = (
+			orgId: string,
+			userId: string,
+			refs: ReadonlyArray<string>,
+		) =>
+			resolveInstructionOverride({
+				sql,
+				organizationId: orgId,
+				userId,
+				agent: 'research',
+				refs,
+			})
+
 		return {
 			start_research: params =>
 				Effect.gen(function* () {
@@ -106,12 +144,12 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 					// belong to the real person behind the key.
 					const userId = (yield* SessionContext).userId
 					const orgId = (yield* CurrentOrg).id
-					const instructions = yield* resolveInstructions({
-						organizationId: orgId,
+					const resolved = yield* resolveForRun(
+						orgId,
 						userId,
-						agent: 'research',
-						overrideTemplateIds: params.template_ids,
-					}).pipe(Effect.provideService(SqlClient.SqlClient, sql))
+						params.instructions ?? [],
+					)
+					if (!resolved.ok) return resolved.clarification
 					const result = yield* svc.create(
 						userId,
 						orgId,
@@ -121,27 +159,32 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 							schemaName: params.schema_name,
 						},
 						systemDefaults,
-						instructions,
+						resolved.instructions,
 					)
-					return result
+					return {
+						_tag: 'started' as const,
+						id: result.id,
+						status: result.status,
+						applied_instructions: resolved.instructions.templateNames,
+					}
 				}).pipe(redactDbErrors),
 
 			get_research: params =>
 				Effect.gen(function* () {
 					const run = yield* svc.get(params.id)
-					return run ?? { error: 'not found' }
+					return run ? withAppliedInstructions(run) : { error: 'not found' }
 				}).pipe(redactDbErrors),
 
 			research_sync: params =>
 				Effect.gen(function* () {
 					const userId = (yield* SessionContext).userId
 					const orgId = (yield* CurrentOrg).id
-					const instructions = yield* resolveInstructions({
-						organizationId: orgId,
+					const resolved = yield* resolveForRun(
+						orgId,
 						userId,
-						agent: 'research',
-						overrideTemplateIds: params.template_ids,
-					}).pipe(Effect.provideService(SqlClient.SqlClient, sql))
+						params.instructions ?? [],
+					)
+					if (!resolved.ok) return resolved.clarification
 					const { id } = yield* svc.create(
 						userId,
 						orgId,
@@ -151,7 +194,7 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 							schemaName: params.schema_name,
 						},
 						systemDefaults,
-						instructions,
+						resolved.instructions,
 					)
 
 					// Poll until the run reaches a terminal status or we exceed
@@ -171,7 +214,7 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 						run = yield* svc.get(id)
 					}
 
-					return run ?? { error: 'not found' }
+					return run ? withAppliedInstructions(run) : { error: 'not found' }
 				}).pipe(redactDbErrors),
 		}
 	}),

--- a/apps/server/src/services/resolve-instruction-refs.integration.test.ts
+++ b/apps/server/src/services/resolve-instruction-refs.integration.test.ts
@@ -1,0 +1,169 @@
+// Live-DB integration test for resolveInstructionRefs — the name-or-id resolver
+// behind the MCP `instructions` per-run override. Runs through enterOrgScope
+// (app_user + GUCs) so RLS is in force, proving names resolve only against the
+// templates the actor can read (the org's plus their own), that an id passes
+// through, and that the unknown / ambiguous failure shapes match what the tools
+// hand back to the AI.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable on $DATABASE_URL, and
+// the instruction tables migrated.
+
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { resolveInstructionRefs } from '@batuda/instructions'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+const ORG = `rir-org-${randomUUID()}`
+const U1 = `rir-u1-${randomUUID()}`
+const U2 = `rir-u2-${randomUUID()}`
+const ORG_OBJ = { id: ORG, name: 'rir', slug: 'rir' }
+
+let orgShared = ''
+let userShared = ''
+let orgOnly = ''
+
+const runRoot = <A>(
+	eff: Effect.Effect<A, unknown, SqlClient.SqlClient>,
+): Promise<A> =>
+	Effect.runPromise(
+		eff.pipe(Effect.orDie, Effect.provide(PgLive)) as Effect.Effect<
+			A,
+			never,
+			never
+		>,
+	)
+
+// Resolve refs as a given user inside the request scope (app_user + GUCs).
+const resolveAs = (userId: string, refs: ReadonlyArray<string>) =>
+	runRoot(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org: ORG_OBJ, userId })(
+				resolveInstructionRefs(refs),
+			)
+		}),
+	)
+
+beforeAll(async () => {
+	const ids = await runRoot(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* sql.withTransaction(
+				Effect.gen(function* () {
+					// app_service (BYPASSRLS) seeds across the FORCE policy.
+					yield* sql`SET LOCAL ROLE app_service`
+					// 'Shared' exists as both an org template and U1's personal one — a
+					// name collision U1 must disambiguate.
+					const os = yield* sql<{ id: string }>`
+						INSERT INTO instruction_templates (organization_id, owner_user_id, name, body, created_by)
+						VALUES (${ORG}, NULL, 'Shared', 'org shared', ${U1}) RETURNING id`
+					const us = yield* sql<{ id: string }>`
+						INSERT INTO instruction_templates (organization_id, owner_user_id, name, body, created_by)
+						VALUES (${ORG}, ${U1}, 'Shared', 'u1 shared', ${U1}) RETURNING id`
+					// A uniquely-named org template U1 can resolve by name.
+					const oo = yield* sql<{ id: string }>`
+						INSERT INTO instruction_templates (organization_id, owner_user_id, name, body, created_by)
+						VALUES (${ORG}, NULL, 'OrgOnly', 'org only', ${U1}) RETURNING id`
+					// U2's personal template — RLS hides it from U1, so U1 resolving
+					// the name 'Secret' must come back unknown. Inserted for that
+					// effect; the row id is never referenced.
+					yield* sql`
+						INSERT INTO instruction_templates (organization_id, owner_user_id, name, body, created_by)
+						VALUES (${ORG}, ${U2}, 'Secret', 'u2 secret', ${U2})`
+					return {
+						orgShared: os[0]?.id ?? '',
+						userShared: us[0]?.id ?? '',
+						orgOnly: oo[0]?.id ?? '',
+					}
+				}),
+			)
+		}),
+	)
+	orgShared = ids.orgShared
+	userShared = ids.userShared
+	orgOnly = ids.orgOnly
+}, 60_000)
+
+afterAll(async () => {
+	await runRoot(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql.withTransaction(
+				Effect.gen(function* () {
+					yield* sql`SET LOCAL ROLE app_service`
+					yield* sql`DELETE FROM instruction_templates WHERE organization_id = ${ORG}`
+				}),
+			)
+		}),
+	)
+})
+
+describe('resolveInstructionRefs (live RLS)', () => {
+	describe('when a name uniquely matches a readable template', () => {
+		it('should resolve the name to its id', async () => {
+			// GIVEN U1 references a uniquely-named org template by name
+			const result = await resolveAs(U1, ['OrgOnly'])
+			// THEN the name resolves to the id
+			expect(result).toEqual({ ok: true, templateIds: [orgOnly] })
+		})
+	})
+
+	describe('when a ref is already an id', () => {
+		it('should pass the id through without a name lookup', async () => {
+			// GIVEN U1 references a template by raw id
+			const result = await resolveAs(U1, [orgOnly])
+			// THEN it is taken at face value (ids are never name-matched)
+			expect(result).toEqual({ ok: true, templateIds: [orgOnly] })
+		})
+	})
+
+	describe('when a name matches both an org and the actor’s personal template', () => {
+		it('should report both candidates with their scope so the AI re-asks by id', async () => {
+			// GIVEN 'Shared' exists as an org template and U1's own
+			const result = await resolveAs(U1, ['Shared'])
+			// THEN the collision is flagged with both readable candidates
+			expect(result.ok).toBe(false)
+			if (!result.ok) {
+				expect(result.unknown).toEqual([])
+				expect(result.ambiguous).toHaveLength(1)
+				const ref = result.ambiguous[0]
+				expect(ref?.query).toBe('Shared')
+				const byId = new Map(ref?.candidates.map(c => [c.id, c.scope]))
+				expect(byId.get(orgShared)).toBe('org')
+				expect(byId.get(userShared)).toBe('personal')
+				expect(byId.size).toBe(2)
+			}
+		})
+	})
+
+	describe('when a name belongs only to another member', () => {
+		it('should report it unknown because RLS hides it from this actor', async () => {
+			// GIVEN U1 references U2's personal template by name
+			const result = await resolveAs(U1, ['Secret'])
+			// THEN RLS hides the row, so the name resolves to nothing
+			expect(result).toEqual({ ok: false, unknown: ['Secret'], ambiguous: [] })
+		})
+	})
+
+	describe('when several refs fail for different reasons at once', () => {
+		it('should collect the unknown and ambiguous failures together', async () => {
+			// GIVEN one bad name, one collision, and one good name in a single call
+			const result = await resolveAs(U1, ['ghost', 'Shared', 'OrgOnly'])
+			// THEN both failures come back so the caller fixes everything at once
+			expect(result.ok).toBe(false)
+			if (!result.ok) {
+				expect(result.unknown).toEqual(['ghost'])
+				expect(result.ambiguous.map(a => a.query)).toEqual(['Shared'])
+			}
+		})
+	})
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,12 @@
      apps/server HTTP API  (/webhooks/...)
 ```
 
+### Intelligence locus
+
+The primary intelligence is *external* — the MCP client (Claude, ChatGPT) the user talks to does most of the reasoning and generation (email bodies, chat replies, synthesis). apps/server is the data, tools, and authoring surface; it hosts *specialized* server-side intelligence only where it earns its place — `research` runs a server-side agent loop because it needs the budget/provider/cache and fan-out the external client can't run. So the leverage is being an excellent MCP context provider (tools, resources, prompts) plus a few deep specialized agents, not a general brain.
+
+Instruction templates follow the same split, *per surface*: the research agent enforces its resolved stack server-side, while client-composed surfaces (email, chat) expose their stack as advisory context the external client reads — via the `batuda://instructions/{agent}` resource — and follows when it composes.
+
 ---
 
 ## Packages
@@ -142,6 +148,16 @@ Bounded context for company research. Owns the research agent loop, provider por
 - `infrastructure/` — boot-time provider selection (`providers-live.ts` for the capability ports, `llm-live.ts` for LLM inference), stub providers for zero-cost local dev, real providers (Brave Search, Firecrawl, libreBORME, einforma, Hunter), cached search wrapper, OpenAI-compatible LLM layer via `@effect/ai-openai-compat`
 
 Provider selection uses `Layer.unwrap + Config.schema` — env vars pick the implementation at startup, same pattern as `EmailProviderLive`. Each provider is a `Layer<PortTag, E, R>` with R declaring its dependencies (stubs need nothing, real providers need `HttpClient` + `Config`).
+
+### `packages/instructions`
+
+Bounded context for AI instruction templates — named, reusable prompt blocks (org- or user-owned) plus per-(surface, scope) default stacks that compose an agent's prompt. Surface-neutral: the same template can apply to any agent. Layered as:
+
+- `domain/` — the code-defined surface set (`research`, `email`; a string set, not a DB enum, so adding a surface is a code change, never a migration), plus template/stack/donation value types. Exposed at the browser-safe `@batuda/instructions/domain` subpath so the web shares the same surface set.
+- pure logic — the precedence ladder (per-run override > user stack > org default > none), name/id reference resolution scoped by RLS, replace/extend stack composition, and the donation flow (personal → org)
+- `resolveInstructions` turns a run's (org, user, agent) into ordered prompt segments + a cache fingerprint; the table DDL lives with the app's migrations, not here
+
+The research agent enforces its resolved stack server-side; client-composed surfaces (email) read their stack as advisory context via the `batuda://instructions/{agent}` MCP resource. See §Intelligence locus.
 
 ### `packages/controllers`
 

--- a/docs/backend-research.md
+++ b/docs/backend-research.md
@@ -1144,16 +1144,20 @@ Same toolkit used by the research fiber, with two differences:
 1. `**research_sync**` — synchronous variant of `/research`:
 
 ```ts
-research_sync({ query, context?, schema_name?, max_wait_seconds?: 120 })
+research_sync({ query, context?, schema_name?, instructions?, max_wait_seconds?: 120 })
 ```
 
-Runs the fiber to completion or deadline, returns full findings inline. Better UX for tool-calling LLM hosts that don't want to poll.
+Runs the fiber to completion or deadline, returns full findings inline (with `applied_instructions`). Better UX for tool-calling LLM hosts that don't want to poll.
 2. `**start_research**` and `**get_research**` — async pair for Claude Desktop users doing long-running research:
 
 ```ts
-start_research({ query, context?, schema_name?, ... }) → { id }
-get_research({ id }) → { status, findings, cost }
+start_research({ query, context?, schema_name?, instructions? })
+  → { _tag: 'started', id, status, applied_instructions }
+  | { _tag: 'instruction_clarification', unknown, ambiguous }
+get_research({ id }) → { status, findings, cost, applied_instructions }
 ```
+
+`instructions` is a per-run override naming instruction templates by name or id (overriding the saved default stack); `applied_instructions` echoes the templates that shaped the run. An unresolved name returns the clarification instead of starting.
 
 ### 15.2 Prompts
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -108,6 +108,7 @@ apps/server/src/
 │   │   ├── company.ts        # batuda://company/{slug} (parameterized)
 │   │   ├── pipeline.ts       # batuda://pipeline (static)
 │   │   ├── document.ts       # batuda://document/{id} (parameterized)
+│   │   ├── instructions.ts   # batuda://instructions/{agent} (parameterized)
 │   │   └── research.ts       # batuda://research/{id} (parameterized)
 │   └── prompts/
 │       ├── _lang.ts           # LangParam + langDirective helper (ca/es/en)
@@ -116,7 +117,8 @@ apps/server/src/
 │       ├── research-designer.ts  # Research plan design prompt
 │       ├── daily-briefing.ts
 │       ├── proposal-draft.ts
-│       └── interaction-follow-up.ts
+│       ├── interaction-follow-up.ts
+│       └── instructions.ts    # apply-instruction, save-instruction
 ├── middleware/
 │   └── session.ts            # SessionMiddleware — validates Better Auth sessions
 ├── types/
@@ -398,8 +400,8 @@ The MCP server uses `effect/unstable/ai` — tools, resources, prompts, and elic
 ```
 McpToolsLive (src/mcp/server.ts)
 ├── Toolkits: companies, contacts, interactions, tasks, documents, pages, pipeline
-├── Resources: batuda://company/{slug}, batuda://pipeline, batuda://document/{id}
-└── Prompts: company-research, daily-briefing, proposal-draft, interaction-follow-up
+├── Resources: batuda://company/{slug}, batuda://pipeline, batuda://document/{id}, batuda://research/{id}, batuda://instructions/{agent}
+└── Prompts: company-research, research-designer, daily-briefing, proposal-draft, interaction-follow-up, apply-instruction, save-instruction
     │
     ├── stdio transport (mcp-stdio.ts) — local Claude Code
     └── HTTP transport (mcp/http.ts) — remote AI at /mcp on main server
@@ -486,7 +488,7 @@ export const CompanyResource = McpServer.resource`batuda://company/${slugParam}`
 
 ### Prompt definition pattern
 
-Prompts are parameterized templates with auto-completion. All prompts accept `lang: 'ca' | 'es' | 'en'` (default `en`) for multilingual output.
+Prompts are parameterized templates with auto-completion. The synthesis prompts (company-research, daily-briefing, proposal-draft, interaction-follow-up, research-designer) accept `lang: 'ca' | 'es' | 'en'` (default `en`) for multilingual output; the action prompts (apply-instruction, save-instruction) emit a directive in the caller's language instead.
 
 ```typescript
 import { McpServer } from 'effect/unstable/ai'

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -9,6 +9,10 @@
 		".": {
 			"types": "./src/index.ts",
 			"import": "./src/index.ts"
+		},
+		"./domain": {
+			"types": "./src/domain.ts",
+			"import": "./src/domain.ts"
 		}
 	},
 	"scripts": {

--- a/packages/instructions/src/domain.ts
+++ b/packages/instructions/src/domain.ts
@@ -1,10 +1,10 @@
 import { Schema } from 'effect'
 
 // The code-defined set of AI agents that compose instruction templates into
-// their prompt. Research today; email/chat/outreach later. Kept as a string
+// their prompt. Research and email today; chat/outreach later. Kept as a string
 // set (not a DB enum) so adding an agent is a code change, never a migration —
 // the same convention research uses for its schema_name registry.
-export const agents = ['research'] as const
+export const agents = ['research', 'email'] as const
 
 export type Agent = (typeof agents)[number]
 

--- a/packages/instructions/src/index.ts
+++ b/packages/instructions/src/index.ts
@@ -44,14 +44,20 @@ export type {
 } from './management-logic'
 export { classifyStackTemplates, decideTemplateEdit } from './management-logic'
 export type {
+	AmbiguousRef,
+	InstructionCandidate,
 	ResolvedInstructions,
 	ResolveInstructionsArgs,
+	ResolveRefsResult,
 	StackComposition,
 	StackSource,
 } from './resolver'
 export {
 	assembleSegments,
+	classifyInstructionRefs,
+	isUuidRef,
 	personalTemplatesInOrgStack,
 	pickStackSource,
+	resolveInstructionRefs,
 	resolveInstructions,
 } from './resolver'

--- a/packages/instructions/src/resolver.test.ts
+++ b/packages/instructions/src/resolver.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	assembleSegments,
+	classifyInstructionRefs,
 	dedupeKeepFirst,
+	isUuidRef,
 	personalTemplatesInOrgStack,
 	pickStackSource,
 } from './resolver'
+
+const UUID_A = '11111111-1111-4111-8111-111111111111'
+const UUID_B = '22222222-2222-4222-8222-222222222222'
 
 describe('pickStackSource', () => {
 	describe('when a per-run override is present', () => {
@@ -167,6 +172,162 @@ describe('dedupeKeepFirst', () => {
 		it('should return an empty list', () => {
 			// GIVEN no ids [resolver.ts:dedupeKeepFirst]
 			expect(dedupeKeepFirst([])).toEqual([])
+		})
+	})
+})
+
+describe('isUuidRef', () => {
+	describe('when the ref is a UUID', () => {
+		it('should treat it as an id regardless of case', () => {
+			// GIVEN a canonical and an upper-case UUID [resolver.ts:isUuidRef]
+			// THEN both read as ids
+			expect(isUuidRef(UUID_A)).toBe(true)
+			expect(isUuidRef(UUID_A.toUpperCase())).toBe(true)
+		})
+	})
+
+	describe('when the ref is a human name', () => {
+		it('should not mistake a name for an id', () => {
+			// GIVEN a plain template name [resolver.ts:isUuidRef]
+			// THEN it is not a UUID
+			expect(isUuidRef('sell to hotels')).toBe(false)
+			expect(isUuidRef('')).toBe(false)
+		})
+	})
+})
+
+describe('classifyInstructionRefs', () => {
+	describe('when a ref is already a UUID', () => {
+		it('should pass the id through without needing a name match', () => {
+			// GIVEN a UUID ref and no matching rows [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({ refs: [UUID_A], found: [] })
+			// THEN the id is taken at face value
+			expect(result).toEqual({ ok: true, templateIds: [UUID_A] })
+		})
+	})
+
+	describe('when a name matches exactly one readable template', () => {
+		it('should resolve the name to that template id', () => {
+			// GIVEN a single org template found by name [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({
+				refs: ['be terse'],
+				found: [{ id: UUID_A, name: 'be terse', ownerUserId: null }],
+			})
+			// THEN the name resolves to the id
+			expect(result).toEqual({ ok: true, templateIds: [UUID_A] })
+		})
+	})
+
+	describe('when ids and names are mixed', () => {
+		it('should preserve the requested order so stack order is kept', () => {
+			// GIVEN a name, then an id, then another name [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({
+				refs: ['be terse', UUID_B, 'sell to hotels'],
+				found: [
+					{ id: UUID_A, name: 'be terse', ownerUserId: 'user_1' },
+					{
+						id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+						name: 'sell to hotels',
+						ownerUserId: null,
+					},
+				],
+			})
+			// THEN ids come back in the order the caller asked for them
+			expect(result).toEqual({
+				ok: true,
+				templateIds: [UUID_A, UUID_B, 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'],
+			})
+		})
+	})
+
+	describe('when a name matches no readable template', () => {
+		it('should report it as unknown so the caller can fix the typo', () => {
+			// GIVEN a name with no matching row [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({ refs: ['nope'], found: [] })
+			// THEN the run is blocked and the unmatched name is surfaced
+			expect(result).toEqual({ ok: false, unknown: ['nope'], ambiguous: [] })
+		})
+	})
+
+	describe('when a name matches both a personal and an org template', () => {
+		it('should report the candidates with their scope so the AI can re-ask by id', () => {
+			// GIVEN one name shared by an org and a personal template
+			// [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({
+				refs: ['tone'],
+				found: [
+					{ id: UUID_A, name: 'tone', ownerUserId: null },
+					{ id: UUID_B, name: 'tone', ownerUserId: 'user_1' },
+				],
+			})
+			// THEN the collision is flagged with both candidates and their scope
+			expect(result).toEqual({
+				ok: false,
+				unknown: [],
+				ambiguous: [
+					{
+						query: 'tone',
+						candidates: [
+							{ id: UUID_A, name: 'tone', scope: 'org' },
+							{ id: UUID_B, name: 'tone', scope: 'personal' },
+						],
+					},
+				],
+			})
+		})
+	})
+
+	describe('when some refs are unknown and others ambiguous', () => {
+		it('should collect both failures in one response', () => {
+			// GIVEN an unknown name and an ambiguous name together
+			// [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({
+				refs: ['ghost', 'tone'],
+				found: [
+					{ id: UUID_A, name: 'tone', ownerUserId: null },
+					{ id: UUID_B, name: 'tone', ownerUserId: 'user_1' },
+				],
+			})
+			// THEN both reasons come back so the caller fixes everything at once
+			expect(result.ok).toBe(false)
+			if (!result.ok) {
+				expect(result.unknown).toEqual(['ghost'])
+				expect(result.ambiguous.map(a => a.query)).toEqual(['tone'])
+			}
+		})
+	})
+
+	describe('when no refs are given', () => {
+		it('should resolve to an empty id list', () => {
+			// GIVEN no refs [resolver.ts:classifyInstructionRefs]
+			// THEN there is nothing to override with
+			expect(classifyInstructionRefs({ refs: [], found: [] })).toEqual({
+				ok: true,
+				templateIds: [],
+			})
+		})
+	})
+
+	describe('when the same template is referenced twice', () => {
+		it('should collapse a repeated name to a single id', () => {
+			// GIVEN one name listed twice [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({
+				refs: ['be terse', 'be terse'],
+				found: [{ id: UUID_A, name: 'be terse', ownerUserId: null }],
+			})
+			// THEN the template appears once, so the prompt isn't doubled
+			expect(result).toEqual({ ok: true, templateIds: [UUID_A] })
+		})
+
+		it('should collapse a name listed alongside its own id', () => {
+			// GIVEN the same template referenced by name then by id
+			// [resolver.ts:classifyInstructionRefs]
+			const result = classifyInstructionRefs({
+				refs: ['be terse', UUID_A],
+				found: [{ id: UUID_A, name: 'be terse', ownerUserId: null }],
+			})
+			// THEN both refs resolve to one id, kept in first position
+			expect(result).toEqual({ ok: true, templateIds: [UUID_A] })
 		})
 	})
 })

--- a/packages/instructions/src/resolver.ts
+++ b/packages/instructions/src/resolver.ts
@@ -67,6 +67,84 @@ export const personalTemplatesInOrgStack = (
 ): ReadonlyArray<string> =>
 	items.filter(item => item.ownerUserId !== null).map(item => item.templateId)
 
+// ── Per-run override refs (names or ids) ───────────────────────────────────
+
+// A per-run override lets a caller name templates by human name OR id. This is
+// the surface a chat AI uses to apply a specific instruction to one run without
+// knowing its UUID. An id passes straight through; a name is matched against the
+// templates the actor can read (RLS scopes that to the org's plus their own). A
+// name with no match is reported back so the caller can fix the typo, and a name
+// that matches more than one template (e.g. a personal and an org template share
+// a name) is ambiguous — its candidates come back with their scope so the AI can
+// re-ask with the exact id instead of silently running the wrong one.
+
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export const isUuidRef = (ref: string): boolean => UUID_RE.test(ref)
+
+export interface InstructionCandidate {
+	readonly id: string
+	readonly name: string
+	readonly scope: 'personal' | 'org'
+}
+
+export interface AmbiguousRef {
+	readonly query: string
+	readonly candidates: ReadonlyArray<InstructionCandidate>
+}
+
+export type ResolveRefsResult =
+	| { readonly ok: true; readonly templateIds: ReadonlyArray<string> }
+	| {
+			readonly ok: false
+			readonly unknown: ReadonlyArray<string>
+			readonly ambiguous: ReadonlyArray<AmbiguousRef>
+	  }
+
+// Pure resolution: given the refs (order preserved, since stack order shapes the
+// prompt) and the templates found by name, map each ref to a single id or record
+// why it couldn't resolve. Ids are taken at face value; names that match exactly
+// one template resolve, the rest are split into unknown vs ambiguous.
+export const classifyInstructionRefs = (args: {
+	readonly refs: ReadonlyArray<string>
+	readonly found: ReadonlyArray<{
+		readonly id: string
+		readonly name: string
+		readonly ownerUserId: string | null
+	}>
+}): ResolveRefsResult => {
+	const byName = new Map<string, Array<InstructionCandidate>>()
+	for (const row of args.found) {
+		const scope = row.ownerUserId === null ? 'org' : 'personal'
+		const list = byName.get(row.name) ?? []
+		list.push({ id: row.id, name: row.name, scope })
+		byName.set(row.name, list)
+	}
+
+	const templateIds: Array<string> = []
+	const unknown: Array<string> = []
+	const ambiguous: Array<AmbiguousRef> = []
+	for (const ref of args.refs) {
+		if (isUuidRef(ref)) {
+			templateIds.push(ref)
+			continue
+		}
+		const candidates = byName.get(ref) ?? []
+		const [first] = candidates
+		if (!first) unknown.push(ref)
+		else if (candidates.length === 1) templateIds.push(first.id)
+		else ambiguous.push({ query: ref, candidates })
+	}
+
+	// Collapse repeats so the same template can't appear twice in the prompt —
+	// whether the caller listed a name twice, an id twice, or a name alongside its
+	// own id (both resolve to one id). First position wins, matching stack order.
+	return unknown.length > 0 || ambiguous.length > 0
+		? { ok: false, unknown, ambiguous }
+		: { ok: true, templateIds: dedupeKeepFirst(templateIds) }
+}
+
 // ── DB resolution (exercised end-to-end when research is wired) ────────────
 
 export interface ResolveInstructionsArgs {
@@ -204,4 +282,32 @@ export const resolveInstructions = (
 			templateNames: ordered.map(row => row.name),
 			source,
 		}
+	})
+
+// Turn a caller's per-run override (template names or ids) into the ordered ids
+// resolveInstructions expects. Must run inside the request transaction: the name
+// lookup reads through RLS, so an actor only ever matches the org's templates and
+// their own. Returns the ids on success, or the unresolved names so the caller
+// can re-ask (a typo) or disambiguate (a name shared by two templates) before any
+// run starts.
+export const resolveInstructionRefs = (
+	refs: ReadonlyArray<string>,
+): Effect.Effect<ResolveRefsResult, SqlError.SqlError, SqlClient.SqlClient> =>
+	Effect.gen(function* () {
+		if (refs.length === 0) return { ok: true, templateIds: [] }
+		const sql = yield* SqlClient.SqlClient
+		const names = [...new Set(refs.filter(ref => !isUuidRef(ref)))]
+		const found =
+			names.length === 0
+				? []
+				: yield* sql<{
+						id: string
+						name: string
+						ownerUserId: string | null
+					}>`
+						SELECT id, name, owner_user_id
+						FROM instruction_templates
+						WHERE name IN ${sql.in(names)}
+					`
+		return classifyInstructionRefs({ refs, found })
 	})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@batuda/email':
         specifier: workspace:*
         version: link:../../packages/email
+      '@batuda/instructions':
+        specifier: workspace:*
+        version: link:../../packages/instructions
       '@batuda/research':
         specifier: workspace:*
         version: link:../../packages/research


### PR DESCRIPTION
## What

Makes the already-built instruction-template feature usable from the surfaces it was designed for. The templates, per-surface default stacks, and donations shipped with a management API + settings UI, but the **runtime** path that feeds them to an AI was silent — only the invisible default stack ever fired, and there was no web way to configure anything but research. This wires up the runtime affordances (MCP `server` + the `instructions` package) and adds a per-surface selector to the settings UI (`internal`).

Design spine: *instructions are per surface* — the research agent enforces its stack server-side; client-composed surfaces (email) expose theirs as advisory context the external AI reads. See the new **Intelligence locus** section in `docs/architecture.md`.

Closes #150.

## Changes

- **Research MCP override by name.** Replaced the undocumented `template_ids: Uuid[]` with `instructions: string[]` accepting template **names or ids**, resolved server-side and scoped by RLS to the org's templates plus the caller's own. A name that's unknown or matches two templates returns a `{_tag:'instruction_clarification'}` with candidates instead of running, so the AI self-corrects.
- **Visible result.** `start_research` now returns `{_tag:'started', id, status, applied_instructions}`; `get_research` / `research_sync` surface the same `applied_instructions`, so the human sees which instructions fired.
- **Standard MCP affordances.** Added a `batuda://instructions/{agent}` resource (the menu + active stack) and two user-controlled prompts, `apply-instruction` / `save-instruction`. Email tools point at the email resource (they can't enforce — the client composes the body).
- **`email` surface registered**, and the surface set single-sourced behind a browser-safe `@batuda/instructions/domain` subpath so the web shares it.
- **Web per-surface selector.** A Research/Email toggle on the personal + org instruction settings, so each surface's default stack is configurable in the UI (was hardcoded to research). Genericized the copy, linked the control to its heading for screen readers, and let the section header wrap on mobile.
- **Docs.** `architecture.md` gains a `packages/instructions` entry + the Intelligence-locus model; `backend.md` / `backend-research.md` updated for the new resource/prompts and the `start_research` shape.

## Impact

- **MCP wire-shape — clean break (pre-prod, no shim).** `start_research`'s `template_ids` → `instructions`, and its success is now a union (`started` | `instruction_clarification`). MCP-only; the **HTTP** research path is untouched (still takes `template_ids`).
- **New MCP surface** — one resource + two prompts registered in `McpToolsLive`; three research tool descriptions rewritten.
- **No migration, no new env var, no RLS-policy change.** Name→id resolution reads through the *existing* instruction-templates RLS (integration-tested: an actor can't resolve another member's template by name).
- **New workspace dep** — `apps/internal` → `@batuda/instructions` (only the browser-safe `/domain` subpath; the SQL modules never reach the client bundle).
- **Email is advisory, by design** — no server-side enforcement, because generation is client-side (intelligence-locus).

## Review guide

- **Riskiest:** the `start_research` clean break (renamed param + union success). Everything downstream of `resolveInstructionRefs` is the new logic.
- **Security-relevant:** `packages/instructions/src/resolver.ts` name resolution — verify it can't cross tenants. Covered by `resolve-instruction-refs.integration.test.ts` (name→id, id passthrough, org/personal collision → ambiguous, RLS-hidden name → unknown).
- **Rebase note:** this rebased onto an MCP-envelope PR that landed under me; my new tools return single objects/unions (not lists), so that envelope convention doesn't apply — auto-merge was clean and typechecks.
- **Skip-able:** the docs and i18n catalog diffs are mechanical.

## Screenshots

_Per-surface selector on the personal instruction settings — desktop overview and mobile (the Research/Email toggle wraps below the title, and the copy is surface-neutral)._

![Desktop — personal instruction settings](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-157/pr-prof-desktop.webp)

![Mobile — the Research/Email selector wraps below the title](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-157/pr-prof-mobile.webp)

## Tests

- **Unit** — `classifyInstructionRefs`: UUID passthrough, name→id, mixed-order, unknown, ambiguous-with-scope, combined failures, dedupe of repeats.
- **Integration (live RLS)** — `resolveInstructionRefs`: name resolves only within the actor's readable set, id passthrough, org/personal name collision → scoped candidates, another member's template → unknown.

## Verification

- Gates green: `pnpm install` (clean lockfile) → `check-types` (12/12) + `test` (18/18 tasks; 487 server tests) → `build` (12/12).
- **Live stack** — logged into the running worktree, confirmed the settings page renders with a working Research/Email selector and the per-surface default stack (screenshots above).
- a11y review + readability pass run on the web changes.

## Deferred

- A focused **a11y / design-system pass**: single-select semantics (toggle → tabs/radiogroup), the pre-existing `ModeRow` keyboard contract, and shared touch-target / focus-ring tokens — they span shared primitives and other features, so they deserve consistent app-wide treatment rather than a one-feature patch.
