### PR TITLE
Correct or remove one of a contact's addresses

### DIFF
--- a/.claude/skills/crm/SKILL.md
+++ b/.claude/skills/crm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crm
-description: This skill should be used when the user asks to "add a company", "update a company", "log an interaction", "create a document", "check the pipeline", "get next steps", "check overdue tasks", "create a page", "publish a page", "research a company", or mentions CRM data, MCP tools, companies, interactions, documents, tasks, or pages.
+description: This skill should be used when the user asks to "add a company", "update a company", "add a contact", "fix a contact's email", "change somebody's phone number", "remove an address", "log an interaction", "create a document", "check the pipeline", "get next steps", "check overdue tasks", "create a page", "publish a page", "research a company", or mentions CRM data, MCP tools, companies, contacts, channels, interactions, documents, tasks, or pages.
 ---
 
 # CRM Operations
@@ -33,7 +33,9 @@ Always call `search_companies` before `get_company`. Fetch document content only
 
 All IDs are UUIDs. All timestamps are UTC.
 
-Fields that take one of a fixed set of words (status, priority, size range, channel kind) are plain strings, not Postgres enums; the sets they take are in `packages/domain/src/schema/`.
+Fields that take one of a fixed set of words (status, priority, size range, email verification) are plain strings, not Postgres enums; the sets they take are in `packages/domain/src/schema/`.
+
+A channel's `kind` is not one of them — it is deliberately open, so a platform nobody has heard of yet needs no change. `CHANNEL_KINDS` lists the ones the web app knows how to draw and name; anything else is stored and shown as it arrived.
 
 `industry` is not one of them. A company's trade is whatever the organisation calls it, so send the words a person would write (`Serralleria`, `Freight forwarding`) and the server files it under that organisation's own entry, creating one the first time anybody uses it. What comes back on the row is that entry's web-address form, which is what a filter and a shared link use.
 
@@ -49,10 +51,15 @@ Status moves forward only: `prospect → contacted → responded → meeting →
 
 - **Slug**: kebab-case from name. If duplicate, append city: `can-joan-girona`
 - **Priority**: 1 = hot (contact this week), 2 = medium, 3 = cold (backlog)
-- **source**: always set when creating. Values: `firecrawl | exa | google_maps | referral | linkedin | instagram | manual`
 - **metadata**: use for data that doesn't fit existing columns (fiscal data, employee names, social stats, competitor notes)
 
 For detailed field values, status flow diagram, and examples, consult `references/companies.md`.
+
+## Contacts
+
+A wrong email is corrected with `manage_contact_channels`, never by deleting the person and starting over — deleting detaches every interaction, proposal and thread they were attached to. `update_contact`'s `channels[]` only ever adds or refreshes, so a correction made there leaves the old address beside the new one.
+
+For adding, correcting, removing and re-electing a channel, and for how far an address is trusted, consult `references/contacts.md`.
 
 ## Interactions
 
@@ -125,5 +132,6 @@ For page structure details, consult `references/documents.md`.
 For detailed field values, workflows, and examples, consult:
 
 - **`references/companies.md`** — Status flow, slug format, priority, size ranges, how a trade is named, metadata patterns
+- **`references/contacts.md`** — Correcting and removing one channel, primary election, how far an address is trusted vs whether it bounced
 - **`references/interactions.md`** — Channel/direction/type/outcome values, log_interaction example, next_action workflow
 - **`references/documents.md`** — Document types, research workflow, pages (Tiptap JSON, publish flow), tasks

--- a/.claude/skills/crm/references/contacts.md
+++ b/.claude/skills/crm/references/contacts.md
@@ -1,0 +1,62 @@
+# Contacts and their channels
+
+A contact is a person at a company. A channel is one way of reaching them — an
+email, a phone, a LinkedIn URL. One person can hold several of a kind.
+
+## Putting a wrong address right
+
+Use `manage_contact_channels`. `update_contact`'s `channels[]` **only ever adds
+or refreshes**: an address corrected there leaves the old one beside it, and the
+person ends up holding both.
+
+| Want to                         | action                                                                              |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| See what is on file             | `list`                                                                              |
+| Add one                         | `add` with `kind` + `value`, and a `label` when there is more than one of that kind |
+| Correct, rename or re-elect one | `update` with `channel_id` and only the fields to change                            |
+| Take one off                    | `remove` with `channel_id`                                                          |
+
+Two things it will refuse rather than guess at:
+
+- **An address the person already holds.** Renaming one onto another is a
+  collision, not a merge — merging would delete a row nobody named. Remove the
+  spare instead.
+- **An address that could never be one of its kind** — a phone number in an
+  email row, and the same the other way round.
+
+`label: null` takes a name back off. `is_primary: true` marks the one to use
+when nothing else says; the primary email is the address mail is sent to, and
+removing it hands that over to the oldest one left of the same kind.
+
+## Do not delete the person to fix an address
+
+`delete_contact` detaches every interaction, proposal and email thread ever
+logged against them — those rows survive with `contact_id = NULL`, so the
+history stays but stops naming anybody. Their channels go with them, including
+any record of an address having bounced.
+
+## Leaving somebody with no email
+
+A later research run and an inbound reply both recognise a person by their
+address first, falling back to their name. A contact with no email may be
+created a second time as a duplicate.
+
+## How far an address is trusted
+
+`verification` on an email channel is what a deliverability check found:
+`deliverable`, `risky`, `catch_all`, `undeliverable`, `unknown`.
+
+Not all of them mean the same thing. `risky` and `undeliverable` say something
+against the address. `catch_all` means the domain answers to every name, so the
+check learned nothing about this particular mailbox, and `unknown` says what no
+verdict at all says. Which of them stop a send is the sending side's rule — read
+it there rather than assuming, because it has changed.
+
+A tool call may only ever **lower** it: `risky` or `undeliverable` to record
+doubt, or `unknown` to withdraw a verdict that looks wrong without putting
+anything in its place. Saying an address is good is something a check finds out
+by reaching the mailbox, so `deliverable` is refused from a caller. A later check
+can raise it again.
+
+This is a different thing from a bounce. `status` records what happened *after*
+a send; `clear_email_suppression` on `update_contact` is what resets that.

--- a/apps/internal/src/components/contacts/channel-icons.ts
+++ b/apps/internal/src/components/contacts/channel-icons.ts
@@ -8,8 +8,12 @@ import {
 	Phone,
 } from 'lucide-react'
 
+import type { ChannelKind } from '@batuda/domain'
+
 // `kind` is open-ended, so a platform nobody has drawn an icon for falls back
-// to a plain link at the call site rather than being hidden.
+// to a plain link at the call site rather than being hidden. Every kind the
+// picker offers must have one, which is what the check against CHANNEL_KINDS
+// says — the lookup stays open so the fallback still works.
 export const CHANNEL_ICON: Record<string, typeof MailIcon> = {
 	email: Mail,
 	phone: Phone,
@@ -19,4 +23,4 @@ export const CHANNEL_ICON: Record<string, typeof MailIcon> = {
 	instagram: AtSign,
 	website: Globe,
 	bluesky: AtSign,
-}
+} satisfies Record<ChannelKind, typeof MailIcon>

--- a/apps/internal/src/components/contacts/channel-kind-label.tsx
+++ b/apps/internal/src/components/contacts/channel-kind-label.tsx
@@ -1,5 +1,7 @@
 import { useLingui } from '@lingui/react/macro'
 
+import type { ChannelKind } from '@batuda/domain'
+
 /**
  * What kind of way of being reached this is, in words.
  *
@@ -13,28 +15,19 @@ import { useLingui } from '@lingui/react/macro'
  */
 export const useChannelKindLabel = (): ((kind: string) => string) => {
 	const { t } = useLingui()
-	return kind => {
-		switch (kind) {
-			case 'email':
-				return t`Email`
-			case 'phone':
-				return t`Phone`
-			case 'whatsapp':
-				return t`WhatsApp`
-			case 'website':
-				return t`Website`
-			case 'linkedin':
-				return t`LinkedIn`
-			case 'instagram':
-				return t`Instagram`
-			case 'x':
-				return t`X`
-			case 'bluesky':
-				return t`Bluesky`
-			// A platform this app has no word for is announced as it was stored,
-			// which is more use than saying nothing.
-			default:
-				return kind
-		}
-	}
+	// Checked against CHANNEL_KINDS so a kind the picker offers cannot end up
+	// without a word, while the lookup itself stays open.
+	const labels: Record<string, string> = {
+		email: t`Email`,
+		phone: t`Phone`,
+		whatsapp: t`WhatsApp`,
+		website: t`Website`,
+		linkedin: t`LinkedIn`,
+		instagram: t`Instagram`,
+		x: t`X`,
+		bluesky: t`Bluesky`,
+	} satisfies Record<ChannelKind, string>
+	// A platform this app has no word for is announced as it was stored, which is
+	// more use than saying nothing.
+	return kind => labels[kind] ?? kind
 }

--- a/apps/internal/src/components/contacts/manage-channels-dialog.tsx
+++ b/apps/internal/src/components/contacts/manage-channels-dialog.tsx
@@ -1,26 +1,34 @@
 import { useAtomSet } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { Star, Trash2, X } from 'lucide-react'
-import { type FormEvent, useState } from 'react'
+import {
+	Check,
+	ChevronsUpDown,
+	Pencil,
+	ShieldAlert,
+	Star,
+	Trash2,
+	X,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import { PriButton, PriDialog, PriInput, usePriToast } from '@batuda/ui/pri'
+import { CHANNEL_KINDS } from '@batuda/domain'
+import {
+	PriButton,
+	PriDialog,
+	PriField,
+	PriInput,
+	PriMenu,
+	PriSelect,
+	usePriToast,
+} from '@batuda/ui/pri'
 
+import { TrustBadge } from '#/components/research/trust-badge'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
+import { badRequestMessage } from '#/lib/tagged-failure'
 import { agedPaperRow, stenciledTitle } from '#/lib/workshop-mixins'
+import { useChannelKindLabel } from './channel-kind-label'
 import type { DisplayChannel } from './display-channels'
-
-// Kinds the picker offers; `kind` is open server-side, these are the common set.
-const CHANNEL_KINDS = [
-	'email',
-	'phone',
-	'whatsapp',
-	'linkedin',
-	'x',
-	'instagram',
-	'website',
-	'bluesky',
-] as const
 
 type Props = {
 	// `null` keeps the dialog closed; any id opens it for that contact.
@@ -31,6 +39,10 @@ type Props = {
 	readonly onChanged: () => void
 }
 
+type Draft = { kind: string; value: string; label: string }
+
+const EMPTY_DRAFT: Draft = { kind: 'email', value: '', label: '' }
+
 export function ManageChannelsDialog({
 	contactId,
 	contactName,
@@ -40,6 +52,7 @@ export function ManageChannelsDialog({
 }: Props) {
 	const { t } = useLingui()
 	const toast = usePriToast()
+	const kindLabel = useChannelKindLabel()
 
 	const addChannel = useAtomSet(
 		BatudaApiAtom.mutation('contacts', 'addChannel'),
@@ -57,20 +70,58 @@ export function ManageChannelsDialog({
 	const [newKind, setNewKind] = useState<string>('email')
 	const [newValue, setNewValue] = useState<string>('')
 	const [newLabel, setNewLabel] = useState<string>('')
-	const [busy, setBusy] = useState(false)
+	const [adding, setAdding] = useState(false)
+	const [addError, setAddError] = useState<string | null>(null)
 
-	const failed = () =>
+	// One row at a time: two half-finished rows on screen cannot be told apart.
+	const [editingId, setEditingId] = useState<string | null>(null)
+	const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT)
+	// Which row is mid-write, so a slow save on one never freezes the others.
+	const [busyId, setBusyId] = useState<string | null>(null)
+	const [rowError, setRowError] = useState<{
+		id: string
+		message: string
+	} | null>(null)
+
+	// The dialog stays mounted between people, so without this the last person's
+	// half-typed address turns up on the next one — and a row id left behind
+	// would point into a list it does not belong to.
+	//
+	// biome-ignore lint/correctness/useExhaustiveDependencies: the contact is what this clears for, and the body only writes — reading it here would be the same value every time
+	useEffect(() => {
+		setNewKind('email')
+		setNewValue('')
+		setNewLabel('')
+		setAdding(false)
+		setAddError(null)
+		setEditingId(null)
+		setDraft(EMPTY_DRAFT)
+		setBusyId(null)
+		setRowError(null)
+	}, [contactId])
+
+	// A refusal is about the text still in the box, so it belongs beside it. A
+	// write that simply did not land has nothing to point at, so it goes to a
+	// toast that names which address it was about.
+	const reportFailure = (ch: DisplayChannel, cause: unknown) => {
+		const message = badRequestMessage(cause)
+		if (message !== null) {
+			setRowError({ id: ch.id, message })
+			return
+		}
 		toast.add({
-			title: t`Could not update channels`,
+			title: t`Could not change ${ch.value}`,
 			description: t`The change didn't go through. Try again.`,
 			type: 'error',
 		})
+		console.error('[batuda] contacts.updateChannel failed', cause)
+	}
 
