### PR TITLE
ai(skills): describe how a new organization is set up and handed over

### DIFF
--- a/.claude/skills/onboard-org/SKILL.md
+++ b/.claude/skills/onboard-org/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: onboard-org
+description: This skill should be used when the user asks to "set up a new org", "create an organization", "onboard a customer", "onboard <name>", "add a member", "add someone to an org", "give <person> access", "create a tenant", or asks what to send a new customer so they can start using Batuda from ChatGPT or Claude.ai. Covers the developer-only `pnpm cli auth` org + first-admin creation (production, rehearsed locally), how members are added afterwards, the one-organization-per-connection rule for people who belong to several orgs, read-only confirmation, and the English getting-started message to hand over.
+allowed-tools: Bash(pnpm:*) Bash(infisical:*) Read
+---
+
+# Onboarding a new organization
+
+Only a Batuda developer can create an organization. Public signup is off
+(`emailAndPassword.disableSignUp = true`), nothing in the product creates an org, and the
+`organization` + `member` rows are written by `pnpm cli auth` talking straight to the
+database. Everything after the first admin is self-serve: that admin adds their own people
+from the web app.
+
+Four steps, in order: **rehearse → create → confirm → hand over** — §1, §2, §5 and §6. The
+two sections in between are reference for when they come up, not steps. Never skip the
+confirm — an org that reaches a customer half-made costs a support round-trip that a
+two-second read would have prevented.
+
+## 1. Rehearse locally
+
+Run the real command against the local database first. It is the only place the CLI hands
+back a sign-in link, so it is the only place the whole path can be walked before a customer
+walks it.
+
+```bash
+pnpm cli auth invite-admin --email owner@acme.com --name "Ada Lovelace" --org-name "Acme" --org-slug acme --locale en
+```
+
+The CLI captures the magic link in-process and prints it. With `pnpm dev:server` running,
+open it and confirm the sign-in lands. (`pnpm cli auth bootstrap-org` is the other local
+path — first admin *and* org on an empty database; it refuses if any `"user"` row exists.)
+
+## 2. Create it in production
+
+Read the target host first, then pass it back as the confirm:
+
+```bash
+infisical run --env=prod -- pnpm cli doctor --env cloud
+```
+
+That run adds a **Cloud DB host** row the local run does not have, carrying the host the
+connection will actually dial — which is not always the address the connection string
+appears to name. That row's value is what `--confirm-host` wants. The check fails rather
+than guessing when `DATABASE_URL` is missing or still points at localhost.
+
+```bash
+infisical run --env=prod -- pnpm cli auth invite-admin --env cloud --email owner@acme.com --name "Ada Lovelace" --org-name "Acme" --org-slug acme --locale en --confirm-host <host from doctor>
+```
+
+What each part is doing, and the traps:
+
+- **Two independent halves.** `infisical run --env=prod` injects the secrets into this one
+  process; `--env cloud` layers the non-secret settings from
+  `apps/server/config.production.json`. Neither stands in for the other, and anything
+  already in the environment outranks both.
+- **`--confirm-host` replaces the interactive `y/N`** and refuses if it disagrees with the
+  resolved `DATABASE_URL`. That is what makes a forgotten `--env cloud` harmless instead of
+  a write to the wrong database. Never guess the value — read it from the `Cloud DB host`
+  row above.
+- **Nothing is emailed and no link is printed** against a database that is not on this
+  machine. The account exists; that is all. The person signs in at
+  `https://batuda.co/login`, enters their address, and gets their own link, good for five
+  minutes from the moment they ask. Minting one here would leave a working way into the
+  account sitting in a mailbox.
+- **A taken slug aborts with `OrgSlugTaken`.** That guard is the reason a mistyped slug
+  cannot bolt a new admin onto another customer's tenant. Add `--allow-existing-org` only
+  when joining an existing org is precisely the intent.
+- **The role follows the org**: creating one makes them `owner`, joining an existing one
+  makes them `admin`.
+- **`--locale en|ca`** decides the language of their welcome email and their first visit.
+  Omitted leaves it unset.
+
+Secrets never go in argv — pnpm echoes its arguments. Nothing here takes one; keep it that
+way.
+
+## 3. Adding more people
+
+- **Another admin, from the CLI** — the same `invite-admin` command with the same
+  `--org-slug` plus `--allow-existing-org`. An email that already has an account is reused:
+  same account, a second membership.
+- **Everyone else — the org's own owner or admin adds them** at
+  `https://batuda.co/settings/organization/members`: email, role (`member` or `admin`), and
+  language. The route resolves the organization from the session and never from the request
+  body, and only an owner or admin of it may add someone.
+- **There is no invitation and nothing to accept.** The person is a member the moment the
+  form is submitted, and the email they receive carries no link that signs them in.
+
+Prefer handing that second path — the members form — to the admin over running it for them.
+It is theirs, it is one form, and it keeps a developer out of the customer's daily work.
+
+## 4. People who belong to more than one organization
+
+An assistant acts in **exactly one organization per call**. A connection authorized for
+several has every call refused, with:
+
+> This connection is authorized for more than one organization. Choose one at
+> /settings/mcp/connections, or send X-Batuda-Organization-Id with one of them.
+
+The header is not a real option for a chat. Claude.ai stores headers once per connection
+from an allow-listed set of names, ChatGPT's connector form has no header field at all, and
+where headers exist at all the value is fixed for the whole connection rather than sent per
+call. Command-line clients (Claude Code, Cursor, Codex) can set one, so the header stays
+useful there and nowhere else.
+
+The approval screen ticks every organization by default, so anyone in two or more lands in
+the broken state on their first connection. The fix — and the only way back — is
+`https://batuda.co/settings/mcp/connections` → **Change organizations** → tick exactly one
+→ **Save**. Reconnecting the assistant does not ask again, because consent is skipped once a
+consent row covers the scopes; that page is the route, not a re-approval. Saving with
+nothing ticked is refused, since an empty choice reads as "nobody has chosen" and widens
+access rather than removing it.
+
+Reading the state on that page:
+
+| What it shows                                          | What it means                                                                                                                              |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| One organization chip                                  | Working. This is the state to aim for.                                                                                                     |
+| All your organizations                                 | Nobody has chosen. It reaches every org this person belongs to — which is what breaks every call for anyone in more than one organization. |
+| No organization selected                               | Every organization has been cut off from this connection. It reaches nothing.                                                              |
+| An owner removed this one. Ask them to allow it again. | The organization stopped it, so the member cannot tick it back on. §4.1                                                                    |
+
+Consequences to state in the handover when they apply:
+
+- One connection per organization — someone working across two adds the connector twice (or
+  uses a second chat profile) and narrows each one.
+- An API key is pinned to one organization for its whole life, so a coding tool needs one
+  key per org.
+
+### 4.1 Who can undo a stop, and who cannot
+
+A stop records who made it, and that record alone decides who can lift it.
+
+- **The member stopped their own connection** — they lift it themselves by choosing that
+  organization again. It stays theirs: the organization can stop a connection, but it cannot
+  switch somebody's assistant back on for them.
+- **The organization stopped it** — an owner or admin lifts it from *Everyone's connections*
+  on the same page, where a **Stopped here** list shows what was stopped, by whom, and when,
+  with **Allow again**. It takes effect from the assistant's next request.
+- **Allowing back only ever reopens the organization doing the allowing**, and only for an
+  assistant whose owner has already chosen that organization — otherwise the page says *Its
+  owner has not chosen this organization* and does not offer it. Lifting a stop on a
+  connection nobody has chosen for would hand it every organization that person belongs to,
+  including ones this organization has no say over.
+- **Nobody can lift a stop somebody else aimed at them**, whatever their role.
+
+So a customer reporting "an owner removed this one" needs their own org's owner or admin,
+not a developer, and not a reconnect.
+
+Include the multi-org part of the handover **only** for people it actually applies to. For a
+single-org person it is noise that invites them to change a setting that is already right.
+
+## 5. Confirm — read-only
+
+Nothing below writes anything or spends anything.
+
+```bash
+infisical run --env=prod -- pnpm cli data orgs --env cloud
+```
+
+```bash
+infisical run --env=prod -- pnpm cli data members --env cloud
+```
+
+What a healthy result looks like:
+
+- `data orgs` — the new slug and name, with a member count of at least 1.
+- `data members` — the person's email against that org slug, with the role that was
+  intended (`owner` for a new org, `admin` for a joined one). One row per membership, so
+  this is also where a multi-org person shows up as two rows.
+- `infisical run --env=prod -- pnpm cli auth list-users --env cloud` — the account itself,
+  if the email needs checking. Both halves are needed here too; without them it reads the
+  local database and reports a healthy-looking absence.
+
+If the org row exists with a member count of 0, the membership did not land. Re-run the same
+`invite-admin` with `--allow-existing-org` — without it the slug that already exists aborts
+with `OrgSlugTaken` — rather than creating a second org under a new slug. The account is
+reused, and the role lands as `admin` rather than `owner`, because the org is no longer new.
+
+## 6. Hand over the getting-started message
+
+Read `references/handover-message.md`, fill the placeholders, and **print the finished
+message in the conversation** in English, ready to paste into an email or a chat. Do not
+write it to a file unless asked for one.
+
+Fill in: the organization name, the person's first name, `https://batuda.co`,
+`https://api.batuda.co/mcp`. Keep or drop the multi-organization block per §4.
+
+The message is customer-facing copy, so it follows `docs/brand-voice.md`:
+
+- One person speaking — "I", never "we".
+- No tool names and no jargon. The connection, not MCP. "Ask it to research", not
+  `start_research`.
+- Nothing from the banned list: solutions, leverage, empower, seamless, unlock.
+- Describe what they will see, not what the system does.
+
+If the customer's locale was set to `ca`, say so when handing the message over — the app and
+their email will be in Catalan even though this message is English.
+
+## Troubleshooting
+
+| Symptom                                    | Cause and fix                                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `UsersAlreadyExist`                        | `bootstrap-org` ran against a database that already has users. Use `invite-admin`.                                  |
+| `OrgSlugTaken`                             | The slug exists. Check for a typo; add `--allow-existing-org` only if joining it is the intent.                     |
+| The command refuses the host               | `--confirm-host` disagrees with the resolved `DATABASE_URL` — the target is not what was assumed. Re-read `doctor`. |
+| Customer says every request is refused     | Multi-organization connection. §4.                                                                                  |
+| Customer signed in but sees 403 everywhere | Signed in with no organization. Check `data members` for a membership row.                                          |
+
+## Additional resources
+
+- **`references/handover-message.md`** — the English getting-started message to fill in and
+  paste: connecting a chat, saving standing instructions, asking for research, and adding
+  companies and people.
+- `docs/getting-started.md` §5–6 — the local bootstrap path in full.
+- `pnpm cli auth --help` — the rest of the family (`list-users`, `promote`,
+  `reset-password`, `sessions`).

