### PR TITLE
feat(internal): load lists as you scroll without losing your place

### DIFF
--- a/apps/internal/src/atoms/companies-atoms.ts
+++ b/apps/internal/src/atoms/companies-atoms.ts
@@ -1,3 +1,5 @@
+import { Atom } from 'effect/unstable/reactivity'
+
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 
 /**
@@ -40,10 +42,15 @@ const cache = new Map<string, ReturnType<typeof makeCompaniesSearchAtom>>()
 export const COMPANIES_PAGE_SIZE = 60
 
 function makeCompaniesSearchAtom(search: CompaniesSearch, limit: number) {
-	return BatudaApiAtom.query('companies', 'list', {
-		query: { ...search, limit },
-		serializationKey: `companies:search:${canonicalSearchKey(search)}::${limit}`,
-	})
+	// Held even while nothing is showing it, so stepping into a company and
+	// coming back puts the same rows straight back on screen instead of
+	// refetching them and collapsing the list to a single page in between.
+	return Atom.keepAlive(
+		BatudaApiAtom.query('companies', 'list', {
+			query: { ...search, limit },
+			serializationKey: `companies:search:${canonicalSearchKey(search)}::${limit}`,
+		}),
+	)
 }
 
 /**

--- a/apps/internal/src/atoms/tasks-atoms.ts
+++ b/apps/internal/src/atoms/tasks-atoms.ts
@@ -1,3 +1,5 @@
+import { Atom } from 'effect/unstable/reactivity'
+
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 
 /**
@@ -76,15 +78,20 @@ const sortForShelf = (shelf: TaskShelf) =>
 const shelfCache = new Map<string, ReturnType<typeof makeShelfAtom>>()
 
 function makeShelfAtom(shelf: TaskShelf, dayKey: string, limit: number) {
-	return BatudaApiAtom.query('tasks', 'list', {
-		query: {
-			shelf,
-			...dayBoundaries(dayKey),
-			sort: sortForShelf(shelf),
-			limit,
-		},
-		serializationKey: `tasks:shelf:${shelf}:${dayKey}:${limit}`,
-	})
+	// Held even while nothing is showing it, so opening a task and coming back
+	// puts the same rows straight back on screen instead of refetching them and
+	// collapsing the shelf to a single page in between.
+	return Atom.keepAlive(
+		BatudaApiAtom.query('tasks', 'list', {
+			query: {
+				shelf,
+				...dayBoundaries(dayKey),
+				sort: sortForShelf(shelf),
+				limit,
+			},
+			serializationKey: `tasks:shelf:${shelf}:${dayKey}:${limit}`,
+		}),
+	)
 }
 
 /**

--- a/apps/internal/src/components/companies/pipeline-board.tsx
+++ b/apps/internal/src/components/companies/pipeline-board.tsx
@@ -29,6 +29,7 @@ import {
 } from '#/atoms/companies-atoms'
 import { pipelineAtom } from '#/atoms/pipeline-atoms'
 import { ErrorState } from '#/components/shared/error-state'
+import { InfiniteListFooter } from '#/components/shared/infinite-list-footer'
 import { PriorityDot } from '#/components/shared/priority-dot'
 import {
 	type CompanyStatus,
@@ -37,6 +38,7 @@ import {
 	statusLabels,
 } from '#/components/shared/status-badge'
 import { useBulkSelection } from '#/hooks/use-bulk-selection'
+import { useInfiniteList } from '#/hooks/use-infinite-list'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import { CompanyOwnerControl } from './company-owner-control'
 
@@ -294,24 +296,20 @@ function BoardColumn({
 	readonly onRegisterIds: (status: string, ids: ReadonlyArray<string>) => void
 }) {
 	const { t } = useLingui()
-	const [colLimit, setColLimit] = useState(COMPANIES_PAGE_SIZE)
 	const columnSearch = useMemo<CompaniesSearch>(
 		() => ({ ...search, status }),
 		[search, status],
 	)
-	const searchKey = canonicalSearchKey(columnSearch)
-	const atom = useMemo(
-		// biome-ignore lint/correctness/useExhaustiveDependencies: keyed by searchKey + limit + refreshNonce
-		() => companiesSearchAtom(columnSearch, colLimit),
-		[searchKey, colLimit, refreshNonce],
-	)
-	const result = useAtomValue(atom)
+	// A refresh has to start the column over at its first page, so it takes part
+	// in identifying the list, just as the filters do.
+	const columnKey = `${canonicalSearchKey(columnSearch)}::${refreshNonce}`
+	const list = useInfiniteList({
+		resetKey: columnKey,
+		pageSize: COMPANIES_PAGE_SIZE,
+		atomFor: limit => companiesSearchAtom(columnSearch, limit),
+	})
 
-	const serverCards = useMemo(
-		() =>
-			AsyncResult.isSuccess(result) ? narrowCards(result.value.items) : [],
-		[result],
-	)
+	const serverCards = useMemo(() => narrowCards(list.items), [list.items])
 
 	// Apply optimistic moves: drop cards that moved OUT of this stage, add cards
 	// that moved IN (rendered from the data captured at move time).
@@ -340,7 +338,6 @@ function BoardColumn({
 
 	const { setNodeRef, isOver } = useDroppable({ id: status })
 	const loaded = cards.length
-	const hasMore = loaded < total
 
 	return (
 		<Column
@@ -353,28 +350,24 @@ function BoardColumn({
 				<ColumnCount data-testid={`board-count-${status}`}>{total}</ColumnCount>
 			</ColumnHeader>
 			<ColumnBody>
-				{loaded === 0 ? (
-					<ColumnEmpty>{t`Empty`}</ColumnEmpty>
-				) : (
-					cards.map(card => (
-						<DraggableCard
-							key={card.id}
-							card={card}
-							selected={selection.isSelected(card.id)}
-							onToggleSelect={() => selection.toggle(card.id)}
-							onMove={onMove}
-						/>
-					))
-				)}
-				{hasMore && (
-					<LoadMore
-						type='button'
-						onClick={() => setColLimit(l => l + COMPANIES_PAGE_SIZE)}
-						data-testid={`board-load-more-${status}`}
-					>
-						{t`Load ${total - loaded} more`}
-					</LoadMore>
-				)}
+				{/* A column still loading has nothing in it yet either, but saying so
+				    would be wrong — it reads as "no work at this stage". */}
+				{loaded === 0
+					? !list.isLoadingFirstPage && <ColumnEmpty>{t`Empty`}</ColumnEmpty>
+					: cards.map(card => (
+							<DraggableCard
+								key={card.id}
+								card={card}
+								selected={selection.isSelected(card.id)}
+								onToggleSelect={() => selection.toggle(card.id)}
+								onMove={onMove}
+							/>
+						))}
+				<InfiniteListFooter
+					list={list}
+					testId={`board-${status}`}
+					announce={false}
+				/>
 			</ColumnBody>
 		</Column>
 	)
