### PR TITLE
fix: run research jobs from a background queue, not the web request

### DIFF
--- a/apps/server/src/db/migrations/0019_research_run_instruction_segments.ts
+++ b/apps/server/src/db/migrations/0019_research_run_instruction_segments.ts
@@ -1,0 +1,16 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// The resolved standing-instruction text segments that shape a run's phase-1
+// prompt. Captured when the run is created so they stay fixed for the whole run
+// even if the underlying templates later change. Existing rows default to an
+// empty set.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		ALTER TABLE research_runs
+			ADD COLUMN instruction_segments jsonb NOT NULL DEFAULT '[]'::jsonb
+	`
+})

--- a/apps/server/src/services/research-dispatch.integration.test.ts
+++ b/apps/server/src/services/research-dispatch.integration.test.ts
@@ -1,0 +1,121 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Deferred, Effect, Exit, Fiber } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client.js'
+
+// A research run is created inside the request transaction (the org middleware
+// wraps every handler in sql.withTransaction) and then dispatched to do its
+// cache writes. A job forked from that request fiber inherits the request's
+// transaction connection; once the request commits, the job's first
+// sql.withTransaction issues SAVEPOINT on a pooled connection with no live BEGIN
+// and dies on "ROLLBACK TO SAVEPOINT can only be used in transaction blocks".
+// The dispatch consumer runs each job from the service's own scope, so its first
+// transaction opens a clean connection. These tests pin that contract with the
+// exact cache write web_search performs: an advisory-locked search_cache upsert
+// inside a transaction.
+
+// The shape of cached-search's web_search cache write.
+const cacheWrite = (key: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		yield* Effect.gen(function* () {
+			yield* sql`SELECT pg_advisory_xact_lock(hashtext(${`search:${key}`}))`
+			yield* sql`
+				INSERT INTO search_cache (
+					key_hash, provider, query, items, units_cost, cached_at, expires_at
+				) VALUES (
+					${key}, 'it-stub', 'q', '[]'::jsonb, 0, now(), now() + interval '1 hour'
+				)
+				ON CONFLICT (key_hash) DO UPDATE SET cached_at = now()
+			`
+		}).pipe(sql.withTransaction)
+	})
+
+const cacheRowExists = (key: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const rows = yield* sql<{
+			keyHash: string
+		}>`SELECT key_hash FROM search_cache WHERE key_hash = ${key}`
+		return rows.length > 0
+	})
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`DELETE FROM search_cache WHERE key_hash LIKE 'it-171-%'`
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('research dispatch transaction context', () => {
+	describe('when a cache-writing job is forked from inside a committed request transaction', () => {
+		it('should die on ROLLBACK TO SAVEPOINT — the failure the consumer removes', async () => {
+			// GIVEN the cache write forked from within a request transaction, so it
+			//   holds that transaction's connection [forkDetach]
+			// WHEN the request transaction commits and the forked job then runs its
+			//   own sql.withTransaction on the now-released connection
+			// THEN it issues SAVEPOINT with no live BEGIN and the fiber fails
+			const key = `it-171-${randomUUID()}`
+			const exit = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					// Release the job only after the request transaction has committed,
+					// so the crash is deterministic rather than a scheduling race.
+					const afterCommit = yield* Deferred.make<void>()
+					const fiber = yield* sql.withTransaction(
+						Effect.gen(function* () {
+							return yield* Deferred.await(afterCommit).pipe(
+								Effect.andThen(cacheWrite(key)),
+								Effect.forkDetach,
+							)
+						}),
+					)
+					yield* Deferred.succeed(afterCommit, undefined)
+					return yield* Fiber.await(fiber)
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					Exit.Exit<void, unknown>,
+					never,
+					never
+				>,
+			)
+
+			expect(Exit.isFailure(exit)).toBe(true)
+		})
+	})
+
+	describe('when the same job runs from the service’s own clean scope', () => {
+		it('should open its own transaction, commit, and write the cache row', async () => {
+			// GIVEN a request transaction that has already committed
+			// WHEN the identical cache write runs on a fiber forked into a clean
+			//   scope — as the layer-scoped dispatch consumer runs it — rather than
+			//   the request fiber [forkIn]
+			// THEN its transaction opens a real BEGIN, commits, and the row lands
+			const key = `it-171-${randomUUID()}`
+			const committed = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const sql = yield* SqlClient.SqlClient
+						const scope = yield* Effect.scope
+						// A prior request transaction, now committed.
+						yield* sql.withTransaction(sql`SELECT 1`)
+						const fiber = yield* cacheWrite(key).pipe(Effect.forkIn(scope))
+						yield* Fiber.await(fiber)
+						return yield* cacheRowExists(key)
+					}),
+				).pipe(Effect.provide(PgLive)) as Effect.Effect<boolean, never, never>,
+			)
+
+			expect(committed).toBe(true)
+		})
+	})
+})

--- a/apps/server/src/services/research-service-dispatch.integration.test.ts
+++ b/apps/server/src/services/research-service-dispatch.integration.test.ts
@@ -1,0 +1,309 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+// The service reads this concurrency gate via Config at layer-build time.
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	type CreateResearchInput,
+	ExtractLanguageModel,
+	ExtractProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	researchToolkitLayer,
+	ScrapeProvider,
+	SearchProvider,
+	type SystemDefaults,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+// A research run is created inside the request transaction (the org middleware
+// wraps every handler in sql.withTransaction) and then handed to the
+// layer-scoped dispatch consumer, which runs the job on the service's OWN clean
+// connection — never the request's already-committed one. This drives the real
+// ResearchService end-to-end: create() inside a request scope, then the job
+// runs to succeeded, including the sql.withTransaction cache write that crashed
+// under bug #171 when a job wrongly inherited the committed request connection.
+//
+// The provider ports below are never exercised: the Agent language model stub
+// returns no tool calls, so the toolkit handlers (web_search/scrape/etc.) are
+// never invoked. They exist only so researchToolkitLayer builds.
+
+interface Org {
+	id: string
+	name: string
+	slug: string
+}
+
+// A deterministic language-model response shaped like the shipped stub — the
+// fields the research fiber reads back (text, usage totals, empty toolCalls).
+const STUB_TEXT =
+	'Acme Corp S.L. is a Barcelona-based industrial solutions company. ' +
+	'They employ 85 people and reported €12M revenue in 2025.'
+
+const stubResponse = {
+	text: STUB_TEXT,
+	content: [{ type: 'text' as const, text: STUB_TEXT }],
+	reasoning: [],
+	reasoningText: undefined,
+	toolCalls: [],
+	toolResults: [],
+	finishReason: 'stop' as const,
+	usage: {
+		inputTokens: {
+			uncached: undefined,
+			total: 0,
+			cacheRead: undefined,
+			cacheWrite: undefined,
+		},
+		outputTokens: { total: 0, text: undefined, reasoning: undefined },
+	},
+}
+
+// The three tiers share this zero-cost stub; the `as never` casts match the
+// shipped stub (the real LanguageModel.Service response type is far wider than
+// what the fiber reads).
+const stubLlm: LanguageModel.Service = {
+	generateText: (_options: unknown) => Effect.succeed(stubResponse) as never,
+	generateObject: (_options: unknown) =>
+		Effect.succeed({
+			...stubResponse,
+			value: {
+				company_name: 'Acme Corp S.L.',
+				tax_id: 'B12345678',
+				summary: STUB_TEXT,
+			},
+		}) as never,
+	streamText: (_options: unknown) =>
+		Stream.succeed({ type: 'text-delta' as const, delta: STUB_TEXT }) as never,
+}
+
+// The search_cache key the Agent stub's #171-shaped write lands on. A committed
+// row here after the run succeeds proves the write ran its own BEGIN/COMMIT on a
+// clean connection (a distinct prefix from the sibling suite's `it-171-%` so
+// neither cleanup touches the other's rows).
+const searchCacheKey = `it-svc-171-${randomUUID()}`
+
+// The Agent tier: before returning the deterministic response, perform the exact
+// advisory-locked search_cache upsert web_search runs, inside its own
+// transaction. Forked onto the request connection (the bug) this dies on
+// "ROLLBACK TO SAVEPOINT ... in transaction blocks"; on the service's clean
+// connection it commits.
+const agentLlm: LanguageModel.Service = {
+	...stubLlm,
+	generateText: (_options: unknown) =>
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* Effect.gen(function* () {
+				yield* sql`SELECT pg_advisory_xact_lock(hashtext(${`search:${searchCacheKey}`}))`
+				yield* sql`
+					INSERT INTO search_cache (
+						key_hash, provider, query, items, units_cost, cached_at, expires_at
+					) VALUES (
+						${searchCacheKey}, 'it-stub', 'q', '[]'::jsonb, 0, now(), now() + interval '1 hour'
+					)
+					ON CONFLICT (key_hash) DO UPDATE SET cached_at = now()
+				`
+			}).pipe(sql.withTransaction)
+			return stubResponse
+		}) as never,
+}
+
+// Provider ports the toolkit builds against but never calls (no tool calls are
+// emitted). Dying makes any accidental invocation fail loudly rather than pass
+// silently.
+const unused = 'research provider not exercised by the Agent stub'
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({ search: () => Effect.die(unused) }),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({ scrape: () => Effect.die(unused) }),
+	),
+	Layer.succeed(ExtractProvider)(
+		ExtractProvider.of({ extract: () => Effect.die(unused) }),
+	),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(unused) }),
+	),
+)
+
+const llmLayer = Layer.mergeAll(
+	Layer.succeed(AgentLanguageModel)(agentLlm),
+	Layer.succeed(ExtractLanguageModel)(stubLlm),
+	Layer.succeed(WriterLanguageModel)(stubLlm),
+)
+
+// A no-op event sink: the run fires observability events we don't assert on.
+const eventSinkLayer = Layer.succeed(ResearchEventSink)(
+	ResearchEventSink.of({ fire: () => Effect.void }),
+)
+
+// The full service under test. provideMerge(PgLive) both feeds the service its
+// SqlClient AND re-exports it, so the test's request transaction and the
+// service's dispatch consumer draw from the same connection pool — exactly the
+// runtime wiring.
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(llmLayer),
+	Layer.provide(researchToolkitLayer.pipe(Layer.provide(providersLayer))),
+	Layer.provide(eventSinkLayer),
+	Layer.provideMerge(PgLive),
+)
+
+const systemDefaults: SystemDefaults = {
+	budgetCents: 100,
+	paidBudgetCents: 500,
+	autoApprovePaidCents: 200,
+	paidMonthlyCapCents: 2000,
+	hardCeiling: 5000,
+}
+
+const researchInput: CreateResearchInput = {
+	query: 'F1 dispatch test',
+	// Skip the outer research_cache lookup so a fresh fiber always runs.
+	forceFresh: true,
+}
+
+const TERMINAL = new Set(['succeeded', 'failed', 'cancelled'])
+
+const ctx = {} as { org: Org }
+let userId = ''
+let runId: string | null = null
+
+beforeAll(async () => {
+	const seed = await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [org] = yield* sql<Org>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [user] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!org || !user) {
+				throw new Error(
+					"taller org / admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			return { org, userId: user.id }
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+			{ org: Org; userId: string },
+			never,
+			never
+		>,
+	)
+	ctx.org = seed.org
+	userId = seed.userId
+}, 60_000)
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			if (runId) {
+				// research_cache has no ON DELETE CASCADE from research_runs, so it
+				// must go first; research_run_sources / research_links / paid_spend
+				// cascade with the run row.
+				yield* sql`DELETE FROM research_cache WHERE research_id = ${runId}::uuid`
+				yield* sql`DELETE FROM research_runs WHERE id = ${runId}::uuid`
+			}
+			yield* sql`DELETE FROM search_cache WHERE key_hash = ${searchCacheKey}`
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('ResearchService dispatch', () => {
+	describe('when a run is created inside a request transaction', () => {
+		it('should run to succeeded on the consumer’s clean connection and commit its cache write', async () => {
+			// GIVEN the real ResearchService with stub providers + LLMs, where the
+			//   Agent tier performs the #171-shaped sql.withTransaction cache write
+			// WHEN create() runs inside enterOrgScope (a real request transaction)
+			//   and the layer-scoped consumer picks the queued run up and runs it
+			// THEN the run reaches 'succeeded' and the cache row committed — proving
+			//   the job's own transaction opened on a clean connection, not the
+			//   request's already-committed one
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const sql = yield* SqlClient.SqlClient
+
+					// create() runs inside the request transaction, like the HTTP
+					// handler under OrgMiddleware. It returns a queued run id.
+					const created = yield* enterOrgScope(sql, {
+						org: ctx.org,
+						userId,
+					})(svc.create(userId, ctx.org.id, researchInput, systemDefaults))
+					runId = created.id
+
+					// Poll get() until the dispatch consumer drives the run terminal.
+					// 50 × 300ms bounds the wait so a stuck run reports its last status
+					// rather than hanging the suite.
+					const poll = (
+						attemptsLeft: number,
+					): Effect.Effect<
+						{ status: string; errorMessage: string | null },
+						never,
+						never
+					> =>
+						Effect.gen(function* () {
+							const run = (yield* svc.get(created.id).pipe(Effect.orDie)) as {
+								status?: string
+								errorMessage?: string | null
+							} | null
+							const status = run?.status ?? 'unknown'
+							if (TERMINAL.has(status) || attemptsLeft <= 0) {
+								return { status, errorMessage: run?.errorMessage ?? null }
+							}
+							yield* Effect.sleep('300 millis')
+							return yield* poll(attemptsLeft - 1)
+						})
+
+					const final = yield* poll(50)
+
+					const cacheRows = yield* sql<{ keyHash: string }>`
+						SELECT key_hash FROM search_cache WHERE key_hash = ${searchCacheKey}
+					`.pipe(Effect.orDie)
+
+					return {
+						status: final.status,
+						errorMessage: final.errorMessage,
+						cacheCommitted: cacheRows.length > 0,
+						queuedId: created.id,
+						createStatus: created.status,
+					}
+				}).pipe(Effect.provide(ResearchLive)) as Effect.Effect<
+					{
+						status: string
+						errorMessage: string | null
+						cacheCommitted: boolean
+						queuedId: string
+						createStatus: string
+					},
+					never,
+					never
+				>,
+			)
+
+			expect(outcome.createStatus).toBe('queued')
+			expect(outcome.queuedId).toBeTruthy()
+			expect(
+				outcome.status,
+				`run did not succeed: ${outcome.errorMessage ?? '(no error recorded)'}`,
+			).toBe('succeeded')
+			expect(outcome.cacheCommitted).toBe(true)
+		}, 30_000)
+	})
+})

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -10,13 +10,14 @@ import {
 	Layer,
 	PartitionedSemaphore,
 	PubSub,
+	Queue,
 	Ref,
+	Schedule,
 	ServiceMap,
 	Stream,
 } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
-import type { ResolvedPolicy } from '../domain/types'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
 	AgentLanguageModel,
@@ -263,9 +264,9 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 
 			const ORPHAN_AGE_SECONDS = 900
 
-			// Reclaim runs that cannot progress after a server restart:
-			// 'running' rows whose fiber vanished mid-execution, and 'queued'
-			// rows whose in-memory permit-wait slot vanished.
+			// Fail 'running' rows whose fiber vanished mid-execution after a
+			// server restart. A paid run isn't safe to silently re-run, so it is
+			// not re-dispatched. (Queued rows are re-offered below instead.)
 			const sweepOrphanRuns = (maxAgeSeconds: number) =>
 				Effect.gen(function* () {
 					// COALESCE guards NULL findings: jsonb_set(NULL, …) returns
@@ -283,33 +284,18 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						  AND (idempotency_key IS NULL OR idempotency_key NOT LIKE 'seed:%')
 						RETURNING id
 					`
