### PR TITLE
refactor(research): share duplicated research output schema fragments

### DIFF
--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -99,7 +99,8 @@ export class ScrapeProvider extends ServiceMap.Service<
 >()('research/ScrapeProvider') {}
 
 // ── Extract ──
-// Returns `unknown` — caller decodes with Schema.decodeUnknown(schema)(raw).
+// Returns `unknown`: the raw provider result is handed to the calling model
+// as-is (it reads untyped JSON), not decoded against the requested schema.
 // Generic methods on ServiceMap.Service lose type params through the tag.
 
 export interface ExtractInput {

--- a/packages/research/src/application/schemas/_shared.ts
+++ b/packages/research/src/application/schemas/_shared.ts
@@ -1,0 +1,42 @@
+import { Schema } from 'effect'
+
+/**
+ * Building blocks shared across the structured research output schemas, so each
+ * shape is defined once instead of copied into every file.
+ *
+ * No `identifier` annotation on purpose: it would emit each shape as a named
+ * reference, and some output paths keep only a schema's top-level shape, so a
+ * reference to a separately-named fragment would be dropped there.
+ */
+
+export const Citation = Schema.Struct({
+	source_id: Schema.String,
+	quote: Schema.optionalKey(Schema.String),
+	confidence: Schema.optionalKey(Schema.Number),
+})
+
+export const DiscoveredExisting = Schema.Struct({
+	subject_table: Schema.Literals(['companies', 'contacts']),
+	subject_id: Schema.String,
+	name: Schema.String,
+})
+
+export const ProposedUpdate = Schema.Struct({
+	subject_table: Schema.Literals(['companies', 'contacts']),
+	subject_id: Schema.String,
+	expected_version: Schema.Number,
+	// Open-ended field map; sent as a JSON-encoded string because OpenAI
+	// structured output has no "any shape" type — decodes back to an object
+	// automatically.
+	fields: Schema.UnknownFromJsonString,
+	reason: Schema.String,
+	citations: Schema.Array(Citation),
+})
+
+export const PendingPaidAction = Schema.Struct({
+	tool: Schema.String,
+	// Same open-ended-map rationale as `fields` above.
+	args: Schema.UnknownFromJsonString,
+	estimated_cents: Schema.Number,
+	reason: Schema.String,
+})

--- a/packages/research/src/application/schemas/company-enrichment-v1.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.ts
@@ -1,10 +1,11 @@
 import { Schema } from 'effect'
 
-const Citation = Schema.Struct({
-	source_id: Schema.String,
-	quote: Schema.optionalKey(Schema.String),
-	confidence: Schema.optionalKey(Schema.Number),
-})
+import {
+	Citation,
+	DiscoveredExisting,
+	PendingPaidAction,
+	ProposedUpdate,
+} from './_shared'
 
 export const CompanyEnrichmentV1Schema = Schema.Struct({
 	enrichment: Schema.Struct({
@@ -42,39 +43,7 @@ export const CompanyEnrichmentV1Schema = Schema.Struct({
 			}),
 		),
 	),
-	discovered_existing: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				name: Schema.String,
-			}),
-		),
-	),
-	proposed_updates: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				expected_version: Schema.Number,
-				// Open-ended field map; sent as a JSON-encoded string because OpenAI
-				// structured output has no "any shape" type — decodes back to an
-				// object automatically.
-				fields: Schema.UnknownFromJsonString,
-				reason: Schema.String,
-				citations: Schema.Array(Citation),
-			}),
-		),
-	),
-	pending_paid_actions: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				tool: Schema.String,
-				// Same open-ended-map rationale as `fields` above.
-				args: Schema.UnknownFromJsonString,
-				estimated_cents: Schema.Number,
-				reason: Schema.String,
-			}),
-		),
-	),
+	discovered_existing: Schema.optionalKey(Schema.Array(DiscoveredExisting)),
+	proposed_updates: Schema.optionalKey(Schema.Array(ProposedUpdate)),
+	pending_paid_actions: Schema.optionalKey(Schema.Array(PendingPaidAction)),
 })

--- a/packages/research/src/application/schemas/competitor-scan-v1.ts
+++ b/packages/research/src/application/schemas/competitor-scan-v1.ts
@@ -1,10 +1,11 @@
 import { Schema } from 'effect'
 
