### PR TITLE
fix: geocode enriched companies instead of asking the model

### DIFF
--- a/apps/internal/src/components/research/findings/company-enrichment-view.tsx
+++ b/apps/internal/src/components/research/findings/company-enrichment-view.tsx
@@ -43,8 +43,6 @@ type EnrichmentBlock = {
 	readonly location?: string
 	readonly region?: string
 	readonly address?: string
-	readonly latitude?: number
-	readonly longitude?: number
 	readonly citations?: ReadonlyArray<Citation>
 }
 

--- a/apps/server/src/handlers/companies.ts
+++ b/apps/server/src/handlers/companies.ts
@@ -1,10 +1,11 @@
-import { DateTime, Effect } from 'effect'
+import { Effect } from 'effect'
 import { HttpServerResponse } from 'effect/unstable/http'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
 import { BatudaApi, NotFound } from '@batuda/controllers'
 
 import { CompanyService } from '../services/companies'
+import { geocodeCompany } from '../services/company-geocoding'
 import { Geocoder } from '../services/geocoder'
 
 export const CompaniesLive = HttpApiBuilder.group(
@@ -65,39 +66,25 @@ export const CompaniesLive = HttpApiBuilder.group(
 					),
 				)
 				.handle('geocode', _ =>
-					Effect.gen(function* () {
-						const company = yield* svc.findById(_.params.id)
-						const name = company['name'] as string | null
-						const location = company['location'] as string | null
-						const query = [name, location].filter(Boolean).join(', ')
-						if (!query) {
-							return yield* new NotFound({
-								entity: 'geocode-query',
-								id: _.params.id,
-							})
-						}
-						const hit = yield* geocoder.lookup(query)
-						if (!hit) {
-							return yield* new NotFound({
-								entity: 'geocode-miss',
-								id: _.params.id,
-							})
-						}
-						const rows = yield* svc.update(_.params.id, {
-							latitude: hit.latitude,
-							longitude: hit.longitude,
-							geocodedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
-							geocodeSource: hit.source,
-						})
-						yield* Effect.logInfo('Company geocoded').pipe(
-							Effect.annotateLogs({
-								event: 'company.geocoded',
-								companyId: _.params.id,
-								source: hit.source,
-							}),
-						)
-						return rows[0]
-					}).pipe(
+					geocodeCompany(_.params.id).pipe(
+						Effect.provideService(CompanyService, svc),
+						Effect.provideService(Geocoder, geocoder),
+						// The helper returns null when there's no address to search on or
+						// the geocoder found no match; the endpoint reports both as a
+						// 404 the Where panel renders as "no match".
+						Effect.flatMap(row =>
+							row === null
+								? Effect.fail(
+										new NotFound({ entity: 'geocode-miss', id: _.params.id }),
+									)
+								: Effect.logInfo('Company geocoded').pipe(
+										Effect.annotateLogs({
+											event: 'company.geocoded',
+											companyId: _.params.id,
+										}),
+										Effect.as(row),
+									),
+						),
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
 						),

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -59,6 +59,7 @@ import { SessionMiddlewareLive } from './middleware/session'
 import { ApiKeyService } from './services/api-keys'
 import { CalendarService } from './services/calendar'
 import { CompanyService } from './services/companies'
+import { geocodeCompany } from './services/company-geocoding'
 import { CredentialCrypto } from './services/credential-crypto'
 import { EmailService } from './services/email'
 import { EmailAttachmentStaging } from './services/email-attachment-staging'
@@ -132,6 +133,8 @@ const ResearchEventSinkLive = Layer.effect(
 		const webhooks = yield* WebhookService
 		const timeline = yield* TimelineActivityService
 		const sql = yield* SqlClient.SqlClient
+		const companyService = yield* CompanyService
+		const geocoder = yield* Geocoder
 		return ResearchEventSink.of({
 			fire: (event, payload) =>
 				Effect.gen(function* () {
@@ -147,8 +150,9 @@ const ResearchEventSinkLive = Layer.effect(
 						createdBy: string | null
 						query: string
 						briefMd: string | null
+						schemaName: string | null
 					}>`
-						SELECT organization_id, created_by, query, brief_md
+						SELECT organization_id, created_by, query, brief_md, schema_name
 						FROM research_runs
 						WHERE id = ${researchId} LIMIT 1
 					`
@@ -167,22 +171,58 @@ const ResearchEventSinkLive = Layer.effect(
 						Effect.gen(function* () {
 							yield* webhooks.fire(event, payload)
 							if (!status) return
-							const linkRows = yield* sql<{ subjectId: string }>`
-								SELECT subject_id FROM research_links
-								WHERE research_id = ${researchId}
-								  AND subject_table = 'companies'
-								  AND link_kind = 'input'
+							const linkRows = yield* sql<{
+								subjectId: string
+								location: string | null
+								needsCoords: boolean | null
+							}>`
+								SELECT rl.subject_id, c.location, (c.latitude IS NULL) AS needs_coords
+								FROM research_links rl
+								LEFT JOIN companies c
+									ON c.id = rl.subject_id
+									AND c.organization_id = ${run.organizationId}
+								WHERE rl.research_id = ${researchId}
+								  AND rl.subject_table = 'companies'
+								  AND rl.link_kind = 'input'
 								LIMIT 1
 							`
+							const linked = linkRows[0]
 							yield* timeline.record(
 								new ResearchRunCompleted({
 									researchRunId: researchId,
-									companyId: linkRows[0]?.subjectId ?? null,
+									companyId: linked?.subjectId ?? null,
 									summary: run.briefMd ?? run.query,
 									status,
 									occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 								}),
 							)
+
+							// An enrichment run no longer asks the model for coordinates,
+							// so resolve them the deterministic way here: when the run
+							// succeeded for a linked company that has a written location
+							// but no coordinates yet, look the location up in the geocoder
+							// and store lat/long. Best-effort — a miss or failure must
+							// never disturb the timeline and webhook fan-out above.
+							if (
+								status === 'succeeded' &&
+								run.schemaName === 'company_enrichment_v1' &&
+								linked?.location &&
+								linked.needsCoords
+							) {
+								yield* geocodeCompany(linked.subjectId).pipe(
+									Effect.provideService(CompanyService, companyService),
+									Effect.provideService(Geocoder, geocoder),
+									Effect.catchCause(cause =>
+										Effect.logWarning('post-enrichment geocode failed').pipe(
+											Effect.annotateLogs({
+												event: 'research.geocode.failed',
+												companyId: linked.subjectId,
+												cause: Cause.pretty(cause),
+											}),
+										),
+									),
+								)
+							}
 						}),
 					).pipe(
 						// Org deleted between run completion and fan-out: skip
@@ -243,7 +283,15 @@ const ServicesLive = Layer.mergeAll(
 	Layer.provideMerge(CalendarService.layer),
 	Layer.provideMerge(EmailAttachmentStaging.layer),
 	Layer.provideMerge(DraftStore.layer),
-	Layer.provideMerge(ResearchEventSinkLive),
+	// The sink resolves the enriched company and geocodes it, so it needs
+	// CompanyService + Geocoder at build time. They live in the merged base
+	// below, which feeds consumers but not this provider — supply them here.
+	Layer.provideMerge(
+		ResearchEventSinkLive.pipe(
+			Layer.provide(CompanyService.layer),
+			Layer.provide(Geocoder.layer),
+		),
+	),
 	Layer.provideMerge(ParticipantMatcher.layer),
 	Layer.provideMerge(TimelineActivityService.layer),
 	Layer.provideMerge(WebhookService.layer),

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -1,9 +1,10 @@
-import { DateTime, Effect, Schema } from 'effect'
+import { Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 
 import { CurrentOrg } from '@batuda/controllers'
 
 import { CompanyService } from '../../services/companies'
+import { geocodeCompany } from '../../services/company-geocoding'
 import { Geocoder } from '../../services/geocoder'
 
 const REQUEST_DEPENDENCIES = [CurrentOrg]
@@ -174,22 +175,11 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 					return rows[0]
 				}).pipe(Effect.orDie),
 			geocode_company: ({ id }) =>
-				Effect.gen(function* () {
-					const company = yield* service.findById(id)
-					const name = company['name'] as string | null
-					const location = company['location'] as string | null
-					const query = [name, location].filter(Boolean).join(', ')
-					if (!query) return null
-					const hit = yield* geocoder.lookup(query)
-					if (!hit) return null
-					const rows = yield* service.update(id, {
-						latitude: hit.latitude,
-						longitude: hit.longitude,
-						geocodedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
-						geocodeSource: hit.source,
-					})
-					return rows[0]
-				}).pipe(Effect.orDie),
+				geocodeCompany(id).pipe(
+					Effect.provideService(CompanyService, service),
+					Effect.provideService(Geocoder, geocoder),
+					Effect.orDie,
+				),
 		}
 	}),
 )

--- a/apps/server/src/services/company-geocoding.test.ts
+++ b/apps/server/src/services/company-geocoding.test.ts
@@ -1,0 +1,113 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { CompanyService } from './companies'
+import { geocodeCompany } from './company-geocoding'
+import { Geocoder } from './geocoder'
+
+const unused = new Error('method not used in this test')
+const currentOrg = { id: 'org-1', name: 'fixture', slug: 'fixture' }
+
+// A CompanyService whose findById returns the given row and whose update
+// records the fields it was asked to write, so the test can inspect them.
+// The other methods are never reached here.
+const companyServiceWith = (
+	company: Record<string, unknown> | null,
+	updates: Array<Record<string, unknown>>,
+) =>
+	CompanyService.of({
+		findById: () =>
+			company === null
+				? Effect.die(new Error('company not found'))
+				: Effect.succeed(company),
+		update: (_id: string, data: Record<string, unknown>) =>
+			Effect.sync(() => {
+				updates.push(data)
+				return [{ ...company, ...data }]
+			}),
+		search: () => Effect.die(unused),
+		findBySlug: () => Effect.die(unused),
+		create: () => Effect.die(unused),
+		getWithRelations: () => Effect.die(unused),
+	})
+
+const geocoderReturning = (
+	hit: { latitude: number; longitude: number; source: string } | null,
+) => Geocoder.of({ lookup: () => Effect.succeed(hit) })
+
+const run = (
+	company: Record<string, unknown> | null,
+	hit: { latitude: number; longitude: number; source: string } | null,
+	updates: Array<Record<string, unknown>>,
+) =>
+	geocodeCompany('c-1').pipe(
+		Effect.provideService(CompanyService, companyServiceWith(company, updates)),
+		Effect.provideService(Geocoder, geocoderReturning(hit)),
+		Effect.provideService(CurrentOrg, currentOrg),
+		Effect.runPromise,
+	)
+
+describe('geocodeCompany', () => {
+	describe('when the geocoder returns a match', () => {
+		it('should store latitude, longitude and the geocode source', async () => {
+			// GIVEN a company with a location and a geocoder that resolves it
+			const updates: Array<Record<string, unknown>> = []
+
+			// WHEN the company is geocoded
+			const result = await run(
+				{ name: 'Sunset Transportation', location: 'St. Louis, MO' },
+				{ latitude: 38.627, longitude: -90.199, source: 'nominatim' },
+				updates,
+			)
+
+			// THEN exactly the four coordinate columns are written, and the
+			// updated row comes back
+			expect(updates).toHaveLength(1)
+			expect(updates[0]).toMatchObject({
+				latitude: 38.627,
+				longitude: -90.199,
+				geocodeSource: 'nominatim',
+			})
+			expect(result).not.toBeNull()
+		})
+	})
+
+	describe('when the geocoder finds no match', () => {
+		it('should store nothing and return null', async () => {
+			// GIVEN a company whose location the geocoder cannot resolve
+			const updates: Array<Record<string, unknown>> = []
+
+			// WHEN the company is geocoded
+			const result = await run(
+				{ name: 'Nowhere Ltd', location: 'Atlantis' },
+				null,
+				updates,
+			)
+
+			// THEN no coordinates are written and the caller learns nothing was stored
+			expect(updates).toHaveLength(0)
+			expect(result).toBeNull()
+		})
+	})
+
+	describe('when the company has no name or location to search on', () => {
+		it('should never send an empty query and return null', async () => {
+			// GIVEN a company with neither a name nor a location, but a geocoder
+			// that would happily return a hit if it were asked
+			const updates: Array<Record<string, unknown>> = []
+
+			// WHEN the company is geocoded
+			const result = await run(
+				{},
+				{ latitude: 1, longitude: 2, source: 'nominatim' },
+				updates,
+			)
+
+			// THEN the lookup is skipped entirely — no write, nothing stored
+			expect(updates).toHaveLength(0)
+			expect(result).toBeNull()
+		})
+	})
+})

--- a/apps/server/src/services/company-geocoding.ts
+++ b/apps/server/src/services/company-geocoding.ts
@@ -1,0 +1,39 @@
+import { DateTime, Effect } from 'effect'
+
+import { CompanyService } from './companies'
+import { Geocoder } from './geocoder'
+
+/**
+ * Resolve a company's coordinates from the deterministic geocoder and store
+ * them. Builds the lookup from the company's name and location, and on a match
+ * writes latitude/longitude/geocoded_at/geocode_source, returning the updated
+ * row. Returns null when there is nothing to store — the company has no
+ * name/location to search on, or the geocoder found no match.
+ *
+ * This is the one place the coordinate columns and the "name, location" lookup
+ * are defined. The geocode_company tool, the HTTP geocode endpoint, and the
+ * post-enrichment research sink all go through here, so coordinates always come
+ * from the geocoder and never from a language model.
+ */
+export const geocodeCompany = (id: string) =>
+	Effect.gen(function* () {
+		const service = yield* CompanyService
+		const geocoder = yield* Geocoder
+		const company = yield* service.findById(id)
+
+		const name = company['name'] as string | null
+		const location = company['location'] as string | null
+		const query = [name, location].filter(Boolean).join(', ')
+		if (!query) return null
+
+		const hit = yield* geocoder.lookup(query)
+		if (!hit) return null
+
+		const rows = yield* service.update(id, {
+			latitude: hit.latitude,
+			longitude: hit.longitude,
+			geocodedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
+			geocodeSource: hit.source,
+		})
+		return rows[0] ?? null
+	})

--- a/packages/research/src/application/schemas/company-enrichment-v1.test.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.test.ts
@@ -1,0 +1,79 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { CompanyEnrichmentV1Schema } from './company-enrichment-v1'
+
+const decode = Schema.decodeUnknownSync(CompanyEnrichmentV1Schema)
+
+describe('CompanyEnrichmentV1Schema', () => {
+	describe('when decoding an enrichment payload with the location in words but no coordinates', () => {
+		it('should decode and expose no latitude or longitude', () => {
+			// GIVEN a model result shaped like a real enrichment: the location is
+			// described in words, and coordinates are absent (their real source is
+			// the deterministic geocoder, not the model)
+			const payload = {
+				enrichment: {
+					industry: 'Freight & logistics',
+					size_range: '51-200',
+					location: 'St. Louis, MO',
+					region: 'United States',
+					citations: [{ source_id: 'src-1' }],
+				},
+			}
+
+			// WHEN it is decoded against the schema
+			const decoded = decode(payload)
+
+			// THEN it succeeds, keeps the textual location, and carries no
+			// coordinate fields at all
+			expect(decoded.enrichment.location).toBe('St. Louis, MO')
+			expect(decoded.enrichment).not.toHaveProperty('latitude')
+			expect(decoded.enrichment).not.toHaveProperty('longitude')
+		})
+	})
+
+	describe('when the model emits "NaN" for coordinates it could not determine', () => {
+		it('should decode without error instead of failing the run', () => {
+			// GIVEN the exact shape that failed in production: unable to produce
+			// real coordinates, the model filled both fields with the string "NaN"
+			const payload = {
+				enrichment: {
+					industry: 'Freight & logistics',
+					location: 'St. Louis, MO',
+					latitude: 'NaN',
+					longitude: 'NaN',
+					citations: [{ source_id: 'src-1' }],
+				},
+			}
+
+			// WHEN it is decoded
+			// THEN decode does not throw — the coordinate keys are no longer part of
+			// the schema, so a stray value is ignored rather than rejected, and an
+			// unlocatable company no longer blocks the whole extraction
+			expect(() => decode(payload)).not.toThrow()
+			expect(decode(payload).enrichment).not.toHaveProperty('latitude')
+		})
+	})
+
+	describe('when the model emits real-looking numeric coordinates', () => {
+		it('should still drop them so coordinates are never model-sourced', () => {
+			// GIVEN a payload where the model guessed plausible-looking numbers
+			const payload = {
+				enrichment: {
+					location: 'St. Louis, MO',
+					latitude: 38.627,
+					longitude: -90.199,
+					citations: [{ source_id: 'src-1' }],
+				},
+			}
+
+			// WHEN it is decoded
+			const decoded = decode(payload)
+
+			// THEN even a valid-looking coordinate is discarded — the model is never
+			// trusted as a coordinate source, whatever it emits
+			expect(decoded.enrichment).not.toHaveProperty('latitude')
+			expect(decoded.enrichment).not.toHaveProperty('longitude')
+		})
+	})
+})

--- a/packages/research/src/application/schemas/company-enrichment-v1.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.ts
@@ -18,8 +18,6 @@ export const CompanyEnrichmentV1Schema = Schema.Struct({
 		location: Schema.optionalKey(Schema.String),
 		region: Schema.optionalKey(Schema.String),
 		address: Schema.optionalKey(Schema.String),
-		latitude: Schema.optionalKey(Schema.Number),
-		longitude: Schema.optionalKey(Schema.Number),
 		citations: Schema.Array(Citation),
 	}),
 	competitors: Schema.optionalKey(


### PR DESCRIPTION
## What

`company_enrichment_v1` research runs were crashing at the final step. The AI model that fills in a company's profile was asked for map coordinates, and when it couldn't work them out it returned the literal text `"NaN"` — which the strict output check rejected, failing the whole run (so almost every enrichment of a company the model couldn't place). This stops asking the model for coordinates at all, and instead fills them in deterministically from the geocoder (the same Nominatim lookup the "Locate this company" button already uses) when an enrichment run finishes. Research + CRM — `@batuda/research` (the extraction schema) and `server` (the geocoding).

## The fix

- **Stop the model producing coordinates** — dropped `latitude`/`longitude` from the `company_enrichment_v1` extraction schema. The model's coordinates were never read anyway (they landed in an unread findings blob and were never shown), so nothing downstream loses data; a stray `"NaN"` in a run's output is now ignored instead of failing the decode.
- **Store coordinates deterministically** — when a `company_enrichment_v1` run succeeds for a company it's linked to, the server looks that company's location up in the geocoder and saves the coordinates — but only when the company has a location and no coordinates yet. This runs in the existing research-completion hook (`ResearchEventSink`), so `@batuda/research` stays free of any server or geocoder import (the enforced app→package direction).
- **One geocoding path** — extracted a `geocodeCompany` helper. The `geocode_company` MCP tool, the HTTP `geocode` endpoint, and the new post-enrichment hook all go through it, so the "name, location" lookup and the four stored columns live in one place instead of three copies.

## Impact

- **MCP + HTTP parity:** the geocode logic is now one helper behind three callers (the tool, the HTTP endpoint, and the enrichment hook), so the two transports and the hook stay identical.
- **Multi-org / RLS:** the new hook writes a company's coordinates under the research run's *own* org scope — `resolveSystemOrg` sets `CurrentOrg` to the run's org, and both the lookup join and the update filter on that org. It cannot reach another org's rows.
- **Wire-shape (minor):** the HTTP `geocode` endpoint's 404 body used to distinguish `geocode-query` (no address to search) from `geocode-miss` (no match); it now returns `geocode-miss` for both. The Where panel already treats them identically, so nothing user-facing changes.
- **Webhooks / fan-out:** the geocode is best-effort inside the run-completion fan-out — a miss or error is logged and swallowed, never disturbing the timeline row or webhooks that fire alongside it.
- **No new env var, no DB migration** — the coordinate columns and the Nominatim geocoder already exist.

## Review guide

- **Start at** `apps/server/src/main.ts` → `ResearchEventSinkLive`: the added `schema_name` read, the `LEFT JOIN` that fetches the linked company's location and whether it still needs coordinates, and the gated best-effort `geocodeCompany` call. This is the riskiest part (a new write inside the fan-out) — I verified it by booting the full server and by running the new query against the live DB (see Verification).
- **Then** `apps/server/src/services/company-geocoding.ts` — the extracted helper; identical logic to what the two existing callers had inline.
- **Decision you might overrule:** the hook geocodes only the *first* time (it skips a company that already has coordinates), so it won't clobber a manually-corrected pin or re-hit Nominatim on every re-enrichment. One line to flip to always-refresh.
- **Skip-able:** the `geocode_company` tool and HTTP handler diffs are mechanical delegation to the helper — behaviour unchanged.
- **Reviews:** I self-reviewed the diff against the repo checklist (reuse, org-scoping, MCP/HTTP parity, scope discipline); I did not run `/code-review` or `/security-review` as separate passes, and Snyk was not run this session.

## Screenshots

> Screenshots skipped (approved): the only UI change removes two unused type fields (`latitude?`/`longitude?`) that were never rendered — nothing visible changes.

## Tests

- **Schema-decode regression** (`company-enrichment-v1.test.ts`): a payload carrying the exact production failure (`latitude: "NaN"`) now decodes instead of failing the run, and coordinates are absent whatever the model emits.
- **`geocodeCompany` helper** (`company-geocoding.test.ts`, with a stub `Geocoder` + `CompanyService`): a hit writes the four coordinate columns; a miss, or a company with no location, writes nothing and returns null.

## Verification

- Gates green: `pnpm install` (no lockfile drift), `check-types` (13/13), `test` (20/20 tasks, 506 server tests), `build` (13/13).
- **Full server boot** of the built server (`dist/main.mjs`, complete env) returned `/health` 200 — confirming the new hook resolves `CompanyService` + `Geocoder` at layer-build time. This matters because the `runMain` cast erases unsatisfied requirements from the type check, so a missing provider would otherwise surface only as a prod boot crash.
- Ran the hook's new `LEFT JOIN … (latitude IS NULL)` query against the live dev DB to confirm it's valid and returns the expected columns.
- The one prod-only proof — a real Qwen extraction that previously emitted `"NaN"` — is the campaign re-run after `/release` (issue checkbox 4); the schema-decode test is its faithful local proxy, since the local extract provider is stubbed and can't reproduce the model's output.

## Deferred

- **Region / coordinate querying** (search companies by bounding box or radius) doesn't exist yet — `search_companies` matches `region` as an exact string, with no spatial index. Storing coordinates now unblocks it; the query capability is separate work.
- **Numeric-guard hardening** for the other model-produced numeric fields (`confidence`, `expected_version`, `estimated_cents`, `total_competitors_found`) that share the same `"NaN"`-decode exposure — a focused follow-up, since a correct guard must coerce the *string* `"NaN"` (not just numeric NaN) and stay green through the OpenAI structured-output codec.
- **Applying enrichment findings to the company row** is still a stub on both surfaces; once it lands, a company that starts with no location could get one from enrichment and then be geocoded.

Closes #180
