### PR TITLE
fix(server): put mailbox ownership out of an ordinary request's reach

### DIFF
--- a/apps/server/src/db/migrations/0054_inbox_ownership_handover.ts
+++ b/apps/server/src/db/migrations/0054_inbox_ownership_handover.ts
@@ -1,0 +1,120 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Who a mailbox belongs to is no longer something an ordinary request can write.
+//
+// A mailbox belongs to one person, or to the whole team when nobody owns it,
+// and since 0046 that single fact decides who may read it, change it, or send
+// from it. Nothing in the database was enforcing it. The rule lived entirely in
+// application code; underneath, the only thing row security asked of a mailbox
+// was that it stay inside the organization, and the request role could write
+// every column. Any member could put their own name on a colleague's mailbox —
+// and a mailbox carries the stored password for someone's real email account.
+//
+// No route reached it. Both ways in go through the same service, which refuses
+// first: a member who does not already own a mailbox cannot see it at all. So
+// this closes a gap under the floor rather than a hole somebody could walk
+// through. It is worth closing because the same arrangement, one table over,
+// stopped being theoretical the moment its application check was removed —
+// the check had been the only thing there, and nobody knew.
+//
+// Handing a mailbox over is a real thing admins do, so the column cannot simply
+// be taken away. It moves instead into a routine that re-checks the rules for
+// itself — the caller runs the organization, the receiver is really a member of
+// it — the same shape 0014 uses for instruction templates. The routine settles
+// the two things that follow from a handover in the same breath, because the
+// database refuses the in-between states: a mailbox nobody owns cannot be
+// hidden from the team, and whoever receives one chooses for themselves whether
+// they send from it.
+//
+// The columns an ordinary request may still write are listed rather than
+// excluded, so a column added later is not writable until somebody says so. If
+// that is forgotten, the write fails loudly and says which table.
+//
+// expand-contract: replacing the grant means dropping it first, and in the
+// moment between, an ordinary member's edit is refused. Both statements sit
+// inside one migration.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		CREATE OR REPLACE FUNCTION public.transfer_inbox(
+			p_inbox_id uuid,
+			p_target_user_id text
+		) RETURNS SETOF public.inboxes
+		LANGUAGE plpgsql
+		SECURITY DEFINER
+		SET search_path = ''
+		AS $$
+		DECLARE
+			v_actor text := current_setting('app.current_user_id', true);
+			v_org   text := current_setting('app.current_org_id', true);
+		BEGIN
+			IF v_actor IS NULL OR v_actor = '' OR v_org IS NULL OR v_org = '' THEN
+				RAISE EXCEPTION 'mailbox handover requires an active org and user scope';
+			END IF;
+
+			IF NOT EXISTS (
+				SELECT 1 FROM public.member
+				WHERE "userId" = v_actor
+					AND "organizationId" = v_org
+					AND role IN ('owner', 'admin')
+			) THEN
+				RAISE EXCEPTION 'only an organization admin can hand a mailbox over';
+			END IF;
+
+			-- A null target gives the mailbox to the whole team, which needs no
+			-- membership check. Anyone else must really be in the organization.
+			IF p_target_user_id IS NOT NULL AND NOT EXISTS (
+				SELECT 1 FROM public.member
+				WHERE "userId" = p_target_user_id AND "organizationId" = v_org
+			) THEN
+				RAISE EXCEPTION 'mailbox handover target is not a member of the active org';
+			END IF;
+
+			RETURN QUERY
+				WITH updated AS (
+					UPDATE public.inboxes
+					SET owner_user_id = p_target_user_id,
+						-- A mailbox the whole team owns cannot be hidden from them.
+						is_private = CASE
+							WHEN p_target_user_id IS NULL THEN false
+							ELSE is_private
+						END,
+						-- Receiving a mailbox does not decide that you send from it.
+						is_default = false,
+						updated_at = now()
+					WHERE id = p_inbox_id AND organization_id = v_org
+					RETURNING *
+				)
+				SELECT * FROM updated;
+		END;
+		$$
+	`
+
+	// Only the request role runs it, while the migration role still owns it.
+	yield* sql`REVOKE EXECUTE ON FUNCTION public.transfer_inbox(uuid, text) FROM PUBLIC`
+	yield* sql`GRANT EXECUTE ON FUNCTION public.transfer_inbox(uuid, text) TO app_user`
+
+	// It has to run as a role whose rights can write the owner column once the
+	// grant below no longer covers it. app_service needs CREATE on the schema for
+	// that one step, so it is given and taken straight back.
+	yield* sql`GRANT CREATE ON SCHEMA public TO app_service`
+	yield* sql`ALTER FUNCTION public.transfer_inbox(uuid, text) OWNER TO app_service`
+	yield* sql`REVOKE CREATE ON SCHEMA public FROM app_service`
+
+	// Everything about a mailbox stays a member's to edit except the two things
+	// that say whose it is and where it lives.
+	yield* sql`REVOKE UPDATE ON inboxes FROM app_user`
+	yield* sql`
+		GRANT UPDATE (
+			email, display_name, description, is_default, is_private, active,
+			imap_host, imap_port, imap_security,
+			smtp_host, smtp_port, smtp_security,
+			username, password_ciphertext, password_nonce, password_tag,
+			grant_status, grant_last_error, grant_last_seen_at,
+			folder_state, updated_at
+		) ON inboxes TO app_user
+	`
+})

--- a/apps/server/src/services/email-inbox-authorization.integration.test.ts
+++ b/apps/server/src/services/email-inbox-authorization.integration.test.ts
@@ -5,11 +5,12 @@ process.env['DATABASE_URL'] ??=
 
 import { Effect, Exit, Layer } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { CurrentOrg, SessionContext } from '@batuda/controllers'
 
 import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
 import { CalendarService } from './calendar.js'
 import { CredentialCrypto } from './credential-crypto.js'
 import { EmailService } from './email.js'
@@ -76,6 +77,10 @@ const actingAs = (userId: string, role: string) =>
 		}),
 	)
 
+// Run the way a request does: inside the organization's own database scope, as
+// the role a request runs as. Some of what these scenarios rely on is enforced
+// down there rather than in the service, and a caller that only stubbed the
+// session would be testing looser conditions than production ever has.
 const run = <A, E>(
 	effect: Effect.Effect<
 		A,
@@ -86,11 +91,19 @@ const run = <A, E>(
 	role: string,
 ) =>
 	Effect.runPromiseExit(
-		effect.pipe(
-			Effect.provide(serviceLayer),
-			Effect.provide(actingAs(userId, role)),
-			Effect.provide(PgLive),
-		),
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, {
+				org: { id: ORG, name: 'Authz Test', slug: 'authz-test' } as never,
+				userId,
+				role,
+			})(
+				effect.pipe(
+					Effect.provide(serviceLayer),
+					Effect.provide(actingAs(userId, role)),
+				),
+			)
+		}).pipe(Effect.provide(PgLive)),
 	)
 
 const placeholder = new Uint8Array([0])
@@ -100,17 +113,19 @@ const insertInbox = (args: {
 	readonly email: string
 	readonly ownerUserId: string | null
 	readonly isDefault?: boolean
+	readonly isPrivate?: boolean
 }) =>
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient
 		const rows = yield* sql<{ id: string }>`
 			INSERT INTO inboxes (
-				organization_id, email, owner_user_id, is_default,
+				organization_id, email, owner_user_id, is_default, is_private,
 				imap_host, imap_port, imap_security,
 				smtp_host, smtp_port, smtp_security, username,
 				password_ciphertext, password_nonce, password_tag
 			) VALUES (
 				${ORG}, ${args.email}, ${args.ownerUserId}, ${args.isDefault ?? false},
+				${args.isPrivate ?? false},
 				'imap.test', 993, 'tls', 'smtp.test', 465, 'tls', ${args.email},
 				${placeholder}, ${placeholder}, ${placeholder}
 			)
