### PR TITLE
feat: open a saved web page at an address that keeps working

### DIFF
--- a/.github/actions/e2e-stack/action.yml
+++ b/.github/actions/e2e-stack/action.yml
@@ -53,9 +53,13 @@ runs:
       env:
         WITH_MAIL: ${{ inputs.with-mail }}
       run: |
-        services="db storage storage-init"
+        services="db storage"
         if [ "$WITH_MAIL" = "true" ]; then services="$services mail-catcher"; fi
         docker compose -f docker/docker-compose.yml up -d --wait $services
+        # The bucket is created by a container that stops as soon as it's done, and
+        # `--wait` treats a stopped container as a failure — listing it above passed
+        # or failed on timing alone. `run` waits and reports whether it worked.
+        docker compose -f docker/docker-compose.yml run --rm --no-deps storage-init
 
     - name: Migrate + seed
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,17 @@ jobs:
       #
       # Bring up Postgres + MinIO from the same docker-compose file dev uses.
       # `--wait` blocks until `db` reports healthy (its pg_isready healthcheck)
-      # and `storage` is up; `storage-init` is a one-shot mc container that
-      # creates the bucket and exits 0. Running the database on the runner keeps
-      # every query on localhost instead of paying an internet round-trip to a
-      # remote host — the whole reason this phase used to run near 15 minutes.
+      # and `storage` is up. Running the database on the runner keeps every query
+      # on localhost instead of paying an internet round-trip to a remote host —
+      # the whole reason this phase used to run near 15 minutes.
+      #
+      # The bucket is created by a container that stops as soon as it's done, and
+      # `--wait` treats a stopped container as a failure — listing it above passed
+      # or failed on timing alone. `run` waits and reports whether it worked.
       - name: Start Postgres + MinIO via docker compose
-        run: docker compose -f docker/docker-compose.yml up -d --wait db storage storage-init
+        run: |
+          docker compose -f docker/docker-compose.yml up -d --wait db storage
+          docker compose -f docker/docker-compose.yml run --rm --no-deps storage-init
 
       # The local container above. Its `batuda` superuser owns the schema, and
       # integration tests SET ROLE into the app_user / app_service roles that the

--- a/apps/cli/src/commands/seed.ts
+++ b/apps/cli/src/commands/seed.ts
@@ -99,7 +99,11 @@ export const seed = (preset: Preset) =>
 				const { insertedInteractions, dataWithContacts } =
 					yield* seedInteractions(ctx, companyMap, contactMap)
 				const insertedTasks = yield* seedTasks(ctx, dataWithContacts)
-				yield* seedCalendar(ctx, companyMap, insertedTasks)
+				const insertedEvents = yield* seedCalendar(
+					ctx,
+					companyMap,
+					insertedTasks,
+				)
 				const testUser = yield* seedResearchPolicy(ctx)
 				const seededInboxes = yield* seedInboxes(ctx)
 				yield* seedDemoEmails(sql, seededInboxes)
@@ -107,8 +111,21 @@ export const seed = (preset: Preset) =>
 				yield* seedMcpOAuth(ctx)
 
 				if (preset === 'full') {
-					yield* seedDocuments(ctx, companyMap, contactMap)
-					yield* seedProposals(ctx, companyMap, contactMap, insertedProducts)
+					// Documents run after proposals so they can be filed against one;
+					// every other record they reach already exists by here.
+					const insertedProposals = yield* seedProposals(
+						ctx,
+						companyMap,
+						contactMap,
+						insertedProducts,
+					)
+					yield* seedDocuments(ctx, {
+						companies: companyMap,
+						contacts: contactMap,
+						tasks: new Map(insertedTasks.map(t => [t.title, t.id])),
+						proposals: new Map(insertedProposals.map(p => [p.title, p.id])),
+						calendar_events: new Map(insertedEvents.map(e => [e.title, e.id])),
+					})
 					yield* seedPages(ctx, companyMap)
 					yield* seedResearchRuns(ctx, testUser, companyMap)
 					yield* seedRecordings(ctx, companyMap)

--- a/apps/cli/src/commands/seed/calendar.ts
+++ b/apps/cli/src/commands/seed/calendar.ts
@@ -303,4 +303,6 @@ export const seedCalendar = (
 		yield* Effect.logInfo(
 			`  ${insertedCalendarEvents.length} events, ${attendeeRows.length} attendees, ${taskEventRows.length} task events`,
 		)
+		// Handed back so documents can be filed against a meeting.
+		return insertedCalendarEvents
 	})

--- a/apps/cli/src/commands/seed/documents.ts
+++ b/apps/cli/src/commands/seed/documents.ts
@@ -1,83 +1,162 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: seed data */
-import { Effect } from 'effect'
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { Config, Effect, Redacted } from 'effect'
 
 import { normalizeRows, type SeedCtx, withSeedIds } from './shared'
 
+type SubjectTable =
+	| 'companies'
+	| 'contacts'
+	| 'tasks'
+	| 'proposals'
+	| 'calendar_events'
+
+// The seed's own handle for a record — a company slug, a person's name, or the
+// title of a task, an offer or a meeting — resolved to a real id below.
+type SubjectRef = { readonly table: SubjectTable; readonly key: string }
+
 type DocumentSeed = {
-	readonly subjectTable: 'companies' | 'contacts'
-	readonly subjectKey: string
 	readonly type: string
+	readonly format: 'markdown' | 'html'
 	readonly title: string
 	readonly content: string
+	readonly filedUnder: ReadonlyArray<SubjectRef>
 }
 
