### PR TITLE
ai(skills): document watching parallel worktree apps in headed windows

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -183,6 +183,7 @@ Quick login test:
 agent-browser open "$WEB/login"                               # $WEB from the pre-flight
 agent-browser fill "input[name='email']" "admin@taller.cat"
 agent-browser fill "input[name='password']" "batuda-dev-2026"
+agent-browser wait 500                                        # let controlled inputs commit first
 agent-browser click "button[type='submit']"
 agent-browser wait 3000
 agent-browser find testid "org-switcher" click                # org-scoped pages error
@@ -190,6 +191,25 @@ agent-browser find testid "org-switcher-option-taller" click  # without an activ
 agent-browser wait 3000
 agent-browser snapshot
 ```
+
+## Watch several worktrees at once
+
+One AI session per worktree — give each its own **headed** window (the default here, via `AGENT_BROWSER_HEADED=1`) to watch them navigate live, side by side. Each worktree owns a distinct `agent-browser` session, so the windows never clash:
+
+```bash
+# inside a worktree — open ITS app in a dedicated window (URL from `worktree doctor`/`ls`)
+agent-browser --session "ai-<slug>" open "<worktree-url>/login"
+```
+
+Tile them instead of stacking with `--args "--window-position=X,Y,--window-size=W,H"`.
+
+Tear down **only this worktree's** window — never blanket-kill while others are live:
+
+```bash
+agent-browser --session "ai-<slug>" close   # closes ONLY this worktree's browser
+```
+
+`agent-browser close --all` (and any `pkill -f .../browsers/chrome`) kill EVERY session's browser at once — use only when no other worktree window is open.
 
 ## Reporting
 

--- a/.claude/skills/debug-apps/references/agent-browser.md
+++ b/.claude/skills/debug-apps/references/agent-browser.md
@@ -2,6 +2,8 @@
 
 Playwright-based CLI for testing apps as a real user. Already installed in this environment.
 
+Windows show by default here (`AGENT_BROWSER_HEADED=1` in `~/.zshenv`); pass `--headed=false` for a one-off headless run. The `snapshot`/`screenshot` commands below work the same either way.
+
 > **Dev URLs carry portless's port.** portless binds 443 when it can, otherwise a fallback like `:1355`. The `https://batuda.localhost/…` examples below omit it — substitute the URL `pnpm dev` printed (e.g. `https://batuda.localhost:1355/…`), or prefix with `$(cat ~/.portless/proxy.port)`.
 
 ## Dev login credentials
@@ -22,6 +24,7 @@ agent-browser open https://batuda.localhost/login
 agent-browser snapshot                                        # see the login form
 agent-browser fill "input[name='email']" "admin@taller.cat"
 agent-browser fill "input[name='password']" "batuda-dev-2026"
+agent-browser wait 500                                        # let controlled inputs commit — a click too soon submits an empty form
 agent-browser click "button[type='submit']"
 agent-browser wait 3000
 agent-browser snapshot                                        # should show dashboard
@@ -111,6 +114,8 @@ agent-browser find testid "company-card-tancaments-garraf" click
 agent-browser find testid "tab-where" click
 ```
 
+Valid device names (curated set): `iPhone 15`, `iPhone 16`, `iPhone 16 Pro`, `iPhone 17`, `iPad`, `iPad Pro`, `Pixel 9`, `Galaxy S25`. `set device` emulates viewport + device-scale + mobile user-agent, but **not touch** — `ontouchstart` stays absent and `pointer: coarse` stays false, so touch-only handlers and `@media (pointer: coarse)` branches don't fire under emulation. Real touch needs a real device.
+
 ## Verify state
 
 ```bash
@@ -145,14 +150,14 @@ agent-browser set offline off
 
 ## Recovering a hung session
 
-If commands start hanging or timing out — including a lone `screenshot` — the browser session is wedged (a prior command, often `eval` waiting on something that never resolves, can leave Chrome stuck). Don't keep retrying the same call; reset the session:
+If commands start hanging or timing out — including a lone `screenshot` — the browser session is wedged (a prior command, often `eval` waiting on something that never resolves, can leave Chrome stuck). Don't keep retrying the same call; reset **only the wedged session**:
 
 ```bash
-agent-browser close --all     # close every session and its Chrome
-# then re-open + re-login — the session is gone, so re-run the login flow
+agent-browser --session <name> close   # reset ONLY this session (safe while others run)
+# then re-open + re-login that session — its state is gone, so re-run the login flow
 ```
 
