### PR TITLE
fix: resolve blob uploads failing against Cloudflare R2

### DIFF
--- a/apps/server/src/services/research-blob-storage.ts
+++ b/apps/server/src/services/research-blob-storage.ts
@@ -9,7 +9,9 @@
  *
  * Errors from the underlying `StorageProvider` are re-raised as plain
  * defects since `BlobStorage`'s Effect signature is error-free — the
- * caller (`cached-scrape.ts`) maps them to `ProviderError` itself.
+ * caller (`cached-scrape.ts`) can't recover from them. `StorageProvider`
+ * itself already logs and traces the failure before it gets here, so
+ * nothing is lost by discarding the typed error at this boundary.
  */
 
 import { Effect, Layer } from 'effect'

--- a/apps/server/src/services/s3-storage-provider.ts
+++ b/apps/server/src/services/s3-storage-provider.ts
@@ -42,6 +42,12 @@ export const S3StorageProviderLive = Layer.effect(
 				secretAccessKey: Redacted.value(secretAccessKey),
 			},
 			forcePathStyle: true,
+			// Cloudflare R2 rejects the CRC-based integrity headers the AWS SDK
+			// sends by default on every request — only send/verify a checksum
+			// when the operation genuinely needs one, matching the fix already
+			// applied to scripts/gh-pr-media.sh for the same R2 behavior.
+			requestChecksumCalculation: 'WHEN_REQUIRED',
+			responseChecksumValidation: 'WHEN_REQUIRED',
 		})
 
 		const put = (params: PutParams): Effect.Effect<void, StorageError> =>
@@ -62,7 +68,25 @@ export const S3StorageProviderLive = Layer.effect(
 						operation: 'put',
 						key: params.key,
 					}),
-			}).pipe(Effect.asVoid)
+			}).pipe(
+				Effect.asVoid,
+				// Every caller (recordings, media, research blob) shares this one
+				// client, so logging and tracing it here — rather than in each
+				// caller — is what makes a write failure visible no matter who
+				// asked for it.
+				Effect.tapError(error =>
+					Effect.logError('storage.put failed').pipe(
+						Effect.annotateLogs({
+							key: params.key,
+							bucket,
+							message: error.message,
+						}),
+					),
+				),
+				Effect.withSpan('storage.put', {
+					attributes: { key: params.key, bucket },
+				}),
+			)
 
 		const get = (key: string): Effect.Effect<Uint8Array, StorageError> =>
 			Effect.tryPromise({
@@ -83,7 +107,16 @@ export const S3StorageProviderLive = Layer.effect(
 						operation: 'get',
 						key,
 					}),
-			})
+			}).pipe(
+				Effect.tapError(error =>
+					Effect.logError('storage.get failed').pipe(
+						Effect.annotateLogs({ key, bucket, message: error.message }),
+					),
+				),
+				Effect.withSpan('storage.get', {
+					attributes: { key, bucket },
+				}),
+			)
 
 		const del = (key: string): Effect.Effect<void, StorageError> =>
 			Effect.tryPromise({

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1169,7 +1169,14 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								findings: result as unknown,
 								outputTokens: structuredResponse.usage.outputTokens.total ?? 0,
 							}
-						})
+						}).pipe(
+							Effect.withSpan('research.phase2', {
+								attributes: {
+									'research.run_id': researchId,
+									schema: schemaName,
+								},
+							}),
+						)
 
 					// Link each page that returned content to the run so findings cite
 					// real sources; the sources row was upserted by the search cache
@@ -1455,6 +1462,9 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							Effect.provide(researchToolkitLayer),
 							Effect.provide(budgetLayer),
 							Effect.provide(Layer.succeed(ResearchRunContext)({ researchId })),
+							Effect.withSpan('research.phase1', {
+								attributes: { 'research.run_id': researchId },
+							}),
 						)
 
 						const loopResult = phaseOutcome.loop
@@ -1551,28 +1561,38 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 
 					// ── Phase 3: Brief generation ──
 					const briefLang = context?.hints?.language ?? 'en'
