### PR TITLE
cicd(ci): run integration tests against a local Postgres container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
     # A draft PR is work in progress, so skip CI until it's marked ready.
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    # The integration phase runs the whole suite against a remote Neon branch,
-    # which is ~15x slower per query than local Postgres; it already sat near the
-    # old 15-minute cap (14m32s–14m52s on passing runs) and grows with the suite,
-    # so give it headroom rather than tip over the ceiling on a slow run.
-    timeout-minutes: 25
+    # The integration phase runs the whole suite against a Postgres container on
+    # the runner itself (the same image dev uses), so every query is a localhost
+    # round-trip instead of an internet hop to a remote database. That removes
+    # the ~15x per-query slowdown that used to push this job toward 15 minutes;
+    # 10 minutes leaves comfortable headroom.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -78,58 +79,39 @@ jobs:
 
       # Fast unit suite first — no external services needed. Any test that
       # touches Postgres lives under `*.integration.test.ts` and runs in
-      # the integration phase below against an ephemeral Neon branch.
+      # the integration phase below against the local Postgres container.
       - name: Test (unit)
         run: pnpm test
 
-      # Integration phase: ephemeral Neon branch, MinIO, seed, and the
-      # integration suite. CI runs only on pull requests, so this phase runs
-      # on every CI run.
+      # Integration phase: a local Postgres + MinIO on the runner, seed, and the
+      # integration suite. CI runs only on pull requests, so this phase runs on
+      # every CI run.
       #
-      # Spin up an ephemeral Neon branch for the integration phase.
-      # Outputs are job-scoped + secret-marked per Neon's docs, so
-      # migrations + seed + integration tests all live in this job.
-      # expires_at is a safety net: if the runner is killed before the
-      # delete step runs, Neon auto-cleans the branch after 6 h.
-      - name: Compute Neon branch expiry (6h)
-        id: neon-expiry
-        run: echo "iso=$(date -u -d '+6 hours' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+      # Bring up Postgres + MinIO from the same docker-compose file dev uses.
+      # `--wait` blocks until `db` reports healthy (its pg_isready healthcheck)
+      # and `storage` is up; `storage-init` is a one-shot mc container that
+      # creates the bucket and exits 0. Running the database on the runner keeps
+      # every query on localhost instead of paying an internet round-trip to a
+      # remote host — the whole reason this phase used to run near 15 minutes.
+      - name: Start Postgres + MinIO via docker compose
+        run: docker compose -f docker/docker-compose.yml up -d --wait db storage storage-init
 
-      - name: Create Neon branch
-        id: neon-branch
-        uses: neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c # 6.3.1
-        with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch_name: ci-${{ github.run_id }}-${{ github.run_attempt }}
-          api_key: ${{ secrets.NEON_API_KEY }}
-          expires_at: ${{ steps.neon-expiry.outputs.iso }}
-          # Our 0001 migration creates app_user + app_service alongside
-          # neondb_owner, so the action's "infer the role" path fails with
-          # "Multiple roles found". Pin neondb_owner — it owns the schema
-          # and integration tests SET LOCAL ROLE to switch into app_user.
-          role: neondb_owner
-
-      - name: Apply migrations to CI branch
+      # The local container above. Its `batuda` superuser owns the schema, and
+      # integration tests SET ROLE into the app_user / app_service roles that the
+      # 0001 migration creates — exactly as every developer's local stack does.
+      - name: Apply migrations
         env:
-          DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
+          DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
         run: pnpm db:migrate
-
-      # Spin up MinIO (S3-compatible storage) via the same docker-compose
-      # file dev uses. `storage-init` is a one-shot mc container that
-      # waits for storage to be reachable and `mb --ignore-existing` the
-      # bucket; `--wait` blocks until both services are healthy or, in
-      # storage-init's case, have exited 0.
-      - name: Start MinIO via docker compose
-        run: docker compose -f docker/docker-compose.yml up -d --wait storage storage-init
 
       # Seed fixtures (notably the `taller` / `restaurant` orgs) that
       # several integration tests rely on. EMAIL_CREDENTIAL_KEY is base64
-      # of 32 zero bytes — fine for a branch that gets deleted at
-      # end-of-run. STORAGE_* points at the MinIO container started
-      # above; the seedDemoEmails stage PUTs raw RFC822 bytes there.
-      - name: Seed CI branch
+      # of 32 zero bytes — fine for a throwaway CI database. STORAGE_*
+      # points at the MinIO container started above; the seedDemoEmails
+      # stage PUTs raw RFC822 bytes there.
+      - name: Seed
         env:
-          DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
+          DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
           BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci
           EMAIL_CREDENTIAL_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
           STORAGE_ENDPOINT: http://localhost:9000
@@ -150,7 +132,7 @@ jobs:
       # tracked as a follow-up CI-perf slice.
       - name: Test (integration)
         env:
