### PR TITLE
fix: restore the company meeting history across calendar, email and the timeline

### DIFF
--- a/apps/internal/src/atoms/company-atoms.ts
+++ b/apps/internal/src/atoms/company-atoms.ts
@@ -23,10 +23,6 @@ import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 
 const companyCache = new Map<string, ReturnType<typeof makeCompanyAtom>>()
 const contactsCache = new Map<string, ReturnType<typeof makeContactsAtom>>()
-const interactionsCache = new Map<
-	string,
-	ReturnType<typeof makeInteractionsAtom>
->()
 const companyTasksCache = new Map<
 	string,
 	ReturnType<typeof makeCompanyTasksAtom>
@@ -44,13 +40,6 @@ function makeContactsAtom(companyId: string) {
 	return BatudaApiAtom.query('contacts', 'list', {
 		query: { companyId },
 		serializationKey: `contacts:${companyId}`,
-	})
-}
-
-function makeInteractionsAtom(companyId: string) {
-	return BatudaApiAtom.query('interactions', 'list', {
-		query: { companyId, limit: 20 },
-		serializationKey: `interactions:${companyId}`,
 	})
 }
 
@@ -89,21 +78,6 @@ export function contactsAtomFor(companyId: string) {
 	if (existing !== undefined) return existing
 	const atom = makeContactsAtom(companyId)
 	contactsCache.set(companyId, atom)
-	return atom
-}
-
-/**
- * Interactions-by-company atom (one per companyId, limit 20). Hydrated
- * alongside the company atom so the always-visible timeline has data on
- * first paint. After logging a new interaction via Quick Capture, call
- * `useAtomRefresh` on this atom + the company atom (the server updates
- * `lastContactedAt` + `nextAction` in the same transaction).
- */
-export function interactionsAtomFor(companyId: string) {
-	const existing = interactionsCache.get(companyId)
-	if (existing !== undefined) return existing
-	const atom = makeInteractionsAtom(companyId)
-	interactionsCache.set(companyId, atom)
 	return atom
 }
 

--- a/apps/internal/src/components/companies/conversations-tab.tsx
+++ b/apps/internal/src/components/companies/conversations-tab.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 import { PriButton } from '@batuda/ui/pri'
 
 import { calendarEventsByCompanyAtom } from '#/atoms/calendar-atoms'