-// `subjectKey` is the seed's own handle for the record a document is filed
-// under — a company slug or a contact name — resolved to a real id once those
-// rows exist. Most of the fixtures sit on a company, one on a person, so the
-// demo data shows a note about someone as well as notes about a business.
+// Covers every kind, both formats, all five records a document can be filed
+// under, and one document filed in two places at once, so every surface the app
+// offers has something to show.
 const DOCUMENTS: ReadonlyArray<DocumentSeed> = [
 	{
-		subjectTable: 'companies',
-		subjectKey: 'cal-pep-fonda',
 		type: 'prenote',
+		format: 'markdown',
 		title: 'Visit prep — Cal Pep',
 		content:
 			'## Goal\nSee the restaurant, understand current booking flow.\n\n## Questions\n- How many covers per service?\n- Do they take reservations via WhatsApp or phone?\n- Do they have a website?',
+		filedUnder: [{ table: 'companies', key: 'cal-pep-fonda' }],
 	},
 	{
-		subjectTable: 'companies',
-		subjectKey: 'cal-pep-fonda',
 		type: 'postnote',
+		format: 'markdown',
 		title: 'Visit summary — Cal Pep',
 		content:
 			"## Summary\n60 covers, 2 services/day. Phone-only reservations — they lose ~15% of walk-ups who won't wait.\n\n## Decision\nWants website + booking. Budget approved up to 1500 EUR.",
+		filedUnder: [{ table: 'companies', key: 'cal-pep-fonda' }],
 	},
 	{
-		subjectTable: 'companies',
-		subjectKey: 'ferros-baix-llobregat',
 		type: 'research',
+		format: 'markdown',
 		title: 'Company analysis — Ferros BL',
 		content:
 			'## Company\n40 employees, 2 warehouses in Cornellà. Revenue ~3M EUR/year.\n\n## Pain points detected\n- Manual invoicing: 2 days/month\n- Transcription errors: ~5% of invoices\n- No real-time stock control',
+		filedUnder: [{ table: 'companies', key: 'ferros-baix-llobregat' }],
 	},
 	{
-		subjectTable: 'companies',
-		subjectKey: 'hostal-pirineu',
 		type: 'visit_notes',
+		format: 'markdown',
 		title: 'Visit notes — Hostal Pirineu',
 		content:
 			'## Context\n12 rooms, high season June–September + ski December–March.\n\n## Commissions\nBooking: 15–18%. They want to drop below 5% with a direct channel.\n\n## Requirements\n- Availability calendar\n- Upfront payment (Stripe/Redsys)\n- Multi-language: ca, es, fr',
+		filedUnder: [{ table: 'companies', key: 'hostal-pirineu' }],
 	},
 	{
-		subjectTable: 'companies',
-		subjectKey: 'tancaments-garraf',
 		type: 'call_notes',
+		format: 'markdown',
 		title: 'Demo debrief — Tancaments Garraf',
 		content:
 			'## Attendees\nRamon Vila (owner), Oriol Camps (project manager)\n\n## Key points\n- Currently tracking 12 concurrent projects in shared Google Sheets\n- Lost a client last month due to a missed deadline nobody saw in the spreadsheet\n- Want a dashboard with alerts per project phase\n\n## Objections\n- Worried about migration effort from existing sheets\n- Need offline access for site visits',
+		filedUnder: [{ table: 'companies', key: 'tancaments-garraf' }],
 	},
 	{
-		subjectTable: 'companies',
-		subjectKey: 'distribuciones-martinez',
 		type: 'general',
+		format: 'markdown',
 		title: 'Competitor landscape — logistics in Alzira',
 		content:
 			'## Notes\nNo direct competitor offering digital delivery notes in this area.\nClosest: a Valencia-based firm doing fleet GPS, but not document digitisation.\n\n## Opportunity\nFirst-mover advantage if we land Distribuciones Martínez as a reference client.',
+		filedUnder: [{ table: 'companies', key: 'distribuciones-martinez' }],
 	},
 	{
-		subjectTable: 'contacts',
-		subjectKey: 'Pep Casals',
 		type: 'general',
+		format: 'markdown',
 		title: 'Working with Pep',
 		content:
 			'## How he likes to work\nPrefers a call before 10am; reads nothing longer than a page.\n\n## Watch out for\nSays yes in the room and reconsiders overnight — confirm in writing the same day.',
+		filedUnder: [{ table: 'contacts', key: 'Pep Casals' }],
+	},
+	// Written for the meeting, and worth finding from the company too, without a
+	// second copy of it.
+	{
+		type: 'prenote',
+		format: 'markdown',
+		title: 'Before the sync — Cal Pep',
+		content:
+			'## Aim\nAgree the booking flow before build starts.\n\n## Bring\n- Two layout options\n- The deposit question, which they have dodged twice',
+		filedUnder: [
+			{ table: 'calendar_events', key: 'Zoom sync with Cal Pep' },
+			{ table: 'companies', key: 'cal-pep-fonda' },
+		],
+	},
+	{
+		type: 'call_notes',
+		format: 'markdown',
+		title: 'What came out of the follow-up call',
+		content:
+			'## Outcome\nThey will send last quarter’s invoice volumes on Friday.\n\n## Blocker\nTheir accountant wants to see the export format first.',
+		filedUnder: [{ table: 'tasks', key: 'Revisió mensual amb Cal Pep' }],
+	},
+	{
+		type: 'general',
+		format: 'markdown',
+		title: 'Why this offer is shaped the way it is',
+		content:
+			'## Reasoning\nBooking management is priced monthly so the first invoice stays under their approval threshold.\n\n## If they push back\nDrop local SEO before touching the booking line.',
+		filedUnder: [{ table: 'proposals', key: 'Web + Booking — Cal Pep Fonda' }],
+	},
+	// The one web page, so the "open the page" link has something to open and
+	// the stored-file path is exercised by the seed, not only by tests.
+	{
+		type: 'research',
+		format: 'html',
+		title: 'Cal Pep Fonda — saved website',
+		content: `<!doctype html>
+<html lang="ca">
+	<head>
+		<meta charset="utf-8" />
+		<title>Cal Pep Fonda</title>
+		<style>
+			body { font-family: Georgia, serif; margin: 3rem auto; max-width: 40rem; }
+			h1 { font-variant: small-caps; }
+		</style>
+	</head>
+	<body>
+		<h1>Cal Pep Fonda</h1>
+		<p>Cuina catalana de mercat des de 1978. Reserva la teva taula trucant al restaurant.</p>
+		<h2>Horaris</h2>
+		<ul><li>Dimarts a dissabte, 13:00-16:00 i 20:00-23:00</li><li>Diumenge, nomes migdia</li></ul>
+		<p>Telefon: 938 000 000</p>
+	</body>
+</html>`,
+		filedUnder: [{ table: 'companies', key: 'cal-pep-fonda' }],
 	},
 ]
 
