### PR TITLE
test: stop the mail tests reading and waiting on the wrong things

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -53,6 +53,7 @@ import { withDb } from './db'
 import { requireLocalDatabase } from './lib/confirm-cloud'
 import { appendEnvKeys, resetEnvFile } from './lib/env-file'
 import { loadEnv } from './lib/load-env'
+import { emailClear } from './lib/mail-catcher'
 import { recoveryHint } from './lib/recovery-hint'
 
 // ── Seed ───────────────────────────────────────────────────
@@ -252,7 +253,7 @@ const dbResetCommand = Command.make('reset', {}, () =>
 ).pipe(
 	Command.withShortDescription('Drop schema + re-run migrations'),
 	Command.withDescription(
-		'Drop the public schema, re-run migrations, and purge the mail catcher (no seed; chain `seed` for sample data)',
+		'Drop the public schema and re-run migrations (no seed; chain `seed` for sample data). Leaves the mail catcher alone — it is shared with every checkout; empty it with `email clear` if you mean to',
 	),
 )
 
@@ -876,7 +877,10 @@ const emailInjectCommand = Command.make(
 		),
 		from: Flag.string('from').pipe(
 			Flag.withDescription('Sender address (any value works locally)'),
-			Flag.withFallbackPrompt(Prompt.text({ message: 'From:' })),
+			// The catcher accepts any sender, so there is nothing here only a person
+			// could answer — and asking would leave a script or an agent waiting
+			// forever at a prompt it cannot see.
+			Flag.withDefault('dev@batuda.test'),
 		),
 		subject: Flag.string('subject').pipe(
 			Flag.withDescription('Subject line'),
@@ -921,11 +925,20 @@ const emailInjectCommand = Command.make(
 	),
 )
 
+const emailClearCommand = Command.make('clear', {}, () => emailClear).pipe(
+	Command.withShortDescription(
+		'Empty the mail catcher (affects every checkout)',
+	),
+	Command.withDescription(
+		'Discard every message the mail catcher is holding. One catcher serves every checkout on this machine, so this empties it for all of them — nothing else does it for you, because the catcher cannot empty one mailbox at a time',
+	),
+)
+
 const emailCommand = Command.make('email').pipe(
 	Command.withDescription(
-		'Email: inject canned messages into the mail catcher',
+		'Email: inject canned messages into the mail catcher, or empty it',
 	),
-	Command.withSubcommands([emailInjectCommand]),
+	Command.withSubcommands([emailInjectCommand, emailClearCommand]),
 )
 
 // ── Research ───────────────────────────────────────────────

