### PR TITLE
fix(research): fix web_search 422 and cached-response crash (research runs 0/3)

### DIFF
--- a/packages/research/src/domain/country.test.ts
+++ b/packages/research/src/domain/country.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	AcceptedCountry,
 	isRegistryCountry,
+	parseCountryAlpha2,
 	REGISTRY_COUNTRIES,
 } from './country'
 
@@ -74,6 +75,59 @@ describe('isRegistryCountry', () => {
 			// WHEN a lowercase registry code is checked
 			// THEN it is not recognized
 			expect(isRegistryCountry('es')).toBe(false)
+		})
+	})
+})
+
+describe('parseCountryAlpha2', () => {
+	describe('when the hint is already a two-letter code', () => {
+		it('should upper-case it', () => {
+			// GIVEN a bare alpha-2 in either case
+			// WHEN it is parsed
+			// THEN it is normalized to upper-case (adapters re-case per API)
+			expect(parseCountryAlpha2('US')).toBe('US')
+			expect(parseCountryAlpha2('us')).toBe('US')
+			expect(parseCountryAlpha2('es')).toBe('ES')
+		})
+
+		it('should ignore surrounding whitespace', () => {
+			// GIVEN a code padded with spaces
+			// WHEN it is parsed
+			// THEN the code is trimmed and upper-cased
+			expect(parseCountryAlpha2('  gb ')).toBe('GB')
+		})
+
+		it('should accept any two letters without an ISO lookup', () => {
+			// GIVEN a two-letter token that is not a real country (e.g. a language)
+			// WHEN it is parsed
+			// THEN it still passes through, matching AcceptedCountry's shape-only
+			// rule — we deliberately ship no country table (the model sends valid
+			// hints), so this is a known, documented limitation
+			expect(parseCountryAlpha2('en')).toBe('EN')
+		})
+	})
+
+	describe('when the hint is a language-and-region locale', () => {
+		it('should keep only the region subtag', () => {
+			// GIVEN a locale the model commonly sends (the exact 422 trigger)
+			// WHEN it is parsed
+			// THEN just the region is kept, upper-cased — never the whole locale
+			expect(parseCountryAlpha2('en-US')).toBe('US')
+			expect(parseCountryAlpha2('es-ES')).toBe('ES')
+			expect(parseCountryAlpha2('es_ES')).toBe('ES')
+		})
+	})
+
+	describe('when the hint is not a recognizable country', () => {
+		it('should drop it so no invalid country reaches the search API', () => {
+			// GIVEN a full name, a language-only tag, junk, empty, or missing input
+			// WHEN each is parsed
+			// THEN nothing is returned and the caller omits the country param
+			expect(parseCountryAlpha2('United States')).toBeUndefined()
+			expect(parseCountryAlpha2('USA')).toBeUndefined()
+			expect(parseCountryAlpha2('123')).toBeUndefined()
+			expect(parseCountryAlpha2('')).toBeUndefined()
+			expect(parseCountryAlpha2(undefined)).toBeUndefined()
 		})
 	})
 })

--- a/packages/research/src/domain/country.ts
+++ b/packages/research/src/domain/country.ts
@@ -20,6 +20,21 @@ export const AcceptedCountry = Schema.String.check(
 )
 export type AcceptedCountry = Schema.Schema.Type<typeof AcceptedCountry>
 
