### PR TITLE
feat(research): recover contacts, titles, and tooling into the record

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -924,7 +924,7 @@ const researchEvalCommand = Command.make(
 		'Score the research pipeline against a golden set',
 	),
 	Command.withDescription(
-		'Drive each company in a golden-set JSON file through the live research pipeline and report grounding accuracy, field precision, field recall, wrong-company rate, and empty rate. Needs the research env configured (LLM + provider keys, DATABASE_URL) and an --org / --user to run as. Writes a full per-run report with --out.',
+		'Drive each company in a golden-set JSON file through the live research pipeline and report grounding accuracy, field precision, field recall, titled-contact recall, wrong-company rate, and empty rate. Needs the research env configured (LLM + provider keys, DATABASE_URL) and an --org / --user to run as. Writes a full per-run report with --out.',
 	),
 )
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -887,6 +887,12 @@ const researchEvalCommand = Command.make(
 			Flag.withDescription('Research output schema to run'),
 			Flag.withDefault('company_enrichment_v1'),
 		),
+		language: Flag.string('language').pipe(
+			Flag.withDescription(
+				"Language hint for the runs (e.g. es, ca, en) — carried into the search so it looks in the target's own language, for testing non-English targets",
+			),
+			Flag.optional,
+		),
 		concurrency: Flag.integer('concurrency').pipe(
 			Flag.withDescription('How many runs to execute at once'),
 			Flag.withDefault(3),
@@ -902,12 +908,13 @@ const researchEvalCommand = Command.make(
 			Flag.optional,
 		),
 	},
