### PR TITLE
fix(server): return 404 for an unknown MCP session so clients recover

### DIFF
--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -62,6 +62,78 @@ const bearerChallenge = (
 		},
 	)
 
+// A redeploy starts a fresh process whose in-memory MCP session table is empty,
+// so effect's McpServer no longer knows the session id a connected client keeps
+// sending and raises "Mcp-Session-Id does not exist". It runs tool calls in the
+// background and folds that failure into a normal HTTP 200 body, so the
+// client is never told to re-initialize and replays the dead id forever. The MCP
+// spec's fix is to answer 404 (a compliant client then drops the session and
+// re-`initialize`s), so we detect that failure in McpServer's own reply and swap
+// it for a 404 — keeping McpServer the sole owner of sessions. Matching its
+// message is the only signal it exposes.
+const UNKNOWN_SESSION_DIE_MESSAGE = 'Mcp-Session-Id does not exist'
+
+// Reused across every MCP reply rather than reallocated per request.
+const mcpBodyDecoder = new TextDecoder()
+
+// True when a decoded JSON-RPC reply carries McpServer's unknown-session
+// failure, not a tool result that merely echoed the same phrase. McpServer
+// buries that failure deep in the reply's error cause, shaped like
+// `{ error: { data: [{ _tag: 'Die', defect: { message } }] } }` — so we check
+// exactly that spot. Handles a single reply or a batched array of them.
+const isUnknownSessionErrorBody = (parsed: unknown): boolean => {
+	const replies = Array.isArray(parsed) ? parsed : [parsed]
+	return replies.some(reply => {
+		const failures = (reply as { error?: { data?: unknown } } | null)?.error
+			?.data
+		return (
+			Array.isArray(failures) &&
+			failures.some(failure => {
+				const die = failure as {
+					_tag?: string
+					defect?: { message?: string }
+				} | null
+				return (
+					die?._tag === 'Die' &&
+					die?.defect?.message === UNKNOWN_SESSION_DIE_MESSAGE
+				)
+			})
+		)
+	})
+}
+
+// Turn McpServer's unknown-session failure — which it hides inside a normal 200
+// reply — into the MCP spec's 404 so the client re-initializes. Any other reply
+// passes through untouched. Exported for its unit test.
+export const recoverUnknownSession = (
+	response: HttpServerResponse.HttpServerResponse,
+) => {
+	const body = response.body
+	// The JSON-RPC transport never streams, so the whole reply body is in hand.
+	if (body._tag !== 'Uint8Array') return Effect.succeed(response)
+	const text = mcpBodyDecoder.decode(body.body)
+	// Cheap gate: only the unknown-session reply contains this phrase, so skip
+	// parsing every other MCP reply.
+	if (!text.includes(UNKNOWN_SESSION_DIE_MESSAGE))
+		return Effect.succeed(response)
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(text)
+	} catch {
+		return Effect.succeed(response)
+	}
+	if (!isUnknownSessionErrorBody(parsed)) return Effect.succeed(response)
+	// Mark the request span so Honeycomb can count how often clients replay a
+	// session the process forgot (chiefly right after a redeploy). The generic
+	// completion log still records the app-layer 200; this is the signal that the
+	// reply was swapped to a 404.
+	return Effect.annotateCurrentSpan({ 'mcp.session_recovered': true }).pipe(
+		Effect.andThen(
+			jsonRpcError(404, -32001, 'MCP session expired; reinitialize'),
+		),
+	)
+}
+
 const McpAuthMiddleware = HttpRouter.middleware(
 	Effect.gen(function* () {
 		const { instance } = yield* Auth
@@ -125,6 +197,9 @@ const McpAuthMiddleware = HttpRouter.middleware(
 									isAgent: principal.isAgent,
 								}),
 								enterOrgScope(sql, { org, userId: principal.userId }),
+								// Recover a client whose session id predates the last redeploy:
+								// turn McpServer's hidden failure into a 404 it can act on.
+								Effect.flatMap(recoverUnknownSession),
 							),
 						),
 					)