--- a/apps/cli/src/lib/mail-catcher.ts
+++ b/apps/cli/src/lib/mail-catcher.ts
@@ -1,0 +1,33 @@
+import { Config, Console, Effect } from 'effect'
+
+/**
+ * Empty the dev mail catcher — every mailbox, for every checkout on this
+ * machine.
+ *
+ * There is no way to empty a single mailbox: the one narrower thing the catcher
+ * offers is deleting an account, which cuts the connection every running server
+ * and mail worker holds open and cannot be put back from the catcher itself.
+ *
+ * So this is a command to run on purpose, never a step folded into another one.
+ * Nothing needs it to pass: each test finds its own messages by name.
+ */
+export const emailClear = Effect.gen(function* () {
+	const url = yield* Config.string('MAIL_CATCHER_HTTP_URL')
+	yield* Console.log(
+		'Emptying the mail catcher. It is shared, so this discards captured mail for every checkout on this machine.',
+	)
+	yield* Effect.tryPromise({
+		try: async () => {
+			const response = await fetch(`${url}/api/mail/purge`, {
+				method: 'POST',
+				signal: AbortSignal.timeout(5_000),
+			})
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}`)
+			}
+		},
+		catch: error =>
+			new Error(error instanceof Error ? error.message : String(error)),
+	})
+	yield* Console.log(`✓ Mail catcher emptied (${url}).`)
+})

--- a/apps/cli/src/lib/smtp-inject.ts
+++ b/apps/cli/src/lib/smtp-inject.ts
@@ -54,7 +54,6 @@ export const injectViaSmtp = (
 				secure: false,
 				requireTLS: false,
 				auth: undefined,
-				tls: { rejectUnauthorized: false },
 			})
 			try {
 				const result = await transport.sendMail({

--- a/apps/internal/tests/e2e/attachment.test.ts
+++ b/apps/internal/tests/e2e/attachment.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 
 import { expect, test } from '@playwright/test'
 
+import { openCompose } from './helpers/compose'
 import { DATABASE_URL } from './helpers/database-url'
 import { getMessage, waitForMessage } from './helpers/mail-catcher'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
@@ -76,16 +77,8 @@ test.describe('compose with attachment', () => {
 			const filename = `${testId}.pdf`
 
 			// GIVEN compose is open and the form is fillable
-			// Wait for hydration before clicking the open button. `goto`'s
-			// default `load` event fires before TanStack Start finishes
-			// streaming + hydrating, so the click can land on the not-yet-
-			// wired form action and the SSR replay buffer occasionally
-			// misses it on hot-rebuilt dev bundles.
 			await page.goto('/emails', { waitUntil: 'networkidle' })
-			await page.getByTestId('emails-compose').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible({
-				timeout: 15_000,
-			})
+			await openCompose(page, 'emails-compose')
 			await page.getByTestId('compose-to').fill(recipient)
 			await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
 			await fillBody(page, `Body ${testId}`)
@@ -110,7 +103,9 @@ test.describe('compose with attachment', () => {
 			await page.getByTestId('compose-send').click()
 
 			// THEN the catcher receives the message with the attachment metadata
-			const summary = await waitForMessage(recipient)
+			const summary = await waitForMessage(recipient, {
+				subject: `Subj ${testId}`,
+			})
 			const detail = await getMessage(summary)
 			const att = detail.Attachments.find(a => a.FileName === filename)
 			expect(att, 'attachment present on catcher message').toBeDefined()
@@ -125,16 +120,8 @@ test.describe('compose with attachment', () => {
 			const recipient = `${testId}@catcher.local`
 			const filename = `${testId}.pdf`
 
-			// Wait for hydration before clicking the open button. `goto`'s
-			// default `load` event fires before TanStack Start finishes
-			// streaming + hydrating, so the click can land on the not-yet-
-			// wired form action and the SSR replay buffer occasionally
-			// misses it on hot-rebuilt dev bundles.
 			await page.goto('/emails', { waitUntil: 'networkidle' })
-			await page.getByTestId('emails-compose').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible({
-				timeout: 15_000,
-			})
+			await openCompose(page, 'emails-compose')
 			await page.getByTestId('compose-to').fill(recipient)
 			await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
 			await fillBody(page, `Body ${testId}`)
@@ -153,7 +140,7 @@ test.describe('compose with attachment', () => {
 
 			// Wait for the send to land in the catcher before reading the
 			// staging row — the post-send purge runs after the SMTP ack.
-			await waitForMessage(recipient)
+			await waitForMessage(recipient, { subject: `Subj ${testId}` })
 
 			// THEN the staging row is gone — markSentAndCleanup deletes it
 			// immediately after the provider acks (see

--- a/apps/internal/tests/e2e/footer.test.ts
+++ b/apps/internal/tests/e2e/footer.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 
 import { expect, test } from '@playwright/test'
 
+import { openCompose } from './helpers/compose'
 import { DATABASE_URL } from './helpers/database-url'
 import {
 	getMessage,
@@ -100,8 +101,7 @@ test.describe('compose with footer', () => {
 
 			// WHEN Alice sends a brand-new email
 			await page.goto('/emails')
-			await page.getByTestId('emails-compose').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await openCompose(page, 'emails-compose')
 			await page.getByTestId('compose-to').fill(recipient)
 			await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
 			await fillBody(page, `Body ${testId}`)
@@ -111,7 +111,9 @@ test.describe('compose with footer', () => {
 			// THEN the catcher's parsed text body and the raw wire bytes both
 			// contain the footer marker — proves the server appended the
 			// footer before serializing.
-			const summary = await waitForMessage(recipient)
+			const summary = await waitForMessage(recipient, {
+				subject: `Subj ${testId}`,
+			})
 			const detail = await getMessage(summary)
 			expect(detail.Text).toContain(footerMarker)
 

--- a/apps/internal/tests/e2e/helpers/compose.ts
+++ b/apps/internal/tests/e2e/helpers/compose.ts
@@ -1,0 +1,23 @@
+import { expect, type Page } from '@playwright/test'
+
+import { waitForInteractive } from './hydration'
+
+/**
+ * Open the compose window from whichever control opens it — the button on the
+ * mail list, Reply on a thread, or the action on a company.
+ *
+ * The wait has to come before the click. The control is drawn by the server and
+ * is clickable long before the code behind it arrives, so a click sent too early
+ * lands on nothing and the window never opens; waiting afterwards cannot rescue
+ * a click that is already gone.
+ */
+export async function openCompose(page: Page, trigger: string): Promise<void> {
+	await waitForInteractive(page, trigger)
+	await page.getByTestId(trigger).click()
+
+	// Generous, because on a development build the window's own code is built the
+	// first time something asks for it.
+	await expect(page.getByTestId('compose-form')).toBeVisible({
+		timeout: 15_000,
+	})
+}

--- a/apps/internal/tests/e2e/helpers/mail-catcher.ts
+++ b/apps/internal/tests/e2e/helpers/mail-catcher.ts
@@ -1,6 +1,8 @@
 // Tiny client over the dev mail-catcher's REST API (GreenMail). The dev
 // compose service exposes it at host :8025; specs poll it to assert what the
-// server actually wrote to the SMTP socket, and purge it between tests.
+// server actually wrote to the SMTP socket. Nothing here empties it: one
+// catcher serves every checkout on this machine, and it can only be emptied
+// whole. `pnpm cli email clear` does that when you mean to.
 // Override MAIL_CATCHER_HTTP_URL to point at a remote dev stack.
 
 import { simpleParser } from 'mailparser'
@@ -50,13 +52,24 @@ async function listMessages(
 	return body.map(m => ({ Subject: m.subject, mimeMessage: m.mimeMessage }))
 }
 
+// How a caller names the message it is waiting for: one of the two is required.
+// A mailbox keeps what earlier runs delivered to it, and the catcher is shared
+// with every other checkout on this machine, so "the first message" is easily
+// somebody else's.
+type MessageIdentifier =
+	| { subject: string; bodyContains?: string }
+	| { subject?: string; bodyContains: string }
+
 // Wait for a message this test can prove is its own.
 //
-// Say which one with `subject`, or with `bodyContains` where the subject is not
-// the test's to choose — a reply inherits its parent's. Say nothing and you get
-// whichever message happens to be first, which on a machine running more than
-// one checkout may belong to somebody else: the catcher is shared, and a
-// mailbox keeps what earlier runs delivered to it.
+// Name it by `subject`, or by `bodyContains` where the subject is not the
+// test's to choose — a reply inherits its parent's.
+export async function waitForMessage(
+	recipient: string,
+	options: MessageIdentifier & { timeoutMs?: number; pollMs?: number },
+): Promise<CatcherMessage>
+// Both names stay optional in the implementation, so a call that skips them
+// reaches the explanation below instead of failing on a missing argument.
 export async function waitForMessage(
 	recipient: string,
 	{
@@ -71,18 +84,26 @@ export async function waitForMessage(
 		pollMs?: number
 	} = {},
 ): Promise<CatcherMessage> {
+	// Checked at run time as well: nothing type-checks this folder, so the
+	// signature above only guides the editor.
+	if (!subject && !bodyContains) {
+		throw new Error(
+			`mail-catcher: say which message you are waiting for on "${recipient}" — pass a subject, or bodyContains where the subject is not yours to choose. The mailbox also holds what earlier runs, and other checkouts on this machine, delivered to it.`,
+		)
+	}
+
 	const deadline = Date.now() + timeoutMs
 	let lastError: unknown = null
+	// Read the same way the check above reads them, so a name given as an empty
+	// string is ignored rather than matched against — which would find nothing
+	// and time out instead of saying what was wrong.
 	const isWanted = (m: CatcherMessage) =>
-		(subject === undefined || m.Subject === subject) &&
-		(bodyContains === undefined || m.mimeMessage.includes(bodyContains))
+		(!subject || m.Subject === subject) &&
+		(!bodyContains || m.mimeMessage.includes(bodyContains))
 	while (Date.now() < deadline) {
 		try {
 			const messages = await listMessages(recipient)
-			const match =
-				subject === undefined && bodyContains === undefined
-					? messages[0]
-					: messages.find(isWanted)
+			const match = messages.find(isWanted)
 			if (match) return match
 		} catch (err) {
 			lastError = err
@@ -104,6 +125,14 @@ export async function expectNoMessage(
 	subject: string,
 	windowMs = 1_500,
 ): Promise<void> {
+	// An empty subject matches nothing, so the check would pass without having
+	// proved anything.
+	if (!subject) {
+		throw new Error(
+			`mail-catcher: name the message that must not arrive for "${recipient}" — an unnamed check on a shared mailbox proves nothing.`,
+		)
+	}
+
 	await new Promise(resolve => setTimeout(resolve, windowMs))
 	const messages = await listMessages(recipient)
 	const arrived = messages.filter(m => m.Subject === subject)

--- a/apps/internal/tests/e2e/inbox-listing.test.ts
+++ b/apps/internal/tests/e2e/inbox-listing.test.ts
@@ -55,10 +55,18 @@ test.describe('emails inbox listing', () => {
 				expected === 1 ? '1 thread' : `${expected} threads`,
 			)
 
-			// AND the seeded threads are among the rows actually drawn
+			// AND rows are actually drawn
 			await expect(
 				page.locator('[data-testid^="thread-row-"]').first(),
 			).toBeVisible()
+
+			// AND a known thread can be reached. Searched for rather than looked
+			// for on screen: the list only draws the rows that fit, so an older
+			// thread sits below the fold and is not there to find — which is the
+			// same trap as counting rows, one step further along.
+			await page
+				.getByTestId('emails-search')
+				.fill('Quote for the booking module')
 			await expect(page.getByText('Quote for the booking module')).toBeVisible()
 		})
 	})

--- a/apps/internal/tests/e2e/reply.test.ts
+++ b/apps/internal/tests/e2e/reply.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 
 import { expect, test } from '@playwright/test'
 
+import { openCompose } from './helpers/compose'
 import { DATABASE_URL } from './helpers/database-url'
 import { getRawMessage, waitForMessage } from './helpers/mail-catcher'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
@@ -66,8 +67,7 @@ test.describe('reply on a seeded thread', () => {
 			await page.goto(`/emails/${threadId}`, { waitUntil: 'networkidle' })
 
 			// WHEN Alice clicks Reply and sends a body via the compose form
-			await page.getByTestId('thread-reply').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await openCompose(page, 'thread-reply')
 			const body = `e2e reply ${Date.now()}`
 			await fillBody(page, body)
 			await expect(page.getByTestId('compose-send')).toBeEnabled()
@@ -75,9 +75,9 @@ test.describe('reply on a seeded thread', () => {
 
 			// THEN the catcher captures the reply, and the raw RFC822 carries
 			// In-Reply-To + References pointing at the parent's Message-Id.
-			// Found by its body: a reply's subject comes from the parent, so every
-			// run of this test — and every other checkout on this machine — would
-			// answer to it.
+			// Found by its body: a reply takes the parent's subject, so a subject
+			// match would also answer with every earlier run's reply, and with any
+			// other checkout's on this machine.
 			const summary = await waitForMessage('pep@calpepfonda.cat', {
 				bodyContains: body,
 				timeoutMs: 10_000,
@@ -105,8 +105,7 @@ test.describe('reply on a seeded thread', () => {
 			await page.goto(`/emails/${threadId}`, { waitUntil: 'networkidle' })
 
 			// WHEN Alice clicks Reply all and sends
-			await page.getByTestId('thread-reply-all').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await openCompose(page, 'thread-reply-all')
 			const body = `e2e reply-all ${Date.now()}`
 			await fillBody(page, body)
 			await expect(page.getByTestId('compose-send')).toBeEnabled()

--- a/apps/internal/tests/e2e/rich-compose.test.ts
+++ b/apps/internal/tests/e2e/rich-compose.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 
 import { expect, test } from '@playwright/test'
 
+import { openCompose } from './helpers/compose'
 import { DATABASE_URL } from './helpers/database-url'
 import {
 	getMessage,
@@ -50,8 +51,7 @@ test.describe('compose with rich formatting', () => {
 
 			// WHEN Alice opens compose and types a rich body
 			await page.goto('/emails')
-			await page.getByTestId('emails-compose').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await openCompose(page, 'emails-compose')
 			await page.getByTestId('compose-to').fill(recipient)
 			await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
 
@@ -92,7 +92,9 @@ test.describe('compose with rich formatting', () => {
 			// THEN the decoded html part carries the formatting. The brand
 			// renderer emits inline-styled spans, not <strong> or bare <ul>:
 			// bold is a font-weight span, list rows wrap their text in <span>.
-			const summary = await waitForMessage(recipient)
+			const summary = await waitForMessage(recipient, {
+				subject: `Subj ${testId}`,
+			})
 			const html = (await getMessage(summary)).Html
 			expect(html).toMatch(/<span style="font-weight:\s*700">Hello<\/span>/i)
 			expect(html).toMatch(/<ul[^>]*>/i)
@@ -109,8 +111,7 @@ test.describe('compose with rich formatting', () => {
 			const recipient = `${testId}@catcher.local`
 
 			await page.goto('/emails')
-			await page.getByTestId('emails-compose').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await openCompose(page, 'emails-compose')
 			await page.getByTestId('compose-to').fill(recipient)
 			await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
 
@@ -120,7 +121,9 @@ test.describe('compose with rich formatting', () => {
 
 			await page.getByTestId('compose-send').click()
 
-			const summary = await waitForMessage(recipient)
+			const summary = await waitForMessage(recipient, {
+				subject: `Subj ${testId}`,
+			})
 			const raw = getRawMessage(summary)
 			// A text/plain part is the baseline for any nodemailer-emitted
 			// message; if this regresses, the rich path probably stopped

--- a/apps/internal/tests/e2e/send-email.test.ts
+++ b/apps/internal/tests/e2e/send-email.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 
 import { expect, test } from '@playwright/test'
 
+import { openCompose } from './helpers/compose'
 import { DATABASE_URL } from './helpers/database-url'
 import { expectNoMessage, waitForMessage } from './helpers/mail-catcher'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
@@ -57,17 +58,16 @@ test.describe('compose and send via the mail catcher', () => {
 		test("should write the message to the catcher's inbox (poll until present)", async ({
 			page,
 		}) => {
-			// A recipient and subject nobody else uses. The catcher is shared with
-			// every other checkout on this machine and keeps what earlier runs
-			// delivered, so this is what makes the lookup below say something.
+			// GIVEN a recipient and subject nobody else uses — the catcher is shared
+			// with every checkout on this machine and keeps what earlier runs
+			// delivered, so only a unique pair makes the lookup below mean anything.
 			const testId = `e2e-${Date.now()}`
 			const recipient = `${testId}@catcher.local`
 			const subject = `Test ${testId}`
 
 			// WHEN Alice opens compose, fills the form, and clicks Send
 			await page.goto('/emails')
-			await page.getByTestId('emails-compose').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await openCompose(page, 'emails-compose')
 			await page.getByTestId('compose-to').fill(recipient)
 			await page.getByTestId('compose-subject').fill(subject)
 			await fillBody(page, `Hello from e2e ${testId}`)
@@ -75,7 +75,7 @@ test.describe('compose and send via the mail catcher', () => {
 			await page.getByTestId('compose-send').click()
 
 			// THEN the mail catcher receives the message within the polling window
-			const msg = await waitForMessage(recipient)
+			const msg = await waitForMessage(recipient, { subject })
 			expect(msg.Subject).toBe(subject)
 		})
 
@@ -86,8 +86,7 @@ test.describe('compose and send via the mail catcher', () => {
 			const recipient = `${testId}@catcher.local`
 
 			await page.goto('/emails')
-			await page.getByTestId('emails-compose').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible()
+			await openCompose(page, 'emails-compose')
 			await page.getByTestId('compose-to').fill(recipient)
 			await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
 			await fillBody(page, `Body ${testId}`)
@@ -95,7 +94,7 @@ test.describe('compose and send via the mail catcher', () => {
 
 			// Wait for the catcher to confirm the round-trip before checking the
 			// UI — eliminates the "did the click do nothing?" failure mode.
-			await waitForMessage(recipient)
+			await waitForMessage(recipient, { subject: `Subj ${testId}` })
 			await expect(page.getByTestId('compose-window')).toBeHidden({
 				timeout: 5_000,
 			})
@@ -123,19 +122,11 @@ test.describe('compose and send via the mail catcher', () => {
 			// GIVEN Alice opens compose from Pep Casals' company so SuppressionGuard
 			// has a companyId to query against
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
-			// Wait for hydration so the click lands on the wired action, and give
-			// the compose dialog room to mount on a cold dev bundle (mirrors the
-			// attachment spec's rationale).
-			await expect(page.getByTestId('action-compose-email')).toBeEnabled()
-			await page.getByTestId('action-compose-email').click()
-			await expect(page.getByTestId('compose-form')).toBeVisible({
-				timeout: 15_000,
-			})
+			await openCompose(page, 'action-compose-email')
 
-			// WHEN Alice puts the suppressed contact in `to`. The subject is made
-			// unique so the check below can name the message that must not arrive;
-			// that mailbox holds what earlier runs, and other checkouts on this
-			// machine, have already delivered to it.
+			// WHEN Alice puts the suppressed contact in `to`, under a subject unique
+			// to this run so the check below can name the message that must not
+			// arrive.
 			const blockedSubject = `blocked send ${Date.now()}`
 			await page.getByTestId('compose-to').fill(SUPPRESSED_EMAIL)
 			await page.getByTestId('compose-subject').fill(blockedSubject)


### PR DESCRIPTION
## What

Five ways the email tests could go wrong for reasons that had nothing to do with the code under review — plus two command-line tools that behaved badly when nothing was watching.

The theme: a test that reads something it does not control, or waits for something that already happened, fails in a way that looks like a broken feature. That is expensive, because it teaches everyone to scroll past a red result.

This is the CRM's web app (`internal`) — its end-to-end tests and one test hook — and the command-line tool (`cli`).

## The fix

**Asking for "the first message" could read another checkout's mail.** One mail catcher serves every copy of the project on the machine, and a mailbox keeps whatever earlier runs delivered to it. A lookup that named nothing took whatever was on top of that pile. Naming the wanted message is now required — by the signature, and again when the test runs, because nothing type-checks that folder and a signature alone would never have stopped anything.

**The compose window sometimes never opened.** The button is drawn by the server and is clickable well before the code behind it arrives, so a click sent too early did nothing at all. Every test that opens compose now waits for the button to come alive first. My first attempt was to wait *longer afterwards*, which did not work and could not have: once the click is gone, no amount of waiting brings the window.

**The inbox test looked on screen for a thread that had scrolled away.** The list only builds the rows that fit, so a named thread drops out of sight as other tests add newer ones. It searches for the thread now.

**Emptying the catcher is a deliberate act again.** Nothing does it automatically any more, so `pnpm cli email clear` exists — and says, in its help and as it runs, that it discards mail for every copy of the project.

**Injecting a message stopped to ask who it was from.** An invisible prompt, so a script or an agent waited forever. It has a sender by default now, as the options beside it already did.

## Impact

- **No product behaviour changes.** The only non-test edits are two test hooks on elements the emails page already rendered, and the command-line changes.
- **`pnpm cli email clear` empties the catcher for every checkout.** That is the point, and it says so, but it is worth knowing before running it while a colleague — or another of your own worktrees — is mid-test.
- **No migration, no environment variables, nothing sent over the wire, nothing touching who can see what.**

## Review guide

**Read the third fix first.** It corrects a bug in a change I merged earlier today, so the flaw is live on `main` right now: the inbox test asserts a named thread is on screen, and that assertion fails once the thread count passes a screenful. I fixed the row-count assertion in that change and then reintroduced the same mistake one line below it — asserting on what the browser happened to draw rather than on what the page knows.

The second thing worth your attention is in `apps/internal/tests/e2e/helpers/mail-catcher.ts`: the guard is enforced **twice**, once in the types and once at run time. That looks redundant and is not. `apps/internal/tsconfig.json` includes only `src`, `tsconfig.node.json` only the browser-test config, and the test runner transpiles without checking types — so nothing type-checks that folder at all. A types-only guard would have been decorative. I found this by writing one and watching it fail to fire.

One decision you might overrule, and one thing I chose not to fix:

- **Opening compose can wait up to 45 seconds** (30 for the page to come alive, 15 for the window) inside a 30-second budget per test, so the last stretch is unreachable. It fails loudly rather than wrongly, but the numbers overpromise. Fixing it means either a shorter wait or a longer budget, and that is your call.
- **Copies of the project still share mailbox names.** They no longer destroy each other's mail and no longer read it by accident, but two copies still deliver to the same address. Giving each its own would mean rewriting the sign-in identity across the suite; I measured the remaining exposure as one test that never runs, so I stopped.

Skip-able: the mechanical switch of ten call sites onto the new helper.

## Screenshots

Nothing to show — no rendered output changes.

## Verification

Run on this branch after rebasing onto current `main`, which had moved 7 commits — every gate below was re-run after the rebase, not before:

- **The full browser suite: 120 passed, 0 failed.**
- **The inbox fix proven against the state that breaks it:** with the database holding **28 threads** against a sample data of 7, all four inbox tests pass. On a fresh database the old assertion also passes, so a clean run proves nothing here — that is why it was worth building the broken state on purpose.
- **The mail specs run three times back to back:** 13 passed each. Before this, the same specs failed a different one each time.
- **Every refusal path exercised**, including the one my first guard missed: omitting the argument entirely used to pass the check vacuously, because a subject of nothing matches nothing.
- **Both command fixes run:** the clear command took a mailbox from one message to none; the inject command exits on its own and delivers, where it previously sat at a prompt.
- `pnpm install` → `pnpm -w check-types` (13/13) + `pnpm -w test` (21/21) → `pnpm -w build` (13/13), and `pnpm exec biome check .` clean.

## Deferred

- **Copies of the project share mailbox names**, as above.
- **Nothing clears the catcher automatically.** It holds everything in memory, so a restart is the other reset.
