### PR TITLE
cicd(deploy): migrate deploys from kraftkit to the new Unikraft CLI

### DIFF
--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -10,49 +10,47 @@ concurrency:
   group: deploy-mail-worker
   cancel-in-progress: false
 
-# Least privilege: deploy authenticates to KraftCloud via secrets, not the
+# Least privilege: deploy authenticates to Unikraft Cloud via secrets, not the
 # GitHub token. It only needs to read the repo.
 permissions:
   contents: read
 
 env:
   KRAFTCLOUD_METRO: fra
-  # Pinned to the same kraft CLI version as deploy_server.yml. Bump
-  # both together after a dry-run on one target.
-  KRAFT_VERSION: v0.12.10
+  # Pinned new Unikraft CLI (`unikraft`, from unikraft-cloud/cli) version.
+  # Bump deliberately after verifying a new release against a dry-run deploy.
+  UNIKRAFT_CLI_VERSION: "0.4.1"
+  # Image namespace on Unikraft Cloud is the organization slug; published
+  # images and running instances live under `<org>/<name>`.
+  KRAFTCLOUD_ORG: gaaaa
 
 jobs:
   deploy:
-    name: Deploy to KraftCloud
+    name: Deploy to Unikraft Cloud
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The image now builds once in its own step (below); an uncached build is
+    # the long pole, so keep a generous ceiling until build caching lands.
+    timeout-minutes: 30
     environment: production
 
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Prepare files for KraftCloud
+      - name: Prepare files for Unikraft Cloud
         run: |
           cp apps/mail-worker/Kraftfile Kraftfile
           cp apps/mail-worker/Dockerfile Dockerfile
 
-      - name: Cache KraftCloud CLI
-        id: kraft-cache
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      # Installs the `unikraft` CLI and logs it in headlessly. The new CLI keeps
+      # its own auth store (a legacy `kraft`/UKC_TOKEN login does not carry
+      # over), so every deploy authenticates here via the org token.
+      - name: Install and log in to Unikraft Cloud
+        uses: unikraft/setup-action@29c9cce5bc7e894f8929c845d4fba518ef8f1015 # v1
         with:
-          path: kraft.deb
-          key: kraft-cli-${{ env.KRAFT_VERSION }}
-
-      - name: Download KraftCloud CLI
-        if: steps.kraft-cache.outputs.cache-hit != 'true'
-        run: |
-          curl -sSfL "https://github.com/unikraft/kraftkit/releases/download/${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION#v}_linux_amd64.deb" -o kraft.deb
-
-      - name: Install KraftCloud CLI
-        run: |
-          sudo dpkg -i kraft.deb
-          which kraft
+          version: ${{ env.UNIKRAFT_CLI_VERSION }}
+          token: ${{ secrets.KRAFTCLOUD_TOKEN }}
+          organization: ${{ env.KRAFTCLOUD_ORG }}
 
       - name: Extract version from tag
         id: meta
@@ -64,21 +62,21 @@ jobs:
           fi
           echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
-      # Background worker — no public HTTP endpoint, so no service. Use a
-      # stable instance name (`batuda-mail-worker`) mirroring the
-      # batuda-server / batuda-web naming so ops commands target a
-      # predictable identity. The IMAP IDLE connections drop on any
-      # restart and the worker's claim-and-reconnect loop re-establishes
-      # them, so a ~5s gap between delete + recreate is acceptable.
-      - name: Delete previous instance (idempotent)
-        env:
-          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
+      # Build and publish the image ONCE. The new CLI separates packaging from
+      # running, so the deploy step below only re-runs the fast `unikraft run`
+      # on retry — never a fresh ~9-min image build (the old kraftkit path
+      # rebuilt on every retry and ran out of each attempt's window). The build
+      # (~9-min compile + ~300 MiB push) has no tight deadline of its own; the
+      # job's timeout-minutes is its single ceiling, so a slow uncached build
+      # isn't killed by a second, shorter clock.
+      - name: Build and publish image
         run: |
-          kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance remove batuda-mail-worker 2>&1 | grep -v "not found" || true
+          unikraft build . \
+            --output ${{ env.KRAFTCLOUD_ORG }}/batuda-mail-worker:${{ steps.meta.outputs.version }}
 
       - name: Pre-flight cmdline size guard
         run: |
