### PR TITLE
Let a member choose which organizations an assistant works in

### DIFF
--- a/apps/cli/src/commands/seed/mcp-oauth.ts
+++ b/apps/cli/src/commands/seed/mcp-oauth.ts
@@ -7,11 +7,15 @@ import { SEED_REFERENCE, type SeedCtx, seedUuid } from './shared'
 // the page always shows the empty state and the multi-org chip UI can't be
 // exercised without running a real OAuth dance.
 //
-// Two clients are seeded:
+// Three clients are seeded:
 //   - "ChatGPT" (redirect host chatgpt.com) — bound to both taller + restaurant,
 //     so the multi-org chip UI with per-org remove is visible.
 //   - "Claude" (redirect host claude.ai) — bound to only taller, so the
 //     single-org-per-connection case is also covered.
+//   - "Codex" — chosen for both orgs, then cut off from each a different way:
+//     taller by Alice herself, restaurant by that organization's owner. Only
+//     her own removal can she take back, and nothing else in local dev leaves
+//     a connection in either state.
 //
 // Runs after identities (which create the users + orgs). The OAuth client /
 // consent tables are managed by Better Auth but written here directly — the
@@ -27,6 +31,11 @@ const MOCK_CLIENTS = [
 		clientId: 'mock-claude-client',
 		name: 'Claude',
 		redirectUris: ['https://claude.ai/callback'],
+	},
+	{
+		clientId: 'mock-codex-client',
+		name: 'Codex',
+		redirectUris: ['https://codex.example/callback'],
 	},
 ] as const
 
@@ -47,7 +56,15 @@ export const seedMcpOAuth = (ctx: SeedCtx) =>
 			return
 		}
 
+		// Bob owns the restaurant organization, so a removal recorded against him
+		// is the real shape of one a member cannot undo.
+		const bobRows = yield* sql<{ id: string }>`
+			SELECT id FROM "user" WHERE email = 'admin@restaurant.demo' LIMIT 1
+		`
+		const bobId = bobRows[0]?.id
+
 		// Clean up any prior seed rows (idempotent re-runs).
+		yield* sql`DELETE FROM mcp_oauth_revocation WHERE user_id = ${aliceId} AND client_id LIKE 'mock-%'`
 		yield* sql`DELETE FROM mcp_oauth_org_membership WHERE user_id = ${aliceId} AND client_id LIKE 'mock-%'`
 		yield* sql`DELETE FROM "oauthConsent" WHERE "userId" = ${aliceId} AND "clientId" LIKE 'mock-%'`
 		yield* sql`DELETE FROM "oauthClient" WHERE "clientId" LIKE 'mock-%'`