@@ -119,11 +134,47 @@ const insertInbox = (args: {
 		return rows[0]!.id
 	})
 
+// Alice and Bob have to be real members, not just names in a stubbed session:
+// handing a mailbox over asks the database who is running the organization,
+// rather than believing what the caller says about itself.
+const seedMembership = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+	yield* sql`
+		INSERT INTO "organization" (id, name, slug, "createdAt")
+		VALUES (${ORG}, 'Authz Test', 'authz-test', now())
+		ON CONFLICT (id) DO NOTHING
+	`
+	for (const [userId, role] of [
+		[ALICE, 'owner'],
+		[BOB, 'member'],
+	] as const) {
+		yield* sql`
+			INSERT INTO "user" (id, name, email, "emailVerified")
+			VALUES (${userId}, ${userId}, ${`${userId}@test.local`}, true)
+			ON CONFLICT (id) DO NOTHING
+		`
+		yield* sql`
+			INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+			VALUES (${`m-${userId}`}, ${ORG}, ${userId}, ${role}, now())
+			ON CONFLICT (id) DO NOTHING
+		`
+	}
+})
+
 const cleanup = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient
 	yield* sql`DELETE FROM email_drafts WHERE organization_id = ${ORG}`
 	yield* sql`DELETE FROM inbox_footers WHERE organization_id = ${ORG}`
 	yield* sql`DELETE FROM inboxes WHERE organization_id = ${ORG}`
