### PR TITLE
feat(research): make research runs honest, resilient, and applicable

### DIFF
--- a/apps/server/src/db/migrations/0025_research_run_entity_match.ts
+++ b/apps/server/src/db/migrations/0025_research_run_entity_match.ts
@@ -1,0 +1,17 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// How strongly a completed run's fetched evidence was about the company it
+// researched: 'strong' | 'weak' | null. A weak run keeps its brief but withholds
+// CRM writes and is flagged low-confidence; the verdict is stored so that
+// handling survives a resume after a crash. Null means the run was not
+// entity-gated (a scan or freeform run whose findings are about third parties).
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		ALTER TABLE research_runs
+			ADD COLUMN IF NOT EXISTS entity_match text
+	`
+})

--- a/apps/server/src/services/research-apply-batch.integration.test.ts
+++ b/apps/server/src/services/research-apply-batch.integration.test.ts
@@ -172,4 +172,40 @@ describe('resolveResearchProposedUpdatesBatch', () => {
 			expect(rows.rows[0]?.role).toBe('CTO')
 		})
 	})
+
+	describe('when an update proposal has a non-UUID subject_id', () => {
+		it('should report it invalid rather than crash on the bad id', async () => {
+			// GIVEN a run whose update proposal carries a hallucinated non-UUID id
+			// with an otherwise valid fields object, so only the id disqualifies it
+			const run = await pool.query<{ id: string }>(
+				`INSERT INTO research_runs (organization_id, query, status, created_by, findings)
+				 VALUES ($1, 'q', 'succeeded', 'u1', $2::jsonb) RETURNING id`,
+				[
+					ORG,
+					JSON.stringify({
+						proposed_updates: [
+							proposal({
+								id: 'bad',
+								subject_table: 'contacts',
+								operation: 'update',
+								subject_id: 'not-a-uuid',
+								expected_version: 0,
+								fields: { role: 'Ghost' },
+							}),
+						],
+					}),
+				],
+			)
+			const badRunId = run.rows[0]!.id
+
+			// WHEN it is applied
+			const results = await runBatch([
+				{ researchId: badRunId, proposedUpdateId: 'bad', decision: 'apply' },
+			])
+
+			// THEN the bad id is reported as invalid, not raised as a server error
+			expect(results).toHaveLength(1)
+			expect(results[0]?.outcome).toBe('invalid')
+		})
+	})
 })

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -194,6 +194,23 @@ const setProposalStatus = (
 		WHERE id = ${runId} AND organization_id = ${orgId}
 	`
 
+// The Postgres error code (e.g. '22P02' bad-uuid, '23503' fk-violation) can sit a
+// couple of `cause` levels down inside a wrapped SqlError, so walk the chain
+// rather than reading only the top cause.
+const pgErrorCode = (error: unknown): string | undefined => {
+	let cursor: unknown = error
+	for (
+		let depth = 0;
+		depth < 6 && cursor != null && typeof cursor === 'object';
+		depth++
+	) {
+		const code = (cursor as { code?: unknown }).code
+		if (typeof code === 'string') return code
+		cursor = (cursor as { cause?: unknown }).cause
+	}
+	return undefined
+}
+
 // Optimistic-concurrency write: lands only if `version` still equals the version
 // the proposal was made against, and bumps it. Branches on the table so the name
 // is never interpolated. Returns the new row (empty on a version/id mismatch).
