### PR TITLE
fix: make every task and company count match what it lists

### DIFF
--- a/apps/cli/src/commands/seed/fixtures.ts
+++ b/apps/cli/src/commands/seed/fixtures.ts
@@ -862,6 +862,103 @@ export const getPresetData = (
 		},
 	]
 
+	// Enough work spread across the inbox rail that every shelf has something
+	// on it and one of them needs a second page to show everything. The dates
+	// hang off SEED_REFERENCE so two runs produce identical data, which also
+	// means the shelves read against the seed's own "today" — to browse them as
+	// today's work, seed with a fresh reference:
+	//   SEED_REFERENCE_DATE="$(date -u +%FT%TZ)" pnpm cli seed
+	const DAY = 86_400_000
+	const fromReference = (offsetMs: number) =>
+		new Date(SEED_REFERENCE.getTime() + offsetMs)
+	// A fixed time of day, so a seed run at 23:50 doesn't push "today" onto
+	// tomorrow. Mid-morning to late-afternoon UTC keeps these on the same
+	// calendar date across the timezones the app is read in.
+	const onReferenceDay = (dayOffset: number, hourUtc: number) => {
+		const date = new Date(SEED_REFERENCE.getTime() + dayOffset * DAY)
+		date.setUTCHours(hourUtc, 0, 0, 0)
+		return date
+	}
+	// The backlog spreads over every company except the two the minimal preset
+	// keeps, so those two are left with their hand-written tasks alone.
+	const backlogCompanies = [...companyMap.entries()]
+		.filter(([slug]) => !MINIMAL_COMPANY_SLUGS.has(slug))
+		.map(([, id]) => id)
+	const spreadCompany = (index: number) =>
+		backlogCompanies[index % backlogCompanies.length]!
+
+	const shelfSpread: ReadonlyArray<{
+		companyId: string
+		contactId: string | null
+		type: string
+		title: string
+		status?: string
+		dueAt?: Date
+		snoozedUntil?: Date
+		completedAt?: Date
+	}> = [
+		// Behind: due between yesterday and a month ago.
+		...Array.from({ length: 12 }, (_, i) => ({
+			companyId: spreadCompany(i),
+			contactId: null,
+			type: 'followup',
+			title: `Chase the pending quote (${i + 1})`,
+			dueAt: onReferenceDay(-(i + 1) * 2, 10),
+		})),
+		// Due today, spread across working hours so no timezone reads them as
+		// belonging to the day before or after.
+		...Array.from({ length: 8 }, (_, i) => ({
+			companyId: spreadCompany(i + 12),
+			contactId: null,
+			type: 'call',
+			title: `Call back about the trial (${i + 1})`,
+			dueAt: onReferenceDay(0, 9 + i),
+		})),
+		// The rest of the week.
+		...Array.from({ length: 10 }, (_, i) => ({
+			companyId: spreadCompany(i + 20),
+			contactId: null,
+			type: 'email',
+			title: `Send the revised proposal (${i + 1})`,
+			dueAt: onReferenceDay((i % 6) + 1, 10),
+		})),
+		// Beyond the week — deliberately more than one page holds, so the
+		// "Load more" button has something to fetch.
+		...Array.from({ length: 55 }, (_, i) => ({
+			companyId: spreadCompany(i + 30),
+			contactId: null,
+			type: 'other',
+			title: `Review the account plan (${i + 1})`,
+			dueAt: onReferenceDay(i + 8, 10),
+		})),
+		// Nobody has put a date on these.
+		...Array.from({ length: 8 }, (_, i) => ({
+			companyId: spreadCompany(i + 85),
+			contactId: null,
+			type: 'other',
+			title: `Research their expansion plans (${i + 1})`,
+		})),
+		// Sleeping until later in the week.
+		...Array.from({ length: 3 }, (_, i) => ({
+			companyId: spreadCompany(i + 93),
+			contactId: null,
+			type: 'followup',
+			title: `Revisit after their busy season (${i + 1})`,
+			dueAt: onReferenceDay(0, 11),
+			snoozedUntil: fromReference((i + 3) * DAY),
+		})),
+		// Finished within the last week, which is as far back as the rail looks.
+		...Array.from({ length: 5 }, (_, i) => ({
+			companyId: spreadCompany(i + 96),
+			contactId: null,
+			type: 'call',
+			title: `Walked them through the handover (${i + 1})`,
+			status: 'done' as const,
+			dueAt: onReferenceDay(-(i + 1), 10),
+			completedAt: onReferenceDay(-(i + 1), 11),
+		})),
+	]
+
 	// `normalizeRows` writes explicit NULL for missing keys, bypassing Postgres column defaults.
 	const withTaskDefaults = <
 		T extends { status?: string; source?: string; priority?: string },
@@ -898,6 +995,9 @@ export const getPresetData = (
 	return {
 		contacts: allContacts,
 		interactions: allInteractions,
-		tasks: allTasks.map(withTaskDefaults),
+		tasks: [
+			...allTasks.map(withTaskDefaults),
+			...shelfSpread.map(withTaskDefaults),
+		],
 	}
 }

