### PR TITLE
fix: give each git worktree its own integration-test database

### DIFF
--- a/.claude/hooks/worktree-down.sh
+++ b/.claude/hooks/worktree-down.sh
@@ -42,6 +42,12 @@ case "$bucket" in batuda-assets-?*) ;; *) exit 0 ;; esac
 
 docker exec batuda-db psql -U batuda -d postgres \
 	-c "DROP DATABASE IF EXISTS ${db} WITH (FORCE)" >/dev/null 2>&1 || true
+# Drop this worktree's integration-test database too — the pre-push suite creates it
+# lazily (batuda_<slug> -> batuda_it__<slug>; see scripts/integration-db.ts) and never
+# records it in .env. The batuda_?* guard above means $db is the suffixed form, so
+# ${db#batuda_} is <slug> and this can never target the main checkout's batuda_it.
+docker exec batuda-db psql -U batuda -d postgres \
+	-c "DROP DATABASE IF EXISTS batuda_it__${db#batuda_} WITH (FORCE)" >/dev/null 2>&1 || true
 docker run --rm --network batuda_default --entrypoint /bin/sh minio/mc:latest \
 	-c "mc alias set local http://storage:9000 batuda batuda-secret >/dev/null 2>&1 && mc rb --force local/${bucket}" \
 	>/dev/null 2>&1 || true

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -21,7 +21,11 @@ is a *logical tenant* inside it:
   `ui/feature-x` gives `batuda_feature_x` / `batuda-assets-feature-x`, which is what
   `ls`/`doctor` print,
 - a generated `.env` pointing `DATABASE_URL` / `STORAGE_BUCKET` at them; everything else
-  (shared endpoints, secrets) is inherited from the main checkout's `.env`.
+  (shared endpoints, secrets) is inherited from the main checkout's `.env`,
+- a per-worktree **integration-test database** `batuda_it__<slug>` (the main checkout's is
+  `batuda_it`) that the pre-push suite creates/migrates/seeds fresh each run, so parallel
+  worktrees running `test:integration` don't race on one shared DB. Branch slug `it` is
+  reserved — its dev DB would collide with `batuda_it`, so `worktree up` refuses it.
 
 portless serves each worktree on that same last-path-segment label — web
 `https://<label>.batuda.localhost`, server `https://<label>.api.batuda.localhost`, so