-	const handleAdd = async (event: FormEvent<HTMLFormElement>) => {
-		event.preventDefault()
+	const handleAdd = async () => {
 		const value = newValue.trim()
-		if (!contactId || !value || busy) return
-		setBusy(true)
+		if (!contactId || value === '' || adding) return
+		setAdding(true)
+		setAddError(null)
 		const label = newLabel.trim()
 		const exit = await addChannel({
 			params: { id: contactId },
@@ -78,35 +129,94 @@ export function ManageChannelsDialog({
 			// this one" stays distinct from "somebody named it the empty string".
 			payload: { kind: newKind, value, ...(label ? { label } : {}) },
 		} as never)
-		setBusy(false)
+		setAdding(false)
 		if (exit._tag === 'Success') {
 			setNewValue('')
 			setNewLabel('')
 			onChanged()
-		} else failed()
+			return
+		}
+		const message = badRequestMessage(exit.cause)
+		if (message !== null) {
+			setAddError(message)
+			return
+		}
+		toast.add({
+			title: t`Could not add ${value}`,
+			description: t`The change didn't go through. Try again.`,
+			type: 'error',
+		})
 	}
 
-	const handleRemove = async (channelId: string) => {
-		if (!contactId || busy) return
-		setBusy(true)
-		const exit = await deleteChannel({
-			params: { id: contactId, channelId },
-		} as never)
-		setBusy(false)
-		if (exit._tag === 'Success') onChanged()
-		else failed()
+	const startEdit = (ch: DisplayChannel) => {
+		setEditingId(ch.id)
+		setDraft({ kind: ch.kind, value: ch.value, label: ch.label ?? '' })
+		setRowError(null)
 	}
 
-	const handleMakePrimary = async (channelId: string) => {
-		if (!contactId || busy) return
-		setBusy(true)
+	const cancelEdit = () => {
+		setEditingId(null)
+		setRowError(null)
+	}
+
+	const submitEdit = async (ch: DisplayChannel) => {
+		if (!contactId || busyId !== null) return
+		const value = draft.value.trim()
+		if (value === '') {
+			setRowError({ id: ch.id, message: t`An address can't be blank.` })
+			return
+		}
+		// An empty box means "take the name back off", which the server spells as
+		// null; leaving the box as it was changes nothing.
+		const label = draft.label.trim() === '' ? null : draft.label.trim()
+		const payload: Record<string, unknown> = {}
+		if (draft.kind !== ch.kind) payload['kind'] = draft.kind
+		if (value !== ch.value) payload['value'] = value
+		if (label !== ch.label) payload['label'] = label
+		// A save that changes nothing is a cancel, not a round trip.
+		if (Object.keys(payload).length === 0) {
+			cancelEdit()
+			return
+		}
+		setBusyId(ch.id)
+		setRowError(null)
 		const exit = await updateChannel({
-			params: { id: contactId, channelId },
-			payload: { is_primary: true },
+			params: { id: contactId, channelId: ch.id },
+			payload,
 		} as never)
-		setBusy(false)
+		setBusyId(null)
+		if (exit._tag === 'Success') {
+			setEditingId(null)
+			onChanged()
+			return
+		}
+		reportFailure(ch, exit.cause)
+	}
+
+	const handleRemove = async (ch: DisplayChannel) => {
+		if (!contactId || busyId !== null) return
+		setBusyId(ch.id)
+		const exit = await deleteChannel({
+			params: { id: contactId, channelId: ch.id },
+		} as never)
+		setBusyId(null)
 		if (exit._tag === 'Success') onChanged()
-		else failed()
+		else reportFailure(ch, exit.cause)
+	}
+
+	const patchRow = async (
+		ch: DisplayChannel,
+		payload: Record<string, unknown>,
+	) => {
+		if (!contactId || busyId !== null) return
+		setBusyId(ch.id)
+		const exit = await updateChannel({
+			params: { id: contactId, channelId: ch.id },
+			payload,
+		} as never)
+		setBusyId(null)
+		if (exit._tag === 'Success') onChanged()
+		else reportFailure(ch, exit.cause)
 	}
 
 	return (
@@ -118,7 +228,7 @@ export function ManageChannelsDialog({
 		>
 			<PriDialog.Portal>
 				<PriDialog.Backdrop />
-				<PriDialog.Popup>
+				<PriDialog.Popup data-testid='manage-channels-dialog'>
 					<Header>
 						<PriDialog.Title render={<Title />}>
 							<Trans>Channels — {contactName}</Trans>
@@ -141,70 +251,357 @@ export function ManageChannelsDialog({
 					) : (
 						<ChannelList>
 							{channels.map(ch => (
-								<ChannelRow key={ch.id}>
-									<Kind>{ch.kind}</Kind>
-									<Value>
-										{ch.value}
-										{ch.label ? <ChannelLabel>{ch.label}</ChannelLabel> : null}
-									</Value>
-									{ch.kind === 'email' && (
-										<IconButton
-											type='button'
-											aria-label={t`Make ${ch.value} primary`}
-											$active={ch.isPrimary}
-											disabled={ch.isPrimary || busy}
-											onClick={() => handleMakePrimary(ch.id)}
+								<ChannelRow key={ch.id} data-testid={`channel-row-${ch.id}`}>
+									{editingId === ch.id ? (
+										<EditForm
+											action={() => {
+												void submitEdit(ch)
+											}}
+											onKeyDown={event => {
+												if (event.key === 'Escape') cancelEdit()
+											}}
 										>
-											<Star
-												size={14}
-												{...(ch.isPrimary ? { fill: 'currentColor' } : {})}
+											<KindPicker
+												value={draft.kind}
+												disabled={busyId === ch.id}
+												label={t`Kind`}
+												testId={`channel-kind-${ch.id}`}
+												kindLabel={kindLabel}
+												onChange={kind => {
+													setDraft(d => ({ ...d, kind }))
+													setRowError(null)
+												}}
 											/>
-										</IconButton>
+											<PriField.Root>
+												<PriField.Label htmlFor={`channel-value-${ch.id}`}>
+													<Trans>Address</Trans>
+												</PriField.Label>
+												<PriInput
+													id={`channel-value-${ch.id}`}
+													data-testid={`channel-value-${ch.id}`}
+													// The row only opens on the reader's own click, and a
+													// wrong address is what they came to change.
+													autoFocus
+													value={draft.value}
+													onChange={e => {
+														setDraft(d => ({ ...d, value: e.target.value }))
+														setRowError(null)
+													}}
+												/>
+											</PriField.Root>
+											<PriField.Root>
+												<PriField.Label htmlFor={`channel-label-${ch.id}`}>
+													<Trans>Name</Trans>
+												</PriField.Label>
+												<PriInput
+													id={`channel-label-${ch.id}`}
+													data-testid={`channel-label-${ch.id}`}
+													placeholder={t`orders, Girona shop…`}
+													value={draft.label}
+													onChange={e => {
+														setDraft(d => ({ ...d, label: e.target.value }))
+														setRowError(null)
+													}}
+												/>
+											</PriField.Root>
+											<EditActions>
+												<PriButton
+													type='submit'
+													data-testid={`channel-save-${ch.id}`}
+													disabled={busyId === ch.id}
+												>
+													<Trans>Save</Trans>
+												</PriButton>
+												<PriButton
+													type='button'
+													$variant='text'
+													data-testid={`channel-cancel-${ch.id}`}
+													onClick={cancelEdit}
+												>
+													<Trans>Cancel</Trans>
+												</PriButton>
+											</EditActions>
+											{rowError?.id === ch.id ? (
+												<RowError
+													role='alert'
+													data-testid={`channel-error-${ch.id}`}
+												>
+													{rowError.message}
+												</RowError>
+											) : null}
+										</EditForm>
+									) : (
+										<>
+											<Kind>{kindLabel(ch.kind)}</Kind>
+											<Value>
+												{ch.value}
+												{ch.label ? (
+													<ChannelLabel>{ch.label}</ChannelLabel>
+												) : null}
+												{ch.kind === 'email' &&
+												(ch.verification !== null || ch.confidence !== null) ? (
+													<TrustBadge
+														verification={ch.verification}
+														confidence={ch.confidence}
+														machineCheckable
+													/>
+												) : null}
+											</Value>
+											<RowActions>
+												{ch.kind === 'email' ? (
+													<PriMenu.Root>
+														<PriMenu.Trigger
+															render={props => (
+																<IconButton
+																	type='button'
+																	aria-label={t`How far ${ch.value} is trusted`}
+																	data-testid={`channel-trust-${ch.id}`}
+																	disabled={busyId === ch.id}
+																	{...props}
+																>
+																	<ShieldAlert size={14} />
+																</IconButton>
+															)}
+														/>
+														<PriMenu.Portal>
+															<PriMenu.Positioner sideOffset={6}>
+																<PriMenu.Popup>
+																	{/* Three verbs rather than a picker: a control
+																that can only ever go down is a lie about
+																being two-way. Each is a whole string of its
+																own — Catalan agrees the adjective with a
+																gender a slot cannot carry — and each reuses
+																the word the badge already shows, so the row
+																and the card never say two things about one
+																address. */}
+																	<PriMenu.Item
+																		data-testid='channel-trust-option-unknown'
+																		onClick={() =>
+																			void patchRow(ch, {
+																				verification: 'unknown',
+																			})
+																		}
+																	>
+																		<span>{t`Mark as unverified`}</span>
+																	</PriMenu.Item>
+																	<PriMenu.Item
+																		data-testid='channel-trust-option-risky'
+																		onClick={() =>
+																			void patchRow(ch, {
+																				verification: 'risky',
+																			})
+																		}
+																	>
+																		<span>{t`Mark as risky`}</span>
+																	</PriMenu.Item>
+																	<PriMenu.Item
+																		data-testid='channel-trust-option-undeliverable'
+																		onClick={() =>
+																			void patchRow(ch, {
+																				verification: 'undeliverable',
+																			})
+																		}
+																	>
+																		<span>{t`Mark as undeliverable`}</span>
+																	</PriMenu.Item>
+																	<MenuNote>
+																		<Trans>
+																			This is what we expect before sending. A
+																			bounce is what happened after.
+																		</Trans>
+																	</MenuNote>
+																</PriMenu.Popup>
+															</PriMenu.Positioner>
+														</PriMenu.Portal>
+													</PriMenu.Root>
+												) : null}
+												<IconButton
+													type='button'
+													aria-label={
+														ch.isPrimary
+															? t`${ch.value} is the main ${kindLabel(ch.kind)}`
+															: t`Use ${ch.value} as the main ${kindLabel(ch.kind)}`
+													}
+													data-testid={`channel-primary-${ch.id}`}
+													$active={ch.isPrimary}
+													disabled={ch.isPrimary || busyId === ch.id}
+													onClick={() =>
+														void patchRow(ch, { is_primary: true })
+													}
+												>
+													<Star
+														size={14}
+														{...(ch.isPrimary ? { fill: 'currentColor' } : {})}
+													/>
+												</IconButton>
+												<IconButton
+													type='button'
+													aria-label={t`Edit ${kindLabel(ch.kind)} ${ch.value}`}
+													data-testid={`channel-edit-${ch.id}`}
+													disabled={busyId === ch.id}
+													onClick={() => startEdit(ch)}
+												>
+													<Pencil size={14} />
+												</IconButton>
+												<IconButton
+													type='button'
+													aria-label={t`Remove ${kindLabel(ch.kind)} ${ch.value}`}
+													data-testid={`channel-remove-${ch.id}`}
+													disabled={busyId === ch.id}
+													onClick={() => void handleRemove(ch)}
+												>
+													<Trash2 size={14} />
+												</IconButton>
+											</RowActions>
+											{rowError?.id === ch.id ? (
+												<RowError
+													role='alert'
+													data-testid={`channel-error-${ch.id}`}
+												>
+													{rowError.message}
+												</RowError>
+											) : null}
+										</>
 									)}
-									<IconButton
-										type='button'
-										aria-label={t`Remove ${ch.value}`}
-										disabled={busy}
-										onClick={() => handleRemove(ch.id)}
-									>
-										<Trash2 size={14} />
-									</IconButton>
 								</ChannelRow>
 							))}
 						</ChannelList>
 					)}
 
-					<AddForm onSubmit={handleAdd}>
-						<KindSelect
-							aria-label={t`Channel kind`}
+					{/* Says what each verb means, not what the send path does with it.
+					    The two are not the same — "unverified" asserts nothing, so it
+					    reads like an address nobody checked — and which verdicts stop a
+					    send is the sending side's rule to state, not this dialog's. */}
+					<Note>
+						<Trans>
+							Risky and undeliverable record doubt about an address. Unverified
+							takes a wrong verdict back off without putting anything in its
+							place. Only a check can confirm an address again.
+						</Trans>
+					</Note>
+
+					<AddForm
+						action={() => {
+							void handleAdd()
+						}}
+					>
+						<KindPicker
 							value={newKind}
-							onChange={e => setNewKind(e.target.value)}
+							disabled={adding}
+							label={t`Kind`}
+							testId='channel-add-kind'
+							kindLabel={kindLabel}
+							onChange={setNewKind}
+						/>
+						<PriField.Root>
+							<PriField.Label htmlFor='channel-add-value'>
+								<Trans>Address</Trans>
+							</PriField.Label>
+							<PriInput
+								id='channel-add-value'
+								data-testid='channel-add-value'
+								placeholder={t`name@company.com`}
+								value={newValue}
+								onChange={e => {
+									setNewValue(e.target.value)
+									setAddError(null)
+								}}
+							/>
+						</PriField.Root>
+						<PriField.Root>
+							<PriField.Label htmlFor='channel-add-label'>
+								<Trans>Name</Trans>
+							</PriField.Label>
+							<PriInput
+								id='channel-add-label'
+								data-testid='channel-add-label'
+								placeholder={t`orders, Girona shop…`}
+								value={newLabel}
+								onChange={e => setNewLabel(e.target.value)}
+							/>
+						</PriField.Root>
+						<PriButton
+							type='submit'
+							data-testid='channel-add-submit'
+							disabled={adding || newValue.trim() === ''}
 						>
-							{CHANNEL_KINDS.map(k => (
-								<option key={k} value={k}>
-									{k}
-								</option>
-							))}
-						</KindSelect>
-						<PriInput
-							aria-label={t`Channel value`}
-							placeholder={t`name@company.com`}
-							value={newValue}
-							onChange={e => setNewValue(e.target.value)}
-						/>
-						<PriInput
-							aria-label={t`Channel label`}
-							placeholder={t`orders, Girona shop…`}
-							value={newLabel}
-							onChange={e => setNewLabel(e.target.value)}
-						/>
-						<PriButton type='submit' disabled={busy || newValue.trim() === ''}>
 							<Trans>Add</Trans>
 						</PriButton>
+						{addError ? (
+							<RowError role='alert' data-testid='channel-add-error'>
+								{addError}
+							</RowError>
+						) : null}
 					</AddForm>
 				</PriDialog.Popup>
 			</PriDialog.Portal>
 		</PriDialog.Root>
+	)
+}
+
+// The kinds the picker offers come from the shared list, so one that has an icon
+// and a spoken name is always one somebody can choose.
+//
+// A synthetic click cannot hold this open — the press opens it and the release
+// closes it again — so an agent driving the app by hand should focus the trigger
+// and press ArrowDown instead. See .claude/skills/debug-apps/SKILL.md. Playwright
+// drives it directly, which is what the end-to-end test does.
+function KindPicker({
+	value,
+	disabled,
+	label,
+	testId,
+	kindLabel,
+	onChange,
+}: {
+	readonly value: string
+	readonly disabled: boolean
+	readonly label: string
+	readonly testId: string
+	readonly kindLabel: (kind: string) => string
+	readonly onChange: (kind: string) => void
+}) {
+	return (
+		<PriField.Root>
+			<PriField.Label>{label}</PriField.Label>
+			<PriSelect.Root
+				items={CHANNEL_KINDS.map(kind => ({
+					value: kind,
+					label: kindLabel(kind),
+				}))}
+				value={value}
+				onValueChange={v => {
+					if (typeof v === 'string') onChange(v)
+				}}
+			>
+				<KindTrigger
+					data-testid={testId}
+					aria-label={label}
+					disabled={disabled}
+				>
+					<PriSelect.Value />
+					<ChevronsUpDown size={13} aria-hidden />
+				</KindTrigger>
+				<PriSelect.Portal>
+					<PriSelect.Positioner sideOffset={6}>
+						<PriSelect.Popup>
+							{CHANNEL_KINDS.map(kind => (
+								<PriSelect.Item
+									key={kind}
+									value={kind}
+									data-testid={`${testId}-option-${kind}`}
+								>
+									<PriSelect.ItemIndicator>
+										<Check size={12} aria-hidden />
+									</PriSelect.ItemIndicator>
+									<PriSelect.ItemText>{kindLabel(kind)}</PriSelect.ItemText>
+								</PriSelect.Item>
+							))}
+						</PriSelect.Popup>
+					</PriSelect.Positioner>
+				</PriSelect.Portal>
+			</PriSelect.Root>
+		</PriField.Root>
 	)
 }
 
@@ -236,6 +633,21 @@ const Empty = styled.p`
 	margin: 0 0 var(--space-md);
 `
 
+const Note = styled.p`
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-body-small-size);
+	margin: 0 0 var(--space-sm);
+`
+
+const MenuNote = styled.p`
+	max-width: 16rem;
+	padding: var(--space-2xs) var(--space-xs);
+	margin: 0;
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-label-small-size);
+	border-top: 1px solid var(--color-outline-variant);
+`
+
 const ChannelList = styled.ul`
 	list-style: none;
 	margin: 0 0 var(--space-md);
@@ -248,6 +660,7 @@ const ChannelList = styled.ul`
 const ChannelRow = styled.li`
 	${agedPaperRow}
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: var(--space-xs);
 	padding: var(--space-2xs) var(--space-xs);
@@ -261,15 +674,34 @@ const Kind = styled.span`
 `
 
 const Value = styled.span`
-	flex: 1;
+	flex: 1 1 8rem;
+	/* Without this the box can be squeezed narrower than a word, and a phone
+	   number comes out one number per line. */
+	min-width: 0;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--space-2xs);
 	font-size: var(--typescale-body-small-size);
 	color: var(--color-on-surface);
 	overflow-wrap: anywhere;
 `
 
+// On a phone the buttons take a line of their own, so the address keeps a whole
+// one rather than being wrapped down to a column of fragments.
+const RowActions = styled.div`
+	flex: 1 0 100%;
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+
+	@media (min-width: 480px) {
+		flex: 0 0 auto;
+	}
+`
+
 const ChannelLabel = styled.span`
 	display: inline-block;
-	margin-inline-start: var(--space-xs);
 	padding: 0 var(--space-2xs);
 	border-radius: var(--shape-2xs);
 	background: var(--color-surface-container-high);
@@ -292,18 +724,58 @@ const IconButton = styled.button<{ $active?: boolean }>`
 	}
 `
 
+const EditForm = styled.form`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+	width: 100%;
+
+	@media (min-width: 640px) {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
+		align-items: end;
+	}
+`
+
+// Their own row, so the three fields split the width between them rather than
+// what a Save and a Cancel leave over — which is not enough to read an address in.
+const EditActions = styled.div`
+	display: flex;
+	gap: var(--space-2xs);
+	align-items: center;
+
+	@media (min-width: 640px) {
+		grid-column: 1 / -1;
+		justify-content: flex-end;
+	}
+`
+
+const RowError = styled.p`
+	width: 100%;
+	margin: 0;
+	color: var(--color-primary);
+	font-size: var(--typescale-body-small-size);
+	border-inline-start: 3px solid var(--color-primary);
+	padding-inline-start: var(--space-xs);
+
+	@media (min-width: 768px) {
+		grid-column: 1 / -1;
+	}
+`
+
 const AddForm = styled.form`
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--space-xs);
-	align-items: center;
+	align-items: end;
 `
 
-const KindSelect = styled.select`
-	padding: var(--space-xs) var(--space-sm);
-	background: var(--color-paper-aged);
-	color: var(--color-on-surface);
-	border: none;
-	border-bottom: 2px solid var(--color-outline);
+const KindTrigger = styled(PriSelect.Trigger).withConfig({
+	displayName: 'ChannelKindTrigger',
+})`
+	gap: var(--space-3xs);
+	padding: var(--space-2xs) var(--space-xs);
 	font-size: var(--typescale-body-small-size);
+	text-transform: none;
+	letter-spacing: 0;
 `

--- a/apps/internal/src/components/research/proposal-logic.ts
+++ b/apps/internal/src/components/research/proposal-logic.ts
@@ -5,13 +5,7 @@
  * import from here; the human-readable labels live in those components.
  */
 
-/** Email deliverability verdicts the research agent can attach to a channel. */
-export type VerificationVerdict =
-	| 'deliverable'
-	| 'risky'
-	| 'catch_all'
-	| 'undeliverable'
-	| 'unknown'
+import type { VerificationVerdict } from '@batuda/domain'
 
 /** Outcome of trying to apply or reject one proposal (single or in a batch). */
 export type ProposalOutcome =

--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -31,6 +31,7 @@ import {
 } from '#/components/instructions/stack-picker'
 import { STATUS_ORDER, statusLabels } from '#/components/shared/status-badge'
 import { formatMoneyCents } from '#/lib/format-money'
+import { taggedFailure } from '#/lib/tagged-failure'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
 // Type-only import; adding a schema server-side forces an option here.
@@ -645,30 +646,6 @@ export function ResearchDialog({
 			</PriDialog.Portal>
 		</PriDialog.Root>
 	)
-}
-
-// Pull a specific tagged error out of a promiseExit failure cause. The atom
-// client fails with the decoded API error, so it sits as `error` on one of the
-// cause's reasons; anything else (or a success) reads as null.
-function taggedFailure(
-	cause: unknown,
-	tag: string,
-): Record<string, unknown> | null {
-	if (!cause || typeof cause !== 'object') return null
-	const reasons = (cause as { reasons?: unknown }).reasons
-	if (!Array.isArray(reasons)) return null
-	for (const reason of reasons) {
-		if (!reason || typeof reason !== 'object') continue
-		const error = (reason as { error?: unknown }).error
-		if (
-			error !== null &&
-			typeof error === 'object' &&
-			(error as { _tag?: unknown })._tag === tag
-		) {
-			return error as Record<string, unknown>
-		}
-	}
-	return null
 }
 
 function narrowOptions(value: unknown): ReadonlyArray<StackOption> {

--- a/apps/internal/src/lib/tagged-failure.test.ts
+++ b/apps/internal/src/lib/tagged-failure.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { badRequestMessage, taggedFailure } from './tagged-failure'
+
+const causeWith = (error: unknown) => ({ reasons: [{ error }] })
+
+describe('reading a named error out of a failed mutation', () => {
+	describe('when the cause carries the error asked for', () => {
+		it('should hand it back with its fields', () => {
+			// GIVEN a cause holding a decoded API error
+			const cause = causeWith({ _tag: 'BadRequest', message: 'no good' })
+			// WHEN that tag is asked for
+			// THEN the error comes back whole, so a screen can read its fields
+			expect(taggedFailure(cause, 'BadRequest')).toEqual({
+				_tag: 'BadRequest',
+				message: 'no good',
+			})
+		})
+
+		it('should find it among several reasons', () => {
+			// GIVEN a cause with more than one reason
+			const cause = {
+				reasons: [
+					{ error: { _tag: 'Other' } },
+					{ error: { _tag: 'NotFound' } },
+				],
+			}
+			// THEN the one asked for is found rather than only the first
+			expect(taggedFailure(cause, 'NotFound')).toEqual({ _tag: 'NotFound' })
+		})
+	})
+
+	describe('when it carries something else', () => {
+		it('should answer nothing rather than guess', () => {
+			// GIVEN a failure that is not the one being looked for
+			// THEN nothing comes back, so the caller falls through to its own wording
+			expect(taggedFailure(causeWith({ _tag: 'NotFound' }), 'BadRequest')).toBe(
+				null,
+			)
+		})
+	})
+
+	describe('when the cause is not the shape it expects', () => {
+		it('should answer nothing rather than throw', () => {
+			// GIVEN causes that are missing, primitive, or shaped differently — all
+			// of which reach here from a fault rather than a declared error
+			expect(taggedFailure(null, 'BadRequest')).toBe(null)
+			expect(taggedFailure('boom', 'BadRequest')).toBe(null)
+			expect(taggedFailure({}, 'BadRequest')).toBe(null)
+			expect(taggedFailure({ reasons: 'nope' }, 'BadRequest')).toBe(null)
+			expect(taggedFailure({ reasons: [null, 3] }, 'BadRequest')).toBe(null)
+			expect(taggedFailure(causeWith(null), 'BadRequest')).toBe(null)
+		})
+	})
+})
+
+describe('the sentence the server sent when it turned a write away', () => {
+	describe('when a refusal carries wording', () => {
+		it('should hand back the sentence itself', () => {
+			// GIVEN a refusal written for the reader
+			const cause = causeWith({
+				_tag: 'BadRequest',
+				message: 'That does not look like a valid email: "nope".',
+			})
+			// THEN it can be shown as-is, instead of a generic "try again"
+			expect(badRequestMessage(cause)).toBe(
+				'That does not look like a valid email: "nope".',
+			)
+		})
+	})
+
+	describe('when there is no wording to show', () => {
+		it('should answer nothing', () => {
+			// GIVEN a refusal with an empty or missing message, or a different failure
+			// THEN there is nothing to put on screen and the caller says so its own way
+			expect(badRequestMessage(causeWith({ _tag: 'BadRequest' }))).toBe(null)
+			expect(
+				badRequestMessage(causeWith({ _tag: 'BadRequest', message: '' })),
+			).toBe(null)
+			expect(
+				badRequestMessage(causeWith({ _tag: 'BadRequest', message: 7 })),
+			).toBe(null)
+			expect(badRequestMessage(causeWith({ _tag: 'NotFound' }))).toBe(null)
+		})
+	})
+})

--- a/apps/internal/src/lib/tagged-failure.ts
+++ b/apps/internal/src/lib/tagged-failure.ts
@@ -1,0 +1,42 @@
+/**
+ * Reading a named error back out of a failed mutation.
+ *
+ * A mutation run with `mode: 'promiseExit'` hands back a cause rather than the
+ * error itself, and the API client puts the decoded error inside one of that
+ * cause's reasons. Without digging it out, every failure looks the same and a
+ * screen can only say "try again" — even when the server sent a sentence written
+ * for the reader.
+ *
+ * The shape it digs through belongs to the client, not to us, so it lives in one
+ * place with one test rather than being worked out again wherever it is needed.
+ */
+export function taggedFailure(
+	cause: unknown,
+	tag: string,
+): Record<string, unknown> | null {
+	if (!cause || typeof cause !== 'object') return null
+	const reasons = (cause as { reasons?: unknown }).reasons
+	if (!Array.isArray(reasons)) return null
+	for (const reason of reasons) {
+		if (!reason || typeof reason !== 'object') continue
+		const error = (reason as { error?: unknown }).error
+		if (
+			error !== null &&
+			typeof error === 'object' &&
+			(error as { _tag?: unknown })._tag === tag
+		) {
+			return error as Record<string, unknown>
+		}
+	}
+	return null
+}
+
+/**
+ * The sentence the server sent when it turned a write away, or null when the
+ * failure was something else — a fault, a dropped connection — that has no
+ * wording worth showing.
+ */
+export function badRequestMessage(cause: unknown): string | null {
+	const message = taggedFailure(cause, 'BadRequest')?.['message']
+	return typeof message === 'string' && message !== '' ? message : null
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -130,6 +130,12 @@ msgstr "{0} ara és l'adreça des d'on envies"
 msgid "{0} is the address you send from"
 msgstr "{0} és l'adreça des d'on envies"
 
+#. placeholder {0}: ch.value
+#. placeholder {1}: kindLabel(ch.kind)
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "{0} is the main {1}"
+msgstr "{1} principal: {0}"
+
 #. placeholder {0}: item.row.messageCount
 #: src/components/companies/conversations-tab.tsx
 msgid "{0} messages"
@@ -468,6 +474,8 @@ msgstr "Afegit com a oportunitat verificada"
 msgid "Adding…"
 msgstr "S'està afegint…"
 
+#: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/research/run-labels.ts
 msgid "Address"
 msgstr "Adreça"
@@ -561,6 +569,10 @@ msgstr "Ja resolt"
 #: src/components/companies/company-fit-section.tsx
 msgid "also reported as {0}"
 msgstr "també indicat com a {0}"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "An address can't be blank."
+msgstr "Una adreça no pot estar en blanc."
 
 #: src/routes/oauth/consent.tsx
 msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
@@ -938,6 +950,7 @@ msgstr "Crides"
 #: src/components/companies/followup-dialog.tsx
 #: src/components/companies/proposals-panel.tsx
 #: src/components/contacts/contact-edit-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/stack-editor.tsx
 #: src/components/instructions/template-dialog.tsx
 #: src/components/instructions/template-transfer-dialog.tsx
@@ -1015,18 +1028,6 @@ msgstr "S'han desat els canvis."
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Channel"
 msgstr "Canal"
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Channel kind"
-msgstr "Tipus de canal"
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Channel label"
-msgstr "Etiqueta del canal"
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Channel value"
-msgstr "Valor del canal"
 
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Channels — {contactName}"
@@ -1395,6 +1396,10 @@ msgstr "No s’ha pogut acceptar {0}"
 msgid "Could not add {trimmed}. Please try again."
 msgstr "No s'ha pogut afegir {trimmed}. Torna-ho a provar."
 
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Could not add {value}"
+msgstr "No s'ha pogut afegir {value}"
+
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Could not add as a lead"
 msgstr "No s'ha pogut afegir com a oportunitat"
@@ -1411,6 +1416,11 @@ msgstr "No s'ha pogut aplicar el lot."
 #: src/components/research/run-actions.tsx
 msgid "Could not cancel the run"
 msgstr "No s'ha pogut cancel·lar l'execució"
+
+#. placeholder {0}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Could not change {0}"
+msgstr "No s'ha pogut canviar {0}"
 
 #: src/components/companies/company-owner-control.tsx
 msgid "Could not change owner"
@@ -1674,10 +1684,6 @@ msgstr "No s'ha pogut iniciar la recerca. Torna-ho a provar."
 #: src/components/layout/org-switcher.tsx
 msgid "Could not switch organization. Please try again."
 msgstr "No s'ha pogut canviar d'organització. Torna-ho a provar."
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Could not update channels"
-msgstr "No s'han pogut actualitzar els canals"
 
 #: src/components/research/findings/shared.tsx
 msgid "Could not update the paid action"
@@ -2187,6 +2193,12 @@ msgstr "Edita"
 msgid "Edit {0}"
 msgstr "Edita {0}"
 
+#. placeholder {0}: kindLabel(ch.kind)
+#. placeholder {1}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Edit {0} {1}"
+msgstr "Edita {0} {1}"
+
 #: src/components/shared/editable-field.tsx
 #: src/components/shared/editable-field.tsx
 msgid "Edit {label}"
@@ -2656,6 +2668,11 @@ msgstr "Prioritat alta"
 msgid "Holds the budget"
 msgstr "Té el pressupost"
 
+#. placeholder {0}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "How far {0} is trusted"
+msgstr "Fins a quin punt es confia en {0}"
+
 #: src/components/instructions/stack-editor.tsx
 msgid "How this stack uses the org default"
 msgstr "Com fa servir aquesta pila el valor per defecte de l'organització"
@@ -2879,6 +2896,11 @@ msgstr "Diferenciadors clau"
 #: src/routes/settings/api-keys/index.tsx
 msgid "Keys let AI agents and MCP clients act on behalf of this organization."
 msgstr "Les claus permeten que els agents d'IA i els clients MCP actuïn en nom d'aquesta organització."
+
+#: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Kind"
+msgstr "Tipus"
 
 #: src/routes/pages/index.tsx
 msgid "Lang"
@@ -3104,11 +3126,6 @@ msgstr "Baixa"
 msgid "Low priority"
 msgstr "Prioritat baixa"
 
-#. placeholder {0}: ch.value
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Make {0} primary"
-msgstr "Fes {0} principal"
-
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Make {0} the address you send from"
@@ -3156,6 +3173,18 @@ msgstr "Marca «{0}» com a completada"
 #: src/components/shared/task-item.tsx
 msgid "Mark \"{0}\" as pending"
 msgstr "Marca «{0}» com a pendent"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Mark as risky"
+msgstr "Marca com a arriscat"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Mark as undeliverable"
+msgstr "Marca com a no lliurable"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Mark as unverified"
+msgstr "Marca com a sense verificar"
 
 #: src/routes/companies/$slug.tsx
 msgid "Mark as verified"
@@ -3354,6 +3383,8 @@ msgid "My stacks"
 msgstr "Les meves piles"
 
 #: src/components/contacts/contact-edit-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/stack-editor.tsx
 #: src/components/instructions/template-dialog.tsx
 #: src/routes/companies/index.tsx
@@ -4035,6 +4066,7 @@ msgid "opens in a new tab"
 msgstr "s'obre en una pestanya nova"
 
 #: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 msgid "orders, Girona shop…"
 msgstr "comandes, botiga de Girona…"
 
@@ -4648,14 +4680,19 @@ msgid "Remove \"{0}\" from the stacks that use it first, then delete it."
 msgstr "Treu «{0}» de les piles que la fan servir abans d'eliminar-la."
 
 #. placeholder {0}: att.filename
-#. placeholder {0}: ch.value
 #. placeholder {0}: industry.label
-#: src/components/contacts/manage-channels-dialog.tsx
+#. placeholder {0}: o.name
 #: src/components/emails/attachment-picker.tsx
 #: src/components/instructions/stack-picker.tsx
 #: src/routes/settings/organization/industries.tsx
 msgid "Remove {0}"
 msgstr "Elimina {0}"
+
+#. placeholder {0}: kindLabel(ch.kind)
+#. placeholder {1}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Remove {0} {1}"
+msgstr "Elimina {0} {1}"
 
 #: src/components/shared/editable-field.tsx
 msgid "Remove {chip}"
@@ -4829,6 +4866,10 @@ msgstr "Revoca {0}"
 msgid "Risky"
 msgstr "Arriscat"
 
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Risky and undeliverable record doubt about an address. Unverified takes a wrong verdict back off without putting anything in its place. Only a check can confirm an address again."
+msgstr "Arriscada i no lliurable registren dubtes sobre una adreça. Sense verificar treu un veredicte equivocat sense posar-hi res al seu lloc. Només una comprovació pot tornar a confirmar una adreça."
+
 #: src/components/research/run-labels.ts
 #: src/routes/settings/organization/members.tsx
 msgid "Role"
@@ -4890,6 +4931,7 @@ msgstr "Context comercial"
 #: src/components/companies/documents-panel.tsx
 #: src/components/companies/proposals-panel.tsx
 #: src/components/contacts/contact-edit-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/template-dialog.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -5615,6 +5657,7 @@ msgid "The board could not be fetched. Check that the session is valid, then try
 msgstr "No s'ha pogut carregar el tauler. Comprova que la sessió sigui vàlida i torna-ho a provar."
 
 #: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "El canvi no s'ha completat. Torna-ho a provar."
@@ -5833,6 +5876,10 @@ msgstr "Això no vol dir que no n'hi hagi cap. Torna-ho a provar per veure què 
 #: src/routes/settings/api-keys/index.tsx
 msgid "This is the only time the full key is shown. Store it somewhere safe — I can't show it again."
 msgstr "Aquest és l'únic moment en què es mostra la clau sencera. Desa-la en un lloc segur — no te la puc tornar a mostrar."
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "This is what we expect before sending. A bounce is what happened after."
+msgstr "Això és el que esperem abans d'enviar. Un rebot és el que ha passat després."
 
 #: src/routes/reset-password.tsx
 #: src/routes/reset-password.tsx
@@ -6090,6 +6137,12 @@ msgstr "Pujant…"
 #: src/routes/emails/inboxes.tsx
 msgid "Use {0} as primary"
 msgstr "Fes servir {0} com a principal"
+
+#. placeholder {0}: ch.value
+#. placeholder {1}: kindLabel(ch.kind)
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Use {0} as the main {1}"
+msgstr "Fes servir {0} com a {1} principal"
 
 #: src/routes/settings/mcp/index.tsx
 msgid "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -130,6 +130,12 @@ msgstr "{0} is now the address you send from"
 msgid "{0} is the address you send from"
 msgstr "{0} is the address you send from"
 
+#. placeholder {0}: ch.value
+#. placeholder {1}: kindLabel(ch.kind)
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "{0} is the main {1}"
+msgstr "{0} is the main {1}"
+
 #. placeholder {0}: item.row.messageCount
 #: src/components/companies/conversations-tab.tsx
 msgid "{0} messages"
@@ -468,6 +474,8 @@ msgstr "Added as a verified lead"
 msgid "Adding…"
 msgstr "Adding…"
 
+#: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/research/run-labels.ts
 msgid "Address"
 msgstr "Address"
@@ -561,6 +569,10 @@ msgstr "Already resolved"
 #: src/components/companies/company-fit-section.tsx
 msgid "also reported as {0}"
 msgstr "also reported as {0}"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "An address can't be blank."
+msgstr "An address can't be blank."
 
 #: src/routes/oauth/consent.tsx
 msgid "An AI assistant wants to connect to your Batuda account over MCP and act on your behalf. Only approve assistants you trust."
@@ -938,6 +950,7 @@ msgstr "Calls"
 #: src/components/companies/followup-dialog.tsx
 #: src/components/companies/proposals-panel.tsx
 #: src/components/contacts/contact-edit-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/stack-editor.tsx
 #: src/components/instructions/template-dialog.tsx
 #: src/components/instructions/template-transfer-dialog.tsx
@@ -1015,18 +1028,6 @@ msgstr "Changes have been saved."
 #: src/components/interactions/quick-capture-dialog.tsx
 msgid "Channel"
 msgstr "Channel"
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Channel kind"
-msgstr "Channel kind"
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Channel label"
-msgstr "Channel label"
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Channel value"
-msgstr "Channel value"
 
 #: src/components/contacts/manage-channels-dialog.tsx
 msgid "Channels — {contactName}"
@@ -1395,6 +1396,10 @@ msgstr "Could not accept {0}"
 msgid "Could not add {trimmed}. Please try again."
 msgstr "Could not add {trimmed}. Please try again."
 
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Could not add {value}"
+msgstr "Could not add {value}"
+
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Could not add as a lead"
 msgstr "Could not add as a lead"
@@ -1411,6 +1416,11 @@ msgstr "Could not apply the batch."
 #: src/components/research/run-actions.tsx
 msgid "Could not cancel the run"
 msgstr "Could not cancel the run"
+
+#. placeholder {0}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Could not change {0}"
+msgstr "Could not change {0}"
 
 #: src/components/companies/company-owner-control.tsx
 msgid "Could not change owner"
@@ -1674,10 +1684,6 @@ msgstr "Could not start the research run. Please try again."
 #: src/components/layout/org-switcher.tsx
 msgid "Could not switch organization. Please try again."
 msgstr "Could not switch organization. Please try again."
-
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Could not update channels"
-msgstr "Could not update channels"
 
 #: src/components/research/findings/shared.tsx
 msgid "Could not update the paid action"
@@ -2187,6 +2193,12 @@ msgstr "Edit"
 msgid "Edit {0}"
 msgstr "Edit {0}"
 
+#. placeholder {0}: kindLabel(ch.kind)
+#. placeholder {1}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Edit {0} {1}"
+msgstr "Edit {0} {1}"
+
 #: src/components/shared/editable-field.tsx
 #: src/components/shared/editable-field.tsx
 msgid "Edit {label}"
@@ -2656,6 +2668,11 @@ msgstr "High priority"
 msgid "Holds the budget"
 msgstr "Holds the budget"
 
+#. placeholder {0}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "How far {0} is trusted"
+msgstr "How far {0} is trusted"
+
 #: src/components/instructions/stack-editor.tsx
 msgid "How this stack uses the org default"
 msgstr "How this stack uses the org default"
@@ -2879,6 +2896,11 @@ msgstr "Key differentiators"
 #: src/routes/settings/api-keys/index.tsx
 msgid "Keys let AI agents and MCP clients act on behalf of this organization."
 msgstr "Keys let AI agents and MCP clients act on behalf of this organization."
+
+#: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Kind"
+msgstr "Kind"
 
 #: src/routes/pages/index.tsx
 msgid "Lang"
@@ -3104,11 +3126,6 @@ msgstr "Low"
 msgid "Low priority"
 msgstr "Low priority"
 
-#. placeholder {0}: ch.value
-#: src/components/contacts/manage-channels-dialog.tsx
-msgid "Make {0} primary"
-msgstr "Make {0} primary"
-
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Make {0} the address you send from"
@@ -3156,6 +3173,18 @@ msgstr "Mark \"{0}\" as complete"
 #: src/components/shared/task-item.tsx
 msgid "Mark \"{0}\" as pending"
 msgstr "Mark \"{0}\" as pending"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Mark as risky"
+msgstr "Mark as risky"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Mark as undeliverable"
+msgstr "Mark as undeliverable"
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Mark as unverified"
+msgstr "Mark as unverified"
 
 #: src/routes/companies/$slug.tsx
 msgid "Mark as verified"
@@ -3354,6 +3383,8 @@ msgid "My stacks"
 msgstr "My stacks"
 
 #: src/components/contacts/contact-edit-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/stack-editor.tsx
 #: src/components/instructions/template-dialog.tsx
 #: src/routes/companies/index.tsx
@@ -4035,6 +4066,7 @@ msgid "opens in a new tab"
 msgstr "opens in a new tab"
 
 #: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 msgid "orders, Girona shop…"
 msgstr "orders, Girona shop…"
 
@@ -4648,14 +4680,19 @@ msgid "Remove \"{0}\" from the stacks that use it first, then delete it."
 msgstr "Remove \"{0}\" from the stacks that use it first, then delete it."
 
 #. placeholder {0}: att.filename
-#. placeholder {0}: ch.value
 #. placeholder {0}: industry.label
-#: src/components/contacts/manage-channels-dialog.tsx
+#. placeholder {0}: o.name
 #: src/components/emails/attachment-picker.tsx
 #: src/components/instructions/stack-picker.tsx
 #: src/routes/settings/organization/industries.tsx
 msgid "Remove {0}"
 msgstr "Remove {0}"
+
+#. placeholder {0}: kindLabel(ch.kind)
+#. placeholder {1}: ch.value
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Remove {0} {1}"
+msgstr "Remove {0} {1}"
 
 #: src/components/shared/editable-field.tsx
 msgid "Remove {chip}"
@@ -4829,6 +4866,10 @@ msgstr "Revoke {0}"
 msgid "Risky"
 msgstr "Risky"
 
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Risky and undeliverable record doubt about an address. Unverified takes a wrong verdict back off without putting anything in its place. Only a check can confirm an address again."
+msgstr "Risky and undeliverable record doubt about an address. Unverified takes a wrong verdict back off without putting anything in its place. Only a check can confirm an address again."
+
 #: src/components/research/run-labels.ts
 #: src/routes/settings/organization/members.tsx
 msgid "Role"
@@ -4890,6 +4931,7 @@ msgstr "Sales context"
 #: src/components/companies/documents-panel.tsx
 #: src/components/companies/proposals-panel.tsx
 #: src/components/contacts/contact-edit-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/template-dialog.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/emails/inboxes.tsx
@@ -5615,6 +5657,7 @@ msgid "The board could not be fetched. Check that the session is valid, then try
 msgstr "The board could not be fetched. Check that the session is valid, then try again."
 
 #: src/components/contacts/manage-channels-dialog.tsx
+#: src/components/contacts/manage-channels-dialog.tsx
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "The change didn't go through. Try again."
@@ -5833,6 +5876,10 @@ msgstr "This is not the same as having none. Try again to see what is scheduled.
 #: src/routes/settings/api-keys/index.tsx
 msgid "This is the only time the full key is shown. Store it somewhere safe — I can't show it again."
 msgstr "This is the only time the full key is shown. Store it somewhere safe — I can't show it again."
+
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "This is what we expect before sending. A bounce is what happened after."
+msgstr "This is what we expect before sending. A bounce is what happened after."
 
 #: src/routes/reset-password.tsx
 #: src/routes/reset-password.tsx
@@ -6090,6 +6137,12 @@ msgstr "Uploading…"
 #: src/routes/emails/inboxes.tsx
 msgid "Use {0} as primary"
 msgstr "Use {0} as primary"
+
+#. placeholder {0}: ch.value
+#. placeholder {1}: kindLabel(ch.kind)
+#: src/components/contacts/manage-channels-dialog.tsx
+msgid "Use {0} as the main {1}"
+msgstr "Use {0} as the main {1}"
 
 #: src/routes/settings/mcp/index.tsx
 msgid "Use <0>httpUrl</0>, not <1>url</1> — plain <2>url</2> selects the old SSE transport."

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -1595,6 +1595,7 @@ function DetailBody({
 											</ContactLinkButton>
 											<ContactLinkButton
 												type='button'
+												data-testid={`contact-channels-${contact.id}`}
 												onClick={() =>
 													openDlg({ kind: 'channels', id: contact.id })
 												}

--- a/apps/internal/tests/e2e/contact-channels.test.ts
+++ b/apps/internal/tests/e2e/contact-channels.test.ts
@@ -1,0 +1,236 @@
+import { execSync } from 'node:child_process'
+
+import { expect, test } from '@playwright/test'
+
+import { DATABASE_URL } from './helpers/database-url'
+import { waitForInteractive } from './helpers/hydration'
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
+// Putting a contact's ways of being reached right, from the People tab of a
+// company: correcting an address in place, being told when a correction cannot
+// land, removing one, and choosing which of a kind is the main one.
+//
+// Controlled inputs are driven directly here. The caveat about `fill()` being
+// dropped is specific to PriPasswordInput, whose eye-toggle wrapper owns the
+// change handler; a PriInput used directly takes a programmatic fill fine
+// (docs/frontend.md § PriPasswordInput).
+//
+// Selectors verified against:
+//   apps/internal/src/components/contacts/manage-channels-dialog.tsx
+//   apps/internal/src/routes/companies/$slug.tsx (contact-channels-{id})
+
+const COMPANY_SLUG = 'cal-pep-fonda'
+const SEEDED_EMAIL = 'pep@calpepfonda.cat'
+const CORRECTED_EMAIL = 'pep.casals@calpepfonda.cat'
+const SPARE_EMAIL = 'comandes-e2e@calpepfonda.cat'
+
+const psql = (sqlText: string): string =>
+	execSync(`psql "${DATABASE_URL}" -tA -c "${sqlText.replace(/"/g, '\\"')}"`, {
+		encoding: 'utf8',
+	}).trim()
+
+const contactId = (): string =>
+	psql(
+		`SELECT id FROM contacts WHERE name = 'Pep Casals' ORDER BY created_at LIMIT 1`,
+	).split('\n')[0] as string
+
+const channelId = (address: string): string =>
+	psql(
+		`SELECT id FROM channels WHERE subject_table='contacts' AND address='${address}' LIMIT 1`,
+	).split('\n')[0] as string
+
+const addressesOf = (id: string): string =>
+	psql(
+		`SELECT address FROM channels WHERE subject_table='contacts' AND subject_id='${id}' ORDER BY address`,
+	)
+
+// Adding one shows it twice — in the dialog row and on the card behind it, both
+// re-derived from the same live list — so a bare text match is ambiguous.
+const addSpare = async (page: import('@playwright/test').Page) => {
+	await page.getByTestId('channel-add-value').fill(SPARE_EMAIL)
+	await page.getByTestId('channel-add-submit').click()
+	await expect(page.getByTestId('manage-channels-dialog')).toContainText(
+		SPARE_EMAIL,
+		{ timeout: 10_000 },
+	)
+	return channelId(SPARE_EMAIL)
+}
+
+test.describe('a contact’s ways of being reached', () => {
+	let pep: string
+	let phone: string
+	let phoneWasPrimary: string
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/', { waitUntil: 'commit' })
+		await setActiveOrgBySlug(page, 'taller')
+		pep = contactId()
+		phone = psql(
+			`SELECT id FROM channels WHERE subject_table='contacts' AND subject_id='${pep}' AND channel='phone' LIMIT 1`,
+		).split('\n')[0] as string
+		phoneWasPrimary =
+			phone === ''
+				? ''
+				: (psql(`SELECT is_primary FROM channels WHERE id='${phone}'`).split(
+						'\n',
+					)[0] as string)
+		// Land on `?tab=people` directly: PriTabs reads the active tab from the URL
+		// at SSR, while clicking it needs hydration and races the assertion.
+		await page.goto(`/companies/${COMPANY_SLUG}?tab=people`, {
+			waitUntil: 'networkidle',
+		})
+		await waitForInteractive(page, `contact-channels-${pep}`)
+		await page.getByTestId(`contact-channels-${pep}`).click()
+		await expect(page.getByTestId('manage-channels-dialog')).toBeVisible()
+	})
+
+	test.afterEach(() => {
+		// Put the seeded row back: other suites join on this exact address
+		// (apps/cli/src/commands/seed/emails.ts), so a corrected one left behind
+		// breaks them rather than this spec.
+		psql(
+			`UPDATE channels SET address='${SEEDED_EMAIL}' WHERE subject_table='contacts' AND address='${CORRECTED_EMAIL}'`,
+		)
+		psql(
+			`DELETE FROM channels WHERE subject_table='contacts' AND address='${SPARE_EMAIL}'`,
+		)
+		// The seed leaves these unset, so anything this spec wrote has to come back
+		// off — a verdict or a default left behind changes what the next run sees.
+		psql(
+			`UPDATE channels SET verification=NULL, label=NULL WHERE subject_table='contacts' AND subject_id='${pep}'`,
+		)
+		if (phone !== '')
+			psql(
+				`UPDATE channels SET is_primary=${phoneWasPrimary === 't'} WHERE id='${phone}'`,
+			)
+	})
+
+	test('should correct a wrong address in place, on the card as well as in the dialog', async ({
+		page,
+	}) => {
+		// GIVEN the address on file is wrong
+		const id = channelId(SEEDED_EMAIL)
+
+		// WHEN it is corrected in the row itself
+		await page.getByTestId(`channel-edit-${id}`).click()
+		await page.getByTestId(`channel-value-${id}`).fill(CORRECTED_EMAIL)
+		await page.getByTestId(`channel-save-${id}`).click()
+
+		// THEN the correction is what is stored, and what the card behind the
+		// dialog shows — the rows are re-derived from the same live list
+		await expect(page.getByTestId(`channel-row-${id}`)).toContainText(
+			CORRECTED_EMAIL,
+			{ timeout: 10_000 },
+		)
+		expect(addressesOf(pep)).toContain(CORRECTED_EMAIL)
+		expect(addressesOf(pep)).not.toContain(SEEDED_EMAIL)
+	})
+
+	test('should say what the server said when a correction cannot land, and keep what was typed', async ({
+		page,
+	}) => {
+		// GIVEN a second address already on file — the state a mistyped address and
+		// its correction leave somebody in
+		const spare = await addSpare(page)
+
+		// WHEN the spare is renamed onto the address already there
+		await page.getByTestId(`channel-edit-${spare}`).click()
+		await page.getByTestId(`channel-value-${spare}`).fill(SEEDED_EMAIL)
+		await page.getByTestId(`channel-save-${spare}`).click()
+
+		// THEN the server's own sentence appears beside the box...
+		const problem = page.getByTestId(`channel-error-${spare}`)
+		await expect(problem).toBeVisible({ timeout: 10_000 })
+		await expect(problem).toContainText(SEEDED_EMAIL)
+		// ...the row stays open with what was typed still in it, so nobody has to
+		// retype it from memory...
+		await expect(page.getByTestId(`channel-value-${spare}`)).toHaveValue(
+			SEEDED_EMAIL,
+		)
+		// ...and nothing was merged away
+		expect(addressesOf(pep)).toContain(SPARE_EMAIL)
+		expect(addressesOf(pep)).toContain(SEEDED_EMAIL)
+	})
+
+	test('should refuse an address that could never be one of its kind', async ({
+		page,
+	}) => {
+		// GIVEN a phone number typed into the address box of an email row
+		const id = channelId(SEEDED_EMAIL)
+		await page.getByTestId(`channel-edit-${id}`).click()
+		await page.getByTestId(`channel-value-${id}`).fill('+34 972 100 200')
+
+		// WHEN it is saved
+		await page.getByTestId(`channel-save-${id}`).click()
+
+		// THEN it is turned away in words, and the address on file is untouched
+		await expect(page.getByTestId(`channel-error-${id}`)).toContainText(
+			'valid email',
+			{ timeout: 10_000 },
+		)
+		expect(addressesOf(pep)).toContain(SEEDED_EMAIL)
+	})
+
+	test('should remove an address that should not be there', async ({
+		page,
+	}) => {
+		// GIVEN a throwaway address added for this test — never a seeded one, which
+		// other suites join on and which cannot be put back with its id
+		const spare = await addSpare(page)
+
+		// WHEN it is removed
+		await page.getByTestId(`channel-remove-${spare}`).click()
+
+		// THEN it is gone from the list and from the record
+		await expect(page.getByTestId(`channel-row-${spare}`)).toHaveCount(0, {
+			timeout: 10_000,
+		})
+		expect(addressesOf(pep)).not.toContain(SPARE_EMAIL)
+	})
+
+	test('should make a number the main one, not only an address', async ({
+		page,
+	}) => {
+		// GIVEN the contact's phone, which is not an email — the control used to be
+		// offered on email rows only, though the flag means something for every kind
+		test.skip(phone === '', 'seed has no phone for this contact')
+		// Start from "not the main one" whatever a previous run left behind. The
+		// dialog is part of the URL, so it comes back by itself on reload.
+		psql(`UPDATE channels SET is_primary=false WHERE id='${phone}'`)
+		await page.reload({ waitUntil: 'networkidle' })
+		await expect(page.getByTestId('manage-channels-dialog')).toBeVisible()
+
+		// WHEN it is made the main phone
+		await page.getByTestId(`channel-primary-${phone}`).click()
+
+		// THEN it is, and it says so rather than only showing a filled star
+		await expect(page.getByTestId(`channel-primary-${phone}`)).toBeDisabled({
+			timeout: 10_000,
+		})
+		expect(psql(`SELECT is_primary FROM channels WHERE id='${phone}'`)).toBe(
+			't',
+		)
+	})
+
+	test('should lower how far an address is trusted without touching whether it bounced', async ({
+		page,
+	}) => {
+		// GIVEN an address nobody has ruled on
+		const id = channelId(SEEDED_EMAIL)
+
+		// WHEN somebody marks it risky
+		await page.getByTestId(`channel-trust-${id}`).click()
+		await page.getByTestId('channel-trust-option-risky').click()
+
+		// THEN that is what is recorded...
+		await expect
+			.poll(() => psql(`SELECT verification FROM channels WHERE id='${id}'`), {
+				timeout: 10_000,
+			})
+			.toBe('risky')
+		// ...and the bounce state is untouched, which is the whole point of keeping
+		// the two apart: one is what we expect before sending, the other what
+		// happened after
+		expect(psql(`SELECT status FROM channels WHERE id='${id}'`)).toBe('unknown')
+	})
+})

