### PR TITLE
feat(research): recover more company data and reject look-alike matches

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -907,8 +907,13 @@ const researchEvalCommand = Command.make(
 			Flag.withDescription('Write the full JSON report to this path'),
 			Flag.optional,
 		),
+		byBucket: Flag.boolean('by-bucket').pipe(
+			Flag.withDescription(
+				'Also print the metrics broken out by size/reach bucket and by country, so a regression in one segment is not averaged away',
+			),
+		),
 	},
-	({ org, user, golden, schema, language, concurrency, runs, out }) =>
+	({ org, user, golden, schema, language, concurrency, runs, out, byBucket }) =>
 		researchEval({
 			org,
 			user,
@@ -918,6 +923,7 @@ const researchEvalCommand = Command.make(
 			concurrency,
 			runs,
 			out,
+			byBucket,
 		}),
 ).pipe(
 	Command.withShortDescription(

--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -293,6 +293,27 @@ const formatSummary = (summary: EvalSummary): string =>
 		`Empty rate:             ${pct(summary.emptyRate)}`,
 	].join('\n')
 
+// One compact line per group (a bucket, a country), so a segment that regressed
+// stands out against the whole-set numbers above.
+const formatGroups = (
+	title: string,
+	groups: Record<string, EvalSummary>,
+): string =>
+	[
+		'',
+		`── ${title} ──`,
+		...Object.entries(groups)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(
+				([key, s]) =>
+					`${key.padEnd(10)} runs ${String(s.runs).padStart(3)}  ground ${pct(
+						s.groundingAccuracy,
+					)}  prec ${pct(s.fieldPrecision)}  recall ${pct(
+						s.fieldRecall,
+					)}  wrong ${pct(s.wrongCompanyRate)}  empty ${pct(s.emptyRate)}`,
+			),
+	].join('\n')
+
 /**
  * Run the golden set through the live research pipeline and report the four quality
  * metrics. This drives real runs (LLM + providers + DB), so it needs the research
@@ -308,6 +329,7 @@ export const researchEval = (opts: {
 	readonly concurrency: number
 	readonly runs: number
 	readonly out: Option.Option<string>
+	readonly byBucket: boolean
 }) =>
 	Effect.gen(function* () {
 		const raw = yield* Effect.tryPromise({
@@ -385,6 +407,10 @@ export const researchEval = (opts: {
 
 		const report = buildEvalReport(scores)
 		yield* Console.log(formatSummary(report.summary))
+		if (opts.byBucket) {
+			yield* Console.log(formatGroups('By bucket', report.byBucket))
+			yield* Console.log(formatGroups('By country', report.byCountry))
+		}
 		yield* Effect.annotateCurrentSpan(evalSummaryAttributes(report.summary))
 		yield* Option.match(opts.out, {
 			onNone: () => Effect.void,

--- a/eval/README.md
+++ b/eval/README.md
@@ -16,6 +16,8 @@ pnpm cli research eval --org <org-id> --user <user-id> --golden eval/golden.json
 
 `eval` prints the metrics — grounding accuracy, field precision, field recall, titled-contact recall, wrong-company rate, empty rate — and writes a full per-run report with `--out`.
 
+Add `--by-bucket` to also print those metrics broken out by the golden rows' size/reach `bucket` (big / small / niche) and by `country`, so a regression that only hits, say, niche companies or one country is visible instead of averaged into the whole-set numbers. The same per-bucket and per-country summaries are always written to the `--out` report as `byBucket` / `byCountry`, and each run's span carries `eval.bucket` / `eval.country` for grouping on the monitoring board.
+
 Titled-contact recall answers a gap the four scalar fields miss: of the people a company is known to publish, how many the run returned **with a title**. Contacts sit outside the scored field set, so a run can pass every field yet hand back the decision-makers with no title — the exact symptom this metric watches. It only appears (else `n/a`) for rows that list expected `contacts`.
 
 ## Reading a change that targets under-filling
@@ -57,6 +59,7 @@ A JSON array of rows. Copy `golden.example.json` to your own `golden.json` and r
   "expectedOutput": {
     "officialDomain": "company.com",
     "altDomains": ["a-registry-profile.example"],
+    "bucket": "small",
     "fields": { "industry": "…", "size_range": "…", "country": "…", "location": "…" },
     "contacts": ["Ada Lovelace", { "name": "Alan Turing" }]
   }
@@ -66,6 +69,7 @@ A JSON array of rows. Copy `golden.example.json` to your own `golden.json` and r
 - `query` — what the pipeline is asked to research (add the city for a generic name).
 - `officialDomain` — the company's own website host; the primary proof the run reached the target. **Required.**
 - `altDomains` — other hosts that also prove the target was reached (a registry profile, a known subsidiary). Optional.
+- `bucket` — the company's size/reach segment: `big` (a household name, easy to research), `small` (an SMB with a light web presence), or `niche` (a specialist with little third-party coverage, the hardest). Optional, but an unknown value is rejected loudly; drives the `--by-bucket` breakdown so a regression that hits only one segment is not averaged away.
 - `fields` — the known-correct values. Only these four keys are scored, and a misspelled key is rejected loudly. All optional — score only the fields you can verify.
 - `contacts` — people the company is known to publish, each a name string or a `{ "name": "…" }` object. They score titled-contact recall: how many came back with a title. Name matching folds accents and tolerates a middle name/initial, but it tokenizes on Latin letters — a name written only in a non-Latin script (CJK, Cyrillic, Greek, Arabic) won't match, so romanize it in the golden row. Optional; a fabricated name skews the metric exactly as a wrong field value does, so list only real, verifiable people. No `role` here — the metric checks that the run supplied *some* title, not which one.
 

--- a/eval/golden.example.json
+++ b/eval/golden.example.json
@@ -4,6 +4,7 @@
 		"query": "Brompton Bicycle, London",
 		"expectedOutput": {
 			"officialDomain": "brompton.com",
+			"bucket": "big",
 			"fields": {
 				"industry": "manufacturing",
 				"country": "GB",
@@ -17,6 +18,7 @@
 		"query": "Gymshark, Solihull",
 		"expectedOutput": {
 			"officialDomain": "gymshark.com",
+			"bucket": "big",
 			"fields": {
 				"industry": "retail",
 				"country": "GB",
@@ -30,6 +32,7 @@
 		"query": "Monzo Bank, London",
 		"expectedOutput": {
 			"officialDomain": "monzo.com",
+			"bucket": "big",
 			"fields": {
 				"industry": "services",
 				"country": "GB",
@@ -44,6 +47,7 @@
 		"expectedOutput": {
 			"officialDomain": "dyson.com",
 			"altDomains": ["dyson.co.uk"],
+			"bucket": "big",
 			"fields": {
 				"industry": "manufacturing",
 				"country": "GB",
@@ -58,6 +62,7 @@
 		"expectedOutput": {
 			"officialDomain": "jcb.com",
 			"altDomains": ["jcb.co.uk"],
+			"bucket": "big",
 			"fields": {
 				"industry": "manufacturing",
 				"country": "GB",
@@ -72,6 +77,7 @@
 		"expectedOutput": {
 			"officialDomain": "nandos.co.uk",
 			"altDomains": ["nandos.com"],
+			"bucket": "big",
 			"fields": {
 				"industry": "restaurants",
 				"country": "GB",
@@ -85,6 +91,7 @@
 		"expectedOutput": {
 			"officialDomain": "greggs.co.uk",
 			"altDomains": ["greggs.com"],
+			"bucket": "big",
 			"fields": {
 				"country": "GB",
 				"location": "Newcastle"
@@ -98,6 +105,7 @@
 		"expectedOutput": {
 			"officialDomain": "deliveroo.co.uk",
 			"altDomains": ["deliveroo.com"],
+			"bucket": "big",
 			"fields": {
 				"country": "GB",
 				"location": "London"
@@ -110,6 +118,7 @@
 		"expectedOutput": {
 			"officialDomain": "ocado.com",
 			"altDomains": ["ocadogroup.com", "ocado.co.uk"],
+			"bucket": "big",
 			"fields": {
 				"country": "GB",
 				"location": "Hatfield"
@@ -122,6 +131,7 @@
 		"query": "Enganches Aragón, Zaragoza",
 		"expectedOutput": {
 			"officialDomain": "enganchesaragon.com",
+			"bucket": "small",
 			"fields": {
 				"industry": "manufacturing",
 				"size_range": "51-200",
@@ -135,6 +145,7 @@
 		"query": "Cohitech, Balsareny",
 		"expectedOutput": {
 			"officialDomain": "cohitech.net",
+			"bucket": "small",
 			"fields": {
 				"industry": "manufacturing",
 				"size_range": "51-200",
@@ -148,6 +159,7 @@
 		"query": "Pronimetal, Alagón",
 		"expectedOutput": {
 			"officialDomain": "pronimetal.com",
+			"bucket": "small",
 			"fields": {
 				"industry": "manufacturing",
 				"size_range": "51-200",
@@ -161,6 +173,7 @@
 		"query": "PCEX Automotive, Alicante",
 		"expectedOutput": {
 			"officialDomain": "pcexautomotive.com",
+			"bucket": "small",
 			"fields": {
 				"industry": "distribution",
 				"size_range": "11-25",
@@ -175,6 +188,7 @@
 		"expectedOutput": {
 			"officialDomain": "canteralaponderosa.com",
 			"altDomains": ["ponderosa.es"],
+			"bucket": "niche",
 			"fields": {
 				"country": "ES",
 				"location": "Alcover"
@@ -186,6 +200,7 @@
 		"query": "Arrive Logistics, Austin",
 		"expectedOutput": {
 			"officialDomain": "arrivelogistics.com",
+			"bucket": "small",
 			"fields": {
 				"size_range": "51-200",
 				"country": "US",
@@ -199,6 +214,7 @@
 		"expectedOutput": {
 			"officialDomain": "ascentlogistics.com",
 			"altDomains": ["ascentgl.com"],
+			"bucket": "small",
 			"fields": {
 				"country": "US",
 				"location": "Belleville"
@@ -210,6 +226,7 @@
 		"query": "Europa Worldwide, Dartford",
 		"expectedOutput": {
 			"officialDomain": "europa-worldwide.com",
+			"bucket": "big",
 			"fields": {
 				"industry": "transport",
 				"country": "GB",
@@ -232,6 +249,7 @@
 		"query": "Lectra, Paris",
 		"expectedOutput": {
 			"officialDomain": "lectra.com",
+			"bucket": "niche",
 			"fields": {
 				"country": "FR",
 				"location": "Paris"
@@ -253,6 +271,7 @@
 		"query": "Beckhoff Automation, Verl",
 		"expectedOutput": {
 			"officialDomain": "beckhoff.com",
+			"bucket": "big",
 			"fields": {
 				"industry": "manufacturing",
 				"country": "DE",
@@ -267,6 +286,7 @@
 		"expectedOutput": {
 			"officialDomain": "vollrathcompany.com",
 			"altDomains": ["vollrathfoodservice.com"],
+			"bucket": "big",
 			"fields": {
 				"industry": "manufacturing",
 				"country": "US",

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	cityGate,
 	classifyEntityMatch,
 	classifyEntityMatchPerSource,
 	deriveAnchorHost,
@@ -10,6 +11,9 @@ import {
 	groundedSourceIds,
 	isConfirmedRegistryMatch,
 	parseQueryDomain,
+	placesCorroborate,
+	queryPlaces,
+	reachedOwnSite,
 	withRedirectDomain,
 } from './entity-guard'
 
@@ -113,6 +117,7 @@ describe('withRedirectDomain', () => {
 		cores: ['ascentgloballogistics'],
 		words: ['ascent'],
 		domains: ['ascentgl.com'],
+		places: [],
 	}
 
 	describe('when the anchor domain redirected to a new host', () => {
@@ -155,6 +160,7 @@ describe('classifyEntityMatch', () => {
 		cores: ['acmelogistics'],
 		words: ['acme'],
 		domains: ['acme.com'],
+		places: [],
 	}
 
 	describe('when the evidence names the target strongly', () => {
@@ -539,6 +545,201 @@ describe('domainHost', () => {
 			// GIVEN text with no dot, or too short to be a host
 			expect(domainHost('localhost')).toBeUndefined()
 			expect(domainHost('a.b')).toBeUndefined()
+		})
+	})
+})
+
+describe('queryPlaces', () => {
+	describe('when the query carries a "Name, City" tail', () => {
+		it('should keep the distinctive place words after the first comma', () => {
+			// GIVEN the convention "Company Name, City" in a free-text query
+			// WHEN the places are parsed
+			// THEN only the location tail is read, not the company name
+			expect(queryPlaces('Deliveroo, London')).toEqual(['london'])
+		})
+
+		it('should drop short tokens and generic administrative words', () => {
+			// GIVEN a location with a short state code and an admin word
+			// WHEN parsed
+			// THEN "st"/"mo" (too short) and "city" (generic) are dropped
+			expect(queryPlaces('Sunset Transportation, St. Louis MO')).toEqual([
+				'louis',
+			])
+			expect(queryPlaces('Acme, Kansas City')).toEqual(['kansas'])
+		})
+	})
+
+	describe('when a location hint is supplied', () => {
+		it('should fold the hint in alongside the query tail and dedupe', () => {
+			// GIVEN both a query tail and a separate location hint
+			// WHEN parsed
+			// THEN both contribute place words, with duplicates collapsed
+			expect(queryPlaces('Acme, Barcelona', 'Barcelona, Spain')).toEqual([
+				'barcelona',
+				'spain',
+			])
+		})
+	})
+
+	describe('when no location is present', () => {
+		it('should return empty for a bare name so the city check fails open', () => {
+			// GIVEN a plain company name with no comma and no hint
+			// WHEN parsed
+			// THEN there are no place words to require
+			expect(queryPlaces('Dyson')).toEqual([])
+		})
+	})
+})
+
+describe('placesCorroborate', () => {
+	const deliveroo: EntityTargets = {
+		cores: ['deliveroo'],
+		words: ['deliveroo'],
+		domains: [],
+		places: ['london'],
+	}
+
+	describe('when the evidence names the queried place', () => {
+		it('should return true regardless of case and punctuation', () => {
+			// GIVEN a corpus that mentions the queried city
+			// WHEN checked
+			// THEN the place corroborates (folding matches "London." to "london")
+			expect(placesCorroborate(deliveroo, 'Head office in London.')).toBe(true)
+		})
+	})
+
+	describe('when the evidence names a different place', () => {
+		it('should return false', () => {
+			// GIVEN a corpus that names only another city
+			expect(placesCorroborate(deliveroo, 'Now operating from New York')).toBe(
+				false,
+			)
+		})
+	})
+
+	describe('when no place was queried', () => {
+		it('should return false', () => {
+			// GIVEN targets with no place keys
+			// THEN there is nothing to corroborate
+			expect(placesCorroborate({ ...deliveroo, places: [] }, 'London')).toBe(
+				false,
+			)
+		})
+	})
+})
+
+describe('reachedOwnSite', () => {
+	const targets: EntityTargets = {
+		cores: ['deliveroo'],
+		words: ['deliveroo'],
+		domains: ['deliveroo.com'],
+		places: ['london'],
+	}
+
+	describe('when a fetched page is the company site', () => {
+		it('should return true for a page whose host is a target domain', () => {
+			// GIVEN a page fetched from the target's own domain
+			expect(reachedOwnSite(targets, [{ host: 'deliveroo.com' }])).toBe(true)
+		})
+
+		it('should return true for a page whose host label matches the name', () => {
+			// GIVEN a page on a country domain the caller never supplied
+			// THEN the "deliveroo" label still identifies the company's own site
+			expect(reachedOwnSite(targets, [{ host: 'deliveroo.co.uk' }])).toBe(true)
+		})
+	})
+
+	describe('when the fetched pages are all third-party', () => {
+		it('should return false for an unrelated host', () => {
+			// GIVEN only a page on a different company's domain
+			expect(reachedOwnSite(targets, [{ host: 'doordash.com' }])).toBe(false)
+		})
+
+		it('should return false for a page with no host', () => {
+			// GIVEN a corpus entry carrying no host (e.g. a tool result)
+			expect(reachedOwnSite(targets, [{ host: undefined }])).toBe(false)
+		})
+	})
+})
+
+describe('cityGate', () => {
+	const targets: EntityTargets = {
+		cores: ['deliveroo'],
+		words: ['deliveroo'],
+		domains: [],
+		places: ['london'],
+	}
+
+	describe('when a name-only match names no reachable site in the queried city', () => {
+		it('should downgrade so the run fails closed', () => {
+			// GIVEN the name appears on third-party pages, no own site was reached,
+			// no register confirmed it, and the queried city is absent
+			// WHEN the city gate runs
+			// THEN it downgrades — a lookalike or stale mention, not the target
+			expect(
+				cityGate({
+					targets,
+					corpus: 'Deliveroo was acquired; operations moved to New York.',
+					pages: [{ host: 'doordash.com' }],
+					registryConfirmed: false,
+				}),
+			).toBe('downgrade')
+		})
+	})
+
+	describe('when the queried city is corroborated', () => {
+		it('should keep the match', () => {
+			// GIVEN the evidence names both the company and the queried city
+			expect(
+				cityGate({
+					targets,
+					corpus: 'Deliveroo, headquartered in London.',
+					pages: [{ host: 'news.example.com' }],
+					registryConfirmed: false,
+				}),
+			).toBe('keep')
+		})
+	})
+
+	describe('when the run reached the company own site', () => {
+		it('should keep even if the city is not spelled out', () => {
+			// GIVEN a page on the company's own domain (the homepage rarely names its city)
+			expect(
+				cityGate({
+					targets,
+					corpus: 'Deliveroo — order food you love.',
+					pages: [{ host: 'deliveroo.co.uk' }],
+					registryConfirmed: false,
+				}),
+			).toBe('keep')
+		})
+	})
+
+	describe('when a register confirmed the company', () => {
+		it('should keep regardless of the city', () => {
+			// GIVEN a registry lookup confirmed the legal entity
+			expect(
+				cityGate({
+					targets,
+					corpus: 'Deliveroo mentioned in a directory.',
+					pages: [{ host: 'directory.example.com' }],
+					registryConfirmed: true,
+				}),
+			).toBe('keep')
+		})
+	})
+
+	describe('when no city was queried', () => {
+		it('should keep so a location-less query is never tightened', () => {
+			// GIVEN targets with no place keys (the caller gave only a name)
+			expect(
+				cityGate({
+					targets: { ...targets, places: [] },
+					corpus: 'Deliveroo somewhere.',
+					pages: [{ host: 'doordash.com' }],
+					registryConfirmed: false,
+				}),
+			).toBe('keep')
 		})
 	})
 })

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -173,6 +173,44 @@ const QUOTED_NAME = /["“]([^"”]{2,80})["”]/
 const queryName = (query: string): string =>
 	query.match(QUOTED_NAME)?.[1] ?? query.split(',')[0] ?? query
 
+// Administrative words that name no particular place — dropped so only the
+// distinctive part of a location ("louis" from "St. Louis city") is kept.
+const GEO_STOPWORDS = new Set([
+	'city',
+	'town',
+	'area',
+	'region',
+	'province',
+	'county',
+	'district',
+	'greater',
+	'metropolitan',
+])
+
+// The part of a free-text query after the first comma, where the convention
+// "Company Name, City" puts the location ("St. Louis MO" from
+// "Sunset Transportation, St. Louis MO"); empty when the query has no comma.
+const queryTail = (query: string): string => {
+	const comma = query.indexOf(',')
+	return comma >= 0 ? query.slice(comma + 1) : ''
+}
+
+// The distinctive place words a caller supplied — the query's post-comma tail
+// plus any location hint — each ≥4 chars and not a generic administrative word.
+// These let a run tell "the target, in the queried city" from a same-named
+// company (or a stale mention) somewhere else. Empty when no location was given,
+// which is what makes the city check below fail open.
+export const queryPlaces = (
+	query: string,
+	location?: string | undefined,
+): ReadonlyArray<string> => [
+	...new Set(
+		foldTokens(`${queryTail(query)} ${location ?? ''}`).filter(
+			t => t.length >= 4 && !GEO_STOPWORDS.has(t),
+		),
+	),
+]
+
 // A domain-shaped token inside free text: one or more dot-separated labels then a
 // 2–24 letter top-level part. The letters-only tail keeps decimals ("3.5") and
 // abbreviations ("e.g", "U.S.A") from matching.
@@ -200,6 +238,9 @@ export interface EntityTargets {
 	readonly words: ReadonlyArray<string>
 	/** Registrable hosts — strong-match keys (checked against the raw corpus). */
 	readonly domains: ReadonlyArray<string>
+	/** Distinctive place words from the query/location — corroboration keys used
+	 * only to fail closed when a name-only match names no reachable official site. */
+	readonly places: ReadonlyArray<string>
 }
 
 // Only these schemas make a claim about their OWN named subject. A scan playbook