--- a/.claude/skills/onboard-org/references/handover-message.md
+++ b/.claude/skills/onboard-org/references/handover-message.md
@@ -1,0 +1,82 @@
+# The getting-started message
+
+The message a new organization's first admin receives once their account exists. English
+only. Print it in the conversation, filled in and ready to paste — never send it anywhere.
+
+Placeholders to replace:
+
+| Placeholder      | Value                                                    |
+| ---------------- | -------------------------------------------------------- |
+| `{{FIRST_NAME}}` | The person's first name                                  |
+| `{{ORG_NAME}}`   | The organization display name, exactly as it was created |
+| `{{APP_URL}}`    | `https://batuda.co`                                      |
+| `{{MCP_URL}}`    | `https://api.batuda.co/mcp`                              |
+
+Keep the **If you work in more than one place** section only when that person actually
+belongs to more than one organization (`pnpm cli data members`). Drop it otherwise.
+
+Trim rather than pad. If they only bought research, cut the companies-and-people section;
+if they are not connecting a chat yet, cut everything after sign-in and say so when handing
+the message over.
+
+---
+
+## The message
+
+Hi {{FIRST_NAME}},
+
+Your account is ready, and so is {{ORG_NAME}}. Here is everything you need for the first
+half hour.
+
+**Signing in.** Go to {{APP_URL}}/login and type your email address. You get a link back
+that signs you in — no password to remember or lose. The link lasts five minutes, so ask
+for it when you are ready to use it.
+
+**Connecting your chat.** This is the part that makes the difference: your own ChatGPT or
+Claude can read and write your customer data directly, in conversation. Add this address as
+a connector:
+
+{{MCP_URL}}
+
+- **ChatGPT** — Settings → Connectors → turn on Developer mode → add the address above and
+  choose OAuth. Needs a Plus, Pro, Business, Enterprise or Edu account.
+- **Claude.ai** — Settings → Connectors → Add custom connector → paste the address above.
+
+Either way it asks you to approve it once, in your own browser, with your own sign-in. If
+you also code, {{APP_URL}}/settings/mcp has ready-made snippets for Claude Code, Cursor, VS
+Code and the rest.
+
+**Telling it how you work.** Say your standing rules once and ask it to remember them:
+
+> "From now on, when you research a company, I only care about firms under 50 people in
+> Catalonia, and I always want the owner's email if you can find it. Save that."
+
+It keeps those rules and applies them to later work without being reminded. To see what it
+is following, just ask — *"what rules are you using for research?"* You can read or edit the
+same list at {{APP_URL}}/settings/organization/templates, shared with your team. A rule that
+is only yours lives at {{APP_URL}}/settings/profile/templates.
+
+**Asking it to research.** Name a company and say what you want to know:
+
+> "Research Forn Sant Jordi in Girona. Do they fit what I sell, and who decides?"
+
+It goes off and reads the company's own site, public records where a country keeps them, and
+the web. That takes a few minutes — you can keep working. It comes back with what it
+found and where each fact came from, and it never changes your records on its own: it
+proposes, you accept. The proposals are waiting for you under Research at {{APP_URL}}
+whenever you want to look.
+
+**Adding companies and people.** Plain language works:
+
+> "Add these three as prospects: Cal Met, Forn Sant Jordi, Vins del Ter. All bakeries in
+> Girona."
+
+> "Add Marta Puig as the owner at Cal Met, marta@calmet.cat."
+
+**If you work in more than one place.** An assistant works in one organization at a time.
+When you approve the connector it ticks every organization you belong to, and then nothing
+works until you choose. Go to {{APP_URL}}/settings/mcp/connections → **Change
+organizations** → tick just {{ORG_NAME}} → Save. If you need both, add the connector a
+second time and point that one at the other organization.
+
+**When something looks off**, tell me. Reply here and I will look at it the same day.


