### PR TITLE
chore: let integration tests run in an unprovisioned worktree

### DIFF
--- a/scripts/integration-db-setup.ts
+++ b/scripts/integration-db-setup.ts
@@ -1,4 +1,8 @@
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+
+import { parse as parseEnv } from 'dotenv'
 
 // Vitest globalSetup for the `*.integration.test.ts` suites. Locally it builds a
 // disposable `batuda_it` database, migrates it to HEAD, and seeds it — the same
@@ -13,10 +17,44 @@ import { execSync } from 'node:child_process'
 
 const IT_URL = 'postgresql://batuda:batuda@localhost:5433/batuda_it'
 
+// The `pnpm cli` calls below migrate + seed batuda_it, and the CLI reads its
+// credentials (STORAGE_*, auth secrets, …) from the checkout's `.env`. A linked
+// worktree created with a bare `git worktree add` has none — only
+// `pnpm cli worktree up` writes one — so the seed would die with a ConfigError
+// and the pre-push hook couldn't run there at all. Read those values from the
+// MAIN checkout's `.env` files (the same source `worktree up` copies from) so
+// the setup works in any worktree, provisioned or not. DATABASE_URL is left out
+// on purpose: the batuda_it override wins because the CLI keeps an
+// explicitly-set env var ahead of any `.env` value. Returns nothing in the main
+// checkout, where the CLI already finds its own `.env`.
+const mainCheckoutEnv = (): Record<string, string> => {
+	try {
+		// `--git-common-dir` is the SHARED `.git`, so its parent is the main
+		// checkout from any worktree (and the current checkout otherwise).
+		const gitCommonDir = execFileSync(
+			'git',
+			['rev-parse', '--path-format=absolute', '--git-common-dir'],
+			{ encoding: 'utf8' },
+		).trim()
+		const mainRoot = dirname(gitCommonDir)
+		const inherited: Record<string, string> = {}
+		for (const relativePath of ['.env', 'apps/cli/.env']) {
+			const file = resolve(mainRoot, relativePath)
+			if (existsSync(file))
+				Object.assign(inherited, parseEnv(readFileSync(file)))
+		}
+		return inherited
+	} catch {
+		return {}
+	}
+}
+
 export default function setup(): void {
 	if (process.env['CI']) return
 
-	const itEnv = { ...process.env, DATABASE_URL: IT_URL }
+	// Main checkout's `.env` first (fills a worktree's missing credentials), then
+	// the live shell, then the batuda_it target — later spreads win.
+	const itEnv = { ...mainCheckoutEnv(), ...process.env, DATABASE_URL: IT_URL }
 	const sh = (cmd: string, env: NodeJS.ProcessEnv = process.env) =>
 		execSync(cmd, { stdio: 'inherit', shell: '/bin/bash', env })
 


### PR DESCRIPTION
## What

The integration-test setup (`scripts/integration-db-setup.ts`, the vitest globalSetup that migrates + seeds the disposable `batuda_it` database before `*.integration.test.ts` runs) does that seeding through `pnpm cli`, which reads its credentials (storage keys, auth secrets, …) from the checkout's `.env`. A git worktree created with a bare `git worktree add` has no `.env` — only `pnpm cli worktree up` writes one — so the seed died with a `ConfigError` and the **pre-push integration hook couldn't run there at all**, forcing `--no-verify` on every push from such a worktree.

This makes the setup **inherit the main checkout's `.env`** (found via the shared `.git` common dir — the same values `worktree up` copies from) so it works in any worktree, provisioned or not.

## Impact

- **Local dev only.** No-op in CI (`if (process.env['CI']) return` — CI supplies a seeded Neon branch). No-op in the main checkout, where the CLI already finds its own `.env`. It only fills a worktree's missing credentials.
- **`batuda_it` stays the target.** `DATABASE_URL` is deliberately not inherited; the explicit `batuda_it` override stays authoritative because the CLI keeps an explicitly-set env var ahead of any `.env` value.
- No schema, API, or dependency change.

## Review guide

- One file. The only new subprocess is `execFileSync('git', […])` (arg-array, no shell). The existing `execSync` calls run **static** commands (`docker … psql`, `pnpm -w cli …`) with no interpolated input — the inherited `.env` values flow into the child `env`, never into a command string.

## Verification

- Pushed this branch from a **freshly `git worktree add`-ed, unprovisioned** worktree with the pre-push hook **enabled**: the hook's `turbo test:integration` ran the full suite — **47 files, 280 tests passed** — where before the fix its globalSetup died with `ConfigError`. That push is the end-to-end proof.

Related: #208 (its work first hit this friction).
