### PR TITLE
Make setup worktree-aware, sharing .env logic with worktree

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -27,7 +27,8 @@ import { doctor } from './commands/doctor'
 import { emailInject } from './commands/email'
 import { seed, seedIdentities } from './commands/seed'
 import { servicesDown, servicesStatus, servicesUp } from './commands/services'
-import { appendEnvKeys, resetEnvFile, setup } from './commands/setup'
+import type { EnvFileResult } from './commands/setup'
+import { setup } from './commands/setup'
 import {
 	worktreeDoctor,
 	worktreeDone,
@@ -37,6 +38,7 @@ import {
 	worktreeUp,
 } from './commands/worktree'
 import { withDb } from './db'
+import { appendEnvKeys, resetEnvFile } from './lib/env-file'
 import { loadEnv } from './lib/load-env'
 import { recoveryHint } from './lib/recovery-hint'
 
@@ -104,15 +106,24 @@ const seedCommand = Command.make(
 
 // ── Setup ──────────────────────────────────────────────────
 
+// The db/bucket names a worktree-managed result actually carries — only the
+// keys that file receives (e.g. `apps/cli/.env` never gets a bucket).
+const worktreeIdentity = (result: EnvFileResult): string =>
+	[result.worktree?.db, result.worktree?.bucket].filter(Boolean).join(' / ')
+
 const setupCommand = Command.make(
 	'setup',
 	{
 		update: Flag.boolean('update').pipe(
-			Flag.withDescription('Append missing .env keys from .env.example'),
+			Flag.withDescription(
+				'Append missing .env keys from .env.example (no effect on the worktree-managed .env/apps/cli/.env)',
+			),
 			Flag.withDefault(false),
 		),
 		reset: Flag.boolean('reset').pipe(
-			Flag.withDescription('Replace .env files entirely from .env.example'),
+			Flag.withDescription(
+				'Replace .env files entirely from .env.example (no effect on the worktree-managed .env/apps/cli/.env)',
+			),
 			Flag.withDefault(false),
 		),
 	},
@@ -121,6 +132,26 @@ const setupCommand = Command.make(
 			yield* Effect.logInfo('Setting up project...')
 			const results = yield* setup
 			for (const result of results) {
+				// Per-worktree overrides: never templated, never reset from the
+				// example — `--update`/`--reset` don't apply to these two files.
+				if (result.status === 'worktree-synced') {
+					yield* Console.log(
+						`  ${result.target} → ${worktreeIdentity(result)} (this worktree)`,
+					)
+					continue
+				}
+				if (result.status === 'worktree-unprovisioned') {
+					yield* Console.log(
+						`  ${result.target}: ${worktreeIdentity(result)} not provisioned yet → run \`pnpm cli worktree up\``,
+					)
+					continue
+				}
+				if (result.status === 'worktree-error') {
+					yield* Console.log(
+						`  ${result.target}: couldn't sync from this worktree's data — ${result.error}`,
+					)
+					continue
+				}
 				if (result.status === 'skipped') {
 					yield* Console.log(`  skip ${result.target} (no ${result.example})`)
 					continue
@@ -162,7 +193,13 @@ const setupCommand = Command.make(
 		}),
 ).pipe(
 	Command.withShortDescription('Copy .env templates into place'),
-	Command.withDescription('Set up local environment (copy .env files)'),
+	Command.withDescription(
+		'Set up local environment (copy .env files). Inside a linked worktree, ' +
+			'`.env` and `apps/cli/.env` are instead repaired from that worktree’s ' +
+			'own database/bucket if already provisioned, or left alone with a hint ' +
+			'to run `pnpm cli worktree up` — this command never creates a database ' +
+			'or bucket.',
+	),
 )
 
 // ── Doctor ─────────────────────────────────────────────────

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -7,8 +7,10 @@ import type { ChildProcessSpawner } from 'effect/unstable/process'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { SqlLive } from '../db'
+import { parseEnvKeys } from '../lib/env-file'
 import { getTarget } from '../lib/load-env'
 import { execSilent, ROOT } from '../shell'
+import { isLinkedWorktree } from './worktree'
 
 export type Status = 'ok' | 'warn' | 'fail'
 
@@ -30,23 +32,6 @@ interface Check {
 const ok = (detail: string) => ({ status: 'ok' as const, detail })
 const warn = (detail: string) => ({ status: 'warn' as const, detail })
 const fail = (detail: string) => ({ status: 'fail' as const, detail })
-
-// Worktrees only carry tracked files, so gitignored configs (`.env`,
-// `.env.pr-media`, …) live in the main checkout and never get copied in.
-// `worktree up` writes a worktree's own root `.env`, but the rest are absent
-// by design — the hint points there instead of crying "missing".
-const IN_WORKTREE = resolve(ROOT).includes(`${join('.claude', 'worktrees')}`)
-
-const envKeys = (content: string): Set<string> => {
-	const keys = new Set<string>()
-	for (const line of content.split('\n')) {
-		const trimmed = line.trim()
-		if (!trimmed || trimmed.startsWith('#')) continue
-		const eq = trimmed.indexOf('=')
-		if (eq !== -1) keys.add(trimmed.slice(0, eq))
-	}
-	return keys
-}
 
 // Every fillable `.env.example*` at the repo root or one level into
 // `apps/`/`packages/`. `.env.example` (and `apps/<x>/.env.example`) are
@@ -77,7 +62,7 @@ const findEnvExamples = (): string[] => {
 	return results
 }
 
-const envFileCheck = (example: string): Check => {
+const envFileCheck = (example: string, inWorktree: boolean): Check => {
 	// `.env.example` → `.env`; `.env.example.cloud` → `.env.cloud`.
 	const target = example.replace('.example', '')
 	const optional = !example.endsWith('.env.example')
@@ -86,9 +71,12 @@ const envFileCheck = (example: string): Check => {
 		run: Effect.sync(() => {
 			const targetPath = resolve(ROOT, target)
 			if (!existsSync(targetPath)) {
-				// In a worktree only the generated root `.env` is present; the rest
-				// are gitignored and intentionally not copied, so this isn't a fault.
-				if (IN_WORKTREE) {
+				// Worktrees only carry tracked files, so gitignored configs (`.env`,
+				// `.env.pr-media`, …) live in the main checkout and never get copied
+				// in. `worktree up`/`setup` write a worktree's own root `.env`, but
+				// the rest are absent by design — the hint points there instead of
+				// crying "missing".
+				if (inWorktree) {
 					return warn(
 						'lives in the main checkout (gitignored — not copied here)',
 					)
@@ -100,9 +88,9 @@ const envFileCheck = (example: string): Check => {
 				}
 				return fail('missing → run `pnpm cli setup`')
 			}
-			const targetKeys = envKeys(readFileSync(targetPath, 'utf8'))
+			const targetKeys = parseEnvKeys(readFileSync(targetPath, 'utf8'))
 			const missing = [
-				...envKeys(readFileSync(resolve(ROOT, example), 'utf8')),
+				...parseEnvKeys(readFileSync(resolve(ROOT, example), 'utf8')),
 			].filter(key => !targetKeys.has(key))
 			return missing.length > 0
 				? warn(
@@ -363,8 +351,8 @@ const cloudAuthUrlCheck: Check = {
 	}),
 }
 
-const localChecks: Check[] = [
-	...findEnvExamples().map(envFileCheck),
+const localChecks = (inWorktree: boolean): Check[] => [
+	...findEnvExamples().map(example => envFileCheck(example, inWorktree)),
 	emailCredentialKeyCheck,
 	dockerCheck,
 	composeCheck,
@@ -395,7 +383,8 @@ export const doctor = Effect.gen(function* () {
 		status: 'ok',
 		detail: target === 'cloud' ? 'CLOUD ⚠' : 'local',
 	}
-	const checks = target === 'cloud' ? cloudChecks : localChecks
+	const checks =
+		target === 'cloud' ? cloudChecks : localChecks(yield* isLinkedWorktree)
 	const results: CheckResult[] = [targetResult]
 	for (const check of checks) {
 		const result = yield* check.run

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -1,12 +1,23 @@
 import { existsSync, readdirSync, statSync } from 'node:fs'
-import { copyFile, readFile, writeFile } from 'node:fs/promises'
+import { copyFile, readFile } from 'node:fs/promises'
 import { join, relative, resolve } from 'node:path'
 
 import { Effect } from 'effect'
 
-const ROOT = resolve(import.meta.dirname, '../../../..')
+import type { EnvEntry } from '../lib/env-file'
+import { missingEnvEntries, tryFs } from '../lib/env-file'
+import { ROOT } from '../shell'
+import {
+	syncWorktreeEnvIfProvisioned,
+	WORKTREE_ENV_FILES,
+	worktreeContext,
+} from './worktree'
 
 const WORKSPACE_DIRS = ['apps', 'packages'] as const
+
+// The paths from `WORKTREE_ENV_FILES` alone, for the generic loop's skip
+// check below — kept in sync with `writeWorktreeEnv`'s own list by construction.
+const WORKTREE_ENV_TARGETS = new Set(WORKTREE_ENV_FILES.map(f => f.path))
 
 /**
  * Return repo-relative paths to every `.env.example` (exact name) located at
@@ -35,88 +46,80 @@ const findEnvExamples = (): string[] => {
 	return results
 }
 
-// ── .env parsing ──────────────────────────────────────────
-
-export type EnvEntry = {
-	key: string
-	line: string
-	/** Comment lines immediately preceding this key (reset by blank lines). */
-	comments: string[]
-}
-
 export type EnvFileResult = {
 	example: string
 	target: string
-	status: 'created' | 'up-to-date' | 'stale' | 'skipped'
+	status:
+		| 'created'
+		| 'up-to-date'
+		| 'stale'
+		| 'skipped'
+		| 'worktree-synced'
+		| 'worktree-unprovisioned'
+		| 'worktree-error'
 	missing: EnvEntry[]
-}
-
-/** Extract the set of defined keys from a .env file. */
-const parseEnvKeys = (content: string): Set<string> => {
-	const keys = new Set<string>()
-	for (const line of content.split('\n')) {
-		const trimmed = line.trim()
-		if (!trimmed || trimmed.startsWith('#')) continue
-		const eq = trimmed.indexOf('=')
-		if (eq !== -1) keys.add(trimmed.slice(0, eq))
-	}
-	return keys
-}
-
-/** Parse a .env file into entries with preceding comment context. */
-const parseEnvEntries = (content: string): EnvEntry[] => {
-	const entries: EnvEntry[] = []
-	let comments: string[] = []
-
-	for (const raw of content.split('\n')) {
-		const trimmed = raw.trim()
-		if (trimmed === '') {
-			comments = []
-			continue
-		}
-		if (trimmed.startsWith('#')) {
-			comments.push(raw)
-			continue
-		}
-		const eq = trimmed.indexOf('=')
-		if (eq !== -1) {
-			entries.push({
-				key: trimmed.slice(0, eq),
-				line: raw,
-				comments: [...comments],
-			})
-		}
-		comments = []
-	}
-
-	return entries
+	/** Set only for the worktree-* statuses: this worktree's intended database
+	 * and/or bucket — only the keys this specific file actually receives. */
+	worktree?: { db?: string | undefined; bucket?: string | undefined }
+	/** Set only for 'worktree-error': what went wrong repairing this file. */
+	error?: string | undefined
 }
 
 // ── Commands ──────────────────────────────────────────────
 
-export const setup: Effect.Effect<EnvFileResult[]> = Effect.gen(function* () {
+export const setup = Effect.gen(function* () {
 	const results: EnvFileResult[] = []
+	const { isLinked: inWorktree, main } = yield* worktreeContext
+
+	// Read-only context detection: in a worktree, `.env` + `apps/cli/.env` are
+	// repaired from this worktree's own database/bucket (if already provisioned)
+	// instead of synced from the template — never created here. `worktree up`
+	// remains the only path that provisions.
+	if (inWorktree) {
+		const sync = yield* syncWorktreeEnvIfProvisioned(main)
+		for (const file of WORKTREE_ENV_FILES) {
+			results.push({
+				example: `${file.path}.example`,
+				target: file.path,
+				status: sync.error
+					? 'worktree-error'
+					: sync.synced
+						? 'worktree-synced'
+						: 'worktree-unprovisioned',
+				missing: [],
+				worktree: {
+					db: file.keys.includes('DATABASE_URL') ? sync.db : undefined,
+					bucket: file.keys.includes('STORAGE_BUCKET')
+						? sync.bucket
+						: undefined,
+				},
+				error: sync.error,
+			})
+		}
+	}
 
 	for (const example of findEnvExamples()) {
 		const target = example.replace(/\.example$/, '')
+		if (inWorktree && WORKTREE_ENV_TARGETS.has(target)) continue
+
 		const src = resolve(ROOT, example)
 		const dst = resolve(ROOT, target)
 
 		if (!existsSync(dst)) {
-			yield* Effect.promise(() => copyFile(src, dst))
+			yield* tryFs(`create ${target}`, () => copyFile(src, dst))
 			results.push({ example, target, status: 'created', missing: [] })
 			continue
 		}
 
-		const [exampleContent, targetContent] = yield* Effect.all([
-			Effect.promise(() => readFile(src, 'utf-8')),
-			Effect.promise(() => readFile(dst, 'utf-8')),
-		])
-
-		const targetKeys = parseEnvKeys(targetContent)
-		const missing = parseEnvEntries(exampleContent).filter(
-			e => !targetKeys.has(e.key),
+		const { exampleContent, targetContent } = yield* Effect.all(
+			{
+				exampleContent: tryFs(`read ${example}`, () => readFile(src, 'utf-8')),
+				targetContent: tryFs(`read ${target}`, () => readFile(dst, 'utf-8')),
+			},
+			{ concurrency: 'unbounded' },
 		)
+
+		const missing = missingEnvEntries(exampleContent, targetContent)
 
 		results.push({
 			example,
@@ -128,19 +131,3 @@ export const setup: Effect.Effect<EnvFileResult[]> = Effect.gen(function* () {
 
 	return results
 })
-
-/** Append missing entries (with their comments) to an existing .env file. */
-export const appendEnvKeys = (targetRel: string, entries: EnvEntry[]) =>
-	Effect.promise(async () => {
-		const dst = resolve(ROOT, targetRel)
-		const existing = await readFile(dst, 'utf-8')
-		const block = entries.flatMap(e => [...e.comments, e.line]).join('\n')
-		const separator = existing.endsWith('\n') ? '\n' : '\n\n'
-		await writeFile(dst, `${existing}${separator}${block}\n`)
-	})
-
-/** Replace target .env entirely with .env.example content. */
-export const resetEnvFile = (exampleRel: string, targetRel: string) =>
-	Effect.promise(() =>
-		copyFile(resolve(ROOT, exampleRel), resolve(ROOT, targetRel)),
-	)

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path'
 
 import { Console, Effect, Schedule } from 'effect'
 
+import { mergeEnvOverrides, missingEnvEntries, tryFs } from '../lib/env-file'
 import { exec, execIn, execSilent, ROOT } from '../shell'
 import { dbMigrate } from './db'
 
@@ -115,7 +116,10 @@ const mainCheckoutRoot = () =>
 		'--git-common-dir',
 	).pipe(Effect.map(dirname))
 
-export const isLinkedWorktree = Effect.gen(function* () {
+// Whether the current checkout is a linked worktree (vs the main checkout),
+// together with the main checkout's path — computed together so a caller that
+// needs both (provisioning, teardown) doesn't shell out to git twice for it.
+export const worktreeContext = Effect.gen(function* () {
 	const gitDir = yield* execSilent(
 		'git',
 		'rev-parse',
@@ -125,8 +129,13 @@ export const isLinkedWorktree = Effect.gen(function* () {
 	const main = yield* mainCheckoutRoot()
 	// In the main checkout gitDir is `<main>/.git`; in a linked worktree it is
 	// `<main>/.git/worktrees/<name>`, so it sits below the common `.git`.
-	return gitDir !== resolve(main, '.git')
+	const isLinked = gitDir !== resolve(main, '.git')
+	return { isLinked, main }
 })
+
+export const isLinkedWorktree = worktreeContext.pipe(
+	Effect.map(c => c.isLinked),
+)
 
 const workingTreeClean = execSilent('git', 'status', '--porcelain').pipe(
 	Effect.map(out => out.trim() === ''),
@@ -141,7 +150,7 @@ const branchExists = (branch: string) =>
 		`refs/heads/${branch}`,
 	).pipe(
 		Effect.map(() => true),
-		Effect.catch(() => Effect.succeed(false)),
+		Effect.orElseSucceed(() => false),
 	)
 
 const branchName = execSilent('git', 'rev-parse', '--abbrev-ref', 'HEAD')
@@ -150,105 +159,87 @@ const slugForCurrentWorktree = branchName.pipe(Effect.map(slugForBranch))
 
 // Only the worktree's own database and bucket differ from main; the shared
 // endpoints (Postgres host/port, MinIO, GreenMail) are inherited as-is.
-const envOverrides = (slug: string): Record<string, string> => ({
-	DATABASE_URL: `postgresql://batuda:batuda@localhost:5433/${dbName(slug)}`,
-	STORAGE_BUCKET: bucketName(slug),
+const envOverridesForNames = (
+	db: string,
+	bucket: string,
+): Record<string, string> => ({
+	DATABASE_URL: `postgresql://batuda:batuda@localhost:5433/${db}`,
+	STORAGE_BUCKET: bucket,
 })
 
-// Rewrite matching keys in a .env body, appending any that weren't present, so the
-// worktree inherits every other value from the main checkout's file.
-const mergeEnv = (base: string, overrides: Record<string, string>): string => {
-	const remaining = new Set(Object.keys(overrides))
-	const lines = base.split('\n').map(line => {
-		const match = line.match(/^([A-Z0-9_]+)=/)
-		const key = match?.[1]
-		if (key && key in overrides) {
-			remaining.delete(key)
-			return `${key}=${overrides[key]}`
-		}
-		return line
-	})
-	for (const key of remaining) lines.push(`${key}=${overrides[key]}`)
-	return lines.join('\n')
-}
+const envOverrides = (slug: string): Record<string, string> =>
+	envOverridesForNames(dbName(slug), bucketName(slug))
 
-// Read the main checkout's .env (the source of every shared value), apply the
-// worktree overrides, and write the worktree's copy. Both apps/server (root .env)
-// and the CLI (apps/cli/.env) need the DB url, so write both.
-const writeWorktreeEnv = (mainRoot: string, slug: string) =>
+// The files `writeWorktreeEnv` overrides, and which of the two keys each one
+// actually receives — `setup` keys its own worktree-aware handling (which
+// files to repair instead of template-copy, and which values to report for
+// each) off this same list, so the two can't disagree about what's
+// worktree-managed.
+export const WORKTREE_ENV_FILES: ReadonlyArray<{
+	path: string
+	keys: readonly string[]
+}> = [
+	{ path: '.env', keys: ['DATABASE_URL', 'STORAGE_BUCKET'] },
+	{ path: 'apps/cli/.env', keys: ['DATABASE_URL'] },
+]
+
+// Read the main checkout's .env files (the source of every shared value),
+// apply the worktree overrides, and write the worktree's copies. Every source
+// is checked for existence before any target is written, so a missing file
+// can't leave the worktree with one target rewritten and the other untouched.
+const writeWorktreeEnv = (
+	mainRoot: string,
+	overrides: Record<string, string>,
+) =>
 	Effect.gen(function* () {
-		const overrides = envOverrides(slug)
-		const targets: Array<{
-			from: string
-			to: string
-			keys?: readonly string[]
-		}> = [
-			{ from: resolve(mainRoot, '.env'), to: resolve(ROOT, '.env') },
-			{
-				from: resolve(mainRoot, 'apps/cli/.env'),
-				to: resolve(ROOT, 'apps/cli/.env'),
-				keys: ['DATABASE_URL'],
-			},
-		]
+		const targets = WORKTREE_ENV_FILES.map(f => ({
+			from: resolve(mainRoot, f.path),
+			to: resolve(ROOT, f.path),
+			keys: f.keys,
+		}))
+
+		const missing = targets.filter(t => !existsSync(t.from))
+		if (missing.length > 0) {
+			return yield* Effect.fail(
+				new Error(
+					`No ${missing.map(t => t.from).join(', ')} in the main checkout — run \`pnpm cli setup\` there first.`,
+				),
+			)
+		}
+
 		for (const t of targets) {
-			if (!existsSync(t.from)) {
-				return yield* Effect.fail(
-					new Error(
-						`No ${t.from} in the main checkout — run \`pnpm cli setup\` there first.`,
-					),
-				)
-			}
 			const base = readFileSync(t.from, 'utf-8')
-			const subset = t.keys
-				? Object.fromEntries(
-						t.keys.flatMap(k => {
-							const v = overrides[k]
-							return v === undefined ? [] : [[k, v] as const]
-						}),
-					)
-				: overrides
-			yield* Effect.promise(() => writeFile(t.to, mergeEnv(base, subset)))
+			const subset = Object.fromEntries(
+				t.keys.flatMap(k => {
+					const v = overrides[k]
+					return v === undefined ? [] : [[k, v] as const]
+				}),
+			)
+			yield* tryFs(`write ${t.to}`, () =>
+				writeFile(t.to, mergeEnvOverrides(base, subset)),
+			)
 		}
 	})
 
-// Active `KEY=` assignments in a .env body, ignoring comments (`# KEY=`) and
-// blanks. Mirrors mergeEnv's key regex so the two agree on what a "key" is.
-const envKeys = (body: string): Set<string> => {
-	const keys = new Set<string>()
-	for (const line of body.split('\n')) {
-		const key = line.match(/^([A-Z0-9_]+)=/)?.[1]
-		if (key) keys.add(key)
-	}
-	return keys
-}
-
-// Keys the committed .env.example declares but the local .env lacks. A worktree
-// inherits its .env from the main checkout, so a key added to the template but
-// not to that .env is missing here too — and the server reads it at boot and dies
-// with a cryptic ConfigError. Surfacing the names turns that into a fixable hint.
-const missingEnvKeys = (exampleBody: string, currentBody: string): string[] => {
-	const present = envKeys(currentBody)
-	return [...envKeys(exampleBody)].filter(key => !present.has(key))
-}
-
-// The current worktree's missing keys, or [] when either file is absent (nothing
-// to compare against).
+// Key names the committed .env.example declares but the local .env lacks. A
+// worktree inherits its .env from the main checkout, so a key added to the
+// template but not to that .env is missing here too — and the server reads it
+// at boot and dies with a cryptic ConfigError. Surfacing the names turns that
+// into a fixable hint.
 const missingWorktreeEnvKeys = (): string[] => {
 	const examplePath = resolve(ROOT, '.env.example')
 	const envPath = resolve(ROOT, '.env')
 	if (!existsSync(examplePath) || !existsSync(envPath)) return []
-	return missingEnvKeys(
+	return missingEnvEntries(
 		readFileSync(examplePath, 'utf-8'),
 		readFileSync(envPath, 'utf-8'),
-	)
+	).map(e => e.key)
 }
 
 const dockerFail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
 	self.pipe(
-		Effect.catch(() =>
-			Effect.fail(
-				new Error('Docker command failed. Is Docker/OrbStack running?'),
-			),
+		Effect.mapError(
+			() => new Error('Docker command failed. Is Docker/OrbStack running?'),
 		),
 	)
 
@@ -267,10 +258,20 @@ const ensureSharedStack = dockerFail(
 // goes through the shared db container's `postgres` maintenance database. These
 // take the resolved database NAME (not a slug): `up` derives it from the branch
 // slug, while `down`/`prune` read it from the worktree's `.env`.
+//
+// Falls back to `false` on any docker/connection error — same reasoning as
+// `stackReachable`/`bucketExists` below: a transient failure here must not
+// crash a caller that's only trying to decide whether a worktree is
+// provisioned yet. `createDatabase`'s own `CREATE DATABASE` call still fails
+// (and so still gets retried by its caller's `settle`) if the container
+// genuinely isn't ready, so this fallback doesn't mask that case.
 const databaseExists = (db: string) =>
 	execSilent(
 		`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${db}'"`,
-	).pipe(Effect.map(out => out.trim() === '1'))
+	).pipe(
+		Effect.map(out => out.trim() === '1'),
+		Effect.orElseSucceed(() => false),
+	)
 
 const createDatabase = (db: string) =>
 	Effect.gen(function* () {
@@ -355,6 +356,16 @@ const listBuckets = mcCapture('mc ls local --json').pipe(
 	),
 )
 
+// Unlike `databaseExists`, MinIO is a separate service from the Postgres
+// `stackReachable` probes — falls back to `false` on any docker/mc error so a
+// bucket check can never itself crash a caller that's only trying to decide
+// whether this worktree is provisioned yet.
+const bucketExists = (bucket: string) =>
+	listBuckets.pipe(
+		Effect.map(names => names.includes(bucket)),
+		Effect.orElseSucceed(() => false),
+	)
+
 // Existing suffixed resources that no live worktree owns. The bare `batuda` /
 // `batuda-assets` (the main checkout) don't carry the `_`/`-` suffix the prefix
 // requires, so they can never be selected.
@@ -371,8 +382,100 @@ const stackReachable = execSilent(
 	`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d postgres -tAc "SELECT 1"`,
 ).pipe(
 	Effect.map(out => out.trim() === '1'),
-	Effect.catch(() => Effect.succeed(false)),
+	Effect.orElseSucceed(() => false),
 )
+
+export type WorktreeEnvSync = {
+	synced: boolean
+	db: string
+	bucket: string
+	/** Set only when provisioned but the repair write itself failed. */
+	error?: string
+}
+
+// A couple of short retries while the stack answers "not ready" instead of
+// erroring outright — long enough to ride out a stack someone else (another
+// worktree's session-start hook, a concurrent `services up`) started moments
+// ago, short enough that `setup` still stays fast when the stack is genuinely
+// down. `worktreeDoctor` calls the un-retried `stackReachable` directly since
+// it should fail fast, not wait, when reporting the stack as down.
+//
+// `Effect.repeat({while, times, schedule})` looks like the purpose-built tool
+// for "retry while this boolean is false," but its result is the *schedule's*
+// output (an attempt count), not the wrapped effect's last value — confirmed
+// empirically, not just from the docs. Converting the falsy result to a
+// failure first (so plain `Effect.retry` retries it) keeps the original
+// boolean as the actual success value.
+const stackReachableSettled = stackReachable.pipe(
+	Effect.flatMap(ok =>
+		ok ? Effect.succeed(true) : Effect.fail(new Error('not ready')),
+	),
+	Effect.retry(Schedule.spaced('1 second').pipe(Schedule.take(2))),
+	Effect.orElseSucceed(() => false),
+)
+
+// For `setup`, called only from inside a linked worktree: if this worktree's
+// database + bucket already exist and are migrated, (re)write its `.env` +
+// `apps/cli/.env` from the main checkout's real `.env` (at `main`) — the same
+// thing `up` does, minus provisioning. Reports `synced: false` (and writes
+// nothing) when the resources aren't ready yet, so `setup` can point the
+// caller at `worktree up` instead of producing a `.env` that names data
+// nothing created.
+//
+// Identity comes from the worktree's own `.env` when it already names a real,
+// existing database/bucket — re-deriving from the current branch would target
+// the wrong data once a merge swaps the branch to `main` before teardown runs
+// (the same reasoning `identityFromEnv`'s other callers already follow). Only
+// when `.env` can't name an identity at all (missing, or a blank
+// `DATABASE_URL` — the exact corruption this command exists to repair) does
+// it fall back to the branch-derived name.
+export const syncWorktreeEnvIfProvisioned = (main: string) =>
+	Effect.gen(function* () {
+		const recorded = identityFromEnv(resolve(ROOT, '.env'))
+		const fallbackSlug = yield* slugForCurrentWorktree
+		const db = recorded?.db ?? dbName(fallbackSlug)
+		const bucket = recorded?.bucket ?? bucketName(fallbackSlug)
+
+		// Postgres and MinIO are independent services, so check both at once
+		// once the stack itself answers — no point paying for either
+		// individually if the stack isn't even up.
+		const stackOk = yield* stackReachableSettled
+		const [dbExists, bucketOk] = stackOk
+			? yield* Effect.all([databaseExists(db), bucketExists(bucket)], {
+					concurrency: 'unbounded',
+				})
+			: [false, false]
+		const migrated = dbExists && (yield* tableCount(db)) > 0
+		const provisioned = stackOk && dbExists && bucketOk && migrated
+
+		if (!provisioned) {
+			const result: WorktreeEnvSync = { synced: false, db, bucket }
+			return result
+		}
+
+		const overrides = envOverridesForNames(db, bucket)
+		const write: WorktreeEnvSync = yield* writeWorktreeEnv(
+			main,
+			overrides,
+		).pipe(
+			Effect.map(() => ({ synced: true as const, db, bucket })),
+			Effect.catch(error =>
+				Effect.succeed({
+					synced: false as const,
+					db,
+					bucket,
+					error: error.message,
+				}),
+			),
+		)
+		// Make the just-written values visible to this process + every
+		// subprocess it spawns, so a follow-up command in the same process (the
+		// TUI) targets this worktree's database, not a stale one from startup.
+		if (write.synced) {
+			for (const [k, v] of Object.entries(overrides)) process.env[k] = v
+		}
+		return write
+	})
 
 // How many public tables a database has — 0 means it exists but isn't migrated.
 const tableCount = (db: string) =>
@@ -380,7 +483,7 @@ const tableCount = (db: string) =>
 		`docker exec ${DB_CONTAINER} psql -U ${PG_USER} -d ${db} -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE'"`,
 	).pipe(
 		Effect.map(out => Number(out.trim()) || 0),
-		Effect.catch(() => Effect.succeed(0)),
+		Effect.orElseSucceed(() => 0),
 	)
 
 // Parse `git worktree list --porcelain` into one entry per worktree; `branch` is
@@ -409,14 +512,14 @@ const parseWorktrees = (
 }
 
 export const worktreeUp = Effect.gen(function* () {
-	if (!(yield* isLinkedWorktree)) {
+	const { isLinked, main } = yield* worktreeContext
+	if (!isLinked) {
 		return yield* Effect.fail(
 			new Error(
 				'Not in a worktree. Use `pnpm cli services up` for the main checkout’s shared stack.',
 			),
 		)
 	}
-	const main = yield* mainCheckoutRoot()
 	const slug = yield* slugForCurrentWorktree
 
 	yield* Effect.logInfo('Ensuring the shared stack is up…')
@@ -428,10 +531,11 @@ export const worktreeUp = Effect.gen(function* () {
 	yield* settle(createDatabase(dbName(slug)))
 	yield* settle(mc(`mc mb --ignore-existing local/${bucketName(slug)}`))
 
-	yield* writeWorktreeEnv(main, slug)
+	const overrides = envOverrides(slug)
+	yield* writeWorktreeEnv(main, overrides)
 	// Make the just-written values visible to this process + every subprocess
 	// (migrate/seed) it spawns, so they target this worktree's database, not main's.
-	for (const [k, v] of Object.entries(envOverrides(slug))) process.env[k] = v
+	for (const [k, v] of Object.entries(overrides)) process.env[k] = v
 
 	// Catch a stale inherited .env now, with the key names, instead of leaving
 	// the server to die at boot with a bare "Expected string, got undefined".
@@ -529,8 +633,7 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 			}
 		}
 
-		const linked = yield* isLinkedWorktree
-		const mainRoot = yield* mainCheckoutRoot()
+		const { isLinked: linked, main: mainRoot } = yield* worktreeContext
 
 		if (linked) {
 			const branch = yield* branchName
@@ -607,10 +710,19 @@ const pruneOrphanDevServers = exec('pnpm exec portless prune').pipe(
 // mistaken for an orphan. Orphaned dev servers are reaped on `--yes` too.
 export const worktreePrune = (apply: boolean) =>
 	Effect.gen(function* () {
-		const owned = yield* liveOwnedResources
-		const orphanDbs = findOrphans(yield* listDatabases, owned.dbs, 'batuda_')
+		// Three independent reads (git+fs, docker, mc) — no reason to pay for
+		// them one after another.
+		const { owned, databases, bucketList } = yield* Effect.all(
+			{
+				owned: liveOwnedResources,
+				databases: listDatabases,
+				bucketList: listBuckets,
+			},
+			{ concurrency: 'unbounded' },
+		)
+		const orphanDbs = findOrphans(databases, owned.dbs, 'batuda_')
 		const orphanBuckets = findOrphans(
-			yield* listBuckets,
+			bucketList,
 			owned.buckets,
 			'batuda-assets-',
 		)
@@ -650,10 +762,19 @@ export const worktreePrune = (apply: boolean) =>
 	})
 
 export const worktreeLs = Effect.gen(function* () {
-	const porcelain = yield* execSilent('git', 'worktree', 'list', '--porcelain')
-	const main = yield* mainCheckoutRoot()
-	const dbs = new Set(yield* listDatabases)
-	const buckets = new Set(yield* listBuckets)
+	// Four independent reads (git metadata, docker, docker, mc) — no reason to
+	// pay for them one after another.
+	const { porcelain, main, databases, bucketList } = yield* Effect.all(
+		{
+			porcelain: execSilent('git', 'worktree', 'list', '--porcelain'),
+			main: mainCheckoutRoot(),
+			databases: listDatabases,
+			bucketList: listBuckets,
+		},
+		{ concurrency: 'unbounded' },
+	)
+	const dbs = new Set(databases)
+	const buckets = new Set(bucketList)
 
 	const rows = parseWorktrees(porcelain).map(e => {
 		// The main checkout owns the unsuffixed `batuda` database/bucket; every
@@ -723,7 +844,13 @@ export const worktreeDoctor = Effect.gen(function* () {
 			})
 		} else {
 			const { db, bucket } = identity
-			const dbOk = stackOk ? yield* databaseExists(db) : false
+			// Independent services, checked at once — the display order below
+			// (database, migrations, bucket) is unaffected either way.
+			const [dbOk, bucketOk] = stackOk
+				? yield* Effect.all([databaseExists(db), bucketExists(bucket)], {
+						concurrency: 'unbounded',
+					})
+				: [false, false]
 			checks.push({
 				ok: dbOk,
 				name: 'database',
@@ -738,8 +865,6 @@ export const worktreeDoctor = Effect.gen(function* () {
 					tables > 0 ? `${tables} tables` : 'none — run `pnpm cli worktree up`',
 			})
 
-			let bucketOk = false
-			if (stackOk) bucketOk = new Set(yield* listBuckets).has(bucket)
 			checks.push({
 				ok: bucketOk,
 				name: 'bucket',

--- a/apps/cli/src/lib/env-file.ts
+++ b/apps/cli/src/lib/env-file.ts
@@ -1,0 +1,118 @@
+import { copyFile, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { Effect } from 'effect'
+
+import { ROOT } from '../shell'
+
+// Shared .env parsing/merging/writing helpers. `setup` (template sync) and
+// `worktree` (per-worktree override) both call these instead of keeping their
+// own copies, so the two commands can't drift into writing a `.env` neither
+// one intends.
+
+export type EnvEntry = {
+	key: string
+	line: string
+	/** Comment lines immediately preceding this key (reset by blank lines). */
+	comments: string[]
+}
+
+/** Every declared key in a .env file's body (comments and blank lines ignored). */
+export const parseEnvKeys = (body: string): Set<string> => {
+	const keys = new Set<string>()
+	for (const line of body.split('\n')) {
+		const trimmed = line.trim()
+		if (!trimmed || trimmed.startsWith('#')) continue
+		const eq = trimmed.indexOf('=')
+		if (eq !== -1) keys.add(trimmed.slice(0, eq))
+	}
+	return keys
+}
+
+/** Parse a .env file into entries, each with the comment lines immediately above it. */
+export const parseEnvEntries = (body: string): EnvEntry[] => {
+	const entries: EnvEntry[] = []
+	let comments: string[] = []
+
+	for (const raw of body.split('\n')) {
+		const trimmed = raw.trim()
+		if (trimmed === '') {
+			comments = []
+			continue
+		}
+		if (trimmed.startsWith('#')) {
+			comments.push(raw)
+			continue
+		}
+		const eq = trimmed.indexOf('=')
+		if (eq !== -1) {
+			entries.push({
+				key: trimmed.slice(0, eq),
+				line: raw,
+				comments: [...comments],
+			})
+		}
+		comments = []
+	}
+
+	return entries
+}
+
+/** Entries `exampleBody` declares that `currentBody` doesn't have — e.g. a
+ * `.env.example` key never copied into the real `.env`. */
+export const missingEnvEntries = (
+	exampleBody: string,
+	currentBody: string,
+): EnvEntry[] => {
+	const present = parseEnvKeys(currentBody)
+	return parseEnvEntries(exampleBody).filter(e => !present.has(e.key))
+}
+
+/** Rewrite matching keys in a .env body, appending any that weren't present, so
+ * every other line is preserved as-is. Used to layer per-worktree overrides
+ * (`DATABASE_URL`, `STORAGE_BUCKET`) onto a copy of another `.env`'s content. */
+export const mergeEnvOverrides = (
+	base: string,
+	overrides: Record<string, string>,
+): string => {
+	const remaining = new Set(Object.keys(overrides))
+	const lines = base.split('\n').map(line => {
+		const match = line.match(/^([A-Z0-9_]+)=/)
+		const key = match?.[1]
+		if (key && key in overrides) {
+			remaining.delete(key)
+			return `${key}=${overrides[key]}`
+		}
+		return line
+	})
+	for (const key of remaining) lines.push(`${key}=${overrides[key]}`)
+	return lines.join('\n')
+}
+
+/** Run a fallible fs promise as a proper Effect failure, not a defect —
+ * `Effect.promise` is for promises that never reject, but Node's fs calls
+ * reject on ENOENT/EACCES/etc, so wrapping them there would turn an ordinary,
+ * reportable error into an unrecoverable defect instead. */
+export const tryFs = <A>(context: string, fn: () => Promise<A>) =>
+	Effect.tryPromise({
+		try: fn,
+		catch: error => new Error(`${context}: ${String(error)}`),
+	})
+
+/** Append missing entries (with their comments) to an existing .env file.
+ * `targetRel` is repo-relative, matching `findEnvExamples`'s output. */
+export const appendEnvKeys = (targetRel: string, entries: EnvEntry[]) =>
+	tryFs(`append keys to ${targetRel}`, async () => {
+		const dst = resolve(ROOT, targetRel)
+		const existing = await readFile(dst, 'utf-8')
+		const block = entries.flatMap(e => [...e.comments, e.line]).join('\n')
+		const separator = existing.endsWith('\n') ? '\n' : '\n\n'
+		await writeFile(dst, `${existing}${separator}${block}\n`)
+	})
+
+/** Replace target .env entirely with .env.example content. Both paths are
+ * repo-relative, matching `findEnvExamples`'s output. */
+export const resetEnvFile = (exampleRel: string, targetRel: string) =>
+	tryFs(`reset ${targetRel} from ${exampleRel}`, () =>
+		copyFile(resolve(ROOT, exampleRel), resolve(ROOT, targetRel)),
+	)


### PR DESCRIPTION
## Summary
- Extracts `.env` parsing/merging/writing into a shared module (`apps/cli/src/lib/env-file.ts`) so `setup` and `worktree` can't drift into writing a `.env` neither command intends.
- Makes `setup` detect when it's running inside a linked git worktree: it repairs that worktree's `.env` from its own already-provisioned database/bucket instead of copying the template — and never creates a database or bucket itself.
- Reads a worktree's identity from its recorded `.env` rather than the current branch, so a post-merge branch swap can't make `setup` orphan a duplicate database.
- Makes the repair write atomic across both worktree-managed files, and reuses the same database/bucket existence checks between `setup` and `worktree doctor` so their diagnoses agree.

Closes #187.

## Test plan
- [x] `pnpm --filter @batuda/cli check-types` / `biome check` / `build` all clean
- [x] Blank `DATABASE_URL` in a worktree's `apps/cli/.env` self-heals via `pnpm cli setup`
- [x] Fresh, never-provisioned worktree: `setup` creates no database/bucket, prints a `worktree up` hint
- [x] Plain branch / main checkout: `setup` still only copies templates (verified via an independent clone)
- [x] Post-merge branch swap: `setup` keeps pointing at the worktree's real, still-provisioned database instead of deriving a new (nonexistent) one from the new branch name
- [x] Main checkout missing a file `setup` needs: reports a clear per-file error, no partial write
- [x] Interrupted provisioning (database exists, zero tables): reported as not-yet-provisioned, not synced
- [x] `worktree doctor`, `worktree ls`, `worktree prune`, `pnpm cli doctor` all still pass