-					yield* publishEvent(researchId, 'tool.called', {
-						tool: 'llm.generateText',
-						phase: 3,
-						language: briefLang,
-					})
-
-					const briefResponse = yield* writerLlm.generateText({
-						prompt: `Write a concise human-readable research brief in ${briefLang}, summarizing ONLY the structured findings below. Do not add any fact, number, name, or contact detail that is not present in the findings.\n\n${JSON.stringify(findings)}`,
-					})
-
-					const briefMd = briefResponse.text
-					tokensOut += briefResponse.usage.outputTokens.total ?? 0
-
-					yield* Ref.update(toolLog, log => [
-						...log,
-						{
-							timestamp: DateTime.nowUnsafe().toString(),
-							type: 'result' as const,
+					const briefMd = yield* Effect.gen(function* () {
+						yield* publishEvent(researchId, 'tool.called', {
 							tool: 'llm.generateText',
-							output: { phase: 3, briefLength: briefMd.length },
-						},
-					])
+							phase: 3,
+							language: briefLang,
+						})
+
+						const briefResponse = yield* writerLlm.generateText({
+							prompt: `Write a concise human-readable research brief in ${briefLang}, summarizing ONLY the structured findings below. Do not add any fact, number, name, or contact detail that is not present in the findings.\n\n${JSON.stringify(findings)}`,
+						})
+
+						tokensOut += briefResponse.usage.outputTokens.total ?? 0
+
+						yield* Ref.update(toolLog, log => [
+							...log,
+							{
+								timestamp: DateTime.nowUnsafe().toString(),
+								type: 'result' as const,
+								tool: 'llm.generateText',
+								output: { phase: 3, briefLength: briefResponse.text.length },
+							},
+						])
+
+						return briefResponse.text
+					}).pipe(
+						Effect.withSpan('research.phase3', {
+							attributes: {
+								'research.run_id': researchId,
+								language: briefLang,
+							},
+						}),
+					)
 
 					// ── Persist results ──
 					const finalToolLog = yield* Ref.get(toolLog)
@@ -1688,6 +1708,12 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						tokensOut,
 					})
 				}).pipe(
+					// One span covering the whole run, so every phase/tool span nests
+					// under it and a failed run points straight at the phase/tool that
+					// broke it.
+					Effect.withSpan('research.run', {
+						attributes: { 'research.run_id': researchId, user_id: userId },
+					}),
 					// Scope the run so the heartbeat fiber (forked above) is
 					// interrupted the moment the run finishes, fails, or is cancelled.
 					Effect.scoped,

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -759,6 +759,29 @@ describe('researchToolkit — a web-fetch failure is non-fatal', () => {
 				expect(isFailure).toBe(true)
 			})
 		})
+
+		describe('when schema_name is not a registered schema', () => {
+			it('should surface the plain validation message, not a re-wrapped failure cause', async () => {
+				// GIVEN a schema_name the model made up — the extract provider is never
+				// reached, so its result here is irrelevant
+				const { isFailure, result } = await extractStructuredResult(
+					() => Effect.succeed({}),
+					{ url: 'https://acmecorp.es', schema_name: 'totally_bogus_schema' },
+				)
+
+				// THEN the model reads a failure...
+				expect(isFailure).toBe(true)
+				// AND the message names the bad value and lists the valid ones in
+				// plain text, not a stringified Cause/Fail dump — that shape appears
+				// if this validation error is ever re-caught and re-wrapped by the
+				// same handling that logs a genuine provider failure
+				const description = (result as { reason: { description: string } })
+					.reason.description
+				expect(description).toBe(
+					'extract_structured: Unknown schema_name: totally_bogus_schema. Valid names: freeform, company_enrichment_v1, competitor_scan_v1, contact_discovery_v1, prospect_scan_v1',
+				)
+			})
+		})
 	})
 })
 

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -17,7 +17,7 @@
  * `ProviderError` cascade through the harness, not inside tool calls.
  */
 
-import { Effect, Schema } from 'effect'
+import { Cause, Effect, Schema } from 'effect'
 import { AiError, Tool, Toolkit } from 'effect/unstable/ai'
 
 import { AcceptedCountry } from '../domain/country'
@@ -180,15 +180,6 @@ const mapToolError = (toolName: string) => (err: unknown) =>
 		}),
 	)
 
