### PR TITLE
feat(research): richer, safer search — Brave LLM Context vendor + source-tier guard

### DIFF
--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -14,7 +14,14 @@ import type {
 
 export class ResearchRunContext extends ServiceMap.Service<
 	ResearchRunContext,
-	{ readonly researchId: string }
+	{
+		readonly researchId: string
+		// The run's language + location hints, so a search reaches the provider in
+		// the target's own language instead of defaulting to English — the company's
+		// own pages are rarely in English for a non-English target.
+		readonly language?: string | undefined
+		readonly location?: string | undefined
+	}
 >()('research/ResearchRunContext') {}
 
 // ── Tier-specific LanguageModel services ──

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -65,6 +65,7 @@ import {
 import { guardScalarFields } from './scalar-field-guard'
 import { type FreeformSchema, schemaRegistry } from './schemas/index'
 import { urlHashForScrape } from './source-key'
+import { enforceSourceTier } from './source-tier-guard'
 import { REGISTRY_LOOKUP_COST_CENTS, SCRAPE_COST_CENTS } from './tool-costs'
 import {
 	isUnsupportedScrapeUrl,
@@ -108,7 +109,15 @@ const MAX_LOOP_PROMPT_CHARS = 90000
 // transcript. The transcript caps each tool result at 4000 chars for the agent
 // loop; the extractor gets the fuller pages here so a fact sitting past that cut
 // (a leadership list, a tools section) still reaches the structured output.
-const MAX_EXTRACTION_PAGE_CHARS = 60000
+//
+// Sized to the extract tier's real capacity: the primary model serves a 256k-token
+// window and the fallback ~128k, so ~45k tokens of pages (this) plus the ~24k-token
+// transcript and the schema/output still leave headroom on the smaller of the two —
+// far above the old 60k-char (~15k-token) budget, which truncated content-rich
+// targets and multi-company discovery scans. A per-page cap keeps one very long
+// page from crowding out the others, so breadth survives when the budget is tight.
+const MAX_EXTRACTION_PAGE_CHARS = 180000
+const MAX_EXTRACTION_CHARS_PER_PAGE = 40000
 
 // When the model finishes without the evidence confirming the target company, it
 // gets this many corrective nudges to search harder before the run fails closed.
@@ -1223,9 +1232,15 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									if (text.trim().length === 0) continue
 									const remaining = MAX_EXTRACTION_PAGE_CHARS - total
 									if (remaining <= 0) break
+									// Cap each page so one very long page can't consume the whole
+									// budget and starve the pages after it.
+									const budget = Math.min(
+										remaining,
+										MAX_EXTRACTION_CHARS_PER_PAGE,
+									)
 									const slice =
-										text.length > remaining
-											? `${text.slice(0, remaining)}…[truncated]`
+										text.length > budget
+											? `${text.slice(0, budget)}…[truncated]`
 											: text
 									parts.push(slice)
 									total += slice.length
@@ -1438,6 +1453,23 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 										criticised: critiqued.criticised,
 										dropped: critiqued.dropped,
 										flagged: critiqued.flagged,
+									}),
+								)
+							}
+							// Source tier: a value cited to a third-party company-profile site
+							// (an aggregator surfaced by the richer search vendors), rather than
+							// the company's own domain, has its confidence held to medium — so an
+							// outside estimate never ships trusted like the company's own word.
+							const sourceTier = enforceSourceTier(
+								result,
+								entityTargets?.domains ?? [],
+							)
+							result = sourceTier.findings
+							if (sourceTier.capped > 0) {
+								yield* Effect.logInfo('research.source_tier.capped').pipe(
+									Effect.annotateLogs({
+										research_id: researchId,
+										capped: sourceTier.capped,
 									}),
 								)
 							}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1898,7 +1898,13 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 						}).pipe(
 							Effect.provide(researchToolkitLayer),
 							Effect.provide(budgetLayer),
-							Effect.provide(Layer.succeed(ResearchRunContext)({ researchId })),
+							Effect.provide(
+								Layer.succeed(ResearchRunContext)({
+									researchId,
+									language: hints?.language,
+									location: hints?.location,
+								}),
+							),
 							Effect.withSpan('research.phase1', {
 								attributes: { 'research.run_id': researchId },
 							}),
@@ -1980,13 +1986,22 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							findings = retryFindings
 							tokensOut += retryExtractTokens
 						} else {
+							// Fill the phase-2 page budget with the company's own
+							// (anchor-seeded) pages first, so if the budget truncates it drops
+							// third-party pages, never the official site the run grounds on.
+							const anchorHashes = new Set(seededAnchorHashes)
+							const anchorFirstCorpus = [...scrapeCorpus].sort(
+								(a, b) =>
+									(anchorHashes.has(a.urlHash) ? 0 : 1) -
+									(anchorHashes.has(b.urlHash) ? 0 : 1),
+							)
 							const extracted = yield* extractStructuredFindings(
 								researchText,
 								[
 									evidenceText,
 									...groundedPageTexts(entityTargets, scrapeCorpus),
 								].join('\n'),
-								groundedPageTexts(entityTargets, scrapeCorpus),
+								groundedPageTexts(entityTargets, anchorFirstCorpus),
 							)
 							findings = extracted.findings
 							tokensOut += extracted.outputTokens

--- a/packages/research/src/application/source-tier-guard.test.ts
+++ b/packages/research/src/application/source-tier-guard.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	enforceSourceTier,
+	THIRD_PARTY_CONFIDENCE_CAP,
+} from './source-tier-guard'
+
+interface SourcedView {
+	value: unknown
+	confidence?: unknown
+}
+interface EnrichmentView {
+	size_range: SourcedView
+	location: SourcedView
+}
+const enrichment = (findings: unknown): EnrichmentView =>
+	(findings as { enrichment: EnrichmentView }).enrichment
+
+const TARGETS = ['acme.com']
+
+describe('enforceSourceTier', () => {
+	describe("when a value is cited to the target's own domain", () => {
+		it('should leave its confidence untouched', () => {
+			// GIVEN a size value the company states on its own site
+			const findings = {
+				enrichment: {
+					size_range: {
+						value: '51-200',
+						source_id: 'https://acme.com/about',
+						confidence: 0.9,
+					},
+				},
+			}
+
+			// WHEN tiered against the target host
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN first-party confidence stands
+			expect(enrichment(result.findings).size_range).toEqual(
+				findings.enrichment.size_range,
+			)
+			expect(result.capped).toBe(0)
+		})
+
+		it('should treat a subdomain of the target as first-party', () => {
+			// GIVEN a value from a subdomain of the company's site
+			const findings = {
+				enrichment: {
+					location: {
+						value: 'Chicago, IL',
+						source_id: 'https://careers.acme.com',
+						confidence: 0.95,
+					},
+				},
+			}
+
+			// WHEN tiered
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN kept
+			expect(enrichment(result.findings).location).toEqual(
+				findings.enrichment.location,
+			)
+			expect(result.capped).toBe(0)
+		})
+	})
+
+	describe('when a value is cited to a third-party aggregator', () => {
+		it('should cap a high confidence down to medium', () => {
+			// GIVEN a headcount an aggregator estimated
+			const findings = {
+				enrichment: {
+					size_range: {
+						value: '501-1000',
+						source_id: 'https://www.datanyze.com/companies/acme',
+						confidence: 0.95,
+					},
+				},
+			}
+
+			// WHEN tiered
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN its confidence is held to the third-party cap, value untouched
+			const size = enrichment(result.findings).size_range
+			expect(size.value).toBe('501-1000')
+			expect(size.confidence).toBe(THIRD_PARTY_CONFIDENCE_CAP)
+			expect(result.capped).toBe(1)
+		})
+
+		it('should set a null confidence to the cap', () => {
+			// GIVEN an aggregator value with no confidence
+			const findings = {
+				enrichment: {
+					size_range: {
+						value: '501-1000',
+						source_id: 'https://zoominfo.com/c/acme',
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN tiered
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN it is stamped at the cap
+			expect(enrichment(result.findings).size_range.confidence).toBe(
+				THIRD_PARTY_CONFIDENCE_CAP,
+			)
+			expect(result.capped).toBe(1)
+		})
+
+		it('should not raise an already-low third-party confidence', () => {
+			// GIVEN an aggregator value already below the cap
+			const findings = {
+				enrichment: {
+					size_range: {
+						value: '501-1000',
+						source_id: 'https://zoominfo.com/c/acme',
+						confidence: 0.3,
+					},
+				},
+			}
+
+			// WHEN tiered
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN it is left as-is (the cap is a ceiling, not a floor)
+			expect(enrichment(result.findings).size_range.confidence).toBe(0.3)
+			expect(result.capped).toBe(0)
+		})
+	})
+
+	describe('when the run has no single target', () => {
+		it('should be a no-op for an empty target list (a discovery scan)', () => {
+			// GIVEN findings from a scan with no anchored company
+			const findings = {
+				enrichment: {
+					size_range: {
+						value: '501-1000',
+						source_id: 'https://datanyze.com/x',
+						confidence: 0.95,
+					},
+				},
+			}
+
+			// WHEN tiered with no targets
+			const result = enforceSourceTier(findings, [])
+
+			// THEN nothing is capped
+			expect(enrichment(result.findings).size_range.confidence).toBe(0.95)
+			expect(result.capped).toBe(0)
+		})
+	})
+
+	describe('when the shape holds subtrees that are not scalar fields', () => {
+		it('should not walk into citations or proposed_updates', () => {
+			// GIVEN a proposed-update blob whose fields could look field-ish
+			const findings = {
+				enrichment: {},
+				proposed_updates: [
+					{
+						subject_id: 'c1',
+						fields: {
+							value: 'x',
+							source_id: 'https://datanyze.com/x',
+							confidence: 0.9,
+						},
+						citations: [{ source_id: 'https://datanyze.com/x' }],
+					},
+				],
+			}
+
+			// WHEN tiered
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN the freeform subtree is untouched
+			expect(result.capped).toBe(0)
+			expect(
+				(result.findings as { proposed_updates: unknown[] }).proposed_updates,
+			).toEqual(findings.proposed_updates)
+		})
+	})
+})

--- a/packages/research/src/application/source-tier-guard.ts
+++ b/packages/research/src/application/source-tier-guard.ts
@@ -1,0 +1,101 @@
+/**
+ * Caps the confidence of a per-field value whose only source is a third party,
+ * not the company itself.
+ *
+ * The rest of the guard chain trusts any value that appears in a page the run
+ * fetched. That was safe when the run only read the company's own site, but the
+ * richer search vendors pull in company-profile aggregators (Datanyze, ZoomInfo
+ * and the like) whose headcounts, revenues, and phone numbers are often estimated
+ * or stale. Left alone, an aggregator's guess grounds and ships at the same high
+ * confidence as a fact stated on the company's own page — "grounding-laundering".
+ *
+ * This guard draws one line: a value cited to the target's **own domain** (or the
+ * official registry) is first-party and keeps its confidence; a value cited to any
+ * other host is third-party and has its confidence capped to no better than medium.
+ * It never drops a value — third-party data is still useful — it just stops the
+ * caller from trusting an outside estimate like the company's own word.
+ *
+ * It applies only when the run has a known target (an entity-grounded run with
+ * target domains); a discovery scan with no single subject is left untouched.
+ */
+
+import { hostOf } from './source-key'
+
+// Confidence a third-party-sourced value is held to: kept and usable, but marked
+// no better than medium so it reads as "reported elsewhere", not "the company says
+// so". Below the 0.7 the UI treats as trustworthy.
+export const THIRD_PARTY_CONFIDENCE_CAP = 0.6
+
+// Subtrees that are not per-field values: block-level citation arrays and the
+// freeform proposed-update blob, whose contents could otherwise look like a field.
+const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
+
+// The value came from one of the target's own hosts — the company's own domain or
+// a subdomain of it. A look-alike or aggregator host never ends with ".<target>".
+const isFirstPartyHost = (
+	host: string,
+	targetHosts: ReadonlyArray<string>,
+): boolean =>
+	targetHosts.some(target => host === target || host.endsWith(`.${target}`))
+
+// A per-field Sourced wrapper: `{ value, source_id, quote?, confidence? }`.
+const isSourcedField = (
+	v: unknown,
+): v is { value: unknown; source_id?: unknown; confidence?: unknown } =>
+	v !== null &&
+	typeof v === 'object' &&
+	!Array.isArray(v) &&
+	'value' in v &&
+	('source_id' in v || 'quote' in v || 'confidence' in v)
+
+export interface SourceTierResult {
+	readonly findings: unknown
+	/** Fields whose confidence was lowered because their source was third-party. */
+	readonly capped: number
+}
+
+/**
+ * Cap the confidence of every per-field value whose cited source is not one of the
+ * target's own hosts. `targetHosts` are the run's target domains (registrable, no
+ * scheme/`www.`); an empty list means the run has no single subject, so the guard
+ * is a no-op.
+ */
+export const enforceSourceTier = (
+	findings: unknown,
+	targetHosts: ReadonlyArray<string>,
+): SourceTierResult => {
+	if (targetHosts.length === 0) return { findings, capped: 0 }
+	let capped = 0
+
+	const walk = (value: unknown): unknown => {
+		if (Array.isArray(value)) return value.map(walk)
+		if (value === null || typeof value !== 'object') return value
+
+		if (isSourcedField(value)) {
+			const wrapper = value as {
+				source_id?: unknown
+				confidence?: unknown
+			}
+			if (typeof wrapper.source_id === 'string') {
+				const host = hostOf(wrapper.source_id)
+				if (host !== null && !isFirstPartyHost(host, targetHosts)) {
+					const current =
+						typeof wrapper.confidence === 'number' ? wrapper.confidence : null
+					if (current === null || current > THIRD_PARTY_CONFIDENCE_CAP) {
+						capped++
+						return { ...value, confidence: THIRD_PARTY_CONFIDENCE_CAP }
+					}
+				}
+			}
+			return value
+		}
+
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>).map(([k, v]) =>
+				SKIP_KEYS.has(k) ? [k, v] : [k, walk(v)],
+			),
+		)
+	}
+
+	return { findings: walk(findings), capped }
+}

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -251,7 +251,11 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 		const registry = yield* RegistryRouter
 		const contactDiscovery = yield* ContactDiscovery
 		const budget = yield* Budget
-		const { researchId } = yield* ResearchRunContext
+		const {
+			researchId,
+			language: hintLanguage,
+			location: hintLocation,
+		} = yield* ResearchRunContext
 
 		// Charged against the run before each vendor call (cheap tier for
 		// search/scrape, paid tier for the registry). When the budget
@@ -324,7 +328,11 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 							params.recency_days != null
 								? { days: params.recency_days }
 								: undefined,
-						location: params.location ?? undefined,
+						// Fall back to the run's location hint when the model gives none, and
+						// carry the run's language so the provider searches in the target's
+						// own language rather than defaulting to English.
+						location: params.location ?? hintLocation ?? undefined,
+						languages: hintLanguage ? [hintLanguage] : undefined,
 					})
 				}).pipe(
 					Effect.catchTag('BudgetExceeded', cheapExhausted('web_search')),

--- a/packages/research/src/infrastructure/_fallback.test.ts
+++ b/packages/research/src/infrastructure/_fallback.test.ts
@@ -1,0 +1,119 @@
+import { Effect, Exit } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { ProviderError } from '../domain/errors'
+import { withFallbackUntil } from './_fallback'
+
+type Behavior = 'hit' | 'empty' | 'error'
+interface Vendor {
+	readonly label: string
+	readonly behavior: Behavior
+}
+interface Result {
+	readonly items: ReadonlyArray<number>
+}
+
+// Records the order vendors are tried, so a test can assert a later slot is only
+// reached when the earlier ones came back empty or errored.
+const invokeWithLog =
+	(tried: string[]) =>
+	(vendor: Vendor): Effect.Effect<Result, ProviderError> => {
+		tried.push(vendor.label)
+		if (vendor.behavior === 'error') {
+			return Effect.fail(
+				new ProviderError({
+					provider: vendor.label,
+					message: 'boom',
+					recoverable: true,
+				}),
+			)
+		}
+		return Effect.succeed({ items: vendor.behavior === 'hit' ? [1] : [] })
+	}
+
+const run = (vendors: ReadonlyArray<Vendor>) => {
+	const tried: string[] = []
+	const exit = Effect.runPromiseExit(
+		withFallbackUntil(
+			vendors,
+			invokeWithLog(tried),
+			r => r.items.length === 0,
+		)(undefined),
+	)
+	return { exit, tried }
+}
+
+describe('withFallbackUntil', () => {
+	describe('when the first vendor has hits', () => {
+		it('should return them without trying the next', async () => {
+			// GIVEN a first vendor that returns results
+			const { exit, tried } = run([
+				{ label: 'firecrawl', behavior: 'hit' },
+				{ label: 'brave-context', behavior: 'hit' },
+			])
+
+			// THEN only the first is tried
+			const resolved = await exit
+			expect(Exit.isSuccess(resolved) && resolved.value.items).toEqual([1])
+			expect(tried).toEqual(['firecrawl'])
+		})
+	})
+
+	describe('when the first vendor is empty', () => {
+		it('should cascade to the next vendor and return its hits', async () => {
+			// GIVEN a first vendor that finds nothing, a second that does
+			const { exit, tried } = run([
+				{ label: 'firecrawl', behavior: 'empty' },
+				{ label: 'brave-context', behavior: 'hit' },
+			])
+
+			// THEN the empty result fell through to the richer vendor
+			const resolved = await exit
+			expect(Exit.isSuccess(resolved) && resolved.value.items).toEqual([1])
+			expect(tried).toEqual(['firecrawl', 'brave-context'])
+		})
+	})
+
+	describe('when the first vendor errors', () => {
+		it('should cascade to the next vendor', async () => {
+			// GIVEN a first vendor that errors
+			const { exit, tried } = run([
+				{ label: 'firecrawl', behavior: 'error' },
+				{ label: 'brave-context', behavior: 'hit' },
+			])
+
+			// THEN it falls through
+			const resolved = await exit
+			expect(Exit.isSuccess(resolved) && resolved.value.items).toEqual([1])
+			expect(tried).toEqual(['firecrawl', 'brave-context'])
+		})
+	})
+
+	describe('when every vendor is empty', () => {
+		it('should return a clean empty result, not an error', async () => {
+			// GIVEN both vendors find nothing
+			const { exit } = run([
+				{ label: 'firecrawl', behavior: 'empty' },
+				{ label: 'brave-context', behavior: 'empty' },
+			])
+
+			// THEN the caller gets an honest zero-hit
+			const resolved = await exit
+			expect(Exit.isSuccess(resolved) && resolved.value.items).toEqual([])
+		})
+	})
+
+	describe('when every vendor errors', () => {
+		it('should fail with the last error', async () => {
+			// GIVEN both vendors error
+			const { exit } = run([
+				{ label: 'firecrawl', behavior: 'error' },
+				{ label: 'brave-context', behavior: 'error' },
+			])
+
+			// THEN it fails (no vendor produced even an empty result)
+			const resolved = await exit
+			expect(Exit.isFailure(resolved)).toBe(true)
+		})
+	})
+})

--- a/packages/research/src/infrastructure/_fallback.ts
+++ b/packages/research/src/infrastructure/_fallback.ts
@@ -36,3 +36,50 @@ export const withFallback =
 			invoke(head, input),
 		)
 	}
