### PR TITLE
fix(internal): show failed and empty company loads honestly

### DIFF
--- a/apps/internal/src/components/shared/empty-state.tsx
+++ b/apps/internal/src/components/shared/empty-state.tsx
@@ -12,17 +12,24 @@ import {
  * via a beige masking-tape strip rotated at the top-left corner, and
  * the icon slot sits inside a brushed-metal bezel so it reads as a
  * tool pinned to the paper.
+ *
+ * `headingLevel` should match where the note sits in the page outline: 1
+ * when the empty state replaces the whole page, 2 when it sits under a
+ * page or section title. The title looks like a heading, so it is marked
+ * up as one — otherwise it is skipped by heading navigation.
  */
 export function EmptyState({
 	icon: Icon,
 	title,
 	description,
 	action,
+	headingLevel = 2,
 }: {
 	icon?: ComponentType<{ size?: number | string; 'aria-hidden'?: boolean }>
 	title: string
 	description?: ReactNode
 	action?: ReactNode
+	headingLevel?: 1 | 2 | 3
 }) {
 	return (
 		<Wrapper>
@@ -32,7 +39,7 @@ export function EmptyState({
 					<Icon size={30} aria-hidden />
 				</Bezel>
 			)}
-			<Title>{title}</Title>
+			<Title as={`h${headingLevel}`}>{title}</Title>
 			{description && <Description>{description}</Description>}
 			{action && <Actions>{action}</Actions>}
 		</Wrapper>

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -182,6 +182,10 @@ function CompaniesListPage() {
 	)
 	const isLoading = AsyncResult.isInitial(result)
 	const isFailure = AsyncResult.isFailure(result)
+	// The count and the pipeline total describe the loaded list. Until the
+	// list actually loads, an empty array would read as "0 companies" — a
+	// failed or still-loading fetch must not look like an empty pipeline.
+	const hasResult = AsyncResult.isSuccess(result)
 	// A full window came back, so there is probably another page to load.
 	const hasMore = companies.length >= visibleLimit
 
@@ -288,9 +292,11 @@ function CompaniesListPage() {
 			<Intro>
 				<TitleRow>
 					<Title>{t`Companies`}</Title>
-					<Subtitle>{countLabel}</Subtitle>
+					{hasResult && <Subtitle>{countLabel}</Subtitle>}
 				</TitleRow>
-				<KpiCounter value={companies.length} label={t`In pipeline`} />
+				{hasResult && (
+					<KpiCounter value={companies.length} label={t`In pipeline`} />
+				)}
 			</Intro>
 
 			<Filters role='group' aria-label={t`Filter companies`}>


### PR DESCRIPTION
## What

Two small frontend follow-ups deferred from #307, both in the internal CRM web app (`apps/internal`). Each is the same bug class #307 set out to fix — a failed or absent load presented as if it were real, empty data — surviving in a place that PR didn't reach.

## The fix

- **Companies header no longer reports a failed load as an empty pipeline.** When the company list failed to fetch (or was still loading), the header kept saying "0 companies" and "0 in pipeline" — telling me my pipeline was empty when the request had simply failed. #307 fixed the list *body* to show an error; the *header* counts came from a different piece of state and were missed. The count and the pipeline total now appear only once the list has actually loaded (`AsyncResult.isSuccess`), so a hiccup shows the error card alone, with no phantom zero above it.
- **The shared empty-state note now marks its title up as a heading.** `EmptyState` styled its title to look like a heading (display font, uppercase) but rendered a `<p>`, so screen-reader heading navigation skipped it — the identical issue #307 fixed in `ErrorState`. It now renders a real heading via a `headingLevel` prop (default 2), matching `ErrorState` exactly. All 10 existing call sites sit under a page or section title, so the default is correct for every one; no call site changed.

## Impact

Frontend-only, inside `apps/internal`. None of the risky categories apply — no migration, no schema or wire-shape change, no new env vars, no auth/RLS change, no MCP/HTTP parity concern, no webhook or spend behaviour. No user-facing strings were added (both reuse existing copy), so nothing new to extract for i18n.

## Review guide

**Start with `empty-state.tsx`** — it's a near-verbatim copy of the `headingLevel` + `as={`h${level}`}` pattern already in `error-state.tsx`, so if you're happy with that one you're happy with this. The companies change is three lines: a `hasResult` boolean and two `{hasResult && …}` gates around the header count and counter.

**A decision you might overrule:** I gated the header counts on `isSuccess`, which also hides them during the initial load (not only on failure). Showing "0 companies" while loading is the same misreport, and gating on success keeps the last-good counts visible during a refetch — so I think this is right, but it's slightly wider than the literal bug.

## Screenshots

The companies header at desktop and mobile, in the normal (loaded) state and the failed-load state. The failure state is the change: before, the same screen showed "0 companies" and a "0 / IN PIPELINE" tile.

**Loaded — desktop / mobile**

![happy-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-312/happy-desktop.webp)
![happy-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-312/happy-mobile.webp)

**Failed load — desktop / mobile** (the change: no "0 companies", no pipeline tile)

![fail-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-312/fail-desktop.webp)
![fail-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-312/fail-mobile.webp)

There is no screenshot for the `EmptyState` fix — it has no visual difference (the title looks identical), only a semantic one. I verified it in the accessibility tree instead: the title now reports as `heading [level=2]` rather than a paragraph.

## Verification

Gates on this branch: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (21/21), `pnpm -w build` (13/13) — all green.

Against the live worktree stack, logged in with an active org:

- **Loaded state** — header shows "2 companies" and the "2 / IN PIPELINE" tile.
- **Failed state** — forced by aborting the `/v1/companies` request during a client-side navigation (a full reload re-seeds a successful value server-side, so the abort has to land on the client fetch). Header shows only the "Companies" title; the count subtitle and the pipeline tile are both absent, and the `ErrorState` with a Retry button renders below. Confirmed at desktop and mobile.
- **Empty state** — filtered to no matches; the "No companies match the filters" title reports as `heading [level=2]` in the accessibility tree.

An accessibility review of the diff (heading order, ARIA) came back clean: the heading change is a proper WCAG 1.3.1 fix, faithfully consistent with `ErrorState`.

Closes #311