-// Charged against the run before each vendor call (cheap tier for
-// search/scrape/extract, paid tier for the registry). When the budget refuses,
-// the refusal is handed back to the model as a tool result so it stops using
-// that tool and wraps up; the loop's own budget check is the hard halt.
-const cheapExhausted = (tool: string) => (e: { readonly remaining: number }) =>
-	mapToolError(tool)(
-		`cheap budget exhausted (${e.remaining}¢ left) — stop searching and summarize what you have`,
-	)
-
 // A model sometimes appends a made-up "site:" filter (e.g. site:example.com) to a
 // search, which guarantees zero results. Detect the obvious placeholder hosts so
 // such a filter can be dropped before the query reaches the provider.
@@ -232,6 +223,44 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 		const budget = yield* Budget
 		const { researchId } = yield* ResearchRunContext
 
+		// Charged against the run before each vendor call (cheap tier for
+		// search/scrape/extract, paid tier for the registry). When the budget
+		// refuses, the refusal is handed back to the model as a tool result so it
+		// stops using that tool and wraps up; the loop's own budget check is the
+		// hard halt. Logged at warning (not error) since running out of budget is
+		// an expected signal, not a failure.
+		const cheapExhausted =
+			(toolName: string) => (e: { readonly remaining: number }) =>
+				Effect.logWarning('research.tool.budget_exhausted').pipe(
+					Effect.annotateLogs({
+						tool: toolName,
+						'research.run_id': researchId,
+						remaining_cents: e.remaining,
+					}),
+					Effect.andThen(
+						mapToolError(toolName)(
+							`cheap budget exhausted (${e.remaining}¢ left) — stop searching and summarize what you have`,
+						),
+					),
+				)
+
+		// A tool failure otherwise reaches the model and the run's tool_log but
+		// never the telemetry backend, so a systemic failure (e.g. every
+		// scrape_page call rejected by the object store) stays invisible outside
+		// the DB. Logged here, before the cause is mapped to the model-facing
+		// tool result, so it shows up in Honeycomb regardless of what kind of
+		// failure it was.
+		const logToolFailure =
+			(toolName: string) => (cause: Cause.Cause<unknown>) =>
+				Effect.logError('research.tool.failed').pipe(
+					Effect.annotateLogs({
+						tool: toolName,
+						'research.run_id': researchId,
+						cause: Cause.pretty(cause),
+					}),
+					Effect.andThen(mapToolError(toolName)(cause)),
+				)
+
 		return researchToolkit.of({
 			web_search: params =>
 				Effect.gen(function* () {
@@ -255,7 +284,14 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					})
 				}).pipe(
 					Effect.catchTag('BudgetExceeded', cheapExhausted('web_search')),
-					Effect.catchCause(cause => mapToolError('web_search')(cause)),
+					Effect.catchCause(logToolFailure('web_search')),
+					Effect.withSpan('research.tool.web_search', {
+						attributes: {
+							'research.tool': 'web_search',
+							'research.run_id': researchId,
+							query: params.query,
+						},
+					}),
 				),
 
 			scrape_page: params =>
@@ -274,14 +310,37 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 						: page
 				}).pipe(
 					Effect.catchTag('BudgetExceeded', cheapExhausted('scrape_page')),
-					Effect.catchCause(cause => mapToolError('scrape_page')(cause)),
+					Effect.catchCause(logToolFailure('scrape_page')),
+					Effect.withSpan('research.tool.scrape_page', {
+						attributes: {
+							'research.tool': 'scrape_page',
+							'research.run_id': researchId,
+							url: params.url,
+						},
+					}),
 				),
 
 			extract_structured: params => {
+				// Both branches reuse these span options so the early return still
+				// emits a research.tool.extract_structured span, but only the
+				// extraction branch runs through catchCause below. An unknown
+				// schema_name is an expected, model-caused error whose message is
+				// already clean; sending it through catchCause too would re-wrap and
+				// pretty-print the cause, burying that message in an unreadable dump.
+				const spanOptions = {
+					attributes: {
+						'research.tool': 'extract_structured',
+						'research.run_id': researchId,
+						url: params.url,
+						schema_name: params.schema_name,
+					},
+				}
 				const schema = schemaRegistry[params.schema_name]
 				if (!schema) {
 					return mapToolError('extract_structured')(
 						`Unknown schema_name: ${params.schema_name}. Valid names: ${Object.keys(schemaRegistry).join(', ')}`,
+					).pipe(
+						Effect.withSpan('research.tool.extract_structured', spanOptions),
 					)
 				}
 				return Effect.gen(function* () {
@@ -297,7 +356,8 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 						'BudgetExceeded',
 						cheapExhausted('extract_structured'),
 					),
-					Effect.catchCause(cause => mapToolError('extract_structured')(cause)),
+					Effect.catchCause(logToolFailure('extract_structured')),
+					Effect.withSpan('research.tool.extract_structured', spanOptions),
 				)
 			},
 