+})
+
+// The organization and its people outlive each scenario; only the mailboxes
+// are swept between them.
+const dropMembership = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+	yield* sql`DELETE FROM member WHERE "organizationId" = ${ORG}`
+	yield* sql`DELETE FROM "organization" WHERE id = ${ORG}`
+	yield* sql`DELETE FROM "user" WHERE id IN (${ALICE}, ${BOB})`
 })
 
 // A half-written message sitting in a mailbox, put there without going through
@@ -151,6 +202,20 @@ const insertDraft = (inboxId: string) =>
 const runPlain = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
 	Effect.runPromise(effect.pipe(Effect.provide(PgLive)))
 
+// Read back the two things a handover settles, without going through the
+// service that performed it.
+const readOwnership = (inboxId: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const rows = yield* sql<{
+			ownerUserId: string | null
+			isPrivate: boolean
+		}>`
+			SELECT owner_user_id, is_private FROM inboxes WHERE id = ${inboxId}
+		`
+		return rows[0] ?? null
+	})
+
 // The mailbox somebody sends from, read straight from the row.
 const defaultOf = (userId: string) =>
 	runPlain(
@@ -166,12 +231,17 @@ const defaultOf = (userId: string) =>
 	)
 
 describe('who may reach a mailbox', () => {
+	beforeAll(async () => {
+		await runPlain(seedMembership)
+	})
+
 	beforeEach(async () => {
 		await runPlain(cleanup)
 	})
 
 	afterAll(async () => {
 		await runPlain(cleanup)
+		await runPlain(dropMembership)
 	})
 
 	describe('when the mailbox belongs to a colleague', () => {
@@ -330,6 +400,71 @@ describe('who may reach a mailbox', () => {
 			// THEN Bob does not silently start sending as that address: the mark
 			// comes off, for him to make the choice himself
 			expect(await defaultOf(BOB)).toHaveLength(0)
+		})
+
+		it('should give it to the whole team, and stop hiding it from them', async () => {
+			// GIVEN a mailbox of Bob's that only he can see
+			const id = await runPlain(
+				insertInbox({
+					email: 'to-the-team@test.local',
+					ownerUserId: BOB,
+					isPrivate: true,
+				}),
+			)
+
+			// WHEN Alice, who runs the organization, gives it to everybody
+			const exit = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.updateInbox(id, { ownerUserId: null })
+				}),
+				ALICE,
+				'admin',
+			)
+
+			// THEN it belongs to nobody in particular, and is no longer hidden —
+			// a mailbox the team owns cannot be kept from them
+			expect(Exit.isSuccess(exit)).toBe(true)
+			const row = await runPlain(readOwnership(id))
+			expect(row).toEqual({ ownerUserId: null, isPrivate: false })
+		})
+	})
+
+	// The checks above are the application's. This one is the database's, asked
+	// directly, because that is the whole point: if the checks above were ever
+	// loosened the way an instruction template's once were, this is what would
+	// still be standing.
+	describe('when a member goes at the owner column directly', () => {
+		it('should refuse the write, admin or not', async () => {
+			// GIVEN a mailbox belonging to Alice
+			const id = await runPlain(
+				insertInbox({ email: 'not-yours@test.local', ownerUserId: ALICE }),
+			)
+
+			// WHEN Bob, an ordinary member, writes his own name onto it under the
+			// role a request actually runs as
+			const exit = await Effect.runPromiseExit(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					yield* sql.withTransaction(
+						Effect.gen(function* () {
+							yield* sql`SET LOCAL ROLE app_user`
+							yield* sql`SELECT set_config('app.current_org_id', ${ORG}, true)`
+							yield* sql`SELECT set_config('app.current_user_id', ${BOB}, true)`
+							yield* sql`
+								UPDATE inboxes SET owner_user_id = ${BOB} WHERE id = ${id}
+							`
+						}),
+					)
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			// THEN the database refuses it: that column is not a request's to write
+			expect(Exit.isFailure(exit)).toBe(true)
+			expect(await runPlain(readOwnership(id))).toEqual({
+				ownerUserId: ALICE,
+				isPrivate: false,
+			})
 		})
 	})
 

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -2207,31 +2207,35 @@ export class EmailService extends Context.Service<EmailService>()(
 							}
 						}
 
