### PR TITLE
feat(cli): flag a worktree .env that lacks keys from .env.example

### DIFF
--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -211,6 +211,38 @@ const writeWorktreeEnv = (mainRoot: string, slug: string) =>
 		}
 	})
 
+// Active `KEY=` assignments in a .env body, ignoring comments (`# KEY=`) and
+// blanks. Mirrors mergeEnv's key regex so the two agree on what a "key" is.
+const envKeys = (body: string): Set<string> => {
+	const keys = new Set<string>()
+	for (const line of body.split('\n')) {
+		const key = line.match(/^([A-Z0-9_]+)=/)?.[1]
+		if (key) keys.add(key)
+	}
+	return keys
+}
+
+// Keys the committed .env.example declares but the local .env lacks. A worktree
+// inherits its .env from the main checkout, so a key added to the template but
+// not to that .env is missing here too — and the server reads it at boot and dies
+// with a cryptic ConfigError. Surfacing the names turns that into a fixable hint.
+const missingEnvKeys = (exampleBody: string, currentBody: string): string[] => {
+	const present = envKeys(currentBody)
+	return [...envKeys(exampleBody)].filter(key => !present.has(key))
+}
+
+// The current worktree's missing keys, or [] when either file is absent (nothing
+// to compare against).
+const missingWorktreeEnvKeys = (): string[] => {
+	const examplePath = resolve(ROOT, '.env.example')
+	const envPath = resolve(ROOT, '.env')
+	if (!existsSync(examplePath) || !existsSync(envPath)) return []
+	return missingEnvKeys(
+		readFileSync(examplePath, 'utf-8'),
+		readFileSync(envPath, 'utf-8'),
+	)
+}
+
 const dockerFail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
 	self.pipe(
 		Effect.catch(() =>
@@ -400,6 +432,15 @@ export const worktreeUp = Effect.gen(function* () {
 	// Make the just-written values visible to this process + every subprocess
 	// (migrate/seed) it spawns, so they target this worktree's database, not main's.
 	for (const [k, v] of Object.entries(envOverrides(slug))) process.env[k] = v
+
+	// Catch a stale inherited .env now, with the key names, instead of leaving
+	// the server to die at boot with a bare "Expected string, got undefined".
+	const missingEnv = missingWorktreeEnvKeys()
+	if (missingEnv.length > 0) {
+		yield* Effect.logWarning(
+			`.env is missing ${missingEnv.length} key(s) that .env.example declares: ${missingEnv.join(', ')}. The server reads these at boot and will fail until you copy their values from .env.example into the main checkout's .env.`,
+		)
+	}
 
 	yield* Effect.logInfo('Running migrations…')
 	yield* settle(dbMigrate)
@@ -678,6 +719,18 @@ export const worktreeDoctor = Effect.gen(function* () {
 				detail: bucketOk
 					? bucket
 					: `${bucket} missing — run \`pnpm cli worktree up\``,
+			})
+
+			// A .env missing keys that .env.example declares boots the server into a
+			// cryptic ConfigError; name them here so the fix is obvious.
+			const missingEnv = missingWorktreeEnvKeys()
+			checks.push({
+				ok: missingEnv.length === 0,
+				name: 'env',
+				detail:
+					missingEnv.length === 0
+						? 'has every key from .env.example'
+						: `.env.example declares keys this .env lacks: ${missingEnv.join(', ')} — copy their values in or the server won't boot`,
 			})
 		}
 


### PR DESCRIPTION
## What
Provisioning or diagnosing a worktree now catches a **stale `.env`** — one missing keys that `.env.example` declares — at provision time, instead of leaving the server to die at boot with a bare `ConfigError: Expected string, got undefined at ["…"]`. This is a `cli` / DX change (`pnpm cli worktree`).

Background: a worktree inherits its `.env` from the main checkout, and `worktree up` doesn't reconcile against `.env.example`. So when a required var is added to the template but not to the local `.env` (e.g. `RESEARCH_PROVIDER_REGISTRY_GB`), every new worktree inherits the gap and only finds out at `pnpm dev`. This bit me while verifying #160.

Closes #162.

## Changes
- Added an env-completeness check: the keys `.env.example` declares (active `KEY=` lines, ignoring commented alternatives) that the local `.env` lacks.
- `worktree up` logs a warning naming the missing keys right after it generates the `.env`.
- `worktree doctor` reports an `env` check (`✓`/`✗`) alongside the database/bucket/migrations lines.

## Impact
- CLI / DX only — no server, schema, wire-shape, or env-loading behaviour changes. The check is advisory (a warning + a doctor line) and never blocks provisioning.

## Review guide
- One file (`apps/cli/src/commands/worktree.ts`): three small pure helpers + two call sites. The key check reuses the same `^([A-Z0-9_]+)=` regex `mergeEnv` already uses, so the two agree on what a "key" is (and `# KEY=` comments are skipped).
- Low-risk tooling change (no auth / RLS / parser / external input), so I skipped the multi-agent code review as disproportionate and verified live instead (below).
- Per the repo convention I did not add a CLI unit test; the logic is exercised by running the real commands.

## Verification
- Gates: `pnpm install` (no lockfile drift) → `check-types` (13/13) + `test` (20/20) → `build` (13/13). All green.
- Live: ran `pnpm cli worktree up` in a fresh worktree — it caught 4 real drifted keys (`EMAIL_AGENT_SOFT_THREAD_LIMIT`, `RESEARCH_PROVIDER_ENRICH`, `RESEARCH_PROVIDER_VERIFY`, `RESEARCH_PROVIDER_REGISTRY_GB`) with an actionable message. `pnpm cli worktree doctor` showed `✗ env …`, flipping to `✓ env has every key from .env.example` once the keys were added.

## Deferred
- **MCP durable sessions (#161)** — filed as a follow-up and intentionally left out of this PR. A feasibility prototype showed the Batuda-side remapping proxy is brittle (needs per-request reconstruction, a self-HTTP-call that re-injects the caller's auth, and order-sensitive effect-internal pre-response handlers); the findings are recorded on #161. Phase 1 (#160, shipped) already recovers every client after a redeploy, so #161 stays open pending genuine need.
