### PR TITLE
feat: let a document belong to a meeting, a person, a task or an offer

### DIFF
--- a/.claude/skills/crm/SKILL.md
+++ b/.claude/skills/crm/SKILL.md
@@ -17,7 +17,7 @@ Fetch only what is needed. Prefer summaries over full profiles.
 | --------------------------- | ----------------------------------------------------- |
 | `search_companies(filters)` | Summaries only, no full profiles                      |
 | `get_company(id_or_slug)`   | Full profile + last 5 interactions (no documents)     |
-| `get_documents(company_id)` | List (id, type, title) — no content                   |
+| `get_documents(subject)`    | Summaries + a snippet — no full body                  |
 | `get_document(id)`          | Full markdown content                                 |
 | `get_pipeline()`            | Counts only                                           |
 | `get_next_steps(limit)`     | Due tasks + overdue `next_action_at`                  |
@@ -71,16 +71,18 @@ For the full `log_interaction` example and workflow, consult `references/interac
 
 `documents.content` is full markdown. Write structured, scannable content — no AI filler phrases.
 
-Types: `research`, `prenote`, `postnote`, `call_notes`, `visit_notes`, `general`.
+Types: `research`, `prenote`, `postnote`, `call_notes`, `visit_notes`, `general`. Nothing else is accepted.
 
-Link to interactions via `interaction_id` when applicable (`prenote`, `postnote`, `call_notes`, `visit_notes`).
+Every document is filed against a CRM record — `subject_table` (`companies`, `contacts`, `tasks`, `proposals`, `calendar_events`) plus `subject_id`. File it against what it is about: a meeting prep note goes on the `calendar_events` row so it appears when someone opens that meeting. `attach_document` files the same document in a second place.
 
 When researching a new company:
 
-1. `create_company(...)` with known fields
-2. `create_document({ type: "research", content: <scraped + structured markdown> })`
+1. `create_companies(...)` with known fields
+2. `create_document({ subject_table: "companies", subject_id: <id>, type: "research", content: <scraped + structured markdown> })`
 
-For type descriptions and research workflow details, consult `references/documents.md`.
+A company's standing summary is `companies.account_brief`, not a document.
+
+For type descriptions and filing details, consult `references/documents.md`.
 
 ## Tasks
 

--- a/.claude/skills/crm/references/documents.md
+++ b/.claude/skills/crm/references/documents.md
@@ -1,15 +1,30 @@
 # Documents, pages, and tasks reference
 
+## Where a document is filed
+
+Every document is filed against a CRM record, named by `subject_table` + `subject_id`:
+`companies`, `contacts`, `tasks`, `proposals`, or `calendar_events`.
+
+File it against the thing it is actually about. A prep note for a meeting belongs on that
+`calendar_events` row, not on the company — that is what makes it show up when someone opens the
+meeting. A note about how a person likes to work belongs on their `contacts` row.
+
+One document can be filed in more than one place. `create_document` takes the first record;
+`attach_document` adds others and `detach_document` removes one. Filing the same pair twice is a
+no-op, not an error.
+
 ## Document types
 
-| Type          | Purpose                            | Interaction link                                |
-| ------------- | ---------------------------------- | ----------------------------------------------- |
-| `research`    | Scraped/researched company profile | No                                              |
-| `prenote`     | Prep before a meeting              | Yes — link via `interaction_id` once scheduled  |
-| `postnote`    | What happened at a meeting         | Yes — always link to meeting's `interaction_id` |
-| `call_notes`  | Phone call notes                   | Yes — link to interaction                       |
-| `visit_notes` | On-site visit notes                | Yes — link to interaction                       |
-| `general`     | Anything else                      | Optional                                        |
+| Type          | Purpose                            |
+| ------------- | ---------------------------------- |
+| `research`    | Scraped/researched company profile |
+| `prenote`     | Prep before a meeting              |
+| `postnote`    | What happened at a meeting         |
+| `call_notes`  | Phone call notes                   |
+| `visit_notes` | On-site visit notes                |
+| `general`     | Anything else                      |
+
+These six are the whole list — the tools reject anything else.
 
 ## Writing documents
 
@@ -19,10 +34,17 @@
 
 When researching a new company with Firecrawl/Exa:
 
-1. `create_company(...)` with known fields (name, slug, source, industry, etc.)
-2. `create_document({ type: "research", content: <scraped + structured markdown> })`
+1. `create_companies(...)` with known fields (name, slug, source, industry, etc.)
+2. `create_document({ subject_table: "companies", subject_id: <id>, type: "research", content: <scraped + structured markdown> })`
 
 Structure research documents with clear sections: overview, products/services, team, location, online presence, opportunities.
+
+A company's standing summary is `companies.account_brief`, not a document — it is one per company and
+kept current, where documents accumulate. Update the brief through `update_company`.
+
+Contacts, tasks and proposals used to carry a `notes` field of their own. They no longer do: anything
+written about one of them is a document filed against it. `create_document` with the matching
+`subject_table` is how you write one now.
 
 ## Pages
 

--- a/apps/cli/src/commands/seed.ts
+++ b/apps/cli/src/commands/seed.ts
@@ -107,7 +107,7 @@ export const seed = (preset: Preset) =>
 				yield* seedMcpOAuth(ctx)
 
 				if (preset === 'full') {
-					yield* seedDocuments(ctx, companyMap, insertedInteractions)
+					yield* seedDocuments(ctx, companyMap, contactMap)
 					yield* seedProposals(ctx, companyMap, contactMap, insertedProducts)
 					yield* seedPages(ctx, companyMap)
 					yield* seedResearchRuns(ctx, testUser, companyMap)

--- a/apps/cli/src/commands/seed/documents.ts
+++ b/apps/cli/src/commands/seed/documents.ts
@@ -1,74 +1,118 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: seed data */
 import { Effect } from 'effect'
 
-import type { InteractionRow } from './crm'
 import { normalizeRows, type SeedCtx, withSeedIds } from './shared'
+
+type DocumentSeed = {
+	readonly subjectTable: 'companies' | 'contacts'
+	readonly subjectKey: string
+	readonly type: string
+	readonly title: string
+	readonly content: string
+}
+
+// `subjectKey` is the seed's own handle for the record a document is filed
+// under — a company slug or a contact name — resolved to a real id once those
+// rows exist. Most of the fixtures sit on a company, one on a person, so the
+// demo data shows a note about someone as well as notes about a business.
+const DOCUMENTS: ReadonlyArray<DocumentSeed> = [
+	{
+		subjectTable: 'companies',
+		subjectKey: 'cal-pep-fonda',
+		type: 'prenote',
+		title: 'Visit prep — Cal Pep',
+		content:
+			'## Goal\nSee the restaurant, understand current booking flow.\n\n## Questions\n- How many covers per service?\n- Do they take reservations via WhatsApp or phone?\n- Do they have a website?',
+	},
+	{
+		subjectTable: 'companies',
+		subjectKey: 'cal-pep-fonda',
+		type: 'postnote',
+		title: 'Visit summary — Cal Pep',
+		content:
+			"## Summary\n60 covers, 2 services/day. Phone-only reservations — they lose ~15% of walk-ups who won't wait.\n\n## Decision\nWants website + booking. Budget approved up to 1500 EUR.",
+	},
+	{
+		subjectTable: 'companies',
+		subjectKey: 'ferros-baix-llobregat',
+		type: 'research',
+		title: 'Company analysis — Ferros BL',
+		content:
+			'## Company\n40 employees, 2 warehouses in Cornellà. Revenue ~3M EUR/year.\n\n## Pain points detected\n- Manual invoicing: 2 days/month\n- Transcription errors: ~5% of invoices\n- No real-time stock control',
+	},
+	{
+		subjectTable: 'companies',
+		subjectKey: 'hostal-pirineu',
+		type: 'visit_notes',
+		title: 'Visit notes — Hostal Pirineu',
+		content:
+			'## Context\n12 rooms, high season June–September + ski December–March.\n\n## Commissions\nBooking: 15–18%. They want to drop below 5% with a direct channel.\n\n## Requirements\n- Availability calendar\n- Upfront payment (Stripe/Redsys)\n- Multi-language: ca, es, fr',
+	},
+	{
+		subjectTable: 'companies',
+		subjectKey: 'tancaments-garraf',
+		type: 'call_notes',
+		title: 'Demo debrief — Tancaments Garraf',
+		content:
+			'## Attendees\nRamon Vila (owner), Oriol Camps (project manager)\n\n## Key points\n- Currently tracking 12 concurrent projects in shared Google Sheets\n- Lost a client last month due to a missed deadline nobody saw in the spreadsheet\n- Want a dashboard with alerts per project phase\n\n## Objections\n- Worried about migration effort from existing sheets\n- Need offline access for site visits',
+	},
+	{
+		subjectTable: 'companies',
+		subjectKey: 'distribuciones-martinez',
+		type: 'general',
+		title: 'Competitor landscape — logistics in Alzira',
+		content:
+			'## Notes\nNo direct competitor offering digital delivery notes in this area.\nClosest: a Valencia-based firm doing fleet GPS, but not document digitisation.\n\n## Opportunity\nFirst-mover advantage if we land Distribuciones Martínez as a reference client.',
+	},
+	{
+		subjectTable: 'contacts',
+		subjectKey: 'Pep Casals',
+		type: 'general',
+		title: 'Working with Pep',
+		content:
+			'## How he likes to work\nPrefers a call before 10am; reads nothing longer than a page.\n\n## Watch out for\nSays yes in the room and reconsiders overnight — confirm in writing the same day.',
+	},
+]
 
 export const seedDocuments = (
 	{ sql, stamp }: SeedCtx,
 	companyMap: Map<string, string>,
-	insertedInteractions: ReadonlyArray<InteractionRow>,
+	contactMap: Map<string, string>,
 ) =>
 	Effect.gen(function* () {
 		yield* Effect.logInfo('Seeding documents...')
-		yield* sql`INSERT INTO documents ${sql.insert(
-			normalizeRows(
-				stamp(
-					withSeedIds(
-						'document',
-						[
-							{
-								companyId: companyMap.get('cal-pep-fonda')!,
-								interactionId: insertedInteractions[0]?.id,
-								type: 'prenote',
-								title: 'Visit prep — Cal Pep',
-								content:
-									'## Goal\nSee the restaurant, understand current booking flow.\n\n## Questions\n- How many covers per service?\n- Do they take reservations via WhatsApp or phone?\n- Do they have a website?',
-							},
-							{
-								companyId: companyMap.get('cal-pep-fonda')!,
-								interactionId: insertedInteractions[0]?.id,
-								type: 'postnote',
-								title: 'Visit summary — Cal Pep',
-								content:
-									"## Summary\n60 covers, 2 services/day. Phone-only reservations — they lose ~15% of walk-ups who won't wait.\n\n## Decision\nWants website + booking. Budget approved up to 1500 EUR.",
-							},
-							{
-								companyId: companyMap.get('ferros-baix-llobregat')!,
-								interactionId: null,
-								type: 'research',
-								title: 'Company analysis — Ferros BL',
-								content:
-									'## Company\n40 employees, 2 warehouses in Cornellà. Revenue ~3M EUR/year.\n\n## Pain points detected\n- Manual invoicing: 2 days/month\n- Transcription errors: ~5% of invoices\n- No real-time stock control',
-							},
-							{
-								companyId: companyMap.get('hostal-pirineu')!,
-								interactionId: insertedInteractions[5]?.id,
-								type: 'visit_notes',
-								title: 'Visit notes — Hostal Pirineu',
-								content:
-									'## Context\n12 rooms, high season June–September + ski December–March.\n\n## Commissions\nBooking: 15–18%. They want to drop below 5% with a direct channel.\n\n## Requirements\n- Availability calendar\n- Upfront payment (Stripe/Redsys)\n- Multi-language: ca, es, fr',
-							},
-							{
-								companyId: companyMap.get('tancaments-garraf')!,
-								interactionId: null,
-								type: 'call_notes',
-								title: 'Demo debrief — Tancaments Garraf',
-								content:
-									'## Attendees\nRamon Vila (owner), Oriol Camps (project manager)\n\n## Key points\n- Currently tracking 12 concurrent projects in shared Google Sheets\n- Lost a client last month due to a missed deadline nobody saw in the spreadsheet\n- Want a dashboard with alerts per project phase\n\n## Objections\n- Worried about migration effort from existing sheets\n- Need offline access for site visits',
-							},
-							{
-								companyId: companyMap.get('distribuciones-martinez')!,
-								interactionId: null,
-								type: 'general',
-								title: 'Competitor landscape — logistics in Alzira',
-								content:
-									'## Notes\nNo direct competitor offering digital delivery notes in this area.\nClosest: a Valencia-based firm doing fleet GPS, but not document digitisation.\n\n## Opportunity\nFirst-mover advantage if we land Distribuciones Martínez as a reference client.',
-							},
-						],
-						(_, index) => String(index),
-					),
-				),
-			),
+
+		const rows = withSeedIds(
+			'document',
+			DOCUMENTS.map(doc => ({
+				type: doc.type,
+				title: doc.title,
+				content: doc.content,
+			})),
+			(_, index) => String(index),
+		)
+
+		yield* sql`INSERT INTO documents ${sql.insert(normalizeRows(stamp(rows)))}`
+
+		const links = DOCUMENTS.flatMap((doc, index) => {
+			const subjectId =
+				doc.subjectTable === 'companies'
+					? companyMap.get(doc.subjectKey)
+					: contactMap.get(doc.subjectKey)
+			// A fixture naming a record the seed did not create is skipped rather
+			// than inserted as a link pointing at nothing.
+			if (subjectId === undefined) return []
+			return [
+				{
+					documentId: rows[index]!.id,
+					subjectTable: doc.subjectTable,
+					subjectId,
+				},
+			]
+		})
+
+		yield* sql`INSERT INTO document_links ${sql.insert(
+			normalizeRows(stamp(links)),
 		)}`
+		yield* Effect.logInfo(`  ${links.length} document_links rows`)
 	})

