### PR TITLE
perf(internal): load the email editor only when writing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # Cloudflare rejects the batuda.co worker past a fixed compressed size,
+      # and it does so at deploy time — on a release tag, once the tag is
+      # already pushed. Catching it here points at the pull request that added
+      # the weight instead. Measures what Build produced, so it runs after it.
+      - name: Check worker bundle size
+        run: node scripts/check-bundle-size.mjs
+
       # The TanStack Start Vite plugin (run by Build) is the single source of
       # truth for apps/internal/src/routeTree.gen.ts. If Build regenerated a
       # different tree, the committed one is stale — fail so it gets committed.

--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -5,7 +5,6 @@ import { AlertTriangle, Plus, Send, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import { EmailEditor } from '@batuda/email/editor'
 import type { EmailBlocks } from '@batuda/email/schema'
 import { PriButton, PriInput, PriSelect } from '@batuda/ui/pri'
 
@@ -24,6 +23,7 @@ import {
 	primaryEmailChannel,
 } from '#/components/contacts/display-channels'
 import { AttachmentPicker } from '#/components/emails/attachment-picker'
+import { EmailEditor } from '#/components/emails/email-editor'
 import { type Draft, useComposeEmail } from '#/context/compose-email-context'
 import type { StagedAttachment } from '#/lib/email-attachments'
 

--- a/apps/internal/src/components/emails/email-editor.client.tsx
+++ b/apps/internal/src/components/emails/email-editor.client.tsx
@@ -1,0 +1,1 @@
+export { EmailEditor } from '@batuda/email/editor'

--- a/apps/internal/src/components/emails/email-editor.tsx
+++ b/apps/internal/src/components/emails/email-editor.tsx
@@ -1,0 +1,24 @@
+import { ClientOnly } from '@tanstack/react-router'
+import { type ComponentProps, lazy, Suspense } from 'react'
+
+import type { EmailEditor as EmailEditorClient } from './email-editor.client'
+
+// The editor only ever runs in a browser, and a plain import drags its whole
+// toolchain — an HTML renderer, a code formatter, a CSS builder — into the
+// server bundle, which has a hard size ceiling. TanStack Start's import
+// protection keeps `.client.tsx` files out of that bundle, `lazy` gives the
+// editor its own browser-only chunk, and `<ClientOnly>` holds off rendering
+// until the page is interactive.
+const Lazy = lazy(() =>
+	import('./email-editor.client').then(m => ({ default: m.EmailEditor })),
+)
+
+export function EmailEditor(props: ComponentProps<typeof EmailEditorClient>) {
+	return (
+		<ClientOnly fallback={null}>
+			<Suspense fallback={null}>
+				<Lazy {...props} />
+			</Suspense>
+		</ClientOnly>
+	)
+}

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -26,7 +26,6 @@ import type { ComponentType } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled, { css } from 'styled-components'
 
-import { EmailEditor } from '@batuda/email/editor'
 import type { EmailBlocks } from '@batuda/email/schema'
 import {
 	PriButton,
@@ -57,6 +56,7 @@ import {
 	type InboxDraft,
 	inboxDraftAtom,
 } from '#/atoms/inbox-draft-atoms'
+import { EmailEditor } from '#/components/emails/email-editor'
 import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
 import { RelativeDate } from '#/components/shared/relative-date'

--- a/apps/internal/vite.config.ts
+++ b/apps/internal/vite.config.ts
@@ -163,7 +163,14 @@ const config = defineConfig(({ command }) => {
 			// magic-link button onClick stops attaching, sign-in form
 			// submits get dropped, etc. Symmetric source load + symmetric
 			// transform fixes the mismatch at the root.
-			conditions: ['development', 'module', 'import', 'default'],
+			//
+			// `browser` is listed because naming any condition here replaces
+			// Vite's own client-side list rather than adding to it, and that
+			// list normally carries `browser`. A package that ships separate
+			// browser and Node builds — `@react-email/render` does — would
+			// otherwise hand the browser its Node build, which reaches for
+			// Node-only globals and throws as soon as it runs.
+			conditions: ['development', 'module', 'browser', 'import', 'default'],
 		},
 		ssr: {
 			// Bundle through Vite for SSR so the React-using deps go through

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"db:up": "docker compose -f docker/docker-compose.yml up -d",
 		"db:down": "docker compose -f docker/docker-compose.yml down",
 		"db:migrate": "pnpm --filter @batuda/server run migrate",
+		"check-bundle-size": "node scripts/check-bundle-size.mjs",
 		"check-migrations": "node scripts/check-migration-safety.mjs",
 		"______ Release ______": "",
 		"release:server": "release-it --config .release-it.server.cjs",

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Guards the size limit Cloudflare enforces on the batuda.co worker.
+//
+// The whole server-side app is uploaded as one script, and the hosting plan
+// rejects it past a fixed compressed size. That rejection lands at DEPLOY time,
+// on a release tag, once the tag is already pushed. Checking here moves the
+// discovery to the pull request that adds the weight.
+//
+// The size comes from `wrangler deploy --dry-run`: the same number the real
+// deploy reports, so it cannot drift from what Cloudflare decides, and it needs
+// no credentials and uploads nothing.
+//
+// Usage: node scripts/check-bundle-size.mjs [--budget <KiB>]   (default: 2700)
+//   Measures the built output — run `pnpm build` first.
+//   Exits 1 when over budget, 2 when the size cannot be measured.
+
+import { execFileSync } from 'node:child_process'
+
+// Cloudflare's own limit is 3072 KiB compressed. The budget sits below it so a
+// pull request fails with room to spare, not at the exact point where the
+// deploy would already be broken.
+const CLOUDFLARE_LIMIT_KIB = 3072
+const DEFAULT_BUDGET_KIB = 2700
+const WORKER_DIR = 'apps/internal'
+
+const budgetFlagIndex = process.argv.indexOf('--budget')
+const budgetKib =
+	budgetFlagIndex === -1
+		? DEFAULT_BUDGET_KIB
+		: Number(process.argv[budgetFlagIndex + 1])
+
+if (!Number.isFinite(budgetKib) || budgetKib <= 0) {
+	console.error(`Invalid --budget: ${process.argv[budgetFlagIndex + 1]}`)
+	process.exit(2)
+}
+
+let output = ''
+try {
+	output = execFileSync('pnpm', ['exec', 'wrangler', 'deploy', '--dry-run'], {
+		cwd: WORKER_DIR,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	})
+} catch (error) {
+	console.error('::error::Could not measure the worker bundle.')
+	console.error(error.stdout ?? '')
+	console.error(error.stderr ?? '')
+	process.exit(2)
+}
+
+// wrangler prints e.g. `Total Upload: 10863.02 KiB / gzip: 2385.95 KiB`.
+const compressedSizeMatch = output.match(/gzip:\s*([\d.]+)\s*KiB/i)
+if (!compressedSizeMatch) {
+	console.error(
+		'::error::Could not read a compressed size from wrangler output. ' +
+			'Its output format may have changed — update scripts/check-bundle-size.mjs.',
+	)
+	console.error(output)
+	process.exit(2)
+}
+
+const actualKib = Number(compressedSizeMatch[1])
+const headroomKib = (CLOUDFLARE_LIMIT_KIB - actualKib).toFixed(1)
+const summary = `${actualKib} KiB compressed (budget ${budgetKib} KiB, Cloudflare rejects above ${CLOUDFLARE_LIMIT_KIB} KiB, headroom ${headroomKib} KiB)`
+
+if (actualKib > budgetKib) {
+	console.error(`::error::Worker bundle over budget — ${summary}`)
+	console.error(
+		'\nSomething heavy reached the server bundle. Most often this is a ' +
+			'browser-only component imported directly by a route: an editor, a map, ' +
+			'a calendar. Those belong in a `.client.tsx` file behind `lazy()` so ' +
+			'they download only for the people who use them — see ' +
+			'apps/internal/src/components/emails/email-editor.tsx.\n\n' +
+			'To see what is taking the space:\n' +
+			'  pnpm --filter @batuda/internal build\n',
+	)
+	process.exit(1)
+}
+
+console.log(`Worker bundle within budget — ${summary}`)


### PR DESCRIPTION
## What

Reading email in Batuda (`apps/internal`, the web app at batuda.co) was downloading the whole writing toolkit before showing a single message. The email editor — the box you type a message into — comes with an HTML renderer, a code formatter and a CSS builder attached, and all of it loaded whether or not you ever wrote anything. It now arrives only the first time you open a compose box or edit a signature.

That also unblocks the deploy. `internal-v2026.7.25` was tagged but never shipped: Cloudflare rejected it because the server-side bundle had grown past the 3 MiB limit on the current plan. The bundle is now well under it, so batuda.co can go out on the free plan with no upgrade.

## Changes

- The editor loads on demand instead of up front, following the same pattern `where-panel` and `schedule-grid` already use here: a `.client.tsx` file that the server build is not allowed to import, a `lazy()` boundary, and `<ClientOnly>` so nothing renders until the page is interactive.
- A size check in CI now fails any pull request that pushes the bundle past a budget of 2700 KiB compressed, measured the same way the real deploy measures it. The budget sits below the host's 3072 KiB limit so a PR fails with room to land a fix. July 25's rejected 3068 KiB would have been caught here.
- Fixed a crash in the editor that predates this work: typing logged an error on every keystroke and the finished HTML was never produced. The build config named its own module-resolution conditions, which *replaces* the built-in browser list rather than adding to it, so an entry added for an unrelated dependency had silently removed the one that tells the bundler to pick browser builds. `@react-email/render` was handed its server build and reached for a Node-only global.

## Impact

**Read speed — the main point.** Compressed sizes:

| | before | after |
|---|---|---|
| Server bundle (runs on every request) | 3068 KiB | **2386 KiB** |
| Editor on the read path | loaded eagerly | **deferred (565 KiB)** |

The 3 MiB ceiling is 3072 KiB, so this moves from ~4 KiB of headroom to ~685 KiB. Reads no longer download the editor or its stylesheet — I confirmed the production build references the chunk only through a dynamic `import()`, and that its CSS sits in Vite's preload dependency map rather than a static `<link>`, with no reference from the server bundle at all.

**No schema, API, auth, RLS or env changes.** No new environment variables, no migration, no wire-shape change, and nothing touching tenant scoping or the MCP/HTTP split. `packages/email` is unchanged — only who imports it and when.

**Deploy coupling:** none beyond re-cutting the `internal` tag. This does not need a coordinated server deploy.

## Review guide

Start with `apps/internal/vite.config.ts` — it is the one non-obvious change, and the failure it fixes was silent. The condition list there is load-bearing for three separate reasons now (tslib's ESM build, workspace packages resolving to source in dev, and browser builds), and the comments explain each; worth a read to check I haven't broken the first two, since a mistake there surfaces as a hydration mismatch rather than a build error.

`email-editor.tsx` and `email-editor.client.tsx` are a deliberate copy of the `where-panel` pattern — if you dislike that pattern, this is the moment to say so, since it is now used in three places.

Two things I want to flag rather than bury:

- The comment claims TanStack Start blocks `**/*.client.*` from the server build. That is a framework guarantee, not something this repo enforces. If it ever changes upstream, this file and `where-panel.tsx` become wrong silently, and the symptom is the server bundle quietly growing past the ceiling again — not a build failure.
- In the screenshots the white message canvas overhangs its container by a few pixels on the right. I noticed it but did not attribute it: this change alters *when* the editor loads, not how it renders, and I did not capture a before-shot to compare. Calling it out so it is not mistaken for something introduced here.

I also found that `fast-check` — a testing library — ships in the production bundle. It is a hard dependency of `effect` itself, statically imported by `Schema.ts`, so anything touching `effect/Schema` pulls it in. Removing it would mean stubbing a dependency, which I did not want to do speculatively now that there is plenty of headroom. Left alone deliberately.

## Screenshots

Compose box with the on-demand editor loaded and accepting text. Captured at both sizes because the compose surface is a panel on desktop and a full sheet on mobile.

**Desktop (1440×900)**

![pr-editor-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-326/pr-editor-desktop.webp)

**Mobile (iPhone 16 Pro)**

![pr-editor-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-326/pr-editor-mobile.webp)

## Verification

Gates run: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (21/21), `pnpm -w build` (13/13).

Against the live stack in a worktree, logged in as the seeded admin:

- Opened Compose, typed into the editor, and confirmed the text reached the database — `POST /v1/email/drafts` then `PATCH` per keystroke batch, and `body_json` read back as `[{"type":"paragraph","spans":[{"kind":"text","value":"Hola Pep"}]}]`.
- Browser console is clean; the `util.TextEncoder` error that fired on every keystroke is gone.
- Measured the bundle with `wrangler deploy --dry-run`, the same figure the failed deploy reported: 3068.55 KiB → 2385.95 KiB.
- Exercised all three of the new check's outcomes, not just the passing one: exit 0 at the current size, exit 1 with the budget forced below it, exit 2 on an unparseable `--budget`.

I confirmed the editor crash was pre-existing rather than assuming it: I reverted this branch's change in place and reproduced the identical error, then restored it.

Not verified: the signature editor on the inboxes page (`mode='footer'`). Reaching it needs a connected IMAP inbox, which the minimal seed does not create. It is the same component behind the same wrapper, so the risk is low, but I did not exercise it.

## Deferred

- An import rule keeping browser-only heavyweights (`@react-email/editor`, `@tiptap/*`, `@schedule-x/*`, `leaflet`) out of route modules. The lazy-loading convention now exists in three places but nothing enforces it, so the next heavy component added is a plain import again. The CI gate catches the consequence; a rule would prevent the cause.
- Removing `fast-check` from the production bundle, as described above.
