### PR TITLE
fix(research): per-tool spend breakdown and honest empty-scan handling

### DIFF
--- a/apps/server/src/services/research-empty-scan-retry.integration.test.ts
+++ b/apps/server/src/services/research-empty-scan-retry.integration.test.ts
@@ -1,0 +1,247 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '4'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	ExtractLanguageModel,
+	ExtractProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	ScrapeProvider,
+	SearchProvider,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client'
+
+// A non-anchored prospect scan whose extraction keeps coming back empty should
+// refine-and-retry once, then finish `no_reliable_data` instead of a green
+// "succeeded" over an empty list. Both agent passes gather the one seeded
+// source (so the grounding gate passes) and the extractor always returns an
+// empty `prospects` list, forcing the retry and the honest terminal status.
+
+// A canonical URL hashes to itself, so this matches what the run fiber's
+// source-linking computes for the web_search result below.
+const SEED_URL = 'https://directory.test/freight-brokers'
+const SEED_URL_HASH = createHash('sha256').update(SEED_URL).digest('hex')
+
+const usage = {
+	inputTokens: {
+		uncached: undefined,
+		total: 0,
+		cacheRead: undefined,
+		cacheWrite: undefined,
+	},
+	outputTokens: { total: 0, text: undefined, reasoning: undefined },
+}
+
+// Agent pass: hand back one web_search result (real fetched evidence) and no
+// further tool calls, so each pass gathers the seeded source then stops.
+const agentLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({
+			text: '',
+			content: [],
+			reasoning: [],
+			reasoningText: undefined,
+			toolCalls: [],
+			toolResults: [
+				{
+					name: 'web_search',
+					isFailure: false,
+					encodedResult: undefined,
+					result: {
+						items: [
+							{
+								url: SEED_URL,
+								content: 'A directory listing of US freight brokerage firms.',
+							},
+						],
+					},
+				},
+			],
+			finishReason: 'stop' as const,
+			usage,
+		}) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+// Extractor: always empty prospects → drives the retry and the empty verdict.
+const extractLlm: LanguageModel.Service = {
+	generateText: () => Effect.succeed({ text: '', content: [], usage }) as never,
+	generateObject: () =>
+		Effect.succeed({ usage, value: { prospects: [] } }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const writerLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({
+			text: 'No prospects found.',
+			content: [],
+			usage,
+		}) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const die = 'provider not exercised'
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({ search: () => Effect.die(die) }),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({ scrape: () => Effect.die(die) }),
+	),
+	Layer.succeed(ExtractProvider)(
+		ExtractProvider.of({ extract: () => Effect.die(die) }),
+	),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(die) }),
+	),
+)
+
+// Record every event the run fires so the test can assert the refine step ran.
+const firedEvents: string[] = []
+const eventSink = Layer.succeed(ResearchEventSink)(
+	ResearchEventSink.of({
+		fire: (event: string) =>
+			Effect.sync(() => {
+				firedEvents.push(event)
+			}),
+	}),
+)
+
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			Layer.succeed(AgentLanguageModel)(agentLlm),
+			Layer.succeed(ExtractLanguageModel)(extractLlm),
+			Layer.succeed(WriterLanguageModel)(writerLlm),
+		),
+	),
+	Layer.provide(providersLayer),
+	Layer.provide(
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test',
+				}),
+		}),
+	),
+	Layer.provide(eventSink),
+	Layer.provideMerge(PgLive),
+)
+
+const runtime = ManagedRuntime.make(ResearchLive)
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+const ORG = `scan-org-${randomUUID()}`
+const USER = `scan-user-${randomUUID()}`
+const TERMINAL = new Set([
+	'succeeded',
+	'failed',
+	'cancelled',
+	'no_reliable_data',
+])
+
+const systemDefaults = {
+	budgetCents: 1000,
+	paidBudgetCents: 500,
+	autoApprovePaidCents: 500,
+	paidMonthlyCapCents: 2000,
+	hardCeiling: 100_000,
+}
+
+let pool: pg.Pool
+
+const create = (query: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ResearchService
+			return yield* svc.create(
+				USER,
+				ORG,
+				{ query, schemaName: 'prospect_scan_v1', forceFresh: true },
+				systemDefaults,
+			)
+		}),
+	)
+
+const runStatus = (id: string) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ResearchService
+			const run = (yield* svc.get(id).pipe(Effect.orDie)) as {
+				status?: string
+			} | null
+			return run?.status ?? 'unknown'
+		}),
+	)
+
+const pollRun = async (id: string): Promise<string> => {
+	for (let left = 60; left > 0; left--) {
+		const status = await runStatus(id)
+		if (TERMINAL.has(status)) return status
+		await new Promise(resolve => setTimeout(resolve, 250))
+	}
+	return 'timeout'
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	// Seed the one source both passes "fetch", so the grounding gate passes and
+	// the run reaches the empty-findings verdict.
+	await pool.query(
+		`INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+		 VALUES ($1, 'web', 'stub', $2, $3, 'directory.test', 'seed')
+		 ON CONFLICT (url_hash) DO NOTHING`,
+		[`src-${randomUUID()}`, SEED_URL, SEED_URL_HASH],
+	)
+})
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM research_runs WHERE organization_id = $1`, [
+		ORG,
+	])
+	await pool.query(`DELETE FROM sources WHERE url_hash = $1`, [SEED_URL_HASH])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('empty discovery-scan retry', () => {
+	describe('when a prospect scan extracts no prospects', () => {
+		it('should refine-and-retry once, then finish no_reliable_data', async () => {
+			// GIVEN a broad, non-anchored prospect scan
+			const created = await create(
+				'Find midsize US freight brokerage prospects',
+			)
+			const id = (created as { id: string }).id
+
+			// WHEN the run completes
+			const status = await pollRun(id)
+
+			// THEN it refined once and settled on the honest terminal status,
+			// not a green success over an empty list
+			expect(status).toBe('no_reliable_data')
+			expect(firedEvents).toContain('research.refining')
+		})
+	})
+})

--- a/apps/server/src/services/research-paid-followup.integration.test.ts
+++ b/apps/server/src/services/research-paid-followup.integration.test.ts
@@ -187,6 +187,14 @@ const spendCount = async (user: string): Promise<number> => {
 	return r.rows[0]?.n ?? 0
 }
 
+const spendTools = async (user: string): Promise<string[]> => {
+	const r = await pool.query<{ tool: string }>(
+		`SELECT tool FROM research_paid_spend WHERE user_id = $1 ORDER BY at`,
+		[user],
+	)
+	return r.rows.map(row => row.tool)
+}
+
 const originFindings = async (
 	id: string,
 ): Promise<{
@@ -243,6 +251,9 @@ describe('paid-action follow-up', () => {
 			// origin run
 			expect(registryCalls).toBe(before + 1)
 			expect(await spendCount(user)).toBe(1)
+			// AND the spend row records the real tool name, so a by-tool
+			// breakdown is meaningful (not the old hardcoded 'paid')
+			expect(await spendTools(user)).toEqual(['registry_lookup'])
 			const findings = await originFindings(origin)
 			expect(findings.followup_results?.length).toBe(1)
 			expect(findings.pending_paid_actions?.[0]?.['status']).toBe('approved')

--- a/apps/server/src/services/research-paid-spend-org-isolation.integration.test.ts
+++ b/apps/server/src/services/research-paid-spend-org-isolation.integration.test.ts
@@ -89,7 +89,12 @@ const charge = (
 
 			const chargeEffect = Effect.gen(function* () {
 				const budget = yield* Budget
-				yield* budget.chargePaid('test-provider', 50, idempotencyKey)
+				yield* budget.chargePaid(
+					'test-provider',
+					50,
+					'discover_contacts',
+					idempotencyKey,
+				)
 			})
 
 			yield* chargeEffect.pipe(Effect.provide(budgetLayer))
@@ -128,12 +133,18 @@ const chargeThenObserve = (
 			return yield* Effect.gen(function* () {
 				const budget = yield* Budget
 				for (const { cents, key } of setupCharges) {
-					yield* budget.chargePaid('test-provider', cents, key)
+					yield* budget.chargePaid(
+						'test-provider',
+						cents,
+						'discover_contacts',
+						key,
+					)
 				}
 				return yield* Effect.result(
 					budget.chargePaid(
 						'test-provider',
 						observedCharge.cents,
+						'discover_contacts',
 						observedCharge.key,
 					),
 				)

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -135,6 +135,7 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 				chargePaid: (
 					provider: string,
 					cents: number,
+					tool: string,
 					idempotencyKey?: string,
 				) =>
 					Effect.gen(function* () {
@@ -154,7 +155,8 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 							cents,
 							researchId: config.researchId,
 							provider,
-							tool: 'paid',
+							// The calling tool's name, so a spend breakdown by tool is real.
+							tool,
 							idempotencyKey:
 								idempotencyKey ??
 								`${config.researchId}:${provider}:${Date.now()}`,
@@ -176,7 +178,7 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 					}).pipe(
 						Effect.tap(() =>
 							Effect.logDebug('budget.chargePaid').pipe(
-								Effect.annotateLogs({ provider, cents }),
+								Effect.annotateLogs({ provider, tool, cents }),
 							),
 						),
 					),

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -267,6 +267,7 @@ export class ContactDiscovery extends ServiceMap.Service<ContactDiscovery>()(
 							yield* budget.chargePaid(
 								'hunter-enrich',
 								ENRICH_COST_CENTS,
+								'discover_contacts',
 								// Idempotency key: a resumed research run re-charges the same
 								// enrichment as a DB no-op instead of paying Hunter twice.
 								`${researchId}:hunter-enrich:${input.domain}`,
@@ -296,6 +297,7 @@ export class ContactDiscovery extends ServiceMap.Service<ContactDiscovery>()(
 								yield* budget.chargePaid(
 									'hunter-verify',
 									VERIFY_COST_CENTS,
+									'discover_contacts',
 									// Idempotency key so a resumed run does not re-pay to
 									// verify the same address.
 									`${researchId}:hunter-verify:${email}`,

--- a/packages/research/src/application/discovery-scan.test.ts
+++ b/packages/research/src/application/discovery-scan.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	isDiscoveryScanEmpty,
+	isRetryEligible,
+	REFINE_HINT,
+} from './discovery-scan'
+
+describe('isRetryEligible', () => {
+	describe('when the schema is an open-ended discovery scan', () => {
+		it('should be true for prospect_scan_v1 and competitor_scan_v1', () => {
+			// GIVEN the two open-ended scan schemas
+			// WHEN checked for retry eligibility
+			// THEN both qualify
+			expect(isRetryEligible('prospect_scan_v1')).toBe(true)
+			expect(isRetryEligible('competitor_scan_v1')).toBe(true)
+		})
+	})
+
+	describe('when the schema is entity-anchored or freeform', () => {
+		it('should be false — those are not open-ended scans', () => {
+			// GIVEN the entity-grounded and freeform schemas
+			// WHEN checked
+			// THEN none qualify for the discovery retry
+			expect(isRetryEligible('company_enrichment_v1')).toBe(false)
+			expect(isRetryEligible('contact_discovery_v1')).toBe(false)
+			expect(isRetryEligible('freeform')).toBe(false)
+			expect(isRetryEligible('unknown_schema')).toBe(false)
+		})
+	})
+})
+
+describe('isDiscoveryScanEmpty', () => {
+	describe('when a prospect scan has no prospects', () => {
+		it('should be true for an empty array', () => {
+			// GIVEN a prospect scan with an empty primary list
+			const findings = { prospects: [] }
+
+			// WHEN checked for emptiness
+			// THEN it is empty
+			expect(isDiscoveryScanEmpty('prospect_scan_v1', findings)).toBe(true)
+		})
+
+		it('should be true when the primary list is missing entirely', () => {
+			// GIVEN findings without the prospects key
+			const findings = { discovered_existing: [] }
+
+			// WHEN checked
+			// THEN a missing primary list counts as empty
+			expect(isDiscoveryScanEmpty('prospect_scan_v1', findings)).toBe(true)
+		})
+
+		it('should be true for a non-object findings value', () => {
+			// GIVEN malformed findings for a discovery schema
+			// WHEN checked
+			// THEN null / array / primitive all count as empty
+			expect(isDiscoveryScanEmpty('prospect_scan_v1', null)).toBe(true)
+			expect(isDiscoveryScanEmpty('prospect_scan_v1', [])).toBe(true)
+			expect(isDiscoveryScanEmpty('prospect_scan_v1', 'nope')).toBe(true)
+		})
+	})
+
+	describe('when a prospect scan found prospects', () => {
+		it('should be false', () => {
+			// GIVEN a prospect scan with at least one result
+			const findings = { prospects: [{ name: 'Acme 3PL' }] }
+
+			// WHEN checked
+			// THEN it is not empty
+			expect(isDiscoveryScanEmpty('prospect_scan_v1', findings)).toBe(false)
+		})
+	})
+
+	describe('when a competitor scan is checked', () => {
+		it('should read its own primary list (competitors)', () => {
+			// GIVEN empty and non-empty competitor scans
+			// WHEN checked
+			// THEN the competitors list drives the verdict
+			expect(
+				isDiscoveryScanEmpty('competitor_scan_v1', { competitors: [] }),
+			).toBe(true)
+			expect(
+				isDiscoveryScanEmpty('competitor_scan_v1', {
+					competitors: [{ name: 'Rival Co' }],
+				}),
+			).toBe(false)
+		})
+	})
+
+	describe('when the schema is not a discovery scan', () => {
+		it('should always be false, even with empty-looking findings', () => {
+			// GIVEN a non-discovery schema with empty findings
+			// WHEN checked
+			// THEN emptiness is not this helper's concern → false
+			expect(isDiscoveryScanEmpty('company_enrichment_v1', {})).toBe(false)
+			expect(isDiscoveryScanEmpty('freeform', null)).toBe(false)
+			expect(
+				isDiscoveryScanEmpty('contact_discovery_v1', { contacts: [] }),
+			).toBe(false)
+		})
+	})
+})
+
+describe('REFINE_HINT', () => {
+	describe('when steering a refined retry', () => {
+		it('should push toward directories and forbid placeholder site: filters', () => {
+			// GIVEN the refinement hint appended on an empty retry
+			// WHEN inspected
+			// THEN it names authoritative sources and bans placeholder filters
+			expect(REFINE_HINT).toMatch(/director/i)
+			expect(REFINE_HINT).toMatch(/registr/i)
+			expect(REFINE_HINT).toMatch(/placeholder site:/i)
+		})
+	})
+})

--- a/packages/research/src/application/discovery-scan.ts
+++ b/packages/research/src/application/discovery-scan.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for the open-ended discovery scans (prospect / competitor). These are
+ * the only schemas whose empty primary list means the search — not the data —
+ * came up short, so they alone earn a refined retry and, if still empty, an
+ * honest terminal status instead of a green "succeeded" over nothing.
+ */
+
+// The primary result array for each discovery-scan schema. A schema absent here
+// is not a discovery scan: it keeps whatever it found and is never retried.
+const DISCOVERY_RESULT_FIELD: Record<string, string> = {
+	prospect_scan_v1: 'prospects',
+	competitor_scan_v1: 'competitors',
+}
+
+/** Whether a schema is an open-ended discovery scan eligible for the retry. */
+export const isRetryEligible = (schemaName: string): boolean =>
+	schemaName in DISCOVERY_RESULT_FIELD
+
+/**
+ * Whether a discovery scan's findings carry no results — an empty or missing
+ * primary list, or a non-object findings value. Always false for a non-discovery
+ * schema, whose emptiness is a different question its own guards answer.
+ */
+export const isDiscoveryScanEmpty = (
+	schemaName: string,
+	findings: unknown,
+): boolean => {
+	const field = DISCOVERY_RESULT_FIELD[schemaName]
+	if (field === undefined) return false
+	if (
+		findings == null ||
+		typeof findings !== 'object' ||
+		Array.isArray(findings)
+	)
+		return true
+	const value = (findings as Record<string, unknown>)[field]
+	return !Array.isArray(value) || value.length === 0
+}
+
+// Appended to the query for a single refined retry after a discovery scan comes
+// back empty, steering the model toward useful sources and away from the social /
+// glossary noise that empties an open-ended search.
+export const REFINE_HINT =
+	'The previous search returned no relevant results. Refine your approach: search business directories, industry association member lists, and sector-specific registries for companies that match the criteria; combine specific location and industry keywords; and ignore social-media posts, forums, and glossary pages. Do not use placeholder site: filters.'

--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -250,6 +250,7 @@ export interface BudgetService {
 	readonly chargePaid: (
 		provider: string,
 		cents: number,
+		tool: string,
 		idempotencyKey?: string,
 	) => Effect.Effect<void, BudgetExceeded | MonthlyCapExceeded>
 	readonly snapshot: () => Effect.Effect<BudgetSnapshot>

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -22,10 +22,15 @@ import { SqlClient } from 'effect/unstable/sql'
 
 import { AcceptedCountry } from '../domain/country'
 import type { ResolvedPolicy } from '../domain/types'
-import { runAgentResearchLoop } from './agent-loop'
+import { canAffordAnotherRound, runAgentResearchLoop } from './agent-loop'
 import { filterApplicableProposals } from './applicability-guard'
 import { makeBudgetLayer } from './budget'
 import { validateFindingCitations } from './citation-guard'
+import {
+	isDiscoveryScanEmpty,
+	isRetryEligible,
+	REFINE_HINT,
+} from './discovery-scan'
 import {
 	classifyEntityMatch,
 	deriveEntityTargets,
@@ -347,6 +352,8 @@ export const buildResearchSystemPrompt = (args: {
 		'Never fabricate sources. Every claim must be verifiable.',
 		'Confirm key facts (employee count, location, sector) from scraped page content — the company site, LinkedIn, or press — not from search snippets alone, and cite the scraped page for each.',
 		'For every citation, set source_id to the exact URL you scraped with scrape_page. Never invent an identifier — a citation that does not match a fetched page is dropped.',
+		'When you search, use plain keywords, and only add a site: filter for a real domain you know — never a placeholder like site:example.com.',
+		'For discovery or prospecting queries, prefer authoritative sources — business directories, industry association member lists, and sector registries — over social media, forums, or glossary pages.',
 		'When extracting structured data from a single page, use the company_enrichment_v1 schema (a per-company shape), not a whole-run aggregate schema.',
 		`Output schema: ${args.schemaName}`,
 		args.subjectContext,
@@ -368,6 +375,7 @@ export type ResearchEventType =
 	| 'run.failed'
 	| 'run.cancelled'
 	| 'run.no_reliable_data'
+	| 'run.refining'
 	| 'provider.circuit_open'
 
 export interface ResearchEvent {
@@ -778,6 +786,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						yield* budget.chargePaid(
 							'registry',
 							REGISTRY_LOOKUP_COST_CENTS,
+							'registry_lookup',
 							key,
 						)
 						return yield* registry.lookup({ country, taxId, query })
@@ -987,6 +996,198 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					// guard checks findings against. Kept separate from the model-facing
 					// transcript (capped per page); empty on a resume that skips phase 1.
 					const scrapeCorpus: string[] = []
+					// Findings the discovery-scan retry path extracts under the shared
+					// budget; undefined on every other path (which extracts in phase 2).
+					let retryFindings: unknown
+					let retryExtractTokens = 0
+
+					// Phase-2 extraction + every grounding guard, shared so both the
+					// normal path and the discovery-scan retry run the same logic. Returns
+					// cleaned findings and the model's output tokens; the caller writes the
+					// single phase-2 checkpoint. `match` carries the entity verdict for the
+					// weak-match strip (null for a scan, which is never entity-gated).
+					const extractStructuredFindings = (
+						transcript: string,
+						evidenceCorpus: string,
+						match: EntityMatch | null,
+					) =>
+						Effect.gen(function* () {
+							yield* publishEvent(researchId, 'tool.called', {
+								tool: 'llm.generateObject',
+								phase: 2,
+								schema: schemaName,
+							})
+							// Cast schema to satisfy generateObject's Encoder constraint.
+							// Registry schemas are all Structs with DecodingServices=never,
+							// but Schema.Top erases that — the cast is safe.
+							const structuredResponse = yield* extractLlm.generateObject({
+								schema: outputSchema as typeof FreeformSchema,
+								// Ground the extraction: the model may only output values that
+								// appear in the transcript, and must leave unsupported fields
+								// empty rather than filling them from prior knowledge — otherwise
+								// it will confidently invent phones, tax ids, and emails.
+								prompt: `Produce structured findings STRICTLY from the research transcript below. Only include a value that appears in the transcript; if the transcript does not support a field, omit it or leave it null — never fill a field from prior knowledge. Set each citation's source_id to the exact scraped URL the value came from.\n\nResearch transcript:\n\n${transcript}`,
+							})
+							let result = withProposalIds(structuredResponse.value as unknown)
+							// Drop citations the model invented: keep only source_ids that map
+							// to a page this run actually fetched. A proposed CRM update left
+							// with no valid citation is dropped whole.
+							const groundedRows = yield* sql<{
+								localRef: string
+								sourceId: string
+							}>`
+								SELECT local_ref AS "localRef", source_id AS "sourceId"
+								FROM research_run_sources WHERE research_id = ${researchId}
+							`
+							const groundedKeys = new Set<string>()
+							for (const row of groundedRows) {
+								groundedKeys.add(canonicalizeUrl(row.localRef))
+								groundedKeys.add(row.sourceId)
+							}
+							const citationCheck = validateFindingCitations(
+								result,
+								sourceId =>
+									groundedKeys.has(canonicalizeUrl(sourceId)) ||
+									groundedKeys.has(sourceId),
+							)
+							result = citationCheck.findings
+							if (citationCheck.total > citationCheck.kept) {
+								yield* Effect.logWarning('research.citations.dropped').pipe(
+									Effect.annotateLogs({
+										research_id: researchId,
+										total: citationCheck.total,
+										kept: citationCheck.kept,
+									}),
+								)
+							}
+							// Value provenance: the citation guard proved the cited pages were
+							// fetched, not that they contain the claimed values. Drop any
+							// proposed CRM write whose email/phone/tax-id value appears nowhere
+							// in the run's evidence — that value was invented, real citation or
+							// not. Evidence is tool results only, never the model's own prose.
+							const valueCheck = verifyValueProvenance(result, evidenceCorpus)
+							result = valueCheck.findings
+							if (
+								valueCheck.droppedProposals > 0 ||
+								valueCheck.strippedValues > 0
+							) {
+								yield* Effect.logWarning('research.values.unsupported').pipe(
+									Effect.annotateLogs({
+										research_id: researchId,
+										dropped_proposals: valueCheck.droppedProposals,
+										stripped_values: valueCheck.strippedValues,
+									}),
+								)
+							}
+							// A weak entity match means the fetched pages only glancingly
+							// mention the target: keep the brief but withhold every CRM write
+							// and flag the low confidence, so a reviewer treats these findings
+							// with care rather than trusting an auto-applied update.
+							if (
+								match === 'weak' &&
+								result != null &&
+								typeof result === 'object' &&
+								!Array.isArray(result)
+							) {
+								const current = result as Record<string, unknown>
+								const strippedProposals = Array.isArray(
+									current['proposed_updates'],
+								)
+									? (current['proposed_updates'] as unknown[]).length
+									: 0
+								result = {
+									...current,
+									proposed_updates: [],
+									entity_confidence: 'low',
+								}
+								yield* Effect.logWarning('research.entity.weak').pipe(
+									Effect.annotateLogs({
+										research_id: researchId,
+										stripped_proposals: strippedProposals,
+									}),
+								)
+							}
+							// Applicability: drop any proposed CRM update that could never be
+							// applied — an update whose subject_id names no live row (the model
+							// can invent one for a company that does not exist), or a proposal
+							// whose fields carry no real values. Existence is checked against
+							// the org's own rows; a malformed id trips a cast error read as
+							// "not found".
+							const organizationId = (run as { organizationId: string })
+								.organizationId
+							const proposalList =
+								result != null &&
+								typeof result === 'object' &&
+								!Array.isArray(result)
+									? (result as Record<string, unknown>)['proposed_updates']
+									: undefined
+							const liveSubjects = new Set<string>()
+							if (Array.isArray(proposalList)) {
+								for (const proposal of proposalList) {
+									if (proposal == null || typeof proposal !== 'object') continue
+									const pu = proposal as Record<string, unknown>
+									if (pu['operation'] === 'create') continue
+									const table = pu['subject_table']
+									const id = pu['subject_id']
+									if (
+										(table !== 'companies' && table !== 'contacts') ||
+										typeof id !== 'string' ||
+										id.trim() === '' ||
+										liveSubjects.has(`${table}:${id}`)
+									)
+										continue
+									const rows = yield* sql`
+										SELECT id FROM ${sql(table)}
+										WHERE id = ${id}
+											AND organization_id = ${organizationId}
+											AND deleted_at IS NULL
+										LIMIT 1
+									`.pipe(Effect.catchTag('SqlError', () => Effect.succeed([])))
+									if (rows.length > 0) liveSubjects.add(`${table}:${id}`)
+								}
+							}
+							const applicability = filterApplicableProposals(
+								result,
+								(table, id) => liveSubjects.has(`${table}:${id}`),
+							)
+							result = applicability.findings
+							if (applicability.dropped > 0) {
+								yield* Effect.logWarning('research.proposals.unappliable').pipe(
+									Effect.annotateLogs({
+										research_id: researchId,
+										dropped: applicability.dropped,
+									}),
+								)
+							}
+							yield* publishEvent(researchId, 'tool.result', {
+								tool: 'llm.generateObject',
+								phase: 2,
+								schema: schemaName,
+							})
+							return {
+								findings: result as unknown,
+								outputTokens: structuredResponse.usage.outputTokens.total ?? 0,
+							}
+						})
+
+					// Link each page that returned content to the run so findings cite
+					// real sources; the sources row was upserted by the search cache
+					// (matched by url_hash). Re-running is a no-op via ON CONFLICT.
+					const linkRunSources = (hashes: ReadonlyArray<string>) =>
+						Effect.gen(function* () {
+							const organizationId = (run as { organizationId: string })
+								.organizationId
+							for (const urlHash of hashes) {
+								yield* sql`
+									INSERT INTO research_run_sources (organization_id, research_id, source_id, local_ref, fetched_at, cost_cents)
+									SELECT ${organizationId}, ${researchId}, s.id, s.url, now(), 0
+									FROM sources s
+									WHERE s.url_hash = ${urlHash}
+									ON CONFLICT DO NOTHING
+								`
+							}
+						})
+
 					if (checkpointPhase >= 1 && cachedResearchText) {
 						researchText = cachedResearchText
 						yield* Effect.logInfo('research.phase1.resume').pipe(
@@ -1057,121 +1258,213 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						// this run. `runRound` threads the growing prompt — each round's
 						// assistant text and tool results feed the next — and maps the
 						// model response into the plain data the loop decides on.
-						const loopResult = yield* Effect.gen(function* () {
+						const phaseOutcome = yield* Effect.gen(function* () {
 							const budget = yield* Budget
 							const toolkit = yield* researchToolkit
-							let prompt: Prompt.Prompt = Prompt.make(
-								`${systemPrompt}\n\n${query}`,
-							)
-							const runRound = (round: number) =>
+
+							// One agent pass = a fresh reflect-and-retry loop. Both the initial
+							// pass and a refined retry run here, under the SAME budget + toolkit:
+							// re-providing the layer would build a fresh MemoMap and reset the
+							// per-run spend, letting one run silently pay twice.
+							const runPass = (
+								basePrompt: string,
+								carryTokensIn: number,
+								carryTokensOut: number,
+							) =>
 								Effect.gen(function* () {
-									const response = yield* agentLlm.generateText({
-										prompt,
-										toolkit,
-										// Force a tool on the first round so the model can't
-										// answer from memory without gathering evidence (which
-										// would leave zero sources and fail the grounding gate
-										// on a legitimate company); reflect freely after.
-										toolChoice: round === 1 ? 'required' : 'auto',
-									})
-									prompt = Prompt.concat(
-										prompt,
-										Prompt.fromResponseParts(response.content),
-									)
-									// Attribute sources only to scrapes that actually returned
-									// content this round — read off the tool RESULTS, not the
-									// requested calls — so a failed or empty scrape can never
-									// count toward grounding; keep the content for the value guard.
-									const scrapeUrlHashes: string[] = []
-									for (const tr of response.toolResults) {
-										if (tr.name === 'scrape_page') {
-											const page = tr.result as
-												| { url?: unknown; markdown?: unknown }
-												| null
-												| undefined
-											if (
-												page != null &&
-												typeof page.url === 'string' &&
-												typeof page.markdown === 'string' &&
-												page.markdown.trim().length > 0
-											) {
-												scrapeUrlHashes.push(urlHashForScrape(page.url))
-												scrapeCorpus.push(page.markdown)
-											}
-										} else if (tr.name === 'web_search') {
-											// A search that returned scraped page content (Firecrawl
-											// scrapeOptions) is real fetched evidence — ground on each
-											// such result, exactly like a scrape. The sources row was
-											// upserted by the search cache when the tool ran.
-											const searchResult = tr.result as
-												| { items?: ReadonlyArray<unknown> }
-												| null
-												| undefined
-											for (const raw of searchResult?.items ?? []) {
-												const item = raw as { url?: unknown; content?: unknown }
-												if (
-													typeof item.url === 'string' &&
-													typeof item.content === 'string' &&
-													item.content.trim().length > 0
-												) {
-													scrapeUrlHashes.push(urlHashForScrape(item.url))
-													scrapeCorpus.push(item.content)
+									let prompt: Prompt.Prompt = Prompt.make(basePrompt)
+									const runRound = (round: number) =>
+										Effect.gen(function* () {
+											const response = yield* agentLlm.generateText({
+												prompt,
+												toolkit,
+												// Force a tool on the first round so the model can't
+												// answer from memory without gathering evidence (which
+												// would leave zero sources and fail the grounding gate
+												// on a legitimate company); reflect freely after.
+												toolChoice: round === 1 ? 'required' : 'auto',
+											})
+											prompt = Prompt.concat(
+												prompt,
+												Prompt.fromResponseParts(response.content),
+											)
+											// Attribute sources only to scrapes that actually returned
+											// content this round — read off the tool RESULTS, not the
+											// requested calls — so a failed or empty scrape can never
+											// count toward grounding; keep the content for the value guard.
+											const scrapeUrlHashes: string[] = []
+											for (const tr of response.toolResults) {
+												if (tr.name === 'scrape_page') {
+													const page = tr.result as
+														| { url?: unknown; markdown?: unknown }
+														| null
+														| undefined
+													if (
+														page != null &&
+														typeof page.url === 'string' &&
+														typeof page.markdown === 'string' &&
+														page.markdown.trim().length > 0
+													) {
+														scrapeUrlHashes.push(urlHashForScrape(page.url))
+														scrapeCorpus.push(page.markdown)
+													}
+												} else if (tr.name === 'web_search') {
+													// A search that returned scraped page content (Firecrawl
+													// scrapeOptions) is real fetched evidence — ground on each
+													// such result, exactly like a scrape. The sources row was
+													// upserted by the search cache when the tool ran.
+													const searchResult = tr.result as
+														| { items?: ReadonlyArray<unknown> }
+														| null
+														| undefined
+													for (const raw of searchResult?.items ?? []) {
+														const item = raw as {
+															url?: unknown
+															content?: unknown
+														}
+														if (
+															typeof item.url === 'string' &&
+															typeof item.content === 'string' &&
+															item.content.trim().length > 0
+														) {
+															scrapeUrlHashes.push(urlHashForScrape(item.url))
+															scrapeCorpus.push(item.content)
+														}
+													}
 												}
 											}
-										}
-									}
-									const renderedResults = response.toolResults.map(
-										tr =>
-											`[${tr.name}] ${boundedToolResult(tr.encodedResult ?? tr.result)}`,
-									)
-									// Record each fetch the model gave up on (a dead URL, a
-									// provider 4xx) so the skipped page shows in the run's tool
-									// log; the run keeps going and only fails if nothing grounds it.
-									for (const tr of response.toolResults) {
-										if (!tr.isFailure) continue
-										yield* Ref.update(toolLog, log => [
-											...log,
-											{
-												timestamp: DateTime.nowUnsafe().toString(),
-												type: 'result' as const,
-												tool: tr.name,
-												error: boundedToolResult(tr.encodedResult ?? tr.result),
-											},
-										])
-									}
-									yield* emitRound(
-										round,
-										response.text.length,
-										response.toolCalls.length,
-									)
-									return {
-										text: response.text,
-										hasToolCalls: response.toolCalls.length > 0,
-										scrapeUrlHashes,
-										renderedResults,
-										promptChars: JSON.stringify(response.content).length,
-										inputTokens: response.usage.inputTokens.total ?? 0,
-										outputTokens: response.usage.outputTokens.total ?? 0,
-									}
+											const renderedResults = response.toolResults.map(
+												tr =>
+													`[${tr.name}] ${boundedToolResult(tr.encodedResult ?? tr.result)}`,
+											)
+											// Record each fetch the model gave up on (a dead URL, a
+											// provider 4xx) so the skipped page shows in the run's tool
+											// log; the run keeps going and only fails if nothing grounds it.
+											for (const tr of response.toolResults) {
+												if (!tr.isFailure) continue
+												yield* Ref.update(toolLog, log => [
+													...log,
+													{
+														timestamp: DateTime.nowUnsafe().toString(),
+														type: 'result' as const,
+														tool: tr.name,
+														error: boundedToolResult(
+															tr.encodedResult ?? tr.result,
+														),
+													},
+												])
+											}
+											yield* emitRound(
+												round,
+												response.text.length,
+												response.toolCalls.length,
+											)
+											return {
+												text: response.text,
+												hasToolCalls: response.toolCalls.length > 0,
+												scrapeUrlHashes,
+												renderedResults,
+												promptChars: JSON.stringify(response.content).length,
+												inputTokens: response.usage.inputTokens.total ?? 0,
+												outputTokens: response.usage.outputTokens.total ?? 0,
+											}
+										})
+									return yield* runAgentResearchLoop({
+										maxSteps: maxAgentSteps,
+										maxPromptChars: MAX_LOOP_PROMPT_CHARS,
+										runRound,
+										budgetSnapshot: budget.snapshot(),
+										priorTokensIn: carryTokensIn,
+										priorTokensOut: carryTokensOut,
+									})
 								})
-							return yield* runAgentResearchLoop({
-								maxSteps: maxAgentSteps,
-								maxPromptChars: MAX_LOOP_PROMPT_CHARS,
-								runRound,
-								budgetSnapshot: budget.snapshot(),
+
+							let loop = yield* runPass(
+								`${systemPrompt}\n\n${query}`,
 								priorTokensIn,
 								priorTokensOut,
-							})
+							)
+
+							// A non-anchored discovery scan (prospect / competitor) that comes
+							// back empty gets ONE refined retry before we accept "found
+							// nothing": only here does an empty primary list mean the search —
+							// not the data — fell short, and only here is the entity gate a
+							// no-op. Extraction runs now so the emptiness check sees real
+							// structured findings; the retry reuses this pass's budget.
+							let findings: unknown
+							let refined = false
+							let extractOutputTokens = 0
+							if (isRetryEligible(schemaName) && entityTargets === null) {
+								yield* linkRunSources(loop.scrapedUrlHashes)
+								let extracted = yield* extractStructuredFindings(
+									loop.researchText,
+									[loop.evidenceText, ...scrapeCorpus].join('\n'),
+									null,
+								)
+								findings = extracted.findings
+								extractOutputTokens += extracted.outputTokens
+								if (
+									isDiscoveryScanEmpty(schemaName, findings) &&
+									canAffordAnotherRound(yield* budget.snapshot())
+								) {
+									refined = true
+									yield* Effect.logInfo('research.refining').pipe(
+										Effect.annotateLogs({
+											research_id: researchId,
+											schema: schemaName,
+										}),
+									)
+									yield* publishEvent(researchId, 'run.refining', {
+										schema: schemaName,
+									})
+									const retryLoop = yield* runPass(
+										`${systemPrompt}\n\n${query}\n\n${REFINE_HINT}`,
+										0,
+										0,
+									)
+									loop = {
+										researchText: [loop.researchText, retryLoop.researchText]
+											.filter(t => t.length > 0)
+											.join('\n\n'),
+										evidenceText: [loop.evidenceText, retryLoop.evidenceText]
+											.filter(t => t.length > 0)
+											.join('\n\n'),
+										scrapedUrlHashes: [
+											...new Set([
+												...loop.scrapedUrlHashes,
+												...retryLoop.scrapedUrlHashes,
+											]),
+										],
+										tokensIn: loop.tokensIn + retryLoop.tokensIn,
+										tokensOut: loop.tokensOut + retryLoop.tokensOut,
+										rounds: loop.rounds + retryLoop.rounds,
+										stopReason: retryLoop.stopReason,
+									}
+									yield* linkRunSources(retryLoop.scrapedUrlHashes)
+									extracted = yield* extractStructuredFindings(
+										loop.researchText,
+										[loop.evidenceText, ...scrapeCorpus].join('\n'),
+										null,
+									)
+									findings = extracted.findings
+									extractOutputTokens += extracted.outputTokens
+								}
+							}
+
+							return { loop, findings, refined, extractOutputTokens }
 						}).pipe(
 							Effect.provide(researchToolkitLayer),
 							Effect.provide(budgetLayer),
 							Effect.provide(Layer.succeed(ResearchRunContext)({ researchId })),
 						)
 
+						const loopResult = phaseOutcome.loop
 						researchText = loopResult.researchText
 						evidenceText = loopResult.evidenceText
 						tokensIn = loopResult.tokensIn
 						tokensOut = loopResult.tokensOut
+						retryFindings = phaseOutcome.findings
+						retryExtractTokens = phaseOutcome.extractOutputTokens
 
 						// Entity grounding gate: from the fetched evidence alone (never the
 						// model's prose), classify how strongly the pages concern the
@@ -1221,20 +1514,9 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						`
 
 						// Link every page scraped across the loop's rounds to the run so
-						// findings cite real sources. Scrapes run inside generateText, so
-						// the URLs of pages that returned content are collected each round
-						// and matched to the sources row the cache upserted (by url_hash).
-						// Writes as the fiber's privileged role, like the research_runs
-						// update above.
-						for (const urlHash of loopResult.scrapedUrlHashes) {
-							yield* sql`
-								INSERT INTO research_run_sources (organization_id, research_id, source_id, local_ref, fetched_at, cost_cents)
-								SELECT ${organizationId}, ${researchId}, s.id, s.url, now(), 0
-								FROM sources s
-								WHERE s.url_hash = ${urlHash}
-								ON CONFLICT DO NOTHING
-							`
-						}
+						// findings cite real sources (a discovery-scan retry may have linked
+						// some already — ON CONFLICT makes the re-link a no-op).
+						yield* linkRunSources(loopResult.scrapedUrlHashes)
 					}
 
 					// ── Phase 2: Structured output ──
@@ -1246,159 +1528,20 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							Effect.annotateLogs({ research_id: researchId }),
 						)
 					} else {
-						yield* publishEvent(researchId, 'tool.called', {
-							tool: 'llm.generateObject',
-							phase: 2,
-							schema: schemaName,
-						})
-						// Cast schema to satisfy generateObject's Encoder constraint.
-						// Registry schemas are all Structs with DecodingServices=never,
-						// but Schema.Top erases that — the cast is safe.
-						const structuredResponse = yield* extractLlm.generateObject({
-							schema: outputSchema as typeof FreeformSchema,
-							// Ground the extraction: the model may only output values that
-							// appear in the transcript, and must leave unsupported fields
-							// empty rather than filling them from prior knowledge — otherwise
-							// it will confidently invent phones, tax ids, and emails.
-							prompt: `Produce structured findings STRICTLY from the research transcript below. Only include a value that appears in the transcript; if the transcript does not support a field, omit it or leave it null — never fill a field from prior knowledge. Set each citation's source_id to the exact scraped URL the value came from.\n\nResearch transcript:\n\n${researchText}`,
-						})
-						findings = withProposalIds(structuredResponse.value as unknown)
-						// Drop citations the model invented: keep only source_ids that map
-						// to a page this run actually fetched. A proposed CRM update left
-						// with no valid citation is dropped whole. Cleaned before the
-						// checkpoint below, so a resumed run reads the validated findings.
-						const groundedRows = yield* sql<{
-							localRef: string
-							sourceId: string
-						}>`
-							SELECT local_ref AS "localRef", source_id AS "sourceId"
-							FROM research_run_sources WHERE research_id = ${researchId}
-						`
-						const groundedKeys = new Set<string>()
-						for (const row of groundedRows) {
-							groundedKeys.add(canonicalizeUrl(row.localRef))
-							groundedKeys.add(row.sourceId)
-						}
-						const citationCheck = validateFindingCitations(
-							findings,
-							sourceId =>
-								groundedKeys.has(canonicalizeUrl(sourceId)) ||
-								groundedKeys.has(sourceId),
-						)
-						findings = citationCheck.findings
-						if (citationCheck.total > citationCheck.kept) {
-							yield* Effect.logWarning('research.citations.dropped').pipe(
-								Effect.annotateLogs({
-									research_id: researchId,
-									total: citationCheck.total,
-									kept: citationCheck.kept,
-								}),
+						if (retryFindings !== undefined) {
+							// The discovery-scan retry path already ran extraction under the
+							// shared budget — reuse those findings and their token cost.
+							findings = retryFindings
+							tokensOut += retryExtractTokens
+						} else {
+							const extracted = yield* extractStructuredFindings(
+								researchText,
+								[evidenceText, ...scrapeCorpus].join('\n'),
+								entityMatch,
 							)
+							findings = extracted.findings
+							tokensOut += extracted.outputTokens
 						}
-						// Value provenance: the citation guard proved the cited pages were
-						// fetched, not that they contain the claimed values. Drop any
-						// proposed CRM write whose email/phone/tax-id value appears nowhere
-						// in the run's evidence (scraped pages + the tool transcript) — that
-						// value was invented, real citation or not.
-						// Check findings against tool-result evidence only — never the
-						// model's own prose (researchText) — so a value the model merely
-						// asserted in its reasoning cannot vouch for itself.
-						const evidenceCorpus = [evidenceText, ...scrapeCorpus].join('\n')
-						const valueCheck = verifyValueProvenance(findings, evidenceCorpus)
-						findings = valueCheck.findings
-						if (
-							valueCheck.droppedProposals > 0 ||
-							valueCheck.strippedValues > 0
-						) {
-							yield* Effect.logWarning('research.values.unsupported').pipe(
-								Effect.annotateLogs({
-									research_id: researchId,
-									dropped_proposals: valueCheck.droppedProposals,
-									stripped_values: valueCheck.strippedValues,
-								}),
-							)
-						}
-						// A weak entity match means the fetched pages only glancingly
-						// mention the target: keep the brief but withhold every CRM write
-						// and flag the low confidence, so a reviewer treats these findings
-						// with care rather than trusting an auto-applied update.
-						if (
-							entityMatch === 'weak' &&
-							findings != null &&
-							typeof findings === 'object' &&
-							!Array.isArray(findings)
-						) {
-							const current = findings as Record<string, unknown>
-							const strippedProposals = Array.isArray(
-								current['proposed_updates'],
-							)
-								? (current['proposed_updates'] as unknown[]).length
-								: 0
-							findings = {
-								...current,
-								proposed_updates: [],
-								entity_confidence: 'low',
-							}
-							yield* Effect.logWarning('research.entity.weak').pipe(
-								Effect.annotateLogs({
-									research_id: researchId,
-									stripped_proposals: strippedProposals,
-								}),
-							)
-						}
-						// Applicability: drop any proposed CRM update that could never be
-						// applied — an update whose subject_id names no live row (the model
-						// can invent one for a company that does not exist), or a proposal
-						// whose fields carry no real values. Existence is checked against
-						// the org's own rows; a malformed id trips a cast error read as
-						// "not found".
-						const organizationId = (run as { organizationId: string })
-							.organizationId
-						const proposalList =
-							findings != null &&
-							typeof findings === 'object' &&
-							!Array.isArray(findings)
-								? (findings as Record<string, unknown>)['proposed_updates']
-								: undefined
-						const liveSubjects = new Set<string>()
-						if (Array.isArray(proposalList)) {
-							for (const proposal of proposalList) {
-								if (proposal == null || typeof proposal !== 'object') continue
-								const pu = proposal as Record<string, unknown>
-								if (pu['operation'] === 'create') continue
-								const table = pu['subject_table']
-								const id = pu['subject_id']
-								if (
-									(table !== 'companies' && table !== 'contacts') ||
-									typeof id !== 'string' ||
-									id.trim() === '' ||
-									liveSubjects.has(`${table}:${id}`)
-								)
-									continue
-								const rows = yield* sql`
-									SELECT id FROM ${sql(table)}
-									WHERE id = ${id}
-										AND organization_id = ${organizationId}
-										AND deleted_at IS NULL
-									LIMIT 1
-								`.pipe(Effect.catchTag('SqlError', () => Effect.succeed([])))
-								if (rows.length > 0) liveSubjects.add(`${table}:${id}`)
-							}
-						}
-						const applicability = filterApplicableProposals(
-							findings,
-							(table, id) => liveSubjects.has(`${table}:${id}`),
-						)
-						findings = applicability.findings
-						if (applicability.dropped > 0) {
-							yield* Effect.logWarning('research.proposals.unappliable').pipe(
-								Effect.annotateLogs({
-									research_id: researchId,
-									dropped: applicability.dropped,
-								}),
-							)
-						}
-						tokensOut += structuredResponse.usage.outputTokens.total ?? 0
 						yield* Ref.update(toolLog, log => [
 							...log,
 							{
@@ -1408,11 +1551,6 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								output: { schema: schemaName },
 							},
 						])
-						yield* publishEvent(researchId, 'tool.result', {
-							tool: 'llm.generateObject',
-							phase: 2,
-							schema: schemaName,
-						})
 						yield* sql`
 							UPDATE research_runs
 							SET phase = 2,
@@ -1476,6 +1614,36 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						`
 						yield* publishEvent(researchId, 'run.no_reliable_data', {
 							sourceCount: sources?.n ?? 0,
+						})
+						const parentGroupId = (run as { parentId: string | null }).parentId
+						if (parentGroupId) yield* rollupParentLocked(parentGroupId)
+						return
+					}
+
+					// An open-ended discovery scan that came back empty even after a
+					// refined retry has no reliable findings to report — mark it
+					// no_reliable_data instead of a green success over an empty list.
+					if (
+						entityTargets === null &&
+						isRetryEligible(schemaName) &&
+						isDiscoveryScanEmpty(schemaName, findings)
+					) {
+						yield* sql`
+							UPDATE research_runs
+							SET status = 'no_reliable_data',
+								phase = 3,
+								findings = ${JSON.stringify({
+									error:
+										'The search found no companies matching the criteria, even after a refined retry, so there are no reliable findings to report.',
+									reason: 'no_reliable_data',
+								})},
+								tool_log = ${JSON.stringify(finalToolLog)},
+								completed_at = now(),
+								updated_at = now()
+							WHERE id = ${researchId} AND status = 'running'
+						`
+						yield* publishEvent(researchId, 'run.no_reliable_data', {
+							reason: 'no_results',
 						})
 						const parentGroupId = (run as { parentId: string | null }).parentId
 						if (parentGroupId) yield* rollupParentLocked(parentGroupId)

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -29,6 +29,7 @@ import {
 	researchToolkit,
 	researchToolkitLayer,
 	ScrapePageTool,
+	stripPlaceholderSiteFilters,
 	WebSearchTool,
 } from './tools'
 
@@ -757,6 +758,93 @@ describe('researchToolkit — a web-fetch failure is non-fatal', () => {
 				// fiber is not killed, so one forbidden page can't sink the whole run
 				expect(isFailure).toBe(true)
 			})
+		})
+	})
+})
+
+describe('stripPlaceholderSiteFilters', () => {
+	describe('when real keywords carry a placeholder site: filter', () => {
+		it('should drop the filter and keep the keywords', () => {
+			// GIVEN a query with a made-up site:example.com filter
+			const query = 'midsize US 3PL freight brokerage site:example.com'
+
+			// WHEN the placeholder filter is stripped
+			const result = stripPlaceholderSiteFilters(query)
+
+			// THEN only the real keywords remain, with no double spaces
+			expect(result).toBe('midsize US 3PL freight brokerage')
+		})
+	})
+
+	describe('when the placeholder uses a non-.com or family host', () => {
+		it('should strip example.org, yourdomain.*, domain.*, and placeholder.*', () => {
+			// GIVEN queries with each recognised placeholder family
+			// WHEN each is stripped
+			// THEN the placeholder token is removed
+			expect(stripPlaceholderSiteFilters('freight site:example.org')).toBe(
+				'freight',
+			)
+			expect(stripPlaceholderSiteFilters('freight site:yourdomain.com')).toBe(
+				'freight',
+			)
+			expect(stripPlaceholderSiteFilters('freight site:domain.net')).toBe(
+				'freight',
+			)
+			expect(stripPlaceholderSiteFilters('freight site:placeholder.io')).toBe(
+				'freight',
+			)
+		})
+	})
+
+	describe('when the placeholder host has trailing punctuation', () => {
+		it('should still recognise and strip it', () => {
+			// GIVEN a site: filter followed by a comma
+			const query = 'brokers site:example.com, midsize'
+
+			// WHEN stripped
+			const result = stripPlaceholderSiteFilters(query)
+
+			// THEN the placeholder is gone and the rest is kept
+			expect(result).toBe('brokers midsize')
+		})
+	})
+
+	describe('when the site: filter targets a real domain', () => {
+		it('should keep it untouched', () => {
+			// GIVEN a query filtering by a real, known domain
+			const query = 'ocado directors site:gov.uk'
+
+			// WHEN stripped
+			const result = stripPlaceholderSiteFilters(query)
+
+			// THEN the real filter is preserved
+			expect(result).toBe('ocado directors site:gov.uk')
+		})
+	})
+
+	describe('when there is no site: filter at all', () => {
+		it('should return the query unchanged', () => {
+			// GIVEN a plain keyword query
+			const query = 'midsize US freight brokerage companies'
+
+			// WHEN stripped
+			const result = stripPlaceholderSiteFilters(query)
+
+			// THEN it is returned as-is
+			expect(result).toBe(query)
+		})
+	})
+
+	describe('when the query is only a placeholder site: filter', () => {
+		it('should keep the original so the search still runs', () => {
+			// GIVEN a query that is nothing but the placeholder filter
+			const query = 'site:example.com'
+
+			// WHEN stripping would leave an empty query
+			const result = stripPlaceholderSiteFilters(query)
+
+			// THEN the original is preserved rather than searching for nothing
+			expect(result).toBe('site:example.com')
 		})
 	})
 })

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -189,6 +189,39 @@ const cheapExhausted = (tool: string) => (e: { readonly remaining: number }) =>
 		`cheap budget exhausted (${e.remaining}¢ left) — stop searching and summarize what you have`,
 	)
 
