### PR TITLE
fix: stop the scrape cache from starving research into fabrication

### DIFF
--- a/apps/server/src/services/cached-scrape.integration.test.ts
+++ b/apps/server/src/services/cached-scrape.integration.test.ts
@@ -1,0 +1,284 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import {
+	BlobStorage,
+	makeCachedScrape,
+	ProviderError,
+	type ScrapedPage,
+	type ScrapeInput,
+	ScrapeProvider,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+
+// The scrape cache wraps the real ScrapeProvider with a `sources`-table lookup
+// and a BlobStorage-backed content cache. These tests drive that wrapper against
+// real Postgres with fakes for the inner provider and the blob store, so a
+// broken cache (unreadable blob, empty content_ref, failing write) can be
+// reproduced deterministically. The core guarantee: a warm-but-broken cache
+// never fails a scrape — it degrades to a fresh fetch — so the model is never
+// denied the page and pushed into inventing facts.
+
+// A unique host per test keeps each run's `sources` row isolated by url_hash.
+const freshHost = () => `cache-fallthrough-${randomUUID()}.example`
+// canonicalizeUrl() runs a bare-host URL through `new URL().toString()`, which
+// keeps the trailing slash — so this matches the hash the cache computes.
+const hashOf = (url: string): string =>
+	createHash('sha256').update(new URL(url).toString()).digest('hex')
+
+type BlobGet = (key: string) => Effect.Effect<Uint8Array, ProviderError>
+type BlobPut = (
+	key: string,
+	bytes: Uint8Array,
+	contentType: string,
+) => Effect.Effect<void, ProviderError>
+
+const okBlobPut: BlobPut = () => Effect.void
+const failingBlobGet: BlobGet = key =>
+	Effect.fail(
+		new ProviderError({
+			provider: 'cache',
+			message: `blob get failed for ${key}: simulated R2 read error`,
+			recoverable: false,
+		}),
+	)
+
+// Seed a warm sources row so a lookup finds a hit (or, with an empty
+// content_ref, deliberately does not).
+const seedWarmSource = (opts: {
+	url: string
+	urlHash: string
+	contentRef: string | null
+	contentHash: string
+}): Promise<void> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`
+				INSERT INTO sources (
+					id, kind, provider, url, url_hash, domain,
+					content_hash, content_ref, first_fetched_at, last_fetched_at
+				) VALUES (
+					${randomUUID()}, 'web', 'it-stub', ${opts.url}, ${opts.urlHash}, 'it.example',
+					${opts.contentHash}, ${opts.contentRef}, now(), now()
+				)
+				ON CONFLICT (url_hash) DO UPDATE SET
+					content_ref  = EXCLUDED.content_ref,
+					content_hash = EXCLUDED.content_hash,
+					last_fetched_at = now()
+			`
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+
+const readContentRef = (urlHash: string): Promise<string | null> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<{ content_ref: string | null }>`
+				SELECT content_ref FROM sources WHERE url_hash = ${urlHash} LIMIT 1
+			`
+			return rows[0]?.content_ref ?? null
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+			string | null,
+			never,
+			never
+		>,
+	)
+
+// Drive one scrape through the cached wrapper with the given fakes wired in.
+const runScrape = (opts: {
+	url: string
+	inner: (input: ScrapeInput) => Effect.Effect<ScrapedPage, ProviderError>
+	blobGet: BlobGet
+	blobPut: BlobPut
+}): Promise<ScrapedPage> => {
+	const cached = makeCachedScrape().pipe(
+		Layer.provide(
+			Layer.mergeAll(
+				Layer.succeed(ScrapeProvider)(
+					ScrapeProvider.of({ scrape: opts.inner }),
+				),
+				Layer.succeed(BlobStorage)(
+					BlobStorage.of({ get: opts.blobGet, put: opts.blobPut }),
+				),
+				PgLive,
+			),
+		),
+	)
+	return Effect.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ScrapeProvider
+			return yield* svc.scrape({ url: opts.url, formats: ['markdown'] })
+		}).pipe(Effect.provide(cached)),
+	)
+}
+
+const seededHashes: string[] = []
+const track = (urlHash: string): string => {
+	seededHashes.push(urlHash)
+	return urlHash
+}
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const urlHash of seededHashes) {
+				yield* sql`DELETE FROM sources WHERE url_hash = ${urlHash}`
+			}
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('scrape cache — a broken cache degrades to a fresh fetch', () => {
+	describe('when a warm row is present but its blob is unreadable', () => {
+		it('should fall through to inner.scrape rather than fail the scrape', async () => {
+			// GIVEN a warm sources row whose content_ref points at a blob the store
+			//   can no longer return
+			const url = `https://${freshHost()}/`
+			const urlHash = track(hashOf(url))
+			await seedWarmSource({
+				url,
+				urlHash,
+				contentRef: 'scrape/warm-but-unreadable',
+				contentHash: 'warm-but-unreadable',
+			})
+			let innerCalls = 0
+
+			// WHEN the wrapper serves that URL and the blob read fails
+			const page = await runScrape({
+				url,
+				inner: () => {
+					innerCalls += 1
+					return Effect.succeed({
+						url,
+						markdown: 'FRESH FROM PROVIDER',
+						contentHash: 'fresh-1',
+						units: 1,
+					} as ScrapedPage)
+				},
+				blobGet: failingBlobGet,
+				blobPut: okBlobPut,
+			})
+
+			// THEN the live page is fetched instead — the model gets real content,
+			//   not a cache error that would starve it into inventing facts
+			expect(page.markdown).toBe('FRESH FROM PROVIDER')
+			expect(innerCalls).toBe(1)
+		})
+	})
+
+	describe('when a warm row has an empty-string content_ref', () => {
+		it('should treat it as a miss and never touch the blob store', async () => {
+			// GIVEN a warm sources row whose content_ref is '' (points at nothing)
+			const url = `https://${freshHost()}/`
+			const urlHash = track(hashOf(url))
+			await seedWarmSource({
+				url,
+				urlHash,
+				contentRef: '',
+				contentHash: 'empty-ref',
+			})
+			let innerCalls = 0
+			let blobGetCalls = 0
+
+			// WHEN the wrapper serves that URL
+			const page = await runScrape({
+				url,
+				inner: () => {
+					innerCalls += 1
+					return Effect.succeed({
+						url,
+						markdown: 'FRESH AFTER EMPTY REF',
+						contentHash: 'fresh-2',
+						units: 1,
+					} as ScrapedPage)
+				},
+				blobGet: key => {
+					blobGetCalls += 1
+					return failingBlobGet(key)
+				},
+				blobPut: okBlobPut,
+			})
+
+			// THEN the tightened lookup excludes the empty row, so no blob read is
+			//   attempted and the page is fetched fresh
+			expect(page.markdown).toBe('FRESH AFTER EMPTY REF')
+			expect(innerCalls).toBe(1)
+			expect(blobGetCalls).toBe(0)
+		})
+	})
+
+	describe('when a warm row has a readable blob', () => {
+		it('should serve the cached markdown without calling inner.scrape', async () => {
+			// GIVEN a warm sources row whose content_ref points at a readable blob
+			const url = `https://${freshHost()}/`
+			const urlHash = track(hashOf(url))
+			await seedWarmSource({
+				url,
+				urlHash,
+				contentRef: 'scrape/readable-hit',
+				contentHash: 'readable-hit',
+			})
+
+			// WHEN the wrapper serves that URL and the blob read succeeds
+			const page = await runScrape({
+				url,
+				// A cache hit must never reach the provider — dying here proves it.
+				inner: () =>
+					Effect.die('inner.scrape must not be called on a cache hit'),
+				blobGet: () =>
+					Effect.succeed(new TextEncoder().encode('CACHED MARKDOWN')),
+				blobPut: okBlobPut,
+			})
+
+			// THEN the cached content is returned, free (units = 0)
+			expect(page.markdown).toBe('CACHED MARKDOWN')
+			expect(page.units).toBe(0)
+		})
+	})
+
+	describe('when the freshly-scraped page cannot be written to the blob store', () => {
+		it('should still return the page and record no content_ref', async () => {
+			// GIVEN no warm row (a cache miss) and a blob store that rejects writes
+			const url = `https://${freshHost()}/`
+			const urlHash = track(hashOf(url))
+
+			// WHEN the wrapper fetches the page fresh and the cache write fails
+			const page = await runScrape({
+				url,
+				inner: () =>
+					Effect.succeed({
+						url,
+						markdown: 'FRESH DESPITE WRITE FAILURE',
+						contentHash: 'fresh-4',
+						units: 1,
+					} as ScrapedPage),
+				blobGet: failingBlobGet,
+				blobPut: key =>
+					Effect.fail(
+						new ProviderError({
+							provider: 'cache',
+							message: `blob put failed for ${key}: simulated R2 write error`,
+							recoverable: false,
+						}),
+					),
+			})
+
+			// THEN the scrape succeeds with the fetched page (the write failure is
+			//   best-effort), and the row records no content_ref so the next lookup
+			//   re-fetches rather than pointing at a blob that was never written
+			expect(page.markdown).toBe('FRESH DESPITE WRITE FAILURE')
+			expect(await readContentRef(urlHash)).toBeNull()
+		})
+	})
+})