@@ -233,6 +274,9 @@ export const deriveEntityTargets = (args: {
 	 * website was null or wrong. An unparseable value is ignored.
 	 */
 	anchorDomain?: string | undefined
+	/** The run's location hint, folded into the place keys alongside the query's
+	 * own "…, City" tail. */
+	location?: string | undefined
 }): EntityTargets | null => {
 	const anchored = args.subjects.length > 0
 	if (!isEntityGroundedSchema(args.schemaName) && !anchored) return null
@@ -268,7 +312,8 @@ export const deriveEntityTargets = (args: {
 
 	if (cores.length === 0 && words.length === 0 && domains.length === 0)
 		return null
-	return { cores, words, domains }
+	const places = queryPlaces(args.query, args.location)
+	return { cores, words, domains, places }
 }
 
 /**
@@ -291,6 +336,7 @@ export const withRedirectDomain = (
 			label != null && !targets.words.includes(label)
 				? [...targets.words, label]
 				: targets.words,
+		places: targets.places,
 	}
 }
 
@@ -343,6 +389,63 @@ export const classifyEntityMatch = (
 	// the run never clearly landed on it.
 	const weak = targets.words.some(word => collapsed.includes(word))
 	return weak ? 'weak' : 'absent'
+}
+
+/** Whether the evidence mentions any of the queried location's distinctive place
+ * words — the queried company "in that city", not a same-named company elsewhere.
+ * Always false when no location was supplied, so the city check fails open. */
+export const placesCorroborate = (
+	targets: EntityTargets,
+	corpus: string,
+): boolean => {
+	if (targets.places.length === 0) return false
+	const collapsed = collapse(corpus)
+	return targets.places.some(place => collapsed.includes(place))
+}
+
+/** Whether the run actually reached the company's own site — a fetched page whose
+ * host is a target domain, or whose registrable label is (part of) the company's
+ * name. A name written only on third-party pages (news, directories) is not an
+ * own-site reach. */
+export const reachedOwnSite = (
+	targets: EntityTargets,
+	pages: ReadonlyArray<{ readonly host?: string | undefined }>,
+): boolean =>
+	pages.some(page => {
+		if (page.host === undefined) return false
+		if (targets.domains.includes(page.host)) return true
+		const label = domainLabelOf(page.host)
+		if (label === undefined) return false
+		const folded = collapse(label)
+		return (
+			targets.words.includes(label) ||
+			targets.cores.some(core => core.includes(folded) || folded.includes(core))
+		)
+	})
+
+/**
+ * Tightens a name-only strong match with the queried location. A page that merely
+ * spells the company name reads as 'strong' even when it is about a different
+ * company sharing the name, or a stale mention of one that has since been renamed
+ * or acquired. When the caller gave a city, the run reached no official site, and
+ * no register confirmed the company, require that city to appear in the evidence
+ * too — otherwise downgrade so the run fails closed rather than shipping a
+ * lookalike's profile. Fails open (keeps) whenever a city was not supplied, an
+ * own site was reached, or a register confirmed the match, so it never costs a
+ * genuinely-grounded run.
+ */
+export const cityGate = (args: {
+	targets: EntityTargets
+	corpus: string
+	pages: ReadonlyArray<{ readonly host?: string | undefined }>
+	registryConfirmed: boolean
+}): 'keep' | 'downgrade' => {
+	const { targets, corpus, pages, registryConfirmed } = args
+	if (targets.places.length === 0) return 'keep'
+	if (registryConfirmed) return 'keep'
+	if (reachedOwnSite(targets, pages)) return 'keep'
+	if (placesCorroborate(targets, corpus)) return 'keep'
+	return 'downgrade'
 }
 
 /**

--- a/packages/research/src/application/eval-golden.test.ts
+++ b/packages/research/src/application/eval-golden.test.ts
@@ -259,3 +259,46 @@ describe('parseGoldenSet', () => {
 		})
 	})
 })
+
+describe('parseGoldenRow — bucket', () => {
+	describe('when the expected output carries a known bucket', () => {
+		it('should carry it through onto the expectation', () => {
+			// GIVEN an answer tagged with a valid size/reach bucket
+			const result = parseGoldenRow(
+				row({ expectedOutput: { officialDomain: 'acme.es', bucket: 'niche' } }),
+			)
+			// WHEN parsed — THEN the bucket is on the expectation
+			expect(result).toEqual({
+				ok: true,
+				value: {
+					id: 'acme',
+					query: 'Acme Logistics, Barcelona',
+					officialDomain: 'acme.es',
+					fields: {},
+					bucket: 'niche',
+				},
+			})
+		})
+	})
+
+	describe('when the bucket is not a known value', () => {
+		it('should reject the row loudly, like any other typo', () => {
+			// GIVEN an answer tagged with a bucket that is not big/small/niche
+			const result = parseGoldenRow(
+				row({ expectedOutput: { officialDomain: 'acme.es', bucket: 'huge' } }),
+			)
+			// WHEN parsed — THEN it fails rather than silently ignoring the tag
+			expect(result.ok).toBe(false)
+		})
+	})
+
+	describe('when no bucket is given', () => {
+		it('should omit the bucket key entirely', () => {
+			// GIVEN an untagged row
+			const result = parseGoldenRow(row({}))
+			// WHEN parsed — THEN there is no bucket key (not an undefined one)
+			expect(result.ok).toBe(true)
+			if (result.ok) expect('bucket' in result.value).toBe(false)
+		})
+	})
+})

--- a/packages/research/src/application/eval-golden.ts
+++ b/packages/research/src/application/eval-golden.ts
@@ -12,6 +12,8 @@
  */
 
 import {
+	GOLDEN_BUCKETS,
+	type GoldenBucket,
 	type GoldenExpectation,
 	SCORABLE_FIELDS,
 	type ScorableField,
@@ -117,6 +119,19 @@ export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 		}
 	}
 
+	// Size/reach bucket, so the harness can report quality per segment. Optional,
+	// but a value that is not a known bucket fails loudly like any other typo.
+	const rawBucket = answer['bucket']
+	if (
+		rawBucket !== undefined &&
+		!GOLDEN_BUCKETS.includes(rawBucket as GoldenBucket)
+	) {
+		return {
+			ok: false,
+			error: `unknown bucket "${String(rawBucket)}" (allowed: ${GOLDEN_BUCKETS.join(', ')})`,
+		}
+	}
+
 	return {
 		ok: true,
 		value: {
@@ -126,6 +141,7 @@ export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 			...(rawAltDomains !== undefined ? { altDomains: rawAltDomains } : {}),
 			fields,
 			...(contacts.length > 0 ? { contacts } : {}),
+			...(rawBucket !== undefined ? { bucket: rawBucket as GoldenBucket } : {}),
 		},
 	}
 }

