### PR TITLE
refactor: stop keeping a second list of who a product is for

### DIFF
--- a/apps/cli/src/commands/seed/fixtures.ts
+++ b/apps/cli/src/commands/seed/fixtures.ts
@@ -65,7 +65,6 @@ export const PRODUCTS = [
 			'Lloc web professional amb SEO local i mòbil-first per a petits negocis.',
 		defaultPrice: '990.00',
 		priceType: 'fixed',
-		targetIndustries: ['Restauració', 'Moda i complements', 'Consultoria'],
 	},
 	{
 		slug: 'gestio-reserves',
@@ -76,7 +75,6 @@ export const PRODUCTS = [
 			'Sistema de reserves online amb calendari, recordatoris i pagaments.',
 		defaultPrice: '49.00',
 		priceType: 'monthly',
-		targetIndustries: ['Restauració', 'Allotjament', 'Consultoria'],
 	},
 	{
 		slug: 'automatitzacions',
@@ -87,11 +85,6 @@ export const PRODUCTS = [
 			'Workflows automàtics: facturació, seguiment clients, notificacions.',
 		defaultPrice: '1500.00',
 		priceType: 'fixed',
-		targetIndustries: [
-			'Serralleria',
-			'Distribució',
-			'Instal·lacions elèctriques',
-		],
 	},
 	{
 		slug: 'ecommerce-local',
@@ -101,7 +94,6 @@ export const PRODUCTS = [
 		description: 'Botiga online amb enviament local i integració amb TPV.',
 		defaultPrice: '2500.00',
 		priceType: 'fixed',
-		targetIndustries: ['Moda i complements', 'Ceràmica', 'Distribució'],
 	},
 	{
 		slug: 'social-media-pack',
@@ -112,7 +104,6 @@ export const PRODUCTS = [
 			'Gestió de xarxes socials: contingut, programació i analítica.',
 		defaultPrice: '300.00',
 		priceType: 'monthly',
-		targetIndustries: ['Restauració', 'Moda i complements', 'Allotjament'],
 	},
 	{
 		slug: 'consultoria-custom',
@@ -122,7 +113,6 @@ export const PRODUCTS = [
 		description: 'Projectes de consultoria digital amb abast i preu negociats.',
 		defaultPrice: null,
 		priceType: 'custom',
-		targetIndustries: ['Consultoria', 'Taller mecànic'],
 		metadata: { requiresDiscoveryCall: true },
 	},
 	{
@@ -134,7 +124,6 @@ export const PRODUCTS = [
 			'El nostre propi CRM — usat internament per validar funcionalitats.',
 		defaultPrice: null,
 		priceType: null,
-		targetIndustries: null,
 		metadata: { internal: true },
 	},
 ]

--- a/apps/server/src/db/migrations/0059_drop_product_target_industries.ts
+++ b/apps/server/src/db/migrations/0059_drop_product_target_industries.ts
@@ -1,0 +1,28 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Stop keeping a second list of who a product is for.
+//
+// The column held the trades a product was meant to be sold into. Nothing ever
+// read it: no filter, no screen, and the research pipeline never saw it. It was
+// written in five places and consumed in none.
+//
+// The organisation already says who it sells to, in its standing instructions,
+// and says it in the form that actually reaches the model — prose it can reason
+// with, alongside the pain each offer removes and the price it goes for. A
+// structured copy beside that prose is a second answer to one question, kept by
+// hand, with nothing checking that the two agree.
+//
+// The live half of the relationship stays: companies.products_fit holds the
+// products that suit a company, which research proposes and the company panel
+// shows.
+//
+// expand-contract: pre-production clean break. This same release removes every
+// writer of products.target_industries — the model, both route inputs, the agent
+// tool and the seeds — so nothing is left asking for it once this is out.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`ALTER TABLE products DROP COLUMN IF EXISTS target_industries`
+})

--- a/apps/server/src/mcp/tools/products.ts
+++ b/apps/server/src/mcp/tools/products.ts
@@ -37,7 +37,6 @@ const CreateProduct = Tool.make('create_product', {
 		description: Schema.optional(Schema.String),
 		default_price: Schema.optional(Schema.String),
 		price_type: Schema.optional(Schema.String),
-		target_industries: Schema.optional(Schema.Array(Schema.String)),
 		metadata: Schema.optional(Schema.Unknown),
 	}),
 	success: Product.json,
@@ -58,7 +57,6 @@ const UpdateProduct = Tool.make('update_product', {
 		description: Schema.optional(Schema.String),
 		default_price: Schema.optional(Schema.String),
 		price_type: Schema.optional(Schema.String),
-		target_industries: Schema.optional(Schema.Array(Schema.String)),
 		metadata: Schema.optional(Schema.Unknown),
 	}),
 	success: Schema.NullOr(Product.json),
@@ -105,8 +103,6 @@ export const ProductHandlersLive = ProductTools.toLayer(
 						row['defaultPrice'] = params.default_price
 					if (params.price_type !== undefined)
 						row['priceType'] = params.price_type
-					if (params.target_industries !== undefined)
-						row['targetIndustries'] = params.target_industries
 					if (params.metadata !== undefined) row['metadata'] = params.metadata
 					const rows =
 						yield* sql`INSERT INTO products ${sql.insert(row)} RETURNING *`
@@ -130,8 +126,6 @@ export const ProductHandlersLive = ProductTools.toLayer(
 					if (rest.default_price !== undefined)
 						data['defaultPrice'] = rest.default_price
 					if (rest.price_type !== undefined) data['priceType'] = rest.price_type
-					if (rest.target_industries !== undefined)
-						data['targetIndustries'] = rest.target_industries
 					if (rest.metadata !== undefined) data['metadata'] = rest.metadata
 					const rows = yield* sql`
 						UPDATE products SET ${sql.update(data, ['id'])}

--- a/apps/server/src/services/company-industries.integration.test.ts
+++ b/apps/server/src/services/company-industries.integration.test.ts
@@ -142,18 +142,25 @@ describe('naming a trade', () => {
 		})
 	})
 
-	describe('when two writers ask for the same new trade at once', () => {
-		it('should still end with one row', async () => {
-			// GIVEN four callers naming a trade the organisation does not have yet
+	describe('when several writers ask for the same new trade at once', () => {
+		it('should give them one row without any of them failing', async () => {
+			// GIVEN six callers naming a trade the organisation does not have yet
 			// WHEN they all resolve it at the same moment
-			// THEN they get one trade between them: the loser of the race reads back
-			//      what the winner wrote instead of failing or making a second row
-			const results = await Promise.all(
-				Array.from({ length: 4 }, () =>
-					run(withSql(sql => resolveIndustry(sql, ORG, 'Fusteria'))),
+			// THEN none of them fails. This is asserted before the count because a
+			//      raised unique violation used to read as a flake: the callers that
+			//      did survive still agreed on one id, so counting alone passed while
+			//      a caller had been handed a server error.
+			const outcomes = await Promise.all(
+				Array.from({ length: 6 }, () =>
+					attempt(withSql(sql => resolveIndustry(sql, ORG, 'Fusteria'))),
 				),
 			)
-			expect(new Set(results.map(r => r.id)).size).toBe(1)
+			expect(outcomes.filter(Exit.isFailure)).toEqual([])
+
+			// AND they get one trade between them: whoever loses the race reads back
+			// what the winner wrote instead of making a second row
+			const ids = outcomes.flatMap(o => (Exit.isSuccess(o) ? [o.value.id] : []))
+			expect(new Set(ids).size).toBe(1)
 		})
 	})
 

--- a/apps/server/src/services/company-industries.ts
+++ b/apps/server/src/services/company-industries.ts
@@ -69,10 +69,18 @@ export const resolveIndustry = (
 		`
 		if (existing[0] !== undefined) return existing[0]
 
+		// No index is named: the table is unique on both the folded name and the
+		// slug, and naming only one of them leaves the other free to raise. With
+		// several writers in flight one can clear the named index and then meet
+		// another's committed row in the second, which is a plain unique violation
+		// rather than the quiet do-nothing this needs. Both indexes say the same
+		// thing here — the slug is the folded name with its spaces hyphenated — so
+		// either one firing means the trade already exists, which is what the read
+		// below goes to fetch.
 		const inserted = yield* sql<Industry>`
 			INSERT INTO company_industries (organization_id, label, slug, folded_key, needs_review)
 			VALUES (${orgId}, ${label.trim()}, ${slugFromLabel(label)}, ${folded}, ${options?.needsReview ?? false})
-			ON CONFLICT (organization_id, folded_key) DO NOTHING
+			ON CONFLICT DO NOTHING
 			RETURNING ${COLUMNS(sql)}
 		`
 		if (inserted[0] !== undefined) return inserted[0]

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -36,10 +36,7 @@ export {
 	CompanyDetail,
 	CompanyResearchRun,
 } from './routes/companies'
-export {
-	CompanyIndustriesGroup,
-	CompanyIndustryView,
-} from './routes/company-industries'
+export { CompanyIndustriesGroup } from './routes/company-industries'
 export {
 	ContactListItem,
 	ContactSummary,

--- a/packages/controllers/src/routes/products.ts
+++ b/packages/controllers/src/routes/products.ts
@@ -14,7 +14,6 @@ const CreateProductInput = Schema.Struct({
 	description: Schema.optional(Schema.String),
 	defaultPrice: Schema.optional(Schema.String),
 	priceType: Schema.optional(Schema.String),
-	targetIndustries: Schema.optional(Schema.Array(Schema.String)),
 	metadata: Schema.optional(Schema.Unknown),
 })
 
@@ -25,7 +24,6 @@ const UpdateProductInput = Schema.Struct({
 	description: Schema.optional(Schema.String),
 	defaultPrice: Schema.optional(Schema.String),
 	priceType: Schema.optional(Schema.String),
-	targetIndustries: Schema.optional(Schema.Array(Schema.String)),
 	metadata: Schema.optional(Schema.Unknown),
 })
 

--- a/packages/domain/src/schema/products.ts
+++ b/packages/domain/src/schema/products.ts
@@ -19,7 +19,6 @@ export class Product extends Model.Class<Product>('Product')({
 	priceType: Schema.NullOr(Schema.String),
 	// values: fixed | monthly | custom
 
-	targetIndustries: Schema.NullOr(Schema.Array(Schema.String)),
 	metadata: Schema.NullOr(Schema.Unknown),
 
 	createdAt: Model.DateTimeInsertFromDate,

--- a/packages/research/src/application/vocabulary-guard.test.ts
+++ b/packages/research/src/application/vocabulary-guard.test.ts
@@ -109,7 +109,7 @@ describe('mapSizeRange', () => {
 			expect(mapSizeRange('500')).toBe('201-500')
 			expect(mapSizeRange('501-1,000')).toBe('501-1000')
 			// AND a head-count written with a thousands separator — "1,700" must read
-			// as 1700, not 1, so a large company is not bucketed as 1-5
+			// as 1700, not 1, so a large company is not bucketed as 1-10
 			expect(mapSizeRange('1,700 employees')).toBe('1001-5000')
 			expect(mapSizeRange('1.700 empleados')).toBe('1001-5000')
 			// AND a size written as a long sentence still buckets on its first integer,

--- a/packages/research/src/application/vocabulary-guard.ts
+++ b/packages/research/src/application/vocabulary-guard.ts
@@ -14,9 +14,11 @@
  * dropped downstream.
  */
 
-import { isBuyingRole } from '@batuda/domain'
-
-import { CRM_SIZE_RANGES, type CrmSizeRange } from '../domain/crm-vocabulary'
+import {
+	COMPANY_SIZE_RANGES,
+	type CompanySizeRange,
+	isBuyingRole,
+} from '@batuda/domain'
 
 // Trim, lowercase, and strip accents so "Manufactura"/"manufactura" and
 // "Girona"/"girona" fold onto one keyword table.
@@ -60,16 +62,16 @@ export const cleanIndustryLabel = (raw: string): string | null => {
 	return raw.trim().replace(/\s+/g, ' ')
 }
 
-export const mapSizeRange = (raw: string): CrmSizeRange | null => {
+export const mapSizeRange = (raw: string): CompanySizeRange | null => {
 	const n = normalize(raw)
 	if (isHardJunk(n)) return null
-	if ((CRM_SIZE_RANGES as readonly string[]).includes(n))
-		return n as CrmSizeRange
+	if ((COMPANY_SIZE_RANGES as readonly string[]).includes(n))
+		return n as CompanySizeRange
 	// Take the first integer — a single head-count, or the lower bound of an
-	// "N-M" / "N to M" range — and bucket it; a value above the top bracket falls
-	// to the closest one. A qualitative size ("SME", "small") has no integer → null.
+	// "N-M" / "N to M" range — and bucket it; the top band is open, so a very large
+	// number lands there. A qualitative size ("SME", "small") has no integer → null.
 	// Strip a thousands separator sitting between digits first ("1,700" / "1.700"
-	// employees), or the match would read "1" and bucket a 1,700-person company as 1-5.
+	// employees), or the match would read "1" and bucket a 1,700-person company as 1-10.
 	const firstInt = n.replace(/(?<=\d)[.,](?=\d)/g, '').match(/\d+/)?.[0]
 	if (firstInt === undefined) return null
 	const count = Number(firstInt)

--- a/packages/research/src/domain/crm-vocabulary.ts
+++ b/packages/research/src/domain/crm-vocabulary.ts
@@ -1,17 +1,3 @@
-// The one classification field research still rewrites to a fixed code. A trade
-// is no longer among them: each organisation keeps its own list, so the words a
-// page uses are stored as written and only the size bands are folded.
-//
-// Read from the CRM's own list rather than copied. This used to be a copy kept in
-// step by a test, which could only ever prove the two were equal — never that
-// they were right — and left a window in which a band added to one silently did
-// not exist in the other.
-
-import { COMPANY_SIZE_RANGES } from '@batuda/domain'
-
-export const CRM_SIZE_RANGES = COMPANY_SIZE_RANGES
-export type CrmSizeRange = (typeof CRM_SIZE_RANGES)[number]
-
 // What a research run is shown of a company or contact it already holds, so it can
 // spot a value the evidence contradicts and propose a correction. Deliberately
 // narrower than everything stored: the pipeline stage, who owns the lead, when

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -143,8 +143,6 @@ export {
 // ── Domain ─────────────────────────────────────────────────────────────────
 export { AcceptedCountry } from './domain/country'
 export {
-	CRM_SIZE_RANGES,
-	type CrmSizeRange,
 	SNAPSHOT_COMPANY_FIELDS,
 	SNAPSHOT_CONTACT_FIELDS,
 } from './domain/crm-vocabulary'


### PR DESCRIPTION
## What

A product could record which trades it was meant to be sold into — a "target industries" list on each thing you sell. Nothing ever read it: no filter, no screen, and the research pipeline never saw it. It was written in five places and consumed in none.

The information itself isn't lost, because it was never the only copy. Every organisation already states who it sells to in its standing instructions, in prose — *"I sell websites, online booking, and workflow automation to small businesses in Catalonia and Spain — restaurants, hospitality, retail, and light manufacturing"* — and that sentence is the form that actually reaches the research model, alongside the pain each offer removes and the price it goes for. A structured list beside that prose was a second answer to one question, kept by hand, with nothing checking the two agreed.

This is CRM data, touching `server` (the migration and the agent tool), `cli` (the seeds), and the shared `domain` and `controllers` packages. A second commit clears up fossils the previous trades change left in `research`.

A third commit is unrelated to any of that: CI on this branch caught a real concurrency bug in the trades code that merged last week, and since it was what turned the build red, I fixed it here rather than leaving the branch blocked.

## Changes

- **Dropped `products.target_industries`** and every place that wrote it: the domain model, both route inputs, both halves of the `create_product` / `update_product` agent tool, and the seed fixtures.
- **Fixed a collision when several people name the same new trade at once.** The insert that creates a trade named one of the table's two unique indexes, which left the other free to raise — so a caller could be handed a server error instead of the trade somebody else had just made a moment earlier. It takes three or more writers at once to show, which is why it passed every local run and only surfaced in CI.
- **Removed three leftovers from the trades PR.** `packages/research` used to keep its own copy of the size bands so the package stayed clear of workspace dependencies, with a test proving the copy matched the CRM's. When that boundary went, the copy became a plain re-export — leaving two names for one array, both published from the package, so a reader could import either and believe they differed. Two comments still bucketed a large company into a band the size reshape removed, and one view schema was exported from `controllers` and imported by nothing.

## Impact

- **Migration `0059` must run before the server tag.** It is a `DROP COLUMN` — destructive and deliberate, marked `expand-contract` in the file, because this same change removes every writer. Deploying the server tag against an unmigrated database is fine in this direction, but the migration and the tag should still go together.
- **A caller still sending the field is ignored, not refused.** Effect's decoding defaults to `onExcessProperty: "ignore"` (`SchemaAST.ts:446`), which strips unknown keys — so an agent or client that still passes `target_industries` keeps working, and the value simply stops being stored. It was going nowhere before, so nothing observable changes for them.
- **Package API narrowed.** `@batuda/research` no longer exports `CRM_SIZE_RANGES` or `CrmSizeRange`. Nothing outside the package imported either; the one internal consumer now reads `COMPANY_SIZE_RANGES` from `@batuda/domain` directly.
- **The concurrency fix is server-side only** and needs no migration: it changes which unique indexes the insert treats as a conflict, not the schema. Both surfaces get it, since agents and the browser share the service.
- **Nothing else.** No row-level-security or tenant-isolation change, no new environment variables, no auth or CORS surface, no webhook or spend behaviour. The agent tools and the HTTP routes lose the field together, so the two transports stay in step.

## Review guide

- **Start at the migration** — [`0059_drop_product_target_industries.ts`](apps/server/src/db/migrations/0059_drop_product_target_industries.ts). Its header carries the whole argument for the change; the rest of the first commit is the five write sites falling away.
- **The riskiest part is the concurrency fix**, not the removal. Read [`company-industries.ts`](apps/server/src/services/company-industries.ts) around the insert: dropping the named index widens what counts as a conflict, which is only safe because the two unique indexes express the same rule — the slug is the folded name with its spaces hyphenated, so neither can fire without the other. If you disagree that they are in step, that is the thing to push back on.
- **The rest is deletion.** The only other behavioural surface is the ignored-key note above, and it is a no-op for callers.
- **A decision you might overrule:** `packages/research/src/domain/crm-vocabulary.ts` now holds only the `SNAPSHOT_*` field lists, so its name is a slight mismatch — it is no longer a vocabulary. I left the filename alone rather than renaming a file for cosmetics; say the word if you'd rather it moved.
- **Not a UI change** — no `apps/internal` or `packages/ui` files in the diff, so there are no screenshots to attach.
- **Not run:** Snyk (tool unavailable here) and the readability / accessibility reviewer agents (session policy is not to spawn subagents unless asked); I self-reviewed instead. I also skipped `/code-review` and `/security-review` deliberately — this is a pure removal with no auth, tenant-isolation, parser or external-input surface for either to bite on.

## Tests

The race test now asserts that nobody failed, rather than only that the survivors agreed on one id — which is why a raised error used to read as a passing run. It races six writers instead of four. I checked it both ways: on the old code it fails 2 runs in 15, and on the fixed code 0 in 15. It is a probabilistic test, so it catches a regression across a few CI runs rather than on the first.

Otherwise no new tests. The removal takes away a field nothing read, and the paths that lost it — creating and updating a product over HTTP and over the agent surface, and the seeds — are already covered by the existing suites, which pass unchanged. One comment in the size-band test was corrected where it still named a band the size reshape removed.

## Verification

- Gates: `pnpm install` (no lockfile drift) → `pnpm -w check-types` (13/13) → `pnpm -w test` (21/21 packages) → `pnpm -w build` (13/13).
- `apps/server` integration suite: 82 files, 546 tests, 0 failures — run again by the pre-push hook.
- Migration applied to the worktree's database, then confirmed by querying `information_schema` that `products.target_industries` no longer exists.
- `pnpm cli db reset && pnpm cli seed` — seven products land with no complaint.
- Read `/v1/products` through a real signed-in browser session: 200, seven rows, and `targetIndustries` absent from the returned keys.
- Full Playwright suite: 128 passed, 6 skipped, 1 flaky (`attachment.test.ts`, mail-catcher timing) which passes on its own and touches nothing near products.
- The concurrency bug reproduced directly before fixing: 150 rounds of four concurrent writers against the real schema shape raised on 41 rounds with the index named, and on 0 with it not named.
- All three commits type-check on their own, so this trail can rebase-merge rather than needing a squash.
