### PR TITLE
fix(server): fall back to a location-only geocode query

### DIFF
--- a/apps/cli/src/commands/companies.ts
+++ b/apps/cli/src/commands/companies.ts
@@ -78,9 +78,19 @@ export const companiesBackfillGeocode = (dryRun: boolean) =>
 				continue
 			}
 
-			const hit = yield* lookup(query)
+			let hit = yield* lookup(query)
 			// Pause between calls to respect Nominatim's ~1 request/second limit.
 			yield* Effect.sleep('1 seconds')
+			let matchedQuery = query
+
+			// The name-prefixed query resolves to no place for many companies, so
+			// fall back to the bare location before giving up — only when it differs
+			// from the query already tried (i.e. a name was part of it).
+			if (!hit && company.location && company.location !== query) {
+				hit = yield* lookup(company.location)
+				yield* Effect.sleep('1 seconds')
+				matchedQuery = company.location
+			}
 
 			if (!hit) {
 				missed++
@@ -100,7 +110,9 @@ export const companiesBackfillGeocode = (dryRun: boolean) =>
 				`
 			}
 			geocoded++
-			yield* Console.log(`  ✓ ${query} → ${hit.latitude}, ${hit.longitude}`)
+			yield* Console.log(
+				`  ✓ ${matchedQuery} → ${hit.latitude}, ${hit.longitude}`,
+			)
 		}
 
 		yield* Console.log(

--- a/apps/server/src/handlers/companies.ts
+++ b/apps/server/src/handlers/companies.ts
@@ -87,22 +87,32 @@ export const CompaniesLive = HttpApiBuilder.group(
 					geocodeCompany(_.params.id).pipe(
 						Effect.provideService(CompanyService, svc),
 						Effect.provideService(Geocoder, geocoder),
-						// The helper returns null when there's no address to search on or
-						// the geocoder found no match; the endpoint reports both as a
-						// 404 the Where panel renders as "no match".
-						Effect.flatMap(row =>
-							row === null
-								? Effect.fail(
-										new NotFound({ entity: 'geocode-miss', id: _.params.id }),
-									)
-								: Effect.logInfo('Company geocoded').pipe(
+						// A resolvable location returns the row. No match, or nothing to
+						// search on, is the 404 the Where panel renders as "no match". A
+						// geocoder that could not be reached is a server fault, kept apart
+						// from "no match" so it surfaces as a 500, not a 404.
+						Effect.flatMap(result => {
+							switch (result._tag) {
+								case 'geocoded':
+									return Effect.logInfo('Company geocoded').pipe(
 										Effect.annotateLogs({
 											event: 'company.geocoded',
 											companyId: _.params.id,
 										}),
-										Effect.as(row),
-									),
-						),
+										Effect.as(result.company),
+									)
+								case 'lookup_failed':
+									return Effect.die(
+										new Error(
+											`geocoder unreachable for company ${_.params.id}`,
+										),
+									)
+								default:
+									return Effect.fail(
+										new NotFound({ entity: 'geocode-miss', id: _.params.id }),
+									)
+							}
+						}),
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
 						),

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -134,11 +134,19 @@ const UpdateCompany = Tool.make('update_company', {
 
 const GeocodeCompany = Tool.make('geocode_company', {
 	description:
-		'Resolve a company to latitude/longitude via the configured geocoder (Nominatim). Persists lat/lng/geocoded_at/geocode_source and returns the updated row. Rate-limited to 1 req/sec.',
+		'Resolve a company to latitude/longitude via the configured geocoder (Nominatim). On a match, persists lat/lng/geocoded_at/geocode_source. Returns { outcome, company }: outcome is "geocoded" (company is the updated row), "no_match" (nothing resolved for the location), "nothing_to_search" (company has no name or location), or "lookup_failed" (the geocoder could not be reached). Rate-limited to 1 req/sec.',
 	parameters: Schema.Struct({
 		id: Schema.String,
 	}),
-	success: Schema.NullOr(Company.json),
+	success: Schema.Struct({
+		outcome: Schema.Literals([
+			'geocoded',
+			'no_match',
+			'nothing_to_search',
+			'lookup_failed',
+		]),
+		company: Schema.NullOr(Company.json),
+	}),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'Geocode Company')
@@ -226,6 +234,10 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 				geocodeCompany(id).pipe(
 					Effect.provideService(CompanyService, service),
 					Effect.provideService(Geocoder, geocoder),
+					Effect.map(result => ({
+						outcome: result._tag,
+						company: result._tag === 'geocoded' ? result.company : null,
+					})),
 					Effect.orDie,
 				),
 		}

--- a/apps/server/src/services/company-geocoding.test.ts
+++ b/apps/server/src/services/company-geocoding.test.ts
@@ -6,7 +6,7 @@ import type { Company } from '@batuda/domain'
 
 import { CompanyService } from './companies'
 import { geocodeCompany, locationWasReplaced } from './company-geocoding'
-import { Geocoder } from './geocoder'
+import { GeocodeLookupError, type GeocodeResult, Geocoder } from './geocoder'
 
 const unused = new Error('method not used in this test')
 const currentOrg = { id: 'org-1', name: 'fixture', slug: 'fixture' }
@@ -36,81 +36,168 @@ const companyServiceWith = (
 		getWithRelations: () => Effect.die(unused),
 	})
 
-const geocoderReturning = (
-	hit: { latitude: number; longitude: number; source: string } | null,
-) => Geocoder.of({ lookup: () => Effect.succeed(hit) })
+// A geocoder that answers each query from a fixed map — a GeocodeResult for a
+// hit, the string 'error' to simulate an unreachable geocoder, and null (any
+// unlisted query) for a genuine no-match. Every query it is asked is pushed to
+// `asked`, so a test can prove the primary and the location-only fallback both
+// (or neither) ran.
+const geocoderFrom = (
+	answers: Record<string, GeocodeResult | 'error'>,
+	asked: Array<string>,
+) =>
+	Geocoder.of({
+		lookup: (query: string) => {
+			asked.push(query)
+			const answer = answers[query] ?? null
+			return answer === 'error'
+				? Effect.fail(new GeocodeLookupError({ query, cause: 'unreachable' }))
+				: Effect.succeed(answer)
+		},
+	})
 
 const run = (
 	company: Record<string, unknown> | null,
-	hit: { latitude: number; longitude: number; source: string } | null,
+	answers: Record<string, GeocodeResult | 'error'>,
 	updates: Array<Record<string, unknown>>,
+	asked: Array<string> = [],
 ) =>
 	geocodeCompany('c-1').pipe(
 		Effect.provideService(CompanyService, companyServiceWith(company, updates)),
-		Effect.provideService(Geocoder, geocoderReturning(hit)),
+		Effect.provideService(Geocoder, geocoderFrom(answers, asked)),
 		Effect.provideService(CurrentOrg, currentOrg),
 		Effect.runPromise,
 	)
 
 describe('geocodeCompany', () => {
-	describe('when the geocoder returns a match', () => {
-		it('should store latitude, longitude and the geocode source', async () => {
-			// GIVEN a company with a location and a geocoder that resolves it
+	describe('when the name-and-location query resolves', () => {
+		it('should store the coordinates and report the geocoded row', async () => {
+			// GIVEN a company whose "name, location" query the geocoder resolves
 			const updates: Array<Record<string, unknown>> = []
+			const asked: Array<string> = []
 
 			// WHEN the company is geocoded
 			const result = await run(
 				{ name: 'Sunset Transportation', location: 'St. Louis, MO' },
-				{ latitude: 38.627, longitude: -90.199, source: 'nominatim' },
+				{
+					'Sunset Transportation, St. Louis, MO': {
+						latitude: 38.627,
+						longitude: -90.199,
+						source: 'nominatim',
+					},
+				},
 				updates,
+				asked,
 			)
 
-			// THEN exactly the four coordinate columns are written, and the
-			// updated row comes back
+			// THEN only the primary query is asked, the four coordinate columns are
+			// written, and the outcome carries the updated row
+			expect(asked).toEqual(['Sunset Transportation, St. Louis, MO'])
 			expect(updates).toHaveLength(1)
 			expect(updates[0]).toMatchObject({
 				latitude: 38.627,
 				longitude: -90.199,
 				geocodeSource: 'nominatim',
 			})
-			expect(result).not.toBeNull()
+			expect(result).toMatchObject({ _tag: 'geocoded' })
 		})
 	})
 
-	describe('when the geocoder finds no match', () => {
-		it('should store nothing and return null', async () => {
-			// GIVEN a company whose location the geocoder cannot resolve
+	describe('when the name-prefixed query misses but the bare location resolves', () => {
+		it('should fall back to a location-only lookup and geocode', async () => {
+			// GIVEN a company whose "name, location" query resolves to no place,
+			// while the location on its own does resolve
 			const updates: Array<Record<string, unknown>> = []
+			const asked: Array<string> = []
+
+			// WHEN the company is geocoded
+			const result = await run(
+				{ name: 'Circle Logistics', location: 'Detroit, MI' },
+				{
+					'Detroit, MI': {
+						latitude: 42.331,
+						longitude: -83.045,
+						source: 'nominatim',
+					},
+				},
+				updates,
+				asked,
+			)
+
+			// THEN the primary query is tried first, then the location alone, and the
+			// fallback hit is persisted
+			expect(asked).toEqual(['Circle Logistics, Detroit, MI', 'Detroit, MI'])
+			expect(updates).toHaveLength(1)
+			expect(updates[0]).toMatchObject({
+				latitude: 42.331,
+				longitude: -83.045,
+				geocodeSource: 'nominatim',
+			})
+			expect(result).toMatchObject({ _tag: 'geocoded' })
+		})
+	})
+
+	describe('when neither the name-and-location nor the location resolves', () => {
+		it('should write nothing and report no_match', async () => {
+			// GIVEN a company no query resolves, primary or fallback
+			const updates: Array<Record<string, unknown>> = []
+			const asked: Array<string> = []
 
 			// WHEN the company is geocoded
 			const result = await run(
 				{ name: 'Nowhere Ltd', location: 'Atlantis' },
-				null,
+				{},
 				updates,
+				asked,
 			)
 
-			// THEN no coordinates are written and the caller learns nothing was stored
+			// THEN both queries were attempted, nothing was written, and the caller
+			// learns it was a genuine no-match
+			expect(asked).toEqual(['Nowhere Ltd, Atlantis', 'Atlantis'])
 			expect(updates).toHaveLength(0)
-			expect(result).toBeNull()
+			expect(result).toEqual({ _tag: 'no_match' })
 		})
 	})
 
 	describe('when the company has no name or location to search on', () => {
-		it('should never send an empty query and return null', async () => {
+		it('should never call the geocoder and report nothing_to_search', async () => {
 			// GIVEN a company with neither a name nor a location, but a geocoder
 			// that would happily return a hit if it were asked
 			const updates: Array<Record<string, unknown>> = []
+			const asked: Array<string> = []
 
 			// WHEN the company is geocoded
 			const result = await run(
 				{},
-				{ latitude: 1, longitude: 2, source: 'nominatim' },
+				{ Anywhere: { latitude: 1, longitude: 2, source: 'nominatim' } },
 				updates,
+				asked,
 			)
 
-			// THEN the lookup is skipped entirely — no write, nothing stored
+			// THEN the geocoder is never asked, nothing is written
+			expect(asked).toEqual([])
 			expect(updates).toHaveLength(0)
-			expect(result).toBeNull()
+			expect(result).toEqual({ _tag: 'nothing_to_search' })
+		})
+	})
+
+	describe('when the geocoder cannot be reached', () => {
+		it('should report lookup_failed, kept apart from a no-match', async () => {
+			// GIVEN a company whose lookup errors instead of returning a result
+			const updates: Array<Record<string, unknown>> = []
+			const asked: Array<string> = []
+
+			// WHEN the company is geocoded
+			const result = await run(
+				{ name: 'Acme', location: 'Berlin' },
+				{ 'Acme, Berlin': 'error' },
+				updates,
+				asked,
+			)
+
+			// THEN no coordinates are written and the outage is its own outcome,
+			// distinct from "no place found"
+			expect(updates).toHaveLength(0)
+			expect(result).toEqual({ _tag: 'lookup_failed' })
 		})
 	})
 })

--- a/apps/server/src/services/company-geocoding.ts
+++ b/apps/server/src/services/company-geocoding.ts
@@ -2,10 +2,23 @@ import { Cause, Context, DateTime, Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
+import type { Company } from '@batuda/domain'
 
 import { enterOrgScope } from '../middleware/org'
 import { CompanyService } from './companies'
-import { Geocoder } from './geocoder'
+import { type GeocodeResult, Geocoder } from './geocoder'
+
+/**
+ * What geocoding a company came to. `geocoded` carries the row with fresh
+ * coordinates; the rest say why none were written, kept apart so a caller can
+ * tell success from each kind of silence: the company had nothing to search on,
+ * the geocoder had no place for it, or the geocoder could not be reached.
+ */
+export type GeocodeCompanyResult =
+	| { readonly _tag: 'geocoded'; readonly company: Company }
+	| { readonly _tag: 'no_match' }
+	| { readonly _tag: 'nothing_to_search' }
+	| { readonly _tag: 'lookup_failed' }
 
 /**
  * Drop the ambient transaction connection so a following `withTransaction`
@@ -27,15 +40,21 @@ const detachFromTransaction =
 
 /**
  * Resolve a company's coordinates from the deterministic geocoder and store
- * them. Builds the lookup from the company's name and location, and on a match
- * writes latitude/longitude/geocoded_at/geocode_source, returning the updated
- * row. Returns null when there is nothing to store — the company has no
- * name/location to search on, or the geocoder found no match.
+ * them. It first asks for the company's "name, location" together — the name is
+ * kept in the query on purpose, since a bare place name can plant a pin on the
+ * wrong same-named town. When that finds nothing it retries with the location
+ * on its own, because prepending a company name (not a geographic word) often
+ * defeats an otherwise easy match. On a hit it writes
+ * latitude/longitude/geocoded_at/geocode_source and returns the updated row.
  *
- * This is the one place the coordinate columns and the "name, location" lookup
- * are defined. The geocode_company tool, the HTTP geocode endpoint, and the
- * post-enrichment research sink all go through here, so coordinates always come
- * from the geocoder and never from a language model.
+ * The result says which of four things happened, so callers can tell a real
+ * geocode from each kind of silence: nothing to search on, no place found, or
+ * the geocoder unreachable (see {@link GeocodeCompanyResult}).
+ *
+ * This is the one place the coordinate columns and that lookup are defined. The
+ * geocode_company tool, the HTTP geocode endpoint, and the post-enrichment
+ * research sink all go through here, so coordinates always come from the
+ * geocoder and never from a language model.
  */
 export const geocodeCompany = (id: string) =>
 	Effect.gen(function* () {
@@ -45,20 +64,44 @@ export const geocodeCompany = (id: string) =>
 
 		const name = company['name'] as string | null
 		const location = company['location'] as string | null
-		const query = [name, location].filter(Boolean).join(', ')
-		if (!query) return null
+		const primaryQuery = [name, location].filter(Boolean).join(', ')
+		if (!primaryQuery) return { _tag: 'nothing_to_search' } as const
 
-		const hit = yield* geocoder.lookup(query)
-		if (!hit) return null
+		// Write the coordinates and hand back the fresh row; a race that removed
+		// the company between lookup and write leaves nothing to return.
+		const persist = (hit: GeocodeResult) =>
+			Effect.gen(function* () {
+				const rows = yield* service.update(id, {
+					latitude: hit.latitude,
+					longitude: hit.longitude,
+					geocodedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
+					geocodeSource: hit.source,
+				})
+				const updated = rows[0]
+				return updated
+					? ({ _tag: 'geocoded', company: updated } as const)
+					: ({ _tag: 'no_match' } as const)
+			})
 
-		const rows = yield* service.update(id, {
-			latitude: hit.latitude,
-			longitude: hit.longitude,
-			geocodedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
-			geocodeSource: hit.source,
-		})
-		return rows[0] ?? null
-	})
+		const primaryHit = yield* geocoder.lookup(primaryQuery)
+		if (primaryHit) return yield* persist(primaryHit)
+
+		// The name-prefixed query resolves to no place for many companies, so fall
+		// back to the bare location before giving up — only when it differs from
+		// the query already tried (i.e. a name was part of it).
+		if (location && location !== primaryQuery) {
+			const locationHit = yield* geocoder.lookup(location)
+			if (locationHit) return yield* persist(locationHit)
+		}
+
+		return { _tag: 'no_match' } as const
+	}).pipe(
+		// A geocoder that could not be reached is not a no-match: report it as its
+		// own outcome instead of folding it into "no place found".
+		Effect.catchTag('GeocodeLookupError', () =>
+			Effect.succeed({ _tag: 'lookup_failed' } as const),
+		),
+	)
 
 /**
  * Whether an update replaced a company's location with a new, non-empty place —

--- a/apps/server/src/services/geocoder.ts
+++ b/apps/server/src/services/geocoder.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Schema, Semaphore } from 'effect'
+import { Context, Data, Effect, Layer, Schema, Semaphore } from 'effect'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
 const NominatimHit = Schema.Struct({
@@ -14,6 +14,17 @@ export interface GeocodeResult {
 	readonly source: string
 }
 
+/**
+ * The geocoder could not be reached or its answer could not be read — a
+ * network, HTTP, or parse fault, as opposed to the geocoder plainly having no
+ * place for the query. Callers use this to tell an outage apart from a genuine
+ * no-match instead of treating both as "nothing found".
+ */
+export class GeocodeLookupError extends Data.TaggedError('GeocodeLookupError')<{
+	readonly query: string
+	readonly cause: string
+}> {}
+
 export class Geocoder extends Context.Service<Geocoder>()('Geocoder', {
 	make: Effect.gen(function* () {
 		const client = yield* HttpClient.HttpClient
@@ -22,7 +33,9 @@ export class Geocoder extends Context.Service<Geocoder>()('Geocoder', {
 		// section spaces them out so the next request can't fire too soon.
 		const semaphore = yield* Semaphore.make(1)
 
-		const lookup = (query: string): Effect.Effect<GeocodeResult | null> =>
+		const lookup = (
+			query: string,
+		): Effect.Effect<GeocodeResult | null, GeocodeLookupError> =>
 			semaphore.withPermits(1)(
 				client
 					.get('https://nominatim.openstreetmap.org/search', {
@@ -57,6 +70,9 @@ export class Geocoder extends Context.Service<Geocoder>()('Geocoder', {
 							}
 						}),
 						Effect.tap(() => Effect.sleep('1 seconds')),
+						// A fault reaching the geocoder or reading its answer is not the
+						// same as the geocoder having no place for the query: fail with a
+						// typed error so the caller can tell an outage from a no-match.
 						Effect.catch((err: unknown) =>
 							Effect.logWarning('Geocode lookup failed')
 								.pipe(
@@ -66,7 +82,13 @@ export class Geocoder extends Context.Service<Geocoder>()('Geocoder', {
 										cause: String(err),
 									}),
 								)
-								.pipe(Effect.as(null)),
+								.pipe(
+									Effect.andThen(
+										Effect.fail(
+											new GeocodeLookupError({ query, cause: String(err) }),
+										),
+									),
+								),
 						),
 					),
 			)


### PR DESCRIPTION
## What

When I ask Batuda to put a company on the map (to "geocode" it — turn its address into map coordinates), it looks the place up in a geocoder. For a company that only has a free-text place like `Detroit, MI`, that lookup silently failed and stored nothing — because it searched for the company **name glued in front of the place** (`Circle Logistics, Detroit, MI`), which the geocoder has no record of as a location. The result was a quiet no-op: no coordinates, no error, no way for the caller to tell what went wrong.

This fixes the CRM's server-side geocoding (`apps/server`) — shared by the `geocode_company` MCP tool, the HTTP geocode endpoint, and the post-enrichment research step — plus the one-time backfill command in the CLI (`apps/cli`).

## The fix

- Keep the `name, location` query as the **primary** lookup (the name deliberately guards against dropping a pin on a wrong same-named town), then **fall back to a location-only query** when that finds nothing.
- Tell a geocoder **outage** apart from a genuine **no-match**: the lookup now fails with a typed `GeocodeLookupError` instead of swallowing a network/parse fault into an empty result.
- Return a tagged outcome — `geocoded` / `no_match` / `nothing_to_search` / `lookup_failed` — so a caller can tell a real geocode from each kind of silence.
- Fold the same location-only fallback into the `companies backfill-geocode` CLI, which mirrors the server geocoder.

## Impact

- **MCP wire-shape (clean break):** the `geocode_company` tool now returns `{ outcome, company }` instead of `Company | null`. Pre-prod, so no shim — MCP clients read the new shape.
- **HTTP behavior:** `POST /companies/:id/geocode` still returns the company row on success and a 404 for a no-match, but an **unreachable geocoder is now a 500** (was a 404) so an outage isn't misread as "no such place".
- **MCP + HTTP parity:** both surfaces call the same `geocodeCompany`, so both gain the fallback and the outage/no-match distinction.
- **No** schema/migration, **no** new env var, **no** RLS/role change — the coordinate write still goes through the existing org-scoped `CompanyService.update`.

## Review guide

- Start at `apps/server/src/services/company-geocoding.ts`: the two-query strategy and the `catchTag` that turns a lookup fault into `lookup_failed`.
- `geocoder.ts` is the one behavior shift outside `geocodeCompany` — it no longer returns null on a fault. Its only caller is `geocodeCompany`.
- The CLI change mirrors the server and has no tests (repo convention: no unit tests for CLI commands).
- A decision you might overrule: an unreachable geocoder maps to HTTP 500 rather than a softer 404 — I chose to make the outage visible rather than hide it as a miss.

## Tests

- `company-geocoding.test.ts`: a query-aware geocoder stub asserting the primary then the location-only fallback queries; one test per outcome, including the exact `Circle Logistics, Detroit, MI` → `Detroit, MI` regression and the `lookup_failed` path.

## Verification

- Gates all green: `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test` (537 passed), `pnpm -w build`.
- Live end-to-end against **real Nominatim + the dev Postgres** via `pnpm cli companies backfill-geocode`: inserted `Circle Logistics / Detroit, MI` with no coordinates; the primary `Circle Logistics, Detroit, MI` returned NO MATCH, the fallback `Detroit, MI` geocoded and persisted (lat `42.331551`, lng `-83.046640`, `geocode_source=nominatim`). Test row removed afterward.
- Confirmed the premise directly too: live Nominatim returns NO MATCH for the name-prefixed query and a Detroit hit for the location alone.

Closes #275
