### PR TITLE
fix(research): survive imperfect model output in Phase-2 extraction

### DIFF
--- a/packages/research/src/application/schemas/_shared.test.ts
+++ b/packages/research/src/application/schemas/_shared.test.ts
@@ -1,0 +1,94 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { TolerantJsonString } from './_shared'
+import { FreeformSchema } from './freeform'
+import { ProspectScanV1Schema } from './prospect-scan-v1'
+
+describe('TolerantJsonString', () => {
+	const decode = Schema.decodeUnknownSync(TolerantJsonString)
+
+	describe('when the string is valid JSON', () => {
+		it('should decode it to the parsed value', () => {
+			// GIVEN a JSON-encoded object — the shape the model is asked to produce
+			// WHEN it is decoded
+			const decoded = decode('{"q":"contact","limit":3}')
+			// THEN it becomes the parsed object
+			expect(decoded).toEqual({ q: 'contact', limit: 3 })
+		})
+	})
+
+	describe('when the model returns prose instead of JSON', () => {
+		it('should keep the raw string instead of throwing', () => {
+			// GIVEN the exact failure from production: the model wrote a
+			// natural-language instruction where a JSON object was expected
+			const prose = 'look up Maria at the town hall'
+			// WHEN it is decoded
+			// THEN it does not throw and the raw text is preserved verbatim
+			expect(() => decode(prose)).not.toThrow()
+			expect(decode(prose)).toBe(prose)
+		})
+	})
+})
+
+describe('ProspectScanV1Schema (shared PendingPaidAction.args)', () => {
+	const decode = Schema.decodeUnknownSync(ProspectScanV1Schema)
+	const withArgs = (args: string) => ({
+		prospects: [
+			{ name: 'Acme', why_relevant: 'fit', citations: [{ source_id: 's1' }] },
+		],
+		pending_paid_actions: [
+			{ tool: 'lookup_registry', args, estimated_cents: 10, reason: 'need id' },
+		],
+	})
+
+	describe('when a pending paid action carries prose in args', () => {
+		it('should decode the whole payload instead of failing the extraction', () => {
+			// GIVEN a structured result whose paid action has prose args — the
+			// case that failed research run 0b9399d7 in production
+			// WHEN the full schema is decoded
+			const decoded = decode(withArgs('look up Maria'))
+			// THEN it succeeds and the prose survives as the raw args
+			expect(decoded.pending_paid_actions?.[0]?.args).toBe('look up Maria')
+		})
+	})
+
+	describe('when a pending paid action carries a JSON-encoded args object', () => {
+		it('should decode args to the parsed object', () => {
+			// GIVEN the well-formed case the model is meant to produce
+			// WHEN the full schema is decoded
+			// THEN args is the parsed object
+			expect(
+				decode(withArgs('{"tax_id":"B123"}')).pending_paid_actions?.[0]?.args,
+			).toEqual({ tax_id: 'B123' })
+		})
+	})
+})
+
+describe('FreeformSchema (inlined proposed_updates.fields)', () => {
+	const decode = Schema.decodeUnknownSync(FreeformSchema)
+
+	describe('when proposed_updates.fields is prose rather than JSON', () => {
+		it('should decode instead of failing, keeping the raw text', () => {
+			// GIVEN freeform's own inlined open-ended field map filled with prose
+			const payload = {
+				proposed_updates: [
+					{
+						subject_table: 'companies',
+						subject_id: 'c1',
+						expected_version: 1,
+						fields: 'set the industry to logistics',
+						reason: 'observed on the site',
+						citations: [{ source_id: 's1' }],
+					},
+				],
+			}
+			// WHEN it is decoded
+			// THEN it does not throw and the raw text is preserved
+			expect(() => decode(payload)).not.toThrow()
+			expect(decode(payload).proposed_updates?.[0]?.fields).toBe(
+				'set the industry to logistics',
+			)
+		})
+	})
+})

--- a/packages/research/src/application/schemas/_shared.ts
+++ b/packages/research/src/application/schemas/_shared.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Schema, SchemaGetter } from 'effect'
 
 /**
  * Building blocks shared across the structured research output schemas, so each
@@ -8,6 +8,27 @@ import { Schema } from 'effect'
  * reference, and some output paths keep only a schema's top-level shape, so a
  * reference to a separately-named fragment would be dropped there.
  */