@@ -539,7 +556,7 @@ export const resolveResearchProposedUpdate = (
 				RETURNING id, version
 			`.pipe(
 				Effect.catchTag('SqlError', e => {
-					const code = (e.cause as { code?: unknown } | null | undefined)?.code
+					const code = pgErrorCode(e)
 					// A hallucinated company_id is a bad proposal, not a server error: a
 					// company that doesn't exist trips the foreign key (23503), a value
 					// that isn't a UUID trips text parsing (22P02). Report it as invalid
@@ -591,6 +608,9 @@ export const resolveResearchProposedUpdate = (
 		if (Object.keys(fields).length === 0)
 			return { outcome: 'no_applicable_fields' } satisfies ResolveOutcome
 
+		// A subject_id that isn't a UUID trips text parsing (22P02) in the WHERE
+		// clause; that is a bad proposal (the model can invent an id), not a server
+		// error, so report it as invalid the way the create branch does.
 		const updatedRows = yield* occUpdate(
 			sql,
 			validated.table,
@@ -598,7 +618,19 @@ export const resolveResearchProposedUpdate = (
 			org.id,
 			validated.expectedVersion,
 			fields,
+		).pipe(
+			Effect.catchTag('SqlError', e => {
+				const code = pgErrorCode(e)
+				return code === '22P02' || code === '23503'
+					? Effect.succeed(null)
+					: Effect.fail(e)
+			}),
 		)
+		if (updatedRows === null)
+			return {
+				outcome: 'invalid',
+				reason: 'subject_id does not reference a known row',
+			} satisfies ResolveOutcome
 		if (updatedRows.length === 0)
 			return { outcome: 'conflict' } satisfies ResolveOutcome
 

--- a/apps/server/src/services/research-entity-gate.integration.test.ts
+++ b/apps/server/src/services/research-entity-gate.integration.test.ts
@@ -1,0 +1,435 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '6'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	type CreateResearchInput,
+	ExtractLanguageModel,
+	ExtractProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	ScrapeProvider,
+	SearchProvider,
+	type SystemDefaults,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+// The entity grounding gate end to end: an enrichment run whose fetched evidence
+// is about a DIFFERENT company must fail closed to no_reliable_data; one that
+// clearly names the target must still succeed; a run that only glancingly
+// mentions it succeeds but is flagged low-confidence with its CRM writes stripped;
+// and a run whose only scrape FAILS must resolve to no_reliable_data, not failed.
+//
+// One shared ResearchService layer drives every case (a fresh layer per case
+// would start a fresh dispatcher + connection pool each time and exhaust the CI
+// database's connection cap). Each test sets the module-level `scenario` before
+// it runs, and the Agent/Extract stubs read it at call time.
+
+interface Org {
+	id: string
+	name: string
+	slug: string
+}
+
+interface Scenario {
+	readonly query: string
+	readonly schemaName: string
+	readonly url: string
+	readonly markdown: string
+	readonly isFailure: boolean
+}
+
+let scenario: Scenario
+let agentCall = 0
+
+const usage = {
+	inputTokens: {
+		uncached: undefined,
+		total: 0,
+		cacheRead: undefined,
+		cacheWrite: undefined,
+	},
+	outputTokens: { total: 0, text: undefined, reasoning: undefined },
+}
+
+const finalRound = {
+	text: 'done',
+	content: [{ type: 'text' as const, text: 'done' }],
+	reasoning: [],
+	reasoningText: undefined,
+	toolCalls: [],
+	toolResults: [],
+	finishReason: 'stop' as const,
+	usage,
+}
+
+// Round 1 scrapes one page; a failing scrape carries an AiError-shaped result the
+// toolkit surfaces with isFailure: true, exactly as failureMode: 'return' does.
+const scrapeRound = () => ({
+	text: '',
+	content: [{ type: 'text' as const, text: 'scraping' }],
+	reasoning: [],
+	reasoningText: undefined,
+	toolCalls: [{ id: 's1', name: 'scrape_page', params: { url: scenario.url } }],
+	toolResults: [
+		{
+			id: 's1',
+			name: 'scrape_page',
+			result: scenario.isFailure
+				? {
+						_tag: 'UnknownError',
+						description: 'scrape_page: scrape failed: HTTP 401',
+					}
+				: { url: scenario.url, markdown: scenario.markdown },
+			encodedResult: undefined,
+			isFailure: scenario.isFailure,
+		},
+	],
+	finishReason: 'tool-calls' as const,
+	usage,
+})
+
+const agentLlm: LanguageModel.Service = {
+	generateText: (_o: unknown) =>
+		Effect.sync(() =>
+			agentCall++ === 0 ? scrapeRound() : finalRound,
+		) as never,
+	generateObject: (_o: unknown) =>
+		Effect.succeed({ ...finalRound, value: {} }) as never,
+	streamText: (_o: unknown) =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+// The extractor proposes creating one contact citing the scraped page. Its only
+// field is a name (no email/phone), so the value guard cannot strip it — whether
+// it survives to the findings is decided by the entity gate alone.
+const extractLlm: LanguageModel.Service = {
+	generateText: (_o: unknown) => Effect.succeed(finalRound) as never,
+	generateObject: (_o: unknown) =>
+		Effect.succeed({
+			...finalRound,
+			value: {
+				enrichment: {
+					industry: 'Freight',
+					citations: [{ source_id: scenario.url }],
+				},
+				proposed_updates: [
+					{
+						subject_table: 'contacts',
+						operation: 'create',
+						fields: { name: 'Jane Doe' },
+						reason: 'discovered on the about page',
+						citations: [{ source_id: scenario.url }],
+					},
+				],
+			},
+		}) as never,
+	streamText: (_o: unknown) =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const writerLlm: LanguageModel.Service = {
+	generateText: (_o: unknown) =>
+		Effect.succeed({ ...finalRound, text: 'a brief' }) as never,
+	generateObject: (_o: unknown) =>
+		Effect.succeed({ ...finalRound, value: {} }) as never,
+	streamText: (_o: unknown) =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const unused = 'research provider not exercised by the Agent stub'
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({ search: () => Effect.die(unused) }),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({ scrape: () => Effect.die(unused) }),
+	),
+	Layer.succeed(ExtractProvider)(
+		ExtractProvider.of({ extract: () => Effect.die(unused) }),
+	),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(unused) }),
+	),
+)
+
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			Layer.succeed(AgentLanguageModel)(agentLlm),
+			Layer.succeed(ExtractLanguageModel)(extractLlm),
+			Layer.succeed(WriterLanguageModel)(writerLlm),
+		),
+	),
+	Layer.provide(providersLayer),
+	Layer.provide(
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test',
+				}),
+		}),
+	),
+	Layer.provide(
+		Layer.succeed(ResearchEventSink)(
+			ResearchEventSink.of({ fire: () => Effect.void }),
+		),
+	),
+	Layer.provideMerge(PgLive),
+)
+
+// Build the whole research stack once and reuse it across every case: a single
+// dispatcher + connection pool serves the file. Building it per case would start a
+// fresh dispatcher + pool each time and exhaust the CI database's connection cap.
+const runtime = ManagedRuntime.make(ResearchLive)
+
+const systemDefaults: SystemDefaults = {
+	budgetCents: 100,
+	paidBudgetCents: 500,
+	autoApprovePaidCents: 200,
+	paidMonthlyCapCents: 2000,
+	hardCeiling: 5000,
+}
+
+const TERMINAL = new Set([
+	'succeeded',
+	'failed',
+	'cancelled',
+	'no_reliable_data',
+])
+
+const ctx = {} as { org: Org }
+let userId = ''
+const createdRunIds: string[] = []
+
+// A source row per scraped URL, standing in for the row the scrape cache would
+// upsert in production, so the loop can link research_run_sources by url_hash.
+const seedSource = (url: string, markdown: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (
+					${randomUUID()}, 'web', 'it-stub', ${url},
+					${createHash('sha256').update(url).digest('hex')},
+					${new URL(url).hostname},
+					${createHash('sha256').update(markdown).digest('hex')}
+				)
+				ON CONFLICT (url_hash) DO NOTHING
+			`
+		}),
+	)
+
+interface RunResult {
+	readonly status: string
+	readonly errorMessage: string | null
+	readonly sourceCount: number
+	readonly findings: {
+		proposedUpdates?: unknown[]
+		entityConfidence?: string
+	} | null
+}
+
+const runScenario = async (next: Scenario): Promise<RunResult> => {
+	scenario = next
+	agentCall = 0
+	if (!next.isFailure) await seedSource(next.url, next.markdown)
+
+	const input: CreateResearchInput = {
+		query: next.query,
+		schemaName: next.schemaName,
+		forceFresh: true,
+	}
+
+	return runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ResearchService
+			const sql = yield* SqlClient.SqlClient
+
+			const created = yield* enterOrgScope(sql, { org: ctx.org, userId })(
+				svc.create(userId, ctx.org.id, input, systemDefaults),
+			)
+			createdRunIds.push(created.id)
+
+			const poll = (
+				attemptsLeft: number,
+			): Effect.Effect<
+				{ status: string; errorMessage: string | null },
+				never,
+				never
+			> =>
+				Effect.gen(function* () {
+					const run = (yield* svc.get(created.id).pipe(Effect.orDie)) as {
+						status?: string
+						errorMessage?: string | null
+					} | null
+					const status = run?.status ?? 'unknown'
+					if (TERMINAL.has(status) || attemptsLeft <= 0) {
+						return { status, errorMessage: run?.errorMessage ?? null }
+					}
+					yield* Effect.sleep('300 millis')
+					return yield* poll(attemptsLeft - 1)
+				})
+
+			const final = yield* poll(50)
+
+			const [sourceCount] = yield* sql<{ n: number }>`
+				SELECT COUNT(*)::int AS n FROM research_run_sources
+				WHERE research_id = ${created.id}::uuid
+			`.pipe(Effect.orDie)
+
+			const [row] = yield* sql<{ findings: RunResult['findings'] }>`
+				SELECT findings FROM research_runs WHERE id = ${created.id}::uuid
+			`.pipe(Effect.orDie)
+
+			return {
+				status: final.status,
+				errorMessage: final.errorMessage,
+				sourceCount: sourceCount?.n ?? 0,
+				findings: row?.findings ?? null,
+			}
+		}),
+	)
+}
+
+beforeAll(async () => {
+	const seed = await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [org] = yield* sql<Org>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [user] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!org || !user) {
+				throw new Error(
+					"taller org / admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			return { org, userId: user.id }
+		}),
+	)
+	ctx.org = seed.org
+	userId = seed.userId
+}, 60_000)
+
+afterAll(async () => {
+	await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const id of createdRunIds) {
+				yield* sql`DELETE FROM research_cache WHERE research_id = ${id}::uuid`
+				yield* sql`DELETE FROM research_runs WHERE id = ${id}::uuid`
+			}
+			yield* sql`DELETE FROM sources WHERE provider = 'it-stub'`
+		}),
+	)
+	await runtime.dispose()
+})
+
+describe('ResearchService entity grounding gate', () => {
+	describe('when the fetched evidence is about a different company', () => {
+		it('should fail closed to no_reliable_data instead of reporting the wrong data', async () => {
+			// GIVEN an enrichment run for a company that does not exist, whose only
+			//   scrape returns a page about an unrelated freight broker
+			const result = await runScenario({
+				query: 'Zxqvon Interstellar Freight Brokerage LLC',
+				schemaName: 'company_enrichment_v1',
+				url: `https://absent-${randomUUID()}.example/about`,
+				markdown: 'Topia Freight is a load broker based in Denver, Colorado.',
+				isFailure: false,
+			})
+
+			// THEN it fails closed — the evidence never named the target
+			expect(
+				result.status,
+				`unexpected status: ${result.errorMessage ?? '(none)'}`,
+			).toBe('no_reliable_data')
+		}, 30_000)
+	})
+
+	describe('when the fetched evidence clearly names the target', () => {
+		it('should succeed and keep its proposal without a low-confidence flag', async () => {
+			// GIVEN an enrichment run whose scrape names the target company in full
+			const result = await runScenario({
+				query: 'Acme Logistics',
+				schemaName: 'company_enrichment_v1',
+				url: `https://acme-${randomUUID()}.example/about`,
+				markdown:
+					'Acme Logistics S.L. is a freight forwarder based in Barcelona.',
+				isFailure: false,
+			})
+
+			// THEN it succeeds with its create proposal intact and no low-confidence flag
+			expect(
+				result.status,
+				`unexpected status: ${result.errorMessage ?? '(none)'}`,
+			).toBe('succeeded')
+			expect(result.findings?.proposedUpdates).toHaveLength(1)
+			expect(result.findings?.entityConfidence).toBeUndefined()
+		}, 30_000)
+	})
+
+	describe('when the fetched evidence only glancingly mentions the target', () => {
+		it('should succeed but strip CRM writes and flag low confidence', async () => {
+			// GIVEN an enrichment run whose scrape mentions the brand word but never
+			//   the full name or the company's own site
+			const result = await runScenario({
+				query: 'Acme Logistics',
+				schemaName: 'company_enrichment_v1',
+				url: `https://dir-${randomUUID()}.example/listing`,
+				markdown: 'A directory lists Acme among many freight brokers.',
+				isFailure: false,
+			})
+
+			// THEN it still succeeds, but its proposals are withheld and it is flagged
+			expect(
+				result.status,
+				`unexpected status: ${result.errorMessage ?? '(none)'}`,
+			).toBe('succeeded')
+			expect(result.findings?.proposedUpdates).toHaveLength(0)
+			expect(result.findings?.entityConfidence).toBe('low')
+		}, 30_000)
+	})
+
+	describe('when the only scrape fails', () => {
+		it('should continue past the failed fetch and end no_reliable_data, not failed', async () => {
+			// GIVEN a run whose single scrape_page call returns a provider failure
+			//   (surfaced to the model, not fatal), leaving no page fetched
+			const result = await runScenario({
+				query: 'anything at all',
+				schemaName: 'freeform',
+				url: `https://dead-${randomUUID()}.example/x`,
+				markdown: '',
+				isFailure: true,
+			})
+
+			// THEN the failed fetch did not crash the run; it fell through to the
+			//   grounding gate with zero sources
+			expect(
+				result.status,
+				`unexpected status: ${result.errorMessage ?? '(none)'}`,
+			).toBe('no_reliable_data')
+			expect(result.sourceCount).toBe(0)
+		}, 30_000)
+	})
+})

