### PR TITLE
Let agents assign a company to a colleague, and fix two data-integrity bugs

### DIFF
--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -26,6 +26,7 @@ import {
 	InstructionsMcpTools,
 } from './tools/instructions-mcp'
 import { InteractionHandlersLive, InteractionTools } from './tools/interactions'
+import { MemberHandlersLive, MemberTools } from './tools/members'
 import { PageHandlersLive, PageTools } from './tools/pages'
 import { PipelineHandlersLive, PipelineTools } from './tools/pipeline'
 import { ProductHandlersLive, ProductTools } from './tools/products'
@@ -50,6 +51,7 @@ import { TimelineHandlersLive, TimelineTools } from './tools/timeline'
 export const McpToolsLive = Layer.mergeAll(
 	mcpToolkitSafe(CompanyTools),
 	mcpToolkitSafe(ContactTools),
+	mcpToolkitSafe(MemberTools),
 	mcpToolkitSafe(InteractionTools),
 	mcpToolkitSafe(TaskTools),
 	mcpToolkitSafe(DocumentTools),
@@ -82,6 +84,7 @@ export const McpToolsLive = Layer.mergeAll(
 ).pipe(
 	Layer.provide(CompanyHandlersLive),
 	Layer.provide(ContactHandlersLive),
+	Layer.provide(MemberHandlersLive),
 	Layer.provide(InteractionHandlersLive),
 	Layer.provide(TaskHandlersLive),
 	Layer.provide(DocumentHandlersLive),

--- a/apps/server/src/mcp/tools/_annotations.test.ts
+++ b/apps/server/src/mcp/tools/_annotations.test.ts
@@ -13,6 +13,7 @@ import { DocumentTools } from './documents'
 import { EmailTools } from './email'
 import { InstructionsMcpTools } from './instructions-mcp'
 import { InteractionTools } from './interactions'
+import { MemberTools } from './members'
 import { PageTools } from './pages'
 import { PipelineTools } from './pipeline'
 import { ProductTools } from './products'
@@ -33,6 +34,7 @@ const TOOLKITS = {
 	EmailTools,
 	InstructionsMcpTools,
 	InteractionTools,
+	MemberTools,
 	PageTools,
 	PipelineTools,
 	ProductTools,
@@ -56,7 +58,7 @@ const isActionParameterized = (toolName: string): boolean =>
 // A floor, not an exact figure: adding one tool should not fail this file, but
 // registering a whole toolkit in the server without listing it in TOOLKITS
 // above should, since everything below only walks what is listed there.
-const EXPECTED_TOOL_COUNT = 94
+const EXPECTED_TOOL_COUNT = 95
 
 const READ_ONLY_NAME = /^(list_|get_|search_|find_|lookup_)/
 const DESTRUCTIVE_NAME = /^(delete_|discard_|cancel_)/

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -93,6 +93,10 @@ const companyInputFields = {
 			'The number the company is registered or taxed under — a Spanish NIF/CIF, a UK company number, an EU VAT number. Copy it exactly as printed; punctuation and case are ignored when matching. Supplying it is the surest way to avoid creating a company you already hold under a different name.',
 	}),
 	status: Schema.optional(CompanyStatus),
+	ownerId: Schema.optional(Schema.String).annotate({
+		description:
+			'The colleague who will work this company, as a user id from list_members — a name or an email address is not one. Leave it out to create the company unowned and assign it later with update_company.',
+	}),
 	industry: Schema.optional(Schema.String),
 	sizeRange: Schema.optional(CompanySizeRange),
 	country: Schema.optional(CompanyCountry),
@@ -124,7 +128,7 @@ const CompanyInput = Schema.Struct(companyInputFields)
 // version drifted: it offered three statuses the app has never had and a priority
 // range twice the real one, and assistants followed it into rows that show up in
 // no board column. Now the sentence cannot say anything the schema would refuse.
-export const CREATE_COMPANIES_DESCRIPTION = `Create one or more companies in a single call — pass \`companies\` as an array (a single element to create just one, the whole shortlist to load a batch). Slug: unique kebab-case from name. Status: ${COMPANY_STATUSES.join('|')} (default: prospect). Priority: ${COMPANY_PRIORITIES[0]} (highest) to ${COMPANY_PRIORITIES[COMPANY_PRIORITIES.length - 1]} (lowest, default: 2). Pass taxId whenever you know it: a company is skipped if its slug already exists OR its registration number already does, so the number catches the same firm arriving under a different trading name. Runs in one transaction; a skip is not an error, so re-running an overlapping list is safe. Returns { created, skipped, possible_duplicates }: the rows that landed, for each one left out its slug plus matched_on ("slug" or "tax_id") saying which identity already existed, and any company that looks like one already on file under a different name — reported, not blocked, so check those before treating them as new.`
+export const CREATE_COMPANIES_DESCRIPTION = `Create one or more companies in a single call — pass \`companies\` as an array (a single element to create just one, the whole shortlist to load a batch). Slug: unique kebab-case from name. Status: ${COMPANY_STATUSES.join('|')} (default: prospect). ownerId assigns the colleague who will work the company — pass a user id from list_members, or leave it out to create it unowned. It only lands on companies actually created: a skipped duplicate keeps the owner it already had, so re-sending a list is never a way to hand companies over. Use update_company for that. Priority: ${COMPANY_PRIORITIES[0]} (highest) to ${COMPANY_PRIORITIES[COMPANY_PRIORITIES.length - 1]} (lowest, default: 2). Pass taxId whenever you know it: a company is skipped if its slug already exists OR its registration number already does, so the number catches the same firm arriving under a different trading name. Runs in one transaction; a skip is not an error, so re-running an overlapping list is safe. Returns { created, skipped, possible_duplicates }: the rows that landed, for each one left out its slug plus matched_on ("slug" or "tax_id") saying which identity already existed, and any company that looks like one already on file under a different name — reported, not blocked, so check those before treating them as new.`
 
 const CreateCompanies = Tool.make('create_companies', {
 	description: CREATE_COMPANIES_DESCRIPTION,
@@ -406,25 +410,14 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 						})),
 						possible_duplicates: possibleDuplicates,
 					}
-				}).pipe(Effect.orDie),
+				}).pipe(
+					Effect.catchTag('BadRequest', e =>
+						Effect.die(new ToolMessage(e.message)),
+					),
+					Effect.orDie,
+				),
 			update_company: ({ id, ...fields }) =>
 				Effect.gen(function* () {
-					// An owner has to be somebody who works here. Row-level security
-					// keeps this lookup to the current organisation, so an id from
-					// another one finds nothing and is turned away — without it a
-					// company could be handed to a stranger, and the only sign would be
-					// a name nobody recognises on the lead.
-					if (fields.ownerId !== undefined && fields.ownerId !== null) {
-						const member = yield* sql`
-							SELECT 1 FROM member WHERE "userId" = ${fields.ownerId} LIMIT 1
-						`
-						if (member.length === 0)
-							return yield* Effect.die(
-								new ToolMessage(
-									'That user is not a member of this organization — call list_members for the ids of people who are.',
-								),
-							)
-					}
 					// Capture the stage before the write so an agent-driven change
 					// is recorded on the timeline too (actor unknown → null).
 					const before =
@@ -448,7 +441,12 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 						actorUserId: null,
 					}).pipe(Effect.provideService(TimelineActivityService, timeline))
 					return result
-				}).pipe(Effect.orDie),
+				}).pipe(
+					Effect.catchTag('BadRequest', e =>
+						Effect.die(new ToolMessage(e.message)),
+					),
+					Effect.orDie,
+				),
 			manage_company_sites: params =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -167,6 +167,10 @@ const UpdateCompany = Tool.make('update_company', {
 			description:
 				'The number the company is registered or taxed under. Worth writing down once a registry lookup returns it — a later lookup can then resolve this company exactly instead of paying to search by name again.',
 		}),
+		ownerId: Schema.optional(Schema.NullOr(Schema.String)).annotate({
+			description:
+				'The colleague responsible for working this company through the pipeline, as a user id from list_members — a name or an email address is not one. Send null to release it, leaving the company unowned. Read list_members first rather than guessing an id: an id belonging to nobody here is refused, and one belonging to the wrong colleague is not.',
+		}),
 		status: Schema.optional(CompanyStatus),
 		industry: Schema.optional(Schema.String),
 		sizeRange: Schema.optional(CompanySizeRange),