-	({ org, user, golden, schema, concurrency, runs, out }) =>
+	({ org, user, golden, schema, language, concurrency, runs, out }) =>
 		researchEval({
 			org,
 			user,
 			goldenPath: golden,
 			schemaName: schema,
+			language,
 			concurrency,
 			runs,
 			out,

--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -206,14 +206,20 @@ const driveOne = (
 	defaults: SystemDefaults,
 	golden: GoldenExpectation,
 	schemaName: string,
+	language: string | undefined,
 ) =>
 	Effect.gen(function* () {
 		const svc = yield* ResearchService
+		// Narrow the free-text flag to a supported language, dropping anything else.
+		const lang = (['ca', 'es', 'en'] as const).find(l => l === language)
 		const input: CreateResearchInput = {
 			query: golden.query,
 			schemaName,
 			// Always execute a fresh run; a cached clone would score stale data.
 			forceFresh: true,
+			// Carry the language hint so the search looks in the target's own
+			// language — the seam for testing a non-English company end to end.
+			...(lang ? { context: { hints: { language: lang } } } : {}),
 		}
 		const created = yield* svc.create(user, org, input, defaults)
 		// A single-subject eval never fans out, so it always carries a run id;
@@ -281,6 +287,7 @@ export const researchEval = (opts: {
 	readonly user: string
 	readonly goldenPath: string
 	readonly schemaName: string
+	readonly language: Option.Option<string>
 	readonly concurrency: number
 	readonly runs: number
 	readonly out: Option.Option<string>
@@ -331,6 +338,7 @@ export const researchEval = (opts: {
 						defaults,
 						company,
 						opts.schemaName,
+						Option.getOrUndefined(opts.language),
 					).pipe(
 						Effect.tap(score =>
 							Effect.annotateCurrentSpan(evalSpanAttributes(score)),

--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -259,7 +259,17 @@ const formatCompanyRuns = (
 	const scored = scores.reduce((sum, score) => sum + score.fieldsScored, 0)
 	const correct = scores.reduce((sum, score) => sum + score.fieldsCorrect, 0)
 	const fields = scored === 0 ? 'n/a' : pct(correct / scored)
-	return `${id.padEnd(20)} grounded ${share(grounded)}  wrong ${share(wrong)}  empty ${share(empty)}  fields ${fields}`
+	const contactsExpected = scores.reduce(
+		(sum, score) => sum + score.contactsExpected,
+		0,
+	)
+	const contactsFound = scores.reduce(
+		(sum, score) => sum + score.contactsFound,
+		0,
+	)
+	const contacts =
+		contactsExpected === 0 ? 'n/a' : `${contactsFound}/${contactsExpected}`
+	return `${id.padEnd(20)} grounded ${share(grounded)}  wrong ${share(wrong)}  empty ${share(empty)}  fields ${fields}  contacts ${contacts}`
 }
 
 const pct = (value: number | null): string =>
@@ -268,12 +278,13 @@ const pct = (value: number | null): string =>
 const formatSummary = (summary: EvalSummary): string =>
 	[
 		'',
-		`Runs:               ${summary.runs}`,
-		`Grounding accuracy: ${pct(summary.groundingAccuracy)}`,
-		`Field precision:    ${pct(summary.fieldPrecision)}`,
-		`Field recall:       ${pct(summary.fieldRecall)}`,
-		`Wrong-company rate: ${pct(summary.wrongCompanyRate)}`,
-		`Empty rate:         ${pct(summary.emptyRate)}`,
+		`Runs:                   ${summary.runs}`,
+		`Grounding accuracy:     ${pct(summary.groundingAccuracy)}`,
+		`Field precision:        ${pct(summary.fieldPrecision)}`,
+		`Field recall:           ${pct(summary.fieldRecall)}`,
+		`Titled-contact recall:  ${pct(summary.contactRecall)}`,
+		`Wrong-company rate:     ${pct(summary.wrongCompanyRate)}`,
+		`Empty rate:             ${pct(summary.emptyRate)}`,
 	].join('\n')
 
 /**

--- a/eval/README.md
+++ b/eval/README.md
@@ -14,7 +14,9 @@ pnpm cli research probe --api-key <nebius-key>
 pnpm cli research eval --org <org-id> --user <user-id> --golden eval/golden.json --out report.json
 ```
 
-`eval` prints the five metrics — grounding accuracy, field precision, field recall, wrong-company rate, empty rate — and writes a full per-run report with `--out`.
+`eval` prints the metrics — grounding accuracy, field precision, field recall, titled-contact recall, wrong-company rate, empty rate — and writes a full per-run report with `--out`.
+
+Titled-contact recall answers a gap the four scalar fields miss: of the people a company is known to publish, how many the run returned **with a title**. Contacts sit outside the scored field set, so a run can pass every field yet hand back the decision-makers with no title — the exact symptom this metric watches. It only appears (else `n/a`) for rows that list expected `contacts`.
 
 ## Providing keys
 
@@ -41,7 +43,8 @@ A JSON array of rows. Copy `golden.example.json` to your own `golden.json` and r
   "expectedOutput": {
     "officialDomain": "company.com",
     "altDomains": ["a-registry-profile.example"],
-    "fields": { "industry": "…", "size_range": "…", "country": "…", "location": "…" }
+    "fields": { "industry": "…", "size_range": "…", "country": "…", "location": "…" },
+    "contacts": ["Ada Lovelace", { "name": "Alan Turing" }]
   }
 }
 ```
@@ -50,6 +53,7 @@ A JSON array of rows. Copy `golden.example.json` to your own `golden.json` and r
 - `officialDomain` — the company's own website host; the primary proof the run reached the target. **Required.**
 - `altDomains` — other hosts that also prove the target was reached (a registry profile, a known subsidiary). Optional.
 - `fields` — the known-correct values. Only these four keys are scored, and a misspelled key is rejected loudly. All optional — score only the fields you can verify.
+- `contacts` — people the company is known to publish, each a name string or a `{ "name": "…" }` object. They score titled-contact recall: how many came back with a title. Name matching folds accents and tolerates a middle name/initial, but it tokenizes on Latin letters — a name written only in a non-Latin script (CJK, Cyrillic, Greek, Arabic) won't match, so romanize it in the golden row. Optional; a fabricated name skews the metric exactly as a wrong field value does, so list only real, verifiable people. No `role` here — the metric checks that the run supplied *some* title, not which one.
 
 ### Allowed field values
 

--- a/eval/golden.example.json
+++ b/eval/golden.example.json
@@ -8,7 +8,8 @@
 				"industry": "manufactura",
 				"country": "GB",
 				"location": "London"
-			}
+			},
+			"contacts": ["Will Butler-Adams"]
 		}
 	},
 	{

--- a/packages/research/src/application/contact-entity-guard.test.ts
+++ b/packages/research/src/application/contact-entity-guard.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import { bindContactsToEntity } from './contact-entity-guard'
+import { deriveEntityTargets } from './entity-guard'
+
+// The run is researching Circle Logistics; targets carry its name-core + domain.
+const targets = deriveEntityTargets({
+	schemaName: 'company_enrichment_v1',
+	query: 'Circle Logistics',
+	anchorDomain: 'circledelivers.com',
+	subjects: [
+		{
+			table: 'companies',
+			name: 'Circle Logistics',
+			website: 'circledelivers.com',
+		},
+	],
+})
+
+const contactsOf = (findings: unknown): Array<{ name: string }> =>
+	(findings as { contacts: Array<{ name: string }> }).contacts
+
+describe('bindContactsToEntity', () => {
+	describe('when a contact quote names a different company as employer', () => {
+		it('should drop the testimonial/client executive', () => {
+			// GIVEN a person quoted on the target's site but working for another company
+			const findings = {
+				contacts: [
+					{
+						name: 'Mark Riskowitz',
+						role: {
+							value: 'VP of Operations',
+							source_id: 'https://circledelivers.com/testimonials',
+							quote: 'Mark Riskowitz, VP of Operations at Caraway Logistics',
+						},
+					},
+				],
+			}
+
+			// WHEN bound to the target
+			const result = bindContactsToEntity(findings, targets)
+
+			// THEN the wrong-company person is removed
+			expect(contactsOf(result.findings)).toHaveLength(0)
+			expect(result.dropped).toBe(1)
+		})
+	})
+
+	describe('when a contact quote names the target as employer', () => {
+		it('should keep them', () => {
+			// GIVEN a press mention naming the target
+			const findings = {
+				contacts: [
+					{
+						name: 'Andrew Smith',
+						role: {
+							value: 'SVP',
+							source_id: 'https://circledelivers.com/news',
+							quote:
+								'Circle Logistics promotes Andrew J. Smith to Senior Vice President',
+						},
+					},
+				],
+			}
+
+			// WHEN bound
+			const result = bindContactsToEntity(findings, targets)
+
+			// THEN kept
+			expect(contactsOf(result.findings)).toHaveLength(1)
+			expect(result.dropped).toBe(0)
+		})
+	})
+
+	describe('when a contact quote names no company', () => {
+		it('should keep them for the critic to judge', () => {
+			// GIVEN a plain title with no employer named
+			const findings = {
+				contacts: [
+					{
+						name: 'Chad Buchanan',
+						role: {
+							value: 'CFO',
+							source_id: 'https://circledelivers.com/about',
+							quote: 'Chad Buchanan – CFO',
+						},
+					},
+				],
+			}
+
+			// WHEN bound
+			const result = bindContactsToEntity(findings, targets)
+
+			// THEN kept (no company to contradict the target)
+			expect(contactsOf(result.findings)).toHaveLength(1)
+			expect(result.dropped).toBe(0)
+		})
+	})
+
+	describe('when the quote names the target and another company', () => {
+		it('should keep them (they are tied to the target)', () => {
+			// GIVEN a bio mentioning a prior employer alongside the target
+			const findings = {
+				contacts: [
+					{
+						name: 'Eric Fortmeyer',
+						citations: [
+							{
+								source_id: 'https://circledelivers.com/about',
+								quote:
+									'Eric Fortmeyer, CEO of Circle Logistics, previously at Acme Freight',
+							},
+						],
+					},
+				],
+			}
+
+			// WHEN bound
+			const result = bindContactsToEntity(findings, targets)
+
+			// THEN kept
+			expect(contactsOf(result.findings)).toHaveLength(1)
+		})
+	})
+
+	describe('when there is no single target (a discovery scan)', () => {
+		it('should be a no-op', () => {
+			// GIVEN null targets
+			const findings = {
+				contacts: [
+					{ name: 'X', role: { value: 'VP', quote: 'X, VP at Other Corp' } },
+				],
+			}
+
+			// WHEN bound with no target
+			const result = bindContactsToEntity(findings, null)
+
+			// THEN untouched
+			expect(contactsOf(result.findings)).toHaveLength(1)
+			expect(result.dropped).toBe(0)
+		})
+	})
+})

--- a/packages/research/src/application/contact-entity-guard.ts
+++ b/packages/research/src/application/contact-entity-guard.ts
@@ -1,0 +1,103 @@
+/**
+ * Drops a contact whose own evidence ties them to a *different* company.
+ *
+ * A company's site often quotes people who don't work there — a client
+ * testimonial, a partner, a competitor's executive in a press mention. The broad
+ * and rescue extractions pick those up as "contacts", and because the quote sits on
+ * the target's own page the source-based checks can't tell them apart. The one
+ * reliable signal is the quote itself naming the person's employer: "…, VP of
+ * Operations at Caraway Logistics" names Caraway, not the company being researched.
+ *
+ * So this guard reads each contact's supporting quotes, pulls out any company-like
+ * name they mention (a proper name followed by a company marker — Inc, Ltd,
+ * Logistics, Group, …), and drops the contact when every company its evidence names
+ * is some *other* company and none is the target. A contact whose quotes name no
+ * company, or name the target, is kept — subtler cases (no company in the quote at
+ * all) are left to the model-backed critic, which already asks whether a quote is
+ * about this company.
+ */
+
+import { classifyEntityMatch, type EntityTargets } from './entity-guard'
+
+// A proper name (one to five capitalised words) directly followed by a company
+// marker — the shape of "<Company> Inc" / "Caraway Logistics". The markers include
+// the sector words that routinely form logistics company names.
+const ORG_PHRASE =
+	/\b([A-Z][A-Za-z0-9&.'’-]*(?:\s+[A-Z][A-Za-z0-9&.'’-]*){0,4})\s+(Inc|LLC|Corp|Corporation|Ltd|Co|Company|Group|Holdings|Logistics|Transport|Transportation|Freight|Shipping|Solutions|Technologies|Systems|Industries|Services|Partners|GmbH|S\.?A|S\.?L|Srl|BV|AG|Pty|PLC)\b\.?/g
+
+const orgPhrasesIn = (text: string): ReadonlyArray<string> =>
+	[...text.matchAll(ORG_PHRASE)].map(m => `${m[1]} ${m[2]}`)
+
+// Every quote a contact carries: its per-field sources (role/email/phone) and its
+// own citation list. These are what tie — or fail to tie — the person to the target.
+const contactQuotes = (contact: Record<string, unknown>): string => {
+	const parts: string[] = []
+	for (const key of ['role', 'email', 'phone']) {
+		const field = contact[key]
+		if (
+			field !== null &&
+			typeof field === 'object' &&
+			typeof (field as { quote?: unknown }).quote === 'string'
+		) {
+			parts.push((field as { quote: string }).quote)
+		}
+	}
+	const citations = contact['citations']
+	if (Array.isArray(citations)) {
+		for (const c of citations) {
+			if (
+				c !== null &&
+				typeof c === 'object' &&
+				typeof (c as { quote?: unknown }).quote === 'string'
+			) {
+				parts.push((c as { quote: string }).quote)
+			}
+		}
+	}
+	return parts.join(' ')
+}
+
+export interface ContactEntityResult {
+	readonly findings: unknown
+	/** Contacts dropped because their evidence named only a different company. */
+	readonly dropped: number
+}
+
+/**
+ * Remove contacts whose supporting quotes name only other companies. `targets` are
+ * the run's entity targets; a null/absent target (a discovery scan) is a no-op.
+ */
+export const bindContactsToEntity = (
+	findings: unknown,
+	targets: EntityTargets | null,
+): ContactEntityResult => {
+	if (
+		targets === null ||
+		findings === null ||
+		typeof findings !== 'object' ||
+		Array.isArray(findings)
+	) {
+		return { findings, dropped: 0 }
+	}
+	const contacts = (findings as { contacts?: unknown }).contacts
+	if (!Array.isArray(contacts)) return { findings, dropped: 0 }
+
+	let dropped = 0
+	const kept = contacts.filter(contact => {
+		if (contact === null || typeof contact !== 'object') return true
+		const orgs = orgPhrasesIn(contactQuotes(contact as Record<string, unknown>))
+		// No company named in the evidence → can't tell from here; keep and let the
+		// critic judge. A company named → keep only if one of them is the target.
+		if (orgs.length === 0) return true
+		const namesTarget = orgs.some(
+			org => classifyEntityMatch(targets, org) === 'strong',
+		)
+		if (!namesTarget) dropped++
+		return namesTarget
+	})
+
+	return {
+		findings: { ...(findings as object), contacts: kept },
+		dropped,
+	}
+}

--- a/packages/research/src/application/contacts-rescue.test.ts
+++ b/packages/research/src/application/contacts-rescue.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	mergeContacts,
+	needsContactRescue,
+	normalizeContactName,
+} from './contacts-rescue'
+
+describe('needsContactRescue', () => {
+	describe('when the broad pass returned few or no named contacts', () => {
+		it('should ask for a rescue on zero contacts', () => {
+			// GIVEN findings with no contacts
+			// THEN a rescue is warranted
+			expect(needsContactRescue({ contacts: [] })).toBe(true)
+			expect(needsContactRescue({})).toBe(true)
+		})
+
+		it('should ask for a rescue on a single contact', () => {
+			// GIVEN one named contact
+			// THEN still thin enough to rescue
+			expect(needsContactRescue({ contacts: [{ name: 'Ada' }] })).toBe(true)
+		})
+
+		it('should not count a nameless entry', () => {
+			// GIVEN one entry with a blank name
+			// THEN it doesn't count, so a rescue is warranted
+			expect(needsContactRescue({ contacts: [{ name: '   ' }] })).toBe(true)
+		})
+	})
+
+	describe('when the broad pass already found people', () => {
+		it('should not rescue with two or more named contacts', () => {
+			// GIVEN two named contacts
+			// THEN the broad pass delivered; no rescue
+			expect(
+				needsContactRescue({ contacts: [{ name: 'Ada' }, { name: 'Chad' }] }),
+			).toBe(false)
+		})
+	})
+})
+
+describe('normalizeContactName', () => {
+	it('should fold case, accents, and punctuation to a comparison key', () => {
+		// GIVEN two spellings of the same name
+		// THEN they reduce to the same key
+		expect(normalizeContactName('José García-López')).toBe(
+			normalizeContactName('Jose Garcia Lopez'),
+		)
+		expect(normalizeContactName('  Eric   Fortmeyer ')).toBe('eric fortmeyer')
+	})
+})
+
+describe('mergeContacts', () => {
+	describe('when broad and rescued name different people', () => {
+		it('should union them in first-seen order', () => {
+			// GIVEN one contact from each pass
+			const broad = [{ name: 'Eric Fortmeyer', role: { value: 'CEO' } }]
+			const rescued = [{ name: 'Chad Buchanan', role: { value: 'CFO' } }]
+
+			// WHEN merged
+			const merged = mergeContacts(broad, rescued)
+
+			// THEN both survive, broad first
+			expect(merged.map(c => c.name)).toEqual([
+				'Eric Fortmeyer',
+				'Chad Buchanan',
+			])
+		})
+	})
+
+	describe('when the same person appears in both', () => {
+		it('should keep the broad fields, fill the gaps, and union citations', () => {
+			// GIVEN the broad contact has a role but no title source, the rescue adds a
+			// citation and a role
+			const broad = [
+				{
+					name: 'Eric Fortmeyer',
+					role: { value: 'President & CEO', source_id: 'https://circle.com' },
+					citations: [{ source_id: 'https://circle.com' }],
+				},
+			]
+			const rescued = [
+				{
+					name: 'eric  fortmeyer',
+					role: { value: 'CEO' },
+					citations: [{ source_id: 'https://circle.com/about' }],
+				},
+			]
+
+			// WHEN merged
+			const merged = mergeContacts(broad, rescued)
+
+			// THEN one contact, broad's richer role kept, citations unioned
+			expect(merged).toHaveLength(1)
+			expect(merged[0]?.role).toEqual({
+				value: 'President & CEO',
+				source_id: 'https://circle.com',
+			})
+			expect(merged[0]?.citations).toEqual([
+				{ source_id: 'https://circle.com' },
+				{ source_id: 'https://circle.com/about' },
+			])
+		})
+
+		it('should fill a missing role from the rescue pass', () => {
+			// GIVEN the broad contact is name-only, the rescue found the title
+			const broad = [{ name: 'Andrew Smith' }]
+			const rescued = [
+				{ name: 'Andrew Smith', role: { value: 'VP Sales & Operations' } },
+			]
+
+			// WHEN merged
+			const merged = mergeContacts(broad, rescued)
+
+			// THEN the recovered title lands on the single contact
+			expect(merged).toHaveLength(1)
+			expect(merged[0]?.role).toEqual({ value: 'VP Sales & Operations' })
+		})
+	})
+
+	describe('when two names differ by an initial', () => {
+		it('should keep both rather than risk merging different people', () => {
+			// GIVEN a plain name and a middle-initial variant
+			const broad = [{ name: 'Andrew Smith' }]
+			const rescued = [{ name: 'Andrew J. Smith' }]
+
+			// WHEN merged
+			const merged = mergeContacts(broad, rescued)
+
+			// THEN both are kept (conservative: no lossy merge)
+			expect(merged.map(c => c.name)).toEqual([
+				'Andrew Smith',
+				'Andrew J. Smith',
+			])
+		})
+	})
+
+	describe('when a contact has a blank name', () => {
+		it('should drop it', () => {
+			// GIVEN a nameless entry
+			const merged = mergeContacts([{ name: '  ' }], [{ name: 'Ada' }])
+
+			// THEN only the named one survives
+			expect(merged.map(c => c.name)).toEqual(['Ada'])
+		})
+	})
+})

--- a/packages/research/src/application/contacts-rescue.ts
+++ b/packages/research/src/application/contacts-rescue.ts
@@ -1,0 +1,139 @@
+/**
+ * A focused second extraction that recovers a company's people when the broad
+ * pass under-delivered.
+ *
+ * The single broad `generateObject` fills the whole schema at once and reliably
+ * drops the contacts list — the evidence names the leaders, but the model's
+ * attention is spread across every other field and it returns one contact or none.
+ * This runs a narrow pass that does nothing but pull named people and their titles,
+ * then folds them into the broad findings. It fires only when the broad pass found
+ * at most one contact, so a run that already has its people pays nothing.
+ *
+ * The recovered contacts flow through the same guard chain as the broad ones
+ * (citations, per-contact entity binding, source tier), so nothing here ships
+ * unguarded — this module only defines the focused schema, its prompt, the merge,
+ * and the "should we bother" test; the run wires them into the guard chain.
+ */
+
+import { Schema } from 'effect'
+
+import { Citation, Sourced } from './schemas/_shared'
+
+// The narrow schema the focused pass fills: people only, each with a title and the
+// source(s) that name them as this company's own staff. Citations are required
+// here (unlike the optional field on the broad schema) so a recovered contact is
+// never added without provenance to bind it to the target.
+const RescueContact = Schema.Struct({
+	name: Schema.String,
+	role: Schema.optionalKey(Sourced(Schema.String)),
+	citations: Schema.Array(Citation),
+})
+
+export const ContactsRescueSchema = Schema.Struct({
+	contacts: Schema.Array(RescueContact),
+})
+
+// Below this many contacts, the broad pass is treated as having under-delivered and
+// the focused pass runs. One-or-none is the signal a company that publishes a team
+// still came back essentially empty.
+const RESCUE_BELOW_CONTACTS = 2
+
+const contactsOf = (findings: unknown): ReadonlyArray<unknown> => {
+	if (findings === null || typeof findings !== 'object') return []
+	const contacts = (findings as { contacts?: unknown }).contacts
+	return Array.isArray(contacts) ? contacts : []
+}
+
+/** Whether the broad findings are thin enough on people to justify a focused pass. */
+export const needsContactRescue = (findings: unknown): boolean =>
+	contactsOf(findings).filter(
+		c =>
+			c !== null &&
+			typeof c === 'object' &&
+			typeof (c as { name?: unknown }).name === 'string' &&
+			(c as { name: string }).name.trim() !== '',
+	).length < RESCUE_BELOW_CONTACTS
+
+export interface ContactsRescueTarget {
+	readonly name: string
+	readonly domain?: string | undefined
+}
+
+/** The focused-pass prompt: people and titles only, bound to the target, verbatim. */
+export const contactsRescuePrompt = (
+	target: ContactsRescueTarget,
+	evidence: string,
+): string =>
+	[
+		`From the evidence below, list EVERY named person who is a leader or employee of "${target.name}"${
+			target.domain ? ` (official site ${target.domain})` : ''
+		}, with their exact job title.`,
+		"For each person return: their full name as written; `role` — their exact title with the source URL and a verbatim quote stating the name and title; and `citations` — the source URL(s) where they appear as this company's own person, each with a verbatim quote.",
+		'Rules:',
+		`- Only ${target.name}'s OWN leaders or staff. IGNORE anyone described as a client, customer, partner, vendor, or testimonial, and anyone who works for a DIFFERENT company — even when they are quoted on this company's own site.`,
+		'- Distinguish current leaders from founders: someone who "co-founded" the company is a founder; give a current role only if the evidence says they still hold it.',
+		'- Copy names and titles verbatim from the evidence; never invent a person, a title, or a source.',
+		'',
+		'Evidence:',
+		evidence,
+	].join('\n')
+
+// A person's name reduced to a comparison key: lowercased, accent-folded, stripped
+// of punctuation and collapsed whitespace. Deliberately exact (no initials/nickname
+// matching) so two genuinely different spellings stay separate rather than risk
+// merging two different people — recall over a lossy merge.
+export const normalizeContactName = (name: string): string =>
+	name
+		.normalize('NFD')
+		.replace(/\p{Diacritic}/gu, '')
+		.toLowerCase()
+		.replace(/[^a-z0-9\s]/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+
+interface RawContact {
+	readonly name?: unknown
+	readonly role?: unknown
+	readonly email?: unknown
+	readonly phone?: unknown
+	readonly citations?: unknown
+}
+
+const citationsArray = (c: RawContact): ReadonlyArray<unknown> =>
+	Array.isArray(c.citations) ? c.citations : []
+
+/**
+ * Union the broad and recovered contacts, keyed on the normalized name. A name seen
+ * in both keeps the broad contact's fields, fills any it lacks (a title, a channel)
+ * from the recovered one, and unions their citations. First-seen order is preserved.
+ */
+export const mergeContacts = (
+	broad: ReadonlyArray<RawContact>,
+	rescued: ReadonlyArray<RawContact>,
+): ReadonlyArray<RawContact> => {
+	const byKey = new Map<string, RawContact>()
+	const order: string[] = []
+
+	const absorb = (c: RawContact): void => {
+		if (typeof c.name !== 'string') return
+		const key = normalizeContactName(c.name)
+		if (key === '') return
+		const existing = byKey.get(key)
+		if (existing === undefined) {
+			byKey.set(key, c)
+			order.push(key)
+			return
+		}
+		byKey.set(key, {
+			name: existing.name,
+			role: existing.role ?? c.role,
+			email: existing.email ?? c.email,
+			phone: existing.phone ?? c.phone,
+			citations: [...citationsArray(existing), ...citationsArray(c)],
+		})
+	}
+
+	for (const c of broad) absorb(c)
+	for (const c of rescued) absorb(c)
+	return order.map(key => byKey.get(key) as RawContact)
+}

--- a/packages/research/src/application/eval-golden.test.ts
+++ b/packages/research/src/application/eval-golden.test.ts
@@ -137,6 +137,81 @@ describe('parseGoldenRow', () => {
 			expect(result.ok).toBe(false)
 		})
 	})
+
+	describe('when contacts are given as names and objects', () => {
+		it('should accept both forms and carry the names through', () => {
+			// GIVEN a bare name string and a { name } object side by side
+			const result = parseGoldenRow(
+				row({
+					expectedOutput: {
+						officialDomain: 'acme.es',
+						contacts: ['Ada Lovelace', { name: 'Alan Turing' }],
+					},
+				}),
+			)
+
+			// WHEN parsed — THEN both are normalized to { name } entries
+			expect(result).toMatchObject({
+				ok: true,
+				value: {
+					contacts: [{ name: 'Ada Lovelace' }, { name: 'Alan Turing' }],
+				},
+			})
+		})
+	})
+
+	describe('when a row lists no contacts', () => {
+		it('should omit the contacts key rather than emit an empty array', () => {
+			// GIVEN a well-formed row with no contacts field
+			const result = parseGoldenRow(
+				row({ expectedOutput: { officialDomain: 'acme.es' } }),
+			)
+
+			// WHEN parsed — THEN contacts is absent, so recall stays inert (not 0/0)
+			expect(result).toMatchObject({ ok: true })
+			if (result.ok) expect('contacts' in result.value).toBe(false)
+		})
+	})
+
+	describe('when contacts is not an array', () => {
+		it('should fail rather than guess', () => {
+			// GIVEN a single object where an array is required
+			const result = parseGoldenRow(
+				row({
+					expectedOutput: {
+						officialDomain: 'acme.es',
+						contacts: { name: 'Ada Lovelace' },
+					},
+				}),
+			)
+
+			// WHEN parsed — THEN it is rejected
+			expect(result.ok).toBe(false)
+		})
+	})
+
+	describe('when a contact has no usable name', () => {
+		it('should fail — a nameless contact cannot be matched', () => {
+			// GIVEN a blank name and, separately, a nameless object
+			expect(
+				parseGoldenRow(
+					row({
+						expectedOutput: { officialDomain: 'acme.es', contacts: ['  '] },
+					}),
+				).ok,
+			).toBe(false)
+			expect(
+				parseGoldenRow(
+					row({
+						expectedOutput: {
+							officialDomain: 'acme.es',
+							contacts: [{ role: 'CEO' }],
+						},
+					}),
+				).ok,
+			).toBe(false)
+		})
+	})
 })
 
 describe('parseGoldenSet', () => {
@@ -178,6 +253,9 @@ describe('parseGoldenSet', () => {
 			expect(arrive?.fields.size_range).toBe('51-200')
 			expect(arrive?.fields.location).toBe('Austin')
 			expect(arrive?.fields.country).toBe('US')
+			// AND the Brompton row carries the contact that seeds titled-contact recall
+			const brompton = result.golden.find(g => g.id === 'brompton-bicycle')
+			expect(brompton?.contacts).toEqual([{ name: 'Will Butler-Adams' }])
 		})
 	})
 })

--- a/packages/research/src/application/eval-golden.ts
+++ b/packages/research/src/application/eval-golden.ts
@@ -97,6 +97,26 @@ export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 		}
 	}
 