### PR DESCRIPTION
## What

Setting up a new customer has only ever existed in my head. Nothing in the product creates an organization — public signup is off, so a customer's first admin exists only because I ran a command-line tool against the production database — and every time I did it I re-derived the same order of steps and re-checked the same guard rails. This writes that down once, as a skill: an instruction file Claude Code loads when the work comes up, so the sequence is followed the same way each time instead of being remembered.

It covers the whole arc: create the organization and its first admin, confirm it actually landed, and hand the customer the message that gets them working in their own ChatGPT or Claude. It sits across the Auth context (`packages/auth`, `apps/cli`) and the connection surface a customer lands on afterwards.

## Changes

- **The sequence, in four steps** — rehearse against the local database, create in production, confirm read-only, hand over. Two reference sections sit in between for the questions that come up rather than as steps to work through.
- **Why the production command looks the way it does** — that `infisical run` supplies the secrets and `--env cloud` the settings, and that neither substitutes for the other; that `--confirm-host` is read from a row only the cloud health check prints; and that against a remote database nothing is emailed and no sign-in link is minted, because a link nobody asked for sits in a mailbox as a working way into the account.
- **How people actually join** — the command-line tool only ever makes an owner or an admin. Everyone else is added by the customer's own admin from a form in the app, and the skill says to hand that over rather than run it for them.
- **The one-organization-per-connection rule** — an assistant reaches exactly one organization per request, anyone belonging to several is refused by default until they narrow it, and no chat client can name one per call. Plus who can undo a stop and who cannot, which changed twice this week (#359 and `37d2b03`).
- **The customer's getting-started message** — a fill-in template covering signing in, connecting the chat, saving standing rules, asking for research, and adding companies and people, each with a sentence they can actually say. English, house voice, with the multi-organization paragraph marked to drop for people it does not apply to.

## Impact

No code, no schema, no environment variable, no wire shape — two markdown files nothing imports. Nothing to deploy, and nothing that can break at runtime.

Worth naming anyway, because the content touches boundaries even though the diff does not: it **describes** a security boundary rather than moving one (who may create an organization, who may add a member, which organization an assistant reaches), so if any of it is wrong the failure mode is a developer confidently doing the wrong thing by hand. That is what the review below is for.

## Review guide

- **Read §4 and §4.1 of `SKILL.md` first.** They are the likeliest to be wrong: the rules changed twice in the last few days, and I had already written the old answer ("an owner's removal is permanent") before `37d2b03` landed and made it lift-able. Everything else is stable ground.
- **The claims are checkable.** I ran the live CLI for every flag and read the current source for every quoted product string, rather than writing from memory — see Verification. If a sentence reads as too confident, it is meant to be, but tell me and I will soften it.
- **The handover message is customer copy**, so judge it on voice, not precision: first person singular, no tool names, nothing from the banned list in `docs/brand-voice.md`.
- **Decisions you might overrule**, both of which I would rather you correct now than discover in front of a customer: the handover is English only even when the customer's language is set to Catalan (the app and their email will be Catalan; only this message is not), and I kept the runbook to organization, members and connection — see Deferred for what I left out.
- **Skip** the placeholder table at the top of the reference file; it is mechanical.

## Verification

- Ran `pnpm cli auth invite-admin --help`, `pnpm cli data --help` and `pnpm cli doctor` against the live CLI. Every flag, entity and check the skill names exists as documented — including that the host row it tells you to read is cloud-only, which is why the skill now names it rather than saying "read it from doctor".
- Checked every file path the skill points at and every product string it quotes against this branch's tree — 11 paths, 8 strings, all resolve.
- Corrected one instruction that would have failed: the recovery step said to re-run `invite-admin` because it reuses the organization. It does not — `invite-admin.ts:76` aborts on an existing slug unless `--allow-existing-org` is passed, and a reader following the old sentence would have hit that error and possibly created a second organization.
- Pre-commit hooks green: `check-deps`, `check-types` (13/13 packages), `format-markdown`, `format-packages`, `lint`.
- **Did not run** `pnpm -w test` or `pnpm -w build`. The branch adds two markdown files under `.claude/skills/`, no manifest or lockfile changed, and nothing imports them — the outcome cannot differ from `main`. CI runs them regardless.
- No user interface change, so no screenshots.

## Deferred

- The organization's monthly research ceiling, the auto-apply confidence threshold, and connecting its mailbox are all part of a full setup but not of this one. Keeping the runbook short is what makes it get followed; each of those is worth its own section once I have done it enough times to know the order.
- `§5`'s third bullet is a command sitting under "what a healthy result looks like". It reads fine and fixing it properly means restructuring the list, so I left it.
