### PR TITLE
feat(internal): add a line-item editor to proposals

### DIFF
--- a/apps/internal/src/components/companies/proposals-panel.tsx
+++ b/apps/internal/src/components/companies/proposals-panel.tsx
@@ -29,6 +29,61 @@ type ProposalRow = {
 	readonly notes: string | null
 	readonly expiresAt: string | null
 	readonly updatedAt: string | null
+	readonly lineItems: unknown
+}
+
+// One editable row in the proposal — a thing being quoted, its quantity, and
+// its unit price. Kept as strings while editing so a half-typed number is fine.
+// `id` is a client-only key so removing a middle row doesn't shuffle the inputs
+// (a plain array index would); it isn't saved.
+type LineItem = {
+	readonly id: string
+	readonly description: string
+	readonly qty: string
+	readonly price: string
+}
+
+let lineIdCounter = 0
+const nextLineId = () => {
+	lineIdCounter += 1
+	return `line-${lineIdCounter}`
+}
+
+// Pull saved line items back into the editable shape. Anything unexpected in the
+// stored JSON is skipped rather than breaking the form.
+function narrowLineItems(raw: unknown): ReadonlyArray<LineItem> {
+	if (!Array.isArray(raw)) return []
+	const out: Array<LineItem> = []
+	for (const item of raw) {
+		if (!item || typeof item !== 'object') continue
+		const r = item as Record<string, unknown>
+		const description =
+			typeof r['description'] === 'string'
+				? r['description']
+				: typeof r['notes'] === 'string'
+					? r['notes']
+					: ''
+		out.push({
+			id: nextLineId(),
+			description,
+			qty: r['qty'] === undefined || r['qty'] === null ? '' : String(r['qty']),
+			price:
+				r['price'] === undefined || r['price'] === null
+					? ''
+					: String(r['price']),
+		})
+	}
+	return out
+}
+
+// Sum the line items into a proposal total (quantity × unit price).
+function lineItemsTotal(items: ReadonlyArray<LineItem>): number {
+	return items.reduce((sum, item) => {
+		const qty = Number.parseFloat(item.qty)
+		const price = Number.parseFloat(item.price)
+		if (!Number.isFinite(qty) || !Number.isFinite(price)) return sum
+		return sum + qty * price
+	}, 0)
 }
 
 // The proposal lifecycle statuses (see proposals.ts schema).
@@ -62,6 +117,7 @@ function narrowProposals(
 			notes: typeof r['notes'] === 'string' ? r['notes'] : null,
 			expiresAt: typeof r['expiresAt'] === 'string' ? r['expiresAt'] : null,
 			updatedAt: typeof r['updatedAt'] === 'string' ? r['updatedAt'] : null,
+			lineItems: r['lineItems'] ?? null,
 		})
 	}
 	return out