-          # KraftCloud bakes every -e var into the unikernel kernel command
+          # Unikraft Cloud bakes every -e var into the unikernel kernel command
           # line, which Unikraft caps at 4096 bytes / 60 args: past the byte
           # cap the boot aborts with -E2BIG, past the arg cap argv is silently
           # truncated and vars vanish at runtime. Assemble the exact -e payload
@@ -110,30 +108,44 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy to KraftCloud
+      - name: Deploy to Unikraft Cloud
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        env:
-          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
         with:
           max_attempts: 3
           retry_wait_seconds: 30
           timeout_minutes: 10
-          # -M 2048 mirrors server's footprint; mail-worker's deploy tree
-          # (aws-sdk + imapflow + mailparser + pg + effect) is comparable.
-          # --timeout 10s is mandatory: UKC caps per-RPC timeouts at
-          # 10000ms; kraft's 60s default is rejected with HTTP 400.
-          # --scale-to-zero off matches the Kraftfile label and keeps the
-          # IDLE-holding worker always-warm.
-          # --restart on-failure: if the worker crashes (non-zero exit), the
-          # platform starts a fresh one instead of leaving it dead but still
-          # listed as "running" and processing no mail. A clean shutdown
-          # (exit 0) is left alone. Pairs with the crash-guards in main.ts.
+          # Background worker — no public HTTP endpoint, so no service group.
+          # Use a stable instance name (`batuda-mail-worker`, mirroring the
+          # batuda-server / batuda-web naming) so ops commands target a
+          # predictable identity. The IMAP IDLE connections drop on any
+          # restart and the worker's claim-and-reconnect loop re-establishes
+          # them, so a ~5s gap between delete + recreate is acceptable.
+          #   Each retry first deletes any leftover instance so the fixed name
+          #     is free before `run` recreates it (a half-created instance from
+          #     a failed attempt would otherwise collide on the name).
+          #   -m 2048M mirrors server's footprint; the deploy tree (aws-sdk +
+          #     imapflow + mailparser + pg + effect) is comparable. 1024 ran
+          #     out of initrd RAM extracting the CPIO.
+          #   --restart on-failure: if the worker crashes (non-zero exit), the
+          #     platform starts a fresh one instead of leaving it dead but still
+          #     listed as "running" and processing no mail. A clean shutdown
+          #     (exit 0) is left alone. Pairs with the crash-guards in main.ts.
+          #   --timeout 5m gives the deploy up to 5 minutes to wait for the
+          #     freshly-pushed ~300 MiB image to become available before the
+          #     instance is created — the Unikraft team's guidance for the
+          #     propagation delay. The new CLI's --timeout is a whole-command
+          #     deadline that takes a real duration; the old kraftkit API
+          #     capped per-RPC timeouts at 10s (HTTP 400 above 10000ms).
+          #   Scale-to-zero stays off via the Kraftfile label (baked into the
+          #     image), keeping the IDLE-holding worker always-warm.
           command: |
-            kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
-              --timeout 10s \
+            unikraft instances delete batuda-mail-worker --metro ${{ env.KRAFTCLOUD_METRO }} 2>&1 | grep -v "not found" || true
+            unikraft run \
+              --timeout 5m \
+              --metro ${{ env.KRAFTCLOUD_METRO }} \
               --name batuda-mail-worker \
-              -M 2048 \
-              --scale-to-zero off \
+              --image ${{ env.KRAFTCLOUD_ORG }}/batuda-mail-worker:${{ steps.meta.outputs.version }} \
+              -m 2048M \
               --restart on-failure \
               -e NODE_ENV=production \
               -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
@@ -143,15 +155,12 @@ jobs:
               -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
               -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
               -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
-              -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
-              .
+              -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}"
 
       - name: Verify deployment
-        env:
-          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
         run: |
           sleep 5
-          kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance get batuda-mail-worker
+          unikraft instances get batuda-mail-worker --metro ${{ env.KRAFTCLOUD_METRO }}
           # claimAvailableInboxes runs every 5 s, so an IDLE-established
           # log line should appear within ~10 s if any inbox is provisioned.