--- a/apps/cli/src/commands/seed/fixtures.ts
+++ b/apps/cli/src/commands/seed/fixtures.ts
@@ -482,7 +482,6 @@ export const getPresetData = (
 			emailStatus: 'valid' as const,
 			emailStatusReason: 'SMTP verified',
 			emailStatusUpdatedAt: new Date('2026-03-20'),
-			notes: 'Prefereix trucades al matí, abans de les 10h.',
 		},
 		{
 			companyId: companyMap.get('tancaments-garraf')!,
@@ -513,8 +512,6 @@ export const getPresetData = (
 			name: 'Desconegut',
 			role: null,
 			isDecisionMaker: false,
-			notes:
-				'No contact info found — company discovered via Google Maps scrape.',
 		},
 		{
 			companyId: companyMap.get('distribuciones-martinez')!,
@@ -535,7 +532,6 @@ export const getPresetData = (
 			email: 'ana.lopez@dismartinez.es',
 			emailStatus: 'unknown' as const,
 			emailSoftBounceCount: 2,
-			notes: 'Only responds on LinkedIn, rarely checks email.',
 		},
 		{
 			companyId: companyMap.get('taller-mecanic-jove')!,
@@ -543,7 +539,6 @@ export const getPresetData = (
 			role: 'Propietari',
 			isDecisionMaker: true,
 			instagram: '@marcjove_tallerjove',
-			notes: 'Instagram only — no email or phone provided.',
 		},
 	]
 
@@ -737,7 +732,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Jordi Puig'),
 			type: 'visit',
 			title: 'Reunió presencial a la fàbrica',
-			notes: 'Portar portàtil per demo. Preguntar pels volums de factures.',
 			dueAt: new Date('2026-04-05'),
 		},
 		{
@@ -745,7 +739,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Sarah Mitchell'),
 			type: 'call',
 			title: 'Ecommerce demo videocall',
-			notes: 'Show retail template + Instagram Shop integration.',
 			dueAt: new Date('2026-04-03'),
 		},
 		{
@@ -753,7 +746,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Arnau Ribas'),
 			type: 'email',
 			title: 'Enviar demo reserves online',
-			notes: 'Incloure link a la demo amb dades de prova.',
 			dueAt: new Date('2026-04-02'),
 		},
 		{
@@ -761,7 +753,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Tom Parker'),
 			type: 'email',
 			title: 'Send automation info pack',
-			notes: 'PDF with logistics use cases + pricing.',
 			dueAt: new Date('2026-04-01'),
 		},
 		{
@@ -769,7 +760,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Pep Casals'),
 			type: 'followup',
 			title: 'Revisió mensual amb Cal Pep',
-			notes: 'Revisar mètriques web i reserves del mes.',
 			dueAt: new Date('2026-04-15'),
 		},
 		{
@@ -777,7 +767,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Ramon Vila'),
 			type: 'proposal',
 			title: 'Enviar proposta automatització Tancaments Garraf',
-			notes: 'Incloure integració Google Sheets + facturació.',
 			dueAt: new Date('2026-04-10'),
 		},
 		{
@@ -785,7 +774,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Pep Casals'),
 			type: 'call',
 			title: 'Trucada onboarding Cal Pep',
-			notes: 'Fet — vam configurar el calendari de reserves.',
 			dueAt: new Date('2026-03-05'),
 			// `status='done'` and `completedAt` must be set together (DB CHECK).
 			status: 'done',
@@ -796,7 +784,6 @@ export const getPresetData = (
 			contactId: contactMap.get('Marta Soler'),
 			type: 'email',
 			title: 'Enviar cas pràctic facturació automàtica',
-			notes: "Hauria d'haver sortit fa dues setmanes.",
 			dueAt: new Date('2026-03-20'),
 		},
 		{
@@ -804,7 +791,6 @@ export const getPresetData = (
 			contactId: null,
 			type: 'other',
 			title: 'Investigar competència logística a Alzira',
-			notes: 'Buscar si tenen proveïdor IT actual.',
 		},
 		{
 			companyId: companyMap.get('ceramiques-emporda')!,
@@ -822,7 +808,6 @@ export const getPresetData = (
 			contactId: null,
 			type: 'other',
 			title: 'Draft a follow-up email for Cal Pep',
-			notes: 'Auto-suggested after the last visit.',
 			source: 'agent',
 			priority: 'high',
 			status: 'in_progress',

--- a/apps/cli/src/commands/seed/proposals.ts
+++ b/apps/cli/src/commands/seed/proposals.ts
@@ -42,7 +42,6 @@ export const seedProposals = (
 								totalValue: '1578.00',
 								sentAt: new Date('2026-02-22'),
 								respondedAt: new Date('2026-02-25'),
-								notes: 'Accepted by phone. Project start March 1st.',
 							},
 							{
 								companyId: companyMap.get('ferros-baix-llobregat')!,
@@ -60,7 +59,6 @@ export const seedProposals = (
 								totalValue: '1500.00',
 								sentAt: null,
 								respondedAt: null,
-								notes: 'Pending on-site meeting to finalise details.',
 							},
 							{
 								companyId: companyMap.get('hostal-pirineu')!,
@@ -84,7 +82,6 @@ export const seedProposals = (
 								totalValue: '1578.00',
 								sentAt: new Date('2026-04-06'),
 								expiresAt: new Date('2026-05-06'),
-								notes: 'Sent after the on-site visit. Waiting for reply.',
 							},
 							{
 								companyId: companyMap.get('bright-lane-boutique')!,
@@ -114,7 +111,6 @@ export const seedProposals = (
 								totalValue: '4390.00',
 								sentAt: new Date('2026-04-01'),
 								expiresAt: new Date('2026-04-30'),
-								notes: 'Sarah opened the proposal link on April 3rd.',
 							},
 							{
 								companyId: companyMap.get('tancaments-garraf')!,
@@ -156,7 +152,6 @@ export const seedProposals = (
 								totalValue: '4184.00',
 								sentAt: new Date('2026-04-08'),
 								expiresAt: new Date('2026-05-08'),
-								notes: 'Ramon wants to reduce scope. Negotiating line items.',
 							},
 							{
 								companyId: companyMap.get('park-stone-design')!,
@@ -174,7 +169,6 @@ export const seedProposals = (
 								totalValue: '990.00',
 								sentAt: new Date('2026-02-18'),
 								respondedAt: new Date('2026-02-20'),
-								notes: 'Already had a web provider. Polite decline.',
 							},
 							{
 								companyId: companyMap.get('coastal-freight')!,
@@ -193,7 +187,6 @@ export const seedProposals = (
 								currency: 'USD',
 								sentAt: new Date('2026-02-01'),
 								expiresAt: new Date('2026-03-01'),
-								notes: 'Tom never responded. Proposal expired.',
 							},
 						],
 						(_, index) => String(index),

--- a/apps/internal/playwright.config.ts
+++ b/apps/internal/playwright.config.ts
@@ -120,6 +120,13 @@ const worktreeHost = (() => {
 const BASE_URL =
 	process.env['E2E_BASE_URL'] ?? `https://${worktreeHost}${portlessPortSuffix}`
 
+// Specs that build their own request context — signing in as a second person,
+// calling the API directly — cannot read this constant, so they fall back to
+// `E2E_BASE_URL`. Publishing it here means that fallback resolves to the origin
+// the browser is actually using, instead of the main checkout's address, which
+// nothing answers on in a worktree or on CI.
+process.env['E2E_BASE_URL'] = BASE_URL
+
 const STORAGE_STATE = 'tests/e2e/.auth/alice.json'
 
 export default defineConfig({

--- a/apps/internal/src/atoms/documents-atoms.ts
+++ b/apps/internal/src/atoms/documents-atoms.ts
@@ -1,0 +1,26 @@
+import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+
+/**
+ * Queries for documents, cached by what they ask for.
+ *
+ * The cache is what lets a page rendered on the server hand its answer to the
+ * browser: both sides have to reach for the same query object, and building a
+ * fresh one each render would give them two.
+ */
+
+const detailCache = new Map<string, ReturnType<typeof makeDetailAtom>>()
+
+function makeDetailAtom(id: string) {
+	return BatudaApiAtom.query('documents', 'get', {
+		params: { id },
+		serializationKey: `document:${id}`,
+	})
+}
+
+export function documentAtomFor(id: string) {
+	const existing = detailCache.get(id)
+	if (existing !== undefined) return existing
+	const atom = makeDetailAtom(id)
+	detailCache.set(id, atom)
+	return atom
+}

--- a/apps/internal/src/components/companies/documents-panel.tsx
+++ b/apps/internal/src/components/companies/documents-panel.tsx
@@ -2,12 +2,14 @@ import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
+import { Link } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { FileText, Pencil, Plus, X } from 'lucide-react'
 import { type FormEvent, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
+import type { DocumentSubjectTable } from '@batuda/domain'
 import {
 	PriButton,
 	PriDialog,
@@ -36,12 +38,13 @@ const documentsDlgSchema = Schema.Union(documentsDlgMembers)
 type DocRow = {
 	readonly id: string
 	readonly type: string
+	readonly format: string
 	readonly title: string | null
-	readonly content: string
+	readonly snippet: string
 	readonly updatedAt: string | null
 }
 
-// The document kinds the picker offers; `type` is free text server-side.
+// The document kinds the picker offers, matching the list the server accepts.
 const DOC_TYPES: ReadonlyArray<{
 	readonly value: string
 	readonly label: MessageDescriptor
@@ -71,12 +74,28 @@ function narrowDocs(rows: ReadonlyArray<unknown>): ReadonlyArray<DocRow> {
 		out.push({
 			id: r['id'],
 			type: typeof r['type'] === 'string' ? r['type'] : 'general',
+			format: r['format'] === 'html' ? 'html' : 'markdown',
 			title: typeof r['title'] === 'string' ? r['title'] : null,
-			content: typeof r['content'] === 'string' ? r['content'] : '',
+			snippet: typeof r['snippet'] === 'string' ? r['snippet'] : '',
 			updatedAt: dateToIsoOrNull(r['updatedAt']),
 		})
 	}
 	return out
+}
+
+type DocBody = {
+	readonly content: string
+	readonly htmlUrl: string | null
+}
+
+function narrowBody(value: unknown): DocBody | null {
+	if (!value || typeof value !== 'object') return null
+	const r = value as Record<string, unknown>
+	if (typeof r['content'] !== 'string') return null
+	return {
+		content: r['content'],
+		htmlUrl: typeof r['htmlUrl'] === 'string' ? r['htmlUrl'] : null,
+	}
 }
 
 type DialogState =
@@ -85,12 +104,26 @@ type DialogState =
 	| { readonly mode: 'edit'; readonly doc: DocRow }
 	| { readonly mode: 'add' }
 
-/** List, read, create, and edit a company's documents (markdown), on the Files tab. */
-export function DocumentsPanel({ companyId }: { readonly companyId: string }) {
+/**
+ * List, read, write and delete the documents filed against one record.
+ *
+ * The record is whatever it is handed — a company, a person, a task, an offer,
+ * a meeting — so the same panel serves every surface that keeps notes.
+ */
+export function DocumentsPanel({
+	subjectTable,
+	subjectId,
+}: {
+	readonly subjectTable: DocumentSubjectTable
+	readonly subjectId: string
+}) {
 	const { i18n, t } = useLingui()
 	const docsAtom = useMemo(
-		() => BatudaApiAtom.query('documents', 'list', { query: { companyId } }),
-		[companyId],
+		() =>
+			BatudaApiAtom.query('documents', 'list', {
+				query: { subjectTable, subjectId },
+			}),
+		[subjectTable, subjectId],
 	)
 	const result = useAtomValue(docsAtom)
 	const refresh = useAtomRefresh(docsAtom)
@@ -163,37 +196,73 @@ export function DocumentsPanel({ companyId }: { readonly companyId: string }) {
 				</List>
 			)}
 
-			<DocumentDialog
-				state={dialog}
-				companyId={companyId}
-				onClose={closeDlg}
-				onSaved={() => {
-					refresh()
-					closeDlg()
-				}}
-				// Reading and editing the same document are one step, so Back leaves
-				// the document instead of returning to the read view.
-				onEdit={doc =>
-					openDlg({ kind: 'doc-edit', id: doc.id }, { replace: true })
-				}
-			/>
+			{dialog.mode === 'closed' ? null : (
+				<DocumentDialogHost
+					state={dialog}
+					subjectTable={subjectTable}
+					subjectId={subjectId}
+					onClose={closeDlg}
+					onSaved={() => {
+						refresh()
+						closeDlg()
+					}}
+					// Reading and editing the same document are one step, so Back
+					// leaves the document instead of returning to the read view.
+					onEdit={doc =>
+						openDlg({ kind: 'doc-edit', id: doc.id }, { replace: true })
+					}
+				/>
+			)}
 		</>
 	)
 }
 
-function DocumentDialog({
-	state,
-	companyId,
-	onClose,
-	onSaved,
-	onEdit,
-}: {
-	readonly state: DialogState
-	readonly companyId: string
+// The host is only rendered while a dialog is open, so everything below it can
+// count on there being something to show.
+type OpenDialogState = Exclude<DialogState, { readonly mode: 'closed' }>
+
+type DialogProps = {
+	readonly state: OpenDialogState
+	readonly subjectTable: DocumentSubjectTable
+	readonly subjectId: string
 	readonly onClose: () => void
 	readonly onSaved: () => void
 	readonly onEdit: (doc: DocRow) => void
-}) {
+}
+
+/**
+ * Fetches the body only when there is a document to read.
+ *
+ * The list carries a snippet, not the whole document, so reading or editing one
+ * needs a second request — but writing a new one does not, and a component that
+ * always asked would fetch on every open of the Add dialog for nothing.
+ */
+function DocumentDialogHost(props: DialogProps) {
+	if (props.state.mode === 'add') {
+		return <DocumentDialog {...props} body={{ content: '', htmlUrl: null }} />
+	}
+	return <DocumentDialogWithBody {...props} id={props.state.doc.id} />
+}
+
+function DocumentDialogWithBody(props: DialogProps & { readonly id: string }) {
+	const bodyAtom = useMemo(
+		() => BatudaApiAtom.query('documents', 'get', { params: { id: props.id } }),
+		[props.id],
+	)
+	const result = useAtomValue(bodyAtom)
+	const body = AsyncResult.isSuccess(result) ? narrowBody(result.value) : null
+	return <DocumentDialog {...props} body={body} />
+}
+
+function DocumentDialog({
+	state,
+	subjectTable,
+	subjectId,
+	body,
+	onClose,
+	onSaved,
+	onEdit,
+}: DialogProps & { readonly body: DocBody | null }) {
 	const { i18n, t } = useLingui()
 	const toast = usePriToast()
 	const create = useAtomSet(BatudaApiAtom.mutation('documents', 'create'), {
@@ -204,23 +273,28 @@ function DocumentDialog({
 	})
 
 	const editing = state.mode === 'edit' ? state.doc : null
+
 	const [title, setTitle] = useState('')
 	const [type, setType] = useState('general')
 	const [content, setContent] = useState('')
 	const [busy, setBusy] = useState(false)
 
-	// Re-seed the form each time the dialog opens for a different doc/mode.
-	const formKey = state.mode === 'edit' ? state.doc.id : state.mode
+	// Re-seed the form each time the dialog opens for a different doc/mode, and
+	// again once the body has arrived for the one being edited — until then the
+	// box would hold nothing, and saving would wipe the document.
+	const formKey =
+		state.mode === 'edit'
+			? `${state.doc.id}:${body === null ? 'loading' : 'ready'}`
+			: state.mode
 	const seededKey = useRef<string | null>(null)
 	if (seededKey.current !== formKey) {
 		seededKey.current = formKey
 		setTitle(editing?.title ?? '')
 		setType(editing?.type ?? 'general')
-		setContent(editing?.content ?? '')
+		setContent(body?.content ?? '')
 		setBusy(false)
 	}
 
-	const open = state.mode !== 'closed'
 	const isForm = state.mode === 'add' || state.mode === 'edit'
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -238,7 +312,8 @@ function DocumentDialog({
 				} as never)
 			: await create({
 					payload: {
-						companyId,
+						subjectTable,
+						subjectId,
 						type,
 						...(trimmedTitle ? { title: trimmedTitle } : {}),
 						content,
@@ -253,7 +328,7 @@ function DocumentDialog({
 	}
 
 	return (
-		<PriDialog.Root open={open} onOpenChange={next => !next && onClose()}>
+		<PriDialog.Root open onOpenChange={next => !next && onClose()}>
 			<PriDialog.Portal>
 				<PriDialog.Backdrop />
 				<PriDialog.Popup data-testid='document-dialog'>
@@ -286,16 +361,59 @@ function DocumentDialog({
 								aria-label={t`Document`}
 								tabIndex={0}
 							>
-								<MarkdownView source={state.doc.content} />
+								{state.doc.format === 'html' ? (
+									// A web page opens in its own tab, exactly as it was
+									// saved. Showing it here would mean stripping it down
+									// to something safe to put beside the rest of the app,
+									// and a stripped page is not what someone opening a
+									// report wants to see.
+									<HtmlNotice>
+										<Trans>
+											This document is a web page. It opens in a new tab.
+										</Trans>
+										<PriButton
+											type='button'
+											$variant='filled'
+											data-testid='document-open-original'
+											disabled={body?.htmlUrl == null}
+											onClick={() => {
+												if (body?.htmlUrl != null) {
+													window.open(
+														body.htmlUrl,
+														'_blank',
+														'noopener,noreferrer',
+													)
+												}
+											}}
+										>
+											<Trans>Open the page</Trans>
+										</PriButton>
+									</HtmlNotice>
+								) : (
+									<MarkdownView source={body?.content ?? state.doc.snippet} />
+								)}
 							</ViewBody>
 							<Footer>
-								<PriButton
-									type='button'
-									$variant='filled'
-									onClick={() => onEdit(state.doc)}
-								>
-									<Trans>Edit</Trans>
-								</PriButton>
+								{state.doc.format === 'html' ? null : (
+									<PriButton
+										type='button'
+										$variant='filled'
+										onClick={() => onEdit(state.doc)}
+									>
+										<Trans>Edit</Trans>
+									</PriButton>
+								)}
+								{/* This popup is for a quick look. The page behind the
+								    link is the one that can be sent to somebody. */}
+								<FullPageLink>
+									<Link
+										to='/documents/$id'
+										params={{ id: state.doc.id }}
+										data-testid='document-open-full-page'
+									>
+										<Trans>Open full page</Trans>
+									</Link>
+								</FullPageLink>
 							</Footer>
 						</>
 					) : isForm ? (
@@ -527,4 +645,25 @@ const Footer = styled.div`
 	gap: var(--space-sm);
 	justify-content: flex-end;
 	margin-top: var(--space-sm);
+`
+
+const HtmlNotice = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--space-md);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-sm);
+`
+
+// Styling wraps the link rather than the router's own component, whose typed
+// route parameters do not survive being wrapped.
+const FullPageLink = styled.span`
+	align-self: center;
+
+	a {
+		color: var(--color-primary);
+		font-size: var(--font-size-sm);
+		text-decoration: underline;
+	}
 `

--- a/apps/internal/src/components/companies/proposals-panel.tsx
+++ b/apps/internal/src/components/companies/proposals-panel.tsx
@@ -8,14 +8,9 @@ import { FileSignature, Plus, X } from 'lucide-react'
 import { type FormEvent, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import {
-	PriButton,
-	PriDialog,
-	PriInput,
-	PriTextarea,
-	usePriToast,
-} from '@batuda/ui/pri'
+import { PriButton, PriDialog, PriInput, usePriToast } from '@batuda/ui/pri'
 
+import { SubjectDocuments } from '#/components/documents/subject-documents'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
@@ -38,7 +33,6 @@ type ProposalRow = {
 	readonly status: string
 	readonly totalValue: string | null
 	readonly currency: string | null
-	readonly notes: string | null
 	readonly expiresAt: string | null
 	readonly updatedAt: string | null
 	readonly lineItems: unknown
@@ -134,7 +128,6 @@ function narrowProposals(
 			status: typeof r['status'] === 'string' ? r['status'] : 'draft',
 			totalValue: typeof r['totalValue'] === 'string' ? r['totalValue'] : null,
 			currency: typeof r['currency'] === 'string' ? r['currency'] : null,
-			notes: typeof r['notes'] === 'string' ? r['notes'] : null,
 			expiresAt: dateToIsoOrNull(r['expiresAt']),
 			updatedAt: dateToIsoOrNull(r['updatedAt']),
 			lineItems: r['lineItems'] ?? null,
@@ -269,7 +262,6 @@ function ProposalDialog({
 	const [status, setStatus] = useState('draft')
 	const [currency, setCurrency] = useState('EUR')
 	const [expiresAt, setExpiresAt] = useState('')
-	const [notes, setNotes] = useState('')
 	const [lineItems, setLineItems] = useState<ReadonlyArray<LineItem>>([])
 	const [busy, setBusy] = useState(false)
 
@@ -281,7 +273,6 @@ function ProposalDialog({
 		setStatus(editing?.status ?? 'draft')
 		setCurrency(editing?.currency ?? 'EUR')
 		setExpiresAt(editing?.expiresAt ? editing.expiresAt.slice(0, 10) : '')
-		setNotes(editing?.notes ?? '')
 		setLineItems(editing ? narrowLineItems(editing.lineItems) : [])
 		setBusy(false)
 	}
@@ -323,7 +314,6 @@ function ProposalDialog({
 						status,
 						lineItems: cleanItems,
 						...(totalValue ? { totalValue } : {}),
-						notes,
 					},
 				} as never)
 			: await create({
@@ -334,7 +324,6 @@ function ProposalDialog({
 						currency,
 						...(totalValue ? { totalValue } : {}),
 						...(expiresAt ? { expiresAt } : {}),
-						...(notes.trim() ? { notes } : {}),
 					},
 				} as never)
 		setBusy(false)
@@ -494,18 +483,12 @@ function ProposalDialog({
 								/>
 							</Field>
 						)}
-						<Field>
-							<Label htmlFor='proposal-notes'>
-								<Trans>Notes (optional)</Trans>
-							</Label>
-							<PriTextarea
-								id='proposal-notes'
-								data-testid='proposal-notes'
-								value={notes}
-								rows={4}
-								onChange={e => setNotes(e.target.value)}
+						{editing === null ? null : (
+							<SubjectDocuments
+								subjectTable='proposals'
+								subjectId={editing.id}
 							/>
-						</Field>
+						)}
 						<Footer>
 							<PriButton
 								type='submit'

--- a/apps/internal/src/components/contacts/contact-edit-dialog.tsx
+++ b/apps/internal/src/components/contacts/contact-edit-dialog.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 
 import { PriButton, PriDialog, PriInput, usePriToast } from '@batuda/ui/pri'
 
+import { SubjectDocuments } from '#/components/documents/subject-documents'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import { stenciledTitle } from '#/lib/workshop-mixins'
 
@@ -174,6 +175,9 @@ export function ContactEditDialog({
 							/>
 						</Footer>
 					</Form>
+					{contact === null ? null : (
+						<SubjectDocuments subjectTable='contacts' subjectId={contact.id} />
+					)}
 				</PriDialog.Popup>
 			</PriDialog.Portal>
 		</PriDialog.Root>

--- a/apps/internal/src/components/documents/document-kinds.ts
+++ b/apps/internal/src/components/documents/document-kinds.ts
@@ -1,0 +1,16 @@
+import type { MessageDescriptor } from '@lingui/core'
+import { msg } from '@lingui/core/macro'
+
+// What each kind of document is called on screen. Shared so a document reads
+// the same in a list, on its own page and in a picker.
+export const DOCUMENT_KIND_LABELS: ReadonlyArray<{
+	readonly value: string
+	readonly label: MessageDescriptor
+}> = [
+	{ value: 'general', label: msg`General` },
+	{ value: 'prenote', label: msg`Meeting prep` },
+	{ value: 'postnote', label: msg`Meeting notes` },
+	{ value: 'call_notes', label: msg`Call notes` },
+	{ value: 'visit_notes', label: msg`Visit notes` },
+	{ value: 'research', label: msg`Research` },
+]

--- a/apps/internal/src/components/documents/subject-documents.tsx
+++ b/apps/internal/src/components/documents/subject-documents.tsx
@@ -1,0 +1,93 @@
+import { useAtomValue } from '@effect/atom-react'
+import { Trans } from '@lingui/react/macro'
+import { Link } from '@tanstack/react-router'
+import { AsyncResult } from 'effect/unstable/reactivity'
+import { useMemo } from 'react'
+import styled from 'styled-components'
+
+import type { DocumentSubjectTable } from '@batuda/domain'
+
+import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+
+/**
+ * What has been written about one record, for somewhere there is no room to
+ * write.
+ *
+ * A person, a task, an offer and a meeting are each shown in a popup rather
+ * than on a page of their own, and a popup cannot hold another popup — so this
+ * only lists, and every row leaves for the document's own page. Writing happens
+ * on the company page or through an agent.
+ */
+export function SubjectDocuments({
+	subjectTable,
+	subjectId,
+}: {
+	readonly subjectTable: DocumentSubjectTable
+	readonly subjectId: string
+}) {
+	const atom = useMemo(
+		() =>
+			BatudaApiAtom.query('documents', 'list', {
+				query: { subjectTable, subjectId, limit: 10 },
+				serializationKey: `documents:${subjectTable}:${subjectId}`,
+			}),
+		[subjectTable, subjectId],
+	)
+	const result = useAtomValue(atom)
+	const items = AsyncResult.isSuccess(result) ? result.value.items : []
+
+	// Nothing written yet is the ordinary case here, and an empty heading in
+	// every popup is noise.
+	if (items.length === 0) return null
+
+	return (
+		<Section data-testid={`subject-documents-${subjectTable}`}>
+			<Heading>
+				<Trans>Documents</Trans>
+			</Heading>
+			<List>
+				{items.map(doc => (
+					<li key={doc.id}>
+						<Link
+							to='/documents/$id'
+							params={{ id: doc.id }}
+							data-testid={`subject-document-${doc.id}`}
+						>
+							{doc.title ?? doc.type}
+						</Link>
+					</li>
+				))}
+			</List>
+		</Section>
+	)
+}
+
+const Section = styled.section`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	margin-top: var(--space-md);
+`
+
+const Heading = styled.h3`
+	margin: 0;
+	color: var(--color-text-muted);
+	font-size: var(--font-size-xs);
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+`
+
+const List = styled.ul`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+
+	a {
+		color: var(--color-primary);
+		font-size: var(--font-size-sm);
+		text-decoration: underline;
+	}
+`

--- a/apps/internal/src/components/layout/nav-items.ts
+++ b/apps/internal/src/components/layout/nav-items.ts
@@ -5,6 +5,7 @@ import {
 	Calendar,
 	CheckSquare,
 	FileText,
+	FileType,
 	FolderOpen,
 	Gauge,
 	Mail,
@@ -65,6 +66,13 @@ export const navItems: ReadonlyArray<NavItem> = [
 		icon: Mail,
 		color: 'var(--color-status-contacted)',
 		testId: 'emails',
+	},
+	{
+		label: msg`Documents`,
+		path: '/documents',
+		icon: FileType,
+		color: 'var(--color-status-proposal)',
+		testId: 'documents',
 	},
 	{
 		label: msg`Pages`,
@@ -137,6 +145,7 @@ export const navGroups: ReadonlyArray<NavGroup> = [
 		items: [
 			itemByPath('/companies'),
 			itemByPath('/research'),
+			itemByPath('/documents'),
 			itemByPath('/pages'),
 		],
 	},

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -174,6 +174,10 @@ msgstr "{total} empreses"
 msgid "{total} companies with filters applied"
 msgstr "{total} empreses amb filtres aplicats"
 
+#: src/routes/documents/index.tsx
+msgid "{total} documents"
+msgstr "{total} documents"
+
 #: src/routes/emails/index.tsx
 msgid "{total} threads"
 msgstr "{total} fils"
@@ -786,6 +790,7 @@ msgid "Call"
 msgstr "Trucada"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Call notes"
 msgstr "Notes de trucada"
 
@@ -1309,6 +1314,10 @@ msgstr "No s'han pogut carregar aquestes tasques"
 msgid "Could not load this company"
 msgstr "No s'ha pogut carregar aquesta empresa"
 
+#: src/routes/documents/$id.tsx
+msgid "Could not load this document"
+msgstr "No s'ha pogut carregar aquest document"
+
 #: src/routes/pages/$id.tsx
 msgid "Could not load this page"
 msgstr "No s'ha pogut carregar aquesta pàgina"
@@ -1804,10 +1813,15 @@ msgstr "Nom a mostrar"
 #: src/components/companies/documents-panel.tsx
 #: src/components/companies/documents-panel.tsx
 #: src/components/shared/channel-icon.tsx
+#: src/routes/documents/$id.tsx
 msgid "Document"
 msgstr "Document"
 
+#: src/components/documents/subject-documents.tsx
+#: src/components/layout/nav-items.ts
 #: src/routes/companies/$slug.tsx
+#: src/routes/documents/index.tsx
+#: src/routes/documents/index.tsx
 msgid "Documents"
 msgstr "Documents"
 
@@ -2070,6 +2084,10 @@ msgstr "Error"
 msgid "Event"
 msgstr "Esdeveniment"
 
+#: src/routes/documents/index.tsx
+msgid "Every kind"
+msgstr "Tots els tipus"
+
 #: src/routes/tasks/index.tsx
 msgid "Every open task has a due date assigned."
 msgstr "Totes les tasques obertes tenen data de venciment."
@@ -2265,6 +2283,7 @@ msgid "Gathering evidence."
 msgstr "Recollint proves."
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "General"
 msgstr "General"
 
@@ -2584,10 +2603,6 @@ msgstr "Les actualitzacions en directe s'han aturat. Potser l'execució encara t
 msgid "Live updates paused. This run may still be working — refresh to check its latest status."
 msgstr "Actualitzacions en directe pausades. Aquesta execució encara pot estar treballant — actualitza per veure el seu estat més recent."
 
-#: src/components/companies/pipeline-board.tsx
-#~ msgid "Load {0} more"
-#~ msgstr "Carrega'n {0} més"
-
 #: src/components/shared/infinite-list-footer.tsx
 msgid "Load more"
 msgstr "Carrega'n més"
@@ -2816,10 +2831,12 @@ msgid "Meeting booked"
 msgstr "Reunió programada"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Meeting notes"
 msgstr "Notes de reunió"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Meeting prep"
 msgstr "Preparació de reunió"
 
@@ -3308,10 +3325,6 @@ msgstr "Nota"
 msgid "Notes"
 msgstr "Notes"
 
-#: src/components/companies/proposals-panel.tsx
-msgid "Notes (optional)"
-msgstr "Notes (opcional)"
-
 #: src/routes/tasks/index.tsx
 msgid "Nothing changed yet."
 msgstr "Encara no ha canviat res."
@@ -3352,6 +3365,10 @@ msgstr "Ara mateix no hi ha res per revisar."
 msgid "Nothing to show in this range."
 msgstr "Res a mostrar en aquest interval."
 
+#: src/routes/documents/index.tsx
+msgid "Nothing written down matches that."
+msgstr "No hi ha res escrit que hi coincideixi."
+
 #: src/components/primitives/pri-rich-text.tsx
 msgid "Numbered list"
 msgstr "Llista numerada"
@@ -3391,6 +3408,10 @@ msgstr "Obre {0}"
 #: src/routes/calendar/index.tsx
 msgid "Open company"
 msgstr "Obre l'empresa"
+
+#: src/components/companies/documents-panel.tsx
+msgid "Open full page"
+msgstr "Obre la pàgina completa"
 
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "Open in Cal.com"
@@ -3439,6 +3460,11 @@ msgstr "Tasques obertes"
 #: src/routes/settings/organization/index.tsx
 msgid "Open the org spend dashboard"
 msgstr "Obre el panell de despesa de l'organització"
+
+#: src/components/companies/documents-panel.tsx
+#: src/routes/documents/$id.tsx
+msgid "Open the page"
+msgstr "Obre la pàgina"
 
 #: src/components/research/inbox/paid-action-queue.tsx
 msgid "Open the run asking for this lookup"
@@ -4107,6 +4133,7 @@ msgstr "Demana un enllaç nou"
 
 #: src/components/companies/documents-panel.tsx
 #: src/components/companies/research-summary-card.tsx
+#: src/components/documents/document-kinds.ts
 #: src/components/instructions/agent-selector.tsx
 #: src/components/layout/nav-items.ts
 #: src/components/research/inbox/research-inbox.tsx
@@ -4320,6 +4347,10 @@ msgstr "Cerca a la cua de revisió"
 #: src/routes/emails/index.tsx
 msgid "Search threads"
 msgstr "Cerca fils"
+
+#: src/routes/documents/index.tsx
+msgid "Search titles and text"
+msgstr "Cerca en títols i text"
 
 #: src/components/research/run-progress.tsx
 msgid "Searching and reasoning"
@@ -4801,10 +4832,6 @@ msgstr "Títol de la tasca"
 msgid "Tasks"
 msgstr "Tasques"
 
-#: src/routes/tasks/index.tsx
-#~ msgid "tasks — showing {0} of {shelfTotal}"
-#~ msgstr "tasques: es mostren {0} de {shelfTotal}"
-
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/run-labels.ts
 msgid "Tax ID"
@@ -5070,6 +5097,14 @@ msgstr "Aquesta empresa no es pot mostrar"
 msgid "This connection is unbound. Bind an org to use it."
 msgstr "Aquesta connexió no està vinculada. Vincula una organització per fer-la servir."
 
+#: src/components/companies/documents-panel.tsx
+msgid "This document is a web page. It opens in a new tab."
+msgstr "Aquest document és una pàgina web. S'obre en una pestanya nova."
+
+#: src/routes/documents/$id.tsx
+msgid "This document is a web page. It opens in a tab of its own, exactly as it was saved."
+msgstr "Aquest document és una pàgina web. S'obre en una pestanya pròpia, tal com es va desar."
+
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "This is not the same as having none. Try again to see what is scheduled."
 msgstr "Això no vol dir que no n'hi hagi cap. Torna-ho a provar per veure què hi ha programat."
@@ -5274,6 +5309,10 @@ msgstr "Canvis sense desar"
 msgid "Untitled"
 msgstr "Sense títol"
 
+#: src/routes/documents/$id.tsx
+msgid "Untitled document"
+msgstr "Document sense títol"
+
 #: src/routes/settings/api-keys/index.tsx
 msgid "Untitled key"
 msgstr "Clau sense títol"
@@ -5397,6 +5436,7 @@ msgid "Visit"
 msgstr "Visita"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Visit notes"
 msgstr "Notes de visita"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -174,6 +174,10 @@ msgstr "{total} companies"
 msgid "{total} companies with filters applied"
 msgstr "{total} companies with filters applied"
 
+#: src/routes/documents/index.tsx
+msgid "{total} documents"
+msgstr "{total} documents"
+
 #: src/routes/emails/index.tsx
 msgid "{total} threads"
 msgstr "{total} threads"
@@ -786,6 +790,7 @@ msgid "Call"
 msgstr "Call"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Call notes"
 msgstr "Call notes"
 
@@ -1309,6 +1314,10 @@ msgstr "Could not load these tasks"
 msgid "Could not load this company"
 msgstr "Could not load this company"
 
+#: src/routes/documents/$id.tsx
+msgid "Could not load this document"
+msgstr "Could not load this document"
+
 #: src/routes/pages/$id.tsx
 msgid "Could not load this page"
 msgstr "Could not load this page"
@@ -1804,10 +1813,15 @@ msgstr "Display name"
 #: src/components/companies/documents-panel.tsx
 #: src/components/companies/documents-panel.tsx
 #: src/components/shared/channel-icon.tsx
+#: src/routes/documents/$id.tsx
 msgid "Document"
 msgstr "Document"
 
+#: src/components/documents/subject-documents.tsx
+#: src/components/layout/nav-items.ts
 #: src/routes/companies/$slug.tsx
+#: src/routes/documents/index.tsx
+#: src/routes/documents/index.tsx
 msgid "Documents"
 msgstr "Documents"
 
@@ -2070,6 +2084,10 @@ msgstr "Error"
 msgid "Event"
 msgstr "Event"
 
+#: src/routes/documents/index.tsx
+msgid "Every kind"
+msgstr "Every kind"
+
 #: src/routes/tasks/index.tsx
 msgid "Every open task has a due date assigned."
 msgstr "Every open task has a due date assigned."
@@ -2265,6 +2283,7 @@ msgid "Gathering evidence."
 msgstr "Gathering evidence."
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "General"
 msgstr "General"
 
@@ -2584,10 +2603,6 @@ msgstr "Live updates have stopped. The run may still be working."
 msgid "Live updates paused. This run may still be working — refresh to check its latest status."
 msgstr "Live updates paused. This run may still be working — refresh to check its latest status."
 
-#: src/components/companies/pipeline-board.tsx
-#~ msgid "Load {0} more"
-#~ msgstr "Load {0} more"
-
 #: src/components/shared/infinite-list-footer.tsx
 msgid "Load more"
 msgstr "Load more"
@@ -2816,10 +2831,12 @@ msgid "Meeting booked"
 msgstr "Meeting booked"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Meeting notes"
 msgstr "Meeting notes"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Meeting prep"
 msgstr "Meeting prep"
 
@@ -3308,10 +3325,6 @@ msgstr "Note"
 msgid "Notes"
 msgstr "Notes"
 
-#: src/components/companies/proposals-panel.tsx
-msgid "Notes (optional)"
-msgstr "Notes (optional)"
-
 #: src/routes/tasks/index.tsx
 msgid "Nothing changed yet."
 msgstr "Nothing changed yet."
@@ -3352,6 +3365,10 @@ msgstr "Nothing to review right now."
 msgid "Nothing to show in this range."
 msgstr "Nothing to show in this range."
 
+#: src/routes/documents/index.tsx
+msgid "Nothing written down matches that."
+msgstr "Nothing written down matches that."
+
 #: src/components/primitives/pri-rich-text.tsx
 msgid "Numbered list"
 msgstr "Numbered list"
@@ -3391,6 +3408,10 @@ msgstr "Open {0}"
 #: src/routes/calendar/index.tsx
 msgid "Open company"
 msgstr "Open company"
+
+#: src/components/companies/documents-panel.tsx
+msgid "Open full page"
+msgstr "Open full page"
 
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "Open in Cal.com"
@@ -3439,6 +3460,11 @@ msgstr "Open tasks"
 #: src/routes/settings/organization/index.tsx
 msgid "Open the org spend dashboard"
 msgstr "Open the org spend dashboard"
+
+#: src/components/companies/documents-panel.tsx
+#: src/routes/documents/$id.tsx
+msgid "Open the page"
+msgstr "Open the page"
 
 #: src/components/research/inbox/paid-action-queue.tsx
 msgid "Open the run asking for this lookup"
@@ -4107,6 +4133,7 @@ msgstr "Request a new link"
 
 #: src/components/companies/documents-panel.tsx
 #: src/components/companies/research-summary-card.tsx
+#: src/components/documents/document-kinds.ts
 #: src/components/instructions/agent-selector.tsx
 #: src/components/layout/nav-items.ts
 #: src/components/research/inbox/research-inbox.tsx
@@ -4320,6 +4347,10 @@ msgstr "Search the review queue"
 #: src/routes/emails/index.tsx
 msgid "Search threads"
 msgstr "Search threads"
+
+#: src/routes/documents/index.tsx
+msgid "Search titles and text"
+msgstr "Search titles and text"
 
 #: src/components/research/run-progress.tsx
 msgid "Searching and reasoning"
@@ -4801,10 +4832,6 @@ msgstr "Task title"
 msgid "Tasks"
 msgstr "Tasks"
 
-#: src/routes/tasks/index.tsx
-#~ msgid "tasks — showing {0} of {shelfTotal}"
-#~ msgstr "tasks — showing {0} of {shelfTotal}"
-
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/run-labels.ts
 msgid "Tax ID"
@@ -5070,6 +5097,14 @@ msgstr "This company can't be displayed"
 msgid "This connection is unbound. Bind an org to use it."
 msgstr "This connection is unbound. Bind an org to use it."
 
+#: src/components/companies/documents-panel.tsx
+msgid "This document is a web page. It opens in a new tab."
+msgstr "This document is a web page. It opens in a new tab."
+
+#: src/routes/documents/$id.tsx
+msgid "This document is a web page. It opens in a tab of its own, exactly as it was saved."
+msgstr "This document is a web page. It opens in a tab of its own, exactly as it was saved."
+
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "This is not the same as having none. Try again to see what is scheduled."
 msgstr "This is not the same as having none. Try again to see what is scheduled."
@@ -5274,6 +5309,10 @@ msgstr "Unsaved changes"
 msgid "Untitled"
 msgstr "Untitled"
 
+#: src/routes/documents/$id.tsx
+msgid "Untitled document"
+msgstr "Untitled document"
+
 #: src/routes/settings/api-keys/index.tsx
 msgid "Untitled key"
 msgstr "Untitled key"
@@ -5397,6 +5436,7 @@ msgid "Visit"
 msgstr "Visit"
 
 #: src/components/companies/documents-panel.tsx
+#: src/components/documents/document-kinds.ts
 msgid "Visit notes"
 msgstr "Visit notes"
 

--- a/apps/internal/src/routeTree.gen.ts
+++ b/apps/internal/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ResearchIndexRouteImport } from './routes/research/index'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
 import { Route as PagesIndexRouteImport } from './routes/pages/index'
 import { Route as EmailsIndexRouteImport } from './routes/emails/index'
+import { Route as DocumentsIndexRouteImport } from './routes/documents/index'
 import { Route as CompaniesIndexRouteImport } from './routes/companies/index'
 import { Route as CalendarIndexRouteImport } from './routes/calendar/index'
 import { Route as ResearchRunsRouteImport } from './routes/research/runs'
@@ -27,6 +28,7 @@ import { Route as PagesIdRouteImport } from './routes/pages/$id'
 import { Route as OauthConsentRouteImport } from './routes/oauth/consent'
 import { Route as EmailsInboxesRouteImport } from './routes/emails/inboxes'
 import { Route as EmailsThreadIdRouteImport } from './routes/emails/$threadId'
+import { Route as DocumentsIdRouteImport } from './routes/documents/$id'
 import { Route as CompaniesBoardRouteImport } from './routes/companies/board'
 import { Route as CompaniesSlugRouteImport } from './routes/companies/$slug'
 import { Route as SettingsProfileIndexRouteImport } from './routes/settings/profile/index'
@@ -90,6 +92,11 @@ const EmailsIndexRoute = EmailsIndexRouteImport.update({
   path: '/emails/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DocumentsIndexRoute = DocumentsIndexRouteImport.update({
+  id: '/documents/',
+  path: '/documents/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CompaniesIndexRoute = CompaniesIndexRouteImport.update({
   id: '/companies/',
   path: '/companies/',
@@ -128,6 +135,11 @@ const EmailsInboxesRoute = EmailsInboxesRouteImport.update({
 const EmailsThreadIdRoute = EmailsThreadIdRouteImport.update({
   id: '/emails/$threadId',
   path: '/emails/$threadId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DocumentsIdRoute = DocumentsIdRouteImport.update({
+  id: '/documents/$id',
+  path: '/documents/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CompaniesBoardRoute = CompaniesBoardRouteImport.update({
@@ -204,6 +216,7 @@ export interface FileRoutesByFullPath {
   '/reset-password': typeof ResetPasswordRoute
   '/companies/$slug': typeof CompaniesSlugRoute
   '/companies/board': typeof CompaniesBoardRoute
+  '/documents/$id': typeof DocumentsIdRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
   '/emails/inboxes': typeof EmailsInboxesRoute
   '/oauth/consent': typeof OauthConsentRoute
@@ -212,6 +225,7 @@ export interface FileRoutesByFullPath {
   '/research/runs': typeof ResearchRunsRoute
   '/calendar/': typeof CalendarIndexRoute
   '/companies/': typeof CompaniesIndexRoute
+  '/documents/': typeof DocumentsIndexRoute
   '/emails/': typeof EmailsIndexRoute
   '/pages/': typeof PagesIndexRoute
   '/profile/': typeof ProfileIndexRoute
@@ -236,6 +250,7 @@ export interface FileRoutesByTo {
   '/reset-password': typeof ResetPasswordRoute
   '/companies/$slug': typeof CompaniesSlugRoute
   '/companies/board': typeof CompaniesBoardRoute
+  '/documents/$id': typeof DocumentsIdRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
   '/emails/inboxes': typeof EmailsInboxesRoute
   '/oauth/consent': typeof OauthConsentRoute
@@ -244,6 +259,7 @@ export interface FileRoutesByTo {
   '/research/runs': typeof ResearchRunsRoute
   '/calendar': typeof CalendarIndexRoute
   '/companies': typeof CompaniesIndexRoute
+  '/documents': typeof DocumentsIndexRoute
   '/emails': typeof EmailsIndexRoute
   '/pages': typeof PagesIndexRoute
   '/profile': typeof ProfileIndexRoute
@@ -269,6 +285,7 @@ export interface FileRoutesById {
   '/reset-password': typeof ResetPasswordRoute
   '/companies/$slug': typeof CompaniesSlugRoute
   '/companies/board': typeof CompaniesBoardRoute
+  '/documents/$id': typeof DocumentsIdRoute
   '/emails/$threadId': typeof EmailsThreadIdRoute
   '/emails/inboxes': typeof EmailsInboxesRoute
   '/oauth/consent': typeof OauthConsentRoute
@@ -277,6 +294,7 @@ export interface FileRoutesById {
   '/research/runs': typeof ResearchRunsRoute
   '/calendar/': typeof CalendarIndexRoute
   '/companies/': typeof CompaniesIndexRoute
+  '/documents/': typeof DocumentsIndexRoute
   '/emails/': typeof EmailsIndexRoute
   '/pages/': typeof PagesIndexRoute
   '/profile/': typeof ProfileIndexRoute
@@ -303,6 +321,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/companies/$slug'
     | '/companies/board'
+    | '/documents/$id'
     | '/emails/$threadId'
     | '/emails/inboxes'
     | '/oauth/consent'
@@ -311,6 +330,7 @@ export interface FileRouteTypes {
     | '/research/runs'
     | '/calendar/'
     | '/companies/'
+    | '/documents/'
     | '/emails/'
     | '/pages/'
     | '/profile/'
@@ -335,6 +355,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/companies/$slug'
     | '/companies/board'
+    | '/documents/$id'
     | '/emails/$threadId'
     | '/emails/inboxes'
     | '/oauth/consent'
@@ -343,6 +364,7 @@ export interface FileRouteTypes {
     | '/research/runs'
     | '/calendar'
     | '/companies'
+    | '/documents'
     | '/emails'
     | '/pages'
     | '/profile'
@@ -367,6 +389,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/companies/$slug'
     | '/companies/board'
+    | '/documents/$id'
     | '/emails/$threadId'
     | '/emails/inboxes'
     | '/oauth/consent'
@@ -375,6 +398,7 @@ export interface FileRouteTypes {
     | '/research/runs'
     | '/calendar/'
     | '/companies/'
+    | '/documents/'
     | '/emails/'
     | '/pages/'
     | '/profile/'
@@ -400,6 +424,7 @@ export interface RootRouteChildren {
   ResetPasswordRoute: typeof ResetPasswordRoute
   CompaniesSlugRoute: typeof CompaniesSlugRoute
   CompaniesBoardRoute: typeof CompaniesBoardRoute
+  DocumentsIdRoute: typeof DocumentsIdRoute
   EmailsThreadIdRoute: typeof EmailsThreadIdRoute
   EmailsInboxesRoute: typeof EmailsInboxesRoute
   OauthConsentRoute: typeof OauthConsentRoute
@@ -408,6 +433,7 @@ export interface RootRouteChildren {
   ResearchRunsRoute: typeof ResearchRunsRoute
   CalendarIndexRoute: typeof CalendarIndexRoute
   CompaniesIndexRoute: typeof CompaniesIndexRoute
+  DocumentsIndexRoute: typeof DocumentsIndexRoute
   EmailsIndexRoute: typeof EmailsIndexRoute
   PagesIndexRoute: typeof PagesIndexRoute
   ProfileIndexRoute: typeof ProfileIndexRoute
@@ -498,6 +524,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EmailsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/documents/': {
+      id: '/documents/'
+      path: '/documents'
+      fullPath: '/documents/'
+      preLoaderRoute: typeof DocumentsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/companies/': {
       id: '/companies/'
       path: '/companies'
@@ -552,6 +585,13 @@ declare module '@tanstack/react-router' {
       path: '/emails/$threadId'
       fullPath: '/emails/$threadId'
       preLoaderRoute: typeof EmailsThreadIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/documents/$id': {
+      id: '/documents/$id'
+      path: '/documents/$id'
+      fullPath: '/documents/$id'
+      preLoaderRoute: typeof DocumentsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/companies/board': {
@@ -648,6 +688,7 @@ const rootRouteChildren: RootRouteChildren = {
   ResetPasswordRoute: ResetPasswordRoute,
   CompaniesSlugRoute: CompaniesSlugRoute,
   CompaniesBoardRoute: CompaniesBoardRoute,
+  DocumentsIdRoute: DocumentsIdRoute,
   EmailsThreadIdRoute: EmailsThreadIdRoute,
   EmailsInboxesRoute: EmailsInboxesRoute,
   OauthConsentRoute: OauthConsentRoute,
@@ -656,6 +697,7 @@ const rootRouteChildren: RootRouteChildren = {
   ResearchRunsRoute: ResearchRunsRoute,
   CalendarIndexRoute: CalendarIndexRoute,
   CompaniesIndexRoute: CompaniesIndexRoute,
+  DocumentsIndexRoute: DocumentsIndexRoute,
   EmailsIndexRoute: EmailsIndexRoute,
   PagesIndexRoute: PagesIndexRoute,
   ProfileIndexRoute: ProfileIndexRoute,

--- a/apps/internal/src/routes/calendar/index.tsx
+++ b/apps/internal/src/routes/calendar/index.tsx
@@ -12,6 +12,7 @@ import { PriButton, PriDialog } from '@batuda/ui/pri'
 import { calendarEventsAtom, rsvpEventAtom } from '#/atoms/calendar-atoms'
 import { companiesListAtom } from '#/atoms/pipeline-atoms'
 import { createTaskAtom } from '#/atoms/tasks-atoms'
+import { SubjectDocuments } from '#/components/documents/subject-documents'
 import { EmptyState } from '#/components/shared/empty-state'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { dehydrateAtom } from '#/lib/atom-hydration'
@@ -349,6 +350,11 @@ function EventDetailDialog({
 							</RsvpButtons>
 						</RsvpRow>
 					) : null}
+
+					<SubjectDocuments
+						subjectTable='calendar_events'
+						subjectId={event.id}
+					/>
 
 					<ActionRow>
 						<PriButton

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -1625,7 +1625,10 @@ function DetailBody({
 								<FilesGroupTitle>
 									<Trans>Documents</Trans>
 								</FilesGroupTitle>
-								<DocumentsPanel companyId={company.id} />
+								<DocumentsPanel
+									subjectTable='companies'
+									subjectId={company.id}
+								/>
 							</FilesGroup>
 							<FilesGroup>
 								<FilesGroupTitle>

--- a/apps/internal/src/routes/documents/$id.tsx
+++ b/apps/internal/src/routes/documents/$id.tsx
@@ -1,0 +1,173 @@
+import { useAtomRefresh, useAtomValue } from '@effect/atom-react'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { DateTime } from 'effect'
+import { AsyncResult } from 'effect/unstable/reactivity'
+import styled from 'styled-components'
+
+import { PriButton } from '@batuda/ui/pri'
+
+import { documentAtomFor } from '#/atoms/documents-atoms'
+import { DOCUMENT_KIND_LABELS } from '#/components/documents/document-kinds'
+import { useSetDocumentTitle } from '#/components/layout/top-bar-title'
+import { MarkdownView } from '#/components/markdown/markdown-view'
+import { ErrorState } from '#/components/shared/error-state'
+import { LoadingSpinner } from '#/components/shared/loading-spinner'
+import { RelativeDate } from '#/components/shared/relative-date'
+import { dehydrateAtom } from '#/lib/atom-hydration'
+import { getServerCookieHeader } from '#/lib/server-cookie'
+import { stenciledTitle } from '#/lib/workshop-mixins'
+
+/**
+ * A document on a page of its own.
+ *
+ * This is what makes a document something you can link to — paste the address
+ * into a message, keep it open in a tab, come back to it tomorrow. Reading one
+ * inside a popup on the company page works, but nothing about that popup can be
+ * shared with anybody.
+ */
+async function loadDocumentOnServer(id: string) {
+	const [{ Effect }, { makeBatudaApiServer }, cookie] = await Promise.all([
+		import('effect'),
+		import('#/lib/batuda-api-server'),
+		getServerCookieHeader(),
+	])
+	const program = Effect.gen(function* () {
+		const client = yield* makeBatudaApiServer(cookie ?? undefined)
+		return yield* client.documents.get({ params: { id } })
+	})
+	return Effect.runPromise(program)
+}
+
+// A kind the app does not know is shown as it is stored rather than blank.
+function kindLabel(i18n: { _: (d: never) => string }, value: string): string {
+	const found = DOCUMENT_KIND_LABELS.find(k => k.value === value)
+	return found ? i18n._(found.label as never) : value
+}
+
+function isNotFoundError(error: unknown): boolean {
+	if (!error || typeof error !== 'object') return false
+	return (error as Record<string, unknown>)['_tag'] === 'NotFound'
+}
+
+export const Route = createFileRoute('/documents/$id')({
+	loader: async ({ params: { id } }) => {
+		if (!import.meta.env.SSR) {
+			return { dehydrated: [] as const }
+		}
+		try {
+			const document = await loadDocumentOnServer(id)
+			return {
+				dehydrated: [
+					dehydrateAtom(documentAtomFor(id), AsyncResult.success(document)),
+				] as const,
+			}
+		} catch (error) {
+			if (isNotFoundError(error)) throw notFound()
+			console.warn('[DocumentLoader] falling back to empty hydration:', error)
+			return { dehydrated: [] as const }
+		}
+	},
+	head: () => ({ meta: [{ title: 'Document — Batuda' }] }),
+	component: DocumentPage,
+})
+
+function DocumentPage() {
+	const { i18n, t } = useLingui()
+	const { id } = Route.useParams()
+	useSetDocumentTitle(t`Document`)
+
+	const atom = documentAtomFor(id)
+	const result = useAtomValue(atom)
+	const refresh = useAtomRefresh(atom)
+
+	if (AsyncResult.isInitial(result)) return <LoadingSpinner />
+	if (AsyncResult.isFailure(result)) {
+		return (
+			<ErrorState
+				title={t`Could not load this document`}
+				onRetry={() => refresh()}
+			/>
+		)
+	}
+
+	const doc = result.value
+
+	return (
+		<Page data-testid='document-page'>
+			<Header>
+				<Title>{doc.title ?? t`Untitled document`}</Title>
+				<Meta>
+					<span>{kindLabel(i18n, doc.type)}</span>
+					<RelativeDate value={DateTime.formatIso(doc.updatedAt)} />
+				</Meta>
+			</Header>
+
+			{doc.format === 'html' ? (
+				<Notice>
+					<Trans>
+						This document is a web page. It opens in a tab of its own, exactly
+						as it was saved.
+					</Trans>
+					<PriButton
+						type='button'
+						$variant='filled'
+						data-testid='document-page-open-original'
+						disabled={doc.htmlUrl == null}
+						onClick={() => {
+							if (doc.htmlUrl != null) {
+								window.open(doc.htmlUrl, '_blank', 'noopener,noreferrer')
+							}
+						}}
+					>
+						<Trans>Open the page</Trans>
+					</PriButton>
+				</Notice>
+			) : (
+				<Body data-testid='document-page-body'>
+					<MarkdownView source={doc.content} />
+				</Body>
+			)}
+		</Page>
+	)
+}
+
+const Page = styled.article`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
+	max-width: 48rem;
+	margin: 0 auto;
+	padding: var(--space-lg);
+`
+
+const Header = styled.header`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const Title = styled.h1`
+	${stenciledTitle};
+	margin: 0;
+`
+
+const Meta = styled.div`
+	display: flex;
+	gap: var(--space-sm);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-sm);
+`
+
+const Body = styled.div`
+	line-height: 1.6;
+`
+
+const Notice = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--space-md);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-sm);
+`

--- a/apps/internal/src/routes/documents/index.tsx
+++ b/apps/internal/src/routes/documents/index.tsx
@@ -1,0 +1,308 @@
+import { useAtomValue } from '@effect/atom-react'
+import { msg } from '@lingui/core/macro'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { DateTime, Schema } from 'effect'
+import { AsyncResult } from 'effect/unstable/reactivity'
+import { FileText } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import styled from 'styled-components'
+
+import { DOCUMENT_TYPES } from '@batuda/domain'
+import { PriInput } from '@batuda/ui/pri'
+
+import { DOCUMENT_KIND_LABELS } from '#/components/documents/document-kinds'
+import { useSetDocumentTitle } from '#/components/layout/top-bar-title'
+import { RelativeDate } from '#/components/shared/relative-date'
+import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+import { validateSearchWith } from '#/lib/search-schema'
+import { stenciledTitle } from '#/lib/workshop-mixins'
+
+// Everything written down, in one place. The company page shows what is filed
+// against that company; this is where you go when you only remember the words.
+const DOC_TYPE_OPTIONS = [
+	{ value: '', label: msg`Every kind` },
+	...DOCUMENT_KIND_LABELS,
+]
+
+const validateSearch = validateSearchWith({
+	q: Schema.String,
+	type: Schema.String,
+})
+
+export const Route = createFileRoute('/documents/')({
+	validateSearch,
+	head: () => ({ meta: [{ title: 'Documents — Batuda' }] }),
+	component: DocumentsPage,
+})
+
+type DocRow = {
+	readonly id: string
+	readonly type: string
+	readonly title: string | null
+	readonly snippet: string
+	readonly updatedAt: string | null
+}
+
+// The snippet is the opening of the stored text, so for markdown it still
+// carries the marks that make a heading a heading. They mean nothing in a
+// one-line preview, so they come off before it is shown.
+function plainPreview(text: string): string {
+	return text
+		.replace(/^\s*#{1,6}\s+/gm, '')
+		.replace(/[*_`>]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim()
+}
+
+function narrowDocs(rows: ReadonlyArray<unknown>): ReadonlyArray<DocRow> {
+	const out: Array<DocRow> = []
+	for (const row of rows) {
+		if (!row || typeof row !== 'object') continue
+		const r = row as Record<string, unknown>
+		if (typeof r['id'] !== 'string') continue
+		const updatedAt = r['updatedAt']
+		out.push({
+			id: r['id'],
+			type: typeof r['type'] === 'string' ? r['type'] : 'general',
+			title: typeof r['title'] === 'string' ? r['title'] : null,
+			snippet:
+				typeof r['snippet'] === 'string' ? plainPreview(r['snippet']) : '',
+			updatedAt: DateTime.isDateTime(updatedAt)
+				? DateTime.formatIso(updatedAt)
+				: typeof updatedAt === 'string'
+					? updatedAt
+					: null,
+		})
+	}
+	return out
+}
+
+function DocumentsPage() {
+	const { i18n, t } = useLingui()
+	useSetDocumentTitle(t`Documents`)
+	const search = Route.useSearch()
+	const navigate = Route.useNavigate()
+
+	// An empty filter leaves the address bar rather than sitting there as an
+	// empty parameter, so a shared link carries only what was actually chosen.
+	const nextSearch = (patch: {
+		readonly q?: string | undefined
+		readonly type?: string | undefined
+	}) => {
+		const merged = { q: search.q, type: search.type, ...patch }
+		const out: { q?: string; type?: string } = {}
+		if (merged.q) out.q = merged.q
+		if (merged.type) out.type = merged.type
+		return out
+	}
+
+	// Typing puts a word in the box straight away and only asks the server once
+	// the typing stops, so the field never lags behind the keyboard.
+	const [draft, setDraft] = useState(search.q ?? '')
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			const next = draft.trim()
+			if (next === (search.q ?? '')) return
+			// The kind is read here rather than captured when the timer was set,
+			// so changing the filter while still typing is not undone when the
+			// pause finally lands.
+			const params: { q?: string; type?: string } = {}
+			if (next !== '') params.q = next
+			if (search.type) params.type = search.type
+			void navigate({ search: params, replace: true })
+		}, 250)
+		return () => clearTimeout(timer)
+	}, [draft, search.q, search.type, navigate])
+
+	// A kind pasted into the address bar that nothing offers is ignored rather
+	// than sent on and rejected.
+	const type = DOCUMENT_TYPES.find(value => value === search.type)
+	const listAtom = useMemo(
+		() =>
+			BatudaApiAtom.query('documents', 'list', {
+				query: {
+					...(search.q ? { q: search.q } : {}),
+					...(type ? { type } : {}),
+					limit: 50,
+				},
+				serializationKey: `documents:list:${search.q ?? ''}:${type ?? ''}`,
+			}),
+		[search.q, type],
+	)
+	const result = useAtomValue(listAtom)
+	const docs = AsyncResult.isSuccess(result)
+		? narrowDocs(result.value.items)
+		: []
+	const total = AsyncResult.isSuccess(result) ? result.value.total : 0
+
+	const typeLabel = (value: string) => {
+		const found = DOC_TYPE_OPTIONS.find(o => o.value === value)
+		return found ? i18n._(found.label) : value
+	}
+
+	return (
+		<Page>
+			<Header>
+				<Title>
+					<Trans>Documents</Trans>
+				</Title>
+				<Controls>
+					<PriInput
+						type='search'
+						data-testid='documents-search'
+						placeholder={t`Search titles and text`}
+						value={draft}
+						onChange={e => setDraft(e.target.value)}
+					/>
+					<TypeSelect
+						data-testid='documents-type'
+						value={search.type ?? ''}
+						onChange={e =>
+							void navigate({
+								search: nextSearch({
+									type: e.target.value === '' ? undefined : e.target.value,
+								}),
+								replace: true,
+							})
+						}
+					>
+						{DOC_TYPE_OPTIONS.map(option => (
+							<option key={option.value} value={option.value}>
+								{i18n._(option.label)}
+							</option>
+						))}
+					</TypeSelect>
+				</Controls>
+			</Header>
+
+			{docs.length === 0 ? (
+				<Empty data-testid='documents-empty'>
+					<FileText size={18} aria-hidden />
+					<Trans>Nothing written down matches that.</Trans>
+				</Empty>
+			) : (
+				<>
+					<Count>
+						<Trans>{total} documents</Trans>
+					</Count>
+					<List data-testid='documents-list'>
+						{docs.map(doc => (
+							<Row key={doc.id}>
+								<Link
+									to='/documents/$id'
+									params={{ id: doc.id }}
+									data-testid={`documents-row-${doc.id}`}
+								>
+									<RowTitle>{doc.title ?? typeLabel(doc.type)}</RowTitle>
+									<RowSnippet>{doc.snippet}</RowSnippet>
+									<RowMeta>
+										<TypeTag>{typeLabel(doc.type)}</TypeTag>
+										<RelativeDate value={doc.updatedAt} />
+									</RowMeta>
+								</Link>
+							</Row>
+						))}
+					</List>
+				</>
+			)}
+		</Page>
+	)
+}
+
+const Page = styled.section`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+	padding: var(--space-lg);
+`
+
+const Header = styled.header`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-sm);
+`
+
+const Title = styled.h1`
+	${stenciledTitle};
+	margin: 0;
+`
+
+const Controls = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-sm);
+`
+
+const TypeSelect = styled.select`
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-sm);
+	background: var(--color-surface);
+	color: var(--color-text);
+	padding: var(--space-2xs) var(--space-xs);
+	font: inherit;
+`
+
+const Count = styled.p`
+	margin: 0;
+	color: var(--color-text-muted);
+	font-size: var(--font-size-sm);
+`
+
+const List = styled.ul`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+`
+
+const Row = styled.li`
+	a {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3xs);
+		padding: var(--space-sm);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		color: inherit;
+		text-decoration: none;
+	}
+
+	a:hover {
+		border-color: var(--color-primary);
+	}
+`
+
+const RowTitle = styled.span`
+	font-weight: 600;
+`
+
+const RowSnippet = styled.span`
+	color: var(--color-text-muted);
+	font-size: var(--font-size-sm);
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+`
+
+const TypeTag = styled.span`
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+`
+
+const RowMeta = styled.span`
+	display: flex;
+	gap: var(--space-sm);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-xs);
+`
+
+const Empty = styled.p`
+	display: flex;
+	align-items: center;
+	gap: var(--space-xs);
+	color: var(--color-text-muted);
+`

--- a/apps/internal/src/routes/tasks/index.tsx
+++ b/apps/internal/src/routes/tasks/index.tsx
@@ -27,6 +27,7 @@ import {
 	tasksShelfAtom,
 	updateTaskAtom,
 } from '#/atoms/tasks-atoms'
+import { SubjectDocuments } from '#/components/documents/subject-documents'
 import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
 import { InfiniteListFooter } from '#/components/shared/infinite-list-footer'
@@ -910,6 +911,8 @@ function DetailPane({
 							<Trans>Cancel</Trans>
 						</PriButton>
 					</ActionRow>
+
+					<SubjectDocuments subjectTable='tasks' subjectId={task.id} />
 
 					<EventsHeader>
 						<Trans>Audit log</Trans>

--- a/apps/internal/tests/e2e/documents-on-company.test.ts
+++ b/apps/internal/tests/e2e/documents-on-company.test.ts
@@ -1,0 +1,324 @@
+import { execSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+
+import { expect, test } from '@playwright/test'
+
+import { DATABASE_URL } from './helpers/database-url'
+import { waitForInteractive } from './helpers/hydration'
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
+// Covers the documents panel on the company Files tab: list, read, create and
+// edit.
+//
+// Both write paths assert against the database, because the dialog closing
+// only proves the mutation resolved — not that the row carries the title,
+// type and content that were typed.
+//
+// Selectors verified against:
+//   apps/internal/src/components/companies/documents-panel.tsx
+//     (company-add-document, document-row-{id}, document-edit-{id},
+//      document-dialog, document-view, document-title, document-type,
+//      document-content, document-save)
+//   apps/internal/src/routes/companies/$slug.tsx (?tab=files)
+//
+// Auth: runs in the `authed` project and inherits Alice's session cookie from
+// the `setup` project's storageState.
+
+const COMPANY_SLUG = 'cal-pep-fonda'
+
+// The one title this file writes through the UI. Named so cleanup can find the
+// row whose id the test never learns.
+const CREATED_TITLE = 'e2e — created document'
+
+const psql = (sqlText: string): string =>
+	execSync(`psql "${DATABASE_URL}" -tA -c "${sqlText.replace(/"/g, '\\"')}"`, {
+		encoding: 'utf8',
+	}).trim()
+
+let companyId = ''
+let readableId = ''
+let editableId = ''
+
+// A document and the record it is filed under are two rows. Both are written
+// here, because a document filed nowhere is one the panel cannot list.
+const seedDocument = (
+	orgId: string,
+	id: string,
+	type: string,
+	title: string,
+	content: string,
+): void => {
+	psql(
+		`INSERT INTO documents (id, organization_id, type, title, content)
+		 VALUES ('${id}', '${orgId}', '${type}', '${title}', '${content}')`,
+	)
+	psql(
+		`INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+		 VALUES ('${orgId}', '${id}', 'companies', '${companyId}')`,
+	)
+}
+
+const deleteDocument = (id: string): void => {
+	// timeline_activity has no FK to documents, so the activity the create path
+	// records outlives the row unless it goes first.
+	psql(
+		`DELETE FROM timeline_activity WHERE entity_type='document' AND entity_id='${id}'`,
+	)
+	psql(`DELETE FROM documents WHERE id='${id}'`)
+}
+
+test.describe('documents on the company Files tab', () => {
+	test.beforeAll(() => {
+		// GIVEN cal-pep-fonda exists. The demo seed already gives it documents,
+		// but this file seeds its own so the assertions below name content this
+		// test controls rather than fixture prose that may be reworded.
+		const orgId = psql(
+			`SELECT organization_id FROM companies WHERE slug='${COMPANY_SLUG}' LIMIT 1`,
+		)
+		companyId = psql(
+			`SELECT id FROM companies WHERE slug='${COMPANY_SLUG}' LIMIT 1`,
+		)
+		expect(orgId, 'taller seeded').not.toBe('')
+		expect(companyId, 'cal-pep-fonda seeded').not.toBe('')
+
+		readableId = randomUUID()
+		seedDocument(
+			orgId,
+			readableId,
+			'call_notes',
+			'e2e — readable document',
+			'## Heading from markdown\n\nBody line the view dialog must render.',
+		)
+
+		editableId = randomUUID()
+		seedDocument(
+			orgId,
+			editableId,
+			'general',
+			'e2e — editable document',
+			'Original body.',
+		)
+	})
+
+	test.afterAll(() => {
+		deleteDocument(readableId)
+		deleteDocument(editableId)
+		const createdIds = psql(
+			`SELECT d.id FROM documents d
+			 JOIN document_links dl ON dl.document_id = d.id
+			 WHERE d.title='${CREATED_TITLE}'
+			   AND dl.subject_table='companies' AND dl.subject_id='${companyId}'`,
+		)
+		for (const id of createdIds.split('\n').filter(Boolean)) {
+			deleteDocument(id)
+		}
+	})
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/', { waitUntil: 'commit' })
+		await setActiveOrgBySlug(page, 'taller')
+	})
+
+	test.describe('when the company has documents', () => {
+		test('should list them and open one for reading', {
+			tag: '@smoke',
+		}, async ({ page }) => {
+			// WHEN Alice opens the Files tab. Going straight to the tab in the
+			// URL avoids having to click the tab trigger first.
+			await page.goto(`/companies/${COMPANY_SLUG}?tab=files`, {
+				waitUntil: 'networkidle',
+			})
+
+			// THEN the seeded document has a row
+			const row = page.getByTestId(`document-row-${readableId}`)
+			await expect(row).toBeVisible()
+			await expect(row).toContainText('e2e — readable document')
+			// AND the row is labelled with its kind, not the raw column value
+			await expect(row).toContainText('Call notes')
+
+			// WHEN she clicks the row itself, which is its first button — the
+			// pencil next to it opens the editor instead. The row opens the
+			// reader from a plain onClick, so the click does nothing at all
+			// until the browser has taken the page over.
+			await waitForInteractive(page, `document-row-${readableId}`)
+			await row.getByRole('button').first().click()
+
+			// THEN the dialog opens showing the rendered markdown. Asserting the
+			// body text proves the content travelled from the row through
+			// MarkdownView, not merely that a dialog appeared.
+			await expect(page.getByTestId('document-dialog')).toBeVisible()
+			const view = page.getByTestId('document-view')
+			await expect(view).toBeVisible()
+			await expect(view).toContainText('Body line the view dialog must render.')
+			// AND the markdown heading rendered as a heading rather than as
+			// literal '##' text
+			await expect(view.getByRole('heading')).toContainText(
+				'Heading from markdown',
+			)
+		})
+	})
+
+	test.describe('when Alice opens a document on its own page', () => {
+		test('should show the body at an address that can be shared', async ({
+			page,
+		}) => {
+			// GIVEN the reader open on the Files tab
+			await page.goto(`/companies/${COMPANY_SLUG}?tab=files`, {
+				waitUntil: 'networkidle',
+			})
+			const row = page.getByTestId(`document-row-${readableId}`)
+			await expect(row).toBeVisible()
+			await waitForInteractive(page, `document-row-${readableId}`)
+			await row.getByRole('button').first().click()
+			await expect(page.getByTestId('document-view')).toBeVisible()
+
+			// WHEN she follows the link out of the popup
+			await page.getByTestId('document-open-full-page').click()
+
+			// THEN the document has an address of its own, and the body is there.
+			// Visiting that address directly is the whole point — a popup cannot
+			// be sent to anybody.
+			await expect(page).toHaveURL(new RegExp(`/documents/${readableId}$`))
+			await expect(page.getByTestId('document-page')).toBeVisible()
+			await expect(page.getByTestId('document-page-body')).toContainText(
+				'Body line the view dialog must render.',
+			)
+
+			// AND arriving cold at the same address works the same way
+			await page.goto(`/documents/${readableId}`, { waitUntil: 'networkidle' })
+			await expect(page.getByTestId('document-page-body')).toContainText(
+				'Body line the view dialog must render.',
+			)
+		})
+	})
+
+	test.describe('when Alice looks for a document by its words', () => {
+		test('should find it from the documents page', async ({ page }) => {
+			// GIVEN the documents page, which lists everything written down
+			await page.goto('/documents', { waitUntil: 'networkidle' })
+			await expect(page.getByTestId('documents-list')).toBeVisible()
+
+			// WHEN she searches for wording that appears only in one body
+			await page.getByTestId('documents-search').fill('Body line the view')
+
+			// THEN that document is the one left, and it links to its own page.
+			// Searching the body, not just the title, is the point — the title
+			// here says nothing about the words being looked for.
+			const row = page.getByTestId(`documents-row-${readableId}`)
+			await expect(row).toBeVisible({ timeout: 10_000 })
+			await expect(
+				page.getByTestId('documents-list').locator('li'),
+			).toHaveCount(1)
+			await row.click()
+			await expect(page).toHaveURL(new RegExp(`/documents/${readableId}$`))
+		})
+	})
+
+	test.describe('when a document is filed against a person', () => {
+		test('should show it on that person, not only on the company', async ({
+			page,
+		}) => {
+			// GIVEN the seed files a note about Pep on his own contact row. This
+			// is the whole point of the change: before it, a note about a person
+			// could only be filed against the business they work for.
+			const contactId = psql(
+				`SELECT c.id FROM contacts c
+				 JOIN document_links dl ON dl.subject_table='contacts' AND dl.subject_id = c.id
+				 WHERE c.company_id = '${companyId}' LIMIT 1`,
+			)
+			test.skip(contactId === '', 'seed files no document against a contact')
+
+			// WHEN Alice opens that person on the company's People tab
+			await page.goto(`/companies/${COMPANY_SLUG}?tab=people`, {
+				waitUntil: 'networkidle',
+			})
+			const editButton = page.getByTestId(`contact-edit-${contactId}`)
+			await expect(editButton).toBeVisible()
+			await waitForInteractive(page, `contact-edit-${contactId}`)
+			await editButton.click()
+
+			// THEN what was written about them is listed there, and leads to the
+			// document's own page
+			const section = page.getByTestId('subject-documents-contacts')
+			await expect(section).toBeVisible()
+			await expect(section).toContainText('Working with Pep')
+		})
+	})
+
+	test.describe('when Alice adds a document', () => {
+		test('should store the title, type and content she typed', async ({
+			page,
+		}) => {
+			// GIVEN the Files tab, with the Add button live. The button opens the
+			// dialog from a plain onClick, so a click landing before React has
+			// wired it up is swallowed silently.
+			await page.goto(`/companies/${COMPANY_SLUG}?tab=files`, {
+				waitUntil: 'networkidle',
+			})
+			await waitForInteractive(page, 'company-add-document')
+
+			// WHEN she opens the add dialog
+			await page.getByTestId('company-add-document').click()
+			await expect(page.getByTestId('document-dialog')).toBeVisible()
+
+			// AND fills in every field the form offers
+			await page.getByTestId('document-title').fill(CREATED_TITLE)
+			await page.getByTestId('document-type').selectOption('visit_notes')
+			await page
+				.getByTestId('document-content')
+				.fill('Notes taken during the e2e visit.')
+			await page.getByTestId('document-save').click()
+
+			// THEN the dialog closes, which only happens once the create mutation
+			// resolved Success — a failure keeps it open with a toast
+			await expect(page.getByTestId('document-dialog')).toHaveCount(0)
+
+			// AND the stored row carries the type she chose and the body she
+			// typed. The body never appears on the list, and the type can only
+			// be set while creating — there is no picker once the document
+			// exists — so a wrong value here would go unnoticed on screen.
+			await expect(async () => {
+				const stored = psql(
+					`SELECT d.type || '|' || d.content FROM documents d
+					 JOIN document_links dl ON dl.document_id = d.id
+					 WHERE d.title='${CREATED_TITLE}'
+					   AND dl.subject_table='companies' AND dl.subject_id='${companyId}'`,
+				)
+				expect(stored).toBe('visit_notes|Notes taken during the e2e visit.')
+			}).toPass({ timeout: 10_000 })
+		})
+	})
+
+	test.describe('when Alice edits an existing document', () => {
+		test('should overwrite its content', async ({ page }) => {
+			// GIVEN the Files tab with the seeded editable document
+			await page.goto(`/companies/${COMPANY_SLUG}?tab=files`, {
+				waitUntil: 'networkidle',
+			})
+			const editButton = page.getByTestId(`document-edit-${editableId}`)
+			await expect(editButton).toBeVisible()
+			await waitForInteractive(page, `document-edit-${editableId}`)
+
+			// WHEN she opens it for editing and replaces the body
+			await editButton.click()
+			await expect(page.getByTestId('document-dialog')).toBeVisible()
+			const content = page.getByTestId('document-content')
+			await expect(content).toHaveValue('Original body.')
+			// AND the type picker is absent — type is fixed at creation on this
+			// surface, so editing must not offer it
+			await expect(page.getByTestId('document-type')).toHaveCount(0)
+
+			await content.fill('Rewritten by the e2e edit test.')
+			await page.getByTestId('document-save').click()
+
+			// THEN the dialog closes and the stored row carries the new body
+			await expect(page.getByTestId('document-dialog')).toHaveCount(0)
+			await expect(async () => {
+				const stored = psql(
+					`SELECT content FROM documents WHERE id='${editableId}'`,
+				)
+				expect(stored).toBe('Rewritten by the e2e edit test.')
+			}).toPass({ timeout: 10_000 })
+		})
+	})
+})

--- a/apps/internal/tests/e2e/research-findings.test.ts
+++ b/apps/internal/tests/e2e/research-findings.test.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import { expect, test } from '@playwright/test'
 
 import { DATABASE_URL } from './helpers/database-url'
+import { waitForInteractive } from './helpers/hydration'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // A run's findings are the research schema filled in by the model, and they
@@ -142,6 +143,10 @@ test.describe('research findings', () => {
 
 			// WHEN the company page is opened and the fit panel expanded
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
+			// The trigger opens the panel from a plain onClick, so a click that
+			// lands before the browser has taken the page over does nothing and
+			// leaves no trace.
+			await waitForInteractive(page, 'company-fit-trigger')
 			await page.getByTestId('company-fit-trigger').click()
 
 			// THEN the criterion and its evidence both render — the quote is the

--- a/apps/server/src/db/migrations/0039_document_links.ts
+++ b/apps/server/src/db/migrations/0039_document_links.ts
@@ -1,0 +1,85 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// A document used to belong to exactly one company, so a note could not be
+// filed against the meeting it was written for, the person it is about, the
+// task it came out of, or the offer it argues for.
+//
+// `document_links` names the record a document is filed under by table and id,
+// the way `research_links` already does, so one document can sit in several
+// places at once. `organization_id` is on the link row because the isolation
+// policy reads it there rather than following the parent, and `subject_id`
+// carries no foreign key because one key cannot point at five tables.
+//
+// `interaction_id` goes with the company column. It was meant to tie a prep
+// note to a meeting, nothing ever read it, and the other half of that chain
+// (`calendar_events.interaction_id`) is empty in every environment including
+// the seeds. A link to the meeting itself replaces it.
+//
+// `type` was free text, so rows exist carrying a word no picker or filter
+// offers. Those become 'general'.
+//
+// expand-contract: pre-production clean break — this same release rewrites every
+// reader and writer of `company_id` and `interaction_id` (HTTP route + handler,
+// MCP tool, MCP resource, the company-research prompt, the seed, and the web
+// app) to go through the link table. Nothing queries the dropped columns on the
+// request path once this deploy is out. This also removes the documents table's
+// only ON DELETE CASCADE: no code path hard-deletes a company today, and a
+// document whose last link is removed stays reachable from the documents list
+// rather than disappearing.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		CREATE TABLE IF NOT EXISTS document_links (
+			organization_id TEXT NOT NULL,
+			document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+			subject_table TEXT NOT NULL CHECK (subject_table IN ('companies','contacts','tasks','proposals','calendar_events')),
+			subject_id UUID NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			PRIMARY KEY (document_id, subject_table, subject_id)
+		)
+	`
+
+	// "What is filed against this record" is the hot read — every subject panel
+	// asks it. The org index matches the one every other org-scoped table keeps.
+	yield* sql`CREATE INDEX IF NOT EXISTS document_links_subject_idx ON document_links(subject_table, subject_id)`
+	yield* sql`CREATE INDEX IF NOT EXISTS idx_document_links_org ON document_links(organization_id)`
+
+	yield* sql`GRANT SELECT, INSERT, UPDATE, DELETE ON document_links TO app_user, app_service`
+
+	yield* sql`ALTER TABLE document_links ENABLE ROW LEVEL SECURITY`
+	yield* sql`ALTER TABLE document_links FORCE ROW LEVEL SECURITY`
+	yield* sql`
+		CREATE POLICY org_isolation_document_links ON document_links
+			TO app_user
+			USING (organization_id = current_setting('app.current_org_id', true))
+			WITH CHECK (organization_id = current_setting('app.current_org_id', true))
+	`
+
+	// Every document that exists today belongs to a company, so each one keeps
+	// that filing.
+	yield* sql`
+		INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+		SELECT organization_id, id, 'companies', company_id
+		FROM documents
+		WHERE company_id IS NOT NULL
+		ON CONFLICT DO NOTHING
+	`
+
+	// Anything filed under a word the app does not offer becomes a plain note,
+	// so every row answers to one of the six kinds the pickers and filters use.
+	yield* sql`
+		UPDATE documents
+		SET type = 'general'
+		WHERE type NOT IN ('general','prenote','postnote','call_notes','visit_notes','research')
+	`
+
+	yield* sql`ALTER TABLE documents DROP COLUMN IF EXISTS company_id`
+	yield* sql`ALTER TABLE documents DROP COLUMN IF EXISTS interaction_id`
+
+	// Documents are listed newest-touched first within one organisation, which
+	// is the order this index serves.
+	yield* sql`CREATE INDEX IF NOT EXISTS idx_documents_org_updated ON documents(organization_id, updated_at DESC)`
+})

--- a/apps/server/src/db/migrations/0040_document_html.ts
+++ b/apps/server/src/db/migrations/0040_document_html.ts
@@ -1,0 +1,41 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Documents can now hold a whole HTML page, not just markdown.
+//
+// The two formats are written and read differently, so they are stored
+// differently. Markdown is typed by a person, edited in place, and has to be
+// searchable, so it stays in `content`. HTML arrives already finished — from an
+// agent or an import — is read whole and replaced whole, and is often far
+// larger, so its bytes go to object storage and the row keeps only the key.
+//
+// That split also decides where an HTML document opens. Serving it back from
+// the app's own address would put a page somebody else wrote next to the
+// signed-in session; a short-lived link to the storage address does not, and
+// the browser treats it as the separate place it is.
+//
+// `search_text` is the plain words of an HTML document, kept so searching still
+// works when the body itself is not in the database. It is never shown to
+// anyone — the stored bytes are what a reader sees.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		ALTER TABLE documents
+			ADD COLUMN IF NOT EXISTS format TEXT NOT NULL DEFAULT 'markdown'
+				CHECK (format IN ('markdown','html')),
+			ADD COLUMN IF NOT EXISTS storage_key TEXT,
+			ADD COLUMN IF NOT EXISTS search_text TEXT
+	`
+
+	// A markdown document keeps its body in `content` and an HTML one keeps a
+	// key instead, so exactly one of the two is always filled in.
+	yield* sql`
+		ALTER TABLE documents
+			ADD CONSTRAINT documents_body_matches_format CHECK (
+				(format = 'markdown' AND storage_key IS NULL)
+				OR (format = 'html' AND storage_key IS NOT NULL)
+			)
+	`
+})

--- a/apps/server/src/db/migrations/0041_notes_into_documents.ts
+++ b/apps/server/src/db/migrations/0041_notes_into_documents.ts
@@ -1,0 +1,66 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Three places kept a free-text box of their own: a contact, a task and a
+// proposal each had `notes`. None of them talked to each other, none could hold
+// more than one note, and the one on a contact was never shown on any screen —
+// written by the contacts form, the agent tool and the research apply path, and
+// read by nobody but a language model.
+//
+// Now that a document can be filed against any of those records, the boxes have
+// nothing left to do. Whatever was written in one becomes a document filed
+// against the row it came from, so nothing is lost and everything ends up
+// somewhere it can be found, searched and read.
+//
+// Each note becomes two rows written together — the document and the filing
+// that says where it belongs — because a document filed nowhere is one nothing
+// can reach.
+//
+// expand-contract: pre-production clean break — this same release rewrites every
+// reader and writer of the three columns (domain schemas, HTTP payloads,
+// handlers, agent tools, the task search, the proposals panel and the seeds).
+// Nothing queries them on the request path once this deploy is out.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		WITH source AS (
+			SELECT id AS subject_id, organization_id, notes, gen_random_uuid() AS document_id
+			FROM contacts WHERE notes IS NOT NULL AND btrim(notes) <> ''
+		), created AS (
+			INSERT INTO documents (id, organization_id, type, format, title, content)
+			SELECT document_id, organization_id, 'general', 'markdown', 'Notes', notes FROM source
+		)
+		INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+		SELECT organization_id, document_id, 'contacts', subject_id FROM source
+	`
+
+	yield* sql`
+		WITH source AS (
+			SELECT id AS subject_id, organization_id, notes, gen_random_uuid() AS document_id
+			FROM tasks WHERE notes IS NOT NULL AND btrim(notes) <> ''
+		), created AS (
+			INSERT INTO documents (id, organization_id, type, format, title, content)
+			SELECT document_id, organization_id, 'general', 'markdown', 'Notes', notes FROM source
+		)
+		INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+		SELECT organization_id, document_id, 'tasks', subject_id FROM source
+	`
+
+	yield* sql`
+		WITH source AS (
+			SELECT id AS subject_id, organization_id, notes, gen_random_uuid() AS document_id
+			FROM proposals WHERE notes IS NOT NULL AND btrim(notes) <> ''
+		), created AS (
+			INSERT INTO documents (id, organization_id, type, format, title, content)
+			SELECT document_id, organization_id, 'general', 'markdown', 'Notes', notes FROM source
+		)
+		INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+		SELECT organization_id, document_id, 'proposals', subject_id FROM source
+	`
+
+	yield* sql`ALTER TABLE contacts DROP COLUMN IF EXISTS notes`
+	yield* sql`ALTER TABLE tasks DROP COLUMN IF EXISTS notes`
+	yield* sql`ALTER TABLE proposals DROP COLUMN IF EXISTS notes`
+})

--- a/apps/server/src/handlers/contacts.ts
+++ b/apps/server/src/handlers/contacts.ts
@@ -16,6 +16,7 @@ import {
 	patchChannel,
 	writeChannels,
 } from '../services/contact-channels'
+import { unlinkSubject } from '../services/documents'
 
 const decodeContact = Schema.decodeUnknownEffect(Contact)
 const decodeChannel = Schema.decodeUnknownEffect(ContactChannel)
@@ -135,6 +136,9 @@ export const ContactsLive = HttpApiBuilder.group(
 				)
 				.handle('remove', _ =>
 					Effect.gen(function* () {
+						// No foreign key clears these, so they would outlive the
+						// person and point at nobody.
+						yield* unlinkSubject(sql, 'contacts', _.params.id)
 						yield* sql`DELETE FROM contacts WHERE id = ${_.params.id}`
 						yield* Effect.logInfo('Contact removed').pipe(
 							Effect.annotateLogs({

--- a/apps/server/src/handlers/documents-create.integration.test.ts
+++ b/apps/server/src/handlers/documents-create.integration.test.ts
@@ -8,15 +8,17 @@ import { randomUUID } from 'node:crypto'
 import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-// SQL-contract test for the documents INSERT that
+// SQL-contract test for the pair of writes that
 // `apps/server/src/handlers/documents.ts` and
-// `apps/server/src/mcp/tools/documents.ts` both run from their create
-// paths. Mirrors the post-fix shape (organization_id stamped from
-// CurrentOrg) using raw `pg` with `app.current_org_id` set on the
-// session, so the org_isolation_documents RLS policy engages exactly
-// as it does at runtime. Also pins the pre-fix shape as a failure
-// case so a future hand-edit that drops the column from the INSERT
-// immediately fails the suite.
+// `apps/server/src/mcp/tools/documents.ts` both run when a document is
+// created: the row itself, then the link saying which record it is filed
+// under. Uses raw `pg` with `app.current_org_id` set on the session, so the
+// org_isolation_documents and org_isolation_document_links policies engage
+// exactly as they do at runtime.
+//
+// Two failure shapes are pinned alongside the passing one, because both are
+// silent if the guard ever goes: an INSERT that forgets organization_id, and
+// a link that claims to belong to another organisation.
 //
 // Prereq: `pnpm cli services up` so Postgres is reachable.
 
@@ -24,7 +26,7 @@ const DATABASE_URL =
 	process.env['DATABASE_URL'] ??
 	'postgresql://batuda:batuda@localhost:5433/batuda'
 
-describe('documents INSERT — RLS contract', () => {
+describe('documents create — RLS contract', () => {
 	let pool: pg.Pool
 	let orgId: string
 	const seededDocumentIds: string[] = []
@@ -49,6 +51,7 @@ describe('documents INSERT — RLS contract', () => {
 
 	afterAll(async () => {
 		for (const id of seededDocumentIds) {
+			// The link goes with the document through its foreign key.
 			await pool.query(`DELETE FROM documents WHERE id = $1::uuid`, [id])
 		}
 		for (const id of seededCompanyIds) {
@@ -90,69 +93,130 @@ describe('documents INSERT — RLS contract', () => {
 		return id
 	}
 
-	describe('when the create INSERT includes organization_id', () => {
-		it('should pass the org_isolation_documents WITH CHECK clause as app_user', async () => {
+	describe('when a document and its first filing are written together', () => {
+		it('should store both and report where the document is filed', async () => {
 			// GIVEN app.current_org_id = taller.id and SET ROLE app_user
-			// WHEN INSERT INTO documents runs with organization_id=taller.id
-			//      (mirrors handlers/documents.ts + tools/documents.ts post-fix shape)
-			// THEN the policy approves the row
-			// [handlers/documents.ts + tools/documents.ts — create handler INSERT shape]
+			// WHEN the create path inserts the document then its link
+			// THEN both policies approve, and the document is reachable through
+			//      the record it was filed under — which is the only way a
+			//      document is found now that it carries no company column
 			const id = randomUUID()
 			seededDocumentIds.push(id)
 
-			const inserted = await withOrgScope(async client => {
+			const filed = await withOrgScope(async client => {
 				const companyId = await seedCompany(client)
+				await client.query(
+					`INSERT INTO documents (id, organization_id, type, content)
+					 VALUES ($1::uuid, $2, 'general', 'Test content')`,
+					[id, orgId],
+				)
+				await client.query(
+					`INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+					 VALUES ($1, $2::uuid, 'companies', $3::uuid)`,
+					[orgId, id, companyId],
+				)
 				const result = await client.query<{
 					id: string
-					organization_id: string
 					type: string
+					subject_table: string
+					subject_id: string
 				}>(
-					`INSERT INTO documents (
-						id,
-						organization_id,
-						company_id, type, content
-					) VALUES (
-						$1::uuid,
-						$2,
-						$3::uuid, 'note', 'Test content'
-					)
-					RETURNING id, organization_id, type`,
-					[id, orgId, companyId],
+					`SELECT d.id, d.type, dl.subject_table, dl.subject_id
+					 FROM documents d
+					 JOIN document_links dl ON dl.document_id = d.id
+					 WHERE d.id = $1::uuid`,
+					[id],
 				)
-				return result.rows[0]
+				return { row: result.rows[0], companyId }
 			})
 
-			expect(inserted?.id).toBe(id)
-			expect(inserted?.organization_id).toBe(orgId)
-			expect(inserted?.type).toBe('note')
+			expect(filed.row?.id).toBe(id)
+			expect(filed.row?.type).toBe('general')
+			expect(filed.row?.subject_table).toBe('companies')
+			expect(filed.row?.subject_id).toBe(filed.companyId)
+		})
+
+		it('should refuse a second filing of the same pair without failing', async () => {
+			// GIVEN a document already filed against a company
+			// WHEN the same pair is written again, as re-filing does
+			// THEN the primary key absorbs it: one link, no error
+			const id = randomUUID()
+			seededDocumentIds.push(id)
+
+			const count = await withOrgScope(async client => {
+				const companyId = await seedCompany(client)
+				await client.query(
+					`INSERT INTO documents (id, organization_id, type, content)
+					 VALUES ($1::uuid, $2, 'general', 'Test content')`,
+					[id, orgId],
+				)
+				for (let attempt = 0; attempt < 2; attempt += 1) {
+					await client.query(
+						`INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+						 VALUES ($1, $2::uuid, 'companies', $3::uuid)
+						 ON CONFLICT DO NOTHING`,
+						[orgId, id, companyId],
+					)
+				}
+				const result = await client.query<{ count: string }>(
+					`SELECT count(*)::text AS count FROM document_links WHERE document_id = $1::uuid`,
+					[id],
+				)
+				return result.rows[0]?.count
+			})
+
+			expect(count).toBe('1')
 		})
 	})
 
-	describe('when the INSERT omits organization_id (the pre-fix shape)', () => {
+	describe('when the document INSERT omits organization_id', () => {
 		it('should fail because the column is NOT NULL', async () => {
-			// GIVEN the pre-fix INSERT — no organization_id column in the list
+			// GIVEN an INSERT with no organization_id column in the list
 			// WHEN it runs as app_user with app.current_org_id set
-			// THEN the INSERT fails because organization_id is NOT NULL with no default
-			// [handlers/documents.ts + tools/documents.ts (pre-fix) — INSERT omitted org_id]
+			// THEN it fails: the column is NOT NULL with no default, so a row
+			//      that no policy could ever match never lands
 			const id = randomUUID()
 
 			await expect(
 				withOrgScope(async client => {
-					const companyId = await seedCompany(client)
 					await client.query(
-						`INSERT INTO documents (
-							id,
-							company_id, type, content
-						) VALUES (
-							$1::uuid,
-							$2::uuid, 'note', 'Bug Repro'
-						)`,
-						[id, companyId],
+						`INSERT INTO documents (id, type, content)
+						 VALUES ($1::uuid, 'general', 'Bug Repro')`,
+						[id],
 					)
 				}),
 			).rejects.toThrow(
 				/null value in column "organization_id"|row.level security/i,
 			)
+		})
+	})
+
+	describe('when a filing claims to belong to another organisation', () => {
+		it('should be refused by the link policy', async () => {
+			// GIVEN a document in this organisation
+			// WHEN a link is written carrying somebody else's organisation id —
+			//      the shape a bug or a crafted call would produce, since
+			//      subject_id has no foreign key to vouch for it
+			// THEN the WITH CHECK clause rejects it, so the link table cannot
+			//      become a way to reach across organisations
+			const id = randomUUID()
+			seededDocumentIds.push(id)
+
+			await expect(
+				withOrgScope(async client => {
+					const companyId = await seedCompany(client)
+					await client.query(
+						`INSERT INTO documents (id, organization_id, type, content)
+						 VALUES ($1::uuid, $2, 'general', 'Test content')`,
+						[id, orgId],
+					)
+					await client.query(
+						`INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+						 VALUES ($1, $2::uuid, 'companies', $3::uuid)`,
+						['some-other-org', id, companyId],
+					)
+				}),
+			).rejects.toThrow(/row.level security/i)
 		})
 	})
 })

--- a/apps/server/src/handlers/documents.ts
+++ b/apps/server/src/handlers/documents.ts
@@ -1,19 +1,62 @@
+import { randomUUID } from 'node:crypto'
+
 import { DateTime, Effect, Schema } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { BatudaApi, CurrentOrg, NotFound } from '@batuda/controllers'
-import { Document } from '@batuda/domain'
+import {
+	BatudaApi,
+	CurrentOrg,
+	DocumentSummary,
+	NotFound,
+} from '@batuda/controllers'
+import { Document, type DocumentSubjectTable } from '@batuda/domain'
 
 import { resolvePageTotal } from '../lib/sql-pagination'
+import {
+	type DocumentSubjectRow,
+	HTML_URL_TTL_SECONDS,
+	htmlStorageKey,
+	linkDocument,
+	searchTextFromHtml,
+	subjectsForDocument,
+	unlinkDocument,
+} from '../services/documents'
+import { StorageProvider } from '../services/storage-provider'
 import {
 	DocumentCreated,
 	TimelineActivityService,
 } from '../services/timeline-activity'
 
 const decodeDocument = Schema.decodeUnknownEffect(Document)
-const decodeDocuments = Schema.decodeUnknownEffect(Schema.Array(Document))
+
+// The listing query reads its columns straight from Postgres, so the timestamps
+// arrive as raw dates; only those need overriding before the rows decode into
+// the wire summary shape.
+//
+// Built when the layer runs rather than when the file loads: `DocumentSummary`
+// comes from another package that is still being set up at that point, and
+// reading it too early throws.
+const makeSummaryDecoder = () =>
+	Schema.decodeUnknownEffect(
+		Schema.Array(
+			Schema.Struct({
+				...DocumentSummary.fields,
+				createdAt: Schema.DateTimeUtcFromDate,
+				updatedAt: Schema.DateTimeUtcFromDate,
+			}),
+		),
+	)
+
+// How much of the body a list row shows. Long enough to recognise a document,
+// short enough that a page of them is not a page of whole documents.
+const SNIPPET_CHARS = 200
+
+// A search term is a plain substring, so the characters Postgres reads as
+// wildcards have to be escaped or a stray `%` matches everything.
+const likeNeedle = (search: string) =>
+	`%${search.replace(/[\\%_]/g, match => `\\${match}`)}%`
 
 export const DocumentsLive = HttpApiBuilder.group(
 	BatudaApi,
@@ -21,30 +64,80 @@ export const DocumentsLive = HttpApiBuilder.group(
 	handlers =>
 		Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
+			const storage = yield* StorageProvider
 			const timeline = yield* TimelineActivityService
+			const decodeSummaries = makeSummaryDecoder()
+
+			const detailFor = (row: unknown, id: string) =>
+				Effect.gen(function* () {
+					const doc = yield* decodeDocument(row)
+					const subjects = yield* subjectsForDocument(sql, id)
+					const storageKey = (row as { storageKey?: string | null }).storageKey
+					// The link is minted per read and expires, so one copied out of
+					// a log or a shared screen stops working shortly after.
+					const htmlUrl =
+						doc.format === 'html' && storageKey
+							? yield* storage
+									.signedUrl(storageKey, HTML_URL_TTL_SECONDS)
+									.pipe(Effect.orDie)
+							: null
+					return { ...doc, subjects, htmlUrl }
+				})
+
 			return handlers
 				.handle('list', _ =>
 					Effect.gen(function* () {
-						const limit = _.query.limit ?? 100
+						const limit = Math.min(_.query.limit ?? 50, 200)
 						const offset = _.query.offset ?? 0
 						const conditions: Array<Statement.Fragment> = []
-						if (_.query.companyId)
-							conditions.push(sql`company_id = ${_.query.companyId}`)
-						if (_.query.type) conditions.push(sql`type = ${_.query.type}`)
-						const rows = yield* sql<{ readonly total: string | number }>`
-							SELECT *, COUNT(*) OVER () AS total FROM documents
-							WHERE ${sql.and(conditions)}
+						if (_.query.subjectTable && _.query.subjectId) {
+							conditions.push(sql`EXISTS (
+								SELECT 1 FROM document_links dl
+								WHERE dl.document_id = d.id
+									AND dl.subject_table = ${_.query.subjectTable}
+									AND dl.subject_id = ${_.query.subjectId}
+							)`)
+						}
+						if (_.query.type) conditions.push(sql`d.type = ${_.query.type}`)
+						if (_.query.q) {
+							const needle = likeNeedle(_.query.q)
+							conditions.push(
+								// An HTML body is not in the database, so its plain words
+								// are what the search has to match against.
+								sql`(d.title ILIKE ${needle} OR d.content ILIKE ${needle} OR d.search_text ILIKE ${needle})`,
+							)
+						}
+						const whereClause =
+							conditions.length > 0 ? sql`WHERE ${sql.and(conditions)}` : sql``
+						const rows = yield* sql<{
+							readonly total: string | number
+							readonly id: string
+						}>`
+							SELECT
+								d.id, d.type, d.format, d.title, d.created_at, d.updated_at,
+								left(COALESCE(NULLIF(d.content, ''), d.search_text, ''), ${SNIPPET_CHARS}) AS snippet,
+								COALESCE((
+									SELECT json_agg(json_build_object(
+										'subjectTable', dl.subject_table,
+										'subjectId', dl.subject_id
+									) ORDER BY dl.subject_table, dl.created_at)
+									FROM document_links dl WHERE dl.document_id = d.id
+								), '[]'::json) AS subjects,
+								COUNT(*) OVER () AS total
+							FROM documents d
+							${whereClause}
+							ORDER BY d.updated_at DESC
 							LIMIT ${limit} OFFSET ${offset}
 						`
 						const total = yield* resolvePageTotal(
 							rows,
 							offset,
 							() => sql<{ readonly count: string | number }>`
-								SELECT count(*) AS count FROM documents
-								WHERE ${sql.and(conditions)}
+								SELECT count(*) AS count FROM documents d
+								${whereClause}
 							`,
 						)
-						const items = yield* decodeDocuments(rows)
+						const items = yield* decodeSummaries(rows)
 						return { items, total, limit, offset }
 					}).pipe(Effect.orDie),
 				)
@@ -58,7 +151,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 								entity: 'document',
 								id: _.params.id,
 							})