@@ -83,7 +100,32 @@ export const seedMcpOAuth = (ctx: SeedCtx) =>
 			ON CONFLICT (user_id, client_id, organization_id) DO NOTHING
 		`
 
+		// Codex → chosen for both, then cut off from both. The choices are kept
+		// under the removals on purpose: that is what lets Alice put back the one
+		// she made herself.
+		yield* sql`
+			INSERT INTO mcp_oauth_org_membership (user_id, client_id, organization_id, updated_at)
+			VALUES
+				(${aliceId}, 'mock-codex-client', ${tallerOrgId}, ${SEED_REFERENCE}),
+				(${aliceId}, 'mock-codex-client', ${restaurantOrgId}, ${SEED_REFERENCE})
+			ON CONFLICT (user_id, client_id, organization_id) DO NOTHING
+		`
+		yield* sql`
+			INSERT INTO mcp_oauth_revocation
+				(user_id, client_id, organization_id, revoked_at, revoked_by_user_id)
+			VALUES (${aliceId}, 'mock-codex-client', ${tallerOrgId}, ${SEED_REFERENCE}, ${aliceId})
+			ON CONFLICT (user_id, client_id, organization_id) DO NOTHING
+		`
+		if (bobId) {
+			yield* sql`
+				INSERT INTO mcp_oauth_revocation
+					(user_id, client_id, organization_id, revoked_at, revoked_by_user_id)
+				VALUES (${aliceId}, 'mock-codex-client', ${restaurantOrgId}, ${SEED_REFERENCE}, ${bobId})
+				ON CONFLICT (user_id, client_id, organization_id) DO NOTHING
+			`
+		}
+
 		yield* Effect.logInfo(
-			'  mcp-oauth: seeded 2 mock connections (ChatGPT multi-org, Claude single-org)',
+			'  mcp-oauth: seeded 3 mock connections (ChatGPT multi-org, Claude single-org, Codex blocked)',
 		)
 	})

--- a/apps/cli/src/commands/seed/reset.ts
+++ b/apps/cli/src/commands/seed/reset.ts
@@ -6,6 +6,9 @@ export const seedReset = Effect.gen(function* () {
 	yield* Effect.logInfo('Truncating CRM tables...')
 	// DELETE (not TRUNCATE CASCADE) so `member.primary_inbox_id`'s ON DELETE SET NULL fires.
 	yield* sql`DELETE FROM inboxes`
+	// Removals go too: they outlive the choice they sit on, so one left behind
+	// would keep cutting a freshly seeded connection off from an organization.
+	yield* sql`DELETE FROM mcp_oauth_revocation WHERE client_id LIKE 'mock-%'`
 	yield* sql`DELETE FROM mcp_oauth_org_membership WHERE client_id LIKE 'mock-%'`
 	yield* sql`DELETE FROM "oauthConsent" WHERE "clientId" LIKE 'mock-%'`
 	yield* sql`DELETE FROM "oauthClient" WHERE "clientId" LIKE 'mock-%'`

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -426,8 +426,8 @@ msgid "AI agent"
 msgstr "Agent IA"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
-msgstr "Assistents d'IA que has connectat per MCP. Cadascun pot actuar en una o més de les teves organitzacions; l'assistent tria quina en cada petició."
+msgid "AI assistants you've connected over MCP. Each works in the organizations you choose for it — usually one, since most assistants cannot say which they mean when there are several."
+msgstr "Assistents d'IA que has connectat per MCP. Cadascun treballa a les organitzacions que li triïs — normalment una, perquè la majoria d'assistents no poden dir a quina es refereixen quan n'hi ha diverses."
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
@@ -472,6 +472,10 @@ msgstr "Tot el temps"
 msgid "All under control"
 msgstr "Tot sota control"
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "All your organizations"
+msgstr "Totes les teves organitzacions"
+
 #: src/routes/oauth/consent.tsx
 msgid "Allow"
 msgstr "Permet"
@@ -501,6 +505,10 @@ msgstr "Un assistent d'IA vol connectar-se al teu compte de Batuda per MCP i act
 #: src/routes/settings/organization/templates.tsx
 msgid "An org stack runs for every member who hasn't set their own. The one marked default applies to a run that names none. Only org templates can go in an org stack."
 msgstr "Una pila de l'organització s'aplica a tots els membres que no n'han definit una de pròpia. La marcada per defecte s'aplica quan una execució no n'anomena cap. En una pila de l'organització només hi poden anar plantilles de l'organització."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "An owner removed this one."
+msgstr "Un propietari l’ha tret."
 
 #: src/components/research/inbox/research-inbox.tsx
 msgid "and {hidden} more on the run"
@@ -827,6 +835,7 @@ msgstr "Crides"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/settings/api-keys/index.tsx
 #: src/routes/settings/mcp/connections.tsx
+#: src/routes/settings/mcp/connections.tsx
 #: src/routes/tasks/index.tsx
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -859,6 +868,10 @@ msgstr "Cc"
 #: src/routes/settings/profile/index.tsx
 msgid "Change my mind — set a password anyway"
 msgstr "Canvio d'opinió — vull posar contrasenya"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Change organizations"
+msgstr "Canvia les organitzacions"
 
 #: src/routes/settings/profile/index.tsx
 #: src/routes/settings/profile/index.tsx
@@ -909,6 +922,10 @@ msgstr "ChatGPT i Claude.ai no poden enviar una clau, així que es connecten amb
 #: src/routes/login.tsx
 msgid "Check your inbox"
 msgstr "Mira la safata d'entrada"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Choose organizations"
+msgstr "Tria les organitzacions"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -1396,6 +1413,7 @@ msgid "Could not revoke"
 msgstr "No s'ha pogut revocar"
 
 #: src/routes/companies/$slug.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Could not save"
 msgstr "No s'ha pogut desar"
 
@@ -2694,6 +2712,10 @@ msgstr "S'estan carregant els canvis pendents de revisió."
 msgid "Loading the review queue"
 msgstr "S'està carregant la cua de revisió"
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "Loading your organizations…"
+msgstr "S’estan carregant les teves organitzacions…"
+
 #: src/routes/settings/organization/policy.tsx
 msgid "Loading your research budget…"
 msgstr "Carregant el teu pressupost de recerca…"
@@ -2960,6 +2982,14 @@ msgstr "Confiança mínima per aplicar automàticament"
 #: src/routes/settings/organization/policy.tsx
 msgid "Monthly paid cap"
 msgstr "Límit mensual de pagament"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Most assistants can only work in one organization per connection. With more than one ticked, this one will keep asking you to choose."
+msgstr "La majoria d’assistents només poden treballar en una organització per connexió. Amb més d’una marcada, aquest et continuarà demanant que en triïs una."
+
+#: src/routes/oauth/consent.tsx
+msgid "Most assistants can only work in one organization, so picking a single one here is usually what you want. You can change this later in Settings → MCP connections."
+msgstr "La majoria d’assistents només poden treballar en una organització, així que aquí normalment et convé triar-ne una de sola. Ho pots canviar més endavant a Configuració → Connexions MCP."
 
 #: src/routes/settings/organization/policy.tsx
 msgid "Most this organization can spend on paid research each month, shared by everyone in it."
@@ -3598,8 +3628,13 @@ msgstr "Organització"
 #: src/components/layout/org-switcher.tsx
 #: src/routes/oauth/consent.tsx
 #: src/routes/settings/mcp/connections.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Organizations"
 msgstr "Organitzacions"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Organizations updated"
+msgstr "Organitzacions actualitzades"
 
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "organizer"
@@ -3824,10 +3859,6 @@ msgstr "Tria una pila desada o fes servir la teva predeterminada."
 #: src/routes/emails/index.tsx
 msgid "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
 msgstr "Tria una organització al selector de la barra superior, o tanca la sessió i torna a entrar. Després d'un reset recent de la base de dades de dev, les sessions existents poden apuntar a identificadors d'organització que el reset ha esborrat."
-
-#: src/routes/oauth/consent.tsx
-msgid "Pick one or more. The assistant will ask which to use per request."
-msgstr "Tria'n una o més. L'assistent demanarà quina fer servir en cada petició."
 
 #: src/routes/emails/inboxes.tsx
 msgid "Pick one to use as your default sender."
@@ -4348,6 +4379,7 @@ msgstr "Context comercial"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/pages/$id.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Save"
 msgstr "Desa"
 
@@ -4384,6 +4416,7 @@ msgstr "Desada, però no s'ha marcat com a predeterminada"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/pages/$id.tsx
 #: src/routes/reset-password.tsx
+#: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/organization/policy.tsx
 #: src/routes/settings/profile/index.tsx
 #: src/routes/settings/profile/index.tsx
@@ -4682,6 +4715,7 @@ msgid "Something went wrong. Start the connection again from your assistant."
 msgstr "Alguna cosa ha anat malament. Torna a iniciar la connexió des del teu assistent."
 
 #: src/routes/reset-password.tsx
+#: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/profile/index.tsx
@@ -5160,6 +5194,19 @@ msgstr "La persona inicia la sessió a la pàgina d'inici de sessió amb aquesta
 #: src/routes/settings/mcp/connections.tsx
 msgid "This assistant can no longer reach this organization."
 msgstr "Aquest assistent ja no pot accedir a aquesta organització."
+
+#. placeholder {0}: tickedOrgIds.length
+#: src/routes/settings/mcp/connections.tsx
+msgid "This assistant is authorized for {0} organizations."
+msgstr "Aquest assistent està autoritzat a {0} organitzacions."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "This assistant now works in one organization."
+msgstr "Aquest assistent ara treballa en una sola organització."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "This assistant works in the organizations you tick here."
+msgstr "Aquest assistent treballa a les organitzacions que marquis aquí."
 
 #: src/routes/companies/$slug.tsx
 msgid "This company can't be displayed"
@@ -5652,6 +5699,10 @@ msgstr "No tens permís per veure aquesta pàgina."
 msgid "You got in from a link in your email."
 msgstr "Has entrat des d'un enllaç al teu correu."
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "You removed this one. Tick it to restore it."
+msgstr "L’has tret tu. Marca-la per tornar-la a activar."
+
 #: src/routes/settings/profile/index.tsx
 msgid "You sign in from email links. I won't bring it up again."
 msgstr "Entres des d'enllaços al correu. No t'ho tornaré a esmentar."
@@ -5667,6 +5718,10 @@ msgstr "tu@exemple.com"
 #: src/routes/settings/profile/index.tsx
 msgid "Your Batuda workbench identity."
 msgstr "La teva identitat al banc de Batuda."
+
+#: src/routes/oauth/consent.tsx
+msgid "Your choice of organization could not be saved, so this was stopped rather than give the assistant more access than you picked. Try again."
+msgstr "No s’ha pogut desar la teva tria d’organització, així que s’ha aturat en comptes de donar a l’assistent més accés del que has triat. Torna-ho a provar."
 
 #: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/index.tsx

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -426,8 +426,8 @@ msgid "AI agent"
 msgstr "AI agent"
 
 #: src/routes/settings/mcp/connections.tsx
-msgid "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
-msgstr "AI assistants you've connected over MCP. Each may act in one or more of your organizations; the assistant picks which per request."
+msgid "AI assistants you've connected over MCP. Each works in the organizations you choose for it — usually one, since most assistants cannot say which they mean when there are several."
+msgstr "AI assistants you've connected over MCP. Each works in the organizations you choose for it — usually one, since most assistants cannot say which they mean when there are several."
 
 #: src/routes/companies/index.tsx
 #: src/routes/emails/index.tsx
@@ -472,6 +472,10 @@ msgstr "All time"
 msgid "All under control"
 msgstr "All under control"
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "All your organizations"
+msgstr "All your organizations"
+
 #: src/routes/oauth/consent.tsx
 msgid "Allow"
 msgstr "Allow"
@@ -501,6 +505,10 @@ msgstr "An AI assistant wants to connect to your Batuda account over MCP and act
 #: src/routes/settings/organization/templates.tsx
 msgid "An org stack runs for every member who hasn't set their own. The one marked default applies to a run that names none. Only org templates can go in an org stack."
 msgstr "An org stack runs for every member who hasn't set their own. The one marked default applies to a run that names none. Only org templates can go in an org stack."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "An owner removed this one."
+msgstr "An owner removed this one."
 
 #: src/components/research/inbox/research-inbox.tsx
 msgid "and {hidden} more on the run"
@@ -827,6 +835,7 @@ msgstr "Calls"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/settings/api-keys/index.tsx
 #: src/routes/settings/mcp/connections.tsx
+#: src/routes/settings/mcp/connections.tsx
 #: src/routes/tasks/index.tsx
 msgid "Cancel"
 msgstr "Cancel"
@@ -859,6 +868,10 @@ msgstr "Cc"
 #: src/routes/settings/profile/index.tsx
 msgid "Change my mind — set a password anyway"
 msgstr "Change my mind — set a password anyway"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Change organizations"
+msgstr "Change organizations"
 
 #: src/routes/settings/profile/index.tsx
 #: src/routes/settings/profile/index.tsx
@@ -909,6 +922,10 @@ msgstr "ChatGPT and Claude.ai can't send a key, so they connect over OAuth. Add 
 #: src/routes/login.tsx
 msgid "Check your inbox"
 msgstr "Check your inbox"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Choose organizations"
+msgstr "Choose organizations"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -1396,6 +1413,7 @@ msgid "Could not revoke"
 msgstr "Could not revoke"
 
 #: src/routes/companies/$slug.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -2694,6 +2712,10 @@ msgstr "Loading the changes waiting for review."
 msgid "Loading the review queue"
 msgstr "Loading the review queue"
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "Loading your organizations…"
+msgstr "Loading your organizations…"
+
 #: src/routes/settings/organization/policy.tsx
 msgid "Loading your research budget…"
 msgstr "Loading your research budget…"
@@ -2960,6 +2982,14 @@ msgstr "Minimum confidence to auto-apply"
 #: src/routes/settings/organization/policy.tsx
 msgid "Monthly paid cap"
 msgstr "Monthly paid cap"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Most assistants can only work in one organization per connection. With more than one ticked, this one will keep asking you to choose."
+msgstr "Most assistants can only work in one organization per connection. With more than one ticked, this one will keep asking you to choose."
+
+#: src/routes/oauth/consent.tsx
+msgid "Most assistants can only work in one organization, so picking a single one here is usually what you want. You can change this later in Settings → MCP connections."
+msgstr "Most assistants can only work in one organization, so picking a single one here is usually what you want. You can change this later in Settings → MCP connections."
 
 #: src/routes/settings/organization/policy.tsx
 msgid "Most this organization can spend on paid research each month, shared by everyone in it."
@@ -3598,8 +3628,13 @@ msgstr "Organization"
 #: src/components/layout/org-switcher.tsx
 #: src/routes/oauth/consent.tsx
 #: src/routes/settings/mcp/connections.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Organizations"
 msgstr "Organizations"
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "Organizations updated"
+msgstr "Organizations updated"
 
 #: src/components/companies/upcoming-meetings-card.tsx
 msgid "organizer"
@@ -3824,10 +3859,6 @@ msgstr "Pick a saved stack, or use your default."
 #: src/routes/emails/index.tsx
 msgid "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
 msgstr "Pick an organization from the switcher in the header, or sign out and back in. After a recent dev DB reset, existing sessions can point at organization ids that the reset removed."
-
-#: src/routes/oauth/consent.tsx
-msgid "Pick one or more. The assistant will ask which to use per request."
-msgstr "Pick one or more. The assistant will ask which to use per request."
 
 #: src/routes/emails/inboxes.tsx
 msgid "Pick one to use as your default sender."
@@ -4348,6 +4379,7 @@ msgstr "Sales context"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/pages/$id.tsx
+#: src/routes/settings/mcp/connections.tsx
 msgid "Save"
 msgstr "Save"
 
@@ -4384,6 +4416,7 @@ msgstr "Saved, but not made the default"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/pages/$id.tsx
 #: src/routes/reset-password.tsx
+#: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/organization/policy.tsx
 #: src/routes/settings/profile/index.tsx
 #: src/routes/settings/profile/index.tsx
@@ -4682,6 +4715,7 @@ msgid "Something went wrong. Start the connection again from your assistant."
 msgstr "Something went wrong. Start the connection again from your assistant."
 
 #: src/routes/reset-password.tsx
+#: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/profile/index.tsx
@@ -5160,6 +5194,19 @@ msgstr "They sign in at the sign-in page with this address and ask for their own
 #: src/routes/settings/mcp/connections.tsx
 msgid "This assistant can no longer reach this organization."
 msgstr "This assistant can no longer reach this organization."
+
+#. placeholder {0}: tickedOrgIds.length
+#: src/routes/settings/mcp/connections.tsx
+msgid "This assistant is authorized for {0} organizations."
+msgstr "This assistant is authorized for {0} organizations."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "This assistant now works in one organization."
+msgstr "This assistant now works in one organization."
+
+#: src/routes/settings/mcp/connections.tsx
+msgid "This assistant works in the organizations you tick here."
+msgstr "This assistant works in the organizations you tick here."
 
 #: src/routes/companies/$slug.tsx
 msgid "This company can't be displayed"
@@ -5652,6 +5699,10 @@ msgstr "You don't have permission to see this page."
 msgid "You got in from a link in your email."
 msgstr "You got in from a link in your email."
 
+#: src/routes/settings/mcp/connections.tsx
+msgid "You removed this one. Tick it to restore it."
+msgstr "You removed this one. Tick it to restore it."
+
 #: src/routes/settings/profile/index.tsx
 msgid "You sign in from email links. I won't bring it up again."
 msgstr "You sign in from email links. I won't bring it up again."
@@ -5667,6 +5718,10 @@ msgstr "you@example.com"
 #: src/routes/settings/profile/index.tsx
 msgid "Your Batuda workbench identity."
 msgstr "Your Batuda workbench identity."
+
+#: src/routes/oauth/consent.tsx
+msgid "Your choice of organization could not be saved, so this was stopped rather than give the assistant more access than you picked. Try again."
+msgstr "Your choice of organization could not be saved, so this was stopped rather than give the assistant more access than you picked. Try again."
 
 #: src/routes/settings/mcp/connections.tsx
 #: src/routes/settings/mcp/index.tsx

--- a/apps/internal/src/routes/oauth/consent.tsx
+++ b/apps/internal/src/routes/oauth/consent.tsx
@@ -20,9 +20,15 @@ import { agedPaperSurface, stenciledTitle } from '#/lib/workshop-mixins'
  *
  * Organization binding happens here, not later: a single-org user is auto-bound
  * (no selector); a multi-org user must select one or more orgs before Allow.
- * The binding is written through `/v1/mcp-oauth/select-orgs` before the
- * consent POST, so the connection is usable the moment the assistant gets its
- * code — no trip to /settings/mcp/connections first.
+ * The binding is written through `/v1/mcp-oauth/select-orgs` after the consent
+ * POST succeeds but before the redirect, so the connection is usable the moment
+ * the assistant gets its code, and a consent that fails leaves no binding behind
+ * for a connection that was never created.
+ *
+ * This is the only time this screen appears for a given assistant: once a
+ * consent covers the scopes it asks for, later authorize requests skip straight
+ * past it. Changing the organizations afterwards happens at
+ * /settings/mcp/connections.
  */
 
 export const Route = createFileRoute('/oauth/consent')({
@@ -105,15 +111,29 @@ function ConsentPage() {
 						? [memberships[0]!.id]
 						: []
 				if (orgIds.length > 0) {
-					await fetch(`${apiBaseUrl()}/v1/mcp-oauth/select-orgs`, {
-						method: 'POST',
-						credentials: 'include',
-						headers: { 'content-type': 'application/json' },
-						body: JSON.stringify({
-							clientId: client_id,
-							organizationIds: orgIds,
-						}),
-					})
+					const bindRes = await fetch(
+						`${apiBaseUrl()}/v1/mcp-oauth/select-orgs`,
+						{
+							method: 'POST',
+							credentials: 'include',
+							headers: { 'content-type': 'application/json' },
+							body: JSON.stringify({
+								clientId: client_id,
+								organizationIds: orgIds,
+							}),
+						},
+					)
+					// Stop rather than send them onward: a connection with no
+					// organization recorded reaches every organization the person
+					// belongs to, so carrying on here would hand the assistant more
+					// than they just chose to give it.
+					if (!bindRes.ok) {
+						setSubmitting(null)
+						setError(
+							t`Your choice of organization could not be saved, so this was stopped rather than give the assistant more access than you picked. Try again.`,
+						)
+						return
+					}
 				}
 			}
 			if (data.url) {
@@ -217,8 +237,9 @@ function ConsentPage() {
 						</CheckboxGroup>
 						<OrgHint>
 							<Trans>
-								Pick one or more. The assistant will ask which to use per
-								request.
+								Most assistants can only work in one organization, so picking a
+								single one here is usually what you want. You can change this
+								later in Settings → MCP connections.
 							</Trans>
 						</OrgHint>
 					</OrgSection>

--- a/apps/internal/src/routes/settings/mcp/connections.tsx
+++ b/apps/internal/src/routes/settings/mcp/connections.tsx
@@ -1,12 +1,13 @@
+import { CheckboxGroup } from '@base-ui/react/checkbox-group'
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import { ArrowLeft, Plug, X } from 'lucide-react'
+import { ArrowLeft, Check, Plug, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
-import { PriButton, PriDialog, usePriToast } from '@batuda/ui/pri'
+import { PriButton, PriCheckbox, PriDialog, usePriToast } from '@batuda/ui/pri'
 
 import { PriTable } from '#/components/primitives/pri-table'
 import { ErrorState } from '#/components/shared/error-state'
@@ -20,17 +21,24 @@ import {
 
 /**
  * The AI assistants (ChatGPT, Claude.ai, …) a member has connected over MCP.
- * Each connection may act in one or more organizations. Single-org users have
- * their lone org auto-bound at consent time; multi-org users pick one or more
- * there. This page only takes access away again; per-request org selection
- * happens via the X-Batuda-Organization-Id header the MCP client sends.
+ * Each connection reaches the organizations chosen for it, and every request
+ * settles on exactly one — an assistant cannot say which it means, so in
+ * practice a connection wants a single organization. This page is where that
+ * choice is changed, and where access is taken away again.
  */
+
+type ConnectionBlock = {
+	readonly organizationId: string
+	readonly blockedBySelf: boolean
+}
 
 type Connection = {
 	readonly clientId: string
 	readonly name: string | null
 	readonly createdAt: string
 	readonly organizationIds: ReadonlyArray<string>
+	readonly chosenOrganizationIds: ReadonlyArray<string>
+	readonly blocks: ReadonlyArray<ConnectionBlock>
 	readonly redirectHost: string | null
 }
 
@@ -101,6 +109,12 @@ function ConnectionsPage() {
 			mode: 'promiseExit',
 		},
 	)
+	const selectOrgs = useAtomSet(
+		BatudaApiAtom.mutation('mcpOAuth', 'selectOrgs'),
+		{
+			mode: 'promiseExit',
+		},
+	)
 
 	const orgs = authClient.useListOrganizations()
 	const orgNameById = useMemo(() => {
@@ -124,6 +138,29 @@ function ConnectionsPage() {
 	// The connection currently being revoked, so its button can disable until
 	// the call finishes and a second click can't race it.
 	const [revokingId, setRevokingId] = useState<string | null>(null)
+
+	// The connection whose organizations are being changed, and the ticks shown
+	// for it. One dialog serves every row, so both are set the moment its button
+	// is pressed — ticks filled in any later would still show the connection
+	// opened before this one.
+	const [editingConnection, setEditingConnection] = useState<Connection | null>(
+		null,
+	)
+	const [tickedOrgIds, setTickedOrgIds] = useState<ReadonlyArray<string>>([])
+	const [saving, setSaving] = useState(false)
+
+	const openOrgPicker = (connection: Connection) => {
+		const blockedIds = new Set(connection.blocks.map(b => b.organizationId))
+		setEditingConnection(connection)
+		// Start ticked as whatever the connection reaches today: everything the
+		// person belongs to while nobody has chosen for it, and only what survives
+		// once anything has been chosen or blocked.
+		setTickedOrgIds(
+			connection.chosenOrganizationIds.length === 0 && blockedIds.size === 0
+				? (orgs.data ?? []).map(o => o.id)
+				: connection.organizationIds,
+		)
+	}
 
 	const rows = useMemo<ReadonlyArray<Connection>>(
 		() =>
@@ -169,6 +206,44 @@ function ConnectionsPage() {
 		}
 	}
 
+	// Save the ticked organizations for this connection. What goes out is exactly
+	// what is ticked — nothing is added back behind the person's back. That
+	// matters for the organizations they blocked themselves: sending one again is
+	// what lifts their own block, so it has to be their tick that sends it, never
+	// something this screen quietly carries along.
+	const handleSaveOrgs = async () => {
+		if (!editingConnection || tickedOrgIds.length === 0) return
+		setSaving(true)
+		try {
+			const exit = await selectOrgs({
+				payload: {
+					clientId: editingConnection.clientId,
+					organizationIds: tickedOrgIds,
+				},
+				reactivityKeys: ['mcpConnections'],
+			} as never)
+			if (exit._tag === 'Success') {
+				toastManager.add({
+					title: t`Organizations updated`,
+					description:
+						tickedOrgIds.length === 1
+							? t`This assistant now works in one organization.`
+							: t`This assistant is authorized for ${tickedOrgIds.length} organizations.`,
+					type: 'success',
+				})
+				setEditingConnection(null)
+				return
+			}
+			toastManager.add({
+				title: t`Could not save`,
+				description: t`Something went wrong. Try again.`,
+				type: 'error',
+			})
+		} finally {
+			setSaving(false)
+		}
+	}
+
 	return (
 		<Page>
 			<BackLink to='/settings' aria-label={t`Back to settings`}>
@@ -185,8 +260,9 @@ function ConnectionsPage() {
 				</Heading>
 				<Subtitle>
 					<Trans>
-						AI assistants you've connected over MCP. Each may act in one or more
-						of your organizations; the assistant picks which per request.
+						AI assistants you've connected over MCP. Each works in the
+						organizations you choose for it — usually one, since most assistants
+						cannot say which they mean when there are several.
 					</Trans>
 				</Subtitle>
 			</Intro>
@@ -239,9 +315,19 @@ function ConnectionsPage() {
 										<Trans>Organizations</Trans>
 									</OrgsLabel>
 									{row.organizationIds.length === 0 ? (
-										<UnboundTag data-testid='mcp-connection-unbound'>
-											<Trans>No organization selected</Trans>
-										</UnboundTag>
+										row.chosenOrganizationIds.length === 0 &&
+										row.blocks.length === 0 ? (
+											// Nothing chosen and nothing in the way: the connection
+											// reaches everything this person can. Saying "none" here
+											// would understate what the assistant can already see.
+											<UnboundTag data-testid='mcp-connection-unbound'>
+												<Trans>All your organizations</Trans>
+											</UnboundTag>
+										) : (
+											<UnboundTag data-testid='mcp-connection-unbound'>
+												<Trans>No organization selected</Trans>
+											</UnboundTag>
+										)
 									) : (
 										<OrgChips>
 											{row.organizationIds.map(orgId => (
@@ -267,6 +353,17 @@ function ConnectionsPage() {
 											))}
 										</OrgChips>
 									)}
+									<PriButton
+										type='button'
+										$variant='text'
+										data-testid={`mcp-connection-change-orgs-${row.clientId}`}
+										disabled={orgs.isPending}
+										onClick={() => {
+											openOrgPicker(row)
+										}}
+									>
+										<Trans>Change organizations</Trans>
+									</PriButton>
 								</OrgsForConnection>
 							</ConnRow>
 						))}
@@ -275,7 +372,164 @@ function ConnectionsPage() {
 			</ListSection>
 
 			{canManage ? <OrgConnectionsSection /> : null}
+
+			<PriDialog.Root
+				open={editingConnection !== null}
+				onOpenChange={(nextOpen: boolean) => {
+					if (!nextOpen && !saving) setEditingConnection(null)
+				}}
+			>
+				<PriDialog.Portal>
+					<PriDialog.Backdrop />
+					<PriDialog.Popup data-testid='mcp-connection-orgs-dialog'>
+						<PriDialog.Title>
+							<Trans>Choose organizations</Trans>
+						</PriDialog.Title>
+						<PriDialog.Description>
+							<Trans>
+								This assistant works in the organizations you tick here.
+							</Trans>
+						</PriDialog.Description>
+
+						{editingConnection ? (
+							<OrgPicker
+								connection={editingConnection}
+								orgs={orgs.data ?? []}
+								tickedOrgIds={tickedOrgIds}
+								onTickedOrgIdsChange={setTickedOrgIds}
+							/>
+						) : null}
+
+						<ConfirmActions>
+							<PriDialog.Close
+								render={props => (
+									<PriButton
+										type='button'
+										$variant='text'
+										disabled={saving}
+										data-testid='mcp-connection-orgs-cancel'
+										{...props}
+									>
+										<Trans>Cancel</Trans>
+									</PriButton>
+								)}
+							/>
+							<PriButton
+								type='button'
+								$variant='filled'
+								disabled={saving || tickedOrgIds.length === 0}
+								data-testid='mcp-connection-orgs-save'
+								onClick={() => {
+									void handleSaveOrgs()
+								}}
+							>
+								{saving ? <Trans>Saving…</Trans> : <Trans>Save</Trans>}
+							</PriButton>
+						</ConfirmActions>
+					</PriDialog.Popup>
+				</PriDialog.Portal>
+			</PriDialog.Root>
 		</Page>
+	)
+}
+
+// The organization picker inside the dialog. The two ways a connection loses an
+// organization are offered differently: one the person cut off themselves comes
+// back by ticking it and saving, which is the way out of an accidental removal,
+// while one an owner cut off is shown but not tickable, because nothing done
+// here can undo it.
+//
+// Blocked organizations are never in the ticked list. A checkbox reads its state
+// from that list alone, so leaving one in would draw it ticked and greyed —
+// telling someone the assistant reaches an organization it cannot.
+function OrgPicker({
+	connection,
+	orgs,
+	tickedOrgIds,
+	onTickedOrgIdsChange,
+}: {
+	readonly connection: Connection
+	readonly orgs: ReadonlyArray<{ readonly id: string; readonly name: string }>
+	readonly tickedOrgIds: ReadonlyArray<string>
+	readonly onTickedOrgIdsChange: (next: ReadonlyArray<string>) => void
+}) {
+	// Missing from the map means the organization is not blocked at all.
+	const blockedBySelfByOrgId = useMemo(() => {
+		const map = new Map<string, boolean>()
+		for (const block of connection.blocks) {
+			map.set(block.organizationId, block.blockedBySelf)
+		}
+		return map
+	}, [connection.blocks])
+
+	if (orgs.length === 0) {
+		return (
+			<PickerEmpty>
+				<Trans>Loading your organizations…</Trans>
+			</PickerEmpty>
+		)
+	}
+
+	return (
+		<>
+			<CheckboxGroup
+				value={tickedOrgIds as Array<string>}
+				onValueChange={onTickedOrgIdsChange}
+				aria-labelledby='mcp-org-picker-label'
+			>
+				<PickerLabel id='mcp-org-picker-label'>
+					<Trans>Organizations</Trans>
+				</PickerLabel>
+				<PickerList>
+					{orgs.map(org => {
+						const blockedBySelf = blockedBySelfByOrgId.get(org.id)
+						const blockedByOwner = blockedBySelf === false
+						const labelId = `mcp-org-pick-label-${org.id}`
+						const reasonId = `mcp-org-pick-reason-${org.id}`
+						return (
+							<PickerRow key={org.id} $blocked={blockedByOwner}>
+								<PriCheckbox.Root
+									name={org.id}
+									disabled={blockedByOwner}
+									aria-labelledby={labelId}
+									aria-describedby={
+										blockedBySelf === undefined ? undefined : reasonId
+									}
+									data-testid={`mcp-connection-org-pick-${org.id}`}
+								>
+									<PriCheckbox.Indicator>
+										<Check size={14} aria-hidden />
+									</PriCheckbox.Indicator>
+								</PriCheckbox.Root>
+								<PickerText>
+									<PickerName id={labelId}>{org.name}</PickerName>
+									{blockedBySelf === true ? (
+										<PickerReason id={reasonId}>
+											<Trans>
+												You removed this one. Tick it to restore it.
+											</Trans>
+										</PickerReason>
+									) : null}
+									{blockedByOwner ? (
+										<PickerReason id={reasonId}>
+											<Trans>An owner removed this one.</Trans>
+										</PickerReason>
+									) : null}
+								</PickerText>
+							</PickerRow>
+						)
+					})}
+				</PickerList>
+			</CheckboxGroup>
+			{tickedOrgIds.length > 1 ? (
+				<PickerWarning role='status' data-testid='mcp-connection-orgs-warning'>
+					<Trans>
+						Most assistants can only work in one organization per connection.
+						With more than one ticked, this one will keep asking you to choose.
+					</Trans>
+				</PickerWarning>
+			) : null}
+		</>
 	)
 }
 
@@ -550,11 +804,33 @@ function narrowConnections(
 		const organizationIds = Array.isArray(organizationIdsRaw)
 			? organizationIdsRaw.filter((id): id is string => typeof id === 'string')
 			: []
+		const chosenRaw = r['chosenOrganizationIds']
+		const chosenOrganizationIds = Array.isArray(chosenRaw)
+			? chosenRaw.filter((id): id is string => typeof id === 'string')
+			: []
+		const blocksRaw = r['blocks']
+		const blocks = Array.isArray(blocksRaw)
+			? blocksRaw.flatMap((block): ReadonlyArray<ConnectionBlock> => {
+					if (!block || typeof block !== 'object') return []
+					const b = block as Record<string, unknown>
+					return typeof b['organizationId'] === 'string' &&
+						typeof b['blockedBySelf'] === 'boolean'
+						? [
+								{
+									organizationId: b['organizationId'],
+									blockedBySelf: b['blockedBySelf'],
+								},
+							]
+						: []
+				})
+			: []
 		out.push({
 			clientId,
 			createdAt,
 			name: typeof r['name'] === 'string' ? r['name'] : null,
 			organizationIds,
+			chosenOrganizationIds,
+			blocks,
 			redirectHost:
 				typeof r['redirectHost'] === 'string' ? r['redirectHost'] : null,
 		})
@@ -741,6 +1017,74 @@ const UnboundTag = styled.span.withConfig({ displayName: 'McpConnUnbound' })`
 	font-family: var(--font-body);
 	font-size: var(--typescale-body-small-size);
 	font-style: italic;