-          kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance logs batuda-mail-worker --tail 100 || echo "::warning::No logs yet"
+          unikraft instances logs batuda-mail-worker --metro ${{ env.KRAFTCLOUD_METRO }} --tail 100 || echo "::warning::No logs yet"

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -10,24 +10,23 @@ concurrency:
   group: deploy-server
   cancel-in-progress: false
 
-# Least privilege: deploy authenticates to KraftCloud via secrets, not the
+# Least privilege: deploy authenticates to Unikraft Cloud via secrets, not the
 # GitHub token. It only needs to read the repo.
 permissions:
   contents: read
 
 env:
   KRAFTCLOUD_METRO: fra
-  # Pinned to a known-good kraft CLI version. UKC's API caps the
-  # `--timeout` per-RPC value at 10000ms and rejects anything higher with
-  # HTTP 400 ("Timeout value must be in the range -1 to 10000"); kraft's
-  # default of 60s (60000ms) trips this on every deploy, so the
-  # invocation explicitly passes `--timeout 10s`. Bump this version
-  # deliberately after verifying the new release against a dry-run deploy.
-  KRAFT_VERSION: v0.12.10
+  # Pinned new Unikraft CLI (`unikraft`, from unikraft-cloud/cli) version.
+  # Bump deliberately after verifying a new release against a dry-run deploy.
+  UNIKRAFT_CLI_VERSION: "0.4.1"
+  # Image namespace on Unikraft Cloud is the organization slug; published
+  # images and running instances live under `<org>/<name>`.
+  KRAFTCLOUD_ORG: gaaaa
 
 jobs:
-  # Run pending migrations before the rolling deploy; they must be
-  # backward-compatible with the still-running version (docs/runbooks.md).
+  # Run pending migrations before the deploy; they must be backward-compatible
+  # with the still-running version (docs/runbooks.md).
   migrate:
     name: Migrate prod database
     runs-on: ubuntu-latest
@@ -63,13 +62,11 @@ jobs:
         run: pnpm db:migrate
 
   deploy:
-    name: Deploy to KraftCloud
+    name: Deploy to Unikraft Cloud
     needs: migrate
     runs-on: ubuntu-latest
-    # An uncached re-run rebuilds the whole server image from scratch, which on
-    # its own overran the old 15-minute limit and got auto-cancelled mid-build,
-    # before the KraftCloud rollout. 30 covers an uncached build + push + rollout
-    # until build caching lands.
+    # The image now builds once in its own step (below); an uncached build is
+    # the long pole, so keep a generous ceiling until build caching lands.
     timeout-minutes: 30
     environment: production
 
@@ -77,27 +74,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Prepare files for KraftCloud
+      - name: Prepare files for Unikraft Cloud
         run: |
           cp apps/server/Kraftfile Kraftfile
           cp apps/server/Dockerfile Dockerfile
 
-      - name: Cache KraftCloud CLI
-        id: kraft-cache
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      # Installs the `unikraft` CLI and logs it in headlessly. The new CLI keeps
+      # its own auth store (a legacy `kraft`/UKC_TOKEN login does not carry
+      # over), so every deploy authenticates here via the org token.
+      - name: Install and log in to Unikraft Cloud
+        uses: unikraft/setup-action@29c9cce5bc7e894f8929c845d4fba518ef8f1015 # v1
         with:
-          path: kraft.deb
-          key: kraft-cli-${{ env.KRAFT_VERSION }}
-
-      - name: Download KraftCloud CLI
-        if: steps.kraft-cache.outputs.cache-hit != 'true'
-        run: |
-          curl -sSfL "https://github.com/unikraft/kraftkit/releases/download/${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION#v}_linux_amd64.deb" -o kraft.deb
-
-      - name: Install KraftCloud CLI
-        run: |
-          sudo dpkg -i kraft.deb
-          which kraft
+          version: ${{ env.UNIKRAFT_CLI_VERSION }}
+          token: ${{ secrets.KRAFTCLOUD_TOKEN }}
+          organization: ${{ env.KRAFTCLOUD_ORG }}
 
       - name: Extract version from tag
         id: meta
