### PR TITLE
cicd: skip CI on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # Run on ready-for-review too (not a default type), so a draft flipped to
+    # ready is checked immediately instead of waiting for the next push.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +18,8 @@ permissions:
 jobs:
   ci:
     name: Lint, Build, Type Check, Test
+    # A draft PR is work in progress, so skip CI until it's marked ready.
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## What

CI runs on every pull request to `main` today — including **drafts** — so a work-in-progress PR spends CI minutes before it's ready for review. This gates CI on the PR not being a draft.

## Changes

- Gated the CI job on `github.event.pull_request.draft == false`, so a draft PR triggers no CI run.
- Added `ready_for_review` to the trigger types (it is not a default type), so marking a draft ready runs CI immediately rather than waiting for the next push.

## Impact

- Draft PRs show no CI checks until marked ready. A draft can't be merged, so no required-check / branch-protection gate is affected — a ready PR runs and gates exactly as before.
- Because `pull_request` workflows run from the base branch's copy, this only takes effect once merged to `main` (it will not change the current draft's behavior until then).

## Verification

- YAML-only change, no code paths touched; standard GitHub Actions draft-gating.