+// Mirrors `searchTextFromHtml` in the server: the plain words of a page, so a
+// search still reaches a document whose body is a file. Duplicated rather than
+// imported because the CLI does not depend on the server package.
+const plainWordsOf = (html: string): string =>
+	html
+		.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+		.replace(/<[^>]+>/g, ' ')
+		.replace(/&nbsp;/gi, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+
+const htmlKeyFor = (orgId: string, documentId: string): string =>
+	`documents/${orgId}/${documentId}.html`
+
 export const seedDocuments = (
-	{ sql, stamp }: SeedCtx,
-	companyMap: Map<string, string>,
-	contactMap: Map<string, string>,
+	{ sql, stamp, tallerOrgId }: SeedCtx,
+	subjects: Record<SubjectTable, Map<string, string>>,
 ) =>
 	Effect.gen(function* () {
 		yield* Effect.logInfo('Seeding documents...')
@@ -86,33 +165,70 @@ export const seedDocuments = (
 			'document',
 			DOCUMENTS.map(doc => ({
 				type: doc.type,
+				format: doc.format,
 				title: doc.title,
-				content: doc.content,
+				// A web page's body is a file, not a column; only its plain words
+				// stay behind so search can still reach it.
+				content: doc.format === 'html' ? '' : doc.content,
+				searchText: doc.format === 'html' ? plainWordsOf(doc.content) : null,
+				// A placeholder until the loop below, which needs the row's id to
+				// name the file.
+				storageKey: doc.format === 'html' ? ('pending' as string | null) : null,
 			})),
 			(_, index) => String(index),
 		)
 
+		// The page has to be in storage before the row that points at it, and its
+		// name is built from the id — which is why the ids are chosen above rather
+		// than left to the database.
+		const htmlDocs = DOCUMENTS.map((doc, index) => ({ doc, index })).filter(
+			({ doc }) => doc.format === 'html',
+		)
+		if (htmlDocs.length > 0) {
+			const s3 = new S3Client({
+				endpoint: yield* Config.string('STORAGE_ENDPOINT'),
+				region: yield* Config.string('STORAGE_REGION'),
+				credentials: {
+					accessKeyId: yield* Config.string('STORAGE_ACCESS_KEY_ID'),
+					secretAccessKey: Redacted.value(
+						yield* Config.redacted('STORAGE_SECRET_ACCESS_KEY'),
+					),
+				},
+				forcePathStyle: true,
+			})
+			const bucket = yield* Config.string('STORAGE_BUCKET')
+			for (const { doc, index } of htmlDocs) {
+				const key = htmlKeyFor(tallerOrgId, rows[index]!.id)
+				rows[index]!.storageKey = key
+				yield* Effect.promise(() =>
+					s3.send(
+						new PutObjectCommand({
+							Bucket: bucket,
+							Key: key,
+							Body: doc.content,
+							ContentType: 'text/html; charset=utf-8',
+						}),
+					),
+				)
+			}
+		}
+
 		yield* sql`INSERT INTO documents ${sql.insert(normalizeRows(stamp(rows)))}`
 
-		const links = DOCUMENTS.flatMap((doc, index) => {
-			const subjectId =
-				doc.subjectTable === 'companies'
-					? companyMap.get(doc.subjectKey)
-					: contactMap.get(doc.subjectKey)
-			// A fixture naming a record the seed did not create is skipped rather
-			// than inserted as a link pointing at nothing.
-			if (subjectId === undefined) return []
-			return [
-				{
-					documentId: rows[index]!.id,
-					subjectTable: doc.subjectTable,
-					subjectId,
-				},
-			]
-		})
+		const links = DOCUMENTS.flatMap((doc, index) =>
+			doc.filedUnder.flatMap(ref => {
+				const subjectId = subjects[ref.table].get(ref.key)
+				// A fixture naming a record the seed did not create is skipped rather
+				// than filed against an id that resolves to nothing.
+				if (subjectId === undefined) return []
+				return [
+					{ documentId: rows[index]!.id, subjectTable: ref.table, subjectId },
+				]
+			}),
+		)
 
 		yield* sql`INSERT INTO document_links ${sql.insert(
 			normalizeRows(stamp(links)),
 		)}`
-		yield* Effect.logInfo(`  ${links.length} document_links rows`)
+		yield* Effect.logInfo(`  ${rows.length} documents, ${links.length} filings`)
 	})

--- a/apps/cli/src/commands/seed/proposals.ts
+++ b/apps/cli/src/commands/seed/proposals.ts
@@ -14,7 +14,10 @@ export const seedProposals = (
 	Effect.gen(function* () {
 		yield* Effect.logInfo('Seeding proposals...')
 		const productMap = new Map(insertedProducts.map(p => [p.slug, p.id]))
-		yield* sql`INSERT INTO proposals ${sql.insert(
+		const insertedProposals = yield* sql<{
+			id: string
+			title: string
+		}>`INSERT INTO proposals ${sql.insert(
 			normalizeRows(
 				stamp(
 					withSeedIds(
@@ -193,5 +196,7 @@ export const seedProposals = (
 					),
 				),
 			),
-		)}`
+		)} RETURNING id, title`
+		// Handed back so documents can be filed against an offer.
+		return insertedProposals
 	})

--- a/apps/internal/src/components/companies/documents-panel.tsx
+++ b/apps/internal/src/components/companies/documents-panel.tsx
@@ -22,6 +22,7 @@ import { MarkdownView } from '#/components/markdown/markdown-view'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
+import { documentOpenUrl } from '#/lib/document-links'
 import { useDlg } from '#/lib/use-dlg'
 import { stenciledTitle } from '#/lib/workshop-mixins'
 
@@ -85,17 +86,12 @@ function narrowDocs(rows: ReadonlyArray<unknown>): ReadonlyArray<DocRow> {
 
 type DocBody = {
 	readonly content: string
-	readonly htmlUrl: string | null
 }
 
 function narrowBody(value: unknown): DocBody | null {
 	if (!value || typeof value !== 'object') return null
-	const r = value as Record<string, unknown>
-	if (typeof r['content'] !== 'string') return null
-	return {
-		content: r['content'],
-		htmlUrl: typeof r['htmlUrl'] === 'string' ? r['htmlUrl'] : null,
-	}
+	const content = (value as Record<string, unknown>)['content']
+	return typeof content === 'string' ? { content } : null
 }
 
 type DialogState =
@@ -239,7 +235,7 @@ type DialogProps = {
  */
 function DocumentDialogHost(props: DialogProps) {
 	if (props.state.mode === 'add') {
-		return <DocumentDialog {...props} body={{ content: '', htmlUrl: null }} />
+		return <DocumentDialog {...props} body={{ content: '' }} />
 	}
 	return <DocumentDialogWithBody {...props} id={props.state.doc.id} />
 }
@@ -371,23 +367,14 @@ function DocumentDialog({
 										<Trans>
 											This document is a web page. It opens in a new tab.
 										</Trans>
-										<PriButton
-											type='button'
-											$variant='filled'
+										<OpenPageLink
+											href={documentOpenUrl(state.doc.id)}
+											target='_blank'
+											rel='noreferrer'
 											data-testid='document-open-original'
-											disabled={body?.htmlUrl == null}
-											onClick={() => {
-												if (body?.htmlUrl != null) {
-													window.open(
-														body.htmlUrl,
-														'_blank',
-														'noopener,noreferrer',
-													)
-												}
-											}}
 										>
 											<Trans>Open the page</Trans>
-										</PriButton>
+										</OpenPageLink>
 									</HtmlNotice>
 								) : (
 									<MarkdownView source={body?.content ?? state.doc.snippet} />
@@ -666,4 +653,10 @@ const FullPageLink = styled.span`
 		font-size: var(--font-size-sm);
 		text-decoration: underline;
 	}
+`
+
+const OpenPageLink = styled.a`
+	color: var(--color-primary);
+	font-size: var(--font-size-sm);
+	text-decoration: underline;
 `

--- a/apps/internal/src/lib/document-links.ts
+++ b/apps/internal/src/lib/document-links.ts
@@ -1,0 +1,17 @@
+import { apiBaseUrl } from '#/lib/api-base'
+
+/**
+ * Where an HTML document opens: an address that never changes, checked on every
+ * visit, which forwards to a storage link that expires.
+ *
+ * Relative in dev for the reason `downloadUrlFor` spells out: this goes into an
+ * `<a href>` during SSR, and the dev value of `apiBaseUrl()` is a loopback
+ * address the browser would not send the session cookie to.
+ */
+export function documentOpenUrl(documentId: string): string {
+	const base =
+		typeof import.meta !== 'undefined' && import.meta.env?.DEV
+			? ''
+			: apiBaseUrl()
+	return `${base}/v1/documents/${encodeURIComponent(documentId)}/open`
+}

--- a/apps/internal/src/routes/documents/$id.tsx
+++ b/apps/internal/src/routes/documents/$id.tsx
@@ -5,8 +5,6 @@ import { DateTime } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import styled from 'styled-components'
 
-import { PriButton } from '@batuda/ui/pri'
-
 import { documentAtomFor } from '#/atoms/documents-atoms'
 import { DOCUMENT_KIND_LABELS } from '#/components/documents/document-kinds'
 import { useSetDocumentTitle } from '#/components/layout/top-bar-title'
@@ -15,6 +13,7 @@ import { ErrorState } from '#/components/shared/error-state'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { dehydrateAtom } from '#/lib/atom-hydration'
+import { documentOpenUrl } from '#/lib/document-links'
 import { getServerCookieHeader } from '#/lib/server-cookie'
 import { stenciledTitle } from '#/lib/workshop-mixins'
 
@@ -109,19 +108,14 @@ function DocumentPage() {
 						This document is a web page. It opens in a tab of its own, exactly
 						as it was saved.
 					</Trans>
-					<PriButton
-						type='button'
-						$variant='filled'
+					<OpenPageLink
+						href={documentOpenUrl(id)}
+						target='_blank'
+						rel='noreferrer'
 						data-testid='document-page-open-original'
-						disabled={doc.htmlUrl == null}
-						onClick={() => {
-							if (doc.htmlUrl != null) {
-								window.open(doc.htmlUrl, '_blank', 'noopener,noreferrer')
-							}
-						}}
 					>
 						<Trans>Open the page</Trans>
-					</PriButton>
+					</OpenPageLink>
 				</Notice>
 			) : (
 				<Body data-testid='document-page-body'>
@@ -170,4 +164,13 @@ const Notice = styled.div`
 	gap: var(--space-md);
 	color: var(--color-text-muted);
 	font-size: var(--font-size-sm);
+`
+
+// An ordinary link, so the address is there to copy and the browser opens it
+// the way it opens any other page.
+const OpenPageLink = styled.a`
+	align-self: flex-start;
+	color: var(--color-primary);
+	font-size: var(--font-size-sm);
+	text-decoration: underline;
 `

--- a/apps/internal/tests/e2e/documents-on-company.test.ts
+++ b/apps/internal/tests/e2e/documents-on-company.test.ts
@@ -245,6 +245,43 @@ test.describe('documents on the company Files tab', () => {
 		})
 	})
 
+	test.describe('when a document is a saved web page', () => {
+		test('should open at an address that keeps working', async ({ page }) => {
+			// GIVEN the seeded web page, whose body is a stored file rather than a
+			// column, so the only way to read it is the link
+			const pageDoc = psql(
+				`SELECT id FROM documents WHERE format='html' LIMIT 1`,
+			)
+			expect(pageDoc, 'seed should provide one HTML document').not.toBe('')
+
+			await page.goto(`/documents/${pageDoc}`, { waitUntil: 'networkidle' })
+
+			// WHEN the link out to the page is read off the rendered markup
+			const link = page.getByTestId('document-page-open-original')
+			await expect(link).toBeVisible()
+			const href = await link.getAttribute('href')
+			expect(href).toContain(`/v1/documents/${pageDoc}/open`)
+
+			// THEN following it lands on the stored page. Asserting the body proves
+			// the whole chain: the session was accepted, the organisation checked,
+			// a fresh storage link minted, and the redirect followed.
+			const landed = await page.evaluate(async (url: string) => {
+				const res = await fetch(url, { credentials: 'include' })
+				return { ok: res.ok, body: (await res.text()).slice(0, 200) }
+			}, href!)
+			expect(landed.ok).toBe(true)
+			expect(landed.body).toContain('Cal Pep Fonda')
+
+			// AND the address is not a one-shot: it is checked and re-minted each
+			// time, so a second visit works exactly as the first did
+			const again = await page.evaluate(async (url: string) => {
+				const res = await fetch(url, { credentials: 'include' })
+				return res.ok
+			}, href!)
+			expect(again).toBe(true)
+		})
+	})
+
 	test.describe('when Alice adds a document', () => {
 		test('should store the title, type and content she typed', async ({
 			page,

--- a/apps/server/src/handlers/documents.ts
+++ b/apps/server/src/handlers/documents.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import { DateTime, Effect, Schema } from 'effect'
+import { HttpServerResponse } from 'effect/unstable/http'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
@@ -16,10 +17,13 @@ import { Document, type DocumentSubjectTable } from '@batuda/domain'
 import { resolvePageTotal } from '../lib/sql-pagination'
 import {
 	type DocumentSubjectRow,
+	deleteStoredFile,
 	HTML_URL_TTL_SECONDS,
 	htmlStorageKey,
 	linkDocument,
+	rewriteStoredHtml,
 	searchTextFromHtml,
+	storedFileFor,
 	subjectsForDocument,
 	unlinkDocument,
 } from '../services/documents'
@@ -72,16 +76,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 				Effect.gen(function* () {
 					const doc = yield* decodeDocument(row)
 					const subjects = yield* subjectsForDocument(sql, id)
-					const storageKey = (row as { storageKey?: string | null }).storageKey
-					// The link is minted per read and expires, so one copied out of
-					// a log or a shared screen stops working shortly after.
-					const htmlUrl =
-						doc.format === 'html' && storageKey
-							? yield* storage
-									.signedUrl(storageKey, HTML_URL_TTL_SECONDS)
-									.pipe(Effect.orDie)
-							: null
-					return { ...doc, subjects, htmlUrl }
+					return { ...doc, subjects }
 				})
 
 			return handlers
@@ -152,6 +147,30 @@ export const DocumentsLive = HttpApiBuilder.group(
 								id: _.params.id,
 							})
 						return yield* detailFor(doc, _.params.id)
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
+				)
+				.handleRaw('open', _ =>
+					Effect.gen(function* () {
+						const storageKey = yield* storedFileFor(sql, _.params.id)
+						// A markdown document keeps its body on the row, so there is no
+						// stored page for this address to open.
+						if (storageKey === null)
+							return yield* new NotFound({
+								entity: 'document page',
+								id: _.params.id,
+							})
+						const url = yield* storage
+							.signedUrl(storageKey, HTML_URL_TTL_SECONDS)
+							.pipe(Effect.orDie)
+						// Never cached: a remembered redirect would send the next visit
+						// to a storage link that has already expired.
+						return HttpServerResponse.redirect(url, {
+							headers: { 'cache-control': 'no-store' },
+						})
 					}).pipe(
 						Effect.catch(e =>
 							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
@@ -272,8 +291,22 @@ export const DocumentsLive = HttpApiBuilder.group(
 				)
 				.handle('update', _ =>
 					Effect.gen(function* () {
+						// A web page's body is a stored file, so new content goes there
+						// and the row takes only the fields that come back with it.
+						const storageKey = yield* storedFileFor(sql, _.params.id)
+						const fields =
+							storageKey !== null && _.payload.content !== undefined
+								? {
+										..._.payload,
+										...(yield* rewriteStoredHtml(
+											storage,
+											storageKey,
+											_.payload.content,
+										)),
+									}
+								: _.payload
 						const rows = yield* sql`
-							UPDATE documents SET ${sql.update({ ..._.payload, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
+							UPDATE documents SET ${sql.update({ ...fields, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						yield* Effect.logInfo('Document updated').pipe(
@@ -288,8 +321,14 @@ export const DocumentsLive = HttpApiBuilder.group(
 				)
 				.handle('remove', _ =>
 					Effect.gen(function* () {
+						// Read where the bytes are before the row that names them is
+						// gone, or nothing can find them afterwards.
+						const storageKey = yield* storedFileFor(sql, _.params.id)
 						// The links go with the row through their foreign key.
 						yield* sql`DELETE FROM documents WHERE id = ${_.params.id}`
+						if (storageKey !== null) {
+							yield* deleteStoredFile(storage, _.params.id, storageKey)
+						}
 						yield* Effect.logInfo('Document removed').pipe(
 							Effect.annotateLogs({
 								event: 'document.removed',

--- a/apps/server/src/mcp/tools/documents.ts
+++ b/apps/server/src/mcp/tools/documents.ts
@@ -10,10 +10,15 @@ import {
 } from '@batuda/domain'
 
 import {
+	deleteStoredFile,
+	HTML_URL_TTL_SECONDS,
 	linkDocument,
+	rewriteStoredHtml,
+	storedFileFor,
 	subjectsForDocument,
 	unlinkDocument,
 } from '../../services/documents'
+import { StorageProvider } from '../../services/storage-provider'
 import {
 	DocumentCreated,
 	TimelineActivityService,
@@ -69,12 +74,14 @@ const GetDocuments = Tool.make('get_documents', {
 	.annotate(Tool.OpenWorld, false)
 
 const GetDocument = Tool.make('get_document', {
-	description: `Get a single document with its markdown body and the records it is filed against. A body longer than ${MAX_BODY_CHARS} characters comes back cut off, ending in "…[truncated]".`,
+	description: `Get a single document and the records it is filed against. A markdown document carries its body in \`content\`, cut off past ${MAX_BODY_CHARS} characters with a trailing "…[truncated]". A web page (format=html) has an empty \`content\` and a short-lived \`bodyUrl\` to fetch it from instead — that link is the only way to read one, and it expires.`,
 	parameters: Schema.Struct({
 		id: Schema.String,
 	}),
 	success: Schema.Struct({
 		...Document.json.fields,
+		// Null for markdown, whose body is right here in `content`.
+		bodyUrl: Schema.NullOr(Schema.String),
 		subjects: Schema.Array(
 			Schema.Struct({
 				subjectTable: DocumentSubjectTable,
@@ -181,6 +188,7 @@ export const DocumentTools = Toolkit.make(
 export const DocumentHandlersLive = DocumentTools.toLayer(
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
+		const storage = yield* StorageProvider
 		const timeline = yield* TimelineActivityService
 		const decodeSummaries = makeSummaryDecoder()
 		return {
@@ -233,9 +241,20 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 					if (!doc) return yield* Effect.die(`Document ${id} not found`)
 					const decoded = yield* decodeDocument(doc)
 					const subjects = yield* subjectsForDocument(sql, id)
+					// An agent authenticates with a key and has no browser session,
+					// so it gets a short-lived link straight to the stored page
+					// rather than the address a person opens.
+					const storageKey = yield* storedFileFor(sql, id)
+					const bodyUrl =
+						storageKey === null
+							? null
+							: yield* storage
+									.signedUrl(storageKey, HTML_URL_TTL_SECONDS)
+									.pipe(Effect.orDie)
 					return {
 						...decoded,
 						content: truncateLongBody(decoded.content),
+						bodyUrl,
 						subjects,
 					}
 				}).pipe(Effect.orDie),
@@ -305,8 +324,12 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 				}).pipe(Effect.orDie),
 			update_document: ({ id, ...fields }) =>
 				Effect.gen(function* () {
+					const storageKey = yield* storedFileFor(sql, id)
 					const data: Record<string, unknown> = {
 						...fields,
+						...(storageKey !== null && fields.content !== undefined
+							? yield* rewriteStoredHtml(storage, storageKey, fields.content)
+							: {}),
 						updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 					}
 					const rows =
@@ -316,8 +339,13 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 				}).pipe(Effect.orDie),
 			delete_document: ({ id }) =>
 				Effect.gen(function* () {
+					// Read where the bytes are before the row that names them goes.
+					const storageKey = yield* storedFileFor(sql, id)
 					// The filings go with the document through their foreign key.
 					yield* sql`DELETE FROM documents WHERE id = ${id}`
+					if (storageKey !== null) {
+						yield* deleteStoredFile(storage, id, storageKey)
+					}
 					return { status: 'deleted' as const }
 				}).pipe(Effect.orDie),
 			attach_document: params =>

--- a/apps/server/src/services/document-storage.integration.test.ts
+++ b/apps/server/src/services/document-storage.integration.test.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { StorageError } from '@batuda/controllers'
+
+import { PgLive } from '../db/client.js'
+import {
+	deleteStoredFile,
+	rewriteStoredHtml,
+	storedFileFor,
+} from './documents.js'
+import { StorageProvider } from './storage-provider.js'
+
+// A web page's body is a file, not a column, and nothing in the database knows
+// that. Two faults followed from it and are pinned here: deleting a document
+// left its page in storage forever, and editing one wrote the new HTML onto the
+// row while the stored page kept the old bytes, so the edit vanished with no
+// error. Storage is stubbed, so these assert what the code asks of it rather
+// than re-testing S3; the real path runs against MinIO in the API round trip.
+
+const ORG = `docstore-${randomUUID()}`
+
+const written: Array<{ key: string; body: string }> = []
+const deleted: string[] = []
+
+const storageStub = Layer.succeed(StorageProvider)(
+	StorageProvider.of({
+		put: params =>
+			Effect.sync(() => {
+				written.push({
+					key: params.key,
+					body: new TextDecoder().decode(params.body),
+				})
+			}),
+		get: () => Effect.die('unused'),
+		delete: key =>
+			Effect.sync(() => {
+				deleted.push(key)
+			}),
+		head: () => Effect.die('unused'),
+		signedUrl: () => Effect.die('unused'),
+	}),
+)
+
+const run = <A>(eff: Effect.Effect<A, unknown, SqlClient.SqlClient>) =>
+	Effect.runPromise(
+		eff.pipe(Effect.orDie, Effect.provide(PgLive)) as Effect.Effect<
+			A,
+			never,
+			never
+		>,
+	)
+
+const runWithStorage = <A>(
+	eff: Effect.Effect<A, unknown, SqlClient.SqlClient | StorageProvider>,
+) =>
+	Effect.runPromise(
+		eff.pipe(
+			Effect.orDie,
+			Effect.provide(storageStub),
+			Effect.provide(PgLive),
+		) as Effect.Effect<A, never, never>,
+	)
+
+const seedDocument = (format: 'markdown' | 'html') =>
+	run(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const id = randomUUID()
+			const storageKey =
+				format === 'html' ? `documents/${ORG}/${id}.html` : null
+			yield* sql`
+				INSERT INTO documents (id, organization_id, type, format, content, storage_key, search_text)
+				VALUES (
+					${id}, ${ORG}, 'general', ${format},
+					${format === 'html' ? '' : '# markdown body'},
+					${storageKey},
+					${format === 'html' ? 'old words' : null}
+				)
+			`
+			return { id, storageKey }
+		}),
+	)
+
+describe('a document whose body is a stored file', () => {
+	beforeAll(() => {
+		written.length = 0
+		deleted.length = 0
+	})
+
+	afterAll(async () => {
+		await run(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				yield* sql`DELETE FROM documents WHERE organization_id = ${ORG}`
+			}),
+		)
+	})
+
+	describe('when asked where a document keeps its body', () => {
+		it('should name the file for a web page and nothing for markdown', async () => {
+			// GIVEN one document of each kind
+			const html = await seedDocument('html')
+			const markdown = await seedDocument('markdown')
+
+			// WHEN each is asked where its body lives
+			const forHtml = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* storedFileFor(sql, html.id)
+				}),
+			)
+			const forMarkdown = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* storedFileFor(sql, markdown.id)
+				}),
+			)
+
+			// THEN only the web page has one, which is what tells a caller whether
+			// storage has to be touched at all
+			expect(forHtml).toBe(html.storageKey)
+			expect(forMarkdown).toBeNull()
+		})
+	})
+
+	describe('when a web page is edited', () => {
+		it('should write the new body where the page is read from, not onto the row', async () => {
+			// GIVEN a stored page
+			const html = await seedDocument('html')
+
+			// WHEN it is edited
+			const fields = await runWithStorage(
+				Effect.gen(function* () {
+					const storage = yield* StorageProvider
+					return yield* rewriteStoredHtml(
+						storage,
+						html.storageKey!,
+						'<html><body><h1>Second draft</h1></body></html>',
+					)
+				}),
+			)
+
+			// THEN the new bytes went to the file the page is served from
+			expect(written.at(-1)?.key).toBe(html.storageKey)
+			expect(written.at(-1)?.body).toContain('Second draft')
+			// AND the row keeps no body of its own, so there is one answer to what
+			// the page says
+			expect(fields.content).toBe('')
+			// AND the words a search matches on moved with it, or the page would
+			// stay findable by wording it no longer contains
+			expect(fields.searchText).toBe('Second draft')
+		})
+	})
+
+	describe('when a document is deleted', () => {
+		it('should take its stored page with it', async () => {
+			// GIVEN a stored page
+			const html = await seedDocument('html')
+
+			// WHEN the document is deleted
+			await runWithStorage(
+				Effect.gen(function* () {
+					const storage = yield* StorageProvider
+					return yield* deleteStoredFile(storage, html.id, html.storageKey!)
+				}),
+			)
+
+			// THEN the file goes too — otherwise the content of something somebody
+			// deleted is still sitting in storage
+			expect(deleted).toContain(html.storageKey)
+		})
+
+		it('should still count as deleted when storage refuses', async () => {
+			// GIVEN storage that refuses the delete
+			const failing = Layer.succeed(StorageProvider)(
+				StorageProvider.of({
+					put: () => Effect.die('unused'),
+					get: () => Effect.die('unused'),
+					delete: key =>
+						Effect.fail(
+							new StorageError({
+								message: 'bucket unreachable',
+								operation: 'delete',
+								key,
+							}),
+						),
+					head: () => Effect.die('unused'),
+					signedUrl: () => Effect.die('unused'),
+				}),
+			)
+
+			// WHEN a document is deleted anyway
+			// THEN this resolves rather than raising: an unreachable file is worth
+			// less than a document somebody cannot get rid of
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageProvider
+					return yield* deleteStoredFile(storage, 'some-id', 'some/key.html')
+				}).pipe(Effect.provide(failing)) as Effect.Effect<
+					unknown,
+					never,
+					never
+				>,
+			)
+		})
+	})
+})

--- a/apps/server/src/services/documents.ts
+++ b/apps/server/src/services/documents.ts
@@ -3,6 +3,8 @@ import type { SqlClient } from 'effect/unstable/sql'
 
 import type { DocumentSubjectTable } from '@batuda/domain'
 
+import type { StorageProvider } from './storage-provider'
+
 /**
  * Filing documents against CRM records.
  *
@@ -161,3 +163,66 @@ export const subjectsForDocument = (
 		WHERE document_id = ${documentId}
 		ORDER BY subject_table, created_at
 	`.pipe(Effect.orDie)
+
+/**
+ * The stored file behind an HTML document, or nothing for a markdown one, whose
+ * body is on the row itself.
+ */
+export const storedFileFor = (sql: SqlClient.SqlClient, documentId: string) =>
+	Effect.gen(function* () {
+		const rows = yield* sql<{
+			format: string
+			storageKey: string | null
+		}>`SELECT format, storage_key FROM documents WHERE id = ${documentId} LIMIT 1`
+		const row = rows[0]
+		if (!row || row.format !== 'html' || !row.storageKey) return null
+		return row.storageKey
+	}).pipe(Effect.orDie)
+
+/**
+ * Remove the stored page behind a document that is being deleted.
+ *
+ * Deliberately best-effort: a storage failure leaves a file nobody can reach,
+ * which is better than refusing to delete the document.
+ */
+export const deleteStoredFile = (
+	storage: StorageProvider['Service'],
+	documentId: string,
+	storageKey: string,
+) =>
+	storage.delete(storageKey).pipe(
+		Effect.catchTag('StorageError', error =>
+			Effect.logError('Stored page outlived its document').pipe(
+				Effect.annotateLogs({
+					event: 'document.storage_delete_failed',
+					documentId,
+					storageKey,
+					error: error.message,
+				}),
+			),
+		),
+	)
+
+/**
+ * Write a web page's new body where the page is actually read from, and return
+ * the row fields that go with it.
+ *
+ * Putting new HTML on the row instead would leave the stored page serving the
+ * old bytes, with no error. The plain words move with it, or a search would keep
+ * finding the page by wording it no longer contains.
+ */
+export const rewriteStoredHtml = (
+	storage: StorageProvider['Service'],
+	storageKey: string,
+	content: string,
+) =>
+	storage
+		.put({
+			key: storageKey,
+			body: new TextEncoder().encode(content),
+			contentType: 'text/html; charset=utf-8',
+		})
+		.pipe(
+			Effect.orDie,
+			Effect.as({ content: '', searchText: searchTextFromHtml(content) }),
+		)

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -632,7 +632,41 @@ Key files:
 
 ### Cross-origin policy
 
-The web app and the API are different origins. In dev, portless serves the app at `https://batuda.localhost` and the API at `https://api.batuda.localhost` — binding 443 when it can, otherwise a non-privileged port like `:1355`, which it prints on startup; in prod the app (Cloudflare Workers, `batuda.co`) and API (Unikraft, `api.batuda.co`) split the same way. The browser fetches `/auth/*` same-origin (the Vite dev proxy / Worker forwards them to the API, so the session cookie lands on the app host) and `/v1/*` cross-origin to the API host. CORS is a global `HttpRouter.middleware` in `src/main.ts` via `HttpMiddleware.cors({ allowedOrigins, credentials: true, ... })`; `allowedOrigins` comes from the **required** `ALLOWED_ORIGINS` env — comma-separated **literal** origins matched exactly, with no wildcards (any `*` fails boot) and no dev fallback (boot fails if unset). The same array is fed to Better-Auth as `trustedOrigins` (`src/lib/auth.ts`) so CORS and CSRF agree, and `credentials: true` lets the browser attach the `__Secure-batuda.session_token` cookie on `credentials: 'include'` fetches. A git-worktree dev stack needs no per-worktree origin config: the server derives the worktree's `<branch>.batuda.localhost` origin from `PORTLESS_URL` and merges it into the trusted set (see the `worktrees` skill).
+The web app and the API are different origins. In dev, portless serves the app at `https://batuda.localhost` and the API at `https://api.batuda.localhost` — binding 443 when it can, otherwise a non-privileged port like `:1355`, which it prints on startup; in prod the app (Cloudflare Workers, `batuda.co`) and API (Unikraft, `api.batuda.co`) split the same way. The browser fetches `/auth/*` same-origin (the Vite dev proxy / Worker forwards them to the API, so the session cookie lands on the app host) and `/v1/*` cross-origin to the API host — that is what `apiBaseUrl()` (`apps/internal/src/lib/api-base.ts`) returns in prod. Dev is the exception: there it returns the app's own origin, so a `/v1/*` call goes through the Vite proxy instead. Both the dev proxy and the Worker (`apps/internal/src/worker.ts`) forward `/v1/*` as well as `/auth/*`, so a relative `/v1/…` works in either.
+
+**A URL baked into an `<a href>` has to respect that split.** SSR renders the markup, so the URL is chosen on the server and then used by the browser: in dev `apiBaseUrl()` is a loopback address that would ship inside the HTML and be refused (the browser will not send a `Secure` cookie there), while a relative path resolves against the page's own origin, whose `/v1/*` the dev server forwards. In prod it is the real API origin, reached directly like every other call. `downloadUrlFor` (`apps/internal/src/lib/email-attachments.ts`) and `documentOpenUrl` (`apps/internal/src/lib/document-links.ts`) are the two places that do this, and both pick the base the same way. Such a link works on the session cookie alone: a top-level navigation sends no `Origin`, so CORS does not apply, and nothing on `/v1/*` checks `Origin`, `Referer` or a CSRF token.
+
+CORS is a global `HttpRouter.middleware` in `src/main.ts` via `HttpMiddleware.cors({ allowedOrigins, credentials: true, ... })`; `allowedOrigins` comes from the **required** `ALLOWED_ORIGINS` env — comma-separated **literal** origins matched exactly, with no wildcards (any `*` fails boot) and no dev fallback (boot fails if unset). The same array is fed to Better-Auth as `trustedOrigins` (`src/lib/auth.ts`) so CORS and CSRF agree, and `credentials: true` lets the browser attach the `__Secure-batuda.session_token` cookie on `credentials: 'include'` fetches. A git-worktree dev stack needs no per-worktree origin config: the server derives the worktree's `<branch>.batuda.localhost` origin from `PORTLESS_URL` and merges it into the trusted set (see the `worktrees` skill).
+
+### Object storage and who can read a stored file
+
+Some things are too big, or too file-shaped, to sit in a database column: call recordings, the research scrape cache, and the body of a document saved as a web page. Those go to object storage — MinIO locally, Cloudflare R2 in production (`STORAGE_ENDPOINT`, `STORAGE_BUCKET` in `config.production.json`; the two keys arrive as deploy secrets). One provider-agnostic port, `StorageProvider` (`apps/server/src/services/storage-provider.ts`), with `S3StorageProviderLive` as the only adapter today.
+
+**The bucket is private.** Nothing in it is reachable without a credential, so every read is either a presigned URL or bytes the server streams itself.
+
+A document makes the trade-off visible, because it has both kinds of body:
+
+- **Markdown** stays in `documents.content`. It is small, edited in place, and has to be searchable.
+- **A web page** goes to storage under `documents/<org>/<document>.html`, and the row keeps only the key plus `search_text` — the page's plain words, so a search still reaches it. `content` is empty, and the `documents_body_matches_format` constraint keeps the two shapes from mixing. `search_text` is never shown to anyone; what a reader opens is the stored page.
+
+Storing a page rather than rendering it is a deliberate boundary. The HTML was written by an agent or scraped from somewhere, and serving it from the app's own address would put markup nobody vetted next to the signed-in session. From the storage address the browser treats it as the separate place it is.
+
+**Two link shapes, for two kinds of caller:**
+
+|                | `GET /v1/documents/:id/open`                           | A presigned URL                                                                                        |
+| -------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| Lives for      | ever — the address never changes                       | `HTML_URL_TTL_SECONDS`, 10 minutes                                                                     |
+| Checked        | on every open, by session + organisation               | once, when it is minted                                                                                |
+| Who can use it | a signed-in member of the owning organisation          | anyone holding it, until it expires                                                                    |
+| Used by        | the web app, and anything a person pastes or bookmarks | the agent tools (`get_document`'s `bodyUrl`), which authenticate with a key and have no browser cookie |
+
+`/open` answers a `302` to a freshly minted presigned URL, with `Cache-Control: no-store` — a remembered redirect would send the next visit to a link that has already expired. It answers `404` for a markdown document, which has no stored file.
+
+**A presigned URL cannot be made permanent.** The signing scheme R2 implements caps validity at seven days, so a link that never dies is not reachable by lengthening the window — and every extra hour widens the blast radius of one that leaks. That is why the permanent address is a checked endpoint rather than a longer signature.
+
+**Writes and deletes touch both places.** Creating a page writes the bytes *before* the row, because a stored file with no row is invisible and costs a little space, while a row pointing at a file that was never written is a document that opens to nothing. Editing one rewrites the stored file and refreshes `search_text`; putting new HTML on the row instead would leave the page serving the old bytes with no error. Deleting one removes the file too, best-effort — an unreachable file is worth less than a document somebody cannot get rid of. All three live in `apps/server/src/services/documents.ts`, so the HTTP handler and the agent tools share one copy of the rules rather than each keeping its own.
+
+Not handled, deliberately: nothing reclaims a file orphaned by a crash between the storage write and the row insert. The write order makes that the cheap failure, and a sweep is its own job.
 
 ### Invite-only signup
 

--- a/packages/controllers/src/routes/documents.ts
+++ b/packages/controllers/src/routes/documents.ts
@@ -14,14 +14,13 @@ import { PaginatedList } from '../pagination'
 
 // A document plus the records it is filed under. The subjects live in their own
 // table, so they ride alongside the row rather than in it.
+//
+// An HTML document's body is not here. It is a stored file, opened through
+// `GET /documents/:id/open` — an address anyone holding this id can build, so it
+// needs no field of its own.
 export const DocumentDetail = Schema.Struct({
 	...Document.json.fields,
 	subjects: Schema.Array(DocumentSubject),
-	// Where an HTML document actually opens: a short-lived link to the stored
-	// page, on the storage address rather than this one, so a page somebody else
-	// wrote never loads beside the signed-in session. Null for markdown, whose
-	// body is right here in `content`.
-	htmlUrl: Schema.NullOr(Schema.String),
 })
 
 // Listing projection: everything but the full markdown `content`, so a long
@@ -78,6 +77,20 @@ export const DocumentsGroup = HttpApiGroup.make('documents')
 		HttpApiEndpoint.get('get', '/documents/:id', {
 			params: { id: Schema.String },
 			success: DocumentDetail,
+			error: NotFound.pipe(HttpApiSchema.status(404)),
+		}),
+	)
+	.add(
+		// The address an HTML document opens at. It never changes, so it can be
+		// sent to somebody or kept in a tab, and it is checked on every open —
+		// unlike the storage link it redirects to, which expires and, while it
+		// lasts, works for whoever holds it. Redirecting rather than serving the
+		// page keeps markup somebody else wrote off this origin. `Schema.Unknown`
+		// because the response is that redirect, not a body — same as the
+		// attachment download.
+		HttpApiEndpoint.get('open', '/documents/:id/open', {
+			params: { id: Schema.String },
+			success: Schema.Unknown,
 			error: NotFound.pipe(HttpApiSchema.status(404)),
 		}),
 	)


### PR DESCRIPTION
## What

A document saved as a web page — the kind an agent writes or an import brings in — is stored as a file rather than as text in the database. Until now it opened through a link to that file which expired after ten minutes and, until it did, worked for **anyone it was forwarded to**. So a link pasted into a message was dead by the time somebody read it, a tab left open failed on reload, and a link that leaked let a stranger read the page.

It now opens at an address that never changes and is checked every single time, which forwards to a fresh storage link behind the scenes. Copy it, bookmark it, send it to a colleague — it keeps working, and only for people in the organisation that owns the document.

Lengthening the old link could not have solved this: the way those links are signed caps them at seven days, and every extra hour widens what a leak exposes.

This lives in the CRM — the `server` API, the `internal` web app, the agent tools and the `cli` sample data.

## Changes

- **A permanent address.** `GET /v1/documents/:id/open` checks the session and the organisation, then redirects to a newly minted storage link. It redirects rather than serving the page itself, so markup somebody else wrote never loads on the address that holds the signed-in session — the reason the body went to storage in the first place.
- **The old expiring link is gone from the document shape**, with nothing in its place. The web app builds the address from the document's own id, so the two buttons became ordinary links and render immediately instead of waiting on a request whose only purpose was the URL.
- **Agents can read such a page at all.** `get_document` returned an empty body and no way to fetch one. It now returns a short-lived link, because an agent authenticates with a key and has no browser session to check.
- **Sample data covers documents properly** — eleven of them, both formats, all five records a document can be filed against, and one filed against both a meeting and its company.

## Two bugs fixed

Both were mine, from the pull request that added HTML documents, and both were invisible.

- **Deleting a document left its page in storage forever.** The row went, the file stayed. A cost, and worse than a cost for notes about named people: "delete" has to mean the words are gone.
- **Editing one silently did nothing.** The new content was written onto the database row while the stored file kept the old bytes, so the page carried on showing what it said before and nothing reported a problem. The database constraint could not catch it, because it only checks that a stored key exists, not that the body is where it belongs.

Each existed **twice over** — once for the web app, once for the agent tools — because each surface had its own copy of the rules. That is also how they came to differ in the first place, so the rules now live once in `apps/server/src/services/documents.ts` and both callers use them.

## One unrelated fix, folded in

The end-to-end job was red on this branch for a reason that has nothing to do with documents, and that re-running could not fix.

The container that creates the storage bucket does its one job and stops. `docker compose up --wait` counts a stopped container as a failure, so listing it alongside the services that stay running passed or failed on **timing alone** — on whether compose happened to look before or after it finished. Reproduced in an isolated throwaway project: the old form exits `1` with `container … exited (0)`, byte-for-byte the message in the failing log.

It now runs as its own waited-on step. That also means a bucket which genuinely cannot be created fails the run with its own exit code, where the old form reported that identically to a success. Fixed at both call sites — `ci.yml` and the shared `e2e-stack` action — so no other branch keeps rolling the same dice.

## Impact

- **No migration.** Nothing about the schema changes.
- **Wire shape changed.** `htmlUrl` is gone from the document shape both the server and the web app's typed client read; `get_document` gained `bodyUrl`. Pre-production, so a clean break with no shim.
- **Both surfaces get everything.** The API and the agent tools share one implementation of reading, rewriting and removing a stored file.
- **Multi-organisation.** The new endpoint runs under the same session and organisation checks as every other `/v1` route, so a member of another organisation is refused. That is a real change in kind: the old link was checked once when minted and then worked for whoever held it.
- **No new environment variables.** It reuses the storage already carrying call recordings and the research scrape cache.
- **The sample data now writes to storage** when seeding the web page, as the call-recordings step already does — so `pnpm cli seed --preset full` needs the storage service reachable.

## Review guide

Start at `apps/server/src/services/documents.ts`. The three storage rules live there and both callers use them; if anything is wrong, it is wrong once.

Two things worth a look:

1. **The redirect surviving the proxy.** In production the link goes straight to the API origin, but in development a relative `/v1/…` passes through the dev server, and if that had *followed* the redirect the page would have come back through the app's own address — losing the separation the whole design rests on. I checked this before writing anything else: `302` with the `Location` on the storage origin through both paths.
2. **`Cache-Control: no-store` on the redirect.** Without it a browser could remember the redirect and send the next visit to a storage link that has already expired — the exact failure this replaces.

One decision you might overrule: **agents keep getting a short-lived link rather than the permanent one.** The permanent address needs a browser session, so handing it to an MCP client would be giving out a URL the tool itself cannot use. If you would rather have one link shape everywhere, that is the trade.

Duplication I chose and would rather flag than hide: **`plainWordsOf` in the sample data repeats `searchTextFromHtml` in the server.** The CLI does not depend on the server package, so importing it would mean a new cross-package dependency for four lines. If the two drift, a seeded web page quietly stops being findable by its wording. Worth moving both somewhere shared at some point.

Skip-able: the sample-data fixtures are prose.

## Screenshots

**A document that is a web page.** The link is an ordinary anchor, so its address is there to copy.

![document page with the open link](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-354/pr-open-link.webp)

**Where the link lands** — the saved page, served from the storage address. Confirmed in the browser: `location.origin` is the storage host, not the app.

![the opened page](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-354/pr-opened-page.webp)

## Tests

- **Integration** (4 new): which documents keep their body in a file and which do not; an edit writing to the file rather than the row, with the searchable words moving too; a delete taking the file with it; and a delete still succeeding when storage refuses, because an unreachable file is worth less than a document nobody can get rid of.
- **End-to-end** (1 new): reads the link off the rendered page, follows it to the stored page, and follows it a second time — the second visit is the point, since it is what the old expiring link could not do.

## Verification

Actually run on this branch, after rebasing onto current `main`:

- `pnpm install` → `pnpm -w check-types` (13/13) + `pnpm -w test` → `pnpm -w build`. All exit 0.
- `pnpm exec biome check .` clean across 1014 files. Worth noting: this caught two import-order violations that `pnpm lint-biome <paths>` had missed, because that form only inspects the paths you hand it.
- `pnpm turbo test:integration` — 379 server tests, 16 in the mail worker.
- `pnpm cli db reset && pnpm cli seed` from empty, then the 8 documents end-to-end tests against the live stack.
- By hand against the running API: `302` with `Cache-Control: no-store` and a storage-origin `Location`, through both the API host and the dev proxy; following it returns the page; `404` for a plain-text document; `401` with no session.
- By hand for each bug: edited a web page and confirmed the served page changed, the searchable words changed, the row's body stayed empty and a search found it by the new wording; deleted one and confirmed the file was gone from storage.
- Drove the real app for the screenshots above.
- CI on the pushed branch: both jobs green. The seed inserted 11 documents and 12 filings on a database created from scratch, which is the case the fixtures had never been proven against.

## Deferred

- Nothing reclaims a file orphaned by a crash between writing it and inserting the row. The write order makes that the cheap failure — an unreachable file rather than a document that opens to nothing — and a sweep is its own job.
- The presigned read does not pin the response content type, which would be defence in depth over trusting what was stored.
