### PR TITLE
feat(cli): stop a worktree's dev servers on teardown

### DIFF
--- a/.claude/hooks/worktree-down.sh
+++ b/.claude/hooks/worktree-down.sh
@@ -20,6 +20,11 @@ if [ -z "$wt" ] || [ ! -d "$wt" ]; then
 fi
 [ -n "$wt" ] && [ -d "$wt" ] || exit 0
 
+# Stop any dev servers running inside the worktree before its directory is
+# removed, so a server isn't left bound to a deleted path. Same script the CLI
+# teardown uses; self-guarding and always exits 0.
+bash "${CLAUDE_PROJECT_DIR:-.}/scripts/worktree-stop-procs.sh" "$wt" "$$" 2>/dev/null || true
+
 # Mirror the CLI's slug: branch name with a leading `worktree-` dropped,
 # lowercased, non-alphanumerics collapsed to `-`, capped at 24 chars. The
 # database swaps `-` for `_` (Postgres identifiers); the bucket keeps `-`.

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -114,6 +114,11 @@ If the directory was removed manually before `worktree down`, run `pnpm cli work
   `pnpm cli worktree down` **first**, or `pnpm cli worktree prune` later. `prune` only *lists*
   orphans by default (pass `--yes` to drop) and keys ownership off each live worktree's `.env`,
   so it never reaps a live worktree — even one whose branch was switched.
+- **Teardown stops the worktree's dev server too.** `worktree down`/`done` (and the `WorktreeRemove`
+  hook) kill any `pnpm dev` servers running inside the worktree before its data + directory go away,
+  so nothing is left serving a deleted checkout and holding its port. The shared portless proxy is
+  never touched. A server orphaned by a *crashed* session (its `pnpm dev` gone but the port still
+  held) is reaped by `pnpm cli worktree prune --yes`.
 - **Merging a worktree's PR switches its branch.** `gh pr merge --delete-branch` checks `main`
   out into the worktree (the PR branch is gone). `down`/`doctor`/`ls`/`prune` read this worktree's
   identity from its `.env`, not the live branch, so teardown stays correct — but the portless

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -461,6 +461,17 @@ export const worktreeUp = Effect.gen(function* () {
 	)
 })
 
+// Stop any dev servers running inside this worktree before its data and
+// directory go away — otherwise a server keeps running against a deleted
+// checkout and holds its port. Delegates to the shared script (also called by
+// the WorktreeRemove hook); the script is self-guarding and always exits 0, so
+// this can never block teardown. `process.pid` is passed so the script won't
+// signal the CLI running the teardown, whose own cwd is inside the worktree.
+const stopWorktreeDevServers = (worktreePath: string) =>
+	exec(
+		`bash "${resolve(ROOT, 'scripts/worktree-stop-procs.sh')}" "${worktreePath}" ${process.pid}`,
+	).pipe(Effect.catch(() => Effect.void))
+
 export const worktreeDown = Effect.gen(function* () {
 	if (!(yield* isLinkedWorktree)) {
 		return yield* Effect.fail(
@@ -486,6 +497,9 @@ export const worktreeDown = Effect.gen(function* () {
 			),
 		)
 	}
+	// Only now that teardown is actually going ahead — stop the worktree's dev
+	// servers before its data + directory go away, not on a path that refuses.
+	yield* stopWorktreeDevServers(ROOT)
 	yield* Effect.logInfo(`Dropping database ${db} + bucket ${bucket}…`)
 	yield* dropDatabase(db)
 	// The bucket may already be gone (or never created) — don't fail teardown on it.
@@ -578,10 +592,19 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 		}
 	})
 
+// Reap dev servers left behind by crashed sessions — those whose owning CLI is
+// gone but whose port is still held. portless finds them from its own route
+// registry, so the shared proxy (which is not a route) is never touched. Runs
+// only on `--yes`; portless has no dry-run, and best-effort so it can't fail the
+// prune.
+const pruneOrphanDevServers = exec('pnpm exec portless prune').pipe(
+	Effect.catch(() => Effect.void),
+)
+
 // Dry-run by default: list the orphans and stop. `--yes` is required to drop,
 // so prune can never silently delete data — and because ownership is read from
 // each live worktree's `.env`, a worktree whose branch was swapped is never
-// mistaken for an orphan.
+// mistaken for an orphan. Orphaned dev servers are reaped on `--yes` too.
 export const worktreePrune = (apply: boolean) =>
 	Effect.gen(function* () {
 		const owned = yield* liveOwnedResources
@@ -591,22 +614,24 @@ export const worktreePrune = (apply: boolean) =>
 			owned.buckets,
 			'batuda-assets-',
 		)
+		const hasData = orphanDbs.length > 0 || orphanBuckets.length > 0
 
-		if (orphanDbs.length === 0 && orphanBuckets.length === 0) {
-			yield* Console.log('No orphaned worktree data — nothing to prune.')
-			return
+		if (hasData) {
+			yield* Console.log('')
+			yield* Console.log('Orphaned worktree data (no live worktree owns it):')
+			for (const db of orphanDbs) yield* Console.log(`  database  ${db}`)
+			for (const bucket of orphanBuckets)
+				yield* Console.log(`  bucket    ${bucket}`)
+			yield* Console.log('')
+		} else {
+			yield* Console.log('No orphaned worktree data.')
 		}
 
-		yield* Console.log('')
-		yield* Console.log('Orphaned worktree data (no live worktree owns it):')
-		for (const db of orphanDbs) yield* Console.log(`  database  ${db}`)
-		for (const bucket of orphanBuckets)
-			yield* Console.log(`  bucket    ${bucket}`)
-		yield* Console.log('')
-
 		if (!apply) {
+			// Orphaned dev servers can't be listed without stopping them (portless
+			// has no dry-run), so name the action rather than the count.
 			yield* Console.log(
-				'Dry run — re-run with `--yes` to drop the above. (The main `batuda` / `batuda-assets` are never listed.)',
+				'Re-run with `--yes` to drop any listed data and stop dev servers orphaned by crashed sessions. (The main `batuda` / `batuda-assets` are never listed.)',
 			)
 			return
 		}
@@ -617,6 +642,8 @@ export const worktreePrune = (apply: boolean) =>
 				Effect.catch(() => Effect.void),
 			)
 		}
+		// Reports its own result line for the dev-server side.
+		yield* pruneOrphanDevServers
 		yield* Console.log(
 			`✓ Pruned ${orphanDbs.length} database(s) + ${orphanBuckets.length} bucket(s).`,
 		)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
 		"dprint": "^0.53.1",
 		"lefthook": "^2.1.4",
-		"portless": "^0.10.2",
+		"portless": "^0.15.1",
 		"release-it": "^19.0.0",
 		"secretlint": "^13.0.2",
 		"syncpack": "^14.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4
       portless:
-        specifier: ^0.10.2
-        version: 0.10.3
+        specifier: ^0.15.1
+        version: 0.15.1
       release-it:
         specifier: ^19.0.0
         version: 19.2.4(@types/node@22.19.15)
@@ -6677,9 +6677,9 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  portless@0.10.3:
-    resolution: {integrity: sha512-lXbVUsNiwWMKJGMi49HhTMW0lS7u0EzawonDZQ+yglSnHioiQK18Y4Fe0Ilk+TuXej71E/nTOHIFIBjUGvTm9w==}
-    engines: {node: '>=20'}
+  portless@0.15.1:
+    resolution: {integrity: sha512-MQTt405HrcIa3m9OSKpH6WjJDbfNP4oFMNg0VzAoUO4B19l1eFJBFcSWfQY8KYMhzZVfa+Gea2OUrlDm8+/M4A==}
+    engines: {node: '>=24'}
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -14358,7 +14358,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  portless@0.10.3: {}
+  portless@0.15.1: {}
 
   postcss-value-parser@4.2.0: {}
 

--- a/scripts/worktree-stop-procs.sh
+++ b/scripts/worktree-stop-procs.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Stop the dev servers running inside a worktree, so tearing the worktree down
+# doesn't leave a server bound to a now-deleted directory (it keeps serving,
+# and its port stays taken, until killed by hand).
+#
+# The candidate list comes from portless's own route registry
+# (~/.portless/routes.json, an array of {hostname, port, pid}) rather than a
+# scan of every process — so we only ever touch dev servers portless is actually
+# proxying, and never the shared proxy daemon itself (the proxy reads that file;
+# it is not listed in it). A candidate is kept only when its working directory
+# is inside this worktree, which stays correct even after a merge has swapped the
+# branch (portless's hostnames follow the branch; a directory does not).
+#
+# Best-effort by contract: teardown must never fail because a process couldn't
+# be signalled, so every step tolerates errors and the script always exits 0.
+#
+# Usage: worktree-stop-procs.sh <worktree-abs-path> [caller-pid]
+set -uo pipefail
+
+wt="${1:-}"
+caller_pid="${2:-}"
+[ -n "$wt" ] || exit 0
+# Resolve symlinks so the comparison matches lsof's real paths. The directory
+# still exists at teardown time (removal happens later), but fall back to the
+# raw string if it's already gone.
+if [ -d "$wt" ]; then wt="$(cd "$wt" && pwd -P)"; fi
+# Re-check: if the `cd` above failed (a race with the removal, or permissions),
+# `wt` is now empty — and an empty pattern below would match every path and kill
+# every worktree's servers. Bail rather than over-reach.
+[ -n "$wt" ] || exit 0
+
+routes="${HOME}/.portless/routes.json"
+[ -f "$routes" ] || exit 0
+
+proxy_pid="$(cat "${HOME}/.portless/proxy.pid" 2>/dev/null || true)"
+
+# The pid registered for each active route. node is always present (Node
+# monorepo); a parse failure yields nothing and the script simply stops nobody.
+route_pids="$(node -e 'try{for(const r of require(process.argv[1]))if(r&&r.pid)console.log(r.pid)}catch{}' "$routes" 2>/dev/null || true)"
+[ -n "$route_pids" ] || exit 0
+
+# The working directory of a pid, read from kernel state so it still resolves
+# after the directory is unlinked.
+proc_cwd() { lsof -a -d cwd -p "$1" -Fn 2>/dev/null | sed -n 's/^n//p' | head -1; }
+
+# Every descendant of a pid (depth-first), so killing a route's wrapper also
+# takes the `node --watch` / `vite` child it spawned.
+descendants() {
+	local parent="$1" child
+	for child in $(pgrep -P "$parent" 2>/dev/null || true); do
+		descendants "$child"
+		printf '%s\n' "$child"
+	done
+}
+
+# Collect the route wrappers rooted in this worktree, plus their descendants.
+targets=""
+for pid in $route_pids; do
+	[ "$pid" = "$proxy_pid" ] && continue
+	[ -n "$caller_pid" ] && [ "$pid" = "$caller_pid" ] && continue
+	[ "$pid" = "$$" ] && continue
+	cwd="$(proc_cwd "$pid")"
+	case "$cwd" in
+		"$wt" | "$wt"/*) targets="$targets $pid $(descendants "$pid")" ;;
+	esac
+done
+
+# De-dupe, then drop the proxy, the caller, and this script itself, so neither
+# kill loop below can ever signal them. They can't reach the target set through
+# the route scan or the descendant walk, but filtering here keeps that guarantee
+# in one place instead of trusting it — and applies it to both signals.
+kept=""
+for pid in $(printf '%s\n' $targets | awk 'NF' | sort -u); do
+	[ "$pid" = "$proxy_pid" ] && continue
+	[ -n "$caller_pid" ] && [ "$pid" = "$caller_pid" ] && continue
+	[ "$pid" = "$$" ] && continue
+	kept="$kept $pid"
+done
+set -- $kept
+[ "$#" -gt 0 ] || exit 0
+
+stopped=0
+for pid in "$@"; do
+	kill -TERM "$pid" 2>/dev/null && stopped=$((stopped + 1))
+done
+
+# Give them a moment to exit on SIGTERM, then SIGKILL any holdouts.
+[ "$stopped" -gt 0 ] && sleep 2
+for pid in "$@"; do
+	kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+done
+
+[ "$stopped" -gt 0 ] &&
+	printf 'stopped %s dev-server process(es): %s\n' "$stopped" "$*"
+exit 0


### PR DESCRIPTION
## What

Worktree teardown (`apps/cli` — `pnpm cli worktree down`/`done`, and the Claude `WorktreeRemove` hook) reclaimed a worktree's **data + git** but never stopped the **dev server** running inside it. `pnpm dev` spawns the server independently, the CLI held no handle to it, and a booted process outlives the deletion of its directory — so it kept serving a now-deleted checkout and holding its port until killed by hand. This session hit it twice.

The fix had to work for **both Claude Code and Opencode**, whose automation layers are per-harness (`.claude/hooks` vs `.opencode/plugins`). The only surface both share is the CLI — both harnesses (and humans) tear down via `pnpm cli worktree down` — so the mechanism lives there, in a shared script the `WorktreeRemove` hook also calls.

## Changes

- Teardown now stops the dev servers running inside the worktree before its data and directory go away. Candidates come from **portless's own route registry** (`~/.portless/routes.json`) and are kept only when their working directory is inside the worktree — so the shared portless proxy (not a route entry) and other worktrees' servers are never touched, and it stays correct even after a merge swaps the branch (cwd doesn't move; hostnames do). The route wrapper's descendant tree is signalled SIGTERM → SIGKILL.
- `worktree prune --yes` additionally reaps dev servers orphaned by a *crashed* session (owning CLI gone, port still held), via the new `portless prune`.
- Bumped portless 0.10.3 → 0.15.1, which is what adds `portless prune`.

## Impact

- **No app / server / schema / RLS / API / env / migration change.** This is dev-tooling only (`apps/cli` teardown + a root script + the Claude hook + the `/worktrees` skill doc). Nothing in the running product changes.
- **portless bump is a 5-minor jump (0.10 → 0.15)** and portless drives *every* dev server (`portless run …` in `apps/server`/`apps/internal` dev scripts), so the risk isn't `prune` — it's the runtime. I verified the full `pnpm dev` stack still boots and routes on 0.15.1: both `<label>.batuda.localhost` (vite) and `<label>.api.batuda.localhost` (server) resolve and `/health` returns 200 through the proxy. The 0.11 Turborepo/orchestration changes did not affect our `portless run`-per-app model.
- **`portless prune` is global** (reaps orphans across all worktrees + main), but it only ever kills *orphans* — dead owning CLI + port still held — never a live server or the proxy. `worktree prune` is already a global orphan reaper for DBs/buckets, so this is consistent.
- **Signals/kills processes** — see the Review guide for how the wrong-process risk is contained.

## Review guide

- Start in `scripts/worktree-stop-procs.sh` — it's the load-bearing part and where the safety lives. The contract: only kill dev servers whose cwd is under this worktree; **never** the portless proxy (excluded by `~/.portless/proxy.pid` and by not being a route), the caller CLI (passed as `$2`; its own cwd is inside the worktree), or the script itself. It's best-effort and always exits 0 so teardown can't fail on it.
- The riskiest line is the cwd match. It bails if the worktree path resolves empty (a failed `cd`) — without that guard an empty pattern would become `/*` and match every path. I reproduced that over-kill and confirmed the guard blocks it.
- **Decision you might overrule:** both call sites swallow the script's failure (`Effect.catch` / `|| true`). That's deliberate — teardown must never fail because a process couldn't be signalled — but it means a *missing* script degrades to a silent no-op. The script is committed (with its exec bit), so this only matters if it's later deleted.
- `worktree.ts` uses the repo's existing `exec` (shell:true) with interpolated paths — same pattern as the neighbouring `docker`/`mc` commands (see the safety note at the top of that block). The interpolated values are a filesystem path from `import.meta.dirname` and a numeric pid, both quoted — no untrusted input. A security hook flagged the shell-string on principle; I kept it idiomatic since there's no injection surface. `snyk_code_scan` was not available in this environment.
- No unit tests: repo convention is no unit tests for `apps/cli` commands — verified end-to-end instead (below).

## Verification

- Gates on the final tree, all green: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (0 failures), `pnpm -w build` (13/13); `biome` clean.
- **End-to-end against the live stack** (this worktree, real dev server):
  - `pnpm cli worktree down` with a running `pnpm dev:server`: printed `stopped N dev-server process(es)`, `ps`/`lsof` showed the whole tree gone, the shared proxy (`~/.portless/proxy.pid`) stayed alive, the CLI process itself was not killed, and the DB/bucket drop still ran.
  - Started a server in a second context and confirmed teardown left it running.
  - `portless prune`: reaped a stale route, left the proxy alive.
  - `pnpm dev` full stack boots and routes on portless 0.15.1 (server `/health` → 200 through the proxy).
- Reviewed adversarially before opening: two independent reviewers plus my own pass found five issues (a critical empty-path over-kill, an untracked-script trap, a SIGKILL-loop exclusion gap, a kill-before-guards ordering, and messaging nits) — all fixed and re-verified.

## Deferred

- Opencode gets this only through the manual `pnpm cli worktree down`/`prune` path — it has no worktree-removal event to hook, so there's no auto-teardown equivalent to Claude's `WorktreeRemove`. Adding one would be a separate Opencode-plugin change.
- The SIGTERM→SIGKILL window means a pid that dies and is instantly recycled could in theory be re-signalled — inherent to signalling by pid in a shell script; not worth guarding for a best-effort teardown.
