### PR TITLE
cicd: refuse a migration numbered where it would never run

### DIFF
--- a/scripts/check-migration-safety.mjs
+++ b/scripts/check-migration-safety.mjs
@@ -11,6 +11,25 @@
 //
 //   // expand-contract: <why the old shape is safe to drop in this same deploy>
 //
+// It also checks how the new migrations are NUMBERED, which matters more than it
+// looks. A migration's number is the only thing deciding whether it ever runs:
+// the migrator records the highest number applied and, next time, runs only what
+// is above it. Two failures follow from that, and a long-lived branch hits both.
+//
+// A number already taken on the base ref is the loud one — the migrator refuses
+// to start, naming duplicate ids, so nothing corrupts but nothing migrates either
+// until somebody renumbers.
+//
+// A number at or below the base ref's highest is the quiet one, and the reason
+// this check exists. Two branches numbering from the same starting point is
+// normal; whichever merges second is then numbered below something already on
+// the base, and any database that applied that branch first will never run the
+// other's migration. No error, no retry, no way back — it is simply skipped
+// forever, and the mismatch surfaces later as a missing column.
+//
+// One rule catches both: a new migration must be numbered above everything on
+// the base ref. Rebase, renumber, and the branch is safe again.
+//
 // Usage: node scripts/check-migration-safety.mjs [baseRef]   (default: origin/main)
 
 import { execSync } from 'node:child_process'
@@ -54,6 +73,67 @@ if (added.length === 0) {
 }
 
 let failed = false
+
+// ── Numbering ────────────────────────────────────────────────────────────────
+// The number off the front of the filename: `0047_company_tax_id.ts` → 47.
+const idOf = file => {
+	const match = /(?:^|\/)(\d+)_/.exec(file)
+	return match ? Number(match[1]) : null
+}
+
+const baseIds = new Set(
+	execSync(`git ls-tree --name-only ${baseRef} -- ${MIGRATIONS_DIR}`, {
+		encoding: 'utf8',
+	})
+		.trim()
+		.split('\n')
+		.filter(Boolean)
+		.map(idOf)
+		.filter(id => id !== null),
+)
+const highestOnBase = baseIds.size === 0 ? -1 : Math.max(...baseIds)
+const seen = new Map()
+
+for (const file of added) {
+	const id = idOf(file)
+	if (id === null) {
+		failed = true
+		console.error(
+			`✗ ${file} — no number at the front of the filename; name it <number>_<what_it_does>.ts`,
+		)
+	} else if (baseIds.has(id)) {
+		failed = true
+		console.error(
+			`✗ ${file} — number ${id} is already taken on ${baseRef}. Rebase and renumber above ${highestOnBase}.`,
+		)
+	} else if (seen.has(id)) {
+		failed = true
+		console.error(
+			`✗ ${file} — number ${id} is used twice here (also ${seen.get(id)}).`,
+		)
+	} else if (id <= highestOnBase) {
+		failed = true
+		seen.set(id, file)
+		console.error(
+			`✗ ${file} — number ${id} sits below ${highestOnBase}, the highest on ${baseRef}. ` +
+				`A database that already ran this branch would skip everything in between, permanently. ` +
+				`Rebase and renumber above ${highestOnBase}.`,
+		)
+	} else {
+		seen.set(id, file)
+		console.log(`✓ ${file} — numbered ${id}, above ${highestOnBase}`)
+	}
+}
+
+if (failed) {
+	console.error(
+		'\nA migration runs only if its number is above the highest the database has\n' +
+			'already applied. Numbering at or below that means it is skipped — silently,\n' +
+			'once, and for good. Rebase onto the base ref and renumber.\n',
+	)
+	process.exit(1)
+}
+
 for (const file of added) {
 	const sql = readFileSync(file, 'utf8')
 	const hits = DESTRUCTIVE.filter(([, re]) => re.test(sql)).map(


### PR DESCRIPTION
## What

A migration's number is the only thing deciding whether it ever runs. The database records the highest number it has applied, and next time runs only what is above that. Nothing re-checks, nothing backfills.

That makes a mistake possible which nobody catches by reading a diff, because both halves look correct on their own: two branches start from the same point and each numbers its migrations from there. Whichever merges second is now numbered below something already on `main` — and any database that applied that branch first will never run the other's migration. No error, no retry, no way back. The mismatch shows up much later as a column that is simply not there.

This makes the check that already reads new migrations for unsafe DDL read their numbers too. This is `cicd` — it changes what CI refuses, nothing the product does.

## The fix

One rule, checked against the PR's own base branch: a new migration must be numbered above everything already on the base. That covers all three ways it goes wrong:

- **The number is already taken on the base.** The loud one — the migrator itself refuses to start, naming duplicate ids, so nothing corrupts but nothing migrates either until somebody renumbers. Better to hear it on the PR than when a colleague's database won't come up.
- **The same number twice within one change.** Same outcome, caught before it leaves the branch.
- **A number at or below the base's highest.** The quiet one, and the reason this exists. It is the case above, described from the other side, and it is the one that leaves a database permanently missing a migration.

Each message names the number to renumber above, so the fix is one rename after a rebase.

## Impact

- **CI will now fail two branches that are currently in flight**, both of which have a migration numbered `0047` while `main` gained its own `0047` last night. That failure is the point — they would otherwise have found out when their database refused to migrate. Each needs a rebase and a rename; I have deliberately not touched either branch, since their own sessions are working in them.
- **No product behaviour changes**, no schema change, no new environment variables, nothing touching tenant isolation or auth. One script and its CI step.
- **No new dependency** — it reads the base ref's filenames with `git ls-tree`, the same two-dot approach the existing check uses, so it still works under CI's shallow checkout.

## Review guide

**The rule is deliberately stricter than "don't collide".** Refusing any number at or below the base's highest also refuses filling a gap in the base's own numbering, which is technically harmless once merged. I took the stricter rule because the harmful and harmless cases are indistinguishable from the files alone — what makes one harmful is which databases already ran which branch, which no check can see. Renumbering upward is free; the failure it prevents is not recoverable.

**What it deliberately does not catch:** a database that already applied a branch before a lower-numbered migration landed on `main`. That is a state problem, not a file problem, and no file-level check can see it. The fix there is recreating the database, which is why the message says so plainly.

## Tests

Exercised against the three real outcomes on throwaway commits, plus the passing case:

- a migration numbered `0047` when `main` already has one → refused, naming `53` as the number to beat
- the same number used twice in one change → refused, naming both files
- a correctly numbered `0054` → passes
- run against an older base ref, where every migration from this month reports the number it sits above

## Verification

- `pnpm -w check-types` — 13/13 packages.
- The script run against `origin/main` (no new migrations → clean pass) and against `origin/main~12` (reports each of the eight migrations added since).
- Confirmed CI invokes it per-PR against `origin/$GITHUB_BASE_REF`, so it checks against the branch being merged into rather than a fixed ref.