--- a/apps/server/src/services/research-grounding.integration.test.ts
+++ b/apps/server/src/services/research-grounding.integration.test.ts
@@ -52,6 +52,11 @@ const SCRAPED_HOST = new URL(SCRAPED_URL).hostname
 const URL_HASH = createHash('sha256').update(SCRAPED_URL).digest('hex')
 const SOURCE_ID = randomUUID()
 
+// Set in beforeAll: a real contact the grounded proposal targets, and its
+// company, so the applicability guard keeps that proposal and cleanup cascades.
+let realContactId = ''
+let seededCompanyId = ''
+
 // The scraped markdown carries the real phone the grounded proposal cites, so
 // the value guard finds it in the evidence and keeps that proposal.
 const SCRAPE_MARKDOWN =
@@ -127,7 +132,7 @@ const extractLlm: LanguageModel.Service = {
 				proposed_updates: [
 					{
 						subject_table: 'contacts',
-						subject_id: 'c-real',
+						subject_id: realContactId,
 						operation: 'update',
 						expected_version: 0,
 						fields: { phone: '936 123 456' },
@@ -256,15 +261,35 @@ beforeAll(async () => {
 				)
 				ON CONFLICT (url_hash) DO NOTHING
 			`
-			return { org, userId: user.id }
+			// A real contact the grounded proposal updates, so the applicability
+			// guard keeps it — a proposal targeting a row that does not exist is
+			// dropped as un-appliable.
+			const [company] = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, slug, name)
+				VALUES (${org.id}, ${`grounding-${randomUUID()}`}, 'Acme Logistics')
+				RETURNING id
+			`
+			const [contact] = yield* sql<{ id: string }>`
+				INSERT INTO contacts (organization_id, company_id, name)
+				VALUES (${org.id}, ${company?.id ?? ''}, 'Grace Hopper')
+				RETURNING id
+			`
+			return {
+				org,
+				userId: user.id,
+				companyId: company?.id ?? '',
+				contactId: contact?.id ?? '',
+			}
 		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
-			{ org: Org; userId: string },
+			{ org: Org; userId: string; companyId: string; contactId: string },
 			never,
 			never
 		>,
 	)
 	ctx.org = seed.org
 	userId = seed.userId
+	seededCompanyId = seed.companyId
+	realContactId = seed.contactId
 }, 60_000)
 
 afterAll(async () => {
@@ -277,6 +302,10 @@ afterAll(async () => {
 				yield* sql`DELETE FROM research_runs WHERE id = ${runId}::uuid`
 			}
 			yield* sql`DELETE FROM sources WHERE url_hash = ${URL_HASH}`
+			if (seededCompanyId) {
+				// Cascades the seeded contact.
+				yield* sql`DELETE FROM companies WHERE id = ${seededCompanyId}::uuid`
+			}
 		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
 	)
 })
@@ -364,7 +393,7 @@ describe('ResearchService grounding', () => {
 					proposedUpdates?: Array<{ subjectId: string }>
 				} | null
 			)?.proposedUpdates
-			expect(proposals?.map(p => p.subjectId)).toEqual(['c-real'])
+			expect(proposals?.map(p => p.subjectId)).toEqual([realContactId])
 		}, 30_000)
 	})
 })

--- a/packages/research/src/application/applicability-guard.test.ts
+++ b/packages/research/src/application/applicability-guard.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterApplicableProposals } from './applicability-guard'
+
+// A subject resolver that knows one real row and nothing else.
+const onlyKnows = (table: string, id: string) => (t: string, i: string) =>
+	t === table && i === id
+
+const withProposals = (proposals: unknown[]) => ({
+	enrichment: { citations: [] },
+	proposed_updates: proposals,
+})
+
+const survivors = (result: { findings: unknown }): unknown[] =>
+	(result.findings as { proposed_updates: unknown[] }).proposed_updates
+
+describe('filterApplicableProposals', () => {
+	describe('when an update targets a company that does not exist', () => {
+		it('should drop it', () => {
+			// GIVEN an update whose subject_id resolves to no live row
+			const findings = withProposals([
+				{
+					subject_table: 'companies',
+					operation: 'update',
+					subject_id: 'not-a-real-id',
+					fields: { website: 'https://x.test' },
+				},
+			])
+			// WHEN filtered against a resolver that knows a different id
+			const result = filterApplicableProposals(
+				findings,
+				onlyKnows('companies', 'real-id'),
+			)
+			// THEN the proposal is dropped and counted
+			expect(survivors(result)).toHaveLength(0)
+			expect(result.dropped).toBe(1)
+		})
+	})
+
+	describe('when an update resolves to a real row with values to write', () => {
+		it('should keep it', () => {
+			// GIVEN an update for a company that exists, carrying real fields
+			const findings = withProposals([
+				{
+					subject_table: 'companies',
+					operation: 'update',
+					subject_id: 'real-id',
+					fields: { website: 'https://acme.test' },
+				},
+			])
+			// WHEN filtered against a resolver that knows that row
+			const result = filterApplicableProposals(
+				findings,
+				onlyKnows('companies', 'real-id'),
+			)
+			// THEN the proposal survives untouched
+			expect(survivors(result)).toHaveLength(1)
+			expect(result.dropped).toBe(0)
+		})
+	})
+
+	describe('when fields is not a usable object', () => {
+		it('should drop an update whose fields is prose or empty', () => {
+			// GIVEN two updates the model malformed: column names as a string, and {}
+			const findings = withProposals([
+				{
+					subject_table: 'companies',
+					operation: 'update',
+					subject_id: 'real-id',
+					fields: 'location, website',
+				},
+				{
+					subject_table: 'companies',
+					operation: 'update',
+					subject_id: 'real-id',
+					fields: {},
+				},
+			])
+			// WHEN filtered (the subject exists, so only the fields disqualify them)
+			const result = filterApplicableProposals(
+				findings,
+				onlyKnows('companies', 'real-id'),
+			)
+			// THEN both are dropped
+			expect(survivors(result)).toHaveLength(0)
+			expect(result.dropped).toBe(2)
+		})
+	})
+
+	describe('when a create carries a new row', () => {
+		it('should keep a create with a fields object and no subject', () => {
+			// GIVEN a create (contacts) with the new row in fields and no subject_id
+			const findings = withProposals([
+				{
+					subject_table: 'contacts',
+					operation: 'create',
+					fields: { name: 'Jane Doe', email: 'jane@acme.test' },
+				},
+			])
+			// WHEN filtered — a create needs no existing subject
+			const result = filterApplicableProposals(findings, () => false)
+			// THEN it survives
+			expect(survivors(result)).toHaveLength(1)
+			expect(result.dropped).toBe(0)
+		})
+
+		it('should drop a create whose fields is prose', () => {
+			// GIVEN a create with malformed fields
+			const findings = withProposals([
+				{
+					subject_table: 'contacts',
+					operation: 'create',
+					fields: 'a new contact',
+				},
+			])
+			// WHEN filtered
+			const result = filterApplicableProposals(findings, () => false)
+			// THEN it is dropped
+			expect(survivors(result)).toHaveLength(0)
+			expect(result.dropped).toBe(1)
+		})
+	})
+
+	describe('when a proposal omits its operation', () => {
+		it('should treat a missing operation as an update needing a subject', () => {
+			// GIVEN a proposal with no operation and an unresolvable subject
+			const findings = withProposals([
+				{
+					subject_table: 'companies',
+					subject_id: 'ghost',
+					fields: { website: 'https://x.test' },
+				},
+			])
+			// WHEN filtered against a resolver that does not know it
+			const result = filterApplicableProposals(findings, () => false)
+			// THEN it is dropped like any un-resolvable update
+			expect(survivors(result)).toHaveLength(0)
+			expect(result.dropped).toBe(1)
+		})
+	})
+})