+
+/**
+ * Like `withFallback`, but also moves to the next slot when a slot succeeds with
+ * an *empty* result, per the caller's `isEmpty` test — not only on error.
+ *
+ * Search uses this: one vendor returning zero hits is a plausible "found nothing",
+ * but a second, richer vendor often has what the first missed, so trying it once is
+ * worth the cost (the plain `withFallback` deliberately doesn't, to keep an honest
+ * zero-hit cheap). Returns the first non-empty result; if every slot is empty it
+ * returns an empty result (a real zero-hit the caller can act on), and it only
+ * fails when every slot errored.
+ */
+export const withFallbackUntil =
+	<Service, Input, Output, R>(
+		instances: ReadonlyArray<Service>,
+		invoke: (
+			svc: Service,
+			input: Input,
+		) => Effect.Effect<Output, ProviderError, R>,
+		isEmpty: (output: Output) => boolean,
+	) =>
+	(input: Input): Effect.Effect<Output, ProviderError, R> =>
+		Effect.gen(function* () {
+			let lastEmpty: Output | undefined
+			let lastError: ProviderError | undefined
+			for (const svc of instances) {
+				const outcome = yield* invoke(svc, input).pipe(
+					Effect.map(result => ({ _tag: 'ok' as const, result })),
+					Effect.catchTag('ProviderError', error =>
+						Effect.succeed({ _tag: 'err' as const, error }),
+					),
+				)
+				if (outcome._tag === 'err') {
+					lastError = outcome.error
+					continue
+				}
+				if (!isEmpty(outcome.result)) return outcome.result
+				lastEmpty = outcome.result
+			}
+			// Every slot was empty or errored: prefer handing back a real zero-hit over
+			// an error, so the model gets a clean "nothing found" it can act on.
+			if (lastEmpty !== undefined) return lastEmpty
+			if (lastError !== undefined) return yield* Effect.fail(lastError)
+			return yield* Effect.die(
+				new Error('withFallbackUntil: requires at least one provider instance'),
+			)
+		})

