### PR TITLE
fix(internal): correct the companies list and board layout

### DIFF
--- a/apps/internal/src/components/companies/companies-header.tsx
+++ b/apps/internal/src/components/companies/companies-header.tsx
@@ -1,0 +1,156 @@
+import { useLingui } from '@lingui/react/macro'
+import { Columns3, LayoutGrid } from 'lucide-react'
+import styled from 'styled-components'
+
+import { KpiCounter } from '#/components/shared/kpi-counter'
+import { rulerUnderRule, stenciledTitle } from '#/lib/workshop-mixins'
+
+/**
+ * Shared header for the two companies views (card list and pipeline board).
+ * Both routes render this so the title, the ruler underline, and the
+ * List/Board switch stay in the same place and style as the user flips
+ * between views — only the body below changes. The optional KPI plate is
+ * shown by the list (which knows its total); the board leaves it out.
+ */
+export function CompaniesHeader({
+	title,
+	subtitle,
+	view,
+	listHref,
+	boardHref,
+	kpi,
+}: {
+	readonly title: string
+	readonly subtitle?: string
+	readonly view: 'list' | 'board'
+	readonly listHref: string
+	readonly boardHref: string
+	readonly kpi?: { readonly value: number; readonly label: string }
+}) {
+	const { t } = useLingui()
+	return (
+		<Intro>
+			<TitleRow>
+				<TitleBlock>
+					<Title>{title}</Title>
+					{subtitle && <Subtitle>{subtitle}</Subtitle>}
+				</TitleBlock>
+				<ViewToggle role='group' aria-label={t`Switch view`}>
+					<ViewLink
+						$active={view === 'list'}
+						href={listHref}
+						data-testid='companies-view-list'
+						{...(view === 'list' ? { 'aria-current': 'page' } : {})}
+					>
+						<LayoutGrid size={14} aria-hidden />
+						<span>{t`List`}</span>
+					</ViewLink>
+					<ViewLink
+						$active={view === 'board'}
+						href={boardHref}
+						data-testid='companies-view-board'
+						{...(view === 'board' ? { 'aria-current': 'page' } : {})}
+					>
+						<Columns3 size={14} aria-hidden />
+						<span>{t`Board`}</span>
+					</ViewLink>
+				</ViewToggle>
+			</TitleRow>
+			{kpi && <KpiCounter value={kpi.value} label={kpi.label} />}
+		</Intro>
+	)
+}
+
+const Intro = styled.div.withConfig({ displayName: 'CompaniesHeaderIntro' })`
+	display: grid;
+	gap: var(--space-md);
+	align-items: end;
+
+	@media (min-width: 768px) {
+		grid-template-columns: 1fr auto;
+	}
+`
+
+const TitleRow = styled.div.withConfig({
+	displayName: 'CompaniesHeaderTitleRow',
+})`
+	${rulerUnderRule}
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-sm);
+	padding-bottom: var(--space-sm);
+`
+
+const TitleBlock = styled.div.withConfig({
+	displayName: 'CompaniesHeaderTitleBlock',
+})`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	min-width: 0;
+`
+
+const Title = styled.h2.withConfig({ displayName: 'CompaniesHeaderTitle' })`
+	${stenciledTitle}
+	margin: 0;
+	font-size: var(--typescale-headline-large-size);
+	line-height: var(--typescale-headline-large-line);
+`
+
+const Subtitle = styled.p.withConfig({
+	displayName: 'CompaniesHeaderSubtitle',
+})`
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-large-size);
+	line-height: var(--typescale-body-large-line);
+	letter-spacing: var(--typescale-body-large-tracking);
+	color: var(--color-on-surface-variant);
+	font-style: italic;
+`
+
+const ViewToggle = styled.div.withConfig({
+	displayName: 'CompaniesHeaderViewToggle',
+})`
+	display: inline-flex;
+	align-items: stretch;
+	border: 2px solid var(--color-outline);
+	border-radius: var(--shape-2xs);
+	overflow: hidden;
+	flex-shrink: 0;
+`
+
+const ViewLink = styled.a.withConfig({
+	displayName: 'CompaniesHeaderViewLink',
+	shouldForwardProp: prop => prop !== '$active',
+})<{ $active?: boolean }>`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	padding: var(--space-2xs) var(--space-sm);
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	text-decoration: none;
+	background: ${p => (p.$active ? 'var(--color-primary)' : 'transparent')};
+	color: ${p =>
+		p.$active ? 'var(--color-on-primary)' : 'var(--color-on-surface)'};
+
+	& + & {
+		border-left: 2px solid var(--color-outline);
+	}
+
+	&:hover {
+		color: ${p =>
+			p.$active ? 'var(--color-on-primary)' : 'var(--color-primary)'};
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`