+	// Expected people, given as a name string or a `{ name }` object. Optional —
+	// only rows that list them are scored for contact recall.
+	const contacts: Array<{ name: string }> = []
+	const rawContacts = answer['contacts']
+	if (rawContacts !== undefined) {
+		if (!Array.isArray(rawContacts)) {
+			return { ok: false, error: 'contacts must be an array' }
+		}
+		for (const item of rawContacts) {
+			const name = typeof item === 'string' ? item : asRecord(item)?.['name']
+			if (typeof name !== 'string' || name.trim() === '') {
+				return {
+					ok: false,
+					error: 'each contact must be a name string or a { name } object',
+				}
+			}
+			contacts.push({ name })
+		}
+	}
+
 	return {
 		ok: true,
 		value: {
@@ -105,6 +125,7 @@ export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 			officialDomain,
 			...(rawAltDomains !== undefined ? { altDomains: rawAltDomains } : {}),
 			fields,
+			...(contacts.length > 0 ? { contacts } : {}),
 		},
 	}
 }

--- a/packages/research/src/application/eval-outcome.ts
+++ b/packages/research/src/application/eval-outcome.ts
@@ -99,6 +99,23 @@ export const outcomeFromRun = (input: {
 		}
 	}
 
+	// The people the run kept (after the entity + grounding guards), each with the
+	// title it found or null — so the scorer can measure how many known contacts
+	// came back with a title.
+	const contacts: Array<{ name: string; role: string | null }> = []
+	const rawContacts = (findings as { contacts?: unknown }).contacts
+	if (Array.isArray(rawContacts)) {
+		for (const contact of rawContacts) {
+			if (contact === null || typeof contact !== 'object') continue
+			const name = (contact as { name?: unknown }).name
+			if (typeof name !== 'string' || name.trim() === '') continue
+			contacts.push({
+				name,
+				role: readFieldValue((contact as { role?: unknown }).role),
+			})
+		}
+	}
+
 	const reachedDomains: string[] = []
 	for (const url of input.fetchedUrls) {
 		const host = hostOf(url)
@@ -116,6 +133,7 @@ export const outcomeFromRun = (input: {
 		status: toTerminalStatus(input.status),
 		reachedDomains,
 		fields,
+		contacts,
 		registryConfirmed,
 	}
 }

--- a/packages/research/src/application/eval-report.test.ts
+++ b/packages/research/src/application/eval-report.test.ts
@@ -16,6 +16,8 @@ const score = (over: Partial<RunScore>): RunScore => ({
 	fieldsExpected: 0,
 	fieldsScored: 0,
 	fieldsCorrect: 0,
+	contactsExpected: 0,
+	contactsFound: 0,
 	...over,
 })
 
@@ -155,6 +157,7 @@ describe('evalSummaryAttributes', () => {
 				emptyRate: 0.25,
 				fieldPrecision: 0.75,
 				fieldRecall: 0.5,
+				contactRecall: 0.6,
 			})
 
 			// WHEN flattened — THEN each top-line rate is present
@@ -162,12 +165,13 @@ describe('evalSummaryAttributes', () => {
 			expect(attrs['eval.grounding_accuracy']).toBe(0.5)
 			expect(attrs['eval.field_precision']).toBe(0.75)
 			expect(attrs['eval.field_recall']).toBe(0.5)
+			expect(attrs['eval.contact_recall']).toBe(0.6)
 		})
 	})
 
 	describe('when nothing was filled to judge', () => {
 		it('should omit the null precision', () => {
-			// GIVEN a summary whose precision is null (nothing filled)
+			// GIVEN a summary whose precision and contact recall are null (nothing to judge)
 			const attrs = evalSummaryAttributes({
 				runs: 1,
 				groundingAccuracy: 1,
@@ -175,10 +179,12 @@ describe('evalSummaryAttributes', () => {
 				emptyRate: 1,
 				fieldPrecision: null,
 				fieldRecall: 0,
+				contactRecall: null,
 			})
 
-			// WHEN flattened — THEN a null precision is left off, not charted as zero
+			// WHEN flattened — THEN each null rate is left off, not charted as zero
 			expect('eval.field_precision' in attrs).toBe(false)
+			expect('eval.contact_recall' in attrs).toBe(false)
 			expect(attrs['eval.field_recall']).toBe(0)
 		})
 	})

--- a/packages/research/src/application/eval-report.ts
+++ b/packages/research/src/application/eval-report.ts
@@ -76,6 +76,17 @@ export const scorePayloadsForRun = (score: RunScore): ScorePayload[] => {
 			feedback: `${score.fieldsCorrect}/${score.fieldsExpected} known fields recovered`,
 		})
 	}
