### PR TITLE
chore: say the mailbox rules once instead of three times

### DIFF
--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -97,9 +97,8 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		[inboxes, meUserId],
 	)
 
-	// Nothing is chosen until we know who is asking: before that only the
-	// team's mailboxes look sendable, and picking one would bind the draft to
-	// an address the person never meant to write from.
+	// Nothing is chosen until we know who is asking — before that only team
+	// mailboxes look sendable, and the draft would bind to one of those.
 	const defaultInboxId = useMemo(
 		() =>
 			meUserId === undefined
@@ -123,17 +122,15 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		attachments: [],
 	}))
 
-	// A draft picked up later can name a mailbox that has since been removed
-	// or was never this person's to write from; fall back rather than send
-	// from an address the server will refuse.
+	// A draft picked up later can name a mailbox since removed, or never this
+	// person's; fall back rather than send from an address that is refused.
 	const chosenInboxId =
 		form.inboxId !== null && sendableInboxes.some(i => i.id === form.inboxId)
 			? form.inboxId
 			: null
 	const effectiveInboxId = chosenInboxId ?? defaultInboxId
-	// Sending from an address you did not pick is not a mistake you can take
-	// back, so a swap is said out loud — and on a reply, where no picker is
-	// drawn at all, the address that will actually go out is written down.
+	// Sending from an address you did not pick cannot be taken back, so a swap
+	// is said out loud and a reply writes down what will go out.
 	const substituted =
 		form.inboxId !== null && chosenInboxId === null && effectiveInboxId !== null
 	const sendingFrom =