-					// Queued rows have no started_at — the fiber never reached
-					// the status-to-running flip. Fall back to created_at.
-					const queued = yield* sql<{ id: string }>`
-						UPDATE research_runs
-						SET status = 'failed',
-							findings = jsonb_set(COALESCE(findings, '{}'::jsonb), '{error}', '"server restarted before fiber started"'),
-							completed_at = now(),
-							updated_at = now()
-						WHERE status = 'queued'
-						  AND created_at < now() - interval '1 second' * ${maxAgeSeconds}
-						  AND (idempotency_key IS NULL OR idempotency_key NOT LIKE 'seed:%')
-						RETURNING id
-					`
-					return { running, queued }
+					return { running }
 				}).pipe(sql.withTransaction)
 
 			// ── Startup sweep ──
 			const swept = yield* sweepOrphanRuns(ORPHAN_AGE_SECONDS)
-			if (swept.running.length > 0 || swept.queued.length > 0) {
+			if (swept.running.length > 0) {
 				yield* Effect.logWarning(
-					'research.sweepOrphans: marked orphaned runs as failed',
+					'research.sweepOrphans: failed runs orphaned mid-run',
 				).pipe(
 					Effect.annotateLogs({
 						running_count: swept.running.length,
-						queued_count: swept.queued.length,
 						running_ids: swept.running.map(r => r.id),
-						queued_ids: swept.queued.map(r => r.id),
 					}),
 				)
 			}
@@ -331,6 +317,50 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 			)
 			const fiberSem = yield* PartitionedSemaphore.make<string>({
 				permits: maxConcurrentFibersTotal,
+			})
+
+			// Dispatch channel: create() offers a queued run here; the
+			// layer-scoped consumer (below) drains it and runs each job on the
+			// service's own connection. Unbounded so create() never blocks —
+			// concurrency is bounded by the permit pool above. research_runs is
+			// the durable record and this queue is only an in-process hand-off,
+			// so the reconcile below re-offers any run left queued.
+			const dispatch = yield* Queue.unbounded<{
+				researchId: string
+				userId: string
+			}>()
+
+			// Re-offer every committed queued run to the dispatch queue. create()
+			// also offers on the request path, but it does so while the run's row is
+			// still uncommitted in the request transaction, so the consumer's own
+			// connection may not see it yet. This runs outside any request
+			// transaction, so it picks up every run left queued — a raced offer, a
+			// crash, or another process. The consumer skips runs already in flight,
+			// so re-offers never double-run.
+			const reofferQueued = Effect.gen(function* () {
+				const pending = yield* sql<{ id: string; createdBy: string }>`
+					SELECT id, created_by FROM research_runs
+					WHERE status = 'queued'
+					  AND (idempotency_key IS NULL OR idempotency_key NOT LIKE 'seed:%')
+					-- Oldest first, capped at the concurrency limit so a large backlog
+					-- drains in waves instead of forking every run at once.
+					ORDER BY created_at
+					LIMIT ${maxConcurrentFibersTotal}
+				`
+				yield* Effect.forEach(
+					pending,
+					row =>
+						Queue.offer(dispatch, {
+							researchId: row.id,
+							userId: row.createdBy,
+						}),
+					{ discard: true },
+				)
+				if (pending.length > 0) {
+					yield* Effect.logInfo(
+						'research.dispatch: re-offered queued runs',
+					).pipe(Effect.annotateLogs({ count: pending.length }))
+				}
 			})
 
 			// ── Event sink (observability: webhooks, metrics) ──