+	// Contacts are outside the scorable-field set, so their recall is tracked on its
+	// own — a run can fill every field yet return the decision-makers with no title,
+	// the exact gap this metric watches.
+	if (score.contactsExpected > 0) {
+		payloads.push({
+			name: 'contact_recall',
+			value: score.contactsFound / score.contactsExpected,
+			passed: score.contactsFound === score.contactsExpected,
+			feedback: `${score.contactsFound}/${score.contactsExpected} known contacts found with a title`,
+		})
+	}
 	return payloads
 }
 
@@ -110,6 +121,8 @@ export const evalSpanAttributes = (
 		'eval.fields_expected': score.fieldsExpected,
 		'eval.fields_scored': score.fieldsScored,
 		'eval.fields_correct': score.fieldsCorrect,
+		'eval.contacts_expected': score.contactsExpected,
+		'eval.contacts_found': score.contactsFound,
 	}
 	if (score.fieldsScored > 0) {
 		attributes['eval.field_precision'] =
@@ -117,6 +130,10 @@ export const evalSpanAttributes = (
 	}
 	if (score.fieldsExpected > 0) {
 		attributes['eval.field_recall'] = score.fieldsCorrect / score.fieldsExpected
+	}
+	if (score.contactsExpected > 0) {
+		attributes['eval.contact_recall'] =
+			score.contactsFound / score.contactsExpected
 	}
 	return attributes
 }