@@ -109,22 +99,38 @@ jobs:
           fi
           echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
-      - name: Check if KraftCloud service exists
-        id: service-check
-        env:
-          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
+      # Build and publish the image ONCE. The new CLI separates packaging from
+      # running, so the deploy step below only re-runs the fast `unikraft run`
+      # on retry — never a fresh ~9-min image build (the old kraftkit path
+      # rebuilt on every retry and ran out of each attempt's window). The build
+      # (~9-min compile + ~300 MiB push) has no tight deadline of its own; the
+      # job's timeout-minutes is its single ceiling, so a slow uncached build
+      # isn't killed by a second, shorter clock.
+      - name: Build and publish image
         run: |
-          if kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} service get batuda-server >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Service batuda-server already exists — will perform rolling update"
+          unikraft build . \
+            --output ${{ env.KRAFTCLOUD_ORG }}/batuda-server:${{ steps.meta.outputs.version }}
+
+      # The service (load balancer) owns the domain + ports and persists across
+      # releases; instances are attached to it. It already exists in prod, so
+      # this is an idempotent safety net for a from-scratch environment.
+      - name: Ensure Unikraft Cloud service exists
+        run: |
+          if unikraft services get batuda-server >/dev/null 2>&1; then
+            echo "Service batuda-server already exists"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Service batuda-server does not exist — will create it"
+            echo "Creating service batuda-server"
+            unikraft services create \
+              --name batuda-server \
+              --metro ${{ env.KRAFTCLOUD_METRO }} \
+              --domains api.batuda.co \
+              --services 443:3000/tls+http \
+              --services 80:443/http+redirect
           fi
 
       - name: Pre-flight cmdline size guard
         run: |
-          # KraftCloud bakes every -e var into the unikernel kernel command
+          # Unikraft Cloud bakes every -e var into the unikernel kernel command
           # line, which Unikraft caps at 4096 bytes / 60 args: past the byte
           # cap the boot aborts with -E2BIG, past the arg cap argv is silently
           # truncated and vars vanish at runtime. Assemble the exact -e payload
@@ -172,101 +178,78 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy to KraftCloud
+      - name: Deploy to Unikraft Cloud
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        env:
-          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
         with:
           max_attempts: 3
           retry_wait_seconds: 30
           timeout_minutes: 10
-          # Rollout strategy:
-          #   --rollout remove_sequential: new instance starts first, old
-          #     one is removed only after --rollout-wait, so the API keeps
-          #     serving traffic during the swap (zero downtime).
-          #   --rollout-wait 5s: capped by UKC's 10s per-RPC limit (see
-          #     timeout note below); 30s tripped HTTP 400 and aborted the
-          #     rollout. Node + DB pool warm-up fits in 5s on the cold
-          #     unikernel path because connection-pool init is lazy.
+          #   --timeout 5m gives the deploy up to 5 minutes to wait for the
+          #     freshly-pushed ~300 MiB image to become available before the
+          #     instance is created — the Unikraft team's guidance for the
+          #     propagation delay. The new CLI's --timeout is a whole-command
+          #     deadline that takes a real duration; the old kraftkit API
+          #     capped per-RPC timeouts at 10s (HTTP 400 above 10000ms).
+          #   --service batuda-server attaches the instance to the existing
+          #     load balancer that owns api.batuda.co + the ports; do NOT pass
+          #     -p/--domain here (the service owns them).
+          #   --name batuda-server-<sha> is unique per release so retries and
+          #     future deploys never collide on the name.
+          #   -m 2048M: pnpm v11 hoisted deploy ships apps/server's full install
+          #     tree (~303 MB); 1024 ran out of initrd RAM extracting the CPIO.
           #   --restart on-failure: if the process crashes (non-zero exit) the