--- a/packages/research/src/infrastructure/brave/llm-context.test.ts
+++ b/packages/research/src/infrastructure/brave/llm-context.test.ts
@@ -1,0 +1,184 @@
+import { Cause, ConfigProvider, Effect, Exit, Fiber, Option } from 'effect'
+import { TestClock } from 'effect/testing'
+import {
+	HttpClient,
+	type HttpClientError,
+	type HttpClientRequest,
+	type HttpClientResponse,
+	HttpClientResponse as HttpClientResponseNs,
+} from 'effect/unstable/http'
+import { describe, expect, it } from 'vitest'
+
+import { ProviderError } from '../../domain/errors'
+import { makeBraveLlmContextSearch } from './llm-context'
+
+const jsonResponse = (
+	request: HttpClientRequest.HttpClientRequest,
+	status: number,
+	body: unknown,
+): HttpClientResponse.HttpClientResponse =>
+	HttpClientResponseNs.fromWeb(
+		request,
+		new Response(JSON.stringify(body), {
+			status,
+			headers: { 'content-type': 'application/json' },
+		}),
+	)
+
+interface CallLog {
+	count: number
+	last: HttpClientRequest.HttpClientRequest | undefined
+}
+
+const countingClient = (
+	log: CallLog,
+	status: number,
+	body: unknown,
+): HttpClient.HttpClient =>
+	HttpClient.makeWith<
+		HttpClientError.HttpClientError,
+		never,
+		HttpClientError.HttpClientError,
+		never
+	>(
+		effect =>
+			Effect.flatMap(effect, request => {
+				log.count += 1
+				log.last = request
+				return Effect.succeed(jsonResponse(request, status, body))
+			}),
+		Effect.succeed,
+	)
+
+const runWithVirtualClock = async <A, E>(
+	build: () => Effect.Effect<A, E, never>,
+	budgetMs = 60_000,
+	stepMs = 100,
+): Promise<Exit.Exit<A, E>> => {
+	const program = Effect.gen(function* () {
+		const fiber = yield* Effect.forkChild(build())
+		for (let elapsed = 0; elapsed < budgetMs; elapsed += stepMs) {
+			if (fiber.pollUnsafe() !== undefined) break
+			yield* Effect.yieldNow
+			yield* TestClock.adjust(`${stepMs} millis`)
+		}
+		return yield* Fiber.await(fiber)
+	})
+	return Effect.runPromise(
+		Effect.scoped(program).pipe(Effect.provide(TestClock.layer())),
+	)
+}
+
+const errorOf = (
+	exit: Exit.Exit<unknown, unknown>,
+): ProviderError | undefined => {
+	if (!Exit.isFailure(exit)) return undefined
+	const err = Option.getOrUndefined(Cause.findErrorOption(exit.cause))
+	return err instanceof ProviderError ? err : undefined
+}
+
+interface SearchArgs {
+	readonly query: string
+	readonly recency?: { days: number }
+	readonly languages?: string[]
+	readonly location?: string
+}
+
+const runSearch = (
+	status: number,
+	body: unknown,
+	args: SearchArgs = { query: 'acme logistics' },
+) => {
+	const log: CallLog = { count: 0, last: undefined }
+	const client = countingClient(log, status, body)
+	const exit = runWithVirtualClock(() =>
+		Effect.gen(function* () {
+			const provider = yield* makeBraveLlmContextSearch(0)
+			return yield* provider.search(args)
+		}).pipe(
+			Effect.provideService(HttpClient.HttpClient, client),
+			Effect.provide(
+				ConfigProvider.layer(
+					ConfigProvider.fromEnv({
+						env: { RESEARCH_API_KEY_SEARCH: 'brv_k' },
+					}),
+				),
+			),
+		),
+	)
+	return { exit, log }
+}
+
+describe('makeBraveLlmContextSearch', () => {
+	describe('when the endpoint returns grounding passages', () => {
+		it('should map each source to an item whose content is its joined snippets', async () => {
+			// GIVEN two grounded sources, the second with no usable snippets
+			const { exit } = runSearch(200, {
+				grounding: {
+					generic: [
+						{
+							url: 'https://acme.com/about',
+							title: 'About Acme',
+							snippets: ['Acme was founded in 2011.', 'HQ in Chicago, IL.'],
+						},
+						{ url: 'https://empty.com', title: 'Empty', snippets: ['  '] },
+					],
+				},
+			})
+
+			// THEN the first becomes a content-bearing item; the empty one is dropped
+			const resolved = await exit
+			const result = Exit.isSuccess(resolved) ? resolved.value : undefined
+			expect(result?.items.map(i => i.url)).toEqual(['https://acme.com/about'])
+			expect(result?.items[0]?.content).toBe(
+				'Acme was founded in 2011.\n\nHQ in Chicago, IL.',
+			)
+			expect(result?.units).toBe(1)
+		})
+	})
+
+	describe('when passed recency and language hints', () => {
+		it('should send the context token budgets, a freshness bucket, and the language', async () => {
+			// GIVEN a 3-day recency window and a Spanish language hint
+			const { exit, log } = runSearch(
+				200,
+				{ grounding: { generic: [] } },
+				{ query: 'acme', recency: { days: 3 }, languages: ['es'] },
+			)
+			await exit
+
+			// THEN the request carries the token budgets, the past-week bucket, and lang
+			const params = [...(log.last?.urlParams ?? [])]
+			const has = (k: string, v: string) =>
+				params.some(([pk, pv]) => pk === k && pv === v)
+			expect(has('maximum_number_of_tokens', '8192')).toBe(true)
+			expect(has('maximum_number_of_tokens_per_url', '4096')).toBe(true)
+			expect(has('freshness', 'pw')).toBe(true)
+			expect(has('search_lang', 'es')).toBe(true)
+		})
+	})
+
+	describe('when the endpoint fails', () => {
+		it('should surface a 401 as a ProviderError, not a clean empty result', async () => {
+			// GIVEN a rejected request (bad key)
+			const { exit } = runSearch(401, { detail: 'unauthorized' })
+
+			// THEN it fails loudly so the fallback and retry harness see it
+			const err = errorOf(await exit)
+			expect(err?.provider).toBe('brave-context')
+			expect(err?.recoverable).toBe(false)
+		})
+	})
+
+	describe('when the response has no grounding', () => {
+		it('should return an empty result without error', async () => {
+			// GIVEN a 200 with an absent grounding block
+			const { exit } = runSearch(200, {})
+
+			// THEN it is a clean empty success (an honest zero-hit)
+			const resolved = await exit
+			const result = Exit.isSuccess(resolved) ? resolved.value : undefined
+			expect(result?.items).toEqual([])
+		})
+	})
+})