@@ -722,24 +715,4 @@ const MoveTrigger = styled(PriButton).withConfig({
 	gap: var(--space-3xs);
 	padding: var(--space-3xs) var(--space-2xs);
 	font-size: var(--typescale-label-small-size);
-`
-
-const LoadMore = styled.button.withConfig({
-	displayName: 'PipelineBoardLoadMore',
-})`
-	padding: var(--space-2xs);
-	border: 1px dashed var(--color-outline);
-	border-radius: var(--shape-2xs);
-	background: transparent;
-	font-family: var(--font-display);
-	font-size: var(--typescale-label-small-size);
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
-	color: var(--color-on-surface-variant);
-	cursor: pointer;
-
-	&:hover {
-		border-color: var(--color-primary);
-		color: var(--color-primary);
-	}
 `

--- a/apps/internal/src/components/layout/blueprint-sheet.tsx
+++ b/apps/internal/src/components/layout/blueprint-sheet.tsx
@@ -32,6 +32,13 @@ type ViewportRef = RefObject<HTMLDivElement | null>
 
 const ViewportRefContext = createContext<ViewportRef | null>(null)
 
+/**
+ * The name the router files this scroller's position under. Phones scroll the
+ * page itself, which the router already tracks on its own, so only the desktop
+ * scroller carries it.
+ */
+export const SHEET_SCROLL_ID = 'blueprint-sheet'
+
 export function useBlueprintViewportRef(): ViewportRef {
 	const ctx = useContext(ViewportRefContext)
 	if (!ctx) {
@@ -40,6 +47,16 @@ export function useBlueprintViewportRef(): ViewportRef {
 		)
 	}
 	return ctx
+}
+
+/**
+ * The same viewport, or null when there is no sheet around the caller.
+ * Something that merely watches the scrolling — and can fall back to the page
+ * itself — can use this and still render outside a sheet, in a test or a
+ * standalone screen.
+ */
+export function useOptionalBlueprintViewportRef(): ViewportRef | null {
+	return useContext(ViewportRefContext)
 }
 
 export function BlueprintSheet({ children }: { children: React.ReactNode }) {
@@ -66,7 +83,13 @@ export function BlueprintSheet({ children }: { children: React.ReactNode }) {
 					<Vignette />
 					{isDesktopScroll ? (
 						<PriScrollArea.Root>
-							<PriScrollArea.Viewport ref={viewportRef}>
+							{/* Naming the scroller lets the router remember how far down it
+							    was on the way back, instead of guessing at it by position
+							    in the tree — which moves whenever the layout does. */}
+							<PriScrollArea.Viewport
+								ref={viewportRef}
+								data-scroll-restoration-id={SHEET_SCROLL_ID}
+							>
 								<Content>{children}</Content>
 							</PriScrollArea.Viewport>
 							<PriScrollArea.Scrollbar orientation='vertical'>

--- a/apps/internal/src/components/shared/infinite-list-footer.tsx
+++ b/apps/internal/src/components/shared/infinite-list-footer.tsx
@@ -1,0 +1,137 @@
+import { useLingui } from '@lingui/react/macro'
+import { useEffect, useRef } from 'react'
+import styled from 'styled-components'
+
+import { PriButton } from '@batuda/ui/pri'
+
+import { useOptionalBlueprintViewportRef } from '#/components/layout/blueprint-sheet'
+import { SrOnly } from '#/components/shared/sr-only'
+import type { InfiniteList } from '#/hooks/use-infinite-list'
+
+/**
+ * How far past the end of the visible area the next rows start loading. Far
+ * enough that they are usually already there by the time the reader gets to
+ * the bottom, so the list reads as continuous rather than as a series of
+ * waits.
+ */
+const PREFETCH_MARGIN_PX = 600
+
+/**
+ * The end of a list that keeps going.
+ *
+ * Two ways to reach the next rows, on purpose. Scrolling near the end loads
+ * them without being asked, which is what nearly everyone will do — and a
+ * real button stays in the markup for everyone who never triggers that:
+ * people moving through the page by keyboard, anyone using a screen reader,
+ * and any browser where the observer does not fire. Auto-loading alone would
+ * simply strand them at the first page.
+ */
+export function InfiniteListFooter({
+	list,
+	testId,
+	announce = true,
+}: {
+	readonly list: InfiniteList<unknown>
+	/** Names the button, for tests: `<testId>-load-more`. */
+	readonly testId: string
+	/**
+	 * Whether to count the rows out loud as they arrive. Turn it off where the
+	 * screen already says the same thing — a page that announces its own list,
+	 * or a board where one footer per column would say it eight times at once.
+	 */
+	readonly announce?: boolean
+}) {
+	const { t } = useLingui()
+	const sentinelRef = useRef<HTMLDivElement>(null)
+	const viewportRef = useOptionalBlueprintViewportRef()
+
+	const { hasMore, isLoadingMore, loadMoreFailed, loadMore, refresh } = list
+	const loadedCount = list.items.length
+	// Named rather than read inline so the announcement reaches translators with
+	// two named blanks to place, instead of one named and one numbered.
+	const totalCount = list.total
+
+	// Held in a ref so the watcher below is not torn down and set up again every
+	// time the list grows.
+	const onReach = useRef(loadMore)
+	onReach.current = loadMore
+
+	const canAutoLoad = hasMore && !isLoadingMore && !loadMoreFailed
+	useEffect(() => {
+		const sentinel = sentinelRef.current
+		if (!sentinel || !canAutoLoad) return
+		// Read the scroller now rather than when the sheet mounted: which element
+		// owns the scrolling changes with the width of the window, and a stale one
+		// would measure the load-early margin against nothing. Falling back to null
+		// watches the page, which is what phones scroll.
+		const sheetViewport = viewportRef?.current ?? null
+		const scrollRoot =
+			sheetViewport !== null &&
+			sheetViewport.scrollHeight > sheetViewport.clientHeight
+				? sheetViewport
+				: null
+		const observer = new IntersectionObserver(
+			entries => {
+				if (entries.some(entry => entry.isIntersecting)) onReach.current()
+			},
+			{ root: scrollRoot, rootMargin: `0px 0px ${PREFETCH_MARGIN_PX}px 0px` },
+		)
+		observer.observe(sentinel)
+		return () => observer.disconnect()
+	}, [canAutoLoad, viewportRef])
+
+	if (!hasMore) return null
+
+	return (
+		<Footer>
+			<Sentinel ref={sentinelRef} aria-hidden />
+			<PriButton
+				type='button'
+				$variant='outlined'
+				onClick={loadMoreFailed ? refresh : loadMore}
+				disabled={isLoadingMore}
+				data-testid={`${testId}-load-more`}
+			>
+				<span>{loadMoreFailed ? t`Try again` : t`Load more`}</span>
+			</PriButton>
+			{loadMoreFailed && (
+				<FailureNote role='status'>
+					{t`Could not load more. The rows already here are still current.`}
+				</FailureNote>
+			)}
+			{/* Scrolling more rows into view says nothing on its own to somebody
+			    who cannot see them arrive, so count them out loud instead. */}
+			{announce && (
+				<SrOnly aria-live='polite'>
+					{t`Showing ${loadedCount} of ${totalCount}`}
+				</SrOnly>
+			)}
+		</Footer>
+	)
+}
+
+const Footer = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--space-xs);
+	padding: var(--space-lg) 0;
+	position: relative;
+`
+
+// Sits above the button so the next rows are already on their way by the time
+// the button itself would come into view.
+const Sentinel = styled.div`
+	position: absolute;
+	top: 0;
+	height: 1px;
+	width: 100%;
+	pointer-events: none;
+`
+
+const FailureNote = styled.p`
+	margin: 0;
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-body-small-size);
+	text-align: center;
+`

--- a/apps/internal/src/hooks/use-infinite-list.test.ts
+++ b/apps/internal/src/hooks/use-infinite-list.test.ts
@@ -1,0 +1,166 @@
+import { AsyncResult } from 'effect/unstable/reactivity'
+import { describe, expect, it } from 'vitest'
+
+import { readListState } from '#/hooks/use-infinite-list'
+import type { PaginatedList } from '#/lib/paginated-list'
+
+const page = (
+	rowCount: number,
+	total: number,
+	offset = 0,
+): PaginatedList<string> => ({
+	items: Array.from({ length: rowCount }, (_, index) => `row-${index}`),
+	total,
+	limit: rowCount,
+	offset,
+})
+
+describe('readListState', () => {
+	describe('when the first window is still on its way', () => {
+		it('should report the first load and offer nothing to show', () => {
+			// GIVEN nothing has arrived and no rows are being held
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.initial<PaginatedList<string>, Error>(true),
+				loaded: undefined,
+			})
+
+			// THEN the list blocks on its own spinner and promises nothing
+			expect(state.isLoadingFirstPage).toBe(true)
+			expect(state.isLoadingMore).toBe(false)
+			expect(state.items).toEqual([])
+			expect(state.total).toBe(0)
+			expect(state.hasMore).toBe(false)
+			expect(state.isError).toBe(false)
+			expect(state.loadMoreFailed).toBe(false)
+		})
+	})
+
+	describe('when a window has loaded', () => {
+		it('should show the rows and promise more while some are unloaded', () => {
+			// GIVEN 60 of 312 matching rows have arrived
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.success(page(60, 312)),
+				loaded: page(60, 312),
+			})
+
+			// THEN the rows show and the list knows it is not finished
+			expect(state.items).toHaveLength(60)
+			expect(state.total).toBe(312)
+			expect(state.hasMore).toBe(true)
+			expect(state.isLoadingFirstPage).toBe(false)
+			expect(state.isLoadingMore).toBe(false)
+		})
+
+		it('should stop promising more once every row is loaded', () => {
+			// GIVEN every matching row has arrived
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.success(page(42, 42)),
+				loaded: page(42, 42),
+			})
+
+			// THEN there is nothing left to ask for
+			expect(state.hasMore).toBe(false)
+		})
+
+		it('should treat an empty list as finished rather than loading', () => {
+			// GIVEN the filters match nothing at all
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.success(page(0, 0)),
+				loaded: page(0, 0),
+			})
+
+			// THEN the empty state shows instead of a spinner or a "load more"
+			expect(state.items).toEqual([])
+			expect(state.hasMore).toBe(false)
+			expect(state.isLoadingFirstPage).toBe(false)
+			expect(state.isError).toBe(false)
+		})
+	})
+
+	describe('when a longer window is on its way', () => {
+		it('should keep the rows in hand on screen instead of blanking', () => {
+			// GIVEN a longer window was asked for, so the new request reports
+			// `Initial` while the rows from the shorter one are still held
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.initial<PaginatedList<string>, Error>(true),
+				loaded: page(60, 312),
+			})
+
+			// THEN the reader keeps their place instead of losing the list
+			expect(state.items).toHaveLength(60)
+			expect(state.isLoadingFirstPage).toBe(false)
+			expect(state.isLoadingMore).toBe(true)
+			expect(state.hasMore).toBe(true)
+		})
+
+		it('should report more on the way when a refresh marks it waiting', () => {
+			// GIVEN a refresh of the window already on screen
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.success(page(60, 312), { waiting: true }),
+				loaded: page(60, 312),
+			})
+
+			// THEN the rows stay put; a refresh is not a first load
+			expect(state.isLoadingFirstPage).toBe(false)
+			expect(state.items).toHaveLength(60)
+		})
+	})
+
+	describe('when the request fails', () => {
+		it('should report an error only when there is nothing to fall back on', () => {
+			// GIVEN the first window failed and no rows are being held
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.fail<Error, PaginatedList<string>>(
+					new Error('offline'),
+				),
+				loaded: undefined,
+			})
+
+			// THEN the whole list gives way to the error
+			expect(state.isError).toBe(true)
+			expect(state.loadMoreFailed).toBe(false)
+			expect(state.isLoadingFirstPage).toBe(false)
+			expect(state.isLoadingMore).toBe(false)
+		})
+
+		it('should keep already-loaded rows when only the next window fails', () => {
+			// GIVEN asking for more failed while rows are being held
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.fail<Error, PaginatedList<string>>(
+					new Error('offline'),
+				),
+				loaded: page(60, 312),
+			})
+
+			// THEN the rows survive and only the footer reports the failure, so
+			// nothing keeps asking on the reader's behalf
+			expect(state.items).toHaveLength(60)
+			expect(state.isError).toBe(false)
+			expect(state.loadMoreFailed).toBe(true)
+			expect(state.isLoadingMore).toBe(false)
+		})
+	})
+
+	describe('when the server reports fewer rows than it promised', () => {
+		it('should stop asking rather than chase rows that never arrive', () => {
+			// GIVEN a total that undercounts the rows actually returned, which
+			// would otherwise leave the list asking for a window it already has
+			// WHEN the state is read
+			const state = readListState({
+				result: AsyncResult.success(page(60, 12)),
+				loaded: page(60, 12),
+			})
+
+			// THEN nothing more is asked for
+			expect(state.hasMore).toBe(false)
+		})
+	})
+})

