### PR TITLE
fix(research): follow a moved company domain to its new site

### DIFF
--- a/apps/server/src/services/cached-scrape.integration.test.ts
+++ b/apps/server/src/services/cached-scrape.integration.test.ts
@@ -94,6 +94,23 @@ const readContentRef = (urlHash: string): Promise<string | null> =>
 		>,
 	)
 
+const readUrlAndDomain = (
+	urlHash: string,
+): Promise<{ url: string; domain: string } | null> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<{ url: string; domain: string }>`
+				SELECT url, domain FROM sources WHERE url_hash = ${urlHash} LIMIT 1
+			`
+			return rows[0] ?? null
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+			{ url: string; domain: string } | null,
+			never,
+			never
+		>,
+	)
+
 // Drive one scrape through the cached wrapper with the given fakes wired in.
 const runScrape = (opts: {
 	url: string
@@ -279,6 +296,74 @@ describe('scrape cache — a broken cache degrades to a fresh fetch', () => {
 			//   re-fetches rather than pointing at a blob that was never written
 			expect(page.markdown).toBe('FRESH DESPITE WRITE FAILURE')
 			expect(await readContentRef(urlHash)).toBeNull()
+		})
+	})
+})
+
+describe('scrape cache — a redirect destination survives the cache', () => {
+	describe('when a freshly-fetched page resolved to a different host', () => {
+		it('should store the resolved url + domain, keyed by the requested url_hash', async () => {
+			// GIVEN a cache miss on a domain that 301s elsewhere (a rebrand), so the
+			//   inner provider reports the destination in resolvedUrl
+			const requested = `https://${freshHost()}/`
+			const destination = `https://dest-${randomUUID()}.example/`
+			const urlHash = track(hashOf(requested))
+
+			// WHEN the wrapper fetches it fresh
+			const page = await runScrape({
+				url: requested,
+				inner: () =>
+					Effect.succeed({
+						url: requested,
+						resolvedUrl: destination,
+						markdown: 'REBRANDED SITE',
+						contentHash: 'redirect-1',
+						units: 1,
+					} as ScrapedPage),
+				blobGet: failingBlobGet,
+				blobPut: okBlobPut,
+			})
+
+			// THEN the returned page keeps the requested url but carries the
+			//   destination, and the persisted row records the destination the page
+			//   really resolved to (still keyed by the requested url_hash so the
+			//   lookup hits)
+			expect(page.resolvedUrl).toBe(destination)
+			const stored = await readUrlAndDomain(urlHash)
+			expect(stored?.url).toBe(destination)
+			expect(stored?.domain).toBe(new URL(destination).hostname)
+		})
+	})
+
+	describe('when a warm row was stored under a redirect destination', () => {
+		it('should return the destination as resolvedUrl on a cache hit', async () => {
+			// GIVEN a warm sources row whose stored url is the redirect destination,
+			//   keyed by the requested host's url_hash, with a readable blob
+			const requested = `https://${freshHost()}/`
+			const destination = `https://dest-${randomUUID()}.example/`
+			const urlHash = track(hashOf(requested))
+			await seedWarmSource({
+				url: destination,
+				urlHash,
+				contentRef: 'scrape/redirect-hit',
+				contentHash: 'redirect-hit',
+			})
+
+			// WHEN the wrapper serves the requested URL from cache
+			const page = await runScrape({
+				url: requested,
+				inner: () =>
+					Effect.die('inner.scrape must not be called on a cache hit'),
+				blobGet: () =>
+					Effect.succeed(new TextEncoder().encode('CACHED REBRAND')),
+				blobPut: okBlobPut,
+			})
+
+			// THEN the hit exposes the destination via resolvedUrl (so grounding can
+			//   still follow the rebrand) while url stays the requested address
+			expect(page.markdown).toBe('CACHED REBRAND')
+			expect(page.resolvedUrl).toBe(destination)
+			expect(page.url).toBe(new URL(requested).toString())
 		})
 	})
 })