@@ -420,29 +450,41 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					`
 				}).pipe(sql.withTransaction)
 
+			// Release a run's in-memory resources on any exit — success, failure, or
+			// an interrupt while it is still waiting for a concurrency slot. Applied
+			// around the whole job below (permit wait included), not inside it, so a
+			// cancel before the run acquires a slot still shuts the channel down and
+			// clears the maps.
+			const cleanupRun = (researchId: string) =>
+				Effect.gen(function* () {
+					// Shut the channel before dropping the map entry so the terminal
+					// signal reaches subscribers; otherwise the subscriber's event
+					// stream stays open until the HTTP socket drops.
+					const pubsubMap = yield* Ref.get(activePubSubs)
+					const maybePubSub = HashMap.get(pubsubMap, researchId)
+					if (maybePubSub._tag === 'Some') {
+						yield* PubSub.shutdown(maybePubSub.value)
+					}
+					yield* Ref.update(activePubSubs, m => HashMap.remove(m, researchId))
+					yield* Ref.update(activeFibers, m => HashMap.remove(m, researchId))
+				})
+
 			// ── Core: run a single research fiber ──
 
-			const runFiber = (
-				researchId: string,
-				userId: string,
-				// Reserved for the full budget/quota wiring (not yet plumbed
-				// into the LLM tool loop — will feed makeBudgetLayer).
-				_policy: ResolvedPolicy,
-				_systemCeiling: number,
-				// Resolved instruction segments + their fingerprint, threaded from
-				// create() so the detached fiber never re-resolves (its RLS GUCs
-				// are unset). Segments shape phase 1; the fingerprint keys the
-				// cache write-back to match the read-check.
-				segments: ReadonlyArray<string>,
-				templateFingerprint: string,
-			) =>
+			const runFiber = (researchId: string, userId: string) =>
 				Effect.gen(function* () {
-					// Update status to running
-					yield* sql`
+					// Claim the run: proceed only if it is still queued. The consumer
+					// forks this after acquiring a concurrency permit, so the flip to
+					// running lands when work actually starts (a run waiting for a
+					// slot stays queued), and a run cancelled or already claimed while
+					// it waited is skipped.
+					const [claimed] = yield* sql<{ id: string }>`
 						UPDATE research_runs
 						SET status = 'running', started_at = now(), updated_at = now()
-						WHERE id = ${researchId}
+						WHERE id = ${researchId} AND status = 'queued'
+						RETURNING id
 					`