-          #     platform starts a fresh instance, instead of leaving a dead-but-
-          #     "running" box that serves nothing. A clean shutdown (exit 0) is
-          #     left alone. Pairs with the process crash-guards in main.ts.
-          #   -M 2048: pnpm v11 hoisted-mode `pnpm deploy --prod` under legacy
-          #     deploy doesn't prune to apps/server's runtime deps — /deploy
-          #     ends up with the workspace's full install tree (~303 MB).
-          #     1024 ran out of initrd RAM extracting the CPIO. 2048 fits.
-          #     Slimming the image is tracked as a follow-up; bumping memory
-          #     unblocks the first prod boot today.
-          #   --timeout 10s is mandatory: kraft's default per-RPC timeout
-          #     is 60s, but UKC's API caps it at 10000ms and rejects
-          #     anything higher with HTTP 400 ("Timeout value must be in
-          #     the range -1 to 10000"). 10s is the maximum allowed.
-          #   --service is mutually exclusive with -p/-d; those are set
-          #   once during the first-time create branch below.
+          #     platform starts a fresh instance instead of leaving a dead-but-
+          #     "running" box. A clean shutdown (exit 0) is left alone. Pairs
+          #     with the process crash-guards in main.ts.
+          #   Scale-to-zero stays off via the Kraftfile label (baked in).
           command: |