--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -254,20 +254,17 @@ function InboxesPage() {
 	// until then, since every control on them turns on whose mailbox it is.
 	const isLoading = AsyncResult.isInitial(inboxesResult) || identityPending
 	const isFailure = AsyncResult.isFailure(inboxesResult)
-	// Settled means both the list and who is asking. The list arrives already
-	// filled from the server, so without the second half a link straight to a
-	// mailbox's settings would judge it unreachable and shut itself before the
-	// answer to "whose is it" had even come back.
+	// Both the list and who is asking. The list arrives already filled from
+	// the server, so without the second half a link to a mailbox's settings
+	// would judge it unreachable and shut itself.
 	const listSettled =
 		(AsyncResult.isSuccess(inboxesResult) ||
 			AsyncResult.isFailure(inboxesResult)) &&
 		!identityPending
 
 	// Edit/footers dialogs carry only the row id in the URL; resolve the row
-	// from the loaded list. A deep link to a row that no longer exists closes
-	// itself once the list has loaded — and so does one naming a mailbox this
-	// person cannot change, since the address bar is as much a way in as the
-	// buttons are.
+	// from the loaded list. A deep link closes itself when the row is gone, or
+	// is not this person's to change — the address bar is a way in too.
 	const targetRow = useMemo(() => {
 		if (dlg === undefined || dlg.kind === 'create') return null
 		const row = rows.find(row => row.id === dlg.id) ?? null
@@ -650,10 +647,8 @@ function InboxesPage() {
 											{t`Primary`}
 										</PrimaryLabel>
 									) : (
-										// Which address somebody sends from is theirs to pick,
-										// so there is nothing to offer on anyone else's. A bare
-										// dash is punctuation a screen reader may pass over,
-										// leaving the cell sounding empty.
+										// Nothing to offer on anyone else's. The dash alone is
+										// punctuation a screen reader may pass over.
 										<Muted>
 											<SrOnly>{t`Not yours to set`}</SrOnly>
 											<span aria-hidden>—</span>
@@ -813,9 +808,8 @@ function useMeUserId(): string | undefined {
 	return authClient.useSession().data?.user?.id
 }
 
-// Whether we yet know who is asking. Until we do, every mailbox looks like
-// somebody else's, so the rows would draw with nothing on them and then fill
-// in — moving what a person can tab to while they are already tabbing.
+// Until we know who is asking every mailbox looks like somebody else's, so
+// the rows would fill in after paint — moving what a person can tab to.
 function useIdentityPending(): boolean {
 	const member = authClient.useActiveMember()
 	const session = authClient.useSession()
@@ -1018,10 +1012,8 @@ function InboxFormDialog({
 				? await onUpdate(editing.id, {
 						displayName: draft.displayName === '' ? null : draft.displayName,
 						description: draft.description === '' ? null : draft.description,
-						// Only sent when the owner is actually being changed. A blank
-						// field means "leave it as it is", never "give it to the team"
-						// — handing a mailbox over is always something typed on
-						// purpose.
+						// Blank means "leave it as it is", never "give it to the team":
+						// handing a mailbox over is always typed on purpose.
 						...(draft.shared
 							? { ownerUserId: null }
 							: draft.ownerUserId !== '' && { ownerUserId: draft.ownerUserId }),

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -527,25 +527,20 @@ export class EmailService extends Context.Service<EmailService>()(
 				created_at, updated_at
 			`
 
-			// Whose mailbox someone may act through: their own, and the team's.
-			// A colleague's mailbox is not theirs to send from, whatever else
-			// they are allowed to do around the organization.
+			// Their own and the team's. A colleague's is not theirs to send from.
 			const mayActThrough = (inbox: InboxRow, userId: string) =>
 				inbox.ownerUserId === null || inbox.ownerUserId === userId
 
-			// Whose settings someone may change, or remove: their own mailbox,
-			// and — for whoever runs the organization — anyone's. A mailbox with
-			// no owner is the organization's own, so it is theirs to look after
-			// rather than any one member's.
+			// Their own, or anyone's for whoever runs the organization — which
+			// includes the team's, since it belongs to no one member.
 			const mayLookAfter = (
 				inbox: InboxRow,
 				userId: string,
 				role: string | null,
 			) => isOrgManager(role) || inbox.ownerUserId === userId
 
-			// A half-written message is as private as a sent one, so reaching it
-			// takes the same standing as the mailbox it will go out from — which
-			// is the draft's own mailbox, not whichever one the caller names.
+			// Gated on the draft's own mailbox, not whichever one the caller
+			// names — a half-written message is as private as a sent one.
 			const assertDraftReachable = (
 				draftInboxId: string,
 				draftId: string,
@@ -572,9 +567,7 @@ export class EmailService extends Context.Service<EmailService>()(
 					return mayActThrough(inbox, session.userId) ? inbox : null
 				})
 
-			// The same lookup for changing a mailbox rather than acting through
-			// it, which is the stricter of the two for a member and the looser
-			// for whoever runs the organization.
+			// For changing a mailbox rather than acting through it.
 			const resolveInboxToLookAfter = (inboxId: string) =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
@@ -1939,9 +1932,8 @@ export class EmailService extends Context.Service<EmailService>()(
 							? null
 							: (input.ownerUserId ?? session.userId)
 
-						// Connecting a mailbox in somebody else's name, or one that
-						// belongs to everyone, is looking after the organization
-						// rather than looking after yourself.
+						// Connecting one in somebody else's name, or the team's, is
+						// looking after the organization rather than yourself.
 						const actsForSomeoneElse =
 							ownerUserId === null || ownerUserId !== session.userId
 						if (actsForSomeoneElse && !isOrgManager(currentOrg.role)) {
@@ -1950,10 +1942,8 @@ export class EmailService extends Context.Service<EmailService>()(
 									'Only an organization admin can connect a mailbox for the team or for another member',
 							})
 						}
-						// One address is connected once at a time. Answered here so
-						// reconnecting an address already in use gets a plain reply
-						// rather than a database error, and the same reply whoever
-						// holds that address — it never names the colleague who does.
+						// Answered here so reconnecting an address in use gets a plain
+						// reply rather than a database error.
 						const alreadyConnected = yield* sql<{ count: number }>`
 							SELECT count(*)::int AS count FROM inboxes
 							WHERE organization_id = ${currentOrg.id}
@@ -1984,11 +1974,9 @@ export class EmailService extends Context.Service<EmailService>()(
 							})
 						}
 
-						// The first mailbox somebody connects becomes the address they
-						// send from, so nobody has to go looking for a setting to make
-						// sending work at all. Only ever for the person doing the
-						// connecting: setting one up on somebody's behalf leaves that
-						// choice to them, the same as everywhere else.
+						// A first mailbox becomes what that person sends from, so
+						// sending works without hunting for a setting. Only for the
+						// person connecting it: choosing is never done for somebody.
 						const isFirstOwnMailbox =
 							ownerUserId === session.userId &&
 							(yield* sql<{ count: number }>`
@@ -2044,10 +2032,9 @@ export class EmailService extends Context.Service<EmailService>()(
 								}),
 							)
 
-						// Giving up the previously marked mailbox and marking this one
-						// happen together, and only once the connection has been tried:
-						// a mailbox that turns out unreachable must not leave somebody
-						// with nothing to send from. Only ever the same person's.
+						// Unmarking the old and marking the new happen together, after
+						// the connection is tried, so a mailbox that turns out
+						// unreachable cannot leave somebody with nothing to send from.
 						const rows = yield* sql
 							.withTransaction(
 								Effect.gen(function* () {
@@ -2091,10 +2078,9 @@ export class EmailService extends Context.Service<EmailService>()(
 								}),
 							)
 							.pipe(
-								// Two people connecting the same address at once both get
-								// past the check above, since the connection attempt between
-								// them takes real time. The loser is told the same thing the
-								// check would have told them, rather than seeing a crash.
+								// Two at once both pass the check above, since the connection
+								// attempt between takes real time. The loser gets told, not
+								// crashed.
 								Effect.catchTag('SqlError', error =>
 									String(error.cause).includes('idx_inboxes_email_active')
 										? Effect.fail(
@@ -2317,11 +2303,9 @@ export class EmailService extends Context.Service<EmailService>()(
 						if (!target) {
 							return yield* new NotFound({ entity: 'Inbox', id })
 						}
-						// Removing a mailbox stops it syncing and takes it out of the
-						// pickers, but the row stays: threads and message search go on
-						// resolving through it long after somebody removes it.
-						// Removing one that was already gone changes nothing, and says
-						// so, rather than reporting a removal that never happened.
+						// The row stays so threads and search keep resolving through
+						// it. Removing one already gone says so, rather than reporting
+						// a removal that never happened.
 						if (!target.active) {
 							return yield* new NotFound({ entity: 'Inbox', id })
 						}
@@ -2338,11 +2322,8 @@ export class EmailService extends Context.Service<EmailService>()(
 						return yield* decodeInbox(rows[0]!).pipe(Effect.orDie)
 					}),
 
-				// Manual re-test of a stored mailbox — decrypt, probe, and write
-				// back the grant status. Shares reprobeInbox with updateInbox,
-				// which does its own checking; asked for directly, it is the
-				// mailbox's keeper who may ask, since the answer is whether
-				// somebody's stored password still works.
+				// Decrypt, probe, write back the grant status. Gated on its own,
+				// since the answer is whether somebody's password still works.
 				testInbox: (id: string) =>
 					Effect.gen(function* () {
 						const target = yield* resolveInboxToLookAfter(id)
@@ -2352,9 +2333,8 @@ export class EmailService extends Context.Service<EmailService>()(
 						return yield* reprobeInbox(id)
 					}),
 
-				// Chooses which of the caller's own mailboxes they send from when
-				// they don't say. Nobody else's is touched, and nobody else can
-				// make this choice for them.
+				// Which of the caller's own mailboxes they send from when they
+				// don't say. Nobody else's is touched, or can be.
 				setPrimaryInbox: (id: string) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
@@ -2594,9 +2574,8 @@ export class EmailService extends Context.Service<EmailService>()(
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
 						const session = yield* SessionContext
-						// A mailbox out of the caller's reach answers with an empty
-						// page, the same as one that is not there at all, so this can
-						// never be used to find out what exists.
+						// Out of reach answers empty, same as absent, so this can never
+						// be used to find out what exists.
 						if (inboxId !== undefined && !(yield* resolveInbox(inboxId))) {
 							return {
 								items: [],
@@ -2609,9 +2588,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							}
 						}
 						const list = yield* drafts.list(inboxId)
-						// Naming no mailbox means "mine", not "everyone's" — half-written
-						// mail is as private as sent mail, so a colleague's never comes
-						// back here.
+						// Naming no mailbox means "mine", not "everyone's".
 						const reachable = yield* sql<{ id: string }>`
 							SELECT id FROM inboxes
 							WHERE organization_id = ${currentOrg.id}
@@ -2794,9 +2771,8 @@ export class EmailService extends Context.Service<EmailService>()(
 				listFooters: (inboxId: string) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						// Visible to whoever sends through the mailbox, and to whoever
-						// looks after it — otherwise an admin would be shown nothing on
-						// a mailbox whose signature they are allowed to rewrite.
+						// Either standing: an admin who may rewrite a signature would
+						// otherwise be shown none.
 						const inbox =
 							(yield* resolveInbox(inboxId)) ??
 							(yield* resolveInboxToLookAfter(inboxId))
@@ -2843,9 +2819,8 @@ export class EmailService extends Context.Service<EmailService>()(
 				}) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						// Writing a signature changes what goes out on every message
-						// the mailbox sends, so it takes the same standing as changing
-						// the mailbox itself.
+						// A signature goes out on every message the mailbox sends, so
+						// writing one takes the same standing as changing the mailbox.
 						const inbox = yield* resolveInboxToLookAfter(input.inboxId)
 						if (!inbox) {
 							return yield* new NotFound({


### PR DESCRIPTION
## What

The comments explaining who may reach which mailbox were too long. They said each rule, then its consequence, then its mechanism — three sentences doing one sentence's work, running to five and six lines above two-line statements. This trims them to the part a reader cannot get from the code beside them.

Comments only. No behaviour, no code, no tests changed.

## Changes

- Cut the multi-line blocks in the email service, the mailbox settings page and the compose form from 86 comment lines to 50.
- Kept at length the few that record something genuinely unobtainable from the code: why a live region has to be mounted before it has words or it goes unread, and why a check exists at all where the code alone looks like it could be simpler.

An example of the shape of it — this:

```
// Which address somebody sends from is their own choice, so it
// is not something anyone else changes for them — running the
// organization included, and taking it away counts as changing
// it. Read against who will own the mailbox once this call is
// done, so handing it over and marking it in one go cannot slip
// past.
```

became this:

```
// Read against the owner after this call, so handing a mailbox over
// and marking it in one go cannot slip past.
```

The rule itself is already stated once, at the guard it belongs to. Repeating it at every site that touches it is what made the file long.

## Impact

None. Nothing outside these three files' comments changes — no schema, no wire shape, no environment variables, no behaviour on either transport.

## Review guide

The one thing worth checking is that this really is comments only. I verified it by filtering the diff for any line that is not a comment, and there are none — but it is a one-command check if you want it yourself:

```bash
git diff origin/main...HEAD | grep -E "^[+-]" | grep -v "^[+-][+-]" | grep -vE "^[+-][[:space:]]*(//|\*|/\*|\{/\*)"
```

Empty output means the claim holds.

Beyond that it is a judgement call about voice, so read a couple and tell me if I have cut too far. My aim was one line of why, which is the convention the repo already states.

## Verification

`check-types` (13 packages), `test` (21 packages) and `build` (13 packages) all pass, plus Biome and the i18n catalog check via the pre-commit hook. Those prove little for a comment change, which is the point — the real check is the diff filter above.