--- a/apps/server/src/db/migrations/0063_channel_verification_vocabulary.ts
+++ b/apps/server/src/db/migrations/0063_channel_verification_vocabulary.ts
@@ -1,0 +1,88 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Put right what the deliverability column holds, now that the app refuses
+// anything else on the way in.
+//
+// `verification` was free text at every door, so a word nothing in the app
+// understands could be written and then never changed: the edit path deliberately
+// left verdicts alone, so an address stamped with one was stuck with it. Our own
+// data has addresses guessed from a company's email pattern carrying the word
+// "inferred", which no reader knows.
+//
+// Nothing is added to the database to enforce the list. A CHECK belongs here by
+// the usual rule — a closed vocabulary, repaired first — but the deploy applies
+// migrations *before* the new build goes out and the old one keeps serving
+// meanwhile (docs/runbooks.md, Rolling-deploy compatibility). The instance still
+// running accepts any string, so a constraint landing now would start rejecting
+// its writes mid-release. It goes in the release after this one, once no running
+// version can write a word the list does not have.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	// Case and stray spacing first, before anything is judged unrecognisable.
+	// "Deliverable" from the same import that produced "inferred" is exactly as
+	// likely, and demoting that one would put a warning on an address a check had
+	// already cleared.
+	yield* sql`
+		UPDATE channels SET verification = lower(trim(verification))
+		WHERE verification IS NOT NULL
+			AND verification <> lower(trim(verification))
+			AND lower(trim(verification)) IN
+				('deliverable','risky','catch_all','undeliverable','unknown')
+	`
+
+	// Then whatever is left that was never a verdict. "risky" is the honest
+	// reading: a word nobody recognises is not a check that came back, it is
+	// something somebody wrote, and an address carrying it should show doubt.
+	//
+	// Not "unknown", which says a check ran and settled nothing. Nothing ran on
+	// these. Our own data has addresses guessed from a company's email pattern
+	// stamped "inferred" — a guess is exactly what "risky" is for, and filing it
+	// as a finished check would claim more than anybody knows.
+	//
+	// Only rows that hold something. A null verdict is not an unrecognised one:
+	// it means nobody has checked, which is no evidence against the address at
+	// all. Almost every address somebody typed by hand is null, so sweeping those
+	// in would put a warning on the entire book — and there is no way back.
+	yield* sql`
+		UPDATE channels SET verification = 'risky'
+		WHERE verification IS NOT NULL
+			AND verification NOT IN
+				('deliverable','risky','catch_all','undeliverable','unknown')
+	`
+
+	// The score that came with a repaired word is left alone. It is about the
+	// address, not the wording — a model's own confidence, a verifier's score, an
+	// enrichment match strength — and every reader that acts on a verdict wants
+	// `deliverable` before the score matters at all. Clearing it would destroy
+	// something this migration cannot put back.
+
+	// And the rows that belong to nobody. A channel names its subject by two plain
+	// columns because one key cannot point at two tables, so there is no foreign
+	// key to cascade and deleting a contact used to leave their addresses behind.
+	// Those rows still answer: the send gate looks a bounced address up across the
+	// whole organisation without asking whose it is, so a leftover row goes on
+	// blocking mail — and the only way to lift a block is scoped to a contact who
+	// is gone. Deleting a person now takes their channels with them; this clears
+	// what the old behaviour left.
+	yield* sql`
+		DELETE FROM channels
+		WHERE subject_table = 'contacts'
+			AND NOT EXISTS (SELECT 1 FROM contacts c WHERE c.id = channels.subject_id)
+	`
+	// The other two subjects for completeness. Companies are never hard-deleted,
+	// and a branch has cleaned its own channels since the release that gave
+	// branches channels at all, so both are expected to be nothing.
+	yield* sql`
+		DELETE FROM channels
+		WHERE subject_table = 'companies'
+			AND NOT EXISTS (SELECT 1 FROM companies c WHERE c.id = channels.subject_id)
+	`
+	yield* sql`
+		DELETE FROM channels
+		WHERE subject_table = 'sites'
+			AND NOT EXISTS (SELECT 1 FROM sites s WHERE s.id = channels.subject_id)
+	`
+})