-            # Shared deploy invocation: the -e block (secrets + build-meta)
-            # is identical for the rolling-update and first-time-create paths,
-            # so it lives in one function and the caller passes the rollout
-            # flags that differ between them. Non-secret config ships in the
-            # baked /app/config.production.json and is not passed on the
-            # cmdline.
-            deploy() {
-              kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} deploy \
-                --timeout 10s \
-                --restart on-failure \
-                --service batuda-server \
-                -M 2048 \
-                "$@" \
-                -e NODE_ENV=production \
-                -e PORT=3000 \
-                -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
-                -e GIT_SHA="${{ github.sha }}" \
-                -e REGION="${{ env.KRAFTCLOUD_METRO }}" \
-                -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-server" \
-                -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
-                -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
-                -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
-                -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
-                -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
-                -e EMAIL_API_KEY_TRANSACTIONAL="${{ secrets.EMAIL_API_KEY_TRANSACTIONAL }}" \
-                -e CALENDAR_API_KEY="${{ secrets.CALENDAR_API_KEY }}" \
-                -e CALENDAR_WEBHOOK_SECRET="${{ secrets.CALENDAR_WEBHOOK_SECRET }}" \
-                -e RESEARCH_LLM_AGENT_API_KEY="${{ secrets.RESEARCH_LLM_AGENT_API_KEY }}" \
-                -e RESEARCH_LLM_EXTRACT_API_KEY="${{ secrets.RESEARCH_LLM_EXTRACT_API_KEY }}" \
-                -e RESEARCH_LLM_WRITER_API_KEY="${{ secrets.RESEARCH_LLM_WRITER_API_KEY }}" \
-                -e RESEARCH_API_KEY_SEARCH="${{ secrets.RESEARCH_API_KEY_SEARCH }}" \
-                -e RESEARCH_API_KEY_SEARCH_2="${{ secrets.RESEARCH_API_KEY_SEARCH_2 }}" \
-                -e RESEARCH_API_KEY_SCRAPE="${{ secrets.RESEARCH_API_KEY_SCRAPE }}" \
-                -e RESEARCH_API_KEY_EXTRACT="${{ secrets.RESEARCH_API_KEY_EXTRACT }}" \
-                -e RESEARCH_API_KEY_REGISTRY_ES="${{ secrets.RESEARCH_API_KEY_REGISTRY_ES }}" \
-                -e RESEARCH_API_KEY_ENRICH="${{ secrets.RESEARCH_API_KEY_ENRICH }}" \
-                -e RESEARCH_API_KEY_VERIFY="${{ secrets.RESEARCH_API_KEY_VERIFY }}" \
-                -e RESEARCH_API_KEY_REGISTRY_GB="${{ secrets.RESEARCH_API_KEY_REGISTRY_GB }}" \
-                .
-            }
-            if [ "${{ steps.service-check.outputs.exists }}" = "true" ]; then
-              deploy --rollout remove_sequential --rollout-wait 5s
-            else
-              # First-time: create an explicitly-named service, then attach
-              # the instance to it. `deploy --name` alone lets UKC auto-name
-              # the service, which breaks the next deploy's service lookup.
-              # The explicit `service create` makes the name stable across
-              # releases so --rollout remove_sequential works.
-              kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} service create \
-                --name batuda-server \
-                -d api.batuda.co \
-                443:3000/tls+http \
-                80:443/http+redirect
-              deploy
-            fi
+            # No users yet, so a brief gap is fine: remove every current
+            # batuda-server instance (the old release, plus any half-created one
+            # from a failed retry) so the new instance is the sole member of the
+            # service and the /health check below unambiguously tests this
+            # release. -f name -o quiet prints only names — never the instance
+            # env, which the API returns in cleartext.
+            for old in $(unikraft instances list --filter 'image~="${{ env.KRAFTCLOUD_ORG }}/batuda-server"' -f name -o quiet); do
+              unikraft instances delete "$old" --metro ${{ env.KRAFTCLOUD_METRO }} 2>&1 | grep -v "not found" || true
+            done
+            unikraft run \
+              --timeout 5m \
+              --metro ${{ env.KRAFTCLOUD_METRO }} \
+              --service batuda-server \
+              --name batuda-server-${{ steps.meta.outputs.short_sha }} \
+              --image ${{ env.KRAFTCLOUD_ORG }}/batuda-server:${{ steps.meta.outputs.version }} \
+              -m 2048M \
+              --restart on-failure \
+              -e NODE_ENV=production \
+              -e PORT=3000 \
+              -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
+              -e GIT_SHA="${{ github.sha }}" \
+              -e REGION="${{ env.KRAFTCLOUD_METRO }}" \
+              -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-server" \
+              -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
+              -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
+              -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
+              -e STORAGE_SECRET_ACCESS_KEY="${{ secrets.STORAGE_SECRET_ACCESS_KEY }}" \
+              -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
+              -e EMAIL_API_KEY_TRANSACTIONAL="${{ secrets.EMAIL_API_KEY_TRANSACTIONAL }}" \
+              -e CALENDAR_API_KEY="${{ secrets.CALENDAR_API_KEY }}" \
+              -e CALENDAR_WEBHOOK_SECRET="${{ secrets.CALENDAR_WEBHOOK_SECRET }}" \
+              -e RESEARCH_LLM_AGENT_API_KEY="${{ secrets.RESEARCH_LLM_AGENT_API_KEY }}" \
+              -e RESEARCH_LLM_EXTRACT_API_KEY="${{ secrets.RESEARCH_LLM_EXTRACT_API_KEY }}" \
+              -e RESEARCH_LLM_WRITER_API_KEY="${{ secrets.RESEARCH_LLM_WRITER_API_KEY }}" \
+              -e RESEARCH_API_KEY_SEARCH="${{ secrets.RESEARCH_API_KEY_SEARCH }}" \
+              -e RESEARCH_API_KEY_SEARCH_2="${{ secrets.RESEARCH_API_KEY_SEARCH_2 }}" \
+              -e RESEARCH_API_KEY_SCRAPE="${{ secrets.RESEARCH_API_KEY_SCRAPE }}" \
+              -e RESEARCH_API_KEY_EXTRACT="${{ secrets.RESEARCH_API_KEY_EXTRACT }}" \
+              -e RESEARCH_API_KEY_REGISTRY_ES="${{ secrets.RESEARCH_API_KEY_REGISTRY_ES }}" \
+              -e RESEARCH_API_KEY_ENRICH="${{ secrets.RESEARCH_API_KEY_ENRICH }}" \
+              -e RESEARCH_API_KEY_VERIFY="${{ secrets.RESEARCH_API_KEY_VERIFY }}" \
+              -e RESEARCH_API_KEY_REGISTRY_GB="${{ secrets.RESEARCH_API_KEY_REGISTRY_GB }}"
 
       - name: Verify deployment
-        env:
-          KRAFTCLOUD_TOKEN: ${{ secrets.KRAFTCLOUD_TOKEN }}
         run: |
           sleep 5