@@ -126,6 +130,10 @@ If the directory was removed manually before `worktree down`, run `pnpm cli work
   **URL** then follows the new branch. Run `pnpm cli worktree down` before removing the dir.
 - **`pnpm cli worktree up` re-seeds** (`--preset minimal`) every run, so re-running it resets the
   worktree's seed data — don't re-run it on a worktree whose data you've hand-edited.
+- **The integration-test DB is per-worktree and disposable.** The pre-push suite builds
+  `batuda_it__<slug>` (main: `batuda_it`) fresh each run; `worktree down`/`done` and the
+  `WorktreeRemove` hook drop it alongside the dev DB, and `prune` reaps it for a worktree that's
+  gone. You never manage it by hand — and it never touches another worktree's `batuda_it__…`.
 - **`pnpm cli services down` from a worktree** stops the *shared* stack (every worktree + main),
   so it refuses unless run from the main checkout or given `--force`. To remove just your
   worktree's data, use `worktree down`.

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -60,8 +60,14 @@ const seedCommand = Command.make(
 			),
 			Flag.withDefault('full' as const),
 		),
+		quiet: Flag.boolean('quiet').pipe(
+			Flag.withDescription(
+				'Skip the dev-server access hints — for seeding a disposable integration DB, where nothing is being served',
+			),
+			Flag.withDefault(false),
+		),
 	},
-	({ preset }) =>
+	({ preset, quiet }) =>
 		withDb(
 			Effect.gen(function* () {
 				yield* seedIdentities
@@ -70,6 +76,9 @@ const seedCommand = Command.make(
 				yield* Console.log(
 					`Seeded (${preset}): ${counts.products} products, ${counts.companies} companies, ${counts.contacts} contacts, ${counts.interactions} interactions, ${counts.tasks} tasks, ${counts.documents} documents, ${counts.proposals} proposals, ${counts.pages} pages, ${counts.callRecordings} call recordings`,
 				)
+				// These hints would name the dev server — which serves the dev DB, not the
+				// integration DB just seeded — so skip them for a disposable integration DB.
+				if (quiet) return
 				// Hosts follow this checkout: bare batuda.localhost in the main
 				// checkout, <label>.batuda.localhost inside a worktree — so the hints
 				// name the URL actually being served, not main's.

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -93,6 +93,26 @@ const slugForBranch = (branch: string) =>
 const dbName = (slug: string) => `batuda_${slug.replace(/-/g, '_')}`
 const bucketName = (slug: string) => `batuda-assets-${slug}`
 
+// The disposable integration-test database that belongs to a dev database:
+// `batuda` -> `batuda_it`, `batuda_<slug>` -> `batuda_it__<slug>`. Kept in sync
+// with scripts/integration-db.ts (the canonical rule the pre-push suite builds
+// from; a pure string transform can't be shared across the CLI/scripts type-check
+// boundary). The double underscore keeps it out of the dev-database namespace — a
+// dev name never contains `__` because `dnsLabel` collapses runs of `-` before
+// `dbName` maps `-` to `_` — so `down`/`prune` can drop and protect it without ever
+// colliding with real dev data.
+const integrationDbFromDevDb = (db: string): string =>
+	db === 'batuda' ? 'batuda_it' : db.replace(/^batuda_/, 'batuda_it__')
+
+// Last path segment of a `.env` DATABASE_URL — the database name, any `?sslmode=…`
+// query stripped. The one place worktree.ts parses that URL; `identityFromEnv` and
+// `dbFromEnv` share it (and scripts/integration-db.ts mirrors it) so the name the
+// pre-push suite CREATEs and the one teardown DROPs can't drift.
+const dbFromEnvBody = (body: string): string | undefined => {
+	const url = body.match(/^DATABASE_URL=(.+)$/m)?.[1]?.trim()
+	return url?.match(/\/([^/?]+)(?:\?|$)/)?.[1]
+}
+
 // A worktree's real database + bucket, read from the `.env` it generated at
 // provision time. That file is the stable record of what `up` actually created;
 // the live branch is not, because `gh pr merge --delete-branch` checks `main`
@@ -105,18 +125,28 @@ const identityFromEnv = (
 ): { db: string; bucket: string } | null => {
 	if (!existsSync(envPath)) return null
 	const body = readFileSync(envPath, 'utf-8')
-	const url = body.match(/^DATABASE_URL=(.+)$/m)?.[1]?.trim()
+	const db = dbFromEnvBody(body)
 	const bucket = body.match(/^STORAGE_BUCKET=(.+)$/m)?.[1]?.trim()
-	// Last path segment of the DB URL, with any `?sslmode=…` query stripped.
-	const db = url?.match(/\/([^/?]+)(?:\?|$)/)?.[1]
 	return db && bucket ? { db, bucket } : null
+}
+
+// Just the dev database from a checkout's `.env`, without requiring STORAGE_BUCKET
+// — so `prune` can keep this checkout's integration-test database owned (and safe
+// from reaping) even when the `.env` is missing its bucket key.
+const dbFromEnv = (envPath: string): string | null => {
+	if (!existsSync(envPath)) return null
+	return dbFromEnvBody(readFileSync(envPath, 'utf-8')) ?? null
 }
 
 // Guard for destructive ops: only a suffixed `batuda_<slug>` / `batuda-assets-<slug>`
 // pair belongs to a worktree. The main checkout's bare `batuda` / `batuda-assets`
-// must never be dropped, so anything without the suffix is refused.
+// must never be dropped, so anything without the suffix is refused — and `batuda_it`
+// (the main checkout's integration-test database) is excluded too, so a stray `.env`
+// naming it can't make teardown drop it.
 const isWorktreeOwned = (db: string, bucket: string) =>
-	db.startsWith('batuda_') && bucket.startsWith('batuda-assets-')
+	db.startsWith('batuda_') &&
+	db !== 'batuda_it' &&
+	bucket.startsWith('batuda-assets-')
 
 // The shared `.git` is identical from any worktree, so its parent is the main
 // checkout — where the real .env (the values to inherit) lives.
@@ -371,11 +401,18 @@ const liveOwnedResources = execSilent(
 		const dbs = new Set<string>()
 		const buckets = new Set<string>()
 		for (const entry of parseWorktrees(out)) {
-			const id = identityFromEnv(resolve(entry.path, '.env'))
+			const envPath = resolve(entry.path, '.env')
+			const id = identityFromEnv(envPath)
 			if (id) {
 				dbs.add(id.db)
 				buckets.add(id.bucket)
 			}
+			// Own this checkout's integration-test database (`batuda_it` for main,
+			// `batuda_it__<slug>` for a worktree) so `prune` never reaps a live one.
+			// Keyed off the dev database alone — a `.env` missing STORAGE_BUCKET makes
+			// `identityFromEnv` null, but the integration sibling must stay owned.
+			const devDb = dbFromEnv(envPath)
+			if (devDb?.startsWith('batuda')) dbs.add(integrationDbFromDevDb(devDb))
 		}
 		return { dbs, buckets }
 	}),
@@ -574,6 +611,18 @@ export const worktreeUp = Effect.gen(function* () {
 	}
 	const slug = yield* slugForCurrentWorktree
 
+	// `batuda_it` is reserved for the main checkout's integration-test database, so
+	// a branch whose slug is exactly `it` would share that name — and the pre-push
+	// suite's `db reset` would wipe this worktree's dev data. Refuse it (the only
+	// reserved branch name, like `main`).
+	if (dbName(slug) === 'batuda_it') {
+		return yield* Effect.fail(
+			new Error(
+				'Branch slug `it` is reserved — its database would collide with the integration-test database `batuda_it`. Rename the branch.',
+			),
+		)
+	}
+
 	yield* Effect.logInfo('Ensuring the shared stack is up…')
 	yield* ensureSharedStack
 
@@ -659,6 +708,9 @@ export const worktreeDown = Effect.gen(function* () {
 	yield* stopWorktreeDevServers(ROOT)
 	yield* Effect.logInfo(`Dropping database ${db} + bucket ${bucket}…`)
 	yield* dropDatabase(db)
+	// Drop this worktree's integration-test database too — the pre-push suite creates
+	// it lazily (never recorded in `.env`); `IF EXISTS` no-ops if it never ran here.
+	yield* dropDatabase(integrationDbFromDevDb(db))
 	// The bucket may already be gone (or never created) — don't fail teardown on it.
 	yield* mc(`mc rb --force local/${bucket}`).pipe(
 		Effect.catch(() => Effect.void),

--- a/apps/mail-worker/vitest.integration.config.ts
+++ b/apps/mail-worker/vitest.integration.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vitest/config'
 
+import { integrationDbUrl } from '../../scripts/integration-db'
+
 // DB-integration runner — `*.integration.test.ts` files that need a real
 // Postgres ($DATABASE_URL). `globalSetup` builds a disposable, HEAD-migrated +
-// seeded `batuda_it` DB locally (no-op in CI, which supplies a fresh Neon
-// branch), so the suite runs against the current schema, not a stale shared dev
+// seeded integration DB locally, named per checkout (`batuda_it`, or
+// `batuda_it__<slug>` in a worktree) so parallel worktrees don't race on one
+// shared DB — a no-op in CI, which points DATABASE_URL at its own migrated
+// Postgres. So the suite runs against the current schema, not a stale shared dev
 // DB. Sequential file execution because suites across workspaces (notably
 // apps/server's multi-org-isolation) TRUNCATE shared tables in beforeAll;
 // parallel files race fixture inserts against the truncate.
@@ -14,7 +18,7 @@ export default defineConfig({
 		env: {
 			DATABASE_URL: process.env['CI']
 				? (process.env['DATABASE_URL'] ?? '')
-				: 'postgresql://batuda:batuda@localhost:5433/batuda_it',
+				: integrationDbUrl(),
 		},
 		environment: 'node',
 		globals: false,

--- a/apps/server/vitest.integration.config.ts
+++ b/apps/server/vitest.integration.config.ts
@@ -1,12 +1,16 @@
 import { defineConfig } from 'vitest/config'
 
+import { integrationDbUrl } from '../../scripts/integration-db'
+
 // DB-integration runner — `*.integration.test.ts` files that need a real
 // Postgres ($DATABASE_URL) but no other services. `globalSetup` builds a
-// disposable, HEAD-migrated + seeded `batuda_it` DB locally (no-op in CI, which
-// supplies a fresh Neon branch), so the suite always runs against the current
-// schema rather than a stale shared dev DB. Sequential file execution because
-// several suites TRUNCATE shared tables in beforeAll (notably
-// multi-org-isolation), which races with any parallel suite that inserts.
+// disposable, HEAD-migrated + seeded integration DB locally, named per checkout
+// (`batuda_it`, or `batuda_it__<slug>` in a worktree) so parallel worktrees don't
+// race on one shared DB — a no-op in CI, which points DATABASE_URL at its own
+// migrated Postgres. So the suite always runs against the current schema rather
+// than a stale shared dev DB. Sequential file execution because several suites
+// TRUNCATE shared tables in beforeAll (notably multi-org-isolation), which races
+// with any parallel suite that inserts.
 export default defineConfig({
 	test: {
 		include: ['src/**/*.integration.test.ts'],
@@ -14,7 +18,7 @@ export default defineConfig({
 		env: {
 			DATABASE_URL: process.env['CI']
 				? (process.env['DATABASE_URL'] ?? '')
-				: 'postgresql://batuda:batuda@localhost:5433/batuda_it',
+				: integrationDbUrl(),
 		},
 		environment: 'node',
 		globals: false,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -53,10 +53,11 @@ pre-push:
       # Unit suite AND the live-DB integration suite. `turbo test` alone runs
       # only the default config, which EXCLUDES `*.integration.test.ts`, so
       # schema bugs used to slip straight to CI; `test:integration` closes that.
-      # It runs against a disposable `batuda_it` DB that
-      # scripts/integration-db-setup.ts creates, migrates to HEAD, and seeds, so
-      # local matches CI's fresh schema instead of a stale shared dev DB.
-      # `--concurrency=1` serialises @batuda/server and @batuda/mail-worker,
-      # which share that one DB and TRUNCATE shared tables in beforeAll.
+      # It runs against a disposable integration DB that
+      # scripts/integration-db-setup.ts creates, migrates to HEAD, and seeds —
+      # named per checkout (`batuda_it`, or `batuda_it__<slug>` in a worktree) so
+      # parallel worktrees don't race on one shared DB. `--concurrency=1`
+      # serialises @batuda/server and @batuda/mail-worker, which share this
+      # checkout's integration DB and TRUNCATE shared tables in beforeAll.
       run: |
         pnpm turbo test test:integration --concurrency=1

--- a/scripts/integration-db-setup.ts
+++ b/scripts/integration-db-setup.ts
@@ -4,27 +4,31 @@ import { dirname, resolve } from 'node:path'
 
 import { parse as parseEnv } from 'dotenv'
 
+import { integrationDbUrl, resolveIntegrationDbName } from './integration-db'
+
 // Vitest globalSetup for the `*.integration.test.ts` suites. Locally it builds a
-// disposable `batuda_it` database, migrates it to HEAD, and seeds it — the same
-// shape CI gives its fresh Neon branch — and the integration vitest configs
-// point DATABASE_URL at it. This keeps the local integration run on the CURRENT
-// schema instead of a stale shared dev DB; running the new code against an
+// disposable, HEAD-migrated + seeded integration database and the integration
+// vitest configs point DATABASE_URL at it, so the run is always on the CURRENT
+// schema instead of a stale shared dev DB — running new code against an
 // un-migrated schema is exactly what let a dropped-column bug pass pre-push but
-// fail CI. In CI, DATABASE_URL is already a migrated + seeded Neon branch, so
-// this is a no-op.
+// fail CI. The database is named PER CHECKOUT (`batuda_it` in the main checkout,
+// `batuda_it__<slug>` in a worktree — see ./integration-db) so two worktrees
+// running the suite at once don't race on one shared database.
 //
-// `CI` reaches here via turbo `passThroughEnv` (turbo.json → test:integration).
+// In CI this is a no-op: CI points DATABASE_URL at its own migrated local Postgres
+// (the `batuda` container), so there is nothing to build here. `CI` reaches this
+// file via turbo `passThroughEnv` (turbo.json → test:integration).
 
-const IT_URL = 'postgresql://batuda:batuda@localhost:5433/batuda_it'
+const IT_URL = integrationDbUrl()
 
-// The `pnpm cli` calls below migrate + seed batuda_it, and the CLI reads its
-// credentials (STORAGE_*, auth secrets, …) from the checkout's `.env`. A linked
+// The `pnpm cli` calls below migrate + seed the integration DB, and the CLI reads
+// its credentials (STORAGE_*, auth secrets, …) from the checkout's `.env`. A linked
 // worktree created with a bare `git worktree add` has none — only
 // `pnpm cli worktree up` writes one — so the seed would die with a ConfigError
 // and the pre-push hook couldn't run there at all. Read those values from the
 // MAIN checkout's `.env` files (the same source `worktree up` copies from) so
 // the setup works in any worktree, provisioned or not. DATABASE_URL is left out
-// on purpose: the batuda_it override wins because the CLI keeps an
+// on purpose: the integration-DB override wins because the CLI keeps an
 // explicitly-set env var ahead of any `.env` value. Returns nothing in the main
 // checkout, where the CLI already finds its own `.env`.
 const mainCheckoutEnv = (): Record<string, string> => {
@@ -53,17 +57,17 @@ export default function setup(): void {
 	if (process.env['CI']) return
 
 	// Main checkout's `.env` first (fills a worktree's missing credentials), then
-	// the live shell, then the batuda_it target — later spreads win.
+	// the live shell, then the integration-DB target — later spreads win.
 	const itEnv = { ...mainCheckoutEnv(), ...process.env, DATABASE_URL: IT_URL }
 	const sh = (cmd: string, env: NodeJS.ProcessEnv = process.env) =>
 		execSync(cmd, { stdio: 'inherit', shell: '/bin/bash', env })
 
 	// CREATE DATABASE can't run inside a transaction; ignore "already exists".
 	sh(
-		`docker exec batuda-db psql -U batuda -d postgres -c "CREATE DATABASE batuda_it" 2>/dev/null || true`,
+		`docker exec batuda-db psql -U batuda -d postgres -c "CREATE DATABASE ${resolveIntegrationDbName()}" 2>/dev/null || true`,
 	)
-	// `db reset` migrates to HEAD AND truncates, so a reused batuda_it starts
+	// `db reset` migrates to HEAD AND truncates, so a reused integration DB starts
 	// from a clean slate (the seed refuses to run against leftover CRM rows).
 	sh('pnpm -w cli db reset', itEnv)
-	sh('pnpm -w cli seed', itEnv) // taller/restaurant fixtures the suites rely on
+	sh('pnpm -w cli seed --quiet', itEnv) // taller/restaurant fixtures the suites rely on
 }

--- a/scripts/integration-db.ts
+++ b/scripts/integration-db.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// The pre-push integration suite runs against a disposable Postgres database that
+// scripts/integration-db-setup.ts creates, migrates, and seeds. It is named PER
+// CHECKOUT so two git worktrees running the suite at once don't race on one shared
+// database — one worktree's `beforeAll` TRUNCATE wiping rows the other is mid-test
+// on (issue #295). The name is derived from the checkout's own dev database (the
+// one its `.env` DATABASE_URL points at, which `pnpm cli worktree up` writes): the
+// main checkout's `batuda` yields the historical `batuda_it`; a worktree's
+// `batuda_<slug>` yields `batuda_it__<slug>`.
+//
+// The DOUBLE underscore is load-bearing: a dev database name can never contain
+// `__` (the slug generator collapses runs of `-`, then maps `-` to `_`), so the
+// `batuda_it__` prefix keeps every worktree's integration database out of the
+// dev-database namespace. Without it a branch slug like `it-foo` would map to a dev
+// database equal to another checkout's integration database, and the suite's
+// `db reset` (migrate + TRUNCATE) would silently wipe live dev data. apps/cli's
+// worktree.ts and .claude/hooks/worktree-down.sh mirror this rule (a pure string
+// transform can't be shared across the TS/bash boundary) so teardown and prune drop
+// and protect the integration database alongside the dev database it belongs to.
+
+const HOST = 'postgresql://batuda:batuda@localhost:5433'
+
+// The integration database that belongs to a given dev database. Splices `it` in
+// after the `batuda_` prefix: `batuda` -> `batuda_it`, `batuda_x` -> `batuda_it__x`.
+export const integrationDbFromDevDb = (devDb: string): string =>
+	devDb === 'batuda' ? 'batuda_it' : devDb.replace(/^batuda_/, 'batuda_it__')
+
+const git = (...args: string[]): string | null => {
+	try {
+		return execFileSync('git', args, { encoding: 'utf8' }).trim()
+	} catch {
+		return null
+	}
+}
+
+// The dev database this checkout's own `.env` points at, parsed from DATABASE_URL
+// with the SAME last-path-segment regex identityFromEnv uses in worktree.ts, so the
+// name the suite CREATEs matches the one teardown later DROPs. Returns null unless
+// DATABASE_URL names a clean `batuda*` identifier — a hand-pointed or malformed URL
+// must never drive the destructive `db reset`, and the strict `[a-z0-9_]` shape
+// guarantees the resolved name is safe to interpolate into the `CREATE DATABASE`
+// shell command (no injection from a crafted `.env`).
+const devDbFromEnv = (): string | null => {
+	const root = git('rev-parse', '--show-toplevel')
+	if (!root) return null
+	const envPath = resolve(root, '.env')
+	if (!existsSync(envPath)) return null
+	const url = readFileSync(envPath, 'utf8')
+		.match(/^DATABASE_URL=(.+)$/m)?.[1]
+		?.trim()
+	const db = url?.match(/\/([^/?]+)(?:\?|$)/)?.[1]
+	return db && /^batuda[a-z0-9_]*$/.test(db) ? db : null
+}
+
+// Postgres caps identifiers at 63 bytes; `batuda_it__` is 11, leaving 52 for the
+// suffix. Dev-database-derived names are already within budget (their slug is
+// capped tighter); only the bare-worktree fallback below needs trimming.
+const MAX_SUFFIX = 52
+
+// A bare `git worktree add` (never `pnpm cli worktree up`) has no `.env`, so key the
+// name off the registered git-worktree name instead — `<main>/.git/worktrees/<name>`
+// — sanitized to a valid, collision-free identifier so even an unprovisioned
+// worktree stays off the main checkout's `batuda_it`. The main checkout's git dir
+// has no `/worktrees/` segment, so it falls through to the shared `batuda_it`.
+const nameFromGitWorktree = (): string => {
+	const gitDir = git(
+		'rev-parse',
+		'--path-format=absolute',
+		'--absolute-git-dir',
+	)
+	const name = gitDir?.match(/\/worktrees\/([^/]+)\/?$/)?.[1]
+	if (!name) return 'batuda_it'
+	const suffix = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.slice(0, MAX_SUFFIX)
+	return suffix ? `batuda_it__${suffix}` : 'batuda_it'
+}
+
+// The integration database name for the current checkout.
+export const resolveIntegrationDbName = (): string => {
+	const devDb = devDbFromEnv()
+	return devDb ? integrationDbFromDevDb(devDb) : nameFromGitWorktree()
+}
+
+export const integrationDbUrl = (): string =>
+	`${HOST}/${resolveIntegrationDbName()}`

--- a/turbo.json
+++ b/turbo.json
@@ -52,7 +52,8 @@
 				"$TURBO_DEFAULT$",
 				"src/**/*",
 				"**/*.integration.test.*",
-				"../../scripts/integration-db-setup.ts"
+				"../../scripts/integration-db-setup.ts",
+				"../../scripts/integration-db.ts"
 			],
 			"outputs": ["coverage/**/*"],
 			"cache": true


### PR DESCRIPTION
## What

The check that runs before every `git push` includes a live-database test suite. Until now every checkout rebuilt and shared **one** test database, `batuda_it`. So when two git worktrees ran that suite at the same time — two parallel `/pr` pushes, or two people — they clobbered each other: one worktree's setup wiped the rows the other was mid-test on, the suite flaked, and the push was blocked even though the branch's own code was fine. (This bit me on #286 / PR #294.)

This is a dev-tooling change (the `cli` package, the test-harness scripts, and the git hooks — no product code). Each checkout now gets its **own** throwaway test database, so parallel runs stay out of each other's way.

## The fix

- Each checkout builds its own integration-test database: `batuda_it` in the main checkout (unchanged), `batuda_it__<branch>` in a worktree. The name is derived from the database the checkout already uses, so the whole worktree lifecycle that already reads that name gets the new one for free.
- The `__` (double underscore) is the safety guarantee: the branch-name → database-name rule can never produce a `__`, so a worktree's *test* database can never accidentally equal a real *dev* database — which matters because the setup does a destructive reset, and colliding would silently wipe live dev data. The one leftover collision (a branch literally named `it`, whose dev database would be `batuda_it`) is refused up front by `worktree up`, like `main` is reserved.
- Teardown keeps up: `worktree down`/`done` and the worktree-removal hook drop the test database alongside the dev one, and `worktree prune` protects the live ones while reaping databases from worktrees that are gone.
- Seeding this throwaway database no longer prints "access hints" (links to the running app) — a new `pnpm cli seed --quiet` flag — because those links pointed at the dev server, not the database just seeded.

## Impact

- **CI is unaffected.** CI already points the suite at its own local Postgres (`.../batuda`) with `CI` set; the per-checkout naming only runs when `CI` is unset, so CI keeps behaving exactly as before. (I also corrected stale comments that claimed CI uses a "fresh Neon branch" — it's a local Postgres container since PR #283.)
- **No schema / RLS / API / env-var / auth / webhook surface.** Nothing here touches the database schema, tenant isolation, the wire contract, boot-time config, or any product path.
- **Security (shell + SQL):** the setup interpolates the resolved name into a `CREATE DATABASE …` shell command. The resolver only accepts a strict `^batuda[a-z0-9_]*$` name (else it falls back to a sanitized identifier), so a hand-edited or malformed local `.env` can't inject shell or SQL.

## Review guide

- **Start at `scripts/integration-db.ts`** — the ~30-line canonical naming rule and the reasoning for the double underscore. If that rule is sound, the rest follows.
- **`apps/cli/src/commands/worktree.ts`** is the biggest hunk: a small naming helper mirrored from the script (it can't import across the CLI/scripts type-check boundary), the reserved-`it` guard in `worktreeUp`, and the teardown/prune ownership. `.claude/hooks/worktree-down.sh` mirrors the same one-line rule in bash.
- **A decision you might overrule:** I kept the main checkout's name as `batuda_it` and reserved the single branch slug `it`, rather than renaming main to a fully uniform `batuda__it`. Keeping `batuda_it` avoids churning ~42 test files' fallback literals and preserves standalone-run behavior; the trade is one reserved branch name. Say the word if you'd rather the uniform scheme.
- I ran an adversarial multi-agent review of the plan (it caught the collision class above before any code) and addressed a shell-injection flag from the security hook. No Snyk run (tool not invoked here).
- The comment-only edits in the two `vitest.integration.config.ts` files and `lefthook.yml` are skip-able.

## Verification

Everything below I actually ran on this branch:

- `check-types`, unit `test` (33 tasks), and `build` — all green.
- The **full** integration suite via the pre-push hook — **314 tests / 56 files** (server) + mail-worker, all passing against the derived `batuda_it`.
- A single integration test end-to-end, confirming the seed no longer prints access hints.
- In a throwaway worktree: the resolver returns `batuda_it__<slug>`, the hook's bash expansion produces the identical name (so create and teardown agree), and `worktree up` on slug `it` is refused.

## Deferred

- A bare `git worktree add` that never ran `worktree up` gets an isolated test database but isn't tracked by `prune` (it has no `.env` to key off). It's disposable and rebuilt each run, so I left it as a noted edge rather than building for it.

Closes #295
