### PR TITLE
fix(internal): show the whole page of mail instead of a few rows

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -127,11 +127,20 @@ last path segment (so `ui/foo` → `foo.batuda.localhost`), so there's no clash
 with the main checkout. See the `/worktree` skill for the full model.
 
 ```bash
-# Provision this worktree: creates its DB + bucket, writes .env, migrates + seeds.
+# 1. Install. In a worktree this MUST be --ignore-scripts: core.hooksPath points at
+# the main checkout, so lefthook's `prepare` step fails and takes the install with it.
+pnpm install --ignore-scripts
+
+# 2. --ignore-scripts leaves workspace dist/ unbuilt, and the server imports
+# @batuda/ui as built output — without this it dies on `Cannot find module
+# '@batuda/ui/dist/blocks/index.mjs'`.
+pnpm --filter @batuda/ui build
+
+# 3. Provision this worktree: creates its DB + bucket, writes .env, migrates + seeds.
 # Auto-runs once on session start (skips once the DB exists); re-running re-seeds.
 pnpm cli worktree up
 
-# Run the stack — portless injects PORT/PORTLESS_URL per service, no clash with main.
+# 4. Run the stack — portless injects PORT/PORTLESS_URL per service, no clash with main.
 pnpm dev
 
 pnpm cli worktree ls        # every worktree + its DB + provisioned state + URL
@@ -178,6 +187,8 @@ Use `agent-browser` (Playwright-based CLI) to test the app as a real user. Ensur
 
 For the full command reference (login flow, navigation, interaction, network inspection), consult `references/agent-browser.md`.
 
+If the session has browser MCP tools (`preview_start`, `read_page`, `form_input`, `javascript_tool`, `resize_window`), they drive the same app and suit some jobs better: `read_page` returns an accessibility tree with stable refs, `resize_window` sweeps viewports, and `javascript_tool` reads computed styles and element geometry — which is what the layout section below needs and `agent-browser` cannot do. Use whichever is available; don't mix both against one page.
+
 A click on an element below the fold does nothing and still prints `✓ Done`, which looks identical to a broken handler — scroll it into view first. Before reporting any button as broken, verify the click actually landed; see the interaction section of `references/agent-browser.md` for the recipe.
 
 **Wait after loading `/login` before filling anything.** Without a pause the password field is often not in the DOM yet, so `fill` reports `✗ Element not found`, the submit click posts an empty form, and the next `find testid "org-switcher"` also misses — three failures that together read exactly like broken auth. It is a hydration race, not a bug in the app. The same applies after `pnpm dev` restarts: the session cookie is gone, so a page you had open lands back on `/login?returnTo=…` and every subsequent `find` fails until you sign in again.
@@ -205,6 +216,41 @@ To force one feed to fail while the rest of a page keeps working — the only ho
 docker exec batuda-db psql -U batuda -d <db> -c "REVOKE SELECT ON calendar_events FROM app_user, app_service;"
 # ... check the page shows its failure state, then ...
 docker exec batuda-db psql -U batuda -d <db> -c "GRANT SELECT ON calendar_events TO app_user, app_service;"
+```
+
+## When the page renders but looks wrong
+
+The checks above all assume something *errors*. A layout bug throws nothing: the request is 200, the rows are in the DOM, and the screen is still wrong. Do not reach for the network tab or the server log — measure the box that is the wrong size.
+
+Two symptoms, one cause. A list that shows a couple of rows and refuses to grow, or content clipped with no way to scroll to it, is almost always a scroll container that collapsed to leftover flex space.
+
+**Find the clipped container.** Anything whose content is taller than its own box is a scroller that is losing:
+
+```js
+[...document.querySelectorAll('*')]
+  .filter(el => { const s = getComputedStyle(el)
+    return (s.overflowY === 'auto' || s.overflowY === 'scroll') && el.scrollHeight > el.clientHeight + 4 })
+  .map(el => ({ cls: el.className.toString().slice(0, 60),
+                clientH: el.clientHeight, scrollH: el.scrollHeight }))
+```
+
+Styled-components names each class after its component and the file it sits in, so a hit names the file to open. `side-nav__NavList` is a normal hit — ignore it.
+
+**Then walk the height chain upward** from that element, reading `clientHeight`, `display`, `flex`, `minHeight` and `overflowY` at each ancestor up to `<body>`. The break is the first ancestor whose height stops coming from real content — a `flex: 1` child inside a viewport-locked parent gets whatever the fixed siblings above it left over, which can be almost nothing.
+
+**Sweep viewport sizes before concluding anything.** These bugs scale with height, so one window size tells you nothing about severity — the same page can look acceptable at 1920×1080 and show half a row at 1440×620. Resize to at least 1280×720, 1440×900, 1920×1080, tablet and mobile, re-measuring at each. Note that below 768px the app drops the viewport height lock and the document scrolls instead, so a desktop-only bug disappears on mobile.
+
+**The app's intended pattern is that `PriScrollArea` scrolls the whole page.** A route with its own `overflow-y: auto` is the exception and deserves suspicion. Two things break when a route introduces one: `infinite-list-footer.tsx` observes the sheet viewport, never a page-local scroller, so auto-load silently stops firing; and only the sheet viewport carries `data-scroll-restoration-id`, so an inner scroller loses its position on back-navigation.
+
+**Row counts lie when a list is paginated.** `EMAILS_PAGE_SIZE` caps the emails list at 100, so a DOM row count answers to the page size, not to how much data exists. Assert on the page's own total (`emails-thread-total`) instead — see `apps/internal/tests/e2e/inbox-listing.test.ts`.
+
+**Need more rows than the seed provides?** `--preset full` scales companies, not mail — it still leaves 7 threads. Insert them directly into the worktree's disposable DB:
+
+```bash
+docker exec batuda-db psql -U batuda -d batuda_<slug> -c "
+INSERT INTO email_thread_links (organization_id, external_thread_id, inbox_id, subject, status, created_at, updated_at)
+SELECT '<org-id>', 'bulk-' || g, '<inbox-id>', 'Test thread ' || g, 'open', now(), now()
+FROM generate_series(1, 113) g;"
 ```
 
 ## Watch several worktrees at once

--- a/apps/internal/package.json
+++ b/apps/internal/package.json
@@ -39,7 +39,6 @@
 		"@tanstack/react-router": "1.170.17",
 		"@tanstack/react-start": "1.168.27",
 		"@tanstack/react-table": "^8.21.3",
-		"@tanstack/react-virtual": "^3.14.6",
 		"@tiptap/core": "^3.28.0",
 		"@tiptap/markdown": "^3.28.0",
 		"@tiptap/pm": "^3.28.0",

--- a/apps/internal/src/components/layout/blueprint-sheet.tsx
+++ b/apps/internal/src/components/layout/blueprint-sheet.tsx
@@ -303,18 +303,6 @@ const Content = styled.div`
 	position: relative;
 	z-index: 2;
 
