### PR TITLE
fix(research): treat a refused-site scrape as a skip, not a run failure

### DIFF
--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -7,6 +7,7 @@ import type {
 	MonthlyCapExceeded,
 	NoRegistry,
 	ProviderError,
+	UnsupportedSite,
 } from '../domain/errors'
 
 // ── Research run context (available inside the LLM tool loop fiber) ──
@@ -99,7 +100,9 @@ export class ScrapeProvider extends ServiceMap.Service<
 	{
 		readonly scrape: (
 			input: ScrapeInput,
-		) => Effect.Effect<ScrapedPage, ProviderError>
+			// UnsupportedSite is a routing outcome (the provider refuses this site),
+			// not a fetch failure — the tool loop catches it and skips the URL.
+		) => Effect.Effect<ScrapedPage, ProviderError | UnsupportedSite>
 	}
 >()('research/ScrapeProvider') {}
 

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer, Schema, Stream } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { NoRegistry, ProviderError } from '../domain/errors'
+import { NoRegistry, ProviderError, UnsupportedSite } from '../domain/errors'
 import { RegistryRecord, ScrapedPage, SearchResult } from '../domain/types'
 import { StubExtractProvider } from '../infrastructure/stub/extract'
 import { StubRegistryEsProvider } from '../infrastructure/stub/registry-es'
@@ -25,10 +25,12 @@ import {
 } from './ports'
 import {
 	ExtractStructuredTool,
+	isUnsupportedScrapeUrl,
 	RegistryLookupTool,
 	researchToolkit,
 	researchToolkitLayer,
 	ScrapePageTool,
+	scrapeSkipResult,
 	stripPlaceholderSiteFilters,
 	WebSearchTool,
 } from './tools'
