### PR TITLE
test(internal): bold a word without guessing where it sits on screen

### DIFF
--- a/.github/actions/e2e-stack/action.yml
+++ b/.github/actions/e2e-stack/action.yml
@@ -114,3 +114,15 @@ runs:
         grep_arg=""
         if [ -n "$GREP" ]; then grep_arg="--grep $GREP"; fi
         pnpm --filter @batuda/internal exec playwright test $grep_arg
+
+    # Each failing test leaves a screenshot and a replayable recording of the
+    # browser on disk. They disappear with the runner unless uploaded, and a
+    # red run then has to be diagnosed from its printed output alone.
+    - name: Keep the failure screenshots and traces
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: playwright-failures-${{ github.run_id }}-${{ github.run_attempt }}
+        path: apps/internal/test-results/
+        retention-days: 7
+        if-no-files-found: ignore

--- a/apps/internal/tests/e2e/rich-compose.test.ts
+++ b/apps/internal/tests/e2e/rich-compose.test.ts
@@ -13,8 +13,8 @@ import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // Rich-compose path. The Tiptap editor's bubble-menu controls carry no
 // stable testids, so formatting is applied the way a user would: the
-// "- " Markdown rule starts a bullet list, and a double-click word
-// selection plus the stock Cmd+B keymap bolds a word. The proof is
+// "- " Markdown rule starts a bullet list, and selecting a word and
+// pressing the stock bold shortcut bolds it. The proof is
 // wire-side: the decoded text/html part the recipient receives, where the
 // brand renderer emits inline-styled spans — a font-weight span for bold,
 // and <ul>/<li> whose rows wrap their text in <span> — not <strong> or
@@ -66,20 +66,27 @@ test.describe('compose with rich formatting', () => {
 			await editor.pressSequentially('- one')
 			await page.keyboard.press('Enter')
 			await editor.pressSequentially('two')
-			// Bold "Hello" by selecting the word — double-click is a reliable
-			// browser primitive — then toggling the editor's stock bold shortcut.
-			// Toggling bold on an empty caret (stored marks) does not survive the
-			// typing that follows in headless Chromium.
+			// Bold the first word by selecting the line and shrinking the selection
+			// with arrow keys, never by clicking a measured spot: a character sits
+			// at a different place on a machine with different fonts, so the click
+			// would land beside the word and select nothing.
 			//
-			// The modifier must be the portable one: bold is Cmd+B on a Mac and
-			// Ctrl+B elsewhere, and naming one outright sends nothing on the other
-			// machine, so the mail simply goes out unbolded.
-			await editor
+			// The modifier must be the portable one too: bold is Cmd+B on a Mac and
+			// Ctrl+B elsewhere, and naming one outright sends nothing on the other.
+			const firstLine = editor
 				.locator('p')
 				.filter({ hasText: 'Hello world' })
 				.first()
-				.dblclick({ position: { x: 8, y: 10 } })
+			await firstLine.selectText()
+			await page.keyboard.press('ArrowLeft')
+			for (let i = 0; i < 'Hello'.length; i++) {
+				await page.keyboard.press('Shift+ArrowRight')
+			}
 			await page.keyboard.press('ControlOrMeta+b')
+
+			// Check the bold landed before sending, so a shortcut that never
+			// arrived is reported here instead of as a wall of email HTML below.
+			await expect(firstLine.locator('strong')).toHaveText('Hello')
 
 			await expect(page.getByTestId('compose-send')).toBeEnabled()
 			await page.getByTestId('compose-send').click()


### PR DESCRIPTION
## What

One browser test was still failing on `main` after the last round: the one that checks a bold word survives into a sent email. It was failing for a reason that had nothing to do with email — it was picking the word to bold by clicking at a measured spot on screen.

This fixes that, and stops throwing away the evidence a failing run already produces.

This is the CRM's web app (`internal`) — one end-to-end test, plus the shared setup that runs the browser tests in CI.

## The fix

- **Choosing a word by where it looks like it is.** The test double-clicked at a fixed point inside the line to select "Hello". Where a character sits depends on the fonts the machine has, so on the Linux machine that runs the full suite the click landed beside the word and selected nothing — bold had nothing to apply to, and the mail went out unbolded. It now selects the line through the browser's own selection and shrinks that selection with arrow keys, which does not depend on how the text is drawn.
- **A failure that pointed nowhere.** When the bold did not land, the test carried on and failed much later on the received email — several kilobytes of HTML with no indication of which step went wrong. It now checks the editor took the bold before sending, so the failure is reported where it happened.
- **Evidence that was being binned.** Every failing browser test already leaves a screenshot and a replayable recording behind. Those live on the CI machine and vanish with it, so a red suite could only be read from its printed output. They are now kept for a week.

## Impact

- **No product change at all.** One test file and one CI setup file; nothing in the app is touched.
- **The artifact upload helps both suites**, because it sits in the setup shared by the quick pull-request check and the full post-merge run.
- **Only on failure, and short-lived.** Nothing is uploaded by a green run, and what is uploaded expires after seven days.
- **No migration, no environment variables, no wire-shape change, nothing touching tenant isolation or authentication.**

## Review guide

The test change is the part worth reading; the CI step is three lines.

**What I could not prove, stated plainly:** I cannot run Linux here, so I cannot show that this makes CI green. What I can show is that the thing the failure depended on is gone — there are no screen coordinates left in the test. I checked the replacement behaves as intended before writing it: selecting the line and walking it back with arrow keys selects exactly `Hello`, and the editor then renders `<strong>Hello</strong> world`.

This is worth saying because **my previous attempt at this test was wrong in a way I presented as verified.** I had reproduced the failure locally by forcing the non-Mac shortcut, and treated that as having found the cause. It only showed one way to break it. The keyboard shortcut genuinely was wrong and is still fixed — it was not what was breaking CI. Hence the two additions here: remove the remaining machine-dependent step, and make the next failure explain itself rather than leaving it to be inferred.

A decision you might overrule: **the artifact upload rides in this commit rather than its own.** It exists to serve these tests, so splitting a three-line CI step felt like more ceremony than it earns — but it is a CI change inside a `test:` commit, which a reviewer scanning types could miss.

## Screenshots

Nothing to show — no rendered output changes.

## Verification

Actually run on this branch, level with current `main`:

- **The two compose specs pass**, and the full suite from a database built from scratch was otherwise green. Three specs failed in that run and all three pass on their own, are green on `main`, and are in files this change cannot reach — my local stack, not the code.
- `pnpm install` → `pnpm -w check-types` (13/13) + `pnpm -w test` (21/21) → `pnpm -w build` (13/13).
- `pnpm exec biome check .` across the repo — clean.
- The replacement checked before it was written, as described above.
- The CI file parses, and I confirmed the pinned upload action really is the version named beside it, then read that version's own definition to confirm it still accepts the settings used here.

## Deferred

Unchanged from the previous round — two real defects found while diagnosing, neither a test fix:

- The spend dashboard shows an internal account id where a person's name belongs.
- Text inside a collapsed section cannot be found with the browser's find-in-page, because a closed panel leaves the page entirely.
