### PR TITLE
cicd: pin the storage images and retry fetching them

### DIFF
--- a/.github/actions/e2e-stack/action.yml
+++ b/.github/actions/e2e-stack/action.yml
@@ -55,6 +55,21 @@ runs:
       run: |
         services="db storage"
         if [ "$WITH_MAIL" = "true" ]; then services="$services mail-catcher"; fi
+        # Fetching the images is the one step here that reaches outside the
+        # runner, and a slow minute at the registry used to fail the whole run
+        # before a single test had started. Three tries, backing off, so a bad
+        # minute costs a wait instead of a red build that says nothing about
+        # the change under test.
+        pull_attempt=1
+        until docker compose -f docker/docker-compose.yml pull --quiet $services storage-init; do
+          if [ "$pull_attempt" -ge 3 ]; then
+            echo "Could not fetch the container images after 3 tries." >&2
+            exit 1
+          fi
+          echo "Image pull failed (attempt $pull_attempt) — retrying shortly."
+          sleep $((pull_attempt * 10))
+          pull_attempt=$((pull_attempt + 1))
+        done
         docker compose -f docker/docker-compose.yml up -d --wait $services
         # The bucket is created by a container that stops as soon as it's done, and
         # `--wait` treats a stopped container as a failure — listing it above passed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
       # or failed on timing alone. `run` waits and reports whether it worked.
       - name: Start Postgres + MinIO via docker compose
         run: |
+          # Fetching the images is the one step here that reaches outside the
+          # runner, so it gets a few tries: a slow minute at the registry
+          # should cost a wait, not a red build on an unrelated change.
+          pull_attempt=1
+          until docker compose -f docker/docker-compose.yml pull --quiet db storage storage-init; do
+            if [ "$pull_attempt" -ge 3 ]; then
+              echo "Could not fetch the container images after 3 tries." >&2
+              exit 1
+            fi
+            echo "Image pull failed (attempt $pull_attempt) — retrying shortly."
+            sleep $((pull_attempt * 10))
+            pull_attempt=$((pull_attempt + 1))
+          done
           docker compose -f docker/docker-compose.yml up -d --wait db storage
           docker compose -f docker/docker-compose.yml run --rm --no-deps storage-init
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,11 @@ services:
   # via STORAGE_ENDPOINT (http://localhost:9000 in dev, R2 endpoint in prod).
   storage:
     container_name: batuda-storage
-    image: minio/minio:latest
+    # Pinned like every other service here: `latest` re-checks the registry on
+    # every start, so a slow day at Docker Hub failed the build rather than
+    # reusing what was already on the machine — and it could change underneath
+    # a laptop between two mornings.
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     ports:
       - "9000:9000" # S3 API
@@ -51,7 +55,7 @@ services:
   # safe to re-run; exits 0 once the bucket exists.
   storage-init:
     container_name: batuda-storage-init
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       - storage
     restart: "no"


### PR DESCRIPTION
## What

A pull request's checks should fail when the change is wrong, and pass when it is right. Twice this week they failed for neither reason: the run stopped while fetching the container images it needs, before a single test had started, and the red mark said nothing at all about the code under review. This makes that step steady.

It touches only the local container definitions (`docker/docker-compose.yml`) and the two CI jobs that stand them up — no application code.

## Changes

- **The two MinIO images now name a version.** They asked for `latest` while Postgres and GreenMail beside them are pinned, so every run re-checked the registry and could quietly pick up a different build from one morning to the next. Both now name the versions already in use.
- **Fetching the images gets three tries, backing off.** Pinning alone does not help here: a CI runner starts empty and pulls every time, and what failed was a timeout, not a wrong tag. Applied in both places that pull these images — the shared end-to-end action and the integration job.

## Impact

- **No application code, no schema, no environment variables.** Nothing to deploy and nothing for production to set.
- **Local development sees the same pinned versions.** A laptop that has already pulled `latest` keeps working; the next `pnpm cli services up` fetches the pinned tags instead. Storage is a named volume, so existing buckets are untouched — I confirmed this locally, including other worktrees' buckets going back to April.
- **A genuinely unreachable registry still fails the build**, after three tries and about half a minute. That is the correct outcome — this makes a bad minute survivable, not a broken registry invisible.

## Review guide

Three files, all mechanical. The one judgment call worth your eye: **whether three tries with a 10/20-second backoff is the right budget.** It adds at most ~30 seconds to a genuinely broken run and nothing to a healthy one. Easy to change if you would rather it fail faster.

The pinned versions are the ones the containers were already running locally, read off the images themselves rather than picked from a changelog.

## Verification

Ran, not assumed:

- `docker compose config` validates.
- Pulled both pinned tags — the first `mc` tag I derived from the image's build-timestamp label **did not exist**, so the tag in this PR is the real one taken from the registry's tag list and pulled successfully.
- Ran the exact command CI will run (`docker compose pull db storage storage-init`) and checked its real exit code: 0, all three images.
- Brought the pinned stack up, ran the bucket sidecar (`Bucket created successfully`), and confirmed the API health probe still answers.
- Listed the buckets afterwards: all eight survived, including every other worktree's and the oldest from April.

The retry branch itself was run in isolation under the same shell flags CI uses (`set -eo pipefail`), against a stubbed pull, for all three cases: fails-then-succeeds retries and continues, always-fails gives up after exactly three tries with a non-zero exit, and succeeds-first-time never retries. Worth doing separately, because a green run here only exercises the happy path — the retry never fires when nothing goes wrong, so a bug in that branch would sit unnoticed.

Also confirmed that `docker compose up` uses the already-pulled images and makes no registry call of its own. That matters: the failure this fixes happened during `up`, so the retried `pull` only helps if `up` stops reaching out once the images are present. It does.

## What this does not fix

Retrying covers a slow minute. A sustained registry outage still fails the build — three tries over about thirty seconds, then red. That is the right outcome, but it means this reduces the flakiness rather than removing it.

The upgrade that would remove it is **mirroring these images into GHCR** and pulling from there: same registry as the code, no shared-address pool, no third-party authentication hop. It costs a small sync workflow and four changed image references.

An authenticated Docker Hub pull is the more obvious suggestion, and I do not think it would have helped here. What the failing run recorded was a timeout reaching the token endpoint, not a `429` refusal — rate limiting announces itself as a fast, explicit rejection, and authenticating raises a limit rather than making a slow endpoint fast. That said, I am inferring from one log line, and I cannot rule out that Docker Hub throttles by stalling rather than refusing, in which case authentication would have mattered. If the retries start absorbing failures regularly, that is the signal to mirror rather than to authenticate.

