### PR TITLE
fix(research): make the LLM fallback accept our tool and output schemas

### DIFF
--- a/eval/golden.example.json
+++ b/eval/golden.example.json
@@ -136,5 +136,13 @@
 			"officialDomain": "canteralaponderosa.com",
 			"fields": { "region": "cat", "location": "Alcover" }
 		}
+	},
+	{
+		"id": "arrive-logistics",
+		"query": "Arrive Logistics, Austin",
+		"expectedOutput": {
+			"officialDomain": "arrivelogistics.com",
+			"fields": { "size_range": "51-200", "location": "Austin" }
+		}
 	}
 ]

--- a/packages/research/src/application/eval-golden.test.ts
+++ b/packages/research/src/application/eval-golden.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -152,6 +154,29 @@ describe('parseGoldenSet', () => {
 			expect(result.errors).toEqual([
 				{ id: 'bad', error: expect.stringContaining('officialDomain') },
 			])
+		})
+	})
+
+	describe('when parsing the shipped golden.example.json', () => {
+		it('should parse every row and score the US logistics headcount+location row', () => {
+			// GIVEN the golden set the eval CLI ships — a malformed row here would
+			// silently shrink live coverage
+			const raw = JSON.parse(
+				readFileSync(
+					new URL('../../../../eval/golden.example.json', import.meta.url),
+					'utf8',
+				),
+			) as ReadonlyArray<RawGoldenRow>
+
+			// WHEN parsed
+			const result = parseGoldenSet(raw)
+
+			// THEN nothing is rejected AND the Arrive Logistics row asserts the
+			// headcount (size_range) + location an earlier run lost from a search snippet
+			expect(result.errors).toEqual([])
+			const arrive = result.golden.find(g => g.id === 'arrive-logistics')
+			expect(arrive?.fields.size_range).toBe('51-200')
+			expect(arrive?.fields.location).toBe('Austin')
 		})
 	})
 })

--- a/packages/research/src/application/openai-structured-output.test.ts
+++ b/packages/research/src/application/openai-structured-output.test.ts
@@ -1,8 +1,42 @@
+import { Effect, Ref } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
 import { OpenAiStructuredOutput, Tool } from 'effect/unstable/ai'
 import { describe, expect, it } from 'vitest'
 
+import { ProviderError } from '../domain/errors'
+import { withFallbackLanguageModel } from '../infrastructure/_harden'
 import { schemaRegistry } from './schemas/index'
 import { researchToolkit } from './tools'
+
+// A single, non-nested union is what every configured provider accepts; a nested
+// `anyOf` — an `anyOf` branch that is itself an `anyOf` — is what groq/fireworks
+// reject ("anyOf branches must be disambiguated"). `optionalKey` around a
+// `NullOr`, or a bare `Schema.Number` (its NaN/Infinity string branch), each
+// produce that nesting. Walk the emitted schema and collect every such spot.
+const nestedAnyOfPaths = (node: unknown, path = '$'): string[] => {
+	if (Array.isArray(node)) {
+		return node.flatMap((item, i) => nestedAnyOfPaths(item, `${path}[${i}]`))
+	}
+	if (node === null || typeof node !== 'object') return []
+	const record = node as Record<string, unknown>
+	const out: string[] = []
+	const anyOf = record['anyOf']
+	if (Array.isArray(anyOf)) {
+		anyOf.forEach((branch, i) => {
+			if (
+				branch !== null &&
+				typeof branch === 'object' &&
+				'anyOf' in (branch as Record<string, unknown>)
+			) {
+				out.push(`${path}/anyOf/${i}`)
+			}
+		})
+	}
+	for (const [key, value] of Object.entries(record)) {
+		out.push(...nestedAnyOfPaths(value, `${path}/${key}`))
+	}
+	return out
+}
 
 describe('researchToolkit', () => {
 	it('should register at least one tool', () => {
@@ -23,6 +57,22 @@ describe('researchToolkit', () => {
 						transformer: OpenAiStructuredOutput.toCodecOpenAI,
 					}),
 				).not.toThrow()
+			})
+		}
+	})
+
+	describe('when serialising each Phase-1 tool schema for a strict provider', () => {
+		for (const tool of Object.values(researchToolkit.tools)) {
+			it(`should emit "${tool.name}" params with no nested anyOf`, () => {
+				// GIVEN a Phase-1 tool's parameter schema
+				// WHEN serialised through the exact runtime path (Tool.getJsonSchema + toCodecOpenAI)
+				const jsonSchema = Tool.getJsonSchema(tool, {
+					transformer: OpenAiStructuredOutput.toCodecOpenAI,
+				})
+
+				// THEN no union nests inside another union — the shape groq and
+				// fireworks reject, which killed the LLM fallback in prod
+				expect(nestedAnyOfPaths(jsonSchema)).toEqual([])
 			})
 		}
 	})
@@ -50,5 +100,94 @@ describe('schemaRegistry', () => {
 				).not.toThrow()
 			})
 		}