@@ -141,6 +158,9 @@ export const evalSummaryAttributes = (
 	}
 	if (summary.fieldRecall !== null) {
 		attributes['eval.field_recall'] = summary.fieldRecall
+	}
+	if (summary.contactRecall !== null) {
+		attributes['eval.contact_recall'] = summary.contactRecall
 	}
 	return attributes
 }

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -23,6 +23,7 @@ const outcome = (over: Partial<RunOutcome>): RunOutcome => ({
 	status: 'succeeded',
 	reachedDomains: ['acme.es'],
 	fields: {},
+	contacts: [],
 	...over,
 })
 
@@ -248,6 +249,101 @@ describe('scoreRun', () => {
 			expect(result.fieldsCorrect).toBe(2)
 		})
 	})
+
+	describe('when the golden set lists expected contacts', () => {
+		const withContacts: GoldenExpectation = {
+			...acme,
+			contacts: [{ name: 'Andrew Smith' }, { name: 'María García' }],
+		}
+
+		it('should count a known contact returned with a title as found', () => {
+			// GIVEN a run that returned one of the two known people, with a title
+			const result = scoreRun(
+				withContacts,
+				outcome({
+					contacts: [{ name: 'Andrew Smith', role: 'CEO' }],
+				}),
+			)
+
+			// WHEN scored — THEN both are expected, one was recovered with a title
+			expect(result.contactsExpected).toBe(2)
+			expect(result.contactsFound).toBe(1)
+		})
+
+		it('should not count a known contact returned without a title', () => {
+			// GIVEN the person came back as a bare name, no role
+			const result = scoreRun(
+				withContacts,
+				outcome({
+					contacts: [{ name: 'Andrew Smith', role: null }],
+				}),
+			)
+
+			// WHEN scored — THEN a titleless contact is the gap this metric watches, so it isn't "found"
+			expect(result.contactsExpected).toBe(2)
+			expect(result.contactsFound).toBe(0)
+		})
+
+		it('should match a name that carries an extra middle token or an accent', () => {
+			// GIVEN the run reports a fuller name and an un-accented spelling
+			const result = scoreRun(
+				withContacts,
+				outcome({
+					contacts: [
+						{ name: 'Andrew J. Smith', role: 'CEO' },
+						{ name: 'Maria Garcia', role: 'CFO' },
+					],
+				}),
+			)
+
+			// WHEN scored — THEN token-subset + accent-folding match both people
+			expect(result.contactsFound).toBe(2)
+		})
+
+		it('should not match a different person who shares one name token', () => {
+			// GIVEN a same-surname stranger the run returned with a title
+			const result = scoreRun(
+				withContacts,
+				outcome({
+					contacts: [{ name: 'Robert Smith', role: 'Intern' }],
+				}),
+			)
+
+			// WHEN scored — THEN a partial token overlap is not a match; recall stays honest
+			expect(result.contactsFound).toBe(0)
+		})
+
+		it('should not match two people who differ only by a middle initial', () => {
+			// GIVEN a golden person whose name carries a middle initial
+			const withInitial: GoldenExpectation = {
+				...acme,
+				contacts: [{ name: 'Jon A Park' }],
+			}
+
+			// WHEN the run returns a different person with the same first+last but
+			// another initial
+			const result = scoreRun(
+				withInitial,
+				outcome({ contacts: [{ name: 'Jon B Park', role: 'CEO' }] }),
+			)
+
+			// THEN the differing initial keeps them distinct — the initial is a real
+			// token, not dropped, so recall doesn't over-count a look-alike name
+			expect(result.contactsFound).toBe(0)
+		})
+
+		it('should expect zero contacts when the golden set lists none', () => {
+			// GIVEN acme, whose golden row has no contacts, and a run that found one
+			const result = scoreRun(
+				acme,
+				outcome({ contacts: [{ name: 'Someone', role: 'CEO' }] }),
+			)
+
+			// WHEN scored — THEN there is nothing to recall, so the metric is inert
+			expect(result.contactsExpected).toBe(0)
+			expect(result.contactsFound).toBe(0)
+		})
+	})
 })
 
 describe('summarizeScores', () => {
@@ -259,6 +355,8 @@ describe('summarizeScores', () => {
 		fieldsExpected: 0,
 		fieldsScored: 0,
 		fieldsCorrect: 0,
+		contactsExpected: 0,
+		contactsFound: 0,
 		...over,
 	})
 
@@ -275,6 +373,7 @@ describe('summarizeScores', () => {
 				emptyRate: 0,
 				fieldPrecision: null,
 				fieldRecall: null,
+				contactRecall: null,
 			})
 		})
 	})
@@ -322,6 +421,29 @@ describe('summarizeScores', () => {
 			// everything known was missed (recall 0) — the two are not the same signal
 			expect(summary.fieldPrecision).toBeNull()
 			expect(summary.fieldRecall).toBe(0)
+		})
+	})
+
+	describe('when runs listed expected contacts', () => {
+		it('should micro-average contact recall over all known contacts', () => {
+			// GIVEN 3 found of 5 known contacts across two runs
+			const summary = summarizeScores([
+				score({ contactsExpected: 2, contactsFound: 2 }),
+				score({ contactsExpected: 3, contactsFound: 1 }),
+			])
+
+			// WHEN summarized — THEN recall is found÷known across the batch, not a per-run mean
+			expect(summary.contactRecall).toBe(0.6)
+		})
+	})
+
+	describe('when no run listed expected contacts', () => {
+		it('should report contact recall null, not zero', () => {
+			// GIVEN runs whose golden rows named no people to recover
+			const summary = summarizeScores([score({}), score({})])
+
+			// WHEN summarized — THEN there was nothing to recall, so the rate is absent
+			expect(summary.contactRecall).toBeNull()
 		})
 	})
 })

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -1,11 +1,15 @@
 /**
  * Pure scoring for the research eval harness. Given a company's known-correct
  * answer (the golden expectation) and a normalized view of what one research run
- * produced, it computes the four numbers the harness reports:
+ * produced, it computes the numbers the harness reports:
  *
  *   grounding accuracy   did the run actually reach the *target* company's own site?
  *   field precision      of the fields it filled that we have a true answer for,
  *                        how many are right?
+ *   contact recall       of the people the company is known to publish, how many
+ *                        came back *with a title* — contacts sit outside the scorable
+ *                        field set, so a run can pass every field yet lose the
+ *                        decision-makers' titles, the exact gap this metric watches.
  *   wrong-company rate   did it confidently return data without reaching the target
  *                        (the look-alike failure this harness exists to catch)?
  *   empty rate           did it return no usable data at all?
@@ -55,6 +59,9 @@ export interface GoldenExpectation {
 	readonly altDomains?: ReadonlyArray<string>
 	/** Known-correct field values. Only fields listed here are scored for precision. */
 	readonly fields: Partial<Record<ScorableField, string>>
+	/** People the company is known to publish; scores whether the run recovered them
+	 * *with a title* — the recall the focused contacts pass exists to lift. */
+	readonly contacts?: ReadonlyArray<{ readonly name: string }>
 }
 
 /**
@@ -74,6 +81,12 @@ export interface RunOutcome {
 	readonly reachedDomains: ReadonlyArray<string>
 	/** Extracted enrichment scalars; a missing/blank value counts as unfilled. */
 	readonly fields: Partial<Record<ScorableField, string | null>>
+	/** Contacts the run extracted (after the guards), each with the title it found
+	 * or null — a named person recovered without a title still counts as titleless. */
+	readonly contacts: ReadonlyArray<{
+		readonly name: string
+		readonly role: string | null
+	}>
 	/**
 	 * Whether an official-registry lookup this run resolved the target company by
 	 * its legal name. Independent of the fetched pages: a company confirmed in the
@@ -93,6 +106,10 @@ export interface RunScore {
 	readonly fieldsScored: number
 	/** Of the filled-and-checkable fields, how many matched (the shared numerator). */
 	readonly fieldsCorrect: number