--- a/packages/research/src/application/eval-report.test.ts
+++ b/packages/research/src/application/eval-report.test.ts
@@ -208,4 +208,30 @@ describe('buildEvalReport', () => {
 			expect(report.runs).toHaveLength(2)
 		})
 	})
+
+	describe('when the scores carry buckets and countries', () => {
+		it('should break the summary out by bucket and by country', () => {
+			// GIVEN a grounded big/GB run and an empty niche/FR run
+			const runs = [
+				score({ bucket: 'big', country: 'GB', grounded: true }),
+				score({ bucket: 'niche', country: 'FR', grounded: false, empty: true }),
+			]
+			// WHEN a report is built
+			const report = buildEvalReport(runs)
+			// THEN each segment is summarized on its own
+			expect(Object.keys(report.byBucket).sort()).toEqual(['big', 'niche'])
+			expect(Object.keys(report.byCountry).sort()).toEqual(['FR', 'GB'])
+			expect(report.byBucket['big']?.groundingAccuracy).toBe(1)
+			expect(report.byBucket['niche']?.emptyRate).toBe(1)
+		})
+
+		it('should bucket untagged and country-less scores under fallback keys', () => {
+			// GIVEN a score with neither a bucket nor a country
+			const report = buildEvalReport([score({})])
+			// WHEN a report is built
+			// THEN it falls into the explicit fallback groups, never dropped
+			expect(Object.keys(report.byBucket)).toEqual(['untagged'])
+			expect(Object.keys(report.byCountry)).toEqual(['unknown'])
+		})
+	})
 })

