### PR TITLE
fix(research): tolerate null service_tier in LLM provider responses

### DIFF
--- a/packages/research/src/infrastructure/_service-tier.test.ts
+++ b/packages/research/src/infrastructure/_service-tier.test.ts
@@ -1,0 +1,236 @@
+import { OpenAiClient, OpenAiLanguageModel } from '@effect/ai-openai-compat'
+import { Cause, Effect, Exit, Layer, Option } from 'effect'
+import { AiError } from 'effect/unstable/ai'
+import {
+	HttpClient,
+	type HttpClientError,
+	HttpClientResponse as HttpClientResponseNs,
+} from 'effect/unstable/http'
+import { describe, expect, it } from 'vitest'
+
+import { stripNullServiceTier, tolerateNullServiceTier } from './_service-tier'
+
+// ── Test helpers ──
+
+// A chat-completion body shaped like the Qwen endpoint's, parameterized on the
+// value it reports for `service_tier`.
+const chatCompletionBody = (serviceTier: unknown): string =>
+	JSON.stringify({
+		id: 'chatcmpl-1',
+		model: 'Qwen/Qwen3-32B',
+		created: 0,
+		choices: [
+			{
+				index: 0,
+				finish_reason: 'stop',
+				message: { role: 'assistant', content: 'hi there' },
+			},
+		],
+		usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+		service_tier: serviceTier,
+	})
+
+// A one-shot HttpClient that answers every request with a canned body, so the
+// real `@effect/ai-openai-compat` decode path runs against a controlled payload.
+const cannedClient = (
+	body: string,
+	contentType = 'application/json',
+): HttpClient.HttpClient =>
+	HttpClient.makeWith<
+		HttpClientError.HttpClientError,
+		never,
+		HttpClientError.HttpClientError,
+		never
+	>(
+		effect =>
+			Effect.map(effect, request =>
+				HttpClientResponseNs.fromWeb(
+					request,
+					new Response(body, {
+						status: 200,
+						headers: { 'content-type': contentType },
+					}),
+				),
+			),
+		Effect.succeed,
+	)
+
+const createResponse = (client: OpenAiClient.Service) =>
+	client.createResponse({
+		model: 'Qwen/Qwen3-32B',
+		messages: [{ role: 'user', content: 'hi' }],
+	})
+
+const decodeThrough = (
+	body: string,
+	transformClient?: (c: HttpClient.HttpClient) => HttpClient.HttpClient,
+) =>
+	Effect.gen(function* () {
+		const client = yield* OpenAiClient.make({
+			apiUrl: 'http://qwen.test/v1',
+			transformClient,
+		})
+		return yield* createResponse(client)
+	}).pipe(Effect.provideService(HttpClient.HttpClient, cannedClient(body)))
+
+// Build the tier LanguageModel exactly as `llm-live.ts` buildSlot does — real
+// OpenAiLanguageModel over a wrapped OpenAiClient — but with the canned client
+// swapped in for the network, then run one non-streaming generateText.
+const generateThrough = (body: string) =>
+	Effect.gen(function* () {
+		const model = yield* OpenAiLanguageModel.make({ model: 'Qwen/Qwen3-32B' })
+		return yield* model.generateText({ prompt: 'hi' })
+	}).pipe(
+		Effect.provide(
+			OpenAiClient.layer({
+				apiUrl: 'http://qwen.test/v1',
+				transformClient: tolerateNullServiceTier,
+			}).pipe(
+				Layer.provide(Layer.succeed(HttpClient.HttpClient, cannedClient(body))),
+			),
+		),
+	)
+
+describe('stripNullServiceTier', () => {
+	describe('when the provider sends service_tier as null', () => {
+		it('should drop the field and return the re-serialized body', () => {
+			// GIVEN a body whose service_tier is null (the Qwen behavior)
+			const body = JSON.stringify({ id: 'x', service_tier: null, foo: 1 })
+
+			// WHEN the body is sanitized
+			// THEN service_tier is gone and the remaining fields keep their order
+			expect(stripNullServiceTier(body)).toBe(
+				JSON.stringify({ id: 'x', foo: 1 }),
+			)
+		})
+	})
+
+	describe('when there is nothing to strip', () => {
+		it('should return undefined for a string service_tier', () => {
+			// GIVEN a valid string service_tier (real OpenAI shape)
+			const body = JSON.stringify({ id: 'x', service_tier: 'default' })
+
+			// THEN the sanitizer signals "no change" so the caller reuses the body
+			expect(stripNullServiceTier(body)).toBeUndefined()
+		})
+
+		it('should return undefined when service_tier is absent', () => {
+			// GIVEN a body without the field at all
+			// THEN there is nothing to strip
+			expect(stripNullServiceTier(JSON.stringify({ id: 'x' }))).toBeUndefined()
+		})
+	})
+
+	describe('when the body is not a JSON object', () => {
+		it('should return undefined for a non-JSON string', () => {
+			// GIVEN a body that is not JSON (e.g. an HTML error page)
+			// THEN parsing fails and the sanitizer reports no change
+			expect(stripNullServiceTier('<html>bad gateway</html>')).toBeUndefined()
+		})
+
+		it('should return undefined for a JSON array', () => {
+			// GIVEN a top-level JSON array
+			// THEN it has no service_tier key to strip
+			expect(stripNullServiceTier('[1,2,3]')).toBeUndefined()
+		})
+
+		it('should return undefined for a JSON null literal', () => {
+			// GIVEN the literal `null` — typeof null is "object", so the guard
+			// against null is what saves the caller here
+			expect(stripNullServiceTier('null')).toBeUndefined()
+		})
+	})
+})
+
+describe('tolerateNullServiceTier', () => {
+	describe('when the OpenAI-compatible client decodes a response with service_tier: null', () => {
+		it('should decode successfully once the client is wrapped', async () => {
+			// GIVEN the Qwen endpoint answering with service_tier: null
+			const body = chatCompletionBody(null)
+
+			// WHEN the research LLM client wraps its HttpClient with the sanitizer
+			const [decoded] = await Effect.runPromise(
+				decodeThrough(body, tolerateNullServiceTier),
+			)
+
+			// THEN the response decodes instead of failing at ["service_tier"]
+			expect(decoded.id).toBe('chatcmpl-1')
+			expect(decoded.choices[0]?.message?.content).toBe('hi there')
+		})
+
+		it('should fail without the wrapper, proving the wrapper is the fix', async () => {
+			// GIVEN the same service_tier: null body but no sanitizer
+			const body = chatCompletionBody(null)
+
+			// WHEN the unwrapped client tries to decode it
+			const exit = await Effect.runPromiseExit(decodeThrough(body))
+
+			// THEN decode fails with an AiError naming the offending field
+			expect(Exit.isFailure(exit)).toBe(true)
+			const error = Exit.isFailure(exit)
+				? Option.getOrUndefined(Cause.findErrorOption(exit.cause))
+				: undefined
+			expect(error).toBeInstanceOf(AiError.AiError)
+			expect(String((error as AiError.AiError | undefined)?.message)).toContain(
+				'service_tier',
+			)
+		})
+	})
+
+	describe('when the assembled research LanguageModel runs generateText', () => {
+		it('should return the generated text past a service_tier: null response', async () => {
+			// GIVEN the tier model wired exactly as llm-live.ts builds it, answering
+			// with service_tier: null
+			const body = chatCompletionBody(null)
+
+			// WHEN the agent tier generates text (the first research LLM call)
+			const response = await Effect.runPromise(generateThrough(body))
+
+			// THEN the run gets its text instead of stalling on a decode failure
+			expect(response.text).toBe('hi there')
+		})
+	})
+
+	describe('when the response already carries a valid service_tier', () => {
+		it('should leave the body untouched and still decode', async () => {
+			// GIVEN a string service_tier that the library accepts as-is
+			const body = chatCompletionBody('default')
+
+			// WHEN it flows through the wrapper (the strip is a no-op)
+			const [decoded] = await Effect.runPromise(
+				decodeThrough(body, tolerateNullServiceTier),
+			)
+
+			// THEN the field survives — reusing the original response is safe
+			expect(decoded.service_tier).toBe('default')
+			expect(decoded.choices[0]?.message?.content).toBe('hi there')
+		})
+	})
+
+	describe('when the response is a Server-Sent Events stream', () => {
+		it('should pass the stream through without buffering or altering it', async () => {
+			// GIVEN an SSE body that itself contains service_tier: null
+			const sse = 'data: {"id":"1","service_tier":null}\n\ndata: [DONE]\n\n'
+			const wrapped = tolerateNullServiceTier(
+				cannedClient(sse, 'text/event-stream'),
+			)
+
+			// WHEN a request runs through the wrapped client
+			const seen = await Effect.runPromise(
+				wrapped.get('http://qwen.test/v1/chat/completions').pipe(
+					Effect.flatMap(response =>
+						Effect.map(response.text, text => ({
+							contentType: response.headers['content-type'],
+							text,
+						})),
+					),
+				),
+			)
+
+			// THEN the event-stream body is delivered verbatim — the sanitizer never
+			// touches a stream (research only calls the non-streaming paths)
+			expect(seen.contentType).toBe('text/event-stream')
+			expect(seen.text).toBe(sse)
+		})
+	})
+})

