### PR TITLE
fix(research): keep open-web searches anchored to the target company

### DIFF
--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -170,7 +170,7 @@ const QUOTED_NAME = /["“]([^"”]{2,80})["”]/
 // A free-text query's company name: the first quoted phrase if one is present,
 // else the part before the first comma ("Sunset Transportation, St. Louis MO");
 // fall back to the whole query.
-const queryName = (query: string): string =>
+export const queryName = (query: string): string =>
 	query.match(QUOTED_NAME)?.[1] ?? query.split(',')[0] ?? query
 
 // Administrative words that name no particular place — dropped so only the

--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -10,6 +10,7 @@ import type {
 	ProviderError,
 	UnsupportedSite,
 } from '../domain/errors'
+import type { EntityTargets } from './entity-guard'
 
 // ── Research run context (available inside the LLM tool loop fiber) ──
 
@@ -22,6 +23,14 @@ export class ResearchRunContext extends Context.Service<
 		// own pages are rarely in English for a non-English target.
 		readonly language?: string | undefined
 		readonly location?: string | undefined
+		// The run's target company, so a web search that dropped the company name can
+		// be re-anchored to it before it reaches the provider. `entityTargets` is the
+		// match keys used to tell an already-anchored query from one that drifted off
+		// the company; `entityName` is the display name appended to a drifted query.
+		// `entityTargets` is null for a scan/freeform run that has no single target
+		// company, and that alone turns the re-anchoring off.
+		readonly entityTargets?: EntityTargets | null | undefined
+		readonly entityName?: string | undefined
 	}
 >()('research/ResearchRunContext') {}
 

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -79,6 +79,7 @@ import {
 	groundedSourceIds,
 	isConfirmedRegistryMatch,
 	isEntityGroundedSchema,
+	queryName,
 	reachedOwnSite,
 	withRedirectDomain,
 } from './entity-guard'
@@ -1650,6 +1651,16 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					})
 					let entityMatch: EntityMatch | null =
 						(run as { entityMatch?: EntityMatch | null }).entityMatch ?? null
+
+					// The target's display name, to re-anchor a web search that dropped it:
+					// an anchored subject's own name, else the name read from the query. Used
+					// only when `entityTargets` is set (an enrichment/contact run with one
+					// subject); a scan/freeform run never scopes its searches to a name.
+					const entityName =
+						subjectTargets
+							.map(s => s.name)
+							.find((n): n is string => n != null && n.trim() !== '') ??
+						queryName((run as { query: string }).query)
 
 					// The company's own official site to fetch up front, when the caller
 					// gave its domain — a target-correction re-run's anchor, an anchored
@@ -3480,6 +3491,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									researchId,
 									language: hints?.language,
 									location: hints?.location,
