### PR TITLE
feat(cli): add worktree watch for a live browser window per worktree

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -169,6 +169,7 @@ origin is derived from `PORTLESS_URL`, no wildcard needed.
 | `pnpm cli worktree doctor` | Diagnose the current worktree's data layer     |
 | `pnpm cli worktree down`   | Drop this worktree's DB + bucket               |
 | `pnpm cli worktree prune`  | Reap orphaned worktree DBs + buckets           |
+| `pnpm cli worktree watch`  | Open this worktree in a live browser window    |
 | `pnpm cli:tui`             | Interactive TUI (same commands)                |
 
 ## Browser debugging
@@ -194,22 +195,23 @@ agent-browser snapshot
 
 ## Watch several worktrees at once
 
-One AI session per worktree — give each its own **headed** window (the default here, via `AGENT_BROWSER_HEADED=1`) to watch them navigate live, side by side. Each worktree owns a distinct `agent-browser` session, so the windows never clash:
+One AI session per worktree — give each its own **headed** browser window (the default here, via `AGENT_BROWSER_HEADED=1`) to watch them navigate live, side by side. From inside each worktree:
 
 ```bash
-# inside a worktree — open ITS app in a dedicated window (URL from `worktree doctor`/`ls`)
-agent-browser --session "ai-<slug>" open "<worktree-url>/login"
+pnpm cli worktree watch          # opens THIS worktree's app in its own visible window
+pnpm cli worktree watch --stop   # closes only this worktree's window (others untouched)
 ```
 
-Tile them instead of stacking with `--args "--window-position=X,Y,--window-size=W,H"`.
+`watch` opens a stable per-worktree `agent-browser` session (`ai-<slug>`) at the worktree's URL; `--stop` closes only that one. Arrange the windows with your OS window manager (macOS tiling / Rectangle) — agent-browser can't position them itself.
 
-Tear down **only this worktree's** window — never blanket-kill while others are live:
+For an extra tile of the same worktree (e.g. a mobile viewport), open another named session by hand:
 
 ```bash
-agent-browser --session "ai-<slug>" close   # closes ONLY this worktree's browser
+agent-browser --session "ai-<slug>-mobile" set device "iPhone 16 Pro"
+agent-browser --session "ai-<slug>-mobile" open "<worktree-url>/login"
 ```
 
-`agent-browser close --all` (and any `pkill -f .../browsers/chrome`) kill EVERY session's browser at once — use only when no other worktree window is open.
+Never `agent-browser close --all` (or `pkill -f .../browsers/chrome`) while other worktree windows are live — those close **every** session at once.
 
 ## Reporting
 

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -42,7 +42,7 @@ fires the auto-provision/teardown hooks below.
    `pnpm install && pnpm cli worktree up`, then skips once the worktree's database exists). Or
    run `pnpm cli worktree up` yourself: it ensures the shared stack is up, creates the DB +
    bucket, writes `.env`, and migrates + seeds (re-running re-seeds — see Caveats).
