### PR TITLE
fix(internal): show failed loads as errors instead of empty lists

### DIFF
--- a/apps/internal/src/components/companies/pipeline-board.tsx
+++ b/apps/internal/src/components/companies/pipeline-board.tsx
@@ -28,7 +28,7 @@ import {
 	companiesSearchAtom,
 } from '#/atoms/companies-atoms'
 import { pipelineAtom } from '#/atoms/pipeline-atoms'
-import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { PriorityDot } from '#/components/shared/priority-dot'
 import {
 	type CompanyStatus,
@@ -203,9 +203,11 @@ export function PipelineBoard({
 
 	if (AsyncResult.isFailure(pipelineResult)) {
 		return (
-			<EmptyState
+			<ErrorState
+				data-testid='pipeline-error'
 				title={t`Could not load the board`}
-				description={t`Check that your session is valid or try again.`}
+				description={t`The board could not be fetched. Check that the session is valid, then try again.`}
+				onRetry={refreshPipeline}
 			/>
 		)
 	}

--- a/apps/internal/src/components/instructions/instruction-page-chrome.tsx
+++ b/apps/internal/src/components/instructions/instruction-page-chrome.tsx
@@ -132,17 +132,6 @@ export const Empty = styled.p`
 	margin: 0;
 `
 
-// Inline error notice for a failed load or save (pair with role='alert').
-export const Notice = styled.p`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-small-size);
-	color: var(--color-error);
-	padding: var(--space-2xs) var(--space-sm);
-	border-left: 3px solid var(--color-error);
-	background: color-mix(in srgb, var(--color-error) 6%, transparent);
-	margin: 0;
-`
-
 export const DialogActions = styled.div`
 	display: flex;
 	gap: var(--space-sm);

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -28,6 +28,7 @@ import {
 } from '#/components/research/run-labels'
 import { narrowResearch } from '#/components/research/run-shapes'
 import { TrustBadge } from '#/components/research/trust-badge'
+import { ErrorState } from '#/components/shared/error-state'
 import {
 	type ResolveDecision,
 	type ResolveOutcome,
@@ -419,17 +420,12 @@ export function ResearchInbox() {
 					))}
 				</SkeletonList>
 			) : isFailure ? (
-				<FailureBox role='alert'>
-					<Trans>Could not load the review queue.</Trans>
-					<PriButton
-						type='button'
-						$variant='outlined'
-						data-testid='research-inbox-retry'
-						onClick={() => refreshProposals()}
-					>
-						<Trans>Retry</Trans>
-					</PriButton>
-				</FailureBox>
+				<ErrorState
+					variant='inline'
+					data-testid='research-inbox-error'
+					title={t`Could not load the review queue.`}
+					onRetry={refreshProposals}
+				/>
 			) : (
 				<>
 					{attention.length > 0 ? (
@@ -1046,16 +1042,6 @@ const Empty = styled.p`
 	font-style: italic;
 	color: var(--color-on-surface-variant);
 	margin: 0;
-`
-
-const FailureBox = styled.div`
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: var(--space-sm);
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-medium-size);
-	color: var(--color-on-surface-variant);
 `
 
 const SkeletonList = styled.div`

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -26,6 +26,7 @@ import { ProposedUpdatesReview } from '#/components/research/review/proposed-upd
 import { RunActions } from '#/components/research/run-actions'
 import { RunProgress } from '#/components/research/run-progress'
 import { TargetCorrection } from '#/components/research/target-correction'
+import { ErrorState } from '#/components/shared/error-state'
 import { useResearchEvents } from '#/hooks/use-research-events'
 import {
 	brushedMetalPlate,
@@ -70,6 +71,7 @@ type ResearchRunDetail = {
 }
 
 export function RunDetail({ researchId }: { readonly researchId: string }) {
+	const { t } = useLingui()
 	const result = useAtomValue(researchDetailAtom(researchId))
 	const refreshRun = useAtomRefresh(researchDetailAtom(researchId))
 
@@ -94,9 +96,12 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 	if (AsyncResult.isFailure(result)) {
 		return (
 			<Panel data-testid='research-run-detail'>
-				<ErrorBlock role='alert'>
-					<Trans>Could not load this run.</Trans>
-				</ErrorBlock>
+				<ErrorState
+					variant='inline'
+					data-testid='research-run-error'
+					title={t`Could not load this run.`}
+					onRetry={refreshRun}
+				/>
 			</Panel>
 		)
 	}
@@ -104,9 +109,11 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 	if (run === null) {
 		return (
 			<Panel data-testid='research-run-detail'>
-				<ErrorBlock role='alert'>
-					<Trans>Run shape unrecognised.</Trans>
-				</ErrorBlock>
+				<ErrorState
+					variant='inline'
+					data-testid='research-run-shape-error'
+					title={t`Run shape unrecognised.`}
+				/>
 			</Panel>
 		)
 	}

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -7,11 +7,14 @@ import { RefreshCw } from 'lucide-react'
 import type { ComponentType } from 'react'
 import styled from 'styled-components'
 
+import type { SchemaName } from '@batuda/research'
+// Straight from the domain file rather than the package entry point: that entry
+// point also reaches the services that talk to the database and the outside
+// world, and pulling those into the browser breaks this page outright.
 import {
 	RESEARCH_REASON_CODES,
 	type ReasonCode,
-	type SchemaName,
-} from '@batuda/research'
+} from '@batuda/research/domain/types'
 import { PriButton } from '@batuda/ui/pri'
 
 import { researchDetailAtom } from '#/atoms/research-atoms'

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -112,7 +112,8 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 				<ErrorState
 					variant='inline'
 					data-testid='research-run-shape-error'
-					title={t`Run shape unrecognised.`}
+					title={t`This run can't be displayed.`}
+					description={t`The run arrived in a form this page cannot read. Go back to the run list and open it again; report it if it keeps happening.`}
 				/>
 			</Panel>
 		)

--- a/apps/internal/src/components/research/run-list.tsx
+++ b/apps/internal/src/components/research/run-list.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from '@effect/atom-react'
+import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import { PriButton } from '@batuda/ui/pri'
 
 import { researchListAtom } from '#/atoms/research-atoms'
+import { ErrorState } from '#/components/shared/error-state'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { formatMoneyCents } from '#/lib/format-money'
 import { stenciledTitle } from '#/lib/workshop-mixins'
@@ -25,10 +26,11 @@ export function researchRunsAtom() {
 }
 
 export function ResearchRuns() {
-	const { i18n } = useLingui()
+	const { t, i18n } = useLingui()
 	const navigate = useNavigate()
 	const [dialogOpen, setDialogOpen] = useState(false)
 	const result = useAtomValue(researchRunsAtom())
+	const refreshRuns = useAtomRefresh(researchRunsAtom())
 	const runs = AsyncResult.isSuccess(result) ? narrowResearch(result.value) : []
 
 	return (
@@ -58,9 +60,12 @@ export function ResearchRuns() {
 					<Trans>Loading runs…</Trans>
 				</Empty>
 			) : AsyncResult.isFailure(result) ? (
-				<Empty role='alert'>
-					<Trans>Could not load your runs.</Trans>
-				</Empty>
+				<ErrorState
+					variant='inline'
+					data-testid='research-runs-error'
+					title={t`Could not load your runs.`}
+					onRetry={refreshRuns}
+				/>
 			) : runs.length === 0 ? (
 				<Empty data-testid='runs-empty'>
 					<Trans>No research runs yet. Find companies to get started.</Trans>

--- a/apps/internal/src/components/shared/error-state.tsx
+++ b/apps/internal/src/components/shared/error-state.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/react/macro'
-import type { ReactNode } from 'react'
+import { type ReactNode, useId } from 'react'
 import styled from 'styled-components'
 
 import { PriButton } from '@batuda/ui/pri'
@@ -10,31 +10,54 @@ import { agedPaperSurface } from '#/lib/workshop-mixins'
  * Tells the reader something broke while loading, so a failed fetch is never
  * mistaken for "you have no data". Omit `onRetry` when trying again cannot
  * help — a button that does nothing is worse than no button.
+ *
+ * `headingLevel` should match where the message sits in the page outline: 1
+ * when the error replaces the whole page, 2 when it sits under a page title.
  */
 export function ErrorState({
 	title,
 	description,
 	onRetry,
 	variant = 'card',
+	headingLevel = 2,
 	'data-testid': testId,
 }: {
 	title: string
 	description?: ReactNode
 	onRetry?: () => void
 	variant?: 'card' | 'inline'
+	headingLevel?: 1 | 2 | 3
 	'data-testid'?: string
 }) {
+	const titleId = useId()
+
+	// Naming the message keeps several Retry buttons on one page apart: a
+	// screen reader reads "Retry, could not load your templates" rather than
+	// an indistinguishable list of "Retry".
 	const retryButton = onRetry && (
-		<PriButton type='button' $variant='outlined' onClick={() => onRetry()}>
+		<PriButton
+			type='button'
+			$variant='outlined'
+			aria-describedby={titleId}
+			onClick={() => onRetry()}
+		>
 			<Trans>Retry</Trans>
 		</PriButton>
 	)
 
 	if (variant === 'inline') {
 		return (
-			<InlineWrapper role='alert' data-testid={testId}>
-				<InlineText>
-					<InlineTitle>{title}</InlineTitle>
+			<InlineWrapper
+				role='group'
+				aria-labelledby={titleId}
+				data-testid={testId}
+			>
+				{/* Announced politely: something that failed to load is not
+				    urgent enough to cut off whatever is being read. The Retry
+				    button stays outside the announced part so it is offered as a
+				    button to press, not read out as part of the sentence. */}
+				<InlineText role='status'>
+					<InlineTitle id={titleId}>{title}</InlineTitle>
 					{description && <InlineDescription>{description}</InlineDescription>}
 				</InlineText>
 				{retryButton && <InlineActions>{retryButton}</InlineActions>}
@@ -43,9 +66,13 @@ export function ErrorState({
 	}
 
 	return (
-		<CardWrapper role='alert' data-testid={testId}>
-			<CardTitle>{title}</CardTitle>
-			{description && <CardDescription>{description}</CardDescription>}
+		<CardWrapper role='group' aria-labelledby={titleId} data-testid={testId}>
+			<CardText role='status'>
+				<CardTitle as={`h${headingLevel}`} id={titleId}>
+					{title}
+				</CardTitle>
+				{description && <CardDescription>{description}</CardDescription>}
+			</CardText>
 			{retryButton && <CardActions>{retryButton}</CardActions>}
 		</CardWrapper>
 	)
@@ -62,8 +89,15 @@ const CardWrapper = styled.div.withConfig({ displayName: 'ErrorState' })`
 	margin: var(--space-md) auto;
 	max-width: 32rem;
 	text-align: center;
-	border-left: 4px solid var(--color-error);
+	border-inline-start: 4px solid var(--color-error);
 	color: var(--color-on-surface);
+`
+
+const CardText = styled.div.withConfig({ displayName: 'ErrorStateText' })`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--space-sm);
 `
 
 const CardTitle = styled.p.withConfig({ displayName: 'ErrorStateTitle' })`
@@ -104,8 +138,8 @@ const InlineWrapper = styled.div.withConfig({
 	gap: var(--space-sm);
 	flex-wrap: wrap;
 	padding: var(--space-2xs) var(--space-sm);
-	border-left: 3px solid var(--color-error);
-	background: color-mix(in srgb, var(--color-error) 6%, transparent);
+	border-inline-start: 3px solid var(--color-error);
+	background: var(--color-error-container);
 `
 
 const InlineText = styled.div.withConfig({
@@ -122,7 +156,7 @@ const InlineTitle = styled.p.withConfig({
 	margin: 0;
 	font-family: var(--font-body);
 	font-size: var(--typescale-body-small-size);
-	color: var(--color-error);
+	color: var(--color-on-error-container);
 `
 
 const InlineDescription = styled.div.withConfig({
@@ -131,7 +165,8 @@ const InlineDescription = styled.div.withConfig({
 	margin: 0;
 	font-family: var(--font-body);
 	font-size: var(--typescale-body-small-size);
-	color: var(--color-on-surface-variant);
+	color: var(--color-on-error-container);
+	opacity: 0.85;
 `
 
 const InlineActions = styled.div.withConfig({

--- a/apps/internal/src/components/shared/error-state.tsx
+++ b/apps/internal/src/components/shared/error-state.tsx
@@ -1,0 +1,143 @@
+import { Trans } from '@lingui/react/macro'
+import type { ReactNode } from 'react'
+import styled from 'styled-components'
+
+import { PriButton } from '@batuda/ui/pri'
+
+import { agedPaperSurface } from '#/lib/workshop-mixins'
+
+/**
+ * Tells the reader something broke while loading, so a failed fetch is never
+ * mistaken for "you have no data". Omit `onRetry` when trying again cannot
+ * help — a button that does nothing is worse than no button.
+ */
+export function ErrorState({
+	title,
+	description,
+	onRetry,
+	variant = 'card',
+	'data-testid': testId,
+}: {
+	title: string
+	description?: ReactNode
+	onRetry?: () => void
+	variant?: 'card' | 'inline'
+	'data-testid'?: string
+}) {
+	const retryButton = onRetry && (
+		<PriButton type='button' $variant='outlined' onClick={() => onRetry()}>
+			<Trans>Retry</Trans>
+		</PriButton>
+	)
+
+	if (variant === 'inline') {
+		return (
+			<InlineWrapper role='alert' data-testid={testId}>
+				<InlineText>
+					<InlineTitle>{title}</InlineTitle>
+					{description && <InlineDescription>{description}</InlineDescription>}
+				</InlineText>
+				{retryButton && <InlineActions>{retryButton}</InlineActions>}
+			</InlineWrapper>
+		)
+	}
+
+	return (
+		<CardWrapper role='alert' data-testid={testId}>
+			<CardTitle>{title}</CardTitle>
+			{description && <CardDescription>{description}</CardDescription>}
+			{retryButton && <CardActions>{retryButton}</CardActions>}
+		</CardWrapper>
+	)
+}
+
+const CardWrapper = styled.div.withConfig({ displayName: 'ErrorState' })`
+	${agedPaperSurface}
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--space-sm);
+	padding: var(--space-xl) var(--space-lg);
+	margin: var(--space-md) auto;
+	max-width: 32rem;
+	text-align: center;
+	border-left: 4px solid var(--color-error);
+	color: var(--color-on-surface);
+`
+
+const CardTitle = styled.p.withConfig({ displayName: 'ErrorStateTitle' })`
+	margin: 0;
+	font-family: var(--font-display);
+	font-size: var(--typescale-title-medium-size);
+	line-height: var(--typescale-title-medium-line);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-error);
+`
+
+const CardDescription = styled.div.withConfig({
+	displayName: 'ErrorStateDescription',
+})`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	line-height: var(--typescale-body-medium-line);
+	color: var(--color-on-surface-variant);
+	max-width: 28rem;
+`
+
+const CardActions = styled.div.withConfig({ displayName: 'ErrorStateActions' })`
+	display: flex;
+	align-items: center;
+	gap: var(--space-sm);
+	margin-top: var(--space-2xs);
+`
+
+const InlineWrapper = styled.div.withConfig({
+	displayName: 'ErrorStateInline',
+})`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-sm);
+	flex-wrap: wrap;
+	padding: var(--space-2xs) var(--space-sm);
+	border-left: 3px solid var(--color-error);
+	background: color-mix(in srgb, var(--color-error) 6%, transparent);
+`
+
+const InlineText = styled.div.withConfig({
+	displayName: 'ErrorStateInlineText',
+})`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+`
+
+const InlineTitle = styled.p.withConfig({
+	displayName: 'ErrorStateInlineTitle',
+})`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-error);
+`
+
+const InlineDescription = styled.div.withConfig({
+	displayName: 'ErrorStateInlineDescription',
+})`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const InlineActions = styled.div.withConfig({
+	displayName: 'ErrorStateInlineActions',
+})`
+	display: flex;
+	align-items: center;
+	gap: var(--space-2xs);
+`

--- a/apps/internal/src/components/shared/relative-date.tsx
+++ b/apps/internal/src/components/shared/relative-date.tsx
@@ -30,7 +30,15 @@ export function RelativeDate({
 
 	const label = formatRelative(date)
 	return (
-		<Time dateTime={date.toISOString()} title={date.toLocaleString('en')}>
+		// The server sits in UTC and the reader's browser does not, so the
+		// spelled-out time and the "5 months ago" wording are both allowed to
+		// differ between the two. Saying so keeps React from giving up on this
+		// part of the page, which would leave nearby buttons unclickable.
+		<Time
+			suppressHydrationWarning
+			dateTime={date.toISOString()}
+			title={date.toLocaleString('en')}
+		>
 			{label}
 		</Time>
 	)

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -791,21 +791,6 @@ msgstr "Interfícies de xat (OAuth)"
 msgid "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
 msgstr "ChatGPT i Claude.ai no poden enviar una clau, així que es connecten amb OAuth. Afegeix aquest servidor per URL, aprova'l i apareixerà a les teves connexions."
 
-#: src/routes/companies/$slug.tsx
-#: src/routes/emails/index.tsx
-#: src/routes/pages/$id.tsx
-#~ msgid "Check that the session is valid or try again."
-#~ msgstr "Comprova que la sessió sigui vàlida o torna-ho a provar."
-
-#: src/components/companies/pipeline-board.tsx
-#: src/routes/companies/index.tsx
-#~ msgid "Check that your session is valid or try again."
-#~ msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
-
-#: src/routes/emails/inboxes.tsx
-#~ msgid "Check the session or try again."
-#~ msgstr "Comprova la sessió o torna-ho a provar."
-
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
 msgid "Check your inbox"
@@ -931,10 +916,6 @@ msgstr "Empresa"
 #: src/components/research/research-dialog.tsx
 msgid "Company enrichment"
 msgstr "Enriquiment d'empresa"
-
-#: src/routes/companies/$slug.tsx
-msgid "Company shape unrecognised"
-msgstr "Format d'empresa no reconegut"
 
 #: src/components/research/research-dialog.tsx
 msgid "Competitor scan"
@@ -1197,17 +1178,9 @@ msgstr "No s'han pogut carregar els fils"
 msgid "Could not load your connections."
 msgstr "No s'han pogut carregar les teves connexions."
 
-#: src/routes/settings/mcp/connections.tsx
-#~ msgid "Could not load your connections. Refresh to try again."
-#~ msgstr "No s'han pogut carregar les connexions. Actualitza per tornar-ho a provar."
-
 #: src/routes/settings/api-keys/index.tsx
 msgid "Could not load your keys."
 msgstr "No s'han pogut carregar les teves claus."
-
-#: src/routes/settings/api-keys/index.tsx
-#~ msgid "Could not load your keys. Refresh to try again."
-#~ msgstr "No s'han pogut carregar les teves claus. Actualitza per tornar-ho a provar."
 
 #: src/components/research/run-list.tsx
 msgid "Could not load your runs."
@@ -1354,25 +1327,13 @@ msgstr "No s'ha pogut eliminar la plantilla. Torna-ho a provar."
 msgid "Couldn't load the org default."
 msgstr "No s'ha pogut carregar el valor per defecte de l'organització."
 
-#: src/routes/settings/organization/templates.tsx
-#~ msgid "Couldn't load the org default. Refresh to try again."
-#~ msgstr "No s'ha pogut carregar el valor per defecte de l'organització. Actualitza per tornar-ho a provar."
-
 #: src/routes/settings/profile/templates.tsx
 msgid "Couldn't load your default."
 msgstr "No s'ha pogut carregar el teu valor per defecte."
 
 #: src/routes/settings/profile/templates.tsx
-#~ msgid "Couldn't load your default. Refresh to try again."
-#~ msgstr "No s'ha pogut carregar el teu valor per defecte. Actualitza per tornar-ho a provar."
-
-#: src/routes/settings/profile/templates.tsx
 msgid "Couldn't load your templates."
 msgstr "No s'han pogut carregar les teves plantilles."
-
-#: src/routes/settings/profile/templates.tsx
-#~ msgid "Couldn't load your templates. Refresh to try again."
-#~ msgstr "No s'han pogut carregar les teves plantilles. Actualitza per tornar-ho a provar."
 
 #: src/routes/settings/organization/templates.tsx
 msgid "Couldn't save"
@@ -3173,10 +3134,6 @@ msgid "Page saved"
 msgstr "Pàgina desada"
 
 #: src/routes/pages/$id.tsx
-msgid "Page shape unrecognised"
-msgstr "Format de pàgina no reconegut"
-
-#: src/routes/pages/$id.tsx
 msgid "Page title"
 msgstr "Títol de la pàgina"
 
@@ -3784,10 +3741,6 @@ msgstr "Inicia una recerca"
 msgid "Run not found"
 msgstr "Execució no trobada"
 
-#: src/components/research/run-detail.tsx
-msgid "Run shape unrecognised."
-msgstr "Format d'execució no reconegut."
-
 #: src/components/research/run-labels.ts
 msgid "Running"
 msgstr "En execució"
@@ -4393,6 +4346,14 @@ msgstr "El canvi no s'ha completat. Torna-ho a provar."
 msgid "The company could not be fetched. Check that the session is valid, then try again."
 msgstr "No s'ha pogut carregar l'empresa. Comprova que la sessió sigui vàlida i torna-ho a provar."
 
+#: src/routes/pages/$id.tsx
+msgid "The content arrived in a form the editor cannot read, so there is nothing to edit. Go back to the list and open the page again; report it if it keeps happening."
+msgstr "El contingut ha arribat en un format que l'editor no pot llegir, així que no hi ha res per editar. Torna a la llista i obre la pàgina de nou; informa-ho si continua passant."
+
+#: src/routes/companies/$slug.tsx
+msgid "The details arrived in a form this page cannot read, so there is nothing to show. Go back to the list and open the company again; report it if it keeps happening."
+msgstr "Les dades han arribat en un format que aquesta pàgina no pot llegir, així que no hi ha res per mostrar. Torna a la llista i obre l'empresa de nou; informa-ho si continua passant."
+
 #: src/components/companies/where-panel-client.client.tsx
 msgid "The geocoder did not return a match. Try editing the location field."
 msgstr "El geocodificador no ha trobat cap coincidència. Prova d'editar el camp d'ubicació."
@@ -4425,6 +4386,10 @@ msgstr "La pàgina ja està publicada."
 #: src/components/research/run-detail.tsx
 msgid "The pages I found were about a different company, so I didn't save anything."
 msgstr "Les pàgines que he trobat eren d'una altra empresa, així que no he desat res."
+
+#: src/components/research/run-detail.tsx
+msgid "The run arrived in a form this page cannot read. Go back to the run list and open it again; report it if it keeps happening."
+msgstr "L'execució ha arribat en un format que aquesta pàgina no pot llegir. Torna a la llista d'execucions i obre-la de nou; informa-ho si continua passant."
 
 #: src/components/research/findings/freeform-view.tsx
 msgid "The run finished without proposed updates or paid actions."
@@ -4498,6 +4463,10 @@ msgstr "Han respost — defineix la següent acció per mantenir-ho actiu."
 msgid "They sign in at the sign-in page with this address and ask for their own link, so nothing sent here can expire."
 msgstr "La persona inicia la sessió a la pàgina d'inici de sessió amb aquesta adreça i demana el seu propi enllaç, de manera que res del que s'enviï des d'aquí no pot caducar."
 
+#: src/routes/companies/$slug.tsx
+msgid "This company can't be displayed"
+msgstr "Aquesta empresa no es pot mostrar"
+
 #: src/routes/settings/mcp/connections.tsx
 msgid "This connection is unbound. Bind an org to use it."
 msgstr "Aquesta connexió no està vinculada. Vincula una organització per fer-la servir."
@@ -4519,9 +4488,17 @@ msgstr "Aquest mes"
 msgid "This overrides the site I auto-detected and re-runs the research locked onto the company at that domain."
 msgstr "Això substitueix el lloc que he detectat automàticament i torna a executar la recerca fixada en l'empresa d'aquest domini."
 
+#: src/routes/pages/$id.tsx
+msgid "This page can't be displayed"
+msgstr "Aquesta pàgina no es pot mostrar"
+
 #: src/routes/oauth/consent.tsx
 msgid "This page opens when an AI assistant asks to connect. Start the connection from your assistant."
 msgstr "Aquesta pàgina s'obre quan un assistent d'IA demana connectar-se. Inicia la connexió des del teu assistent."
+
+#: src/components/research/run-detail.tsx
+msgid "This run can't be displayed."
+msgstr "Aquesta execució no es pot mostrar."
 
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "This run found no changes to review."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -794,17 +794,17 @@ msgstr "ChatGPT i Claude.ai no poden enviar una clau, així que es connecten amb
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/index.tsx
 #: src/routes/pages/$id.tsx
-msgid "Check that the session is valid or try again."
-msgstr "Comprova que la sessió sigui vàlida o torna-ho a provar."
+#~ msgid "Check that the session is valid or try again."
+#~ msgstr "Comprova que la sessió sigui vàlida o torna-ho a provar."
 
 #: src/components/companies/pipeline-board.tsx
 #: src/routes/companies/index.tsx
-msgid "Check that your session is valid or try again."
-msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
+#~ msgid "Check that your session is valid or try again."
+#~ msgstr "Comprova que la teva sessió sigui vàlida o torna-ho a provar."
 
 #: src/routes/emails/inboxes.tsx
-msgid "Check the session or try again."
-msgstr "Comprova la sessió o torna-ho a provar."
+#~ msgid "Check the session or try again."
+#~ msgstr "Comprova la sessió o torna-ho a provar."
 
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
@@ -931,6 +931,10 @@ msgstr "Empresa"
 #: src/components/research/research-dialog.tsx
 msgid "Company enrichment"
 msgstr "Enriquiment d'empresa"
+
+#: src/routes/companies/$slug.tsx
+msgid "Company shape unrecognised"
+msgstr "Format d'empresa no reconegut"
 
 #: src/components/research/research-dialog.tsx
 msgid "Competitor scan"
@@ -1161,6 +1165,10 @@ msgstr "No s'han pogut carregar les empreses"
 msgid "Could not load inboxes"
 msgstr "No s'han pogut carregar les safates"
 
+#: src/routes/pages/index.tsx
+msgid "Could not load pages"
+msgstr "No s'han pogut carregar les pàgines"
+
 #: src/components/companies/pipeline-board.tsx
 msgid "Could not load the board"
 msgstr "No s'ha pogut carregar el tauler"
@@ -1186,12 +1194,20 @@ msgid "Could not load threads"
 msgstr "No s'han pogut carregar els fils"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "Could not load your connections. Refresh to try again."
-msgstr "No s'han pogut carregar les connexions. Actualitza per tornar-ho a provar."
+msgid "Could not load your connections."
+msgstr "No s'han pogut carregar les teves connexions."
+
+#: src/routes/settings/mcp/connections.tsx
+#~ msgid "Could not load your connections. Refresh to try again."
+#~ msgstr "No s'han pogut carregar les connexions. Actualitza per tornar-ho a provar."
 
 #: src/routes/settings/api-keys/index.tsx
-msgid "Could not load your keys. Refresh to try again."
-msgstr "No s'han pogut carregar les teves claus. Actualitza per tornar-ho a provar."
+msgid "Could not load your keys."
+msgstr "No s'han pogut carregar les teves claus."
+
+#: src/routes/settings/api-keys/index.tsx
+#~ msgid "Could not load your keys. Refresh to try again."
+#~ msgstr "No s'han pogut carregar les teves claus. Actualitza per tornar-ho a provar."
 
 #: src/components/research/run-list.tsx
 msgid "Could not load your runs."
@@ -1335,16 +1351,28 @@ msgid "Couldn't delete the template. Please try again."
 msgstr "No s'ha pogut eliminar la plantilla. Torna-ho a provar."
 
 #: src/routes/settings/organization/templates.tsx
-msgid "Couldn't load the org default. Refresh to try again."
-msgstr "No s'ha pogut carregar el valor per defecte de l'organització. Actualitza per tornar-ho a provar."
+msgid "Couldn't load the org default."
+msgstr "No s'ha pogut carregar el valor per defecte de l'organització."
+
+#: src/routes/settings/organization/templates.tsx
+#~ msgid "Couldn't load the org default. Refresh to try again."
+#~ msgstr "No s'ha pogut carregar el valor per defecte de l'organització. Actualitza per tornar-ho a provar."
 
 #: src/routes/settings/profile/templates.tsx
-msgid "Couldn't load your default. Refresh to try again."
-msgstr "No s'ha pogut carregar el teu valor per defecte. Actualitza per tornar-ho a provar."
+msgid "Couldn't load your default."
+msgstr "No s'ha pogut carregar el teu valor per defecte."
 
 #: src/routes/settings/profile/templates.tsx
-msgid "Couldn't load your templates. Refresh to try again."
-msgstr "No s'han pogut carregar les teves plantilles. Actualitza per tornar-ho a provar."
+#~ msgid "Couldn't load your default. Refresh to try again."
+#~ msgstr "No s'ha pogut carregar el teu valor per defecte. Actualitza per tornar-ho a provar."
+
+#: src/routes/settings/profile/templates.tsx
+msgid "Couldn't load your templates."
+msgstr "No s'han pogut carregar les teves plantilles."
+
+#: src/routes/settings/profile/templates.tsx
+#~ msgid "Couldn't load your templates. Refresh to try again."
+#~ msgstr "No s'han pogut carregar les teves plantilles. Actualitza per tornar-ho a provar."
 
 #: src/routes/settings/organization/templates.tsx
 msgid "Couldn't save"
@@ -3145,6 +3173,10 @@ msgid "Page saved"
 msgstr "Pàgina desada"
 
 #: src/routes/pages/$id.tsx
+msgid "Page shape unrecognised"
+msgstr "Format de pàgina no reconegut"
+
+#: src/routes/pages/$id.tsx
 msgid "Page title"
 msgstr "Títol de la pàgina"
 
@@ -3703,7 +3735,7 @@ msgstr "Reprèn l'esborrany (1)"
 msgid "Resume syncing"
 msgstr "Reprèn la sincronització"
 
-#: src/components/research/inbox/research-inbox.tsx
+#: src/components/shared/error-state.tsx
 msgid "Retry"
 msgstr "Torna-ho a provar"
 
@@ -4348,14 +4380,31 @@ msgstr "Les 20 tasques obertes editades més recentment. Fes-hi clic per reobrir
 msgid "The API key can no longer be used."
 msgstr "La clau d'API ja no es pot fer servir."
 
+#: src/components/companies/pipeline-board.tsx
+msgid "The board could not be fetched. Check that the session is valid, then try again."
+msgstr "No s'ha pogut carregar el tauler. Comprova que la sessió sigui vàlida i torna-ho a provar."
+
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "El canvi no s'ha completat. Torna-ho a provar."
 
+#: src/routes/companies/$slug.tsx
+msgid "The company could not be fetched. Check that the session is valid, then try again."
+msgstr "No s'ha pogut carregar l'empresa. Comprova que la sessió sigui vàlida i torna-ho a provar."
+
 #: src/components/companies/where-panel-client.client.tsx
 msgid "The geocoder did not return a match. Try editing the location field."
 msgstr "El geocodificador no ha trobat cap coincidència. Prova d'editar el camp d'ubicació."
+
+#: src/routes/emails/inboxes.tsx
+msgid "The inboxes could not be fetched. Check that the session is valid, then try again."
+msgstr "No s'han pogut carregar les safates. Comprova que la sessió sigui vàlida i torna-ho a provar."
+
+#: src/routes/companies/index.tsx
+#: src/routes/pages/index.tsx
+msgid "The list could not be fetched. Check that the session is valid, then try again."
+msgstr "No s'ha pogut carregar la llista. Comprova que la sessió sigui vàlida i torna-ho a provar."
 
 #: src/routes/emails/inboxes.tsx
 msgid "The mailbox is ready."
@@ -4364,6 +4413,10 @@ msgstr "La bústia està a punt."
 #: src/components/research/run-detail.tsx
 msgid "The name matched too many companies to tell them apart."
 msgstr "El nom coincidia amb massa empreses per distingir-les."
+
+#: src/routes/pages/$id.tsx
+msgid "The page could not be fetched. Check that the session is valid, then try again."
+msgstr "No s'ha pogut carregar la pàgina. Comprova que la sessió sigui vàlida i torna-ho a provar."
 
 #: src/routes/pages/$id.tsx
 msgid "The page is now live."
@@ -4384,6 +4437,10 @@ msgstr "El fil existeix però el proveïdor no ha retornat cap missatge."
 #: src/routes/emails/$threadId.tsx
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "Potser el fil s'ha arxivat al proveïdor o l'enllaç és obsolet."
+
+#: src/routes/emails/index.tsx
+msgid "The threads could not be fetched. Check that the session is valid, then try again."
+msgstr "No s'han pogut carregar les converses. Comprova que la sessió sigui vàlida i torna-ho a provar."
 
 #: src/routes/reset-password.tsx
 msgid "The token expired or was already used. Request a fresh link."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -791,21 +791,6 @@ msgstr "Chat interfaces (OAuth)"
 msgid "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
 msgstr "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add this server by URL, approve it, and it appears under your connections."
 
-#: src/routes/companies/$slug.tsx
-#: src/routes/emails/index.tsx
-#: src/routes/pages/$id.tsx
-#~ msgid "Check that the session is valid or try again."
-#~ msgstr "Check that the session is valid or try again."
-
-#: src/components/companies/pipeline-board.tsx
-#: src/routes/companies/index.tsx
-#~ msgid "Check that your session is valid or try again."
-#~ msgstr "Check that your session is valid or try again."
-
-#: src/routes/emails/inboxes.tsx
-#~ msgid "Check the session or try again."
-#~ msgstr "Check the session or try again."
-
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
 msgid "Check your inbox"
@@ -931,10 +916,6 @@ msgstr "Company"
 #: src/components/research/research-dialog.tsx
 msgid "Company enrichment"
 msgstr "Company enrichment"
-
-#: src/routes/companies/$slug.tsx
-msgid "Company shape unrecognised"
-msgstr "Company shape unrecognised"
 
 #: src/components/research/research-dialog.tsx
 msgid "Competitor scan"
@@ -1197,17 +1178,9 @@ msgstr "Could not load threads"
 msgid "Could not load your connections."
 msgstr "Could not load your connections."
 
-#: src/routes/settings/mcp/connections.tsx
-#~ msgid "Could not load your connections. Refresh to try again."
-#~ msgstr "Could not load your connections. Refresh to try again."
-
 #: src/routes/settings/api-keys/index.tsx
 msgid "Could not load your keys."
 msgstr "Could not load your keys."
-
-#: src/routes/settings/api-keys/index.tsx
-#~ msgid "Could not load your keys. Refresh to try again."
-#~ msgstr "Could not load your keys. Refresh to try again."
 
 #: src/components/research/run-list.tsx
 msgid "Could not load your runs."
@@ -1354,25 +1327,13 @@ msgstr "Couldn't delete the template. Please try again."
 msgid "Couldn't load the org default."
 msgstr "Couldn't load the org default."
 
-#: src/routes/settings/organization/templates.tsx
-#~ msgid "Couldn't load the org default. Refresh to try again."
-#~ msgstr "Couldn't load the org default. Refresh to try again."
-
 #: src/routes/settings/profile/templates.tsx
 msgid "Couldn't load your default."
 msgstr "Couldn't load your default."
 
 #: src/routes/settings/profile/templates.tsx
-#~ msgid "Couldn't load your default. Refresh to try again."
-#~ msgstr "Couldn't load your default. Refresh to try again."
-
-#: src/routes/settings/profile/templates.tsx
 msgid "Couldn't load your templates."
 msgstr "Couldn't load your templates."
-
-#: src/routes/settings/profile/templates.tsx
-#~ msgid "Couldn't load your templates. Refresh to try again."
-#~ msgstr "Couldn't load your templates. Refresh to try again."
 
 #: src/routes/settings/organization/templates.tsx
 msgid "Couldn't save"
@@ -3173,10 +3134,6 @@ msgid "Page saved"
 msgstr "Page saved"
 
 #: src/routes/pages/$id.tsx
-msgid "Page shape unrecognised"
-msgstr "Page shape unrecognised"
-
-#: src/routes/pages/$id.tsx
 msgid "Page title"
 msgstr "Page title"
 
@@ -3784,10 +3741,6 @@ msgstr "Run new research"
 msgid "Run not found"
 msgstr "Run not found"
 
-#: src/components/research/run-detail.tsx
-msgid "Run shape unrecognised."
-msgstr "Run shape unrecognised."
-
 #: src/components/research/run-labels.ts
 msgid "Running"
 msgstr "Running"
@@ -4393,6 +4346,14 @@ msgstr "The change didn't go through. Try again."
 msgid "The company could not be fetched. Check that the session is valid, then try again."
 msgstr "The company could not be fetched. Check that the session is valid, then try again."
 
+#: src/routes/pages/$id.tsx
+msgid "The content arrived in a form the editor cannot read, so there is nothing to edit. Go back to the list and open the page again; report it if it keeps happening."
+msgstr "The content arrived in a form the editor cannot read, so there is nothing to edit. Go back to the list and open the page again; report it if it keeps happening."
+
+#: src/routes/companies/$slug.tsx
+msgid "The details arrived in a form this page cannot read, so there is nothing to show. Go back to the list and open the company again; report it if it keeps happening."
+msgstr "The details arrived in a form this page cannot read, so there is nothing to show. Go back to the list and open the company again; report it if it keeps happening."
+
 #: src/components/companies/where-panel-client.client.tsx
 msgid "The geocoder did not return a match. Try editing the location field."
 msgstr "The geocoder did not return a match. Try editing the location field."
@@ -4425,6 +4386,10 @@ msgstr "The page is now live."
 #: src/components/research/run-detail.tsx
 msgid "The pages I found were about a different company, so I didn't save anything."
 msgstr "The pages I found were about a different company, so I didn't save anything."
+
+#: src/components/research/run-detail.tsx
+msgid "The run arrived in a form this page cannot read. Go back to the run list and open it again; report it if it keeps happening."
+msgstr "The run arrived in a form this page cannot read. Go back to the run list and open it again; report it if it keeps happening."
 
 #: src/components/research/findings/freeform-view.tsx
 msgid "The run finished without proposed updates or paid actions."
@@ -4498,6 +4463,10 @@ msgstr "They responded — set the next action to keep it warm."
 msgid "They sign in at the sign-in page with this address and ask for their own link, so nothing sent here can expire."
 msgstr "They sign in at the sign-in page with this address and ask for their own link, so nothing sent here can expire."
 
+#: src/routes/companies/$slug.tsx
+msgid "This company can't be displayed"
+msgstr "This company can't be displayed"
+
 #: src/routes/settings/mcp/connections.tsx
 msgid "This connection is unbound. Bind an org to use it."
 msgstr "This connection is unbound. Bind an org to use it."
@@ -4519,9 +4488,17 @@ msgstr "This month"
 msgid "This overrides the site I auto-detected and re-runs the research locked onto the company at that domain."
 msgstr "This overrides the site I auto-detected and re-runs the research locked onto the company at that domain."
 
+#: src/routes/pages/$id.tsx
+msgid "This page can't be displayed"
+msgstr "This page can't be displayed"
+
 #: src/routes/oauth/consent.tsx
 msgid "This page opens when an AI assistant asks to connect. Start the connection from your assistant."
 msgstr "This page opens when an AI assistant asks to connect. Start the connection from your assistant."
+
+#: src/components/research/run-detail.tsx
+msgid "This run can't be displayed."
+msgstr "This run can't be displayed."
 
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "This run found no changes to review."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -794,17 +794,17 @@ msgstr "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add 
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/index.tsx
 #: src/routes/pages/$id.tsx
-msgid "Check that the session is valid or try again."
-msgstr "Check that the session is valid or try again."
+#~ msgid "Check that the session is valid or try again."
+#~ msgstr "Check that the session is valid or try again."
 
 #: src/components/companies/pipeline-board.tsx
 #: src/routes/companies/index.tsx
-msgid "Check that your session is valid or try again."
-msgstr "Check that your session is valid or try again."
+#~ msgid "Check that your session is valid or try again."
+#~ msgstr "Check that your session is valid or try again."
 
 #: src/routes/emails/inboxes.tsx
-msgid "Check the session or try again."
-msgstr "Check the session or try again."
+#~ msgid "Check the session or try again."
+#~ msgstr "Check the session or try again."
 
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
@@ -931,6 +931,10 @@ msgstr "Company"
 #: src/components/research/research-dialog.tsx
 msgid "Company enrichment"
 msgstr "Company enrichment"
+
+#: src/routes/companies/$slug.tsx
+msgid "Company shape unrecognised"
+msgstr "Company shape unrecognised"
 
 #: src/components/research/research-dialog.tsx
 msgid "Competitor scan"
@@ -1161,6 +1165,10 @@ msgstr "Could not load companies"
 msgid "Could not load inboxes"
 msgstr "Could not load inboxes"
 
+#: src/routes/pages/index.tsx
+msgid "Could not load pages"
+msgstr "Could not load pages"
+
 #: src/components/companies/pipeline-board.tsx
 msgid "Could not load the board"
 msgstr "Could not load the board"
@@ -1186,12 +1194,20 @@ msgid "Could not load threads"
 msgstr "Could not load threads"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "Could not load your connections. Refresh to try again."
-msgstr "Could not load your connections. Refresh to try again."
+msgid "Could not load your connections."
+msgstr "Could not load your connections."
+
+#: src/routes/settings/mcp/connections.tsx
+#~ msgid "Could not load your connections. Refresh to try again."
+#~ msgstr "Could not load your connections. Refresh to try again."
 
 #: src/routes/settings/api-keys/index.tsx
-msgid "Could not load your keys. Refresh to try again."
-msgstr "Could not load your keys. Refresh to try again."
+msgid "Could not load your keys."
+msgstr "Could not load your keys."
+
+#: src/routes/settings/api-keys/index.tsx
+#~ msgid "Could not load your keys. Refresh to try again."
+#~ msgstr "Could not load your keys. Refresh to try again."
 
 #: src/components/research/run-list.tsx
 msgid "Could not load your runs."
@@ -1335,16 +1351,28 @@ msgid "Couldn't delete the template. Please try again."
 msgstr "Couldn't delete the template. Please try again."
 
 #: src/routes/settings/organization/templates.tsx
-msgid "Couldn't load the org default. Refresh to try again."
-msgstr "Couldn't load the org default. Refresh to try again."
+msgid "Couldn't load the org default."
+msgstr "Couldn't load the org default."
+
+#: src/routes/settings/organization/templates.tsx
+#~ msgid "Couldn't load the org default. Refresh to try again."
+#~ msgstr "Couldn't load the org default. Refresh to try again."
 
 #: src/routes/settings/profile/templates.tsx
-msgid "Couldn't load your default. Refresh to try again."
-msgstr "Couldn't load your default. Refresh to try again."
+msgid "Couldn't load your default."
+msgstr "Couldn't load your default."
 
 #: src/routes/settings/profile/templates.tsx
-msgid "Couldn't load your templates. Refresh to try again."
-msgstr "Couldn't load your templates. Refresh to try again."
+#~ msgid "Couldn't load your default. Refresh to try again."
+#~ msgstr "Couldn't load your default. Refresh to try again."
+
+#: src/routes/settings/profile/templates.tsx
+msgid "Couldn't load your templates."
+msgstr "Couldn't load your templates."
+
+#: src/routes/settings/profile/templates.tsx
+#~ msgid "Couldn't load your templates. Refresh to try again."
+#~ msgstr "Couldn't load your templates. Refresh to try again."
 
 #: src/routes/settings/organization/templates.tsx
 msgid "Couldn't save"
@@ -3145,6 +3173,10 @@ msgid "Page saved"
 msgstr "Page saved"
 
 #: src/routes/pages/$id.tsx
+msgid "Page shape unrecognised"
+msgstr "Page shape unrecognised"
+
+#: src/routes/pages/$id.tsx
 msgid "Page title"
 msgstr "Page title"
 
@@ -3703,7 +3735,7 @@ msgstr "Resume drafting (1)"
 msgid "Resume syncing"
 msgstr "Resume syncing"
 
-#: src/components/research/inbox/research-inbox.tsx
+#: src/components/shared/error-state.tsx
 msgid "Retry"
 msgstr "Retry"
 
@@ -4348,14 +4380,31 @@ msgstr "The 20 most recently edited open tasks. Click one to reopen it."
 msgid "The API key can no longer be used."
 msgstr "The API key can no longer be used."
 
+#: src/components/companies/pipeline-board.tsx
+msgid "The board could not be fetched. Check that the session is valid, then try again."
+msgstr "The board could not be fetched. Check that the session is valid, then try again."
+
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "The change didn't go through. Try again."
 
+#: src/routes/companies/$slug.tsx
+msgid "The company could not be fetched. Check that the session is valid, then try again."
+msgstr "The company could not be fetched. Check that the session is valid, then try again."
+
 #: src/components/companies/where-panel-client.client.tsx
 msgid "The geocoder did not return a match. Try editing the location field."
 msgstr "The geocoder did not return a match. Try editing the location field."
+
+#: src/routes/emails/inboxes.tsx
+msgid "The inboxes could not be fetched. Check that the session is valid, then try again."
+msgstr "The inboxes could not be fetched. Check that the session is valid, then try again."
+
+#: src/routes/companies/index.tsx
+#: src/routes/pages/index.tsx
+msgid "The list could not be fetched. Check that the session is valid, then try again."
+msgstr "The list could not be fetched. Check that the session is valid, then try again."
 
 #: src/routes/emails/inboxes.tsx
 msgid "The mailbox is ready."
@@ -4364,6 +4413,10 @@ msgstr "The mailbox is ready."
 #: src/components/research/run-detail.tsx
 msgid "The name matched too many companies to tell them apart."
 msgstr "The name matched too many companies to tell them apart."
+
+#: src/routes/pages/$id.tsx
+msgid "The page could not be fetched. Check that the session is valid, then try again."
+msgstr "The page could not be fetched. Check that the session is valid, then try again."
 
 #: src/routes/pages/$id.tsx
 msgid "The page is now live."
@@ -4384,6 +4437,10 @@ msgstr "The thread exists but the provider returned no messages."
 #: src/routes/emails/$threadId.tsx
 msgid "The thread may have been archived upstream or the link is stale."
 msgstr "The thread may have been archived upstream or the link is stale."
+
+#: src/routes/emails/index.tsx
+msgid "The threads could not be fetched. Check that the session is valid, then try again."
+msgstr "The threads could not be fetched. Check that the session is valid, then try again."
 
 #: src/routes/reset-password.tsx
 msgid "The token expired or was already used. Request a fresh link."

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -386,6 +386,7 @@ function CompanyDetailPage() {
 			<Page>
 				<ErrorState
 					data-testid='company-error'
+					headingLevel={1}
 					title={t`Could not load this company`}
 					description={t`The company could not be fetched. Check that the session is valid, then try again.`}
 					onRetry={refreshCompany}
@@ -401,7 +402,9 @@ function CompanyDetailPage() {
 			<Page>
 				<ErrorState
 					data-testid='company-shape-error'
-					title={t`Company shape unrecognised`}
+					headingLevel={1}
+					title={t`This company can't be displayed`}
+					description={t`The details arrived in a form this page cannot read, so there is nothing to show. Go back to the list and open the company again; report it if it keeps happening.`}
 				/>
 			</Page>
 		)

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -94,6 +94,7 @@ import {
 } from '#/components/research/run-shapes'
 import { TrustBadge } from '#/components/research/trust-badge'
 import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { PriorityDot } from '#/components/shared/priority-dot'
 import { RelativeDate } from '#/components/shared/relative-date'
@@ -380,12 +381,27 @@ function CompanyDetailPage() {
 		)
 	}
 
-	if (AsyncResult.isFailure(companyResult) || company === null) {
+	if (AsyncResult.isFailure(companyResult)) {
 		return (
 			<Page>
-				<EmptyState
+				<ErrorState
+					data-testid='company-error'
 					title={t`Could not load this company`}
-					description={t`Check that the session is valid or try again.`}
+					description={t`The company could not be fetched. Check that the session is valid, then try again.`}
+					onRetry={refreshCompany}
+				/>
+			</Page>
+		)
+	}
+
+	// The request succeeded but the company came back in a shape we don't
+	// recognise, so asking again would only return the same thing.
+	if (company === null) {
+		return (
+			<Page>
+				<ErrorState
+					data-testid='company-shape-error'
+					title={t`Company shape unrecognised`}
 				/>
 			</Page>
 		)

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from '@effect/atom-react'
+import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
 import { useLingui } from '@lingui/react/macro'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
@@ -25,6 +25,7 @@ import {
 } from '#/atoms/companies-atoms'
 import { CompanyCard } from '#/components/shared/company-card'
 import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { KpiCounter } from '#/components/shared/kpi-counter'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import {
@@ -173,6 +174,7 @@ function CompaniesListPage() {
 		[searchKey, visibleLimit],
 	)
 	const result = useAtomValue(atom)
+	const refreshCompanies = useAtomRefresh(atom)
 
 	const companies = useMemo<ReadonlyArray<CompanyRow>>(
 		() => (AsyncResult.isSuccess(result) ? narrowCompanies(result.value) : []),
@@ -411,9 +413,11 @@ function CompaniesListPage() {
 			{isLoading ? (
 				<LoadingSpinner label={t`Loading companies…`} />
 			) : isFailure ? (
-				<EmptyState
+				<ErrorState
+					data-testid='companies-error'
 					title={t`Could not load companies`}
-					description={t`Check that your session is valid or try again.`}
+					description={t`The list could not be fetched. Check that the session is valid, then try again.`}
+					onRetry={refreshCompanies}
 				/>
 			) : companies.length === 0 ? (
 				<EmptyState

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -58,6 +58,7 @@ import {
 	inboxDraftAtom,
 } from '#/atoms/inbox-draft-atoms'
 import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { SkeletonRows } from '#/components/shared/skeleton-row'
 import { dehydrateAtom } from '#/lib/atom-hydration'
@@ -477,9 +478,11 @@ function InboxesPage() {
 			{isLoading ? (
 				<SkeletonRows count={5} height='3rem' />
 			) : isFailure ? (
-				<EmptyState
+				<ErrorState
+					data-testid='inboxes-error'
 					title={t`Could not load inboxes`}
-					description={t`Check the session or try again.`}
+					description={t`The inboxes could not be fetched. Check that the session is valid, then try again.`}
+					onRetry={refreshInboxes}
 				/>
 			) : rows.length === 0 ? (
 				<EmptyState

--- a/apps/internal/src/routes/emails/index.tsx
+++ b/apps/internal/src/routes/emails/index.tsx
@@ -74,6 +74,7 @@ import {
 import { companiesListAtom } from '#/atoms/pipeline-atoms'
 import { PriTable } from '#/components/primitives/pri-table'
 import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { SkeletonRows } from '#/components/shared/skeleton-row'
 import { useComposeEmail } from '#/context/compose-email-context'
@@ -747,9 +748,11 @@ function EmailsIndexPage() {
 							description={t`Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed.`}
 						/>
 					) : isFailure ? (
-						<EmptyState
+						<ErrorState
+							data-testid='emails-error'
 							title={t`Could not load threads`}
-							description={t`Check that the session is valid or try again.`}
+							description={t`The threads could not be fetched. Check that the session is valid, then try again.`}
+							onRetry={refreshList}
 						/>
 					) : threads.length === 0 ? (
 						<EmptyState

--- a/apps/internal/src/routes/pages/$id.tsx
+++ b/apps/internal/src/routes/pages/$id.tsx
@@ -136,6 +136,7 @@ function PageEditorPage() {
 			<Page>
 				<ErrorState
 					data-testid='page-error'
+					headingLevel={1}
 					title={t`Could not load this page`}
 					description={t`The page could not be fetched. Check that the session is valid, then try again.`}
 					onRetry={refreshPage}
@@ -151,7 +152,9 @@ function PageEditorPage() {
 			<Page>
 				<ErrorState
 					data-testid='page-shape-error'
-					title={t`Page shape unrecognised`}
+					headingLevel={1}
+					title={t`This page can't be displayed`}
+					description={t`The content arrived in a form the editor cannot read, so there is nothing to edit. Go back to the list and open the page again; report it if it keeps happening.`}
 				/>
 			</Page>
 		)

--- a/apps/internal/src/routes/pages/$id.tsx
+++ b/apps/internal/src/routes/pages/$id.tsx
@@ -21,7 +21,7 @@ import { PriButton, PriTabs, usePriToast } from '@batuda/ui/pri'
 
 import { pageAtomFor } from '#/atoms/pages-atoms'
 import { useSetDocumentTitle } from '#/components/layout/top-bar-title'
-import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { dehydrateAtom } from '#/lib/atom-hydration'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
@@ -116,6 +116,7 @@ function PageEditorPage() {
 	const { id } = Route.useParams()
 	const atom = useMemo(() => pageAtomFor(id), [id])
 	const result = useAtomValue(atom)
+	const refreshPage = useAtomRefresh(atom)
 
 	const page = useMemo<PageDetail | null>(
 		() => (AsyncResult.isSuccess(result) ? narrowPage(result.value) : null),
@@ -130,12 +131,27 @@ function PageEditorPage() {
 		)
 	}
 
-	if (AsyncResult.isFailure(result) || page === null) {
+	if (AsyncResult.isFailure(result)) {
 		return (
 			<Page>
-				<EmptyState
+				<ErrorState
+					data-testid='page-error'
 					title={t`Could not load this page`}
-					description={t`Check that the session is valid or try again.`}
+					description={t`The page could not be fetched. Check that the session is valid, then try again.`}
+					onRetry={refreshPage}
+				/>
+			</Page>
+		)
+	}
+
+	// The request succeeded but the page came back in a shape we don't
+	// recognise, so asking again would only return the same thing.
+	if (page === null) {
+		return (
+			<Page>
+				<ErrorState
+					data-testid='page-shape-error'
+					title={t`Page shape unrecognised`}
 				/>
 			</Page>
 		)

--- a/apps/internal/src/routes/pages/index.tsx
+++ b/apps/internal/src/routes/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from '@effect/atom-react'
+import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
@@ -15,6 +15,7 @@ import {
 	pagesSearchAtom,
 } from '#/atoms/pages-atoms'
 import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { dehydrateAtom } from '#/lib/atom-hydration'
@@ -92,12 +93,14 @@ function PagesListPage() {
 	const searchKey = canonicalKey(search)
 	const atom = useMemo(() => pagesSearchAtom(search), [searchKey])
 	const result = useAtomValue(atom)
+	const refreshPages = useAtomRefresh(atom)
 
 	const pages = useMemo<ReadonlyArray<PageRow>>(
 		() => (AsyncResult.isSuccess(result) ? narrowPages(result.value) : []),
 		[result],
 	)
 	const isLoading = AsyncResult.isInitial(result)
+	const isFailure = AsyncResult.isFailure(result)
 
 	const [statusFilter, setStatusFilter] = useState(search.status ?? '')
 
@@ -134,6 +137,13 @@ function PagesListPage() {
 
 			{isLoading ? (
 				<LoadingSpinner />
+			) : isFailure ? (
+				<ErrorState
+					data-testid='pages-error'
+					title={t`Could not load pages`}
+					description={t`The list could not be fetched. Check that the session is valid, then try again.`}
+					onRetry={refreshPages}
+				/>
 			) : pages.length === 0 ? (
 				<EmptyState
 					title={t`No pages yet`}

--- a/apps/internal/src/routes/settings/api-keys/index.tsx
+++ b/apps/internal/src/routes/settings/api-keys/index.tsx
@@ -1,4 +1,4 @@
-import { useAtomSet, useAtomValue } from '@effect/atom-react'
+import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
@@ -15,6 +15,7 @@ import {
 	usePriToast,
 } from '@batuda/ui/pri'
 
+import { ErrorState } from '#/components/shared/error-state'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import {
 	brushedMetalPlate,
@@ -73,6 +74,7 @@ function ApiKeysPage() {
 	const toastManager = usePriToast()
 
 	const listResult = useAtomValue(apiKeysListAtom)
+	const refreshList = useAtomRefresh(apiKeysListAtom)
 
 	const createKey = useAtomSet(BatudaApiAtom.mutation('apiKeys', 'create'), {
 		mode: 'promiseExit',
@@ -278,9 +280,12 @@ function ApiKeysPage() {
 						<Trans>Loading…</Trans>
 					</Empty>
 				) : isFailure ? (
-					<Empty role='alert'>
-						<Trans>Could not load your keys. Refresh to try again.</Trans>
-					</Empty>
+					<ErrorState
+						variant='inline'
+						data-testid='api-keys-error'
+						title={t`Could not load your keys.`}
+						onRetry={refreshList}
+					/>
 				) : rows.length === 0 ? (
 					<Empty data-testid='api-keys-empty'>
 						<Trans>No keys yet. Create one above to connect an agent.</Trans>

--- a/apps/internal/src/routes/settings/mcp/connections.tsx
+++ b/apps/internal/src/routes/settings/mcp/connections.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { PriButton, usePriToast } from '@batuda/ui/pri'
 
+import { ErrorState } from '#/components/shared/error-state'
 import { authClient } from '#/lib/auth-client'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import {
@@ -168,11 +169,12 @@ function ConnectionsPage() {
 						<Trans>Loading…</Trans>
 					</Empty>
 				) : isFailure ? (
-					<Empty role='alert'>
-						<Trans>
-							Could not load your connections. Refresh to try again.
-						</Trans>
-					</Empty>
+					<ErrorState
+						variant='inline'
+						data-testid='mcp-connections-error'
+						title={t`Could not load your connections.`}
+						onRetry={refreshList}
+					/>
 				) : rows.length === 0 ? (
 					<Empty data-testid='mcp-connections-empty'>
 						<Trans>

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -36,7 +36,6 @@ import {
 	Empty,
 	Heading,
 	Intro,
-	Notice,
 	Page,
 	RowActions,
 	Section,
@@ -63,6 +62,7 @@ import {
 	type TemplateDraft,
 	TemplateEditorDialog,
 } from '#/components/instructions/template-editor-dialog'
+import { ErrorState } from '#/components/shared/error-state'
 import { authClient } from '#/lib/auth-client'
 import { ruledLedgerRow } from '#/lib/workshop-mixins'
 
@@ -389,9 +389,12 @@ function OrgTemplateAdmin({
 					</Trans>
 				</Hint>
 				{stacksFailed ? (
-					<Notice role='alert'>
-						<Trans>Couldn't load the org default. Refresh to try again.</Trans>
-					</Notice>
+					<ErrorState
+						variant='inline'
+						data-testid='org-stacks-error'
+						title={t`Couldn't load the org default.`}
+						onRetry={refreshStacks}
+					/>
 				) : orgTemplates.length === 0 ? (
 					<Empty>
 						<Trans>Add an org template first.</Trans>

--- a/apps/internal/src/routes/settings/profile/templates.tsx
+++ b/apps/internal/src/routes/settings/profile/templates.tsx
@@ -26,7 +26,6 @@ import {
 	Empty,
 	Heading,
 	Intro,
-	Notice,
 	Page,
 	RowActions,
 	Section,
@@ -50,6 +49,7 @@ import {
 	type TemplateDraft,
 	TemplateEditorDialog,
 } from '#/components/instructions/template-editor-dialog'
+import { ErrorState } from '#/components/shared/error-state'
 import { authClient } from '#/lib/auth-client'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
@@ -222,9 +222,12 @@ function TemplatesPage() {
 				</SectionHead>
 
 				{templatesFailed ? (
-					<Notice role='alert'>
-						<Trans>Couldn't load your templates. Refresh to try again.</Trans>
-					</Notice>
+					<ErrorState
+						variant='inline'
+						data-testid='profile-templates-error'
+						title={t`Couldn't load your templates.`}
+						onRetry={refreshTemplates}
+					/>
 				) : templates.length === 0 ? (
 					<Empty>
 						<Trans>
@@ -297,9 +300,12 @@ function TemplatesPage() {
 				</SectionHead>
 
 				{stacksFailed ? (
-					<Notice role='alert'>
-						<Trans>Couldn't load your default. Refresh to try again.</Trans>
-					</Notice>
+					<ErrorState
+						variant='inline'
+						data-testid='profile-stacks-error'
+						title={t`Couldn't load your default.`}
+						onRetry={refreshStacks}
+					/>
 				) : templates.length === 0 ? (
 					<EmptyDefault>
 						<EmptyDefaultTitle>

--- a/apps/internal/tests/e2e/company-overview.test.ts
+++ b/apps/internal/tests/e2e/company-overview.test.ts
@@ -116,12 +116,21 @@ test.describe('company-detail Overview tab', () => {
 			// AND the panel content is not visible before the trigger is clicked
 			await expect(page.getByTestId('company-about-panel')).toBeHidden()
 
-			// WHEN the user clicks the About trigger
-			await trigger.click()
+			// WHEN the user clicks the About trigger.
+			// The header runs a shared-layout animation and the dev server applies
+			// styles after first paint, so the trigger slides roughly 900px over the
+			// first second and a click sent mid-flight lands on empty space. Retry
+			// until it lands, and only while still closed so a click that did
+			// register is never undone by the next attempt.
+			const panel = page.getByTestId('company-about-panel')
+			await expect(async () => {
+				if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
+					await trigger.click()
+				}
+				await expect(panel).toBeVisible({ timeout: 1_000 })
+			}).toPass({ timeout: 15_000 })
 
 			// THEN the panel becomes visible
-			const panel = page.getByTestId('company-about-panel')
-			await expect(panel).toBeVisible()
 
 			// AND every grouped field label is reachable inside the panel
 			//   Sales context (5)

--- a/apps/internal/tests/e2e/mcp-connections.test.ts
+++ b/apps/internal/tests/e2e/mcp-connections.test.ts
@@ -14,20 +14,34 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe('settings — MCP connections', () => {
-	test('should reach the connections page from the settings nav and show the empty state', async ({
+	test('should reach the connections page from the settings nav and list the authorized clients', async ({
 		page,
 	}) => {
 		// GIVEN the Settings hub, which lands on the profile page
 		await page.goto('/settings', { waitUntil: 'networkidle' })
 		await expect(page).toHaveURL(/\/settings\/profile$/)
 
-		// WHEN she follows the Connections link
-		await page.getByTestId('settings-nav-mcp-connections').click()
+		// WHEN she follows the Connections link. On a cold dev server the route
+		// is still compiling, so a first click can land before the link is
+		// interactive; clicking a link is idempotent, so retry until it moves.
+		await expect(async () => {
+			await page.getByTestId('settings-nav-mcp-connections').click()
+			await expect(page).toHaveURL(/\/settings\/mcp\/connections$/, {
+				timeout: 2_000,
+			})
+		}).toPass({ timeout: 15_000 })
 
-		// THEN the connections page loads and shows the empty state (no clients
-		// authorized yet)
-		await expect(page).toHaveURL(/\/settings\/mcp\/connections$/)
-		await expect(page.getByTestId('mcp-connections-empty')).toBeVisible()
+		// THEN the page lists the clients the seed authorized for her — ChatGPT
+		// across two organizations and Claude across one, which is what the page
+		// exists to show. Asserting an empty state here would contradict the
+		// seed, whose whole purpose is to give this page something to render.
+		await expect(page.getByTestId('mcp-connection-row')).toHaveCount(2)
+		await expect(
+			page.getByTestId('mcp-connection-name').filter({ hasText: 'ChatGPT' }),
+		).toBeVisible()
+		await expect(
+			page.getByTestId('mcp-connection-name').filter({ hasText: 'Claude' }),
+		).toBeVisible()
 	})
 })
 

--- a/packages/research/package.json
+++ b/packages/research/package.json
@@ -9,6 +9,10 @@
 		".": {
 			"types": "./src/index.ts",
 			"import": "./src/index.ts"
+		},
+		"./domain/types": {
+			"types": "./src/domain/types.ts",
+			"import": "./src/domain/types.ts"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
## What

When a screen in the Batuda web app (`internal`) failed to fetch its data, it usually told you the opposite of what happened: it showed the "nothing here yet" message. Someone opening Pages after a network hiccup was told "No pages yet" — as if their work had vanished — when the request had simply failed. This makes a failed load say so, and gives you a Retry button that actually re-runs the request.

The surfaces affected are spread across the whole app: companies (list, board, detail), emails (threads, inboxes), pages (list, editor), research (review queue, run list, run detail), and four settings screens.

## The fix

- A shared `ErrorState` component replaces two bad habits: reusing the empty state for failures (which misreports), and hand-rolling a one-off error box per screen (there were four different ones).
- Pages was the worst case — its list had **no failure branch at all**, so every failed fetch fell through to "No pages yet". It now has a real error.
- Four settings screens told you to "Refresh to try again" without giving you anything to press. Each now has a working Retry.
- The page and company detail screens used to lump "the request failed" together with "the response came back malformed". They're now separate: only the first offers Retry, because refetching cannot repair a malformed response.

## Also in here (unrelated to error states)

Four of the commits fix things I found while chasing failing tests. None are about error states; each was small and I had the diagnosis in hand, so they rode along rather than waiting. Merged as a single squashed commit, so they are listed here rather than being separable from the history.

- **`RelativeDate` hydration mismatch** — it formatted its tooltip in the reader's local timezone while the server rendered UTC, so React logged a mismatch and warned it would not patch the difference up. The `<time>` element now declares that difference as expected.
- **A page crash on `/research/<id>`** — the run detail view imported a list of reason codes from the research package's entry point, which also reaches the services that talk to the database and the outside world. The bundler followed that into the browser and the page died on load with `node:crypto has been externalized`, showing "Something went wrong!" instead of the run. The codes now come from the domain file directly, exposed as its own entry point so a browser import cannot drag the rest along.
- **Two E2E tests** that were already failing before this work — one per commit (see Verification).

## Impact

None of the risky categories apply — no migration, no schema or wire-shape change, no new environment variables, no auth or RLS change, no MCP/HTTP parity concern, no webhook or spend behaviour. This is frontend-only, inside `apps/internal`.

Two things worth knowing:

- **A test hook was renamed.** `research-inbox-retry` became `research-inbox-error`. Nothing in the E2E suite referenced the old one — I checked the whole repo, and traced it back to the commit that introduced it (`11e3dfec26`, the feature that added the button, not a fix for a flaky test).
- **`Notice` was deleted** from `components/instructions/instruction-page-chrome.tsx`. This change removed its last two callers, so it was left with none.

## Review guide

**Start with `apps/internal/src/components/shared/error-state.tsx`** — everything else is the same three-line edit repeated at 16 call sites, so once you've read one you can skim the rest.

**The riskiest part is a colour decision, and it's worth your eye.** This branch rebased onto the design-token restructure, and that exposed a real bug in my first attempt: the inline variant painted its own background with `color-mix(--color-error 6%, transparent)`, a tint I'd copied from the old `Notice`. Measured against the new token values that gives **4.47:1 on light-theme container surfaces — under the 4.5:1 readability minimum**. The repo's new contrast check only covers `on-surface` pairings, so it would not have caught this. I switched to the `--color-error-container` / `--color-on-error-container` pair the restructure introduced, which measures 13.26 / 7.24 / 10.35:1 across light, dark and high-contrast. **The visible consequence is that the inline strip is now a solid tinted band rather than a barely-there wash** — more prominent than before. That's deliberate, but it's a look you should sign off on.

**A decision you might overrule:** I gave `ErrorState` a `headingLevel` prop rather than hardcoding a level. Four screens where the error replaces the entire page pass `1`; everything else takes the default `2`. The alternative was to always emit `h2`, which is simpler but wrong on those four, since they'd then have no top-level heading.

**Skip-able:** the two `.po` catalogues are generated by `i18n:extract`; only the Catalan `msgstr` lines are hand-written.

**Verified rather than assumed:** an accessibility review claimed that pressing Retry destroys its own focus. I measured it and it is false — `AsyncResult` keeps the previous failure while refetching, so nothing unmounts and focus stays on the button. I did act on its other findings: the announcement is now polite rather than interrupting, the Retry button sits outside the announced region (it was being read as flat text rather than offered as a control), and each Retry is named after its message so several on one page stay apart.

## Screenshots

The card variant replaces a page body; the inline variant sits inside a section that still has content around it. Both at desktop and mobile width.

**Card — desktop / mobile**

![card-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-307/card-desktop.webp)
![card-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-307/card-mobile.webp)

**Inline — desktop / mobile**

![inline-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-307/inline-desktop.webp)
![inline-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-307/inline-mobile.webp)

## Verification

Gates run on this branch: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (21/21), `pnpm -w build` (13/13) — all green.

Against the live local stack, with the relevant request aborted so the failure branch actually renders:

- The card variant on `/companies` and the inline variant on `/settings/mcp/connections` both render, carry the right ARIA semantics, and their Retry re-fires the request (verified by counting network requests: one per click, with a control click confirming no background refetch was responsible).
- `api-keys` specifically, because PR #104 had removed a manual refresh there in favour of `reactivityKeys`; the retry works and the mint/revoke flow still passes 3/3.
- Contrast computed for every text/background pairing in all three themes.

Two E2E tests failed when I started. **Both failed identically on a clean tree** (confirmed by stashing), so neither came from this work — and both are now fixed.

- **`company-overview` "About section"** — not a broken component. The About trigger measures `44x38` at first paint and `147x59` about 800ms later, moving roughly 900px, because styled-components CSS arrives late under the dev server and the header's `layoutId` shared-layout animation adds a second settle. The test clicked a target still being laid out, so the click missed entirely — zero pointer events reached the button, while keyboard `Enter` worked throughout. It now retries the click while the section is still closed, so a click that did register is never undone. **5/5 green, from 0/3.**
- **`mcp-connections` empty state** — a test that contradicted its own fixture. It asserted "no clients authorized yet", but `seed/mcp-oauth.ts` deliberately authorizes two clients for this user, with the stated purpose of giving the page something to render in local dev. The database holds 2 consents, 3 org memberships and 2 clients, and `/v1/mcp-oauth/connections` returns 200 — nothing was broken. The test now asserts what the seed actually creates (ChatGPT across two organizations, Claude across one), which exercises more of the page than the empty state did. It also retries the navigation click, since a cold dev server can still be compiling the route. **4/4 green, from 0/3.**

**Worth knowing: the E2E suite runs nowhere automatically.** `ci.yml` covers lint, build, type-check and unit tests only, which is why a test contradicting its own seed sat broken without anyone noticing. The green check on this PR is narrower than it looks.

`research-review` still has two failures at `:173` and `:200`. They predate this work and reproduce on a clean tree. Chasing them is what surfaced the `/research/<id>` crash fixed above, but that was not their cause: the apply request succeeds (`200`, real outcome) and the interface simply never shows it, because the outcome lives only in browser memory and is lost if the component is replaced mid-flight. Filed as #308 rather than fixed here, since the fix means changing how the review card sources its state.

Two further failures in that file appear only when it runs after other suites — fixture interference between files, not a fault in the tests themselves.

## Deferred

- The companies page header still reads "0 companies" and "0 in pipeline" when the list fails — a different atom with the same silent-failure shape. Visible in the screenshot above; out of scope here.
- `EmptyState` has the same styled-as-a-heading-but-marked-up-as-a-paragraph issue this branch fixes in `ErrorState`. Pre-existing, worth the same treatment.
- `research-review` `:173` and `:200` still fail, now for a known reason: applying a proposal while the page is still coming alive succeeds on the server (`200`, real outcome) but the interface never shows it, because the outcome lives only in browser memory and is lost if the component is replaced mid-flight. Filed as #308.
- Those same tests also interfere across files when the suite runs in sequence, which points at fixture isolation in the E2E setup generally.
- The E2E suite runs nowhere automatically. Worth deciding whether it should gate merges, since a broken test there is currently invisible.

