### PR TITLE
cicd: keep the changelog header version in step with the release tag

### DIFF
--- a/.release-it.internal.cjs
+++ b/.release-it.internal.cjs
@@ -2,6 +2,7 @@ const {
 	getCommitPathsArray,
 	changelogPreset,
 	changelogHeader,
+	changelogWriterOpts,
 } = require('./scripts/release-utils.cjs')
 
 module.exports = {
@@ -34,9 +35,7 @@ module.exports = {
 			ignoreRecommendedBump: true,
 			infile: 'apps/internal/CHANGELOG.md',
 			preset: changelogPreset,
-			writerOpts: {
-				headerPartial: '## {{date}} ({{currentTag}})\n',
-			},
+			writerOpts: changelogWriterOpts,
 		},
 	},
 }

--- a/.release-it.mail-worker.cjs
+++ b/.release-it.mail-worker.cjs
@@ -2,6 +2,7 @@ const {
 	getCommitPathsArray,
 	changelogPreset,
 	changelogHeader,
+	changelogWriterOpts,
 } = require('./scripts/release-utils.cjs')
 
 module.exports = {
@@ -34,9 +35,7 @@ module.exports = {
 			ignoreRecommendedBump: true,
 			infile: 'apps/mail-worker/CHANGELOG.md',
 			preset: changelogPreset,
-			writerOpts: {
-				headerPartial: '## {{date}} ({{currentTag}})\n',
-			},
+			writerOpts: changelogWriterOpts,
 		},
 	},
 }

--- a/.release-it.server.cjs
+++ b/.release-it.server.cjs
@@ -2,6 +2,7 @@ const {
 	getCommitPathsArray,
 	changelogPreset,
 	changelogHeader,
+	changelogWriterOpts,
 } = require('./scripts/release-utils.cjs')
 
 module.exports = {
@@ -34,9 +35,7 @@ module.exports = {
 			ignoreRecommendedBump: true,
 			infile: 'apps/server/CHANGELOG.md',
 			preset: changelogPreset,
-			writerOpts: {
-				headerPartial: '## {{date}} ({{currentTag}})\n',
-			},
+			writerOpts: changelogWriterOpts,
 		},
 	},
 }

--- a/.release-it.ui.cjs
+++ b/.release-it.ui.cjs
@@ -2,6 +2,7 @@ const {
 	getCommitPathsArray,
 	changelogPreset,
 	changelogHeader,
+	changelogWriterOpts,
 } = require('./scripts/release-utils.cjs')
 
 module.exports = {
@@ -34,9 +35,7 @@ module.exports = {
 			ignoreRecommendedBump: true,
 			infile: 'packages/ui/CHANGELOG.md',
 			preset: changelogPreset,
-			writerOpts: {
-				headerPartial: '## {{date}} ({{currentTag}})\n',
-			},
+			writerOpts: changelogWriterOpts,
 		},
 	},
 }

--- a/scripts/release-calver-plugin.cjs
+++ b/scripts/release-calver-plugin.cjs
@@ -1,5 +1,7 @@
 const { Plugin } = require('release-it')
 
