### PR TITLE
fix(server): extract research fields with gpt-oss-120b, not Qwen

### DIFF
--- a/apps/server/config.production.json
+++ b/apps/server/config.production.json
@@ -31,7 +31,7 @@
 	"RESEARCH_LLM_AGENT_PROVIDERS": "custom,groq",
 	"RESEARCH_LLM_AGENT_TIMEOUT_SEC": "90",
 	"RESEARCH_LLM_EXTRACT_BASE_URL": "https://api.tokenfactory.nebius.com/v1",
-	"RESEARCH_LLM_EXTRACT_MODEL": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+	"RESEARCH_LLM_EXTRACT_MODEL": "openai/gpt-oss-120b",
 	"RESEARCH_LLM_EXTRACT_MODEL_2": "accounts/fireworks/models/gpt-oss-120b",
 	"RESEARCH_LLM_EXTRACT_PROVIDERS": "custom,fireworks",
 	"RESEARCH_LLM_EXTRACT_TIMEOUT_SEC": "90",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,7 +268,7 @@ Batuda has three bounded contexts. Each owns its own domain errors and types; de
 
 **Why research is a separate bounded context.** Research has its own domain model (providers, budgets, quotas, schemas), its own error hierarchy (`ProviderError`, `BudgetExceeded`, `QuotaExhausted`), and its own infrastructure concerns (external API keys, LLM inference, cost tracking). It reads CRM data (companies, contacts) but never writes directly — proposed changes go through the `propose_update` tool, reviewed by the outer AI or user before applying. This separation means research provider implementations, pricing models, and LLM providers can evolve independently of the CRM schema.
 
-**Provider selection pattern.** Each research capability (search, scrape, extract, discover, enrich, verify, registry, report) plus LLM inference is configured by an env var (`RESEARCH_PROVIDER_*`) that picks the implementation at boot time. The pattern is `Layer.unwrap(Config.schema(...) → switch → return Layer)` — same as `EmailProviderLive`. Stubs provide zero-cost deterministic data for local dev. Real providers (Brave, Firecrawl, libreBORME, Companies House, Hunter) declare their dependencies (`HttpClient`, `Config`) in the R type, satisfied at the composition root.
+**Provider selection pattern.** Each research capability (search, scrape, enrich, verify, registry, report) plus LLM inference is configured by an env var (`RESEARCH_PROVIDER_*`) that picks the implementation at boot time. The pattern is `Layer.unwrap(Config.schema(...) → switch → return Layer)` — same as `EmailProviderLive`. Stubs provide zero-cost deterministic data for local dev. Real providers (Brave, Firecrawl, libreBORME, Companies House, Hunter) declare their dependencies (`HttpClient`, `Config`) in the R type, satisfied at the composition root.
 
 ---
 
@@ -344,8 +344,7 @@ Most Batuda intelligence is external — the MCP client does the reasoning and g
 Every external capability is a role, not a vendor. Each is a port selected at boot by a `RESEARCH_PROVIDER_*` env var, with a comma-list fallback chain and a zero-cost stub for local dev. The roles:
 
 - **search** — web search (e.g. Firecrawl, Brave)
-- **scrape / extract** — fetch a page as markdown, or as structured JSON against a schema (Firecrawl)
-- **discover** — autonomous multi-page browsing (optional; disabled by default)
+- **scrape** — fetch a page as markdown, or as structured JSON against a schema (Firecrawl)
 - **enrich** — decision-maker name + email discovery for a company (Hunter)
 - **verify** — email deliverability, with a free DNS MX pre-gate in front of it (Hunter)
 - **registry** — company identity + officers, routed by country (libreBORME for Spain, Companies House for the UK)
@@ -392,7 +391,7 @@ Research owns a small set of tables, created together in the `research` migratio
 
 ### Quality — the eval harness
 
-A CLI eval measures the pipeline against a fixed golden set of companies whose correct answers are known, so a change to grounding or extraction shows up as a number rather than a guess. It reports grounding accuracy (did the run reach the target company's own site, or confirm it in a registry?), field precision and recall, and the wrong-company and empty rates — the look-alike failure the harness exists to catch. It runs on demand from the CLI, never in production, and can export each run's scores to the observability board.
+A CLI eval measures the pipeline against a fixed golden set of companies whose correct answers are known, so a change to grounding or extraction shows up as a number rather than a guess. It reports grounding accuracy (did the run reach the target company's own site, or confirm it in a registry?), field precision and recall, titled-contact recall (did it find the company's decision-makers?), and the wrong-company and empty rates — the look-alike failure the harness exists to catch. It runs on demand from the CLI, never in production, and can export each run's scores to the observability board.
 
 ### Observability
 


### PR DESCRIPTION
## What

Two research-reliability follow-ups to #286, on top of the merged #294:

1. **Prod extract model: `Qwen3-235B` → `gpt-oss-120b`** (`apps/server/config.production.json`) — a one-line fix for a live production recall bug.
2. **Architecture doc refresh** — corrects the research capability list (dropped the removed `extract`/`discover` roles) and adds titled-contact recall to the eval-metrics description.

## The prod bug (item 1)

Production runs the research **fact-extraction** step on Nebius's `Qwen/Qwen3-235B-A22B-Instruct-2507`. Qwen returns valid JSON but omits the per-field `source_id` citations the grounding guard requires, so the guard nulls nearly every field as ungrounded. The Fireworks `gpt-oss-120b` fallback only fires on an *error* — and source-id-less-but-valid output is not an error — so it never triggers. Net: **prod research field recall is ~5% right now.**

## Evidence — a controlled three-arm eval (20 companies × 3 runs, web-first)

| extract config | recall | empty | titled-contact | source-id drops | llm failures |
|---|---|---|---|---|---|
| A — Nebius `Qwen3-235B` | 5% | 60% | 0% | 459 | 0 |
| B — Fireworks `gpt-oss-120b` | 67% | 23% | 39% | 0 | 12 |
| **C — Nebius `gpt-oss-120b`** | **73%** | **13%** | **47%** | **0** | **2** |

Two single-variable comparisons isolate the cause:

- **A → C** (hold provider = Nebius, swap only the model Qwen → gpt-oss): recall **5% → 73%**, source-id drops **459 → 0** ⇒ it's the **model**.
- **B ↔ C** (hold model = gpt-oss, swap only the provider Fireworks ↔ Nebius): **67% ↔ 73%** ⇒ the provider barely matters.
- Grounding accuracy is the control: **85 / 83 / 85%** (within 2pp) ⇒ all three arms reached equivalent evidence, so the comparison is valid.

Nebius serving `gpt-oss-120b` is the **best** arm and the cheapest (no vendor switch, fewest transient failures). The Fireworks fallback stays `gpt-oss-120b`, so primary and fallback now run the same reliable model on two providers. Agent and writer tiers are unchanged — Arm C kept them at Nebius `Qwen3-32B` and still won; the source-id problem is extract-tier-only.

## Verification

The exact model id (`openai/gpt-oss-120b`) was run end-to-end through the real pipeline against the full 20-company golden set (Arm C) — a live eval pass, stronger than a smoke test. `config.production.json` parses; pre-commit check-types + lint green.

## Deploy

Config-only; it ships with the image and loads at boot, so it **needs a `/release server` deploy to take effect** — this PR does not deploy it.

Part of #286.
