### PR TITLE
fix: name the spender, find folded text, and trust the browser tests

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -7,6 +7,17 @@ name: E2E full suite
 on:
   push:
     branches: [main]
+    # Release commits only bump a changelog and a version — nothing the browser
+    # can exercise, and worse: a newer push cancels the run underneath it
+    # (below), so four release commits in a row used to cancel the run for the
+    # real commit they were releasing. `paths-ignore` stops the run being
+    # created at all; a job-level `if` cannot, because a run joins the
+    # concurrency group before any job condition is read.
+    #
+    # A dependency change still runs — it also moves pnpm-lock.yaml.
+    paths-ignore:
+      - "**/CHANGELOG.md"
+      - "**/package.json"
 
 # A newer push supersedes an in-flight full run — the latest commit is what
 # matters for a post-merge backstop.

--- a/apps/cli/src/commands/db.ts
+++ b/apps/cli/src/commands/db.ts
@@ -1,35 +1,10 @@
-import { Config, Effect } from 'effect'
+import { Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
+import { clearMailCatcher } from '../lib/mail-catcher'
 import { execIn, ROOT } from '../shell'
 
 export const dbMigrate = execIn(ROOT, 'pnpm', 'db:migrate')
-
-// Purge every message the mail catcher has captured so a re-seed starts from
-// zero. The endpoint is MAIL_CATCHER_HTTP_URL (see .env.example; `pnpm cli
-// setup` copies it) — no hardcoded fallback. Failures (catcher down, or the
-// var unset) are logged but don't abort the reset; it's a dev-only convenience.
-const clearCatcher = Effect.gen(function* () {
-	const url = yield* Config.string('MAIL_CATCHER_HTTP_URL')
-	yield* Effect.tryPromise({
-		try: async () => {
-			const res = await fetch(`${url}/api/mail/purge`, {
-				method: 'POST',
-				signal: AbortSignal.timeout(2_000),
-			})
-			if (!res.ok) {
-				throw new Error(`HTTP ${res.status}`)
-			}
-		},
-		catch: e => new Error(e instanceof Error ? e.message : String(e)),
-	})
-}).pipe(
-	Effect.catch(() =>
-		Effect.logWarning(
-			'mail catcher purge skipped (catcher unreachable or MAIL_CATCHER_HTTP_URL unset)',
-		),
-	),
-)
 
 export const dbReset = Effect.gen(function* () {
 	yield* Effect.logInfo('Dropping public schema...')
@@ -41,7 +16,7 @@ export const dbReset = Effect.gen(function* () {
 	yield* dbMigrate
 
 	yield* Effect.logInfo('Purging mail catcher...')
-	yield* clearCatcher
+	yield* clearMailCatcher
 
 	yield* Effect.logInfo(
 		'Database reset complete. Run `pnpm cli seed` to insert sample data.',

--- a/apps/cli/src/commands/seed.ts
+++ b/apps/cli/src/commands/seed.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
+import { clearMailCatcher } from '../lib/mail-catcher'
 import { seedCalendar } from './seed/calendar'
 import {
 	seedCompanies,
@@ -37,6 +38,11 @@ export { PRESETS, type Preset } from './seed/shared'
 export const seed = (preset: Preset) =>
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
+
+		// Outside the transaction below: emptying the catcher is a call to
+		// another service and cannot be taken back if the seed rolls back.
+		yield* Effect.logInfo('Purging mail catcher...')
+		yield* clearMailCatcher
 
 		return yield* sql.withTransaction(
 			Effect.gen(function* () {

--- a/apps/cli/src/lib/mail-catcher.ts
+++ b/apps/cli/src/lib/mail-catcher.ts
@@ -1,0 +1,34 @@
+import { Config, Effect } from 'effect'
+
+/**
+ * Throw away every message the dev mail catcher is holding.
+ *
+ * Rebuilding the sample data clears the email tables, so mail the catcher kept
+ * from an earlier run no longer matches what the database says — and the mail
+ * worker, which reads from the catcher, would carry it into the fresh data.
+ * Both `db reset` and `seed` clear it for that reason.
+ *
+ * A catcher that is down, or an unset address, is logged and skipped: this is a
+ * convenience for local work, not something worth failing a seed over.
+ */
+export const clearMailCatcher = Effect.gen(function* () {
+	const url = yield* Config.string('MAIL_CATCHER_HTTP_URL')
+	yield* Effect.tryPromise({
+		try: async () => {
+			const res = await fetch(`${url}/api/mail/purge`, {
+				method: 'POST',
+				signal: AbortSignal.timeout(2_000),
+			})
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`)
+			}
+		},
+		catch: e => new Error(e instanceof Error ? e.message : String(e)),
+	})
+}).pipe(
+	Effect.catch(() =>
+		Effect.logWarning(
+			'mail catcher purge skipped (catcher unreachable or MAIL_CATCHER_HTTP_URL unset)',
+		),
+	),
+)

--- a/apps/cli/src/lib/smtp-inject.ts
+++ b/apps/cli/src/lib/smtp-inject.ts
@@ -1,12 +1,12 @@
 import { Effect } from 'effect'
 import nodemailer from 'nodemailer'
 
-// Shared SMTP injector into the dev mail catcher. The seed uses it to populate
-// demo inboxes via the real ingest path; the `email inject` CLI command uses
-// it for ad-hoc dev pokes; the e2e helper re-exports it for the IMAP-roundtrip
-// spec. One transport per call — connection cost is negligible against the
-// catcher on localhost and removes any cross-process state we'd otherwise have
-// to manage.
+// Shared SMTP injector into the dev mail catcher, used by the `email inject`
+// CLI command for ad-hoc dev pokes and mirrored by an e2e helper for the
+// IMAP-roundtrip spec. Not by the seed: it writes its demo messages straight to
+// the database, so nothing it creates passes through the catcher. One transport
+// per call — connection cost is negligible against the catcher on localhost and
+// removes any cross-process state we'd otherwise have to manage.
 
 export interface InjectAttachment {
 	readonly filename: string

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -2543,10 +2543,6 @@ msgstr "Continua editant"
 msgid "Keep it"
 msgstr "Conserva-la"
 
-#: src/routes/settings/organization/spend.tsx
-msgid "Key"
-msgstr "Clau"
-
 #: src/routes/settings/api-keys/index.tsx
 msgid "Key deleted"
 msgstr "Clau eliminada"
@@ -3791,6 +3787,10 @@ msgstr "Pressupost per execució"
 #: src/routes/settings/organization/policy.tsx
 msgid "Per-run paid budget"
 msgstr "Pressupost de pagament per execució"
+
+#: src/routes/settings/organization/spend.tsx
+msgid "Person"
+msgstr "Persona"
 
 #: src/routes/calendar/index.tsx
 #: src/routes/emails/inboxes.tsx
@@ -5283,6 +5283,10 @@ msgstr "Avui"
 #: src/routes/login.tsx
 msgid "Too many attempts. Try again in a minute."
 msgstr "Massa intents. Torna-ho a provar d'aquí un minut."
+
+#: src/routes/settings/organization/spend.tsx
+msgid "Tool"
+msgstr "Eina"
 
 #: src/components/companies/proposals-panel.tsx
 msgid "Total"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -2543,10 +2543,6 @@ msgstr "Keep editing"
 msgid "Keep it"
 msgstr "Keep it"
 
-#: src/routes/settings/organization/spend.tsx
-msgid "Key"
-msgstr "Key"
-
 #: src/routes/settings/api-keys/index.tsx
 msgid "Key deleted"
 msgstr "Key deleted"
@@ -3791,6 +3787,10 @@ msgstr "Per-run budget"
 #: src/routes/settings/organization/policy.tsx
 msgid "Per-run paid budget"
 msgstr "Per-run paid budget"
+
+#: src/routes/settings/organization/spend.tsx
+msgid "Person"
+msgstr "Person"
 
 #: src/routes/calendar/index.tsx
 #: src/routes/emails/inboxes.tsx
@@ -5283,6 +5283,10 @@ msgstr "Today"
 #: src/routes/login.tsx
 msgid "Too many attempts. Try again in a minute."
 msgstr "Too many attempts. Try again in a minute."
+
+#: src/routes/settings/organization/spend.tsx
+msgid "Tool"
+msgstr "Tool"
 
 #: src/components/companies/proposals-panel.tsx
 msgid "Total"

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -1228,7 +1228,11 @@ function DetailBody({
 												<ChevronRight size={14} aria-hidden />
 												<Trans>Timeline</Trans>
 											</TimelineTrigger>
-											<PriCollapsible.Panel>
+											{/* This panel starts open, so staying findable while
+											    folded buys nothing — and it holds a status line read
+											    aloud, which would go on announcing from a folded
+											    section. */}
+											<PriCollapsible.Panel hiddenUntilFound={false}>
 												<TimelinePanelInner>
 													<TimelineToolbar>
 														<SystemEventsToggle>

--- a/apps/internal/src/routes/settings/organization/spend.tsx
+++ b/apps/internal/src/routes/settings/organization/spend.tsx
@@ -3,7 +3,7 @@ import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { ArrowLeft, Wallet } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { authClient } from '#/lib/auth-client'
@@ -24,6 +24,17 @@ type SpendBucket = {
 
 const EMPTY: ReadonlyArray<SpendBucket> = []
 
+// Only the fields needed to put a name to a spender. Declared here, as the
+// members page declares its own, because the auth client hands back a loosely
+// typed payload.
+interface OrgMember {
+	readonly userId: string
+	readonly user: {
+		readonly email: string
+		readonly name: string | null
+	}
+}
+
 export const Route = createFileRoute('/settings/organization/spend')({
 	head: () => ({ meta: [{ title: 'Spend — Batuda' }] }),
 	component: SpendPage,
@@ -32,6 +43,7 @@ export const Route = createFileRoute('/settings/organization/spend')({
 function SpendPage() {
 	const { t } = useLingui()
 	const activeMember = authClient.useActiveMember()
+	const activeOrg = authClient.useActiveOrganization()
 	const myRole = activeMember.data?.role ?? null
 	const canSeeSpend = myRole === 'owner' || myRole === 'admin'
 
@@ -87,6 +99,17 @@ function SpendPage() {
 
 	const total = provider.reduce((sum, b) => sum + b.amountCents, 0)
 	const maxBucket = provider.reduce((max, b) => Math.max(max, b.amountCents), 0)
+
+	// Spend is recorded against an account id, which says nothing to a reader.
+	// The organisation payload already carries everyone's name, so falling back
+	// to the id only ever shows for somebody who has since left.
+	const members = (activeOrg.data?.members ?? []) as ReadonlyArray<OrgMember>
+	const nameOf = useMemo(() => {
+		const byId = new Map(
+			members.map(m => [m.userId, m.user.name ?? m.user.email] as const),
+		)
+		return (userId: string) => byId.get(userId) ?? userId
+	}, [members])
 
 	if (!canSeeSpend) {
 		return (
@@ -203,14 +226,18 @@ function SpendPage() {
 				<SectionTitle>
 					<Trans>By user</Trans>
 				</SectionTitle>
-				<BreakdownTable rows={byUser} />
+				<BreakdownTable
+					rows={byUser}
+					heading={<Trans>Person</Trans>}
+					labelOf={nameOf}
+				/>
 			</Section>
 
 			<Section data-testid='settings-spend-by-tool'>
 				<SectionTitle>
 					<Trans>By tool</Trans>
 				</SectionTitle>
-				<BreakdownTable rows={byTool} />
+				<BreakdownTable rows={byTool} heading={<Trans>Tool</Trans>} />
 			</Section>
 		</Page>
 	)
@@ -218,8 +245,15 @@ function SpendPage() {
 
 function BreakdownTable({
 	rows,
+	heading,
+	labelOf,
 }: {
 	readonly rows: ReadonlyArray<SpendBucket>
+	// Names what the first column lists — people, or tools.
+	readonly heading: ReactNode
+	// Turns a row's key into something a reader recognises. Left out where the
+	// key already reads as itself, as a tool or provider name does.
+	readonly labelOf?: (key: string) => string
 }) {
 	if (rows.length === 0) {
 		return (
@@ -232,9 +266,7 @@ function BreakdownTable({
 		<Table>
 			<thead>
 				<tr>
-					<th>
-						<Trans>Key</Trans>
-					</th>
+					<th>{heading}</th>
 					<th>
 						<Trans>Spend</Trans>
 					</th>
@@ -245,8 +277,10 @@ function BreakdownTable({
 			</thead>
 			<tbody>
 				{rows.map(r => (
+					// Keyed by what was stored, not by the label: two people can share
+					// a name.
 					<tr key={r.key}>
-						<td>{r.key}</td>
+						<td>{labelOf ? labelOf(r.key) : r.key}</td>
 						<td>{formatCents(r.amountCents)}</td>
 						<td>{r.calls}</td>
 					</tr>

--- a/apps/internal/tests/e2e/company-overview.test.ts
+++ b/apps/internal/tests/e2e/company-overview.test.ts
@@ -113,8 +113,17 @@ test.describe('company-detail Overview tab', () => {
 			//   [components/companies/about-section.tsx — PriCollapsible.Root, no defaultOpen]
 			const trigger = page.getByTestId('company-about-trigger')
 			await expect(trigger).toBeVisible()
-			// AND the panel content is not visible before the trigger is clicked
-			await expect(page.getByTestId('company-about-panel')).toBeHidden()
+			// AND the panel content is not visible before the trigger is clicked,
+			// but is still on the page — marked so the browser's Find can reach it.
+			// Checking the mark too: "hidden" alone would also pass if the panel
+			// were not rendered at all. The mark sits on the parent, because the
+			// test id is on the inner body.
+			const panel = page.getByTestId('company-about-panel')
+			await expect(panel).toBeHidden()
+			await expect(panel.locator('xpath=..')).toHaveAttribute(
+				'hidden',
+				'until-found',
+			)
 
 			// WHEN the user clicks the About trigger.
 			// The header runs a shared-layout animation and the dev server applies
@@ -122,7 +131,6 @@ test.describe('company-detail Overview tab', () => {
 			// first second and a click sent mid-flight lands on empty space. Retry
 			// until it lands, and only while still closed so a click that did
 			// register is never undone by the next attempt.
-			const panel = page.getByTestId('company-about-panel')
 			await expect(async () => {
 				if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
 					await trigger.click()

--- a/apps/internal/tests/e2e/helpers/smtp-inject.ts
+++ b/apps/internal/tests/e2e/helpers/smtp-inject.ts
@@ -1,6 +1,6 @@
 // Tiny SMTP injector for e2e specs that need to drive the inbound side of the
 // mail-worker. Mirrors `apps/cli/src/lib/smtp-inject.ts` — the CLI helper sits
-// behind an Effect API the seed uses, while this helper is a thin Promise
+// behind an Effect API its commands use, while this helper is a thin Promise
 // wrapper specs can `await`. Both target the same dev mail catcher on
 // localhost:1025.
 

--- a/apps/internal/tests/e2e/settings-spend.test.ts
+++ b/apps/internal/tests/e2e/settings-spend.test.ts
@@ -7,7 +7,7 @@ import { DATABASE_URL } from './helpers/database-url'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // Asserts /settings/organization/spend renders aggregated paid-research
-// spend and re-fetches when the range toggle changes. Slice B.
+// spend and re-fetches when the range toggle changes.
 //
 // Selectors verified against:
 //   apps/internal/src/routes/settings/organization/index.tsx
@@ -22,7 +22,8 @@ const psql = (sqlText: string): string =>
 	}).trim()
 
 const seededKeys: string[] = []
-// Who the seeded spend is charged to, and how its row is found on the page.
+// Who the seeded spend is charged to — the page should show their name
+// instead.
 let seededUserId = ''
 
 test.describe('org spend dashboard', () => {
@@ -112,11 +113,13 @@ test.describe('org spend dashboard', () => {
 			await expect(byProvider).toContainText('brave')
 			await expect(byProvider).toContainText('firecrawl')
 
-			// AND the user table shows that person with money against them. Not a
-			// call count: this table totals everything the organisation ever spent
-			// per person, and the sample data charges the same person too.
+			// AND the user table names that person and shows money against them,
+			// rather than the account id the spend is stored under. Not a call
+			// count: this table totals everything the organisation ever spent per
+			// person, and the sample data charges the same person too.
 			const byUser = page.getByTestId('settings-spend-by-user')
-			await expect(byUser).toContainText(seededUserId)
+			await expect(byUser).toContainText('Alice Admin')
+			await expect(byUser).not.toContainText(seededUserId)
 			await expect(byUser).toContainText(/€\d/)
 
 			// AND the tool table lists the two seeded tools

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -439,6 +439,8 @@ const StatusBadge = styled.span<{ $status: string }>`
 | `PriTooltip`     | `Tooltip`     | Short field explanations                                    |
 | `PriCollapsible` | `Collapsible` | Expandable sections on company detail                       |
 
+A folded `PriCollapsible` panel keeps its text on the page rather than dropping it, so the browser's own find-in-page reaches it and opens the section on a match. That is `hiddenUntilFound`, defaulted on in the wrapper — pass `hiddenUntilFound={false}` where content should not linger while folded, as the company timeline does because it holds a status line read aloud by screen readers. It relies on Tailwind's reset scoping `display: none` to `[hidden]:where(:not([hidden='until-found']))`; without that carve-out a folded section would be permanently invisible rather than merely unfindable.
+
 ---
 
 ## Motion — animations

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"check-types": "turbo check-types",
 		"test": "turbo test",
 		"test:integration": "turbo test:integration",
+		"test:e2e": "pnpm cli db reset && pnpm cli seed --quiet && pnpm --filter @batuda/internal test:e2e",
 		"______ Code Quality ______": "",
 		"lint": "pnpm lint-syncpack && pnpm lint-biome && pnpm lint-markdown",
 		"lint-biome": "biome check --write --no-errors-on-unmatched --max-diagnostics=none",

--- a/packages/ui/src/pri/pri-collapsible.tsx
+++ b/packages/ui/src/pri/pri-collapsible.tsx
@@ -59,9 +59,22 @@ const PriTrigger = styled(Collapsible.Trigger).withConfig({
 	}
 `
 
-const PriPanel = styled(Collapsible.Panel).withConfig({
-	displayName: 'PriCollapsiblePanel',
-})`
+// A folded panel keeps its text on the page instead of throwing it away, so
+// the browser's own Find reaches it and opens the section on a match. On by
+// default so sections written later get it too; pass `hiddenUntilFound={false}`
+// where content should not linger. Reading the prop here, rather than fixing
+// the value, is what leaves that choice to the caller.
+//
+// It rests on Tailwind's reset sparing `hidden='until-found'` from
+// `display: none`. If that exception ever goes, a folded section stays
+// invisible for good rather than merely unfindable.
+const PriPanel = styled(Collapsible.Panel)
+	.attrs<{
+		readonly hiddenUntilFound?: boolean
+	}>(props => ({ hiddenUntilFound: props.hiddenUntilFound ?? true }))
+	.withConfig({
+		displayName: 'PriCollapsiblePanel',
+	})`
 	overflow: hidden;
 	transition: height 260ms cubic-bezier(0.22, 1.2, 0.4, 1);
 


### PR DESCRIPTION
## What

Four unrelated follow-ups from fixing the failing browser tests. Two are things a person using the app would notice; two are about trusting the tests that guard it.

- The spend page showed a random-looking code where a person's name belongs.
- Text tucked inside a folded section could not be found with the browser's own search.
- Cutting a release silently switched off the safety net that runs the browser tests after each merge.
- Running those tests locally could fail on leftovers from the last run rather than on the code.

This is the CRM's web app (`internal`), its shared components (`ui`), the command-line tool (`cli`), and one CI setup file.

## Changes

**A name instead of a code, on the spend page.** The "By user" table printed the internal account id every row is stored under, while the two tables beside it read plainly. An owner reviewing what the organisation spent saw something like `eubkj4SyEK4y…` instead of who spent it. The names already arrive with the organisation, so this is a change of what gets rendered, not a new request — the stored figures, the shape sent over the wire, and the agent-facing tool are all untouched. Somebody who has since left still shows as the id, which at least says the money belongs to someone.

**Folded sections keep their text.** A folded section used to be removed from the page outright, so pressing Cmd+F for a phrase sitting inside one found nothing and gave no hint it was there. Folded sections now hold their text, and the browser opens the right one when it matches. The company timeline is the one exception: it starts open, so it gains nothing, and it holds a status line read aloud by screen readers, which should not go on announcing from inside something hidden.

**A release no longer cancels the post-merge browser suite.** That suite runs after every merge, and a newer push cancels whatever is still running. A release lands one commit per app — four in a row, each changing only a changelog and a version number — so every one killed the run for the real commit underneath. Five runs in a row reported nothing during one release. Those commits now create no run at all.

**One command to run the browser tests honestly.** Several tests change the shared data, so a later run can fail on the leftovers. The browser-test config already spelled out the rebuild as something to remember; `pnpm test:e2e` now does it. Rebuilding also empties the mail catcher, since rebuilding clears the email tables and mail left over from an earlier run would otherwise be pulled into the fresh data.

## Impact

- **No migration, no environment variables, no change to anything sent over the wire, nothing touching who can see what.**
- **The shared collapsible affects every folded section in the app.** That is the one change here with reach beyond its own screen — see the review guide.
- **The agent-facing spend tool is deliberately unchanged.** It still answers with account ids. Naming people there would need the server to resolve them, which this does not do.
- **Two new pieces of text** on the spend page, with Catalan added.
- **`pnpm test:e2e` rebuilds the local database before running.** It is destructive to local sample data by design; the existing guard against pointing at anything but a local database still applies.

## Review guide

Start with `packages/ui/src/pri/pri-collapsible.tsx`. It is nine lines but it changes every folded section in the app at once, and its comment carries the two things that are not visible from the code: why the default has to be overridable, and that the whole thing rests on a rule Tailwind's reset happens to ship.

Two decisions you might overrule:

1. **The spend fix resolves names in the browser rather than on the server.** The server route could join the accounts table and hand back a name, which would also cover people who have left. I chose the smaller change: the page already receives the member list, so this touches one file and leaves the wire shape and the agent tool alone. It also avoids the research code reaching into the authentication tables for the first time, which felt like a precedent worth deciding on deliberately rather than inheriting from a convenience.
2. **The comment fixes ride in the last commit.** Two files claimed the sample data sends its mail through the catcher; it writes straight to the database. They are unrelated to the command, but that wrong claim is what sent me looking in the wrong place, so splitting them off would lose the reason they were found.

Skip-able: the translation catalogues.

## Screenshots

Nothing to show for three of the four. For the spend page the change is one column of one table — an account id becomes a person's name — which the test now pins in both directions: it asserts the name appears **and** that the id does not.

## Verification

Actually run on this branch, level with current `main`:

- **The full browser suite: 116 of 117 passed.** The one failure is an email test that passes on its own; three separate mail workers from three worktrees are competing for the one shared mail catcher on this machine, so one can consume a message another's test just sent. Nothing to do with this change — those tests empty the catcher themselves before each run.
- `pnpm install` → `pnpm -w check-types` (13/13) + `pnpm -w test` → `pnpm -w build` (13/13). Clean, no generated file moved.
- `pnpm exec biome check .` across the repo — clean.
- **Folded sections checked in a real browser, not assumed:** a folded panel carries the mark that makes it findable, its text is present while folded, and the section opens when the browser's find event fires. The test now asserts the mark, because asserting "hidden" alone would still pass if the panel went back to being dropped.
- **The spend page** shows `Alice Admin` under a `Person` heading, with the tool table unchanged.
- **The release fix** cannot be proven before merge. I checked the ignore patterns against the file lists of four real release commits — every one matches, so no run would be created.
- **The rebuild command** run against a deliberately dirty database.

One thing worth reporting because it shaped the change: my first version of that command rebuilt the sample data without dropping the schema, which is cheaper. It fails on an already-seeded database — the accounts and organisations are not cleared, so it hits a duplicate. That is exactly the state the command exists to rescue, so it would have shipped broken and failed the first time it was needed. Running it is what caught that.

## Deferred

- **A test that counts rows against a live database count.** The inbox listing compares rendered rows against a `SELECT count(*)`, and every test that sends an email adds to that count, so it drifts out of agreement with what the page shows. Reseeding hides it; the test itself is still fragile.
- **The shared mail catcher across worktrees.** Several checkouts each run their own mail worker against one instance, which makes email tests unreliable locally in a way no reseed fixes.