--- a/packages/research/src/infrastructure/brave/llm-context.ts
+++ b/packages/research/src/infrastructure/brave/llm-context.ts
@@ -1,0 +1,161 @@
+/**
+ * Brave LLM Context provider — web search whose results are pre-extracted,
+ * relevance-ranked page content built for a model to read, not a person.
+ *
+ * A normal search returns links plus a one-line snippet; this endpoint returns,
+ * for each result, the actual passages of the page that answer the query, each
+ * still carrying its own source URL. That lands directly in this pipeline's
+ * grounding model — every value ties back to the page it came from — and, because
+ * Brave ranks by relevance across its whole index in the requested language, it
+ * finds a company's leadership or headquarters wherever it lives on the web
+ * regardless of the site's language or how its pages are named, without guessing
+ * URLs or crawling. It reuses the same Brave subscription key as the plain search
+ * provider, so switching a search slot to this vendor needs no new key.
+ *
+ * The extracted passages include third-party aggregators (company-profile sites),
+ * not just the company's own site — richer recall, but the source-tier guard
+ * downstream is what keeps an aggregator's estimate from being trusted like the
+ * company's own page.
+ *
+ * @see https://api-dashboard.search.brave.com/documentation/services/llm-context
+ */
+
+import { Config, Effect, Redacted, Schema } from 'effect'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
+
+import { type SearchInput, SearchProvider } from '../../application/ports'
+import { parseCountryAlpha2 } from '../../domain/country'
+import { ProviderError } from '../../domain/errors'
+import { SearchResult, SearchResultItem } from '../../domain/types'
+import { keyForSlot } from '../_config'
+import { hardenHttp } from '../_http-harden'
+
+// Context budget returned per request and per source page. Set to Brave's own
+// defaults (total 8192 of 1024–32768; per-url 4096 of 512–8192): billing is
+// per request, not per token, so a larger budget costs nothing extra and only
+// helps recall. Kept at the default rather than higher because the phase-2 prompt
+// caps the fetched-page text it reads anyway (MAX_EXTRACTION_PAGE_CHARS), so more
+// context here would be truncated there.
+const MAX_CONTEXT_TOKENS = 8192
+const MAX_TOKENS_PER_URL = 4096
+
+// ── Brave LLM Context response schema (subset we care about) ──
+
+// One source's extracted passages. `snippets` may hold plain prose or
+// JSON-serialized structured data (an FAQ block, a table); both read as text.
+const GroundingItem = Schema.Struct({
+	url: Schema.String,
+	title: Schema.optional(Schema.String),
+	snippets: Schema.optional(Schema.Array(Schema.String)),
+})
+
+const LlmContextResponse = Schema.Struct({
+	grounding: Schema.optional(
+		Schema.Struct({
+			generic: Schema.optional(Schema.Array(GroundingItem)),
+		}),
+	),
+})
+
+// Brave's freshness takes discrete buckets (past day/week/month/year), never a
+// "past N days" number, so map the requested window to the nearest bucket.
+const freshnessForRecency = (days: number): string =>
+	days <= 1 ? 'pd' : days <= 7 ? 'pw' : days <= 31 ? 'pm' : 'py'
+
+// ── Provider factory ──
+
+export const makeBraveLlmContextSearch = (slot: number) =>
+	Effect.gen(function* () {
+		const apiKey = yield* Config.redacted(
+			keyForSlot('RESEARCH_API_KEY_SEARCH', slot),
+		)
+		const client = yield* HttpClient.HttpClient
+		const harden = hardenHttp('brave-context')
+
+		return SearchProvider.of({
+			search: (input: SearchInput) =>
+				harden(
+					Effect.gen(function* () {
+						const country = parseCountryAlpha2(input.location)
+						const response = yield* client
+							.get('https://api.search.brave.com/res/v1/llm/context', {
+								headers: {
+									Accept: 'application/json',
+									'Accept-Encoding': 'gzip',
+									'X-Subscription-Token': Redacted.value(apiKey),
+								},
+								urlParams: {
+									q: input.query,
+									count: String(input.limit ?? 10),
+									maximum_number_of_tokens: String(MAX_CONTEXT_TOKENS),
+									maximum_number_of_tokens_per_url: String(MAX_TOKENS_PER_URL),
+									...(input.recency
+										? { freshness: freshnessForRecency(input.recency.days) }
+										: {}),
+									...(country ? { country } : {}),
+									...(input.languages?.[0]
+										? { search_lang: input.languages[0] }
+										: {}),
+								},
+							})
+							.pipe(
+								Effect.mapError(
+									e =>
+										new ProviderError({
+											provider: 'brave-context',
+											message: String(e),
+											recoverable: true,
+										}),
+								),
+							)
+						// A failed call (bad key → 401, quota → 429) must surface as an
+						// error, not decode to an empty grounding that looks like a clean
+						// zero-hit — otherwise the retry harness and the cross-vendor
+						// fallback never see the failure.
+						if (response.status < 200 || response.status >= 300) {
+							return yield* Effect.fail(
+								new ProviderError({
+									provider: 'brave-context',
+									message: `llm-context failed: HTTP ${response.status}`,
+									recoverable:
+										response.status === 429 || response.status >= 500,
+								}),
+							)
+						}
+						const body = yield* HttpClientResponse.schemaBodyJson(
+							LlmContextResponse,
+						)(response).pipe(
+							Effect.mapError(
+								e =>
+									new ProviderError({
+										provider: 'brave-context',
+										message: `unexpected llm-context response: ${e}`,
+										recoverable: false,
+									}),
+							),
+						)
+						return new SearchResult({
+							// Each extracted source becomes a result whose `content` is the
+							// grounding passages — real page text the run can cite, not just a
+							// snippet. Drop any item with no usable text.
+							items: (body.grounding?.generic ?? []).flatMap(item => {
+								const content = (item.snippets ?? [])
+									.map(s => s.trim())
+									.filter(s => s.length > 0)
+									.join('\n\n')
+								if (content.length === 0) return []
+								return [
+									new SearchResultItem({
+										url: item.url,
+										title: item.title ?? item.url,
+										snippet: content.slice(0, 300),
+										content,
+									}),
+								]
+							}),
+							units: 1,
+						})
+					}),
+				),
+		})
+	})