+
+// Open-ended maps (`fields`, `args`) arrive as a JSON-encoded string (OpenAI
+// structured output has no "any shape" type). Open-weights models sometimes
+// emit prose here, so decoding falls back to the raw string instead of failing
+// the whole extraction; valid JSON still decodes to an object.
+const parseJsonOrRaw = (value: string): unknown => {
+	try {
+		return JSON.parse(value)
+	} catch {
+		return value
+	}
+}
+
+export const TolerantJsonString = Schema.String.annotate({
+	description: 'a string that will be decoded as JSON',
+}).pipe(
+	Schema.decodeTo(Schema.Unknown, {
+		decode: SchemaGetter.transform(parseJsonOrRaw),
+		encode: SchemaGetter.stringifyJson(),
+	}),
+)
 
 export const Citation = Schema.Struct({
 	source_id: Schema.String,
@@ -25,18 +46,14 @@ export const ProposedUpdate = Schema.Struct({
 	subject_table: Schema.Literals(['companies', 'contacts']),
 	subject_id: Schema.String,
 	expected_version: Schema.Number,
-	// Open-ended field map; sent as a JSON-encoded string because OpenAI
-	// structured output has no "any shape" type — decodes back to an object
-	// automatically.
-	fields: Schema.UnknownFromJsonString,
+	fields: TolerantJsonString,
 	reason: Schema.String,
 	citations: Schema.Array(Citation),
 })
 
 export const PendingPaidAction = Schema.Struct({
 	tool: Schema.String,
-	// Same open-ended-map rationale as `fields` above.
-	args: Schema.UnknownFromJsonString,
+	args: TolerantJsonString,
 	estimated_cents: Schema.Number,
 	reason: Schema.String,
 })

--- a/packages/research/src/application/schemas/freeform.ts
+++ b/packages/research/src/application/schemas/freeform.ts
@@ -1,5 +1,7 @@
 import { Schema } from 'effect'
 
+import { TolerantJsonString } from './_shared'
+
 /** Freeform research — no structured output, markdown brief only. */
 export const FreeformSchema = Schema.Struct({
 	proposed_updates: Schema.optionalKey(
@@ -8,10 +10,7 @@ export const FreeformSchema = Schema.Struct({
 				subject_table: Schema.Literals(['companies', 'contacts']),
 				subject_id: Schema.String,
 				expected_version: Schema.Number,
-				// Open-ended field map; sent as a JSON-encoded string because OpenAI
-				// structured output has no "any shape" type — decodes back to an
-				// object automatically.
-				fields: Schema.UnknownFromJsonString,
+				fields: TolerantJsonString,
 				reason: Schema.String,
 				citations: Schema.Array(
 					Schema.Struct({
@@ -26,8 +25,7 @@ export const FreeformSchema = Schema.Struct({
 		Schema.Array(
 			Schema.Struct({
 				tool: Schema.String,
-				// Same open-ended-map rationale as `fields` above.
-				args: Schema.UnknownFromJsonString,
+				args: TolerantJsonString,
 				estimated_cents: Schema.Number,
 				reason: Schema.String,
 			}),

--- a/packages/research/src/infrastructure/_harden.test.ts
+++ b/packages/research/src/infrastructure/_harden.test.ts
@@ -4,6 +4,7 @@ import type { LanguageModel } from 'effect/unstable/ai'
 import { AiError } from 'effect/unstable/ai'
 import { describe, expect, it } from 'vitest'
 
+import { ProviderError } from '../domain/errors'
 import { hardenLanguageModel, withFallbackLanguageModel } from './_harden'
 
 // ── Test helpers ──
@@ -109,6 +110,22 @@ const invokeGenerateText = (
 			o: unknown,
 		) => Effect.Effect<unknown, unknown, never>
 	)({ prompt: 'hi' })
+
+const invokeGenerateObject = (
+	svc: LanguageModel.Service,
+): Effect.Effect<unknown, unknown, never> =>
+	(
+		svc.generateObject as unknown as (
+			o: unknown,
+		) => Effect.Effect<unknown, unknown, never>
+	)({ prompt: 'hi', schema: {} })
+
+const makeObjectFailingLm = (fail: unknown): LanguageModel.Service =>
+	({
+		generateText: () => Effect.succeed({}),
+		generateObject: () => Effect.fail(fail),
+		streamText: () => Effect.succeed({}),
+	}) as unknown as LanguageModel.Service
 
 describe('hardenLanguageModel', () => {
 	it('should return the successful response after transient failures under its retry budget', async () => {
@@ -229,6 +246,68 @@ describe('hardenLanguageModel', () => {
 
 		// THEN the harness surfaces a failure (timeout does not trigger the retry gate)
 		expect(Exit.isFailure(exit)).toBe(true)
+	})
+
+	it('should surface a ProviderError carrying the real message when the inner extract error has one', async () => {
+		// GIVEN an extract call whose inner failure carries a real message
+		const hardened = hardenLanguageModel(
+			makeObjectFailingLm(new Error('firecrawl 500')),
+			'together',
+		)
+
+		// WHEN generateObject is invoked and its failure is captured
+		const error = await Effect.runPromise(
+			Effect.flip(invokeGenerateObject(hardened)),
+		)
+
+		// THEN the underlying message is what surfaces, not a wrapper artifact
+		expect(error).toBeInstanceOf(ProviderError)
+		if (error instanceof ProviderError) {
+			expect(error.message).toContain('firecrawl 500')
+		}
+	})
+
+	it('should still surface a ProviderError instead of crashing when the inner extract error has no message', async () => {
+		// GIVEN the production failure mode: the wrapped error's `message` is
+		// undefined, which used to make the ProviderError schema reject its own
+		// construction and throw a contentless error over the real one
+		const noMessage = new Error('placeholder')
+		Object.defineProperty(noMessage, 'message', { value: undefined })
+		const hardened = hardenLanguageModel(
+			makeObjectFailingLm(noMessage),
+			'together',
+		)
+
+		// WHEN generateObject is invoked and its failure is captured — a
+		// construction crash would surface as an uncaught defect here
+		const error = await Effect.runPromise(
+			Effect.flip(invokeGenerateObject(hardened)),
+		)
+
+		// THEN a ProviderError still surfaces, with a non-empty fallback message
+		expect(error).toBeInstanceOf(ProviderError)
+		if (error instanceof ProviderError) {
+			expect(error.message.length).toBeGreaterThan(0)
+		}
+	})
+
+	it('should read the message off a bare error object that is not an Error instance', async () => {
+		// GIVEN a non-Error thrown value that still carries a message
+		const hardened = hardenLanguageModel(
+			makeObjectFailingLm({ message: 'quota exceeded', code: 429 }),
+			'together',
+		)
+
+		// WHEN generateObject is invoked and its failure is captured
+		const error = await Effect.runPromise(
+			Effect.flip(invokeGenerateObject(hardened)),
+		)
+
+		// THEN the object's own message surfaces, not the generic fallback
+		expect(error).toBeInstanceOf(ProviderError)
+		if (error instanceof ProviderError) {
+			expect(error.message).toContain('quota exceeded')
+		}
 	})
 })
 

--- a/packages/research/src/infrastructure/_harden.ts
+++ b/packages/research/src/infrastructure/_harden.ts
@@ -37,20 +37,32 @@ import { ProviderError } from '../domain/errors'
 const DEFAULT_TIMEOUT: Duration.Input = '120 seconds'
 const DEFAULT_MAX_ATTEMPTS = 3
 
-const toProviderError = (provider: string, err: unknown): ProviderError => {
-	if (err instanceof AiError.AiError) {
-		return new ProviderError({
-			provider,
-			message: err.message,
-			recoverable: err.isRetryable,
-		})
+// Pull a human-usable message out of an arbitrary thrown value, or `undefined`
+// when there is nothing usable (an absent/blank message, or a bare object).
+const messageOf = (err: unknown): string | undefined => {
+	if (err instanceof Error) return err.message || undefined
+	if (typeof err === 'string') return err || undefined
+	if (err === null || err === undefined) return undefined
+	// Some callers throw a bare object that carries the message (e.g. `{ message,
+	// code }`); read it before falling back to `String(err)`'s "[object Object]".
+	if (typeof err === 'object' && 'message' in err) {
+		const inner = err.message
+		if (typeof inner === 'string' && inner.length > 0) return inner
 	}
+	const text = String(err)
+	return text === '[object Object]' ? undefined : text
+}
+
+const toProviderError = (provider: string, err: unknown): ProviderError => {
 	if (err instanceof ProviderError) return err
-	return new ProviderError({
-		provider,
-		message: err instanceof Error ? err.message : String(err),
-		recoverable: true,
-	})
+	// A ProviderError's `message` is a required string; building one with an
+	// empty or missing message makes the error class reject its own construction
+	// and throw — a second, contentless error that buries the real failure.
+	// Always hand it a usable string so the true cause is what gets reported.
+	const message = messageOf(err) ?? `${provider} request failed`
+	return err instanceof AiError.AiError
+		? new ProviderError({ provider, message, recoverable: err.isRetryable })
+		: new ProviderError({ provider, message, recoverable: true })
 }
 
 const isRetryableFailure = (err: unknown): boolean =>


### PR DESCRIPTION
## What

Two bugs in the **Research** bounded context stopped a research run from finishing at its final step. When a run has gathered its notes, that step asks the AI model for structured findings; on imperfect output from open-weights models (Qwen), it crashed and the whole run failed — a campaign on 2026-07-04 completed 0 of 3 runs. This makes the extraction survive that imperfect output instead of throwing.

(The sibling issue #180 — the model returning `NaN` for coordinates — was fixed and merged separately; this PR is the other two defects from the same batch.)

## The fix

- **Prose where JSON was expected no longer fails the run.** Two open-ended maps — a paid action's `args` and a proposed update's `fields` — are sent to the model as JSON strings. Open-weights models sometimes write a plain sentence there instead; the old decoder threw on the failed parse and lost the entire extraction. A new `TolerantJsonString` codec keeps the raw text as a fallback when the value isn't valid JSON. The schema shown to the model is byte-for-byte unchanged, so JSON is still what's asked for — the raw text is only a safety net.
- **The error wrapper no longer hides the real error.** When the step failed for some other reason, the code wrapped that error to report it — but if the underlying error had no message, building the wrapper threw a *second*, empty error that buried the real cause, so the run reported only a meaningless schema error. The wrapper is now always handed a usable message, so the true failure is what surfaces.

## Impact

- **Wire shape unchanged.** The model-facing JSON schema is identical (I emitted both the old and new codec and compared), and the decoded field type stays `unknown`. Stored findings can now hold a raw string where a parsed object used to sit, but no runtime consumer reads into `args`/`fields` — the resolve/apply paths are placeholders and everything else treats findings as opaque JSON (checked across `server`).
- No migration, no schema change, no RLS/tenant-scope change, no new env vars, no auth or CORS change. Behavior is identical for well-formed model output; it only changes what happens on malformed output — recover instead of crash.

## Review guide

- Start at `packages/research/src/application/schemas/_shared.ts` — the `TolerantJsonString` codec is the heart of it. The correctness question (does the model still get asked for JSON?) is settled by the unchanged emitted schema, which I verified empirically.
- `packages/research/src/infrastructure/_harden.ts` `toProviderError` is the error-wrapper fix. **A decision you might overrule:** I fixed it at the construction site (a `messageOf` helper that always yields a non-empty string) rather than hardening the `ProviderError` schema itself — the localized fix keeps `message` required and TypeScript-enforced, and I confirmed no other `new ProviderError(...)` site can construct with an empty message. A code-review pass then surfaced that `messageOf` also dropped the message from a bare `{ message }` object; that's folded in.
- **What I couldn't verify:** a full live research run — it needs production provider secrets not present in a dev worktree, and the model can't be made to emit prose on demand. Instead I reproduced both exact production failures directly against the real decode and error-mapping code paths (see Tests).

## Tests

- `TolerantJsonString`: valid JSON decodes to an object; prose is kept as the raw string; a full schema decode with a prose `args` (the shape that failed run `0b9399d7`) succeeds — covering the shared fragments and freeform's inlined copies.
- `toProviderError`: an extract failure surfaces the real message; an error with no message yields a non-empty fallback instead of the construction crash (the run `d67a1d46` symptom); a bare `{ message }` object's own message is read.

## Verification

Reproduced both failures with throwaway probes against the real code paths, before and after the fix. The research suite passes, and repo-wide `check-types` (13/13), `test` (20/20 tasks — `server` alone 506 tests), and `build` (13/13) are all green. No UI change, so no screenshots.

Closes #181