--- a/apps/server/src/services/provider-quota.integration.test.ts
+++ b/apps/server/src/services/provider-quota.integration.test.ts
@@ -1,0 +1,217 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, Result } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import {
+	makeProviderQuotaLayer,
+	ProviderQuota,
+	type QuotaExhausted,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+
+// Provider quota gates the research-web MCP tool: usage is read from
+// `provider_usage`, the ceiling from `provider_quotas`. Because the SQL client
+// camelCases result keys, reading those rows must use the camelCase names — the
+// snake_case spelling reads back undefined, which silently reports zero usage
+// and an undefined ceiling, so the gate never fires. These tests prove the
+// module actually reads the seeded config and usage against real Postgres.
+
+const seededUsers: string[] = []
+
+const seedQuota = (opts: {
+	userId: string
+	provider: string
+	total: number
+	unit: string
+	usedThisMonth?: number
+}): Promise<void> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`
+				INSERT INTO provider_quotas (
+					user_id, provider, billing_model, sync_mode, quota_total, quota_unit
+				) VALUES (
+					${opts.userId}, ${opts.provider}, 'monthly_plan', 'manual',
+					${opts.total}, ${opts.unit}
+				)
+				ON CONFLICT (user_id, provider) DO UPDATE SET
+					quota_total = EXCLUDED.quota_total, quota_unit = EXCLUDED.quota_unit
+			`
+			if (opts.usedThisMonth != null) {
+				yield* sql`
+					INSERT INTO provider_usage (user_id, provider, period_start, units_consumed)
+					VALUES (
+						${opts.userId}, ${opts.provider},
+						date_trunc('month', now())::date, ${opts.usedThisMonth}
+					)
+					ON CONFLICT (user_id, provider, period_start) DO UPDATE SET
+						units_consumed = EXCLUDED.units_consumed
+				`
+			}
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+
+interface QuotaSvc {
+	readonly check: (
+		provider: string,
+		units: number,
+	) => Effect.Effect<void, QuotaExhausted>
+	readonly consume: (
+		provider: string,
+		units: number,
+	) => Effect.Effect<void, QuotaExhausted>
+	readonly remaining: (
+		provider: string,
+	) => Effect.Effect<{ total: number; used: number; unit: string }>
+}
+
+// Drive one ProviderQuota method for the seeded user against real Postgres.
+const withQuota = <A>(
+	userId: string,
+	use: (quota: QuotaSvc) => Effect.Effect<A, QuotaExhausted>,
+): Promise<Result.Result<A, QuotaExhausted>> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const quota = yield* ProviderQuota
+			return yield* Effect.result(use(quota))
+		}).pipe(
+			Effect.provide(
+				makeProviderQuotaLayer({ userId }).pipe(Layer.provide(PgLive)),
+			),
+		) as Effect.Effect<Result.Result<A, QuotaExhausted>, never, never>,
+	)
+
+const freshUser = (): string => {
+	const id = `quota-it-${randomUUID()}`
+	seededUsers.push(id)
+	return id
+}
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const userId of seededUsers) {
+				yield* sql`DELETE FROM provider_usage WHERE user_id = ${userId}`
+				yield* sql`DELETE FROM provider_quotas WHERE user_id = ${userId}`
+			}
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('ProviderQuota — reads the configured quota and usage', () => {
+	describe('when a quota is configured with no usage yet', () => {
+		it('should report the configured total and zero used', async () => {
+			// GIVEN a provider with a 10-credit quota and no usage this period
+			const userId = freshUser()
+			await seedQuota({
+				userId,
+				provider: 'search',
+				total: 10,
+				unit: 'credits',
+			})
+
+			// WHEN the remaining allowance is read
+			const result = await withQuota(userId, quota => quota.remaining('search'))
+
+			// THEN the seeded ceiling and unit come through and usage is zero —
+			//   reading the snake_case keys would have returned undefined/NaN here
+			expect(Result.isSuccess(result)).toBe(true)
+			if (Result.isSuccess(result)) {
+				expect(result.success).toEqual({ total: 10, used: 0, unit: 'credits' })
+			}
+		})
+	})
+
+	describe('when usage already exists this period', () => {
+		it('should subtract recorded usage from the ceiling', async () => {
+			// GIVEN a 10-credit quota with 8 already consumed this month
+			const userId = freshUser()
+			await seedQuota({
+				userId,
+				provider: 'scrape',
+				total: 10,
+				unit: 'pages',
+				usedThisMonth: 8,
+			})
+
+			// WHEN the remaining allowance is read
+			const result = await withQuota(userId, quota => quota.remaining('scrape'))
+
+			// THEN used reflects the recorded usage (proves the usage row is read)
+			expect(Result.isSuccess(result)).toBe(true)
+			if (Result.isSuccess(result)) {
+				expect(result.success).toEqual({ total: 10, used: 8, unit: 'pages' })
+			}
+		})
+	})
+
+	describe('when a check would exceed the remaining allowance', () => {
+		it('should pass under the limit and fail over it with QuotaExhausted', async () => {
+			// GIVEN a 10-unit quota with 8 already used (2 remaining)
+			const userId = freshUser()
+			await seedQuota({
+				userId,
+				provider: 'extract',
+				total: 10,
+				unit: 'calls',
+				usedThisMonth: 8,
+			})
+
+			// WHEN a 2-unit check runs (fits) and a 3-unit check runs (exceeds)
+			const underLimit = await withQuota(userId, quota =>
+				quota.check('extract', 2),
+			)
+			const overLimit = await withQuota(userId, quota =>
+				quota.check('extract', 3),
+			)
+
+			// THEN the fitting check passes and the exceeding one is refused with the
+			//   real remaining count — the gate only works if usage/ceiling are read
+			expect(Result.isSuccess(underLimit)).toBe(true)
+			expect(Result.isFailure(overLimit)).toBe(true)
+			if (Result.isFailure(overLimit)) {
+				expect(overLimit.failure._tag).toBe('QuotaExhausted')
+				expect(overLimit.failure.remaining).toBe(2)
+				expect(overLimit.failure.unit).toBe('calls')
+			}
+		})
+	})
+
+	describe('when consume records usage', () => {
+		it('should increment the usage the next read sees', async () => {
+			// GIVEN a 10-credit quota with no usage yet
+			const userId = freshUser()
+			await seedQuota({
+				userId,
+				provider: 'discover',
+				total: 10,
+				unit: 'credits',
+			})
+
+			// WHEN 4 units are consumed
+			const consumed = await withQuota(userId, quota =>
+				quota.consume('discover', 4),
+			)
+			const after = await withQuota(userId, quota =>
+				quota.remaining('discover'),
+			)
+
+			// THEN the recorded usage is 4 (proves the write + read agree)
+			expect(Result.isSuccess(consumed)).toBe(true)
+			expect(Result.isSuccess(after)).toBe(true)
+			if (Result.isSuccess(after)) {
+				expect(after.success).toEqual({ total: 10, used: 4, unit: 'credits' })
+			}
+		})
+	})
+})