@@ -188,7 +190,9 @@ const registryLookupResult = async (
 // element, so a test can assert the model saw a failure (isFailure) rather than
 // the run fiber being aborted.
 const scrapePageResult = async (
-	scrape: (input: ScrapeInput) => Effect.Effect<ScrapedPage, ProviderError>,
+	scrape: (
+		input: ScrapeInput,
+	) => Effect.Effect<ScrapedPage, ProviderError | UnsupportedSite>,
 	params: { url: string },
 ): Promise<{ result: unknown; isFailure: boolean }> => {
 	const ports = Layer.mergeAll(
@@ -781,6 +785,117 @@ describe('researchToolkit — a web-fetch failure is non-fatal', () => {
 					'extract_structured: Unknown schema_name: totally_bogus_schema. Valid names: freeform, company_enrichment_v1, competitor_scan_v1, contact_discovery_v1, prospect_scan_v1',
 				)
 			})
+		})
+	})
+})
+
+describe('researchToolkit scrape_page — an unsupported site is skipped, not failed', () => {
+	describe('when the url is a known people directory (LinkedIn)', () => {
+		it('should return a discover_contacts skip result without ever calling the scrape provider', async () => {
+			// GIVEN a scrape provider that would fail loudly if it were ever reached
+			let called = false
+			const { result, isFailure } = await scrapePageResult(
+				() => {
+					called = true
+					return Effect.fail(
+						new ProviderError({
+							provider: 'firecrawl',
+							message: 'should not be called',
+							recoverable: false,
+						}),
+					)
+				},
+				{ url: 'https://www.linkedin.com/company/echo-global-logistics' },
+			)
+
+			// THEN the provider is never invoked (no scrape spent) and the model
+			// reads a non-failure skip that routes people lookups to discover_contacts
+			expect(called).toBe(false)
+			expect(isFailure).toBe(false)
+			expect(result).toEqual(
+				scrapeSkipResult(
+					'https://www.linkedin.com/company/echo-global-logistics',
+				),
+			)
+		})
+	})
+
+	describe('when the provider refuses the site with UnsupportedSite', () => {
+		it('should map the refusal to a non-failure skip so the run keeps going', async () => {
+			// GIVEN a scrape provider that reports the site is unsupported (the 403 no
+			// key or retry can fix)
+			const { result, isFailure } = await scrapePageResult(
+				() =>
+					Effect.fail(
+						new UnsupportedSite({
+							provider: 'firecrawl',
+							url: 'https://directory.example/profile',
+						}),
+					),
+				{ url: 'https://directory.example/profile' },
+			)
+
+			// THEN the model receives a skip result rather than a failure it can't act on
+			expect(isFailure).toBe(false)
+			expect(result).toEqual(
+				scrapeSkipResult('https://directory.example/profile'),
+			)
+		})
+	})
+})
+
+describe('isUnsupportedScrapeUrl', () => {
+	describe('when the url is a LinkedIn page or subdomain', () => {
+		it('should flag the apex, www, a country subdomain, and a company path', () => {
+			// GIVEN LinkedIn urls the loop must never scrape
+			// THEN each is recognised regardless of subdomain or path
+			expect(isUnsupportedScrapeUrl('https://linkedin.com')).toBe(true)
+			expect(isUnsupportedScrapeUrl('https://www.linkedin.com/in/jane')).toBe(
+				true,
+			)
+			expect(
+				isUnsupportedScrapeUrl('https://es.linkedin.com/company/acme'),
+			).toBe(true)
+		})
+	})
+
+	describe('when the url is a normal company site', () => {
+		it('should not flag a homepage, and must not match a look-alike host', () => {
+			// GIVEN a real company site and a host that merely contains the word
+			// THEN neither is treated as unsupported — only the real registrable host is
+			expect(isUnsupportedScrapeUrl('https://www.echo.com')).toBe(false)
+			expect(isUnsupportedScrapeUrl('https://sunsettrans.com/about')).toBe(
+				false,
+			)
+			expect(isUnsupportedScrapeUrl('https://notlinkedin.com')).toBe(false)
+			expect(isUnsupportedScrapeUrl('https://linkedin.com.evil.example')).toBe(
+				false,
+			)
+		})
+	})
+
+	describe('when the url is unparseable', () => {
+		it('should return false rather than throw', () => {
+			// GIVEN a value that is not a url
+			// THEN classification is a safe false
+			expect(isUnsupportedScrapeUrl('not a url')).toBe(false)
+			expect(isUnsupportedScrapeUrl('')).toBe(false)
+		})
+	})
+})
+
+describe('scrapeSkipResult', () => {
+	describe('when building the model-facing skip', () => {
+		it('should carry the url, the unsupported_site reason, and a discover_contacts pointer', () => {
+			// GIVEN a url the loop skipped
+			const result = scrapeSkipResult('https://www.linkedin.com/company/acme')
+
+			// THEN the shape is a non-failure status that names the reason and the
+			// next tool to use
+			expect(result.status).toBe('skipped')
+			expect(result.reason).toBe('unsupported_site')
+			expect(result.url).toBe('https://www.linkedin.com/company/acme')
+			expect(result.message).toContain('discover_contacts')
 		})
 	})
 })

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -213,6 +213,47 @@ export const stripPlaceholderSiteFilters = (query: string): string => {
 	return stripped.length > 0 ? stripped : query
 }
 
