### PR TITLE
fix(research): drop ungrounded fields and read full source pages

### DIFF
--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -6,7 +6,12 @@ import { dirname, resolve } from 'node:path'
 
 import { Console, Effect, Schedule } from 'effect'
 
-import { mergeEnvOverrides, missingEnvEntries, tryFs } from '../lib/env-file'
+import {
+	fillMissingFromExample,
+	mergeEnvOverrides,
+	missingEnvEntries,
+	tryFs,
+} from '../lib/env-file'
 import {
 	exec,
 	execArgs,
@@ -200,6 +205,7 @@ const writeWorktreeEnv = (
 ) =>
 	Effect.gen(function* () {
 		const targets = WORKTREE_ENV_FILES.map(f => ({
+			path: f.path,
 			from: resolve(mainRoot, f.path),
 			to: resolve(ROOT, f.path),
 			keys: f.keys,
@@ -214,8 +220,23 @@ const writeWorktreeEnv = (
 			)
 		}
 
+		// The committed template, the source of default values for any required key
+		// the main checkout's `.env` never synced.
+		const examplePath = resolve(ROOT, '.env.example')
+		const exampleBody = existsSync(examplePath)
+			? readFileSync(examplePath, 'utf-8')
+			: undefined
+		const filled: string[] = []
+
 		for (const t of targets) {
 			const base = readFileSync(t.from, 'utf-8')
+			// Only the root `.env` is gap-filled against the template — `apps/cli/.env`
+			// is a deliberately small subset, not a copy of the whole template.
+			const source =
+				t.path === '.env' && exampleBody !== undefined
+					? fillMissingFromExample(base, exampleBody)
+					: { body: base, filled: [] as string[] }
+			filled.push(...source.filled)
 			const subset = Object.fromEntries(
 				t.keys.flatMap(k => {
 					const v = overrides[k]
@@ -223,9 +244,10 @@ const writeWorktreeEnv = (
 				}),
 			)
 			yield* tryFs(`write ${t.to}`, () =>
-				writeFile(t.to, mergeEnvOverrides(base, subset)),
+				writeFile(t.to, mergeEnvOverrides(source.body, subset)),
 			)
 		}
+		return filled
 	})
 
 // Key names the committed .env.example declares but the local .env lacks. A
@@ -539,17 +561,18 @@ export const worktreeUp = Effect.gen(function* () {
 	yield* settle(mc(`mc mb --ignore-existing local/${bucketName(slug)}`))
 
 	const overrides = envOverrides(slug)
-	yield* writeWorktreeEnv(main, overrides)
+	const filledEnv = yield* writeWorktreeEnv(main, overrides)
 	// Make the just-written values visible to this process + every subprocess
 	// (migrate/seed) it spawns, so they target this worktree's database, not main's.
 	for (const [k, v] of Object.entries(overrides)) process.env[k] = v
 
-	// Catch a stale inherited .env now, with the key names, instead of leaving
-	// the server to die at boot with a bare "Expected string, got undefined".
-	const missingEnv = missingWorktreeEnvKeys()
-	if (missingEnv.length > 0) {
-		yield* Effect.logWarning(
-			`.env is missing ${missingEnv.length} key(s) that .env.example declares: ${missingEnv.join(', ')}. The server reads these at boot and will fail until you copy their values from .env.example into the main checkout's .env.`,
+	// A required key the inherited .env never carried was just filled from the
+	// template's default so this worktree boots instead of dying at boot with a
+	// bare "Expected string, got undefined". Name them so a non-default value can
+	// be set deliberately when the default doesn't fit.
+	if (filledEnv.length > 0) {
+		yield* Effect.logInfo(
+			`Filled ${filledEnv.length} key(s) missing from the inherited .env with .env.example defaults: ${filledEnv.join(', ')}. Set a value in the main checkout's .env if a default doesn't fit.`,
 		)
 	}
 

--- a/apps/cli/src/lib/env-file.ts
+++ b/apps/cli/src/lib/env-file.ts
@@ -68,6 +68,26 @@ export const missingEnvEntries = (
 	return parseEnvEntries(exampleBody).filter(e => !present.has(e.key))
 }
 
+/** Append to `base` every active key the template declares but `base` lacks,
+ * carrying each key's default value and its doc comments. A worktree inherits its
+ * `.env` from the main checkout, so a required key added to the template but never
+ * synced into that `.env` is absent here too and the server dies at boot on the
+ * missing var; filling it from the template's default keeps the worktree bootable.
+ * Returns the merged body plus the names it added, so the caller can report them. */
+export const fillMissingFromExample = (
+	base: string,
+	exampleBody: string,
+): { body: string; filled: string[] } => {
+	const missing = missingEnvEntries(exampleBody, base)
+	if (missing.length === 0) return { body: base, filled: [] }
+	const block = missing.flatMap(e => [...e.comments, e.line]).join('\n')
+	const separator = base.endsWith('\n') ? '' : '\n'
+	return {
+		body: `${base}${separator}${block}\n`,
+		filled: missing.map(e => e.key),
+	}
+}
+
 /** Rewrite matching keys in a .env body, appending any that weren't present, so
  * every other line is preserved as-is. Used to layer per-worktree overrides
  * (`DATABASE_URL`, `STORAGE_BUCKET`) onto a copy of another `.env`'s content. */

--- a/packages/research/src/application/citation-guard.test.ts
+++ b/packages/research/src/application/citation-guard.test.ts
@@ -113,7 +113,7 @@ describe('validateFindingCitations', () => {
 			const result = validateFindingCitations(findings, isGrounded)
 
 			// THEN each is filtered independently: the grounded wrapper keeps its
-			// source, the ungrounded wrapper keeps only its value, the invented
+			// source, the ungrounded scalar wrapper is dropped whole, the invented
 			// competitor citation is dropped, the grounded proposal survives
 			const f = result.findings as {
 				enrichment: { industry: unknown; location: unknown }
@@ -124,7 +124,7 @@ describe('validateFindingCitations', () => {
 				value: 'Retail',
 				source_id: 'https://acme.es',
 			})
-			expect(f.enrichment.location).toEqual({ value: 'Barcelona' })
+			expect(f.enrichment.location).toBeNull()
 			expect(f.competitors[0]?.citations).toEqual([])
 			expect(f.proposed_updates).toHaveLength(1)
 			expect(result.total).toBe(4)
@@ -133,7 +133,7 @@ describe('validateFindingCitations', () => {
 	})
 
 	describe('when a per-field wrapper carries quote and confidence', () => {
-		it('should keep them on a grounded field and drop them all on an ungrounded one', () => {
+		it('should keep a grounded field whole and drop an ungrounded one', () => {
 			// GIVEN two sourced fields — one citing the fetched page, one invented
 			const findings = {
 				enrichment: {
@@ -150,8 +150,8 @@ describe('validateFindingCitations', () => {
 			// WHEN validated against the one fetched source
 			const result = validateFindingCitations(findings, isGrounded)
 
-			// THEN the grounded field keeps its full provenance; the invented one
-			// keeps only its value
+			// THEN the grounded field keeps its full provenance; the invented one is
+			// dropped whole (a scalar fact with a fabricated source is treated as absent)
 			const f = result.findings as {
 				enrichment: { industry: unknown; country: unknown }
 			}
@@ -161,7 +161,7 @@ describe('validateFindingCitations', () => {
 				quote: 'a shop',
 				confidence: 0.9,
 			})
-			expect(f.enrichment.country).toEqual({ value: 'ES' })
+			expect(f.enrichment.country).toBeNull()
 			expect(result.total).toBe(2)
 			expect(result.kept).toBe(1)
 		})

--- a/packages/research/src/application/citation-guard.ts
+++ b/packages/research/src/application/citation-guard.ts
@@ -84,10 +84,12 @@ export const validateFindingCitations = (
 		if (value !== null && typeof value === 'object') {
 			// A per-field Sourced wrapper carries its own `source_id` beside a
 			// `value` (a bare citation entry has a source_id but no `value`). Judge it
-			// like a citation: keep the whole wrapper when the source was fetched,
-			// otherwise drop just the provenance and let the field's value stand
-			// unsourced — the same "keep the data, remove the fabricated source" rule
-			// the citations array follows.
+			// like a citation, but drop the whole field when the source was not
+			// fetched: a single scalar with a fabricated source is treated as absent
+			// rather than shipped unsourced, so a value that never reached a real page
+			// cannot survive. (A descriptive finding's citations array still keeps its
+			// value and drops only the bad citation — that rule is for prose, not a
+			// scalar fact.)
 			const record = value as { source_id?: unknown; value?: unknown }
 			if (typeof record.source_id === 'string' && 'value' in record) {
 				total++
@@ -95,7 +97,7 @@ export const validateFindingCitations = (
 					kept++
 					return value
 				}
-				return { value: walk(record.value) }
+				return null
 			}
 			return Object.fromEntries(
 				Object.entries(value as Record<string, unknown>).map(

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -61,6 +61,7 @@ import {
 	ScrapeProvider,
 	WriterLanguageModel,
 } from './ports'
+import { guardScalarFields } from './scalar-field-guard'
 import { type FreeformSchema, schemaRegistry } from './schemas/index'
 import { urlHashForScrape } from './source-key'
 import { REGISTRY_LOOKUP_COST_CENTS, SCRAPE_COST_CENTS } from './tool-costs'
@@ -101,6 +102,12 @@ const MIN_GROUNDED_SOURCES = 1
 // used when the model provider omits token usage so the token budget below can't
 // fire. Scrapes are capped per page but many of them still add up.
 const MAX_LOOP_PROMPT_CHARS = 90000
+
+// How much full fetched-page text phase-2 extraction may read on top of the
+// transcript. The transcript caps each tool result at 4000 chars for the agent
+// loop; the extractor gets the fuller pages here so a fact sitting past that cut
+// (a leadership list, a tools section) still reaches the structured output.
+const MAX_EXTRACTION_PAGE_CHARS = 60000
 
 // When the model finishes without the evidence confirming the target company, it
 // gets this many corrective nudges to search harder before the run fails closed.
@@ -443,7 +450,6 @@ export const buildResearchSystemPrompt = (args: {
 		'For a citation to a page you scraped, set source_id to the exact URL you scraped with scrape_page. Never invent an identifier — a made-up source is dropped.',
 		'When you search, use plain keywords, and only add a site: filter for a real domain you know — never a placeholder like site:example.com.',
 		'For discovery or prospecting queries, prefer authoritative sources — business directories, industry association member lists, and sector registries — over social media, forums, or glossary pages.',
-		'When extracting structured data from a single page, use the company_enrichment_v1 schema (a per-company shape), not a whole-run aggregate schema.',
 		`Output schema: ${args.schemaName}`,
 		args.subjectContext,
 		args.hintsContext,
@@ -1180,6 +1186,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 					const extractStructuredFindings = (
 						transcript: string,
 						evidenceCorpus: string,
+						pages: ReadonlyArray<string> = [],
 					) =>
 						Effect.gen(function* () {
 							yield* publishEvent(researchId, 'tool.called', {
@@ -1202,16 +1209,39 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								sourceManifest.length > 0
 									? `For each citation, prefer one of these exact fetched source URLs, copied verbatim — especially the company's own official website:\n\n${sourceManifest}\n\nIf a value appears only in a search result in the transcript, still include it and quote the snippet, citing that result's URL — do not drop a real fact just because its page was not fetched.`
 									: "Cite the URL each value came from; if it was only a search result, quote its snippet and cite that result's URL."
+							// The full fetched pages, ahead of the transcript, so a fact past the
+							// transcript's per-result cut still reaches extraction. Bounded so a
+							// handful of long pages can't blow up the phase-2 prompt.
+							const pagesSection = (() => {
+								const parts: string[] = []
+								let total = 0
+								for (const text of pages) {
+									if (text.trim().length === 0) continue
+									const remaining = MAX_EXTRACTION_PAGE_CHARS - total
+									if (remaining <= 0) break
+									const slice =
+										text.length > remaining
+											? `${text.slice(0, remaining)}…[truncated]`
+											: text
+									parts.push(slice)
+									total += slice.length
+								}
+								return parts.length > 0
+									? `Fetched pages (primary evidence — read these first):\n\n${parts.join('\n\n---\n\n')}\n\n`
+									: ''
+							})()
 							// Cast schema to satisfy generateObject's Encoder constraint.
 							// Registry schemas are all Structs with DecodingServices=never,
 							// but Schema.Top erases that — the cast is safe.
 							const structuredResponse = yield* extractLlm.generateObject({
 								schema: outputSchema as typeof FreeformSchema,
 								// Ground the extraction: the model may only output values that
-								// appear in the transcript, and must leave unsupported fields
+								// appear in the evidence, and must leave unsupported fields
 								// empty rather than filling them from prior knowledge — otherwise
-								// it will confidently invent phones, tax ids, and emails.
-								prompt: `Produce structured findings STRICTLY from the research transcript below. Only include a value that appears in the transcript; if the transcript does not support a field, omit it or leave it null — never fill a field from prior knowledge.\n\n${citationInstruction}\n\nResearch transcript:\n\n${transcript}`,
+								// it will confidently invent phones, tax ids, and emails. Never
+								// emit a schema field's name or a placeholder ("headquarters",
+								// "unknown") as a value; omit a field with no real value instead.
+								prompt: `Produce structured findings STRICTLY from the evidence below (the fetched pages and the research transcript). Only include a value that appears in the evidence; if it does not support a field, omit it or leave it null — never fill a field from prior knowledge, and never put a placeholder or the field's own name as its value.\n\n${citationInstruction}\n\n${pagesSection}Research transcript:\n\n${transcript}`,
 							})
 							let result = withProposalIds(structuredResponse.value as unknown)
 							// Drop citations the model invented: keep only source_ids that map
@@ -1238,6 +1268,38 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									}),
 								)
 							}
+							// Scalar grounding: hold each per-field value to "grounded or absent".
+							// The citation guard has just removed fabricated sources, so a scalar
+							// left without one is dropped here rather than shipped unsourced; a
+							// placeholder word or a quote that does not back the value goes too.
+							const scalarCheck = guardScalarFields(result, evidenceCorpus)
+							result = scalarCheck.findings
+							if (
+								scalarCheck.droppedPlaceholder > 0 ||
+								scalarCheck.droppedUngrounded > 0 ||
+								scalarCheck.droppedUnsupported > 0
+							) {
+								yield* Effect.logWarning('research.fields.ungrounded').pipe(
+									Effect.annotateLogs({
+										research_id: researchId,
+										dropped_placeholder: scalarCheck.droppedPlaceholder,
+										dropped_ungrounded: scalarCheck.droppedUngrounded,
+										dropped_unsupported: scalarCheck.droppedUnsupported,
+									}),
+								)
+							}
+							// Grounding telemetry on the phase-2 span, so the share of fields a
+							// run drops for want of a real source is a dashboard, not an anecdote.
+							yield* Effect.annotateCurrentSpan({
+								'research.citations.total': citationCheck.total,
+								'research.citations.kept': citationCheck.kept,
+								'research.fields.dropped_placeholder':
+									scalarCheck.droppedPlaceholder,
+								'research.fields.dropped_ungrounded':
+									scalarCheck.droppedUngrounded,
+								'research.fields.dropped_unsupported':
+									scalarCheck.droppedUnsupported,
+							})
 							// Value provenance: the citation guard proved the cited pages were
 							// fetched, not that they contain the claimed values. Drop any
 							// proposed CRM write whose email/phone/tax-id value appears nowhere
@@ -1713,6 +1775,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 										loop.evidenceText,
 										...scrapeCorpus.map(page => page.text),
 									].join('\n'),
+									scrapeCorpus.map(page => page.text),
 								)
 								findings = extracted.findings
 								extractOutputTokens += extracted.outputTokens
@@ -1760,6 +1823,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 											loop.evidenceText,
 											...scrapeCorpus.map(page => page.text),
 										].join('\n'),
+										scrapeCorpus.map(page => page.text),
 									)
 									findings = extracted.findings
 									extractOutputTokens += extracted.outputTokens
@@ -1858,6 +1922,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									evidenceText,
 									...groundedPageTexts(entityTargets, scrapeCorpus),
 								].join('\n'),
+								groundedPageTexts(entityTargets, scrapeCorpus),
 							)
 							findings = extracted.findings
 							tokensOut += extracted.outputTokens

--- a/packages/research/src/application/scalar-field-guard.test.ts
+++ b/packages/research/src/application/scalar-field-guard.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from 'vitest'
+
+import { guardScalarFields } from './scalar-field-guard'
+
+// The evidence the run gathered, against which quotes are checked. Kept small and
+// explicit per test so it is obvious what is and isn't grounded.
+interface EnrichmentView {
+	industry?: unknown
+	size_range?: unknown
+	location?: unknown
+	country?: unknown
+	address?: unknown
+	current_tools?: unknown
+}
+const enrichment = (findings: unknown): EnrichmentView =>
+	(findings as { enrichment: EnrichmentView }).enrichment
+
+describe('guardScalarFields', () => {
+	describe('when a field holds a placeholder or the schema word', () => {
+		it('should drop the literal word "headquarters" in the location field', () => {
+			// GIVEN the Circle case: the extractor echoed the schema instead of a place
+			const findings = {
+				enrichment: {
+					location: {
+						value: 'headquarters',
+						source_id: 'https://circle.com',
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(findings, 'circle logistics fort wayne')
+
+			// THEN the field is gone, counted as a placeholder drop
+			expect(enrichment(result.findings).location).toBeNull()
+			expect(result.droppedPlaceholder).toBe(1)
+		})
+
+		it('should drop a value that is just the field name', () => {
+			// GIVEN a value echoing its own key
+			const findings = {
+				enrichment: {
+					industry: {
+						value: 'industry',
+						source_id: 'https://acme.es',
+						confidence: 0.5,
+					},
+				},
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(findings, 'acme sells shoes')
+
+			// THEN dropped as a placeholder
+			expect(enrichment(result.findings).industry).toBeNull()
+			expect(result.droppedPlaceholder).toBe(1)
+		})
+
+		it('should drop generic non-answers like "unknown"', () => {
+			// GIVEN a filled-but-empty value
+			const findings = {
+				enrichment: {
+					size_range: {
+						value: 'unknown',
+						source_id: 'https://acme.es',
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(findings, 'acme is a small firm')
+
+			// THEN dropped
+			expect(enrichment(result.findings).size_range).toBeNull()
+			expect(result.droppedPlaceholder).toBe(1)
+		})
+	})
+
+	describe('when a field carries no fetched source', () => {
+		it('should drop a bare value with no source_id', () => {
+			// GIVEN the Redwood/ITS shape: a value with provenance but no source_id
+			// (the citation guard strips a fabricated source to exactly this)
+			const findings = {
+				enrichment: {
+					address: {
+						value: '2811 West Carson Street, Suite 200, Pittsburgh, PA',
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(
+				findings,
+				'redwood logistics is headquartered in chicago, illinois',
+			)
+
+			// THEN the unsourced fact is treated as absent
+			expect(enrichment(result.findings).address).toBeNull()
+			expect(result.droppedUngrounded).toBe(1)
+		})
+
+		it('should drop a value whose source_id is blank', () => {
+			// GIVEN an empty-string source_id
+			const findings = {
+				enrichment: {
+					country: { value: 'ES', source_id: '   ', confidence: 0.8 },
+				},
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(findings, 'based in catalonia, spain')
+
+			// THEN dropped as ungrounded
+			expect(enrichment(result.findings).country).toBeNull()
+			expect(result.droppedUngrounded).toBe(1)
+		})
+	})
+
+	describe('when a literal field quote does not back the value', () => {
+		it('should drop the Sunset location whose quote never mentions it', () => {
+			// GIVEN a location taken from the query, quoted with an unrelated snippet
+			const findings = {
+				enrichment: {
+					location: {
+						value: 'St. Louis, Missouri, USA',
+						source_id: 'https://sunsettrans.com',
+						quote: 'second generation Midwest roots',
+						confidence: 0.3,
+					},
+				},
+			}
+
+			// WHEN grounded against a corpus that DOES contain the quote
+			const result = guardScalarFields(
+				findings,
+				'a company with second generation midwest roots serving shippers',
+			)
+
+			// THEN the field is dropped: the quote is real but supports nothing
+			expect(enrichment(result.findings).location).toBeNull()
+			expect(result.droppedUnsupported).toBe(1)
+		})
+
+		it('should keep a location whose quote actually names it', () => {
+			// GIVEN a grounded location whose quote contains the place
+			const findings = {
+				enrichment: {
+					location: {
+						value: 'Chicago, IL',
+						source_id: 'https://redwood.com',
+						quote: 'Redwood is headquartered in Chicago, Illinois',
+						confidence: 0.9,
+					},
+				},
+			}
+
+			// WHEN grounded against a corpus containing the quote
+			const result = guardScalarFields(
+				findings,
+				'redwood is headquartered in chicago, illinois since 2001',
+			)
+
+			// THEN it survives untouched
+			expect(enrichment(result.findings).location).toEqual(
+				findings.enrichment.location,
+			)
+			expect(result.droppedUnsupported).toBe(0)
+		})
+	})
+
+	describe('when a quote is largely absent from the evidence', () => {
+		it('should drop a field whose quote was invented', () => {
+			// GIVEN a plausible value but a quote whose words appear nowhere fetched
+			const findings = {
+				enrichment: {
+					current_tools: {
+						value: 'SAP ERP',
+						source_id: 'https://acme.es',
+						quote:
+							'we run our operations entirely on Oracle NetSuite and Salesforce',
+						confidence: 0.8,
+					},
+				},
+			}
+
+			// WHEN grounded against a corpus that never mentions those tools
+			const result = guardScalarFields(
+				findings,
+				'acme is a logistics firm serving european shippers',
+			)
+
+			// THEN the fabricated-quote field is dropped
+			expect(enrichment(result.findings).current_tools).toBeNull()
+			expect(result.droppedUnsupported).toBe(1)
+		})
+	})
+
+	describe('when a field is paraphrased or coded, not verbatim', () => {
+		it('should keep an industry whose quote paraphrases it', () => {
+			// GIVEN industry (a non-literal field): the quote supports the category
+			// without repeating the word, so a text-overlap test must NOT reject it
+			const findings = {
+				enrichment: {
+					industry: {
+						value: 'manufacturing',
+						source_id: 'https://acme.es',
+						quote: 'a leading manufacturer of industrial pumps',
+						confidence: 0.9,
+					},
+				},
+			}
+
+			// WHEN grounded against a corpus containing the quote
+			const result = guardScalarFields(
+				findings,
+				'acme is a leading manufacturer of industrial pumps in europe',
+			)
+
+			// THEN it survives — industry is not held to verbatim overlap
+			expect(enrichment(result.findings).industry).toEqual(
+				findings.enrichment.industry,
+			)
+			expect(result.droppedUnsupported).toBe(0)
+		})
+
+		it('should keep a size band whose quote gives a different but supporting number', () => {
+			// GIVEN size_range (coded): value is a band, quote is a headcount
+			const findings = {
+				enrichment: {
+					size_range: {
+						value: '51-200',
+						source_id: 'https://acme.es',
+						quote: 'our team of 120 people',
+						confidence: 0.7,
+					},
+				},
+			}
+
+			// WHEN grounded against a corpus containing the quote
+			const result = guardScalarFields(findings, 'acme, our team of 120 people')
+
+			// THEN kept — size is not a literal field
+			expect(enrichment(result.findings).size_range).toEqual(
+				findings.enrichment.size_range,
+			)
+		})
+
+		it('should keep an everyday-word value that is a real industry, not a placeholder', () => {
+			// GIVEN a software company: "software" is an everyday word but a genuine
+			// industry value, so it must not be mistaken for a schema placeholder
+			const findings = {
+				enrichment: {
+					industry: {
+						value: 'software',
+						source_id: 'https://acme.es',
+						quote: 'Acme builds software for logistics teams',
+						confidence: 0.9,
+					},
+				},
+			}
+
+			// WHEN grounded against a corpus containing the quote
+			const result = guardScalarFields(
+				findings,
+				'acme builds software for logistics teams',
+			)
+
+			// THEN it survives
+			expect(enrichment(result.findings).industry).toEqual(
+				findings.enrichment.industry,
+			)
+			expect(result.droppedPlaceholder).toBe(0)
+		})
+	})
+
+	describe('when the field is a contact channel', () => {
+		it('should leave email and phone to the value guard', () => {
+			// GIVEN an unsourced email + phone the value guard owns
+			const findings = {
+				contacts: [
+					{
+						name: 'Ada',
+						email: { value: 'ada@acme.es', confidence: null },
+						phone: { value: '+34 600 000 000', confidence: null },
+					},
+				],
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(findings, 'contact ada@acme.es')
+
+			// THEN neither channel is touched here (no source_id required of them)
+			const contact = (
+				result.findings as { contacts: Array<Record<string, unknown>> }
+			).contacts[0]
+			expect(contact?.['email']).toEqual({
+				value: 'ada@acme.es',
+				confidence: null,
+			})
+			expect(contact?.['phone']).toEqual({
+				value: '+34 600 000 000',
+				confidence: null,
+			})
+			expect(result.droppedUngrounded).toBe(0)
+		})
+
+		it('should still ground a contact role', () => {
+			// GIVEN a role (not a channel) with no source
+			const findings = {
+				contacts: [{ name: 'Ada', role: { value: 'CEO', confidence: null } }],
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(findings, 'ada is the ceo')
+
+			// THEN the unsourced role is dropped
+			const contact = (
+				result.findings as { contacts: Array<Record<string, unknown>> }
+			).contacts[0]
+			expect(contact?.['role']).toBeNull()
+			expect(result.droppedUngrounded).toBe(1)
+		})
+	})
+
+	describe('when the shape holds subtrees that are not scalar fields', () => {
+		it('should not walk into citations or proposed_updates', () => {
+			// GIVEN a citation entry and a proposed-update blob that could look field-ish
+			const findings = {
+				enrichment: {},
+				competitors: [
+					{ name: 'Rival', citations: [{ source_id: 'x', quote: 'a rival' }] },
+				],
+				proposed_updates: [
+					{
+						subject_id: 'c1',
+						fields: { value: 'headquarters' },
+						citations: [{ source_id: 'x' }],
+					},
+				],
+			}
+
+			// WHEN grounded
+			const result = guardScalarFields(findings, 'some evidence')
+
+			// THEN those subtrees are untouched (no drops)
+			expect(result.droppedPlaceholder).toBe(0)
+			expect(result.droppedUngrounded).toBe(0)
+			expect(result.droppedUnsupported).toBe(0)
+			expect(
+				(result.findings as { proposed_updates: unknown[] }).proposed_updates,
+			).toEqual(findings.proposed_updates)
+		})
+	})
+
+	describe('when no corpus is supplied', () => {
+		it('should skip the quote-in-evidence check but still drop placeholders and unsourced values', () => {
+			// GIVEN a grounded field with a quote, plus a placeholder, plus an unsourced one
+			const findings = {
+				enrichment: {
+					industry: {
+						value: 'retail',
+						source_id: 'https://acme.es',
+						quote: 'a shop we could not re-verify',
+						confidence: 0.9,
+					},
+					location: {
+						value: 'headquarters',
+						source_id: 'https://acme.es',
+						confidence: null,
+					},
+					country: { value: 'ES', confidence: 0.5 },
+				},
+			}
+
+			// WHEN grounded with an empty corpus
+			const result = guardScalarFields(findings, '')
+
+			// THEN the quote check is skipped (industry kept) but the other rules still fire
+			expect(enrichment(result.findings).industry).toEqual(
+				findings.enrichment.industry,
+			)
+			expect(enrichment(result.findings).location).toBeNull()
+			expect(enrichment(result.findings).country).toBeNull()
+			expect(result.droppedPlaceholder).toBe(1)
+			expect(result.droppedUngrounded).toBe(1)
+		})
+	})
+})

--- a/packages/research/src/application/scalar-field-guard.ts
+++ b/packages/research/src/application/scalar-field-guard.ts
@@ -1,0 +1,228 @@
+/**
+ * Holds the per-field `Sourced` scalars (industry, size, location, tools, a
+ * contact's role, …) to a "grounded value or nothing" contract.
+ *
+ * The other guards leave a gap here. The citation guard proves the cited page was
+ * fetched; the value guard only checks emails and phone/tax-id digits; the critic
+ * is a fail-open model call that keeps a thinly-supported value at low confidence
+ * rather than removing it. So a free-text scalar could still ship as a bare value
+ * with no real source, as a schema word the model emitted instead of a fact
+ * ("headquarters" in the location field), or paired with a quote that does not
+ * actually mention it. This guard closes that gap deterministically, before the
+ * model-backed critic runs.
+ *
+ * For each per-field `Sourced` scalar it drops the whole field (to null) when:
+ *  - the value is a placeholder or the field's own name, not a real fact;
+ *  - it carries no fetched source at all — an unsourced fact is treated as absent;
+ *  - its quote is largely missing from the gathered evidence (a fabricated quote);
+ *  - for a field whose value should read verbatim from the page (location, tools),
+ *    the quote shares nothing with the value it claims to back.
+ *
+ * Email and phone fields are left to the value guard, which checks them against the
+ * evidence far more precisely than a text-overlap test could. Citation arrays and
+ * the freeform proposed-update blob are skipped so their internal shapes are never
+ * mistaken for a scalar field.
+ */
+
+// Generic non-answers a model emits when it has nothing — never a real value.
+const PLACEHOLDER_VALUES = new Set([
+	'',
+	'-',
+	'—',
+	'?',
+	'n/a',
+	'n.a.',
+	'na',
+	'none',
+	'null',
+	'nil',
+	'undefined',
+	'unknown',
+	'not available',
+	'not found',
+	'not specified',
+	'not applicable',
+	'no data',
+	'no information',
+	'tbd',
+	'value',
+	'string',
+])
+
+// Stand-in words a model emits in place of a real location — "headquarters" is
+// never itself a place. Kept deliberately narrow: a value that merely echoes its
+// own field name ("location" in the location field) is caught by the field-name
+// check below, and everyday words like "software" or "business" are dropped from
+// this set on purpose, since they are legitimate values for the industry or tools
+// fields and must not be mistaken for placeholders.
+const SCHEMA_WORDS = new Set([
+	'headquarters',
+	'head office',
+	'headquarter',
+	'hq',
+])
+
+// Fields whose value is meant to read straight off the page (a city name, a tool's
+// name), so its supporting quote should actually contain it. Coded or paraphrased
+// fields (industry, size band, the ISO country code) are deliberately excluded —
+// their value is a category, not a span, so a text-overlap test would wrongly
+// reject them.
+const QUOTE_LITERAL_FIELDS = new Set(['location', 'current_tools'])
+
+// Contact channels the value guard already checks against the evidence far more
+// precisely than a text test could, so this guard leaves them alone.
+const CHANNEL_KEYS = new Set(['email', 'phone', 'whatsapp'])
+
+// Subtrees that are not scalar fields: the block-level citation arrays and the
+// freeform proposed-update JSON, whose contents could otherwise look like a field.
+const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
+
+// A quote counts as real when at least this share of its distinctive words appear
+// in the gathered evidence. Set low so a lightly paraphrased real quote survives
+// and only a wholesale-invented one (almost none of its words present) is dropped.
+const QUOTE_PRESENCE_THRESHOLD = 0.5
+
+const normalize = (value: string): string =>
+	value
+		.toLowerCase()
+		.trim()
+		.replace(/\s+/g, ' ')
+		.replace(/[.,;:!?"'`()]+$/g, '')
+
+// The distinctive words of a string: long-enough words and multi-digit numbers,
+// which carry the meaning (place names, tool names, employee counts) — short
+// function words are dropped so they can't create coincidental overlaps.
+const salientTokens = (value: string): ReadonlyArray<string> =>
+	normalize(value)
+		.split(/[^a-z0-9]+/)
+		.filter(token => token.length >= 4 || /^\d{2,}$/.test(token))
+
+const isPlaceholderValue = (value: string, key: string): boolean => {
+	const n = normalize(value)
+	if (PLACEHOLDER_VALUES.has(n)) return true
+	if (SCHEMA_WORDS.has(n)) return true
+	// The value is just the field's own name (`location` → "location").
+	return n === normalize(key.replace(/_/g, ' '))
+}
+
+// The quote backs the value when it contains it outright or shares one of its
+// distinctive words. A value with no distinctive words (all short) can't be judged
+// this way, so it is given the benefit of the doubt.
+const quoteSupportsValue = (quote: string, value: string): boolean => {
+	const nq = normalize(quote)
+	const nv = normalize(value)
+	if (nv.length > 0 && nq.includes(nv)) return true
+	const tokens = salientTokens(value)
+	if (tokens.length === 0) return true
+	return tokens.some(token => nq.includes(token))
+}
+
+// Most of the quote's distinctive words appear somewhere in the gathered evidence,
+// so it was copied from a real page rather than invented.
+const quoteIsInCorpus = (quote: string, lowerCorpus: string): boolean => {
+	const tokens = salientTokens(quote)
+	if (tokens.length === 0) return true
+	const present = tokens.filter(token => lowerCorpus.includes(token)).length
+	return present / tokens.length >= QUOTE_PRESENCE_THRESHOLD
+}
+
+// A per-field Sourced wrapper: `{ value, source_id?, quote?, confidence? }`. Keys on
+// its own `value` beside at least one provenance field, which distinguishes it from
+// an arbitrary object that merely happens to have a `value` property.
+const isSourcedField = (
+	v: unknown,
+): v is {
+	value: unknown
+	source_id?: unknown
+	quote?: unknown
+	confidence?: unknown
+} =>
+	v !== null &&
+	typeof v === 'object' &&
+	!Array.isArray(v) &&
+	'value' in v &&
+	('source_id' in v || 'quote' in v || 'confidence' in v)
+
+export interface ScalarFieldGuardResult {
+	readonly findings: unknown
+	/** Fields dropped because the value was a placeholder or the field's own name. */
+	readonly droppedPlaceholder: number
+	/** Fields dropped because no fetched source backed the value. */
+	readonly droppedUngrounded: number
+	/** Fields dropped because the quote did not support or was absent from evidence. */
+	readonly droppedUnsupported: number
+}
+
+/**
+ * Enforce the grounded-or-absent contract on every per-field `Sourced` scalar in a
+ * run's findings. `corpus` is the same evidence text the value guard checks against
+ * — the run's fetched pages and tool results, never the model's own prose; pass an
+ * empty string to skip the "quote is really in the evidence" check.
+ */
+export const guardScalarFields = (
+	findings: unknown,
+	corpus: string,
+): ScalarFieldGuardResult => {
+	const lowerCorpus = corpus.toLowerCase()
+	let droppedPlaceholder = 0
+	let droppedUngrounded = 0
+	let droppedUnsupported = 0
+
+	const walk = (value: unknown, key: string | undefined): unknown => {
+		if (Array.isArray(value)) return value.map(item => walk(item, undefined))
+		if (value === null || typeof value !== 'object') return value
+
+		if (isSourcedField(value) && key !== undefined && !CHANNEL_KEYS.has(key)) {
+			const wrapper = value as {
+				value: unknown
+				source_id?: unknown
+				quote?: unknown
+			}
+			// Only text scalars are judged here; a non-string value is left as-is.
+			if (typeof wrapper.value !== 'string') return value
+			if (isPlaceholderValue(wrapper.value, key)) {
+				droppedPlaceholder++
+				return null
+			}
+			// An unsourced fact is treated as absent: the citation guard has already
+			// stripped every fabricated source_id, so a field with none left never
+			// reached a fetched page.
+			if (
+				typeof wrapper.source_id !== 'string' ||
+				wrapper.source_id.trim() === ''
+			) {
+				droppedUngrounded++
+				return null
+			}
+			const quote =
+				typeof wrapper.quote === 'string' ? wrapper.quote.trim() : ''
+			if (quote !== '') {
+				if (corpus !== '' && !quoteIsInCorpus(quote, lowerCorpus)) {
+					droppedUnsupported++
+					return null
+				}
+				if (
+					QUOTE_LITERAL_FIELDS.has(key) &&
+					!quoteSupportsValue(quote, wrapper.value)
+				) {
+					droppedUnsupported++
+					return null
+				}
+			}
+			return value
+		}
+
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>).map(([k, v]) =>
+				SKIP_KEYS.has(k) ? [k, v] : [k, walk(v, k)],
+			),
+		)
+	}
+
+	return {
+		findings: walk(findings, undefined),
+		droppedPlaceholder,
+		droppedUngrounded,
+		droppedUnsupported,
+	}
+}

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -13,8 +13,6 @@ import {
 } from './contact-discovery'
 import {
 	Budget,
-	type ExtractInput,
-	ExtractProvider,
 	type RegistryInput,
 	RegistryRouter,
 	ResearchRunContext,
@@ -24,7 +22,6 @@ import {
 	SearchProvider,
 } from './ports'
 import {
-	ExtractStructuredTool,
 	isUnsupportedScrapeUrl,
 	RegistryLookupTool,
 	researchToolkit,
@@ -231,36 +228,6 @@ const scrapePageResult = async (
 	return { result: last?.result, isFailure: last?.isFailure ?? false }
 }
 
-const extractStructuredResult = async (
-	extract: (input: ExtractInput) => Effect.Effect<unknown, ProviderError>,
-	params: { url: string; schema_name: string },
-): Promise<{ result: unknown; isFailure: boolean }> => {
-	const ports = Layer.mergeAll(
-		Layer.succeed(ExtractProvider)(ExtractProvider.of({ extract })),
-		StubSearchProvider,
-		StubScrapeProvider,
-		StubRegistryEsProvider,
-	)
-	const results = await Effect.runPromise(
-		Effect.gen(function* () {
-			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('extract_structured', {
-				prompt: null,
-				...params,
-			})
-			return yield* Stream.runCollect(stream)
-		}).pipe(
-			Effect.provide(
-				researchToolkitLayer.pipe(
-					Layer.provide(Layer.mergeAll(ports, testInfra)),
-				),
-			),
-		),
-	)
-	const last = results[results.length - 1]
-	return { result: last?.result, isFailure: last?.isFailure ?? false }
-}
-
 const webSearchResult = async (
 	search: (input: SearchInput) => Effect.Effect<SearchResult, ProviderError>,
 	params: { query: string },
@@ -291,49 +258,6 @@ const webSearchResult = async (
 	)
 	const last = results[results.length - 1]
 	return { result: last?.result, isFailure: last?.isFailure ?? false }
-}
-
-const extractInput = async (params: {
-	url: string
-	schema_name: string
-	prompt?: string | null
-}): Promise<ExtractInput> => {
-	let captured: ExtractInput | undefined
-	const ports = Layer.mergeAll(
-		Layer.succeed(ExtractProvider)(
-			ExtractProvider.of({
-				extract: input => {
-					captured = input
-					return Effect.succeed({})
-				},
-			}),
-		),
-		StubSearchProvider,
-		StubScrapeProvider,
-		StubRegistryEsProvider,
-	)
-	await Effect.runPromise(
-		Effect.gen(function* () {
-			const toolkit = yield* researchToolkit
-			const stream = yield* toolkit.handle('extract_structured', {
-				prompt: null,
-				...params,
-			})
-			yield* Stream.runDrain(stream)
-		}).pipe(
-			Effect.provide(
-				researchToolkitLayer.pipe(
-					Layer.provide(Layer.mergeAll(ports, testInfra)),
-				),
-			),
-		),
-	)
-	if (captured === undefined) {
-		throw new Error(
-			'extract_structured handler never called the extract provider',
-		)
-	}
-	return captured
 }
 
 const scrapeInput = async (params: { url: string }): Promise<ScrapeInput> => {
@@ -571,39 +495,6 @@ describe('researchToolkit tool params — model-emitted null is treated as omitt
 		})
 	})
 
-	describe('extract_structured handler', () => {
-		describe('when prompt is null', () => {
-			it('should hand the extractor undefined for prompt', async () => {
-				// GIVEN a registered schema name and a null prompt
-				// WHEN the extract_structured tool call is handled
-				const input = await extractInput({
-					url: 'https://acmecorp.es',
-					schema_name: 'freeform',
-					prompt: null,
-				})
-
-				// THEN the null prompt folds to undefined while schema wiring is preserved
-				expect(input.prompt).toBeUndefined()
-				expect(input.schemaName).toBe('freeform')
-			})
-		})
-
-		describe('when prompt carries a value', () => {
-			it('should pass it through', async () => {
-				// GIVEN extra guidance for the extractor
-				// WHEN handled
-				const input = await extractInput({
-					url: 'https://acmecorp.es',
-					schema_name: 'freeform',
-					prompt: 'focus on revenue figures',
-				})
-
-				// THEN the prompt reaches the extractor unchanged
-				expect(input.prompt).toBe('focus on revenue figures')
-			})
-		})
-	})
-
 	describe('scrape_page handler (no optional params — unaffected by the fix)', () => {
 		describe('when called with a url', () => {
 			it('should pass the url through and request the markdown format', async () => {
@@ -637,11 +528,6 @@ describe('researchToolkit tool params — model-emitted null is treated as omitt
 				expect(web.limit).toBeNull()
 				expect(web.recency_days).toBeNull()
 				expect(web.location).toBeNull()
-
-				const extract = Schema.decodeUnknownSync(
-					ExtractStructuredTool.parametersSchema,
-				)({ url: 'https://x.test', schema_name: 'freeform', prompt: null })
-				expect(extract.prompt).toBeNull()
 
 				const registry = Schema.decodeUnknownSync(
 					RegistryLookupTool.parametersSchema,
@@ -802,52 +688,6 @@ describe('researchToolkit — a web-fetch failure is non-fatal', () => {
 
 				// THEN the model receives a failure result and the run continues
 				expect(isFailure).toBe(true)
-			})
-		})
-	})
-
-	describe('extract_structured handler', () => {
-		describe('when the extract provider fails with a forbidden ProviderError', () => {
-			it('should surface the failure to the model instead of aborting the run', async () => {
-				// GIVEN an extract provider that rejects the page with a 403 (forbidden)
-				const { isFailure } = await extractStructuredResult(
-					() =>
-						Effect.fail(
-							new ProviderError({
-								provider: 'firecrawl',
-								message: 'extract failed: HTTP 403',
-								recoverable: false,
-							}),
-						),
-					{ url: 'https://acmecorp.es', schema_name: 'freeform' },
-				)
-
-				// THEN the model reads the failure and moves on — the generateText
-				// fiber is not killed, so one forbidden page can't sink the whole run
-				expect(isFailure).toBe(true)
-			})
-		})
-
-		describe('when schema_name is not a registered schema', () => {
-			it('should surface the plain validation message, not a re-wrapped failure cause', async () => {
-				// GIVEN a schema_name the model made up — the extract provider is never
-				// reached, so its result here is irrelevant
-				const { isFailure, result } = await extractStructuredResult(
-					() => Effect.succeed({}),
-					{ url: 'https://acmecorp.es', schema_name: 'totally_bogus_schema' },
-				)
-
-				// THEN the model reads a failure...
-				expect(isFailure).toBe(true)
-				// AND the message names the bad value and lists the valid ones in
-				// plain text, not a stringified Cause/Fail dump — that shape appears
-				// if this validation error is ever re-caught and re-wrapped by the
-				// same handling that logs a genuine provider failure
-				const description = (result as { reason: { description: string } })
-					.reason.description
-				expect(description).toBe(
-					'extract_structured: Unknown schema_name: totally_bogus_schema. Valid names: freeform, company_enrichment_v1, competitor_scan_v1, contact_discovery_v1, prospect_scan_v1',
-				)
 			})
 		})
 	})

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -26,15 +26,12 @@ import { ScrapedPage } from '../domain/types'
 import { ContactDiscovery } from './contact-discovery'
 import {
 	Budget,
-	ExtractProvider,
 	RegistryRouter,
 	ResearchRunContext,
 	ScrapeProvider,
 	SearchProvider,
 } from './ports'
-import { schemaRegistry } from './schemas/index'
 import {
-	EXTRACT_COST_CENTS,
 	REGISTRY_LOOKUP_COST_CENTS,
 	SCRAPE_COST_CENTS,
 	SEARCH_COST_CENTS,
@@ -72,19 +69,6 @@ const WebSearchParams = Schema.Struct({
 
 const ScrapePageParams = Schema.Struct({
 	url: Schema.String.annotate({ description: 'Absolute URL to scrape' }),
-})
-
-const ExtractStructuredParams = Schema.Struct({
-	url: Schema.String.annotate({
-		description: 'URL of the page whose content should be re-extracted',
-	}),
-	schema_name: Schema.String.annotate({
-		description: `Name of a registered schema. One of: ${Object.keys(schemaRegistry).join(', ')}`,
-	}),
-	prompt: Schema.NullOr(Schema.String).annotate({
-		description:
-			'Optional extra guidance for the extractor (e.g. "focus on revenue figures"); null for none.',
-	}),
 })
 
 const RegistryLookupParams = Schema.Struct({
@@ -141,14 +125,6 @@ export const ScrapePageTool = Tool.make('scrape_page', {
 	failureMode: 'return',
 })
 
-export const ExtractStructuredTool = Tool.make('extract_structured', {
-	description:
-		'Re-extract a page into a named structured schema. Use when downstream consumers need typed fields rather than prose.',
-	parameters: ExtractStructuredParams,
-	success: ToolResultSchema,
-	failureMode: 'return',
-})
-
 export const RegistryLookupTool = Tool.make('registry_lookup', {
 	description:
 		'Look up a company in its national business registry. Accepts any ISO country; one without a national registry returns {status:"no_registry"} — use discover_contacts for contact enrichment there. Metered (~€0.29/lookup), so use it to confirm a specific company rather than browsing. Returns legal name, tax id, status, and (when available) directors.',
@@ -166,7 +142,6 @@ export const DiscoverContactsTool = Tool.make('discover_contacts', {
 export const researchToolkit = Toolkit.make(
 	WebSearchTool,
 	ScrapePageTool,
-	ExtractStructuredTool,
 	RegistryLookupTool,
 	DiscoverContactsTool,
 )
@@ -273,14 +248,13 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 	Effect.gen(function* () {
 		const search = yield* SearchProvider
 		const scrape = yield* ScrapeProvider
-		const extract = yield* ExtractProvider
 		const registry = yield* RegistryRouter
 		const contactDiscovery = yield* ContactDiscovery
 		const budget = yield* Budget
 		const { researchId } = yield* ResearchRunContext
 
 		// Charged against the run before each vendor call (cheap tier for
-		// search/scrape/extract, paid tier for the registry). When the budget
+		// search/scrape, paid tier for the registry). When the budget
 		// refuses, the refusal is handed back to the model as a tool result so it
 		// stops using that tool and wraps up; the loop's own budget check is the
 		// hard halt. Logged at warning (not error) since running out of budget is
@@ -398,47 +372,6 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 						},
 					}),
 				),
-
-			extract_structured: params => {
-				// Both branches reuse these span options so the early return still
-				// emits a research.tool.extract_structured span, but only the
-				// extraction branch runs through catchCause below. An unknown
-				// schema_name is an expected, model-caused error whose message is
-				// already clean; sending it through catchCause too would re-wrap and
-				// pretty-print the cause, burying that message in an unreadable dump.
-				const spanOptions = {
-					attributes: {
-						'research.tool': 'extract_structured',
-						'research.run_id': researchId,
-						url: params.url,
-						schema_name: params.schema_name,
-					},
-				}
-				const schema = schemaRegistry[params.schema_name]
-				if (!schema) {
-					return mapToolError('extract_structured')(
-						`Unknown schema_name: ${params.schema_name}. Valid names: ${Object.keys(schemaRegistry).join(', ')}`,
-					).pipe(
-						Effect.withSpan('research.tool.extract_structured', spanOptions),
-					)
-				}
-				return Effect.gen(function* () {
-					yield* budget.chargeCheap('extract', EXTRACT_COST_CENTS)
-					return yield* extract.extract({
-						url: params.url,
-						schema,
-						schemaName: params.schema_name,
-						prompt: params.prompt ?? undefined,
-					})
-				}).pipe(
-					Effect.catchTag(
-						'BudgetExceeded',
-						cheapExhausted('extract_structured'),
-					),
-					Effect.catchCause(logToolFailure('extract_structured')),
-					Effect.withSpan('research.tool.extract_structured', spanOptions),
-				)
-			},
 
 			registry_lookup: params =>
 				Effect.gen(function* () {


### PR DESCRIPTION
## What

When you research a company, the useful output isn't the prose brief — it's the **structured record** a caller can act on (leadership contacts, size, tooling, location). On the current release that record comes back nearly empty or filled with junk even when the agent clearly found the facts: a company's location shipped as the literal word "headquarters", a fabricated street address appeared with no source, and more than half of runs returned zero contacts. This PR makes the structured extraction (the CRM's **Research** context, `server`/`cli`) only keep facts it can actually stand behind, and lets it see the full pages the agent fetched so real facts stop getting cut off.

It also fixes an unrelated developer-tooling papercut: a fresh git worktree could refuse to boot because a required setting was missing from its generated `.env`.

This is **PR #1 of two**. It fixes the grounding (precision) and the truncation-driven recall gap. PR #2 will add a dedicated contacts-and-titles extraction pass and per-contact entity binding.

## The fix

- **Grounded value or nothing.** A new deterministic guard holds every per-field value (industry, size, location, tools, a contact's role) to a simple contract: keep it only if a fetched page backs it. It drops a value that is a filler word ("headquarters", "unknown") or the field's own name, one that kept no real source after the citation check, and — for fields whose value should read straight off the page (location, address, region, tools) — one whose supporting quote never mentions it. The citation guard now drops such a scalar field entirely instead of shipping it stripped of its source.
- **Let the extractor see what the agent saw.** The extraction step read a transcript that capped each fetched page at 4000 characters, so a leadership roster or a tools section further down a page never reached it. It now also reads the full fetched pages (bounded), so those facts land in the structured output.
- **Removed the `extract_structured` tool.** It re-extracted a page into a schema and folded that model-made result back into the evidence a run is grounded against — letting a field vouch for itself, the single biggest source of ungrounded values. Scraping the page and extracting in the normal step covers the same need without the self-grounding.
- **Grounding telemetry.** Each run now records how many fields it dropped for a missing source, a placeholder, or an unsupported quote, so the grounding rate is a dashboard rather than an anecdote.
- **Worktree `.env` gap-fill.** `pnpm cli worktree up` now fills any required key the inherited `.env` never carried from the committed template's default, so a new worktree can't die at boot on a missing variable.

## Impact

- **No migration, no schema change, no wire-shape change.** The findings JSON shape is unchanged; fields that used to ship ungrounded are now simply absent (which the UI already treats as "no value").
- **No new production env var.** The `extract_structured` removal leaves its provider plumbing (`ExtractProvider` and the Firecrawl extract adapter) in place but unused — a deliberate deferral, not a break; nothing in production reads it.
- **No RLS / tenant-isolation / auth surface touched.** Pure server-side research logic + a dev-only CLI change.
- **Recall trade-off, on purpose.** Dropping more ungrounded values can make an occasional run emptier; that is the intended direction (issue #255 asks for "grounded or absent"), and the full-pages change pulls recall back up — the live run below shows both effects.
- **The CLI change affects worktree provisioning only** (developer machines), never prod.

## Review guide

- **Start here:** `packages/research/src/application/scalar-field-guard.ts` — the whole new contract lives in one pure, unit-tested file.
- **Riskiest part — false positives.** The guard must not drop *real* values. Two knobs manage that: the quote-must-back-the-value check is scoped to literal fields only (not the paraphrased/coded `industry`/`size_range`), and the placeholder word list is kept deliberately narrow. My self-review caught one over-drop here — an early draft would have dropped a software company's `industry: "software"` as a "schema word"; I narrowed the list and added a regression test. Worth a second look if you can think of another everyday word that's a legitimate value.
- **Decision you might overrule:** removing `extract_structured` outright vs. keeping it and filtering its output from the evidence. I removed it (simpler, closes the hole fully); the tradeoff is the orphaned provider code noted above.
- **The CLI commit** (`fix(cli):`) is independent and low-risk — a pure helper plus one call site.

## Tests

- New `scalar-field-guard.test.ts` covers the exact reported cases (Circle's "headquarters", the fabricated address, the size mismatch, the Sunset quote mismatch) **and** the guardrails that keep real values (paraphrased industry, a size band whose quote is a different-but-supporting headcount, the "software" industry, contact email/phone left to the value guard).
- `citation-guard.test.ts` updated for the drop-instead-of-strip behavior.

## Verification

- Gates run green: `pnpm -w check-types`, `pnpm -w test` (531 pass), `pnpm -w build`.
- **Live end-to-end** against real vendors (Firecrawl + the production LLM tiers, keys injected via Infisical, run on the worktree's own database): researched Circle Logistics and Sunset Transportation with `pnpm cli research eval`.
  - Circle: all **3 named executives with titles**, each grounded in a real quote; `location = "Fort Wayne, Indiana, US"` with a supporting quote — the `"headquarters"` placeholder is gone.
  - Sunset: the ungrounded location did **not** ship.
  - Zero placeholder values across both runs; grounding 100%, field precision 100%.
- Verified the CLI helper fills the missing key from the template, doesn't duplicate existing keys, and is idempotent.

## Deferred

- **PR #2:** a dedicated contacts-and-titles extraction pass (to lift the zero-contacts rate further), per-contact entity binding (so a testimonial client isn't extracted as staff), anchor-site subpage fetching (About/Team/Leadership), and a retry when web search comes back empty.
- Extracting a company's operational tooling (e.g. Circle's TMS) was not recovered in this run — a target for the decomposed extraction in PR #2.
- Removing the now-orphaned `ExtractProvider` plumbing and its cache table.

Addresses #255. Linked non-closing on purpose: this is PR #1 of two, and one acceptance criterion (recovering a company's tooling, e.g. Circle's TMS) is left to PR #2's decomposed extraction — so merging this shouldn't auto-close the issue.
