### PR TITLE
feat(server): name a company's addresses and let a branch hold its own

### DIFF
--- a/apps/internal/src/components/companies/company-channels-section.tsx
+++ b/apps/internal/src/components/companies/company-channels-section.tsx
@@ -1,0 +1,164 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { ChevronRight, ExternalLink, Link2, Send } from 'lucide-react'
+import styled from 'styled-components'
+
+import { PriCollapsible } from '@batuda/ui/pri'
+
+import { CHANNEL_ICON } from '#/components/contacts/channel-icons'
+import {
+	channelHref,
+	type DisplayChannel,
+} from '#/components/contacts/display-channels'
+import { agedPaperSurface, stenciledTitle } from '#/lib/workshop-mixins'
+
+type Props = {
+	readonly channels: ReadonlyArray<DisplayChannel>
+	/** Opens a new message to this address. Only offered for mailboxes. */
+	readonly onEmail: (address: string) => void
+}
+
+/**
+ * Every way of reaching the company, not just the first of each kind.
+ *
+ * The header row above shows one mailbox, one number and one handle — right for
+ * a quick action, but it makes a firm with an orders mailbox, an accounts
+ * mailbox and a switchboard look like a firm with one of each. Everything is
+ * listed here under the name somebody gave it, so "orders" and "accounts" can be
+ * told apart before one of them is written to.
+ */
+export function CompanyChannelsSection({ channels, onEmail }: Props) {
+	const { t } = useLingui()
+	if (channels.length === 0) return null
+
+	return (
+		<PriCollapsible.Root defaultOpen>
+			<TriggerWrap>
+				<Trigger data-testid='company-channels-trigger'>
+					<ChevronRight size={14} aria-hidden />
+					<Link2 size={14} aria-hidden />
+					<Trans>Ways to reach</Trans>
+					<Count>{channels.length}</Count>
+				</Trigger>
+			</TriggerWrap>
+			<PriCollapsible.Panel>
+				<Body data-testid='company-channels-panel'>
+					{channels.map(ch => {
+						const Icon = CHANNEL_ICON[ch.kind] ?? Link2
+						const { href, external } = channelHref(ch.kind, ch.value)
+						return (
+							<Row key={ch.id}>
+								<Icon size={14} aria-hidden />
+								<Address
+									href={href}
+									{...(external
+										? { target: '_blank', rel: 'noopener noreferrer' }
+										: {})}
+								>
+									{ch.value}
+									{external && <ExternalLink size={11} aria-hidden />}
+								</Address>
+								{ch.label ? <Label>{ch.label}</Label> : null}
+								{ch.isPrimary ? (
+									<Primary>
+										<Trans>primary</Trans>
+									</Primary>
+								) : null}
+								{ch.kind === 'email' ? (
+									<Compose
+										type='button'
+										aria-label={t`Write to ${ch.value}`}
+										onClick={() => onEmail(ch.value)}
+									>
+										<Send size={13} aria-hidden />
+									</Compose>
+								) : null}
+							</Row>
+						)
+					})}
+				</Body>
+			</PriCollapsible.Panel>
+		</PriCollapsible.Root>
+	)
+}
+
+const TriggerWrap = styled.div`
+	display: flex;
+	justify-content: flex-start;
+`
+
+const Trigger = styled(PriCollapsible.Trigger)`
+	& > svg:first-child {
+		transition: transform 200ms ease;
+	}
+
+	&[data-open] > svg:first-child,
+	&[aria-expanded='true'] > svg:first-child {
+		transform: rotate(90deg);
+	}
+`
+
+const Count = styled.span`
+	${stenciledTitle}
+	padding: 0 var(--space-2xs);
+	border: 1px solid currentColor;
+	border-radius: var(--radius-xs);
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const Body = styled.div`
+	${agedPaperSurface}
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+	padding: var(--space-md);
+	margin-top: var(--space-sm);
+`
+
+// The chips after the address wrap onto their own line in a narrow column
+// rather than squeezing it — an address broken mid-word is harder to read than
+// one that takes two lines.
+const Row = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--space-2xs);
+	color: var(--color-on-surface-variant);
+`
+
+const Address = styled.a`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	color: var(--color-on-surface);
+	font-size: var(--typescale-body-small-size);
+	overflow-wrap: break-word;
+`
+
+const Label = styled.span`
+	padding: 0 var(--space-2xs);
+	border-radius: var(--radius-xs);
+	background: var(--color-surface-container-high);
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-label-small-size);
+`
+
+const Primary = styled.span`
+	${stenciledTitle}
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-on-surface-variant);
+`
+
+const Compose = styled.button`
+	display: inline-flex;
+	align-items: center;
+	padding: var(--space-2xs);
+	border: none;
+	background: none;
+	color: var(--color-on-surface-variant);
+	cursor: pointer;
+
+	&:hover {
+		color: var(--color-on-surface);
+	}
+`

--- a/apps/internal/src/components/companies/company-channels-section.tsx
+++ b/apps/internal/src/components/companies/company-channels-section.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { PriCollapsible } from '@batuda/ui/pri'
 
 import { CHANNEL_ICON } from '#/components/contacts/channel-icons'
