### PR TITLE
fix(research): unblock research runs on OpenAI structured output

### DIFF
--- a/packages/research/src/application/openai-structured-output.test.ts
+++ b/packages/research/src/application/openai-structured-output.test.ts
@@ -1,0 +1,54 @@
+import { OpenAiStructuredOutput, Tool } from 'effect/unstable/ai'
+import { describe, expect, it } from 'vitest'
+
+import { schemaRegistry } from './schemas/index'
+import { researchToolkit } from './tools'
+
+describe('researchToolkit', () => {
+	it('should register at least one tool', () => {
+		// GIVEN the live toolkit
+		// THEN the loop below covers a non-empty set — an empty toolkit would
+		// otherwise register zero "it" blocks and pass with no coverage
+		expect(Object.keys(researchToolkit.tools).length).toBeGreaterThan(0)
+	})
+
+	describe('when converting each Phase-1 tool schema for OpenAI structured output', () => {
+		for (const tool of Object.values(researchToolkit.tools)) {
+			it(`should convert "${tool.name}" params without throwing`, () => {
+				// GIVEN a Phase-1 tool's parameter schema
+				// WHEN it is converted through the same path prepareTools uses (Tool.getJsonSchema + toCodecOpenAI)
+				// THEN it does not throw — a Schema.optional field would hit "Unsupported AST Undefined"
+				expect(() =>
+					Tool.getJsonSchema(tool, {
+						transformer: OpenAiStructuredOutput.toCodecOpenAI,
+					}),
+				).not.toThrow()
+			})
+		}
+	})
+})
+
+describe('schemaRegistry', () => {
+	it('should register at least one schema', () => {
+		// GIVEN the live registry
+		// THEN the loop below covers a non-empty set — an empty registry would
+		// otherwise register zero "it" blocks and pass with no coverage
+		expect(Object.keys(schemaRegistry).length).toBeGreaterThan(0)
+	})
+
+	describe('when converting each Phase-2 output schema for OpenAI structured output', () => {
+		for (const [name, schema] of Object.entries(schemaRegistry)) {
+			it(`should convert "${name}" without throwing`, () => {
+				// GIVEN a registered Phase-2 output schema
+				// WHEN it is converted through the same path generateObject uses (Tool.getJsonSchemaFromSchema + toCodecOpenAI)
+				// THEN it does not throw — a Schema.optional field would hit "Unsupported AST
+				// Undefined", and a Schema.Unknown field "Unsupported AST Unknown"
+				expect(() =>
+					Tool.getJsonSchemaFromSchema(schema, {
+						transformer: OpenAiStructuredOutput.toCodecOpenAI,
+					}),
+				).not.toThrow()
+			})
+		}
+	})
+})

--- a/packages/research/src/application/schemas/company-enrichment-v1.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.ts
@@ -2,47 +2,47 @@ import { Schema } from 'effect'
 
 const Citation = Schema.Struct({
 	source_id: Schema.String,
-	quote: Schema.optional(Schema.String),
-	confidence: Schema.optional(Schema.Number),
+	quote: Schema.optionalKey(Schema.String),
+	confidence: Schema.optionalKey(Schema.Number),
 })
 
 export const CompanyEnrichmentV1Schema = Schema.Struct({
 	enrichment: Schema.Struct({
-		industry: Schema.optional(Schema.String),
-		size_range: Schema.optional(Schema.String),
-		pain_points: Schema.optional(Schema.String),
-		current_tools: Schema.optional(Schema.String),
-		products_fit: Schema.optional(Schema.Array(Schema.String)),
-		tags: Schema.optional(Schema.Array(Schema.String)),
-		location: Schema.optional(Schema.String),
-		region: Schema.optional(Schema.String),
-		address: Schema.optional(Schema.String),
-		latitude: Schema.optional(Schema.Number),
-		longitude: Schema.optional(Schema.Number),
+		industry: Schema.optionalKey(Schema.String),
+		size_range: Schema.optionalKey(Schema.String),
+		pain_points: Schema.optionalKey(Schema.String),
+		current_tools: Schema.optionalKey(Schema.String),
+		products_fit: Schema.optionalKey(Schema.Array(Schema.String)),
+		tags: Schema.optionalKey(Schema.Array(Schema.String)),
+		location: Schema.optionalKey(Schema.String),
+		region: Schema.optionalKey(Schema.String),
+		address: Schema.optionalKey(Schema.String),
+		latitude: Schema.optionalKey(Schema.Number),
+		longitude: Schema.optionalKey(Schema.Number),
 		citations: Schema.Array(Citation),
 	}),
-	competitors: Schema.optional(
+	competitors: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				name: Schema.String,
-				website: Schema.optional(Schema.String),
-				why: Schema.optional(Schema.String),
+				website: Schema.optionalKey(Schema.String),
+				why: Schema.optionalKey(Schema.String),
 				citations: Schema.Array(Citation),
 			}),
 		),
 	),