-	/* Opt-in full height: a page marks its root [data-sheet-fill] to fill the
-	   sheet (e.g. a list that grows to the available space and scrolls inside
-	   itself). Bounded to the viewport height so the inner list scrolls rather
-	   than pushing the whole page taller. Every other page keeps the default
-	   top-stacked, sheet-scrolled flow untouched. */
-	&:has(> [data-sheet-fill]) {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-		min-height: 0;
-	}
-
 	@media (min-width: 768px) {
 		padding-top: var(--space-xl);
 		padding-right: var(--space-xl);

--- a/apps/internal/src/components/primitives/pri-table.tsx
+++ b/apps/internal/src/components/primitives/pri-table.tsx
@@ -15,7 +15,11 @@ import styled from 'styled-components'
  * card for mobile.
  */
 
-const Root = styled.table.withConfig({
+// Every part of the table names its own role. A `display: block`/`flex`/`grid`
+// override drops the role a browser would otherwise infer from the tag, and the
+// chain has to be unbroken — a table owns rowgroups, a rowgroup owns rows, a row
+// owns cells — or a screen reader stops treating any of it as a table.
+const Root = styled.table.attrs({ role: 'table' }).withConfig({
 	displayName: 'PriTable.Root',
 	shouldForwardProp: prop => !prop.startsWith('$'),
 })<{ $dense?: boolean }>`
@@ -28,7 +32,7 @@ const Root = styled.table.withConfig({
 	display: block;
 `
 
-const Head = styled.thead.withConfig({
+const Head = styled.thead.attrs({ role: 'rowgroup' }).withConfig({
 	displayName: 'PriTable.Head',
 })`
 	display: block;
@@ -50,19 +54,23 @@ const Head = styled.thead.withConfig({
 	}
 `
 
-const Body = styled.tbody.withConfig({
+const Body = styled.tbody.attrs({ role: 'rowgroup' }).withConfig({
 	displayName: 'PriTable.Body',
 })`
 	display: block;
 	position: relative;
 `
 
-const Row = styled.tr.withConfig({
+const Row = styled.tr.attrs({ role: 'row' }).withConfig({
 	displayName: 'PriTable.Row',
 })`
 	display: flex;
 	align-items: stretch;
 	width: 100%;
+	/* Keyboard focus scrolls a row into view against the page, which has the
+	   pinned head across its top and, on a phone, the nav bar across its
+	   bottom. Hold the row clear of both so focus is never behind them. */
+	scroll-margin-block: 3rem calc(var(--bottom-nav-space) + var(--space-sm));
 	transition: background 120ms ease;
 	border-bottom: 1px solid var(--color-outline-variant);
 	cursor: pointer;
@@ -98,7 +106,7 @@ const Row = styled.tr.withConfig({
 const flexFor = (intent?: 'fixed' | 'grow' | 'shrink') =>
 	intent === 'grow' ? '1 1 0' : intent === 'shrink' ? '0 1 auto' : '0 0 auto'
 
-const ColumnHeader = styled.th.withConfig({
+const ColumnHeader = styled.th.attrs({ role: 'columnheader' }).withConfig({
 	displayName: 'PriTable.ColumnHeader',
 	shouldForwardProp: prop => !prop.startsWith('$'),
 })<{
@@ -122,7 +130,7 @@ const ColumnHeader = styled.th.withConfig({
 	user-select: none;
 `
 
-const Cell = styled.td.withConfig({
+const Cell = styled.td.attrs({ role: 'cell' }).withConfig({
 	displayName: 'PriTable.Cell',
 	shouldForwardProp: prop => !prop.startsWith('$'),
 })<{

--- a/apps/internal/src/components/primitives/pri-table.tsx
+++ b/apps/internal/src/components/primitives/pri-table.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components'
 /**
  * Batuda-internal table primitive. Compound export: `PriTable = { Root, Head,
  * Body, Row, ColumnHeader, Cell, Resizer }`. Semantic `<table>` subtree with
- * `display: block`/`flex` overrides so TanStack Virtual rows can live inside
- * `<tbody>` as absolutely-positioned `<tr>`s. Explicit ARIA roles are set so
+ * `display: block`/`flex` overrides so a row can restack as a card on narrow
+ * screens and the head can stay pinned. Explicit ARIA roles are set so
  * assistive tech still treats the subtree as a table after CSS display
  * overrides strip the implicit roles.
  *

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -2944,10 +2944,6 @@ msgstr "Fes que {0} sigui l'adreça des d'on envies"
 msgid "Make {0} the default"
 msgstr "Fes que {0} sigui la predeterminada"
 
-#: src/components/contacts/manage-channels-dialog.tsx
-#~ msgid "Make primary"
-#~ msgstr "Fes-lo principal"
-
 #: src/components/instructions/stack-editor.tsx
 msgid "Make this my default"
 msgstr "Fes que sigui la meva predeterminada"
@@ -4396,10 +4392,6 @@ msgstr "Elimina {chip}"
 msgid "Remove {email} from this organization?"
 msgstr "Vols eliminar {email} d'aquesta organització?"
 
-#: src/components/contacts/manage-channels-dialog.tsx
-#~ msgid "Remove channel"
-#~ msgstr "Elimina el canal"
-
 #: src/components/companies/proposals-panel.tsx
 msgid "Remove line"
 msgstr "Elimina la línia"
@@ -5567,6 +5559,10 @@ msgstr "Metadades del fil"
 #: src/routes/emails/$threadId.tsx
 msgid "Thread not found"
 msgstr "Fil no trobat"
+
+#: src/routes/emails/index.tsx
+msgid "Thread pages"
+msgstr "Pàgines de fils"
 
 #: src/routes/settings/organization/spend.tsx
 msgid "Time range"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -2944,10 +2944,6 @@ msgstr "Make {0} the address you send from"
 msgid "Make {0} the default"
 msgstr "Make {0} the default"
 
-#: src/components/contacts/manage-channels-dialog.tsx
-#~ msgid "Make primary"
-#~ msgstr "Make primary"
-
 #: src/components/instructions/stack-editor.tsx
 msgid "Make this my default"
 msgstr "Make this my default"
@@ -4396,10 +4392,6 @@ msgstr "Remove {chip}"
 msgid "Remove {email} from this organization?"
 msgstr "Remove {email} from this organization?"
 
-#: src/components/contacts/manage-channels-dialog.tsx
-#~ msgid "Remove channel"
-#~ msgstr "Remove channel"
-
 #: src/components/companies/proposals-panel.tsx
 msgid "Remove line"
 msgstr "Remove line"
@@ -5567,6 +5559,10 @@ msgstr "Thread metadata"
 #: src/routes/emails/$threadId.tsx
 msgid "Thread not found"
 msgstr "Thread not found"
+
+#: src/routes/emails/index.tsx
+msgid "Thread pages"
+msgstr "Thread pages"
 
 #: src/routes/settings/organization/spend.tsx
 msgid "Time range"

--- a/apps/internal/src/routes/emails/index.tsx
+++ b/apps/internal/src/routes/emails/index.tsx
@@ -16,7 +16,6 @@ import {
 	useReactTable,
 	type VisibilityState,
 } from '@tanstack/react-table'
-import { useVirtualizer } from '@tanstack/react-virtual'
 import { Cause, DateTime, Option, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import {
@@ -41,14 +40,7 @@ import {
 	Search,
 	X,
 } from 'lucide-react'
-import {
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import {
@@ -72,6 +64,7 @@ import {
 	updateThreadStatusAtom,
 } from '#/atoms/emails-atoms'
 import { companiesListAtom } from '#/atoms/pipeline-atoms'
+import { useOptionalBlueprintViewportRef } from '#/components/layout/blueprint-sheet'
 import { PriTable } from '#/components/primitives/pri-table'
 import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
@@ -248,6 +241,7 @@ function EmailsIndexPage() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
 	const { openCompose, drafts } = useComposeEmail()
+	const sheetViewportRef = useOptionalBlueprintViewportRef()
 	const wire = useMemo(() => toWireSearch(search), [search])
 
 	// Atom identity is keyed by the canonical wire-shape key, not by the
@@ -418,8 +412,15 @@ function EmailsIndexPage() {
 				search: prev =>
 					mergeSearch(prev, { page: page <= 1 ? undefined : page }),
 			})
+			// The page buttons sit under the last row, so without this the next
+			// page opens at its end instead of at its first thread. Phones
+			// scroll the page itself, and the sheet hands out the same ref
+			// either way, so ask whether it really scrolls before trusting it.
+			const sheet = sheetViewportRef?.current
+			if (sheet && sheet.scrollHeight > sheet.clientHeight) sheet.scrollTop = 0
+			else window.scrollTo({ top: 0 })
 		},
-		[navigate],
+		[navigate, sheetViewportRef],
 	)
 	const handleClearFilters = useCallback(() => {
 		setSearchInput('')
@@ -558,7 +559,7 @@ function EmailsIndexPage() {
 	const allSelected = threads.length > 0 && selectedCount === threads.length
 
 	return (
-		<Page data-sheet-fill>
+		<Page>
 			<Intro>
 				<IntroText>
 					<Title>{t`Emails`}</Title>
@@ -830,7 +831,7 @@ function EmailsIndexPage() {
 	)
 }
 
-// ── ThreadsGrid: TanStack Table + Virtual + PriTable ──────────────
+// ── ThreadsGrid: TanStack Table + PriTable ────────────────────────
 
 type ThreadsGridProps = {
 	readonly threads: ReadonlyArray<ThreadRow>
@@ -1016,22 +1017,14 @@ function ThreadsGrid({
 		defaultColumn: { minSize: 48 },
 	})
 
-	const scrollRef = useRef<HTMLDivElement>(null)
 	const rows = table.getRowModel().rows
-	const virtualizer = useVirtualizer({
-		count: rows.length,
-		getScrollElement: () => scrollRef.current,
-		estimateSize: () => 64,
-		overscan: 8,
-	})
-	const virtualRows = virtualizer.getVirtualItems()
 
 	return (
 		<GridShell>
 			<GridToolbar>
 				<ColumnVisibilityMenu table={table} />
 			</GridToolbar>
-			<GridScroll ref={scrollRef}>
+			<GridFrame>
 				<PriTable.Root>
 					{selectedCount > 0 ? (
 						<SelectionHead>
@@ -1143,36 +1136,16 @@ function ThreadsGrid({
 							))}
 						</PriTable.Head>
 					)}
-					<PriTable.Body
-						style={{
-							height: virtualizer.getTotalSize(),
-							position: 'relative',
-						}}
-					>
-						{virtualRows.map(vi => {
-							const row = rows[vi.index]
-							if (row === undefined) return null
+					<PriTable.Body>
+						{rows.map(row => {
 							const thread = row.original
 							return (
 								<GridRow
 									key={row.id}
-									// Rows vary in height (the stacked mobile card is taller
-									// than a desktop row), so let the virtualizer measure each
-									// one instead of assuming the estimate — otherwise
-									// absolutely-positioned rows would overlap.
-									ref={virtualizer.measureElement}
-									data-index={vi.index}
 									data-testid={`thread-row-${thread.id}`}
 									data-unread={thread.isUnread ? 'true' : 'false'}
 									data-draft={thread.hasDraft ? 'true' : 'false'}
 									data-selected={selected.has(thread.id) ? 'true' : 'false'}
-									style={{
-										position: 'absolute',
-										top: 0,
-										left: 0,
-										right: 0,
-										transform: `translateY(${vi.start}px)`,
-									}}
 									tabIndex={0}
 									aria-label={
 										thread.subject
@@ -1224,7 +1197,7 @@ function ThreadsGrid({
 						})}
 					</PriTable.Body>
 				</PriTable.Root>
-			</GridScroll>
+			</GridFrame>
 		</GridShell>
 	)
 }
@@ -1666,10 +1639,6 @@ const Page = styled.div.withConfig({ displayName: 'EmailsIndexPage' })`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-lg);
-	/* Fill the sheet so the thread list can grow to the available height
-	   instead of collapsing to a fixed max-height. */
-	flex: 1;
-	min-height: 0;
 `
 
 const Intro = styled.div.withConfig({ displayName: 'EmailsIndexIntro' })`
@@ -1984,9 +1953,6 @@ const GridShell = styled.div.withConfig({ displayName: 'EmailsGridShell' })`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-xs);
-	/* Grow to fill the page so the scroll area below takes the free height. */
-	flex: 1;
-	min-height: 0;
 `
 
 // Below the table breakpoint each row is a stacked card: checkbox on the
@@ -2061,13 +2027,8 @@ const GridToolbar = styled.div.withConfig({
 	gap: var(--space-xs);
 `
 
-const GridScroll = styled.div.withConfig({ displayName: 'EmailsGridScroll' })`
+const GridFrame = styled.div.withConfig({ displayName: 'EmailsGridFrame' })`
 	position: relative;
-	/* Fill the remaining page height (no fixed cap) and scroll the rows
-	   internally; pagination will bound the row count later. */
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
 	border: 1px solid var(--color-outline-variant);
 	border-radius: var(--shape-2xs);
 	background: var(--color-surface);

--- a/apps/internal/src/routes/emails/index.tsx
+++ b/apps/internal/src/routes/emails/index.tsx
@@ -40,7 +40,14 @@ import {
 	Search,
 	X,
 } from 'lucide-react'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react'
 import styled, { css } from 'styled-components'
 
 import {
@@ -64,7 +71,6 @@ import {
 	updateThreadStatusAtom,
 } from '#/atoms/emails-atoms'
 import { companiesListAtom } from '#/atoms/pipeline-atoms'
-import { useOptionalBlueprintViewportRef } from '#/components/layout/blueprint-sheet'
 import { PriTable } from '#/components/primitives/pri-table'
 import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
@@ -241,7 +247,7 @@ function EmailsIndexPage() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
 	const { openCompose, drafts } = useComposeEmail()
-	const sheetViewportRef = useOptionalBlueprintViewportRef()
+	const listTopRef = useRef<HTMLDivElement>(null)
 	const wire = useMemo(() => toWireSearch(search), [search])
 
 	// Atom identity is keyed by the canonical wire-shape key, not by the
@@ -412,15 +418,14 @@ function EmailsIndexPage() {
 				search: prev =>
 					mergeSearch(prev, { page: page <= 1 ? undefined : page }),
 			})
-			// The page buttons sit under the last row, so without this the next
-			// page opens at its end instead of at its first thread. Phones
-			// scroll the page itself, and the sheet hands out the same ref
-			// either way, so ask whether it really scrolls before trusting it.
-			const sheet = sheetViewportRef?.current
-			if (sheet && sheet.scrollHeight > sheet.clientHeight) sheet.scrollTop = 0
-			else window.scrollTo({ top: 0 })
+			// The page buttons sit under the last row, so the next page would
+			// otherwise open at its end instead of at its first thread. Moving
+			// focus to the top of the list scrolls it there and takes the
+			// keyboard with it — the button just pressed is about to be disabled
+			// on the first and last page, which would strand focus on nothing.
+			listTopRef.current?.focus()
 		},
-		[navigate, sheetViewportRef],
+		[navigate],
 	)
 	const handleClearFilters = useCallback(() => {
 		setSearchInput('')
@@ -782,6 +787,9 @@ function EmailsIndexPage() {
 						/>
 					) : (
 						<>
+							{/* Where paging sends the keyboard and the screen, so a new
+							    page opens at its first thread. */}
+							<ListTop ref={listTopRef} tabIndex={-1} />
 							{drafts.length > 0 && <DraftsResumeStrip drafts={drafts} />}
 							<ThreadsGrid
 								threads={threads}
@@ -798,8 +806,8 @@ function EmailsIndexPage() {
 					)}
 
 					{total > EMAILS_PAGE_SIZE && (
-						<Pagination>
-							<PageLabel>{t`Showing ${firstRow}–${lastRow} of ${total}`}</PageLabel>
+						<Pagination aria-label={t`Thread pages`}>
+							<PageLabel role='status'>{t`Showing ${firstRow}–${lastRow} of ${total}`}</PageLabel>
 							<PageNav>
 								<PriButton
 									type='button'
@@ -1029,80 +1037,81 @@ function ThreadsGrid({
 					{selectedCount > 0 ? (
 						<SelectionHead>
 							<PriTable.Row>
-								<SelectionCell
-									$flex='grow'
-									role='toolbar'
-									aria-label={t`Bulk thread actions`}
-								>
-									<PriCheckbox.Root
-										checked={allSelected}
-										onCheckedChange={checked => {
-											if (checked) selectAll()
-											else clearSelection()
-										}}
-										aria-label={t`Select all threads on this page`}
+								<SelectionCell $flex='grow'>
+									<BulkToolbar
+										role='toolbar'
+										aria-label={t`Bulk thread actions`}
 									>
-										<PriCheckbox.Indicator>
-											<Check size={12} aria-hidden />
-										</PriCheckbox.Indicator>
-									</PriCheckbox.Root>
-									<BulkLabel aria-live='polite'>
-										{selectedCount === 1
-											? t`1 thread selected`
-											: t`${selectedCount} threads selected`}
-									</BulkLabel>
-									<PriButton
-										type='button'
-										$variant='outlined'
-										onClick={() => {
-											void applyStatus(Array.from(selected), 'closed')
-											clearSelection()
-										}}
-									>
-										<CheckCheck size={14} aria-hidden />
-										<span>{t`Close`}</span>
-									</PriButton>
-									<PriButton
-										type='button'
-										$variant='outlined'
-										onClick={() => {
-											void applyStatus(Array.from(selected), 'open')
-											clearSelection()
-										}}
-									>
-										<ArchiveRestore size={14} aria-hidden />
-										<span>{t`Reopen`}</span>
-									</PriButton>
-									<PriButton
-										type='button'
-										$variant='outlined'
-										onClick={() => {
-											void applyStatus(Array.from(selected), 'archived')
-											clearSelection()
-										}}
-									>
-										<Archive size={14} aria-hidden />
-										<span>{t`Archive`}</span>
-									</PriButton>
-									<PriButton
-										type='button'
-										$variant='outlined'
-										onClick={() => {
-											void applyRead(Array.from(selected), true)
-											clearSelection()
-										}}
-									>
-										<Eye size={14} aria-hidden />
-										<span>{t`Mark read`}</span>
-									</PriButton>
-									<PriButton
-										type='button'
-										$variant='text'
-										onClick={clearSelection}
-									>
-										<X size={14} aria-hidden />
-										<span>{t`Clear`}</span>
-									</PriButton>
+										<PriCheckbox.Root
+											checked={allSelected}
+											onCheckedChange={checked => {
+												if (checked) selectAll()
+												else clearSelection()
+											}}
+											aria-label={t`Select all threads on this page`}
+										>
+											<PriCheckbox.Indicator>
+												<Check size={12} aria-hidden />
+											</PriCheckbox.Indicator>
+										</PriCheckbox.Root>
+										<BulkLabel aria-live='polite'>
+											{selectedCount === 1
+												? t`1 thread selected`
+												: t`${selectedCount} threads selected`}
+										</BulkLabel>
+										<PriButton
+											type='button'
+											$variant='outlined'
+											onClick={() => {
+												void applyStatus(Array.from(selected), 'closed')
+												clearSelection()
+											}}
+										>
+											<CheckCheck size={14} aria-hidden />
+											<span>{t`Close`}</span>
+										</PriButton>
+										<PriButton
+											type='button'
+											$variant='outlined'
+											onClick={() => {
+												void applyStatus(Array.from(selected), 'open')
+												clearSelection()
+											}}
+										>
+											<ArchiveRestore size={14} aria-hidden />
+											<span>{t`Reopen`}</span>
+										</PriButton>
+										<PriButton
+											type='button'
+											$variant='outlined'
+											onClick={() => {
+												void applyStatus(Array.from(selected), 'archived')
+												clearSelection()
+											}}
+										>
+											<Archive size={14} aria-hidden />
+											<span>{t`Archive`}</span>
+										</PriButton>
+										<PriButton
+											type='button'
+											$variant='outlined'
+											onClick={() => {
+												void applyRead(Array.from(selected), true)
+												clearSelection()
+											}}
+										>
+											<Eye size={14} aria-hidden />
+											<span>{t`Mark read`}</span>
+										</PriButton>
+										<PriButton
+											type='button'
+											$variant='text'
+											onClick={clearSelection}
+										>
+											<X size={14} aria-hidden />
+											<span>{t`Clear`}</span>
+										</PriButton>
+									</BulkToolbar>
 								</SelectionCell>
 							</PriTable.Row>
 						</SelectionHead>
@@ -1158,13 +1167,11 @@ function ThreadsGrid({
 											params: { threadId: thread.id },
 										})
 									}}
-									// Enter/Space opens the focused row; ignore keys that
-									// bubbled up from the checkbox or action buttons.
+									// Enter opens the focused row; ignore keys that bubbled up
+									// from the checkbox or action buttons. Space is left to the
+									// page, where it is how you scroll down a long list.
 									onKeyDown={e => {
-										if (
-											(e.key === 'Enter' || e.key === ' ') &&
-											e.target === e.currentTarget
-										) {
+										if (e.key === 'Enter' && e.target === e.currentTarget) {
 											e.preventDefault()
 											void navigate({
 												to: '/emails/$threadId',
@@ -1806,15 +1813,25 @@ const SelectionCell = styled(PriTable.ColumnHeader).withConfig({
 	displayName: 'EmailsIndexSelectionCell',
 })`
 	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: var(--space-xs);
 	width: 100%;
 	padding: var(--space-2xs) var(--space-sm);
 	text-transform: none;
 	letter-spacing: normal;
 	white-space: normal;
 	background: color-mix(in oklab, var(--color-primary) 12%, var(--color-surface));
+`
+
+// The bulk buttons group as a toolbar on their own element rather than on the
+// header cell around them: a row owns cells, so a cell that called itself a
+// toolbar would break the table apart for a screen reader.
+const BulkToolbar = styled.div.withConfig({
+	displayName: 'EmailsIndexBulkToolbar',
+})`
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--space-xs);
+	width: 100%;
 `
 
 const BulkLabel = styled.span.withConfig({
@@ -1899,7 +1916,19 @@ const SuspiciousTag = styled.span.withConfig({
 	text-transform: uppercase;
 `
 
-const Pagination = styled.div.withConfig({
+// Carries no styling of its own — it exists to be focused, and the scroll
+// margin keeps the top of the list clear of the bar pinned above it.
+const ListTop = styled.div.withConfig({
+	displayName: 'EmailsIndexListTop',
+})`
+	scroll-margin-block-start: var(--space-md);
+
+	&:focus {
+		outline: none;
+	}
+`
+
+const Pagination = styled.nav.withConfig({
 	displayName: 'EmailsIndexPagination',
 })`
 	${brushedMetalPlate}

--- a/apps/internal/tests/e2e/inbox-listing.test.ts
+++ b/apps/internal/tests/e2e/inbox-listing.test.ts
@@ -16,6 +16,10 @@ import { setActiveOrgBySlug } from './helpers/set-active-org'
 //     (thread-row-{id}, emails-thread-total, inbox-filter-trigger,
 //      inbox-filter-option, data-inbox-email)
 
+// Hand-copy of EMAILS_PAGE_SIZE in src/atoms/emails-atoms.ts: importing it
+// pulls in Vite's `import.meta.env`, which Node does not have.
+const PAGE_SIZE = 100
+
 const psql = (sqlText: string): string =>
 	execSync(`psql "${DATABASE_URL}" -tA -c "${sqlText.replace(/"/g, '\\"')}"`, {
 		encoding: 'utf8',
@@ -48,9 +52,9 @@ test.describe('emails inbox listing', () => {
 			await page.goto('/emails', { waitUntil: 'networkidle' })
 
 			// THEN the page accounts for all of them. Counting rows instead would
-			// be counting the window, not the mail: the list only builds the rows
-			// that fit on screen, so its row count answers to the height of the
-			// browser rather than to how much mail there is.
+			// count one page of mail rather than all of it: the list draws a
+			// page at a time, so its row count stops at the page size however
+			// much mail there is.
 			await expect(page.getByTestId('emails-thread-total')).toHaveText(
 				expected === 1 ? '1 thread' : `${expected} threads`,
 			)
@@ -61,13 +65,38 @@ test.describe('emails inbox listing', () => {
 			).toBeVisible()
 
 			// AND a known thread can be reached. Searched for rather than looked
-			// for on screen: the list only draws the rows that fit, so an older
-			// thread sits below the fold and is not there to find — which is the
-			// same trap as counting rows, one step further along.
+			// for on screen: an older thread can sit on a later page, and is
+			// then not there to find — the same trap as counting rows, one step
+			// further along.
 			await page
 				.getByTestId('emails-search')
 				.fill('Quote for the booking module')
 			await expect(page.getByText('Quote for the booking module')).toBeVisible()
+		})
+	})
+
+	test.describe('when a page holds more threads than fit on screen', () => {
+		test('should draw a row for every thread on the page', async ({ page }) => {
+			// GIVEN however many threads Taller has, capped at the one page the
+			// list draws at a time.
+			const totalThreads = Number(
+				psql(
+					`SELECT count(*) FROM email_thread_links l
+					 JOIN organization o ON o.id = l.organization_id
+					 WHERE o.slug = 'taller'`,
+				),
+			)
+			const expectedRows = Math.min(totalThreads, PAGE_SIZE)
+
+			// WHEN the user lands on /emails
+			await page.goto('/emails', { waitUntil: 'networkidle' })
+
+			// THEN every one of them has a row, including the ones below the
+			// fold. A list that draws only what fits the window leaves the rest
+			// of the page unreachable on a short screen.
+			await expect(page.locator('[data-testid^="thread-row-"]')).toHaveCount(
+				expectedRows,
+			)
 		})
 	})
 
@@ -100,8 +129,8 @@ test.describe('emails inbox listing', () => {
 			)
 			expect(expectedAgent, 'agent inbox must have threads').toBeGreaterThan(0)
 			// The page's own tally, for the same reason as the test above: a row
-			// count would answer to the height of the browser. It holds today
-			// only because the agent inbox has a single thread.
+			// count would stop at the page size. It holds today only because the
+			// agent inbox has a single thread.
 			await expect(page.getByTestId('emails-thread-total')).toHaveText(
 				expectedAgent === 1 ? '1 thread' : `${expectedAgent} threads`,
 			)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-virtual':
-        specifier: ^3.14.6
-        version: 3.14.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tiptap/core':
         specifier: 3.28.0
         version: 3.28.0(@tiptap/pm@3.28.0)
@@ -3953,12 +3950,6 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.14.6':
-    resolution: {integrity: sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@tanstack/router-core@1.171.14':
     resolution: {integrity: sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==}
     engines: {node: '>=20.19'}
@@ -4026,9 +4017,6 @@ packages:
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
-
-  '@tanstack/virtual-core@3.17.4':
-    resolution: {integrity: sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==}
 
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
@@ -11163,12 +11151,6 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-virtual@3.14.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@tanstack/virtual-core': 3.17.4
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@tanstack/router-core@1.171.14':
     dependencies:
       '@tanstack/history': 1.162.0
@@ -11292,8 +11274,6 @@ snapshots:
   '@tanstack/store@0.9.3': {}
 
   '@tanstack/table-core@8.21.3': {}
-
-  '@tanstack/virtual-core@3.17.4': {}
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 


### PR DESCRIPTION
## What

The Emails screen in the internal CRM (`apps/internal`) said "33 threads" and then showed two or three of them, with no way to reach the rest. The mail had loaded and was sitting in the page; an invisible box was cutting it off. This restores the full list, and along the way makes the list readable by a screen reader and usable from the keyboard.

The cause was a layout opt-in. The page asked to fill the height of the sheet it sits in, which meant the thread list got whatever space was left after the title, the search box and the filter row — and those are fixed. On a 1440×900 window that left 330px, about four rows. On a shorter window, 50px: half of one row. Every other list in the app scrolls with the page instead, and now this one does too.

## The fix

- Removed the `data-sheet-fill` opt-in from the Emails page and the flex chain underneath it, so the list scrolls with the page like the other 31 routes. The mechanism had exactly one user; the rule that implemented it in the sheet is gone with it.
- Removed the row virtualizer. It existed only to serve the inner scroller, it was the app's only use of `@tanstack/react-virtual`, and a page holds at most 100 rows — every other list renders its rows plainly. Its size estimate (64px) was also below the real row heights of 80px desktop and 199px tablet.
- Paging returns to the top of the list. The Previous/Next buttons sit below the last row, so without this the next page opened at its end.
- Gave the table its ARIA roles. The CSS that restacks a row into a card on a phone drops the meaning a browser infers from `<table>`/`<tr>`/`<td>`, so a screen reader met a hundred unlabelled blocks rather than a table, and each row's own "Open thread" label went unread with them. This barrier predates the change, but making all 100 rows reachable is what stopped it being hidden behind rows that did not exist.
- Held a keyboard-focused row clear of the pinned header and the phone's bottom nav, and moved the focus target on paging so it is never left on a button that has just become disabled.

## Impact

- **No migration, no schema change, no new environment variables.** Nothing to run before or after deploying.
- **No API or wire-shape change.** The thread-list endpoint, its parameters and its response are untouched; this is `apps/internal` only.
- **`packages/ui` is not affected** — `PriTable` here is the internal primitive at `apps/internal/src/components/primitives/pri-table.tsx`, not the published package.
- **The ARIA roles reach every `PriTable` consumer**, so the MCP connections and API keys screens gain them too. That is the intended direction, and the full e2e suite covers those pages.
- **One dependency drops out**: `@tanstack/react-virtual` leaves `apps/internal`, with the matching lockfile change.
- **One new translated string** (`Thread pages`), with its Catalan translation filled in. Running the extractor also pruned two obsolete entries for a contacts dialog that were already stale in the catalogue.

## Review guide

Start with `apps/internal/src/routes/emails/index.tsx` — the layout change is the first thing to look at and is almost entirely deletions.

`git diff -w` is worth using on that file. Of its 221 changed lines, 142 are indentation: the bulk-actions toolbar moved inside a new wrapper element, which re-indented everything it contains. The real change is 79 lines.

The riskiest part is the ARIA role chain in `pri-table.tsx`. It is applied through `styled.attrs`, which takes precedence over a role passed in by a consumer — that is why the emails bulk bar had to stop putting `role="toolbar"` on a header cell and put it on an element inside instead. If any other consumer passes a role to a `PriTable` part, it would be silently overridden; I checked the two that exist and neither does.

A decision you might overrule: I removed virtualization rather than rewiring it to the page scroller. Keeping it would have meant `scrollMargin` arithmetic against the shared viewport for a list capped at 100 rows, which seemed like a lot of machinery for no gain — but it does mean a future larger page size would render every row.

Skip `pnpm-lock.yaml` and the `.po` catalogues; both are generated.

Not covered here, and filed as #393: column sorting is still mouse-only, the bulk bar still replaces the column headers while active, status icons still convey state by colour alone, and three labels are still hardcoded English. All pre-existing, none touched by this change.

## Screenshots

Desktop at 1440×900, scrolled into the list — ten rows filling the screen, the column header pinned, and a scrollbar showing there is more below. Before this change the same window showed four rows and stopped.

![Emails list on desktop, ten rows filling the screen with the column header pinned](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-394/pr-emails-desktop.webp)

Mobile at 393×852, where each row is a stacked card and the document scrolls rather than the sheet.

![Emails list on mobile, threads as stacked cards](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-394/pr-emails-mobile.webp)

## Tests

The regression test is in `apps/internal/tests/e2e/inbox-listing.test.ts` and asserts a row exists for every thread on the page. I checked it actually catches this bug rather than just passing: against the pre-fix code it fails, finding 11 rows where 32 threads exist.

Two comments in that file described the virtualization as the reason not to count rows. That reason is gone; the reason now is pagination, and they say so.

## Verification

- `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test` (148 unit tests), `pnpm -w build` — all green, with `@batuda/internal` genuinely re-running rather than replaying cache.
- Full Playwright e2e suite: **126 passed, 6 skipped, 0 failed** — including the other `PriTable` consumers.
- Pre-push hooks: contrast, e2e-smoke, secrets, test.
- Driven live against the worktree stack with 32 seeded threads at 1280×720, 1440×900, 1440×620, 1920×1080, tablet and mobile. All 32 rows render at every size, with no page-local scroll container left anywhere.
- Checked in the browser: the role chain reads `table › rowgroup › row › cell`; a focused row clears the pinned header at three scroll positions; Space scrolls the list instead of opening a thread; paging from the bottom of a page lands at the top of the next one on both desktop and mobile.

## Deferred

- Keyset pagination, a smaller page size and denser rows — #391. The list pages by counting from the start, which goes stale as mail arrives, so a thread can be shown twice or skipped between pages.
- The remaining accessibility work — #393.