-          kraft cloud --metro ${{ env.KRAFTCLOUD_METRO }} instance list | grep batuda-server || true
+          unikraft instances list --filter 'image~="${{ env.KRAFTCLOUD_ORG }}/batuda-server"' -f name,state -o table || true
           # Gate the deploy on /health actually serving. curl already retries
           # to absorb cold-boot latency; fail the job if it never comes up so a
           # broken release doesn't pass with only a warning.

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,46 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        # The new Unikraft Cloud CLI (`unikraft`), used to build and deploy
+        # apps/server + apps/mail-worker to Unikraft Cloud. It replaces the old
+        # `kraft` (kraftkit) CLI. nixpkgs only ships the old `kraft` (0.12.5),
+        # not this new binary, so it's pulled straight from the upstream release
+        # tarball at unikraft-cloud/cli and pinned per platform. CI installs the
+        # same CLI via unikraft/setup-action; this keeps `unikraft build`,
+        # `unikraft login`, and `unikraft run` available in the dev shell for
+        # local spikes and manual deploys. Bump `unikraftCliVersion` + all four
+        # hashes together from a new release (see cli_<version>_checksums.txt).
+        unikraftCliVersion = "0.4.1";
+        unikraftCliPlatform = {
+          "x86_64-linux" = { os = "linux"; arch = "amd64"; hash = "df819d8f1ad31c96999d3452ca8fa366d3296b78e189ba5b3a011af487457df3"; };
+          "aarch64-linux" = { os = "linux"; arch = "arm64"; hash = "a4b753909d19d2f92913a45675f3455bb2f56f6a9f02a973d5f649e90015b64c"; };
+          "x86_64-darwin" = { os = "darwin"; arch = "amd64"; hash = "b8b92139fc18cb4f6ee5d9e7226a4a8927c87a79f26025ce9756af983527d6b6"; };
+          "aarch64-darwin" = { os = "darwin"; arch = "arm64"; hash = "373e0aee92733484b073e5da99129bfda7638555fe8cb7ffb30e85b5dd4c4f0c"; };
+        }.${system};
+        unikraft-cli = pkgs.stdenv.mkDerivation {
+          pname = "unikraft-cli";
+          version = unikraftCliVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/unikraft-cloud/cli/releases/download/v${unikraftCliVersion}/unikraft-cli_${unikraftCliVersion}_${unikraftCliPlatform.os}_${unikraftCliPlatform.arch}.tar.gz";
+            sha256 = unikraftCliPlatform.hash;
+          };
+          # The tarball holds the `unikraft` binary plus a docs/ tree at its
+          # root with no single top-level folder, so unpack in place.
+          sourceRoot = ".";
+          # The Linux build is a dynamically linked Go binary; patch its
+          # interpreter so it runs on NixOS. macOS needs no patching.
+          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 unikraft $out/bin/unikraft
+            runHook postInstall
+          '';
+          # The binary is `unikraft`, not the package name `unikraft-cli`, so
+          # name it for `nix run .#unikraft-cli`.
+          meta.mainProgram = "unikraft";
+        };
       in
       {
         devShells.default = pkgs.mkShell {
@@ -17,6 +57,8 @@
             pkgs.nodejs_24
             pkgs.pnpm
             pkgs.dprint
+            # New Unikraft Cloud CLI — see the unikraft-cli derivation above.
+            unikraft-cli
             # Cloudflare Workers CLI. Used to deploy apps/internal (the
             # batuda-web TanStack Start app) to Workers. Installed via nix
             # so `wrangler login`, `wrangler deploy`, `wrangler dev` work
@@ -54,6 +96,7 @@
           shellHook = ''
             echo "Forja dev environment"
             echo "Node:     $(node --version)"
+            echo "unikraft: $(unikraft version 2>/dev/null | awk '/version:/{print $2; exit}' || echo 'available')"
             echo "pnpm:     $(pnpm --version)"
             echo "infisical:$(infisical --version 2>/dev/null || echo ' available')"
             echo "wrangler: $(wrangler --version 2>/dev/null || echo 'available')"
@@ -63,6 +106,10 @@
             echo "otel-tui: $(otel-tui --version 2>/dev/null || echo 'available')"
           '';
         };
+
+        # Also exposed as a package so `nix build .#unikraft-cli` /
+        # `nix run .#unikraft-cli` work without entering the dev shell.
+        packages.unikraft-cli = unikraft-cli;
       }
     );
 }