### PR DESCRIPTION
## What

This fixes a bug in Research — the CRM feature that autonomously investigates a company by searching and reading its web pages. When the research agent reads a page (`scrape_page`), it saves that page's content to cloud storage (Cloudflare R2) so the rest of the run can reference it. That save was silently failing in production: a data-integrity header the storage client sends by default is one Cloudflare R2 rejects. The practical effect — real company-enrichment runs had nothing to ground their findings on, so they fell back to "no reliable data" instead of returning a profile.

## The fix

- **Root cause**: told the shared storage client to only send that integrity header when the operation actually requires one, matching the exact fix already applied to `scripts/gh-pr-media.sh` for the same Cloudflare R2 behavior (#212).
- **Why it took a week to diagnose**: the original failure reached the model and the run's own stored tool log, but never Honeycomb — there was no log line and no trace for it. Every tool call, research phase (agent loop / extraction / brief-writing), the whole run, and the storage read/write now open a trace span, and a genuine failure logs an error before it's handed back to the model. A budget running out mid-run logs a warning instead — that's an expected stop signal, not a failure.

## Impact

- No migrations, no new environment variables, no API/wire-shape changes, no auth changes.
- **Observability surface change**: new trace spans (`research.run`, `research.phase1/2/3`, `research.tool.web_search|scrape_page|extract_structured`, `storage.put`, `storage.get`) and new error/warning logs will start appearing for the research pipeline once this deploys. Worth knowing if anything is watching for silence in that space.
- The checksum setting applies to the one `S3Client` shared by both Cloudflare R2 (prod) and MinIO (local dev) — matches the precedent in #212, applied at the client level rather than per-caller.

## Review guide

- **Can't be verified locally or in CI** — the bug is specific to how Cloudflare R2 handles this header; local dev runs against MinIO, which doesn't reproduce it. The only real confirmation is after deploy: re-run the exact company-enrichment runs cited when #205 was reopened (Sunset, Green Worldwide) and confirm `scrape_page` succeeds instead of falling to `no_reliable_data`.
- **Riskiest part**: wrapping the run and its phases in spans touches `research-service.ts`'s resume/checkpoint logic — the same function the crash-resilience audit covers, including the entity-gate fail-closed guards. I verified this specifically against the full 280-test integration suite (which exercises the entity-gate resume path) both before and after every change.
- **Deliberate scope boundary**: only `web_search` / `scrape_page` / `extract_structured` got tool-level logging and spans, matching what was actually asked for. `registry_lookup` and `discover_contacts` — the two tools that spend real money — still have no equivalent instrumentation; flagging in case that's wanted as a follow-up rather than assuming it's out of scope.
- **A regression I introduced and fixed during self-review**: restructuring `extract_structured` to share one trace span across both its branches initially routed the "unknown schema_name" validation error through the same path that logs a genuine tool failure — which double-wrapped that message into an unreadable JSON dump instead of the clean text the model used to see. Fixed by keeping the two branches separate (sharing only the span options), and pinned down with the new test in `tools.test.ts` — confirmed it fails against the buggy version and passes against the fix.

## Tests

- New test in `tools.test.ts`: `extract_structured` with an unregistered `schema_name` still returns the plain, single-wrapped validation message. No other new tests — this PR is primarily configuration plus logging/tracing plumbing, and the existing suites (322 research unit tests, 548 server unit tests, 280 integration tests) already exercise every code path touched.

## Verification

- `pnpm install`, `check-types` (13 packages), `test` (20 workspace test tasks), `build` (13 packages) — all green.
- Full integration suite (280 tests against live local Postgres, including the entity-gate resume test) — green, both before and after the self-review fixes.
- Did not verify against a live dev server or real R2 — see Review guide for why, and how to confirm after deploy.

Closes #205
