### PR TITLE
feat(cli): auto-tile worktree watch windows into a 2×2 grid

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -202,7 +202,7 @@ pnpm cli worktree watch          # opens THIS worktree's app in its own visible 
 pnpm cli worktree watch --stop   # closes only this worktree's window (others untouched)
 ```
 
-`watch` opens a stable per-worktree `agent-browser` session (`ai-<slug>`) at the worktree's URL; `--stop` closes only that one. Arrange the windows with your OS window manager (macOS tiling / Rectangle) — agent-browser can't position them itself.
+`watch` opens a stable per-worktree `agent-browser` session (`ai-<slug>`) at the worktree's URL; `--stop` closes only that one. A freshly opened window auto-tiles into a 2×2 grid cell (up to four side by side), so parallel worktrees don't stack on top of each other; a reused window is left where you dragged it.
 
 For an extra tile of the same worktree (e.g. a mobile viewport), open another named session by hand:
 

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -7,7 +7,14 @@ import { dirname, resolve } from 'node:path'
 import { Console, Effect, Schedule } from 'effect'
 
 import { mergeEnvOverrides, missingEnvEntries, tryFs } from '../lib/env-file'
-import { exec, execArgs, execIn, execSilent, ROOT } from '../shell'
+import {
+	exec,
+	execArgs,
+	execIn,
+	execSilent,
+	execSilentArgs,
+	ROOT,
+} from '../shell'
 import { dbMigrate } from './db'
 
 // The whole machine runs ONE shared Docker stack (the `batuda` compose project).
@@ -908,9 +915,11 @@ export const worktreeDoctor = Effect.gen(function* () {
 // developer running several sessions at once can watch each one navigate the
 // app side by side. The window is a per-worktree agent-browser session named
 // after the branch, so it's identifiable at a glance and re-running `watch`
-// reuses it instead of opening a second. Teardown (`--stop`) closes only this
-// worktree's window — never every session — so cleaning up one worktree can't
-// kill another's live view.
+// reuses it instead of opening a second. A brand-new window is tiled into a free
+// cell of a 2×2 grid so several fit on screen without stacking; a reused one is
+// left where it was dragged. Teardown (`--stop`) closes only this worktree's
+// window — never every session — so cleaning up one worktree can't kill
+// another's live view.
 
 // A readable, per-worktree window name (branch label, not an opaque hash) so
 // the window is easy to spot; distinct per worktree, so parallel windows never
@@ -922,6 +931,132 @@ const watchSessionName = (branch: string) => `ai-${slugForBranch(branch)}`
 // (portless routes it there, not to `main.batuda.localhost`).
 const watchUrl = (isLinked: boolean, branch: string) =>
 	isLinked ? branchUrl(branch) : `https://batuda.localhost${portSuffix()}`