+	/** Known-published people we expected the run to recover (contact recall's denominator). */
+	readonly contactsExpected: number
+	/** Of those, how many the run returned *with a title* (contact recall's numerator). */
+	readonly contactsFound: number
 }
 
 export interface EvalSummary {
@@ -104,6 +121,9 @@ export interface EvalSummary {
 	readonly fieldPrecision: number | null
 	/** Micro-averaged correct ÷ known across all runs; null when the golden set specified no fields. */
 	readonly fieldRecall: number | null
+	/** Micro-averaged known people recovered *with a title* ÷ known people, across all
+	 * runs; null when no golden row listed expected contacts. */
+	readonly contactRecall: number | null
 }
 
 /**
@@ -129,6 +149,30 @@ const isFilled = (value: string | null | undefined): value is string =>
 /** Strip accents so "García" and "Garcia" compare equal. */
 export const foldDiacritics = (value: string): string =>
 	value.normalize('NFD').replace(/\p{Diacritic}/gu, '')
+
+// A person's name as its accent-folded, lower-cased word tokens. Single-character
+// tokens (a middle initial) are kept, so two people who differ only by initial stay
+// distinct — the same tokenizing the contact-discovery eval uses.
+const nameTokens = (name: string): ReadonlyArray<string> =>
+	foldDiacritics(name)
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(token => token.length > 0)
+
+// Two names refer to the same person when the shorter one's tokens are all in the
+// longer's — so "Andrew Smith" matches "Andrew J. Smith" without matching a
+// different Smith. A lone shared token (just a first name) is too weak to confirm
+// the same person, so the shorter name must carry at least two tokens — the same
+// rule the contact-discovery eval uses, so both agree on what "same person" means.
+// Conservative on purpose: an unmatched real person is a miss the eval should show,
+// not paper over.
+const contactNameMatches = (expected: string, actual: string): boolean => {
+	const e = nameTokens(expected)
+	const a = nameTokens(actual)
+	const [small, big] = e.length <= a.length ? [e, new Set(a)] : [a, new Set(e)]
+	if (small.length < 2) return false
+	return small.every(token => big.has(token))
+}
 
 /**
  * Industry is an open free-text field: the pipeline reports it in the source page's
@@ -226,6 +270,19 @@ export const scoreRun = (
 	// the look-alike bug: it returned some other company's data as a success.
 	const wrongCompany = outcome.status === 'succeeded' && !empty && !grounded
 
+	// Contact recall: of the people we know the company publishes, how many the run
+	// returned WITH a title — a named person with no title doesn't count, since a
+	// titleless contact is the gap the focused pass exists to close.
+	const expectedContacts = expected.contacts ?? []
+	let contactsFound = 0
+	for (const person of expectedContacts) {
+		const match = outcome.contacts.some(
+			found =>
+				isFilled(found.role) && contactNameMatches(person.name, found.name),
+		)
+		if (match) contactsFound++
+	}
+
 	return {
 		id: expected.id,
 		grounded,
@@ -234,10 +291,12 @@ export const scoreRun = (
 		fieldsExpected,
 		fieldsScored,
 		fieldsCorrect,
+		contactsExpected: expectedContacts.length,
+		contactsFound,
 	}
 }
 
-/** Roll per-run scores up into the four rates the harness reports. */
+/** Roll per-run scores up into the rates the harness reports. */
 export const summarizeScores = (
 	scores: ReadonlyArray<RunScore>,
 ): EvalSummary => {
@@ -250,6 +309,7 @@ export const summarizeScores = (
 			emptyRate: 0,
 			fieldPrecision: null,
 			fieldRecall: null,
+			contactRecall: null,
 		}
 	}
 
@@ -259,6 +319,8 @@ export const summarizeScores = (
 	let totalExpected = 0
 	let totalScored = 0
 	let totalCorrect = 0
+	let totalContactsExpected = 0
+	let totalContactsFound = 0
 	for (const score of scores) {
 		if (score.grounded) grounded++
 		if (score.wrongCompany) wrong++
@@ -266,6 +328,8 @@ export const summarizeScores = (
 		totalExpected += score.fieldsExpected
 		totalScored += score.fieldsScored
 		totalCorrect += score.fieldsCorrect
+		totalContactsExpected += score.contactsExpected
+		totalContactsFound += score.contactsFound
 	}
 
 	return {
@@ -275,5 +339,9 @@ export const summarizeScores = (
 		emptyRate: empty / runs,
 		fieldPrecision: totalScored === 0 ? null : totalCorrect / totalScored,
 		fieldRecall: totalExpected === 0 ? null : totalCorrect / totalExpected,
+		contactRecall:
+			totalContactsExpected === 0
+				? null
+				: totalContactsFound / totalContactsExpected,
 	}
 }

--- a/packages/research/src/application/firmographics-rescue.test.ts
+++ b/packages/research/src/application/firmographics-rescue.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	mergeFirmographics,
+	needsFirmographicsRescue,
+} from './firmographics-rescue'
+
+const sized = (value: string) => ({
+	value,
+	source_id: 'https://acme.com',
+	confidence: null,
+})
+
+describe('needsFirmographicsRescue', () => {
+	describe('when a firmographic field is empty', () => {
+		it('should rescue when both are missing', () => {
+			expect(needsFirmographicsRescue({ enrichment: {} })).toBe(true)
+			expect(needsFirmographicsRescue({})).toBe(true)
+		})
+
+		it('should rescue when only one is present', () => {
+			// GIVEN size present but tools missing
+			expect(
+				needsFirmographicsRescue({
+					enrichment: { size_range: sized('51-200') },
+				}),
+			).toBe(true)
+		})
+
+		it('should treat a blanked value as still missing', () => {
+			// GIVEN a value a guard blanked to null
+			expect(
+				needsFirmographicsRescue({
+					enrichment: {
+						size_range: sized('51-200'),
+						current_tools: { value: null },
+					},
+				}),
+			).toBe(true)
+		})
+	})
+
+	describe('when both firmographics are present', () => {
+		it('should not rescue', () => {
+			expect(
+				needsFirmographicsRescue({
+					enrichment: {
+						size_range: sized('51-200'),
+						current_tools: sized('SAP TMS'),
+					},
+				}),
+			).toBe(false)
+		})
+	})
+})
+
+describe('mergeFirmographics', () => {
+	describe('when the broad pass left a field empty', () => {
+		it('should fill it from the rescue without overwriting a grounded value', () => {
+			// GIVEN the broad pass grounded tools but not size
+			const findings = {
+				enrichment: { current_tools: sized('TransportPro') },
+			}
+			const rescued = {
+				size_range: sized('501-1000'),
+				current_tools: sized('SomethingElse'),
+			}
+
+			// WHEN merged
+			const result = mergeFirmographics(findings, rescued)
+
+			// THEN size is filled; the already-grounded tools value is kept
+			const enrichment = (
+				result.findings as {
+					enrichment: Record<string, { value: unknown }>
+				}
+			).enrichment
+			expect(enrichment['size_range']?.value).toBe('501-1000')
+			expect(enrichment['current_tools']?.value).toBe('TransportPro')
+			expect(result.filled).toBe(1)
+		})
+	})
+
+	describe('when the rescue found nothing new', () => {
+		it('should return the findings unchanged', () => {
+			// GIVEN both already present
+			const findings = {
+				enrichment: {
+					size_range: sized('51-200'),
+					current_tools: sized('SAP'),
+				},
+			}
+
+			// WHEN merged with a rescue that only repeats them
+			const result = mergeFirmographics(findings, { size_range: sized('9-9') })
+
+			// THEN nothing filled
+			expect(result.filled).toBe(0)
+			expect(result.findings).toBe(findings)
+		})
+	})
+})

--- a/packages/research/src/application/firmographics-rescue.ts
+++ b/packages/research/src/application/firmographics-rescue.ts
@@ -1,0 +1,108 @@
+/**
+ * A focused second extraction that recovers a company's size and tooling when the
+ * broad pass left them empty.
+ *
+ * Same story as the contacts rescue: the broad `generateObject` spreads its
+ * attention across the whole schema and drops the firmographic fields even when the
+ * evidence states them — a live run had "624 employees" and a named TMS sitting in
+ * the fetched pages, unread. This narrow pass pulls only the employee-size band and
+ * the operational software, then fills them into the broad findings where they were
+ * blank. It fires only when at least one is missing, so a complete run pays nothing.
+ *
+ * A value the pass recovers from a third-party aggregator is capped to medium
+ * confidence by the source-tier guard downstream, exactly like any other
+ * non-first-party field — this module only recovers the value; the guard chain
+ * still decides how much to trust it.
+ */
+
+import { Schema } from 'effect'
+
+import { Sourced } from './schemas/_shared'
+
+// The narrow schema the focused pass fills — the two firmographics the broad pass
+// most often drops. Both optional: the pass returns only what the evidence states.
+export const FirmographicsRescueSchema = Schema.Struct({
+	size_range: Schema.optionalKey(Sourced(Schema.String)),
+	current_tools: Schema.optionalKey(Sourced(Schema.String)),
+})
+
+const RESCUE_KEYS = ['size_range', 'current_tools'] as const
+
+const enrichmentOf = (
+	findings: unknown,
+): Record<string, unknown> | undefined => {
+	if (findings === null || typeof findings !== 'object') return undefined
+	const enrichment = (findings as { enrichment?: unknown }).enrichment
+	return enrichment !== null && typeof enrichment === 'object'
+		? (enrichment as Record<string, unknown>)
+		: undefined
+}
+
+// A per-field value counts as present only when it carries a non-empty string
+// value — a missing key, or a `{ value: null }` a guard blanked, is still "empty".
+const hasValue = (field: unknown): boolean =>
+	field !== null &&
+	typeof field === 'object' &&
+	typeof (field as { value?: unknown }).value === 'string' &&
+	(field as { value: string }).value.trim() !== ''
+
+/** Whether the broad findings are missing a size band or a tools value. */
+export const needsFirmographicsRescue = (findings: unknown): boolean => {
+	const enrichment = enrichmentOf(findings)
+	if (enrichment === undefined) return true
+	return RESCUE_KEYS.some(key => !hasValue(enrichment[key]))
+}
+
+export interface FirmographicsRescueTarget {
+	readonly name: string
+	readonly domain?: string | undefined
+}
+
+/** The focused-pass prompt: employee size band and operational software only. */
+export const firmographicsRescuePrompt = (
+	target: FirmographicsRescueTarget,
+	evidence: string,
+): string =>
+	[
+		`From the evidence below, find two facts about "${target.name}"${
+			target.domain ? ` (official site ${target.domain})` : ''
+		}:`,
+		"- `size_range`: the company's employee-count band (e.g. an employee count or a range), with the source URL and a verbatim quote.",
+		"- `current_tools`: the company's own business or operations software it actually uses — TMS, ERP, CRM, WMS, a load board — with the source URL and a verbatim quote. Exclude generic website infrastructure (analytics, CDNs, cookie/consent banners, reCAPTCHA).",
+		'Only report a value that appears in the evidence; omit a field the evidence does not state. Never invent a headcount or a tool.',
+		'',
+		'Evidence:',
+		evidence,
+	].join('\n')
+
+/**
+ * Fill the broad findings' `size_range` / `current_tools` from the rescued values,
+ * but only where the broad pass left them empty — a value the broad pass already
+ * grounded is never overwritten. Returns the findings and how many fields it filled.
+ */
+export const mergeFirmographics = (
+	findings: unknown,
+	rescued: unknown,
+): { readonly findings: unknown; readonly filled: number } => {
+	const enrichment = enrichmentOf(findings)
+	const rescuedEnrichment =
+		rescued !== null && typeof rescued === 'object'
+			? (rescued as Record<string, unknown>)
+			: undefined
+	if (enrichment === undefined || rescuedEnrichment === undefined) {
+		return { findings, filled: 0 }
+	}
+	let filled = 0
+	const nextEnrichment: Record<string, unknown> = { ...enrichment }
+	for (const key of RESCUE_KEYS) {
+		if (!hasValue(enrichment[key]) && hasValue(rescuedEnrichment[key])) {
+			nextEnrichment[key] = rescuedEnrichment[key]
+			filled++
+		}
+	}
+	if (filled === 0) return { findings, filled: 0 }
+	return {
+		findings: { ...(findings as object), enrichment: nextEnrichment },
+		filled,
+	}
+}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -29,6 +29,13 @@ import {
 	groundedCitationTest,
 	validateFindingCitations,
 } from './citation-guard'
+import { bindContactsToEntity } from './contact-entity-guard'
+import {
+	ContactsRescueSchema,
+	contactsRescuePrompt,
+	mergeContacts,
+	needsContactRescue,
+} from './contacts-rescue'
 import {
 	CriticVerdictsSchema,
 	criticPrompt,
@@ -51,6 +58,12 @@ import {
 	isConfirmedRegistryMatch,
 	withRedirectDomain,
 } from './entity-guard'
+import {
+	FirmographicsRescueSchema,
+	firmographicsRescuePrompt,
+	mergeFirmographics,
+	needsFirmographicsRescue,
+} from './firmographics-rescue'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
 	AgentLanguageModel,
@@ -1249,6 +1262,9 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 									? `Fetched pages (primary evidence — read these first):\n\n${parts.join('\n\n---\n\n')}\n\n`
 									: ''
 							})()
+							// The full evidence handed to extraction — reused by the focused
+							// contacts rescue below so it reads exactly what the broad pass did.
+							const evidenceBlock = `${pagesSection}Research transcript:\n\n${transcript}`
 							// Cast schema to satisfy generateObject's Encoder constraint.
 							// Registry schemas are all Structs with DecodingServices=never,
 							// but Schema.Top erases that — the cast is safe.
@@ -1260,9 +1276,107 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								// it will confidently invent phones, tax ids, and emails. Never
 								// emit a schema field's name or a placeholder ("headquarters",
 								// "unknown") as a value; omit a field with no real value instead.
-								prompt: `Produce structured findings STRICTLY from the evidence below (the fetched pages and the research transcript). Only include a value that appears in the evidence; if it does not support a field, omit it or leave it null — never fill a field from prior knowledge, and never put a placeholder or the field's own name as its value.\n\n${citationInstruction}\n\n${pagesSection}Research transcript:\n\n${transcript}`,
+								prompt: `Produce structured findings STRICTLY from the evidence below (the fetched pages and the research transcript). Only include a value that appears in the evidence; if it does not support a field, omit it or leave it null — never fill a field from prior knowledge, and never put a placeholder or the field's own name as its value.\n\n${citationInstruction}\n\n${evidenceBlock}`,
 							})
 							let result = withProposalIds(structuredResponse.value as unknown)