--- a/packages/research/src/application/applicability-guard.ts
+++ b/packages/research/src/application/applicability-guard.ts
@@ -1,0 +1,69 @@
+/**
+ * Drops proposed CRM updates that could never be applied, so the review surface
+ * and the apply path are not cluttered with un-actionable suggestions — the model
+ * sometimes emits an update for a company that does not exist, or lists column
+ * names as a bare string instead of values to write.
+ *
+ * A proposal survives only when it could actually land:
+ *  - its `fields` is a non-empty object of values (a raw string or an empty object
+ *    can never be written);
+ *  - an update (the default) additionally needs a `subject_id` that resolves to a
+ *    real, non-deleted CRM row — the model can invent an id for a made-up company;
+ *  - a create carries the whole new row in `fields`, so it needs no subject.
+ *
+ * `subjectExists` answers whether a (table, id) names a live row; the caller
+ * supplies it so this module stays free of a database.
+ */
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+	value !== null && typeof value === 'object' && !Array.isArray(value)
+
+export interface ApplicabilityResult {
+	readonly findings: unknown
+	/** Proposed writes dropped because they could never be applied. */
+	readonly dropped: number
+}
+
+export const filterApplicableProposals = (
+	findings: unknown,
+	subjectExists: (subjectTable: string, subjectId: string) => boolean,
+): ApplicabilityResult => {
+	let dropped = 0
+
+	const isApplicable = (proposal: unknown): boolean => {
+		if (!isPlainObject(proposal)) return false
+		const { operation, subject_table, subject_id, fields } = proposal
+		// Every proposal needs real values to write; the model sometimes emits
+		// `fields` as prose or an empty object, neither of which can apply.
+		if (!isPlainObject(fields) || Object.keys(fields).length === 0) return false
+		// A create carries the new row in `fields` and needs no subject. Anything
+		// else is an update, which also needs a subject that resolves to a live
+		// row — matching how the apply path treats a missing/unknown operation.
+		if (operation === 'create') return true
+		if (typeof subject_table !== 'string' || typeof subject_id !== 'string')
+			return false
+		if (subject_id.trim() === '') return false
+		return subjectExists(subject_table, subject_id)
+	}
+
+	const walk = (value: unknown, key?: string): unknown => {
+		if (Array.isArray(value)) {
+			if (key === 'proposed_updates') {
+				return value.filter(proposal => {
+					const ok = isApplicable(proposal)
+					if (!ok) dropped++
+					return ok
+				})
+			}
+			return value.map(item => walk(item))
+		}
+		if (isPlainObject(value)) {
+			return Object.fromEntries(
+				Object.entries(value).map(([k, v]) => [k, walk(v, k)] as const),
+			)
+		}
+		return value
+	}
+
+	return { findings: walk(findings), dropped }
+}

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	classifyEntityMatch,
+	deriveEntityTargets,
+	type EntityTargets,
+} from './entity-guard'
+
+describe('deriveEntityTargets', () => {
+	describe('when the schema reports third-party companies', () => {
+		it('should return null for a scan or freeform run with no anchored subject', () => {
+			// GIVEN a scan/freeform run whose findings are legitimately about other
+			// companies, so its own query name need not dominate the evidence
+			// WHEN targets are derived with no subjects
+			// THEN the run is not entity-gated
+			for (const schemaName of [
+				'prospect_scan_v1',
+				'competitor_scan_v1',
+				'freeform',
+			]) {
+				expect(
+					deriveEntityTargets({ schemaName, query: 'anything', subjects: [] }),
+				).toBeNull()
+			}
+		})
+	})
+
+	describe('when the run is entity-centric', () => {
+		it('should derive keys from the query for a query-only enrichment', () => {
+			// GIVEN a company_enrichment_v1 run identified only by a free-text query
+			// WHEN targets are derived
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Sunset Transportation, St. Louis MO',
+				subjects: [],
+			})
+			// THEN the pre-comma company name becomes the strong-match core
+			expect(targets?.cores).toContain('sunsettransportation')
+		})
+
+		it('should derive keys from the subject name and website when anchored', () => {
+			// GIVEN any schema but with an anchored company subject
+			const targets = deriveEntityTargets({
+				schemaName: 'freeform',
+				query: 'unused',
+				subjects: [
+					{
+						table: 'companies',
+						name: 'Acme Widgets',
+						website: 'https://acme.com',
+					},
+				],
+			})
+			// THEN the name core is a strong key and the full host is a domain key
+			expect(targets?.cores).toContain('acmewidgets')
+			expect(targets?.domains).toContain('acme.com')
+		})
+	})
+
+	describe('when the target has no usable identity', () => {
+		it('should return null so nothing false-fails', () => {
+			// GIVEN an anchored subject with neither a name nor a website
+			// WHEN targets are derived
+			// THEN the gate is skipped rather than failing an unidentifiable run
+			expect(
+				deriveEntityTargets({
+					schemaName: 'company_enrichment_v1',
+					query: '',
+					subjects: [{ table: 'companies' }],
+				}),
+			).toBeNull()
+		})
+	})
+})
+
+describe('classifyEntityMatch', () => {
+	const acme: EntityTargets = {
+		cores: ['acmelogistics'],
+		words: ['acme'],
+		domains: ['acme.com'],
+	}
+
+	describe('when the evidence names the target strongly', () => {
+		it('should return strong on a full-name match regardless of spacing and legal form', () => {
+			// GIVEN a corpus that spells the whole name with a legal form appended
+			// WHEN classified
+			// THEN the match is strong (folding makes "Acme Logistics S.L." == the core)
+			expect(
+				classifyEntityMatch(acme, 'Contact Acme Logistics S.L. for a quote'),
+			).toBe('strong')
+		})
+
+		it('should return strong on the target host, not a passing brand mention', () => {
+			// GIVEN a corpus that references the company's own host
+			// WHEN classified
+			// THEN reaching the target's own site is a strong signal
+			expect(
+				classifyEntityMatch(acme, 'Homepage at https://www.acme.com/about'),
+			).toBe('strong')
+		})
+
+		it('should match a name across diacritics', () => {
+			// GIVEN a target whose name carries accents
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Cafés Ordóñez',
+				subjects: [],
+			})
+			// WHEN a corpus writes the same name without the accents
+			// THEN folding makes the two equal and the match is strong
+			expect(classifyEntityMatch(targets!, 'the cafes ordonez brand')).toBe(
+				'strong',
+			)
+		})
+	})
+
+	describe('when the evidence only hints at the target', () => {
+		it('should return weak when a lone distinctive word appears', () => {
+			// GIVEN a corpus that mentions the distinctive word but never the full
+			// name or domain
+			// WHEN classified
+			// THEN the match is weak — it might be the target, not confidently
+			expect(
+				classifyEntityMatch(acme, 'A profile listing for Acme on a directory'),
+			).toBe('weak')
+		})
+	})
+
+	describe('when the evidence is about a different company', () => {
+		it('should return absent so the run fails closed', () => {
+			// GIVEN a corpus that names neither the company, its words, nor its domain
+			// WHEN classified
+			// THEN nothing grounds the target and the verdict is absent
+			expect(
+				classifyEntityMatch(acme, 'Topia Freight scored 100/100 on LoadWrap'),
+			).toBe('absent')
+		})
+
+		it('should return absent for a non-existent company whose name is nowhere in the evidence', () => {
+			// GIVEN the exact misattribution case: a made-up company
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Zxqvon Interstellar Freight Brokerage LLC',
+				subjects: [],
+			})
+			// WHEN its keys are classified against a corpus about other freight firms
+			// THEN the run is absent (its distinctive words appear nowhere)
+			expect(
+				classifyEntityMatch(targets!, 'Topia and Sunset are freight brokers'),
+			).toBe('absent')
+		})
+	})
+})

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -1,0 +1,251 @@
+/**
+ * Decides whether a run's fetched evidence is actually about the company the run
+ * was asked to research, so a run that only scraped unrelated pages cannot report
+ * another company's data as if it were the target's.
+ *
+ * The check is deterministic and reads ONLY the evidence corpus (scraped pages +
+ * tool results), never the model's own prose — the model always repeats the
+ * queried name, so its prose could vouch for any target. A company that was truly
+ * reached almost always spells its own name (or its domain) on its own pages.
+ *
+ * Three verdicts drive the run:
+ *  - 'strong'  the target's full name or its own domain appears in the evidence;
+ *  - 'weak'    only a distinctive word of the name appears — it might be the
+ *              target, so the run still completes, but its CRM writes are withheld
+ *              and the findings are flagged low-confidence for the reviewer;
+ *  - 'absent'  nothing in the evidence names the target — the run is misattributed
+ *              and is failed closed as no_reliable_data.
+ */
+
+// Legal-form suffixes dropped before matching, so "Acme Logistics S.L." and a
+// page that writes "Acme Logistica SL" still match on the same name core.
+const LEGAL_SUFFIXES = new Set([
+	'sl',
+	'slu',
+	'sa',
+	'sau',
+	'scp',
+	'sccl',
+	'srl',
+	'sarl',
+	'slne',
+	'gmbh',
+	'ltd',
+	'limited',
+	'llc',
+	'inc',
+	'incorporated',
+	'bv',
+	'plc',
+	'ag',
+	'oy',
+	'spa',
+	'sas',
+	'co',
+	'corp',
+	'llp',
+	'kg',
+	'ab',
+	'as',
+	'nv',
+	'kft',
+])
+
+// Generic words that do not prove a page is about the target — a page about any
+// freight company contains "logistics"/"transport". A name reduced to only these
+// yields no distinctive word, so the run cannot reach a weak (let alone strong)
+// match on an industry term alone.
+const GENERIC_WORDS = new Set([
+	'logistics',
+	'logistica',
+	'transport',
+	'transports',
+	'transporte',
+	'transportes',
+	'transportation',
+	'trucking',
+	'cargo',
+	'shipping',
+	'freight',
+	'brokerage',
+	'delivery',
+	'express',
+	'group',
+	'grupo',
+	'holding',
+	'holdings',
+	'services',
+	'servicios',
+	'solutions',
+	'soluciones',
+	'company',
+	'compania',
+	'international',
+	'global',
+	'consulting',
+	'partners',
+	'associates',
+	'industries',
+])
+
+// Second-level public labels ("co.uk", "com.au") dropped so the registrable
+// label is read, not the country's second level.
+const SECOND_LEVEL = new Set([
+	'co',
+	'com',
+	'org',
+	'net',
+	'gov',
+	'edu',
+	'ac',
+	'gob',
+])
+
+// Lower-case, strip accents, drop everything but letters and digits — the same
+// folding the email-guess step uses, so text matches regardless of punctuation,
+// case, or diacritics. Word boundaries are removed too, so a spelled-out name
+// like "Acme Logistics" is found as the contiguous run "acmelogistics".
+const collapse = (value: string): string =>
+	value
+		.normalize('NFKD')
+		.replace(/\p{Diacritic}/gu, '')
+		.toLowerCase()
+		.replace(/[^a-z0-9]/g, '')
+
+// Accent-folded word tokens of a name, punctuation split out.
+const foldTokens = (value: string): string[] =>
+	value
+		.normalize('NFKD')
+		.replace(/\p{Diacritic}/gu, '')
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean)
+
+// The whole name minus its legal suffix, collapsed — "Acme Logistics S.L." →
+// "acmelogistics". This is the strong-match key: it appears verbatim on the
+// company's own pages but is long enough not to hit by coincidence.
+const nameCore = (name: string): string =>
+	foldTokens(name)
+		.filter(t => !LEGAL_SUFFIXES.has(t))
+		.join('')
+
+// The distinctive words of a name: each ≥4 chars and neither a legal suffix nor a
+// generic industry term. These drive the weak match.
+const distinctiveWords = (name: string): string[] =>
+	foldTokens(name).filter(
+		t => t.length >= 4 && !LEGAL_SUFFIXES.has(t) && !GENERIC_WORDS.has(t),
+	)
+
+// The bare host of a website — "acme.co.uk" from "https://www.acme.co.uk/about".
+// A page that references this exact host really points at the target's site,
+// unlike a passing mention of the brand word, so it is a strong signal.
+const domainHost = (website: string): string | undefined => {
+	const host = website
+		.trim()
+		.toLowerCase()
+		.replace(/^[a-z]+:\/\//, '')
+		.replace(/[/:?#].*$/, '')
+		.replace(/^www\./, '')
+	return host.includes('.') && host.length >= 4 ? host : undefined
+}
+
+// The distinctive label inside a host — "acme" from "acme.co.uk" — used only as a
+// weak signal alongside the name's own words.
+const domainLabelOf = (host: string): string | undefined => {
+	const labels = host.split('.').filter(Boolean)
+	labels.pop() // drop the TLD
+	if (labels.length >= 2 && SECOND_LEVEL.has(labels[labels.length - 1] ?? '')) {
+		labels.pop() // drop a second-level public suffix (co.uk, com.au…)
+	}
+	const label = labels[labels.length - 1]
+	return label && label.length >= 4 ? label : undefined
+}
+
+// A free-text query's company name is usually the part before the first comma
+// ("Sunset Transportation, St. Louis MO"); fall back to the whole query.
+const queryName = (query: string): string => query.split(',')[0] ?? query
+
+export interface EntityTarget {
+	readonly table: string
+	readonly name?: string | undefined
+	readonly website?: string | undefined
+}
+
+export interface EntityTargets {
+	/** Full collapsed names — strong-match keys (checked against collapsed text). */
+	readonly cores: ReadonlyArray<string>
+	/** Distinctive words + domain labels — weak-match keys. */
+	readonly words: ReadonlyArray<string>
+	/** Registrable hosts — strong-match keys (checked against the raw corpus). */
+	readonly domains: ReadonlyArray<string>
+}
+
+// Only these schemas make a claim about their OWN named subject. A scan playbook
+// legitimately reports third-party companies, so it is never entity-gated;
+// freeform makes no entity guarantee.
+const ENTITY_GROUNDED_SCHEMAS = new Set([
+	'company_enrichment_v1',
+	'contact_discovery_v1',
+])
+
+/**
+ * Builds the match keys for a run's target, or null when the run should not be
+ * entity-gated (a scan/freeform run with no anchored subject, or a target with no
+ * usable name or domain).
+ */
+export const deriveEntityTargets = (args: {
+	schemaName: string
+	query: string
+	subjects: ReadonlyArray<EntityTarget>
+}): EntityTargets | null => {
+	const anchored = args.subjects.length > 0
+	if (!ENTITY_GROUNDED_SCHEMAS.has(args.schemaName) && !anchored) return null
+
+	const names = anchored
+		? args.subjects
+				.map(s => s.name)
+				.filter((n): n is string => n != null && n.trim() !== '')
+		: [queryName(args.query)]
+	const websites = args.subjects
+		.map(s => s.website)
+		.filter((w): w is string => w != null && w.trim() !== '')
+
+	const domains = [
+		...new Set(websites.map(domainHost).filter((h): h is string => h != null)),
+	]
+	const cores = names.map(nameCore).filter(c => c.length >= 4)
+	const words = [
+		...new Set([
+			...names.flatMap(distinctiveWords),
+			...domains.map(domainLabelOf).filter((d): d is string => d != null),
+		]),
+	]
+
+	if (cores.length === 0 && words.length === 0 && domains.length === 0)
+		return null
+	return { cores, words, domains }
+}
+
+export type EntityMatch = 'strong' | 'weak' | 'absent'
+
+/**
+ * Classifies how strongly the evidence corpus concerns the target. `corpus` is
+ * the evidence-only text (scraped pages + tool results), never the model's prose.
+ */
+export const classifyEntityMatch = (
+	targets: EntityTargets,
+	corpus: string,
+): EntityMatch => {
+	const lowerCorpus = corpus.toLowerCase()
+	const collapsed = collapse(corpus)
+	// Reaching the target's own site (its exact host appears in the text) or a
+	// page that spells the whole name is a strong signal the run landed on it.
+	const strong =
+		targets.domains.some(host => lowerCorpus.includes(host)) ||
+		targets.cores.some(core => collapsed.includes(core))
+	if (strong) return 'strong'
+	// A lone distinctive word is a weak signal — the target may be mentioned, but
+	// the run never clearly landed on it.
+	const weak = targets.words.some(word => collapsed.includes(word))
+	return weak ? 'weak' : 'absent'
+}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -23,8 +23,14 @@ import { SqlClient } from 'effect/unstable/sql'
 import { AcceptedCountry } from '../domain/country'
 import type { ResolvedPolicy } from '../domain/types'
 import { runAgentResearchLoop } from './agent-loop'
+import { filterApplicableProposals } from './applicability-guard'
 import { makeBudgetLayer } from './budget'
 import { validateFindingCitations } from './citation-guard'
+import {
+	classifyEntityMatch,
+	deriveEntityTargets,
+	type EntityMatch,
+} from './entity-guard'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
 	AgentLanguageModel,
@@ -894,6 +900,29 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						? yield* snapshotSubjects(context.subjects)
 						: []
 
+					// The keys that prove the fetched evidence is about the requested
+					// company (its name or its own domain). A scan or freeform run with
+					// no anchored subject is not entity-gated (targets is null). The
+					// verdict is computed from the phase-1 evidence below and, on resume,
+					// read back from the row so the weak-match handling survives a restart.
+					const entityTargets = deriveEntityTargets({
+						schemaName,
+						query: (run as { query: string }).query,
+						subjects: subjects.map(s => {
+							const row = s.snapshot as Record<string, unknown>
+							return {
+								table: s.table,
+								name: typeof row['name'] === 'string' ? row['name'] : undefined,
+								website:
+									typeof row['website'] === 'string'
+										? row['website']
+										: undefined,
+							}
+						}),
+					})
+					let entityMatch: EntityMatch | null =
+						(run as { entityMatch?: EntityMatch | null }).entityMatch ?? null
+
 					// A follow-up run performs one approved paid call instead of the
 					// normal research loop, then merges the result onto the origin run.
 					if ((run as { kind?: string }).kind === 'followup') {
@@ -1095,6 +1124,21 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 										tr =>
 											`[${tr.name}] ${boundedToolResult(tr.encodedResult ?? tr.result)}`,
 									)
+									// Record each fetch the model gave up on (a dead URL, a
+									// provider 4xx) so the skipped page shows in the run's tool
+									// log; the run keeps going and only fails if nothing grounds it.
+									for (const tr of response.toolResults) {
+										if (!tr.isFailure) continue
+										yield* Ref.update(toolLog, log => [
+											...log,
+											{
+												timestamp: DateTime.nowUnsafe().toString(),
+												type: 'result' as const,
+												tool: tr.name,
+												error: boundedToolResult(tr.encodedResult ?? tr.result),
+											},
+										])
+									}
 									yield* emitRound(
 										round,
 										response.text.length,
@@ -1129,10 +1173,47 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						tokensIn = loopResult.tokensIn
 						tokensOut = loopResult.tokensOut
 
+						// Entity grounding gate: from the fetched evidence alone (never the
+						// model's prose), classify how strongly the pages concern the
+						// requested company. Nothing about the target → fail closed now,
+						// before spending phase 2/3, so the run cannot report another
+						// company's data as a success. Strong/weak is carried into phase 2.
+						entityMatch = entityTargets
+							? classifyEntityMatch(
+									entityTargets,
+									[evidenceText, ...scrapeCorpus].join('\n'),
+								)
+							: null
+						if (entityMatch === 'absent') {
+							const absentToolLog = yield* Ref.get(toolLog)
+							yield* sql`
+								UPDATE research_runs
+								SET status = 'no_reliable_data',
+									phase = 1,
+									findings = ${JSON.stringify({
+										error:
+											'The fetched pages were not about the requested company, so the findings could not be grounded.',
+										reason: 'no_reliable_data',
+									})},
+									tool_log = ${JSON.stringify(absentToolLog)},
+									completed_at = now(),
+									updated_at = now()
+								WHERE id = ${researchId} AND status = 'running'
+							`
+							yield* publishEvent(researchId, 'run.no_reliable_data', {
+								reason: 'entity_mismatch',
+							})
+							const parentGroupId = (run as { parentId: string | null })
+								.parentId
+							if (parentGroupId) yield* rollupParentLocked(parentGroupId)
+							return
+						}
+
 						yield* sql`
 							UPDATE research_runs
 							SET phase = 1,
 								research_text = ${researchText},
+								entity_match = ${entityMatch},
 								tokens_in = ${tokensIn},
 								tokens_out = ${tokensOut},
 								updated_at = now()
@@ -1234,6 +1315,86 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									research_id: researchId,
 									dropped_proposals: valueCheck.droppedProposals,
 									stripped_values: valueCheck.strippedValues,
+								}),
+							)
+						}
+						// A weak entity match means the fetched pages only glancingly
+						// mention the target: keep the brief but withhold every CRM write
+						// and flag the low confidence, so a reviewer treats these findings
+						// with care rather than trusting an auto-applied update.
+						if (
+							entityMatch === 'weak' &&
+							findings != null &&
+							typeof findings === 'object' &&
+							!Array.isArray(findings)
+						) {
+							const current = findings as Record<string, unknown>
+							const strippedProposals = Array.isArray(
+								current['proposed_updates'],
+							)
+								? (current['proposed_updates'] as unknown[]).length
+								: 0
+							findings = {
+								...current,
+								proposed_updates: [],
+								entity_confidence: 'low',
+							}
+							yield* Effect.logWarning('research.entity.weak').pipe(
+								Effect.annotateLogs({
+									research_id: researchId,
+									stripped_proposals: strippedProposals,
+								}),
+							)
+						}
+						// Applicability: drop any proposed CRM update that could never be
+						// applied — an update whose subject_id names no live row (the model
+						// can invent one for a company that does not exist), or a proposal
+						// whose fields carry no real values. Existence is checked against
+						// the org's own rows; a malformed id trips a cast error read as
+						// "not found".
+						const organizationId = (run as { organizationId: string })
+							.organizationId
+						const proposalList =
+							findings != null &&
+							typeof findings === 'object' &&
+							!Array.isArray(findings)
+								? (findings as Record<string, unknown>)['proposed_updates']
+								: undefined
+						const liveSubjects = new Set<string>()
+						if (Array.isArray(proposalList)) {
+							for (const proposal of proposalList) {
+								if (proposal == null || typeof proposal !== 'object') continue
+								const pu = proposal as Record<string, unknown>
+								if (pu['operation'] === 'create') continue
+								const table = pu['subject_table']
+								const id = pu['subject_id']
+								if (
+									(table !== 'companies' && table !== 'contacts') ||
+									typeof id !== 'string' ||
+									id.trim() === '' ||
+									liveSubjects.has(`${table}:${id}`)
+								)
+									continue
+								const rows = yield* sql`
+									SELECT id FROM ${sql(table)}
+									WHERE id = ${id}
+										AND organization_id = ${organizationId}
+										AND deleted_at IS NULL
+									LIMIT 1
+								`.pipe(Effect.catchTag('SqlError', () => Effect.succeed([])))
+								if (rows.length > 0) liveSubjects.add(`${table}:${id}`)
+							}
+						}
+						const applicability = filterApplicableProposals(
+							findings,
+							(table, id) => liveSubjects.has(`${table}:${id}`),
+						)
+						findings = applicability.findings
+						if (applicability.dropped > 0) {
+							yield* Effect.logWarning('research.proposals.unappliable').pipe(
+								Effect.annotateLogs({
+									research_id: researchId,
+									dropped: applicability.dropped,
 								}),
 							)
 						}

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer, Schema, Stream } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { NoRegistry, type ProviderError } from '../domain/errors'
+import { NoRegistry, ProviderError } from '../domain/errors'
 import { RegistryRecord, ScrapedPage, SearchResult } from '../domain/types'
 import { StubExtractProvider } from '../infrastructure/stub/extract'
 import { StubRegistryEsProvider } from '../infrastructure/stub/registry-es'
@@ -181,6 +181,63 @@ const registryLookupResult = async (
 		),
 	)
 	return results[results.length - 1]?.result
+}
+
+// Drive a web-fetch tool with a failing provider and return the final stream
+// element, so a test can assert the model saw a failure (isFailure) rather than
+// the run fiber being aborted.
+const scrapePageResult = async (
+	scrape: (input: ScrapeInput) => Effect.Effect<ScrapedPage, ProviderError>,
+	params: { url: string },
+): Promise<{ result: unknown; isFailure: boolean }> => {
+	const ports = Layer.mergeAll(
+		Layer.succeed(ScrapeProvider)(ScrapeProvider.of({ scrape })),
+		StubSearchProvider,
+		StubExtractProvider,
+		StubRegistryEsProvider,
+	)
+	const results = await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('scrape_page', params)
+			return yield* Stream.runCollect(stream)
+		}).pipe(
+			Effect.provide(
+				researchToolkitLayer.pipe(
+					Layer.provide(Layer.mergeAll(ports, testInfra)),
+				),
+			),
+		),
+	)
+	const last = results[results.length - 1]
+	return { result: last?.result, isFailure: last?.isFailure ?? false }
+}
+
+const webSearchResult = async (
+	search: (input: SearchInput) => Effect.Effect<SearchResult, ProviderError>,
+	params: { query: string },
+): Promise<{ result: unknown; isFailure: boolean }> => {
+	const ports = Layer.mergeAll(
+		Layer.succeed(SearchProvider)(SearchProvider.of({ search })),
+		StubScrapeProvider,
+		StubExtractProvider,
+		StubRegistryEsProvider,
+	)
+	const results = await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('web_search', params)
+			return yield* Stream.runCollect(stream)
+		}).pipe(
+			Effect.provide(
+				researchToolkitLayer.pipe(
+					Layer.provide(Layer.mergeAll(ports, testInfra)),
+				),
+			),
+		),
+	)
+	const last = results[results.length - 1]
+	return { result: last?.result, isFailure: last?.isFailure ?? false }
 }
 
 const extractInput = async (params: {
@@ -603,6 +660,53 @@ describe('discover_contacts handler — delegates to the shared ContactDiscovery
 
 			// THEN the null folds to "not provided"
 			expect(input.country).toBeUndefined()
+		})
+	})
+})
+
+describe('researchToolkit — a web-fetch failure is non-fatal', () => {
+	describe('scrape_page handler', () => {
+		describe('when the scrape provider fails with a ProviderError', () => {
+			it('should surface the failure to the model instead of aborting the run', async () => {
+				// GIVEN a scrape provider that rejects the page with a 401
+				const { isFailure } = await scrapePageResult(
+					() =>
+						Effect.fail(
+							new ProviderError({
+								provider: 'firecrawl',
+								message: 'scrape failed: HTTP 401',
+								recoverable: false,
+							}),
+						),
+					{ url: 'https://dead.example' },
+				)
+
+				// THEN handling completes and the last result is a failure the model
+				// can read — the fiber running generateText is never killed
+				expect(isFailure).toBe(true)
+			})
+		})
+	})
+
+	describe('web_search handler', () => {
+		describe('when the search provider fails with a ProviderError', () => {
+			it('should surface the failure to the model instead of aborting the run', async () => {
+				// GIVEN a search provider that returns a 422
+				const { isFailure } = await webSearchResult(
+					() =>
+						Effect.fail(
+							new ProviderError({
+								provider: 'brave',
+								message: 'search failed: HTTP 422',
+								recoverable: false,
+							}),
+						),
+					{ query: 'acme corp' },
+				)
+
+				// THEN the model receives a failure result and the run continues
+				expect(isFailure).toBe(true)
+			})
 		})
 	})
 })

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -114,11 +114,16 @@ const ToolResultSchema = Schema.Unknown
 
 // ── Tool definitions ──
 
+// A failed fetch (a dead URL, a provider 4xx) comes back to the model as a tool
+// result instead of aborting the run, so one unreachable page can't sink a whole
+// research pass — the model reads the error and moves on to another source. Only
+// the two web-fetch tools opt in; budget and registry failures stay fatal.
 export const WebSearchTool = Tool.make('web_search', {
 	description:
 		'Search the public web for URLs relevant to a query. Returns a list of (url, title, snippet). Prefer this over scrape_page when you do not yet have a specific URL.',
 	parameters: WebSearchParams,
 	success: ToolResultSchema,
+	failureMode: 'return',
 })
 
 export const ScrapePageTool = Tool.make('scrape_page', {
@@ -126,6 +131,7 @@ export const ScrapePageTool = Tool.make('scrape_page', {
 		'Fetch and parse a specific URL, returning markdown plus metadata. Use only after web_search has surfaced a concrete URL.',
 	parameters: ScrapePageParams,
 	success: ToolResultSchema,
+	failureMode: 'return',
 })
 
 export const ExtractStructuredTool = Tool.make('extract_structured', {

--- a/packages/research/src/domain/types.ts
+++ b/packages/research/src/domain/types.ts
@@ -75,7 +75,6 @@ export class RegistryRecord extends Schema.Class<RegistryRecord>(
 			}),
 		),
 	),
-	raw: Schema.optional(Schema.Unknown),
 	units: Schema.Number,
 }) {}
 

--- a/packages/research/src/infrastructure/companies-house/registry.test.ts
+++ b/packages/research/src/infrastructure/companies-house/registry.test.ts
@@ -177,6 +177,17 @@ describe('makeCompaniesHouseRegistry', () => {
 			expect(log.count).toBe(2)
 		})
 
+		it('should not expose the raw provider payload or any resigned officer', async () => {
+			// GIVEN the same lookup whose officers include a resigned director
+			const { exit } = runLookup({ country: 'GB', taxId: '12345678' }, routeOk)
+			// WHEN the record is built
+			const rec = recordOf(await exit)
+			// THEN there is no raw passthrough, and the resigned officer that used
+			// to ride along in raw.officers is nowhere in the record
+			expect(Object.keys(rec ?? {})).not.toContain('raw')
+			expect(JSON.stringify(rec)).not.toContain('OLD')
+		})
+
 		it('should authenticate with the key as the Basic username', async () => {
 			// GIVEN any successful lookup with key "chkey"
 			const { exit, log } = runLookup(

--- a/packages/research/src/infrastructure/companies-house/registry.ts
+++ b/packages/research/src/infrastructure/companies-house/registry.ts
@@ -191,7 +191,6 @@ export const makeCompaniesHouseRegistry = (slot: number) =>
 								role: o.officer_role ?? undefined,
 								since: o.appointed_on ?? undefined,
 							})),
-							raw: { profile, officers },
 							units: 1,
 						})
 					}),

--- a/packages/research/src/infrastructure/librebor/registry.test.ts
+++ b/packages/research/src/infrastructure/librebor/registry.test.ts
@@ -167,6 +167,17 @@ describe('makeLibreborRegistry', () => {
 		expect(log.count).toBe(1)
 	})
 
+	it('should not expose the raw provider payload', async () => {
+		// GIVEN a resolved NIF lookup
+		const { exit } = runLookup({ country: 'ES', taxId: 'A46103834' }, () => ({
+			status: 200,
+			body: companyBody(),
+		}))
+		// THEN the parsed record carries no raw passthrough duplicating its fields
+		const rec = recordOf(await exit)
+		expect(Object.keys(rec ?? {})).not.toContain('raw')
+	})
+
 	it('should send HTTP Basic auth from the AccessId:AccessKey pair', async () => {
 		// GIVEN any successful lookup with the credential pair "id:key"
 		const { exit, log } = runLookup(

--- a/packages/research/src/infrastructure/librebor/registry.ts
+++ b/packages/research/src/infrastructure/librebor/registry.ts
@@ -129,7 +129,6 @@ export const makeLibreborRegistry = (slot: number) =>
 					role: p.role ?? undefined,
 					since: p.date_from ?? undefined,
 				})),
-				raw: company,
 				units: 1,
 			})
 


### PR DESCRIPTION
## What

This is the second half of issue #199's post-grounding punch-list for the **Research** feature (the server-side agent that gathers company intelligence). It makes a research run's *outcome* trustworthy: a run now fails honestly when it couldn't actually find the company it was asked about, keeps going when a single page won't load, and stops cluttering the review queue with suggestions that could never be applied. It also drops a bloated payload the company-registry lookup was sending to clients.

Four of the six #199 findings land here (C, D, E, G). The blocker (A, the Firecrawl scrape key) was already fixed by rotating the key; the web-search fix (B) and the observability gap (F) shipped in earlier releases. The provider-key deploy-gate (H) is intentionally deferred.

## Changes

- **A failed page fetch no longer kills the run (G).** A dead URL or a provider 4xx used to abort the whole research pass. The failure is now handed back to the model as a tool result; the run continues and only ends as "no reliable data" when nothing at all could be fetched to ground its findings.
- **A run is grounded in the company it was asked about (C).** From the fetched pages alone (never the model's own words), a run is graded: clearly about the target → succeeds; only a weak name match → still succeeds but withholds its proposed CRM changes and is flagged low-confidence; not about the target at all → stopped as "no reliable data" instead of reporting another company's data as if it were the target's. A new `entity_match` column records the verdict so this survives a restart mid-run.
- **Un-appliable CRM suggestions are dropped (D).** When a run produces them, a suggestion that points at a company row that does not exist, or that carries column names instead of real values, is removed before it reaches the review list. And when a suggestion *is* applied, an invented (non-UUID) target id is now reported as an invalid suggestion instead of crashing the request on a database type error.
- **The company registry stops over-sending (E).** A registry lookup no longer ships a large untouched copy of the provider's response next to the parsed fields; for the UK that copy even re-listed officers who had resigned years ago.

## Impact

- **Migration — must run before the next server release.** `0025_research_run_entity_match` adds a nullable `research_runs.entity_match` column. The deploy does **not** run migrations, so apply this to prod **before** tagging the server, or the new code boots against a schema without the column. Non-destructive (`ADD COLUMN IF NOT EXISTS`).
- **Wire-shape (MCP clients).** `RegistryRecord` no longer has a `raw` field — the `lookup_registry` MCP tool and the in-run registry lookup return a slimmer payload (the parsed fields are unchanged). Research findings can now carry an `entity_confidence: "low"` marker on a weak-match run.
- **Behavior change reviewers should expect.** Some query-only enrichment runs that previously *succeeded* with misattributed data will now return `no_reliable_data` (a non-existent or unfindable company), and a real company matched only weakly will succeed without auto-suggesting CRM writes. This is the intended fix, but it changes outcomes.
- **Tenant isolation preserved.** The new existence check and the apply-path update are scoped by the run's `organization_id`, so a suggestion can never confirm or touch another org's row — even though the research fiber runs under a privileged role.
- **MCP + HTTP parity.** All changes live in the shared research service / apply path, so both the MCP tools and the HTTP handlers get the same behavior.
- No new environment variables.

## Review guide

- **Start with `entity-guard.ts`** — the deterministic name/domain matcher and its strong / weak / absent bands. This is the most judgement-heavy part; the thresholds (which industry words count as "generic", the pre-comma query-name heuristic) are tunable and the place I'd most welcome an overrule. Unit-tested for each band + diacritics.
- **The security-relevant lines** are the org-scoped existence `SELECT` in `research-service.ts` (the applicability wiring) and the org-scoped `occUpdate` in `research-apply.ts` — both filter on the run's `organization_id`.
- I relied on a thorough self-review plus the integration suite below rather than a separate `/code-review` pass; say the word if you'd like one before merge.
- The registry change (E) and the `pgErrorCode` helper are mechanical — skim-able.

## Tests

- Unit: new `entity-guard` (each band, diacritics, applicability) and `applicability-guard` (drop/keep matrix); `tools` (a failed fetch surfaces as a non-fatal tool result); registry adapters (no `raw`, no resigned-officer leak).
- Integration (live Postgres): the entity gate end to end — absent → `no_reliable_data`, strong → succeeds with its proposal, weak → succeeds flagged with proposals stripped, failed-only scrape → `no_reliable_data` (not failed); the apply path reports a non-UUID subject as `invalid`; the existing grounding + dispatch suites still pass (grounding updated to seed a real contact, since a fake id is now correctly dropped).

## Verification

- `pnpm check-types` (13/13), `pnpm test` (server 548, research 296), `pnpm build` (13/13) — all green on the final commit.
- 9 research integration tests green against the live `batuda_it` database.

## Deferred

- **H — a boot/deploy check that fails a release when a provider key is unauthorized.** Not in this PR; the blocker it would have caught (the Firecrawl scrape 401) is already fixed by rotating the key. Fileable as a follow-up.

Addresses #199 (findings C, D, E, G). Not auto-closing — finding H remains open.