-	contacts: Schema.optional(
+	contacts: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				name: Schema.String,
-				role: Schema.optional(Schema.String),
-				email: Schema.optional(Schema.String),
-				phone: Schema.optional(Schema.String),
+				role: Schema.optionalKey(Schema.String),
+				email: Schema.optionalKey(Schema.String),
+				phone: Schema.optionalKey(Schema.String),
 				citations: Schema.Array(Citation),
 			}),
 		),
 	),
-	discovered_existing: Schema.optional(
+	discovered_existing: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
@@ -51,23 +51,27 @@ export const CompanyEnrichmentV1Schema = Schema.Struct({
 			}),
 		),
 	),
-	proposed_updates: Schema.optional(
+	proposed_updates: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
 				subject_id: Schema.String,
 				expected_version: Schema.Number,
-				fields: Schema.Unknown,
+				// Open-ended field map; sent as a JSON-encoded string because OpenAI
+				// structured output has no "any shape" type — decodes back to an
+				// object automatically.
+				fields: Schema.UnknownFromJsonString,
 				reason: Schema.String,
 				citations: Schema.Array(Citation),
 			}),
 		),
 	),
-	pending_paid_actions: Schema.optional(
+	pending_paid_actions: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				tool: Schema.String,
-				args: Schema.Unknown,
+				// Same open-ended-map rationale as `fields` above.
+				args: Schema.UnknownFromJsonString,
 				estimated_cents: Schema.Number,
 				reason: Schema.String,
 			}),

--- a/packages/research/src/application/schemas/competitor-scan-v1.ts
+++ b/packages/research/src/application/schemas/competitor-scan-v1.ts
@@ -2,31 +2,31 @@ import { Schema } from 'effect'
 
 const Citation = Schema.Struct({
 	source_id: Schema.String,
-	quote: Schema.optional(Schema.String),
-	confidence: Schema.optional(Schema.Number),
+	quote: Schema.optionalKey(Schema.String),
+	confidence: Schema.optionalKey(Schema.Number),
 })
 
 export const CompetitorScanV1Schema = Schema.Struct({
 	competitors: Schema.Array(
 		Schema.Struct({
 			name: Schema.String,
-			website: Schema.optional(Schema.String),
-			description: Schema.optional(Schema.String),
-			strengths: Schema.optional(Schema.Array(Schema.String)),
-			weaknesses: Schema.optional(Schema.Array(Schema.String)),
-			overlap: Schema.optional(Schema.String),
+			website: Schema.optionalKey(Schema.String),
+			description: Schema.optionalKey(Schema.String),
+			strengths: Schema.optionalKey(Schema.Array(Schema.String)),
+			weaknesses: Schema.optionalKey(Schema.Array(Schema.String)),
+			overlap: Schema.optionalKey(Schema.String),
 			citations: Schema.Array(Citation),
 		}),
 	),
-	market_summary: Schema.optional(
+	market_summary: Schema.optionalKey(
 		Schema.Struct({
 			total_competitors_found: Schema.Number,
-			market_maturity: Schema.optional(Schema.String),
-			key_differentiators: Schema.optional(Schema.Array(Schema.String)),
+			market_maturity: Schema.optionalKey(Schema.String),
+			key_differentiators: Schema.optionalKey(Schema.Array(Schema.String)),
 			citations: Schema.Array(Citation),
 		}),
 	),
-	discovered_existing: Schema.optional(
+	discovered_existing: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
@@ -35,23 +35,27 @@ export const CompetitorScanV1Schema = Schema.Struct({
 			}),
 		),
 	),
-	proposed_updates: Schema.optional(
+	proposed_updates: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
 				subject_id: Schema.String,
 				expected_version: Schema.Number,
-				fields: Schema.Unknown,
+				// Open-ended field map; sent as a JSON-encoded string because OpenAI
+				// structured output has no "any shape" type — decodes back to an
+				// object automatically.
+				fields: Schema.UnknownFromJsonString,
 				reason: Schema.String,
 				citations: Schema.Array(Citation),
 			}),
 		),
 	),