+`
+
+// ── The organization picker ──
+
+const PickerLabel = styled.span.withConfig({
+	displayName: 'McpConnPickerLabel',
+})`
+	display: block;
+	font-family: var(--font-body);
+	font-size: var(--typescale-label-medium-size);
+	font-weight: var(--typescale-label-medium-weight);
+	color: var(--color-on-surface-variant);
+	margin-bottom: var(--space-2xs);
+`
+
+const PickerList = styled.div.withConfig({ displayName: 'McpConnPickerList' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+`
+
+const PickerRow = styled.div.withConfig({
+	displayName: 'McpConnPickerRow',
+})<{ $blocked?: boolean }>`
+	display: flex;
+	align-items: flex-start;
+	gap: var(--space-2xs);
+	opacity: ${p => (p.$blocked ? 0.6 : 1)};
+`
+
+const PickerText = styled.span.withConfig({ displayName: 'McpConnPickerText' })`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+`
+
+const PickerName = styled.span.withConfig({ displayName: 'McpConnPickerName' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	color: var(--color-on-surface);
+`
+
+const PickerReason = styled.span.withConfig({
+	displayName: 'McpConnPickerReason',
+})`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const PickerEmpty = styled.p.withConfig({ displayName: 'McpConnPickerEmpty' })`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-medium-size);
+	color: var(--color-on-surface-variant);
+	margin: 0;
+`
+
+const PickerWarning = styled.p.withConfig({
+	displayName: 'McpConnPickerWarning',
+})`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	line-height: var(--typescale-body-small-line);
+	color: var(--color-on-surface-variant);
+	padding: var(--space-2xs);
+	border-radius: var(--shape-3xs);
+	background: color-mix(in srgb, var(--color-secondary) 8%, transparent);
+	margin: 0;
 `
 
 // ── The organization-wide section ──

--- a/apps/internal/tests/e2e/mcp-connections.test.ts
+++ b/apps/internal/tests/e2e/mcp-connections.test.ts
@@ -2,11 +2,16 @@ import { expect, test } from '@playwright/test'
 
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
-// The MCP OAuth UI: the connections settings page (where a member binds each
-// authorized AI client to an org) and the consent screen. The full OAuth dance
-// (a real client → authorize → login → consent → token) needs a live OAuth
-// client, so this covers the routing + the unauthenticated/empty states; the
-// happy-path consent flow is validated against the dev stack manually.
+// The MCP OAuth UI: the connections settings page (where a member chooses which
+// organizations each authorized AI client works in) and the consent screen. The
+// full OAuth dance (a real client → authorize → login → consent → token) needs a
+// live OAuth client, so this covers the routing, the listing, and the
+// organization picker; the happy-path consent flow is validated against the dev
+// stack manually.
+//
+// The picker test changes seeded data, so it puts it back — the suite runs
+// against the live development database and `db reset` / `seed` are run by hand,
+// so a change left behind would make the next run start somewhere else.
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/', { waitUntil: 'commit' })
@@ -32,16 +37,120 @@ test.describe('settings — MCP connections', () => {
 		}).toPass({ timeout: 15_000 })
 
 		// THEN the page lists the clients the seed authorized for her — ChatGPT
-		// across two organizations and Claude across one, which is what the page
-		// exists to show. Asserting an empty state here would contradict the
-		// seed, whose whole purpose is to give this page something to render.
-		await expect(page.getByTestId('mcp-connection-row')).toHaveCount(2)
+		// across two organizations, Claude across one, and Codex cut off from
+		// both, which is what the page exists to show. Asserting an empty state
+		// here would contradict the seed, whose whole purpose is to give this
+		// page something to render.
+		await expect(page.getByTestId('mcp-connection-row')).toHaveCount(3)
 		await expect(
 			page.getByTestId('mcp-connection-name').filter({ hasText: 'ChatGPT' }),
 		).toBeVisible()
 		await expect(
 			page.getByTestId('mcp-connection-name').filter({ hasText: 'Claude' }),
 		).toBeVisible()
+	})
+})
+
+test.describe('settings — choosing a connection’s organizations', () => {
+	// Alice belongs to taller + restaurant, and the seed authorizes ChatGPT for
+	// both — the state that leaves an assistant unable to say which one it means.
+	const CHATGPT_CHANGE_ORGS = 'mcp-connection-change-orgs-mock-chatgpt-client'
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/settings/mcp/connections', { waitUntil: 'networkidle' })
+	})
+
+	// Tick every organization back on, whatever the test left ChatGPT reaching,
+	// so a re-run starts from the same place the seed left.
+	test.afterEach(async ({ page }) => {
+		await page.goto('/settings/mcp/connections', { waitUntil: 'networkidle' })
+		await page.getByTestId(CHATGPT_CHANGE_ORGS).click()
+		const orgCheckboxes = page
+			.getByTestId('mcp-connection-orgs-dialog')
+			.locator('[data-testid^="mcp-connection-org-pick-"]')
+		const count = await orgCheckboxes.count()
+		for (let i = 0; i < count; i++) {
+			const box = orgCheckboxes.nth(i)
+			if ((await box.getAttribute('aria-checked')) !== 'true') await box.click()
+		}
+		await page.getByTestId('mcp-connection-orgs-save').click()
+		await expect(page.getByTestId('mcp-connection-orgs-dialog')).toBeHidden()
+	})
+
+	test('should narrow a two-organization connection down to one', async ({
+		page,
+	}) => {
+		// GIVEN ChatGPT reaching both of Alice's organizations
+		const chatgptRow = page
+			.getByTestId('mcp-connection-row')
+			.filter({ hasText: 'ChatGPT' })
+		await expect(chatgptRow.getByTestId('mcp-connection-org')).toHaveCount(2)
+
+		// WHEN she opens the picker and unticks all but the first organization
+		await page.getByTestId(CHATGPT_CHANGE_ORGS).click()
+		const dialog = page.getByTestId('mcp-connection-orgs-dialog')
+		await expect(dialog).toBeVisible()
+		const boxes = dialog.locator('[data-testid^="mcp-connection-org-pick-"]')
+		await expect(boxes).toHaveCount(2)
+		// Warned while more than one is ticked — an assistant cannot choose
+		// between them, so this state is the one that leaves it stuck
+		await expect(page.getByTestId('mcp-connection-orgs-warning')).toBeVisible()
+		await boxes.nth(1).click()
+		await expect(page.getByTestId('mcp-connection-orgs-warning')).toBeHidden()
+		await page.getByTestId('mcp-connection-orgs-save').click()
+
+		// THEN the connection is left reaching exactly one organization, which is
+		// what makes it usable without the assistant being asked to pick
+		await expect(dialog).toBeHidden()
+		await expect(chatgptRow.getByTestId('mcp-connection-org')).toHaveCount(1)
+	})
+
+	test('should refuse to save when nothing is ticked', async ({ page }) => {
+		// GIVEN the picker open on ChatGPT
+		await page.getByTestId(CHATGPT_CHANGE_ORGS).click()
+		const dialog = page.getByTestId('mcp-connection-orgs-dialog')
+		const boxes = dialog.locator('[data-testid^="mcp-connection-org-pick-"]')
+
+		// WHEN every organization is unticked
+		const count = await boxes.count()
+		for (let i = 0; i < count; i++) await boxes.nth(i).click()
+
+		// THEN saving is refused here rather than at the server, which reads an
+		// empty choice as "nobody has chosen" and would widen access instead of
+		// removing it. Taking access away is what the revoke button is for
+		await expect(page.getByTestId('mcp-connection-orgs-save')).toBeDisabled()
+	})
+
+	test('should offer back an organization the member removed, but not one an owner removed', async ({
+		page,
+	}) => {
+		// GIVEN Codex, cut off from one organization by Alice and from the other
+		// by that organization's owner
+		const codexRow = page
+			.getByTestId('mcp-connection-row')
+			.filter({ hasText: 'Codex' })
+		// It reaches nothing, and says so rather than claiming nothing was chosen
+		await expect(codexRow.getByTestId('mcp-connection-unbound')).toHaveText(
+			/no organization selected/i,
+		)
+
+		// WHEN she opens its picker
+		await page
+			.getByTestId('mcp-connection-change-orgs-mock-codex-client')
+			.click()
+		const dialog = page.getByTestId('mcp-connection-orgs-dialog')
+		const boxes = dialog.locator('[data-testid^="mcp-connection-org-pick-"]')
+
+		// THEN her own removal is offered back and the owner's is not — one of
+		// them she can undo by choosing it again, the other she cannot
+		await expect(dialog.getByText(/you removed this one/i)).toBeVisible()
+		await expect(dialog.getByText(/an owner removed this one/i)).toBeVisible()
+		await expect(boxes).toHaveCount(2)
+		const enabled = await Promise.all([
+			boxes.nth(0).isEnabled(),
+			boxes.nth(1).isEnabled(),
+		])
+		expect(enabled.filter(Boolean)).toHaveLength(1)
 	})
 })
 

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -413,6 +413,12 @@ const McpAuthMiddleware = HttpRouter.middleware(
 								? allowedOrgIds[0]
 								: undefined
 						if (!orgId) {
+							// Point at the settings page first: an assistant sets headers
+							// once for a whole connection, if at all, so asking someone to
+							// send one per call is asking for something most of them cannot
+							// do. Narrowing the connection to one organization works
+							// everywhere; the header stays as a footnote for the
+							// command-line clients that can send it.
 							return yield* rejectAuth(
 								hint ? 'org_hint_not_authorized' : 'org_selection_required',
 								jsonRpcError(
@@ -420,9 +426,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 									-32002,
 									hint
 										? 'X-Batuda-Organization-Id is not authorized for this connection'
-										: allowedOrgIds.length === 1
-											? 'Select an organization for this connection at /settings/mcp/connections'
-											: 'Send X-Batuda-Organization-Id with one of the authorized organizations',
+										: 'This connection is authorized for more than one organization. Choose one at /settings/mcp/connections, or send X-Batuda-Organization-Id with one of them.',
 								),
 							)
 						}

--- a/apps/server/src/mcp/oauth-auth.integration.test.ts
+++ b/apps/server/src/mcp/oauth-auth.integration.test.ts
@@ -567,6 +567,28 @@ describe('OAuth Bearer org resolution', () => {
 			// THEN it refuses (no org entered) with the select-an-org code
 			expect(outcome).toEqual({ kind: 'forbidden', code: -32002 })
 		})
+
+		it('should start working once they narrow the connection to one org', async () => {
+			// GIVEN that same refused connection, narrowed to a single organization
+			// through the call the settings screen makes — not by staging rows, so
+			// this covers the whole path a person actually takes out of the refusal
+			const token = await mintToken({ sub: multiOrgUserId })
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					return yield* service.selectOrgs(multiOrgUserId, CLIENT_ID, [
+						taller.id,
+					])
+				}),
+			)
+
+			// WHEN the Bearer path resolves again, still without a hint — assistants
+			// cannot send one, which is why narrowing has to be enough on its own
+			const outcome = await resolveBearer(token)
+
+			// THEN it resolves to the chosen organization
+			expect(outcome).toEqual({ kind: 'scoped', orgIds: [taller.id] })
+		})
 	})
 
 	describe('a multi-org user whose last selected org was revoked', () => {
@@ -1212,6 +1234,102 @@ describe('McpOAuthService.listConnections', () => {
 			// THEN the connection's organizationIds is empty (unbound)
 			expect(connections).toHaveLength(1)
 			expect(connections[0]?.organizationIds).toEqual([])
+		})
+
+		it('should return an empty chosenOrganizationIds array', async () => {
+			// GIVEN a consented client but no selection
+			await seedConsentedClient(multiOrgUserId, CLIENT_ID, 'mcp-oauth-test')
+
+			// WHEN listConnections runs
+			const connections = await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					return yield* service.listConnections(multiOrgUserId)
+				}),
+			)
+
+			// THEN nothing has been chosen either — which is what tells the screen
+			// this connection reaches every organization rather than none
+			expect(connections[0]?.chosenOrganizationIds).toEqual([])
+			expect(connections[0]?.blocks).toEqual([])
+		})
+	})
+
+	describe('a connection cut off by an owner', () => {
+		it('should report the block as not raised by the connection owner', async () => {
+			// GIVEN a connection authorized for both orgs, cut off from taller by an
+			// admin rather than by the person who owns the connection
+			await seedConsentedClient(multiOrgUserId, CLIENT_ID, 'mcp-oauth-test')
+			await setSelections(multiOrgUserId, [taller.id, restaurant.id])
+			await setRevocations(multiOrgUserId, [taller.id], adminUserId)
+
+			// WHEN listConnections runs
+			const connections = await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					return yield* service.listConnections(multiOrgUserId)
+				}),
+			)
+
+			// THEN the block is reported as someone else's, so the screen can show it
+			// as something this person cannot undo
+			expect(connections[0]?.blocks).toEqual([
+				{ organizationId: taller.id, blockedBySelf: false },
+			])
+			// AND the choice behind it survives, even though it is unreachable
+			expect(connections[0]?.chosenOrganizationIds).toEqual(
+				[restaurant.id, taller.id].sort(),
+			)
+			expect(connections[0]?.organizationIds).toEqual([restaurant.id])
+		})
+	})
+
+	describe('a connection the caller cut off themselves', () => {
+		it('should report the block as their own', async () => {
+			// GIVEN a connection the person cut off from taller themselves
+			await seedConsentedClient(multiOrgUserId, CLIENT_ID, 'mcp-oauth-test')
+			await setSelections(multiOrgUserId, [taller.id, restaurant.id])
+			await setRevocations(multiOrgUserId, [taller.id])
+
+			// WHEN listConnections runs
+			const connections = await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					return yield* service.listConnections(multiOrgUserId)
+				}),
+			)
+
+			// THEN it is marked as theirs — the screen offers it back, because
+			// choosing that organization again lifts their own block
+			expect(connections[0]?.blocks).toEqual([
+				{ organizationId: taller.id, blockedBySelf: true },
+			])
+		})
+	})
+
+	describe('a connection cut off from an org it never chose', () => {
+		it('should still report the block', async () => {
+			// GIVEN a connection nobody has scoped, cut off from taller anyway.
+			// There is no choice for the removal to hang off, which is exactly the
+			// case a join through the chosen organizations cannot see
+			await seedConsentedClient(multiOrgUserId, CLIENT_ID, 'mcp-oauth-test')
+			await setSelections(multiOrgUserId, [])
+			await setRevocations(multiOrgUserId, [taller.id], adminUserId)
+
+			// WHEN listConnections runs
+			const connections = await runtime.runPromise(
+				Effect.gen(function* () {
+					const service = yield* McpOAuthService
+					return yield* service.listConnections(multiOrgUserId)
+				}),
+			)
+
+			// THEN the block is still reported, so the screen never claims the way is
+			// clear while the connection stays shut out
+			expect(connections[0]?.chosenOrganizationIds).toEqual([])
+			expect(connections[0]?.blocks).toEqual([
+				{ organizationId: taller.id, blockedBySelf: false },
+			])
 		})
 	})
 })