+					if (!claimed) return
 
 					yield* publishEvent(researchId, 'run.started', {})
 
@@ -451,6 +493,16 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						SELECT * FROM research_runs WHERE id = ${researchId}
 					`
 					if (!run) return
+
+					// The run's inputs live on the row so the dispatch consumer can
+					// reconstruct it (including after a restart): segments shape the
+					// phase-1 prompt, the fingerprint keys the cache write-back.
+					const segments = ((
+						run as { instructionSegments?: ReadonlyArray<string> }
+					).instructionSegments ?? []) as ReadonlyArray<string>
+					const templateFingerprint =
+						(run as { templateFingerprint?: string | null })
+							.templateFingerprint ?? ''
 
 					const context = run['context'] as CreateResearchInput['context']
 					const schemaName =
@@ -486,7 +538,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							SET status = 'failed',
 								findings = ${JSON.stringify({ error: `Unknown schema: ${schemaName}` })},
 								completed_at = now(), updated_at = now()
-							WHERE id = ${researchId}
+							WHERE id = ${researchId} AND status = 'running'
 						`
 						yield* publishEvent(researchId, 'run.failed', {
 							error: `Unknown schema: ${schemaName}`,
@@ -690,7 +742,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							tool_log = ${JSON.stringify(finalToolLog)},
 							completed_at = now(),
 							updated_at = now()
-						WHERE id = ${researchId}
+						WHERE id = ${researchId} AND status = 'running'
 					`
 
 					// ── Write to research_cache so identical requests can skip the fiber ──
@@ -739,7 +791,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 										findings = ${JSON.stringify({ error: detail })},
 										completed_at = now(),
 										updated_at = now()
-									WHERE id = ${researchId}
+									WHERE id = ${researchId} AND status = 'running'
 								`
 								yield* publishEvent(researchId, 'run.failed', {
 									error: detail,
@@ -750,26 +802,6 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						// path sets the status itself, so don't overwrite it.
 						return Effect.interrupt
 					}),
-					Effect.ensuring(
-						Effect.gen(function* () {
-							// Without this shutdown, Stream.fromPubSub keeps the
-							// subscriber channel open past the terminal event — the
-							// stream only ends when the HTTP socket drops. Shut
-							// down before removing the map entry so the interrupt
-							// signal reaches waiting subscribers.
-							const pubsubMap = yield* Ref.get(activePubSubs)
-							const maybePubSub = HashMap.get(pubsubMap, researchId)
-							if (maybePubSub._tag === 'Some') {
-								yield* PubSub.shutdown(maybePubSub.value)
-							}
-							yield* Ref.update(activePubSubs, m =>
-								HashMap.remove(m, researchId),
-							)
-							yield* Ref.update(activeFibers, m =>
-								HashMap.remove(m, researchId),
-							)
-						}),
-					),
 					Effect.annotateLogs({
 						research_id: researchId,
 						user_id: userId,
@@ -777,8 +809,52 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					}),
 				)
 
+			// ── Dispatch ──
+			// Two layer-scoped daemons: the reconcile re-offers committed queued
+			// runs, and the consumer drains the queue and runs each job on the layer
+			// fiber's clean services — never a request's committed connection. Runs
+			// fork into the layer scope so a shutdown interrupts them; their rows are
+			// reclaimed on the next boot. A failure in either is logged, not fatal.
+			const layerScope = yield* Effect.scope
+			yield* reofferQueued.pipe(
+				Effect.catchCause(cause =>
+					Effect.logError('research.dispatch: reconcile failed').pipe(
+						Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+					),
+				),
+				Effect.repeat(Schedule.spaced('2 seconds')),
+				Effect.forkScoped,
+			)
+			yield* Queue.take(dispatch).pipe(
+				Effect.flatMap(({ researchId, userId }) =>
+					Effect.gen(function* () {
+						// Skip a run already in flight: the reconcile re-offers queued
+						// rows, so the same run can arrive twice. (The guarded claim is
+						// the final backstop; this just avoids a redundant fiber.)
+						const inFlight = yield* Ref.get(activeFibers)
+						if (HashMap.has(inFlight, researchId)) return
+						const fiber = yield* fiberSem
+							.withPermit(userId)(runFiber(researchId, userId))
+							.pipe(
+								Effect.ensuring(cleanupRun(researchId)),
+								Effect.forkIn(layerScope),
+							)
+						yield* Ref.update(activeFibers, m =>
+							HashMap.set(m, researchId, fiber),
+						)
+					}),
+				),
+				Effect.catchCause(cause =>
+					Effect.logError('research.dispatch: failed to start run').pipe(
+						Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+					),
+				),
+				Effect.forever,
+				Effect.forkScoped,
+			)
+
 			return {
-				/** Create a research run, fork the fiber, return the run id. */
+				/** Create a research run, enqueue it, and return the run id. */
 				create: (
 					userId: string,
 					organizationId: string,
@@ -929,7 +1005,8 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								query, mode, schema_name, status, context,
 								budget_cents, paid_budget_cents,
 								paid_policy, idempotency_key, created_by,
-								template_ids, template_names, template_fingerprint
+								template_ids, template_names, template_fingerprint,
+								instruction_segments
 							) VALUES (
 								${organizationId},
 								${input.query},
@@ -944,7 +1021,8 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								${userId},
 								${JSON.stringify(templateIds)},
 								${JSON.stringify(templateNames)},
-								${templateFingerprint}
+								${templateFingerprint},
+								${JSON.stringify(segments)}
 							) RETURNING id
 						`
 						const researchId = (row as { id: string }).id
@@ -967,26 +1045,12 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							HashMap.set(m, researchId, pubsub),
 						)
 
-						// withPermit is wrapped inside the fork, not around it, so
-						// create() returns immediately and the permit wait plus its
-						// interrupt handler live on the forked fiber. Cancellation
-						// while queued then releases the slot cleanly without
-						// touching the caller's flow.
-						const fiber = yield* Effect.forkDetach(
-							fiberSem.withPermit(userId)(
-								runFiber(
-									researchId,
-									userId,
-									policy,
-									systemDefaults.hardCeiling,
-									segments,
-									templateFingerprint,
-								),
-							),
-						)
-						yield* Ref.update(activeFibers, m =>
-							HashMap.set(m, researchId, fiber),
-						)
+						// The row is queued; the dispatch consumer runs it on the
+						// service's own connection once a concurrency slot frees.
+						// Running it on this request's fiber would reuse the request
+						// transaction's connection — already committed by the time
+						// the job writes its first cache row.
+						yield* Queue.offer(dispatch, { researchId, userId })
 
 						return { id: researchId, status: 'queued' as const }
 					}),

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -513,8 +513,8 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					// phase; on resume we skip already-completed phases.
 					const checkpointPhase = ((run as { phase?: number | null }).phase ??
 						0) as number
-					const cachedResearchText = (run as { research_text?: string | null })
-						.research_text
+					const cachedResearchText = (run as { researchText?: string | null })
+						.researchText
 					const existingFindings = run['findings'] as Record<
 						string,
 						unknown
@@ -554,8 +554,13 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						subjects.length > 0
 							? `\n\nSubject data (frozen snapshot):\n${JSON.stringify(subjects, null, 2)}`
 							: ''
-					const hintsContext = context?.hints
-						? `\n\nHints: language=${context.hints.language ?? 'en'}, recency=${context.hints.recency_days ?? 'any'}, location=${context.hints.location ?? 'any'}`
+					// The stored hints round-trip through the camelCasing row transform,
+					// so read `recencyDays`, not the request's `recency_days`.
+					const hints = context?.hints as
+						| { language?: string; recencyDays?: number; location?: string }
+						| undefined
+					const hintsContext = hints
+						? `\n\nHints: language=${hints.language ?? 'en'}, recency=${hints.recencyDays ?? 'any'}, location=${hints.location ?? 'any'}`
 						: ''
 					const systemPrompt = buildResearchSystemPrompt({
 						schemaName,


### PR DESCRIPTION
## What

Company research (the CRM's Research feature) was failing **100% in production** — every run died on its first cache write. This fixes it by changing *how* a run starts: instead of running the job on the web request that triggered it, the run's database row becomes a small work queue that a background worker drains.

Root cause (Research context — `apps/server` + `packages/research`): `research.create` forked the job with `Effect.forkDetach` **inside** the request transaction. The detached job inherited the request's connection — via effect-sql's `TransactionConnection`, which is a **ServiceMap service, not a FiberRef** as issue #171 guessed. By the time the job ran, the request had committed, so its first `sql.withTransaction` issued `SAVEPOINT` on a pooled connection with no open transaction and died on `ROLLBACK TO SAVEPOINT can only be used in transaction blocks`.

## The fix

- **`research_runs.status='queued'` is the durable queue.** `create` inserts the row inside the request transaction and returns `{id, status:'queued'}` — it no longer forks anything.
- **A layer-scoped consumer daemon** (`forkScoped`, mirroring `inbox-health-probe`) drains the queue and runs each job on the service's **own clean connection** — never a request's committed one. `runFiber` claims its run atomically (`WHERE status='queued'`).
- **A reconcile daemon** re-offers committed `queued` rows (capped at the concurrency limit), with an in-flight dedup guard — so a run offered before its `INSERT` commits is never stranded.
- **New column `instruction_segments`** (migration `0019`) so the worker can rebuild a run's phase-1 inputs from its row after the request is gone.
- Second commit: two **pre-existing** camelCase read bugs (`research_text` resume, `recency_days` hint) that read snake_case keys under a camelCasing SQL client, so both always read `undefined`.

## Impact

- **Migration (must run before the new server boots):** `0019` adds `research_runs.instruction_segments` (`jsonb NOT NULL DEFAULT '[]'`); `create` INSERTs it, so an un-migrated schema crashes on the first run.
- **RLS / role:** the reconcile SELECT and the startup sweep read/write `research_runs` cross-org as the base pooled role — the *same role and point* `sweepOrphanRuns` already uses; no new tenant-isolation boundary is crossed. `runFiber`'s org-scoped writes take `organization_id` from the run row (unchanged — the detached fiber already ran without request GUCs).
- **MCP + HTTP parity:** `create` is the shared service both transports call; both now enqueue identically.
- No wire-shape change (`create` still returns `{id, status:'queued'}`), no new env vars, no webhook / paid-spend change.

## Review guide

- Start in `research-service.ts`: the `make()` `── Dispatch ──` block (reconcile + consumer) and `runFiber`'s guarded claim.
- **The riskiest part is the consumer concurrency** — `forkScoped` / `forkIn` + the per-user semaphore + reconcile/dedup + cleanup placement. This was hardened by a **3-agent adversarial review** that found and I fixed three real bugs: a publish-before-commit race (→ the reconcile daemon + dedup), a cancel-while-parked cleanup leak (→ cleanup moved *outside* `withPermit`), and unguarded terminal `UPDATE`s (→ `AND status='running'`). The review also confirmed the guarded claim is race-safe and the base-role cross-org reads match existing patterns.
- **A decision you might overrule:** I kept the create-time `Queue.offer` as a best-effort fast path and rely on the reconcile as the correctness backstop, rather than offering strictly after commit (which this request-transaction wrapping makes awkward).
- Corrects two notes in the issue: the tx marker is a ServiceMap service (not a FiberRef); and `cached-llm.ts:143` is a plain upsert, not a `withTransaction` site.
- Snyk not run (tool unavailable in this worktree).

## Tests

- `research-dispatch.integration.test.ts` — reproduces the exact `SAVEPOINT` crash when the cache write is forked from a committed request transaction, and proves it commits when run from a clean scope.
- `research-service-dispatch.integration.test.ts` — drives the **real `ResearchService`**: `create` inside `enterOrgScope` → the consumer runs the job to `succeeded`, with the Agent-LLM stub performing the advisory-locked `search_cache` `withTransaction` (the #171-shaped write) and committing.

## Verification

Ran: `pnpm install` (clean lockfile) · `pnpm -w check-types` (13/13) · `pnpm -w test` (20/20, 503 server tests) · `pnpm -w build` (13/13) · the 3 research integration tests · a clean server boot · and a live runtime proof — inserted a `queued` row directly, the reconcile logged it (`count=1`), and the run reached `succeeded`. (The worktree `globalSetup` doesn't auto-migrate `batuda_it`, so I migrated it manually; CI runs against a HEAD Neon branch, so it's a no-op there.)

## Deferred (follow-ups, not this PR)

- A run **heartbeat** + heartbeat-aware sweep, so a run interrupted on deploy is reclaimed promptly (today the startup sweep reclaims on the next boot; a naive age-based periodic sweep would wrongly kill legitimately long runs) — tracked in #178.
- Group-run rollup hardening (an interrupt between a leaf's `succeeded` commit and `mergeToParent`) — unreachable today, since nothing creates `kind='group'` runs.
- Fully bounding fan-out under a burst of concurrent `create`s (the reconcile is capped; the create-path fast offer is not).

Closes #171
