### PR TITLE
cicd: cover Better Auth schema changes before they reach production

### DIFF
--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -70,11 +70,35 @@ jobs:
             echo "has_migrations=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Migrations are TypeScript (Effect SqlClient), named NNNN_*.ts — not .sql,
-          # so the old '\.sql$' filter matched nothing and silently skipped every migrate.
+          # Our own migrations are TypeScript (Effect SqlClient), named NNNN_*.ts —
+          # not .sql, so the old '\.sql$' filter matched nothing and silently
+          # skipped every migrate.
           files=$(git diff --name-only "$prev..HEAD" -- apps/server/src/db/migrations/ | grep -E '[0-9]{4}_.*\.(ts|sql)$' || true)
-          if [ -n "$files" ]; then
-            echo "New migrations since $prev:"; echo "$files"
+
+          # Better Auth owns its own tables and generates their DDL at migrate
+          # time from the config it is handed — there is no file under
+          # migrations/ to notice. So a release that adds, say, a column to the
+          # user table changes no migration file at all, and a path-only check
+          # waves it through to a deploy whose code expects a column that does
+          # not exist yet.
+          #
+          # Its schema comes from the plugin list and the additionalFields on
+          # user/session/account/verification (see `getAuthTables`), all of
+          # which reach the generator through migrate.ts, with the shared config
+          # mirroring them for the running server. Watch both.
+          ba_config=$(git diff --name-only "$prev..HEAD" -- \
+            apps/server/src/db/migrate.ts \
+            packages/auth/src/infrastructure/build-better-auth-config.ts || true)
+
+          # A Better Auth upgrade can add columns of its own without anyone here
+          # touching a config file, so a version change gates too.
+          ba_version=$(git diff "$prev..HEAD" -- '*package.json' \
+            | grep -E '^[+-][[:space:]]*"(better-auth|@better-auth/[a-z-]+)":' || true)
+
+          if [ -n "$files" ] || [ -n "$ba_config" ] || [ -n "$ba_version" ]; then
+            [ -n "$files" ] && { echo "New migrations since $prev:"; echo "$files"; }
+            [ -n "$ba_config" ] && { echo "Better Auth schema config changed since $prev:"; echo "$ba_config"; }
+            [ -n "$ba_version" ] && { echo "Better Auth version changed since $prev:"; echo "$ba_version"; }
             echo "has_migrations=true" >> "$GITHUB_OUTPUT"
           else
             echo "No new migrations since $prev — skipping the migrate gate."

--- a/apps/server/src/db/migrate.test.ts
+++ b/apps/server/src/db/migrate.test.ts
@@ -1,0 +1,91 @@
+import pg from 'pg'
+import { describe, expect, it } from 'vitest'
+
+import { buildBetterAuthConfig } from '@batuda/auth'
+
+import { betterAuthSchemaConfig } from './migrate.js'
+
+// Better Auth owns its own tables and builds their shape from the config it is
+// handed. Batuda hands it two: one here, which the migrator uses to create the
+// columns, and one the running server builds, which is how the server knows
+// those columns exist.
+//
+// Nothing makes the two agree. Add a field to only one and the failure is
+// silent and deferred — a column nothing reads, or a server asking for a column
+// that was never created, which surfaces on boot in production rather than
+// here. This is the check that makes them agree.
+
+// The builder needs a pool to hand Better Auth a dialect. Nothing in this file
+// connects; only the declared shape is read.
+const configForComparison = () =>
+	buildBetterAuthConfig({
+		env: {
+			secret: 'test-secret',
+			baseURL: 'https://api.batuda.localhost',
+			useSecureCookies: false,
+			trustedOrigins: ['https://batuda.localhost'],
+			rateLimit: 'strict',
+		},
+		pool: new pg.Pool({ connectionString: 'postgresql://unused/unused' }),
+		plugins: [],
+	})
+
+describe('Better Auth schema config', () => {
+	describe('when compared with the config the running server builds', () => {
+		it('should declare the same extra fields on the user table', () => {
+			// GIVEN the config the migrator uses to create columns
+			const migrator = betterAuthSchemaConfig.user.additionalFields
+
+			// AND the config the running server uses to read them
+			const runtime = configForComparison().user.additionalFields
+
+			// WHEN the two are compared
+			// THEN they name the same fields — a field on one side only is either
+			// a column nothing reads or a read of a column that does not exist
+			expect(Object.keys(migrator).sort()).toEqual(Object.keys(runtime).sort())
+		})
+
+		it('should agree on the type and nullability of each field', () => {
+			// GIVEN both configs
+			const migrator: Record<string, { type: unknown; required?: boolean }> =
+				betterAuthSchemaConfig.user.additionalFields
+			const runtime: Record<string, { type: unknown; required?: boolean }> =
+				configForComparison().user.additionalFields
+
+			// WHEN each shared field is compared
+			for (const name of Object.keys(migrator)) {
+				const created = migrator[name]
+				const expected = runtime[name]
+				// THEN the column the migrator creates matches the one the server
+				// expects. A field created nullable but read as required fails at
+				// runtime on the first row that lacks it.
+				expect(created?.type, `${name} type`).toBe(expected?.type)
+				expect(created?.required ?? false, `${name} required`).toBe(
+					expected?.required ?? false,
+				)
+			}
+		})
+	})
+
+	describe('when a plugin that brings its own tables is added', () => {
+		it('should list it here too, or the migrator never creates them', () => {
+			// GIVEN the plugins this config carries
+			const ids = betterAuthSchemaConfig.plugins.map(plugin => plugin.id).sort()
+
+			// WHEN compared with the set the migrator is known to cover
+			// THEN they match. The server assembles its own plugin list at
+			// runtime, so nothing can compare the two automatically — this pins
+			// the migrator's side, so adding a plugin to the server without
+			// adding it here is a deliberate act rather than an oversight.
+			expect(ids).toEqual([
+				'admin',
+				'api-key',
+				'bearer',
+				'jwt',
+				'oauth-provider',
+				'open-api',
+				'organization',
+			])
+		})
+	})
+})

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -1,6 +1,7 @@
 import { apiKey } from '@better-auth/api-key'
 import { oauthProvider } from '@better-auth/oauth-provider'
 import { NodeRuntime } from '@effect/platform-node'