--- a/apps/internal/src/atoms/pipeline-atoms.ts
+++ b/apps/internal/src/atoms/pipeline-atoms.ts
@@ -28,17 +28,21 @@ export const companiesListAtom = BatudaApiAtom.query('companies', 'list', {
 
 /**
  * All open tasks (not completed). The dashboard buckets these into
- * overdue / today / this-week, and the Tasks page renders the same set
- * grouped by due date.
+ * overdue / today / this-week.
  *
  * `completed: 'false'` is a string on purpose — the server parses it
  * from the URL via `Schema.optional(Schema.String)` (see
  * `packages/controllers/src/routes/tasks.ts`). Passing a boolean would
  * fail the schema.
+ *
+ * The limit is spelled out because leaving it off means 50, not "all", and the
+ * dashboard has no "load more" — anything past the cut vanishes from the date
+ * groups, and since the furthest-out dates come back first, the most overdue
+ * are the first to go (promote to a paginated fetch as the count nears 500).
  */
 export const openTasksAtom = BatudaApiAtom.query('tasks', 'list', {
-	query: { completed: 'false' },
-	serializationKey: 'tasks:open',
+	query: { completed: 'false', limit: 500 },
+	serializationKey: 'tasks:open:500',
 })
 
 /**

--- a/apps/internal/src/atoms/tasks-atoms.ts
+++ b/apps/internal/src/atoms/tasks-atoms.ts
@@ -67,10 +67,11 @@ export function dayBoundaries(dayKey: string): {
 	}
 }
 
-// The soonest deadline leads every shelf still waiting to be worked. Nothing
-// is pending on the undated and the finished ones, so those read latest-first.
+// The soonest deadline leads every shelf still waiting to be worked. Finished
+// work reads by when it was finished, and undated work has no deadline to lead
+// with, so it falls back to the latest date the task carries.
 const sortForShelf = (shelf: TaskShelf) =>
-	shelf === 'noDue' || shelf === 'doneRecent' ? 'recent' : 'due'
+	shelf === 'doneRecent' ? 'completed' : shelf === 'noDue' ? 'recent' : 'due'
 
 const shelfCache = new Map<string, ReturnType<typeof makeShelfAtom>>()
 

--- a/apps/internal/src/atoms/tasks-atoms.ts
+++ b/apps/internal/src/atoms/tasks-atoms.ts
@@ -1,32 +1,129 @@
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 
 /**
- * Dedicated atom registry for the tasks inbox (§7 of the calendar plan).
+ * Dedicated atom registry for the tasks inbox.
  *
- * `openTasksAtom` + `companiesListAtom` still live in
- * `pipeline-atoms.ts` because the dashboard and the tasks page both read
- * them — they MUST share identity so SSR hydration doesn't refetch.
+ * `companiesListAtom` still lives in `pipeline-atoms.ts` because the
+ * dashboard and the tasks page both read it — they MUST share identity so
+ * SSR hydration doesn't refetch.
  *
  * Everything here is tasks-inbox-only:
- *   - Smart-view queries that never fire on the dashboard (snoozed,
- *     done-recently).
+ *   - One query per shelf of the rail, plus the counts behind their labels.
  *   - Id-keyed event feed for the right-pane audit log.
  *   - Module-level mutation setters for the inline/row actions.
  */
 
-export const snoozedTasksAtom = BatudaApiAtom.query('tasks', 'list', {
-	query: { includeSnoozed: 'true', status: 'open' },
-})
+/** The shelves the inbox rail sorts work onto. */
+export type TaskShelf =
+	| 'overdue'
+	| 'today'
+	| 'thisWeek'
+	| 'later'
+	| 'noDue'
+	| 'snoozed'
+	| 'doneRecent'
 
 /**
- * Completed in the last 7 days. The server filter is `status=done`; the
- * 7-day window is applied client-side by bucket logic so the atom stays
- * a stable cache key (an atom that re-keys on `now()` would refetch on
- * every tick). 7-day cutoff is enforced in the bucket selector.
+ * How many tasks one shelf shows before asking, and how many more each
+ * "Load more" adds.
  */
-export const doneTasksAtom = BatudaApiAtom.query('tasks', 'list', {
-	query: { status: 'done', limit: 100 },
-})
+export const TASKS_PAGE_SIZE = 50
+
+/**
+ * Which day it is where the reader is, as `2026-07-25`.
+ *
+ * Everything below keys on the day rather than the moment. An atom keyed on
+ * the current instant would be a different atom on every render and refetch
+ * forever, and the shelves only change at midnight anyway.
+ */
+export function localDayKey(reference: Date = new Date()): string {
+	const month = String(reference.getMonth() + 1).padStart(2, '0')
+	const day = String(reference.getDate()).padStart(2, '0')
+	return `${reference.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * The stretch of time a day key stands for, in the reader's own timezone.
+ * `weekEnd` is the next seven days from tonight, not the end of the calendar
+ * week, so "this week" always covers the same amount of ground.
+ *
+ * These are computed from a plain local `Date` on purpose: "today" is a
+ * different span of hours in every timezone, and the server has no way to
+ * know which one the person reading the screen is in.
+ */
+export function dayBoundaries(dayKey: string): {
+	readonly todayStart: string
+	readonly todayEnd: string
+	readonly weekEnd: string
+} {
+	const start = new Date(`${dayKey}T00:00:00`)
+	const end = new Date(start)
+	end.setHours(23, 59, 59, 999)
+	const weekEnd = new Date(end.getTime() + 7 * 86400_000)
+	return {
+		todayStart: start.toISOString(),
+		todayEnd: end.toISOString(),
+		weekEnd: weekEnd.toISOString(),
+	}
+}
+
+// The soonest deadline leads every shelf still waiting to be worked. Nothing
+// is pending on the undated and the finished ones, so those read latest-first.
+const sortForShelf = (shelf: TaskShelf) =>
+	shelf === 'noDue' || shelf === 'doneRecent' ? 'recent' : 'due'
+
+const shelfCache = new Map<string, ReturnType<typeof makeShelfAtom>>()
+
+function makeShelfAtom(shelf: TaskShelf, dayKey: string, limit: number) {
+	return BatudaApiAtom.query('tasks', 'list', {
+		query: {
+			shelf,
+			...dayBoundaries(dayKey),
+			sort: sortForShelf(shelf),
+			limit,
+		},
+		serializationKey: `tasks:shelf:${shelf}:${dayKey}:${limit}`,
+	})
+}
+
+/**
+ * One page of a single shelf. The server decides which tasks belong on it, so
+ * the page reports how many there are in total even while showing far fewer.
+ */
+export function tasksShelfAtom(
+	shelf: TaskShelf,
+	dayKey: string,
+	limit: number = TASKS_PAGE_SIZE,
+) {
+	const key = `${shelf}::${dayKey}::${limit}`
+	const existing = shelfCache.get(key)
+	if (existing !== undefined) return existing
+	const atom = makeShelfAtom(shelf, dayKey, limit)
+	shelfCache.set(key, atom)
+	return atom
+}
+
+const countsCache = new Map<string, ReturnType<typeof makeTaskCountsAtom>>()
+
+function makeTaskCountsAtom(dayKey: string) {
+	return BatudaApiAtom.query('tasks', 'counts', {
+		query: dayBoundaries(dayKey),
+		serializationKey: `tasks:counts:${dayKey}`,
+	})
+}
+
+/**
+ * How big every shelf is, in one request — what the rail shows beside each
+ * name. Counted over the whole organization, so the numbers stay honest no
+ * matter how little of a shelf is on screen.
+ */
+export function taskCountsAtom(dayKey: string) {
+	const existing = countsCache.get(dayKey)
+	if (existing !== undefined) return existing
+	const atom = makeTaskCountsAtom(dayKey)
+	countsCache.set(dayKey, atom)
+	return atom
+}
 
 export const updateTaskAtom = BatudaApiAtom.mutation('tasks', 'update')
 export const reopenTaskAtom = BatudaApiAtom.mutation('tasks', 'reopen')

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -389,6 +389,10 @@ msgid "All"
 msgstr "Tots"
 
 #: src/routes/companies/index.tsx
+msgid "All companies"
+msgstr "Totes les empreses"
+
+#: src/routes/companies/index.tsx
 msgid "All countries"
 msgstr "Tots els països"
 
@@ -418,6 +422,7 @@ msgid "All time"
 msgstr "Tot el temps"
 
 #: src/routes/index.tsx
+#: src/routes/tasks/index.tsx
 msgid "All under control"
 msgstr "Tot sota control"
 
@@ -1947,6 +1952,14 @@ msgstr "Error"
 msgid "Event"
 msgstr "Esdeveniment"
 
+#: src/routes/tasks/index.tsx
+msgid "Every open task has a due date assigned."
+msgstr "Totes les tasques obertes tenen data de venciment."
+
+#: src/routes/tasks/index.tsx
+msgid "Every task has a date"
+msgstr "Totes les tasques tenen data"
+
 #: src/components/emails/compose-window.tsx
 msgid "Exit full screen"
 msgstr "Surt de pantalla completa"
@@ -2236,10 +2249,6 @@ msgstr "Port IMAP"
 msgid "IMAP security"
 msgstr "Seguretat IMAP"
 
-#: src/routes/companies/index.tsx
-msgid "In pipeline"
-msgstr "Al pipeline"
-
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/routes/emails/index.tsx
 msgid "Inbound"
@@ -2405,7 +2414,7 @@ msgstr "Última visita"
 
 #: src/routes/tasks/index.tsx
 msgid "Later"
-msgstr "Més tard"
+msgstr "Més endavant"
 
 #: src/components/research/research-dialog.tsx
 msgid "Layered after the stack, in order."
@@ -2438,6 +2447,7 @@ msgid "Load {0} more"
 msgstr "Carrega'n {0} més"
 
 #: src/routes/companies/index.tsx
+#: src/routes/tasks/index.tsx
 msgid "Load more"
 msgstr "Carrega'n més"
 
@@ -2611,6 +2621,10 @@ msgstr "Resum de mercat"
 #: src/components/profile/theme-select.tsx
 msgid "Match device"
 msgstr "Segons el dispositiu"
+
+#: src/routes/companies/index.tsx
+msgid "Matching"
+msgstr "Coincidents"
 
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Maturity"
@@ -2933,7 +2947,7 @@ msgstr "sense data de venciment"
 
 #: src/routes/tasks/index.tsx
 msgid "No due date"
-msgstr "Sense data de venciment"
+msgstr "Sense data"
 
 #: src/components/research/findings/company-enrichment-view.tsx
 msgid "No fit"
@@ -3000,6 +3014,10 @@ msgstr "Encara no hi ha pàgines"
 msgid "No paid calls in this range."
 msgstr "No hi ha crides de pagament en aquest interval."
 
+#: src/routes/tasks/index.tsx
+msgid "No pending tasks today. Time to prospect or take a walk."
+msgstr "Avui no hi ha tasques pendents. És hora de prospectar o de fer un tomb."
+
 #: src/routes/emails/inboxes.tsx
 msgid "No primary inbox set."
 msgstr "No hi ha cap bústia principal."
@@ -3046,9 +3064,25 @@ msgstr "No hi ha troballes estructurades."
 msgid "No tags yet"
 msgstr "Encara sense etiquetes"
 
+#: src/routes/tasks/index.tsx
+msgid "No tasks are sleeping."
+msgstr "No hi ha cap tasca adormida."
+
+#: src/routes/tasks/index.tsx
+msgid "No tasks completed in the last 7 days."
+msgstr "Cap tasca completada els darrers 7 dies."
+
 #: src/routes/index.tsx
 msgid "No tasks for today"
 msgstr "Cap tasca per a avui"
+
+#: src/routes/tasks/index.tsx
+msgid "No tasks scheduled beyond this week."
+msgstr "No hi ha tasques programades més enllà d'aquesta setmana."
+
+#: src/routes/tasks/index.tsx
+msgid "No tasks this week"
+msgstr "Cap tasca aquesta setmana"
 
 #: src/components/instructions/stack-picker.tsx
 msgid "No templates added yet."
@@ -3105,6 +3139,22 @@ msgstr "Notes (opcional)"
 #: src/routes/tasks/index.tsx
 msgid "Nothing changed yet."
 msgstr "Encara no ha canviat res."
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing completed recently"
+msgstr "Res completat recentment"
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing later in the queue"
+msgstr "Res més endavant a la cua"
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing overdue"
+msgstr "Res endarrerit"
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing snoozed"
+msgstr "Res ajornat"
 
 #: src/components/research/proposal-outcome.tsx
 msgid "Nothing to apply"
@@ -4290,7 +4340,7 @@ msgstr "Posposa 1d"
 
 #: src/routes/tasks/index.tsx
 msgid "Snoozed"
-msgstr "Posposades"
+msgstr "Ajornades"
 
 #: src/routes/emails/$threadId.tsx
 msgid "someone"
@@ -4586,8 +4636,8 @@ msgid "That link is no longer valid. Request a fresh one below."
 msgstr "L'enllaç ja no és vàlid. Demana'n un de nou a sota."
 
 #: src/routes/tasks/index.tsx
-msgid "The 20 most recently edited open tasks. Click one to reopen it."
-msgstr "Les 20 tasques obertes editades més recentment. Fes-hi clic per reobrir-ne una."
+msgid "The 20 most recently edited tasks on this shelf. Click one to reopen it."
+msgstr "Les 20 tasques editades més recentment d'aquest prestatge. Fes clic en una per reobrir-la."
 
 #: src/routes/companies/$slug.tsx
 msgid "The activity for this company could not be fetched. Check that the session is valid, then try again."
@@ -4625,6 +4675,10 @@ msgstr "El geocodificador no ha trobat cap coincidència. Prova d'editar el camp
 #: src/routes/emails/inboxes.tsx
 msgid "The inboxes could not be fetched. Check that the session is valid, then try again."
 msgstr "No s'han pogut carregar les safates. Comprova que la sessió sigui vàlida i torna-ho a provar."
+
+#: src/routes/tasks/index.tsx
+msgid "The ledger is clean."
+msgstr "El llibre de comptes està net."
 
 #: src/routes/companies/index.tsx
 #: src/routes/pages/index.tsx
@@ -4694,6 +4748,10 @@ msgstr "Les dues contrasenyes no coincideixen."
 #: src/routes/reset-password.tsx
 msgid "The two passwords don't match."
 msgstr "Les dues contrasenyes no coincideixen."
+
+#: src/routes/tasks/index.tsx
+msgid "The week is clear — good time to plan."
+msgstr "La setmana és lliure: bon moment per planificar."
 
 #: src/routes/tasks/index.tsx
 msgid "The workshop ledger — tear off one strip at a time."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -54,6 +54,11 @@ msgstr "(sense assumpte)"
 msgid "(no summary)"
 msgstr "(sense resum)"
 
+#. placeholder {0}: counts[shelf]
+#: src/routes/tasks/index.tsx
+msgid "{0, plural, one {# task} other {# tasks}}"
+msgstr "{0, plural, one {# tasca} other {# tasques}}"
+
 #. placeholder {0}: stack.templateIds.length
 #: src/components/instructions/stack-list.tsx
 msgid "{0, plural, one {# template} other {# templates}}"
@@ -106,6 +111,12 @@ msgstr "{0} passos fets"
 #: src/routes/emails/index.tsx
 msgid "{0} thread could not be updated."
 msgstr "No s'han pogut actualitzar {0} fils."
+
+#. placeholder {0}: t(shelfCopy(selectedShelf).label)
+#. placeholder {1}: visibleTasks.length
+#: src/routes/tasks/index.tsx
+msgid "{0}: showing {1} of {shelfTotal} tasks."
+msgstr "{0}: es mostren {1} de {shelfTotal} tasques."
 
 #: src/routes/settings/organization/members.tsx
 msgid "{addedEmail} is now a member. They've been emailed."
@@ -1217,6 +1228,10 @@ msgstr "No s'ha pogut carregar el tauler"
 msgid "Could not load the review queue."
 msgstr "No s'ha pogut carregar la cua de revisió."
 
+#: src/routes/tasks/index.tsx
+msgid "Could not load these tasks"
+msgstr "No s'han pogut carregar aquestes tasques"
+
 #: src/routes/companies/$slug.tsx
 msgid "Could not load this company"
 msgstr "No s'ha pogut carregar aquesta empresa"
@@ -1421,6 +1436,10 @@ msgstr "No s'ha pogut canviar"
 #: src/routes/settings/profile/index.tsx
 msgid "Couldn't update your preference. Try again."
 msgstr "No he pogut desar la teva preferència. Prova-ho de nou."
+
+#: src/routes/tasks/index.tsx
+msgid "count loading"
+msgstr "carregant el recompte"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
@@ -2044,6 +2063,10 @@ msgstr "Filtra les converses"
 msgid "Filter emails"
 msgstr "Filtra correus"
 
+#: src/routes/tasks/index.tsx
+msgid "Filter tasks by shelf"
+msgstr "Filtra les tasques per prestatge"
+
 #: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/research-dialog.tsx
 #: src/components/research/research-dialog.tsx
@@ -2471,6 +2494,10 @@ msgstr "Carregant l'execució…"
 msgid "Loading runs…"
 msgstr "S'estan carregant les execucions…"
 
+#: src/routes/tasks/index.tsx
+msgid "Loading tasks…"
+msgstr "S'estan carregant les tasques…"
+
 #: src/components/research/inbox/research-inbox.tsx
 msgid "Loading the review queue"
 msgstr "S'està carregant la cua de revisió"
@@ -2623,8 +2650,8 @@ msgid "Match device"
 msgstr "Segons el dispositiu"
 
 #: src/routes/companies/index.tsx
-msgid "Matching"
-msgstr "Coincidents"
+msgid "Matching companies"
+msgstr "Empreses coincidents"
 
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Maturity"
@@ -4570,6 +4597,11 @@ msgstr "Títol de la tasca"
 msgid "Tasks"
 msgstr "Tasques"
 
+#. placeholder {0}: visibleTasks.length
+#: src/routes/tasks/index.tsx
+msgid "tasks — showing {0} of {shelfTotal}"
+msgstr "tasques: es mostren {0} de {shelfTotal}"
+
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Tax ID"
 msgstr "NIF"
@@ -4684,6 +4716,10 @@ msgstr "El llibre de comptes està net."
 #: src/routes/pages/index.tsx
 msgid "The list could not be fetched. Check that the session is valid, then try again."
 msgstr "No s'ha pogut carregar la llista. Comprova que la sessió sigui vàlida i torna-ho a provar."
+
+#: src/routes/tasks/index.tsx
+msgid "The list could not be fetched. Check the connection, then try again."
+msgstr "No s'ha pogut obtenir la llista. Comprova la connexió i torna-ho a provar."
 
 #: src/routes/emails/inboxes.tsx
 msgid "The mailbox is ready."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -389,6 +389,10 @@ msgid "All"
 msgstr "All"
 
 #: src/routes/companies/index.tsx
+msgid "All companies"
+msgstr "All companies"
+
+#: src/routes/companies/index.tsx
 msgid "All countries"
 msgstr "All countries"
 
@@ -418,6 +422,7 @@ msgid "All time"
 msgstr "All time"
 
 #: src/routes/index.tsx
+#: src/routes/tasks/index.tsx
 msgid "All under control"
 msgstr "All under control"
 
@@ -1947,6 +1952,14 @@ msgstr "Error"
 msgid "Event"
 msgstr "Event"
 
+#: src/routes/tasks/index.tsx
+msgid "Every open task has a due date assigned."
+msgstr "Every open task has a due date assigned."
+
+#: src/routes/tasks/index.tsx
+msgid "Every task has a date"
+msgstr "Every task has a date"
+
 #: src/components/emails/compose-window.tsx
 msgid "Exit full screen"
 msgstr "Exit full screen"
@@ -2236,10 +2249,6 @@ msgstr "IMAP port"
 msgid "IMAP security"
 msgstr "IMAP security"
 
-#: src/routes/companies/index.tsx
-msgid "In pipeline"
-msgstr "In pipeline"
-
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/routes/emails/index.tsx
 msgid "Inbound"
@@ -2438,6 +2447,7 @@ msgid "Load {0} more"
 msgstr "Load {0} more"
 
 #: src/routes/companies/index.tsx
+#: src/routes/tasks/index.tsx
 msgid "Load more"
 msgstr "Load more"
 
@@ -2611,6 +2621,10 @@ msgstr "Market summary"
 #: src/components/profile/theme-select.tsx
 msgid "Match device"
 msgstr "Match device"
+
+#: src/routes/companies/index.tsx
+msgid "Matching"
+msgstr "Matching"
 
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Maturity"
@@ -3000,6 +3014,10 @@ msgstr "No pages yet"
 msgid "No paid calls in this range."
 msgstr "No paid calls in this range."
 
+#: src/routes/tasks/index.tsx
+msgid "No pending tasks today. Time to prospect or take a walk."
+msgstr "No pending tasks today. Time to prospect or take a walk."
+
 #: src/routes/emails/inboxes.tsx
 msgid "No primary inbox set."
 msgstr "No primary inbox set."
@@ -3046,9 +3064,25 @@ msgstr "No structured findings."
 msgid "No tags yet"
 msgstr "No tags yet"
 
+#: src/routes/tasks/index.tsx
+msgid "No tasks are sleeping."
+msgstr "No tasks are sleeping."
+
+#: src/routes/tasks/index.tsx
+msgid "No tasks completed in the last 7 days."
+msgstr "No tasks completed in the last 7 days."
+
 #: src/routes/index.tsx
 msgid "No tasks for today"
 msgstr "No tasks for today"
+
+#: src/routes/tasks/index.tsx
+msgid "No tasks scheduled beyond this week."
+msgstr "No tasks scheduled beyond this week."
+
+#: src/routes/tasks/index.tsx
+msgid "No tasks this week"
+msgstr "No tasks this week"
 
 #: src/components/instructions/stack-picker.tsx
 msgid "No templates added yet."
@@ -3105,6 +3139,22 @@ msgstr "Notes (optional)"
 #: src/routes/tasks/index.tsx
 msgid "Nothing changed yet."
 msgstr "Nothing changed yet."
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing completed recently"
+msgstr "Nothing completed recently"
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing later in the queue"
+msgstr "Nothing later in the queue"
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing overdue"
+msgstr "Nothing overdue"
+
+#: src/routes/tasks/index.tsx
+msgid "Nothing snoozed"
+msgstr "Nothing snoozed"
 
 #: src/components/research/proposal-outcome.tsx
 msgid "Nothing to apply"
@@ -4586,8 +4636,8 @@ msgid "That link is no longer valid. Request a fresh one below."
 msgstr "That link is no longer valid. Request a fresh one below."
 
 #: src/routes/tasks/index.tsx
-msgid "The 20 most recently edited open tasks. Click one to reopen it."
-msgstr "The 20 most recently edited open tasks. Click one to reopen it."
+msgid "The 20 most recently edited tasks on this shelf. Click one to reopen it."
+msgstr "The 20 most recently edited tasks on this shelf. Click one to reopen it."
 
 #: src/routes/companies/$slug.tsx
 msgid "The activity for this company could not be fetched. Check that the session is valid, then try again."
@@ -4625,6 +4675,10 @@ msgstr "The geocoder did not return a match. Try editing the location field."
 #: src/routes/emails/inboxes.tsx
 msgid "The inboxes could not be fetched. Check that the session is valid, then try again."
 msgstr "The inboxes could not be fetched. Check that the session is valid, then try again."
+
+#: src/routes/tasks/index.tsx
+msgid "The ledger is clean."
+msgstr "The ledger is clean."
 
 #: src/routes/companies/index.tsx
 #: src/routes/pages/index.tsx
@@ -4694,6 +4748,10 @@ msgstr "The two password fields don't match."
 #: src/routes/reset-password.tsx
 msgid "The two passwords don't match."
 msgstr "The two passwords don't match."
+
+#: src/routes/tasks/index.tsx
+msgid "The week is clear — good time to plan."
+msgstr "The week is clear — good time to plan."
 
 #: src/routes/tasks/index.tsx
 msgid "The workshop ledger — tear off one strip at a time."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -54,6 +54,11 @@ msgstr "(no subject)"
 msgid "(no summary)"
 msgstr "(no summary)"
 
+#. placeholder {0}: counts[shelf]
+#: src/routes/tasks/index.tsx
+msgid "{0, plural, one {# task} other {# tasks}}"
+msgstr "{0, plural, one {# task} other {# tasks}}"
+
 #. placeholder {0}: stack.templateIds.length
 #: src/components/instructions/stack-list.tsx
 msgid "{0, plural, one {# template} other {# templates}}"
@@ -106,6 +111,12 @@ msgstr "{0} steps run"
 #: src/routes/emails/index.tsx
 msgid "{0} thread could not be updated."
 msgstr "{0} thread could not be updated."
+
+#. placeholder {0}: t(shelfCopy(selectedShelf).label)
+#. placeholder {1}: visibleTasks.length
+#: src/routes/tasks/index.tsx
+msgid "{0}: showing {1} of {shelfTotal} tasks."
+msgstr "{0}: showing {1} of {shelfTotal} tasks."
 
 #: src/routes/settings/organization/members.tsx
 msgid "{addedEmail} is now a member. They've been emailed."
@@ -1217,6 +1228,10 @@ msgstr "Could not load the board"
 msgid "Could not load the review queue."
 msgstr "Could not load the review queue."
 
+#: src/routes/tasks/index.tsx
+msgid "Could not load these tasks"
+msgstr "Could not load these tasks"
+
 #: src/routes/companies/$slug.tsx
 msgid "Could not load this company"
 msgstr "Could not load this company"
@@ -1421,6 +1436,10 @@ msgstr "Couldn't switch"
 #: src/routes/settings/profile/index.tsx
 msgid "Couldn't update your preference. Try again."
 msgstr "Couldn't update your preference. Try again."
+
+#: src/routes/tasks/index.tsx
+msgid "count loading"
+msgstr "count loading"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
@@ -2044,6 +2063,10 @@ msgstr "Filter conversations"
 msgid "Filter emails"
 msgstr "Filter emails"
 
+#: src/routes/tasks/index.tsx
+msgid "Filter tasks by shelf"
+msgstr "Filter tasks by shelf"
+
 #: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/research-dialog.tsx
 #: src/components/research/research-dialog.tsx
@@ -2471,6 +2494,10 @@ msgstr "Loading run…"
 msgid "Loading runs…"
 msgstr "Loading runs…"
 
+#: src/routes/tasks/index.tsx
+msgid "Loading tasks…"
+msgstr "Loading tasks…"
+
 #: src/components/research/inbox/research-inbox.tsx
 msgid "Loading the review queue"
 msgstr "Loading the review queue"
@@ -2623,8 +2650,8 @@ msgid "Match device"
 msgstr "Match device"
 
 #: src/routes/companies/index.tsx
-msgid "Matching"
-msgstr "Matching"
+msgid "Matching companies"
+msgstr "Matching companies"
 
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Maturity"
@@ -4570,6 +4597,11 @@ msgstr "Task title"
 msgid "Tasks"
 msgstr "Tasks"
 
+#. placeholder {0}: visibleTasks.length
+#: src/routes/tasks/index.tsx
+msgid "tasks — showing {0} of {shelfTotal}"
+msgstr "tasks — showing {0} of {shelfTotal}"
+
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Tax ID"
 msgstr "Tax ID"
@@ -4684,6 +4716,10 @@ msgstr "The ledger is clean."
 #: src/routes/pages/index.tsx
 msgid "The list could not be fetched. Check that the session is valid, then try again."
 msgstr "The list could not be fetched. Check that the session is valid, then try again."
+
+#: src/routes/tasks/index.tsx
+msgid "The list could not be fetched. Check the connection, then try again."
+msgstr "The list could not be fetched. Check the connection, then try again."
 
 #: src/routes/emails/inboxes.tsx
 msgid "The mailbox is ready."

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -249,6 +249,9 @@ function CompaniesListPage() {
 		: total === 1
 			? t`1 company`
 			: t`${total} companies`
+	// This counts every match, closed and dead companies included, so the label
+	// avoids "pipeline" — that word belongs to the dashboard's active-only count.
+	const countKpiLabel = activeFilters ? t`Matching` : t`All companies`
 
 	const countryItems = [
 		{ value: ALL, label: t`All countries` },
@@ -289,7 +292,7 @@ function CompaniesListPage() {
 				{...(hasResult
 					? {
 							subtitle: countLabel,
-							kpi: { value: total, label: t`In pipeline` },
+							kpi: { value: total, label: countKpiLabel },
 						}
 					: {})}
 			/>

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -251,7 +251,7 @@ function CompaniesListPage() {
 			: t`${total} companies`
 	// This counts every match, closed and dead companies included, so the label
 	// avoids "pipeline" — that word belongs to the dashboard's active-only count.
-	const countKpiLabel = activeFilters ? t`Matching` : t`All companies`
+	const countKpiLabel = activeFilters ? t`Matching companies` : t`All companies`
 
 	const countryItems = [
 		{ value: ALL, label: t`All countries` },

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -83,7 +83,7 @@ async function loadPipelineDataOnServer(): Promise<PipelineData> {
 		const [companies, openTasks] = yield* Effect.all(
 			[
 				client.companies.list({ query: { limit: 500 } }),
-				client.tasks.list({ query: { completed: 'false' } }),
+				client.tasks.list({ query: { completed: 'false', limit: 500 } }),
 			],
 			{ concurrency: 2 },
 		)
@@ -190,6 +190,12 @@ function PipelinePage() {
 				: [],
 		[openTasksResult],
 	)
+
+	// Counting the rows in hand would under-report as soon as someone has more
+	// open tasks than one page holds, so the total comes from the server.
+	const openTaskCount = AsyncResult.isSuccess(openTasksResult)
+		? openTasksResult.value.total
+		: 0
 
 	const isLoading =
 		AsyncResult.isInitial(companiesResult) ||
@@ -301,7 +307,7 @@ function PipelinePage() {
 
 			<KpiRow>
 				<KpiCounter value={activeCompanyCount} label={t`Active companies`} />
-				<KpiCounter value={openTasks.length} label={t`Open tasks`} />
+				<KpiCounter value={openTaskCount} label={t`Open tasks`} />
 				<KpiCounter
 					value={snapshot?.overdueTaskCount ?? overdueTasksCount}
 					label={t`Overdue`}

--- a/apps/internal/src/routes/tasks/index.tsx
+++ b/apps/internal/src/routes/tasks/index.tsx
@@ -1,4 +1,6 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
+import type { MessageDescriptor } from '@lingui/core'
+import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
@@ -7,19 +9,22 @@ import { Clock, History, Plus } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import type { Company, Task } from '@batuda/domain'
+import type { Company } from '@batuda/domain'
 import { PriButton, PriDialog, PriInput } from '@batuda/ui/pri'
 
-import { companiesListAtom, openTasksAtom } from '#/atoms/pipeline-atoms'
+import { companiesListAtom } from '#/atoms/pipeline-atoms'
 import {
 	cancelTaskAtom,
 	createTaskAtom,
-	doneTasksAtom,
+	localDayKey,
 	reopenTaskAtom,
 	rescheduleTaskAtom,
-	snoozedTasksAtom,
 	snoozeTaskAtom,
+	TASKS_PAGE_SIZE,
+	type TaskShelf,
+	taskCountsAtom,
 	taskEventsAtomFor,
+	tasksShelfAtom,
 	updateTaskAtom,
 } from '#/atoms/tasks-atoms'
 import { EmptyState } from '#/components/shared/empty-state'
@@ -47,11 +52,13 @@ import {
 } from '#/lib/workshop-mixins'
 
 /**
- * Task inbox — extends `openTasksAtom` (dashboard) with a smart-view rail
- * (today / overdue / this week / later / no due / snoozed / done 7d),
- * inline edit on title + due, and a right-pane detail editor backed by
- * `task_events`. Mutations go through `@batuda/controllers` typed atoms
- * so optimistic concurrency (`If-Match`) is cheap to enable later.
+ * Task inbox — a rail of shelves (today / overdue / this week / later / no
+ * due / snoozed / done 7d), inline edit on title + due, and a right-pane
+ * detail editor backed by `task_events`. The server decides which shelf a
+ * task sits on and how big each shelf is, so a rail count and the rows
+ * underneath it always describe the same set. Mutations go through
+ * `@batuda/controllers` typed atoms so optimistic concurrency (`If-Match`)
+ * is cheap to enable later.
  */
 type TaskRow = {
 	readonly id: string
@@ -73,21 +80,100 @@ type CompanyLookup = {
 	readonly name: string
 }
 
-type SmartView =
-	| 'today'
-	| 'overdue'
-	| 'this-week'
-	| 'later'
-	| 'no-due'
-	| 'snoozed'
-	| 'done'
+// The rail, in the order it reads top to bottom, with the copy each shelf
+// shows when it is empty. Every string is a `msg` descriptor at module scope
+// so `lingui extract` can find it: passing `t` into a helper shadows the
+// macro, and the string then ships in English whatever the reader's language.
+const SHELVES: ReadonlyArray<{
+	readonly shelf: TaskShelf
+	readonly testId: string
+	readonly label: MessageDescriptor
+	readonly emptyTitle: MessageDescriptor
+	readonly emptyDescription: MessageDescriptor
+}> = [
+	{
+		shelf: 'today',
+		testId: 'tasks-view-today',
+		label: msg`Today`,
+		emptyTitle: msg`All under control`,
+		emptyDescription: msg`No pending tasks today. Time to prospect or take a walk.`,
+	},
+	{
+		shelf: 'overdue',
+		testId: 'tasks-view-overdue',
+		label: msg`Overdue`,
+		emptyTitle: msg`Nothing overdue`,
+		emptyDescription: msg`The ledger is clean.`,
+	},
+	{
+		shelf: 'thisWeek',
+		testId: 'tasks-view-this-week',
+		label: msg`This week`,
+		emptyTitle: msg`No tasks this week`,
+		emptyDescription: msg`The week is clear — good time to plan.`,
+	},
+	{
+		shelf: 'later',
+		testId: 'tasks-view-later',
+		label: msg`Later`,
+		emptyTitle: msg`Nothing later in the queue`,
+		emptyDescription: msg`No tasks scheduled beyond this week.`,
+	},
+	{
+		shelf: 'noDue',
+		testId: 'tasks-view-no-due',
+		label: msg`No due date`,
+		emptyTitle: msg`Every task has a date`,
+		emptyDescription: msg`Every open task has a due date assigned.`,
+	},
+	{
+		shelf: 'snoozed',
+		testId: 'tasks-view-snoozed',
+		label: msg`Snoozed`,
+		emptyTitle: msg`Nothing snoozed`,
+		emptyDescription: msg`No tasks are sleeping.`,
+	},
+	{
+		shelf: 'doneRecent',
+		testId: 'tasks-view-done',
+		label: msg`Done 7d`,
+		emptyTitle: msg`Nothing completed recently`,
+		emptyDescription: msg`No tasks completed in the last 7 days.`,
+	},
+]
+
+const shelfCopy = (shelf: TaskShelf) =>
+	SHELVES.find(entry => entry.shelf === shelf) ?? SHELVES[0]!
+
+// What the rail shows before the real sizes arrive. Zeroes rather than blanks
+// keep the buttons from resizing under the pointer as the counts land.
+const EMPTY_COUNTS: Record<TaskShelf, number> = {
+	overdue: 0,
+	today: 0,
+	thisWeek: 0,
+	later: 0,
+	noDue: 0,
+	snoozed: 0,
+	doneRecent: 0,
+}
+
+// Everything still waiting, wherever it sits on the rail.
+const OPEN_SHELVES: ReadonlyArray<TaskShelf> = [
+	'overdue',
+	'today',
+	'thisWeek',
+	'later',
+	'noDue',
+]
 
 const completeTaskAtom = BatudaApiAtom.mutation('tasks', 'complete')
 
-async function loadTasksOnServer(): Promise<{
-	tasks: PaginatedList<Task>
-	companies: PaginatedList<Company>
-}> {
+/**
+ * Only the companies are fetched ahead of time. Which tasks are due "today"
+ * depends on where the reader is in the world, and the server has no way to
+ * know that, so the shelves are left for the browser to ask for.
+ */
+async function loadCompaniesOnServer(): Promise<PaginatedList<Company>> {
 	const [{ Effect }, { makeBatudaApiServer }, cookie] = await Promise.all([
 		import('effect'),
 		import('#/lib/batuda-api-server'),
@@ -95,14 +181,7 @@ async function loadTasksOnServer(): Promise<{
 	])
 	const program = Effect.gen(function* () {
 		const client = yield* makeBatudaApiServer(cookie ?? undefined)
-		const [tasks, companies] = yield* Effect.all(
-			[
-				client.tasks.list({ query: { completed: 'false' } }),
-				client.companies.list({ query: { limit: 500 } }),
-			],
-			{ concurrency: 2 },
-		)
-		return { tasks, companies }
+		return yield* client.companies.list({ query: { limit: 500 } })
 	})
 	return Effect.runPromise(program)
 }
@@ -125,10 +204,9 @@ export const Route = createFileRoute('/tasks/')({
 			return { dehydrated: [] as const }
 		}
 		try {
-			const { tasks, companies } = await loadTasksOnServer()
+			const companies = await loadCompaniesOnServer()
 			return {
 				dehydrated: [
-					dehydrateAtom(openTasksAtom, AsyncResult.success(tasks)),
 					dehydrateAtom(companiesListAtom, AsyncResult.success(companies)),
 				] as const,
 			}
@@ -143,13 +221,26 @@ export const Route = createFileRoute('/tasks/')({
 
 function TasksPage() {
 	const { t } = useLingui()
-	const tasksResult = useAtomValue(openTasksAtom)
-	const snoozedResult = useAtomValue(snoozedTasksAtom)
-	const doneResult = useAtomValue(doneTasksAtom)
+	const [selectedShelf, setSelectedShelf] = useState<TaskShelf>('today')
+	// Fixed for as long as the page is open. Reading the clock on every render
+	// would hand every render a different atom to fetch.
+	const [dayKey] = useState(() => localDayKey())
+	const [visibleLimit, setVisibleLimit] = useState(TASKS_PAGE_SIZE)
+	// Moving to another shelf starts again at its first page.
+	useEffect(() => {
+		setVisibleLimit(TASKS_PAGE_SIZE)
+	}, [selectedShelf])
+
+	const shelfAtom = useMemo(
+		() => tasksShelfAtom(selectedShelf, dayKey, visibleLimit),
+		[selectedShelf, dayKey, visibleLimit],
+	)
+	const countsAtom = useMemo(() => taskCountsAtom(dayKey), [dayKey])
+	const tasksResult = useAtomValue(shelfAtom)
+	const countsResult = useAtomValue(countsAtom)
 	const companiesResult = useAtomValue(companiesListAtom)
-	const refreshTasks = useAtomRefresh(openTasksAtom)
-	const refreshSnoozed = useAtomRefresh(snoozedTasksAtom)
-	const refreshDone = useAtomRefresh(doneTasksAtom)
+	const refreshTasks = useAtomRefresh(shelfAtom)
+	const refreshCounts = useAtomRefresh(countsAtom)
 	const refreshCompanies = useAtomRefresh(companiesListAtom)
 	const completeTask = useAtomSet(completeTaskAtom, { mode: 'promiseExit' })
 	const reopenTask = useAtomSet(reopenTaskAtom, { mode: 'promiseExit' })
@@ -162,7 +253,6 @@ function TasksPage() {
 	const createTask = useAtomSet(createTaskAtom, { mode: 'promiseExit' })
 	const { open: openQuickCapture } = useQuickCapture()
 
-	const [selectedView, setSelectedView] = useState<SmartView>('today')
 	const { dlg, open: openDlg, close: closeDlg } = useDlg(tasksDlgSchema)
 	const undoOpen = dlg?.kind === 'recent-changes'
 
@@ -217,31 +307,22 @@ function TasksPage() {
 	)
 	const quickAddRef = useRef<HTMLInputElement | null>(null)
 
-	const openTasks = useMemo<ReadonlyArray<TaskRow>>(
-		() =>
-			AsyncResult.isSuccess(tasksResult)
-				? narrowTasks(tasksResult.value.items)
-				: [],
-		[tasksResult],
+	const loadedShelf = AsyncResult.isSuccess(tasksResult)
+		? tasksResult.value
+		: undefined
+	const visibleTasks = useMemo<ReadonlyArray<TaskRow>>(
+		() => (loadedShelf ? narrowTasks(loadedShelf.items) : []),
+		[loadedShelf],
 	)
-	const snoozedTasks = useMemo<ReadonlyArray<TaskRow>>(
-		() =>
-			AsyncResult.isSuccess(snoozedResult)
-				? narrowTasks(snoozedResult.value.items).filter(
-						t =>
-							t.snoozedUntil !== null &&
-							Date.parse(t.snoozedUntil) > Date.now(),
-					)
-				: [],
-		[snoozedResult],
-	)
-	const doneTasks = useMemo<ReadonlyArray<TaskRow>>(() => {
-		if (!AsyncResult.isSuccess(doneResult)) return []
-		const cutoff = Date.now() - 7 * 86400_000
-		return narrowTasks(doneResult.value.items).filter(
-			t => t.completedAt !== null && Date.parse(t.completedAt) >= cutoff,
-		)
-	}, [doneResult])
+	// How many the shelf holds altogether, which is what the rail promises —
+	// the rows in hand stop at whatever has been asked for so far.
+	const shelfTotal = loadedShelf?.total ?? 0
+	const hasMore = visibleTasks.length < shelfTotal
+
+	const counts = AsyncResult.isSuccess(countsResult)
+		? countsResult.value
+		: EMPTY_COUNTS
+	const openCount = OPEN_SHELVES.reduce((sum, shelf) => sum + counts[shelf], 0)
 
 	const companiesById = useMemo<Map<string, CompanyLookup>>(() => {
 		if (!AsyncResult.isSuccess(companiesResult)) return new Map()
@@ -264,33 +345,13 @@ function TasksPage() {
 		return map
 	}, [companiesResult])
 
-	const buckets = useMemo(() => bucketise(openTasks), [openTasks])
-
-	const visibleTasks = useMemo<ReadonlyArray<TaskRow>>(() => {
-		switch (selectedView) {
-			case 'today':
-				return buckets.today
-			case 'overdue':
-				return buckets.overdue
-			case 'this-week':
-				return buckets.thisWeek
-			case 'later':
-				return buckets.later
-			case 'no-due':
-				return buckets.noDue
-			case 'snoozed':
-				return snoozedTasks
-			case 'done':
-				return doneTasks
-		}
-	}, [selectedView, buckets, snoozedTasks, doneTasks])
-
+	// Any edit can move a task between shelves, so the sizes on the rail are
+	// refreshed alongside the list itself.
 	const refreshAll = useCallback(() => {
 		refreshTasks()
-		refreshSnoozed()
-		refreshDone()
+		refreshCounts()
 		refreshCompanies()
-	}, [refreshTasks, refreshSnoozed, refreshDone, refreshCompanies])
+	}, [refreshTasks, refreshCounts, refreshCompanies])
 
 	// Refresh when the window regains focus — catches webhook-driven
 	// edits (an agent updated a task in another tab or via MCP).
@@ -441,13 +502,13 @@ function TasksPage() {
 			}
 			if (gPrimed && ev.key === 'o') {
 				ev.preventDefault()
-				setSelectedView('overdue')
+				setSelectedShelf('overdue')
 				setGPrimed(false)
 				return
 			}
 			if (gPrimed && ev.key === 't') {
 				ev.preventDefault()
-				setSelectedView('today')
+				setSelectedShelf('today')
 				setGPrimed(false)
 				return
 			}
@@ -503,15 +564,9 @@ function TasksPage() {
 		)
 	}
 
-	// A link may name a task the current view doesn't show — a snoozed or
-	// already-finished one — so the other lists are searched before giving up.
 	const selectedTask =
 		selectedTaskId !== null
-			? (visibleTasks.find(r => r.id === selectedTaskId) ??
-				openTasks.find(r => r.id === selectedTaskId) ??
-				snoozedTasks.find(r => r.id === selectedTaskId) ??
-				doneTasks.find(r => r.id === selectedTaskId) ??
-				null)
+			? (visibleTasks.find(r => r.id === selectedTaskId) ?? null)
 			: null
 
 	return (
@@ -526,78 +581,27 @@ function TasksPage() {
 					</Subtitle>
 				</IntroText>
 				<KpiRow>
-					<KpiCounter value={openTasks.length} label={t`Open`} />
-					{buckets.overdue.length > 0 && (
-						<KpiCounter value={buckets.overdue.length} label={t`Overdue`} />
+					<KpiCounter value={openCount} label={t`Open`} />
+					{counts.overdue > 0 && (
+						<KpiCounter value={counts.overdue} label={t`Overdue`} />
 					)}
 				</KpiRow>
 			</Intro>
 
 			<Layout>
 				<Rail data-testid='tasks-view-rail'>
-					<RailButton
-						$active={selectedView === 'today'}
-						type='button'
-						onClick={() => setSelectedView('today')}
-						data-testid='tasks-view-today'
-					>
-						<Trans>Today</Trans>
-						<Count>{buckets.today.length}</Count>
-					</RailButton>
-					<RailButton
-						$active={selectedView === 'overdue'}
-						type='button'
-						onClick={() => setSelectedView('overdue')}
-						data-testid='tasks-view-overdue'
-					>
-						<Trans>Overdue</Trans>
-						<Count>{buckets.overdue.length}</Count>
-					</RailButton>
-					<RailButton
-						$active={selectedView === 'this-week'}
-						type='button'
-						onClick={() => setSelectedView('this-week')}
-						data-testid='tasks-view-this-week'
-					>
-						<Trans>This week</Trans>
-						<Count>{buckets.thisWeek.length}</Count>
-					</RailButton>
-					<RailButton
-						$active={selectedView === 'later'}
-						type='button'
-						onClick={() => setSelectedView('later')}
-						data-testid='tasks-view-later'
-					>
-						<Trans>Later</Trans>
-						<Count>{buckets.later.length}</Count>
-					</RailButton>
-					<RailButton
-						$active={selectedView === 'no-due'}
-						type='button'
-						onClick={() => setSelectedView('no-due')}
-						data-testid='tasks-view-no-due'
-					>
-						<Trans>No due date</Trans>
-						<Count>{buckets.noDue.length}</Count>
-					</RailButton>
-					<RailButton
-						$active={selectedView === 'snoozed'}
-						type='button'
-						onClick={() => setSelectedView('snoozed')}
-						data-testid='tasks-view-snoozed'
-					>
-						<Trans>Snoozed</Trans>
-						<Count>{snoozedTasks.length}</Count>
-					</RailButton>
-					<RailButton
-						$active={selectedView === 'done'}
-						type='button'
-						onClick={() => setSelectedView('done')}
-						data-testid='tasks-view-done'
-					>
-						<Trans>Done 7d</Trans>
-						<Count>{doneTasks.length}</Count>
-					</RailButton>
+					{SHELVES.map(({ shelf, testId, label }) => (
+						<RailButton
+							key={shelf}
+							$active={selectedShelf === shelf}
+							type='button'
+							onClick={() => setSelectedShelf(shelf)}
+							data-testid={testId}
+						>
+							{t(label)}
+							<Count>{counts[shelf]}</Count>
+						</RailButton>
+					))}
 					<RailDivider aria-hidden />
 					<RailButton
 						$active={false}
@@ -619,38 +623,55 @@ function TasksPage() {
 
 					{visibleTasks.length === 0 ? (
 						<EmptyState
-							title={emptyTitle(selectedView, t)}
-							description={emptyDescription(selectedView, t)}
+							title={t(shelfCopy(selectedShelf).emptyTitle)}
+							description={t(shelfCopy(selectedShelf).emptyDescription)}
 						/>
 					) : (
-						<Stack>
-							{visibleTasks.map(task => {
-								const companyId = task.companyId
-								const logInteractionProps =
-									companyId !== null
-										? {
-												onLogInteraction: () => handleLogInteraction(companyId),
+						<>
+							<Stack>
+								{visibleTasks.map(task => {
+									const companyId = task.companyId
+									const logInteractionProps =
+										companyId !== null
+											? {
+													onLogInteraction: () =>
+														handleLogInteraction(companyId),
+												}
+											: {}
+									return (
+										<TaskItem
+											key={task.id}
+											task={toTaskItemData(task)}
+											completed={task.status === 'done'}
+											overdue={
+												selectedShelf === 'overdue' ||
+												(task.dueAt !== null &&
+													Date.parse(task.dueAt) < startOfDay(Date.now()))
 											}
-										: {}
-								return (
-									<TaskItem
-										key={task.id}
-										task={toTaskItemData(task)}
-										completed={task.status === 'done'}
-										overdue={
-											selectedView === 'overdue' ||
-											(task.dueAt !== null &&
-												Date.parse(task.dueAt) < startOfDay(Date.now()))
+											onToggle={next => void handleToggle(task.id, next)}
+											onEditTitle={next => handleEditTitle(task.id, next)}
+											onEditDue={next => handleReschedule(task.id, next)}
+											onOpenDetail={() => openTask(task.id)}
+											{...logInteractionProps}
+										/>
+									)
+								})}
+							</Stack>
+							{hasMore && (
+								<LoadMoreWrap>
+									<PriButton
+										type='button'
+										$variant='outlined'
+										onClick={() =>
+											setVisibleLimit(shown => shown + TASKS_PAGE_SIZE)
 										}
-										onToggle={next => void handleToggle(task.id, next)}
-										onEditTitle={next => handleEditTitle(task.id, next)}
-										onEditDue={next => handleReschedule(task.id, next)}
-										onOpenDetail={() => openTask(task.id)}
-										{...logInteractionProps}
-									/>
-								)
-							})}
-						</Stack>
+										data-testid='tasks-load-more'
+									>
+										<span>{t`Load more`}</span>
+									</PriButton>
+								</LoadMoreWrap>
+							)}
+						</>
 					)}
 				</Column>
 			</Layout>
@@ -676,7 +697,7 @@ function TasksPage() {
 					if (next) openDlg({ kind: 'recent-changes' })
 					else closeDlg()
 				}}
-				tasks={openTasks}
+				tasks={visibleTasks}
 			/>
 		</Page>
 	)
@@ -873,9 +894,8 @@ function UndoDialog({
 	tasks: ReadonlyArray<TaskRow>
 }) {
 	const { t } = useLingui()
-	// Pull the latest `updated_at` from the already-loaded task list.
-	// A full cross-task event feed endpoint is out of scope for PR #4;
-	// per-task audit lives in the detail pane.
+	// Pull the latest `updated_at` from the tasks already on screen — there is
+	// no cross-task event feed; per-task audit lives in the detail pane.
 	const recent = useMemo(() => {
 		const withUpdate = tasks.filter(
 			(r): r is TaskRow & { updatedAt: string } => r.updatedAt !== null,
@@ -895,7 +915,8 @@ function UndoDialog({
 					</PriDialog.Title>
 					<PriDialog.Description>
 						<Trans>
-							The 20 most recently edited open tasks. Click one to reopen it.
+							The 20 most recently edited tasks on this shelf. Click one to
+							reopen it.
 						</Trans>
 					</PriDialog.Description>
 					{recent.length === 0 ? (
@@ -938,44 +959,6 @@ function startOfDay(ms: number): number {
 	const d = new Date(ms)
 	d.setHours(0, 0, 0, 0)
 	return d.getTime()
-}
-
-function isSameDay(a: number, b: number): boolean {
-	const da = new Date(a)
-	const db = new Date(b)
-	return (
-		da.getFullYear() === db.getFullYear() &&
-		da.getMonth() === db.getMonth() &&
-		da.getDate() === db.getDate()
-	)
-}
-
-function bucketise(tasks: ReadonlyArray<TaskRow>) {
-	const now = Date.now()
-	const sevenDaysOut = now + 7 * 86400_000
-	const overdue: TaskRow[] = []
-	const today: TaskRow[] = []
-	const thisWeek: TaskRow[] = []
-	const later: TaskRow[] = []
-	const noDue: TaskRow[] = []
-	for (const task of tasks) {
-		if (task.dueAt === null) {
-			noDue.push(task)
-			continue
-		}
-		const dueMs = Date.parse(task.dueAt)
-		if (dueMs < startOfDay(now)) overdue.push(task)
-		else if (isSameDay(dueMs, now)) today.push(task)
-		else if (dueMs < sevenDaysOut) thisWeek.push(task)
-		else later.push(task)
-	}
-	const byDue = (a: TaskRow, b: TaskRow) =>
-		Date.parse(a.dueAt ?? '') - Date.parse(b.dueAt ?? '')
-	overdue.sort(byDue)
-	today.sort(byDue)
-	thisWeek.sort(byDue)
-	later.sort(byDue)
-	return { overdue, today, thisWeek, later, noDue }
 }
 
 function narrowTasks(rows: ReadonlyArray<unknown>): ReadonlyArray<TaskRow> {
@@ -1153,47 +1136,6 @@ function atNineAm(daysFromNow: number): Date {
 	return d
 }
 
-function emptyTitle(view: SmartView, t: (s: TemplateStringsArray) => string) {
-	switch (view) {
-		case 'today':
-			return t`All under control`
-		case 'overdue':
-			return t`Nothing overdue`
-		case 'this-week':
-			return t`No tasks this week`
-		case 'later':
-			return t`Nothing later in the queue`
-		case 'no-due':
-			return t`Every task has a date`
-		case 'snoozed':
-			return t`Nothing snoozed`
-		case 'done':
-			return t`Nothing completed recently`
-	}
-}
-
-function emptyDescription(
-	view: SmartView,
-	t: (s: TemplateStringsArray) => string,
-) {
-	switch (view) {
-		case 'today':
-			return t`No pending tasks today. Time to prospect or take a walk.`
-		case 'overdue':
-			return t`The ledger is clean.`
-		case 'this-week':
-			return t`The week is clear — good time to plan.`
-		case 'later':
-			return t`No tasks scheduled beyond this week.`
-		case 'no-due':
-			return t`Every open task has a due date assigned.`
-		case 'snoozed':
-			return t`No tasks are sleeping.`
-		case 'done':
-			return t`No tasks completed in the last 7 days.`
-	}
-}
-
 // ── Styles ────────────────────────────────────────────────────────
 
 const Page = styled.div.withConfig({ displayName: 'TasksPage' })`
@@ -1317,6 +1259,12 @@ const Stack = styled.div.withConfig({ displayName: 'TasksStack' })`
 	display: flex;
 	flex-direction: column;
 	gap: 0;
+`
+
+const LoadMoreWrap = styled.div.withConfig({ displayName: 'TasksLoadMore' })`
+	display: flex;
+	justify-content: center;
+	padding: var(--space-md) 0;
 `
 
 const QuickAddRow = styled.form.withConfig({ displayName: 'TasksQuickAddRow' })`

--- a/apps/internal/src/routes/tasks/index.tsx
+++ b/apps/internal/src/routes/tasks/index.tsx
@@ -1,7 +1,7 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
-import { Trans, useLingui } from '@lingui/react/macro'
+import { Plural, Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
@@ -28,8 +28,10 @@ import {
 	updateTaskAtom,
 } from '#/atoms/tasks-atoms'
 import { EmptyState } from '#/components/shared/empty-state'
+import { ErrorState } from '#/components/shared/error-state'
 import { KpiCounter } from '#/components/shared/kpi-counter'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
+import { SrOnly } from '#/components/shared/sr-only'
 import {
 	TaskItem,
 	type TaskItemData,
@@ -222,9 +224,11 @@ export const Route = createFileRoute('/tasks/')({
 function TasksPage() {
 	const { t } = useLingui()
 	const [selectedShelf, setSelectedShelf] = useState<TaskShelf>('today')
-	// Fixed for as long as the page is open. Reading the clock on every render
-	// would hand every render a different atom to fetch.
-	const [dayKey] = useState(() => localDayKey())
+	// Which day it is where the reader sits. Held in state rather than read on
+	// every render, which would hand every render a different atom to fetch —
+	// but a tab left open overnight would then keep filing work under
+	// yesterday, so it is re-read whenever the window comes back to the front.
+	const [dayKey, setDayKey] = useState(() => localDayKey())
 	const [visibleLimit, setVisibleLimit] = useState(TASKS_PAGE_SIZE)
 	// Moving to another shelf starts again at its first page.
 	useEffect(() => {
@@ -306,10 +310,25 @@ function TasksPage() {
 		[],
 	)
 	const quickAddRef = useRef<HTMLInputElement | null>(null)
+	// The last version of the task the pane is showing.
+	const lastOpenTask = useRef<TaskRow | null>(null)
 
+	// Asking for another page means a fresh request, so the rows in hand would
+	// otherwise blank out mid-scroll and take the reader's place in the list
+	// with them. Holding the last page of *this* shelf keeps them on screen
+	// until the longer one arrives; moving to a different shelf drops them,
+	// because showing one shelf's work under another's name would be a lie.
+	const lastPage = useRef<
+		{ shelf: TaskShelf; page: PaginatedList<unknown> } | undefined
+	>(undefined)
+	if (AsyncResult.isSuccess(tasksResult)) {
+		lastPage.current = { shelf: selectedShelf, page: tasksResult.value }
+	}
 	const loadedShelf = AsyncResult.isSuccess(tasksResult)
 		? tasksResult.value
-		: undefined
+		: lastPage.current?.shelf === selectedShelf
+			? lastPage.current.page
+			: undefined
 	const visibleTasks = useMemo<ReadonlyArray<TaskRow>>(
 		() => (loadedShelf ? narrowTasks(loadedShelf.items) : []),
 		[loadedShelf],
@@ -324,6 +343,14 @@ function TasksPage() {
 		: EMPTY_COUNTS
 	const openCount = OPEN_SHELVES.reduce((sum, shelf) => sum + counts[shelf], 0)
 
+	// Only the arrival of rows is announced here. While they are on their way
+	// the spinner says "loading" out loud, and a failure is read out by the
+	// error message itself — repeating either would say it twice.
+	const shelfAnnouncement = AsyncResult.isSuccess(tasksResult)
+		? t`${t(shelfCopy(selectedShelf).label)}: showing ${visibleTasks.length} of ${shelfTotal} tasks.`
+		: ''
+
+	const companiesLoaded = AsyncResult.isSuccess(companiesResult)
 	const companiesById = useMemo<Map<string, CompanyLookup>>(() => {
 		if (!AsyncResult.isSuccess(companiesResult)) return new Map()
 		const map = new Map<string, CompanyLookup>()
@@ -356,7 +383,10 @@ function TasksPage() {
 	// Refresh when the window regains focus — catches webhook-driven
 	// edits (an agent updated a task in another tab or via MCP).
 	useEffect(() => {
-		const onFocus = () => refreshAll()
+		const onFocus = () => {
+			setDayKey(localDayKey())
+			refreshAll()
+		}
 		window.addEventListener('focus', onFocus)
 		return () => window.removeEventListener('focus', onFocus)
 	}, [refreshAll])
@@ -460,18 +490,24 @@ function TasksPage() {
 				task.companyId !== null
 					? (companiesById.get(task.companyId) ?? null)
 					: null
+			// "Personal" means the task belongs to nobody in particular — only
+			// true once the companies are in hand. While they are still on their
+			// way the name is left blank rather than mislabelling real accounts.
+			const companyName =
+				company?.name ??
+				(task.companyId === null || companiesLoaded ? t`Personal` : '')
 			return {
 				id: task.id,
 				title: task.title,
 				dueAt: task.dueAt,
 				companyId: task.companyId ?? '',
-				companyName: company?.name ?? t`Personal`,
+				companyName,
 				priority: task.priority,
 				source: task.source,
 				...(company?.slug !== undefined ? { companySlug: company.slug } : {}),
 			}
 		},
-		[companiesById, t],
+		[companiesById, companiesLoaded, t],
 	)
 
 	// ── Keyboard shortcuts (j/k, x, s, /, c, g o, g t, e) ──
@@ -553,21 +589,30 @@ function TasksPage() {
 		moveTaskSelection,
 	])
 
-	const isLoading =
-		AsyncResult.isInitial(tasksResult) || AsyncResult.isInitial(companiesResult)
+	// Only the list waits for its rows: blanking the whole page on every shelf
+	// switch would make the shelf buttons vanish under the pointer and send the
+	// keyboard back to the top of the page.
+	const isShelfPending = AsyncResult.isInitial(tasksResult) && !loadedShelf
+	const hasShelfFailed = AsyncResult.isFailure(tasksResult)
 
-	if (isLoading) {
-		return (
-			<Page>
-				<LoadingSpinner />
-			</Page>
-		)
-	}
+	const countsReady = AsyncResult.isSuccess(countsResult)
 
-	const selectedTask =
+	// Acting on a task from its own detail pane — snoozing it, cancelling it,
+	// ticking it off — usually moves it to another shelf. Keeping the last
+	// version of the open task means the pane stays put and shows the result
+	// instead of vanishing mid-interaction.
+	const onScreen =
 		selectedTaskId !== null
 			? (visibleTasks.find(r => r.id === selectedTaskId) ?? null)
 			: null
+	if (onScreen !== null) lastOpenTask.current = onScreen
+	const selectedTask =
+		selectedTaskId === null
+			? null
+			: (onScreen ??
+				(lastOpenTask.current?.id === selectedTaskId
+					? lastOpenTask.current
+					: null))
 
 	return (
 		<Page>
@@ -588,24 +633,50 @@ function TasksPage() {
 				</KpiRow>
 			</Intro>
 
+			{/* The list changes without the keyboard moving anywhere, so anyone not
+			 * looking at the screen gets no sign of it. This line sits outside the
+			 * column that swaps, because a spoken message that disappears along
+			 * with the list it describes is often never read out. */}
+			<SrOnly role='status' aria-live='polite'>
+				{shelfAnnouncement}
+			</SrOnly>
+
 			<Layout>
-				<Rail data-testid='tasks-view-rail'>
+				<Rail
+					as='div'
+					role='group'
+					aria-label={t`Filter tasks by shelf`}
+					aria-busy={!countsReady}
+					data-testid='tasks-view-rail'
+				>
 					{SHELVES.map(({ shelf, testId, label }) => (
 						<RailButton
 							key={shelf}
 							$active={selectedShelf === shelf}
 							type='button'
+							aria-pressed={selectedShelf === shelf}
 							onClick={() => setSelectedShelf(shelf)}
 							data-testid={testId}
 						>
 							{t(label)}
-							<Count>{counts[shelf]}</Count>
+							{/* The badge shows 0 until the real counts arrive so the buttons
+							 * keep their width, but reading "0" out loud would be wrong —
+							 * the number is only spoken once it is true. */}
+							<Count aria-hidden>{counts[shelf]}</Count>
+							<SrOnly>
+								{countsReady ? (
+									<Plural value={counts[shelf]} one='# task' other='# tasks' />
+								) : (
+									t`count loading`
+								)}
+							</SrOnly>
 						</RailButton>
 					))}
 					<RailDivider aria-hidden />
 					<RailButton
 						$active={false}
 						type='button'
+						aria-haspopup='dialog'
 						onClick={() => openDlg({ kind: 'recent-changes' })}
 						data-testid='tasks-recent-changes-open'
 					>
@@ -621,7 +692,19 @@ function TasksPage() {
 						placeholder={t`Quick add: "Call Acme tomorrow #high"`}
 					/>
 
-					{visibleTasks.length === 0 ? (
+					{isShelfPending ? (
+						<LoadingSpinner label={t`Loading tasks…`} />
+					) : hasShelfFailed ? (
+						// A shelf that failed to load must not read as a shelf with
+						// nothing on it — "the ledger is clean" would be a lie about
+						// work that is still waiting.
+						<ErrorState
+							data-testid='tasks-error'
+							title={t`Could not load these tasks`}
+							description={t`The list could not be fetched. Check the connection, then try again.`}
+							onRetry={refreshAll}
+						/>
+					) : visibleTasks.length === 0 ? (
 						<EmptyState
 							title={t(shelfCopy(selectedShelf).emptyTitle)}
 							description={t(shelfCopy(selectedShelf).emptyDescription)}
@@ -668,6 +751,7 @@ function TasksPage() {
 										data-testid='tasks-load-more'
 									>
 										<span>{t`Load more`}</span>
+										<SrOnly>{t`tasks — showing ${visibleTasks.length} of ${shelfTotal}`}</SrOnly>
 									</PriButton>
 								</LoadMoreWrap>
 							)}

--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -34,15 +34,35 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 									: _.query.completed === 'false'
 										? false
 										: undefined,
+							shelf: _.query.shelf,
+							// A shelf only means something once the caller says where
+							// its own day starts and ends.
+							boundaries:
+								_.query.todayStart && _.query.todayEnd && _.query.weekEnd
+									? {
+											todayStart: _.query.todayStart,
+											todayEnd: _.query.todayEnd,
+											weekEnd: _.query.weekEnd,
+										}
+									: undefined,
 							search: _.query.search,
 						},
 						{
-							sort: 'recent',
+							sort: _.query.sort ?? 'recent',
 							limit: _.query.limit ?? 50,
 							offset: _.query.offset ?? 0,
 						},
 					)
 				}).pipe(Effect.orDie),
+			)
+			.handle('counts', _ =>
+				taskService
+					.counts({
+						todayStart: _.query.todayStart,
+						todayEnd: _.query.todayEnd,
+						weekEnd: _.query.weekEnd,
+					})
+					.pipe(Effect.orDie),
 			)
 			.handle('get', _ => taskService.get(_.params.id))
 			.handle('create', _ =>

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -21,7 +21,12 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { CurrentOrg } from '@batuda/controllers'
 
 import { PgLive } from '../db/client'
-import { type TaskFilters, type TaskPage, TaskService } from './tasks'
+import {
+	type TaskDayBoundaries,
+	type TaskFilters,
+	type TaskPage,
+	TaskService,
+} from './tasks'
 import { TimelineActivityService } from './timeline-activity'
 
 const DATABASE_URL =
@@ -385,6 +390,376 @@ describe('TaskService.list', () => {
 			// THEN the separate count agrees there is genuinely nothing
 			expect(page.items).toHaveLength(0)
 			expect(page.total).toBe(0)
+		})
+	})
+
+	describe('when listing one shelf of the inbox', () => {
+		it('should return only the tasks nobody has dated for noDue', async () => {
+			// GIVEN one dated and one undated task for a unique assignee
+			const assignee = `shelf-fixture-${randomUUID()}`
+			const boundaries = boundariesAround(Date.now())
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} dated`,
+				status: 'open',
+				assigneeId: assignee,
+				dueAt: new Date(),
+			})
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} undated`,
+				status: 'open',
+				assigneeId: assignee,
+			})
+
+			// WHEN asking for the shelf of undated work
+			const rows = (
+				await listWith(tallerOrgId, {
+					assigneeId: assignee,
+					shelf: 'noDue',
+					boundaries,
+				})
+			).items as ReadonlyArray<{ dueAt: unknown }>
+
+			// THEN only the undated task comes back
+			expect(rows).toHaveLength(1)
+			expect(rows[0]?.dueAt).toBeNull()
+		})
+
+		it('should keep a task due earlier today on today rather than overdue', async () => {
+			// GIVEN a task that was due this morning, with the day already underway
+			const assignee = `shelf-fixture-${randomUUID()}`
+			const boundaries = boundariesAround(Date.now())
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} this morning`,
+				status: 'open',
+				assigneeId: assignee,
+				dueAt: new Date(Date.parse(boundaries.todayStart) + 3600_000),
+			})
+
+			// WHEN asking for each of the two shelves it could fall on
+			const today = await listWith(tallerOrgId, {
+				assigneeId: assignee,
+				shelf: 'today',
+				boundaries,
+			})
+			const overdue = await listWith(tallerOrgId, {
+				assigneeId: assignee,
+				shelf: 'overdue',
+				boundaries,
+			})
+
+			// THEN the day it is due decides, so an hour late is not yet late
+			expect(today.total).toBe(1)
+			expect(overdue.total).toBe(0)
+		})
+
+		it('should report the same size the rail counts for that shelf', async () => {
+			// GIVEN one task on each shelf, so none of them is trivially empty
+			const boundaries = boundariesAround(Date.now())
+			const day = Date.parse(boundaries.todayStart)
+			for (const [label, data] of [
+				['overdue', { dueAt: new Date(day - DAY_MS) }],
+				['today', { dueAt: new Date(day + 3600_000) }],
+				[
+					'thisWeek',
+					{ dueAt: new Date(Date.parse(boundaries.todayEnd) + 2 * DAY_MS) },
+				],
+				['later', { dueAt: new Date(Date.parse(boundaries.weekEnd) + DAY_MS) }],
+				['noDue', {}],
+				[
+					'snoozed',
+					{
+						dueAt: new Date(day + 3600_000),
+						snoozedUntil: new Date(Date.now() + 3 * DAY_MS),
+					},
+				],
+			] as const) {
+				await createWith(tallerOrgId, tallerOrgId, {
+					type: 'follow_up',
+					title: `${FIXTURE_TITLE} ${label}`,
+					status: 'open',
+					...data,
+				})
+			}
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} doneRecent`,
+				status: 'done',
+				completedAt: new Date(),
+			})
+
+			// WHEN each shelf is counted and then listed
+			const counts = await countsWith(tallerOrgId, boundaries)
+			const shelves = [
+				'overdue',
+				'today',
+				'thisWeek',
+				'later',
+				'noDue',
+				'snoozed',
+				'doneRecent',
+			] as const
+
+			// THEN the number on the rail matches the rows behind it, every time
+			for (const shelf of shelves) {
+				const page = await listWith(
+					tallerOrgId,
+					{ shelf, boundaries },
+					{ limit: 1 },
+				)
+				expect(counts[shelf]).toBeGreaterThan(0)
+				expect(page.total).toBe(counts[shelf])
+			}
+		})
+	})
+
+	describe('when ordering the page', () => {
+		it('should put the soonest deadline first for sort=due', async () => {
+			// GIVEN three tasks dated out of order
+			const assignee = `sort-fixture-${randomUUID()}`
+			const now = Date.now()
+			for (const [label, offset] of [
+				['middle', 2 * DAY_MS],
+				['last', 5 * DAY_MS],
+				['first', 1 * DAY_MS],
+			] as const) {
+				await createWith(tallerOrgId, tallerOrgId, {
+					type: 'follow_up',
+					title: `${FIXTURE_TITLE} ${label}`,
+					status: 'open',
+					assigneeId: assignee,
+					dueAt: new Date(now + offset),
+				})
+			}
+
+			// WHEN listing them soonest-first
+			const rows = (
+				await listWith(tallerOrgId, { assigneeId: assignee }, { sort: 'due' })
+			).items as ReadonlyArray<{ title: string }>
+
+			// THEN the nearest deadline leads and the furthest trails
+			expect(rows.map(r => r.title.split(' ').pop())).toEqual([
+				'first',
+				'middle',
+				'last',
+			])
+		})
+
+		it('should put the furthest deadline first for sort=recent', async () => {
+			// GIVEN three tasks dated out of order
+			const assignee = `sort-fixture-${randomUUID()}`
+			const now = Date.now()
+			for (const [label, offset] of [
+				['middle', 2 * DAY_MS],
+				['last', 5 * DAY_MS],
+				['first', 1 * DAY_MS],
+			] as const) {
+				await createWith(tallerOrgId, tallerOrgId, {
+					type: 'follow_up',
+					title: `${FIXTURE_TITLE} ${label}`,
+					status: 'open',
+					assigneeId: assignee,
+					dueAt: new Date(now + offset),
+				})
+			}
+
+			// WHEN listing them newest-first
+			const rows = (
+				await listWith(
+					tallerOrgId,
+					{ assigneeId: assignee },
+					{ sort: 'recent' },
+				)
+			).items as ReadonlyArray<{ title: string }>
+
+			// THEN the order is the exact reverse of the soonest-first one
+			expect(rows.map(r => r.title.split(' ').pop())).toEqual([
+				'last',
+				'middle',
+				'first',
+			])
+		})
+	})
+})
+
+const countsWith = (org: string, boundaries: TaskDayBoundaries) => {
+	const deps = Layer.mergeAll(
+		TaskService.layer,
+		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+	).pipe(
+		Layer.provideMerge(TimelineActivityService.layer),
+		Layer.provideMerge(PgLive),
+	)
+
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const tasks = yield* TaskService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${org}, true)`
+				return yield* tasks.counts(boundaries)
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.runPromise)
+}
+
+const DAY_MS = 86_400_000
+
+// The day and week edges a browser would send, taken from the machine running
+// the test.
+const boundariesAround = (reference: number): TaskDayBoundaries => {
+	const start = new Date(reference)
+	start.setHours(0, 0, 0, 0)
+	const end = new Date(reference)
+	end.setHours(23, 59, 59, 999)
+	return {
+		todayStart: start.toISOString(),
+		todayEnd: end.toISOString(),
+		weekEnd: new Date(end.getTime() + 7 * DAY_MS).toISOString(),
+	}
+}
+
+// Counts cover the whole organization and the seeded org already holds tasks,
+// so each test compares before/after instead of pinning an absolute number.
+describe('TaskService.counts', () => {
+	describe('when a task sits in each stretch of time', () => {
+		it('should add it to the shelf its due date falls in', async () => {
+			// GIVEN the counts before anything is added
+			const boundaries = boundariesAround(Date.now())
+			const before = await countsWith(tallerOrgId, boundaries)
+
+			// WHEN one task lands in each dated shelf, plus one with no date
+			const dueDates: ReadonlyArray<[string, Date]> = [
+				['overdue', new Date(Date.parse(boundaries.todayStart) - DAY_MS)],
+				['today', new Date(Date.parse(boundaries.todayStart) + 3600_000)],
+				['thisWeek', new Date(Date.parse(boundaries.todayEnd) + 2 * DAY_MS)],
+				['later', new Date(Date.parse(boundaries.weekEnd) + DAY_MS)],
+			]
+			for (const [shelf, dueAt] of dueDates) {
+				await createWith(tallerOrgId, tallerOrgId, {
+					type: 'follow_up',
+					title: `${FIXTURE_TITLE} ${shelf}`,
+					status: 'open',
+					dueAt,
+				})
+			}
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} noDue`,
+				status: 'open',
+			})
+
+			// THEN each shelf grew by exactly one
+			const after = await countsWith(tallerOrgId, boundaries)
+			expect(after.overdue).toBe(before.overdue + 1)
+			expect(after.today).toBe(before.today + 1)
+			expect(after.thisWeek).toBe(before.thisWeek + 1)
+			expect(after.later).toBe(before.later + 1)
+			expect(after.noDue).toBe(before.noDue + 1)
+		})
+	})
+
+	describe('when a task is due at the very start of today', () => {
+		it('should count it as today rather than overdue', async () => {
+			// GIVEN the counts before anything is added
+			const boundaries = boundariesAround(Date.now())
+			const before = await countsWith(tallerOrgId, boundaries)
+
+			// WHEN a task falls exactly on the boundary between the two shelves
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} boundary`,
+				status: 'open',
+				dueAt: new Date(boundaries.todayStart),
+			})
+
+			// THEN the day it is due wins, so nothing reads as already late
+			const after = await countsWith(tallerOrgId, boundaries)
+			expect(after.today).toBe(before.today + 1)
+			expect(after.overdue).toBe(before.overdue)
+		})
+	})
+
+	describe('when a task is not waiting to be worked', () => {
+		it('should keep a sleeping task off its date shelf', async () => {
+			// GIVEN the counts before anything is added
+			const boundaries = boundariesAround(Date.now())
+			const before = await countsWith(tallerOrgId, boundaries)
+
+			// WHEN a task due today is snoozed into next week
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} snoozed`,
+				status: 'open',
+				dueAt: new Date(Date.parse(boundaries.todayStart) + 3600_000),
+				snoozedUntil: new Date(Date.now() + 3 * DAY_MS),
+			})
+
+			// THEN it shows up as sleeping instead of as today's work
+			const after = await countsWith(tallerOrgId, boundaries)
+			expect(after.snoozed).toBe(before.snoozed + 1)
+			expect(after.today).toBe(before.today)
+		})
+
+		it('should keep a finished task off its date shelf', async () => {
+			// GIVEN the counts before anything is added
+			const boundaries = boundariesAround(Date.now())
+			const before = await countsWith(tallerOrgId, boundaries)
+
+			// WHEN a task due today is already done
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} finished`,
+				status: 'done',
+				completedAt: new Date(),
+				dueAt: new Date(Date.parse(boundaries.todayStart) + 3600_000),
+			})
+
+			// THEN it counts as recently finished, not as today's work
+			const after = await countsWith(tallerOrgId, boundaries)
+			expect(after.doneRecent).toBe(before.doneRecent + 1)
+			expect(after.today).toBe(before.today)
+		})
+
+		it('should leave a cancelled task off every shelf', async () => {
+			// GIVEN the counts before anything is added
+			const boundaries = boundariesAround(Date.now())
+			const before = await countsWith(tallerOrgId, boundaries)
+
+			// WHEN a task due today is cancelled instead of worked
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} cancelled`,
+				status: 'cancelled',
+				dueAt: new Date(Date.parse(boundaries.todayStart) + 3600_000),
+			})
+
+			// THEN nothing about the inbox changes
+			const after = await countsWith(tallerOrgId, boundaries)
+			expect(after).toEqual(before)
+		})
+	})
+
+	describe('when another organization holds the tasks', () => {
+		it('should count only the ones the active org can see', async () => {
+			// GIVEN a task due today in the taller org
+			const boundaries = boundariesAround(Date.now())
+			const before = await countsWith(restaurantOrgId, boundaries)
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} isolation`,
+				status: 'open',
+				dueAt: new Date(Date.parse(boundaries.todayStart) + 3600_000),
+			})
+
+			// WHEN the other org counts its own shelves
+			const after = await countsWith(restaurantOrgId, boundaries)
+
+			// THEN it sees none of the neighbour's work
+			expect(after).toEqual(before)
 		})
 	})
 })

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -393,6 +393,44 @@ describe('TaskService.list', () => {
 		})
 	})
 
