### PR TITLE
fix(research): fetch the caller's domain up front so the run grounds

### DIFF
--- a/apps/server/src/services/research-anchor-seed.integration.test.ts
+++ b/apps/server/src/services/research-anchor-seed.integration.test.ts
@@ -1,0 +1,368 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '6'
+process.env['RESEARCH_MAX_LOOP_PROMPT_TOKENS'] ??= '24000'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import { Effect, Layer, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	type CreateResearchInput,
+	ExtractLanguageModel,
+	ExtractProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	type ScrapedPage,
+	ScrapeProvider,
+	SearchProvider,
+	type SystemDefaults,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+// The anchor path: a run whose caller wrote the company's own domain into the
+// query grounds on that official site even when the model never fetches it. The
+// Agent stub deliberately gathers nothing (an empty web_search, then a final
+// answer) — the mirror of the dispatch suite's "scrapes nothing → no_reliable_data"
+// — so the ONLY evidence is the site the fiber fetches up front from the domain.
+
+interface Org {
+	id: string
+	name: string
+	slug: string
+}
+
+// A domain unique per run so the seeded sources row can't collide across runs.
+const ANCHOR_HOST = `acme-anchor-${randomUUID()}.example`
+const ANCHOR_URL = `https://${ANCHOR_HOST}`
+// canonicalizeUrl() runs the URL through `new URL().toString()`, which appends a
+// trailing slash to a bare host — so the run links its source by this hash.
+const ANCHOR_CANONICAL = new URL(ANCHOR_URL).toString()
+const ANCHOR_URL_HASH = createHash('sha256')
+	.update(ANCHOR_CANONICAL)
+	.digest('hex')
+// The official-site markdown spells the whole company name, so the entity gate
+// strong-matches on the seeded page alone.
+const ANCHOR_MARKDOWN =
+	'Acme Anchor Logistics — freight forwarding based in Barcelona.'
+
+const usage = {
+	inputTokens: {
+		uncached: undefined,
+		total: 0,
+		cacheRead: undefined,
+		cacheWrite: undefined,
+	},
+	outputTokens: { total: 0, text: undefined, reasoning: undefined },
+}
+
+// Round 1: a forced tool call that grounds nothing (empty search results).
+const searchRound = {
+	text: '',
+	content: [{ type: 'text' as const, text: 'Searching the web.' }],
+	reasoning: [],
+	reasoningText: undefined,
+	toolCalls: [
+		{
+			id: 'w1',
+			name: 'web_search',
+			params: { query: 'acme anchor logistics' },
+		},
+	],
+	toolResults: [
+		{
+			id: 'w1',
+			name: 'web_search',
+			result: { items: [] },
+			encodedResult: undefined,
+			isFailure: false,
+		},
+	],
+	finishReason: 'tool-calls' as const,
+	usage,
+}
+
+// Round 2: no tool calls, so the loop stops — the model gathered nothing itself.
+const finalRound = {
+	...searchRound,
+	text: 'Could not find much on the open web.',
+	content: [
+		{ type: 'text' as const, text: 'Could not find much on the open web.' },
+	],
+	toolCalls: [],
+	toolResults: [],
+	finishReason: 'stop' as const,
+}
+
+let agentCall = 0
+const agentLlm: LanguageModel.Service = {
+	generateText: (_options: unknown) =>
+		Effect.sync(() => (agentCall++ === 0 ? searchRound : finalRound)) as never,
+	generateObject: (_options: unknown) =>
+		Effect.succeed({ ...finalRound, value: {} }) as never,
+	streamText: (_options: unknown) =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+// The extractor produces a plain summary — no proposals to citation-check, so the
+// run's success turns purely on the anchor site grounding it.
+const extractLlm: LanguageModel.Service = {
+	generateText: (_options: unknown) => Effect.succeed(finalRound) as never,
+	generateObject: (_options: unknown) =>
+		Effect.succeed({
+			...finalRound,
+			value: {
+				summary: 'Acme Anchor Logistics is a Barcelona freight forwarder.',
+			},
+		}) as never,
+	streamText: (_options: unknown) =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const writerLlm: LanguageModel.Service = {
+	generateText: (_options: unknown) =>
+		Effect.succeed({
+			...finalRound,
+			text: 'Acme Anchor Logistics is a Barcelona freight forwarder.',
+		}) as never,
+	generateObject: (_options: unknown) =>
+		Effect.succeed({ ...finalRound, value: {} }) as never,
+	streamText: (_options: unknown) =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+// The fiber fetches the anchor site itself; every other provider dies so an
+// accidental call fails loudly. Scraping anything but the anchor url is a bug.
+const unused = 'research provider not exercised by this test'
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({ search: () => Effect.die(unused) }),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({
+			// ScrapedPage is re-exported as a type only, so hand back a plain object
+			// of the same shape (the seed reads its url + markdown) rather than newing
+			// the class. Any url but the anchor is a bug — the model fetches nothing.
+			scrape: input =>
+				input.url === ANCHOR_URL
+					? Effect.succeed({
+							url: ANCHOR_URL,
+							markdown: ANCHOR_MARKDOWN,
+							contentHash: createHash('sha256')
+								.update(ANCHOR_MARKDOWN)
+								.digest('hex'),
+							units: 1,
+						} as ScrapedPage)
+					: Effect.die(`unexpected scrape url: ${input.url}`),
+		}),
+	),
+	Layer.succeed(ExtractProvider)(
+		ExtractProvider.of({ extract: () => Effect.die(unused) }),
+	),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(unused) }),
+	),
+)
+
+const llmLayer = Layer.mergeAll(
+	Layer.succeed(AgentLanguageModel)(agentLlm),
+	Layer.succeed(ExtractLanguageModel)(extractLlm),
+	Layer.succeed(WriterLanguageModel)(writerLlm),
+)
+
+const eventSinkLayer = Layer.succeed(ResearchEventSink)(
+	ResearchEventSink.of({ fire: () => Effect.void }),
+)
+
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(llmLayer),
+	Layer.provide(providersLayer),
+	Layer.provide(
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test',
+				}),
+		}),
+	),
+	Layer.provide(eventSinkLayer),
+	Layer.provideMerge(PgLive),
+)
+
+const systemDefaults: SystemDefaults = {
+	budgetCents: 100,
+	paidBudgetCents: 500,
+	autoApprovePaidCents: 200,
+	paidMonthlyCapCents: 2000,
+	hardCeiling: 5000,
+}
+
+// The company's own domain rides the query text (the shape the repro used), not a
+// structured field — the loop must still fetch it.
+const researchInput: CreateResearchInput = {
+	query: `Acme Anchor Logistics, ${ANCHOR_HOST}`,
+	schemaName: 'company_enrichment_v1',
+	// Skip the outer research_cache lookup so a fresh fiber always runs.
+	forceFresh: true,
+}
+
+const TERMINAL = new Set([
+	'succeeded',
+	'failed',
+	'cancelled',
+	'no_reliable_data',
+])
+
+const ctx = {} as { org: Org }
+let userId = ''
+let runId: string | null = null
+
+beforeAll(async () => {
+	const seed = await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [org] = yield* sql<Org>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [user] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!org || !user) {
+				throw new Error(
+					"taller org / admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			// Seed the global sources row the run links the anchor fetch to by
+			// url_hash — it stands in for the row the scrape cache would upsert in
+			// production (the stub ScrapeProvider here does no caching).
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (
+					${randomUUID()}, 'web', 'it-stub', ${ANCHOR_CANONICAL}, ${ANCHOR_URL_HASH},
+					${ANCHOR_HOST}, ${createHash('sha256').update(ANCHOR_MARKDOWN).digest('hex')}
+				)
+				ON CONFLICT (url_hash) DO NOTHING
+			`
+			return { org, userId: user.id }
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+			{ org: Org; userId: string },
+			never,
+			never
+		>,
+	)
+	ctx.org = seed.org
+	userId = seed.userId
+}, 60_000)
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			if (runId) {
+				// research_cache has no cascade from research_runs; delete it first.
+				yield* sql`DELETE FROM research_cache WHERE research_id = ${runId}::uuid`
+				yield* sql`DELETE FROM research_runs WHERE id = ${runId}::uuid`
+			}
+			yield* sql`DELETE FROM sources WHERE url_hash = ${ANCHOR_URL_HASH}`
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('ResearchService anchor seed', () => {
+	describe('when the caller gives the domain but the model gathers nothing', () => {
+		it('should ground the run on the official site the fiber fetched up front', async () => {
+			// GIVEN a company_enrichment run whose query carries the official domain,
+			//   an Agent tier that gathers nothing itself (an empty web_search then a
+			//   final answer), and a scrape provider that serves only that one site
+			// WHEN the dispatch consumer drives the run to a terminal state
+			// THEN the run succeeds — grounded on the anchor page the fiber fetched,
+			//   not the model's own (empty) searching — with a strong entity match and
+			//   that page linked as a source
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const sql = yield* SqlClient.SqlClient
+
+					const created = yield* enterOrgScope(sql, {
+						org: ctx.org,
+						userId,
+					})(svc.create(userId, ctx.org.id, researchInput, systemDefaults))
+					runId = created.id
+
+					const poll = (
+						attemptsLeft: number,
+					): Effect.Effect<
+						{ status: string; errorMessage: string | null },
+						never,
+						never
+					> =>
+						Effect.gen(function* () {
+							const run = (yield* svc.get(created.id).pipe(Effect.orDie)) as {
+								status?: string
+								errorMessage?: string | null
+							} | null
+							const status = run?.status ?? 'unknown'
+							if (TERMINAL.has(status) || attemptsLeft <= 0) {
+								return { status, errorMessage: run?.errorMessage ?? null }
+							}
+							yield* Effect.sleep('300 millis')
+							return yield* poll(attemptsLeft - 1)
+						})
+
+					const final = yield* poll(50)
+
+					const [sourceRow] = yield* sql<{ n: number }>`
+						SELECT COUNT(*)::int AS n FROM research_run_sources
+						WHERE research_id = ${created.id}::uuid
+							AND source_id IN (
+								SELECT id FROM sources WHERE url_hash = ${ANCHOR_URL_HASH}
+							)
+					`.pipe(Effect.orDie)
+
+					const [entityRow] = yield* sql<{ entityMatch: string | null }>`
+						SELECT entity_match AS "entityMatch"
+						FROM research_runs WHERE id = ${created.id}::uuid
+					`.pipe(Effect.orDie)
+
+					return {
+						status: final.status,
+						errorMessage: final.errorMessage,
+						anchorSourceCount: sourceRow?.n ?? 0,
+						entityMatch: entityRow?.entityMatch ?? null,
+					}
+				}).pipe(Effect.provide(ResearchLive)) as Effect.Effect<
+					{
+						status: string
+						errorMessage: string | null
+						anchorSourceCount: number
+						entityMatch: string | null
+					},
+					never,
+					never
+				>,
+			)
+
+			expect(
+				outcome.status,
+				`run not succeeded: ${outcome.errorMessage ?? '(no error recorded)'}`,
+			).toBe('succeeded')
+			// The anchor site was fetched and linked, even though the model never did.
+			expect(outcome.anchorSourceCount).toBeGreaterThanOrEqual(1)
+			// Grounding is strong on the official page alone.
+			expect(outcome.entityMatch).toBe('strong')
+		})
+	})
+})

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest'
 import {
 	classifyEntityMatch,
 	classifyEntityMatchPerSource,
+	deriveAnchorHost,
 	deriveEntityTargets,
 	domainHost,
 	type EntityTargets,
 	groundedSourceIds,
 	isConfirmedRegistryMatch,
+	parseQueryDomain,
 } from './entity-guard'
 
 describe('deriveEntityTargets', () => {
@@ -312,6 +314,125 @@ describe('deriveEntityTargets with an anchor domain', () => {
 			})
 			// THEN it is dropped and the result matches the no-anchor derivation
 			expect(withJunk?.domains).toEqual(without?.domains)
+		})
+	})
+})
+
+describe('deriveEntityTargets with a domain in the query', () => {
+	describe('when the caller writes the official domain into the query text', () => {
+		it('should fold that host into the strong-match domain keys', () => {
+			// GIVEN a query-only enrichment whose text carries the company's domain
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Sunset Transportation (sunsettrans.com)',
+				subjects: [],
+			})
+			// THEN a page referencing that host will strong-match the target
+			expect(targets?.domains).toContain('sunsettrans.com')
+		})
+	})
+})
+
+describe('parseQueryDomain', () => {
+	describe('when the query carries a domain-shaped token', () => {
+		it('should pull it out of parentheses, plain text, or an email address', () => {
+			// GIVEN queries that mention the company domain in different shapes
+			// THEN each yields the bare registrable host
+			expect(parseQueryDomain('Sunset Transportation (sunsettrans.com)')).toBe(
+				'sunsettrans.com',
+			)
+			expect(parseQueryDomain('Echo Global Logistics echo.com')).toBe(
+				'echo.com',
+			)
+			expect(parseQueryDomain('reach me at jane@acme.co.uk please')).toBe(
+				'acme.co.uk',
+			)
+			expect(parseQueryDomain('visit https://www.monzo.com/about')).toBe(
+				'monzo.com',
+			)
+		})
+	})
+
+	describe('when the query has no real domain', () => {
+		it('should return undefined rather than match an abbreviation or decimal', () => {
+			// GIVEN text with dotted tokens that are not domains
+			// THEN nothing is treated as a domain
+			expect(parseQueryDomain('Sunset Transportation, St. Louis MO')).toBe(
+				undefined,
+			)
+			expect(parseQueryDomain('e.g. a freight broker')).toBe(undefined)
+			expect(parseQueryDomain('revenue grew 3.5 last year')).toBe(undefined)
+			expect(parseQueryDomain('just a plain company name')).toBe(undefined)
+		})
+	})
+})
+
+describe('deriveAnchorHost', () => {
+	describe('when several domain signals are present', () => {
+		it('should prefer the corrected anchor domain over the subject website', () => {
+			// GIVEN a subject website and a later human-corrected anchor domain
+			const host = deriveAnchorHost({
+				schemaName: 'company_enrichment_v1',
+				query: 'Acme (acme-query.com)',
+				subjects: [
+					{ table: 'companies', name: 'Acme', website: 'https://sub.com' },
+				],
+				anchorDomain: 'https://www.corrected.com/x',
+			})
+			// THEN the corrected domain wins
+			expect(host).toBe('corrected.com')
+		})
+
+		it('should prefer the subject website over a domain in the query', () => {
+			// GIVEN a subject website and a domain in the query, but no anchor domain
+			const host = deriveAnchorHost({
+				schemaName: 'company_enrichment_v1',
+				query: 'Acme (acme-query.com)',
+				subjects: [
+					{ table: 'companies', name: 'Acme', website: 'https://sub.com' },
+				],
+			})
+			// THEN the subject's own site wins
+			expect(host).toBe('sub.com')
+		})
+	})
+
+	describe('when only the query carries a domain', () => {
+		it('should anchor an entity-grounded run on the query domain', () => {
+			// GIVEN a query-only enrichment with the domain in the text
+			// THEN the query domain is the anchor
+			expect(
+				deriveAnchorHost({
+					schemaName: 'company_enrichment_v1',
+					query: 'Echo Global Logistics echo.com',
+					subjects: [],
+				}),
+			).toBe('echo.com')
+		})
+
+		it('should not read the query for a scan run with no subject', () => {
+			// GIVEN a scan schema (reports third parties) with a domain in the query
+			// THEN there is no single official site to anchor on
+			expect(
+				deriveAnchorHost({
+					schemaName: 'prospect_scan_v1',
+					query: 'freight brokers near acme.com',
+					subjects: [],
+				}),
+			).toBe(undefined)
+		})
+	})
+
+	describe('when no domain signal is present', () => {
+		it('should return undefined', () => {
+			// GIVEN a plain company-name query with no subject or anchor
+			expect(
+				deriveAnchorHost({
+					schemaName: 'company_enrichment_v1',
+					query: 'Sunset Transportation, St. Louis MO',
+					subjects: [],
+				}),
+			).toBe(undefined)
 		})
 	})
 })

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -165,6 +165,20 @@ const domainLabelOf = (host: string): string | undefined => {
 // ("Sunset Transportation, St. Louis MO"); fall back to the whole query.
 const queryName = (query: string): string => query.split(',')[0] ?? query
 
+// A domain-shaped token inside free text: one or more dot-separated labels then a
+// 2–24 letter top-level part. The letters-only tail keeps decimals ("3.5") and
+// abbreviations ("e.g", "U.S.A") from matching.
+const DOMAIN_IN_TEXT = /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,24}/i
+
+// A caller often writes the company's own domain straight into the query, e.g.
+// "Sunset Transportation (sunsettrans.com)". Pull the first domain-shaped token so
+// the run can treat it as the target's official site. Normalised and validated
+// through domainHost, so only a real registrable host comes back.
+export const parseQueryDomain = (query: string): string | undefined => {
+	const match = query.match(DOMAIN_IN_TEXT)
+	return match ? domainHost(match[0]) : undefined
+}
+
 export interface EntityTarget {
 	readonly table: string
 	readonly name?: string | undefined
@@ -218,10 +232,13 @@ export const deriveEntityTargets = (args: {
 		.filter((w): w is string => w != null && w.trim() !== '')
 	const anchorHost =
 		args.anchorDomain != null ? domainHost(args.anchorDomain) : undefined
+	// A domain written into the query is the target's own site too — fold it in so
+	// a page that references it counts as a strong match, like an anchor domain.
+	const queryHost = parseQueryDomain(args.query)
 
 	const domains = [
 		...new Set(
-			[...websites.map(domainHost), anchorHost].filter(
+			[...websites.map(domainHost), anchorHost, queryHost].filter(
 				(h): h is string => h != null,
 			),
 		),
@@ -237,6 +254,34 @@ export const deriveEntityTargets = (args: {
 	if (cores.length === 0 && words.length === 0 && domains.length === 0)
 		return null
 	return { cores, words, domains }
+}
+
+/**
+ * The single official-site host to fetch up front for an entity run, or undefined
+ * when there is none to anchor on. The human-corrected domain wins, then an
+ * anchored subject's own website, then a domain written into the query. Only a
+ * single-target run (an entity-grounded schema, or one with an anchored subject)
+ * reads the query — a scan has no one official site, so it never anchors.
+ */
+export const deriveAnchorHost = (args: {
+	schemaName: string
+	query: string
+	subjects: ReadonlyArray<EntityTarget>
+	anchorDomain?: string | undefined
+}): string | undefined => {
+	const fromAnchor =
+		args.anchorDomain != null ? domainHost(args.anchorDomain) : undefined
+	if (fromAnchor !== undefined) return fromAnchor
+	const fromSubject = args.subjects
+		.map(s => s.website)
+		.filter((w): w is string => w != null && w.trim() !== '')
+		.map(domainHost)
+		.find((h): h is string => h !== undefined)
+	if (fromSubject !== undefined) return fromSubject
+	const anchored = args.subjects.length > 0
+	if (!ENTITY_GROUNDED_SCHEMAS.has(args.schemaName) && !anchored)
+		return undefined
+	return parseQueryDomain(args.query)
 }
 
 export type EntityMatch = 'strong' | 'weak' | 'absent'

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -42,6 +42,7 @@ import {
 import {
 	classifyEntityMatch,
 	classifyEntityMatchPerSource,
+	deriveAnchorHost,
 	deriveEntityTargets,
 	domainHost,
 	type EntityMatch,
@@ -57,12 +58,17 @@ import {
 	RegistryRouter,
 	ResearchEventSink,
 	ResearchRunContext,
+	ScrapeProvider,
 	WriterLanguageModel,
 } from './ports'
 import { type FreeformSchema, schemaRegistry } from './schemas/index'
 import { urlHashForScrape } from './source-key'
-import { REGISTRY_LOOKUP_COST_CENTS } from './tool-costs'
-import { researchToolkit, researchToolkitLayer } from './tools'
+import { REGISTRY_LOOKUP_COST_CENTS, SCRAPE_COST_CENTS } from './tool-costs'
+import {
+	isUnsupportedScrapeUrl,
+	researchToolkit,
+	researchToolkitLayer,
+} from './tools'
 import { verifyValueProvenance } from './value-guard'
 import { constrainVocabulary } from './vocabulary-guard'
 
@@ -940,16 +946,6 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							.templateFingerprint ?? ''
 
 					const context = run['context'] as CreateResearchInput['context']
-					// A target-correction re-run seeds context.anchorDomain: point both
-					// the grounding path and the model's first prompt at that official site.
-					const anchorHost =
-						context?.anchorDomain != null
-							? domainHost(context.anchorDomain)
-							: undefined
-					const anchorInstruction =
-						anchorHost !== undefined
-							? `\n\n${ANCHOR_DOMAIN_INSTRUCTION(anchorHost)}`
-							: ''
 					const schemaName =
 						(run as { schemaName: string | null }).schemaName ?? 'freeform'
 
@@ -980,24 +976,39 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					// no anchored subject is not entity-gated (targets is null). The
 					// verdict is computed from the phase-1 evidence below and, on resume,
 					// read back from the row so the weak-match handling survives a restart.
+					const subjectTargets = subjects.map(s => {
+						const row = s.snapshot as Record<string, unknown>
+						return {
+							table: s.table,
+							name: typeof row['name'] === 'string' ? row['name'] : undefined,
+							website:
+								typeof row['website'] === 'string' ? row['website'] : undefined,
+						}
+					})
 					const entityTargets = deriveEntityTargets({
 						schemaName,
 						anchorDomain: context?.anchorDomain,
 						query: (run as { query: string }).query,
-						subjects: subjects.map(s => {
-							const row = s.snapshot as Record<string, unknown>
-							return {
-								table: s.table,
-								name: typeof row['name'] === 'string' ? row['name'] : undefined,
-								website:
-									typeof row['website'] === 'string'
-										? row['website']
-										: undefined,
-							}
-						}),
+						subjects: subjectTargets,
 					})
 					let entityMatch: EntityMatch | null =
 						(run as { entityMatch?: EntityMatch | null }).entityMatch ?? null
+
+					// The company's own official site to fetch up front, when the caller
+					// gave its domain — a target-correction re-run's anchor, an anchored
+					// subject's website, or a domain written into the query. The instruction
+					// nudges the model there; the seeded scrape below guarantees the page is
+					// fetched even if the model never navigates to it.
+					const anchorHost = deriveAnchorHost({
+						schemaName,
+						anchorDomain: context?.anchorDomain,
+						query: (run as { query: string }).query,
+						subjects: subjectTargets,
+					})
+					const anchorInstruction =
+						anchorHost !== undefined
+							? `\n\n${ANCHOR_DOMAIN_INSTRUCTION(anchorHost)}`
+							: ''
 
 					// A follow-up run performs one approved paid call instead of the
 					// normal research loop, then merges the result onto the origin run.
@@ -1110,6 +1121,11 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					// guard checks findings against. Kept separate from the model-facing
 					// transcript (capped per page); empty on a resume that skips phase 1.
 					const scrapeCorpus: Array<{ urlHash: string; text: string }> = []
+					// The anchor site fetched up front (see below): its url hash to link as
+					// a source, and its capped rendered text to prepend to the transcript so
+					// phase-2 extraction reads the official site even if the model never did.
+					const seededAnchorHashes: string[] = []
+					const seededTranscriptParts: string[] = []
 					// Findings the discovery-scan retry path extracts under the shared
 					// budget; undefined on every other path (which extracts in phase 2).
 					let retryFindings: unknown
@@ -1423,6 +1439,53 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						const phaseOutcome = yield* Effect.gen(function* () {
 							const budget = yield* Budget
 							const toolkit = yield* researchToolkit
+							const scrape = yield* ScrapeProvider
+
+							// Anchor: when the caller handed in the company's own domain, fetch
+							// that official site once now so grounding has the right company's
+							// page even if the model never navigates there. Best-effort — a
+							// refused, unreachable, or empty site just falls back to the model's
+							// own searching, and a people directory (LinkedIn) is left to
+							// discover_contacts rather than fetched here.
+							if (
+								anchorHost !== undefined &&
+								!isUnsupportedScrapeUrl(`https://${anchorHost}`)
+							) {
+								yield* Effect.gen(function* () {
+									yield* budget.chargeCheap('scrape', SCRAPE_COST_CENTS)
+									const page = yield* scrape.scrape({
+										url: `https://${anchorHost}`,
+										formats: ['markdown'],
+									})
+									if (
+										page.markdown !== undefined &&
+										page.markdown.trim().length > 0
+									) {
+										const hash = urlHashForScrape(page.url)
+										scrapeCorpus.push({ urlHash: hash, text: page.markdown })
+										seededAnchorHashes.push(hash)
+										seededTranscriptParts.push(
+											`[scrape_page] ${boundedToolResult({ url: page.url, markdown: page.markdown })}`,
+										)
+										yield* Effect.logInfo('research.anchor.seeded').pipe(
+											Effect.annotateLogs({
+												research_id: researchId,
+												host: anchorHost,
+											}),
+										)
+									}
+								}).pipe(
+									Effect.catchCause(cause =>
+										Effect.logWarning('research.anchor.seed_failed').pipe(
+											Effect.annotateLogs({
+												research_id: researchId,
+												host: anchorHost,
+												cause: Cause.pretty(cause),
+											}),
+										),
+									),
+								)
+							}
 
 							// One agent pass = a fresh reflect-and-retry loop. Both the initial
 							// pass and a refined retry run here, under the SAME budget + toolkit:
@@ -1672,7 +1735,11 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						)
 
 						const loopResult = phaseOutcome.loop
-						researchText = loopResult.researchText
+						// Prepend the anchor site's content so phase-2 extraction reads the
+						// official page first; empty when nothing was seeded.
+						researchText = [...seededTranscriptParts, loopResult.researchText]
+							.filter(part => part.length > 0)
+							.join('\n\n')
 						evidenceText = loopResult.evidenceText
 						tokensIn = loopResult.tokensIn
 						tokensOut = loopResult.tokensOut
@@ -1709,10 +1776,14 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							WHERE id = ${researchId}
 						`
 
-						// Link every page scraped across the loop's rounds to the run so
-						// findings cite real sources (a discovery-scan retry may have linked
-						// some already — ON CONFLICT makes the re-link a no-op).
-						yield* linkRunSources(loopResult.scrapedUrlHashes)
+						// Link every page scraped across the loop's rounds — plus the anchor
+						// site seeded before the loop — to the run so findings cite real
+						// sources (a discovery-scan retry may have linked some already —
+						// ON CONFLICT makes the re-link a no-op).
+						yield* linkRunSources([
+							...loopResult.scrapedUrlHashes,
+							...seededAnchorHashes,
+						])
 					}
 
 					// The phase-1 entity gate is skipped when a run resumes from a checkpoint


### PR DESCRIPTION
Part 2 of #234 (domain anchoring).

> **Stacked on #241 — review/merge that first.** This PR's base is `234-scrape-resilience`, so the diff below is only the anchoring change. After #241 merges I'll rebase this onto `main`.

## Problem
Scrape resilience (#241) stops LinkedIn starving a run, but a run only grounds if it reaches the company's own site — and the loop left that to the model. When the caller put the domain in the query text (as the repro did: `Sunset Transportation (sunsettrans.com)`), the loop never turned it into a scrape, so a run that searched but never fetched the official site still refused real companies as `weak_no_official_site`.

## Change
The fiber now fetches the caller-provided domain itself, up front:
- **`deriveAnchorHost`** picks the official-site host from whichever signal the caller gave — a re-run's corrected `anchorDomain`, an anchored subject's website, or a domain parsed from the free-text query (`parseQueryDomain`). A scan (no single target) never anchors.
- That domain is folded into the entity-grounding keys, and the fiber **deterministically scrapes it once before the model runs** — seeding the grounding corpus, prepending its content to the phase-2 transcript, and linking it as a source. Best-effort: a refused / unreachable site, or a people directory (reuses #241's `isUnsupportedScrapeUrl` guard), just falls back to the model's own searching.

Together with #241 this resolves the repro (Sunset / Green / Echo): #241 stops LinkedIn starving the run, this guarantees the official site is in evidence.

## Testing
- `entity-guard.test.ts`: `parseQueryDomain` (parens / plain / email / no-match) and `deriveAnchorHost` precedence.
- **New `research-anchor-seed.integration.test.ts`**: a `company_enrichment` run whose domain is only in the query text reaches **succeeded** — strong entity match, anchor linked as a source — even when the Agent tier scrapes nothing. The mirror of the dispatch suite's "scrapes nothing → no_reliable_data".
- Existing entity-gate + grounding integration tests still pass — verified this coexists with the `registry_confirmed` grounding path merged into `main` (#231) after a rebase.
- Repo gates green: `check-types` + `test` + `build`.
