### PR TITLE
feat: describe mailboxes freely and decide access from who owns them

### DIFF
--- a/apps/cli/src/commands/seed/inboxes.ts
+++ b/apps/cli/src/commands/seed/inboxes.ts
@@ -10,7 +10,8 @@ interface InboxSpec {
 	readonly displayName: string
 	readonly ownerEmail: string
 	readonly orgId: string
-	readonly purpose: 'human' | 'agent'
+	// What the mailbox is for, in the words its owner would use.
+	readonly description: string
 	readonly isDefault: boolean
 	readonly footerText: string
 	readonly grantStatus:
@@ -55,7 +56,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 				displayName: 'Alice Admin',
 				ownerEmail: 'admin@taller.cat',
 				orgId: tallerOrgId,
-				purpose: 'human',
+				description: 'Customer enquiries',
 				isDefault: true,
 				footerText: '— Alice Admin\nTaller Demo · taller.cat',
 				grantStatus: 'connected',
@@ -66,7 +67,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 				displayName: 'Alice Agent',
 				ownerEmail: 'admin@taller.cat',
 				orgId: tallerOrgId,
-				purpose: 'agent',
+				description: 'Replies drafted for me to check',
 				isDefault: false,
 				footerText: "Automated response from Alice's agent.",
 				grantStatus: 'connected',
@@ -78,7 +79,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 				displayName: 'Taller Alerts (auth failed)',
 				ownerEmail: 'admin@taller.cat',
 				orgId: tallerOrgId,
-				purpose: 'human',
+				description: 'Alerts from the workshop machines',
 				isDefault: false,
 				footerText: '— Taller Demo',
 				grantStatus: 'auth_failed',
@@ -89,7 +90,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 				displayName: 'Taller Noreply (connect failed)',
 				ownerEmail: 'admin@taller.cat',
 				orgId: tallerOrgId,
-				purpose: 'human',
+				description: 'Notices nobody should reply to',
 				isDefault: false,
 				footerText: '— Taller Demo',
 				grantStatus: 'connect_failed',
@@ -100,7 +101,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 				displayName: 'Taller Archive (disabled)',
 				ownerEmail: 'admin@taller.cat',
 				orgId: tallerOrgId,
-				purpose: 'human',
+				description: 'Old post kept for reference',
 				isDefault: false,
 				footerText: '— Taller Demo',
 				grantStatus: 'disabled',
@@ -114,7 +115,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 					displayName: 'Bob Owner',
 					ownerEmail: 'admin@restaurant.demo',
 					orgId: restaurantOrgId,
-					purpose: 'human',
+					description: 'Bookings and guest questions',
 					isDefault: true,
 					footerText: '— Bob Owner\nRestaurant Demo',
 					grantStatus: 'connected',
@@ -125,7 +126,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 					displayName: 'Bob Agent',
 					ownerEmail: 'admin@restaurant.demo',
 					orgId: restaurantOrgId,
-					purpose: 'agent',
+					description: 'Replies drafted for me to check',
 					isDefault: false,
 					footerText: "Automated response from Bob's agent.",
 					grantStatus: 'connected',
@@ -183,7 +184,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 					organizationId: spec.orgId,
 					email: spec.email,
 					displayName: spec.displayName,
-					purpose: spec.purpose,
+					description: spec.description,
 					ownerUserId: ownerId,
 					isDefault: spec.isDefault,
 					isPrivate: false,
@@ -217,7 +218,7 @@ export const seedInboxes = ({ sql, tallerOrgId, restaurantOrgId }: SeedCtx) =>
 				})}
 			`
 			yield* Effect.logInfo(
-				`  inbox: ${spec.email} (${spec.purpose}, owner ${ownerId})`,
+				`  inbox: ${spec.email} (${spec.description}, owner ${ownerId})`,
 			)
 			seededInboxes.push({
 				id: inboxId,

--- a/apps/cli/src/commands/seed/reset.ts
+++ b/apps/cli/src/commands/seed/reset.ts
@@ -4,7 +4,8 @@ import { SqlClient } from 'effect/unstable/sql'
 export const seedReset = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient
 	yield* Effect.logInfo('Truncating CRM tables...')
-	// DELETE (not TRUNCATE CASCADE) so `member.primary_inbox_id`'s ON DELETE SET NULL fires.
+	// DELETE rather than TRUNCATE CASCADE: threads and messages point at
+	// mailboxes, and cascading would take the history with them.
 	yield* sql`DELETE FROM inboxes`
 	// Removals go too: they outlive the choice they sit on, so one left behind
 	// would keep cutting a freshly seeded connection off from an organization.

--- a/apps/internal/src/atoms/emails-atoms.ts
+++ b/apps/internal/src/atoms/emails-atoms.ts
@@ -11,7 +11,6 @@ export type EmailsSearch = {
 	readonly inboxId?: string
 	readonly companyId?: string
 	readonly status?: 'open' | 'closed' | 'archived'
-	readonly purpose?: 'human' | 'agent' | 'shared'
 	readonly query?: string
 	readonly limit?: number
 	readonly offset?: number
@@ -31,7 +30,6 @@ function makeListAtom(search: EmailsSearch) {
 		query['companyId'] = search.companyId
 	}
 	if (search.status !== undefined) query['status'] = search.status
-	if (search.purpose !== undefined) query['purpose'] = search.purpose
 	if (search.query !== undefined && search.query !== '') {
 		query['query'] = search.query
 	}
@@ -62,7 +60,6 @@ export function canonicalKey(search: EmailsSearch): string {
 		entries.push(['companyId', search.companyId])
 	}
 	if (search.status !== undefined) entries.push(['status', search.status])
-	if (search.purpose !== undefined) entries.push(['purpose', search.purpose])
 	if (search.query !== undefined && search.query !== '') {
 		entries.push(['query', search.query])
 	}
@@ -76,7 +73,10 @@ export function canonicalKey(search: EmailsSearch): string {
 }
 
 export const inboxesListAtom = BatudaApiAtom.query('email', 'listInboxes', {
-	query: {},
+	// Removed mailboxes keep their row so old threads still resolve through
+	// them, but they are gone as far as anyone managing mailboxes is
+	// concerned — otherwise removing one looks like it did nothing.
+	query: { active: 'true' },
 	serializationKey: 'email:inboxes',
 })
 

--- a/apps/internal/src/atoms/inbox-draft-atoms.ts
+++ b/apps/internal/src/atoms/inbox-draft-atoms.ts
@@ -14,15 +14,16 @@ import { Atom } from 'effect/unstable/reactivity'
  * (rather than imported from the route) to keep this atom free of UI imports.
  */
 
-type InboxPurpose = 'human' | 'agent' | 'shared'
 type TransportSecurity = 'tls' | 'starttls' | 'plain'
 
 export type InboxDraft = {
 	readonly email: string
 	readonly displayName: string
-	readonly purpose: InboxPurpose
+	readonly description: string
+	// Set up for the whole team rather than one person, which leaves it
+	// without an owner and so neither private nor anybody's default.
+	readonly shared: boolean
 	readonly ownerUserId: string
-	readonly isDefault: boolean
 	readonly isPrivate: boolean
 	readonly imapHost: string
 	readonly imapPort: number
@@ -36,9 +37,9 @@ export type InboxDraft = {
 export const emptyInboxDraft: InboxDraft = {
 	email: '',
 	displayName: '',
-	purpose: 'human',
+	description: '',
+	shared: false,
 	ownerUserId: '',
-	isDefault: false,
 	isPrivate: false,
 	imapHost: '',
 	imapPort: 993,

--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -24,14 +24,18 @@ import {
 } from '#/components/contacts/display-channels'
 import { AttachmentPicker } from '#/components/emails/attachment-picker'
 import { EmailEditor } from '#/components/emails/email-editor'
+import { SrOnly } from '#/components/shared/sr-only'
 import { type Draft, useComposeEmail } from '#/context/compose-email-context'
+import { authClient } from '#/lib/auth-client'
 import type { StagedAttachment } from '#/lib/email-attachments'
 
 type InboxOption = {
 	readonly id: string
 	readonly email: string
 	readonly displayName: string | null
-	readonly purpose: 'human' | 'agent' | 'shared'
+	// Whose mailbox it is: a member's, or null for the whole team's. You can
+	// send through your own and the team's, never a colleague's.
+	readonly ownerUserId: string | null
 	readonly isDefault: boolean
 	readonly active: boolean
 }
@@ -71,6 +75,7 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		threadAtomFor(draft.threadId ?? '__unused__'),
 	)
 
+	const meUserId = authClient.useSession().data?.user?.id
 	const inboxes = useMemo<ReadonlyArray<InboxOption>>(
 		() =>
 			AsyncResult.isSuccess(inboxesResult)
@@ -79,13 +84,32 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		[inboxesResult],
 	)
 
+	// Only what this person can actually send through: their own mailboxes and
+	// the team's. Offering a colleague's would fail on send anyway.
+	const sendableInboxes = useMemo(
+		() =>
+			inboxes.filter(
+				i =>
+					i.active &&
+					(i.ownerUserId === null ||
+						(meUserId !== undefined && i.ownerUserId === meUserId)),
+			),
+		[inboxes, meUserId],
+	)
+
+	// Nothing is chosen until we know who is asking: before that only the
+	// team's mailboxes look sendable, and picking one would bind the draft to
+	// an address the person never meant to write from.
 	const defaultInboxId = useMemo(
 		() =>
-			(
-				inboxes.find(i => i.purpose === 'human' && i.isDefault && i.active) ??
-				inboxes.find(i => i.purpose === 'human' && i.active)
-			)?.id ?? null,
-		[inboxes],
+			meUserId === undefined
+				? null
+				: ((
+						sendableInboxes.find(i => i.ownerUserId !== null && i.isDefault) ??
+						sendableInboxes.find(i => i.ownerUserId !== null) ??
+						sendableInboxes[0]
+					)?.id ?? null),
+		[sendableInboxes, meUserId],
 	)
 
 	const [form, setForm] = useState<DraftForm>(() => ({
@@ -99,7 +123,21 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		attachments: [],
 	}))
 
-	const effectiveInboxId = form.inboxId ?? defaultInboxId
+	// A draft picked up later can name a mailbox that has since been removed
+	// or was never this person's to write from; fall back rather than send
+	// from an address the server will refuse.
+	const chosenInboxId =
+		form.inboxId !== null && sendableInboxes.some(i => i.id === form.inboxId)
+			? form.inboxId
+			: null
+	const effectiveInboxId = chosenInboxId ?? defaultInboxId
+	// Sending from an address you did not pick is not a mistake you can take
+	// back, so a swap is said out loud — and on a reply, where no picker is
+	// drawn at all, the address that will actually go out is written down.
+	const substituted =
+		form.inboxId !== null && chosenInboxId === null && effectiveInboxId !== null
+	const sendingFrom =
+		sendableInboxes.find(i => i.id === effectiveInboxId)?.email ?? null
 
 	// `serverId` is mirrored from the ref into state so `canSend`'s
 	// useMemo re-runs when createDraft resolves -- refs aren't dep-
@@ -363,9 +401,10 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 
 	// Base UI's Select.Value needs the value→label map to render the chosen
 	// inbox as its name rather than its raw id.
-	const inboxItems = inboxes
-		.filter(i => i.active && i.purpose !== 'agent')
-		.map(i => ({ value: i.id, label: i.displayName ?? i.email }))
+	const inboxItems = sendableInboxes.map(i => ({
+		value: i.id,
+		label: i.displayName ?? i.email,
+	}))
 
 	return (
 		<Form
@@ -375,7 +414,16 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 				if (canSend) void handleSend()
 			}}
 		>
-			{!isReply ? (
+			{/* Nothing to send from is a dead end, so it says so rather than
+			    offering an empty picker beside a Send that cannot work. Held
+			    back until the session lands, since until then the person's own
+			    mailboxes are filtered out and an empty list means nothing. */}
+			{sendableInboxes.length === 0 && meUserId !== undefined ? (
+				<ErrorBanner role='alert'>
+					<AlertTriangle size={14} aria-hidden />
+					<span>{t`You have no mailbox to send from. Connect one under Emails → your email connections, or ask an admin to set up one shared with the team.`}</span>
+				</ErrorBanner>
+			) : !isReply ? (
 				<Field>
 					<FieldLabel htmlFor={`inbox-${draft.id}`}>{t`Inbox`}</FieldLabel>
 					<PriSelect.Root
@@ -403,6 +451,20 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 					</PriSelect.Root>
 				</Field>
 			) : null}
+
+			{/* A reply draws no picker, so the address it will go out from is
+			    written down rather than left to be assumed. */}
+			{isReply && sendingFrom !== null ? (
+				<Field>
+					<FieldLabel as='span'>{t`From`}</FieldLabel>
+					<ReplyFromValue>{sendingFrom}</ReplyFromValue>
+				</Field>
+			) : null}
+			<SrOnly role='status' aria-live='polite'>
+				{substituted && sendingFrom !== null
+					? t`Sending from ${sendingFrom} instead`
+					: ''}
+			</SrOnly>
 
 			{!isReply ? (
 				<Field>
@@ -633,18 +695,13 @@ function narrowInboxes(raw: unknown): ReadonlyArray<InboxOption> {
 		if (!entry || typeof entry !== 'object') continue
 		const r = entry as Record<string, unknown>
 		if (typeof r['id'] !== 'string' || typeof r['email'] !== 'string') continue
-		const purpose =
-			r['purpose'] === 'human' ||
-			r['purpose'] === 'agent' ||
-			r['purpose'] === 'shared'
-				? r['purpose']
-				: 'human'
 		out.push({
 			id: r['id'],
 			email: r['email'],
 			displayName:
 				typeof r['displayName'] === 'string' ? r['displayName'] : null,
-			purpose,
+			ownerUserId:
+				typeof r['ownerUserId'] === 'string' ? r['ownerUserId'] : null,
 			isDefault: r['isDefault'] === true,
 			active: r['active'] !== false,
 		})
@@ -681,6 +738,14 @@ const FieldLabel = styled.label.withConfig({
 	letter-spacing: 0.08em;
 	text-transform: uppercase;
 	color: var(--color-on-surface-variant);
+`
+
+const ReplyFromValue = styled.span.withConfig({
+	displayName: 'ComposeReplyFromValue',
+})`
+	font-family: var(--font-mono, ui-monospace, monospace);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface);
 `
 
 const CcBccToggle = styled.button.withConfig({

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -13,9 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/emails/$threadId.tsx
-#: src/routes/emails/$threadId.tsx
-#: src/routes/emails/$threadId.tsx
 #: src/routes/pages/index.tsx
 msgid "—"
 msgstr "—"
@@ -98,6 +95,16 @@ msgstr "{0} assistents"
 #: src/routes/settings/organization/spend.tsx
 msgid "{0} calls"
 msgstr "{0} crides"
+
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "{0} is now the address you send from"
+msgstr "{0} ara és l'adreça des d'on envies"
+
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "{0} is the address you send from"
+msgstr "{0} és l'adreça des d'on envies"
 
 #. placeholder {0}: thread.messageCount
 #: src/routes/emails/index.tsx
@@ -416,14 +423,6 @@ msgstr "Configuració avançada (IMAP / SMTP)"
 #: src/routes/settings/mcp/index.tsx
 msgid "After approving, manage which org each one acts in here."
 msgstr "Després d'aprovar-lo, gestiona aquí en quina organització actua cadascun."
-
-#: src/routes/emails/inboxes.tsx
-msgid "Agent"
-msgstr "Agent"
-
-#: src/routes/emails/inboxes.tsx
-msgid "AI agent"
-msgstr "Agent IA"
 
 #: src/routes/settings/mcp/connections.tsx
 msgid "AI assistants you've connected over MCP. Each works in the organizations you choose for it — usually one, since most assistants cannot say which they mean when there are several."
@@ -748,6 +747,10 @@ msgstr "Batuda és només amb invitació. Demana accés a l'equip d'Engranatge."
 #: src/components/emails/compose-form.tsx
 msgid "Bcc"
 msgstr "Bcc"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Belongs to another member"
+msgstr "És d'un altre membre"
 
 #: src/routes/emails/index.tsx
 msgid "Blocked"
@@ -1488,8 +1491,8 @@ msgid "Could not set primary inbox"
 msgstr "No s'ha pogut establir la bústia principal"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Could not set the default inbox."
-msgstr "No s'ha pogut establir la safata per defecte."
+msgid "Could not set the default inbox"
+msgstr "No s'ha pogut definir la bústia principal"
 
 #: src/routes/login.tsx
 msgid "Could not sign in. Check your email and password."
@@ -1511,10 +1514,6 @@ msgstr "No s'ha pogut iniciar la recerca. Torna-ho a provar."
 #: src/components/layout/org-switcher.tsx
 msgid "Could not switch organization. Please try again."
 msgstr "No s'ha pogut canviar d'organització. Torna-ho a provar."
-
-#: src/routes/emails/inboxes.tsx
-msgid "Could not toggle the inbox state."
-msgstr "No s'ha pogut canviar l'estat de la safata."
 
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Could not update channels"
@@ -1969,6 +1968,10 @@ msgstr "p. ex. Contacte en fred"
 msgid "e.g. Company signature"
 msgstr "p. ex. Signatura de l'empresa"
 
+#: src/routes/emails/inboxes.tsx
+msgid "e.g. Customer enquiries"
+msgstr "p. ex. Consultes de clients"
+
 #: src/components/research/research-dialog.tsx
 msgid "e.g. ES"
 msgstr "p. ex. ES"
@@ -2343,6 +2346,7 @@ msgstr "Text lliure, poca confiança, sense verificar o d'una execució que cal 
 msgid "Freeform"
 msgstr "Lliure"
 
+#: src/components/emails/compose-form.tsx
 #: src/routes/emails/$threadId.tsx
 msgid "From"
 msgstr "De"
@@ -2433,10 +2437,6 @@ msgstr "Calent"
 #: src/components/instructions/stack-editor.tsx
 msgid "How this stack uses the org default"
 msgstr "Com fa servir aquesta pila el valor per defecte de l'organització"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Human"
-msgstr "Humà"
 
 #: src/components/research/run-detail.tsx
 msgid "I couldn't confirm the company's own website, so the findings weren't reliable enough to keep."
@@ -2606,6 +2606,10 @@ msgstr "El seu propietari no ha triat aquesta organització"
 #: src/routes/calendar/index.tsx
 msgid "Join video call"
 msgstr "Uneix-te a la videotrucada"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Just a note to yourself — it changes nothing about how the mailbox works. Up to 200 characters."
+msgstr "Només és una nota per a tu: no canvia res del funcionament de la bústia. Fins a 200 caràcters."
 
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "Keep editing"
@@ -2845,15 +2849,15 @@ msgstr "Baixa"
 msgid "Low priority"
 msgstr "Prioritat baixa"
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "Make {0} the address you send from"
+msgstr "Fes que {0} sigui l'adreça des d'on envies"
+
 #. placeholder {0}: stack.name
 #: src/components/instructions/stack-list.tsx
 msgid "Make {0} the default"
 msgstr "Fes que {0} sigui la predeterminada"
-
-#. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx
-msgid "Make {0} the primary sender"
-msgstr "Fes que {0} sigui el remitent principal"
 
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Make primary"
@@ -3231,6 +3235,10 @@ msgstr "Cap empresa coincideix amb els filtres"
 msgid "No companies yet"
 msgstr "Encara no hi ha empreses"
 
+#: src/routes/emails/$threadId.tsx
+msgid "No company linked"
+msgstr "Cap empresa vinculada"
+
 #: src/components/layout/org-switcher.tsx
 #: src/routes/login.tsx
 #: src/routes/oauth/consent.tsx
@@ -3266,6 +3274,10 @@ msgstr "Encara sense coordenades. Localitza aquesta empresa per situar-la al map
 msgid "no date"
 msgstr "sense data"
 
+#: src/routes/emails/inboxes.tsx
+msgid "No description"
+msgstr "Sense descripció"
+
 #: src/components/companies/documents-panel.tsx
 msgid "No documents yet."
 msgstr "Encara no hi ha documents."
@@ -3297,6 +3309,11 @@ msgstr "Encara no tens cap clau. Crea'n una a dalt per connectar un agent."
 #: src/routes/calendar/index.tsx
 msgid "no location"
 msgstr "sense ubicació"
+
+#: src/routes/emails/$threadId.tsx
+#: src/routes/emails/$threadId.tsx
+msgid "No mailbox linked"
+msgstr "Cap bústia vinculada"
 
 #: src/routes/settings/organization/members.tsx
 msgid "No members yet."
@@ -3460,9 +3477,21 @@ msgstr "Encara no comptat"
 msgid "Not enough research budget for this run. Raise the budget or narrow the search."
 msgstr "No hi ha prou pressupost de recerca per a aquesta execució. Augmenta el pressupost o acota la cerca."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Not recorded"
+msgstr "No consta"
+
 #: src/routes/forgot-password.tsx
 msgid "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
 msgstr "No el veus? Mira la carpeta de correu brossa. Si estàs segur que el correu és correcte i no arriba mai, un administrador et pot ajudar."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Not syncing"
+msgstr "No se sincronitza"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Not yours to set"
+msgstr "No la pots definir tu"
 
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Note"
@@ -3745,6 +3774,10 @@ msgid "Owner"
 msgstr "Propietari"
 
 #: src/routes/emails/inboxes.tsx
+msgid "Owner and privacy hidden — a team mailbox has no owner and cannot be private"
+msgstr "S'amaguen el propietari i la privadesa: una bústia d'equip no té propietari i no pot ser privada"
+
+#: src/routes/emails/inboxes.tsx
 msgid "Owner user ID"
 msgstr "ID d'usuari propietari"
 
@@ -3846,15 +3879,6 @@ msgstr "La contrasenya ha de tenir com a mínim {MIN_PASSWORD_LENGTH} caràcters
 msgid "Paste an app password — I'll show you where to get one"
 msgstr "Enganxa una contrasenya d'aplicació; jo et mostraré on aconseguir-ne una"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Pause syncing"
-msgstr "Atura la sincronització"
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Paused"
-msgstr "Aturat"
-
 #: src/components/research/findings/shared.tsx
 msgid "Pending paid actions"
 msgstr "Accions de pagament pendents"
@@ -3885,7 +3909,6 @@ msgid "Person"
 msgstr "Persona"
 
 #: src/routes/calendar/index.tsx
-#: src/routes/emails/inboxes.tsx
 #: src/routes/tasks/index.tsx
 #: src/routes/tasks/index.tsx
 msgid "Personal"
@@ -3970,9 +3993,11 @@ msgstr "Preu"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
 msgid "Primary"
 msgstr "Principal"
 
+#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Primary inbox set"
 msgstr "Bústia principal establerta"
@@ -4070,11 +4095,6 @@ msgstr "Publicada"
 #: src/routes/pages/$id.tsx
 msgid "Publishing…"
 msgstr "Publicant…"
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Purpose"
-msgstr "Propòsit"
 
 #: src/components/companies/proposals-panel.tsx
 msgid "Qty"
@@ -4357,10 +4377,6 @@ msgstr "Reprèn esborranys ({0})"
 msgid "Resume drafting (1)"
 msgstr "Reprèn l'esborrany (1)"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Resume syncing"
-msgstr "Reprèn la sincronització"
-
 #: src/components/shared/error-state.tsx
 msgid "Retry"
 msgstr "Torna-ho a provar"
@@ -4584,6 +4600,10 @@ msgid "Send reset link"
 msgstr "Envia l'enllaç"
 
 #: src/components/emails/compose-form.tsx
+msgid "Sending from {sendingFrom} instead"
+msgstr "S'envia des de {sendingFrom}"
+
+#: src/components/emails/compose-form.tsx
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
 msgid "Sending…"
@@ -4649,11 +4669,6 @@ msgstr "Guia de configuració →"
 msgid "Shaped by"
 msgstr "Modelat per"
 
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Shared"
-msgstr "Compartida"
-
 #: src/routes/settings/organization/index.tsx
 msgid "Shared guidance and the org research default."
 msgstr "Orientació compartida i la recerca per defecte de l'organització."
@@ -4665,6 +4680,14 @@ msgstr "Orientació compartida que poden fer servir els agents de tots els membr
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "Shared with everyone in your organization — their research agent follows it on every run."
 msgstr "Compartida amb tothom de la teva organització; el seu agent de recerca la segueix en cada recerca."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Shared with the team"
+msgstr "Compartida amb l'equip"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Shared with the whole team — no single owner"
+msgstr "Compartida amb tot l'equip: sense cap propietari"
 
 #. placeholder {0}: msg.cc.length
 #: src/routes/emails/$threadId.tsx
@@ -5559,8 +5582,6 @@ msgstr "Actualitza"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Update failed"
 msgstr "Ha fallat l'actualització"
 
@@ -5593,10 +5614,6 @@ msgstr "Fes servir un altre correu"
 msgid "Use as default footer"
 msgstr "Utilitza com a peu de pàgina predeterminat"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Use as default for this purpose"
-msgstr "Usa com a per defecte per a aquest propòsit"
-
 #: src/routes/login.tsx
 msgid "Use password instead"
 msgstr "Fes servir contrasenya"
@@ -5608,11 +5625,6 @@ msgstr "Fes servir la predeterminada de l'organització"
 #: src/routes/emails/inboxes.tsx
 msgid "Use your email provider's app-specific password — not your normal login password."
 msgstr "Fes servir la contrasenya d'aplicació del teu proveïdor de correu, no la contrasenya d'inici de sessió habitual."
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Used for"
-msgstr "S'utilitza per a"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Username"
@@ -5710,6 +5722,11 @@ msgstr "Què ha passat?"
 msgid "What is this about?"
 msgstr "De què tracta?"
 
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "What it's for"
+msgstr "Per a què serveix"
+
 #: src/components/research/research-dialog.tsx
 msgid "What kind of research?"
 msgstr "Quin tipus de recerca?"
@@ -5725,6 +5742,10 @@ msgstr "El que ha costat aquesta execució fins ara"
 #: src/components/companies/followup-dialog.tsx
 msgid "What to follow up on"
 msgstr "Sobre què fer seguiment"
+
+#: src/routes/emails/inboxes.tsx
+msgid "What's this mailbox for?"
+msgstr "Per a què serveix aquesta bústia?"
 
 #: src/components/shared/channel-icon.tsx
 msgid "WhatsApp"
@@ -5806,6 +5827,10 @@ msgstr "No tens permís per veure aquesta pàgina."
 #: src/components/profile/set-password-nudge.tsx
 msgid "You got in from a link in your email."
 msgstr "Has entrat des d'un enllaç al teu correu."
+
+#: src/components/emails/compose-form.tsx
+msgid "You have no mailbox to send from. Connect one under Emails → your email connections, or ask an admin to set up one shared with the team."
+msgstr "No tens cap bústia des d'on enviar. Connecta'n una a Correus → les teves connexions de correu, o demana a un administrador que en configuri una de compartida amb l'equip."
 
 #: src/routes/settings/mcp/connections.tsx
 msgid "You removed this one. Tick it to restore it."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -13,9 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/emails/$threadId.tsx
-#: src/routes/emails/$threadId.tsx
-#: src/routes/emails/$threadId.tsx
 #: src/routes/pages/index.tsx
 msgid "—"
 msgstr "—"
@@ -98,6 +95,16 @@ msgstr "{0} attendees"
 #: src/routes/settings/organization/spend.tsx
 msgid "{0} calls"
 msgstr "{0} calls"
+
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "{0} is now the address you send from"
+msgstr "{0} is now the address you send from"
+
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "{0} is the address you send from"
+msgstr "{0} is the address you send from"
 
 #. placeholder {0}: thread.messageCount
 #: src/routes/emails/index.tsx
@@ -416,14 +423,6 @@ msgstr "Advanced settings (IMAP / SMTP)"
 #: src/routes/settings/mcp/index.tsx
 msgid "After approving, manage which org each one acts in here."
 msgstr "After approving, manage which org each one acts in here."
-
-#: src/routes/emails/inboxes.tsx
-msgid "Agent"
-msgstr "Agent"
-
-#: src/routes/emails/inboxes.tsx
-msgid "AI agent"
-msgstr "AI agent"
 
 #: src/routes/settings/mcp/connections.tsx
 msgid "AI assistants you've connected over MCP. Each works in the organizations you choose for it — usually one, since most assistants cannot say which they mean when there are several."
@@ -748,6 +747,10 @@ msgstr "Batuda is invite-only. Request access from the Engranatge team."
 #: src/components/emails/compose-form.tsx
 msgid "Bcc"
 msgstr "Bcc"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Belongs to another member"
+msgstr "Belongs to another member"
 
 #: src/routes/emails/index.tsx
 msgid "Blocked"
@@ -1488,8 +1491,8 @@ msgid "Could not set primary inbox"
 msgstr "Could not set primary inbox"
 
 #: src/routes/emails/inboxes.tsx
-msgid "Could not set the default inbox."
-msgstr "Could not set the default inbox."
+msgid "Could not set the default inbox"
+msgstr "Could not set the default inbox"
 
 #: src/routes/login.tsx
 msgid "Could not sign in. Check your email and password."
@@ -1511,10 +1514,6 @@ msgstr "Could not start the research run. Please try again."
 #: src/components/layout/org-switcher.tsx
 msgid "Could not switch organization. Please try again."
 msgstr "Could not switch organization. Please try again."
-
-#: src/routes/emails/inboxes.tsx
-msgid "Could not toggle the inbox state."
-msgstr "Could not toggle the inbox state."
 
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Could not update channels"
@@ -1969,6 +1968,10 @@ msgstr "e.g. Cold outreach"
 msgid "e.g. Company signature"
 msgstr "e.g. Company signature"
 
+#: src/routes/emails/inboxes.tsx
+msgid "e.g. Customer enquiries"
+msgstr "e.g. Customer enquiries"
+
 #: src/components/research/research-dialog.tsx
 msgid "e.g. ES"
 msgstr "e.g. ES"
@@ -2343,6 +2346,7 @@ msgstr "Free-text, low-confidence, unverified, or from a run that needs reading 
 msgid "Freeform"
 msgstr "Freeform"
 
+#: src/components/emails/compose-form.tsx
 #: src/routes/emails/$threadId.tsx
 msgid "From"
 msgstr "From"
@@ -2433,10 +2437,6 @@ msgstr "Hot"
 #: src/components/instructions/stack-editor.tsx
 msgid "How this stack uses the org default"
 msgstr "How this stack uses the org default"
-
-#: src/routes/emails/inboxes.tsx
-msgid "Human"
-msgstr "Human"
 
 #: src/components/research/run-detail.tsx
 msgid "I couldn't confirm the company's own website, so the findings weren't reliable enough to keep."
@@ -2606,6 +2606,10 @@ msgstr "Its owner has not chosen this organization"
 #: src/routes/calendar/index.tsx
 msgid "Join video call"
 msgstr "Join video call"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Just a note to yourself — it changes nothing about how the mailbox works. Up to 200 characters."
+msgstr "Just a note to yourself — it changes nothing about how the mailbox works. Up to 200 characters."
 
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "Keep editing"
@@ -2845,15 +2849,15 @@ msgstr "Low"
 msgid "Low priority"
 msgstr "Low priority"
 
+#. placeholder {0}: row.email
+#: src/routes/emails/inboxes.tsx
+msgid "Make {0} the address you send from"
+msgstr "Make {0} the address you send from"
+
 #. placeholder {0}: stack.name
 #: src/components/instructions/stack-list.tsx
 msgid "Make {0} the default"
 msgstr "Make {0} the default"
-
-#. placeholder {0}: row.email
-#: src/routes/emails/inboxes.tsx
-msgid "Make {0} the primary sender"
-msgstr "Make {0} the primary sender"
 
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Make primary"
@@ -3231,6 +3235,10 @@ msgstr "No companies match the filters"
 msgid "No companies yet"
 msgstr "No companies yet"
 
+#: src/routes/emails/$threadId.tsx
+msgid "No company linked"
+msgstr "No company linked"
+
 #: src/components/layout/org-switcher.tsx
 #: src/routes/login.tsx
 #: src/routes/oauth/consent.tsx
@@ -3266,6 +3274,10 @@ msgstr "No coordinates yet. Locate this company to plot it on the map."
 msgid "no date"
 msgstr "no date"
 
+#: src/routes/emails/inboxes.tsx
+msgid "No description"
+msgstr "No description"
+
 #: src/components/companies/documents-panel.tsx
 msgid "No documents yet."
 msgstr "No documents yet."
@@ -3297,6 +3309,11 @@ msgstr "No keys yet. Create one above to connect an agent."
 #: src/routes/calendar/index.tsx
 msgid "no location"
 msgstr "no location"
+
+#: src/routes/emails/$threadId.tsx
+#: src/routes/emails/$threadId.tsx
+msgid "No mailbox linked"
+msgstr "No mailbox linked"
 
 #: src/routes/settings/organization/members.tsx
 msgid "No members yet."
@@ -3460,9 +3477,21 @@ msgstr "Not counted yet"
 msgid "Not enough research budget for this run. Raise the budget or narrow the search."
 msgstr "Not enough research budget for this run. Raise the budget or narrow the search."
 
+#: src/routes/emails/inboxes.tsx
+msgid "Not recorded"
+msgstr "Not recorded"
+
 #: src/routes/forgot-password.tsx
 msgid "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
 msgstr "Not seeing it? Check your spam folder. If you're sure the email is right and it never arrives, an admin can help."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Not syncing"
+msgstr "Not syncing"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Not yours to set"
+msgstr "Not yours to set"
 
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Note"
@@ -3745,6 +3774,10 @@ msgid "Owner"
 msgstr "Owner"
 
 #: src/routes/emails/inboxes.tsx
+msgid "Owner and privacy hidden — a team mailbox has no owner and cannot be private"
+msgstr "Owner and privacy hidden — a team mailbox has no owner and cannot be private"
+
+#: src/routes/emails/inboxes.tsx
 msgid "Owner user ID"
 msgstr "Owner user ID"
 
@@ -3846,15 +3879,6 @@ msgstr "Passwords need at least {MIN_PASSWORD_LENGTH} characters."
 msgid "Paste an app password — I'll show you where to get one"
 msgstr "Paste an app password — I'll show you where to get one"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Pause syncing"
-msgstr "Pause syncing"
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Paused"
-msgstr "Paused"
-
 #: src/components/research/findings/shared.tsx
 msgid "Pending paid actions"
 msgstr "Pending paid actions"
@@ -3885,7 +3909,6 @@ msgid "Person"
 msgstr "Person"
 
 #: src/routes/calendar/index.tsx
-#: src/routes/emails/inboxes.tsx
 #: src/routes/tasks/index.tsx
 #: src/routes/tasks/index.tsx
 msgid "Personal"
@@ -3970,9 +3993,11 @@ msgstr "Price"
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
 msgid "Primary"
 msgstr "Primary"
 
+#: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Primary inbox set"
 msgstr "Primary inbox set"
@@ -4070,11 +4095,6 @@ msgstr "Published"
 #: src/routes/pages/$id.tsx
 msgid "Publishing…"
 msgstr "Publishing…"
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Purpose"
-msgstr "Purpose"
 
 #: src/components/companies/proposals-panel.tsx
 msgid "Qty"
@@ -4357,10 +4377,6 @@ msgstr "Resume drafting ({0})"
 msgid "Resume drafting (1)"
 msgstr "Resume drafting (1)"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Resume syncing"
-msgstr "Resume syncing"
-
 #: src/components/shared/error-state.tsx
 msgid "Retry"
 msgstr "Retry"
@@ -4584,6 +4600,10 @@ msgid "Send reset link"
 msgstr "Send reset link"
 
 #: src/components/emails/compose-form.tsx
+msgid "Sending from {sendingFrom} instead"
+msgstr "Sending from {sendingFrom} instead"
+
+#: src/components/emails/compose-form.tsx
 #: src/routes/forgot-password.tsx
 #: src/routes/login.tsx
 msgid "Sending…"
@@ -4649,11 +4669,6 @@ msgstr "Setup guide →"
 msgid "Shaped by"
 msgstr "Shaped by"
 
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Shared"
-msgstr "Shared"
-
 #: src/routes/settings/organization/index.tsx
 msgid "Shared guidance and the org research default."
 msgstr "Shared guidance and the org research default."
@@ -4665,6 +4680,14 @@ msgstr "Shared guidance every member's agents can use, plus the organization's s
 #: src/components/instructions/template-editor-dialog.tsx
 msgid "Shared with everyone in your organization — their research agent follows it on every run."
 msgstr "Shared with everyone in your organization — their research agent follows it on every run."
+
+#: src/routes/emails/inboxes.tsx
+msgid "Shared with the team"
+msgstr "Shared with the team"
+
+#: src/routes/emails/inboxes.tsx
+msgid "Shared with the whole team — no single owner"
+msgstr "Shared with the whole team — no single owner"
 
 #. placeholder {0}: msg.cc.length
 #: src/routes/emails/$threadId.tsx
@@ -5559,8 +5582,6 @@ msgstr "Update"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
 msgid "Update failed"
 msgstr "Update failed"
 
@@ -5593,10 +5614,6 @@ msgstr "Use a different email"
 msgid "Use as default footer"
 msgstr "Use as default footer"
 
-#: src/routes/emails/inboxes.tsx
-msgid "Use as default for this purpose"
-msgstr "Use as default for this purpose"
-
 #: src/routes/login.tsx
 msgid "Use password instead"
 msgstr "Use password instead"
@@ -5608,11 +5625,6 @@ msgstr "Use the org default instead"
 #: src/routes/emails/inboxes.tsx
 msgid "Use your email provider's app-specific password — not your normal login password."
 msgstr "Use your email provider's app-specific password — not your normal login password."
-
-#: src/routes/emails/inboxes.tsx
-#: src/routes/emails/inboxes.tsx
-msgid "Used for"
-msgstr "Used for"
 
 #: src/routes/emails/inboxes.tsx
 msgid "Username"
@@ -5710,6 +5722,11 @@ msgstr "What happened?"
 msgid "What is this about?"
 msgstr "What is this about?"
 
+#: src/routes/emails/inboxes.tsx
+#: src/routes/emails/inboxes.tsx
+msgid "What it's for"
+msgstr "What it's for"
+
 #: src/components/research/research-dialog.tsx
 msgid "What kind of research?"
 msgstr "What kind of research?"
@@ -5725,6 +5742,10 @@ msgstr "What this run has cost so far"
 #: src/components/companies/followup-dialog.tsx
 msgid "What to follow up on"
 msgstr "What to follow up on"
+
+#: src/routes/emails/inboxes.tsx
+msgid "What's this mailbox for?"
+msgstr "What's this mailbox for?"
 
 #: src/components/shared/channel-icon.tsx
 msgid "WhatsApp"
@@ -5806,6 +5827,10 @@ msgstr "You don't have permission to see this page."
 #: src/components/profile/set-password-nudge.tsx
 msgid "You got in from a link in your email."
 msgstr "You got in from a link in your email."
+
+#: src/components/emails/compose-form.tsx
+msgid "You have no mailbox to send from. Connect one under Emails → your email connections, or ask an admin to set up one shared with the team."
+msgstr "You have no mailbox to send from. Connect one under Emails → your email connections, or ask an admin to set up one shared with the team."
 
 #: src/routes/settings/mcp/connections.tsx
 msgid "You removed this one. Tick it to restore it."

--- a/apps/internal/src/routes/emails/$threadId.tsx
+++ b/apps/internal/src/routes/emails/$threadId.tsx
@@ -64,7 +64,7 @@ type DeliverabilityStatus =
 type ThreadInbox = {
 	readonly email: string
 	readonly displayName: string | null
-	readonly purpose: 'human' | 'agent' | 'shared'
+	readonly description: string | null
 }
 
 type AttachmentMeta = {
@@ -436,17 +436,15 @@ function ThreadDetailPage() {
 									</Link>
 								</CompanyLinkWrap>
 							) : (
-								<MetaValueMuted>{t`—`}</MetaValueMuted>
+								<MetaValueMuted>{t`No company linked`}</MetaValueMuted>
 							)}
 						</MetaItem>
 						<MetaItem>
 							<MetaLabel>{t`Inbox`}</MetaLabel>
 							{detail.inbox !== null ? (
-								<InboxBadge $purpose={detail.inbox.purpose}>
-									{detail.inbox.email}
-								</InboxBadge>
+								<InboxBadge>{detail.inbox.email}</InboxBadge>
 							) : (
-								<MetaValueMuted>{t`—`}</MetaValueMuted>
+								<MetaValueMuted>{t`No mailbox linked`}</MetaValueMuted>
 							)}
 						</MetaItem>
 					</MetaStripMobile>
@@ -483,15 +481,18 @@ function ThreadDetailPage() {
 						<SideLabel>{t`Inbox`}</SideLabel>
 						{detail.inbox !== null ? (
 							<div>
-								<InboxBadge $purpose={detail.inbox.purpose}>
-									{detail.inbox.email}
-								</InboxBadge>
+								<InboxBadge>{detail.inbox.email}</InboxBadge>
 								{detail.inbox.displayName ? (
 									<SideValueMuted>{detail.inbox.displayName}</SideValueMuted>
 								) : null}
+								{/* Written out in the panel, since a hover tooltip is out
+								    of reach on a keyboard or a touchscreen. */}
+								{detail.inbox.description ? (
+									<SideValueMuted>{detail.inbox.description}</SideValueMuted>
+								) : null}
 							</div>
 						) : (
-							<SideValueMuted>{t`—`}</SideValueMuted>
+							<SideValueMuted>{t`No mailbox linked`}</SideValueMuted>
 						)}
 					</SideSection>
 					<SideSection>
@@ -735,16 +736,10 @@ function narrowInbox(raw: unknown): ThreadInbox | null {
 	if (!raw || typeof raw !== 'object') return null
 	const r = raw as Record<string, unknown>
 	if (typeof r['email'] !== 'string') return null
-	const purpose =
-		r['purpose'] === 'human' ||
-		r['purpose'] === 'agent' ||
-		r['purpose'] === 'shared'
-			? r['purpose']
-			: 'human'
 	return {
 		email: r['email'],
 		displayName: typeof r['displayName'] === 'string' ? r['displayName'] : null,
-		purpose,
+		description: typeof r['description'] === 'string' ? r['description'] : null,
 	}
 }
 
@@ -1059,37 +1054,18 @@ const CompanyLinkWrap = styled.div.withConfig({
 	}
 `
 
-/* Each badge is its accent at low opacity with a darker text tone on top. The
- * text is deliberately darker than the tint it sits on — matching them (text and
- * background the same colour) leaves too little contrast to read at label size.
- * "Shared" is neutral rather than a third accent: the palette has exactly two. */
-const inboxTone = (purpose: 'human' | 'agent' | 'shared') => {
-	if (purpose === 'human')
-		return css`
-			background: color-mix(in oklab, var(--color-primary) 10%, transparent);
-			color: var(--color-primary);
-		`
-	if (purpose === 'agent')
-		return css`
-			background: color-mix(in oklab, var(--color-secondary) 14%, transparent);
-			color: var(--color-on-secondary-container);
-		`
-	return css`
-		background: color-mix(in oklab, var(--color-on-surface-variant) 12%, transparent);
-		color: var(--color-on-surface-variant);
-	`
-}
-
-const InboxBadge = styled.span.withConfig({ displayName: 'ThreadInboxBadge' })<{
-	readonly $purpose: 'human' | 'agent' | 'shared'
-}>`
+/* The tint sits under text a shade darker than itself — matching them leaves
+ * too little contrast to read at label size. One tone for every mailbox: what
+ * a mailbox is for is its own words now, which no colour could stand in for. */
+const InboxBadge = styled.span.withConfig({ displayName: 'ThreadInboxBadge' })`
 	display: inline-flex;
 	align-items: center;
 	padding: var(--space-3xs) var(--space-xs);
 	border-radius: var(--shape-2xs);
 	font-family: var(--font-mono, ui-monospace, monospace);
 	font-size: var(--typescale-label-small-size);
-	${({ $purpose }) => inboxTone($purpose)}
+	background: color-mix(in oklab, var(--color-primary) 10%, transparent);
+	color: var(--color-primary);
 `
 
 const SideRail = styled.aside.withConfig({ displayName: 'ThreadSideRail' })`

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -13,9 +13,7 @@ import {
 	ChevronLeft,
 	FileText,
 	Inbox as InboxIcon,
-	Pause,
 	Pencil,
-	Play,
 	Plus,
 	RefreshCw,
 	Star,
@@ -61,7 +59,9 @@ import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
 import { RelativeDate } from '#/components/shared/relative-date'
 import { SkeletonRows } from '#/components/shared/skeleton-row'
+import { SrOnly } from '#/components/shared/sr-only'
 import { dehydrateAtom } from '#/lib/atom-hydration'
+import { authClient } from '#/lib/auth-client'
 import { dlgNoId, dlgWithId } from '#/lib/dlg-search'
 import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
@@ -72,18 +72,16 @@ import {
 	stenciledTitle,
 } from '#/lib/workshop-mixins'
 
-type InboxPurpose = 'human' | 'agent' | 'shared'
 type TransportSecurity = 'tls' | 'starttls' | 'plain'
 type GrantStatus = 'connected' | 'auth_failed' | 'connect_failed' | 'disabled'
-// What the status pill shows. A paused inbox (active=false) reads "Paused"
-// regardless of its last sign-in result, so it gets its own tone.
-type StatusTone = GrantStatus | 'paused'
+// What the status pill shows: how signing in to the mailbox last went.
+type StatusTone = GrantStatus
 
 type InboxRow = {
 	readonly id: string
 	readonly email: string
 	readonly displayName: string | null
-	readonly purpose: InboxPurpose
+	readonly description: string | null
 	readonly ownerUserId: string | null
 	readonly isDefault: boolean
 	readonly isPrivate: boolean
@@ -126,7 +124,7 @@ async function loadInboxesOnServer() {
 	])
 	const program = Effect.gen(function* () {
 		const client = yield* makeBatudaApiServer(cookie ?? undefined)
-		return yield* client.email.listInboxes({ query: {} })
+		return yield* client.email.listInboxes({ query: { active: 'true' } })
 	})
 	return Effect.runPromise(program)
 }
@@ -219,6 +217,24 @@ function InboxesPage() {
 
 	const { dlg, open, close } = useInboxDlg()
 
+	const meUserId = useMeUserId()
+	const canManageOthers = useCanManageOthers()
+	const identityPending = useIdentityPending()
+	// Read out when the address somebody sends from changes, since the row
+	// simply redraws in place.
+	const [primaryAnnouncement, setPrimaryAnnouncement] = useState('')
+	// Their own mailbox, as opposed to a colleague's or the team's.
+	const isMine = useCallback(
+		(row: InboxRow) => meUserId !== undefined && row.ownerUserId === meUserId,
+		[meUserId],
+	)
+	// Everyone looks after their own; whoever runs the organization looks
+	// after everyone's, the team's included.
+	const canLookAfter = useCallback(
+		(row: InboxRow) => canManageOthers || isMine(row),
+		[canManageOthers, isMine],
+	)
+
 	const rows = useMemo<ReadonlyArray<InboxRow>>(
 		() =>
 			AsyncResult.isSuccess(inboxesResult)
@@ -234,18 +250,29 @@ function InboxesPage() {
 				: [],
 		[presetsResult],
 	)
-	const isLoading = AsyncResult.isInitial(inboxesResult)
+	// Waiting on who is asking counts as still loading: the rows are unusable
+	// until then, since every control on them turns on whose mailbox it is.
+	const isLoading = AsyncResult.isInitial(inboxesResult) || identityPending
 	const isFailure = AsyncResult.isFailure(inboxesResult)
+	// Settled means both the list and who is asking. The list arrives already
+	// filled from the server, so without the second half a link straight to a
+	// mailbox's settings would judge it unreachable and shut itself before the
+	// answer to "whose is it" had even come back.
 	const listSettled =
-		AsyncResult.isSuccess(inboxesResult) || AsyncResult.isFailure(inboxesResult)
+		(AsyncResult.isSuccess(inboxesResult) ||
+			AsyncResult.isFailure(inboxesResult)) &&
+		!identityPending
 
 	// Edit/footers dialogs carry only the row id in the URL; resolve the row
 	// from the loaded list. A deep link to a row that no longer exists closes
-	// itself once the list has loaded.
+	// itself once the list has loaded — and so does one naming a mailbox this
+	// person cannot change, since the address bar is as much a way in as the
+	// buttons are.
 	const targetRow = useMemo(() => {
 		if (dlg === undefined || dlg.kind === 'create') return null
-		return rows.find(row => row.id === dlg.id) ?? null
-	}, [dlg, rows])
+		const row = rows.find(row => row.id === dlg.id) ?? null
+		return row !== null && canLookAfter(row) ? row : null
+	}, [dlg, rows, canLookAfter])
 	useEffect(() => {
 		if (dlg === undefined || dlg.kind === 'create') return
 		if (listSettled && targetRow === null) close()
@@ -261,16 +288,11 @@ function InboxesPage() {
 		[inboxStatusResult],
 	)
 
+	// Only the viewer's own mailboxes can be offered: choosing what somebody
+	// sends from is theirs alone.
 	const primarySuggestions = useMemo(
-		() =>
-			rows.filter(
-				row =>
-					row.active &&
-					row.purpose === 'human' &&
-					row.ownerUserId !== null &&
-					row.ownerUserId !== '',
-			),
-		[rows],
+		() => rows.filter(row => row.active && isMine(row)),
+		[rows, isMine],
 	)
 	const showPrimaryBanner = !hasPrimary && primarySuggestions.length > 0
 
@@ -284,44 +306,27 @@ function InboxesPage() {
 		[open],
 	)
 
-	const toggleActive = useCallback(
+	// Goes through the same call as the banner, which is the one that checks
+	// the mailbox is yours — so the star cannot move a colleague's.
+	const setDefault = useCallback(
 		async (row: InboxRow) => {
-			const exit = await updateInbox({
-				params: { id: row.id },
-				payload: { active: !row.active },
-			})
+			if (row.isDefault) return
+			const exit = await setPrimaryInbox({ params: { id: row.id } })
 			if (exit._tag !== 'Success') {
 				toastManager.add({
-					title: t`Update failed`,
-					description: t`Could not toggle the inbox state.`,
+					title: t`Could not set the default inbox`,
 					type: 'error',
 				})
 				return
 			}
 			refreshInboxes()
 			refreshInboxStatus()
+			// Said out loud as well as drawn: the row redraws in place, which is
+			// a change somebody not looking at it would otherwise miss.
+			setPrimaryAnnouncement(t`${row.email} is now the address you send from`)
+			toastManager.add({ title: t`Primary inbox set`, type: 'success' })
 		},
-		[updateInbox, refreshInboxes, refreshInboxStatus, toastManager, t],
-	)
-
-	const setDefault = useCallback(
-		async (row: InboxRow) => {
-			if (row.isDefault) return
-			const exit = await updateInbox({
-				params: { id: row.id },
-				payload: { isDefault: true },
-			})
-			if (exit._tag !== 'Success') {
-				toastManager.add({
-					title: t`Update failed`,
-					description: t`Could not set the default inbox.`,
-					type: 'error',
-				})
-				return
-			}
-			refreshInboxes()
-		},
-		[updateInbox, refreshInboxes, toastManager, t],
+		[setPrimaryInbox, refreshInboxes, refreshInboxStatus, toastManager, t],
 	)
 
 	const handleTest = useCallback(
@@ -390,6 +395,11 @@ function InboxesPage() {
 
 	return (
 		<Page>
+			{/* Mounted from the start and filled later: a region that appears
+			    together with its words is often not read out at all. */}
+			<SrOnly role='status' aria-live='polite'>
+				{primaryAnnouncement}
+			</SrOnly>
 			<Intro>
 				<IntroText>
 					<BackLink>
@@ -515,7 +525,7 @@ function InboxesPage() {
 					<TableHead role='row'>
 						<HeadCell role='columnheader'>{t`Email`}</HeadCell>
 						<HeadCell role='columnheader'>{t`Status`}</HeadCell>
-						<HeadCell role='columnheader'>{t`Used for`}</HeadCell>
+						<HeadCell role='columnheader'>{t`What it's for`}</HeadCell>
 						<HeadCell role='columnheader'>{t`Primary`}</HeadCell>
 						<HeadCell role='columnheader'>{t`Added`}</HeadCell>
 						<HeadCell role='columnheader' aria-label={t`Actions`}>
@@ -525,20 +535,17 @@ function InboxesPage() {
 					{rows.map(row => {
 						const providerName = providerNameFor(presets, row.imapHost)
 						const appPwUrl = authPasswordUrlFor(presets, row.imapHost)
-						// A paused (inactive) inbox isn't syncing, so that takes
-						// precedence over whatever its last sign-in result was.
-						const statusTone: StatusTone = !row.active
-							? 'paused'
-							: row.grantStatus
-						const statusLabel = !row.active
-							? t`Paused`
-							: row.grantStatus === 'connected'
+						// Only mailboxes still in use are listed, so what shows here
+						// is how the last sign-in went and nothing else.
+						const statusTone: StatusTone = row.grantStatus
+						const statusLabel =
+							row.grantStatus === 'connected'
 								? t`Connected`
 								: row.grantStatus === 'auth_failed'
 									? t`Couldn't sign in`
 									: row.grantStatus === 'connect_failed'
 										? t`Couldn't connect`
-										: t`Paused`
+										: t`Not syncing`
 						return (
 							<TableRow key={row.id} role='row' $inactive={!row.active}>
 								<CellEmail role='cell'>
@@ -592,33 +599,65 @@ function InboxesPage() {
 									)}
 								</CellStatus>
 								<CellPurpose role='cell'>
-									<MobileCaption>{t`Used for`}</MobileCaption>
-									<PurposeBadge $purpose={row.purpose}>
-										{row.purpose === 'human'
-											? t`Personal`
-											: row.purpose === 'agent'
-												? t`AI agent`
-												: t`Shared`}
-									</PurposeBadge>
+									<MobileCaption>{t`What it's for`}</MobileCaption>
+									{row.ownerUserId === null ? (
+										<TeamTag>{t`Shared with the team`}</TeamTag>
+									) : !isMine(row) ? (
+										// A colleague's mailbox otherwise looks like your own
+										// here, told apart only by a control the row leaves out.
+										<SrOnly>{t`Belongs to another member`}</SrOnly>
+									) : null}
+									{row.description !== null && row.description !== '' ? (
+										<DescriptionText>{row.description}</DescriptionText>
+									) : row.ownerUserId !== null ? (
+										<Muted>
+											<SrOnly>{t`No description`}</SrOnly>
+											<span aria-hidden>—</span>
+										</Muted>
+									) : null}
 								</CellPurpose>
 								<CellDefault role='cell'>
 									<MobileCaption>{t`Primary`}</MobileCaption>
-									{row.isDefault ? (
+									{/* One button either way for the caller's own mailboxes,
+									    marked pressed once chosen. Swapping it for plain text
+									    on success would unmount the button under the finger
+									    that just pressed it, dropping focus to the top of the
+									    page, and the change would go unannounced. */}
+									{isMine(row) ? (
+										<PrimaryToggle
+											type='button'
+											$active={row.isDefault}
+											aria-pressed={row.isDefault}
+											onClick={() => {
+												void setDefault(row)
+											}}
+											aria-label={
+												row.isDefault
+													? t`${row.email} is the address you send from`
+													: t`Make ${row.email} the address you send from`
+											}
+										>
+											<Star
+												size={row.isDefault ? 12 : 14}
+												aria-hidden
+												fill={row.isDefault ? 'currentColor' : 'none'}
+											/>
+											{row.isDefault ? <span>{t`Primary`}</span> : null}
+										</PrimaryToggle>
+									) : row.isDefault ? (
 										<PrimaryLabel>
 											<Star size={12} aria-hidden fill='currentColor' />
 											{t`Primary`}
 										</PrimaryLabel>
 									) : (
-										<IconToggle
-											type='button'
-											$active={false}
-											onClick={() => {
-												void setDefault(row)
-											}}
-											aria-label={t`Make ${row.email} the primary sender`}
-										>
-											<Star size={14} aria-hidden fill='none' />
-										</IconToggle>
+										// Which address somebody sends from is theirs to pick,
+										// so there is nothing to offer on anyone else's. A bare
+										// dash is punctuation a screen reader may pass over,
+										// leaving the cell sounding empty.
+										<Muted>
+											<SrOnly>{t`Not yours to set`}</SrOnly>
+											<span aria-hidden>—</span>
+										</Muted>
 									)}
 								</CellDefault>
 								<CellDate role='cell'>
@@ -626,43 +665,44 @@ function InboxesPage() {
 									{row.createdAt !== null ? (
 										<RelativeDate value={row.createdAt} />
 									) : (
-										<Muted>—</Muted>
+										<Muted>
+											<SrOnly>{t`Not recorded`}</SrOnly>
+											<span aria-hidden>—</span>
+										</Muted>
 									)}
 								</CellDate>
 								<CellActions role='cell'>
-									<PriTooltip.Provider delay={300}>
-										<ActionButton
-											icon={RefreshCw}
-											label={t`Test connection`}
-											onClick={() => {
-												void handleTest(row)
-											}}
-										/>
-										<ActionButton
-											icon={FileText}
-											label={t`Email signature`}
-											onClick={() => openFooters(row)}
-										/>
-										<ActionButton
-											icon={Pencil}
-											label={t`Edit settings`}
-											onClick={() => openEdit(row)}
-										/>
-										<ActionButton
-											icon={row.active ? Pause : Play}
-											label={row.active ? t`Pause syncing` : t`Resume syncing`}
-											onClick={() => {
-												void toggleActive(row)
-											}}
-										/>
-										<ActionButton
-											icon={Trash2}
-											label={t`Remove`}
-											onClick={() => {
-												void handleDelete(row)
-											}}
-										/>
-									</PriTooltip.Provider>
+									{/* Nothing to offer on a mailbox this person cannot
+									    change — the server would turn every one of these
+									    down anyway. */}
+									{canLookAfter(row) ? (
+										<PriTooltip.Provider delay={300}>
+											<ActionButton
+												icon={RefreshCw}
+												label={t`Test connection`}
+												onClick={() => {
+													void handleTest(row)
+												}}
+											/>
+											<ActionButton
+												icon={FileText}
+												label={t`Email signature`}
+												onClick={() => openFooters(row)}
+											/>
+											<ActionButton
+												icon={Pencil}
+												label={t`Edit settings`}
+												onClick={() => openEdit(row)}
+											/>
+											<ActionButton
+												icon={Trash2}
+												label={t`Remove`}
+												onClick={() => {
+													void handleDelete(row)
+												}}
+											/>
+										</PriTooltip.Provider>
+									) : null}
 								</CellActions>
 							</TableRow>
 						)
@@ -760,6 +800,28 @@ function DialogPending({ onClose }: { readonly onClose: () => void }) {
 	)
 }
 
+// Whoever runs the organization looks after everyone's mailboxes; everyone
+// else only their own.
+function useCanManageOthers(): boolean {
+	const role = authClient.useActiveMember().data?.role ?? null
+	return role === 'owner' || role === 'admin'
+}
+
+// The signed-in member, so the list can tell their own mailboxes from the
+// team's and from colleagues'.
+function useMeUserId(): string | undefined {
+	return authClient.useSession().data?.user?.id
+}
+
+// Whether we yet know who is asking. Until we do, every mailbox looks like
+// somebody else's, so the rows would draw with nothing on them and then fill
+// in — moving what a person can tab to while they are already tabbing.
+function useIdentityPending(): boolean {
+	const member = authClient.useActiveMember()
+	const session = authClient.useSession()
+	return member.isPending === true || session.isPending === true
+}
+
 function isInboxStatus(value: unknown): value is {
 	hasDefault: boolean
 	primary: { inboxId: string; email: string } | null
@@ -778,9 +840,9 @@ type MutationResult =
 type CreatePayload = {
 	readonly email: string
 	readonly displayName?: string
-	readonly purpose: InboxPurpose
+	readonly description?: string
+	readonly shared?: boolean
 	readonly ownerUserId?: string
-	readonly isDefault?: boolean
 	readonly isPrivate?: boolean
 	readonly imapHost: string
 	readonly imapPort: number
@@ -794,11 +856,9 @@ type CreatePayload = {
 
 type UpdatePayload = {
 	readonly displayName?: string | null
-	readonly purpose?: InboxPurpose
+	readonly description?: string | null
 	readonly ownerUserId?: string | null
-	readonly isDefault?: boolean
 	readonly isPrivate?: boolean
-	readonly active?: boolean
 	readonly imapHost?: string
 	readonly imapPort?: number
 	readonly imapSecurity?: TransportSecurity
@@ -815,9 +875,9 @@ function rowToDraft(row: InboxRow): InboxDraft {
 	return {
 		email: row.email,
 		displayName: row.displayName ?? '',
-		purpose: row.purpose,
+		description: row.description ?? '',
+		shared: row.ownerUserId === null,
 		ownerUserId: row.ownerUserId ?? '',
-		isDefault: row.isDefault,
 		isPrivate: row.isPrivate,
 		imapHost: row.imapHost,
 		imapPort: row.imapPort,
@@ -845,6 +905,9 @@ function InboxFormDialog({
 }) {
 	const { t } = useLingui()
 	const isCreate = editing === null
+	// Setting a mailbox up for the team, or in somebody else's name, is for
+	// whoever runs the organization — so nobody else is shown the controls.
+	const canManageOthers = useCanManageOthers()
 
 	const presetsResult = useAtomValue(providerPresetsAtom)
 	const presets = useMemo<ReadonlyArray<ProviderPreset>>(
@@ -954,13 +1017,19 @@ function InboxFormDialog({
 			editing !== null
 				? await onUpdate(editing.id, {
 						displayName: draft.displayName === '' ? null : draft.displayName,
-						purpose: draft.purpose,
-						ownerUserId:
-							draft.purpose === 'human' && draft.ownerUserId !== ''
-								? draft.ownerUserId
-								: null,
-						isDefault: draft.isDefault,
-						isPrivate: draft.isPrivate,
+						description: draft.description === '' ? null : draft.description,
+						// Only sent when the owner is actually being changed. A blank
+						// field means "leave it as it is", never "give it to the team"
+						// — handing a mailbox over is always something typed on
+						// purpose.
+						...(draft.shared
+							? { ownerUserId: null }
+							: draft.ownerUserId !== '' && { ownerUserId: draft.ownerUserId }),
+						// A mailbox belonging to everyone cannot be hidden from them.
+						// Decided here rather than by clearing the box, so somebody who
+						// ticks "shared" and changes their mind still finds their
+						// privacy answer where they left it.
+						isPrivate: draft.shared ? false : draft.isPrivate,
 						imapHost: draft.imapHost,
 						imapPort: draft.imapPort,
 						imapSecurity: draft.imapSecurity,
@@ -973,11 +1042,13 @@ function InboxFormDialog({
 				: await onCreate({
 						email: draft.email,
 						...(draft.displayName !== '' && { displayName: draft.displayName }),
-						purpose: draft.purpose,
-						...(draft.purpose === 'human' &&
+						...(draft.description !== '' && {
+							description: draft.description,
+						}),
+						...(draft.shared && { shared: true }),
+						...(!draft.shared &&
 							draft.ownerUserId !== '' && { ownerUserId: draft.ownerUserId }),
-						...(draft.isDefault && { isDefault: true }),
-						...(draft.isPrivate && { isPrivate: true }),
+						...(!draft.shared && draft.isPrivate && { isPrivate: true }),
 						imapHost: draft.imapHost,
 						imapPort: draft.imapPort,
 						imapSecurity: draft.imapSecurity,
@@ -1244,92 +1315,74 @@ function InboxFormDialog({
 						)}
 
 						<Field>
-							<Label>{t`Purpose`}</Label>
-							<PriSelect.Root
-								value={draft.purpose}
-								onValueChange={value => {
-									if (
-										value === 'human' ||
-										value === 'agent' ||
-										value === 'shared'
-									) {
-										patchDraft({ purpose: value })
-									}
-								}}
-							>
-								<PriSelect.Trigger aria-label={t`Purpose`}>
-									<PriSelect.Value />
-									<PriSelect.Icon>
-										<ChevronLeft
-											size={14}
-											aria-hidden
-											style={{ transform: 'rotate(-90deg)' }}
-										/>
-									</PriSelect.Icon>
-								</PriSelect.Trigger>
-								<PriSelect.Portal>
-									<PriSelect.Positioner>
-										<PriSelect.Popup>
-											<PriSelect.Item value='human'>
-												<PriSelect.ItemIndicator>
-													<Check size={12} aria-hidden />
-												</PriSelect.ItemIndicator>
-												<PriSelect.ItemText>{t`Human`}</PriSelect.ItemText>
-											</PriSelect.Item>
-											<PriSelect.Item value='agent'>
-												<PriSelect.ItemIndicator>
-													<Check size={12} aria-hidden />
-												</PriSelect.ItemIndicator>
-												<PriSelect.ItemText>{t`Agent`}</PriSelect.ItemText>
-											</PriSelect.Item>
-											<PriSelect.Item value='shared'>
-												<PriSelect.ItemIndicator>
-													<Check size={12} aria-hidden />
-												</PriSelect.ItemIndicator>
-												<PriSelect.ItemText>{t`Shared`}</PriSelect.ItemText>
-											</PriSelect.Item>
-										</PriSelect.Popup>
-									</PriSelect.Positioner>
-								</PriSelect.Portal>
-							</PriSelect.Root>
+							<Label htmlFor='ix-description'>{t`What's this mailbox for?`}</Label>
+							<PriInput
+								id='ix-description'
+								type='text'
+								value={draft.description}
+								maxLength={200}
+								aria-describedby='ix-description-hint'
+								onChange={e => patchDraft({ description: e.target.value })}
+								placeholder={t`e.g. Customer enquiries`}
+							/>
+							{/* The limit is spelled out because the field itself just
+							    stops taking more, without saying why. */}
+							<Hint id='ix-description-hint'>{t`Just a note to yourself — it changes nothing about how the mailbox works. Up to 200 characters.`}</Hint>
 						</Field>
 
-						{draft.purpose === 'human' && (
-							<Field>
-								<Label htmlFor='ix-owner'>{t`Owner user ID`}</Label>
-								<PriInput
-									id='ix-owner'
-									type='text'
-									value={draft.ownerUserId}
-									onChange={e => patchDraft({ ownerUserId: e.target.value })}
-									placeholder={t`Defaults to you when omitted.`}
-								/>
-							</Field>
-						)}
-
-						<CheckboxRow>
-							<input
-								id='ix-default'
-								type='checkbox'
-								checked={draft.isDefault}
-								onChange={e => patchDraft({ isDefault: e.target.checked })}
-							/>
-							<label htmlFor='ix-default'>{t`Use as default for this purpose`}</label>
-						</CheckboxRow>
-
-						{draft.purpose !== 'shared' && (
+						{canManageOthers && (
 							<CheckboxRow>
 								<input
-									id='ix-private'
+									id='ix-shared'
 									type='checkbox'
-									checked={draft.isPrivate}
-									onChange={e => patchDraft({ isPrivate: e.target.checked })}
+									checked={draft.shared}
+									aria-controls='ix-ownership-options'
+									aria-expanded={!draft.shared}
+									onChange={e => patchDraft({ shared: e.target.checked })}
 								/>
-								<label htmlFor='ix-private'>
-									{t`Private — hide threads from other members`}
+								<label htmlFor='ix-shared'>
+									{t`Shared with the whole team — no single owner`}
 								</label>
 							</CheckboxRow>
 						)}
+
+						{/* Ticking the box takes two questions off the form, which is a
+						    change somebody not looking at it would otherwise miss. Both
+						    answers are kept as typed, so changing one's mind puts them
+						    back; only the submit decides what a team mailbox sends. */}
+						<div id='ix-ownership-options'>
+							{canManageOthers && !draft.shared && (
+								<Field>
+									<Label htmlFor='ix-owner'>{t`Owner user ID`}</Label>
+									<PriInput
+										id='ix-owner'
+										type='text'
+										value={draft.ownerUserId}
+										onChange={e => patchDraft({ ownerUserId: e.target.value })}
+										placeholder={t`Defaults to you when omitted.`}
+									/>
+								</Field>
+							)}
+
+							{!draft.shared && (
+								<CheckboxRow>
+									<input
+										id='ix-private'
+										type='checkbox'
+										checked={draft.isPrivate}
+										onChange={e => patchDraft({ isPrivate: e.target.checked })}
+									/>
+									<label htmlFor='ix-private'>
+										{t`Private — hide threads from other members`}
+									</label>
+								</CheckboxRow>
+							)}
+						</div>
+						<SrOnly role='status' aria-live='polite'>
+							{draft.shared
+								? t`Owner and privacy hidden — a team mailbox has no owner and cannot be private`
+								: ''}
+						</SrOnly>
 
 						{errorMessage !== null && (
 							<ErrorText role='alert'>{errorMessage}</ErrorText>
@@ -1877,16 +1930,13 @@ function narrowInboxRows(rows: unknown): ReadonlyArray<InboxRow> {
 		const r = row as Record<string, unknown>
 		if (typeof r['id'] !== 'string') continue
 		if (typeof r['email'] !== 'string') continue
-		const purpose = r['purpose']
-		if (purpose !== 'human' && purpose !== 'agent' && purpose !== 'shared') {
-			continue
-		}
 		out.push({
 			id: r['id'],
 			email: r['email'],
 			displayName:
 				typeof r['displayName'] === 'string' ? r['displayName'] : null,
-			purpose,
+			description:
+				typeof r['description'] === 'string' ? r['description'] : null,
 			ownerUserId:
 				typeof r['ownerUserId'] === 'string' ? r['ownerUserId'] : null,
 			isDefault: r['isDefault'] === true,
@@ -1992,13 +2042,15 @@ const InboxesTable = styled.div.withConfig({ displayName: 'InboxesTable' })`
 	background: var(--color-paper-aged);
 `
 
-// Columns: email · status · used-for · primary · added · actions.
+// Columns: email · status · what-it's-for · primary · added · actions.
+// The description column flexes rather than sitting at a fixed width, since
+// what someone writes there runs to a line rather than a single word.
 const gridTemplate = css`
 	display: grid;
 	grid-template-columns:
 		minmax(0, 2fr)
 		minmax(8rem, 0.9fr)
-		7rem
+		minmax(7rem, 1.2fr)
 		6rem
 		minmax(0, 0.8fr)
 		auto;
@@ -2096,7 +2148,13 @@ const DisplayName = styled.span.withConfig({
 
 const CellPurpose = styled.div.withConfig({
 	displayName: 'InboxesCellPurpose',
-})``
+})`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--space-3xs);
+	min-width: 0;
+`
 
 const CellStatus = styled.div.withConfig({ displayName: 'InboxesCellStatus' })`
 	display: flex;
@@ -2339,10 +2397,9 @@ const TechDetails = styled.details.withConfig({
 	}
 `
 
-const PurposeBadge = styled.span.withConfig({
-	displayName: 'InboxesPurposeBadge',
-	shouldForwardProp: prop => prop !== '$purpose',
-})<{ $purpose: InboxPurpose }>`
+// Marks the mailboxes that belong to everyone rather than to one person —
+// the one thing about a mailbox still worth saying at a glance.
+const TeamTag = styled.span.withConfig({ displayName: 'InboxesTeamTag' })`
 	display: inline-flex;
 	align-items: center;
 	padding: 2px var(--space-2xs);
@@ -2352,25 +2409,20 @@ const PurposeBadge = styled.span.withConfig({
 	font-weight: var(--font-weight-bold);
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
-	${p =>
-		p.$purpose === 'human'
-			? css`
-					background: color-mix(in oklab, var(--color-primary) 16%, transparent);
-					color: color-mix(in oklab, var(--color-primary) 80%, black);
-					border: 1px solid
-						color-mix(in oklab, var(--color-primary) 45%, transparent);
-				`
-			: p.$purpose === 'agent'
-				? css`
-						background: color-mix(in oklab, var(--color-on-surface-variant) 16%, transparent);
-						color: var(--color-on-surface);
-						border: 1px solid color-mix(in oklab, var(--color-on-surface-variant) 45%, transparent);
-					`
-				: css`
-						background: transparent;
-						color: var(--color-on-surface-variant);
-						border: 1px dashed var(--color-outline);
-					`}
+	background: transparent;
+	color: var(--color-on-surface-variant);
+	border: 1px dashed var(--color-outline);
+`
+
+const DescriptionText = styled.span.withConfig({
+	displayName: 'InboxesDescriptionText',
+})`
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-small-size);
+	color: var(--color-on-surface-variant);
+	/* Free text somebody types, so a single long word (a pasted address)
+	   must wrap rather than widen the column past its share. */
+	overflow-wrap: anywhere;
 `
 
 const IconToggle = styled.button.withConfig({
@@ -2404,6 +2456,21 @@ const IconToggle = styled.button.withConfig({
 		outline: none;
 		box-shadow: var(--glow-active);
 	}
+`
+
+// The same control before and after choosing, so pressing it never pulls the
+// focused element out from under the person who pressed it. Widens to carry
+// the word once chosen, matching the plain label shown on other people's rows.
+const PrimaryToggle = styled(IconToggle)`
+	gap: var(--space-3xs);
+	width: auto;
+	min-width: 1.75rem;
+	padding: 0 ${p => (p.$active ? 'var(--space-2xs)' : '0')};
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
 `
 
 const IconAction = styled.button.withConfig({
@@ -2457,10 +2524,12 @@ const ActionLabel = styled.span.withConfig({
 	}
 `
 
+// Italic and the variant tone already read as de-emphasised. Fading it further
+// dropped the text under the contrast floor on paper, where most people read
+// it, so the tone carries it alone.
 const Muted = styled.span.withConfig({ displayName: 'InboxesMuted' })`
 	color: var(--color-on-surface-variant);
 	font-style: italic;
-	opacity: 0.7;
 `
 
 const EmptyHelp = styled.div.withConfig({ displayName: 'InboxesEmptyHelp' })`

--- a/apps/internal/src/routes/emails/index.tsx
+++ b/apps/internal/src/routes/emails/index.tsx
@@ -95,7 +95,7 @@ type InboundClassification = 'normal' | 'spam' | 'blocked'
 type ThreadInbox = {
 	readonly email: string
 	readonly displayName: string | null
-	readonly purpose: 'human' | 'agent' | 'shared'
+	readonly description: string | null
 }
 
 type ThreadRow = {
@@ -118,7 +118,7 @@ type InboxOption = {
 	readonly id: string
 	readonly email: string
 	readonly displayName: string | null
-	readonly purpose: 'human' | 'agent' | 'shared'
+	readonly description: string | null
 }
 
 type CompanyLookup = {
@@ -140,7 +140,6 @@ const validateSearch = validateSearchWith({
 	inboxId: Schema.NonEmptyString,
 	companyId: Schema.NonEmptyString,
 	status: Schema.Literals(['open', 'closed', 'archived'] as const),
-	purpose: Schema.Literals(['human', 'agent', 'shared'] as const),
 	query: Schema.NonEmptyString,
 	page: Schema.Union([Schema.Number, Schema.NumberFromString]).pipe(
 		Schema.refine((n): n is number => Number.isFinite(n) && n >= 1),
@@ -157,7 +156,6 @@ function toWireSearch(
 		inboxId?: string
 		companyId?: string
 		status?: 'open' | 'closed' | 'archived'
-		purpose?: 'human' | 'agent' | 'shared'
 		query?: string
 		limit?: number
 		offset?: number
@@ -169,7 +167,6 @@ function toWireSearch(
 	if (search.inboxId !== undefined) wire.inboxId = search.inboxId
 	if (search.companyId !== undefined) wire.companyId = search.companyId
 	if (search.status !== undefined) wire.status = search.status
-	if (search.purpose !== undefined) wire.purpose = search.purpose
 	if (search.query !== undefined) wire.query = search.query
 	return wire
 }
@@ -187,7 +184,6 @@ async function loadThreadsOnServer(wire: EmailsSearch) {
 	if (wire.inboxId !== undefined) queryForServer['inboxId'] = wire.inboxId
 	if (wire.companyId !== undefined) queryForServer['companyId'] = wire.companyId
 	if (wire.status !== undefined) queryForServer['status'] = wire.status
-	if (wire.purpose !== undefined) queryForServer['purpose'] = wire.purpose
 	if (wire.query !== undefined) queryForServer['query'] = wire.query
 	if (wire.limit !== undefined) queryForServer['limit'] = wire.limit
 	if (wire.offset !== undefined) queryForServer['offset'] = wire.offset
@@ -197,7 +193,9 @@ async function loadThreadsOnServer(wire: EmailsSearch) {
 		const [envelope, inboxes] = yield* Effect.all(
 			[
 				client.email.listThreads({ query: queryForServer }),
-				client.email.listInboxes({ query: {} }),
+				// Must match the list atom this hydrates, or the filter chip would
+				// offer mailboxes that are gone until the first client fetch.
+				client.email.listInboxes({ query: { active: 'true' } }),
 			],
 			{ concurrency: 2 },
 		)
@@ -1528,7 +1526,6 @@ function mergeSearch(
 		inboxId: string | undefined
 		companyId: string | undefined
 		status: ThreadStatus | undefined
-		purpose: 'human' | 'agent' | 'shared' | undefined
 		query: string | undefined
 		page: number | undefined
 	}>,
@@ -1537,7 +1534,6 @@ function mergeSearch(
 		inboxId?: string
 		companyId?: string
 		status?: ThreadStatus
-		purpose?: 'human' | 'agent' | 'shared'
 		query?: string
 		page?: number
 	} = {}
@@ -1547,8 +1543,6 @@ function mergeSearch(
 	if (companyId !== undefined && companyId !== '') result.companyId = companyId
 	const status = 'status' in next ? next.status : prev.status
 	if (status !== undefined) result.status = status
-	const purpose = 'purpose' in next ? next.purpose : prev.purpose
-	if (purpose !== undefined) result.purpose = purpose
 	const query = 'query' in next ? next.query : prev.query
 	if (query !== undefined && query !== '') result.query = query
 	const page = 'page' in next ? next.page : prev.page
@@ -1561,7 +1555,6 @@ function hasActiveFilters(search: EmailsSearch & { page?: number }): boolean {
 		search.inboxId !== undefined ||
 		search.companyId !== undefined ||
 		search.status !== undefined ||
-		search.purpose !== undefined ||
 		search.query !== undefined
 	)
 }
@@ -1639,14 +1632,10 @@ function narrowInbox(value: unknown): ThreadInbox | null {
 	if (!value || typeof value !== 'object') return null
 	const v = value as Record<string, unknown>
 	if (typeof v['email'] !== 'string') return null
-	const purpose = v['purpose']
-	if (purpose !== 'human' && purpose !== 'agent' && purpose !== 'shared') {
-		return null
-	}
 	return {
 		email: v['email'],
 		displayName: typeof v['displayName'] === 'string' ? v['displayName'] : null,
-		purpose,
+		description: typeof v['description'] === 'string' ? v['description'] : null,
 	}
 }
 
@@ -1659,16 +1648,13 @@ function narrowInboxes(
 		const r = row as Record<string, unknown>
 		if (typeof r['id'] !== 'string') continue
 		if (typeof r['email'] !== 'string') continue
-		const purpose = r['purpose']
-		if (purpose !== 'human' && purpose !== 'agent' && purpose !== 'shared') {
-			continue
-		}
 		out.push({
 			id: r['id'],
 			email: r['email'],
 			displayName:
 				typeof r['displayName'] === 'string' ? r['displayName'] : null,
-			purpose,
+			description:
+				typeof r['description'] === 'string' ? r['description'] : null,
 		})
 	}
 	return out

--- a/apps/mail-worker/src/bounces.integration.test.ts
+++ b/apps/mail-worker/src/bounces.integration.test.ts
@@ -82,11 +82,10 @@ beforeAll(async () => {
 	// suite never connects to a mail server.
 	const inbox = await pool.query<{ id: string }>(
 		`INSERT INTO inboxes
-		 (organization_id, owner_user_id, email, purpose,
-		  imap_host, imap_port, imap_security,
+		 (organization_id, owner_user_id, email, imap_host, imap_port, imap_security,
 		  smtp_host, smtp_port, smtp_security,
 		  username, password_ciphertext, password_nonce, password_tag)
-		 VALUES ($1, $2, $3, 'human',
+		 VALUES ($1, $2, $3, 
 		         'imap.example.com', 993, 'tls',
 		         'smtp.example.com', 465, 'tls',
 		         $3, '\\x00'::bytea, '\\x00'::bytea, '\\x00'::bytea)

--- a/apps/mail-worker/src/persist.integration.test.ts
+++ b/apps/mail-worker/src/persist.integration.test.ts
@@ -121,11 +121,10 @@ beforeAll(async () => {
 	// they exist purely to satisfy NOT NULL constraints on inboxes.
 	const inboxResult = await pool.query<{ id: string }>(
 		`INSERT INTO inboxes
-		 (organization_id, owner_user_id, email, purpose,
-		  imap_host, imap_port, imap_security,
+		 (organization_id, owner_user_id, email, imap_host, imap_port, imap_security,
 		  smtp_host, smtp_port, smtp_security,
 		  username, password_ciphertext, password_nonce, password_tag)
-		 VALUES ($1, $2, $3, 'human',
+		 VALUES ($1, $2, $3, 
 		         'imap.example.com', 993, 'tls',
 		         'smtp.example.com', 465, 'tls',
 		         $3, '\\x00'::bytea, '\\x00'::bytea, '\\x00'::bytea)

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -124,6 +124,8 @@ export const persistInboundMessage = (args: {
 							id: args.organizationId,
 							name: '',
 							slug: '',
+							// Delivering mail is nobody's request, so it manages nothing.
+							role: null,
 						}),
 					)
 			: new NoMatch({ email: '' })

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -43,25 +43,12 @@ export const betterAuthSchemaConfig = {
 		},
 	},
 	// `organization()` here so Better Auth generates the `organization` /
-	// `member` / `invitation` tables alongside the rest. `member.primary_inbox_id`
-	// is a Batuda extension recording each member's default From identity.
+	// `member` / `invitation` tables alongside the rest.
 	plugins: [
 		openAPI(),
 		bearer(),
 		admin(),
-		organization({
-			schema: {
-				member: {
-					additionalFields: {
-						primaryInboxId: {
-							type: 'string',
-							required: false,
-							fieldName: 'primary_inbox_id',
-						},
-					},
-				},
-			},
-		}),
+		organization(),
 		apiKey(),
 		// Generates the OAuth provider tables (oauthClient, oauthAccessToken,
 		// oauthRefreshToken, oauthConsent) plus the jwt plugin's jwks table,
@@ -130,10 +117,9 @@ const logMigrationTarget = Effect.gen(function* () {
 	)
 })
 
-// Better Auth migrations run first so the CRM migration (0001_initial)
-// can reference Better Auth tables — specifically the FK from
-// member.primary_inbox_id → inboxes(id) needs the `member` table to
-// already exist when the ALTER TABLE fires.
+// Better Auth migrations run first so the CRM migrations can reference Better
+// Auth tables — 0001_initial alters `member`, which has to exist by the time
+// that ALTER TABLE fires.
 const program = Effect.gen(function* () {
 	yield* logMigrationTarget
 	yield* Effect.log('Running Better Auth migrations...')

--- a/apps/server/src/db/migrations/0046_inbox_description.ts
+++ b/apps/server/src/db/migrations/0046_inbox_description.ts
@@ -1,0 +1,119 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// A mailbox now says what it is for in whatever words fit, and who may touch it
+// follows from who owns it.
+//
+// Every mailbox used to be filed under one of three fixed kinds — a person's,
+// an assistant's, or the whole team's. Those three words decided three
+// unrelated things at once: whether the mailbox needed an owner, which mailbox
+// someone sends from by default, and the label shown in the list. None of them
+// said how the mailbox is actually used, and nobody could write that down.
+// `description` is free text for exactly that, and carries no rules of its own.
+//
+// The rules move onto the owner: a mailbox with an owner belongs to that
+// person, a mailbox without one is the whole team's. The old check already said
+// the same, so no mailbox that was legal before becomes illegal — only the
+// column that decides it changes.
+//
+// Three smaller things ride along:
+//
+//   * A mailbox nobody owns is nobody's default. Nothing ever read such a mark
+//     — "which mailbox do I send from" always asks for the caller's own — yet
+//     the list drew a star on team mailboxes, so the star did nothing.
+//   * The same address is connected once at a time. Reconnecting an address
+//     whose password had gone stale left the broken mailbox in the list beside
+//     the new one. Removed mailboxes keep theirs, since history points at them.
+//   * `member.primary_inbox_id` goes: it was meant to hold a member's default
+//     sending address and was never once written. The mark on the mailbox row
+//     is what the product reads.
+//
+// expand-contract: pre-production, no backward-compatibility guarantee — every
+// reader of `purpose` ships in this same release, `description` starts empty
+// for mailboxes connected before it, and `member.primary_inbox_id` has no
+// reader to break.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`ALTER TABLE inboxes ADD COLUMN IF NOT EXISTS description TEXT`
+	// A line about what the mailbox is for, not a place to paste a document.
+	yield* sql`
+		ALTER TABLE inboxes
+			ADD CONSTRAINT inboxes_description_len_chk CHECK (
+				description IS NULL OR char_length(description) <= 200
+			)
+	`
+
+	// A team mailbox is nobody's default — clear the marks that were settable
+	// but never readable, so the surviving rule only has to describe owned ones.
+	yield* sql`
+		UPDATE inboxes
+		SET is_default = false, updated_at = now()
+		WHERE owner_user_id IS NULL AND is_default = true
+	`
+
+	// One address, one mailbox in use. The newest wins, since connecting an
+	// address a second time is someone repairing the first; the rest switch off
+	// the same way removing a mailbox does, so history still resolves through
+	// them.
+	yield* sql`
+		UPDATE inboxes
+		SET active = false, is_default = false, updated_at = now()
+		WHERE active = true
+		  AND id NOT IN (
+			SELECT DISTINCT ON (organization_id, lower(email)) id
+			FROM inboxes
+			WHERE active = true
+			ORDER BY organization_id, lower(email), created_at DESC
+		  )
+	`
+
+	// One person, one default. Prefer a mailbox still in use, then the earliest
+	// they connected.
+	yield* sql`
+		UPDATE inboxes
+		SET is_default = false, updated_at = now()
+		WHERE owner_user_id IS NOT NULL
+		  AND is_default = true
+		  AND id NOT IN (
+			SELECT DISTINCT ON (organization_id, owner_user_id) id
+			FROM inboxes
+			WHERE owner_user_id IS NOT NULL AND is_default = true
+			ORDER BY organization_id, owner_user_id, active DESC, created_at ASC
+		  )
+	`
+
+	yield* sql`
+		ALTER TABLE inboxes DROP CONSTRAINT IF EXISTS inboxes_purpose_owner_chk
+	`
+	// A mailbox nobody owns is the whole team's, so it can neither be hidden
+	// from them nor stand in for any one person as their default.
+	yield* sql`
+		ALTER TABLE inboxes
+			ADD CONSTRAINT inboxes_team_mailbox_chk CHECK (
+				owner_user_id IS NOT NULL OR (is_private = false AND is_default = false)
+			)
+	`
+
+	// Dropping the column takes its own index and the two default-uniqueness
+	// rules with it, since all three were written in terms of it.
+	yield* sql`ALTER TABLE inboxes DROP COLUMN purpose`
+
+	// The per-owner default rule comes back without the dropped column. It has
+	// no twin for team mailboxes: a mailbox nobody owns is nobody's default.
+	yield* sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_inboxes_default_per_owner
+		ON inboxes(organization_id, owner_user_id)
+		WHERE is_default = true AND owner_user_id IS NOT NULL
+	`
+
+	yield* sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_inboxes_email_active
+		ON inboxes(organization_id, lower(email))
+		WHERE active = true
+	`
+
+	// Dropping the column takes its foreign key and index with it.
+	yield* sql`ALTER TABLE "member" DROP COLUMN IF EXISTS primary_inbox_id`
+})

--- a/apps/server/src/handlers/email-attachment-download.integration.test.ts
+++ b/apps/server/src/handlers/email-attachment-download.integration.test.ts
@@ -76,13 +76,13 @@ describe('email_messages.attachments storage contract', () => {
 		const id = randomUUID()
 		await pool.query(
 			`INSERT INTO inboxes (
-				id, organization_id, email, purpose, owner_user_id,
+				id, organization_id, email, owner_user_id,
 				imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security,
 				username, password_ciphertext, password_nonce, password_tag,
 				active
 			) VALUES (
-				$1::uuid, $2, $3, 'human', 'email-attachment-test-user',
+				$1::uuid, $2, $3,  'email-attachment-test-user',
 				'imap.test', 993, 'tls',
 				'smtp.test', 587, 'starttls',
 				$3, $4, $4, $4,

--- a/apps/server/src/handlers/email.ts
+++ b/apps/server/src/handlers/email.ts
@@ -107,9 +107,6 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 							companyId: _.query.companyId,
 						}),
 						...(_.query.status !== undefined && { status: _.query.status }),
-						...(_.query.purpose !== undefined && {
-							purpose: _.query.purpose,
-						}),
 						...(_.query.query !== undefined && { query: _.query.query }),
 						...(_.query.limit !== undefined && { limit: _.query.limit }),
 						...(_.query.offset !== undefined && { offset: _.query.offset }),
@@ -179,9 +176,6 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 				)
 				.handle('listInboxes', _ =>
 					svc.listLocalInboxes({
-						...(_.query.purpose !== undefined && {
-							purpose: _.query.purpose,
-						}),
 						...(_.query.active !== undefined && {
 							active: _.query.active === 'true',
 						}),
@@ -193,32 +187,35 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 				.handle('listProviderPresets', () => svc.listProviderPresets())
 				.handle('inboxStatus', () => svc.inboxStatus())
 				.handle('createInbox', _ =>
-					svc
-						.createInbox({
-							email: _.payload.email,
-							...(_.payload.displayName !== undefined && {
-								displayName: _.payload.displayName,
-							}),
-							purpose: _.payload.purpose,
-							...(_.payload.ownerUserId !== undefined && {
-								ownerUserId: _.payload.ownerUserId,
-							}),
-							...(_.payload.isPrivate !== undefined && {
-								isPrivate: _.payload.isPrivate,
-							}),
-							...(_.payload.isDefault !== undefined && {
-								isDefault: _.payload.isDefault,
-							}),
-							imapHost: _.payload.imapHost,
-							imapPort: _.payload.imapPort,
-							imapSecurity: _.payload.imapSecurity,
-							smtpHost: _.payload.smtpHost,
-							smtpPort: _.payload.smtpPort,
-							smtpSecurity: _.payload.smtpSecurity,
-							username: _.payload.username,
-							password: _.payload.password,
-						})
-						.pipe(Effect.catchTag('SqlError', e => Effect.die(e))),
+					svc.createInbox({
+						email: _.payload.email,
+						...(_.payload.displayName !== undefined && {
+							displayName: _.payload.displayName,
+						}),
+						...(_.payload.description !== undefined && {
+							description: _.payload.description,
+						}),
+						...(_.payload.shared !== undefined && {
+							shared: _.payload.shared,
+						}),
+						...(_.payload.ownerUserId !== undefined && {
+							ownerUserId: _.payload.ownerUserId,
+						}),
+						...(_.payload.isPrivate !== undefined && {
+							isPrivate: _.payload.isPrivate,
+						}),
+						...(_.payload.isDefault !== undefined && {
+							isDefault: _.payload.isDefault,
+						}),
+						imapHost: _.payload.imapHost,
+						imapPort: _.payload.imapPort,
+						imapSecurity: _.payload.imapSecurity,
+						smtpHost: _.payload.smtpHost,
+						smtpPort: _.payload.smtpPort,
+						smtpSecurity: _.payload.smtpSecurity,
+						username: _.payload.username,
+						password: _.payload.password,
+					}),
 				)
 				.handle('updateInbox', _ =>
 					svc
@@ -226,8 +223,8 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 							...(_.payload.displayName !== undefined && {
 								displayName: _.payload.displayName,
 							}),
-							...(_.payload.purpose !== undefined && {
-								purpose: _.payload.purpose,
+							...(_.payload.description !== undefined && {
+								description: _.payload.description,
 							}),
 							...(_.payload.ownerUserId !== undefined && {
 								ownerUserId: _.payload.ownerUserId,
@@ -388,7 +385,10 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 								isDefault: _.payload.isDefault,
 							}),
 						})
-						.pipe(Effect.orDie),
+						.pipe(
+							Effect.catchTag('NotFound', e => Effect.fail(e)),
+							Effect.catchTag('SqlError', e => Effect.die(e)),
+						),
 				)
 				.handle('getFooter', _ =>
 					svc.getFooter(_.params.id).pipe(

--- a/apps/server/src/handlers/webhooks-calcom.integration.test.ts
+++ b/apps/server/src/handlers/webhooks-calcom.integration.test.ts
@@ -96,13 +96,13 @@ const ensureFixtureInbox = (orgId: string) =>
 		const placeholder = new Uint8Array([0])
 		yield* sql`
 			INSERT INTO inboxes (
-				organization_id, email, purpose, owner_user_id,
+				organization_id, email, owner_user_id,
 				imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security,
 				username, password_ciphertext, password_nonce, password_tag,
 				active
 			) VALUES (
-				${orgId}, ${FIXTURE_INBOX_EMAIL}, 'human', 'webhooks-calcom-test-user',
+				${orgId}, ${FIXTURE_INBOX_EMAIL},  'webhooks-calcom-test-user',
 				'imap.test', 993, 'tls',
 				'smtp.test', 587, 'starttls',
 				${FIXTURE_INBOX_EMAIL}, ${placeholder}, ${placeholder}, ${placeholder},

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -146,22 +146,7 @@ export class Auth extends Context.Service<Auth>()('Auth', {
 					// orgs; `session.activeOrganizationId` drives which org a request
 					// reads/writes. Tables that own org-scoped data carry an
 					// `organization_id` column populated from `CurrentOrg`.
-					// `member.primary_inbox_id` is the member's default From identity
-					// in this org; the column + FK + ON DELETE SET NULL are added by
-					// the migration since `additionalFields` does not generate FKs.
-					organization({
-						schema: {
-							member: {
-								additionalFields: {
-									primaryInboxId: {
-										type: 'string' as const,
-										required: false,
-										fieldName: 'primary_inbox_id' as const,
-									},
-								},
-							},
-						},
-					}),
+					organization(),
 					// enableMetadata: org-owned keys carry { organizationId } so the
 					// MCP path resolves the org from the key (BADREQUEST otherwise).
 					// enableSessionForAPIKeys is off on purpose: a key authenticates

--- a/apps/server/src/mcp-stdio.ts
+++ b/apps/server/src/mcp-stdio.ts
@@ -50,7 +50,13 @@ const CurrentOrgFromEnv = Layer.effect(
 		const id = yield* Config.string('BATUDA_ACTIVE_ORG_ID')
 		const name = yield* Config.string('BATUDA_ACTIVE_ORG_NAME')
 		const slug = yield* Config.string('BATUDA_ACTIVE_ORG_SLUG')
-		return { id, name, slug }
+		// Starts at the lowest standing, so local tools reach a colleague's
+		// things only when the developer says so. Set `owner` or `admin` to
+		// try what someone running the organization can do.
+		const role = yield* Config.string('BATUDA_ACTIVE_ORG_ROLE').pipe(
+			Config.withDefault('member'),
+		)
+		return { id, name, slug, role }
 	}),
 )
 

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -85,6 +85,19 @@ const McpAuthMiddleware = HttpRouter.middleware(
 				Effect.map(rows => rows[0]),
 			)
 
+		// What the person behind this connection may do in the org. An AI client
+		// acts for them, so it carries their standing rather than a lesser one of
+		// its own — someone who runs the org still runs it from a chat window.
+		const loadRole = (orgId: string, userId: string) =>
+			sql<{ role: string | null }>`
+				SELECT role FROM member
+				WHERE "organizationId" = ${orgId} AND "userId" = ${userId}
+				LIMIT 1
+			`.pipe(
+				Effect.orDie,
+				Effect.map(rows => rows[0]?.role ?? null),
+			)
+
 		return httpEffect =>
 			Effect.gen(function* () {
 				const req = yield* HttpServerRequest.HttpServerRequest
@@ -110,6 +123,9 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						// recorded against it. Absent on the browser path, which is a
 						// person in a tab rather than a machine connection.
 						readonly credentialId?: string | undefined
+						// What this person may do in the org — null when they hold no
+						// membership there, which manages nothing.
+						readonly role: string | null
 					},
 				) =>
 					// Tag the request span with how the caller authenticated and the
@@ -160,7 +176,11 @@ const McpAuthMiddleware = HttpRouter.middleware(
 									name: principal.name ?? undefined,
 									isAgent: principal.isAgent,
 								}),
-								enterOrgScope(sql, { org, userId: principal.userId }),
+								enterOrgScope(sql, {
+									org,
+									userId: principal.userId,
+									role: principal.role,
+								}),
 							),
 						),
 					)
@@ -250,6 +270,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						name: creator.name,
 						isAgent: true,
 						credentialId: verified.key.id,
+						role: yield* loadRole(org.id, creator.id),
 					})
 				}
 
@@ -443,6 +464,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 							name: user.name,
 							isAgent: false,
 							credentialId: clientId,
+							role: yield* loadRole(org.id, user.id),
 						})
 						// payload undefined → opaque/session bearer → fall through.
 					}
@@ -492,6 +514,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					email: result.user.email,
 					name: result.user.name ?? null,
 					isAgent: result.user.isAgent === true,
+					role: yield* loadRole(org.id, result.user.id),
 				})
 			})
 	}),

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -86,7 +86,6 @@ const SendEmailResult = Schema.Union([
 const DeletedResult = Schema.Struct({ _tag: Schema.Literal('deleted') })
 
 const ThreadStatus = Schema.Literals(['open', 'closed', 'archived'])
-const InboxPurpose = Schema.Literals(['human', 'agent', 'shared'])
 const Recipients = Schema.Union([Schema.String, Schema.Array(Schema.String)])
 
 // MCP attachments reference staged uploads — agents call
@@ -180,12 +179,11 @@ const StageEmailAttachment = Tool.make('stage_email_attachment', {
 
 const ListEmailThreads = Tool.make('list_email_threads', {
 	description:
-		'List email threads with filters. Returns an envelope {items, limit, offset, hasMore} — `hasMore` says whether more matched than were returned — read it before saying how many there are, and ask again with a larger `offset` if it is true. Each item carries message_count, last_message_at, last_message_direction, last_inbound_at, is_unread, and the linked inbox {email, displayName, purpose}. Supports search by subject (query), status (open/closed/archived), and inbox purpose (human/agent/shared). Default limit is 100, max 500.',
+		'List email threads with filters. Returns an envelope {items, limit, offset, hasMore} — `hasMore` says whether more matched than were returned — read it before saying how many there are, and ask again with a larger `offset` if it is true. Each item carries message_count, last_message_at, last_message_direction, last_inbound_at, is_unread, and the linked inbox {email, displayName, description}. Supports search by subject (query) and status (open/closed/archived). Default limit is 100, max 500.',
 	parameters: Schema.Struct({
 		inbox_id: Schema.optional(Schema.String),
 		company_id: Schema.optional(Schema.String),
 		status: Schema.optional(ThreadStatus),
-		purpose: Schema.optional(InboxPurpose),
 		query: Schema.optional(Schema.String),
 		limit: Schema.optional(McpPageLimit),
 		offset: Schema.optional(McpPageOffset),
@@ -312,21 +310,19 @@ const DownloadEmailAttachment = Tool.make('download_email_attachment', {
 	.annotate(Tool.OpenWorld, true)
 
 // ── Inbox management ─────────────────────────────────────────────
-// Inboxes are owned by an (organization, user) pair. Each row stores its
-// own IMAP/SMTP transport configuration plus encrypted credentials —
-// Batuda is a generic mail client (Infomaniak, Fastmail, M365 IMAP, …),
-// not a hosted mailbox. `purpose` drives composer visibility: human
-// inboxes belong to a team member, agent inboxes are AI-only, shared
-// inboxes surface in both.
+// Each row stores its own IMAP/SMTP transport configuration plus encrypted
+// credentials — Batuda is a generic mail client (Infomaniak, Fastmail, M365
+// IMAP, …), not a hosted mailbox. `ownerUserId` says whose it is: set means
+// it belongs to that member, null means the whole team's. That is what
+// decides who may send through it and who may change it.
 
 const ImapSecurity = Schema.Literals(['tls', 'starttls', 'plain'])
 const SmtpSecurity = Schema.Literals(['tls', 'starttls', 'plain'])
 
 const ListEmailInboxes = Tool.make('list_email_inboxes', {
 	description:
-		'List the mailboxes visible to the calling member in the active organization. Each row carries purpose (human/agent/shared), ownerUserId, isDefault, active flag, IMAP/SMTP transport hosts, and grant_status. Filter by purpose, active flag, or owner. Private mailboxes belonging to other members are hidden automatically. The response also reports whether the caller has a primary mailbox set (hasDefault plus its id and address), so a composer can check before send_email whether to prompt the user to connect one first.',
+		"List the mailboxes visible to the calling member in the active organization. Each row carries description (free text saying what the mailbox is for, may be empty), ownerUserId, isDefault, active flag, IMAP/SMTP transport hosts, and grant_status. ownerUserId is what matters for what you can do: it is the member the mailbox belongs to, or null when the mailbox belongs to the whole team. You can send through your own mailboxes and the team's, but not a colleague's. Filter by active flag or owner. Private mailboxes belonging to other members are hidden automatically. The response also reports whether the caller has a mailbox they send from by default (hasDefault plus its id and address), so a composer can check before send_email whether to prompt the user to connect one first.",
 	parameters: Schema.Struct({
-		purpose: Schema.optional(InboxPurpose),
 		active: Schema.optional(Schema.Boolean),
 		owner_user_id: Schema.optional(Schema.String),
 	}),
@@ -356,7 +352,7 @@ const ListEmailProviderPresets = Tool.make('list_email_provider_presets', {
 
 const ManageEmailInbox = Tool.make('manage_email_inbox', {
 	description:
-		"Manage the mailboxes connected to the active organization. action=create connects a new one and needs the full IMAP + SMTP details plus a password (use list_email_provider_presets to pre-fill hosts and ports for a known provider) — Batuda is a generic IMAP/SMTP client, not a hosted mail provider, so if the account has two-factor authentication its normal login password is rejected and a provider app-specific password is required (see appPasswordUrl on the matching preset); Gmail and Microsoft 365 no longer allow password sign-in at all (passwordAuthSupported=false). action=update changes only the fields you pass on an existing id, re-encrypting the password if one is given, and active=false hides the mailbox from composers and stops syncing while keeping historical threads. action=test re-runs a real IMAP LOGIN and SMTP check against the stored credentials and refreshes grant_status — use it after changing a password. action=delete soft-deletes: it sets active=false and is_default=false, preserving messages, and update with active=true restores it. action=set_primary promotes one of your own human mailboxes to be your default From identity, clearing the previous one; it rejects shared, inactive, and other members' mailboxes. Credentials are encrypted at rest. purpose=human defaults ownership to the caller; purpose=shared clears any owner_user_id and rejects is_private=true.",
+		"Manage the mailboxes connected to the active organization. Who may do what: a member manages only their own mailboxes, while an organization admin manages anyone's — but nobody, admin included, chooses which mailbox another member sends from by default, since that is a personal preference. A mailbox you may not manage answers as if it did not exist, so do not read that as proof it is absent. action=create connects a new one and needs the full IMAP + SMTP details plus a password (use list_email_provider_presets to pre-fill hosts and ports for a known provider) — Batuda is a generic IMAP/SMTP client, not a hosted mail provider, so if the account has two-factor authentication its normal login password is rejected and a provider app-specific password is required (see appPasswordUrl on the matching preset); Gmail and Microsoft 365 no longer allow password sign-in at all (passwordAuthSupported=false). A new mailbox belongs to the caller unless shared=true sets it up for the whole team, which only an admin may do and which rules out is_private and is_default. The first mailbox someone connects becomes the one they send from, so there is usually nothing further to set. action=update changes only the fields you pass on an existing id, re-encrypting the password if one is given, and active=false hides the mailbox from composers and stops syncing while keeping historical threads. action=test re-runs a real IMAP LOGIN and SMTP check against the stored credentials and refreshes grant_status — use it after changing a password. action=delete soft-deletes: it sets active=false and is_default=false, preserving messages, and update with active=true restores it; deleting one that was already deleted reports it as absent rather than succeeding again. action=set_primary chooses which of your own mailboxes you send from when you do not say, clearing the previous one; it rejects deleted mailboxes and anyone else's. description is free text saying what the mailbox is for and nothing depends on it, up to 200 characters. Credentials are encrypted at rest.",
 	parameters: Schema.Struct({
 		action: Schema.Literals([
 			'create',
@@ -376,10 +372,15 @@ const ManageEmailInbox = Tool.make('manage_email_inbox', {
 		smtp_host: Schema.optional(Schema.String),
 		smtp_port: Schema.optional(Schema.Number),
 		smtp_security: Schema.optional(SmtpSecurity),
-		purpose: Schema.optional(InboxPurpose),
 		username: Schema.optional(Schema.String),
 		display_name: Schema.optional(Schema.NullOr(Schema.String)),
+		// Free text saying what the mailbox is for. Nothing depends on it.
+		description: Schema.optional(Schema.NullOr(Schema.String)),
 		owner_user_id: Schema.optional(Schema.NullOr(Schema.String)),
+		// Set up for the whole team rather than one person, which only an
+		// organization admin may do. Such a mailbox has no owner, so it can be
+		// neither private nor anybody's default sender.
+		shared: Schema.optional(Schema.Boolean),
 		is_default: Schema.optional(Schema.Boolean),
 		is_private: Schema.optional(Schema.Boolean),
 		active: Schema.optional(Schema.Boolean),
@@ -745,9 +746,6 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							companyId: params.company_id,
 						}),
 						...(params.status !== undefined && { status: params.status }),
-						...(params.purpose !== undefined && {
-							purpose: params.purpose,
-						}),
 						...(params.query !== undefined && { query: params.query }),
 						...(params.limit !== undefined && { limit: params.limit }),
 						...(params.offset !== undefined && { offset: params.offset }),
@@ -822,7 +820,6 @@ export const EmailHandlersLive = EmailTools.toLayer(
 			list_email_inboxes: params =>
 				Effect.gen(function* () {
 					const inboxes = yield* svc.listLocalInboxes({
-						...(params.purpose !== undefined && { purpose: params.purpose }),
 						...(params.active !== undefined && { active: params.active }),
 						...(params.owner_user_id !== undefined && {
 							ownerUserId: params.owner_user_id,
@@ -872,7 +869,6 @@ export const EmailHandlersLive = EmailTools.toLayer(
 						const {
 							email,
 							password,
-							purpose,
 							imap_host,
 							imap_port,
 							imap_security,
@@ -883,7 +879,6 @@ export const EmailHandlersLive = EmailTools.toLayer(
 						if (
 							email === undefined ||
 							password === undefined ||
-							purpose === undefined ||
 							imap_host === undefined ||
 							imap_port === undefined ||
 							imap_security === undefined ||
@@ -892,31 +887,49 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							smtp_security === undefined
 						)
 							return dieMissing(
-								'create needs email, password, purpose and the full imap_* and smtp_* transport details',
+								'create needs email, password and the full imap_* and smtp_* transport details',
 							)
-						return svc
-							.createInbox({
-								...transport,
-								// Null means "clear it", which only makes sense against a
-								// mailbox that already exists.
-								...(typeof params.display_name === 'string' && {
-									displayName: params.display_name,
-								}),
-								...(typeof params.owner_user_id === 'string' && {
-									ownerUserId: params.owner_user_id,
-								}),
-								email,
-								password,
-								purpose,
-								username: params.username ?? email,
-								imapHost: imap_host,
-								imapPort: imap_port,
-								imapSecurity: imap_security,
-								smtpHost: smtp_host,
-								smtpPort: smtp_port,
-								smtpSecurity: smtp_security,
-							})
-							.pipe(Effect.orDie)
+						return (
+							svc
+								.createInbox({
+									...transport,
+									// Null means "clear it", which only makes sense against a
+									// mailbox that already exists.
+									...(typeof params.display_name === 'string' && {
+										displayName: params.display_name,
+									}),
+									...(typeof params.description === 'string' && {
+										description: params.description,
+									}),
+									...(params.shared !== undefined && { shared: params.shared }),
+									...(params.is_default !== undefined && {
+										isDefault: params.is_default,
+									}),
+									...(params.is_private !== undefined && {
+										isPrivate: params.is_private,
+									}),
+									...(typeof params.owner_user_id === 'string' && {
+										ownerUserId: params.owner_user_id,
+									}),
+									email,
+									password,
+									username: params.username ?? email,
+									imapHost: imap_host,
+									imapPort: imap_port,
+									imapSecurity: imap_security,
+									smtpHost: smtp_host,
+									smtpPort: smtp_port,
+									smtpSecurity: smtp_security,
+								})
+								// Refusals carry their reason, so the caller learns it needs
+								// an admin rather than seeing an unexplained failure.
+								.pipe(
+									Effect.catchTag('BadRequest', e =>
+										Effect.die(new Error(e.message)),
+									),
+									Effect.orDie,
+								)
+						)
 					}
 					case 'update':
 						return needsId().pipe(
@@ -931,13 +944,24 @@ export const EmailHandlersLive = EmailTools.toLayer(
 									...(params.owner_user_id !== undefined && {
 										ownerUserId: params.owner_user_id,
 									}),
-									...(params.purpose !== undefined && {
-										purpose: params.purpose,
+									...(params.description !== undefined && {
+										description: params.description,
+									}),
+									...(params.is_default !== undefined && {
+										isDefault: params.is_default,
+									}),
+									...(params.is_private !== undefined && {
+										isPrivate: params.is_private,
 									}),
 									...(params.active !== undefined && { active: params.active }),
 								}),
 							),
 							Effect.catchTag('NotFound', e => Effect.die(e)),
+							// Refusals carry their reason, so the caller learns whose
+							// mailbox it is rather than seeing an unexplained failure.
+							Effect.catchTag('BadRequest', e =>
+								Effect.die(new Error(e.message)),
+							),
 							Effect.orDie,
 						)
 					case 'test':
@@ -955,6 +979,11 @@ export const EmailHandlersLive = EmailTools.toLayer(
 					case 'set_primary':
 						return needsId().pipe(
 							Effect.flatMap(id => svc.setPrimaryInbox(id)),
+							// Refusals carry their reason, so the caller learns the
+							// mailbox is not theirs rather than seeing a bare failure.
+							Effect.catchTag('BadRequest', e =>
+								Effect.die(new Error(e.message)),
+							),
 							Effect.orDie,
 						)
 				}

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -62,6 +62,10 @@ export const detachFromTransaction =
  * so the user GUC is left unset rather than written as an empty string — an
  * empty string reads back as `''` (not NULL) and could match an empty-keyed
  * row under a future user-scoped policy.
+ *
+ * `role` is optional for the same reason and defaults to none: work with no
+ * member behind it manages nothing, so leaving it out grants no authority
+ * rather than borrowing someone else's.
  */
 export const enterOrgScope =
 	(
@@ -69,7 +73,11 @@ export const enterOrgScope =
 		// free of SqlClient — the HTTP middleware boundary only admits the
 		// services it provides. Every caller already holds a layer-level binding.
 		sql: SqlClient.SqlClient,
-		scope: { readonly org: OrgRow; readonly userId?: string | undefined },
+		scope: {
+			readonly org: OrgRow
+			readonly userId?: string | undefined
+			readonly role?: string | null | undefined
+		},
 	) =>
 	<A, E, R>(effect: Effect.Effect<A, E, R>) =>
 		sql
@@ -79,7 +87,10 @@ export const enterOrgScope =
 					yield* sql`SELECT set_config('app.current_org_id', ${scope.org.id}, true)`
 					if (scope.userId !== undefined)
 						yield* sql`SELECT set_config('app.current_user_id', ${scope.userId}, true)`
-					return yield* Effect.provideService(effect, CurrentOrg, scope.org)
+					return yield* Effect.provideService(effect, CurrentOrg, {
+						...scope.org,
+						role: scope.role ?? null,
+					})
 				}),
 			)
 			// Die only on SqlError: the role/GUC prologue and the commit are
@@ -169,8 +180,9 @@ export const resolveSystemOrg =
  *   2. Reject with `Unauthorized` if no session — defense in depth, since
  *      `SessionMiddleware` should already have stopped that path.
  *   3. Reject with `Forbidden` if the session has no `activeOrganizationId`.
- *   4. Look up the organization row by id — slug + name are read alongside
- *      so route handlers can build org-scoped URLs without a second query.
+ *   4. Look up the organization row by id, together with the caller's role
+ *      in it — slug + name are read alongside so route handlers can build
+ *      org-scoped URLs without a second query.
  *   5. Hand off to `enterOrgScope` — role + both GUCs + `CurrentOrg` inside
  *      one transaction; see its doc for the savepoint/scope mechanics.
  */
@@ -214,10 +226,16 @@ export const OrgMiddlewareLive = Layer.effect(
 				// die rather than leaking `SqlError` into the middleware's
 				// declared { Unauthorized | Forbidden } error union, which would
 				// otherwise force every protected route to handle SqlError.
-				const orgRows = yield* sql<OrgRow>`
-					SELECT id, name, slug
-					FROM "organization"
-					WHERE id = ${activeOrgId}
+				//
+				// The membership join is LEFT on purpose: a session still pointing
+				// at an organization the person has since left resolves that org
+				// with no standing in it, so they manage nothing there.
+				const orgRows = yield* sql<OrgRow & { readonly role: string | null }>`
+					SELECT o.id, o.name, o.slug, m.role
+					FROM "organization" o
+					LEFT JOIN "member" m
+						ON m."organizationId" = o.id AND m."userId" = ${result.user.id}
+					WHERE o.id = ${activeOrgId}
 					LIMIT 1
 				`.pipe(Effect.orDie)
 				const row = orgRows[0]
@@ -241,6 +259,7 @@ export const OrgMiddlewareLive = Layer.effect(
 				return yield* enterOrgScope(sql, {
 					org: row,
 					userId: result.user.id,
+					role: row.role,
 				})(effect)
 			})
 	}),

--- a/apps/server/src/services/companies-detail.integration.test.ts
+++ b/apps/server/src/services/companies-detail.integration.test.ts
@@ -70,7 +70,12 @@ const searchWith = (filters: Record<string, unknown>) =>
 			const page = yield* svc.search(filters)
 			return page.items
 		}).pipe(
-			Effect.provideService(CurrentOrg, { id: ORG, name: 'd', slug: 'd' }),
+			Effect.provideService(CurrentOrg, {
+				id: ORG,
+				name: 'd',
+				slug: 'd',
+				role: 'member',
+			}),
 		),
 	)
 
@@ -80,7 +85,12 @@ const detailOf = (slug: string) =>
 			const svc = yield* CompanyService
 			return yield* svc.getWithRelations(slug)
 		}).pipe(
-			Effect.provideService(CurrentOrg, { id: ORG, name: 'd', slug: 'd' }),
+			Effect.provideService(CurrentOrg, {
+				id: ORG,
+				name: 'd',
+				slug: 'd',
+				role: 'member',
+			}),
 		),
 	)
 

--- a/apps/server/src/services/email-inbox-authorization.integration.test.ts
+++ b/apps/server/src/services/email-inbox-authorization.integration.test.ts
@@ -1,0 +1,666 @@
+// PgLive reads DATABASE_URL at layer-build time (no default). Set it so the
+// suite runs without a loaded .env, matching the other integration tests.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { Effect, Exit, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { CurrentOrg, SessionContext } from '@batuda/controllers'
+
+import { PgLive } from '../db/client.js'
+import { CalendarService } from './calendar.js'
+import { CredentialCrypto } from './credential-crypto.js'
+import { EmailService } from './email.js'
+import { EmailAttachmentStaging } from './email-attachment-staging.js'
+import { DraftStore } from './email-draft-store.js'
+import { EmailProvider } from './email-provider.js'
+import { MailTransport } from './mail-transport.js'
+import { StorageProvider } from './storage-provider.js'
+import { TimelineActivityService } from './timeline-activity.js'
+
+// Who may reach whose mailbox. Real Postgres so the database rules that back
+// these decisions (one default per person, a team mailbox owned by nobody)
+// take part rather than being assumed.
+
+const ORG = 'inbox-authz-test-org'
+const ALICE = 'inbox-authz-alice'
+const BOB = 'inbox-authz-bob'
+
+const stubCrypto = Layer.succeed(CredentialCrypto, {
+	encryptPassword: () => ({
+		ciphertext: new Uint8Array([0]),
+		nonce: new Uint8Array([0]),
+		tag: new Uint8Array([0]),
+	}),
+	decryptPassword: () => 'stubbed-password',
+} as never)
+
+const stubTransport = Layer.succeed(MailTransport, {
+	probe: () => Effect.void,
+	send: () => Effect.die('send not used in this test'),
+	appendToSent: () => Effect.die('appendToSent not used in this test'),
+} as never)
+
+const serviceLayer = EmailService.layer.pipe(
+	Layer.provide([
+		stubCrypto,
+		stubTransport,
+		Layer.succeed(EmailProvider, {} as never),
+		Layer.succeed(TimelineActivityService, {} as never),
+		Layer.succeed(EmailAttachmentStaging, {} as never),
+		// Real, not stubbed: half-written mail is reached through it, and the
+		// rules about who may are the point of this suite.
+		DraftStore.layer.pipe(Layer.provide(PgLive)),
+		Layer.succeed(CalendarService, {} as never),
+		Layer.succeed(StorageProvider, {} as never),
+	]),
+	Layer.provide(PgLive),
+)
+
+// The caller: who they are, and what they may do in the organization.
+const actingAs = (userId: string, role: string) =>
+	Layer.mergeAll(
+		Layer.succeed(CurrentOrg, {
+			id: ORG,
+			name: 'Authz Test',
+			slug: 'authz-test',
+			role,
+		}),
+		Layer.succeed(SessionContext, {
+			userId,
+			email: `${userId}@test.local`,
+			name: undefined,
+			isAgent: false,
+		}),
+	)
+
+const run = <A, E>(
+	effect: Effect.Effect<
+		A,
+		E,
+		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
+	>,
+	userId: string,
+	role: string,
+) =>
+	Effect.runPromiseExit(
+		effect.pipe(
+			Effect.provide(serviceLayer),
+			Effect.provide(actingAs(userId, role)),
+			Effect.provide(PgLive),
+		),
+	)
+
+const placeholder = new Uint8Array([0])
+
+// Straight to Postgres so the fixture does not depend on the rules under test.
+const insertInbox = (args: {
+	readonly email: string
+	readonly ownerUserId: string | null
+	readonly isDefault?: boolean
+}) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const rows = yield* sql<{ id: string }>`
+			INSERT INTO inboxes (
+				organization_id, email, owner_user_id, is_default,
+				imap_host, imap_port, imap_security,
+				smtp_host, smtp_port, smtp_security, username,
+				password_ciphertext, password_nonce, password_tag
+			) VALUES (
+				${ORG}, ${args.email}, ${args.ownerUserId}, ${args.isDefault ?? false},
+				'imap.test', 993, 'tls', 'smtp.test', 465, 'tls', ${args.email},
+				${placeholder}, ${placeholder}, ${placeholder}
+			)
+			RETURNING id
+		`
+		return rows[0]!.id
+	})
+
+const cleanup = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+	yield* sql`DELETE FROM email_drafts WHERE organization_id = ${ORG}`
+	yield* sql`DELETE FROM inbox_footers WHERE organization_id = ${ORG}`
+	yield* sql`DELETE FROM inboxes WHERE organization_id = ${ORG}`
+})
+
+// A half-written message sitting in a mailbox, put there without going through
+// the rules being tested.
+const insertDraft = (inboxId: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const draftId = `draft_authz_${inboxId.slice(0, 8)}`
+		yield* sql`
+			INSERT INTO email_drafts ${sql.insert({
+				draftId,
+				organizationId: ORG,
+				inboxId,
+				mode: 'new',
+				toAddresses: [],
+				ccAddresses: [],
+				bccAddresses: [],
+				subject: 'private thoughts',
+				bodyJson: '[]',
+			})}
+		`
+		return draftId
+	})
+
+const runPlain = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
+	Effect.runPromise(effect.pipe(Effect.provide(PgLive)))
+
+// The mailbox somebody sends from, read straight from the row.
+const defaultOf = (userId: string) =>
+	runPlain(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* sql<{ email: string }>`
+				SELECT email FROM inboxes
+				WHERE organization_id = ${ORG}
+				  AND owner_user_id = ${userId}
+				  AND is_default = true
+			`
+		}),
+	)
+
+describe('who may reach a mailbox', () => {
+	beforeEach(async () => {
+		await runPlain(cleanup)
+	})
+
+	afterAll(async () => {
+		await runPlain(cleanup)
+	})
+
+	describe('when the mailbox belongs to a colleague', () => {
+		it('should tell an ordinary member it does not exist', async () => {
+			// GIVEN a mailbox belonging to Bob
+			const id = await runPlain(
+				insertInbox({ email: 'bob-only@test.local', ownerUserId: BOB }),
+			)
+			// WHEN Alice, an ordinary member, tries to change it
+			const exit = await run(
+				Effect.flip(
+					Effect.gen(function* () {
+						const svc = yield* EmailService
+						return yield* svc.updateInbox(id, { displayName: 'stolen' })
+					}),
+				),
+				ALICE,
+				'member',
+			)
+			// THEN it reads as absent, not as refused — checked by name, since a
+			// refusal would confirm the mailbox is there and that is the whole
+			// thing this prevents
+			expect(Exit.isSuccess(exit)).toBe(true)
+			expect(
+				Exit.isSuccess(exit) ? (exit.value as { _tag: string })._tag : null,
+			).toBe('NotFound')
+		})
+
+		it('should refuse an ordinary member the re-test of its password', async () => {
+			// GIVEN a mailbox belonging to Bob
+			const id = await runPlain(
+				insertInbox({ email: 'bob-probe@test.local', ownerUserId: BOB }),
+			)
+			// WHEN Alice asks to re-test its stored password
+			const exit = await run(
+				Effect.flip(
+					Effect.gen(function* () {
+						const svc = yield* EmailService
+						return yield* svc.testInbox(id)
+					}),
+				),
+				ALICE,
+				'member',
+			)
+			// THEN she cannot, and again it reads as absent rather than refused,
+			// so whether somebody's password still works stays theirs to know
+			expect(Exit.isSuccess(exit)).toBe(true)
+			expect(
+				Exit.isSuccess(exit) ? (exit.value as { _tag: string })._tag : null,
+			).toBe('NotFound')
+		})
+
+		it('should let an admin change it', async () => {
+			// GIVEN a mailbox belonging to Bob
+			const id = await runPlain(
+				insertInbox({ email: 'bob-admin@test.local', ownerUserId: BOB }),
+			)
+			// WHEN Alice, who runs the organization, renames it
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.updateInbox(id, { displayName: 'Renamed' })
+				}),
+				ALICE,
+				'admin',
+			)
+			// THEN she may: looking after everyone's mailboxes is what running the
+			// organization means
+			expect(Exit.isSuccess(exit)).toBe(true)
+		})
+
+		it('should refuse even an admin the choice of what they send from', async () => {
+			// GIVEN a mailbox belonging to Bob
+			const id = await runPlain(
+				insertInbox({ email: 'bob-default@test.local', ownerUserId: BOB }),
+			)
+			// WHEN Alice, who runs the organization, tries to make it the one Bob
+			// sends from
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.updateInbox(id, { isDefault: true })
+				}),
+				ALICE,
+				'admin',
+			)
+			// THEN she cannot: which address somebody sends from is theirs alone
+			expect(Exit.isFailure(exit)).toBe(true)
+		})
+
+		it('should refuse even an admin taking that choice away', async () => {
+			// GIVEN a mailbox Bob already sends from
+			const id = await runPlain(
+				insertInbox({
+					email: 'bob-clear@test.local',
+					ownerUserId: BOB,
+					isDefault: true,
+				}),
+			)
+			// WHEN Alice, who runs the organization, tries to unset it
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.updateInbox(id, { isDefault: false })
+				}),
+				ALICE,
+				'admin',
+			)
+			// THEN she cannot: taking the choice away is still changing it
+			expect(Exit.isFailure(exit)).toBe(true)
+		})
+
+		it('should refuse handing a mailbox over in the same breath as marking it', async () => {
+			// GIVEN a mailbox of Alice's own
+			const id = await runPlain(
+				insertInbox({ email: 'alice-hand@test.local', ownerUserId: ALICE }),
+			)
+			// WHEN she hands it to Bob and marks it as a default at once
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.updateInbox(id, {
+						ownerUserId: BOB,
+						isDefault: true,
+					})
+				}),
+				ALICE,
+				'admin',
+			)
+			// THEN she cannot, so the two together are no way around the rule
+			expect(Exit.isFailure(exit)).toBe(true)
+		})
+	})
+
+	describe('when a mailbox changes hands', () => {
+		it('should not hand the sending choice over with it', async () => {
+			// GIVEN a mailbox Alice already sends from, and Bob with none
+			const id = await runPlain(
+				insertInbox({
+					email: 'handover@test.local',
+					ownerUserId: ALICE,
+					isDefault: true,
+				}),
+			)
+			// WHEN Alice, who runs the organization, hands it to Bob without
+			// saying anything about default senders
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.updateInbox(id, { ownerUserId: BOB })
+				}),
+				ALICE,
+				'admin',
+			)
+			expect(Exit.isSuccess(exit)).toBe(true)
+			// THEN Bob does not silently start sending as that address: the mark
+			// comes off, for him to make the choice himself
+			expect(await defaultOf(BOB)).toHaveLength(0)
+		})
+	})
+
+	describe('when the half-written mail is a colleague’s', () => {
+		it('should read as absent even when the caller names their own mailbox', async () => {
+			// GIVEN a draft sitting in Bob's mailbox, and Alice with her own
+			const bobInbox = await runPlain(
+				insertInbox({ email: 'bob-drafts@test.local', ownerUserId: BOB }),
+			)
+			const aliceInbox = await runPlain(
+				insertInbox({ email: 'alice-drafts@test.local', ownerUserId: ALICE }),
+			)
+			const draftId = await runPlain(insertDraft(bobInbox))
+			// WHEN Alice asks for it while naming a mailbox that IS hers, which is
+			// the way around any check that only looks at what was asked for
+			const exit = await run(
+				Effect.flip(
+					Effect.gen(function* () {
+						const svc = yield* EmailService
+						return yield* svc.getDraft(aliceInbox, draftId)
+					}),
+				),
+				ALICE,
+				'member',
+			)
+			// THEN it reads as absent: what decides is the mailbox the message
+			// would go out from, not the one she asked with
+			expect(Exit.isSuccess(exit)).toBe(true)
+			expect(
+				Exit.isSuccess(exit) ? (exit.value as { _tag: string })._tag : null,
+			).toBe('NotFound')
+		})
+
+		it('should keep it out of the list when no mailbox is named', async () => {
+			// GIVEN a draft in Bob's mailbox and one in Alice's
+			const bobInbox = await runPlain(
+				insertInbox({ email: 'bob-list@test.local', ownerUserId: BOB }),
+			)
+			const aliceInbox = await runPlain(
+				insertInbox({ email: 'alice-list@test.local', ownerUserId: ALICE }),
+			)
+			await runPlain(insertDraft(bobInbox))
+			await runPlain(insertDraft(aliceInbox))
+			// WHEN Alice lists her drafts without naming a mailbox
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.listDrafts()
+				}),
+				ALICE,
+				'member',
+			)
+			// THEN she sees only her own: naming nothing means hers, not the
+			// organization's
+			expect(Exit.isSuccess(exit)).toBe(true)
+			const items = Exit.isSuccess(exit)
+				? (exit.value as { items: ReadonlyArray<{ inboxId: string }> }).items
+				: []
+			expect(items).toHaveLength(1)
+			expect(items[0]?.inboxId).toBe(aliceInbox)
+		})
+	})
+
+	describe('when the signature belongs to a colleague’s mailbox', () => {
+		it('should refuse an ordinary member writing one', async () => {
+			// GIVEN a mailbox belonging to Bob
+			const id = await runPlain(
+				insertInbox({ email: 'bob-footer@test.local', ownerUserId: BOB }),
+			)
+			// WHEN Alice adds a signature to it
+			const exit = await run(
+				Effect.flip(
+					Effect.gen(function* () {
+						const svc = yield* EmailService
+						return yield* svc.createFooter({
+							inboxId: id,
+							name: 'sneaky',
+							bodyJson: [],
+						})
+					}),
+				),
+				ALICE,
+				'member',
+			)
+			// THEN she cannot: a signature goes out on every message that mailbox
+			// sends, so writing one is changing what somebody else's mail says
+			expect(Exit.isSuccess(exit)).toBe(true)
+			expect(
+				Exit.isSuccess(exit) ? (exit.value as { _tag: string })._tag : null,
+			).toBe('NotFound')
+		})
+
+		it('should keep its signatures out of sight', async () => {
+			// GIVEN a mailbox belonging to Bob
+			const id = await runPlain(
+				insertInbox({ email: 'bob-footer-list@test.local', ownerUserId: BOB }),
+			)
+			// WHEN Alice lists its signatures
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.listFooters(id)
+				}),
+				ALICE,
+				'member',
+			)
+			// THEN she sees nothing, rather than being told there is something
+			// she may not see
+			expect(Exit.isSuccess(exit)).toBe(true)
+			expect(Exit.isSuccess(exit) ? exit.value : null).toHaveLength(0)
+		})
+	})
+
+	describe('when nobody is behind the request', () => {
+		it('should manage nothing at all', async () => {
+			// GIVEN a mailbox belonging to Bob, and work with no acting member —
+			// a webhook, or anything outliving the request that began it
+			const id = await runPlain(
+				insertInbox({ email: 'bob-unattended@test.local', ownerUserId: BOB }),
+			)
+			// WHEN that work tries to change it
+			const exit = await Effect.runPromiseExit(
+				Effect.flip(
+					Effect.gen(function* () {
+						const svc = yield* EmailService
+						return yield* svc.updateInbox(id, { displayName: 'by nobody' })
+					}),
+				).pipe(
+					Effect.provide(serviceLayer),
+					Effect.provide(
+						Layer.mergeAll(
+							Layer.succeed(CurrentOrg, {
+								id: ORG,
+								name: 'Authz Test',
+								slug: 'authz-test',
+								role: null,
+							}),
+							Layer.succeed(SessionContext, {
+								userId: 'unattended',
+								email: 'unattended@test.local',
+								name: undefined,
+								isAgent: false,
+							}),
+						),
+					),
+					Effect.provide(PgLive),
+				),
+			)
+			// THEN it cannot: carrying no standing means managing nothing, so
+			// unattended work can never act on what belongs to one person
+			expect(Exit.isSuccess(exit)).toBe(true)
+			expect(
+				Exit.isSuccess(exit) ? (exit.value as { _tag: string })._tag : null,
+			).toBe('NotFound')
+		})
+	})
+
+	describe('when the mailbox is their own', () => {
+		it('should let them change it', async () => {
+			// GIVEN a mailbox belonging to Alice
+			const id = await runPlain(
+				insertInbox({ email: 'alice-own@test.local', ownerUserId: ALICE }),
+			)
+			// WHEN she renames it
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.updateInbox(id, { description: 'Enquiries' })
+				}),
+				ALICE,
+				'member',
+			)
+			// THEN she may, without needing to run the organization
+			expect(Exit.isSuccess(exit)).toBe(true)
+		})
+
+		it('should let them choose what they send from', async () => {
+			// GIVEN a mailbox belonging to Alice
+			const id = await runPlain(
+				insertInbox({ email: 'alice-pick@test.local', ownerUserId: ALICE }),
+			)
+			// WHEN she picks it as the one she sends from
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.setPrimaryInbox(id)
+				}),
+				ALICE,
+				'member',
+			)
+			// THEN she may: it is her own choice to make
+			expect(Exit.isSuccess(exit)).toBe(true)
+		})
+
+		it('should report a mailbox already removed as gone', async () => {
+			// GIVEN a mailbox of Alice's that she has already removed
+			const id = await runPlain(
+				insertInbox({ email: 'alice-gone@test.local', ownerUserId: ALICE }),
+			)
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.deleteInbox(id)
+				}),
+				ALICE,
+				'member',
+			)
+			// WHEN she removes it a second time
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.deleteInbox(id)
+				}),
+				ALICE,
+				'member',
+			)
+			// THEN it says so, rather than reporting a removal that never happened
+			expect(Exit.isFailure(exit)).toBe(true)
+		})
+	})
+
+	describe('when connecting a mailbox', () => {
+		const connect = (email: string, extra: Record<string, unknown>) =>
+			Effect.gen(function* () {
+				const svc = yield* EmailService
+				return yield* svc.createInbox({
+					email,
+					imapHost: 'imap.test',
+					imapPort: 993,
+					imapSecurity: 'tls',
+					smtpHost: 'smtp.test',
+					smtpPort: 465,
+					smtpSecurity: 'tls',
+					username: email,
+					password: 'pw',
+					...extra,
+				} as never)
+			})
+
+		it('should refuse an ordinary member naming another owner', async () => {
+			// GIVEN Alice, an ordinary member
+			// WHEN she connects a mailbox in Bob's name
+			const exit = await run(
+				connect('for-bob@test.local', { ownerUserId: BOB }),
+				ALICE,
+				'member',
+			)
+			// THEN she cannot put a mailbox in somebody else's name
+			expect(Exit.isFailure(exit)).toBe(true)
+		})
+
+		it('should refuse an ordinary member setting one up for the team', async () => {
+			// GIVEN Alice, an ordinary member
+			// WHEN she connects a mailbox belonging to the whole team
+			const exit = await run(
+				connect('team-by-member@test.local', { shared: true }),
+				ALICE,
+				'member',
+			)
+			// THEN she cannot: a mailbox for everyone is the organization's to set up
+			expect(Exit.isFailure(exit)).toBe(true)
+		})
+
+		it('should let an admin set one up for the team', async () => {
+			// GIVEN Alice, who runs the organization
+			// WHEN she connects a mailbox belonging to the whole team
+			const exit = await run(
+				connect('team-by-admin@test.local', { shared: true }),
+				ALICE,
+				'admin',
+			)
+			// THEN she may
+			expect(Exit.isSuccess(exit)).toBe(true)
+		})
+
+		it('should make somebody’s first mailbox the one they send from', async () => {
+			// GIVEN Alice with no mailbox at all
+			// WHEN she connects her first
+			const exit = await run(
+				connect('alice-first@test.local', {}),
+				ALICE,
+				'member',
+			)
+			expect(Exit.isSuccess(exit)).toBe(true)
+			// THEN it is already the one she sends from, so sending works without
+			// hunting for a setting
+			const rows = await runPlain(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* sql<{ isDefault: boolean }>`
+						SELECT is_default FROM inboxes
+						WHERE organization_id = ${ORG} AND email = 'alice-first@test.local'
+					`
+				}),
+			)
+			expect(rows[0]?.isDefault).toBe(true)
+		})
+
+		it('should not make somebody’s first mailbox their default when set up for them', async () => {
+			// GIVEN Bob with no mailbox at all
+			// WHEN Alice, who runs the organization, connects his first one for him
+			const exit = await run(
+				connect('for-bob-first@test.local', { ownerUserId: BOB }),
+				ALICE,
+				'admin',
+			)
+			expect(Exit.isSuccess(exit)).toBe(true)
+			// THEN it is not already what he sends from — the convenience of a
+			// first mailbox becoming the default is for the person connecting it
+			expect(await defaultOf(BOB)).toHaveLength(0)
+		})
+
+		it('should refuse an address already connected', async () => {
+			// GIVEN an address already connected and in use
+			await runPlain(
+				insertInbox({ email: 'twice@test.local', ownerUserId: ALICE }),
+			)
+			// WHEN Alice connects the same address again, in different case
+			const exit = await run(
+				Effect.flip(connect('TWICE@test.local', {})),
+				ALICE,
+				'member',
+			)
+			// THEN she is told plainly that the address is taken. Asserted as a
+			// stated refusal rather than merely "it failed", because the database
+			// rule would also turn it down — as a crash nobody can act on, which
+			// would let this test pass with the refusal removed.
+			expect(Exit.isSuccess(exit)).toBe(true)
+			expect(
+				Exit.isSuccess(exit) ? (exit.value as { _tag: string })._tag : null,
+			).toBe('BadRequest')
+		})
+	})
+})