-						return yield* decodeDocument(doc)
+						return yield* detailFor(doc, _.params.id)
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
@@ -68,30 +161,93 @@ export const DocumentsLive = HttpApiBuilder.group(
 				.handle('create', _ =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const payload = _.payload as {
-							companyId: string
-							interactionId?: string
-							type: string
-							title?: string
-							content: string
+						const payload = _.payload
+						const isHtml = payload.format === 'html'
+						// The id is chosen here rather than by the database, because
+						// an HTML body is stored under a name built from it and the
+						// row has to carry that name from the moment it exists.
+						const documentId = randomUUID()
+						const storageKey = isHtml
+							? htmlStorageKey(currentOrg.id, documentId)
+							: null
+
+						// Bytes first. A stored page with no row is invisible and
+						// costs a little space; a row pointing at a page that was
+						// never written is a document that opens to nothing.
+						if (storageKey !== null) {
+							yield* storage
+								.put({
+									key: storageKey,
+									body: new TextEncoder().encode(payload.content),
+									contentType: 'text/html; charset=utf-8',
+								})
+								.pipe(Effect.orDie)
 						}
-						const rows = yield* sql<{ id: string; title: string | null }>`
-							INSERT INTO documents ${sql.insert({
-								...payload,
-								organizationId: currentOrg.id,
-							})} RETURNING id, title
-						`
-						const created = rows[0]
-						if (!created) {
-							return yield* Effect.die(
-								new Error('INSERT INTO documents RETURNING yielded no row'),
+
+						// The row and its first filing land together, so a filing
+						// that turns out to be impossible takes the document back
+						// out with it: a document filed nowhere is one nothing can
+						// reach.
+						const created = yield* sql
+							.withTransaction(
+								Effect.gen(function* () {
+									const rows = yield* sql<{
+										id: string
+										title: string | null
+									}>`
+										INSERT INTO documents ${sql.insert({
+											id: documentId,
+											organizationId: currentOrg.id,
+											type: payload.type,
+											format: payload.format ?? 'markdown',
+											title: payload.title,
+											// An HTML body lives in storage; only its plain
+											// words stay behind, so search still reaches it.
+											content: isHtml ? '' : payload.content,
+											searchText: isHtml
+												? searchTextFromHtml(payload.content)
+												: null,
+											storageKey,
+										})} RETURNING id, title
+									`
+									const row = rows[0]
+									if (!row) {
+										return yield* Effect.die(
+											new Error(
+												'INSERT INTO documents RETURNING yielded no row',
+											),
+										)
+									}
+									const linked = yield* linkDocument(
+										sql,
+										currentOrg.id,
+										row.id,
+										payload.subjectTable,
+										payload.subjectId,
+									)
+									if (!linked) {
+										return yield* Effect.die(
+											new Error(
+												`document subject ${payload.subjectTable}/${payload.subjectId} not found`,
+											),
+										)
+									}
+									return row
+								}),
 							)
-						}
+							.pipe(Effect.orDie)
+
 						yield* timeline.record(
 							new DocumentCreated({
 								documentId: created.id,
-								companyId: payload.companyId,
-								contactId: null,
+								companyId:
+									payload.subjectTable === 'companies'
+										? payload.subjectId
+										: null,
+								contactId:
+									payload.subjectTable === 'contacts'
+										? payload.subjectId
+										: null,
 								title: created.title ?? payload.type,
 								actorUserId: null,
 								occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
@@ -100,7 +256,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 						yield* Effect.logInfo('Document created').pipe(
 							Effect.annotateLogs({
 								event: 'document.created',
-								companyId: payload.companyId,
+								subjectTable: payload.subjectTable,
 								type: payload.type,
 							}),
 						)
@@ -111,7 +267,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 							return yield* Effect.die(
 								new Error('document vanished after insert'),
 							)
-						return yield* decodeDocument(doc)
+						return yield* detailFor(doc, created.id)
 					}).pipe(Effect.orDie),
 				)
 				.handle('update', _ =>
@@ -127,8 +283,51 @@ export const DocumentsLive = HttpApiBuilder.group(
 							}),
 						)
 						const row = rows[0]
-						return row === undefined ? null : yield* decodeDocument(row)
+						return row === undefined ? null : yield* detailFor(row, _.params.id)
 					}).pipe(Effect.orDie),
+				)
+				.handle('remove', _ =>
+					Effect.gen(function* () {
+						// The links go with the row through their foreign key.
+						yield* sql`DELETE FROM documents WHERE id = ${_.params.id}`
+						yield* Effect.logInfo('Document removed').pipe(
+							Effect.annotateLogs({
+								event: 'document.removed',
+								documentId: _.params.id,
+							}),
+						)
+					}).pipe(Effect.orDie),
+				)
+				.handle('attach', _ =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const linked = yield* linkDocument(
+							sql,
+							currentOrg.id,
+							_.params.id,
+							_.payload.subjectTable,
+							_.payload.subjectId,
+						)
+						if (!linked)
+							return yield* new NotFound({
+								entity: _.payload.subjectTable,
+								id: _.payload.subjectId,
+							})
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
+				)
+				.handle('detach', _ =>
+					unlinkDocument(
+						sql,
+						_.params.id,
+						_.params.subjectTable as DocumentSubjectTable,
+						_.params.subjectId,
+					).pipe(Effect.asVoid),
 				)
 		}),
 )