--- a/apps/server/src/services/research-anchor-seed.integration.test.ts
+++ b/apps/server/src/services/research-anchor-seed.integration.test.ts
@@ -58,6 +58,21 @@ const ANCHOR_URL_HASH = createHash('sha256')
 const ANCHOR_MARKDOWN =
 	'Acme Anchor Logistics — freight forwarding based in Barcelona.'
 
+// Redirect (rebrand) scenario: the caller's domain 301s to a different canonical
+// host. The seed fetches the old host; the stub reports the destination in
+// resolvedUrl, and its markdown names neither the old host nor the full company
+// name — only a distinctive word — so ONLY following the redirect and folding the
+// destination host in can push the run to a strong match.
+const REBRAND_OLD_HOST = `zephyr-old-${randomUUID()}.example`
+const REBRAND_NEW_HOST = `zephyr-new-${randomUUID()}.example`
+const REBRAND_OLD_URL = `https://${REBRAND_OLD_HOST}`
+const REBRAND_OLD_URL_HASH = createHash('sha256')
+	.update(new URL(REBRAND_OLD_URL).toString())
+	.digest('hex')
+const REBRAND_NEW_URL = `https://${REBRAND_NEW_HOST}/`
+const REBRAND_MARKDOWN =
+	'Zephyr keeps time-critical freight moving across the region.'
+
 const usage = {
 	inputTokens: {
 		uncached: undefined,
@@ -154,18 +169,33 @@ const providersLayer = Layer.mergeAll(
 		ScrapeProvider.of({
 			// ScrapedPage is re-exported as a type only, so hand back a plain object
 			// of the same shape (the seed reads its url + markdown) rather than newing
-			// the class. Any url but the anchor is a bug — the model fetches nothing.
-			scrape: input =>
-				input.url === ANCHOR_URL
-					? Effect.succeed({
-							url: ANCHOR_URL,
-							markdown: ANCHOR_MARKDOWN,
-							contentHash: createHash('sha256')
-								.update(ANCHOR_MARKDOWN)
-								.digest('hex'),
-							units: 1,
-						} as ScrapedPage)
-					: Effect.die(`unexpected scrape url: ${input.url}`),
+			// the class. The anchor host serves its page; the rebrand host serves a
+			// page that resolved (301) to a different host via resolvedUrl. Any other
+			// url is a bug — the model fetches nothing.
+			scrape: input => {
+				if (input.url === ANCHOR_URL) {
+					return Effect.succeed({
+						url: ANCHOR_URL,
+						markdown: ANCHOR_MARKDOWN,
+						contentHash: createHash('sha256')
+							.update(ANCHOR_MARKDOWN)
+							.digest('hex'),
+						units: 1,
+					} as ScrapedPage)
+				}
+				if (input.url === REBRAND_OLD_URL) {
+					return Effect.succeed({
+						url: REBRAND_OLD_URL,
+						resolvedUrl: REBRAND_NEW_URL,
+						markdown: REBRAND_MARKDOWN,
+						contentHash: createHash('sha256')
+							.update(REBRAND_MARKDOWN)
+							.digest('hex'),
+						units: 1,
+					} as ScrapedPage)
+				}
+				return Effect.die(`unexpected scrape url: ${input.url}`)
+			},
 		}),
 	),
 	Layer.succeed(ExtractProvider)(
@@ -219,6 +249,14 @@ const researchInput: CreateResearchInput = {
 	forceFresh: true,
 }
 
+// The rebrand run: the query carries the OLD domain (no quotes, no clean name, so
+// the name core can't rescue it) — grounding must come from following the 301.
+const redirectInput: CreateResearchInput = {
+	query: `Zephyr Freight Systems (${REBRAND_OLD_HOST}), Denver CO`,
+	schemaName: 'company_enrichment_v1',
+	forceFresh: true,
+}
+
 const TERMINAL = new Set([
 	'succeeded',
 	'failed',
@@ -229,6 +267,7 @@ const TERMINAL = new Set([
 const ctx = {} as { org: Org }
 let userId = ''
 let runId: string | null = null
+let redirectRunId: string | null = null
 
 beforeAll(async () => {
 	const seed = await Effect.runPromise(
@@ -256,6 +295,16 @@ beforeAll(async () => {
 				)
 				ON CONFLICT (url_hash) DO NOTHING
 			`
+			// Same stand-in row for the rebrand run — the seed links the anchor fetch
+			// by the OLD host's url_hash (page.url is the requested address).
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (
+					${randomUUID()}, 'web', 'it-stub', ${new URL(REBRAND_OLD_URL).toString()}, ${REBRAND_OLD_URL_HASH},
+					${REBRAND_OLD_HOST}, ${createHash('sha256').update(REBRAND_MARKDOWN).digest('hex')}
+				)
+				ON CONFLICT (url_hash) DO NOTHING
+			`
 			return { org, userId: user.id }
 		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
 			{ org: Org; userId: string },
@@ -271,12 +320,14 @@ afterAll(async () => {
 	await Effect.runPromise(
 		Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
-			if (runId) {
+			for (const id of [runId, redirectRunId]) {
+				if (!id) continue
 				// research_cache has no cascade from research_runs; delete it first.
-				yield* sql`DELETE FROM research_cache WHERE research_id = ${runId}::uuid`
-				yield* sql`DELETE FROM research_runs WHERE id = ${runId}::uuid`
+				yield* sql`DELETE FROM research_cache WHERE research_id = ${id}::uuid`
+				yield* sql`DELETE FROM research_runs WHERE id = ${id}::uuid`
 			}
 			yield* sql`DELETE FROM sources WHERE url_hash = ${ANCHOR_URL_HASH}`
+			yield* sql`DELETE FROM sources WHERE url_hash = ${REBRAND_OLD_URL_HASH}`
 		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
 	)
 })
@@ -368,6 +419,92 @@ describe('ResearchService anchor seed', () => {
 			// The anchor site was fetched and linked, even though the model never did.
 			expect(outcome.anchorSourceCount).toBeGreaterThanOrEqual(1)
 			// Grounding is strong on the official page alone.
+			expect(outcome.entityMatch).toBe('strong')
+		})
+	})
+
+	describe('when the anchor domain redirects to a rebranded host', () => {
+		it('should follow the 301, anchor on the destination, and ground the run', async () => {
+			// GIVEN a run whose query carries a domain that 301s to a different host,
+			//   whose fetched page names only the new host + a distinctive word (never
+			//   the old host or the full name), and a model that gathers nothing itself
+			// WHEN the fiber seeds the anchor, follows the redirect, and folds the
+			//   destination host into the entity targets
+			// THEN the run grounds (strong) and succeeds instead of failing closed as
+			//   no_reliable_data — and the seeded page is linked by the old host's hash
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const sql = yield* SqlClient.SqlClient
+
+					const created = yield* enterOrgScope(sql, {
+						org: ctx.org,
+						userId,
+					})(svc.create(userId, ctx.org.id, redirectInput, systemDefaults))
+					if (created.status === 'confirm_required')
+						return yield* Effect.die(
+							new Error('redirect anchor test input should not fan out'),
+						)
+					redirectRunId = created.id
+
+					const poll = (
+						attemptsLeft: number,
+					): Effect.Effect<
+						{ status: string; errorMessage: string | null },
+						never,
+						never
+					> =>
+						Effect.gen(function* () {
+							const run = (yield* svc.get(created.id).pipe(Effect.orDie)) as {
+								status?: string
+								errorMessage?: string | null
+							} | null
+							const status = run?.status ?? 'unknown'
+							if (TERMINAL.has(status) || attemptsLeft <= 0) {
+								return { status, errorMessage: run?.errorMessage ?? null }
+							}
+							yield* Effect.sleep('300 millis')
+							return yield* poll(attemptsLeft - 1)
+						})
+
+					const final = yield* poll(50)
+
+					const [sourceRow] = yield* sql<{ n: number }>`
+						SELECT COUNT(*)::int AS n FROM research_run_sources
+						WHERE research_id = ${created.id}::uuid
+							AND source_id IN (
+								SELECT id FROM sources WHERE url_hash = ${REBRAND_OLD_URL_HASH}
+							)
+					`.pipe(Effect.orDie)
+
+					const [entityRow] = yield* sql<{ entityMatch: string | null }>`
+						SELECT entity_match AS "entityMatch"
+						FROM research_runs WHERE id = ${created.id}::uuid
+					`.pipe(Effect.orDie)
+
+					return {
+						status: final.status,
+						errorMessage: final.errorMessage,
+						anchorSourceCount: sourceRow?.n ?? 0,
+						entityMatch: entityRow?.entityMatch ?? null,
+					}
+				}).pipe(Effect.provide(ResearchLive)) as Effect.Effect<
+					{
+						status: string
+						errorMessage: string | null
+						anchorSourceCount: number
+						entityMatch: string | null
+					},
+					never,
+					never
+				>,
+			)
+
+			expect(
+				outcome.status,
+				`redirect run not succeeded: ${outcome.errorMessage ?? '(no error recorded)'}`,
+			).toBe('succeeded')
+			expect(outcome.anchorSourceCount).toBeGreaterThanOrEqual(1)
 			expect(outcome.entityMatch).toBe('strong')
 		})
 	})

--- a/eval/golden.example.json
+++ b/eval/golden.example.json
@@ -168,5 +168,17 @@
 				"location": "Austin"
 			}
 		}
+	},
+	{
+		"id": "ascent-global-logistics",
+		"query": "Ascent Global Logistics (ascentgl.com), Belleville MI",
+		"expectedOutput": {
+			"officialDomain": "ascentlogistics.com",
+			"altDomains": ["ascentgl.com"],
+			"fields": {
+				"country": "US",
+				"location": "Belleville"
+			}
+		}
 	}
 ]

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -10,6 +10,7 @@ import {
 	groundedSourceIds,
 	isConfirmedRegistryMatch,
 	parseQueryDomain,
+	withRedirectDomain,
 } from './entity-guard'
 
 describe('deriveEntityTargets', () => {
@@ -44,6 +45,34 @@ describe('deriveEntityTargets', () => {
 			expect(targets?.cores).toContain('sunsettransportation')
 		})
 
+		it('should read the company name from a quoted phrase in an instruction query', () => {
+			// GIVEN an instruction-style query that names the company in quotes and
+			// then adds its domain and location (how the MCP client phrases runs)
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query:
+					'Research "Ascent Global Logistics" (ascentgl.com, Belleville, MI) — a US 3PL. Find headcount.',
+				subjects: [],
+			})
+			// THEN the quoted name — not the whole sentence — becomes the core, so it
+			// can actually match the company's own pages
+			expect(targets?.cores).toContain('ascentgloballogistics')
+			expect(targets?.cores).not.toContain(
+				'researchascentgloballogisticsascentglcom',
+			)
+		})
+
+		it('should read the company name from curly quotes too', () => {
+			// GIVEN a query whose name is wrapped in typographic quotes
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Look up “Cohitech”, Balsareny',
+				subjects: [],
+			})
+			// THEN the curly-quoted phrase is the core
+			expect(targets?.cores).toContain('cohitech')
+		})
+
 		it('should derive keys from the subject name and website when anchored', () => {
 			// GIVEN any schema but with an anchored company subject
 			const targets = deriveEntityTargets({
@@ -75,6 +104,48 @@ describe('deriveEntityTargets', () => {
 					subjects: [{ table: 'companies' }],
 				}),
 			).toBeNull()
+		})
+	})
+})
+
+describe('withRedirectDomain', () => {
+	const baseTargets: EntityTargets = {
+		cores: ['ascentgloballogistics'],
+		words: ['ascent'],
+		domains: ['ascentgl.com'],
+	}
+
+	describe('when the anchor domain redirected to a new host', () => {
+		it('should fold the destination host in as a strong-match key', () => {
+			// GIVEN targets built from the caller's old domain, and a rebrand
+			// destination the fetch resolved to
+			// WHEN the destination host is folded in
+			const folded = withRedirectDomain(baseTargets, 'ascentlogistics.com')
+			// THEN both hosts are strong-match domains and the new label is a weak key
+			expect(folded.domains).toEqual(['ascentgl.com', 'ascentlogistics.com'])
+			expect(folded.words).toContain('ascentlogistics')
+			// AND a page under the new host now strong-matches
+			expect(
+				classifyEntityMatch(folded, 'see https://ascentlogistics.com/'),
+			).toBe('strong')
+		})
+
+		it('should leave the name cores untouched', () => {
+			// GIVEN any targets
+			// WHEN a destination host is folded in
+			// THEN the name cores are unchanged (only domain/word keys grow)
+			expect(withRedirectDomain(baseTargets, 'ascentlogistics.com').cores).toBe(
+				baseTargets.cores,
+			)
+		})
+	})
+
+	describe('when the destination is already a target domain', () => {
+		it('should return the targets unchanged', () => {
+			// GIVEN a destination host that is already a known domain (no real redirect)
+			// WHEN it is folded in
+			// THEN the same targets come back, unmodified
+			expect(withRedirectDomain(baseTargets, 'ascentgl.com')).toBe(baseTargets)
 		})
 	})
 })

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -161,9 +161,17 @@ const domainLabelOf = (host: string): string | undefined => {
 	return label && label.length >= 4 ? label : undefined
 }
 