+// A model sometimes appends a made-up "site:" filter (e.g. site:example.com) to a
+// search, which guarantees zero results. Detect the obvious placeholder hosts so
+// such a filter can be dropped before the query reaches the provider.
+const isPlaceholderSiteHost = (host: string): boolean => {
+	const normalizedHost = host
+		.toLowerCase()
+		.replace(/^www\./, '')
+		.replace(/[).,;:'"]+$/, '')
+	return (
+		/^example\.[a-z]{2,}$/.test(normalizedHost) ||
+		normalizedHost === 'example' ||
+		/^(your|my)domain\.[a-z]{2,}$/.test(normalizedHost) ||
+		/^domain\.[a-z]{2,}$/.test(normalizedHost) ||
+		/^placeholder\.[a-z]{2,}$/.test(normalizedHost) ||
+		/^(your|my)site\.[a-z]{2,}$/.test(normalizedHost)
+	)
+}
+
+/**
+ * Removes any `site:` filter that targets an obvious placeholder host from a
+ * search query. If stripping would leave nothing to search, the original query
+ * is kept so the search still runs.
+ */
+export const stripPlaceholderSiteFilters = (query: string): string => {
+	const stripped = query
+		.replace(/\bsite:(\S+)/gi, (match, host: string) =>
+			isPlaceholderSiteHost(host) ? '' : match,
+		)
+		.replace(/\s{2,}/g, ' ')
+		.trim()
+	return stripped.length > 0 ? stripped : query
+}
+
 export const researchToolkitLayer = researchToolkit.toLayer(
 	Effect.gen(function* () {
 		const search = yield* SearchProvider
@@ -203,8 +236,16 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 			web_search: params =>
 				Effect.gen(function* () {
 					yield* budget.chargeCheap('search', SEARCH_COST_CENTS)
+					// Drop a made-up placeholder site: filter (e.g. site:example.com)
+					// so it can't force a zero-result search.
+					const query = stripPlaceholderSiteFilters(params.query)
+					if (query !== params.query) {
+						yield* Effect.logWarning(
+							'research.search.placeholder_site_stripped',
+						).pipe(Effect.annotateLogs({ tool: 'web_search' }))
+					}
 					return yield* search.search({
-						query: params.query,
+						query,
 						limit: params.limit ?? undefined,
 						recency:
 							params.recency_days != null
@@ -269,6 +310,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					yield* budget.chargePaid(
 						'registry',
 						REGISTRY_LOOKUP_COST_CENTS,
+						'registry_lookup',
 						idempotencyKey,
 					)
 					return yield* registry.lookup({


### PR DESCRIPTION
## What

A prod test-campaign sweep on the research service (server v2026.7.8) surfaced three issues, filed together as #213. This fixes them in the Research bounded context (`packages/research`, with integration tests in `apps/server`).

- **Spend-by-tool was unusable.** The paid-spend ledger recorded every charge under a fixed label `"paid"`, so asking for spend "grouped by tool" always returned one meaningless bucket. It now records the real tool that spent the money.
- **Open-ended prospect scans could report success while finding nothing.** A broad "find me prospects" search that turned up only social-media / glossary noise still finished as a green `succeeded` with an empty list. It now refines and retries once, and if still empty says so honestly.

## Changes

- **Per-tool paid spend (A):** thread the calling tool's name (`registry_lookup`, `discover_contacts`) into `chargePaid` instead of the hardcoded `"paid"`, so `get_research_spend { group_by: "tool" }` returns a real breakdown.
- **Query hygiene (B1):** strip a made-up placeholder `site:` filter (e.g. `site:example.com`) before a web search runs, and add query-construction guidance to the agent's system prompt (prefer directories / industry lists / registries; never emit a placeholder `site:` filter).
- **Refine-and-retry + honest status (B2/B3):** when a non-anchored prospect/competitor scan extracts no results, re-run the agent once with a refinement hint — under the **same** run budget — then re-extract; if still empty, mark the run `no_reliable_data` instead of `succeeded`.
- **Finding C (issue-only):** #199's `costCents > 0` acceptance item was reworded directly on that issue (a US enrichment run legitimately costs 0) — no code here.

## Impact

- **Paid-spend rows:** new rows carry real tool names in the `tool` column; existing rows keep `"paid"`. No migration — the column was already free-form text. `group_by=tool` becomes meaningful; `group_by=provider` is unchanged.
- **MCP + HTTP parity:** the fix lives in the shared research service / run fiber, so both transports get identical behavior.
- **Run outcomes:** an empty **non-anchored** prospect/competitor scan now ends `no_reliable_data` rather than `succeeded` — a deliberate behavior change for that one case. Entity-anchored schemas (`company_enrichment_v1`, `contact_discovery_v1`) and anchored scans keep today's single-pass behavior.
- **Cost:** a refined retry is one extra agent pass, bounded to a single retry and gated on the run budget still having room — it reuses the same budget, no reset. No new env vars, no schema or wire-shape change.

## Review guide

- Start in `packages/research/src/application/research-service.ts`: the `runPass` wrapper + the refine-retry `if` in the phase-1 scope, and the `no_reliable_data` empty-scan gate before the `succeeded` write. **Riskiest part is budget sharing** — both passes run under one `Effect.provide(budgetLayer)` scope on purpose; re-providing would build a fresh Effect `MemoMap` and reset the per-run spend, so the retry stays inside the same provided scope rather than a second `runPass` with its own provide.
- The large `research-service.ts` diff is mostly the existing `runRound` body re-indenting one level when wrapped in `runPass`; the genuinely new code is the two factored closures (`extractStructuredFindings`, `linkRunSources`), the retry block, the empty gate, and the prompt/stripper additions.
- `discovery-scan.ts` is the small pure module: which schemas retry, what "empty" means, the refinement hint.
- Rebased onto `origin/main` after #208's extract-failure fix landed; the `tools.ts` / `tools.test.ts` overlap merged cleanly (all three fetch tools keep `failureMode: 'return'`).

## Tests

- Unit: the placeholder-`site:` stripper and the discovery-scan helpers (eligibility, emptiness, refinement hint) — branches + edge cases.
- Integration (real DB): a follow-up registry lookup persists `tool = 'registry_lookup'` on its spend row; a full non-anchored prospect scan that extracts nothing fires the refine step and ends `no_reliable_data`.

## Verification

- Ran `pnpm check-types` (13/13), `pnpm test` (research unit 37 + both research integration suites, 6 tests), and `pnpm build` (13/13) — all green, post-rebase.
- Drove the empty-scan path end-to-end via the new integration test against local Postgres (`batuda_it`): confirmed the `research.refining` event fires and the run terminates `no_reliable_data`.
- Note: a local live LLM run can't exercise B — local dev uses stub providers, whose `generateText` returns no tool calls (0 sources), so the integration test drives the path deterministically instead.

Closes #213