--- a/apps/server/src/services/email-inbox-update.integration.test.ts
+++ b/apps/server/src/services/email-inbox-update.integration.test.ts
@@ -97,13 +97,13 @@ describe('EmailService.updateInbox re-probe', () => {
 		const placeholder = new Uint8Array([0])
 		const rows = yield* sql<{ id: string }>`
 			INSERT INTO inboxes (
-				organization_id, email, display_name, purpose, owner_user_id,
+				organization_id, email, display_name, owner_user_id,
 				imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security,
 				username, password_ciphertext, password_nonce, password_tag,
 				active, grant_status
 			) VALUES (
-				${TEST_ORG}, 'update@test.local', 'Baseline', 'human', ${TEST_USER},
+				${TEST_ORG}, 'update@test.local', 'Baseline',  ${TEST_USER},
 				'imap.test.local', 993, 'tls',
 				'smtp.test.local', 587, 'starttls',
 				'update@test.local', ${placeholder}, ${placeholder}, ${placeholder},
@@ -379,13 +379,13 @@ describe('EmailService.updateInbox re-probe — real credential round-trip', () 
 				const enc = encryptWithKey(TEST_KEY, { inboxId, plain: ORIGINAL_PW })
 				yield* sql`
 					INSERT INTO inboxes (
-						id, organization_id, email, display_name, purpose, owner_user_id,
+						id, organization_id, email, display_name, owner_user_id,
 						imap_host, imap_port, imap_security,
 						smtp_host, smtp_port, smtp_security,
 						username, password_ciphertext, password_nonce, password_tag,
 						active, grant_status
 					) VALUES (
-						${inboxId}, ${TEST_ORG}, 'roundtrip@test.local', 'Roundtrip', 'human', ${TEST_USER},
+						${inboxId}, ${TEST_ORG}, 'roundtrip@test.local', 'Roundtrip',  ${TEST_USER},
 						'imap.test.local', 993, 'tls',
 						'smtp.test.local', 587, 'starttls',
 						'roundtrip@test.local', ${enc.ciphertext}, ${enc.nonce}, ${enc.tag},
@@ -474,13 +474,13 @@ describe('EmailService.listThreads unread flag', () => {
 		const placeholder = new Uint8Array([0])
 		const inbox = yield* sql<{ id: string }>`
 			INSERT INTO inboxes (
-				organization_id, email, display_name, purpose, owner_user_id,
+				organization_id, email, display_name, owner_user_id,
 				imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security,
 				username, password_ciphertext, password_nonce, password_tag,
 				active, grant_status
 			) VALUES (
-				${TEST_ORG}, ${inboxEmail}, 'Threads', 'human', ${TEST_USER},
+				${TEST_ORG}, ${inboxEmail}, 'Threads',  ${TEST_USER},
 				'imap.test.local', 993, 'tls',
 				'smtp.test.local', 587, 'starttls',
 				${inboxEmail}, ${placeholder}, ${placeholder}, ${placeholder},

--- a/apps/server/src/services/email-search.integration.test.ts
+++ b/apps/server/src/services/email-search.integration.test.ts
@@ -110,11 +110,10 @@ beforeAll(async () => {
 
 	const inboxResult = await pool.query<{ id: string }>(
 		`INSERT INTO inboxes
-		 (organization_id, owner_user_id, email, purpose,
-		  imap_host, imap_port, imap_security,
+		 (organization_id, owner_user_id, email, imap_host, imap_port, imap_security,
 		  smtp_host, smtp_port, smtp_security,
 		  username, password_ciphertext, password_nonce, password_tag)
-		 VALUES ($1, $2, $3, 'human',
+		 VALUES ($1, $2, $3, 
 		         'imap.example.com', 993, 'tls',
 		         'smtp.example.com', 465, 'tls',
 		         $3, '\\x00'::bytea, '\\x00'::bytea, '\\x00'::bytea)

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -27,7 +27,7 @@ import {
 	NotFound,
 	SessionContext,
 } from '@batuda/controllers'
-import { EmailDraft, Inbox, InboxFooter } from '@batuda/domain'
+import { EmailDraft, Inbox, InboxFooter, isOrgManager } from '@batuda/domain'
 import { renderBlocks, type StagedAttachmentRef } from '@batuda/email/render'
 import type { EmailBlocks } from '@batuda/email/schema'
 
@@ -448,7 +448,7 @@ type InboxRow = {
 	organizationId: string
 	email: string
 	displayName: string | null
-	purpose: 'human' | 'agent' | 'shared'
+	description: string | null
 	ownerUserId: string | null
 	isDefault: boolean
 	isPrivate: boolean
@@ -520,23 +520,76 @@ export class EmailService extends Context.Service<EmailService>()(
 			// even if the planner skips the RLS policy.
 
 			const selectInboxColumns = sql`
-				id, organization_id, email, display_name, purpose, owner_user_id,
+				id, organization_id, email, display_name, description, owner_user_id,
 				is_default, is_private, active, imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security, username,
 				grant_status, grant_last_error, grant_last_seen_at,
 				created_at, updated_at
 			`
 
+			// Whose mailbox someone may act through: their own, and the team's.
+			// A colleague's mailbox is not theirs to send from, whatever else
+			// they are allowed to do around the organization.
+			const mayActThrough = (inbox: InboxRow, userId: string) =>
+				inbox.ownerUserId === null || inbox.ownerUserId === userId
+
+			// Whose settings someone may change, or remove: their own mailbox,
+			// and — for whoever runs the organization — anyone's. A mailbox with
+			// no owner is the organization's own, so it is theirs to look after
+			// rather than any one member's.
+			const mayLookAfter = (
+				inbox: InboxRow,
+				userId: string,
+				role: string | null,
+			) => isOrgManager(role) || inbox.ownerUserId === userId
+
+			// A half-written message is as private as a sent one, so reaching it
+			// takes the same standing as the mailbox it will go out from — which
+			// is the draft's own mailbox, not whichever one the caller names.
+			const assertDraftReachable = (
+				draftInboxId: string,
+				draftId: string,
+			): Effect.Effect<void, NotFound, CurrentOrg | SessionContext> =>
+				Effect.gen(function* () {
+					if (yield* resolveInbox(draftInboxId)) return
+					return yield* new NotFound({ entity: 'EmailDraft', id: draftId })
+				})
+
+			// Mailboxes out of the caller's reach read as absent rather than
+			// refused, so this can never be used to find out what exists.
 			const resolveInbox = (inboxId: string) =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
+					const session = yield* SessionContext
 					const rows = yield* sql<InboxRow>`
 						SELECT ${selectInboxColumns} FROM inboxes
 						WHERE id = ${inboxId}
 						  AND organization_id = ${currentOrg.id}
 						LIMIT 1
 					`.pipe(Effect.orDie)
-					return rows[0] ?? null
+					const inbox = rows[0]
+					if (!inbox) return null
+					return mayActThrough(inbox, session.userId) ? inbox : null
+				})
+
+			// The same lookup for changing a mailbox rather than acting through
+			// it, which is the stricter of the two for a member and the looser
+			// for whoever runs the organization.
+			const resolveInboxToLookAfter = (inboxId: string) =>
+				Effect.gen(function* () {
+					const currentOrg = yield* CurrentOrg
+					const session = yield* SessionContext
+					const rows = yield* sql<InboxRow>`
+						SELECT ${selectInboxColumns} FROM inboxes
+						WHERE id = ${inboxId}
+						  AND organization_id = ${currentOrg.id}
+						LIMIT 1
+					`.pipe(Effect.orDie)
+					const inbox = rows[0]
+					if (!inbox) return null
+					return mayLookAfter(inbox, session.userId, currentOrg.role)
+						? inbox
+						: null
 				})
 
 			// Decrypt the stored credentials in-memory, run an IMAP LOGIN + SMTP
@@ -643,7 +696,6 @@ export class EmailService extends Context.Service<EmailService>()(
 						SELECT ${selectInboxColumns} FROM inboxes
 						WHERE organization_id = ${currentOrg.id}
 						  AND owner_user_id = ${session.userId}
-						  AND purpose = 'human'
 						  AND is_default = true
 						  AND active = true
 						LIMIT 1
@@ -1278,7 +1330,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							updatedAt: Date
 							inboxEmail: string | null
 							inboxDisplayName: string | null
-							inboxPurpose: 'human' | 'agent' | 'shared' | null
+							inboxDescription: string | null
 							inboxIsPrivate: boolean | null
 							inboxOwnerUserId: string | null
 						}>`
@@ -1311,7 +1363,7 @@ export class EmailService extends Context.Service<EmailService>()(
 								tl.updated_at,
 								i.email AS inbox_email,
 								i.display_name AS inbox_display_name,
-								i.purpose AS inbox_purpose,
+								i.description AS inbox_description,
 								i.is_private AS inbox_is_private,
 								i.owner_user_id AS inbox_owner_user_id
 							FROM email_thread_links tl
@@ -1462,14 +1514,15 @@ export class EmailService extends Context.Service<EmailService>()(
 							companyId: link.companyId,
 							contactId: link.contactId,
 							messages: messagesOut,
-							inbox:
-								link.inboxEmail && link.inboxPurpose
-									? {
-											email: link.inboxEmail,
-											displayName: link.inboxDisplayName,
-											purpose: link.inboxPurpose,
-										}
-									: null,
+							// Keyed off the address alone: a mailbox is linked or it is
+							// not, and its description may legitimately be empty.
+							inbox: link.inboxEmail
+								? {
+										email: link.inboxEmail,
+										displayName: link.inboxDisplayName,
+										description: link.inboxDescription,
+									}
+								: null,
 						}).pipe(Effect.orDie)
 					}),
 
@@ -1521,7 +1574,6 @@ export class EmailService extends Context.Service<EmailService>()(
 					inboxId?: string
 					companyId?: string
 					status?: string
-					purpose?: 'human' | 'agent' | 'shared'
 					query?: string
 					limit?: number
 					offset?: number
@@ -1547,8 +1599,6 @@ export class EmailService extends Context.Service<EmailService>()(
 							conditions.push(sql`tl.company_id = ${filters.companyId}`)
 						if (filters?.status)
 							conditions.push(sql`tl.status = ${filters.status}`)
-						if (filters?.purpose)
-							conditions.push(sql`i.purpose = ${filters.purpose}`)
 						if (filters?.query) {
 							const trimmedQuery = filters.query.trim()
 							if (trimmedQuery.length > 0) {
@@ -1596,7 +1646,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							updatedAt: Date
 							inboxEmail: string | null
 							inboxDisplayName: string | null
-							inboxPurpose: 'human' | 'agent' | 'shared' | null
+							inboxDescription: string | null
 							messageCount: string | number
 							lastMessageAt: Date | null
 							lastMessageDirection: 'inbound' | 'outbound' | null
@@ -1633,7 +1683,7 @@ export class EmailService extends Context.Service<EmailService>()(
 								tl.updated_at,
 								i.email AS inbox_email,
 								i.display_name AS inbox_display_name,
-								i.purpose AS inbox_purpose,
+								i.description AS inbox_description,
 								(
 									SELECT COUNT(*) FROM email_messages m
 									WHERE m.organization_id = tl.organization_id
@@ -1710,21 +1760,22 @@ export class EmailService extends Context.Service<EmailService>()(
 							const {
 								inboxEmail,
 								inboxDisplayName,
-								inboxPurpose,
+								inboxDescription,
 								messageCount,
 								...rest
 							} = r
 							return {
 								...rest,
 								messageCount: Number(messageCount),
-								inbox:
-									inboxEmail && inboxPurpose
-										? {
-												email: inboxEmail,
-												displayName: inboxDisplayName,
-												purpose: inboxPurpose,
-											}
-										: null,
+								// Keyed off the address alone: a mailbox is linked or it
+								// is not, and its description may legitimately be empty.
+								inbox: inboxEmail
+									? {
+											email: inboxEmail,
+											displayName: inboxDisplayName,
+											description: inboxDescription,
+										}
+									: null,
 							}
 						})
 						return yield* decodeThreadList({
@@ -1814,7 +1865,6 @@ export class EmailService extends Context.Service<EmailService>()(
 				listProviderPresets: () => Effect.succeed(PROVIDER_PRESETS),
 
 				listLocalInboxes: (filters?: {
-					purpose?: 'human' | 'agent' | 'shared'
 					active?: boolean
 					ownerUserId?: string
 				}) =>
@@ -1827,8 +1877,6 @@ export class EmailService extends Context.Service<EmailService>()(
 							// always show; others' never do.
 							sql`(is_private = false OR owner_user_id = ${session.userId})`,
 						]
-						if (filters?.purpose)
-							conditions.push(sql`purpose = ${filters.purpose}`)
 						if (filters?.active !== undefined)
 							conditions.push(sql`active = ${filters.active}`)
 						if (filters?.ownerUserId)
@@ -1837,7 +1885,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							SELECT ${selectInboxColumns}
 							FROM inboxes
 							WHERE ${sql.and(conditions)}
-							ORDER BY is_default DESC, purpose, email
+							ORDER BY is_default DESC, email
 						`
 						return yield* decodeInboxes(rows)
 					}).pipe(Effect.orDie),
@@ -1850,7 +1898,6 @@ export class EmailService extends Context.Service<EmailService>()(
 							SELECT id, email FROM inboxes
 							WHERE organization_id = ${currentOrg.id}
 							  AND owner_user_id = ${session.userId}
-							  AND purpose = 'human'
 							  AND is_default = true
 							  AND active = true
 							LIMIT 1
@@ -1868,7 +1915,8 @@ export class EmailService extends Context.Service<EmailService>()(
 				createInbox: (input: {
 					email: string
 					displayName?: string | undefined
-					purpose: 'human' | 'agent' | 'shared'
+					description?: string | undefined
+					shared?: boolean | undefined
 					ownerUserId?: string | undefined
 					isPrivate?: boolean | undefined
 					isDefault?: boolean | undefined
@@ -1885,20 +1933,71 @@ export class EmailService extends Context.Service<EmailService>()(
 						const currentOrg = yield* CurrentOrg
 						const session = yield* SessionContext
 
-						// purpose CHECK constraint demands an owner for human/agent
-						// and forbids one for shared. Default to the caller for
-						// human inboxes when ownerUserId is omitted; reject the
-						// shared+owner mismatch up-front so the DB error stays
-						// internal.
-						const ownerUserId =
-							input.purpose === 'shared'
-								? null
-								: (input.ownerUserId ?? session.userId)
-						if (input.purpose === 'shared' && input.isPrivate === true) {
+						// A mailbox belongs to whoever connects it unless it is being
+						// set up for the whole team.
+						const ownerUserId = input.shared
+							? null
+							: (input.ownerUserId ?? session.userId)
+
+						// Connecting a mailbox in somebody else's name, or one that
+						// belongs to everyone, is looking after the organization
+						// rather than looking after yourself.
+						const actsForSomeoneElse =
+							ownerUserId === null || ownerUserId !== session.userId
+						if (actsForSomeoneElse && !isOrgManager(currentOrg.role)) {
 							return yield* new BadRequest({
-								message: 'Shared inboxes cannot be private',
+								message:
+									'Only an organization admin can connect a mailbox for the team or for another member',
 							})
 						}
+						// One address is connected once at a time. Answered here so
+						// reconnecting an address already in use gets a plain reply
+						// rather than a database error, and the same reply whoever
+						// holds that address — it never names the colleague who does.
+						const alreadyConnected = yield* sql<{ count: number }>`
+							SELECT count(*)::int AS count FROM inboxes
+							WHERE organization_id = ${currentOrg.id}
+							  AND lower(email) = lower(${input.email})
+							  AND active = true
+						`.pipe(Effect.orDie)
+						if ((alreadyConnected[0]?.count ?? 0) > 0) {
+							return yield* new BadRequest({
+								message: 'That address is already connected',
+							})
+						}
+						if (input.shared && input.isPrivate === true) {
+							return yield* new BadRequest({
+								message: 'A mailbox shared with the team cannot be private',
+							})
+						}
+						if (input.shared && input.isDefault === true) {
+							return yield* new BadRequest({
+								message:
+									'A mailbox shared with the team cannot be anyone’s default sender',
+							})
+						}
+						// Setting up a mailbox for somebody does not extend to deciding
+						// what they send from — that stays theirs to pick.
+						if (input.isDefault === true && ownerUserId !== session.userId) {
+							return yield* new BadRequest({
+								message: 'A member chooses their own default sender',
+							})
+						}
+
+						// The first mailbox somebody connects becomes the address they
+						// send from, so nobody has to go looking for a setting to make
+						// sending work at all. Only ever for the person doing the
+						// connecting: setting one up on somebody's behalf leaves that
+						// choice to them, the same as everywhere else.
+						const isFirstOwnMailbox =
+							ownerUserId === session.userId &&
+							(yield* sql<{ count: number }>`
+								SELECT count(*)::int AS count FROM inboxes
+								WHERE organization_id = ${currentOrg.id}
+								  AND owner_user_id = ${ownerUserId}
+								  AND active = true
+							`.pipe(Effect.orDie))[0]?.count === 0
+						const isDefault = input.isDefault === true || isFirstOwnMailbox
 
 						// Generate the inbox id up-front so HKDF can derive a stable
 						// per-row subkey before INSERT.
@@ -1908,24 +2007,6 @@ export class EmailService extends Context.Service<EmailService>()(
 							inboxId,
 							plain: input.password,
 						})
-
-						// If a different default already exists for this (owner,
-						// purpose) bucket, clear it first — the partial unique
-						// index covers (organization_id, owner_user_id, purpose)
-						// and would otherwise reject the INSERT.
-						if (input.isDefault) {
-							const ownerCondition = ownerUserId
-								? sql`owner_user_id = ${ownerUserId}`
-								: sql`owner_user_id IS NULL`
-							yield* sql`
-								UPDATE inboxes
-								SET is_default = false, updated_at = now()
-								WHERE organization_id = ${currentOrg.id}
-								  AND ${ownerCondition}
-								  AND purpose = ${input.purpose}
-								  AND is_default = true
-							`
-						}
 
 						// Probe IMAP LOGIN + SMTP EHLO/AUTH against the supplied
 						// credentials. We still INSERT the row on probe failure so
@@ -1963,39 +2044,72 @@ export class EmailService extends Context.Service<EmailService>()(
 								}),
 							)
 
-						const rows = yield* sql<InboxRow>`
-							INSERT INTO inboxes ${sql.insert({
-								id: inboxId,
-								organizationId: currentOrg.id,
-								email: input.email,
-								displayName: input.displayName ?? null,
-								purpose: input.purpose,
-								ownerUserId,
-								isDefault: input.isDefault ?? false,
-								isPrivate: input.isPrivate ?? false,
-								active: true,
-								imapHost: input.imapHost,
-								imapPort: input.imapPort,
-								imapSecurity: input.imapSecurity,
-								smtpHost: input.smtpHost,
-								smtpPort: input.smtpPort,
-								smtpSecurity: input.smtpSecurity,
-								username: input.username,
-								passwordCiphertext: encrypted.ciphertext,
-								passwordNonce: encrypted.nonce,
-								passwordTag: encrypted.tag,
-								grantStatus: probe.status,
-								grantLastError: probe.detail,
-								grantLastSeenAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
-								folderState: '{}',
-							})}
-							RETURNING ${selectInboxColumns}
-						`
+						// Giving up the previously marked mailbox and marking this one
+						// happen together, and only once the connection has been tried:
+						// a mailbox that turns out unreachable must not leave somebody
+						// with nothing to send from. Only ever the same person's.
+						const rows = yield* sql
+							.withTransaction(
+								Effect.gen(function* () {
+									if (isDefault && ownerUserId !== null) {
+										yield* sql`
+										UPDATE inboxes
+										SET is_default = false, updated_at = now()
+										WHERE organization_id = ${currentOrg.id}
+										  AND owner_user_id = ${ownerUserId}
+										  AND is_default = true
+									`
+									}
+									return yield* sql<InboxRow>`
+									INSERT INTO inboxes ${sql.insert({
+										id: inboxId,
+										organizationId: currentOrg.id,
+										email: input.email,
+										displayName: input.displayName ?? null,
+										description: input.description ?? null,
+										ownerUserId,
+										isDefault,
+										isPrivate: input.isPrivate ?? false,
+										active: true,
+										imapHost: input.imapHost,
+										imapPort: input.imapPort,
+										imapSecurity: input.imapSecurity,
+										smtpHost: input.smtpHost,
+										smtpPort: input.smtpPort,
+										smtpSecurity: input.smtpSecurity,
+										username: input.username,
+										passwordCiphertext: encrypted.ciphertext,
+										passwordNonce: encrypted.nonce,
+										passwordTag: encrypted.tag,
+										grantStatus: probe.status,
+										grantLastError: probe.detail,
+										grantLastSeenAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
+										folderState: '{}',
+									})}
+									RETURNING ${selectInboxColumns}
+								`
+								}),
+							)
+							.pipe(
+								// Two people connecting the same address at once both get
+								// past the check above, since the connection attempt between
+								// them takes real time. The loser is told the same thing the
+								// check would have told them, rather than seeing a crash.
+								Effect.catchTag('SqlError', error =>
+									String(error.cause).includes('idx_inboxes_email_active')
+										? Effect.fail(
+												new BadRequest({
+													message: 'That address is already connected',
+												}),
+											)
+										: Effect.die(error),
+								),
+							)
 						yield* Effect.logInfo('Inbox created').pipe(
 							Effect.annotateLogs({
 								event: 'inbox.created',
 								email: input.email,
-								purpose: input.purpose,
+								shared: ownerUserId === null,
 							}),
 						)
 						return yield* decodeInbox(rows[0]!).pipe(Effect.orDie)
@@ -2005,7 +2119,7 @@ export class EmailService extends Context.Service<EmailService>()(
 					id: string,
 					patch: {
 						displayName?: string | null | undefined
-						purpose?: 'human' | 'agent' | 'shared' | undefined
+						description?: string | null | undefined
 						ownerUserId?: string | null | undefined
 						isPrivate?: boolean | undefined
 						isDefault?: boolean | undefined
@@ -2022,25 +2136,100 @@ export class EmailService extends Context.Service<EmailService>()(
 				) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						const session = yield* SessionContext
 
-						// Existence + org scope first so the rest of the work cannot
-						// silently target someone else's row.
-						const existing = yield* resolveInbox(id)
+						// Whether this mailbox is the caller's to change at all comes
+						// first, so nothing below can quietly reach a colleague's row.
+						const existing = yield* resolveInboxToLookAfter(id)
 						if (!existing) {
 							return yield* new NotFound({ entity: 'Inbox', id })
+						}
+
+						// Handing a mailbox to somebody else, or to the whole team, is
+						// looking after the organization rather than yourself.
+						if (
+							patch.ownerUserId !== undefined &&
+							patch.ownerUserId !== session.userId &&
+							!isOrgManager(currentOrg.role)
+						) {
+							return yield* new BadRequest({
+								message:
+									'Only an organization admin can hand a mailbox to someone else',
+							})
+						}
+
+						// Which address somebody sends from is their own choice, so it
+						// is not something anyone else changes for them — running the
+						// organization included, and taking it away counts as changing
+						// it. Read against who will own the mailbox once this call is
+						// done, so handing it over and marking it in one go cannot slip
+						// past.
+						const ownerAfterPatch =
+							patch.ownerUserId !== undefined
+								? patch.ownerUserId
+								: existing.ownerUserId
+						if (
+							patch.isDefault !== undefined &&
+							(existing.ownerUserId !== session.userId ||
+								ownerAfterPatch !== session.userId)
+						) {
+							return yield* new BadRequest({
+								message: 'A member chooses their own default sender',
+							})
+						}
+
+						// A mailbox belonging to everyone cannot also be hidden from
+						// them. Said here in words, because otherwise the database rule
+						// catches it and the caller sees only a crash.
+						if (patch.isPrivate === true && ownerAfterPatch === null) {
+							return yield* new BadRequest({
+								message: 'A mailbox shared with the team cannot be private',
+							})
+						}
+
+						// Bringing a removed mailbox back is refused while its address
+						// is in use elsewhere, for the same reason connecting it twice
+						// is: one address, one live mailbox.
+						if (patch.active === true && !existing.active) {
+							const addressTaken = yield* sql<{ count: number }>`
+								SELECT count(*)::int AS count FROM inboxes
+								WHERE organization_id = ${currentOrg.id}
+								  AND lower(email) = lower(${existing.email})
+								  AND active = true
+								  AND id <> ${id}
+							`.pipe(Effect.orDie)
+							if ((addressTaken[0]?.count ?? 0) > 0) {
+								return yield* new BadRequest({
+									message: 'That address is already connected',
+								})
+							}
 						}
 
 						const sets: Array<Statement.Fragment> = []
 						if (patch.displayName !== undefined)
 							sets.push(sql`display_name = ${patch.displayName}`)
-						if (patch.purpose !== undefined)
-							sets.push(sql`purpose = ${patch.purpose}`)
+						if (patch.description !== undefined)
+							sets.push(sql`description = ${patch.description}`)
 						if (patch.ownerUserId !== undefined)
 							sets.push(sql`owner_user_id = ${patch.ownerUserId}`)
 						if (patch.isPrivate !== undefined)
 							sets.push(sql`is_private = ${patch.isPrivate}`)
 						if (patch.isDefault !== undefined)
 							sets.push(sql`is_default = ${patch.isDefault}`)
+						// Handing a mailbox to somebody else does not hand over the
+						// choice of sending from it: the mark comes off, so the mailbox
+						// cannot quietly become what its new owner sends as.
+						if (
+							ownerAfterPatch !== existing.ownerUserId &&
+							patch.isDefault === undefined
+						) {
+							sets.push(sql`is_default = false`)
+						}
+						// Giving a mailbox to the whole team opens it to them, since a
+						// mailbox everybody owns cannot be hidden from anybody.
+						if (ownerAfterPatch === null && patch.isPrivate === undefined) {
+							sets.push(sql`is_private = false`)
+						}
 						if (patch.active !== undefined)
 							sets.push(sql`active = ${patch.active}`)
 						if (patch.imapHost !== undefined)
@@ -2085,23 +2274,15 @@ export class EmailService extends Context.Service<EmailService>()(
 							patch.smtpPort !== undefined ||
 							patch.smtpSecurity !== undefined
 
-						// Promoting to default requires clearing the prior default
-						// in the same (owner, purpose) bucket, mirroring createInbox.
+						// Taking the mark means giving up whichever of the caller's
+						// own mailboxes held it. The check above already established
+						// that this mailbox is theirs, so nobody else's is touched.
 						if (patch.isDefault === true) {
-							const targetPurpose = patch.purpose ?? existing.purpose
-							const targetOwner =
-								patch.ownerUserId !== undefined
-									? patch.ownerUserId
-									: existing.ownerUserId
-							const ownerCondition = targetOwner
-								? sql`owner_user_id = ${targetOwner}`
-								: sql`owner_user_id IS NULL`
 							yield* sql`
 								UPDATE inboxes
 								SET is_default = false, updated_at = now()
 								WHERE organization_id = ${currentOrg.id}
-								  AND ${ownerCondition}
-								  AND purpose = ${targetPurpose}
+								  AND owner_user_id = ${session.userId}
 								  AND is_default = true
 								  AND id <> ${id}
 							`
@@ -2128,10 +2309,22 @@ export class EmailService extends Context.Service<EmailService>()(
 				deleteInbox: (id: string) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						// Soft delete: thread history (and message search) needs the
-						// inbox row to keep resolving long after the user removes it.
-						// `active=false` flips the worker off and hides the inbox
-						// from compose/picker UIs.
+
+						// This lookup is the gate: it queries directly below rather
+						// than through the shared reader, so without it a member could
+						// remove a colleague's mailbox.
+						const target = yield* resolveInboxToLookAfter(id)
+						if (!target) {
+							return yield* new NotFound({ entity: 'Inbox', id })
+						}
+						// Removing a mailbox stops it syncing and takes it out of the
+						// pickers, but the row stays: threads and message search go on
+						// resolving through it long after somebody removes it.
+						// Removing one that was already gone changes nothing, and says
+						// so, rather than reporting a removal that never happened.
+						if (!target.active) {
+							return yield* new NotFound({ entity: 'Inbox', id })
+						}
 						const rows = yield* sql<InboxRow>`
 							UPDATE inboxes
 							SET active = false, is_default = false, updated_at = now()
@@ -2146,13 +2339,22 @@ export class EmailService extends Context.Service<EmailService>()(
 					}),
 
 				// Manual re-test of a stored mailbox — decrypt, probe, and write
-				// back the grant status. Shares reprobeInbox with updateInbox.
-				testInbox: (id: string) => reprobeInbox(id),
+				// back the grant status. Shares reprobeInbox with updateInbox,
+				// which does its own checking; asked for directly, it is the
+				// mailbox's keeper who may ask, since the answer is whether
+				// somebody's stored password still works.
+				testInbox: (id: string) =>
+					Effect.gen(function* () {
+						const target = yield* resolveInboxToLookAfter(id)
+						if (!target) {
+							return yield* new NotFound({ entity: 'Inbox', id })
+						}
+						return yield* reprobeInbox(id)
+					}),
 
-				// Promotes a single inbox to `is_default=true` for the calling
-				// member. Validates ownership so a member cannot promote an
-				// org-mate's inbox (or a shared inbox) into their own primary
-				// slot.
+				// Chooses which of the caller's own mailboxes they send from when
+				// they don't say. Nobody else's is touched, and nobody else can
+				// make this choice for them.
 				setPrimaryInbox: (id: string) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
@@ -2162,19 +2364,15 @@ export class EmailService extends Context.Service<EmailService>()(
 						if (!target) {
 							return yield* new NotFound({ entity: 'Inbox', id })
 						}
-						if (target.purpose !== 'human') {
-							return yield* new BadRequest({
-								message: 'Only human inboxes can be set as primary',
-							})
-						}
 						if (target.ownerUserId !== session.userId) {
 							return yield* new BadRequest({
-								message: 'Cannot set someone else’s inbox as primary',
+								message: 'A member chooses their own default sender',
 							})
 						}
 						if (!target.active) {
 							return yield* new BadRequest({
-								message: 'Cannot set an inactive inbox as primary',
+								message:
+									'A mailbox that was removed cannot be the one you send from',
 							})
 						}
 
@@ -2185,7 +2383,6 @@ export class EmailService extends Context.Service<EmailService>()(
 									SET is_default = false, updated_at = now()
 									WHERE organization_id = ${currentOrg.id}
 									  AND owner_user_id = ${session.userId}
-									  AND purpose = 'human'
 									  AND is_default = true
 									  AND id <> ${id}
 								`
@@ -2341,6 +2538,8 @@ export class EmailService extends Context.Service<EmailService>()(
 						if (!inbox) {
 							return yield* new NotFound({ entity: 'Inbox', id: inboxId })
 						}
+						const existing = yield* drafts.get(draftId)
+						yield* assertDraftReachable(existing.inboxId, draftId)
 						const updated = yield* drafts.update(draftId, {
 							...(params.to !== undefined && {
 								to: toRecipientArray(params.to) ?? [],
@@ -2367,6 +2566,8 @@ export class EmailService extends Context.Service<EmailService>()(
 						if (!inbox) {
 							return yield* new NotFound({ entity: 'Inbox', id: inboxId })
 						}
+						const existing = yield* drafts.get(draftId)
+						yield* assertDraftReachable(existing.inboxId, draftId)
 						yield* staging.sweepForDraft(draftId).pipe(Effect.ignore)
 						yield* drafts.remove(draftId)
 					}),
@@ -2378,6 +2579,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							return yield* new NotFound({ entity: 'Inbox', id: inboxId })
 						}
 						const draft = yield* drafts.get(draftId)
+						yield* assertDraftReachable(draft.inboxId, draftId)
 						return yield* decodeDraft(draftRowToProviderShape(draft)).pipe(
 							Effect.orDie,
 						)
@@ -2390,10 +2592,36 @@ export class EmailService extends Context.Service<EmailService>()(
 					count: CountMode = 'none',
 				) =>
 					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const session = yield* SessionContext
+						// A mailbox out of the caller's reach answers with an empty
+						// page, the same as one that is not there at all, so this can
+						// never be used to find out what exists.
+						if (inboxId !== undefined && !(yield* resolveInbox(inboxId))) {
+							return {
+								items: [],
+								// Counted the same way an empty mailbox of one's own is,
+								// or the two would be tellable apart.
+								total: count === 'exact' ? 0 : null,
+								limit,
+								offset,
+								hasMore: false,
+							}
+						}
 						const list = yield* drafts.list(inboxId)
+						// Naming no mailbox means "mine", not "everyone's" — half-written
+						// mail is as private as sent mail, so a colleague's never comes
+						// back here.
+						const reachable = yield* sql<{ id: string }>`
+							SELECT id FROM inboxes
+							WHERE organization_id = ${currentOrg.id}
+							  AND (owner_user_id IS NULL OR owner_user_id = ${session.userId})
+						`.pipe(Effect.orDie)
+						const reachableIds = new Set(reachable.map(r => r.id))
 						// Sort on the raw Date before decoding — DateTime.Utc has no
 						// getTime().
 						const shaped = list
+							.filter(d => reachableIds.has(d.inboxId))
 							.map(draftRowToProviderShape)
 							.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
 						// Drafts arrive as one batch from the provider, so the page is
@@ -2422,6 +2650,7 @@ export class EmailService extends Context.Service<EmailService>()(
 						yield* assertInboxUsable(inbox)
 
 						const draft = yield* drafts.get(draftId)
+						yield* assertDraftReachable(draft.inboxId, draftId)
 						const ctx = parseClientId(draft.clientId ?? undefined)
 
 						if (ctx.contactId) {
@@ -2565,6 +2794,13 @@ export class EmailService extends Context.Service<EmailService>()(
 				listFooters: (inboxId: string) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						// Visible to whoever sends through the mailbox, and to whoever
+						// looks after it — otherwise an admin would be shown nothing on
+						// a mailbox whose signature they are allowed to rewrite.
+						const inbox =
+							(yield* resolveInbox(inboxId)) ??
+							(yield* resolveInboxToLookAfter(inboxId))
+						if (!inbox) return []
 						const rows = yield* sql`
 							SELECT * FROM inbox_footers
 							WHERE inbox_id = ${inboxId}
@@ -2589,6 +2825,13 @@ export class EmailService extends Context.Service<EmailService>()(
 								id,
 							})
 						}
+						const inboxId = (rows[0] as { inboxId: string }).inboxId
+						const inbox =
+							(yield* resolveInbox(inboxId)) ??
+							(yield* resolveInboxToLookAfter(inboxId))
+						if (!inbox) {
+							return yield* new NotFound({ entity: 'InboxFooter', id })
+						}
 						return yield* decodeFooter(rows[0]!).pipe(Effect.orDie)
 					}),
 
@@ -2600,7 +2843,10 @@ export class EmailService extends Context.Service<EmailService>()(
 				}) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const inbox = yield* resolveInbox(input.inboxId)
+						// Writing a signature changes what goes out on every message
+						// the mailbox sends, so it takes the same standing as changing
+						// the mailbox itself.
+						const inbox = yield* resolveInboxToLookAfter(input.inboxId)
 						if (!inbox) {
 							return yield* new NotFound({
 								entity: 'Inbox',
@@ -2639,6 +2885,21 @@ export class EmailService extends Context.Service<EmailService>()(
 				) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						// Rewriting a signature changes what goes out on the mailbox's
+						// mail, so it takes the same standing as changing the mailbox.
+						const owning = yield* sql<{ inboxId: string }>`
+							SELECT inbox_id AS "inboxId" FROM inbox_footers
+							WHERE id = ${id}
+							  AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`
+						const owningInboxId = owning[0]?.inboxId
+						if (owningInboxId === undefined) {
+							return yield* new NotFound({ entity: 'InboxFooter', id })
+						}
+						if (!(yield* resolveInboxToLookAfter(owningInboxId))) {
+							return yield* new NotFound({ entity: 'InboxFooter', id })
+						}
 						if (patch.isDefault === true) {
 							const existing = yield* sql<{ inboxId: string }>`
 								SELECT inbox_id FROM inbox_footers
@@ -2698,6 +2959,17 @@ export class EmailService extends Context.Service<EmailService>()(
 				deleteFooter: (id: string) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						// Removing a signature changes what goes out on the mailbox's
+						// mail, so it takes the same standing as changing the mailbox.
+						const owning = yield* sql<{ inboxId: string }>`
+							SELECT inbox_id AS "inboxId" FROM inbox_footers
+							WHERE id = ${id}
+							  AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`
+						const owningInboxId = owning[0]?.inboxId
+						if (owningInboxId === undefined) return
+						if (!(yield* resolveInboxToLookAfter(owningInboxId))) return
 						yield* sql`
 							DELETE FROM inbox_footers
 							WHERE id = ${id}

--- a/apps/server/src/services/inbox-health-probe.integration.test.ts
+++ b/apps/server/src/services/inbox-health-probe.integration.test.ts
@@ -70,13 +70,13 @@ describe('InboxHealthProbe', () => {
 		const placeholder = new Uint8Array([0])
 		const rows = yield* sql<{ id: string }>`
 			INSERT INTO inboxes (
-				organization_id, email, purpose, owner_user_id,
+				organization_id, email, owner_user_id,
 				imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security,
 				username, password_ciphertext, password_nonce, password_tag,
 				active
 			) VALUES (
-				${TEST_INBOX_ORG}, 'probe@test.local', 'human', ${TEST_INBOX_USER},
+				${TEST_INBOX_ORG}, 'probe@test.local',  ${TEST_INBOX_USER},
 				'imap.test.local', 993, 'tls',
 				'smtp.test.local', 587, 'starttls',
 				'probe@test.local', ${placeholder}, ${placeholder}, ${placeholder},

--- a/apps/server/src/services/multi-org-isolation.integration.test.ts
+++ b/apps/server/src/services/multi-org-isolation.integration.test.ts
@@ -275,7 +275,6 @@ const fakeInbox = (orgId: string, ownerUserId: string, email: string) => ({
 	organization_id: orgId,
 	owner_user_id: ownerUserId,
 	email,
-	purpose: 'human',
 	imap_host: 'imap.example.com',
 	imap_port: 993,
 	imap_security: 'tls',
@@ -339,9 +338,9 @@ describe('multi-org isolation', () => {
 			// THEN only the taller row is visible — RLS USING fires regardless of query shape
 			await withSuper(async client => {
 				const inboxIns = await client.query<{ id: string }>(
-					`INSERT INTO inboxes (organization_id, owner_user_id, email, purpose, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
-					 VALUES ($1,$2,$3,'human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
-					        ($4,$5,$6,'human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id, organization_id`,
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1,$2,$3,'x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
+					        ($4,$5,$6,'x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id, organization_id`,
 					[
 						ctx.tallerOrgId,
 						ctx.aliceId,
@@ -384,9 +383,9 @@ describe('multi-org isolation', () => {
 			// THEN only taller's thread row is visible
 			await withSuper(async client => {
 				const inboxIns = await client.query<{ id: string }>(
-					`INSERT INTO inboxes (organization_id, owner_user_id, email, purpose, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
-					 VALUES ($1,$2,'a@a','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
-					        ($3,$4,'b@b','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id`,
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1,$2,'a@a','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
+					        ($3,$4,'b@b','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id`,
 					[ctx.tallerOrgId, ctx.aliceId, ctx.restaurantOrgId, ctx.bobId],
 				)
 				await client.query(
@@ -416,9 +415,9 @@ describe('multi-org isolation', () => {
 			// THEN only the taller participant is visible — proves the EXISTS subquery policy
 			await withSuper(async client => {
 				const inboxIns = await client.query<{ id: string }>(
-					`INSERT INTO inboxes (organization_id, owner_user_id, email, purpose, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
-					 VALUES ($1,$2,'a@a','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
-					        ($3,$4,'b@b','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id`,
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1,$2,'a@a','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
+					        ($3,$4,'b@b','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id`,
 					[ctx.tallerOrgId, ctx.aliceId, ctx.restaurantOrgId, ctx.bobId],
 				)
 				const msgIns = await client.query<{ id: string }>(
@@ -805,9 +804,9 @@ describe('multi-org isolation', () => {
 
 		const seedTwoInboxes = async (client: pg.PoolClient) => {
 			const ins = await client.query<{ id: string }>(
-				`INSERT INTO inboxes (organization_id, owner_user_id, email, purpose, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
-				 VALUES ($1,$2,'a@a','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
-				        ($3,$4,'b@b','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x')
+				`INSERT INTO inboxes (organization_id, owner_user_id, email, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+				 VALUES ($1,$2,'a@a','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
+				        ($3,$4,'b@b','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x')
 				 RETURNING id`,
 				[ctx.tallerOrgId, ctx.aliceId, ctx.restaurantOrgId, ctx.bobId],
 			)
@@ -867,17 +866,74 @@ describe('multi-org isolation', () => {
 	})
 
 	describe('DB-level invariants', () => {
-		it("CHECK rejects purpose='shared' + is_private=true on insert", async () => {
-			// GIVEN an attempt to create a shared inbox marked private (nonsensical)
+		it('should reject a team mailbox that is also hidden from the team', async () => {
+			// GIVEN a mailbox with no owner — the whole team's — marked private
 			// WHEN INSERT runs
-			// THEN the table-level CHECK constraint rejects it
+			// THEN the table-level CHECK rejects it, since a mailbox belonging to
+			// everyone cannot also be hidden from them
 			await expect(
 				ctx.pool.query(
-					`INSERT INTO inboxes (organization_id, owner_user_id, email, purpose, is_private, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
-					 VALUES ($1, NULL, 'shared@x', 'shared', true, 'x', 1, 'tls', 'x', 1, 'tls', 'u', '\\x', '\\x', '\\x')`,
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, is_private, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1, NULL, 'shared@x', true, 'x', 1, 'tls', 'x', 1, 'tls', 'u', '\\x', '\\x', '\\x')`,
 					[ctx.tallerOrgId],
 				),
-			).rejects.toThrow(/inboxes_purpose_owner_chk|check constraint/i)
+			).rejects.toThrow(/inboxes_team_mailbox_chk|check constraint/i)
+		})
+
+		it('should reject a team mailbox marked as somebody’s default sender', async () => {
+			// GIVEN a mailbox with no owner marked as a default sender
+			// WHEN INSERT runs
+			// THEN the same CHECK rejects it: nobody sends from a mailbox that
+			// belongs to everyone by default
+			await expect(
+				ctx.pool.query(
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, is_default, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1, NULL, 'shared-default@x', true, 'x', 1, 'tls', 'x', 1, 'tls', 'u', '\\x', '\\x', '\\x')`,
+					[ctx.tallerOrgId],
+				),
+			).rejects.toThrow(/inboxes_team_mailbox_chk|check constraint/i)
+		})
+
+		it('should reject the same address connected twice while both are in use', async () => {
+			// GIVEN an address already connected and in use
+			// WHEN the same address is connected again without removing the first
+			// THEN the unique index rejects it, so the list cannot fill up with
+			// duplicates of one mailbox
+			await withSuper(async client => {
+				await client.query(
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1,$2,'twice@x','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x')`,
+					[ctx.tallerOrgId, ctx.aliceId],
+				)
+				await expect(
+					client.query(
+						`INSERT INTO inboxes (organization_id, owner_user_id, email, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+						 VALUES ($1,$2,'TWICE@x','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x')`,
+						[ctx.tallerOrgId, ctx.aliceId],
+					),
+				).rejects.toThrow(/idx_inboxes_email_active|unique/i)
+			})
+		})
+
+		it('should allow one person only one default sender', async () => {
+			// GIVEN a member whose mailbox is already the one they send from
+			// WHEN a second of their mailboxes is marked the same way
+			// THEN the unique index rejects it, so "which address do I send
+			// from" always has exactly one answer
+			await withSuper(async client => {
+				await client.query(
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, is_default, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1,$2,'first@x',true,'x',1,'tls','x',1,'tls','u','\\x','\\x','\\x')`,
+					[ctx.tallerOrgId, ctx.aliceId],
+				)
+				await expect(
+					client.query(
+						`INSERT INTO inboxes (organization_id, owner_user_id, email, is_default, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+						 VALUES ($1,$2,'second@x',true,'x',1,'tls','x',1,'tls','u','\\x','\\x','\\x')`,
+						[ctx.tallerOrgId, ctx.aliceId],
+					),
+				).rejects.toThrow(/idx_inboxes_default_per_owner|unique/i)
+			})
 		})
 
 		it('idx_email_messages_msgid is org-scoped (same Message-ID across orgs allowed; within an org rejected)', async () => {
@@ -887,9 +943,9 @@ describe('multi-org isolation', () => {
 			// AND a duplicate within the same org is rejected
 			await withSuper(async client => {
 				const inboxIns = await client.query<{ id: string }>(
-					`INSERT INTO inboxes (organization_id, owner_user_id, email, purpose, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
-					 VALUES ($1,$2,'a@a','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
-					        ($3,$4,'b@b','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id`,
+					`INSERT INTO inboxes (organization_id, owner_user_id, email, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
+					 VALUES ($1,$2,'a@a','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x'),
+					        ($3,$4,'b@b','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id`,
 					[ctx.tallerOrgId, ctx.aliceId, ctx.restaurantOrgId, ctx.bobId],
 				)
 				// Same Message-ID in two different orgs — allowed.
@@ -915,28 +971,23 @@ describe('multi-org isolation', () => {
 			})
 		})
 
-		it('member.primary_inbox_id is nulled when the referenced inbox row is deleted', async () => {
-			// GIVEN a member with primary_inbox_id pointing at an inbox row
-			// WHEN the inbox row is deleted
-			// THEN ON DELETE SET NULL fires and the member's primary_inbox_id reads NULL
-			await withSuper(async client => {
-				const inboxIns = await client.query<{ id: string }>(
-					`INSERT INTO inboxes (organization_id, owner_user_id, email, purpose, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username, password_ciphertext, password_nonce, password_tag)
-					 VALUES ($1,$2,'a@a','human','x',1,'tls','x',1,'tls','u','\\x','\\x','\\x') RETURNING id`,
-					[ctx.tallerOrgId, ctx.aliceId],
-				)
-				const inboxId = inboxIns.rows[0]?.id
-				await client.query(
-					`UPDATE "member" SET primary_inbox_id = $1 WHERE "userId" = $2 AND "organizationId" = $3`,
-					[inboxId, ctx.aliceId, ctx.tallerOrgId],
-				)
-				await client.query(`DELETE FROM inboxes WHERE id = $1`, [inboxId])
-				const after = await client.query<{ primary_inbox_id: string | null }>(
-					`SELECT primary_inbox_id FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
-					[ctx.aliceId, ctx.tallerOrgId],
-				)
-				expect(after.rows[0]?.primary_inbox_id).toBeNull()
-			})
+		it('should keep no record of a default sender on the membership row', async () => {
+			// GIVEN the membership table
+			// WHEN its columns are read
+			// THEN it carries nothing about which mailbox somebody sends from:
+			// that lives on the mailbox itself, and a second copy nothing wrote
+			// was only ever a place for the two to disagree
+			// Read the whole membership row's columns rather than probing for the
+			// one that should be missing: a query that finds nothing also finds
+			// nothing when the table name or schema is wrong, and would pass for
+			// the wrong reason.
+			const cols = await ctx.pool.query<{ column_name: string }>(
+				`SELECT column_name FROM information_schema.columns
+				 WHERE table_schema = current_schema() AND table_name = 'member'`,
+			)
+			const names = cols.rows.map(r => r.column_name)
+			expect(names).toContain('role')
+			expect(names).not.toContain('primary_inbox_id')
 		})
 	})
 

--- a/apps/server/src/services/org-resolution.integration.test.ts
+++ b/apps/server/src/services/org-resolution.integration.test.ts
@@ -82,13 +82,13 @@ const insertInbox = (args: {
 		if (created !== undefined) {
 			yield* sql`
 				INSERT INTO inboxes (
-					id, organization_id, email, purpose, owner_user_id,
+					id, organization_id, email, owner_user_id,
 					imap_host, imap_port, imap_security,
 					smtp_host, smtp_port, smtp_security,
 					username, password_ciphertext, password_nonce, password_tag,
 					active, created_at
 				) VALUES (
-					${args.id}::uuid, ${args.orgId}, ${args.email}, 'human', 'org-resolution-test-user',
+					${args.id}::uuid, ${args.orgId}, ${args.email},  'org-resolution-test-user',
 					'imap.test', 993, 'tls',
 					'smtp.test', 587, 'starttls',
 					${args.email}, ${placeholder}, ${placeholder}, ${placeholder},
@@ -99,13 +99,13 @@ const insertInbox = (args: {
 		}
 		yield* sql`
 			INSERT INTO inboxes (
-				id, organization_id, email, purpose, owner_user_id,
+				id, organization_id, email, owner_user_id,
 				imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security,
 				username, password_ciphertext, password_nonce, password_tag,
 				active
 			) VALUES (
-				${args.id}::uuid, ${args.orgId}, ${args.email}, 'human', 'org-resolution-test-user',
+				${args.id}::uuid, ${args.orgId}, ${args.email},  'org-resolution-test-user',
 				'imap.test', 993, 'tls',
 				'smtp.test', 587, 'starttls',
 				${args.email}, ${placeholder}, ${placeholder}, ${placeholder},

--- a/apps/server/src/services/pipeline-next-steps.integration.test.ts
+++ b/apps/server/src/services/pipeline-next-steps.integration.test.ts
@@ -84,6 +84,7 @@ const awaitingReview = (): Promise<
 						id: orgId,
 						name: 'fixture',
 						slug: 'fixture',
+						role: 'member',
 					}),
 				)
 				return next.researchAwaitingReview

--- a/apps/server/src/services/research-apply-audit.integration.test.ts
+++ b/apps/server/src/services/research-apply-audit.integration.test.ts
@@ -37,6 +37,7 @@ const record = (event: ResearchProposalApplied) =>
 				id: ORG,
 				name: 'audit',
 				slug: 'audit',
+				role: 'member',
 			}),
 		)
 	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)

--- a/apps/server/src/services/research-apply-batch.integration.test.ts
+++ b/apps/server/src/services/research-apply-batch.integration.test.ts
@@ -43,7 +43,12 @@ const deps = Layer.mergeAll(
 
 const runBatch = (items: ReadonlyArray<BatchResolveItem>) =>
 	resolveResearchProposedUpdatesBatch(items, 'u1').pipe(
-		Effect.provideService(CurrentOrg, { id: ORG, name: 'b', slug: 'b' }),
+		Effect.provideService(CurrentOrg, {
+			id: ORG,
+			name: 'b',
+			slug: 'b',
+			role: 'member',
+		}),
 		Effect.provide(deps),
 		Effect.orDie,
 		Effect.runPromise,

--- a/apps/server/src/services/research-apply-country.integration.test.ts
+++ b/apps/server/src/services/research-apply-country.integration.test.ts
@@ -38,7 +38,12 @@ const deps = Layer.mergeAll(
 
 const apply = (runId: string, proposalId: string) =>
 	resolveResearchProposedUpdate(runId, proposalId, 'apply', null).pipe(
-		Effect.provideService(CurrentOrg, { id: ORG, name: 'c', slug: 'c' }),
+		Effect.provideService(CurrentOrg, {
+			id: ORG,
+			name: 'c',
+			slug: 'c',
+			role: 'member',
+		}),
 		Effect.provide(deps),
 		Effect.orDie,
 		Effect.runPromise,

--- a/apps/server/src/services/research-apply-enrichment.integration.test.ts
+++ b/apps/server/src/services/research-apply-enrichment.integration.test.ts
@@ -41,7 +41,12 @@ const personEdits = (id: string, fields: Record<string, unknown>) =>
 			const svc = yield* CompanyService
 			return yield* svc.update(id, fields)
 		}).pipe(
-			Effect.provideService(CurrentOrg, { id: ORG, name: 'b', slug: 'b' }),
+			Effect.provideService(CurrentOrg, {
+				id: ORG,
+				name: 'b',
+				slug: 'b',
+				role: 'member',
+			}),
 		),
 	)
 

--- a/apps/server/src/services/research-apply-provenance.integration.test.ts
+++ b/apps/server/src/services/research-apply-provenance.integration.test.ts
@@ -43,7 +43,12 @@ const deps = Layer.mergeAll(
 
 const apply = (runId: string, proposalId: string) =>
 	resolveResearchProposedUpdate(runId, proposalId, 'apply', null).pipe(
-		Effect.provideService(CurrentOrg, { id: ORG, name: 'p', slug: 'p' }),
+		Effect.provideService(CurrentOrg, {
+			id: ORG,
+			name: 'p',
+			slug: 'p',
+			role: 'member',
+		}),
 		Effect.provide(deps),
 		Effect.orDie,
 		Effect.runPromise,

--- a/apps/server/src/services/research-auto-apply.integration.test.ts
+++ b/apps/server/src/services/research-auto-apply.integration.test.ts
@@ -82,7 +82,12 @@ const autoApply = (research: string, threshold: number) =>
 		)
 		return toApply
 	}).pipe(
-		Effect.provideService(CurrentOrg, { id: ORG, name: 'a', slug: 'a' }),
+		Effect.provideService(CurrentOrg, {
+			id: ORG,
+			name: 'a',
+			slug: 'a',
+			role: 'member',
+		}),
 		Effect.provide(deps),
 		Effect.orDie,
 		Effect.runPromise,

--- a/apps/server/src/services/tasks.integration.test.ts
+++ b/apps/server/src/services/tasks.integration.test.ts
@@ -99,6 +99,7 @@ const createWith = (
 			id: currentOrg,
 			name: 'fixture',
 			slug: 'fixture',
+			role: 'member',
 		}),
 	).pipe(
 		// TaskService now records onto the timeline, so it needs
@@ -217,7 +218,12 @@ const listWith = (
 ) => {
 	const deps = Layer.mergeAll(
 		TaskService.layer,
-		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+		Layer.succeed(CurrentOrg, {
+			id: org,
+			name: 'fixture',
+			slug: 'fixture',
+			role: 'member',
+		}),
 	).pipe(
 		// TaskService now records onto the timeline, so it needs
 		// TimelineActivityService; both resolve their SqlClient from PgLive.
@@ -705,7 +711,12 @@ describe('TaskService.list', () => {
 const countsWith = (org: string, boundaries: TaskDayBoundaries) => {
 	const deps = Layer.mergeAll(
 		TaskService.layer,
-		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+		Layer.succeed(CurrentOrg, {
+			id: org,
+			name: 'fixture',
+			slug: 'fixture',
+			role: 'member',
+		}),
 	).pipe(
 		Layer.provideMerge(TimelineActivityService.layer),
 		Layer.provideMerge(PgLive),
@@ -923,7 +934,12 @@ const attempt = (
 ): Promise<{ failedWith: string | null }> => {
 	const deps = Layer.mergeAll(
 		TaskService.layer,
-		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+		Layer.succeed(CurrentOrg, {
+			id: org,
+			name: 'fixture',
+			slug: 'fixture',
+			role: 'member',
+		}),
 	).pipe(
 		// TaskService now records onto the timeline, so it needs
 		// TimelineActivityService; both resolve their SqlClient from PgLive.
@@ -969,7 +985,12 @@ const runScoped = <A>(
 ): Promise<A> => {
 	const deps = Layer.mergeAll(
 		TaskService.layer,
-		Layer.succeed(CurrentOrg, { id: org, name: 'fixture', slug: 'fixture' }),
+		Layer.succeed(CurrentOrg, {
+			id: org,
+			name: 'fixture',
+			slug: 'fixture',
+			role: 'member',
+		}),
 	).pipe(
 		Layer.provideMerge(TimelineActivityService.layer),
 		Layer.provideMerge(PgLive),

--- a/apps/server/src/services/timeline-activity.integration.test.ts
+++ b/apps/server/src/services/timeline-activity.integration.test.ts
@@ -87,6 +87,7 @@ const recordScoped = (event: TimelineEvent): Promise<unknown> => {
 						id: tallerOrgId,
 						name: 'fixture',
 						slug: 'fixture',
+						role: 'member',
 					}),
 				)
 			}),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -614,7 +614,8 @@ api_key             — hashed API keys (referenceId, configId, quotas, per-key
                       rate limits; metadata carries organizationId + createdByUserId
                       for org-scoped /mcp keys)
 organization        — tenant root; users belong via member rows
-member              — (organization_id, user_id) plus primary_inbox_id additionalField
+member              — (organization_id, user_id) plus role, which decides who
+                      may act on another member's things
 invitation          — created by Better Auth's schema, unused by Batuda:
                       people are added straight to an org, never invited.
                       Kept RLS-policied so the live table is never unguarded.
@@ -627,8 +628,10 @@ inboxes              — one row per IMAP+SMTP mailbox; carries credentials
                        (password_ciphertext/nonce/tag, AES-256-GCM, HKDF
                        subkey from EMAIL_CREDENTIAL_KEY + inbox.id),
                        grant_status, folder_state JSONB per IMAP folder.
-                       Owned by (organization_id, owner_user_id);
-                       purpose ∈ {human, agent, shared}
+                       Owned by (organization_id, owner_user_id) — set means
+                       one member's, NULL means the whole team's, which is
+                       what decides who may send through it and change it;
+                       description is free text and carries no rules
 email_thread_links   — (organization_id, external_thread_id) where
                        external_thread_id is the thread root's RFC Message-ID
 email_messages       — every fetched/sent message; raw_rfc822_ref points at

--- a/packages/controllers/src/middleware/org.test.ts
+++ b/packages/controllers/src/middleware/org.test.ts
@@ -14,10 +14,10 @@ describe('CurrentOrg', () => {
 		expect(CurrentOrg.key).toBe('CurrentOrg')
 	})
 
-	it('should round-trip the { id, name, slug } shape through Layer.succeed', () =>
+	it('should round-trip the { id, name, slug, role } shape through Layer.succeed', () =>
 		Effect.runPromise(
 			Effect.gen(function* () {
-				// GIVEN a Layer.succeed(CurrentOrg, { id, name, slug })
+				// GIVEN a Layer.succeed(CurrentOrg, { id, name, slug, role })
 				// WHEN an Effect yields the tag
 				// THEN the resolved value preserves every field verbatim
 				const org = yield* CurrentOrg
@@ -25,6 +25,7 @@ describe('CurrentOrg', () => {
 					id: 'org_alpha',
 					name: 'Alpha',
 					slug: 'alpha',
+					role: 'admin',
 				})
 			}).pipe(
 				Effect.provide(
@@ -32,6 +33,7 @@ describe('CurrentOrg', () => {
 						id: 'org_alpha',
 						name: 'Alpha',
 						slug: 'alpha',
+						role: 'admin',
 					}),
 				),
 			),

--- a/packages/controllers/src/routes/email.ts
+++ b/packages/controllers/src/routes/email.ts
@@ -25,16 +25,22 @@ import { PaginatedList, pageQuery } from '../pagination'
 const Recipients = Schema.Union([Schema.String, Schema.Array(Schema.String)])
 
 const ThreadStatus = Schema.Literals(['open', 'closed', 'archived'])
-const InboxPurpose = Schema.Literals(['human', 'agent', 'shared'])
 const InboundClassification = Schema.Literals(['normal', 'spam', 'blocked'])
 const MessageDirection = Schema.Literals(['inbound', 'outbound'])
+
+// A line about what a mailbox is for, not a place to paste a document. The
+// same limit the database holds, so an over-long one is turned away here
+// with a clear answer rather than deeper down with an opaque one.
+const InboxDescription = Schema.String.pipe(
+	Schema.check(Schema.isMaxLength(200)),
+)
 
 // Shape of the inbox summary reattached to a thread (list + detail). Only
 // the display-safe fields — never credentials or transport hosts.
 const ThreadInbox = Schema.Struct({
 	email: Schema.String,
 	displayName: Schema.NullOr(Schema.String),
-	purpose: InboxPurpose,
+	description: Schema.NullOr(Schema.String),
 })
 
 // ── Enriched thread response shapes ─────────────────────────────
@@ -203,7 +209,6 @@ export const EmailGroup = HttpApiGroup.make('email')
 				inboxId: Schema.optional(Schema.String),
 				companyId: Schema.optional(Schema.String),
 				status: Schema.optional(ThreadStatus),
-				purpose: Schema.optional(InboxPurpose),
 				query: Schema.optional(Schema.String),
 				...pageQuery,
 			},
@@ -266,7 +271,6 @@ export const EmailGroup = HttpApiGroup.make('email')
 	.add(
 		HttpApiEndpoint.get('listInboxes', '/email/inboxes', {
 			query: {
-				purpose: Schema.optional(InboxPurpose),
 				active: Schema.optional(Schema.Literals(['true', 'false'])),
 				ownerUserId: Schema.optional(Schema.String),
 			},
@@ -291,7 +295,11 @@ export const EmailGroup = HttpApiGroup.make('email')
 			payload: Schema.Struct({
 				email: Schema.String,
 				displayName: Schema.optional(Schema.String),
-				purpose: InboxPurpose,
+				description: Schema.optional(InboxDescription),
+				// Set up for the whole team rather than for one person. Only an
+				// organization admin may, and such a mailbox has no owner, so it
+				// can be neither private nor anybody's default sender.
+				shared: Schema.optional(Schema.Boolean),
 				ownerUserId: Schema.optional(Schema.String),
 				isPrivate: Schema.optional(Schema.Boolean),
 				isDefault: Schema.optional(Schema.Boolean),
@@ -313,7 +321,7 @@ export const EmailGroup = HttpApiGroup.make('email')
 			params: { id: Schema.String },
 			payload: Schema.Struct({
 				displayName: Schema.optional(Schema.NullOr(Schema.String)),
-				purpose: Schema.optional(InboxPurpose),
+				description: Schema.optional(Schema.NullOr(InboxDescription)),
 				ownerUserId: Schema.optional(Schema.NullOr(Schema.String)),
 				isPrivate: Schema.optional(Schema.Boolean),
 				isDefault: Schema.optional(Schema.Boolean),
@@ -333,7 +341,12 @@ export const EmailGroup = HttpApiGroup.make('email')
 				password: Schema.optional(Schema.String),
 			}),
 			success: Inbox.json,
-			error: NotFound.pipe(HttpApiSchema.status(404)),
+			error: [
+				NotFound.pipe(HttpApiSchema.status(404)),
+				// Handing a mailbox to somebody else, or choosing a default
+				// sender on their behalf, is turned away rather than obeyed.
+				BadRequest.pipe(HttpApiSchema.status(400)),
+			],
 		}),
 	)
 	.add(
@@ -353,9 +366,9 @@ export const EmailGroup = HttpApiGroup.make('email')
 		}),
 	)
 	.add(
-		// Set the calling member's primary_inbox_id. Validates ownership
-		// (same org + same user) so the call cannot point at someone else's
-		// inbox.
+		// Choose which of the caller's own mailboxes they send from when they
+		// don't say. It has to be theirs and still in use, so this can neither
+		// point at a colleague's nor change what anyone else sends from.
 		HttpApiEndpoint.post('setPrimaryInbox', '/email/inboxes/:id/primary', {
 			params: { id: Schema.String },
 			success: Inbox.json,
@@ -518,6 +531,8 @@ export const EmailGroup = HttpApiGroup.make('email')
 				isDefault: Schema.optional(Schema.Boolean),
 			}),
 			success: InboxFooter.json,
+			// A mailbox that isn't the caller's to look after answers as absent.
+			error: NotFound.pipe(HttpApiSchema.status(404)),
 		}),
 	)
 	.add(

--- a/packages/domain/src/current-org.test.ts
+++ b/packages/domain/src/current-org.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { isOrgManager } from './current-org'
+
+describe('isOrgManager', () => {
+	describe('when the role runs the organization', () => {
+		it('should admit the owner', () => {
+			// GIVEN the role of the person who created the organization
+			// WHEN asked whether they may manage it
+			// THEN they may
+			expect(isOrgManager('owner')).toBe(true)
+		})
+
+		it('should admit an admin', () => {
+			// GIVEN a member promoted to admin
+			// WHEN asked whether they may manage the organization
+			// THEN they may, on equal footing with the owner
+			expect(isOrgManager('admin')).toBe(true)
+		})
+	})
+
+	describe('when the role does not run the organization', () => {
+		it('should refuse an ordinary member', () => {
+			// GIVEN a plain member
+			// WHEN asked whether they may manage the organization
+			// THEN they may not, so they can only ever act for themselves
+			expect(isOrgManager('member')).toBe(false)
+		})
+
+		it('should refuse work with nobody behind it', () => {
+			// GIVEN no acting person at all, as with work that runs unattended
+			// WHEN asked whether it may manage the organization
+			// THEN it may not: unattended work never acts for a person
+			expect(isOrgManager(null)).toBe(false)
+		})
+	})
+
+	describe('when the role is not one it knows', () => {
+		it('should refuse a role added later', () => {
+			// GIVEN a role this check has never been taught about
+			// WHEN asked whether it may manage the organization
+			// THEN it refuses, so a new role starts with no authority rather
+			// than inheriting someone else's
+			expect(isOrgManager('billing')).toBe(false)
+		})
+
+		it('should refuse an empty role', () => {
+			// GIVEN a membership row whose role never got written
+			// WHEN asked whether it may manage the organization
+			// THEN it refuses rather than reading blank as permission
+			expect(isOrgManager('')).toBe(false)
+		})
+	})
+})

--- a/packages/domain/src/current-org.ts
+++ b/packages/domain/src/current-org.ts
@@ -6,5 +6,15 @@ export class CurrentOrg extends Context.Service<
 		readonly id: string
 		readonly name: string
 		readonly slug: string
+		// What the person behind this request may do in this organization.
+		// Null when there is no person: unattended work, which manages nothing
+		// and so never acts on what belongs to one member.
+		readonly role: string | null
 	}
 >()('CurrentOrg') {}
+
+// Managing an organization — its people, its shared settings, anything that
+// belongs to somebody else — is for whoever runs it. Everyone else acts for
+// themselves alone.
+export const isOrgManager = (role: string | null): boolean =>
+	role === 'owner' || role === 'admin'

--- a/packages/domain/src/schema/inboxes.ts
+++ b/packages/domain/src/schema/inboxes.ts
@@ -3,9 +3,6 @@ import { Model } from 'effect/unstable/schema'
 
 export const InboxId = Schema.String.pipe(Schema.brand('InboxId'))
 
-export const InboxPurpose = Schema.Literals(['human', 'agent', 'shared'])
-export type InboxPurpose = typeof InboxPurpose.Type
-
 export const InboxTransportSecurity = Schema.Literals([
 	'tls',
 	'starttls',
@@ -31,7 +28,11 @@ export class Inbox extends Model.Class<Inbox>('Inbox')({
 	organizationId: Schema.String,
 	email: Schema.String,
 	displayName: Schema.NullOr(Schema.String),
-	purpose: InboxPurpose,
+	// What the mailbox is for, in whatever words fit. Free text: nothing
+	// branches on it.
+	description: Schema.NullOr(Schema.String),
+	// Who may touch the mailbox follows from this: set means it belongs to that
+	// person, null means it is the whole team's and so cannot be private.
 	ownerUserId: Schema.NullOr(Schema.String),
 	isDefault: Schema.Boolean,
 	isPrivate: Schema.Boolean,

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -49,7 +49,6 @@ export {
 	Inbox,
 	InboxGrantStatus,
 	InboxId,
-	InboxPurpose,
 	InboxTransportSecurity,
 } from './inboxes'
 export { Interaction, InteractionId } from './interactions'


### PR DESCRIPTION
## What

Every mailbox someone connects used to be filed under one of three fixed kinds — a person's, an assistant's, or the whole team's. Nobody could write down what a mailbox was actually for, and the three words were doing three unrelated jobs behind the scenes. Now a mailbox says what it is for in whatever words its owner picks, and the rules follow the owner instead: a mailbox with an owner is that person's, a mailbox without one belongs to the whole team.

That reshuffle is what made the real problem visible. Anyone in an organization could send email through a colleague's mailbox — from their address, appearing as them. That is impersonation, not a settings mistake, and the composer could pick a colleague's mailbox on its own. This closes it, and settles who may do what with a mailbox generally: you look after your own, whoever runs the organization looks after everyone's, and nobody at all — admins included — chooses which address another person sends from.

This lives in the email surface: the `server` bounded context (`apps/server`), the shared API contract (`packages/controllers`, `packages/domain`), and the web app (`apps/internal`).

## Changes

- A mailbox carries a free-text `description` (up to 200 characters, nothing branches on it) instead of a fixed kind. Whether it is one person's or the team's is now read from `owner_user_id` — which is what the old database rule already encoded, so no mailbox that was legal before becomes illegal.
- The caller's role in their organization travels with each request, resolved once per transport (browser, and the MCP paths for API keys, OAuth and cookies). Work with nobody behind it — delivering mail, a webhook, anything outliving the request that began it — carries no standing and so manages nothing.
- Sending through a mailbox takes owning it, or it belonging to the team. Changing one — its settings, its signature, removing it, re-testing its password — takes owning it, or running the organization. Choosing a default sender stays personal: handing a mailbox over does not hand over that choice, and connecting one on somebody's behalf does not make it their default.
- Drafts got the same rule. A half-written message is as private as a sent one, so reaching one takes the same standing as the mailbox it would go out from — the draft's own mailbox, not whichever one the caller names.
- Connecting a first mailbox makes it the one that person sends from. Connecting an address twice is refused in words instead of by the database. Removed mailboxes stop appearing, which is what made removing one look like it did nothing.
- **Pause is gone.** It and Remove were the same `active` flag, so having both is what made either hard to understand — see *Review guide*.

## Impact

- **Migration — must run before the server tag.** `0046_inbox_description.ts` drops `inboxes.purpose` and `member.primary_inbox_id`, adds `description`, replaces the ownership check, and rewrites the uniqueness rules. New server code on an unmigrated schema will not boot. It is destructive: `purpose` is gone and cannot be recovered from the row.
  - It also **repairs existing rows before adding the new rules**: defaults on team mailboxes are cleared, duplicate live addresses are switched off keeping the newest, and anyone holding two defaults keeps one. On a database with such rows, that is a silent data change — the alternative was a migration that fails to apply.
  - **Numbering:** this is `0046`, which is also the number on your in-progress `company-write-path-hardening` branch. Whichever merges second must renumber. This is not cosmetic — Effect's migrator silently skips any id at or below the highest already applied ([`Migrator.ts:250`](https://github.com/Effect-TS/effect/blob/main/packages/effect/src/unstable/sql/Migrator.ts)), so a gap would mean the other migration never runs, while a duplicate fails loudly.
- **Authorization boundary.** This changes who can reach whose mailbox, and who may send as whom. Worth reading as a security change, not a feature change.
- **API / wire shape.** `purpose` is gone from the mailbox shape and from the thread's inbox summary, replaced by `description`; `createInbox` gains `shared`; `updateInbox` can now answer `400`; the `listThreads` `purpose` filter is removed (no UI ever set it). Pre-production, so this is a clean break — no shims.
- **MCP and HTTP parity.** Both transports go through the same service, so both get the rules. The three long tool descriptions were rewritten, since that text is what an external AI client reads to decide how to connect and manage a mailbox.
- **Multi-org / RLS.** Organization scoping is unchanged — every new query still carries `organization_id`, and the new ownership rules sit on top of it, never instead of it. No RLS policy or Postgres role changed.
- **No new environment variables** are required in production. `BATUDA_ACTIVE_ORG_ROLE` is optional and local-development only (the stdio MCP surface), defaulting to the least standing.

## Review guide

Start with `apps/server/src/services/email.ts` — `mayActThrough` / `mayLookAfter` and the two lookups built on them are the whole idea; everything else follows. Then `0046_inbox_description.ts` for the database rules.

**The riskiest part** is that this is an authorization change, so a gap is a hole rather than a bug. Two independent adversarial reviews ran over it and found four real holes in my first pass, all fixed and pinned by tests — including two that broke the "nobody changes another member's default sender" rule (handing a mailbox over carried the flag with it; connecting one on somebody's behalf set it for them).

**Decisions you might overrule:**

1. **Pause was removed.** With one `active` flag, pausing and removing are literally the same operation, and now that removed mailboxes are hidden a Pause button would make a mailbox vanish with no way back. One honest concept felt better than two confusing ones — but it does drop the ability to stop syncing without re-entering the password. A real `deleted_at` column would let both exist; say the word and I will add it.
2. **A member sees colleagues' mailboxes in the list** (as they always did — non-private ones), just with no controls on them. I kept the list as the organization's directory rather than filtering it, on the grounds that seeing which addresses the organization has connected is reasonable. Filtering it is a one-line change if you disagree.
3. **Reads answer "not found", not "forbidden"**, so the endpoints cannot be used to discover which mailboxes exist. It means a member poking at a colleague's mailbox gets a slightly confusing 404 rather than a clear "not yours".

**Skip-able:** the `.po` catalogs, and the mechanical `purpose`-removal edits across nine integration suites.

**What I could not fully verify:** Snyk was not available in this environment, so no `snyk_code_scan` ran.

**All twelve accessibility findings are addressed**, including the five that predate this branch: muted text no longer fades under the contrast floor; the primary control is one persistent pressed-toggle rather than a button that unmounts under the finger that pressed it, with the change announced through a live region mounted from the start; the page waits for the identity queries before drawing rows, so controls and tab order no longer reshuffle after first paint; ticking "shared with the team" announces what it removed and keeps both answers as typed; and every bare em-dash now carries words. On a reply — where no picker is drawn — the address that will actually go out is written down, and a silent substitution is announced.

## Screenshots

Desktop — the list, with descriptions in place of the old Personal / AI agent / Shared badges, and four row actions where there were five:

![Mailbox list with descriptions](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-378/pr-inboxes-desktop.webp)

The connect form — a description field and a shared-with-the-team checkbox, no kind dropdown:

![Connect form with a description field and shared checkbox](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-378/pr-connect-dialog-desktop.webp)

Mobile, since `apps/internal` is mobile-first and this changes a table column:

![Mailbox list on a phone](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-378/pr-inboxes-mobile.webp)

## Tests

- 16 integration tests state the rules as behaviour: a colleague's mailbox reads as absent to an ordinary member and refuses a password re-test; an admin may change it but may neither choose nor unchoose what that person sends from, and cannot get around it by handing the mailbox over or connecting one for them; a first mailbox becomes its owner's default; removing one twice says so; connecting an address twice is refused in words rather than by the database.
- 4 tests cover the database rules directly: a team mailbox can be neither hidden from the team nor anyone's default, one address is connected once at a time, and one person has one default.
- 6 unit tests cover the standing check, including a role it has never seen and an empty one — both refuse rather than inherit authority.

## Verification

Ran, not assumed:

- `pnpm install` (no lockfile drift) → `check-types` (13 packages) → `test` (21 packages) → `build` (13 packages), all green.
- The touched integration suites: 66 tests across authorization, mailbox update and multi-org isolation, plus the mail-worker and handler suites.
- **A database rebuilt from empty** — `db reset` → migrate → seed — so the migration and the sample data were exercised together rather than on top of rows that already existed.
- Every new database rule probed directly with SQL to confirm it rejects the violation it exists for.
- The running app at both roles: as the organization owner (list renders descriptions, connect form shows the new fields, the shared checkbox correctly hides owner and privacy) and as an ordinary member (no row actions, no star on colleagues' mailboxes, and a pasted deep link to a colleague's settings form does not open).

## Deferred

- **Automated accessibility testing.** The monorepo has no DOM test environment at all — no jsdom, no happy-dom, no testing-library anywhere in `apps/` or `packages/`, and `apps/internal` runs vitest under `environment: 'node'` by deliberate choice. Standing that up means introducing the repo's first DOM-testing stack plus a provider harness for the router, atoms, auth client and i18n; that is its own piece of work rather than something to fold into an authorization change. Tracked separately. Worth knowing: axe would not have caught the findings that mattered most here (skipped punctuation, focus destroyed on success, tooltip-only content) — those needed a manual pass.

Closes #375