--- a/packages/research/src/application/eval-report.ts
+++ b/packages/research/src/application/eval-report.ts
@@ -10,6 +10,7 @@
 
 import {
 	type EvalSummary,
+	groupSummaries,
 	type RunScore,
 	summarizeScores,
 } from './eval-scoring'
@@ -90,10 +91,14 @@ export const scorePayloadsForRun = (score: RunScore): ScorePayload[] => {
 	return payloads
 }
 
-/** The offline baseline report: the aggregate rates plus every run's raw score. */
+/** The offline baseline report: the aggregate rates plus every run's raw score,
+ * and the same rates broken out by size/reach bucket and by country so a
+ * regression confined to one segment is visible rather than averaged away. */
 export interface EvalReport {
 	readonly summary: EvalSummary
 	readonly runs: ReadonlyArray<RunScore>
+	readonly byBucket: Record<string, EvalSummary>
+	readonly byCountry: Record<string, EvalSummary>
 }
 
 export const buildEvalReport = (
@@ -101,6 +106,8 @@ export const buildEvalReport = (
 ): EvalReport => ({
 	summary: summarizeScores(scores),
 	runs: scores,
+	byBucket: groupSummaries(scores, score => score.bucket ?? 'untagged'),
+	byCountry: groupSummaries(scores, score => score.country ?? 'unknown'),
 })
 
 /**
@@ -124,6 +131,8 @@ export const evalSpanAttributes = (
 		'eval.contacts_expected': score.contactsExpected,
 		'eval.contacts_found': score.contactsFound,
 	}
+	if (score.bucket !== undefined) attributes['eval.bucket'] = score.bucket
+	if (score.country !== undefined) attributes['eval.country'] = score.country
 	if (score.fieldsScored > 0) {
 		attributes['eval.field_precision'] =
 			score.fieldsCorrect / score.fieldsScored

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	type GoldenExpectation,
+	groupSummaries,
 	type RunOutcome,
 	type RunScore,
 	scoreRun,
@@ -556,6 +557,60 @@ describe('summarizeScores', () => {
 
 			// WHEN summarized — THEN there was nothing to recall, so the rate is absent
 			expect(summary.contactRecall).toBeNull()
+		})
+	})
+})
+
+describe('scoreRun — bucket and country', () => {
+	describe('when the golden row is tagged with a bucket', () => {
+		it('should carry the bucket and expected country onto the score', () => {
+			// GIVEN a golden row tagged niche (its country is ES)
+			const result = scoreRun({ ...acme, bucket: 'niche' }, outcome({}))
+			// WHEN scored — THEN both are carried through for grouping
+			expect(result.bucket).toBe('niche')
+			expect(result.country).toBe('ES')
+		})
+	})
+
+	describe('when the golden row has no bucket', () => {
+		it('should leave the bucket undefined', () => {
+			// GIVEN an untagged golden row
+			const result = scoreRun(acme, outcome({}))
+			// WHEN scored — THEN there is no bucket, but the country still rides along
+			expect(result.bucket).toBeUndefined()
+			expect(result.country).toBe('ES')
+		})
+	})
+})
+
+describe('groupSummaries', () => {
+	describe('when scores span several buckets', () => {
+		it('should summarize each bucket independently', () => {
+			// GIVEN a grounded big-bucket run and an empty niche-bucket run
+			const scores: RunScore[] = [
+				scoreRun(
+					{ ...acme, bucket: 'big' },
+					outcome({
+						reachedDomains: ['acme.es'],
+						fields: { industry: 'transport' },
+					}),
+				),
+				scoreRun(
+					{ ...acme, id: 'other', bucket: 'niche' },
+					outcome({
+						status: 'no_reliable_data',
+						reachedDomains: [],
+						fields: {},
+					}),
+				),
+			]
+			// WHEN grouped by bucket
+			const byBucket = groupSummaries(scores, s => s.bucket ?? 'untagged')
+			// THEN each bucket is summarized on its own
+			expect(Object.keys(byBucket).sort()).toEqual(['big', 'niche'])
+			expect(byBucket['big']?.runs).toBe(1)
+			expect(byBucket['big']?.emptyRate).toBe(0)
+			expect(byBucket['niche']?.emptyRate).toBe(1)
 		})
 	})
 })

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -40,6 +40,17 @@ export const SCORABLE_FIELDS = [
 
 export type ScorableField = (typeof SCORABLE_FIELDS)[number]
 
+/**
+ * Size/reach buckets a golden company can be tagged with, so a regression that
+ * hits only one segment (a niche or small company, the hardest to research) shows
+ * up in a per-bucket breakdown instead of being averaged away. `big` = a
+ * household name; `small` = an SMB with a light web presence; `niche` = a
+ * specialist with little third-party coverage.
+ */
+export const GOLDEN_BUCKETS = ['big', 'small', 'niche'] as const
+
+export type GoldenBucket = (typeof GOLDEN_BUCKETS)[number]
+
 /** The run outcomes that end a run; a run in any of these is what the eval scores. */
 export type TerminalStatus =
 	| 'succeeded'
@@ -65,6 +76,8 @@ export interface GoldenExpectation {
 	/** People the company is known to publish; scores whether the run recovered them
 	 * *with a title* — the recall the focused contacts pass exists to lift. */
 	readonly contacts?: ReadonlyArray<{ readonly name: string }>
+	/** Size/reach segment, so quality can be reported per bucket, not just overall. */
+	readonly bucket?: GoldenBucket
 }
 
 /**
@@ -113,6 +126,10 @@ export interface RunScore {
 	readonly contactsExpected: number
 	/** Of those, how many the run returned *with a title* (contact recall's numerator). */
 	readonly contactsFound: number
+	/** The golden row's size/reach bucket, carried through so scores can be grouped. */
+	readonly bucket?: GoldenBucket
+	/** The golden row's expected country (ISO alpha-2), for a by-country breakdown. */
+	readonly country?: string
 }
 
 export interface EvalSummary {
@@ -438,6 +455,10 @@ export const scoreRun = (
 		fieldsCorrect,
 		contactsExpected: expectedContacts.length,
 		contactsFound,
+		...(expected.bucket !== undefined ? { bucket: expected.bucket } : {}),
+		...(expected.fields.country !== undefined
+			? { country: expected.fields.country }
+			: {}),
 	}
 }
 