+
+// The browser windows currently alive, one name per line. `agent-browser session
+// list` prints a header then `→ name` (focused) / `  name` (others); strip the
+// markers. Best-effort — if agent-browser can't be reached, treat none as open.
+const liveWatchSessions = execSilent('agent-browser session list').pipe(
+	Effect.map(out =>
+		out
+			.split('\n')
+			.map(line => line.replace(/^[→\s]+/, '').trim())
+			.filter(name => name && name !== 'Active sessions:'),
+	),
+	Effect.orElseSucceed(() => [] as string[]),
+)
+
+// One cell of a 2×2 grid over the usable screen — the window bounds for `slot`.
+// Past four windows the slots wrap and overlap (rare: more than four worktrees
+// watched at once).
+const gridCell = (screenW: number, screenH: number, slot: number) => {
+	const cellW = Math.floor(screenW / 2)
+	const cellH = Math.floor(screenH / 2)
+	const cell = slot % 4
+	return {
+		left: (cell % 2) * cellW,
+		top: Math.floor(cell / 2) * cellH,
+		width: cellW,
+		height: cellH,
+	}
+}
+
+// Move a Chrome window to exact screen coordinates over the DevTools Protocol.
+// agent-browser ignores Chrome's `--window-position` launch flags in headed mode,
+// but `Browser.setWindowBounds` on the session's OWN debugger endpoint moves its
+// window directly — so there's no ambiguity about which window belongs to which
+// session. Resolves when the window has moved, rejects on any protocol error.
+type CdpTarget = { type: string; targetId: string }
+const cdpSetWindowBounds = (
+	cdpUrl: string,
+	bounds: { left: number; top: number; width: number; height: number },
+): Promise<void> =>
+	new Promise<void>((resolve, reject) => {
+		const socket = new WebSocket(cdpUrl)
+		const pending = new Map<
+			number,
+			{
+				resolve: (value: Record<string, unknown>) => void
+				reject: (error: Error) => void
+			}
+		>()
+		let nextId = 0
+		const finish = (error?: Error) => {
+			clearTimeout(timer)
+			socket.close()
+			error ? reject(error) : resolve()
+		}
+		const timer = setTimeout(() => finish(new Error('CDP timed out')), 5000)
+		const call = (method: string, params: Record<string, unknown> = {}) =>
+			new Promise<Record<string, unknown>>((res, rej) => {
+				const id = ++nextId
+				pending.set(id, { resolve: res, reject: rej })
+				socket.send(JSON.stringify({ id, method, params }))
+			})
+		socket.onmessage = event => {
+			const message = JSON.parse(String(event.data)) as {
+				id?: number
+				result?: Record<string, unknown>
+				error?: { message: string }
+			}
+			if (message.id === undefined) return
+			const waiting = pending.get(message.id)
+			if (!waiting) return
+			pending.delete(message.id)
+			if (message.error) waiting.reject(new Error(message.error.message))
+			else waiting.resolve(message.result ?? {})
+		}
+		socket.onerror = () => finish(new Error('CDP socket error'))
+		socket.onopen = () => {
+			void (async () => {
+				const targets = await call('Target.getTargets')
+				const page = (targets['targetInfos'] as CdpTarget[] | undefined)?.find(
+					target => target.type === 'page',
+				)
+				if (!page) throw new Error('no page target')
+				const win = await call('Browser.getWindowForTarget', {
+					targetId: page.targetId,
+				})
+				await call('Browser.setWindowBounds', {
+					windowId: win['windowId'],
+					bounds: { ...bounds, windowState: 'normal' },
+				})
+				finish()
+			})().catch(finish)
+		}
+	})
+
+// Tile a freshly-opened watch window into its grid cell. Reads the usable screen
+// from the browser itself (cross-display, no OS permissions) and moves the window
+// over CDP. Best-effort at every step: if the screen can't be read or the window
+// can't be reached, it simply stays where Chrome put it and is arranged by hand.
+const tileWindow = (session: string, slot: number) =>
+	Effect.gen(function* () {
+		const size = yield* execSilentArgs('agent-browser', [
+			'--session',
+			session,
+			'eval',
+			'screen.availWidth + "," + screen.availHeight',
+		]).pipe(Effect.orElseSucceed(() => ''))
+		const dims = size.replace(/"/g, '').split(',')
+		const screenW = Number(dims[0])
+		const screenH = Number(dims[1])
+		if (!(screenW > 0 && screenH > 0)) return
+
+		const cdpUrl = yield* execSilentArgs('agent-browser', [
+			'--session',
+			session,
+			'get',
+			'cdp-url',
+		]).pipe(
+			Effect.map(out => out.match(/ws:\/\/\S+/)?.[0] ?? ''),
+			Effect.orElseSucceed(() => ''),
+		)
+		if (!cdpUrl) return
+
+		yield* Effect.tryPromise(() =>
+			cdpSetWindowBounds(cdpUrl, gridCell(screenW, screenH, slot)),
+		).pipe(Effect.catch(() => Effect.void))
+	})
 
 export const worktreeWatch = (options: { stop: boolean }) =>
 	Effect.gen(function* () {
@@ -943,6 +1078,12 @@ export const worktreeWatch = (options: { stop: boolean }) =>
 		}
 
 		const target = watchUrl(isLinked, branch)
+		// A window already up for this session is reused (and left where it was
+		// dragged); a brand-new one is tiled below. Snapshot the open windows
+		// before launching, so this window's grid slot is the count that preceded it.
+		const openBefore = yield* liveWatchSessions
+		const isNew = !openBefore.includes(session)
+
 		// `open` launches a new headed window for this session, or re-points the
 		// existing one — `--headed` is a no-op once the window is up, so the one
 		// call both creates and reuses. Passed through `execArgs` (no shell) so the
@@ -954,6 +1095,13 @@ export const worktreeWatch = (options: { stop: boolean }) =>
 			'open',
 			`${target}/login`,
 		])