--- a/apps/server/src/mcp/session-recovery.test.ts
+++ b/apps/server/src/mcp/session-recovery.test.ts
@@ -1,0 +1,296 @@
+// Pins the recovery that unblocks every MCP client after a server redeploy:
+// McpServer answers a tools/call whose session id it no longer knows with a
+// normal HTTP 200 whose body hides the failure, so recoverUnknownSession swaps
+// that for the MCP spec's 404 (and leaves every other reply alone).
+//
+// Two levels of cover: the unit block feeds recoverUnknownSession hand-built
+// replies to exercise every branch; the round-trip block drives a real
+// McpServer over an in-process HTTP server so a future effect release that
+// changes the unknown-session reply's shape or message fails here, not in prod.
+
+import { createServer } from 'node:http'
+
+import { NodeHttpServer } from '@effect/platform-node'
+import { Effect, Layer, ManagedRuntime, Schema } from 'effect'
+import { McpServer, Tool, Toolkit } from 'effect/unstable/ai'
+import {
+	HttpRouter,
+	HttpServer,
+	HttpServerResponse,
+} from 'effect/unstable/http'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { recoverUnknownSession } from './http'
+
+// The reply effect's McpServer sends when it does not recognise the request's
+// Mcp-Session-Id: an HTTP 200 with the failure folded into the JSON-RPC error
+// cause as a `Die`. The nested `message` string is McpServer's own; the matcher
+// keys off the structured `data` array, so this is shaped exactly as observed.
+const UNKNOWN_SESSION_REPLY = JSON.stringify({
+	jsonrpc: '2.0',
+	id: 3,
+	error: {
+		_tag: 'Cause',
+		code: 0,
+		message:
+			'[{"_tag":"Die","defect":{"message":"Mcp-Session-Id does not exist","name":"Error"}}]',
+		data: [
+			{
+				_tag: 'Die',
+				defect: { message: 'Mcp-Session-Id does not exist', name: 'Error' },
+			},
+		],
+	},
+})
+
+// Build the same kind of collected-text reply the JSON-RPC transport emits, so
+// recovery sees a byte-array body just as it does in production.
+const jsonReply = (body: string) =>
+	HttpServerResponse.text(body, { contentType: 'application/json' })
+
+const bodyText = (response: HttpServerResponse.HttpServerResponse) =>
+	response.body._tag === 'Uint8Array'
+		? new TextDecoder().decode(response.body.body)
+		: undefined
+
+const run = (response: HttpServerResponse.HttpServerResponse) =>
+	Effect.runPromise(recoverUnknownSession(response))
+
+describe('recoverUnknownSession', () => {
+	describe('when McpServer buries an unknown-session failure in a 200 reply', () => {
+		it('should answer 404 with a JSON-RPC error so the client re-initializes', async () => {
+			// GIVEN McpServer's unknown-session reply (HTTP 200, failure in the body)
+			const response = jsonReply(UNKNOWN_SESSION_REPLY)
+
+			// WHEN recovery inspects it
+			const recovered = await run(response)
+
+			// THEN it becomes a 404 carrying the reinitialize hint, not a 200 or 5xx
+			expect(recovered.status).toBe(404)
+			const body = JSON.parse(bodyText(recovered) ?? '{}') as {
+				error?: { code?: number; message?: string }
+			}
+			expect(body.error?.code).toBe(-32001)
+			expect(body.error?.message).toBe('MCP session expired; reinitialize')
+		})
+
+		it('should also answer 404 when the failure arrives inside a batched array', async () => {
+			// GIVEN the same failure wrapped in a JSON-RPC batch (array of replies)
+			const response = jsonReply(`[${UNKNOWN_SESSION_REPLY}]`)
+
+			// WHEN recovery inspects it
+			const recovered = await run(response)
+
+			// THEN the batch is still recognised and rewritten to 404
+			expect(recovered.status).toBe(404)
+		})
+	})
+
+	describe('when the reply is anything else', () => {
+		it('should pass a healthy tool reply straight through', async () => {
+			// GIVEN a normal tools/call reply (HTTP 200 with a real result)
+			const response = jsonReply(
+				JSON.stringify({
+					jsonrpc: '2.0',
+					id: 2,
+					result: {
+						content: [{ type: 'text', text: '"pong"' }],
+						isError: false,
+					},
+				}),
+			)
+
+			// WHEN recovery inspects it
+			const recovered = await run(response)
+
+			// THEN the original reply is returned untouched (same object, still 200)
+			expect(recovered).toBe(response)
+			expect(recovered.status).toBe(200)
+		})
+
+		it('should not rewrite a tool result that merely echoes the failure phrase', async () => {
+			// GIVEN a successful reply whose text happens to contain the phrase, but
+			// as tool content under `result` — not in McpServer's error cause
+			const response = jsonReply(
+				JSON.stringify({
+					jsonrpc: '2.0',
+					id: 5,
+					result: {
+						content: [
+							{ type: 'text', text: 'log line: Mcp-Session-Id does not exist' },
+						],
+						isError: false,
+					},
+				}),
+			)
+
+			// WHEN recovery inspects it
+			const recovered = await run(response)
+
+			// THEN the cheap phrase gate opens but the structural check rejects it, so
+			// the real result is preserved (no false 404)
+			expect(recovered).toBe(response)
+		})
+
+		it('should pass through a body that carries the phrase but is not valid JSON', async () => {
+			// GIVEN a non-JSON body that still contains the phrase (defensive: the
+			// transport always sends JSON, but a parse failure must never 404)
+			const response = jsonReply('plain text: Mcp-Session-Id does not exist')
+
+			// WHEN recovery inspects it
+			const recovered = await run(response)
+
+			// THEN it is left untouched
+			expect(recovered).toBe(response)
+		})
+
+		it('should pass through a reply whose body is not a readable byte array', async () => {
+			// GIVEN a response with no materialised body for recovery to inspect
+			const response = HttpServerResponse.empty({ status: 200 })
+
+			// WHEN recovery inspects it
+			const recovered = await run(response)
+
+			// THEN it is returned untouched
+			expect(recovered).toBe(response)
+		})
+	})
+})
+
+// Drives a real McpServer wrapped with recoverUnknownSession over a loopback
+// HTTP server, mirroring how the /mcp route wires the recovery. This is the
+// guard against the exact production bug: a session id from before a redeploy is
+// unknown to the fresh process.
+describe('the /mcp route recovering an unknown session end to end', () => {
+	const Ping = Tool.make('ping', { success: Schema.String })
+	const PingTools = Toolkit.make(Ping)
+	const PingHandlersLive = PingTools.toLayer(
+		Effect.succeed({ ping: () => Effect.succeed('pong') }),
+	)
+
+	// Same shape as the /mcp wiring: recoverUnknownSession runs on the McpServer
+	// handler's reply. httpEffect is left un-annotated so its branded middleware
+	// error type is inferred, exactly as the real /mcp middleware does.
+	const RecoveryMiddleware = HttpRouter.middleware(
+		Effect.gen(function* () {
+			return httpEffect =>
+				httpEffect.pipe(Effect.flatMap(recoverUnknownSession))
+		}),
+		{ global: true },
+	)
+
+	const McpHttpLive = Layer.mergeAll(
+		McpServer.toolkit(PingTools),
+		RecoveryMiddleware,
+	).pipe(
+		Layer.provide(PingHandlersLive),
+		Layer.provide(
+			McpServer.layerHttp({ name: 'test', version: '1.0.0', path: '/mcp' }),
+		),
+	)
+
+	const ServerLive = HttpRouter.serve(McpHttpLive, {
+		disableListenLog: true,
+	}).pipe(Layer.provideMerge(NodeHttpServer.layer(createServer, { port: 0 })))
+
+	const runtime = ManagedRuntime.make(ServerLive)
+	let baseUrl: string
+
+	const post = (body: unknown, sessionId?: string) =>
+		fetch(`${baseUrl}/mcp`, {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				accept: 'application/json, text/event-stream',
+				...(sessionId ? { 'mcp-session-id': sessionId } : {}),
+			},
+			body: JSON.stringify(body),
+		})
+
+	const initialize = () =>
+		post({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: { name: 'test', version: '1.0' },
+			},
+		})
+
+	const callPing = (sessionId: string) =>
+		post(
+			{
+				jsonrpc: '2.0',
+				id: 2,
+				method: 'tools/call',
+				params: { name: 'ping', arguments: {} },
+			},
+			sessionId,
+		)
+
+	beforeAll(async () => {
+		// Building the server layer binds the loopback port; read it back for the
+		// request URLs.
+		const address = await runtime.runPromise(
+			Effect.gen(function* () {
+				const server = yield* HttpServer.HttpServer
+				return server.address
+			}),
+		)
+		if (address._tag !== 'TcpAddress')
+			throw new Error('expected a TCP address for the test server')
+		baseUrl = `http://127.0.0.1:${address.port}`
+	}, 30_000)
+
+	afterAll(() => runtime.dispose())
+
+	describe('when the session id is one the process minted', () => {
+		it('should serve a tool call after initialize', async () => {
+			// GIVEN a fresh initialize handshake
+			const initRes = await initialize()
+			const sessionId = initRes.headers.get('mcp-session-id')
+
+			// THEN the server issues a session id
+			expect(initRes.status).toBe(200)
+			expect(sessionId).toBeTruthy()
+
+			// WHEN a tool is called with that live session
+			const okRes = await callPing(sessionId as string)
+
+			// THEN it succeeds
+			expect(okRes.status).toBe(200)
+		})
+	})
+
+	describe('when the session id predates the last redeploy', () => {
+		it('should answer 404 so the client re-initializes', async () => {
+			// GIVEN a session id the process never minted (as every id becomes after
+			// a redeploy replaces the process)
+			const staleSessionId = '00000000-0000-0000-0000-000000000000'
+
+			// WHEN a tool is called with it
+			const res = await callPing(staleSessionId)
+
+			// THEN the client is told to re-initialize (404), not handed a
+			// hidden-failure 200 or a 5xx
+			expect(res.status).toBe(404)
+			const body = (await res.json()) as { error?: { code?: number } }
+			expect(body.error?.code).toBe(-32001)
+		})
+
+		it('should recover once the client initializes again', async () => {
+			// GIVEN a client that re-initializes (what a compliant client does on 404)
+			const initRes = await initialize()
+			const sessionId = initRes.headers.get('mcp-session-id')
+			expect(initRes.status).toBe(200)
+
+			// WHEN it retries the tool call with the fresh session
+			const okRes = await callPing(sessionId as string)
+
+			// THEN it is back to working
+			expect(okRes.status).toBe(200)
+		})
+	})
+})


