### PR TITLE
cicd(deploy): drop invalid --metro flag from unikraft instances commands

### DIFF
--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -139,7 +139,9 @@ jobs:
           #   Scale-to-zero stays off via the Kraftfile label (baked into the
           #     image), keeping the IDLE-holding worker always-warm.
           command: |
-            unikraft instances delete batuda-mail-worker --metro ${{ env.KRAFTCLOUD_METRO }} 2>&1 | grep -v "not found" || true
+            # instances delete/get/logs take a bare name and reject --metro
+            # (only run/services create accept it); the login profile spans metros.
+            unikraft instances delete batuda-mail-worker 2>&1 | grep -v "not found" || true
             unikraft run \
               --timeout 5m \
               --metro ${{ env.KRAFTCLOUD_METRO }} \
@@ -160,7 +162,7 @@ jobs:
       - name: Verify deployment
         run: |
           sleep 5
-          unikraft instances get batuda-mail-worker --metro ${{ env.KRAFTCLOUD_METRO }}
+          unikraft instances get batuda-mail-worker
           # claimAvailableInboxes runs every 5 s, so an IDLE-established
           # log line should appear within ~10 s if any inbox is provisioned.
-          unikraft instances logs batuda-mail-worker --metro ${{ env.KRAFTCLOUD_METRO }} --tail 100 || echo "::warning::No logs yet"
+          unikraft instances logs batuda-mail-worker --tail 100 || echo "::warning::No logs yet"

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -209,8 +209,10 @@ jobs:
             # service and the /health check below unambiguously tests this
             # release. -f name -o quiet prints only names — never the instance
             # env, which the API returns in cleartext.
+            # instances list/delete take a bare name and reject --metro (only
+            # run/services create accept it); the login profile spans metros.
             for old in $(unikraft instances list --filter 'image~="${{ env.KRAFTCLOUD_ORG }}/batuda-server"' -f name -o quiet); do
-              unikraft instances delete "$old" --metro ${{ env.KRAFTCLOUD_METRO }} 2>&1 | grep -v "not found" || true
+              unikraft instances delete "$old" 2>&1 | grep -v "not found" || true
             done
             unikraft run \
               --timeout 5m \


### PR DESCRIPTION
Hotfix for #228. The first real deploy of the new-CLI workflows failed: `unikraft instances delete/get/logs` reject `--metro` (only `run`/`services create` accept it), so the old instance was never deleted and `run` then collided with "instance already exists". Dropped `--metro` from those three commands (they take a bare name; the login profile spans metros) and added a regression-guard comment.

Login + build+push (amd64) + pre-flight all passed on the failed run — only the deploy step was affected. Verified: `instances delete <bare-name>` parses against live UKC ("references not found", not "unknown flag"), actionlint clean.

Merging without waiting for CI (per the same instruction as #228); re-releasing both apps after.