### PR TITLE
cicd: let the model capability check reach its keys and settings

### DIFF
--- a/.github/workflows/model_capability.yml
+++ b/.github/workflows/model_capability.yml
@@ -29,6 +29,10 @@ jobs:
     name: Probe configured models
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # The RESEARCH_LLM_*_API_KEY secrets below live on the `production`
+    # environment (Infisical syncs them there), and a job only sees an
+    # environment's secrets when it names that environment.
+    environment: production
     permissions:
       contents: read
       issues: write
@@ -46,6 +50,20 @@ jobs:
 
       # Routing comes from the committed production settings, so the check looks
       # at the models production really uses. Only the keys are secret.
+      #
+      # The probe runs as its own step below: what a step writes to GITHUB_ENV
+      # reaches later steps, never the rest of the step that wrote it.
+      - name: Export the configured model settings
+        run: |
+          node -e '
+            const config = require("./apps/server/config.production.json")
+            for (const [key, value] of Object.entries(config)) {
+              if (key.startsWith("RESEARCH_LLM_") && !key.includes("API_KEY")) {
+                console.log(`${key}=${value}`)
+              }
+            }
+          ' >> "$GITHUB_ENV"
+
       - name: Probe every configured slot
         id: probe
         env:
@@ -57,14 +75,6 @@ jobs:
           RESEARCH_LLM_WRITER_API_KEY_2: ${{ secrets.RESEARCH_LLM_WRITER_API_KEY_2 }}
         run: |
           set -o pipefail
-          node -e '
-            const config = require("./apps/server/config.production.json")
-            for (const [key, value] of Object.entries(config)) {
-              if (key.startsWith("RESEARCH_LLM_") && !key.includes("API_KEY")) {
-                console.log(`${key}=${value}`)
-              }
-            }
-          ' >> "$GITHUB_ENV"
           pnpm cli research probe-config 2>&1 | tee probe.log
 
       - name: Open or update an issue when a model can no longer do its work


### PR DESCRIPTION
## What

A scheduled check called "Model capability" is supposed to ping every AI model the research pipeline is configured to use, and open a bug report early if a vendor breaks a feature the pipeline depends on — before that break shows up as a failed customer-facing research run. On its first real run, the check never got to check anything: it crashed within four seconds and, doing exactly what it's designed to do on failure, filed issue #368 reporting that a model could no longer do its job. No model was ever actually contacted — the check's own CI wiring was broken in two ways.

## The fix

- The job now names the `production` GitHub environment, the same one the deploy job already uses. The six API keys it needs are already there (Infisical syncs them in), but a GitHub Actions job only sees an environment's secrets when it explicitly opts into that environment — this job never did, so every key silently read as empty.
- The step that works out which models/providers to check now runs on its own, before the step that checks them. Both used to be one script: the first half wrote the settings to a file GitHub Actions uses to pass values between steps, and the second half tried to read them back within that same script — but that file only takes effect for steps that run *after* the one that wrote it, so the check never actually saw which models it was supposed to probe.

## Impact

- **No migration, no schema change, no new environment variables.** The six secrets this job needs already exist in the `production` GitHub environment (verified directly against the GitHub API) — this is purely about the job seeing what was already there.
- **CI/CD only — no application code changed.** Nothing in `apps/` or `packages/` is touched.
- **Same branch restriction as every other job on this environment.** `production` only allows `main` and release tags to use it, so this job — like `deploy` — only ever runs for real against `main`.

## Review guide

The whole change is one file, two spots: the `environment: production` line on the job, and splitting one step into two. Both mirror a pattern already proven in `deploy_server.yml`'s `deploy` job, so there's nothing novel here to second-guess.

What I couldn't verify pre-merge: GitHub only exposes `production`'s secrets to jobs on an allowed branch (`main` + release tags), so I couldn't dispatch this workflow from a branch to prove the API keys resolve — that only happens for real once this lands on `main`. I verified it as far as possible without merging: confirmed via the GitHub API that all six keys already sit in that environment, and confirmed the `deploy` job (which needs the identical secrets) already runs fine from it. I judged that, plus the pattern match, is strong enough not to need a full `/code-review` pass on a 26-line CI diff — happy to run one if you'd rather.

## Verification

- Reproduced the actual failure locally: exported the same non-secret settings the fixed first step now writes (read straight out of `apps/server/config.production.json`, the same code the step runs), then ran `pnpm cli research probe-config`. Before the fix this throws `ConfigError` in under 4 seconds, matching the failed run's own log (`gh run view 30396576456 --log`); with the settings present, it completes and correctly reports "no key" for each slot instead of crashing.
- `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (21/21, 724 passed), `pnpm -w build` — all green.
- No UI surface touched, so no screenshots.

Closes #368