-const Citation = Schema.Struct({
-	source_id: Schema.String,
-	quote: Schema.optionalKey(Schema.String),
-	confidence: Schema.optionalKey(Schema.Number),
-})
+import {
+	Citation,
+	DiscoveredExisting,
+	PendingPaidAction,
+	ProposedUpdate,
+} from './_shared'
 
 export const CompetitorScanV1Schema = Schema.Struct({
 	competitors: Schema.Array(
@@ -26,39 +27,7 @@ export const CompetitorScanV1Schema = Schema.Struct({
 			citations: Schema.Array(Citation),
 		}),
 	),
-	discovered_existing: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				name: Schema.String,
-			}),
-		),
-	),
-	proposed_updates: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				expected_version: Schema.Number,
-				// Open-ended field map; sent as a JSON-encoded string because OpenAI
-				// structured output has no "any shape" type — decodes back to an
-				// object automatically.
-				fields: Schema.UnknownFromJsonString,
-				reason: Schema.String,
-				citations: Schema.Array(Citation),
-			}),
-		),
-	),
-	pending_paid_actions: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				tool: Schema.String,
-				// Same open-ended-map rationale as `fields` above.
-				args: Schema.UnknownFromJsonString,
-				estimated_cents: Schema.Number,
-				reason: Schema.String,
-			}),
-		),
-	),
+	discovered_existing: Schema.optionalKey(Schema.Array(DiscoveredExisting)),
+	proposed_updates: Schema.optionalKey(Schema.Array(ProposedUpdate)),
+	pending_paid_actions: Schema.optionalKey(Schema.Array(PendingPaidAction)),
 })

--- a/packages/research/src/application/schemas/contact-discovery-v1.ts
+++ b/packages/research/src/application/schemas/contact-discovery-v1.ts
@@ -1,12 +1,12 @@
 import { Schema } from 'effect'
 
 import { VerificationVerdict } from '../../domain/types'
-
-const Citation = Schema.Struct({
-	source_id: Schema.String,
-	quote: Schema.optionalKey(Schema.String),
-	confidence: Schema.optionalKey(Schema.Number),
-})
+import {
+	Citation,
+	DiscoveredExisting,
+	PendingPaidAction,
+	ProposedUpdate,
+} from './_shared'
 
 export const ContactDiscoveryV1Schema = Schema.Struct({
 	contacts: Schema.Array(
@@ -31,39 +31,7 @@ export const ContactDiscoveryV1Schema = Schema.Struct({
 			citations: Schema.Array(Citation),
 		}),
 	),
-	discovered_existing: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				name: Schema.String,
-			}),
-		),
-	),
-	proposed_updates: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				expected_version: Schema.Number,
-				// Open-ended field map; sent as a JSON-encoded string because OpenAI
-				// structured output has no "any shape" type — decodes back to an
-				// object automatically.
-				fields: Schema.UnknownFromJsonString,
-				reason: Schema.String,
-				citations: Schema.Array(Citation),
-			}),
-		),
-	),
-	pending_paid_actions: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				tool: Schema.String,
-				// Same open-ended-map rationale as `fields` above.
-				args: Schema.UnknownFromJsonString,
-				estimated_cents: Schema.Number,
-				reason: Schema.String,
-			}),
-		),
-	),
+	discovered_existing: Schema.optionalKey(Schema.Array(DiscoveredExisting)),
+	proposed_updates: Schema.optionalKey(Schema.Array(ProposedUpdate)),
+	pending_paid_actions: Schema.optionalKey(Schema.Array(PendingPaidAction)),
 })

--- a/packages/research/src/application/schemas/prospect-scan-v1.ts
+++ b/packages/research/src/application/schemas/prospect-scan-v1.ts
@@ -1,10 +1,11 @@
 import { Schema } from 'effect'
 
-const Citation = Schema.Struct({
-	source_id: Schema.String,
-	quote: Schema.optionalKey(Schema.String),
-	confidence: Schema.optionalKey(Schema.Number),
-})
+import {
+	Citation,
+	DiscoveredExisting,
+	PendingPaidAction,
+	ProposedUpdate,
+} from './_shared'
 
 export const ProspectScanV1Schema = Schema.Struct({
 	prospects: Schema.Array(
@@ -19,39 +20,7 @@ export const ProspectScanV1Schema = Schema.Struct({
 			citations: Schema.Array(Citation),
 		}),
 	),
-	discovered_existing: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				name: Schema.String,
-			}),
-		),
-	),
-	proposed_updates: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				subject_table: Schema.Literals(['companies', 'contacts']),
-				subject_id: Schema.String,
-				expected_version: Schema.Number,
-				// Open-ended field map; sent as a JSON-encoded string because OpenAI
-				// structured output has no "any shape" type — decodes back to an
-				// object automatically.
-				fields: Schema.UnknownFromJsonString,
-				reason: Schema.String,
-				citations: Schema.Array(Citation),
-			}),
-		),
-	),
-	pending_paid_actions: Schema.optionalKey(
-		Schema.Array(
-			Schema.Struct({
-				tool: Schema.String,
-				// Same open-ended-map rationale as `fields` above.
-				args: Schema.UnknownFromJsonString,
-				estimated_cents: Schema.Number,
-				reason: Schema.String,
-			}),
-		),
-	),
+	discovered_existing: Schema.optionalKey(Schema.Array(DiscoveredExisting)),
+	proposed_updates: Schema.optionalKey(Schema.Array(ProposedUpdate)),
+	pending_paid_actions: Schema.optionalKey(Schema.Array(PendingPaidAction)),
 })

