### PR TITLE
fix(research): keep findings snake_case on cache-hit reuse and resume

### DIFF
--- a/apps/server/src/handlers/research-cache-clone.integration.test.ts
+++ b/apps/server/src/handlers/research-cache-clone.integration.test.ts
@@ -157,3 +157,48 @@ describe('cloneCacheHitRun', () => {
 		})
 	})
 })
+
+// The gotcha the resume-path fix (research-service.ts) turns on: a plain
+// `SELECT findings` through the SQL client camelCases every nested jsonb key,
+// while `SELECT findings::text` returns the raw bytes unchanged.
+describe('reading findings through the SQL client', () => {
+	describe('when the stored findings use snake_case keys', () => {
+		it('should camelCase a plain SELECT but preserve snake_case via ::text', async () => {
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* Effect.gen(function* () {
+						yield* enterOrgScope
+						const id = yield* seedSourceRun(JSON.stringify(SNAKE_FINDINGS))
+						// A plain select — the client parses + camelCases the jsonb.
+						const [plain] = yield* sql<{
+							findings: Record<string, unknown>
+						}>`SELECT findings FROM research_runs WHERE id = ${id}`
+						// A ::text select — the value comes back as raw JSON text.
+						const [raw] = yield* sql<{
+							findings: string
+						}>`SELECT findings::text AS findings FROM research_runs WHERE id = ${id}`
+						return {
+							plain: plain?.findings ?? null,
+							rawText: raw?.findings ?? null,
+						}
+					}).pipe(sql.withTransaction)
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			// GIVEN snake_case findings, WHEN read plainly THEN keys are camelCased
+			expect(result.plain).not.toBeNull()
+			expect(result.plain).toHaveProperty('proposedUpdates')
+			expect(result.plain).not.toHaveProperty('proposed_updates')
+
+			// WHEN read as ::text THEN the raw snake_case bytes survive
+			expect(result.rawText).not.toBeNull()
+			const parsed = JSON.parse(result.rawText as string) as Record<
+				string,
+				unknown
+			>
+			expect(parsed).toHaveProperty('proposed_updates')
+			expect(parsed).not.toHaveProperty('proposedUpdates')
+		})
+	})
+})

