### PR TITLE
fix(server): settle duplicate-contact search on the oldest match

### DIFF
--- a/apps/server/src/services/research-apply.integration.test.ts
+++ b/apps/server/src/services/research-apply.integration.test.ts
@@ -50,6 +50,20 @@ const seedContact = async (
 	return r.rows[0]?.id ?? ''
 }
 
+// Rows are stamped with the moment they are inserted, so making a row older
+// than one seeded before it takes an explicit update.
+const backdateContact = (contactId: string, createdAt: string) =>
+	pool.query(`UPDATE contacts SET created_at = $2 WHERE id = $1`, [
+		contactId,
+		createdAt,
+	])
+
+const backdateChannel = (contactId: string, createdAt: string) =>
+	pool.query(
+		`UPDATE contact_channels SET created_at = $2 WHERE contact_id = $1`,
+		[contactId, createdAt],
+	)
+
 const seedChannel = (
 	contactId: string,
 	kind: string,
@@ -264,6 +278,57 @@ describe('findDuplicateContact', () => {
 
 			// THEN the name + company still identify the same person
 			expect(found).toBe(contactId)
+		})
+	})
+
+	describe('when two contacts at one company share a name', () => {
+		it('should settle on the older one, so repeated searches give the same answer', async () => {
+			// GIVEN two people recorded under the same name at the same company
+			const companyId = await seedCompany()
+			const newer = await seedContact(companyId, 'Grace Hopper')
+			const older = await seedContact(companyId, 'Grace Hopper')
+			// The newer row is seeded first, so age and insert order disagree: a
+			// search that takes whichever row comes back first picks the wrong one
+			await backdateContact(newer, '2024-01-01T00:00:00Z')
+			await backdateContact(older, '2020-01-01T00:00:00Z')
+
+			// WHEN the same search runs repeatedly
+			const answers = await Promise.all([
+				dedup('Grace Hopper', companyId, []),
+				dedup('Grace Hopper', companyId, []),
+				dedup('Grace Hopper', companyId, []),
+			])
+
+			// THEN every search names the older contact
+			expect(answers).toEqual([older, older, older])
+		})
+	})
+
+	describe('when two contacts are reachable at the same proposed channel value', () => {
+		it('should settle on the older one rather than either at random', async () => {
+			// GIVEN two people who answer the same switchboard number
+			const companyId = await seedCompany()
+			const newer = await seedContact(companyId, 'Charles Babbage')
+			const older = await seedContact(companyId, 'Ada Lovelace')
+			const switchboard = '+34 900 111 222'
+			await seedChannel(newer, 'phone', switchboard)
+			await seedChannel(older, 'phone', switchboard)
+			// The newer channel goes in first, so age and insert order disagree
+			await backdateChannel(newer, '2024-01-01T00:00:00Z')
+			await backdateChannel(older, '2020-01-01T00:00:00Z')
+
+			// WHEN a proposal carrying that number is checked twice
+			const answers = await Promise.all([
+				dedup('Someone Else', companyId, [
+					{ kind: 'phone', value: switchboard },
+				]),
+				dedup('Someone Else', companyId, [
+					{ kind: 'phone', value: switchboard },
+				]),
+			])
+
+			// THEN both searches reach the older contact
+			expect(answers).toEqual([older, older])
 		})
 	})
 

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -456,7 +456,8 @@ export const linkSubjectToRun = (
 // reachable at one of the proposed channel values, matched on the (kind, value)
 // pair so a shared switchboard number can't merge two different people; (2) one
 // the model itself flagged as already existing; (3) same name under the same
-// company.
+// company. The same search has to name the same person every time it is asked,
+// so where several rows match, each lookup settles on the oldest.
 export const findDuplicateContact = (
 	sql: SqlClient.SqlClient,
 	orgId: string,
@@ -478,6 +479,7 @@ export const findDuplicateContact = (
 			const rows = yield* sql<{ contactId: string }>`
 				SELECT contact_id FROM contact_channels
 				WHERE organization_id = ${orgId} AND (${sql.or(pairs)})
+				ORDER BY created_at, contact_id
 				LIMIT 1
 			`
 			if (rows[0]) return rows[0].contactId
@@ -510,6 +512,7 @@ export const findDuplicateContact = (
 			WHERE organization_id = ${orgId}
 				AND company_id = ${companyId}
 				AND lower(name) = lower(${name})
+			ORDER BY created_at, id
 			LIMIT 1
 		`
 		return byName[0]?.id ?? null


### PR DESCRIPTION
## What

When research suggests adding a person to the CRM, the server first checks whether that person is already there, so two runs on the same contact don't leave two rows. That check could give different answers to the same question. It asked the database for "any one row that matches" without saying which one, and where several rows match, a database is free to hand back a different one each time.

This makes the check settle on the oldest matching row, so the same search names the same person every time. Server side only (the CRM context), no visible change to any screen.

## The fix

- Both lookups the check uses — one that finds a person by a phone number or email already on file, one that finds them by name within a company — now order by age before taking a single row.
- Neither lookup has a uniqueness rule behind it that would make one row the only possible answer. More than one row can legitimately match: two people can share a switchboard number, and nothing stops two contacts having the same name at the same company. So "pick one" genuinely needed to say which one.

## Impact

- **No migration, no schema change, no new environment variables.** Nothing to run before or after deploying.
- **No wire-shape change.** `packages/controllers` and `packages/domain` are untouched, so nothing ripples to the web app's typed client.
- **MCP and HTTP both get it.** Both transports reach this check through the same service, so the two surfaces stay identical.
- **Multi-org isolation is unchanged.** Both queries already scoped to `organization_id`; ordering was added inside that existing scope, and a test covers that the check still refuses to match across organizations.
- **The one behaviour change** is which row is chosen when several match. Previously arbitrary, now the oldest. No caller was relying on the old answer, because the old answer wasn't stable enough to rely on.

This is the same class of bug as `53f3308` ("give the paged proposal and page lists a settled order"), which landed today for the paged proposal and page lists. Different files, same root cause: a query that reads rows without naming an order.

## Review guide

The whole change is three lines of SQL and two lines of comment — start with `git diff` on `research-apply.ts` and you've seen it.

The part worth actual attention is the tests. A test for "this query is deterministic" is easy to write and worthless, because with two rows the database will usually return them in insert order anyway and the test passes whether or not the fix is there. Both tests therefore seed the **newer** record first, so age and table order disagree; a lookup that takes whichever row arrives first picks the wrong one. I verified this the only way that means anything: removed the ordering, watched both tests fail, put it back, watched them pass.

Nothing here I'd expect you to overrule. The one judgement call is "oldest" rather than "newest" — oldest means an established contact wins over a recently added duplicate, which seemed the safer default for a de-duplication check.

## Tests

Two integration cases against the live database, alongside the existing duplicate-detection coverage:

- two contacts sharing a name at one company — three repeated searches all name the older one
- two contacts reachable at one switchboard number — both searches reach the older one

## Verification

- `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (21/21), `pnpm -w build`
- Full server integration suite against the live local database: 68 files, 428 tests
- The removal check described in the review guide: with the ordering taken out, exactly the two new tests fail; with it restored, all 428 pass

No screenshots: server-side only, no UI surface touched.