+									entityTargets,
+									entityName,
 								}),
 							),
 							Effect.withSpan('research.phase1', {

--- a/packages/research/src/application/search-query-scope.test.ts
+++ b/packages/research/src/application/search-query-scope.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import type { EntityTargets } from './entity-guard'
+import { scopeSearchQuery } from './search-query-scope'
+
+// A representative target: "Acme Logistics" at acme.com, no place keys.
+const acme: EntityTargets = {
+	cores: ['acmelogistics'],
+	words: ['acme'],
+	domains: ['acme.com'],
+	places: [],
+}
+
+describe('scopeSearchQuery', () => {
+	describe('when the query has drifted off the target company', () => {
+		it('should prepend the quoted company name to re-anchor it', () => {
+			// GIVEN a query that names neither the company, its domain, nor a
+			// distinctive word from it — the drift that makes a provider return
+			// off-company pages
+			// WHEN scoped to the target
+			// THEN the company's quoted name leads the query so the provider stays on it
+			expect(
+				scopeSearchQuery({
+					query: 'sheet metal fabrication number of employees',
+					name: 'Acme Logistics',
+					targets: acme,
+				}),
+			).toBe('"Acme Logistics" sheet metal fabrication number of employees')
+		})
+
+		it('should trim surrounding whitespace on both the name and the query', () => {
+			// GIVEN a name and query padded with whitespace
+			// WHEN scoped
+			// THEN neither the anchor nor the query carries stray padding
+			expect(
+				scopeSearchQuery({
+					query: '  industry sector  ',
+					name: '  Acme Logistics  ',
+					targets: acme,
+				}),
+			).toBe('"Acme Logistics" industry sector')
+		})
+	})
+
+	describe('when the query already reaches the target company', () => {
+		it('should leave a query that spells the full name untouched', () => {
+			// GIVEN a query that already names the company (a strong match)
+			// WHEN scoped
+			// THEN it is returned unchanged — re-anchoring would only narrow it
+			const query = 'Acme Logistics headquarters city'
+			expect(
+				scopeSearchQuery({ query, name: 'Acme Logistics', targets: acme }),
+			).toBe(query)
+		})
+
+		it('should leave a query carrying the target domain untouched', () => {
+			// GIVEN a query scoped with a site: filter on the company's own domain
+			// WHEN scoped
+			// THEN it already reaches the target, so it is unchanged
+			const query = 'site:acme.com team'
+			expect(
+				scopeSearchQuery({ query, name: 'Acme Logistics', targets: acme }),
+			).toBe(query)
+		})
+
+		it('should leave a query carrying only a distinctive word untouched', () => {
+			// GIVEN a query with a distinctive word from the name but not the full name
+			// (a weak match) — still on-target, so no anchor is needed
+			// WHEN scoped
+			// THEN it is unchanged
+			const query = 'acme employee headcount'
+			expect(
+				scopeSearchQuery({ query, name: 'Acme Logistics', targets: acme }),
+			).toBe(query)
+		})
+
+		it('should be idempotent — a second pass adds no second anchor', () => {
+			// GIVEN a query already re-anchored by a prior pass
+			// WHEN scoped again
+			// THEN the name is now present (a strong match) so nothing is prepended
+			const once = scopeSearchQuery({
+				query: 'number of employees',
+				name: 'Acme Logistics',
+				targets: acme,
+			})
+			expect(
+				scopeSearchQuery({
+					query: once,
+					name: 'Acme Logistics',
+					targets: acme,
+				}),
+			).toBe(once)
+		})
+	})
+
+	describe('when the run has no single target company', () => {
+		it('should leave the query untouched for null targets', () => {
+			// GIVEN a scan/freeform run that reports third parties (targets null)
+			// WHEN scoped
+			// THEN the query is never narrowed to a name
+			const query = 'top metal fabrication shops in Ohio'
+			expect(
+				scopeSearchQuery({ query, name: 'Acme Logistics', targets: null }),
+			).toBe(query)
+		})
+
+		it('should leave the query untouched for undefined targets', () => {
+			// GIVEN a run whose context carries no targets at all
+			// WHEN scoped
+			// THEN the query is returned as-is
+			const query = 'best CRM for job shops'
+			expect(
+				scopeSearchQuery({ query, name: 'Acme Logistics', targets: undefined }),
+			).toBe(query)
+		})
+	})
+
+	describe('when no usable company name is available', () => {
+		it('should leave the query untouched for an undefined name', () => {
+			// GIVEN targets but no display name to anchor with
+			// WHEN scoped
+			// THEN there is nothing to prepend, so the query is unchanged
+			const query = 'industry sector'
+			expect(scopeSearchQuery({ query, name: undefined, targets: acme })).toBe(
+				query,
+			)
+		})
+
+		it('should leave the query untouched for a blank name', () => {
+			// GIVEN a name that is only whitespace
+			// WHEN scoped
+			// THEN it yields no anchor, so the query is unchanged
+			const query = 'industry sector'
+			expect(scopeSearchQuery({ query, name: '   ', targets: acme })).toBe(
+				query,
+			)
+		})
+	})
+})

--- a/packages/research/src/application/search-query-scope.ts
+++ b/packages/research/src/application/search-query-scope.ts
@@ -1,0 +1,36 @@
+/**
+ * Keeps an open-web search anchored to the company the run is about.
+ *
+ * The model writes its own `web_search` queries, and when one leaves out the
+ * company name the provider answers with pages about something else entirely — a
+ * research paper, an unrelated PDF — that the run then wastes a fetch on. This
+ * prepends the company's quoted name to a query that does not already name it, so
+ * the provider stays on the target. A query that already reaches the company (its
+ * name, a distinctive word from it, or its own domain is present) is left alone,
+ * and a run with no single target company (a scan or freeform run, where
+ * `targets` is null) is never rewritten.
+ */
+
+import { classifyEntityMatch, type EntityTargets } from './entity-guard'
+
+/**
+ * The search query to actually send: the original when it already reaches the
+ * target company or the run has no single target, otherwise the original with the
+ * company's quoted name prepended as an anchor.
+ */
+export const scopeSearchQuery = (args: {
+	readonly query: string
+	readonly name: string | undefined
+	readonly targets: EntityTargets | null | undefined
+}): string => {
+	const { query, name, targets } = args
+	// A scan/freeform run reports third-party companies, so a search of its own is
+	// not about one target and must not be narrowed to a name.
+	if (targets == null) return query
+	const trimmedName = name?.trim() ?? ''
+	if (trimmedName === '') return query
+	// The query already names the company (or its domain/a distinctive word) — it
+	// is on-target, and prepending the name again would only narrow it.
+	if (classifyEntityMatch(targets, query) !== 'absent') return query
+	return `"${trimmedName}" ${query.trim()}`.trim()
+}

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -10,6 +10,7 @@ import {
 	ContactDiscovery,
 	type DiscoverContactsInput,
 } from './contact-discovery'
+import type { EntityTargets } from './entity-guard'
 import {
 	Budget,
 	type RegistryInput,
@@ -108,6 +109,62 @@ const webSearchInput = async (params: {
 				researchToolkitLayer.pipe(
 					Layer.provide(Layer.mergeAll(ports, testInfra)),
 				),
+			),
+		),
+	)
+	if (captured === undefined) {
+		throw new Error('web_search handler never called the search provider')
+	}
+	return captured
+}
+
+// Drive web_search under a run context that targets a specific company, so the
+// captured query reveals whether the handler re-anchored it to that company
+// before the query reached the provider.
+const webSearchInputForTarget = async (
+	params: { query: string },
+	target: {
+		entityTargets: EntityTargets | null
+		entityName?: string | undefined
+	},
+): Promise<SearchInput> => {
+	let captured: SearchInput | undefined
+	const ports = Layer.mergeAll(
+		Layer.succeed(SearchProvider)(
+			SearchProvider.of({
+				search: input => {
+					captured = input
+					return Effect.succeed(new SearchResult({ items: [], units: 0 }))
+				},
+			}),
+		),
+		StubScrapeProvider,
+		StubRegistryEsProvider,
+	)
+	const infra = Layer.mergeAll(
+		stubBudget,
+		Layer.succeed(ResearchRunContext)({ researchId: 'test-run', ...target }),
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test-run',
+				}),
+		}),
+	)
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const toolkit = yield* researchToolkit
+			const stream = yield* toolkit.handle('web_search', {
+				limit: null,
+				recency_days: null,
+				location: null,
+				...params,
+			})
+			yield* Stream.runDrain(stream)
+		}).pipe(
+			Effect.provide(
+				researchToolkitLayer.pipe(Layer.provide(Layer.mergeAll(ports, infra))),
 			),
 		),
 	)