+import { useChannelKindLabel } from '#/components/contacts/channel-kind-label'
 import {
 	channelHref,
 	type DisplayChannel,
@@ -28,6 +29,7 @@ type Props = {
  */
 export function CompanyChannelsSection({ channels, onEmail }: Props) {
 	const { t } = useLingui()
+	const kindLabel = useChannelKindLabel()
 	if (channels.length === 0) return null
 
 	return (
@@ -45,11 +47,25 @@ export function CompanyChannelsSection({ channels, onEmail }: Props) {
 					{channels.map(ch => {
 						const Icon = CHANNEL_ICON[ch.kind] ?? Link2
 						const { href, external } = channelHref(ch.kind, ch.value)
+						// Everything sitting beside the address is said in the link's own
+						// name too. On screen they are read together; to somebody moving
+						// link by link they would otherwise be lost — and which kind an
+						// address belongs to is carried only by a drawing that three
+						// platforms share.
+						const spoken = [
+							`${kindLabel(ch.kind)}: ${ch.value}`,
+							ch.label,
+							ch.isPrimary ? t`default` : null,
+							external ? t`opens in a new tab` : null,
+						]
+							.filter(Boolean)
+							.join(', ')
 						return (
 							<Row key={ch.id}>
 								<Icon size={14} aria-hidden />
 								<Address
 									href={href}
+									aria-label={spoken}
 									{...(external
 										? { target: '_blank', rel: 'noopener noreferrer' }
 										: {})}
@@ -57,9 +73,11 @@ export function CompanyChannelsSection({ channels, onEmail }: Props) {
 									{ch.value}
 									{external && <ExternalLink size={11} aria-hidden />}
 								</Address>
-								{ch.label ? <Label>{ch.label}</Label> : null}
+								{/* Hidden from a reader who hears the page, because the link
+								 * above already says both. */}
+								{ch.label ? <Label aria-hidden>{ch.label}</Label> : null}
 								{ch.isPrimary ? (
-									<Primary>
+									<Primary aria-hidden>
 										<Trans>primary</Trans>
 									</Primary>
 								) : null}
@@ -106,19 +124,20 @@ const Count = styled.span`
 	color: var(--color-on-surface-variant);
 `
 
-const Body = styled.div`
+const Body = styled.ul`
 	${agedPaperSurface}
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-xs);
 	padding: var(--space-md);
 	margin-top: var(--space-sm);
+	list-style: none;
 `
 
 // The chips after the address wrap onto their own line in a narrow column
 // rather than squeezing it — an address broken mid-word is harder to read than
 // one that takes two lines.
-const Row = styled.div`
+const Row = styled.li`
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
@@ -130,9 +149,19 @@ const Address = styled.a`
 	display: inline-flex;
 	align-items: center;
 	gap: var(--space-2xs);
+	border-bottom: 1px dashed var(--color-outline-variant);
 	color: var(--color-on-surface);
 	font-size: var(--typescale-body-small-size);
 	overflow-wrap: break-word;
+
+	&:hover {
+		border-bottom-color: var(--color-on-surface);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
 `
 
 const Label = styled.span`
@@ -160,5 +189,10 @@ const Compose = styled.button`
 
 	&:hover {
 		color: var(--color-on-surface);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
 	}
 `

--- a/apps/internal/src/components/contacts/channel-icons.ts
+++ b/apps/internal/src/components/contacts/channel-icons.ts
@@ -1,0 +1,22 @@
+import {
+	AtSign,
+	Briefcase,
+	Globe,
+	Mail,
+	type Mail as MailIcon,
+	MessageCircle,
+	Phone,
+} from 'lucide-react'
+
+// `kind` is open-ended, so a platform nobody has drawn an icon for falls back
+// to a plain link at the call site rather than being hidden.
+export const CHANNEL_ICON: Record<string, typeof MailIcon> = {
+	email: Mail,
+	phone: Phone,
+	whatsapp: MessageCircle,
+	linkedin: Briefcase,
+	x: AtSign,
+	instagram: AtSign,
+	website: Globe,
+	bluesky: AtSign,
+}

--- a/apps/internal/src/components/contacts/channel-kind-label.tsx
+++ b/apps/internal/src/components/contacts/channel-kind-label.tsx
@@ -1,0 +1,40 @@
+import { useLingui } from '@lingui/react/macro'
+
+/**
+ * What kind of way of being reached this is, in words.
+ *
+ * The icon beside an address is decoration: three platforms share one drawing,
+ * so it cannot say which of them an address belongs to, and a reader who hears
+ * the page rather than sees it gets nothing from it at all. The words are what
+ * carries the answer, whether they are shown or only announced.
+ *
+ * Read through a hook rather than a constant map so they are translated at
+ * render time, in the reader's language, rather than frozen at module load.
+ */
+export const useChannelKindLabel = (): ((kind: string) => string) => {
+	const { t } = useLingui()
+	return kind => {
+		switch (kind) {
+			case 'email':
+				return t`Email`
+			case 'phone':
+				return t`Phone`
+			case 'whatsapp':
+				return t`WhatsApp`
+			case 'website':
+				return t`Website`
+			case 'linkedin':
+				return t`LinkedIn`
+			case 'instagram':
+				return t`Instagram`
+			case 'x':
+				return t`X`
+			case 'bluesky':
+				return t`Bluesky`
+			// A platform this app has no word for is announced as it was stored,
+			// which is more use than saying nothing.
+			default:
+				return kind
+		}
+	}
+}

--- a/apps/internal/src/components/contacts/display-channels.test.ts
+++ b/apps/internal/src/components/contacts/display-channels.test.ts
@@ -39,6 +39,7 @@ describe('narrowChannels', () => {
 				id: 'x',
 				kind: 'email',
 				value: 'pep@calpepfonda.cat',
+				label: null,
 				verification: 'deliverable',
 				confidence: null,
 				isPrimary: true,
@@ -226,6 +227,38 @@ describe('channelHref', () => {
 				href: 'https://acme.com',
 				external: true,
 			})
+		})
+	})
+})
+
+describe('narrowChannels labels', () => {
+	describe('when a channel carries the name somebody gave it', () => {
+		it('should keep the label so two of a kind can be told apart', () => {
+			// GIVEN two mailboxes of the same kind, each named
+			// WHEN narrowed
+			// THEN each keeps its own label
+			const [orders, accounts] = narrowChannels([
+				channel({ id: '1', value: 'orders@x.cat', label: 'orders' }),
+				channel({ id: '2', value: 'accounts@x.cat', label: 'accounts' }),
+			])
+			expect(orders?.label).toBe('orders')
+			expect(accounts?.label).toBe('accounts')
+		})
+	})
+
+	describe('when nobody named the channel', () => {
+		it('should read a missing, blank or non-string label as none', () => {
+			// GIVEN channels with no label, a whitespace-only one, and a number
+			// WHEN narrowed
+			// THEN all three come back as null rather than an empty chip
+			const [absent, blank, wrongType] = narrowChannels([
+				channel({ id: '1' }),
+				channel({ id: '2', label: '   ' }),
+				channel({ id: '3', label: 7 }),
+			])
+			expect(absent?.label).toBeNull()
+			expect(blank?.label).toBeNull()
+			expect(wrongType?.label).toBeNull()
 		})
 	})
 })

--- a/apps/internal/src/components/contacts/display-channels.ts
+++ b/apps/internal/src/components/contacts/display-channels.ts
@@ -8,6 +8,11 @@ export type DisplayChannel = {
 	readonly id: string
 	readonly kind: string
 	readonly value: string
+	/**
+	 * Which of several this is, in somebody's own words: "orders", "Girona shop".
+	 * Null when nobody said — one mailbox needs no name.
+	 */
+	readonly label: string | null
 	readonly verification: string | null
 	/** Stored 0–100 confidence score, or null. Shown as a trust badge. */
 	readonly confidence: number | null
@@ -35,6 +40,10 @@ export function narrowChannels(raw: unknown): ReadonlyArray<DisplayChannel> {
 			id: r['id'],
 			kind: r['kind'],
 			value: r['value'],
+			label:
+				typeof r['label'] === 'string' && r['label'].trim() !== ''
+					? r['label']
+					: null,
 			verification:
 				typeof r['verification'] === 'string' ? r['verification'] : null,
 			confidence: typeof r['confidence'] === 'number' ? r['confidence'] : null,

--- a/apps/internal/src/components/contacts/manage-channels-dialog.tsx
+++ b/apps/internal/src/components/contacts/manage-channels-dialog.tsx
@@ -150,7 +150,7 @@ export function ManageChannelsDialog({
 									{ch.kind === 'email' && (
 										<IconButton
 											type='button'
-											aria-label={t`Make primary`}
+											aria-label={t`Make ${ch.value} primary`}
 											$active={ch.isPrimary}
 											disabled={ch.isPrimary || busy}
 											onClick={() => handleMakePrimary(ch.id)}
@@ -163,7 +163,7 @@ export function ManageChannelsDialog({
 									)}
 									<IconButton
 										type='button'
-										aria-label={t`Remove channel`}
+										aria-label={t`Remove ${ch.value}`}
 										disabled={busy}
 										onClick={() => handleRemove(ch.id)}
 									>
@@ -268,6 +268,7 @@ const Value = styled.span`
 `
 
 const ChannelLabel = styled.span`
+	display: inline-block;
 	margin-inline-start: var(--space-xs);
 	padding: 0 var(--space-2xs);
 	border-radius: var(--radius-xs);

--- a/apps/internal/src/components/contacts/manage-channels-dialog.tsx
+++ b/apps/internal/src/components/contacts/manage-channels-dialog.tsx
@@ -56,6 +56,7 @@ export function ManageChannelsDialog({
 
 	const [newKind, setNewKind] = useState<string>('email')
 	const [newValue, setNewValue] = useState<string>('')
+	const [newLabel, setNewLabel] = useState<string>('')
 	const [busy, setBusy] = useState(false)
 
 	const failed = () =>
@@ -70,13 +71,17 @@ export function ManageChannelsDialog({
 		const value = newValue.trim()
 		if (!contactId || !value || busy) return
 		setBusy(true)
+		const label = newLabel.trim()
 		const exit = await addChannel({
 			params: { id: contactId },
-			payload: { kind: newKind, value },
+			// An empty label is left out rather than stored blank, so "nobody named
+			// this one" stays distinct from "somebody named it the empty string".
+			payload: { kind: newKind, value, ...(label ? { label } : {}) },
 		} as never)
 		setBusy(false)
 		if (exit._tag === 'Success') {
 			setNewValue('')
+			setNewLabel('')
 			onChanged()
 		} else failed()
 	}
@@ -138,7 +143,10 @@ export function ManageChannelsDialog({
 							{channels.map(ch => (
 								<ChannelRow key={ch.id}>
 									<Kind>{ch.kind}</Kind>
-									<Value>{ch.value}</Value>
+									<Value>
+										{ch.value}
+										{ch.label ? <ChannelLabel>{ch.label}</ChannelLabel> : null}
+									</Value>
 									{ch.kind === 'email' && (
 										<IconButton
 											type='button'
@@ -183,6 +191,12 @@ export function ManageChannelsDialog({
 							placeholder={t`name@company.com`}
 							value={newValue}
 							onChange={e => setNewValue(e.target.value)}
+						/>
+						<PriInput
+							aria-label={t`Channel label`}
+							placeholder={t`orders, Girona shop…`}
+							value={newLabel}
+							onChange={e => setNewLabel(e.target.value)}
 						/>
 						<PriButton type='submit' disabled={busy || newValue.trim() === ''}>
 							<Trans>Add</Trans>
@@ -253,6 +267,15 @@ const Value = styled.span`
 	overflow-wrap: anywhere;
 `
 
+const ChannelLabel = styled.span`
+	margin-inline-start: var(--space-xs);
+	padding: 0 var(--space-2xs);
+	border-radius: var(--radius-xs);
+	background: var(--color-surface-container-high);
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-label-small-size);
+`
+
 const IconButton = styled.button<{ $active?: boolean }>`
 	display: inline-flex;
 	padding: var(--space-2xs);
@@ -270,6 +293,7 @@ const IconButton = styled.button<{ $active?: boolean }>`
 
 const AddForm = styled.form`
 	display: flex;
+	flex-wrap: wrap;
 	gap: var(--space-xs);
 	align-items: center;
 `

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -946,6 +946,10 @@ msgid "Channel kind"
 msgstr "Tipus de canal"
 
 #: src/components/contacts/manage-channels-dialog.tsx
+msgid "Channel label"
+msgstr "Etiqueta del canal"
+
+#: src/components/contacts/manage-channels-dialog.tsx
 msgid "Channel value"
 msgstr "Valor del canal"
 
@@ -3761,6 +3765,10 @@ msgstr "Resum lliure. Tria-ho quan la pregunta no encaixa en una forma fixa — 
 msgid "Opened"
 msgstr "Obert"
 
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "orders, Girona shop…"
+msgstr "comandes, botiga de Girona…"
+
 #: src/components/instructions/stack-picker.tsx
 #: src/components/instructions/template-library.tsx
 msgid "Org"
@@ -4083,6 +4091,10 @@ msgstr "Anterior"
 #: src/components/companies/proposals-panel.tsx
 msgid "Price"
 msgstr "Preu"
+
+#: src/components/companies/company-channels-section.tsx
+msgid "primary"
+msgstr "principal"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -5792,6 +5804,10 @@ msgstr "Visita"
 msgid "Visit notes"
 msgstr "Notes de visita"
 
+#: src/components/companies/company-channels-section.tsx
+msgid "Ways to reach"
+msgstr "Com contactar"
+
 #: src/routes/login.tsx
 msgid "We couldn't sign you in via that link. Try again."
 msgstr "No s'ha pogut iniciar sessió amb aquest enllaç. Torna-ho a provar."
@@ -5910,6 +5926,11 @@ msgstr "passaria a ser"
 #: src/routes/emails/inboxes.tsx
 msgid "Write footer…"
 msgstr "Escriu el peu de pàgina…"
+
+#. placeholder {0}: ch.value
+#: src/components/companies/company-channels-section.tsx
+msgid "Write to {0}"
+msgstr "Escriu a {0}"
 
 #: src/components/emails/compose-form.tsx
 msgid "Write your message…"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -774,6 +774,10 @@ msgstr "Bloquejat"
 msgid "Blocked by the provider. The body is shown for review only."
 msgstr "Bloquejat pel proveïdor. El cos es mostra només per revisar-lo."
 
+#: src/components/contacts/channel-kind-label.tsx
+msgid "Bluesky"
+msgstr "Bluesky"
+
 #: src/components/companies/companies-header.tsx
 msgid "Board"
 msgstr "Tauler"
@@ -1790,6 +1794,10 @@ msgstr "Rebutja"
 msgid "declined"
 msgstr "ha declinat"
 
+#: src/components/companies/company-channels-section.tsx
+msgid "default"
+msgstr "predeterminat"
+
 #: src/components/instructions/stack-list.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Default"
@@ -2108,6 +2116,7 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/companies/conversations-tab.tsx
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/instructions/agent-selector.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
@@ -2611,6 +2620,7 @@ msgstr "Infomaniak necessita una contrasenya d'aplicació de Mail creada al teu 
 msgid "Infomaniak needs a Mail app password created in your Mail service — not an account application password."
 msgstr "Infomaniak necessita una contrasenya d'aplicació de Mail creada al teu servei Mail, no una contrasenya d'aplicació del compte."
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "Instagram"
 msgstr "Instagram"
@@ -2781,6 +2791,7 @@ msgstr "Clar"
 msgid "Line items"
 msgstr "Línies"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
 #: src/components/research/run-labels.ts
 #: src/components/shared/channel-icon.tsx
@@ -2918,6 +2929,11 @@ msgstr "Baixa"
 msgid "Low priority"
 msgstr "Prioritat baixa"
 
+#. placeholder {0}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Make {0} primary"
+msgstr "Fes {0} principal"
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Make {0} the address you send from"
@@ -2929,8 +2945,8 @@ msgid "Make {0} the default"
 msgstr "Fes que {0} sigui la predeterminada"
 
 #: src/components/contacts/manage-channels-dialog.tsx
-msgid "Make primary"
-msgstr "Fes-lo principal"
+#~ msgid "Make primary"
+#~ msgstr "Fes-lo principal"
 
 #: src/components/instructions/stack-editor.tsx
 msgid "Make this my default"
@@ -3765,6 +3781,10 @@ msgstr "Resum lliure. Tria-ho quan la pregunta no encaixa en una forma fixa — 
 msgid "Opened"
 msgstr "Obert"
 
+#: src/components/companies/company-channels-section.tsx
+msgid "opens in a new tab"
+msgstr "s'obre en una pestanya nova"
+
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "orders, Girona shop…"
 msgstr "comandes, botiga de Girona…"
@@ -4010,6 +4030,7 @@ msgstr "Persona"
 msgid "Personal"
 msgstr "Personal"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
 #: src/components/research/run-labels.ts
@@ -4359,7 +4380,9 @@ msgid "Remove \"{0}\" from the stacks that use it first, then delete it."
 msgstr "Treu «{0}» de les piles que la fan servir abans d'eliminar-la."
 
 #. placeholder {0}: att.filename
+#. placeholder {0}: ch.value
 #. placeholder {0}: o.name
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/emails/attachment-picker.tsx
 #: src/components/instructions/stack-picker.tsx
 msgid "Remove {0}"
@@ -4374,8 +4397,8 @@ msgid "Remove {email} from this organization?"
 msgstr "Vols eliminar {email} d'aquesta organització?"
 
 #: src/components/contacts/manage-channels-dialog.tsx
-msgid "Remove channel"
-msgstr "Elimina el canal"
+#~ msgid "Remove channel"
+#~ msgstr "Elimina el canal"
 
 #: src/components/companies/proposals-panel.tsx
 msgid "Remove line"
@@ -5829,6 +5852,7 @@ msgstr "Encaix feble"
 msgid "Weaknesses"
 msgstr "Punts febles"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/run-labels.ts
 msgid "Website"
 msgstr "Lloc web"
@@ -5879,6 +5903,7 @@ msgstr "Sobre què fer seguiment"
 msgid "What's this mailbox for?"
 msgstr "Per a què serveix aquesta bústia?"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "WhatsApp"
 msgstr "WhatsApp"
@@ -5951,6 +5976,10 @@ msgstr "Escrit per la recerca. Si l'edites, passa a ser teu."
 #: src/components/research/target-correction.tsx
 msgid "Wrong company? Enter its official website"
 msgstr "Empresa equivocada? Introdueix el seu lloc web oficial"
+
+#: src/components/contacts/channel-kind-label.tsx
+msgid "X"
+msgstr "X"
 
 #: src/routes/settings/profile/index.tsx
 msgid "You currently sign in from email links. Add a password to skip checking your email next time."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -946,6 +946,10 @@ msgid "Channel kind"
 msgstr "Channel kind"
 
 #: src/components/contacts/manage-channels-dialog.tsx
+msgid "Channel label"
+msgstr "Channel label"
+
+#: src/components/contacts/manage-channels-dialog.tsx
 msgid "Channel value"
 msgstr "Channel value"
 
@@ -3761,6 +3765,10 @@ msgstr "Open-ended brief. Pick when the question does not fit a fixed shape — 
 msgid "Opened"
 msgstr "Opened"
 
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "orders, Girona shop…"
+msgstr "orders, Girona shop…"
+
 #: src/components/instructions/stack-picker.tsx
 #: src/components/instructions/template-library.tsx
 msgid "Org"
@@ -4083,6 +4091,10 @@ msgstr "Previous"
 #: src/components/companies/proposals-panel.tsx
 msgid "Price"
 msgstr "Price"
+
+#: src/components/companies/company-channels-section.tsx
+msgid "primary"
+msgstr "primary"
 
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -5792,6 +5804,10 @@ msgstr "Visit"
 msgid "Visit notes"
 msgstr "Visit notes"
 
+#: src/components/companies/company-channels-section.tsx
+msgid "Ways to reach"
+msgstr "Ways to reach"
+
 #: src/routes/login.tsx
 msgid "We couldn't sign you in via that link. Try again."
 msgstr "We couldn't sign you in via that link. Try again."
@@ -5910,6 +5926,11 @@ msgstr "would become"
 #: src/routes/emails/inboxes.tsx
 msgid "Write footer…"
 msgstr "Write footer…"
+
+#. placeholder {0}: ch.value
+#: src/components/companies/company-channels-section.tsx
+msgid "Write to {0}"
+msgstr "Write to {0}"
 
 #: src/components/emails/compose-form.tsx
 msgid "Write your message…"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -774,6 +774,10 @@ msgstr "Blocked"
 msgid "Blocked by the provider. The body is shown for review only."
 msgstr "Blocked by the provider. The body is shown for review only."
 
+#: src/components/contacts/channel-kind-label.tsx
+msgid "Bluesky"
+msgstr "Bluesky"
+
 #: src/components/companies/companies-header.tsx
 msgid "Board"
 msgstr "Board"
@@ -1790,6 +1794,10 @@ msgstr "Decline"
 msgid "declined"
 msgstr "declined"
 
+#: src/components/companies/company-channels-section.tsx
+msgid "default"
+msgstr "default"
+
 #: src/components/instructions/stack-list.tsx
 #: src/routes/emails/inboxes.tsx
 msgid "Default"
@@ -2108,6 +2116,7 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/companies/conversations-tab.tsx
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/instructions/agent-selector.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
@@ -2611,6 +2620,7 @@ msgstr "Infomaniak needs a Mail app password created in your Mail service — no
 msgid "Infomaniak needs a Mail app password created in your Mail service — not an account application password."
 msgstr "Infomaniak needs a Mail app password created in your Mail service — not an account application password."
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "Instagram"
 msgstr "Instagram"
@@ -2781,6 +2791,7 @@ msgstr "Light"
 msgid "Line items"
 msgstr "Line items"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
 #: src/components/research/run-labels.ts
 #: src/components/shared/channel-icon.tsx
@@ -2918,6 +2929,11 @@ msgstr "Low"
 msgid "Low priority"
 msgstr "Low priority"
 
+#. placeholder {0}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Make {0} primary"
+msgstr "Make {0} primary"
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Make {0} the address you send from"
@@ -2929,8 +2945,8 @@ msgid "Make {0} the default"
 msgstr "Make {0} the default"
 
 #: src/components/contacts/manage-channels-dialog.tsx
-msgid "Make primary"
-msgstr "Make primary"
+#~ msgid "Make primary"
+#~ msgstr "Make primary"
 
 #: src/components/instructions/stack-editor.tsx
 msgid "Make this my default"
@@ -3765,6 +3781,10 @@ msgstr "Open-ended brief. Pick when the question does not fit a fixed shape — 
 msgid "Opened"
 msgstr "Opened"
 
+#: src/components/companies/company-channels-section.tsx
+msgid "opens in a new tab"
+msgstr "opens in a new tab"
+
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "orders, Girona shop…"
 msgstr "orders, Girona shop…"
@@ -4010,6 +4030,7 @@ msgstr "Person"
 msgid "Personal"
 msgstr "Personal"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/findings/contact-discovery-view.tsx
 #: src/components/research/run-labels.ts
@@ -4359,7 +4380,9 @@ msgid "Remove \"{0}\" from the stacks that use it first, then delete it."
 msgstr "Remove \"{0}\" from the stacks that use it first, then delete it."
 
 #. placeholder {0}: att.filename
+#. placeholder {0}: ch.value
 #. placeholder {0}: o.name
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/emails/attachment-picker.tsx
 #: src/components/instructions/stack-picker.tsx
 msgid "Remove {0}"
@@ -4374,8 +4397,8 @@ msgid "Remove {email} from this organization?"
 msgstr "Remove {email} from this organization?"
 
 #: src/components/contacts/manage-channels-dialog.tsx
-msgid "Remove channel"
-msgstr "Remove channel"
+#~ msgid "Remove channel"
+#~ msgstr "Remove channel"
 
 #: src/components/companies/proposals-panel.tsx
 msgid "Remove line"
@@ -5829,6 +5852,7 @@ msgstr "Weak fit"
 msgid "Weaknesses"
 msgstr "Weaknesses"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/run-labels.ts
 msgid "Website"
 msgstr "Website"
@@ -5879,6 +5903,7 @@ msgstr "What to follow up on"
 msgid "What's this mailbox for?"
 msgstr "What's this mailbox for?"
 
+#: src/components/contacts/channel-kind-label.tsx
 #: src/components/shared/channel-icon.tsx
 msgid "WhatsApp"
 msgstr "WhatsApp"
@@ -5951,6 +5976,10 @@ msgstr "Written by research. Editing it makes it yours."
 #: src/components/research/target-correction.tsx
 msgid "Wrong company? Enter its official website"
 msgstr "Wrong company? Enter its official website"
+
+#: src/components/contacts/channel-kind-label.tsx
+msgid "X"
+msgstr "X"
 
 #: src/routes/settings/profile/index.tsx
 msgid "You currently sign in from email links. Add a password to skip checking your email next time."

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -12,7 +12,6 @@ import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import {
 	AlertTriangle,
-	AtSign,
 	BadgeCheck,
 	Briefcase,
 	CalendarClock,
@@ -27,7 +26,6 @@ import {
 	Mail,
 	MailPlus,
 	MapPin,
-	MessageCircle,
 	Pencil,
 	Phone,
 	Plus,
@@ -64,6 +62,7 @@ import { researchListAtom } from '#/atoms/research-atoms'
 import { AboutSection } from '#/components/companies/about-section'
 import { AccountBriefSection } from '#/components/companies/account-brief-section'
 import { CadenceCard } from '#/components/companies/cadence-card'
+import { CompanyChannelsSection } from '#/components/companies/company-channels-section'
 import {
 	CompanyFitSection,
 	type FieldSource,
@@ -91,6 +90,7 @@ import { ResearchSummaryCard } from '#/components/companies/research-summary-car
 import { UpcomingMeetingsCard } from '#/components/companies/upcoming-meetings-card'
 import { WherePanel } from '#/components/companies/where-panel'
 import { useBuyingRoleLabel } from '#/components/contacts/buying-role-label'
+import { CHANNEL_ICON } from '#/components/contacts/channel-icons'
 import {
 	ContactEditDialog,
 	type EditableContact,
@@ -169,6 +169,7 @@ type CompanyDetail = {
 	readonly location: string | null
 	readonly source: string | null
 	readonly priority: number | null
+	readonly channels: ReadonlyArray<DisplayChannel>
 	readonly website: string | null
 	readonly email: string | null
 	readonly phone: string | null
@@ -1319,6 +1320,16 @@ function DetailBody({
 											onRunNew={() => openDlg({ kind: 'research' })}
 										/>
 									)}
+									<CompanyChannelsSection
+										channels={company.channels}
+										onEmail={address =>
+											openCompose({
+												mode: 'new',
+												companyId: company.id,
+												to: address,
+											})
+										}
+									/>
 									<WherePanel company={company} compact />
 									<AccountBriefSection
 										company={company}
@@ -1473,6 +1484,9 @@ function DetailBody({
 																<ExternalLink size={12} aria-hidden />
 															)}
 														</ContactLink>
+														{ch.label ? (
+															<ChannelLabel>{ch.label}</ChannelLabel>
+														) : null}
 														{hasTrust ? (
 															<TrustBadge
 																verification={ch.verification}
@@ -1772,6 +1786,9 @@ function narrowCompany(raw: unknown): CompanyDetail | null {
 		location: str('location'),
 		source: str('source'),
 		priority: num('priority'),
+		// The fields below hold one of each kind; keeping the whole list is the
+		// only way a second mailbox is ever seen.
+		channels: narrowChannels(r['channels']),
 		website: channel('website'),
 		email: channel('email'),
 		phone: channel('phone'),
@@ -1922,16 +1939,14 @@ function narrowContactProvenance(
 	return out
 }
 
-const CHANNEL_ICON: Record<string, typeof Mail> = {
-	email: Mail,
-	phone: Phone,
-	whatsapp: MessageCircle,
-	linkedin: Briefcase,
-	x: AtSign,
-	instagram: AtSign,
-	website: Globe,
-	bluesky: AtSign,
-}
+const ChannelLabel = styled.span`
+	padding: 0 var(--space-2xs);
+	border-radius: var(--radius-xs);
+	background: var(--color-surface-container-high);
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-label-small-size);
+	white-space: nowrap;
+`
 
 const textOrNull = (value: unknown): string | null =>
 	typeof value === 'string' && value.trim().length > 0 ? value : null

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -1940,6 +1940,7 @@ function narrowContactProvenance(
 }
 
 const ChannelLabel = styled.span`
+	display: inline-block;
 	padding: 0 var(--space-2xs);
 	border-radius: var(--radius-xs);
 	background: var(--color-surface-container-high);

--- a/apps/server/src/db/migrations/0055_sites_own_channels_and_people.ts
+++ b/apps/server/src/db/migrations/0055_sites_own_channels_and_people.ts
@@ -1,0 +1,43 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// A branch is somewhere you can reach and somewhere people work, so it holds
+// its own addresses and its own staff. Otherwise a chain with three shops keeps
+// one pile of addresses and one pile of names, with nothing saying which shop
+// any of them belong to.
+//
+// The site on a person is optional and sits beside `company_id` rather than
+// replacing it: most companies have a single place, and somebody who moves
+// between branches belongs to the company rather than to any one of them. When
+// a branch closes they should stay with the company, which is why this is
+// ON DELETE SET NULL rather than a cascade.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	// expand-contract: the wider rule accepts everything the narrower one did plus
+	// one more answer, so an instance still serving through the deploy cannot
+	// write anything it rejects. Widening has to drop and re-state the check —
+	// there is no way to add to one that already exists.
+	yield* sql`
+		ALTER TABLE channels
+			DROP CONSTRAINT IF EXISTS channels_subject_table_check
+	`
+	yield* sql`
+		ALTER TABLE channels
+			ADD CONSTRAINT channels_subject_table_check
+			CHECK (subject_table IN ('companies', 'contacts', 'sites'))
+	`
+
+	yield* sql`
+		ALTER TABLE contacts
+			ADD COLUMN IF NOT EXISTS site_id UUID
+				REFERENCES sites(id) ON DELETE SET NULL
+	`
+	// "Who works at this branch" is the question this answers, so it is the one
+	// worth an index. Partial, because most people name no site at all.
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS contacts_site_idx ON contacts(site_id)
+			WHERE site_id IS NOT NULL
+	`
+})

--- a/apps/server/src/handlers/contacts.ts
+++ b/apps/server/src/handlers/contacts.ts
@@ -23,6 +23,7 @@ import {
 	writeChannels,
 } from '../services/channels'
 import { unlinkSubject } from '../services/documents'
+import { ownedSiteId } from '../services/sites'
 
 const decodeContact = Schema.decodeUnknownEffect(Contact)
 const decodeChannel = Schema.decodeUnknownEffect(ContactChannel)
@@ -104,9 +105,16 @@ export const ContactsLive = HttpApiBuilder.group(
 				.handle('create', _ =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const { channels, ...fields } = _.payload
+						const { channels, siteId, ...fields } = _.payload
+						const ownedSite = yield* ownedSiteId(
+							sql,
+							currentOrg.id,
+							_.payload.companyId,
+							siteId,
+						)
 						const rows = yield* sql`INSERT INTO contacts ${sql.insert({
 							...fields,
+							siteId: ownedSite ?? null,
 							organizationId: currentOrg.id,
 						})} RETURNING *`
 						const contact = rows[0] as { id: string }
@@ -135,9 +143,28 @@ export const ContactsLive = HttpApiBuilder.group(
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const { channels, ...fields } = _.payload
+						const { channels, siteId, ...fields } = _.payload
+						// A branch counts as theirs only if it belongs to the company this
+						// person works for, and only the stored row says which company
+						// that is.
+						const owner = yield* sql`
+							SELECT company_id AS "companyId" FROM contacts
+							WHERE id = ${_.params.id} AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`
+						const companyId = (
+							owner[0] as { readonly companyId: string } | undefined
+						)?.companyId
+						const ownedSite =
+							companyId === undefined
+								? undefined
+								: yield* ownedSiteId(sql, currentOrg.id, companyId, siteId)
+						// Left out when nobody named a branch, so a caller changing only a
+						// phone number does not wipe where that person works.
+						const siteChange =
+							ownedSite === undefined ? {} : { siteId: ownedSite }
 						const rows = yield* sql`
-							UPDATE contacts SET ${sql.update({ ...fields, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
+							UPDATE contacts SET ${sql.update({ ...fields, ...siteChange, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						if (channels && channels.length > 0)

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -5,6 +5,11 @@ import { SqlClient } from 'effect/unstable/sql'
 import { CompanyDetail, CurrentOrg } from '@batuda/controllers'
 import { Company } from '@batuda/domain'
 
+import {
+	addChannel,
+	patchChannel,
+	subjectChannelsOf,
+} from '../../services/channels'
 import { CompanyService } from '../../services/companies'
 import { withBriefOwnership } from '../../services/company-brief'
 import {
@@ -214,6 +219,31 @@ const ManageCompanySites = Tool.make('manage_company_sites', {
 	.annotate(Tool.Destructive, false)
 	.annotate(Tool.OpenWorld, false)
 
+// One tool for the ways of reaching a company, flat `action` for the same reason
+// the sites tool has one. A branch's own phone differs from the company
+// switchboard only by `site_id`, so a second tool would duplicate the lot.
+const ManageCompanyChannels = Tool.make('manage_company_channels', {
+	description:
+		"The ways of reaching a company — its mailboxes, phones, website, social handles. A company can hold several of a kind, which is the point of this tool: `update_company` writes one email and one phone, and a firm with an orders mailbox, an accounts mailbox and a switchboard needs all of them kept apart. Give each one a `label` in the words somebody would actually use — 'orders', 'accounts', 'Girona shop' — because two addresses with no labels are indistinguishable a month later. Pass `site_id` to hang the channel off one branch instead of the company as a whole. action: 'list' (all of them; add site_id to see one branch's), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). kind is open — email, phone, linkedin, instagram, website, x, bluesky, … — and `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to.",
+	parameters: Schema.Struct({
+		action: Schema.Literals(['list', 'add', 'update', 'remove']),
+		company_id: Schema.String,
+		site_id: Schema.optional(Schema.String),
+		channel_id: Schema.optional(Schema.String),
+		kind: Schema.optional(Schema.String),
+		value: Schema.optional(Schema.String),
+		label: Schema.optional(Schema.NullOr(Schema.String)),
+		is_primary: Schema.optional(Schema.Boolean),
+	}),
+	success: Schema.Struct({
+		channels: Schema.Array(Schema.Unknown),
+	}),
+	dependencies: REQUEST_DEPENDENCIES,
+})
+	.annotate(Tool.Title, 'Manage Company Channels')
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
 // One tool for how two companies belong together, with a flat `action` for the
 // same reason the sites tool has one.
 const ManageCompanyRelations = Tool.make('manage_company_relations', {
@@ -245,6 +275,7 @@ export const CompanyTools = Toolkit.make(
 	UpdateCompany,
 	GeocodeCompany,
 	ManageCompanySites,
+	ManageCompanyChannels,
 	ManageCompanyRelations,
 )
 
@@ -390,14 +421,99 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 						`
 					}
 					if (params.action === 'remove' && params.site_id !== undefined) {
-						yield* sql`
+						const removed = yield* sql`
 							DELETE FROM sites
 							WHERE id = ${params.site_id}
 								AND company_id = ${params.company_id}
 								AND organization_id = ${currentOrg.id}
+							RETURNING id
 						`
+						// A channel says what it hangs off by table and id, with no
+						// foreign key to follow, so nothing clears these on its own —
+						// they would sit there for good, pointing at a place that is
+						// closed.
+						if (removed.length > 0) {
+							yield* sql`
+								DELETE FROM channels
+								WHERE subject_table = 'sites'
+									AND subject_id = ${params.site_id}
+									AND organization_id = ${currentOrg.id}
+							`
+						}
 					}
 					return { sites: yield* list() }
+				}).pipe(Effect.orDie),
+			manage_company_channels: params =>
+				Effect.gen(function* () {
+					const currentOrg = yield* CurrentOrg
+					const subject = params.site_id
+						? ({ table: 'sites', id: params.site_id } as const)
+						: ({ table: 'companies', id: params.company_id } as const)
+
+					// An id only proves the row exists, not whose it is, so without this
+					// a channel could be hung off somebody else's company or branch.
+					const owned = params.site_id
+						? yield* sql`
+							SELECT s.id FROM sites s
+							JOIN companies c ON c.id = s.company_id AND c.deleted_at IS NULL
+							WHERE s.id = ${params.site_id}
+								AND s.company_id = ${params.company_id}
+								AND s.organization_id = ${currentOrg.id}
+							LIMIT 1
+						`
+						: yield* sql`
+							SELECT id FROM companies
+							WHERE id = ${params.company_id}
+								AND organization_id = ${currentOrg.id}
+								AND deleted_at IS NULL
+							LIMIT 1
+						`
+					if (owned.length === 0) return { channels: [] }
+
+					if (
+						params.action === 'add' &&
+						params.kind !== undefined &&
+						params.value !== undefined
+					) {
+						yield* addChannel(sql, currentOrg.id, subject, {
+							kind: params.kind,
+							value: params.value,
+							// On a new one there is nothing to take back, so a null name
+							// and no name are the same thing.
+							label: params.label ?? undefined,
+							is_primary: params.is_primary,
+						})
+					}
+					if (params.action === 'update' && params.channel_id !== undefined) {
+						// Scoped to the subject we just proved is theirs, so a channel id
+						// belonging to another company cannot be edited through it.
+						const mine = yield* sql`
+							SELECT id FROM channels
+							WHERE id = ${params.channel_id}
+								AND subject_table = ${subject.table}
+								AND subject_id = ${subject.id}
+								AND organization_id = ${currentOrg.id}
+							LIMIT 1
+						`
+						if (mine.length > 0) {
+							yield* patchChannel(sql, params.channel_id, {
+								kind: params.kind,
+								value: params.value,
+								label: params.label,
+								is_primary: params.is_primary,
+							})
+						}
+					}
+					if (params.action === 'remove' && params.channel_id !== undefined) {
+						yield* sql`
+							DELETE FROM channels
+							WHERE id = ${params.channel_id}
+								AND subject_table = ${subject.table}
+								AND subject_id = ${subject.id}
+								AND organization_id = ${currentOrg.id}
+						`
+					}
+					return { channels: yield* subjectChannelsOf(sql, subject) }
 				}).pipe(Effect.orDie),
 			manage_company_relations: params =>
 				Effect.gen(function* () {

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -16,6 +16,7 @@ import {
 	writeChannels,
 } from '../../services/channels'
 import { unlinkSubject } from '../../services/documents'
+import { ownedSiteId } from '../../services/sites'
 import { McpPageLimit, TruncatableResult, toTruncatable } from './_result'
 
 const decodeContact = Schema.decodeUnknownEffect(Contact)
@@ -26,6 +27,10 @@ const decodeChannels = Schema.decodeUnknownEffect(Schema.Array(ContactChannel))
 const ChannelInput = Schema.Struct({
 	kind: Schema.String,
 	value: Schema.String,
+	label: Schema.optional(Schema.String).annotate({
+		description:
+			'Which of several this is, in the words a person would use: "Girona shop", "sales office", "switchboard". Give it whenever somebody holds more than one of a kind — without it a second address is indistinguishable from the first.',
+	}),
 	verification: Schema.optional(Schema.String),
 	confidence: Schema.optional(Schema.Number),
 	is_primary: Schema.optional(Schema.Boolean),
@@ -50,6 +55,10 @@ const CreateContact = Tool.make('create_contact', {
 		'Create a contact linked to a company. Role examples: CEO, CTO, Marketing Director, Sales Manager. Pass channels[] for every reachable address (kind: email | phone | linkedin | x | website | bluesky | …); the primary email channel is the address used for sending.',
 	parameters: Schema.Struct({
 		company_id: Schema.String,
+		site_id: Schema.optional(Schema.String).annotate({
+			description:
+				'The branch this person works at, when the company has more than one and it is known which. Leave it out for someone who works for the company at large or moves between its branches — most people, and guessing here is worse than saying nothing.',
+		}),
 		name: Schema.String,
 		role: Schema.optional(Schema.String),
 		channels: Schema.optional(Schema.Array(ChannelInput)),
@@ -66,6 +75,10 @@ const UpdateContact = Tool.make('update_contact', {
 		'Update one or more fields on an existing contact by UUID. Only include fields to change. Pass channels[] to add/refresh reachable addresses. Set clear_email_suppression=true to reset the email channel to "unknown" (use after a bounced/complained contact confirms their address is good again — this re-enables outbound mail to that address).',
 	parameters: Schema.Struct({
 		id: Schema.String,
+		site_id: Schema.optional(Schema.NullOr(Schema.String)).annotate({
+			description:
+				'The branch this person works at, when the company has more than one and it is known which. Leave it out for someone who works for the company at large or moves between its branches — most people, and guessing here is worse than saying nothing. Pass null to clear a branch somebody no longer works at; leaving it out changes nothing.',
+		}),
 		name: Schema.optional(Schema.String),
 		role: Schema.optional(Schema.String),
 		channels: Schema.optional(Schema.Array(ChannelInput)),
@@ -130,12 +143,19 @@ export const ContactHandlersLive = ContactTools.toLayer(
 					return toTruncatable(contacts, limit)
 				}).pipe(Effect.orDie),
 
-			create_contact: ({ company_id, channels, ...fields }) =>
+			create_contact: ({ company_id, site_id, channels, ...fields }) =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
+					const siteId = yield* ownedSiteId(
+						sql,
+						currentOrg.id,
+						company_id,
+						site_id,
+					)
 					const rows = yield* sql`INSERT INTO contacts ${sql.insert({
 						organizationId: currentOrg.id,
 						companyId: company_id,
+						siteId: siteId ?? null,
 						...fields,
 					})} RETURNING *`
 					const contact = rows[0] as { id: string }
@@ -156,11 +176,34 @@ export const ContactHandlersLive = ContactTools.toLayer(
 					return { ...decoded, channels: decodedChannels }
 				}).pipe(Effect.orDie),
 
-			update_contact: ({ id, channels, clear_email_suppression, ...fields }) =>
+			update_contact: ({
+				id,
+				site_id,
+				channels,
+				clear_email_suppression,
+				...fields
+			}) =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
+					// A branch counts as theirs only if it belongs to the company this
+					// person works for, and only the stored row says which company that is.
+					const owner = yield* sql`
+						SELECT company_id AS "companyId" FROM contacts
+						WHERE id = ${id} AND organization_id = ${currentOrg.id}
+						LIMIT 1
+					`
+					const companyId = (
+						owner[0] as { readonly companyId: string } | undefined
+					)?.companyId
+					const siteId =
+						companyId === undefined
+							? undefined
+							: yield* ownedSiteId(sql, currentOrg.id, companyId, site_id)
 					const rows = yield* sql`UPDATE contacts SET ${sql.update({
 						...fields,
+						// Only when named: leaving it out means "don't touch", which is
+						// what a caller changing only a phone number expects.
+						...(siteId === undefined ? {} : { siteId }),
 						updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 					})} WHERE id = ${id} RETURNING *`
 					if (clear_email_suppression) yield* clearEmailSuppression(sql, id)

--- a/apps/server/src/services/channel-primary.integration.test.ts
+++ b/apps/server/src/services/channel-primary.integration.test.ts
@@ -1,0 +1,215 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { addChannel, patchChannel, subjectChannelsOf } from './channels'
+
+// Which address a message actually leaves for.
+//
+// A company used to have one mailbox, so "the" address was never in question.
+// With several, `is_primary` is the answer, and two of them for one kind means
+// the answer is whichever the sort surfaces first. Pinned here: marking one
+// stands the others down, and touching an address that is already on file —
+// which is what labelling one does — never moves the default by itself.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+const ORG = `primary-org-${randomUUID()}`
+let company: string
+
+const run = <A>(effect: Effect.Effect<A, unknown, SqlClient.SqlClient>) =>
+	effect.pipe(Effect.provide(PgLive), Effect.runPromise)
+
+const add = (address: string, isPrimary?: boolean, label?: string) =>
+	run(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* addChannel(
+				sql,
+				ORG,
+				{ table: 'companies', id: company },
+				{
+					kind: 'email',
+					value: address,
+					...(label === undefined ? {} : { label }),
+					...(isPrimary === undefined ? {} : { is_primary: isPrimary }),
+				},
+			)
+		}),
+	) as Promise<{ readonly id: string }>
+
+const primaries = async (): Promise<ReadonlyArray<string>> => {
+	const r = await pool.query<{ address: string }>(
+		`SELECT address FROM channels
+		 WHERE subject_table = 'companies' AND subject_id = $1
+		   AND channel = 'email' AND is_primary
+		 ORDER BY address`,
+		[company],
+	)
+	return r.rows.map(row => row.address)
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	const c = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, 'Neteges Pla') RETURNING id`,
+		[ORG, `neteges-pla-${randomUUID()}`],
+	)
+	company = c.rows[0]!.id
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM channels WHERE organization_id = $1`, [ORG])
+	await pool.query(`DELETE FROM companies WHERE organization_id = $1`, [ORG])
+	await pool.end()
+})
+
+describe('the address a company is written to by default', () => {
+	describe('when a second address of the same kind is made the default', () => {
+		it('should leave exactly one, standing the old one down', async () => {
+			// GIVEN one mailbox holding the default
+			await add('comandes@netegespla.cat', true)
+			expect(await primaries()).toEqual(['comandes@netegespla.cat'])
+			// WHEN a second is made the default
+			await add('factures@netegespla.cat', true)
+			// THEN only the second is, so where mail goes is never ambiguous
+			expect(await primaries()).toEqual(['factures@netegespla.cat'])
+		})
+	})
+
+	describe('when an address already on file is given a name', () => {
+		it('should not move the default by itself', async () => {
+			// GIVEN a mailbox that holds the default
+			const before = await primaries()
+			expect(before).toEqual(['factures@netegespla.cat'])
+			// WHEN somebody labels that same address, saying nothing about defaults
+			await add('factures@netegespla.cat', undefined, 'factures')
+			// THEN it still holds it — labelling is not a decision about sending
+			expect(await primaries()).toEqual(['factures@netegespla.cat'])
+			const labelled = await pool.query<{ label: string }>(
+				`SELECT label FROM channels WHERE address = $1 AND subject_id = $2`,
+				['factures@netegespla.cat', company],
+			)
+			expect(labelled.rows[0]?.label).toBe('factures')
+		})
+	})
+
+	describe('when a new address arrives saying nothing about defaults', () => {
+		it('should not become the default and should not disturb the current one', async () => {
+			// GIVEN a company that already has a default mailbox
+			// WHEN an unrelated address is recorded with nothing said
+			await add('rrhh@netegespla.cat')
+			// THEN the standing default is untouched and the newcomer is not one
+			expect(await primaries()).toEqual(['factures@netegespla.cat'])
+		})
+	})
+
+	describe('when the default is handed over by editing a channel', () => {
+		it('should stand the previous one down', async () => {
+			// GIVEN a mailbox that is not the default
+			const rows = await pool.query<{ id: string }>(
+				`SELECT id FROM channels WHERE address = $1 AND subject_id = $2`,
+				['rrhh@netegespla.cat', company],
+			)
+			const id = rows.rows[0]!.id
+			// WHEN it is marked the default
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* patchChannel(sql, id, { is_primary: true })
+				}),
+			)
+			// THEN it is the only one
+			expect(await primaries()).toEqual(['rrhh@netegespla.cat'])
+		})
+	})
+
+	describe('when a different kind is made the default', () => {
+		it('should leave the mailbox default alone', async () => {
+			// GIVEN a company whose default mailbox is settled
+			// WHEN a phone number is made the default phone
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* addChannel(
+						sql,
+						ORG,
+						{ table: 'companies', id: company },
+						{ kind: 'phone', value: '+34 972 100 200', is_primary: true },
+					)
+				}),
+			)
+			// THEN the mailbox default is untouched — each kind has its own
+			expect(await primaries()).toEqual(['rrhh@netegespla.cat'])
+		})
+	})
+})
+
+describe('naming a company mailbox so two can be told apart', () => {
+	describe('when each of two mailboxes is given a name', () => {
+		it('should hand both back under their own names', async () => {
+			// GIVEN two mailboxes of the same kind, each named
+			await add('comptabilitat@netegespla.cat', false, 'comptabilitat')
+			await add('rrhh@netegespla.cat', undefined, 'recursos humans')
+			// WHEN the company's ways of being reached are read
+			const rows = (await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* subjectChannelsOf(sql, {
+						table: 'companies',
+						id: company,
+					})
+				}),
+			)) as ReadonlyArray<{
+				readonly value: string
+				readonly label: string | null
+				readonly subjectTable: string
+			}>
+			// THEN each carries the name somebody gave it
+			const byAddress = new Map(rows.map(r => [r.value, r.label]))
+			expect(byAddress.get('comptabilitat@netegespla.cat')).toBe(
+				'comptabilitat',
+			)
+			expect(byAddress.get('rrhh@netegespla.cat')).toBe('recursos humans')
+			// AND they say plainly what they hang off, rather than posing as a person's
+			expect(rows.every(r => r.subjectTable === 'companies')).toBe(true)
+		})
+	})
+
+	describe('when a name was given by mistake', () => {
+		it('should be able to take it back off', async () => {
+			// GIVEN a mailbox carrying a name
+			const rows = await pool.query<{ id: string }>(
+				`SELECT id FROM channels WHERE address = $1 AND subject_id = $2`,
+				['comptabilitat@netegespla.cat', company],
+			)
+			const id = rows.rows[0]!.id
+			// WHEN the name is cleared
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* patchChannel(sql, id, { label: null })
+				}),
+			)
+			// THEN it carries none, rather than being stuck with the wrong one
+			const after = await pool.query<{ label: string | null }>(
+				`SELECT label FROM channels WHERE id = $1`,
+				[id],
+			)
+			expect(after.rows[0]?.label).toBeNull()
+		})
+	})
+})

--- a/apps/server/src/services/channels.ts
+++ b/apps/server/src/services/channels.ts
@@ -22,7 +22,7 @@ export interface ChannelInput {
 }
 
 /** What a way of reaching someone can hang off. */
-export type ChannelSubject = 'companies' | 'contacts'
+export type ChannelSubject = 'companies' | 'contacts' | 'sites'
 
 // The ways of reaching a company that used to be columns on its row. Callers
 // still name them that way — a company "has a website" reads naturally, and the
@@ -105,13 +105,13 @@ export const writeChannels = (
 				(organization_id, subject_table, subject_id, channel, address, label, verification, confidence, is_primary)
 			VALUES (
 				${orgId}, ${subject.table}, ${subject.id}, ${c.kind}, ${c.value}, ${c.label ?? null},
-				${c.verification ?? null}, ${clampConfidence(c.confidence)}, ${c.is_primary ?? false}
+				${c.verification ?? null}, ${clampConfidence(c.confidence)}, COALESCE(${c.is_primary ?? null}, false)
 			)
 			ON CONFLICT (subject_table, subject_id, channel, address) DO UPDATE SET
 				label = COALESCE(EXCLUDED.label, channels.label),
 				verification = EXCLUDED.verification,
 				confidence = EXCLUDED.confidence,
-				is_primary = EXCLUDED.is_primary,
+				is_primary = COALESCE(${c.is_primary ?? null}, channels.is_primary),
 				updated_at = now()
 		`,
 		{ discard: true },
@@ -151,19 +151,12 @@ export const channelsJsonFor = (sql: Sql, subject: ChannelSubject) =>
 	`
 
 /**
- * The columns a channel row is handed back as, named one by one.
- *
- * Storage keys a channel by its subject and calls its two main columns `channel`
- * and `address`; every caller outside this file — the HTTP API, the web app, the
- * MCP tools — knows them as `contact_id`, `kind` and `value`. Translating in this
- * one place is what let the columns be renamed, and a company's channels be
- * stored beside a person's, without any of them noticing. Moving the outside
- * names is then a separate decision, made on purpose.
+ * Storage calls a channel's two main columns `channel` and `address`, while
+ * everyone reading a channel knows them as `kind` and `value`. Translating in
+ * this one place keeps the storage names free to change on their own.
  */
-const channelRowColumns = (sql: Sql) =>
+const channelColumnsWithoutSubject = (sql: Sql) =>
 	sql`
-		id,
-		subject_id AS contact_id,
 		channel AS kind,
 		address AS value,
 		label, verification, confidence, is_primary,
@@ -171,7 +164,12 @@ const channelRowColumns = (sql: Sql) =>
 		created_at, updated_at
 	`
 
-/** Every channel of one subject, primary first. */
+// A person's channels are handed back keyed `contact_id`: that is the name
+// callers read them by, whatever storage calls the column.
+const channelRowColumns = (sql: Sql) =>
+	sql`id, subject_id AS contact_id, ${channelColumnsWithoutSubject(sql)}`
+
+/** Every channel of one person, primary first. */
 export const channelsOf = (
 	sql: Sql,
 	subject: { readonly table: ChannelSubject; readonly id: string },
@@ -182,6 +180,47 @@ export const channelsOf = (
 		ORDER BY is_primary DESC, channel
 	`
 
+/**
+ * Every channel of a company or one of its branches, primary first.
+ *
+ * Kept apart from `channelsOf` because that one hands the subject back as
+ * `contact_id`, which is a lie for a company: anyone passing that id where a
+ * contact id belongs would be trusting the field name, not misreading it.
+ */
+export const subjectChannelsOf = (
+	sql: Sql,
+	subject: { readonly table: ChannelSubject; readonly id: string },
+) =>
+	sql`
+		SELECT id, subject_table, subject_id, ${channelColumnsWithoutSubject(sql)}
+		FROM channels
+		WHERE subject_table = ${subject.table} AND subject_id = ${subject.id}
+		ORDER BY is_primary DESC, channel
+	`
+
+/**
+ * Stand down whichever address of the same kind was the default before, leaving
+ * the named one as the only one.
+ *
+ * "Primary" is what decides where a message actually goes, so two of them for
+ * one kind is not a cosmetic mess: the address a message leaves for becomes
+ * whichever the sort happens to surface first. That was unaskable while a
+ * company had a single mailbox, and is asked constantly once it has three.
+ *
+ * The old default is read from the newly-marked row itself, so nothing has to be
+ * looked up first and no caller can pass a subject that disagrees with the row.
+ */
+const standDownOtherPrimaries = (sql: Sql, channelId: string) =>
+	sql`
+		UPDATE channels SET is_primary = false, updated_at = now()
+		WHERE id <> ${channelId}
+			AND is_primary
+			AND (subject_table, subject_id, channel) = (
+				SELECT subject_table, subject_id, channel
+				FROM channels WHERE id = ${channelId}
+			)
+	`
+
 /** Add a single channel (the UI's "add"), returning the stored row. */
 export const addChannel = (
 	sql: Sql,
@@ -189,19 +228,30 @@ export const addChannel = (
 	subject: { readonly table: ChannelSubject; readonly id: string },
 	c: ChannelInput,
 ) =>
-	sql`
-		INSERT INTO channels
-			(organization_id, subject_table, subject_id, channel, address, label, verification, confidence, is_primary)
-		VALUES (
-			${orgId}, ${subject.table}, ${subject.id}, ${c.kind}, ${c.value}, ${c.label ?? null},
-			${c.verification ?? null}, ${clampConfidence(c.confidence)}, ${c.is_primary ?? false}
-		)
-		ON CONFLICT (subject_table, subject_id, channel, address) DO UPDATE SET
-			label = COALESCE(EXCLUDED.label, channels.label),
-			is_primary = EXCLUDED.is_primary,
-			updated_at = now()
-		RETURNING ${channelRowColumns(sql)}
-	`.pipe(Effect.map(rows => rows[0]))
+	Effect.gen(function* () {
+		// Saying nothing about the default is not the same as saying "not the
+		// default": naming an address already on file — which is how somebody
+		// labels one — must not quietly move where mail goes.
+		const wantsPrimary = c.is_primary ?? null
+		const rows = yield* sql`
+			INSERT INTO channels
+				(organization_id, subject_table, subject_id, channel, address, label, verification, confidence, is_primary)
+			VALUES (
+				${orgId}, ${subject.table}, ${subject.id}, ${c.kind}, ${c.value}, ${c.label ?? null},
+				${c.verification ?? null}, ${clampConfidence(c.confidence)}, COALESCE(${wantsPrimary}, false)
+			)
+			ON CONFLICT (subject_table, subject_id, channel, address) DO UPDATE SET
+				label = COALESCE(EXCLUDED.label, channels.label),
+				is_primary = COALESCE(${wantsPrimary}, channels.is_primary),
+				updated_at = now()
+			RETURNING ${channelRowColumns(sql)}
+		`
+		const stored = rows[0] as { readonly id: string } | undefined
+		if (c.is_primary === true && stored !== undefined) {
+			yield* standDownOtherPrimaries(sql, stored.id)
+		}
+		return rows[0]
+	})
 
 /**
  * Edit a channel's reachable value / kind / label / primary flag. Never touches
@@ -230,6 +280,9 @@ export const patchChannel = (
 			UPDATE channels SET ${sql.update(data)}
 			WHERE id = ${channelId} RETURNING ${channelRowColumns(sql)}
 		`
+		if (patch.is_primary === true) {
+			yield* standDownOtherPrimaries(sql, channelId)
+		}
 		return rows[0]
 	})
 

--- a/apps/server/src/services/site-channels-and-people.integration.test.ts
+++ b/apps/server/src/services/site-channels-and-people.integration.test.ts
@@ -1,0 +1,163 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// SQL-contract test for a branch holding its own way of being reached and its
+// own people: a channel can hang off a branch, a person can name the branch they
+// work at without leaving the company, and closing a branch keeps its people —
+// still with the company — rather than deleting them.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+const ORG = `site-org-${randomUUID()}`
+let company: string
+let girona: string
+
+const seedSite = async (name: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO sites (organization_id, company_id, name)
+		 VALUES ($1, $2, $3) RETURNING id`,
+		[ORG, company, name],
+	)
+	return r.rows[0]!.id
+}
+
+const seedContact = async (
+	name: string,
+	siteId: string | null,
+): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO contacts (organization_id, company_id, site_id, name)
+		 VALUES ($1, $2, $3, $4) RETURNING id`,
+		[ORG, company, siteId, name],
+	)
+	return r.rows[0]!.id
+}
+
+const addChannel = (
+	subjectTable: string,
+	subjectId: string,
+	address: string,
+	label: string | null,
+) =>
+	pool.query(
+		`INSERT INTO channels
+			(organization_id, subject_table, subject_id, channel, address, label)
+		 VALUES ($1, $2, $3, 'phone', $4, $5)`,
+		[ORG, subjectTable, subjectId, address, label],
+	)
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	const c = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, 'Neteges Pla') RETURNING id`,
+		[ORG, `neteges-pla-${randomUUID()}`],
+	)
+	company = c.rows[0]!.id
+	girona = await seedSite('Botiga de Girona')
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM channels WHERE organization_id = $1`, [ORG])
+	await pool.query(`DELETE FROM companies WHERE organization_id = $1`, [ORG])
+	await pool.end()
+})
+
+describe('a branch holding its own way of being reached', () => {
+	describe('when a phone number is recorded against the branch', () => {
+		it('should store it against the branch rather than the company', async () => {
+			// GIVEN a company and one of its branches
+			// WHEN a number is recorded against the branch
+			await addChannel('sites', girona, '+34 972 100 201', 'taulell')
+			// THEN it belongs to the branch, under the name somebody gave it,
+			// and the company's own list is untouched
+			const branch = await pool.query<{ address: string; label: string }>(
+				`SELECT address, label FROM channels
+				 WHERE subject_table = 'sites' AND subject_id = $1`,
+				[girona],
+			)
+			expect(branch.rows).toHaveLength(1)
+			expect(branch.rows[0]?.address).toBe('+34 972 100 201')
+			expect(branch.rows[0]?.label).toBe('taulell')
+
+			const onCompany = await pool.query(
+				`SELECT 1 FROM channels
+				 WHERE subject_table = 'companies' AND subject_id = $1`,
+				[company],
+			)
+			expect(onCompany.rowCount).toBe(0)
+		})
+	})
+
+	describe('when the subject is a table channels do not belong to', () => {
+		it('should be refused by the database, not by whoever called it', async () => {
+			// GIVEN a way of reaching something that is not a company, person or branch
+			// WHEN it is stored
+			// THEN the database refuses it
+			await expect(
+				addChannel('invoices', randomUUID(), '+34 900 000 000', null),
+			).rejects.toThrow(/channels_subject_table_check/)
+		})
+	})
+})
+
+describe('a person naming the branch they work at', () => {
+	describe('when somebody works at one branch', () => {
+		it('should record the branch beside the company, not instead of it', async () => {
+			// GIVEN a person who works at the Girona branch
+			const laia = await seedContact('Laia Llopis', girona)
+			// WHEN their row is read
+			const r = await pool.query<{ companyId: string; siteId: string }>(
+				`SELECT company_id AS "companyId", site_id AS "siteId"
+				 FROM contacts WHERE id = $1`,
+				[laia],
+			)
+			// THEN they belong to both — the branch says where, the company says whose
+			expect(r.rows[0]?.siteId).toBe(girona)
+			expect(r.rows[0]?.companyId).toBe(company)
+		})
+	})
+
+	describe('when somebody covers the whole company', () => {
+		it('should leave the branch unsaid rather than guessing one', async () => {
+			// GIVEN a person recorded without a branch — the ordinary case
+			const roving = await seedContact('Pere Roving', null)
+			// WHEN their row is read
+			const r = await pool.query<{ siteId: string | null }>(
+				`SELECT site_id AS "siteId" FROM contacts WHERE id = $1`,
+				[roving],
+			)
+			// THEN no branch is claimed for them
+			expect(r.rows[0]?.siteId).toBeNull()
+		})
+	})
+
+	describe('when the branch they worked at closes', () => {
+		it('should keep the person, still with the company', async () => {
+			// GIVEN a branch with somebody working at it
+			const closing = await seedSite('Botiga de Salt')
+			const marc = await seedContact('Marc Serra', closing)
+			// WHEN the branch is removed
+			await pool.query(`DELETE FROM sites WHERE id = $1`, [closing])
+			// THEN the person survives with no branch, rather than being deleted
+			const r = await pool.query<{ siteId: string | null; companyId: string }>(
+				`SELECT site_id AS "siteId", company_id AS "companyId"
+				 FROM contacts WHERE id = $1`,
+				[marc],
+			)
+			expect(r.rowCount).toBe(1)
+			expect(r.rows[0]?.siteId).toBeNull()
+			expect(r.rows[0]?.companyId).toBe(company)
+		})
+	})
+})

--- a/apps/server/src/services/sites.integration.test.ts
+++ b/apps/server/src/services/sites.integration.test.ts
@@ -1,0 +1,133 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { ownedSiteId } from './sites'
+
+// What stops a person being filed under somebody else's shop.
+//
+// The foreign key on `contacts.site_id` says the branch exists; it does not say
+// whose it is, or that it belongs to the company the person works for. That gap
+// is closed in code, so it is worth pinning: a branch from another organisation
+// and a branch of a different company are both dropped, while the person is
+// still recorded — the branch is the guess, not the person.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+const ORG = `owned-site-${randomUUID()}`
+const OTHER_ORG = `other-org-${randomUUID()}`
+let company: string
+let ownSite: string
+let otherCompanySite: string
+let otherOrgSite: string
+
+const seedCompany = async (org: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, 'Company') RETURNING id`,
+		[org, `co-${randomUUID()}`],
+	)
+	return r.rows[0]!.id
+}
+
+const seedSite = async (org: string, companyId: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO sites (organization_id, company_id, name)
+		 VALUES ($1, $2, 'Branch') RETURNING id`,
+		[org, companyId],
+	)
+	return r.rows[0]!.id
+}
+
+// The helper takes a resolved SqlClient, so the test provides the app's own —
+// same name conversion, so a mismatch there would show up here too.
+const check = (siteId: string | null | undefined) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		return yield* ownedSiteId(sql, ORG, company, siteId)
+	}).pipe(Effect.provide(PgLive), Effect.runPromise)
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	company = await seedCompany(ORG)
+	ownSite = await seedSite(ORG, company)
+	const sibling = await seedCompany(ORG)
+	otherCompanySite = await seedSite(ORG, sibling)
+	const foreign = await seedCompany(OTHER_ORG)
+	otherOrgSite = await seedSite(OTHER_ORG, foreign)
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM companies WHERE organization_id = ANY($1)`, [
+		[ORG, OTHER_ORG],
+	])
+	await pool.end()
+})
+
+describe('checking the branch named for a person', () => {
+	describe("when the branch is the company's own", () => {
+		it('should keep it', async () => {
+			// GIVEN a branch of the company this person works for
+			// WHEN it is checked
+			// THEN it is kept as given
+			await expect(check(ownSite)).resolves.toBe(ownSite)
+		})
+	})
+
+	describe('when the branch belongs to another organisation', () => {
+		it('should say nothing rather than file the person under it', async () => {
+			// GIVEN a branch nobody in this organisation can see
+			// WHEN it is checked
+			// THEN it answers "say nothing", so a branch already recorded survives
+			await expect(check(otherOrgSite)).resolves.toBeUndefined()
+		})
+	})
+
+	describe('when the branch belongs to a different company in the same org', () => {
+		it('should say nothing — visible is not the same as theirs', async () => {
+			// GIVEN a branch of a company this person does not work for
+			// WHEN it is checked
+			// THEN it answers "say nothing"
+			await expect(check(otherCompanySite)).resolves.toBeUndefined()
+		})
+	})
+
+	describe('when the branch does not exist at all', () => {
+		it('should say nothing', async () => {
+			// GIVEN an id matching no branch — a typo, or one since closed
+			// WHEN it is checked
+			// THEN it answers "say nothing" rather than clearing a good branch
+			await expect(check(randomUUID())).resolves.toBeUndefined()
+		})
+	})
+
+	describe('when the caller said nothing about a branch', () => {
+		it('should leave the stored value alone', async () => {
+			// GIVEN a caller changing something else entirely
+			// WHEN no branch is named
+			// THEN the answer is "do not touch", which is not the same as clearing it
+			await expect(check(undefined)).resolves.toBeUndefined()
+		})
+	})
+
+	describe('when the caller clears the branch', () => {
+		it('should clear it without a lookup', async () => {
+			// GIVEN somebody who no longer works at any one branch
+			// WHEN null is passed
+			// THEN it clears, rather than being treated as an unknown branch
+			await expect(check(null)).resolves.toBeNull()
+		})
+	})
+})

--- a/apps/server/src/services/sites.ts
+++ b/apps/server/src/services/sites.ts
@@ -1,0 +1,34 @@
+import { Effect } from 'effect'
+import type { SqlClient } from 'effect/unstable/sql'
+
+/**
+ * The branch to store for a person, checked against the company they work for.
+ * A foreign key only says the branch exists, not whose it is, so without this
+ * somebody could be filed under another organisation's shop.
+ *
+ * Two answers, and the difference matters: `undefined` means store nothing and
+ * change nothing, `null` means the caller cleared the branch on purpose, and a
+ * string is one that checked out.
+ *
+ * A branch that fails the check answers `undefined`, not `null` — a typo'd or
+ * stale id must never wipe the branch somebody already recorded. Saying nothing
+ * is the safe reading of a guess, and on a new person it stores nothing anyway.
+ */
+export const ownedSiteId = (
+	sql: SqlClient.SqlClient,
+	orgId: string,
+	companyId: string,
+	siteId: string | null | undefined,
+) =>
+	Effect.gen(function* () {
+		if (siteId === undefined) return undefined
+		if (siteId === null) return null
+		const rows = yield* sql`
+			SELECT id FROM sites
+			WHERE id = ${siteId}
+				AND company_id = ${companyId}
+				AND organization_id = ${orgId}
+			LIMIT 1
+		`
+		return rows.length > 0 ? siteId : undefined
+	})

--- a/packages/controllers/src/routes/contacts.ts
+++ b/packages/controllers/src/routes/contacts.ts
@@ -14,6 +14,7 @@ import { PaginatedList, pageQuery } from '../pagination'
 const ChannelInput = Schema.Struct({
 	kind: Schema.String,
 	value: Schema.String,
+	label: Schema.optional(Schema.String),
 	verification: Schema.optional(Schema.String),
 	confidence: Schema.optional(Schema.Number),
 	is_primary: Schema.optional(Schema.Boolean),
@@ -21,6 +22,8 @@ const ChannelInput = Schema.Struct({
 
 const CreateContactInput = Schema.Struct({
 	companyId: Schema.String,
+	// The branch this person works at, when the company has more than one.
+	siteId: Schema.optional(Schema.String),
 	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 	role: Schema.optional(Schema.String),
 	buyingRole: Schema.optional(Schema.String),
@@ -29,6 +32,7 @@ const CreateContactInput = Schema.Struct({
 })
 
 const UpdateContactInput = Schema.Struct({
+	siteId: Schema.optional(Schema.NullOr(Schema.String)),
 	name: Schema.optional(Schema.String),
 	role: Schema.optional(Schema.String),
 	buyingRole: Schema.optional(Schema.String),
@@ -41,12 +45,18 @@ const UpdateContactInput = Schema.Struct({
 const AddChannelInput = Schema.Struct({
 	kind: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 	value: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+	// Which of several this is, in a person's own words: "Girona shop",
+	// "switchboard". Without it a second mailbox is just another address.
+	label: Schema.optional(Schema.String),
 	is_primary: Schema.optional(Schema.Boolean),
 })
 
 const PatchChannelInput = Schema.Struct({
 	kind: Schema.optional(Schema.String),
 	value: Schema.optional(Schema.String),
+	// Nullable so a name given by mistake can be taken back off; leaving it out
+	// keeps whatever is there.
+	label: Schema.optional(Schema.NullOr(Schema.String)),
 	is_primary: Schema.optional(Schema.Boolean),
 })
 

--- a/packages/domain/src/schema/contacts.ts
+++ b/packages/domain/src/schema/contacts.ts
@@ -8,6 +8,10 @@ export const ContactId = Schema.String.pipe(Schema.brand('ContactId'))
 export class Contact extends Model.Class<Contact>('Contact')({
 	id: Model.GeneratedByDb(ContactId),
 	companyId: Schema.String,
+	// The branch this person works at. Beside `companyId` rather than replacing
+	// it: someone who covers several branches belongs to the company, and that is
+	// most people, so null is an ordinary answer rather than a gap.
+	siteId: Schema.NullOr(Schema.String),
 
 	name: Schema.String,
 	role: Schema.NullOr(Schema.String),

--- a/packages/ui/src/pri/pri-collapsible.tsx
+++ b/packages/ui/src/pri/pri-collapsible.tsx
@@ -50,11 +50,14 @@ const PriTrigger = styled(Collapsible.Trigger).withConfig({
 		box-shadow: var(--glow-active);
 	}
 
-	& svg {
+	/* Only the leading arrow turns. A trigger is free to carry another icon
+	 * alongside its label — one naming the section — and turning that one on
+	 * open leaves it lying on its side. */
+	& > svg:first-child {
 		transition: transform 200ms ease;
 	}
 
-	&[data-panel-open] svg {
+	&[data-panel-open] > svg:first-child {
 		transform: rotate(90deg);
 	}
 `


### PR DESCRIPTION
## What

A company is rarely reachable at one address. A cleaning firm has an orders mailbox, an accounts mailbox and a switchboard; a chain has a phone per shop. Until now the CRM could hold one of each, so the second mailbox either overwrote the first or was never recorded — and once recorded, nothing said which was which.

This finishes issue #376 by making a company's ways of being reached a list rather than a field, each carrying the name somebody actually gave it ("comandes", "factures", "botiga de Girona"), and by making a branch a real place: it holds its own phone and its own staff instead of everything piling up on the parent company. It touches the CRM context across `server` (storage, HTTP, and the MCP tools an AI assistant drives), `internal` (the web app), and `ui`.

Issue #376 was closed once already. Re-reading its acceptance list against what shipped showed three criteria unmet — I reopened it and this PR covers two of them. The third, measuring the change in the research eval, has moved to #389: the golden set has no row that exercises any of this, so running it today would cost real money and report nothing about it.

## Changes

- **A way of being reached carries a name.** Settable from the web app, the HTTP API and the MCP tools, and clearable, so a name given by mistake is not permanent. The storage column existed already; nothing could write it.
- **One default per kind.** Marking an address the default stands the others down. Two defaults for one kind meant the address a message left for was whichever the sort happened to surface first — a question that could not arise while a company had a single mailbox, and one that arises constantly once it has three.
- **Naming an address already on file no longer moves the default.** Recording an address that is already stored is exactly what naming one does, and it was silently flipping the company's primary mailbox.
- **A branch holds its own addresses and its own people.** A person names their branch *beside* their company rather than instead of it, so somebody who covers several branches still belongs to the company, and closing a branch leaves them with it rather than deleting them.
- **A new MCP tool, `manage_company_channels`**, lists, adds, renames and removes a company's addresses — or one branch's. One tool with a flat `action`, matching `manage_company_sites`, because a strict provider rejects the nested shape a union serialises to.
- **The web app shows all of them.** A "Ways to reach" panel on the company overview lists every address under its own name, with a send button per mailbox. The icon row at the top still shows one of each, which is right for a quick action.
- **A shared UI fix:** a collapsible section's trigger turned *every* icon it contained on open, not just the disclosure arrow, so a second icon naming the section ended up on its side. This affected existing sections too.
- **Accessible to somebody who hears the page.** Each address is announced with its kind, the name it was given and whether it is the default one — the kind was carried only by a small drawing that three platforms share, which said nothing to a screen reader and little to anyone else. The addresses are a list rather than a run of loose fragments, and they carry the same dashed underline the rest of the page uses, since colour alone was well under the contrast needed to mark something clickable.

## Impact

- **Migration `0055_sites_own_channels_and_people` must run before the server tag.** The deploy does not run migrations, so new server code on an unmigrated schema crashes on boot. It widens a check constraint and adds a nullable `contacts.site_id` — additive, nothing dropped, no data recreated. It carries the `expand-contract:` marker: it drops and re-states a rule to widen it, and the widened rule accepts everything the old one did, so the instance still running through the deploy cannot write anything the new rule rejects.
  Note this stacks on migrations 0047–0053 from PRs #379 and #383, which are also unreleased.
- **Multi-org isolation.** Every id a caller passes to the new write paths — a company, a branch, a channel — is checked against the caller's organization before anything is written, because an id only proves a row exists, not whose it is. I confirmed against the live stack that an MCP call using one organization's key, naming another organization's company, returns an empty result and writes nothing.
- **Wire shape.** `Contact` gains a required-but-nullable `siteId`, consumed by both the server and the web app's typed client. Every read that decodes a contact selects all its columns, so no explicit column list needed updating — I checked each one. A company's addresses are now returned saying they belong to a company; previously they came back keyed `contactId`, which was true for a person and a lie for a company, and an agent following that field name would have passed a company id where a contact id belongs. The reply for a person is unchanged.
- **MCP and HTTP parity.** Both transports get the name and the branch. The bulk `writeChannels` path shared with the research apply flow gets the same default-handling fix, so re-discovering an address no longer demotes it.
- **No new environment variables**, no auth or route-protection change, no CORS or cross-app coupling, no webhook or paid-provider spend change.

## Review guide

Start with `apps/server/src/services/channels.ts` — it is the riskiest file. `standDownOtherPrimaries` and the two `COALESCE(…)` clauses are what decide where a message actually goes; everything else is plumbing. `apps/server/src/services/sites.ts` is small but worth a careful read: its three-way return is load-bearing, and getting it wrong silently deletes data (see below).

Decisions you might overrule:

- **A branch id that fails the ownership check is ignored rather than refused.** The person is still worth recording; the branch is the guess. Crucially it answers "say nothing" rather than "clear it", so a mistyped or stale id cannot wipe a branch already recorded — an adversarial review of this branch caught that exact data-loss path, where the rejection answer and the deliberate-clear answer were the same value.
- **I fixed the collapsible trigger in `packages/ui` rather than working around it locally.** It changes every foldable section in the app. The intent of the rule was clearly to turn the disclosure arrow, and one existing section (company fit) has the same two-icon shape and the same bug.
- **I did not build a branch UI.** Branches have had no screen since they shipped; the acceptance criterion is about the relationships, and adding a whole surface would be a separate piece of work.
- **`list` on a company that is not yours returns an empty list rather than an error**, matching the sibling tools. It does mean "not yours" and "has none" read the same to an agent.

Skip-able: the two `.po` catalogs are generated by `i18n:extract` apart from five Catalan strings I translated by hand.

I ran an accessibility review over the new components and fixed what it found in the last commit — the two Level A failures were mine (the kind carried only by an `aria-hidden` icon, and the chips floating outside any accessible name). Three things it raised are pre-existing and left alone; they are in **Deferred**.

I did not run Snyk — the tool was not available in this session.

## Screenshots

Captured at both sizes because the panel sits in the overview's right-hand column on desktop and stacks into the single column on mobile.

Desktop — every way of reaching the company, each under its own name, with a send button per mailbox:

![ways-to-reach](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-388/ways-to-reach.webp)

Mobile, the same panel:

![ways-to-reach-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-388/ways-to-reach-mobile.webp)

The People tab — a person's two mailboxes, told apart by name:

![people-labels](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-388/people-labels.webp)

## Tests

Three new integration files, all against a live Postgres:

- `channel-primary.integration.test.ts` — one default per kind; handing the default over stands the previous one down; naming an address already on file does not move it; a new address claims nothing; each kind has its own default; names round-trip and can be cleared.
- `site-channels-and-people.integration.test.ts` — a branch holds its own number; a subject the table does not recognise is refused by the database rather than by whoever called it; a person's branch sits beside their company; closing a branch keeps the person.
- `sites.integration.test.ts` — the ownership check across every case: the company's own branch, another organization's, a sibling company's, one that does not exist, saying nothing, and clearing.

Plus label cases added to the web app's channel-narrowing unit tests, including blank and wrong-typed values.

## Verification

- `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test`, `pnpm -w build` — all green.
- `pnpm turbo run test:integration --concurrency=1` across every package: 79 files, 520 tests passing in `server`, 3 files / 16 tests in `mail-worker`.
- Each of the four commits type-checks on its own, checked by walking the branch commit by commit.
- Live stack, this worktree's own database: added a named address through the web app and confirmed it stored and re-rendered; added one through the real MCP endpoint over a JSON-RPC session and confirmed it appeared in the web app; opened a compose window addressed to the *second* mailbox, which was unreachable before; confirmed a cross-organization write returns empty and stores nothing; confirmed the widened constraint, `contacts.site_id` and its index in the running database.
- Every new user-facing string is wrapped in Lingui macros; `i18n:extract` run, both locales at zero missing.
- Read the rendered accessibility tree in the browser to confirm the fixes landed rather than trusting the code: the panel is a `list`, and each row announces e.g. "Email: comandes@netegespla.cat, comandes, default".

## Deferred

- **The research evaluation** — the third acceptance criterion of #376, now tracked as its own work in #389. The eval code is complete, but not one of the 20 golden rows lacks a website or expects a company mailbox, so a run today would measure none of this. The comparable before/after the criterion asked for is also unrecoverable: the profile-fullness denominator moved from six fields to ten when PR #379 landed, so there is no pre-change run to compare against.
- **Three accessibility findings that predate this branch**: the shared text input names its fields by placeholder only, which disappears on the first keystroke and fails contrast in the light theme (a design-system fix that would touch every input in the app); collapsible section titles are buttons rather than headings, so heading navigation skips them, which is the house pattern across every section; and X, Instagram and Bluesky share one icon, so sighted readers cannot tell them apart either — the spoken name now can, but the drawing still cannot.
- **Deleting a person leaves their addresses behind** — channels carry no foreign key, so nothing removes them, and `delete_contact` claims otherwise. Pre-existing; I fixed the equivalent hole for branches because branch addresses are new here.

Closes #376 — the measurement criterion moved to #389, so merging this finishes the modelling work the issue is about.
