### PR TITLE
fix(research): keep a rejected page extraction from failing the run

### DIFF
--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -213,6 +213,33 @@ const scrapePageResult = async (
 	return { result: last?.result, isFailure: last?.isFailure ?? false }
 }
 
+const extractStructuredResult = async (
+	extract: (input: ExtractInput) => Effect.Effect<unknown, ProviderError>,
+	params: { url: string; schema_name: string },
+): Promise<{ result: unknown; isFailure: boolean }> => {
+	const ports = Layer.mergeAll(
+		Layer.succeed(ExtractProvider)(ExtractProvider.of({ extract })),
+		StubSearchProvider,
+		StubScrapeProvider,
+		StubRegistryEsProvider,
+	)
+	const results = await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('extract_structured', params)
+			return yield* Stream.runCollect(stream)
+		}).pipe(
+			Effect.provide(
+				researchToolkitLayer.pipe(
+					Layer.provide(Layer.mergeAll(ports, testInfra)),
+				),
+			),
+		),
+	)
+	const last = results[results.length - 1]
+	return { result: last?.result, isFailure: last?.isFailure ?? false }
+}
+
 const webSearchResult = async (
 	search: (input: SearchInput) => Effect.Effect<SearchResult, ProviderError>,
 	params: { query: string },
@@ -705,6 +732,29 @@ describe('researchToolkit — a web-fetch failure is non-fatal', () => {
 				)
 
 				// THEN the model receives a failure result and the run continues
+				expect(isFailure).toBe(true)
+			})
+		})
+	})
+
+	describe('extract_structured handler', () => {
+		describe('when the extract provider fails with a forbidden ProviderError', () => {
+			it('should surface the failure to the model instead of aborting the run', async () => {
+				// GIVEN an extract provider that rejects the page with a 403 (forbidden)
+				const { isFailure } = await extractStructuredResult(
+					() =>
+						Effect.fail(
+							new ProviderError({
+								provider: 'firecrawl',
+								message: 'extract failed: HTTP 403',
+								recoverable: false,
+							}),
+						),
+					{ url: 'https://acmecorp.es', schema_name: 'freeform' },
+				)
+
+				// THEN the model reads the failure and moves on — the generateText
+				// fiber is not killed, so one forbidden page can't sink the whole run
 				expect(isFailure).toBe(true)
 			})
 		})

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -115,9 +115,10 @@ const ToolResultSchema = Schema.Unknown
 // ── Tool definitions ──
 
 // A failed fetch (a dead URL, a provider 4xx) comes back to the model as a tool
-// result instead of aborting the run, so one unreachable page can't sink a whole
-// research pass — the model reads the error and moves on to another source. Only
-// the two web-fetch tools opt in; budget and registry failures stay fatal.
+// result instead of aborting the run, so one unreachable page or a forbidden
+// extraction can't sink a whole research pass — the model reads the error and
+// moves on to another source. All three web-fetch tools (search, scrape, extract)
+// opt in; budget and registry failures stay fatal.
 export const WebSearchTool = Tool.make('web_search', {
 	description:
 		'Search the public web for URLs relevant to a query. Returns a list of (url, title, snippet). Prefer this over scrape_page when you do not yet have a specific URL.',
@@ -139,6 +140,7 @@ export const ExtractStructuredTool = Tool.make('extract_structured', {
 		'Re-extract a page into a named structured schema. Use when downstream consumers need typed fields rather than prose.',
 	parameters: ExtractStructuredParams,
 	success: ToolResultSchema,
+	failureMode: 'return',
 })
 
 export const RegistryLookupTool = Tool.make('registry_lookup', {


### PR DESCRIPTION
## What

When the research agent (the **Research** bounded context, `packages/research`) tried to pull structured data off a page and the provider refused it, that single refusal killed the **entire** research run — the person got a failed run instead of a brief. This makes that one tool failure survivable: the agent reads the error and keeps going with its other sources, exactly like the other web-fetch tools already do.

Concretely, `extract_structured` (the tool that re-reads a page into typed fields via Firecrawl) was the only web-fetch tool missing `failureMode: 'return'`. Without it, a non-recoverable provider error — in production, a Firecrawl **HTTP 403** — escaped the model call (`generateText`) and marked the whole run `failed`, with no retry and no fallback.

## The fix

- Gave `extract_structured` the same `failureMode: 'return'` its siblings `web_search` and `scrape_page` already carry, so a failed extraction comes back to the model as a tool result instead of aborting the run. The agent then falls back to another source, and the run can still ground on `web_search` content and produce a brief.
- This is defense-in-depth, independent of the underlying key problem: even a genuinely plan-gated or forbidden extraction on one page can no longer sink a run.

## Impact (blast radius)

- **Behavioral, no schema/wire/env change.** No migration, no new env var, no API shape change, no RLS/auth surface touched.
- **MCP + HTTP parity:** research runs the same way regardless of transport; this changes the in-loop tool-failure handling for every research run on both.
- **Cost:** a failed extract still pre-charges the cheap-tool budget for that attempt (unchanged — same as scrape/search); the reflect loop's step cap bounds retries. No new spend behavior.

## Root cause (separate from this fix)

The production 403s were **not** the json-extraction plan-gate the issue hypothesized. Fresh probes of the current keys return 200 for markdown scrape, markdown extract, **and** json extract. The real cause was that `RESEARCH_API_KEY_SCRAPE` and `RESEARCH_API_KEY_EXTRACT` were both revoked/invalid (403), while `RESEARCH_API_KEY_SEARCH` stayed healthy. Those two keys have since been re-issued and verified.

**The prod unblock is a redeploy, not this PR:** the Firecrawl keys are read at boot (`Config.redacted` in `providers-live.ts`), and prod has not redeployed since before the rotation — so it's still holding the old 403ing keys. A `/release server` is what makes prod pick up the re-issued keys. This PR just makes the run resilient if any extraction is ever forbidden again.

## Review guide

- One real line to review: `failureMode: 'return'` on `ExtractStructuredTool` in `packages/research/src/application/tools.ts`. The comment above the tool block was updated to say all three web-fetch tools now opt in.
- The rest is one mirrored test (`extractStructuredResult` + a non-fatal 403 case) that copies the existing `scrapePageResult` / `webSearchResult` helpers verbatim in shape.
- **Not run:** no `/code-review` / `/security-review` — the change is a one-flag alignment with two already-tested sibling tools on a non-sensitive surface (no auth/RLS/crypto/parser/upload). Self-read only.

## Tests

- Added a non-fatal test that drives the **real** toolkit (`researchToolkit.handle('extract_structured', …)`) with a provider that fails with a 403 and asserts the result surfaces to the model (`isFailure: true`) rather than aborting the fiber — mirroring the existing scrape/search non-fatal tests. Rides in the same commit as the fix.

## Verification

- `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (all workspace suites green, incl. `@batuda/research` 297 tests + the new one), `pnpm -w build` — all run locally and green.
- Live proof of the exact mechanism, not just tests: in the failing prod run (`03dc82bb…`, Honeycomb trace `7244441b…`), a `scrape failed: HTTP 403` was **non-fatal** (it has `failureMode: 'return'`) while an identical `extract failed: HTTP 403` **killed** `generateText`. This fix makes extract behave like scrape. The 403 path can't be reproduced against the live stack now that the keys return 200, so the toolkit-level behavioral test is the faithful check.

## Deferred

- Re-issuing the keys and the `/release server` that loads them are ops actions tracked in #211, outside this PR.

Closes #211