--- a/packages/research/src/infrastructure/stub/extract.ts
+++ b/packages/research/src/infrastructure/stub/extract.ts
@@ -3,8 +3,8 @@
  *
  * Exports both the instance (for the provider factory table in
  * `providers-live.ts`) and the standalone Layer (single-slot callers, tests).
- * Returns `unknown` matching the ExtractProvider port — the caller decodes
- * with Schema.decodeUnknown(schema)(raw).
+ * Returns `unknown` matching the ExtractProvider port — the raw object is
+ * handed to the calling model as-is, not decoded against the requested schema.
  */
 
 import { Effect, Layer } from 'effect'


### PR DESCRIPTION
## What

Follow-up cleanup to the deferred items from #163 (the research OpenAI-structured-output fix), in `packages/research`. Pure `refactor` — no behavior change:

1. The four structured research output schemas (`company-enrichment-v1`, `competitor-scan-v1`, `contact-discovery-v1`, `prospect-scan-v1`) each carried a verbatim copy of `Citation`, `DiscoveredExisting`, `ProposedUpdate`, and `PendingPaidAction`. #163 had to hand-edit every copy for both halves of that fix, and two review angles independently flagged the duplication as a recurring maintenance trap. This extracts them into one `schemas/_shared.ts`.
2. Corrects two stale doc comments that claimed the caller decodes the `ExtractProvider` result — no caller does; the raw value is handed to the calling model as-is.

## Changes

- **`schemas/_shared.ts`** (new): the four shared fragments, as plain structs. Deliberately no `identifier` annotation — that would emit them as named `$ref`s, which the Firecrawl extract path (`toJsonSchemaDocument(schema).schema`, top-level only) would drop. A WHY comment guards this.
- The four v1 schema files import the fragments and drop their local copies (net −83 lines).
- **`freeform.ts` intentionally left inline** — its citation shape genuinely differs (no `confidence` field), so sharing it would change freeform's schema rather than dedup. Called out so it doesn't read as an oversight.
- **`ports.ts` / `stub/extract.ts`**: the "caller decodes with `Schema.decodeUnknown(schema)(raw)`" comments were false (grep confirms no caller decodes). Rewritten to describe actual behavior. The schema is still used to shape Firecrawl's *outbound* request — the comments scope the claim to decoding the *response*.

## Impact

- **No behavior change — proven, not assumed.** I captured the `toCodecOpenAI` output for all 5 registry schemas + 4 toolkit tools on `main`, ran the same capture after the refactor, and diffed: **byte-identical**. Extracting a plain (un-annotated) struct into a shared const inlines identically to defining it in place, in both the OpenAI (`toCodecOpenAI`) and Firecrawl (`toJsonSchemaDocument`) codec paths.
- No migration, RLS, auth, env var, wire-shape, or MCP/HTTP-parity change. The persisted `findings` jsonb shape is untouched.
- `web_read` (`research-web.ts`) still uses `Schema.optional`/`Schema.Unknown` and is **left alone**: it's an MCP-tool param schema (standard JSON-schema path, not `toCodecOpenAI`), so it's not a latent #159-style crash — and it's currently unregistered in `server.ts` regardless.

## Review guide

- Start in `schemas/_shared.ts` (the four fragments + the `identifier` guard-rail comment). The four v1 files are then the same mechanical edit repeated (import + delete local copy), compiler- and diff-verified.
- The one judgment call to sanity-check: **why the shared fragments carry no `identifier` annotation.** If you'd prefer them named/`$ref`'d, note that Firecrawl's `extract.ts` sends only `.schema` (not `.definitions`), so a `$ref` would dangle there — inlining is deliberate. The byte-identical diff (below) is the proof it's a no-op.
- `contact-discovery-v1.ts` keeps its own `VerificationVerdict` import and still uses `Citation` in its `contacts` struct — that's expected, not a leftover.

## Tests

- No new tests. The existing regression guard from #163 (`openai-structured-output.test.ts`) already asserts every registered schema + tool converts through the production `toCodecOpenAI` path without throwing, and it passes (11/11) against the refactored schemas — so it doubles as the guard that this refactor didn't break conversion.

## Verification

- Byte-identical `toCodecOpenAI` output before/after for all 9 schemas+tools (capture-and-diff described in Impact).
- Full gates green locally: `pnpm install`, `pnpm -w check-types` (13/13), `pnpm -w test` (20/20, incl. integration via pre-push), `pnpm -w build` (13/13); `biome check` clean.
- Booted the server against this worktree's local stack — starts cleanly.

## Deferred

- The `extract_structured` handler could decode the provider result against the requested schema (gaining validation), but that would require the stub — and the real Firecrawl provider — to return schema-conforming data, and would turn a currently-tolerated soft mismatch into a hard run-failure. Out of scope; the corrected comments now describe the intentional raw-passthrough instead.

---

_Heads-up unrelated to this PR: local `.env` files are missing `RESEARCH_PROVIDER_REGISTRY_GB` (present in `.env.example` since the UK-registry work), so `pnpm dev:server` throws a `ConfigError` at boot until it's added. Not a repo change — just a per-machine `.env` sync._