+const { computeCalverVersion } = require('./release-utils.cjs')
+
 class CalVerPlugin extends Plugin {
 	static disablePlugin() {
 		return ['version']
@@ -10,32 +12,11 @@ class CalVerPlugin extends Plugin {
 	}
 
 	getIncrementedVersionCI({ latestVersion }) {
-		return this._computeNextVersion(latestVersion)
+		return computeCalverVersion(latestVersion)
 	}
 
 	getIncrementedVersion({ latestVersion }) {
-		return this._computeNextVersion(latestVersion)
-	}
-
-	_computeNextVersion(latestVersion) {
-		const now = new Date()
-		const year = now.getFullYear()
-		const month = now.getMonth() + 1
-		const day = now.getDate()
-		const todayPrefix = `${year}.${month}.${day}`
-
-		if (latestVersion) {
-			// Accept "YYYY.M.D" or "YYYY.M.D-N". Same-day bumps use the -N
-			// prerelease suffix so the base remains valid 3-segment SemVer,
-			// which is what pnpm's workspace resolver requires.
-			const match = latestVersion.match(/^(\d+\.\d+\.\d+)(?:-(\d+))?$/)
-			if (match && match[1] === todayPrefix) {
-				const n = match[2] === undefined ? 1 : parseInt(match[2], 10) + 1
-				return `${todayPrefix}-${n}`
-			}
-		}
-
-		return todayPrefix
+		return computeCalverVersion(latestVersion)
 	}
 }
 

--- a/scripts/release-utils.cjs
+++ b/scripts/release-utils.cjs
@@ -81,9 +81,55 @@ const changelogPreset = {
 const changelogHeader =
 	'# Changelog\n\nAll notable changes to this project will be documented in this file.\n'
 
+// The release version is the date (YYYY.M.D). A second release on the same day
+// gets a "-N" suffix so the base stays a valid 3-segment SemVer, which pnpm's
+// workspace resolver requires. This is the single source of truth for the
+// version — used by both the release-it version plugin and the changelog
+// finalizeContext below, so the two can never disagree.
+function computeCalverVersion(latestVersion) {
+	const now = new Date()
+	const todayPrefix = `${now.getFullYear()}.${now.getMonth() + 1}.${now.getDate()}`
+	if (latestVersion) {
+		const match = latestVersion.match(/^(\d+\.\d+\.\d+)(?:-(\d+))?$/)
+		if (match && match[1] === todayPrefix) {
+			const n = match[2] === undefined ? 1 : parseInt(match[2], 10) + 1
+			return `${todayPrefix}-${n}`
+		}
+	}
+	return todayPrefix
+}
+
+// The changelog writer fills the header's {{currentTag}} from a standard SemVer
+// bump of the last version (a feature is a minor bump), which disagrees with the
+// date-based version the release actually tags — so a release with a feature
+// previewed the wrong number in the header. This rewrites the render context to
+// the date-based version, keeping the header in step with the tag. The previous
+// tag (e.g. "server-v2026.7.7-1") supplies both the tag prefix and the version to
+// bump from.
+function calverFinalizeContext(context) {
+	const priorTag = context.previousTag || context.currentTag || ''
+	const match = priorTag.match(/^(.*?v)(\d.*)$/)
+	if (match) {
+		const version = computeCalverVersion(match[2])
+		context.version = version
+		context.currentTag = `${match[1]}${version}`
+	}
+	return context
+}
+
+// Shared changelog writer options for every target's release config, so the
+// header template and the version-alignment fix live in one place.
+const changelogWriterOpts = {
+	headerPartial: '## {{date}} ({{currentTag}})\n',
+	finalizeContext: calverFinalizeContext,
+}
+
 module.exports = {
 	getCommitPaths,
 	getCommitPathsArray,
 	changelogPreset,
 	changelogHeader,
+	computeCalverVersion,
+	calverFinalizeContext,
+	changelogWriterOpts,
 }


### PR DESCRIPTION
## What

The release **changelog** and the release **tag** compute their version two different ways, and they silently disagree whenever a release contains a `feat` commit. This aligns them, for all four release targets (server / internal / ui / mail-worker).

- **Tag** comes from the custom CalVer plugin → today's date, e.g. `server-v2026.7.8`.
- **Changelog header** was filled by the conventional-changelog writer from a standard **SemVer** bump of the last version — and a feature is a *minor* bump, so `2026.7.7` → `2026.8.0`.

On a fix-only release the SemVer bump is a *patch* (`2026.7.7` → `2026.7.8`), which coincidentally equals the next day's CalVer — so the two agreed by accident and nobody noticed. The `feat:` in last release (`server-v2026.7.8`) broke the coincidence and the changelog **preview** showed `server-v2026.8.0`.

Note: the changelog *file* that was actually committed was already correct — the plugin regenerates it with release-it's final version via its `bump()` pass. Only the dry-run **preview** showed the wrong number. This PR fixes that preview and, more importantly, removes the latent desync so the two version calculators can never drift again.

## The fix

- Extracted the CalVer date-version calculation into **one shared helper** (`computeCalverVersion` in `scripts/release-utils.cjs`), used by *both* the version plugin and the changelog — so they can't compute different versions.
- Added a shared `finalizeContext` (a supported `conventional-changelog-writer` v8 hook) that rewrites the changelog render context's `currentTag`/`version` to the same CalVer version the tag uses, derived from the previous tag.
- Pointed all four release configs at a shared `changelogWriterOpts` (header template + the hook), replacing the duplicated inline `writerOpts`.

## Impact

- **Release tooling only** — no application code, no runtime behavior, no schema. Nothing in `apps/` or `packages/` imports these files.
- Already-published changelogs/releases were correct; this makes the **preview** correct and the alignment **robust** across all targets.

## Verification

- **Deterministic unit checks:** `computeCalverVersion` still bumps correctly (prior-day → today; same-day → `-N`), and `finalizeContext` rewrites `currentTag`/`version` to the matching CalVer value for every tag format — including `server-v`, whose own internal "v" must not fool the prefix split — and equals the plugin's tag version by construction.
- **Clean end-to-end dry-run** (no tag manipulation, a `feat` commit in range): the preview header now renders `## 2026-07-08 (server-v2026.7.8-1)` — matching the tag the release would create — instead of `server-v2026.8.0`.

Follow-up from the `server-v2026.7.8` release; not tied to an open issue.