+	describe('when a shelf is asked for without the day it refers to', () => {
+		it('should go on hiding sleeping tasks rather than returning everything', async () => {
+			// GIVEN one awake and one sleeping task for a unique assignee
+			const assignee = `shelf-fixture-${randomUUID()}`
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} awake`,
+				status: 'open',
+				assigneeId: assignee,
+				dueAt: new Date(),
+			})
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} sleeping`,
+				status: 'open',
+				assigneeId: assignee,
+				dueAt: new Date(),
+				snoozedUntil: new Date(Date.now() + 3 * DAY_MS),
+			})
+
+			// WHEN a shelf is named but the day edges it needs are missing, so no
+			// shelf can actually be applied
+			const page = await listWith(tallerOrgId, {
+				assigneeId: assignee,
+				shelf: 'today',
+			})
+
+			// THEN the ordinary rule that hides sleeping work still holds — naming
+			// a shelf must not switch every other filter off
+			expect(page.total).toBe(1)
+			expect(
+				(page.items as ReadonlyArray<{ title: string }>).map(r =>
+					r.title.split(' ').pop(),
+				),
+			).toEqual(['awake'])
+		})
+	})
+
 	describe('when listing one shelf of the inbox', () => {
 		it('should return only the tasks nobody has dated for noDue', async () => {
 			// GIVEN one dated and one undated task for a unique assignee
@@ -740,6 +778,38 @@ describe('TaskService.counts', () => {
 			// THEN nothing about the inbox changes
 			const after = await countsWith(tallerOrgId, boundaries)
 			expect(after).toEqual(before)
+		})
+	})
+
+	describe('when a sleeping task is not simply untouched', () => {
+		it('should still count it as snoozed once work has started on it', async () => {
+			// GIVEN the counts before anything is added
+			const boundaries = boundariesAround(Date.now())
+			const before = await countsWith(tallerOrgId, boundaries)
+
+			// WHEN a task someone already started is put to sleep
+			await createWith(tallerOrgId, tallerOrgId, {
+				type: 'follow_up',
+				title: `${FIXTURE_TITLE} started then snoozed`,
+				status: 'in_progress',
+				dueAt: new Date(Date.parse(boundaries.todayStart) + 3600_000),
+				snoozedUntil: new Date(Date.now() + 3 * DAY_MS),
+			})
+
+			// THEN it sits on the sleeping shelf rather than falling off all of them
+			const after = await countsWith(tallerOrgId, boundaries)
+			expect(after.snoozed).toBe(before.snoozed + 1)
+			const shelves = [
+				'overdue',
+				'today',
+				'thisWeek',
+				'later',
+				'noDue',
+				'doneRecent',
+			] as const
+			for (const shelf of shelves) {
+				expect(after[shelf]).toBe(before[shelf])
+			}
 		})
 	})
 

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -29,7 +29,29 @@ export interface TaskFilters {
 	readonly overdueOnly?: boolean | undefined
 	readonly includeSnoozed?: boolean | undefined
 	readonly completed?: boolean | undefined
+	readonly shelf?: TaskShelfName | undefined
+	readonly boundaries?: TaskDayBoundaries | undefined
 	readonly search?: string | undefined
+}
+
+// A task belongs to exactly one shelf, so the same name serves the list and
+// the count.
+export type TaskShelfName =
+	| 'overdue'
+	| 'today'
+	| 'thisWeek'
+	| 'later'
+	| 'noDue'
+	| 'snoozed'
+	| 'doneRecent'
+
+// The edges of the reader's own day and week, as instants. They come from the
+// browser because the server has no idea which timezone the reader is in, and
+// "today" is a different stretch of time in each one.
+export interface TaskDayBoundaries {
+	readonly todayStart: string
+	readonly todayEnd: string
+	readonly weekEnd: string
 }
 
 // `recent` surfaces newest-first for the web inbox; `due` surfaces the most
@@ -89,6 +111,39 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 		const sql = yield* SqlClient.SqlClient
 		const timeline = yield* TimelineActivityService
 
+		// Work still in play: nobody has finished it, nobody has called it off,
+		// and it is not sleeping until a later date.
+		const waiting = sql`status NOT IN ('done', 'cancelled')
+			AND (snoozed_until IS NULL OR snoozed_until <= now())`
+
+		// Where one shelf begins and ends. Listing a shelf and counting it both
+		// come through here, so a number on the rail and the rows underneath it
+		// can never describe different sets of tasks.
+		const shelfCondition = (
+			shelf: TaskShelfName,
+			boundaries: TaskDayBoundaries,
+		): Statement.Fragment => {
+			switch (shelf) {
+				case 'overdue':
+					return sql`${waiting} AND due_at < ${boundaries.todayStart}`
+				case 'today':
+					return sql`${waiting} AND due_at >= ${boundaries.todayStart}
+						AND due_at <= ${boundaries.todayEnd}`
+				case 'thisWeek':
+					return sql`${waiting} AND due_at > ${boundaries.todayEnd}
+						AND due_at <= ${boundaries.weekEnd}`
+				case 'later':
+					return sql`${waiting} AND due_at > ${boundaries.weekEnd}`
+				case 'noDue':
+					return sql`${waiting} AND due_at IS NULL`
+				case 'snoozed':
+					return sql`status = 'open' AND snoozed_until > now()`
+				case 'doneRecent':
+					return sql`status = 'done'
+						AND completed_at >= now() - interval '7 days'`
+			}
+		}
+
 		const conditionsFor = (
 			orgId: string,
 			filters: TaskFilters,
@@ -112,8 +167,11 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 				conditions.push(sql`due_at <= ${filters.dueBefore}`)
 			if (filters.overdueOnly)
 				conditions.push(sql`due_at < now() AND status = 'open'`)
-			// Snoozed rows hide by default; includeSnoozed surfaces them.
-			if (filters.includeSnoozed !== true)
+			if (filters.shelf && filters.boundaries)
+				conditions.push(shelfCondition(filters.shelf, filters.boundaries))
+			// Snoozed rows hide by default; includeSnoozed surfaces them. A shelf
+			// already says where sleeping tasks belong, so it opts out.
+			if (filters.includeSnoozed !== true && filters.shelf === undefined)
 				conditions.push(sql`(snoozed_until IS NULL OR snoozed_until <= now())`)
 			// `completed=false` excludes cancelled as well as done — a cancelled
 			// task is not open work. Shared by both transports so the meaning of
@@ -226,6 +284,37 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 
 					const items = yield* decodeTasks(rows).pipe(Effect.orDie)
 					return { items, total, limit: page.limit, offset: page.offset }
+				}),
+
+			// Every shelf sized in one pass, so the rail can show real totals
+			// without fetching the tasks behind them.
+			counts: (boundaries: TaskDayBoundaries) =>
+				Effect.gen(function* () {
+					const currentOrg = yield* CurrentOrg
+					const tally = (shelf: TaskShelfName) =>
+						sql`count(*) FILTER (WHERE ${shelfCondition(shelf, boundaries)})`
+					const rows = yield* sql<Record<TaskShelfName, string | number>>`
+						SELECT
+							${tally('overdue')} AS "overdue",
+							${tally('today')} AS "today",
+							${tally('thisWeek')} AS "thisWeek",
+							${tally('later')} AS "later",
+							${tally('noDue')} AS "noDue",
+							${tally('snoozed')} AS "snoozed",
+							${tally('doneRecent')} AS "doneRecent"
+						FROM tasks
+						WHERE organization_id = ${currentOrg.id}
+					`
+					const row = rows[0]
+					return {
+						overdue: Number(row?.overdue ?? 0),
+						today: Number(row?.today ?? 0),
+						thisWeek: Number(row?.thisWeek ?? 0),
+						later: Number(row?.later ?? 0),
+						noDue: Number(row?.noDue ?? 0),
+						snoozed: Number(row?.snoozed ?? 0),
+						doneRecent: Number(row?.doneRecent ?? 0),
+					}
 				}),
 
 			complete: (id: string, actor: TaskActor) =>

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -55,8 +55,9 @@ export interface TaskDayBoundaries {
 }
 
 // `recent` surfaces newest-first for the web inbox; `due` surfaces the most
-// overdue first for an agent picking the next thing to act on.
-export type TaskSort = 'recent' | 'due'
+// overdue first for an agent picking the next thing to act on; `completed`
+// orders finished work by when it was actually finished.
+export type TaskSort = 'recent' | 'due' | 'completed'
 
 export interface TaskPage {
 	readonly sort: TaskSort
@@ -137,7 +138,10 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 				case 'noDue':
 					return sql`${waiting} AND due_at IS NULL`
 				case 'snoozed':
-					return sql`status = 'open' AND snoozed_until > now()`
+					// Any unfinished task can be put to sleep, not only an untouched
+					// one — a blocked or in-progress task still belongs here.
+					return sql`status NOT IN ('done', 'cancelled')
+						AND snoozed_until > now()`
 				case 'doneRecent':
 					return sql`status = 'done'
 						AND completed_at >= now() - interval '7 days'`
@@ -167,11 +171,18 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 				conditions.push(sql`due_at <= ${filters.dueBefore}`)
 			if (filters.overdueOnly)
 				conditions.push(sql`due_at < now() AND status = 'open'`)
-			if (filters.shelf && filters.boundaries)
-				conditions.push(shelfCondition(filters.shelf, filters.boundaries))
+			// A shelf needs the day edges to mean anything, so the two travel
+			// together or not at all.
+			const shelf =
+				filters.shelf && filters.boundaries
+					? shelfCondition(filters.shelf, filters.boundaries)
+					: undefined
+			if (shelf) conditions.push(shelf)
 			// Snoozed rows hide by default; includeSnoozed surfaces them. A shelf
-			// already says where sleeping tasks belong, so it opts out.
-			if (filters.includeSnoozed !== true && filters.shelf === undefined)
+			// already says where sleeping tasks belong, so it opts out — but only
+			// when one actually applied, or asking for a shelf without the day
+			// edges would drop every filter at once.
+			if (filters.includeSnoozed !== true && shelf === undefined)
 				conditions.push(sql`(snoozed_until IS NULL OR snoozed_until <= now())`)
 			// `completed=false` excludes cancelled as well as done — a cancelled
 			// task is not open work. Shared by both transports so the meaning of

--- a/packages/controllers/src/routes/tasks.ts
+++ b/packages/controllers/src/routes/tasks.ts
@@ -129,9 +129,10 @@ export const TasksGroup = HttpApiGroup.make('tasks')
 				todayStart: Schema.optional(Schema.String),
 				todayEnd: Schema.optional(Schema.String),
 				weekEnd: Schema.optional(Schema.String),
-				// `due` leads with the soonest deadline; `recent` leads with the
-				// latest date on the task — its due date, or when it was created.
-				sort: Schema.optional(Schema.Literals(['recent', 'due'])),
+				// `due` leads with the soonest deadline; `recent` with the latest
+				// date on the task — its due date, or when it was created; and
+				// `completed` with the most recently finished.
+				sort: Schema.optional(Schema.Literals(['recent', 'due', 'completed'])),
 				limit: Schema.optional(Schema.NumberFromString),
 				offset: Schema.optional(Schema.NumberFromString),
 			},

--- a/packages/controllers/src/routes/tasks.ts
+++ b/packages/controllers/src/routes/tasks.ts
@@ -24,6 +24,30 @@ export const BulkCompleteResult = Schema.Struct({
 	ids: Schema.Array(Schema.String),
 })
 
+// The shelves the task inbox sorts work onto — a task belongs to exactly one.
+export const TaskShelf = Schema.Literals([
+	'overdue',
+	'today',
+	'thisWeek',
+	'later',
+	'noDue',
+	'snoozed',
+	'doneRecent',
+])
+
+// How many tasks sit in each shelf of the inbox. Counted over the whole
+// organization, so a shelf shows its real size even when the screen only
+// holds its first page.
+export const TaskCounts = Schema.Struct({
+	overdue: Schema.Number,
+	today: Schema.Number,
+	thisWeek: Schema.Number,
+	later: Schema.Number,
+	noDue: Schema.Number,
+	snoozed: Schema.Number,
+	doneRecent: Schema.Number,
+})
+
 // ── Input schemas ──
 
 export const CreateTaskInput = Schema.Struct({
@@ -95,14 +119,35 @@ export const TasksGroup = HttpApiGroup.make('tasks')
 				dueFrom: Schema.optional(Schema.String),
 				dueTo: Schema.optional(Schema.String),
 				search: Schema.optional(Schema.String),
-				// Legacy alias kept until the Forja tasks inbox is rewritten in PR #4
-				// (§7 of the calendar plan). `completed=true` → status='done';
-				// `completed=false` → status NOT IN ('done','cancelled').
+				// Status alias for callers that only care whether work is finished.
+				// `completed=true` → status='done'; `completed=false` → status NOT
+				// IN ('done','cancelled').
 				completed: Schema.optional(Schema.String),
+				// One shelf of the inbox. Needs the day edges below to know where
+				// "today" starts and ends for whoever is asking.
+				shelf: Schema.optional(TaskShelf),
+				todayStart: Schema.optional(Schema.String),
+				todayEnd: Schema.optional(Schema.String),
+				weekEnd: Schema.optional(Schema.String),
+				// `due` leads with the soonest deadline; `recent` leads with the
+				// latest date on the task — its due date, or when it was created.
+				sort: Schema.optional(Schema.Literals(['recent', 'due'])),
 				limit: Schema.optional(Schema.NumberFromString),
 				offset: Schema.optional(Schema.NumberFromString),
 			},
 			success: PaginatedList(Task.json),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.get('counts', '/tasks/counts', {
+			// The caller sends the edges of its own day and week, because only it
+			// knows which timezone the person reading the screen is in.
+			query: {
+				todayStart: Schema.String,
+				todayEnd: Schema.String,
+				weekEnd: Schema.String,
+			},
+			success: TaskCounts,
 		}),
 	)
 	.add(


### PR DESCRIPTION
## What

Three counters in the CRM web app (`internal`) were telling me numbers that weren't true, and the task inbox was quietly hiding work.

The task inbox is the page listing everything I have to do, sorted into sections — today, overdue, this week, later, no due date, snoozed, recently done. It used to ask the server for one batch of tasks and sort them into those sections in the browser. The server caps a batch at fifty. So past fifty open tasks the sections stopped agreeing with reality: the number beside a section counted only what had been fetched, and tasks that didn't make the batch simply vanished from the page — no "load more", no indication anything was missing. The dashboard's "Open tasks" counter had the same problem and would sit at fifty forever.

Now the server decides which section a task belongs to and how many are in each, so a number and the list beneath it always describe the same set of tasks, and a long section offers to load more.

## Changes

- The server understands a *shelf* — one section of the inbox — and answers two questions about it: give me a page of it, and how big is it. Both go through a single definition, so the count and the list can't drift apart.
- The browser asks for one shelf at a time, with a "Load more" when a shelf runs past a page.
- The dashboard's "Open tasks" counter reads the total the server reports instead of counting the rows it happened to receive.
- The `/companies` counter no longer calls itself "In pipeline". It counts every company the filters match, closed and dead ones included, so it now reads "All companies" — or "Matching" once a filter is on. The dashboard's own counter deliberately excludes closed and dead, and the two labels were contradicting each other over the same organization.
- Seed data now spreads tasks across every shelf, with one shelf deliberately longer than a page.

Review of this branch turned up defects worth naming, all fixed here:

- Naming a shelf without the day it refers to switched off the rule that hides sleeping tasks, so the answer came back with far more work than it should have. Two guards disagreed about when a shelf had actually applied.
- A sleeping task only counted as snoozed while nobody had started it, so one that was blocked or in progress sat on no shelf at all — invisible in the inbox and missing from every total.
- Changing shelf or asking for more replaced the whole page with a spinner, pulling the rail out from under the pointer and sending the keyboard back to the top of the page.
- A shelf that failed to load showed the same reassuring "nothing here" message as an empty one, so a connection problem read as finished work.
- A tab left open overnight went on filing work under the previous day; the detail pane closed itself whenever the task it showed moved shelves — which is exactly what snoozing or completing it from that pane does.
- "Done 7d" was ordered by due date, so something just ticked off could land past the first page. It reads by when work was finished now.
- The rail says which shelf is selected and what its numbers count, and announces the shelf you moved to.

## Impact

- **Wire shape** — `GET /v1/tasks` gains optional `shelf`, `todayStart`, `todayEnd`, `weekEnd` and `sort`; a new `GET /v1/tasks/counts` returns the seven totals. All additive: every existing caller behaves exactly as before, including the `sort` default.
- **MCP and HTTP parity** — both transports share `TaskService`. The MCP task tools pass no `shelf`, so the new branch never engages for them and their behavior is unchanged.
- **No migration, no new environment variables.** Nothing to run before deploying, nothing production must set.
- **Timezone** — a shelf only means something relative to the reader's own day, so the browser sends the edges of its day and week. The server never guesses a timezone.
- **Multi-org** — the counts query is scoped by `organization_id` the same way the list query is, on top of the row-level-security policy.
- **One thing got slower to paint**: the task list no longer arrives pre-rendered with the page, because the server can't know the reader's timezone and would otherwise paint the wrong shelves. Hard-loading `/tasks` shows a brief spinner. Company data still arrives with the page.

## Review guide

- **Start at** `apps/server/src/services/tasks.ts` → `shelfCondition()`. It is the whole idea: one definition of each shelf, used by both the list and the counts. If that's right, the rest follows.
- **Riskiest part** is the shelf boundaries — a task must land on exactly one shelf, never zero, never two. The integration tests pin this, including a task due at the exact stroke of midnight and one due earlier today (which stays on "Today" rather than jumping to "Overdue" the moment its hour passes — the deliberate choice not to use the server's existing instant-based `overdueOnly`).
- **A decision you might overrule**: I dropped the server-rendered first paint for the task list rather than build a timezone cookie. Reversible either way.
- **Skip** the `.po` catalogs — generated.
- Snyk was not available in this session, so no dependency scan ran. The change adds no dependencies and no new external input.

## Screenshots

**Task inbox** — every shelf shows its real size, and the dashboard counter reads 106 where it used to stop at 50.

| Desktop | Mobile |
| --- | --- |
| ![tasks desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-333/tasks-desktop.webp) | ![tasks mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-333/tasks-mobile.webp) |

"Later" holds 55, so it shows a page and offers the rest:

![load more](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-333/tasks-desktop-loadmore.webp)

**Companies** — the counter says what it counts.

| Desktop | Mobile |
| --- | --- |
| ![companies desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-333/companies-desktop.webp) | ![companies mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-333/companies-mobile.webp) |

## Tests

Integration tests against real Postgres in `apps/server/src/services/tasks.integration.test.ts`, including one that asserts the invariant this PR exists for: for every one of the seven shelves, the count and the list report the same size.

## Verification

Rebased onto current `main` after four commits landed under it, including one that moved the task pane and the recent-changes dialog into the address bar. That conflicted with this branch's rewrite of the same page; the merged result keeps the address-driven panes — verified live: opening a task writes `?dlg=` and Back steps out of it.

- `pnpm check-types`, `pnpm test`, `pnpm build` — all green, before and after the rebase.
- `pnpm --filter @batuda/server test:integration src/services/tasks.integration.test.ts` — 34 passed. The two guarding the defects above were confirmed to fail with their fixes reverted, so they guard something real.
- Drove the running app against a seeded worktree database and compared every shelf to a direct SQL count. Before the rebase: today 8, overdue 22, this week 10, later 55, no due date 11, snoozed 3, done 5 — "Later" showed 50 rows plus "Load more", then 55 with the button gone. After the rebase, on a later date: overdue 30, today 2, this week 9, later 54, no due date 11, snoozed 3, done 5 — matching the database on all seven.
- With 106 open tasks seeded, the dashboard counter read 106; before this change it would have read 50.
- `/companies` reads "120 companies / All companies", and "39 companies with filters applied / Matching" under `?status=prospect`.
- Not proven: that "Load more" never blanks the list mid-fetch. My probe kept measuring a page a previous run had already paged — clicking an already-selected shelf does not reset the window, so the list legitimately showed every row with no button. The end state is right and it is the same code path proven frame-by-frame for shelf switches, but I never captured the intermediate frames.

## Deferred

- The "Recent changes" drawer now only sees the shelf currently open. Making it span everything needs a sort by last-edited that the endpoint doesn't offer yet.
- The per-row "overdue" styling still derives its own notion of today from the browser clock, separately from the shelf the server assigned. They agree today; worth unifying.
- Two pre-existing accessibility gaps on this page, both older than this branch: single-character shortcuts (`x` completes a task, `s` snoozes it) with no way to turn them off or remap them, and a focus indicator on the rail at roughly 1.7:1 where WCAG asks for 3:1.
