### PR TITLE
fix(research): stop website noise from polluting enrichment output

### DIFF
--- a/packages/research/src/application/schemas/company-enrichment-v1.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.ts
@@ -12,7 +12,10 @@ export const CompanyEnrichmentV1Schema = Schema.Struct({
 		industry: Schema.optionalKey(Schema.String),
 		size_range: Schema.optionalKey(Schema.String),
 		pain_points: Schema.optionalKey(Schema.String),
-		current_tools: Schema.optionalKey(Schema.String),
+		current_tools: Schema.optionalKey(Schema.String).annotate({
+			description:
+				"The company's own business or operations software (e.g. TMS, ERP, CRM, WMS, load boards). Exclude generic website infrastructure that appears on any site — reCAPTCHA, analytics, CDNs, cookie/consent banners.",
+		}),
 		products_fit: Schema.optionalKey(Schema.Array(Schema.String)),
 		tags: Schema.optionalKey(Schema.Array(Schema.String)),
 		location: Schema.optionalKey(Schema.String),
@@ -24,7 +27,10 @@ export const CompanyEnrichmentV1Schema = Schema.Struct({
 		Schema.Array(
 			Schema.Struct({
 				name: Schema.String,
-				website: Schema.optionalKey(Schema.String),
+				website: Schema.optionalKey(Schema.String).annotate({
+					description:
+						"The competitor's own official website. It must belong to the named competitor — not a directory/aggregator profile page and not another company that happened to appear in search results.",
+				}),
 				why: Schema.optionalKey(Schema.String),
 				citations: Schema.Array(Citation),
 			}),


### PR DESCRIPTION
## What

When the research tool builds a company profile (the Research context, `packages/research`), it was sometimes listing generic website widgets — like the reCAPTCHA anti-bot notice in a page footer — as the company's own "software tools", and pairing a competitor with the wrong website (a directory listing, or an unrelated company that showed up in search results). This adds short field descriptions to the `company_enrichment_v1` research output schema so the model filling those fields knows what belongs in them. Surfaced while testing real US logistics companies (the Sunset Transportation run reported `current_tools: "reCAPTCHA"`).

## Changes

- **`current_tools`** — now described as the company's own business/operations software (TMS, ERP, CRM, WMS, load boards), explicitly excluding generic site infrastructure (reCAPTCHA, analytics, CDNs, cookie/consent banners).
- **competitor `website`** — now described as the competitor's own official site, not a directory/aggregator profile page and not another company that happened to appear in search.

## Impact

- **No wire-shape change.** Both fields keep the exact same type (optional string); only the OpenAI structured-output *description* is added. The `company_enrichment_v1` findings shape is identical, so nothing downstream (`apps/internal`, `packages/controllers`) changes.
- No migration, no new env var, no auth/RLS, no MCP/HTTP-parity concern. It's a pure extraction-guidance nudge read by the LLM.
- It's guidance, not a hard constraint — the model can still occasionally ignore it. The bare fields previously carried **no** description at all, which is why the mis-extraction happened.

## Review guide

- The entire change is two `.annotate({ description })` strings in one file — read the two descriptions for accuracy, since they're what the extraction model sees.
- Matches the existing `.annotate({ description })` pattern already used on the research tool params in `tools.ts`.
- **Can't be fully verified deterministically:** the payoff (the model stops classifying reCAPTCHA as a tool) only shows up in a live research run, which is non-deterministic. Happy to run one to confirm.

## Verification

- `pnpm install` (clean), `pnpm -w check-types` (green, 13/13), pre-commit hook (check-types / lint / format green), readability-improver pass (no changes suggested).
- `test` / `build` gates skipped by request — schema-description-only change, no logic or build-only paths touched.
- Behavioural confirmation (a real enrichment run no longer surfacing reCAPTCHA) not yet run.

## Deferred

- The broader grounding-gate quality work — fail-closed / suppress proposals when no fetched source concerns the target, and enforcing competitor-URL relevance — stays in #199. This PR only adds extraction guidance, not gate logic.

Related to #199.