-`close` without `--all` closes only the current session. Reach for this the moment 2–3 calls in a row fail or time out, rather than burning attempts (see the `pr` skill's "avoid rabbit holes" guidance).
+`agent-browser close --all` — and any `pkill -f .../browsers/chrome` — kill **every** session's Chrome at once, so never use them to fix one session while other worktree windows are live; reach for them only when nothing else is running. Reset the moment 2–3 calls in a row fail or time out, rather than burning attempts (see the `pr` skill's "avoid rabbit holes" guidance).
 
 ## Record a video (WebM)
 

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -42,7 +42,7 @@ fires the auto-provision/teardown hooks below.
    `pnpm install && pnpm cli worktree up`, then skips once the worktree's database exists). Or
    run `pnpm cli worktree up` yourself: it ensures the shared stack is up, creates the DB +
    bucket, writes `.env`, and migrates + seeds (re-running re-seeds — see Caveats).
-3. **Run** — `pnpm dev` → portless serves `https://<label>.batuda.localhost` (the branch's last path segment).
+3. **Run** — `pnpm dev` → portless serves `https://<label>.batuda.localhost` (the branch's last path segment). To watch a worktree's app live in a browser — one headed window per worktree — see the `/debug-apps` skill → *Watch several worktrees at once*.
 4. **Inspect** — `pnpm cli worktree ls` (every worktree + its DB/URL/provisioned state),
    `pnpm cli worktree doctor` (deep health of the current one).
 5. **Tear down / finish** — after the PR merges, run `pnpm cli worktree done` once to drop the data, remove the linked worktree, and clean up the local branch. For manual teardown run `pnpm cli worktree down` (DB + bucket only) and then `git worktree remove`. Auto when **Claude** removes the worktree (the `WorktreeRemove` hook drops the DB + bucket).


### PR DESCRIPTION
## What

This updates the developer tooling docs — the "skills" that guide AI coding sessions on this repo — for a setup I use often: running several AI sessions at once, each in its own git worktree, and watching each one drive the app in its own browser window. It documents that workflow in the `debug-apps` skill and fixes a few pieces of stale or unsafe guidance. Documentation only — no application code.

## Changes

- Added a **"Watch several worktrees at once"** section: one live browser window per worktree (windows now show by default), so I can watch each parallel session navigate the app side by side, with a note on tiling the windows instead of stacking them.
- Made the browser-cleanup guidance **session-scoped**: teardown closes only the one worktree's window, and `close --all` / blanket process-kills are flagged as closing *every* worktree's window at once — so cleaning up one session never kills another's live view.
- Fixed the documented login flow: added a short wait before the submit, so the click can't fire before the typed email and password have registered — which was silently submitting an empty form and leaving the page stuck on the login screen.
- Documented the accepted device-emulation names, and that emulating a phone does **not** emulate touch — so touch-only behavior still needs a real device.
- Noted that headed (visible) browser windows are now the default, and added a pointer from the `worktree` skill to the new watch section.

## Impact

Documentation only — three `.claude/skills/**` markdown files. No runtime code, schema, API/wire-shape, env vars, RLS / multi-org scoping, auth, or deploy coupling. Nothing to migrate or deploy.

## Review guide

Fast to review — it's prose. The one part worth a careful read is the **safe-teardown** guidance (in both the new *Watch several worktrees at once* section and *Recovering a hung session*): the point is that per-worktree cleanup must never blanket-kill Chrome, or it would close other worktrees' live windows. Everything else is additive (a new section, a note) or a small correction to existing command examples.

## Verification

- Pre-commit hooks ran and passed: `check-deps`, `check-types`, `format-markdown`, `format-packages`, `lint`.
- Docs-only (skill markdown, not source), so I did not run the local `test` / `build` gates — they don't exercise these files. CI runs the full suite on this PR.
