### PR TITLE
feat(research): show what a proposed change would write, and stop reporting work that never happened

### DIFF
--- a/apps/cli/src/commands/seed/research.ts
+++ b/apps/cli/src/commands/seed/research.ts
@@ -3053,6 +3053,28 @@ const TALLER_RUN_SPECS: ReadonlyArray<RunSpec> = [
 						],
 					},
 				}),
+				// Two addresses that disagree, with the bad one listed first: one
+				// deliverable address still reaches the person, so this belongs in
+				// "Ready to apply" and the best verdict has to win over the first.
+				proposal({
+					key: 'trusted-mixed-verdicts',
+					citation: {
+						sourceId: 'src_firecrawl_001',
+						quote: 'Sílvia Roig, reserves de grups',
+						confidence: 0.9,
+					},
+					subjectTable: 'contacts',
+					operation: 'create',
+					reason: 'Group-bookings contact; old address still on the page',
+					fields: {
+						name: 'Sílvia Roig',
+						company_id: CAL_PEP_ID,
+						channels: [
+							channel('email', 'grups@calpepfonda.es', 'undeliverable', 0.35),
+							channel('email', 'silvia@calpepfonda.cat', 'deliverable', 0.94),
+						],
+					},
+				}),
 				proposal({
 					key: 'trusted-percent',
 					citation: {

--- a/apps/internal/src/atoms/research-atoms.ts
+++ b/apps/internal/src/atoms/research-atoms.ts
@@ -119,6 +119,9 @@ export type PendingProposal = {
 	readonly runQuery: string
 	readonly runCreatedAt: unknown
 	readonly runCostCents: number
+	// Paid lookups are tallied apart from the cheap work; both belong to the run,
+	// not to this one proposal.
+	readonly runPaidCostCents: number
 	readonly proposedUpdateId: string | null
 	readonly subjectTable: string | null
 	readonly subjectId: string | null
@@ -128,6 +131,15 @@ export type PendingProposal = {
 	readonly confidence: number | null
 	readonly verification: string | null
 	readonly machineCheckable: boolean
+	// The values this change would write, and the pages they were read from. Both
+	// arrive as plain JSON of no fixed shape, so a reader narrows them itself
+	// rather than trusting a shape nothing enforces.
+	readonly fields: unknown
+	readonly citations: ReadonlyArray<unknown>
+	// What the record holds today for those same fields, so a reader can see what
+	// a value replaces. Null when the change would create a new record, and a
+	// field is absent when the record has nothing there yet.
+	readonly subjectCurrent: unknown
 }
 
 export type PendingProposalsParams = {

--- a/apps/internal/src/atoms/research-atoms.ts
+++ b/apps/internal/src/atoms/research-atoms.ts
@@ -199,6 +199,41 @@ export function pendingProposalsAtom(params: PendingProposalsParams = {}) {
 	return atom
 }
 
+/**
+ * One paid lookup waiting on a decision, anywhere in the org. A run parks these
+ * and stops before spending, so this is the only place they surface together.
+ */
+export type PendingPaidAction = {
+	readonly researchId: string
+	readonly runQuery: string
+	readonly runStatus: string
+	readonly runCreatedAt: unknown
+	readonly actionId: string | null
+	readonly tool: string
+	readonly args: unknown
+	readonly estimatedCents: number | null
+	readonly reason: string | null
+	readonly subjectTable: string | null
+	readonly subjectId: string | null
+	readonly subjectName: string | null
+}
+
+let pendingPaidActionsAtomCache:
+	| ReturnType<typeof makePendingPaidActionsAtom>
+	| undefined
+
+function makePendingPaidActionsAtom(limit: number) {
+	return BatudaApiAtom.query('research', 'listPendingPaidActions', {
+		query: { limit },
+		serializationKey: `research:pending-paid-actions:${limit}`,
+	})
+}
+
+export function pendingPaidActionsAtom(limit: number) {
+	pendingPaidActionsAtomCache ??= makePendingPaidActionsAtom(limit)
+	return pendingPaidActionsAtomCache
+}
+
 const eventsCache = new Map<string, ReturnType<typeof makeEventsAtom>>()
 
 function makeEventsAtom(researchId: string) {

--- a/apps/internal/src/components/companies/research-summary-card.tsx
+++ b/apps/internal/src/components/companies/research-summary-card.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { PriButton } from '@batuda/ui/pri'
 
+import { statusLabel } from '#/components/research/run-labels'
 import type { ResearchRunRow } from '#/components/research/run-shapes'
 import { RelativeDate } from '#/components/shared/relative-date'
 import {
@@ -23,7 +24,7 @@ export function ResearchSummaryCard({
 	readonly lastEnrichedAt: string | null
 	readonly onRunNew: () => void
 }) {
-	const { t } = useLingui()
+	const { t, i18n } = useLingui()
 	const latest = runs[0] ?? null
 
 	return (
@@ -68,7 +69,14 @@ export function ResearchSummaryCard({
 					<LatestRow>
 						<Query title={latest.query}>{latest.query}</Query>
 						<Meta>
-							<Status>{latest.status}</Status>
+							<Status>
+								{(() => {
+									// The stored word was shown as-is, so this read
+									// "succeeded_low_confidence" on a company's own page.
+									const label = statusLabel(latest.status)
+									return label ? i18n._(label) : latest.status
+								})()}
+							</Status>
 							<Dot>·</Dot>
 							<RelativeDate value={latest.createdAt} fallback={t`unknown`} />
 						</Meta>

--- a/apps/internal/src/components/research/field-diff.test.ts
+++ b/apps/internal/src/components/research/field-diff.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	displayValue,
+	fieldChanges,
+	humanizeFieldKey,
+	proposedChannels,
+} from './field-diff'
+
+describe('fieldChanges', () => {
+	describe('when the record already holds a value for a proposed field', () => {
+		it('should pair the proposed value with the current one', () => {
+			// GIVEN a change proposing a new industry
+			// WHEN the record already records an industry
+			const changes = fieldChanges(
+				{ industry: 'restaurants' },
+				{ industry: 'hospitality' },
+			)
+			// THEN both sides travel together so the reader sees the replacement
+			expect(changes).toEqual([
+				{
+					key: 'industry',
+					from: 'hospitality',
+					to: 'restaurants',
+					unchanged: false,
+				},
+			])
+		})
+	})
+
+	describe('when the record holds nothing for a proposed field', () => {
+		it('should report the change as an addition', () => {
+			// GIVEN a record with nothing on file for the field
+			const changes = fieldChanges({ industry: 'restaurants' }, {})
+			// THEN there is no previous value to show
+			expect(changes[0]?.from).toBeNull()
+			expect(changes[0]?.unchanged).toBe(false)
+		})
+
+		it('should treat a missing current record as an addition', () => {
+			// GIVEN a change that would create a brand-new record
+			const changes = fieldChanges({ industry: 'restaurants' }, null)
+			expect(changes[0]?.from).toBeNull()
+		})
+	})
+
+	describe('when the field name is written the other way round', () => {
+		it('should still find the value the record holds', () => {
+			// GIVEN a change naming the field in one style
+			// WHEN the record names the same field in the other
+			const changes = fieldChanges(
+				{ currentTools: 'Notion' },
+				{ current_tools: 'Excel' },
+			)
+			// THEN the previous value is found rather than reported as absent,
+			// because both spellings are accepted when the change is applied
+			expect(changes[0]?.from).toBe('Excel')
+		})
+	})
+
+	describe('when the proposed value matches what is already there', () => {
+		it('should mark it as no change', () => {
+			const changes = fieldChanges({ country: 'ES' }, { country: 'ES' })
+			expect(changes[0]?.unchanged).toBe(true)
+		})
+	})
+
+	describe('when a value arrives wrapped with the page it came from', () => {
+		it('should read the value out of the wrapper', () => {
+			// GIVEN a value stored alongside its source
+			const changes = fieldChanges(
+				{ industry: { value: 'restaurants', source_id: 'src_1' } },
+				{},
+			)
+			// THEN the reader sees the value, not the wrapper
+			expect(changes[0]?.to).toBe('restaurants')
+		})
+	})
+
+	describe('when fields are handled elsewhere on the row', () => {
+		it('should leave out the name, contact points and owning company', () => {
+			const changes = fieldChanges(
+				{
+					name: 'Rosa',
+					channels: [{ kind: 'email', value: 'r@x.cat' }],
+					company_id: 'abc',
+					companyId: 'abc',
+					industry: 'restaurants',
+				},
+				{},
+			)
+			expect(changes.map(c => c.key)).toEqual(['industry'])
+		})
+	})
+
+	describe('when a proposed value is empty', () => {
+		it('should skip it rather than show a blank change', () => {
+			// GIVEN values that amount to nothing
+			const changes = fieldChanges(
+				{ a: null, b: undefined, c: '   ', d: [], e: {} },
+				{},
+			)
+			// THEN none of them is offered as a change
+			expect(changes).toEqual([])
+		})
+	})
+
+	describe('when given something that is not a set of fields', () => {
+		it('should return nothing', () => {
+			// GIVEN shapes the server should never send
+			for (const bad of [null, undefined, 'x', 3, []]) {
+				expect(fieldChanges(bad, {})).toEqual([])
+			}
+		})
+	})
+})
+
+describe('displayValue', () => {
+	describe('when given a list', () => {
+		it('should read it out as one line', () => {
+			expect(displayValue(['a', 'b'])).toBe('a, b')
+		})
+	})
+
+	describe('when given a number or a yes/no', () => {
+		it('should show it rather than dropping it', () => {
+			expect(displayValue(0)).toBe('0')
+			expect(displayValue(false)).toBe('false')
+		})
+	})
+})
+
+describe('proposedChannels', () => {
+	describe('when a change proposes ways to reach someone', () => {
+		it('should list each with its checked status', () => {
+			const channels = proposedChannels({
+				channels: [
+					{ kind: 'email', value: 'a@x.cat', verification: 'deliverable' },
+					{ kind: 'phone', value: '+34 900' },
+				],
+			})
+			expect(channels).toEqual([
+				{ kind: 'email', value: 'a@x.cat', verification: 'deliverable' },
+				{ kind: 'phone', value: '+34 900', verification: null },
+			])
+		})
+	})
+
+	describe('when an entry is malformed', () => {
+		it('should skip it and keep the rest', () => {
+			const channels = proposedChannels({
+				channels: [null, { kind: 'email' }, { value: 'x@y.cat' }, 'nope', 3],
+			})
+			expect(channels).toEqual([])
+		})
+	})
+
+	describe('when there are no contact points at all', () => {
+		it('should return nothing', () => {
+			expect(proposedChannels({})).toEqual([])
+			expect(proposedChannels(null)).toEqual([])
+			expect(proposedChannels({ channels: 'not a list' })).toEqual([])
+		})
+	})
+})
+
+describe('humanizeFieldKey', () => {
+	describe('when a field name comes off the wire', () => {
+		it('should read it as words however it was spelled', () => {
+			expect(humanizeFieldKey('sizeRange')).toBe('Size range')
+			expect(humanizeFieldKey('size_range')).toBe('Size range')
+			expect(humanizeFieldKey('painPoints')).toBe('Pain points')
+			expect(humanizeFieldKey('country')).toBe('Country')
+		})
+	})
+})

--- a/apps/internal/src/components/research/field-diff.ts
+++ b/apps/internal/src/components/research/field-diff.ts
@@ -1,0 +1,130 @@
+/**
+ * Turning a proposed change into "what the record says now" versus "what it
+ * would say", so someone deciding on it can see what a value replaces instead of
+ * only the new value. Kept free of JSX so it can be unit-tested plainly.
+ */
+
+/** Handled elsewhere on the row, so they are left out of the value list. */
+const SKIPPED_FIELDS = new Set(['name', 'channels', 'companyId', 'company_id'])
+
+export type FieldChange = {
+	readonly key: string
+	/** What the record holds now, or null when it holds nothing yet. */
+	readonly from: string | null
+	readonly to: string
+	/** The new value matches what is already there, so nothing would change. */
+	readonly unchanged: boolean
+}
+
+/**
+ * A value can arrive on its own, or wrapped together with the page it was read
+ * from. Both mean the same thing to a reader, so the wrapper is unwrapped before
+ * anything is shown — otherwise the row displays the wrapper itself.
+ */
+function unwrap(value: unknown): unknown {
+	if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+		const o = value as Record<string, unknown>
+		if ('value' in o) return o['value']
+	}
+	return value
+}
+
+/** A value as a person would read it, or null when there is nothing to show. */
+export function displayValue(value: unknown): string | null {
+	const v = unwrap(value)
+	if (v === null || v === undefined) return null
+	if (typeof v === 'string') return v.trim() === '' ? null : v
+	if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+	if (Array.isArray(v)) {
+		const parts = v.map(displayValue).filter((x): x is string => x !== null)
+		return parts.length > 0 ? parts.join(', ') : null
+	}
+	return null
+}
+
+/** The same field name written the other way round, for looking up the record. */
+function snakeCase(key: string): string {
+	return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+}
+
+function currentFor(
+	current: Record<string, unknown> | null,
+	key: string,
+): unknown {
+	if (current === null) return undefined
+	if (key in current) return current[key]
+	const snake = snakeCase(key)
+	return snake in current ? current[snake] : undefined
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value !== null && typeof value === 'object' && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null
+}
+
+/**
+ * Pair each proposed value with what the record holds for it today. A field the
+ * record has nothing for reads as an addition; one that already matches is
+ * marked so it can be played down rather than presented as a change.
+ */
+export function fieldChanges(
+	fields: unknown,
+	subjectCurrent: unknown,
+): ReadonlyArray<FieldChange> {
+	const proposed = asRecord(fields)
+	if (proposed === null) return []
+	const current = asRecord(subjectCurrent)
+	const out: Array<FieldChange> = []
+	for (const [key, raw] of Object.entries(proposed)) {
+		if (SKIPPED_FIELDS.has(key)) continue
+		const to = displayValue(raw)
+		if (to === null) continue
+		const from = displayValue(currentFor(current, key))
+		out.push({ key, from, to, unchanged: from === to })
+	}
+	return out
+}
+
+/** Contact points carry their own trust marks, so they are read out separately. */
+export type ProposedChannel = {
+	readonly kind: string
+	readonly value: string
+	readonly verification: string | null
+}
+
+export function proposedChannels(
+	fields: unknown,
+): ReadonlyArray<ProposedChannel> {
+	const proposed = asRecord(fields)
+	const raw = proposed?.['channels']
+	if (!Array.isArray(raw)) return []
+	const out: Array<ProposedChannel> = []
+	for (const item of raw) {
+		const c = asRecord(item)
+		if (c === null) continue
+		const value = displayValue(c['value'])
+		if (typeof c['kind'] !== 'string' || value === null) continue
+		out.push({
+			kind: c['kind'],
+			value,
+			verification:
+				typeof c['verification'] === 'string' ? c['verification'] : null,
+		})
+	}
+	return out
+}
+
+/**
+ * A field name as a person would read it: "sizeRange" and "size_range" both
+ * become "Size range". A proper name for each field belongs in the shared label
+ * list; until every field has one, this keeps the raw wire spelling off screen.
+ */
+export function humanizeFieldKey(key: string): string {
+	const spaced = key
+		.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+		.replace(/[_-]+/g, ' ')
+		.trim()
+		.toLowerCase()
+	return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}

--- a/apps/internal/src/components/research/findings/company-enrichment-view.tsx
+++ b/apps/internal/src/components/research/findings/company-enrichment-view.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/react/macro'
 import type { ReactNode } from 'react'
 
+import { SafeLink } from '#/components/research/safe-link'
 import {
 	type Citation,
 	CitationList,
@@ -316,9 +317,7 @@ export function CompanyEnrichmentView({
 								<RowHead>
 									<Pill>{c.name}</Pill>
 									{c.website !== undefined ? (
-										<a href={c.website} target='_blank' rel='noreferrer'>
-											{c.website}
-										</a>
+										<SafeLink href={c.website}>{c.website}</SafeLink>
 									) : null}
 								</RowHead>
 								{c.why !== undefined ? <Reason>{c.why}</Reason> : null}
@@ -352,7 +351,9 @@ export function CompanyEnrichmentView({
 												<Trans>Email</Trans>
 											</FieldKey>
 											<FieldValue>
-												<a href={`mailto:${c.email.value}`}>{c.email.value}</a>
+												<SafeLink href={`mailto:${c.email.value}`}>
+													{c.email.value}
+												</SafeLink>
 												<CitationList citations={sourcedToCitations(c.email)} />
 											</FieldValue>
 										</FieldRow>

--- a/apps/internal/src/components/research/findings/company-enrichment-view.tsx
+++ b/apps/internal/src/components/research/findings/company-enrichment-view.tsx
@@ -1,4 +1,4 @@
-import { Trans } from '@lingui/react/macro'
+import { Plural, Trans } from '@lingui/react/macro'
 import type { ReactNode } from 'react'
 
 import { SafeLink } from '#/components/research/safe-link'
@@ -14,6 +14,7 @@ import {
 	List,
 	ListItem,
 	Pill,
+	QualityList,
 	Reason,
 	RowHead,
 	Section,
@@ -381,13 +382,29 @@ export function CompanyEnrichmentView({
 					<SectionTitle>
 						<Trans>Quality</Trans>
 					</SectionTitle>
-					<Reason>
-						<Trans>
-							{quality.fields_grounded ?? 0} fields grounded ·{' '}
-							{quality.sources_matched ?? 0} own-domain sources ·{' '}
-							{quality.rounds ?? 0} rounds
-						</Trans>
-					</Reason>
+					<QualityList>
+						<li>
+							<Plural
+								value={quality.fields_grounded ?? 0}
+								one='# fact backed by a source'
+								other='# facts backed by a source'
+							/>
+						</li>
+						<li>
+							<Plural
+								value={quality.sources_matched ?? 0}
+								one="# page on the company's own site"
+								other="# pages on the company's own site"
+							/>
+						</li>
+						<li>
+							<Plural
+								value={quality.rounds ?? 0}
+								one='# pass over the evidence'
+								other='# passes over the evidence'
+							/>
+						</li>
+					</QualityList>
 				</Section>
 			) : null}
 

--- a/apps/internal/src/components/research/findings/competitor-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/competitor-scan-view.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/react/macro'
 
+import { SafeLink } from '#/components/research/safe-link'
 import {
 	type Citation,
 	CitationList,
@@ -110,9 +111,7 @@ export function CompetitorScanView({
 								<RowHead>
 									<Pill>{c.name}</Pill>
 									{c.website !== undefined ? (
-										<a href={c.website} target='_blank' rel='noreferrer'>
-											{c.website}
-										</a>
+										<SafeLink href={c.website}>{c.website}</SafeLink>
 									) : null}
 								</RowHead>
 								{c.description !== undefined ? (

--- a/apps/internal/src/components/research/findings/contact-discovery-view.tsx
+++ b/apps/internal/src/components/research/findings/contact-discovery-view.tsx
@@ -129,8 +129,10 @@ const DecisionMakerBadge = styled.span`
 	font-size: var(--typescale-label-small-size);
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
-	background: color-mix(in oklab, var(--color-primary) 60%, white);
-	color: var(--color-on-primary);
+	/* Container tokens rather than a mix toward white: in a dark theme the accent
+	   is already pale, so lightening it further left the text on top unreadable. */
+	background: var(--color-primary-container);
+	color: var(--color-on-primary-container);
 	padding: var(--space-3xs) var(--space-2xs);
 	border-radius: var(--shape-3xs);
 `

--- a/apps/internal/src/components/research/findings/contact-discovery-view.tsx
+++ b/apps/internal/src/components/research/findings/contact-discovery-view.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/react/macro'
 import styled from 'styled-components'
 
+import { SafeLink } from '#/components/research/safe-link'
 import {
 	type Citation,
 	CitationList,
@@ -74,7 +75,9 @@ export function ContactDiscoveryView({
 												<Trans>Email</Trans>
 											</FieldKey>
 											<FieldValue>
-												<a href={`mailto:${c.email}`}>{c.email}</a>
+												<SafeLink href={`mailto:${c.email}`}>
+													{c.email}
+												</SafeLink>
 											</FieldValue>
 										</FieldRow>
 									) : null}
@@ -92,9 +95,7 @@ export function ContactDiscoveryView({
 												<Trans>LinkedIn</Trans>
 											</FieldKey>
 											<FieldValue>
-												<a href={c.linkedin} target='_blank' rel='noreferrer'>
-													{c.linkedin}
-												</a>
+												<SafeLink href={c.linkedin}>{c.linkedin}</SafeLink>
 											</FieldValue>
 										</FieldRow>
 									) : null}

--- a/apps/internal/src/components/research/findings/contact-discovery-view.tsx
+++ b/apps/internal/src/components/research/findings/contact-discovery-view.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/react/macro'
 import styled from 'styled-components'
 
+import { displayValue } from '#/components/research/field-diff'
 import { SafeLink } from '#/components/research/safe-link'
 import {
 	type Citation,
@@ -57,53 +58,63 @@ export function ContactDiscoveryView({
 						<Trans>Contacts found</Trans>
 					</SectionTitle>
 					<List>
-						{contacts.map(c => (
-							<ListItem key={`${c.name}|${c.email ?? c.linkedin ?? ''}`}>
-								<RowHead>
-									<Pill>{c.name}</Pill>
-									{c.role !== undefined ? <Reason>{c.role}</Reason> : null}
-									{c.is_decision_maker === true ? (
-										<DecisionMakerBadge>
-											<Trans>Decision maker</Trans>
-										</DecisionMakerBadge>
-									) : null}
-								</RowHead>
-								<FieldsTable>
-									{c.email !== undefined ? (
-										<FieldRow>
-											<FieldKey>
-												<Trans>Email</Trans>
-											</FieldKey>
-											<FieldValue>
-												<SafeLink href={`mailto:${c.email}`}>
-													{c.email}
-												</SafeLink>
-											</FieldValue>
-										</FieldRow>
-									) : null}
-									{c.phone !== undefined ? (
-										<FieldRow>
-											<FieldKey>
-												<Trans>Phone</Trans>
-											</FieldKey>
-											<FieldValue>{c.phone}</FieldValue>
-										</FieldRow>
-									) : null}
-									{c.linkedin !== undefined ? (
-										<FieldRow>
-											<FieldKey>
-												<Trans>LinkedIn</Trans>
-											</FieldKey>
-											<FieldValue>
-												<SafeLink href={c.linkedin}>{c.linkedin}</SafeLink>
-											</FieldValue>
-										</FieldRow>
-									) : null}
-								</FieldsTable>
-								{c.notes !== undefined ? <Reason>{c.notes}</Reason> : null}
-								<CitationList citations={c.citations} />
-							</ListItem>
-						))}
+						{contacts.map(c => {
+							// A value can arrive on its own or wrapped together with the page
+							// it was read from. Rendering the wrapper puts an object where
+							// text belongs, which takes the whole page down, so every value
+							// is read out before it is shown.
+							const name = displayValue(c.name) ?? ''
+							const role = displayValue(c.role)
+							const email = displayValue(c.email)
+							const phone = displayValue(c.phone)
+							const linkedin = displayValue(c.linkedin)
+							const notes = displayValue(c.notes)
+							return (
+								<ListItem key={`${name}|${email ?? linkedin ?? ''}`}>
+									<RowHead>
+										<Pill>{name}</Pill>
+										{role !== null ? <Reason>{role}</Reason> : null}
+										{c.is_decision_maker === true ? (
+											<DecisionMakerBadge>
+												<Trans>Decision maker</Trans>
+											</DecisionMakerBadge>
+										) : null}
+									</RowHead>
+									<FieldsTable>
+										{email !== null ? (
+											<FieldRow>
+												<FieldKey>
+													<Trans>Email</Trans>
+												</FieldKey>
+												<FieldValue>
+													<SafeLink href={`mailto:${email}`}>{email}</SafeLink>
+												</FieldValue>
+											</FieldRow>
+										) : null}
+										{phone !== null ? (
+											<FieldRow>
+												<FieldKey>
+													<Trans>Phone</Trans>
+												</FieldKey>
+												<FieldValue>{phone}</FieldValue>
+											</FieldRow>
+										) : null}
+										{linkedin !== null ? (
+											<FieldRow>
+												<FieldKey>
+													<Trans>LinkedIn</Trans>
+												</FieldKey>
+												<FieldValue>
+													<SafeLink href={linkedin}>{linkedin}</SafeLink>
+												</FieldValue>
+											</FieldRow>
+										) : null}
+									</FieldsTable>
+									{notes !== null ? <Reason>{notes}</Reason> : null}
+									<CitationList citations={c.citations} />
+								</ListItem>
+							)
+						})}
 					</List>
 				</Section>
 			) : null}

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 
 import { PriButton, usePriToast } from '@batuda/ui/pri'
 
+import { SafeLink } from '#/components/research/safe-link'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import {
 	type Citation,
@@ -69,9 +70,7 @@ export function ProspectScanView({
 								<RowHead>
 									<Pill>{p.name}</Pill>
 									{p.website !== undefined ? (
-										<a href={p.website} target='_blank' rel='noreferrer'>
-											{p.website}
-										</a>
+										<SafeLink href={p.website}>{p.website}</SafeLink>
 									) : null}
 								</RowHead>
 								<Reason>{p.why_relevant}</Reason>
@@ -159,7 +158,7 @@ function AddAsLeadButton({ prospect }: { readonly prospect: ProspectEntry }) {
 				...(prospect.country ? { country: prospect.country } : {}),
 				...(prospect.website ? { website: prospect.website } : {}),
 			},
-		} as never)
+		})
 		if (exit._tag !== 'Success') {
 			setBusy(false)
 			toast.add({ title: t`Could not add as a lead`, type: 'error' })
@@ -172,7 +171,7 @@ function AddAsLeadButton({ prospect }: { readonly prospect: ProspectEntry }) {
 			await verifyCompany({
 				params: { id },
 				payload: { verified: true },
-			} as never)
+			})
 		}
 		toast.add({ title: t`Added as a verified lead`, type: 'success' })
 		void navigate({ to: '/companies/$slug', params: { slug: newSlug } })

--- a/apps/internal/src/components/research/findings/shared.tsx
+++ b/apps/internal/src/components/research/findings/shared.tsx
@@ -485,3 +485,18 @@ const DiscoveredName = styled.span`
 	font-size: var(--typescale-body-medium-size);
 	color: var(--color-on-surface);
 `
+
+// Counts read one per line, so each can agree with its own number — several
+// welded into one sentence could not be made to agree in any language, nor
+// reordered by whoever translates it.
+export const QualityList = styled.ul`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+`

--- a/apps/internal/src/components/research/findings/shared.tsx
+++ b/apps/internal/src/components/research/findings/shared.tsx
@@ -167,7 +167,7 @@ function PaidActionRow({ action }: { readonly action: PendingPaidAction }) {
 		const call = decision === 'approve' ? approve : skip
 		const exit = await call({
 			params: { id: runId, paId: action.id },
-		} as never)
+		})
 		setBusy(false)
 		if (exit._tag === 'Success') {
 			refreshRun()

--- a/apps/internal/src/components/research/inbox/paid-action-queue.tsx
+++ b/apps/internal/src/components/research/inbox/paid-action-queue.tsx
@@ -1,0 +1,282 @@
+import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { Link } from '@tanstack/react-router'
+import { AsyncResult } from 'effect/unstable/reactivity'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { normalizePaidActionTool } from '@batuda/research/application/paid-action-tool'
+import { PriButton, usePriToast } from '@batuda/ui/pri'
+
+import {
+	approvePaidActionAtom,
+	type PendingPaidAction,
+	pendingPaidActionsAtom,
+	skipPaidActionAtom,
+} from '#/atoms/research-atoms'
+import { humanizeFieldKey } from '#/components/research/field-diff'
+import { formatMoneyCents } from '#/lib/format-money'
+import { agedPaperSurface, stenciledTitle } from '#/lib/workshop-mixins'
+
+/** How many waiting lookups the queue shows at once. */
+export const PAID_ACTION_LIMIT = 50
+
+/**
+ * Paid lookups that a run stopped short of paying for. Each one is real money
+ * the run will not spend until somebody says so, and a run holding one reads as
+ * finished everywhere else — so without this list they wait unnoticed until
+ * somebody happens to open that particular run.
+ */
+export function PaidActionQueue() {
+	const { t, i18n } = useLingui()
+	const atom = pendingPaidActionsAtom(PAID_ACTION_LIMIT)
+	const result = useAtomValue(atom)
+	const refresh = useAtomRefresh(atom)
+	const toast = usePriToast()
+	const approve = useAtomSet(approvePaidActionAtom, { mode: 'promiseExit' })
+	const skip = useAtomSet(skipPaidActionAtom, { mode: 'promiseExit' })
+	const [busyId, setBusyId] = useState<string | null>(null)
+
+	const actions: ReadonlyArray<PendingPaidAction> = AsyncResult.isSuccess(
+		result,
+	)
+		? result.value.items
+		: []
+	if (actions.length === 0) return null
+
+	const totalCents = actions.reduce(
+		(sum, a) => sum + (a.estimatedCents ?? 0),
+		0,
+	)
+
+	const decide = async (
+		action: PendingPaidAction,
+		decision: 'approve' | 'skip',
+	) => {
+		if (action.actionId === null) return
+		setBusyId(action.actionId)
+		const call = decision === 'approve' ? approve : skip
+		const exit = await call({
+			params: { id: action.researchId, paId: action.actionId },
+		})
+		setBusyId(null)
+		if (exit._tag !== 'Success') {
+			toast.add({ title: t`Could not update this lookup.`, type: 'error' })
+			return
+		}
+		// The reply says what actually happened: someone may have decided this
+		// already, or the run may have named a lookup that does not exist.
+		const outcome = (exit.value as { outcome?: string } | null)?.outcome
+		toast.add({
+			title:
+				outcome === 'approved'
+					? t`Lookup approved — the run is picking it up.`
+					: outcome === 'skipped'
+						? t`Lookup skipped. Nothing was spent.`
+						: outcome === 'not_pending'
+							? t`Someone had already decided this one.`
+							: t`That lookup isn't available, so it can only be skipped.`,
+			type:
+				outcome === 'approved' || outcome === 'skipped' ? 'success' : 'info',
+		})
+		refresh()
+	}
+
+	return (
+		<Section data-testid='research-inbox-paid-actions'>
+			<SectionTitle>
+				<Trans>Paid lookups waiting for your OK</Trans>
+			</SectionTitle>
+			<SectionHint>
+				<Trans>
+					These cost money, so nothing runs until you say so. About{' '}
+					{formatMoneyCents(totalCents, { locale: i18n.locale })} in total.
+				</Trans>
+			</SectionHint>
+			<Rows>
+				{actions.map(action => {
+					const canApprove =
+						action.actionId !== null &&
+						normalizePaidActionTool(action.tool) !== null
+					const busy = busyId !== null && busyId === action.actionId
+					return (
+						<Row key={`${action.researchId}:${action.actionId ?? action.tool}`}>
+							<Main>
+								<Head>
+									<Tool>{humanizeFieldKey(action.tool)}</Tool>
+									{action.estimatedCents !== null ? (
+										<Cost>
+											{formatMoneyCents(action.estimatedCents, {
+												locale: i18n.locale,
+											})}
+										</Cost>
+									) : null}
+								</Head>
+								<Subject>{action.subjectName ?? action.runQuery}</Subject>
+								{action.reason !== null ? (
+									<Reason>{action.reason}</Reason>
+								) : null}
+								<OpenRunChrome>
+									<Link
+										to='/research/$id'
+										params={{ id: action.researchId }}
+										aria-label={t`Open the run asking for this lookup`}
+									>
+										<Trans>Open run</Trans>
+									</Link>
+								</OpenRunChrome>
+							</Main>
+							<Actions>
+								{action.actionId === null ? (
+									<Unavailable>
+										<Trans>
+											Recorded before these could be decided — open the run.
+										</Trans>
+									</Unavailable>
+								) : (
+									<>
+										{canApprove ? (
+											<PriButton
+												type='button'
+												$variant='filled'
+												disabled={busy}
+												aria-label={t`Approve ${action.tool}`}
+												data-testid='paid-queue-approve'
+												onClick={() => void decide(action, 'approve')}
+											>
+												{busy ? t`Working…` : t`Approve`}
+											</PriButton>
+										) : null}
+										<PriButton
+											type='button'
+											$variant='outlined'
+											disabled={busy}
+											aria-label={t`Skip ${action.tool}`}
+											data-testid='paid-queue-skip'
+											onClick={() => void decide(action, 'skip')}
+										>
+											<Trans>Skip</Trans>
+										</PriButton>
+									</>
+								)}
+							</Actions>
+						</Row>
+					)
+				})}
+			</Rows>
+		</Section>
+	)
+}
+
+const Section = styled.section`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+`
+
+const SectionTitle = styled.h3`
+	${stenciledTitle}
+	font-size: var(--typescale-title-medium-size);
+	line-height: var(--typescale-title-medium-line);
+	margin: 0;
+`
+
+const SectionHint = styled.p`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const Rows = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+`
+
+const Row = styled.div`
+	${agedPaperSurface}
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-sm);
+	align-items: flex-start;
+	justify-content: space-between;
+	padding: var(--space-sm) var(--space-md);
+	border-radius: var(--shape-2xs);
+`
+
+const Main = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+	min-width: 12rem;
+	flex: 1;
+`
+
+const Head = styled.div`
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: var(--space-2xs);
+`
+
+const Tool = styled.span`
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-primary);
+`
+
+const Cost = styled.span`
+	font-family: var(--font-mono);
+	font-size: var(--typescale-body-small-size);
+	font-variant-numeric: tabular-nums;
+	color: var(--color-on-surface-variant);
+`
+
+const Subject = styled.span`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	color: var(--color-on-surface);
+`
+
+const Reason = styled.p`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const Unavailable = styled.span`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	max-width: 16rem;
+`
+
+const Actions = styled.div`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+`
+
+// Styling `Link` directly erases TanStack's typed `params` inference, so the
+// chrome lives on a wrapper and the real Link stays plain.
+const OpenRunChrome = styled.span`
+	& > a {
+		font-family: var(--font-display);
+		font-size: var(--typescale-label-small-size);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--color-on-surface-variant);
+		text-decoration: none;
+	}
+
+	& > a:hover {
+		color: var(--color-primary);
+	}
+`

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -15,6 +15,12 @@ import {
 	resolveProposalsBatchAtom,
 } from '#/atoms/research-atoms'
 import {
+	fieldChanges,
+	humanizeFieldKey,
+	proposedChannels,
+} from '#/components/research/field-diff'
+import { PaidActionQueue } from '#/components/research/inbox/paid-action-queue'
+import {
 	isEnteredOutcome,
 	type ProposalOutcome,
 	trustTier,
@@ -30,6 +36,7 @@ import {
 import { narrowResearch } from '#/components/research/run-shapes'
 import { TrustBadge } from '#/components/research/trust-badge'
 import { ErrorState } from '#/components/shared/error-state'
+import { SrOnly } from '#/components/shared/sr-only'
 import {
 	type ResolveDecision,
 	type ResolveOutcome,
@@ -106,8 +113,26 @@ export function ResearchInbox() {
 	const navigate = useNavigate()
 	const [discoveryOpen, setDiscoveryOpen] = useResearchDlg()
 
-	const proposalsResult = useAtomValue(inboxPendingProposalsAtom())
-	const refreshProposals = useAtomRefresh(inboxPendingProposalsAtom())
+	const [subject, setSubject] = useState<SubjectFilter>('all')
+	const [search, setSearch] = useState('')
+	const [minConfidence, setMinConfidence] = useState(0)
+	const [machineOnly, setMachineOnly] = useState(false)
+
+	// Filtering happens where the rows live. Sifting a fetched page in the browser
+	// only ever searched the newest hundred, so a matching change beyond that was
+	// invisible and the queue could read as empty while work was waiting.
+	const proposalsAtom = useMemo(
+		() =>
+			pendingProposalsAtom({
+				limit: INBOX_PROPOSAL_LIMIT,
+				...(subject === 'all' ? {} : { subjectTable: subject }),
+				...(minConfidence > 0 ? { minConfidence } : {}),
+				...(machineOnly ? { machineCheckable: true } : {}),
+			}),
+		[subject, minConfidence, machineOnly],
+	)
+	const proposalsResult = useAtomValue(proposalsAtom)
+	const refreshProposals = useAtomRefresh(proposalsAtom)
 	const runsAtom = useMemo(
 		() => researchListAtom({ limit: INBOX_PROPOSAL_LIMIT }),
 		[],
@@ -128,10 +153,6 @@ export function ResearchInbox() {
 	const { results, pending, sending, resolve, undo, setResults } =
 		useProposalResolution()
 
-	const [subject, setSubject] = useState<SubjectFilter>('all')
-	const [search, setSearch] = useState('')
-	const [minConfidence, setMinConfidence] = useState(0)
-	const [machineOnly, setMachineOnly] = useState(false)
 	// Whether the "apply all verified" button is waiting on its confirm step.
 	const [confirmingBatch, setConfirmingBatch] = useState(false)
 	const [batchBusy, setBatchBusy] = useState(false)
@@ -156,26 +177,18 @@ export function ResearchInbox() {
 		[spendResult],
 	)
 
+	// Subject, confidence and verifiable-only are applied where the rows live, so
+	// only the free-text search narrows what has been fetched — there is no
+	// server-side search to defer it to.
 	const visible = useMemo(() => {
 		const term = search.trim().toLowerCase()
+		if (term.length === 0) return proposals
 		return proposals.filter(p => {
-			if (subject !== 'all' && p.subjectTable !== subject) return false
-			if (machineOnly && !p.machineCheckable) return false
-			// A minimum keeps only rows scored at least that high; an unscored row
-			// (no channel confidence) can't clear a positive bar, so it drops out.
-			if (
-				minConfidence > 0 &&
-				(p.confidence === null || p.confidence < minConfidence)
-			)
-				return false
-			if (term.length > 0) {
-				const haystack =
-					`${p.subjectName ?? ''} ${p.runQuery} ${p.reason ?? ''}`.toLowerCase()
-				if (!haystack.includes(term)) return false
-			}
-			return true
+			const haystack =
+				`${p.subjectName ?? ''} ${p.runQuery} ${p.reason ?? ''}`.toLowerCase()
+			return haystack.includes(term)
 		})
-	}, [proposals, subject, machineOnly, minConfidence, search])
+	}, [proposals, search])
 
 	const trustworthy = useMemo(
 		() => visible.filter(p => tierOf(p) === 'trustworthy'),
@@ -205,7 +218,14 @@ export function ResearchInbox() {
 			isEnteredOutcome(r.outcome as ProposalOutcome) ||
 			r.outcome === 'rejected',
 	).length
-	const pendingCount = Math.max(0, proposals.length - resolvedCount)
+	// The count comes back with the rows, so the tile states the real figure
+	// instead of "100+" whenever a page happened to fill up.
+	const totalPending = AsyncResult.isSuccess(proposalsResult)
+		? proposalsResult.value.total
+		: proposals.length
+	const pendingCount = Math.max(0, totalPending - resolvedCount)
+	// More are waiting than were fetched, so say so rather than quietly ending.
+	const notShown = Math.max(0, totalPending - proposals.length)
 	const recentRuns = runs.length
 
 	const isLoading = AsyncResult.isInitial(proposalsResult)
@@ -305,9 +325,7 @@ export function ResearchInbox() {
 					</TileLabel>
 				</Tile>
 				<Tile>
-					<TileValue>
-						{pendingCount >= INBOX_PROPOSAL_LIMIT ? '100+' : pendingCount}
-					</TileValue>
+					<TileValue>{pendingCount}</TileValue>
 					<TileLabel>
 						<Trans>Pending review</Trans>
 					</TileLabel>
@@ -471,6 +489,8 @@ export function ResearchInbox() {
 						</Section>
 					) : null}
 
+					<PaidActionQueue />
+
 					<ProposalSection
 						testId='research-inbox-trustworthy'
 						title={t`Ready to apply`}
@@ -496,6 +516,12 @@ export function ResearchInbox() {
 						onResolve={resolveOne}
 						onUndo={undo}
 					/>
+
+					{notShown > 0 ? (
+						<Truncated data-testid='research-inbox-truncated'>
+							{t`Showing ${proposals.length} of ${totalPending}. Narrow the filters to reach the rest.`}
+						</Truncated>
+					) : null}
 
 					{trustworthy.length === 0 &&
 					needsReview.length === 0 &&
@@ -619,6 +645,7 @@ function ProposalRow({
 				{proposal.reason !== null ? (
 					<RowReason>{proposal.reason}</RowReason>
 				) : null}
+				<ProposedValues proposal={proposal} />
 				<RowBadges>
 					<TrustBadge
 						verification={proposal.verification}
@@ -693,6 +720,63 @@ function ProposalRow({
 				)}
 			</RowActions>
 		</Row>
+	)
+}
+
+// How many values a row shows before it stops; the rest are on the run's page.
+const INLINE_FIELD_LIMIT = 4
+
+/**
+ * What this change would actually write. Without it the row asks for a yes or a
+ * no on a value the reader cannot see — the reason line says why the run
+ * believes something, never what it would put in the record.
+ */
+function ProposedValues({ proposal }: { readonly proposal: PendingProposal }) {
+	const { t } = useLingui()
+	const changes = fieldChanges(proposal.fields, proposal.subjectCurrent)
+	const channels = proposedChannels(proposal.fields)
+	if (changes.length === 0 && channels.length === 0) return null
+	const shown = changes.slice(0, INLINE_FIELD_LIMIT)
+	const hidden = changes.length - shown.length
+
+	return (
+		<Values data-testid='research-inbox-values'>
+			{channels.map(channel => (
+				<ValueLine key={`${channel.kind}:${channel.value}`}>
+					<ValueKey>{humanizeFieldKey(channel.kind)}</ValueKey>
+					<ValueNew>{channel.value}</ValueNew>
+				</ValueLine>
+			))}
+			{shown.map(change => (
+				<ValueLine key={change.key}>
+					<ValueKey>{humanizeFieldKey(change.key)}</ValueKey>
+					{change.unchanged ? (
+						<ValueSame>{t`already ${change.to}`}</ValueSame>
+					) : (
+						<>
+							{/* The line through the old value and the arrow are both
+							    visual only, so which value is which is spoken outright —
+							    otherwise the row reads as two values in a row with nothing
+							    to say one replaces the other. */}
+							{change.from !== null ? (
+								<>
+									<SrOnly>{t`currently`}</SrOnly>
+									<ValueOld>{change.from}</ValueOld>
+									<ValueArrow aria-hidden>→</ValueArrow>
+									<SrOnly>{t`would become`}</SrOnly>
+								</>
+							) : (
+								<SrOnly>{t`nothing on file, would add`}</SrOnly>
+							)}
+							<ValueNew>{change.to}</ValueNew>
+						</>
+					)}
+				</ValueLine>
+			))}
+			{hidden > 0 ? (
+				<ValueMore>{t`and ${hidden} more on the run`}</ValueMore>
+			) : null}
+		</Values>
 	)
 }
 
@@ -1120,4 +1204,63 @@ const SkeletonRow = styled.div`
 	@media (prefers-reduced-motion: reduce) {
 		animation: none;
 	}
+`
+
+const Values = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+`
+
+const ValueLine = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: var(--space-3xs) var(--space-2xs);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	min-width: 0;
+`
+
+const ValueKey = styled.span`
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--color-on-surface-variant);
+`
+
+const ValueOld = styled.span`
+	color: var(--color-on-surface-variant);
+	text-decoration: line-through;
+	word-break: break-word;
+`
+
+const ValueArrow = styled.span`
+	color: var(--color-on-surface-variant);
+`
+
+const ValueNew = styled.span`
+	color: var(--color-on-surface);
+	word-break: break-word;
+`
+
+const ValueSame = styled.span`
+	color: var(--color-on-surface-variant);
+	font-style: italic;
+`
+
+const ValueMore = styled.span`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+`
+
+const Truncated = styled.p`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+	margin: 0;
 `

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -28,6 +28,7 @@ import {
 } from '#/components/research/proposal-logic'
 import { OutcomeBadge } from '#/components/research/proposal-outcome'
 import { ResearchDialog } from '#/components/research/research-dialog'
+import { Money, ResolveStatus } from '#/components/research/resolve-status'
 import {
 	operationLabel,
 	statusLabel,
@@ -70,8 +71,6 @@ const ATTENTION_STATUSES = new Set([
 	'succeeded_low_confidence',
 ])
 
-type SubjectFilter = 'all' | 'companies' | 'contacts'
-
 function rowKey(p: PendingProposal): string {
 	return `${p.researchId}::${p.proposedUpdateId ?? ''}`
 }
@@ -113,7 +112,6 @@ export function ResearchInbox() {
 	const navigate = useNavigate()
 	const [discoveryOpen, setDiscoveryOpen] = useResearchDlg()
 
-	const [subject, setSubject] = useState<SubjectFilter>('all')
 	const [search, setSearch] = useState('')
 	const [minConfidence, setMinConfidence] = useState(0)
 	const [machineOnly, setMachineOnly] = useState(false)
@@ -125,11 +123,10 @@ export function ResearchInbox() {
 		() =>
 			pendingProposalsAtom({
 				limit: INBOX_PROPOSAL_LIMIT,
-				...(subject === 'all' ? {} : { subjectTable: subject }),
 				...(minConfidence > 0 ? { minConfidence } : {}),
 				...(machineOnly ? { machineCheckable: true } : {}),
 			}),
-		[subject, minConfidence, machineOnly],
+		[minConfidence, machineOnly],
 	)
 	const proposalsResult = useAtomValue(proposalsAtom)
 	const refreshProposals = useAtomRefresh(proposalsAtom)
@@ -347,32 +344,6 @@ export function ResearchInbox() {
 			</Counters>
 
 			<Toolbar>
-				<Segmented role='group' aria-label={t`Filter by subject`}>
-					<SegButton
-						type='button'
-						aria-pressed={subject === 'all'}
-						$active={subject === 'all'}
-						onClick={() => setSubject('all')}
-					>
-						<Trans>All</Trans>
-					</SegButton>
-					<SegButton
-						type='button'
-						aria-pressed={subject === 'companies'}
-						$active={subject === 'companies'}
-						onClick={() => setSubject('companies')}
-					>
-						<Trans>Companies</Trans>
-					</SegButton>
-					<SegButton
-						type='button'
-						aria-pressed={subject === 'contacts'}
-						$active={subject === 'contacts'}
-						onClick={() => setSubject('contacts')}
-					>
-						<Trans>Contacts</Trans>
-					</SegButton>
-				</Segmented>
 				<Filters>
 					<PriInput
 						type='search'
@@ -653,12 +624,12 @@ function ProposalRow({
 						machineCheckable={proposal.machineCheckable}
 					/>
 					{runTotalCents > 0 ? (
-						<RowCost
+						<Money
 							data-testid='research-inbox-row-cost'
 							title={t`What this run has cost so far`}
 						>
 							{formatMoneyCents(runTotalCents, { locale: i18n.locale })}
-						</RowCost>
+						</Money>
 					) : null}
 					<OpenRunLink
 						id={proposal.researchId}
@@ -676,24 +647,19 @@ function ProposalRow({
 						reason={result.reason}
 					/>
 				) : pending !== undefined ? (
-					<PendingResolve data-testid='research-inbox-pending'>
-						<PendingLabel>
-							{pending === 'apply' ? t`Applying…` : t`Rejecting…`}
-						</PendingLabel>
-						<UndoButton
-							type='button'
-							onClick={onUndo}
-							data-testid='research-inbox-undo'
-						>
-							<Trans>Undo</Trans>
-						</UndoButton>
-					</PendingResolve>
+					<ResolveStatus
+						decision={pending}
+						undoable
+						onUndo={onUndo}
+						testId='research-inbox-pending'
+					/>
 				) : sending !== undefined ? (
-					<PendingResolve data-testid='research-inbox-sending'>
-						<PendingLabel>
-							{sending === 'apply' ? t`Applying…` : t`Rejecting…`}
-						</PendingLabel>
-					</PendingResolve>
+					<ResolveStatus
+						decision={sending}
+						undoable={false}
+						onUndo={onUndo}
+						testId='research-inbox-sending'
+					/>
 				) : (
 					<>
 						<PriButton
@@ -934,35 +900,6 @@ const ToggleLabel = styled.label`
 	cursor: pointer;
 `
 
-const Segmented = styled.div`
-	display: inline-flex;
-	gap: var(--space-2xs);
-	flex: 1;
-`
-
-const SegButton = styled.button.withConfig({
-	shouldForwardProp: prop => prop !== '$active',
-})<{ $active: boolean }>`
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	padding: var(--space-2xs) var(--space-sm);
-	border-radius: var(--shape-2xs);
-	border: 1px solid
-		${p =>
-			p.$active
-				? 'var(--color-primary)'
-				: 'color-mix(in oklab, var(--color-on-surface) 12%, transparent)'};
-	background: ${p =>
-		p.$active
-			? 'color-mix(in oklab, var(--color-primary) 16%, transparent)'
-			: 'transparent'};
-	color: ${p =>
-		p.$active ? 'var(--color-primary)' : 'var(--color-on-surface-variant)'};
-	cursor: pointer;
-`
-
 const RefreshLink = styled.button`
 	/* Small text made these under the 24px a pointer needs, and Undo is the only
 	   thing that stops a change being written. */
@@ -1052,12 +989,6 @@ const RowQuery = styled.span`
 	color: var(--color-on-surface);
 `
 
-const RowCost = styled.span`
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	color: var(--color-on-surface-variant);
-`
-
 const RowReason = styled.p`
 	font-family: var(--font-body);
 	font-size: var(--typescale-body-small-size);
@@ -1089,46 +1020,6 @@ const ConfirmBatch = styled.div`
 	display: inline-flex;
 	align-items: center;
 	gap: var(--space-2xs);
-`
-
-const PendingResolve = styled.div`
-	display: inline-flex;
-	align-items: center;
-	gap: var(--space-2xs);
-`
-
-const PendingLabel = styled.span`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-small-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-`
-
-const UndoButton = styled.button`
-	/* Small text made these under the 24px a pointer needs, and Undo is the only
-	   thing that stops a change being written. */
-	min-height: 1.5rem;
-	min-width: 1.5rem;
-	padding-inline: var(--space-2xs);
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
-	color: var(--color-primary);
-	background: none;
-	border: none;
-	cursor: pointer;
-	padding: var(--space-3xs) var(--space-2xs);
-
-	&:hover {
-		text-decoration: underline;
-	}
-
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
-		border-radius: var(--shape-2xs);
-	}
 `
 
 // Styling `Link` directly with styled-components erases TanStack's typed

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -15,6 +15,7 @@ import {
 	resolveProposalsBatchAtom,
 } from '#/atoms/research-atoms'
 import {
+	isEnteredOutcome,
 	type ProposalOutcome,
 	trustTier,
 	verdictRank,
@@ -23,6 +24,7 @@ import { OutcomeBadge } from '#/components/research/proposal-outcome'
 import { ResearchDialog } from '#/components/research/research-dialog'
 import {
 	operationLabel,
+	statusLabel,
 	subjectTableLabel,
 } from '#/components/research/run-labels'
 import { narrowResearch } from '#/components/research/run-shapes'
@@ -123,7 +125,7 @@ export function ResearchInbox() {
 	const resolveBatch = useAtomSet(resolveProposalsBatchAtom, {
 		mode: 'promiseExit',
 	})
-	const { results, pending, resolve, undo, setResults } =
+	const { results, pending, sending, resolve, undo, setResults } =
 		useProposalResolution()
 
 	const [subject, setSubject] = useState<SubjectFilter>('all')
@@ -195,7 +197,14 @@ export function ResearchInbox() {
 		[runs],
 	)
 
-	const resolvedCount = Object.keys(results).length
+	// A change that came back as a conflict or as invalid is still waiting for
+	// someone, so counting every reply as dealt with made the queue look shorter
+	// than it is.
+	const resolvedCount = Object.values(results).filter(
+		r =>
+			isEnteredOutcome(r.outcome as ProposalOutcome) ||
+			r.outcome === 'rejected',
+	).length
 	const pendingCount = Math.max(0, proposals.length - resolvedCount)
 	const recentRuns = runs.length
 
@@ -216,7 +225,8 @@ export function ResearchInbox() {
 				p =>
 					p.proposedUpdateId !== null &&
 					results[rowKey(p)] === undefined &&
-					pending[rowKey(p)] === undefined,
+					pending[rowKey(p)] === undefined &&
+					sending[rowKey(p)] === undefined,
 			)
 			.map(p => ({
 				research_id: p.researchId,
@@ -249,7 +259,8 @@ export function ResearchInbox() {
 		p =>
 			p.proposedUpdateId !== null &&
 			results[rowKey(p)] === undefined &&
-			pending[rowKey(p)] === undefined,
+			pending[rowKey(p)] === undefined &&
+			sending[rowKey(p)] === undefined,
 	).length
 
 	return (
@@ -435,24 +446,27 @@ export function ResearchInbox() {
 								<Trans>Attention needed</Trans>
 							</SectionTitle>
 							<Rows>
-								{attention.map(run => (
-									<AttentionRow key={run.id}>
-										<RowMain>
-											<RowQuery>{run.query}</RowQuery>
-											<RowMeta>
-												{run.status === 'no_reliable_data' ? (
-													<Trans>No reliable data found</Trans>
-												) : (
-													<Trans>Run failed</Trans>
-												)}
-											</RowMeta>
-										</RowMain>
-										<OpenRunLink id={run.id} label={t`Open run: ${run.query}`}>
-											<Trans>Open</Trans>
-											<ArrowRight size={14} aria-hidden />
-										</OpenRunLink>
-									</AttentionRow>
-								))}
+								{attention.map(run => {
+									// Each status says its own name. Treating everything that is
+									// not "no reliable data" as a failure reported a run that
+									// succeeded but wants a second look as broken.
+									const label = statusLabel(run.status)
+									return (
+										<AttentionRow key={run.id}>
+											<RowMain>
+												<RowQuery>{run.query}</RowQuery>
+												<RowMeta>{label ? i18n._(label) : run.status}</RowMeta>
+											</RowMain>
+											<OpenRunLink
+												id={run.id}
+												label={t`Open run: ${run.query}`}
+											>
+												<Trans>Open</Trans>
+												<ArrowRight size={14} aria-hidden />
+											</OpenRunLink>
+										</AttentionRow>
+									)
+								})}
 							</Rows>
 						</Section>
 					) : null}
@@ -464,6 +478,8 @@ export function ResearchInbox() {
 						proposals={trustworthy}
 						results={results}
 						pending={pending}
+						sending={sending}
+						batchBusy={batchBusy}
 						onResolve={resolveOne}
 						onUndo={undo}
 					/>
@@ -475,6 +491,8 @@ export function ResearchInbox() {
 						proposals={needsReview}
 						results={results}
 						pending={pending}
+						sending={sending}
+						batchBusy={batchBusy}
 						onResolve={resolveOne}
 						onUndo={undo}
 					/>
@@ -507,6 +525,8 @@ function ProposalSection({
 	proposals,
 	results,
 	pending,
+	sending,
+	batchBusy,
 	onResolve,
 	onUndo,
 }: {
@@ -516,6 +536,9 @@ function ProposalSection({
 	readonly proposals: ReadonlyArray<PendingProposal>
 	readonly results: Record<string, ResolveOutcome>
 	readonly pending: Record<string, ResolveDecision>
+	readonly sending: Record<string, ResolveDecision>
+	/** A bulk apply is in flight, so single rows must not be resolved alongside it. */
+	readonly batchBusy: boolean
 	readonly onResolve: (p: PendingProposal, decision: ResolveDecision) => void
 	readonly onUndo: (key: string) => void
 }) {
@@ -525,12 +548,18 @@ function ProposalSection({
 			<SectionTitle>{title}</SectionTitle>
 			<SectionHint>{hint}</SectionHint>
 			<Rows>
-				{proposals.map(p => (
+				{proposals.map((p, index) => (
 					<ProposalRow
-						key={rowKey(p)}
+						// A proposal recorded before these carried their own id has none,
+						// and two such from the same run cannot be told apart, so position
+						// is the only thing left to separate them.
+						// biome-ignore lint/suspicious/noArrayIndexKey: the index only breaks ties behind a real key; without it two id-less proposals from one run collide and React drops a row.
+						key={`${rowKey(p)}#${index}`}
 						proposal={p}
 						result={results[rowKey(p)]}
 						pending={pending[rowKey(p)]}
+						sending={sending[rowKey(p)]}
+						batchBusy={batchBusy}
 						onResolve={onResolve}
 						onUndo={() => onUndo(rowKey(p))}
 					/>
@@ -544,12 +573,16 @@ function ProposalRow({
 	proposal,
 	result,
 	pending,
+	sending,
+	batchBusy,
 	onResolve,
 	onUndo,
 }: {
 	readonly proposal: PendingProposal
 	readonly result: ResolveOutcome | undefined
 	readonly pending: ResolveDecision | undefined
+	readonly sending: ResolveDecision | undefined
+	readonly batchBusy: boolean
 	readonly onResolve: (p: PendingProposal, decision: ResolveDecision) => void
 	readonly onUndo: () => void
 }) {
@@ -570,6 +603,9 @@ function ProposalRow({
 					: proposal.subjectTable
 			: proposal.runQuery)
 	const opLabel = operationLabel(proposal.operation)
+	// Cheap work and paid lookups are tallied separately, so a run whose whole
+	// cost was a paid lookup reads as free unless both are counted.
+	const runTotalCents = proposal.runCostCents + proposal.runPaidCostCents
 
 	return (
 		<Row data-testid='research-inbox-row'>
@@ -589,11 +625,12 @@ function ProposalRow({
 						confidence={proposal.confidence}
 						machineCheckable={proposal.machineCheckable}
 					/>
-					{proposal.runCostCents > 0 ? (
-						<RowCost data-testid='research-inbox-row-cost'>
-							{formatMoneyCents(proposal.runCostCents, {
-								locale: i18n.locale,
-							})}
+					{runTotalCents > 0 ? (
+						<RowCost
+							data-testid='research-inbox-row-cost'
+							title={t`What this run has cost so far`}
+						>
+							{formatMoneyCents(runTotalCents, { locale: i18n.locale })}
 						</RowCost>
 					) : null}
 					<OpenRunLink
@@ -624,13 +661,19 @@ function ProposalRow({
 							<Trans>Undo</Trans>
 						</UndoButton>
 					</PendingResolve>
+				) : sending !== undefined ? (
+					<PendingResolve data-testid='research-inbox-sending'>
+						<PendingLabel>
+							{sending === 'apply' ? t`Applying…` : t`Rejecting…`}
+						</PendingLabel>
+					</PendingResolve>
 				) : (
 					<>
 						<PriButton
 							type='button'
 							$variant='filled'
 							aria-label={t`Apply ${subjectLabel}`}
-							disabled={proposal.proposedUpdateId === null}
+							disabled={proposal.proposedUpdateId === null || batchBusy}
 							onClick={() => onResolve(proposal, 'apply')}
 							data-testid='research-inbox-apply'
 						>
@@ -640,7 +683,7 @@ function ProposalRow({
 							type='button'
 							$variant='outlined'
 							aria-label={t`Reject ${subjectLabel}`}
-							disabled={proposal.proposedUpdateId === null}
+							disabled={proposal.proposedUpdateId === null || batchBusy}
 							onClick={() => onResolve(proposal, 'reject')}
 							data-testid='research-inbox-reject'
 						>

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -155,6 +155,10 @@ export function ResearchInbox() {
 	// Whether the "apply all verified" button is waiting on its confirm step.
 	const [confirmingBatch, setConfirmingBatch] = useState(false)
 	const [batchBusy, setBatchBusy] = useState(false)
+	// What the last bulk apply did, said out loud. Writing several records at once
+	// finished in silence: the rows quietly turned into badges, which tells a
+	// reader watching the screen but nobody listening to it.
+	const [batchOutcome, setBatchOutcome] = useState<string | null>(null)
 
 	const proposals = useMemo<ReadonlyArray<PendingProposal>>(
 		() =>
@@ -239,7 +243,8 @@ export function ResearchInbox() {
 		? t`Loading the changes waiting for review.`
 		: isFailure
 			? t`The list of changes could not be loaded.`
-			: t`${trustworthy.length} ready to apply, ${needsReview.length} need reading, ${attention.length} runs need attention.`
+			: (batchOutcome ??
+				t`${trustworthy.length} ready to apply, ${needsReview.length} need reading, ${attention.length} runs need attention.`)
 
 	function resolveOne(p: PendingProposal, decision: ResolveDecision): void {
 		if (p.proposedUpdateId === null) return
@@ -265,6 +270,7 @@ export function ResearchInbox() {
 			}))
 		if (items.length === 0) return
 		setBatchBusy(true)
+		setBatchOutcome(t`Applying ${items.length} changes…`)
 		const exit = await resolveBatch({ payload: { items } })
 		setBatchBusy(false)
 		if (exit._tag === 'Success') {
@@ -278,8 +284,20 @@ export function ResearchInbox() {
 				}
 				return next
 			})
+			// Say how it actually went. Some of a batch can come back as a clash or
+			// as unusable, and those are still waiting for someone.
+			const entered = exit.value.results.filter(r =>
+				isEnteredOutcome(r.outcome as ProposalOutcome),
+			).length
+			const leftover = exit.value.results.length - entered
+			setBatchOutcome(
+				leftover === 0
+					? t`${entered} changes entered the records.`
+					: t`${entered} entered the records, ${leftover} still need you.`,
+			)
 		} else {
 			toast.add({ title: t`Could not apply the batch.`, type: 'error' })
+			setBatchOutcome(t`The changes could not be applied.`)
 		}
 	}
 
@@ -424,6 +442,9 @@ export function ResearchInbox() {
 					type='button'
 					onClick={() => {
 						setResults({})
+						// Last batch's news is stale once the queue is re-read, so the
+						// spoken summary goes back to describing what is waiting.
+						setBatchOutcome(null)
 						refreshProposals()
 					}}
 				>

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -964,6 +964,11 @@ const SegButton = styled.button.withConfig({
 `
 
 const RefreshLink = styled.button`
+	/* Small text made these under the 24px a pointer needs, and Undo is the only
+	   thing that stops a change being written. */
+	min-height: 1.5rem;
+	min-width: 1.5rem;
+	padding-inline: var(--space-2xs);
 	font-family: var(--font-display);
 	font-size: var(--typescale-label-small-size);
 	letter-spacing: 0.06em;
@@ -1100,6 +1105,11 @@ const PendingLabel = styled.span`
 `
 
 const UndoButton = styled.button`
+	/* Small text made these under the 24px a pointer needs, and Undo is the only
+	   thing that stops a change being written. */
+	min-height: 1.5rem;
+	min-width: 1.5rem;
+	padding-inline: var(--space-2xs);
 	font-family: var(--font-display);
 	font-size: var(--typescale-label-small-size);
 	letter-spacing: 0.04em;

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -228,6 +228,17 @@ export function ResearchInbox() {
 	const isLoading = AsyncResult.isInitial(proposalsResult)
 	const isFailure = AsyncResult.isFailure(proposalsResult)
 
+	// Read out what the queue currently holds. A sighted reader watches the list
+	// change when they search or filter; a listener got silence, with no way to
+	// tell "nothing matches" from "still loading". The region is always on the
+	// page so a change to its wording is announced — one added at the same moment
+	// as its text is not.
+	const liveSummary = isLoading
+		? t`Loading the changes waiting for review.`
+		: isFailure
+			? t`The list of changes could not be loaded.`
+			: t`${trustworthy.length} ready to apply, ${needsReview.length} need reading, ${attention.length} runs need attention.`
+
 	function resolveOne(p: PendingProposal, decision: ResolveDecision): void {
 		if (p.proposedUpdateId === null) return
 		resolve(rowKey(p), p.researchId, p.proposedUpdateId, decision, () =>
@@ -311,6 +322,10 @@ export function ResearchInbox() {
 					</RunsLink>
 				</IntroActions>
 			</IntroRow>
+
+			<SrOnly role='status' data-testid='research-inbox-live'>
+				{liveSummary}
+			</SrOnly>
 
 			<Counters data-testid='research-inbox-counters'>
 				<Tile>

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -1,4 +1,5 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
+import type { MessageDescriptor } from '@lingui/core'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
@@ -30,6 +31,7 @@ import { OutcomeBadge } from '#/components/research/proposal-outcome'
 import { ResearchDialog } from '#/components/research/research-dialog'
 import { Money, ResolveStatus } from '#/components/research/resolve-status'
 import {
+	fieldLabel,
 	operationLabel,
 	statusLabel,
 	subjectTableLabel,
@@ -704,6 +706,16 @@ function ProposalRow({
 	)
 }
 
+/**
+ * A field's proper name when it has one, otherwise its wire spelling read as
+ * words — so a field nobody has named yet still reads sensibly instead of
+ * showing the name the database uses.
+ */
+function fieldName(key: string, i18n: { _: (d: MessageDescriptor) => string }) {
+	const label = fieldLabel(key)
+	return label === null ? humanizeFieldKey(key) : i18n._(label)
+}
+
 // How many values a row shows before it stops; the rest are on the run's page.
 const INLINE_FIELD_LIMIT = 4
 
@@ -713,7 +725,7 @@ const INLINE_FIELD_LIMIT = 4
  * believes something, never what it would put in the record.
  */
 function ProposedValues({ proposal }: { readonly proposal: PendingProposal }) {
-	const { t } = useLingui()
+	const { t, i18n } = useLingui()
 	const changes = fieldChanges(proposal.fields, proposal.subjectCurrent)
 	const channels = proposedChannels(proposal.fields)
 	if (changes.length === 0 && channels.length === 0) return null
@@ -724,13 +736,13 @@ function ProposedValues({ proposal }: { readonly proposal: PendingProposal }) {
 		<Values data-testid='research-inbox-values'>
 			{channels.map(channel => (
 				<ValueLine key={`${channel.kind}:${channel.value}`}>
-					<ValueKey>{humanizeFieldKey(channel.kind)}</ValueKey>
+					<ValueKey>{fieldName(channel.kind, i18n)}</ValueKey>
 					<ValueNew>{channel.value}</ValueNew>
 				</ValueLine>
 			))}
 			{shown.map(change => (
 				<ValueLine key={change.key}>
-					<ValueKey>{humanizeFieldKey(change.key)}</ValueKey>
+					<ValueKey>{fieldName(change.key, i18n)}</ValueKey>
 					{change.unchanged ? (
 						<ValueSame>{t`already ${change.to}`}</ValueSame>
 					) : (

--- a/apps/internal/src/components/research/provenance.tsx
+++ b/apps/internal/src/components/research/provenance.tsx
@@ -2,6 +2,8 @@ import { Trans, useLingui } from '@lingui/react/macro'
 import { Link2 } from 'lucide-react'
 import styled from 'styled-components'
 
+import { safeHref } from '#/components/research/safe-link'
+
 /**
  * "Sourced from research on {date}" trail with links to the source pages a
  * finding came from — so a stored value is traceable back to the run and the
@@ -45,16 +47,25 @@ export function Provenance({
 			</Label>
 			{uniqueSources.length > 0 ? (
 				<SourceList>
-					{uniqueSources.map(source => (
-						<SourceLink
-							key={source.url}
-							href={source.url}
-							target='_blank'
-							rel='noopener noreferrer'
-						>
-							{source.title ?? hostOf(source.url)}
-						</SourceLink>
-					))}
+					{uniqueSources.map(source => {
+						// The address comes from a page the run read, so it is only made
+						// clickable when it is an ordinary web address.
+						const href = safeHref(source.url)
+						return href === null ? (
+							<SourceText key={source.url}>
+								{source.title ?? hostOf(source.url)}
+							</SourceText>
+						) : (
+							<SourceLink
+								key={source.url}
+								href={href}
+								target='_blank'
+								rel='noopener noreferrer'
+							>
+								{source.title ?? hostOf(source.url)}
+							</SourceLink>
+						)
+					})}
 				</SourceList>
 			) : null}
 		</Wrap>
@@ -111,4 +122,10 @@ const SourceLink = styled.a`
 	&:hover {
 		text-decoration-thickness: 2px;
 	}
+`
+
+const SourceText = styled.span`
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	word-break: break-word;
 `

--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -29,6 +29,7 @@ import {
 	type StackOption,
 	StackPicker,
 } from '#/components/instructions/stack-picker'
+import { STATUS_ORDER, statusLabels } from '#/components/shared/status-badge'
 import { formatMoneyCents } from '#/lib/format-money'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
@@ -75,16 +76,10 @@ const SCHEMA_CARDS: ReadonlyArray<SchemaCard> = [
 const QUERY_MAX_LENGTH = 2000
 const FILTER_MAX_LENGTH = 120
 
-// The pipeline stages a company moves through; a discovery run can fan out
-// across the ones already in a stage instead of finding net-new companies.
-const STATUS_OPTIONS: ReadonlyArray<string> = [
-	'prospect',
-	'contacted',
-	'responded',
-	'meeting',
-	'proposal',
-	'client',
-]
+// Stages come from the one list the rest of the app shares. Keeping a private
+// copy here left out "closed" and "dead", so companies in those stages could
+// never be covered by a run at all — and it showed the reader the raw stored
+// words rather than their proper names.
 
 export function ResearchDialog({
 	open,
@@ -360,10 +355,11 @@ export function ResearchDialog({
 						</Field>
 
 						<Field>
-							<Label as='div'>
+							<Label as='div' id='research-kind-label'>
 								<Trans>What kind of research?</Trans>
 							</Label>
 							<SchemaGrid
+								aria-labelledby='research-kind-label'
 								value={schema}
 								onValueChange={value => {
 									if (typeof value === 'string') {
@@ -445,9 +441,9 @@ export function ResearchDialog({
 											onChange={e => setFilterStatus(e.target.value)}
 										>
 											<option value=''>{t`Find net-new`}</option>
-											{STATUS_OPTIONS.map(s => (
-												<option key={s} value={s}>
-													{s}
+											{STATUS_ORDER.map(stage => (
+												<option key={stage} value={stage}>
+													{i18n._(statusLabels[stage])}
 												</option>
 											))}
 										</SelectInput>

--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -3,7 +3,7 @@ import { RadioGroup } from '@base-ui/react/radio-group'
 import { useAtomSet, useAtomValue } from '@effect/atom-react'
 import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
-import { Trans, useLingui } from '@lingui/react/macro'
+import { Plural, Trans, useLingui } from '@lingui/react/macro'
 import { Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { Check, ChevronsUpDown, X } from 'lucide-react'
@@ -592,7 +592,11 @@ export function ResearchDialog({
 										{submitting ? (
 											<Trans>Starting…</Trans>
 										) : (
-											<Trans>Start {pendingConfirm.subjectCount} runs</Trans>
+											<Plural
+												value={pendingConfirm.subjectCount}
+												one='Start # run'
+												other='Start # runs'
+											/>
 										)}
 									</PriButton>
 									<PriButton

--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -228,12 +228,21 @@ export function ResearchDialog({
 					...(templateIds.length > 0 ? { template_ids: templateIds } : {}),
 					...(confirm ? { confirm: true } : {}),
 				},
-			} as never)
+			})
 
 			if (exit._tag === 'Success') {
 				const value = exit.value as Record<string, unknown> | null
 				const newId = typeof value?.['id'] === 'string' ? value['id'] : null
-				if (newId !== null && onCreated) onCreated(newId)
+				// A reply with no run to open means nothing was queued. Closing here
+				// would leave the reader believing their research had started.
+				if (newId === null) {
+					setErrorMessage(
+						t`Could not start the research run. Please try again.`,
+					)
+					setSubmitting(false)
+					return
+				}
+				if (onCreated) onCreated(newId)
 				onOpenChange(false)
 				return
 			}
@@ -257,10 +266,15 @@ export function ResearchDialog({
 				return
 			}
 			const budgetErr = taggedFailure(exit.cause, 'InsufficientBudget')
+			// A saved set of instructions that has since been deleted, or belongs to
+			// someone else, is refused outright rather than quietly swapped.
+			const stackErr = taggedFailure(exit.cause, 'UnknownStack')
 			setErrorMessage(
 				budgetErr
 					? t`Not enough research budget for this run. Raise the budget or narrow the search.`
-					: t`Could not start the research run. Please try again.`,
+					: stackErr
+						? t`That set of instructions is no longer available. Pick another and try again.`
+						: t`Could not start the research run. Please try again.`,
 			)
 			setSubmitting(false)
 		},

--- a/apps/internal/src/components/research/resolve-status.tsx
+++ b/apps/internal/src/components/research/resolve-status.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from '@lingui/react/macro'
+import { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 
 import type { ResolveDecision } from '#/hooks/use-proposal-resolution'
@@ -23,11 +24,35 @@ export function ResolveStatus({
 	readonly testId: string
 }) {
 	const { t } = useLingui()
+	const undoRef = useRef<HTMLButtonElement>(null)
+	const wrapRef = useRef<HTMLDivElement>(null)
+
+	// Pressing apply or reject removes the button that was pressed, which left
+	// the keyboard back at the top of the document — from there, reaching the next
+	// row meant tabbing past the whole toolbar and every row above it. Taking the
+	// change back is what follows from the press, so that is where the keyboard
+	// goes; it also puts the one control that stops the write within reach of
+	// someone who cannot see that it appeared.
+	//
+	// Once the change is on its way that button goes too, which would drop the
+	// keyboard a second time — so the row itself takes over, but only while the
+	// reader is still standing here. Pulling focus back to a row they have already
+	// left would be worse than losing it.
+	useEffect(() => {
+		if (undoable) {
+			undoRef.current?.focus()
+			return
+		}
+		const wrap = wrapRef.current
+		if (wrap?.contains(document.activeElement)) wrap.focus()
+	}, [undoable])
+
 	return (
-		<Wrap data-testid={testId}>
+		<Wrap ref={wrapRef} tabIndex={-1} data-testid={testId}>
 			<Label>{decision === 'apply' ? t`Applying…` : t`Rejecting…`}</Label>
 			{undoable ? (
 				<UndoButton
+					ref={undoRef}
 					type='button'
 					onClick={onUndo}
 					data-testid={`${testId}-undo`}
@@ -51,6 +76,14 @@ const Wrap = styled.div.withConfig({ displayName: 'ResolveStatusWrap' })`
 	display: inline-flex;
 	align-items: center;
 	gap: var(--space-2xs);
+
+	/* Takes the keyboard when the take-back control goes away, so it shows a mark
+	   there rather than appearing to land nowhere. */
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+		border-radius: var(--shape-2xs);
+	}
 `
 
 const Label = styled.span.withConfig({ displayName: 'ResolveStatusLabel' })`

--- a/apps/internal/src/components/research/resolve-status.tsx
+++ b/apps/internal/src/components/research/resolve-status.tsx
@@ -1,0 +1,87 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import styled from 'styled-components'
+
+import type { ResolveDecision } from '#/hooks/use-proposal-resolution'
+
+/**
+ * What a row says about a change the reader has just decided on, shared by the
+ * review queue and a run's own review so both behave identically.
+ *
+ * Two states, and the difference matters: while the change is still held back it
+ * can be taken back, and while it is on its way it cannot. Offering to take back
+ * something already sent would clear the row while the change still lands.
+ */
+export function ResolveStatus({
+	decision,
+	undoable,
+	onUndo,
+	testId,
+}: {
+	readonly decision: ResolveDecision
+	readonly undoable: boolean
+	readonly onUndo: () => void
+	readonly testId: string
+}) {
+	const { t } = useLingui()
+	return (
+		<Wrap data-testid={testId}>
+			<Label>{decision === 'apply' ? t`Applying…` : t`Rejecting…`}</Label>
+			{undoable ? (
+				<UndoButton
+					type='button'
+					onClick={onUndo}
+					data-testid={`${testId}-undo`}
+				>
+					<Trans>Undo</Trans>
+				</UndoButton>
+			) : null}
+		</Wrap>
+	)
+}
+
+/** An amount, aligned so figures in a column line up. */
+export const Money = styled.span.withConfig({ displayName: 'Money' })`
+	font-family: var(--font-mono);
+	font-size: var(--typescale-body-small-size);
+	font-variant-numeric: tabular-nums;
+	color: var(--color-on-surface-variant);
+`
+
+const Wrap = styled.div.withConfig({ displayName: 'ResolveStatusWrap' })`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+`
+
+const Label = styled.span.withConfig({ displayName: 'ResolveStatusLabel' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	font-style: italic;
+	color: var(--color-on-surface-variant);
+`
+
+const UndoButton = styled.button.withConfig({ displayName: 'UndoButton' })`
+	/* Small text made this under the 24px a pointer needs, and it is the only
+	   thing that stops a change being written. */
+	min-height: 1.5rem;
+	min-width: 1.5rem;
+	padding-inline: var(--space-2xs);
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--color-primary);
+	background: none;
+	border: none;
+	cursor: pointer;
+
+	&:hover {
+		text-decoration: underline;
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+		border-radius: var(--shape-2xs);
+	}
+`

--- a/apps/internal/src/components/research/review/proposed-updates-review.tsx
+++ b/apps/internal/src/components/research/review/proposed-updates-review.tsx
@@ -515,6 +515,11 @@ const Hint = styled.p`
 `
 
 const RefreshButton = styled.button`
+	/* Small text made these under the 24px a pointer needs, and Undo is the only
+	   thing that stops a change being written. */
+	min-height: 1.5rem;
+	min-width: 1.5rem;
+	padding-inline: var(--space-2xs);
 	font-family: var(--font-display);
 	font-size: var(--typescale-label-small-size);
 	letter-spacing: 0.06em;
@@ -626,6 +631,11 @@ const PendingLabel = styled.span`
 `
 
 const UndoButton = styled.button`
+	/* Small text made these under the 24px a pointer needs, and Undo is the only
+	   thing that stops a change being written. */
+	min-height: 1.5rem;
+	min-width: 1.5rem;
+	padding-inline: var(--space-2xs);
 	font-family: var(--font-display);
 	font-size: var(--typescale-label-small-size);
 	letter-spacing: 0.04em;

--- a/apps/internal/src/components/research/review/proposed-updates-review.tsx
+++ b/apps/internal/src/components/research/review/proposed-updates-review.tsx
@@ -29,6 +29,7 @@ import {
 	Provenance,
 	type ProvenanceSource,
 } from '#/components/research/provenance'
+import { ResolveStatus } from '#/components/research/resolve-status'
 import {
 	narrowProposedUpdates,
 	type ReviewProposal,
@@ -340,24 +341,19 @@ function ProposalCard({
 						reason={shownOutcome.reason}
 					/>
 				) : pending !== undefined ? (
-					<PendingResolve data-testid='research-review-pending'>
-						<PendingLabel>
-							{pending === 'apply' ? t`Applying…` : t`Rejecting…`}
-						</PendingLabel>
-						<UndoButton
-							type='button'
-							onClick={onUndo}
-							data-testid='research-review-undo'
-						>
-							<Trans>Undo</Trans>
-						</UndoButton>
-					</PendingResolve>
+					<ResolveStatus
+						decision={pending}
+						undoable
+						onUndo={onUndo}
+						testId='research-review-pending'
+					/>
 				) : sending !== undefined ? (
-					<PendingResolve data-testid='research-review-sending'>
-						<PendingLabel>
-							{sending === 'apply' ? t`Applying…` : t`Rejecting…`}
-						</PendingLabel>
-					</PendingResolve>
+					<ResolveStatus
+						decision={sending}
+						undoable={false}
+						onUndo={onUndo}
+						testId='research-review-sending'
+					/>
 				) : (
 					<>
 						<PriButton
@@ -615,44 +611,4 @@ const CardActions = styled.div`
 	align-items: center;
 	gap: var(--space-2xs);
 	margin-top: var(--space-3xs);
-`
-
-const PendingResolve = styled.div`
-	display: inline-flex;
-	align-items: center;
-	gap: var(--space-2xs);
-`
-
-const PendingLabel = styled.span`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-small-size);
-	font-style: italic;
-	color: var(--color-on-surface-variant);
-`
-
-const UndoButton = styled.button`
-	/* Small text made these under the 24px a pointer needs, and Undo is the only
-	   thing that stops a change being written. */
-	min-height: 1.5rem;
-	min-width: 1.5rem;
-	padding-inline: var(--space-2xs);
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
-	color: var(--color-primary);
-	background: none;
-	border: none;
-	cursor: pointer;
-	padding: var(--space-3xs) var(--space-2xs);
-
-	&:hover {
-		text-decoration: underline;
-	}
-
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
-		border-radius: var(--shape-2xs);
-	}
 `

--- a/apps/internal/src/components/research/review/proposed-updates-review.tsx
+++ b/apps/internal/src/components/research/review/proposed-updates-review.tsx
@@ -66,6 +66,7 @@ export function ProposedUpdatesReview({
 	const {
 		results,
 		pending: pendingResolve,
+		sending: sendingResolve,
 		resolve,
 		undo,
 		setResults,
@@ -104,7 +105,8 @@ export function ProposedUpdatesReview({
 		p =>
 			p.status === 'pending' &&
 			results[p.id] === undefined &&
-			pendingResolve[p.id] === undefined,
+			pendingResolve[p.id] === undefined &&
+			sendingResolve[p.id] === undefined,
 	)
 	const verifiedPending = pending.filter(
 		p => trustTier(strongestChannelTrust(p.channels)) === 'trustworthy',
@@ -237,6 +239,7 @@ export function ProposedUpdatesReview({
 						proposal={proposal}
 						result={results[proposal.id]}
 						pending={pendingResolve[proposal.id]}
+						sending={sendingResolve[proposal.id]}
 						completedAt={context.completedAt}
 						sources={sourcesFor(proposal, context.sourceById)}
 						onResolve={resolveOne}
@@ -252,6 +255,7 @@ function ProposalCard({
 	proposal,
 	result,
 	pending,
+	sending,
 	completedAt,
 	sources,
 	onResolve,
@@ -260,6 +264,7 @@ function ProposalCard({
 	readonly proposal: ReviewProposal
 	readonly result: ResolveOutcome | undefined
 	readonly pending: ResolveDecision | undefined
+	readonly sending: ResolveDecision | undefined
 	readonly completedAt: string | null
 	readonly sources: ReadonlyArray<ProvenanceSource>
 	readonly onResolve: (p: ReviewProposal, decision: ResolveDecision) => void
@@ -346,6 +351,12 @@ function ProposalCard({
 						>
 							<Trans>Undo</Trans>
 						</UndoButton>
+					</PendingResolve>
+				) : sending !== undefined ? (
+					<PendingResolve data-testid='research-review-sending'>
+						<PendingLabel>
+							{sending === 'apply' ? t`Applying…` : t`Rejecting…`}
+						</PendingLabel>
 					</PendingResolve>
 				) : (
 					<>

--- a/apps/internal/src/components/research/run-actions.tsx
+++ b/apps/internal/src/components/research/run-actions.tsx
@@ -37,6 +37,24 @@ function subjectsOf(context: unknown): ReadonlyArray<Subject> {
 	return out
 }
 
+/**
+ * The parts of a run's stored setup that a repeat run can be started from: the
+ * companies it was pointed at, the filter that chose them, and the search hints.
+ */
+function reusableContext(
+	context: unknown,
+): Record<string, unknown> | undefined {
+	if (!context || typeof context !== 'object') return undefined
+	const c = context as Record<string, unknown>
+	const out: Record<string, unknown> = {}
+	const subjects = subjectsOf(context)
+	if (subjects.length > 0) out['subjects'] = subjects
+	if (c['selector'] && typeof c['selector'] === 'object')
+		out['selector'] = c['selector']
+	if (c['hints'] && typeof c['hints'] === 'object') out['hints'] = c['hints']
+	return Object.keys(out).length > 0 ? out : undefined
+}
+
 /** Cancel a live run, re-run a finished one, or delete it — the run-detail toolbar. */
 export function RunActions({
 	run,
@@ -47,6 +65,8 @@ export function RunActions({
 		readonly schemaName: string | null
 		readonly status: string
 		readonly context: unknown
+		readonly mode: string | null
+		readonly templateIds: ReadonlyArray<string>
 	}
 }) {
 	const { t } = useLingui()
@@ -57,12 +77,16 @@ export function RunActions({
 	const create = useAtomSet(createResearchAtom, { mode: 'promiseExit' })
 	const refreshRun = useAtomRefresh(researchDetailAtom(run.id))
 	const [busy, setBusy] = useState<null | 'cancel' | 'delete' | 'rerun'>(null)
+	// Deleting takes the run, its findings and anything still waiting on review
+	// with it, and there is no way back — so it asks first. The reversible
+	// bulk-apply already works this way.
+	const [confirmingDelete, setConfirmingDelete] = useState(false)
 
 	const isActive = run.status === 'running' || run.status === 'queued'
 
 	const onCancel = async () => {
 		setBusy('cancel')
-		const exit = await cancel({ params: { id: run.id } } as never)
+		const exit = await cancel({ params: { id: run.id } })
 		setBusy(null)
 		if (exit._tag === 'Success') {
 			refreshRun()
@@ -74,9 +98,11 @@ export function RunActions({
 
 	const onDelete = async () => {
 		setBusy('delete')
-		const exit = await del({ params: { id: run.id } } as never)
+		const exit = await del({ params: { id: run.id } })
 		setBusy(null)
+		setConfirmingDelete(false)
 		if (exit._tag === 'Success') {
+			toast.add({ title: t`Run deleted`, type: 'success' })
 			void navigate({ to: '/research/runs' })
 		} else {
 			toast.add({ title: t`Could not delete the run`, type: 'error' })
@@ -85,14 +111,23 @@ export function RunActions({
 
 	const onRerun = async () => {
 		setBusy('rerun')
-		const subjects = subjectsOf(run.context)
+		// Repeat the whole setup, not just the question. Sending only the question
+		// and its subjects quietly dropped how thorough the run was, the
+		// instructions that shaped it, and — on a batch — the filter that chose
+		// which companies to cover, so the second run was not comparable with the
+		// first and a batch collapsed into a single run about nothing.
+		const context = reusableContext(run.context)
 		const exit = await create({
 			payload: {
 				query: run.query,
 				...(run.schemaName ? { schema_name: run.schemaName } : {}),
-				...(subjects.length > 0 ? { context: { subjects } } : {}),
+				...(run.mode ? { mode: run.mode } : {}),
+				...(context === undefined ? {} : { context }),
+				...(run.templateIds.length > 0
+					? { template_ids: run.templateIds }
+					: {}),
 			},
-		} as never)
+		})
 		setBusy(null)
 		if (exit._tag === 'Success') {
 			const value = exit.value as Record<string, unknown> | null
@@ -128,16 +163,40 @@ export function RunActions({
 					<Trans>Run again</Trans>
 				</PriButton>
 			)}
-			<PriButton
-				type='button'
-				$variant='text'
-				data-testid='run-delete'
-				disabled={busy !== null}
-				onClick={() => void onDelete()}
-			>
-				<Trash2 size={14} aria-hidden />
-				<Trans>Delete</Trans>
-			</PriButton>
+			{confirmingDelete ? (
+				<>
+					<PriButton
+						type='button'
+						$variant='filled'
+						data-testid='run-delete-confirm'
+						disabled={busy !== null}
+						onClick={() => void onDelete()}
+					>
+						<Trash2 size={14} aria-hidden />
+						{busy === 'delete' ? t`Deleting…` : t`Delete for good`}
+					</PriButton>
+					<PriButton
+						type='button'
+						$variant='text'
+						data-testid='run-delete-cancel'
+						disabled={busy !== null}
+						onClick={() => setConfirmingDelete(false)}
+					>
+						<Trans>Keep it</Trans>
+					</PriButton>
+				</>
+			) : (
+				<PriButton
+					type='button'
+					$variant='text'
+					data-testid='run-delete'
+					disabled={busy !== null}
+					onClick={() => setConfirmingDelete(true)}
+				>
+					<Trash2 size={14} aria-hidden />
+					<Trans>Delete</Trans>
+				</PriButton>
+			)}
 		</Actions>
 	)
 }

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -2,6 +2,7 @@ import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
 import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
+import { Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { RefreshCw } from 'lucide-react'
 import type { ComponentType } from 'react'
@@ -19,6 +20,7 @@ import { PriButton } from '@batuda/ui/pri'
 
 import { researchDetailAtom } from '#/atoms/research-atoms'
 import { MarkdownView } from '#/components/markdown/markdown-view'
+import { Badge } from '#/components/research/badge'
 import { CompanyEnrichmentView } from '#/components/research/findings/company-enrichment-view'
 import { CompetitorScanView } from '#/components/research/findings/competitor-scan-view'
 import { ContactDiscoveryView } from '#/components/research/findings/contact-discovery-view'
@@ -27,6 +29,7 @@ import { ProspectScanView } from '#/components/research/findings/prospect-scan-v
 import { ResearchRunIdProvider } from '#/components/research/research-run-context'
 import { ProposedUpdatesReview } from '#/components/research/review/proposed-updates-review'
 import { RunActions } from '#/components/research/run-actions'
+import { statusLabel, statusTone } from '#/components/research/run-labels'
 import { RunProgress } from '#/components/research/run-progress'
 import { TargetCorrection } from '#/components/research/target-correction'
 import { ErrorState } from '#/components/shared/error-state'
@@ -59,11 +62,25 @@ const REASON_LABEL: Record<ReasonCode, MessageDescriptor> = {
 	internal_error: msg`Something went wrong while running this research.`,
 }
 
+/** One run in a batch, as listed on the batch that started it. */
+type ChildRun = {
+	readonly id: string
+	readonly query: string
+	readonly status: string
+}
+
 type ResearchRunDetail = {
 	readonly id: string
 	readonly query: string
 	readonly schemaName: string | null
 	readonly status: string
+	// A batch fans work out to one run per company; `children` are those runs.
+	readonly kind: string
+	readonly children: ReadonlyArray<ChildRun>
+	// How thorough the run was, and the instruction templates that shaped it,
+	// both carried so running it again repeats the same run.
+	readonly mode: string | null
+	readonly templateIds: ReadonlyArray<string>
 	readonly templateNames: readonly string[]
 	readonly briefMd: string | null
 	readonly findings: unknown
@@ -82,11 +99,18 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 	// an early return) knows whether the run is still in flight.
 	const run = AsyncResult.isSuccess(result) ? narrowRun(result.value) : null
 	const isRunning = run?.status === 'running' || run?.status === 'queued'
-	const { progress, failed, stalled } = useResearchEvents(researchId, {
-		enabled: isRunning,
+	// A batch hands its work to one run per company and does none itself, so it
+	// never reports progress. Listening to it returned nothing and then announced
+	// itself as stalled, on a page that showed no sign of the runs doing the work.
+	const isBatch = run?.kind === 'group'
+	const { progress, failed, stalled, retry } = useResearchEvents(researchId, {
+		enabled: isRunning && !isBatch,
 	})
 
-	if (AsyncResult.isInitial(result) || AsyncResult.isWaiting(result)) {
+	// Only a first load has nothing to show. Treating a refresh as "loading" threw
+	// the whole panel away and rebuilt it, which cut short the few seconds a
+	// reader has to take back a change they just approved.
+	if (AsyncResult.isInitial(result)) {
 		return (
 			<Panel data-testid='research-run-detail'>
 				<Loading>
@@ -142,11 +166,11 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 					<RunActions run={run} />
 				</Header>
 
-				{isRunning && !failed && !stalled ? (
+				{isRunning && !isBatch && !failed && !stalled ? (
 					<RunProgress progress={progress} />
 				) : null}
 
-				{isRunning && (failed || stalled) ? (
+				{isRunning && !isBatch && (failed || stalled) ? (
 					<StalledNotice role='status' data-testid='research-run-stalled'>
 						<span>
 							<Trans>
@@ -158,7 +182,10 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 							type='button'
 							$variant='outlined'
 							data-testid='research-run-refresh'
-							onClick={() => refreshRun()}
+							onClick={() => {
+								retry()
+								refreshRun()
+							}}
 						>
 							<RefreshCw size={14} aria-hidden />
 							<Trans>Refresh</Trans>
@@ -200,6 +227,8 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 					</Section>
 				) : null}
 
+				{run.children.length > 0 ? <BatchRuns runs={run.children} /> : null}
+
 				{isRunning ? null : <ProposedUpdatesReview researchId={run.id} />}
 
 				<Section data-testid='research-run-findings'>
@@ -210,6 +239,39 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 				</Section>
 			</Panel>
 		</ResearchRunIdProvider>
+	)
+}
+
+/**
+ * The runs a batch handed its work to. Without this a batch showed nothing at
+ * all — no progress, no findings, and no way to reach any of the runs it
+ * started, which is where all of the actual results live.
+ */
+function BatchRuns({ runs }: { readonly runs: ReadonlyArray<ChildRun> }) {
+	const { i18n } = useLingui()
+	return (
+		<Section data-testid='research-run-children'>
+			<SectionTitle>
+				<Trans>Runs in this batch</Trans>
+			</SectionTitle>
+			<ChildList>
+				{runs.map(child => {
+					const label = statusLabel(child.status)
+					return (
+						<ChildRow key={child.id}>
+							<ChildLinkChrome>
+								<Link to='/research/$id' params={{ id: child.id }}>
+									{child.query === '' ? child.id : child.query}
+								</Link>
+							</ChildLinkChrome>
+							<Badge $tone={statusTone(child.status)}>
+								{label ? i18n._(label) : child.status}
+							</Badge>
+						</ChildRow>
+					)
+				})}
+			</ChildList>
+		</Section>
 	)
 }
 
@@ -276,6 +338,22 @@ function FailureReason({ reasonCode }: { readonly reasonCode: ReasonCode }) {
 	return <span>{i18n._(REASON_LABEL[reasonCode])}</span>
 }
 
+function narrowChildren(raw: unknown): ReadonlyArray<ChildRun> {
+	if (!Array.isArray(raw)) return []
+	const out: Array<ChildRun> = []
+	for (const row of raw) {
+		if (!row || typeof row !== 'object') continue
+		const r = row as Record<string, unknown>
+		if (typeof r['id'] !== 'string') continue
+		out.push({
+			id: r['id'],
+			query: typeof r['query'] === 'string' ? r['query'] : '',
+			status: typeof r['status'] === 'string' ? r['status'] : 'queued',
+		})
+	}
+	return out
+}
+
 function narrowRun(raw: unknown): ResearchRunDetail | null {
 	if (!raw || typeof raw !== 'object') return null
 	const r = raw as Record<string, unknown>
@@ -287,6 +365,12 @@ function narrowRun(raw: unknown): ResearchRunDetail | null {
 		query: r['query'],
 		schemaName: typeof r['schemaName'] === 'string' ? r['schemaName'] : null,
 		status: r['status'],
+		kind: typeof r['kind'] === 'string' ? r['kind'] : 'leaf',
+		children: narrowChildren(r['children']),
+		mode: typeof r['mode'] === 'string' ? r['mode'] : null,
+		templateIds: Array.isArray(r['templateIds'])
+			? r['templateIds'].filter((x): x is string => typeof x === 'string')
+			: [],
 		templateNames: Array.isArray(r['templateNames'])
 			? r['templateNames'].filter((x): x is string => typeof x === 'string')
 			: [],
@@ -427,4 +511,39 @@ const Pre = styled.pre`
 	padding: var(--space-sm);
 	border-radius: var(--shape-2xs);
 	margin: 0;
+`
+
+const ChildList = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const ChildRow = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-sm);
+	padding: var(--space-2xs) var(--space-xs);
+	border: 1px solid var(--color-outline-variant);
+	border-radius: var(--shape-2xs);
+`
+
+// Styling `Link` directly erases TanStack's typed `params` inference, so the
+// chrome lives on a wrapper and the real Link stays plain.
+const ChildLinkChrome = styled.span`
+	min-width: 0;
+
+	& > a {
+		font-family: var(--font-body);
+		font-size: var(--typescale-body-small-size);
+		color: var(--color-primary);
+		text-decoration: underline;
+	}
+
+	& > a:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+		border-radius: var(--shape-3xs);
+	}
 `

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -30,9 +30,10 @@ import { ResearchRunIdProvider } from '#/components/research/research-run-contex
 import { ProposedUpdatesReview } from '#/components/research/review/proposed-updates-review'
 import { RunActions } from '#/components/research/run-actions'
 import { statusLabel, statusTone } from '#/components/research/run-labels'
-import { RunProgress } from '#/components/research/run-progress'
+import { phaseMessage, RunProgress } from '#/components/research/run-progress'
 import { TargetCorrection } from '#/components/research/target-correction'
 import { ErrorState } from '#/components/shared/error-state'
+import { SrOnly } from '#/components/shared/sr-only'
 import { useResearchEvents } from '#/hooks/use-research-events'
 import {
 	brushedMetalPlate,
@@ -105,9 +106,25 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 	const isBatch = run?.kind === 'group'
 	// The raw token was being shown, so a reader saw "succeeded_low_confidence".
 	const runStatusLabel = run !== null ? statusLabel(run.status) : null
-	const { progress, failed, stalled, retry } = useResearchEvents(researchId, {
-		enabled: isRunning && !isBatch,
-	})
+	const { progress, done, failed, stalled, retry } = useResearchEvents(
+		researchId,
+		{ enabled: isRunning && !isBatch },
+	)
+
+	// One short sentence about where the run is, said only when it changes. The
+	// progress panel itself is silent: announcing it re-read every figure in it on
+	// every poll. This lives outside the panel so it is still on the page when the
+	// run finishes, which is the moment most worth hearing about — a region that
+	// appears at the same time as its text is not announced at all.
+	const runLive = isBatch
+		? null
+		: done
+			? t`This run has finished.`
+			: stalled || failed
+				? t`Live updates have stopped. The run may still be working.`
+				: isRunning
+					? i18n._(phaseMessage(progress.phase))
+					: null
 
 	// Only a first load has nothing to show. Treating a refresh as "loading" threw
 	// the whole panel away and rebuilt it, which cut short the few seconds a
@@ -151,6 +168,12 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 	return (
 		<ResearchRunIdProvider value={run.id}>
 			<Panel data-testid='research-run-detail'>
+				{runLive !== null ? (
+					<SrOnly role='status' data-testid='research-run-live'>
+						{runLive}
+					</SrOnly>
+				) : null}
+
 				<Header>
 					<Heading>{run.query}</Heading>
 					<HeaderMeta>

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -511,7 +511,9 @@ const Pre = styled.pre`
 	font-size: var(--typescale-body-small-size);
 	white-space: pre-wrap;
 	word-wrap: break-word;
-	background: color-mix(in oklab, var(--color-surface) 60%, black 6%);
+	/* A surface token rather than a mix toward black: darkening the surface again
+	   made this near-invisible against the plate it sits on in a dark theme. */
+	background: var(--color-surface-container-lowest);
 	padding: var(--space-sm);
 	border-radius: var(--shape-2xs);
 	margin: 0;

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -91,7 +91,7 @@ type ResearchRunDetail = {
 }
 
 export function RunDetail({ researchId }: { readonly researchId: string }) {
-	const { t } = useLingui()
+	const { t, i18n } = useLingui()
 	const result = useAtomValue(researchDetailAtom(researchId))
 	const refreshRun = useAtomRefresh(researchDetailAtom(researchId))
 
@@ -103,6 +103,8 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 	// never reports progress. Listening to it returned nothing and then announced
 	// itself as stalled, on a page that showed no sign of the runs doing the work.
 	const isBatch = run?.kind === 'group'
+	// The raw token was being shown, so a reader saw "succeeded_low_confidence".
+	const runStatusLabel = run !== null ? statusLabel(run.status) : null
 	const { progress, failed, stalled, retry } = useResearchEvents(researchId, {
 		enabled: isRunning && !isBatch,
 	})
@@ -156,7 +158,7 @@ export function RunDetail({ researchId }: { readonly researchId: string }) {
 							$status={run.status}
 							data-testid={`research-run-status-${run.id}`}
 						>
-							{run.status}
+							{runStatusLabel ? i18n._(runStatusLabel) : run.status}
 						</StatusText>
 						{run.schemaName !== null ? (
 							<SchemaText>{run.schemaName}</SchemaText>
@@ -387,7 +389,9 @@ function narrowRun(raw: unknown): ResearchRunDetail | null {
 	}
 }
 
-const Panel = styled.aside`
+// A section, not an aside: this holds the page's own content, and landmark
+// navigation announced the entire run as something off to the side.
+const Panel = styled.section`
 	${brushedMetalPlate}
 	display: flex;
 	flex-direction: column;
@@ -404,7 +408,7 @@ const Header = styled.header`
 	padding-bottom: var(--space-xs);
 `
 
-const Heading = styled.h3`
+const Heading = styled.h2`
 	${stenciledTitle}
 	font-size: var(--typescale-title-large-size);
 	line-height: var(--typescale-title-large-line);
@@ -480,7 +484,7 @@ const Section = styled.section`
 	gap: var(--space-sm);
 `
 
-const SectionTitle = styled.h4`
+const SectionTitle = styled.h3`
 	${stenciledTitle}
 	font-size: var(--typescale-title-medium-size);
 	line-height: var(--typescale-title-medium-line);

--- a/apps/internal/src/components/research/run-labels.ts
+++ b/apps/internal/src/components/research/run-labels.ts
@@ -59,3 +59,37 @@ const SUBJECT_TABLE_LABEL: Record<string, MessageDescriptor> = {
 export function subjectTableLabel(table: string): MessageDescriptor | null {
 	return SUBJECT_TABLE_LABEL[table] ?? null
 }
+
+// Proper names for the record fields a change can write, so a reader never sees
+// the name the database uses. Both spellings of a field are accepted, because a
+// change may name it either way round and both are honoured when it is applied.
+const FIELD_LABEL: Record<string, MessageDescriptor> = {
+	industry: msg`Industry`,
+	size_range: msg`Size`,
+	country: msg`Country`,
+	location: msg`Location`,
+	address: msg`Address`,
+	website: msg`Website`,
+	pain_points: msg`Pain points`,
+	current_tools: msg`Current tools`,
+	tax_id: msg`Tax ID`,
+	role: msg`Role`,
+	email: msg`Email`,
+	phone: msg`Phone`,
+	linkedin: msg`LinkedIn`,
+	notes: msg`Notes`,
+	tags: msg`Tags`,
+	products_fit: msg`Products that fit`,
+	latitude: msg`Latitude`,
+	longitude: msg`Longitude`,
+}
+
+/** The same field name written the other way round, to look up one spelling. */
+function toSnake(key: string): string {
+	return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+}
+
+/** Proper name for a record field, or null when the field has none yet. */
+export function fieldLabel(key: string): MessageDescriptor | null {
+	return FIELD_LABEL[key] ?? FIELD_LABEL[toSnake(key)] ?? null
+}

--- a/apps/internal/src/components/research/run-labels.ts
+++ b/apps/internal/src/components/research/run-labels.ts
@@ -11,7 +11,6 @@ import type { Tone } from './proposal-logic'
 const STATUS_LABEL: Record<string, MessageDescriptor> = {
 	queued: msg`Queued`,
 	running: msg`Running`,
-	paused: msg`Paused`,
 	succeeded: msg`Succeeded`,
 	succeeded_low_confidence: msg`Needs review`,
 	failed: msg`Failed`,
@@ -28,7 +27,6 @@ export function statusLabel(status: string): MessageDescriptor | null {
 const STATUS_TONE: Record<string, Tone> = {
 	queued: 'neutral',
 	running: 'info',
-	paused: 'caution',
 	succeeded: 'positive',
 	succeeded_low_confidence: 'caution',
 	failed: 'negative',
@@ -45,8 +43,6 @@ export function statusTone(status: string): Tone {
 const OPERATION_LABEL: Record<string, MessageDescriptor> = {
 	create: msg`New`,
 	update: msg`Update`,
-	add_channel: msg`Add channel`,
-	merge: msg`Merge`,
 }
 
 /** Localized label for a proposal operation, or null for an unknown token. */

--- a/apps/internal/src/components/research/run-list.tsx
+++ b/apps/internal/src/components/research/run-list.tsx
@@ -136,10 +136,6 @@ const Wrap = styled.div`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-lg);
-	padding: var(--space-lg);
-	max-width: 60rem;
-	margin: 0 auto;
-	width: 100%;
 `
 
 const HeaderRow = styled.div`
@@ -156,9 +152,10 @@ const HeaderText = styled.div`
 	gap: var(--space-3xs);
 `
 
-const PageTitle = styled.h1`
+const PageTitle = styled.h2`
 	${stenciledTitle}
-	font-size: var(--typescale-headline-small-size);
+	font-size: var(--typescale-headline-large-size);
+	line-height: var(--typescale-headline-large-line);
 	margin: 0;
 `
 

--- a/apps/internal/src/components/research/run-list.tsx
+++ b/apps/internal/src/components/research/run-list.tsx
@@ -107,7 +107,9 @@ export function ResearchRuns() {
 								</RowMain>
 								<RowSide>
 									<Cost>
-										{formatMoneyCents(run.costCents, { locale: i18n.locale })}
+										{formatMoneyCents(run.costCents + run.paidCostCents, {
+											locale: i18n.locale,
+										})}
 									</Cost>
 									<RelativeDate value={run.createdAt} />
 								</RowSide>

--- a/apps/internal/src/components/research/run-list.tsx
+++ b/apps/internal/src/components/research/run-list.tsx
@@ -89,7 +89,7 @@ export function ResearchRuns() {
 									<Link
 										to='/research/$id'
 										params={{ id: run.id }}
-										aria-label={run.query}
+										aria-label={run.query || run.id}
 									/>
 								</RowLinkOverlay>
 								<RowMain>
@@ -211,6 +211,9 @@ const RowLinkOverlay = styled.div`
 		inset: 0;
 	}
 
+	/* The row draws its own mark when the link inside it takes focus (see the
+	   :focus-within rule on Row), so the link's default outline is stood down —
+	   deliberately, and only because something visible replaces it. */
 	a:focus-visible {
 		outline: none;
 	}

--- a/apps/internal/src/components/research/run-progress.tsx
+++ b/apps/internal/src/components/research/run-progress.tsx
@@ -1,4 +1,4 @@
-import { Trans, useLingui } from '@lingui/react/macro'
+import { Plural, Trans, useLingui } from '@lingui/react/macro'
 import type { ReactNode } from 'react'
 import styled from 'styled-components'
 
@@ -32,12 +32,20 @@ export function RunProgress({
 					) : null}
 					{progress.toolCalls > 0 ? (
 						<MetaItem>
-							<Trans>{progress.toolCalls} steps run</Trans>
+							<Plural
+								value={progress.toolCalls}
+								one='# step run'
+								other='# steps run'
+							/>
 						</MetaItem>
 					) : null}
 					{progress.sourceCount !== null ? (
 						<MetaItem>
-							<Trans>{progress.sourceCount} sources</Trans>
+							<Plural
+								value={progress.sourceCount}
+								one='# source'
+								other='# sources'
+							/>
 						</MetaItem>
 					) : null}
 				</Meta>

--- a/apps/internal/src/components/research/run-progress.tsx
+++ b/apps/internal/src/components/research/run-progress.tsx
@@ -1,3 +1,5 @@
+import type { MessageDescriptor } from '@lingui/core'
+import { msg } from '@lingui/core/macro'
 import { Plural, Trans, useLingui } from '@lingui/react/macro'
 import type { ReactNode } from 'react'
 import styled from 'styled-components'
@@ -9,6 +11,12 @@ import type { ResearchProgress } from '#/components/research/event-shapes'
  * which of the three phases the agent is in (gather → extract → write), the
  * step count, and how many sources it has pulled — so a paid, minutes-long
  * job doesn't look frozen.
+ *
+ * Read silently on purpose. Announcing this panel meant re-reading every figure
+ * in it each time a poll returned — "gathering evidence, step 1 of 3, searching
+ * and reasoning, 7 steps run, 4 sources", over and over, interrupting whatever
+ * the reader was on. The page announces the phase alone, when it changes, from a
+ * region that outlives this panel; see `phaseMessage`.
  */
 export function RunProgress({
 	progress,
@@ -17,7 +25,7 @@ export function RunProgress({
 }) {
 	const { t } = useLingui()
 	return (
-		<Wrap data-testid='research-run-progress' role='status' aria-live='polite'>
+		<Wrap data-testid='research-run-progress'>
 			<Pulse aria-hidden />
 			<Body>
 				<Line>
@@ -150,3 +158,20 @@ const Meta = styled.div`
 `
 
 const MetaItem = styled.span``
+
+/**
+ * The phase as one short sentence, for the page's spoken summary. Kept beside
+ * the visual labels so the two cannot drift apart.
+ */
+export function phaseMessage(phase: number | null): MessageDescriptor {
+	switch (phase) {
+		case 1:
+			return msg`Gathering evidence.`
+		case 2:
+			return msg`Extracting findings.`
+		case 3:
+			return msg`Writing the brief.`
+		default:
+			return msg`Starting the run.`
+	}
+}

--- a/apps/internal/src/components/research/run-shapes.ts
+++ b/apps/internal/src/components/research/run-shapes.ts
@@ -1,8 +1,15 @@
 /**
- * Narrow row shape for a research run summary and the boundary narrower that
- * produces it. The `list` endpoint returns `Schema.Unknown`, so callers
- * runtime-narrow here. Shared by the company research card, the company
- * detail page, and the research inbox.
+ * Narrow row shape for a research run summary and the narrower that produces it.
+ * Shared by the company research card, the company detail page, and the research
+ * inbox.
+ *
+ * The `list` endpoint is fully typed, so this is not the boundary check it looks
+ * like: what it still earns its place for is turning the decoded date into a
+ * plain string for display. Everything else it does is a liability — a row it
+ * does not recognise is skipped rather than reported, so a shape that drifts
+ * loses rows off the screen silently instead of failing. Reading the typed rows
+ * directly is the right end state; it waits on the date formatting those rows
+ * feed, which is being changed separately.
  */
 
 import { DateTime } from 'effect'
@@ -14,6 +21,9 @@ export type ResearchRunRow = {
 	readonly kind: string
 	readonly status: string
 	readonly costCents: number
+	// Paid lookups are tallied apart from the cheap work, so a reader that shows
+	// only one of the two can report a run that spent money as free.
+	readonly paidCostCents: number
 	readonly createdAt: string
 }
 
@@ -44,6 +54,8 @@ export function narrowResearch(
 			kind: typeof r['kind'] === 'string' ? r['kind'] : 'leaf',
 			status: r['status'],
 			costCents: typeof r['costCents'] === 'number' ? r['costCents'] : 0,
+			paidCostCents:
+				typeof r['paidCostCents'] === 'number' ? r['paidCostCents'] : 0,
 			createdAt,
 		})
 	}

--- a/apps/internal/src/components/research/safe-link.tsx
+++ b/apps/internal/src/components/research/safe-link.tsx
@@ -1,0 +1,86 @@
+import styled from 'styled-components'
+
+/**
+ * Links to addresses that came out of a research run.
+ *
+ * Two reasons this is not a plain anchor. The address was read off a page the
+ * run found, so it is not trusted: only ordinary web and mail addresses become
+ * links, and anything else is shown as text rather than made clickable — a
+ * "link" that runs code the moment it is clicked would otherwise be one click
+ * away inside a signed-in page. And the app's baseline styling strips colour and
+ * underline from anchors, so a link with no styling of its own is invisible;
+ * these carry their own, always underlined, so a reader can tell what is
+ * clickable.
+ */
+
+/** Web and mail addresses only — everything else is not a link. */
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:'])
+
+/**
+ * The address if it is safe to link to, otherwise null. A value with no protocol
+ * at all is read as a bare domain and offered over https.
+ */
+export function safeHref(value: string | null | undefined): string | null {
+	if (typeof value !== 'string') return null
+	const trimmed = value.trim()
+	if (trimmed === '') return null
+	const candidate = /^[a-z][a-z0-9+.-]*:/i.test(trimmed)
+		? trimmed
+		: `https://${trimmed}`
+	try {
+		const url = new URL(candidate)
+		return SAFE_PROTOCOLS.has(url.protocol) ? url.toString() : null
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Render an address found by a run: a link when it can be followed safely, plain
+ * text when it cannot, so nothing is silently dropped from the page.
+ */
+export function SafeLink({
+	href,
+	children,
+	newTab = true,
+}: {
+	readonly href: string | null | undefined
+	readonly children?: React.ReactNode
+	/** Mail addresses open in place; web addresses open in a new tab. */
+	readonly newTab?: boolean
+}) {
+	const safe = safeHref(href)
+	const label = children ?? href ?? ''
+	if (safe === null) return <Plain>{label}</Plain>
+	const isMail = safe.startsWith('mailto:')
+	return (
+		<Anchor
+			href={safe}
+			{...(newTab && !isMail
+				? { target: '_blank', rel: 'noreferrer noopener' }
+				: {})}
+		>
+			{label}
+		</Anchor>
+	)
+}
+
+const Anchor = styled.a`
+	color: var(--color-primary);
+	text-decoration: underline;
+
+	&:hover {
+		text-decoration-thickness: 2px;
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+		border-radius: var(--shape-3xs);
+	}
+`
+
+const Plain = styled.span`
+	color: var(--color-on-surface-variant);
+	word-break: break-word;
+`

--- a/apps/internal/src/components/research/target-correction.tsx
+++ b/apps/internal/src/components/research/target-correction.tsx
@@ -37,7 +37,7 @@ export function TargetCorrection({
 		const exit = await rerun({
 			params: { id: researchId },
 			payload: { domain: domain.trim() },
-		} as never)
+		})
 
 		if (exit._tag === 'Success') {
 			const value = exit.value as Record<string, unknown> | null

--- a/apps/internal/src/components/shared/relative-date.tsx
+++ b/apps/internal/src/components/shared/relative-date.tsx
@@ -1,14 +1,26 @@
+import { useLingui } from '@lingui/react/macro'
 import styled from 'styled-components'
 
 /**
- * Relative date formatter using `Intl.RelativeTimeFormat` in English.
+ * Relative date formatter, in the reader's own language.
  * Accepts a `Date`, an ISO string, or a Unix timestamp. Renders
  * semantically as a `<time>` element with the ISO `datetime` attribute
  * so screen readers and copy-paste actions get the absolute value.
  *
  * Examples: "today", "yesterday", "3 days ago", "2 weeks ago", "in 5 days".
  */
-const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+// Built per locale rather than once at load: a single shared formatter fixed
+// every date on every screen to one language, so a reader working in another
+// language saw English dates beside otherwise translated text.
+const formatterCache = new Map<string, Intl.RelativeTimeFormat>()
+
+function relativeFormatter(locale: string): Intl.RelativeTimeFormat {
+	const cached = formatterCache.get(locale)
+	if (cached !== undefined) return cached
+	const made = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+	formatterCache.set(locale, made)
+	return made
+}
 
 type RelativeDateInput = Date | string | number | null | undefined
 
@@ -19,6 +31,8 @@ export function RelativeDate({
 	value: RelativeDateInput
 	fallback?: string
 }) {
+	const { i18n } = useLingui()
+	const locale = i18n.locale
 	if (value === null || value === undefined || value === '') {
 		return <Muted>{fallback}</Muted>
 	}
@@ -28,7 +42,7 @@ export function RelativeDate({
 		return <Muted>{fallback}</Muted>
 	}
 
-	const label = formatRelative(date)
+	const label = formatRelative(date, locale)
 	return (
 		// The server sits in UTC and the reader's browser does not, so the
 		// spelled-out time and the "5 months ago" wording are both allowed to
@@ -37,14 +51,15 @@ export function RelativeDate({
 		<Time
 			suppressHydrationWarning
 			dateTime={date.toISOString()}
-			title={date.toLocaleString('en')}
+			title={date.toLocaleString(locale)}
 		>
 			{label}
 		</Time>
 	)
 }
 
-function formatRelative(date: Date): string {
+function formatRelative(date: Date, locale: string): string {
+	const rtf = relativeFormatter(locale)
 	const diffMs = date.getTime() - Date.now()
 	const diffSec = Math.round(diffMs / 1000)
 

--- a/apps/internal/src/hooks/use-proposal-resolution.ts
+++ b/apps/internal/src/hooks/use-proposal-resolution.ts
@@ -10,7 +10,11 @@ export type ResolveOutcome = {
 export type ResolveDecision = 'apply' | 'reject'
 
 // How long a reviewer can take back an apply/reject before it actually writes.
-export const UNDO_WINDOW_MS = 5000
+// Long enough to be usable by someone who has to find the control first: a
+// listener hears the row change, moves to the button and presses it, which does
+// not happen in five seconds. There is no way to extend it once it starts, so
+// the window itself has to be generous.
+export const UNDO_WINDOW_MS = 20000
 
 /**
  * Shared apply/reject behavior for both proposal-review surfaces (the cross-run

--- a/apps/internal/src/hooks/use-proposal-resolution.ts
+++ b/apps/internal/src/hooks/use-proposal-resolution.ts
@@ -36,6 +36,10 @@ export function useProposalResolution(options?: {
 	const [results, setResults] = useState<Record<string, ResolveOutcome>>({})
 	// Rows whose write is still held back inside the undo window.
 	const [pending, setPending] = useState<Record<string, ResolveDecision>>({})
+	// Rows whose write has already left for the server. Kept apart from `pending`
+	// because taking it back is no longer possible: offering to undo here would
+	// clear the row on screen while the change still lands.
+	const [sending, setSending] = useState<Record<string, ResolveDecision>>({})
 	const held = useRef(
 		new Map<
 			string,
@@ -56,8 +60,15 @@ export function useProposalResolution(options?: {
 			decision: ResolveDecision,
 			onError: () => void,
 		) => {
-			// The write is on its way now — past the point where Undo could stop it.
+			// The write is on its way now — past the point where Undo could stop it,
+			// so the row moves out of the undoable set and says so on screen.
 			held.current.delete(key)
+			setPending(prev => {
+				const next = { ...prev }
+				delete next[key]
+				return next
+			})
+			setSending(prev => ({ ...prev, [key]: decision }))
 			const run = decision === 'apply' ? apply : reject
 			const exit = await run({ params: { id: researchId, puId } })
 			// The write has landed. Re-read the stored proposals now, before the
@@ -67,7 +78,7 @@ export function useProposalResolution(options?: {
 			// The reviewer may have left while the write was in flight; it still
 			// landed, so only the on-screen updates below are skipped.
 			if (!mounted.current) return
-			setPending(prev => {
+			setSending(prev => {
 				const next = { ...prev }
 				delete next[key]
 				return next
@@ -106,10 +117,12 @@ export function useProposalResolution(options?: {
 
 	const undo = useCallback((key: string) => {
 		const entry = held.current.get(key)
-		if (entry !== undefined) {
-			clearTimeout(entry.timer)
-			held.current.delete(key)
-		}
+		// Nothing held means the write already left. Clearing the row here would
+		// tell the reader it was taken back while the change still lands, so the
+		// row is left alone to finish and report its real outcome.
+		if (entry === undefined) return
+		clearTimeout(entry.timer)
+		held.current.delete(key)
 		setPending(prev => {
 			const next = { ...prev }
 			delete next[key]
@@ -131,5 +144,5 @@ export function useProposalResolution(options?: {
 		}
 	}, [])
 
-	return { results, pending, resolve, undo, setResults }
+	return { results, pending, sending, resolve, undo, setResults }
 }

--- a/apps/internal/src/hooks/use-research-events.ts
+++ b/apps/internal/src/hooks/use-research-events.ts
@@ -1,6 +1,6 @@
 import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { researchDetailAtom, researchEventsAtom } from '#/atoms/research-atoms'
 import {
@@ -46,6 +46,18 @@ export function useResearchEvents(
 	// The page uses this to swap the endless progress bar for a manual refresh.
 	const [stalled, setStalled] = useState(false)
 
+	/**
+	 * Start listening again after the loop gave up, or after a poll failed. The
+	 * counters reset, so a run that was simply slow to start streaming gets a
+	 * fresh set of attempts rather than staying silent for the life of the page.
+	 */
+	const retry = useCallback(() => {
+		emptyPollsRef.current = 0
+		setStalled(false)
+		setFailed(false)
+		refreshEvents()
+	}, [refreshEvents])
+
 	// biome-ignore lint/correctness/useExhaustiveDependencies: `result` is the poll signal — the loop re-runs each time a poll resolves.
 	useEffect(() => {
 		if (!enabled) return
@@ -54,6 +66,13 @@ export function useResearchEvents(
 			return
 		}
 		if (!AsyncResult.isSuccess(result)) return
+		// Asking for the next poll re-renders with the previous answer still in
+		// hand, before the new one arrives. That is not an answer, so it must not
+		// count as an empty round — counting it burned two attempts per poll and
+		// the loop gave up about ten seconds into any run that had yet to start
+		// streaming. It also armed the retry timer while a request was still open,
+		// cutting off a long poll that was waiting to collect events.
+		if (result.waiting) return
 
 		const value = result.value
 		const fresh = narrowEvents(value.events).filter(
@@ -103,5 +122,5 @@ export function useResearchEvents(
 
 	const progress = useMemo(() => deriveProgress(events), [events])
 
-	return { progress, events, done, failed, stalled }
+	return { progress, events, done, failed, stalled, retry }
 }

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -54,6 +54,21 @@ msgstr "(sense assumpte)"
 msgid "(no summary)"
 msgstr "(sense resum)"
 
+#. placeholder {0}: quality.fields_grounded ?? 0
+#: src/components/research/findings/company-enrichment-view.tsx
+msgid "{0, plural, one {# fact backed by a source} other {# facts backed by a source}}"
+msgstr "{0, plural, one {# fet amb font} other {# fets amb font}}"
+
+#. placeholder {0}: quality.sources_matched ?? 0
+#: src/components/research/findings/company-enrichment-view.tsx
+msgid "{0, plural, one {# page on the company's own site} other {# pages on the company's own site}}"
+msgstr "{0, plural, one {# pàgina del web de l'empresa} other {# pàgines del web de l'empresa}}"
+
+#. placeholder {0}: quality.rounds ?? 0
+#: src/components/research/findings/company-enrichment-view.tsx
+msgid "{0, plural, one {# pass over the evidence} other {# passes over the evidence}}"
+msgstr "{0, plural, one {# passada sobre les proves} other {# passades sobre les proves}}"
+
 #. placeholder {0}: progress.sourceCount
 #: src/components/research/run-progress.tsx
 msgid "{0, plural, one {# source} other {# sources}}"
@@ -89,12 +104,9 @@ msgstr "{0} assistents"
 msgid "{0} calls"
 msgstr "{0} crides"
 
-#. placeholder {0}: quality.fields_grounded ?? 0
-#. placeholder {1}: quality.sources_matched ?? 0
-#. placeholder {2}: quality.rounds ?? 0
 #: src/components/research/findings/company-enrichment-view.tsx
-msgid "{0} fields grounded · {1} own-domain sources · {2} rounds"
-msgstr "{0} camps documentats · {1} fonts del domini propi · {2} rondes"
+#~ msgid "{0} fields grounded · {1} own-domain sources · {2} rounds"
+#~ msgstr "{0} camps documentats · {1} fonts del domini propi · {2} rondes"
 
 #. placeholder {0}: thread.messageCount
 #: src/routes/emails/index.tsx
@@ -133,6 +145,14 @@ msgstr "{0}: es mostren {1} de {shelfTotal} tasques."
 #: src/routes/settings/organization/members.tsx
 msgid "{addedEmail} is now a member. They've been emailed."
 msgstr "{addedEmail} ja és membre. Se li ha enviat un correu."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "{entered} changes entered the records."
+msgstr "{entered} canvis han entrat als registres."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "{entered} entered the records, {leftover} still need you."
+msgstr "{entered} han entrat als registres, {leftover} encara et necessiten."
 
 #: src/components/layout/nav-group-knob.tsx
 msgid "{groupLabel} sections"
@@ -538,6 +558,11 @@ msgstr "Aplica tot el verificat ({verifiedToApply})"
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Apply field updates ({0})"
 msgstr "Aplica actualitzacions de camps ({0})"
+
+#. placeholder {0}: items.length
+#: src/components/research/inbox/research-inbox.tsx
+msgid "Applying {0} changes…"
+msgstr "S'estan aplicant {0} canvis…"
 
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Applying a discovered contact merges it into a matching record if one already exists."
@@ -4832,6 +4857,10 @@ msgstr "No s'ha pogut carregar el tauler. Comprova que la sessió sigui vàlida 
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "El canvi no s'ha completat. Torna-ho a provar."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "The changes could not be applied."
+msgstr "No s'han pogut aplicar els canvis."
 
 #: src/routes/companies/$slug.tsx
 msgid "The company could not be fetched. Check that the session is valid, then try again."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -436,6 +436,11 @@ msgstr "Tot sota control"
 msgid "Allow"
 msgstr "Permet"
 
+#. placeholder {0}: change.to
+#: src/components/research/inbox/research-inbox.tsx
+msgid "already {0}"
+msgstr "ja hi diu {0}"
+
 #: src/components/research/findings/shared.tsx
 msgid "Already in CRM"
 msgstr "Ja al CRM"
@@ -456,6 +461,10 @@ msgstr "Un assistent d'IA vol connectar-se al teu compte de Batuda per MCP i act
 #: src/routes/settings/organization/templates.tsx
 msgid "An org stack runs for every member who hasn't set their own. The one marked default applies to a run that names none. Only org templates can go in an org stack."
 msgstr "Una pila de l'organització s'aplica a tots els membres que no n'han definit una de pròpia. La marcada per defecte s'aplica quan una execució no n'anomena cap. En una pila de l'organització només hi poden anar plantilles de l'organització."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "and {hidden} more on the run"
+msgstr "i {hidden} més a l'execució"
 
 #: src/components/research/research-dialog.tsx
 msgid "Any"
@@ -1560,6 +1569,10 @@ msgstr "La contrasenya actual no és correcta."
 #: src/components/research/findings/company-enrichment-view.tsx
 msgid "Current tools"
 msgstr "Eines actuals"
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "currently"
+msgstr "actualment"
 
 #: src/components/profile/theme-select.tsx
 msgid "Dark"
@@ -3193,6 +3206,10 @@ msgstr "Res completat recentment"
 #: src/routes/tasks/index.tsx
 msgid "Nothing later in the queue"
 msgstr "Res més endavant a la cua"
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "nothing on file, would add"
+msgstr "no hi ha res, s'afegiria"
 
 #: src/routes/tasks/index.tsx
 msgid "Nothing overdue"
@@ -5313,6 +5330,10 @@ msgstr "S'està fent…"
 #: src/routes/index.tsx
 msgid "Workshop floor — live counters on the bench."
 msgstr "Planta del taller — comptadors en viu al banc."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "would become"
+msgstr "passaria a ser"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Write footer…"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -319,10 +319,6 @@ msgstr "Afegeix adjunt"
 msgid "Add Cc / Bcc"
 msgstr "Afegeix Cc / Bcc"
 
-#: src/components/research/run-labels.ts
-msgid "Add channel"
-msgstr "Afegeix canal"
-
 #: src/components/contacts/contact-edit-dialog.tsx
 #: src/routes/companies/$slug.tsx
 msgid "Add contact"
@@ -2736,10 +2732,6 @@ msgstr "Membre"
 msgid "Members"
 msgstr "Membres"
 
-#: src/components/research/run-labels.ts
-msgid "Merge"
-msgstr "Fusiona"
-
 #: src/components/research/proposal-outcome.tsx
 msgid "Merged into existing"
 msgstr "Fusionat amb un existent"
@@ -3556,7 +3548,6 @@ msgstr "Enganxa una contrasenya d'aplicació; jo et mostraré on aconseguir-ne u
 msgid "Pause syncing"
 msgstr "Atura la sincronització"
 
-#: src/components/research/run-labels.ts
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Paused"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -54,6 +54,16 @@ msgstr "(sense assumpte)"
 msgid "(no summary)"
 msgstr "(sense resum)"
 
+#. placeholder {0}: progress.sourceCount
+#: src/components/research/run-progress.tsx
+msgid "{0, plural, one {# source} other {# sources}}"
+msgstr "{0, plural, one {# font} other {# fonts}}"
+
+#. placeholder {0}: progress.toolCalls
+#: src/components/research/run-progress.tsx
+msgid "{0, plural, one {# step run} other {# steps run}}"
+msgstr "{0, plural, one {# pas fet} other {# passos fets}}"
+
 #. placeholder {0}: counts[shelf]
 #: src/routes/tasks/index.tsx
 msgid "{0, plural, one {# task} other {# tasks}}"
@@ -63,6 +73,11 @@ msgstr "{0, plural, one {# tasca} other {# tasques}}"
 #: src/components/instructions/stack-list.tsx
 msgid "{0, plural, one {# template} other {# templates}}"
 msgstr "{0, plural, one {# plantilla} other {# plantilles}}"
+
+#. placeholder {0}: pendingConfirm.subjectCount
+#: src/components/research/research-dialog.tsx
+msgid "{0, plural, one {Start # run} other {Start # runs}}"
+msgstr "{0, plural, one {Inicia # execució} other {Inicia # execucions}}"
 
 #. placeholder {0}: ev.attendees.length
 #: src/components/companies/upcoming-meetings-card.tsx
@@ -91,20 +106,17 @@ msgstr "{0} missatges"
 msgid "{0} no longer allows password sign-in for mail apps, so it can't be connected here yet — it needs an OAuth sign-in. Pick another provider or use Generic IMAP."
 msgstr "{0} ja no permet iniciar la sessió amb contrasenya a les aplicacions de correu, així que de moment no es pot connectar aquí: necessita un inici de sessió OAuth. Tria un altre proveïdor o fes servir IMAP genèric."
 
+#. placeholder {0}: trustworthy.length
+#. placeholder {1}: needsReview.length
+#. placeholder {2}: attention.length
+#: src/components/research/inbox/research-inbox.tsx
+msgid "{0} ready to apply, {1} need reading, {2} runs need attention."
+msgstr "{0} a punt d’aplicar, {1} per llegir, {2} execucions requereixen atenció."
+
 #. placeholder {0}: selection.selectedCount
 #: src/components/companies/pipeline-board.tsx
 msgid "{0} selected"
 msgstr "{0} seleccionats"
-
-#. placeholder {0}: progress.sourceCount
-#: src/components/research/run-progress.tsx
-msgid "{0} sources"
-msgstr "{0} fonts"
-
-#. placeholder {0}: progress.toolCalls
-#: src/components/research/run-progress.tsx
-msgid "{0} steps run"
-msgstr "{0} passos fets"
 
 #. placeholder {0}: failedIds.length
 #: src/routes/emails/index.tsx
@@ -2520,6 +2532,10 @@ msgid "Loading tasks…"
 msgstr "S'estan carregant les tasques…"
 
 #: src/components/research/inbox/research-inbox.tsx
+msgid "Loading the changes waiting for review."
+msgstr "S'estan carregant els canvis pendents de revisió."
+
+#: src/components/research/inbox/research-inbox.tsx
 msgid "Loading the review queue"
 msgstr "S'està carregant la cua de revisió"
 
@@ -4549,11 +4565,6 @@ msgstr "Orientació permanent que el teu agent de recerca segueix en cada recerc
 msgid "Start"
 msgstr "Inicia"
 
-#. placeholder {0}: pendingConfirm.subjectCount
-#: src/components/research/research-dialog.tsx
-msgid "Start {0} runs"
-msgstr "Inicia {0} execucions"
-
 #: src/routes/emails/inboxes.tsx
 msgid "Start sending and receiving"
 msgstr "Comença a enviar i rebre"
@@ -4806,6 +4817,10 @@ msgstr "No s'ha pogut carregar la llista. Comprova que la sessió sigui vàlida 
 #: src/routes/tasks/index.tsx
 msgid "The list could not be fetched. Check the connection, then try again."
 msgstr "No s'ha pogut obtenir la llista. Comprova la connexió i torna-ho a provar."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "The list of changes could not be loaded."
+msgstr "No s'ha pogut carregar la llista de canvis."
 
 #: src/routes/emails/inboxes.tsx
 msgid "The mailbox is ready."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -533,8 +533,14 @@ msgid "Applying…"
 msgstr "Aplicant…"
 
 #: src/components/research/findings/shared.tsx
+#: src/components/research/inbox/paid-action-queue.tsx
 msgid "Approve"
 msgstr "Aprova"
+
+#. placeholder {0}: action.tool
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Approve {0}"
+msgstr "Aprova {0}"
 
 #: src/routes/emails/$threadId.tsx
 #: src/routes/emails/index.tsx
@@ -1373,6 +1379,10 @@ msgstr "No s'han pogut actualitzar els canals"
 #: src/components/research/findings/shared.tsx
 msgid "Could not update the paid action"
 msgstr "No s'ha pogut actualitzar l'acció de pagament"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Could not update this lookup."
+msgstr "No s'ha pogut actualitzar aquesta cerca."
 
 #: src/routes/companies/$slug.tsx
 msgid "Could not update verification"
@@ -2570,6 +2580,14 @@ msgstr "Registra interacció"
 msgid "Logging…"
 msgstr "Registrant…"
 
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Lookup approved — the run is picking it up."
+msgstr "Cerca aprovada: l'execució se n'ocupa."
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Lookup skipped. Nothing was spent."
+msgstr "Cerca omesa. No s'ha gastat res."
+
 #: src/routes/companies/$slug.tsx
 msgid "Low"
 msgstr "Baixa"
@@ -3279,6 +3297,7 @@ msgstr "Obre Instagram"
 msgid "Open LinkedIn"
 msgstr "Obre LinkedIn"
 
+#: src/components/research/inbox/paid-action-queue.tsx
 #: src/components/research/inbox/research-inbox.tsx
 msgid "Open run"
 msgstr "Obre l'execució"
@@ -3304,6 +3323,10 @@ msgstr "Tasques obertes"
 #: src/routes/settings/organization/index.tsx
 msgid "Open the org spend dashboard"
 msgstr "Obre el panell de despesa de l'organització"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Open the run asking for this lookup"
+msgstr "Obre l'execució que demana aquesta cerca"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Open the setup guide, opens in a new tab"
@@ -3465,6 +3488,10 @@ msgstr "Acció de pagament omesa"
 #: src/routes/settings/organization/policy.tsx
 msgid "Paid calls at or below this run without asking."
 msgstr "Les crides de pagament iguals o inferiors a aquest import s'executen sense preguntar."
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Paid lookups waiting for your OK"
+msgstr "Cerques de pagament que esperen el teu vistiplau"
 
 #: src/routes/settings/organization/policy.tsx
 msgid "Paid provider calls allowed within one run."
@@ -3838,6 +3865,10 @@ msgstr "El destinatari ha marcat el missatge com a brossa"
 #: src/components/research/proposal-outcome.tsx
 msgid "Record changed since research"
 msgstr "El registre ha canviat des de la recerca"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Recorded before these could be decided — open the run."
+msgstr "Desada abans que es poguessin decidir: obre l'execució."
 
 #: src/components/layout/nav-items.ts
 msgid "Records"
@@ -4333,6 +4364,11 @@ msgstr "Mostra la contrasenya"
 msgid "Show system events"
 msgstr "Mostra esdeveniments del sistema"
 
+#. placeholder {0}: proposals.length
+#: src/components/research/inbox/research-inbox.tsx
+msgid "Showing {0} of {totalPending}. Narrow the filters to reach the rest."
+msgstr "Es mostren {0} de {totalPending}. Afina els filtres per arribar a la resta."
+
 #: src/routes/emails/index.tsx
 msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Mostrant {firstRow}–{lastRow} de {total}"
@@ -4371,8 +4407,14 @@ msgid "Size"
 msgstr "Mida"
 
 #: src/components/research/findings/shared.tsx
+#: src/components/research/inbox/paid-action-queue.tsx
 msgid "Skip"
 msgstr "Omet"
+
+#. placeholder {0}: action.tool
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Skip {0}"
+msgstr "Omet {0}"
 
 #: src/routes/pages/$id.tsx
 #: src/routes/pages/index.tsx
@@ -4404,6 +4446,10 @@ msgstr "Ajornades"
 #: src/routes/emails/$threadId.tsx
 msgid "someone"
 msgstr "algú"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Someone had already decided this one."
+msgstr "Algú ja havia decidit aquesta."
 
 #: src/components/research/run-detail.tsx
 msgid "Something went wrong while running this research."
@@ -4704,6 +4750,10 @@ msgstr "L'enllaç ha caducat. Demana'n un de nou a sota."
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "L'enllaç ja no és vàlid. Demana'n un de nou a sota."
 
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "That lookup isn't available, so it can only be skipped."
+msgstr "Aquesta cerca no està disponible, així que només es pot ometre."
+
 #: src/components/research/research-dialog.tsx
 msgid "That set of instructions is no longer available. Pick another and try again."
 msgstr "Aquest conjunt d'instruccions ja no està disponible. Tria'n un altre i torna-ho a provar."
@@ -4841,6 +4891,11 @@ msgstr "El taller ha rebutjat el canvi. Torna-ho a provar."
 #: src/routes/settings/organization/index.tsx
 msgid "The workspace your CRM data lives in."
 msgstr "L'espai de treball on viuen les dades del CRM."
+
+#. placeholder {0}: formatMoneyCents(totalCents, { locale: i18n.locale })
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "These cost money, so nothing runs until you say so. About {0} in total."
+msgstr "Costen diners, així que no es fa res fins que ho diguis. Uns {0} en total."
 
 #: src/routes/settings/organization/members.tsx
 msgid "They join straight away and get an email telling them so. It carries no password and no link to sign in with."
@@ -5273,6 +5328,10 @@ msgstr "Qui"
 #: src/routes/emails/inboxes.tsx
 msgid "Who's your email provider?"
 msgstr "Quin és el teu proveïdor de correu?"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Working…"
+msgstr "S'està fent…"
 
 #: src/routes/index.tsx
 msgid "Workshop floor — live counters on the bench."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -525,6 +525,8 @@ msgstr "En aplicar un contacte descobert, es fusiona amb un registre coincident 
 
 #: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/review/proposed-updates-review.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Applying…"
@@ -1348,6 +1350,7 @@ msgid "Could not start the re-run. Please try again."
 msgstr "No he pogut iniciar la reexecució. Torna-ho a provar."
 
 #: src/components/research/research-dialog.tsx
+#: src/components/research/research-dialog.tsx
 msgid "Could not start the research run. Please try again."
 msgstr "No s'ha pogut iniciar la recerca. Torna-ho a provar."
 
@@ -1628,6 +1631,10 @@ msgstr "Elimina {0}"
 msgid "Delete failed"
 msgstr "Error en eliminar"
 
+#: src/components/research/run-actions.tsx
+msgid "Delete for good"
+msgstr "Elimina-la definitivament"
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
@@ -1666,6 +1673,7 @@ msgid "Deleted"
 msgstr "Eliminada"
 
 #: src/components/instructions/template-delete-confirm.tsx
+#: src/components/research/run-actions.tsx
 #: src/routes/settings/api-keys/index.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Deleting…"
@@ -2379,6 +2387,10 @@ msgstr "Uneix-te a la videotrucada"
 msgid "Keep editing"
 msgstr "Continua editant"
 
+#: src/components/research/run-actions.tsx
+msgid "Keep it"
+msgstr "Conserva-la"
+
 #: src/routes/settings/organization/spend.tsx
 msgid "Key"
 msgstr "Clau"
@@ -3069,7 +3081,6 @@ msgstr "Sense URI de redirecció"
 msgid "No reliable data"
 msgstr "Sense dades fiables"
 
-#: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/run-detail.tsx
 msgid "No reliable data found"
 msgstr "No s'han trobat dades fiables"
@@ -3861,6 +3872,8 @@ msgid "Rejected"
 msgstr "Rebutjat"
 
 #: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/review/proposed-updates-review.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Rejecting…"
 msgstr "S'està rebutjant…"
@@ -4047,7 +4060,10 @@ msgstr "Torna a executar"
 msgid "Run cancelled"
 msgstr "Execució cancel·lada"
 
-#: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/run-actions.tsx
+msgid "Run deleted"
+msgstr "Execució eliminada"
+
 #: src/components/research/run-detail.tsx
 msgid "Run failed"
 msgstr "Execució fallida"
@@ -4067,6 +4083,10 @@ msgstr "Execució no trobada"
 #: src/components/research/run-labels.ts
 msgid "Running"
 msgstr "En execució"
+
+#: src/components/research/run-detail.tsx
+msgid "Runs in this batch"
+msgstr "Execucions d'aquest lot"
 
 #: src/components/companies/about-section.tsx
 msgid "Sales context"
@@ -4684,6 +4704,10 @@ msgstr "L'enllaç ha caducat. Demana'n un de nou a sota."
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "L'enllaç ja no és vàlid. Demana'n un de nou a sota."
 
+#: src/components/research/research-dialog.tsx
+msgid "That set of instructions is no longer available. Pick another and try again."
+msgstr "Aquest conjunt d'instruccions ja no està disponible. Tria'n un altre i torna-ho a provar."
+
 #: src/routes/tasks/index.tsx
 msgid "The 20 most recently edited tasks on this shelf. Click one to reopen it."
 msgstr "Les 20 tasques editades més recentment d'aquest prestatge. Fes clic en una per reobrir-la."
@@ -5209,6 +5233,10 @@ msgstr "Quin tipus de recerca?"
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "What needs to happen?"
 msgstr "Què cal fer?"
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "What this run has cost so far"
+msgstr "El que ha costat aquesta execució fins ara"
 
 #: src/components/companies/followup-dialog.tsx
 msgid "What to follow up on"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -389,7 +389,6 @@ msgstr "Agent IA"
 msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
 msgstr "Assistents d'IA que has connectat per MCP. Cadascun pot actuar en una o més de les teves organitzacions; l'assistent tria quina en cada petició."
 
-#: src/components/research/inbox/research-inbox.tsx
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
 msgid "All"
@@ -520,10 +519,7 @@ msgid "Applying a discovered contact merges it into a matching record if one alr
 msgstr "En aplicar un contacte descobert, es fusiona amb un registre coincident si ja existeix."
 
 #: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/review/proposed-updates-review.tsx
-#: src/components/research/review/proposed-updates-review.tsx
+#: src/components/research/resolve-status.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Applying…"
 msgstr "Aplicant…"
@@ -956,7 +952,6 @@ msgid "Comms"
 msgstr "Comunicació"
 
 #: src/components/layout/nav-items.ts
-#: src/components/research/inbox/research-inbox.tsx
 #: src/routes/companies/index.tsx
 msgid "Companies"
 msgstr "Empreses"
@@ -1094,7 +1089,6 @@ msgid "Contacted — set the next action (a follow-up date)."
 msgstr "Contactat — defineix la següent acció (una data de seguiment)."
 
 #: src/components/research/findings/company-enrichment-view.tsx
-#: src/components/research/inbox/research-inbox.tsx
 msgid "Contacts"
 msgstr "Contactes"
 
@@ -2064,10 +2058,6 @@ msgstr "Filtra per safata"
 #: src/routes/emails/index.tsx
 msgid "Filter by status"
 msgstr "Filtra per estat"
-
-#: src/components/research/inbox/research-inbox.tsx
-msgid "Filter by subject"
-msgstr "Filtra per subjecte"
 
 #: src/routes/companies/index.tsx
 msgid "Filter companies"
@@ -3893,10 +3883,7 @@ msgstr "Rebutja {subjectLabel}"
 msgid "Rejected"
 msgstr "Rebutjat"
 
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/review/proposed-updates-review.tsx
-#: src/components/research/review/proposed-updates-review.tsx
+#: src/components/research/resolve-status.tsx
 msgid "Rejecting…"
 msgstr "S'està rebutjant…"
 
@@ -5060,8 +5047,7 @@ msgstr "Sense assignar"
 msgid "Undeliverable"
 msgstr "No es pot lliurar"
 
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/review/proposed-updates-review.tsx
+#: src/components/research/resolve-status.tsx
 msgid "Undo"
 msgstr "Desfés"
 

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -376,6 +376,10 @@ msgstr "Afegit com a oportunitat verificada"
 msgid "Adding…"
 msgstr "S'està afegint…"
 
+#: src/components/research/run-labels.ts
+msgid "Address"
+msgstr "Adreça"
+
 #: src/routes/settings/organization/members.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Admin"
@@ -1468,6 +1472,7 @@ msgstr "carregant el recompte"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/prospect-scan-view.tsx
+#: src/components/research/run-labels.ts
 #: src/routes/companies/index.tsx
 msgid "Country"
 msgstr "País"
@@ -1579,6 +1584,7 @@ msgstr "La contrasenya actual no és correcta."
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Current tools"
 msgstr "Eines actuals"
 
@@ -1926,6 +1932,7 @@ msgstr "Editor"
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
+#: src/components/research/run-labels.ts
 #: src/components/shared/channel-icon.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/inboxes.tsx
@@ -2340,6 +2347,7 @@ msgstr "Bústies"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/prospect-scan-view.tsx
+#: src/components/research/run-labels.ts
 #: src/routes/companies/index.tsx
 msgid "Industry"
 msgstr "Sector"
@@ -2472,6 +2480,10 @@ msgstr "Última visita"
 msgid "Later"
 msgstr "Més endavant"
 
+#: src/components/research/run-labels.ts
+msgid "Latitude"
+msgstr "Latitud"
+
 #: src/components/research/research-dialog.tsx
 msgid "Layered after the stack, in order."
 msgstr "S'apliquen després de la pila, en ordre."
@@ -2485,6 +2497,7 @@ msgid "Line items"
 msgstr "Línies"
 
 #: src/components/research/findings/contact-discovery-view.tsx
+#: src/components/research/run-labels.ts
 #: src/components/shared/channel-icon.tsx
 msgid "LinkedIn"
 msgstr "LinkedIn"
@@ -2568,6 +2581,7 @@ msgstr "Localitzant…"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/research-dialog.tsx
+#: src/components/research/run-labels.ts
 #: src/routes/calendar/index.tsx
 msgid "Location"
 msgstr "Ubicació"
@@ -2594,6 +2608,10 @@ msgstr "Registra interacció"
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Logging…"
 msgstr "Registrant…"
+
+#: src/components/research/run-labels.ts
+msgid "Longitude"
+msgstr "Longitud"
 
 #: src/components/research/inbox/paid-action-queue.tsx
 msgid "Lookup approved — the run is picking it up."
@@ -3207,6 +3225,10 @@ msgstr "No el veus? Mira la carpeta de correu brossa. Si estàs segur que el cor
 msgid "Note"
 msgstr "Nota"
 
+#: src/components/research/run-labels.ts
+msgid "Notes"
+msgstr "Notes"
+
 #: src/components/companies/proposals-panel.tsx
 msgid "Notes (optional)"
 msgstr "Notes (opcional)"
@@ -3530,6 +3552,7 @@ msgstr "Indicadors de dolor"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Pain points"
 msgstr "Punts febles"
 
@@ -3610,6 +3633,7 @@ msgstr "Personal"
 
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Phone"
 msgstr "Telèfon"
 
@@ -3722,6 +3746,10 @@ msgstr "Bústia privada"
 #: src/components/companies/about-section.tsx
 msgid "Products fit"
 msgstr "Encaix de productes"
+
+#: src/components/research/run-labels.ts
+msgid "Products that fit"
+msgstr "Productes que encaixen"
 
 #: src/routes/settings/profile/index.tsx
 msgid "Profile"
@@ -4082,6 +4110,7 @@ msgstr "Revisa què ha trobat l'agent de recerca i decideix què entra al CRM."
 msgid "Risky"
 msgstr "Arriscat"
 
+#: src/components/research/run-labels.ts
 #: src/routes/settings/organization/members.tsx
 msgid "Role"
 msgstr "Rol"
@@ -4414,6 +4443,7 @@ msgstr "Tancant sessió…"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Size"
 msgstr "Mida"
 
@@ -4657,6 +4687,7 @@ msgstr "Sistema"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Tags"
 msgstr "Etiquetes"
 
@@ -4688,6 +4719,7 @@ msgid "tasks — showing {0} of {shelfTotal}"
 msgstr "tasques: es mostren {0} de {shelfTotal}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Tax ID"
 msgstr "NIF"
 
@@ -5268,6 +5300,10 @@ msgstr "Encaix feble"
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Weaknesses"
 msgstr "Punts febles"
+
+#: src/components/research/run-labels.ts
+msgid "Website"
+msgstr "Lloc web"
 
 #: src/routes/emails/index.tsx
 #: src/routes/emails/index.tsx

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -2064,6 +2064,10 @@ msgstr "Plantilles addicionals per a aquesta execució"
 msgid "Extracting findings"
 msgstr "Extraient conclusions"
 
+#: src/components/research/run-progress.tsx
+msgid "Extracting findings."
+msgstr "Extraient conclusions."
+
 #: src/components/research/findings/company-enrichment-view.tsx
 msgid "Fail"
 msgstr "No compleix"
@@ -2200,6 +2204,10 @@ msgstr "Pantalla completa"
 #: src/components/research/run-progress.tsx
 msgid "Gathering evidence"
 msgstr "Recollint proves"
+
+#: src/components/research/run-progress.tsx
+msgid "Gathering evidence."
+msgstr "Recollint proves."
 
 #: src/components/companies/documents-panel.tsx
 msgid "General"
@@ -2505,6 +2513,10 @@ msgstr "LinkedIn"
 #: src/components/companies/companies-header.tsx
 msgid "List"
 msgstr "Llista"
+
+#: src/components/research/run-detail.tsx
+msgid "Live updates have stopped. The run may still be working."
+msgstr "Les actualitzacions en directe s'han aturat. Potser l'execució encara treballa."
 
 #: src/components/research/run-detail.tsx
 msgid "Live updates paused. This run may still be working — refresh to check its latest status."
@@ -4600,6 +4612,10 @@ msgid "Start sending and receiving"
 msgstr "Comença a enviar i rebre"
 
 #: src/components/research/run-progress.tsx
+msgid "Starting the run."
+msgstr "Iniciant l'execució."
+
+#: src/components/research/run-progress.tsx
 msgid "Starting the run…"
 msgstr "Iniciant l'execució…"
 
@@ -4995,6 +5011,10 @@ msgstr "Aquesta execució no es pot mostrar."
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "This run found no changes to review."
 msgstr "Aquesta execució no ha trobat cap canvi per revisar."
+
+#: src/components/research/run-detail.tsx
+msgid "This run has finished."
+msgstr "Aquesta execució ha acabat."
 
 #. placeholder {0}: pendingConfirm.subjectCount
 #. placeholder {1}: formatMoneyCents(pendingConfirm.estimatedCostCents, { locale: i18n.locale, })
@@ -5397,6 +5417,10 @@ msgstr "Escriu el teu missatge…"
 #: src/components/research/run-progress.tsx
 msgid "Writing the brief"
 msgstr "Redactant l'informe"
+
+#: src/components/research/run-progress.tsx
+msgid "Writing the brief."
+msgstr "Escrivint el resum."
 
 #: src/components/companies/account-brief-section.tsx
 msgid "Written by research. Editing it makes it yours."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -319,10 +319,6 @@ msgstr "Add attachment"
 msgid "Add Cc / Bcc"
 msgstr "Add Cc / Bcc"
 
-#: src/components/research/run-labels.ts
-msgid "Add channel"
-msgstr "Add channel"
-
 #: src/components/contacts/contact-edit-dialog.tsx
 #: src/routes/companies/$slug.tsx
 msgid "Add contact"
@@ -2736,10 +2732,6 @@ msgstr "Member"
 msgid "Members"
 msgstr "Members"
 
-#: src/components/research/run-labels.ts
-msgid "Merge"
-msgstr "Merge"
-
 #: src/components/research/proposal-outcome.tsx
 msgid "Merged into existing"
 msgstr "Merged into existing"
@@ -3556,7 +3548,6 @@ msgstr "Paste an app password — I'll show you where to get one"
 msgid "Pause syncing"
 msgstr "Pause syncing"
 
-#: src/components/research/run-labels.ts
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Paused"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -389,7 +389,6 @@ msgstr "AI agent"
 msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
 msgstr "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
 
-#: src/components/research/inbox/research-inbox.tsx
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
 msgid "All"
@@ -520,10 +519,7 @@ msgid "Applying a discovered contact merges it into a matching record if one alr
 msgstr "Applying a discovered contact merges it into a matching record if one already exists."
 
 #: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/review/proposed-updates-review.tsx
-#: src/components/research/review/proposed-updates-review.tsx
+#: src/components/research/resolve-status.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Applying…"
 msgstr "Applying…"
@@ -956,7 +952,6 @@ msgid "Comms"
 msgstr "Comms"
 
 #: src/components/layout/nav-items.ts
-#: src/components/research/inbox/research-inbox.tsx
 #: src/routes/companies/index.tsx
 msgid "Companies"
 msgstr "Companies"
@@ -1094,7 +1089,6 @@ msgid "Contacted — set the next action (a follow-up date)."
 msgstr "Contacted — set the next action (a follow-up date)."
 
 #: src/components/research/findings/company-enrichment-view.tsx
-#: src/components/research/inbox/research-inbox.tsx
 msgid "Contacts"
 msgstr "Contacts"
 
@@ -2064,10 +2058,6 @@ msgstr "Filter by inbox"
 #: src/routes/emails/index.tsx
 msgid "Filter by status"
 msgstr "Filter by status"
-
-#: src/components/research/inbox/research-inbox.tsx
-msgid "Filter by subject"
-msgstr "Filter by subject"
 
 #: src/routes/companies/index.tsx
 msgid "Filter companies"
@@ -3893,10 +3883,7 @@ msgstr "Reject {subjectLabel}"
 msgid "Rejected"
 msgstr "Rejected"
 
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/review/proposed-updates-review.tsx
-#: src/components/research/review/proposed-updates-review.tsx
+#: src/components/research/resolve-status.tsx
 msgid "Rejecting…"
 msgstr "Rejecting…"
 
@@ -5060,8 +5047,7 @@ msgstr "Unassigned"
 msgid "Undeliverable"
 msgstr "Undeliverable"
 
-#: src/components/research/inbox/research-inbox.tsx
-#: src/components/research/review/proposed-updates-review.tsx
+#: src/components/research/resolve-status.tsx
 msgid "Undo"
 msgstr "Undo"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -54,6 +54,21 @@ msgstr "(no subject)"
 msgid "(no summary)"
 msgstr "(no summary)"
 
+#. placeholder {0}: quality.fields_grounded ?? 0
+#: src/components/research/findings/company-enrichment-view.tsx
+msgid "{0, plural, one {# fact backed by a source} other {# facts backed by a source}}"
+msgstr "{0, plural, one {# fact backed by a source} other {# facts backed by a source}}"
+
+#. placeholder {0}: quality.sources_matched ?? 0
+#: src/components/research/findings/company-enrichment-view.tsx
+msgid "{0, plural, one {# page on the company's own site} other {# pages on the company's own site}}"
+msgstr "{0, plural, one {# page on the company's own site} other {# pages on the company's own site}}"
+
+#. placeholder {0}: quality.rounds ?? 0
+#: src/components/research/findings/company-enrichment-view.tsx
+msgid "{0, plural, one {# pass over the evidence} other {# passes over the evidence}}"
+msgstr "{0, plural, one {# pass over the evidence} other {# passes over the evidence}}"
+
 #. placeholder {0}: progress.sourceCount
 #: src/components/research/run-progress.tsx
 msgid "{0, plural, one {# source} other {# sources}}"
@@ -89,12 +104,9 @@ msgstr "{0} attendees"
 msgid "{0} calls"
 msgstr "{0} calls"
 
-#. placeholder {0}: quality.fields_grounded ?? 0
-#. placeholder {1}: quality.sources_matched ?? 0
-#. placeholder {2}: quality.rounds ?? 0
 #: src/components/research/findings/company-enrichment-view.tsx
-msgid "{0} fields grounded · {1} own-domain sources · {2} rounds"
-msgstr "{0} fields grounded · {1} own-domain sources · {2} rounds"
+#~ msgid "{0} fields grounded · {1} own-domain sources · {2} rounds"
+#~ msgstr "{0} fields grounded · {1} own-domain sources · {2} rounds"
 
 #. placeholder {0}: thread.messageCount
 #: src/routes/emails/index.tsx
@@ -133,6 +145,14 @@ msgstr "{0}: showing {1} of {shelfTotal} tasks."
 #: src/routes/settings/organization/members.tsx
 msgid "{addedEmail} is now a member. They've been emailed."
 msgstr "{addedEmail} is now a member. They've been emailed."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "{entered} changes entered the records."
+msgstr "{entered} changes entered the records."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "{entered} entered the records, {leftover} still need you."
+msgstr "{entered} entered the records, {leftover} still need you."
 
 #: src/components/layout/nav-group-knob.tsx
 msgid "{groupLabel} sections"
@@ -538,6 +558,11 @@ msgstr "Apply all verified ({verifiedToApply})"
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Apply field updates ({0})"
 msgstr "Apply field updates ({0})"
+
+#. placeholder {0}: items.length
+#: src/components/research/inbox/research-inbox.tsx
+msgid "Applying {0} changes…"
+msgstr "Applying {0} changes…"
 
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Applying a discovered contact merges it into a matching record if one already exists."
@@ -4832,6 +4857,10 @@ msgstr "The board could not be fetched. Check that the session is valid, then tr
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "The change didn't go through. Try again."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "The changes could not be applied."
+msgstr "The changes could not be applied."
 
 #: src/routes/companies/$slug.tsx
 msgid "The company could not be fetched. Check that the session is valid, then try again."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -2064,6 +2064,10 @@ msgstr "Extra templates for this run"
 msgid "Extracting findings"
 msgstr "Extracting findings"
 
+#: src/components/research/run-progress.tsx
+msgid "Extracting findings."
+msgstr "Extracting findings."
+
 #: src/components/research/findings/company-enrichment-view.tsx
 msgid "Fail"
 msgstr "Fail"
@@ -2200,6 +2204,10 @@ msgstr "Full screen"
 #: src/components/research/run-progress.tsx
 msgid "Gathering evidence"
 msgstr "Gathering evidence"
+
+#: src/components/research/run-progress.tsx
+msgid "Gathering evidence."
+msgstr "Gathering evidence."
 
 #: src/components/companies/documents-panel.tsx
 msgid "General"
@@ -2505,6 +2513,10 @@ msgstr "LinkedIn"
 #: src/components/companies/companies-header.tsx
 msgid "List"
 msgstr "List"
+
+#: src/components/research/run-detail.tsx
+msgid "Live updates have stopped. The run may still be working."
+msgstr "Live updates have stopped. The run may still be working."
 
 #: src/components/research/run-detail.tsx
 msgid "Live updates paused. This run may still be working — refresh to check its latest status."
@@ -4600,6 +4612,10 @@ msgid "Start sending and receiving"
 msgstr "Start sending and receiving"
 
 #: src/components/research/run-progress.tsx
+msgid "Starting the run."
+msgstr "Starting the run."
+
+#: src/components/research/run-progress.tsx
 msgid "Starting the run…"
 msgstr "Starting the run…"
 
@@ -4995,6 +5011,10 @@ msgstr "This run can't be displayed."
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "This run found no changes to review."
 msgstr "This run found no changes to review."
+
+#: src/components/research/run-detail.tsx
+msgid "This run has finished."
+msgstr "This run has finished."
 
 #. placeholder {0}: pendingConfirm.subjectCount
 #. placeholder {1}: formatMoneyCents(pendingConfirm.estimatedCostCents, { locale: i18n.locale, })
@@ -5397,6 +5417,10 @@ msgstr "Write your message…"
 #: src/components/research/run-progress.tsx
 msgid "Writing the brief"
 msgstr "Writing the brief"
+
+#: src/components/research/run-progress.tsx
+msgid "Writing the brief."
+msgstr "Writing the brief."
 
 #: src/components/companies/account-brief-section.tsx
 msgid "Written by research. Editing it makes it yours."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -525,6 +525,8 @@ msgstr "Applying a discovered contact merges it into a matching record if one al
 
 #: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/review/proposed-updates-review.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Applying…"
@@ -1348,6 +1350,7 @@ msgid "Could not start the re-run. Please try again."
 msgstr "Could not start the re-run. Please try again."
 
 #: src/components/research/research-dialog.tsx
+#: src/components/research/research-dialog.tsx
 msgid "Could not start the research run. Please try again."
 msgstr "Could not start the research run. Please try again."
 
@@ -1628,6 +1631,10 @@ msgstr "Delete {0}"
 msgid "Delete failed"
 msgstr "Delete failed"
 
+#: src/components/research/run-actions.tsx
+msgid "Delete for good"
+msgstr "Delete for good"
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Delete inbox {0}? Stored messages stay; the connection stops."
@@ -1666,6 +1673,7 @@ msgid "Deleted"
 msgstr "Deleted"
 
 #: src/components/instructions/template-delete-confirm.tsx
+#: src/components/research/run-actions.tsx
 #: src/routes/settings/api-keys/index.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Deleting…"
@@ -2379,6 +2387,10 @@ msgstr "Join video call"
 msgid "Keep editing"
 msgstr "Keep editing"
 
+#: src/components/research/run-actions.tsx
+msgid "Keep it"
+msgstr "Keep it"
+
 #: src/routes/settings/organization/spend.tsx
 msgid "Key"
 msgstr "Key"
@@ -3069,7 +3081,6 @@ msgstr "No redirect URI"
 msgid "No reliable data"
 msgstr "No reliable data"
 
-#: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/run-detail.tsx
 msgid "No reliable data found"
 msgstr "No reliable data found"
@@ -3861,6 +3872,8 @@ msgid "Rejected"
 msgstr "Rejected"
 
 #: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/review/proposed-updates-review.tsx
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Rejecting…"
 msgstr "Rejecting…"
@@ -4047,7 +4060,10 @@ msgstr "Run again"
 msgid "Run cancelled"
 msgstr "Run cancelled"
 
-#: src/components/research/inbox/research-inbox.tsx
+#: src/components/research/run-actions.tsx
+msgid "Run deleted"
+msgstr "Run deleted"
+
 #: src/components/research/run-detail.tsx
 msgid "Run failed"
 msgstr "Run failed"
@@ -4067,6 +4083,10 @@ msgstr "Run not found"
 #: src/components/research/run-labels.ts
 msgid "Running"
 msgstr "Running"
+
+#: src/components/research/run-detail.tsx
+msgid "Runs in this batch"
+msgstr "Runs in this batch"
 
 #: src/components/companies/about-section.tsx
 msgid "Sales context"
@@ -4684,6 +4704,10 @@ msgstr "That link expired. Request a fresh one below."
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "That link is no longer valid. Request a fresh one below."
 
+#: src/components/research/research-dialog.tsx
+msgid "That set of instructions is no longer available. Pick another and try again."
+msgstr "That set of instructions is no longer available. Pick another and try again."
+
 #: src/routes/tasks/index.tsx
 msgid "The 20 most recently edited tasks on this shelf. Click one to reopen it."
 msgstr "The 20 most recently edited tasks on this shelf. Click one to reopen it."
@@ -5209,6 +5233,10 @@ msgstr "What kind of research?"
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "What needs to happen?"
 msgstr "What needs to happen?"
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "What this run has cost so far"
+msgstr "What this run has cost so far"
 
 #: src/components/companies/followup-dialog.tsx
 msgid "What to follow up on"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -54,6 +54,16 @@ msgstr "(no subject)"
 msgid "(no summary)"
 msgstr "(no summary)"
 
+#. placeholder {0}: progress.sourceCount
+#: src/components/research/run-progress.tsx
+msgid "{0, plural, one {# source} other {# sources}}"
+msgstr "{0, plural, one {# source} other {# sources}}"
+
+#. placeholder {0}: progress.toolCalls
+#: src/components/research/run-progress.tsx
+msgid "{0, plural, one {# step run} other {# steps run}}"
+msgstr "{0, plural, one {# step run} other {# steps run}}"
+
 #. placeholder {0}: counts[shelf]
 #: src/routes/tasks/index.tsx
 msgid "{0, plural, one {# task} other {# tasks}}"
@@ -63,6 +73,11 @@ msgstr "{0, plural, one {# task} other {# tasks}}"
 #: src/components/instructions/stack-list.tsx
 msgid "{0, plural, one {# template} other {# templates}}"
 msgstr "{0, plural, one {# template} other {# templates}}"
+
+#. placeholder {0}: pendingConfirm.subjectCount
+#: src/components/research/research-dialog.tsx
+msgid "{0, plural, one {Start # run} other {Start # runs}}"
+msgstr "{0, plural, one {Start # run} other {Start # runs}}"
 
 #. placeholder {0}: ev.attendees.length
 #: src/components/companies/upcoming-meetings-card.tsx
@@ -91,20 +106,17 @@ msgstr "{0} msgs"
 msgid "{0} no longer allows password sign-in for mail apps, so it can't be connected here yet — it needs an OAuth sign-in. Pick another provider or use Generic IMAP."
 msgstr "{0} no longer allows password sign-in for mail apps, so it can't be connected here yet — it needs an OAuth sign-in. Pick another provider or use Generic IMAP."
 
+#. placeholder {0}: trustworthy.length
+#. placeholder {1}: needsReview.length
+#. placeholder {2}: attention.length
+#: src/components/research/inbox/research-inbox.tsx
+msgid "{0} ready to apply, {1} need reading, {2} runs need attention."
+msgstr "{0} ready to apply, {1} need reading, {2} runs need attention."
+
 #. placeholder {0}: selection.selectedCount
 #: src/components/companies/pipeline-board.tsx
 msgid "{0} selected"
 msgstr "{0} selected"
-
-#. placeholder {0}: progress.sourceCount
-#: src/components/research/run-progress.tsx
-msgid "{0} sources"
-msgstr "{0} sources"
-
-#. placeholder {0}: progress.toolCalls
-#: src/components/research/run-progress.tsx
-msgid "{0} steps run"
-msgstr "{0} steps run"
 
 #. placeholder {0}: failedIds.length
 #: src/routes/emails/index.tsx
@@ -2520,6 +2532,10 @@ msgid "Loading tasks…"
 msgstr "Loading tasks…"
 
 #: src/components/research/inbox/research-inbox.tsx
+msgid "Loading the changes waiting for review."
+msgstr "Loading the changes waiting for review."
+
+#: src/components/research/inbox/research-inbox.tsx
 msgid "Loading the review queue"
 msgstr "Loading the review queue"
 
@@ -4549,11 +4565,6 @@ msgstr "Standing guidance your research agent follows on every run."
 msgid "Start"
 msgstr "Start"
 
-#. placeholder {0}: pendingConfirm.subjectCount
-#: src/components/research/research-dialog.tsx
-msgid "Start {0} runs"
-msgstr "Start {0} runs"
-
 #: src/routes/emails/inboxes.tsx
 msgid "Start sending and receiving"
 msgstr "Start sending and receiving"
@@ -4806,6 +4817,10 @@ msgstr "The list could not be fetched. Check that the session is valid, then try
 #: src/routes/tasks/index.tsx
 msgid "The list could not be fetched. Check the connection, then try again."
 msgstr "The list could not be fetched. Check the connection, then try again."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "The list of changes could not be loaded."
+msgstr "The list of changes could not be loaded."
 
 #: src/routes/emails/inboxes.tsx
 msgid "The mailbox is ready."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -533,8 +533,14 @@ msgid "Applying…"
 msgstr "Applying…"
 
 #: src/components/research/findings/shared.tsx
+#: src/components/research/inbox/paid-action-queue.tsx
 msgid "Approve"
 msgstr "Approve"
+
+#. placeholder {0}: action.tool
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Approve {0}"
+msgstr "Approve {0}"
 
 #: src/routes/emails/$threadId.tsx
 #: src/routes/emails/index.tsx
@@ -1373,6 +1379,10 @@ msgstr "Could not update channels"
 #: src/components/research/findings/shared.tsx
 msgid "Could not update the paid action"
 msgstr "Could not update the paid action"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Could not update this lookup."
+msgstr "Could not update this lookup."
 
 #: src/routes/companies/$slug.tsx
 msgid "Could not update verification"
@@ -2570,6 +2580,14 @@ msgstr "Log interaction"
 msgid "Logging…"
 msgstr "Logging…"
 
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Lookup approved — the run is picking it up."
+msgstr "Lookup approved — the run is picking it up."
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Lookup skipped. Nothing was spent."
+msgstr "Lookup skipped. Nothing was spent."
+
 #: src/routes/companies/$slug.tsx
 msgid "Low"
 msgstr "Low"
@@ -3279,6 +3297,7 @@ msgstr "Open Instagram"
 msgid "Open LinkedIn"
 msgstr "Open LinkedIn"
 
+#: src/components/research/inbox/paid-action-queue.tsx
 #: src/components/research/inbox/research-inbox.tsx
 msgid "Open run"
 msgstr "Open run"
@@ -3304,6 +3323,10 @@ msgstr "Open tasks"
 #: src/routes/settings/organization/index.tsx
 msgid "Open the org spend dashboard"
 msgstr "Open the org spend dashboard"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Open the run asking for this lookup"
+msgstr "Open the run asking for this lookup"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Open the setup guide, opens in a new tab"
@@ -3465,6 +3488,10 @@ msgstr "Paid action skipped"
 #: src/routes/settings/organization/policy.tsx
 msgid "Paid calls at or below this run without asking."
 msgstr "Paid calls at or below this run without asking."
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Paid lookups waiting for your OK"
+msgstr "Paid lookups waiting for your OK"
 
 #: src/routes/settings/organization/policy.tsx
 msgid "Paid provider calls allowed within one run."
@@ -3838,6 +3865,10 @@ msgstr "Recipient marked as spam"
 #: src/components/research/proposal-outcome.tsx
 msgid "Record changed since research"
 msgstr "Record changed since research"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Recorded before these could be decided — open the run."
+msgstr "Recorded before these could be decided — open the run."
 
 #: src/components/layout/nav-items.ts
 msgid "Records"
@@ -4333,6 +4364,11 @@ msgstr "Show password"
 msgid "Show system events"
 msgstr "Show system events"
 
+#. placeholder {0}: proposals.length
+#: src/components/research/inbox/research-inbox.tsx
+msgid "Showing {0} of {totalPending}. Narrow the filters to reach the rest."
+msgstr "Showing {0} of {totalPending}. Narrow the filters to reach the rest."
+
 #: src/routes/emails/index.tsx
 msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Showing {firstRow}–{lastRow} of {total}"
@@ -4371,8 +4407,14 @@ msgid "Size"
 msgstr "Size"
 
 #: src/components/research/findings/shared.tsx
+#: src/components/research/inbox/paid-action-queue.tsx
 msgid "Skip"
 msgstr "Skip"
+
+#. placeholder {0}: action.tool
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Skip {0}"
+msgstr "Skip {0}"
 
 #: src/routes/pages/$id.tsx
 #: src/routes/pages/index.tsx
@@ -4404,6 +4446,10 @@ msgstr "Snoozed"
 #: src/routes/emails/$threadId.tsx
 msgid "someone"
 msgstr "someone"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Someone had already decided this one."
+msgstr "Someone had already decided this one."
 
 #: src/components/research/run-detail.tsx
 msgid "Something went wrong while running this research."
@@ -4704,6 +4750,10 @@ msgstr "That link expired. Request a fresh one below."
 msgid "That link is no longer valid. Request a fresh one below."
 msgstr "That link is no longer valid. Request a fresh one below."
 
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "That lookup isn't available, so it can only be skipped."
+msgstr "That lookup isn't available, so it can only be skipped."
+
 #: src/components/research/research-dialog.tsx
 msgid "That set of instructions is no longer available. Pick another and try again."
 msgstr "That set of instructions is no longer available. Pick another and try again."
@@ -4841,6 +4891,11 @@ msgstr "The workshop rejected the change. Try again."
 #: src/routes/settings/organization/index.tsx
 msgid "The workspace your CRM data lives in."
 msgstr "The workspace your CRM data lives in."
+
+#. placeholder {0}: formatMoneyCents(totalCents, { locale: i18n.locale })
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "These cost money, so nothing runs until you say so. About {0} in total."
+msgstr "These cost money, so nothing runs until you say so. About {0} in total."
 
 #: src/routes/settings/organization/members.tsx
 msgid "They join straight away and get an email telling them so. It carries no password and no link to sign in with."
@@ -5273,6 +5328,10 @@ msgstr "Who"
 #: src/routes/emails/inboxes.tsx
 msgid "Who's your email provider?"
 msgstr "Who's your email provider?"
+
+#: src/components/research/inbox/paid-action-queue.tsx
+msgid "Working…"
+msgstr "Working…"
 
 #: src/routes/index.tsx
 msgid "Workshop floor — live counters on the bench."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -376,6 +376,10 @@ msgstr "Added as a verified lead"
 msgid "Adding…"
 msgstr "Adding…"
 
+#: src/components/research/run-labels.ts
+msgid "Address"
+msgstr "Address"
+
 #: src/routes/settings/organization/members.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Admin"
@@ -1468,6 +1472,7 @@ msgstr "count loading"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/prospect-scan-view.tsx
+#: src/components/research/run-labels.ts
 #: src/routes/companies/index.tsx
 msgid "Country"
 msgstr "Country"
@@ -1579,6 +1584,7 @@ msgstr "Current password is incorrect."
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Current tools"
 msgstr "Current tools"
 
@@ -1926,6 +1932,7 @@ msgstr "Editor"
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
+#: src/components/research/run-labels.ts
 #: src/components/shared/channel-icon.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/inboxes.tsx
@@ -2340,6 +2347,7 @@ msgstr "Inboxes"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/prospect-scan-view.tsx
+#: src/components/research/run-labels.ts
 #: src/routes/companies/index.tsx
 msgid "Industry"
 msgstr "Industry"
@@ -2472,6 +2480,10 @@ msgstr "Last meet"
 msgid "Later"
 msgstr "Later"
 
+#: src/components/research/run-labels.ts
+msgid "Latitude"
+msgstr "Latitude"
+
 #: src/components/research/research-dialog.tsx
 msgid "Layered after the stack, in order."
 msgstr "Layered after the stack, in order."
@@ -2485,6 +2497,7 @@ msgid "Line items"
 msgstr "Line items"
 
 #: src/components/research/findings/contact-discovery-view.tsx
+#: src/components/research/run-labels.ts
 #: src/components/shared/channel-icon.tsx
 msgid "LinkedIn"
 msgstr "LinkedIn"
@@ -2568,6 +2581,7 @@ msgstr "Locating…"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/research-dialog.tsx
+#: src/components/research/run-labels.ts
 #: src/routes/calendar/index.tsx
 msgid "Location"
 msgstr "Location"
@@ -2594,6 +2608,10 @@ msgstr "Log interaction"
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Logging…"
 msgstr "Logging…"
+
+#: src/components/research/run-labels.ts
+msgid "Longitude"
+msgstr "Longitude"
 
 #: src/components/research/inbox/paid-action-queue.tsx
 msgid "Lookup approved — the run is picking it up."
@@ -3207,6 +3225,10 @@ msgstr "Not seeing it? Check your spam folder. If you're sure the email is right
 msgid "Note"
 msgstr "Note"
 
+#: src/components/research/run-labels.ts
+msgid "Notes"
+msgstr "Notes"
+
 #: src/components/companies/proposals-panel.tsx
 msgid "Notes (optional)"
 msgstr "Notes (optional)"
@@ -3530,6 +3552,7 @@ msgstr "Pain indicators"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Pain points"
 msgstr "Pain points"
 
@@ -3610,6 +3633,7 @@ msgstr "Personal"
 
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Phone"
 msgstr "Phone"
 
@@ -3722,6 +3746,10 @@ msgstr "Private inbox"
 #: src/components/companies/about-section.tsx
 msgid "Products fit"
 msgstr "Products fit"
+
+#: src/components/research/run-labels.ts
+msgid "Products that fit"
+msgstr "Products that fit"
 
 #: src/routes/settings/profile/index.tsx
 msgid "Profile"
@@ -4082,6 +4110,7 @@ msgstr "Review what the research agent found and decide what enters the CRM."
 msgid "Risky"
 msgstr "Risky"
 
+#: src/components/research/run-labels.ts
 #: src/routes/settings/organization/members.tsx
 msgid "Role"
 msgstr "Role"
@@ -4414,6 +4443,7 @@ msgstr "Signing out…"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Size"
 msgstr "Size"
 
@@ -4657,6 +4687,7 @@ msgstr "System"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Tags"
 msgstr "Tags"
 
@@ -4688,6 +4719,7 @@ msgid "tasks — showing {0} of {shelfTotal}"
 msgstr "tasks — showing {0} of {shelfTotal}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
+#: src/components/research/run-labels.ts
 msgid "Tax ID"
 msgstr "Tax ID"
 
@@ -5268,6 +5300,10 @@ msgstr "Weak fit"
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Weaknesses"
 msgstr "Weaknesses"
+
+#: src/components/research/run-labels.ts
+msgid "Website"
+msgstr "Website"
 
 #: src/routes/emails/index.tsx
 #: src/routes/emails/index.tsx

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -436,6 +436,11 @@ msgstr "All under control"
 msgid "Allow"
 msgstr "Allow"
 
+#. placeholder {0}: change.to
+#: src/components/research/inbox/research-inbox.tsx
+msgid "already {0}"
+msgstr "already {0}"
+
 #: src/components/research/findings/shared.tsx
 msgid "Already in CRM"
 msgstr "Already in CRM"
@@ -456,6 +461,10 @@ msgstr "An AI assistant wants to connect to your Batuda account over MCP and act
 #: src/routes/settings/organization/templates.tsx
 msgid "An org stack runs for every member who hasn't set their own. The one marked default applies to a run that names none. Only org templates can go in an org stack."
 msgstr "An org stack runs for every member who hasn't set their own. The one marked default applies to a run that names none. Only org templates can go in an org stack."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "and {hidden} more on the run"
+msgstr "and {hidden} more on the run"
 
 #: src/components/research/research-dialog.tsx
 msgid "Any"
@@ -1560,6 +1569,10 @@ msgstr "Current password is incorrect."
 #: src/components/research/findings/company-enrichment-view.tsx
 msgid "Current tools"
 msgstr "Current tools"
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "currently"
+msgstr "currently"
 
 #: src/components/profile/theme-select.tsx
 msgid "Dark"
@@ -3193,6 +3206,10 @@ msgstr "Nothing completed recently"
 #: src/routes/tasks/index.tsx
 msgid "Nothing later in the queue"
 msgstr "Nothing later in the queue"
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "nothing on file, would add"
+msgstr "nothing on file, would add"
 
 #: src/routes/tasks/index.tsx
 msgid "Nothing overdue"
@@ -5313,6 +5330,10 @@ msgstr "Working…"
 #: src/routes/index.tsx
 msgid "Workshop floor — live counters on the bench."
 msgstr "Workshop floor — live counters on the bench."
+
+#: src/components/research/inbox/research-inbox.tsx
+msgid "would become"
+msgstr "would become"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Write footer…"

--- a/apps/internal/src/routes/__root.tsx
+++ b/apps/internal/src/routes/__root.tsx
@@ -10,7 +10,7 @@ import {
 	useMatches,
 } from '@tanstack/react-router'
 import { LayoutGroup } from 'motion/react'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { PriToast } from '@batuda/ui/pri'
 
@@ -180,20 +180,29 @@ export const Route = createRootRoute({
 })
 
 function RootComponent() {
-	// Collect dehydrated atom values from every matched route's loader
-	// data. Routes without loaders (or without a `dehydrated` field)
-	// contribute nothing. Order matches the route hierarchy top-down;
-	// HydrationBoundary is idempotent so duplicates from nested routes are
-	// harmless.
+	// Collect the page-load data snapshots from every matched route's loader
+	// data. Routes without loaders (or without a `dehydrated` field) contribute
+	// nothing. Order matches the route hierarchy top-down.
 	const matches = useMatches()
 	const location = useLocation()
 	const { lang, themePreference, theme } = Route.useLoaderData()
-	const dehydrated = matches.flatMap(m => {
+	const collected = matches.flatMap(m => {
 		const data = m.loaderData as
 			| { dehydrated?: ReadonlyArray<DehydratedAtomValue> }
 			| undefined
 		return data?.dehydrated ?? []
 	})
+	// A snapshot is where a screen starts, not what it currently holds. Handing
+	// the same one over again on a later render puts the page back to how it
+	// looked on load — a change the reader had already approved would reappear
+	// waiting for them, and re-approving it fails as a duplicate. So the list is
+	// held to one identity per set of snapshots, and only a loader that actually
+	// ran again (which stamps a new time) produces a new one worth applying.
+	// Deliberately keyed on the snapshots themselves rather than the matches:
+	// opening a dialog changes the matches without changing the data.
+	const signature = collected.map(d => `${d.key}@${d.dehydratedAt}`).join('|')
+	// biome-ignore lint/correctness/useExhaustiveDependencies: the signature is the identity of `collected`; depending on the array itself would defeat the point.
+	const dehydrated = useMemo(() => collected, [signature])
 
 	// The sign-in pages render standalone — no sidebar, no top bar, no Quick
 	// Capture dialog — because they run before there is an account or an

--- a/apps/server/src/handlers/research.ts
+++ b/apps/server/src/handlers/research.ts
@@ -7,8 +7,10 @@ import {
 	ConfirmRequired,
 	CurrentOrg,
 	NotFound,
+	PendingPaidAction,
 	PendingProposal,
 	SessionContext,
+	UnknownStack,
 } from '@batuda/controllers'
 import { isTerminalResearchStatus } from '@batuda/domain'
 import { resolveInstructions, resolveStackRef } from '@batuda/instructions'
@@ -38,6 +40,15 @@ const decodePendingProposals = Schema.decodeUnknownEffect(
 	Schema.Array(PendingProposalRow),
 )
 
+// Same raw-Date handling for the waiting paid lookups.
+const PendingPaidActionRow = Schema.Struct({
+	...PendingPaidAction.fields,
+	runCreatedAt: Schema.DateTimeUtcFromDate,
+})
+const decodePendingPaidActions = Schema.decodeUnknownEffect(
+	Schema.Array(PendingPaidActionRow),
+)
+
 export const ResearchLive = HttpApiBuilder.group(
 	BatudaApi,
 	'research',
@@ -54,7 +65,9 @@ export const ResearchLive = HttpApiBuilder.group(
 			const timeline = yield* TimelineActivityService
 
 			// Shared apply/reject path: run the resolver, then surface a missing run
-			// or proposal as a 404 and let any DB fault die as a defect.
+			// as a 404 and let any DB fault die as a defect. A proposal that is no
+			// longer pending is not an error — someone else already resolved it — so
+			// it comes back as a plain outcome, the same way the bulk endpoint does.
 			const resolveProposal = (
 				id: string,
 				puId: string,
@@ -69,11 +82,7 @@ export const ResearchLive = HttpApiBuilder.group(
 					Effect.flatMap(result =>
 						result.outcome === 'run_not_found'
 							? Effect.fail(new NotFound({ entity: 'research', id }))
-							: result.outcome === 'proposal_not_found'
-								? Effect.fail(
-										new NotFound({ entity: 'proposed-update', id: puId }),
-									)
-								: Effect.succeed(result),
+							: Effect.succeed(result),
 					),
 					Effect.catch(e =>
 						e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
@@ -110,7 +119,10 @@ export const ResearchLive = HttpApiBuilder.group(
 						const stackId = _.payload.stack_id
 						if (stackId !== undefined) {
 							const picked = yield* resolveStackRef('research', stackId)
-							if (!picked.ok) return { error: 'unknown_stack', stack: stackId }
+							// Refused, not reported in a success body: a caller that
+							// cannot tell this apart from a started run reports the run
+							// as under way when nothing was ever queued.
+							if (!picked.ok) return yield* new UnknownStack({ stack: stackId })
 						}
 						const instructions = yield* resolveInstructions({
 							organizationId: currentOrg.id,
@@ -138,7 +150,9 @@ export const ResearchLive = HttpApiBuilder.group(
 						return result
 					}).pipe(
 						Effect.catch(e =>
-							e._tag === 'ConfirmRequired' ? Effect.fail(e) : Effect.die(e),
+							e._tag === 'ConfirmRequired' || e._tag === 'UnknownStack'
+								? Effect.fail(e)
+								: Effect.die(e),
 						),
 					),
 				)
@@ -264,7 +278,9 @@ export const ResearchLive = HttpApiBuilder.group(
 								entity: 'research',
 								id: _.params.id,
 							})
-						return { status: 'cancelled' }
+						// A run that has already finished cannot be cancelled, so pass the
+						// real outcome through instead of always claiming a cancellation.
+						return { outcome: res.outcome }
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
@@ -321,7 +337,15 @@ export const ResearchLive = HttpApiBuilder.group(
 							return yield* Effect.fail(
 								new NotFound({ entity: 'research', id: _.params.id }),
 							)
-						return result
+						// An action someone already decided, or one naming a lookup that
+						// does not exist, spends nothing and changes nothing — the caller
+						// has to tell that apart from a real approval.
+						return {
+							outcome: result.status,
+							...(result.status === 'approved'
+								? { followupRunId: result.followup_run_id }
+								: {}),
+						}
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
@@ -338,7 +362,7 @@ export const ResearchLive = HttpApiBuilder.group(
 							return yield* Effect.fail(
 								new NotFound({ entity: 'research', id: _.params.id }),
 							)
-						return result
+						return { outcome: result.status }
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
@@ -365,6 +389,25 @@ export const ResearchLive = HttpApiBuilder.group(
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
 						),
 					),
+				)
+				.handle('listPendingPaidActions', _ =>
+					Effect.gen(function* () {
+						// Org scope is enforced by RLS, like the run list.
+						const page = yield* svc.listPendingPaidActions({
+							researchId: _.query.research_id,
+							limit: _.query.limit,
+							offset: _.query.offset,
+						})
+						const items = yield* decodePendingPaidActions(page.items).pipe(
+							Effect.orDie,
+						)
+						return {
+							items,
+							total: page.total,
+							limit: page.limit,
+							offset: page.offset,
+						}
+					}).pipe(Effect.orDie),
 				)
 				.handle('listPendingProposals', _ =>
 					Effect.gen(function* () {

--- a/packages/controllers/src/errors.ts
+++ b/packages/controllers/src/errors.ts
@@ -137,3 +137,15 @@ export class ConfirmRequired extends Schema.TaggedErrorClass<ConfirmRequired>()(
 		subjectCount: Schema.Number,
 	},
 ) {}
+
+/**
+ * A run asked for a saved set of instructions that cannot be used — deleted, or
+ * belonging to someone else. Starting the run anyway would silently apply
+ * different instructions than the caller asked for, so it is refused outright.
+ */
+export class UnknownStack extends Schema.TaggedErrorClass<UnknownStack>()(
+	'UnknownStack',
+	{
+		stack: Schema.String,
+	},
+) {}

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -18,6 +18,7 @@ export {
 	StorageError,
 	StorageErrorOperation,
 	Unauthorized,
+	UnknownStack,
 } from './errors'
 export { CurrentOrg, OrgMiddleware } from './middleware/org'
 export { SessionContext, SessionMiddleware } from './middleware/session'
@@ -57,10 +58,12 @@ export {
 } from './routes/recordings'
 export { ContextInput, ResearchGroup } from './routes/research'
 export {
+	PendingPaidAction,
 	PendingProposal,
 	ResearchPolicy,
 	ResearchRunDetail,
 	ResearchRunSummary,
+	ResearchSpendBucket,
 } from './routes/research-schemas'
 export { BulkCompleteResult, TasksGroup } from './routes/tasks'
 export { TimelineGroup } from './routes/timeline'

--- a/packages/controllers/src/routes/research-schemas.ts
+++ b/packages/controllers/src/routes/research-schemas.ts
@@ -61,10 +61,15 @@ export type ResearchPolicy = typeof ResearchPolicy.Type
 
 /**
  * One pending proposed update in the cross-run review inbox: the run + subject
- * it belongs to, plus the trust signals a reviewer sorts by. `confidence` is a
- * 0–100 score (or null when the proposal carries none); `verification` is the
- * email deliverability verdict; `machineCheckable` is true when the value is an
- * email or phone the system can verify rather than free text.
+ * it belongs to, the values it would write, and the trust signals a reviewer
+ * sorts by. `confidence` is a 0–100 score (or null when the proposal carries
+ * none); `verification` is the best email deliverability verdict among its
+ * channels; `machineCheckable` is true when the value is an email or phone the
+ * system can verify rather than free text.
+ *
+ * `fields` carries the proposed values and `subjectCurrent` what the record
+ * holds today for those same keys, so a caller can show a before-and-after
+ * without a request per row. Both are plain JSON, so they stay `Unknown`.
  */
 export const PendingProposal = Schema.Struct({
 	researchId: Schema.String,
@@ -73,6 +78,7 @@ export const PendingProposal = Schema.Struct({
 	runQuery: Schema.String,
 	runCreatedAt: Schema.DateTimeUtcFromString,
 	runCostCents: Schema.Number,
+	runPaidCostCents: Schema.Number,
 	proposedUpdateId: Schema.NullOr(Schema.String),
 	subjectTable: Schema.NullOr(Schema.String),
 	subjectId: Schema.NullOr(Schema.String),
@@ -82,13 +88,46 @@ export const PendingProposal = Schema.Struct({
 	confidence: Schema.NullOr(Schema.Number),
 	verification: Schema.NullOr(Schema.String),
 	machineCheckable: Schema.Boolean,
+	fields: Schema.Unknown,
+	citations: Schema.Array(Schema.Unknown),
+	subjectCurrent: Schema.NullOr(Schema.Unknown),
 })
 export type PendingProposal = typeof PendingProposal.Type
 
 /**
+ * The outcome of asking to cancel a run. `already_terminal` means the run was
+ * finished — or cancelled — by the time the request arrived, so nothing changed
+ * and a caller must not report it as a cancellation.
+ */
+export const CancelResult = Schema.Struct({
+	outcome: Schema.Literals(['cancelled', 'already_terminal']),
+})
+export type CancelResult = typeof CancelResult.Type
+
+/**
+ * The outcome of deciding a pending paid action. `approved` carries the
+ * follow-up run that will do the paid work; `skipped` spends nothing;
+ * `not_pending` means someone else already decided it; `unsupported_tool` means
+ * the run named a lookup that does not exist, so it can only ever be skipped.
+ * The last two change nothing, so a caller must not report them as an approval.
+ */
+export const PaidActionResult = Schema.Struct({
+	outcome: Schema.Literals([
+		'approved',
+		'skipped',
+		'not_pending',
+		'unsupported_tool',
+	]),
+	followupRunId: Schema.optional(Schema.String),
+})
+export type PaidActionResult = typeof PaidActionResult.Type
+
+/**
  * The result of applying or rejecting one proposed update. `applied`/`created`
  * carry the row version; `duplicate` names the existing row the change merged
- * onto; `invalid` explains why; the rest carry only the outcome.
+ * onto; `invalid` explains why; `proposal_not_found` means someone already
+ * resolved it, which is a harmless no-op rather than a failure and carries the
+ * same name the bulk response uses.
  */
 export const ProposedUpdateResult = Schema.Struct({
 	outcome: Schema.Literals([
@@ -99,6 +138,7 @@ export const ProposedUpdateResult = Schema.Struct({
 		'conflict',
 		'invalid',
 		'no_applicable_fields',
+		'proposal_not_found',
 	]),
 	subject_table: Schema.optional(Schema.String),
 	subject_id: Schema.optional(Schema.String),
@@ -106,6 +146,43 @@ export const ProposedUpdateResult = Schema.Struct({
 	reason: Schema.optional(Schema.String),
 })
 export type ProposedUpdateResult = typeof ProposedUpdateResult.Type
+
+/**
+ * One paid lookup a run stopped short of paying for, waiting on a person to
+ * approve or skip it. `estimatedCents` is what it is expected to cost in whole
+ * cents, or null when the run made no estimate. `actionId` is null on a run
+ * recorded before these were individually identified — such a one can be seen
+ * but not decided. `subjectName` is filled only when the run was about exactly
+ * one company or person. `args` is the lookup's own input, so it stays `Unknown`.
+ */
+export const PendingPaidAction = Schema.Struct({
+	researchId: Schema.String,
+	runQuery: Schema.String,
+	runStatus: Schema.String,
+	runCreatedAt: Schema.DateTimeUtcFromString,
+	actionId: Schema.NullOr(Schema.String),
+	tool: Schema.String,
+	args: Schema.Unknown,
+	estimatedCents: Schema.NullOr(Schema.Number),
+	reason: Schema.NullOr(Schema.String),
+	subjectTable: Schema.NullOr(Schema.String),
+	subjectId: Schema.NullOr(Schema.String),
+	subjectName: Schema.NullOr(Schema.String),
+})
+export type PendingPaidAction = typeof PendingPaidAction.Type
+
+/**
+ * One bucket of paid research spend: what it was grouped by (`key` — a provider,
+ * a person or a tool, depending on the request), the whole cents it came to, and
+ * how many charged calls made it up. Typed rather than left as free-form JSON so
+ * a renamed column fails loudly instead of quietly reading as zero spend.
+ */
+export const ResearchSpendBucket = Schema.Struct({
+	key: Schema.NullOr(Schema.String),
+	amountCents: Schema.Number,
+	calls: Schema.Number,
+})
+export type ResearchSpendBucket = typeof ResearchSpendBucket.Type
 
 /**
  * The live-progress contract: a 30-second JSON long-poll (not a raw event

--- a/packages/controllers/src/routes/research.ts
+++ b/packages/controllers/src/routes/research.ts
@@ -5,18 +5,27 @@ import {
 	HttpApiSchema,
 } from 'effect/unstable/httpapi'
 
-import { ConfirmRequired, InsufficientBudget, NotFound } from '../errors'
+import {
+	ConfirmRequired,
+	InsufficientBudget,
+	NotFound,
+	UnknownStack,
+} from '../errors'
 import { OrgMiddleware } from '../middleware/org'
 import { SessionMiddleware } from '../middleware/session'
 import { PaginatedList } from '../pagination'
 import {
 	BulkResolveResult,
+	CancelResult,
+	PaidActionResult,
+	PendingPaidAction,
 	PendingProposal,
 	ProposedUpdateResult,
 	ResearchEvents,
 	ResearchPolicy,
 	ResearchRunDetail,
 	ResearchRunSummary,
+	ResearchSpendBucket,
 } from './research-schemas'
 
 // ── Input schemas ──
@@ -113,6 +122,7 @@ export const ResearchGroup = HttpApiGroup.make('research')
 			error: [
 				InsufficientBudget.pipe(HttpApiSchema.status(409)),
 				ConfirmRequired.pipe(HttpApiSchema.status(409)),
+				UnknownStack.pipe(HttpApiSchema.status(422)),
 			],
 		}),
 	)
@@ -152,7 +162,7 @@ export const ResearchGroup = HttpApiGroup.make('research')
 	.add(
 		HttpApiEndpoint.post('cancel', '/research/:id/cancel', {
 			params: { id: Schema.String },
-			success: Schema.Unknown,
+			success: CancelResult,
 			error: NotFound.pipe(HttpApiSchema.status(404)),
 		}),
 	)
@@ -198,7 +208,7 @@ export const ResearchGroup = HttpApiGroup.make('research')
 			'/research/:id/paid-actions/:paId/approve',
 			{
 				params: { id: Schema.String, paId: Schema.String },
-				success: Schema.Unknown,
+				success: PaidActionResult,
 				error: NotFound.pipe(HttpApiSchema.status(404)),
 			},
 		),
@@ -209,10 +219,23 @@ export const ResearchGroup = HttpApiGroup.make('research')
 			'/research/:id/paid-actions/:paId/skip',
 			{
 				params: { id: Schema.String, paId: Schema.String },
-				success: Schema.Unknown,
+				success: PaidActionResult,
 				error: NotFound.pipe(HttpApiSchema.status(404)),
 			},
 		),
+	)
+	// Every paid lookup in the org still waiting on a decision. A run parks these
+	// and stops before spending, so without this list nothing surfaces one until
+	// somebody opens that run. Static path wins over /research/:id.
+	.add(
+		HttpApiEndpoint.get('listPendingPaidActions', '/research/paid-actions', {
+			query: {
+				research_id: Schema.optional(Schema.String),
+				limit: Schema.optional(Schema.NumberFromString),
+				offset: Schema.optional(Schema.NumberFromString),
+			},
+			success: PaginatedList(PendingPaidAction),
+		}),
 	)
 	// Cross-run review inbox: every pending proposed update in the org, not
 	// scoped to one run. Static path wins over /research/:id, like /preferences.
@@ -293,7 +316,7 @@ export const ResearchGroup = HttpApiGroup.make('research')
 				range: Schema.optional(Schema.String),
 				groupBy: Schema.optional(Schema.String),
 			},
-			success: Schema.Array(Schema.Unknown),
+			success: Schema.Array(ResearchSpendBucket),
 		}),
 	)
 	.middleware(SessionMiddleware)

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -584,9 +584,20 @@ export interface PendingProposalRow {
 	readonly confidence: number | null
 	readonly verification: string | null
 	readonly machineCheckable: boolean
-	// The run's total spend so far, in cents; the same value repeats on every
-	// proposal that came from the same run.
+	// The run's cheap spend so far (search, scraping, model calls), in cents; the
+	// same value repeats on every proposal from that run, so it belongs to the
+	// run rather than to this one proposal.
 	readonly runCostCents: number
+	// What the run paid outside providers, in cents — a tally of its own, not a
+	// slice of the one above, so a cheap-looking run may still have spent money.
+	readonly runPaidCostCents: number
+	// The values this proposal would write, keyed by column.
+	readonly fields: Record<string, unknown>
+	// The pages each value came from.
+	readonly citations: ReadonlyArray<unknown>
+	// What the record holds today for those same columns; null for a proposal
+	// that would create a new row, and absent per-key when the column is unset.
+	readonly subjectCurrent: Record<string, unknown> | null
 }
 
 /**
@@ -639,11 +650,19 @@ export const queryPendingProposals = (
 					r.query AS run_query,
 					r.created_at AS run_created_at,
 					r.cost_cents AS run_cost_cents,
+					r.paid_cost_cents AS run_paid_cost_cents,
 					pu->>'id' AS proposed_update_id,
 					pu->>'subject_table' AS subject_table,
 					pu->>'subject_id' AS subject_id,
 					COALESCE(pu->>'operation', 'update') AS operation,
 					pu->>'reason' AS reason,
+					-- The values the run wants to write and the pages they came from
+					-- travel with the row, so deciding on a proposal needs no further
+					-- lookup of its own.
+					CASE WHEN jsonb_typeof(pu->'fields') = 'object'
+						THEN pu->'fields' ELSE '{}'::jsonb END AS fields,
+					CASE WHEN jsonb_typeof(pu->'citations') = 'array'
+						THEN pu->'citations' ELSE '[]'::jsonb END AS citations,
 					(
 						SELECT max(
 							CASE
@@ -660,6 +679,10 @@ export const queryPendingProposals = (
 								THEN pu->'fields'->'channels' ELSE '[]'::jsonb END
 						) ch
 					)::int AS confidence,
+					-- A proposal is only as good as its best email address: an
+					-- undeliverable address sitting next to a deliverable one still
+					-- reaches the person, so the verdicts are ranked and the strongest
+					-- one wins, rather than whichever channel happens to be listed first.
 					(
 						SELECT ch->>'verification'
 						FROM jsonb_array_elements(
@@ -667,6 +690,14 @@ export const queryPendingProposals = (
 								THEN pu->'fields'->'channels' ELSE '[]'::jsonb END
 						) ch
 						WHERE ch->>'kind' = 'email'
+						ORDER BY CASE ch->>'verification'
+							WHEN 'deliverable' THEN 0
+							WHEN 'risky' THEN 1
+							WHEN 'catch_all' THEN 2
+							WHEN 'unknown' THEN 3
+							WHEN 'undeliverable' THEN 4
+							ELSE 5
+						END
 						LIMIT 1
 					) AS verification,
 					jsonb_path_exists(
@@ -686,7 +717,35 @@ export const queryPendingProposals = (
 				p.*,
 				-- Resolve the subject's current name from its table and id; these
 				-- joins are org-scoped by row-level security like the rest of the query.
-				COALESCE(c.name, ct.name) AS subject_name
+				-- A proposal that would create a brand-new row has no id to look up, so
+				-- its name comes from the values the run proposes instead of being blank.
+				COALESCE(c.name, ct.name, p.fields->>'name') AS subject_name,
+				-- What the record holds today for exactly the fields this proposal would
+				-- write — enough to tell an addition apart from an overwrite — and
+				-- nothing else about the row. A proposal may name a field either way
+				-- round ("size_range" or "sizeRange") and both are accepted on apply, so
+				-- both spellings are looked up against the record's snake_case columns
+				-- and keyed back to the spelling the proposal used.
+				(
+					SELECT jsonb_object_agg(picked.key_out, picked.val)
+					FROM (
+						SELECT
+							k AS key_out,
+							COALESCE(
+								to_jsonb(c) -> k,
+								to_jsonb(ct) -> k,
+								to_jsonb(c) -> s.snake,
+								to_jsonb(ct) -> s.snake
+							) AS val
+						FROM jsonb_object_keys(p.fields) k,
+							LATERAL (
+								SELECT lower(
+									regexp_replace(k, '([a-z0-9])([A-Z])', '\\1_\\2', 'g')
+								) AS snake
+							) s
+					) picked
+					WHERE picked.val IS NOT NULL
+				) AS subject_current
 			FROM pending p
 			LEFT JOIN companies c
 				ON p.subject_table = 'companies' AND c.id::text = p.subject_id
@@ -697,6 +756,118 @@ export const queryPendingProposals = (
 
 		const rows = yield* sql<
 			PendingProposalRow & { readonly total: string | number }
+		>`
+			SELECT sub.*, COUNT(*) OVER () AS total
+			FROM (${matching}) sub
+			ORDER BY sub.run_created_at DESC
+			LIMIT ${limit}
+			OFFSET ${offset}
+		`
+		const total = yield* resolvePageTotal(
+			rows,
+			offset,
+			() => sql<{ readonly count: string | number }>`
+				SELECT count(*) AS count FROM (${matching}) sub
+			`,
+		)
+		return { items: rows, total, limit, offset }
+	})
+
+export interface PendingPaidActionRow {
+	readonly researchId: string
+	readonly runQuery: string
+	readonly runStatus: string
+	readonly runCreatedAt: Date
+	readonly actionId: string | null
+	// The lookup the run wants to pay for, as the run named it. A name matching no
+	// real lookup can only be skipped.
+	readonly tool: string
+	readonly args: Record<string, unknown>
+	// What the lookup is expected to cost, in whole cents; null when the run made
+	// no estimate.
+	readonly estimatedCents: number | null
+	readonly reason: string | null
+	// The company or person the run was about, when it was about exactly one, so a
+	// decision can be made without opening the run.
+	readonly subjectTable: string | null
+	readonly subjectId: string | null
+	readonly subjectName: string | null
+}
+
+/**
+ * Paid lookups across every run in the org that are waiting for a person to
+ * approve or skip them. A run stores these inside its own findings and stops
+ * short of spending, so without a list like this one nothing surfaces a run
+ * holding an unspent decision — it waits until somebody happens to open it.
+ * Org scope is enforced by row-level security, like the run list.
+ */
+export const queryPendingPaidActions = (
+	sql: SqlClient.SqlClient,
+	filters: {
+		researchId?: string | undefined
+		limit?: number | undefined
+		offset?: number | undefined
+	},
+) =>
+	Effect.gen(function* () {
+		const conditions: Array<import('effect/unstable/sql').Statement.Fragment> =
+			[]
+		if (filters.researchId)
+			conditions.push(sql`research_id = ${filters.researchId}`)
+
+		const { limit, offset } = clampPagination(filters.limit, filters.offset)
+
+		// An action written before the id stamp has no id and cannot be resolved,
+		// but it still shows, so a run that is stuck waiting is at least visible.
+		// An absent status counts as pending: that is the shape a run writes first.
+		const matching = sql`
+			WITH waiting AS (
+				SELECT
+					r.id AS research_id,
+					r.query AS run_query,
+					r.status AS run_status,
+					r.created_at AS run_created_at,
+					pa->>'id' AS action_id,
+					COALESCE(pa->>'tool', '') AS tool,
+					CASE WHEN jsonb_typeof(pa->'args') = 'object'
+						THEN pa->'args' ELSE '{}'::jsonb END AS args,
+					CASE WHEN jsonb_typeof(pa->'estimated_cents') = 'number'
+						THEN (pa->>'estimated_cents')::int END AS estimated_cents,
+					pa->>'reason' AS reason,
+					-- A run anchored to exactly one company or person names it here.
+					-- The count guard is what keeps a run about several of them from
+					-- picking one at random and presenting it as the subject.
+					(
+						SELECT min(rl.subject_table) FROM research_links rl
+						WHERE rl.research_id = r.id
+						HAVING count(*) = 1
+					) AS subject_table,
+					(
+						SELECT min(rl.subject_id::text) FROM research_links rl
+						WHERE rl.research_id = r.id
+						HAVING count(*) = 1
+					) AS subject_id
+				FROM research_runs r,
+					LATERAL jsonb_array_elements(
+						CASE WHEN jsonb_typeof(r.findings->'pending_paid_actions') = 'array'
+							THEN r.findings->'pending_paid_actions' ELSE '[]'::jsonb END
+					) pa
+				WHERE r.status != 'deleted'
+					AND COALESCE(pa->>'status', 'pending') = 'pending'
+			)
+			SELECT
+				w.*,
+				COALESCE(c.name, ct.name) AS subject_name
+			FROM waiting w
+			LEFT JOIN companies c
+				ON w.subject_table = 'companies' AND c.id::text = w.subject_id
+			LEFT JOIN contacts ct
+				ON w.subject_table = 'contacts' AND ct.id::text = w.subject_id
+			${conditions.length > 0 ? sql`WHERE ${sql.and(conditions)}` : sql``}
+		`
+
+		const rows = yield* sql<
+			PendingPaidActionRow & { readonly total: string | number }
 		>`
 			SELECT sub.*, COUNT(*) OVER () AS total
 			FROM (${matching}) sub
@@ -4742,8 +4913,20 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						> = [sql`r.status != 'deleted'`]
 						if (filters.createdBy)
 							conditions.push(sql`r.created_by = ${filters.createdBy}`)
-						if (filters.status)
-							conditions.push(sql`r.status = ${filters.status}`)
+						// A comma-separated status asks for several at once — "everything
+						// that needs a human", say — and answering that here saves the
+						// caller from paging through runs and sifting them by hand.
+						if (filters.status) {
+							const requestedStatuses = filters.status
+								.split(',')
+								.map(s => s.trim())
+								.filter(s => s !== '')
+							if (requestedStatuses.length > 1) {
+								conditions.push(sql`r.status = ANY(${requestedStatuses})`)
+							} else if (requestedStatuses.length === 1) {
+								conditions.push(sql`r.status = ${requestedStatuses[0]}`)
+							}
+						}
 						if (filters.since)
 							conditions.push(sql`r.created_at >= ${filters.since}`)
 
@@ -4798,6 +4981,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					offset?: number | undefined
 				}) => queryPendingProposals(sql, filters),
 
+				/** Paid lookups across the org still waiting on a person's decision. */
+				listPendingPaidActions: (filters: {
+					researchId?: string | undefined
+					limit?: number | undefined
+					offset?: number | undefined
+				}) => queryPendingPaidActions(sql, filters),
+
 				/** Get all runs linked to a subject row. */
 				bySubject: (table: string, id: string) =>
 					Effect.gen(function* () {
@@ -4843,7 +5033,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									? sql`tool`
 									: sql`provider`
 
-						return yield* sql`
+						// Column names arrive camelCased by the SQL client, so the row
+						// type names them the way a reader receives them.
+						return yield* sql<{
+							readonly key: string | null
+							readonly amountCents: number
+							readonly calls: number
+						}>`
 							SELECT ${keyFragment} AS key,
 								SUM(amount_cents)::int AS amount_cents,
 								COUNT(*)::int AS calls

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -111,6 +111,7 @@ export {
 	type CreateResearchInput,
 	cloneCacheHitRun,
 	type PendingProposalRow,
+	queryPendingPaidActions,
 	queryPendingProposals,
 	type ResearchEvent,
 	type ResearchEventType,

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -404,9 +404,13 @@
 		transparent 3px
 	);
 
-	/* Warm amber focus/active glow — used by nav active state,
-	   focus rings on metal surfaces, and stencil highlights. */
-	--glow-active: 0 0 0 3px rgba(245, 158, 11, 0.35);
+	/* Warm amber focus/active ring — used by nav active state, focus rings on
+	   metal surfaces, and stencil highlights. Solid rather than translucent: at
+	   35% alpha it washed out to little over 1:1 against both plain and metal
+	   surfaces, so a keyboard user tabbing a list could not tell where they were.
+	   The second, surface-coloured ring sits underneath as a gap, so the mark
+	   reads on a dark plate as well as a pale one. */
+	--glow-active: 0 0 0 1px var(--color-surface), 0 0 0 3px #a1620f;
 }
 
 /* ============================================================
@@ -423,6 +427,10 @@
 :root[data-theme="dark"],
 :root[data-theme="dark-hc"] {
 	color-scheme: dark;
+
+	/* The light theme's ring is a deep amber, which all but disappears on these
+	   surfaces, so the dark themes mark focus with a pale one instead. */
+	--glow-active: 0 0 0 1px var(--color-surface), 0 0 0 3px #f7c69b;
 
 	/* --- Ground — the workshop lit by one lamp instead of daylight.
 	   The ramp climbs with elevation, the reverse of the light theme. --- */
@@ -610,7 +618,7 @@
 	--color-tape-edge: #8a8276;
 
 	/* A solid ring rather than a soft halo — a blur is unreadable here. */
-	--glow-active: 0 0 0 3px #ffc9a6;
+	--glow-active: 0 0 0 1px var(--color-surface), 0 0 0 3px #ffc9a6;
 	--color-highlight-amber: rgba(255, 201, 166, 0.3);
 	--color-highlight-amber-strong: rgba(255, 201, 166, 0.45);
 }


### PR DESCRIPTION
## What

The research review screens asked people to approve changes they could not see, and several actions reported success when nothing had happened. This branch fixes that: the queue now shows the values a change would write and what they replace, surfaces paid lookups that were waiting unnoticed, and stops four separate paths from claiming work they never did. It came out of a multi-reviewer audit of `/research` in the internal app (`apps/internal`), with supporting changes to the research service and the shared UI package.

## Changes

- **Show the change, not just a reason.** Each row in the review queue lists the values it would write, struck through against what the record holds today, so a replacement can be told from an addition. Previously the section headed "read before applying" had nothing to read — the data never reached the browser.
- **Surface paid lookups waiting on a decision.** A run that wants to pay for a lookup stops and waits, but reads as finished everywhere else, so the request sat unnoticed until somebody opened that exact run. In the seeded data that is €2.65 nobody would have known was pending.
- **Stop reporting success that did not happen.** Cancelling a finished run said "cancelled"; deciding an already-decided paid lookup said "approved"; approving an already-resolved change reported a failure; starting a run with an unusable instruction set closed the dialog as though it had started.
- **Fix a page that crashed.** A contact's role, email and phone can arrive wrapped together with the page they were read from; the run page put the wrapper straight into the text and React took the whole findings section down.
- **Judge a contact by its best address, not its first.** One stale address dragged an otherwise reachable contact into the review pile, and made the queue and the run's own screen disagree about the same change.
- **Filter where the rows live.** Subject, confidence and verifiable-only sifted the page already fetched, so they only ever searched the hundred most recent changes.
- **Keep a page-load snapshot from undoing later work**, stop "undo" clearing a row whose change had already been sent, confirm before deleting a run, show a batch's child runs, keep live progress alive, and carry a run's full setup when running it again.
- **Make the keyboard focus mark visible** across every app, and give dates and pipeline stages the reader's own language.

## Impact

- **Wire shapes changed** (`packages/controllers`, consumed by both the server and the internal app's typed client): pending changes now carry the proposed values, their sources, the record's current values and the metered cost; cancelling and deciding a paid lookup return a named outcome instead of free-form JSON; applying or rejecting can now return `proposal_not_found` as an outcome rather than a 404. Anything reading those responses sees new fields.
- **One new endpoint**: paid lookups waiting on a decision, across the whole organisation. Read-only, org-scoped by row-level security like the run list.
- **No migrations.** Nothing about the database shape changes, so there is no ordering constraint with the server tag.
- **No new environment variables.**
- **`packages/ui` token changed** — the focus ring affects every screen in every app, not only research. Worth a look on its own.
- **MCP is unaffected.** The paid-lookup decision keeps its existing service-level shape and the new naming is applied at the HTTP boundary only, so the MCP tool and its integration tests are untouched.
- **Row-level security unchanged.** The new query and endpoint rely on the same org scoping as the existing run list; no policy or role changed.

## Review guide

- Start with `packages/research/src/application/research-service.ts` — the pending-changes query is where most of the new behaviour comes from, and I ran it against a seeded database rather than only type-checking it.
- The riskiest change is the page-load snapshot handling in `apps/internal/src/routes/__root.tsx`. It affects every route. I deliberately avoided the obvious fix (remembering which snapshots were applied in a ref), because mutating a ref during render means React's development double-invoke marks them as applied and then discards the result, silently killing the first paint's data.
- A decision you may want to overrule: I removed the company-or-person filter from the queue rather than rebuilding it. It sorted by which kind of record a change writes to, which is a filing detail rather than a question anyone arrives with, and the two trust sections above it already sort by what a reader actually wants. Restoring it is a one-file change if you disagree.
- Adopting the shared form controls in these screens is deliberately **not** here — it is #337, low priority, because one of the controls involved is the filter above.
- `apps/internal/src/components/research/run-shapes.ts` keeps a hand-written narrowing step whose comment I corrected rather than removing: its real job turns out to be formatting the date, and removing it means changing date handling across three screens, which collides with work in flight.

## Screenshots

The review queue, with the values each change would write and the paid lookups waiting on a decision. Captured at desktop and phone width, since the app is mobile-first and the two layouts differ.

**Review queue — desktop**

![queue desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-338/pr338-queue-desktop.webp)

**Review queue — phone**

![queue mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-338/pr338-queue-mobile.webp)

**A run's page — desktop.** This is the page that was crashing: a contact's role, email and phone arrive wrapped together with the page they were read from, and drawing the wrapper took the whole findings section down. It renders now.

![run desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-338/pr338-run-desktop.webp)

## Tests

- 15 new unit tests for reading a proposed value and pairing it with the current one, covering the wrapped-value shape, both field-name spellings, empty values, and inputs the server should never send.
- 119 unit tests pass in the internal app; the pre-push suite (including the sign-in smoke tests) passes.

## Verification

- `pnpm install`, `pnpm -w build` and `pnpm -w test` all pass. For type-checking I ran `tsc` directly in each of the six changed packages, because Turbo reports a full cache hit inside a linked worktree even with changes present, which makes `check-types` there a false green.
- The new SQL was executed against a seeded database and its results read row by row, including the case where a proposed field name is spelled the other way round.
- Drove these screens in the browser against the branch: the values-and-replacements list, the paid-lookup queue (including the lookup nothing can run, which correctly offers only "skip"), filtering by company or person returning the right counts, and the phone layout. The run page that was crashing renders its contacts again — confirmed by reading the rendered text, not only the diff.

## Deferred

- The remaining accessibility work: announcing status changes to a screen reader, the fixed-length undo window, focus handling on navigation, and a skip link. Text contrast was excluded by request.
- Linking an applied change to the record it landed on: the endpoint returns an identifier but the company route takes a slug and there is no route for a person at all.
- An idempotency key on starting a run, and a way to dismiss an item from "attention needed" — both need a migration and serve interface that does not exist yet.
- Seed rows shaped to break each findings view. The crash fixed here would have been caught by one.