+						// Who a mailbox belongs to is not written from here. The column
+						// is out of this role's reach, so the change goes through a
+						// routine that re-checks the rules for itself — the database
+						// says no even if the checks above were ever loosened. It
+						// settles what follows from a handover in the same statement:
+						// the mark for sending comes off, so the mailbox cannot quietly
+						// become what its new owner sends as, and a mailbox given to the
+						// whole team stops being hidden from them.
+						const handingOver =
+							patch.ownerUserId !== undefined &&
+							patch.ownerUserId !== existing.ownerUserId
+						if (handingOver) {
+							yield* sql`
+								SELECT 1 FROM transfer_inbox(
+									${id}::uuid,
+									${patch.ownerUserId ?? null}
+								)
+							`.pipe(Effect.orDie)
+						}
+
 						const sets: Array<Statement.Fragment> = []
 						if (patch.displayName !== undefined)
 							sets.push(sql`display_name = ${patch.displayName}`)
 						if (patch.description !== undefined)
 							sets.push(sql`description = ${patch.description}`)
-						if (patch.ownerUserId !== undefined)
-							sets.push(sql`owner_user_id = ${patch.ownerUserId}`)
 						if (patch.isPrivate !== undefined)
 							sets.push(sql`is_private = ${patch.isPrivate}`)
 						if (patch.isDefault !== undefined)
 							sets.push(sql`is_default = ${patch.isDefault}`)
-						// Handing a mailbox to somebody else does not hand over the
-						// choice of sending from it: the mark comes off, so the mailbox
-						// cannot quietly become what its new owner sends as.
-						if (
-							ownerAfterPatch !== existing.ownerUserId &&
-							patch.isDefault === undefined
-						) {
-							sets.push(sql`is_default = false`)
-						}
-						// Giving a mailbox to the whole team opens it to them, since a
-						// mailbox everybody owns cannot be hidden from anybody.
-						if (ownerAfterPatch === null && patch.isPrivate === undefined) {
-							sets.push(sql`is_private = false`)
-						}
 						if (patch.active !== undefined)
 							sets.push(sql`active = ${patch.active}`)
 						if (patch.imapHost !== undefined)
@@ -2258,8 +2262,19 @@ export class EmailService extends Context.Service<EmailService>()(
 							sets.push(sql`password_tag = ${encrypted.tag}`)
 						}
 