@@ -489,4 +510,27 @@ export const summarizeScores = (
 				? null
 				: totalContactsFound / totalContactsExpected,
 	}
+}
+
+/**
+ * Group scores by a key (a bucket, a country) and summarize each group, so a
+ * regression confined to one segment is visible instead of averaged into the
+ * whole-set numbers. Keys are returned in first-seen order.
+ */
+export const groupSummaries = (
+	scores: ReadonlyArray<RunScore>,
+	keyOf: (score: RunScore) => string,
+): Record<string, EvalSummary> => {
+	const groups = new Map<string, RunScore[]>()
+	for (const score of scores) {
+		const key = keyOf(score)
+		const group = groups.get(key)
+		if (group) group.push(score)
+		else groups.set(key, [score])
+	}
+	const summaries: Record<string, EvalSummary> = {}
+	for (const [key, group] of groups) {
+		summaries[key] = summarizeScores(group)
+	}
+	return summaries
 }

--- a/packages/research/src/application/generic-emails.test.ts
+++ b/packages/research/src/application/generic-emails.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { harvestGenericEmails } from './generic-emails'
+
+describe('harvestGenericEmails', () => {
+	describe('when a role mailbox is published on the company own domain', () => {
+		it('should capture it with the page host and the line as the quote', () => {
+			// GIVEN the company's contact page listing a role address on its own domain
+			const pages = [{ text: 'Contact us: info@acme.com', host: 'acme.com' }]
+			// WHEN harvested against the company's own hosts
+			const found = harvestGenericEmails(pages, ['acme.com'])
+			// THEN the address is captured, grounded to the page it was read from
+			expect(found).toEqual([
+				{
+					value: 'info@acme.com',
+					source_id: 'acme.com',
+					quote: 'Contact us: info@acme.com',
+				},
+			])
+		})
+
+		it('should match a subdomain of an own host', () => {
+			// GIVEN a role address on a mail subdomain of the company
+			const pages = [{ text: 'sales@mail.acme.com', host: 'acme.com' }]
+			// WHEN harvested
+			const found = harvestGenericEmails(pages, ['acme.com'])
+			// THEN a subdomain of an own host still counts as the company's
+			expect(found.map(e => e.value)).toEqual(['sales@mail.acme.com'])
+		})
+	})
+
+	describe('when the address is not a company role mailbox', () => {
+		it('should drop a personal address (a name, not a role)', () => {
+			// GIVEN a named person's address on the company site
+			const pages = [{ text: 'john.smith@acme.com', host: 'acme.com' }]
+			// WHEN harvested
+			// THEN only shared role mailboxes are captured, never a person
+			expect(harvestGenericEmails(pages, ['acme.com'])).toEqual([])
+		})
+
+		it('should drop a role address at a different domain (a testimonial)', () => {
+			// GIVEN a supplier's role address quoted on the company's page
+			const pages = [
+				{ text: '"Great partner" — info@supplier.com', host: 'acme.com' },
+			]
+			// WHEN harvested against the company's own hosts
+			// THEN an address that is not at a company domain is ignored
+			expect(harvestGenericEmails(pages, ['acme.com'])).toEqual([])
+		})
+	})
+
+	describe('when several role mailboxes are published', () => {
+		it('should de-duplicate and order by role preference', () => {
+			// GIVEN press, sales, and contact addresses across two fetched pages
+			const pages = [
+				{ text: 'press@acme.com and sales@acme.com', host: 'acme.com' },
+				{
+					text: 'General: contact@acme.com (also sales@acme.com)',
+					host: 'acme.com',
+				},
+			]
+			// WHEN harvested
+			const found = harvestGenericEmails(pages, ['acme.com'])
+			// THEN each address appears once, general contact first, press last
+			expect(found.map(e => e.value)).toEqual([
+				'contact@acme.com',
+				'sales@acme.com',
+				'press@acme.com',
+			])
+		})
+	})
+
+	describe('when there is nothing to capture', () => {
+		it('should return empty for pages with no addresses', () => {
+			// GIVEN a page with no email at all
+			expect(
+				harvestGenericEmails(
+					[{ text: 'No contact details here.' }],
+					['acme.com'],
+				),
+			).toEqual([])
+		})
+
+		it('should return empty when no company hosts are known', () => {
+			// GIVEN a role address but no own hosts to match against
+			// WHEN harvested with an empty host list
+			// THEN nothing can be trusted as the company's, so nothing is captured
+			expect(
+				harvestGenericEmails([{ text: 'info@acme.com', host: 'acme.com' }], []),
+			).toEqual([])
+		})
+	})
+})

