### PR TITLE
cicd(deploy): fix migration detection and add a force-migrate switch

### DIFF
--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "server-v*"
   workflow_dispatch:
+    inputs:
+      force_migrate:
+        description: "Apply pending prod migrations even when none are newly detected, then skip the redeploy. For a migration that missed its deploy, or a re-run after a partial failure. Still gated by the production-db reviewer."
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-server
@@ -45,7 +50,18 @@ jobs:
 
       - name: Detect new migrations since the previous release
         id: detect
+        env:
+          FORCE_MIGRATE: ${{ inputs.force_migrate }}
         run: |
+          # A manual force_migrate dispatch runs the gated migrate even when no
+          # new migration is detected — for a migration that missed its deploy,
+          # or a re-run after a partial failure. The migrator is incremental, so
+          # it applies only what is still pending.
+          if [ "$FORCE_MIGRATE" = "true" ]; then
+            echo "force_migrate requested — gating the migrate."
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # New migration files between the previous server-v* tag and this one.
           # When there's no previous tag (first deploy) we gate, to be safe.
           prev=$(git describe --tags --match='server-v[0-9]*' --abbrev=0 HEAD^ 2>/dev/null || echo "")
@@ -54,7 +70,9 @@ jobs:
             echo "has_migrations=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files=$(git diff --name-only "$prev..HEAD" -- apps/server/src/db/migrations/ | grep '\.sql$' || true)
+          # Migrations are TypeScript (Effect SqlClient), named NNNN_*.ts — not .sql,
+          # so the old '\.sql$' filter matched nothing and silently skipped every migrate.
+          files=$(git diff --name-only "$prev..HEAD" -- apps/server/src/db/migrations/ | grep -E '[0-9]{4}_.*\.(ts|sql)$' || true)
           if [ -n "$files" ]; then
             echo "New migrations since $prev:"; echo "$files"
             echo "has_migrations=true" >> "$GITHUB_OUTPUT"
@@ -107,8 +125,10 @@ jobs:
     name: Deploy to Unikraft Cloud
     needs: [detect-migrations, migrate]
     # Deploy when migrate succeeded OR was skipped (no new migrations); block
-    # only if detection failed or the migration itself failed.
-    if: ${{ !cancelled() && needs.detect-migrations.result == 'success' && needs.migrate.result != 'failure' }}
+    # only if detection failed or the migration itself failed. A force_migrate
+    # dispatch is migrate-only — it skips the redeploy (the running version is
+    # unchanged), so a branch dispatch never ships branch code to prod.
+    if: ${{ !cancelled() && needs.detect-migrations.result == 'success' && needs.migrate.result != 'failure' && !inputs.force_migrate }}
     runs-on: ubuntu-latest
     # The image now builds once in its own step (below); an uncached build is
     # the long pole, so keep a generous ceiling until build caching lands.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -445,6 +445,34 @@ The server runs on Unikraft (stateless Node.js, scales to zero when idle); the w
 
 ---
 
