### PR TITLE
research eval follow-ups: fill more fields, test on Spanish SMBs, chart the eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,8 @@ pnpm cli db reset         # truncate + migrate + seed (clean slate)
 pnpm cli services up      # start Docker Postgres
 pnpm cli services down    # stop Docker services
 pnpm cli services status  # show Docker status
+pnpm cli research eval    # measure research quality vs a golden set (needs real keys; see eval/README.md)
+pnpm cli research probe   # check which LLMs support the research tiers' features
 pnpm cli:tui              # interactive TUI (same commands)
 ```
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -13,6 +13,7 @@
 		"@batuda/auth": "workspace:*",
 		"@batuda/calendar": "workspace:*",
 		"@batuda/domain": "workspace:*",
+		"@batuda/observability": "workspace:*",
 		"@batuda/research": "workspace:*",
 		"@better-auth/api-key": "1.6.11",
 		"@clack/prompts": "^1.2.0",

--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -5,12 +5,15 @@ import { Config, Console, Effect, Layer, Option, type Redacted } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { SqlClient } from 'effect/unstable/sql'
 
+import { makeOtlpObservability } from '@batuda/observability'
 import {
 	BlobStorage,
 	buildEvalReport,
 	ContactDiscovery,
 	type CreateResearchInput,
 	type EvalSummary,
+	evalSpanAttributes,
+	evalSummaryAttributes,
 	type GoldenExpectation,
 	type ModelProbeResult,
 	makeResearchLlmLive,
@@ -275,6 +278,20 @@ export const researchEval = (opts: {
 		}
 		yield* Console.log(`Evaluating ${golden.length} companies…\n`)
 
+		// Tag the run's spans so a drift chart can group quality by which models
+		// produced it; the endpoint/commit ride the OTLP resource, not here.
+		const agentModel = yield* Config.string('RESEARCH_LLM_AGENT_MODEL').pipe(
+			Config.withDefault('unknown'),
+		)
+		const extractModel = yield* Config.string(
+			'RESEARCH_LLM_EXTRACT_MODEL',
+		).pipe(Config.withDefault('unknown'))
+		yield* Effect.annotateCurrentSpan({
+			'eval.agent_model': agentModel,
+			'eval.extract_model': extractModel,
+			'eval.companies': golden.length,
+		})
+
 		const scores = yield* Effect.gen(function* () {
 			const defaults = yield* systemDefaults
 			// Each company runs `runs` times: per-run grounding is noisy, so averaging
@@ -286,7 +303,26 @@ export const researchEval = (opts: {
 			return yield* Effect.forEach(
 				tasks,
 				company =>
-					driveOne(opts.org, opts.user, defaults, company, opts.schemaName),
+					driveOne(
+						opts.org,
+						opts.user,
+						defaults,
+						company,
+						opts.schemaName,
+					).pipe(
+						Effect.tap(score =>
+							Effect.annotateCurrentSpan(evalSpanAttributes(score)),
+						),
+						Effect.withSpan('research_eval.run', {
+							attributes: {
+								'eval.company_id': company.id,
+								'eval.query': company.query,
+								'eval.schema': opts.schemaName,
+								'eval.agent_model': agentModel,
+								'eval.extract_model': extractModel,
+							},
+						}),
+					),
 				{ concurrency: opts.concurrency },
 			)
 		}).pipe(Effect.provide(researchLive))
@@ -302,6 +338,7 @@ export const researchEval = (opts: {
 
 		const report = buildEvalReport(scores)
 		yield* Console.log(formatSummary(report.summary))
+		yield* Effect.annotateCurrentSpan(evalSummaryAttributes(report.summary))
 		yield* Option.match(opts.out, {
 			onNone: () => Effect.void,
 			onSome: path =>
@@ -315,4 +352,17 @@ export const researchEval = (opts: {
 					),
 				),
 		})
-	})
+	}).pipe(
+		// One span per eval run plus this batch span, exported to the monitoring
+		// board when OTEL_EXPORTER_OTLP_ENDPOINT is set; a no-op native tracer
+		// otherwise, so a local run still prints its table and writes its report.
+		Effect.withSpan('research_eval.batch', {
+			attributes: {
+				'eval.schema': opts.schemaName,
+				'eval.runs_per_company': opts.runs,
+			},
+		}),
+		Effect.provide(
+			makeOtlpObservability({ serviceName: 'batuda-research-eval' }),
+		),
+	)

--- a/apps/internal/src/components/research/findings/shared.tsx
+++ b/apps/internal/src/components/research/findings/shared.tsx
@@ -1,7 +1,11 @@
 import { Trans } from '@lingui/react/macro'
+import { AlertTriangle } from 'lucide-react'
 import styled from 'styled-components'
 
-import { normalizeConfidence } from '#/components/research/proposal-logic'
+import {
+	DEFAULT_TRUST_THRESHOLD,
+	normalizeConfidence,
+} from '#/components/research/proposal-logic'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
 /**
@@ -70,6 +74,11 @@ export function CitationList({
 				// model score arrives as a 0–1 fraction, so the old ×100 turned an
 				// already-0–100 value into "8500%".
 				const confidence = normalizeConfidence(c.confidence)
+				// Below the trust threshold reads as a caution: the critic keeps a
+				// value it could not vouch for but could not rule out, marking it
+				// shaky — so a reader tells a confirmed value from a kept-but-uncertain
+				// one at a glance (the low % plus a warning mark).
+				const low = confidence !== null && confidence < DEFAULT_TRUST_THRESHOLD
 				return (
 					<CitationLi key={stableKey(['cit', c.sourceId, c.quote ?? ''])}>
 						<CitationKey>{c.sourceId}</CitationKey>
@@ -77,7 +86,10 @@ export function CitationList({
 							<CitationQuote>“{c.quote}”</CitationQuote>
 						) : null}
 						{confidence !== null ? (
-							<CitationConfidence>{confidence}%</CitationConfidence>
+							<CitationConfidence $low={low} data-low={low}>
+								{low ? <AlertTriangle size={11} aria-hidden /> : null}
+								{confidence}%
+							</CitationConfidence>
 						) : null}
 					</CitationLi>
 				)
@@ -317,10 +329,13 @@ const CitationQuote = styled.span`
 	font-style: italic;
 `
 
-const CitationConfidence = styled.span`
+const CitationConfidence = styled.span<{ $low?: boolean }>`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3xs);
 	font-variant-numeric: tabular-nums;
 	font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-	color: var(--color-primary);
+	color: ${p => (p.$low ? 'var(--color-error, #c6664b)' : 'var(--color-primary)')};
 `
 
 const DiscoveredList = styled.ul`

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -926,6 +926,10 @@ POST /v1/research → create run row (status: queued) → fork fiber
 
 Fan-out groups: a `kind='group'` parent creates N `kind='leaf'` children. Each leaf completion merges findings onto the parent (`pg_advisory_xact_lock` for serialization) and rolls up the parent status.
 
+### Research eval
+
+A CLI harness measures the pipeline's quality against a fixed set of companies whose correct answers are known (the "golden set"), so a change to grounding or extraction shows up as a number instead of a guess. `pnpm cli research eval` drives the same pipeline the server runs — from the CLI, on demand, never in production — and reports grounding accuracy, field precision and recall, and the wrong-company and empty rates; `pnpm cli research probe` checks which candidate LLMs support the forced tool-calling and strict-JSON output the research tiers need. It needs the research env configured (real LLM + provider keys, `DATABASE_URL`) and an org/user to run as, and can export each run's scores to the monitoring board (Honeycomb). See [../eval/README.md](../eval/README.md).
+
 ---
 
 ## Code quality — Biome

--- a/eval/README.md
+++ b/eval/README.md
@@ -67,10 +67,14 @@ Match the CRM's own vocabulary, or the value can never match what the pipeline e
 
 ## Registries: UK is free, ES is paid
 
-The `RegistryRouter` picks a registry by the company's country. **Companies House (UK)** is free — register a key at `developer.company-information.service.gov.uk` and set `RESEARCH_PROVIDER_REGISTRY_GB=companies-house`. **libreBORME (ES)** is ~€0.29/lookup. So a UK golden set costs nothing on the registry side, which makes it the low-barrier default for contributors; use Catalan/Spanish companies (and fill `region`) when you want the product's real domain.
+The `RegistryRouter` picks a registry by the company's country. **Companies House (UK)** is free — register a key at `developer.company-information.service.gov.uk` and set `RESEARCH_PROVIDER_REGISTRY_GB=companies-house`. **libreBORME (ES)** is ~€0.29/lookup — set `RESEARCH_PROVIDER_REGISTRY_ES=librebor` with `RESEARCH_API_KEY_REGISTRY_ES` (an `AccessId:AccessKey` pair). Turn both on for the Spanish set so the pipeline can confirm each company against its official register.
+
+A registry lookup that resolves the target company by its legal name now counts toward grounding — it proves the run reached the right legal entity even when the company's own site was never scraped, which is common for small businesses with a thin web presence. So running the Spanish set with the registers on makes the "did it reach the company" number trustworthy in a way a keyless run cannot.
 
 ## Note
 
-`golden.example.json` ships three real UK companies with verified official domains, carrying only the fields that are objectively checkable (`industry`, `location`) and omitting `region` (it is ES-only). Replace them with your own targets — the pipeline extracts English industry terms for UK companies, so `industry` precision there mostly measures the vocabulary gap, not grounding.
+`golden.example.json` ships a mix of real, verified companies: UK ones (whose register, Companies House, is free) that exercise grounding and the wrong-company rate, and Catalan/Spanish small businesses that exercise `region` and `size_range` — the two fields that are Spain-SMB-only in the CRM (region codes `cat`/`ara`/`cv`, size brackets up to `51-200`). Replace them with your own targets; for UK companies the pipeline extracts English industry terms, so `industry` precision there mostly measures the vocabulary gap, not grounding.
 
-Pushing the per-run scores to the observability dashboard is a separate step (it needs each run recorded as a trace first); today the report is the JSON file and the console summary.
+## Charting runs on the monitoring board
+
+Each run's scores are also exported to the monitoring board (Honeycomb) as spans when `OTEL_EXPORTER_OTLP_ENDPOINT` (+ `OTEL_EXPORTER_OTLP_HEADERS` with `x-honeycomb-dataset`) is set — one span per run plus a batch-summary span, tagged with the agent/extract model, so you can chart grounding accuracy, field precision/recall, and the empty rate drifting across model and prompt changes instead of eyeballing two terminal outputs. Without those env vars the eval still prints its table and writes `--out`, just with no export.

--- a/eval/golden.example.json
+++ b/eval/golden.example.json
@@ -76,5 +76,65 @@
 			"altDomains": ["ocadogroup.com", "ocado.co.uk"],
 			"fields": { "location": "Hatfield" }
 		}
+	},
+	{
+		"id": "enganches-aragon",
+		"query": "Enganches Aragón, Zaragoza",
+		"expectedOutput": {
+			"officialDomain": "enganchesaragon.com",
+			"fields": {
+				"industry": "manufactura",
+				"size_range": "51-200",
+				"region": "ara",
+				"location": "Zaragoza"
+			}
+		}
+	},
+	{
+		"id": "cohitech",
+		"query": "Cohitech, Balsareny",
+		"expectedOutput": {
+			"officialDomain": "cohitech.net",
+			"fields": {
+				"industry": "manufactura",
+				"size_range": "51-200",
+				"region": "cat",
+				"location": "Balsareny"
+			}
+		}
+	},
+	{
+		"id": "pronimetal",
+		"query": "Pronimetal, Alagón",
+		"expectedOutput": {
+			"officialDomain": "pronimetal.com",
+			"fields": {
+				"industry": "manufactura",
+				"size_range": "51-200",
+				"region": "ara",
+				"location": "Alagón"
+			}
+		}
+	},
+	{
+		"id": "pcex-automotive",
+		"query": "PCEX Automotive, Alicante",
+		"expectedOutput": {
+			"officialDomain": "pcexautomotive.com",
+			"fields": {
+				"industry": "distribució",
+				"size_range": "11-25",
+				"region": "cv",
+				"location": "Alicante"
+			}
+		}
+	},
+	{
+		"id": "canteras-la-ponderosa",
+		"query": "Canteras La Ponderosa, Alcover",
+		"expectedOutput": {
+			"officialDomain": "canteralaponderosa.com",
+			"fields": { "region": "cat", "location": "Alcover" }
+		}
 	}
 ]

--- a/packages/research/src/application/critic-guard.test.ts
+++ b/packages/research/src/application/critic-guard.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
 	applyCriticVerdicts,
+	CRITIC_UNSURE_CONFIDENCE,
 	type CriticJudge,
 	collectFieldClaims,
 	critiqueFieldSupport,
@@ -89,9 +90,9 @@ describe('collectFieldClaims', () => {
 })
 
 describe('applyCriticVerdicts', () => {
-	describe('when a verdict rejects a field', () => {
+	describe('when a verdict clearly rejects a field', () => {
 		it('should blank exactly that field to null and leave its siblings', () => {
-			// GIVEN two sourced fields and a verdict dropping one
+			// GIVEN two sourced fields and an 'unsupported' verdict on one
 			const findings = {
 				enrichment: {
 					industry: sourced('retail', 'sells clothes'),
@@ -101,27 +102,52 @@ describe('applyCriticVerdicts', () => {
 
 			// WHEN the rejecting verdict is applied
 			const result = applyCriticVerdicts(findings, [
-				{ id: 'enrichment.industry', keep: false },
-				{ id: 'enrichment.location', keep: true },
+				{ id: 'enrichment.industry', verdict: 'unsupported' },
+				{ id: 'enrichment.location', verdict: 'supported' },
 			])
 
-			// THEN only the rejected field is nulled
+			// THEN only the rejected field is nulled; the supported one is untouched
 			const e = (result.findings as { enrichment: Record<string, unknown> })
 				.enrichment
 			expect(e['industry']).toBeNull()
 			expect(e['location']).toEqual(sourced('Barcelona', 'based here'))
 			expect(result.dropped).toBe(1)
+			expect(result.flagged).toBe(0)
+		})
+	})
+
+	describe('when a verdict is unsure about a field', () => {
+		it('should keep the value but stamp it low-confidence', () => {
+			// GIVEN a sourced field the judge cannot vouch for or rule out
+			const findings = {
+				enrichment: { industry: sourced('retail', 'maybe a shop') },
+			}
+
+			// WHEN an 'unsure' verdict is applied
+			const result = applyCriticVerdicts(findings, [
+				{ id: 'enrichment.industry', verdict: 'unsure' },
+			])
+
+			// THEN the value survives, carries the low-confidence stamp, and is counted
+			const e = (result.findings as { enrichment: Record<string, unknown> })
+				.enrichment
+			expect(e['industry']).toEqual({
+				...sourced('retail', 'maybe a shop'),
+				confidence: CRITIC_UNSURE_CONFIDENCE,
+			})
+			expect(result.dropped).toBe(0)
+			expect(result.flagged).toBe(1)
 		})
 	})
 
 	describe('when a verdict id is unknown or a field has no verdict', () => {
 		it('should default to keep', () => {
-			// GIVEN a field with no matching verdict and a verdict for a ghost id
+			// GIVEN a field with no matching verdict and an 'unsupported' verdict for a ghost id
 			const findings = { enrichment: { industry: sourced('retail', 'q') } }
 
 			// WHEN applied
 			const result = applyCriticVerdicts(findings, [
-				{ id: 'enrichment.ghost', keep: false },
+				{ id: 'enrichment.ghost', verdict: 'unsupported' },
 			])
 
 			// THEN the real field is untouched
@@ -129,12 +155,13 @@ describe('applyCriticVerdicts', () => {
 				.enrichment
 			expect(e['industry']).toEqual(sourced('retail', 'q'))
 			expect(result.dropped).toBe(0)
+			expect(result.flagged).toBe(0)
 		})
 	})
 })
 
 describe('critiqueFieldSupport', () => {
-	describe('when the judge rejects one field', () => {
+	describe('when the judge clearly rejects one field', () => {
 		it('should blank it, keep the rest, and thread the judge tokens', async () => {
 			// GIVEN a supported industry, an unsupported size, and a quote-less
 			// location (which is never sent to the judge)
@@ -149,7 +176,8 @@ describe('critiqueFieldSupport', () => {
 				Effect.succeed({
 					verdicts: claims.map(c => ({
 						id: c.id,
-						keep: c.id !== 'enrichment.size_range',
+						verdict:
+							c.id === 'enrichment.size_range' ? 'unsupported' : 'supported',
 					})),
 					outputTokens: 42,
 				})
@@ -167,7 +195,45 @@ describe('critiqueFieldSupport', () => {
 			expect(e['location']).toEqual(sourced('Barcelona'))
 			expect(result.criticised).toBe(2)
 			expect(result.dropped).toBe(1)
+			expect(result.flagged).toBe(0)
 			expect(result.outputTokens).toBe(42)
+		})
+	})
+
+	describe('when the judge is unsure about a field', () => {
+		it('should keep the value, stamp it low-confidence, and count it flagged', async () => {
+			// GIVEN a supported industry and an unsure size
+			const findings = {
+				enrichment: {
+					industry: sourced('retail', 'a shop'),
+					size_range: sourced('26-50', 'a vague headcount hint'),
+				},
+			}
+			const judge: CriticJudge = claims =>
+				Effect.succeed({
+					verdicts: claims.map(c => ({
+						id: c.id,
+						verdict: c.id === 'enrichment.size_range' ? 'unsure' : 'supported',
+					})),
+					outputTokens: 7,
+				})
+
+			// WHEN critiqued
+			const result = await Effect.runPromise(
+				critiqueFieldSupport(findings, judge),
+			)
+
+			// THEN the unsure field survives with the low-confidence stamp; nothing dropped
+			const e = (result.findings as { enrichment: Record<string, unknown> })
+				.enrichment
+			expect(e['size_range']).toEqual({
+				...sourced('26-50', 'a vague headcount hint'),
+				confidence: CRITIC_UNSURE_CONFIDENCE,
+			})
+			expect(e['industry']).toEqual(sourced('retail', 'a shop'))
+			expect(result.dropped).toBe(0)
+			expect(result.flagged).toBe(1)
+			expect(result.outputTokens).toBe(7)
 		})
 	})
 

--- a/packages/research/src/application/critic-guard.ts
+++ b/packages/research/src/application/critic-guard.ts
@@ -4,9 +4,12 @@
  * The deterministic guards prove a value appears somewhere in the run's evidence
  * and that its citation was fetched — but not that the *cited quote* actually
  * backs the value, nor that the quote is about the target company rather than a
- * look-alike. This guard asks exactly that, one question per sourced field, and
- * blanks the fields that fail. It is the only guard that calls a model, so it runs
- * LAST (after the free deterministic guards have pruned the findings) and only
+ * look-alike. This guard asks exactly that, one question per sourced field. It
+ * blanks a field only on a clear "no"; a field it cannot vouch for but cannot rule
+ * out either is kept and marked low-confidence, not deleted — so a caution about a
+ * thin quote no longer costs a probably-correct value. It is the only guard that
+ * calls a model, so it runs LAST (after the free deterministic guards have pruned
+ * the findings) and only
  * looks at values that still carry a source + quote — the per-field Sourced shape
  * introduced for enrichment scalars and contact channels.
  *
@@ -26,12 +29,21 @@ export interface FieldClaim {
 	readonly quote: string
 }
 
-// The judge's ruling on one field: keep it, or drop it (with an optional reason).
+// The judge's ruling on one field: the quote backs it ('supported', keep as-is),
+// clearly does not ('unsupported', drop), or is too thin to tell ('unsure', keep
+// the value but flag it low-confidence rather than deleting a maybe-correct field).
+export type CriticVerdictType = 'supported' | 'unsupported' | 'unsure'
+
 export interface CriticVerdict {
 	readonly id: string
-	readonly keep: boolean
+	readonly verdict: CriticVerdictType
 	readonly reason?: string
 }
+
+// The confidence stamped on an 'unsure' field: kept, but marked shaky so the UI
+// shows it as low-confidence. 0.3 normalizes to 30%, under the 70 the UI treats as
+// trustworthy.
+export const CRITIC_UNSURE_CONFIDENCE = 0.3
 
 export interface CriticJudgeResult {
 	readonly verdicts: ReadonlyArray<CriticVerdict>
@@ -47,8 +59,10 @@ export interface FieldCritiqueResult {
 	readonly findings: unknown
 	/** Fields sent to the judge. */
 	readonly criticised: number
-	/** Fields the judge rejected and this blanked. */
+	/** Fields the judge clearly rejected and this blanked. */
 	readonly dropped: number
+	/** Fields the judge was unsure about — kept, but marked low-confidence. */
+	readonly flagged: number
 	readonly outputTokens: number
 }
 
@@ -63,7 +77,7 @@ export const CriticVerdictsSchema = Schema.Struct({
 	verdicts: Schema.Array(
 		Schema.Struct({
 			id: Schema.String,
-			keep: Schema.Boolean,
+			verdict: Schema.Literals(['supported', 'unsupported', 'unsure']),
 			reason: Schema.optionalKey(Schema.String),
 		}),
 	),
@@ -124,11 +138,23 @@ export const collectFieldClaims = (
 export const applyCriticVerdicts = (
 	findings: unknown,
 	verdicts: ReadonlyArray<CriticVerdict>,
-): { readonly findings: unknown; readonly dropped: number } => {
-	// An id absent from `drop` (unknown id, or a field the judge gave no verdict
-	// for) defaults to keep — the critic only removes what it affirmatively rejects.
-	const drop = new Set(verdicts.filter(v => v.keep === false).map(v => v.id))
+): {
+	readonly findings: unknown
+	readonly dropped: number
+	readonly flagged: number
+} => {
+	// Only an affirmative ruling changes a field: 'unsupported' blanks it, 'unsure'
+	// keeps the value but stamps it low-confidence. An id absent from both (unknown
+	// id, no verdict, or 'supported') is left exactly as the guards produced it — the
+	// critic never removes or downgrades what it did not clearly rule against.
+	const drop = new Set(
+		verdicts.filter(v => v.verdict === 'unsupported').map(v => v.id),
+	)
+	const flag = new Set(
+		verdicts.filter(v => v.verdict === 'unsure').map(v => v.id),
+	)
 	let dropped = 0
+	let flagged = 0
 	const apply = (value: unknown, path: string): unknown => {
 		if (Array.isArray(value)) {
 			return value.map((item, i) => apply(item, childPath(path, String(i))))
@@ -145,6 +171,9 @@ export const applyCriticVerdicts = (
 				if (drop.has(p)) {
 					dropped++
 					out[key] = null
+				} else if (flag.has(p)) {
+					flagged++
+					out[key] = { ...v, confidence: CRITIC_UNSURE_CONFIDENCE }
 				} else {
 					out[key] = v
 				}
@@ -154,7 +183,7 @@ export const applyCriticVerdicts = (
 		}
 		return out
 	}
-	return { findings: apply(findings, ''), dropped }
+	return { findings: apply(findings, ''), dropped, flagged }
 }
 
 export const critiqueFieldSupport = <E, R>(
@@ -166,17 +195,25 @@ export const critiqueFieldSupport = <E, R>(
 		// No sourced+quoted fields (a scan/freeform schema, or empty findings) →
 		// don't spend a model call.
 		if (claims.length === 0) {
-			return { findings, criticised: 0, dropped: 0, outputTokens: 0 }
+			return {
+				findings,
+				criticised: 0,
+				dropped: 0,
+				flagged: 0,
+				outputTokens: 0,
+			}
 		}
 		const { verdicts, outputTokens } = yield* judge(claims)
-		const { findings: applied, dropped } = applyCriticVerdicts(
-			findings,
-			verdicts,
-		)
+		const {
+			findings: applied,
+			dropped,
+			flagged,
+		} = applyCriticVerdicts(findings, verdicts)
 		return {
 			findings: applied,
 			criticised: claims.length,
 			dropped,
+			flagged,
 			outputTokens,
 		}
 	})
@@ -200,13 +237,18 @@ export const criticPrompt = (
 		`You are auditing extracted CRM fields for the company "${target.name}"${
 			target.domain ? ` (official site ${target.domain})` : ''
 		}.`,
-		'For each field, set keep=true only if BOTH hold:',
-		'1) the quote actually supports the value, and',
-		'2) the quote is about this company, not a different or look-alike one.',
+		'For each field, return exactly one verdict:',
+		'- "supported": the quote clearly backs the value AND is about this company,',
+		'  not a different or look-alike one.',
+		'- "unsupported": the quote clearly contradicts the value, or is clearly about a',
+		'  different or look-alike company. Use this ONLY when you are confident it is wrong.',
+		'- "unsure": the quote is thin, ambiguous, or you cannot tell — not clearly wrong,',
+		'  just not clearly right. Prefer "unsure" over "unsupported" whenever in doubt;',
+		'  the value is kept but flagged low-confidence rather than thrown away.',
 		'A value may be a short CRM category code (e.g. "serveis" = a services or',
 		'finance business, "retail" = a shop, "manufactura" = a maker); judge whether',
 		'the quote fits that category, not an exact word match.',
-		'Otherwise set keep=false. Return exactly one verdict per id, matching the id verbatim.',
+		'Return exactly one verdict per id, matching the id verbatim.',
 		'',
 		'Fields:',
 		fields,

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -7,6 +7,7 @@ import {
 	domainHost,
 	type EntityTargets,
 	groundedSourceIds,
+	isConfirmedRegistryMatch,
 } from './entity-guard'
 
 describe('deriveEntityTargets', () => {
@@ -151,6 +152,70 @@ describe('classifyEntityMatch', () => {
 			expect(
 				classifyEntityMatch(targets!, 'Topia and Sunset are freight brokers'),
 			).toBe('absent')
+		})
+	})
+})
+
+describe('isConfirmedRegistryMatch', () => {
+	const targets = deriveEntityTargets({
+		schemaName: 'company_enrichment_v1',
+		query: 'Acme Logistics, Barcelona',
+		subjects: [],
+	})
+
+	describe('when the lookup resolved the target company', () => {
+		it('should confirm on a legal name that strongly matches the target', () => {
+			// GIVEN a resolved record whose legal name spells the target with a legal form
+			// WHEN checked against the target's keys
+			// THEN the registry lookup confirms the run reached the right company
+			expect(
+				isConfirmedRegistryMatch(targets, {
+					legalName: 'ACME LOGISTICS SL',
+					taxId: 'B12345678',
+					status: 'active',
+				}),
+			).toBe(true)
+		})
+	})
+
+	describe('when the lookup resolved a same-named different company', () => {
+		it('should not confirm when the legal name does not match the target', () => {
+			// GIVEN a resolved record for an unrelated firm
+			// WHEN checked
+			// THEN a look-alike registry hit does not count as reaching the target
+			expect(
+				isConfirmedRegistryMatch(targets, {
+					legalName: 'Global Freight Partners SA',
+					status: 'active',
+				}),
+			).toBe(false)
+		})
+	})
+
+	describe('when the country has no registry match', () => {
+		it('should not confirm on a no_registry result', () => {
+			// GIVEN the tool returned {status:'no_registry'} (no company resolved)
+			// WHEN checked
+			// THEN there is nothing to confirm
+			expect(
+				isConfirmedRegistryMatch(targets, {
+					status: 'no_registry',
+					country: 'ES',
+				}),
+			).toBe(false)
+		})
+	})
+
+	describe('when there is no target or the result is not a record', () => {
+		it('should not confirm without targets, or on a non-object result', () => {
+			// GIVEN a discovery run has no entity targets, or a failed/empty result
+			// WHEN checked
+			// THEN neither can confirm a target
+			expect(
+				isConfirmedRegistryMatch(null, { legalName: 'ACME LOGISTICS SL' }),
+			).toBe(false)
+			expect(isConfirmedRegistryMatch(targets, null)).toBe(false)
+			expect(isConfirmedRegistryMatch(targets, 'not a record')).toBe(false)
 		})
 	})
 })

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -263,6 +263,28 @@ export const classifyEntityMatch = (
 	return weak ? 'weak' : 'absent'
 }
 
+/**
+ * Whether a `registry_lookup` tool result confirms the target company. True only
+ * when the lookup resolved a real company — a record carrying a `legalName`, not a
+ * `{status:'no_registry'}` miss — whose legal name strongly matches the run's
+ * entity targets. A registry's fuzzy name search can surface a look-alike, so the
+ * legal name must clear the same 'strong' bar scraped evidence does, not merely be
+ * present. Returns false when there are no targets (a discovery scan) or the result
+ * is not a resolved record.
+ */
+export const isConfirmedRegistryMatch = (
+	targets: EntityTargets | null,
+	result: unknown,
+): boolean => {
+	if (targets === null) return false
+	if (result === null || typeof result !== 'object') return false
+	const record = result as { legalName?: unknown; status?: unknown }
+	if (typeof record.legalName !== 'string' || record.legalName.trim() === '')
+		return false
+	if (record.status === 'no_registry') return false
+	return classifyEntityMatch(targets, record.legalName) === 'strong'
+}
+
 export interface SourceEntityVerdict {
 	readonly sourceId: string
 	readonly match: EntityMatch

--- a/packages/research/src/application/eval-outcome.test.ts
+++ b/packages/research/src/application/eval-outcome.test.ts
@@ -119,4 +119,39 @@ describe('outcomeFromRun', () => {
 			expect(outcome.reachedDomains).toEqual(['acme.es'])
 		})
 	})
+
+	describe('when the pipeline confirmed the target in the official register', () => {
+		it('should carry registryConfirmed through, in snake or camel case', () => {
+			// GIVEN a run that fetched no site but stamped the registry-confirmation flag
+			const snake = outcomeFromRun({
+				status: 'no_reliable_data',
+				findings: { registry_confirmed: true, error: 'no site fetched' },
+				fetchedUrls: [],
+			})
+			// AND the CLI's camelCasing client can deliver the same flag camelCased
+			const camel = outcomeFromRun({
+				status: 'succeeded',
+				findings: { registryConfirmed: true, enrichment: { region: 'cat' } },
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN both surface the reached-via-registry signal
+			expect(snake.registryConfirmed).toBe(true)
+			expect(camel.registryConfirmed).toBe(true)
+		})
+	})
+
+	describe('when no registry confirmation was recorded', () => {
+		it('should leave registryConfirmed false', () => {
+			// GIVEN findings without the flag
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				findings: { enrichment: { industry: 'transport' } },
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN the flag defaults false
+			expect(outcome.registryConfirmed).toBe(false)
+		})
+	})
 })

--- a/packages/research/src/application/eval-outcome.ts
+++ b/packages/research/src/application/eval-outcome.ts
@@ -105,5 +105,17 @@ export const outcomeFromRun = (input: {
 		if (host !== null) reachedDomains.push(host)
 	}
 
-	return { status: toTerminalStatus(input.status), reachedDomains, fields }
+	// The pipeline stamps this on the findings when a registry lookup resolved the
+	// target company by legal name — a reached signal independent of the fetch log.
+	const registryConfirmed =
+		findings !== null &&
+		typeof findings === 'object' &&
+		(findings as { registry_confirmed?: unknown }).registry_confirmed === true
+
+	return {
+		status: toTerminalStatus(input.status),
+		reachedDomains,
+		fields,
+		registryConfirmed,
+	}
 }

--- a/packages/research/src/application/eval-report.test.ts
+++ b/packages/research/src/application/eval-report.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildEvalReport, scorePayloadsForRun } from './eval-report'
+import {
+	buildEvalReport,
+	evalSpanAttributes,
+	evalSummaryAttributes,
+	scorePayloadsForRun,
+} from './eval-report'
 import type { RunScore } from './eval-scoring'
 
 const score = (over: Partial<RunScore>): RunScore => ({
@@ -99,6 +104,82 @@ describe('scorePayloadsForRun', () => {
 
 			// WHEN mapped — THEN recall is not reported
 			expect(payloads.has('field_recall')).toBe(false)
+		})
+	})
+})
+
+describe('evalSpanAttributes', () => {
+	describe('when a run filled and scored some fields', () => {
+		it('should carry the booleans and both rates', () => {
+			// GIVEN a grounded run, 1 correct of 2 filled, 1 of 4 known
+			const attrs = evalSpanAttributes(
+				score({
+					id: 'acme',
+					grounded: true,
+					fieldsExpected: 4,
+					fieldsScored: 2,
+					fieldsCorrect: 1,
+				}),
+			)
+
+			// WHEN flattened — THEN the id, booleans, and both rates ride along
+			expect(attrs['eval.company_id']).toBe('acme')
+			expect(attrs['eval.grounded']).toBe(true)
+			expect(attrs['eval.field_precision']).toBe(0.5)
+			expect(attrs['eval.field_recall']).toBe(0.25)
+		})
+	})
+
+	describe('when a run filled no fields', () => {
+		it('should omit precision but keep recall', () => {
+			// GIVEN a run that filled nothing but had known fields
+			const attrs = evalSpanAttributes(
+				score({ fieldsExpected: 3, fieldsScored: 0, fieldsCorrect: 0 }),
+			)
+
+			// WHEN flattened — THEN there is no precision to chart, but recall (0) rides
+			expect('eval.field_precision' in attrs).toBe(false)
+			expect(attrs['eval.field_recall']).toBe(0)
+		})
+	})
+})
+
+describe('evalSummaryAttributes', () => {
+	describe('when precision and recall are present', () => {
+		it('should carry every rate', () => {
+			// GIVEN a full summary
+			const attrs = evalSummaryAttributes({
+				runs: 4,
+				groundingAccuracy: 0.5,
+				wrongCompanyRate: 0.25,
+				emptyRate: 0.25,
+				fieldPrecision: 0.75,
+				fieldRecall: 0.5,
+			})
+
+			// WHEN flattened — THEN each top-line rate is present
+			expect(attrs['eval.runs']).toBe(4)
+			expect(attrs['eval.grounding_accuracy']).toBe(0.5)
+			expect(attrs['eval.field_precision']).toBe(0.75)
+			expect(attrs['eval.field_recall']).toBe(0.5)
+		})
+	})
+
+	describe('when nothing was filled to judge', () => {
+		it('should omit the null precision', () => {
+			// GIVEN a summary whose precision is null (nothing filled)
+			const attrs = evalSummaryAttributes({
+				runs: 1,
+				groundingAccuracy: 1,
+				wrongCompanyRate: 0,
+				emptyRate: 1,
+				fieldPrecision: null,
+				fieldRecall: 0,
+			})
+
+			// WHEN flattened — THEN a null precision is left off, not charted as zero
+			expect('eval.field_precision' in attrs).toBe(false)
+			expect(attrs['eval.field_recall']).toBe(0)
 		})
 	})
 })

--- a/packages/research/src/application/eval-report.ts
+++ b/packages/research/src/application/eval-report.ts
@@ -91,3 +91,56 @@ export const buildEvalReport = (
 	summary: summarizeScores(scores),
 	runs: scores,
 })
+
+/**
+ * Flatten one run's score into span attributes for the monitoring board, so a
+ * chart can group runs by company and average the rates over time. Precision and
+ * recall ride along only where there was something to judge — the same rule the
+ * summary uses, so a run that filled nothing charts no precision rather than a
+ * misleading zero.
+ */
+export const evalSpanAttributes = (
+	score: RunScore,
+): Record<string, string | number | boolean> => {
+	const attributes: Record<string, string | number | boolean> = {
+		'eval.company_id': score.id,
+		'eval.grounded': score.grounded,
+		'eval.wrong_company': score.wrongCompany,
+		'eval.empty': score.empty,
+		'eval.fields_expected': score.fieldsExpected,
+		'eval.fields_scored': score.fieldsScored,
+		'eval.fields_correct': score.fieldsCorrect,
+	}
+	if (score.fieldsScored > 0) {
+		attributes['eval.field_precision'] =
+			score.fieldsCorrect / score.fieldsScored
+	}
+	if (score.fieldsExpected > 0) {
+		attributes['eval.field_recall'] = score.fieldsCorrect / score.fieldsExpected
+	}
+	return attributes
+}
+
+/**
+ * Flatten the whole-batch summary into span attributes for the monitoring board —
+ * the top-line rates a drift chart tracks across model and prompt changes. A null
+ * precision/recall (nothing filled, or no known fields) is left off rather than
+ * charted as a zero.
+ */
+export const evalSummaryAttributes = (
+	summary: EvalSummary,
+): Record<string, string | number | boolean> => {
+	const attributes: Record<string, string | number | boolean> = {
+		'eval.runs': summary.runs,
+		'eval.grounding_accuracy': summary.groundingAccuracy,
+		'eval.wrong_company_rate': summary.wrongCompanyRate,
+		'eval.empty_rate': summary.emptyRate,
+	}
+	if (summary.fieldPrecision !== null) {
+		attributes['eval.field_precision'] = summary.fieldPrecision
+	}
+	if (summary.fieldRecall !== null) {
+		attributes['eval.field_recall'] = summary.fieldRecall
+	}
+	return attributes
+}

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -85,6 +85,24 @@ describe('scoreRun', () => {
 		})
 	})
 
+	describe('when a registry lookup confirmed the target but no page was reached', () => {
+		it('should count as grounded and not wrong-company', () => {
+			// GIVEN a run that fetched no page but resolved the company in the register
+			const result = scoreRun(
+				acme,
+				outcome({
+					reachedDomains: [],
+					registryConfirmed: true,
+					fields: { region: 'cat' },
+				}),
+			)
+
+			// WHEN scored — THEN the registry confirmation grounds it; not a look-alike
+			expect(result.grounded).toBe(true)
+			expect(result.wrongCompany).toBe(false)
+		})
+	})
+
 	describe('when a succeeded run returned data but never reached the target', () => {
 		it('should flag it as wrong-company', () => {
 			// GIVEN a confident run whose sources are a same-named different company

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -14,6 +14,9 @@
  * once per-field citations point at whichever page stated each fact, a run that
  * correctly reached the target's own site still cites third-party pages per field,
  * so citation hosts no longer track "reached the right company" — the fetch log does.
+ * A run is also grounded without fetching the target's site at all when an official
+ * company-register lookup resolved the target by legal name — an independent proof
+ * the right entity was reached.
  */
 
 /**
@@ -72,6 +75,12 @@ export interface RunOutcome {
 	readonly reachedDomains: ReadonlyArray<string>
 	/** Extracted enrichment scalars; a missing/blank value counts as unfilled. */
 	readonly fields: Partial<Record<ScorableField, string | null>>
+	/**
+	 * Whether an official-registry lookup this run resolved the target company by
+	 * its legal name. Independent of the fetched pages: a company confirmed in the
+	 * register was reached even if its own site was never scraped.
+	 */
+	readonly registryConfirmed?: boolean
 }
 
 export interface RunScore {
@@ -179,15 +188,20 @@ export const scoreRun = (
 	const anchors = [expected.officialDomain, ...(expected.altDomains ?? [])].map(
 		normalizeDomain,
 	)
-	const grounded = outcome.reachedDomains.some(reached => {
-		const host = normalizeDomain(reached)
-		// The official host itself, or a subdomain of it (careers.acme.com,
-		// us.acme.com) — both are the company's own pages, so both prove the run
-		// reached the target. A look-alike host never ends with ".<official>".
-		return anchors.some(
-			anchor => host === anchor || host.endsWith(`.${anchor}`),
-		)
-	})
+	// Reached the target either by fetching its own site (or a subdomain / alt
+	// domain), or by resolving it in the official company register — a registry
+	// confirmation grounds a company whose own site was never scraped.
+	const grounded =
+		outcome.registryConfirmed === true ||
+		outcome.reachedDomains.some(reached => {
+			const host = normalizeDomain(reached)
+			// The official host itself, or a subdomain of it (careers.acme.com,
+			// us.acme.com) — both are the company's own pages, so both prove the run
+			// reached the target. A look-alike host never ends with ".<official>".
+			return anchors.some(
+				anchor => host === anchor || host.endsWith(`.${anchor}`),
+			)
+		})
 
 	let fieldsExpected = 0
 	let fieldsScored = 0

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -47,6 +47,7 @@ import {
 	type EntityMatch,
 	type EntityTargets,
 	groundedSourceIds,
+	isConfirmedRegistryMatch,
 } from './entity-guard'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
@@ -1025,6 +1026,18 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					// Tool log accumulator
 					const toolLog = yield* Ref.make<ToolLogEntry[]>([])
 
+					// True once a registry_lookup this run resolved the target company by
+					// its legal name — a strong, site-independent confirmation the run
+					// reached the right entity. Stamped onto the findings so the eval can
+					// count it toward grounding even when the company's own site was never
+					// fetched; nothing in the product reads it. A resumed run skips phase 1
+					// and so never sets it (the eval always runs fresh, so it never resumes).
+					let registryConfirmed = false
+					const withRegistryFlag = (
+						obj: Record<string, unknown>,
+					): Record<string, unknown> =>
+						registryConfirmed ? { ...obj, registry_confirmed: true } : obj
+
 					// Fail a run closed as no_reliable_data because its evidence was not clearly
 					// about the requested company. Called by the phase-1 entity gate and again on
 					// resume, where that gate is skipped — so a weak or absent match never reaches
@@ -1038,11 +1051,13 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									reason_code = ${(verdict === 'weak' ? 'weak_no_official_site' : 'entity_mismatch') satisfies ReasonCode},
 									phase = 1,
 									entity_match = ${verdict},
-									findings = ${JSON.stringify({
-										error:
-											'The fetched pages were not clearly about the requested company, so the findings could not be grounded.',
-										reason: 'no_reliable_data',
-									})},
+									findings = ${JSON.stringify(
+										withRegistryFlag({
+											error:
+												'The fetched pages were not clearly about the requested company, so the findings could not be grounded.',
+											reason: 'no_reliable_data',
+										}),
+									)},
 									tool_log = ${JSON.stringify(toolLogNow)},
 									completed_at = now(),
 									updated_at = now()
@@ -1507,6 +1522,21 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 													},
 												])
 											}
+											// A registry_lookup that resolved the target by its legal name
+											// strongly confirms the run reached the right company, even if
+											// its own site was never scraped. OR-accumulate across rounds.
+											if (!registryConfirmed) {
+												for (const tr of response.toolResults) {
+													if (
+														!tr.isFailure &&
+														tr.name === 'registry_lookup' &&
+														isConfirmedRegistryMatch(entityTargets, tr.result)
+													) {
+														registryConfirmed = true
+														break
+													}
+												}
+											}
 											yield* emitRound(
 												round,
 												response.text.length,
@@ -1790,11 +1820,13 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							SET status = 'no_reliable_data',
 								reason_code = ${'no_sources' satisfies ReasonCode},
 								phase = 3,
-								findings = ${JSON.stringify({
-									error:
-										'No pages were fetched, so the findings could not be grounded.',
-									reason: 'no_reliable_data',
-								})},
+								findings = ${JSON.stringify(
+									withRegistryFlag({
+										error:
+											'No pages were fetched, so the findings could not be grounded.',
+										reason: 'no_reliable_data',
+									}),
+								)},
 								tool_log = ${JSON.stringify(finalToolLog)},
 								completed_at = now(),
 								updated_at = now()
@@ -1843,7 +1875,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						UPDATE research_runs
 						SET status = 'succeeded',
 							phase = 3,
-							findings = ${JSON.stringify(findings)},
+							findings = ${JSON.stringify(withRegistryFlag(findings as Record<string, unknown>))},
 							brief_md = ${briefMd},
 							tokens_in = ${tokensIn},
 							tokens_out = ${tokensOut},

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1292,12 +1292,13 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									),
 							)
 							result = critiqued.findings
-							if (critiqued.dropped > 0) {
+							if (critiqued.dropped > 0 || critiqued.flagged > 0) {
 								yield* Effect.logWarning('research.critic.dropped').pipe(
 									Effect.annotateLogs({
 										research_id: researchId,
 										criticised: critiqued.criticised,
 										dropped: critiqued.dropped,
+										flagged: critiqued.flagged,
 									}),
 								)
 							}

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -24,6 +24,8 @@ export { outcomeFromRun } from './application/eval-outcome'
 export {
 	buildEvalReport,
 	type EvalReport,
+	evalSpanAttributes,
+	evalSummaryAttributes,
 	type ScorePayload,
 	scorePayloadsForRun,
 } from './application/eval-report'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@batuda/domain':
         specifier: workspace:*
         version: link:../../packages/domain
+      '@batuda/observability':
+        specifier: workspace:*
+        version: link:../../packages/observability
       '@batuda/research':
         specifier: workspace:*
         version: link:../../packages/research


### PR DESCRIPTION
Closes #231. Three follow-ups from #214 (PR #221), which built the research pipeline that auto-fills a company's CRM card and the eval harness that scores each run against companies whose answers we already know.

## What & why

The #214 eval showed the pipeline finds the *right* company and writes correct values, but blanks more than half the fields it's asked for — more cautious than needed. It also couldn't run against the Catalan/Spanish small businesses I actually sell to, and its scores only ever landed in a terminal. This PR closes those three gaps.

### 1. Gentler critic — keep uncertain fields instead of dropping them

The per-field critic returned a binary keep/drop and blanked every field whose cited quote it couldn't fully vouch for. It now returns a three-way verdict: a clear "no" still drops the field, but **"unsure" keeps the value and marks it low-confidence** (rendered as a caution in the enrichment view) instead of deleting a probably-correct value. The critic log now reports `flagged` alongside `dropped`, so the discard rate is measurable.

> ⚠️ **Production behavior change, not just the eval** — the real research pipeline will now keep "unsure" fields as low-confidence too. Enrichment scalars are display-only and never auto-apply, so a kept low-confidence field can't enter the CRM on its own. No DB migration.

### 2. Test on Spanish SMBs, with the registers on

- Added **5 real, verified Catalan/Spanish small businesses** to the golden set (`eval/golden.example.json`) so it can exercise `region` (`cat`/`ara`/`cv`) and `size_range` — the two fields that are Spain-SMB-only in the CRM and that the UK companies are too large / out-of-region to test. Every official domain was checked to load; every region/industry/size value comes from a named source (chamber-of-commerce award coverage), never a guess.
- **Registry lookups now count toward grounding**: a `registry_lookup` that resolves the target company by its legal name marks the run, and the eval treats that as reaching the company even when its site was never scraped (common for thin-web SMBs). Identity-checked against the target name, recorded on every terminal findings write; nothing in the product reads the mark.
- Documented switching the official registers on (Companies House, libreBORME) for the Spanish set.

### 3. Chart the eval on the monitoring board

Each run plus a per-batch summary now export as Honeycomb spans (tagged with the models used) when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so grounding accuracy, field precision/recall, and the empty rate can be charted over model and prompt changes. No-op locally — a run without the OTEL env prints its table and writes its `--out` report exactly as before.

Also pointed `docs/backend.md` + `AGENTS.md` at `eval/README.md` — the harness had gone undocumented in the top-level docs since #214.

## You run it (needs secrets/budget I don't have)

The "did the numbers improve?" re-measure is the manual step: it needs the research keys + budget, the two registers on (`RESEARCH_PROVIDER_REGISTRY_ES=librebor` / `_GB=companies-house` + keys), and — for the chart — `OTEL_EXPORTER_OTLP_ENDPOINT` / `_HEADERS` in the run env. All documented in `eval/README.md`.

## Test plan

- `pnpm --filter @batuda/research test` — 438 pass (new coverage: critic 3-way verdict + low-confidence flag, `isConfirmedRegistryMatch`, registry-grounded scoring, span-attribute helpers).
- `pnpm check-types` — 13/13 packages; Biome clean; pre-push `test` gate green.
- `pnpm cli research eval --help` smoke-tested (CLI + OTLP wiring loads).
- Pure-logic + CLI/UI changes; the live eval run is the manual step above.

## Commits

1. `feat(research): keep uncertain fields instead of dropping them`
2. `feat(research): count an official-registry match toward eval grounding`
3. `docs: add Spanish small-business golden rows and register/chart notes`
4. `feat: export eval run scores to the monitoring board as spans`
5. `docs: reference the research eval harness in backend and agent docs`
