### PR TITLE
cicd(release): let a dependency-only change pass the release gate

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -33,25 +33,34 @@ Otherwise, use `AskUserQuestion`:
 
 ## Step 3: Check Commits Exist
 
+Count commits touching the target's app dir **and every workspace dependency it bundles** — the
+exact paths `scripts/release-utils.cjs` resolves, which is what the release gate itself now uses.
+Get the latest tag with `git describe`, then substitute it for `<tag>`. The paths are resolved
+inline via command substitution (not a `$paths` variable — zsh does not word-split an unquoted
+variable, so it would collapse to one bogus pathspec):
+
 ```bash
 # Server
 git describe --tags --match='server-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || echo "no-tag"
-git rev-list <tag>..HEAD --count -- apps/server packages/
+git rev-list <tag>..HEAD --count -- $(node -e "process.stdout.write(require('./scripts/release-utils.cjs').getCommitPathsArray('apps/server').join(' '))")
 
 # Internal
 git describe --tags --match='internal-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || echo "no-tag"
-git rev-list <tag>..HEAD --count -- apps/internal packages/
+git rev-list <tag>..HEAD --count -- $(node -e "process.stdout.write(require('./scripts/release-utils.cjs').getCommitPathsArray('apps/internal').join(' '))")
 
 # UI
 git describe --tags --match='ui-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || echo "no-tag"
-git rev-list <tag>..HEAD --count -- packages/ui
+git rev-list <tag>..HEAD --count -- $(node -e "process.stdout.write(require('./scripts/release-utils.cjs').getCommitPathsArray('packages/ui').join(' '))")
 
 # Mail-worker
 git describe --tags --match='mail-worker-v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || echo "no-tag"
-git rev-list <tag>..HEAD --count -- apps/mail-worker packages/
+git rev-list <tag>..HEAD --count -- $(node -e "process.stdout.write(require('./scripts/release-utils.cjs').getCommitPathsArray('apps/mail-worker').join(' '))")
 ```
 
-If 0 commits, ask if they want to force with `--no-git.requireCommits`.
+A count of 0 means nothing the deployed artifact bundles has changed since the last tag — there
+is genuinely nothing to release. A dependency-only change (e.g. `packages/research`) counts here
+and releases without `--no-git.requireCommits`, since the gate now resolves the same paths. The
+Step 4 dry run enforces this for real.
 
 ## Step 4: Dry Run
 