--- a/apps/server/src/services/mcp-oauth.ts
+++ b/apps/server/src/services/mcp-oauth.ts
@@ -10,6 +10,14 @@ import { Auth } from '../lib/auth'
 // whole organization; everyone else may only manage their own connections.
 const MANAGING_ROLES: ReadonlySet<string> = new Set(['owner', 'admin'])
 
+// An organization a connection has been cut off from. `blockedBySelf` marks a
+// block the person placed on their own connection — that one lifts when they
+// choose the organization again; an owner's does not.
+export interface McpConnectionBlock {
+	readonly organizationId: string
+	readonly blockedBySelf: boolean
+}
+
 // A user's MCP OAuth connection: an OAuth client they've consented to, the
 // orgs its access tokens may act in (empty until chosen), and the host of
 // its first redirect URI. The host is provenance — the client `name` is
@@ -19,7 +27,11 @@ export interface McpConnection {
 	readonly clientId: string
 	readonly name: string | null
 	readonly createdAt: string
+	// Where the connection can act right now.
 	readonly organizationIds: ReadonlyArray<string>
+	// Everything ever chosen for it, blocked organizations included.
+	readonly chosenOrganizationIds: ReadonlyArray<string>
+	readonly blocks: ReadonlyArray<McpConnectionBlock>
 	readonly redirectHost: string | null
 }
 