+
+export type { DocumentSubjectRow }

--- a/apps/server/src/handlers/tasks.ts
+++ b/apps/server/src/handlers/tasks.ts
@@ -74,7 +74,6 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 							contact_id: _.payload.contactId ?? null,
 							type: _.payload.type,
 							title: _.payload.title,
-							notes: _.payload.notes ?? null,
 							status: _.payload.status ?? 'open',
 							source: _.payload.source ?? 'user',
 							priority: _.payload.priority ?? 'normal',
@@ -109,7 +108,6 @@ export const TasksLive = HttpApiBuilder.group(BatudaApi, 'tasks', handlers =>
 						_.params.id,
 						{
 							title: _.payload.title,
-							notes: _.payload.notes,
 							status: _.payload.status,
 							priority: _.payload.priority,
 							assigneeId: _.payload.assigneeId,

--- a/apps/server/src/handlers/timeline.ts
+++ b/apps/server/src/handlers/timeline.ts
@@ -25,6 +25,14 @@ export const TimelineLive = HttpApiBuilder.group(
 						conditions.push(sql`company_id = ${_.query.companyId}`)
 					if (_.query.contactId)
 						conditions.push(sql`contact_id = ${_.query.contactId}`)
+					// Both together, or neither: an entity id means nothing without
+					// the kind of record it belongs to, and ids are only unique
+					// within their own table.
+					if (_.query.entityType && _.query.entityId) {
+						conditions.push(
+							sql`entity_type = ${_.query.entityType} AND entity_id = ${_.query.entityId}`,
+						)
+					}
 					if (_.query.channel)
 						conditions.push(sql`channel = ${_.query.channel}`)
 					if (_.query.kind) conditions.push(sql`kind = ${_.query.kind}`)

--- a/apps/server/src/lib/calendar-attendees.ts
+++ b/apps/server/src/lib/calendar-attendees.ts
@@ -23,7 +23,8 @@ const attendeesByEvent = (
 		// Result keys arrive camelCased whatever the column spelling, hence
 		// `eventId` rather than `event_id`.
 		const rows = yield* sql<{ readonly eventId: string }>`
-			SELECT id, event_id, email, name, contact_id, company_id, rsvp, is_organizer
+			SELECT id, event_id, email, name, contact_id, company_id, rsvp, is_organizer,
+				match_status, match_candidates
 			FROM calendar_event_attendees
 			WHERE event_id = ANY(${eventIds as unknown as string[]})
 			ORDER BY is_organizer DESC, email ASC

--- a/apps/server/src/mcp/prompts/company-research.ts
+++ b/apps/server/src/mcp/prompts/company-research.ts
@@ -22,8 +22,12 @@ export const CompanyResearchPrompt = McpServer.prompt({
 			const data = rawData as Record<string, unknown>
 			const sql = yield* SqlClient.SqlClient
 			const companyId = data['id'] as string
-			const docs =
-				yield* sql`SELECT id, type, title FROM documents WHERE company_id = ${companyId}`
+			const docs = yield* sql`
+				SELECT d.id, d.type, d.title FROM documents d
+				JOIN document_links dl ON dl.document_id = d.id
+				WHERE dl.subject_table = 'companies' AND dl.subject_id = ${companyId}
+				ORDER BY d.updated_at DESC
+			`
 			const tasks =
 				yield* sql`SELECT * FROM tasks WHERE company_id = ${companyId} AND completed_at IS NULL ORDER BY due_at`
 

--- a/apps/server/src/mcp/resources/document.ts
+++ b/apps/server/src/mcp/resources/document.ts
@@ -7,13 +7,19 @@ const docIdParam = McpSchema.param('id', Schema.String)
 export const DocumentResource =
 	McpServer.resource`batuda://document/${docIdParam}`({
 		name: 'Document',
-		description: 'Full document content by ID (markdown or other).',
+		description:
+			'Full markdown body of a document by ID, with the CRM records it is filed against.',
 		mimeType: 'application/json',
 		audience: ['assistant'],
 		content: Effect.fn(function* (_uri, id) {
 			const sql = yield* SqlClient.SqlClient
 			const rows = yield* sql`SELECT * FROM documents WHERE id = ${id} LIMIT 1`
-			if (!rows[0]) return yield* Effect.die(`Document ${id} not found`)
-			return JSON.stringify(rows[0], null, 2)
+			const doc = rows[0]
+			if (!doc) return yield* Effect.die(`Document ${id} not found`)
+			// Where a document is filed lives in its own table, so reading the
+			// row alone would hand back a document with no home.
+			const subjects =
+				yield* sql`SELECT subject_table, subject_id FROM document_links WHERE document_id = ${id} ORDER BY subject_table, created_at`
+			return JSON.stringify({ ...doc, subjects }, null, 2)
 		}),
 	})

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -15,6 +15,7 @@ import {
 	contactChannelsJson,
 	writeChannels,
 } from '../../services/contact-channels'
+import { unlinkSubject } from '../../services/documents'
 import { ListResult, toItems } from './_result'
 
 const decodeContact = Schema.decodeUnknownEffect(Contact)
@@ -49,7 +50,6 @@ const CreateContact = Tool.make('create_contact', {
 		company_id: Schema.String,
 		name: Schema.String,
 		role: Schema.optional(Schema.String),
-		notes: Schema.optional(Schema.String),
 		channels: Schema.optional(Schema.Array(ChannelInput)),
 	}),
 	success: ContactWithChannels,
@@ -66,7 +66,6 @@ const UpdateContact = Tool.make('update_contact', {
 		id: Schema.String,
 		name: Schema.optional(Schema.String),
 		role: Schema.optional(Schema.String),
-		notes: Schema.optional(Schema.String),
 		channels: Schema.optional(Schema.Array(ChannelInput)),
 		clear_email_suppression: Schema.optional(Schema.Boolean),
 	}),
@@ -164,6 +163,9 @@ export const ContactHandlersLive = ContactTools.toLayer(
 
 			delete_contact: ({ id }) =>
 				Effect.gen(function* () {
+					// No foreign key clears these, so they would outlive the person
+					// and point at nobody.
+					yield* unlinkSubject(sql, 'contacts', id)
 					yield* sql`DELETE FROM contacts WHERE id = ${id}`
 					return { status: 'deleted' as const }
 				}).pipe(Effect.orDie),

--- a/apps/server/src/mcp/tools/documents.ts
+++ b/apps/server/src/mcp/tools/documents.ts
@@ -3,8 +3,17 @@ import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg, DocumentSummary } from '@batuda/controllers'
-import { Document } from '@batuda/domain'
+import {
+	DOCUMENT_SUBJECT_TABLES,
+	Document,
+	DocumentSubjectTable,
+} from '@batuda/domain'
 
+import {
+	linkDocument,
+	subjectsForDocument,
+	unlinkDocument,
+} from '../../services/documents'
 import {
 	DocumentCreated,
 	TimelineActivityService,
@@ -14,22 +23,42 @@ import { ListResult, toItems } from './_result'
 const REQUEST_DEPENDENCIES = [CurrentOrg]
 
 const decodeDocument = Schema.decodeUnknownEffect(Document)
+
 // The listing query reads the summary columns with the raw Date, so override
-// just the timestamp before decoding into the wire summary shape.
-const DocumentSummaryRow = Schema.Struct({
-	...DocumentSummary.fields,
-	createdAt: Schema.DateTimeUtcFromDate,
-})
-const decodeSummaries = Schema.decodeUnknownEffect(
-	Schema.Array(DocumentSummaryRow),
-)
+// just the timestamps before decoding into the wire summary shape. Built when
+// the layer runs, not when the file loads: `DocumentSummary` comes from another
+// package that is still being set up at that point.
+const makeSummaryDecoder = () =>
+	Schema.decodeUnknownEffect(
+		Schema.Array(
+			Schema.Struct({
+				...DocumentSummary.fields,
+				createdAt: Schema.DateTimeUtcFromDate,
+				updatedAt: Schema.DateTimeUtcFromDate,
+			}),
+		),
+	)
+
+// The same amount of the body the web list shows.
+const SNIPPET_CHARS = 200
+
+// A body has no size limit, so one very long document could use up all the
+// room an agent has left to think in. It comes back cut off, and says so.
+const MAX_BODY_CHARS = 100_000
+const truncateLongBody = (content: string) =>
+	content.length > MAX_BODY_CHARS
+		? `${content.slice(0, MAX_BODY_CHARS)}…[truncated]`
+		: content
+
+const SUBJECT_TABLE_CHOICES = DOCUMENT_SUBJECT_TABLES.join('|')
 
 const GetDocuments = Tool.make('get_documents', {
-	description:
-		'List documents for a company. Returns id, type, and title only — NOT content. Call get_document for full content.',
+	description: `List documents filed against a CRM record. subject_table (${SUBJECT_TABLE_CHOICES}) + subject_id narrows to one record; type and q (substring of title or body) filter further; all are optional and combinable. Returns id, type, title, timestamps, a short snippet and where each document is filed — NOT the full body. Call get_document for that.`,
 	parameters: Schema.Struct({
-		company_id: Schema.String,
-		type: Schema.optional(Schema.String),
+		subject_table: Schema.optional(DocumentSubjectTable),
+		subject_id: Schema.optional(Schema.String),
+		type: Schema.optional(Document.json.fields.type),
+		q: Schema.optional(Schema.String),
 	}),
 	success: ListResult(DocumentSummary),
 	dependencies: REQUEST_DEPENDENCIES,
@@ -40,11 +69,19 @@ const GetDocuments = Tool.make('get_documents', {
 	.annotate(Tool.OpenWorld, false)
 
 const GetDocument = Tool.make('get_document', {
-	description: 'Get a single document with full markdown content.',
+	description: `Get a single document with its markdown body and the records it is filed against. A body longer than ${MAX_BODY_CHARS} characters comes back cut off, ending in "…[truncated]".`,
 	parameters: Schema.Struct({
 		id: Schema.String,
 	}),
-	success: Document.json,
+	success: Schema.Struct({
+		...Document.json.fields,
+		subjects: Schema.Array(
+			Schema.Struct({
+				subjectTable: DocumentSubjectTable,
+				subjectId: Schema.String,
+			}),
+		),
+	}),
 	dependencies: REQUEST_DEPENDENCIES,
 })
 	.annotate(Tool.Title, 'Get Document')
@@ -53,12 +90,11 @@ const GetDocument = Tool.make('get_document', {
 	.annotate(Tool.OpenWorld, false)
 
 const CreateDocument = Tool.make('create_document', {
-	description:
-		'Create a document for a company. Type: note|proposal|contract|report|brief|other. Content: full markdown.',
+	description: `Create a document filed against a CRM record: subject_table (${SUBJECT_TABLE_CHOICES}) + subject_id say where it belongs, and attach_document files the same document in more places afterwards. Content is markdown. A prep note for a meeting is filed against that calendar_event, not against the company.`,
 	parameters: Schema.Struct({
-		company_id: Schema.String,
-		interaction_id: Schema.optional(Schema.String),
-		type: Schema.String,
+		subject_table: DocumentSubjectTable,
+		subject_id: Schema.String,
+		type: Document.json.fields.type,
 		title: Schema.optional(Schema.String),
 		content: Schema.String,
 	}),
@@ -70,9 +106,11 @@ const CreateDocument = Tool.make('create_document', {
 	.annotate(Tool.OpenWorld, false)
 
 const UpdateDocument = Tool.make('update_document', {
-	description: 'Update a document content or title.',
+	description:
+		'Update a document title, body or type. Only the fields you pass change.',
 	parameters: Schema.Struct({
 		id: Schema.String,
+		type: Schema.optional(Document.json.fields.type),
 		title: Schema.optional(Schema.String),
 		content: Schema.optional(Schema.String),
 	}),
@@ -84,24 +122,107 @@ const UpdateDocument = Tool.make('update_document', {
 	.annotate(Tool.Idempotent, true)
 	.annotate(Tool.OpenWorld, false)
 
+const DeleteDocument = Tool.make('delete_document', {
+	description:
+		'Permanently delete a document and every filing of it. There is no version history, so the body is gone. An id that is already gone still reports deleted. To keep the document but stop showing it against one record, use detach_document instead.',
+	parameters: Schema.Struct({ id: Schema.String }),
+	success: Schema.Struct({ status: Schema.Literal('deleted') }),
+	dependencies: REQUEST_DEPENDENCIES,
+})
+	.annotate(Tool.Title, 'Delete Document')
+	.annotate(Tool.Destructive, true)
+	.annotate(Tool.Idempotent, true)
+	.annotate(Tool.OpenWorld, false)
+
+const AttachDocument = Tool.make('attach_document', {
+	description: `File an existing document against one more CRM record: subject_table (${SUBJECT_TABLE_CHOICES}) + subject_id. A document can be filed in any number of places, and filing it where it already sits is a no-op. Returns not_found when the record does not exist or belongs to another organisation.`,
+	parameters: Schema.Struct({
+		id: Schema.String,
+		subject_table: DocumentSubjectTable,
+		subject_id: Schema.String,
+	}),
+	success: Schema.Union([
+		Schema.Struct({ status: Schema.Literal('attached') }),
+		Schema.Struct({ error: Schema.Literal('not_found') }),
+	]),
+	dependencies: REQUEST_DEPENDENCIES,
+})
+	.annotate(Tool.Title, 'Attach Document')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.Idempotent, true)
+	.annotate(Tool.OpenWorld, false)
+
+const DetachDocument = Tool.make('detach_document', {
+	description:
+		'Stop filing a document against one record. The document itself survives, along with its other filings; unfiling something already unfiled is a no-op.',
+	parameters: Schema.Struct({
+		id: Schema.String,
+		subject_table: DocumentSubjectTable,
+		subject_id: Schema.String,
+	}),
+	success: Schema.Struct({ status: Schema.Literal('detached') }),
+	dependencies: REQUEST_DEPENDENCIES,
+})
+	.annotate(Tool.Title, 'Detach Document')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.Idempotent, true)
+	.annotate(Tool.OpenWorld, false)
+
 export const DocumentTools = Toolkit.make(
 	GetDocuments,
 	GetDocument,
 	CreateDocument,
 	UpdateDocument,
+	DeleteDocument,
+	AttachDocument,
+	DetachDocument,
 )
 
 export const DocumentHandlersLive = DocumentTools.toLayer(
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
 		const timeline = yield* TimelineActivityService
+		const decodeSummaries = makeSummaryDecoder()
 		return {
 			get_documents: params =>
 				Effect.gen(function* () {
-					const conditions = [sql`company_id = ${params.company_id}`]
-					if (params.type) conditions.push(sql`type = ${params.type}`)
-					const rows =
-						yield* sql`SELECT id, company_id, type, title, created_at FROM documents WHERE ${sql.and(conditions)}`
+					const conditions = []
+					if (params.subject_table && params.subject_id) {
+						conditions.push(sql`EXISTS (
+							SELECT 1 FROM document_links dl
+							WHERE dl.document_id = d.id
+								AND dl.subject_table = ${params.subject_table}
+								AND dl.subject_id = ${params.subject_id}
+						)`)
+					}
+					if (params.type) conditions.push(sql`d.type = ${params.type}`)
+					if (params.q) {
+						// A search term is a plain substring, so the characters
+						// Postgres reads as wildcards have to be escaped or a stray
+						// `%` matches everything.
+						const needle = `%${params.q.replace(/[\\%_]/g, match => `\\${match}`)}%`
+						conditions.push(
+							sql`(d.title ILIKE ${needle} OR d.content ILIKE ${needle})`,
+						)
+					}
+					const whereClause =
+						conditions.length > 0 ? sql`WHERE ${sql.and(conditions)}` : sql``
+					const rows = yield* sql`
+						SELECT
+							d.id, d.type, d.title, d.created_at, d.updated_at,
+							left(d.content, ${SNIPPET_CHARS}) AS snippet,
+							COALESCE((
+								SELECT json_agg(json_build_object(
+									'subjectTable', dl.subject_table,
+									'subjectId', dl.subject_id
+								) ORDER BY dl.subject_table, dl.created_at)
+								FROM document_links dl WHERE dl.document_id = d.id
+							), '[]'::json) AS subjects
+						FROM documents d
+						${whereClause}
+						ORDER BY d.updated_at DESC
+						LIMIT 100
+					`
 					return toItems(yield* decodeSummaries(rows))
 				}).pipe(Effect.orDie),
 			get_document: ({ id }) =>
@@ -110,32 +231,64 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 						yield* sql`SELECT * FROM documents WHERE id = ${id} LIMIT 1`
 					const doc = rows[0]
 					if (!doc) return yield* Effect.die(`Document ${id} not found`)
-					return yield* decodeDocument(doc)
+					const decoded = yield* decodeDocument(doc)
+					const subjects = yield* subjectsForDocument(sql, id)
+					return {
+						...decoded,
+						content: truncateLongBody(decoded.content),
+						subjects,
+					}
 				}).pipe(Effect.orDie),
 			create_document: params =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
-					const rows = yield* sql<{ id: string; title: string | null }>`
-						INSERT INTO documents ${sql.insert({
-							organizationId: currentOrg.id,
-							companyId: params.company_id,
-							interactionId: params.interaction_id,
-							type: params.type,
-							title: params.title,
-							content: params.content,
-						})} RETURNING id, title
-					`
-					const created = rows[0]
-					if (!created) {
-						return yield* Effect.die(
-							new Error('INSERT INTO documents RETURNING yielded no row'),
+					// The row and its first filing land together, so a filing that
+					// turns out to be impossible takes the document back out with
+					// it. The local stdio surface has no request transaction of its
+					// own to fall back on.
+					const created = yield* sql
+						.withTransaction(
+							Effect.gen(function* () {
+								const rows = yield* sql<{ id: string; title: string | null }>`
+									INSERT INTO documents ${sql.insert({
+										organizationId: currentOrg.id,
+										type: params.type,
+										title: params.title,
+										content: params.content,
+									})} RETURNING id, title
+								`
+								const row = rows[0]
+								if (!row) {
+									return yield* Effect.die(
+										new Error('INSERT INTO documents RETURNING yielded no row'),
+									)
+								}
+								const linked = yield* linkDocument(
+									sql,
+									currentOrg.id,
+									row.id,
+									params.subject_table,
+									params.subject_id,
+								)
+								if (!linked) {
+									return yield* Effect.die(
+										new Error(
+											`document subject ${params.subject_table}/${params.subject_id} not found`,
+										),
+									)
+								}
+								return row
+							}),
 						)
-					}
+						.pipe(Effect.orDie)
+
 					yield* timeline.record(
 						new DocumentCreated({
 							documentId: created.id,
-							companyId: params.company_id,
-							contactId: null,
+							companyId:
+								params.subject_table === 'companies' ? params.subject_id : null,
+							contactId:
+								params.subject_table === 'contacts' ? params.subject_id : null,
 							title: created.title ?? params.type,
 							actorUserId: null,
 							occurredAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
@@ -160,6 +313,36 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 						yield* sql`UPDATE documents SET ${sql.update(data, ['id'])} WHERE id = ${id} RETURNING *`
 					const row = rows[0]
 					return row === undefined ? null : yield* decodeDocument(row)
+				}).pipe(Effect.orDie),
+			delete_document: ({ id }) =>
+				Effect.gen(function* () {
+					// The filings go with the document through their foreign key.
+					yield* sql`DELETE FROM documents WHERE id = ${id}`
+					return { status: 'deleted' as const }
+				}).pipe(Effect.orDie),
+			attach_document: params =>
+				Effect.gen(function* () {
+					const currentOrg = yield* CurrentOrg
+					const linked = yield* linkDocument(
+						sql,
+						currentOrg.id,
+						params.id,
+						params.subject_table,
+						params.subject_id,
+					)
+					return linked
+						? { status: 'attached' as const }
+						: { error: 'not_found' as const }
+				}).pipe(Effect.orDie),
+			detach_document: params =>
+				Effect.gen(function* () {
+					yield* unlinkDocument(
+						sql,
+						params.id,
+						params.subject_table,
+						params.subject_id,
+					)
+					return { status: 'detached' as const }
 				}).pipe(Effect.orDie),
 		}
 	}),

--- a/apps/server/src/mcp/tools/proposals.ts
+++ b/apps/server/src/mcp/tools/proposals.ts
@@ -57,7 +57,6 @@ const CreateProposal = Tool.make('create_proposal', {
 		total_value: Schema.optional(Schema.String),
 		currency: Schema.optional(Schema.String),
 		expires_at: Schema.optional(Schema.String),
-		notes: Schema.optional(Schema.String),
 		metadata: Schema.optional(Schema.Unknown),
 	}),
 	success: Proposal.json,
@@ -76,7 +75,6 @@ const UpdateProposal = Tool.make('update_proposal', {
 		title: Schema.optional(Schema.String),
 		line_items: Schema.optional(Schema.Unknown),
 		total_value: Schema.optional(Schema.String),
-		notes: Schema.optional(Schema.String),
 		metadata: Schema.optional(Schema.Unknown),
 	}),
 	success: Schema.NullOr(Proposal.json),
@@ -121,7 +119,6 @@ export const ProposalHandlersLive = ProposalTools.toLayer(
 					if (params.currency !== undefined) row['currency'] = params.currency
 					if (params.expires_at !== undefined)
 						row['expiresAt'] = params.expires_at
-					if (params.notes !== undefined) row['notes'] = params.notes
 					if (params.metadata !== undefined) row['metadata'] = params.metadata
 					const rows =
 						yield* sql`INSERT INTO proposals ${sql.insert(row)} RETURNING *`
@@ -152,7 +149,6 @@ export const ProposalHandlersLive = ProposalTools.toLayer(
 					if (rest.line_items !== undefined) data['lineItems'] = rest.line_items
 					if (rest.total_value !== undefined)
 						data['totalValue'] = rest.total_value
-					if (rest.notes !== undefined) data['notes'] = rest.notes
 					if (rest.metadata !== undefined) data['metadata'] = rest.metadata
 					// Stamp the send/first-response moments on the transition into each.
 					if (rest.status === 'sent' && before?.status !== 'sent') {

--- a/apps/server/src/mcp/tools/research-lifecycle.ts
+++ b/apps/server/src/mcp/tools/research-lifecycle.ts
@@ -8,6 +8,7 @@ import {
 	ResearchRunSummary,
 	SessionContext,
 } from '@batuda/controllers'
+import { RESEARCH_SUBJECT_TABLES, ResearchSubjectTable } from '@batuda/domain'
 import { ResearchService } from '@batuda/research'
 
 import { CompanyService } from '../../services/companies'
@@ -61,11 +62,12 @@ const CancelResearch = Tool.make('cancel_research', {
 	.annotate(Tool.OpenWorld, false)
 
 const AttachResearch = Tool.make('attach_research', {
-	description:
-		'Post-hoc link a research run to a CRM subject (companies|contacts). Inserts a finding row in research_links; re-attaching the same pair is a no-op.',
+	// The allowed subjects are read off the same list the parameter is built
+	// from, so the sentence an agent reads cannot drift from what it accepts.
+	description: `Post-hoc link a research run to a CRM subject (${RESEARCH_SUBJECT_TABLES.join('|')}). Inserts a finding row in research_links; re-attaching the same pair is a no-op.`,
 	parameters: Schema.Struct({
 		id: Schema.String,
-		subject_table: Schema.Literals(['companies', 'contacts']),
+		subject_table: ResearchSubjectTable,
 		subject_id: Uuid,
 	}),
 	success: Schema.Union([

--- a/apps/server/src/mcp/tools/tasks.ts
+++ b/apps/server/src/mcp/tools/tasks.ts
@@ -49,7 +49,6 @@ const CreateTask = Tool.make('create_task', {
 		type: Schema.String,
 		company_id: Schema.optional(Schema.NullOr(Schema.String)),
 		contact_id: Schema.optional(Schema.NullOr(Schema.String)),
-		notes: Schema.optional(Schema.NullOr(Schema.String)),
 		due_at: Schema.optional(Schema.NullOr(Schema.String)),
 		priority: Schema.optional(TaskPriority),
 		source: Schema.optional(TaskSource),
@@ -98,7 +97,7 @@ const ListTasks = Tool.make('list_tasks', {
 
 const SearchTasks = Tool.make('search_tasks', {
 	description:
-		'Full-text-ish search by ILIKE against title/notes. Accepts the same filters as list_tasks; `query` is the substring to match. Returns at most `limit` rows (default 25).',
+		'Substring search over a task title and the documents filed against it. Accepts the same filters as list_tasks; `query` is the substring to match. Returns at most `limit` rows (default 25).',
 	parameters: Schema.Struct({
 		query: Schema.String,
 		company_id: Schema.optional(Schema.String),
@@ -126,7 +125,6 @@ const UpdateTask = Tool.make('update_task', {
 		id: Schema.String,
 		title: Schema.optional(Schema.String),
 		type: Schema.optional(Schema.String),
-		notes: Schema.optional(Schema.NullOr(Schema.String)),
 		priority: Schema.optional(TaskPriority),
 		due_at: Schema.optional(Schema.NullOr(Schema.String)),
 		assignee_id: Schema.optional(Schema.NullOr(Schema.String)),
@@ -274,7 +272,6 @@ export const TaskHandlersLive = TaskTools.toLayer(
 							type: params.type,
 							companyId: params.company_id ?? null,
 							contactId: params.contact_id ?? null,
-							notes: params.notes ?? null,
 							dueAt: asDate(params.due_at ?? null),
 							priority: params.priority ?? 'normal',
 							source: params.source ?? 'agent',
@@ -346,7 +343,6 @@ export const TaskHandlersLive = TaskTools.toLayer(
 					const fields: Record<string, unknown> = {}
 					if (params.title !== undefined) fields['title'] = params.title
 					if (params.type !== undefined) fields['type'] = params.type
-					if (params.notes !== undefined) fields['notes'] = params.notes
 					if (params.priority !== undefined)
 						fields['priority'] = params.priority
 					if (params.due_at !== undefined)

--- a/apps/server/src/mcp/tools/timeline.ts
+++ b/apps/server/src/mcp/tools/timeline.ts
@@ -3,7 +3,7 @@ import { Tool, Toolkit } from 'effect/unstable/ai'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { TimelineActivity } from '@batuda/domain'
+import { TimelineActivity, TimelineEntityType } from '@batuda/domain'
 
 import { ListResult, toItems } from './_result'
 
@@ -13,10 +13,12 @@ const decodeActivities = Schema.decodeUnknownEffect(
 
 const ListTimeline = Tool.make('list_timeline', {
 	description:
-		'List timeline activity for a company or contact. Covers emails, calls, meetings, documents, proposals, research runs. Filter by channel, kind, since (ISO 8601). Max 200 rows.',
+		'List timeline activity. company_id or contact_id gives a company or person their whole history; entity_type + entity_id gives one record its own — the events about a single task, proposal or meeting. Covers emails, calls, meetings, documents, proposals, research runs. Filter by channel, kind, since (ISO 8601). Max 200 rows.',
 	parameters: Schema.Struct({
 		company_id: Schema.optional(Schema.String),
 		contact_id: Schema.optional(Schema.String),
+		entity_type: Schema.optional(TimelineEntityType),
+		entity_id: Schema.optional(Schema.String),
 		channel: Schema.optional(Schema.String),
 		kind: Schema.optional(Schema.String),
 		since: Schema.optional(Schema.String),
@@ -42,6 +44,13 @@ export const TimelineHandlersLive = TimelineTools.toLayer(
 						conditions.push(sql`company_id = ${params.company_id}`)
 					if (params.contact_id)
 						conditions.push(sql`contact_id = ${params.contact_id}`)
+					// Both together, or neither: an id means nothing without the
+					// kind of record it belongs to.
+					if (params.entity_type && params.entity_id) {
+						conditions.push(
+							sql`entity_type = ${params.entity_type} AND entity_id = ${params.entity_id}`,
+						)
+					}
 					if (params.channel) conditions.push(sql`channel = ${params.channel}`)
 					if (params.kind) conditions.push(sql`kind = ${params.kind}`)
 					if (params.since) {

--- a/apps/server/src/services/documents.integration.test.ts
+++ b/apps/server/src/services/documents.integration.test.ts
@@ -1,0 +1,215 @@
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+import {
+	linkDocument,
+	subjectsForDocument,
+	unlinkSubject,
+} from './documents.js'
+
+// `document_links.subject_id` carries no foreign key — one key cannot point at
+// five tables — so nothing in the database stops a link pointing at a record
+// that does not exist, or at one belonging to somebody else. `linkDocument` is
+// the only thing standing between those two cases and a stored link, which
+// makes it worth exercising against a real database rather than a mock.
+//
+// Runs through `enterOrgScope`, so the app_user role and the org GUC are in
+// force exactly as they are on a request.
+
+const ORG_A = `docs-a-${randomUUID()}`
+const ORG_B = `docs-b-${randomUUID()}`
+const ORG_A_OBJ = { id: ORG_A, name: 'docs-a', slug: 'docs-a' }
+
+let documentId = ''
+let companyInOrgA = ''
+let companyInOrgB = ''
+
+const runRoot = <A>(
+	eff: Effect.Effect<A, unknown, SqlClient.SqlClient>,
+): Promise<A> =>
+	Effect.runPromise(
+		eff.pipe(Effect.orDie, Effect.provide(PgLive)) as Effect.Effect<
+			A,
+			never,
+			never
+		>,
+	)
+
+// Seeding runs outside the org scope, as the migration-owning role, so both
+// organisations' fixtures can be written from one place.
+const seed = () =>
+	runRoot(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [docRow] = yield* sql<{ id: string }>`
+				INSERT INTO documents (organization_id, type, content)
+				VALUES (${ORG_A}, 'general', 'Guard fixture') RETURNING id
+			`
+			documentId = docRow?.id ?? ''
+			const [a] = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, slug, name)
+				VALUES (${ORG_A}, ${`docs-a-${randomUUID()}`}, 'In org A') RETURNING id
+			`
+			companyInOrgA = a?.id ?? ''
+			const [b] = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, slug, name)
+				VALUES (${ORG_B}, ${`docs-b-${randomUUID()}`}, 'In org B') RETURNING id
+			`
+			companyInOrgB = b?.id ?? ''
+		}),
+	)
+
+const linkAsOrgA = (subjectId: string) =>
+	runRoot(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org: ORG_A_OBJ })(
+				linkDocument(sql, ORG_A, documentId, 'companies', subjectId),
+			)
+		}),
+	)
+
+describe('filing a document against a record', () => {
+	beforeAll(async () => {
+		await seed()
+	})
+
+	afterAll(async () => {
+		await runRoot(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				yield* sql`DELETE FROM documents WHERE organization_id IN (${ORG_A}, ${ORG_B})`
+				yield* sql`DELETE FROM companies WHERE organization_id IN (${ORG_A}, ${ORG_B})`
+			}),
+		)
+	})
+
+	describe('when the record is real and belongs to the same organisation', () => {
+		it('should store the filing', async () => {
+			// GIVEN a company in the caller's own organisation
+			// WHEN the document is filed against it
+			const filed = await linkAsOrgA(companyInOrgA)
+			// THEN it is accepted and readable back
+			expect(filed).toBe(true)
+			const subjects = await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* subjectsForDocument(sql, documentId)
+				}),
+			)
+			expect(subjects.map(s => s.subjectId)).toContain(companyInOrgA)
+		})
+
+		it('should absorb a repeat rather than fail', async () => {
+			// GIVEN the same document already filed there
+			// WHEN the same pair is filed again, as re-filing does
+			// THEN it succeeds and leaves one filing, not two
+			expect(await linkAsOrgA(companyInOrgA)).toBe(true)
+			const subjects = await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* subjectsForDocument(sql, documentId)
+				}),
+			)
+			expect(subjects.filter(s => s.subjectId === companyInOrgA)).toHaveLength(
+				1,
+			)
+		})
+	})
+
+	describe('when the record belongs to another organisation', () => {
+		it('should refuse, so a filing cannot reach across organisations', async () => {
+			// GIVEN a company id that is real but owned by a different organisation
+			// WHEN the caller tries to file their document against it — the shape a
+			//      guessed or leaked id would take
+			const filed = await linkAsOrgA(companyInOrgB)
+			// THEN it is refused, and nothing is written
+			expect(filed).toBe(false)
+			const subjects = await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* subjectsForDocument(sql, documentId)
+				}),
+			)
+			expect(subjects.map(s => s.subjectId)).not.toContain(companyInOrgB)
+		})
+	})
+
+	describe('when the document belongs to another organisation', () => {
+		it('should refuse, rather than reveal that the id is real', async () => {
+			// GIVEN a document owned by a different organisation. The caller cannot
+			// read it, but the link's foreign key is checked by the database itself
+			// and does not apply that restriction — so the write would otherwise
+			// succeed and answer "does this id exist?" for free.
+			const otherDocument = await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					const [row] = yield* sql<{ id: string }>`
+						INSERT INTO documents (organization_id, type, content)
+						VALUES (${ORG_B}, 'general', 'Not yours') RETURNING id
+					`
+					return row?.id ?? ''
+				}),
+			)
+
+			// WHEN the caller files that document against their own company
+			const filed = await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org: ORG_A_OBJ })(
+						linkDocument(sql, ORG_A, otherDocument, 'companies', companyInOrgA),
+					)
+				}),
+			)
+
+			// THEN it is refused, and no link exists to point at it
+			expect(filed).toBe(false)
+			const links = await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* sql<{
+						count: string
+					}>`SELECT count(*)::text AS count FROM document_links WHERE document_id = ${otherDocument}`
+				}),
+			)
+			expect(links[0]?.count).toBe('0')
+		})
+	})
+
+	describe('when the record does not exist at all', () => {
+		it('should refuse rather than leave a filing pointing at nothing', async () => {
+			// GIVEN an id no company carries
+			// WHEN the document is filed against it
+			// THEN it is refused — the database would have accepted the row, since
+			//      subject_id has no foreign key to check it against
+			expect(await linkAsOrgA(randomUUID())).toBe(false)
+		})
+	})
+
+	describe('when a record is deleted', () => {
+		it('should take its filings with it', async () => {
+			// GIVEN a document filed against a company
+			await linkAsOrgA(companyInOrgA)
+			// WHEN the delete path clears that record's filings
+			await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* unlinkSubject(sql, 'companies', companyInOrgA)
+				}),
+			)
+			// THEN none are left behind pointing at an id that no longer resolves
+			const subjects = await runRoot(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* subjectsForDocument(sql, documentId)
+				}),
+			)
+			expect(subjects.map(s => s.subjectId)).not.toContain(companyInOrgA)
+		})
+	})
+})

--- a/apps/server/src/services/documents.ts
+++ b/apps/server/src/services/documents.ts
@@ -1,0 +1,163 @@
+import { Effect } from 'effect'
+import type { SqlClient } from 'effect/unstable/sql'
+
+import type { DocumentSubjectTable } from '@batuda/domain'
+
+/**
+ * Filing documents against CRM records.
+ *
+ * The web app and the agent tools both file documents, and a second copy of the
+ * rules is how the two would drift apart.
+ *
+ * A link names its record by table and id, which no foreign key can enforce, so
+ * the record is checked for existence and ownership before a link is written.
+ */
+
+/**
+ * Is this record real, and does it belong to this organisation?
+ *
+ * A branch per table keeps the table name a literal rather than a value dropped
+ * into the statement. Companies and contacts can be retired without being
+ * removed, and a retired one should not accept new filings; the other three
+ * have no such state.
+ */
+const subjectExists = (
+	sql: SqlClient.SqlClient,
+	orgId: string,
+	subjectTable: DocumentSubjectTable,
+	subjectId: string,
+) => {
+	switch (subjectTable) {
+		case 'companies':
+			return sql<{
+				id: string
+			}>`SELECT id FROM companies WHERE id = ${subjectId} AND organization_id = ${orgId} AND deleted_at IS NULL LIMIT 1`
+		case 'contacts':
+			return sql<{
+				id: string
+			}>`SELECT id FROM contacts WHERE id = ${subjectId} AND organization_id = ${orgId} AND deleted_at IS NULL LIMIT 1`
+		case 'tasks':
+			return sql<{
+				id: string
+			}>`SELECT id FROM tasks WHERE id = ${subjectId} AND organization_id = ${orgId} LIMIT 1`
+		case 'proposals':
+			return sql<{
+				id: string
+			}>`SELECT id FROM proposals WHERE id = ${subjectId} AND organization_id = ${orgId} LIMIT 1`
+		case 'calendar_events':
+			return sql<{
+				id: string
+			}>`SELECT id FROM calendar_events WHERE id = ${subjectId} AND organization_id = ${orgId} LIMIT 1`
+	}
+}
+
+/**
+ * File a document against a record, if that record is really there.
+ *
+ * Returns false when the record does not exist or belongs to someone else, so a
+ * caller can answer "not found" instead of leaving a link pointing at nothing.
+ * Filing the same pair twice is not an error — it just stays filed once.
+ */
+export const linkDocument = (
+	sql: SqlClient.SqlClient,
+	orgId: string,
+	documentId: string,
+	subjectTable: DocumentSubjectTable,
+	subjectId: string,
+): Effect.Effect<boolean, never, never> =>
+	Effect.gen(function* () {
+		// Both ends are checked, not just the record. The isolation policy keeps
+		// another organisation's document out of any result the caller reads, but
+		// the link's foreign key is checked by the database itself and ignores
+		// that policy — so without this, filing against a document id belonging to
+		// somebody else would succeed and quietly report whether that id is real.
+		const [document] = yield* sql<{ id: string }>`
+			SELECT id FROM documents
+			WHERE id = ${documentId} AND organization_id = ${orgId}
+			LIMIT 1
+		`
+		if (!document) return false
+		const [subject] = yield* subjectExists(sql, orgId, subjectTable, subjectId)
+		if (!subject) return false
+		yield* sql`
+			INSERT INTO document_links (organization_id, document_id, subject_table, subject_id)
+			VALUES (${orgId}, ${documentId}, ${subjectTable}, ${subjectId})
+			ON CONFLICT DO NOTHING
+		`
+		return true
+	}).pipe(Effect.orDie)
+
+/** Stop filing a document against a record. Unfiling twice is harmless. */
+export const unlinkDocument = (
+	sql: SqlClient.SqlClient,
+	documentId: string,
+	subjectTable: DocumentSubjectTable,
+	subjectId: string,
+) =>
+	sql`
+		DELETE FROM document_links
+		WHERE document_id = ${documentId}
+			AND subject_table = ${subjectTable}
+			AND subject_id = ${subjectId}
+	`.pipe(Effect.orDie)
+
+/**
+ * Drop every filing that points at a record about to be deleted.
+ *
+ * `subject_id` has no foreign key, so nothing removes these on its own — the
+ * links would outlive the row and point at an id that no longer resolves. Call
+ * this from each delete path, in the same transaction as the delete.
+ */
+export const unlinkSubject = (
+	sql: SqlClient.SqlClient,
+	subjectTable: DocumentSubjectTable,
+	subjectId: string,
+) =>
+	sql`
+		DELETE FROM document_links
+		WHERE subject_table = ${subjectTable} AND subject_id = ${subjectId}
+	`.pipe(Effect.orDie)
+
+export type DocumentSubjectRow = {
+	readonly subjectTable: DocumentSubjectTable
+	readonly subjectId: string
+}
+
+/**
+ * The plain words of an HTML page, for searching only.
+ *
+ * An HTML document's body lives in storage, so a search over the database would
+ * miss it entirely without this. It never reaches a reader — what someone opens
+ * is the stored page itself — so a careful strip is enough here and no HTML
+ * parser is warranted. Script and style blocks go first, contents and all, or
+ * their code would turn up as search hits.
+ */
+export const searchTextFromHtml = (html: string): string =>
+	html
+		.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+		.replace(/<[^>]+>/g, ' ')
+		.replace(/&nbsp;/gi, ' ')
+		.replace(/&amp;/gi, '&')
+		.replace(/&lt;/gi, '<')
+		.replace(/&gt;/gi, '>')
+		.replace(/&quot;/gi, '"')
+		.replace(/\s+/g, ' ')
+		.trim()
+
+/** Where an HTML document's bytes live. */
+export const htmlStorageKey = (orgId: string, documentId: string): string =>
+	`documents/${orgId}/${documentId}.html`
+
+/** How long a link to a stored document stays good for. */
+export const HTML_URL_TTL_SECONDS = 600
+
+/** Where a single document is filed. */
+export const subjectsForDocument = (
+	sql: SqlClient.SqlClient,
+	documentId: string,
+) =>
+	sql<DocumentSubjectRow>`
+		SELECT subject_table, subject_id FROM document_links
+		WHERE document_id = ${documentId}
+		ORDER BY subject_table, created_at
+	`.pipe(Effect.orDie)

--- a/apps/server/src/services/research-apply.test.ts
+++ b/apps/server/src/services/research-apply.test.ts
@@ -45,12 +45,15 @@ describe('allowlistFields', () => {
 			// GIVEN a contact proposal that also carries a company-only field
 			const { fields: kept } = allowlistFields('contacts', {
 				is_decision_maker: true,
-				notes: 'met at fair',
+				role: 'Head of operations',
 				industry: 'company-only, should drop',
 			})
 
 			// THEN only contact columns survive
-			expect(kept).toEqual({ isDecisionMaker: true, notes: 'met at fair' })
+			expect(kept).toEqual({
+				isDecisionMaker: true,
+				role: 'Head of operations',
+			})
 		})
 	})
 

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -57,12 +57,7 @@ export const COMPANY_FIELDS = new Set([
 // Reachable addresses (email/phone/whatsapp/linkedin/instagram) live on
 // contact_channels, not on `contacts`, so they are not settable here; only
 // the row's own columns remain.
-export const CONTACT_FIELDS = new Set([
-	'name',
-	'role',
-	'isDecisionMaker',
-	'notes',
-])
+export const CONTACT_FIELDS = new Set(['name', 'role', 'isDecisionMaker'])
 
 const snakeToCamel = (s: string) =>
 	s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
@@ -345,7 +340,7 @@ const jsonOrNull = (value: unknown): string | null =>
 //   - provenance is MERGED, never replaced — a run that fills only the phone
 //     must not erase where an earlier run found the industry;
 //   - the brief is seeded while nobody has edited it and appended once somebody
-//     has, so research can extend a person's notes but never overwrite them.
+//     has, so research can extend the brief but never overwrite it.
 // Both decisions read the row as it is at write time, inside the same statement
 // that checks the version, so a concurrent edit cannot slip between the two.
 export const occUpdate = (

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -1152,7 +1152,7 @@ describe('TaskService.update', () => {
 		// GIVEN an open task
 		const id = await seedTask({ status: 'open' })
 
-		// WHEN its notes are updated through the service (title stays the
+		// WHEN its priority is changed through the service (the title stays the
 		// fixture so afterAll still cleans it up)
 		await runScoped(
 			tallerOrgId,
@@ -1160,18 +1160,18 @@ describe('TaskService.update', () => {
 				const tasks = yield* TaskService
 				return yield* tasks.update(
 					id,
-					{ notes: 'consolidation-test-note' },
+					{ priority: 'high' },
 					{ id: null, kind: 'user' },
 				)
 			}),
 		)
 
 		// THEN the committed row reflects the change
-		const after = await pool.query<{ notes: string | null }>(
-			`SELECT notes FROM tasks WHERE id = $1`,
+		const after = await pool.query<{ priority: string | null }>(
+			`SELECT priority FROM tasks WHERE id = $1`,
 			[id],
 		)
-		expect(after.rows[0]?.notes).toBe('consolidation-test-note')
+		expect(after.rows[0]?.priority).toBe('high')
 		// [apps/server/src/services/tasks.ts — update]
 	})
 

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -78,7 +78,6 @@ export interface TaskActor {
 // keeps the status ⇔ completed_at invariant.
 export interface TaskUpdateInput {
 	readonly title?: string | undefined
-	readonly notes?: string | null | undefined
 	readonly status?: string | undefined
 	readonly priority?: string | undefined
 	readonly assigneeId?: string | null | undefined
@@ -192,7 +191,22 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 				conditions.push(sql`status NOT IN ('done', 'cancelled')`)
 			if (filters.search) {
 				const needle = `%${filters.search.replace(/[\\%_]/g, match => `\\${match}`)}%`
-				conditions.push(sql`(title ILIKE ${needle} OR notes ILIKE ${needle})`)
+				// The words a task carries used to sit in a box on the row itself.
+				// They are documents now, so a search that only read the row would
+				// quietly stop finding half of what it used to.
+				conditions.push(sql`(
+					title ILIKE ${needle}
+					OR EXISTS (
+						SELECT 1 FROM document_links dl
+						JOIN documents d ON d.id = dl.document_id
+						WHERE dl.subject_table = 'tasks' AND dl.subject_id = tasks.id
+							AND (
+								d.title ILIKE ${needle}
+								OR d.content ILIKE ${needle}
+								OR d.search_text ILIKE ${needle}
+							)
+					)
+				)`)
 			}
 			return conditions
 		}
@@ -516,7 +530,6 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 
 					const updates: Record<string, unknown> = {}
 					if (input.title !== undefined) updates['title'] = input.title
-					if (input.notes !== undefined) updates['notes'] = input.notes
 					if (input.status !== undefined) updates['status'] = input.status
 					if (input.priority !== undefined) updates['priority'] = input.priority
 					if (input.assigneeId !== undefined)

--- a/packages/controllers/src/routes/contacts.ts
+++ b/packages/controllers/src/routes/contacts.ts
@@ -24,7 +24,6 @@ const CreateContactInput = Schema.Struct({
 	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 	role: Schema.optional(Schema.String),
 	isDecisionMaker: Schema.optional(Schema.Boolean),
-	notes: Schema.optional(Schema.String),
 	metadata: Schema.optional(Schema.Unknown),
 	channels: Schema.optional(Schema.Array(ChannelInput)),
 })
@@ -33,7 +32,6 @@ const UpdateContactInput = Schema.Struct({
 	name: Schema.optional(Schema.String),
 	role: Schema.optional(Schema.String),
 	isDecisionMaker: Schema.optional(Schema.Boolean),
-	notes: Schema.optional(Schema.String),
 	metadata: Schema.optional(Schema.Unknown),
 	channels: Schema.optional(Schema.Array(ChannelInput)),
 })

--- a/packages/controllers/src/routes/documents.ts
+++ b/packages/controllers/src/routes/documents.ts
@@ -5,67 +5,124 @@ import {
 	HttpApiSchema,
 } from 'effect/unstable/httpapi'
 
-import { Document } from '@batuda/domain'
+import { Document, DocumentSubject, DocumentSubjectTable } from '@batuda/domain'
 
 import { NotFound } from '../errors'
 import { OrgMiddleware } from '../middleware/org'
 import { SessionMiddleware } from '../middleware/session'
 import { PaginatedList } from '../pagination'
 
-// Listing projection: everything but the full markdown `content`, so a company
-// index stays cheap.
+// A document plus the records it is filed under. The subjects live in their own
+// table, so they ride alongside the row rather than in it.
+export const DocumentDetail = Schema.Struct({
+	...Document.json.fields,
+	subjects: Schema.Array(DocumentSubject),
+	// Where an HTML document actually opens: a short-lived link to the stored
+	// page, on the storage address rather than this one, so a page somebody else
+	// wrote never loads beside the signed-in session. Null for markdown, whose
+	// body is right here in `content`.
+	htmlUrl: Schema.NullOr(Schema.String),
+})
+
+// Listing projection: everything but the full markdown `content`, so a long
+// list stays cheap; `snippet` is the opening of it, enough for a row to show
+// what the document says. Taken by leaving `content` out rather than by listing
+// what to keep, so a field added to a document shows up here on its own.
+const { content: _content, ...summaryFields } = Document.json.fields
 export const DocumentSummary = Schema.Struct({
-	id: Document.json.fields.id,
-	companyId: Document.json.fields.companyId,
-	type: Document.json.fields.type,
-	title: Document.json.fields.title,
-	createdAt: Document.json.fields.createdAt,
+	...summaryFields,
+	snippet: Schema.String,
+	subjects: Schema.Array(DocumentSubject),
 })
 
 const CreateDocumentInput = Schema.Struct({
-	companyId: Schema.String,
-	interactionId: Schema.optional(Schema.String),
-	type: Schema.String,
+	// Every document starts filed somewhere; attach adds the rest later.
+	subjectTable: DocumentSubjectTable,
+	subjectId: Schema.String,
+	type: Document.json.fields.type,
+	// Markdown unless said otherwise. HTML is stored as sent and opens in its
+	// own tab; it is replaced whole rather than edited.
+	format: Schema.optional(Document.json.fields.format),
 	title: Schema.optional(Schema.String),
 	content: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 })
 
 const UpdateDocumentInput = Schema.Struct({
+	type: Schema.optional(Document.json.fields.type),
 	title: Schema.optional(Schema.String),
+	// Replaces the body, in whatever format the document already is.
 	content: Schema.optional(Schema.String),
+})
+
+const LinkInput = Schema.Struct({
+	subjectTable: DocumentSubjectTable,
+	subjectId: Schema.String,
 })
 
 export const DocumentsGroup = HttpApiGroup.make('documents')
 	.add(
 		HttpApiEndpoint.get('list', '/documents', {
 			query: {
-				companyId: Schema.optional(Schema.String),
-				type: Schema.optional(Schema.String),
+				subjectTable: Schema.optional(DocumentSubjectTable),
+				subjectId: Schema.optional(Schema.String),
+				type: Schema.optional(Document.json.fields.type),
+				// Substring match over title and content.
+				q: Schema.optional(Schema.String),
 				limit: Schema.optional(Schema.NumberFromString),
 				offset: Schema.optional(Schema.NumberFromString),
 			},
-			success: PaginatedList(Document.json),
+			success: PaginatedList(DocumentSummary),
 		}),
 	)
 	.add(
 		HttpApiEndpoint.get('get', '/documents/:id', {
 			params: { id: Schema.String },
-			success: Document.json,
+			success: DocumentDetail,
 			error: NotFound.pipe(HttpApiSchema.status(404)),
 		}),
 	)
 	.add(
 		HttpApiEndpoint.post('create', '/documents', {
 			payload: CreateDocumentInput,
-			success: Document.json,
+			success: DocumentDetail,
 		}),
 	)
 	.add(
 		HttpApiEndpoint.patch('update', '/documents/:id', {
 			params: { id: Schema.String },
 			payload: UpdateDocumentInput,
-			success: Schema.NullOr(Document.json),
+			success: Schema.NullOr(DocumentDetail),
 		}),
+	)
+	.add(
+		HttpApiEndpoint.delete('remove', '/documents/:id', {
+			params: { id: Schema.String },
+			success: Schema.Void,
+		}),
+	)
+	.add(
+		// File an existing document under one more record. Filing it where it
+		// already sits changes nothing rather than failing.
+		HttpApiEndpoint.post('attach', '/documents/:id/subjects', {
+			params: { id: Schema.String },
+			payload: LinkInput,
+			success: Schema.Void,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	.add(
+		HttpApiEndpoint.delete(
+			'detach',
+			'/documents/:id/subjects/:subjectTable/:subjectId',
+			{
+				params: {
+					id: Schema.String,
+					subjectTable: DocumentSubjectTable,
+					subjectId: Schema.String,
+				},
+				success: Schema.Void,
+			},
+		),
 	)
 	.middleware(SessionMiddleware)
 	.middleware(OrgMiddleware)

--- a/packages/controllers/src/routes/proposals.ts
+++ b/packages/controllers/src/routes/proposals.ts
@@ -22,7 +22,6 @@ const CreateProposalInput = Schema.Struct({
 	// An ISO date string (e.g. "2026-08-01"), passed straight to the timestamptz
 	// column — a decoded DateTime object doesn't serialize into the SQL insert.
 	expiresAt: Schema.optional(Schema.String),
-	notes: Schema.optional(Schema.String),
 	metadata: Schema.optional(Schema.Unknown),
 })
 
@@ -31,7 +30,6 @@ const UpdateProposalInput = Schema.Struct({
 	title: Schema.optional(Schema.String),
 	lineItems: Schema.optional(Schema.Unknown),
 	totalValue: Schema.optional(Schema.String),
-	notes: Schema.optional(Schema.String),
 	metadata: Schema.optional(Schema.Unknown),
 })
 

--- a/packages/controllers/src/routes/research.ts
+++ b/packages/controllers/src/routes/research.ts
@@ -5,6 +5,8 @@ import {
 	HttpApiSchema,
 } from 'effect/unstable/httpapi'
 
+import { ResearchSubjectTable } from '@batuda/domain'
+
 import {
 	ConfirmRequired,
 	InsufficientBudget,
@@ -31,7 +33,7 @@ import {
 // ── Input schemas ──
 
 const SubjectRef = Schema.Struct({
-	table: Schema.Literals(['companies', 'contacts']),
+	table: ResearchSubjectTable,
 	id: Schema.String,
 })
 
@@ -93,7 +95,7 @@ const UpdatePolicyInput = Schema.Struct({
 })
 
 const AttachInput = Schema.Struct({
-	subject_table: Schema.Literals(['companies', 'contacts']),
+	subject_table: ResearchSubjectTable,
 	subject_id: Schema.String,
 })
 

--- a/packages/controllers/src/routes/tasks.test.ts
+++ b/packages/controllers/src/routes/tasks.test.ts
@@ -125,12 +125,11 @@ describe('UpdateTaskInput', () => {
 	})
 
 	it('should accept null to clear nullable fields', () => {
-		// GIVEN explicit null for `notes`, `assigneeId`, `dueAt`, `snoozedUntil`
+		// GIVEN explicit null for `assigneeId`, `dueAt`, `snoozedUntil`
 		// WHEN decode runs
 		// THEN each null round-trips (so the server can distinguish "clear" from
 		// "leave as-is" using schema-level NullOr)
 		const out = decode(UpdateTaskInput, {
-			notes: null,
 			assigneeId: null,
 			dueAt: null,
 			snoozedUntil: null,
@@ -138,7 +137,6 @@ describe('UpdateTaskInput', () => {
 			contactId: null,
 			metadata: null,
 		})
-		expect(out.notes).toBeNull()
 		expect(out.assigneeId).toBeNull()
 		expect(out.dueAt).toBeNull()
 		expect(out.snoozedUntil).toBeNull()

--- a/packages/controllers/src/routes/tasks.ts
+++ b/packages/controllers/src/routes/tasks.ts
@@ -55,7 +55,6 @@ export const CreateTaskInput = Schema.Struct({
 	contactId: Schema.optional(Schema.String),
 	type: Schema.String,
 	title: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
-	notes: Schema.optional(Schema.String),
 	status: Schema.optional(TaskStatus),
 	priority: Schema.optional(TaskPriority),
 	source: Schema.optional(TaskSource),
@@ -72,7 +71,6 @@ export const CreateTaskInput = Schema.Struct({
 // current row and records the change in `task_events`.
 export const UpdateTaskInput = Schema.Struct({
 	title: Schema.optional(Schema.String),
-	notes: Schema.optional(Schema.NullOr(Schema.String)),
 	status: Schema.optional(TaskStatus),
 	priority: Schema.optional(TaskPriority),
 	assigneeId: Schema.optional(Schema.NullOr(Schema.String)),

--- a/packages/controllers/src/routes/timeline.ts
+++ b/packages/controllers/src/routes/timeline.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'effect'
 import { HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
 
-import { TimelineActivity } from '@batuda/domain'
+import { TimelineActivity, TimelineEntityType } from '@batuda/domain'
 
 import { OrgMiddleware } from '../middleware/org'
 import { SessionMiddleware } from '../middleware/session'
@@ -13,6 +13,10 @@ export const TimelineGroup = HttpApiGroup.make('timeline')
 			query: {
 				companyId: Schema.optional(Schema.String),
 				contactId: Schema.optional(Schema.String),
+				// The thing an entry is about — a task, a proposal, a meeting.
+				// Pass both to read one record's own history.
+				entityType: Schema.optional(TimelineEntityType),
+				entityId: Schema.optional(Schema.String),
 				channel: Schema.optional(Schema.String),
 				kind: Schema.optional(Schema.String),
 				since: Schema.optional(Schema.String),

--- a/packages/domain/src/schema/contacts.ts
+++ b/packages/domain/src/schema/contacts.ts
@@ -13,7 +13,6 @@ export class Contact extends Model.Class<Contact>('Contact')({
 	role: Schema.NullOr(Schema.String),
 	isDecisionMaker: Schema.NullOr(Schema.Boolean),
 
-	notes: Schema.NullOr(Schema.String),
 	metadata: Schema.NullOr(Schema.Unknown),
 
 	lastEmailAt: Schema.NullOr(Schema.DateTimeUtcFromDate),

--- a/packages/domain/src/schema/documents.ts
+++ b/packages/domain/src/schema/documents.ts
@@ -1,19 +1,46 @@
 import { Schema } from 'effect'
 import { Model } from 'effect/unstable/schema'
 
+import { DocumentSubjectTable } from './subject-tables'
+
 export const DocumentId = Schema.String.pipe(Schema.brand('DocumentId'))
+
+// What a document is for. The list is closed and kept here so that everything
+// offering, filtering or writing a type means the same thing by it.
+export const DOCUMENT_TYPES = [
+	'general',
+	'prenote',
+	'postnote',
+	'call_notes',
+	'visit_notes',
+	'research',
+] as const
+export const DocumentType = Schema.Literals(DOCUMENT_TYPES)
+export type DocumentType = typeof DocumentType.Type
+
+// Which record a document is filed under. A document can be filed in several
+// places at once — a note from a visit belongs to the meeting and to the
+// company both — so these come back as a list.
+export const DocumentSubject = Schema.Struct({
+	subjectTable: DocumentSubjectTable,
+	subjectId: Schema.String,
+})
+export type DocumentSubject = typeof DocumentSubject.Type
+
+// How a document's body is written. Markdown is typed and edited in place;
+// HTML arrives already finished and is replaced whole rather than edited.
+export const DOCUMENT_FORMATS = ['markdown', 'html'] as const
+export const DocumentFormat = Schema.Literals(DOCUMENT_FORMATS)
+export type DocumentFormat = typeof DocumentFormat.Type
 
 export class Document extends Model.Class<Document>('Document')({
 	id: Model.GeneratedByDb(DocumentId),
-	companyId: Schema.String,
-	interactionId: Schema.NullOr(Schema.String),
-	// links prenote/postnote to a specific meeting
-
-	type: Schema.String,
-	// values: research | prenote | postnote | call_notes | visit_notes | general
+	type: DocumentType,
+	format: DocumentFormat,
 	title: Schema.NullOr(Schema.String),
+	// The markdown body. An HTML document keeps its body in storage instead, so
+	// this is empty for one.
 	content: Schema.String,
-	// full markdown
 
 	createdAt: Model.DateTimeInsertFromDate,
 	updatedAt: Model.DateTimeUpdateFromDate,

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -26,7 +26,15 @@ export {
 	EmailStatus,
 } from './contact-channels'
 export { Contact, ContactId } from './contacts'
-export { Document, DocumentId } from './documents'
+export {
+	DOCUMENT_FORMATS,
+	DOCUMENT_TYPES,
+	Document,
+	DocumentFormat,
+	DocumentId,
+	DocumentSubject,
+	DocumentType,
+} from './documents'
 export { EmailDraft, EmailDraftId } from './email-drafts'
 export {
 	EmailDirection,
@@ -62,6 +70,12 @@ export {
 	SUCCEEDED_RESEARCH_STATUSES,
 	TERMINAL_RESEARCH_STATUSES,
 } from './research-runs'
+export {
+	DOCUMENT_SUBJECT_TABLES,
+	DocumentSubjectTable,
+	RESEARCH_SUBJECT_TABLES,
+	ResearchSubjectTable,
+} from './subject-tables'
 export { TaskActorKind, TaskEvent, TaskEventId } from './task-events'
 export {
 	Task,

--- a/packages/domain/src/schema/proposals.ts
+++ b/packages/domain/src/schema/proposals.ts
@@ -21,7 +21,6 @@ export class Proposal extends Model.Class<Proposal>('Proposal')({
 	sentAt: Schema.NullOr(Schema.DateTimeUtcFromDate),
 	expiresAt: Schema.NullOr(Schema.DateTimeUtcFromDate),
 	respondedAt: Schema.NullOr(Schema.DateTimeUtcFromDate),
-	notes: Schema.NullOr(Schema.String),
 	metadata: Schema.NullOr(Schema.Unknown),
 
 	createdAt: Model.DateTimeInsertFromDate,

--- a/packages/domain/src/schema/subject-tables.ts
+++ b/packages/domain/src/schema/subject-tables.ts
@@ -1,0 +1,25 @@
+import { Schema } from 'effect'
+
+// The CRM rows something can be attached to. A link row names its target as a
+// table name plus an id — one foreign key cannot point at several different
+// tables — so the name is checked against a fixed list, kept here so everything
+// reading or writing a link agrees on it. The checks stay unnamed on purpose: a
+// name would reach outside systems in place of the values it allows.
+
+// A research run reaches only these two — it enriches an organisation or a
+// person, and has nothing to say about a task or a meeting.
+export const RESEARCH_SUBJECT_TABLES = ['companies', 'contacts'] as const
+export const ResearchSubjectTable = Schema.Literals(RESEARCH_SUBJECT_TABLES)
+export type ResearchSubjectTable = typeof ResearchSubjectTable.Type
+
+// Notes get written about anything, so a document also hangs off the work in
+// flight — a task, an offer, a meeting — not just the organisation or person.
+export const DOCUMENT_SUBJECT_TABLES = [
+	'companies',
+	'contacts',
+	'tasks',
+	'proposals',
+	'calendar_events',
+] as const
+export const DocumentSubjectTable = Schema.Literals(DOCUMENT_SUBJECT_TABLES)
+export type DocumentSubjectTable = typeof DocumentSubjectTable.Type

--- a/packages/domain/src/schema/tasks.ts
+++ b/packages/domain/src/schema/tasks.ts
@@ -33,7 +33,6 @@ export class Task extends Model.Class<Task>('Task')({
 	type: Schema.String,
 	// values: call | visit | email | proposal | followup | other
 	title: Schema.String,
-	notes: Schema.NullOr(Schema.String),
 
 	status: TaskStatus,
 	source: TaskSource,

--- a/packages/research/src/application/schemas/_shared.ts
+++ b/packages/research/src/application/schemas/_shared.ts
@@ -1,5 +1,7 @@
 import { Schema, SchemaGetter } from 'effect'
 
+import { ResearchSubjectTable } from '@batuda/domain'
+
 /**
  * Building blocks shared across the structured research output schemas, so each
  * shape is defined once instead of copied into every file.
@@ -95,13 +97,13 @@ export const Sourced = <Value extends Schema.Top>(value: Value) =>
 	Schema.Struct({ value, ...Citation.fields })
 
 export const DiscoveredExisting = Schema.Struct({
-	subject_table: Schema.Literals(['companies', 'contacts']),
+	subject_table: ResearchSubjectTable,
 	subject_id: Schema.String,
 	name: Schema.String,
 })
 
 export const ProposedUpdate = Schema.Struct({
-	subject_table: Schema.Literals(['companies', 'contacts']),
+	subject_table: ResearchSubjectTable,
 	// 'create' inserts a newly discovered row (contacts only); the default,
 	// 'update', applies the fields to an existing row. A create carries the new
 	// row's data in `fields` and omits subject_id/expected_version (there is no

--- a/packages/research/src/application/schemas/contact-discovery-v1.ts
+++ b/packages/research/src/application/schemas/contact-discovery-v1.ts
@@ -31,7 +31,6 @@ export const ContactDiscoveryV1Schema = Schema.Struct({
 					}),
 				),
 			),
-			notes: Schema.optionalKey(Schema.String),
 			citations: Schema.Array(Citation),
 		}),
 	),

--- a/packages/research/src/application/value-guard.test.ts
+++ b/packages/research/src/application/value-guard.test.ts
@@ -188,13 +188,14 @@ describe('verifyValueProvenance', () => {
 
 	describe('when several proposals mix supported and invented values', () => {
 		it('should drop only the unsupported ones', () => {
-			// GIVEN a supported phone, an invented email, and a fuzzy-only proposal
+			// GIVEN a supported phone, an invented email, and a free-text field
+			// nothing in the page can confirm either way
 			const corpus = 'Phone: 936 123 456. Email: info@acme.es'
 			const findings = {
 				proposed_updates: [
 					{ subject_id: 'a', fields: { phone: '936123456' } },
 					{ subject_id: 'b', fields: { email: 'fake@nowhere.io' } },
-					{ subject_id: 'c', fields: { notes: 'friendly' } },
+					{ subject_id: 'c', fields: { role: 'friendly sort' } },
 				],
 			}
 

--- a/packages/research/src/domain/crm-vocabulary.ts
+++ b/packages/research/src/domain/crm-vocabulary.ts
@@ -57,5 +57,4 @@ export const SNAPSHOT_CONTACT_FIELDS = [
 	'name',
 	'role',
 	'isDecisionMaker',
-	'notes',
 ] as const


### PR DESCRIPTION
## What

Until now a note could only belong to a company. If you wrote something down before a meeting, about a particular person, while working a task, or while putting an offer together, it had nowhere to go — so it landed on the company as one undifferentiated pile, or in a box that no screen ever showed. This makes a document belong to any of those five things, and to more than one at once: the note from a visit can sit on the meeting *and* on the company without being copied.

That was the whole point. Preparing for a meeting means reading what was written before it, and the app could not answer that question.

This lives in the CRM (the `server` API, the `internal` web app, the agent tools, and the `cli` seed). Three things came along with it, each explained below: documents can now hold a whole web page, the three separate `notes` boxes are gone, and a task, offer or meeting can show its own history.

## Changes

- **A document belongs to any record, and to several.** A new `document_links` table names what a document is filed against by table and id, the same shape `research_links` already uses. `documents.company_id` and `documents.interaction_id` are gone.
- **The dead meeting link is deleted, not repaired.** `interaction_id` was meant to tie a prep note to a meeting: three code paths wrote it, nothing ever read it, and the other half of that chain was empty in every environment including the seeds. Filing against the meeting itself replaces it.
- **Documents can hold a whole web page.** Markdown stays in the row, editable and searchable. HTML goes to file storage and opens through a short-lived link on the storage address — not this one — so a page somebody else wrote never loads beside the signed-in session.
- **The three `notes` boxes are retired.** A contact, a task and a proposal each carried one. None talked to each other, none held more than one note, and the one on a contact was shown on no screen at all. Everything written in one is now a document filed against the row it came from.
- **Documents have a home and an address.** A `/documents` page searches titles *and* bodies; each document has its own URL. A person, task, offer or meeting shows what has been written about it, linking out to that page.
- **The agent tools reached parity.** Deleting, filing and unfiling a document had no tool. Reading one now truncates a very long body so it cannot swallow an agent's context.
- **A task, offer or meeting can show its own history.** The history table has always recorded which record each entry is about, with an index for it — nothing could ever ask.

Two fixes ride along, found while getting the browser tests green and called out because they are not documents work:

- **A company's meetings card was empty whenever a meeting had attendees.** The query behind it names its columns one by one and was never told about the two the invitation-matching migration added, so every response failed to take shape. This is a live bug on main, not just a test failure.
- **Tests that build their own request context used the wrong address**, so nothing answered them from a worktree or from CI. Fourteen tests across four files came back.

## Impact

- **Migrations — must run before the server tag.** Three: `0039_document_links`, `0040_document_html`, `0041_notes_into_documents`. The deploy does not run migrations, so new server code on an unmigrated schema crashes on boot. All three are irreversible: `0039` drops `documents.company_id` and `interaction_id`, `0041` drops `notes` from `contacts`, `tasks` and `proposals`. Each moves its data into documents first — verified on a live database, 18 notes moved with nothing left behind.
- **Wire shape changed.** `notes` is gone from the contact, task and proposal shapes in `packages/domain` and `packages/controllers`, which both the server and the web app's typed client read. Documents gained `format`, and its listing returns a summary with a snippet instead of full bodies. Pre-production, so this is a clean break — no shims.
- **MCP and HTTP both get everything.** Filing, unfiling and deleting exist on both surfaces, sharing one service. `create_document`'s advertised kinds were wrong before this — six words sharing no values with the six the app understands, so anything an agent filed carried a kind no screen could show. Those rows become plain notes.
- **Multi-org.** `document_links` has its own isolation policy. `subject_id` carries no foreign key — one key cannot point at five tables — so both ends are checked in code before a link is written. Without that, filing against another organisation's document id would have succeeded and told the caller the id was real; there is a test for it.
- **Research no longer proposes a note about a person.** Removing `notes` from what the apply path may write forces removing it from the prompt snapshot too, since a test requires the two lists to agree. Research can still write a document through `create_document`; it just will not propose one automatically. **This is the part most likely to conflict with the parallel research work.**
- **No new environment variables.** HTML reuses the storage the recordings and the scrape cache already use.

## Review guide

Start at `apps/server/src/services/documents.ts` — it is where filing is decided, and the only thing standing between a link and a record that does not exist or belongs to somebody else.

The riskiest parts, in order:

1. **`0041_notes_into_documents`** — irreversible, and it moves real writing. Each note becomes a document *and* its link in one statement; a document filed nowhere is one nothing can reach.
2. **The HTML read path** — a page somebody else wrote, shown to a signed-in person. It is served from the storage address rather than the app's, which is what keeps it away from the session. I originally planned to serve it from our own address behind a sandbox header; that is weaker, and this replaced it.
3. **The task search** — it used to read a box on the row and now reaches the documents filed against the task. Losing this silently would have narrowed search with nothing to show for it.

Two decisions you might overrule: **HTML is read-and-replace, not editable** — a textarea full of markup is not editing; and **`companies.account_brief` was left alone** — it is one per company and kept current, where documents accumulate, and it has human-versus-machine rules a plain document does not.

Skip-able: the two `chore:` commits are migration renumbering and message catalogues, and `routeTree.gen.ts` is generated.

**The browser suite was already broken on main, and this fixes most of it.** Eleven specs were failing; eight now pass. I confirmed the starting point against main's own post-merge run rather than guessing — `e2e-main.yml` has been red for its last three completed runs, on the same specs. Note that pull requests only ever run the `@smoke` subset, which is why no PR showed it.

**Three still fail, and I am handing them over rather than guessing further:** `research-review` (two), `settings-spend` (one). All three sit in components your research-audit and usage-metering work is actively rewriting, so a second pair of hands in those files means a painful rebase for one of us. On the fit-panel quote I did chase it to the end and can rule out the whole chain — the database has the quote, the API returns it, the schema declares it, the narrowing maps it, and the component renders it conditionally — so what remains needs a debugger attached to that component. None of the three is caused by this branch: the proposal the research test applies carries `name`, `company_id` and `channels`, no `notes`.

Snyk was not available in this session.

## Screenshots

**A note filed against a person** — the change in one picture. Before this, a note about someone could only be filed against the business they work for.

![contact documents](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-349/pr-contact-documents.webp)

**A document on its own page** — an address that can be sent to somebody.

![document page](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-349/pr-document-page.webp)

**The documents page** — search over titles *and* bodies, filter by kind. Both sizes, because the navigation differs: a sidebar on desktop, the Records group in the bottom belt on mobile.

![documents page, desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-349/pr-documents-desktop.webp)

![documents page, mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-349/pr-documents-mobile.webp)

## Tests

- **Unit** — the kinds a document may have, the search-term escaping, the extracted narrowing helpers.
- **Integration** — filing refused when the record does not exist, belongs to another organisation, or when the *document* belongs to another organisation; refiling absorbed; a deleted record taking its filings with it; the isolation policy on the link table.
- **End-to-end** — seven specs over the documents surface: listing and reading, a document's own page, searching by words that appear only in a body, a note filed against a person showing on that person, creating, and editing. The first of these was written *before* any of the refactor, and caught three bugs the type-checker could not: raw dates where the schema wanted a decoded one, a start-up crash that took the server down, and the panel breaking after the schema change.

## Verification

Actually run on this branch, after rebasing onto current `main`:

- `pnpm install` (clean lockfile) → `pnpm -w check-types` (13/13) + `pnpm -w test` (21/21) → `pnpm -w build` (13/13). All four exit 0.
- `pnpm turbo test:integration` — 375 server tests across 64 files, plus 16 in the mail worker.
- `pnpm cli db reset && pnpm cli seed` from empty, then the seven documents specs against the live stack: all pass.
- Drove the real app for the screenshots above.
- Exercised the API by hand end to end: create a document against a company → file it against a task → list by that task → unfile → delete, with the links cleaned up.
- Created an HTML document and confirmed the bytes land in storage, the row keeps only the plain words, the search finds it by wording that exists only inside the page, and the link it opens through is on a different address.
- Planted notes on a contact, a task and a proposal, ran `0041`, and confirmed all 18 moved into linked documents with the columns gone — then confirmed a task search still finds words that now live in a document.

## Deferred

- Making the history table itself polymorphic. It already carries what each entry is about, and this PR exposes that; giving it the same two columns as documents would copy a changeable filing into an append-only log, which goes stale the first time a note is re-filed. Worth its own issue.
- `companies.account_brief` and `interactions.summary` stay as they are, so this retires the three unstructured `notes` boxes rather than every free-text field.

Closes #330
