### PR TITLE
feat(internal): let anyone read an instruction template

### DIFF
--- a/apps/internal/src/components/companies/documents-panel.tsx
+++ b/apps/internal/src/components/companies/documents-panel.tsx
@@ -2,7 +2,7 @@ import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { DateTime } from 'effect'
+import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { FileText, Pencil, Plus, X } from 'lucide-react'
 import { type FormEvent, useMemo, useRef, useState } from 'react'
@@ -19,7 +19,19 @@ import {
 import { MarkdownView } from '#/components/markdown/markdown-view'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
+import { useDlg } from '#/lib/use-dlg'
 import { stenciledTitle } from '#/lib/workshop-mixins'
+
+// Prefixed because the company page this panel sits on carries one `?dlg=` for
+// all of its dialogs: two kinds sharing a name would leave the second
+// unreachable.
+export const documentsDlgMembers = [
+	dlgWithId('doc-view'),
+	dlgWithId('doc-edit'),
+	dlgNoId('doc-add'),
+] as const
+const documentsDlgSchema = Schema.Union(documentsDlgMembers)
 
 type DocRow = {
 	readonly id: string
@@ -85,7 +97,20 @@ export function DocumentsPanel({ companyId }: { readonly companyId: string }) {
 	const docs = AsyncResult.isSuccess(result)
 		? narrowDocs(result.value.items)
 		: []
-	const [dialog, setDialog] = useState<DialogState>({ mode: 'closed' })
+
+	const { dlg, open: openDlg, close: closeDlg } = useDlg(documentsDlgSchema)
+	// Only the id travels in the URL; the row is rebuilt from the loaded list, so
+	// a link reopens the same document, and one that has since gone leaves the
+	// dialog closed.
+	const dialog = useMemo<DialogState>(() => {
+		if (dlg === undefined) return { mode: 'closed' }
+		if (dlg.kind === 'doc-add') return { mode: 'add' }
+		const doc = docs.find(d => d.id === dlg.id)
+		if (doc === undefined) return { mode: 'closed' }
+		return dlg.kind === 'doc-view'
+			? { mode: 'view', doc }
+			: { mode: 'edit', doc }
+	}, [dlg, docs])
 
 	const typeLabel = (type: string) => {
 		const found = DOC_TYPES.find(dt => dt.value === type)
@@ -99,7 +124,7 @@ export function DocumentsPanel({ companyId }: { readonly companyId: string }) {
 					type='button'
 					$variant='outlined'
 					data-testid='company-add-document'
-					onClick={() => setDialog({ mode: 'add' })}
+					onClick={() => openDlg({ kind: 'doc-add' })}
 				>
 					<Plus size={14} aria-hidden />
 					<Trans>Add document</Trans>
@@ -117,7 +142,7 @@ export function DocumentsPanel({ companyId }: { readonly companyId: string }) {
 						<Row key={doc.id} data-testid={`document-row-${doc.id}`}>
 							<RowButton
 								type='button'
-								onClick={() => setDialog({ mode: 'view', doc })}
+								onClick={() => openDlg({ kind: 'doc-view', id: doc.id })}
 							>
 								<RowTitle>{doc.title ?? typeLabel(doc.type)}</RowTitle>
 								<RowMeta>
@@ -129,7 +154,7 @@ export function DocumentsPanel({ companyId }: { readonly companyId: string }) {
 								type='button'
 								aria-label={t`Edit document`}
 								data-testid={`document-edit-${doc.id}`}
-								onClick={() => setDialog({ mode: 'edit', doc })}
+								onClick={() => openDlg({ kind: 'doc-edit', id: doc.id })}
 							>
 								<Pencil size={14} aria-hidden />
 							</EditButton>
@@ -141,12 +166,16 @@ export function DocumentsPanel({ companyId }: { readonly companyId: string }) {
 			<DocumentDialog
 				state={dialog}
 				companyId={companyId}
-				onClose={() => setDialog({ mode: 'closed' })}
+				onClose={closeDlg}
 				onSaved={() => {
 					refresh()
-					setDialog({ mode: 'closed' })
+					closeDlg()
 				}}
-				onEdit={doc => setDialog({ mode: 'edit', doc })}
+				// Reading and editing the same document are one step, so Back leaves
+				// the document instead of returning to the read view.
+				onEdit={doc =>
+					openDlg({ kind: 'doc-edit', id: doc.id }, { replace: true })
+				}
 			/>
 		</>
 	)

--- a/apps/internal/src/components/companies/documents-panel.tsx
+++ b/apps/internal/src/components/companies/documents-panel.tsx
@@ -280,7 +280,12 @@ function DocumentDialog({
 
 					{state.mode === 'view' ? (
 						<>
-							<ViewBody data-testid='document-view'>
+							<ViewBody
+								data-testid='document-view'
+								role='region'
+								aria-label={t`Document`}
+								tabIndex={0}
+							>
 								<MarkdownView source={state.doc.content} />
 							</ViewBody>
 							<Footer>
@@ -473,10 +478,17 @@ const CloseButton = styled.button`
 	cursor: pointer;
 `
 
+// A document longer than the dialog scrolls here, and the region takes keyboard
+// focus so it can be read without a mouse.
 const ViewBody = styled.div`
 	margin-top: var(--space-sm);
 	max-height: 60vh;
 	overflow-y: auto;
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
 `
 
 const Form = styled.form`

--- a/apps/internal/src/components/companies/proposals-panel.tsx
+++ b/apps/internal/src/components/companies/proposals-panel.tsx
@@ -2,7 +2,7 @@ import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { DateTime } from 'effect'
+import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { FileSignature, Plus, X } from 'lucide-react'
 import { type FormEvent, useMemo, useRef, useState } from 'react'
@@ -18,8 +18,19 @@ import {
 
 import { RelativeDate } from '#/components/shared/relative-date'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
 import { formatMoneyCents } from '#/lib/format-money'
+import { useDlg } from '#/lib/use-dlg'
 import { stenciledTitle } from '#/lib/workshop-mixins'
+
+// Prefixed because the company page this panel sits on carries one `?dlg=` for
+// all of its dialogs. Only the id travels in the URL — a proposal holds nested
+// line items, which have no business in a query string.
+export const proposalsDlgMembers = [
+	dlgWithId('proposal-edit'),
+	dlgNoId('proposal-new'),
+] as const
+const proposalsDlgSchema = Schema.Union(proposalsDlgMembers)
 
 type ProposalRow = {
 	readonly id: string
@@ -160,7 +171,15 @@ export function ProposalsPanel({ companyId }: { readonly companyId: string }) {
 	const proposals = AsyncResult.isSuccess(result)
 		? narrowProposals(result.value.items)
 		: []
-	const [editing, setEditing] = useState<ProposalRow | 'new' | null>(null)
+
+	const { dlg, open: openDlg, close: closeDlg } = useDlg(proposalsDlgSchema)
+	// The dialog's target is rebuilt from the loaded list, so a link reopens the
+	// same proposal; one that has since gone leaves the dialog closed.
+	const editing = useMemo<ProposalRow | 'new' | null>(() => {
+		if (dlg === undefined) return null
+		if (dlg.kind === 'proposal-new') return 'new'
+		return proposals.find(p => p.id === dlg.id) ?? null
+	}, [dlg, proposals])
 
 	const statusLabel = (status: string) => {
 		const found = STATUSES.find(s => s.value === status)
@@ -174,7 +193,7 @@ export function ProposalsPanel({ companyId }: { readonly companyId: string }) {
 					type='button'
 					$variant='outlined'
 					data-testid='company-add-proposal'
-					onClick={() => setEditing('new')}
+					onClick={() => openDlg({ kind: 'proposal-new' })}
 				>
 					<Plus size={14} aria-hidden />
 					<Trans>New proposal</Trans>
@@ -193,7 +212,7 @@ export function ProposalsPanel({ companyId }: { readonly companyId: string }) {
 							key={p.id}
 							type='button'
 							data-testid={`proposal-row-${p.id}`}
-							onClick={() => setEditing(p)}
+							onClick={() => openDlg({ kind: 'proposal-edit', id: p.id })}
 						>
 							<RowMain>
 								<RowTitle>{p.title}</RowTitle>
@@ -215,10 +234,10 @@ export function ProposalsPanel({ companyId }: { readonly companyId: string }) {
 			<ProposalDialog
 				companyId={companyId}
 				target={editing}
-				onClose={() => setEditing(null)}
+				onClose={closeDlg}
 				onSaved={() => {
 					refresh()
-					setEditing(null)
+					closeDlg()
 				}}
 			/>
 		</>

--- a/apps/internal/src/components/instructions/instruction-chrome.tsx
+++ b/apps/internal/src/components/instructions/instruction-chrome.tsx
@@ -36,6 +36,12 @@ export const InstructionIconButton = styled.button`
 	justify-content: center;
 	width: 1.6rem;
 	height: 1.6rem;
+
+	/* Bigger tap target on touch, matching the dialog close controls. */
+	@media (pointer: coarse) {
+		width: 2.5rem;
+		height: 2.5rem;
+	}
 	padding: 0;
 	border: 1px solid color-mix(in oklab, var(--color-on-surface) 14%, transparent);
 	border-radius: var(--shape-2xs);

--- a/apps/internal/src/components/instructions/instruction-page-chrome.tsx
+++ b/apps/internal/src/components/instructions/instruction-page-chrome.tsx
@@ -119,6 +119,35 @@ export const TemplateName = styled.span`
 	white-space: nowrap;
 `
 
+// The name is what a reader reaches for, so it is the button that opens the
+// template rather than a small icon off to the side.
+export const TemplateNameButton = styled.button`
+	flex: 1 1 auto;
+	min-width: 0;
+	padding: var(--space-2xs) var(--space-3xs);
+	margin-inline-start: calc(var(--space-3xs) * -1);
+	background: none;
+	border: none;
+	border-radius: var(--shape-2xs);
+	text-align: left;
+	cursor: pointer;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	color: var(--color-on-surface);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	&:hover {
+		background: color-mix(in oklab, var(--color-primary) 6%, transparent);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
 export const RowActions = styled.div`
 	display: inline-flex;
 	gap: var(--space-2xs);

--- a/apps/internal/src/components/instructions/instruction-shapes.ts
+++ b/apps/internal/src/components/instructions/instruction-shapes.ts
@@ -8,6 +8,9 @@ export type TemplateShape = {
 	readonly name: string
 	readonly body: string
 	readonly ownerUserId: string | null
+	// When the guidance last changed — worth knowing for a template you follow
+	// but don't maintain.
+	readonly updatedAt: string | null
 }
 
 function str(r: Record<string, unknown>, key: string): string | null {
@@ -28,6 +31,7 @@ export function narrowTemplates(value: unknown): ReadonlyArray<TemplateShape> {
 			name,
 			body: str(r, 'body') ?? '',
 			ownerUserId: str(r, 'ownerUserId'),
+			updatedAt: str(r, 'updatedAt'),
 		})
 	}
 	return out

--- a/apps/internal/src/components/instructions/stack-editor.tsx
+++ b/apps/internal/src/components/instructions/stack-editor.tsx
@@ -31,6 +31,7 @@ export function StackEditor({
 	orgDefaultTemplateIds,
 	hasExistingDefault,
 	onDone,
+	onRead,
 }: {
 	readonly agent: string
 	readonly scope: 'org' | 'personal'
@@ -42,6 +43,9 @@ export function StackEditor({
 	// pre-ticks the default box so the common case needs no extra click.
 	readonly hasExistingDefault: boolean
 	readonly onDone: () => void
+	// Opening a template for reading from the picker; it layers over this editor
+	// rather than replacing it, so a half-written stack survives the detour.
+	readonly onRead?: ((id: string) => void) | undefined
 }) {
 	const { t } = useLingui()
 	const toast = usePriToast()
@@ -237,7 +241,12 @@ export function StackEditor({
 				</OrgBlock>
 			) : null}
 
-			<StackPicker options={options} selectedIds={ids} onChange={setIds} />
+			<StackPicker
+				options={options}
+				selectedIds={ids}
+				onChange={setIds}
+				onRead={onRead}
+			/>
 			{ids.length === 0 ? (
 				<Hint>
 					<Trans>Add at least one template before saving.</Trans>

--- a/apps/internal/src/components/instructions/stack-picker.tsx
+++ b/apps/internal/src/components/instructions/stack-picker.tsx
@@ -17,7 +17,7 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { useLingui } from '@lingui/react/macro'
 import { ClientOnly } from '@tanstack/react-router'
-import { GripVertical, Plus, X } from 'lucide-react'
+import { Eye, GripVertical, Plus, X } from 'lucide-react'
 import styled from 'styled-components'
 
 import { brushedMetalPlate } from '#/lib/workshop-mixins'
@@ -38,10 +38,14 @@ export function StackPicker({
 	options,
 	selectedIds,
 	onChange,
+	onRead,
 }: {
 	readonly options: ReadonlyArray<StackOption>
 	readonly selectedIds: ReadonlyArray<string>
 	readonly onChange: (ids: ReadonlyArray<string>) => void
+	// Choosing which guidance to group is the moment you most need to see what
+	// each one says, so a row can be opened for reading from right here.
+	readonly onRead?: ((id: string) => void) | undefined
 }) {
 	const { t } = useLingui()
 	const byId = new Map(options.map(o => [o.id, o]))
@@ -112,7 +116,11 @@ export function StackPicker({
 										name={o.name}
 										ownerLabel={ownerLabel(o)}
 										dragLabel={t`Drag ${o.name} to reorder`}
+										readLabel={t`Read ${o.name}`}
 										removeLabel={t`Remove ${o.name}`}
+										onRead={
+											onRead === undefined ? undefined : () => onRead(o.id)
+										}
 										onRemove={() => remove(o.id)}
 									/>
 								))}
@@ -152,7 +160,9 @@ function SortableRow({
 	name,
 	ownerLabel,
 	dragLabel,
+	readLabel,
 	removeLabel,
+	onRead,
 	onRemove,
 }: {
 	readonly id: string
@@ -160,7 +170,9 @@ function SortableRow({
 	readonly name: string
 	readonly ownerLabel: string
 	readonly dragLabel: string
+	readonly readLabel: string
 	readonly removeLabel: string
+	readonly onRead?: (() => void) | undefined
 	readonly onRemove: () => void
 }) {
 	const {
@@ -196,6 +208,16 @@ function SortableRow({
 			<Position aria-hidden>{position}</Position>
 			<RowName>{name}</RowName>
 			<RowBadge>{ownerLabel}</RowBadge>
+			{onRead === undefined ? null : (
+				<InstructionIconButton
+					type='button'
+					data-testid={`stack-read-${id}`}
+					aria-label={readLabel}
+					onClick={onRead}
+				>
+					<Eye size={14} aria-hidden />
+				</InstructionIconButton>
+			)}
 			<InstructionIconButton
 				type='button'
 				data-testid={`stack-remove-${id}`}

--- a/apps/internal/src/components/instructions/template-view-dialog.tsx
+++ b/apps/internal/src/components/instructions/template-view-dialog.tsx
@@ -1,10 +1,12 @@
 import { Trans, useLingui } from '@lingui/react/macro'
-import { X } from 'lucide-react'
+import { Copy, X } from 'lucide-react'
+import { useRef } from 'react'
 import styled from 'styled-components'
 
-import { PriButton, PriDialog } from '@batuda/ui/pri'
+import { PriButton, PriDialog, usePriToast } from '@batuda/ui/pri'
 
 import { MarkdownView } from '#/components/markdown/markdown-view'
+import { RelativeDate } from '#/components/shared/relative-date'
 import { stenciledTitle } from '#/lib/workshop-mixins'
 
 // Reading a template, shared by the personal and org template pages. The
@@ -15,7 +17,9 @@ export function TemplateViewDialog({
 	open,
 	name,
 	body,
+	updatedAt = null,
 	canEdit,
+	orgOwned = false,
 	onEdit,
 	onClose,
 	testId,
@@ -23,14 +27,38 @@ export function TemplateViewDialog({
 	readonly open: boolean
 	readonly name: string
 	readonly body: string
+	readonly updatedAt?: string | null
 	// The page decides: a template you own, or an org template you administer.
 	readonly canEdit: boolean
+	// Looked after by the organization rather than the reader, so the footer can
+	// say why there is no Edit button instead of leaving a bare Close.
+	readonly orgOwned?: boolean
 	readonly onEdit: () => void
 	readonly onClose: () => void
 	readonly testId: string
 }) {
 	const { t } = useLingui()
-	const hasBody = body.trim().length > 0
+	const toast = usePriToast()
+
+	// The dialog fades out over a moment, and by then the page has already let go
+	// of the row. Keep showing the last template so the title doesn't blank out
+	// while it is still on screen.
+	const lastShown = useRef({ name, body, updatedAt, canEdit, orgOwned })
+	if (open) lastShown.current = { name, body, updatedAt, canEdit, orgOwned }
+	const shown = open
+		? { name, body, updatedAt, canEdit, orgOwned }
+		: lastShown.current
+
+	const hasBody = shown.body.trim().length > 0
+
+	const copyBody = async () => {
+		try {
+			await navigator.clipboard.writeText(shown.body)
+			toast.add({ title: t`Instructions copied`, type: 'success' })
+		} catch {
+			toast.add({ title: t`Couldn't copy the instructions`, type: 'error' })
+		}
+	}
 
 	return (
 		<PriDialog.Root open={open} onOpenChange={next => !next && onClose()}>
@@ -38,9 +66,17 @@ export function TemplateViewDialog({
 				<PriDialog.Backdrop />
 				<PriDialog.Popup mobile='sheet' data-testid={testId}>
 					<Header>
-						<PriDialog.Title>
-							<Title>{name}</Title>
-						</PriDialog.Title>
+						<TitleBlock>
+							<PriDialog.Title>
+								<Title>{shown.name}</Title>
+							</PriDialog.Title>
+							{shown.updatedAt !== null ? (
+								<Meta>
+									<Trans>Last changed</Trans>{' '}
+									<RelativeDate value={shown.updatedAt} />
+								</Meta>
+							) : null}
+						</TitleBlock>
 						<PriDialog.Close
 							render={props => (
 								<CloseButton type='button' aria-label={t`Close`} {...props}>
@@ -60,7 +96,7 @@ export function TemplateViewDialog({
 						tabIndex={hasBody ? 0 : -1}
 					>
 						{hasBody ? (
-							<MarkdownView source={body} />
+							<MarkdownView source={shown.body} />
 						) : (
 							<EmptyBody>
 								<Trans>
@@ -71,8 +107,26 @@ export function TemplateViewDialog({
 						)}
 					</Body>
 
-					{canEdit ? (
-						<Footer>
+					<Footer>
+						{!shown.canEdit && shown.orgOwned ? (
+							<FooterNote data-testid={`${testId}-managed`}>
+								<Trans>Your organization looks after this one.</Trans>
+							</FooterNote>
+						) : null}
+						{hasBody ? (
+							<PriButton
+								type='button'
+								$variant='text'
+								data-testid={`${testId}-copy`}
+								onClick={() => {
+									void copyBody()
+								}}
+							>
+								<Copy size={14} aria-hidden />
+								<Trans>Copy</Trans>
+							</PriButton>
+						) : null}
+						{shown.canEdit ? (
 							<PriButton
 								type='button'
 								$variant='filled'
@@ -81,8 +135,8 @@ export function TemplateViewDialog({
 							>
 								<Trans>Edit</Trans>
 							</PriButton>
-						</Footer>
-					) : null}
+						) : null}
+					</Footer>
 				</PriDialog.Popup>
 			</PriDialog.Portal>
 		</PriDialog.Root>
@@ -96,10 +150,31 @@ const Header = styled.div`
 	gap: var(--space-sm);
 `
 
+const TitleBlock = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+	min-width: 0;
+`
+
 const Title = styled.span`
 	${stenciledTitle}
 	font-size: var(--typescale-title-large-size);
 	line-height: var(--typescale-title-large-line);
+`
+
+const Meta = styled.span`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const FooterNote = styled.span`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin-right: auto;
 `
 
 // Long guidance scrolls here rather than pushing the dialog off screen. The
@@ -157,11 +232,16 @@ const CloseButton = styled.button`
 
 const Footer = styled.div`
 	display: flex;
+	align-items: center;
 	gap: var(--space-sm);
 	justify-content: flex-end;
 	margin-top: var(--space-md);
 
 	@media (max-width: 40rem) {
+		flex-direction: column;
+		align-items: stretch;
+		gap: var(--space-2xs);
+
 		& > * {
 			width: 100%;
 		}

--- a/apps/internal/src/components/instructions/template-view-dialog.tsx
+++ b/apps/internal/src/components/instructions/template-view-dialog.tsx
@@ -1,0 +1,169 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { X } from 'lucide-react'
+import styled from 'styled-components'
+
+import { PriButton, PriDialog } from '@batuda/ui/pri'
+
+import { MarkdownView } from '#/components/markdown/markdown-view'
+import { stenciledTitle } from '#/lib/workshop-mixins'
+
+// Reading a template, shared by the personal and org template pages. The
+// standing guidance an agent follows on every run is worth reading even when
+// you are not the one who may change it, so anyone can open any template they
+// can see; changing one stays with its owner.
+export function TemplateViewDialog({
+	open,
+	name,
+	body,
+	canEdit,
+	onEdit,
+	onClose,
+	testId,
+}: {
+	readonly open: boolean
+	readonly name: string
+	readonly body: string
+	// The page decides: a template you own, or an org template you administer.
+	readonly canEdit: boolean
+	readonly onEdit: () => void
+	readonly onClose: () => void
+	readonly testId: string
+}) {
+	const { t } = useLingui()
+	const hasBody = body.trim().length > 0
+
+	return (
+		<PriDialog.Root open={open} onOpenChange={next => !next && onClose()}>
+			<PriDialog.Portal>
+				<PriDialog.Backdrop />
+				<PriDialog.Popup mobile='sheet' data-testid={testId}>
+					<Header>
+						<PriDialog.Title>
+							<Title>{name}</Title>
+						</PriDialog.Title>
+						<PriDialog.Close
+							render={props => (
+								<CloseButton type='button' aria-label={t`Close`} {...props}>
+									<X size={18} aria-hidden />
+								</CloseButton>
+							)}
+						/>
+					</Header>
+
+					{/* Long guidance scrolls on its own, so it has to be reachable by
+					    keyboard — otherwise anything past the first screenful can only
+					    be read with a mouse wheel. */}
+					<Body
+						data-testid={`${testId}-body`}
+						role='region'
+						aria-label={t`Instructions`}
+						tabIndex={hasBody ? 0 : -1}
+					>
+						{hasBody ? (
+							<MarkdownView source={body} />
+						) : (
+							<EmptyBody>
+								<Trans>
+									This template is empty, so it adds nothing to a run. Ask
+									whoever looks after it to fill it in.
+								</Trans>
+							</EmptyBody>
+						)}
+					</Body>
+
+					{canEdit ? (
+						<Footer>
+							<PriButton
+								type='button'
+								$variant='filled'
+								data-testid={`${testId}-edit`}
+								onClick={onEdit}
+							>
+								<Trans>Edit</Trans>
+							</PriButton>
+						</Footer>
+					) : null}
+				</PriDialog.Popup>
+			</PriDialog.Portal>
+		</PriDialog.Root>
+	)
+}
+
+const Header = styled.div`
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--space-sm);
+`
+
+const Title = styled.span`
+	${stenciledTitle}
+	font-size: var(--typescale-title-large-size);
+	line-height: var(--typescale-title-large-line);
+`
+
+// Long guidance scrolls here rather than pushing the dialog off screen. The
+// dialog already caps its own height, so this takes whatever room is left over
+// instead of setting a height of its own — two nested scrollbars otherwise.
+const Body = styled.div`
+	margin-top: var(--space-sm);
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+const EmptyBody = styled.p`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const CloseButton = styled.button`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
+	padding: 0;
+
+	/* Bigger tap target on touch, matching the editor dialog. */
+	@media (pointer: coarse) {
+		width: 2.75rem;
+		height: 2.75rem;
+	}
+	border: none;
+	border-radius: var(--shape-2xs);
+	background: transparent;
+	color: var(--color-on-surface-variant);
+	cursor: pointer;
+
+	&:hover {
+		background: color-mix(in oklab, var(--color-on-surface) 12%, transparent);
+		color: var(--color-on-surface);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+const Footer = styled.div`
+	display: flex;
+	gap: var(--space-sm);
+	justify-content: flex-end;
+	margin-top: var(--space-md);
+
+	@media (max-width: 40rem) {
+		& > * {
+			width: 100%;
+		}
+	}
+`

--- a/apps/internal/src/components/markdown/markdown-view.tsx
+++ b/apps/internal/src/components/markdown/markdown-view.tsx
@@ -1,10 +1,24 @@
 import { Streamdown } from 'streamdown'
 import styled from 'styled-components'
 
+// A heading someone writes inside stored prose belongs under the title of the
+// page or dialog around it, never above it, so every level renders a step lower
+// and the page keeps one sensible run of headings for anyone moving through it
+// by heading.
+const nestedHeadings = {
+	h1: (props: object) => <h3 {...props} />,
+	h2: (props: object) => <h4 {...props} />,
+	h3: (props: object) => <h5 {...props} />,
+	h4: (props: object) => <h6 {...props} />,
+	h5: (props: object) => <h6 {...props} />,
+	h6: (props: object) => <h6 {...props} />,
+}
+
 export function MarkdownView({ source }: { readonly source: string }) {
 	return (
 		<Wrapper>
 			<Streamdown
+				components={nestedHeadings}
 				urlTransform={url => {
 					const trimmed = url.trim()
 					if (/^(javascript|data|vbscript):/i.test(trimmed)) return ''
@@ -23,26 +37,30 @@ const Wrapper = styled.div.withConfig({ displayName: 'MarkdownView' })`
 	line-height: var(--typescale-body-medium-line);
 	color: var(--color-on-surface);
 
-	h1,
-	h2,
-	h3 {
+	/* Headings render a step lower (see nestedHeadings), so h3 is the largest one
+	   this prose ever reaches. */
+	h3,
+	h4,
+	h5,
+	h6 {
 		font-family: var(--font-display);
 		letter-spacing: 0.04em;
 		text-transform: uppercase;
 		margin: var(--space-md) 0 var(--space-sm);
 	}
 
-	h1 {
+	h3 {
 		font-size: var(--typescale-headline-medium-size);
 		line-height: var(--typescale-headline-medium-line);
 	}
 
-	h2 {
+	h4 {
 		font-size: var(--typescale-title-large-size);
 		line-height: var(--typescale-title-large-line);
 	}
 
-	h3 {
+	h5,
+	h6 {
 		font-size: var(--typescale-title-medium-size);
 		line-height: var(--typescale-title-medium-line);
 	}

--- a/apps/internal/src/lib/return-focus-to-page.ts
+++ b/apps/internal/src/lib/return-focus-to-page.ts
@@ -1,0 +1,32 @@
+const SETTLE_STEP_MS = 50
+const SETTLE_LIMIT_MS = 600
+
+/**
+ * Put keyboard focus back on the page after a dialog closes.
+ *
+ * A dialog hands focus back to whatever opened it, but one opened straight from
+ * the address bar had no opener, so focus is left on nothing: the next Tab
+ * starts again from the top of the app and a screen reader loses its place.
+ * Landing on the main region keeps the reader roughly where they were. A closing
+ * dialog holds focus until its fade-out finishes, so this watches for a short
+ * while rather than checking once, and never fires when the dialog hands focus
+ * back itself.
+ */
+export function returnFocusToPage(): void {
+	if (typeof document === 'undefined') return
+
+	let waited = 0
+	const check = () => {
+		if (document.activeElement === document.body) {
+			const main = document.querySelector('main')
+			if (main !== null) {
+				if (!main.hasAttribute('tabindex')) main.setAttribute('tabindex', '-1')
+				main.focus({ preventScroll: true })
+			}
+			return
+		}
+		waited += SETTLE_STEP_MS
+		if (waited < SETTLE_LIMIT_MS) setTimeout(check, SETTLE_STEP_MS)
+	}
+	setTimeout(check, SETTLE_STEP_MS)
+}

--- a/apps/internal/src/lib/tab-search.ts
+++ b/apps/internal/src/lib/tab-search.ts
@@ -26,10 +26,17 @@ export function useTabSearchParam<T extends string>(
 			: fallback
 
 	const navigate = useNavigate()
+	// Leaving a tab closes whatever dialog it was showing. A dialog belongs to the
+	// tab it opened from, and its panel stops rendering on the way out, so keeping
+	// the key would strand it in the address bar and spring it open again on the
+	// way back.
 	const setTab = useCallback(
 		(next: T) => {
 			void navigate({
-				search: (prev: Record<string, unknown>) => ({ ...prev, tab: next }),
+				search: ({ dlg: _drop, ...prev }: Record<string, unknown>) => ({
+					...prev,
+					tab: next,
+				}),
 			} as never)
 		},
 		[navigate],

--- a/apps/internal/src/lib/use-dlg.ts
+++ b/apps/internal/src/lib/use-dlg.ts
@@ -2,6 +2,8 @@ import { useLocation, useNavigate } from '@tanstack/react-router'
 import { Option, Schema } from 'effect'
 import { useCallback, useMemo } from 'react'
 
+import { returnFocusToPage } from './return-focus-to-page'
+
 /**
  * URL-addressable dialog state via the `?dlg=` search param, shared by every
  * route that opens a dialog (see `dlg-search.ts` for the struct vocabulary).
@@ -68,6 +70,7 @@ export function useDlg<S extends Schema.Top>(
 			replace: true,
 			resetScroll: false,
 		} as never)
+		returnFocusToPage()
 	}, [navigate])
 
 	return { dlg, open, close }

--- a/apps/internal/src/lib/use-dlg.ts
+++ b/apps/internal/src/lib/use-dlg.ts
@@ -16,12 +16,20 @@ import { useCallback, useMemo } from 'react'
  * the dialog; closing drops the key with `replace` so Back does not reopen it
  * and the URL goes clean. `dlg` is read from the live location because removing
  * the last search param can leave the route match's validated search stale.
+ *
+ * `open(next, { replace: true })` swaps the current entry instead of pushing.
+ * Use it when an open dialog moves from one row to the next: a keyboard walk
+ * down a list would otherwise leave a history entry per keystroke, so Back
+ * would retrace the walk instead of closing the dialog.
  */
 export function useDlg<S extends Schema.Top>(
 	schema: S,
 ): {
 	readonly dlg: S['Type'] | undefined
-	readonly open: (next: S['Type']) => void
+	readonly open: (
+		next: S['Type'],
+		options?: { readonly replace?: boolean },
+	) => void
 	readonly close: () => void
 } {
 	const rawDlg = useLocation({
@@ -41,10 +49,15 @@ export function useDlg<S extends Schema.Top>(
 	)
 
 	const navigate = useNavigate()
+	// Opening and closing a dialog leaves the page where it was. Without this the
+	// router treats each one as a fresh navigation and jumps to the top, so on a
+	// phone you would lose your place in the list every time.
 	const open = useCallback(
-		(next: S['Type']) => {
+		(next: S['Type'], options?: { readonly replace?: boolean }) => {
 			void navigate({
 				search: (prev: Record<string, unknown>) => ({ ...prev, dlg: next }),
+				resetScroll: false,
+				...(options?.replace === true ? { replace: true } : {}),
 			} as never)
 		},
 		[navigate],
@@ -53,6 +66,7 @@ export function useDlg<S extends Schema.Top>(
 		void navigate({
 			search: ({ dlg: _drop, ...rest }: Record<string, unknown>) => rest,
 			replace: true,
+			resetScroll: false,
 		} as never)
 	}, [navigate])
 

--- a/apps/internal/src/lib/use-read-param.ts
+++ b/apps/internal/src/lib/use-read-param.ts
@@ -1,0 +1,49 @@
+import { useLocation, useNavigate } from '@tanstack/react-router'
+import { useCallback } from 'react'
+
+import { returnFocusToPage } from './return-focus-to-page'
+
+/**
+ * The row a reader is looking at, held in `?read=<id>`.
+ *
+ * Reading sits apart from the `?dlg=` key on purpose: `dlg` says which editor
+ * is open and only one can be, so its values replace each other, while reading
+ * opens *over* any of them — above all over a half-written stack, where losing
+ * the draft to check what a template says would be the wrong trade.
+ *
+ * Opening pushes a history entry so Back stops reading; closing drops the key
+ * with `replace` so Back doesn't reopen it. Neither scrolls the page.
+ */
+export function useReadParam(): {
+	readonly readId: string | undefined
+	readonly openRead: (id: string) => void
+	readonly closeRead: () => void
+} {
+	const readId = useLocation({
+		select: l => {
+			const raw = (l.search as { readonly read?: unknown } | undefined)?.read
+			return typeof raw === 'string' && raw.length > 0 ? raw : undefined
+		},
+	})
+
+	const navigate = useNavigate()
+	const openRead = useCallback(
+		(id: string) => {
+			void navigate({
+				search: (prev: Record<string, unknown>) => ({ ...prev, read: id }),
+				resetScroll: false,
+			} as never)
+		},
+		[navigate],
+	)
+	const closeRead = useCallback(() => {
+		void navigate({
+			search: ({ read: _drop, ...rest }: Record<string, unknown>) => rest,
+			replace: true,
+			resetScroll: false,
+		} as never)
+		returnFocusToPage()
+	}, [navigate])
+
+	return { readId, openRead, closeRead }
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -1113,6 +1113,7 @@ msgstr "Copiada"
 msgid "Copied {label}"
 msgstr "S'ha copiat {label}"
 
+#: src/components/instructions/template-view-dialog.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Copy"
 msgstr "Copia"
@@ -1361,6 +1362,10 @@ msgstr "No s'ha pogut connectar"
 #: src/components/primitives/pri-copy-button.tsx
 msgid "Couldn't copy"
 msgstr "No s'ha pogut copiar"
+
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Couldn't copy the instructions"
+msgstr "No s'han pogut copiar les instruccions"
 
 #: src/routes/settings/organization/templates.tsx
 #: src/routes/settings/profile/templates.tsx
@@ -1679,6 +1684,7 @@ msgstr "Descarta"
 msgid "Display name"
 msgstr "Nom a mostrar"
 
+#: src/components/companies/documents-panel.tsx
 #: src/components/companies/documents-panel.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "Document"
@@ -2305,6 +2311,10 @@ msgstr "Plantilles d'instruccions"
 msgid "Instructions"
 msgstr "Instruccions"
 
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Instructions copied"
+msgstr "Instruccions copiades"
+
 #: src/components/research/research-dialog.tsx
 msgid "Instructions stack"
 msgstr "Pila d'instruccions"
@@ -2375,6 +2385,10 @@ msgstr "Última activitat"
 #: src/components/companies/cadence-card.tsx
 msgid "Last call"
 msgstr "Última trucada"
+
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Last changed"
+msgstr "Última modificació"
 
 #: src/components/shared/company-card.tsx
 #: src/routes/companies/$slug.tsx
@@ -3674,7 +3688,9 @@ msgstr "Torna a executar amb aquest domini"
 msgid "Re-running…"
 msgstr "Reexecutant…"
 
+#. placeholder {0}: o.name
 #. placeholder {0}: row.name
+#: src/components/instructions/stack-picker.tsx
 #: src/routes/settings/organization/templates.tsx
 #: src/routes/settings/organization/templates.tsx
 #: src/routes/settings/profile/templates.tsx
@@ -5201,6 +5217,10 @@ msgstr "La teva organització encara no té cap valor per defecte."
 #: src/routes/settings/profile/templates.tsx
 msgid "Your organization has no default yet. Make a stack your default to steer every run."
 msgstr "La teva organització encara no té cap predeterminada. Marca una pila com a predeterminada per guiar totes les execucions."
+
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Your organization looks after this one."
+msgstr "D'aquesta se n'ocupa la teva organització."
 
 #: src/routes/settings/organization/templates.tsx
 msgid "Your organization's admins manage these templates. You can read any of them, and use them in your own stacks or per run."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -869,6 +869,7 @@ msgstr "Client"
 #: src/components/contacts/contact-edit-dialog.tsx
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/template-editor-dialog.tsx
+#: src/components/instructions/template-view-dialog.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/research-dialog.tsx
 #: src/routes/calendar/index.tsx
@@ -1785,6 +1786,7 @@ msgstr "p. ex. vip, càlid"
 
 #: src/components/companies/account-brief-section.tsx
 #: src/components/companies/documents-panel.tsx
+#: src/components/instructions/template-view-dialog.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Edit"
@@ -2299,6 +2301,7 @@ msgstr "Plantilles d'instruccions"
 
 #: src/components/instructions/template-editor-dialog.tsx
 #: src/components/instructions/template-editor-dialog.tsx
+#: src/components/instructions/template-view-dialog.tsx
 msgid "Instructions"
 msgstr "Instruccions"
 
@@ -3671,6 +3674,13 @@ msgstr "Torna a executar amb aquest domini"
 msgid "Re-running…"
 msgstr "Reexecutant…"
 
+#. placeholder {0}: row.name
+#: src/routes/settings/organization/templates.tsx
+#: src/routes/settings/organization/templates.tsx
+#: src/routes/settings/profile/templates.tsx
+msgid "Read {0}"
+msgstr "Llegeix {0}"
+
 #: src/routes/emails/index.tsx
 msgid "Read state update failed"
 msgstr "Ha fallat l'actualització de l'estat de lectura"
@@ -4748,6 +4758,10 @@ msgstr "Això farà recerca sobre {0} empreses, fins a uns {1} en dades de pagam
 msgid "This stack no longer exists."
 msgstr "Aquesta pila ja no existeix."
 
+#: src/components/instructions/template-view-dialog.tsx
+msgid "This template is empty, so it adds nothing to a run. Ask whoever looks after it to fill it in."
+msgstr "Aquesta plantilla és buida, així que no aporta res a cap execució. Demana a qui se n'ocupa que l'ompli."
+
 #: src/components/research/findings/shared.tsx
 msgid "This tool isn't available, so it can only be skipped."
 msgstr "Aquesta eina no està disponible, així que només es pot ometre."
@@ -5189,8 +5203,8 @@ msgid "Your organization has no default yet. Make a stack your default to steer 
 msgstr "La teva organització encara no té cap predeterminada. Marca una pila com a predeterminada per guiar totes les execucions."
 
 #: src/routes/settings/organization/templates.tsx
-msgid "Your organization's admins manage these templates. You can use any of them in your own stacks or per run."
-msgstr "Els administradors de la teva organització gestionen aquestes plantilles. Pots fer servir-ne qualsevol en les teves piles o per execució."
+msgid "Your organization's admins manage these templates. You can read any of them, and use them in your own stacks or per run."
+msgstr "Els administradors de la teva organització gestionen aquestes plantilles. Pots llegir-ne qualsevol i fer-les servir en les teves piles o per execució."
 
 #: src/routes/settings/organization/members.tsx
 msgid "Your session has expired. Sign in again to continue."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -869,6 +869,7 @@ msgstr "Client"
 #: src/components/contacts/contact-edit-dialog.tsx
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/template-editor-dialog.tsx
+#: src/components/instructions/template-view-dialog.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/research-dialog.tsx
 #: src/routes/calendar/index.tsx
@@ -1785,6 +1786,7 @@ msgstr "e.g. vip, warm"
 
 #: src/components/companies/account-brief-section.tsx
 #: src/components/companies/documents-panel.tsx
+#: src/components/instructions/template-view-dialog.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Edit"
@@ -2299,6 +2301,7 @@ msgstr "Instruction templates"
 
 #: src/components/instructions/template-editor-dialog.tsx
 #: src/components/instructions/template-editor-dialog.tsx
+#: src/components/instructions/template-view-dialog.tsx
 msgid "Instructions"
 msgstr "Instructions"
 
@@ -3671,6 +3674,13 @@ msgstr "Re-run with this domain"
 msgid "Re-running…"
 msgstr "Re-running…"
 
+#. placeholder {0}: row.name
+#: src/routes/settings/organization/templates.tsx
+#: src/routes/settings/organization/templates.tsx
+#: src/routes/settings/profile/templates.tsx
+msgid "Read {0}"
+msgstr "Read {0}"
+
 #: src/routes/emails/index.tsx
 msgid "Read state update failed"
 msgstr "Read state update failed"
@@ -4748,6 +4758,10 @@ msgstr "This runs research on {0} companies, up to about {1} in paid data. Start
 msgid "This stack no longer exists."
 msgstr "This stack no longer exists."
 
+#: src/components/instructions/template-view-dialog.tsx
+msgid "This template is empty, so it adds nothing to a run. Ask whoever looks after it to fill it in."
+msgstr "This template is empty, so it adds nothing to a run. Ask whoever looks after it to fill it in."
+
 #: src/components/research/findings/shared.tsx
 msgid "This tool isn't available, so it can only be skipped."
 msgstr "This tool isn't available, so it can only be skipped."
@@ -5189,8 +5203,8 @@ msgid "Your organization has no default yet. Make a stack your default to steer 
 msgstr "Your organization has no default yet. Make a stack your default to steer every run."
 
 #: src/routes/settings/organization/templates.tsx
-msgid "Your organization's admins manage these templates. You can use any of them in your own stacks or per run."
-msgstr "Your organization's admins manage these templates. You can use any of them in your own stacks or per run."
+msgid "Your organization's admins manage these templates. You can read any of them, and use them in your own stacks or per run."
+msgstr "Your organization's admins manage these templates. You can read any of them, and use them in your own stacks or per run."
 
 #: src/routes/settings/organization/members.tsx
 msgid "Your session has expired. Sign in again to continue."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -1113,6 +1113,7 @@ msgstr "Copied"
 msgid "Copied {label}"
 msgstr "Copied {label}"
 
+#: src/components/instructions/template-view-dialog.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Copy"
 msgstr "Copy"
@@ -1361,6 +1362,10 @@ msgstr "Couldn't connect"
 #: src/components/primitives/pri-copy-button.tsx
 msgid "Couldn't copy"
 msgstr "Couldn't copy"
+
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Couldn't copy the instructions"
+msgstr "Couldn't copy the instructions"
 
 #: src/routes/settings/organization/templates.tsx
 #: src/routes/settings/profile/templates.tsx
@@ -1679,6 +1684,7 @@ msgstr "Dismiss"
 msgid "Display name"
 msgstr "Display name"
 
+#: src/components/companies/documents-panel.tsx
 #: src/components/companies/documents-panel.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "Document"
@@ -2305,6 +2311,10 @@ msgstr "Instruction templates"
 msgid "Instructions"
 msgstr "Instructions"
 
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Instructions copied"
+msgstr "Instructions copied"
+
 #: src/components/research/research-dialog.tsx
 msgid "Instructions stack"
 msgstr "Instructions stack"
@@ -2375,6 +2385,10 @@ msgstr "Last activity"
 #: src/components/companies/cadence-card.tsx
 msgid "Last call"
 msgstr "Last call"
+
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Last changed"
+msgstr "Last changed"
 
 #: src/components/shared/company-card.tsx
 #: src/routes/companies/$slug.tsx
@@ -3674,7 +3688,9 @@ msgstr "Re-run with this domain"
 msgid "Re-running…"
 msgstr "Re-running…"
 
+#. placeholder {0}: o.name
 #. placeholder {0}: row.name
+#: src/components/instructions/stack-picker.tsx
 #: src/routes/settings/organization/templates.tsx
 #: src/routes/settings/organization/templates.tsx
 #: src/routes/settings/profile/templates.tsx
@@ -5201,6 +5217,10 @@ msgstr "Your organization has no default yet."
 #: src/routes/settings/profile/templates.tsx
 msgid "Your organization has no default yet. Make a stack your default to steer every run."
 msgstr "Your organization has no default yet. Make a stack your default to steer every run."
+
+#: src/components/instructions/template-view-dialog.tsx
+msgid "Your organization looks after this one."
+msgstr "Your organization looks after this one."
 
 #: src/routes/settings/organization/templates.tsx
 msgid "Your organization's admins manage these templates. You can read any of them, and use them in your own stacks or per run."

--- a/apps/internal/src/routes/calendar/index.tsx
+++ b/apps/internal/src/routes/calendar/index.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { DateTime } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { CalendarPlus, Check, CircleHelp, X } from 'lucide-react'
-import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
+import { lazy, Suspense, useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
 import type { CalendarEvent, CalendarEventType, Company } from '@batuda/domain'
@@ -20,8 +20,11 @@ import { createTaskAtom } from '#/atoms/tasks-atoms'
 import { EmptyState } from '#/components/shared/empty-state'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { dehydrateAtom } from '#/lib/atom-hydration'
+import { dlgWithId } from '#/lib/dlg-search'
 import type { PaginatedList } from '#/lib/paginated-list'
+import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
+import { useDlg } from '#/lib/use-dlg'
 import {
 	agedPaperSurface,
 	brushedMetalPlate,
@@ -83,7 +86,12 @@ async function loadCalendarOnServer(): Promise<{
 	return Effect.runPromise(program)
 }
 
+// The open event lives in `?dlg=`, so a meeting can be linked to directly and
+// Back closes it instead of leaving the page.
+const calendarDlgSchema = dlgWithId('event')
+
 export const Route = createFileRoute('/calendar/')({
+	validateSearch: validateSearchWith({ dlg: calendarDlgSchema }),
 	loader: async () => {
 		if (!import.meta.env.SSR) {
 			return { dehydrated: [] as const }
@@ -130,11 +138,16 @@ function CalendarPage() {
 			.filter((c): c is CompanyLookup => c !== null)
 	}, [companiesResult])
 
-	const [selectedEventId, setSelectedEventId] = useState<string | null>(null)
+	const { dlg, open: openDlg, close: closeDlg } = useDlg(calendarDlgSchema)
 	const selectedEvent = useMemo(
-		() => events.find(e => e.id === selectedEventId) ?? null,
-		[events, selectedEventId],
+		() => (dlg ? (events.find(e => e.id === dlg.id) ?? null) : null),
+		[events, dlg],
 	)
+
+	// A link to an event the loaded range doesn't cover is left alone rather than
+	// cleared: this page holds a window around today, not every event, so a link
+	// to a meeting further out is good even when it can't be shown yet. Erasing
+	// it would destroy the address the reader was given.
 
 	const handleCreateFollowUp = useCallback(
 		(event: CalendarEventRow) => {
@@ -150,9 +163,9 @@ function CalendarPage() {
 					...companyIdProps,
 				},
 			})
-			setSelectedEventId(null)
+			closeDlg()
 		},
-		[createTask],
+		[createTask, closeDlg],
 	)
 
 	// Respond to an email-sourced or booking invitation in-place. The
@@ -201,7 +214,7 @@ function CalendarPage() {
 					>
 						<ScheduleGrid
 							events={events}
-							onEventClick={id => setSelectedEventId(id)}
+							onEventClick={id => openDlg({ kind: 'event', id })}
 						/>
 					</Suspense>
 				)}
@@ -215,7 +228,7 @@ function CalendarPage() {
 							? (companies.find(c => c.id === selectedEvent.companyId) ?? null)
 							: null
 					}
-					onClose={() => setSelectedEventId(null)}
+					onClose={closeDlg}
 					onCreateFollowUp={() => handleCreateFollowUp(selectedEvent)}
 					onRsvp={rsvp => handleRsvp(selectedEvent.id, rsvp)}
 					rsvpPending={rsvpPending}

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -72,11 +72,17 @@ import {
 } from '#/components/companies/company-fit-section'
 import { CompanyOwnerControl } from '#/components/companies/company-owner-control'
 import { ConversationsTab } from '#/components/companies/conversations-tab'
-import { DocumentsPanel } from '#/components/companies/documents-panel'
+import {
+	DocumentsPanel,
+	documentsDlgMembers,
+} from '#/components/companies/documents-panel'
 import { FollowupDialog } from '#/components/companies/followup-dialog'
 import { NextActionCard } from '#/components/companies/next-action-card'
 import { OpenTasksCard } from '#/components/companies/open-tasks-card'
-import { ProposalsPanel } from '#/components/companies/proposals-panel'
+import {
+	ProposalsPanel,
+	proposalsDlgMembers,
+} from '#/components/companies/proposals-panel'
 import { ResearchSummaryCard } from '#/components/companies/research-summary-card'
 import { UpcomingMeetingsCard } from '#/components/companies/upcoming-meetings-card'
 import { WherePanel } from '#/components/companies/where-panel'
@@ -120,7 +126,7 @@ import { useComposeEmail } from '#/context/compose-email-context'
 import { useQuickCapture } from '#/context/quick-capture-context'
 import { dehydrateAtom } from '#/lib/atom-hydration'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
-import { dlgNoId } from '#/lib/dlg-search'
+import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
 import type { PaginatedList } from '#/lib/paginated-list'
 import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
@@ -291,10 +297,23 @@ function extractCompanyName(raw: unknown): string | null {
 const COMPANY_TABS = ['overview', 'conversations', 'people', 'files'] as const
 type CompanyTab = (typeof COMPANY_TABS)[number]
 
-// The "Run research" dialog lives in `?dlg=research` so it is deep-linkable and
-// Back closes it. The company id comes from the route, so the dialog carries no
-// id of its own.
-const companyDlgSchema = dlgNoId('research')
+// A research run, a contact, a document and a proposal all open through the one
+// `?dlg=` param this page carries, so each kind is named for the thing it opens
+// — two sharing a name would leave the second silently unreachable. Research
+// needs no id, since the company comes from the route; the rest name a row that
+// the panel owning them looks up in its own loaded list.
+const contactDlgMembers = [
+	dlgNoId('contact-new'),
+	dlgWithId('contact-edit'),
+	dlgWithId('channels'),
+] as const
+
+const companyDlgSchema = Schema.Union([
+	dlgNoId('research'),
+	...contactDlgMembers,
+	...documentsDlgMembers,
+	...proposalsDlgMembers,
+])
 
 const validateSearch = validateSearchWith({
 	tab: Schema.Literals(COMPANY_TABS),
@@ -654,23 +673,44 @@ function DetailBody({
 				: [],
 		[researchResult],
 	)
-	const {
-		dlg: researchDlg,
-		open: openResearchDlg,
-		close: closeResearchDlg,
-	} = useDlg(companyDlgSchema)
-	const researchDialogOpen = researchDlg !== undefined
-	const [manageChannelsContactId, setManageChannelsContactId] = useState<
-		string | null
-	>(null)
+
+	// One `?dlg=` param serves every dialog on this page, so each one below asks
+	// for its own kind rather than for "something is open".
+	const { dlg, open: openDlg, close: closeDlg } = useDlg(companyDlgSchema)
+	const researchDialogOpen = dlg?.kind === 'research'
+
 	// Re-derived from the live list so the dialog reflects channel edits live.
 	const manageChannelsContact =
-		contacts.find(c => c.id === manageChannelsContactId) ?? null
-	// null contact = add; an EditableContact = edit. Closed when not open.
-	const [contactDialog, setContactDialog] = useState<{
-		readonly open: boolean
-		readonly contact: EditableContact | null
-	}>({ open: false, contact: null })
+		dlg?.kind === 'channels'
+			? (contacts.find(c => c.id === dlg.id) ?? null)
+			: null
+
+	// Adding a contact names no row; editing one rebuilds the editable fields
+	// from the loaded list, so a link reopens the same contact after a refresh.
+	const editingContactRow =
+		dlg?.kind === 'contact-edit'
+			? (contacts.find(c => c.id === dlg.id) ?? null)
+			: null
+	// Held steady while the dialog is open: the form seeds itself from this value,
+	// so handing it a fresh object on every render would wipe out whatever the
+	// user had typed each time one of this page's other lists finished loading.
+	const editingContactId = editingContactRow?.id ?? null
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the contact being edited, not the row object the list rebuilds on every refresh
+	const editingContact: EditableContact | null = useMemo(
+		() =>
+			editingContactRow !== null
+				? {
+						id: editingContactRow.id,
+						name: editingContactRow.name,
+						role: editingContactRow.role,
+						isDecisionMaker: editingContactRow.isDecisionMaker,
+					}
+				: null,
+		[editingContactId],
+	)
+	const contactDialogOpen =
+		dlg?.kind === 'contact-new' || editingContact !== null
+
 	type PageEntry = {
 		readonly id: string
 		readonly title: string
@@ -1231,7 +1271,7 @@ function DetailBody({
 									<ResearchSummaryCard
 										runs={researchRuns}
 										lastEnrichedAt={company.lastEnrichedAt}
-										onRunNew={() => openResearchDlg({ kind: 'research' })}
+										onRunNew={() => openDlg({ kind: 'research' })}
 									/>
 									<WherePanel company={company} compact />
 									<AccountBriefSection
@@ -1256,7 +1296,7 @@ function DetailBody({
 								type='button'
 								$variant='outlined'
 								data-testid='company-add-contact'
-								onClick={() => setContactDialog({ open: true, contact: null })}
+								onClick={() => openDlg({ kind: 'contact-new' })}
 							>
 								<Plus size={14} aria-hidden />
 								<Trans>Add contact</Trans>
@@ -1414,15 +1454,7 @@ function DetailBody({
 												type='button'
 												data-testid={`contact-edit-${contact.id}`}
 												onClick={() =>
-													setContactDialog({
-														open: true,
-														contact: {
-															id: contact.id,
-															name: contact.name,
-															role: contact.role,
-															isDecisionMaker: contact.isDecisionMaker,
-														},
-													})
+													openDlg({ kind: 'contact-edit', id: contact.id })
 												}
 											>
 												<Pencil size={14} aria-hidden />
@@ -1432,7 +1464,9 @@ function DetailBody({
 											</ContactLinkButton>
 											<ContactLinkButton
 												type='button'
-												onClick={() => setManageChannelsContactId(contact.id)}
+												onClick={() =>
+													openDlg({ kind: 'channels', id: contact.id })
+												}
 											>
 												<Settings2 size={14} aria-hidden />
 												<span>
@@ -1541,7 +1575,7 @@ function DetailBody({
 			<ResearchDialog
 				open={researchDialogOpen}
 				onOpenChange={next => {
-					if (!next) closeResearchDlg()
+					if (!next) closeDlg()
 				}}
 				companyId={company.id}
 				onCreated={() => {
@@ -1552,15 +1586,15 @@ function DetailBody({
 				contactId={manageChannelsContact?.id ?? null}
 				contactName={manageChannelsContact?.name ?? ''}
 				channels={manageChannelsContact?.channels ?? []}
-				onClose={() => setManageChannelsContactId(null)}
+				onClose={closeDlg}
 				onChanged={refreshContacts}
 			/>
 
 			<ContactEditDialog
-				open={contactDialog.open}
+				open={contactDialogOpen}
 				companyId={company.id}
-				contact={contactDialog.contact}
-				onClose={() => setContactDialog({ open: false, contact: null })}
+				contact={editingContact}
+				onClose={closeDlg}
 				onSaved={refreshContacts}
 			/>
 

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -58,13 +58,13 @@ import { authClient } from '#/lib/auth-client'
 import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
 import { validateSearchWith } from '#/lib/search-schema'
 import { useDlg } from '#/lib/use-dlg'
+import { useReadParam } from '#/lib/use-read-param'
 
 // As on the personal templates page, the dialogs live in `?dlg=` so they are
-// deep-linkable and Back closes them. `view` is the only one a regular member
-// reaches; the rest belong to the admin half of the page, which is the only
-// place that offers them.
+// deep-linkable and Back closes them. Every one of them belongs to the admin
+// half of the page; a regular member only reads, which carries its own `?read=`
+// key.
 const orgTemplatesDlgSchema = Schema.Union([
-	dlgWithId('view'),
 	dlgNoId('create'),
 	dlgWithId('edit'),
 	dlgNoId('new-stack'),
@@ -72,7 +72,10 @@ const orgTemplatesDlgSchema = Schema.Union([
 ])
 
 export const Route = createFileRoute('/settings/organization/templates')({
-	validateSearch: validateSearchWith({ dlg: orgTemplatesDlgSchema }),
+	validateSearch: validateSearchWith({
+		dlg: orgTemplatesDlgSchema,
+		read: Schema.NonEmptyString,
+	}),
 	head: () => ({ meta: [{ title: 'Org instruction templates — Batuda' }] }),
 	component: OrgTemplatesPage,
 })
@@ -101,10 +104,10 @@ function OrgTemplatesPage() {
 	// member get the same dialog — an admin opens it from the row they manage, a
 	// regular member from the list they can only read.
 	const { dlg, open: openDlg, close: closeDlg } = useDlg(orgTemplatesDlgSchema)
-	const openView = (row: TemplateShape) => openDlg({ kind: 'view', id: row.id })
+	const { readId, openRead, closeRead } = useReadParam()
 	const viewingRow =
-		dlg?.kind === 'view'
-			? (orgTemplates.find(row => row.id === dlg.id) ?? null)
+		readId !== undefined
+			? (orgTemplates.find(row => row.id === readId) ?? null)
 			: null
 
 	// Settle the link once the list has loaded. A template that is gone drops its
@@ -116,14 +119,35 @@ function OrgTemplatesPage() {
 		dlg?.kind === 'edit'
 			? (orgTemplates.find(row => row.id === dlg.id) ?? null)
 			: null
+	// A regular member never renders the admin half, so one of its links would
+	// otherwise sit in the address bar opening nothing, with no way to clear it.
+	const adminOnlyDialog =
+		dlg?.kind === 'create' || dlg?.kind === 'new-stack' || dlg?.kind === 'stack'
 	useEffect(() => {
+		if (!isAdmin && adminOnlyDialog) {
+			closeDlg()
+			return
+		}
 		if (!templatesLoaded) return
-		if (dlg?.kind === 'view' && viewingRow === null) closeDlg()
+		if (readId !== undefined && viewingRow === null) closeRead()
 		if (dlg?.kind !== 'edit') return
 		if (editTarget === null) closeDlg()
-		else if (!isAdmin)
-			openDlg({ kind: 'view', id: editTarget.id }, { replace: true })
-	}, [dlg, templatesLoaded, viewingRow, editTarget, isAdmin, openDlg, closeDlg])
+		else if (!isAdmin) {
+			closeDlg()
+			openRead(editTarget.id)
+		}
+	}, [
+		dlg,
+		templatesLoaded,
+		readId,
+		viewingRow,
+		editTarget,
+		isAdmin,
+		adminOnlyDialog,
+		openRead,
+		closeRead,
+		closeDlg,
+	])
 
 	return (
 		<Page>
@@ -151,7 +175,7 @@ function OrgTemplatesPage() {
 				<OrgTemplateAdmin
 					orgTemplates={orgTemplates}
 					refreshTemplates={refreshTemplates}
-					onView={openView}
+					onRead={openRead}
 				/>
 			) : (
 				<>
@@ -170,7 +194,7 @@ function OrgTemplatesPage() {
 											type='button'
 											aria-label={t`Read ${row.name}`}
 											data-testid={`org-template-view-${row.id}`}
-											onClick={() => openView(row)}
+											onClick={() => openRead(row.id)}
 										>
 											{row.name}
 										</TemplateNameButton>
@@ -194,15 +218,18 @@ function OrgTemplatesPage() {
 				open={viewingRow !== null}
 				name={viewingRow?.name ?? ''}
 				body={viewingRow?.body ?? ''}
+				updatedAt={viewingRow?.updatedAt ?? null}
 				canEdit={isAdmin}
+				orgOwned
 				// Stepping from reading to editing swaps one dialog for the other, so
 				// Back leaves the template rather than dropping you back into reading
 				// what you just finished editing.
 				onEdit={() => {
-					if (viewingRow !== null)
-						openDlg({ kind: 'edit', id: viewingRow.id }, { replace: true })
+					if (viewingRow === null) return
+					closeRead()
+					openDlg({ kind: 'edit', id: viewingRow.id })
 				}}
-				onClose={closeDlg}
+				onClose={closeRead}
 				testId='org-template-view-dialog'
 			/>
 		</Page>
@@ -273,12 +300,12 @@ function OrgStacksViewer() {
 function OrgTemplateAdmin({
 	orgTemplates,
 	refreshTemplates,
-	onView,
+	onRead,
 }: {
 	readonly orgTemplates: ReadonlyArray<TemplateShape>
 	readonly refreshTemplates: () => void
 	// Reading is owned by the page above so both member and admin share one dialog.
-	readonly onView: (row: TemplateShape) => void
+	readonly onRead: (id: string) => void
 }) {
 	const { t } = useLingui()
 	const toast = usePriToast()
@@ -473,7 +500,7 @@ function OrgTemplateAdmin({
 									type='button'
 									aria-label={t`Read ${row.name}`}
 									data-testid={`org-template-view-${row.id}`}
-									onClick={() => onView(row)}
+									onClick={() => onRead(row.id)}
 								>
 									{row.name}
 								</TemplateNameButton>
@@ -559,6 +586,7 @@ function OrgTemplateAdmin({
 								orgDefaultTemplateIds={[]}
 								hasExistingDefault={hasOrgDefault}
 								onDone={stackSaved}
+								onRead={onRead}
 							/>
 						) : (
 							<Actions>

--- a/apps/internal/src/routes/settings/organization/templates.tsx
+++ b/apps/internal/src/routes/settings/organization/templates.tsx
@@ -1,9 +1,10 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute } from '@tanstack/react-router'
+import { Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { ArrowLeft, Pencil, Plus, ScrollText, Trash2 } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import type { Agent } from '@batuda/instructions/domain'
@@ -33,7 +34,7 @@ import {
 	SectionTitle,
 	Subtitle,
 	TemplateList,
-	TemplateName,
+	TemplateNameButton,
 	TemplateRowItem,
 } from '#/components/instructions/instruction-page-chrome'
 import {
@@ -51,15 +52,33 @@ import {
 	type TemplateDraft,
 	TemplateEditorDialog,
 } from '#/components/instructions/template-editor-dialog'
+import { TemplateViewDialog } from '#/components/instructions/template-view-dialog'
 import { ErrorState } from '#/components/shared/error-state'
 import { authClient } from '#/lib/auth-client'
+import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
+import { validateSearchWith } from '#/lib/search-schema'
+import { useDlg } from '#/lib/use-dlg'
+
+// As on the personal templates page, the dialogs live in `?dlg=` so they are
+// deep-linkable and Back closes them. `view` is the only one a regular member
+// reaches; the rest belong to the admin half of the page, which is the only
+// place that offers them.
+const orgTemplatesDlgSchema = Schema.Union([
+	dlgWithId('view'),
+	dlgNoId('create'),
+	dlgWithId('edit'),
+	dlgNoId('new-stack'),
+	dlgWithId('stack'),
+])
 
 export const Route = createFileRoute('/settings/organization/templates')({
+	validateSearch: validateSearchWith({ dlg: orgTemplatesDlgSchema }),
 	head: () => ({ meta: [{ title: 'Org instruction templates — Batuda' }] }),
 	component: OrgTemplatesPage,
 })
 
 function OrgTemplatesPage() {
+	const { t } = useLingui()
 	const activeMember = authClient.useActiveMember()
 	const role = activeMember.data?.role ?? null
 	const isAdmin = role === 'owner' || role === 'admin'
@@ -77,6 +96,34 @@ function OrgTemplatesPage() {
 				: [],
 		[templatesResult],
 	)
+
+	// Reading is handled here rather than in the admin half so both kinds of
+	// member get the same dialog — an admin opens it from the row they manage, a
+	// regular member from the list they can only read.
+	const { dlg, open: openDlg, close: closeDlg } = useDlg(orgTemplatesDlgSchema)
+	const openView = (row: TemplateShape) => openDlg({ kind: 'view', id: row.id })
+	const viewingRow =
+		dlg?.kind === 'view'
+			? (orgTemplates.find(row => row.id === dlg.id) ?? null)
+			: null
+
+	// Settle the link once the list has loaded. A template that is gone drops its
+	// link rather than leaving an empty dialog open. An edit link handed to
+	// someone who may only read falls back to reading, so a shared address shows
+	// them the template instead of nothing at all.
+	const templatesLoaded = AsyncResult.isSuccess(templatesResult)
+	const editTarget =
+		dlg?.kind === 'edit'
+			? (orgTemplates.find(row => row.id === dlg.id) ?? null)
+			: null
+	useEffect(() => {
+		if (!templatesLoaded) return
+		if (dlg?.kind === 'view' && viewingRow === null) closeDlg()
+		if (dlg?.kind !== 'edit') return
+		if (editTarget === null) closeDlg()
+		else if (!isAdmin)
+			openDlg({ kind: 'view', id: editTarget.id }, { replace: true })
+	}, [dlg, templatesLoaded, viewingRow, editTarget, isAdmin, openDlg, closeDlg])
 
 	return (
 		<Page>
@@ -104,21 +151,29 @@ function OrgTemplatesPage() {
 				<OrgTemplateAdmin
 					orgTemplates={orgTemplates}
 					refreshTemplates={refreshTemplates}
+					onView={openView}
 				/>
 			) : (
 				<>
 					<Section>
 						<Hint role='note'>
 							<Trans>
-								Your organization's admins manage these templates. You can use
-								any of them in your own stacks or per run.
+								Your organization's admins manage these templates. You can read
+								any of them, and use them in your own stacks or per run.
 							</Trans>
 						</Hint>
 						{orgTemplates.length > 0 ? (
 							<TemplateList>
 								{orgTemplates.map(row => (
 									<TemplateRowItem key={row.id} data-testid='org-template-row'>
-										<TemplateName>{row.name}</TemplateName>
+										<TemplateNameButton
+											type='button'
+											aria-label={t`Read ${row.name}`}
+											data-testid={`org-template-view-${row.id}`}
+											onClick={() => openView(row)}
+										>
+											{row.name}
+										</TemplateNameButton>
 										<OwnerBadge>
 											<Trans>Org</Trans>
 										</OwnerBadge>
@@ -134,6 +189,22 @@ function OrgTemplatesPage() {
 					<OrgStacksViewer />
 				</>
 			)}
+
+			<TemplateViewDialog
+				open={viewingRow !== null}
+				name={viewingRow?.name ?? ''}
+				body={viewingRow?.body ?? ''}
+				canEdit={isAdmin}
+				// Stepping from reading to editing swaps one dialog for the other, so
+				// Back leaves the template rather than dropping you back into reading
+				// what you just finished editing.
+				onEdit={() => {
+					if (viewingRow !== null)
+						openDlg({ kind: 'edit', id: viewingRow.id }, { replace: true })
+				}}
+				onClose={closeDlg}
+				testId='org-template-view-dialog'
+			/>
 		</Page>
 	)
 }
@@ -202,9 +273,12 @@ function OrgStacksViewer() {
 function OrgTemplateAdmin({
 	orgTemplates,
 	refreshTemplates,
+	onView,
 }: {
 	readonly orgTemplates: ReadonlyArray<TemplateShape>
 	readonly refreshTemplates: () => void
+	// Reading is owned by the page above so both member and admin share one dialog.
+	readonly onView: (row: TemplateShape) => void
 }) {
 	const { t } = useLingui()
 	const toast = usePriToast()
@@ -241,36 +315,65 @@ function OrgTemplateAdmin({
 		[orgTemplates],
 	)
 
-	const [dialogOpen, setDialogOpen] = useState(false)
-	const [editing, setEditing] = useState<TemplateDraft | null>(null)
+	// The confirmations stay local: they are a passing step in something the user
+	// is already doing, not a place worth linking someone to.
 	const [confirmTarget, setConfirmTarget] = useState<{
 		readonly id: string
 		readonly name: string
 	} | null>(null)
 	const [deleting, setDeleting] = useState(false)
-	// Local master-detail: null = closed, or a create/edit target for the editor.
-	const [stackEditing, setStackEditing] = useState<
-		| { readonly mode: 'new' }
-		| { readonly mode: 'edit'; readonly stack: StackShape }
-		| null
-	>(null)
 	const [confirmStack, setConfirmStack] = useState<StackShape | null>(null)
 	const [deletingStack, setDeletingStack] = useState(false)
 
-	// Switching surface drops any open editor for the previous surface.
+	const { dlg, open: openDlg, close: closeDlg } = useDlg(orgTemplatesDlgSchema)
+
+	// Both editors resolve their target from the loaded list, so a link to an
+	// open row reopens the right one after a refresh.
+	const editingRow =
+		dlg?.kind === 'edit'
+			? (orgTemplates.find(row => row.id === dlg.id) ?? null)
+			: null
+	// Held steady while the editor is open. The editor resets its unsaved-changes
+	// guard and any error message whenever this value changes, so rebuilding it
+	// on every render would quietly drop a draft and hide failed saves.
+	const editingId = editingRow?.id ?? null
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the template being edited, not the row object the list rebuilds on every refresh
+	const editing: TemplateDraft | null = useMemo(
+		() =>
+			editingRow
+				? { id: editingRow.id, name: editingRow.name, body: editingRow.body }
+				: null,
+		[editingId],
+	)
+	const dialogOpen =
+		dlg?.kind === 'create' || (dlg?.kind === 'edit' && editingRow !== null)
+
+	const editingStack =
+		dlg?.kind === 'stack'
+			? (orgStacks.find(s => s.id === dlg.id) ?? null)
+			: null
+	const stackEditorOpen =
+		dlg?.kind === 'new-stack' ||
+		(dlg?.kind === 'stack' && editingStack !== null)
+
+	// A link to a stack that is gone — deleted, or belonging to another surface —
+	// drops itself once the list has loaded. Templates are handled by the page
+	// above, which is the half that knows whether they arrived.
+	const stacksLoaded = AsyncResult.isSuccess(stacksResult)
+	useEffect(() => {
+		if (dlg?.kind === 'stack' && stacksLoaded && editingStack === null) {
+			closeDlg()
+		}
+	}, [dlg, stacksLoaded, editingStack, closeDlg])
+
+	// Switching surface drops any open stack editor for the previous surface.
 	const selectAgent = (next: Agent) => {
 		setAgent(next)
-		setStackEditing(null)
+		if (dlg?.kind === 'new-stack' || dlg?.kind === 'stack') closeDlg()
 	}
 
-	const openCreate = () => {
-		setEditing(null)
-		setDialogOpen(true)
-	}
-	const openEdit = (row: TemplateShape) => {
-		setEditing({ id: row.id, name: row.name, body: row.body })
-		setDialogOpen(true)
-	}
+	const openCreate = () => openDlg({ kind: 'create' })
+	const openEdit = (row: TemplateShape) => openDlg({ kind: 'edit', id: row.id })
 
 	const confirmDelete = async () => {
 		const target = confirmTarget
@@ -336,7 +439,7 @@ function OrgTemplateAdmin({
 	}
 
 	const stackSaved = () => {
-		setStackEditing(null)
+		closeDlg()
 		refreshStacks()
 	}
 
@@ -366,7 +469,14 @@ function OrgTemplateAdmin({
 					<TemplateList>
 						{orgTemplates.map(row => (
 							<TemplateRowItem key={row.id} data-testid='org-template-row'>
-								<TemplateName>{row.name}</TemplateName>
+								<TemplateNameButton
+									type='button'
+									aria-label={t`Read ${row.name}`}
+									data-testid={`org-template-view-${row.id}`}
+									onClick={() => onView(row)}
+								>
+									{row.name}
+								</TemplateNameButton>
 								<OwnerBadge>
 									<Trans>Org</Trans>
 								</OwnerBadge>
@@ -428,7 +538,7 @@ function OrgTemplateAdmin({
 						{orgStacks.length > 0 ? (
 							<StackList
 								stacks={orgStacks}
-								onEdit={s => setStackEditing({ mode: 'edit', stack: s })}
+								onEdit={s => openDlg({ kind: 'stack', id: s.id })}
 								onSetDefault={s => {
 									void setDefault(s)
 								}}
@@ -440,11 +550,11 @@ function OrgTemplateAdmin({
 							</Empty>
 						)}
 
-						{stackEditing !== null ? (
+						{stackEditorOpen ? (
 							<StackEditor
 								agent={agent}
 								scope='org'
-								stack={stackEditing.mode === 'edit' ? stackEditing.stack : null}
+								stack={editingStack}
 								options={stackOptions}
 								orgDefaultTemplateIds={[]}
 								hasExistingDefault={hasOrgDefault}
@@ -456,7 +566,7 @@ function OrgTemplateAdmin({
 									type='button'
 									$variant='filled'
 									data-testid='org-stack-new'
-									onClick={() => setStackEditing({ mode: 'new' })}
+									onClick={() => openDlg({ kind: 'new-stack' })}
 								>
 									<Plus size={16} aria-hidden />
 									<Trans>New org template stack</Trans>
@@ -469,7 +579,9 @@ function OrgTemplateAdmin({
 
 			<TemplateEditorDialog
 				open={dialogOpen}
-				onOpenChange={setDialogOpen}
+				onOpenChange={next => {
+					if (!next) closeDlg()
+				}}
 				editing={editing}
 				scope='org'
 				onSaved={() => {

--- a/apps/internal/src/routes/settings/profile/templates.tsx
+++ b/apps/internal/src/routes/settings/profile/templates.tsx
@@ -36,7 +36,7 @@ import {
 	SectionTitle,
 	Subtitle,
 	TemplateList,
-	TemplateName,
+	TemplateNameButton,
 	TemplateRowItem,
 } from '#/components/instructions/instruction-page-chrome'
 import {
@@ -55,6 +55,7 @@ import {
 	type TemplateDraft,
 	TemplateEditorDialog,
 } from '#/components/instructions/template-editor-dialog'
+import { TemplateViewDialog } from '#/components/instructions/template-view-dialog'
 import { ErrorState } from '#/components/shared/error-state'
 import { authClient } from '#/lib/auth-client'
 import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
@@ -62,10 +63,11 @@ import { validateSearchWith } from '#/lib/search-schema'
 import { useDlg } from '#/lib/use-dlg'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
-// The create/edit surfaces live in the `?dlg=` param so they are deep-linkable
-// and the browser Back button closes them — `create`/`new-stack` open on their
-// own, `edit`/`stack` target a row by id.
+// The view/create/edit surfaces live in the `?dlg=` param so they are
+// deep-linkable and the browser Back button closes them — `create`/`new-stack`
+// open on their own, `view`/`edit`/`stack` target a row by id.
 const templatesDlgSchema = Schema.Union([
+	dlgWithId('view'),
 	dlgNoId('create'),
 	dlgWithId('edit'),
 	dlgNoId('new-stack'),
@@ -162,17 +164,39 @@ function TemplatesPage() {
 	const [confirmStack, setConfirmStack] = useState<StackShape | null>(null)
 	const [deletingStack, setDeletingStack] = useState(false)
 
-	// The edit dialog resolves its target from the loaded list, so a deep link
-	// (?dlg=edit&id=…) reopens the right template on refresh.
+	// The edit dialog resolves its target from the loaded list, so a link to an
+	// open template reopens the right one on refresh. The list also carries the
+	// organization's templates, which this page can only read — an edit link
+	// naming one is turned into a read below rather than opening an editor whose
+	// Save could never work.
 	const editingRow =
 		dlg?.kind === 'edit'
-			? (templates.find(row => row.id === dlg.id) ?? null)
+			? (templates.find(
+					row =>
+						row.id === dlg.id &&
+						row.ownerUserId !== null &&
+						row.ownerUserId === myUserId,
+				) ?? null)
 			: null
-	const editing: TemplateDraft | null = editingRow
-		? { id: editingRow.id, name: editingRow.name, body: editingRow.body }
-		: null
+	// Held steady while the editor is open. The editor resets its unsaved-changes
+	// guard and any error message whenever this value changes, so rebuilding it
+	// on every render would quietly drop a draft and hide failed saves.
+	const editingId = editingRow?.id ?? null
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the template being edited, not the row object the list rebuilds on every refresh
+	const editing: TemplateDraft | null = useMemo(
+		() =>
+			editingRow
+				? { id: editingRow.id, name: editingRow.name, body: editingRow.body }
+				: null,
+		[editingId],
+	)
 	const dialogOpen =
 		dlg?.kind === 'create' || (dlg?.kind === 'edit' && editingRow !== null)
+
+	const viewingRow =
+		dlg?.kind === 'view'
+			? (templates.find(row => row.id === dlg.id) ?? null)
+			: null
 
 	// The stack editor mounts for a create (`new-stack`) or an edit (`stack`)
 	// whose target is loaded. Resolving from the loaded list keeps a deep link
@@ -185,19 +209,43 @@ function TemplatesPage() {
 		dlg?.kind === 'new-stack' ||
 		(dlg?.kind === 'stack' && editingStack !== null)
 
-	// A deep link to a row that no longer exists drops itself once the list loads.
+	// A link to a row that is gone drops itself once the list loads. An edit link
+	// naming a template this page can't change becomes a read of it, so a shared
+	// address still shows the template.
 	const templatesLoaded = AsyncResult.isSuccess(templatesResult)
 	const stacksLoaded = AsyncResult.isSuccess(stacksResult)
+	const readableInstead =
+		dlg?.kind === 'edit' && editingRow === null
+			? (templates.find(row => row.id === dlg.id) ?? null)
+			: null
 	useEffect(() => {
 		if (dlg?.kind === 'edit' && templatesLoaded && editingRow === null) {
+			if (readableInstead !== null) {
+				openDlg({ kind: 'view', id: readableInstead.id }, { replace: true })
+			} else {
+				closeDlg()
+			}
+		}
+		if (dlg?.kind === 'view' && templatesLoaded && viewingRow === null) {
 			closeDlg()
 		}
 		if (dlg?.kind === 'stack' && stacksLoaded && editingStack === null) {
 			closeDlg()
 		}
-	}, [dlg, templatesLoaded, editingRow, stacksLoaded, editingStack, closeDlg])
+	}, [
+		dlg,
+		templatesLoaded,
+		editingRow,
+		readableInstead,
+		viewingRow,
+		stacksLoaded,
+		editingStack,
+		openDlg,
+		closeDlg,
+	])
 
 	const openCreate = () => openDlg({ kind: 'create' })
+	const openView = (row: TemplateShape) => openDlg({ kind: 'view', id: row.id })
 	const openEdit = (row: TemplateShape) => openDlg({ kind: 'edit', id: row.id })
 	const openNewStack = () => openDlg({ kind: 'new-stack' })
 	const openEditStack = (s: StackShape) => openDlg({ kind: 'stack', id: s.id })
@@ -360,7 +408,16 @@ function TemplatesPage() {
 								row.ownerUserId !== null && row.ownerUserId === myUserId
 							return (
 								<TemplateRowItem key={row.id} data-testid='template-row'>
-									<TemplateName>{row.name}</TemplateName>
+									{/* Any template on this page can be read, the org's as well
+									    as your own; only its owner can change it. */}
+									<TemplateNameButton
+										type='button'
+										aria-label={t`Read ${row.name}`}
+										data-testid={`template-view-${row.id}`}
+										onClick={() => openView(row)}
+									>
+										{row.name}
+									</TemplateNameButton>
 									<OwnerBadge>
 										{row.ownerUserId === null ? (
 											<Trans>Org</Trans>
@@ -368,26 +425,28 @@ function TemplatesPage() {
 											<Trans>Mine</Trans>
 										)}
 									</OwnerBadge>
-									{mine ? (
-										<RowActions>
-											<InstructionIconButton
-												type='button'
-												aria-label={t`Edit ${row.name}`}
-												onClick={() => openEdit(row)}
-											>
-												<Pencil size={14} aria-hidden />
-											</InstructionIconButton>
-											<InstructionIconButton
-												type='button'
-												aria-label={t`Delete ${row.name}`}
-												onClick={() =>
-													setConfirmTarget({ id: row.id, name: row.name })
-												}
-											>
-												<Trash2 size={14} aria-hidden />
-											</InstructionIconButton>
-										</RowActions>
-									) : null}
+									<RowActions>
+										{mine ? (
+											<>
+												<InstructionIconButton
+													type='button'
+													aria-label={t`Edit ${row.name}`}
+													onClick={() => openEdit(row)}
+												>
+													<Pencil size={14} aria-hidden />
+												</InstructionIconButton>
+												<InstructionIconButton
+													type='button'
+													aria-label={t`Delete ${row.name}`}
+													onClick={() =>
+														setConfirmTarget({ id: row.id, name: row.name })
+													}
+												>
+													<Trash2 size={14} aria-hidden />
+												</InstructionIconButton>
+											</>
+										) : null}
+									</RowActions>
 								</TemplateRowItem>
 							)
 						})}
@@ -505,6 +564,26 @@ function TemplatesPage() {
 					</>
 				)}
 			</Section>
+
+			<TemplateViewDialog
+				open={viewingRow !== null}
+				name={viewingRow?.name ?? ''}
+				body={viewingRow?.body ?? ''}
+				canEdit={
+					viewingRow !== null &&
+					viewingRow.ownerUserId !== null &&
+					viewingRow.ownerUserId === myUserId
+				}
+				// Stepping from reading to editing swaps one dialog for the other, so
+				// Back leaves the template rather than dropping you back into reading
+				// what you just finished editing.
+				onEdit={() => {
+					if (viewingRow !== null)
+						openDlg({ kind: 'edit', id: viewingRow.id }, { replace: true })
+				}}
+				onClose={closeDlg}
+				testId='template-view-dialog'
+			/>
 
 			<TemplateEditorDialog
 				open={dialogOpen}

--- a/apps/internal/src/routes/settings/profile/templates.tsx
+++ b/apps/internal/src/routes/settings/profile/templates.tsx
@@ -61,13 +61,14 @@ import { authClient } from '#/lib/auth-client'
 import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
 import { validateSearchWith } from '#/lib/search-schema'
 import { useDlg } from '#/lib/use-dlg'
+import { useReadParam } from '#/lib/use-read-param'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
-// The view/create/edit surfaces live in the `?dlg=` param so they are
-// deep-linkable and the browser Back button closes them — `create`/`new-stack`
-// open on their own, `view`/`edit`/`stack` target a row by id.
+// The writing surfaces live in the `?dlg=` param so they are deep-linkable and
+// the browser Back button closes them — `create`/`new-stack` open on their own,
+// `edit`/`stack` target a row by id. Reading carries its own `?read=` key so it
+// can open over any of them.
 const templatesDlgSchema = Schema.Union([
-	dlgWithId('view'),
 	dlgNoId('create'),
 	dlgWithId('edit'),
 	dlgNoId('new-stack'),
@@ -75,7 +76,10 @@ const templatesDlgSchema = Schema.Union([
 ])
 
 export const Route = createFileRoute('/settings/profile/templates')({
-	validateSearch: validateSearchWith({ dlg: templatesDlgSchema }),
+	validateSearch: validateSearchWith({
+		dlg: templatesDlgSchema,
+		read: Schema.NonEmptyString,
+	}),
 	head: () => ({ meta: [{ title: 'Instruction templates — Batuda' }] }),
 	component: TemplatesPage,
 })
@@ -156,6 +160,7 @@ function TemplatesPage() {
 	)
 
 	const { dlg, open: openDlg, close: closeDlg } = useDlg(templatesDlgSchema)
+	const { readId, openRead, closeRead } = useReadParam()
 	const [confirmTarget, setConfirmTarget] = useState<{
 		readonly id: string
 		readonly name: string
@@ -194,8 +199,8 @@ function TemplatesPage() {
 		dlg?.kind === 'create' || (dlg?.kind === 'edit' && editingRow !== null)
 
 	const viewingRow =
-		dlg?.kind === 'view'
-			? (templates.find(row => row.id === dlg.id) ?? null)
+		readId !== undefined
+			? (templates.find(row => row.id === readId) ?? null)
 			: null
 
 	// The stack editor mounts for a create (`new-stack`) or an edit (`stack`)
@@ -220,14 +225,11 @@ function TemplatesPage() {
 			: null
 	useEffect(() => {
 		if (dlg?.kind === 'edit' && templatesLoaded && editingRow === null) {
-			if (readableInstead !== null) {
-				openDlg({ kind: 'view', id: readableInstead.id }, { replace: true })
-			} else {
-				closeDlg()
-			}
-		}
-		if (dlg?.kind === 'view' && templatesLoaded && viewingRow === null) {
 			closeDlg()
+			if (readableInstead !== null) openRead(readableInstead.id)
+		}
+		if (readId !== undefined && templatesLoaded && viewingRow === null) {
+			closeRead()
 		}
 		if (dlg?.kind === 'stack' && stacksLoaded && editingStack === null) {
 			closeDlg()
@@ -237,15 +239,16 @@ function TemplatesPage() {
 		templatesLoaded,
 		editingRow,
 		readableInstead,
+		readId,
 		viewingRow,
 		stacksLoaded,
 		editingStack,
-		openDlg,
+		openRead,
+		closeRead,
 		closeDlg,
 	])
 
 	const openCreate = () => openDlg({ kind: 'create' })
-	const openView = (row: TemplateShape) => openDlg({ kind: 'view', id: row.id })
 	const openEdit = (row: TemplateShape) => openDlg({ kind: 'edit', id: row.id })
 	const openNewStack = () => openDlg({ kind: 'new-stack' })
 	const openEditStack = (s: StackShape) => openDlg({ kind: 'stack', id: s.id })
@@ -414,7 +417,7 @@ function TemplatesPage() {
 										type='button'
 										aria-label={t`Read ${row.name}`}
 										data-testid={`template-view-${row.id}`}
-										onClick={() => openView(row)}
+										onClick={() => openRead(row.id)}
 									>
 										{row.name}
 									</TemplateNameButton>
@@ -547,6 +550,7 @@ function TemplatesPage() {
 								orgDefaultTemplateIds={orgDefaultTemplateIds}
 								hasExistingDefault={hasPersonalDefault}
 								onDone={stackSaved}
+								onRead={openRead}
 							/>
 						) : (
 							<Actions>
@@ -569,19 +573,22 @@ function TemplatesPage() {
 				open={viewingRow !== null}
 				name={viewingRow?.name ?? ''}
 				body={viewingRow?.body ?? ''}
+				updatedAt={viewingRow?.updatedAt ?? null}
 				canEdit={
 					viewingRow !== null &&
 					viewingRow.ownerUserId !== null &&
 					viewingRow.ownerUserId === myUserId
 				}
+				orgOwned={viewingRow?.ownerUserId === null}
 				// Stepping from reading to editing swaps one dialog for the other, so
 				// Back leaves the template rather than dropping you back into reading
 				// what you just finished editing.
 				onEdit={() => {
-					if (viewingRow !== null)
-						openDlg({ kind: 'edit', id: viewingRow.id }, { replace: true })
+					if (viewingRow === null) return
+					closeRead()
+					openDlg({ kind: 'edit', id: viewingRow.id })
 				}}
-				onClose={closeDlg}
+				onClose={closeRead}
 				testId='template-view-dialog'
 			/>
 

--- a/apps/internal/src/routes/tasks/index.tsx
+++ b/apps/internal/src/routes/tasks/index.tsx
@@ -114,6 +114,10 @@ const tasksDlgSchema = Schema.Union([
 	dlgNoId('recent-changes'),
 ])
 
+// How long the address waits behind a keyboard walk before it names the task
+// the pane is on.
+const ADDRESS_CATCH_UP_MS = 200
+
 export const Route = createFileRoute('/tasks/')({
 	validateSearch: validateSearchWith({ dlg: tasksDlgSchema }),
 	loader: async () => {
@@ -160,18 +164,56 @@ function TasksPage() {
 
 	const [selectedView, setSelectedView] = useState<SmartView>('today')
 	const { dlg, open: openDlg, close: closeDlg } = useDlg(tasksDlgSchema)
-	const selectedTaskId = dlg?.kind === 'task' ? dlg.id : null
 	const undoOpen = dlg?.kind === 'recent-changes'
-	// Opening a task is a step the reader can take back. Walking the open pane
-	// down the list with j/k is not — one entry per keystroke would turn Back
-	// into an undo of every key pressed, so those moves overwrite instead.
+
+	// While j/k are moving the open pane down the list, the task under the cursor
+	// is held here and the address catches up once the keys stop. Holding a key
+	// repeats it dozens of times a second, and browsers cap how often a page may
+	// rewrite its address — so a long press would otherwise be refused outright.
+	const [movingToId, setMovingToId] = useState<string | null>(null)
+	const moveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const selectedTaskId = movingToId ?? (dlg?.kind === 'task' ? dlg.id : null)
+
+	// Opening a task is a step the reader can take back. Moving the pane between
+	// rows is not — one entry per keystroke would turn Back into an undo of every
+	// key pressed, so those moves overwrite instead.
 	const openTask = useCallback(
 		(id: string) => openDlg({ kind: 'task', id }),
 		[openDlg],
 	)
 	const moveTaskSelection = useCallback(
-		(id: string) => openDlg({ kind: 'task', id }, { replace: true }),
+		(id: string) => {
+			setMovingToId(id)
+			if (moveTimer.current !== null) clearTimeout(moveTimer.current)
+			moveTimer.current = setTimeout(() => {
+				moveTimer.current = null
+				openDlg({ kind: 'task', id }, { replace: true })
+			}, ADDRESS_CATCH_UP_MS)
+		},
 		[openDlg],
+	)
+	// Closing the pane also drops any move still waiting to be written, so a key
+	// pressed a moment earlier can't bring the pane back after it has gone.
+	const closeTaskPane = useCallback(() => {
+		if (moveTimer.current !== null) {
+			clearTimeout(moveTimer.current)
+			moveTimer.current = null
+		}
+		setMovingToId(null)
+		closeDlg()
+	}, [closeDlg])
+	// Once the address names the same task, drop the held one so the address is
+	// the single answer again.
+	useEffect(() => {
+		if (movingToId !== null && dlg?.kind === 'task' && dlg.id === movingToId) {
+			setMovingToId(null)
+		}
+	}, [dlg, movingToId])
+	useEffect(
+		() => () => {
+			if (moveTimer.current !== null) clearTimeout(moveTimer.current)
+		},
+		[],
 	)
 	const quickAddRef = useRef<HTMLInputElement | null>(null)
 
@@ -266,13 +308,13 @@ function TasksPage() {
 				// the list, and there is nothing left to do with a task you just ticked
 				// off. Finished tasks stay readable for a week, so it will not close
 				// itself.
-				if (taskId === selectedTaskId) closeDlg()
+				if (taskId === selectedTaskId) closeTaskPane()
 			} else {
 				await reopenTask({ params: { id: taskId } } as never)
 			}
 			refreshAll()
 		},
-		[completeTask, reopenTask, refreshAll, selectedTaskId, closeDlg],
+		[completeTask, reopenTask, refreshAll, selectedTaskId, closeTaskPane],
 	)
 
 	const handleCancel = useCallback(
@@ -621,7 +663,7 @@ function TasksPage() {
 							? (companiesById.get(selectedTask.companyId) ?? null)
 							: null
 					}
-					onClose={closeDlg}
+					onClose={closeTaskPane}
 					onSnooze={() => void handleSnooze(selectedTask.id)}
 					onCancel={() => void handleCancel(selectedTask.id)}
 					onToggle={next => void handleToggle(selectedTask.id, next)}

--- a/apps/internal/src/routes/tasks/index.tsx
+++ b/apps/internal/src/routes/tasks/index.tsx
@@ -1,7 +1,7 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute } from '@tanstack/react-router'
-import { DateTime } from 'effect'
+import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { Clock, History, Plus } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -34,8 +34,11 @@ import {
 import { useQuickCapture } from '#/context/quick-capture-context'
 import { dehydrateAtom } from '#/lib/atom-hydration'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
 import type { PaginatedList } from '#/lib/paginated-list'
+import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
+import { useDlg } from '#/lib/use-dlg'
 import {
 	agedPaperSurface,
 	brushedMetalPlate,
@@ -104,7 +107,15 @@ async function loadTasksOnServer(): Promise<{
 	return Effect.runPromise(program)
 }
 
+// The open task and the recent-changes list live in `?dlg=`, so a task can be
+// linked to and Back steps out of it.
+const tasksDlgSchema = Schema.Union([
+	dlgWithId('task'),
+	dlgNoId('recent-changes'),
+])
+
 export const Route = createFileRoute('/tasks/')({
+	validateSearch: validateSearchWith({ dlg: tasksDlgSchema }),
 	loader: async () => {
 		if (!import.meta.env.SSR) {
 			return { dehydrated: [] as const }
@@ -148,8 +159,20 @@ function TasksPage() {
 	const { open: openQuickCapture } = useQuickCapture()
 
 	const [selectedView, setSelectedView] = useState<SmartView>('today')
-	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
-	const [undoOpen, setUndoOpen] = useState(false)
+	const { dlg, open: openDlg, close: closeDlg } = useDlg(tasksDlgSchema)
+	const selectedTaskId = dlg?.kind === 'task' ? dlg.id : null
+	const undoOpen = dlg?.kind === 'recent-changes'
+	// Opening a task is a step the reader can take back. Walking the open pane
+	// down the list with j/k is not — one entry per keystroke would turn Back
+	// into an undo of every key pressed, so those moves overwrite instead.
+	const openTask = useCallback(
+		(id: string) => openDlg({ kind: 'task', id }),
+		[openDlg],
+	)
+	const moveTaskSelection = useCallback(
+		(id: string) => openDlg({ kind: 'task', id }, { replace: true }),
+		[openDlg],
+	)
 	const quickAddRef = useRef<HTMLInputElement | null>(null)
 
 	const openTasks = useMemo<ReadonlyArray<TaskRow>>(
@@ -239,12 +262,17 @@ function TasksPage() {
 		async (taskId: string, nextCompleted: boolean) => {
 			if (nextCompleted) {
 				await completeTask({ params: { id: taskId } } as never)
+				// Finishing the task you have open closes it: the detail pane covers
+				// the list, and there is nothing left to do with a task you just ticked
+				// off. Finished tasks stay readable for a week, so it will not close
+				// itself.
+				if (taskId === selectedTaskId) closeDlg()
 			} else {
 				await reopenTask({ params: { id: taskId } } as never)
 			}
 			refreshAll()
 		},
-		[completeTask, reopenTask, refreshAll],
+		[completeTask, reopenTask, refreshAll, selectedTaskId, closeDlg],
 	)
 
 	const handleCancel = useCallback(
@@ -390,14 +418,14 @@ function TasksPage() {
 				ev.preventDefault()
 				const nextIdx = Math.min(visibleTasks.length - 1, currentIdx + 1)
 				const next = visibleTasks[nextIdx]
-				if (next) setSelectedTaskId(next.id)
+				if (next) moveTaskSelection(next.id)
 				return
 			}
 			if (ev.key === 'k') {
 				ev.preventDefault()
 				const prevIdx = Math.max(0, currentIdx - 1)
 				const prev = visibleTasks[prevIdx]
-				if (prev) setSelectedTaskId(prev.id)
+				if (prev) moveTaskSelection(prev.id)
 				return
 			}
 			if (ev.key === 'x' && selectedTaskId !== null) {
@@ -413,7 +441,14 @@ function TasksPage() {
 		}
 		document.addEventListener('keydown', onKey)
 		return () => document.removeEventListener('keydown', onKey)
-	}, [gPrimed, visibleTasks, selectedTaskId, handleToggle, handleSnooze])
+	}, [
+		gPrimed,
+		visibleTasks,
+		selectedTaskId,
+		handleToggle,
+		handleSnooze,
+		moveTaskSelection,
+	])
 
 	const isLoading =
 		AsyncResult.isInitial(tasksResult) || AsyncResult.isInitial(companiesResult)
@@ -426,10 +461,14 @@ function TasksPage() {
 		)
 	}
 
+	// A link may name a task the current view doesn't show — a snoozed or
+	// already-finished one — so the other lists are searched before giving up.
 	const selectedTask =
 		selectedTaskId !== null
 			? (visibleTasks.find(r => r.id === selectedTaskId) ??
 				openTasks.find(r => r.id === selectedTaskId) ??
+				snoozedTasks.find(r => r.id === selectedTaskId) ??
+				doneTasks.find(r => r.id === selectedTaskId) ??
 				null)
 			: null
 
@@ -521,7 +560,7 @@ function TasksPage() {
 					<RailButton
 						$active={false}
 						type='button'
-						onClick={() => setUndoOpen(true)}
+						onClick={() => openDlg({ kind: 'recent-changes' })}
 						data-testid='tasks-recent-changes-open'
 					>
 						<History size={12} aria-hidden />
@@ -564,7 +603,7 @@ function TasksPage() {
 										onToggle={next => void handleToggle(task.id, next)}
 										onEditTitle={next => handleEditTitle(task.id, next)}
 										onEditDue={next => handleReschedule(task.id, next)}
-										onOpenDetail={() => setSelectedTaskId(task.id)}
+										onOpenDetail={() => openTask(task.id)}
 										{...logInteractionProps}
 									/>
 								)
@@ -582,7 +621,7 @@ function TasksPage() {
 							? (companiesById.get(selectedTask.companyId) ?? null)
 							: null
 					}
-					onClose={() => setSelectedTaskId(null)}
+					onClose={closeDlg}
 					onSnooze={() => void handleSnooze(selectedTask.id)}
 					onCancel={() => void handleCancel(selectedTask.id)}
 					onToggle={next => void handleToggle(selectedTask.id, next)}
@@ -591,7 +630,10 @@ function TasksPage() {
 
 			<UndoDialog
 				open={undoOpen}
-				onOpenChange={setUndoOpen}
+				onOpenChange={next => {
+					if (next) openDlg({ kind: 'recent-changes' })
+					else closeDlg()
+				}}
 				tasks={openTasks}
 			/>
 		</Page>

--- a/apps/internal/tests/e2e/instruction-stacks.test.ts
+++ b/apps/internal/tests/e2e/instruction-stacks.test.ts
@@ -51,6 +51,17 @@ test.describe('instruction stacks', () => {
 			// only once a row is on screen — otherwise the baseline reads zero.
 			await expect(page.getByTestId('stack-row').first()).toBeVisible()
 			const stacksBefore = await page.getByTestId('stack-row').count()
+			// Remember which stack currently holds the default so it can be put back
+			// afterwards — the default is a single seat, and the first test in this
+			// file expects the seeded stack to still hold it.
+			const defaultBefore =
+				(await page
+					.getByTestId('stack-row')
+					.filter({ hasText: 'Default' })
+					.first()
+					.locator('span')
+					.first()
+					.textContent()) ?? ''
 
 			// GIVEN the stack editor is open
 			await page.getByTestId('new-stack').click()
@@ -74,6 +85,14 @@ test.describe('instruction stacks', () => {
 			await page.getByLabel(`Make ${name} the default`).click()
 			await expect(created).toContainText('Default')
 			await expect(page.getByLabel(`Make ${name} the default`)).toHaveCount(0)
+
+			// Hand the default back and remove what this test made, so running the
+			// file twice in a row still starts from the seeded arrangement.
+			await page.getByLabel(`Make ${defaultBefore.trim()} the default`).click()
+			await expect(created).not.toContainText('Default')
+			await created.getByLabel(`Delete ${name}`).click()
+			await page.getByTestId('stack-delete-confirm-button').click()
+			await expect(page.getByTestId('stack-row')).toHaveCount(stacksBefore)
 		})
 
 		test('should keep the save disabled until a name and a template are picked', async ({

--- a/apps/internal/tests/e2e/instruction-template-reading.test.ts
+++ b/apps/internal/tests/e2e/instruction-template-reading.test.ts
@@ -2,20 +2,23 @@ import { expect, test } from '@playwright/test'
 
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
-// Reading an instruction template, and the `?dlg=` addressing that carries it.
+// Reading an instruction template, and the `?read=` address that carries it.
 // Standing guidance steers every agent run, so a member can read any template
 // the list returns — the organization's as well as their own — while editing
-// stays with the owner. The dialog lives in the URL, so it survives a refresh
-// and Back steps out of it.
+// stays with the owner. Reading has its own key rather than sharing `?dlg=`
+// with the editors, so it can open over a half-written stack without
+// discarding it.
 // Selectors verified against:
 //   apps/internal/src/routes/settings/profile/templates.tsx
-//     (template-row, template-view-{id})
+//     (template-row, template-view-{id}, new-stack)
 //   apps/internal/src/routes/settings/organization/templates.tsx
 //     (org-template-row, org-template-view-{id}, org-template-view-dialog)
 //   apps/internal/src/components/instructions/template-view-dialog.tsx
 //     (template-view-dialog, -body, -edit)
 //   apps/internal/src/components/instructions/template-editor-dialog.tsx
 //     (template-editor-dialog, template-editor-name)
+//   apps/internal/src/components/instructions/stack-picker.tsx (stack-read-{id})
+//   apps/internal/src/components/instructions/stack-editor.tsx (stack-name)
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/', { waitUntil: 'commit' })
@@ -114,7 +117,7 @@ test.describe('reading an instruction template', () => {
 
 			// GIVEN the address of the open template
 			const shared = page.url()
-			expect(decodeURIComponent(shared)).toContain('"kind":"view"')
+			expect(shared).toContain('read=')
 
 			// WHEN that address is loaded fresh
 			await page.goto(shared, { waitUntil: 'networkidle' })
@@ -130,7 +133,7 @@ test.describe('reading an instruction template', () => {
 
 			// THEN the dialog closes and the address is clean again
 			await expect(page.getByTestId('template-view-dialog')).toBeHidden()
-			expect(page.url()).not.toContain('dlg=')
+			expect(page.url()).not.toContain('read=')
 		})
 	})
 
@@ -138,18 +141,11 @@ test.describe('reading an instruction template', () => {
 		test('should settle on the list rather than an empty dialog', async ({
 			page,
 		}) => {
-			// GIVEN a link to a template id that is not in the organization
-			const missing = encodeURIComponent(
-				JSON.stringify({
-					kind: 'view',
-					id: '00000000-0000-4000-8000-000000000000',
-				}),
+			// WHEN a link to a template id that is not in the organization is opened
+			await page.goto(
+				'/settings/profile/templates?read=00000000-0000-4000-8000-000000000000',
+				{ waitUntil: 'networkidle' },
 			)
-
-			// WHEN it is opened
-			await page.goto(`/settings/profile/templates?dlg=${missing}`, {
-				waitUntil: 'networkidle',
-			})
 
 			// THEN the page drops the dead link and shows the list
 			await expect(page.getByTestId('template-row').first()).toBeVisible()
@@ -188,7 +184,44 @@ test.describe('reading an instruction template', () => {
 			// THEN the template opens for reading, with no editor to save from
 			await expect(page.getByTestId('template-view-dialog')).toBeVisible()
 			await expect(page.getByTestId('template-editor-dialog')).toBeHidden()
-			expect(decodeURIComponent(page.url())).toContain('"kind":"view"')
+			expect(page.url()).toContain('read=')
+		})
+	})
+
+	test.describe('when a reader checks a template while building a stack', () => {
+		test('should show it without losing the half-written stack', async ({
+			page,
+		}) => {
+			const name = `e2e-draft-${Date.now()}`
+			await page.goto('/settings/profile/templates', {
+				waitUntil: 'networkidle',
+			})
+
+			// GIVEN a stack part-way through being written
+			await page.getByTestId('new-stack').click()
+			await expect(page.getByTestId('stack-editor')).toBeVisible()
+			await page.getByTestId('stack-name').fill(name)
+			await page.locator('[data-testid^="stack-add-"]').first().click()
+			const picked = page.locator('[data-testid^="stack-read-"]').first()
+			await expect(picked).toBeVisible()
+
+			// WHEN one of its templates is opened for reading
+			await picked.click()
+
+			// THEN the guidance is on screen
+			await expect(page.getByTestId('template-view-dialog')).toBeVisible()
+			await expect(
+				page.getByTestId('template-view-dialog-body'),
+			).not.toBeEmpty()
+
+			// AND the stack being written is still there, name and all
+			await expect(page.getByTestId('stack-editor')).toBeVisible()
+			await expect(page.getByTestId('stack-name')).toHaveValue(name)
+
+			// AND closing the reader leaves the draft untouched
+			await page.keyboard.press('Escape')
+			await expect(page.getByTestId('template-view-dialog')).toBeHidden()
+			await expect(page.getByTestId('stack-name')).toHaveValue(name)
 		})
 	})
 

--- a/apps/internal/tests/e2e/instruction-template-reading.test.ts
+++ b/apps/internal/tests/e2e/instruction-template-reading.test.ts
@@ -1,0 +1,217 @@
+import { expect, test } from '@playwright/test'
+
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
+// Reading an instruction template, and the `?dlg=` addressing that carries it.
+// Standing guidance steers every agent run, so a member can read any template
+// the list returns — the organization's as well as their own — while editing
+// stays with the owner. The dialog lives in the URL, so it survives a refresh
+// and Back steps out of it.
+// Selectors verified against:
+//   apps/internal/src/routes/settings/profile/templates.tsx
+//     (template-row, template-view-{id})
+//   apps/internal/src/routes/settings/organization/templates.tsx
+//     (org-template-row, org-template-view-{id}, org-template-view-dialog)
+//   apps/internal/src/components/instructions/template-view-dialog.tsx
+//     (template-view-dialog, -body, -edit)
+//   apps/internal/src/components/instructions/template-editor-dialog.tsx
+//     (template-editor-dialog, template-editor-name)
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/', { waitUntil: 'commit' })
+	await setActiveOrgBySlug(page, 'taller')
+})
+
+test.describe('reading an instruction template', () => {
+	test.describe('when the template belongs to the organization, not the reader', () => {
+		test('should open it for reading without offering to edit it', async ({
+			page,
+		}) => {
+			// GIVEN the personal templates page, which lists org templates too
+			await page.goto('/settings/profile/templates', {
+				waitUntil: 'networkidle',
+			})
+			await expect(page.getByTestId('template-row').first()).toBeVisible()
+
+			// AND a row the reader does not own, marked "Org"
+			const orgRow = page
+				.getByTestId('template-row')
+				.filter({ hasText: 'Org' })
+				.first()
+			await expect(orgRow).toBeVisible()
+
+			// WHEN its Read button is used
+			await orgRow.getByRole('button', { name: /^Read / }).click()
+
+			// THEN the template's guidance is on screen
+			const dialog = page.getByTestId('template-view-dialog')
+			await expect(dialog).toBeVisible()
+			await expect(
+				page.getByTestId('template-view-dialog-body'),
+			).not.toBeEmpty()
+
+			// AND no edit affordance is offered, because it is not theirs to change
+			await expect(page.getByTestId('template-view-dialog-edit')).toBeHidden()
+		})
+	})
+
+	test.describe('when the reader owns the template', () => {
+		test('should offer Edit, and hand over to the editor seeded with it', async ({
+			page,
+		}) => {
+			await page.goto('/settings/profile/templates', {
+				waitUntil: 'networkidle',
+			})
+			const ownRow = page
+				.getByTestId('template-row')
+				.filter({ hasText: 'Mine' })
+				.first()
+			await expect(ownRow).toBeVisible()
+
+			// GIVEN their own template open for reading. The Read button names the
+			// template, so the name comes from there rather than from row position.
+			const readButton = ownRow.getByRole('button', { name: /^Read / })
+			const name = (
+				(await readButton.getAttribute('aria-label')) ?? ''
+			).replace(/^Read /, '')
+			await readButton.click()
+			await expect(page.getByTestId('template-view-dialog')).toBeVisible()
+
+			// WHEN Edit is taken
+			await page.getByTestId('template-view-dialog-edit').click()
+
+			// THEN the editor replaces it, already holding that template
+			await expect(page.getByTestId('template-editor-dialog')).toBeVisible()
+			await expect(page.getByTestId('template-view-dialog')).toBeHidden()
+			await expect(page.getByTestId('template-editor-name')).toHaveValue(
+				name.trim(),
+			)
+			// AND the URL now addresses the editor rather than the reader
+			expect(decodeURIComponent(page.url())).toContain('"kind":"edit"')
+		})
+	})
+
+	test.describe('when a reader shares the link to an open template', () => {
+		test('should reopen the same template on load, and close on Back', async ({
+			page,
+		}) => {
+			await page.goto('/settings/profile/templates', {
+				waitUntil: 'networkidle',
+			})
+			await expect(page.getByTestId('template-row').first()).toBeVisible()
+			await page
+				.getByTestId('template-row')
+				.first()
+				.getByRole('button', { name: /^Read / })
+				.click()
+			await expect(page.getByTestId('template-view-dialog')).toBeVisible()
+			const title =
+				(await page
+					.getByTestId('template-view-dialog')
+					.getByRole('heading')
+					.first()
+					.textContent()) ?? ''
+
+			// GIVEN the address of the open template
+			const shared = page.url()
+			expect(decodeURIComponent(shared)).toContain('"kind":"view"')
+
+			// WHEN that address is loaded fresh
+			await page.goto(shared, { waitUntil: 'networkidle' })
+
+			// THEN the same template is open again
+			await expect(page.getByTestId('template-view-dialog')).toBeVisible()
+			await expect(
+				page.getByTestId('template-view-dialog').getByRole('heading').first(),
+			).toHaveText(title)
+
+			// WHEN Back is pressed
+			await page.goBack()
+
+			// THEN the dialog closes and the address is clean again
+			await expect(page.getByTestId('template-view-dialog')).toBeHidden()
+			expect(page.url()).not.toContain('dlg=')
+		})
+	})
+
+	test.describe('when the link names a template that no longer exists', () => {
+		test('should settle on the list rather than an empty dialog', async ({
+			page,
+		}) => {
+			// GIVEN a link to a template id that is not in the organization
+			const missing = encodeURIComponent(
+				JSON.stringify({
+					kind: 'view',
+					id: '00000000-0000-4000-8000-000000000000',
+				}),
+			)
+
+			// WHEN it is opened
+			await page.goto(`/settings/profile/templates?dlg=${missing}`, {
+				waitUntil: 'networkidle',
+			})
+
+			// THEN the page drops the dead link and shows the list
+			await expect(page.getByTestId('template-row').first()).toBeVisible()
+			await expect(page.getByTestId('template-view-dialog')).toBeHidden()
+			await expect(page).toHaveURL(/\/settings\/profile\/templates$/)
+		})
+	})
+
+	test.describe('when an edit link names a template the page cannot change', () => {
+		test('should fall back to reading it instead of a dead address', async ({
+			page,
+		}) => {
+			// GIVEN the id of an organization template, which the personal page
+			// lists but cannot save
+			await page.goto('/settings/profile/templates', {
+				waitUntil: 'networkidle',
+			})
+			const orgRow = page
+				.getByTestId('template-row')
+				.filter({ hasText: 'Org' })
+				.first()
+			await expect(orgRow).toBeVisible()
+			const testId =
+				(await orgRow
+					.getByRole('button', { name: /^Read / })
+					.getAttribute('data-testid')) ?? ''
+			const id = testId.replace('template-view-', '')
+			expect(id).not.toHaveLength(0)
+
+			// WHEN an edit link for it is opened
+			const editLink = encodeURIComponent(JSON.stringify({ kind: 'edit', id }))
+			await page.goto(`/settings/profile/templates?dlg=${editLink}`, {
+				waitUntil: 'networkidle',
+			})
+
+			// THEN the template opens for reading, with no editor to save from
+			await expect(page.getByTestId('template-view-dialog')).toBeVisible()
+			await expect(page.getByTestId('template-editor-dialog')).toBeHidden()
+			expect(decodeURIComponent(page.url())).toContain('"kind":"view"')
+		})
+	})
+
+	test.describe('when an admin reads a template on the organization page', () => {
+		test('should show the guidance and offer to edit it', async ({ page }) => {
+			// GIVEN the org templates page as an admin
+			await page.goto('/settings/organization/templates', {
+				waitUntil: 'networkidle',
+			})
+			const row = page.getByTestId('org-template-row').first()
+			await expect(row).toBeVisible()
+
+			// WHEN a template is opened for reading
+			await row.getByRole('button', { name: /^Read / }).click()
+
+			// THEN its guidance is readable, and an admin may change it
+			await expect(page.getByTestId('org-template-view-dialog')).toBeVisible()
+			await expect(
+				page.getByTestId('org-template-view-dialog-body'),
+			).not.toBeEmpty()
+			await expect(
+				page.getByTestId('org-template-view-dialog-edit'),
+			).toBeVisible()
+		})
+	})
+})


### PR DESCRIPTION
## What

Instruction templates are the standing guidance an agent follows on every run — what I sell, who I target, tone, which sources to trust. Until now you could see a template's **name** and never its **text** unless you owned it. A member could read "[org] Qualification rubric" in the list, watch it steer every research run their agent did, and have no way to find out what it actually said. This opens reading to anyone the template is already visible to; changing one stays with its owner, or an admin for the organization's.

The second half is consistency work in the same app (`internal`): six dialogs that open over a record — a task, a calendar event, a contact, a document, a proposal, an org template — now live in the page address like the rest of the app already does, so one can be linked to or reopened after a refresh, and the browser's Back button closes it instead of leaving the page.

No server, database, or API change: the template text was already being sent to the browser, and the row-security policy already permits every member to read the organization's templates. Only the screen was withholding it.

## Changes

- Reading a template is open to anyone who can see it. The name is the button that opens it — that is what a reader reaches for — instead of a small icon at the end of the row.
- The text renders as formatted prose rather than raw markdown, in a region that takes keyboard focus so guidance longer than one screen can be read without a mouse.
- An address pointing at a template someone may not edit now opens it for reading rather than stranding them on a page with nothing on it.
- The six dialogs above moved from in-memory state to the `?dlg=` address key that `emails/inboxes` and the research surfaces already used.
- Reading a template has its own address key rather than sharing `?dlg=` with the editors, so checking what a template says while grouping templates into a stack no longer discards the half-written stack — and the picker offers a way to read each one.
- The reader says who looks after a template when it isn't yours to change, shows when the guidance last changed, and offers to copy it.
- A heading someone writes inside stored prose renders below the title of the page or dialog around it rather than above it.
- Walking the open task down the list with `j`/`k` overwrites the address instead of adding to history, so Back steps out of the task rather than retracing every keypress.
- Opening or closing any dialog no longer scrolls the page back to the top — on a phone that had been losing the reader's place in a long list.

## Impact

- **No migration, no schema change, no new environment variables.** Nothing to run before or after deploying.
- **Row security is unchanged, and this does not widen it.** The policy on `instruction_templates` already reads "templates owned by the organization, plus your own", so a member could always have been shown the organization's guidance — the screen was the only thing hiding it. Personal templates belonging to other members remain invisible, as before.
- **No wire-shape change.** `body` was already in the list response; that is how the edit dialog was being filled.
- **No service change, so nothing shifts for the MCP surface** — this is presentation only.
- **Two shared helpers changed, so the effect reaches dialogs outside this branch.** `use-dlg` and `tab-search` are used by the email inboxes page and the research surfaces too. Both changes are ones I would want everywhere — dialogs stop scrolling the page to the top, and leaving a tab closes the dialog that tab was showing instead of leaving it in the address to spring open on return — but they are the widest-reaching lines in the diff and worth a look.

## Review guide

**Look first at `apps/internal/src/lib/use-dlg.ts` and `lib/tab-search.ts`** — smallest diff, widest blast radius, for the reason in the last bullet above.

**The riskiest part was a bug class I introduced and then had to fix**, worth understanding because it is invisible to types and tests. Replacing `useState` with a value rebuilt on every render broke two dialogs that seed their form from that value: the contact editor reverted what you typed whenever any other list on the company page finished loading, and the org template editor silently reset its unsaved-changes guard, so Escape would discard a draft with no prompt. Both are now held steady on the row id. If you only read three hunks, make them the `useMemo` calls in `routes/companies/$slug.tsx` and both `settings/*/templates.tsx`.

**A decision you might overrule:** I *removed* a cleanup I had written for the calendar. It cleared `?dlg=` when the event wasn't found — but that page loads a window around today rather than every event, so a link to a meeting three months out was being erased irrecoverably. A link outside the window is now left intact and simply doesn't open. The cost is that a genuinely dead calendar link stays in the address bar.

**Skip-able:** the `.po` catalogue diffs are generated by `i18n:extract`; only three Catalan strings are hand-written.

**Not run:** Snyk was not available in this session.

**A second review round found nine more issues, all now fixed** — I verified each against the code or the running app before acting rather than taking the reports at face value. Two were bugs in my own first round of fixes: the organization page left the reader open underneath the editor, and a task-list keypress could reopen the pane a moment after it was closed. The rest: a scrolling document was keyboard-unreachable; closing a dialog opened from a link dropped focus entirely; admin-only links sat unclearable for everyone else; and a keyboard walk down the task list wrote the address once per keypress, which browsers refuse when a key is held (measured: five presses produced six history writes, now one).

## Screenshots

Desktop and mobile, since the row layout and the dialog both change by size.

_Templates list — every row is now openable; edit and delete stay on rows you own:_

![pr-templates-list-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-331/pr-templates-list-desktop.webp)

![pr-templates-list-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-331/pr-templates-list-mobile.webp)

_Reading an organization template — the case that was previously impossible. No Edit is offered here, because this page cannot change the organization's templates:_

![pr-read-dialog-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-331/pr-read-dialog-desktop.webp)

![pr-read-dialog-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-331/pr-read-dialog-mobile.webp)

## Tests

Eight new browser tests covering reading an organization template without an edit affordance, the owner's read-then-edit handover, a shared link reopening the same template and closing on Back, a link to a template that no longer exists, an edit link falling back to reading, an admin reading on the organization page, and reading a template mid-way through building a stack without losing the draft.

I also fixed a pre-existing isolation flaw in the neighbouring stack tests: one test claimed the single "default" stack seat and never gave it back, so the whole file failed on every run after the first. It now restores the previous default and removes what it made — three consecutive runs pass.

## Verification

- `check-types` (13/13), `test` (104), `build`, and the worker bundle budget (2392 KiB against a 2700 KiB budget) all run and green.
- The full browser suite: 91 passing. Seven failures (`members`, `profile-password`, `settings-spend`) I confirmed pre-existing by stashing this branch's changes and reproducing them unchanged on the base; two more (`send-email`, `superadmin`) pass in isolation and are order-dependent on shared fixtures.
- The smoke gate passes on a freshly seeded database.
- Every one of the six dialogs driven by hand against the live stack: opening, the address updating, reloading the link, and Back. Confirmed the task keyboard navigation adds one history entry for a click and none for two `j` presses, and that a link to a calendar event outside the loaded window still opens it.
- Language catalogues extracted; 1183 of 1183 messages translated in both English and Catalan.

## Deferred

- Adding `@axe-core/playwright`; it would have caught the keyboard-unreachable scroll region automatically.
- The dialog title blanks for a quarter of a second while the dialog fades out — fixed for the template reader, still there for other dialogs that pass their content in as props.
- `send-email` and `inbox-listing` share fixtures without cleaning up after themselves, so the smoke check fails on a second run against the same database. Same class as the stack-test fix in this branch, but in a part of the app this change doesn't touch.
