### PR TITLE
fix: close three research MCP safety gaps

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -48,7 +48,11 @@ type(scope): subject in imperative mood
 
 - Body bullet in past tense with period.
 - Another change description.
+
+Closes #123
 ```
+
+The `Closes #123` trailer is optional — include it only when this single commit is the complete fix for a tracked issue (see Rule 9).
 
 ## Types
 
@@ -138,6 +142,7 @@ If ALL changed files match `ai` patterns → use `ai` type. If mixed with non-AI
 6. **Plain language for everyone**: Write the subject and body so a non-technical reader and a brand-new contributor can follow the change without prior context. Lead with the everyday-terms "what changed and why it matters," spell out an acronym or internal name (a table, a service, a flag) the first time it appears, and don't lean on unstated background. Keep the precise technical terms — add the plain-language point on top, don't drop it. (Commit messages outlive their context: they're read in `git blame`, changelogs, and release notes long after the surrounding work is forgotten.)
 7. **No tautology**: The subject must not repeat the type as a verb. The type already conveys the action — e.g., `fix: fix the login` → `fix: resolve login failure`, `refactor: refactor auth` → `refactor: simplify auth flow`
 8. **No bare `#` tokens in the body**: The changelog generator reads `#<token>` as a GitHub issue reference and renders it as a "closes" link, so a hex color or fragment becomes a broken issue link in the release notes — write `b05220 → 95400f`, not `#b05220 → #95400f`
+9. **Issue-closing trailer**: When one commit is the *complete* fix for a tracked issue, add a `Closes #<issue>` line as the last line, after a blank line — GitHub auto-closes the issue when the commit lands on the default branch (`Fixes`/`Resolves` are equivalent keywords). This deliberate reference is the one sanctioned exception to Rule 8: a `Closes #<issue>` trailer is fine; a bare `#<token>` anywhere else is not. Only tag the commit that finishes the issue — if the fix spans several commits, leave the trailer off each partial commit and put `Closes #<issue>` in the PR description instead, so the issue closes once on merge, not on the first partial commit. Skip it entirely for a commit that touches no tracked issue.
 
 ## Body sizing
 
@@ -176,6 +181,7 @@ Run this checklist on every message **before** returning the preview:
 4. **Mood**: Subject uses imperative ("add", "fix", "migrate") — not past tense ("added", "fixed")
 5. **Body**: Every bullet starts with a capital letter, uses past tense, ends with a period
 6. **Body wrapping**: Each bullet is a single physical line — no hard wrap mid-sentence
+7. **Issue trailer**: If this one commit fully closes a tracked issue, confirm a `Closes #<issue>` trailer sits on its own last line; if the fix spans commits, confirm the trailer is absent (it belongs in the PR body)
 
 ## Examples
 

--- a/apps/server/src/mcp/tools/research-mcp.ts
+++ b/apps/server/src/mcp/tools/research-mcp.ts
@@ -14,6 +14,7 @@ import {
 } from '@batuda/research'
 
 import { EnvVars } from '../../lib/env'
+import { detachFromTransaction, enterOrgScope } from '../../middleware/org'
 import {
 	InstructionClarification,
 	InstructionsOverride,
@@ -28,6 +29,11 @@ import {
 
 const REQUEST_DEPENDENCIES = [SessionContext, CurrentOrg]
 
+// The longest research_sync will block for findings before handing back a
+// still-running run to poll. Held under the MCP transport's ~1-minute hard cap
+// on a blocking call, so a longer wait would error instead of returning.
+const RESEARCH_SYNC_MAX_WAIT_SECONDS = 45
+
 // A run plus `applied_instructions` (the instruction templates that shaped it).
 // Dates encode to ISO strings via ResearchRunDetail.
 const RunWithInstructions = Schema.Struct({
@@ -36,14 +42,25 @@ const RunWithInstructions = Schema.Struct({
 })
 const NotFoundResult = Schema.Struct({ error: Schema.String })
 
+// An unconfirmed selector fan-out: how many companies matched and the paid-data
+// ceiling summed across them, so the caller can re-submit with confirm:true (or
+// narrow the filter) before one run per company launches.
+const ConfirmRequired = Schema.Struct({
+	_tag: Schema.Literal('confirm_required'),
+	subject_count: Schema.Number,
+	estimated_cost_cents: Schema.Number,
+})
+
 // get_research: the found run, or a not-found marker.
 const GetResearchResult = Schema.Union([RunWithInstructions, NotFoundResult])
 
-// research_sync: the same, plus an instruction clarification when a passed
-// instruction name can't be resolved (the run never starts in that case).
+// research_sync: the found run, a not-found marker, the fan-out cost gate, or an
+// instruction clarification when a passed instruction name can't be resolved
+// (the run never starts in the last two cases).
 const ResearchSyncResult = Schema.Union([
 	RunWithInstructions,
 	NotFoundResult,
+	ConfirmRequired,
 	InstructionClarification,
 ])
 
@@ -51,12 +68,13 @@ const ResearchSyncResult = Schema.Union([
 
 const StartResearch = Tool.make('start_research', {
 	description:
-		"Start a research run; returns {_tag:'started', id, status, applied_instructions} immediately — poll get_research for results. applied_instructions lists the instruction templates that shaped the run. The user's default research instructions apply automatically; pass `instructions` (template names or ids) to override them for this run. An unknown or ambiguous name returns {_tag:'instruction_clarification'} with candidates instead of starting. If the user states a new standing preference, save it with manage_instruction_template.",
+		"Start a research run; returns {_tag:'started', id, status, applied_instructions} immediately — poll get_research for results. applied_instructions lists the instruction templates that shaped the run. The user's default research instructions apply automatically; pass `instructions` (template names or ids) to override them for this run. An unknown or ambiguous name returns {_tag:'instruction_clarification'} with candidates instead of starting. A `context.selector` researches every matching company (one run each); without `confirm:true` it returns {_tag:'confirm_required', subject_count, estimated_cost_cents} first so you can preview the scale — re-submit with confirm:true to launch (or narrow the filter). If the user states a new standing preference, save it with manage_instruction_template.",
 	parameters: Schema.Struct({
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
 		schema_name: Schema.optional(SchemaNameParam),
 		instructions: Schema.optional(InstructionsOverride),
+		confirm: Schema.optional(Schema.Boolean),
 	}),
 	success: Schema.Union([
 		Schema.Struct({
@@ -65,6 +83,7 @@ const StartResearch = Tool.make('start_research', {
 			status: Schema.String,
 			applied_instructions: Schema.Array(Schema.String),
 		}),
+		ConfirmRequired,
 		InstructionClarification,
 	]),
 	dependencies: REQUEST_DEPENDENCIES,
@@ -93,13 +112,14 @@ const GetResearch = Tool.make('get_research', {
 
 const ResearchSync = Tool.make('research_sync', {
 	description:
-		"Run research to completion and return full findings inline (blocks until done or timeout); best for short research. The returned run includes applied_instructions — the instruction templates that shaped it. The user's default research instructions apply automatically; pass `instructions` (template names or ids) to override them for this run. An unknown or ambiguous name returns {_tag:'instruction_clarification'} with candidates instead of running.",
+		"Run research and return full findings inline when it finishes quickly; best for short or cached research. Blocks up to ~45s (the transport's limit): a short/cached run returns completed findings; a longer one returns the run still 'running' for you to poll get_research — the run keeps going regardless and is never lost. The returned run includes applied_instructions — the instruction templates that shaped it. The user's default research instructions apply automatically; pass `instructions` (template names or ids) to override them for this run. An unknown or ambiguous name returns {_tag:'instruction_clarification'} with candidates instead of running. A `context.selector` fans out one run per matching company; without `confirm:true` it returns {_tag:'confirm_required', subject_count, estimated_cost_cents} first.",
 	parameters: Schema.Struct({
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
 		schema_name: Schema.optional(SchemaNameParam),
 		instructions: Schema.optional(InstructionsOverride),
 		max_wait_seconds: Schema.optional(Schema.Number),
+		confirm: Schema.optional(Schema.Boolean),
 	}),
 	success: ResearchSyncResult,
 	dependencies: REQUEST_DEPENDENCIES,
@@ -180,22 +200,20 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 							query: params.query,
 							context: params.context as CreateResearchInput['context'],
 							schemaName: params.schema_name,
-							// An agent that picks a selector is intentionally batching, so
-							// auto-confirm the fan-out instead of bouncing a cost prompt it
-							// would only echo back.
-							confirm: true,
+							// Default off: a selector that matches companies bounces with
+							// the matched count so the caller can preview the scale before
+							// one (potentially paid) run per company launches.
+							confirm: params.confirm ?? false,
 						},
 						systemDefaults,
 						resolved.instructions,
 					)
 					if (result.status === 'confirm_required') {
-						// Unreachable given the auto-confirm above, but the widened
-						// result type carries the estimate variant, so rule it out.
-						return yield* Effect.die(
-							new Error(
-								'research fan-out returned confirm_required despite confirm',
-							),
-						)
+						return {
+							_tag: 'confirm_required' as const,
+							subject_count: result.subjectCount,
+							estimated_cost_cents: result.estimatedCostCents,
+						}
 					}
 					return {
 						_tag: 'started' as const,
@@ -214,39 +232,61 @@ export const ResearchMcpHandlersLive = ResearchMcpTools.toLayer(
 			research_sync: params =>
 				Effect.gen(function* () {
 					const userId = (yield* SessionContext).userId
-					const orgId = (yield* CurrentOrg).id
+					const org = yield* CurrentOrg
 					const resolved = yield* resolveForRun(
-						orgId,
+						org.id,
 						userId,
 						params.instructions ?? [],
 					)
 					if (!resolved.ok) return resolved.clarification
-					const created = yield* svc.create(
-						userId,
-						orgId,
-						{
-							query: params.query,
-							context: params.context as CreateResearchInput['context'],
-							schemaName: params.schema_name,
-							// A synchronous agent run intends to batch when it passes a
-							// selector, so auto-confirm the fan-out.
-							confirm: true,
-						},
-						systemDefaults,
-						resolved.instructions,
-					)
-					if (created.status === 'confirm_required') {
-						return yield* Effect.die(
-							new Error(
-								'research fan-out returned confirm_required despite confirm',
-							),
+
+					// Create the run in its OWN top-level transaction on a fresh
+					// pooled connection, detached from this request's transaction.
+					// The whole MCP request runs inside one transaction that commits
+					// only when the handler returns — but the poll below holds it open
+					// for up to ~45s. Without detaching, the run row would stay
+					// uncommitted the whole time: invisible to the dispatch worker
+					// (which runs the job on its own connection, so it never leaves the
+					// queue), and rolled back outright if a client/transport timeout
+					// interrupts the handler — silently losing the run. Committing it
+					// here makes it durable and pollable the instant create() returns.
+					const created = yield* svc
+						.create(
+							userId,
+							org.id,
+							{
+								query: params.query,
+								context: params.context as CreateResearchInput['context'],
+								schemaName: params.schema_name,
+								confirm: params.confirm ?? false,
+							},
+							systemDefaults,
+							resolved.instructions,
 						)
+						.pipe(
+							enterOrgScope(sql, { org, userId }),
+							detachFromTransaction(sql),
+						)
+					if (created.status === 'confirm_required') {
+						return {
+							_tag: 'confirm_required' as const,
+							subject_count: created.subjectCount,
+							estimated_cost_cents: created.estimatedCostCents,
+						}
 					}
 					const { id } = created
 
-					// Poll until the run reaches a terminal status or we exceed
-					// the caller's timeout (default 2 minutes).
-					const maxWaitMs = (params.max_wait_seconds ?? 120) * 1000
+					// Block for the findings, but only up to a transport-safe bound:
+					// a blocking MCP call is hard-capped near a minute, and real
+					// enrichment runs outlast that, so a longer wait would just error.
+					// A short/cached run returns findings inline; a longer one comes
+					// back still 'running' for the caller to poll. The poll reads the
+					// worker's committed progress on this request's connection.
+					const maxWaitMs =
+						Math.min(
+							params.max_wait_seconds ?? RESEARCH_SYNC_MAX_WAIT_SECONDS,
+							RESEARCH_SYNC_MAX_WAIT_SECONDS,
+						) * 1000
 					const startedAt = Date.now()
 
 					let run = yield* svc.get(id)

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -1,6 +1,6 @@
 import { NodeHttpServerRequest } from '@effect/platform-node'
 import { fromNodeHeaders } from 'better-auth/node'
-import { Data, Effect, Layer } from 'effect'
+import { Context, Data, Effect, Layer } from 'effect'
 import { HttpServerRequest } from 'effect/unstable/http'
 import { SqlClient } from 'effect/unstable/sql'
 
@@ -18,6 +18,29 @@ interface OrgRow {
 	readonly name: string
 	readonly slug: string
 }
+
+/**
+ * Drop the ambient transaction connection so a following `withTransaction`
+ * opens a fresh top-level transaction instead of a savepoint on the caller's
+ * (about-to-commit) connection. Each client owns its transaction connection
+ * under `sql.transactionService`, and `withTransaction` only makes a savepoint
+ * when that key is present, so removing it forces a fresh transaction. The key
+ * is read via `serviceOption` and is never part of `R`, so removing it leaves
+ * the requirements unchanged — the assertion only tells the compiler that.
+ *
+ * Pair it with `enterOrgScope` to run a block in its own top-level transaction
+ * on a fresh pooled connection: work that must survive (commit) even if the
+ * request that started it is later cancelled — a backgrounded write, or a
+ * blocking handler that keeps polling after the row is already durable.
+ */
+export const detachFromTransaction =
+	(sql: SqlClient.SqlClient) =>
+	<A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+		Effect.updateContext(
+			self,
+			(services: Context.Context<R>) =>
+				Context.omit(sql.transactionService)(services) as Context.Context<R>,
+		)
 
 /**
  * Enter the per-request org scope on the SQL connection, then run `effect`

--- a/apps/server/src/services/company-geocoding.ts
+++ b/apps/server/src/services/company-geocoding.ts
@@ -1,10 +1,10 @@
-import { Cause, Context, DateTime, Effect } from 'effect'
+import { Cause, DateTime, Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
 import type { Company } from '@batuda/domain'
 
-import { enterOrgScope } from '../middleware/org'
+import { detachFromTransaction, enterOrgScope } from '../middleware/org'
 import { CompanyService } from './companies'
 import { type GeocodeResult, Geocoder } from './geocoder'
 
@@ -19,24 +19,6 @@ export type GeocodeCompanyResult =
 	| { readonly _tag: 'no_match' }
 	| { readonly _tag: 'nothing_to_search' }
 	| { readonly _tag: 'lookup_failed' }
-
-/**
- * Drop the ambient transaction connection so a following `withTransaction`
- * opens a fresh top-level transaction instead of a savepoint on the caller's
- * (about-to-commit) connection. Each client owns its transaction connection
- * under `sql.transactionService`, and `withTransaction` only makes a savepoint
- * when that key is present, so removing it forces a fresh transaction. The key
- * is read via `serviceOption` and is never part of `R`, so removing it leaves
- * the requirements unchanged — the assertion only tells the compiler that.
- */
-const detachFromTransaction =
-	(sql: SqlClient.SqlClient) =>
-	<A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-		Effect.updateContext(
-			self,
-			(services: Context.Context<R>) =>
-				Context.omit(sql.transactionService)(services) as Context.Context<R>,
-		)
 
 /**
  * Resolve a company's coordinates from the deterministic geocoder and store

--- a/apps/server/src/services/research-auto-approve-gate.integration.test.ts
+++ b/apps/server/src/services/research-auto-approve-gate.integration.test.ts
@@ -1,0 +1,195 @@
+// Live-DB integration test for the in-run auto-approve gate. When enforced,
+// Budget.chargePaid must refuse a paid charge that would push a run's spend past
+// the caller's auto-approve limit — with ApprovalRequired, spending nothing —
+// so a user who sets auto_approve_paid_cents low is actually protected inside a
+// research run. When not enforced (the standalone tool gates interactively; an
+// approved follow-up must charge), the per-run budget stays the only ceiling.
+//
+// Prereq: `pnpm cli services up` — this suite's own globalSetup builds and
+// migrates the disposable batuda_it database it runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { Budget, makeBudgetLayer, resolvePolicy } from '@batuda/research'
+
+import { PgLive } from '../db/client'
+import { applyTestEnv } from '../test-env'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+const runtime = ManagedRuntime.make(PgLive)
+
+const ORG = `aa-org-${randomUUID()}`
+const USER = `aa-u1-${randomUUID()}`
+
+// Budgets high enough that only the auto-approve limit — set per test — can
+// reject a charge, never the per-run budget or the monthly cap.
+const BASE_DEFAULTS = {
+	budgetCents: 100_000,
+	paidBudgetCents: 100_000,
+	autoApprovePaidCents: 100_000,
+	paidMonthlyCapCents: 100_000,
+	hardCeiling: 100_000,
+}
+
+let pool: pg.Pool
+
+const seedRun = async (): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO research_runs (organization_id, query, status, created_by)
+		 VALUES ($1, 'aa query', 'succeeded', $2) RETURNING id`,
+		[ORG, USER],
+	)
+	return r.rows[0]?.id ?? ''
+}
+
+// Charge zero or more setup calls against ONE Budget instance built with the
+// given auto-approve limit + enforcement, then capture the outcome of one final
+// charge via Effect.result — a typed failure (ApprovalRequired, BudgetExceeded)
+// resolves as a value; only an unexpected defect still rejects the promise.
+const chargeThenObserve = (
+	researchId: string,
+	autoApprovePaidCents: number,
+	enforceAutoApprove: boolean,
+	setupCharges: ReadonlyArray<{ readonly cents: number; readonly key: string }>,
+	observedCharge: { readonly cents: number; readonly key: string },
+) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const policy = yield* resolvePolicy({
+				sql,
+				userId: USER,
+				systemDefaults: { ...BASE_DEFAULTS, autoApprovePaidCents },
+			})
+			const budgetLayer = makeBudgetLayer({
+				organizationId: ORG,
+				userId: USER,
+				researchId,
+				policy,
+				systemCeiling: BASE_DEFAULTS.hardCeiling,
+				enforceAutoApprove,
+			}).pipe(Layer.provide(Layer.succeed(SqlClient.SqlClient)(sql)))
+
+			return yield* Effect.gen(function* () {
+				const budget = yield* Budget
+				for (const { cents, key } of setupCharges) {
+					yield* budget.chargePaid(
+						'test-provider',
+						cents,
+						'discover_contacts',
+						key,
+					)
+				}
+				return yield* Effect.result(
+					budget.chargePaid(
+						'test-provider',
+						observedCharge.cents,
+						'discover_contacts',
+						observedCharge.key,
+					),
+				)
+			}).pipe(Effect.provide(budgetLayer))
+		}),
+	)
+
+const spendRowCount = async (researchId: string): Promise<number> => {
+	const r = await pool.query(
+		`SELECT id FROM research_paid_spend WHERE research_id = $1`,
+		[researchId],
+	)
+	return r.rows.length
+}
+
+beforeAll(() => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+})
+
+afterAll(async () => {
+	// research_paid_spend.research_id cascades from research_runs, so deleting
+	// the runs alone clears both tables.
+	await pool.query(`DELETE FROM research_runs WHERE organization_id = $1`, [
+		ORG,
+	])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('enforcing the in-run auto-approve limit', () => {
+	describe('when enforced and the first paid charge is over the limit', () => {
+		it('should refuse with ApprovalRequired and spend nothing', async () => {
+			// GIVEN a run whose policy auto-approves 0 paid cents, enforced in-run
+			const researchId = await seedRun()
+			// WHEN any paid call is charged
+			const outcome = await chargeThenObserve(researchId, 0, true, [], {
+				cents: 5,
+				key: `key-${randomUUID()}`,
+			})
+			// THEN it fails with the approval gate, not a silent charge
+			expect(outcome._tag).toBe('Failure')
+			if (outcome._tag === 'Failure') {
+				expect(outcome.failure._tag).toBe('ApprovalRequired')
+			}
+			// AND no money moved
+			expect(await spendRowCount(researchId)).toBe(0)
+		})
+	})
+
+	describe('when enforced and cumulative spend crosses the limit', () => {
+		it('should charge up to the limit, then gate the charge that exceeds it', async () => {
+			// GIVEN a run auto-approving 5 paid cents, enforced
+			const researchId = await seedRun()
+			// WHEN a 5-cent charge (reaching the limit) is followed by another
+			const outcome = await chargeThenObserve(
+				researchId,
+				5,
+				true,
+				[{ cents: 5, key: `key-${randomUUID()}` }],
+				{ cents: 5, key: `key-${randomUUID()}` },
+			)
+			// THEN the second (which would total 10 > 5) is gated
+			expect(outcome._tag).toBe('Failure')
+			if (outcome._tag === 'Failure') {
+				expect(outcome.failure._tag).toBe('ApprovalRequired')
+			}
+			// AND only the first, within-limit charge was recorded
+			expect(await spendRowCount(researchId)).toBe(1)
+		})
+	})
+
+	describe('when enforced and the charge stays within the limit', () => {
+		it('should charge normally', async () => {
+			// GIVEN a run auto-approving 100 paid cents, enforced
+			const researchId = await seedRun()
+			// WHEN a 5-cent call (well under the limit) is charged
+			const outcome = await chargeThenObserve(researchId, 100, true, [], {
+				cents: 5,
+				key: `key-${randomUUID()}`,
+			})
+			// THEN it succeeds and records the spend
+			expect(outcome._tag).toBe('Success')
+			expect(await spendRowCount(researchId)).toBe(1)
+		})
+	})
+
+	describe('when not enforced (standalone tool or approved follow-up)', () => {
+		it('should charge even over the auto-approve limit', async () => {
+			// GIVEN a run auto-approving 0 paid cents but with enforcement off
+			const researchId = await seedRun()
+			// WHEN a paid call above that limit is charged
+			const outcome = await chargeThenObserve(researchId, 0, false, [], {
+				cents: 5,
+				key: `key-${randomUUID()}`,
+			})
+			// THEN the per-run budget is the only gate — it still charges
+			expect(outcome._tag).toBe('Success')
+			expect(await spendRowCount(researchId)).toBe(1)
+		})
+	})
+})

--- a/apps/server/src/services/research-sync-durability.integration.test.ts
+++ b/apps/server/src/services/research-sync-durability.integration.test.ts
@@ -1,0 +1,117 @@
+// Live-DB integration test for research_sync run durability. The blocking sync
+// tool creates its run in its OWN transaction on a fresh pooled connection (via
+// enterOrgScope + detachFromTransaction), so the run commits — and stays
+// pollable — even when the MCP request transaction that started it is later
+// rolled back by a client/transport timeout. The contrast case pins why the
+// detach is needed: the same write nested in the request transaction is lost
+// when that transaction rolls back.
+//
+// Prereq: `pnpm cli services up` — this suite's own globalSetup builds and
+// migrates the disposable batuda_it database it runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, ManagedRuntime } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { detachFromTransaction, enterOrgScope } from '../middleware/org'
+import { applyTestEnv } from '../test-env'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+const runtime = ManagedRuntime.make(PgLive)
+
+const ORG = {
+	id: `sync-org-${randomUUID()}`,
+	name: 'Sync Durability Org',
+	slug: `sync-${randomUUID()}`,
+}
+const USER = `sync-u-${randomUUID()}`
+
+let pool: pg.Pool
+
+const runExists = async (id: string): Promise<boolean> => {
+	const r = await pool.query(`SELECT id FROM research_runs WHERE id = $1`, [id])
+	return r.rows.length > 0
+}
+
+const insertRun = (researchId: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		yield* sql`
+			INSERT INTO research_runs (id, organization_id, query, status, created_by)
+			VALUES (${researchId}, ${ORG.id}, 'sync durability probe', 'queued', ${USER})
+		`
+	})
+
+// Run `write` inside a request transaction that then rolls back — standing in
+// for the fiber interrupt a client/transport cancel causes mid-handler.
+const writeThenRollBackRequest = (
+	write: Effect.Effect<void, unknown, SqlClient.SqlClient>,
+) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql
+				.withTransaction(
+					write.pipe(
+						Effect.andThen(Effect.fail(new Error('client cancelled'))),
+					),
+				)
+				.pipe(Effect.catchCause(() => Effect.void))
+		}),
+	)
+
+beforeAll(() => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+})
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM research_runs WHERE organization_id = $1`, [
+		ORG.id,
+	])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('research_sync run durability', () => {
+	describe('when the run is created detached and the request transaction rolls back', () => {
+		it('should keep the committed run row instead of losing it', async () => {
+			const researchId = randomUUID()
+			// GIVEN the run written in its own org scope, detached from the request
+			//   transaction — exactly how the sync handler creates it
+			const durableCreate = Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				yield* insertRun(researchId).pipe(
+					enterOrgScope(sql, { org: ORG, userId: USER }),
+					detachFromTransaction(sql),
+				)
+			})
+			// WHEN the surrounding request transaction rolls back (a client cancel)
+			await writeThenRollBackRequest(durableCreate)
+			// THEN the run survived on its own connection and stays pollable
+			expect(await runExists(researchId)).toBe(true)
+		})
+	})
+
+	describe('when the run is created inside the request transaction that rolls back', () => {
+		it('should be lost — the failure the detach prevents', async () => {
+			const researchId = randomUUID()
+			// GIVEN the same write nested in the request transaction (no detach)
+			const fragileCreate = Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				yield* insertRun(researchId).pipe(
+					enterOrgScope(sql, { org: ORG, userId: USER }),
+				)
+			})
+			// WHEN the request transaction rolls back
+			await writeThenRollBackRequest(fragileCreate)
+			// THEN the run vanishes with the rolled-back transaction
+			expect(await runExists(researchId)).toBe(false)
+		})
+	})
+})

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -1,7 +1,11 @@
 import { Effect, Layer, Ref } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { BudgetExceeded, MonthlyCapExceeded } from '../domain/errors'
+import {
+	ApprovalRequired,
+	BudgetExceeded,
+	MonthlyCapExceeded,
+} from '../domain/errors'
 import type { BudgetSnapshot, ResolvedPolicy } from '../domain/types'
 import { Budget } from './ports'
 
@@ -76,6 +80,14 @@ export interface BudgetConfig {
 	readonly researchId: string
 	readonly policy: ResolvedPolicy
 	readonly systemCeiling: number
+	// When true, a paid charge that would push this run's paid spend past the
+	// caller's auto-approve limit is refused with ApprovalRequired instead of
+	// charged — so an agent tool call above the limit surfaces an approval gate
+	// rather than spending silently. Off by default (the per-run paid budget is
+	// the only ceiling): set it on the in-run agent budget, but not on the
+	// standalone tool (which gates interactively) or a follow-up run that is
+	// executing an already-approved paid action.
+	readonly enforceAutoApprove?: boolean
 }
 
 export const makeBudgetLayer = (config: BudgetConfig) =>
@@ -145,6 +157,21 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 								tier: 'paid-run',
 								needed: cents,
 								remaining: state.remaining,
+							})
+						}
+
+						// Stop before spending past the caller's auto-approve limit:
+						// hand back an approval gate the agent surfaces as a pending
+						// paid action for the user to approve, rather than charging.
+						// Only when enforced (the in-run agent budget) — the standalone
+						// tool gates interactively and an approved follow-up must charge.
+						if (
+							config.enforceAutoApprove &&
+							state.spent + cents > config.policy.autoApprovePaidCents
+						) {
+							return yield* new ApprovalRequired({
+								tool,
+								estimatedCents: cents,
 							})
 						}
 

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -182,6 +182,14 @@ export type DiscoverContactsOutcome =
 	  }
 	| { readonly status: 'no_reliable_contact'; readonly researchId: string }
 	| { readonly status: 'budget_exceeded'; readonly researchId: string }
+	// A paid step would spend past the caller's auto-approve limit: no charge
+	// was made, and the model records it as a pending paid action to approve.
+	| {
+			readonly status: 'approval_required'
+			readonly researchId: string
+			readonly tool: string
+			readonly estimatedCents: number
+	  }
 
 export interface DiscoverContactsInput {
 	readonly companyName: string
@@ -502,6 +510,16 @@ export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 								Effect.succeed({
 									status: 'budget_exceeded' as const,
 									researchId,
+								}),
+							// A paid step over the auto-approve limit (in-run budgets only):
+							// return the gate as an outcome so the run keeps its findings
+							// and the model can propose the action for approval.
+							ApprovalRequired: e =>
+								Effect.succeed({
+									status: 'approval_required' as const,
+									researchId,
+									tool: e.tool,
+									estimatedCents: e.estimatedCents,
 								}),
 						}),
 					)

--- a/packages/research/src/application/eval-contacts-outcome.ts
+++ b/packages/research/src/application/eval-contacts-outcome.ts
@@ -10,7 +10,11 @@
  */
 
 import { type DiscoverContactsOutcome, emailChannel } from './contact-discovery'
-import type { ContactRunOutcome, OutcomeContact } from './eval-contacts-scoring'
+import type {
+	ContactRunOutcome,
+	ContactTerminalStatus,
+	OutcomeContact,
+} from './eval-contacts-scoring'
 
 export const outcomeFromContactRun = (
 	outcome: DiscoverContactsOutcome,
@@ -38,5 +42,10 @@ export const outcomeFromContactRun = (
 				})
 			: []
 
-	return { status: outcome.status, contacts, spendCents: meta.spendCents }
+	// An approval-gated run delivered no contacts because a paid step hit the
+	// spend limit — the same "spend-stopped, empty" bucket as budget_exceeded for
+	// the purpose of scoring contact quality.
+	const status: ContactTerminalStatus =
+		outcome.status === 'approval_required' ? 'budget_exceeded' : outcome.status
+	return { status, contacts, spendCents: meta.spendCents }
 }

--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -3,6 +3,7 @@ import type { LanguageModel } from 'effect/unstable/ai'
 
 import type { AcceptedCountry } from '../domain/country'
 import type {
+	ApprovalRequired,
 	BudgetExceeded,
 	MonthlyCapExceeded,
 	NoRegistry,
@@ -243,7 +244,10 @@ export interface BudgetService {
 		cents: number,
 		tool: string,
 		idempotencyKey?: string,
-	) => Effect.Effect<void, BudgetExceeded | MonthlyCapExceeded>
+	) => Effect.Effect<
+		void,
+		BudgetExceeded | MonthlyCapExceeded | ApprovalRequired
+	>
 	readonly snapshot: () => Effect.Effect<BudgetSnapshot>
 }
 

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -2161,6 +2161,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							researchId,
 							policy,
 							systemCeiling: monthlyCapHardCeilingCents,
+							// A run's own paid tool calls can't spend past the user's
+							// auto-approve limit without an approval gate — the agent turns
+							// a refusal into a pending paid action instead of charging.
+							enforceAutoApprove: true,
 						}).pipe(Layer.provide(Layer.succeed(SqlClient.SqlClient)(sql)))
 
 						// One tool-log + SSE pair per round, so a multi-round run is

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -26,7 +26,7 @@ import {
 } from 'effect/unstable/ai'
 
 import { AcceptedCountry } from '../domain/country'
-import { noRegistryResult } from '../domain/errors'
+import { approvalRequiredResult, noRegistryResult } from '../domain/errors'
 import { ScrapedPage } from '../domain/types'
 import { ContactDiscovery } from './contact-discovery'
 import {
@@ -447,6 +447,11 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 						mapToolError('registry_lookup')(
 							`monthly paid cap reached (${e.spentCents}/${e.capCents}¢) — stop using registry_lookup`,
 						),
+					),
+					// Over the auto-approve limit: hand back the gate as a result so the
+					// model records a pending paid action instead of retrying the charge.
+					Effect.catchTag('ApprovalRequired', e =>
+						Effect.succeed(approvalRequiredResult(e.tool, e.estimatedCents)),
 					),
 					Effect.catchCause(cause => mapToolError('registry_lookup')(cause)),
 				),

--- a/packages/research/src/domain/errors.ts
+++ b/packages/research/src/domain/errors.ts
@@ -44,7 +44,11 @@ export class QuotaExhausted extends Schema.TaggedErrorClass<QuotaExhausted>()(
 	},
 ) {}
 
-/** Paid call above auto-approve threshold. LLM should call propose_paid_action. */
+/**
+ * A paid call whose cost is over the user's auto-approve limit. Raised in-run
+ * instead of spending; the model records it under findings.pending_paid_actions
+ * for the user to approve (resolve_research_paid_action) rather than retrying.
+ */
 export class ApprovalRequired extends Schema.TaggedErrorClass<ApprovalRequired>()(
 	'ApprovalRequired',
 	{
@@ -52,6 +56,17 @@ export class ApprovalRequired extends Schema.TaggedErrorClass<ApprovalRequired>(
 		estimatedCents: Schema.Number,
 	},
 ) {}
+
+/** The approval gate rendered as a plain result value the model can act on. */
+export const approvalRequiredResult = (
+	tool: string,
+	estimatedCents: number,
+) => ({
+	status: 'approval_required' as const,
+	tool,
+	estimated_cents: estimatedCents,
+	message: `Paid ${tool} (~${estimatedCents}¢) is over the auto-approve limit — record it under pending_paid_actions for the user to approve instead of retrying.`,
+})
 
 /**
  * The requested country has no national business registry — a routing outcome,


### PR DESCRIPTION
## What

Three separate safety gaps in the research subsystem — the part of Batuda that runs background "research runs" to enrich companies and find contacts, driven by the AI agent over MCP (the tool protocol the external assistant speaks) and mirrored on the HTTP API. Each gap let the system do something the caller didn't expect: lose a run, spend paid money without approval, or launch a batch of runs with no preview. This closes all three, across `apps/server` (the MCP tool handlers) and `packages/research` (the run + budget logic).

## The fix

- **`research_sync` no longer loses runs (#277).** The blocking "run and wait for the answer" tool created its run inside the same database transaction it then held open while polling — so the run never committed for the background worker to pick up, and a client or network timeout rolled the row back and lost the work entirely. It now creates the run in its own committed transaction on a fresh connection, so the run is durable and pollable the instant it's created; the wait is capped at the transport's ~45s limit and hands back the still-running run to poll instead of erroring.
- **Selector fan-out asks first (#278).** A `context.selector` researches every matching company — one run each. Both `start_research` and `research_sync` hardcoded auto-confirm, so an MCP caller could silently launch up to ~100 (potentially paid) runs. They now take a `confirm` flag (default off) and return the matched count + estimated cost first, so the caller previews the scale before launching.
- **`auto_approve_paid_cents` is honored inside runs (#279).** A run's own paid tool calls — contact enrichment, email verification, registry lookups — spent up to the per-run budget no matter what the auto-approve limit was, so a user who set it low (even to 0) to stop unapproved spend was still charged inside runs. A paid charge that would carry the run past that limit now stops with an approval gate the agent records as a pending paid action, spending nothing until the user approves it. The interactive standalone tool and approved follow-up runs still charge normally.

## Impact

- **MCP + HTTP parity.** The confirm gate was already reachable on the HTTP handler (which passes `confirm` through); this closes the gap on the MCP side, so the cost preview now behaves the same on both surfaces.
- **Wire-shape / contract.** `start_research` and `research_sync` gain an optional `confirm` input and a new `{_tag:'confirm_required', subject_count, estimated_cost_cents}` success variant. Additive — existing single-subject calls are unchanged.
- **Behavior change — selectors bounce once now.** An MCP agent that used a selector and relied on auto-confirm must re-submit with `confirm: true`. Intended (that is the cost gate); flagged so it is not a surprise.
- **Behavior change — in-run auto-spend ceiling.** Under the default policy, a run's automatic paid spend is now capped at `auto_approve_paid_cents` (200¢) rather than the per-run `paid_budget_cents` (500¢); past that it asks. Only runs that would spend over 200¢ are affected — a typical contact discovery (~16¢) is not.
- **Connection / RLS.** `research_sync`'s create now runs in its own top-level transaction on a fresh pooled connection (the existing `detachFromTransaction` + `enterOrgScope` pattern from `company-geocoding.ts`), re-applying the `app_user` role + org GUC — the same isolation posture as the request, just a separate transaction so a cancel can't roll it back.
- **No migration, no new env vars.**

## Review guide

- **Start at** the `research_sync` handler in `research-mcp.ts` (#277/#278) and `chargePaid` in `budget.ts` (#279) — the three behaviors live there.
- **Riskiest part:** the #277 detach. The run must commit independently of the request transaction; `research-sync-durability.integration.test.ts` pins both directions — it survives a rolled-back request transaction with the detach, and is lost without it.
- **Decisions you might overrule:** (1) the in-run auto-spend ceiling now equals `auto_approve_paid_cents` rather than `paid_budget_cents` — enforced uniformly in `chargePaid`, per our earlier discussion; (2) `confirm` defaults off, so selectors always bounce once. Both are deliberate — say if you'd rather keep the old ceiling or default confirm on.
- **What I verified vs not:** I drove the real Budget + service against the live DB (spend ledger, run durability, confirm gate) via integration tests, plus the full gate suite. I did **not** make a live MCP JSON-RPC call (that needs an issued API key); the MCP handler over those tested services is thin, type-checked glue.
- **Ride-along:** the first commit updates the `/commit` skill with the `Closes #N` trailer convention you asked for — separable if you'd rather split it out.

## Tests

- New `research-auto-approve-gate.integration.test.ts` — the gate refuses over-limit charges (0¢ spent) when enforced, charges within the limit, gates once cumulative spend crosses it, and still charges when unenforced (standalone / follow-up).
- New `research-sync-durability.integration.test.ts` — a detached run survives a rolled-back request transaction; the same write without the detach is lost.
- Existing selector-fanout, paid-followup, dispatch, and cache-clone integration tests still pass.

## Verification

- Gates after rebasing onto current `main`: `pnpm install` → `check-types` (13/13) + `test` (all unit green) → `build` (13/13).
- Integration: the two new suites plus selector-fanout / paid-followup / dispatch / cache-clone — 18 tests — pass against the live local Postgres.
- 688 research unit tests pass.

Closes #277
Closes #278
Closes #279