--- a/packages/research/src/infrastructure/providers-live.ts
+++ b/packages/research/src/infrastructure/providers-live.ts
@@ -52,7 +52,7 @@ import type {
 	SearchResult,
 } from '../domain/types'
 import { providerListConfig } from './_config'
-import { withFallback } from './_fallback'
+import { withFallback, withFallbackUntil } from './_fallback'
 import {
 	disabledError,
 	noRegistryError,
@@ -276,10 +276,14 @@ const searchLayer = Layer.effect(
 			vendors.map((vendor, slot) => searchInstance(vendor, slot)),
 		)
 		if (instances.length === 1) return instances[0]!
-		const search = withFallback(
+		// Search cascades on an empty result too, not only on error: a firecrawl
+		// zero-hit falls through to the next vendor (e.g. brave-context), which often
+		// has what the first missed.
+		const search = withFallbackUntil(
 			instances,
 			(svc, input: SearchInput): Effect.Effect<SearchResult, ProviderError> =>
 				svc.search(input),
+			result => result.items.length === 0,
 		)
 		return SearchProvider.of({ search })
 	}),

--- a/packages/research/src/infrastructure/providers-live.ts
+++ b/packages/research/src/infrastructure/providers-live.ts
@@ -58,6 +58,7 @@ import {
 	noRegistryError,
 	notYetImplementedError,
 } from './_shared'