+// People directories the loop should not scrape: their staff/decision-maker data
+// belongs in discover_contacts, and the scrape provider refuses them anyway
+// (Firecrawl 403s LinkedIn). Skipping them up front spends no scrape on a fetch
+// that can't help; the provider-side UnsupportedSite catch is the backstop for
+// any site not listed here that the provider still turns away. Registrable hosts.
+const SCRAPE_SKIP_HOSTS = new Set(['linkedin.com'])
+
+const registrableHost = (url: string): string | undefined => {
+	try {
+		return new URL(url).hostname.toLowerCase().replace(/^www\./, '')
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * Whether a URL points at a site the scrape provider won't fetch — LinkedIn and
+ * other people directories. A subdomain (e.g. es.linkedin.com) counts too.
+ */
+export const isUnsupportedScrapeUrl = (url: string): boolean => {
+	const host = registrableHost(url)
+	if (host === undefined) return false
+	return [...SCRAPE_SKIP_HOSTS].some(
+		skip => host === skip || host.endsWith(`.${skip}`),
+	)
+}
+
+/**
+ * The model-facing result for a scrape the loop skips: not a failure, just a
+ * pointer to fetch that data another way — discover_contacts for people, the
+ * company's own site for the company. Mirrors `noRegistryResult`'s shape.
+ */
+export const scrapeSkipResult = (url: string) =>
+	({
+		status: 'skipped',
+		url,
+		reason: 'unsupported_site',
+		message:
+			"This site can't be fetched with scrape_page. For a company's decision-makers or staff, use discover_contacts with the company domain; for the company itself, scrape its official website instead.",
+	}) as const
+
 export const researchToolkitLayer = researchToolkit.toLayer(
 	Effect.gen(function* () {
 		const search = yield* SearchProvider
@@ -261,6 +302,20 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					Effect.andThen(mapToolError(toolName)(cause)),
 				)
 
+		// A scrape the provider refuses (or one of the known people directories) is
+		// logged as a skip, not a failure, so it stays queryable without the
+		// error-level noise a starved-run investigation would otherwise sift.
+		const skipUnsupportedScrape = (url: string) =>
+			Effect.logInfo('research.scrape.skipped_unsupported').pipe(
+				Effect.annotateLogs({
+					tool: 'scrape_page',
+					'research.run_id': researchId,
+					url,
+					reason: 'unsupported_site',
+				}),
+				Effect.as(scrapeSkipResult(url)),
+			)
+
 		return researchToolkit.of({
 			web_search: params =>
 				Effect.gen(function* () {
@@ -296,6 +351,11 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 
 			scrape_page: params =>
 				Effect.gen(function* () {
+					// Skip a site the provider refuses (LinkedIn etc.) before spending a
+					// scrape: hand the model a routing hint, not a guaranteed-failing fetch.
+					if (isUnsupportedScrapeUrl(params.url)) {
+						return yield* skipUnsupportedScrape(params.url)
+					}
 					yield* budget.chargeCheap('scrape', SCRAPE_COST_CENTS)
 					const page = yield* scrape.scrape({
 						url: params.url,
@@ -309,6 +369,10 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 							})
 						: page
 				}).pipe(
+					// The provider refused the site (a 403 no key or retry can fix):
+					// skip the URL and let the loop keep going, rather than logging a
+					// failure and handing the model an error it can't act on.
+					Effect.catchTag('UnsupportedSite', e => skipUnsupportedScrape(e.url)),
 					Effect.catchTag('BudgetExceeded', cheapExhausted('scrape_page')),
 					Effect.catchCause(logToolFailure('scrape_page')),
 					Effect.withSpan('research.tool.scrape_page', {

--- a/packages/research/src/domain/errors.ts
+++ b/packages/research/src/domain/errors.ts
@@ -71,3 +71,20 @@ export const noRegistryResult = (country: string) => ({
 	country,
 	message: `No national business registry for ${country}. Use discover_contacts for contact enrichment.`,
 })
+
+/**
+ * The scrape provider flatly refuses this site — Firecrawl answers a page fetch
+ * with "we do not support this site" (LinkedIn and other people directories).
+ * A routing outcome, not a failure: the page can never be fetched no matter the
+ * key or the retry, so the run should skip it and gather that data another way
+ * (its own official site, or discover_contacts for people). Kept distinct from
+ * ProviderError so it neither retries, cascades to another key, nor counts as a
+ * tool failure.
+ */
+export class UnsupportedSite extends Schema.TaggedErrorClass<UnsupportedSite>()(
+	'UnsupportedSite',
+	{
+		provider: Schema.String,
+		url: Schema.String,
+	},
+) {}

--- a/packages/research/src/infrastructure/_http-harden.test.ts
+++ b/packages/research/src/infrastructure/_http-harden.test.ts
@@ -2,7 +2,7 @@ import { Cause, Effect, Exit, Fiber, Option, Ref } from 'effect'
 import { TestClock } from 'effect/testing'
 import { describe, expect, it } from 'vitest'
 
-import { ProviderError } from '../domain/errors'
+import { ProviderError, UnsupportedSite } from '../domain/errors'
 import { hardenHttp } from './_http-harden'
 
 // ── Test helpers ──
@@ -111,6 +111,32 @@ describe('hardenHttp', () => {
 		// THEN it fails on the first attempt with no retry
 		expect(Ref.getUnsafe(callsRef)).toBe(1)
 		expect(errorOf(exit)?.recoverable).toBe(false)
+	})
+
+	it('should pass a non-ProviderError routing error straight through, un-retried', async () => {
+		// GIVEN an inner call that fails with a routing error that is NOT a
+		// ProviderError — the scrape provider refusing an unsupported site
+		const callsRef = Ref.makeUnsafe(0)
+		const inner = Effect.gen(function* () {
+			yield* Ref.update(callsRef, x => x + 1)
+			return yield* Effect.fail(
+				new UnsupportedSite({
+					provider: 'firecrawl',
+					url: 'https://www.linkedin.com/company/x',
+				}),
+			)
+		})
+
+		// WHEN it runs through the hardener
+		const exit = await runWithVirtualClock(() => hardenHttp('test')(inner))
+
+		// THEN it fails on the first attempt (no retry) and keeps its identity —
+		// never re-cast to a recoverable "timed out" ProviderError
+		expect(Ref.getUnsafe(callsRef)).toBe(1)
+		const err = Exit.isFailure(exit)
+			? Option.getOrUndefined(Cause.findErrorOption(exit.cause))
+			: undefined
+		expect(err).toBeInstanceOf(UnsupportedSite)
 	})
 
 	it('should convert a timed-out attempt into a recoverable error and retry', async () => {

--- a/packages/research/src/infrastructure/_http-harden.ts
+++ b/packages/research/src/infrastructure/_http-harden.ts
@@ -16,7 +16,7 @@
  * cascade in `_fallback.ts`.
  */
 
-import { Duration, Effect, Schedule } from 'effect'
+import { Cause, Duration, Effect, Schedule } from 'effect'
 
 import { ProviderError } from '../domain/errors'
 
@@ -55,28 +55,33 @@ export interface HttpHardenOptions {
  * Wrap one HTTP provider call with timeout + recoverable-only retry. Returns a
  * function so a provider builds it once (`const harden = hardenHttp('firecrawl')`)
  * and reuses it per request.
+ *
+ * The wrapped call may also fail with an extra routing error `Ex` (e.g. a scrape
+ * of a site the provider flatly refuses). Only the timeout is re-cast to a
+ * recoverable ProviderError; a ProviderError keeps its own `recoverable` flag and
+ * an `Ex` passes straight through — never retried and never mislabeled a timeout.
  */
 export const hardenHttp =
 	(provider: string, opts?: HttpHardenOptions) =>
-	<A, R>(
-		eff: Effect.Effect<A, ProviderError, R>,
-	): Effect.Effect<A, ProviderError, R> => {
+	<A, Ex, R>(
+		eff: Effect.Effect<A, ProviderError | Ex, R>,
+	): Effect.Effect<A, ProviderError | Ex, R> => {
 		const attempt = Effect.timeout(eff, opts?.timeout ?? DEFAULT_TIMEOUT).pipe(
-			Effect.mapError(
-				(err): ProviderError =>
-					err instanceof ProviderError
-						? err
-						: new ProviderError({
-								provider,
-								message: 'request timed out',
-								recoverable: true,
-							}),
+			Effect.mapError((err): ProviderError | Ex =>
+				Cause.isTimeoutError(err)
+					? new ProviderError({
+							provider,
+							message: 'request timed out',
+							recoverable: true,
+						})
+					: err,
 			),
 		)
 		return attempt.pipe(
 			Effect.retry({
 				schedule: makeSchedule(provider),
-				while: (e: ProviderError) => e.recoverable,
+				while: (e: ProviderError | Ex) =>
+					e instanceof ProviderError && e.recoverable,
 			}),
 		)
 	}

--- a/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
+++ b/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
@@ -20,7 +20,7 @@ import {
 import { describe, expect, it } from 'vitest'
 
 import type { SearchInput } from '../../application/ports'
-import { ProviderError } from '../../domain/errors'
+import { ProviderError, UnsupportedSite } from '../../domain/errors'
 import { makeFirecrawlExtract } from './extract'
 import { makeFirecrawlScrape } from './scrape'
 import { makeFirecrawlSearch } from './search'
@@ -259,6 +259,56 @@ describe('makeFirecrawlScrape', () => {
 		const resolved = await exit
 		expect(log.count).toBe(1)
 		expect(errorOf(resolved)?.recoverable).toBe(false)
+	})
+
+	it('should map a 403 "we do not support this site" to an UnsupportedSite skip, not retried', async () => {
+		// GIVEN Firecrawl refuses the site (its LinkedIn/people-directory response)
+		const { exit, log } = runScrape(
+			403,
+			{ success: false, error: 'This website is no longer supported' },
+			'https://www.linkedin.com/company/echo',
+		)
+
+		// THEN it fails once (no retry) with UnsupportedSite carrying the url — a
+		// routing outcome, not a ProviderError the run treats as a hard failure
+		const resolved = await exit
+		expect(log.count).toBe(1)
+		expect(Exit.isFailure(resolved)).toBe(true)
+		const err = Exit.isFailure(resolved)
+			? Option.getOrUndefined(Cause.findErrorOption(resolved.cause))
+			: undefined
+		expect(err).toBeInstanceOf(UnsupportedSite)
+		expect((err as UnsupportedSite | undefined)?.url).toBe(
+			'https://www.linkedin.com/company/echo',
+		)
+	})
+
+	it('should keep a plain 403 (no unsupported-site body) as a non-recoverable ProviderError', async () => {
+		// GIVEN a 403 that is a real auth/permission refusal, not an unsupported site
+		const { exit, log } = runScrape(403, { error: 'forbidden' })
+
+		// THEN it stays a fail-fast ProviderError — only the unsupported-site body
+		// is treated as a skip
+		const resolved = await exit
+		expect(log.count).toBe(1)
+		expect(errorOf(resolved)?.recoverable).toBe(false)
+		expect(errorOf(resolved)?.message).toContain('HTTP 403')
+	})
+
+	it('should detect the unsupported-site phrase even when it is not in an `error` field', async () => {
+		// GIVEN a 403 whose off-limits message rides a different field than `error`
+		// (Firecrawl's exact JSON shape is not guaranteed)
+		const { exit } = runScrape(403, {
+			success: false,
+			message: 'we do not support this site',
+		})
+
+		// THEN the whole-body fallback still recognises it as an UnsupportedSite skip
+		const resolved = await exit
+		const err = Exit.isFailure(resolved)
+			? Option.getOrUndefined(Cause.findErrorOption(resolved.cause))
+			: undefined
+		expect(err).toBeInstanceOf(UnsupportedSite)
 	})
 
 	it('should fail non-recoverably on a malformed body', async () => {

--- a/packages/research/src/infrastructure/firecrawl/scrape.ts
+++ b/packages/research/src/infrastructure/firecrawl/scrape.ts
@@ -20,7 +20,7 @@ import {
 } from 'effect/unstable/http'
 
 import { type ScrapeInput, ScrapeProvider } from '../../application/ports'
-import { ProviderError } from '../../domain/errors'
+import { ProviderError, UnsupportedSite } from '../../domain/errors'
 import { ScrapedPage } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
@@ -49,6 +49,26 @@ const sha256Hex = (input: string): string =>
 // 429 + 5xx are transient (retry); other 4xx are auth/quota/bad-request (fail fast).
 const statusRecoverable = (status: number): boolean =>
 	status === 429 || status >= 500
+
+// Firecrawl answers a fetch of a site it refuses (LinkedIn and other people
+// directories) with 403 + a body like {"success":false,"error":"…we do not
+// support this site…"}. That is the site being off-limits, not a credential,
+// quota, or rate problem — so it is told apart from every other 403 (which stays
+// a fail-fast auth/quota error) and surfaced as a skip the run can route around.
+const UNSUPPORTED_SITE_PATTERN =
+	/unsupported|not\s+support|no longer\s+support/i
+
+const isUnsupportedSiteBody = (body: string): boolean => {
+	const errorField = ((): string => {
+		try {
+			const parsed = JSON.parse(body) as { error?: unknown }
+			return typeof parsed.error === 'string' ? parsed.error : body
+		} catch {
+			return body
+		}
+	})()
+	return UNSUPPORTED_SITE_PATTERN.test(errorField)
+}
 
 export const makeFirecrawlScrape = (slot: number) =>
 	Effect.gen(function* () {
@@ -84,6 +104,22 @@ export const makeFirecrawlScrape = (slot: number) =>
 							),
 						)
 						if (response.status < 200 || response.status >= 300) {
+							// A 403 whose body says the site is off-limits means Firecrawl
+							// refuses to fetch it at all (LinkedIn etc.): surface a skip the
+							// run routes around, not a fail-fast error that could starve it.
+							if (response.status === 403) {
+								const body = yield* response.text.pipe(
+									Effect.orElseSucceed(() => ''),
+								)
+								if (isUnsupportedSiteBody(body)) {
+									return yield* Effect.fail(
+										new UnsupportedSite({
+											provider: 'firecrawl',
+											url: input.url,
+										}),
+									)
+								}
+							}
 							return yield* Effect.fail(
 								new ProviderError({
 									provider: 'firecrawl',

--- a/packages/research/src/infrastructure/providers-live.ts
+++ b/packages/research/src/infrastructure/providers-live.ts
@@ -36,7 +36,11 @@ import {
 	REPORT_VENDORS_BY_COUNTRY,
 	type RegistryCountry,
 } from '../domain/country'
-import type { NoRegistry, ProviderError } from '../domain/errors'
+import type {
+	NoRegistry,
+	ProviderError,
+	UnsupportedSite,
+} from '../domain/errors'
 import type {
 	CompanyReport,
 	DiscoverResult,
@@ -295,7 +299,12 @@ const scrapeLayer = Layer.effect(
 		if (instances.length === 1) return instances[0]!
 		const scrape = withFallback(
 			instances,
-			(svc, input: ScrapeInput): Effect.Effect<ScrapedPage, ProviderError> =>
+			(
+				svc,
+				input: ScrapeInput,
+				// UnsupportedSite passes through withFallback un-cascaded (every key
+				// refuses the same site), so it never wastefully retries a second slot.
+			): Effect.Effect<ScrapedPage, ProviderError | UnsupportedSite> =>
 				svc.scrape(input),
 		)
 		return ScrapeProvider.of({ scrape })


### PR DESCRIPTION
Part 1 of #234 (scrape resilience). Stacked base for the anchoring half (#234 part 2).

## Problem
On prod, every real company tested returned `no_reliable_data` / `weak_no_official_site` — even a $5B public 3PL. Per the issue's corrected diagnosis: company-enrichment queries ask for leadership, so the loop scrapes LinkedIn, and Firecrawl answers a LinkedIn fetch with `HTTP 403 {"success":false,"error":"…we do not support this site…"}`. `scrape.ts` treated any 403 as a non-recoverable `ProviderError`, so the refusal surfaced as a tool failure and starved the run of the company's own site.

## Change
A site the scrape provider flatly refuses is now a routing outcome, not a failure:
- **New `UnsupportedSite` error** (mirrors `NoRegistry`): a 403 whose body says the site is unsupported becomes `UnsupportedSite`, carrying the URL. A plain auth/permission 403 stays a fail-fast `ProviderError`.
- **`hardenHttp`** widened so a non-`ProviderError` routing error passes through un-retried; only the timeout is re-cast. Existing callers (`Ex = never`) are byte-for-byte unaffected.
- **`withFallback`** already passes `UnsupportedSite` through un-cascaded — every key refuses the same site, so it never wastes a second slot.
- **`scrape_page` tool**: skips known people directories (LinkedIn + subdomains) up front with no scrape charged, and catches `UnsupportedSite` — both return a non-failure skip result routing people lookups to `discover_contacts`, plus a `research.scrape.skipped_unsupported` log so skips are queryable in Honeycomb (closes the diagnostic-visibility gap the issue called out).

## Testing
- `firecrawl.test.ts`: unsupported-403 → `UnsupportedSite` (no retry); plain 403 stays non-recoverable `ProviderError`; whole-body fallback when the phrase isn't in an `error` field.
- `tools.test.ts`: LinkedIn skipped without calling the provider; provider `UnsupportedSite` → skip; `isUnsupportedScrapeUrl` / `scrapeSkipResult` unit coverage.
- `_http-harden.test.ts`: a routing error passes straight through, un-retried.
- Repo gates green: `check-types` + `test` + `build`.

Deploy note: production fix — needs `/release server` after this and part 2 merge.