+## Environment variables & secrets
+
+Configuration splits two ways: **secret vs non-secret** (secrets are never committed), and **where the code runs** — a developer's machine versus the deployed cloud. The through-line is that Infisical is the single source of truth for every secret, while non-secret values are committed to the repo.
+
+### Local machine
+
+A local process (server, CLI, tests) reads a gitignored root `.env`, seeded from the committed `.env.example` template — Docker Postgres/MinIO endpoints, `stub` research providers, throwaway dev secrets — so a fresh clone runs end-to-end with no real credentials. `apps/internal/.env.example` is the web app's template; a git worktree gets its own generated `.env` from `pnpm cli worktree up` (see the `worktrees` skill).
+
+There are two ways to reach **real** cloud values from a local machine, both ultimately fed by Infisical:
+
+- `infisical run --env=dev -- <command>` injects one Infisical environment's secrets into a single process (how the research eval gets real dev-tier keys) — nothing lands on disk.
+- The CLI's `--env cloud` mode (§ `apps/cli` above) layers non-secret GitHub Actions **Variables** (`gh variable list --env production`) over the `.env` baseline, plus the developer's local `.env.cloud` for secrets — because GitHub, unlike Infisical, never serves its Actions **Secrets** back over the API.
+
+### Deployed cloud — Infisical → GitHub Actions → the instance
+
+Infisical (project pinned in `.infisical.json`) holds the cloud secrets, organized by **environment** (`dev`, `prod`) and by **folder**, and a sync in Infisical's GitHub integration pushes each folder down into a GitHub Actions **environment**. No workflow calls `infisical` — the deploy only ever reads `${{ secrets.* }}`. The folder → GitHub-environment split mirrors a trust boundary: the one credential that can rewrite the prod schema sits alone, behind its own reviewer gate.
+
+| Infisical `prod` folder | GitHub environment | Read by                                                                 | Holds                                                                                                                                                                             |
+| ----------------------- | ------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/` (root)              | `production`       | server `deploy` job → injected into the Unikraft instance as `-e VAR=…` | runtime secrets — `DATABASE_URL` (pooled, `app_service`), `BETTER_AUTH_SECRET`, `STORAGE_*`, `EMAIL_*`, `RESEARCH_*`, `CALENDAR_*`, plus `KRAFTCLOUD_TOKEN` for the deploy itself |
+| `/ci`                   | `production-db`    | gated `migrate` job                                                     | only `MIGRATION_DATABASE_URL` — schema-owner `neondb_owner` over the **unpooled** endpoint, the connection that runs DDL/`GRANT`; `production-db` requires a reviewer's approval  |
+
+So adding or rotating a cloud secret is an edit in Infisical (the matching `prod` folder) — never in GitHub and never in a file — and the sync carries it to the right environment. The prod migration credential, for instance, is `MIGRATION_DATABASE_URL` in `prod` → `/ci`; see [runbooks.md → Applying database migrations](runbooks.md#applying-database-migrations) for why it is quarantined and reviewer-gated.
+
+Non-secret deployed config does **not** ride this path: boot-required non-secret values (`ALLOWED_ORIGINS`, the research provider/model selections, `RESEARCH_MAX_*`) live in `apps/server/config.production.json`, shipped with the image and loaded at boot — `apps/server/src/lib/config-provider.ts` throws if the file is missing. The GitHub Actions **Variables** mentioned above are a separate non-secret store, used only by the CLI's cloud mode, not by the deploy.
+
+---
+
 ## Tables
 
 ### CRM tables (Effect SQL migrations)

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -169,6 +169,8 @@ pnpm dev:server   # starts the server (also runs migrations on startup)
 
 For production, `DATABASE_URL` points to NeonDB (or any Postgres). The db layer works with any Postgres — local Docker or cloud.
 
+For how environment variables and secrets are sourced across local dev and the deployed cloud — the `.env` baseline, `infisical run` for real dev keys, and the Infisical → GitHub Actions sync that feeds the deploy — see [architecture.md → Environment variables & secrets](architecture.md#environment-variables--secrets).
+
 ---
 
 ## Database layer (`apps/server/src/db/`)


### PR DESCRIPTION
## What

The server deploy pipeline had silently stopped applying database migrations. This fixes that, adds a manual escape hatch to apply a migration that already missed its deploy — **migration 0026 (`research_runs.reason_code`), unapplied on prod right now** — and documents how configuration and secrets are sourced across local dev and the cloud (an undocumented area this work surfaced).

Bounded surface: the server deploy workflow (`cicd`) plus two docs files. No application code.

## Changes

- **Fixed the migration-detection gate.** The deploy's `detect-migrations` step filtered the changed-files list for `.sql`, but this repo's migrations are TypeScript (`NNNN_*.ts`) — so it matched nothing, reported "no migrations," and skipped the migrate job. That gate landed recently (`141f0045b8`); before it the migrate ran unconditionally and worked, so `v2026.7.10-1` was the first release to carry both the gate and a pending migration — and 0026 never applied. Now it matches the real `.ts`/`.sql` migration filenames.
- **Added a `force_migrate` dispatch input.** A manual `workflow_dispatch` that forces the (reviewer-gated) migrate to run and applies any pending migration, then skips the redeploy — for exactly this case (a migration that missed its deploy) or a re-run after a partial failure. The migrator is incremental, so it only applies what's still pending.
- **Documented env/secret sourcing.** A new "Environment variables & secrets" section in `architecture.md` — the local `.env` baseline, `infisical run` for real dev keys, and the Infisical → GitHub Actions sync that feeds the deploy (with the prod folder → GitHub-environment trust split that isolates the schema-owner migration credential) — reconciled with the existing CLI cloud-loader note; `backend.md` points to it.

## Impact

- **No schema change in this PR**, but it is the mechanism to apply the already-released, still-unapplied migration 0026. After merge, dispatching `deploy_server.yml` with `force_migrate=true` (gated by the `production-db` reviewer) applies it — migrate-only, no redeploy.
- **Normal releases are unaffected**: a `server-v*` tag still detects new migrations (now correctly) and deploys; `force_migrate` only changes manual dispatches.
- Future `.ts` migrations auto-detect again, so this silent-skip class won't recur.

## Review guide

- The one line to scrutinize is the deploy job's `if:` — `… && !inputs.force_migrate`. On a tag push `inputs.force_migrate` is null/false, so the deploy still runs; only a `force_migrate=true` dispatch skips it (which also keeps a branch dispatch from ever shipping branch code to prod).
- actionlint isn't installed locally — validated via YAML parse plus a trace of all four run scenarios (tag+migration, tag+none, force-dispatch, plain dispatch).

## Verification

- Pre-commit + pre-push hooks green (`check-types`, `lint`, `format`, full `test` suite in 69s).
- Confirmed the fixed filter matches `0026_research_run_reason_code.ts` across `server-v2026.7.10..HEAD`, and the old `.sql` filter matched nothing.

Related: #214 (migration 0026 is from that work).