### PR DESCRIPTION
## What
After any server redeploy, every already-connected MCP client's next `tools/call` failed and a reconnect did not help — the client stayed broken until it fully re-initialized, which it never did on its own. This restores that recovery for the **MCP transport** (`apps/server` → `/mcp`): a client whose session id predates the deploy is now told to re-initialize and recovers on its next call.

Root cause: effect's `McpServer` keeps sessions in a process-local `Map` minted only by `initialize`. A redeploy starts a fresh process with an empty map, so every previously-issued `Mcp-Session-Id` is unknown — and effect answers an unknown id with an `Effect.die` that, because it runs on a background fiber with `disableFatalDefects`, gets **encoded into a normal HTTP 200 body** and never surfaces as a defect. The client is never told its session is gone, so it replays the dead id forever.

Closes #160.

## The fix
- Added a `recoverUnknownSession` wrapper on the `/mcp` reply, in the auth middleware's `enterScope` so it covers all three auth paths (api-key, OAuth, cookie). It detects McpServer's buried unknown-session `Die` in the reply body and swaps the 200 for the MCP StreamableHTTP spec's **404 `-32001 "MCP session expired; reinitialize"`**, which makes a compliant client (Claude Code, ChatGPT) drop the session and re-`initialize`.
- Batuda-side only — effect is not patched (its `clientSessions` `Map` has no injection point). McpServer stays the single source of truth for sessions; matching its die message is the only signal it exposes.
- Tags the request span `mcp.session_recovered` so recoveries are queryable in Honeycomb.