@@ -183,10 +239,10 @@ function ProposalDialog({
 	const editing = target !== 'new' && target !== null ? target : null
 	const [title, setTitle] = useState('')
 	const [status, setStatus] = useState('draft')
-	const [totalValue, setTotalValue] = useState('')
 	const [currency, setCurrency] = useState('EUR')
 	const [expiresAt, setExpiresAt] = useState('')
 	const [notes, setNotes] = useState('')
+	const [lineItems, setLineItems] = useState<ReadonlyArray<LineItem>>([])
 	const [busy, setBusy] = useState(false)
 
 	const key = editing ? editing.id : target === 'new' ? 'new' : 'closed'
@@ -195,25 +251,50 @@ function ProposalDialog({
 		seeded.current = key
 		setTitle(editing?.title ?? '')
 		setStatus(editing?.status ?? 'draft')
-		setTotalValue(editing?.totalValue ?? '')
 		setCurrency(editing?.currency ?? 'EUR')
 		setExpiresAt(editing?.expiresAt ? editing.expiresAt.slice(0, 10) : '')
 		setNotes(editing?.notes ?? '')
+		setLineItems(editing ? narrowLineItems(editing.lineItems) : [])
 		setBusy(false)
 	}
+
+	const total = lineItemsTotal(lineItems)
+
+	const setLine = (index: number, patch: Partial<LineItem>) =>
+		setLineItems(items =>
+			items.map((item, i) => (i === index ? { ...item, ...patch } : item)),
+		)
+	const addLine = () =>
+		setLineItems(items => [
+			...items,
+			{ id: nextLineId(), description: '', qty: '1', price: '' },
+		])
+	const removeLine = (index: number) =>
+		setLineItems(items => items.filter((_, i) => i !== index))
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault()
 		const trimmedTitle = title.trim()
 		if (trimmedTitle.length === 0 || busy) return
 		setBusy(true)
+		// Drop blank rows; the total is derived from the lines, not typed by hand.
+		const cleanItems = lineItems
+			.filter(li => li.description.trim() || li.qty.trim() || li.price.trim())
+			.map(li => ({
+				product_id: null,
+				notes: li.description.trim(),
+				qty: Number.parseFloat(li.qty) || 0,
+				price: Number.parseFloat(li.price) || 0,
+			}))
+		const totalValue = total > 0 ? total.toFixed(2) : undefined
 		const exit = editing
 			? await update({
 					params: { id: editing.id },
 					payload: {
 						title: trimmedTitle,
 						status,
-						...(totalValue.trim() ? { totalValue: totalValue.trim() } : {}),
+						lineItems: cleanItems,
+						...(totalValue ? { totalValue } : {}),
 						notes,
 					},
 				} as never)
@@ -221,10 +302,9 @@ function ProposalDialog({
 					payload: {
 						companyId,
 						title: trimmedTitle,
-						// A draft starts with no line items; they're edited later.
-						lineItems: [],
+						lineItems: cleanItems,
 						currency,
-						...(totalValue.trim() ? { totalValue: totalValue.trim() } : {}),
+						...(totalValue ? { totalValue } : {}),
 						...(expiresAt ? { expiresAt } : {}),
 						...(notes.trim() ? { notes } : {}),
 					},
@@ -278,34 +358,82 @@ function ProposalDialog({
 								required
 							/>
 						</Field>
-						<TwoCol>
-							<Field>
-								<Label htmlFor='proposal-total'>
-									<Trans>Total value</Trans>
-								</Label>
-								<PriInput
-									id='proposal-total'
-									data-testid='proposal-total'
-									value={totalValue}
-									inputMode='decimal'
-									placeholder='0.00'
-									onChange={e => setTotalValue(e.target.value)}
-								/>
-							</Field>
+						<Field>
+							<Label>
+								<Trans>Line items</Trans>
+							</Label>
+							<Lines>
+								{lineItems.map((line, index) => (
+									<LineRow key={line.id} data-testid='proposal-line'>
+										<PriInput
+											aria-label={t`Description`}
+											data-testid='proposal-line-description'
+											value={line.description}
+											maxLength={200}
+											placeholder={t`e.g. Setup fee`}
+											onChange={e =>
+												setLine(index, { description: e.target.value })
+											}
+										/>
+										<QtyInput
+											aria-label={t`Quantity`}
+											data-testid='proposal-line-qty'
+											value={line.qty}
+											inputMode='decimal'
+											placeholder={t`Qty`}
+											onChange={e => setLine(index, { qty: e.target.value })}
+										/>
+										<PriceInput
+											aria-label={t`Unit price`}
+											data-testid='proposal-line-price'
+											value={line.price}
+											inputMode='decimal'
+											placeholder={t`Price`}
+											onChange={e => setLine(index, { price: e.target.value })}
+										/>
+										<RemoveLine
+											type='button'
+											aria-label={t`Remove line`}
+											data-testid='proposal-line-remove'
+											onClick={() => removeLine(index)}
+										>
+											<X size={14} aria-hidden />
+										</RemoveLine>
+									</LineRow>
+								))}
+								<AddLine
+									type='button'
+									data-testid='proposal-line-add'
+									onClick={addLine}
+								>
+									<Plus size={14} aria-hidden />
+									<Trans>Add line</Trans>
+								</AddLine>
+								<TotalRow data-testid='proposal-computed-total'>
+									<Trans>Total</Trans>
+									<TotalValue>
+										{formatMoneyCents(Math.round(total * 100), {
+											currency: currency || 'EUR',
+											locale: i18n.locale,
+										})}
+									</TotalValue>
+								</TotalRow>
+							</Lines>
+						</Field>
+						{!editing ? (
 							<Field>
 								<Label htmlFor='proposal-currency'>
 									<Trans>Currency</Trans>
 								</Label>
-								<PriInput
+								<CurrencyInput
 									id='proposal-currency'
 									data-testid='proposal-currency'
 									value={currency}
 									maxLength={3}
-									disabled={editing !== null}
 									onChange={e => setCurrency(e.target.value.toUpperCase())}
 								/>
 							</Field>
-						</TwoCol>
+						) : null}
 						{editing ? (
 							<Field>
 								<Label htmlFor='proposal-status'>
@@ -481,10 +609,81 @@ const Form = styled.form`
 	margin-top: var(--space-sm);
 `
 
-const TwoCol = styled.div`
+const Lines = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const LineRow = styled.div`
 	display: grid;
-	grid-template-columns: 2fr 1fr;
-	gap: var(--space-sm);
+	grid-template-columns: 1fr 4rem 6rem auto;
+	gap: var(--space-2xs);
+	align-items: center;
+`
+
+const QtyInput = styled(PriInput)`
+	text-align: right;
+`
+
+const PriceInput = styled(PriInput)`
+	text-align: right;
+`
+
+const CurrencyInput = styled(PriInput)`
+	max-width: 6rem;
+`
+
+const RemoveLine = styled.button`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--space-2xs);
+	background: none;
+	border: none;
+	color: var(--color-on-surface-variant);
+	cursor: pointer;
+
+	&:hover {
+		color: var(--color-error);
+	}
+`
+
+const AddLine = styled.button`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3xs);
+	align-self: flex-start;
+	padding: var(--space-2xs) 0;
+	background: none;
+	border: none;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-primary);
+	cursor: pointer;
+
+	&:hover {
+		text-decoration: underline;
+	}
+`
+
+const TotalRow = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	padding-top: var(--space-2xs);
+	border-top: 1px solid var(--color-outline-variant);
+	font-family: var(--font-display);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const TotalValue = styled.span`
+	font-size: var(--typescale-title-medium-size);
+	color: var(--color-on-surface);
+	text-transform: none;
 `
 
 const Field = styled.div`

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -289,6 +289,10 @@ msgstr "Afegeix contacte"
 msgid "Add document"
 msgstr "Afegeix document"
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Add line"
+msgstr "Afegeix línia"
+
 #: src/components/shared/company-card.tsx
 msgid "Add task"
 msgstr "Afegeix tasca"
@@ -1558,6 +1562,10 @@ msgstr "Lliurat"
 msgid "Deny"
 msgstr "Denega"
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Description"
+msgstr "Descripció"
+
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Direction"
 msgstr "Direcció"
@@ -1680,6 +1688,10 @@ msgstr "p. ex. Marta Puig"
 #: src/routes/emails/inboxes.tsx
 msgid "e.g. Sales — Acme"
 msgstr "p. ex. Vendes — Acme"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "e.g. Setup fee"
+msgstr "p. ex. Tarifa d'instal·lació"
 
 #: src/components/research/research-dialog.tsx
 msgid "e.g. vip, warm"
@@ -2276,6 +2288,10 @@ msgstr "Última visita"
 #: src/routes/tasks/index.tsx
 msgid "Later"
 msgstr "Més tard"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Line items"
+msgstr "Línies"
 
 #: src/components/research/findings/contact-discovery-view.tsx
 #: src/components/shared/channel-icon.tsx
@@ -3327,6 +3343,10 @@ msgstr "Vista prèvia"
 msgid "Previous"
 msgstr "Anterior"
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Price"
+msgstr "Preu"
+
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -3432,6 +3452,14 @@ msgstr "Publicant…"
 #: src/routes/emails/inboxes.tsx
 msgid "Purpose"
 msgstr "Propòsit"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Qty"
+msgstr "Quant."
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Quantity"
+msgstr "Quantitat"
 
 #: src/components/research/research-dialog.tsx
 msgid "Question"
@@ -3579,6 +3607,10 @@ msgstr "Vols eliminar {email} d'aquesta organització?"
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Remove channel"
 msgstr "Elimina el canal"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Remove line"
+msgstr "Elimina la línia"
 
 #: src/routes/settings/organization/members.tsx
 msgid "Removing…"
@@ -4546,13 +4578,13 @@ msgstr "Avui"
 msgid "Too many attempts. Try again in a minute."
 msgstr "Massa intents. Torna-ho a provar d'aquí un minut."
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Total"
+msgstr "Total"
+
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Total competitors"
 msgstr "Total competidors"
-
-#: src/components/companies/proposals-panel.tsx
-msgid "Total value"
-msgstr "Valor total"
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
@@ -4589,6 +4621,10 @@ msgstr "No es pot lliurar"
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Undo"
 msgstr "Desfés"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Unit price"
+msgstr "Preu unitari"
 
 #: src/components/companies/conversations-tab.tsx
 #: src/components/companies/research-summary-card.tsx

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -289,6 +289,10 @@ msgstr "Add contact"
 msgid "Add document"
 msgstr "Add document"
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Add line"
+msgstr "Add line"
+
 #: src/components/shared/company-card.tsx
 msgid "Add task"
 msgstr "Add task"
@@ -1558,6 +1562,10 @@ msgstr "Delivered"
 msgid "Deny"
 msgstr "Deny"
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Description"
+msgstr "Description"
+
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Direction"
 msgstr "Direction"
@@ -1680,6 +1688,10 @@ msgstr "e.g. Marta Puig"
 #: src/routes/emails/inboxes.tsx
 msgid "e.g. Sales — Acme"
 msgstr "e.g. Sales — Acme"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "e.g. Setup fee"
+msgstr "e.g. Setup fee"
 
 #: src/components/research/research-dialog.tsx
 msgid "e.g. vip, warm"
@@ -2276,6 +2288,10 @@ msgstr "Last meet"
 #: src/routes/tasks/index.tsx
 msgid "Later"
 msgstr "Later"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Line items"
+msgstr "Line items"
 
 #: src/components/research/findings/contact-discovery-view.tsx
 #: src/components/shared/channel-icon.tsx
@@ -3327,6 +3343,10 @@ msgstr "Preview"
 msgid "Previous"
 msgstr "Previous"
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Price"
+msgstr "Price"
+
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -3432,6 +3452,14 @@ msgstr "Publishing…"
 #: src/routes/emails/inboxes.tsx
 msgid "Purpose"
 msgstr "Purpose"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Qty"
+msgstr "Qty"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Quantity"
+msgstr "Quantity"
 
 #: src/components/research/research-dialog.tsx
 msgid "Question"
@@ -3579,6 +3607,10 @@ msgstr "Remove {email} from this organization?"
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Remove channel"
 msgstr "Remove channel"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Remove line"
+msgstr "Remove line"
 
 #: src/routes/settings/organization/members.tsx
 msgid "Removing…"
@@ -4546,13 +4578,13 @@ msgstr "Today"
 msgid "Too many attempts. Try again in a minute."
 msgstr "Too many attempts. Try again in a minute."
 
+#: src/components/companies/proposals-panel.tsx
+msgid "Total"
+msgstr "Total"
+
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Total competitors"
 msgstr "Total competitors"
-
-#: src/components/companies/proposals-panel.tsx
-msgid "Total value"
-msgstr "Total value"
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
@@ -4589,6 +4621,10 @@ msgstr "Undeliverable"
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Undo"
 msgstr "Undo"
+
+#: src/components/companies/proposals-panel.tsx
+msgid "Unit price"
+msgstr "Unit price"
 
 #: src/components/companies/conversations-tab.tsx
 #: src/components/companies/research-summary-card.tsx


### PR DESCRIPTION
## What

Part 3 for #224 — **stacked on #244** (base `worktree-224-crm-screens`, retarget to `main` after #244 merges). A small follow-up: the one item I deferred in #244.

The proposal dialog created drafts with an empty quote. This adds a **line-item editor** — the operator builds the quote from rows (description, quantity, unit price), and the proposal total is computed from them instead of typed by hand.

## Changes

- Add / remove line-item rows in the proposal create + edit dialog; each row is description + quantity + unit price.
- The total is derived from the lines (Σ quantity × unit price) and shown live; the old free-typed total field is gone.
- Editing an existing proposal loads its saved lines; blank rows are dropped on save.

## Impact

- **Wire-shape**: none new — line items already live in the `proposals.line_items` JSONB column (the create/update contracts already accept them). Rows are saved as `{ product_id: null, notes, qty, price }`; a client-only row id keys the form and isn't persisted.
- No migration, no env vars, no backend change.

## Review guide

- One file (`proposals-panel.tsx`). The only subtlety is the per-row `id` (so removing a middle row doesn't shuffle the inputs) and the `Σ qty × price` total.

## Verification

- `pnpm check-types` (internal) and biome — green. (Company-page screenshots are blocked by the MapLibre panel, same as #244; the editor is a standard controlled form.)

## Deferred

- A product picker (rows are free-text descriptions for now, not linked to catalog products).
- The follow-up-from-a-specific-email-thread trigger (carried over from #244).

Addresses #224 (final follow-up).
