### PR TITLE
fix(research): fail closed on weak entity match + strip page-builder markup

### DIFF
--- a/apps/server/src/db/migrations/0025_research_run_entity_match.ts
+++ b/apps/server/src/db/migrations/0025_research_run_entity_match.ts
@@ -2,10 +2,10 @@ import { Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 // How strongly a completed run's fetched evidence was about the company it
-// researched: 'strong' | 'weak' | null. A weak run keeps its brief but withholds
-// CRM writes and is flagged low-confidence; the verdict is stored so that
-// handling survives a resume after a crash. Null means the run was not
-// entity-gated (a scan or freeform run whose findings are about third parties).
+// researched: 'strong' | 'weak' | 'absent' | null. Only a strong match proceeds;
+// a weak or absent run fails closed to no_reliable_data, and the verdict is stored
+// so a reviewer can tell the two apart. Null means the run was not entity-gated
+// (a scan or freeform run whose findings are about third parties).
 
 export default Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient

--- a/apps/server/src/services/research-entity-gate.integration.test.ts
+++ b/apps/server/src/services/research-entity-gate.integration.test.ts
@@ -33,8 +33,9 @@ import { enterOrgScope } from '../middleware/org.js'
 // The entity grounding gate end to end: an enrichment run whose fetched evidence
 // is about a DIFFERENT company must fail closed to no_reliable_data; one that
 // clearly names the target must still succeed; a run that only glancingly
-// mentions it succeeds but is flagged low-confidence with its CRM writes stripped;
-// and a run whose only scrape FAILS must resolve to no_reliable_data, not failed.
+// mentions it (a weak match) must also fail closed to no_reliable_data rather than
+// present a lookalike's profile; and a run whose only scrape FAILS must resolve to
+// no_reliable_data, not failed.
 //
 // One shared ResearchService layer drives every case (a fresh layer per case
 // would start a fresh dispatcher + connection pool each time and exhaust the CI
@@ -244,7 +245,6 @@ interface RunResult {
 	readonly sourceCount: number
 	readonly findings: {
 		proposedUpdates?: unknown[]
-		entityConfidence?: string
 	} | null
 }
 
@@ -368,7 +368,7 @@ describe('ResearchService entity grounding gate', () => {
 	})
 
 	describe('when the fetched evidence clearly names the target', () => {
-		it('should succeed and keep its proposal without a low-confidence flag', async () => {
+		it('should succeed and keep its create proposal intact', async () => {
 			// GIVEN an enrichment run whose scrape names the target company in full
 			const result = await runScenario({
 				query: 'Acme Logistics',
@@ -379,20 +379,19 @@ describe('ResearchService entity grounding gate', () => {
 				isFailure: false,
 			})
 
-			// THEN it succeeds with its create proposal intact and no low-confidence flag
+			// THEN it succeeds with its create proposal intact
 			expect(
 				result.status,
 				`unexpected status: ${result.errorMessage ?? '(none)'}`,
 			).toBe('succeeded')
 			expect(result.findings?.proposedUpdates).toHaveLength(1)
-			expect(result.findings?.entityConfidence).toBeUndefined()
 		}, 30_000)
 	})
 
 	describe('when the fetched evidence only glancingly mentions the target', () => {
-		it('should succeed but strip CRM writes and flag low confidence', async () => {
+		it('should fail closed to no_reliable_data instead of presenting a lookalike', async () => {
 			// GIVEN an enrichment run whose scrape mentions the brand word but never
-			//   the full name or the company's own site
+			//   the full name or the company's own site (a weak match)
 			const result = await runScenario({
 				query: 'Acme Logistics',
 				schemaName: 'company_enrichment_v1',
@@ -401,13 +400,12 @@ describe('ResearchService entity grounding gate', () => {
 				isFailure: false,
 			})
 
-			// THEN it still succeeds, but its proposals are withheld and it is flagged
+			// THEN it fails closed — the evidence never clearly named the target, so no
+			//   lookalike profile is extracted or presented
 			expect(
 				result.status,
 				`unexpected status: ${result.errorMessage ?? '(none)'}`,
-			).toBe('succeeded')
-			expect(result.findings?.proposedUpdates).toHaveLength(0)
-			expect(result.findings?.entityConfidence).toBe('low')
+			).toBe('no_reliable_data')
 		}, 30_000)
 	})
 

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -10,11 +10,11 @@
  *
  * Three verdicts drive the run:
  *  - 'strong'  the target's full name or its own domain appears in the evidence;
- *  - 'weak'    only a distinctive word of the name appears — it might be the
- *              target, so the run still completes, but its CRM writes are withheld
- *              and the findings are flagged low-confidence for the reviewer;
+ *  - 'weak'    only a distinctive word of the name appears — the run never
+ *              clearly landed on the target, so it fails closed as no_reliable_data
+ *              rather than present a lookalike's pages as the target's profile;
  *  - 'absent'  nothing in the evidence names the target — the run is misattributed
- *              and is failed closed as no_reliable_data.
+ *              and also fails closed as no_reliable_data.
  */
 
 // Legal-form suffixes dropped before matching, so "Acme Logistics S.L." and a

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -958,6 +958,37 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					// Tool log accumulator
 					const toolLog = yield* Ref.make<ToolLogEntry[]>([])
 
+					// Fail a run closed as no_reliable_data because its evidence was not clearly
+					// about the requested company. Called by the phase-1 entity gate and again on
+					// resume, where that gate is skipped — so a weak or absent match never reaches
+					// extraction to present a lookalike's profile.
+					const failClosedOnEntity = (verdict: EntityMatch) =>
+						Effect.gen(function* () {
+							const toolLogNow = yield* Ref.get(toolLog)
+							yield* sql`
+								UPDATE research_runs
+								SET status = 'no_reliable_data',
+									phase = 1,
+									entity_match = ${verdict},
+									findings = ${JSON.stringify({
+										error:
+											'The fetched pages were not clearly about the requested company, so the findings could not be grounded.',
+										reason: 'no_reliable_data',
+									})},
+									tool_log = ${JSON.stringify(toolLogNow)},
+									completed_at = now(),
+									updated_at = now()
+								WHERE id = ${researchId} AND status = 'running'
+							`
+							yield* publishEvent(researchId, 'run.no_reliable_data', {
+								reason: verdict === 'weak' ? 'entity_weak' : 'entity_mismatch',
+								entityMatch: verdict,
+							})
+							const parentGroupId = (run as { parentId: string | null })
+								.parentId
+							if (parentGroupId) yield* rollupParentLocked(parentGroupId)
+						})
+
 					// Build system prompt
 					const subjectContext =
 						subjects.length > 0
@@ -1004,12 +1035,10 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					// Phase-2 extraction + every grounding guard, shared so both the
 					// normal path and the discovery-scan retry run the same logic. Returns
 					// cleaned findings and the model's output tokens; the caller writes the
-					// single phase-2 checkpoint. `match` carries the entity verdict for the
-					// weak-match strip (null for a scan, which is never entity-gated).
+					// single phase-2 checkpoint.
 					const extractStructuredFindings = (
 						transcript: string,
 						evidenceCorpus: string,
-						match: EntityMatch | null,
 					) =>
 						Effect.gen(function* () {
 							yield* publishEvent(researchId, 'tool.called', {
@@ -1076,34 +1105,6 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 										research_id: researchId,
 										dropped_proposals: valueCheck.droppedProposals,
 										stripped_values: valueCheck.strippedValues,
-									}),
-								)
-							}
-							// A weak entity match means the fetched pages only glancingly
-							// mention the target: keep the brief but withhold every CRM write
-							// and flag the low confidence, so a reviewer treats these findings
-							// with care rather than trusting an auto-applied update.
-							if (
-								match === 'weak' &&
-								result != null &&
-								typeof result === 'object' &&
-								!Array.isArray(result)
-							) {
-								const current = result as Record<string, unknown>
-								const strippedProposals = Array.isArray(
-									current['proposed_updates'],
-								)
-									? (current['proposed_updates'] as unknown[]).length
-									: 0
-								result = {
-									...current,
-									proposed_updates: [],
-									entity_confidence: 'low',
-								}
-								yield* Effect.logWarning('research.entity.weak').pipe(
-									Effect.annotateLogs({
-										research_id: researchId,
-										stripped_proposals: strippedProposals,
 									}),
 								)
 							}
@@ -1399,7 +1400,6 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								let extracted = yield* extractStructuredFindings(
 									loop.researchText,
 									[loop.evidenceText, ...scrapeCorpus].join('\n'),
-									null,
 								)
 								findings = extracted.findings
 								extractOutputTokens += extracted.outputTokens
@@ -1444,7 +1444,6 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									extracted = yield* extractStructuredFindings(
 										loop.researchText,
 										[loop.evidenceText, ...scrapeCorpus].join('\n'),
-										null,
 									)
 									findings = extracted.findings
 									extractOutputTokens += extracted.outputTokens
@@ -1468,37 +1467,18 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 
 						// Entity grounding gate: from the fetched evidence alone (never the
 						// model's prose), classify how strongly the pages concern the
-						// requested company. Nothing about the target → fail closed now,
-						// before spending phase 2/3, so the run cannot report another
-						// company's data as a success. Strong/weak is carried into phase 2.
+						// requested company. Nothing about the target ('absent'), or only a
+						// glancing mention of it ('weak'), fails closed now — before phase 2
+						// extraction can turn a lookalike's pages into a confident profile.
+						// Only a strong match proceeds.
 						entityMatch = entityTargets
 							? classifyEntityMatch(
 									entityTargets,
 									[evidenceText, ...scrapeCorpus].join('\n'),
 								)
 							: null
-						if (entityMatch === 'absent') {
-							const absentToolLog = yield* Ref.get(toolLog)
-							yield* sql`
-								UPDATE research_runs
-								SET status = 'no_reliable_data',
-									phase = 1,
-									findings = ${JSON.stringify({
-										error:
-											'The fetched pages were not about the requested company, so the findings could not be grounded.',
-										reason: 'no_reliable_data',
-									})},
-									tool_log = ${JSON.stringify(absentToolLog)},
-									completed_at = now(),
-									updated_at = now()
-								WHERE id = ${researchId} AND status = 'running'
-							`
-							yield* publishEvent(researchId, 'run.no_reliable_data', {
-								reason: 'entity_mismatch',
-							})
-							const parentGroupId = (run as { parentId: string | null })
-								.parentId
-							if (parentGroupId) yield* rollupParentLocked(parentGroupId)
+						if (entityMatch === 'absent' || entityMatch === 'weak') {
+							yield* failClosedOnEntity(entityMatch)
 							return
 						}
 
@@ -1519,6 +1499,15 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						yield* linkRunSources(loopResult.scrapedUrlHashes)
 					}
 
+					// The phase-1 entity gate is skipped when a run resumes from a checkpoint
+					// (the loop that decides the verdict does not re-run), so re-check the stored
+					// verdict here: a weak or absent match fails closed before phase 2 instead of
+					// extracting a lookalike's profile on resume.
+					if (entityMatch === 'weak' || entityMatch === 'absent') {
+						yield* failClosedOnEntity(entityMatch)
+						return
+					}
+
 					// ── Phase 2: Structured output ──
 					// Skipped on resume if findings were already captured.
 					let findings: unknown
@@ -1537,7 +1526,6 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							const extracted = yield* extractStructuredFindings(
 								researchText,
 								[evidenceText, ...scrapeCorpus].join('\n'),
-								entityMatch,
 							)
 							findings = extracted.findings
 							tokensOut += extracted.outputTokens

--- a/packages/research/src/infrastructure/firecrawl/clean-scraped-markdown.test.ts
+++ b/packages/research/src/infrastructure/firecrawl/clean-scraped-markdown.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+
+import { cleanScrapedMarkdown } from './clean-scraped-markdown'
+
+describe('cleanScrapedMarkdown', () => {
+	describe('when the markdown is page-builder scaffolding around real text', () => {
+		it('should strip the shortcodes and keep the readable prose', () => {
+			// GIVEN a Fusion/Avada page whose body text is wrapped in builder shortcodes
+			const raw = [
+				'[fusion_builder_container type="flex" hundred_percent="no"]',
+				'[fusion_builder_row][fusion_builder_column type="1_1"][fusion_text]',
+				'',
+				'Green Worldwide Shipping is a licensed freight forwarder headquartered in Atlanta, Georgia, offering air freight, ocean freight, and customs brokerage across the United States.',
+				'',
+				'[/fusion_text][/fusion_builder_column][/fusion_builder_row][/fusion_builder_container]',
+			].join('\n')
+
+			// WHEN it is cleaned
+			const cleaned = cleanScrapedMarkdown(raw)
+
+			// THEN the prose survives and every shortcode is gone
+			expect(cleaned).toContain(
+				'Green Worldwide Shipping is a licensed freight forwarder',
+			)
+			expect(cleaned).not.toContain('[fusion')
+			expect(cleaned).not.toContain('fusion_builder')
+		})
+
+		it('should strip Divi and WPBakery shortcodes too', () => {
+			// GIVEN a page mixing Divi (et_pb) and WPBakery (vc) shortcodes
+			const raw =
+				'[et_pb_section][et_pb_row][et_pb_column type="4_4"][et_pb_text]Divi body copy about logistics services and freight solutions for many clients.[/et_pb_text][/et_pb_column][/et_pb_row][/et_pb_section] [vc_row][vc_column]More content about ocean and air shipping options.[/vc_column][/vc_row]'
+
+			// WHEN it is cleaned
+			const cleaned = cleanScrapedMarkdown(raw)
+
+			// THEN both builders' tags are gone and their text remains
+			expect(cleaned).toContain('Divi body copy about logistics services')
+			expect(cleaned).toContain('More content about ocean and air shipping')
+			expect(cleaned).not.toContain('[et_pb')
+			expect(cleaned).not.toContain('[vc_')
+		})
+
+		it('should keep a page whose only readable content is the company name', () => {
+			// GIVEN a builder page stripped down to just the company name
+			// WHEN it is cleaned
+			// THEN the name survives — shortness alone never marks a clean page
+			//   low-signal, and that name is exactly the grounding cue
+			expect(
+				cleanScrapedMarkdown('[fusion_text]Acme Logistics[/fusion_text]'),
+			).toBe('Acme Logistics')
+		})
+	})
+
+	describe('when the markdown is nothing but scaffolding', () => {
+		it('should return empty so the source is skipped', () => {
+			// GIVEN a builder skeleton carrying no readable text
+			const raw = [
+				'[fusion_builder_container][fusion_builder_row]',
+				'[fusion_builder_column type="1_1"]',
+				'[fusion_separator style_type="none" sep_color="#ffffff"][/fusion_separator]',
+				'[/fusion_builder_column][/fusion_builder_row][/fusion_builder_container]',
+			].join('\n')
+
+			// WHEN it is cleaned
+			// THEN nothing readable is left, so it is treated as empty
+			expect(cleanScrapedMarkdown(raw)).toBe('')
+		})
+	})
+
+	describe('when the markdown is a long page of almost no readable text', () => {
+		it('should return empty as low-signal even without a known builder', () => {
+			// GIVEN a long page dominated by symbols (an unrecognized builder's soup)
+			const raw = '<> == || ++ ** ## $$ %% [1] [2] {3} (4) :: ;; '.repeat(12)
+
+			// WHEN it is cleaned
+			// THEN its letter content is too thin to extract, so it is skipped
+			expect(cleanScrapedMarkdown(raw)).toBe('')
+		})
+	})
+
+	describe('when the markdown is ordinary content', () => {
+		it('should preserve markdown links, images, and references', () => {
+			// GIVEN clean markdown with a link, a mailto, an image, and a reference
+			const raw = [
+				'# Acme Logistics',
+				'',
+				'We move freight worldwide. Read our [shipping guide](https://acme.example/guide) or contact [sales](mailto:sales@acme.example).',
+				'',
+				'![Acme logo](https://acme.example/logo.png)',
+				'',
+				'See footnote [1].',
+			].join('\n')
+
+			// WHEN it is cleaned
+			const cleaned = cleanScrapedMarkdown(raw)
+
+			// THEN every markdown construct is left untouched
+			expect(cleaned).toContain('[shipping guide](https://acme.example/guide)')
+			expect(cleaned).toContain('[sales](mailto:sales@acme.example)')
+			expect(cleaned).toContain('![Acme logo](https://acme.example/logo.png)')
+			expect(cleaned).toContain('[1]')
+		})
+
+		it('should keep a bare reference whose label matches a builder prefix', () => {
+			// GIVEN references labelled exactly like short builder prefixes (cs, av)
+			const raw = 'Details in [cs]: https://example.com/spec and note [av].'
+
+			// WHEN it is cleaned
+			// THEN they survive — only real `prefix_word` shortcodes are stripped
+			const cleaned = cleanScrapedMarkdown(raw)
+			expect(cleaned).toContain('[cs]:')
+			expect(cleaned).toContain('[av]')
+		})
+
+		it('should pass clean prose through unchanged', () => {
+			// GIVEN a plain paragraph with no builder markup
+			const raw =
+				'Acme Logistics S.L. is a freight forwarder based in Barcelona, Spain. It operates road and ocean freight across Europe.'
+
+			// WHEN it is cleaned
+			// THEN it comes back byte-for-byte
+			expect(cleanScrapedMarkdown(raw)).toBe(raw)
+		})
+
+		it('should keep a genuinely short but clean page', () => {
+			// GIVEN a short clean page with fewer than the low-signal letter floor
+			const raw = 'Bilbao freight office. Call +34 944 000 000.'
+
+			// WHEN it is cleaned
+			// THEN it is kept — shortness alone never skips a page without markup
+			expect(cleanScrapedMarkdown(raw)).toBe(raw)
+		})
+	})
+
+	describe('when the markdown is empty or whitespace', () => {
+		it('should return empty', () => {
+			// GIVEN blank inputs
+			// THEN cleaning yields an empty string
+			expect(cleanScrapedMarkdown('')).toBe('')
+			expect(cleanScrapedMarkdown('   \n\t  ')).toBe('')
+		})
+	})
+})

--- a/packages/research/src/infrastructure/firecrawl/clean-scraped-markdown.ts
+++ b/packages/research/src/infrastructure/firecrawl/clean-scraped-markdown.ts
@@ -1,0 +1,71 @@
+/**
+ * Cleans scraped page markdown before it reaches the research extractor.
+ *
+ * Some sites built with a WordPress page builder (Avada/Fusion, Divi, WPBakery,
+ * …) hand back their body as shortcode scaffolding — `[fusion_builder_container
+ * …]` and the like — instead of readable prose, because the real text is
+ * assembled by the builder. Firecrawl's own main-content extraction does not
+ * always strip these, so the model is left with markup soup and nothing to pull.
+ *
+ * This removes those page-builder shortcodes (opening `[name …]` and closing
+ * `[/name]`), taking care never to touch an ordinary markdown link `[text](url)`,
+ * image `![alt](url)`, or reference `[1]` / `[cs]: url`. When what remains is a
+ * long page that is still mostly markup, it returns an empty string — the caller's
+ * signal to skip the source rather than feed the model noise. A short, clean page
+ * (even one carrying only the company name) is always kept: shortness alone is
+ * never treated as low-signal, because that name is exactly the grounding cue.
+ */
+
+// Builder prefixes whose real shortcodes are ALWAYS `prefix_word` (e.g. `vc_row`,
+// `fusion_text`, `et_pb_section`). Requiring the `_word` suffix means a bare
+// markdown reference like `[cs]:` or `[av]` is never mistaken for a shortcode.
+const PREFIXES_WITH_SUFFIX = [
+	'fusion', // Avada / Fusion Builder
+	'et_pb', // Divi
+	'vc', // WPBakery (Visual Composer)
+	'su', // Shortcodes Ultimate
+	'kc', // King Composer
+	'av', // Avia / Enfold
+	'mk', // Jupiter / MK
+	'cs', // Cornerstone
+	'dt_sc', // DesignThemes
+]
+// Builder shortcodes that legitimately appear bare (just the tag plus optional
+// attributes). Their names are long and distinctive enough not to collide with
+// ordinary markdown, so a `_word` suffix is optional here.
+const PREFIXES_STANDALONE = ['rev_slider', 'layerslider', 'tatsu']
+
+// Matches an opening `[prefix…]` or closing `[/prefix…]` shortcode, with any
+// attributes up to the closing bracket on the same line.
+const SHORTCODE_GLOBAL = new RegExp(
+	`\\[/?(?:(?:${PREFIXES_WITH_SUFFIX.join('|')})_[a-z0-9]+(?:_[a-z0-9]+)*` +
+		`|(?:${PREFIXES_STANDALONE.join('|')})(?:_[a-z0-9]+)*)(?:\\s[^\\]\\n]*)?\\]`,
+	'gi',
+)
+
+// A long page whose letters are only a small fraction of its characters is markup
+// soup (e.g. from a builder we don't recognize); skip it. The length floor keeps a
+// short, clean page from ever being judged low-signal.
+const MOSTLY_MARKUP_MIN_LENGTH = 400
+const MOSTLY_MARKUP_LETTER_RATIO = 0.3
+
+const letterCount = (text: string): number =>
+	(text.match(/\p{L}/gu) ?? []).length
+
+export const cleanScrapedMarkdown = (raw: string): string => {
+	if (raw.trim().length === 0) return ''
+	const cleaned = raw
+		.replace(SHORTCODE_GLOBAL, ' ')
+		// Collapse the whitespace and blank-line residue the removed tags leave.
+		.replace(/[ \t]+\n/g, '\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.replace(/[ \t]{2,}/g, ' ')
+		.trim()
+	if (cleaned.length === 0) return ''
+	if (
+		cleaned.length > MOSTLY_MARKUP_MIN_LENGTH &&
+		letterCount(cleaned) / cleaned.length < MOSTLY_MARKUP_LETTER_RATIO
+	)
+		return ''
+	return cleaned
+}

--- a/packages/research/src/infrastructure/firecrawl/scrape.ts
+++ b/packages/research/src/infrastructure/firecrawl/scrape.ts
@@ -24,6 +24,7 @@ import { ProviderError } from '../../domain/errors'
 import { ScrapedPage } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
+import { cleanScrapedMarkdown } from './clean-scraped-markdown'
 
 const SCRAPE_URL = 'https://api.firecrawl.dev/v2/scrape'
 
@@ -103,7 +104,10 @@ export const makeFirecrawlScrape = (slot: number) =>
 									}),
 							),
 						)
-						const markdown = body.data.markdown ?? ''
+						// Clean page-builder markup out of the fetched markdown; an empty
+						// result means the page was mostly scaffolding, so it carries no
+						// content and the loop's grounding check skips it.
+						const markdown = cleanScrapedMarkdown(body.data.markdown ?? '')
 						return new ScrapedPage({
 							url: input.url,
 							markdown,

--- a/packages/research/src/infrastructure/firecrawl/search.ts
+++ b/packages/research/src/infrastructure/firecrawl/search.ts
@@ -24,6 +24,7 @@ import { ProviderError } from '../../domain/errors'
 import { SearchResult, SearchResultItem } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
+import { cleanScrapedMarkdown } from './clean-scraped-markdown'
 
 const SEARCH_URL = 'https://api.firecrawl.dev/v2/search'
 
@@ -126,17 +127,18 @@ export const makeFirecrawlSearch = (slot: number) =>
 							),
 						)
 						return new SearchResult({
-							items: (body.data.web ?? []).map(
-								r =>
-									new SearchResultItem({
-										url: r.url,
-										title: r.title ?? '',
-										snippet: r.description ?? '',
-										...(r.markdown && r.markdown.trim().length > 0
-											? { content: r.markdown }
-											: {}),
-									}),
-							),
+							items: (body.data.web ?? []).map(r => {
+								// Clean page-builder markup out of the scraped content before
+								// it becomes grounding evidence; an empty result means the page
+								// was mostly scaffolding, so the item carries no content.
+								const content = cleanScrapedMarkdown(r.markdown ?? '')
+								return new SearchResultItem({
+									url: r.url,
+									title: r.title ?? '',
+									snippet: r.description ?? '',
+									...(content.length > 0 ? { content } : {}),
+								})
+							}),
 							// Bill the credits Firecrawl actually charged (search plus the
 							// per-result scrape), not a flat 1, so the run budget is honest.
 							units: body.creditsUsed ?? 1,


### PR DESCRIPTION
## What

Two grounding-quality fixes to the **research engine** — the `@batuda/research` package that automatically researches a company and fills in its CRM profile — both from issue #208. In plain terms: the automated research could either confidently present *the wrong company's* details, or come back nearly empty even when it found good sources. This PR stops the first and fixes the second. Backend only — no UI.

## The fix

**A — a run that can't confirm it found the right company now stops honestly.** The engine already scores how strongly the fetched pages are about the company it was asked to research: `strong`, `weak`, or `absent`. `absent` already failed closed (ended as "no reliable data"). But a `weak` match — pages that only glancingly named the company, e.g. researching "Sunset Transportation" but landing on CEVA Logistics — used to finish as a *success* and present the look-alike's profile, stripping only the proposed CRM edits while keeping the enrichment, competitors, and contacts. Now a weak match fails closed to `no_reliable_data` just like absent, so extraction never runs on the wrong company's pages. The same check re-runs when a crashed run resumes from a checkpoint, so it can't be skipped after a restart.

**B — page-builder markup no longer starves extraction.** Some sites built with a WordPress page builder (Fusion/Avada, Divi, WPBakery) return their body as shortcode scaffolding — `[fusion_builder_container …]` soup — instead of readable text, so the model had nothing to extract and the profile came back nearly empty despite real sources. Scraped markdown is now cleaned of those shortcodes before extraction, and a page that is still mostly markup is skipped rather than fed to the model as noise. The cleaner deliberately never touches ordinary markdown links, images, or references.

## Impact

- **No schema/migration change.** The `entity_match` column already exists (migration 0025) and the findings shape is unchanged — nothing to run before the server tag.
- **Cost goes down, not up.** A weak run now fails closed *before* phases 2–3, so it spends fewer tokens than it did when it ran the full extraction on the wrong company.
- **MCP + HTTP parity:** the change lives in the shared research engine, so both transports get the behavior.
- **Event payload (minor):** the `run.no_reliable_data` SSE event now carries the verdict (`entityMatch`) and a precise `reason` (`entity_weak` vs `entity_mismatch`). The payload is untyped and has no current consumer.
- No RLS / multi-org, auth, env var, or CORS changes.

## Review guide

- Start in `research-service.ts`: the new `failClosedOnEntity` helper and its two call sites — the phase-1 gate (`entityMatch === 'absent' || 'weak'`) and the resume re-check just before phase 2. The deleted block is the old phase-2 weak-blanking path.
- Riskiest bit: the **resume re-check**, because the entity gate is normally skipped when a run resumes from a checkpoint. It's covered by a resume-simulation integration test that seeds a checkpointed `weak` run *plus a linked source* (so it would otherwise succeed) — I mutation-tested it (disabled the guard → the test fails), so it genuinely isolates the guard rather than passing for another reason.
- `clean-scraped-markdown.ts`: the shortcode regex splits "always `prefix_word`" builders (require a suffix) from standalone ones, so a bare markdown reference like `[cs]:` is never stripped. The low-signal skip is conservative — only a long page that is still mostly markup.
- Not run: `/security-review` / Snyk. The cleaner is a text transform feeding an LLM (not an executed or rendered sanitizer), so the security surface is low; I did a deep adversarial self-review plus the mutation test instead.

## Tests

- Unit — new `clean-scraped-markdown.test.ts`: strips Fusion/Divi/WPBakery shortcodes, preserves links/images/references (including bare-prefix refs), keeps a name-only page, skips scaffolding and long low-signal pages.
- Integration — `research-entity-gate.integration.test.ts`: flipped the weak case to assert `no_reliable_data`, and added the resume-simulation test. The strong / absent / failed-scrape cases stay as guards against the gate over-firing.

## Verification

- `pnpm -w check-types` (13/13), `pnpm -w test` (20/20), `pnpm -w build` (13/13) — all green on the rebased base.
- Research unit suite 306 passed; entity-gate integration 5/5 against the live `batuda_it` Postgres, including the mutation-proven resume test. (The local pre-push integration hook can't run in a worktree — its DB seed needs CLI env the worktree lacks — so I ran the integration suite directly; GitHub CI runs it against a fresh Neon branch.)

## Deferred

- The broader "best data" work — per-source grounding, registry-first entity resolution, per-field confidence, and a model upgrade — is tracked separately in #214.

Closes #208.
