### PR TITLE
fix(cli): honor eval-contacts --enrich / --enrich-mode flags

### DIFF
--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -1,7 +1,15 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { isAbsolute, resolve } from 'node:path'
 
-import { Config, Console, Effect, Layer, Option, type Redacted } from 'effect'
+import {
+	Config,
+	ConfigProvider,
+	Console,
+	Effect,
+	Layer,
+	Option,
+	type Redacted,
+} from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -479,22 +487,18 @@ export const researchEvalContacts = (opts: {
 	readonly out: Option.Option<string>
 }) =>
 	Effect.gen(function* () {
-		// Set before the layer reads Config — the CLI's loadEnv → process.env →
-		// Config model means the chosen chain/mode must be in the env first.
-		yield* Option.match(opts.enrich, {
-			onNone: () => Effect.void,
-			onSome: value =>
-				Effect.sync(() => {
-					process.env['RESEARCH_PROVIDER_ENRICH'] = value
-				}),
-		})
-		yield* Option.match(opts.enrichMode, {
-			onNone: () => Effect.void,
-			onSome: value =>
-				Effect.sync(() => {
-					process.env['RESEARCH_ENRICH_MODE'] = value
-				}),
-		})
+		// The --enrich / --enrich-mode flags need to reach the settings the
+		// enrichment step reads. Those settings are captured from the environment
+		// once, before this handler runs, so writing to process.env now would be
+		// ignored. Instead the flag values become a top-priority settings source
+		// that wins over the existing one, which still supplies everything else.
+		const enrichOverrides: Record<string, string> = {}
+		if (Option.isSome(opts.enrich)) {
+			enrichOverrides['RESEARCH_PROVIDER_ENRICH'] = opts.enrich.value
+		}
+		if (Option.isSome(opts.enrichMode)) {
+			enrichOverrides['RESEARCH_ENRICH_MODE'] = opts.enrichMode.value
+		}
 
 		const raw = yield* Effect.tryPromise({
 			try: () => readFile(fromRepoRoot(opts.goldenPath), 'utf8'),
@@ -542,7 +546,15 @@ export const researchEvalContacts = (opts: {
 					),
 				{ concurrency: opts.concurrency },
 			)
-		}).pipe(Effect.provide(contactsLive))
+		}).pipe(
+			Effect.provide(contactsLive),
+			Effect.provide(
+				ConfigProvider.layerAdd(
+					ConfigProvider.fromEnv({ env: enrichOverrides }),
+					{ asPrimary: true },
+				),
+			),
+		)
 
 		for (const company of golden) {
 			yield* Console.log(


### PR DESCRIPTION
## What

The contact-finding eval (`pnpm cli research eval-contacts`) has two flags — `--enrich` (which vendor chain to use for decision-maker discovery) and `--enrich-mode` (`fallback` = stop at the first vendor that returns people; `union` = run every vendor and merge) — so one command can score the same golden set under different provider setups. They were silently ignored: every run used whatever the environment defaulted to, which made the whole point of the flags — comparing Hunter-only vs Hunter+FullEnrich vs union from the CLI — impossible to actually drive.

This is `cli` tooling only. It changes how the eval command is configured; nothing in the research engine or any production path moves.

## The fix

The flags were written into `process.env` from inside the command handler. But Effect's configuration layer reads the environment **once**, at the first config lookup — and that first lookup happens during the eval's telemetry (OTLP) setup, *before* the handler runs. So by the time the handler wrote to `process.env`, the snapshot was already taken and the writes were dead on arrival.

The fix layers the flag values as a **top-priority configuration source** over the existing one (`ConfigProvider.layerAdd(fromEnv({ env: overrides }), { asPrimary: true })`), supplying just the two enrich-related keys and deferring every other key to the normal provider. One invocation now cleanly picks both the vendor chain and the mode.

## Impact

- **Eval tooling only.** No change to the research run loop, the MCP `discover_contacts` tools, the web UI, or any provider adapter — those already read the same two settings through the normal environment and are untouched.
- Corrects behaviour shipped in #254 (the eval landed with these two flags non-functional).

## Review guide

- One file: `apps/cli/src/commands/research.ts`, the `researchEvalContacts` handler.
- The only subtlety worth a look is the **config-snapshot timing** — why the previous `process.env` write was too late, and why the overlay is deliberately scoped to just the two keys so it can't drop everything else the eval reads (DB URL, other provider keys). `orElse` semantics make that safe: the primary provider returns `undefined` for any key it doesn't hold, which falls through to the existing provider.

## Verification

- Gates: `pnpm install` (up to date) → `pnpm -w check-types` (13/13) + `pnpm -w test` (20/20 tasks, 552 server tests) → `pnpm -w build` (13/13). The pre-push hook re-ran the suite green.
- Live, against the dev stack with the real FullEnrich key:
  - `--enrich fullenrich` → logs `research.enrich: fullenrich` (the dev default is *not* fullenrich, so the override demonstrably took hold); the eval ran end-to-end (Stripe: 10 deliverable contacts, 16¢).
  - `--enrich-mode union` → logs `research.enrich: fullenrich (union)` (vs the `fallback` default), confirming the mode override is independent of the chain override.

## Tests

None. Repo house rule is no unit tests for CLI command code; the tested surface — the enrichment chain and provider layer these flags select — is covered in `packages/research` from #254.