+
+		if (isNew) {
+			// Only watch windows are named `ai-…`; other agent-browser sessions
+			// don't count toward this window's grid slot.
+			const slot = openBefore.filter(name => name.startsWith('ai-')).length
+			yield* tileWindow(session, slot)
+		}
 
 		yield* Console.log(
 			[

--- a/apps/cli/src/shell.ts
+++ b/apps/cli/src/shell.ts
@@ -75,3 +75,25 @@ export const execSilent = (cmd: string, ...args: string[]) =>
 			.toString()
 			.trim()
 	}).pipe(Effect.scoped)
+
+/**
+ * Like `execSilent`, but runs the command directly WITHOUT a shell: `args` are
+ * passed as an array, so a derived argument (a name, a script to evaluate) can't
+ * be read as shell syntax. Returns the command's stdout, trimmed.
+ */
+export const execSilentArgs = (cmd: string, args: string[]) =>
+	Effect.gen(function* () {
+		const handle = yield* ChildProcess.make(cmd, args, {
+			shell: false,
+		})
+		const chunks = yield* Stream.runCollect(handle.stdout)
+		const code = yield* handle.exitCode
+		if (code !== 0) {
+			return yield* Effect.fail(
+				new Error(`\`${cmd} ${args.join(' ')}\` exited with code ${code}`),
+			)
+		}
+		return Buffer.concat([...chunks])
+			.toString()
+			.trim()
+	}).pipe(Effect.scoped)


### PR DESCRIPTION
## What

A follow-up to `pnpm cli worktree watch` (#239): freshly opened watch windows now **auto-tile into a 2×2 grid** instead of all stacking on the same default spot. Run `watch` in two, three, or four worktrees and their windows land in different screen quadrants — the whole point of watching several sessions at once. Lives in the `cli` app (local dev tooling); behavior is opt-in and best-effort.

## Changes

- A brand-new watch window is positioned into a free grid cell (the count of already-open watch windows picks the cell). A reused window is left where you dragged it.
- Because agent-browser **ignores Chrome's `--window-position` launch flags in headed mode** (verified), the window is moved *after* it opens, via the Chrome DevTools Protocol on that session's own debugger endpoint. The usable screen size is read from the browser itself (`screen.availWidth/Height`) — cross-display, no OS permissions.
- Added a shell-free `execSilentArgs` helper (like the existing `execArgs`, but captures stdout) and used it for the derived agent-browser calls.
- Updated the `debug-apps` skill note (windows auto-tile now, rather than "arrange them by hand").

## Impact

- **CLI surface only** — extends `worktree watch`'s behavior; no other command changes.
- **No schema, API/wire-shape, env var, RLS, auth, or deploy coupling.**
- `execSilentArgs` is a new exported helper in `apps/cli/src/shell.ts`, available to other CLI commands.

## Review guide

- The tiling lives in `apps/cli/src/commands/worktree.ts`: `gridCell` (pure grid math), `cdpSetWindowBounds` (a minimal CDP WebSocket round-trip: `Target.getTargets` → `Browser.getWindowForTarget` → `Browser.setWindowBounds`), `tileWindow` (reads screen size + CDP url, then positions), and the tile call inside `worktreeWatch`.
- **Best-effort by design:** every step catches its own failure and returns — if the screen can't be read or the window can't be reached, the window just stays at Chrome's default spot. Tiling never blocks or fails the `watch` command.
- **Security:** the derived session name goes through the shell-free `execSilentArgs` (no shell); the CDP url is opened as a `WebSocket`, never interpolated into a shell. The CDP socket is always closed via a single `finish()` (success, error, or 5s timeout).
- **Why CDP, not launch flags:** I verified empirically that `--args "--window-position=…"` is ignored (windows opened at the same default coords). CDP `Browser.setWindowBounds` on each session's own endpoint moves the right window unambiguously.

## Verification

- Type-check (`pnpm --filter @batuda/cli check-types`, repo `check-types`) and `pnpm -w build` — pass. Pre-push hook ran `pnpm -w test` — pass.
- Ran the real command from a worktree and read back `window.screenX`:
  - No other windows → `watch` window landed **top-left** `(0, 26) 573×375`.
  - One decoy window present → next `watch` window landed **top-right** `(573, 26)`.

## Deferred

- More than four windows wrap and overlap (2×2 only).
- Multi-monitor: the window tiles within whichever display it opened on.
- A `--device` extra tile per worktree is still the manual `agent-browser` two-liner documented in the skill.
