### PR TITLE
fix(research): accept model-emitted null for optional tool params

### DIFF
--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -1,0 +1,412 @@
+import { Effect, Layer, Schema, Stream } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { RegistryRecord, ScrapedPage, SearchResult } from '../domain/types'
+import { StubExtractProvider } from '../infrastructure/stub/extract'
+import { StubRegistryEsProvider } from '../infrastructure/stub/registry-es'
+import { StubScrapeProvider } from '../infrastructure/stub/scrape'
+import { StubSearchProvider } from '../infrastructure/stub/search'
+import {
+	type ExtractInput,
+	ExtractProvider,
+	type RegistryInput,
+	RegistryRouter,
+	type ScrapeInput,
+	ScrapeProvider,
+	type SearchInput,
+	SearchProvider,
+} from './ports'
+import {
+	ExtractStructuredTool,
+	RegistryLookupTool,
+	researchToolkit,
+	researchToolkitLayer,
+	ScrapePageTool,
+	WebSearchTool,
+} from './tools'
+
+// ── Test harness ──
+// Each helper drives one tool through the real toolkit. `researchToolkit.handle`
+// decodes the raw params with the tool's own parameter schema — the exact path
+// that rejected a model-emitted `null` before this fix — then runs the handler
+// on a forked fiber. Draining the result stream forces that handler to run, so
+// the capturing port stub records the input the handler actually built. The
+// three ports not under test are the shared deterministic stubs.
+
+const webSearchInput = async (params: {
+	query: string
+	limit?: number | null
+	recency_days?: number | null
+	location?: string | null
+}): Promise<SearchInput> => {
+	let captured: SearchInput | undefined
+	const ports = Layer.mergeAll(
+		Layer.succeed(SearchProvider)(
+			SearchProvider.of({
+				search: input => {
+					captured = input
+					return Effect.succeed(new SearchResult({ items: [], units: 0 }))
+				},
+			}),
+		),
+		StubScrapeProvider,
+		StubExtractProvider,
+		StubRegistryEsProvider,
+	)
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('web_search', params)
+			yield* Stream.runDrain(stream)
+		}).pipe(Effect.provide(researchToolkitLayer.pipe(Layer.provide(ports)))),
+	)
+	if (captured === undefined) {
+		throw new Error('web_search handler never called the search provider')
+	}
+	return captured
+}
+
+const registryLookupInput = async (params: {
+	country: 'ES' | 'GB'
+	query?: string | null
+	tax_id?: string | null
+}): Promise<RegistryInput> => {
+	let captured: RegistryInput | undefined
+	const ports = Layer.mergeAll(
+		Layer.succeed(RegistryRouter)(
+			RegistryRouter.of({
+				lookup: input => {
+					captured = input
+					return Effect.succeed(
+						new RegistryRecord({ legalName: 'ACME', units: 0 }),
+					)
+				},
+			}),
+		),
+		StubSearchProvider,
+		StubScrapeProvider,
+		StubExtractProvider,
+	)
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('registry_lookup', params)
+			yield* Stream.runDrain(stream)
+		}).pipe(Effect.provide(researchToolkitLayer.pipe(Layer.provide(ports)))),
+	)
+	if (captured === undefined) {
+		throw new Error('registry_lookup handler never called the registry router')
+	}
+	return captured
+}
+
+const extractInput = async (params: {
+	url: string
+	schema_name: string
+	prompt?: string | null
+}): Promise<ExtractInput> => {
+	let captured: ExtractInput | undefined
+	const ports = Layer.mergeAll(
+		Layer.succeed(ExtractProvider)(
+			ExtractProvider.of({
+				extract: input => {
+					captured = input
+					return Effect.succeed({})
+				},
+			}),
+		),
+		StubSearchProvider,
+		StubScrapeProvider,
+		StubRegistryEsProvider,
+	)
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('extract_structured', params)
+			yield* Stream.runDrain(stream)
+		}).pipe(Effect.provide(researchToolkitLayer.pipe(Layer.provide(ports)))),
+	)
+	if (captured === undefined) {
+		throw new Error(
+			'extract_structured handler never called the extract provider',
+		)
+	}
+	return captured
+}
+
+const scrapeInput = async (params: { url: string }): Promise<ScrapeInput> => {
+	let captured: ScrapeInput | undefined
+	const ports = Layer.mergeAll(
+		Layer.succeed(ScrapeProvider)(
+			ScrapeProvider.of({
+				scrape: input => {
+					captured = input
+					return Effect.succeed(
+						new ScrapedPage({ url: input.url, contentHash: 'h', units: 0 }),
+					)
+				},
+			}),
+		),
+		StubSearchProvider,
+		StubExtractProvider,
+		StubRegistryEsProvider,
+	)
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('scrape_page', params)
+			yield* Stream.runDrain(stream)
+		}).pipe(Effect.provide(researchToolkitLayer.pipe(Layer.provide(ports)))),
+	)
+	if (captured === undefined) {
+		throw new Error('scrape_page handler never called the scrape provider')
+	}
+	return captured
+}
+
+describe('researchToolkit tool params — model-emitted null is treated as omitted', () => {
+	describe('web_search handler', () => {
+		describe('when the optional params are explicit null', () => {
+			it('should hand the search provider undefined for limit, recency, and location', async () => {
+				// GIVEN a model that emits null for every optional field it is not using
+				// WHEN the web_search tool call is handled
+				const input = await webSearchInput({
+					query: 'acme corp',
+					limit: null,
+					recency_days: null,
+					location: null,
+				})
+
+				// THEN the required query still arrives
+				expect(input.query).toBe('acme corp')
+				// AND each optional null is folded to "not provided"
+				expect(input.limit).toBeUndefined()
+				expect(input.recency).toBeUndefined()
+				expect(input.location).toBeUndefined()
+			})
+		})
+
+		describe('when the optional params carry real values', () => {
+			it('should pass limit and location through and wrap recency_days as { days }', async () => {
+				// GIVEN a fully specified search
+				// WHEN handled
+				const input = await webSearchInput({
+					query: 'acme corp',
+					limit: 5,
+					recency_days: 7,
+					location: 'ES',
+				})
+
+				// THEN the values reach the provider unchanged, recency as a { days } object
+				expect(input.limit).toBe(5)
+				expect(input.recency).toEqual({ days: 7 })
+				expect(input.location).toBe('ES')
+			})
+		})
+
+		describe('when the optional keys are omitted entirely', () => {
+			it('should hand the search provider undefined (original optional-key behavior)', async () => {
+				// GIVEN only the required query, all optional keys absent
+				// WHEN handled
+				const input = await webSearchInput({ query: 'acme corp' })
+
+				// THEN the absent keys behave exactly like the null case
+				expect(input.limit).toBeUndefined()
+				expect(input.recency).toBeUndefined()
+				expect(input.location).toBeUndefined()
+			})
+		})
+
+		describe('when a falsy-but-valid value is given', () => {
+			it('should keep recency_days: 0 as { days: 0 } — only null is folded, not zero', async () => {
+				// GIVEN recency_days of 0 (a real value, distinct from "omitted")
+				// WHEN handled
+				const input = await webSearchInput({
+					query: 'acme corp',
+					recency_days: 0,
+				})
+
+				// THEN it is preserved because the guard tests for null, not truthiness
+				// [recency_days != null]
+				expect(input.recency).toEqual({ days: 0 })
+			})
+
+			it('should keep limit: 0 — ?? preserves zero', async () => {
+				// GIVEN a limit of 0
+				// WHEN handled
+				const input = await webSearchInput({ query: 'acme corp', limit: 0 })
+
+				// THEN zero survives (unlike a `|| undefined` would do) [limit ?? undefined]
+				expect(input.limit).toBe(0)
+			})
+
+			it('should keep location as an empty string — only nullish is folded', async () => {
+				// GIVEN an empty-string location
+				// WHEN handled
+				const input = await webSearchInput({ query: 'acme corp', location: '' })
+
+				// THEN the empty string is a real value and is preserved
+				expect(input.location).toBe('')
+			})
+		})
+	})
+
+	describe('registry_lookup handler', () => {
+		describe('when query and tax_id are null', () => {
+			it('should hand the router undefined for both, renaming tax_id to taxId', async () => {
+				// GIVEN a model emitting null for the optional lookup fields
+				// WHEN the registry_lookup tool call is handled
+				const input = await registryLookupInput({
+					country: 'ES',
+					query: null,
+					tax_id: null,
+				})
+
+				// THEN the required country arrives and both optionals fold to undefined
+				expect(input.country).toBe('ES')
+				expect(input.query).toBeUndefined()
+				expect(input.taxId).toBeUndefined()
+			})
+		})
+
+		describe('when tax_id carries a value', () => {
+			it('should pass it through as taxId', async () => {
+				// GIVEN a concrete tax id
+				// WHEN handled
+				const input = await registryLookupInput({
+					country: 'ES',
+					tax_id: 'B12345678',
+				})
+
+				// THEN it reaches the router under the renamed key
+				expect(input.taxId).toBe('B12345678')
+			})
+		})
+
+		describe('when query is an empty string', () => {
+			it('should keep the empty string (only nullish is folded)', async () => {
+				// GIVEN an empty-string query
+				// WHEN handled
+				const input = await registryLookupInput({ country: 'ES', query: '' })
+
+				// THEN the empty string survives
+				expect(input.query).toBe('')
+			})
+		})
+	})
+
+	describe('extract_structured handler', () => {
+		describe('when prompt is null', () => {
+			it('should hand the extractor undefined for prompt', async () => {
+				// GIVEN a registered schema name and a null prompt
+				// WHEN the extract_structured tool call is handled
+				const input = await extractInput({
+					url: 'https://acmecorp.es',
+					schema_name: 'freeform',
+					prompt: null,
+				})
+
+				// THEN the null prompt folds to undefined while schema wiring is preserved
+				expect(input.prompt).toBeUndefined()
+				expect(input.schemaName).toBe('freeform')
+			})
+		})
+
+		describe('when prompt carries a value', () => {
+			it('should pass it through', async () => {
+				// GIVEN extra guidance for the extractor
+				// WHEN handled
+				const input = await extractInput({
+					url: 'https://acmecorp.es',
+					schema_name: 'freeform',
+					prompt: 'focus on revenue figures',
+				})
+
+				// THEN the prompt reaches the extractor unchanged
+				expect(input.prompt).toBe('focus on revenue figures')
+			})
+		})
+	})
+
+	describe('scrape_page handler (no optional params — unaffected by the fix)', () => {
+		describe('when called with a url', () => {
+			it('should pass the url through and request the markdown format', async () => {
+				// GIVEN a url to scrape
+				// WHEN handled
+				const input = await scrapeInput({ url: 'https://acmecorp.es' })
+
+				// THEN the url is forwarded and the format is fixed to markdown
+				expect(input.url).toBe('https://acmecorp.es')
+				expect(input.formats).toEqual(['markdown'])
+			})
+		})
+	})
+
+	describe('tool parameter schemas — decode contract', () => {
+		describe('when an optional param is explicit null', () => {
+			it('should decode without rejecting for every widened optional param', () => {
+				// GIVEN the raw args a model sends with null for unused optionals — the
+				// exact decode that threw "Expected number, got null" before the fix
+				// WHEN each tool schema decodes them
+				// THEN the null passes through instead of failing validation
+				// [Schema.optionalKey(Schema.NullOr(...))]
+				const web = Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
+					query: 'acme',
+					limit: null,
+					recency_days: null,
+					location: null,
+				})
+				expect(web.limit).toBeNull()
+				expect(web.recency_days).toBeNull()
+				expect(web.location).toBeNull()
+
+				const extract = Schema.decodeUnknownSync(
+					ExtractStructuredTool.parametersSchema,
+				)({ url: 'https://x.test', schema_name: 'freeform', prompt: null })
+				expect(extract.prompt).toBeNull()
+
+				const registry = Schema.decodeUnknownSync(
+					RegistryLookupTool.parametersSchema,
+				)({ country: 'ES', query: null, tax_id: null })
+				expect(registry.query).toBeNull()
+				expect(registry.tax_id).toBeNull()
+			})
+		})
+
+		describe('when an optional param has a wrong, non-null type', () => {
+			it('should still reject — the schema was widened to null, not to anything', () => {
+				// GIVEN a string where a number is expected
+				// THEN decode still fails (null tolerance did not loosen the value type)
+				expect(() =>
+					Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
+						query: 'acme',
+						recency_days: 'soon',
+					}),
+				).toThrow()
+				expect(() =>
+					Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
+						query: 'acme',
+						limit: 'ten',
+					}),
+				).toThrow()
+			})
+		})
+
+		describe('when a required field is null', () => {
+			it('should reject — only the optional params were widened', () => {
+				// GIVEN null for a required field
+				// THEN decode fails, because required fields were left as bare String
+				expect(() =>
+					Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
+						query: null,
+					}),
+				).toThrow()
+				expect(() =>
+					Schema.decodeUnknownSync(ScrapePageTool.parametersSchema)({
+						url: null,
+					}),
+				).toThrow()
+			})
+		})
+	})
+})

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -30,19 +30,22 @@ import {
 import { schemaRegistry } from './schemas/index'
 
 // ── Tool parameter schemas ──
+// Optional params accept `null` (via `NullOr`) because a model may send an
+// explicit `null` for a field it isn't using instead of omitting it; the
+// handlers below treat that null as "not provided".
 
 const WebSearchParams = Schema.Struct({
 	query: Schema.String.annotate({
 		description: 'Search query; concise keywords work best',
 	}),
-	limit: Schema.optionalKey(Schema.Number).annotate({
+	limit: Schema.optionalKey(Schema.NullOr(Schema.Number)).annotate({
 		description: 'Max results to return (default 10)',
 	}),
-	recency_days: Schema.optionalKey(Schema.Number).annotate({
+	recency_days: Schema.optionalKey(Schema.NullOr(Schema.Number)).annotate({
 		description:
 			'Restrict to results published within the last N days. Omit for no filter.',
 	}),
-	location: Schema.optionalKey(Schema.String).annotate({
+	location: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
 		description: 'Geographic locale hint (e.g. "ES", "es-ES")',
 	}),
 })
@@ -58,7 +61,7 @@ const ExtractStructuredParams = Schema.Struct({
 	schema_name: Schema.String.annotate({
 		description: `Name of a registered schema. One of: ${Object.keys(schemaRegistry).join(', ')}`,
 	}),
-	prompt: Schema.optionalKey(Schema.String).annotate({
+	prompt: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
 		description:
 			'Optional extra guidance for the extractor (e.g. "focus on revenue figures").',
 	}),
@@ -68,10 +71,10 @@ const RegistryLookupParams = Schema.Struct({
 	country: Schema.Literals(SUPPORTED_COUNTRIES).annotate({
 		description: 'ISO country code; determines which registry to query',
 	}),
-	query: Schema.optionalKey(Schema.String).annotate({
+	query: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
 		description: 'Company name or fuzzy search string',
 	}),
-	tax_id: Schema.optionalKey(Schema.String).annotate({
+	tax_id: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
 		description: 'National tax id (e.g. ES CIF/NIF) — more precise than query',
 	}),
 })
@@ -144,12 +147,12 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 				search
 					.search({
 						query: params.query,
-						limit: params.limit,
+						limit: params.limit ?? undefined,
 						recency:
-							params.recency_days !== undefined
+							params.recency_days != null
 								? { days: params.recency_days }
 								: undefined,
-						location: params.location,
+						location: params.location ?? undefined,
 					})
 					.pipe(Effect.catchCause(cause => mapToolError('web_search')(cause))),
 
@@ -170,7 +173,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 						url: params.url,
 						schema,
 						schemaName: params.schema_name,
-						prompt: params.prompt,
+						prompt: params.prompt ?? undefined,
 					})
 					.pipe(
 						Effect.catchCause(cause =>
@@ -183,8 +186,8 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 				registry
 					.lookup({
 						country: params.country,
-						query: params.query,
-						taxId: params.tax_id,
+						query: params.query ?? undefined,
+						taxId: params.tax_id ?? undefined,
 					})
 					.pipe(
 						Effect.catchCause(cause => mapToolError('registry_lookup')(cause)),


### PR DESCRIPTION
## What

Research runs failed mid-flight whenever the phase-1 agent model (Qwen) emitted an explicit `null` for an optional tool param it wasn't using — e.g. a `web_search` call with `recency_days: null`. Tool-call arguments are decoded with the tool's raw parameter schema, where `Schema.optionalKey(Schema.Number)` permits an *absent* key but rejects an explicit `null`, so the call threw `Invalid parameters for tool 'web_search': Expected number, got null at ["recency_days"]` and the run died. This widens the six optional research tool params to accept `null` and treats it as "omitted" in the handlers. Scoped to the Research context (the `server`-hosted phase-1 tool loop). Same `optionalKey`-vs-`null` class as #167 — on the tool-call side rather than the LLM-response side.

## The fix

- Wrapped the six optional params in `Schema.NullOr(...)` (`limit`/`recency_days`/`location` on `web_search`, `prompt` on `extract_structured`, `query`/`tax_id` on `registry_lookup`) so the raw argument decode accepts a model-emitted `null` instead of throwing.
- Folded `null` back to "not provided" in each handler before calling the provider port (the ports treat only `undefined` as absent): `?? undefined` for the five pass-through params, and `recency_days != null ? { days } : undefined` — which also drops the latent `{ days: null }` the old `!== undefined` guard would have built.

## Impact

- Scoped to the phase-1 research tool loop; the toolkit's external shape (what `generateText({ toolkit })` consumes) is unchanged.
- No schema/migration, no new env vars, no RLS/tenant change, no wire-shape/API change, no MCP-vs-HTTP parity concern.
- The structured-output schemas (`schemas/*.ts`) share the `optionalKey` shape but are **not** affected and are intentionally untouched: `generateObject` decodes through `OpenAiStructuredOutput.toCodecOpenAI`, which already rewrites optional fields to nullable unions and filters `null`→absent on decode. The tool-call path is the only one that decodes against the *raw* schema, which is why it alone broke.
- The model was already *told* these fields are nullable — the JSON schema it sees is generated by that same `toCodecOpenAI` (renders `optionalKey` as `type: [T, "null"]`) — so this only aligns the decode with what the encode already advertised.

## Review guide

- Start at `tools.ts`: the six `optionalKey(NullOr(...))` params and the matching handler folds directly below.
- Riskiest line: `recency_days != null ? { days: params.recency_days } : undefined`. `!= null` (not the old `!== undefined`) is deliberate so both `null` and `undefined` map to omitted while `0` still yields `{ days: 0 }`; pinned by the falsy-but-valid tests.
- **Decision you might overrule:** I widened the raw param schemas + normalized in the handler, rather than routing the toolkit's arg decode through the null-filtering `toCodecOpenAI` codec (a framework-level change). The local fix matches #167/#159 and keeps the blast radius to one file.
- The `?? undefined` on the five pass-through params is required for type-correctness — the ports are typed `T | undefined`, so `check-types` fails if a `null` is left un-normalized; it isn't cosmetic.

## Tests

- New `tools.test.ts` drives each tool through the real `researchToolkit.handle` (decode → forked handler → a capturing port stub): a model-emitted `null` reaches the port as `undefined` for all six params; real values pass through (`recency_days: 7` → `{ days: 7 }`); omitted keys behave exactly as before.
- Falsy-but-valid distinctions: `recency_days: 0` → `{ days: 0 }`, `limit: 0` kept, `location`/`query: ''` kept — proving only nullish is folded, not falsy.
- Schema decode contract: `null` accepted for every widened param; a wrong non-null type (`recency_days: 'soon'`) and a `null` in a required field still reject.

## Verification

- Gates green repo-wide (turbo 37/37): `pnpm install` (no lockfile drift) → `check-types` + `test` (server 503, research 186 + 21 todo) → `build`. The existing `openai-structured-output.test.ts` (11) still passes — the guard that `NullOr` didn't break the model-facing JSON-schema generation through `toCodecOpenAI`.
- **Live end-to-end note:** forcing the model to emit `null` on a real run isn't deterministic, so the handler test — which exercises the exact decode → handler → port path that failed in prod on the "Sallaz Logistics" run — is the faithful reproduction.

## Deferred

- No dedicated `/release` for this PR — it ships with the next `server` deploy.
- The MCP tools in `apps/server/src/mcp/tools/*.ts` use the same `Tool.make` + `optionalKey` shape and could share this class if their external client sends `null` for an optional param; not observed, and outside this `[research]` issue — a separate issue if it surfaces.

Closes #173.
