### PR TITLE
fix(research): save the spending limits instead of dropping them

### DIFF
--- a/apps/server/src/services/research-policy-save.integration.test.ts
+++ b/apps/server/src/services/research-policy-save.integration.test.ts
@@ -1,0 +1,294 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+// The service reads these via Config at layer-build time.
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '6'
+process.env['RESEARCH_MAX_LOOP_PROMPT_TOKENS'] ??= '24000'
+process.env['RESEARCH_ORPHAN_SWEEP_INTERVAL_SEC'] ??= '3600'
+
+import { Effect, Layer, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	ExtractLanguageModel,
+	MapProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	ScrapeProvider,
+	SearchProvider,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+
+// Saving the research budget, against the real schema.
+//
+// What a person may spend on one run lives on their own row; what the whole
+// company may spend in a month lives on the company's. A single save writes
+// both, and hands back the combined picture. It runs against a database with
+// the real tables in place, because what can go wrong here is a disagreement
+// between those tables and the shape the service reads them into — something a
+// stubbed database cannot show.
+//
+// No research job runs here, so the language-model and provider ports are never
+// called; the stubs exist only so the service layer builds.
+
+const stubLlm: LanguageModel.Service = {
+	generateText: (_options: unknown) => Effect.die('llm not exercised') as never,
+	generateObject: (_options: unknown) =>
+		Effect.die('llm not exercised') as never,
+	streamText: (_options: unknown) => Stream.die('llm not exercised') as never,
+}
+
+const providerNotExercised =
+	'research provider not exercised by the policy-save suite'
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({ search: () => Effect.die(providerNotExercised) }),
+	),
+	Layer.succeed(MapProvider)(
+		MapProvider.of({ map: () => Effect.die(providerNotExercised) }),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({ scrape: () => Effect.die(providerNotExercised) }),
+	),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(providerNotExercised) }),
+	),
+)
+
+const llmLayer = Layer.mergeAll(
+	Layer.succeed(AgentLanguageModel)(stubLlm),
+	Layer.succeed(ExtractLanguageModel)(stubLlm),
+	Layer.succeed(WriterLanguageModel)(stubLlm),
+)
+
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(llmLayer),
+	Layer.provide(providersLayer),
+	Layer.provide(
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test',
+				}),
+		}),
+	),
+	Layer.provide(
+		Layer.succeed(ResearchEventSink)(
+			ResearchEventSink.of({ fire: () => Effect.void }),
+		),
+	),
+	Layer.provideMerge(PgLive),
+)
+
+type PolicyRow = {
+	budgetCents: number
+	paidBudgetCents: number
+	autoApprovePaidCents: number
+	autoApplyMinConfidence: number | null
+}
+
+let orgId = ''
+let userId = ''
+// What the seed left on both rows, so this suite can put its figures back.
+let seededPolicy: PolicyRow | undefined
+let seededOrgCapCents: number | undefined
+
+beforeAll(async () => {
+	const seed = await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [org] = yield* sql<{ id: string }>`
+				SELECT id FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [user] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!org || !user) {
+				throw new Error(
+					"taller org / admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			const [policy] = yield* sql<PolicyRow>`
+				SELECT budget_cents, paid_budget_cents, auto_approve_paid_cents, auto_apply_min_confidence
+				FROM user_research_policy WHERE user_id = ${user.id}
+			`
+			const [orgPolicy] = yield* sql<{ paidMonthlyCapCents: number }>`
+				SELECT paid_monthly_cap_cents
+				FROM organization_research_policy WHERE organization_id = ${org.id}
+			`
+			return {
+				orgId: org.id,
+				userId: user.id,
+				policy,
+				orgCapCents: orgPolicy?.paidMonthlyCapCents,
+			}
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+			{
+				orgId: string
+				userId: string
+				policy: PolicyRow | undefined
+				orgCapCents: number | undefined
+			},
+			never,
+			never
+		>,
+	)
+	orgId = seed.orgId
+	userId = seed.userId
+	seededPolicy = seed.policy
+	seededOrgCapCents = seed.orgCapCents
+}, 60_000)
+
+// Both rows belong to the shared seed and other suites read them, so the
+// figures written here are put back rather than left behind — and a row this
+// suite brought into being is removed again.
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const policy = seededPolicy
+			if (policy === undefined) {
+				yield* sql`DELETE FROM user_research_policy WHERE user_id = ${userId}`
+			} else {
+				yield* sql`
+					UPDATE user_research_policy SET
+						budget_cents = ${policy.budgetCents},
+						paid_budget_cents = ${policy.paidBudgetCents},
+						auto_approve_paid_cents = ${policy.autoApprovePaidCents},
+						auto_apply_min_confidence = ${policy.autoApplyMinConfidence}
+					WHERE user_id = ${userId}
+				`
+			}
+			if (seededOrgCapCents === undefined) {
+				yield* sql`DELETE FROM organization_research_policy WHERE organization_id = ${orgId}`
+			} else {
+				yield* sql`
+					UPDATE organization_research_policy
+					SET paid_monthly_cap_cents = ${seededOrgCapCents}
+					WHERE organization_id = ${orgId}
+				`
+			}
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('ResearchService policy saving', () => {
+	describe('when a per-run budget is saved on its own', () => {
+		it('should hand back the new figure and keep it in the table', async () => {
+			// GIVEN a save carrying a new per-run figure
+			// WHEN it runs against the real table
+			// THEN the answer carries the new figure
+			// AND reading the policy back afterwards agrees with it
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const saved = yield* svc.updatePolicy(userId, orgId, {
+						budgetCents: 725,
+					})
+					const reread = yield* svc.getPolicy(userId, orgId)
+					return { saved, reread }
+				}).pipe(Effect.provide(ResearchLive), Effect.orDie),
+			)
+
+			expect(outcome.saved.budgetCents).toBe(725)
+			expect(outcome.reread?.budgetCents).toBe(725)
+		})
+	})
+
+	describe('when the same save also sets the company monthly ceiling', () => {
+		it('should keep both, rather than losing one to the other', async () => {
+			// GIVEN a save that carries the person's own limits and the company's
+			//   monthly ceiling together
+			// WHEN it runs
+			// THEN the answer reports the company ceiling alongside the personal ones
+			// AND every figure is still there when the policy is read back, so
+			//   neither write was discarded on the way out
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const saved = yield* svc.updatePolicy(userId, orgId, {
+						budgetCents: 450,
+						paidBudgetCents: 900,
+						autoApprovePaidCents: 300,
+						paidMonthlyCapCents: 4200,
+					})
+					const reread = yield* svc.getPolicy(userId, orgId)
+					const sql = yield* SqlClient.SqlClient
+					const [orgRow] = yield* sql<{ paidMonthlyCapCents: number }>`
+						SELECT paid_monthly_cap_cents
+						FROM organization_research_policy
+						WHERE organization_id = ${orgId}
+					`
+					return { saved, reread, orgRow }
+				}).pipe(Effect.provide(ResearchLive), Effect.orDie),
+			)
+
+			expect(outcome.saved.budgetCents).toBe(450)
+			expect(outcome.saved.paidBudgetCents).toBe(900)
+			expect(outcome.saved.autoApprovePaidCents).toBe(300)
+			expect(outcome.saved.paidMonthlyCapCents).toBe(4200)
+
+			expect(outcome.reread?.budgetCents).toBe(450)
+			expect(outcome.reread?.paidMonthlyCapCents).toBe(4200)
+
+			// The company ceiling is the other half of the same save; if the save had
+			// come apart, this row would be missing while the personal one stood.
+			expect(outcome.orgRow?.paidMonthlyCapCents).toBe(4200)
+		})
+	})
+
+	describe('when a save leaves the auto-apply confidence out', () => {
+		it('should leave the existing setting alone', async () => {
+			// GIVEN auto-apply is set to a minimum confidence of 80 percent
+			// WHEN a later save changes only the per-run budget
+			// THEN the confidence is untouched, because an omitted field means
+			//   "leave this as it is" rather than "clear it"
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					yield* svc.updatePolicy(userId, orgId, {
+						autoApplyMinConfidence: 80,
+					})
+					const after = yield* svc.updatePolicy(userId, orgId, {
+						budgetCents: 610,
+					})
+					return after
+				}).pipe(Effect.provide(ResearchLive), Effect.orDie),
+			)
+
+			expect(outcome.budgetCents).toBe(610)
+			expect(outcome.autoApplyMinConfidence).toBe(80)
+		})
+	})
+
+	describe('when a save passes a null auto-apply confidence', () => {
+		it('should turn auto-apply off', async () => {
+			// GIVEN auto-apply is on at a minimum confidence of 90 percent
+			// WHEN a save passes null for it explicitly
+			// THEN it is cleared, because passing null means "turn auto-apply off"
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					yield* svc.updatePolicy(userId, orgId, {
+						autoApplyMinConfidence: 90,
+					})
+					return yield* svc.updatePolicy(userId, orgId, {
+						autoApplyMinConfidence: null,
+					})
+				}).pipe(Effect.provide(ResearchLive), Effect.orDie),
+			)
+
+			expect(outcome.autoApplyMinConfidence).toBeNull()
+		})
+	})
+})

--- a/packages/research/src/application/research-policy-shape.test.ts
+++ b/packages/research/src/application/research-policy-shape.test.ts
@@ -1,0 +1,106 @@
+import { Option, Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { ResearchPolicyRow } from './research-service'
+
+// What a saved research policy has to look like before it can be read back.
+//
+// The figures a person sets for themselves live on their own row; the ceiling
+// for a whole month belongs to the company and lives on the company's row. So
+// whoever reads a person's policy has to fetch that one figure separately and
+// add it in, and these cases pin that requirement down: a row handed over
+// without it is refused rather than accepted half-formed.
+
+const decode = Schema.decodeUnknownOption(ResearchPolicyRow)
+
+// What the person's own table hands back, with no company ceiling in it.
+const rowFromPersonTable = {
+	budgetCents: 725,
+	paidBudgetCents: 900,
+	autoApprovePaidCents: 300,
+	autoApplyMinConfidence: 80,
+	updatedAt: new Date('2026-07-25T10:00:00Z'),
+}
+
+describe('the shape a saved research policy is read back in', () => {
+	describe('when the row comes straight from the person’s own table', () => {
+		it('should refuse it, because the company ceiling is missing', () => {
+			// GIVEN a row exactly as the person's table returns it
+			// WHEN it is read back without the company's ceiling added
+			// THEN it is refused, so a caller cannot skip fetching that figure
+			expect(Option.isNone(decode(rowFromPersonTable))).toBe(true)
+		})
+	})
+
+	describe('when the company ceiling is added alongside', () => {
+		it('should accept it and keep every figure', () => {
+			// GIVEN the same row with the company's monthly ceiling supplied
+			// WHEN it is read back
+			// THEN it is accepted, carrying the person's figures and the company's
+			const decoded = decode({
+				...rowFromPersonTable,
+				paidMonthlyCapCents: 4200,
+			})
+
+			expect(Option.isSome(decoded)).toBe(true)
+			if (Option.isNone(decoded)) return
+			expect(decoded.value.budgetCents).toBe(725)
+			expect(decoded.value.paidBudgetCents).toBe(900)
+			expect(decoded.value.autoApprovePaidCents).toBe(300)
+			expect(decoded.value.paidMonthlyCapCents).toBe(4200)
+			expect(decoded.value.autoApplyMinConfidence).toBe(80)
+		})
+	})
+
+	describe('when auto-apply is switched off', () => {
+		it('should accept a policy with no confidence set', () => {
+			// GIVEN a policy whose auto-apply confidence is empty, which is how
+			//   auto-apply being switched off is recorded
+			// WHEN it is read back
+			// THEN it is accepted, because empty is a real setting here rather than
+			//   a missing one
+			const decoded = decode({
+				...rowFromPersonTable,
+				autoApplyMinConfidence: null,
+				paidMonthlyCapCents: 3000,
+			})
+
+			expect(Option.isSome(decoded)).toBe(true)
+			if (Option.isNone(decoded)) return
+			expect(decoded.value.autoApplyMinConfidence).toBeNull()
+		})
+	})
+
+	describe('when the last-changed time is empty', () => {
+		it('should still accept the row', () => {
+			// GIVEN a row whose last-changed time is empty
+			// WHEN it is read back
+			// THEN it is accepted, because a policy is still a policy without a
+			//   record of when it last changed
+			const decoded = decode({
+				...rowFromPersonTable,
+				updatedAt: null,
+				paidMonthlyCapCents: 3000,
+			})
+
+			expect(Option.isSome(decoded)).toBe(true)
+		})
+	})
+
+	describe('when a figure arrives as text', () => {
+		it('should refuse it rather than guess at the number', () => {
+			// GIVEN a budget that arrived as text instead of a number
+			// WHEN it is read back
+			// THEN it is refused, so money is never read from a loose value
+			expect(
+				Option.isNone(
+					decode({
+						...rowFromPersonTable,
+						budgetCents: '725',
+						paidMonthlyCapCents: 3000,
+					}),
+				),
+			).toBe(true)
+		})
+	})
+})

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -167,7 +167,9 @@ const decodeResearchRunSummaries = Schema.decodeUnknownEffect(
 
 // The user_research_policy row; `userId` is dropped on decode (internal, not
 // part of the wire shape). `updatedAt` is always present on a real row.
-const ResearchPolicyRow = Schema.Struct({
+// `paidMonthlyCapCents` is the company's ceiling and lives on the company's
+// table, so a caller has to add it to the row before decoding.
+export const ResearchPolicyRow = Schema.Struct({
 	budgetCents: Schema.Number,
 	paidBudgetCents: Schema.Number,
 	autoApprovePaidCents: Schema.Number,
@@ -5530,7 +5532,20 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							return yield* Effect.die(
 								new Error('user_research_policy upsert returned no row'),
 							)
-						return yield* decodeResearchPolicy(row).pipe(Effect.orDie)
+						// The monthly ceiling is the company's, not this person's, so it is
+						// read from the company and returned alongside their own limits.
+						const [savedOrgRow] = yield* sql<{ paidMonthlyCapCents: number }>`
+							SELECT paid_monthly_cap_cents
+							FROM organization_research_policy
+							WHERE organization_id = ${organizationId}
+						`
+						return yield* decodeResearchPolicy({
+							...(row as Record<string, unknown>),
+							paidMonthlyCapCents: Math.min(
+								savedOrgRow?.paidMonthlyCapCents ?? defaultMonthlyCapCents,
+								monthlyCapHardCeilingCents,
+							),
+						}).pipe(Effect.orDie)
 					}),
 
 				/** Mark orphaned running + queued rows as failed. */


### PR DESCRIPTION
## What

The research budget screen (`/settings/organization/policy`) silently refuses every save. You change the per-run budget, press save, reload — and the old figure is back. Nothing warns you; the limits simply never move.

This is in the `research` bounded context, and it reaches the server's HTTP surface and the MCP tools alike, because both go through the same service.

## The fix

What a company may spend in a month is kept on the company's row rather than on each person's. Describing a saved policy therefore means fetching that one figure separately and adding it in. Reading a policy already did this; saving did not — so the answer could not be put together, and the failure took the whole save down with it: the person's limits **and** the company's ceiling were both discarded.

Saving now fetches the company ceiling the same way reading does. One hunk.

## Why nothing caught it

The mismatch is between a database table and the shape the service reads it into. Every existing suite passed because none of them exercised saving against a database with the real tables in place — a stubbed database cannot show a column that is missing from the real one.

Reading kept working throughout, which is what made it look like forgetfulness rather than a failure.

## Impact

- **No migration, no schema change, no new environment variables.**
- **Not in production.** The break arrived after `server-v2026.7.25`, so it has only ever existed on `main` — but it would ship with the next server release.
- **Every field on that screen was affected**, not only the per-run budget. The per-run budget, the paid budget, the auto-approve threshold, the auto-apply confidence and the company's monthly ceiling all failed to save together, because one request is one transaction.
- **No wire-shape change**, and the units are untouched: still cents, still the same field names end to end.

## Review guide

The whole fix is one hunk in `updatePolicy`. It is deliberately a copy of what `getPolicy` above it already does — the two now read the same, which is the point: they were meant to be a pair and had drifted.

**Worth knowing, not fixed here:** the monthly ceiling is written **unclamped** but reported **clamped** to the system hard ceiling, so a save above the ceiling stores the higher figure while the answer shows the lower one. That predates this change and matches `getPolicy`; the new read-back just makes the asymmetry visible in one place. Recorded on #339.

## Tests

Two levels, because they catch different things.

**Integration** (`research-policy-save.integration.test.ts`) against a database with the real tables — the only level that can catch this class of bug:

- a per-run budget round-trips and reads back the same
- a save carrying the personal limits *and* the company ceiling together keeps both, which is what proves the two halves of the save no longer come apart
- an omitted auto-apply confidence leaves the existing setting alone
- an explicit null turns auto-apply off

**Unit** (`research-policy-shape.test.ts`) — a cheap drift check that pins the requirement itself: a row taken straight from the person's table is refused until the company ceiling is supplied. That requirement is what quietly broke when the column moved, so it is now held still.

The suite restores the seeded figures it borrows rather than deleting them, so running it twice in a row leaves the shared data as it found it.

## Verification

- The regression test genuinely regresses: with the fix reverted all four cases fail with `SchemaError: Missing key at ["paidMonthlyCapCents"]`; with it restored they pass. I re-ran that proof after rebasing onto current `main`.
- The browser test that first surfaced this (`settings-research-policy.test.ts`) now passes.
- `check-types` 13/13, unit tests across all 21 packages, `build`, lint.
- The **full server integration suite: 63 files, 367 tests, all passing** — so the change disturbs nothing else.
- The new suite run twice in a row, to confirm it puts the seeded rows back.