--- a/apps/server/src/handlers/contacts.ts
+++ b/apps/server/src/handlers/contacts.ts
@@ -3,7 +3,7 @@ import { HttpApiBuilder } from 'effect/unstable/httpapi'
 import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { BatudaApi, CurrentOrg } from '@batuda/controllers'
+import { BatudaApi, CurrentOrg, NotFound } from '@batuda/controllers'
 import { Contact, ContactChannel } from '@batuda/domain'
 
 import {
@@ -19,6 +19,7 @@ import {
 	channelsOf,
 	clearEmailSuppression,
 	deleteChannel,
+	deleteSubjectChannels,
 	patchChannel,
 	writeChannels,
 } from '../services/channels'
@@ -194,14 +195,34 @@ export const ContactsLive = HttpApiBuilder.group(
 				)
 				.handle('remove', _ =>
 					Effect.gen(function* () {
-						// No foreign key clears these, so they would outlive the
-						// person and point at nobody.
-						yield* unlinkSubject(sql, 'contacts', _.params.id)
-						yield* sql`DELETE FROM contacts WHERE id = ${_.params.id}`
+						const currentOrg = yield* CurrentOrg
+						const subject = { table: 'contacts' as const, id: _.params.id }
+						// How many of their addresses were being kept out of the send
+						// path. Read before the delete, because afterwards there is
+						// nothing left to count, and worth recording: the block is
+						// organisation-wide by address, so it goes with them.
+						const suppressed = yield* sql<{ n: number }>`
+							SELECT count(*)::int AS n FROM channels
+							WHERE subject_table = 'contacts' AND subject_id = ${_.params.id}
+								AND organization_id = ${currentOrg.id}
+								AND status IN ('bounced', 'complained')
+						`
+						const removed = yield* sql`
+							DELETE FROM contacts
+							WHERE id = ${_.params.id} AND organization_id = ${currentOrg.id}
+							RETURNING id
+						`
+						// Only once the person really went, and after them: nothing in the
+						// database clears either of these on its own.
+						if (removed.length > 0) {
+							yield* unlinkSubject(sql, 'contacts', _.params.id)
+							yield* deleteSubjectChannels(sql, currentOrg.id, subject)
+						}
 						yield* Effect.logInfo('Contact removed').pipe(
 							Effect.annotateLogs({
 								event: 'contact.removed',
 								contactId: _.params.id,
+								suppressedChannelsRemoved: suppressed[0]?.n ?? 0,
 							}),
 						)
 					}).pipe(Effect.orDie),
@@ -225,17 +246,51 @@ export const ContactsLive = HttpApiBuilder.group(
 					),
 				)
 				.handle('updateChannel', _ =>
-					patchChannel(sql, _.params.channelId, _.payload).pipe(
-						Effect.flatMap(decodeChannel),
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const patched = yield* patchChannel(
+							sql,
+							currentOrg.id,
+							{ table: 'contacts' as const, id: _.params.id },
+							_.params.channelId,
+							_.payload,
+						)
+						if (patched === undefined)
+							return yield* new NotFound({
+								entity: 'channel',
+								id: _.params.channelId,
+							})
+						return yield* decodeChannel(patched)
+					}).pipe(
+						// Only the two answers reach the caller; everything else is a
+						// fault. Re-failing and then calling orDie would put them back and
+						// kill them, which reads as a server error rather than an answer.
 						Effect.catch(e =>
-							e._tag === 'BadRequest' ? Effect.fail(e) : Effect.die(e),
+							e._tag === 'BadRequest' || e._tag === 'NotFound'
+								? Effect.fail(e)
+								: Effect.die(e),
 						),
 					),
 				)
 				.handle('deleteChannel', _ =>
 					Effect.gen(function* () {
-						yield* deleteChannel(sql, _.params.channelId)
-					}).pipe(Effect.orDie),
+						const currentOrg = yield* CurrentOrg
+						const removed = yield* deleteChannel(
+							sql,
+							currentOrg.id,
+							{ table: 'contacts' as const, id: _.params.id },
+							_.params.channelId,
+						)
+						if (!removed)
+							return yield* new NotFound({
+								entity: 'channel',
+								id: _.params.channelId,
+							})
+					}).pipe(
+						Effect.catch(e =>
+							e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e),
+						),
+					),
 				)
 				.handle('clearSuppression', _ =>
 					Effect.gen(function* () {

--- a/apps/server/src/lib/pg-error.ts
+++ b/apps/server/src/lib/pg-error.ts
@@ -1,0 +1,22 @@
+/**
+ * The Postgres error code (e.g. '22P02' bad-uuid, '23503' fk-violation, '23505'
+ * duplicate-row) can sit a couple of `cause` levels down inside a wrapped
+ * SqlError, so walk the chain rather than reading only the top cause.
+ *
+ * It lives here rather than beside any one caller because two of them now need
+ * it — the research apply path and the channel writes — and they already point
+ * at each other the other way round.
+ */
+export const pgErrorCode = (error: unknown): string | undefined => {
+	let cursor: unknown = error
+	for (
+		let depth = 0;
+		depth < 6 && cursor != null && typeof cursor === 'object';
+		depth++
+	) {
+		const code = (cursor as { code?: unknown }).code
+		if (typeof code === 'string') return code
+		cursor = (cursor as { cause?: unknown }).cause
+	}
+	return undefined
+}

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -24,6 +24,8 @@ import {
 
 import {
 	addChannel,
+	deleteChannel,
+	deleteSubjectChannels,
 	patchChannel,
 	subjectChannelsOf,
 } from '../../services/channels'
@@ -275,7 +277,7 @@ const ManageCompanySites = Tool.make('manage_company_sites', {
 // switchboard only by `site_id`, so a second tool would duplicate the lot.
 const ManageCompanyChannels = Tool.make('manage_company_channels', {
 	description:
-		"The ways of reaching a company — its mailboxes, phones, website, social handles. A company can hold several of a kind, which is the point of this tool: `update_company` writes one email and one phone, and a firm with an orders mailbox, an accounts mailbox and a switchboard needs all of them kept apart. Give each one a `label` in the words somebody would actually use — 'orders', 'accounts', 'Girona shop' — because two addresses with no labels are indistinguishable a month later. Pass `site_id` to hang the channel off one branch instead of the company as a whole. action: 'list' (all of them; add site_id to see one branch's), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). kind is open — email, phone, linkedin, instagram, website, x, bluesky, … — and `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to.",
+		"The ways of reaching a company — its mailboxes, phones, website, social handles. A company can hold several of a kind, which is the point of this tool: `update_company` writes one email and one phone, and a firm with an orders mailbox, an accounts mailbox and a switchboard needs all of them kept apart. Give each one a `label` in the words somebody would actually use — 'orders', 'accounts', 'Girona shop' — because two addresses with no labels are indistinguishable a month later. Pass `site_id` to hang the channel off one branch instead of the company as a whole. action: 'list' (all of them; add site_id to see one branch's), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). An address the company already holds is refused rather than merged, so correcting one onto another means removing the spare instead. kind is open — email, phone, linkedin, instagram, website, x, bluesky, … — and `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind.",
 	parameters: Schema.Struct({
 		action: Schema.Literals(['list', 'add', 'update', 'remove']),
 		company_id: Schema.String,
@@ -568,17 +570,14 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 								AND organization_id = ${currentOrg.id}
 							RETURNING id
 						`
-						// A channel says what it hangs off by table and id, with no
-						// foreign key to follow, so nothing clears these on its own —
-						// they would sit there for good, pointing at a place that is
-						// closed.
+						// Only once the branch really went: the delete above is scoped by
+						// company as well, and this is not, so an id paired with the wrong
+						// company would otherwise strip a branch that is still trading.
 						if (removed.length > 0) {
-							yield* sql`
-								DELETE FROM channels
-								WHERE subject_table = 'sites'
-									AND subject_id = ${params.site_id}
-									AND organization_id = ${currentOrg.id}
-							`
+							yield* deleteSubjectChannels(sql, currentOrg.id, {
+								table: 'sites',
+								id: params.site_id,
+							})
 						}
 					}
 					return { sites: yield* list() }
@@ -625,33 +624,21 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 						})
 					}
 					if (params.action === 'update' && params.channel_id !== undefined) {
-						// Scoped to the subject we just proved is theirs, so a channel id
-						// belonging to another company cannot be edited through it.
-						const mine = yield* sql`
-							SELECT id FROM channels
-							WHERE id = ${params.channel_id}
-								AND subject_table = ${subject.table}
-								AND subject_id = ${subject.id}
-								AND organization_id = ${currentOrg.id}
-							LIMIT 1
-						`
-						if (mine.length > 0) {
-							yield* patchChannel(sql, params.channel_id, {
+						yield* patchChannel(
+							sql,
+							currentOrg.id,
+							subject,
+							params.channel_id,
+							{
 								kind: params.kind,
 								value: params.value,
 								label: params.label,
 								is_primary: params.is_primary,
-							})
-						}
+							},
+						)
 					}
 					if (params.action === 'remove' && params.channel_id !== undefined) {
-						yield* sql`
-							DELETE FROM channels
-							WHERE id = ${params.channel_id}
-								AND subject_table = ${subject.table}
-								AND subject_id = ${subject.id}
-								AND organization_id = ${currentOrg.id}
-						`
+						yield* deleteChannel(sql, currentOrg.id, subject, params.channel_id)
 					}
 					return { channels: yield* subjectChannelsOf(sql, subject) }
 				}).pipe(

--- a/apps/server/src/mcp/tools/contact-channels.integration.test.ts
+++ b/apps/server/src/mcp/tools/contact-channels.integration.test.ts
@@ -1,0 +1,439 @@
+// Exercises manage_contact_channels end-to-end against a real Postgres, driven
+// through the real toolkit handlers the way a `tools/call` would, inside the same
+// org RLS scope (`enterOrgScope`) the /mcp middleware applies.
+//
+// This is the only place a refusal can be checked honestly: every request runs
+// inside one transaction, and a write Postgres rejects poisons it until something
+// rolls back — so a refusal that "works" against an autocommit connection can
+// still take the rest of the call down here. Requires $DATABASE_URL.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { Tool } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../../db/client'
+import { EnvVars } from '../../lib/env'
+import { enterOrgScope } from '../../middleware/org'
+import { applyTestEnv } from '../../test-env'
+import { ContactHandlersLive, ContactTools } from './contacts'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+// Namespaces every row this suite creates so cleanup never touches seed data.
+const MARKER = `channels-verify-${randomUUID()}-`
+
+type Org = { id: string; name: string; slug: string }
+type Tools = typeof ContactTools.tools
+type Channel = {
+	readonly id: string
+	readonly kind: string
+	readonly value: string
+	readonly label: string | null
+	readonly isPrimary: boolean
+	readonly verification: string | null
+	readonly confidence: number | null
+}
+
+const makeRuntime = () =>
+	ManagedRuntime.make(PgLive.pipe(Layer.provide(EnvVars.layer)))
+
+let pool: pg.Pool
+let runtime: ReturnType<typeof makeRuntime>
+let taller: Org
+let ownerId: string
+let company: string
+let pep: string
+let other: string
+
+// Runs a tool the way the MCP server does — validate params, run the handler,
+// take its single result — inside the org's RLS scope.
+const callInOrg = <A, E>(
+	body: Effect.Effect<A, E, CurrentOrg | SqlClient.SqlClient>,
+): Promise<A> =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org: taller, userId: ownerId })(body)
+		}),
+	)
+
+type ManageParams = Tool.Parameters<Tools['manage_contact_channels']>
+
+const manage = (params: ManageParams): Promise<ReadonlyArray<Channel>> =>
+	callInOrg(
+		Effect.gen(function* () {
+			const toolkit = yield* ContactTools
+			const stream = yield* toolkit.handle('manage_contact_channels', params)
+			const [first] = yield* Stream.runCollect(stream)
+			if (first === undefined) return yield* Effect.die(new Error('no result'))
+			return (first.result as { channels: ReadonlyArray<Channel> }).channels
+		}).pipe(Effect.provide(ContactHandlersLive)),
+	)
+
+// A call carrying something the parameters forbid — what an MCP client can put
+// on the wire, and what the schema is there to turn away. Typed loosely on
+// purpose: the point is that it never reaches the handler.
+const manageRaw = (
+	params: Record<string, unknown>,
+): Promise<ReadonlyArray<Channel>> => manage(params as ManageParams)
+
+const deleteContact = (id: string): Promise<unknown> =>
+	callInOrg(
+		Effect.gen(function* () {
+			const toolkit = yield* ContactTools
+			const stream = yield* toolkit.handle('delete_contact', { id })
+			const [first] = yield* Stream.runCollect(stream)
+			return first?.result as unknown
+		}).pipe(Effect.provide(ContactHandlersLive)),
+	)
+
+// What a caller is told when a call is turned away. A refusal is raised as a
+// defect carrying wording written for the assistant, so it surfaces here as a
+// rejected promise rather than a value.
+const refusalFrom = async (call: Promise<unknown>): Promise<string> => {
+	try {
+		await call
+	} catch (error) {
+		return String(error)
+	}
+	throw new Error('expected the call to be refused, but it went through')
+}
+
+const rowsOf = async (contactId: string): Promise<ReadonlyArray<string>> => {
+	const r = await pool.query<{ address: string }>(
+		`SELECT address FROM channels
+		 WHERE subject_table = 'contacts' AND subject_id = $1 ORDER BY address`,
+		[contactId],
+	)
+	return r.rows.map(row => row.address)
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	runtime = makeRuntime()
+
+	const org = await pool.query<Org>(
+		'SELECT id, name, slug FROM organization WHERE slug = $1 LIMIT 1',
+		['taller'],
+	)
+	if (!org.rows[0])
+		throw new Error(
+			"taller org missing — run 'pnpm cli db reset && pnpm cli seed'",
+		)
+	taller = org.rows[0]
+
+	const member = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 LIMIT 1',
+		[taller.id],
+	)
+	if (!member.rows[0])
+		throw new Error("taller has no members — run 'pnpm cli seed'")
+	ownerId = member.rows[0].userId
+
+	const c = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, $3) RETURNING id`,
+		[taller.id, `${MARKER}co`, `${MARKER}Fusteria`],
+	)
+	company = c.rows[0]!.id
+
+	const people = await pool.query<{ id: string }>(
+		`INSERT INTO contacts (organization_id, company_id, name)
+		 VALUES ($1, $2, $3), ($1, $2, $4) RETURNING id`,
+		[taller.id, company, `${MARKER}Pep`, `${MARKER}Berta`],
+	)
+	pep = people.rows[0]!.id
+	other = people.rows[1]!.id
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(
+		`DELETE FROM channels WHERE subject_id IN (SELECT id FROM contacts WHERE name LIKE $1)`,
+		[`${MARKER}%`],
+	)
+	await pool.query(`DELETE FROM channels WHERE subject_id = $1`, [company])
+	await pool.query(`DELETE FROM contacts WHERE name LIKE $1`, [`${MARKER}%`])
+	await pool.query(`DELETE FROM companies WHERE slug = $1`, [`${MARKER}co`])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('managing one person’s ways of being reached', () => {
+	describe('when addresses are added, named, elected and removed one at a time', () => {
+		it('should do each in turn and hand back what is on file', async () => {
+			// GIVEN a person with nothing on file
+			expect(await manage({ action: 'list', contact_id: pep })).toEqual([])
+
+			// WHEN an address is added
+			const added = await manage({
+				action: 'add',
+				contact_id: pep,
+				kind: 'email',
+				value: 'pep@fusteria.cat',
+			})
+			expect(added.map(c => c.value)).toEqual(['pep@fusteria.cat'])
+
+			// AND a second one is added and made the one mail goes to
+			const both = await manage({
+				action: 'add',
+				contact_id: pep,
+				kind: 'email',
+				value: 'comandes@fusteria.cat',
+				label: 'comandes',
+				is_primary: true,
+			})
+			expect(both.filter(c => c.isPrimary).map(c => c.value)).toEqual([
+				'comandes@fusteria.cat',
+			])
+
+			// AND the name given by mistake is taken back off
+			const orders = both.find(c => c.value === 'comandes@fusteria.cat')!
+			const unnamed = await manage({
+				action: 'update',
+				contact_id: pep,
+				channel_id: orders.id,
+				label: null,
+			})
+			expect(unnamed.find(c => c.id === orders.id)?.label).toBeNull()
+
+			// AND it is removed
+			const left = await manage({
+				action: 'remove',
+				contact_id: pep,
+				channel_id: orders.id,
+			})
+
+			// THEN only the first is left, and it holds the default the removed one
+			// was carrying rather than the person being left with none
+			expect(left.map(c => c.value)).toEqual(['pep@fusteria.cat'])
+			expect(left[0]?.isPrimary).toBe(true)
+		})
+	})
+
+	describe('when an address is corrected onto one the person already holds', () => {
+		it('should refuse, keep both, and leave the call able to answer', async () => {
+			// GIVEN the state the issue reports: a typo and its correction both on
+			// file, where the obvious repair is to rename one onto the other
+			await manage({
+				action: 'add',
+				contact_id: pep,
+				kind: 'email',
+				value: 'p@fusteria.cat',
+			})
+			const before = await manage({ action: 'list', contact_id: pep })
+			const typo = before.find(c => c.value === 'p@fusteria.cat')!
+
+			// WHEN the typo is renamed onto the address already there
+			const refusal = await refusalFrom(
+				manage({
+					action: 'update',
+					contact_id: pep,
+					channel_id: typo.id,
+					value: 'pep@fusteria.cat',
+				}),
+			)
+
+			// THEN it is turned away in words that say what to do instead...
+			expect(refusal).toContain('pep@fusteria.cat')
+			expect(refusal).toContain('Remove')
+			// ...both addresses are still there, neither quietly eaten...
+			expect(await rowsOf(pep)).toEqual(['p@fusteria.cat', 'pep@fusteria.cat'])
+			// ...and the next call on the same connection still answers, which a
+			// rejected write left unrolled-back would have made impossible
+			expect((await manage({ action: 'list', contact_id: pep })).length).toBe(2)
+		})
+	})
+
+	describe('when an address could never be one of its kind', () => {
+		it('should refuse it rather than store it', async () => {
+			// GIVEN a phone number offered as an email
+			// WHEN it is added
+			const refusal = await refusalFrom(
+				manage({
+					action: 'add',
+					contact_id: pep,
+					kind: 'email',
+					value: '+34 972 100 200',
+				}),
+			)
+			// THEN it is turned away and nothing is written
+			expect(refusal).toContain('valid email')
+			expect(await rowsOf(pep)).not.toContain('+34 972 100 200')
+		})
+	})
+})
+
+describe('a channel that is not this person’s', () => {
+	describe('when it belongs to somebody else in the same organisation', () => {
+		it('should say so rather than edit them', async () => {
+			// GIVEN an address on another person
+			const hers = await manage({
+				action: 'add',
+				contact_id: other,
+				kind: 'email',
+				value: 'berta@fusteria.cat',
+			})
+			const id = hers[0]!.id
+
+			// WHEN it is edited through the first person
+			const refusal = await refusalFrom(
+				manage({
+					action: 'update',
+					contact_id: pep,
+					channel_id: id,
+					value: 'canviada@fusteria.cat',
+				}),
+			)
+
+			// THEN the caller is told, rather than reading back an unchanged list and
+			// being unable to tell a wrong id from a write that did nothing
+			expect(refusal).toContain(id)
+			expect(await rowsOf(other)).toEqual(['berta@fusteria.cat'])
+		})
+	})
+
+	describe('when it belongs to a company', () => {
+		it('should refuse — every channel of every subject lives in one table', async () => {
+			// GIVEN a company mailbox
+			const ch = await pool.query<{ id: string }>(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address)
+				 VALUES ($1, 'companies', $2, 'email', 'hola@fusteria.cat') RETURNING id`,
+				[taller.id, company],
+			)
+			const id = ch.rows[0]!.id
+
+			// WHEN it is removed through a person
+			const refusal = await refusalFrom(
+				manage({ action: 'remove', contact_id: pep, channel_id: id }),
+			)
+
+			// THEN it is refused and the company keeps its mailbox
+			expect(refusal).toContain(id)
+			const after = await pool.query(`SELECT id FROM channels WHERE id = $1`, [
+				id,
+			])
+			expect(after.rowCount).toBe(1)
+		})
+	})
+
+	describe('when the person belongs to another organisation', () => {
+		it('should answer with nothing rather than reach across', async () => {
+			// GIVEN a contact id from outside this organisation
+			const outsider = await pool.query<{ id: string }>(
+				`SELECT id FROM contacts WHERE organization_id <> $1 LIMIT 1`,
+				[taller.id],
+			)
+			if (!outsider.rows[0]) return
+
+			// WHEN their channels are asked for
+			const channels = await manage({
+				action: 'list',
+				contact_id: outsider.rows[0].id,
+			})
+
+			// THEN nothing comes back — an id alone never proves whose it is
+			expect(channels).toEqual([])
+		})
+	})
+})
+
+describe('how far an address is trusted', () => {
+	describe('when a caller tries to say an address is good', () => {
+		it('should refuse the word outright', async () => {
+			// GIVEN 'deliverable' is the one verdict that opens the send path
+			const list = await manage({ action: 'list', contact_id: pep })
+			// WHEN a caller offers it
+			const refusal = await refusalFrom(
+				manageRaw({
+					action: 'update',
+					contact_id: pep,
+					channel_id: list[0]!.id,
+					verification: 'deliverable',
+				}),
+			)
+			// THEN it never reaches the handler — only a check that reached the
+			// mailbox may say this
+			expect(refusal.length).toBeGreaterThan(0)
+			expect(list[0]?.verification).not.toBe('deliverable')
+		})
+	})
+
+	describe('when a verdict is withdrawn by hand', () => {
+		it('should record it and drop the score that came with the old one', async () => {
+			// GIVEN an address a check called deliverable, with a score behind it
+			const list = await manage({ action: 'list', contact_id: pep })
+			const target = list.find(c => c.value === 'pep@fusteria.cat')!
+			await pool.query(
+				`UPDATE channels SET verification = 'deliverable', confidence = 95 WHERE id = $1`,
+				[target.id],
+			)
+
+			// WHEN somebody who thinks it is wrong marks it undeliverable
+			const after = await manage({
+				action: 'update',
+				contact_id: pep,
+				channel_id: target.id,
+				verification: 'undeliverable',
+			})
+
+			// THEN the verdict is theirs and the old score goes with the claim it
+			// belonged to, rather than lending weight to a new one
+			const updated = after.find(c => c.id === target.id)
+			expect(updated?.verification).toBe('undeliverable')
+			expect(updated?.confidence).toBeNull()
+		})
+	})
+
+	describe('when a verdict is offered to any action but update', () => {
+		it('should say which action sets it', async () => {
+			// GIVEN adding a channel, where a verdict would apply or not depending on
+			// whether the address was already on file — which the caller cannot see
+			const refusal = await refusalFrom(
+				manage({
+					action: 'add',
+					contact_id: pep,
+					kind: 'email',
+					value: 'nova@fusteria.cat',
+					verification: 'risky',
+				}),
+			)
+			// THEN it is refused with the action that does set it named
+			expect(refusal).toContain('update')
+		})
+	})
+})
+
+describe('deleting a person', () => {
+	describe('when they had an address that had bounced', () => {
+		it('should take their channels with them rather than leave the block behind', async () => {
+			// GIVEN somebody whose mailbox the send gate is holding back
+			const c = await pool.query<{ id: string }>(
+				`INSERT INTO contacts (organization_id, company_id, name)
+				 VALUES ($1, $2, $3) RETURNING id`,
+				[taller.id, company, `${MARKER}Rebot`],
+			)
+			const doomed = c.rows[0]!.id
+			await pool.query(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, status)
+				 VALUES ($1, 'contacts', $2, 'email', 'rebot@fusteria.cat', 'bounced')`,
+				[taller.id, doomed],
+			)
+
+			// WHEN they are deleted
+			await deleteContact(doomed)
+
+			// THEN nothing of theirs is left answering. A channel names its subject
+			// by plain columns with no foreign key, so rows left behind would go on
+			// blocking that address for the whole organisation with nobody to lift
+			// it from.
+			expect(await rowsOf(doomed)).toEqual([])
+		})
+	})
+})

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -7,12 +7,20 @@ import {
 	ContactWithChannels,
 	CurrentOrg,
 } from '@batuda/controllers'
-import { Contact, ContactChannel } from '@batuda/domain'
+import {
+	Contact,
+	ContactChannel,
+	HandSetVerificationVerdict,
+} from '@batuda/domain'
 
 import {
+	addChannel,
 	channelsJsonFor,
 	channelsOf,
 	clearEmailSuppression,
+	deleteChannel,
+	deleteSubjectChannels,
+	patchChannel,
 	writeChannels,
 } from '../../services/channels'
 import { requireLiveCompany } from '../../services/company-liveness'
@@ -25,7 +33,10 @@ const decodeContact = Schema.decodeUnknownEffect(Contact)
 const decodeChannels = Schema.decodeUnknownEffect(Schema.Array(ContactChannel))
 
 // One reachable channel. `kind` is open (email, phone, linkedin, x, website,
-// bluesky, …); only the email channel carries a deliverability `verification`.
+// bluesky, …); only the email channel carries a deliverability `verification`,
+// and only ever a verdict that lowers how far the address is trusted — saying
+// one is good is something a mailbox check finds out, not something a caller
+// declares. The score behind a verdict is not accepted here at all.
 const ChannelInput = Schema.Struct({
 	kind: Schema.String,
 	value: Schema.String,
@@ -33,8 +44,10 @@ const ChannelInput = Schema.Struct({
 		description:
 			'Which of several this is, in the words a person would use: "Girona shop", "sales office", "switchboard". Give it whenever somebody holds more than one of a kind — without it a second address is indistinguishable from the first.',
 	}),
-	verification: Schema.optional(Schema.String),
-	confidence: Schema.optional(Schema.Number),
+	verification: Schema.optional(HandSetVerificationVerdict).annotate({
+		description:
+			"How far this address is trusted, and only ever downwards: 'risky', 'undeliverable', or 'unknown' to withdraw a verdict that looks wrong. An address is only ever called deliverable by a check that reached the mailbox.",
+	}),
 	is_primary: Schema.optional(Schema.Boolean),
 })
 
@@ -74,7 +87,7 @@ const CreateContact = Tool.make('create_contact', {
 
 const UpdateContact = Tool.make('update_contact', {
 	description:
-		'Update one or more fields on an existing contact by UUID. Only include fields to change. Pass channels[] to add/refresh reachable addresses. Set clear_email_suppression=true to reset the email channel to "unknown" (use after a bounced/complained contact confirms their address is good again — this re-enables outbound mail to that address).',
+		'Update one or more fields on an existing contact by UUID. Only include fields to change. channels[] only adds an address or refreshes one already on file — it never removes or replaces one, so correcting an address here leaves the old one behind and the person ends up holding both. Use manage_contact_channels to correct, remove, label or re-elect a single channel. Set clear_email_suppression=true to reset the email channel to "unknown" (use after a bounced/complained contact confirms their address is good again — this re-enables outbound mail to that address).',
 	parameters: Schema.Struct({
 		id: Schema.String,
 		site_id: Schema.optional(Schema.NullOr(Schema.String)).annotate({
@@ -96,17 +109,47 @@ const UpdateContact = Tool.make('update_contact', {
 
 const DeleteContact = Tool.make('delete_contact', {
 	description:
-		'Permanently delete a contact by UUID. Cascade-detaches the contact from interactions / proposals / threads via ON DELETE SET NULL — those rows survive with contact_id=NULL. Channels are removed with the contact.',
+		'Permanently delete a contact by UUID. Cascade-detaches the contact from interactions / proposals / threads via ON DELETE SET NULL — those rows survive with contact_id=NULL, so the history stays but stops naming anybody. Their channels go with them, including any record of an address having bounced, so re-creating the person starts that address clean. To fix a wrong address, use manage_contact_channels rather than deleting the person — this loses everything they are attached to.',
 	parameters: Schema.Struct({
 		id: Schema.String,
 	}),
 	success: Schema.Struct({
 		status: Schema.Literal('deleted'),
 	}),
+	dependencies: [CurrentOrg],
 })
 	.annotate(Tool.Title, 'Delete Contact')
 	.annotate(Tool.Destructive, true)
 	.annotate(Tool.Idempotent, true)
+	.annotate(Tool.OpenWorld, false)
+
+// One tool for a person's ways of being reached, with a flat `action` for the
+// same reason the company one has: a strict provider rejects the nested shape a
+// union serialises to.
+const ManageContactChannels = Tool.make('manage_contact_channels', {
+	description:
+		"The ways of reaching one person — their mailboxes, phones, social handles — one at a time. This is where a wrong address is put right: update_contact's channels[] only ever adds, so an address corrected there leaves the old one sitting beside it, and deleting the person to start over detaches every email, meeting and interaction ever logged against them. action: 'list' (all of them), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). Renaming an address onto one this person already holds is refused rather than merged — remove the spare instead. `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind. `verification` only ever lowers how far an address is trusted, and only on 'update'; a later check can raise it again. Leaving somebody with no email address at all means a later research run or an inbound reply will not recognise them and may create a second copy of the same person.",
+	parameters: Schema.Struct({
+		action: Schema.Literals(['list', 'add', 'update', 'remove']),
+		contact_id: Schema.String,
+		channel_id: Schema.optional(Schema.String),
+		kind: Schema.optional(Schema.String),
+		value: Schema.optional(Schema.String),
+		// Nullable so a name given by mistake can be taken back off.
+		label: Schema.optional(Schema.NullOr(Schema.String)),
+		is_primary: Schema.optional(Schema.Boolean),
+		verification: Schema.optional(HandSetVerificationVerdict),
+	}),
+	success: Schema.Struct({
+		channels: Schema.Array(ContactChannel.json),
+	}),
+	dependencies: [CurrentOrg],
+})
+	.annotate(Tool.Title, 'Manage Contact Channels')
+	// 'remove' throws an address away for good, and no other action here can be
+	// undone by repeating it either. The company siblings say otherwise; this is
+	// the honest value for a tool whose whole point is taking one off.
+	.annotate(Tool.Destructive, true)
 	.annotate(Tool.OpenWorld, false)
 
 export const ContactTools = Toolkit.make(
@@ -114,6 +157,7 @@ export const ContactTools = Toolkit.make(
 	CreateContact,
 	UpdateContact,
 	DeleteContact,
+	ManageContactChannels,
 )
 
 export const ContactHandlersLive = ContactTools.toLayer(
@@ -239,12 +283,129 @@ export const ContactHandlersLive = ContactTools.toLayer(
 
 			delete_contact: ({ id }) =>
 				Effect.gen(function* () {
-					// No foreign key clears these, so they would outlive the person
-					// and point at nobody.
-					yield* unlinkSubject(sql, 'contacts', id)
-					yield* sql`DELETE FROM contacts WHERE id = ${id}`
+					const currentOrg = yield* CurrentOrg
+					const subject = { table: 'contacts' as const, id }
+					// How many of their addresses were being kept out of the send path.
+					// Read first, because afterwards there is nothing left to count, and
+					// worth recording: the block is organisation-wide by address, so it
+					// goes with them.
+					const suppressed = yield* sql<{ n: number }>`
+						SELECT count(*)::int AS n FROM channels
+						WHERE subject_table = 'contacts' AND subject_id = ${id}
+							AND organization_id = ${currentOrg.id}
+							AND status IN ('bounced', 'complained')
+					`
+					const removed = yield* sql`
+						DELETE FROM contacts
+						WHERE id = ${id} AND organization_id = ${currentOrg.id}
+						RETURNING id
+					`
+					// Only once the person really went, and after them: no foreign key
+					// clears either of these, so they would outlive the person and point
+					// at nobody.
+					if (removed.length > 0) {
+						yield* unlinkSubject(sql, 'contacts', id)
+						yield* deleteSubjectChannels(sql, currentOrg.id, subject)
+					}
+					yield* Effect.logInfo('Contact removed').pipe(
+						Effect.annotateLogs({
+							event: 'contact.removed',
+							contactId: id,
+							suppressedChannelsRemoved: suppressed[0]?.n ?? 0,
+						}),
+					)
 					return { status: 'deleted' as const }
 				}).pipe(Effect.orDie),
+
+			manage_contact_channels: params =>
+				Effect.gen(function* () {
+					const currentOrg = yield* CurrentOrg
+					const subject = { table: 'contacts' as const, id: params.contact_id }
+					const channels = () =>
+						channelsOf(sql, subject).pipe(Effect.flatMap(decodeChannels))
+
+					// An id only proves the row exists, not whose it is, so without this
+					// a channel could be hung off somebody else's person.
+					const owned = yield* sql`
+						SELECT id FROM contacts
+						WHERE id = ${params.contact_id}
+							AND organization_id = ${currentOrg.id}
+						LIMIT 1
+					`
+					if (owned.length === 0) return { channels: [] }
+
+					// A verdict on any other action would work or not depending on
+					// whether the address was already on file, which is invisible from
+					// the outside — better to say so than to half-apply it.
+					if (params.verification !== undefined && params.action !== 'update')
+						return yield* Effect.die(
+							new ToolMessage(
+								'verification is only set by action: "update", on a channel already on file.',
+							),
+						)
+
+					if (
+						params.action === 'add' &&
+						params.kind !== undefined &&
+						params.value !== undefined
+					) {
+						yield* addChannel(sql, currentOrg.id, subject, {
+							kind: params.kind,
+							value: params.value,
+							// On a new one there is nothing to take back, so a null name
+							// and no name are the same thing.
+							label: params.label ?? undefined,
+							is_primary: params.is_primary,
+						})
+					}
+					if (params.action === 'update' && params.channel_id !== undefined) {
+						const patched = yield* patchChannel(
+							sql,
+							currentOrg.id,
+							subject,
+							params.channel_id,
+							{
+								kind: params.kind,
+								value: params.value,
+								label: params.label,
+								is_primary: params.is_primary,
+								verification: params.verification,
+							},
+						)
+						// Saying nothing here would hand back a list that looks unchanged
+						// because it is, and the caller could not tell a wrong id from a
+						// write that did nothing.
+						if (patched === undefined)
+							return yield* Effect.die(
+								new ToolMessage(
+									`No channel ${params.channel_id} on this contact.`,
+								),
+							)
+					}
+					if (params.action === 'remove' && params.channel_id !== undefined) {
+						const removed = yield* deleteChannel(
+							sql,
+							currentOrg.id,
+							subject,
+							params.channel_id,
+						)
+						if (!removed)
+							return yield* Effect.die(
+								new ToolMessage(
+									`No channel ${params.channel_id} on this contact.`,
+								),
+							)
+					}
+					return { channels: yield* channels() }
+				}).pipe(
+					// An address that could never be one of its kind, or one already on
+					// file, is worth saying in words the assistant can act on rather than
+					// the fixed sentence a raw fault gets.
+					Effect.catchTag('BadRequest', e =>
+						Effect.die(new ToolMessage(e.message)),
+					),
+					Effect.orDie,
+				),
 		}
 	}),
 )

--- a/apps/server/src/services/channel-primary.integration.test.ts
+++ b/apps/server/src/services/channel-primary.integration.test.ts
@@ -11,7 +11,12 @@ import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { PgLive } from '../db/client'
-import { addChannel, patchChannel, subjectChannelsOf } from './channels'
+import {
+	addChannel,
+	deleteChannel,
+	patchChannel,
+	subjectChannelsOf,
+} from './channels'
 
 // Which address a message actually leaves for.
 //
@@ -49,6 +54,48 @@ const add = (address: string, isPrimary?: boolean, label?: string) =>
 			)
 		}),
 	) as Promise<{ readonly id: string }>
+
+const subject = () => ({ table: 'companies' as const, id: company })
+
+const patch = (
+	id: string,
+	change: Parameters<typeof patchChannel>[4],
+): Promise<unknown> =>
+	run(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* patchChannel(sql, ORG, subject(), id, change)
+		}),
+	)
+
+// The refusal message when a write is turned away, or null when it went through.
+const patchRefusal = (
+	id: string,
+	change: Parameters<typeof patchChannel>[4],
+): Promise<string | null> =>
+	run(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* patchChannel(sql, ORG, subject(), id, change)
+			return null
+		}).pipe(Effect.catchTag('BadRequest', e => Effect.succeed(e.message))),
+	)
+
+const remove = (id: string): Promise<boolean> =>
+	run(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* deleteChannel(sql, ORG, subject(), id)
+		}),
+	) as Promise<boolean>
+
+const idOf = async (address: string): Promise<string> => {
+	const rows = await pool.query<{ id: string }>(
+		`SELECT id FROM channels WHERE address = $1 AND subject_id = $2`,
+		[address, company],
+	)
+	return rows.rows[0]!.id
+}
 
 const primaries = async (): Promise<ReadonlyArray<string>> => {
 	const r = await pool.query<{ address: string }>(
@@ -120,18 +167,9 @@ describe('the address a company is written to by default', () => {
 	describe('when the default is handed over by editing a channel', () => {
 		it('should stand the previous one down', async () => {
 			// GIVEN a mailbox that is not the default
-			const rows = await pool.query<{ id: string }>(
-				`SELECT id FROM channels WHERE address = $1 AND subject_id = $2`,
-				['rrhh@netegespla.cat', company],
-			)
-			const id = rows.rows[0]!.id
+			const id = await idOf('rrhh@netegespla.cat')
 			// WHEN it is marked the default
-			await run(
-				Effect.gen(function* () {
-					const sql = yield* SqlClient.SqlClient
-					return yield* patchChannel(sql, id, { is_primary: true })
-				}),
-			)
+			await patch(id, { is_primary: true })
 			// THEN it is the only one
 			expect(await primaries()).toEqual(['rrhh@netegespla.cat'])
 		})
@@ -192,24 +230,286 @@ describe('naming a company mailbox so two can be told apart', () => {
 	describe('when a name was given by mistake', () => {
 		it('should be able to take it back off', async () => {
 			// GIVEN a mailbox carrying a name
-			const rows = await pool.query<{ id: string }>(
-				`SELECT id FROM channels WHERE address = $1 AND subject_id = $2`,
-				['comptabilitat@netegespla.cat', company],
-			)
-			const id = rows.rows[0]!.id
+			const id = await idOf('comptabilitat@netegespla.cat')
 			// WHEN the name is cleared
-			await run(
-				Effect.gen(function* () {
-					const sql = yield* SqlClient.SqlClient
-					return yield* patchChannel(sql, id, { label: null })
-				}),
-			)
+			await patch(id, { label: null })
 			// THEN it carries none, rather than being stuck with the wrong one
 			const after = await pool.query<{ label: string | null }>(
 				`SELECT label FROM channels WHERE id = $1`,
 				[id],
 			)
 			expect(after.rows[0]?.label).toBeNull()
+		})
+	})
+})
+
+describe('putting a wrong address right', () => {
+	describe('when it is renamed onto one already on file', () => {
+		it('should refuse rather than merge, and leave both where they were', async () => {
+			// GIVEN two mailboxes, one of them a near-miss of the other — the state
+			// somebody is in when they typed an address wrong and re-entered it
+			await add('w@netegespla.cat')
+			await add('wattie@netegespla.cat')
+			const wrong = await idOf('w@netegespla.cat')
+
+			// WHEN the wrong one is renamed onto the right one
+			const refusal = await patchRefusal(wrong, {
+				value: 'wattie@netegespla.cat',
+			})
+
+			// THEN it is turned away in words that name the address and say what to
+			// do instead, rather than dying as a fault or silently eating a row
+			expect(refusal).toContain('wattie@netegespla.cat')
+			expect(refusal).toContain('Remove')
+			const rows = await pool.query<{ address: string }>(
+				`SELECT address FROM channels
+				 WHERE subject_id = $1 AND address LIKE '%@netegespla.cat'
+				   AND address IN ('w@netegespla.cat', 'wattie@netegespla.cat')
+				 ORDER BY address`,
+				[company],
+			)
+			expect(rows.rows.map(r => r.address)).toEqual([
+				'w@netegespla.cat',
+				'wattie@netegespla.cat',
+			])
+		})
+
+		it('should leave the connection usable afterwards', async () => {
+			// GIVEN the refusal above happened inside the caller's transaction
+			// WHEN anything else is asked on the same connection
+			const rows = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* subjectChannelsOf(sql, subject())
+				}),
+			)
+			// THEN it answers — a rejected write that poisoned the transaction would
+			// take every later statement down with it
+			expect((rows as ReadonlyArray<unknown>).length).toBeGreaterThan(0)
+		})
+	})
+
+	describe('when only the kind is changed', () => {
+		it('should judge the address on the kind it is being given', async () => {
+			// GIVEN a phone number stored as a phone
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* addChannel(sql, ORG, subject(), {
+						kind: 'phone',
+						value: '+34 972 100 201',
+					})
+				}),
+			)
+			const id = await idOf('+34 972 100 201')
+
+			// WHEN somebody retypes its kind as email, saying nothing about the value
+			const refusal = await patchRefusal(id, { kind: 'email' })
+
+			// THEN it is refused — checking only when the address moves would let a
+			// phone number into the send path carrying no verdict against it, which
+			// is the one state the send gate lets straight through
+			expect(refusal).toContain('valid email')
+			const after = await pool.query<{ channel: string }>(
+				`SELECT channel FROM channels WHERE id = $1`,
+				[id],
+			)
+			expect(after.rows[0]?.channel).toBe('phone')
+		})
+	})
+
+	describe('when an address that bounced stops being an email', () => {
+		it('should take the block with it rather than leave it on a phone row', async () => {
+			// GIVEN a mailbox the send gate is holding back
+			await add('rebotat@netegespla.cat')
+			const id = await idOf('rebotat@netegespla.cat')
+			await pool.query(
+				`UPDATE channels SET status = 'bounced', status_reason = 'mailbox unavailable',
+				 soft_bounce_count = 3, verification = 'undeliverable' WHERE id = $1`,
+				[id],
+			)
+
+			// WHEN it is retyped as a website, which needs no mailbox
+			await patch(id, { kind: 'website', value: 'netegespla.cat' })
+
+			// THEN nothing is left claiming a bounce on a row that is no longer an
+			// address, where no screen would ever show it
+			const after = await pool.query<{
+				status: string
+				status_reason: string | null
+				soft_bounce_count: number
+				verification: string | null
+			}>(
+				`SELECT status, status_reason, soft_bounce_count, verification
+				 FROM channels WHERE id = $1`,
+				[id],
+			)
+			expect(after.rows[0]).toMatchObject({
+				status: 'unknown',
+				status_reason: null,
+				soft_bounce_count: 0,
+				verification: null,
+			})
+		})
+	})
+})
+
+// Its own company, because "the oldest one left" is only readable when the
+// mailboxes on file are the ones the test put there.
+describe('who holds the default once the one holding it is gone', () => {
+	let firm: string
+	const at = () => ({ table: 'companies' as const, id: firm })
+
+	const addTo = (address: string, isPrimary?: boolean) =>
+		run(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				return yield* addChannel(sql, ORG, at(), {
+					kind: 'email',
+					value: address,
+					...(isPrimary === undefined ? {} : { is_primary: isPrimary }),
+				})
+			}),
+		) as Promise<{ readonly id: string }>
+
+	const defaultsOf = async (kind: string): Promise<ReadonlyArray<string>> => {
+		const r = await pool.query<{ address: string }>(
+			`SELECT address FROM channels
+			 WHERE subject_table = 'companies' AND subject_id = $1
+			   AND channel = $2 AND is_primary
+			 ORDER BY address`,
+			[firm, kind],
+		)
+		return r.rows.map(row => row.address)
+	}
+
+	beforeAll(async () => {
+		const c = await pool.query<{ id: string }>(
+			`INSERT INTO companies (organization_id, slug, name)
+			 VALUES ($1, $2, 'Handover SL') RETURNING id`,
+			[ORG, `handover-${randomUUID()}`],
+		)
+		firm = c.rows[0]!.id
+	})
+
+	describe('when the default address is removed', () => {
+		it('should hand it to the oldest one left of that kind', async () => {
+			// GIVEN three mailboxes with the newest holding the default
+			await addTo('un@handover.cat')
+			await addTo('dos@handover.cat')
+			const newest = await addTo('tres@handover.cat', true)
+			expect(await defaultsOf('email')).toEqual(['tres@handover.cat'])
+
+			// WHEN the one holding it is removed
+			const removed = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* deleteChannel(sql, ORG, at(), newest.id)
+				}),
+			)
+			expect(removed).toBe(true)
+
+			// THEN the oldest survivor takes it, rather than the kind being left with
+			// none and every reader picking a different address
+			expect(await defaultsOf('email')).toEqual(['un@handover.cat'])
+		})
+	})
+
+	describe('when the default moves to another kind', () => {
+		it('should leave one default in each kind, not two in one and none in the other', async () => {
+			// GIVEN a mailbox holding the email default, and another email behind it
+			const rows = await pool.query<{ id: string }>(
+				`SELECT id FROM channels WHERE address = $1 AND subject_id = $2`,
+				['un@handover.cat', firm],
+			)
+			// WHEN that row is retyped as a website
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* patchChannel(sql, ORG, at(), rows.rows[0]!.id, {
+						kind: 'website',
+						value: 'handover.cat',
+					})
+				}),
+			)
+
+			// THEN the mailboxes it left behind elect one of their own...
+			expect(await defaultsOf('email')).toEqual(['dos@handover.cat'])
+			// ...and it is the only default among the websites it joined
+			expect(await defaultsOf('website')).toEqual(['handover.cat'])
+		})
+	})
+})
+
+describe('reading the same addresses twice', () => {
+	describe('when two addresses of a kind are read twice', () => {
+		it('should hand them back in the same order both times', async () => {
+			// GIVEN more than one mailbox, none of which is the newest default
+			// WHEN the ways of being reached are read twice
+			const read = async () =>
+				(
+					(await run(
+						Effect.gen(function* () {
+							const sql = yield* SqlClient.SqlClient
+							return yield* subjectChannelsOf(sql, subject())
+						}),
+					)) as ReadonlyArray<{ readonly value: string }>
+				).map(r => r.value)
+
+			// THEN the order is the same — without a tiebreak the rows sort equal and
+			// two readers can each name a different address as "the" one
+			expect(await read()).toEqual(await read())
+		})
+	})
+})
+
+describe('a channel that belongs to somebody else', () => {
+	let otherCompany: string
+	let otherChannel: string
+
+	beforeAll(async () => {
+		const c = await pool.query<{ id: string }>(
+			`INSERT INTO companies (organization_id, slug, name)
+			 VALUES ($1, $2, 'Forn Vidal') RETURNING id`,
+			[ORG, `forn-vidal-${randomUUID()}`],
+		)
+		otherCompany = c.rows[0]!.id
+		const ch = await pool.query<{ id: string }>(
+			`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address)
+			 VALUES ($1, 'companies', $2, 'email', 'hola@fornvidal.cat') RETURNING id`,
+			[ORG, otherCompany],
+		)
+		otherChannel = ch.rows[0]!.id
+	})
+
+	describe('when it is edited through a subject that does not own it', () => {
+		it('should answer nothing and leave the address alone', async () => {
+			// GIVEN a mailbox belonging to another company in the same organisation
+			// WHEN it is edited through this company
+			const result = await patch(otherChannel, { value: 'altre@fornvidal.cat' })
+
+			// THEN nothing happens — an id only proves a row exists, and every
+			// channel of every company, branch and person lives in one table
+			expect(result).toBeUndefined()
+			const after = await pool.query<{ address: string }>(
+				`SELECT address FROM channels WHERE id = $1`,
+				[otherChannel],
+			)
+			expect(after.rows[0]?.address).toBe('hola@fornvidal.cat')
+		})
+	})
+
+	describe('when it is removed through a subject that does not own it', () => {
+		it('should say no row went and leave it there', async () => {
+			// GIVEN the same mailbox
+			// WHEN a removal is asked through this company
+			expect(await remove(otherChannel)).toBe(false)
+			// THEN it is still on file, and the caller can tell a wrong id from a
+			// removal that already happened
+			const after = await pool.query(`SELECT id FROM channels WHERE id = $1`, [
+				otherChannel,
+			])
+			expect(after.rowCount).toBe(1)
 		})
 	})
 })