+							let rescueOutputTokens = 0
+							// The company the focused rescue passes below target — the subject's
+							// name + its own domain, so a recovered person or fact is tied to the
+							// right company. Only company_enrichment runs these passes.
+							const rescueSnapshot = subjects[0]?.snapshot as
+								| Record<string, unknown>
+								| undefined
+							const rescueTarget = {
+								name:
+									typeof rescueSnapshot?.['name'] === 'string'
+										? rescueSnapshot['name']
+										: (run as { query: string }).query,
+								domain:
+									(typeof rescueSnapshot?.['website'] === 'string'
+										? rescueSnapshot['website']
+										: undefined) ?? entityTargets?.domains?.[0],
+							}
+							const runsRescue = schemaName === 'company_enrichment_v1'
+							// Contacts rescue: the broad pass reliably drops the people list. If
+							// it came back with at most one contact, run a focused pass that pulls
+							// only named people + titles from the same evidence and fold them in —
+							// before the guard chain, so recovered contacts are guarded like the
+							// rest. Fail-open: a rescue error keeps the broad result.
+							if (runsRescue && needsContactRescue(result)) {
+								const rescue = yield* extractLlm
+									.generateObject({
+										schema: ContactsRescueSchema,
+										prompt: contactsRescuePrompt(rescueTarget, evidenceBlock),
+									})
+									.pipe(
+										Effect.map(r => ({
+											contacts: (r.value as { contacts?: unknown }).contacts,
+											tokens: r.usage.outputTokens.total ?? 0,
+										})),
+										Effect.catchCause(() =>
+											Effect.succeed({ contacts: undefined, tokens: 0 }),
+										),
+									)
+								rescueOutputTokens += rescue.tokens
+								if (
+									Array.isArray(rescue.contacts) &&
+									rescue.contacts.length > 0
+								) {
+									const broadContacts = Array.isArray(
+										(result as { contacts?: unknown }).contacts,
+									)
+										? ((result as { contacts: unknown[] }).contacts as Array<
+												Record<string, unknown>
+											>)
+										: []
+									const merged = mergeContacts(
+										broadContacts,
+										rescue.contacts as Array<Record<string, unknown>>,
+									)
+									result = { ...(result as object), contacts: merged }
+									yield* Effect.logInfo('research.contacts.rescued').pipe(
+										Effect.annotateLogs({
+											research_id: researchId,
+											before: broadContacts.length,
+											after: merged.length,
+										}),
+									)
+								}
+							}
+							// Firmographics rescue: the broad pass also drops the size band and
+							// tooling even when a page states them. When either is empty, a focused
+							// pass fills it in (without overwriting a value the broad pass grounded);
+							// an aggregator-sourced value is capped to medium by the source tier.
+							if (runsRescue && needsFirmographicsRescue(result)) {
+								const fRescue = yield* extractLlm
+									.generateObject({
+										schema: FirmographicsRescueSchema,
+										prompt: firmographicsRescuePrompt(
+											rescueTarget,
+											evidenceBlock,
+										),
+									})
+									.pipe(
+										Effect.map(r => ({
+											enrichment: r.value as unknown,
+											tokens: r.usage.outputTokens.total ?? 0,
+										})),
+										Effect.catchCause(() =>
+											Effect.succeed({ enrichment: undefined, tokens: 0 }),
+										),
+									)
+								rescueOutputTokens += fRescue.tokens
+								const fMerged = mergeFirmographics(result, fRescue.enrichment)
+								if (fMerged.filled > 0) {
+									result = fMerged.findings
+									yield* Effect.logInfo('research.firmographics.rescued').pipe(
+										Effect.annotateLogs({
+											research_id: researchId,
+											filled: fMerged.filled,
+										}),
+									)
+								}
+							}
 							// Drop citations the model invented: keep only source_ids that map
 							// to a page this run actually fetched. A proposed CRM update left
 							// with no valid citation is dropped whole.
@@ -1284,6 +1398,20 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 										research_id: researchId,
 										total: citationCheck.total,
 										kept: citationCheck.kept,
+									}),
+								)
+							}
+							// Contact entity binding: drop a person whose quotes name only a
+							// different company (a client testimonial or a competitor's exec
+							// quoted on the target's own page), so the richer extraction can't
+							// present someone else's leader as this company's contact.
+							const contactBind = bindContactsToEntity(result, entityTargets)
+							result = contactBind.findings
+							if (contactBind.dropped > 0) {
+								yield* Effect.logWarning('research.contacts.wrong_entity').pipe(
+									Effect.annotateLogs({
+										research_id: researchId,
+										dropped: contactBind.dropped,
 									}),
 								)
 							}
@@ -1477,6 +1605,7 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 								findings: result as unknown,
 								outputTokens:
 									(structuredResponse.usage.outputTokens.total ?? 0) +