-3. **Run** — `pnpm dev` → portless serves `https://<label>.batuda.localhost` (the branch's last path segment). To watch a worktree's app live in a browser — one headed window per worktree — see the `/debug-apps` skill → *Watch several worktrees at once*.
+3. **Run** — `pnpm dev` → portless serves `https://<label>.batuda.localhost` (the branch's last path segment). To watch it live in a browser, `pnpm cli worktree watch` opens one headed window for this worktree (`--stop` closes it) — see the `/debug-apps` skill → *Watch several worktrees at once*.
 4. **Inspect** — `pnpm cli worktree ls` (every worktree + its DB/URL/provisioned state),
    `pnpm cli worktree doctor` (deep health of the current one).
 5. **Tear down / finish** — after the PR merges, run `pnpm cli worktree done` once to drop the data, remove the linked worktree, and clean up the local branch. For manual teardown run `pnpm cli worktree down` (DB + bucket only) and then `git worktree remove`. Auto when **Claude** removes the worktree (the `WorktreeRemove` hook drops the DB + bucket).
@@ -106,6 +106,7 @@ If the directory was removed manually before `worktree down`, run `pnpm cli work
 | `ls`     | table of every worktree + database + provisioned (✓) + URL             |
 | `doctor` | health of the current worktree (stack, DB, migrations, bucket, URL)    |
 | `prune`  | list orphaned DBs + buckets (worktrees that are gone); `--yes` to drop |
+| `watch`  | open this worktree in a live browser window (`--stop` closes it)       |
 
 ## Caveats
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -37,6 +37,7 @@ import {
 	worktreeLs,
 	worktreePrune,
 	worktreeUp,
+	worktreeWatch,
 } from './commands/worktree'
 import { withDb } from './db'
 import { appendEnvKeys, resetEnvFile } from './lib/env-file'
@@ -671,6 +672,27 @@ const worktreeDoctorCommand = Command.make(
 	),
 )
 
+const worktreeWatchCommand = Command.make(
+	'watch',
+	{
+		stop: Flag.boolean('stop').pipe(
+			Flag.withDescription(
+				'Close this worktree’s watch window (leaves other worktrees’ windows open)',
+			),
+			Flag.withDefault(false),
+		),
+	},
+	({ stop }) => worktreeWatch({ stop }),
+).pipe(
+	Command.withShortDescription('Open this worktree in a live browser window'),
+	Command.withDescription(
+		'Open this worktree’s app in its own visible Chrome window (a stable ' +
+			'per-worktree browser session), so parallel worktrees can be watched ' +
+			'navigating live, side by side. Re-running reuses the same window; ' +
+			'`--stop` closes only this worktree’s window, never the others.',
+	),
+)
+
 const worktreeCommand = Command.make('worktree').pipe(
 	Command.withShortDescription('Per-worktree dev data on the shared stack'),
 	Command.withDescription(
@@ -687,6 +709,7 @@ const worktreeCommand = Command.make('worktree').pipe(
 		worktreePruneCommand,
 		worktreeLsCommand,
 		worktreeDoctorCommand,
+		worktreeWatchCommand,
 	]),
 )
 

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -7,7 +7,7 @@ import { dirname, resolve } from 'node:path'
 import { Console, Effect, Schedule } from 'effect'
 
 import { mergeEnvOverrides, missingEnvEntries, tryFs } from '../lib/env-file'
-import { exec, execIn, execSilent, ROOT } from '../shell'
+import { exec, execArgs, execIn, execSilent, ROOT } from '../shell'
 import { dbMigrate } from './db'
 
 // The whole machine runs ONE shared Docker stack (the `batuda` compose project).
@@ -901,3 +901,69 @@ export const worktreeDoctor = Effect.gen(function* () {
 	}
 	yield* Console.log('')
 })
+
+// ── watch: one live browser window per worktree ──────────────
+//
+// `watch` opens THIS worktree's app in its own visible Chrome window, so a
+// developer running several sessions at once can watch each one navigate the
+// app side by side. The window is a per-worktree agent-browser session named
+// after the branch, so it's identifiable at a glance and re-running `watch`
+// reuses it instead of opening a second. Teardown (`--stop`) closes only this
+// worktree's window — never every session — so cleaning up one worktree can't
+// kill another's live view.
+
+// A readable, per-worktree window name (branch label, not an opaque hash) so
+// the window is easy to spot; distinct per worktree, so parallel windows never
+// collide.
+const watchSessionName = (branch: string) => `ai-${slugForBranch(branch)}`
+
+// The URL this checkout actually serves: a linked worktree is on its own
+// <label>.batuda.localhost; the main checkout is on the bare batuda.localhost
+// (portless routes it there, not to `main.batuda.localhost`).
+const watchUrl = (isLinked: boolean, branch: string) =>
+	isLinked ? branchUrl(branch) : `https://batuda.localhost${portSuffix()}`
+
+export const worktreeWatch = (options: { stop: boolean }) =>
+	Effect.gen(function* () {
+		const { isLinked } = yield* worktreeContext
+		const branch = yield* branchName
+		const session = watchSessionName(branch)
+
+		if (options.stop) {
+			// Scoped to THIS worktree's window only — never `close --all`, which
+			// would take down every other worktree's live window too. Closing a
+			// window that was never opened is a no-op, not an error.
+			yield* execArgs('agent-browser', ['--session', session, 'close']).pipe(
+				Effect.catch(() => Effect.void),
+			)
+			yield* Console.log(
+				`✓ Closed watch window ${session} (other worktrees untouched).`,
+			)
+			return
+		}
+
+		const target = watchUrl(isLinked, branch)
+		// `open` launches a new headed window for this session, or re-points the
+		// existing one — `--headed` is a no-op once the window is up, so the one
+		// call both creates and reuses. Passed through `execArgs` (no shell) so the
+		// derived name/URL can never be read as shell syntax.
+		yield* execArgs('agent-browser', [
+			'--session',
+			session,
+			'--headed',
+			'open',
+			`${target}/login`,
+		])
+
+		yield* Console.log(
+			[
+				'',
+				`✓ Watching this worktree at ${target}`,
+				`  Window:  ${session}  (a visible Chrome window — look for it on screen)`,
+				'  Stop:    pnpm cli worktree watch --stop',
+				'',
+				'Run `pnpm dev` in this worktree if the window shows a connection error.',
+				'',
+			].join('\n'),
+		)
+	})

--- a/apps/cli/src/shell.ts
+++ b/apps/cli/src/shell.ts
@@ -21,6 +21,26 @@ export const exec = (cmd: string, ...args: string[]) =>
 		}
 	}).pipe(Effect.scoped)
 