+						// A handover writes on its own, so a patch that only changed
+						// hands has nothing left to write — but the row it started from
+						// is now out of date, and reading it back is what the caller
+						// gets to see.
 						if (sets.length === 0) {
-							return yield* decodeInbox(existing).pipe(Effect.orDie)
+							if (!handingOver) {
+								return yield* decodeInbox(existing).pipe(Effect.orDie)
+							}
+							const handed = yield* resolveInboxToLookAfter(id)
+							if (!handed) {
+								return yield* new NotFound({ entity: 'Inbox', id })
+							}
+							return yield* decodeInbox(handed).pipe(Effect.orDie)
 						}
 
 						// A credential or transport change is re-probed after the


### PR DESCRIPTION
## What

A mailbox belongs to one person, or to the whole team when nobody owns it, and that single fact decides who may read it, change it, and send from it. Until now nothing below the application was enforcing it. The database asked only that a mailbox stay inside the organization, and the role a request runs as could write every column — so at the database level any member could put their own name on a colleague's mailbox, and a mailbox carries the stored password for somebody's real email account.

Lives in `apps/server` — the email service, shared by the web API and the MCP tools.

## Changes

- **Ownership left the reach of an ordinary request.** The grant that let a request write any column of a mailbox is replaced by one naming the columns it legitimately writes; who owns the mailbox and which organization it belongs to are not among them.
- **Handing a mailbox over moved into a routine that re-checks the rules itself** — the caller runs the organization, the receiver is really a member of it — mirroring the one instruction templates have used since `0014`. It settles what a handover implies in the same statement, because the database refuses the in-between states: the sending mark comes off, and a mailbox given to the team stops being hidden from them.
- **The authorization tests run the way a request does**, inside the organization's own database scope and as the role a request uses.

## Impact

- **Migration `0054` must run before the server tag.** The deploy does not run migrations, and the new code calls a routine the migration creates.
- **No API or wire-shape change.** Handing a mailbox over behaves exactly as before from the outside — same endpoint, same MCP tool, same payload, same response.
- **No new environment variables, no CORS or cross-app coupling.**
- The mail worker and the health probe are untouched: they run as the connection owner or `app_service`, not as a request, so the narrowed grant does not apply to them.

## Review guide

Start with the migration's own comment — it carries the reasoning, and the rest follows from it.

The part worth a careful look is the ownership branch in `updateInbox`. Ownership is no longer written with the rest of the patch, so a patch that *only* changes hands now has nothing left to write and has to read the row back instead; that path is easy to get wrong and returns stale data if you do. I drove it against a running server rather than trusting it.

One decision you might overrule: **the routine reads who is acting from the connection's organization scope rather than from its arguments**, so a caller cannot claim to be somebody else. It matches `0014`, and it means the routine depends on middleware having established that scope — true on every real request. It is also what forced the test change below.

**The test harness change is larger than the diff suggests, and it is in a file this PR otherwise only adds to.** Those tests were stubbing the session and never establishing database scope, so nothing beneath the service took part. Wiring them through `enterOrgScope` makes them faithful — and is how I found that one pre-existing test had been passing under conditions production never has. If you would rather that landed separately, say so and I will split it.

## Tests

- **Integration, at the database** — a member writing their own name onto a colleague's mailbox under the role a request runs as is refused, and the row is unchanged. This one talks to Postgres directly on purpose: it is the layer being added, so testing it through the service would prove nothing.
- **Integration, through the service** — an admin still hands a mailbox to a colleague and to the whole team, and giving it to the team stops it being hidden from them.

## Verification

`check-types`, `test` and `build` pass. The pre-push gate ran the whole server integration suite: **502 tests across 76 files**, plus the internal unit tests and the end-to-end smoke run.

Beyond that, driven by hand against a running server with a real seeded organization:

- A member writing the owner column directly in SQL is refused; before this it reported `UPDATE 1`.
- A member calling the handover routine is told only an admin may do it.
- An admin hands a mailbox to a member, and gives one to the whole team, both through the real API — including a single call that changes hands and renames at once.
- A handover naming somebody outside the organization is refused.
- A member claiming a colleague's mailbox through the API still answers `404`, exactly as before.
- Nine mail end-to-end tests (listing, send, reply) pass against the running stack.

Closes #386