--- a/packages/research/src/infrastructure/_service-tier.ts
+++ b/packages/research/src/infrastructure/_service-tier.ts
@@ -1,0 +1,88 @@
+/**
+ * Tolerate a `null` `service_tier` in OpenAI-compatible chat-completion
+ * responses.
+ *
+ * The custom endpoint serving Qwen answers with `"service_tier": null` — a
+ * field it does not populate. `@effect/ai-openai-compat` decodes the raw body
+ * with a schema that types that field as "absent or a string" (never null), so
+ * decode throws before any findings are produced and every research call fails.
+ *
+ * The fix lives on the HTTP boundary Batuda already supplies to the client, not
+ * in the dependency: `tolerateNullServiceTier` wraps the `HttpClient` so a
+ * `null` `service_tier` is dropped from the JSON body before the library reads
+ * it. Dropping the field (rather than coercing it) makes the body satisfy the
+ * "absent or a string" shape the library expects.
+ *
+ * Scope: only the research LLM client is wrapped, and only JSON responses are
+ * touched. Streaming (Server-Sent Events) responses are passed through
+ * untouched — buffering their body as text to sanitize it would collapse the
+ * stream, and research only ever calls the non-streaming generateText /
+ * generateObject paths.
+ */
+
+import { Effect } from 'effect'
+import {
+	HttpClient,
+	HttpClientResponse as HttpClientResponseNs,
+} from 'effect/unstable/http'
+
+const CONTENT_TYPE_HEADER = 'content-type'
+const CONTENT_LENGTH_HEADER = 'content-length'
+const EVENT_STREAM_CONTENT_TYPE = 'text/event-stream'
+
+/**
+ * Drop `service_tier` from a chat-completion body when the provider sent it as
+ * `null`. Returns the re-serialized JSON when the body changed, or `undefined`
+ * when there is nothing to strip — the field is absent, already a string, or
+ * the body is not a JSON object — so the caller can reuse the original response
+ * unchanged.
+ */
+export const stripNullServiceTier = (body: string): string | undefined => {
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(body)
+	} catch {
+		return undefined
+	}
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		return undefined
+	}
+	const record = parsed as Record<string, unknown>
+	if (record['service_tier'] !== null) return undefined
+	delete record['service_tier']
+	return JSON.stringify(record)
+}
+
+/**
+ * Wrap an `HttpClient` so JSON responses carrying a `null` `service_tier` are
+ * sanitized before `@effect/ai-openai-compat` decodes them. The transform
+ * callback receives the response effect and the originating request; the
+ * request is needed to rebuild the response after reading its body.
+ */
+export const tolerateNullServiceTier = (
+	client: HttpClient.HttpClient,
+): HttpClient.HttpClient =>
+	HttpClient.transform(client, (responseEffect, request) =>
+		Effect.flatMap(responseEffect, response => {
+			const contentType = response.headers[CONTENT_TYPE_HEADER] ?? ''
+			if (contentType.includes(EVENT_STREAM_CONTENT_TYPE)) {
+				return Effect.succeed(response)
+			}
+			return Effect.map(response.text, body => {
+				const sanitized = stripNullServiceTier(body)
+				if (sanitized === undefined) return response
+				const headers: Record<string, string> = {}
+				for (const [key, value] of Object.entries(response.headers)) {
+					// The body shrank by one field; a stale content-length would
+					// misreport its size to anything that trusts the header.
+					if (key.toLowerCase() !== CONTENT_LENGTH_HEADER) {
+						headers[key] = value
+					}
+				}
+				return HttpClientResponseNs.fromWeb(
+					request,
+					new Response(sanitized, { status: response.status, headers }),
+				)
+			})
+		}),
+	)

