### PR TITLE
cicd: run the end-to-end suite automatically and fix what it surfaced

### DIFF
--- a/.github/actions/e2e-stack/action.yml
+++ b/.github/actions/e2e-stack/action.yml
@@ -1,0 +1,112 @@
+name: E2E stack
+description: >-
+  Stand up the app the way `pnpm dev` does — a local Postgres + MinIO, migrate,
+  seed, then the server and web served under portless — and run Playwright
+  against it. The browser hits the exact dev environment the suite was written
+  for (batuda.localhost over portless's TLS), so a pass locally is a pass here.
+
+inputs:
+  grep:
+    description: 'Playwright --grep filter (e.g. "@smoke"). Empty runs the full suite.'
+    required: false
+    default: ''
+  with-mail:
+    description: 'Start GreenMail (mail-catcher) + the mail-worker for the email round-trip specs.'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: "24"
+        cache: "pnpm"
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    # The dev server runs from TS source via tsx and imports several workspace
+    # packages (notably @batuda/ui) from their built `dist/`, so build first.
+    - name: Build
+      shell: bash
+      run: pnpm build
+
+    # The committed template is the full local env (dummy secrets, everything
+    # `stub`/`local`, and DATABASE_URL/STORAGE_* already pointed at the compose
+    # services below). The dev server reads it via `--env-file`; we source it
+    # for the migrate/seed steps too so every process shares one BETTER_AUTH_SECRET.
+    - name: Local env from the committed template
+      shell: bash
+      run: |
+        cp .env.example .env
+        # otel-tui isn't running on the runner — silence the per-tick exporter error.
+        printf '\nOTEL_EXPORTER_OTLP_ENDPOINT=\n' >> .env
+
+    - name: Start Postgres + MinIO (+ GreenMail when with-mail)
+      shell: bash
+      env:
+        WITH_MAIL: ${{ inputs.with-mail }}
+      run: |
+        services="db storage storage-init"
+        if [ "$WITH_MAIL" = "true" ]; then services="$services mail-catcher"; fi
+        docker compose -f docker/docker-compose.yml up -d --wait $services
+
+    - name: Migrate + seed
+      shell: bash
+      run: |
+        set -a; . ./.env; set +a
+        pnpm db:migrate
+        pnpm cli seed
+
+    - name: Install Playwright browser
+      shell: bash
+      run: pnpm --filter @batuda/internal exec playwright install --with-deps chromium
+
+    # Serve the stack under portless. A plain `actions/checkout` is not a linked
+    # worktree, so portless serves the bare `batuda.localhost` /
+    # `api.batuda.localhost` hosts; the proxy port ends up in
+    # ~/.portless/proxy.port, which playwright.config.ts reads to build BASE_URL.
+    - name: Serve under portless + run Playwright
+      shell: bash
+      env:
+        WITH_MAIL: ${{ inputs.with-mail }}
+        GREP: ${{ inputs.grep }}
+      run: |
+        set -a; . ./.env; set +a
+
+        # Start the proxy explicitly on an unprivileged port. On a runner there
+        # is no TTY for the sudo that binding :443 needs, and `portless run`
+        # errors instead of falling back — so bind a high port up front; the
+        # dev servers below then reuse this already-running proxy.
+        pnpm exec portless proxy start --port 1355 --https
+
+        pnpm --filter @batuda/server dev  > /tmp/e2e-server.log 2>&1 &
+        pnpm --filter @batuda/internal dev > /tmp/e2e-web.log 2>&1 &
+        if [ "$WITH_MAIL" = "true" ]; then
+          pnpm --filter @batuda/mail-worker dev > /tmp/e2e-mail-worker.log 2>&1 &
+        fi
+
+        echo "Waiting for the API health probe through portless…"
+        ready=""
+        for i in $(seq 1 60); do
+          port="$(cat "$HOME/.portless/proxy.port" 2>/dev/null || echo 443)"
+          code="$(curl -sk -o /dev/null -w '%{http_code}' "https://api.batuda.localhost:${port}/health" 2>/dev/null || true)"
+          if [ "$code" = "200" ]; then ready="1"; echo "Stack healthy on :${port} after ~$((i*3))s"; break; fi
+          sleep 3
+        done
+        if [ -z "$ready" ]; then
+          echo "::error::The dev stack never reported healthy."
+          echo "─── server log ───"; tail -60 /tmp/e2e-server.log || true
+          echo "─── web log ───";    tail -30 /tmp/e2e-web.log || true
+          exit 1
+        fi
+
+        grep_arg=""
+        if [ -n "$GREP" ]; then grep_arg="--grep $GREP"; fi
+        pnpm --filter @batuda/internal exec playwright test $grep_arg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,24 @@ jobs:
           STORAGE_SECRET_ACCESS_KEY: batuda-secret
           STORAGE_BUCKET: batuda-assets
         run: pnpm --filter @batuda/server exec vitest run src/main.boot.test.ts --config vitest.boot.config.ts
+
+  # Browser-level smoke (sign-in + one read + one write) on its own runner, in
+  # parallel with the job above so it never eats into that 10-minute budget. It
+  # stands up its own Postgres + seed and serves the app under portless, so the
+  # e2e database is isolated from the integration suite's truncations. Make this
+  # a required status check so a red smoke run blocks the merge — the whole point
+  # of the suite is to be the un-skippable browser gate (docs/runbooks.md). The
+  # full suite runs post-merge in e2e-main.yml.
+  e2e-smoke:
+    name: E2E smoke (Playwright)
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Stand up the stack and run the smoke subset
+        uses: ./.github/actions/e2e-stack
+        with:
+          grep: "@smoke"

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -1,0 +1,36 @@
+name: E2E full suite
+
+# Post-merge backstop: the whole browser suite on every push to main. This is
+# NOT a required check and does NOT run on pull requests — it reports a break on
+# the commit without gating review. The PR gate is the `e2e-smoke` job in
+# ci.yml; this catches whatever the smoke subset doesn't (docs/runbooks.md).
+on:
+  push:
+    branches: [main]
+
+# A newer push supersedes an in-flight full run — the latest commit is what
+# matters for a post-merge backstop.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-full:
+    name: E2E full suite (Playwright)
+    runs-on: ubuntu-latest
+    # The full 34-spec suite runs sequentially (workers: 1); ~6 min of tests on
+    # top of setup, so 20 leaves comfortable headroom.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # with-mail brings up GreenMail + the mail-worker so the email round-trip
+      # specs (send, reply, bounce, magic-link, …) run; no grep = the full suite.
+      - name: Stand up the stack and run the full suite
+        uses: ./.github/actions/e2e-stack
+        with:
+          with-mail: "true"

--- a/apps/internal/playwright.config.ts
+++ b/apps/internal/playwright.config.ts
@@ -51,7 +51,11 @@ export default defineConfig({
 	// from `pnpm cli db reset && pnpm cli seed` between manual runs, not from parallelism.
 	fullyParallel: false,
 	workers: 1,
-	retries: 0,
+	// One retry in CI so a single transient blip (a slow mount, a network
+	// hiccup) doesn't fail a PR on the smoke gate; a test that only passes on
+	// retry still surfaces in the report and gets triaged (docs/runbooks.md).
+	// Zero locally so a flake is loud instead of silently absorbed.
+	retries: process.env['CI'] ? 1 : 0,
 	reporter: [['list']],
 	use: {
 		baseURL: BASE_URL,

--- a/apps/internal/src/components/contacts/display-channels.test.ts
+++ b/apps/internal/src/components/contacts/display-channels.test.ts
@@ -12,26 +12,27 @@ const channel = (over: Partial<Record<string, unknown>> = {}) => ({
 	kind: 'email',
 	value: 'a@b.com',
 	verification: 'deliverable',
-	is_primary: true,
+	isPrimary: true,
 	status: 'unknown',
-	status_reason: null,
+	statusReason: null,
 	...over,
 })
 
 describe('narrowChannels', () => {
 	describe('when given the json_agg channel array', () => {
-		it('should map snake_case json keys to a typed channel', () => {
-			// GIVEN one email channel with snake_case keys (is_primary, status_reason)
+		it('should map the camelCased json_agg keys to a typed channel', () => {
+			// GIVEN one email channel with the camelCased keys PgLive emits
+			// inside the json_agg blob (isPrimary, statusReason)
 			// WHEN narrowed
-			// THEN it reads the snake_case keys into camelCase fields
+			// THEN it reads them into the typed channel fields
 			const [c] = narrowChannels([
 				channel({
 					id: 'x',
 					kind: 'email',
 					value: 'pep@calpepfonda.cat',
-					is_primary: true,
+					isPrimary: true,
 					status: 'bounced',
-					status_reason: 'Permanent',
+					statusReason: 'Permanent',
 				}),
 			])
 			expect(c).toEqual<DisplayChannel>({
@@ -68,10 +69,10 @@ describe('narrowChannels', () => {
 		})
 
 		it('should default missing optional fields', () => {
-			// GIVEN a phone channel with no verification / status / status_reason
+			// GIVEN a phone channel with no verification / status / statusReason
 			// THEN verification + statusReason are null and status is unknown
 			const [c] = narrowChannels([
-				{ id: 'p', kind: 'phone', value: '+34 600', is_primary: false },
+				{ id: 'p', kind: 'phone', value: '+34 600', isPrimary: false },
 			])
 			expect(c).toMatchObject({
 				kind: 'phone',
@@ -113,8 +114,8 @@ describe('primaryEmailChannel', () => {
 			// GIVEN two email channels, one flagged primary
 			// THEN the primary one is chosen
 			const channels = narrowChannels([
-				channel({ id: 'a', value: 'second@x.com', is_primary: false }),
-				channel({ id: 'b', value: 'primary@x.com', is_primary: true }),
+				channel({ id: 'a', value: 'second@x.com', isPrimary: false }),
+				channel({ id: 'b', value: 'primary@x.com', isPrimary: true }),
 			])
 			expect(primaryEmailChannel(channels)?.value).toBe('primary@x.com')
 		})
@@ -123,8 +124,8 @@ describe('primaryEmailChannel', () => {
 			// GIVEN email channels with none marked primary
 			// THEN the first email is chosen
 			const channels = narrowChannels([
-				channel({ id: 'a', value: 'first@x.com', is_primary: false }),
-				channel({ id: 'b', value: 'second@x.com', is_primary: false }),
+				channel({ id: 'a', value: 'first@x.com', isPrimary: false }),
+				channel({ id: 'b', value: 'second@x.com', isPrimary: false }),
 			])
 			expect(primaryEmailChannel(channels)?.value).toBe('first@x.com')
 		})

--- a/apps/internal/src/components/contacts/display-channels.ts
+++ b/apps/internal/src/components/contacts/display-channels.ts
@@ -1,7 +1,6 @@
 // Pure helpers for rendering a contact's channels. Channels are the single
 // source of truth for reachable addresses; the API ships them as a json_agg
-// array whose keys stay snake_case (the pg camelCase transform only touches
-// top-level columns, not nested json), so the narrower reads snake_case.
+// array that the narrower turns into a typed list.
 
 export type EmailChannelStatus = 'unknown' | 'valid' | 'bounced' | 'complained'
 
@@ -39,10 +38,15 @@ export function narrowChannels(raw: unknown): ReadonlyArray<DisplayChannel> {
 			verification:
 				typeof r['verification'] === 'string' ? r['verification'] : null,
 			confidence: typeof r['confidence'] === 'number' ? r['confidence'] : null,
-			isPrimary: r['is_primary'] === true,
+			// The API carries these channels as a json_agg blob, and the database
+			// layer camelCases the keys inside it too — so read `isPrimary` /
+			// `statusReason`, not the raw `is_primary` / `status_reason` column
+			// names. The snake_case form comes back empty and silently hides every
+			// contact's suppression reason on the company page.
+			isPrimary: r['isPrimary'] === true,
 			status: asEmailStatus(r['status']),
 			statusReason:
-				typeof r['status_reason'] === 'string' ? r['status_reason'] : null,
+				typeof r['statusReason'] === 'string' ? r['statusReason'] : null,
 		})
 	}
 	return out

--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -19,6 +19,10 @@ import {
 	threadAtomFor,
 	updateDraftAtom,
 } from '#/atoms/emails-atoms'
+import {
+	narrowChannels,
+	primaryEmailChannel,
+} from '#/components/contacts/display-channels'
 import { AttachmentPicker } from '#/components/emails/attachment-picker'
 import { type Draft, useComposeEmail } from '#/context/compose-email-context'
 import type { StagedAttachment } from '#/lib/email-attachments'
@@ -582,8 +586,12 @@ function SuppressionGuard({
 		for (const raw of contacts) {
 			if (raw === null || typeof raw !== 'object') continue
 			const r = raw as Record<string, unknown>
-			const email = typeof r['email'] === 'string' ? r['email'] : null
-			const status = r['emailStatus']
+			// A contact's email and suppression state live on its primary email
+			// channel, not as top-level `email`/`emailStatus` fields, so derive
+			// both from that channel.
+			const primaryEmail = primaryEmailChannel(narrowChannels(r['channels']))
+			const email = primaryEmail?.value ?? null
+			const status = primaryEmail?.status
 			if (email === null) continue
 			if (status !== 'bounced' && status !== 'complained') continue
 			const name = typeof r['name'] === 'string' ? r['name'] : email

--- a/apps/internal/tests/e2e/auth.setup.ts
+++ b/apps/internal/tests/e2e/auth.setup.ts
@@ -14,29 +14,35 @@ import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 const AUTH_FILE = 'tests/e2e/.auth/alice.json'
 
-setup('sign in as Alice and persist storage state', async ({ page }) => {
-	// GIVEN the dev stack is up and the seed has provisioned alice
-	await page.goto('/login')
-	await expect(page.getByTestId('login-form')).toBeVisible()
+// Tagged @smoke: the authed smoke tests depend on this setup project, and
+// `--grep @smoke` filters dependency projects too — so it must match to run.
+setup(
+	'sign in as Alice and persist storage state',
+	{ tag: '@smoke' },
+	async ({ page }) => {
+		// GIVEN the dev stack is up and the seed has provisioned alice
+		await page.goto('/login')
+		await expect(page.getByTestId('login-form')).toBeVisible()
 
-	// WHEN Alice signs in with seeded credentials
-	// The form submits through a handler that only exists once the page is
-	// live, so submitting before then quietly does nothing at all.
-	await waitForInteractive(page, 'login-submit')
-	await page.getByTestId('login-email').fill('admin@taller.cat')
-	await page.getByTestId('login-password').fill('batuda-dev-2026')
-	await page.getByTestId('login-submit').click()
+		// WHEN Alice signs in with seeded credentials
+		// The form submits through a handler that only exists once the page is
+		// live, so submitting before then quietly does nothing at all.
+		await waitForInteractive(page, 'login-submit')
+		await page.getByTestId('login-email').fill('admin@taller.cat')
+		await page.getByTestId('login-password').fill('batuda-dev-2026')
+		await page.getByTestId('login-submit').click()
 
-	// THEN the dashboard route renders (proves the cookie is set)
-	await page.waitForURL(/\/$/)
-	await expect(page.getByTestId('login-form')).toHaveCount(0)
+		// THEN the dashboard route renders (proves the cookie is set)
+		await page.waitForURL(/\/$/)
+		await expect(page.getByTestId('login-form')).toHaveCount(0)
 
-	// AND set the active org to taller so downstream tests start with a
-	// CurrentOrg-resolvable session. Alice belongs to two orgs (taller
-	// owner, restaurant member), so Better Auth's auto-set-active hook
-	// only fires for single-org users — multi-org users have to pick.
-	await setActiveOrgBySlug(page, 'taller')
+		// AND set the active org to taller so downstream tests start with a
+		// CurrentOrg-resolvable session. Alice belongs to two orgs (taller
+		// owner, restaurant member), so Better Auth's auto-set-active hook
+		// only fires for single-org users — multi-org users have to pick.
+		await setActiveOrgBySlug(page, 'taller')
 
-	// AND we persist the resulting cookies for downstream tests
-	await page.context().storageState({ path: AUTH_FILE })
-})
+		// AND we persist the resulting cookies for downstream tests
+		await page.context().storageState({ path: AUTH_FILE })
+	},
+)

--- a/apps/internal/tests/e2e/bounce-visibility.test.ts
+++ b/apps/internal/tests/e2e/bounce-visibility.test.ts
@@ -4,9 +4,9 @@ import { expect, test } from '@playwright/test'
 
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
-// Bounce visibility on the contact page. Slice 6 wires the suppression
-// banner (and inline badge) on company → Contacts when a contact's
-// `email_status` is bounced or complained.
+// Bounce visibility on the contact page: the suppression banner (and inline
+// badge) render on company → Contacts when a contact's primary email channel
+// carries a `bounced` or `complained` status.
 //
 // We seed the bounced state directly via psql instead of driving the
 // mail-worker's DSN parser end-to-end — the worker is a separate process
@@ -40,17 +40,17 @@ test.describe('contact suppression banner', () => {
 		await page.goto('/', { waitUntil: 'commit' })
 		await setActiveOrgBySlug(page, 'taller')
 
-		// AND the seeded Pep Casals row is forced to bounced state.
+		// AND the seeded Pep Casals email channel is forced to bounced state.
 		psql(
-			`UPDATE contacts SET email_status='bounced', email_status_reason='${TARGET_REASON}', email_status_updated_at=now() WHERE email='${TARGET_EMAIL}'`,
+			`UPDATE contact_channels SET status='bounced', status_reason='${TARGET_REASON}', status_updated_at=now() WHERE kind='email' AND value='${TARGET_EMAIL}'`,
 		)
 	})
 
 	test.afterEach(() => {
-		// Revert the seeded bounce so the row is reusable across runs and
+		// Revert the seeded bounce so the channel is reusable across runs and
 		// other suites that read the same contact don't see leftover state.
 		psql(
-			`UPDATE contacts SET email_status='unknown', email_status_reason=NULL, email_status_updated_at=now(), email_soft_bounce_count=0 WHERE email='${TARGET_EMAIL}'`,
+			`UPDATE contact_channels SET status='unknown', status_reason=NULL, status_updated_at=now(), soft_bounce_count=0 WHERE kind='email' AND value='${TARGET_EMAIL}'`,
 		)
 	})
 
@@ -99,10 +99,10 @@ test.describe('contact suppression banner', () => {
 			page.getByTestId(/^contact-suppression-banner-/).first(),
 		).toBeHidden({ timeout: 10_000 })
 
-		// AND the DB row should reflect email_status='unknown' (the route
+		// AND the channel row should reflect status='unknown' (the route
 		// resets it to that value, not to 'valid').
 		const row = psql(
-			`SELECT email_status FROM contacts WHERE email='${TARGET_EMAIL}'`,
+			`SELECT status FROM contact_channels WHERE kind='email' AND value='${TARGET_EMAIL}'`,
 		)
 		expect(row).toBe('unknown')
 	})

--- a/apps/internal/tests/e2e/calendar-on-company.test.ts
+++ b/apps/internal/tests/e2e/calendar-on-company.test.ts
@@ -37,11 +37,12 @@ const seededIds: string[] = []
 
 test.describe('calendar on company page', () => {
 	test.beforeAll(() => {
-		// GIVEN the seeded `cal-pep-fonda` company has at least one
-		// confirmed upcoming event (the seed inserts "Zoom sync with Cal
-		// Pep" by default). We additionally seed:
-		//   - a cancelled event in the past so D.2's struck-through
-		//     treatment has something to render
+		// GIVEN cal-pep-fonda exists, seed the events this file asserts on so it
+		// owns its fixture rather than depending on the demo seed's date-pinned
+		// "Zoom sync" event, which drifts into the past as real time advances:
+		//   - a confirmed event a few days out (with an attendee) so the
+		//     upcoming-meetings card has a row to render
+		//   - a cancelled event in the past so the cancelled treatment renders
 		const orgId = psql(
 			`SELECT organization_id FROM companies WHERE slug='${COMPANY_SLUG}' LIMIT 1`,
 		)
@@ -50,6 +51,31 @@ test.describe('calendar on company page', () => {
 		)
 		expect(orgId, 'taller seeded').not.toBe('')
 		expect(companyId, 'cal-pep-fonda seeded').not.toBe('')
+
+		const upcomingId = randomUUID()
+		seededIds.push(upcomingId)
+		psql(
+			`INSERT INTO calendar_events (
+				id, organization_id, source, provider, provider_booking_id,
+				ical_uid, ical_sequence, start_at, end_at, status, title,
+				location_type, organizer_email, company_id
+			) VALUES (
+				'${upcomingId}', '${orgId}', 'booking', 'calcom', 'upcoming-fixture-${upcomingId}',
+				'upcoming-fixture-${upcomingId}', 0,
+				now() + interval '3 days',
+				now() + interval '3 days' + interval '30 minutes',
+				'confirmed',
+				'Upcoming sync with Cal Pep',
+				'video', 'organizer@taller.cat', '${companyId}'
+			)`,
+		)
+		psql(
+			`INSERT INTO calendar_event_attendees (
+				id, organization_id, event_id, email, name, rsvp
+			) VALUES (
+				gen_random_uuid(), '${orgId}', '${upcomingId}', 'pep@calpepfonda.cat', 'Pep Casals', 'accepted'
+			)`,
+		)
 
 		const cancelledId = randomUUID()
 		seededIds.push(cancelledId)
@@ -72,6 +98,7 @@ test.describe('calendar on company page', () => {
 
 	test.afterAll(() => {
 		for (const id of seededIds) {
+			psql(`DELETE FROM calendar_event_attendees WHERE event_id='${id}'`)
 			psql(`DELETE FROM calendar_events WHERE id='${id}'`)
 		}
 	})
@@ -91,7 +118,7 @@ test.describe('calendar on company page', () => {
 			})
 
 			// THEN the upcoming-meetings card is visible with at least one
-			// meeting row (the seed includes "Zoom sync with Cal Pep")
+			// meeting row (the confirmed event seeded above)
 			const card = page.getByTestId('company-upcoming-meetings-card')
 			await expect(card).toBeVisible()
 			const rows = card.locator('[data-testid^="company-upcoming-meeting-"]')

--- a/apps/internal/tests/e2e/company-not-found.test.ts
+++ b/apps/internal/tests/e2e/company-not-found.test.ts
@@ -35,10 +35,15 @@ test.describe('GET /v1/companies/:slug', () => {
 			// [handlers/companies.ts:18-26 — get success path]
 			const cookies = await page.context().cookies()
 			const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ')
-			const response = await request.get(
-				'https://api.batuda.localhost/v1/companies/cal-pep-fonda',
-				{ headers: { cookie: cookieHeader }, ignoreHTTPSErrors: true },
-			)
+			// Relative to the configured baseURL so this rides the app's `/v1`
+			// proxy on whatever origin/port is serving — bare `batuda.localhost`
+			// in a plain checkout, `<label>.batuda.localhost:<port>` in a
+			// worktree. Hardcoding `https://api.batuda.localhost` assumed portless
+			// had bound :443, which isn't true on a non-privileged fallback port.
+			const response = await request.get('/v1/companies/cal-pep-fonda', {
+				headers: { cookie: cookieHeader },
+				ignoreHTTPSErrors: true,
+			})
 			expect(response.status()).toBe(200)
 			const body = (await response.json()) as { slug?: string }
 			expect(body.slug).toBe('cal-pep-fonda')
@@ -58,10 +63,11 @@ test.describe('GET /v1/companies/:slug', () => {
 			// [routes/companies.ts:88 + handlers/companies.ts:22-24 — Effect.catch maps NotFound]
 			const cookies = await page.context().cookies()
 			const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ')
-			const response = await request.get(
-				'https://api.batuda.localhost/v1/companies/__not-a-real-slug__',
-				{ headers: { cookie: cookieHeader }, ignoreHTTPSErrors: true },
-			)
+			// Relative to baseURL — see the 200 case above for why not a hardcoded host.
+			const response = await request.get('/v1/companies/__not-a-real-slug__', {
+				headers: { cookie: cookieHeader },
+				ignoreHTTPSErrors: true,
+			})
 			expect(response.status()).toBe(404)
 			// The body should at minimum carry the NotFound tag / entity name.
 			// We're permissive on shape because Effect HttpApi's exact JSON

--- a/apps/internal/tests/e2e/inbox-listing.test.ts
+++ b/apps/internal/tests/e2e/inbox-listing.test.ts
@@ -33,9 +33,9 @@ test.describe('emails inbox listing', () => {
 	})
 
 	test.describe('when the user opens /emails', () => {
-		test('should render at least one row per seeded thread', async ({
-			page,
-		}) => {
+		test('should render at least one row per seeded thread', {
+			tag: '@smoke',
+		}, async ({ page }) => {
 			// GIVEN the seed produces 4 inbound threads on Taller (M1+M2
 			// share, M3 single, M4 single on agent inbox, M8 single).
 			// Resolve the count from the DB so the assertion stays in
@@ -88,14 +88,19 @@ test.describe('emails inbox listing', () => {
 		})
 	})
 
-	test.describe('when the user clicks a thread row', () => {
+	test.describe('when the user opens a thread row', () => {
 		test('should navigate to /emails/<uuid>', async ({ page }) => {
 			await page.goto('/emails', { waitUntil: 'networkidle' })
 
-			// Click the first row and assert the URL transitions
+			// Open the first row via its keyboard affordance (the row is
+			// tabindex=0 with an "Open thread" aria-label and an Enter/Space
+			// handler). A positional click on row 0 is flaky: Playwright scrolls
+			// it to the top of the grid, where the sticky table header then
+			// intercepts the click. Pressing Enter on the focused row activates
+			// the same navigation without hit-testing under that header.
 			const firstRow = page.locator('[data-testid^="thread-row-"]').first()
 			await expect(firstRow).toBeVisible()
-			await firstRow.click()
+			await firstRow.press('Enter')
 
 			await page.waitForURL(/\/emails\/[0-9a-f-]{36}$/, { timeout: 5_000 })
 		})

--- a/apps/internal/tests/e2e/quick-capture.test.ts
+++ b/apps/internal/tests/e2e/quick-capture.test.ts
@@ -21,9 +21,9 @@ import { expect, test } from '@playwright/test'
 
 test.describe('quick capture', () => {
 	test.describe('when the authenticated user logs an interaction against a seeded company', () => {
-		test('the interaction is created and the dialog closes', async ({
-			page,
-		}) => {
+		test('the interaction is created and the dialog closes', {
+			tag: '@smoke',
+		}, async ({ page }) => {
 			// GIVEN Alice is on the dashboard (cookie injected by setup)
 			// AND the page has reached networkidle so React has had time
 			// to hydrate the TopBar — the Log button uses a plain onClick

--- a/apps/internal/tests/e2e/send-email.test.ts
+++ b/apps/internal/tests/e2e/send-email.test.ts
@@ -113,16 +113,16 @@ test.describe('compose and send via the mail catcher', () => {
 
 	test.describe('when the recipient is suppressed', () => {
 		test.beforeEach(() => {
-			// AND Pep Casals is forced into bounced state so SuppressionGuard
-			// trips on the recipient
+			// AND Pep Casals' email channel is forced into bounced state so
+			// SuppressionGuard trips on the recipient
 			psql(
-				`UPDATE contacts SET email_status='bounced', email_status_reason='${SUPPRESSED_REASON}', email_status_updated_at=now() WHERE email='${SUPPRESSED_EMAIL}'`,
+				`UPDATE contact_channels SET status='bounced', status_reason='${SUPPRESSED_REASON}', status_updated_at=now() WHERE kind='email' AND value='${SUPPRESSED_EMAIL}'`,
 			)
 		})
 
 		test.afterEach(() => {
 			psql(
-				`UPDATE contacts SET email_status='unknown', email_status_reason=NULL, email_status_updated_at=now(), email_soft_bounce_count=0 WHERE email='${SUPPRESSED_EMAIL}'`,
+				`UPDATE contact_channels SET status='unknown', status_reason=NULL, status_updated_at=now(), soft_bounce_count=0 WHERE kind='email' AND value='${SUPPRESSED_EMAIL}'`,
 			)
 		})
 

--- a/apps/internal/tests/e2e/sign-in.test.ts
+++ b/apps/internal/tests/e2e/sign-in.test.ts
@@ -19,7 +19,9 @@ import { waitForInteractive } from './helpers/hydration'
 
 test.describe('sign-in', () => {
 	test.describe('with seeded credentials and no returnTo', () => {
-		test('should land Alice on / and drop the login form', async ({ page }) => {
+		test('should land Alice on / and drop the login form', {
+			tag: '@smoke',
+		}, async ({ page }) => {
 			// GIVEN the dev stack is up and the seed has provisioned alice
 			// AND the browser is at /login with the form rendered
 			await page.goto('/login')
@@ -87,11 +89,14 @@ test.describe('sign-in', () => {
 
 			// THEN the URL becomes / (NOT //evil.example/) — the open-redirect
 			// vector is closed. The host must be batuda.localhost; the optional
-			// port tolerates portless's non-443 dev port without weakening the
+			// leading label tolerates a worktree's `<label>.batuda.localhost`, and
+			// the optional port portless's non-443 dev port, without weakening the
 			// check that an evil host is rejected.
 			// [routes/login.tsx:20-22 — isSafeReturnTo rejects protocol-relative]
 			await page.waitForURL(/\/$/)
-			await expect(page).toHaveURL(/^https:\/\/batuda\.localhost(:\d+)?\/$/)
+			await expect(page).toHaveURL(
+				/^https:\/\/(?:[a-z0-9-]+\.)?batuda\.localhost(:\d+)?\/$/,
+			)
 			await expect(page.getByTestId('login-form')).toHaveCount(0)
 		})
 	})

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -52,3 +52,19 @@ CI enforces this on every PR: `scripts/check-migration-safety.mjs` fails when a 
 ### Rehearsing and re-running
 
 For a destructive or large change, rehearse on a Neon branch first (branch prod → apply → verify → let the pipeline run it on prod); CI already runs every migration on an ephemeral Neon branch per PR. The migrator is incremental — it records applied migrations and a re-run only applies the pending ones, so a re-run after a partial failure resumes safely.
+
+## End-to-end tests in CI
+
+The Playwright end-to-end suite (`apps/internal/tests/e2e`) drives a real browser against a running stack, so it catches breakages that types, build, and unit tests wave through — a page that crashes only in the browser, a seed that contradicts its own assertion. It runs in three places, and where a failure blocks depends on the place.
+
+**Pre-push (`lefthook.yml`).** A small smoke subset (`--grep @smoke`: sign-in, one read, one write) runs against your live `pnpm dev` stack for fast local feedback, the same way the integration suite runs pre-push. It **skips with a notice rather than failing** when the dev stack isn't reachable or Chromium isn't installed — a hook can be skipped, so it is bonus feedback, not the gate.
+
+**CI on every pull request (`ci.yml`, the `e2e-smoke` job).** The same smoke subset runs in its own parallel job that stands up its own Postgres + seed and serves the app under portless — the exact dev environment, so a pass locally means a pass here. This job is a **required status check: a failure blocks the merge.** It is the un-skippable gate the pre-push hook cannot be.
+
+**CI on push to `main` (`e2e-main.yml`).** The full suite runs post-merge as a non-required workflow (it also brings up GreenMail + a mail-worker for the email round-trip specs). It **reports a failure on the commit without gating any pull request** — a backstop that tells you a break landed, not a merge gate.
+
+### When an end-to-end test is flaky
+
+Smoke runs with `retries: 1` in CI (`playwright.config.ts`) so a single transient blip does not fail a PR; a test that only passes on retry still shows in the run and is triaged, not ignored.
+
+A test that fails or flakes repeatedly is **quarantined** — marked `test.fixme` with a tracking issue that names the cause — never left silently red. A quarantined test is off the gate but on the record, so a green run means every non-quarantined test passed and the quarantine list is the honest backlog.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -68,3 +68,24 @@ pre-push:
       # checkout's integration DB and TRUNCATE shared tables in beforeAll.
       run: |
         pnpm turbo test test:integration --concurrency=1
+
+    e2e-smoke:
+      # Browser-level smoke (sign-in + one read + one write, tagged @smoke) run
+      # against your live `pnpm dev` stack — fast local feedback, the way the
+      # integration suite runs here too. The CI `e2e-smoke` job is the
+      # un-skippable gate; this hook is a bonus, so it SKIPS (never blocks a
+      # push) when the dev stack isn't reachable or Chromium isn't installed.
+      # `portless get batuda` resolves the right origin whether this is the main
+      # checkout (batuda.localhost) or a worktree (<label>.batuda.localhost).
+      run: |
+        url="$(pnpm exec portless get batuda 2>/dev/null)"
+        if [ -z "$url" ] || ! curl -skf --max-time 3 -o /dev/null "$url/login"; then
+          echo "skip: e2e smoke — dev stack not reachable (start it with 'pnpm dev'); CI will run it"
+          exit 0
+        fi
+        if ! find "$HOME/Library/Caches/ms-playwright" "$HOME/.cache/ms-playwright" \
+             -maxdepth 1 -name 'chromium-*' -print -quit 2>/dev/null | grep -q .; then
+          echo "skip: e2e smoke — Chromium not installed (run 'pnpm --filter @batuda/internal exec playwright install chromium'); CI will run it"
+          exit 0
+        fi
+        E2E_BASE_URL="$url" pnpm --filter @batuda/internal exec playwright test --grep @smoke


### PR DESCRIPTION
## What

Batuda's 34 browser-level end-to-end (e2e) tests never ran automatically — nothing checked them on a pull request, a merge, or a schedule, so they only ran when someone remembered to. This PR (issue #309) makes them run on their own: a fast **smoke** subset gates every pull request, and the full suite runs after each merge to `main`. It lives across the CRM web app (`internal`) and the CI configuration.

Turning the suite on meant getting it green first — and doing that surfaced **two real, user-facing bugs** that types, build, and unit tests all passed. That's the whole argument for the suite: only a real browser against a running app catches this class.

## Changes

- **Automated the suite.** A parallel `e2e-smoke` CI job serves the app under portless and runs a sign-in + one-read + one-write smoke subset on every PR as a **required check**; a `pre-push` hook runs the same subset against a developer's live stack (skipping, never blocking, when the stack is down); an `e2e-main` workflow runs the whole suite after each push to `main` as a non-blocking backstop.
- **Fixed a bounced contact showing no reason.** On the company page the suppression banner rendered but its explanation was blank — the code read the bounce reason under raw database column names while the API returns those keys camelCased.
- **Fixed the compose window not blocking bounced recipients.** The send guard checked a contact field that no longer carries the bounced/complained status, so Send stayed enabled for an address that had hard-bounced.
- **Made the suite green on a clean checkout.** Fixed specs that assumed a fixed hostname, a fixed seed date, or the old contact email columns (open-redirect host check, sticky-header row click, the calendar's upcoming-event card, the bounce/suppression fixtures now reading `contact_channels`).

## Impact

- **Merges are now gated on `e2e-smoke`.** It's a new required status check — a red browser smoke run blocks the merge. The full suite on `main` only reports; it does not gate.
- **Behavior change (a fix):** composing to a hard-bounced address now disables Send, where before it silently allowed the send. No API wire-shape change — the fix reads keys the API already sent.
- **No migrations, no new env vars, no RLS/tenant-scoping changes.**
- **New CI serving path.** The e2e jobs stand the app up under portless on the runner (the exact dev environment). Proven green in CI: the `e2e-smoke` job ran in **2m20s**, in parallel with the existing job, so it doesn't touch the main job's 10-minute budget.

## Review guide

- **Start with the two app fixes** — `apps/internal/src/components/contacts/display-channels.ts` (read camelCase channel keys) and `apps/internal/src/components/emails/compose-form.tsx` (derive suppression from the primary email channel). Both are small; the unit test in `display-channels.test.ts` now encodes the real camelCase contract (it previously asserted a fictional snake_case one, which is how the bug hid).
- **The CI YAML** — `.github/actions/e2e-stack/action.yml` (shared serving) + the `e2e-smoke` job in `ci.yml` + `e2e-main.yml`. It mirrors `pnpm dev`; the one runner-specific wrinkle (portless needs its proxy started explicitly on an unprivileged port, since a runner has no TTY for sudo) is handled in the composite action.
- **The e2e test changes are mechanical** — host-agnostic assertions, a keyboard row activation, a self-seeded calendar event, `contact_channels` fixtures. Skim-able.

## Screenshots

Company → People, a hard-bounced contact — the banner now shows the upstream reason ("550 5.1.1 mailbox not found"), which was previously blank:

![pr-suppression-banner.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-319/pr-suppression-banner.webp)

## Tests

- The full e2e suite is green on a clean checkout (96 passed / 6 intentionally-skipped locally).
- Tagged a `@smoke` subset (sign-in, one inbox read, one quick-capture write, plus the shared sign-in setup) selected with `--grep @smoke`.
- Added the real camelCase contract to the `narrowChannels` unit test.

## Verification

- Ran locally: `check-types` ✓, unit `test` ✓ (660 tests), `build` ✓, `biome + dprint check` ✓.
- Ran the full e2e suite against the live stack: green apart from one worktree-only flake (`send-email:91`, contention on the shared mail catcher; passes in isolation, and CI has a single stack + `retries: 1`).
- Verified the suppression fix end-to-end in the browser (screenshot above).
- Rebased onto current `origin/main` (9 commits landed under me) and re-ran `install` → `check-types` + `test` → `build`, all green.
- **CI is green:** both the existing job and the new `e2e-smoke` gate pass on this PR — the smoke job stood the app up under portless on the runner and ran the subset in 2m20s.

## Deferred

Per-test data isolation → multiple Playwright workers → moving the *full* suite onto every PR (the issue's task "D", an "L") is left for a follow-up issue. It's a larger redesign of fixture ownership; the smoke gate here meets the issue's definition of done without it.

Closes #309