--- a/apps/server/src/handlers/research-cache-clone.integration.test.ts
+++ b/apps/server/src/handlers/research-cache-clone.integration.test.ts
@@ -1,0 +1,159 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { cloneCacheHitRun } from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+
+// Regression coverage for #276: reusing an identical research query as a
+// `cache_hit` clone must keep `findings` byte-identical to the source run. The
+// bug read findings through the SQL client — which camelCases every jsonb key on
+// read — and re-serialized them, so `proposed_updates` silently became
+// `proposedUpdates` and downstream readers of the documented snake_case keys got
+// `undefined`. `cloneCacheHitRun` now copies findings src → clone inside Postgres
+// so it never round-trips through JS. These run as `app_user` with
+// `app.current_org_id` set, exactly like a request handler (see middleware/org.ts),
+// so the research_runs RLS policy engages just as it does at runtime.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable; the integration
+// runner builds + seeds `batuda_it`.
+
+// organization_id / created_by are free text on research_runs (no FK), so the
+// suite owns a synthetic org + user and cleans up by org id — no seed coupling.
+const ORG_ID = `it-276-org-${randomUUID()}`
+const USER_ID = `it-276-user-${randomUUID()}`
+
+// The exact snake_case shape from the issue: a top-level list plus a deeply
+// nested key, both of which the buggy read camelCased.
+const SNAKE_FINDINGS = {
+	proposed_updates: [
+		{
+			id: 'p-1',
+			status: 'pending',
+			subject_table: 'companies',
+			subject_id: 'c-1',
+			fields: {},
+		},
+	],
+	enrichment: { country: { value: 'ES', source_id: 's-1' } },
+}
+
+// Enter app_user org scope for the current transaction, mirroring middleware/org.ts.
+const enterOrgScope = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+	yield* sql`SET LOCAL ROLE app_user`
+	yield* sql`SELECT set_config('app.current_org_id', ${ORG_ID}, true)`
+})
+
+// Seed a succeeded source run whose findings are byte-controlled snake_case.
+const seedSourceRun = (findingsJson: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const [row] = yield* sql<{ id: string }>`
+			INSERT INTO research_runs (
+				organization_id, query, mode, schema_name, kind, status,
+				findings, brief_md, tokens_in, tokens_out, created_by,
+				started_at, completed_at
+			) VALUES (
+				${ORG_ID}, 'it-276 cache casing', 'deep', 'company_enrichment_v1',
+				'leaf', 'succeeded',
+				${findingsJson}::jsonb, 'source brief', 11, 22, ${USER_ID},
+				now(), now()
+			) RETURNING id
+		`
+		return row?.id ?? ''
+	})
+
+beforeAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`GRANT app_user TO CURRENT_USER`
+		}).pipe(Effect.provide(PgLive)),
+	)
+})
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`DELETE FROM research_runs WHERE organization_id = ${ORG_ID}`
+		}).pipe(Effect.provide(PgLive)),
+	)
+})
+
+describe('cloneCacheHitRun', () => {
+	describe('when cloning a succeeded run whose findings use snake_case keys', () => {
+		it('should store the clone findings jsonb-equal to the source, keys still snake_case', async () => {
+			// GIVEN a succeeded source run with the issue's snake_case findings, WHEN
+			// it is reused as a cache_hit clone, THEN the clone's findings equal the
+			// source's and keep snake_case keys.
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* Effect.gen(function* () {
+						yield* enterOrgScope
+						const sourceId = yield* seedSourceRun(
+							JSON.stringify(SNAKE_FINDINGS),
+						)
+						const cloned = yield* cloneCacheHitRun({
+							sql,
+							cachedId: sourceId,
+							organizationId: ORG_ID,
+							userId: USER_ID,
+							input: {
+								query: 'it-276 cache casing',
+								mode: 'deep',
+								schemaName: 'company_enrichment_v1',
+							},
+							templateIds: [],
+							templateNames: [],
+							templateFingerprint: '',
+						})
+						if (!cloned) return { clonedId: null, cmp: null }
+						const [cmp] = yield* sql<{
+							eq: boolean
+							cloneText: string
+							kind: string
+						}>`
+							SELECT
+								(c.findings = s.findings) AS eq,
+								c.findings::text AS clone_text,
+								c.kind AS kind
+							FROM research_runs c, research_runs s
+							WHERE c.id = ${cloned.id} AND s.id = ${sourceId}
+						`
+						return { clonedId: cloned.id, cmp: cmp ?? null }
+					}).pipe(sql.withTransaction)
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			expect(result.clonedId).not.toBeNull()
+			expect(result.cmp).not.toBeNull()
+			const cmp = result.cmp
+			if (!cmp) throw new Error('no clone row read back')
+
+			// The clone is recorded as a cache_hit and its findings are jsonb-equal.
+			expect(cmp.kind).toBe('cache_hit')
+			expect(cmp.eq).toBe(true)
+
+			// The stored keys are snake_case, never the camelCased shape the bug produced.
+			const findings = JSON.parse(cmp.cloneText) as Record<string, unknown>
+			expect(findings).toHaveProperty('proposed_updates')
+			expect(findings).not.toHaveProperty('proposedUpdates')
+			const country = (
+				findings['enrichment'] as { country?: Record<string, unknown> }
+			).country
+			expect(country).toHaveProperty('source_id')
+			expect(country).not.toHaveProperty('sourceId')
+		})
+	})
+})

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -759,6 +759,96 @@ export interface ResolvedInstructions {
 	readonly templateNames: ReadonlyArray<string>
 }
 