--- a/packages/research/src/infrastructure/llm-live.ts
+++ b/packages/research/src/infrastructure/llm-live.ts
@@ -37,6 +37,7 @@ import {
 } from '../application/ports'
 import { keyForSlot, providerListConfig } from './_config'
 import { hardenLanguageModel, withFallbackLanguageModel } from './_harden'
+import { tolerateNullServiceTier } from './_service-tier'
 import { type LlmTier, makeCachedLanguageModel } from './cached-llm'
 import { stubLanguageModelService } from './stub/llm'
 
@@ -79,9 +80,13 @@ const buildSlot = (
 				: LLM_BASE_URLS[vendor]
 		const service = yield* OpenAiLanguageModel.make({ model }).pipe(
 			Effect.provide(
-				OpenAiClient.layer({ apiKey, apiUrl: baseUrl }).pipe(
-					Layer.provide(FetchHttpClient.layer),
-				),
+				OpenAiClient.layer({
+					apiKey,
+					apiUrl: baseUrl,
+					// Qwen's OpenAI-compatible endpoint returns `service_tier: null`,
+					// which the client's response schema rejects; strip it before decode.
+					transformClient: tolerateNullServiceTier,
+				}).pipe(Layer.provide(FetchHttpClient.layer)),
 			),
 		)
 		return hardenLanguageModel(service, vendor)


### PR DESCRIPTION
## What

Research LLM calls were starting but never completing: the custom OpenAI-compatible endpoint serving Qwen answers with `"service_tier": null`, and `@effect/ai-openai-compat`'s response schema types that field as *absent or a string, never null* — so every call threw at decode (`Expected string, got null at ["service_tier"]`) and retried until the run was cancelled. This wraps the research LLM HTTP client to drop the null field before the library decodes it, so runs complete. Scoped to the Research context (the `server`-hosted research service); the dependency stays unpatched.

## The fix

- Added a scoped `HttpClient` wrapper (`tolerateNullServiceTier`), supplied through `OpenAiClient.layer`'s typed `transformClient` option, that strips a null `service_tier` from JSON response bodies before decode. Dropping the field (not coercing it) makes the body match the shape the library already accepts.
- Left streaming/SSE responses untouched — buffering their body to sanitize it would collapse the stream, and research only ever calls the non-streaming `generateText` / `generateObject` paths.

## Impact

- Scoped to the research LLM client only; the global `HttpClient` is untouched.
- No schema/migration, no new env vars, no RLS/tenant change, no wire-shape or API change, no MCP-vs-HTTP parity concern — only the research LLM transport moved.
- Dropping `service_tier` is behaviorally identical to a provider omitting it: it feeds only optional finish-metadata (`normalizeServiceTier(undefined) → undefined`), never the generated text, tool calls, usage, or finish reason.

## Review guide

- Start at `_service-tier.ts`: `stripNullServiceTier` (pure, ~14 lines) + `tolerateNullServiceTier` (the transform).
- Riskiest line: on the no-change path the wrapper reads `response.text` and then returns the **original** response. Safe because effect's `WebHttpClientResponse.text` is memoized, so the library's later `.json` decode reads the same cached bytes — verified in the vendored source and pinned by the "leave the body untouched and still decode" test.
- **Decision you might overrule:** the wrapper is applied to *every* provider slot, not just the custom/Qwen one. Intentional — the provider list is runtime config (`RESEARCH_LLM_*_PROVIDERS`), and `service_tier` is an OpenAI-proprietary field many compat providers leave null, so a provider swap stays fixed with no code change. Cost is one extra `JSON.parse` per non-streaming response, negligible against the LLM round-trip. A per-vendor gate would re-arm the same landmine on the next switch.
- The content-length strip when rebuilding is defensive hygiene (a WHATWG `Response.text()` reads the body regardless of the header); exercised indirectly, not by a dedicated assertion.

## Tests

- Real-dependency decode: a `service_tier: null` body **fails without** the wrapper (reproducing the exact `AiError`) and **succeeds with** it — a negative control proving the wrapper is what fixes it.
- The assembled LanguageModel, built exactly as `llm-live.ts` does it, returns text past a null-tier response.
- Edge cases: valid string tier (no-op reuse), absent field, non-JSON, array, `null` literal; and SSE pass-through leaving the body verbatim.

## Verification

- Gates green: `pnpm install` (no lockfile drift) → `check-types` (13/13) + `test` (server 503 + research 171) → `build` (13/13). Pre-push hook (secrets + full suite incl. `server#test:integration`) also green.
- **Live-provider end-to-end is prod-gated:** locally `RESEARCH_LLM_*_PROVIDERS=stub` (no real HTTP), and the Qwen endpoint + its secrets exist only in prod — so the real `research_sync` run confirms after `/release server`. The decode fix itself is exercised against the real `@effect/ai-openai-compat` dependency in the tests above.

## Deferred

- Deploy + prod verification (Honeycomb shows no `service_tier` decode errors; a `research_sync` completes with `costCents > 0`) — via `/release server`.
- Optional upstream effect report proposing `optionalKey(NullOr(Schema.String))` for `service_tier`, to eventually retire the wrapper (effect `main` has the identical schema, so a version bump alone would not fix this).

> Not in this diff: I separately reset Engranatge's org-default research instruction stack off the Spain template in prod (issue #167's last checkbox) — a production data change, already applied and verified.

Addresses #167.