@@ -405,6 +409,22 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 				}).pipe(Effect.orDie),
 			update_company: ({ id, ...fields }) =>
 				Effect.gen(function* () {
+					// An owner has to be somebody who works here. Row-level security
+					// keeps this lookup to the current organisation, so an id from
+					// another one finds nothing and is turned away — without it a
+					// company could be handed to a stranger, and the only sign would be
+					// a name nobody recognises on the lead.
+					if (fields.ownerId !== undefined && fields.ownerId !== null) {
+						const member = yield* sql`
+							SELECT 1 FROM member WHERE "userId" = ${fields.ownerId} LIMIT 1
+						`
+						if (member.length === 0)
+							return yield* Effect.die(
+								new ToolMessage(
+									'That user is not a member of this organization — call list_members for the ids of people who are.',
+								),
+							)
+					}
 					// Capture the stage before the write so an agent-driven change
 					// is recorded on the timeline too (actor unknown → null).
 					const before =

--- a/apps/server/src/mcp/tools/members-and-owner.integration.test.ts
+++ b/apps/server/src/mcp/tools/members-and-owner.integration.test.ts
@@ -163,6 +163,41 @@ const setOwner = (
 		),
 	)
 
+// Creates companies through the tool, the way an agent would, so the owner it
+// carries goes through the same check a written owner does.
+const createCompanies = (
+	org: Org,
+	companies: ReadonlyArray<{ name: string; slug: string; ownerId?: string }>,
+): Promise<{ ok: true; created: number } | { ok: false; message: string }> =>
+	callInOrg(
+		org,
+		Effect.gen(function* () {
+			const toolkit = yield* CompanyTools
+			const stream = yield* toolkit.handle('create_companies', { companies })
+			const [first] = yield* Stream.runCollect(stream)
+			if (first === undefined)
+				return yield* Effect.die(
+					new Error('create_companies produced no result'),
+				)
+			const result = first.result as { created: ReadonlyArray<unknown> }
+			return { ok: true as const, created: result.created.length }
+		}).pipe(
+			Effect.provideService(CurrentUser, actor()),
+			Effect.provide(CompanyHandlers),
+			Effect.catchCause(cause =>
+				Effect.succeed({ ok: false as const, message: String(cause) }),
+			),
+		),
+	)
+
+const countCompanies = async (slugPrefix: string): Promise<number> => {
+	const r = await pool.query<{ n: string }>(
+		'SELECT count(*)::text AS n FROM companies WHERE slug LIKE $1',
+		[`${slugPrefix}%`],
+	)
+	return Number(r.rows[0]?.n ?? 0)
+}
+
 const seedCompany = async (orgId: string): Promise<string> => {
 	const r = await pool.query<{ id: string }>(
 		`INSERT INTO companies (organization_id, slug, name)
@@ -193,6 +228,28 @@ afterAll(async () => {
 	await runtime.dispose()
 	await pool.end()
 })
+
+// The web app does not go through the tools — it calls the service straight.
+// The check has to catch it there too, which is the whole reason it lives beside
+// the write rather than in the tool.
+const setOwnerViaService = (
+	org: Org,
+	companyId: string,
+	ownerId: string,
+): Promise<{ ok: true } | { ok: false; message: string }> =>
+	callInOrg(
+		org,
+		Effect.gen(function* () {
+			const service = yield* CompanyService
+			yield* service.update(companyId, { ownerId })
+			return { ok: true as const }
+		}).pipe(
+			Effect.provide(CompanyService.layer),
+			Effect.catchCause(cause =>
+				Effect.succeed({ ok: false as const, message: String(cause) }),
+			),
+		),
+	)
 
 describe('list_members', () => {
 	describe('when read inside an organization', () => {
@@ -252,6 +309,94 @@ describe('list_members', () => {
 	})
 })
 
+describe('create_companies owner', () => {
+	describe('when a new company names a colleague', () => {
+		it('should create it already belonging to them', async () => {
+			// GIVEN a colleague here and a company to open in their name
+			const [member] = await listMembers(taller)
+			const slug = `${MARKER}-create-${randomUUID()}`
+
+			// WHEN the company is created carrying that owner
+			const result = await createCompanies(taller, [
+				{ name: 'Created Owned', slug, ownerId: member!.user_id },
+			])
+
+			// THEN it lands owned, with nobody having to assign it afterwards
+			expect(result.ok).toBe(true)
+			const r = await pool.query<{ id: string; owner_id: string | null }>(
+				'SELECT id, owner_id FROM companies WHERE slug = $1',
+				[slug],
+			)
+			expect(r.rows[0]?.owner_id).toBe(member!.user_id)
+		})
+	})
+
+	describe('when a batch names somebody from another organization', () => {
+		it('should create none of it, not just skip the one', async () => {
+			// GIVEN a batch whose second company names an outsider — the call lands
+			// in one transaction, so a partial write would leave the caller working
+			// out which ones missed
+			const outsider = await memberOnlyIn(restaurant.id, taller.id)
+			const prefix = `${MARKER}-batch-${randomUUID()}`
+			const result = await createCompanies(taller, [
+				{ name: 'Fine', slug: `${prefix}-a` },
+				{ name: 'Stranger', slug: `${prefix}-b`, ownerId: outsider },
+			])
+
+			// THEN the whole call is refused and nothing was written
+			expect(result.ok).toBe(false)
+			if (result.ok) return
+			expect(result.message).toContain('not a member')
+			expect(await countCompanies(prefix)).toBe(0)
+		})
+	})
+
+	describe('when a company already on file is sent again with a new owner', () => {
+		it('should leave the owner it had, since a duplicate is skipped not rewritten', async () => {
+			// GIVEN a company created for one colleague, and a second colleague to
+			// try to hand it to
+			const members = await listMembers(taller)
+			const [first, second] = members
+			const slug = `${MARKER}-reassign-${randomUUID()}`
+			await createCompanies(taller, [
+				{ name: 'Already Here', slug, ownerId: first!.user_id },
+			])
+
+			// WHEN the same company is sent again naming somebody else
+			const again = await createCompanies(taller, [
+				{ name: 'Already Here', slug, ownerId: second!.user_id },
+			])
+
+			// THEN it is skipped and the original owner stands — re-sending a list is
+			// not a way to hand companies over, which is why the tool says so
+			expect(again.ok).toBe(true)
+			const r = await pool.query<{ owner_id: string | null }>(
+				'SELECT owner_id FROM companies WHERE slug = $1',
+				[slug],
+			)
+			expect(r.rows[0]?.owner_id).toBe(first!.user_id)
+		})
+	})
+
+	describe('when a new company names nobody', () => {
+		it('should create it unowned', async () => {
+			// GIVEN a company created without an owner
+			const slug = `${MARKER}-unowned-${randomUUID()}`
+			const result = await createCompanies(taller, [
+				{ name: 'Created Unowned', slug },
+			])
+
+			// THEN it exists with nobody responsible for it yet
+			expect(result.ok).toBe(true)
+			const r = await pool.query<{ owner_id: string | null }>(
+				'SELECT owner_id FROM companies WHERE slug = $1',
+				[slug],
+			)
+			expect(r.rows[0]?.owner_id).toBeNull()
+		})
+	})
+})
+
 describe('update_company owner', () => {
 	describe('when the owner works here', () => {
 		it('should record them as responsible for the company', async () => {
@@ -264,6 +409,36 @@ describe('update_company owner', () => {
 
 			// THEN the company is theirs
 			expect(result.ok).toBe(true)
+			expect(await ownerOf(companyId)).toBe(member!.user_id)
+		})
+	})
+
+	describe('when an unrelated field is updated', () => {
+		it('should leave the owner alone, since omitting is not clearing', async () => {
+			// GIVEN a company that already belongs to somebody
+			const companyId = await seedCompany(taller.id)
+			const [member] = await listMembers(taller)
+			await setOwner(taller, companyId, member!.user_id)
+
+			// WHEN something else about it changes, with no owner mentioned
+			await callInOrg(
+				taller,
+				Effect.gen(function* () {
+					const toolkit = yield* CompanyTools
+					const stream = yield* toolkit.handle('update_company', {
+						id: companyId,
+						industry: 'logistics',
+					})
+					yield* Stream.runCollect(stream)
+				}).pipe(
+					Effect.provideService(CurrentUser, actor()),
+					Effect.provide(CompanyHandlers),
+					Effect.catchCause(() => Effect.void),
+				),
+			)
+
+			// THEN they still own it — an edit that quietly unassigned the lead
+			// would be noticed by nobody
 			expect(await ownerOf(companyId)).toBe(member!.user_id)
 		})
 	})
@@ -299,6 +474,25 @@ describe('update_company owner', () => {
 			if (result.ok) return
 			expect(result.message).toContain('not a member')
 			expect(result.message).toContain('list_members')
+			expect(await ownerOf(companyId)).toBeNull()
+		})
+	})
+
+	describe('when the web app assigns an owner from another organization', () => {
+		it('should refuse there too, not only through the tools', async () => {
+			// GIVEN the path the company page itself uses, which never touches the
+			// MCP tools
+			const companyId = await seedCompany(taller.id)
+			const outsider = await memberOnlyIn(restaurant.id, taller.id)
+
+			// WHEN it is asked to hand the company to somebody from elsewhere
+			const result = await setOwnerViaService(taller, companyId, outsider)
+
+			// THEN it is refused on the same terms — a rule that only one way in
+			// obeys is not a rule
+			expect(result.ok).toBe(false)
+			if (result.ok) return
+			expect(result.message).toContain('not a member')
 			expect(await ownerOf(companyId)).toBeNull()
 		})
 	})

--- a/apps/server/src/mcp/tools/members-and-owner.integration.test.ts
+++ b/apps/server/src/mcp/tools/members-and-owner.integration.test.ts
@@ -1,0 +1,325 @@
+// Exercises the two halves of assigning a company to a colleague end-to-end
+// against a real Postgres, driven through the real toolkit handlers the way a
+// `tools/call` would, inside the same org RLS scope (`enterOrgScope`) the /mcp
+// middleware applies: reading the member directory, and writing an owner onto a
+// company. The cross-org cases are the point of the suite — the directory and
+// the owner it accepts both have to stop at the organisation boundary, or a
+// company can be handed to somebody who does not work there. Uses the seeded
+// `taller` and `restaurant` orgs. Requires $DATABASE_URL.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../../db/client'
+import { EnvVars } from '../../lib/env'
+import { enterOrgScope } from '../../middleware/org'
+import { CompanyService } from '../../services/companies'
+import { Geocoder } from '../../services/geocoder'
+import { TimelineActivityService } from '../../services/timeline-activity'
+import { applyTestEnv } from '../../test-env'
+import { CurrentUser } from '../current-user'
+import { CompanyHandlersLive, CompanyTools } from './companies'
+import { MemberHandlersLive, MemberTools } from './members'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+const MARKER = `owner-verify-${randomUUID()}`
+
+type Org = { id: string; name: string; slug: string }
+type Member = { user_id: string; name: string | null; email: string }
+
+const CompanyHandlers = CompanyHandlersLive.pipe(
+	Layer.provide(CompanyService.layer),
+	Layer.provide(TimelineActivityService.layer),
+	Layer.provide(Geocoder.layer),
+	Layer.provide(FetchHttpClient.layer),
+)
+const makeRuntime = () =>
+	ManagedRuntime.make(PgLive.pipe(Layer.provide(EnvVars.layer)))
+
+let pool: pg.Pool
+let runtime: ReturnType<typeof makeRuntime>
+let taller: Org
+let restaurant: Org
+let actorId: string
+
+const orgBySlug = async (slug: string): Promise<Org> => {
+	const r = await pool.query<Org>(
+		'SELECT id, name, slug FROM organization WHERE slug = $1 LIMIT 1',
+		[slug],
+	)
+	const row = r.rows[0]
+	if (!row)
+		throw new Error(
+			`${slug} org missing — run 'pnpm cli db reset && pnpm cli seed'`,
+		)
+	return row
+}
+
+const anyMemberOf = async (orgId: string): Promise<string> => {
+	const r = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 LIMIT 1',
+		[orgId],
+	)
+	const id = r.rows[0]?.userId
+	if (!id) throw new Error(`org ${orgId} has no members — run 'pnpm cli seed'`)
+	return id
+}
+
+// Somebody who works in one organisation and not the other. People can belong
+// to several, so a plain "member of the restaurant" may work in the workshop
+// too, and would rightly be accepted as an owner there.
+const memberOnlyIn = async (orgId: string, notIn: string): Promise<string> => {
+	const r = await pool.query<{ userId: string }>(
+		`SELECT "userId" FROM member
+		 WHERE "organizationId" = $1
+			 AND "userId" NOT IN (SELECT "userId" FROM member WHERE "organizationId" = $2)
+		 LIMIT 1`,
+		[orgId, notIn],
+	)
+	const id = r.rows[0]?.userId
+	if (!id)
+		throw new Error(
+			`no user belongs to ${orgId} alone — run 'pnpm cli db reset && pnpm cli seed'`,
+		)
+	return id
+}
+
+// Every tool call carries who is making it; these tests are about which
+// organisation the caller is in, not which colleague, so one stands in for all.
+const actor = () => ({
+	userId: actorId,
+	email: `${actorId}@verify.local`,
+	name: 'Verifier',
+	isAgent: true,
+})
+
+// Runs a tool the way the MCP server does — validate params, run the handler,
+// take its single result — inside the given org's RLS scope.
+const callInOrg = <A, E>(
+	org: Org,
+	body: Effect.Effect<A, E, CurrentOrg | SqlClient.SqlClient>,
+): Promise<A> =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org, userId: actorId })(body)
+		}),
+	)
+
+const listMembers = (
+	org: Org,
+	query?: string,
+): Promise<ReadonlyArray<Member>> =>
+	callInOrg(
+		org,
+		Effect.gen(function* () {
+			const toolkit = yield* MemberTools
+			const stream = yield* toolkit.handle(
+				'list_members',
+				query === undefined ? {} : { query },
+			)
+			const [first] = yield* Stream.runCollect(stream)
+			if (first === undefined)
+				return yield* Effect.die(new Error('list_members produced no result'))
+			return (first.result as { members: ReadonlyArray<Member> }).members
+		}).pipe(
+			Effect.provideService(CurrentUser, actor()),
+			Effect.provide(MemberHandlersLive),
+		),
+	)
+
+// The tool dies with a ToolMessage when an owner is refused, which is how the
+// MCP layer turns a bad argument into something the caller can read.
+const setOwner = (
+	org: Org,
+	companyId: string,
+	ownerId: string | null,
+): Promise<{ ok: true } | { ok: false; message: string }> =>
+	callInOrg(
+		org,
+		Effect.gen(function* () {
+			const toolkit = yield* CompanyTools
+			const stream = yield* toolkit.handle('update_company', {
+				id: companyId,
+				ownerId,
+			})
+			yield* Stream.runCollect(stream)
+			return { ok: true as const }
+		}).pipe(
+			Effect.provideService(CurrentUser, actor()),
+			Effect.provide(CompanyHandlers),
+			Effect.catchCause(cause =>
+				Effect.succeed({ ok: false as const, message: String(cause) }),
+			),
+		),
+	)
+
+const seedCompany = async (orgId: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, 'Owner Probe') RETURNING id`,
+		[orgId, `${MARKER}-${randomUUID()}`],
+	)
+	return r.rows[0]!.id
+}
+
+const ownerOf = async (companyId: string): Promise<string | null> => {
+	const r = await pool.query<{ owner_id: string | null }>(
+		'SELECT owner_id FROM companies WHERE id = $1',
+		[companyId],
+	)
+	return r.rows[0]?.owner_id ?? null
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	runtime = makeRuntime()
+	taller = await orgBySlug('taller')
+	restaurant = await orgBySlug('restaurant')
+	actorId = await anyMemberOf(taller.id)
+})
+
+afterAll(async () => {
+	await pool.query('DELETE FROM companies WHERE slug LIKE $1', [`${MARKER}%`])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('list_members', () => {
+	describe('when read inside an organization', () => {
+		it('should return the people who work there, with the ids other tools need', async () => {
+			// GIVEN the seeded workshop organisation
+			const members = await listMembers(taller)
+
+			// THEN its colleagues come back, each carrying the id an owner or an
+			// assignee is set by
+			expect(members.length).toBeGreaterThan(0)
+			for (const member of members) {
+				expect(member.user_id).not.toBe('')
+				expect(member.email).toContain('@')
+			}
+		})
+	})
+
+	describe('when another organization reads it', () => {
+		it('should leave out somebody who only works in the other one', async () => {
+			// GIVEN a colleague who belongs to the restaurant and nowhere else —
+			// people can hold membership of several organisations, so only these
+			// prove the boundary
+			const outsider = await memberOnlyIn(restaurant.id, taller.id)
+
+			// WHEN the workshop reads its directory
+			const tallerIds = (await listMembers(taller)).map(m => m.user_id)
+
+			// THEN they are not in it, though the restaurant's own directory has them
+			expect(tallerIds.length).toBeGreaterThan(0)
+			expect(tallerIds).not.toContain(outsider)
+			expect((await listMembers(restaurant)).map(m => m.user_id)).toContain(
+				outsider,
+			)
+		})
+	})
+
+	describe('when a query is given', () => {
+		it('should match on part of an email, case-insensitively', async () => {
+			// GIVEN a fragment taken from a real colleague's address
+			const [first] = await listMembers(taller)
+			const fragment = first!.email.slice(0, 4).toUpperCase()
+
+			// THEN searching for it in the wrong case still finds them
+			const found = await listMembers(taller, fragment)
+			expect(found.map(m => m.user_id)).toContain(first!.user_id)
+		})
+	})
+
+	describe('when the query matches nobody', () => {
+		it('should come back empty rather than falling back to everyone', async () => {
+			// GIVEN a name nobody here has
+			const found = await listMembers(taller, 'zzz-nobody-by-this-name')
+
+			// THEN the caller is told plainly that there is no match
+			expect(found).toEqual([])
+		})
+	})
+})
+
+describe('update_company owner', () => {
+	describe('when the owner works here', () => {
+		it('should record them as responsible for the company', async () => {
+			// GIVEN a company and a colleague from the same organisation
+			const companyId = await seedCompany(taller.id)
+			const [member] = await listMembers(taller)
+
+			// WHEN they are made its owner
+			const result = await setOwner(taller, companyId, member!.user_id)
+
+			// THEN the company is theirs
+			expect(result.ok).toBe(true)
+			expect(await ownerOf(companyId)).toBe(member!.user_id)
+		})
+	})
+
+	describe('when the owner is cleared', () => {
+		it('should leave the company unowned rather than untouched', async () => {
+			// GIVEN a company that already belongs to somebody
+			const companyId = await seedCompany(taller.id)
+			const [member] = await listMembers(taller)
+			await setOwner(taller, companyId, member!.user_id)
+
+			// WHEN the lead is released
+			await setOwner(taller, companyId, null)
+
+			// THEN nobody is responsible for it
+			expect(await ownerOf(companyId)).toBeNull()
+		})
+	})
+
+	describe('when the proposed owner belongs to another organization', () => {
+		it('should refuse, leaving the company unowned', async () => {
+			// GIVEN a company here and somebody who works somewhere else
+			const companyId = await seedCompany(taller.id)
+			const outsider = await memberOnlyIn(restaurant.id, taller.id)
+
+			// WHEN that outsider is proposed as its owner
+			const result = await setOwner(taller, companyId, outsider)
+
+			// THEN the write is turned away, saying why and where to look, and the
+			// company is left as it was — one handed to a stranger would show only
+			// as an unfamiliar name on the lead
+			expect(result.ok).toBe(false)
+			if (result.ok) return
+			expect(result.message).toContain('not a member')
+			expect(result.message).toContain('list_members')
+			expect(await ownerOf(companyId)).toBeNull()
+		})
+	})
+
+	describe('when the proposed owner is nobody at all', () => {
+		it('should refuse an invented id', async () => {
+			// GIVEN an id the model made up
+			const companyId = await seedCompany(taller.id)
+
+			// WHEN it is proposed as the owner
+			const result = await setOwner(
+				taller,
+				companyId,
+				`no-such-user-${randomUUID()}`,
+			)
+
+			// THEN it is refused like any other stranger, for the same stated reason
+			expect(result.ok).toBe(false)
+			if (result.ok) return
+			expect(result.message).toContain('not a member')
+			expect(await ownerOf(companyId)).toBeNull()
+		})
+	})
+})

--- a/apps/server/src/mcp/tools/members.ts
+++ b/apps/server/src/mcp/tools/members.ts
@@ -10,7 +10,7 @@ const REQUEST_DEPENDENCIES = [CurrentOrg, CurrentUser]
 
 const ListMembers = Tool.make('list_members', {
 	description:
-		"The people who work in this organisation — colleagues, not the contacts at companies you sell to. Read it to turn a name somebody said out loud into the id every other tool wants: a company's owner, a task's assignee. Names repeat and nicknames are not stored, so when two people could be meant, ask which rather than guessing — assigning work to the wrong colleague is quiet, and nobody finds out until the work is missed. `query` narrows by name or email; omit it for everyone.",
+		"The people who work in this organization — colleagues, not the contacts at companies you sell to. Read it to turn a name somebody said out loud into an id: each row's `user_id` is what a company's ownerId and a task's assignee_id take. It reads the other way too, for putting a name to an owner you were shown, but only by looking down the list — `query` matches names and emails, never ids. Names repeat and nicknames are not stored, so if more than one person matches, stop and ask which; do not take the first row, the order is alphabetical and means nothing. Assigning work to the wrong colleague is quiet, and nobody finds out until the work is missed. Everyone comes back at once — this list is short and never paged.",
 	parameters: Schema.Struct({
 		query: Schema.optional(Schema.String).annotate({
 			description:

--- a/apps/server/src/mcp/tools/members.ts
+++ b/apps/server/src/mcp/tools/members.ts
@@ -1,0 +1,82 @@
+import { Effect, Schema } from 'effect'
+import { Tool, Toolkit } from 'effect/unstable/ai'
+import { SqlClient, type Statement } from 'effect/unstable/sql'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { CurrentUser } from '../current-user'
+
+const REQUEST_DEPENDENCIES = [CurrentOrg, CurrentUser]
+
+const ListMembers = Tool.make('list_members', {
+	description:
+		"The people who work in this organisation — colleagues, not the contacts at companies you sell to. Read it to turn a name somebody said out loud into the id every other tool wants: a company's owner, a task's assignee. Names repeat and nicknames are not stored, so when two people could be meant, ask which rather than guessing — assigning work to the wrong colleague is quiet, and nobody finds out until the work is missed. `query` narrows by name or email; omit it for everyone.",
+	parameters: Schema.Struct({
+		query: Schema.optional(Schema.String).annotate({
+			description:
+				'Part of a name or email address. Matched loosely and case-insensitively, so "ana" finds Ana Ruiz and ana@…',
+		}),
+	}),
+	success: Schema.Struct({
+		members: Schema.Array(
+			Schema.Struct({
+				user_id: Schema.String,
+				name: Schema.NullOr(Schema.String),
+				email: Schema.String,
+				role: Schema.String,
+			}),
+		),
+	}),
+	dependencies: REQUEST_DEPENDENCIES,
+})
+	.annotate(Tool.Title, 'List Members')
+	.annotate(Tool.Readonly, true)
+	.annotate(Tool.Destructive, false)
+	.annotate(Tool.OpenWorld, false)
+
+export const MemberTools = Toolkit.make(ListMembers)
+
+export const MemberHandlersLive = MemberTools.toLayer(
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		return {
+			list_members: ({ query }) =>
+				Effect.gen(function* () {
+					// No organisation predicate: row-level security scopes `member` to
+					// the org this request runs in, and the join keeps the user rows to
+					// those members. The user table carries no policy of its own, so
+					// reading it any other way would reach across organisations.
+					const conditions: Array<Statement.Fragment> = [sql`TRUE`]
+					if (query !== undefined) {
+						const like = `%${query}%`
+						conditions.push(
+							sql`(u.name ILIKE ${like} OR u.email ILIKE ${like})`,
+						)
+					}
+					// Read back camelCase whatever the column is called — the SQL client
+					// renames every key on the way out — and spelled snake_case again
+					// for the tool result, the way the rest of this surface reads.
+					const rows = yield* sql<{
+						userId: string
+						name: string | null
+						email: string
+						role: string
+					}>`
+						SELECT u.id AS "userId", u.name, u.email, m.role
+						FROM member m
+						JOIN "user" u ON u.id = m."userId"
+						WHERE ${sql.and(conditions)}
+						ORDER BY u.name NULLS LAST, u.email
+					`
+					return {
+						members: rows.map(row => ({
+							user_id: row.userId,
+							name: row.name,
+							email: row.email,
+							role: row.role,
+						})),
+					}
+				}).pipe(Effect.orDie),
+		}
+	}),
+)

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -23,6 +23,7 @@ import {
 	industryForWrite,
 	withIndustry,
 } from './company-industries'
+import { requireOrgMembers } from './org-members'
 import { researchProvenance } from './research-provenance'
 
 export interface CompanyFilters {
@@ -284,6 +285,13 @@ export class CompanyService extends Context.Service<CompanyService>()(
 				createMany: (items: ReadonlyArray<Record<string, unknown>>) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						// Checked before anything lands: the batch is one transaction, so
+						// a single unusable owner refuses the call rather than creating
+						// most of the list and leaving the caller to work out which.
+						yield* requireOrgMembers(
+							sql,
+							items.map(item => item['ownerId']),
+						)
 						const inserted: Array<unknown> = []
 						const skipped: Array<{
 							readonly slug: string
@@ -347,6 +355,7 @@ export class CompanyService extends Context.Service<CompanyService>()(
 				update: (id: string, data: Record<string, unknown>) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
+						yield* requireOrgMembers(sql, [data['ownerId']])
 						// Bumping the version on every edit is what lets a research apply notice
 						// that somebody changed the row while the run was thinking, so its findings
 						// can never quietly overwrite a person's edit.

--- a/apps/server/src/services/org-members.ts
+++ b/apps/server/src/services/org-members.ts
@@ -1,0 +1,50 @@
+import { Effect } from 'effect'
+import type { SqlClient } from 'effect/unstable/sql'
+
+import { BadRequest, CurrentOrg } from '@batuda/controllers'
+
+/**
+ * Refuse a person who does not work here.
+ *
+ * Anywhere a record names somebody — the colleague who owns a company, the one
+ * a task is waiting on — the column holds a plain Better Auth user id with no
+ * foreign key behind it, because the auth stack owns the user table and runs its
+ * own migrations. Nothing in the database will object to an id from another
+ * organisation, or to one that was never a person at all: the write lands, and
+ * the record then matches no per-person view, so the work simply stops appearing
+ * on anybody's list. Nobody is told.
+ *
+ * This lives beside the write rather than in front of it so every way in reaches
+ * it — the tools an assistant calls and the web app's own requests alike.
+ */
+export const requireOrgMembers = (
+	sql: SqlClient.SqlClient,
+	// Taken as unknown because callers hand over raw field maps: an id that is
+	// not a string was never a person, and is refused below rather than here.
+	ids: ReadonlyArray<unknown>,
+) =>
+	Effect.gen(function* () {
+		const currentOrg = yield* CurrentOrg
+		const wanted = [
+			...new Set(
+				ids.filter((id): id is string => typeof id === 'string' && id !== ''),
+			),
+		]
+		if (wanted.length === 0) return
+		// Named in the query as well as left to row-level security: this is the
+		// check that decides whether a person is one of ours, so it should not
+		// depend on the caller having entered org scope correctly.
+		const rows = yield* sql<{ userId: string }>`
+			SELECT "userId" FROM member
+			WHERE "organizationId" = ${currentOrg.id}
+				AND "userId" IN ${sql.in(wanted)}
+		`
+		const known = new Set(rows.map(row => row.userId))
+		const stranger = wanted.find(id => !known.has(id))
+		if (stranger !== undefined)
+			return yield* Effect.fail(
+				new BadRequest({
+					message: `"${stranger}" is not a member of this organization, so nothing was saved — call list_members for the ids of people who are, then try again.`,
+				}),
+			)
+	})

--- a/apps/server/src/services/pipeline-deleted-companies.integration.test.ts
+++ b/apps/server/src/services/pipeline-deleted-companies.integration.test.ts
@@ -1,0 +1,141 @@
+// Live-DB integration test for keeping deleted companies out of the pipeline
+// numbers and the daily-planning list. A deleted company is hidden everywhere a
+// person looks at companies, so a count that still includes it reports a book of
+// business that is not there, and a plan that still includes it sends someone to
+// chase a lead that was dropped.
+//
+// Prereq: `pnpm cli services up` — the integration runner's globalSetup builds,
+// migrates and seeds the disposable database this suite runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../db/client'
+import { applyTestEnv } from '../test-env'
+import { PipelineService } from './pipeline'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+let orgId: string
+
+// Each case seeds its own company: the slug stays unique per organisation even
+// once a row is deleted, so two cases cannot share one.
+const SLUG_PREFIX = `deleted-probe-${randomUUID()}`
+const slugFor = (name: string) => `${SLUG_PREFIX}-${name}`
+
+const asOrg = { id: '', name: 'fixture', slug: 'fixture', role: 'member' }
+
+// Read as the request path does: role app_user, scoped to this org, so row-level
+// security applies exactly as it would in production.
+const statusCountFor = (status: string): Promise<number> => {
+	const deps = PipelineService.layer.pipe(Layer.provideMerge(PgLive))
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const pipeline = yield* PipelineService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				const summary = yield* pipeline
+					.getPipeline()
+					.pipe(Effect.provideService(CurrentOrg, { ...asOrg, id: orgId }))
+				return summary.statusCounts[status] ?? 0
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+}
+
+const overdueSlugs = (): Promise<ReadonlyArray<string>> => {
+	const deps = PipelineService.layer.pipe(Layer.provideMerge(PgLive))
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const pipeline = yield* PipelineService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				const next = yield* pipeline
+					.getNextSteps(50)
+					.pipe(Effect.provideService(CurrentOrg, { ...asOrg, id: orgId }))
+				return next.overdueCompanies.map(company => company.slug)
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+}
+
+// A company carrying an overdue next action, so it lands on the planning list
+// too, not only in the counts.
+const seedCompany = async (slug: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO companies
+			(organization_id, slug, name, status, next_action, next_action_at)
+		 VALUES ($1, $2, $2, 'prospect', 'call them', now() - interval '1 day')
+		 RETURNING id`,
+		[orgId, slug],
+	)
+	return r.rows[0]!.id
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	const org = await pool.query<{ id: string }>(
+		`SELECT id FROM organization LIMIT 1`,
+	)
+	const id = org.rows[0]?.id
+	if (!id) throw new Error('no organization seeded — run the integration setup')
+	orgId = id
+})
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM companies WHERE slug LIKE $1`, [
+		`${SLUG_PREFIX}%`,
+	])
+	await pool.end()
+})
+
+describe('pipeline reads against a deleted company', () => {
+	describe('when a company is deleted', () => {
+		it('should drop out of the status counts it was counted in', async () => {
+			// GIVEN a live prospect, counted in the pipeline
+			const companyId = await seedCompany(slugFor('counts'))
+			const before = await statusCountFor('prospect')
+
+			// WHEN it is deleted
+			await pool.query(
+				`UPDATE companies SET deleted_at = now() WHERE id = $1`,
+				[companyId],
+			)
+
+			// THEN the count it contributed to goes back down
+			expect(await statusCountFor('prospect')).toBe(before - 1)
+		})
+	})
+
+	describe('when a deleted company still has an overdue next action', () => {
+		it('should not appear on the daily planning list', async () => {
+			// GIVEN a company overdue for a next action, on the list
+			const slug = slugFor('planning')
+			const companyId = await seedCompany(slug)
+			expect(await overdueSlugs()).toContain(slug)
+
+			// WHEN it is deleted
+			await pool.query(
+				`UPDATE companies SET deleted_at = now() WHERE id = $1`,
+				[companyId],
+			)
+
+			// THEN nobody is sent to chase a company that was dropped
+			expect(await overdueSlugs()).not.toContain(slug)
+		})
+	})
+})

--- a/apps/server/src/services/pipeline-deleted-companies.integration.test.ts
+++ b/apps/server/src/services/pipeline-deleted-companies.integration.test.ts
@@ -54,6 +54,24 @@ const statusCountFor = (status: string): Promise<number> => {
 	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
 }
 
+const overdueTaskCount = (): Promise<number> => {
+	const deps = PipelineService.layer.pipe(Layer.provideMerge(PgLive))
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const pipeline = yield* PipelineService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				const summary = yield* pipeline
+					.getPipeline()
+					.pipe(Effect.provideService(CurrentOrg, { ...asOrg, id: orgId }))
+				return summary.overdueTaskCount
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+}
+
 const overdueSlugs = (): Promise<ReadonlyArray<string>> => {
 	const deps = PipelineService.layer.pipe(Layer.provideMerge(PgLive))
 	return Effect.gen(function* () {
@@ -136,6 +154,48 @@ describe('pipeline reads against a deleted company', () => {
 
 			// THEN nobody is sent to chase a company that was dropped
 			expect(await overdueSlugs()).not.toContain(slug)
+		})
+	})
+})
+
+describe('the overdue task figure', () => {
+	describe('when an overdue task belongs to no company', () => {
+		it('should still be counted, since it is somebody’s own work', async () => {
+			// GIVEN a standalone overdue task — most of the seeded ones are these
+			const before = await overdueTaskCount()
+			const r = await pool.query<{ id: string }>(
+				`INSERT INTO tasks (organization_id, title, type, due_at)
+				 VALUES ($1, $2, 'todo', now() - interval '1 day') RETURNING id`,
+				[orgId, `${SLUG_PREFIX}-standalone`],
+			)
+
+			// THEN it raises the figure rather than being filtered out with the
+			// company tasks
+			expect(await overdueTaskCount()).toBe(before + 1)
+			await pool.query('DELETE FROM tasks WHERE id = $1', [r.rows[0]!.id])
+		})
+	})
+
+	describe('when an overdue task belongs to a deleted company', () => {
+		it('should drop out of the figure', async () => {
+			// GIVEN an overdue task on a live company
+			const companyId = await seedCompany(slugFor('task-company'))
+			const r = await pool.query<{ id: string }>(
+				`INSERT INTO tasks (organization_id, company_id, title, type, due_at)
+				 VALUES ($1, $2, $3, 'todo', now() - interval '1 day') RETURNING id`,
+				[orgId, companyId, `${SLUG_PREFIX}-owned-task`],
+			)
+			const before = await overdueTaskCount()
+
+			// WHEN the company is deleted
+			await pool.query(
+				'UPDATE companies SET deleted_at = now() WHERE id = $1',
+				[companyId],
+			)
+
+			// THEN the work goes with it — nobody can reach it any more
+			expect(await overdueTaskCount()).toBe(before - 1)
+			await pool.query('DELETE FROM tasks WHERE id = $1', [r.rows[0]!.id])
 		})
 	})
 })

--- a/apps/server/src/services/pipeline.ts
+++ b/apps/server/src/services/pipeline.ts
@@ -177,8 +177,12 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						const overdueTasks = yield* sql<{
 							count: number
 						}>`
-							SELECT count(*)::int as count FROM tasks
-							WHERE completed_at IS NULL AND due_at < now()
+							SELECT count(*)::int as count FROM tasks t
+							WHERE t.completed_at IS NULL AND t.due_at < now()
+								AND EXISTS (
+									SELECT 1 FROM companies c
+									WHERE c.id = t.company_id AND c.deleted_at IS NULL
+								)
 						`
 
 						const companiesWithoutNextAction = yield* sql<{

--- a/apps/server/src/services/pipeline.ts
+++ b/apps/server/src/services/pipeline.ts
@@ -179,9 +179,14 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						}>`
 							SELECT count(*)::int as count FROM tasks t
 							WHERE t.completed_at IS NULL AND t.due_at < now()
-								AND EXISTS (
-									SELECT 1 FROM companies c
-									WHERE c.id = t.company_id AND c.deleted_at IS NULL
+								-- A task belonging to no company is somebody's own work and
+								-- still counts; only one whose company was deleted drops out.
+								AND (
+									t.company_id IS NULL
+									OR EXISTS (
+										SELECT 1 FROM companies c
+										WHERE c.id = t.company_id AND c.deleted_at IS NULL
+									)
 								)
 						`
 

--- a/apps/server/src/services/pipeline.ts
+++ b/apps/server/src/services/pipeline.ts
@@ -54,14 +54,19 @@ export class PipelineService extends Context.Service<PipelineService>()(
 
 			return {
 				getCounts: () =>
-					sql`SELECT status, count(*)::int as count FROM companies GROUP BY status`,
+					sql`
+						SELECT status, count(*)::int as count FROM companies
+						WHERE deleted_at IS NULL
+						GROUP BY status
+					`,
 
 				getOverdueTasks: (limit = 10) =>
 					sql`
 						SELECT t.id, t.title, t.type, t.due_at,
 							t.company_id, c.name as company_name, c.slug as company_slug
 						FROM tasks t
-						INNER JOIN companies c ON t.company_id = c.id
+						INNER JOIN companies c
+							ON t.company_id = c.id AND c.deleted_at IS NULL
 						WHERE t.completed_at IS NULL AND t.due_at < now()
 						ORDER BY t.due_at
 						LIMIT ${limit}
@@ -73,7 +78,8 @@ export class PipelineService extends Context.Service<PipelineService>()(
 							SELECT t.id, t.title, t.type, t.due_at,
 								t.company_id, c.name as company_name, c.slug as company_slug
 							FROM tasks t
-							INNER JOIN companies c ON t.company_id = c.id
+							INNER JOIN companies c
+								ON t.company_id = c.id AND c.deleted_at IS NULL
 							WHERE t.completed_at IS NULL
 							ORDER BY t.due_at
 							LIMIT ${probeLimit(limit)}
@@ -83,6 +89,7 @@ export class PipelineService extends Context.Service<PipelineService>()(
 							SELECT id, slug, name, next_action, next_action_at
 							FROM companies
 							WHERE next_action_at < now()
+								AND deleted_at IS NULL
 								AND status NOT IN ('closed', 'dead')
 							ORDER BY next_action_at
 							LIMIT ${probeLimit(limit)}
@@ -125,7 +132,11 @@ export class PipelineService extends Context.Service<PipelineService>()(
 									AND rl.link_kind = 'input'
 								LIMIT 1
 							) link ON true
-							LEFT JOIN companies c ON c.id = link.subject_id
+							-- Filtered in the join, not the WHERE clause: a run whose company
+							-- was deleted still belongs on the list, the same as a run that
+							-- points at no company. Only the company's name drops off.
+							LEFT JOIN companies c
+								ON c.id = link.subject_id AND c.deleted_at IS NULL
 							WHERE f.pending_update_count > 0
 								OR f.status IN ${sql.in(ATTENTION_RESEARCH_STATUSES)}
 							ORDER BY f.completed_at DESC NULLS LAST
@@ -157,7 +168,11 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						const counts = yield* sql<{
 							status: string
 							count: number
-						}>`SELECT status, count(*)::int as count FROM companies GROUP BY status`
+						}>`
+							SELECT status, count(*)::int as count FROM companies
+							WHERE deleted_at IS NULL
+							GROUP BY status
+						`
 
 						const overdueTasks = yield* sql<{
 							count: number
@@ -171,6 +186,7 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						}>`
 							SELECT count(*)::int as count FROM companies
 							WHERE next_action IS NULL
+								AND deleted_at IS NULL
 								AND status NOT IN ('closed', 'dead', 'client')
 						`
 

--- a/apps/server/src/services/research-apply-field-values.integration.test.ts
+++ b/apps/server/src/services/research-apply-field-values.integration.test.ts
@@ -1,0 +1,174 @@
+// Live-DB integration test for refusing a research-proposed value that the
+// target column does not accept. The columns with a fixed vocabulary are backed
+// by CHECK constraints, so a value the model invented would otherwise reach the
+// database and come back as a failed request; these assert it is turned away as
+// a bad proposal first, and that nothing on the row moves when it is.
+//
+// Prereq: `pnpm cli services up` — this suite's globalSetup builds and migrates
+// the disposable batuda_it database it runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../db/client'
+import { applyTestEnv } from '../test-env'
+import { CompanyService } from './companies'
+import { Geocoder } from './geocoder'
+import { resolveResearchProposedUpdate } from './research-apply'
+import { TimelineActivityService } from './timeline-activity'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+const ORG = `field-values-org-${randomUUID()}`
+
+let pool: pg.Pool
+
+const deps = Layer.mergeAll(
+	TimelineActivityService.layer,
+	CompanyService.layer,
+	Geocoder.layer,
+).pipe(Layer.provide(FetchHttpClient.layer), Layer.provideMerge(PgLive))
+
+const apply = (runId: string, proposalId: string) =>
+	resolveResearchProposedUpdate(runId, proposalId, 'apply', null).pipe(
+		Effect.provideService(CurrentOrg, {
+			id: ORG,
+			name: 'c',
+			slug: 'c',
+			role: 'member',
+		}),
+		Effect.provide(deps),
+		Effect.orDie,
+		Effect.runPromise,
+	)
+
+const seedCompany = async (): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name, status)
+		 VALUES ($1, $2, 'Acme', 'prospect') RETURNING id`,
+		[ORG, `acme-${randomUUID()}`],
+	)
+	return r.rows[0]!.id
+}
+
+const seedRun = async (
+	companyId: string,
+	fields: Record<string, unknown>,
+): Promise<{ runId: string; proposalId: string }> => {
+	const proposalId = randomUUID()
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO research_runs
+			(organization_id, query, status, created_by, findings)
+		 VALUES ($1, 'q', 'succeeded', 'u1', $2::jsonb) RETURNING id`,
+		[
+			ORG,
+			JSON.stringify({
+				proposed_updates: [
+					{
+						id: proposalId,
+						status: 'pending',
+						subject_table: 'companies',
+						operation: 'update',
+						subject_id: companyId,
+						expected_version: 0,
+						fields,
+						citations: [],
+					},
+				],
+			}),
+		],
+	)
+	return { runId: r.rows[0]!.id, proposalId }
+}
+
+const companyRow = async (id: string) => {
+	const r = await pool.query<{
+		status: string
+		industry: string | null
+	}>(`SELECT status, industry FROM companies WHERE id = $1`, [id])
+	return r.rows[0]
+}
+
+beforeAll(() => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+})
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM timeline_activity WHERE organization_id = $1`, [
+		ORG,
+	])
+	await pool.query(`DELETE FROM research_runs WHERE organization_id = $1`, [
+		ORG,
+	])
+	await pool.query(`DELETE FROM companies WHERE organization_id = $1`, [ORG])
+	await pool.end()
+})
+
+describe('resolveResearchProposedUpdate field values', () => {
+	describe('when a proposal carries a status outside the vocabulary', () => {
+		it('should refuse it as a bad proposal rather than failing the request', async () => {
+			// GIVEN a run proposing a stage from a vocabulary the app no longer has,
+			// alongside a field that on its own would apply cleanly
+			const companyId = await seedCompany()
+			const { runId, proposalId } = await seedRun(companyId, {
+				status: 'qualified',
+				industry: 'transport',
+			})
+
+			// WHEN it is applied
+			const outcome = await apply(runId, proposalId)
+
+			// THEN it comes back as an unusable proposal, naming what was wrong
+			expect(outcome.outcome).toBe('invalid')
+			if (outcome.outcome !== 'invalid') return
+			expect(outcome.reason).toContain('status')
+		})
+	})
+
+	describe('when a proposal is refused for one bad value', () => {
+		it('should leave every other proposed field unwritten', async () => {
+			// GIVEN the same mix of one unusable value and one good one
+			const companyId = await seedCompany()
+			const { runId, proposalId } = await seedRun(companyId, {
+				status: 'qualified',
+				industry: 'transport',
+			})
+
+			// WHEN it is applied
+			await apply(runId, proposalId)
+
+			// THEN the row is untouched — a reviewer approved the set they were
+			// shown, so a partial write would misreport what happened
+			const row = await companyRow(companyId)
+			expect(row?.status).toBe('prospect')
+			expect(row?.industry).toBeNull()
+		})
+	})
+
+	describe('when every proposed value is one the column accepts', () => {
+		it('should apply it as before', async () => {
+			// GIVEN a proposal whose stage is in the current vocabulary
+			const companyId = await seedCompany()
+			const { runId, proposalId } = await seedRun(companyId, {
+				status: 'contacted',
+				industry: 'transport',
+			})
+
+			// WHEN it is applied
+			const outcome = await apply(runId, proposalId)
+
+			// THEN both fields land
+			expect(outcome.outcome).toBe('applied')
+			const row = await companyRow(companyId)
+			expect(row?.status).toBe('contacted')
+			expect(row?.industry).toBe('transport')
+		})
+	})
+})

--- a/apps/server/src/services/research-apply-field-values.integration.test.ts
+++ b/apps/server/src/services/research-apply-field-values.integration.test.ts
@@ -142,10 +142,11 @@ describe('resolveResearchProposedUpdate field values', () => {
 			})
 
 			// WHEN it is applied
-			await apply(runId, proposalId)
+			const outcome = await apply(runId, proposalId)
 
-			// THEN the row is untouched — a reviewer approved the set they were
-			// shown, so a partial write would misreport what happened
+			// THEN the row is untouched for the stated reason — any other refusal
+			// would leave it untouched too, so the reason is what pins this
+			expect(outcome.outcome).toBe('invalid')
 			const row = await companyRow(companyId)
 			expect(row?.status).toBe('prospect')
 			expect(row?.industry).toBeNull()

--- a/apps/server/src/services/research-apply.test.ts
+++ b/apps/server/src/services/research-apply.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { allowlistFields, validate, validateCreate } from './research-apply'
+import {
+	allowlistFields,
+	checkCompanyFieldValues,
+	validate,
+	validateCreate,
+} from './research-apply'
 
 describe('allowlistFields', () => {
 	describe('when a company proposal carries writable and non-writable keys', () => {
@@ -248,6 +253,139 @@ describe('validateCreate', () => {
 			expect(result.ok).toBe(true)
 			if (!result.ok) return
 			expect(result.channels).toEqual([])
+		})
+	})
+})
+
+describe('checkCompanyFieldValues', () => {
+	describe('when every constrained value is one the column accepts', () => {
+		it('should report nothing to reject', () => {
+			// GIVEN a proposal whose status, priority and size all come from the
+			// vocabularies the database constrains those columns to
+			const reason = checkCompanyFieldValues({
+				status: 'contacted',
+				priority: 2,
+				sizeRange: '51-200',
+				industry: 'logistics',
+			})
+
+			// THEN it is applicable
+			expect(reason).toBeNull()
+		})
+	})
+
+	describe('when the proposal mentions none of the constrained fields', () => {
+		it('should report nothing to reject', () => {
+			// GIVEN a proposal touching only free-text columns
+			const reason = checkCompanyFieldValues({
+				industry: 'logistics',
+				location: 'Sitges',
+			})
+
+			// THEN there is nothing to check
+			expect(reason).toBeNull()
+		})
+	})
+
+	describe('when the model invents a status outside the vocabulary', () => {
+		it('should reject it and name both the field and the value', () => {
+			// GIVEN a status from an older vocabulary the app no longer has
+			const reason = checkCompanyFieldValues({ status: 'qualified' })
+
+			// THEN the proposal is refused, and the message says what was wrong so a
+			// reviewer is not left with a bare failure
+			expect(reason).not.toBeNull()
+			expect(reason).toContain('status')
+			expect(reason).toContain('qualified')
+		})
+	})
+
+	describe('when a priority falls outside the allowed range', () => {
+		it('should reject it', () => {
+			// GIVEN a priority from the old 1-5 scale, which is now 1-3
+			expect(checkCompanyFieldValues({ priority: 5 })).not.toBeNull()
+		})
+	})
+
+	describe('when a size range is not one of the bands', () => {
+		it('should reject it', () => {
+			// GIVEN a band the model made up rather than one of COMPANY_SIZE_RANGES
+			expect(checkCompanyFieldValues({ sizeRange: '20-30' })).not.toBeNull()
+		})
+	})
+
+	describe('when a nullable column is explicitly cleared', () => {
+		it('should allow it, since null is how a value is removed', () => {
+			// GIVEN a proposal clearing the two columns the database lets be null
+			expect(checkCompanyFieldValues({ priority: null })).toBeNull()
+			expect(checkCompanyFieldValues({ sizeRange: null })).toBeNull()
+		})
+	})
+
+	describe('when status is cleared', () => {
+		it('should reject it, since the column is NOT NULL', () => {
+			// GIVEN a proposal trying to empty a column that always holds a stage
+			expect(checkCompanyFieldValues({ status: null })).not.toBeNull()
+		})
+	})
+
+	describe('when a value carries the right vocabulary but the wrong type', () => {
+		it('should reject it rather than coerce', () => {
+			// GIVEN a priority sent as text and a status sent as a number — the
+			// database compares by type, so neither would match its constraint
+			expect(checkCompanyFieldValues({ priority: '2' })).not.toBeNull()
+			expect(checkCompanyFieldValues({ status: 1 })).not.toBeNull()
+		})
+	})
+
+	describe('when several fields are wrong at once', () => {
+		it('should report the first one, since the whole proposal goes back', () => {
+			// GIVEN a proposal with two unusable values
+			const reason = checkCompanyFieldValues({
+				status: 'lead',
+				priority: 9,
+			})
+
+			// THEN one clear reason comes back rather than a merged list
+			expect(reason).toContain('status')
+		})
+	})
+})
+
+describe('allowlistFields feeding checkCompanyFieldValues', () => {
+	describe('when a bad value arrives wrapped with the page it came from', () => {
+		it('should still be caught, since the wrapper is unwrapped first', () => {
+			// GIVEN an enrichment finding carrying its provenance envelope, which is
+			// the shape the apply path unwraps before any value is checked
+			const { fields } = allowlistFields('companies', {
+				status: { value: 'negotiation', source_id: 'src-1' },
+			})
+
+			// THEN the value inside the wrapper is the one judged
+			expect(fields['status']).toBe('negotiation')
+			expect(checkCompanyFieldValues(fields)).not.toBeNull()
+		})
+	})
+
+	describe('when a good value arrives wrapped', () => {
+		it('should pass, so provenance does not make a valid value unusable', () => {
+			// GIVEN the same envelope around a stage that is in the vocabulary
+			const { fields } = allowlistFields('companies', {
+				status: { value: 'meeting', source_id: 'src-1' },
+			})
+
+			// THEN nothing is rejected
+			expect(checkCompanyFieldValues(fields)).toBeNull()
+		})
+	})
+
+	describe('when a snake_case key carries a bad value', () => {
+		it('should be caught under its camelCase column name', () => {
+			// GIVEN the model writing size_range, which the allowlist renames
+			const { fields } = allowlistFields('companies', { size_range: '2-7' })
+
+			// THEN the renamed field is the one checked
+			expect(checkCompanyFieldValues(fields)).toContain('sizeRange')
 		})
 	})
 })

--- a/apps/server/src/services/research-apply.test.ts
+++ b/apps/server/src/services/research-apply.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	allowlistFields,
-	checkCompanyFieldValues,
+	checkFieldValues,
 	validate,
 	validateCreate,
 } from './research-apply'
@@ -262,7 +262,7 @@ describe('checkCompanyFieldValues', () => {
 		it('should report nothing to reject', () => {
 			// GIVEN a proposal whose status, priority and size all come from the
 			// vocabularies the database constrains those columns to
-			const reason = checkCompanyFieldValues({
+			const reason = checkFieldValues('companies', {
 				status: 'contacted',
 				priority: 2,
 				sizeRange: '51-200',
@@ -277,7 +277,7 @@ describe('checkCompanyFieldValues', () => {
 	describe('when the proposal mentions none of the constrained fields', () => {
 		it('should report nothing to reject', () => {
 			// GIVEN a proposal touching only free-text columns
-			const reason = checkCompanyFieldValues({
+			const reason = checkFieldValues('companies', {
 				industry: 'logistics',
 				location: 'Sitges',
 			})
@@ -290,7 +290,7 @@ describe('checkCompanyFieldValues', () => {
 	describe('when the model invents a status outside the vocabulary', () => {
 		it('should reject it and name both the field and the value', () => {
 			// GIVEN a status from an older vocabulary the app no longer has
-			const reason = checkCompanyFieldValues({ status: 'qualified' })
+			const reason = checkFieldValues('companies', { status: 'qualified' })
 
 			// THEN the proposal is refused, and the message says what was wrong so a
 			// reviewer is not left with a bare failure
@@ -303,45 +303,50 @@ describe('checkCompanyFieldValues', () => {
 	describe('when a priority falls outside the allowed range', () => {
 		it('should reject it', () => {
 			// GIVEN a priority from the old 1-5 scale, which is now 1-3
-			expect(checkCompanyFieldValues({ priority: 5 })).not.toBeNull()
+			expect(checkFieldValues('companies', { priority: 5 })).toContain(
+				'priority',
+			)
 		})
 	})
 
 	describe('when a size range is not one of the bands', () => {
 		it('should reject it', () => {
 			// GIVEN a band the model made up rather than one of COMPANY_SIZE_RANGES
-			expect(checkCompanyFieldValues({ sizeRange: '20-30' })).not.toBeNull()
+			expect(checkFieldValues('companies', { sizeRange: '20-30' })).toContain(
+				'sizeRange',
+			)
 		})
 	})
 
 	describe('when a nullable column is explicitly cleared', () => {
 		it('should allow it, since null is how a value is removed', () => {
 			// GIVEN a proposal clearing the two columns the database lets be null
-			expect(checkCompanyFieldValues({ priority: null })).toBeNull()
-			expect(checkCompanyFieldValues({ sizeRange: null })).toBeNull()
+			expect(checkFieldValues('companies', { priority: null })).toBeNull()
+			expect(checkFieldValues('companies', { sizeRange: null })).toBeNull()
 		})
 	})
 
 	describe('when status is cleared', () => {
 		it('should reject it, since the column is NOT NULL', () => {
 			// GIVEN a proposal trying to empty a column that always holds a stage
-			expect(checkCompanyFieldValues({ status: null })).not.toBeNull()
+			expect(checkFieldValues('companies', { status: null })).toContain(
+				'status',
+			)
 		})
 	})
 
 	describe('when a value carries the right vocabulary but the wrong type', () => {
-		it('should reject it rather than coerce', () => {
-			// GIVEN a priority sent as text and a status sent as a number — the
-			// database compares by type, so neither would match its constraint
-			expect(checkCompanyFieldValues({ priority: '2' })).not.toBeNull()
-			expect(checkCompanyFieldValues({ status: 1 })).not.toBeNull()
+		it('should reject a value no reading of it could make valid', () => {
+			// GIVEN a status sent as a number — nothing it could be parsed into is
+			// one of the stages
+			expect(checkFieldValues('companies', { status: 1 })).toContain('status')
 		})
 	})
 
 	describe('when several fields are wrong at once', () => {
 		it('should report the first one, since the whole proposal goes back', () => {
 			// GIVEN a proposal with two unusable values
-			const reason = checkCompanyFieldValues({
+			const reason = checkFieldValues('companies', {
 				status: 'lead',
 				priority: 9,
 			})
@@ -363,7 +368,7 @@ describe('allowlistFields feeding checkCompanyFieldValues', () => {
 
 			// THEN the value inside the wrapper is the one judged
 			expect(fields['status']).toBe('negotiation')
-			expect(checkCompanyFieldValues(fields)).not.toBeNull()
+			expect(checkFieldValues('companies', fields)).not.toBeNull()
 		})
 	})
 
@@ -375,7 +380,7 @@ describe('allowlistFields feeding checkCompanyFieldValues', () => {
 			})
 
 			// THEN nothing is rejected
-			expect(checkCompanyFieldValues(fields)).toBeNull()
+			expect(checkFieldValues('companies', fields)).toBeNull()
 		})
 	})
 
@@ -385,7 +390,48 @@ describe('allowlistFields feeding checkCompanyFieldValues', () => {
 			const { fields } = allowlistFields('companies', { size_range: '2-7' })
 
 			// THEN the renamed field is the one checked
-			expect(checkCompanyFieldValues(fields)).toContain('sizeRange')
+			expect(checkFieldValues('companies', fields)).toContain('sizeRange')
+		})
+	})
+})
+
+describe('checkFieldValues on values a model is likely to send', () => {
+	describe('when a whole number arrives quoted', () => {
+		it('should read it as the number, since the column takes it either way', () => {
+			// GIVEN a model that wrote JSON with the priority as text
+			expect(checkFieldValues('companies', { priority: '2' })).toBeNull()
+		})
+	})
+
+	describe('when a quoted value is not a whole number', () => {
+		it('should still refuse it', () => {
+			// GIVEN text that is not any priority
+			expect(checkFieldValues('companies', { priority: 'high' })).toContain(
+				'priority',
+			)
+			expect(checkFieldValues('companies', { priority: '9' })).toContain(
+				'priority',
+			)
+		})
+	})
+
+	describe('when a contact is given a part in the decision', () => {
+		it('should accept one of the five and refuse anything else', () => {
+			// GIVEN the vocabulary the rest of the app reads buying roles through
+			expect(
+				checkFieldValues('contacts', { buyingRole: 'economic_buyer' }),
+			).toBeNull()
+			// GIVEN a plausible-sounding role that is not one of them
+			expect(
+				checkFieldValues('contacts', { buyingRole: 'decision_maker' }),
+			).toContain('buyingRole')
+		})
+	})
+
+	describe('when a contact proposal carries a company vocabulary field', () => {
+		it('should not judge it by the company rules', () => {
+			// GIVEN status, which is a company column and no part of a contact
+			expect(checkFieldValues('contacts', { status: 'nonsense' })).toBeNull()
 		})
 	})
 })

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -2,6 +2,11 @@ import { Cause, DateTime, Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
+import {
+	COMPANY_PRIORITIES,
+	COMPANY_SIZE_RANGES,
+	COMPANY_STATUSES,
+} from '@batuda/domain'
 
 export {
 	type ProvenanceEntry,
@@ -176,6 +181,40 @@ export const allowlistFields = (
 		if (read.citation !== undefined) citations[camel] = read.citation
 	}
 	return { fields: out, citations }
+}
+
+// The allowlist above says which fields may be written, not what they may be
+// set to. These three columns take only a fixed set of values, so a stage the
+// model invented would otherwise reach the database and come back as a failed
+// request — telling the reviewer the server broke, when the suggestion was
+// simply unusable.
+const COMPANY_FIELD_VOCABULARIES: ReadonlyArray<{
+	readonly field: string
+	readonly allowed: ReadonlyArray<string | number>
+}> = [
+	{ field: 'status', allowed: COMPANY_STATUSES },
+	{ field: 'priority', allowed: COMPANY_PRIORITIES },
+	{ field: 'sizeRange', allowed: COMPANY_SIZE_RANGES },
+]
+
+// The reason a company proposal cannot be applied, or null when it can. An
+// explicit null is how a value is cleared, which these columns allow except
+// status — a company always sits at some stage.
+export const checkCompanyFieldValues = (
+	fields: Record<string, unknown>,
+): string | null => {
+	for (const { field, allowed } of COMPANY_FIELD_VOCABULARIES) {
+		if (!(field in fields)) continue
+		const value = fields[field]
+		if (value === null && field !== 'status') continue
+		if (
+			(typeof value === 'string' || typeof value === 'number') &&
+			allowed.includes(value)
+		)
+			continue
+		return `${field} must be one of ${allowed.join(', ')} — got ${JSON.stringify(value)}`
+	}
+	return null
 }
 
 export type Validated =
@@ -826,6 +865,14 @@ export const resolveResearchProposedUpdate = (
 			validated.table,
 			validated.fields,
 		)
+		// The whole proposal goes back, not just the offending field: a reviewer
+		// approved the set they were shown, so quietly applying the rest would
+		// leave them believing a change landed that never did.
+		if (validated.table === 'companies') {
+			const badValue = checkCompanyFieldValues(fields)
+			if (badValue !== null)
+				return { outcome: 'invalid', reason: badValue } satisfies ResolveOutcome
+		}
 		const sources = yield* resolveFieldSources(sql, runId, {
 			...channelCitations,
 			...fieldCitations,

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -3,6 +3,7 @@ import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
 import {
+	BUYING_ROLES,
 	COMPANY_PRIORITIES,
 	COMPANY_SIZE_RANGES,
 	COMPANY_STATUSES,
@@ -188,31 +189,51 @@ export const allowlistFields = (
 // model invented would otherwise reach the database and come back as a failed
 // request — telling the reviewer the server broke, when the suggestion was
 // simply unusable.
-const COMPANY_FIELD_VOCABULARIES: ReadonlyArray<{
+type FieldVocabulary = {
 	readonly field: string
 	readonly allowed: ReadonlyArray<string | number>
-}> = [
+}
+
+const COMPANY_FIELD_VOCABULARIES: ReadonlyArray<FieldVocabulary> = [
 	{ field: 'status', allowed: COMPANY_STATUSES },
 	{ field: 'priority', allowed: COMPANY_PRIORITIES },
 	{ field: 'sizeRange', allowed: COMPANY_SIZE_RANGES },
 ]
 
+// A contact's part in the buying decision reads back through a guard that only
+// knows these five words, so one the model invented is stored but belongs to no
+// group and shows up nowhere — the same quiet disappearance the company
+// vocabularies prevent.
+const CONTACT_FIELD_VOCABULARIES: ReadonlyArray<FieldVocabulary> = [
+	{ field: 'buyingRole', allowed: BUYING_ROLES },
+]
+
 // The reason a company proposal cannot be applied, or null when it can. An
 // explicit null is how a value is cleared, which these columns allow except
 // status — a company always sits at some stage.
-export const checkCompanyFieldValues = (
+export const checkFieldValues = (
+	table: 'companies' | 'contacts',
 	fields: Record<string, unknown>,
 ): string | null => {
-	for (const { field, allowed } of COMPANY_FIELD_VOCABULARIES) {
+	const vocabularies =
+		table === 'companies'
+			? COMPANY_FIELD_VOCABULARIES
+			: CONTACT_FIELD_VOCABULARIES
+	for (const { field, allowed } of vocabularies) {
 		if (!(field in fields)) continue
-		const value = fields[field]
-		if (value === null && field !== 'status') continue
+		const raw = fields[field]
+		if (raw === null && field !== 'status') continue
+		// A model writing JSON often quotes a small number, and the column takes
+		// it either way, so "2" is the priority 2 the reviewer read — not a
+		// different value to refuse them over.
+		const value =
+			typeof raw === 'string' && /^\d+$/.test(raw) ? Number(raw) : raw
 		if (
 			(typeof value === 'string' || typeof value === 'number') &&
 			allowed.includes(value)
 		)
 			continue
-		return `${field} must be one of ${allowed.join(', ')} — got ${JSON.stringify(value)}`
+		return `${field} must be one of ${allowed.join(', ')} — got ${JSON.stringify(raw)}`
 	}
 	return null
 }
@@ -308,10 +329,13 @@ export const validateCreate = (
 	const companyId = fields['company_id'] ?? fields['companyId']
 	if (typeof companyId !== 'string' || companyId === '')
 		return { ok: false, reason: 'missing company_id' }
+	const allowed = allowlistFields('contacts', fields).fields
+	const badValue = checkFieldValues('contacts', allowed)
+	if (badValue !== null) return { ok: false, reason: badValue }
 	return {
 		ok: true,
 		companyId,
-		fields: allowlistFields('contacts', fields).fields,
+		fields: allowed,
 		channels: parseChannels(fields['channels']),
 	}
 }
@@ -868,11 +892,9 @@ export const resolveResearchProposedUpdate = (
 		// The whole proposal goes back, not just the offending field: a reviewer
 		// approved the set they were shown, so quietly applying the rest would
 		// leave them believing a change landed that never did.
-		if (validated.table === 'companies') {
-			const badValue = checkCompanyFieldValues(fields)
-			if (badValue !== null)
-				return { outcome: 'invalid', reason: badValue } satisfies ResolveOutcome
-		}
+		const badValue = checkFieldValues(validated.table, fields)
+		if (badValue !== null)
+			return { outcome: 'invalid', reason: badValue } satisfies ResolveOutcome
 		const sources = yield* resolveFieldSources(sql, runId, {
 			...channelCitations,
 			...fieldCitations,


### PR DESCRIPTION
Closes #397

An assistant could see who owned a company but never change it, and had no way to turn a name somebody said out loud into the id every tool wants. Handing a lead to a colleague meant leaving the assistant and doing it by hand. This closes that, and fixes two data-integrity bugs found while confirming the gap.

## Assigning a company to a colleague

`list_members` is new: the people who work in this organization, each with the `user_id` that a company's `ownerId` and a task's `assignee_id` take. It is its own tool rather than part of the company one because task assignee and instruction transfer need the same ids.

`ownerId` is now writable on `update_company` (null releases the lead) and on `create_companies`, so a shortlist can be loaded and handed out in one call.

No schema change was needed — `companies.owner_id` has existed since migration 0027, the REST API already accepted it, and the web app's owner picker already wrote it. Only the assistant's door was missing.

**The check lives beside the write, not in the tool.** It started in the MCP handler, which left the company page's own requests free to assign a company to somebody from another organization: `owner_id` is plain text with no foreign key, so the write lands and the lead then shows a name nobody recognises. It now sits in `CompanyService`, so both ways in obey it. There is a test for each.

One sharp edge is documented rather than fixed: an `ownerId` sent with a company that already exists does nothing, because `create_companies` skips duplicates rather than rewriting them. Re-sending a list is the obvious wrong way to hand companies over, so the tool description now says so and a test pins it.

## Two bugs fixed

**`get_pipeline` counted deleted companies.** No `deleted_at IS NULL` anywhere in `pipeline.ts`, while every other company read has it. This is latent rather than live — nothing in production sets `deleted_at` yet, so no number is wrong today. What was wrong is that this was the one place not following the convention, so the day a delete path lands the pipeline figures and the daily plan would be the last thing to notice.

**The research apply path checked field names but not field values.** `status` is allowlisted by key only, so a stage a model invented reached the database, tripped its CHECK constraint and came back as a failed request — telling the reviewer the server broke when the suggestion was simply unusable. Values are now checked against the same vocabularies the rest of the app reads them through, and the whole suggestion is refused rather than the bad field quietly dropped: a reviewer approves the set they were shown.

## What review changed

Four review passes over the diff. Their findings are folded in:

- The owner check was in the wrong layer (above) — the most valuable finding by some margin.
- The overdue-task figure counted work on companies that had been deleted. The reviewer framed this as the figure disagreeing with the task lists, and that framing was wrong — the lists carry a company name in their shape, so they only ever showed company work and were never meant to match. Fixing it to the reviewer's framing dropped every task belonging to no company, which in the seeded data is all of them: the figure went to zero while the work was still there. Corrected, and both halves now have a test.
- A model writing JSON often quotes a whole number, and the priority column takes it either way — a quoted `2` was being refused as if it were a different value.
- A contact's part in the buying decision has a five-word vocabulary and was not checked, the same gap the company fields had.
- Several tests asserted only "something was refused", which passes on any error. They now pin the field and the reason.

One finding was rejected: a reviewer reported that `companies.status` has no CHECK constraint, having read only `0001_initial`. Migration 0057 adds `companies_status_chk`, and the constraint is present in the live database.

## Verification

`check-types` 13/13 · 799 server unit tests (+938 research, +148 internal, +54 controllers) · 71 integration tests across 12 suites · `build` 13/13 · Biome clean.

Each fix was confirmed load-bearing by reverting it and watching the matching tests fail, then pass again on restore — including the cross-org owner case, which without the guard assigns the outsider successfully.

## Known, not addressed

Each of these was checked against the running database rather than assumed:

- `search_companies`, `get_company` and `findById` do not filter soft-deleted companies. The `companies` row-level-security policy scopes by organization only, and a soft-deleted row inserted under it comes straight back. Same class as the pipeline bug, wider surface, equally latent — left for its own change.
- `assignee_id` on tasks takes any string unchecked: the column has no foreign key and no CHECK, and `'totally-not-a-user-abc'` inserts cleanly. `requireOrgMembers` is written to serve it; wiring it in is a separate change.
- Nothing clears `owner_id` when a member leaves an organization, so a departed colleague stays listed as owner. Member removal belongs to the auth stack, and no code here reacts to it. Confirmed intended.