Note: the originally-proposed `Effect.catchDefect` around the handler was proven non-functional (the die is encoded into a 200, so no defect ever propagates) — see #160's updated Implementation section.

## Impact
- **MCP + HTTP parity:** lives in the `/mcp` transport middleware only. It changes how an MCP reply's status is derived, not any shared service — no server-side HTTP route or tool behaviour changes.
- **Auth / RLS:** no change to auth decisions, `organization_id` scoping, or Postgres roles. The wrapper runs *after* `enterOrgScope` and only rewrites the status for the unknown-session case; it never changes what a caller can see.
- **No new env vars, no schema/migration, no wire-shape change.**

## Review guide
- Start at `recoverUnknownSession` + `isUnknownSessionErrorBody` in `apps/server/src/mcp/http.ts`, then the one-line `Effect.flatMap(recoverUnknownSession)` added to `enterScope`.
- Riskiest part is the false-positive question — could a normal reply be wrongly turned into a 404? Guarded twice: a cheap substring gate, then a structural check that the phrase appears as a `Die` in the JSON-RPC `error.data`. A tool result that merely echoes the phrase lands under `result`, not `error`, and is covered by a test.
- Decisions you might overrule: (a) the 404 body uses `id: null`, matching every other error response in this file (a 404 re-inits regardless of JSON-RPC id); (b) I kept the batch-array branch because effect still accepts older protocol versions that permit JSON-RPC batching.
- `snyk_code_scan` was unavailable in this environment; the change parses only our own McpServer's reply (not external input) and makes no auth/RLS decision.