--- a/apps/internal/src/components/companies/pipeline-board.tsx
+++ b/apps/internal/src/components/companies/pipeline-board.tsx
@@ -557,6 +557,12 @@ const Column = styled.div.withConfig({
 	flex-direction: column;
 	gap: var(--space-2xs);
 	flex: 0 0 clamp(15rem, 78vw, 18rem);
+	/* Hold every column to the flex basis. Without this a card whose content
+	 * can't shrink (a long name, the owner control) would push its column
+	 * past the basis — and since the columns don't shrink, that one ends up
+	 * visibly wider than the rest. Flooring at 0 lets the cards truncate
+	 * instead. */
+	min-width: 0;
 	min-height: 8rem;
 	scroll-snap-align: start;
 	padding: var(--space-2xs);

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -625,8 +625,7 @@ msgstr "Bloquejat"
 msgid "Blocked by the provider. The body is shown for review only."
 msgstr "Bloquejat pel proveïdor. El cos es mostra només per revisar-lo."
 
-#: src/routes/companies/board.tsx
-#: src/routes/companies/index.tsx
+#: src/components/companies/companies-header.tsx
 msgid "Board"
 msgstr "Tauler"
 
@@ -2304,8 +2303,7 @@ msgstr "Línies"
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/routes/companies/board.tsx
-#: src/routes/companies/index.tsx
+#: src/components/companies/companies-header.tsx
 msgid "List"
 msgstr "Llista"
 
@@ -4251,8 +4249,7 @@ msgstr "Resum"
 msgid "Switch organization"
 msgstr "Canvia d'organització"
 
-#: src/routes/companies/board.tsx
-#: src/routes/companies/index.tsx
+#: src/components/companies/companies-header.tsx
 msgid "Switch view"
 msgstr "Canvia de vista"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -625,8 +625,7 @@ msgstr "Blocked"
 msgid "Blocked by the provider. The body is shown for review only."
 msgstr "Blocked by the provider. The body is shown for review only."
 
-#: src/routes/companies/board.tsx
-#: src/routes/companies/index.tsx
+#: src/components/companies/companies-header.tsx
 msgid "Board"
 msgstr "Board"
 
@@ -2304,8 +2303,7 @@ msgstr "Line items"
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/routes/companies/board.tsx
-#: src/routes/companies/index.tsx
+#: src/components/companies/companies-header.tsx
 msgid "List"
 msgstr "List"
 
@@ -4251,8 +4249,7 @@ msgstr "Summary"
 msgid "Switch organization"
 msgstr "Switch organization"
 
-#: src/routes/companies/board.tsx
-#: src/routes/companies/index.tsx
+#: src/components/companies/companies-header.tsx
 msgid "Switch view"
 msgstr "Switch view"
 

--- a/apps/internal/src/routes/companies/board.tsx
+++ b/apps/internal/src/routes/companies/board.tsx
@@ -1,14 +1,13 @@
 import { useLingui } from '@lingui/react/macro'
 import { ClientOnly, createFileRoute } from '@tanstack/react-router'
 import { Schema } from 'effect'
-import { Columns3, LayoutGrid } from 'lucide-react'
 import styled from 'styled-components'
 
 import type { CompaniesSearch } from '#/atoms/companies-atoms'
+import { CompaniesHeader } from '#/components/companies/companies-header'
 import { PipelineBoard } from '#/components/companies/pipeline-board'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { validateSearchWith } from '#/lib/search-schema'
-import { rulerUnderRule, stenciledTitle } from '#/lib/workshop-mixins'
 
 // Same filters as the list minus `status` — the board's columns are the statuses.
 const validateSearch = validateSearchWith({
@@ -32,41 +31,27 @@ function BoardPage() {
 
 	// Carry the active filters back to the list view.
 	const listHref = (() => {
-		const p = new URLSearchParams()
-		if (search.country) p.set('country', search.country)
-		if (search.industry) p.set('industry', search.industry)
+		const params = new URLSearchParams()
+		if (search.country) params.set('country', search.country)
+		if (search.industry) params.set('industry', search.industry)
 		if (search.priority !== undefined)
-			p.set('priority', String(search.priority))
-		if (search.owner) p.set('owner', search.owner)
-		if (search.sort) p.set('sort', search.sort)
-		if (search.query) p.set('query', search.query)
-		const qs = p.toString()
+			params.set('priority', String(search.priority))
+		if (search.owner) params.set('owner', search.owner)
+		if (search.sort) params.set('sort', search.sort)
+		if (search.query) params.set('query', search.query)
+		const qs = params.toString()
 		return qs ? `/companies?${qs}` : '/companies'
 	})()
 
 	return (
 		<Page>
-			<Intro>
-				<TitleRow>
-					<Title>{t`Pipeline board`}</Title>
-					<ViewToggle role='group' aria-label={t`Switch view`}>
-						<ViewLink href={listHref} data-testid='board-view-list'>
-							<LayoutGrid size={14} aria-hidden />
-							<span>{t`List`}</span>
-						</ViewLink>
-						<ViewLink
-							$active
-							href='/companies/board'
-							aria-current='page'
-							data-testid='board-view-board'
-						>
-							<Columns3 size={14} aria-hidden />
-							<span>{t`Board`}</span>
-						</ViewLink>
-					</ViewToggle>
-				</TitleRow>
-				<Subtitle>{t`Drag a lead across stages, or use its Move menu.`}</Subtitle>
-			</Intro>
+			<CompaniesHeader
+				view='board'
+				title={t`Pipeline board`}
+				subtitle={t`Drag a lead across stages, or use its Move menu.`}
+				listHref={listHref}
+				boardHref='/companies/board'
+			/>
 
 			<ClientOnly fallback={<LoadingSpinner label={t`Loading board…`} />}>
 				<PipelineBoard search={search as CompaniesSearch} />
@@ -75,73 +60,10 @@ function BoardPage() {
 	)
 }
 
+// Full-bleed on purpose: the pipeline is a horizontal kanban whose columns
+// need the whole sheet width, so this view is not capped like the list.
 const Page = styled.div.withConfig({ displayName: 'BoardPage' })`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-lg);
-`
-
-const Intro = styled.div.withConfig({ displayName: 'BoardIntro' })`
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-2xs);
-`
-
-const TitleRow = styled.div.withConfig({ displayName: 'BoardTitleRow' })`
-	${rulerUnderRule}
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	justify-content: space-between;
-	gap: var(--space-sm);
-	padding-bottom: var(--space-sm);
-`
-
-const Title = styled.h2.withConfig({ displayName: 'BoardTitle' })`
-	${stenciledTitle}
-	margin: 0;
-	font-size: var(--typescale-headline-large-size);
-	line-height: var(--typescale-headline-large-line);
-`
-
-const Subtitle = styled.p.withConfig({ displayName: 'BoardSubtitle' })`
-	margin: 0;
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-large-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-`
-
-const ViewToggle = styled.div.withConfig({ displayName: 'BoardViewToggle' })`
-	display: inline-flex;
-	align-items: stretch;
-	border: 2px solid var(--color-outline);
-	border-radius: var(--shape-2xs);
-	overflow: hidden;
-`
-
-const ViewLink = styled.a.withConfig({
-	displayName: 'BoardViewLink',
-	shouldForwardProp: prop => prop !== '$active',
-})<{ $active?: boolean }>`
-	display: inline-flex;
-	align-items: center;
-	gap: var(--space-2xs);
-	padding: var(--space-2xs) var(--space-sm);
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	font-weight: var(--font-weight-bold);
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	text-decoration: none;
-	background: ${p => (p.$active ? 'var(--color-primary)' : 'transparent')};
-	color: ${p => (p.$active ? 'var(--color-on-primary)' : 'var(--color-on-surface)')};
-
-	& + & {
-		border-left: 2px solid var(--color-outline);
-	}
-
-	&:hover {
-		color: ${p => (p.$active ? 'var(--color-on-primary)' : 'var(--color-primary)')};
-	}
 `

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -661,6 +661,19 @@ const Page = styled.div.withConfig({ displayName: 'CompaniesListPage' })`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-lg);
+
+	/* Cap the reading column and centre it so the header, filters, and card
+	 * grid don't stretch edge-to-edge on wide monitors — matching the
+	 * research list convention. */
+	width: 100%;
+	max-width: 64rem;
+	margin-inline: auto;
+
+	/* Measure children against this element's own width, not the window's.
+	 * The card list keys its column count off the space it actually has —
+	 * the capped column here, narrowed further by the fixed side rail —
+	 * instead of the raw viewport. */
+	container-type: inline-size;
 `
 
 const Intro = styled.div.withConfig({ displayName: 'CompaniesListIntro' })`
@@ -789,15 +802,20 @@ const Grid = styled(motion.div).withConfig({
 	displayName: 'CompaniesListGrid',
 })`
 	display: grid;
-	grid-template-columns: 1fr;
+	/* minmax(0, …) not a bare 1fr: a plain 1fr track keeps its default
+	 * auto minimum, which is the card's min-content width (the status
+	 * badge + last-contact row can't shrink). On a narrow phone that
+	 * min-content is wider than the column, so the track grows past the
+	 * sheet and the whole list scrolls sideways. Flooring the track at 0
+	 * lets the card shrink and its own text ellipsis take over instead. */
+	grid-template-columns: minmax(0, 1fr);
 	gap: var(--space-md);
 
-	@media (min-width: 768px) {
-		grid-template-columns: 1fr 1fr;
-	}
-
-	@media (min-width: 1024px) {
-		grid-template-columns: 1fr 1fr 1fr;
+	/* Two columns once the list's own width — not the window's — has room
+	 * for them; a single card fills a desktop sheet comfortably at two, so
+	 * the list tops out there rather than cramming a third. */
+	@container (min-width: 40rem) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
 	/* Micro-rotation to break grid rhythm. See CompanyCard for the

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -3,14 +3,7 @@ import { useLingui } from '@lingui/react/macro'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import {
-	Check,
-	ChevronsUpDown,
-	Columns3,
-	LayoutGrid,
-	Search,
-	X,
-} from 'lucide-react'
+import { Check, ChevronsUpDown, Search, X } from 'lucide-react'
 import { LayoutGroup, motion } from 'motion/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
@@ -23,10 +16,10 @@ import {
 	canonicalSearchKey,
 	companiesSearchAtom,
 } from '#/atoms/companies-atoms'
+import { CompaniesHeader } from '#/components/companies/companies-header'
 import { CompanyCard } from '#/components/shared/company-card'
 import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
-import { KpiCounter } from '#/components/shared/kpi-counter'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import {
 	type CompanyStatus,
@@ -38,11 +31,7 @@ import { dehydrateAtom } from '#/lib/atom-hydration'
 import { useOrgMembers } from '#/lib/org-members'
 import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
-import {
-	brushedMetalPlate,
-	rulerUnderRule,
-	stenciledTitle,
-} from '#/lib/workshop-mixins'
+import { brushedMetalPlate } from '#/lib/workshop-mixins'
 
 /**
  * Narrow row shape for the list view. The server returns `Schema.Unknown`
@@ -289,51 +278,34 @@ function CompaniesListPage() {
 
 	return (
 		<Page>
-			<Intro>
-				<TitleRow>
-					<Title>{t`Companies`}</Title>
-					{hasResult && <Subtitle>{countLabel}</Subtitle>}
-				</TitleRow>
-				{hasResult && (
-					<KpiCounter value={companies.length} label={t`In pipeline`} />
-				)}
-			</Intro>
+			<CompaniesHeader
+				view='list'
+				title={t`Companies`}
+				listHref='/companies'
+				boardHref={boardHref(boardSearch(search))}
+				{...(hasResult
+					? {
+							subtitle: countLabel,
+							kpi: { value: companies.length, label: t`In pipeline` },
+						}
+					: {})}
+			/>
 
 			<Filters role='group' aria-label={t`Filter companies`}>
-				<TopRow>
-					<SearchWrap>
-						<SearchIcon>
-							<Search size={16} aria-hidden />
-						</SearchIcon>
-						<PriInput
-							type='search'
-							placeholder={t`Search by name, industry, or location…`}
-							value={searchInput}
-							onChange={event => setSearchInput(event.target.value)}
-							aria-label={t`Search companies`}
-							style={{ paddingLeft: 'calc(var(--space-sm) * 2 + 16px)' }}
-							data-testid='companies-search'
-						/>
-					</SearchWrap>
-					<ViewToggle role='group' aria-label={t`Switch view`}>
-						<ViewLink
-							$active
-							href='/companies'
-							data-testid='companies-view-list'
-							aria-current='page'
-						>
-							<LayoutGrid size={14} aria-hidden />
-							<span>{t`List`}</span>
-						</ViewLink>
-						<ViewLink
-							href={boardHref(boardSearch(search))}
-							data-testid='companies-view-board'
-						>
-							<Columns3 size={14} aria-hidden />
-							<span>{t`Board`}</span>
-						</ViewLink>
-					</ViewToggle>
-				</TopRow>
+				<SearchWrap>
+					<SearchIcon>
+						<Search size={16} aria-hidden />
+					</SearchIcon>
+					<PriInput
+						type='search'
+						placeholder={t`Search by name, industry, or location…`}
+						value={searchInput}
+						onChange={event => setSearchInput(event.target.value)}
+						aria-label={t`Search companies`}
+						style={{ paddingLeft: 'calc(var(--space-sm) * 2 + 16px)' }}
+						data-testid='companies-search'
+					/>
+				</SearchWrap>
 
 				<StatusFilters role='group' aria-label={t`Filter by status`}>
 					<StatusFilterButton
@@ -676,43 +648,6 @@ const Page = styled.div.withConfig({ displayName: 'CompaniesListPage' })`
 	container-type: inline-size;
 `
 
-const Intro = styled.div.withConfig({ displayName: 'CompaniesListIntro' })`
-	display: grid;
-	gap: var(--space-md);
-	align-items: end;
-
-	@media (min-width: 768px) {
-		grid-template-columns: 1fr auto;
-	}
-`
-
-const TitleRow = styled.div.withConfig({
-	displayName: 'CompaniesListTitleRow',
-})`
-	${rulerUnderRule}
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-2xs);
-	padding-bottom: var(--space-sm);
-`
-
-const Title = styled.h2.withConfig({ displayName: 'CompaniesListTitle' })`
-	${stenciledTitle}
-	margin: 0;
-	font-size: var(--typescale-headline-large-size);
-	line-height: var(--typescale-headline-large-line);
-`
-
-const Subtitle = styled.p.withConfig({ displayName: 'CompaniesListSubtitle' })`
-	margin: 0;
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-large-size);
-	line-height: var(--typescale-body-large-line);
-	letter-spacing: var(--typescale-body-large-tracking);
-	color: var(--color-on-surface-variant);
-	font-style: italic;
-`
-
 const Filters = styled.div.withConfig({ displayName: 'CompaniesListFilters' })`
 	${brushedMetalPlate}
 	display: flex;
@@ -831,63 +766,6 @@ const Grid = styled(motion.div).withConfig({
 	}
 	& > :nth-child(3n + 3) {
 		--card-rotate: -0.15deg;
-	}
-`
-
-const TopRow = styled.div.withConfig({ displayName: 'CompaniesListTopRow' })`
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: var(--space-sm);
-
-	@media (min-width: 640px) {
-		flex-wrap: nowrap;
-	}
-
-	& > :first-child {
-		flex: 1 1 12rem;
-	}
-`
-
-const ViewToggle = styled.div.withConfig({
-	displayName: 'CompaniesListViewToggle',
-})`
-	display: inline-flex;
-	align-items: stretch;
-	border: 2px solid var(--color-outline);
-	border-radius: var(--shape-2xs);
-	overflow: hidden;
-	flex-shrink: 0;
-`
-
-const ViewLink = styled.a.withConfig({
-	displayName: 'CompaniesListViewLink',
-	shouldForwardProp: prop => prop !== '$active',
-})<{ $active?: boolean }>`
-	display: inline-flex;
-	align-items: center;
-	gap: var(--space-2xs);
-	padding: var(--space-2xs) var(--space-sm);
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	font-weight: var(--font-weight-bold);
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	text-decoration: none;
-	background: ${p => (p.$active ? 'var(--color-primary)' : 'transparent')};
-	color: ${p => (p.$active ? 'var(--color-on-primary)' : 'var(--color-on-surface)')};
-
-	& + & {
-		border-left: 2px solid var(--color-outline);
-	}
-
-	&:hover {
-		color: ${p => (p.$active ? 'var(--color-on-primary)' : 'var(--color-primary)')};
-	}
-
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
 	}
 `
 


### PR DESCRIPTION
## What

The Companies section of the internal CRM (`apps/internal`) has two views of the same pipeline — a card **list** and a drag-and-drop **board**. This fixes their layout so the section reads as intended on any screen: the list no longer scrolls sideways on a phone or stretches edge-to-edge on a wide monitor, the two views now share one header (the board's title had been rendering unstyled), and the board's columns are all the same width.

Frontend only, CRM surface — no backend, schema, or API involved.

## The fix

- **List stopped overflowing and stretching.** A card whose content couldn't shrink was widening its grid column past the sheet, so on narrow screens the whole list scrolled sideways. The column can now shrink and the card truncates its own text. The list is also capped to a readable width and centred so it no longer spans a huge monitor, and the one- vs two-column switch is based on the space the list actually has (which the side rail narrows), not the raw window width.
- **List and board share one header.** Each view built its own header, so they had drifted apart — and the board's title was rendering in the plain body font because its header styles weren't loading (duplicate styled-components that failed to inject on that route). A single shared header now fixes the styling and keeps both views consistent. The List/Board switch moved into that header, so it sits in the same place on both views instead of inside the list's filter bar.
- **Board columns are equal width.** A card that couldn't shrink was widening its column past the others; every column now holds its width and long card text truncates.

## Impact

- **Blast radius: contained to `apps/internal` frontend.** No migration or schema change, no `organization_id` / RLS scoping, no API or wire-shape change, no new env vars, no auth/route changes, no MCP surface. It's styled-components layout plus one new presentational component (`CompaniesHeader`).
- The shared header is used by **both** the list and board routes. The count and "in pipeline" total still hide while the list is loading or after a failed load — that behaviour landed on `main` mid-branch (the "empty pipeline" fix) and I preserved it by conditionally passing those props into the shared header.

## Review guide

- Start at **`companies-header.tsx`** (new shared component) — it's the crux. Then the `Grid` and `Page` styled blocks in `routes/companies/index.tsx` (overflow floor + cap/centre) and the `Column` `min-width: 0` in `pipeline-board.tsx`.
- **Riskiest part — the rebase merge.** `main`'s recent "stop a failed load reading as empty pipeline" fix (a `hasResult` gate on the count + KPI) landed while I was working; I re-applied it by conditionally spreading `subtitle`/`kpi` into the shared header (same pattern as the `EmptyState` call in this file). Worth confirming the loaded state shows the count + KPI and a failed/loading state hides them.
- **A decision you might overrule:** I left `RelativeDate` untouched. Its `Date.now()`-at-render already carries `suppressHydrationWarning`, and I verified it is *not* the source of any hydration warning (the companies list SSRs 60 of them with zero warnings). A benign, board-only `ClientOnly` hydration warning remains (console-only, no visible or functional effect) — deferred, not chased.
- **Accessibility:** reviewed the new header (heading level, toggle labelling, focus, `aria-current`) — no issues; the `h2` sits correctly under the TopBar's `h1`, and the switch is real anchor links with `aria-current` and `aria-hidden` icons.
- CSS-only and mechanical parts (the removed old per-route header styled-components) are skip-able.

## Screenshots

**List — desktop (1440):** capped, centred, two columns, header + toggle.

![pr-list-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-317/pr-list-desktop.webp)

**List — mobile (iPhone 16 Pro):** single column, no sideways scroll, header + toggle, KPI stacks below.

![pr-list-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-317/pr-list-mobile.webp)

**Board — desktop (1440):** styled header (was unstyled), equal-width columns.

![pr-board-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-317/pr-board-desktop.webp)

## Verification

- Gates run green: `pnpm install` (no lockfile drift) → `pnpm -w check-types` (13/13) + `pnpm --filter @batuda/internal test` (90/90) → `pnpm -w build` (13/13).
- Live stack (this worktree): drove `/companies` and `/companies/board` at 320 / 375 / 768 / 1024 / 1280 / 1600 px and on iPhone 16 Pro. Measured `document.scrollWidth === innerWidth` at every width (no overflow), the grid adapting 1 → 2 columns by container width, the list column capped at 1024 px and centred, all eight board columns at 288 px, and both headers rendering in the display font.

## Deferred

- The benign board-only `ClientOnly` hydration console warning (no visible or functional effect).