--- a/apps/server/src/services/research-blob-storage.ts
+++ b/apps/server/src/services/research-blob-storage.ts
@@ -7,16 +7,17 @@
  * research runtime use the same object store the rest of the app uses
  * (scrape markdown cache, recordings, etc.).
  *
- * Errors from the underlying `StorageProvider` are re-raised as plain
- * defects since `BlobStorage`'s Effect signature is error-free — the
- * caller (`cached-scrape.ts`) can't recover from them. `StorageProvider`
- * itself already logs and traces the failure before it gets here, so
- * nothing is lost by discarding the typed error at this boundary.
+ * A `StorageProvider` failure is mapped to a typed `ProviderError` (provider
+ * `cache`) rather than raised as a defect. That classification is what lets the
+ * scrape cache (`cached-scrape.ts`) recover from a broken read — degrading to a
+ * fresh fetch — instead of failing the whole scrape and denying the model the
+ * page. `StorageProvider` still logs and traces the failure before it reaches
+ * here, so this only adds a typed error channel; it drops nothing.
  */
 
 import { Effect, Layer } from 'effect'
 
-import { BlobStorage } from '@batuda/research'
+import { BlobStorage, ProviderError } from '@batuda/research'
 
 import { StorageProvider } from './storage-provider'
 
@@ -26,8 +27,27 @@ export const ResearchBlobStorageLive = Layer.effect(
 		const storage = yield* StorageProvider
 		return BlobStorage.of({
 			put: (key, bytes, contentType) =>
-				storage.put({ key, body: bytes, contentType }).pipe(Effect.orDie),
-			get: key => storage.get(key).pipe(Effect.orDie),
+				storage.put({ key, body: bytes, contentType }).pipe(
+					Effect.mapError(
+						error =>
+							new ProviderError({
+								provider: 'cache',
+								message: `blob put failed for ${key}: ${error.message}`,
+								recoverable: false,
+							}),
+					),
+				),
+			get: key =>
+				storage.get(key).pipe(
+					Effect.mapError(
+						error =>
+							new ProviderError({
+								provider: 'cache',
+								message: `blob get failed for ${key}: ${error.message}`,
+								recoverable: false,
+							}),
+					),
+				),
 		})
 	}),
 )

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -193,6 +193,8 @@ export const PgLive = PgClient.layerConfig({
 
 The transform functions handle snake_case ↔ camelCase mapping automatically — `sql.insert({ sizeRange: 'x' })` generates `INSERT INTO ... (size_range) VALUES ('x')`, and SELECT results map `size_range` → `sizeRange`.
 
+**This result mapping applies to *every* query, raw `` sql`…` `` template literals included** — not just the `sql.insert`/query-builder helpers. A `SELECT foo_bar` column comes back on the row as `fooBar`, **not** `foo_bar`. So read result columns in camelCase and type your `` sql<{ … }>` `` row shapes in camelCase, even though the SQL text itself — column names, `WHERE`, `INSERT`/`UPDATE` targets — stays snake_case. The trap: reading a snake_case key that the transform renamed (`row.foo_bar`) returns `undefined` with no type error and no runtime error, so the miss reads as an empty/missing value and slips through silently.
+
 ### Migrator layer (`@effect/sql-pg/PgMigrator`)
 
 ```typescript

--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -39,7 +39,10 @@ export class WriterLanguageModel extends ServiceMap.Service<
 
 // ── BlobStorage port (research-local view of app storage) ──
 // Narrow put/get used by scrape caching. Server wires this to S3StorageProvider
-// so research stays independent of the server package.
+// so research stays independent of the server package. A store failure surfaces
+// as a typed ProviderError (not a defect) so the scrape cache can degrade a
+// broken read to a fresh fetch instead of failing — and denying the model the
+// page, which makes it invent facts.
 
 export class BlobStorage extends ServiceMap.Service<
 	BlobStorage,
@@ -48,8 +51,8 @@ export class BlobStorage extends ServiceMap.Service<
 			key: string,
 			bytes: Uint8Array,
 			contentType: string,
-		) => Effect.Effect<void>
-		readonly get: (key: string) => Effect.Effect<Uint8Array>
+		) => Effect.Effect<void, ProviderError>
+		readonly get: (key: string) => Effect.Effect<Uint8Array, ProviderError>
 	}
 >()('research/BlobStorage') {}
 