--- a/.release-it.internal.cjs
+++ b/.release-it.internal.cjs
@@ -8,7 +8,7 @@ const {
 module.exports = {
 	extends: './.release-it.base.json',
 	git: {
-		commitsPath: 'apps/internal',
+		commitsPath: getCommitPathsArray('apps/internal').join(' '),
 		commitMessage: 'cicd(release): internal v${version}',
 		tagAnnotation: 'Internal Release v${version}',
 		tagMatch: 'internal-v[0-9]*.[0-9]*.[0-9]*',

--- a/.release-it.mail-worker.cjs
+++ b/.release-it.mail-worker.cjs
@@ -8,7 +8,7 @@ const {
 module.exports = {
 	extends: './.release-it.base.json',
 	git: {
-		commitsPath: 'apps/mail-worker',
+		commitsPath: getCommitPathsArray('apps/mail-worker').join(' '),
 		commitMessage: 'cicd(release): mail-worker v${version}',
 		tagAnnotation: 'Mail-worker Release v${version}',
 		tagMatch: 'mail-worker-v[0-9]*.[0-9]*.[0-9]*',

--- a/.release-it.server.cjs
+++ b/.release-it.server.cjs
@@ -8,7 +8,7 @@ const {
 module.exports = {
 	extends: './.release-it.base.json',
 	git: {
-		commitsPath: 'apps/server',
+		commitsPath: getCommitPathsArray('apps/server').join(' '),
 		commitMessage: 'cicd(release): server v${version}',
 		tagAnnotation: 'Server Release v${version}',
 		tagMatch: 'server-v[0-9]*.[0-9]*.[0-9]*',

--- a/.release-it.ui.cjs
+++ b/.release-it.ui.cjs
@@ -8,7 +8,7 @@ const {
 module.exports = {
 	extends: './.release-it.base.json',
 	git: {
-		commitsPath: 'packages/ui',
+		commitsPath: getCommitPathsArray('packages/ui').join(' '),
 		commitMessage: 'cicd(release): ui v${version}',
 		tagAnnotation: 'UI Release v${version}',
 		tagMatch: 'ui-v[0-9]*.[0-9]*.[0-9]*',


### PR DESCRIPTION
## What

When I release an app — the API server, the internal web app, the shared UI package, or the mail worker — a safety check runs first and asks "is there anything new to release since the last version?". Until now that check only looked at the app's **own** folder. So if the only change lived in a shared package the app bundles (for example the `packages/research` code the server ships), the check saw nothing and refused to release — even though the deployed app genuinely had changed. This makes the check look at the app **and every shared workspace package it depends on**, the exact same set of paths the release notes (changelog) already use. It lives entirely in the release tooling (`.release-it.*.cjs`) and the `/release` skill — no application code.

## The fix

- The "are there commits to release?" gate (release-it's `requireCommits`) now resolves the app directory **plus every workspace dependency**, via the existing `getCommitPathsArray` helper — the identical paths the changelog plugin already feeds. The gate and the changelog can no longer disagree, which is what forced the manual override before.
- Applied to all four targets (server, internal, ui, mail-worker). `ui` is a leaf with no workspace deps, so its behavior is unchanged; it's updated for consistency and to stay correct if it ever gains one.
- Updated the `/release` skill's Step 3 pre-check to count over the same dependency-aware paths, and dropped the `--no-git.requireCommits` manual bypass the old split previously required.

## Impact

- **Release tooling only.** No runtime, schema, wire-shape, env var, auth/RLS, or MCP/HTTP-parity surface is touched. Nothing deploys differently — this only changes *when* `pnpm release:<target>` proceeds vs aborts.
- **Strictly more permissive, never less.** The new path set is a superset of the old single directory, so no target will now count *fewer* commits than before. A dependency-only change cuts a tag on its own; previously it was blocked until you passed the manual flag.

## Review guide

- Start at any one `.release-it.*.cjs` — the one-line `commitsPath` change is the whole fix, and the other three are identical. `getCommitPathsArray` is the existing resolver in `scripts/release-utils.cjs`, already used two lines down for the changelog's `gitRawCommitsOpts.path`.
- Why a space-joined **string** here (vs the array the changelog takes): release-it interpolates `commitsPath` straight into `git rev-list … -- ${commitsPath}` (`GitBase.js`), so the gate needs one string of pathspecs; the changelog plugin wants the array. Both derive from the same resolver, so they agree.
- The SKILL.md Step 3 command uses an inline `$(node -e …)` command substitution rather than a `$paths` variable **on purpose** — zsh does not word-split an unquoted variable, which would collapse the paths into one bogus pathspec (I hit this during verification; the inline form is confirmed working).
- Nothing sensitive (auth/RLS/parser/crypto) and no UI, so no security or a11y review applies.

## Verification

Only what I actually ran:

- Reproduced release-it's exact gate through its real execution path (`child_process.exec` → `/bin/sh -c` of `git rev-list <tag>..HEAD --count -- <commitsPath>`): for a real `packages/research`-only commit, the old single-directory path counts **0** (release-it would abort with "no commits since the latest tag") and the new dependency-aware path counts **1** (release proceeds). Confirmed the same flip on a full range (8 → 28).
- All four configs load and resolve the correct path sets (`ui` = `packages/ui` only).
- `pnpm install` → no `pnpm-lock.yaml` drift; Biome clean on the four configs; readability pass found nothing to change.
- I did **not** run the app `check-types` / `test` / `build` gates: this change touches only release-it config (loaded by release-it, not by any tsconfig or the build) and one markdown skill file, so those gates cannot be affected by it. CI will still run them.

Closes #256
