### PR TITLE
feat: apply research proposed-updates to the CRM row

### DIFF
--- a/apps/server/src/handlers/research.ts
+++ b/apps/server/src/handlers/research.ts
@@ -1,5 +1,6 @@
 import { DateTime, Effect, Stream } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
+import { SqlClient } from 'effect/unstable/sql'
 
 import {
 	BatudaApi,
@@ -15,6 +16,9 @@ import {
 } from '@batuda/research'
 
 import { EnvVars } from '../lib/env'
+import { CompanyService } from '../services/companies'
+import { Geocoder } from '../services/geocoder'
+import { resolveResearchProposedUpdate } from '../services/research-apply'
 
 export const ResearchLive = HttpApiBuilder.group(
 	BatudaApi,
@@ -23,6 +27,37 @@ export const ResearchLive = HttpApiBuilder.group(
 		Effect.gen(function* () {
 			const svc = yield* ResearchService
 			const env = yield* EnvVars
+			// Applying a proposed update writes a CRM row and may fork an
+			// org-scoped re-geocode; resolve those services here so both the apply
+			// and reject handlers can provide them to the shared resolver.
+			const companyService = yield* CompanyService
+			const geocoder = yield* Geocoder
+			const sql = yield* SqlClient.SqlClient
+
+			// Shared apply/reject path: run the resolver, then surface a missing run
+			// or proposal as a 404 and let any DB fault die as a defect.
+			const resolveProposal = (
+				id: string,
+				puId: string,
+				decision: 'apply' | 'reject',
+			) =>
+				resolveResearchProposedUpdate(id, puId, decision).pipe(
+					Effect.provideService(CompanyService, companyService),
+					Effect.provideService(Geocoder, geocoder),
+					Effect.provideService(SqlClient.SqlClient, sql),
+					Effect.flatMap(result =>
+						result.outcome === 'run_not_found'
+							? Effect.fail(new NotFound({ entity: 'research', id }))
+							: result.outcome === 'proposal_not_found'
+								? Effect.fail(
+										new NotFound({ entity: 'proposed-update', id: puId }),
+									)
+								: Effect.succeed(result),
+					),
+					Effect.catch(e =>
+						e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+					),
+				)
 
 			const systemDefaults: SystemDefaults = {
 				budgetCents: env.RESEARCH_DEFAULT_BUDGET_CENTS,
@@ -242,10 +277,12 @@ export const ResearchLive = HttpApiBuilder.group(
 								entity: 'research',
 								id: _.params.id,
 							})
+						// The SQL client camelCases JSONB keys on read, so the stored
+						// `proposed_updates` surfaces here as `proposedUpdates`.
 						const findings = (run as { findings: unknown }).findings as {
-							proposed_updates?: unknown[]
+							proposedUpdates?: unknown[]
 						}
-						return findings?.proposed_updates ?? []
+						return findings?.proposedUpdates ?? []
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
@@ -253,12 +290,10 @@ export const ResearchLive = HttpApiBuilder.group(
 					),
 				)
 				.handle('applyProposedUpdate', _ =>
-					// Fires the domain update endpoint with OCC.
-					// Placeholder for now.
-					Effect.succeed({ status: 'applied' }),
+					resolveProposal(_.params.id, _.params.puId, 'apply'),
 				)
 				.handle('rejectProposedUpdate', _ =>
-					Effect.succeed({ status: 'rejected' }),
+					resolveProposal(_.params.id, _.params.puId, 'reject'),
 				)
 				.handle('getPolicy', _ =>
 					Effect.gen(function* () {

--- a/apps/server/src/mcp/tools/research-lifecycle.ts
+++ b/apps/server/src/mcp/tools/research-lifecycle.ts
@@ -1,9 +1,13 @@
 import { Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg, SessionContext } from '@batuda/controllers'
 import { ResearchService } from '@batuda/research'
 
+import { CompanyService } from '../../services/companies'
+import { Geocoder } from '../../services/geocoder'
+import { resolveResearchProposedUpdate } from '../../services/research-apply'
 import { redactDbErrors, Uuid } from './_research-shared'
 import { ListResult, toItems } from './_result'
 
@@ -191,6 +195,12 @@ export const ResearchLifecycleTools = Toolkit.make(
 export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 	Effect.gen(function* () {
 		const svc = yield* ResearchService
+		// The apply path writes a CRM row and, on a location change, forks an
+		// org-scoped re-geocode — resolve those services here and provide them,
+		// keeping CurrentOrg as the only per-request service the handler needs.
+		const companyService = yield* CompanyService
+		const geocoder = yield* Geocoder
+		const sql = yield* SqlClient.SqlClient
 		return {
 			list_research: filters =>
 				svc
@@ -241,19 +251,23 @@ export const ResearchLifecycleHandlersLive = ResearchLifecycleTools.toLayer(
 				Effect.gen(function* () {
 					const run = yield* svc.get(id)
 					if (!run) return []
+					// The SQL client camelCases JSONB keys on read, so the stored
+					// `proposed_updates` surfaces here as `proposedUpdates`.
 					const findings = (run as { findings: unknown }).findings as {
-						proposed_updates?: unknown[]
+						proposedUpdates?: unknown[]
 					} | null
-					return findings?.proposed_updates ?? []
+					return findings?.proposedUpdates ?? []
 				}).pipe(redactDbErrors, Effect.map(toItems)),
-			resolve_research_proposed_update: ({ decision }) =>
-				// Placeholder: the OCC-protected CRM write that would land on
-				// apply is not yet wired, so this returns the resolution
-				// shape without mutating any row.
-				Effect.succeed(
-					decision === 'apply'
-						? { status: 'applied' as const }
-						: { status: 'rejected' as const },
+			resolve_research_proposed_update: ({
+				id,
+				proposed_update_id,
+				decision,
+			}) =>
+				resolveResearchProposedUpdate(id, proposed_update_id, decision).pipe(
+					Effect.provideService(CompanyService, companyService),
+					Effect.provideService(Geocoder, geocoder),
+					Effect.provideService(SqlClient.SqlClient, sql),
+					redactDbErrors,
 				),
 			research_policy: params =>
 				Effect.gen(function* () {

--- a/apps/server/src/mcp/tools/research-sink.ts
+++ b/apps/server/src/mcp/tools/research-sink.ts
@@ -96,6 +96,10 @@ export const ResearchSinkHandlersLive = ResearchSinkTools.toLayer(
 							COALESCE(findings->'proposed_updates', '[]'::jsonb)
 								|| ${JSON.stringify([
 									{
+										// Stable id so a human can later apply or reject this
+										// exact proposal — the resolve/apply surfaces address
+										// proposals by id.
+										id: crypto.randomUUID(),
 										subject_table: params.subject_table,
 										subject_id: params.subject_id,
 										expected_version: params.expected_version,

--- a/apps/server/src/services/company-geocoding.ts
+++ b/apps/server/src/services/company-geocoding.ts
@@ -77,18 +77,18 @@ export const locationWasReplaced = (
 }
 
 /**
- * Re-geocode a company off the update path, on its own connection.
+ * Re-geocode a company in the background, on its own connection.
  *
  * The geocoder call runs ~1.5s (Nominatim's rate limit) and must not block the
- * update response, so it forks. But it must NOT reuse the request's transaction:
- * that connection commits and returns to the pool the moment the response is
- * sent. Dropping the inherited `TransactionConnection` makes `enterOrgScope`
- * open its own top-level transaction on a fresh pooled connection and re-apply
- * the app_user role + org GUC, so the coordinate write passes RLS. Best-effort:
- * a miss or failure just leaves the previous coordinates in place. Mirrors the
- * research event sink's out-of-band, org-scoped write.
+ * caller's response, so it forks. But it must NOT reuse the request's
+ * transaction: that connection commits and returns to the pool the moment the
+ * response is sent. Dropping the inherited `TransactionConnection` makes
+ * `enterOrgScope` open its own top-level transaction on a fresh pooled
+ * connection and re-apply the app_user role + org GUC, so the coordinate write
+ * passes RLS. Best-effort: a miss or failure just leaves the previous
+ * coordinates in place. Callers: a location edit and an applied research update.
  */
-const regeocodeOutOfBand = (id: string) =>
+export const forkCompanyRegeocode = (id: string) =>
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
 		const org = yield* CurrentOrg
@@ -100,7 +100,7 @@ const regeocodeOutOfBand = (id: string) =>
 			Effect.catchCause(cause =>
 				Cause.hasInterruptsOnly(cause)
 					? Effect.interrupt
-					: Effect.logWarning('post-update geocode failed').pipe(
+					: Effect.logWarning('background geocode failed').pipe(
 							Effect.annotateLogs({
 								event: 'company.geocode.failed',
 								companyId: id,
@@ -139,7 +139,7 @@ export const updateCompanyRegeocoding = (
 		const updated = rows[0] ?? null
 
 		if (updated && locationWasReplaced(before, fields)) {
-			yield* regeocodeOutOfBand(id)
+			yield* forkCompanyRegeocode(id)
 		}
 
 		return updated

--- a/apps/server/src/services/research-apply.test.ts
+++ b/apps/server/src/services/research-apply.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { allowlistFields, validate } from './research-apply'
+
+describe('allowlistFields', () => {
+	describe('when a company proposal carries writable and non-writable keys', () => {
+		it('should keep only known columns and drop everything else', () => {
+			// GIVEN a proposal mixing real company columns with fields that must
+			// never be written from a suggestion (identity, coordinates, version)
+			const kept = allowlistFields('companies', {
+				industry: 'logistics',
+				location: 'Sitges',
+				id: 'should-drop',
+				latitude: 1.23,
+				version: 99,
+				made_up: 'nope',
+			})
+
+			// THEN only the writable columns survive
+			expect(kept).toEqual({ industry: 'logistics', location: 'Sitges' })
+		})
+	})
+
+	describe('when proposal keys are snake_case', () => {
+		it('should normalize them to the camelCase the SQL client expects', () => {
+			// GIVEN a model that sent snake_case field names
+			const kept = allowlistFields('companies', {
+				size_range: '51-200',
+				pain_points: 'slow onboarding',
+			})
+
+			// THEN they map to the camelCase column keys
+			expect(kept).toEqual({
+				sizeRange: '51-200',
+				painPoints: 'slow onboarding',
+			})
+		})
+	})
+
+	describe('when the target is a contact', () => {
+		it('should use the contact allowlist, not the company one', () => {
+			// GIVEN a contact proposal that also carries a company-only field
+			const kept = allowlistFields('contacts', {
+				is_decision_maker: true,
+				notes: 'met at fair',
+				industry: 'company-only, should drop',
+			})
+
+			// THEN only contact columns survive
+			expect(kept).toEqual({ isDecisionMaker: true, notes: 'met at fair' })
+		})
+	})
+})
+
+describe('validate', () => {
+	const base = {
+		subject_table: 'companies',
+		subject_id: 'c-1',
+		expected_version: 2,
+		fields: { industry: 'logistics' },
+	}
+
+	describe('when the proposal is well-formed', () => {
+		it('should accept it and surface the parsed parts', () => {
+			// GIVEN a complete, well-typed proposal
+			const result = validate(base)
+
+			// THEN it validates and exposes the target and fields
+			expect(result).toMatchObject({
+				ok: true,
+				table: 'companies',
+				subjectId: 'c-1',
+				expectedVersion: 2,
+			})
+		})
+	})
+
+	describe('when the subject table is not a CRM table', () => {
+		it('should reject it', () => {
+			// GIVEN a proposal targeting an unknown table
+			expect(validate({ ...base, subject_table: 'invoices' }).ok).toBe(false)
+		})
+	})
+
+	describe('when the expected version is not a finite number', () => {
+		it('should reject it (a "NaN" the guard coerced to null cannot drive OCC)', () => {
+			// GIVEN a proposal whose expected version was coerced away
+			expect(validate({ ...base, expected_version: null }).ok).toBe(false)
+			expect(validate({ ...base, expected_version: Number.NaN }).ok).toBe(false)
+		})
+	})
+
+	describe('when fields is prose instead of an object', () => {
+		it('should reject it, since a sentence is not an actionable field map', () => {
+			// GIVEN the tolerant-decoder fallback: the model wrote a sentence where
+			// a JSON object was expected, kept verbatim as a string
+			expect(
+				validate({ ...base, fields: 'set the industry to logistics' }).ok,
+			).toBe(false)
+			// GIVEN an array, which is also not a field map
+			expect(validate({ ...base, fields: ['industry'] }).ok).toBe(false)
+		})
+	})
+})

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -1,0 +1,251 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { forkCompanyRegeocode } from './company-geocoding'
+
+/**
+ * Apply (or reject) a research-proposed CRM update — the one place a research
+ * run's suggestion is written back onto a company or contact row.
+ *
+ * A research run records suggested field changes in its findings as "proposed
+ * updates", each awaiting human review. Applying one writes the suggested fields
+ * onto the target row under optimistic concurrency control: the write only lands
+ * if the row's `version` still matches the version the run saw, so a proposal
+ * made against a since-changed row is rejected as a conflict instead of
+ * clobbering newer data. The MCP tool `resolve_research_proposed_update` and the
+ * HTTP apply/reject endpoints both go through here, so the two transports stay
+ * identical.
+ */
+
+// Only these columns can be set by an applied proposal — never an arbitrary
+// column. Keys are the camelCase names the SQL client maps to snake_case; the
+// model may send either casing, so proposal keys are normalized before the
+// lookup. Excludes identity, coordinates (set by the geocoder), version, and
+// timestamps.
+const COMPANY_FIELDS = new Set([
+	'name',
+	'status',
+	'industry',
+	'sizeRange',
+	'region',
+	'location',
+	'source',
+	'priority',
+	'website',
+	'email',
+	'phone',
+	'instagram',
+	'linkedin',
+	'googleMapsUrl',
+	'productsFit',
+	'tags',
+	'painPoints',
+	'currentTools',
+])
+
+const CONTACT_FIELDS = new Set([
+	'name',
+	'role',
+	'isDecisionMaker',
+	'email',
+	'phone',
+	'whatsapp',
+	'linkedin',
+	'instagram',
+	'notes',
+])
+
+const snakeToCamel = (s: string) =>
+	s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+
+/**
+ * Keep only the proposal fields that map to a writable column on the target
+ * table, normalizing snake_case keys to the camelCase the SQL client expects.
+ */
+export const allowlistFields = (
+	table: 'companies' | 'contacts',
+	fields: Record<string, unknown>,
+): Record<string, unknown> => {
+	const allowed = table === 'companies' ? COMPANY_FIELDS : CONTACT_FIELDS
+	const out: Record<string, unknown> = {}
+	for (const [key, value] of Object.entries(fields)) {
+		const camel = snakeToCamel(key)
+		if (allowed.has(camel)) out[camel] = value
+	}
+	return out
+}
+
+export type Validated =
+	| {
+			readonly ok: true
+			readonly table: 'companies' | 'contacts'
+			readonly subjectId: string
+			readonly expectedVersion: number
+			readonly fields: Record<string, unknown>
+	  }
+	| { readonly ok: false; readonly reason: string }
+
+export const validate = (proposal: Record<string, unknown>): Validated => {
+	const table = proposal['subject_table']
+	if (table !== 'companies' && table !== 'contacts')
+		return { ok: false, reason: 'unknown subject_table' }
+	const subjectId = proposal['subject_id']
+	if (typeof subjectId !== 'string' || subjectId === '')
+		return { ok: false, reason: 'missing subject_id' }
+	const expectedVersion = proposal['expected_version']
+	if (typeof expectedVersion !== 'number' || !Number.isFinite(expectedVersion))
+		return { ok: false, reason: 'missing or non-finite expected_version' }
+	// A proposal's fields arrive as JSON, but an open-weights model sometimes
+	// writes a plain sentence there instead (kept as a raw string by the tolerant
+	// decoder); prose is not an actionable field map, so refuse it.
+	const fields = proposal['fields']
+	if (typeof fields !== 'object' || fields === null || Array.isArray(fields))
+		return { ok: false, reason: 'fields is not an object' }
+	return {
+		ok: true,
+		table,
+		subjectId,
+		expectedVersion,
+		fields: fields as Record<string, unknown>,
+	}
+}
+
+// Mark one proposal (found by array index) applied or rejected in the run's
+// findings, leaving the rest of the findings untouched.
+const setProposalStatus = (
+	sql: SqlClient.SqlClient,
+	runId: string,
+	orgId: string,
+	index: number,
+	status: 'applied' | 'rejected',
+) =>
+	sql`
+		UPDATE research_runs
+		SET findings = jsonb_set(
+				findings,
+				${`{proposed_updates,${index},status}`}::text[],
+				${JSON.stringify(status)}::jsonb
+			),
+			updated_at = now()
+		WHERE id = ${runId} AND organization_id = ${orgId}
+	`
+
+// Optimistic-concurrency write: lands only if `version` still equals the version
+// the proposal was made against, and bumps it. Branches on the table so the name
+// is never interpolated. Returns the new row (empty on a version/id mismatch).
+const occUpdate = (
+	sql: SqlClient.SqlClient,
+	table: 'companies' | 'contacts',
+	subjectId: string,
+	orgId: string,
+	expectedVersion: number,
+	fields: Record<string, unknown>,
+) =>
+	table === 'companies'
+		? sql<{ version: number }>`
+				UPDATE companies
+				SET ${sql.update(fields)}, version = version + 1, updated_at = now()
+				WHERE id = ${subjectId}
+					AND organization_id = ${orgId}
+					AND version = ${expectedVersion}
+				RETURNING version
+			`
+		: sql<{ version: number }>`
+				UPDATE contacts
+				SET ${sql.update(fields)}, version = version + 1, updated_at = now()
+				WHERE id = ${subjectId}
+					AND organization_id = ${orgId}
+					AND version = ${expectedVersion}
+				RETURNING version
+			`
+
+export type ResolveOutcome =
+	| {
+			readonly outcome: 'applied'
+			readonly subject_table: 'companies' | 'contacts'
+			readonly subject_id: string
+			readonly version: number
+	  }
+	| { readonly outcome: 'rejected' }
+	| { readonly outcome: 'conflict' }
+	| { readonly outcome: 'invalid'; readonly reason: string }
+	| { readonly outcome: 'no_applicable_fields' }
+	| { readonly outcome: 'run_not_found' }
+	| { readonly outcome: 'proposal_not_found' }
+
+export const resolveResearchProposedUpdate = (
+	runId: string,
+	proposedUpdateId: string,
+	decision: 'apply' | 'reject',
+) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const org = yield* CurrentOrg
+
+		const rows = yield* sql<{ findings: string | null }>`
+			SELECT findings::text AS findings FROM research_runs
+			WHERE id = ${runId} AND organization_id = ${org.id}
+			LIMIT 1
+		`
+		const run = rows[0]
+		if (!run) return { outcome: 'run_not_found' } satisfies ResolveOutcome
+
+		// Read the raw JSONB text and parse it, so the proposal keeps its stored
+		// snake_case shape. The SQL client camelCases result keys — including
+		// nested JSONB object keys — which would otherwise rename
+		// `proposed_updates` to `proposedUpdates` and hide every proposal.
+		const findings = (run.findings ? JSON.parse(run.findings) : null) as {
+			proposed_updates?: Array<Record<string, unknown>>
+		} | null
+		const proposals = findings?.proposed_updates ?? []
+		const index = proposals.findIndex(
+			p => p['id'] === proposedUpdateId && p['status'] === 'pending',
+		)
+		if (index === -1)
+			return { outcome: 'proposal_not_found' } satisfies ResolveOutcome
+		const proposal = proposals[index] as Record<string, unknown>
+
+		if (decision === 'reject') {
+			yield* setProposalStatus(sql, runId, org.id, index, 'rejected')
+			return { outcome: 'rejected' } satisfies ResolveOutcome
+		}
+
+		const validated = validate(proposal)
+		if (!validated.ok)
+			return {
+				outcome: 'invalid',
+				reason: validated.reason,
+			} satisfies ResolveOutcome
+
+		const fields = allowlistFields(validated.table, validated.fields)
+		if (Object.keys(fields).length === 0)
+			return { outcome: 'no_applicable_fields' } satisfies ResolveOutcome
+
+		const updatedRows = yield* occUpdate(
+			sql,
+			validated.table,
+			validated.subjectId,
+			org.id,
+			validated.expectedVersion,
+			fields,
+		)
+		if (updatedRows.length === 0)
+			return { outcome: 'conflict' } satisfies ResolveOutcome
+
+		yield* setProposalStatus(sql, runId, org.id, index, 'applied')
+
+		// Applying a new location makes the stored coordinates stale; refresh them
+		// the same background, org-scoped way a manual location edit does.
+		if (validated.table === 'companies' && Object.hasOwn(fields, 'location')) {
+			yield* forkCompanyRegeocode(validated.subjectId)
+		}
+
+		return {
+			outcome: 'applied',
+			subject_table: validated.table,
+			subject_id: validated.subjectId,
+			version: updatedRows[0]?.version ?? validated.expectedVersion + 1,
+		} satisfies ResolveOutcome
+	})

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -11,6 +11,7 @@ import {
 	researchCacheTtlDaysFor,
 	schemaVersionFor,
 	shouldMarkRunFailed,
+	withProposalIds,
 } from './research-service'
 
 describe('normalizeResearchQuery', () => {
@@ -30,6 +31,46 @@ describe('normalizeResearchQuery', () => {
 		// GIVEN a query with numbers and punctuation
 		// THEN punctuation is kept — only whitespace and case are normalized
 		expect(normalizeResearchQuery('Q3 2025 revenue?')).toBe('q3 2025 revenue?')
+	})
+})
+
+describe('withProposalIds', () => {
+	describe('when findings carry proposed updates', () => {
+		it('should give each a stable id and a pending status, keeping its fields', () => {
+			// GIVEN Phase-2 findings whose proposals have no id or status yet
+			const out = withProposalIds({
+				enrichment: { industry: 'logistics' },
+				proposed_updates: [
+					{ subject_table: 'companies', subject_id: 'c-1', fields: {} },
+				],
+			}) as {
+				enrichment: unknown
+				proposed_updates: Array<Record<string, unknown>>
+			}
+
+			// THEN each proposal gains an id + pending status, other keys untouched
+			expect(out.enrichment).toEqual({ industry: 'logistics' })
+			expect(typeof out.proposed_updates[0]?.['id']).toBe('string')
+			expect(out.proposed_updates[0]?.['status']).toBe('pending')
+			expect(out.proposed_updates[0]?.['subject_id']).toBe('c-1')
+		})
+	})
+
+	describe('when findings have no proposed updates', () => {
+		it('should pass them through untouched', () => {
+			// GIVEN findings without a proposed_updates array
+			const findings = { competitors: [] }
+			// THEN nothing is added
+			expect(withProposalIds(findings)).toBe(findings)
+		})
+	})
+
+	describe('when findings are not an object', () => {
+		it('should return them as-is', () => {
+			// GIVEN a non-object findings value (e.g. a bare string)
+			expect(withProposalIds('oops')).toBe('oops')
+			expect(withProposalIds(null)).toBe(null)
+		})
 	})
 })
 

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 import {
 	Cause,
@@ -68,6 +68,34 @@ export const normalizeResearchQuery = (query: string): string =>
 export const schemaVersionFor = (schemaName: string): number => {
 	const match = schemaName.match(/_v(\d+)$/)
 	return match ? Number(match[1]) : 1
+}
+
+/**
+ * Give each extracted proposed-update a stable id and a pending status before
+ * the findings are stored, so a human can later apply or reject that exact
+ * proposal by id (the apply surface addresses them by id). Non-object findings
+ * and every other key pass through untouched.
+ */
+export const withProposalIds = (findings: unknown): unknown => {
+	if (
+		typeof findings !== 'object' ||
+		findings === null ||
+		Array.isArray(findings)
+	)
+		return findings
+	const record = findings as Record<string, unknown>
+	const proposals = record['proposed_updates']
+	if (!Array.isArray(proposals)) return findings
+	return {
+		...record,
+		proposed_updates: proposals.map(proposal =>
+			typeof proposal === 'object' &&
+			proposal !== null &&
+			!Array.isArray(proposal)
+				? { id: randomUUID(), status: 'pending', ...proposal }
+				: proposal,
+		),
+	}
 }
 
 // Clamp list pagination so out-of-range input can't reach SQL: a negative limit
@@ -700,7 +728,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							schema: outputSchema as typeof FreeformSchema,
 							prompt: `Based on this research, produce structured findings:\n\n${researchText}`,
 						})
-						findings = structuredResponse.value as unknown
+						findings = withProposalIds(structuredResponse.value as unknown)
 						tokensOut += structuredResponse.usage.outputTokens.total ?? 0
 						yield* Ref.update(toolLog, log => [
 							...log,


### PR DESCRIPTION
## What

The last of the four deferred follow-ups from #183 (item 3 of #184). A research run can suggest changes to a company or contact — "proposed updates" a person reviews before they touch the CRM. Until now, approving one did nothing: both the MCP tool (`resolve_research_proposed_update`) and the HTTP apply/reject endpoints were stubs that reported success without writing a row. This wires the real write, in the Research + CRM contexts (`server`, `@batuda/research`). With this, an enrichment run's findings — including a company's location — can finally reach the company row and get geocoded.

## Changes

- **Apply a proposed update.** One shared resolver writes the suggested fields onto the target row under **optimistic concurrency control**: the change lands only if the row's `version` still equals the version the run saw. A suggestion made against a since-edited row comes back as a `conflict` instead of overwriting newer data. Reject just marks the proposal dismissed. Both the MCP tool and the two HTTP endpoints go through it.
- **Only safe columns, only real field maps.** An applied suggestion can set only an allowlisted set of columns per table (company / contact) — never identity, `version`, coordinates, or an arbitrary column. A suggestion whose `fields` came back as a plain sentence (the tolerant decoder's fallback for a model that wrote prose where JSON was expected) is refused, not applied.
- **Stable proposal ids.** Each proposed update now gets an id and a `pending` status when it's recorded, so a person can apply or reject that exact one; the surfaces address proposals by that id.
- **Re-geocode on a location apply.** Applying a new `location` to a company refreshes its map coordinates in the background, reusing the org-scoped re-geocode seam from #186.

## Impact

- **Multi-org / RLS.** The apply runs under the request's `app_user` org scope; the write filters `organization_id` explicitly *and* checks `version`. The background re-geocode is the same detached, org-scoped write #186 added (own connection, `app_user` role re-applied) — it can't reach another org's rows.
- **MCP + HTTP parity.** Both transports resolve through the one helper, so apply/reject behave identically.
- **Security surface.** The column allowlist is the guard against a suggestion writing an arbitrary column; prose `fields` are rejected. Worth a careful look.
- **Wire-shape.** Proposals now carry `id` + `status`; the resolve/apply/reject responses return a richer outcome (`applied` / `conflict` / `invalid` / `rejected` / …). Pre-prod — existing findings are recreated, no shim.
- **Latent read bug fixed.** The SQL client camelCases result keys, *including nested JSONB keys*, so stored `proposed_updates` surfaced as `proposedUpdates` — which had been silently making the list endpoints return empty. The list handlers and the apply's lookup now read the correct shape.
- **No migration** (uses the existing `version` column), **no new env vars**, no auth/CORS change.
- **Depends on #186** (merged) — reuses its re-geocode seam.

## Review guide

- **Start at `apps/server/src/services/research-apply.ts`** — the whole feature. Riskiest parts: the OCC `UPDATE` (branches on the table so the name is never interpolated) and `allowlistFields` (the security boundary). 
- **The JSONB-camelCase fix** is the subtle one: `resolveResearchProposedUpdate` reads `findings::text` and parses it to keep the stored snake_case shape; the two list handlers instead read the camelCased `proposedUpdates` key. A live probe caught this — without it the whole flow silently no-ops.
- **A decision you might overrule:** a version mismatch returns `{ outcome: 'conflict' }` (a normal result the caller re-fetches on), not a thrown error. Similarly `invalid` / `no_applicable_fields` are returned, not raised.
- **Reviews:** I self-reviewed the whole branch against the repo checklist (reuse, RLS/org-scoping, MCP/HTTP parity, the allowlist security boundary, AI-code smells) and verified the write path live (below). I did not run `/code-review` or `/security-review` as separate passes, and Snyk was not run this session.

## Tests

- `research-apply.test.ts`: `allowlistFields` (keeps only writable columns, normalizes snake→camel, uses the right per-table list) and `validate` (rejects an unknown table, a non-finite `expected_version` — e.g. a `"NaN"` the guard coerced to null — and prose/array `fields`).
- `research-service.test.ts`: `withProposalIds` stamps id + pending status and leaves other findings untouched.
- The full apply / OCC / conflict / reject / re-geocode path is covered by a live probe (below), since a stub can't model the OCC + RLS + JSONB round-trip that made the naive version wrong.

## Verification

- Gates green: `check-types` (13/13), `test` (20/20 tasks — `server` 518), `build` (13/13).
- **Live probe** under a real `enterOrgScope` transaction (as the request path runs), against the worktree DB as `app_user`, all passing:
  - apply → row updated, `version` 0→1, the disallowed `version` field in the suggestion **not** written, proposal marked `applied`;
  - the applied location → the detached re-geocode wrote coordinates on its own connection;
  - a stale `expected_version` → `conflict`, row unchanged;
  - prose `fields` → `invalid`;
  - reject → proposal marked `rejected`.
- The probe is what surfaced the JSONB-camelCase bug — the reason the flow is exercised end-to-end and not only through stubs.

Closes #184.