-	pending_paid_actions: Schema.optional(
+	pending_paid_actions: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				tool: Schema.String,
-				args: Schema.Unknown,
+				// Same open-ended-map rationale as `fields` above.
+				args: Schema.UnknownFromJsonString,
 				estimated_cents: Schema.Number,
 				reason: Schema.String,
 			}),

--- a/packages/research/src/application/schemas/contact-discovery-v1.ts
+++ b/packages/research/src/application/schemas/contact-discovery-v1.ts
@@ -4,34 +4,34 @@ import { VerificationVerdict } from '../../domain/types'
 
 const Citation = Schema.Struct({
 	source_id: Schema.String,
-	quote: Schema.optional(Schema.String),
-	confidence: Schema.optional(Schema.Number),
+	quote: Schema.optionalKey(Schema.String),
+	confidence: Schema.optionalKey(Schema.Number),
 })
 
 export const ContactDiscoveryV1Schema = Schema.Struct({
 	contacts: Schema.Array(
 		Schema.Struct({
 			name: Schema.String,
-			role: Schema.optional(Schema.String),
-			is_decision_maker: Schema.optional(Schema.Boolean),
+			role: Schema.optionalKey(Schema.String),
+			is_decision_maker: Schema.optionalKey(Schema.Boolean),
 			// Open channel list (email, phone, linkedin, x, website, bluesky, …).
 			// Only the email channel carries a deliverability verdict + confidence.
-			channels: Schema.optional(
+			channels: Schema.optionalKey(
 				Schema.Array(
 					Schema.Struct({
 						kind: Schema.String,
 						value: Schema.String,
-						verification: Schema.optional(VerificationVerdict),
-						confidence: Schema.optional(Schema.Number),
-						is_primary: Schema.optional(Schema.Boolean),
+						verification: Schema.optionalKey(VerificationVerdict),
+						confidence: Schema.optionalKey(Schema.Number),
+						is_primary: Schema.optionalKey(Schema.Boolean),
 					}),
 				),
 			),
-			notes: Schema.optional(Schema.String),
+			notes: Schema.optionalKey(Schema.String),
 			citations: Schema.Array(Citation),
 		}),
 	),
-	discovered_existing: Schema.optional(
+	discovered_existing: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
@@ -40,23 +40,27 @@ export const ContactDiscoveryV1Schema = Schema.Struct({
 			}),
 		),
 	),
-	proposed_updates: Schema.optional(
+	proposed_updates: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
 				subject_id: Schema.String,
 				expected_version: Schema.Number,
-				fields: Schema.Unknown,
+				// Open-ended field map; sent as a JSON-encoded string because OpenAI
+				// structured output has no "any shape" type — decodes back to an
+				// object automatically.
+				fields: Schema.UnknownFromJsonString,
 				reason: Schema.String,
 				citations: Schema.Array(Citation),
 			}),
 		),
 	),