+// Turn a model-supplied place hint into a two-letter country code (upper-case),
+// or nothing when it isn't clearly a country. Handles a bare code ("US"/"us")
+// or a language-and-region hint ("en-US"/"es_ES") by keeping just the region.
+// Anything else (a full country name, junk) is dropped, because sending an
+// unrecognized country to the search API is rejected outright and fails the run.
+export const parseCountryAlpha2 = (
+	raw: string | undefined,
+): string | undefined => {
+	if (raw == null) return undefined
+	const trimmed = raw.trim()
+	if (/^[A-Za-z]{2}$/.test(trimmed)) return trimmed.toUpperCase()
+	const region = /^[A-Za-z]{2,3}[-_]([A-Za-z]{2})$/.exec(trimmed)?.[1]
+	return region ? region.toUpperCase() : undefined
+}
+
 export const REGISTRY_VENDORS_BY_COUNTRY = {
 	ES: ['stub', 'librebor', 'none'] as const,
 	GB: ['stub', 'companies-house', 'none'] as const,

--- a/packages/research/src/infrastructure/brave/search.test.ts
+++ b/packages/research/src/infrastructure/brave/search.test.ts
@@ -81,6 +81,7 @@ interface SearchArgs {
 	readonly query: string
 	readonly recency?: { days: number }
 	readonly languages?: string[]
+	readonly location?: string
 }
 
 const runSearch = (
@@ -158,6 +159,34 @@ describe('makeBraveSearch', () => {
 		expect(has('extra_snippets', 'true')).toBe(true)
 		expect(has('freshness', 'pw')).toBe(true)
 		expect(has('search_lang', 'es')).toBe(true)
+	})
+
+	it('should send a normalized upper-case country for a locale hint', async () => {
+		// GIVEN the model passes a language-and-region locale as the location
+		const { exit, log } = runSearch(
+			200,
+			{ web: { results: [] } },
+			{ query: 'acme', location: 'en-US' },
+		)
+		await exit
+
+		// THEN Brave receives a valid upper-case alpha-2, not the raw locale
+		const params = [...(log.last?.urlParams ?? [])]
+		expect(params.some(([k, v]) => k === 'country' && v === 'US')).toBe(true)
+	})
+
+	it('should omit country when the location hint is not a country', async () => {
+		// GIVEN a free-form place name Brave would reject
+		const { exit, log } = runSearch(
+			200,
+			{ web: { results: [] } },
+			{ query: 'acme', location: 'United States' },
+		)
+		await exit
+
+		// THEN no country param is sent rather than an invalid one
+		const params = [...(log.last?.urlParams ?? [])]
+		expect(params.some(([k]) => k === 'country')).toBe(false)
 	})
 
 	it('should surface an HTTP error instead of masking it as an empty result', async () => {

--- a/packages/research/src/infrastructure/brave/search.ts
+++ b/packages/research/src/infrastructure/brave/search.ts
@@ -12,6 +12,7 @@ import { Config, Effect, Layer, Redacted, Schema } from 'effect'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
 import { type SearchInput, SearchProvider } from '../../application/ports'
+import { parseCountryAlpha2 } from '../../domain/country'
 import { ProviderError } from '../../domain/errors'
 import { SearchResult, SearchResultItem } from '../../domain/types'
 import { keyForSlot } from '../_config'
@@ -59,6 +60,9 @@ export const makeBraveSearch = (slot: number) =>
 			search: (input: SearchInput) =>
 				harden(
 					Effect.gen(function* () {
+						// Brave's `country` wants an upper-case two-letter code; a raw model
+						// hint like "en-US" is invalid, so normalize it or leave it out.
+						const country = parseCountryAlpha2(input.location)
 						const response = yield* client
 							.get('https://api.search.brave.com/res/v1/web/search', {
 								headers: {
@@ -74,7 +78,7 @@ export const makeBraveSearch = (slot: number) =>
 									...(input.recency
 										? { freshness: freshnessForRecency(input.recency.days) }
 										: {}),
-									...(input.location ? { country: input.location } : {}),
+									...(country ? { country } : {}),
 									...(input.languages?.[0]
 										? { search_lang: input.languages[0] }
 										: {}),

--- a/packages/research/src/infrastructure/cached-llm.test.ts
+++ b/packages/research/src/infrastructure/cached-llm.test.ts
@@ -1,8 +1,10 @@
+import { LanguageModel } from 'effect/unstable/ai'
 import { describe, expect, it } from 'vitest'
 
 import {
 	computeLlmCacheKey,
 	isLlmCacheable,
+	rehydrateCachedResponse,
 	stableStringifyForCache,
 } from './cached-llm'
 
@@ -101,6 +103,90 @@ describe('stableStringifyForCache', () => {
 
 		// THEN the function is omitted — two calls with different closures hash the same
 		expect(serialized).toBe('{"prompt":"x"}')
+	})
+})
+
+describe('rehydrateCachedResponse', () => {
+	// text, toolCalls, toolResults, and usage are all getters derived from
+	// `content`; the cache stores only `content` as JSON, so a Pg hit returns a
+	// bare object where those getters read undefined — the reflect loop then
+	// crashes iterating `response.toolResults`.
+	const content = [
+		{ type: 'text', text: 'Acme is a logistics company.' },
+		{
+			type: 'tool-call',
+			id: 'call_1',
+			name: 'scrape_page',
+			params: { url: 'https://acme.example' },
+		},
+		{
+			type: 'tool-result',
+			id: 'call_1',
+			name: 'scrape_page',
+			result: { url: 'https://acme.example', markdown: '# Acme' },
+			encodedResult: undefined,
+		},
+		{
+			type: 'finish',
+			reason: 'stop',
+			usage: {
+				inputTokens: {
+					uncached: undefined,
+					total: 12,
+					cacheRead: undefined,
+					cacheWrite: undefined,
+				},
+				outputTokens: { total: 7, text: undefined, reasoning: undefined },
+			},
+		},
+	] as ConstructorParameters<typeof LanguageModel.GenerateTextResponse>[0]
+
+	describe('when a text response is replayed from the JSON cache', () => {
+		it('should restore the getters a fresh generation would expose', () => {
+			// GIVEN a real text response serialized to the cache and read back (Pg hit)
+			const original = new LanguageModel.GenerateTextResponse(content)
+			const stored = JSON.parse(JSON.stringify(original)) as unknown
+
+			// THEN the bare JSON has lost its getters — the exact crash the loop hit
+			expect((stored as { toolResults?: unknown }).toolResults).toBeUndefined()
+
+			// WHEN it is rehydrated
+			const replayed = rehydrateCachedResponse(
+				'text',
+				stored,
+			) as typeof original
+
+			// THEN every getter behaves exactly like the fresh response
+			expect(replayed.toolResults.length).toBe(1)
+			expect((replayed.toolResults[0] as { name: string }).name).toBe(
+				'scrape_page',
+			)
+			expect(replayed.text).toBe(original.text)
+			expect(replayed.toolCalls.length).toBe(1)
+			expect(replayed.usage.inputTokens.total).toBe(12)
+		})
+	})
+
+	describe('when an object response is replayed', () => {
+		it('should restore the parsed value alongside the getters', () => {
+			// GIVEN a structured (object) response round-tripped through the cache
+			const original = new LanguageModel.GenerateObjectResponse(
+				{ company: 'Acme' },
+				content,
+			)
+			const stored = JSON.parse(JSON.stringify(original)) as unknown
+
+			// WHEN it is rehydrated as an object result
+			const replayed = rehydrateCachedResponse(
+				'object',
+				stored,
+			) as typeof original
+
+			// THEN both the parsed value and the derived getters come back
+			expect(replayed.value).toEqual({ company: 'Acme' })
+			expect(replayed.toolResults.length).toBe(1)
+			expect(replayed.text).toBe(original.text)
+		})
 	})
 })
 

--- a/packages/research/src/infrastructure/cached-llm.ts
+++ b/packages/research/src/infrastructure/cached-llm.ts
@@ -20,7 +20,7 @@
 import { createHash } from 'node:crypto'
 
 import { Cache, Duration, Effect, Option } from 'effect'
-import type { LanguageModel } from 'effect/unstable/ai'
+import { LanguageModel } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
 export type LlmTier = 'agent' | 'extract' | 'writer'
@@ -59,6 +59,24 @@ export const isLlmCacheable = (options: unknown): boolean => {
 	const temperature = o['temperature']
 	if (typeof temperature === 'number' && temperature > 0) return false
 	return true
+}
+
+// A cached response is stored as plain JSON of its parts, which loses the
+// helpers that read back its text, tool calls, and tool results. Rebuild the
+// proper response object from those parts so a cache hit behaves exactly like a
+// fresh answer — otherwise the research loop reads nothing back for its tool
+// results and crashes the whole run.
+export const rehydrateCachedResponse = (
+	method: 'text' | 'object',
+	raw: unknown,
+): unknown => {
+	const row = (raw ?? {}) as { content?: unknown; value?: unknown }
+	const content = (
+		Array.isArray(row.content) ? row.content : []
+	) as ConstructorParameters<typeof LanguageModel.GenerateTextResponse>[0]
+	return method === 'object'
+		? new LanguageModel.GenerateObjectResponse(row.value, content)
+		: new LanguageModel.GenerateTextResponse(content)
 }
 
 const promptPreview = (options: unknown): string => {
@@ -186,11 +204,15 @@ export const makeCachedLanguageModel = (
 				const hit = hits[0]
 				if (hit) {
 					yield* bumpHitCount(keyHash)
-					yield* Cache.set(memCache, keyHash, hit.response)
+					// Storing JSON dropped the response class, so rebuild it before
+					// use and keep the rebuilt one in memory — the mem-hit path above
+					// then always hands back a usable response, never bare JSON.
+					const response = rehydrateCachedResponse(method, hit.response)
+					yield* Cache.set(memCache, keyHash, response)
 					yield* Effect.logDebug('cache.hit').pipe(
 						Effect.annotateLogs({ ...baseAttrs, layer: 'pg' }),
 					)
-					return hit.response as A
+					return response as A
 				}
 
 				const response = yield* call

--- a/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
+++ b/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
@@ -19,6 +19,7 @@ import {
 } from 'effect/unstable/http'
 import { describe, expect, it } from 'vitest'
 
+import type { SearchInput } from '../../application/ports'
 import { ProviderError } from '../../domain/errors'
 import { makeFirecrawlExtract } from './extract'
 import { makeFirecrawlScrape } from './scrape'
@@ -90,6 +91,19 @@ const runWithVirtualClock = async <A, E>(
 	)
 }
 
+// Decode the JSON body an adapter POSTed, so tests can assert the exact params
+// (e.g. the normalized `country`) sent to the provider.
+const bodyJson = (
+	request: HttpClientRequest.HttpClientRequest | undefined,
+): Record<string, unknown> => {
+	const body = request?.body
+	if (body?._tag !== 'Uint8Array') return {}
+	return JSON.parse(new TextDecoder().decode(body.body)) as Record<
+		string,
+		unknown
+	>
+}
+
 const errorOf = (
 	exit: Exit.Exit<unknown, unknown>,
 ): ProviderError | undefined => {
@@ -148,13 +162,17 @@ const runExtract = (
 	return { exit, log }
 }
 
-const runSearch = (status: number, body: unknown, query = 'acme logistics') => {
+const runSearch = (
+	status: number,
+	body: unknown,
+	input: Partial<SearchInput> = {},
+) => {
 	const log: CallLog = { count: 0, last: undefined }
 	const client = countingClient(log, status, body)
 	const exit = runWithVirtualClock(() =>
 		Effect.gen(function* () {
 			const provider = yield* makeFirecrawlSearch(0)
-			return yield* provider.search({ query })
+			return yield* provider.search({ query: 'acme logistics', ...input })
 		}).pipe(
 			Effect.provideService(HttpClient.HttpClient, client),
 			Effect.provide(
@@ -373,6 +391,32 @@ describe('makeFirecrawlSearch', () => {
 		expect(log.last?.method).toBe('POST')
 		expect(log.last?.url).toContain('api.firecrawl.dev/v2/search')
 		expect(log.last?.headers['authorization']).toBe('Bearer fc_k')
+	})
+
+	it('should send a normalized lower-case country for a locale hint', async () => {
+		// GIVEN the model passes a language-and-region locale (the 422 trigger)
+		const { exit, log } = runSearch(
+			200,
+			{ data: { web: [] } },
+			{ location: 'en-US' },
+		)
+		await exit
+
+		// THEN Firecrawl receives a valid lower-case alpha-2, not the raw locale
+		expect(bodyJson(log.last)['country']).toBe('us')
+	})
+
+	it('should omit country when the location hint is not a country', async () => {
+		// GIVEN a free-form place name the search API would reject
+		const { exit, log } = runSearch(
+			200,
+			{ data: { web: [] } },
+			{ location: 'United States' },
+		)
+		await exit
+
+		// THEN no country param is sent rather than an invalid one
+		expect(bodyJson(log.last)).not.toHaveProperty('country')
 	})
 
 	it('should retry a 5xx as recoverable', async () => {

--- a/packages/research/src/infrastructure/firecrawl/search.ts
+++ b/packages/research/src/infrastructure/firecrawl/search.ts
@@ -19,6 +19,7 @@ import {
 } from 'effect/unstable/http'
 
 import { type SearchInput, SearchProvider } from '../../application/ports'
+import { parseCountryAlpha2 } from '../../domain/country'
 import { ProviderError } from '../../domain/errors'
 import { SearchResult, SearchResultItem } from '../../domain/types'
 import { keyForSlot } from '../_config'
@@ -67,6 +68,9 @@ export const makeFirecrawlSearch = (slot: number) =>
 			search: (input: SearchInput) =>
 				harden(
 					Effect.gen(function* () {
+						// Firecrawl's `country` wants a lower-case two-letter code; a raw
+						// model hint like "en-US" is rejected (422), so normalize or drop it.
+						const country = parseCountryAlpha2(input.location)
 						const request = HttpClientRequest.post(SEARCH_URL).pipe(
 							HttpClientRequest.setHeaders({
 								Authorization: `Bearer ${Redacted.value(apiKey)}`,
@@ -87,7 +91,7 @@ export const makeFirecrawlSearch = (slot: number) =>
 								...(input.recency
 									? { tbs: tbsForRecency(input.recency.days) }
 									: {}),
-								...(input.location ? { country: input.location } : {}),
+								...(country ? { country: country.toLowerCase() } : {}),
 							}),
 						)
 						const response = yield* client.execute(request).pipe(


### PR DESCRIPTION
## What

Batuda's automated company **research** runs — the background feature that gathers web evidence about a company — were failing on every attempt in production. This fixes the two code-level causes; the third was a bad API key I've already rotated in the production secrets. Everything here lives in the Research bounded context (`packages/research`, driven by the `server` app and its MCP tools).

Issue #203 pinned three independent failures. The two code ones are fixed here.

## The fix

- **Web search stopped rejecting valid queries.** When the model gave a location hint like `en-US` or `es-ES`, we passed it straight through as the search provider's `country`, which only accepts a two-letter ISO country code (e.g. `us`). The provider rejected the whole request (HTTP 422) and the run failed. The hint is now normalized to a two-letter code — sent lower-cased to Firecrawl, upper-cased to Brave — and dropped entirely when it isn't a recognizable country, so a bad hint can no longer sink a search.
- **A cache hit no longer crashes the research loop.** A model completion is stored in the database cache as plain JSON of its parts. That JSON drops the accessors that read back the answer's text, tool calls, tool results, and token counts. When a later run (a different process) read that cached entry it got a bare object and crashed the instant it tried to iterate the now-missing tool results. Cached entries are now rebuilt into a proper response object on read, so a cache hit behaves exactly like a fresh answer.

## Impact

- **Research spend resumes (intended).** Runs that previously died at the first search now complete, so normal paid-provider usage (Firecrawl / Brave) returns — this is the fix working, not a regression.
- **Both transports benefit.** The research service is shared between the MCP tools and the HTTP API; both get the search and cache fixes.
- **No schema, env-var, auth, or wire-shape changes.** No migration to run and nothing new to set in production. The cache fix is transparent to callers.

## Review guide

- Start at `packages/research/src/domain/country.ts` (`parseCountryAlpha2`) — the one new piece of logic — and its two call sites in `firecrawl/search.ts` (lower-cased) and `brave/search.ts` (upper-cased).
- The riskiest part is the cache fix in `infrastructure/cached-llm.ts`: `rehydrateCachedResponse` rebuilds the Effect `GenerateTextResponse` / `GenerateObjectResponse` class from the stored parts. It relies on those classes being reconstructable from `content` alone — they are: every accessor derives from `content`, and `GenerateObjectResponse` also carries `value`. The method (`text` vs `object`) is part of the cache key, so a stored row is always rebuilt as the shape it was written as.
- A decision you might overrule: I diagnosed the crash differently from the issue. The issue proposed guarding `response.toolResults ?? []` in the research loop; that only relocates the crash, because the same cache-hit object is also missing `text` / `toolCalls` / `usage`. Fixing it once at the cache boundary restores all of them, and the `generateObject` callers too.

## Tests

- `parseCountryAlpha2`: locale, bare-code, whitespace, and unmappable inputs.
- Both search adapters assert the real outgoing `country` (`en-US` → `us` / `US`; an unmappable hint is omitted).
- `rehydrateCachedResponse`: text and object responses round-tripped through JSON prove the accessors come back — and the test documents the bug, asserting bare JSON's `toolResults` is `undefined` before the rebuild.

## Verification

- Ran the gates: `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test` (research + full suite, 20 tasks), `pnpm -w build` — all green.
- The search and cache paths only run against real providers (local dev uses stubs), so full live confirmation happens once this deploys with the rotated key. The unit tests exercise the exact request-building and cache-deserialization logic that failed in production.

## Deferred

- Problem A (scrape HTTP 401) was a stale `RESEARCH_API_KEY_SCRAPE` production secret — I've rotated it; no code change belongs here.
- A boot-time warning for a blank provider key was considered and dropped by choice: local tooling can't see production secrets, and the underlying HTTP status is already visible in telemetry since #199.

Closes #203