--- a/apps/server/src/services/channel-verdict.integration.test.ts
+++ b/apps/server/src/services/channel-verdict.integration.test.ts
@@ -1,0 +1,235 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import repairVerdicts from '../db/migrations/0063_channel_verification_vocabulary'
+import { writeChannels } from './channels'
+
+// What survives a write, and what the repair migration does to what is already
+// stored.
+//
+// Both are about the same asymmetry: an address with no verdict is sent to
+// without comment, while any verdict other than `deliverable` makes the send path
+// stop and ask. So losing a verdict is not a cosmetic slip — it quietly reopens
+// an address a check had ruled out. The migration is run here rather than copied,
+// so the statements that ship are the ones under test.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+const ORG = `verdict-org-${randomUUID()}`
+let company: string
+
+const run = <A>(effect: Effect.Effect<A, unknown, SqlClient.SqlClient>) =>
+	effect.pipe(Effect.provide(PgLive), Effect.runPromise)
+
+const subject = () => ({ table: 'companies' as const, id: company })
+
+const write = (channel: {
+	kind: string
+	value: string
+	verification?: 'deliverable' | 'risky' | 'undeliverable' | 'unknown'
+	confidence?: number
+}) =>
+	run(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* writeChannels(sql, ORG, subject(), [channel])
+		}),
+	)
+
+const stored = async (
+	address: string,
+): Promise<{ verification: string | null; confidence: number | null }> => {
+	const r = await pool.query<{
+		verification: string | null
+		confidence: number | null
+	}>(
+		`SELECT verification, confidence FROM channels
+		 WHERE subject_id = $1 AND address = $2`,
+		[company, address],
+	)
+	return r.rows[0]!
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	const c = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, 'Cristalls Roca') RETURNING id`,
+		[ORG, `cristalls-roca-${randomUUID()}`],
+	)
+	company = c.rows[0]!.id
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM channels WHERE organization_id = $1`, [ORG])
+	await pool.query(`DELETE FROM companies WHERE organization_id = $1`, [ORG])
+	await pool.end()
+})
+
+describe('what a verdict survives', () => {
+	describe('when an address is saved again without one', () => {
+		it('should keep the verdict and the score already on file', async () => {
+			// GIVEN an address a check ruled out
+			await write({
+				kind: 'email',
+				value: 'tancat@cristalls.cat',
+				verification: 'undeliverable',
+				confidence: 90,
+			})
+
+			// WHEN the same address is written again saying nothing about it — the
+			// ordinary "re-save this person's addresses" call
+			await write({ kind: 'email', value: 'tancat@cristalls.cat' })
+
+			// THEN the ruling stands. Erased, it would read as "never checked",
+			// which is the one state mail goes out on without comment.
+			expect(await stored('tancat@cristalls.cat')).toEqual({
+				verification: 'undeliverable',
+				confidence: 90,
+			})
+		})
+	})
+
+	describe('when a later check reaches a different conclusion', () => {
+		it('should take the new verdict and the score that came with it', async () => {
+			// GIVEN the same address, now re-checked and merely doubtful
+			await write({
+				kind: 'email',
+				value: 'tancat@cristalls.cat',
+				verification: 'risky',
+			})
+
+			// THEN the fresh ruling replaces the old one, and the old score goes
+			// with the claim it belonged to rather than lending weight to this one
+			expect(await stored('tancat@cristalls.cat')).toEqual({
+				verification: 'risky',
+				confidence: null,
+			})
+		})
+	})
+
+	describe('when only a score arrives', () => {
+		it('should refresh the score and leave the verdict alone', async () => {
+			// GIVEN an address with a verdict on file
+			// WHEN something records a score without re-stating the verdict
+			await write({
+				kind: 'email',
+				value: 'tancat@cristalls.cat',
+				confidence: 40,
+			})
+			// THEN the verdict stands and the score is the new one
+			expect(await stored('tancat@cristalls.cat')).toEqual({
+				verification: 'risky',
+				confidence: 40,
+			})
+		})
+	})
+})
+
+describe('putting stored verdicts right', () => {
+	let orphan: string
+
+	beforeAll(async () => {
+		// Words that reached the column while it was free text, plus the two that
+		// must come through untouched.
+		await pool.query(
+			`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, verification, confidence)
+			 VALUES
+			   ($1, 'companies', $2, 'email', 'a@repair.cat', 'inferred', 55),
+			   ($1, 'companies', $2, 'email', 'b@repair.cat', 'Deliverable', 80),
+			   ($1, 'companies', $2, 'email', 'c@repair.cat', NULL, NULL),
+			   ($1, 'companies', $2, 'email', 'd@repair.cat', 'risky', 30)`,
+			[ORG, company],
+		)
+		// A channel whose contact is already gone — what deleting somebody used to
+		// leave behind.
+		const gone = randomUUID()
+		const o = await pool.query<{ id: string }>(
+			`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, status)
+			 VALUES ($1, 'contacts', $2, 'email', 'orfe@repair.cat', 'bounced') RETURNING id`,
+			[ORG, gone],
+		)
+		orphan = o.rows[0]!.id
+
+		await run(repairVerdicts)
+	})
+
+	describe('when a verdict is only mis-spelled', () => {
+		it('should repair it rather than demote it', async () => {
+			// GIVEN a real verdict written with a capital
+			// THEN it is read as what it plainly says, so an address a check had
+			// cleared is not left carrying a warning
+			expect(await stored('b@repair.cat')).toEqual({
+				verification: 'deliverable',
+				confidence: 80,
+			})
+		})
+	})
+
+	describe('when a word is not a verdict at all', () => {
+		it('should record doubt about it and keep the score', async () => {
+			// GIVEN "inferred" — a pattern-guessed address nothing in the app knows
+			// how to read
+			// THEN it carries doubt, because a word nobody recognises is something
+			// somebody wrote rather than a check that came back. Not "unknown", which
+			// would claim a check ran and settled nothing. The score is about the
+			// address, not the wording, so it stays.
+			expect(await stored('a@repair.cat')).toEqual({
+				verification: 'risky',
+				confidence: 55,
+			})
+		})
+	})
+
+	describe('when nobody has checked an address at all', () => {
+		it('should leave it untouched', async () => {
+			// GIVEN a hand-typed address with no verdict — almost every address on
+			// file
+			// THEN it stays that way. Folding these into "unverified" would put a
+			// warning on the whole book, and nothing here could put it back.
+			expect(await stored('c@repair.cat')).toEqual({
+				verification: null,
+				confidence: null,
+			})
+		})
+
+		it('should leave a verdict that was already right alone', async () => {
+			expect(await stored('d@repair.cat')).toEqual({
+				verification: 'risky',
+				confidence: 30,
+			})
+		})
+	})
+
+	describe('when a channel belongs to somebody who is gone', () => {
+		it('should remove it, and leave the live ones', async () => {
+			// GIVEN an address hanging off a contact that no longer exists, holding a
+			// bounce the send gate still honours organisation-wide
+			const left = await pool.query(`SELECT id FROM channels WHERE id = $1`, [
+				orphan,
+			])
+			// THEN it is gone — nobody could have lifted that block, because the only
+			// way to lift one names a contact who is not there
+			expect(left.rowCount).toBe(0)
+			// AND the addresses that still belong to somebody are untouched
+			const live = await pool.query(
+				`SELECT id FROM channels WHERE organization_id = $1 AND subject_table = 'companies'`,
+				[ORG],
+			)
+			expect(live.rowCount).toBeGreaterThan(0)
+		})
+	})
+})