## Tests
`apps/server/src/mcp/session-recovery.test.ts`:
- Unit: branch coverage of `recoverUnknownSession` — die → 404, batched array, healthy passthrough, the false-positive "tool echoes the phrase" case, non-JSON body, non-byte body.
- Integration: a real `McpServer` over an in-process HTTP server — initialize → 200; unknown session → 404; recover via re-initialize → 200. Fails loudly if a future effect release changes the unknown-session reply shape.

## Verification
- Gates (repo-wide): `pnpm install` (no lockfile drift) → `check-types` (13/13) + `test` (20/20; server 503) → `build` (13/13). All green.
- Live stack: ran the real server against the worktree DB with API-key auth and reproduced the reported bug — initialize → 200 + session; tool call → 200; **restarted the process** (wipes the in-memory session map, like a deploy); replayed the pre-restart session → **404**; re-initialize → 200. No 5xx, and no die surfaced in the log.

## Deferred
- **Phase 2 — sessions survive a redeploy with no re-initialize:** tracked in #161. Needs a custom HTTP transport owning session mint/lookup (effect's `clientSessions` has no hook). Phase 1's auto-reinitialize already recovers clients, so this is deferred pending need.
- **Unrelated env/DX gap** found while verifying: a stale local `.env` missing a required var (`RESEARCH_PROVIDER_REGISTRY_GB`, already present in `.env.example`) fails server boot with a cryptic `ConfigError`, and worktree provisioning inherits the gap. Tracked in #162 — not touched here.