+									rescueOutputTokens +
 									critiqued.outputTokens,
 							}
 						}).pipe(

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1280,9 +1280,9 @@ export class ResearchService extends ServiceMap.Service<ResearchService>()(
 							})
 							let result = withProposalIds(structuredResponse.value as unknown)
 							let rescueOutputTokens = 0
-							// The company the focused rescue passes below target — the subject's
-							// name + its own domain, so a recovered person or fact is tied to the
-							// right company. Only company_enrichment runs these passes.
+							// The focused rescue passes below aim at one company — the subject's
+							// name + its own domain — so a recovered person or fact is tied to
+							// the right company. Only company_enrichment runs these passes.
 							const rescueSnapshot = subjects[0]?.snapshot as
 								| Record<string, unknown>
 								| undefined

--- a/packages/research/src/application/schemas/company-enrichment-v1.test.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.test.ts
@@ -44,6 +44,13 @@ describe('CompanyEnrichmentV1Schema', () => {
 							source_id: 'src-2',
 							confidence: null,
 						},
+						citations: [
+							{
+								source_id: 'src-1',
+								quote: 'Ada Lovelace, CTO',
+								confidence: null,
+							},
+						],
 					},
 				],
 			}
@@ -59,6 +66,8 @@ describe('CompanyEnrichmentV1Schema', () => {
 			expect(decoded.enrichment.country?.source_id).toBe('src-2')
 			expect(decoded.contacts?.[0]?.email?.value).toBe('ada@acme.es')
 			expect(decoded.contacts?.[0]?.role?.value).toBe('CTO')
+			// The per-contact citation ties the person to the company's own page.
+			expect(decoded.contacts?.[0]?.citations?.[0]?.source_id).toBe('src-1')
 		})
 	})
 

--- a/packages/research/src/application/schemas/company-enrichment-v1.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.ts
@@ -53,6 +53,13 @@ export const CompanyEnrichmentV1Schema = Schema.Struct({
 				role: Schema.optionalKey(Sourced(Schema.String)),
 				email: Schema.optionalKey(Sourced(Schema.String)),
 				phone: Schema.optionalKey(Sourced(Schema.String)),
+				// The page(s) that name this person as the company's own staff, so a
+				// contact can be tied to the target and not confused with a client,
+				// partner, or competitor's executive quoted on the same site.
+				citations: Schema.optionalKey(Schema.Array(Citation)).annotate({
+					description:
+						'Sources naming this person as the company\'s own leader or employee (prefer the company\'s own website). A person described as a client, partner, or "customer testimonial" is not a contact.',
+				}),
 			}),
 		),
 	),


### PR DESCRIPTION
## What

This is the **third and final PR of the #255 effort**, and the one that pays it off. #261 fixed grounding (only trustworthy values ship) and #263 fixed acquisition (richer, source-attributed evidence reaches the extractor) — but a company's people, size, and tooling still weren't landing in the structured record. The reason was the extraction step itself: one broad model call fills the whole schema at once, and with its attention spread across every field it drops the hard ones (the leadership list, a headcount, a named tool) even when the evidence plainly states them.

This PR adds **focused rescue extractions**: when the broad pass comes back thin on people, or missing size/tooling, a narrow second pass reads the same evidence for *only* that family and folds what it finds in — and every recovered value runs through the same grounding, citation, and source-tier guards. It also stops the richer extraction from mistaking a *client testimonial* or a *competitor's executive* quoted on the company's own page for one of its contacts. Finally, it makes the recovery **measurable**: a new eval metric scores how many of a company's known people come back with a title.

Research context (`server`).

## Changes

- **Per-contact citations** — a contact now carries its own sources (the person, not just their email/phone), so it can be grounded and tied to the company. Additive; the apply flow and UI are unaffected.
- **Focused contacts rescue** — when the broad pass returns ≤1 contact, a narrow pass pulls named people + exact titles (ignoring clients/partners, distinguishing founders from current leaders) and merges them in, deduped by name.
- **Focused firmographics rescue** — when size or tooling is empty, a narrow pass fills it, without overwriting a value the broad pass already grounded.
- **Per-contact entity binding** — a contact whose supporting quote names only a *different* company (and never the target) is dropped.
- **`--language` flag on `research eval`** — carries a language hint into a run, so the golden set can exercise a non-English target end to end.
- **Titled-contact recall metric** — the enrichment eval now scores, of the people a company is known to publish, how many the run returned *with a title*. Contacts sit outside the four scored scalar fields (industry/size/country/location), so without this a run could recover the leadership yet the eval stay flat — this is the metric that makes the recovery above visible. Opt-in per golden row via a `contacts` list; a row without one reads `n/a`, so existing golden sets are unaffected.

The rescues fire *only* when the broad pass under-delivered, so a complete run costs nothing extra.

## Impact

- **Schema change (additive).** Contacts gained an optional `citations` list; nothing else in the findings shape changed. No migration.
- **The source-tier guard from #263 now does visible work** — a size or tool the firmographics rescue recovers from a third-party aggregator is capped to medium confidence, exactly as intended.
- **Extra model calls, bounded.** Up to two focused `generateObject` calls per run, only when the broad pass left that family thin.
- **Two "contact recall" numbers now exist, in different evals.** The pre-existing contact-finding eval scores the `discover_contacts` tool in isolation (name-match, email precision, cost). This PR's *titled-contact recall* scores the end-to-end enrichment findings, gated on a title — a distinct measurement point, surfaced by a different CLI command (`research eval`, not `research eval-contacts`). The CLI label reads "Titled-contact recall" to keep them apart.
- **No RLS / auth / wire-shape / cross-app coupling.** The apply path works on `proposed_updates`, not the contacts list, so it's untouched.

## Review guide

- **Start:** `contacts-rescue.ts` + `firmographics-rescue.ts` (the focused schemas, prompts, and pure merges) and `contact-entity-guard.ts` (the wrong-company drop). The wiring is one block in `research-service.ts`, before the guard chain.
- **The metric:** `eval-scoring.ts` (the `scoreRun` contact loop + `contactNameMatches`), adapted in from the findings by `eval-outcome.ts` and parsed from the golden by `eval-golden.ts`. Name-matching is accent- and middle-name-tolerant but requires two distinct tokens, and now keeps single-character tokens so two people who differ only by a middle initial stay distinct — deliberately the same rule the contact-finding eval uses.
- **A decision you might overrule:** entity binding is deliberately *conservative and deterministic* — it drops a contact only when a quote names a company-with-a-suffix that isn't the target (the clear testimonial case), and leaves subtler cases to the existing critic. A fuller per-contact critic is a filed follow-up (#268).
- **A boundary I want to flag:** this adds a *second* rescue family (contacts, then firmographics). Two is justified by the evidence; a third would be the signal to decompose the broad extraction wholesale rather than keep bolting on rescues.

## Tests

- New unit tests: contact-name merge/dedup (conservative — won't merge "Andrew Smith" with "Andrew J. Smith", and won't match "Jon A Park" to "Jon B Park"), the rescue trigger predicates, the firmographics fill (never overwrites a grounded value), the wrong-company drop (testimonial dropped, target-named contact kept), the per-contact citations decode, and the metric itself (title-gated recall, golden `contacts` parsing, batch micro-average, `n/a` when a row lists none). Research package: 584 tests pass.

## Verification

- Gates: `pnpm -w check-types` green (pre-commit hook), full `pnpm -w test` green (pre-push hook, whole monorepo), `pnpm -w build` green.
- **Live — English**, against real vendors (Brave + Nebius/Fireworks/Groq tiers, keys via Infisical, on the worktree DB): `company_enrichment_v1` for Circle Logistics returns **four contacts, every one with an exact title, all grounded to the company's own site** (Fortmeyer — President & CEO; Buchanan — CFO; Smith — VP Sales & Operations; Shipe — Director of Premium Transportation) **and `current_tools` = "TransportPro"**. That is the exact #255 golden row — the named execs *and* TransportPro — which #261 and #263 both missed.
- **Live — Spanish (multilingual seam)**, prod keys, worktree DB: `research eval --language es` on Enganches Aragón (Zaragoza) → grounding **100%**, wrong-company **0%**, **3/4 scalar fields correct**, titled-contact recall **`n/a`** (that golden row lists no contacts). Confirms the `--language` hint reaches search end to end and the new metric abstains correctly when a row has no known people.
- **What the metric now shows.** Because titled-contact recall lands in this PR, the leadership recovery is no longer invisible to the eval — a golden row that lists a company's execs will move this number when the rescues work. `size_range` reliability on the Spanish run remained imperfect (3/4), tracked as a follow-up.

## Deferred — now filed as issues

- **#268 — field-extraction follow-ups**: reliably capturing a headcount (`size_range`), a model-backed per-contact critic for wrong-entity cases the deterministic guard can't see, a registry/gov trust tier (or corroboration-based un-capping) for source-tier, and a decision on the unregistered `web_*` MCP toolkit + its `ExtractProvider`.
- **#267 — enable the Brave LLM Context search vendor in production**: the config step that makes the richer, source-attributed evidence actually reach prod runs (prod still runs `firecrawl,brave`, not `brave-context`).

Closes #255.