-	pending_paid_actions: Schema.optional(
+	pending_paid_actions: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				tool: Schema.String,
-				args: Schema.Unknown,
+				// Same open-ended-map rationale as `fields` above.
+				args: Schema.UnknownFromJsonString,
 				estimated_cents: Schema.Number,
 				reason: Schema.String,
 			}),

--- a/packages/research/src/application/schemas/freeform.ts
+++ b/packages/research/src/application/schemas/freeform.ts
@@ -2,28 +2,32 @@ import { Schema } from 'effect'
 
 /** Freeform research — no structured output, markdown brief only. */
 export const FreeformSchema = Schema.Struct({
-	proposed_updates: Schema.optional(
+	proposed_updates: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
 				subject_id: Schema.String,
 				expected_version: Schema.Number,
-				fields: Schema.Unknown,
+				// Open-ended field map; sent as a JSON-encoded string because OpenAI
+				// structured output has no "any shape" type — decodes back to an
+				// object automatically.
+				fields: Schema.UnknownFromJsonString,
 				reason: Schema.String,
 				citations: Schema.Array(
 					Schema.Struct({
 						source_id: Schema.String,
-						quote: Schema.optional(Schema.String),
+						quote: Schema.optionalKey(Schema.String),
 					}),
 				),
 			}),
 		),
 	),
-	pending_paid_actions: Schema.optional(
+	pending_paid_actions: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				tool: Schema.String,
-				args: Schema.Unknown,
+				// Same open-ended-map rationale as `fields` above.
+				args: Schema.UnknownFromJsonString,
 				estimated_cents: Schema.Number,
 				reason: Schema.String,
 			}),

--- a/packages/research/src/application/schemas/prospect-scan-v1.ts
+++ b/packages/research/src/application/schemas/prospect-scan-v1.ts
@@ -2,24 +2,24 @@ import { Schema } from 'effect'
 
 const Citation = Schema.Struct({
 	source_id: Schema.String,
-	quote: Schema.optional(Schema.String),
-	confidence: Schema.optional(Schema.Number),
+	quote: Schema.optionalKey(Schema.String),
+	confidence: Schema.optionalKey(Schema.Number),
 })
 
 export const ProspectScanV1Schema = Schema.Struct({
 	prospects: Schema.Array(
 		Schema.Struct({
 			name: Schema.String,
-			website: Schema.optional(Schema.String),
-			tax_id: Schema.optional(Schema.String),
-			industry: Schema.optional(Schema.String),
-			region: Schema.optional(Schema.String),
+			website: Schema.optionalKey(Schema.String),
+			tax_id: Schema.optionalKey(Schema.String),
+			industry: Schema.optionalKey(Schema.String),
+			region: Schema.optionalKey(Schema.String),
 			why_relevant: Schema.String,
-			pain_indicators: Schema.optional(Schema.Array(Schema.String)),
+			pain_indicators: Schema.optionalKey(Schema.Array(Schema.String)),
 			citations: Schema.Array(Citation),
 		}),
 	),
-	discovered_existing: Schema.optional(
+	discovered_existing: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
@@ -28,23 +28,27 @@ export const ProspectScanV1Schema = Schema.Struct({
 			}),
 		),
 	),
-	proposed_updates: Schema.optional(
+	proposed_updates: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
 				subject_id: Schema.String,
 				expected_version: Schema.Number,
-				fields: Schema.Unknown,
+				// Open-ended field map; sent as a JSON-encoded string because OpenAI
+				// structured output has no "any shape" type — decodes back to an
+				// object automatically.
+				fields: Schema.UnknownFromJsonString,
 				reason: Schema.String,
 				citations: Schema.Array(Citation),
 			}),
 		),
 	),