-          DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
+          DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
           BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci
           EMAIL_CREDENTIAL_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
           STORAGE_ENDPOINT: http://localhost:9000
@@ -164,23 +146,13 @@ jobs:
       # deploy workflow's exact `-e` secret list (dummy values), so a release
       # where the baked config needs a key the deploy never injects fails the
       # build instead of crashing on boot and taking prod down (2026-07-11).
-      # Reuses the Neon branch + MinIO the integration job already stood up.
+      # Reuses the Postgres + MinIO the integration phase already stood up.
       - name: Test (deploy boot parity)
         env:
-          DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
+          DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
           STORAGE_ENDPOINT: http://localhost:9000
           STORAGE_REGION: us-east-1
           STORAGE_ACCESS_KEY_ID: batuda
           STORAGE_SECRET_ACCESS_KEY: batuda-secret
           STORAGE_BUCKET: batuda-assets
         run: pnpm --filter @batuda/server exec vitest run src/main.boot.test.ts --config vitest.boot.config.ts
-
-      # Cleanup runs even on test failure; only skipped if the branch was
-      # never created (e.g. earlier step failed).
-      - name: Delete Neon branch
-        if: always() && steps.neon-branch.outcome == 'success'
-        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3.2.1
-        with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch: ci-${{ github.run_id }}-${{ github.run_attempt }}
-          api_key: ${{ secrets.NEON_API_KEY }}

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -35,6 +35,7 @@ import { servicesDown, servicesStatus, servicesUp } from './commands/services'
 import type { EnvFileResult } from './commands/setup'
 import { setup } from './commands/setup'
 import {
+	accessUrls,
 	worktreeDoctor,
 	worktreeDone,
 	worktreeDown,
@@ -69,34 +70,24 @@ const seedCommand = Command.make(
 				yield* Console.log(
 					`Seeded (${preset}): ${counts.products} products, ${counts.companies} companies, ${counts.contacts} contacts, ${counts.interactions} interactions, ${counts.tasks} tasks, ${counts.documents} documents, ${counts.proposals} proposals, ${counts.pages} pages, ${counts.callRecordings} call recordings`,
 				)
+				// Hosts follow this checkout: bare batuda.localhost in the main
+				// checkout, <label>.batuda.localhost inside a worktree — so the hints
+				// name the URL actually being served, not main's.
+				const { web, api } = yield* accessUrls
 				yield* Console.log('')
 				yield* Console.log('─── Access hints ───────────────────────────────')
+				yield* Console.log(`  API server:   pnpm dev:server   → ${api}`)
+				yield* Console.log(`  Batuda web:    pnpm dev:internal → ${web}`)
+				yield* Console.log('')
+				yield* Console.log(`  API docs (Scalar): ${api}/docs`)
+				yield* Console.log(`  OpenAPI spec:      ${api}/openapi.json`)
+				yield* Console.log(`  Auth docs:         ${api}/auth/reference`)
 				yield* Console.log(
-					'  API server:   pnpm dev:server   → https://api.batuda.localhost',
-				)
-				yield* Console.log(
-					'  Batuda web:    pnpm dev:internal → https://batuda.localhost',
+					`  Auth OpenAPI:      ${api}/auth/open-api/generate-schema`,
 				)
 				yield* Console.log('')
-				yield* Console.log(
-					'  API docs (Scalar): https://api.batuda.localhost/docs',
-				)
-				yield* Console.log(
-					'  OpenAPI spec:      https://api.batuda.localhost/openapi.json',
-				)
-				yield* Console.log(
-					'  Auth docs:         https://api.batuda.localhost/auth/reference',
-				)
-				yield* Console.log(
-					'  Auth OpenAPI:      https://api.batuda.localhost/auth/open-api/generate-schema',
-				)
-				yield* Console.log('')
-				yield* Console.log(
-					'  Health check:    curl https://api.batuda.localhost/health',
-				)
-				yield* Console.log(
-					'  List companies:  curl https://api.batuda.localhost/v1/companies',
-				)
+				yield* Console.log(`  Health check:    curl ${api}/health`)
+				yield* Console.log(`  List companies:  curl ${api}/v1/companies`)
 				yield* Console.log(
 					'  Docker DB:       docker exec -it batuda-db psql -U batuda',
 				)

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -169,6 +169,25 @@ const branchName = execSilent('git', 'rev-parse', '--abbrev-ref', 'HEAD')
 
 const slugForCurrentWorktree = branchName.pipe(Effect.map(slugForBranch))
 
+// The web + API URLs this checkout is actually reached on. The main checkout is
+// served on the bare batuda.localhost / api.batuda.localhost; a linked worktree
+// is on its own <label>.batuda.localhost / <label>.api.batuda.localhost, since
+// portless routes both off the branch's last path segment. `seed` prints these
+// as access hints, so deriving them here — the one place that already knows the
+// worktree's host — stops the hints from naming main's URLs inside a worktree.
+export const accessUrls = Effect.gen(function* () {
+	const { isLinked } = yield* worktreeContext
+	const branch = yield* branchName
+	const suffix = portSuffix()
+	const prefix = isLinked
+		? `${dnsLabel(branchLabel(branch), MAX_DNS_LABEL)}.`
+		: ''
+	return {
+		web: `https://${prefix}batuda.localhost${suffix}`,
+		api: `https://${prefix}api.batuda.localhost${suffix}`,
+	}
+})
+
 // Only the worktree's own database and bucket differ from main; the shared
 // endpoints (Postgres host/port, MinIO, GreenMail) are inherited as-is.
 const envOverridesForNames = (

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,18 @@ services:
       POSTGRES_DB: batuda
       POSTGRES_USER: batuda
       POSTGRES_PASSWORD: batuda
+    # `docker compose up --wait db` blocks until this reports healthy, which is
+    # when Postgres actually accepts connections — not merely when the container
+    # has started. CI relies on it so the migrate step never runs against a
+    # database that isn't listening yet. Probes the always-present `batuda`
+    # database, so it stays valid no matter which per-worktree databases exist
+    # alongside it in this one shared container.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U batuda -d batuda"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+      start_period: 5s
     volumes:
       # pg18+ moved the data dir up one level so a single mount can host
       # multiple major versions (enables pg_upgrade --link); see


### PR DESCRIPTION
## What

CI's integration-test phase — the slowest part of every pull-request check — talked to a remote Neon database over the internet. Every query paid a network round-trip, and because that phase runs the whole suite serially, it stretched each CI run to ~15–18 minutes. This moves the database onto the CI machine itself (the same Postgres image every developer already runs locally), so queries stay on localhost. The integration phase drops from ~15 minutes to under 2. It also fixes a small papercut in the `cli` developer tool that lived in the same startup path.

## Changes

- **CI runs its own Postgres.** Removed the three Neon steps (create branch / compute expiry / delete branch) and start a local Postgres container alongside the existing MinIO one, from the same `docker/docker-compose.yml` dev uses. Migrations, seed, the integration suite, and the deploy-boot-parity check all point at `localhost` now.
- **Readiness gate on the shared Postgres service.** Added a `pg_isready` healthcheck so `docker compose up --wait db` returns only once the database accepts connections — the migration step can no longer race a database that is still starting.
- **Lowered the job timeout 25 → 10 minutes** to match the new reality.
- **Fixed the worktree access hints.** `pnpm cli seed` (which `worktree up` runs) printed the main checkout's URLs (`batuda.localhost`) even inside a worktree, contradicting the "Worktree ready" summary printed right below it. The hints now follow the current checkout — a worktree shows its own `<branch-label>.batuda.localhost` host.

## Impact

- **CI isolation is unchanged, if anything cleaner.** Each PR's CI job already runs on its own throwaway runner; it now uses that runner's own local Postgres instead of a shared external Neon project. No cross-run interference.
- **New env vars: none. Migrations / schema: none. RLS / multi-org, MCP↔HTTP parity, API wire-shape, auth: untouched.**
- **Shared dev stack:** the healthcheck lands on the one shared `batuda-db` container, so the next `docker compose up` in any checkout recreates that container once (a ~5 s Postgres restart; data persists on the volume). One-time, then stable.
- **Repo-settings follow-up:** the `NEON_API_KEY` secret and `NEON_PROJECT_ID` variable are now unused (only `ci.yml` referenced them) — safe to delete from GitHub settings once you confirm nothing else needs them.

## Review guide

- Start with `.github/workflows/ci.yml` — the integration phase (start services → migrate → seed → test) is the substance; everything else is comment refresh and the timeout drop.
- `docker/docker-compose.yml`: the healthcheck probes the always-present `batuda` database, so it stays valid regardless of which per-worktree databases live in the shared container.
- The `cli` fix is a display-string change only — a new `accessUrls` helper in `worktree.ts`, consumed by the seed hints in `cli.ts`. No behavioral path.

## Verification

- Ran the full integration suite against a localhost Postgres container (the worktree's own database, to avoid touching shared data): 11 files, all green, **1m40s** wall-clock — vs ~14–15 min on Neon.
- `pnpm cli seed` inside this worktree now prints `https://ci-local-postgres.api.batuda.localhost:1355` (matching the worktree summary) instead of the bare host.
- Confirmed `pg_isready -U batuda -d batuda` succeeds against the running image and `docker compose config` renders the healthcheck.
- Gates: `pnpm install` (no lockfile drift) → `check-types` + `test` (workspace, green) → `build` (green). Workflow YAML parses; Biome clean on the changed files.

## Deferred

- Dropping `--concurrency=1` on the integration run (a `TRUNCATE`-vs-`INSERT` race in one multi-org test forces it) — a separate follow-up; still fast on local Postgres either way.