--- a/packages/research/src/application/generic-emails.ts
+++ b/packages/research/src/application/generic-emails.ts
@@ -1,0 +1,123 @@
+/**
+ * Harvests a company's published role-based inboxes — `info@`, `sales@`,
+ * `press@`, `hola@` — from the pages the run fetched.
+ *
+ * For a thin-web small or niche company that lists no named executive, a
+ * department mailbox printed on its contact page is often the only actionable way
+ * to reach it. Nothing else in the pipeline captures these: the email steps only
+ * guess a *person's* address and verify it, and the value guard only ever strips
+ * an invented email — it never harvests a real one.
+ *
+ * The capture is deliberately conservative, so it can never invent an address:
+ *  - the local part must be a known role word (not a person's name);
+ *  - the domain must belong to the company (a target domain, or the host of a
+ *    page that is the company's own site) — so a supplier's `info@` quoted in a
+ *    testimonial, or a directory's own mailbox, is ignored;
+ *  - the address is read verbatim from a fetched page, with the line it sat on
+ *    kept as the quote, so it is grounded by construction.
+ */
+
+// Role / department local parts across the languages the pipeline researches in.
+// A person's name is never in this list, so only shared mailboxes are captured.
+const ROLE_LOCALPARTS = new Set([
+	'info',
+	'contact',
+	'contacto',
+	'contacte',
+	'sales',
+	'press',
+	'media',
+	'hello',
+	'hola',
+	'support',
+	'office',
+	'admin',
+	'enquiries',
+])
+
+// Preference order when several role mailboxes are published: a general contact
+// address first, then a sales one, then press/media, then the rest.
+const PRIORITY: ReadonlyArray<string> = [
+	'contact',
+	'contacto',
+	'contacte',
+	'info',
+	'hola',
+	'hello',
+	'sales',
+	'press',
+	'media',
+	'support',
+	'office',
+	'admin',
+	'enquiries',
+]
+
+const rankOf = (localPart: string): number => {
+	const index = PRIORITY.indexOf(localPart)
+	return index === -1 ? PRIORITY.length : index
+}
+
+// A plain email, restrictive enough that markdown link syntax around an address
+// ("[info@acme.com](mailto:…)") yields the bare address, not the punctuation.
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi
+
+// The address's domain belongs to the company when it is one of the company's own
+// hosts, or a subdomain of one.
+const domainIsOwn = (
+	domain: string,
+	ownHosts: ReadonlyArray<string>,
+): boolean =>
+	ownHosts.some(host => domain === host || domain.endsWith(`.${host}`))
+
+export interface GenericEmail {
+	/** The role address, lower-cased. */
+	readonly value: string
+	/** The host of the page it was read from — where the value is grounded. */
+	readonly source_id: string
+	/** The line the address sat on, so the capture is auditable. */
+	readonly quote: string
+}
+
+/**
+ * Scan the fetched pages for the company's published role mailboxes.
+ *
+ * `ownHosts` are the company's own domains (target domains plus the hosts of its
+ * own-site pages); an address is kept only when its domain is one of them.
+ * Results are de-duplicated and ordered by role preference, so the first is the
+ * best general contact address.
+ */
+export const harvestGenericEmails = (
+	pages: ReadonlyArray<{
+		readonly text: string
+		readonly host?: string | undefined
+	}>,
+	ownHosts: ReadonlyArray<string>,
+): ReadonlyArray<GenericEmail> => {
+	if (ownHosts.length === 0) return []
+	const seen = new Set<string>()
+	const found: Array<GenericEmail & { readonly rank: number }> = []
+	for (const page of pages) {
+		for (const line of page.text.split(/\r?\n/)) {
+			for (const raw of line.match(EMAIL_RE) ?? []) {
+				const email = raw.toLowerCase()
+				const at = email.indexOf('@')
+				const localPart = email.slice(0, at).split('+')[0] ?? ''
+				const domain = email.slice(at + 1)
+				if (!ROLE_LOCALPARTS.has(localPart)) continue
+				if (!domainIsOwn(domain, ownHosts)) continue
+				if (seen.has(email)) continue
+				seen.add(email)
+				found.push({
+					value: email,
+					source_id: page.host ?? domain,
+					quote: line.trim().slice(0, 200),
+					rank: rankOf(localPart),
+				})
+			}
+		}
+	}
+	return found
+		.sort((a, b) => a.rank - b.rank)
+		.map(({ rank: _rank, ...email }) => email)
+}

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	HIGH_VALUE_FIELDS,
+	mergePerFieldSearch,
+	needsPerFieldSearch,
+	perFieldSearchQuery,
+} from './per-field-search'
+
+// A per-field-citation value the way the enrichment schema stores one.
+const sourced = (value: string) => ({ value, source_id: 'https://x.test' })
+
+describe('needsPerFieldSearch', () => {
+	describe('when every high-value field is already filled', () => {
+		it('should return no fields to search', () => {
+			// GIVEN findings whose country/industry/location/size_range all carry a value
+			const findings = {
+				enrichment: {
+					country: sourced('ES'),
+					industry: sourced('manufacturing'),
+					location: sourced('Barcelona'),
+					size_range: sourced('51-200'),
+				},
+			}
+			// WHEN the still-empty high-value fields are computed
+			// THEN there is nothing to search for
+			expect(needsPerFieldSearch(findings)).toEqual([])
+		})
+	})
+
+	describe('when some high-value fields are empty', () => {
+		it('should return only the empty ones, in HIGH_VALUE_FIELDS order', () => {
+			// GIVEN industry + size_range filled, country + location empty
+			const findings = {
+				enrichment: {
+					industry: sourced('manufacturing'),
+					size_range: sourced('51-200'),
+					country: { value: null },
+				},
+			}
+			// WHEN computed
+			// THEN the two empty high-value fields come back in a stable order
+			expect(needsPerFieldSearch(findings)).toEqual(['country', 'location'])
+		})
+
+		it('should ignore non-high-value fields that are empty', () => {
+			// GIVEN the high-value four filled but pain_points/current_tools empty
+			const findings = {
+				enrichment: {
+					country: sourced('GB'),
+					industry: sourced('retail'),
+					location: sourced('London'),
+					size_range: sourced('1000+'),
+				},
+			}
+			// WHEN computed
+			// THEN only high-value fields are ever searched, so nothing is returned
+			expect(needsPerFieldSearch(findings)).toEqual([])
+		})
+	})
+
+	describe('when findings have no enrichment block', () => {
+		it('should return all high-value fields', () => {
+			// GIVEN a degenerate findings object with nothing filled
+			// WHEN computed
+			// THEN every high-value field is a search candidate
+			expect(needsPerFieldSearch({})).toEqual([...HIGH_VALUE_FIELDS])
+			expect(needsPerFieldSearch(null)).toEqual([...HIGH_VALUE_FIELDS])
+		})
+	})
+})
+
+describe('perFieldSearchQuery', () => {
+	describe('when a city was queried', () => {
+		it('should quote the name and include the city and the field intent', () => {
+			// GIVEN a company name, a city, and the size field
+			// WHEN the query is built
+			// THEN it phrases a focused search
+			expect(perFieldSearchQuery('Acme Corp', 'Barcelona', 'size_range')).toBe(
+				'"Acme Corp" Barcelona number of employees',
+			)
+		})
+	})
+
+	describe('when no city was queried', () => {
+		it('should omit the city and trim the name', () => {
+			// GIVEN a padded name, no city, and the country field
+			expect(perFieldSearchQuery('  Acme Corp  ', undefined, 'country')).toBe(
+				'"Acme Corp" head office country',
+			)
+		})
+	})
+
+	describe('when the field has no known intent', () => {
+		it('should fall back to the raw field name', () => {
+			// GIVEN a field with no phrasing mapped
+			expect(perFieldSearchQuery('Acme', undefined, 'pain_points')).toBe(
+				'"Acme" pain_points',
+			)
+		})
+	})
+})
+
+describe('mergePerFieldSearch', () => {
+	describe('when the re-extraction recovered an empty field', () => {
+		it('should fill only the empty high-value fields and count them', () => {
+			// GIVEN findings with country empty and industry already grounded
+			const findings = {
+				enrichment: {
+					industry: sourced('manufacturing'),
+					country: { value: null },
+				},
+			}
+			// AND a refreshed extraction that now carries a country and a different industry
+			const refreshed = {
+				enrichment: {
+					industry: sourced('logistics'),
+					country: sourced('ES'),
+				},
+			}
+			// WHEN merged
+			const { findings: next, filled } = mergePerFieldSearch(
+				findings,
+				refreshed,
+			)
+			// THEN the empty country is filled but the grounded industry is untouched
+			expect(filled).toBe(1)
+			const enrichment = (next as { enrichment: Record<string, unknown> })
+				.enrichment
+			expect(enrichment['country']).toEqual(sourced('ES'))
+			expect(enrichment['industry']).toEqual(sourced('manufacturing'))
+		})
+	})
+
+	describe('when the re-extraction recovered nothing', () => {
+		it('should return the findings unchanged with a zero count', () => {
+			// GIVEN findings with country already filled
+			const findings = { enrichment: { country: sourced('ES') } }
+			// AND a refreshed extraction with no enrichment block
+			// WHEN merged
+			const { findings: next, filled } = mergePerFieldSearch(findings, {})
+			// THEN nothing is filled and the same findings come back
+			expect(filled).toBe(0)
+			expect(next).toBe(findings)
+		})
+	})
+})

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -1,0 +1,111 @@
+/**
+ * A last-resort recovery for the high-value firmographics the broad pass and the
+ * focused rescues both left empty.
+ *
+ * The rescues re-read the evidence the run already gathered; this step goes
+ * further and fetches new evidence: for each still-empty high-value field it
+ * fires one focused web search, so a fact that was simply not on any page the run
+ * reached (a company's headquarters country, its sector, its city, its size) still
+ * has a chance to be found. It fires only for fields that are still blank and is
+ * capped, so a complete run pays nothing and an all-empty one cannot loop.
+ *
+ * This module is the pure part — which fields to search for and the query to fire.
+ * The search, source linking, and re-extraction happen in the research service,
+ * where a recovered value passes the same grounding guards as any other.
+ */
+
+import { enrichmentFill } from './extraction-fill'
+
+// The firmographic scalars worth spending an extra search on. `size_range` is also
+// nudged during the loop (headcount is rarely on the homepage); the other three
+// have no search-backed recovery until now, so an empty one simply stayed empty.
+export const HIGH_VALUE_FIELDS: ReadonlyArray<string> = [
+	'country',
+	'industry',
+	'location',
+	'size_range',
+]
+
+// At most this many extra searches per run: an all-empty profile would otherwise
+// fire one per field. Any missing field beyond the cap is left for the operator to
+// see in the fill telemetry rather than silently searched.
+export const MAX_PER_FIELD_SEARCHES = 3
+
+/** The still-empty high-value fields, in a stable order — the ones a per-field
+ * search should try to recover. Empty when the profile is already complete. */
+export const needsPerFieldSearch = (
+	findings: unknown,
+): ReadonlyArray<string> => {
+	const missing = new Set(enrichmentFill(findings).missing)
+	return HIGH_VALUE_FIELDS.filter(field => missing.has(field))
+}
+
+// A short, human-readable label per field, used to phrase the search.
+const FIELD_INTENT: Record<string, string> = {
+	country: 'head office country',
+	industry: 'industry sector',
+	location: 'headquarters city address',
+	size_range: 'number of employees',
+}
+
+/**
+ * A focused web-search query for one missing field: the company name (quoted so
+ * search treats it as a phrase), the city if one was queried, and the fact wanted.
+ * Example: `"Acme Corp" Barcelona number of employees`.
+ */
+export const perFieldSearchQuery = (
+	name: string,
+	city: string | undefined,
+	field: string,
+): string => {
+	const intent = FIELD_INTENT[field] ?? field
+	const cityPart = city && city.trim() !== '' ? ` ${city.trim()}` : ''
+	return `"${name.trim()}"${cityPart} ${intent}`
+}
+
+// A field is present only when it carries a non-empty string value; a missing key
+// or a `{ value: null }` a guard blanked still counts as empty.
+const hasValue = (fieldValue: unknown): boolean =>
+	fieldValue !== null &&
+	typeof fieldValue === 'object' &&
+	typeof (fieldValue as { value?: unknown }).value === 'string' &&
+	(fieldValue as { value: string }).value.trim() !== ''
+
+const enrichmentOf = (
+	findings: unknown,
+): Record<string, unknown> | undefined => {
+	if (findings === null || typeof findings !== 'object') return undefined
+	const enrichment = (findings as { enrichment?: unknown }).enrichment
+	return enrichment !== null && typeof enrichment === 'object'
+		? (enrichment as Record<string, unknown>)
+		: undefined
+}
+
+/**
+ * Fill the high-value fields from a re-extraction over the enlarged evidence, but
+ * only where the first pass left them empty — a value already grounded is never
+ * overwritten. Returns the findings and how many fields it filled.
+ */
+export const mergePerFieldSearch = (
+	findings: unknown,
+	refreshed: unknown,
+): { readonly findings: unknown; readonly filled: number } => {
+	const enrichment = enrichmentOf(findings)
+	const refreshedEnrichment = enrichmentOf(refreshed)
+	if (enrichment === undefined || refreshedEnrichment === undefined) {
+		return { findings, filled: 0 }
+	}
+	let filled = 0
+	const nextEnrichment: Record<string, unknown> = { ...enrichment }
+	for (const key of HIGH_VALUE_FIELDS) {
+		if (!hasValue(enrichment[key]) && hasValue(refreshedEnrichment[key])) {
+			nextEnrichment[key] = refreshedEnrichment[key]
+			filled++
+		}
+	}
+	if (filled === 0) return { findings, filled: 0 }
+	return {
+		findings: { ...(findings as object), enrichment: nextEnrichment },
+		filled,
+	}
+}

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -684,6 +684,7 @@ describe('groundedPageTexts', () => {
 		cores: ['acmelogistics'],
 		words: ['acme'],
 		domains: ['acme.es'],
+		places: [],
 	}
 
 	describe('when the run has no entity target', () => {

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -64,6 +64,7 @@ import {
 	REFINE_HINT,
 } from './discovery-scan'
 import {
+	cityGate,
 	classifyEntityMatch,
 	classifyEntityMatchPerSource,
 	deriveAnchorHost,
@@ -74,6 +75,7 @@ import {
 	groundedSourceIds,
 	isConfirmedRegistryMatch,
 	isEntityGroundedSchema,
+	reachedOwnSite,
 	withRedirectDomain,
 } from './entity-guard'
 import { contactFill, enrichmentFill } from './extraction-fill'
@@ -87,7 +89,14 @@ import {
 	SizeRescueSchema,
 	sizeRescuePrompt,
 } from './firmographics-rescue'
+import { harvestGenericEmails } from './generic-emails'
 import { normalizePaidActionTool } from './paid-action-tool'
+import {
+	MAX_PER_FIELD_SEARCHES,
+	mergePerFieldSearch,
+	needsPerFieldSearch,
+	perFieldSearchQuery,
+} from './per-field-search'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
 	AgentLanguageModel,
@@ -97,6 +106,7 @@ import {
 	ResearchEventSink,
 	ResearchRunContext,
 	ScrapeProvider,
+	SearchProvider,
 	WriterLanguageModel,
 } from './ports'
 import {
@@ -1520,6 +1530,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								typeof row['website'] === 'string' ? row['website'] : undefined,
 						}
 					})
+					// The caller's location hint, folded into the entity targets' place keys
+					// so the city verification below can tell the queried company "in that
+					// city" from a same-named company (or a stale mention) elsewhere.
+					const hintLocation = (
+						context?.hints as { location?: string } | undefined
+					)?.location
 					// `let`, not `const`: when the seeded anchor domain redirects to a
 					// different host (a rebrand), the seed below folds that destination
 					// in as a strong-match key so the run grounds on the live site.
@@ -1528,6 +1544,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						anchorDomain: context?.anchorDomain,
 						query: (run as { query: string }).query,
 						subjects: subjectTargets,
+						location: hintLocation,
 					})
 					let entityMatch: EntityMatch | null =
 						(run as { entityMatch?: EntityMatch | null }).entityMatch ?? null