-	pending_paid_actions: Schema.optional(
+	pending_paid_actions: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				tool: Schema.String,
-				args: Schema.Unknown,
+				// Same open-ended-map rationale as `fields` above.
+				args: Schema.UnknownFromJsonString,
 				estimated_cents: Schema.Number,
 				reason: Schema.String,
 			}),

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -35,14 +35,14 @@ const WebSearchParams = Schema.Struct({
 	query: Schema.String.annotate({
 		description: 'Search query; concise keywords work best',
 	}),
-	limit: Schema.optional(Schema.Number).annotate({
+	limit: Schema.optionalKey(Schema.Number).annotate({
 		description: 'Max results to return (default 10)',
 	}),
-	recency_days: Schema.optional(Schema.Number).annotate({
+	recency_days: Schema.optionalKey(Schema.Number).annotate({
 		description:
 			'Restrict to results published within the last N days. Omit for no filter.',
 	}),
-	location: Schema.optional(Schema.String).annotate({
+	location: Schema.optionalKey(Schema.String).annotate({
 		description: 'Geographic locale hint (e.g. "ES", "es-ES")',
 	}),
 })
@@ -58,7 +58,7 @@ const ExtractStructuredParams = Schema.Struct({
 	schema_name: Schema.String.annotate({
 		description: `Name of a registered schema. One of: ${Object.keys(schemaRegistry).join(', ')}`,
 	}),
-	prompt: Schema.optional(Schema.String).annotate({
+	prompt: Schema.optionalKey(Schema.String).annotate({
 		description:
 			'Optional extra guidance for the extractor (e.g. "focus on revenue figures").',
 	}),
@@ -68,10 +68,10 @@ const RegistryLookupParams = Schema.Struct({
 	country: Schema.Literals(SUPPORTED_COUNTRIES).annotate({
 		description: 'ISO country code; determines which registry to query',
 	}),
-	query: Schema.optional(Schema.String).annotate({
+	query: Schema.optionalKey(Schema.String).annotate({
 		description: 'Company name or fuzzy search string',
 	}),
-	tax_id: Schema.optional(Schema.String).annotate({
+	tax_id: Schema.optionalKey(Schema.String).annotate({
 		description: 'National tax id (e.g. ES CIF/NIF) — more precise than query',
 	}),
 })


### PR DESCRIPTION
Fixes #159

## What

Fixes the research feature (`packages/research`) being 100% broken in prod: every `research_sync`/`start_research` run failed instantly (`costCents: 0`) because the toolkit and output schemas used two Effect Schema forms that OpenAI's structured-output converter (`toCodecOpenAI`, also used by the OpenAI-compatible endpoint that serves prod's Qwen3-32B) rejects outright — `Schema.optional(X)` and `Schema.Unknown`. The crash happens during request construction, before any network call, so it reproduced for every `schema_name` and every instruction template.

## The fix

- **`Schema.optional` → `Schema.optionalKey`** across the Phase-1 toolkit params (`application/tools.ts`) and all five Phase-2 registry output schemas (`application/schemas/*.ts`). `Schema.optional(X)` compiles to `X | undefined`, an explicit `Undefined` AST node the converter's walker throws on; `Schema.optionalKey(X)` marks the key omittable without adding that node — same "may be absent" behavior, OpenAI-compatible.
- **`Schema.Unknown` → `Schema.UnknownFromJsonString`** for the two open-ended fields (`proposed_updates[].fields`, `pending_paid_actions[].args`) in the same five schema files. This was a second, undocumented crash the issue didn't catch (`Unsupported AST Unknown`) — my regression test surfaced it the moment I wrote it, before this fix Phase 2 would still have crashed after Phase 1 was unblocked. `UnknownFromJsonString`'s wire type is a plain string (OpenAI-compatible); the model emits a JSON-encoded string and Effect's own `generateObject` decode transparently parses it back into the original value — no downstream code changes needed.
- **New regression test** (`openai-structured-output.test.ts`) that runs the toolkit and every registered schema through the exact conversion functions (`Tool.getJsonSchema`/`Tool.getJsonSchemaFromSchema` with `transformer: toCodecOpenAI`) that `prepareTools`/`generateObject` use in production, so either failure mode fails CI instead of prod. Includes non-emptiness sanity checks so the suite can't silently pass with zero coverage if the toolkit/registry ever resolved empty.

## Impact

- **Research feature goes from 0% functional to expected-functional once deployed** — real LLM token spend (and metered registry-lookup spend, ~€0.29/lookup, where a live provider is configured) resumes as runs actually execute instead of failing instantly for free. This PR only lands the fix on `main`; a `/release server` deploy is still required to restore the feature in prod.
- **Firecrawl's `extract_structured` tool sees a different declared schema** for the same two fields, via the same registry-schema objects (a separate conversion path, `Schema.toJsonSchemaDocument`, unrelated to the OpenAI crash this PR fixes — confirmed it never crashed either way). Verified low-risk: these fields are Phase-2-synthesized workflow metadata, not naturally present in scraped page content, and the tool handler doesn't decode Firecrawl's raw result against the schema regardless of this change (a pre-existing gap — see Review guide).
- **New, narrow decode-failure mode**: unlike `Schema.Unknown` (never fails to decode), `Schema.UnknownFromJsonString` can fail if the model emits syntactically invalid nested JSON as the string content. Confirmed this is an incremental widening of an already-existing all-or-nothing decode behavior (every other required field already had this property), mitigated by existing retry/fallback-vendor infrastructure, and an unavoidable trade-off — `Schema.Unknown` was strictly worse (guaranteed, deterministic crash on every call).
- No migration, RLS, auth, env var, or CORS changes.

## Review guide

- Riskiest part: the `Schema.Unknown` → `Schema.UnknownFromJsonString` swap, since it's the first use of `UnknownFromJsonString` in this codebase (the `optional` → `optionalKey` swap is a well-trodden pattern already used elsewhere). I verified the AST mechanism from the vendored effect source, round-tripped realistic payloads (nested objects/arrays, unicode, quotes, backslashes) through the full codec, and ran an 8-angle multi-agent code review with adversarial verification on every surviving candidate — no correctness bugs found.
- **Deferred, not fixed here:** the five schema files under `application/schemas/` duplicate `Citation`/`proposed_updates`/`pending_paid_actions`/`discovered_existing` verbatim — this fix had to hand-edit each copy. Worth extracting into a shared module, but that refactor has its own risk: `firecrawl/extract.ts` explicitly does not inline `$defs`, so a shared/referenced schema could silently break that path — deserves its own PR with its own verification.
- **Deferred, not fixed here:** `extract_structured`'s handler (and a second, unrelated tool, `web_read`) never decode the provider's raw result against the schema despite a doc comment implying they should (`ports.ts:102`) — pre-existing, broader than this bug.
- The remaining ~58 `Schema.optional(` sites in `domain/types.ts`/`infrastructure/*` are intentionally untouched: confirmed by tracing `prepareTools`/`prepareResponseFormat` in the vendored effect source that only a tool's `parametersSchema` and an explicitly-passed `generateObject` schema ever reach `toCodecOpenAI` — these are provider-response codecs (Brave/Companies House/Firecrawl/Hunter/LibreBORME) that never do.

## Tests

- `openai-structured-output.test.ts` (new, rides with the logic fix): asserts the toolkit and every registered schema convert without throwing via the production code path, plus non-emptiness guards on both collections.

## Verification

- `pnpm install`, `pnpm -w check-types` (13/13), `pnpm -w test` (all green, including integration suites via the pre-push hook), `pnpm -w build` (13/13) — all passed, both before and after the final review-driven test hardening.
- Booted the server against this worktree's local stack (stub providers) and confirmed it starts cleanly with no regressions from this change.
- Did not run a live OpenAI/Qwen call — that requires real, billed credentials I don't have locally, and would test model behavior rather than the schema-compatibility bug this PR fixes. The regression test exercises the literal crash point (schema-to-JSON-Schema conversion, which fails before any network request) with full fidelity — confirmed empirically by reverting individual sites and observing the exact original errors reproduce.

## Deferred

- Extracting shared schema fragments across the five `application/schemas/*.ts` files (see Review guide — has its own `$defs`/Firecrawl risk to work out first).
- Implementing the `extract_structured`/`web_read` "caller decodes the provider result" contract that's currently just an aspirational comment.