--- a/packages/research/src/application/provider-quota.ts
+++ b/packages/research/src/application/provider-quota.ts
@@ -18,6 +18,9 @@ export const makeProviderQuotaLayer = (config: ProviderQuotaConfig) =>
 
 			// Read the quota config for a provider. Returns null if no quota
 			// is configured (quota check is skipped — budget is the only gate).
+			// The SQL client camelCases result keys (snake_case DB ↔ camelCase TS),
+			// so the selected columns arrive as `quotaTotal`/`quotaUnit`/… — read
+			// them by those names, not the SQL spelling.
 			const getQuotaConfig = (provider: string) =>
 				Effect.gen(function* () {
 					const rows = yield* sql`
@@ -29,13 +32,13 @@ export const makeProviderQuotaLayer = (config: ProviderQuotaConfig) =>
 					`
 					return rows[0] as
 						| {
-								quota_total: number
-								quota_unit: string
-								period_months: number
-								period_anchor: string | null
-								sync_mode: string
-								billing_model: string
-								cents_per_unit: number
+								quotaTotal: number
+								quotaUnit: string
+								periodMonths: number
+								periodAnchor: string | null
+								syncMode: string
+								billingModel: string
+								centsPerUnit: number
 						  }
 						| undefined
 				}).pipe(Effect.orDie)