+/**
+ * Like `exec`, but runs the command directly WITHOUT a shell: `args` are passed
+ * as an array, so no interpolated value (a name, a URL) can be read as shell
+ * syntax. Use this whenever an argument is derived rather than a fixed literal.
+ */
+export const execArgs = (cmd: string, args: string[]) =>
+	Effect.gen(function* () {
+		const handle = yield* ChildProcess.make(cmd, args, {
+			shell: false,
+			stdout: 'inherit',
+			stderr: 'inherit',
+		})
+		const code = yield* handle.exitCode
+		if (code !== 0) {
+			return yield* Effect.fail(
+				new Error(`\`${cmd} ${args.join(' ')}\` exited with code ${code}`),
+			)
+		}
+	}).pipe(Effect.scoped)
+
 /** Like `exec`, but runs in a specific working directory. */
 export const execIn = (cwd: string, cmd: string, ...args: string[]) =>
 	Effect.gen(function* () {


### PR DESCRIPTION
## What

A new developer command — `pnpm cli worktree watch` — that opens **this** git worktree's app in its own visible browser window. The point: I often run several AI coding sessions at once, one per worktree, and want to watch each one drive the app live, side by side. Each worktree gets its own window; closing one never touches the others. This lives in the `cli` app (the local dev tooling), and it's opt-in — nothing runs it automatically.

## Changes

- **`pnpm cli worktree watch`** opens the worktree's app (at the URL portless already serves for it) in a headed browser window. The window is a stable per-worktree browser session named `ai-<slug>`, so re-running the command reuses the same window instead of opening a second.
- **`pnpm cli worktree watch --stop`** closes **only** this worktree's window. It never runs a "close everything" command, so tearing down one worktree can't kill another's live view — the safety property that motivated a dedicated command over a raw one-liner.
- Added a small shell-free `execArgs` helper (runs a command with its arguments as an array, no shell), and used it here so the derived window name and URL can never be interpreted as shell syntax.
- Updated the `debug-apps` and `worktree` skills to document the command, and removed a now-known-wrong tip that windows could be tiled with Chrome `--window-position` args.

## Impact

- **CLI surface only.** One new `worktree` subcommand; no change to any existing command's behavior.
- **No schema, API/wire-shape, env var, RLS/tenant, auth, or deploy coupling.** Nothing to migrate or deploy.
- `execArgs` is a new exported helper in `apps/cli/src/shell.ts` — available for other CLI commands that need to pass derived arguments without a shell.

## Review guide

- Start in `apps/cli/src/commands/worktree.ts` → the `worktreeWatch` effect (bottom of file). It reuses the existing `branchUrl` / `slugForBranch` helpers rather than re-deriving anything.
- The one property worth verifying is the **scoped teardown**: `--stop` runs `agent-browser --session ai-<slug> close` for this worktree alone — never `close --all`.
- **Security note:** the browser is launched through the new shell-free `execArgs` (not the shell-interpolating `exec`), so the interpolated name/URL can't inject. The values are also `[a-z0-9-]` slugs by construction.
- **Design decision you might question — no auto-tiling.** I wanted the windows to auto-tile into a grid, but verified empirically that agent-browser ignores Chrome `--window-position` / `--window-size` args in headed mode (windows opened at the same default spot regardless). Per-session separate browser instances also make OS-level positioning ambiguous. So windows open at the default position and you arrange them with the OS (macOS tiling / Rectangle); the skill says so. Auto-tiling is noted as deferred below.

## Verification

- Type-check: `pnpm --filter @batuda/cli check-types` and repo-wide `pnpm -w check-types` — both pass.
- Gates: `pnpm -w build` — pass. Pre-push hook ran `pnpm -w test` — pass.
- Ran the command live from a real worktree:
  - `pnpm cli worktree watch` opened a session at `https://worktree-watch.batuda.localhost:1355/login` — matches the URL `pnpm cli worktree ls` prints for the worktree.
  - With a second decoy session standing in for a sibling worktree, `pnpm cli worktree watch --stop` closed **only** this worktree's window; the sibling survived.

## Deferred

- **Auto-tiling** the windows into a grid — not feasible cleanly (agent-browser ignores window-position args; separate per-session browser instances make OS-level positioning ambiguous). Would need fragile OS window-management to add later.
- **`--device` / extra viewport tiles** per worktree — the skill documents the manual `agent-browser` two-liner for now; a flag could fold it in if it turns out to be common.
