### PR TITLE
fix(server): keep MCP tool results valid and hide internal errors

### DIFF
--- a/apps/cli/src/lib/load-env.ts
+++ b/apps/cli/src/lib/load-env.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { config as dotenvConfig } from 'dotenv'
+import { config as dotenvConfig, parse as dotenvParse } from 'dotenv'
 
 const ROOT = resolve(import.meta.dirname, '../../../..')
 
@@ -148,11 +148,18 @@ const fetchGhVariables = (): void => {
  *   4. `<repo>/.env.cloud`                (cloud only — secrets + overrides)
  *   5. `<repo>/apps/cli/.env.cloud`       (cloud only)
  *
+ * A value the caller already exported into the environment wins over the
+ * baseline files, and a blank entry (`KEY=`) never overwrites a value another
+ * file provided. Both matter for the integration db-setup, which exports
+ * `DATABASE_URL` for a throwaway test DB and shells out to the CLI: a stray
+ * empty `apps/cli/.env` line must not blank that out, and the baseline dev URL
+ * must not shadow it (that would point `db reset` at the wrong database).
+ *
  * Why gh fetch runs *between* the baselines and `.env.cloud`: the baseline
  * usually carries dev defaults like `BETTER_AUTH_BASE_URL=…localhost`, and
  * cloud mode must not inherit those. `.env.cloud` is reserved for secrets
- * (which gh can't expose) and rare local overrides — putting it last keeps
- * the user's explicit overrides authoritative.
+ * (which gh can't expose) and rare local overrides — putting it last, and
+ * still authoritative, keeps those overrides in charge.
  *
  * Must run before `NodeRuntime.runMain` / any Effect Config resolution so
  * process.env is populated before the layer stack is built.
@@ -168,16 +175,38 @@ export const loadEnv = (): EnvTarget => {
 		resolve(ROOT, 'apps/cli/.env.cloud'),
 	]
 
-	const loadFile = (file: string): void => {
+	// Keys the caller exported before invoking the CLI. The baseline files must
+	// not overwrite these, so an explicit `DATABASE_URL=…` stays authoritative.
+	const callerProvided = new Set(
+		Object.entries(process.env)
+			.filter(([, value]) => value !== undefined && value !== '')
+			.map(([key]) => key),
+	)
+
+	// Baseline load: later file wins, but skip blank entries and keys the caller
+	// already set, so neither an empty line nor a dev default can shadow them.
+	const loadBaseline = (file: string): void => {
+		if (!existsSync(file)) return
+		for (const [key, value] of Object.entries(
+			dotenvParse(readFileSync(file)),
+		)) {
+			if (value === '' || callerProvided.has(key)) continue
+			process.env[key] = value
+		}
+	}
+
+	// Cloud overrides are authoritative for secrets and rare local overrides, so
+	// they replace whatever the baselines or gh set.
+	const loadCloudOverride = (file: string): void => {
 		if (existsSync(file)) {
 			dotenvConfig({ path: file, override: true, quiet: true })
 		}
 	}
 
-	for (const file of baselineFiles) loadFile(file)
+	for (const file of baselineFiles) loadBaseline(file)
 	if (target === 'cloud') {
 		fetchGhVariables()
-		for (const file of cloudOverrideFiles) loadFile(file)
+		for (const file of cloudOverrideFiles) loadCloudOverride(file)
 	}
 
 	resolvedTarget = target

--- a/apps/server/src/mcp/safe-toolkit.test.ts
+++ b/apps/server/src/mcp/safe-toolkit.test.ts
@@ -1,0 +1,343 @@
+// Covers the two client-facing defects mcpToolkitSafe corrects (issue #168), at
+// two levels: the unit blocks feed the shaping helpers (toStructuredContent,
+// sanitizeCause) the shapes that handlers actually produce; the round-trip block
+// drives tools registered with mcpToolkitSafe over a real in-process MCP HTTP
+// server and asserts what the client receives, so a future effect release that
+// changes the bridge's result/error rendering fails here rather than in prod.
+
+import { createServer } from 'node:http'
+
+import { NodeHttpServer } from '@effect/platform-node'
+import { Cause, Effect, Exit, Layer, ManagedRuntime, Schema } from 'effect'
+import { McpServer, Tool, Toolkit } from 'effect/unstable/ai'
+import { HttpRouter, HttpServer } from 'effect/unstable/http'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	mcpToolkitSafe,
+	sanitizeCause,
+	toStructuredContent,
+} from './safe-toolkit'
+
+// Render the cause of a failing effect the way the MCP bridge does, so the
+// tests exercise sanitizeCause against a real Cause (not a hand-built one).
+const causeOf = (
+	effect: Effect.Effect<unknown, unknown>,
+): Cause.Cause<unknown> => {
+	const exit = Effect.runSyncExit(effect)
+	if (Exit.isFailure(exit)) return exit.cause
+	throw new Error('expected the effect to fail')
+}
+
+describe('toStructuredContent', () => {
+	describe('when the handler returns a plain object', () => {
+		it('should pass the record through unchanged', () => {
+			// GIVEN a record result (the already-valid shape)
+			const value = { id: 1, name: 'Ada' }
+			// WHEN normalizing it for structured output
+			// THEN it is returned as-is
+			expect(toStructuredContent(value)).toBe(value)
+		})
+	})
+
+	describe('when the handler returns a bare array', () => {
+		it('should wrap it in an items record so it stays valid structured output', () => {
+			// GIVEN a list result — a bare array is not valid MCP structured output
+			// WHEN normalizing it
+			const result = toStructuredContent([1, 2, 3])
+			// THEN it becomes an object under `items`, preserving the rows
+			expect(result).toEqual({ items: [1, 2, 3] })
+		})
+
+		it('should wrap an empty array too', () => {
+			// GIVEN an empty list
+			// WHEN normalizing it
+			// THEN it is still an object, not a bare array
+			expect(toStructuredContent([])).toEqual({ items: [] })
+		})
+	})
+
+	describe('when the handler returns a value that cannot be a record', () => {
+		it('should omit structured output for null', () => {
+			// GIVEN a null result (e.g. a missing row) — `null` is not a JSON object
+			// WHEN normalizing it
+			// THEN structured output is omitted; the field is optional, so no
+			//      non-record value reaches the client
+			expect(toStructuredContent(null)).toBeUndefined()
+		})
+
+		it('should omit structured output for a scalar', () => {
+			// GIVEN a scalar result
+			// WHEN normalizing a number and a string
+			// THEN both omit structured output rather than shipping a non-record
+			expect(toStructuredContent(42)).toBeUndefined()
+			expect(toStructuredContent('done')).toBeUndefined()
+		})
+
+		it('should omit structured output for undefined', () => {
+			// GIVEN a handler that returned nothing
+			// WHEN normalizing undefined
+			// THEN structured output is omitted
+			expect(toStructuredContent(undefined)).toBeUndefined()
+		})
+	})
+})
+
+describe('sanitizeCause', () => {
+	describe('when the effect dies with a redacted string defect', () => {
+		it('should surface the string without decoration', () => {
+			// GIVEN a defect that is already a safe string (as redactDbErrors emits)
+			const cause = causeOf(Effect.die('internal error'))
+			// WHEN sanitizing it for the client
+			// THEN the message is preserved verbatim
+			expect(sanitizeCause(cause)).toBe('internal error')
+		})
+	})
+
+	describe('when the effect dies with an Error carrying a stack and bundle path', () => {
+		it('should not leak the stack, bundle path, or nested cause', () => {
+			// GIVEN an Error whose message and stack reference an internal bundle
+			const err = new Error(
+				'read failed at /app/dist/s3-storage-provider-a1b2.mjs',
+			)
+			err.stack =
+				'Error: read failed\n    at load (/app/dist/s3-storage-provider-a1b2.mjs:12:9)\n    at run (/app/dist/index.mjs:3:1)'
+			const cause = causeOf(Effect.die(err))
+
+			// WHEN sanitizing it for the client
+			const rendered = sanitizeCause(cause)
+
+			// THEN no bundle path, no `.mjs`, and no stack frame survives
+			expect(rendered).not.toContain('/app/dist')
+			expect(rendered).not.toContain('.mjs')
+			expect(rendered).not.toMatch(/\n\s*at\s/)
+			// AND the caller still gets a short, human-readable signal
+			expect(rendered).toContain('read failed')
+			expect(rendered.length).toBeLessThanOrEqual(500)
+		})
+	})
+
+	describe('when the message embeds a non-JavaScript absolute path', () => {
+		it('should redact the path regardless of its extension', () => {
+			// GIVEN a filesystem error naming an internal secret path
+			const cause = causeOf(
+				Effect.die(new Error("ENOENT: open '/app/secrets/key.pem'")),
+			)
+			// WHEN sanitizing it
+			const rendered = sanitizeCause(cause)
+			// THEN the path is gone even though it does not end in .js/.ts
+			expect(rendered).not.toContain('/app/secrets')
+			expect(rendered).not.toContain('.pem')
+		})
+
+		it('should leave a URL in the message intact', () => {
+			// GIVEN a scraping failure that names the URL it hit — useful signal
+			const cause = causeOf(
+				Effect.die(new Error('fetch failed for https://example.com/a/b/c')),
+			)
+			// WHEN sanitizing it
+			// THEN the URL survives; only server filesystem paths are redacted
+			expect(sanitizeCause(cause)).toContain('https://example.com/a/b/c')
+		})
+	})
+
+	describe('when the message is a long slash-heavy string', () => {
+		it('should redact it without pathological backtracking', () => {
+			// GIVEN a message with many path segments and no file extension —
+			// the shape that made the previous regex backtrack exponentially
+			const segments = `/${Array.from({ length: 60 }, (_, i) => `seg${i}`).join('/')}`
+			const cause = causeOf(Effect.die(new Error(`fetch failed ${segments}`)))
+			// WHEN sanitizing it (this returns promptly; a hang would fail the run)
+			const rendered = sanitizeCause(cause)
+			// THEN the path is redacted
+			expect(rendered).toContain('<path>')
+			expect(rendered).not.toContain('/seg59')
+		})
+	})
+
+	describe('when the effect fails with a tagged domain error', () => {
+		it('should surface the tag and message but nothing more', () => {
+			// GIVEN a tagged error the way a provider failure would surface
+			const cause = causeOf(
+				Effect.fail({
+					_tag: 'ProviderError',
+					message: 'no credit remaining',
+				}),
+			)
+			// WHEN sanitizing it
+			// THEN the client sees the tag and message, useful but internals-free
+			expect(sanitizeCause(cause)).toBe('ProviderError: no credit remaining')
+		})
+	})
+
+	describe('when the cause carries no renderable error', () => {
+		it('should fall back to a generic message', () => {
+			// GIVEN an empty cause (no failure or defect to render)
+			// WHEN sanitizing it
+			// THEN a generic, safe message is returned rather than an empty string
+			expect(sanitizeCause(Cause.empty)).toBe('internal error')
+		})
+	})
+})
+
+// Four tools covering the shapes the bridge must normalize: a list (bare array),
+// a miss (null), an already-valid record, and a failure that dies with an Error
+// whose message and stack reference an internal bundle path.
+const ListTool = Tool.make('list_thing', { success: Schema.Unknown })
+const MissTool = Tool.make('missing_thing', { success: Schema.Unknown })
+const RecordTool = Tool.make('one_thing', { success: Schema.Unknown })
+const BoomTool = Tool.make('boom_thing', { success: Schema.Unknown })
+const SafeTools = Toolkit.make(ListTool, MissTool, RecordTool, BoomTool)
+
+const SafeHandlersLive = SafeTools.toLayer(
+	Effect.succeed({
+		list_thing: () => Effect.succeed([{ id: 'a' }, { id: 'b' }]),
+		missing_thing: () => Effect.succeed(null),
+		one_thing: () => Effect.succeed({ ok: true }),
+		boom_thing: () => {
+			const err = new Error('provider exploded at /app/dist/thing-9f.mjs')
+			err.stack =
+				'Error: provider exploded\n    at load (/app/dist/thing-9f.mjs:5:3)'
+			return Effect.die(err)
+		},
+	}),
+)
+
+const McpHttpLive = mcpToolkitSafe(SafeTools).pipe(
+	Layer.provide(SafeHandlersLive),
+	Layer.provide(
+		McpServer.layerHttp({ name: 'test', version: '1.0.0', path: '/mcp' }),
+	),
+)
+
+const ServerLive = HttpRouter.serve(McpHttpLive, {
+	disableListenLog: true,
+}).pipe(Layer.provideMerge(NodeHttpServer.layer(createServer, { port: 0 })))
+
+const runtime = ManagedRuntime.make(ServerLive)
+
+type RpcReply = {
+	result?: {
+		isError?: boolean
+		structuredContent?: unknown
+		content?: ReadonlyArray<{ type: string; text: string }>
+	}
+}
+
+let baseUrl: string
+let sessionId: string
+
+const post = (body: unknown, sid?: string): Promise<Response> =>
+	fetch(`${baseUrl}/mcp`, {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			accept: 'application/json, text/event-stream',
+			...(sid ? { 'mcp-session-id': sid } : {}),
+		},
+		body: JSON.stringify(body),
+	})
+
+// The reply comes back either as plain JSON or a single SSE frame; take the last
+// `data:` payload when framed, otherwise the whole body.
+const readReply = async (res: Response): Promise<RpcReply> => {
+	const text = await res.text()
+	const dataLine = text
+		.split('\n')
+		.filter(line => line.startsWith('data:'))
+		.at(-1)
+	return JSON.parse(dataLine ? dataLine.replace(/^data:\s*/, '') : text)
+}
+
+const callTool = (name: string): Promise<Response> =>
+	post(
+		{
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'tools/call',
+			params: { name, arguments: {} },
+		},
+		sessionId,
+	)
+
+describe('a tool served through mcpToolkitSafe', () => {
+	beforeAll(async () => {
+		const address = await runtime.runPromise(
+			Effect.gen(function* () {
+				const server = yield* HttpServer.HttpServer
+				return server.address
+			}),
+		)
+		if (address._tag !== 'TcpAddress')
+			throw new Error('expected a TCP address for the test server')
+		baseUrl = `http://127.0.0.1:${address.port}`
+
+		const initRes = await post({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: { name: 'test', version: '1.0' },
+			},
+		})
+		sessionId = initRes.headers.get('mcp-session-id') as string
+		if (!sessionId) throw new Error('server did not issue a session id')
+	}, 30_000)
+
+	afterAll(() => runtime.dispose())
+
+	describe('when the handler returns a bare array', () => {
+		it('should deliver it as an items record, not a bare array', async () => {
+			// WHEN the client calls a list-returning tool
+			const reply = await readReply(await callTool('list_thing'))
+
+			// THEN the structured output is an object under `items` a strict
+			// client accepts, with the rows intact
+			expect(reply.result?.isError).toBeFalsy()
+			expect(Array.isArray(reply.result?.structuredContent)).toBe(false)
+			expect(reply.result?.structuredContent).toEqual({
+				items: [{ id: 'a' }, { id: 'b' }],
+			})
+		})
+	})
+
+	describe('when the handler returns null', () => {
+		it('should omit structured output rather than ship a bare null', async () => {
+			// WHEN the client calls a tool that finds nothing
+			const reply = await readReply(await callTool('missing_thing'))
+
+			// THEN no non-record structured output is sent (the field is absent),
+			// so the call is not rejected client-side
+			expect(reply.result?.isError).toBeFalsy()
+			expect(reply.result?.structuredContent).toBeUndefined()
+		})
+	})
+
+	describe('when the handler returns a record', () => {
+		it('should pass the object through untouched', async () => {
+			// WHEN the client calls a record-returning tool
+			const reply = await readReply(await callTool('one_thing'))
+
+			// THEN the record is delivered as-is
+			expect(reply.result?.structuredContent).toEqual({ ok: true })
+		})
+	})
+
+	describe('when the handler dies with an internal error', () => {
+		it('should return a sanitized message with no stack or bundle path', async () => {
+			// WHEN the client calls a tool that dies referencing a bundle path
+			const reply = await readReply(await callTool('boom_thing'))
+
+			// THEN the call is flagged as an error but the text leaks no internals
+			expect(reply.result?.isError).toBe(true)
+			const text = reply.result?.content?.[0]?.text ?? ''
+			expect(text).not.toContain('/app/dist')
+			expect(text).not.toContain('.mjs')
+			expect(text).not.toMatch(/\n\s*at\s/)
+			// AND the caller still gets a usable signal
+			expect(text).toContain('provider exploded')
+		})
+	})
+})

--- a/apps/server/src/mcp/safe-toolkit.ts
+++ b/apps/server/src/mcp/safe-toolkit.ts
@@ -1,0 +1,155 @@
+import { Cause, Effect, Layer, Option, ServiceMap, Sink, Stream } from 'effect'
+import { McpSchema, McpServer, Tool, type Toolkit } from 'effect/unstable/ai'
+
+// The MCP bridge that turns a tool handler's return value into a client
+// response has two client-facing defects. This is a faithful reimplementation
+// of the library's `registerToolkit`/`toolkit` (see
+// docs/repos/effect/packages/effect/src/unstable/ai/McpServer.ts) that
+// registers into the same shared server registry (McpServer.layer) but corrects
+// both — done in our own code rather than by patching the dependency. Re-sync
+// with the vendored source on an effect upgrade.
+//
+// 1. Result shape: the library copies the raw return straight into
+//    `structuredContent`, but the MCP spec requires structured output to be a
+//    JSON object. A handler that returns a bare array or `null` therefore ships
+//    a value strict clients reject, hiding the tool entirely.
+// 2. Error text: the library renders any failure with the full `Cause.pretty`,
+//    leaking internal stack frames, bundle paths, and nested cause dumps to the
+//    caller. We surface only the top-level error's tag and message.
+
+// Coerce a handler result into a value the MCP spec accepts as structured
+// output. A record passes through; an array is wrapped so it stays reachable;
+// anything else (null, a scalar) can't be a record, so we omit structured
+// output — the field is optional and the value still rides in the text block.
+export const toStructuredContent = (
+	value: unknown,
+): Record<string, unknown> | undefined => {
+	if (Array.isArray(value)) return { items: value }
+	if (value !== null && typeof value === 'object')
+		return value as Record<string, unknown>
+	return undefined
+}
+
+// Remove anything that would expose our internals: whole stack frames and
+// absolute file paths (a bundle path like `/app/dist/*.mjs`, a config or secret
+// path), and cap the length so a giant serialized object can't flood the caller.
+const stripInternals = (text: string): string =>
+	text
+		// Cap first so the scan stays bounded no matter how large the input is.
+		.slice(0, 2000)
+		.replace(/\n\s*at\s+.*/g, '')
+		// Redact absolute filesystem paths (two or more segments) while leaving
+		// URLs intact — the leading slash must not follow a `:` (as in `https://`)
+		// or a host character. Each segment forbids `/`, so the match is linear and
+		// a slash-heavy message can't trigger runaway backtracking.
+		.replace(/(?<![:\w/])(?:\/[^\s:/)'"]+){2,}\/?/g, '<path>')
+		.slice(0, 500)
+		.trim()
+
+const errorLabel = (error: Error): string => {
+	const tag = (error as { _tag?: unknown })._tag
+	const name =
+		typeof tag === 'string'
+			? tag
+			: error.name && error.name !== 'Error'
+				? error.name
+				: ''
+	const message = typeof error.message === 'string' ? error.message : ''
+	const label =
+		name && message
+			? `${name}: ${message}`
+			: name || message || 'internal error'
+	return stripInternals(label)
+}
+
+// Render a failure for the client from the top-level error(s) only — never the
+// stack, the nested cause chain, or file paths. `prettyErrors` flattens each
+// cause reason into a plain Error whose message/name/_tag we read but whose
+// stack we ignore; the full cause is still logged server-side below.
+export const sanitizeCause = (cause: Cause.Cause<unknown>): string => {
+	const errors = Cause.prettyErrors(cause)
+	if (errors.length === 0) return 'internal error'
+	return errors.map(errorLabel).join('; ')
+}
+
+const registerToolkitSafe = <Tools extends Record<string, Tool.Any>>(
+	toolkit: Toolkit.Toolkit<Tools>,
+) =>
+	Effect.gen(function* () {
+		const registry = yield* McpServer.McpServer
+		// The toolkit is yieldable as the Effect that builds its handler map; the
+		// cast mirrors the library's own cast at this boundary.
+		const built = yield* toolkit as unknown as Effect.Effect<
+			Toolkit.WithHandler<Tools>,
+			never,
+			Exclude<Tool.HandlersFor<Tools>, McpSchema.McpServerClient>
+		>
+		const services = yield* Effect.services<never>()
+		for (const tool of Object.values(built.tools)) {
+			const annotations = tool.annotations
+			const mcpTool = new McpSchema.Tool({
+				name: tool.name,
+				description: Tool.getDescription(tool),
+				inputSchema: Tool.getJsonSchema(tool),
+				annotations: {
+					...Option.getOrUndefined(
+						Option.map(
+							ServiceMap.getOption(annotations, Tool.Title),
+							title => ({ title }),
+						),
+					),
+					readOnlyHint: ServiceMap.get(annotations, Tool.Readonly),
+					destructiveHint: ServiceMap.get(annotations, Tool.Destructive),
+					idempotentHint: ServiceMap.get(annotations, Tool.Idempotent),
+					openWorldHint: ServiceMap.get(annotations, Tool.OpenWorld),
+				},
+				_meta: ServiceMap.getOrUndefined(annotations, Tool.Meta),
+			})
+			yield* registry.addTool({
+				tool: mcpTool,
+				annotations,
+				handle: payload =>
+					built.handle(tool.name as keyof Tools, payload).pipe(
+						Stream.unwrap,
+						Stream.run(Sink.last()),
+						Effect.flatMap(Effect.fromOption),
+						Effect.provideServices(services as ServiceMap.ServiceMap<never>),
+						Effect.matchCause({
+							onFailure: cause =>
+								new McpSchema.CallToolResult({
+									isError: true,
+									content: [{ type: 'text', text: sanitizeCause(cause) }],
+								}),
+							onSuccess: (result: { readonly encodedResult: unknown }) => {
+								const structured = toStructuredContent(result.encodedResult)
+								return new McpSchema.CallToolResult({
+									isError: false,
+									structuredContent: structured,
+									content: [
+										{
+											type: 'text',
+											text: JSON.stringify(structured ?? result.encodedResult),
+										},
+									],
+								})
+							},
+						}),
+						Effect.tapCause(Effect.log),
+					),
+			})
+		}
+	})
+
+// Drop-in replacement for `McpServer.toolkit` that registers a toolkit's tools
+// with the record-shape and error-redaction fixes above.
+export const mcpToolkitSafe = <Tools extends Record<string, Tool.Any>>(
+	toolkit: Toolkit.Toolkit<Tools>,
+): Layer.Layer<
+	never,
+	never,
+	| Tool.HandlersFor<Tools>
+	| Exclude<Tool.HandlerServices<Tools>, McpSchema.McpServerClient>
+> =>
+	Layer.effectDiscard(registerToolkitSafe(toolkit)).pipe(
+		Layer.provide(McpServer.McpServer.layer),
+	)

--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -1,5 +1,4 @@
 import { Layer } from 'effect'
-import { McpServer } from 'effect/unstable/ai'
 
 import { CompanyResearchPrompt } from './prompts/company-research'
 import { DailyBriefingPrompt } from './prompts/daily-briefing'
@@ -16,6 +15,7 @@ import { InstructionsResource } from './resources/instructions'
 import { PipelineResource } from './resources/pipeline'
 import { ResearchResource } from './resources/research'
 import { TimelineResource } from './resources/timeline'
+import { mcpToolkitSafe } from './safe-toolkit'
 import { CalendarHandlersLive, CalendarTools } from './tools/calendar'
 import { CompanyHandlersLive, CompanyTools } from './tools/companies'
 import { ContactHandlersLive, ContactTools } from './tools/contacts'
@@ -48,24 +48,24 @@ import { TaskHandlersLive, TaskTools } from './tools/tasks'
 import { TimelineHandlersLive, TimelineTools } from './tools/timeline'
 
 export const McpToolsLive = Layer.mergeAll(
-	McpServer.toolkit(CompanyTools),
-	McpServer.toolkit(ContactTools),
-	McpServer.toolkit(InteractionTools),
-	McpServer.toolkit(TaskTools),
-	McpServer.toolkit(DocumentTools),
-	McpServer.toolkit(PageTools),
-	McpServer.toolkit(PipelineTools),
-	McpServer.toolkit(ProductTools),
-	McpServer.toolkit(ProposalTools),
-	McpServer.toolkit(EmailTools),
-	McpServer.toolkit(RecordingTools),
-	McpServer.toolkit(ResearchLifecycleTools),
-	McpServer.toolkit(ResearchMcpTools),
-	McpServer.toolkit(ResearchContactsTools),
-	McpServer.toolkit(ResearchRegistryTools),
-	McpServer.toolkit(InstructionsMcpTools),
-	McpServer.toolkit(TimelineTools),
-	McpServer.toolkit(CalendarTools),
+	mcpToolkitSafe(CompanyTools),
+	mcpToolkitSafe(ContactTools),
+	mcpToolkitSafe(InteractionTools),
+	mcpToolkitSafe(TaskTools),
+	mcpToolkitSafe(DocumentTools),
+	mcpToolkitSafe(PageTools),
+	mcpToolkitSafe(PipelineTools),
+	mcpToolkitSafe(ProductTools),
+	mcpToolkitSafe(ProposalTools),
+	mcpToolkitSafe(EmailTools),
+	mcpToolkitSafe(RecordingTools),
+	mcpToolkitSafe(ResearchLifecycleTools),
+	mcpToolkitSafe(ResearchMcpTools),
+	mcpToolkitSafe(ResearchContactsTools),
+	mcpToolkitSafe(ResearchRegistryTools),
+	mcpToolkitSafe(InstructionsMcpTools),
+	mcpToolkitSafe(TimelineTools),
+	mcpToolkitSafe(CalendarTools),
 	CompanyResource,
 	PipelineResource,
 	DocumentResource,

--- a/apps/server/src/mcp/tools/instructions-mcp.integration.test.ts
+++ b/apps/server/src/mcp/tools/instructions-mcp.integration.test.ts
@@ -331,6 +331,26 @@ describe('MCP instruction tools against live Postgres', () => {
 		})
 	})
 
+	describe('when an agent lists instruction templates', () => {
+		it('should wrap the rows in an items object, never a bare array', async () => {
+			// GIVEN the member owns at least one template
+			const id = await createPersonalTemplate(memberId, 'list-shape')
+
+			// WHEN the agent lists templates
+			// [instructions-mcp.ts manage_instruction_template:list]
+			const res = await callTool(memberId, 'manage_instruction_template', {
+				action: 'list',
+			})
+
+			// THEN the result is an object under `items`, not a bare array — a bare
+			// array is not valid MCP structured output and strict clients reject it
+			expect(Array.isArray(res)).toBe(false)
+			expect(res).toMatchObject({ items: expect.any(Array) })
+			const { items } = res as { items: ReadonlyArray<{ id: string }> }
+			expect(items.some(t => t.id === id)).toBe(true)
+		})
+	})
+
 	// The transfer function self-elevates (BYPASSRLS), so it re-checks the rules
 	// the service checks above. These call it directly, past the service, to prove
 	// the elevation can't be abused even if a caller's checks were wrong.

--- a/apps/server/src/mcp/tools/instructions-mcp.ts
+++ b/apps/server/src/mcp/tools/instructions-mcp.ts
@@ -7,6 +7,7 @@ import { type Agent, AgentSchema } from '@batuda/instructions'
 
 import { InstructionsService } from '../../services/instructions'
 import { Uuid } from './_research-shared'
+import { toItems } from './_result'
 
 // Consolidated, action-based management tools so the MCP surface gains the
 // instruction-template controls without ~16 individual tools. Each acts as the
@@ -90,7 +91,9 @@ export const InstructionsMcpHandlersLive = InstructionsMcpTools.toLayer(
 					const { userId } = yield* SessionContext
 					switch (params.action) {
 						case 'list':
-							return yield* run(svc.listTemplates())
+							// Wrap the row list in an object — a bare array is not valid
+							// MCP structured output and strict clients reject it.
+							return toItems(yield* run(svc.listTemplates()))
 						case 'create':
 							if (
 								params.name === undefined ||

--- a/apps/server/src/mcp/tools/research-lifecycle.ts
+++ b/apps/server/src/mcp/tools/research-lifecycle.ts
@@ -260,7 +260,9 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 					const { userId } = yield* SessionContext
 					if (params.action === 'get') {
 						const policy = yield* svc.getPolicy(userId)
-						return policy ?? null
+						// A missing policy row must still come back as an object — the
+						// MCP contract rejects a bare `null` as structured output.
+						return { policy: policy ?? null }
 					}
 					return yield* svc
 						.updatePolicy(userId, {


### PR DESCRIPTION
## What

Batuda's MCP server is the tool interface external AI clients (Claude, ChatGPT) use to drive the CRM. Two defects there degraded every agent that talks to it, and this fixes both in the `server` app's MCP layer.

First, several tools returned a value the MCP spec forbids as "structured output" — a bare list, or nothing at all — which strict clients reject outright, so the tool silently fails on every call (I reproduced it live: `manage_instruction_template` list returned `expected record, received array`). Second, when a tool failed, the raw internal error — stack traces, server bundle paths like `/app/dist/*.mjs`, nested cause dumps — was handed straight to the external caller.

This resolves findings **A** and **D** of #168. (Findings B and C were already resolved separately — B by clearing a Spain-specific org default, C by the country-agnostic `lookup_registry` in `de9fdd6608`.)

## The fix

- **One shared wrapper for every tool result.** A Batuda-local `mcpToolkitSafe` replaces the library's `McpServer.toolkit` for all 18 toolkits. It's a faithful reimplementation of effect's bridge (public API only — not a dependency patch) that, at one choke point, shapes any non-object result into a valid object (a list → `{ items: [...] }`; a `null`/scalar drops the optional structured field, keeping the value in the text channel) so no tool can ship an invalid result again. The sweep found this affected **17 handlers**, not just the two the issue named.
- **Errors are redacted before they leave the process.** The wrapper surfaces only the failure's tag and message — never a stack, a server path, or a nested cause — while the full detail still goes to the server log. Redaction is linear-time (a slash-heavy provider error can't make it backtrack) and strips absolute filesystem paths regardless of extension, while leaving URLs intact (useful signal for research tools).
- **The two tools the bug was first seen on** now return objects idiomatically: reading the research budget policy with none saved returns `{ policy: null }`, and listing instruction templates returns `{ items: [...] }`.

## Prerequisite (rides along — `fix(cli)` commit)

The verification hooks couldn't run locally because of a separate CLI bug: the `.env` loader read every file with override on, so a blank `apps/cli/.env` line wiped the `DATABASE_URL` the integration test setup exports for its throwaway database, and `db reset` connected to nothing (`3D000`). One commit fixes it — baseline `.env` files now skip blank entries and never overwrite a caller-exported value. It's an unrelated concern but a prerequisite to running the MCP fix through the local gates, so it's a clearly separated commit here. The larger consolidation it points to is tracked in **#187**.

## Impact

- **MCP-transport only.** This is the tool→client bridge; the HTTP API doesn't share it, so no HTTP behavior changes.
- **Wire-shape change (intentional, pre-prod clean break):** ~10 list tools that returned a bare array now return `{ items: [...] }` in `structuredContent` (and the mirroring text block). This is the correct MCP shape — strict clients were already rejecting the bare-array form. `research_policy` (get) changes from a bare row/`null` to `{ policy: <row|null> }`.
- **No schema/RLS/auth/env change** in the MCP fix. The `fix(cli)` commit touches only local `.env` loading. Note the rebase pulled in the base's new migration `0021_companies_geo_index` — unrelated to this PR.

## Review guide

- **Start at `apps/server/src/mcp/safe-toolkit.ts`** — the only non-trivial file. Header comment maps the two changes and flags "re-sync on effect upgrade." The rest of the MCP diff is a mechanical `McpServer.toolkit` → `mcpToolkitSafe` swap plus two one-line handler fixes.
- **Riskiest part: the layer wiring** — `mcpToolkitSafe` must register into the *same* shared `McpServer` registry that `layerHttp` serves. Verified two ways: an independent line-by-line review against the vendored library, and an end-to-end round-trip test that boots a real MCP HTTP server and confirms tools are served with the fix.
- **A security review during self-review caught (and I fixed) a ReDoS** in the first version of the error sanitizer — worth a look at the `stripInternals` regex and its tests.
- **`fix(cli)` commit** is independent; review it on its own.
- Snyk was not run (tool unavailable in this session).

## Tests

- **Unit** (`safe-toolkit.test.ts`): both shaping helpers across every result shape, and the sanitizer (string die, stack+bundle-path die, tagged error, non-JS path, URL preservation, ReDoS-shaped input, empty cause).
- **Round-trip** (same file): tools registered via `mcpToolkitSafe` driven over a real in-process MCP HTTP server — array→`{items}`, null→omitted, record→passthrough, dying tool→sanitized error.
- **Integration** (`instructions-mcp.integration.test.ts`): `manage_instruction_template` list returns `{ items }` through the real handler against Postgres.

## Verification

- Rebased onto current `origin/main` (+3). Ran the gates: `pnpm install` → `pnpm -w check-types` + `pnpm -w test` → `pnpm -w build`.
- Server integration suite runs against a freshly-migrated (incl. `0021`) + seeded `batuda_it` — provisioning that the `fix(cli)` commit is what unblocked.
- The round-trip test is the live proof: a real MCP HTTP server serves the wrapped tools and returns the corrected shapes/error.

## Follow-up

- **#187** — make `setup` context-aware and share the `.env`-writing logic with `worktree` (the root cause behind the blank-`DATABASE_URL` the `fix(cli)` commit works around).

Closes #168