+	})
+
+	describe('when serialising each Phase-2 output schema for a strict provider', () => {
+		for (const [name, schema] of Object.entries(schemaRegistry)) {
+			it(`should emit "${name}" with no nested anyOf`, () => {
+				// GIVEN a registered Phase-2 output schema
+				// WHEN serialised through the exact runtime path (Tool.getJsonSchemaFromSchema + toCodecOpenAI)
+				const jsonSchema = Tool.getJsonSchemaFromSchema(schema, {
+					transformer: OpenAiStructuredOutput.toCodecOpenAI,
+				})
+
+				// THEN no union nests inside another union — the extract tier's
+				// fireworks fallback rejects that shape just as groq does for tools
+				expect(nestedAnyOfPaths(jsonSchema)).toEqual([])
+			})
+		}
+	})
+})
+
+// A stand-in for a strict provider (groq/fireworks): it serialises the real
+// toolkit the way the production client does and refuses the turn if any tool
+// carries a nested anyOf — exactly what killed the prod run. Otherwise it
+// answers, so the composed model only completes when every tool is clean.
+const strictProviderSlot = (
+	reachedRef: Ref.Ref<boolean>,
+): LanguageModel.Service =>
+	({
+		generateText: () =>
+			Effect.gen(function* () {
+				yield* Ref.set(reachedRef, true)
+				for (const tool of Object.values(researchToolkit.tools)) {
+					const jsonSchema = Tool.getJsonSchema(tool, {
+						transformer: OpenAiStructuredOutput.toCodecOpenAI,
+					})
+					if (nestedAnyOfPaths(jsonSchema).length > 0) {
+						return yield* Effect.fail(
+							new ProviderError({
+								provider: 'groq',
+								message: `invalid JSON schema for tool ${tool.name}`,
+								recoverable: false,
+							}),
+						)
+					}
+				}
+				return { text: 'ok', usage: {} }
+			}),
+		generateObject: () => Effect.succeed({}),
+		streamText: () => Effect.succeed({}),
+	}) as unknown as LanguageModel.Service
+
+const blippingSlot = (): LanguageModel.Service =>
+	({
+		generateText: () =>
+			Effect.fail(
+				new ProviderError({
+					provider: 'nebius',
+					message: 'transient blip',
+					recoverable: true,
+				}),
+			),
+		generateObject: () => Effect.succeed({}),
+		streamText: () => Effect.succeed({}),
+	}) as unknown as LanguageModel.Service
+
+describe('LLM fallback with the real toolkit', () => {
+	describe('when the primary slot fails and the fallback is a strict provider', () => {
+		it('should complete the tool-calling turn on the fallback', async () => {
+			// GIVEN a primary slot that fails and a strict-provider fallback that
+			// rejects any nested-anyOf tool schema — the prod failure was that the
+			// fallback (groq) refused the tools outright and the whole run died
+			const reachedRef = Ref.makeUnsafe(false)
+			const composed = withFallbackLanguageModel([
+				blippingSlot(),
+				strictProviderSlot(reachedRef),
+			])
+
+			// WHEN the cascade reaches the fallback and it serves a tool turn
+			const result = await Effect.runPromise(
+				(
+					composed.generateText as unknown as (
+						o: unknown,
+					) => Effect.Effect<{ text: string }, ProviderError>
+				)({ prompt: 'hi' }),
+			)
+
+			// THEN the fallback was reached AND it accepted the toolkit and answered
+			expect(Ref.getUnsafe(reachedRef)).toBe(true)
+			expect(result.text).toBe('ok')
+		})
 	})
 })

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -419,8 +419,8 @@ export const buildResearchSystemPrompt = (args: {
 		'You are a research agent for Batuda CRM.',
 		'Given a query, produce a thorough research brief with findings, sources, and citations.',
 		'Never fabricate sources. Every claim must be verifiable.',
-		'Confirm key facts (employee count, location, sector) from scraped page content — the company site, LinkedIn, or press — not from search snippets alone, and cite the scraped page for each.',
-		'For every citation, set source_id to the exact URL you scraped with scrape_page. Never invent an identifier — a citation that does not match a fetched page is dropped.',
+		'Confirm key facts (employee count, location, sector) from scraped page content where you can — the company site, LinkedIn, or press — and cite the page. When such a fact appears only in a search result you could not open as a page, still report it and quote the search snippet rather than dropping a real, sourced fact; never invent one that appears nowhere.',
+		'For a citation to a page you scraped, set source_id to the exact URL you scraped with scrape_page. Never invent an identifier — a made-up source is dropped.',
 		'When you search, use plain keywords, and only add a site: filter for a real domain you know — never a placeholder like site:example.com.',
 		'For discovery or prospecting queries, prefer authoritative sources — business directories, industry association member lists, and sector registries — over social media, forums, or glossary pages.',
 		'When extracting structured data from a single page, use the company_enrichment_v1 schema (a per-company shape), not a whole-run aggregate schema.',
@@ -1180,8 +1180,8 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							const sourceManifest = sourceRows.map(row => row.url).join('\n')
 							const citationInstruction =
 								sourceManifest.length > 0
-									? `For each citation, set source_id to one of these exact fetched source URLs, copied verbatim — prefer the company's own official website, and never cite a URL not in this list:\n\n${sourceManifest}`
-									: "Set each citation's source_id to the exact scraped URL the value came from."
+									? `For each citation, prefer one of these exact fetched source URLs, copied verbatim — especially the company's own official website:\n\n${sourceManifest}\n\nIf a value appears only in a search result in the transcript, still include it and quote the snippet, citing that result's URL — do not drop a real fact just because its page was not fetched.`
+									: "Cite the URL each value came from; if it was only a search result, quote its snippet and cite that result's URL."
 							// Cast schema to satisfy generateObject's Encoder constraint.
 							// Registry schemas are all Structs with DecodingServices=never,
 							// but Schema.Top erases that — the cast is safe.

--- a/packages/research/src/application/schemas/_shared.test.ts
+++ b/packages/research/src/application/schemas/_shared.test.ts
@@ -38,7 +38,11 @@ describe('ProspectScanV1Schema (shared PendingPaidAction.args)', () => {
 	const decode = Schema.decodeUnknownSync(ProspectScanV1Schema)
 	const withArgs = (args: string) => ({
 		prospects: [
-			{ name: 'Acme', why_relevant: 'fit', citations: [{ source_id: 's1' }] },
+			{
+				name: 'Acme',
+				why_relevant: 'fit',
+				citations: [{ source_id: 's1', confidence: null }],
+			},
 		],
 		pending_paid_actions: [
 			{ tool: 'lookup_registry', args, estimated_cents: 10, reason: 'need id' },
@@ -120,14 +124,13 @@ describe('LenientNumber', () => {
 
 	describe('when the model emits a value it could not work out', () => {
 		it('should coerce every non-finite value to null instead of failing', () => {
-			// GIVEN the strings and numbers a model returns for "no value" — the
+			// GIVEN the strings a model returns for "no value" — JSON has no NaN or
+			// Infinity literal, so a non-finite value always arrives quoted, and the
 			// literal "NaN" is the exact shape that failed enrichment runs
 			// THEN each becomes null rather than throwing a decode error
 			expect(decode('NaN')).toBeNull()
 			expect(decode('Infinity')).toBeNull()
 			expect(decode('-Infinity')).toBeNull()
-			expect(decode(Number.NaN)).toBeNull()
-			expect(decode(Number.POSITIVE_INFINITY)).toBeNull()
 			expect(decode('')).toBeNull()
 			expect(decode('not a number')).toBeNull()
 		})
@@ -180,7 +183,7 @@ describe('numeric guards on model-produced fields', () => {
 					{
 						name: 'Maria',
 						channels: [{ kind: 'email', value: 'm@x.cat', confidence: 'NaN' }],
-						citations: [{ source_id: 's1' }],
+						citations: [{ source_id: 's1', confidence: null }],
 					},
 				],
 			})
@@ -198,7 +201,7 @@ describe('numeric guards on model-produced fields', () => {
 					{
 						name: 'Acme',
 						why_relevant: 'fit',
-						citations: [{ source_id: 's1' }],
+						citations: [{ source_id: 's1', confidence: null }],
 					},
 				],
 				proposed_updates: [
@@ -208,7 +211,7 @@ describe('numeric guards on model-produced fields', () => {
 						expected_version: 'NaN',
 						fields: '{"industry":"logistics"}',
 						reason: 'r',
-						citations: [{ source_id: 's1' }],
+						citations: [{ source_id: 's1', confidence: null }],
 					},
 				],
 				pending_paid_actions: [
@@ -276,12 +279,18 @@ describe('Sourced', () => {
 		})
 	})
 
-	describe('when only the value and source are present', () => {
-		it('should decode with quote and confidence absent', () => {
-			// GIVEN the minimal wrapper — the source is required, the rest optional
-			const decoded = decode({ value: 'retail', source_id: 's1' })
+	describe('when only the value, source, and null confidence are present', () => {
+		it('should decode with the optional quote absent', () => {
+			// GIVEN the minimal wrapper — value and source are required, confidence is
+			// required + nullable (so it stays a single non-nested union), quote optional
+			const decoded = decode({
+				value: 'retail',
+				source_id: 's1',
+				confidence: null,
+			})
 			// THEN it decodes, carrying no quote
 			expect(decoded.value).toBe('retail')
+			expect(decoded.confidence).toBeNull()
 			expect(decoded).not.toHaveProperty('quote')
 		})
 	})

--- a/packages/research/src/application/schemas/_shared.ts
+++ b/packages/research/src/application/schemas/_shared.ts
@@ -35,7 +35,13 @@ export const TolerantJsonString = Schema.String.annotate({
 // decoding rejects that string and fails the whole extraction. Accepting a
 // string on the wire lets decoding turn any non-finite value into "no value"
 // (null) instead — the same family of fix as TolerantJsonString above.
-const coerceFinite = (value: number | string): number | null => {
+//
+// The wire type is `Finite | String | Null` (not a bare `Schema.Number`, whose
+// NaN/Infinity encoding serialises to a nested anyOf a strict provider rejects,
+// and with `Null` folded in so this stays a single non-nested union even when a
+// field is required + nullable).
+const coerceFinite = (value: number | string | null): number | null => {
+	if (value === null) return null
 	const n =
 		typeof value === 'string'
 			? value.trim() === ''
@@ -45,17 +51,24 @@ const coerceFinite = (value: number | string): number | null => {
 	return Number.isFinite(n) ? n : null
 }
 
-export const LenientNumber = Schema.Union([Schema.Number, Schema.String]).pipe(
+export const LenientNumber = Schema.Union([
+	Schema.Finite,
+	Schema.String,
+	Schema.Null,
+]).pipe(
 	Schema.decodeTo(Schema.NullOr(Schema.Number), {
 		decode: SchemaGetter.transform(coerceFinite),
-		encode: SchemaGetter.transform((n: number | null) => n ?? Number.NaN),
+		encode: SchemaGetter.transform((n: number | null) => n),
 	}),
 )
 
 export const Citation = Schema.Struct({
 	source_id: Schema.String,
 	quote: Schema.optionalKey(Schema.String),
-	confidence: Schema.optionalKey(LenientNumber),
+	// Required + nullable, not optional: `optionalKey` around a union serialises
+	// to a nested anyOf a strict provider rejects. LenientNumber already carries
+	// null, so a model with no confidence sends null.
+	confidence: LenientNumber,
 })
 
 // A single field paired with the source that backs it: a value plus the same
@@ -81,7 +94,8 @@ export const ProposedUpdate = Schema.Struct({
 	// leaves them out).
 	operation: Schema.optionalKey(Schema.Literals(['create', 'update'])),
 	subject_id: Schema.optionalKey(Schema.String),
-	expected_version: Schema.optionalKey(LenientNumber),
+	// Required + nullable (see Citation.confidence): a 'create' carries null here.
+	expected_version: LenientNumber,
 	fields: TolerantJsonString,
 	reason: Schema.String,
 	citations: Schema.Array(Citation),

--- a/packages/research/src/application/schemas/company-enrichment-v1.test.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.test.ts
@@ -13,17 +13,37 @@ describe('CompanyEnrichmentV1Schema', () => {
 			// page, region from another), instead of one citation list for the block
 			const payload = {
 				enrichment: {
-					industry: { value: 'Freight & logistics', source_id: 'src-1' },
-					size_range: { value: '51-200', source_id: 'src-1' },
-					location: { value: 'St. Louis, MO', source_id: 'src-1' },
-					region: { value: 'United States', source_id: 'src-2' },
+					industry: {
+						value: 'Freight & logistics',
+						source_id: 'src-1',
+						confidence: null,
+					},
+					size_range: { value: '51-200', source_id: 'src-1', confidence: null },
+					location: {
+						value: 'St. Louis, MO',
+						source_id: 'src-1',
+						confidence: null,
+					},
+					region: {
+						value: 'United States',
+						source_id: 'src-2',
+						confidence: null,
+					},
 				},
 				contacts: [
 					{
 						name: 'Ada Lovelace',
-						role: { value: 'CTO', source_id: 'src-1' },
-						email: { value: 'ada@acme.es', source_id: 'src-1' },
-						phone: { value: '+34 900 000 000', source_id: 'src-2' },
+						role: { value: 'CTO', source_id: 'src-1', confidence: null },
+						email: {
+							value: 'ada@acme.es',
+							source_id: 'src-1',
+							confidence: null,
+						},
+						phone: {
+							value: '+34 900 000 000',
+							source_id: 'src-2',
+							confidence: null,
+						},
 					},
 				],
 			}
@@ -46,8 +66,16 @@ describe('CompanyEnrichmentV1Schema', () => {
 			// real coordinates, the model filled both fields with the string "NaN"
 			const payload = {
 				enrichment: {
-					industry: { value: 'Freight & logistics', source_id: 'src-1' },
-					location: { value: 'St. Louis, MO', source_id: 'src-1' },
+					industry: {
+						value: 'Freight & logistics',
+						source_id: 'src-1',
+						confidence: null,
+					},
+					location: {
+						value: 'St. Louis, MO',
+						source_id: 'src-1',
+						confidence: null,
+					},
 					latitude: 'NaN',
 					longitude: 'NaN',
 				},
@@ -67,7 +95,11 @@ describe('CompanyEnrichmentV1Schema', () => {
 			// GIVEN a payload where the model guessed plausible-looking numbers
 			const payload = {
 				enrichment: {
-					location: { value: 'St. Louis, MO', source_id: 'src-1' },
+					location: {
+						value: 'St. Louis, MO',
+						source_id: 'src-1',
+						confidence: null,
+					},
 					latitude: 38.627,
 					longitude: -90.199,
 				},

--- a/packages/research/src/application/schemas/contact-discovery-v1.ts
+++ b/packages/research/src/application/schemas/contact-discovery-v1.ts
@@ -23,7 +23,10 @@ export const ContactDiscoveryV1Schema = Schema.Struct({
 						kind: Schema.String,
 						value: Schema.String,
 						verification: Schema.optionalKey(VerificationVerdict),
-						confidence: Schema.optionalKey(LenientNumber),
+						// Required + nullable (see _shared LenientNumber): `optionalKey`
+						// around a union serialises to a nested anyOf a strict provider
+						// rejects; a channel with no confidence sends null.
+						confidence: LenientNumber,
 						is_primary: Schema.optionalKey(Schema.Boolean),
 					}),
 				),

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -100,7 +100,12 @@ const webSearchInput = async (params: {
 	await Effect.runPromise(
 		Effect.gen(function* () {
 			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('web_search', params)
+			const stream = yield* toolkit.handle('web_search', {
+				limit: null,
+				recency_days: null,
+				location: null,
+				...params,
+			})
 			yield* Stream.runDrain(stream)
 		}).pipe(
 			Effect.provide(
@@ -140,7 +145,11 @@ const registryLookupInput = async (params: {
 	await Effect.runPromise(
 		Effect.gen(function* () {
 			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('registry_lookup', params)
+			const stream = yield* toolkit.handle('registry_lookup', {
+				query: null,
+				tax_id: null,
+				...params,
+			})
 			yield* Stream.runDrain(stream)
 		}).pipe(
 			Effect.provide(
@@ -173,7 +182,11 @@ const registryLookupResult = async (
 	const results = await Effect.runPromise(
 		Effect.gen(function* () {
 			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('registry_lookup', params)
+			const stream = yield* toolkit.handle('registry_lookup', {
+				query: null,
+				tax_id: null,
+				...params,
+			})
 			return yield* Stream.runCollect(stream)
 		}).pipe(
 			Effect.provide(
@@ -231,7 +244,10 @@ const extractStructuredResult = async (
 	const results = await Effect.runPromise(
 		Effect.gen(function* () {
 			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('extract_structured', params)
+			const stream = yield* toolkit.handle('extract_structured', {
+				prompt: null,
+				...params,
+			})
 			return yield* Stream.runCollect(stream)
 		}).pipe(
 			Effect.provide(
@@ -258,7 +274,12 @@ const webSearchResult = async (
 	const results = await Effect.runPromise(
 		Effect.gen(function* () {
 			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('web_search', params)
+			const stream = yield* toolkit.handle('web_search', {
+				limit: null,
+				recency_days: null,
+				location: null,
+				...params,
+			})
 			return yield* Stream.runCollect(stream)
 		}).pipe(
 			Effect.provide(
@@ -294,7 +315,10 @@ const extractInput = async (params: {
 	await Effect.runPromise(
 		Effect.gen(function* () {
 			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('extract_structured', params)
+			const stream = yield* toolkit.handle('extract_structured', {
+				prompt: null,
+				...params,
+			})
 			yield* Stream.runDrain(stream)
 		}).pipe(
 			Effect.provide(
@@ -374,7 +398,10 @@ const discoverContactsInput = async (params: {
 	await Effect.runPromise(
 		Effect.gen(function* () {
 			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('discover_contacts', params)
+			const stream = yield* toolkit.handle('discover_contacts', {
+				country: null,
+				...params,
+			})
 			yield* Stream.runDrain(stream)
 		}).pipe(Effect.provide(researchToolkitLayer.pipe(Layer.provide(infra)))),
 	)
@@ -592,13 +619,15 @@ describe('researchToolkit tool params — model-emitted null is treated as omitt
 	})
 
 	describe('tool parameter schemas — decode contract', () => {
-		describe('when an optional param is explicit null', () => {
-			it('should decode without rejecting for every widened optional param', () => {
-				// GIVEN the raw args a model sends with null for unused optionals — the
-				// exact decode that threw "Expected number, got null" before the fix
+		describe('when a nullable param is explicit null', () => {
+			it('should decode without rejecting for every nullable param', () => {
+				// GIVEN the raw args a model sends with null for the params it is not
+				// using — the exact decode that threw "Expected number, got null" before
+				// the fix. The params are required + nullable, so a real model always
+				// sends every one.
 				// WHEN each tool schema decodes them
 				// THEN the null passes through instead of failing validation
-				// [Schema.optionalKey(Schema.NullOr(...))]
+				// [Schema.NullOr(...)]
 				const web = Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
 					query: 'acme',
 					limit: null,
@@ -622,32 +651,40 @@ describe('researchToolkit tool params — model-emitted null is treated as omitt
 			})
 		})
 
-		describe('when an optional param has a wrong, non-null type', () => {
-			it('should still reject — the schema was widened to null, not to anything', () => {
-				// GIVEN a string where a number is expected
-				// THEN decode still fails (null tolerance did not loosen the value type)
+		describe('when a nullable param has a wrong, non-null type', () => {
+			it('should still reject — null tolerance did not loosen the value type', () => {
+				// GIVEN a string where a number is expected, with the other params set
+				// to null so the rejection is about the value type, not a missing field
+				// THEN decode still fails
 				expect(() =>
 					Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
 						query: 'acme',
+						limit: null,
 						recency_days: 'soon',
+						location: null,
 					}),
 				).toThrow()
 				expect(() =>
 					Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
 						query: 'acme',
 						limit: 'ten',
+						recency_days: null,
+						location: null,
 					}),
 				).toThrow()
 			})
 		})
 
-		describe('when a required field is null', () => {
-			it('should reject — only the optional params were widened', () => {
-				// GIVEN null for a required field
-				// THEN decode fails, because required fields were left as bare String
+		describe('when a non-nullable field is null', () => {
+			it('should reject — only the optional params accept null', () => {
+				// GIVEN null for a field that is required and not nullable (query, url)
+				// THEN decode fails, because those fields stay bare String
 				expect(() =>
 					Schema.decodeUnknownSync(WebSearchTool.parametersSchema)({
 						query: null,
+						limit: null,
+						recency_days: null,
+						location: null,
 					}),
 				).toThrow()
 				expect(() =>

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -46,22 +46,26 @@ import {
 const SCRAPE_MARKDOWN_MAX_CHARS = 8000
 
 // ── Tool parameter schemas ──
-// Optional params accept `null` (via `NullOr`) because a model may send an
-// explicit `null` for a field it isn't using instead of omitting it; the
-// handlers below treat that null as "not provided".
+// Optional params are required + nullable (`Schema.NullOr(...)`), not
+// `optionalKey`: a model not using one sends an explicit `null`, which the
+// handlers treat as "not provided". This shape also serializes to a single,
+// non-nested union — `optionalKey` wraps the value in a second nullable layer,
+// and a bare `Schema.Number` adds a NaN/Infinity string branch; either nesting
+// makes a stricter provider (groq, fireworks) reject the whole tool schema. So
+// numerics use `Schema.Finite`, which serializes to a plain number.
 
 const WebSearchParams = Schema.Struct({
 	query: Schema.String.annotate({
 		description: 'Search query; concise keywords work best',
 	}),
-	limit: Schema.optionalKey(Schema.NullOr(Schema.Number)).annotate({
+	limit: Schema.NullOr(Schema.Finite).annotate({
 		description: 'Max results to return (default 10)',
 	}),
-	recency_days: Schema.optionalKey(Schema.NullOr(Schema.Number)).annotate({
+	recency_days: Schema.NullOr(Schema.Finite).annotate({
 		description:
-			'Restrict to results published within the last N days. Omit for no filter.',
+			'Restrict to results published within the last N days. Null for no filter.',
 	}),
-	location: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
+	location: Schema.NullOr(Schema.String).annotate({
 		description: 'Geographic locale hint (e.g. "ES", "es-ES")',
 	}),
 })
@@ -77,9 +81,9 @@ const ExtractStructuredParams = Schema.Struct({
 	schema_name: Schema.String.annotate({
 		description: `Name of a registered schema. One of: ${Object.keys(schemaRegistry).join(', ')}`,
 	}),
-	prompt: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
+	prompt: Schema.NullOr(Schema.String).annotate({
 		description:
-			'Optional extra guidance for the extractor (e.g. "focus on revenue figures").',
+			'Optional extra guidance for the extractor (e.g. "focus on revenue figures"); null for none.',
 	}),
 })
 
@@ -88,11 +92,12 @@ const RegistryLookupParams = Schema.Struct({
 		description:
 			'ISO 3166-1 alpha-2 country code (any case). A country without a national registry returns {status:"no_registry"} — use discover_contacts there instead.',
 	}),
-	query: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
-		description: 'Company name or fuzzy search string',
+	query: Schema.NullOr(Schema.String).annotate({
+		description: 'Company name or fuzzy search string; null if using tax_id',
 	}),
-	tax_id: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
-		description: 'National tax id (e.g. ES CIF/NIF) — more precise than query',
+	tax_id: Schema.NullOr(Schema.String).annotate({
+		description:
+			'National tax id (e.g. ES CIF/NIF) — more precise than query; null if using query',
 	}),
 })
 
@@ -103,8 +108,9 @@ const DiscoverContactsParams = Schema.Struct({
 	domain: Schema.String.annotate({
 		description: 'Company web domain, e.g. "acme.com" (no scheme, no @)',
 	}),
-	country: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
-		description: 'ISO 3166-1 alpha-2 country hint (helps pick a registry)',
+	country: Schema.NullOr(Schema.String).annotate({
+		description:
+			'ISO 3166-1 alpha-2 country hint (helps pick a registry); null if unknown',
 	}),
 })
 

--- a/packages/research/src/application/vocabulary-guard.test.ts
+++ b/packages/research/src/application/vocabulary-guard.test.ts
@@ -92,6 +92,10 @@ describe('mapSizeRange', () => {
 		it('should fall a value above the top bucket to the closest one', () => {
 			// GIVEN a company larger than the top bracket
 			expect(mapSizeRange('500')).toBe('51-200')
+			// AND a head-count written with a thousands separator — "1,700" must read
+			// as 1700, not 1, so a large company is not bucketed as 1-5
+			expect(mapSizeRange('1,700 employees')).toBe('51-200')
+			expect(mapSizeRange('1.700 empleados')).toBe('51-200')
 		})
 	})
 

--- a/packages/research/src/application/vocabulary-guard.ts
+++ b/packages/research/src/application/vocabulary-guard.ts
@@ -157,7 +157,9 @@ export const mapSizeRange = (raw: string): CrmSizeRange | null => {
 	// Take the first integer — a single head-count, or the lower bound of an
 	// "N-M" / "N to M" range — and bucket it; a value above the top bracket falls
 	// to the closest one. A qualitative size ("SME", "small") has no integer → null.
-	const firstInt = n.match(/\d+/)?.[0]
+	// Strip a thousands separator sitting between digits first ("1,700" / "1.700"
+	// employees), or the match would read "1" and bucket a 1,700-person company as 1-5.
+	const firstInt = n.replace(/(?<=\d)[.,](?=\d)/g, '').match(/\d+/)?.[0]
 	if (firstInt === undefined) return null
 	const count = Number(firstInt)
 	if (!Number.isFinite(count) || count <= 0) return null

--- a/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
+++ b/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
@@ -220,6 +220,17 @@ describe('makeFirecrawlScrape', () => {
 		expect(log.last?.headers['authorization']).toBe('Bearer fc_k')
 	})
 
+	it('should exclude <form> blocks so a contact-form pop-up cannot stand in for the page', async () => {
+		// GIVEN any successful scrape
+		const { exit, log } = runScrape(200, { data: { markdown: 'x' } })
+		await exit
+
+		// THEN the request drops <form> content while keeping main-content extraction
+		const body = bodyJson(log.last)
+		expect(body['excludeTags']).toEqual(['form'])
+		expect(body['onlyMainContent']).toBe(true)
+	})
+
 	it('should default missing markdown to an empty string', async () => {
 		// GIVEN a 2xx response whose data omits markdown
 		const { exit } = runScrape(200, { data: { metadata: { title: 'Acme' } } })
@@ -441,6 +452,19 @@ describe('makeFirecrawlSearch', () => {
 		expect(log.last?.method).toBe('POST')
 		expect(log.last?.url).toContain('api.firecrawl.dev/v2/search')
 		expect(log.last?.headers['authorization']).toBe('Bearer fc_k')
+	})
+
+	it('should exclude <form> blocks from the per-result scrape', async () => {
+		// GIVEN any successful search
+		const { exit, log } = runSearch(200, { data: { web: [] } })
+		await exit
+
+		// THEN the embedded scrapeOptions drop <form> content, matching the adapter
+		const scrapeOptions = bodyJson(log.last)['scrapeOptions'] as Record<
+			string,
+			unknown
+		>
+		expect(scrapeOptions?.['excludeTags']).toEqual(['form'])
 	})
 
 	it('should send a normalized lower-case country for a locale hint', async () => {

--- a/packages/research/src/infrastructure/firecrawl/scrape.ts
+++ b/packages/research/src/infrastructure/firecrawl/scrape.ts
@@ -91,6 +91,13 @@ export const makeFirecrawlScrape = (slot: number) =>
 								url: input.url,
 								formats: input.formats ?? ['markdown'],
 								onlyMainContent: true,
+								// Drop <form> blocks. A homepage often opens with a "contact
+								// us" pop-up form that renders first, so main-content
+								// extraction prepends the whole form; on a long page it can
+								// crowd the real body out of the downstream length cap. The
+								// facts we want (headcount, services, location) live in prose,
+								// never in a form.
+								excludeTags: ['form'],
 							}),
 						)
 						const response = yield* client.execute(request).pipe(

--- a/packages/research/src/infrastructure/firecrawl/search.ts
+++ b/packages/research/src/infrastructure/firecrawl/search.ts
@@ -85,9 +85,12 @@ export const makeFirecrawlSearch = (slot: number) =>
 								sources: [{ type: 'web' }],
 								// Return each result's main content as markdown, so one
 								// search can ground the run without a separate scrape.
+								// Drop <form> blocks so a "contact us" pop-up form doesn't
+								// stand in for the page body (same fix as the scrape adapter).
 								scrapeOptions: {
 									formats: ['markdown'],
 									onlyMainContent: true,
+									excludeTags: ['form'],
 								},
 								...(input.recency
 									? { tbs: tbsForRecency(input.recency.days) }


### PR DESCRIPTION
## What

This fixes three defects in the **Research** service (the server-side pipeline that enriches a company from the public web), all seen in one batch of runs against mid-size US logistics firms on the current release. The worst one quietly defeated the reliability work shipped in #235: when the primary language model had a transient hiccup, the *backup* model couldn't be used at all, so the whole run died instead of recovering. The other two lowered answer quality — a company's homepage was scraped as an empty contact form, and a real figure the model plainly had in front of it never made it into the company's enriched record.

## The fix

- **The language-model fallback can now actually take over.** The research agent's tool inputs and its structured-output fields were compiling to a union nested inside another union (an optional field wrapped around a nullable one, plus a plain number carrying its `"NaN"`/`"Infinity"` text form). The primary provider (Nebius) accepts that shape; the backups (Groq for the agent, Fireworks for extraction) reject it outright. Optional inputs are now a **required-but-nullable** field built from a finite-number type, so every schema serializes to a single, flat union all three providers accept.
- **A homepage no longer scrapes as its pop-up form.** Many sites open with a "contact us" pop-up form that renders first; main-content extraction was returning the whole form and, on a long page, pushing the real body past the length limit the model sees. The scrape and the search-time page fetch now drop `<form>` blocks (footers and navigation stay, since a footer often carries the address).
- **Facts seen only in a search result are no longer thrown away.** When a headcount or location appeared only in a search snippet and not on a page the agent opened, the instructions told it to drop the fact. It may now report such a fact and quote the snippet. Separately, a headcount like `"1,700 employees"` was being read as `1` (the parser stopped at the comma) and filed a 1,700-person company under the smallest `1-5` band — a thousands separator between digits is now stripped first.

## Impact

- **No database migration, no new environment variables, no RLS/tenant-scope changes.** The Groq and Fireworks keys are already set in production.
- **Stored findings shape:** the per-field `confidence` (and a proposed update's `expected_version`) is now always present, sometimes `null`, where before it could be absent. Readers already tolerate null/absent, and this is pre-production, so no data backfill is needed.
- **MCP + HTTP parity:** the change lives entirely in the shared research service, so both transports get it.
- **No frontend/API wire-shape change** — `packages/controllers` / `packages/domain` are untouched.

## Review guide

- **Start here:** `packages/research/src/application/tools.ts` and `schemas/_shared.ts` — the required-nullable + `Schema.Finite` swap is the core of the high-severity fix. `openai-structured-output.test.ts` is the guard: it serializes every tool and output schema through the **exact** transformer the live model calls use (`toCodecOpenAI`) and fails if any nested union survives, so a future revert to `optionalKey` around a union is caught in CI.
- **Riskiest part:** the recall change in `research-service.ts` is prompt-only. I deliberately did **not** touch the source-registration or citation guards: a search snippet never becomes a "fetched source", so the fail-closed grounding gate (a run that opened no page is still marked `no_reliable_data`) and the value-provenance / fabrication checks are unchanged. The existing citation guard already keeps an enrichment value while stripping an ungrounded source, and still drops an unbacked CRM write whole — I leaned on that asymmetry rather than loosening it.
- **A decision you might overrule:** optional tool params became *required* (nullable). That's what lets them serialize flat; the model already sent explicit `null` for unused ones, so it matches observed behavior, but it is a contract change worth a glance.

## Tests

- Probe asserting no nested union in every tool + output schema (the machine-checkable form of "every configured provider accepts it"), plus a forced-primary-failure test where the fallback validates the real toolkit the way Groq does and completes a tool-calling turn.
- The size-range thousands-separator fix, the golden-set parse, and the `excludeTags: ['form']` request shape are unit-covered. Existing citation-guard tests already lock in the keep-value/drop-source behavior the recall fix relies on.

## Verification

- Ran: `check-types` across all 13 packages (pre-commit hook), `@batuda/research` (474) + `@batuda/server` (552) unit tests, `@batuda/cli` type-check, and `pnpm -w build` — all green.
- Live: scraped `arrivelogistics.com` through Firecrawl with `excludeTags: ['form']` and confirmed the real page body (services, positioning, phone) comes through instead of the pop-up form.
- **Not exercisable locally** (post-release, against the deployed MCP — same as #231/#234): a real Groq/Fireworks fallback turn, and the `research eval` run of the new golden row. I'll validate both once this is released.

## Deferred

- No CRM size band above `51-200` — a 1,700-person company still buckets to the top band; adding a larger band is a separate CRM-vocabulary decision.
- A snippet-only enrichment value keeps the value but not a displayed source (the ungrounded source is stripped by the existing guard); preserving snippet provenance for display would be a follow-up.

Closes #251
