### PR TITLE
fix(internal): keep a proposal's outcome visible after the page settles

### DIFF
--- a/apps/internal/src/components/research/review/proposed-updates-review.tsx
+++ b/apps/internal/src/components/research/review/proposed-updates-review.tsx
@@ -69,7 +69,7 @@ export function ProposedUpdatesReview({
 		resolve,
 		undo,
 		setResults,
-	} = useProposalResolution()
+	} = useProposalResolution({ onResolved: refreshProposals })
 
 	const [confirmingBatch, setConfirmingBatch] = useState(false)
 	const [batchBusy, setBatchBusy] = useState(false)
@@ -145,6 +145,9 @@ export function ProposedUpdatesReview({
 				}
 				return next
 			})
+			// Re-read so each applied row now carries its saved status, keeping the
+			// outcome after a reload or a remount rather than only in this reply.
+			refreshProposals()
 		} else {
 			toast.add({ title: t`Could not apply the batch.`, type: 'error' })
 		}
@@ -264,8 +267,19 @@ function ProposalCard({
 }) {
 	const { t } = useLingui()
 	const trust = strongestChannelTrust(proposal.channels)
-	const alreadyResolved = proposal.status !== 'pending'
 	const cardLabel = proposal.name ?? proposal.subjectTable ?? proposal.id
+
+	// The outcome to show: this session's fresh reply if we have it, otherwise
+	// the run's own saved status. Deriving from the stored status is what makes
+	// an applied or rejected proposal keep its badge across a reload, a remount,
+	// or a second reviewer — the reply alone would not survive any of those.
+	const shownOutcome: ResolveOutcome | null =
+		result ??
+		(proposal.status === 'applied'
+			? { outcome: 'applied', reason: null }
+			: proposal.status === 'rejected'
+				? { outcome: 'rejected', reason: null }
+				: null)
 
 	return (
 		<Card data-testid='research-review-card' data-proposal-id={proposal.id}>
@@ -315,10 +329,10 @@ function ProposalCard({
 			<Provenance date={completedAt} sources={sources} />
 
 			<CardActions>
-				{result !== undefined ? (
+				{shownOutcome !== null ? (
 					<OutcomeBadge
-						outcome={result.outcome as ProposalOutcome}
-						reason={result.reason}
+						outcome={shownOutcome.outcome as ProposalOutcome}
+						reason={shownOutcome.reason}
 					/>
 				) : pending !== undefined ? (
 					<PendingResolve data-testid='research-review-pending'>
@@ -333,14 +347,6 @@ function ProposalCard({
 							<Trans>Undo</Trans>
 						</UndoButton>
 					</PendingResolve>
-				) : alreadyResolved ? (
-					<ResolvedNote>
-						{proposal.status === 'applied' ? (
-							<Trans>Applied</Trans>
-						) : (
-							<Trans>Rejected</Trans>
-						)}
-					</ResolvedNote>
 				) : (
 					<>
 						<PriButton
@@ -593,14 +599,6 @@ const CardActions = styled.div`
 	align-items: center;
 	gap: var(--space-2xs);
 	margin-top: var(--space-3xs);
-`
-
-const ResolvedNote = styled.span`
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	color: var(--color-on-surface-variant);
 `
 
 const PendingResolve = styled.div`

--- a/apps/internal/src/hooks/use-proposal-resolution.ts
+++ b/apps/internal/src/hooks/use-proposal-resolution.ts
@@ -20,8 +20,16 @@ export const UNDO_WINDOW_MS = 5000
  * an accidental Apply or Reject changes nothing. A resolution still inside its
  * window is flushed if the reviewer leaves the page, so nothing is silently
  * dropped.
+ *
+ * `onResolved` runs once each write reaches the server, whether or not the
+ * surface is still on screen. The per-run review passes it to re-read the run's
+ * saved proposals, so the outcome is drawn from what is stored rather than only
+ * from this reply — that is what keeps the outcome visible when the page settles
+ * and swaps the card out from under an in-flight write.
  */
-export function useProposalResolution() {
+export function useProposalResolution(options?: {
+	readonly onResolved?: () => void
+}) {
 	const apply = useAtomSet(applyProposalAtom, { mode: 'promiseExit' })
 	const reject = useAtomSet(rejectProposalAtom, { mode: 'promiseExit' })
 	// Committed outcomes, keyed by the caller's row key.
@@ -35,6 +43,10 @@ export function useProposalResolution() {
 		>(),
 	)
 	const mounted = useRef(true)
+	// Held in a ref so the callback can change between renders without rebuilding
+	// the mutation, and so the flush that fires on unmount still reaches it.
+	const onResolvedRef = useRef(options?.onResolved)
+	onResolvedRef.current = options?.onResolved
 
 	const runMutation = useCallback(
 		async (
@@ -48,6 +60,10 @@ export function useProposalResolution() {
 			held.current.delete(key)
 			const run = decision === 'apply' ? apply : reject
 			const exit = await run({ params: { id: researchId, puId } })
+			// The write has landed. Re-read the stored proposals now, before the
+			// mounted check, so a card swapped in by the settling page still shows
+			// the outcome even though the card that fired the write has gone.
+			onResolvedRef.current?.()
 			// The reviewer may have left while the write was in flight; it still
 			// landed, so only the on-screen updates below are skipped.
 			if (!mounted.current) return

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -452,7 +452,6 @@ msgid "Appearance"
 msgstr "Aparença"
 
 #: src/components/research/proposal-outcome.tsx
-#: src/components/research/review/proposed-updates-review.tsx
 msgid "Applied"
 msgstr "Aplicat"
 
@@ -3557,7 +3556,6 @@ msgstr "Rebutja {subjectLabel}"
 
 #: src/components/companies/proposals-panel.tsx
 #: src/components/research/proposal-outcome.tsx
-#: src/components/research/review/proposed-updates-review.tsx
 msgid "Rejected"
 msgstr "Rebutjat"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -452,7 +452,6 @@ msgid "Appearance"
 msgstr "Appearance"
 
 #: src/components/research/proposal-outcome.tsx
-#: src/components/research/review/proposed-updates-review.tsx
 msgid "Applied"
 msgstr "Applied"
 
@@ -3557,7 +3556,6 @@ msgstr "Reject {subjectLabel}"
 
 #: src/components/companies/proposals-panel.tsx
 #: src/components/research/proposal-outcome.tsx
-#: src/components/research/review/proposed-updates-review.tsx
 msgid "Rejected"
 msgstr "Rejected"
 

--- a/apps/internal/tests/e2e/research-review.test.ts
+++ b/apps/internal/tests/e2e/research-review.test.ts
@@ -2,6 +2,9 @@ import { execSync } from 'node:child_process'
 
 import { expect, test } from '@playwright/test'
 
+import { waitForInteractive } from './helpers/hydration'
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
 // Exercises the research review flow on /research (inbox) and
 // /research/$id (per-run review): trust badges, provenance, single
 // apply/reject, and a bulk "apply all verified" whose batch contains a
@@ -40,6 +43,14 @@ test.beforeAll(() => {
 	pepContactId = psql(
 		`select id from contacts where company_id='${companyId}' and name='Pep Casals' limit 1`,
 	)
+})
+
+// The run is seeded under `taller`, and RLS scopes it to the active org. A
+// sibling suite may have left Alice on Restaurant, which would render /research
+// empty here, so pin the org before each test the way the other authed specs do.
+test.beforeEach(async ({ page }) => {
+	await page.goto('/', { waitUntil: 'commit' })
+	await setActiveOrgBySlug(page, 'taller')
 })
 
 // Reset to a clean, all-pending fixture and remove any contacts a prior run
@@ -173,24 +184,48 @@ test.describe('research review', () => {
 		test('should apply a single proposal and show its outcome', async ({
 			page,
 		}) => {
-			// GIVEN the review screen
+			// GIVEN the review screen, interactive so the click reaches a live
+			// handler rather than an inert server-rendered button
 			await page.goto(`/research/${RUN_ID}`, { waitUntil: 'networkidle' })
+			await waitForInteractive(page, 'research-review-apply')
 			const needsReviewCard = page.getByTestId('research-review-card').filter({
 				hasText: 'Jordi Garcia',
 			})
 			const badge = needsReviewCard.getByTestId('research-outcome-badge')
 
-			// WHEN the reviewer applies the needs-review proposal (retry the click
-			// until the outcome lands — the handler may attach a beat after
-			// hydration, and a resolved row can't be applied twice)
-			await expect(async () => {
-				if ((await badge.count()) === 0) {
-					await needsReviewCard.getByTestId('research-review-apply').click()
-				}
-				await expect(badge).toBeVisible({ timeout: 2000 })
-			}).toPass()
+			// WHEN the reviewer applies the needs-review proposal. Its write is held
+			// for a short undo window before it reaches the server, so the outcome
+			// lands a few seconds after the click.
+			await needsReviewCard.getByTestId('research-review-apply').click()
 
-			// THEN it enters the CRM (created, or merged if it already existed)
+			// THEN it enters the CRM (created, or merged if it already existed) and
+			// the card shows the outcome the run now stores
+			await expect(badge).toBeVisible({ timeout: 15_000 })
+			await expect(badge).toHaveAttribute(
+				'data-outcome',
+				/created|duplicate|applied/,
+			)
+		})
+
+		test('should keep an applied proposal outcome after a reload', async ({
+			page,
+		}) => {
+			// GIVEN a proposal that has just been applied and shows its outcome
+			await page.goto(`/research/${RUN_ID}`, { waitUntil: 'networkidle' })
+			await waitForInteractive(page, 'research-review-apply')
+			const card = page
+				.getByTestId('research-review-card')
+				.filter({ hasText: 'Jordi Garcia' })
+			const badge = card.getByTestId('research-outcome-badge')
+			await card.getByTestId('research-review-apply').click()
+			await expect(badge).toBeVisible({ timeout: 15_000 })
+
+			// WHEN the page is reloaded, dropping every in-memory reply
+			await page.reload({ waitUntil: 'networkidle' })
+
+			// THEN the card still shows the outcome, read back from the stored run
+			// rather than from this session's now-discarded reply
+			await expect(badge).toBeVisible()
 			await expect(badge).toHaveAttribute(
 				'data-outcome',
 				/created|duplicate|applied/,
@@ -200,8 +235,10 @@ test.describe('research review', () => {
 		test('should apply all verified without aborting on a conflict', async ({
 			page,
 		}) => {
-			// GIVEN a batch whose verified set includes a stale-version update
+			// GIVEN a batch whose verified set includes a stale-version update, on a
+			// screen that is interactive so the bulk action reaches a live handler
 			await page.goto(`/research/${RUN_ID}`, { waitUntil: 'networkidle' })
+			await waitForInteractive(page, 'research-review-apply-all')
 
 			const created = page
 				.getByTestId('research-review-card')
@@ -213,18 +250,13 @@ test.describe('research review', () => {
 				.filter({ hasText: 'Head Chef' })
 				.getByTestId('research-outcome-badge')
 
-			// WHEN the reviewer applies every verified proposal in one batch
-			// (retry the click until the outcomes land — the button's handler may
-			// attach a beat after hydration; the batch is idempotent to re-click
-			// because resolved rows no longer sit in the verified set)
-			await expect(async () => {
-				if ((await created.count()) === 0) {
-					await page.getByTestId('research-review-apply-all').click()
-				}
-				await expect(created).toBeVisible({ timeout: 2000 })
-			}).toPass()
+			// WHEN the reviewer applies every verified proposal in one batch. The
+			// bulk write is guarded by a confirm step, so it takes two clicks.
+			await page.getByTestId('research-review-apply-all').click()
+			await page.getByTestId('research-review-apply-all-confirm').click()
 
 			// THEN the fresh create succeeds
+			await expect(created).toBeVisible({ timeout: 15_000 })
 			await expect(created).toHaveAttribute('data-outcome', /created|duplicate/)
 
 			// AND the stale update reports a conflict rather than aborting the batch


### PR DESCRIPTION
## What

When someone reviewed a research run and applied a proposed change to the CRM (the companies and contacts data), the change was saved on the server but the screen sometimes showed no confirmation at all — the **Apply** button just disappeared and no outcome badge ("Created" / "Merged into existing" / "Applied") ever appeared. So it looked as if the apply had failed, and it was natural to click again or assume nothing happened. This makes the confirmation stick. It lives in the research review surface of the internal web app (`apps/internal`, the `/research/<run id>` screen).

## The fix

- The outcome used to live only in the browser tab's memory, filled in from the reply to the apply request. If the page finished coming alive a beat after the click — which swaps the card out from under the in-flight request — that memory was wiped and the confirmation was gone, even though the change had been written. A resolved proposal's card now reads its outcome from the research run's own saved data, so the badge reflects what is actually stored.
- The immediate reply is kept as an optimistic signal for instant feedback, reconciled against the stored value: a fresh apply still shows the precise outcome ("Created" vs "Merged into existing"), while a reload, a remount, or a second reviewer opening the same run sees the durable "Applied" / "Rejected" the run records.
- After each apply/reject — single or the bulk "apply all verified" — the run's proposals are re-read, so the stored outcome is picked up even if the card that fired the write is already gone.

## Impact

Frontend-only, inside `apps/internal` (Research review). None of the risky categories apply:

- **No migration / schema / wire-shape change** — the server's apply/reject logic and the proposal shape are untouched; I only read them to understand what is stored.
- **No new env vars, no auth / RLS change** — the screen reads the same org-scoped, RLS-gated endpoints it already read; the extra re-fetch hits the same endpoint with the same `researchId`, widening nothing.
- **No MCP / HTTP parity concern** — no shared service changed; this is UI-only.
- Worth knowing: the server persists only a proposal's `status` (`applied` / `rejected`), never the fine-grained outcome, and a `conflict` deliberately leaves the proposal `pending`. So the durable badge after a reload is the generic "Applied" / "Rejected"; the finer "Created" / "Merged" / "Record changed since research" stay as the just-happened optimistic signal — which is what they are. By design, not a gap.

## Review guide

- Start at `proposed-updates-review.tsx` → `ProposalCard`: the `shownOutcome` derivation (`result ?? status-derived`) is the heart of the change.
- Riskiest part: the hook's `onResolved` fires the re-read *before* the `mounted` guard, on purpose — so a write that lands after its card unmounted still heals the card now on screen (the proposals atom is memoized module-level, so both cards share one atom). An adversarial bug-hunt and I both checked the unmount/remount, hydration, and conflict-re-apply paths; nothing found.
- Decision you might overrule: after a reload an applied *create* shows the generic "Applied" rather than "Created", because only `status` is stored. I judged a durable-but-generic badge better than no badge; persisting the fine-grained outcome would be a server change I kept out of scope.
- Reviews run, all clean: `/code-review` (adversarial, no bugs), `/security-review` (no vulnerabilities — frontend-only, no unsafe sinks, reads already-authorized data), a11y agent (net positive — keeps the text label, adds a redundant non-color icon). a11y note: the green "Applied" badge sits right at the AA contrast threshold (4.5:1) — a pre-existing property of the existing `OutcomeBadge`, not introduced here; flagging for a future token pass.
- The two `.po` catalog files are a mechanical `i18n:extract` sync (dropped two now-unused source-location refs) — skip-able.

## Tests

- Re-enabled the two research-review tests this bug made flaky, dropping their retry-until-pass scaffolding for a single click after waiting for the page to become interactive.
- Added a test that applies a proposal, reloads the page, and asserts the outcome badge is still shown from stored data — the exact scenario #308 describes.
- Fixed the bulk-apply test, which clicked "Apply all verified" but never clicked the confirm step it now requires.
- Added a defensive active-org reset in `beforeEach`, matching the sibling suites (the run is org-scoped, so a sibling leaving a different org active would blank the screen).

## Verification

- Gates green: `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test`, `pnpm -w build`.
- Ran the research-review E2E suite against the live worktree stack: 6/6 pass, including the new reload-durability test; the two mutation tests pass 3× each (deterministic). That reload test is the browser-level proof the outcome survives a reload — captured in code rather than as a screenshot.

Closes #308