+// Clone a succeeded run as a `cache_hit` so an identical query skips the fiber.
+// The findings / brief / token columns are copied straight from the source row to
+// the clone inside Postgres (INSERT … SELECT), so `findings` is never read into
+// JS — where the SQL client would camelCase every nested key and change the stored
+// shape. Returns null when the cached run is gone or no longer succeeded, so the
+// caller runs a fresh query instead.
+export const cloneCacheHitRun = (params: {
+	readonly sql: SqlClient.SqlClient
+	readonly cachedId: string
+	readonly organizationId: string
+	readonly userId: string
+	readonly input: CreateResearchInput
+	readonly templateIds: ReadonlyArray<string>
+	readonly templateNames: ReadonlyArray<string>
+	readonly templateFingerprint: string
+}) =>
+	Effect.gen(function* () {
+		const {
+			sql,
+			cachedId,
+			organizationId,
+			userId,
+			input,
+			templateIds,
+			templateNames,
+			templateFingerprint,
+		} = params
+		const clonedRows = yield* sql<{ id: string }>`
+			INSERT INTO research_runs (
+				organization_id,
+				query, mode, schema_name, kind, status, context,
+				findings, brief_md,
+				tokens_in, tokens_out,
+				cost_cents, paid_cost_cents,
+				idempotency_key, created_by,
+				template_ids, template_names, template_fingerprint,
+				started_at, completed_at
+			)
+			SELECT
+				${organizationId},
+				${input.query},
+				${input.mode ?? 'deep'},
+				${input.schemaName ?? null},
+				'cache_hit',
+				'succeeded',
+				${JSON.stringify(input.context ?? {})}::jsonb,
+				src.findings, src.brief_md,
+				src.tokens_in, src.tokens_out,
+				0, 0,
+				${input.idempotencyKey ?? null},
+				${userId},
+				${JSON.stringify(templateIds)}::jsonb, ${JSON.stringify(templateNames)}::jsonb, ${templateFingerprint},
+				now(), now()
+			FROM research_runs src
+			WHERE src.id = ${cachedId} AND src.status = 'succeeded'
+			RETURNING id
+		`
+		const cloned = clonedRows[0]
+		if (!cloned) return null
+		const clonedId = cloned.id
+		// Clone source attributions from the cached run.
+		// research_run_sources / research_links are RLS-checked
+		// against `current_setting('app.current_org_id')`, so the
+		// org id has to be in the row, not just on the parent run.
+		yield* sql`
+			INSERT INTO research_run_sources (organization_id, research_id, source_id, local_ref, fetched_at, cost_cents)
+			SELECT ${organizationId}, ${clonedId}, source_id, local_ref, fetched_at, 0
+			FROM research_run_sources
+			WHERE research_id = ${cachedId}
+			ON CONFLICT DO NOTHING
+		`
+		if (input.context?.subjects) {
+			for (const s of input.context.subjects) {
+				yield* sql`
+					INSERT INTO research_links (organization_id, research_id, subject_table, subject_id, link_kind)
+					VALUES (${organizationId}, ${clonedId}, ${s.table}, ${s.id}, 'input')
+					ON CONFLICT DO NOTHING
+				`
+			}
+		}
+		yield* Effect.logInfo('research.cache_hit').pipe(
+			Effect.annotateLogs({
+				user_id: userId,
+				research_id: clonedId,
+				source_research_id: cachedId,
+			}),
+		)
+		return { id: clonedId }
+	})
+
 // ── ResearchService ──
 
 export class ResearchService extends Context.Service<ResearchService>()(
@@ -3052,81 +3142,18 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								LIMIT 1
 							`
 							if (hits[0]) {
-								const cachedId = hits[0].researchId
-								const [cachedRun] = yield* sql<{
-									findings: unknown
-									briefMd: string | null
-									tokensIn: number
-									tokensOut: number
-								}>`
-									SELECT findings, brief_md, tokens_in, tokens_out
-									FROM research_runs
-									WHERE id = ${cachedId} AND status = 'succeeded'
-									LIMIT 1
-								`
-								if (cachedRun) {
-									const clonedRows = yield* sql<{ id: string }>`
-										INSERT INTO research_runs (
-											organization_id,
-											query, mode, schema_name, kind, status, context,
-											findings, brief_md,
-											tokens_in, tokens_out,
-											cost_cents, paid_cost_cents,
-											idempotency_key, created_by,
-											template_ids, template_names, template_fingerprint,
-											started_at, completed_at
-										) VALUES (
-											${organizationId},
-											${input.query},
-											${input.mode ?? 'deep'},
-											${input.schemaName ?? null},
-											'cache_hit',
-											'succeeded',
-											${JSON.stringify(input.context ?? {})},
-											${JSON.stringify(cachedRun.findings)},
-											${cachedRun.briefMd},
-											${cachedRun.tokensIn},
-											${cachedRun.tokensOut},
-											0, 0,
-											${input.idempotencyKey ?? null},
-											${userId},
-											${JSON.stringify(templateIds)}, ${JSON.stringify(templateNames)}, ${templateFingerprint},
-											now(), now()
-										) RETURNING id
-									`
-									const cloned = clonedRows[0]
-									if (!cloned)
-										return { id: cachedId, status: 'succeeded' as const }
-									const clonedId = cloned.id
-									// Clone source attributions from the cached run.
-									// research_run_sources / research_links are RLS-checked
-									// against `current_setting('app.current_org_id')`, so the
-									// org id has to be in the row, not just on the parent run.
-									yield* sql`
-										INSERT INTO research_run_sources (organization_id, research_id, source_id, local_ref, fetched_at, cost_cents)
-										SELECT ${organizationId}, ${clonedId}, source_id, local_ref, fetched_at, 0
-										FROM research_run_sources
-										WHERE research_id = ${cachedId}
-										ON CONFLICT DO NOTHING
-									`
-									if (input.context?.subjects) {
-										for (const s of input.context.subjects) {
-											yield* sql`
-												INSERT INTO research_links (organization_id, research_id, subject_table, subject_id, link_kind)
-												VALUES (${organizationId}, ${clonedId}, ${s.table}, ${s.id}, 'input')
-												ON CONFLICT DO NOTHING
-											`
-										}
-									}
-									yield* Effect.logInfo('research.cache_hit').pipe(
-										Effect.annotateLogs({
-											user_id: userId,
-											research_id: clonedId,
-											source_research_id: cachedId,
-										}),
-									)
-									return { id: clonedId, status: 'succeeded' as const }
-								}
+								const cloned = yield* cloneCacheHitRun({
+									sql,
+									cachedId: hits[0].researchId,
+									organizationId,
+									userId,
+									input,
+									templateIds,
+									templateNames,
+									templateFingerprint,
+								})
+								if (cloned)
+									return { id: cloned.id, status: 'succeeded' as const }
 							}
 						}
 

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1331,10 +1331,15 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						0) as number
 					const cachedResearchText = (run as { researchText?: string | null })
 						.researchText
-					const existingFindings = run['findings'] as Record<
-						string,
-						unknown
-					> | null
+					// Read findings as raw text so a resumed run keeps the snake_case keys
+					// it was stored with; a plain SELECT would camelCase every nested key
+					// and change the findings shape when it is re-persisted on success.
+					const [findingsRow] = yield* sql<{ findings: string | null }>`
+						SELECT findings::text AS findings FROM research_runs WHERE id = ${researchId}
+					`
+					const existingFindings = (
+						findingsRow?.findings ? JSON.parse(findingsRow.findings) : null
+					) as Record<string, unknown> | null
 					const existingFindingsHasValue =
 						existingFindings !== null &&
 						typeof existingFindings === 'object' &&

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -103,6 +103,7 @@ export {
 } from './application/provider-quota'
 export {
 	type CreateResearchInput,
+	cloneCacheHitRun,
 	type PendingProposalRow,
 	queryPendingProposals,
 	type ResearchEvent,


### PR DESCRIPTION
## What

Research runs store their results (the "findings") as structured data with snake_case field names like `proposed_updates` and `source_id` — the names the rest of the product reads. In the Research bounded context (`packages/research`, reached from both the HTTP API and the MCP server), two paths were quietly renaming those fields to camelCase (`proposedUpdates`, `sourceId`) when they re-saved findings, so anything reading the documented names got `undefined` back.

This fixes both paths so a reused or resumed run keeps the exact field names and values it was first stored with.

## The fix

- **Re-running an identical query (cache hit).** When the same research query is asked again, the system serves a saved copy instead of paying to run it again. That copy read the earlier run's findings *through the database client*, which renames every field to camelCase, then wrote the renamed copy back. The copy now happens entirely inside Postgres (`INSERT … SELECT`), so findings never passes through the renaming step and the copy is identical to the original.
- **A run that resumes after an interruption.** When a run is interrupted partway and later picks up where it left off, it re-reads its already-saved findings — through the same renaming client — and rewrote them on success. It now reads that saved value as raw text, keeping the original names. Same root cause as the cache-hit path; folded in here rather than left for a follow-up.

Both changes follow a pattern already used a few lines away for the run's `context` column: keep the JSON inside the database, or read it as raw text, so the client's snake→camel renaming never touches it.

## Impact

- **No migration / no schema change** — code only; nothing to run before the server tag.
- **Multi-org / RLS — unchanged.** The cache-hit copy's `INSERT … SELECT` reads the source run under the *same* org-scoped `research_runs` policy the previous two-step read used, and the new row's `organization_id` is the caller's org (the cache is looked up per org + user). No new cross-tenant path; an integration test exercises it as `app_user` with `app.current_org_id` set, exactly as a request does.
- **MCP + HTTP parity.** The fix lives in the shared `ResearchService.create()` / research fiber, so both the HTTP and MCP research-start surfaces get it.
- **Data shape restored, not changed.** Consumers of `findings` (the CRM proposed-updates list, enrichment `source_id`, etc.) now receive the documented snake_case shape on reused/resumed runs instead of `undefined`. No fields added or removed.
- **No new env vars, no auth/route, cross-app, or cost changes.** Cache-hit clones stay `cost_cents = 0`.

## Review guide

- Start at `cloneCacheHitRun` in `packages/research/src/application/research-service.ts` — it is mostly the previous inline cache-hit block moved into an exported helper; the only substantive change is the single `INSERT … SELECT` (findings / brief / token columns copied `src → clone` in-DB) replacing the old read-then-reinsert.
- The riskiest line is that `INSERT … SELECT` under RLS; I verified WITH CHECK / USING both hold under `app_user` (Test A). All interpolations are bound params or static identifiers — no injection.
- The resume-path change (one read swapped to `SELECT findings::text`) is covered at the *mechanism* level (Test B: plain `SELECT` camelCases, `::text` preserves) rather than by driving a full fiber resume — that path only triggers on a mid-run restart at phase ≥ 2, so I judged a full-fiber test disproportionate. Flagging so you can overrule.
- I did **not** run a separate `/security-review` or Snyk (Snyk tool not available here): the change touches RLS-scoped `research_runs` but does not alter the isolation model — same policy, same role, same org derivation. Say the word if you want a dedicated pass.
- `seedSourceRun`'s `?? ''` in the test is defensive dead code (the INSERT always returns a row); skip-able.

## Tests

New integration test `apps/server/src/handlers/research-cache-clone.integration.test.ts`:

- Drives the real `cloneCacheHitRun` through the live SQL client under `app_user` + org RLS with the issue's exact findings, asserting the clone is jsonb-equal to the source and keeps snake_case keys (`proposed_updates`, `enrichment.country.source_id`). This fails against the pre-fix code.
- A second case pins the gotcha the resume fix relies on: a plain `SELECT findings` camelCases nested keys, `SELECT findings::text` preserves them.

## Verification

- Gates run and green: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (20/20), `pnpm -w build` (13/13).
- New integration test against a HEAD-migrated `batuda_it` (2/2 pass); 688 research unit tests pass.
- I did **not** run the paid `start_research`-twice end-to-end repro on a live server (it needs live paid providers). The integration test drives the actual fix code with the issue's data as the substitute.

Closes #276
