### PR TITLE
test(internal): make four browser tests check what they meant to

### DIFF
--- a/apps/internal/src/hooks/use-proposal-resolution.ts
+++ b/apps/internal/src/hooks/use-proposal-resolution.ts
@@ -2,19 +2,13 @@ import { useAtomSet } from '@effect/atom-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { applyProposalAtom, rejectProposalAtom } from '#/atoms/research-atoms'
+import { UNDO_WINDOW_MS } from '#/lib/undo-window'
 
 export type ResolveOutcome = {
 	readonly outcome: string
 	readonly reason: string | null
 }
 export type ResolveDecision = 'apply' | 'reject'
-
-// How long a reviewer can take back an apply/reject before it actually writes.
-// Long enough to be usable by someone who has to find the control first: a
-// listener hears the row change, moves to the button and presses it, which does
-// not happen in five seconds. There is no way to extend it once it starts, so
-// the window itself has to be generous.
-export const UNDO_WINDOW_MS = 20000
 
 /**
  * Shared apply/reject behavior for both proposal-review surfaces (the cross-run

--- a/apps/internal/src/lib/undo-window.ts
+++ b/apps/internal/src/lib/undo-window.ts
@@ -1,0 +1,7 @@
+// How long a reviewer can take back an apply/reject before it actually writes.
+// Generous because it cannot be extended once it starts, and someone who has to
+// hear the row change and then find the button needs more than a few seconds.
+//
+// Kept in a file that imports nothing so tests can read the real value without
+// pulling in the screen it belongs to.
+export const UNDO_WINDOW_MS = 20000

--- a/apps/internal/tests/e2e/research-findings.test.ts
+++ b/apps/internal/tests/e2e/research-findings.test.ts
@@ -4,7 +4,6 @@ import { randomUUID } from 'node:crypto'
 import { expect, test } from '@playwright/test'
 
 import { DATABASE_URL } from './helpers/database-url'
-import { waitForInteractive } from './helpers/hydration'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // A run's findings are the research schema filled in by the model, and they
@@ -141,18 +140,16 @@ test.describe('research findings', () => {
 				).replace(/'/g, "''")}'::jsonb WHERE slug='cal-pep-fonda'`,
 			)
 
-			// WHEN the company page is opened and the fit panel expanded
+			// WHEN the company page is opened
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
-			// The trigger opens the panel from a plain onClick, so a click that
-			// lands before the browser has taken the page over does nothing and
-			// leaves no trace.
-			await waitForInteractive(page, 'company-fit-trigger')
-			await page.getByTestId('company-fit-trigger').click()
 
-			// THEN the criterion and its evidence both render — the quote is the
-			// part that silently disappears if the stored names are read wrongly
+			// THEN the fit panel is already open, because a company that has been
+			// judged shows its reasoning unasked — clicking the trigger would close
+			// it
 			const panel = page.getByTestId('company-fit-panel')
 			await expect(panel).toBeVisible()
+			// AND the criterion and its evidence both render — the quote is the
+			// part that silently disappears if the stored names are read wrongly
 			await expect(panel).toContainText('Takes bookings')
 			await expect(panel).toContainText('Reserva la teva taula')
 		})

--- a/apps/internal/tests/e2e/research-review.test.ts
+++ b/apps/internal/tests/e2e/research-review.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 
 import { expect, test } from '@playwright/test'
 
+import { UNDO_WINDOW_MS } from '#/lib/undo-window'
 import { DATABASE_URL } from './helpers/database-url'
 import { waitForInteractive } from './helpers/hydration'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
@@ -19,6 +20,14 @@ const psql = (sqlText: string): string =>
 	execSync(`psql "${DATABASE_URL}" -tA -c "${sqlText.replace(/"/g, '\\"')}"`, {
 		encoding: 'utf8',
 	}).trim()
+
+// An apply is held back for the whole undo window before it is sent, so the
+// outcome cannot appear sooner. Derived from the screen's own constant, so
+// lengthening the window does not turn these tests red.
+const OUTCOME_TIMEOUT_MS = UNDO_WINDOW_MS + 10_000
+// That wait does not fit in the 30s every other test gets, so the two applying
+// tests ask for the wait plus a normal test's worth of time.
+const APPLY_TEST_TIMEOUT_MS = OUTCOME_TIMEOUT_MS + 30_000
 
 const RUN_ID = '9f000000-0000-4000-8000-0000000000e2'
 const PU_TRUSTWORTHY = 'aaaaaaaa-0000-4000-8000-0000000000e2'
@@ -180,6 +189,7 @@ test.describe('research review', () => {
 		test('should apply a single proposal and show its outcome', async ({
 			page,
 		}) => {
+			test.setTimeout(APPLY_TEST_TIMEOUT_MS)
 			// GIVEN the review screen, interactive so the click reaches a live
 			// handler rather than an inert server-rendered button
 			await page.goto(`/research/${RUN_ID}`, { waitUntil: 'networkidle' })
@@ -190,13 +200,13 @@ test.describe('research review', () => {
 			const badge = needsReviewCard.getByTestId('research-outcome-badge')
 
 			// WHEN the reviewer applies the needs-review proposal. Its write is held
-			// for a short undo window before it reaches the server, so the outcome
-			// lands a few seconds after the click.
+			// back for the whole undo window before it reaches the server, so the
+			// outcome cannot land until that has run out.
 			await needsReviewCard.getByTestId('research-review-apply').click()
 
 			// THEN it enters the CRM (created, or merged if it already existed) and
 			// the card shows the outcome the run now stores
-			await expect(badge).toBeVisible({ timeout: 15_000 })
+			await expect(badge).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS })
 			await expect(badge).toHaveAttribute(
 				'data-outcome',
 				/created|duplicate|applied/,
@@ -206,6 +216,7 @@ test.describe('research review', () => {
 		test('should keep an applied proposal outcome after a reload', async ({
 			page,
 		}) => {
+			test.setTimeout(APPLY_TEST_TIMEOUT_MS)
 			// GIVEN a proposal that has just been applied and shows its outcome
 			await page.goto(`/research/${RUN_ID}`, { waitUntil: 'networkidle' })
 			await waitForInteractive(page, 'research-review-apply')
@@ -214,7 +225,7 @@ test.describe('research review', () => {
 				.filter({ hasText: 'Jordi Garcia' })
 			const badge = card.getByTestId('research-outcome-badge')
 			await card.getByTestId('research-review-apply').click()
-			await expect(badge).toBeVisible({ timeout: 15_000 })
+			await expect(badge).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS })
 
 			// WHEN the page is reloaded, dropping every in-memory reply
 			await page.reload({ waitUntil: 'networkidle' })

--- a/apps/internal/tests/e2e/rich-compose.test.ts
+++ b/apps/internal/tests/e2e/rich-compose.test.ts
@@ -67,15 +67,19 @@ test.describe('compose with rich formatting', () => {
 			await page.keyboard.press('Enter')
 			await editor.pressSequentially('two')
 			// Bold "Hello" by selecting the word — double-click is a reliable
-			// browser primitive — then toggling Tiptap's stock Cmd+B. Toggling
-			// bold on an empty caret (stored marks) does not survive the typing
-			// that follows in headless Chromium.
+			// browser primitive — then toggling the editor's stock bold shortcut.
+			// Toggling bold on an empty caret (stored marks) does not survive the
+			// typing that follows in headless Chromium.
+			//
+			// The modifier must be the portable one: bold is Cmd+B on a Mac and
+			// Ctrl+B elsewhere, and naming one outright sends nothing on the other
+			// machine, so the mail simply goes out unbolded.
 			await editor
 				.locator('p')
 				.filter({ hasText: 'Hello world' })
 				.first()
 				.dblclick({ position: { x: 8, y: 10 } })
-			await page.keyboard.press('Meta+b')
+			await page.keyboard.press('ControlOrMeta+b')
 
 			await expect(page.getByTestId('compose-send')).toBeEnabled()
 			await page.getByTestId('compose-send').click()

--- a/apps/internal/tests/e2e/settings-spend.test.ts
+++ b/apps/internal/tests/e2e/settings-spend.test.ts
@@ -22,6 +22,8 @@ const psql = (sqlText: string): string =>
 	}).trim()
 
 const seededKeys: string[] = []
+// Who the seeded spend is charged to, and how its row is found on the page.
+let seededUserId = ''
 
 test.describe('org spend dashboard', () => {
 	test.beforeAll(() => {
@@ -34,6 +36,7 @@ test.describe('org spend dashboard', () => {
 		const userId = psql(
 			`SELECT id FROM "user" WHERE email='admin@taller.cat' LIMIT 1`,
 		)
+		seededUserId = userId
 		const researchId = psql(
 			`SELECT id FROM research_runs WHERE organization_id='${orgId}' LIMIT 1`,
 		)
@@ -109,10 +112,12 @@ test.describe('org spend dashboard', () => {
 			await expect(byProvider).toContainText('brave')
 			await expect(byProvider).toContainText('firecrawl')
 
-			// AND the user table includes Alice's row (3 calls — the three
-			// seeded rows above)
+			// AND the user table shows that person with money against them. Not a
+			// call count: this table totals everything the organisation ever spent
+			// per person, and the sample data charges the same person too.
 			const byUser = page.getByTestId('settings-spend-by-user')
-			await expect(byUser).toContainText(/3/)
+			await expect(byUser).toContainText(seededUserId)
+			await expect(byUser).toContainText(/€\d/)
 
 			// AND the tool table lists the two seeded tools
 			const byTool = page.getByTestId('settings-spend-by-tool')


### PR DESCRIPTION
## What

Five browser tests had been failing on `main`. None of them was reporting a broken product — each was checking the wrong thing, in its own unrelated way, and the red was hiding whatever might break next. This makes all five check what they were written to check.

Browser tests are the ones that drive the real app in a real browser, so a permanently red suite is expensive: it stops being a signal, and a genuine regression arrives looking exactly like the noise everyone has learned to scroll past.

This is all in the CRM's web app (`internal`) — its end-to-end tests, plus one constant that moved so a test can read it.

## The fix

Four unrelated causes, one per area:

- **A wait shorter than the thing it waits for.** Applying a research proposal is deliberately held back so a reviewer can take it back — a pause that grew from 5 to 20 seconds when it was made usable for someone listening to the page rather than looking at it. Two tests still allowed 15, so they gave up before the change had even been sent. They now read that pause from the screen's own value, which is why `UNDO_WINDOW_MS` moved to a file of its own.
- **A count the test did not own.** The spend test looked for "3 calls" from the three rows it created, but that table totals everything the organisation has ever spent per person, and the sample data charges 11 more calls to the same person. It now checks the row it created.
- **A keyboard shortcut that only exists on a Mac.** The compose test asked for bold with Cmd+B. The full suite runs on Linux, where bold is Ctrl+B, so nothing was pressed and the mail went out unbolded.
- **A click that closed what it wanted to read.** A company that has been judged already shows its reasoning open. The test sets a verdict and then clicked to "expand" — collapsing the panel it was about to read.

## Impact

- **No product behaviour changes.** The only non-test file is `UNDO_WINDOW_MS` moving out of the hook into `apps/internal/src/lib/undo-window.ts`, same value, one importer. Nothing renders differently.
- **No migration, no new environment variables, no wire-shape change, nothing touching tenant isolation or authentication.**
- **Two tests are now slower on purpose.** Waiting out a 20-second pause cannot be avoided without pretending the pause is shorter than it is, so those two ask for their own time budget. Roughly 40 seconds added to a suite that runs about 7 minutes.
- **One of these was mine.** The fit-panel test began failing because of `b239eb0b05`, which I landed the day before: it added a wait for the page to come alive, and before that the click was landing too early and being silently swallowed — so the test had been passing for the wrong reason. Making the click work is what exposed it.

## Review guide

Start with `apps/internal/src/lib/undo-window.ts` — it is the only file that is not a test, and the comment on it explains why it exists at all.

The judgement call worth your attention: **the spend test now asserts a raw internal account id.** That is the only thing the table renders for a person, so it is what the test can name — but it pins behaviour I think is wrong (see Deferred). If you would rather the test asserted nothing about that column until it shows a name, say so.

Two things I could not prove locally:

1. **The Linux half of the keyboard fix.** `ControlOrMeta+b` resolves to Cmd on this Mac, so a local pass only shows the Mac path still works. What I could prove is the diagnosis: forcing `Control+b` on macOS reproduced CI's output exactly — `<span>Hello world</span>`, unbolded, with the bullet list intact. The Linux half is documented behaviour, and the post-merge run is what confirms it.
2. **That CI agrees.** The checks on this pull request run only the smoke subset, and none of these four specs carries that tag — so **a green tick here says nothing about the fixes**. The real proof is the full suite on `main` after merge.

Skip-able: the comment rewording across the four spec files.

## Screenshots

Nothing to show — no rendered output changes. The only non-test edit moves a constant between modules without altering its value.

## Verification

Actually run on this branch, rebased on current `main`:

- The **full browser suite: 117 passed, 0 failed, 6.9 minutes** — from a database built from scratch with `pnpm cli db reset && pnpm cli seed`, the way CI starts. This matters more than it sounds: an earlier run against a database I had dirtied by hand produced two failures that were purely my own mess, so only a run from a clean seed is worth anything here.
- `pnpm install` → `pnpm -w check-types` (13/13) + `pnpm -w test` (21/21) → `pnpm -w build` (13/13). All exit 0, and the build left no generated file changed.
- `pnpm exec biome check .` across the repo — clean. This caught an import-order error of mine that would have gone red in CI.
- Each of the four areas re-run individually after the final comment edits: 15 passed.
- The keyboard diagnosis reproduced deliberately, as described above.

## Deferred

Two real defects found while diagnosing these, both left out because neither is a test fix and folding them in would bury them:

- **The spend dashboard shows an internal account id where a person's name belongs.** `By user` is the only breakdown on that page that is not human-readable, so an admin sees a random string. The backend should return the name and let the web app render it; the assertion in this pull request should become name-based once it does.
- **Text inside a collapsed section cannot be found with the browser's own find-in-page.** A closed panel leaves the page entirely, so someone searching for a phrase they know is there gets no match and no hint that it is hidden. This is also the mechanism that made the fit-panel failure so confusing to read.