@@ -28,7 +40,14 @@ interface ConnectionRow {
 	readonly name: string | null
 	readonly createdAt: string | Date
 	readonly organizationIds: ReadonlyArray<string> | null
+	readonly chosenOrganizationIds: ReadonlyArray<string> | null
 	readonly redirectUris: unknown
+}
+
+interface RevocationRow {
+	readonly clientId: string
+	readonly organizationId: string
+	readonly revokedByUserId: string
 }
 
 // One connection as an owner or an admin sees it: whose it is, what tool last
@@ -396,45 +415,78 @@ export class McpOAuthService extends Context.Service<McpOAuthService>()(
 				// with the orgs each is currently bound to (empty until chosen).
 				// Aggregated with array_agg so one row per connection carries the
 				// full org list, instead of one row per (connection, org).
+				//
+				// Removals are read on their own rather than joined to the choices,
+				// because a connection can be cut off from an organization it was
+				// never chosen for, and a join hanging off the choice would miss that
+				// removal entirely. Both reads share one transaction, so they cannot
+				// disagree.
 				listConnections: (
 					userId: string,
 				): Effect.Effect<ReadonlyArray<McpConnection>> =>
 					Effect.gen(function* () {
-						const result = yield* withResolverTx(userId, client =>
-							client.query<ConnectionRow>(
-								`SELECT c."clientId"            AS "clientId",
-								        oc.name               AS name,
-								        oc."redirectUris"     AS "redirectUris",
-								        c."createdAt"         AS "createdAt",
-								        COALESCE(
-								          array_agg(sel.organization_id ORDER BY sel.organization_id)
-								          FILTER (WHERE sel.organization_id IS NOT NULL
-									            AND rev.organization_id IS NULL),
-								          ARRAY[]::text[]
-								        )                    AS "organizationIds"
-								 FROM "oauthConsent" c
-								 JOIN "oauthClient" oc ON oc."clientId" = c."clientId"
-								 LEFT JOIN mcp_oauth_org_membership sel
-								   ON sel.user_id = c."userId" AND sel.client_id = c."clientId"
-								 -- An organization the connection has been cut off from is left
-								 -- out: the choice behind it is kept so it can be put back, but
-								 -- showing it would claim the connection still reaches data it
-								 -- can no longer touch.
-								 LEFT JOIN mcp_oauth_revocation rev
-								   ON rev.user_id = sel.user_id
-								  AND rev.client_id = sel.client_id
-								  AND rev.organization_id = sel.organization_id
-								 WHERE c."userId" = $1
-								 GROUP BY c."clientId", oc.name, oc."redirectUris", c."createdAt"
-								 ORDER BY c."createdAt" DESC`,
-								[userId],
-							),
+						const { connections, revocations } = yield* withResolverTx(
+							userId,
+							async client => {
+								const connections = await client.query<ConnectionRow>(
+									`SELECT c."clientId"            AS "clientId",
+									        oc.name               AS name,
+									        oc."redirectUris"     AS "redirectUris",
+									        c."createdAt"         AS "createdAt",
+									        COALESCE(
+									          array_agg(sel.organization_id ORDER BY sel.organization_id)
+									          FILTER (WHERE sel.organization_id IS NOT NULL
+										            AND rev.organization_id IS NULL),
+									          ARRAY[]::text[]
+									        )                    AS "organizationIds",
+									        COALESCE(
+									          array_agg(sel.organization_id ORDER BY sel.organization_id)
+									          FILTER (WHERE sel.organization_id IS NOT NULL),
+									          ARRAY[]::text[]
+									        )                    AS "chosenOrganizationIds"
+									 FROM "oauthConsent" c
+									 JOIN "oauthClient" oc ON oc."clientId" = c."clientId"
+									 LEFT JOIN mcp_oauth_org_membership sel
+									   ON sel.user_id = c."userId" AND sel.client_id = c."clientId"
+									 -- An organization the connection has been cut off from is left
+									 -- out of what it can reach, but kept in what was chosen: the
+									 -- choice survives the removal so it can be put back.
+									 LEFT JOIN mcp_oauth_revocation rev
+									   ON rev.user_id = sel.user_id
+									  AND rev.client_id = sel.client_id
+									  AND rev.organization_id = sel.organization_id
+									 WHERE c."userId" = $1
+									 GROUP BY c."clientId", oc.name, oc."redirectUris", c."createdAt"
+									 ORDER BY c."createdAt" DESC`,
+									[userId],
+								)
+								const revocations = await client.query<RevocationRow>(
+									`SELECT client_id          AS "clientId",
+									        organization_id    AS "organizationId",
+									        revoked_by_user_id AS "revokedByUserId"
+									 FROM mcp_oauth_revocation
+									 WHERE user_id = $1`,
+									[userId],
+								)
+								return { connections, revocations }
+							},
 						)
-						return result.rows.map(row => ({
+						const blocksByClient = new Map<string, Array<McpConnectionBlock>>()
+						for (const row of revocations.rows) {
+							const blocks = blocksByClient.get(row.clientId) ?? []
+							blocks.push({
+								organizationId: row.organizationId,
+								blockedBySelf: row.revokedByUserId === userId,
+							})
+							blocksByClient.set(row.clientId, blocks)
+						}
+						return connections.rows.map(row => ({
 							clientId: row.clientId,
 							name: row.name,
 							createdAt: new Date(row.createdAt).toISOString(),
 							organizationIds: row.organizationIds ?? [],
+							chosenOrganizationIds: row.chosenOrganizationIds ?? [],
+							blocks: blocksByClient.get(row.clientId) ?? [],
 							redirectHost: firstRedirectHost(row.redirectUris),
 						}))
 					}),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -458,13 +458,13 @@ All auth is handled by [Better Auth](https://www.better-auth.com/) v1.6.11 with 
 
 **Route protection:**
 
-| Routes                                                      | Auth                                                                              |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `GET /health`, `GET /pages/:slug`, `POST /pages/:slug/view` | Public — no auth                                                                  |
-| `/auth/*`                                                   | Better Auth endpoints (sign-up, sign-in, session, API key management)             |
-| All `/v1/*` routes                                          | Protected — `SessionMiddleware` validates cookie, bearer token, or API key        |
-| `/mcp` (HTTP transport)                                     | Protected — HTTP middleware validates Better Auth session, provides `CurrentUser` |
-| MCP stdio                                                   | Trusted local process — static `CurrentUser`                                      |
+| Routes                                                      | Auth                                                                            |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `GET /health`, `GET /pages/:slug`, `POST /pages/:slug/view` | Public — no auth                                                                |
+| `/auth/*`                                                   | Better Auth endpoints (sign-up, sign-in, session, API key management)           |
+| All `/v1/*` routes                                          | Protected — `SessionMiddleware` validates cookie, bearer token, or API key      |
+| `/mcp` (HTTP transport)                                     | Protected — API key, OAuth bearer, or cookie session; resolves one org per call |
+| MCP stdio                                                   | Trusted local process — static `CurrentUser`, org from an env var               |
 
 **API key flow.** Two kinds of `x-api-key` keys exist:
 
@@ -480,15 +480,21 @@ All auth is handled by [Better Auth](https://www.better-auth.com/) v1.6.11 with 
   `POST /auth/api-key/create`). They carry no org metadata and serve `/auth/admin/*`
   and webhook callers, not `/mcp`.
 
-Both are validated by `@better-auth/api-key` (`enableSessionForAPIKeys: true`); `SessionMiddleware` validates `/v1/*` uniformly via `auth.api.getSession()`.
+Both are validated by `@better-auth/api-key` with `enableSessionForAPIKeys: false` — a key authenticates the `/mcp` path only, checked there with `verifyApiKey`, and never stands in for a login session on the cookie-gated REST API, so a leaked key cannot be replayed beyond `/mcp`. `SessionMiddleware` validates `/v1/*` uniformly via `auth.api.getSession()`.
 
 **MCP auth on behalf of user:**
 
-MCP protocol has no built-in auth. Auth happens at the transport level:
+MCP protocol has no built-in auth. Auth happens at the transport level, and every call resolves exactly one organization before a tool runs — the organization is never a tool argument. Tool handlers read `CurrentUser` and `CurrentOrg` for attribution and permissions; the organization scope itself is enforced by RLS, not by the handler.
 
-- **HTTP** (`/mcp`): middleware validates Better Auth session on each POST, provides `CurrentUser` context to tool handlers
-- **Stdio**: `CurrentUser` provided statically (trusted local user)
-- Tool handlers can `yield* CurrentUser` for audit logging and permissions
+The three credential paths on HTTP `/mcp` differ only in where the organization comes from:
+
+- **API key** (`x-api-key`) — organization and acting member come from the key's metadata, so a key is pinned to one organization for its whole life. The creating member's `member` row is re-checked on every call, so the key stops working once that person leaves.
+- **OAuth bearer** (web-chat clients) — an access token is self-contained and cannot be called back once issued, so authorization is re-read on every request instead of being baked into the token. Under the `app_mcp_resolver` role, in a user-scoped transaction that precedes any organization scope, the server reads the caller's live memberships, the organizations this connection (`client_id`) was authorized for, and the ones it has been cut off from. The authorized set is the intersection, minus removals, which is what makes cutting a connection off take effect immediately. A connection nobody has configured yet falls back to the user's live organizations, so a single-organization user never has to visit a settings page; a connection that *was* configured but whose every choice has gone stale is rejected rather than widened, since silently granting organizations the user never chose would be a privilege escalation.
+- **Cookie session** (a person in a browser tab) — uses the session's `activeOrganizationId`; a session with none is refused rather than defaulted.
+
+**One organization per connection.** When an OAuth connection is authorized for several organizations, a request has to name which one in an `X-Batuda-Organization-Id` header — but no assistant can do that per call. Claude.ai stores headers once per connection from an allow-listed set of names, Claude Code takes them per server entry, and ChatGPT's connector form has no header field at all. So a connection authorized for more than one organization is a dead end in practice, and the refusal points the member at `/settings/mcp/connections`, where a connection can be narrowed to a single organization at any time. That page is the only way back: Better Auth skips the consent screen once a consent row covers the requested scopes, so reconnecting the same assistant never asks again.
+
+Stdio is the local-development transport: a trusted local process with no session at all, so `CurrentUser` is static and the organization is read from an env var — required, never defaulted, so a local run cannot silently target whichever organization happened to be seeded first.
 
 ---
 

--- a/packages/controllers/src/routes/mcp-oauth.ts
+++ b/packages/controllers/src/routes/mcp-oauth.ts
@@ -31,15 +31,31 @@ export const RevokeConnectionInput = Schema.Struct({
 
 // ── View ──
 
+// An organization this connection has been cut off from. `blockedBySelf`
+// tells apart a removal the person made on their own connection, which they
+// can undo by choosing that organization again, from one an owner made for
+// the whole organization, which they cannot.
+export const McpConnectionBlock = Schema.Struct({
+	organizationId: Schema.String,
+	blockedBySelf: Schema.Boolean,
+})
+
 // One MCP OAuth connection: an OAuth client the caller consented to, with
 // the orgs its tokens may act in (empty until chosen). The /mcp Bearer path
-// re-checks each against live membership and picks one per request via the
-// X-Batuda-Organization-Id hint (single-org users are auto-resolved).
+// re-checks each against live membership; a single organization resolves on
+// its own, and a request has to name which one when there are several.
 export const McpConnectionView = Schema.Struct({
 	clientId: Schema.String,
 	name: Schema.NullOr(Schema.String),
 	createdAt: Schema.String,
+	// What the connection can reach right now: chosen, minus anything blocked.
 	organizationIds: Schema.Array(Schema.String),
+	// Everything chosen, blocked organizations included. Empty means nobody has
+	// chosen yet, which — with nothing blocked — reaches every organization the
+	// person belongs to. Kept apart from `organizationIds` so a connection
+	// blocked down to nothing is not read as one nobody has chosen for.
+	chosenOrganizationIds: Schema.Array(Schema.String),
+	blocks: Schema.Array(McpConnectionBlock),
 	// Host of the client's first redirect URI — provenance shown beside the
 	// self-asserted `name` (null if it registered none / they're unparseable).
 	redirectHost: Schema.NullOr(Schema.String),


### PR DESCRIPTION
## Why

An assistant connected over MCP has to act in exactly one organization per call. When one is approved for several, the server refuses every call and tells the person to send an `X-Batuda-Organization-Id` header naming which.

Nobody can do that. Where assistants support custom headers at all, the value is fixed once for the whole connection: Claude.ai's is an allow-listed-names beta, Claude Code takes them per server entry, and ChatGPT's connector form has no header field. So "several organizations, the client names one per call" describes a client that does not exist.

Two things then made it a dead end rather than an inconvenience:

- The approval screen pre-ticks every organization, so a member of more than one lands in the broken state by default.
- The connections page could only take access away, and re-approving the assistant does not ask again — Better Auth skips the consent screen once a consent covers the requested scopes. There was no way back.

## What changed

**A picker on the connections page.** Each connection gets *Change organizations*; narrowing one to a single organization is what makes it work again. Saving sends exactly what is ticked, and the save is refused while nothing is — an empty choice reads as "nobody has chosen", which widens access rather than removing it.

**Removals are now told apart by who made them.** `listConnections` returns the raw choice plus one entry per removal, flagged as the member's own or an owner's. That distinction is load-bearing: choosing an organization again lifts a removal the member made themselves, and does nothing to an owner's. So the picker offers the first back and shows the second without offering it — and never silently re-sends either, which would have lifted exactly the removals the screen had just drawn as blocking.

Removals are read in their own query inside the same transaction, because one can exist for an organization nobody ever chose, and the existing lookup hangs off the choice and cannot see those.

**A connection that reaches everything now says so.** "Nothing chosen" and "everything blocked" both produced an empty list and both rendered as "No organization selected" — wrong in the first case, where the assistant reaches every organization the person belongs to.

**The approval screen stops over-granting.** The organization binding runs after consent and its result was never checked; on failure the person was redirected as though it had worked, leaving a connection with nothing recorded — which reaches every organization they belong to. It now stops, explains, and offers retrying, which is what actually completes the approval.

**The refusal points somewhere useful**, and three strings promising per-request organization picking are gone.

## Screenshots

The picker on the seeded "Codex" connection — one organization the member removed themselves, offered back because ticking it restores it; one an owner removed, shown but not offered because nothing here can undo it.

![org-picker.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-359/org-picker.webp)

Captured at desktop width only: the picker is a dialog with a single stacked list and no breakpoint-dependent layout, so the small-screen rendering differs only in dialog width.

## Verification

- `check-types`, `test`, `build` — all green.
- `test:integration` — 409 pass, including new cases for both removal kinds, a removal on a never-chosen organization, and **the end-to-end claim**: a refused multi-organization connection resolves with no header once narrowed. Nothing covered that path before; every existing resolution test staged rows directly rather than going through the call the UI makes.
- E2E — narrowing, the empty-save refusal, and the two removal states, run twice to confirm the restore leaves the seed as it found it.
- Exercised against the live stack.

Sample data grows a third assistant cut off both ways, since neither state could be produced locally, and clearing sample data now clears removals — they outlived it and kept cutting off freshly created assistants.

## Known gap, not fixed here

An owner's removal is permanent: nothing in the product lifts it, so a member cut off from an organization can never be re-admitted to that connection, even by the owner who did it. That predates this work, but the picker now shows it plainly where it was invisible, so it is likelier to be reported. Worth its own issue.

## Considered and not taken

A path per organization (`/mcp/{slug}`) is where this probably goes — the URL is the one thing every client lets a person configure, and it binds each organization to its own token audience. It replaces this change rather than extending it, and means one connector per organization.

