### PR TITLE
ai(mcp): switch the Neon MCP server to the hosted OAuth endpoint

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -20,11 +20,8 @@
 			"url": "https://mcp.eu1.honeycomb.io/mcp"
 		},
 		"neon": {
-			"command": "sh",
-			"args": [
-				"-c",
-				"exec npx -y @neondatabase/mcp-server-neon start \"$NEON_API_KEY\""
-			]
+			"type": "http",
+			"url": "https://mcp.neon.tech/mcp"
 		}
 	}
 }

--- a/opencode.json
+++ b/opencode.json
@@ -22,12 +22,8 @@
 			"url": "https://mcp.eu1.honeycomb.io/mcp"
 		},
 		"neon": {
-			"type": "local",
-			"command": [
-				"sh",
-				"-c",
-				"exec npx -y @neondatabase/mcp-server-neon start \"$NEON_API_KEY\""
-			]
+			"type": "remote",
+			"url": "https://mcp.neon.tech/mcp"
 		}
 	},
 	"permission": {


### PR DESCRIPTION
## What

Switches the Neon MCP server from the local `npx` stdio process (needs `NEON_API_KEY` in the shell) to Neon's **hosted OAuth** endpoint `https://mcp.neon.tech/mcp` — matching the Honeycomb OAuth switch (#156). Browser sign-in on first connect, no key to store.

## Changes

- `.mcp.json` (Claude Code): `type: http` + the hosted URL.
- `opencode.json`: `type: remote` + the hosted URL (opencode auto-detects the 401 and starts OAuth).

## Impact

- AI tooling config only — no code, no runtime, no deploy.
- The `NEON_API_KEY` **repo secret is untouched** (used elsewhere/CI); this only drops the shell-env dependency for the local dev MCP.

## Verification

- Both files valid JSON. OAuth exercised on first connect (browser Authorize).