@@ -43,14 +46,14 @@ export const makeProviderQuotaLayer = (config: ProviderQuotaConfig) =>
 			// Get current usage for a provider in the current period.
 			const getCurrentUsage = (provider: string) =>
 				Effect.gen(function* () {
-					const [row] = yield* sql<{ units_consumed: number }>`
+					const [row] = yield* sql<{ unitsConsumed: number }>`
 						SELECT COALESCE(units_consumed, 0)::int AS units_consumed
 						FROM provider_usage
 						WHERE user_id = ${config.userId}
 						  AND provider = ${provider}
 						  AND period_start = date_trunc('month', now())::date
 					`
-					return row?.units_consumed ?? 0
+					return row?.unitsConsumed ?? 0
 				}).pipe(Effect.orDie)
 
 			return ProviderQuota.of({
@@ -61,11 +64,11 @@ export const makeProviderQuotaLayer = (config: ProviderQuotaConfig) =>
 						if (!quota) return
 
 						const used = yield* getCurrentUsage(provider)
-						const remaining = quota.quota_total - used
+						const remaining = quota.quotaTotal - used
 						if (remaining < units) {
 							return yield* new QuotaExhausted({
 								provider,
-								unit: quota.quota_unit,
+								unit: quota.quotaUnit,
 								remaining: Math.max(0, remaining),
 							})
 						}
@@ -77,11 +80,11 @@ export const makeProviderQuotaLayer = (config: ProviderQuotaConfig) =>
 						if (!quota) return
 
 						const used = yield* getCurrentUsage(provider)
-						const remaining = quota.quota_total - used
+						const remaining = quota.quotaTotal - used
 						if (remaining < units) {
 							return yield* new QuotaExhausted({
 								provider,
-								unit: quota.quota_unit,
+								unit: quota.quotaUnit,
 								remaining: Math.max(0, remaining),
 							})
 						}
@@ -103,19 +106,19 @@ export const makeProviderQuotaLayer = (config: ProviderQuotaConfig) =>
 
 						const used = yield* getCurrentUsage(provider)
 						return {
-							total: quota.quota_total,
+							total: quota.quotaTotal,
 							used,
-							unit: quota.quota_unit,
+							unit: quota.quotaUnit,
 						}
 					}),
 
 				sync: (provider: string) =>
 					Effect.gen(function* () {
 						const quota = yield* getQuotaConfig(provider)
-						if (!quota || quota.sync_mode !== 'api') {
+						if (!quota || quota.syncMode !== 'api') {
 							return yield* new ProviderError({
 								provider,
-								message: `sync not supported for ${provider} (sync_mode=${quota?.sync_mode ?? 'none'})`,
+								message: `sync not supported for ${provider} (sync_mode=${quota?.syncMode ?? 'none'})`,
 								recoverable: false,
 							})
 						}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -2184,7 +2184,10 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							templateFingerprint,
 						})
 						if (!input.forceFresh) {
-							const hits = yield* sql<{ research_id: string }>`
+							// The SQL client camelCases result keys (snake_case DB ↔
+							// camelCase TS), so a selected `research_id` column arrives as
+							// `researchId`.
+							const hits = yield* sql<{ researchId: string }>`
 								SELECT research_id
 								FROM research_cache
 								WHERE key_hash = ${cacheKey}
@@ -2194,12 +2197,12 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								LIMIT 1
 							`
 							if (hits[0]) {
-								const cachedId = hits[0].research_id
+								const cachedId = hits[0].researchId
 								const [cachedRun] = yield* sql<{
 									findings: unknown
-									brief_md: string | null
-									tokens_in: number
-									tokens_out: number
+									briefMd: string | null
+									tokensIn: number
+									tokensOut: number
 								}>`
 									SELECT findings, brief_md, tokens_in, tokens_out
 									FROM research_runs
@@ -2226,9 +2229,9 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 											'succeeded',
 											${JSON.stringify(input.context ?? {})},
 											${JSON.stringify(cachedRun.findings)},
-											${cachedRun.brief_md},
-											${cachedRun.tokens_in},
-											${cachedRun.tokens_out},
+											${cachedRun.briefMd},
+											${cachedRun.tokensIn},
+											${cachedRun.tokensOut},
 											0, 0,
 											${input.idempotencyKey ?? null},
 											${userId},

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -717,6 +717,33 @@ describe('researchToolkit — a web-fetch failure is non-fatal', () => {
 				// can read — the fiber running generateText is never killed
 				expect(isFailure).toBe(true)
 			})
+
+			it('should carry the provider error message into the model-facing result', async () => {
+				// GIVEN a scrape whose cache layer rejects the page with a classified
+				//   provider:'cache' failure that names the offending row
+				const { result, isFailure } = await scrapePageResult(
+					() =>
+						Effect.fail(
+							new ProviderError({
+								provider: 'cache',
+								message: 'sources row src_deadbeef has no content_ref',
+								recoverable: false,
+							}),
+						),
+					{ url: 'https://warm.example' },
+				)
+
+				// THEN the model reads a failure whose description surfaces that exact
+				//   message — not a {provider,recoverable,_tag} dump that drops the
+				//   non-enumerable Error.message — so the failing line is named in the
+				//   run's tool log
+				expect(isFailure).toBe(true)
+				const description = (result as { reason: { description: string } })
+					.reason.description
+				expect(description).toBe(
+					'scrape_page: sources row src_deadbeef has no content_ref',
+				)
+			})
 		})
 	})
 

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -170,8 +170,17 @@ export const researchToolkit = Toolkit.make(
 // failures land in the model's context as strings rather than killing the
 // outer `generateText` effect.
 
-const errorMessage = (err: unknown): string =>
-	err instanceof Error ? err.message : String(err)
+// The tool-failure handlers below feed this a `Cause` (from `catchCause`), not
+// a bare error. `String(cause)` would drop a tagged error's `message` — it
+// extends `Error`, whose `message` is non-enumerable — leaving only
+// `{provider,recoverable,_tag}` in the tool log, which never names the failing
+// line. Squash the cause to its underlying error and read `.message` directly.
+const errorMessage = (err: unknown): string => {
+	if (typeof err === 'string') return err
+	if (Cause.isCause(err)) return errorMessage(Cause.squash(err))
+	if (err instanceof Error) return err.message
+	return String(err)
+}
 
 const mapToolError = (toolName: string) => (err: unknown) =>
 	Effect.fail(

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -140,6 +140,7 @@ export {
 	VERIFICATION_VERDICTS,
 	VerificationVerdict,
 } from './domain/types'
+export { makeCachedScrape } from './infrastructure/cached-scrape'
 export {
 	type ModelProbeResult,
 	type ProbeCheck,

--- a/packages/research/src/infrastructure/cached-scrape.ts
+++ b/packages/research/src/infrastructure/cached-scrape.ts
@@ -4,8 +4,11 @@
  *
  * Lookup path (fast, no lock):
  *   sha256(canonicalUrl) → SELECT … WHERE url_hash = $1 AND last_fetched_at
- *   is fresh → `BlobStorage.get(content_ref)` → decode markdown → return
- *   a `ScrapedPage` with `units = 0` (cache hit is free).
+ *   is fresh AND content_ref is a non-empty blob key → `BlobStorage.get(
+ *   content_ref)` → decode markdown → return a `ScrapedPage` with `units = 0`
+ *   (cache hit is free). A cache-read failure (unreadable or empty blob) is
+ *   not fatal: it degrades to the miss path so the live page is re-fetched
+ *   rather than denied to the model.
  *
  * Miss path (advisory-locked, stampede-safe):
  *   `pg_advisory_xact_lock(hashtext('scrape:<url_hash>'))` → re-check inside
@@ -27,7 +30,7 @@
 
 import { createHash } from 'node:crypto'
 
-import { Effect, Layer } from 'effect'
+import { Effect, Layer, Option } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
@@ -39,10 +42,13 @@ import { canonicalizeUrl } from '../application/source-key'
 import { ProviderError } from '../domain/errors'
 import { ScrapedPage } from '../domain/types'
 
+// The SQL client camelCases result keys (snake_case DB ↔ camelCase TS), so the
+// `content_ref`/`content_hash` columns arrive as `contentRef`/`contentHash` —
+// read them by those names, not the SQL spelling.
 interface SourcesCacheHit {
 	readonly id: string
-	readonly content_ref: string | null
-	readonly content_hash: string
+	readonly contentRef: string | null
+	readonly contentHash: string
 }
 
 const sha256Hex = (input: string): string =>
@@ -87,9 +93,13 @@ export const makeCachedScrape = () =>
 			const sql = yield* SqlClient.SqlClient
 			const blob = yield* BlobStorage
 
+			// Reads a cached row's stored markdown, or fails with a classified
+			// `provider:'cache'` ProviderError when the row points at nothing
+			// (empty content_ref) or the blob store can't return the bytes.
+			// `blob.get` already surfaces its failure as such a ProviderError.
 			const readFromBlob = (hit: SourcesCacheHit) =>
 				Effect.gen(function* () {
-					if (!hit.content_ref) {
+					if (!hit.contentRef) {
 						return yield* Effect.fail(
 							new ProviderError({
 								provider: 'cache',
@@ -98,18 +108,7 @@ export const makeCachedScrape = () =>
 							}),
 						)
 					}
-					const bytes = yield* blob.get(hit.content_ref).pipe(
-						Effect.mapError(
-							(e: unknown) =>
-								new ProviderError({
-									provider: 'cache',
-									message: `blob get failed: ${
-										e instanceof Error ? e.message : String(e)
-									}`,
-									recoverable: false,
-								}),
-						),
-					)
+					const bytes = yield* blob.get(hit.contentRef)
 					return new TextDecoder().decode(bytes)
 				})
 
@@ -127,31 +126,60 @@ export const makeCachedScrape = () =>
 					})()
 					const ttl = scrapeCacheTtlHours(domain, path)
 
+					// Serve a cached row, or fall through to a fresh fetch. A warm row
+					// whose blob is missing, unreadable, or empty must never fail the
+					// scrape: denied the page, the model answers from training memory and
+					// invents unsourced facts. So a cache-read failure degrades to None,
+					// signalling the caller to re-fetch the live page instead.
+					const readCached = (row: SourcesCacheHit) =>
+						readFromBlob(row).pipe(
+							Effect.map(markdown =>
+								Option.some(
+									new ScrapedPage({
+										url: canonical,
+										markdown,
+										contentHash: row.contentHash,
+										units: 0,
+									}),
+								),
+							),
+							Effect.catchTag('ProviderError', error =>
+								Effect.logWarning('cache.read_failed').pipe(
+									Effect.annotateLogs({
+										event: 'cache.read_failed',
+										port: 'scrape',
+										cache_table: 'sources',
+										key_hash: urlHash,
+										message: error.message,
+									}),
+									Effect.as(Option.none<ScrapedPage>()),
+								),
+							),
+						)
+
 					const hits = yield* sql<SourcesCacheHit>`
 						SELECT id, content_ref, content_hash
 						FROM sources
 						WHERE url_hash = ${urlHash}
 							AND last_fetched_at > now() - (${`${ttl} hours`})::interval
 							AND content_ref IS NOT NULL
+							AND content_ref <> ''
 						LIMIT 1
 					`
 					const hit = hits[0]
 					if (hit) {
-						const markdown = yield* readFromBlob(hit)
-						yield* Effect.logDebug('cache.hit').pipe(
-							Effect.annotateLogs({
-								event: 'cache.hit',
-								port: 'scrape',
-								cache_table: 'sources',
-								key_hash: urlHash,
-							}),
-						)
-						return new ScrapedPage({
-							url: canonical,
-							markdown,
-							contentHash: hit.content_hash,
-							units: 0,
-						})
+						const cached = yield* readCached(hit)
+						if (Option.isSome(cached)) {
+							yield* Effect.logDebug('cache.hit').pipe(
+								Effect.annotateLogs({
+									event: 'cache.hit',
+									port: 'scrape',
+									cache_table: 'sources',
+									key_hash: urlHash,
+								}),
+							)
+							return cached.value
+						}
 					}
 
 					return yield* Effect.gen(function* () {
@@ -163,42 +191,47 @@ export const makeCachedScrape = () =>
 							WHERE url_hash = ${urlHash}
 								AND last_fetched_at > now() - (${`${ttl} hours`})::interval
 								AND content_ref IS NOT NULL
+								AND content_ref <> ''
 							LIMIT 1
 						`
 						const rehit = rehits[0]
 						if (rehit) {
-							const markdown = yield* readFromBlob(rehit)
-							return new ScrapedPage({
-								url: canonical,
-								markdown,
-								contentHash: rehit.content_hash,
-								units: 0,
-							})
+							const cached = yield* readCached(rehit)
+							if (Option.isSome(cached)) return cached.value
 						}
 
 						const page = yield* inner.scrape(input)
 						const markdown = page.markdown ?? ''
-						const contentRef = blobKeyFor(page.contentHash)
 
+						// Best-effort cache write: the page is already in hand, so a store
+						// failure must not fail the scrape. On failure we record no
+						// content_ref, so the next lookup re-fetches rather than pointing at
+						// a blob that was never written.
+						let storedRef: string | null = null
 						if (markdown.length > 0) {
-							yield* blob
+							const contentRef = blobKeyFor(page.contentHash)
+							const wrote = yield* blob
 								.put(
 									contentRef,
 									new TextEncoder().encode(markdown),
 									'text/markdown',
 								)
 								.pipe(
-									Effect.mapError(
-										(e: unknown) =>
-											new ProviderError({
-												provider: 'cache',
-												message: `blob put failed: ${
-													e instanceof Error ? e.message : String(e)
-												}`,
-												recoverable: false,
+									Effect.as(true),
+									Effect.catchTag('ProviderError', error =>
+										Effect.logWarning('cache.write_failed').pipe(
+											Effect.annotateLogs({
+												event: 'cache.write_failed',
+												port: 'scrape',
+												cache_table: 'sources',
+												key_hash: urlHash,
+												message: error.message,
 											}),
+											Effect.as(false),
+										),
 									),
 								)
+							if (wrote) storedRef = contentRef
 						}
 
 						yield* sql`
@@ -209,7 +242,7 @@ export const makeCachedScrape = () =>
 							) VALUES (
 								${sourceIdFor(urlHash)}, 'web', 'scrape', ${canonical}, ${urlHash}, ${domain},
 								${page.title ?? null}, ${page.language ?? null},
-								${page.contentHash}, ${markdown.length > 0 ? contentRef : null},
+								${page.contentHash}, ${storedRef},
 								now(), now()
 							)
 							ON CONFLICT (url_hash) DO UPDATE SET


### PR DESCRIPTION
## What

Research runs were reporting success while **inventing company facts** — a CEO named on no source, LinkedIn job posts served as "recent news". The cause was the content cache that stores fetched web pages: on every *warm* read it silently failed, so the research model (the `research` bounded context) was handed nothing and fell back on its training memory. This makes a broken cache **degrade to re-fetching the live page** (or honestly return no reliable data) instead of failing the scrape and starving the model into fabrication.

The root cause is a snake_case/camelCase mismatch. The Postgres client is configured to return result columns in camelCase (`content_ref` → `contentRef`), but the cache read them in snake_case, so a stored page's reference always read as `undefined` — every warm cache row looked empty, and the whole scrape failed.

## The fix

- **Read the camelCase keys the client actually returns.** The scrape cache — and, the same bug, the research-run reuse cache and the per-provider usage-quota module — read SQL result columns in snake_case, which the client had already renamed to camelCase, so they always read undefined. They now read the correct names.
- **A broken cache degrades, it never fabricates.** A cache-read failure (unreadable or empty stored reference) now falls back to fetching the live page instead of failing the whole scrape; a failed cache *write* keeps the page just fetched rather than discarding it; storage read/write errors are classified as a typed error instead of being swallowed as an internal crash, so a real object-store outage also degrades to a fresh fetch. The lookup also ignores empty references.
- **Name the failing step.** A failed research tool was logging only the error's tags and dropping its message (a tagged error inherits a non-enumerable `message` from `Error`). It now logs the underlying message, so a systemic cache failure is visible in the run's tool log rather than invisible.

## Impact

- **Per-provider quota enforcement goes live.** The usage-quota module read usage as always-zero (same camelCase bug), so its limit never fired — the per-run budget was the only gate. Fixing it **activates enforcement**: once deployed, a provider over its configured limit (a `provider_quotas` row) starts refusing calls. If no quota rows are configured for a user, nothing changes.
- **No schema / migration change** — reuses existing tables.
- **MCP + HTTP parity** — research runs through the same service on both transports, so both the cache fix and the quota activation apply to each.
- **New public export** — `makeCachedScrape` is now exported from `@batuda/research` so the server can drive the cache wrapper in an integration test.
- **Cost** — the scrape cache actually serves warm hits now (it had been re-fetching every time, silently), so repeat scrapes within the TTL stop re-spending on the scrape provider.

## Review guide

- Start at `packages/research/src/infrastructure/cached-scrape.ts` — the camelCase read fix plus the degrade-to-fresh-fetch fall-through.
- The systemic root cause is the client's result-name transform, now documented in `docs/backend.md` → *Client layer*: every raw `` sql`…` `` result comes back camelCase. I audited the research package's raw-SQL reads — the three broken spots (scrape cache, run-reuse cache, provider-quota) are all fixed here; the rest either read camelCase already or read parsed JSON, not DB rows.
- Decision you might overrule: I **activated provider-quota enforcement** in this PR (see Impact). It's a real behavior change; if you'd rather stage it separately, that fix is isolated to `provider-quota.ts` + its test.
- Couldn't verify from here: the prod re-run of the two reported companies (Echo, Sunset) needs a deploy — the integration tests reproduce the mechanism against a real Postgres instead.

## Tests

- **Unit** — the tool-failure handler surfaces the provider error message (`tools.test.ts`).
- **Integration (real Postgres)** — the scrape cache degrades a broken read to a fresh fetch, ignores an empty reference, still serves a readable cache hit, and keeps the page on a write failure (`cached-scrape.integration.test.ts`); the quota module reads its configured limit + recorded usage and refuses an over-limit call (`provider-quota.integration.test.ts`).

## Verification

- Gates: `check-types`, `test` (552 server + 460 research unit), `build` — all green on the rebased branch.
- Live stack (real Postgres, worktree database): ran both new integration suites (8 tests), which drive the real cache wrapper and quota module end-to-end — all pass. The cache-hit test is what caught the camelCase root cause: it failed until the result keys were read in camelCase.

## Deferred

- Prod re-verification that the two reported companies (Echo, Sunset) ground on-target with non-fabricated fields after deploy.

Closes #248