@@ -2959,14 +2976,37 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						// glancing mention of it ('weak'), fails closed now — before phase 2
 						// extraction can turn a lookalike's pages into a confident profile.
 						// Only a strong match proceeds.
+						const entityCorpus = [
+							evidenceText,
+							...scrapeCorpus.map(page => page.text),
+						].join('\n')
 						entityMatch = entityTargets
-							? classifyEntityMatch(
-									entityTargets,
-									[evidenceText, ...scrapeCorpus.map(page => page.text)].join(
-										'\n',
-									),
-								)
+							? classifyEntityMatch(entityTargets, entityCorpus)
 							: null
+						// A page that merely spells the company name reads as 'strong' even
+						// for a different same-named company, or a stale mention of one since
+						// renamed or acquired. When a city was queried but the run reached no
+						// official site and no register confirmed the match, require that city
+						// in the evidence too — otherwise fail closed rather than profile a
+						// lookalike.
+						if (
+							entityMatch === 'strong' &&
+							entityTargets &&
+							cityGate({
+								targets: entityTargets,
+								corpus: entityCorpus,
+								pages: scrapeCorpus,
+								registryConfirmed,
+							}) === 'downgrade'
+						) {
+							yield* Effect.annotateCurrentSpan({
+								'research.entity.city_downgraded': true,
+							})
+							yield* Effect.logInfo('research.entity.city_downgraded').pipe(
+								Effect.annotateLogs({ research_id: researchId }),
+							)
+							entityMatch = 'absent'
+						}
 						if (entityMatch === 'absent' || entityMatch === 'weak') {
 							yield* failClosedOnEntity(entityMatch)
 							return
@@ -3046,6 +3086,137 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							)
 							findings = extracted.findings
 							tokensOut += extracted.outputTokens