--- a/apps/internal/src/hooks/use-infinite-list.ts
+++ b/apps/internal/src/hooks/use-infinite-list.ts
@@ -1,0 +1,163 @@
+import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
+import type { Atom } from 'effect/unstable/reactivity'
+import { AsyncResult } from 'effect/unstable/reactivity'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import type { PaginatedList } from '#/lib/paginated-list'
+
+/**
+ * A list that grows as the reader reaches the end of it.
+ *
+ * Every list endpoint answers with the same envelope — the rows asked for,
+ * plus how many match in total — so one hook can drive all of them. Asking
+ * for more means asking for a longer window of the same list rather than for
+ * a separate page, which keeps what is on screen a single consistent
+ * snapshot: no row is duplicated or skipped when somebody else adds one while
+ * the reader is scrolling.
+ */
+export type InfiniteList<T> = {
+	/** Rows loaded so far, in server order. */
+	readonly items: ReadonlyArray<T>
+	/** How many rows match in total, not just how many are loaded. */
+	readonly total: number
+	/** Whether asking again would bring anything new. */
+	readonly hasMore: boolean
+	/** First load, with nothing to show yet. */
+	readonly isLoadingFirstPage: boolean
+	/** More rows are on their way; the ones in hand stay on screen. */
+	readonly isLoadingMore: boolean
+	/** The first load failed, so there is nothing to show. */
+	readonly isError: boolean
+	/**
+	 * Asking for more failed, but the rows already loaded are still on screen.
+	 * Callers must stop asking on their own while this is set, or a failing
+	 * request would be retried forever.
+	 */
+	readonly loadMoreFailed: boolean
+	/** Ask for the next window. A no-op while one is already on its way. */
+	readonly loadMore: () => void
+	/** Refetch what is on screen now. */
+	readonly refresh: () => void
+}
+
+/**
+ * How far into each list the reader has got, kept for as long as the tab
+ * lives. Stepping into a record and coming back then shows the same rows as
+ * before instead of dropping the reader back at the top of a single page.
+ *
+ * Only ever written when somebody asks for more, which cannot happen on the
+ * server, so one reader's place in a list can never reach another's.
+ */
+const rememberedWindows = new Map<string, number>()
+
+export function useInfiniteList<T, E>(options: {
+	/**
+	 * Identifies *which* list this is — the filters, the shelf, the column.
+	 * When it changes the window shrinks back to one page, because the rows in
+	 * hand belong to a list the reader is no longer looking at.
+	 */
+	readonly resetKey: string
+	/** Rows in the first window, and rows added by each subsequent ask. */
+	readonly pageSize: number
+	/** Builds the atom that holds a window of `limit` rows. */
+	readonly atomFor: (
+		limit: number,
+	) => Atom.Atom<AsyncResult.AsyncResult<PaginatedList<T>, E>>
+}): InfiniteList<T> {
+	const { resetKey, pageSize, atomFor } = options
+
+	// Starts at one page every time, including on the server, so the first
+	// client render matches the HTML that was sent. Anything remembered from an
+	// earlier visit goes back on once the browser takes over.
+	const [limit, setLimit] = useState(pageSize)
+	useEffect(() => {
+		setLimit(rememberedWindows.get(resetKey) ?? pageSize)
+	}, [resetKey, pageSize])
+
+	// `resetKey` + `limit` fully identify the atom; `atomFor` is a fresh closure
+	// every render and would hand back a different atom each time on its own.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed by resetKey
+	const atom = useMemo(() => atomFor(limit), [resetKey, limit])
+	const result = useAtomValue(atom)
+	const refresh = useAtomRefresh(atom)
+
+	// Asking for a longer window starts a fresh request, so the rows in hand
+	// would otherwise blank out mid-scroll and take the reader's place in the
+	// list with them. Holding the last rows loaded for *this* list keeps them on
+	// screen until the longer window arrives; switching lists drops them,
+	// because they describe something else.
+	//
+	// Written during render on purpose: it only ever mirrors the value being
+	// rendered, so a repeated render stores the same thing again.
+	const held = useRef<{ key: string; page: PaginatedList<T> } | undefined>(
+		undefined,
+	)
+	if (AsyncResult.isSuccess(result)) {
+		held.current = { key: resetKey, page: result.value }
+	}
+	const loaded = AsyncResult.isSuccess(result)
+		? result.value
+		: held.current?.key === resetKey
+			? held.current.page
+			: undefined
+
+	const state = useMemo(
+		() => readListState<T, E>({ result, loaded }),
+		[result, loaded],
+	)
+
+	// Remembered at the point of asking rather than by watching the window size:
+	// coming back to a list, that size starts at one page before jumping to what
+	// was remembered, and a watcher would file the one-page start over the
+	// reader's real place.
+	const loadMore = useCallback(() => {
+		if (!state.hasMore || state.isLoadingMore || state.loadMoreFailed) return
+		const next = limit + pageSize
+		rememberedWindows.set(resetKey, next)
+		setLimit(next)
+	}, [
+		state.hasMore,
+		state.isLoadingMore,
+		state.loadMoreFailed,
+		limit,
+		pageSize,
+		resetKey,
+	])
+
+	return { ...state, loadMore, refresh }
+}
+
+/**
+ * What the list looks like right now, given the request in flight and the rows
+ * being held from the last one that finished.
+ *
+ * Split out from the hook so every combination is checkable on its own: the
+ * difference between "nothing yet" and "more on the way" decides whether the
+ * reader sees a spinner in place of the list or keeps reading it, and the
+ * difference between the two kinds of failure decides whether the rows in hand
+ * survive.
+ */
+export function readListState<T, E>(input: {
+	readonly result: AsyncResult.AsyncResult<PaginatedList<T>, E>
+	/** Rows to show: the ones just loaded, or the ones being held. */
+	readonly loaded: PaginatedList<T> | undefined
+}): Omit<InfiniteList<T>, 'loadMore' | 'refresh'> {
+	const { result, loaded } = input
+	const items = loaded?.items ?? []
+	const total = loaded?.total ?? 0
+	const failed = AsyncResult.isFailure(result)
+	const hasRows = loaded !== undefined
+	// A longer window is fetched by an atom of its own, so it reports `Initial`
+	// rather than `waiting` — treat anything not yet settled as still on its way.
+	const pending = !AsyncResult.isSuccess(result) && !failed
+
+	return {
+		items,
+		total,
+		hasMore: items.length < total,
+		isLoadingFirstPage: !hasRows && pending,
+		isLoadingMore: hasRows && pending,
+		isError: failed && !hasRows,
+		loadMoreFailed: failed && hasRows,
+	}
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -1276,6 +1276,10 @@ msgstr "No s'han pogut carregar les safates"
 msgid "Could not load meetings"
 msgstr "No s'han pogut carregar les reunions"
 
+#: src/components/shared/infinite-list-footer.tsx
+msgid "Could not load more. The rows already here are still current."
+msgstr "No s'han pogut carregar més files. Les que ja hi ha continuen sent vàlides."
+
 #: src/routes/companies/$slug.tsx
 #: src/routes/pages/index.tsx
 msgid "Could not load pages"
@@ -2580,13 +2584,11 @@ msgstr "Les actualitzacions en directe s'han aturat. Potser l'execució encara t
 msgid "Live updates paused. This run may still be working — refresh to check its latest status."
 msgstr "Actualitzacions en directe pausades. Aquesta execució encara pot estar treballant — actualitza per veure el seu estat més recent."
 
-#. placeholder {0}: total - loaded
 #: src/components/companies/pipeline-board.tsx
-msgid "Load {0} more"
-msgstr "Carrega'n {0} més"
+#~ msgid "Load {0} more"
+#~ msgstr "Carrega'n {0} més"
 
-#: src/routes/companies/index.tsx
-#: src/routes/tasks/index.tsx
+#: src/components/shared/infinite-list-footer.tsx
 msgid "Load more"
 msgstr "Carrega'n més"
 
@@ -4491,6 +4493,10 @@ msgstr "Es mostren {0} de {totalPending}. Afina els filtres per arribar a la res
 msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Mostrant {firstRow}–{lastRow} de {total}"
 
+#: src/components/shared/infinite-list-footer.tsx
+msgid "Showing {loadedCount} of {totalCount}"
+msgstr "Es mostren {loadedCount} de {totalCount}"
+
 #: src/routes/login.tsx
 msgid "Sign in"
 msgstr "Inicia sessió"
@@ -4795,10 +4801,9 @@ msgstr "Títol de la tasca"
 msgid "Tasks"
 msgstr "Tasques"
 
-#. placeholder {0}: visibleTasks.length
 #: src/routes/tasks/index.tsx
-msgid "tasks — showing {0} of {shelfTotal}"
-msgstr "tasques: es mostren {0} de {shelfTotal}"
+#~ msgid "tasks — showing {0} of {shelfTotal}"
+#~ msgstr "tasques: es mostren {0} de {shelfTotal}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/run-labels.ts
@@ -5183,6 +5188,10 @@ msgstr "Total"
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Total competitors"
 msgstr "Total competidors"
+
+#: src/components/shared/infinite-list-footer.tsx
+msgid "Try again"
+msgstr "Torna-ho a provar"
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -1276,6 +1276,10 @@ msgstr "Could not load inboxes"
 msgid "Could not load meetings"
 msgstr "Could not load meetings"
 
+#: src/components/shared/infinite-list-footer.tsx
+msgid "Could not load more. The rows already here are still current."
+msgstr "Could not load more. The rows already here are still current."
+
 #: src/routes/companies/$slug.tsx
 #: src/routes/pages/index.tsx
 msgid "Could not load pages"
@@ -2580,13 +2584,11 @@ msgstr "Live updates have stopped. The run may still be working."
 msgid "Live updates paused. This run may still be working — refresh to check its latest status."
 msgstr "Live updates paused. This run may still be working — refresh to check its latest status."
 
-#. placeholder {0}: total - loaded
 #: src/components/companies/pipeline-board.tsx
-msgid "Load {0} more"
-msgstr "Load {0} more"
+#~ msgid "Load {0} more"
+#~ msgstr "Load {0} more"
 
-#: src/routes/companies/index.tsx
-#: src/routes/tasks/index.tsx
+#: src/components/shared/infinite-list-footer.tsx
 msgid "Load more"
 msgstr "Load more"
 
@@ -4491,6 +4493,10 @@ msgstr "Showing {0} of {totalPending}. Narrow the filters to reach the rest."
 msgid "Showing {firstRow}–{lastRow} of {total}"
 msgstr "Showing {firstRow}–{lastRow} of {total}"
 
+#: src/components/shared/infinite-list-footer.tsx
+msgid "Showing {loadedCount} of {totalCount}"
+msgstr "Showing {loadedCount} of {totalCount}"
+
 #: src/routes/login.tsx
 msgid "Sign in"
 msgstr "Sign in"
@@ -4795,10 +4801,9 @@ msgstr "Task title"
 msgid "Tasks"
 msgstr "Tasks"
 
-#. placeholder {0}: visibleTasks.length
 #: src/routes/tasks/index.tsx
-msgid "tasks — showing {0} of {shelfTotal}"
-msgstr "tasks — showing {0} of {shelfTotal}"
+#~ msgid "tasks — showing {0} of {shelfTotal}"
+#~ msgstr "tasks — showing {0} of {shelfTotal}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/run-labels.ts
@@ -5183,6 +5188,10 @@ msgstr "Total"
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Total competitors"
 msgstr "Total competitors"
+
+#: src/components/shared/infinite-list-footer.tsx
+msgid "Try again"
+msgstr "Try again"
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -1,4 +1,3 @@
-import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
 import { useLingui } from '@lingui/react/macro'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
@@ -20,6 +19,7 @@ import { CompaniesHeader } from '#/components/companies/companies-header'
 import { CompanyCard } from '#/components/shared/company-card'
 import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
+import { InfiniteListFooter } from '#/components/shared/infinite-list-footer'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import {
 	type CompanyStatus,
@@ -27,6 +27,7 @@ import {
 	StatusBadge,
 } from '#/components/shared/status-badge'
 import { useQuickCapture } from '#/context/quick-capture-context'
+import { useInfiniteList } from '#/hooks/use-infinite-list'
 import { dehydrateAtom } from '#/lib/atom-hydration'
 import { useOrgMembers } from '#/lib/org-members'
 import { validateSearchWith } from '#/lib/search-schema'
@@ -149,37 +150,29 @@ function CompaniesListPage() {
 	const { open: openQuickCapture } = useQuickCapture()
 	const { members, meUserId } = useOrgMembers()
 
-	// "Load more" grows the fetched window; reset it whenever the filters change.
+	// The list grows as the reader reaches the end of it; the filters identify
+	// which list that is, so changing them starts over at the first page.
 	const searchKey = canonicalSearchKey(search)
-	const [visibleLimit, setVisibleLimit] = useState(COMPANIES_PAGE_SIZE)
-	useEffect(() => {
-		setVisibleLimit(COMPANIES_PAGE_SIZE)
-	}, [searchKey])
-
-	const atom = useMemo(
-		() => companiesSearchAtom(search, visibleLimit),
-		// searchKey + visibleLimit fully identify the atom; `search` is unstable.
-		// biome-ignore lint/correctness/useExhaustiveDependencies: keyed by searchKey
-		[searchKey, visibleLimit],
-	)
-	const result = useAtomValue(atom)
-	const refreshCompanies = useAtomRefresh(atom)
-	const loadedPage = AsyncResult.isSuccess(result) ? result.value : undefined
+	const list = useInfiniteList({
+		resetKey: searchKey,
+		pageSize: COMPANIES_PAGE_SIZE,
+		atomFor: limit => companiesSearchAtom(search, limit),
+	})
 
 	const companies = useMemo<ReadonlyArray<CompanyRow>>(
-		() => (loadedPage ? narrowCompanies(loadedPage.items) : []),
-		[loadedPage],
+		() => narrowCompanies(list.items),
+		[list.items],
 	)
-	const isLoading = AsyncResult.isInitial(result)
-	const isFailure = AsyncResult.isFailure(result)
+	const isLoading = list.isLoadingFirstPage
+	const isFailure = list.isError
+	const refreshCompanies = list.refresh
 	// Until the list actually loads there is no count to show — a failed or
 	// still-loading fetch must not read as "0 companies", an empty pipeline.
-	const hasResult = loadedPage !== undefined
-	// How many companies match the filters in total, not just the ones
-	// fetched so far: `companies` stops at `visibleLimit`, so its length
-	// would under-report for any org with more than one page of them.
-	const total = loadedPage?.total ?? 0
-	const hasMore = companies.length < total
+	const hasResult = !isLoading && !isFailure
+	// How many companies match the filters in total, not just the ones fetched
+	// so far: `companies` stops at the window loaded, so its length would
+	// under-report for any org with more than one page of them.
+	const total = list.total
 
 	// ── Search input (debounced URL write) ──────────────────────
 	const [searchInput, setSearchInput] = useState(search.query ?? '')
@@ -451,18 +444,7 @@ function CompaniesListPage() {
 							))}
 						</Grid>
 					</LayoutGroup>
-					{hasMore && (
-						<LoadMoreWrap>
-							<PriButton
-								type='button'
-								$variant='outlined'
-								onClick={() => setVisibleLimit(l => l + COMPANIES_PAGE_SIZE)}
-								data-testid='companies-load-more'
-							>
-								<span>{t`Load more`}</span>
-							</PriButton>
-						</LoadMoreWrap>
-					)}
+					<InfiniteListFooter list={list} testId='companies' />
 				</>
 			)}
 		</Page>
