### PR TITLE
ai: fix worktree provisioning and teardown hooks for both agents

### DIFF
--- a/.claude/hooks/worktree-down.sh
+++ b/.claude/hooks/worktree-down.sh
@@ -25,15 +25,20 @@ fi
 # teardown uses; self-guarding and always exits 0.
 bash "${CLAUDE_PROJECT_DIR:-.}/scripts/worktree-stop-procs.sh" "$wt" "$$" 2>/dev/null || true
 
-# Mirror the CLI's slug: branch name with a leading `worktree-` dropped,
-# lowercased, non-alphanumerics collapsed to `-`, capped at 24 chars. The
-# database swaps `-` for `_` (Postgres identifiers); the bucket keeps `-`.
-branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
-slug="$(printf '%s' "${branch#worktree-}" | tr '[:upper:]' '[:lower:]' \
-	| sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-24)"
-[ -n "$slug" ] || exit 0
-db="batuda_${slug//-/_}"
-bucket="batuda-assets-${slug}"
+# Read this worktree's real database + bucket from the `.env` it generated at
+# provision time — never re-derive them from the live branch. `gh pr merge
+# --delete-branch` checks `main` out into the worktree, and switching branches
+# inside it likewise leaves HEAD pointing away from what `up` created; deriving
+# from the branch then would drop the wrong data — or another worktree's. This
+# mirrors the CLI's `down`/`prune`, which key off `.env` for exactly this reason.
+env_file="$wt/.env"
+[ -f "$env_file" ] || exit 0
+db="$(sed -nE 's#^DATABASE_URL=.*/([^/?[:space:]]+).*#\1#p' "$env_file" | head -1)"
+bucket="$(sed -nE 's#^STORAGE_BUCKET=([^[:space:]]+).*#\1#p' "$env_file" | head -1)"
+# Only a suffixed `batuda_<slug>` / `batuda-assets-<slug>` pair belongs to a
+# worktree; the main checkout's bare `batuda` / `batuda-assets` must never drop.
+case "$db" in batuda_?*) ;; *) exit 0 ;; esac
+case "$bucket" in batuda-assets-?*) ;; *) exit 0 ;; esac
 
 docker exec batuda-db psql -U batuda -d postgres \
 	-c "DROP DATABASE IF EXISTS ${db} WITH (FORCE)" >/dev/null 2>&1 || true

--- a/.claude/hooks/worktree-up.sh
+++ b/.claude/hooks/worktree-up.sh
@@ -14,17 +14,20 @@ common="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" ||
 
 root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 
-# Already provisioned if this worktree's database exists in the shared Postgres.
-# Mirror the CLI's slug (branch, drop a leading `worktree-`, lowercase, non-alnum
-# → `-`, cap 24; the database swaps `-` for `_`). Best-effort: if the stack is down
-# or docker is missing the probe is empty and we (re-)provision below.
-branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
-slug="$(printf '%s' "${branch#worktree-}" | tr '[:upper:]' '[:lower:]' \
-	| sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-24)"
-db="batuda_${slug//-/_}"
-exists="$(docker exec batuda-db psql -U batuda -d postgres -tAc \
-	"SELECT 1 FROM pg_database WHERE datname='$db'" 2>/dev/null | tr -d '[:space:]')"
-[ "$exists" = "1" ] && exit 0
+# Already provisioned if this worktree's `.env` exists and names a database that
+# lives in the shared Postgres. Key off the `.env` `up` wrote, not the live
+# branch: a PR merge or a branch switch moves HEAD away from what was created, so
+# a branch-derived name would miss the real database and re-provision (which
+# re-seeds) on every start. No `.env` yet ⇒ first run ⇒ fall through to provision.
+env_file="$root/.env"
+if [ -f "$env_file" ]; then
+	db="$(sed -nE 's#^DATABASE_URL=.*/([^/?[:space:]]+).*#\1#p' "$env_file" | head -1)"
+	if [ -n "$db" ]; then
+		exists="$(docker exec batuda-db psql -U batuda -d postgres -tAc \
+			"SELECT 1 FROM pg_database WHERE datname='$db'" 2>/dev/null | tr -d '[:space:]')"
+		[ "$exists" = "1" ] && exit 0
+	fi
+fi
 
 cd "$root" || exit 0
 log="$root/.claude/worktree-up.log"

--- a/.opencode/plugins/batuda-guards.js
+++ b/.opencode/plugins/batuda-guards.js
@@ -71,9 +71,19 @@ export const BatudaGuards = async ({ client, $, directory }) => {
 		},
 
 		// Provision a linked worktree's database + bucket on session start.
-		// The script exits 0 in non-worktree contexts and on all error paths.
-		'session.created': async () => {
-			await $`${directory}/.claude/hooks/worktree-up.sh`.quiet().nothrow()
+		// opencode delivers session lifecycle through the generic `event` hook,
+		// not a top-level `session.created` key, so subscribe there. The script
+		// no-ops in the main checkout and on every error path, so running it for
+		// each session is safe and idempotent.
+		//
+		// There is no teardown counterpart: opencode has no worktree-removal event
+		// (its session events are session-scoped, not worktree-scoped), so dropping
+		// a worktree's data from one would race other sessions. Tear a worktree
+		// down with `pnpm cli worktree done` until an upstream lifecycle hook lands.
+		event: async ({ event }) => {
+			if (event.type === 'session.created') {
+				await $`${directory}/.claude/hooks/worktree-up.sh`.quiet().nothrow()
+			}
 		},
 	}
 }


### PR DESCRIPTION
## What

Fixes the git-worktree lifecycle hooks — the ones that auto-provision and tear down each worktree's own Postgres database + MinIO bucket — for both Claude Code and opencode. This is why a merged worktree's database + bucket leaked earlier this session and had to be dropped by hand.

## The fix

- **Resolve the DB/bucket from `.env`, not the git branch.** Both hooks re-derived the name from the live branch (stripping a `worktree-` prefix, cap 24), which never matched how `pnpm cli worktree up` actually names them (the branch's last path segment, no strip). So teardown dropped the wrong name and **leaked the real database + bucket** — and on a name collision could have dropped *another* worktree's database — while the provisioning check always missed and re-seeded on every session start. Both now read the worktree's own `.env`, the same source the CLI's `worktree down`/`prune` trust, guarded so the shared main `batuda` / `batuda-assets` is never dropped.
- **Fire opencode provisioning from the documented `event` hook.** The plugin subscribed to `session.created` as a top-level key, but opencode delivers session lifecycle through the generic `event` handler — provisioning moved there.

## Notes

- **Teardown still has no automatic trigger in either harness** — Claude Code's `WorktreeRemove` hook doesn't fire from `ExitWorktree` in a git repo, and opencode has no worktree-removal event at all (its session events are session-scoped; there's an open upstream feature request for a worktree lifecycle hook). The reliable, agent-agnostic teardown remains **`pnpm cli worktree done`**.

## Verification

- `bash -n` on both hooks, `node --check` on the plugin, Biome clean (only pre-existing unused-parameter warnings, untouched).
- Ran the down-hook's resolution against synthetic `.env`s and the live `comms-spine` worktree's `.env`: it resolves the correct names, guard-blocks the bare main `batuda`, and no-ops when there's no `.env`.

Dev-infra only (no application code) — merging without waiting for CI.