+							// Per-field web search: for each high-value firmographic the broad
+							// pass and the focused rescues still left empty, fire one focused
+							// web search and re-extract over the enlarged evidence — a backstop
+							// for a fact (country, sector, city, size) that was on no page the
+							// run reached. Fail-open and capped: a complete run fires none, and
+							// a re-extraction that recovers nothing leaves findings unchanged.
+							const perFieldMissing = needsPerFieldSearch(findings).slice(
+								0,
+								MAX_PER_FIELD_SEARCHES,
+							)
+							if (perFieldMissing.length > 0) {
+								const search = yield* SearchProvider
+								const perFieldTargetName =
+									(run as { query: string }).query.split(',')[0]?.trim() ||
+									(run as { query: string }).query
+								const perFieldHashes: string[] = []
+								let perFieldFired = 0
+								// Phase-2 runs outside the loop's Budget scope, and the focused
+								// rescues here are unbudgeted too; the per-field cap above bounds
+								// the extra spend instead of a per-search charge.
+								for (const field of perFieldMissing) {
+									perFieldFired++
+									const searched = yield* search
+										.search({
+											query: perFieldSearchQuery(
+												perFieldTargetName,
+												hintLocation,
+												field,
+											),
+											limit: 3,
+											location: hintLocation,
+										})
+										.pipe(Effect.catchCause(() => Effect.succeed(null)))
+									for (const item of searched?.items ?? []) {
+										const host = domainHost(item.url)
+										if (host !== undefined) searchResultHosts.add(host)
+										if (item.content && item.content.trim().length > 0) {
+											const hash = urlHashForScrape(item.url)
+											perFieldHashes.push(hash)
+											scrapeCorpus.push({
+												urlHash: hash,
+												text: item.content,
+												host,
+											})
+										}
+									}
+								}
+								if (perFieldHashes.length > 0) {
+									yield* linkRunSources(perFieldHashes)
+									const perFieldAnchorFirst = [...scrapeCorpus].sort(
+										(a, b) =>
+											(anchorHashes.has(a.urlHash) ? 0 : 1) -
+											(anchorHashes.has(b.urlHash) ? 0 : 1),
+									)
+									const refreshed = yield* extractStructuredFindings(
+										researchText,
+										[
+											evidenceText,
+											...seededEvidenceParts,
+											...groundedPageTexts(entityTargets, scrapeCorpus),
+										].join('\n'),
+										groundedPageTexts(entityTargets, perFieldAnchorFirst),
+									)
+									tokensOut += refreshed.outputTokens
+									const merged = mergePerFieldSearch(
+										findings,
+										refreshed.findings,
+									)
+									findings = merged.findings
+									yield* Effect.annotateCurrentSpan({
+										'research.per_field_search.fired': perFieldFired,
+										'research.per_field_search.filled': merged.filled,
+									})
+									if (merged.filled > 0) {
+										yield* Effect.logInfo('research.per_field_search').pipe(
+											Effect.annotateLogs({
+												research_id: researchId,
+												fired: perFieldFired,
+												filled: merged.filled,
+											}),
+										)
+									}
+								}
+							}
+						}
+						// Published role mailboxes (info@, sales@, hola@): read verbatim
+						// from the company's own pages, they are often the only actionable
+						// channel for a thin-web company with no named executive. Added after
+						// the guard chain — grounded by construction (a known role word at one
+						// of the company's own domains) — so the guards never see, and so never
+						// strip, them. Skipped on resume when nothing was re-fetched, leaving
+						// any addresses from the pre-crash pass in place.
+						if (schemaName === 'company_enrichment_v1' && entityTargets) {
+							// Bind to a const so the null-narrowing survives the closures
+							// below (`entityTargets` is a reassignable `let`).
+							const emailTargets = entityTargets
+							const emailVerdicts = classifyEntityMatchPerSource(
+								emailTargets,
+								scrapeCorpus.map(page => ({
+									sourceId: page.urlHash,
+									text: page.text,
+									host: page.host,
+								})),
+							)
+							const emailKeep = new Set(groundedSourceIds(emailVerdicts))
+							const groundedForEmail = scrapeCorpus.filter(page =>
+								emailKeep.has(page.urlHash),
+							)
+							const ownHosts = [
+								...emailTargets.domains,
+								...groundedForEmail
+									.map(page => page.host)
+									.filter(
+										(host): host is string =>
+											host !== undefined &&
+											reachedOwnSite(emailTargets, [{ host }]),
+									),
+							]
+							const genericEmails = harvestGenericEmails(
+								groundedForEmail,
+								ownHosts,
+							)
+							if (genericEmails.length > 0) {
+								findings = {
+									...(findings as object),
+									generic_emails: genericEmails,
+								}
+								yield* Effect.annotateCurrentSpan({
+									'research.generic_emails.found': genericEmails.length,
+								})
+							}
 						}
 						yield* Ref.update(toolLog, log => [
 							...log,


### PR DESCRIPTION
## What

This makes web-first company research — the pipeline that reads a company's public web pages to fill in its CRM profile — more careful about *which* company it profiled and more complete about *what* it recovered, and gives the quality eval a way to catch a regression that only hits one kind of company. The three pipeline changes live in the Research bounded context (`packages/research`, which runs server-side); the eval changes are local tooling (`apps/cli`, `eval/`). Part of #286.

## Changes

- **Reject a look-alike before profiling it.** When the query named a city but the run never reached the company's own website and no official company register confirmed it, a match that rests only on the name is now rejected as "no reliable data" instead of confidently returning a same-named company somewhere else. It only tightens that one borderline case — a query with no city, or a run that reached the official site or a register, is untouched — so a genuinely-grounded run is never penalized. It deliberately does *not* try to catch the hardest case (a company acquired and now redirecting to its acquirer in the same city), which needs a liveness/registry signal.
- **Backfill the firmographics a first pass misses.** For each of country, industry, location, and headcount that the broad extraction and the focused rescues left blank, the pipeline now runs up to three targeted web searches, links the new pages as sources, and re-reads the enlarged evidence — filling only the blanks, and only with values that pass the same grounding checks as any other field.
- **Capture published department mailboxes.** A company's own `info@` / `sales@` / `hola@` addresses, read verbatim from its own pages and matched to its own domains, are surfaced as grounded contact channels (a new `generic_emails` list in the run's findings). For a thin-web small company that lists no named executive, this is often the only actionable way to reach it.
- **Break the quality eval out by company segment.** Golden companies can now be tagged `big` / `small` / `niche`, and the eval reports every metric per segment and per country behind a `--by-bucket` flag, so a regression that only hits, say, niche companies is not hidden in the average.

## Impact

- **Findings wire-shape (additive):** the research findings JSON gains an optional top-level `generic_emails: [{ value, source_id, quote }]`. It is read straight from `research_runs.findings` (no schema decode on read), so existing consumers are unaffected — a consumer that wants the mailboxes reads the new key.
- **Server release required:** `packages/research` runs server-side (the MCP research tools + the HTTP handlers), so the three pipeline changes reach production only after a `/release server` on the merged commit. Both transports get the behavior — it lives in the shared service, not a transport.
- **No migrations:** `generic_emails` is a JSON field on existing findings; nothing touches schema, so the release is a plain redeploy.
- **No new env vars, no auth / RLS / CORS changes.**
- **Cost:** the backfill adds up to three extra web searches per company, and only when high-value fields are still empty (capped, fail-open) — a fully-filled company pays nothing.

## Review guide

- **Start here:** `packages/research/src/application/entity-guard.ts` — the new `cityGate` / `placesCorroborate` / `reachedOwnSite` (pure, fully unit-tested) and their wiring at the phase-1 entity gate in `research-service.ts`.
- **Riskiest part:** the backfill wiring in `research-service.ts` — it fires searches in phase 2, links the new sources, and re-runs extraction over the enlarged evidence. Verifying it surfaced a real bug: the per-run `Budget` service is provided only to the phase-1 scope, so charging budget in phase 2 crashed the run. I dropped the budget charge (the three-search cap bounds cost, matching the other unbudgeted phase-2 rescues). Root cause + the provider-timeout reliability gap are filed as #299.
- **Second look:** the email harvest (`generic-emails.ts`) scans untrusted scraped page text with a regex — it keeps only a role local-part whose domain is one of the company's own hosts, and runs *after* the guard chain, so it cannot be used to smuggle in an ungrounded value. I did not run `/security-review` separately; flagging it here.
- **A decision you might overrule:** the city rule fails *open* when no city was queried, trading some wrong-company coverage for zero recall loss (see the `## What` caveat).
- Skip-able: the pure helper modules + their tests are mechanical; the eval bucketing is additive.

## Tests

Unit tests (vitest, BDD shape) for every new pure function — the city helpers, the backfill field-selection/query/merge, the email harvest, and the eval bucketing + golden-tag parsing — alongside the existing research suite (766 green). The pipeline wiring is exercised by the live eval below.

## Verification

- Gates run and green: `pnpm install` (no lockfile drift) · `check-types` (all 13 packages) · `test` (766 research tests) · `build` (all 13).
- Live eval against the golden set (20 companies × 3 runs, real scraping + LLM, dev single-slot route): grounding **92%**, field precision **88%**, wrong-company **0%**, field recall **66%**, empty **18%**. I did not re-run `main` this session; the prior documented baseline on this route is ~92% precision / ~70% recall, so the −4pp precision reads as within-noise given wrong-company held at 0% and there is no path for these changes to lower precision.
  - Per segment: big precision 95% / empty 17% · niche precision 75% / **empty 0%** · small precision 80% / empty 28%.
  - The **18% empty is exactly the 11 provider timeouts** on the dev single-slot route (infra, filed as #299) — not over-rejection. The city rule fired **zero** downgrades on this set (it contains no acquired-and-redirected case), so it caused zero over-rejection.
  - The backfill was confirmed end-to-end on a single-company run (fired 2 searches, filled 1, recovered value passed the grounding guards).
  - Department mailboxes were captured for 4 companies, including `info@ponderosa.es` for a thin-web Spanish company — the exact case it targets.

## Deferred

- The acquired-and-redirected same-city wrong-company case (needs a liveness/registry signal, not a text heuristic).
- Making recall/empty *measurable*: the dev eval is single-slot, and provider timeouts inflate empty; needs the evidence cache / multi-run consensus (the tracked A3 work) or valid dev fallback keys. Tracked in #299.
- A scheduled (nightly) run of the bucketed eval — the code is here; wiring the CI job is the remaining piece.

Addresses #286 — does not close it; the two follow-ups above remain.