+import { makeBraveLlmContextSearch } from './brave/llm-context'
 import { makeBraveSearch } from './brave/search'
 import { makeCachedExtract } from './cached-extract'
 import { makeCachedScrape } from './cached-scrape'
@@ -83,7 +84,7 @@ import { StubEmailVerifierInstance } from './stub/verifier'
 
 // ── Vendor literal unions ──
 
-const SEARCH_VENDORS = ['stub', 'brave', 'firecrawl'] as const
+const SEARCH_VENDORS = ['stub', 'brave', 'brave-context', 'firecrawl'] as const
 const SCRAPE_VENDORS = ['stub', 'firecrawl', 'local'] as const
 const EXTRACT_VENDORS = ['stub', 'firecrawl', 'local'] as const
 const DISCOVER_VENDORS = ['stub', 'firecrawl', 'anthropic', 'none'] as const
@@ -105,6 +106,8 @@ const searchInstance = (vendor: SearchVendor, slot: number) => {
 			return Effect.succeed(StubSearchProviderInstance)
 		case 'brave':
 			return makeBraveSearch(slot)
+		case 'brave-context':
+			return makeBraveLlmContextSearch(slot)
 		case 'firecrawl':
 			return makeFirecrawlSearch(slot)
 	}


### PR DESCRIPTION
## What

