### PR TITLE
fix(research): make discover_contacts paid-action gates approvable

### DIFF
--- a/apps/server/src/services/research-paid-followup.integration.test.ts
+++ b/apps/server/src/services/research-paid-followup.integration.test.ts
@@ -27,11 +27,14 @@ import {
 
 import { PgLive } from '../db/client'
 
-// Approving a pending paid action spawns a follow-up run that performs one
-// whitelisted paid call, charges the budget once, and merges the result back
-// onto the origin run — and fails closed (no spend) when over the monthly cap
-// or when the tool isn't one we execute. The RegistryRouter is stubbed to a
-// fixed record so no real vendor is called; the money movement is real DB
+// Approving a pending paid action spawns a follow-up run that performs one real
+// paid tool — a registry lookup or a contact discovery — charges the budget once,
+// and merges the result back onto the origin run. It fails closed (no spend) when
+// over the monthly cap, and refuses a tool that names no real capability (after
+// coercing the aliases the model invents, e.g. email_finder → discover_contacts).
+// A discover_contacts gate with no company in its args is backfilled from the
+// origin run's sole company subject. RegistryRouter and ContactDiscovery are
+// stubbed so no real vendor is called; the registry money movement is real DB
 // writes to research_paid_spend.
 
 const stubResponse = {
@@ -60,6 +63,15 @@ const stubLlm: LanguageModel.Service = {
 }
 
 let registryCalls = 0
+// What each approved discover follow-up asked ContactDiscovery for, so a test can
+// assert the follow-up reused the run's id + budget rather than opening a new one.
+interface DiscoverCall {
+	companyName: string
+	domain: string
+	country: string | undefined
+	runContextResearchId: string | undefined
+}
+const discoverCalls: DiscoverCall[] = []
 const die = 'provider not exercised'
 const providersLayer = Layer.mergeAll(
 	Layer.succeed(SearchProvider)(
@@ -88,10 +100,33 @@ const ResearchLive = ResearchService.layer.pipe(
 	Layer.provide(providersLayer),
 	Layer.provide(
 		Layer.succeed(ContactDiscovery)({
-			discover: () =>
-				Effect.succeed({
-					status: 'no_reliable_contact' as const,
-					researchId: 'test',
+			discover: input =>
+				Effect.sync(() => {
+					discoverCalls.push({
+						companyName: input.companyName,
+						domain: input.domain,
+						country: input.country,
+						runContextResearchId: input.runContext?.researchId,
+					})
+					return {
+						status: 'ok' as const,
+						researchId: input.runContext?.researchId ?? 'test',
+						contacts: [
+							{
+								name: 'Dana Director',
+								role: 'CEO',
+								is_decision_maker: true,
+								channels: [
+									{
+										kind: 'email',
+										value: `dana@${input.domain}`,
+										verification: 'deliverable',
+										is_primary: true,
+									},
+								],
+							},
+						],
+					}
 				}),
 		}),
 	),
@@ -128,16 +163,29 @@ const seedOrigin = async (
 	user: string,
 	actions: Array<Record<string, unknown>>,
 	paidPolicy: Record<string, unknown> = policy({}),
+	context: Record<string, unknown> | null = null,
 ): Promise<string> => {
 	const r = await pool.query<{ id: string }>(
-		`INSERT INTO research_runs (organization_id, query, status, created_by, findings, paid_policy)
-		 VALUES ($1, 'origin', 'succeeded', $2, $3::jsonb, $4::jsonb) RETURNING id`,
+		`INSERT INTO research_runs (organization_id, query, status, created_by, findings, paid_policy, context)
+		 VALUES ($1, 'origin', 'succeeded', $2, $3::jsonb, $4::jsonb, $5::jsonb) RETURNING id`,
 		[
 			ORG,
 			user,
 			JSON.stringify({ pending_paid_actions: actions }),
 			JSON.stringify(paidPolicy),
+			JSON.stringify(context ?? {}),
 		],
+	)
+	return r.rows[0]!.id
+}
+
+// A company the origin run can point at as its subject, so an approve can read
+// the company's name + website back when a gate's own args carry neither.
+const seedCompany = async (name: string, website: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name, website)
+		 VALUES ($1, $2, $3, $4) RETURNING id`,
+		[ORG, `c-${randomUUID()}`, name, website],
 	)
 	return r.rows[0]!.id
 }
@@ -218,6 +266,7 @@ afterAll(async () => {
 		`DELETE FROM research_paid_spend WHERE organization_id = $1`,
 		[ORG],
 	)
+	await pool.query(`DELETE FROM companies WHERE organization_id = $1`, [ORG])
 	await runtime.dispose()
 	await pool.end()
 })
@@ -257,6 +306,173 @@ describe('paid-action follow-up', () => {
 			expect(findings.pending_paid_actions?.[0]?.['followup_run_id']).toBe(
 				followupId,
 			)
+		})
+	})
+
+	describe('when a discover_contacts lookup is approved', () => {
+		it('should run a follow-up that discovers contacts and merges them back', async () => {
+			// GIVEN an origin run with one pending contact-discovery action
+			const user = `u-disc-${randomUUID()}`
+			const before = discoverCalls.length
+			const origin = await seedOrigin(user, [
+				{
+					id: 'pa1',
+					status: 'pending',
+					tool: 'discover_contacts',
+					args: { company_name: 'Acme', domain: 'acme.com' },
+				},
+			])
+
+			// WHEN it is approved and the follow-up run completes
+			const result = await approve(origin, 'pa1', user)
+			expect(result.status).toBe('approved')
+			const followupId =
+				result.status === 'approved' ? result.followup_run_id : ''
+			expect(await pollRun(followupId)).toBe('succeeded')
+
+			// THEN discovery ran once, reusing the follow-up run's own id + budget
+			// (not a fresh anchor run)
+			expect(discoverCalls.length).toBe(before + 1)
+			expect(discoverCalls.at(-1)).toEqual({
+				companyName: 'Acme',
+				domain: 'acme.com',
+				country: undefined,
+				runContextResearchId: followupId,
+			})
+
+			// AND the discovered contacts are recorded on the origin run
+			const findings = await originFindings(origin)
+			expect(findings.followup_results?.length).toBe(1)
+			const merged = findings.followup_results?.[0] as {
+				tool: string
+				result: { status: string; contacts: unknown[] }
+			}
+			expect(merged.tool).toBe('discover_contacts')
+			expect(merged.result.status).toBe('ok')
+			expect(merged.result.contacts.length).toBe(1)
+			expect(findings.pending_paid_actions?.[0]?.['status']).toBe('approved')
+		})
+	})
+
+	describe('when the action names an invented contact tool', () => {
+		it('should coerce email_finder to discover_contacts and approve it', async () => {
+			// GIVEN the exact failure from production: the model wrote a hallucinated
+			// tool name for what contact discovery does
+			const user = `u-alias-${randomUUID()}`
+			const before = discoverCalls.length
+			const origin = await seedOrigin(user, [
+				{
+					id: 'pa1',
+					status: 'pending',
+					tool: 'email_finder',
+					args: { company_name: 'Acme', domain: 'acme.com' },
+				},
+			])
+
+			// WHEN it is approved
+			const result = await approve(origin, 'pa1', user)
+
+			// THEN the name is coerced to the real tool and the follow-up runs it
+			expect(result.status).toBe('approved')
+			const followupId =
+				result.status === 'approved' ? result.followup_run_id : ''
+			expect(await pollRun(followupId)).toBe('succeeded')
+			expect(discoverCalls.length).toBe(before + 1)
+			const findings = await originFindings(origin)
+			const merged = findings.followup_results?.[0] as { tool: string }
+			expect(merged.tool).toBe('discover_contacts')
+		})
+	})
+
+	describe('when a discover_contacts action is missing its domain', () => {
+		it('should fail the follow-up closed rather than guess', async () => {
+			// GIVEN a contact-discovery action whose args carry no domain to search
+			const user = `u-nodom-${randomUUID()}`
+			const before = discoverCalls.length
+			const origin = await seedOrigin(user, [
+				{
+					id: 'pa1',
+					status: 'pending',
+					tool: 'discover_contacts',
+					args: { company_name: 'Acme' },
+				},
+			])
+
+			// WHEN it is approved and the follow-up runs
+			const result = await approve(origin, 'pa1', user)
+			const followupId =
+				result.status === 'approved' ? result.followup_run_id : ''
+			expect(await pollRun(followupId)).toBe('failed')
+
+			// THEN discovery was never called and the origin records the failure
+			expect(discoverCalls.length).toBe(before)
+			const findings = await originFindings(origin)
+			expect(findings.followup_results?.length).toBe(1)
+		})
+	})
+
+	describe('when a discover_contacts action carries no company at all', () => {
+		it('should backfill it from the origin run single company subject', async () => {
+			// GIVEN a run about one company and a gate whose args are empty
+			const user = `u-backfill-${randomUUID()}`
+			const before = discoverCalls.length
+			const companyId = await seedCompany(
+				'Backfill Co',
+				'https://www.backfillco.com/',
+			)
+			const origin = await seedOrigin(
+				user,
+				[{ id: 'pa1', status: 'pending', tool: 'discover_contacts', args: {} }],
+				policy({}),
+				{ subjects: [{ table: 'companies', id: companyId }] },
+			)
+
+			// WHEN it is approved and the follow-up runs
+			const result = await approve(origin, 'pa1', user)
+			expect(result.status).toBe('approved')
+			const followupId =
+				result.status === 'approved' ? result.followup_run_id : ''
+			expect(await pollRun(followupId)).toBe('succeeded')
+
+			// THEN discovery ran for that company, its website reduced to a bare
+			// domain
+			expect(discoverCalls.length).toBe(before + 1)
+			expect(discoverCalls.at(-1)).toEqual({
+				companyName: 'Backfill Co',
+				domain: 'backfillco.com',
+				country: undefined,
+				runContextResearchId: followupId,
+			})
+		})
+	})
+
+	describe('when a gate has no company and the run spans several', () => {
+		it('should fail rather than guess which company was meant', async () => {
+			// GIVEN a gate with empty args on a run linked to two companies
+			const user = `u-multi-${randomUUID()}`
+			const before = discoverCalls.length
+			const one = await seedCompany('One Co', 'https://one.com')
+			const two = await seedCompany('Two Co', 'https://two.com')
+			const origin = await seedOrigin(
+				user,
+				[{ id: 'pa1', status: 'pending', tool: 'discover_contacts', args: {} }],
+				policy({}),
+				{
+					subjects: [
+						{ table: 'companies', id: one },
+						{ table: 'companies', id: two },
+					],
+				},
+			)
+
+			// WHEN it is approved and the follow-up runs
+			const result = await approve(origin, 'pa1', user)
+			const followupId =
+				result.status === 'approved' ? result.followup_run_id : ''
+			expect(await pollRun(followupId)).toBe('failed')
+
+			// THEN no company was assumed and discovery never ran
+			expect(discoverCalls.length).toBe(before)
 		})
 	})
 

--- a/packages/research/src/application/paid-action-tool.test.ts
+++ b/packages/research/src/application/paid-action-tool.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizePaidActionTool } from './paid-action-tool'
+
+describe('normalizePaidActionTool', () => {
+	describe('when the tool is already a real paid tool', () => {
+		it('should pass a canonical name through unchanged', () => {
+			// GIVEN the two tools a follow-up can actually run
+			// WHEN each is normalized
+			// THEN it is returned unchanged
+			expect(normalizePaidActionTool('registry_lookup')).toBe('registry_lookup')
+			expect(normalizePaidActionTool('discover_contacts')).toBe(
+				'discover_contacts',
+			)
+		})
+
+		it('should accept a name with stray case or whitespace', () => {
+			// GIVEN a real name the model wrote with different case or padding
+			// WHEN it is normalized
+			// THEN it resolves to the canonical lowercase name
+			expect(normalizePaidActionTool('  Discover_Contacts ')).toBe(
+				'discover_contacts',
+			)
+			expect(normalizePaidActionTool('REGISTRY_LOOKUP')).toBe('registry_lookup')
+		})
+	})
+
+	describe('when the model invents a name for a real capability', () => {
+		it('should coerce a contact-finding alias to discover_contacts', () => {
+			// GIVEN the hallucinated names seen in practice for contact discovery —
+			// email_finder is the one that shipped the bug this fixes
+			// WHEN each is normalized
+			// THEN it maps onto the real contact-discovery tool
+			for (const alias of [
+				'email_finder',
+				'email_verifier',
+				'contact_finder',
+				'find_contacts',
+				'hunter',
+				'fullenrich',
+				'enrichment',
+			]) {
+				expect(normalizePaidActionTool(alias)).toBe('discover_contacts')
+			}
+		})
+
+		it('should coerce a registry alias to registry_lookup', () => {
+			// GIVEN names the model uses for the registry lookup
+			// WHEN each is normalized
+			// THEN it maps onto the real registry tool
+			for (const alias of ['registry', 'registry_search', 'company_registry']) {
+				expect(normalizePaidActionTool(alias)).toBe('registry_lookup')
+			}
+		})
+	})
+
+	describe('when the tool matches nothing real', () => {
+		it('should return null so the caller can reject it', () => {
+			// GIVEN a name that names no real tool, or is not even a string
+			// WHEN it is normalized
+			// THEN there is no tool to run and it returns null
+			expect(normalizePaidActionTool('teleport')).toBeNull()
+			expect(normalizePaidActionTool('')).toBeNull()
+			expect(normalizePaidActionTool(undefined)).toBeNull()
+			expect(normalizePaidActionTool(null)).toBeNull()
+			expect(normalizePaidActionTool(42)).toBeNull()
+		})
+	})
+})

--- a/packages/research/src/application/paid-action-tool.ts
+++ b/packages/research/src/application/paid-action-tool.ts
@@ -1,0 +1,46 @@
+/**
+ * The paid tools a follow-up run can actually perform when a pending paid action
+ * is approved, plus the coercion that maps what the model writes onto them.
+ *
+ * The tool name on a pending paid action is free text the model fills in, so it
+ * often names the capability rather than the tool — "email_finder" for what the
+ * contact-discovery tool does, or "registry" for the registry lookup. A name
+ * that matches nothing real can only be skipped, never approved, so a curated
+ * set of aliases is coerced onto the real tool; anything unrecognized returns
+ * null and the caller reports it as unsupported rather than acting on a name that
+ * would do nothing.
+ */
+
+/** The tools a follow-up run knows how to run. */
+export const PAID_FOLLOWUP_TOOLS = new Set([
+	'registry_lookup',
+	'discover_contacts',
+])
+
+// Names the model tends to invent for the two real tools. Kept small and
+// explicit: each entry is a name seen in practice, not a guess.
+const PAID_TOOL_ALIASES: Record<string, string> = {
+	email_finder: 'discover_contacts',
+	email_verifier: 'discover_contacts',
+	contact_finder: 'discover_contacts',
+	find_contacts: 'discover_contacts',
+	hunter: 'discover_contacts',
+	fullenrich: 'discover_contacts',
+	enrichment: 'discover_contacts',
+	registry: 'registry_lookup',
+	registry_search: 'registry_lookup',
+	company_registry: 'registry_lookup',
+}
+
+/**
+ * Resolve a pending paid action's tool name to a real paid tool, or null when it
+ * matches none. A canonical name passes through, a known alias is coerced, and
+ * anything else returns null so the caller can reject it instead of spawning a
+ * follow-up that can do nothing.
+ */
+export const normalizePaidActionTool = (tool: unknown): string | null => {
+	if (typeof tool !== 'string') return null
+	const key = tool.trim().toLowerCase()
+	if (PAID_FOLLOWUP_TOOLS.has(key)) return key
+	return PAID_TOOL_ALIASES[key] ?? null
+}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -39,6 +39,7 @@ import {
 	groundedCitationTest,
 	validateFindingCitations,
 } from './citation-guard'
+import { ContactDiscovery } from './contact-discovery'
 import {
 	ContactVerdictsSchema,
 	contactCriticPrompt,
@@ -85,6 +86,7 @@ import {
 	SizeRescueSchema,
 	sizeRescuePrompt,
 } from './firmographics-rescue'
+import { normalizePaidActionTool } from './paid-action-tool'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
 	AgentLanguageModel,
@@ -275,15 +277,37 @@ export const schemaVersionFor = (schemaName: string): number => {
 // Stamp each element of an in-findings review list with an id + pending status,
 // so it can later be addressed and resolved one at a time. The id and status are
 // this system's to set, so they are spread last — a model that emitted either of
-// its own never takes their place.
-const withPendingIds = (items: unknown): unknown =>
+// its own never takes their place. An optional per-item transform runs first, so
+// a list can also clean up a field before it is stored (paid actions coerce their
+// tool name below).
+const withPendingIds = (
+	items: unknown,
+	transform?: (item: Record<string, unknown>) => Record<string, unknown>,
+): unknown =>
 	Array.isArray(items)
 		? items.map(item =>
 				typeof item === 'object' && item !== null && !Array.isArray(item)
-					? { ...item, id: randomUUID(), status: 'pending' }
+					? {
+							...(transform
+								? transform(item as Record<string, unknown>)
+								: item),
+							id: randomUUID(),
+							status: 'pending',
+						}
 					: item,
 			)
 		: items
+
+// Rewrite a paid action's tool to the real tool it names before storing, so a
+// stored action a human later approves points at a tool a follow-up can run. A
+// name that matches nothing real is left as the model wrote it — visible to the
+// user, and reported as unsupported at approval time.
+const coercePaidActionTool = (
+	item: Record<string, unknown>,
+): Record<string, unknown> => {
+	const canonical = normalizePaidActionTool(item['tool'])
+	return canonical ? { ...item, tool: canonical } : item
+}
 
 /**
  * Give each entry in the two human-reviewed findings lists — the proposed CRM
@@ -309,7 +333,12 @@ export const withProposalIds = (findings: unknown): unknown => {
 			? { proposed_updates: withPendingIds(record['proposed_updates']) }
 			: {}),
 		...(hasPaidActions
-			? { pending_paid_actions: withPendingIds(record['pending_paid_actions']) }
+			? {
+					pending_paid_actions: withPendingIds(
+						record['pending_paid_actions'],
+						coercePaidActionTool,
+					),
+				}
 			: {}),
 	}
 }
@@ -859,6 +888,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 			const agentLlm = yield* AgentLanguageModel
 			const extractLlm = yield* ExtractLanguageModel
 			const writerLlm = yield* WriterLanguageModel
+			// An approved `discover_contacts` follow-up runs the same contact
+			// discovery the in-loop tool does, so the service is resolved here and
+			// reused in `runFollowup`. Already ambient (the in-loop tool needs it),
+			// so this adds no new dependency to the layer.
+			const contactDiscovery = yield* ContactDiscovery
 			// The toolkit handlers are resolved per-run inside `runFiber` (not
 			// here) so each run's paid tools charge that run's Budget. Resolving
 			// them there discharges `HandlersFor<Tools>` inside the fiber, so it
@@ -1123,11 +1157,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					`
 				}).pipe(sql.withTransaction)
 
-			// Run one approved paid action in a follow-up run. Only a registry lookup
-			// runs automatically — anything else is refused so an unrecognized action
-			// can never spend. Its arguments are validated, the run's budget + monthly
-			// cap are charged (fail-closed with no spend when over cap), and the result
-			// is merged back onto the origin run.
+			// Run one approved paid action in a follow-up run. Only the two real paid
+			// tools run — a registry lookup or a contact discovery — and anything else
+			// is refused so an unrecognized action can never spend. Arguments are
+			// validated, the run's budget + monthly cap are charged (fail-closed with
+			// no spend when over cap), and the result is merged back onto the origin
+			// run.
 			const runFollowup = (researchId: string, run: Record<string, unknown>) =>
 				Effect.gen(function* () {
 					// Read the context as raw text so its keys keep the snake_case they
@@ -1150,7 +1185,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						typeof paidAction?.origin_run_id === 'string'
 							? paidAction.origin_run_id
 							: null
-					const tool = paidAction?.tool
+					// Approve already coerces the tool to a real name before spawning this
+					// run; coercing again keeps the follow-up correct on its own terms.
+					const tool = normalizePaidActionTool(paidAction?.tool)
 
 					const finishFailed = (error: string) =>
 						Effect.gen(function* () {
@@ -1159,7 +1196,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// the origin write is durable before the followup reports done.
 							if (originId)
 								yield* mergeFollowupToOrigin(originId, {
-									tool: typeof tool === 'string' ? tool : null,
+									tool: tool ?? null,
 									error,
 								})
 							yield* sql`
@@ -1179,9 +1216,88 @@ export class ResearchService extends Context.Service<ResearchService>()(
 
 					if (!originId)
 						return yield* finishFailed('follow-up run has no origin')
-					if (tool !== 'registry_lookup')
-						return yield* finishFailed(`unsupported paid tool: ${String(tool)}`)
+					if (tool === null)
+						return yield* finishFailed(
+							`unsupported paid tool: ${String(paidAction?.tool)}`,
+						)
 
+					// A fresh per-call budget on the origin's frozen policy. Its
+					// auto-approve gate is off (the default), since the user already
+					// approved this specific action — the charge must not gate again.
+					const organizationId = (run as { organizationId: string })
+						.organizationId
+					const createdBy =
+						(run as { createdBy: string | null }).createdBy ?? ''
+					const policy = (run as { paidPolicy: ResolvedPolicy }).paidPolicy
+					const budgetLayer = makeBudgetLayer({
+						organizationId,
+						userId: createdBy,
+						researchId,
+						policy,
+						systemCeiling: monthlyCapHardCeilingCents,
+					}).pipe(Layer.provide(Layer.succeed(SqlClient.SqlClient)(sql)))
+
+					if (tool === 'discover_contacts') {
+						const args = (paidAction?.args ?? {}) as {
+							company_name?: unknown
+							domain?: unknown
+							country?: unknown
+						}
+						const companyName =
+							typeof args.company_name === 'string'
+								? args.company_name
+								: undefined
+						const domain =
+							typeof args.domain === 'string' ? args.domain : undefined
+						const country =
+							typeof args.country === 'string' ? args.country : undefined
+						if (!companyName || !domain)
+							return yield* finishFailed(
+								'discover_contacts requires company_name and domain',
+							)
+
+						// Reuse this follow-up's id + budget so the enrichment/verify spend
+						// lands on the run and its cap applies — the same in-loop path the
+						// discover_contacts tool takes, just driven by an approved action.
+						const result = yield* Effect.gen(function* () {
+							const budget = yield* Budget
+							return yield* contactDiscovery.discover({
+								companyName,
+								domain,
+								country,
+								runContext: { researchId, budget },
+							})
+						}).pipe(Effect.provide(budgetLayer))
+
+						// Spend refused mid-discovery leaves nothing to merge — fail closed
+						// so the terminal status reflects it. (approval_required cannot
+						// happen: this budget does not enforce the auto-approve gate.)
+						if (result.status === 'budget_exceeded')
+							return yield* finishFailed('paid budget exhausted')
+						if (result.status === 'approval_required')
+							return yield* finishFailed(`approval required for ${result.tool}`)
+
+						// Merge onto the origin before marking this run terminal, so a
+						// caller that sees 'succeeded' also sees the contacts recorded.
+						yield* mergeFollowupToOrigin(originId, {
+							tool: 'discover_contacts',
+							result,
+						})
+						yield* sql`
+							UPDATE research_runs
+							SET status = 'succeeded',
+								findings = ${JSON.stringify({ paid_action_result: result })},
+								completed_at = now(), updated_at = now()
+							WHERE id = ${researchId} AND status = 'running'
+						`
+						// Record the paid enrichment/verify charges from the ledger. The
+						// follow-up does no cheap search/scrape, so cost_cents is 0.
+						yield* stampRunCostFromLedger(sql, researchId, 0)
+						yield* publishEvent(researchId, 'run.succeeded', {})
+						return
+					}
+
+					// registry_lookup
 					const args = (paidAction?.args ?? {}) as {
 						country?: unknown
 						tax_id?: unknown
@@ -1197,19 +1313,6 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					const taxId =
 						typeof args.tax_id === 'string' ? args.tax_id : undefined
 					const query = typeof args.query === 'string' ? args.query : undefined
-
-					const organizationId = (run as { organizationId: string })
-						.organizationId
-					const createdBy =
-						(run as { createdBy: string | null }).createdBy ?? ''
-					const policy = (run as { paidPolicy: ResolvedPolicy }).paidPolicy
-					const budgetLayer = makeBudgetLayer({
-						organizationId,
-						userId: createdBy,
-						researchId,
-						policy,
-						systemCeiling: monthlyCapHardCeilingCents,
-					}).pipe(Layer.provide(Layer.succeed(SqlClient.SqlClient)(sql)))
 
 					const outcome = yield* Effect.gen(function* () {
 						const budget = yield* Budget
@@ -3805,12 +3908,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					Effect.gen(function* () {
 						const [origin] = yield* sql<{
 							findings: string | null
+							context: string | null
 							organizationId: string
 							paidPolicy: string | null
 							createdBy: string | null
 						}>`
-							SELECT findings::text AS findings, organization_id,
-								paid_policy::text AS paid_policy, created_by
+							SELECT findings::text AS findings, context::text AS context,
+								organization_id, paid_policy::text AS paid_policy, created_by
 							FROM research_runs WHERE id = ${runId}
 						`
 						if (!origin) return { status: 'run_not_found' as const }
@@ -3828,8 +3932,64 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							return { status: 'approved' as const, followup_run_id: existing }
 						if (action['status'] !== 'pending')
 							return { status: 'not_pending' as const }
-						if (action['tool'] !== 'registry_lookup')
-							return { status: 'unsupported_tool' as const }
+						// Coerce the model-written tool to a real paid tool; a name that
+						// matches none can only be skipped, so it stays unsupported.
+						const tool = normalizePaidActionTool(action['tool'])
+						if (tool === null) return { status: 'unsupported_tool' as const }
+
+						// A discover_contacts gate whose args carry neither the company
+						// name nor its domain can't be run as written. When the run is
+						// about a single company, fill both from that company (its name +
+						// its website's bare domain) so the approve still discovers the
+						// run's own company. A gate that named some other company (its args
+						// are present) is used as written, and a run about several companies
+						// is left to fail rather than guess which one was meant.
+						const rawArgs = (action['args'] ?? {}) as Record<string, unknown>
+						let resolvedArgs: Record<string, unknown> = rawArgs
+						if (tool === 'discover_contacts') {
+							const hasName =
+								typeof rawArgs['company_name'] === 'string' &&
+								rawArgs['company_name'].trim() !== ''
+							const hasDomain =
+								typeof rawArgs['domain'] === 'string' &&
+								rawArgs['domain'].trim() !== ''
+							if (!hasName && !hasDomain) {
+								const context = (
+									origin.context ? JSON.parse(origin.context) : null
+								) as { subjects?: unknown } | null
+								const subjects = Array.isArray(context?.subjects)
+									? context.subjects
+									: []
+								const companies = subjects.filter(
+									(s): s is { table: string; id: string } =>
+										typeof s === 'object' &&
+										s !== null &&
+										(s as { table?: unknown }).table === 'companies' &&
+										typeof (s as { id?: unknown }).id === 'string',
+								)
+								const subject =
+									companies.length === 1 ? companies[0] : undefined
+								if (subject) {
+									const [row] = yield* sql<{
+										name: string | null
+										website: string | null
+									}>`
+										SELECT name, website FROM companies
+										WHERE id = ${subject.id} AND deleted_at IS NULL
+										LIMIT 1
+									`
+									const domain = row?.website
+										? domainHost(row.website)
+										: undefined
+									if (row?.name && domain)
+										resolvedArgs = {
+											...rawArgs,
+											company_name: row.name,
+											domain,
+										}
+								}
+							}
+						}
 
 						const paidPolicy = origin.paidPolicy
 							? (JSON.parse(origin.paidPolicy) as {
@@ -3839,8 +3999,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							: {}
 						const followupContext = {
 							paid_action: {
-								tool: action['tool'],
-								args: action['args'] ?? {},
+								tool,
+								args: resolvedArgs,
 								origin_run_id: runId,
 								action_id: paId,
 							},


### PR DESCRIPTION
## What

Batuda's research runs sometimes pause on a **paid-action gate** — a checkpoint where the AI wants to spend money on a paid lookup (finding a decision-maker's email, checking a business registry) but the amount is above the user's auto-approve limit, so it records the intent and waits for the user to approve or skip. Approving is supposed to actually perform that paid lookup and fold the result back into the run.

It only worked for one of the two paid tools. A **registry lookup** gate could be approved; a **contact discovery** gate — the far more common one, and the one that finds the decision-maker emails users care about — returned `unsupported_tool` and could only be *skipped*. So the paid data users were asked to approve was unreachable through the approve flow. This closes that gap, in the research subsystem (`packages/research`, with the follow-up integration test hosted in `apps/server`).

## The fix

- **`discover_contacts` gates are now approvable (#280).** Approving one spawns a follow-up run that performs the contact discovery — reusing that run's own budget and spend cap, exactly like the in-run tool does — and merges the verified contacts back onto the origin run. Previously only `registry_lookup` was wired into both the approve step and the follow-up executor.
- **The tool name on a gate is normalized to a real tool.** The model writes the tool name into a gate as free text and sometimes invents one — the production bug that motivated this issue had it write `email_finder`. A small curated alias map now coerces those onto the real tool (`email_finder`/`hunter`/`fullenrich`/… → `discover_contacts`, `registry`/… → `registry_lookup`) both when the gate is stored and when it is approved; a name that matches nothing real is still refused as `unsupported_tool` rather than acted on.
- **A gate with no company in its args is filled from the run's own company.** A `discover_contacts` gate that carries neither a company name nor a domain can't be run as written. When the run is about a single company, the approve step backfills both — the company's name and its website reduced to a bare domain — from that subject, so a thin gate still runs against the researched company. A gate that already named a company is used as written; a run that spans several companies is left to fail rather than guess which one was meant.

## Impact

- **MCP + HTTP parity.** The approve path (`approvePaidAction`) is a shared service method behind both the MCP tool (`resolve_research_paid_action`) and the HTTP handler, so both surfaces get the new behavior together.
- **Spend / budget.** The follow-up runs on the origin run's frozen paid policy with a fresh per-call budget, and — like the existing registry follow-up — its auto-approve gate is **off** (the user already approved this specific action, so the charge must not gate again). A `discover_contacts` follow-up costs the usual ~16¢ of enrichment/verification, metered against that run.
- **RLS.** The new backfill reads one `companies` row (`name`, `website`) in the approve step. It runs under the same request org-scope the approve already relies on to read `research_runs`, so it never crosses tenants; a subject in another org simply returns no row and the gate fails closed.
- **No migration, no new env vars, no wire-shape change.** Purely internal to how an already-recorded gate is approved and executed.

## Review guide

- **Start at** `approvePaidAction` in `research-service.ts` (the tool normalization + backfill) and `runFollowup` in the same file (the new `discover_contacts` execution branch) — the two places the behavior lives. `paid-action-tool.ts` is the tiny pure normalizer.
- **Riskiest part:** the backfill. It only fires when a gate has *neither* company field *and* the run has *exactly one* company subject, and it fills name+domain *together* — so a model-supplied competitor name can never be paired with the origin's domain. `research-paid-followup.integration.test.ts` pins both the happy path and the multi-subject guard (fails rather than guesses).
- **Decision you might overrule:** I added the backfill (Option C from our discussion) rather than shipping the thin-args case as a clean failure. It's guarded to be safe, but it does mean an all-empty gate defaults to the run's own company. Say if you'd rather it just fail and make the user re-issue discovery.
- **What I verified vs not:** I drove the real approve → follow-up → merge flow against the live local Postgres (run durability, the merged `followup_results`, the backfill reading a seeded company, the guard). The follow-up's `ContactDiscovery` is stubbed in that test, so the real enrichment/verify vendors aren't called — but the budget-reuse wiring and merge are real. I did **not** make a live MCP JSON-RPC call (needs an issued API key); the MCP handler over this service is thin, type-checked glue.

## Tests

- New `paid-action-tool.test.ts` — the normalizer: canonical pass-through, case/whitespace tolerance, each alias → its real tool, and unknown/non-string → null (rejected).
- Extended `research-paid-followup.integration.test.ts` — a `discover_contacts` gate approves, runs a follow-up reusing the run's id + budget, and merges its contacts onto the origin; an `email_finder`-named gate is coerced and approved; a gate missing its domain fails closed; an empty-args gate is backfilled from the run's single company subject; a gate on a multi-company run fails rather than guess.

## Verification

- Gates on current `main` (branch is up to date, no rebase): `pnpm install` → `check-types` (13/13) + `test` (all unit green) → `build` (13/13).
- Integration: `research-paid-followup.integration.test.ts` — 10 tests — pass against the live local Postgres.
- 698 research unit tests pass.

Closes #280