+import type { BetterAuthOptions } from 'better-auth'
 import { getMigrations } from 'better-auth/db/migration'
 import { admin, bearer, jwt, openAPI, organization } from 'better-auth/plugins'
 import { Effect } from 'effect'
@@ -9,8 +10,71 @@ import pg from 'pg'
 
 import { MigratorLive } from './migrator'
 
-// Better Auth migration config — keep plugins and user fields
-// in sync with src/lib/auth.ts
+/**
+ * Everything Better Auth reads when working out what its tables should look
+ * like: the extra fields on its own tables, and the plugins that bring tables
+ * of their own. Separate from the connection because the shape is the same on
+ * every run, and because it is compared against the config the running server
+ * builds — see `migrate.test.ts`.
+ *
+ * These fields are declared twice on purpose: here, so the migrator creates the
+ * columns, and in the shared config, so the server knows they exist. Adding one
+ * here alone makes a column nothing reads; adding it there alone makes the
+ * server expect a column that was never created. The test fails on either.
+ */
+export const betterAuthSchemaConfig = {
+	user: {
+		additionalFields: {
+			isAgent: {
+				type: 'boolean',
+				required: false,
+				defaultValue: false,
+			},
+			locale: {
+				type: 'string',
+				required: false,
+				input: false,
+			},
+			passwordOptOut: {
+				type: 'boolean',
+				required: false,
+				defaultValue: false,
+			},
+		},
+	},
+	// `organization()` here so Better Auth generates the `organization` /
+	// `member` / `invitation` tables alongside the rest. `member.primary_inbox_id`
+	// is a Batuda extension recording each member's default From identity.
+	plugins: [
+		openAPI(),
+		bearer(),
+		admin(),
+		organization({
+			schema: {
+				member: {
+					additionalFields: {
+						primaryInboxId: {
+							type: 'string',
+							required: false,
+							fieldName: 'primary_inbox_id',
+						},
+					},
+				},
+			},
+		}),
+		apiKey(),
+		// Generates the OAuth provider tables (oauthClient, oauthAccessToken,
+		// oauthRefreshToken, oauthConsent) plus the jwt plugin's jwks table,
+		// backing the OAuth MCP path. loginPage/consentPage are runtime-only;
+		// the values don't affect schema generation.
+		jwt(),
+		oauthProvider({
+			loginPage: 'http://localhost/login',
+			consentPage: 'http://localhost/consent',
+		}),
+	],
+} satisfies Pick<BetterAuthOptions, 'user' | 'plugins'>
+
 const authMigrate = Effect.promise(async () => {
 	const pool = new pg.Pool({
 		connectionString: process.env['DATABASE_URL'],
@@ -20,58 +84,7 @@ const authMigrate = Effect.promise(async () => {
 			dialect: new PostgresDialect({ pool }),
 			type: 'postgres',
 		},
-		user: {
-			additionalFields: {
-				isAgent: {
-					type: 'boolean',
-					required: false,
-					defaultValue: false,
-				},
-				locale: {
-					type: 'string',
-					required: false,
-					input: false,
-				},
-				passwordOptOut: {
-					type: 'boolean',
-					required: false,
-					defaultValue: false,
-				},
-			},
-		},
-		// `organization()` here so Better Auth's CLI generates the
-		// `organization` / `member` / `invitation` tables alongside the rest.
-		// `member.primary_inbox_id` is a Batuda extension used to record each
-		// member's default From identity in this org.
-		plugins: [
-			openAPI(),
-			bearer(),
-			admin(),
-			organization({
-				schema: {
-					member: {
-						additionalFields: {
-							primaryInboxId: {
-								type: 'string',
-								required: false,
-								fieldName: 'primary_inbox_id',
-							},
-						},
-					},
-				},
-			}),
-			apiKey(),
-			// Generates the OAuth provider tables (oauthClient, oauthAccessToken,
-			// oauthRefreshToken, oauthConsent) plus the jwt plugin's jwks table,
-			// backing the OAuth MCP path. loginPage/consentPage are runtime-only;
-			// the values don't affect schema generation. Keep in sync with
-			// src/lib/auth.ts.
-			jwt(),
-			oauthProvider({
-				loginPage: 'http://localhost/login',
-				consentPage: 'http://localhost/consent',
-			}),
-		],
+		...betterAuthSchemaConfig,
 	})
 	await runMigrations()
 	await pool.end()


### PR DESCRIPTION
## What

Before a release goes out, the deploy pauses and asks a human to approve applying database changes to production. That pause only happened when the release added a file to our migrations folder.

Better Auth — the library that owns sign-in, accounts and organizations — keeps its own tables and works out their shape at deploy time from the configuration we hand it. So a release that adds a column to one of *its* tables adds no migration file at all. The check saw nothing, skipped the approval, and shipped server code that expected a column the database did not have.

This closes that hole in two places: the deploy now notices those changes, and a test now catches the other way this can break. Affects the Auth surface and the deploy pipeline; no product behaviour changes.

## Changes

- The migrate approval now also fires when the configuration Better Auth reads has changed, or when Better Auth itself has been upgraded — an upgrade can add columns without anyone here editing a config.
- A test now fails if the fields the migrator creates and the fields the running server reads stop matching. They are declared in two separate places and, until now, only a code comment asked anyone to keep them in step.

## Impact

- **Deploy pipeline behaviour changes.** The approval prompt on the `production-db` environment will now appear on more releases than before — any release touching Better Auth's configuration or version, not just ones adding a migration file. That is the point, but it means a release that previously sailed through may now wait on you.
- **No schema change, no migration, no API or wire-shape change, no new environment variables, no auth or tenant-isolation change.** The only production-facing effect is when the existing approval gate fires.
- **Two releases already shipped through the old hole** and got their migration only because they happened to add a migration file as well: the one adding `passwordOptOut`, and the one adding `locale`. Nothing is broken in production as a result — both were applied — but neither was gated on purpose.

## Review guide

Start with the workflow change; the test is the easier half.

- **The judgement call worth checking** is which files count as "Better Auth's schema configuration". I watch the migrator's own config and the shared config the server builds, but deliberately *not* `apps/server/src/lib/auth.ts` — it changes constantly for reasons unrelated to schema, and gating on it would ask for approval on most releases. The trade-off is that a schema change made only there would be missed; in practice such a change has to reach the migrator's config anyway or no column is ever created.
- **Detection is path-based**, so if someone later moves that configuration to a new file, coverage lapses silently. I don't have a good answer for that beyond the test below catching the consequence.
- **The plugin list in the test is pinned, not compared.** The server assembles its own list at runtime and can't be imported into a unit test, so adding a schema-bearing plugin to the server without adding it to the migrator remains a human check. I'd rather say that plainly than imply more coverage than exists.
- Skip nothing; the diff is small.
- **Not verified:** the Snyk CLI is not installed on this machine, so no scan ran. This change adds no dependency and no runtime code.

## Tests

The new test asserts the two configurations declare the same fields, with the same type and nullability. I confirmed it actually fails by breaking it both ways — removing a field from one side, and making one side create a column as required that the other reads as optional — before restoring.

## Verification

`pnpm install` (no lockfile drift), `pnpm check-types` (13/13), `pnpm test` (21/21), `pnpm build` (13/13).

I replayed the new detection against real history rather than trusting it: the releases that added `passwordOptOut` and `locale` are now caught and were not before, five releases that changed no schema still skip the approval, and the range from the last server tag to `main` gates correctly. I also ran the new shell under the exact flags GitHub Actions uses (`bash -eo pipefail`) for the cases where none or only some of the checks match, since a false failure there would block every release.

Not a UI change, so no screenshots.

## Deferred

- A schema change made only in `apps/server/src/lib/auth.ts` without reaching the migrator's config is still not detected. It would create no column, so the test above catches the consequence rather than the cause.
- `check-migration-safety.mjs` cannot see Better Auth's generated DDL either, but I left it alone: Better Auth only ever creates tables and adds columns — it never drops — so there is nothing destructive for that check to find.
