### PR TITLE
chore: use the Unikraft team's NUR for the dev-shell CLI (staging)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "unikraft-nur": "unikraft-nur"
       }
     },
     "systems": {
@@ -52,6 +53,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "unikraft-nur": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783689353,
+        "narHash": "sha256-gLPPj83ltHjNXbtOVxiAMmBieTPoZwTQefpCAhXmGaI=",
+        "owner": "unikraft",
+        "repo": "nur",
+        "rev": "e5b33203b32b9b84ff277051934ee05c7ef11e66",
+        "type": "github"
+      },
+      "original": {
+        "owner": "unikraft",
+        "repo": "nur",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,52 +4,29 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    # The official Unikraft CLI, packaged by the Unikraft team in their NUR
+    # (GoReleaser-generated, auto-updated per release). Follows our nixpkgs so
+    # there's a single package set.
+    unikraft-nur = {
+      url = "github:unikraft/nur";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, unikraft-nur }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        # The new Unikraft Cloud CLI (`unikraft`), used to build and deploy
-        # apps/server + apps/mail-worker to Unikraft Cloud. It replaces the old
-        # `kraft` (kraftkit) CLI. nixpkgs only ships the old `kraft` (0.12.5),
-        # not this new binary, so it's pulled straight from the upstream release
-        # tarball at unikraft-cloud/cli and pinned per platform. CI installs the
-        # same CLI via unikraft/setup-action; this keeps `unikraft build`,
-        # `unikraft login`, and `unikraft run` available in the dev shell for
-        # local spikes and manual deploys. Bump `unikraftCliVersion` + all four
-        # hashes together from a new release (see cli_<version>_checksums.txt).
-        unikraftCliVersion = "0.4.1";
-        unikraftCliPlatform = {
-          "x86_64-linux" = { os = "linux"; arch = "amd64"; hash = "df819d8f1ad31c96999d3452ca8fa366d3296b78e189ba5b3a011af487457df3"; };
-          "aarch64-linux" = { os = "linux"; arch = "arm64"; hash = "a4b753909d19d2f92913a45675f3455bb2f56f6a9f02a973d5f649e90015b64c"; };
-          "x86_64-darwin" = { os = "darwin"; arch = "amd64"; hash = "b8b92139fc18cb4f6ee5d9e7226a4a8927c87a79f26025ce9756af983527d6b6"; };
-          "aarch64-darwin" = { os = "darwin"; arch = "arm64"; hash = "373e0aee92733484b073e5da99129bfda7638555fe8cb7ffb30e85b5dd4c4f0c"; };
-        }.${system};
-        unikraft-cli = pkgs.stdenv.mkDerivation {
-          pname = "unikraft-cli";
-          version = unikraftCliVersion;
-          src = pkgs.fetchurl {
-            url = "https://github.com/unikraft-cloud/cli/releases/download/v${unikraftCliVersion}/unikraft-cli_${unikraftCliVersion}_${unikraftCliPlatform.os}_${unikraftCliPlatform.arch}.tar.gz";
-            sha256 = unikraftCliPlatform.hash;
-          };
-          # The tarball holds the `unikraft` binary plus a docs/ tree at its
-          # root with no single top-level folder, so unpack in place.
-          sourceRoot = ".";
-          # The Linux build is a dynamically linked Go binary; patch its
-          # interpreter so it runs on NixOS. macOS needs no patching.
-          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
-          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
-          installPhase = ''
-            runHook preInstall
-            install -Dm755 unikraft $out/bin/unikraft
-            runHook postInstall
-          '';
-          # The binary is `unikraft`, not the package name `unikraft-cli`, so
-          # name it for `nix run .#unikraft-cli`.
-          meta.mainProgram = "unikraft";
-        };
+        # The official Unikraft Cloud CLI (`unikraft`), used to build and deploy
+        # apps/server + apps/mail-worker. It replaces the old `kraft` (kraftkit)
+        # CLI, which is all nixpkgs ships. Taken from the Unikraft team's NUR —
+        # the `unikraft-cli-staging` attr, since the NUR's stable `unikraft-cli`
+        # attr is being fixed upstream. This keeps `unikraft build`/`login`/`run`
+        # in the dev shell for local spikes and manual deploys; bump it with
+        # `nix flake update unikraft-nur`. (CI installs its own copy via
+        # unikraft/setup-action.)
+        unikraft-cli = unikraft-nur.packages.${system}.unikraft-cli-staging;
       in
       {
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
Switches the dev-shell `unikraft` CLI from my hand-pinned release-tarball derivation to the official `unikraft/nur` flake (`unikraft-cli-staging`, currently v0.4.2-staging.16) — no more manual per-release hash bumps; `nix flake update unikraft-nur` to bump. Verified: `nix flake check` passes, `unikraft version` runs, and authenticated commands work against live UKC. CI is unchanged (still `setup-action` 0.4.1). Tracks staging while the NUR's stable `unikraft-cli` attr is fixed upstream (unikraft-cloud/cli#415).