@@ -334,6 +391,55 @@ const discoverContactsInput = async (params: {
 	}
 	return captured
 }
+
+describe('researchToolkit web_search — a drifted query is re-anchored to the run target', () => {
+	const acme: EntityTargets = {
+		cores: ['acmelogistics'],
+		words: ['acme'],
+		domains: ['acme.com'],
+		places: [],
+	}
+
+	describe('when the run targets a company and the query dropped its name', () => {
+		it('should prepend the company name before the query reaches the provider', async () => {
+			// GIVEN a run whose target is Acme and a query naming neither it nor its domain
+			// WHEN the web_search handler runs
+			// THEN the provider is called with the query re-anchored to the target
+			const input = await webSearchInputForTarget(
+				{ query: 'number of employees' },
+				{ entityTargets: acme, entityName: 'Acme Logistics' },
+			)
+			expect(input.query).toBe('"Acme Logistics" number of employees')
+		})
+	})
+
+	describe('when the query already names the company', () => {
+		it('should pass the query through unchanged', async () => {
+			// GIVEN a query that already reaches the target (a strong name match)
+			// WHEN the handler runs
+			// THEN it is sent as-is — re-anchoring would only narrow an on-target query
+			const input = await webSearchInputForTarget(
+				{ query: 'Acme Logistics headquarters city' },
+				{ entityTargets: acme, entityName: 'Acme Logistics' },
+			)
+			expect(input.query).toBe('Acme Logistics headquarters city')
+		})
+	})
+
+	describe('when the run has no single target company', () => {
+		it('should pass the query through unchanged', async () => {
+			// GIVEN a scan/freeform run (no entity targets) that legitimately searches
+			// for third parties
+			// WHEN the handler runs
+			// THEN the query is never narrowed to a name
+			const input = await webSearchInputForTarget(
+				{ query: 'top metal fabrication shops in Ohio' },
+				{ entityTargets: null, entityName: 'Acme Logistics' },
+			)
+			expect(input.query).toBe('top metal fabrication shops in Ohio')
+		})
+	})
+})
 
 describe('researchToolkit tool params — null and quoted numbers are read, not refused', () => {
 	describe('web_search handler', () => {

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -37,6 +37,7 @@ import {
 	SearchProvider,
 } from './ports'
 import { describedLenientNumber } from './schemas/_shared'
+import { scopeSearchQuery } from './search-query-scope'
 import {
 	REGISTRY_LOOKUP_COST_CENTS,
 	SCRAPE_COST_CENTS,
@@ -289,6 +290,8 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 			researchId,
 			language: hintLanguage,
 			location: hintLocation,
+			entityTargets,
+			entityName,
 		} = yield* ResearchRunContext
 
 		// Charged against the run before each vendor call (cheap tier for
@@ -349,11 +352,28 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					yield* budget.chargeCheap('search', SEARCH_COST_CENTS)
 					// Drop a made-up placeholder site: filter (e.g. site:example.com)
 					// so it can't force a zero-result search.
-					const query = stripPlaceholderSiteFilters(params.query)
-					if (query !== params.query) {
+					const stripped = stripPlaceholderSiteFilters(params.query)
+					if (stripped !== params.query) {
 						yield* Effect.logWarning(
 							'research.search.placeholder_site_stripped',
 						).pipe(Effect.annotateLogs({ tool: 'web_search' }))
+					}
+					// Re-anchor a query that dropped the company name to the run's target,
+					// so the provider stays on it instead of returning off-company pages
+					// the run would then waste a fetch on. A no-op for an already-on-target
+					// query or a scan/freeform run with no single target.
+					const query = scopeSearchQuery({
+						query: stripped,
+						name: entityName,
+						targets: entityTargets,
+					})
+					if (query !== stripped) {
+						yield* Effect.logInfo('research.search.scoped_to_entity').pipe(
+							Effect.annotateLogs({
+								tool: 'web_search',
+								'research.run_id': researchId,
+							}),
+						)
 					}
 					return yield* search.search({
 						query,


### PR DESCRIPTION
## What

Research is the part of Batuda that goes and finds out about a company for you. To do that it runs its own web searches, and it writes those searches itself as it works. Sometimes one of them left out the company's name — and a search engine, given only "number of employees" or "sheet metal fabrication", happily answers with pages about something else entirely. In one benchmark run for a sheet-metal shop the tool ended up fetching an unrelated academic paper on sweeteners and a PDF about job insecurity. Those pages never made it into the answer (other guards already keep off-company facts out), but the run still paid to fetch and read them — wasted time and budget, and a sign the search had drifted off the company.

This change keeps every open-web search anchored to the company the run is about. It lives entirely in the Research bounded context (`packages/research`) — no schema, API, or frontend surface changes.

## The fix

- Before a search leaves for the provider, check whether it still mentions the company (its name, a distinctive word from it, or its own web domain). If it doesn't, put the company's quoted name back in front of it, so the provider stays on the target instead of wandering.
- A search that already reaches the company is sent untouched — re-anchoring an on-target search would only narrow it for no gain.
- A broad scan run — one whose whole job is to report *other* companies — is never narrowed to a single name. The anchor only applies to a run with one target company (enrichment / contact discovery).

The company identity the run already derives for its other grounding checks is now also handed to the search tool, which is what makes this a small change: the decision reuses the existing entity-match logic rather than inventing a new one.

## Impact

- No migration, no schema change, no wire-shape change — the `get_research` / apply contracts are untouched.
- No new env vars, no auth/RLS/role changes.
- MCP + HTTP parity: the change is inside the shared research tool loop, so both transports get it identically.
- Cost/behaviour: the intended effect is *fewer* paid fetches (off-company pages that used to be fetched and discarded). The one behavioural risk is the reverse — see the Review guide.

## Review guide

Start in [`search-query-scope.ts`](packages/research/src/application/search-query-scope.ts) — the whole decision is one small pure function; the rest is wiring (`tools.ts` applies it in the `web_search` handler, `research-service.ts` supplies the target name, `ports.ts` carries it on the run context).

The judgement call worth your eye, flagged by `/code-review`: the anchor is applied to **any** search that dropped the company name — including a search an enrichment run fires *on purpose* without the name, e.g. to find competitors or market context. Anchoring such a search to the company would return the company's own pages instead. I judged this acceptable because (a) issue #314's actual failures were pure drift (an unrelated paper), not comparative searches, and (b) the research eval measures competitor/market grounding, so a regression there would show up. I ran the eval as the end-to-end check — results below. If competitor/market rows regress, the follow-up is to anchor only identity-seeking searches rather than all of them.

Two lower-severity edges from the same review, left as-is for now: a company name that is itself a common word (e.g. "Delta") can make an off-company search look on-target and skip the anchor; and a freeform run whose query has no comma or quotes can derive an over-long name to prepend. Both are confined to freeform runs — CRM-row runs use the stored subject name — and neither can produce a wrong *fact*, only a less-scoped search.

## Tests

- A pure-function suite for the scoping decision: a drifted query is re-anchored; a query that already names the company / carries its domain / carries a distinctive word is left untouched; null/undefined targets and a blank name are no-ops; and the rewrite is idempotent (a second pass adds no second anchor).
- A handler-level test driving the real `web_search` tool under a targeted run context, asserting the query the provider actually receives is re-anchored (and passed through unchanged for on-target and scan runs).

## Verification

- Gates run and green: `pnpm -w check-types` (13/13), `pnpm --filter @batuda/research test` (830 pass), `pnpm -w build` (13/13), `pnpm install` clean (no lockfile drift).
- End-to-end: research quality eval against the live pipeline — numbers added as a comment below.

Closes #314