@@ -782,12 +764,4 @@ const DropdownRow = styled.div.withConfig({
 	flex-wrap: wrap;
 	align-items: center;
 	gap: var(--space-2xs);
-`
-
-const LoadMoreWrap = styled.div.withConfig({
-	displayName: 'CompaniesListLoadMore',
-})`
-	display: flex;
-	justify-content: center;
-	padding: var(--space-md) 0;
 `

--- a/apps/internal/src/routes/tasks/index.tsx
+++ b/apps/internal/src/routes/tasks/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '#/atoms/tasks-atoms'
 import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
+import { InfiniteListFooter } from '#/components/shared/infinite-list-footer'
 import { KpiCounter } from '#/components/shared/kpi-counter'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { SrOnly } from '#/components/shared/sr-only'
@@ -39,6 +40,7 @@ import {
 	type TaskSourceLabel,
 } from '#/components/shared/task-item'
 import { useQuickCapture } from '#/context/quick-capture-context'
+import { useInfiniteList } from '#/hooks/use-infinite-list'
 import { dehydrateAtom } from '#/lib/atom-hydration'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
@@ -229,21 +231,19 @@ function TasksPage() {
 	// but a tab left open overnight would then keep filing work under
 	// yesterday, so it is re-read whenever the window comes back to the front.
 	const [dayKey, setDayKey] = useState(() => localDayKey())
-	const [visibleLimit, setVisibleLimit] = useState(TASKS_PAGE_SIZE)
-	// Moving to another shelf starts again at its first page.
-	useEffect(() => {
-		setVisibleLimit(TASKS_PAGE_SIZE)
-	}, [selectedShelf])
 
-	const shelfAtom = useMemo(
-		() => tasksShelfAtom(selectedShelf, dayKey, visibleLimit),
-		[selectedShelf, dayKey, visibleLimit],
-	)
+	// The shelf grows as the reader reaches the end of it. Moving to another
+	// shelf starts again at its first page, because the rows in hand belong to
+	// work the reader is no longer looking at.
+	const shelfList = useInfiniteList({
+		resetKey: `${selectedShelf}::${dayKey}`,
+		pageSize: TASKS_PAGE_SIZE,
+		atomFor: limit => tasksShelfAtom(selectedShelf, dayKey, limit),
+	})
 	const countsAtom = useMemo(() => taskCountsAtom(dayKey), [dayKey])
-	const tasksResult = useAtomValue(shelfAtom)
 	const countsResult = useAtomValue(countsAtom)
 	const companiesResult = useAtomValue(companiesListAtom)
-	const refreshTasks = useAtomRefresh(shelfAtom)
+	const refreshTasks = shelfList.refresh
 	const refreshCounts = useAtomRefresh(countsAtom)
 	const refreshCompanies = useAtomRefresh(companiesListAtom)
 	const completeTask = useAtomSet(completeTaskAtom, { mode: 'promiseExit' })
@@ -313,30 +313,13 @@ function TasksPage() {
 	// The last version of the task the pane is showing.
 	const lastOpenTask = useRef<TaskRow | null>(null)
 
-	// Asking for another page means a fresh request, so the rows in hand would
-	// otherwise blank out mid-scroll and take the reader's place in the list
-	// with them. Holding the last page of *this* shelf keeps them on screen
-	// until the longer one arrives; moving to a different shelf drops them,
-	// because showing one shelf's work under another's name would be a lie.
-	const lastPage = useRef<
-		{ shelf: TaskShelf; page: PaginatedList<unknown> } | undefined
-	>(undefined)
-	if (AsyncResult.isSuccess(tasksResult)) {
-		lastPage.current = { shelf: selectedShelf, page: tasksResult.value }
-	}
-	const loadedShelf = AsyncResult.isSuccess(tasksResult)
-		? tasksResult.value
-		: lastPage.current?.shelf === selectedShelf
-			? lastPage.current.page
-			: undefined
 	const visibleTasks = useMemo<ReadonlyArray<TaskRow>>(
-		() => (loadedShelf ? narrowTasks(loadedShelf.items) : []),
-		[loadedShelf],
+		() => narrowTasks(shelfList.items),
+		[shelfList.items],
 	)
 	// How many the shelf holds altogether, which is what the rail promises —
 	// the rows in hand stop at whatever has been asked for so far.
-	const shelfTotal = loadedShelf?.total ?? 0
-	const hasMore = visibleTasks.length < shelfTotal
+	const shelfTotal = shelfList.total
 
 	const counts = AsyncResult.isSuccess(countsResult)
 		? countsResult.value
@@ -346,9 +329,10 @@ function TasksPage() {
 	// Only the arrival of rows is announced here. While they are on their way
 	// the spinner says "loading" out loud, and a failure is read out by the
 	// error message itself — repeating either would say it twice.
-	const shelfAnnouncement = AsyncResult.isSuccess(tasksResult)
-		? t`${t(shelfCopy(selectedShelf).label)}: showing ${visibleTasks.length} of ${shelfTotal} tasks.`
-		: ''
+	const shelfAnnouncement =
+		!shelfList.isLoadingFirstPage && !shelfList.isError
+			? t`${t(shelfCopy(selectedShelf).label)}: showing ${visibleTasks.length} of ${shelfTotal} tasks.`
+			: ''
 
 	const companiesLoaded = AsyncResult.isSuccess(companiesResult)
 	const companiesById = useMemo<Map<string, CompanyLookup>>(() => {
@@ -592,8 +576,8 @@ function TasksPage() {
 	// Only the list waits for its rows: blanking the whole page on every shelf
 	// switch would make the shelf buttons vanish under the pointer and send the
 	// keyboard back to the top of the page.
-	const isShelfPending = AsyncResult.isInitial(tasksResult) && !loadedShelf
-	const hasShelfFailed = AsyncResult.isFailure(tasksResult)
+	const isShelfPending = shelfList.isLoadingFirstPage
+	const hasShelfFailed = shelfList.isError
 
 	const countsReady = AsyncResult.isSuccess(countsResult)
 
@@ -740,21 +724,11 @@ function TasksPage() {
 									)
 								})}
 							</Stack>
-							{hasMore && (
-								<LoadMoreWrap>
-									<PriButton
-										type='button'
-										$variant='outlined'
-										onClick={() =>
-											setVisibleLimit(shown => shown + TASKS_PAGE_SIZE)
-										}
-										data-testid='tasks-load-more'
-									>
-										<span>{t`Load more`}</span>
-										<SrOnly>{t`tasks — showing ${visibleTasks.length} of ${shelfTotal}`}</SrOnly>
-									</PriButton>
-								</LoadMoreWrap>
-							)}
+							<InfiniteListFooter
+								list={shelfList}
+								testId='tasks'
+								announce={false}
+							/>
 						</>
 					)}
 				</Column>
@@ -1329,12 +1303,6 @@ const Stack = styled.div.withConfig({ displayName: 'TasksStack' })`
 	display: flex;
 	flex-direction: column;
 	gap: 0;
-`
-
-const LoadMoreWrap = styled.div.withConfig({ displayName: 'TasksLoadMore' })`
-	display: flex;
-	justify-content: center;
-	padding: var(--space-md) 0;
 `
 
 const QuickAddRow = styled.form.withConfig({ displayName: 'TasksQuickAddRow' })`


### PR DESCRIPTION
## What

Long lists in the CRM web app (`apps/internal`) now keep loading as you scroll, and stop throwing you back to the top when they do.

Before this, reaching the end of a list and asking for more emptied the list, showed a spinner, and brought it back scrolled to the very top — so anyone browsing past the first sixty companies lost their place every single time. Now the rows already on screen stay put while the next ones arrive, and reaching the end of a list fetches them without being asked.

This touches the CRM surface only: the companies list, the pipeline board, and the tasks inbox. No server, database, or API change.

## The fix

- **The cause.** Each list is backed by an "atom" — a small holder for fetched data — and the number of rows requested is part of that holder's identity. Asking for more rows therefore created a *different* holder, which starts out empty, and the page read "empty holder" as "still loading". So the list blanked. Holding on to the rows from the previous request until the longer set arrives is what fixes it; nothing blanks, so nothing moves.
- **One implementation instead of three.** The companies list, each pipeline board column, and each tasks shelf each had their own copy of the same four pieces of paging logic, and only the tasks inbox had worked around the blanking. They now share one hook and one footer component, and the bespoke workaround is gone.
- **Loading without asking, without stranding anyone.** Approaching the end of a list loads the next rows automatically. A real button stays in the markup alongside it, because auto-loading on scroll never triggers for someone moving through the page by keyboard or using a screen reader — for them the button *is* the mechanism, not a fallback.
- **Coming back where you left.** The sheet's scrolling area now carries a stable name, so the router files its position under something that does not change when the layout does. Combined with remembering how far into a list you had read, stepping into a company and pressing Back now restores both the rows and the position.
- **A failed "load more" no longer loses the list.** The rows already fetched stay, the footer offers a retry, and automatic loading stops so a failing request is not retried in a loop.

## Impact

- No migration, no schema change, no new environment variable, no wire-shape change. The existing list endpoints already return the shape this needs (`{ items, total, limit, offset }`).
- Nothing touches tenant isolation, row-level security, authentication, or the MCP surface.
- **Trade-off worth knowing:** asking for more requests a *longer window* of the same list rather than a separate page, so the fifth screenful re-fetches the rows above it. That is deliberate — it keeps what is on screen one consistent snapshot, so no row is duplicated or skipped when somebody adds one while you are scrolling. At these page sizes (50–60 rows) the cost is small; if a list ever grows to many screenfuls, switching to a cursor is the next step.

## Review guide

- Start with `apps/internal/src/hooks/use-infinite-list.ts` — everything else follows from it. `readListState` is split out from the hook purely so each combination of states is checkable on its own; that is where the tests point.
- The riskiest line is the ref written during render (`held`) in the hook. It only ever mirrors the value being rendered, so a repeated render stores the same thing again — but it is the one deliberate deviation from ordinary React and worth your eye.
- `apps/internal/src/components/shared/infinite-list-footer.tsx` renders the *end* of a list, not the list. It is named for what it renders.
- The three call sites are mechanical — skim them.
- **A decision you might overrule:** the automatic-loading trigger watches the sheet's scrolling area and starts fetching 600px before you reach the end. That number is a guess at "far enough ahead that it feels continuous"; tune it if it reads wrong to you.
- I ran the readability agent over the diff. It flagged that the footer's screen-reader count would have been announced twice on the tasks page (which already announces its own list) and once per column on the board — up to eight at once. Announcing is now opt-out, and both of those opt out.

## Screenshots

> Screenshots skipped (approved): what changed here is motion over time — a list *not* emptying and *not* jumping to the top — which a still frame cannot show, and the automated browser session could not record one (an occluded window pauses the compositor, so frames stop). The before/after row counts and scroll offsets under **Verification** were sampled every 30ms through the load and show the change more precisely than a screenshot would.

## Tests

Nine unit tests over `readListState`, covering each state a list can be in: nothing loaded yet, a window loaded, a longer window on its way, a refresh in flight, the first load failing, a later load failing with rows still on screen, an empty result, and a server total that undercounts the rows it returned.

The repo's vitest setup for this app is node-environment and pure-logic only, so there is no DOM test of the scroll behaviour — that is covered by the live measurements below instead.

## Verification

Ran against the live local stack in this branch's worktree, with 312 seeded companies and 130 overdue tasks so the paging actually engages. Measured by sampling the row count and scroll offset every 30ms across the load:

| List | Before | After |
| --- | --- | --- |
| Companies | 60 → **0** → 120 rows, scroll 5288 → **0** | 60 → 120, scroll held at 5428 |
| Pipeline board column | 60 → **0** rows + "Empty" → 91, scroll 7423 → **0** | 60 → 91, never empty |
| Tasks shelf | already correct (50 → 100, scroll held) | unchanged |

Also verified live: automatic loading on the companies list (60 → 120 with no click); switching tasks shelves resets to one page; and back-navigation restoring 120 rows at scroll 9000 — a position a 60-row page cannot physically reach.

Gates run on the rebased branch: `pnpm install`, `pnpm -w check-types` (13 packages), `pnpm -w test` (138 tests), `pnpm -w build` (13 packages) — all green. Catalan and English catalogs extracted with no missing strings.

**What I could not verify:** automatic loading was confirmed on the companies list only. On the board and the tasks inbox I exercised the button path instead, because `requestAnimationFrame` stopped firing in the automated browser session (an occluded window pauses the compositor, and `IntersectionObserver` with it). It is the same component in all three places, but I would rather flag that than imply I watched it work everywhere.

## Deferred

- Around twenty other lists still stop at a fixed number of rows with no way to see the rest — company detail tabs, documents, proposals, timeline, research, calendar. They are untouched here; they would each need this same treatment.
- The email list keeps its numbered pages on purpose. It is virtualised over thousands of threads and its page number lives in the URL, so "page 7" is a coordinate people return to.