### PR DESCRIPTION
## What

Batuda's server and mail-worker deploy to Unikraft Cloud. That ran on the legacy kraftkit CLI (`kraft`), whose deploy was unreliable — it rebuilt the ~300 MiB image on every retry and hit a hard 10-second cap on the "wait for the image to become available" step, so releases timed out (#223). This migrates both deploy pipelines (`deploy_server.yml`, `deploy_mail_worker.yml`) to the new `unikraft` CLI (from `unikraft-cloud/cli`, v0.4.1) and adds that CLI to the Nix dev shell so local and CI use the same tool.

## Changes

- Install + log in via `unikraft/setup-action@v1` (token + organization) instead of downloading the kraftkit `.deb`. The new CLI keeps its own login store, separate from kraftkit's.
- Split packaging from deploy: `unikraft build --output <org>/<name>:<version>` publishes the image once; the retry-wrapped deploy step only re-runs the fast `unikraft run`, so a retry never rebuilds.
- The image-propagation wait now uses a real `--timeout 5m` on `run` (the Unikraft team's guidance); the old API capped kraftkit's per-RPC timeout at 10 s.
- Server: replace the instance in place — delete the current `batuda-server` instance(s), then `run` a fresh `batuda-server-<sha>` attached to the existing `batuda-server` service (which owns `api.batuda.co` + the ports). With no users this brief gap is fine and makes the `/health` gate unambiguously test the new release.
- Mail-worker: same setup-action + build-once pattern; delete + recreate the single `batuda-mail-worker` instance (no service).
- Memory flag `-M 2048` → `-m 2048M`; scale-to-zero now comes from the baked Kraftfile label; `flake.nix` vendors `unikraft` 0.4.1 (not in nixpkgs) as a per-platform pinned release tarball.

## Impact

- **Both prod deploy pipelines change.** The first real amd64 run is the redeploy right after merge — until then these commands are verified only by actionlint + live-CLI dry-runs.
- **Migration ordering unchanged:** the server `migrate` job still runs first, and its migrations must stay backward-compatible with the still-running old instance (it serves until the deploy step deletes it).
- **No new env vars, no schema change, no RLS or wire-shape change.** The CI secret `KRAFTCLOUD_TOKEN` and the `-e` secret block are unchanged.
- **Secrets:** instance env is retrievable in cleartext via the API. The workflows only ever read `-f name -o quiet` (names, never env), but the Neon DB password was exposed during this work — rotate it (see Deferred).

## Review guide

- Start with `deploy_server.yml`, the deploy step: snapshot old `batuda-server` instances by image filter → `run` the new one → `/health`. The riskiest thing I could not verify locally is that the `setup-action` login persists into the `nick-fields/retry` deploy step's shell (standard model, but confirm on the first CI run — a failure shows as `profile not setup`).
- `flake.nix` is a mechanical pinned-tarball derivation; skip-able.
- The server deliberately does **not** do a zero-downtime rolling swap — fine with no users (see Deferred / #227).

## Verification

- `actionlint` clean on both workflows (only the pre-existing `$GITHUB_OUTPUT` info notes remain).
- New-CLI commands validated against live Unikraft Cloud via `--dry-run` (`run --service --name --timeout 5m -m 2048M --restart -e …`), and a full local `unikraft build` of the server produced a 432 MB OCI image (exit 0).
- `nix flake check` + `nix run .#unikraft-cli -- version` (0.4.1) + `unikraft` resolves on the dev-shell PATH.
- pre-commit hooks green (check-types, lint, format).
- **Not run:** the real amd64 build-push → run chain — that is the redeploy after merge (kept revertable).

## Deferred

- **Zero-downtime rolling update (#227)** — the new CLI has no single `--rollout`; it would be composed from `run --service` + `instances wait` + `instances delete`. Not needed while there are no users; still pending the Unikraft team's recommended sequence.
- **Rotate the Neon `neondb_owner` password** (and update the `DATABASE_URL` / `MIGRATION_DATABASE_URL` secrets) — exposed in cleartext during this work.
- **`ai-standards` `/unikraft` skill** rewrite for the new CLI — done locally, to be committed in a separate session.

Closes #223