--- a/apps/server/src/services/channels.ts
+++ b/apps/server/src/services/channels.ts
@@ -1,25 +1,38 @@
 import { DateTime, Effect } from 'effect'
-import type { SqlClient } from 'effect/unstable/sql'
+import type { SqlClient, SqlError } from 'effect/unstable/sql'
 
 import { BadRequest } from '@batuda/controllers'
-import { channelAddressIsValid } from '@batuda/domain'
+import {
+	channelAddressIsValid,
+	type HandSetVerificationVerdict,
+	type VerificationVerdict,
+} from '@batuda/domain'
 
-// The open channel shape both the MCP tool and the HTTP API accept. `kind` and
-// `value` are the names the outside world uses; storage calls them `channel` and
-// `address`. The two are mapped explicitly in one place (see `channelsJsonFor`),
-// so renaming a column never silently changes what a caller receives.
+import { pgErrorCode } from '../lib/pg-error'
+
+// The shape a bulk channel write takes. `kind` and `value` are the names the
+// outside world uses; storage calls them `channel` and `address`. The two are
+// mapped explicitly in one place (see `channelsJsonFor`), so renaming a column
+// never silently changes what a caller receives.
 //
 // `kind` is free text — email, phone, linkedin, x, website, bluesky, … — so a new
 // platform needs no schema change; only the email channel carries a
-// deliverability `verification`. The send-suppression `status` is
-// system-managed (the send gate + the bounce handler), never set by callers
-// here, so re-discovering a bounced address never silently un-suppresses it.
+// deliverability `verification`.
+//
+// The full verdict vocabulary is allowed here because the research pipeline
+// writes through this shape and a mailbox probe is the one thing that may say an
+// address is good. The doors a person or an assistant reaches take the narrower
+// hand-set list instead, so nobody can claim a verdict nobody earned.
+//
+// The send-suppression `status` is system-managed (the send gate + the bounce
+// handler) and is never accepted from a caller, so re-discovering a bounced
+// address cannot quietly un-suppress it.
 export interface ChannelInput {
 	readonly kind: string
 	readonly value: string
 	/** Which of several this is, in a person's words: "Girona shop". */
 	readonly label?: string | undefined
-	readonly verification?: string | undefined
+	readonly verification?: VerificationVerdict | undefined
 	readonly confidence?: number | undefined
 	readonly is_primary?: boolean | undefined
 }