+import { channelLabelFor } from '#/components/shared/channel-icon'
 import { RelativeDate } from '#/components/shared/relative-date'
 import {
 	agedPaperSurface,
@@ -95,7 +96,7 @@ export function ConversationsTab({
 	readonly tasks: ReadonlyArray<TaskRow>
 	readonly onCompose: () => void
 }) {
-	const { t } = useLingui()
+	const { i18n, t } = useLingui()
 	const [enabled, setEnabled] = useState<ReadonlySet<ConvKind>>(
 		() => new Set<ConvKind>(ALL_KINDS),
 	)
@@ -166,6 +167,13 @@ export function ConversationsTab({
 	const NO_SUBJECT = t`(no subject)`
 	const FALLBACK_DATE = t`unknown`
 
+	// An interaction row can be a call, a visit or a proposal, so it takes its
+	// channel as the label instead of the catch-all "Interaction".
+	const rowLabel = (item: UnifiedRow): string =>
+		item.kind === 'interaction'
+			? i18n._(channelLabelFor(item.row.channel))
+			: KIND_LABEL[item.kind]
+
 	const titleFor = (item: UnifiedRow): string => {
 		switch (item.kind) {
 			case 'interaction':
@@ -219,7 +227,7 @@ export function ConversationsTab({
 						const body = (
 							<>
 								<RowMain>
-									<RowKind>{KIND_LABEL[item.kind]}</RowKind>
+									<RowKind>{rowLabel(item)}</RowKind>
 									<RowTitle>{titleFor(item)}</RowTitle>
 									{subtitle ? <RowSubtitle>{subtitle}</RowSubtitle> : null}
 								</RowMain>
@@ -282,7 +290,8 @@ function narrowCalendar(
 function rowSubtitle(item: UnifiedRow): string | null {
 	switch (item.kind) {
 		case 'interaction':
-			return item.row.channel
+			// The channel already shows as the row's label.
+			return null
 		case 'email':
 			return `${item.row.messageCount} · ${item.row.status}`
 		case 'calendar':

--- a/apps/internal/src/components/companies/upcoming-meetings-card.tsx
+++ b/apps/internal/src/components/companies/upcoming-meetings-card.tsx
@@ -19,8 +19,18 @@ type EventRow = {
 	readonly title: string
 	readonly startAt: string
 	readonly endAt: string
-	readonly attendeeCount: number
+	readonly attendees: ReadonlyArray<AttendeeRow>
 	readonly url: string | null
+}
+
+type AttendeeRow = {
+	readonly id: string
+	readonly label: string
+	readonly rsvp: string
+	readonly isOrganizer: boolean
+	// False when the address matches no contact on file — the person you most
+	// need to read up on before the meeting.
+	readonly isKnown: boolean
 }
 
 const EMPTY: ReadonlyArray<EventRow> = []
@@ -93,15 +103,50 @@ export function UpcomingMeetingsCard({
 							<Title>{ev.title}</Title>
 							<Meta>
 								<RelativeDate value={ev.startAt} fallback={t`unknown`} />
-								<Dot>·</Dot>
-								<AttendeeCount>
-									{ev.attendeeCount === 1 ? (
-										<Trans>1 attendee</Trans>
-									) : (
-										<Trans>{ev.attendeeCount} attendees</Trans>
-									)}
-								</AttendeeCount>
+								{ev.attendees.length > 0 ? (
+									<>
+										<Dot>·</Dot>
+										<AttendeeCount>
+											{ev.attendees.length === 1 ? (
+												<Trans>1 attendee</Trans>
+											) : (
+												<Trans>{ev.attendees.length} attendees</Trans>
+											)}
+										</AttendeeCount>
+									</>
+								) : null}
 							</Meta>
+							{ev.attendees.length > 0 ? (
+								<Attendees>
+									{ev.attendees.map(person => (
+										<Attendee
+											key={person.id}
+											$known={person.isKnown}
+											title={
+												person.isKnown
+													? undefined
+													: t`Not a contact on file yet`
+											}
+										>
+											{person.label}
+											{person.isOrganizer ? (
+												<AttendeeNote>
+													<Trans>organizer</Trans>
+												</AttendeeNote>
+											) : null}
+											{person.rsvp === 'declined' ? (
+												<AttendeeNote>
+													<Trans>declined</Trans>
+												</AttendeeNote>
+											) : person.rsvp === 'tentative' ? (
+												<AttendeeNote>
+													<Trans>tentative</Trans>
+												</AttendeeNote>
+											) : null}
+										</Attendee>
+									))}
+								</Attendees>
+							) : null}
 						</RowMain>
 						{ev.url !== null ? (
 							<OpenLink href={ev.url} target='_blank' rel='noreferrer'>
@@ -126,6 +171,26 @@ function dateToIsoOrNull(value: unknown): string | null {
 	return null
 }
 
+function narrowAttendees(value: unknown): ReadonlyArray<AttendeeRow> {
+	if (!Array.isArray(value)) return []
+	const out: Array<AttendeeRow> = []
+	for (const row of value) {
+		if (!row || typeof row !== 'object') continue
+		const r = row as Record<string, unknown>
+		const email = typeof r['email'] === 'string' ? r['email'] : null
+		if (email === null) continue
+		const name = typeof r['name'] === 'string' ? r['name'].trim() : ''
+		out.push({
+			id: typeof r['id'] === 'string' ? r['id'] : email,
+			label: name.length > 0 ? name : email,
+			rsvp: typeof r['rsvp'] === 'string' ? r['rsvp'] : 'needs-action',
+			isOrganizer: r['isOrganizer'] === true,
+			isKnown: typeof r['contactId'] === 'string',
+		})
+	}
+	return out
+}
+
 function narrowEvents(rows: ReadonlyArray<unknown>): ReadonlyArray<EventRow> {
 	const out: Array<EventRow> = []
 	for (const row of rows) {
@@ -137,7 +202,10 @@ function narrowEvents(rows: ReadonlyArray<unknown>): ReadonlyArray<EventRow> {
 		if (startAt === null) continue
 		const endAt = dateToIsoOrNull(r['endAt'])
 		if (endAt === null) continue
-		const attendees = Array.isArray(r['attendees']) ? r['attendees'] : []
+		// A meeting that was called off is not upcoming. The Conversations tab
+		// already drops these, so without this the same meeting shows in one
+		// place and not the other.
+		if (r['status'] === 'cancelled') continue
 		const meta = (r['metadata'] ?? null) as Record<string, unknown> | null
 		const url =
 			typeof meta?.['cal_com_url'] === 'string'
@@ -150,7 +218,7 @@ function narrowEvents(rows: ReadonlyArray<unknown>): ReadonlyArray<EventRow> {
 			title: r['title'],
 			startAt,
 			endAt,
-			attendeeCount: Math.max(1, attendees.length),
+			attendees: narrowAttendees(r['attendees']),
 			url,
 		})
 	}
@@ -234,6 +302,36 @@ const Dot = styled.span`
 
 const AttendeeCount = styled.span`
 	font-variant-numeric: tabular-nums;
+`
+
+const Attendees = styled.ul`
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2xs);
+	margin: var(--space-3xs) 0 0;
+	padding: 0;
+	list-style: none;
+	font-size: var(--typescale-body-small-size);
+	line-height: var(--typescale-body-small-line);
+`
+
+// An attendee we hold no contact for is dashed rather than solid: it reads as
+// provisional, and it is the cue to look them up before the meeting.
+const Attendee = styled.li<{ readonly $known: boolean }>`
+	display: inline-flex;
+	align-items: baseline;
+	gap: var(--space-3xs);
+	padding: 0 var(--space-2xs);
+	border-radius: var(--shape-3xs);
+	border: 1px ${p => (p.$known ? 'solid' : 'dashed')}
+		var(--color-outline-variant);
+	color: ${p =>
+		p.$known ? 'var(--color-on-surface)' : 'var(--color-on-surface-variant)'};
+`
+
+const AttendeeNote = styled.span`
+	font-size: 0.85em;
+	color: var(--color-on-surface-variant);
 `
 
 const OpenLink = styled.a`

--- a/apps/internal/src/components/shared/channel-icon.tsx
+++ b/apps/internal/src/components/shared/channel-icon.tsx
@@ -7,6 +7,7 @@ import {
 	Circle,
 	FileSignature,
 	FileText,
+	ListTodo,
 	Mail,
 	MapPin,
 	MessageCircle,
@@ -37,6 +38,7 @@ export type InteractionChannel =
 	| 'document'
 	| 'proposal'
 	| 'research'
+	| 'task'
 	| 'system'
 	| 'other'
 
@@ -54,6 +56,7 @@ const channelIcons: Record<
 	document: FileText,
 	proposal: FileSignature,
 	research: Search,
+	task: ListTodo,
 	system: Settings,
 	other: Circle,
 }
@@ -69,6 +72,7 @@ const channelLabels: Record<InteractionChannel, MessageDescriptor> = {
 	document: msg`Document`,
 	proposal: msg`Proposal`,
 	research: msg`Research`,
+	task: msg`Task`,
 	system: msg`System`,
 	other: msg`Other`,
 }

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -59,7 +59,7 @@ msgstr "(sense resum)"
 msgid "{0, plural, one {# template} other {# templates}}"
 msgstr "{0, plural, one {# plantilla} other {# plantilles}}"
 
-#. placeholder {0}: ev.attendeeCount
+#. placeholder {0}: ev.attendees.length
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "{0} attendees"
 msgstr "{0} assistents"
@@ -1560,6 +1560,10 @@ msgstr "Responsable de decisió"
 #: src/routes/calendar/index.tsx
 msgid "Decline"
 msgstr "Rebutja"
+
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "declined"
+msgstr "ha declinat"
 
 #: src/components/instructions/stack-list.tsx
 #: src/routes/emails/inboxes.tsx
@@ -3082,6 +3086,10 @@ msgstr "cap planificat"
 msgid "Normal priority"
 msgstr "Prioritat normal"
 
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "Not a contact on file yet"
+msgstr "Encara no és un contacte registrat"
+
 #: src/components/companies/company-fit-section.tsx
 msgid "Not a fit"
 msgstr "No encaixa"
@@ -3277,6 +3285,10 @@ msgstr "Organització eliminada"
 #: src/routes/settings/mcp/connections.tsx
 msgid "Organizations"
 msgstr "Organitzacions"
+
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "organizer"
+msgstr "organitza"
 
 #: src/components/shared/channel-icon.tsx
 msgid "Other"
@@ -4508,6 +4520,7 @@ msgid "Tags filter (comma-separated)"
 msgstr "Filtre d'etiquetes (separades per comes)"
 
 #: src/components/companies/conversations-tab.tsx
+#: src/components/shared/channel-icon.tsx
 msgid "Task"
 msgstr "Tasca"
 
@@ -4540,6 +4553,10 @@ msgstr "Plantilla eliminada"
 #: src/routes/settings/profile/templates.tsx
 msgid "Templates"
 msgstr "Plantilles"
+
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "tentative"
+msgstr "provisional"
 
 #: src/routes/calendar/index.tsx
 msgid "Tentative"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -59,7 +59,7 @@ msgstr "(no summary)"
 msgid "{0, plural, one {# template} other {# templates}}"
 msgstr "{0, plural, one {# template} other {# templates}}"
 
-#. placeholder {0}: ev.attendeeCount
+#. placeholder {0}: ev.attendees.length
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "{0} attendees"
 msgstr "{0} attendees"
@@ -1560,6 +1560,10 @@ msgstr "Decision maker"
 #: src/routes/calendar/index.tsx
 msgid "Decline"
 msgstr "Decline"
+
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "declined"
+msgstr "declined"
 
 #: src/components/instructions/stack-list.tsx
 #: src/routes/emails/inboxes.tsx
@@ -3082,6 +3086,10 @@ msgstr "none scheduled"
 msgid "Normal priority"
 msgstr "Normal priority"
 
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "Not a contact on file yet"
+msgstr "Not a contact on file yet"
+
 #: src/components/companies/company-fit-section.tsx
 msgid "Not a fit"
 msgstr "Not a fit"
@@ -3277,6 +3285,10 @@ msgstr "Organization removed"
 #: src/routes/settings/mcp/connections.tsx
 msgid "Organizations"
 msgstr "Organizations"
+
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "organizer"
+msgstr "organizer"
 
 #: src/components/shared/channel-icon.tsx
 msgid "Other"
@@ -4508,6 +4520,7 @@ msgid "Tags filter (comma-separated)"
 msgstr "Tags filter (comma-separated)"
 
 #: src/components/companies/conversations-tab.tsx
+#: src/components/shared/channel-icon.tsx
 msgid "Task"
 msgstr "Task"
 
@@ -4540,6 +4553,10 @@ msgstr "Template deleted"
 #: src/routes/settings/profile/templates.tsx
 msgid "Templates"
 msgstr "Templates"
+
+#: src/components/companies/upcoming-meetings-card.tsx
+msgid "tentative"
+msgstr "tentative"
 
 #: src/routes/calendar/index.tsx
 msgid "Tentative"

--- a/apps/internal/src/routes/calendar/index.tsx
+++ b/apps/internal/src/routes/calendar/index.tsx
@@ -7,7 +7,6 @@ import { CalendarPlus, Check, CircleHelp, X } from 'lucide-react'
 import { lazy, Suspense, useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
-import type { CalendarEvent, CalendarEventType, Company } from '@batuda/domain'
 import { PriButton, PriDialog } from '@batuda/ui/pri'
 
 import {
@@ -21,7 +20,6 @@ import { EmptyState } from '#/components/shared/empty-state'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { dehydrateAtom } from '#/lib/atom-hydration'
 import { dlgWithId } from '#/lib/dlg-search'
-import type { PaginatedList } from '#/lib/paginated-list'
 import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
 import { useDlg } from '#/lib/use-dlg'
@@ -61,11 +59,9 @@ type CompanyLookup = {
 
 const ScheduleGrid = lazy(() => import('#/components/calendar/schedule-grid'))
 
-async function loadCalendarOnServer(): Promise<{
-	events: PaginatedList<CalendarEvent>
-	eventTypes: ReadonlyArray<CalendarEventType>
-	companies: PaginatedList<Company>
-}> {
+// The shape is taken from the API client rather than written out here, so a
+// change to what the endpoint returns can't leave a stale copy behind.
+async function loadCalendarOnServer() {
 	const [{ Effect }, { makeBatudaApiServer }, cookie] = await Promise.all([
 		import('effect'),
 		import('#/lib/batuda-api-server'),

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -1839,9 +1839,8 @@ function toTimelineEntry(
 		outcome: textOrNull(payload['outcome']),
 		nextAction: textOrNull(payload['nextAction']),
 		date: row.date,
-		// Rows don't carry the thread they belong to, so an email entry can't
-		// link through to the conversation yet.
-		threadId: null,
+		// Only email rows carry this, so only those link through to a conversation.
+		threadId: textOrNull(payload['threadLinkId']),
 	}
 }
 

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -41,7 +41,7 @@ import type {
 	CompanyDetail as CompanyDetailResponse,
 	ContactListItem,
 } from '@batuda/controllers'
-import type { Interaction, Task } from '@batuda/domain'
+import type { Task } from '@batuda/domain'
 import { Sidebar, Stack, Switcher } from '@batuda/ui'
 import {
 	PriButton,
@@ -55,7 +55,6 @@ import {
 	companyAtomFor,
 	companyTasksAtomFor,
 	contactsAtomFor,
-	interactionsAtomFor,
 	timelineAtomFor,
 } from '#/atoms/company-atoms'
 import { emailsSearchAtom } from '#/atoms/emails-atoms'
@@ -112,6 +111,7 @@ import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { PriorityDot } from '#/components/shared/priority-dot'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { SrOnly } from '#/components/shared/sr-only'
+import type { CompanyStatus } from '#/components/shared/status-badge'
 import {
 	asCompanyStatus,
 	StatusBadge,
@@ -236,19 +236,17 @@ type TaskEntry = {
 type DetailPayload = {
 	readonly company: (typeof CompanyDetailResponse)['Type']
 	readonly contacts: PaginatedList<(typeof ContactListItem)['Type']>
-	readonly interactions: PaginatedList<Interaction>
 	readonly tasks: PaginatedList<Task>
 }
 
 /**
- * Server-only: fetch the company row and all four relations in parallel.
- * Dynamically imports the server client so Vite excludes it from the
- * client bundle; forwards the Better-Auth cookie via
+ * Server-only: fetch the company row plus its contacts and tasks in
+ * parallel. Dynamically imports the server client so Vite excludes it from
+ * the client bundle; forwards the Better-Auth cookie via
  * `getRequestHeader('cookie')`.
  *
- * Uses `Effect.all` with `concurrency: 4` for the relations so they
- * share a single Better-Auth session roundtrip but run in parallel on
- * the server.
+ * The relations go through a single `Effect.all` so they share one
+ * Better-Auth session roundtrip but still run in parallel on the server.
  */
 async function loadDetailOnServer(slug: string): Promise<DetailPayload> {
 	const [{ Effect }, { makeBatudaApiServer }, cookie] = await Promise.all([
@@ -265,19 +263,17 @@ async function loadDetailOnServer(slug: string): Promise<DetailPayload> {
 			return {
 				company,
 				contacts: emptyPage,
-				interactions: emptyPage,
 				tasks: emptyPage,
 			} as DetailPayload
 		}
-		const [contacts, interactions, tasks] = yield* Effect.all(
+		const [contacts, tasks] = yield* Effect.all(
 			[
 				client.contacts.list({ query: { companyId } }),
-				client.interactions.list({ query: { companyId, limit: 20 } }),
 				client.tasks.list({ query: { companyId } }),
 			],
-			{ concurrency: 3 },
+			{ concurrency: 2 },
 		)
-		return { company, contacts, interactions, tasks } as DetailPayload
+		return { company, contacts, tasks } as DetailPayload
 	})
 	return Effect.runPromise(program)
 }
@@ -361,10 +357,6 @@ export const Route = createFileRoute('/companies/$slug')({
 					dehydrateAtom(
 						contactsAtomFor(companyId),
 						AsyncResult.success(payload.contacts),
-					),
-					dehydrateAtom(
-						interactionsAtomFor(companyId),
-						AsyncResult.success(payload.interactions),
 					),
 					dehydrateAtom(
 						companyTasksAtomFor(companyId),
@@ -492,10 +484,6 @@ function DetailBody({
 	useSetDocumentTitle(topBarTitle)
 
 	const contactsAtom = useMemo(() => contactsAtomFor(company.id), [company.id])
-	const interactionsAtom = useMemo(
-		() => interactionsAtomFor(company.id),
-		[company.id],
-	)
 	const timelineAtom = useMemo(() => timelineAtomFor(company.id), [company.id])
 	const tasksAtom = useMemo(() => companyTasksAtomFor(company.id), [company.id])
 	const companyPagesAtom = useMemo(
@@ -524,7 +512,6 @@ function DetailBody({
 	const researchResult = useAtomValue(companyResearchAtom)
 	const refreshResearch = useAtomRefresh(companyResearchAtom)
 
-	const refreshInteractions = useAtomRefresh(interactionsAtom)
 	const refreshTimeline = useAtomRefresh(timelineAtom)
 	const refreshContacts = useAtomRefresh(contactsAtom)
 	const refreshTasks = useAtomRefresh(tasksAtom)
@@ -870,7 +857,6 @@ function DetailBody({
 			companyId: company.id,
 			companyName: company.name,
 			onSubmitted: () => {
-				refreshInteractions()
 				refreshTimeline()
 				refreshCompany()
 			},
@@ -879,7 +865,6 @@ function DetailBody({
 		openQuickCapture,
 		company.id,
 		company.name,
-		refreshInteractions,
 		refreshTimeline,
 		refreshCompany,
 	])
@@ -1236,30 +1221,16 @@ function DetailBody({
 														/>
 													) : (
 														<TimelineList>
-															{visibleTimeline.map(row => {
-																const isStage = row.kind === 'stage_changed'
-																const stageFrom = asCompanyStatus(
-																	String(row.payload?.['from'] ?? 'prospect'),
-																)
-																const stageTo = asCompanyStatus(
-																	String(row.payload?.['to'] ?? 'prospect'),
-																)
-																const entry: TimelineEntryData = {
-																	id: row.id,
-																	channel: row.channel,
-																	subject: isStage ? t`Stage changed` : null,
-																	summary: isStage
-																		? `${i18n._(statusLabels[stageFrom])} → ${i18n._(statusLabels[stageTo])}`
-																		: row.summary,
-																	outcome: null,
-																	nextAction: null,
-																	date: row.date,
-																	threadId: null,
-																}
-																return (
-																	<TimelineEntry key={row.id} entry={entry} />
-																)
-															})}
+															{visibleTimeline.map(row => (
+																<TimelineEntry
+																	key={row.id}
+																	entry={toTimelineEntry(row, {
+																		stageChangedLabel: t`Stage changed`,
+																		describeStageChange: (from, to) =>
+																			`${i18n._(statusLabels[from])} → ${i18n._(statusLabels[to])}`,
+																	})}
+																/>
+															))}
 														</TimelineList>
 													)}
 												</TimelinePanelInner>
@@ -1825,13 +1796,67 @@ const CHANNEL_ICON: Record<string, typeof Mail> = {
 	bluesky: AtSign,
 }
 
+const textOrNull = (value: unknown): string | null =>
+	typeof value === 'string' && value.trim().length > 0 ? value : null
+
+// Most of what makes an activity row worth reading — the email's subject, how
+// a call ended, what was promised next — sits in its `payload`, not in
+// `summary`, which many kinds leave empty. A row built from `summary` alone
+// shows up as a bare channel name and nothing else.
+function toTimelineEntry(
+	row: TimelineRow,
+	labels: {
+		readonly stageChangedLabel: string
+		readonly describeStageChange: (
+			from: CompanyStatus,
+			to: CompanyStatus,
+		) => string
+	},
+): TimelineEntryData {
+	const payload = row.payload ?? {}
+
+	if (row.kind === 'stage_changed') {
+		return {
+			id: row.id,
+			channel: row.channel,
+			subject: labels.stageChangedLabel,
+			summary: labels.describeStageChange(
+				asCompanyStatus(String(payload['from'] ?? 'prospect')),
+				asCompanyStatus(String(payload['to'] ?? 'prospect')),
+			),
+			outcome: null,
+			nextAction: null,
+			date: row.date,
+			threadId: null,
+		}
+	}
+
+	return {
+		id: row.id,
+		channel: row.channel,
+		subject: textOrNull(payload['subject']),
+		summary: row.summary,
+		outcome: textOrNull(payload['outcome']),
+		nextAction: textOrNull(payload['nextAction']),
+		date: row.date,
+		// Rows don't carry the thread they belong to, so an email entry can't
+		// link through to the conversation yet.
+		threadId: null,
+	}
+}
+
 function timelineKindToChannel(kind: string, fallback: string | null): string {
 	switch (kind) {
 		case 'email_sent':
 		case 'email_received':
+		case 'email_bounced':
 			return 'email'
 		case 'call_logged':
 			return fallback ?? 'phone'
+		// The row names its own channel, so the icon can match the medium — a
+		// visit gets a pin, WhatsApp a speech bubble — with no case per channel.
+		case 'interaction_logged':
+			return fallback ?? 'other'
 		case 'document_created':
 			return 'document'
 		case 'proposal_sent':
@@ -1839,11 +1864,17 @@ function timelineKindToChannel(kind: string, fallback: string | null): string {
 		case 'proposal_responded':
 			return 'proposal'
 		case 'research_run':
+		case 'research_applied':
 			return 'research'
 		case 'meeting_scheduled':
-		case 'meeting_completed':
+		case 'meeting_rescheduled':
 		case 'meeting_cancelled':
+		case 'meeting_rsvp':
 			return 'event'
+		case 'task_created':
+		case 'task_updated':
+		case 'task_completed':
+			return 'task'
 		case 'system_event':
 		case 'stage_changed':
 			return 'system'

--- a/apps/internal/tests/e2e/calendar-on-company.test.ts
+++ b/apps/internal/tests/e2e/calendar-on-company.test.ts
@@ -65,11 +65,15 @@ test.describe('calendar on company page', () => {
 				'video', 'organizer@taller.cat', '${companyId}'
 			)`,
 		)
+		// Two attendees, one of them without a name, so the card has to read
+		// the real rows: a count derived from anything else cannot say "2".
 		psql(
 			`INSERT INTO calendar_event_attendees (
 				id, organization_id, event_id, email, name, rsvp
 			) VALUES (
 				gen_random_uuid(), '${orgId}', '${upcomingId}', 'pep@calpepfonda.cat', 'Pep Casals', 'accepted'
+			), (
+				gen_random_uuid(), '${orgId}', '${upcomingId}', 'nuria@calpepfonda.cat', NULL, 'tentative'
 			)`,
 		)
 
@@ -119,10 +123,14 @@ test.describe('calendar on company page', () => {
 			await expect(card).toBeVisible()
 			const rows = card.locator('[data-testid^="company-upcoming-meeting-"]')
 			await expect(rows.first()).toBeVisible()
-			// AND the row carries the title + an attendee count + a relative
-			// time (full assertion against text would be brittle as time
-			// passes; a non-empty row is the contract under test)
-			await expect(rows.first()).toContainText(/attendee/)
+			// AND the row names the people invited and counts them exactly.
+			// Two were seeded, so a count that ignores the real rows cannot
+			// pass. The one with no name falls back to their address.
+			await expect(rows.first()).toContainText('2 attendees')
+			await expect(rows.first()).toContainText('Pep Casals')
+			await expect(rows.first()).toContainText('nuria@calpepfonda.cat')
+			// AND someone who has not replied for certain is marked as such
+			await expect(rows.first()).toContainText('tentative')
 		})
 	})
 

--- a/apps/mail-worker/src/bounces.integration.test.ts
+++ b/apps/mail-worker/src/bounces.integration.test.ts
@@ -1,185 +1,236 @@
-// PgLive reads DATABASE_URL via Config at layer-build time. Default to
-// the docker-compose service so the suite runs without a loaded .env.
+// Live-DB integration test for `applyBounce` — the path that runs when a
+// message we sent comes back undelivered.
+//
+// The history row it writes has to name its organization: without that the
+// database refuses the write, and because it shares a transaction with
+// storing the bounce notice, the notice is discarded along with it and never
+// reaches the inbox.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable on $DATABASE_URL.
+
 process.env['DATABASE_URL'] ??=
 	'postgresql://batuda:batuda@localhost:5433/batuda'
 
 import { randomUUID } from 'node:crypto'
 
+import { PgClient } from '@effect/sql-pg'
+import { Config, Effect, Redacted } from 'effect'
 import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-// SQL-contract test for the history rows `applyBounce` writes when a message
-// we sent comes back undelivered.
-//
-// Every history row has to say which organization it belongs to. Omitting it
-// doesn't just lose the bounce: the write happens inside the transaction that
-// stores the bounce notice itself, so the failure discards that too and the
-// notice never reaches the inbox. Both shapes are pinned here.
-//
-// Prereq: `pnpm cli services up` so Postgres is reachable.
+import { applyBounce, type ParsedBounce } from './bounces.js'
 
 const DATABASE_URL =
 	process.env['DATABASE_URL'] ??
 	'postgresql://batuda:batuda@localhost:5433/batuda'
 
-const PAYLOAD = JSON.stringify({
-	originalMessageId: '<original@batuda.test>',
-	status: '5.1.1',
+const snakeToCamel = (s: string) =>
+	s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+
+const camelToSnake = (s: string) =>
+	s.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`)
+
+const PgLive = PgClient.layerConfig({
+	url: Config.succeed(Redacted.make(DATABASE_URL)),
+	transformResultNames: Config.succeed(snakeToCamel),
+	transformQueryNames: Config.succeed(camelToSnake),
+})
+
+const ORG_ID = `bounce-org-${randomUUID()}`
+const DOMAIN = `bounce-${randomUUID()}.example`
+
+let pool: pg.Pool
+let inboxId: string
+let companyId: string
+let contactId: string
+
+const apply = (bounce: ParsedBounce) =>
+	Effect.runPromise(
+		applyBounce({ organizationId: ORG_ID, bounce }).pipe(
+			Effect.provide(PgLive),
+		),
+	)
+
+/** An outbound message we can bounce, returning its RFC-5322 Message-ID. */
+const seedOutbound = async (): Promise<string> => {
+	const messageId = `<sent-${randomUUID()}@${DOMAIN}>`
+	await pool.query(
+		`INSERT INTO email_messages (
+			organization_id, inbox_id, folder, message_id, subject, received_at,
+			raw_rfc822_ref, status, status_updated_at, direction, company_id, contact_id
+		) VALUES ($1, $2, 'SENT', $3, 'Quote', now(), 'sentinel', 'normal', now(), 'outbound', $4, $5)`,
+		[ORG_ID, inboxId, messageId, companyId, contactId],
+	)
+	return messageId
+}
+
+const bounceFor = (
+	messageId: string | null,
+	recipients: readonly string[],
+): ParsedBounce => ({
+	originalMessageId: messageId,
+	recipients,
+	statusCode: '5.1.1',
 	diagnostic: 'mailbox unavailable',
-	recipients: ['nobody@example.com'],
 	bounceType: 'hard',
 })
 
-describe('timeline_activity INSERT — bounce contract', () => {
-	let pool: pg.Pool
-	let orgId: string
-	const seededEntityIds: string[] = []
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
 
-	beforeAll(async () => {
-		pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
-		await pool.query('GRANT app_user TO CURRENT_USER')
+	// The transport columns are all required; the values are inert — this
+	// suite never connects to a mail server.
+	const inbox = await pool.query<{ id: string }>(
+		`INSERT INTO inboxes
+		 (organization_id, owner_user_id, email, purpose,
+		  imap_host, imap_port, imap_security,
+		  smtp_host, smtp_port, smtp_security,
+		  username, password_ciphertext, password_nonce, password_tag)
+		 VALUES ($1, $2, $3, 'human',
+		         'imap.example.com', 993, 'tls',
+		         'smtp.example.com', 465, 'tls',
+		         $3, '\\x00'::bytea, '\\x00'::bytea, '\\x00'::bytea)
+		 RETURNING id`,
+		[ORG_ID, `bounce-user-${randomUUID()}`, `desk@${DOMAIN}`],
+	)
+	inboxId = inbox.rows[0]!.id
 
-		const orgs = await pool.query<{ id: string }>(
-			`SELECT id FROM organization WHERE slug = $1 LIMIT 1`,
-			['taller'],
-		)
-		const oid = orgs.rows[0]?.id
-		if (!oid) {
-			throw new Error(
-				"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
-			)
-		}
-		orgId = oid
-	})
+	const company = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name) VALUES ($1, $2, $2) RETURNING id`,
+		[ORG_ID, `bounce-co-${randomUUID()}`],
+	)
+	companyId = company.rows[0]!.id
 
-	afterAll(async () => {
-		for (const id of seededEntityIds) {
-			await pool.query(`DELETE FROM timeline_activity WHERE entity_id = $1`, [
-				id,
-			])
-		}
-		await pool.end()
-	})
+	const contact = await pool.query<{ id: string }>(
+		`INSERT INTO contacts (organization_id, company_id, name) VALUES ($1, $2, 'Bounce Target') RETURNING id`,
+		[ORG_ID, companyId],
+	)
+	contactId = contact.rows[0]!.id
 
-	const withOrgScope = async <T>(
-		body: (client: pg.PoolClient) => Promise<T>,
-	): Promise<T> => {
-		const client = await pool.connect()
-		try {
-			await client.query('BEGIN')
-			await client.query('SET LOCAL ROLE app_user')
-			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
-				orgId,
-			])
-			const result = await body(client)
-			await client.query('COMMIT')
-			return result
-		} catch (err) {
-			await client.query('ROLLBACK')
-			throw err
-		} finally {
-			client.release()
-		}
+	await pool.query(
+		`INSERT INTO contact_channels (organization_id, contact_id, kind, value, is_primary)
+		 VALUES ($1, $2, 'email', $3, true)`,
+		[ORG_ID, contactId, `nobody@${DOMAIN}`],
+	)
+})
+
+afterAll(async () => {
+	// organization_id is a plain column, so one delete per table clears the suite.
+	for (const table of [
+		'timeline_activity',
+		'email_messages',
+		'contact_channels',
+		'contacts',
+		'companies',
+		'inboxes',
+	]) {
+		await pool.query(`DELETE FROM ${table} WHERE organization_id = $1`, [
+			ORG_ID,
+		])
 	}
+	await pool.end()
+})
 
-	describe('when the bounce row carries its organization', () => {
-		it('should be stored and readable from that organization', async () => {
-			// GIVEN the shape applyBounce writes when no contact matched
-			// WHEN it runs under that organization's scope
-			// THEN the row is stored and readable back
-			const entityId = randomUUID()
-			seededEntityIds.push(entityId)
+describe('applyBounce', () => {
+	describe('when a bounce matches a message we sent', () => {
+		it('should mark that message as bounced', async () => {
+			// GIVEN a message we sent, and a bounce naming it
+			const messageId = await seedOutbound()
 
-			const stored = await withOrgScope(async client => {
-				await client.query(
-					`INSERT INTO timeline_activity (
-						organization_id, kind, entity_type, entity_id,
-						channel, direction, occurred_at, payload
-					) VALUES (
-						$1, 'email_bounced', 'email_message', $2::uuid,
-						'email', 'outbound', now(), $3::jsonb
-					)`,
-					[orgId, entityId, PAYLOAD],
-				)
-				const result = await client.query<{ kind: string; channel: string }>(
-					`SELECT kind, channel FROM timeline_activity WHERE entity_id = $1::uuid`,
-					[entityId],
-				)
-				return result.rows[0]
-			})
+			// WHEN the bounce is applied
+			const result = await apply(bounceFor(messageId, [`nobody@${DOMAIN}`]))
 
-			expect(stored?.kind).toBe('email_bounced')
-			expect(stored?.channel).toBe('email')
+			// THEN the original is recorded as undelivered, with the reason
+			expect(result.matchedOriginal).toBe(true)
+			const stored = await pool.query<{
+				status: string
+				bounce_type: string | null
+				bounce_sub_type: string | null
+			}>(
+				`SELECT status, bounce_type, bounce_sub_type FROM email_messages WHERE message_id = $1`,
+				[messageId],
+			)
+			expect(stored.rows[0]?.status).toBe('bounced')
+			expect(stored.rows[0]?.bounce_type).toBe('hard')
+			expect(stored.rows[0]?.bounce_sub_type).toBe('5.1.1')
+		})
+
+		it('should put the bounce on the company history under this organization', async () => {
+			// GIVEN a message we sent to an address we hold a contact for
+			const messageId = await seedOutbound()
+
+			// WHEN the bounce is applied
+			await apply(bounceFor(messageId, [`nobody@${DOMAIN}`]))
+
+			// THEN a history row exists, carrying the organization and the
+			// contact it concerns. Omitting the organization is refused by the
+			// database and would discard the surrounding write with it.
+			const rows = await pool.query<{
+				kind: string
+				organization_id: string
+				contact_id: string | null
+				company_id: string | null
+			}>(
+				`SELECT t.kind, t.organization_id, t.contact_id, t.company_id
+				 FROM timeline_activity t
+				 JOIN email_messages m ON m.id = t.entity_id
+				 WHERE m.message_id = $1`,
+				[messageId],
+			)
+			expect(rows.rows.length).toBeGreaterThan(0)
+			const row = rows.rows[0]
+			expect(row?.kind).toBe('email_bounced')
+			expect(row?.organization_id).toBe(ORG_ID)
+			expect(row?.contact_id).toBe(contactId)
+			expect(row?.company_id).toBe(companyId)
+		})
+
+		it('should still record a bounce for an address matching no contact', async () => {
+			// GIVEN a bounce for someone we hold no contact for
+			const messageId = await seedOutbound()
+
+			// WHEN it is applied
+			const result = await apply(
+				bounceFor(messageId, [`stranger@${randomUUID()}.example`]),
+			)
+
+			// THEN no contact is touched, but the bounce is not silent
+			expect(result.contactsTouched).toBe(0)
+			const rows = await pool.query<{ contact_id: string | null }>(
+				`SELECT t.contact_id FROM timeline_activity t
+				 JOIN email_messages m ON m.id = t.entity_id
+				 WHERE m.message_id = $1`,
+				[messageId],
+			)
+			expect(rows.rows.length).toBe(1)
+			expect(rows.rows[0]?.contact_id).toBeNull()
 		})
 	})
 
-	describe('when the bounce row omits its organization', () => {
-		it('should be rejected, taking the surrounding write with it', async () => {
-			// GIVEN the shape with no organization column in the list
-			// WHEN it runs
-			// THEN it is refused either way: a scoped session trips the rule
-			//      that a row must belong to the reader's organization, and the
-			//      worker's own unscoped role trips the column being required.
-			//      The refusal matters more than which of the two fires — it
-			//      happens inside the same transaction as the bounce notice, so
-			//      the notice is discarded with it and never reaches the inbox.
-			const entityId = randomUUID()
+	describe('when the bounce names nothing we sent', () => {
+		it('should do nothing rather than guess', async () => {
+			// GIVEN a bounce naming a message id we never sent
+			const bounce = bounceFor(`<unknown-${randomUUID()}@nowhere>`, [
+				`nobody@${DOMAIN}`,
+			])
 
-			await expect(
-				withOrgScope(client =>
-					client.query(
-						`INSERT INTO timeline_activity (
-							kind, entity_type, entity_id,
-							channel, direction, occurred_at, payload
-						) VALUES (
-							'email_bounced', 'email_message', $1::uuid,
-							'email', 'outbound', now(), $2::jsonb
-						)`,
-						[entityId, PAYLOAD],
-					),
-				),
-			).rejects.toThrow(/organization_id|row-level security/i)
+			// WHEN it is applied
+			const result = await apply(bounce)
+
+			// THEN nothing is matched and no history is written
+			expect(result.matchedOriginal).toBe(false)
+			expect(result.contactsTouched).toBe(0)
 		})
-	})
 
-	describe('when a bounce affects contacts', () => {
-		it('should carry the organization onto every contact row it writes', async () => {
-			// GIVEN the branch that writes one row per affected contact
-			// WHEN it selects those contacts and inserts
-			// THEN each row carries the organization, not just the first
-			const entityId = randomUUID()
-			seededEntityIds.push(entityId)
+		it('should ignore a bounce carrying no message id or no recipients', async () => {
+			// GIVEN the two degenerate shapes a parser can hand back
+			// WHEN each is applied
+			const noId = await apply(bounceFor(null, ['a@b.test']))
+			const noRecipients = await apply(bounceFor('<x@y>', []))
 
-			const rows = await withOrgScope(async client => {
-				const contacts = await client.query<{ id: string }>(
-					`SELECT id FROM contacts LIMIT 2`,
-				)
-				if (contacts.rows.length === 0) {
-					throw new Error('seed contacts required — run pnpm cli seed')
-				}
-				const ids = contacts.rows.map(r => r.id)
-				await client.query(
-					`INSERT INTO timeline_activity (
-						organization_id, kind, entity_type, entity_id, company_id, contact_id,
-						channel, direction, occurred_at, payload
-					)
-					SELECT $1, 'email_bounced', 'email_message', $2::uuid,
-					       c.company_id, c.id,
-					       'email', 'outbound', now(), $3::jsonb
-					FROM contacts c WHERE c.id = ANY($4::uuid[])`,
-					[orgId, entityId, PAYLOAD, ids],
-				)
-				const result = await client.query<{ count: string; orgs: string }>(
-					`SELECT count(*)::text AS count,
-					        count(DISTINCT organization_id)::text AS orgs
-					 FROM timeline_activity WHERE entity_id = $1::uuid`,
-					[entityId],
-				)
-				return result.rows[0]
-			})
-
-			expect(Number(rows?.count)).toBeGreaterThan(0)
-			expect(rows?.orgs).toBe('1')
+			// THEN both are refused before any write
+			expect(noId.matchedOriginal).toBe(false)
+			expect(noRecipients.matchedOriginal).toBe(false)
 		})
 	})
 })

--- a/apps/mail-worker/src/bounces.integration.test.ts
+++ b/apps/mail-worker/src/bounces.integration.test.ts
@@ -1,0 +1,185 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to
+// the docker-compose service so the suite runs without a loaded .env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// SQL-contract test for the history rows `applyBounce` writes when a message
+// we sent comes back undelivered.
+//
+// Every history row has to say which organization it belongs to. Omitting it
+// doesn't just lose the bounce: the write happens inside the transaction that
+// stores the bounce notice itself, so the failure discards that too and the
+// notice never reaches the inbox. Both shapes are pinned here.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+const PAYLOAD = JSON.stringify({
+	originalMessageId: '<original@batuda.test>',
+	status: '5.1.1',
+	diagnostic: 'mailbox unavailable',
+	recipients: ['nobody@example.com'],
+	bounceType: 'hard',
+})
+
+describe('timeline_activity INSERT — bounce contract', () => {
+	let pool: pg.Pool
+	let orgId: string
+	const seededEntityIds: string[] = []
+
+	beforeAll(async () => {
+		pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+		await pool.query('GRANT app_user TO CURRENT_USER')
+
+		const orgs = await pool.query<{ id: string }>(
+			`SELECT id FROM organization WHERE slug = $1 LIMIT 1`,
+			['taller'],
+		)
+		const oid = orgs.rows[0]?.id
+		if (!oid) {
+			throw new Error(
+				"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
+			)
+		}
+		orgId = oid
+	})
+
+	afterAll(async () => {
+		for (const id of seededEntityIds) {
+			await pool.query(`DELETE FROM timeline_activity WHERE entity_id = $1`, [
+				id,
+			])
+		}
+		await pool.end()
+	})
+
+	const withOrgScope = async <T>(
+		body: (client: pg.PoolClient) => Promise<T>,
+	): Promise<T> => {
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			await client.query('SET LOCAL ROLE app_user')
+			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+				orgId,
+			])
+			const result = await body(client)
+			await client.query('COMMIT')
+			return result
+		} catch (err) {
+			await client.query('ROLLBACK')
+			throw err
+		} finally {
+			client.release()
+		}
+	}
+
+	describe('when the bounce row carries its organization', () => {
+		it('should be stored and readable from that organization', async () => {
+			// GIVEN the shape applyBounce writes when no contact matched
+			// WHEN it runs under that organization's scope
+			// THEN the row is stored and readable back
+			const entityId = randomUUID()
+			seededEntityIds.push(entityId)
+
+			const stored = await withOrgScope(async client => {
+				await client.query(
+					`INSERT INTO timeline_activity (
+						organization_id, kind, entity_type, entity_id,
+						channel, direction, occurred_at, payload
+					) VALUES (
+						$1, 'email_bounced', 'email_message', $2::uuid,
+						'email', 'outbound', now(), $3::jsonb
+					)`,
+					[orgId, entityId, PAYLOAD],
+				)
+				const result = await client.query<{ kind: string; channel: string }>(
+					`SELECT kind, channel FROM timeline_activity WHERE entity_id = $1::uuid`,
+					[entityId],
+				)
+				return result.rows[0]
+			})
+
+			expect(stored?.kind).toBe('email_bounced')
+			expect(stored?.channel).toBe('email')
+		})
+	})
+
+	describe('when the bounce row omits its organization', () => {
+		it('should be rejected, taking the surrounding write with it', async () => {
+			// GIVEN the shape with no organization column in the list
+			// WHEN it runs
+			// THEN it is refused either way: a scoped session trips the rule
+			//      that a row must belong to the reader's organization, and the
+			//      worker's own unscoped role trips the column being required.
+			//      The refusal matters more than which of the two fires — it
+			//      happens inside the same transaction as the bounce notice, so
+			//      the notice is discarded with it and never reaches the inbox.
+			const entityId = randomUUID()
+
+			await expect(
+				withOrgScope(client =>
+					client.query(
+						`INSERT INTO timeline_activity (
+							kind, entity_type, entity_id,
+							channel, direction, occurred_at, payload
+						) VALUES (
+							'email_bounced', 'email_message', $1::uuid,
+							'email', 'outbound', now(), $2::jsonb
+						)`,
+						[entityId, PAYLOAD],
+					),
+				),
+			).rejects.toThrow(/organization_id|row-level security/i)
+		})
+	})
+
+	describe('when a bounce affects contacts', () => {
+		it('should carry the organization onto every contact row it writes', async () => {
+			// GIVEN the branch that writes one row per affected contact
+			// WHEN it selects those contacts and inserts
+			// THEN each row carries the organization, not just the first
+			const entityId = randomUUID()
+			seededEntityIds.push(entityId)
+
+			const rows = await withOrgScope(async client => {
+				const contacts = await client.query<{ id: string }>(
+					`SELECT id FROM contacts LIMIT 2`,
+				)
+				if (contacts.rows.length === 0) {
+					throw new Error('seed contacts required — run pnpm cli seed')
+				}
+				const ids = contacts.rows.map(r => r.id)
+				await client.query(
+					`INSERT INTO timeline_activity (
+						organization_id, kind, entity_type, entity_id, company_id, contact_id,
+						channel, direction, occurred_at, payload
+					)
+					SELECT $1, 'email_bounced', 'email_message', $2::uuid,
+					       c.company_id, c.id,
+					       'email', 'outbound', now(), $3::jsonb
+					FROM contacts c WHERE c.id = ANY($4::uuid[])`,
+					[orgId, entityId, PAYLOAD, ids],
+				)
+				const result = await client.query<{ count: string; orgs: string }>(
+					`SELECT count(*)::text AS count,
+					        count(DISTINCT organization_id)::text AS orgs
+					 FROM timeline_activity WHERE entity_id = $1::uuid`,
+					[entityId],
+				)
+				return result.rows[0]
+			})
+
+			expect(Number(rows?.count)).toBeGreaterThan(0)
+			expect(rows?.orgs).toBe('1')
+		})
+	})
+})

--- a/apps/mail-worker/src/bounces.ts
+++ b/apps/mail-worker/src/bounces.ts
@@ -139,11 +139,10 @@ export const parseBounce = (mail: ParsedMail): ParsedBounce | null => {
 // persisted by the regular inbound path so users see "Mail Delivery
 // Subsystem" as a normal entry in the inbox list.
 //
-// Org isolation: the email_messages match is org-scoped, and the channel
-// update narrows to this org explicitly (contact_channels carries
-// organization_id); timeline_activity has no org column, gated transitively
-// by the contacts it references. Only recipients of an email *we sent from
-// this org* get touched.
+// Org isolation: every statement here names this org explicitly — the
+// email_messages match, the contact_channels update, and the timeline_activity
+// insert, which writes the org onto each row. Only recipients of an email
+// *we sent from this org* get touched.
 export const applyBounce = (args: {
 	readonly organizationId: string
 	readonly bounce: ParsedBounce
@@ -223,10 +222,10 @@ export const applyBounce = (args: {
 		if (updatedContacts.length > 0) {
 			yield* sql`
 				INSERT INTO timeline_activity (
-					kind, entity_type, entity_id, company_id, contact_id,
+					organization_id, kind, entity_type, entity_id, company_id, contact_id,
 					channel, direction, occurred_at, payload
 				)
-				SELECT 'email_bounced', 'email_message', ${originalId}::uuid,
+				SELECT ${organizationId}, 'email_bounced', 'email_message', ${originalId}::uuid,
 				       c.company_id, c.id,
 				       'email', 'outbound', now(), ${payload}::jsonb
 				FROM contacts c
@@ -235,11 +234,11 @@ export const applyBounce = (args: {
 		} else {
 			yield* sql`
 				INSERT INTO timeline_activity (
-					kind, entity_type, entity_id,
+					organization_id, kind, entity_type, entity_id,
 					channel, direction, occurred_at, payload
 				)
 				VALUES (
-					'email_bounced', 'email_message', ${originalId}::uuid,
+					${organizationId}, 'email_bounced', 'email_message', ${originalId}::uuid,
 					'email', 'outbound', now(), ${payload}::jsonb
 				)
 			`

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -150,13 +150,17 @@ export const persistInboundMessage = (args: {
 		// `(organization_id, external_thread_id)` index. The DO UPDATE
 		// clause deliberately leaves `company_id`/`contact_id` alone —
 		// the first message on a thread sets the link, later messages
-		// from a different sender don't re-home the whole thread.
-		yield* sql`
+		// from a different sender don't re-home the whole thread. The id comes
+		// back so the history entry can point at the conversation this message
+		// belongs to.
+		const threadLinks = yield* sql<{ id: string }>`
 			INSERT INTO email_thread_links (organization_id, inbox_id, external_thread_id, company_id, contact_id, updated_at)
 			VALUES (${args.organizationId}, ${args.inboxId}, ${externalThreadId}, ${companyId}, ${contactId}, now())
 			ON CONFLICT (organization_id, external_thread_id)
 			DO UPDATE SET updated_at = now()
+			RETURNING id
 		`
+		const threadLinkId = threadLinks[0]?.id ?? null
 
 		// `idx_email_messages_imap_dedupe` makes the (inbox_id,
 		// uidvalidity, uid) tuple unique, so re-fetches of the same UID
@@ -248,6 +252,7 @@ export const persistInboundMessage = (args: {
 					${JSON.stringify({
 						subject: args.parsed.subject,
 						classification: 'normal',
+						threadLinkId,
 					})}::jsonb
 				)
 			`

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -229,5 +229,40 @@ export const persistInboundMessage = (args: {
 			`
 		}
 
+		// Put the reply on the company's history, so the timeline shows what
+		// they answered and not only what we sent. Skipped when the sender
+		// matched no company: the history is read one company at a time, and
+		// a thread that starts unmatched is never re-homed, so nobody could
+		// ever reach such a row. The message itself is still stored.
+		if (companyId) {
+			yield* sql`
+				INSERT INTO timeline_activity (
+					organization_id, kind, entity_type, entity_id, company_id, contact_id,
+					channel, direction, occurred_at, summary, payload
+				)
+				VALUES (
+					${args.organizationId}, 'email_received', 'email_message',
+					${messageDbId}::uuid, ${companyId}, ${contactId},
+					'email', 'inbound', ${args.parsed.receivedAt},
+					${args.parsed.textPreview},
+					${JSON.stringify({
+						subject: args.parsed.subject,
+						classification: 'normal',
+					})}::jsonb
+				)
+			`
+
+			// The company page reads these dates as stored values rather than
+			// working them out on the fly, so an arriving reply has to move
+			// them here or the page keeps showing the older outbound date.
+			yield* sql`
+				UPDATE companies SET
+					last_email_at = GREATEST(last_email_at, ${args.parsed.receivedAt}),
+					last_contacted_at = GREATEST(last_contacted_at, ${args.parsed.receivedAt}),
+					updated_at = now()
+				WHERE id = ${companyId}
+			`
+		}
+
 		return { messageId: messageDbId }
 	})

--- a/apps/server/src/handlers/calendar.ts
+++ b/apps/server/src/handlers/calendar.ts
@@ -13,7 +13,11 @@ import {
 	NotFound,
 	SessionContext,
 } from '@batuda/controllers'
-import { CalendarEvent, CalendarEventType } from '@batuda/domain'
+import {
+	CalendarEvent,
+	CalendarEventAttendee,
+	CalendarEventType,
+} from '@batuda/domain'
 
 import { resolvePageTotal } from '../lib/sql-pagination'
 import { dispatchRsvpReply } from '../services/calendar-rsvp-dispatch.js'
@@ -23,6 +27,9 @@ const decodeEventTypes = Schema.decodeUnknownEffect(
 )
 const decodeEvent = Schema.decodeUnknownEffect(CalendarEvent)
 const decodeEvents = Schema.decodeUnknownEffect(Schema.Array(CalendarEvent))
+const decodeAttendees = Schema.decodeUnknownEffect(
+	Schema.Array(CalendarEventAttendee),
+)
 // The provider hands back Date slots; read them into DateTime.Utc so the
 // `Slot` wire schema re-encodes them as ISO strings.
 const SlotRow = Schema.Struct({
@@ -44,6 +51,37 @@ type EventRow = {
 
 const cacheKey = (eventTypeId: string, from: string, to: string) =>
 	`${eventTypeId}|${from}|${to}`
+
+// Attendees for a whole page of events in one query, grouped in memory, so a
+// page of meetings doesn't turn into a query per meeting. The organizer sorts
+// first so the caller can show who called the meeting without scanning.
+const attendeesByEvent = (
+	sql: SqlClient.SqlClient,
+	eventIds: ReadonlyArray<string>,
+) =>
+	Effect.gen(function* () {
+		const grouped = new Map<string, Array<CalendarEventAttendee>>()
+		if (eventIds.length === 0) return grouped
+
+		// Result keys arrive camelCased whatever the column spelling, hence
+		// `eventId` rather than `event_id`.
+		const rows = yield* sql<{ readonly eventId: string }>`
+			SELECT id, event_id, email, name, contact_id, company_id, rsvp, is_organizer
+			FROM calendar_event_attendees
+			WHERE event_id = ANY(${eventIds as unknown as string[]})
+			ORDER BY is_organizer DESC, email ASC
+		`
+		// The decoded attendee carries no event of its own, so the raw row at
+		// the same position supplies which meeting it belongs to.
+		const decoded = yield* decodeAttendees(rows)
+		for (const [index, attendee] of decoded.entries()) {
+			const eventId = rows[index]!.eventId
+			const bucket = grouped.get(eventId)
+			if (bucket) bucket.push(attendee)
+			else grouped.set(eventId, [attendee])
+		}
+		return grouped
+	})
 
 export const CalendarLive = HttpApiBuilder.group(
 	BatudaApi,
@@ -133,7 +171,19 @@ export const CalendarLive = HttpApiBuilder.group(
 							`,
 						)
 						const items = yield* decodeEvents(rows)
-						return { items, total, limit, offset }
+						const attendees = yield* attendeesByEvent(
+							sql,
+							items.map(event => event.id),
+						)
+						return {
+							items: items.map(event => ({
+								...event,
+								attendees: attendees.get(event.id) ?? [],
+							})),
+							total,
+							limit,
+							offset,
+						}
 					}).pipe(Effect.orDie),
 				)
 				.handle('getEvent', _ =>
@@ -146,7 +196,9 @@ export const CalendarLive = HttpApiBuilder.group(
 								entity: 'calendar_event',
 								id: _.params.id,
 							})
-						return yield* decodeEvent(rows[0])
+						const event = yield* decodeEvent(rows[0])
+						const attendees = yield* attendeesByEvent(sql, [event.id])
+						return { ...event, attendees: attendees.get(event.id) ?? [] }
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),

--- a/apps/server/src/handlers/calendar.ts
+++ b/apps/server/src/handlers/calendar.ts
@@ -13,12 +13,9 @@ import {
 	NotFound,
 	SessionContext,
 } from '@batuda/controllers'
-import {
-	CalendarEvent,
-	CalendarEventAttendee,
-	CalendarEventType,
-} from '@batuda/domain'
+import { CalendarEvent, CalendarEventType } from '@batuda/domain'
 
+import { withAttendees } from '../lib/calendar-attendees'
 import { resolvePageTotal } from '../lib/sql-pagination'
 import { dispatchRsvpReply } from '../services/calendar-rsvp-dispatch.js'
 
@@ -27,9 +24,6 @@ const decodeEventTypes = Schema.decodeUnknownEffect(
 )
 const decodeEvent = Schema.decodeUnknownEffect(CalendarEvent)
 const decodeEvents = Schema.decodeUnknownEffect(Schema.Array(CalendarEvent))
-const decodeAttendees = Schema.decodeUnknownEffect(
-	Schema.Array(CalendarEventAttendee),
-)
 // The provider hands back Date slots; read them into DateTime.Utc so the
 // `Slot` wire schema re-encodes them as ISO strings.
 const SlotRow = Schema.Struct({
@@ -51,37 +45,6 @@ type EventRow = {
 
 const cacheKey = (eventTypeId: string, from: string, to: string) =>
 	`${eventTypeId}|${from}|${to}`
-
-// Attendees for a whole page of events in one query, grouped in memory, so a
-// page of meetings doesn't turn into a query per meeting. The organizer sorts
-// first so the caller can show who called the meeting without scanning.
-const attendeesByEvent = (
-	sql: SqlClient.SqlClient,
-	eventIds: ReadonlyArray<string>,
-) =>
-	Effect.gen(function* () {
-		const grouped = new Map<string, Array<CalendarEventAttendee>>()
-		if (eventIds.length === 0) return grouped
-
-		// Result keys arrive camelCased whatever the column spelling, hence
-		// `eventId` rather than `event_id`.
-		const rows = yield* sql<{ readonly eventId: string }>`
-			SELECT id, event_id, email, name, contact_id, company_id, rsvp, is_organizer
-			FROM calendar_event_attendees
-			WHERE event_id = ANY(${eventIds as unknown as string[]})
-			ORDER BY is_organizer DESC, email ASC
-		`
-		// The decoded attendee carries no event of its own, so the raw row at
-		// the same position supplies which meeting it belongs to.
-		const decoded = yield* decodeAttendees(rows)
-		for (const [index, attendee] of decoded.entries()) {
-			const eventId = rows[index]!.eventId
-			const bucket = grouped.get(eventId)
-			if (bucket) bucket.push(attendee)
-			else grouped.set(eventId, [attendee])
-		}
-		return grouped
-	})
 
 export const CalendarLive = HttpApiBuilder.group(
 	BatudaApi,
@@ -170,20 +133,8 @@ export const CalendarLive = HttpApiBuilder.group(
 								${whereClause}
 							`,
 						)
-						const items = yield* decodeEvents(rows)
-						const attendees = yield* attendeesByEvent(
-							sql,
-							items.map(event => event.id),
-						)
-						return {
-							items: items.map(event => ({
-								...event,
-								attendees: attendees.get(event.id) ?? [],
-							})),
-							total,
-							limit,
-							offset,
-						}
+						const items = yield* withAttendees(sql, yield* decodeEvents(rows))
+						return { items, total, limit, offset }
 					}).pipe(Effect.orDie),
 				)
 				.handle('getEvent', _ =>
@@ -196,9 +147,10 @@ export const CalendarLive = HttpApiBuilder.group(
 								entity: 'calendar_event',
 								id: _.params.id,
 							})
-						const event = yield* decodeEvent(rows[0])
-						const attendees = yield* attendeesByEvent(sql, [event.id])
-						return { ...event, attendees: attendees.get(event.id) ?? [] }
+						const [event] = yield* withAttendees(sql, [
+							yield* decodeEvent(rows[0]),
+						])
+						return event!
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),

--- a/apps/server/src/lib/calendar-attendees.ts
+++ b/apps/server/src/lib/calendar-attendees.ts
@@ -1,0 +1,58 @@
+import { Effect, Schema } from 'effect'
+import type { SqlClient } from 'effect/unstable/sql'
+
+import { CalendarEventAttendee } from '@batuda/domain'
+
+const decodeAttendees = Schema.decodeUnknownEffect(
+	Schema.Array(CalendarEventAttendee),
+)
+
+/**
+ * Attendees for a page of events in one query, grouped in memory so a page of
+ * meetings doesn't turn into a query per meeting. The organizer sorts first so
+ * a caller can name who called the meeting without scanning the whole list.
+ */
+const attendeesByEvent = (
+	sql: SqlClient.SqlClient,
+	eventIds: ReadonlyArray<string>,
+) =>
+	Effect.gen(function* () {
+		const grouped = new Map<string, Array<CalendarEventAttendee>>()
+		if (eventIds.length === 0) return grouped
+
+		// Result keys arrive camelCased whatever the column spelling, hence
+		// `eventId` rather than `event_id`.
+		const rows = yield* sql<{ readonly eventId: string }>`
+			SELECT id, event_id, email, name, contact_id, company_id, rsvp, is_organizer
+			FROM calendar_event_attendees
+			WHERE event_id = ANY(${eventIds as unknown as string[]})
+			ORDER BY is_organizer DESC, email ASC
+		`
+		// The decoded attendee carries no event of its own, so the raw row at
+		// the same position supplies which meeting it belongs to.
+		const decoded = yield* decodeAttendees(rows)
+		for (const [index, attendee] of decoded.entries()) {
+			const eventId = rows[index]!.eventId
+			const bucket = grouped.get(eventId)
+			if (bucket) bucket.push(attendee)
+			else grouped.set(eventId, [attendee])
+		}
+		return grouped
+	})
+
+/** Attach each event's attendees, keyed by the event's own id. */
+export const withAttendees = <E extends { readonly id: string }>(
+	sql: SqlClient.SqlClient,
+	events: ReadonlyArray<E>,
+) =>
+	attendeesByEvent(
+		sql,
+		events.map(event => event.id),
+	).pipe(
+		Effect.map(grouped =>
+			events.map(event => ({
+				...event,
+				attendees: grouped.get(event.id) ?? [],
+			})),
+		),
+	)

--- a/apps/server/src/mcp/tools/calendar.ts
+++ b/apps/server/src/mcp/tools/calendar.ts
@@ -6,6 +6,7 @@ import { SqlClient } from 'effect/unstable/sql'
 import { CurrentOrg, SessionContext, Slot } from '@batuda/controllers'
 import { CalendarEvent, CalendarEventType } from '@batuda/domain'
 
+import { withAttendees } from '../../lib/calendar-attendees'
 import { CalendarService } from '../../services/calendar'
 import { dispatchForwardInvitation } from '../../services/calendar-forward-dispatch'
 import { dispatchRsvpReply } from '../../services/calendar-rsvp-dispatch'
@@ -426,7 +427,7 @@ export const CalendarHandlersLive = CalendarTools.toLayer(
 						ORDER BY start_at ASC
 						LIMIT ${limit}
 					`
-					return toItems(yield* decodeEvents(rows))
+					return toItems(yield* withAttendees(sql, yield* decodeEvents(rows)))
 				}).pipe(Effect.orDie),
 			list_event_types: params =>
 				Effect.gen(function* () {
@@ -446,7 +447,10 @@ export const CalendarHandlersLive = CalendarTools.toLayer(
 						yield* sql`SELECT * FROM calendar_events WHERE id = ${id} LIMIT 1`
 					if (rows.length === 0)
 						return yield* Effect.die(`Calendar event ${id} not found`)
-					return yield* decodeEvent(rows[0])
+					const [event] = yield* withAttendees(sql, [
+						yield* decodeEvent(rows[0]),
+					])
+					return event!
 				}).pipe(Effect.orDie),
 			create_internal_block: params =>
 				svc

--- a/apps/server/src/services/calendar-event-upsert.integration.test.ts
+++ b/apps/server/src/services/calendar-event-upsert.integration.test.ts
@@ -1,0 +1,232 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to
+// the docker-compose service so the suite runs without a loaded .env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// SQL-contract test for the calendar_events upsert that
+// `apps/server/src/services/calendar.ts` runs when a booking arrives from
+// cal.com and when an invitation arrives by email.
+//
+// An invitation carries an id (`ical_uid`) that is only unique per
+// organization, so the same invitation can legitimately reach two of them.
+// The table enforces that with a two-column unique index, and an upsert has
+// to name both columns for Postgres to accept it. Naming only `ical_uid`
+// fails every write — which is why the broken shape is pinned here too.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL =
+	process.env['DATABASE_URL'] ??
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+describe('calendar_events upsert — conflict-target contract', () => {
+	let pool: pg.Pool
+	let orgId: string
+	const seededIcalUids: string[] = []
+
+	beforeAll(async () => {
+		pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+		await pool.query('GRANT app_user TO CURRENT_USER')
+
+		const orgs = await pool.query<{ id: string }>(
+			`SELECT id FROM organization WHERE slug = $1 LIMIT 1`,
+			['taller'],
+		)
+		const oid = orgs.rows[0]?.id
+		if (!oid) {
+			throw new Error(
+				"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
+			)
+		}
+		orgId = oid
+	})
+
+	afterAll(async () => {
+		for (const uid of seededIcalUids) {
+			await pool.query(`DELETE FROM calendar_events WHERE ical_uid = $1`, [uid])
+		}
+		await pool.end()
+	})
+
+	const withOrgScope = async <T>(
+		body: (client: pg.PoolClient) => Promise<T>,
+	): Promise<T> => {
+		const client = await pool.connect()
+		try {
+			await client.query('BEGIN')
+			await client.query('SET LOCAL ROLE app_user')
+			await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [
+				orgId,
+			])
+			const result = await body(client)
+			await client.query('COMMIT')
+			return result
+		} catch (err) {
+			await client.query('ROLLBACK')
+			throw err
+		} finally {
+			client.release()
+		}
+	}
+
+	const upsert = (
+		client: pg.PoolClient,
+		conflictTarget: string,
+		values: {
+			readonly icalUid: string
+			readonly sequence: number
+			readonly title: string
+		},
+	) =>
+		client.query(
+			`INSERT INTO calendar_events (
+				organization_id, source, provider, provider_booking_id,
+				ical_uid, ical_sequence, start_at, end_at, status,
+				title, location_type, organizer_email
+			) VALUES (
+				$1, 'booking', 'calcom', 'bk-' || $2,
+				$2, $3, now(), now() + interval '30 minutes', 'confirmed',
+				$4, 'video', 'organizer@taller.cat'
+			)
+			ON CONFLICT (${conflictTarget}) DO UPDATE SET
+				title = EXCLUDED.title,
+				ical_sequence = EXCLUDED.ical_sequence
+			WHERE calendar_events.ical_sequence <= EXCLUDED.ical_sequence`,
+			[orgId, values.icalUid, values.sequence, values.title],
+		)
+
+	describe('when the conflict target names both columns of the unique index', () => {
+		it('should store the invitation and update it when it is sent again', async () => {
+			// GIVEN an invitation that has not been seen before
+			// WHEN it is written, then sent again with a higher sequence
+			// THEN one row exists carrying the newer title
+			const icalUid = `contract-${randomUUID()}@calendar.batuda`
+			seededIcalUids.push(icalUid)
+
+			const stored = await withOrgScope(async client => {
+				await upsert(client, 'organization_id, ical_uid', {
+					icalUid,
+					sequence: 0,
+					title: 'First send',
+				})
+				await upsert(client, 'organization_id, ical_uid', {
+					icalUid,
+					sequence: 3,
+					title: 'Moved to Thursday',
+				})
+				const result = await client.query<{
+					count: string
+					title: string
+					ical_sequence: number
+				}>(
+					`SELECT count(*)::text AS count, max(title) AS title,
+					        max(ical_sequence) AS ical_sequence
+					 FROM calendar_events WHERE ical_uid = $1`,
+					[icalUid],
+				)
+				return result.rows[0]
+			})
+
+			expect(stored?.count).toBe('1')
+			expect(stored?.title).toBe('Moved to Thursday')
+			expect(stored?.ical_sequence).toBe(3)
+		})
+
+		it('should ignore a re-send that is older than what is stored', async () => {
+			// GIVEN an invitation already updated to sequence 3
+			// WHEN an out-of-order copy arrives carrying sequence 1
+			// THEN the stored row keeps the newer title
+			const icalUid = `contract-${randomUUID()}@calendar.batuda`
+			seededIcalUids.push(icalUid)
+
+			const stored = await withOrgScope(async client => {
+				await upsert(client, 'organization_id, ical_uid', {
+					icalUid,
+					sequence: 3,
+					title: 'Current',
+				})
+				await upsert(client, 'organization_id, ical_uid', {
+					icalUid,
+					sequence: 1,
+					title: 'Stale copy',
+				})
+				const result = await client.query<{ title: string }>(
+					`SELECT title FROM calendar_events WHERE ical_uid = $1`,
+					[icalUid],
+				)
+				return result.rows[0]
+			})
+
+			expect(stored?.title).toBe('Current')
+		})
+	})
+
+	describe('when the conflict target names only ical_uid', () => {
+		it('should be rejected because no unique index covers that column alone', async () => {
+			// GIVEN a conflict target of just `ical_uid`
+			// WHEN the upsert runs
+			// THEN Postgres refuses it, because the table is unique on
+			//      (organization_id, ical_uid) and a conflict target has to
+			//      match an index exactly. Every booking and emailed
+			//      invitation fails this way, so the shape stays pinned.
+			const icalUid = `contract-${randomUUID()}@calendar.batuda`
+
+			await expect(
+				withOrgScope(client =>
+					upsert(client, 'ical_uid', {
+						icalUid,
+						sequence: 0,
+						title: 'Never stored',
+					}),
+				),
+			).rejects.toThrow(/no unique or exclusion constraint matching/i)
+		})
+	})
+
+	describe('when the same invitation reaches two organizations', () => {
+		it('should keep a separate row for each one', async () => {
+			// GIVEN one invitation id used by two different organizations
+			// WHEN each is written
+			// THEN both survive — the pair, not the id alone, is what is unique
+			const icalUid = `contract-${randomUUID()}@calendar.batuda`
+			seededIcalUids.push(icalUid)
+
+			const otherOrg = await pool.query<{ id: string }>(
+				`SELECT id FROM organization WHERE id <> $1 LIMIT 1`,
+				[orgId],
+			)
+			const otherOrgId = otherOrg.rows[0]?.id
+			if (!otherOrgId) {
+				throw new Error('a second organization is required — reseed first')
+			}
+
+			// Written with the owner's privileges: each row belongs to a
+			// different organization, and one scoped session may only see its own.
+			await pool.query(
+				`INSERT INTO calendar_events (
+					organization_id, source, provider, provider_booking_id,
+					ical_uid, ical_sequence, start_at, end_at, status,
+					title, location_type, organizer_email
+				)
+				SELECT o, 'booking', 'calcom', 'bk-' || $3,
+				       $3, 0, now(), now() + interval '30 minutes', 'confirmed',
+				       'Shared invitation', 'video', 'organizer@taller.cat'
+				FROM unnest(ARRAY[$1::text, $2::text]) AS o
+				ON CONFLICT (organization_id, ical_uid) DO UPDATE SET
+					title = EXCLUDED.title`,
+				[orgId, otherOrgId, icalUid],
+			)
+
+			const rows = await pool.query<{ count: string }>(
+				`SELECT count(*)::text AS count FROM calendar_events WHERE ical_uid = $1`,
+				[icalUid],
+			)
+			expect(rows.rows[0]?.count).toBe('2')
+		})
+	})
+})

--- a/apps/server/src/services/calendar.test.ts
+++ b/apps/server/src/services/calendar.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+
 import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
@@ -85,3 +87,50 @@ describe('decodeCalcomWebhookEnvelope', () => {
 // routing, denorm-bump correctness) live outside this file. The calendar
 // multi-org slice is its own plan; cover those branches when a real bug
 // surfaces or when the calendar slice lands its own integration tests.
+
+// The statements below are read from the source rather than executed. Both
+// matter: running them proves what the database accepts, reading them proves
+// this file still asks for it. Naming the wrong column here stops every booking
+// and emailed invitation from saving, and the ingest path is stubbed wherever
+// it is otherwise tested, so nothing else would notice.
+const calendarSource = readFileSync(
+	new URL('./calendar.ts', import.meta.url),
+	'utf8',
+)
+
+describe('calendar_events upserts in this file', () => {
+	describe('when an invitation is stored or updated', () => {
+		it('should match on the organization together with the invitation id', () => {
+			// GIVEN every upsert this file runs against calendar_events
+			// WHEN their conflict targets are read out of the source
+			// THEN each names both columns, because the table treats an
+			//      invitation as unique only within one organization and
+			//      Postgres refuses a target that doesn't match an index
+			const targets = [
+				...calendarSource.matchAll(/ON CONFLICT \(([^)]*ical_uid[^)]*)\)/g),
+			].map(match => match[1]?.replace(/\s+/g, ' ').trim())
+
+			expect(targets.length).toBeGreaterThan(0)
+			for (const target of targets) {
+				expect(target).toBe('organization_id, ical_uid')
+			}
+		})
+
+		it('should keep an out-of-order copy from overwriting a newer one', () => {
+			// GIVEN the same upserts
+			// WHEN their update guards are read
+			// THEN each still refuses a copy older than what is stored, so a
+			//      late-arriving invitation cannot undo a reschedule
+			const guards = [
+				...calendarSource.matchAll(
+					/ON CONFLICT \([^)]*ical_uid[^)]*\)[\s\S]*?WHERE\s+calendar_events\.ical_sequence\s*<=\s*EXCLUDED\.ical_sequence/g,
+				),
+			]
+			const targets = [
+				...calendarSource.matchAll(/ON CONFLICT \([^)]*ical_uid[^)]*\)/g),
+			]
+
+			expect(guards.length).toBe(targets.length)
+		})
+	})
+})

--- a/apps/server/src/services/calendar.ts
+++ b/apps/server/src/services/calendar.ts
@@ -376,7 +376,9 @@ export class CalendarService extends Context.Service<CalendarService>()(
 							metadata: args.metadata ? JSON.stringify(args.metadata) : null,
 							rawIcs: null,
 						})}
-					ON CONFLICT (ical_uid) DO UPDATE SET
+					-- The same invitation can reach two orgs, so an event is unique
+					-- per org and the conflict target names both columns.
+					ON CONFLICT (organization_id, ical_uid) DO UPDATE SET
 						ical_sequence = EXCLUDED.ical_sequence,
 						provider_booking_id = EXCLUDED.provider_booking_id,
 						provider = EXCLUDED.provider,
@@ -796,7 +798,9 @@ export class CalendarService extends Context.Service<CalendarService>()(
 								}),
 								rawIcs,
 							})}
-							ON CONFLICT (ical_uid) DO UPDATE SET
+							-- The same invitation can reach two orgs, so an event is
+							-- unique per org and the conflict target names both columns.
+							ON CONFLICT (organization_id, ical_uid) DO UPDATE SET
 								ical_sequence = EXCLUDED.ical_sequence,
 								start_at = EXCLUDED.start_at,
 								end_at = EXCLUDED.end_at,

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -837,17 +837,22 @@ export class EmailService extends Context.Service<EmailService>()(
 							let inReplyTo: string | null
 							let referencesArr: string[]
 
+							// Both branches below supply this so the history entry can
+							// link back to the conversation this message belongs to.
+							let threadLinkId: string | null
+
 							if (args.existingThreadLink) {
 								// Reply: reuse the link's root id, append it to References.
 								externalThreadId = args.existingThreadLink.externalThreadId
 								inReplyTo = args.existingThreadLink.externalThreadId
 								referencesArr = [args.existingThreadLink.externalThreadId]
+								threadLinkId = args.existingThreadLink.id
 							} else {
 								// Brand-new thread: provider's threadId IS the root msg id.
 								externalThreadId = args.result.threadId
 								inReplyTo = null
 								referencesArr = []
-								yield* sql`
+								const linkRows = yield* sql<{ id: string }>`
 									INSERT INTO email_thread_links ${sql.insert({
 										organizationId: currentOrg.id,
 										externalThreadId,
@@ -857,7 +862,9 @@ export class EmailService extends Context.Service<EmailService>()(
 										subject: args.subject,
 										status: 'open',
 									})}
+									RETURNING id
 								`
+								threadLinkId = linkRows[0]?.id ?? null
 							}
 
 							const sentAt = DateTime.toDateUtc(DateTime.nowUnsafe())
@@ -923,6 +930,7 @@ export class EmailService extends Context.Service<EmailService>()(
 										contactId: args.contactId,
 										subject: args.subject,
 										summary: null,
+										threadLinkId,
 										actorUserId: null,
 										occurredAt: sentAt,
 									}),

--- a/apps/server/src/services/timeline-activity.integration.test.ts
+++ b/apps/server/src/services/timeline-activity.integration.test.ts
@@ -145,6 +145,7 @@ describe('TimelineActivityService.record cadence denorm', () => {
 					contactId: null,
 					subject: 'cadence',
 					summary: null,
+					threadLinkId: null,
 					actorUserId: null,
 					occurredAt,
 				})

--- a/apps/server/src/services/timeline-activity.test.ts
+++ b/apps/server/src/services/timeline-activity.test.ts
@@ -6,6 +6,7 @@ import {
 	EmailReceived,
 	EmailSent,
 	InteractionLogged,
+	kindForInteractionChannel,
 	MeetingCancelled,
 	MeetingRescheduled,
 	MeetingRsvp,
@@ -646,5 +647,68 @@ describe('mapEventToInteraction', () => {
 				}),
 			),
 		).toBeNull()
+	})
+})
+
+describe('kindForInteractionChannel', () => {
+	describe('when the touchpoint was a phone call', () => {
+		it('should mark it as a call', () => {
+			// GIVEN the two spellings the interaction row uses for a call
+			// WHEN each is classified
+			// THEN both keep the call-specific kind
+			expect(kindForInteractionChannel('phone')).toBe('call_logged')
+			expect(kindForInteractionChannel('call')).toBe('call_logged')
+		})
+	})
+
+	describe('when the touchpoint came through any other channel', () => {
+		it('should mark it as a logged interaction, whatever the channel', () => {
+			// GIVEN every other channel someone can pick when logging a touchpoint
+			// WHEN each is classified
+			// THEN all share one kind — which channel it was is kept on the row
+			//      itself, so supporting a new one needs no new kind here
+			for (const channel of [
+				'email',
+				'visit',
+				'linkedin',
+				'instagram',
+				'whatsapp',
+				'event',
+				'other',
+			]) {
+				expect(kindForInteractionChannel(channel)).toBe('interaction_logged')
+			}
+		})
+
+		it('should still classify a channel it has never seen', () => {
+			// GIVEN a channel added to the product later, or an empty string
+			// WHEN it is classified
+			// THEN it lands in the history rather than a bucket the page hides
+			expect(kindForInteractionChannel('telegram')).toBe('interaction_logged')
+			expect(kindForInteractionChannel('')).toBe('interaction_logged')
+		})
+	})
+
+	describe('when classifying any channel at all', () => {
+		it('should never route a hand-logged touchpoint to the hidden bucket', () => {
+			// GIVEN the bucket the company page hides by default, meant for
+			//       bookkeeping the app does to itself
+			// WHEN any channel someone could log is classified
+			// THEN none of them land there — a note written by hand is not noise
+			for (const channel of [
+				'phone',
+				'call',
+				'email',
+				'visit',
+				'linkedin',
+				'instagram',
+				'whatsapp',
+				'event',
+				'other',
+				'',
+			]) {
+				expect(kindForInteractionChannel(channel)).not.toBe('system_event')
+			}
+		})
 	})
 })

--- a/apps/server/src/services/timeline-activity.test.ts
+++ b/apps/server/src/services/timeline-activity.test.ts
@@ -33,6 +33,7 @@ const emailSent = () =>
 		contactId: 'ct-1',
 		subject: 'Hello',
 		summary: null,
+		threadLinkId: null,
 		actorUserId: null,
 		occurredAt: at,
 	})

--- a/apps/server/src/services/timeline-activity.ts
+++ b/apps/server/src/services/timeline-activity.ts
@@ -2,6 +2,11 @@ import { Context, Data, DateTime, Effect, Layer } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
+import type {
+	TimelineDirection,
+	TimelineEntityType,
+	TimelineKind,
+} from '@batuda/domain'
 
 export class EmailSent extends Data.TaggedClass('EmailSent')<{
 	readonly emailMessageId: string
@@ -241,39 +246,9 @@ export const needsNextMeetingRecompute = (event: TimelineEvent): boolean =>
 	event._tag === 'MeetingRescheduled' ||
 	event._tag === 'MeetingCancelled'
 
-type TimelineKind =
-	| 'email_sent'
-	| 'email_received'
-	| 'call_logged'
-	| 'document_created'
-	| 'proposal_sent'
-	| 'proposal_viewed'
-	| 'proposal_responded'
-	| 'research_run'
-	| 'research_applied'
-	| 'system_event'
-	| 'stage_changed'
-	| 'meeting_scheduled'
-	| 'meeting_rescheduled'
-	| 'meeting_cancelled'
-	| 'meeting_rsvp'
-	| 'task_created'
-	| 'task_updated'
-	| 'task_completed'
-
-type TimelineEntityType =
-	| 'email_message'
-	| 'interaction'
-	| 'call_recording'
-	| 'document'
-	| 'proposal'
-	| 'research_run'
-	| 'system'
-	| 'calendar_event'
-	| 'task'
-
-type TimelineDirection = 'inbound' | 'outbound'
-
+// The shared schema holds the one list of allowed kinds and entity types: a
+// row written with a value it doesn't know fails to decode for everyone
+// reading that company's history.
 interface TimelineRowBase {
 	kind: TimelineKind
 	entityType: TimelineEntityType
@@ -287,10 +262,12 @@ interface TimelineRowBase {
 	payload: Record<string, unknown>
 }
 
-const kindForInteractionChannel = (channel: string): TimelineKind => {
-	if (channel === 'phone' || channel === 'call') return 'call_logged'
-	return 'system_event'
-}
+// Only calls get a kind of their own; every other channel is named in the
+// row's `channel` column, so adding one never needs a new kind here.
+export const kindForInteractionChannel = (channel: string): TimelineKind =>
+	channel === 'phone' || channel === 'call'
+		? 'call_logged'
+		: 'interaction_logged'
 
 const rowBase = (event: TimelineEvent): TimelineRowBase => {
 	switch (event._tag) {

--- a/apps/server/src/services/timeline-activity.ts
+++ b/apps/server/src/services/timeline-activity.ts
@@ -14,6 +14,9 @@ export class EmailSent extends Data.TaggedClass('EmailSent')<{
 	readonly contactId: string | null
 	readonly subject: string | null
 	readonly summary: string | null
+	// The conversation this message belongs to, so the history entry can
+	// open it.
+	readonly threadLinkId: string | null
 	readonly actorUserId: string | null
 	readonly occurredAt: Date
 }> {}
@@ -282,7 +285,7 @@ const rowBase = (event: TimelineEvent): TimelineRowBase => {
 				actorUserId: event.actorUserId,
 				occurredAt: event.occurredAt,
 				summary: event.summary,
-				payload: { subject: event.subject },
+				payload: { subject: event.subject, threadLinkId: event.threadLinkId },
 			}
 		case 'EmailReceived':
 			return {

--- a/packages/controllers/src/routes/calendar.ts
+++ b/packages/controllers/src/routes/calendar.ts
@@ -6,7 +6,11 @@ import {
 } from 'effect/unstable/httpapi'
 
 import { CalendarLocationType } from '@batuda/calendar'
-import { CalendarEvent, CalendarEventType } from '@batuda/domain'
+import {
+	CalendarEvent,
+	CalendarEventAttendee,
+	CalendarEventType,
+} from '@batuda/domain'
 
 import { BadRequest, Conflict, Forbidden, NotFound } from '../errors'
 import { OrgMiddleware } from '../middleware/org'
@@ -18,6 +22,14 @@ import { PaginatedList } from '../pagination'
 export const Slot = Schema.Struct({
 	start: Schema.DateTimeUtcFromString,
 	end: Schema.DateTimeUtcFromString,
+})
+
+// An event plus the people invited to it. Preparing for a meeting starts with
+// who will be in the room, so both the list and the detail endpoint carry the
+// guests alongside the event's own columns.
+export const CalendarEventWithAttendees = Schema.Struct({
+	...CalendarEvent.json.fields,
+	attendees: Schema.Array(CalendarEventAttendee.json),
 })
 
 // ── Input schemas ──
@@ -73,13 +85,13 @@ export const CalendarGroup = HttpApiGroup.make('calendar')
 				limit: Schema.optional(Schema.NumberFromString),
 				offset: Schema.optional(Schema.NumberFromString),
 			},
-			success: PaginatedList(CalendarEvent.json),
+			success: PaginatedList(CalendarEventWithAttendees),
 		}),
 	)
 	.add(
 		HttpApiEndpoint.get('getEvent', '/calendar/events/:id', {
 			params: { id: Schema.String },
-			success: CalendarEvent.json,
+			success: CalendarEventWithAttendees,
 			error: NotFound.pipe(HttpApiSchema.status(404)),
 		}),
 	)

--- a/packages/domain/src/schema/calendar-events.ts
+++ b/packages/domain/src/schema/calendar-events.ts
@@ -63,3 +63,19 @@ export class CalendarEvent extends Model.Class<CalendarEvent>('CalendarEvent')({
 	createdAt: Model.DateTimeInsertFromDate,
 	updatedAt: Model.DateTimeUpdateFromDate,
 }) {}
+
+// Someone invited to an event. `contactId` is null when the address matches
+// nobody we know — which is exactly the person worth looking up before the
+// meeting, so the wire carries the null rather than dropping the row.
+export class CalendarEventAttendee extends Model.Class<CalendarEventAttendee>(
+	'CalendarEventAttendee',
+)({
+	id: Model.GeneratedByDb(Schema.String),
+	email: Schema.String,
+	name: Schema.NullOr(Schema.String),
+	contactId: Schema.NullOr(Schema.String),
+	companyId: Schema.NullOr(Schema.String),
+	rsvp: Schema.String,
+	// values: needs-action | accepted | declined | tentative
+	isOrganizer: Schema.Boolean,
+}) {}

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -2,6 +2,7 @@ export { DbNumber } from './_common'
 export { ApiKey, ApiKeyId } from './api-keys'
 export {
 	CalendarEvent,
+	CalendarEventAttendee,
 	CalendarEventId,
 	CalendarEventType,
 	CalendarEventTypeId,

--- a/packages/domain/src/schema/timeline-activity.test.ts
+++ b/packages/domain/src/schema/timeline-activity.test.ts
@@ -62,6 +62,28 @@ describe('TimelineKind', () => {
 		}
 	})
 
+	it('should accept a hand-logged interaction on any channel', () => {
+		// GIVEN a touchpoint recorded by hand through something other than the
+		// phone — the channel itself is carried separately on the row
+		// WHEN the kind is decoded
+		// THEN it round-trips, so a logged visit or WhatsApp message reaches
+		// the company history under a kind of its own
+		expect(Schema.decodeUnknownSync(TimelineKind)('interaction_logged')).toBe(
+			'interaction_logged',
+		)
+	})
+
+	it('should accept a bounced email', () => {
+		// GIVEN the kind the mail worker writes when a message we sent comes
+		// back undelivered
+		// WHEN it is decoded
+		// THEN it round-trips — without it the row fails to decode and takes
+		// the whole company timeline down with it
+		expect(Schema.decodeUnknownSync(TimelineKind)('email_bounced')).toBe(
+			'email_bounced',
+		)
+	})
+
 	it('should reject unknown kinds like "meeting_ended"', () => {
 		// GIVEN 'meeting_ended' (close to a real kind but not modelled — the
 		// existing 'meeting_cancelled' covers the end-of-life case)

--- a/packages/domain/src/schema/timeline-activity.ts
+++ b/packages/domain/src/schema/timeline-activity.ts
@@ -8,7 +8,13 @@ export const TimelineActivityId = Schema.String.pipe(
 export const TimelineKind = Schema.Literals([
 	'email_sent',
 	'email_received',
+	// A message we sent came back undelivered.
+	'email_bounced',
 	'call_logged',
+	// A touchpoint logged by hand on any channel other than the phone — a
+	// visit, a WhatsApp message, a chat at an event. Which one it was lives
+	// in `channel`, so a new channel never needs a new kind here.
+	'interaction_logged',
 	'document_created',
 	'proposal_sent',
 	'proposal_viewed',


### PR DESCRIPTION
## What

Preparing for a meeting means reading what happened before it — who is coming, what was said last time, what I promised to do next. Six separate defects were quietly emptying that history, so a company page could look calm and up to date when it wasn't. Two of them lost data outright: no calendar invitation had been saved at all, and no bounced email had been recorded.

This touches the CRM surface across three places: the server (`server`), the mail worker (`mail-worker`), and the web app (`internal`).

## The fix

**Calendar invitations were never saved.** The upsert matched an invitation on its id alone, while the table treats that id as unique only *within* one organization — the same invitation can legitimately reach two. Postgres refuses a conflict target that doesn't match an index exactly, so it raised 42P10 and every cal.com booking and every emailed invitation was rejected. The guard that stops an out-of-order copy overwriting a reschedule is preserved.

**Meetings didn't say who was attending.** Attendees were never joined or sent to the browser, so the card computed its count from an always-empty list and reported one attendee for every meeting, whoever was invited. The list and detail endpoints now carry them, and the card shows names, who organized it, and who declined or is unsure. Someone with no contact on file is drawn differently — that's the person worth looking up before the meeting.

**Anything not a phone call was treated as noise.** A touchpoint logged through any other channel — a site visit, WhatsApp, LinkedIn, a conversation at a trade show — was filed under the kind reserved for bookkeeping the app does to itself. The conversations list drops that kind entirely and the overview hides it behind a "Show system events" checkbox, so notes written by hand were effectively invisible. They now get their own kind, and *which* channel it was stays in its own column, so supporting a new one needs no further change.

**Replies never reached the history.** The event for receiving mail was defined and wired through every branch but never actually created, so the history showed what I sent and never what they answered. It's now recorded when mail arrives, along with the last-contact dates, which otherwise would have stopped moving on replies.

**Bounces were discarded, and took the notice with them.** The bounce row left out the organization it belongs to, which is required. Because that write shares a transaction with storing the bounce notice itself, the failure discarded the notice too — so neither the timeline entry nor the "Mail Delivery Subsystem" message in the inbox ever appeared.

**The history threw away its most useful line.** Each row already recorded the subject, how a conversation ended, and what was promised next; the page read only a summary field that most kinds leave empty. It now reads what is stored. A separate fetch of interactions ran on every company page view and its result was never read; that's gone.

Four changes beyond the six, all inside code this PR already touches, called out so they aren't a surprise: a cancelled meeting no longer appears under upcoming (the conversations list already dropped it, so the two disagreed); the icon lookup lost a branch for a kind that doesn't exist while gaining six real ones that were falling through to an anonymous grey circle; every row in the conversations list was labelled "Interaction" whatever it was, so a task read "Interaction / task"; and an email in the history now opens the conversation it belongs to, which nothing recorded before.

## Impact

- **Wire shape changed.** The calendar list and detail endpoints now return an `attendees` array alongside the event's own fields. `packages/controllers` and `packages/domain` are consumed by both the server and the web app's typed client, so this ripples to the frontend — no fields were removed or renamed.
- **New history kinds.** `interaction_logged` and `email_bounced` join the existing set. `email_bounced` was already being written to the database while absent from the accepted set, so a row that had landed would have failed to decode and returned an error for a company's entire history.
- **No migration.** Nothing in the schema changed — the two-column unique index the upsert now names has existed since the initial migration.
- **No new environment variables, no change to tenant isolation.** Bounce rows now carry their organization explicitly, which narrows rather than widens what a session can see.
- **MCP and HTTP.** Both surfaces return attendees, from one shared lookup, so an agent and the web app get the same answer.
- **No backfill.** Touchpoints logged before this stay in the hidden bucket. Recovering them is a single `UPDATE` and can be its own migration whenever you want it.

## Review guide

Start with `apps/server/src/services/calendar.ts` — the conflict target is the whole of the first fix, and the rest of that file is unchanged.

The riskiest piece is `attendeesByEvent` in `apps/server/src/lib/calendar-attendees.ts`: it pairs each decoded attendee with the raw row at the same index to recover which meeting it belongs to. That's correct because both come from one ordered result set, but it is the kind of thing worth a second read.

A judgment call you might overrule: I gave non-phone touchpoints one new kind rather than one per channel, because the row already stores the channel separately and per-channel kinds would grow the set every time the product supports a new messaging app. The trade-off is that `call_logged` remains a channel-specific kind, so the set isn't perfectly consistent — making it so means retiring `call_logged`, which needs the backfill deliberately left out here.

Worth knowing about the tests: the calendar upsert integration test pins what the **database** accepts and on its own would **not** catch someone reverting the source — I confirmed that by reverting, and it still passed. The guard that does catch it is in `calendar.test.ts`, which reads the statements out of the file. The bounce test is different: it drives the real `applyBounce`, and two of its five cases fail when the fix is reverted.

Skip-able: the Catalan and English message catalogs are generated by `i18n:extract`.

The end-to-end calendar spec isn't tagged `@smoke`, so the checks on this PR ran the smoke subset and my strengthened assertion did not execute in CI — it runs in the full suite on main after merge. I confirmed the behaviour by hand against the running app instead (see Verification).

I did not run Snyk — the tool wasn't available in this session.

## Screenshots

Company overview with a meeting two days out, seeded with two attendees: one an organizer who is a known contact, one tentative with no contact on file (drawn with a dashed outline). Before this change, this same meeting displayed "1 attendee" and no names.

**Desktop**

![Company overview at desktop width, upcoming meetings card showing two named attendees](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-332/pr327-desktop.webp)

**Mobile**

![Same company overview at phone width](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-332/pr327-mobile.webp)

## Tests

- A source-shape guard on the calendar upsert that fails when the fix is reverted — verified by reverting it.
- Integration tests against a live Postgres for the calendar upsert (stores, updates on a newer copy, rejects an older one, keeps the same invitation separate across two organizations, and refuses the broken conflict target) and for the bounce write (stored with its organization, refused without it, and carried onto every affected contact).
- Unit tests for how a channel is classified, including channels the product doesn't have yet, asserting none of them land in the hidden bucket.
- The end-to-end calendar spec now seeds a second attendee and asserts an exact count plus both names plus the tentative marker. It previously matched only the word "attendee", which passed against the invented count.

## Verification

- `pnpm check-types` — 13 packages, clean.
- `pnpm test` — 21 tasks, all passing.
- `pnpm build` — 13 packages, clean.
- `pnpm lint` — clean; the remaining warnings are pre-existing lines this PR doesn't touch.
- Both new integration test files run green against a live Postgres.
- Drove the running app: signed in, opened the company page, and confirmed the card reads "2 attendees" with both names, the organizer marker, and the tentative marker. Captured at desktop and mobile widths.

## Deferred

- A backfill, for both the touchpoints logged before this change and the history entries with no conversation recorded on them. Each is a single `UPDATE`.
- The thread link is the one piece I could not drive end to end: it needs a genuinely sent or received message to produce a row carrying it, and the seeded rows predate the change. Type-checked and unit-tested only.

Closes #327