-// A free-text query's company name is usually the part before the first comma
-// ("Sunset Transportation, St. Louis MO"); fall back to the whole query.
-const queryName = (query: string): string => query.split(',')[0] ?? query
+// A caller often wraps the company name in quotes inside a longer instruction
+// ("Research \"Acme Corp\" (acme.com) — find headcount…"), so the quoted phrase,
+// not the whole sentence, is the name to match on. Straight and curly double
+// quotes, 2–80 chars so it can't swallow a paragraph.
+const QUOTED_NAME = /["“]([^"”]{2,80})["”]/
+
+// A free-text query's company name: the first quoted phrase if one is present,
+// else the part before the first comma ("Sunset Transportation, St. Louis MO");
+// fall back to the whole query.
+const queryName = (query: string): string =>
+	query.match(QUOTED_NAME)?.[1] ?? query.split(',')[0] ?? query
 
 // A domain-shaped token inside free text: one or more dot-separated labels then a
 // 2–24 letter top-level part. The letters-only tail keeps decimals ("3.5") and
@@ -254,6 +262,29 @@ export const deriveEntityTargets = (args: {
 	if (cores.length === 0 && words.length === 0 && domains.length === 0)
 		return null
 	return { cores, words, domains }
+}
+
+/**
+ * Fold a redirect destination host into a run's targets. When the caller's own
+ * domain 301/302-redirects to a different host — a rebrand — that destination is
+ * the same company's official site, so its host becomes a strong-match key (and
+ * its label a weak one), exactly as if the caller had supplied it as the website.
+ * A no-op when the host is already a target domain.
+ */
+export const withRedirectDomain = (
+	targets: EntityTargets,
+	destHost: string,
+): EntityTargets => {
+	if (targets.domains.includes(destHost)) return targets
+	const label = domainLabelOf(destHost)
+	return {
+		cores: targets.cores,
+		domains: [...targets.domains, destHost],
+		words:
+			label != null && !targets.words.includes(label)
+				? [...targets.words, label]
+				: targets.words,
+	}
 }
 
 /**

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -49,6 +49,7 @@ import {
 	type EntityTargets,
 	groundedSourceIds,
 	isConfirmedRegistryMatch,
+	withRedirectDomain,
 } from './entity-guard'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
@@ -1033,7 +1034,10 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								typeof row['website'] === 'string' ? row['website'] : undefined,
 						}
 					})
-					const entityTargets = deriveEntityTargets({
+					// `let`, not `const`: when the seeded anchor domain redirects to a
+					// different host (a rebrand), the seed below folds that destination
+					// in as a strong-match key so the run grounds on the live site.
+					let entityTargets = deriveEntityTargets({
 						schemaName,
 						anchorDomain: context?.anchorDomain,
 						query: (run as { query: string }).query,
@@ -1566,15 +1570,43 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 										page.markdown.trim().length > 0
 									) {
 										const hash = urlHashForScrape(page.url)
-										scrapeCorpus.push({ urlHash: hash, text: page.markdown })
+										// The caller's own domain may 301 to a different host (a
+										// rebrand); the fetch followed it, so the destination is the
+										// same company's official site. Fold that host in as a
+										// strong-match key and put the reached URL in the corpus, so
+										// grounding lands on the live site instead of failing closed
+										// when the rebranded page never names the old domain.
+										const resolvedUrl = page.resolvedUrl ?? page.url
+										const destHost = domainHost(resolvedUrl)
+										const followedRedirect =
+											destHost !== undefined && destHost !== anchorHost
+										scrapeCorpus.push({
+											urlHash: hash,
+											text: followedRedirect
+												? `${resolvedUrl}\n${page.markdown}`
+												: page.markdown,
+										})
+										if (followedRedirect && entityTargets !== null) {
+											entityTargets = withRedirectDomain(
+												entityTargets,
+												destHost,
+											)
+										}
 										seededAnchorHashes.push(hash)
 										seededTranscriptParts.push(
 											`[scrape_page] ${boundedToolResult({ url: page.url, markdown: page.markdown })}`,
 										)
-										yield* Effect.logInfo('research.anchor.seeded').pipe(
+										yield* Effect.logInfo(
+											followedRedirect
+												? 'research.anchor.redirect_followed'
+												: 'research.anchor.seeded',
+										).pipe(
 											Effect.annotateLogs({
 												research_id: researchId,
 												host: anchorHost,
+												...(followedRedirect
+													? { resolved_host: destHost }
+													: {}),
 											}),
 										)
 									}

--- a/packages/research/src/domain/types.ts
+++ b/packages/research/src/domain/types.ts
@@ -26,6 +26,10 @@ export class SearchResult extends Schema.Class<SearchResult>('SearchResult')({
 /** A scraped page returned by ScrapeProvider. */
 export class ScrapedPage extends Schema.Class<ScrapedPage>('ScrapedPage')({
 	url: Schema.String,
+	// The final URL after the fetch followed any redirects — differs from `url`
+	// when the requested address 301/302s elsewhere (e.g. a rebranded domain).
+	// Absent when the provider doesn't report it or nothing redirected.
+	resolvedUrl: Schema.optional(Schema.String),
 	markdown: Schema.optional(Schema.String),
 	html: Schema.optional(Schema.String),
 	links: Schema.optional(Schema.Array(Schema.String)),

--- a/packages/research/src/infrastructure/cached-scrape.ts
+++ b/packages/research/src/infrastructure/cached-scrape.ts
@@ -47,6 +47,7 @@ import { ScrapedPage } from '../domain/types'
 // read them by those names, not the SQL spelling.
 interface SourcesCacheHit {
 	readonly id: string
+	readonly url: string
 	readonly contentRef: string | null
 	readonly contentHash: string
 }
@@ -137,6 +138,9 @@ export const makeCachedScrape = () =>
 								Option.some(
 									new ScrapedPage({
 										url: canonical,
+										// The row stores the URL the page finally resolved to, so a
+										// cached hit still knows a redirect destination (a rebrand).
+										resolvedUrl: row.url,
 										markdown,
 										contentHash: row.contentHash,
 										units: 0,
@@ -158,7 +162,7 @@ export const makeCachedScrape = () =>
 						)
 
 					const hits = yield* sql<SourcesCacheHit>`
-						SELECT id, content_ref, content_hash
+						SELECT id, url, content_ref, content_hash
 						FROM sources
 						WHERE url_hash = ${urlHash}
 							AND last_fetched_at > now() - (${`${ttl} hours`})::interval
@@ -186,7 +190,7 @@ export const makeCachedScrape = () =>
 						yield* sql`SELECT pg_advisory_xact_lock(hashtext(${`scrape:${urlHash}`}))`
 
 						const rehits = yield* sql<SourcesCacheHit>`
-							SELECT id, content_ref, content_hash
+							SELECT id, url, content_ref, content_hash
 							FROM sources
 							WHERE url_hash = ${urlHash}
 								AND last_fetched_at > now() - (${`${ttl} hours`})::interval
@@ -202,6 +206,19 @@ export const makeCachedScrape = () =>
 
 						const page = yield* inner.scrape(input)
 						const markdown = page.markdown ?? ''
+
+						// Persist the URL the page actually resolved to, but only when it
+						// truly landed on a different host (a redirect/rebrand) — otherwise
+						// keep the canonical requested url so non-redirect rows are
+						// unchanged. The row stays keyed by the requested url_hash so the
+						// lookup still hits; storing the destination lets a later cache hit
+						// recover it for grounding.
+						const storedUrl =
+							page.resolvedUrl !== undefined &&
+							extractDomain(page.resolvedUrl) !== extractDomain(canonical)
+								? page.resolvedUrl
+								: canonical
+						const storedDomain = extractDomain(storedUrl)
 
 						// Best-effort cache write: the page is already in hand, so a store
 						// failure must not fail the scrape. On failure we record no
@@ -240,13 +257,15 @@ export const makeCachedScrape = () =>
 								title, language, content_hash, content_ref,
 								first_fetched_at, last_fetched_at
 							) VALUES (
-								${sourceIdFor(urlHash)}, 'web', 'scrape', ${canonical}, ${urlHash}, ${domain},
+								${sourceIdFor(urlHash)}, 'web', 'scrape', ${storedUrl}, ${urlHash}, ${storedDomain},
 								${page.title ?? null}, ${page.language ?? null},
 								${page.contentHash}, ${storedRef},
 								now(), now()
 							)
 							ON CONFLICT (url_hash) DO UPDATE SET
 								last_fetched_at = now(),
+								url             = EXCLUDED.url,
+								domain          = EXCLUDED.domain,
 								content_hash    = EXCLUDED.content_hash,
 								content_ref     = EXCLUDED.content_ref,
 								title           = COALESCE(EXCLUDED.title, sources.title),

--- a/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
+++ b/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
@@ -207,6 +207,29 @@ describe('makeFirecrawlScrape', () => {
 		expect(page?.contentHash).toBe(sha256('# Acme'))
 		expect(page?.units).toBe(1)
 		expect(log.count).toBe(1)
+		// AND no resolvedUrl when the response reports no final URL
+		expect(page?.resolvedUrl).toBeUndefined()
+	})
+
+	it('should carry the final URL from metadata.url when the fetch followed a redirect', async () => {
+		// GIVEN a scrape of a domain that 301s elsewhere, so Firecrawl reports the
+		// resolved address in metadata.url
+		const { exit } = runScrape(200, {
+			data: {
+				markdown: '# Ascent',
+				metadata: {
+					title: 'Ascent',
+					sourceURL: 'https://ascentgl.com',
+					url: 'https://ascentlogistics.com/',
+				},
+			},
+		})
+
+		// THEN the page keeps the requested url but exposes the resolved destination
+		const resolved = await exit
+		const page = Exit.isSuccess(resolved) ? resolved.value : undefined
+		expect(page?.url).toBe('https://acme.es/about')
+		expect(page?.resolvedUrl).toBe('https://ascentlogistics.com/')
 	})
 
 	it('should POST to the Firecrawl scrape endpoint with a bearer key', async () => {

--- a/packages/research/src/infrastructure/firecrawl/scrape.ts
+++ b/packages/research/src/infrastructure/firecrawl/scrape.ts
@@ -38,6 +38,10 @@ const ScrapeResponse = Schema.Struct({
 			Schema.Struct({
 				title: Schema.optional(Schema.String),
 				language: Schema.optional(Schema.String),
+				// The address the page finally resolved to after Firecrawl followed
+				// any redirects; `sourceURL` is what we asked for. They differ when
+				// the requested domain 301s elsewhere (a rebrand).
+				url: Schema.optional(Schema.String),
 			}),
 		),
 	}),
@@ -153,6 +157,7 @@ export const makeFirecrawlScrape = (slot: number) =>
 						const markdown = cleanScrapedMarkdown(body.data.markdown ?? '')
 						return new ScrapedPage({
 							url: input.url,
+							resolvedUrl: body.data.metadata?.url,
 							markdown,
 							html: body.data.html,
 							links: body.data.links,


### PR DESCRIPTION
## What

When I research a company whose website address has moved to a new domain — a rebrand, where the old address automatically forwards ("301 redirects") to a new one — the research run used to give up and report **"no reliable data,"** even though the company is real and its site is live. Now the run follows that forward to the new address, recognises it as the same company, and enriches normally.

This lives in the CRM's **Research** context (`packages/research`), on the path that fetches a company's official site to confirm a run is really about the requested company.

## The fix

The reported run failed for **two** compounding reasons, so the fix addresses both:

- **Follow the redirect.** The upfront fetch of a company's official site now reads the final address the page resolved to after any forwarding, and — because a forward straight from the caller's own domain is strong evidence it's the same company — treats that destination as the official site (adds its host as a match key). The scraping provider (Firecrawl) already followed the redirect server-side; the adapter simply keeps the final URL it reported instead of discarding it.
- **Read a quoted name.** When a research request wraps the company name in quotes inside a longer instruction (`Research "Acme Corp" (acme.com) — …`), the quoted phrase is now read as the company name. Before, the whole sentence was collapsed into one blob that matched no real page — this is the deeper reason the run failed *even after* reaching the live site, and it restores name-based grounding for the way the assistant actually phrases runs.
- **Remember it across the cache.** The scraped-page cache now stores the address a page finally resolved to (only when it truly changed host), so a repeat lookup within the cache window recognises the redirect instead of failing again.

## Impact

- **No schema / migration change.** The resolved address reuses the existing `sources.url` / `domain` columns; the row stays keyed by the *requested* address's `url_hash`, so cache lookups are unaffected. (`sources` has no UNIQUE constraint on `url`, so two rows may share a destination — checked against prod.)
- **Scraped-page cache is shared and global (not org-scoped).** For a genuinely redirected page the stored `url`/`domain` now reflect the destination; **non-redirect rows are byte-for-byte unchanged**. Source attribution and eval grounding read the host, which is unchanged for non-redirects.
- **MCP + HTTP parity:** research behaves identically on both transports; both get this.
- No new env vars, no auth/RLS changes, no API/wire-shape changes.

## Review guide

- Start in `research-service.ts`, the anchor-seed block — the `followedRedirect` fold is the heart of the fix.
- `entity-guard.ts`: `withRedirectDomain` (new, pure) and the one-line `queryName` quoted-phrase preference.
- `cached-scrape.ts`: stores the resolved URL keyed by the *requested* `url_hash`, reads it back on a hit.
- **A decision you might overrule:** a 301 straight from the caller's own domain is trusted as the same company (per the issue). A domain that was sold and now parks elsewhere would also be followed — it fails *safe* (empty enrichment, never another company's data), and the fold is deliberately limited to the upfront anchor fetch; arbitrary in-loop scrape redirects are **not** trusted.
- **Couldn't fully verify locally:** this dev environment stubs the research providers, so the real Firecrawl → pipeline path can't run here. I confirmed out-of-band that scraping `https://ascentgl.com` returns `metadata.url = https://ascentlogistics.com/`, and the deterministic integration test exercises the whole pipeline with a simulated redirect.

## Tests

- **Unit** (`packages/research`): `withRedirectDomain` fold + no-op; `queryName` straight/curly-quote extraction; the Firecrawl adapter mapping `metadata.url` → `resolvedUrl`.
- **Integration** (`apps/server`, real Postgres): the full research pipeline follows a redirect, folds the destination, and grounds (`succeeded`) instead of failing closed; the scraped-page cache stores and reads back the resolved URL across a hit.
- **Golden eval:** a rebranded-domain row (`ascentgl.com` → `ascentlogistics.com`) that exercises the anchor-redirect path.

## Verification

- `pnpm install` (no lockfile drift) → `pnpm -w check-types` (13/13) + `pnpm -w test` (20/20) → `pnpm -w build` (13/13). All green.
- Ran the two integration files against real Postgres (`batuda_it`): redirect scenario + cache round-trip pass; the existing anchor-seed test still passes.
- Ran the real entity-guard functions against the actual scraped content: current code → `weak` (the bug); with the fold → `strong`.
- **Not run:** a real-vendor eval — the local env stubs research providers (real vendors run only in prod / with real keys).

Closes #258