Research (the CRM's automated company-research context; `server`) only reaches useful facts if it can *find* and *ground* them. This PR widens and hardens that acquisition side — it's the **second PR of the #255 effort**: #261 fixed the grounding/extraction guards, and a later, third PR will rework the extractor itself.

The centre is a new search vendor built on **Brave's LLM Context API**: instead of a link plus a one-line snippet, it returns the pre-extracted passages of the pages that answer a query — each still carrying its source URL — ranked across Brave's whole index in the requested language. That is richer, already-grounded evidence in one call, and it finds a company's leadership or headquarters wherever they live on the web, whatever the site's language or page names (Batuda researches companies worldwide, so most targets aren't English).

Because that richer feed also pulls in third-party company-profile aggregators (whose headcounts and phones are often estimated or stale), it ships **with a safety net**: a value cited to anything but the company's own domain has its confidence capped to medium, so an outside estimate can never be trusted like the company's own word.

## Changes

- **Brave LLM Context search vendor** (`brave-context`) — selectable via `RESEARCH_PROVIDER_SEARCH`, reusing the existing Brave key.
- **Source-tier guard** — caps confidence on any per-field value cited to a host that isn't the target's own domain. Kept, not dropped — just no longer trusted first-party. Active for entity-gated runs; a no-op for discovery scans.
- **Empty-search cascade** — a search that returns zero hits now falls through to the next vendor (only errors did before), so a richer vendor gets a chance; if every vendor is empty the caller still gets a clean zero-hit.
- **Language reaches search** — the run's language/location hints now flow into the search provider, which previously always defaulted to English.
- **Own-site pages first** — phase-2 extraction fills its page budget with the company's own (anchor) pages before third-party ones.
- **Right-sized phase-2 page budget** — raised 60k→180k chars with a per-page cap, after confirming the extract model actually serves a 256k-token window (128k on the fallback). The old budget truncated content-rich targets and multi-company scans.

## Impact

- **A config change is needed to *use* the vendor in production.** This only adds the capability; prod still runs `firecrawl,brave`. Enabling it means setting `RESEARCH_PROVIDER_SEARCH` (e.g. `firecrawl,brave-context`) in `config.production.json` and making sure the Brave key sits at the matching key slot (`RESEARCH_API_KEY_SEARCH` / `_2`). No new secret — it's the same Brave subscription.
- **`ResearchRunContext` gained two optional fields** (language, location). Additive; every existing provider still compiles.
- **No migration, no schema/wire-shape change, no RLS/auth surface touched.** Findings JSON shape is unchanged (confidence is an existing field; source-tier only lowers it).
- **Cost:** the LLM Context endpoint is $5/1k requests (0.5¢), billed per request; when configured as a fallback it only fires on an empty primary search.

## Review guide

- **Start:** `infrastructure/brave/llm-context.ts` (the vendor, mirrors the existing `brave/search.ts` template) and `application/source-tier-guard.ts` (the safety net).
- **Riskiest new logic:** `_fallback.ts`'s `withFallbackUntil` (the empty-aware cascade — unit-tested for hit/empty/error/all-empty/all-error) and the source-tier guard's first-party/aggregator line.
- **A decision you might overrule:** the source-tier guard uses a strict "own-domain (or subdomain) = first-party, everything else = capped to 0.6" rule — deliberately conservative, so a legit news/registry source is also capped. If that over-caps in the eval, the refinement is a registry/gov tier or corroboration-based un-capping.
- **Honest note on the payoff (see Verification):** the vendor surfaces aggregator facts (a headcount, a phone) as *evidence*, but the current extractor still cites only the official domain and doesn't capture them into fields — that conversion is PR 3's decomposed extraction. So the source-tier guard is a **correct dormant net** today; it engages once PR 3 starts pulling aggregator-cited fields.

## Tests

- New unit tests: the vendor's response mapping + error/empty handling; the source-tier guard (first-party kept, aggregator capped, cap-not-raise, scan no-op, subtree skips); and `withFallbackUntil`'s cascade paths. Research package: 551 tests pass.

## Verification

- Gates green: `pnpm -w check-types` (13/13), `pnpm -w test` (20/20), `pnpm -w build` (13/13).
- **Live**, against real vendors (Brave LLM Context as the search vendor, Nebius/Fireworks/Groq LLM tiers, keys via Infisical, on the worktree DB): `company_enrichment_v1` for Circle Logistics + Sunset Transportation — **grounding 100%, wrong-company 0%, empty 0%**. Sunset, which came back **empty in PR 1 (#261)**, now yields grounded fields; the scalar guard dropped a placeholder; source-tier was a correct no-op (no aggregator-cited field survived the extractor). Field precision was mixed because the extractor kept citing the official site over the aggregator facts — the PR 3 gap called out above.
- The language-hint→search plumb is verified structurally (type-checked end to end); the eval CLI doesn't pass hints, so it wasn't exercised live.

## Deferred

- **PR 3** — decomposed contacts-and-titles extraction + per-contact entity binding: the step that turns the richer evidence this PR gathers into filled fields (size, phone, more contacts), and where the source-tier guard starts doing visible work.
- Optionally: a registry/gov trust tier and corroboration-based un-capping if the strict first-party rule over-caps.

Addresses #255 (PR 2 of the effort; not closing — PR 3 completes the recall payoff).