@@ -92,8 +105,20 @@ export const clampConfidence = (
 
 /**
  * Upsert channels for one company or person — additive: re-discovering a handle
- * refreshes it in place and never deletes the others. `status` is deliberately
- * left out of the conflict update so a prior bounced/complained verdict survives.
+ * refreshes it in place and never deletes the others.
+ *
+ * Nothing a write leaves unsaid is erased. A verdict, once established, is only
+ * replaced by another verdict; a write that mentions the address but says nothing
+ * about its deliverability keeps what is on file. That matters because saying
+ * nothing used to mean "no verdict", and no verdict is the one state the send
+ * gate lets straight through — so re-saving a contact's addresses quietly made a
+ * known-dead one sendable again. `addChannel` already worked this way; this is
+ * the two of them agreeing.
+ *
+ * The score follows the verdict that earned it: a fresh verdict brings its own
+ * (even none), while a write carrying only a score refreshes the score alone.
+ * `status` stays out of the conflict update entirely, so a prior
+ * bounced/complained result survives.
  */
 export const writeChannels = (
 	sql: Sql,
@@ -112,8 +137,11 @@ export const writeChannels = (
 			)
 			ON CONFLICT (subject_table, subject_id, channel, address) DO UPDATE SET
 				label = COALESCE(EXCLUDED.label, channels.label),
-				verification = EXCLUDED.verification,
-				confidence = EXCLUDED.confidence,
+				verification = COALESCE(EXCLUDED.verification, channels.verification),
+				confidence = CASE
+					WHEN EXCLUDED.verification IS NOT NULL THEN EXCLUDED.confidence
+					ELSE COALESCE(EXCLUDED.confidence, channels.confidence)
+				END,
 				is_primary = COALESCE(${c.is_primary ?? null}, channels.is_primary),
 				updated_at = now()
 		`,
@@ -147,7 +175,7 @@ export const channelsJsonFor = (sql: Sql, subject: ChannelSubject) =>
 				'isPrimary', ch.is_primary,
 				'status', ch.status,
 				'statusReason', ch.status_reason
-			) ORDER BY ch.is_primary DESC, ch.channel)
+			) ORDER BY ch.is_primary DESC, ch.channel, ch.created_at, ch.id)
 			FROM channels ch
 			WHERE ch.subject_table = ${subject} AND ch.subject_id = c.id
 		), '[]'::json)
@@ -180,7 +208,7 @@ export const channelsOf = (
 	sql`
 		SELECT ${channelRowColumns(sql)} FROM channels
 		WHERE subject_table = ${subject.table} AND subject_id = ${subject.id}
-		ORDER BY is_primary DESC, channel
+		ORDER BY is_primary DESC, channel, created_at, id
 	`
 
 /**
@@ -198,7 +226,7 @@ export const subjectChannelsOf = (
 		SELECT id, subject_table, subject_id, ${channelColumnsWithoutSubject(sql)}
 		FROM channels
 		WHERE subject_table = ${subject.table} AND subject_id = ${subject.id}
-		ORDER BY is_primary DESC, channel
+		ORDER BY is_primary DESC, channel, created_at, id
 	`
 
 /**
@@ -224,7 +252,45 @@ const standDownOtherPrimaries = (sql: Sql, channelId: string) =>
 			)
 	`
 
-/** Add a single channel (the UI's "add"), returning the stored row. */
+/**
+ * Hand the default to the oldest surviving address of a kind, when whatever held
+ * it is gone.
+ *
+ * Taking the default away and putting it nowhere leaves the kind headless, and
+ * the readers do not agree on what happens then — one takes the first row of a
+ * sort, another the first of a different sort. So a screen, a compose box and the
+ * send gate could each name a different address, and a different one again on the
+ * next load. Handing it on immediately is what keeps them saying the same thing.
+ *
+ * The oldest one takes it, and addresses recorded together — which share a
+ * timestamp — are settled by id, so the answer is always the same one rather
+ * than whichever the sort happens to surface.
+ *
+ * Does nothing when the kind still has a default or has no addresses left, so it
+ * is safe to call after any removal.
+ */
+const electPrimaryIfNone = (
+	sql: Sql,
+	orgId: string,
+	subject: { readonly table: ChannelSubject; readonly id: string },
+	kind: string,
+) =>
+	sql`
+		UPDATE channels SET is_primary = true, updated_at = now()
+		WHERE id = (
+			SELECT id FROM channels
+			WHERE subject_table = ${subject.table} AND subject_id = ${subject.id}
+				AND organization_id = ${orgId} AND channel = ${kind}
+			ORDER BY created_at, id
+			LIMIT 1
+		)
+		AND NOT EXISTS (
+			SELECT 1 FROM channels
+			WHERE subject_table = ${subject.table} AND subject_id = ${subject.id}
+				AND organization_id = ${orgId} AND channel = ${kind} AND is_primary
+		)
+	`
+
 /**
  * Turn away an address that could never be one of its kind.
  *
@@ -244,6 +310,7 @@ const assertAddressLooksRight = (kind: string, value: string) =>
 				}),
 			)
 
+/** Add a single channel (the UI's "add"), returning the stored row. */
 export const addChannel = (
 	sql: Sql,
 	orgId: string,
@@ -277,54 +344,169 @@ export const addChannel = (
 	})
 
 /**
- * Edit a channel's reachable value / kind / label / primary flag. Never touches
- * `verification` or the suppression `status` — those are system-derived, so a
- * human rename can't drop the email channel's deliverability verdict.
+ * Edit one of a subject's channels — its address, kind, label, whether it is the
+ * default, and how far its deliverability is trusted.
+ *
+ * The subject is part of the lookup, not something the caller is trusted to have
+ * checked. An id on its own only proves a row exists, and every channel of every
+ * company, branch and person lives in one table, so an unscoped edit would let a
+ * request about one person reach somebody else's address — or a company's
+ * switchboard. Answers `undefined` when the id is not this subject's, which reads
+ * the same as "no such channel" and is what the caller reports.
+ *
+ * `verification` may only ever be lowered here (the type says which words), and
+ * the score goes with it: it belonged to the verdict being replaced, and nobody
+ * setting a verdict by hand has a score to offer. The suppression `status` stays
+ * out of a caller's reach.
  */
 export const patchChannel = (
 	sql: Sql,
+	orgId: string,
+	subject: { readonly table: ChannelSubject; readonly id: string },
 	channelId: string,
 	patch: {
 		readonly kind?: string | undefined
 		readonly value?: string | undefined
 		readonly label?: string | null | undefined
 		readonly is_primary?: boolean | undefined
+		readonly verification?: HandSetVerificationVerdict | undefined
 	},
 ) =>
 	Effect.gen(function* () {
-		// Changing only the address says nothing about what kind it is, so the kind
-		// on file is what decides whether the new address is plausible.
-		if (patch.value !== undefined) {
-			const kind =
-				patch.kind ??
-				(yield* sql<{
-					channel: string
-				}>`SELECT channel FROM channels WHERE id = ${channelId} LIMIT 1`)[0]
-					?.channel
-			if (kind !== undefined) {
-				yield* assertAddressLooksRight(kind, patch.value)
-			}
+		const stored = (yield* sql<{
+			channel: string
+			address: string
+			isPrimary: boolean
+		}>`
+			SELECT channel, address, is_primary FROM channels
+			WHERE id = ${channelId} AND subject_table = ${subject.table}
+				AND subject_id = ${subject.id} AND organization_id = ${orgId}
+			LIMIT 1
+		`)[0]
+		if (stored === undefined) return undefined
+
+		// Changing one half says nothing about the other, so whichever half is not
+		// being changed comes off the row. Checking only when the address moves
+		// would let a phone number be relabelled an email and walk into the send
+		// path, where no verdict reads as nothing known against it.
+		if (patch.kind !== undefined || patch.value !== undefined) {
+			yield* assertAddressLooksRight(
+				patch.kind ?? stored.channel,
+				patch.value ?? stored.address,
+			)
 		}
-		const data: Record<string, unknown> = {
-			updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
-		}
+
+		const now = DateTime.toDateUtc(DateTime.nowUnsafe())
+		const data: Record<string, unknown> = { updatedAt: now }
 		if (patch.kind !== undefined) data['channel'] = patch.kind
 		if (patch.value !== undefined) data['address'] = patch.value
 		if (patch.label !== undefined) data['label'] = patch.label
 		if (patch.is_primary !== undefined) data['isPrimary'] = patch.is_primary
-		const rows = yield* sql`
-			UPDATE channels SET ${sql.update(data)}
-			WHERE id = ${channelId} RETURNING ${channelRowColumns(sql)}
-		`
-		if (patch.is_primary === true) {
+		if (patch.verification !== undefined) {
+			data['verification'] = patch.verification
+			data['confidence'] = null
+		}
+		// A row that stops being an email takes the email-only bookkeeping with it.
+		// Left behind, a bounce recorded against the old address would go on
+		// blocking mail while sitting on something that is no longer an address at
+		// all, and no screen would show it.
+		const leavingEmail =
+			patch.kind !== undefined &&
+			stored.channel === 'email' &&
+			patch.kind !== 'email'
+		if (leavingEmail) {
+			data['verification'] = null
+			data['confidence'] = null
+			data['status'] = 'unknown'
+			data['statusReason'] = null
+			data['statusUpdatedAt'] = now
+			data['softBounceCount'] = 0
+		}
+
+		// One address of a kind per subject, so renaming onto one already on file
+		// is a collision rather than a merge. Wrapped in its own transaction: the
+		// whole request runs inside one, and a rejected write poisons it until
+		// something rolls back — this rolls back only as far as the attempt, so
+		// the refusal can still be answered with the list it was asked about.
+		const rows = yield* sql
+			.withTransaction(
+				sql`
+					UPDATE channels SET ${sql.update(data)}
+					WHERE id = ${channelId} RETURNING ${channelRowColumns(sql)}
+				`,
+			)
+			.pipe(
+				Effect.catchTag(
+					'SqlError',
+					(error): Effect.Effect<never, BadRequest | SqlError.SqlError> =>
+						pgErrorCode(error) === '23505'
+							? Effect.fail(
+									new BadRequest({
+										message: `"${patch.value ?? stored.address}" is already on file as a ${patch.kind ?? stored.channel}. Remove the one you meant to replace rather than renaming onto it.`,
+									}),
+								)
+							: Effect.fail(error),
+				),
+			)
+
+		// A row carrying the default into another kind would leave two there and
+		// none behind it.
+		const kindChanged =
+			patch.kind !== undefined && patch.kind !== stored.channel
+		if (patch.is_primary === true || (kindChanged && stored.isPrimary)) {
 			yield* standDownOtherPrimaries(sql, channelId)
+		}
+		if (kindChanged && stored.isPrimary) {
+			yield* electPrimaryIfNone(sql, orgId, subject, stored.channel)
 		}
 		return rows[0]
 	})
 
-/** Remove a channel by id. */
-export const deleteChannel = (sql: Sql, channelId: string) =>
-	sql`DELETE FROM channels WHERE id = ${channelId}`
+/**
+ * Remove one of a subject's channels, scoped the same way an edit is. Answers
+ * whether a row went, so a caller can tell a wrong id from a repeat.
+ */
+export const deleteChannel = (
+	sql: Sql,
+	orgId: string,
+	subject: { readonly table: ChannelSubject; readonly id: string },
+	channelId: string,
+) =>
+	Effect.gen(function* () {
+		const removed = yield* sql<{ channel: string; isPrimary: boolean }>`
+			DELETE FROM channels
+			WHERE id = ${channelId} AND subject_table = ${subject.table}
+				AND subject_id = ${subject.id} AND organization_id = ${orgId}
+			RETURNING channel, is_primary
+		`
+		const gone = removed[0]
+		if (gone === undefined) return false
+		if (gone.isPrimary) {
+			yield* electPrimaryIfNone(sql, orgId, subject, gone.channel)
+		}
+		return true
+	})
+
+/**
+ * Remove every way of reaching one company, branch or person — for when the
+ * subject itself is going.
+ *
+ * Nothing in the database does this on its own: a channel names its subject by a
+ * pair of plain columns, because one key cannot point at two tables, so there is
+ * no foreign key to cascade. Left behind, the rows outlive whoever they belonged
+ * to and keep answering — a bounce recorded against one of them goes on blocking
+ * that address for the whole organisation, with nobody left to lift it from.
+ */
+export const deleteSubjectChannels = (
+	sql: Sql,
+	orgId: string,
+	subject: { readonly table: ChannelSubject; readonly id: string },
+) =>
+	sql`
+		DELETE FROM channels
+		WHERE subject_table = ${subject.table} AND subject_id = ${subject.id}
+			AND organization_id = ${orgId}
+	`
 
 /**
  * Reset a person's email suppression to `unknown` — used after a

--- a/apps/server/src/services/research-apply.test.ts
+++ b/apps/server/src/services/research-apply.test.ts
@@ -208,11 +208,33 @@ describe('validateCreate', () => {
 				{
 					kind: 'email',
 					value: 'ada@acme.es',
-					verification: 'valid',
+					// The proposal said 'valid', which is not one of the deliverability
+					// verdicts. The word goes and the address stays: these fields come
+					// out of a model's free-form JSON, and losing a found address over a
+					// stray word about it would throw away the part worth having.
+					verification: undefined,
 					confidence: 90,
 					is_primary: true,
 				},
 			])
+		})
+
+		it('should keep a verdict the vocabulary knows', () => {
+			// GIVEN the same proposal with a real deliverability verdict
+			const result = validateCreate({
+				...base,
+				fields: {
+					...(base['fields'] as Record<string, unknown>),
+					channels: [
+						{ kind: 'email', value: 'ada@acme.es', verification: 'risky' },
+					],
+				},
+			})
+
+			// THEN it survives — only words nothing understands are dropped
+			expect(result.ok).toBe(true)
+			if (!result.ok) return
+			expect(result.channels[0]?.verification).toBe('risky')
 		})
 	})
 

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -7,6 +7,7 @@ import {
 	COMPANY_PRIORITIES,
 	COMPANY_SIZE_RANGES,
 	COMPANY_STATUSES,
+	isVerificationVerdict,
 } from '@batuda/domain'
 
 export {
@@ -14,6 +15,7 @@ export {
 	researchProvenance,
 } from './research-provenance'
 
+import { pgErrorCode } from '../lib/pg-error'
 import {
 	type ChannelInput,
 	splitCompanyChannelFields,
@@ -276,6 +278,13 @@ export const validate = (proposal: Record<string, unknown>): Validated => {
 // Channels arrive from contact discovery as { kind, value, verification?,
 // confidence?, is_primary? }. Keep only well-formed entries — a channel needs
 // both a kind and a value to be reachable.
+//
+// A verdict nobody recognises is dropped and the address kept, rather than the
+// whole proposal being refused. These fields come out of a model's free-form
+// JSON, and a found address is the part that was worth having: throwing it away
+// over a stray word about its deliverability loses the finding to protect a
+// footnote. The tools a person or an assistant calls do the opposite and refuse
+// outright, because there the caller can be told which words are allowed.
 const parseChannels = (raw: unknown): ReadonlyArray<ChannelInput> => {
 	if (!Array.isArray(raw)) return []
 	const channels: ChannelInput[] = []
@@ -291,7 +300,10 @@ const parseChannels = (raw: unknown): ReadonlyArray<ChannelInput> => {
 		channels.push({
 			kind,
 			value,
-			verification: typeof verification === 'string' ? verification : undefined,
+			verification:
+				typeof verification === 'string' && isVerificationVerdict(verification)
+					? verification
+					: undefined,
 			confidence: typeof confidence === 'number' ? confidence : undefined,
 			is_primary: typeof isPrimary === 'boolean' ? isPrimary : undefined,
 		})
@@ -359,23 +371,6 @@ const setProposalStatus = (
 			updated_at = now()
 		WHERE id = ${runId} AND organization_id = ${orgId}
 	`
-
-// The Postgres error code (e.g. '22P02' bad-uuid, '23503' fk-violation) can sit a
-// couple of `cause` levels down inside a wrapped SqlError, so walk the chain
-// rather than reading only the top cause.
-const pgErrorCode = (error: unknown): string | undefined => {
-	let cursor: unknown = error
-	for (
-		let depth = 0;
-		depth < 6 && cursor != null && typeof cursor === 'object';
-		depth++
-	) {
-		const code = (cursor as { code?: unknown }).code
-		if (typeof code === 'string') return code
-		cursor = (cursor as { cause?: unknown }).cause
-	}
-	return undefined
-}
 
 // What an apply records about a company beyond the proposed values themselves:
 // where each value came from, and — when this company is the one the run was

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -572,8 +572,14 @@ Non-secret deployed config does **not** ride this path: boot-required non-secret
 
 ```
 companies           — core entity, all prospect/client data
-contacts            — people at companies (email stays the canonical send address)
-contact_channels    — open per-contact channel list (email, phone, linkedin, x, website, bluesky...)
+contacts            — people at companies
+sites               — a company's branches (each with its own channels and people)
+channels            — open ways of reaching a company, a branch or a person
+                      (email, phone, linkedin, x, website, bluesky...); one table
+                      keyed by subject_table + subject_id, with no foreign key,
+                      so a subject's rows are deleted by hand when it goes
+company_relations   — how two companies are connected (group, supplier, ...)
+company_industries  — the trades an organisation files its companies under
 interactions        — every touchpoint (call, visit, email, DM...)
 tasks               — follow-up queue
 products            — service/product catalog

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -415,6 +415,16 @@ A read answers with nothing: `success: Schema.NullOr(...)`. An action says what 
 
 Two traps. `Effect.orDie` maps the whole error channel to `never`, so catching an error and re-failing it *before* an `orDie` puts it straight back and kills it — the endpoint answers 500 while type-checking perfectly. Write `Effect.catch(e => e._tag === 'NotFound' ? Effect.fail(e) : Effect.die(e))` with no trailing `orDie`. And wrapping a success in `NullOr` makes the flat-result rule in `_annotations.test.ts` pass vacuously unless it looks through the null branch, because the top level stops being an object.
 
+### Ways of reaching a company, a branch or a person
+
+They all live in one `channels` table, named by `subject_table` + `subject_id`. One key cannot point at two tables, so there is no foreign key — which means nothing cascades, and a subject's channels are deleted by hand when the subject goes. `deleteSubjectChannels` is that hand. Left behind, the rows outlive whoever they belonged to and keep answering: the send gate looks a bounced address up across the whole organisation without asking whose it is.
+
+A bulk write (`channels[]` on create/update contact, and the research apply path) only ever adds or refreshes. Correcting or removing one goes through `manage_contact_channels` / `manage_company_channels`, and both scope every edit to the subject as well as the id — an id alone only proves a row exists, not whose it is. Renaming an address onto one the subject already holds is refused rather than merged, because merging would delete a row the caller never named; the refusal is a `BadRequest` mapped from the unique violation, raised inside its own transaction so it does not poison the request it arrived on.
+
+Exactly one channel of each kind is the primary, and removing the one holding it hands it to the oldest left rather than leaving the kind headless — otherwise the readers disagree about which address is "the" one, and disagree differently on the next page load.
+
+`verification` is what a deliverability check found, and only `deliverable` lets the send path through unremarked — no verdict at all also passes, because there is no evidence against the address. So a write that says nothing about a verdict keeps the one on file rather than clearing it. The vocabulary lives in `packages/domain`; callers may only ever lower a verdict, since saying an address is good is something only a mailbox probe finds out. The suppression `status` is a separate axis, written by the bounce handler and never by a caller.
+
 ### How a list endpoint answers
 
 A list endpoint answers with the same envelope, built by `PaginatedList` in `packages/controllers/src/pagination.ts`. Not every list has been moved onto it yet — several short ones (an org's API keys, an inbox's footers, the instruction templates) still answer with a bare array — but any list that grows with the business belongs on the envelope, and a new one should start there.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -439,6 +439,7 @@ const StatusBadge = styled.span<{ $status: string }>`
 | ---------------- | ------------- | ---------------------------------------------------------- |
 | `PriButton`      | `Button`      | All interactive buttons                                    |
 | `PriInput`       | `Input`       | Text inputs in forms                                       |
+| `PriField`       | `Field`       | Labelled fields with their validation text                 |
 | `PriSelect`      | `Select`      | Status and size dropdowns                                  |
 | `PriDialog`      | `Dialog`      | Interaction log modal, company quick-edit                  |
 | `PriTabs`        | `Tabs`        | Company detail (Overview / Conversations / People / Files) |
@@ -447,6 +448,8 @@ const StatusBadge = styled.span<{ $status: string }>`
 | `PriSwitch`      | `Switch`      | A setting that takes effect the moment it is flicked       |
 | `PriTooltip`     | `Tooltip`     | Short field explanations                                   |
 | `PriCollapsible` | `Collapsible` | Expandable sections on company detail                      |
+
+`PriField` is where a validation message belongs. It ties the label, the control and `PriField.Error` together, so what the server said is announced with the input rather than floating beside it, and the label is visible as well as spoken — three unlabelled boxes in a row say nothing about which is the address. Reach for it instead of an `aria-label`ed bare `PriInput` and a hand-rolled error paragraph. A message the server sent rather than the browser needs `match={true}` on the error, which is what tells Base UI to show it.
 
 A folded `PriCollapsible` panel keeps its text on the page rather than dropping it, so the browser's own find-in-page reaches it and opens the section on a match. That is `hiddenUntilFound`, defaulted on in the wrapper — pass `hiddenUntilFound={false}` where content should not linger while folded, as the company timeline does because it holds a status line read aloud by screen readers. It relies on Tailwind's reset scoping `display: none` to `[hidden]:where(:not([hidden='until-found']))`; without that carve-out a folded section would be permanently invisible rather than merely unfindable.
 
@@ -710,6 +713,8 @@ const update = useAtomSet(updateTemplateAtom, { mode: 'promiseExit' })
 
 A query resolves to an `AsyncResult` — narrow it with `AsyncResult.isSuccess` / `isFailure`. `useAtomRefresh` keeps serving the **previous** value while the new one is in flight, so a component that must show what was just written should read the mutation's own reply rather than waiting on the refreshed list.
 
+A mutation run with `mode: 'promiseExit'` fails with a cause rather than the error itself, and the client buries the decoded error inside it — so without digging, every failure looks alike and a screen can only say "try again". `taggedFailure(cause, tag)` in `src/lib/tagged-failure.ts` pulls a named one back out, and `badRequestMessage(cause)` gets straight to the sentence the server wrote for the reader.
+
 Auth is the exception: it goes through `authClient` (Better Auth). `createServerFn` is used in exactly one place, `src/lib/server-cookie.ts`, for cookie access during SSR — not for reaching the API.
 
 ---
@@ -824,6 +829,12 @@ Every list on this page is decided by the server, not assembled in the browser. 
 - **Conversations tab:** emails, calls, meetings and logged interactions in one feed
 - **People tab:** the company's contacts; the tab badge counts everyone on file, not the rows fetched
 - **Files tab:** documents, offers and landing pages, each loading further rows as you reach the end of them
+
+"Manage channels", on a contact in the People tab, is where a person's ways of being reached are put right: added, corrected in place, removed, and told which of a kind is the main one. Rows edit one at a time and only the row being saved is disabled, so a slow write on one address never freezes the rest. An address the contact already holds is refused rather than merged — the server says so in words, shown beside the box with what was typed still in it — because merging would delete a row nobody named.
+
+How far an address is trusted and whether it bounced are two different facts, shown in two different places. The trust badge says what is expected before sending; the suppression banner and its Clear action say what happened after. Trust can only be lowered by hand — `deliverable` is what a check establishes, so nobody at a keyboard may write it — and a later research check can raise it again.
+
+The three verbs do two different jobs, which the wording has to keep apart. Risky and undeliverable record doubt about an address. Unverified asserts nothing — it takes a wrong verdict back off, leaving the address reading as one nobody has checked. The dialog deliberately says only that, and does not promise what a send will do about it: which verdicts stop a send is the sending side's rule, it has changed, and copy that enumerated it would go stale here. Nothing in the web app reads a verdict before sending in any case.
 
 Documents also have a screen of their own at `/documents`, and one page each at `/documents/$id`.
 

--- a/packages/controllers/src/routes/contacts.ts
+++ b/packages/controllers/src/routes/contacts.ts
@@ -5,23 +5,32 @@ import {
 	HttpApiSchema,
 } from 'effect/unstable/httpapi'
 
-import { Contact, ContactChannel } from '@batuda/domain'
+import {
+	Contact,
+	ContactChannel,
+	HandSetVerificationVerdict,
+} from '@batuda/domain'
 
-import { BadRequest } from '../errors'
+import { BadRequest, NotFound } from '../errors'
 import { OrgMiddleware } from '../middleware/org'
 import { SessionMiddleware } from '../middleware/session'
 import { PaginatedList, pageQuery } from '../pagination'
 
 // A reachable channel supplied in bulk (agent/import path). `kind` is open
 // (email, phone, linkedin, x, website, bluesky, …); only the email channel
-// carries a deliverability `verification`. Suppression status is
-// system-managed and never accepted from a client.
+// carries a deliverability `verification`.
+//
+// A verdict here may only ever lower how far an address is trusted: saying one
+// is good is a thing a mailbox probe finds out, and `deliverable` is the single
+// word the send gate lets through, so a caller able to write it could clear its
+// own way. The confidence score that goes with a verdict is not accepted at all
+// — it belongs to whatever established the verdict. Suppression status is
+// system-managed and never accepted from a client either.
 const ChannelInput = Schema.Struct({
 	kind: Schema.String,
 	value: Schema.String,
 	label: Schema.optional(Schema.String),
-	verification: Schema.optional(Schema.String),
-	confidence: Schema.optional(Schema.Number),
+	verification: Schema.optional(HandSetVerificationVerdict),
 	is_primary: Schema.optional(Schema.Boolean),
 })
 
@@ -45,8 +54,8 @@ const UpdateContactInput = Schema.Struct({
 	channels: Schema.optional(Schema.Array(ChannelInput)),
 })
 
-// Granular channel edits (the human UI). Value/kind/primary only — never the
-// system-derived verification or suppression status.
+// Granular channel edits (the human UI). Never the suppression status, and
+// never a verdict that says an address is good — see `ChannelInput` above.
 const AddChannelInput = Schema.Struct({
 	kind: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 	value: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
@@ -58,11 +67,16 @@ const AddChannelInput = Schema.Struct({
 
 const PatchChannelInput = Schema.Struct({
 	kind: Schema.optional(Schema.String),
-	value: Schema.optional(Schema.String),
+	// Held to the same minimum as adding one: most kinds have no shape to check
+	// against, so without this a blank would be stored as an address.
+	value: Schema.optional(
+		Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+	),
 	// Nullable so a name given by mistake can be taken back off; leaving it out
 	// keeps whatever is there.
 	label: Schema.optional(Schema.NullOr(Schema.String)),
 	is_primary: Schema.optional(Schema.Boolean),
+	verification: Schema.optional(HandSetVerificationVerdict),
 })
 
 // A contact plus its reachable channels. `channels` stays open (`Unknown`):
@@ -139,7 +153,13 @@ export const ContactsGroup = HttpApiGroup.make('contacts')
 				params: { id: Schema.String, channelId: Schema.String },
 				payload: PatchChannelInput,
 				success: ContactChannel.json,
-				error: BadRequest.pipe(HttpApiSchema.status(400)),
+				// Every channel of every company, branch and person lives in one
+				// table, so a channel id that is not this contact's is a wrong
+				// address rather than a server fault — and must not be edited.
+				error: Schema.Union([
+					BadRequest.pipe(HttpApiSchema.status(400)),
+					NotFound.pipe(HttpApiSchema.status(404)),
+				]),
 			},
 		),
 	)
@@ -150,6 +170,7 @@ export const ContactsGroup = HttpApiGroup.make('contacts')
 			{
 				params: { id: Schema.String, channelId: Schema.String },
 				success: Schema.Void,
+				error: NotFound.pipe(HttpApiSchema.status(404)),
 			},
 		),
 	)

--- a/packages/domain/src/schema/channel-address.ts
+++ b/packages/domain/src/schema/channel-address.ts
@@ -13,6 +13,32 @@
  * same thing as a wrong value.
  */
 
+/**
+ * The kinds the app knows how to show: what the picker offers, and what has an
+ * icon and a name to be read out. Storage still takes any kind — this is
+ * presentation, not permission, and one arriving from elsewhere is shown as it
+ * was stored rather than refused.
+ *
+ * It is one list because it was three, and they could drift: a kind could be
+ * offered with no icon, or given a name nothing offered. The icon and name maps
+ * are checked against this, so a gap is a build error rather than a blank space
+ * on screen. The address shapes below and the link-building elsewhere stay
+ * deliberately partial — most kinds need no shape, and most links are just the
+ * value.
+ */
+export const CHANNEL_KINDS = [
+	'email',
+	'phone',
+	'whatsapp',
+	'linkedin',
+	'x',
+	'instagram',
+	'website',
+	'bluesky',
+] as const
+
+export type ChannelKind = (typeof CHANNEL_KINDS)[number]
+
 export const EMAIL_ADDRESS_PATTERN = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
 export const PHONE_ADDRESS_PATTERN = /^\+?[0-9][0-9 ().-]{5,19}$/
 // A bare host ("acme.com") counts as well as a full address, because that is how

--- a/packages/domain/src/schema/channel-verification.test.ts
+++ b/packages/domain/src/schema/channel-verification.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	HandSetVerificationVerdict,
+	isVerificationVerdict,
+	VERIFICATION_VERDICTS,
+} from './channel-verification'
+
+describe('channel verification vocabulary', () => {
+	describe('when checking a stored value against the vocabulary', () => {
+		it('should accept every verdict the list names', () => {
+			// GIVEN the five verdicts a deliverability check can produce
+			// WHEN each is checked
+			// THEN all of them are recognised
+			for (const verdict of VERIFICATION_VERDICTS) {
+				expect(isVerificationVerdict(verdict)).toBe(true)
+			}
+		})
+
+		it('should refuse a word that only looks like a verdict', () => {
+			// GIVEN words that reached the column while it was free text, plus the
+			// near-misses a careless import produces
+			// WHEN each is checked
+			// THEN none is recognised, so it can be repaired rather than stored
+			expect(isVerificationVerdict('inferred')).toBe(false)
+			expect(isVerificationVerdict('valid')).toBe(false)
+			expect(isVerificationVerdict('Deliverable')).toBe(false)
+			expect(isVerificationVerdict(' risky')).toBe(false)
+			expect(isVerificationVerdict('')).toBe(false)
+		})
+	})
+
+	describe('when deciding what a person may set by hand', () => {
+		it('should offer only verdicts that take trust away', () => {
+			// GIVEN the hand-set subset
+			// WHEN reading which words it allows
+			// THEN it is exactly the three that withdraw trust
+			expect(HandSetVerificationVerdict.literals).toEqual([
+				'risky',
+				'undeliverable',
+				'unknown',
+			])
+		})
+
+		it('should never let a caller claim an address is good', () => {
+			// GIVEN `deliverable` is the one word the send path lets through, and
+			// `catch_all` is a finding only a mailbox probe can make
+			// WHEN looking for either in the hand-set subset
+			// THEN neither is there, so no caller can grant trust it did not earn
+			const handSet: ReadonlyArray<string> = HandSetVerificationVerdict.literals
+			expect(handSet).not.toContain('deliverable')
+			expect(handSet).not.toContain('catch_all')
+		})
+
+		it('should stay a subset of the full vocabulary', () => {
+			// GIVEN the subset is picked out of the full list rather than retyped
+			// WHEN comparing the two
+			// THEN every hand-set word is still a real verdict
+			for (const verdict of HandSetVerificationVerdict.literals) {
+				expect(isVerificationVerdict(verdict)).toBe(true)
+			}
+		})
+	})
+})

--- a/packages/domain/src/schema/channel-verification.ts
+++ b/packages/domain/src/schema/channel-verification.ts
@@ -1,0 +1,56 @@
+import { Schema } from 'effect'
+
+/**
+ * What a deliverability check said about an email address.
+ *
+ * Only the email channel carries one. It is read at the moment of sending: a
+ * verdict that is anything other than `deliverable` makes the send path stop and
+ * ask, while no verdict at all sails through — there is no evidence the address
+ * is bad. That asymmetry is why the word matters and why the list is closed.
+ *
+ * It used to be free text at every door, which is how a word nothing understands
+ * ended up stored on real addresses. Anything outside this list is refused now.
+ */
+export const VERIFICATION_VERDICTS = [
+	// A mailbox answered. The only word that lets a send go through unremarked.
+	'deliverable',
+	// Something is off — a full mailbox, a disposable domain, a server that
+	// stalled. Might arrive, might not.
+	'risky',
+	// The domain accepts everything, so the check learned nothing about this
+	// particular address.
+	'catch_all',
+	// The mailbox is not there.
+	'undeliverable',
+	// Checked and inconclusive, or somebody withdrew an earlier claim.
+	'unknown',
+] as const
+
+export const VerificationVerdict = Schema.Literals(VERIFICATION_VERDICTS)
+export type VerificationVerdict = typeof VerificationVerdict.Type
+
+/** Whether a stored value is one of the verdicts this vocabulary knows. */
+export const isVerificationVerdict = (
+	verdict: string,
+): verdict is VerificationVerdict =>
+	(VERIFICATION_VERDICTS as ReadonlyArray<string>).includes(verdict)
+
+/**
+ * The verdicts a person or an assistant may set by hand.
+ *
+ * Every one of them takes trust away; none of them grants it. `deliverable` and
+ * `catch_all` are things a checker found out by knocking on a mailbox — nobody
+ * at a keyboard obtained either — and `deliverable` is the single word that opens
+ * the send path, so a caller able to write it could talk its own way past the
+ * check. `unknown` is the way back: it withdraws a claim somebody disagrees with
+ * without asserting a good one in its place.
+ *
+ * Picked out of the list above rather than written again, so a rename there
+ * cannot quietly leave this one naming a word that no longer exists.
+ */
+export const HandSetVerificationVerdict = VerificationVerdict.pick([
+	'risky',
+	'undeliverable',
+	'unknown',
+])
+export type HandSetVerificationVerdict = typeof HandSetVerificationVerdict.Type

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -19,6 +19,8 @@ export {
 	TranscriptStatus,
 } from './call-recordings'
 export {
+	CHANNEL_KINDS,
+	type ChannelKind,
 	channelAddressIsValid,
 	EMAIL_ADDRESS_PATTERN,
 	INSTAGRAM_ADDRESS_PATTERN,
@@ -27,6 +29,12 @@ export {
 	PHONE_ADDRESS_PATTERN,
 	WEBSITE_ADDRESS_PATTERN,
 } from './channel-address'
+export {
+	HandSetVerificationVerdict,
+	isVerificationVerdict,
+	VERIFICATION_VERDICTS,
+	VerificationVerdict,
+} from './channel-verification'
 export {
 	ATTENTION_FILTERS,
 	AttentionFilter,

--- a/packages/research/src/application/contact-discovery.test.ts
+++ b/packages/research/src/application/contact-discovery.test.ts
@@ -1,10 +1,11 @@
 import { Effect, Exit } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import type { VerificationVerdict } from '@batuda/domain'
 import { decidesPurchase } from '@batuda/domain'
 
 import { BudgetExceeded, ProviderError } from '../domain/errors'
-import { EnrichmentResult, type VerificationVerdict } from '../domain/types'
+import { EnrichmentResult } from '../domain/types'
 import {
 	buyingRoleFromTitle,
 	compareContacts,

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -14,10 +14,11 @@
 import { Config, Context, Effect, Layer, Ref } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
+import type { VerificationVerdict } from '@batuda/domain'
 import { decidesPurchase } from '@batuda/domain'
 
 import { isRegistryCountry, type RegistryCountry } from '../domain/country'
-import { EnrichmentResult, type VerificationVerdict } from '../domain/types'
+import { EnrichmentResult } from '../domain/types'
 import { makeBudgetLayer } from './budget'
 import { guessEmails, splitPersonName } from './email-guess'
 import { resolvePolicy, type SystemDefaults } from './policy'

--- a/packages/research/src/application/schemas/contact-discovery-v1.ts
+++ b/packages/research/src/application/schemas/contact-discovery-v1.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'effect'
 
-import { VerificationVerdict } from '../../domain/types'
+import { VerificationVerdict } from '@batuda/domain'
+
 import {
 	Citation,
 	DiscoveredExisting,

--- a/packages/research/src/domain/types.ts
+++ b/packages/research/src/domain/types.ts
@@ -1,5 +1,7 @@
 import { Schema } from 'effect'
 
+import { VerificationVerdict } from '@batuda/domain'
+
 // ── Shared value types across all research providers ──
 
 /** A single search result from any search provider. */
@@ -67,20 +69,6 @@ export class RegistryRecord extends Schema.Class<RegistryRecord>(
 	sourceUrl: Schema.String,
 	units: Schema.Number,
 }) {}
-
-/**
- * Deliverability verdict for a guessed or found email, shared across the
- * enrichment and verification steps of contact discovery.
- */
-export const VERIFICATION_VERDICTS = [
-	'deliverable',
-	'risky',
-	'catch_all',
-	'undeliverable',
-	'unknown',
-] as const
-export const VerificationVerdict = Schema.Literals(VERIFICATION_VERDICTS)
-export type VerificationVerdict = (typeof VERIFICATION_VERDICTS)[number]
 
 /**
  * Why a run ended without usable data — a structured code the UI localizes and

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -168,8 +168,6 @@ export {
 	ReasonCode,
 	SearchResult,
 	SearchResultItem,
-	VERIFICATION_VERDICTS,
-	VerificationVerdict,
 } from './domain/types'
 export { makeCachedScrape } from './infrastructure/cached-scrape'
 export { makeCachedSearch } from './infrastructure/cached-search'

--- a/packages/research/src/infrastructure/fullenrich/enrichment.ts
+++ b/packages/research/src/infrastructure/fullenrich/enrichment.ts
@@ -27,12 +27,14 @@ import {
 	HttpClientResponse,
 } from 'effect/unstable/http'
 
+import type { VerificationVerdict } from '@batuda/domain'
+
 import {
 	type EnrichmentInput,
 	EnrichmentProvider,
 } from '../../application/ports'
 import { ProviderError } from '../../domain/errors'
-import { EnrichmentResult, type VerificationVerdict } from '../../domain/types'
+import { EnrichmentResult } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
 

--- a/packages/research/src/infrastructure/hunter/_client.ts
+++ b/packages/research/src/infrastructure/hunter/_client.ts
@@ -21,8 +21,9 @@ import {
 	HttpClientResponse,
 } from 'effect/unstable/http'
 
+import type { VerificationVerdict } from '@batuda/domain'
+
 import { ProviderError } from '../../domain/errors'
-import type { VerificationVerdict } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
 

--- a/packages/research/src/infrastructure/hunter/verifier.ts
+++ b/packages/research/src/infrastructure/hunter/verifier.ts
@@ -8,8 +8,10 @@
 
 import { Effect, Schema } from 'effect'
 
+import type { VerificationVerdict } from '@batuda/domain'
+
 import { EmailVerifier, type EmailVerifyInput } from '../../application/ports'
-import { EmailVerification, type VerificationVerdict } from '../../domain/types'
+import { EmailVerification } from '../../domain/types'
 import {
 	HunterNullableBoolean,
 	HunterNullableNumber,


### PR DESCRIPTION
## The problem

A wrong email address on a person could not be put right. Passing a corrected one to `update_contact` left the old one beside it, so a person ended up holding both — the issue reports three addresses where there should have been one.

The only way out was `delete_contact` + `create_contact`, and that detaches every interaction, proposal and email thread ever logged against them. So a known-bad address tends to be left in place, because removing it costs more than tolerating it.

Companies already had `manage_company_channels`. People had nothing.

This is CRM, across `server` (the assistant tool surface and the HTTP API), `internal` (the web app), and `research` (which writes deliverability verdicts).

## What this adds

`manage_contact_channels` — list / add / update / remove, one address at a time, mirroring the company tool. `update_contact`'s description now says plainly that `channels[]` only ever adds, and points here.

The web app gets the same capability: a channel row can be edited where it sits, rather than only added or thrown away.

## Defects found underneath it

Every one of these is in the code the new tool sits on, and each would have made it worse rather than better:

- **Correcting an address in place crashed.** Only one of each address per person is allowed, so renaming a typo onto its correction — the issue's exact state — hit that limit and surfaced as an internal server error. It is now answered in words, inside its own savepoint so the refusal does not take the rest of the request with it.
- **An edit never had to say whose address it was.** Every way of reaching every company, branch and person lives in one table, and the web route took an address id on trust. Within one organisation, a request about one person could reach somebody else's address — or a company's switchboard.
- **Changing only a channel's *kind* was unvalidated.** Nothing could do it before, so it never mattered; this change adds exactly that, and unfixed it would have let a phone number be retyped as an email and walk into the send path with nothing recorded against it.
- **Deleting a contact left their addresses behind**, which the tool has claimed otherwise since the move to one shared table removed the database rule that did it. An address recorded as bounced went on blocking mail for the whole organisation, from a row no screen could show and nobody could lift.
- **A save could erase a deliverability verdict.** Re-passing an address without one wiped it, and no verdict at all reads as "nothing known against it" — so a known-dead address quietly became sendable again.

Plus one invariant the change had to establish rather than assume: nothing re-elected a primary. The moment removal becomes cheap, deleting the address a kind sends from left the rest tied, and a screen, a compose box and the send gate could each name a different one — and a different one again on the next load.

## The `inferred` verdict

The issue's smaller note. The deliverability column — the word stored against an address saying what a check found — was free text at every door, which is how a word nothing in the app understands got stored, and the edit path deliberately never touched verdicts, so it was stuck there.

The five real verdicts (`deliverable`, `risky`, `catch_all`, `undeliverable`, `unknown`) now live in `packages/domain` and are enforced at every door. A person or an assistant may only ever *lower* trust — `deliverable` is the single word that lets a send through unremarked, so nobody at a keyboard may write it; only a check that reached the mailbox can.

Migration `0061` repairs capitalisation first, then files whatever is left as `risky`, and leaves never-checked addresses alone: almost every hand-typed address has no verdict, and sweeping those in would put a warning on the entire book with no way back.

## Impact

- **Migration `0061` must run before the server tag.** The deploy does not run migrations, and new server code on an unmigrated schema crashes on boot. It also **deletes channels whose contact is already gone** — irreversible. Those orphans were still answering: the send gate looks a bounced address up across the whole organisation without asking whose it is, so they went on blocking mail from rows nobody could see.
- **Wire-shape break** (pre-production, so a clean break rather than a shim): on the channel input, `verification` narrows from free text to the three hand-settable words, `confidence` is gone (a score belongs to the check that earned it, and nobody setting a verdict by hand has one to offer), and an address must be non-empty. `packages/controllers` and `packages/domain` are consumed by both the server and the web app's typed client, so this ripples to the frontend.
- **MCP + HTTP parity**: both surfaces get the new behaviour. `manage_contact_channels` is a new tool, so the published tool count goes up by one.
- **No new environment variables**, and no change to tenant isolation, RLS policies, or which Postgres role a path runs under — the subject-scoping above tightens an application-level lookup, it does not touch a policy.

## Deliberate calls worth reviewing

- **Unrecognised verdicts land on `risky`, not `unknown`.** `unknown` is the narrower statement that a check ran and settled nothing, and nothing ran on these — they were stamped by whatever wrote them. It also matters ahead: `unknown` and "nobody checked" say the same thing, so anything filed there becomes sendable the moment the send gate stops treating the two differently, and a pattern-guessed address should not.
- **The migration is data-only.** A constraint holding the column to those five words belongs here by the usual rule, but migrations are applied *before* the new build ships and the old one keeps serving meanwhile, so it would start rejecting that instance's writes mid-release. It goes in the next release.
- **The two doors differ on purpose.** A tool call with an unknown verdict is refused outright; the same word inside a research proposal is dropped and the address kept. A tool caller can be told which words are allowed; a proposal is a model's free text wrapped around a genuinely useful address, and losing the address to protect a footnote is the worse trade. Both call sites say so.
- **Deleting a contact now forgets their bounce.** The record survives in the activity trail; what goes is an enforcement nobody could reach anyway, since lifting one names a contact who no longer exists. The honest replacement is an organisation-level do-not-send list keyed by address — worth filing.
- **A hand-set verdict is advisory.** A later research run auto-applies a `deliverable` result with nobody looking, so the UI copy says a check can raise it again rather than implying permanence. There is a test pinning that, so the copy and the code cannot drift apart.

## Screenshots

Desktop (1440×900) — the dialog on a seeded contact:

![manage-channels-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-410/manage-channels-desktop.webp)

Mobile (iPhone 16 Pro) — the same dialog as a bottom sheet, actions stacked under each address:

![manage-channels-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-410/manage-channels-mobile.webp)

## Verification

Re-run on the current branch after the `risky` change: `pnpm check-types` (13/13), `pnpm test` (811 server unit tests pass, 1 skipped), `pnpm test:integration` (89 files, 602 tests pass), `pnpm build` (13/13). Drove the live worktree stack and opened the channels dialog at both sizes above. Both locale catalogues have no untranslated entries.

From the earlier run on this branch: 7 Playwright tests against the running app — correcting an address and seeing it on the card behind the dialog, the refusal shown inline with what was typed still in it, an invalid address, removal, making a phone the main one, and lowering trust without touching the bounce state; plus 938 research, 154 web and 63 domain unit tests. The dialog was checked at 1440, 1280 and 390 wide, which found and fixed two layout bugs (the edit row crushed its address and name fields to about 60px, and a phone number wrapped one number per line on a phone).

Not run in this pass: the Playwright suite (CI covers it) and the destructive half of migration `0061` against production-shaped data — its orphan delete is covered by the integration test's synthetic fixture only.

## Follow-ups worth filing

- The vocabulary `CHECK` constraint, one release later.
- An organisation-level do-not-send list keyed by address.
- Sticky hand-set verdicts, if being overwritten by a later probe turns out to matter.
- The compose form does not read a lowered verdict — only assistants are held back today, which is why the copy says "assistants".
- `manage_company_channels` still skips a wrong id silently and returns an untyped shape.
- Company channels have a tool but only a read-only panel — the mirror image of this issue.

Closes #403
