### PR TITLE
feat: make the pipeline page a work queue rather than a noticeboard

### DIFF
--- a/apps/internal/src/atoms/companies-atoms.ts
+++ b/apps/internal/src/atoms/companies-atoms.ts
@@ -1,5 +1,7 @@
 import { Atom } from 'effect/unstable/reactivity'
 
+import type { AttentionFilter } from '@batuda/domain'
+
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import {
 	firstPage,
@@ -23,6 +25,11 @@ export type CompaniesSearch = {
 	readonly owner?: string
 	readonly sort?: string
 	readonly query?: string
+	// What needs doing, in the dashboard's own words: a missed follow-up, a
+	// company gone quiet, or one with nothing planned. Arriving here from a
+	// dashboard heading sets this, and the threshold it was showing rides along.
+	readonly attention?: AttentionFilter
+	readonly staleDays?: number
 }
 
 /**
@@ -117,6 +124,12 @@ export function canonicalSearchKey(search: CompaniesSearch): string {
 	}
 	if (search.query !== undefined && search.query !== '') {
 		entries.push(['query', search.query])
+	}
+	if (search.attention !== undefined) {
+		entries.push(['attention', search.attention])
+	}
+	if (search.staleDays !== undefined) {
+		entries.push(['staleDays', search.staleDays])
 	}
 	entries.sort(([a], [b]) => a.localeCompare(b))
 	return JSON.stringify(Object.fromEntries(entries))

--- a/apps/internal/src/atoms/pipeline-atoms.ts
+++ b/apps/internal/src/atoms/pipeline-atoms.ts
@@ -57,9 +57,22 @@ export const openTasksAtom = BatudaApiAtom.query('tasks', 'list', {
 export const pipelineAtom = BatudaApiAtom.query('pipeline', 'get', {})
 
 /**
- * Server-computed next steps: the open-task queue (ordered by due date) and the
- * companies past their next-action date. Feeds the dashboard's "needs attention".
+ * How many rows of each attention list the dashboard shows. The lists are meant
+ * to be worked from the top, not read end to end — the server sorts them by
+ * urgency and reports how many there are in total, so a handful plus a real
+ * count says more than a wall of rows.
+ */
+export const ATTENTION_PREVIEW = 5
+
+/**
+ * Server-computed next steps: the companies needing chasing, split into a
+ * missed follow-up, gone quiet, and hot with nothing booked, plus research
+ * waiting on a decision. Feeds the dashboard's "needs attention".
+ *
+ * Asking for only the preview keeps the whole list off the wire — the totals
+ * come back regardless, so the heading stays truthful either way.
  */
 export const nextStepsAtom = BatudaApiAtom.query('pipeline', 'nextSteps', {
-	query: {},
+	query: { limit: ATTENTION_PREVIEW },
+	serializationKey: `pipeline:next-steps:${ATTENTION_PREVIEW}`,
 })

--- a/apps/internal/src/atoms/tasks-atoms.ts
+++ b/apps/internal/src/atoms/tasks-atoms.ts
@@ -21,15 +21,23 @@ import {
  *   - Module-level mutation setters for the inline/row actions.
  */
 
-/** The shelves the inbox rail sorts work onto. */
-export type TaskShelf =
-	| 'overdue'
-	| 'today'
-	| 'thisWeek'
-	| 'later'
-	| 'noDue'
-	| 'snoozed'
-	| 'doneRecent'
+/**
+ * The shelves the inbox rail sorts work onto. Spelled as a list as well as a
+ * type so a shelf arriving in a URL can be checked against it — the dashboard
+ * links straight to one, and an unknown word has to fall back rather than leave
+ * the rail on nothing.
+ */
+export const TASK_SHELVES = [
+	'overdue',
+	'today',
+	'thisWeek',
+	'later',
+	'noDue',
+	'snoozed',
+	'doneRecent',
+] as const
+
+export type TaskShelf = (typeof TASK_SHELVES)[number]
 
 /**
  * How many tasks one shelf shows before asking, and how many more each

--- a/apps/internal/src/components/shared/kpi-counter.tsx
+++ b/apps/internal/src/components/shared/kpi-counter.tsx
@@ -14,25 +14,32 @@ import { brushedMetalPlate } from '#/lib/workshop-mixins'
  * counter flipping through numbers.
  *
  * Used sparingly — only for dashboard hero KPIs and list-intro totals.
+ *
+ * `density='compact'` keeps the plate and its digits but takes far less height,
+ * for a screen showing several at once. At full size four of these fill a phone
+ * for more than a screen and a short laptop almost entirely, which pushes
+ * everything worth acting on below the fold.
  */
 export function KpiCounter({
 	value,
 	label,
 	suffix,
+	density = 'comfortable',
 }: {
 	value: number
 	label: string
 	suffix?: string
+	density?: 'comfortable' | 'compact'
 }) {
 	const ref = useRef<HTMLDivElement>(null)
 	const inView = useInView(ref, { once: true, amount: 0.4 })
 	return (
-		<MetalPlate ref={ref}>
+		<MetalPlate ref={ref} $compact={density === 'compact'}>
 			<ScrewDot $position='top-left' $size={6} aria-hidden />
 			<ScrewDot $position='top-right' $size={6} aria-hidden />
 			<ScrewDot $position='bottom-left' $size={6} aria-hidden />
 			<ScrewDot $position='bottom-right' $size={6} aria-hidden />
-			<Digits>
+			<Digits $compact={density === 'compact'}>
 				<AnimateNumber
 					format={{ useGrouping: true }}
 					transition={{
@@ -49,23 +56,33 @@ export function KpiCounter({
 	)
 }
 
-const MetalPlate = styled.div.withConfig({ displayName: 'KpiCounterPlate' })`
+const MetalPlate = styled.div.withConfig({
+	displayName: 'KpiCounterPlate',
+	shouldForwardProp: prop => prop !== '$compact',
+})<{ $compact?: boolean }>`
 	${brushedMetalPlate}
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-xs);
-	padding: var(--space-lg) var(--space-lg) var(--space-md);
+	gap: ${p => (p.$compact ? 'var(--space-3xs)' : 'var(--space-xs)')};
+	padding: ${p =>
+		p.$compact
+			? 'var(--space-sm) var(--space-md)'
+			: 'var(--space-lg) var(--space-lg) var(--space-md)'};
 	border-radius: var(--shape-2xs);
 	box-shadow: var(--elevation-workshop-md);
 	min-width: 0;
 `
 
-const Digits = styled.div.withConfig({ displayName: 'KpiCounterDigits' })`
+const Digits = styled.div.withConfig({
+	displayName: 'KpiCounterDigits',
+	shouldForwardProp: prop => prop !== '$compact',
+})<{ $compact?: boolean }>`
 	display: inline-flex;
 	align-items: baseline;
 	gap: var(--space-3xs);
 	font-family: var(--font-display);
-	font-size: clamp(2.5rem, 6vw, 4rem);
+	font-size: ${p =>
+		p.$compact ? 'clamp(1.5rem, 3.5vw, 2rem)' : 'clamp(2.5rem, 6vw, 4rem)'};
 	font-weight: var(--font-weight-bold);
 	line-height: 1;
 	letter-spacing: 0.02em;

--- a/apps/internal/src/components/shared/reason-chip.tsx
+++ b/apps/internal/src/components/shared/reason-chip.tsx
@@ -1,0 +1,97 @@
+import { useLingui } from '@lingui/react/macro'
+import styled from 'styled-components'
+
+/**
+ * Why this row is on this list.
+ *
+ * A triage list mixes companies caught by different rules — one has missed a
+ * follow-up, another has just gone quiet — and a card alone shows neither. The
+ * chip answers "why is this here" and "how bad is it" in the same breath, which
+ * is what decides whether it gets called today or on Friday.
+ */
+export type AttentionReason = 'overdue' | 'stale'
+
+export function ReasonChip({
+	reason,
+	since,
+}: {
+	readonly reason: AttentionReason
+	// The date the reason is measured from: the follow-up that was missed, or
+	// the last time anybody made contact. Null means never contacted at all.
+	readonly since: string | null
+}) {
+	const { t } = useLingui()
+	const days = since === null ? null : daysBetween(since, Date.now())
+
+	// Each variant is a whole sentence rather than a span slotted into one.
+	// Building the span separately reads better in code and produces nothing at
+	// all: the macro only rewrites `t` templates where it can see the binding,
+	// and a `t` handed to a helper as an argument is not that. Whole sentences
+	// also give a translator the word order, which a bare "6 weeks" does not.
+	const weeks = days === null ? 0 : Math.round(days / 7)
+	const months = days === null ? 0 : Math.round(days / 30)
+
+	const label =
+		reason === 'overdue'
+			? days === null
+				? t`Follow-up overdue`
+				: days < 1
+					? t`Follow-up overdue by less than a day`
+					: days < 14
+						? t`Follow-up overdue by ${days} days`
+						: days < 60
+							? t`Follow-up overdue by ${weeks} weeks`
+							: t`Follow-up overdue by ${months} months`
+			: days === null
+				? t`Never contacted`
+				: days < 1
+					? t`No contact for less than a day`
+					: days < 14
+						? t`No contact in ${days} days`
+						: days < 60
+							? t`No contact in ${weeks} weeks`
+							: t`No contact in ${months} months`
+
+	return (
+		<Chip $reason={reason} data-testid={`reason-chip-${reason}`}>
+			{label}
+		</Chip>
+	)
+}
+
+/**
+ * Whole days between an instant and now, never negative.
+ *
+ * Counted in days rather than exactly, because the chip reads "3 days" either
+ * way and an hours-precise answer would change on every render.
+ */
+function daysBetween(iso: string, now: number): number | null {
+	const then = Date.parse(iso)
+	if (Number.isNaN(then)) return null
+	return Math.max(0, Math.floor((now - then) / 86_400_000))
+}
+
+const Chip = styled.span.withConfig({
+	displayName: 'ReasonChip',
+	shouldForwardProp: prop => prop !== '$reason',
+})<{ $reason: AttentionReason }>`
+	display: inline-flex;
+	align-items: center;
+	align-self: flex-start;
+	padding: var(--space-3xs) var(--space-2xs);
+	border-radius: var(--shape-2xs);
+	border: 1px dashed
+		${p =>
+			p.$reason === 'overdue' ? 'var(--color-error)' : 'var(--color-outline)'};
+	color: ${p =>
+		p.$reason === 'overdue'
+			? 'var(--color-error)'
+			: 'var(--color-on-surface-variant)'};
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-small-size);
+	line-height: var(--typescale-label-small-line);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	white-space: nowrap;
+`

--- a/apps/internal/src/components/shared/section-header.tsx
+++ b/apps/internal/src/components/shared/section-header.tsx
@@ -1,5 +1,8 @@
+import { Info } from 'lucide-react'
 import type { ReactNode } from 'react'
 import styled from 'styled-components'
+
+import { PriTooltip } from '@batuda/ui/pri'
 
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
@@ -7,14 +10,20 @@ import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
  * Stenciled display-font section title with a ruler under-rule. Optional
  * count badge renders as a mini stamped-metal tag; the action slot stays
  * right-aligned for "show all" links or toolbar buttons.
+ *
+ * `help` is for a section whose membership follows a rule — what puts a row on
+ * this list and what keeps it off. Those rules are decisions somebody made once
+ * and nobody can see, and a heading is where a reader looks for them.
  */
 export function SectionHeader({
 	title,
 	count,
+	help,
 	action,
 }: {
 	title: string
 	count?: number
+	help?: string
 	action?: ReactNode
 }) {
 	return (
@@ -22,11 +31,52 @@ export function SectionHeader({
 			<TitleRow>
 				<Heading>{title}</Heading>
 				{typeof count === 'number' && <Count>{count}</Count>}
+				{help && (
+					<PriTooltip.Provider delay={300}>
+						<PriTooltip.Root>
+							<PriTooltip.Trigger
+								render={
+									<HelpButton type='button' aria-label={help}>
+										<Info size={13} aria-hidden />
+									</HelpButton>
+								}
+							/>
+							<PriTooltip.Portal>
+								<PriTooltip.Positioner side='top' sideOffset={6}>
+									<PriTooltip.Popup>{help}</PriTooltip.Popup>
+								</PriTooltip.Positioner>
+							</PriTooltip.Portal>
+						</PriTooltip.Root>
+					</PriTooltip.Provider>
+				)}
 			</TitleRow>
 			{action && <Actions>{action}</Actions>}
 		</Wrapper>
 	)
 }
+
+const HelpButton = styled.button.withConfig({
+	displayName: 'SectionHeaderHelp',
+})`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	background: none;
+	border: none;
+	cursor: help;
+	color: var(--color-on-surface-variant);
+
+	&:hover {
+		color: var(--color-on-surface);
+	}
+
+	&:focus-visible {
+		outline: none;
+		border-radius: var(--shape-full);
+		box-shadow: var(--glow-active);
+	}
+`
 
 const Wrapper = styled.div.withConfig({ displayName: 'SectionHeader' })`
 	display: flex;

--- a/apps/internal/src/components/shared/task-item.tsx
+++ b/apps/internal/src/components/shared/task-item.tsx
@@ -369,6 +369,22 @@ function SourceBadge({ source }: { source: TaskSourceLabel }) {
 
 // ── Styles ────────────────────────────────────────────────────────
 
+const Body = styled.div.withConfig({ displayName: 'TaskItemBody' })`
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+`
+
+const Meta = styled.span.withConfig({ displayName: 'TaskItemMeta' })`
+	display: inline-flex;
+	align-items: center;
+	font-family: var(--font-body);
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-on-surface-variant);
+	font-style: italic;
+`
+
 const Row = styled(motion.div).withConfig({
 	displayName: 'TaskItemRow',
 	shouldForwardProp: prop => !prop.startsWith('$'),
@@ -385,19 +401,33 @@ const Row = styled(motion.div).withConfig({
 	transition: opacity 200ms ease;
 	min-width: 0;
 
+	/* Below the tablet breakpoint the seven columns stop fitting. Six of them
+	 * size to their content, so the only flexible one — the company and the task
+	 * title, the two things that say which task this is — was squeezed to around
+	 * 55px against ten times that much text, while the date beside it kept its
+	 * full width and wrapped over three lines. Here the text takes the whole
+	 * first line and the date drops beneath it. */
+	@media (max-width: 767px) {
+		grid-template-columns: auto 1fr auto auto;
+		row-gap: var(--space-3xs);
+		column-gap: var(--space-xs);
+
+		${Body} {
+			grid-column: 2 / -1;
+		}
+
+		${Meta} {
+			grid-column: 2 / -1;
+			grid-row: 2;
+		}
+	}
+
 	${p =>
 		p.$overdue &&
 		`
 			border-left: 3px solid var(--color-error);
 			box-shadow: inset 4px 0 8px -4px color-mix(in srgb, var(--color-error) 60%, transparent);
 		`}
-`
-
-const Body = styled.div.withConfig({ displayName: 'TaskItemBody' })`
-	min-width: 0;
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-3xs);
 `
 
 const Company = styled.span.withConfig({ displayName: 'TaskItemCompany' })`
@@ -486,15 +516,6 @@ const InlineInput = styled(PriInput).withConfig({
 	font-size: var(--typescale-body-small-size);
 	line-height: var(--typescale-body-small-line);
 	padding: var(--space-3xs) var(--space-xs);
-`
-
-const Meta = styled.span.withConfig({ displayName: 'TaskItemMeta' })`
-	display: inline-flex;
-	align-items: center;
-	font-family: var(--font-body);
-	font-size: var(--typescale-label-small-size);
-	color: var(--color-on-surface-variant);
-	font-style: italic;
 `
 
 const DueTrigger = styled.button.withConfig({

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -1149,6 +1149,10 @@ msgstr "Comunicació"
 msgid "Companies"
 msgstr "Empreses"
 
+#: src/routes/index.tsx
+msgid "Companies marked hot with nothing scheduled at all. One that has also gone quiet is listed above instead, so it is only asked after once."
+msgstr "Empreses marcades com a prioritàries sense res programat. Si a més ha quedat en silenci, apareix a dalt, així només se li reclama un cop."
+
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/run-labels.ts
@@ -2454,6 +2458,26 @@ msgstr "El proveïdor l'ha marcat com a brossa. El cos es mostra només per revi
 msgid "Follow up"
 msgstr "Fes seguiment"
 
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue"
+msgstr "Seguiment endarrerit"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by {days} days"
+msgstr "Seguiment endarrerit {days} dies"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by {months} months"
+msgstr "Seguiment endarrerit {months} mesos"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by {weeks} weeks"
+msgstr "Seguiment endarrerit {weeks} setmanes"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by less than a day"
+msgstr "Seguiment endarrerit menys d’un dia"
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Footers — {0}"
@@ -3338,6 +3362,10 @@ msgstr "mai"
 msgid "Never"
 msgstr "Mai"
 
+#: src/components/shared/reason-chip.tsx
+msgid "Never contacted"
+msgstr "Mai contactada"
+
 #: src/routes/settings/api-keys/index.tsx
 msgid "Never expires"
 msgstr "No caduca mai"
@@ -3472,6 +3500,22 @@ msgstr "Sense connexió al servidor. Torna-ho a provar d'aquí a uns segons."
 #: src/routes/settings/mcp/connections.tsx
 msgid "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
 msgstr "Encara no hi ha connexions. Afegeix aquest servidor al teu assistent d'IA i autoritza'l; després apareixerà aquí."
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact for less than a day"
+msgstr "Sense contacte des de fa menys d’un dia"
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact in {days} days"
+msgstr "Sense contacte des de fa {days} dies"
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact in {months} months"
+msgstr "Sense contacte des de fa {months} mesos"
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact in {weeks} weeks"
+msgstr "Sense contacte des de fa {weeks} setmanes"
 
 #: src/components/companies/cadence-card.tsx
 msgid "No contact yet."
@@ -3887,6 +3931,14 @@ msgstr "Obre els detalls de la tasca"
 #: src/routes/index.tsx
 msgid "Open tasks"
 msgstr "Tasques obertes"
+
+#: src/routes/index.tsx
+msgid "Open tasks due in the next seven days, counted from tonight rather than to the end of the calendar week."
+msgstr "Tasques obertes que vencen els propers set dies, comptats des d’aquesta nit i no fins al final de la setmana natural."
+
+#: src/routes/index.tsx
+msgid "Open tasks due today, in your own timezone. Anything already past its due date is under Needs attention instead."
+msgstr "Tasques obertes que vencen avui, en el teu fus horari. Les que ja han passat la data són a Necessita atenció."
 
 #: src/components/companies/where-panel-client.client.tsx
 msgid "Open the map full screen"
@@ -5387,6 +5439,10 @@ msgstr "Títol de la tasca"
 #: src/routes/tasks/index.tsx
 msgid "Tasks"
 msgstr "Tasques"
+
+#: src/routes/index.tsx
+msgid "Tasks past their due date, companies whose follow-up date has passed, companies mid-deal with no contact in two weeks, and finished research nobody has decided on. Each company is listed once, under its most urgent reason. Closed and dead companies are left out."
+msgstr "Tasques amb la data passada, empreses amb el seguiment vençut, empreses amb una venda en curs sense contacte des de fa dues setmanes, i recerques acabades que ningú ha resolt. Cada empresa apareix un sol cop, pel motiu més urgent. Les tancades i les descartades queden fora."
 
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/run-labels.ts

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -110,6 +110,11 @@ msgstr "{0} assistents"
 msgid "{0} calls"
 msgstr "{0} crides"
 
+#. placeholder {0}: run.pendingUpdateCount
+#: src/routes/index.tsx
+msgid "{0} changes to review"
+msgstr "{0} canvis per revisar"
+
 #. placeholder {0}: industry.companyCount
 #: src/routes/settings/organization/industries.tsx
 msgid "{0} companies"
@@ -279,6 +284,10 @@ msgstr "70%+"
 #: src/components/research/inbox/research-inbox.tsx
 msgid "90%+"
 msgstr "90%+"
+
+#: src/routes/index.tsx
+msgid "A high-priority company that has gone quiet is listed once, under Needs attention."
+msgstr "Una empresa prioritària que ha quedat en silenci apareix un sol cop, a Necessita atenció."
 
 #: src/components/instructions/template-dialog.tsx
 msgid "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
@@ -1145,9 +1154,6 @@ msgstr "Empreses"
 #: src/components/research/run-labels.ts
 #: src/routes/emails/$threadId.tsx
 #: src/routes/emails/$threadId.tsx
-#: src/routes/index.tsx
-#: src/routes/index.tsx
-#: src/routes/index.tsx
 msgid "Company"
 msgstr "Empresa"
 
@@ -4624,6 +4630,10 @@ msgstr "Pressupost de recerca"
 #: src/routes/settings/organization/policy.tsx
 msgid "Research budget saved."
 msgstr "Pressupost de recerca desat."
+
+#: src/routes/index.tsx
+msgid "Research finished — needs a look"
+msgstr "Recerca acabada — cal revisar-la"
 
 #: src/components/companies/company-fit-section.tsx
 msgid "Research has not weighed this company up yet. Run it to get a verdict and the reasons behind it."

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -348,6 +348,7 @@ msgid "Active client"
 msgstr "Client actiu"
 
 #: src/routes/index.tsx
+#: src/routes/index.tsx
 msgid "Active companies"
 msgstr "Empreses actives"
 
@@ -3329,6 +3330,7 @@ msgid "name@example.com, another@example.com"
 msgstr "nom@exemple.cat, altre@exemple.cat"
 
 #: src/routes/index.tsx
+#: src/routes/index.tsx
 msgid "Needs action"
 msgstr "Necessita acció"
 
@@ -3929,6 +3931,7 @@ msgstr "Obre els detalls de la tasca"
 
 #: src/components/companies/open-tasks-card.tsx
 #: src/routes/index.tsx
+#: src/routes/index.tsx
 msgid "Open tasks"
 msgstr "Tasques obertes"
 
@@ -4065,6 +4068,7 @@ msgid "Outcome: {outcomeLabel}"
 msgstr "Resultat: {outcomeLabel}"
 
 #: src/components/companies/next-action-card.tsx
+#: src/routes/index.tsx
 #: src/routes/index.tsx
 #: src/routes/tasks/index.tsx
 #: src/routes/tasks/index.tsx
@@ -5061,6 +5065,16 @@ msgstr "Compartida amb l'equip"
 #: src/routes/emails/inboxes.tsx
 msgid "Shared with the whole team — no single owner"
 msgstr "Compartida amb tot l'equip: sense cap propietari"
+
+#: src/routes/index.tsx
+#: src/routes/index.tsx
+#: src/routes/index.tsx
+msgid "Show all"
+msgstr "Mostra-ho tot"
+
+#: src/routes/index.tsx
+msgid "Show all quiet companies"
+msgstr "Mostra totes les empreses en silenci"
 
 #. placeholder {0}: msg.cc.length
 #: src/routes/emails/$threadId.tsx

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -348,6 +348,7 @@ msgid "Active client"
 msgstr "Active client"
 
 #: src/routes/index.tsx
+#: src/routes/index.tsx
 msgid "Active companies"
 msgstr "Active companies"
 
@@ -3329,6 +3330,7 @@ msgid "name@example.com, another@example.com"
 msgstr "name@example.com, another@example.com"
 
 #: src/routes/index.tsx
+#: src/routes/index.tsx
 msgid "Needs action"
 msgstr "Needs action"
 
@@ -3929,6 +3931,7 @@ msgstr "Open task details"
 
 #: src/components/companies/open-tasks-card.tsx
 #: src/routes/index.tsx
+#: src/routes/index.tsx
 msgid "Open tasks"
 msgstr "Open tasks"
 
@@ -4065,6 +4068,7 @@ msgid "Outcome: {outcomeLabel}"
 msgstr "Outcome: {outcomeLabel}"
 
 #: src/components/companies/next-action-card.tsx
+#: src/routes/index.tsx
 #: src/routes/index.tsx
 #: src/routes/tasks/index.tsx
 #: src/routes/tasks/index.tsx
@@ -5061,6 +5065,16 @@ msgstr "Shared with the team"
 #: src/routes/emails/inboxes.tsx
 msgid "Shared with the whole team — no single owner"
 msgstr "Shared with the whole team — no single owner"
+
+#: src/routes/index.tsx
+#: src/routes/index.tsx
+#: src/routes/index.tsx
+msgid "Show all"
+msgstr "Show all"
+
+#: src/routes/index.tsx
+msgid "Show all quiet companies"
+msgstr "Show all quiet companies"
 
 #. placeholder {0}: msg.cc.length
 #: src/routes/emails/$threadId.tsx

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -1149,6 +1149,10 @@ msgstr "Comms"
 msgid "Companies"
 msgstr "Companies"
 
+#: src/routes/index.tsx
+msgid "Companies marked hot with nothing scheduled at all. One that has also gone quiet is listed above instead, so it is only asked after once."
+msgstr "Companies marked hot with nothing scheduled at all. One that has also gone quiet is listed above instead, so it is only asked after once."
+
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/run-labels.ts
@@ -2454,6 +2458,26 @@ msgstr "Flagged as spam by the provider. The body is shown for review only."
 msgid "Follow up"
 msgstr "Follow up"
 
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue"
+msgstr "Follow-up overdue"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by {days} days"
+msgstr "Follow-up overdue by {days} days"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by {months} months"
+msgstr "Follow-up overdue by {months} months"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by {weeks} weeks"
+msgstr "Follow-up overdue by {weeks} weeks"
+
+#: src/components/shared/reason-chip.tsx
+msgid "Follow-up overdue by less than a day"
+msgstr "Follow-up overdue by less than a day"
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Footers — {0}"
@@ -3338,6 +3362,10 @@ msgstr "never"
 msgid "Never"
 msgstr "Never"
 
+#: src/components/shared/reason-chip.tsx
+msgid "Never contacted"
+msgstr "Never contacted"
+
 #: src/routes/settings/api-keys/index.tsx
 msgid "Never expires"
 msgstr "Never expires"
@@ -3472,6 +3500,22 @@ msgstr "No connection to the server. Try again in a few seconds."
 #: src/routes/settings/mcp/connections.tsx
 msgid "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
 msgstr "No connections yet. Add this server in your AI assistant and authorize it, then it appears here."
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact for less than a day"
+msgstr "No contact for less than a day"
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact in {days} days"
+msgstr "No contact in {days} days"
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact in {months} months"
+msgstr "No contact in {months} months"
+
+#: src/components/shared/reason-chip.tsx
+msgid "No contact in {weeks} weeks"
+msgstr "No contact in {weeks} weeks"
 
 #: src/components/companies/cadence-card.tsx
 msgid "No contact yet."
@@ -3887,6 +3931,14 @@ msgstr "Open task details"
 #: src/routes/index.tsx
 msgid "Open tasks"
 msgstr "Open tasks"
+
+#: src/routes/index.tsx
+msgid "Open tasks due in the next seven days, counted from tonight rather than to the end of the calendar week."
+msgstr "Open tasks due in the next seven days, counted from tonight rather than to the end of the calendar week."
+
+#: src/routes/index.tsx
+msgid "Open tasks due today, in your own timezone. Anything already past its due date is under Needs attention instead."
+msgstr "Open tasks due today, in your own timezone. Anything already past its due date is under Needs attention instead."
 
 #: src/components/companies/where-panel-client.client.tsx
 msgid "Open the map full screen"
@@ -5387,6 +5439,10 @@ msgstr "Task title"
 #: src/routes/tasks/index.tsx
 msgid "Tasks"
 msgstr "Tasks"
+
+#: src/routes/index.tsx
+msgid "Tasks past their due date, companies whose follow-up date has passed, companies mid-deal with no contact in two weeks, and finished research nobody has decided on. Each company is listed once, under its most urgent reason. Closed and dead companies are left out."
+msgstr "Tasks past their due date, companies whose follow-up date has passed, companies mid-deal with no contact in two weeks, and finished research nobody has decided on. Each company is listed once, under its most urgent reason. Closed and dead companies are left out."
 
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/run-labels.ts

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -110,6 +110,11 @@ msgstr "{0} attendees"
 msgid "{0} calls"
 msgstr "{0} calls"
 
+#. placeholder {0}: run.pendingUpdateCount
+#: src/routes/index.tsx
+msgid "{0} changes to review"
+msgstr "{0} changes to review"
+
 #. placeholder {0}: industry.companyCount
 #: src/routes/settings/organization/industries.tsx
 msgid "{0} companies"
@@ -279,6 +284,10 @@ msgstr "70%+"
 #: src/components/research/inbox/research-inbox.tsx
 msgid "90%+"
 msgstr "90%+"
+
+#: src/routes/index.tsx
+msgid "A high-priority company that has gone quiet is listed once, under Needs attention."
+msgstr "A high-priority company that has gone quiet is listed once, under Needs attention."
 
 #: src/components/instructions/template-dialog.tsx
 msgid "A short label. Start it with a [tag] like [research] to group related templates if you like — the brackets are just part of the name."
@@ -1145,9 +1154,6 @@ msgstr "Companies"
 #: src/components/research/run-labels.ts
 #: src/routes/emails/$threadId.tsx
 #: src/routes/emails/$threadId.tsx
-#: src/routes/index.tsx
-#: src/routes/index.tsx
-#: src/routes/index.tsx
 msgid "Company"
 msgstr "Company"
 
@@ -4624,6 +4630,10 @@ msgstr "Research budget"
 #: src/routes/settings/organization/policy.tsx
 msgid "Research budget saved."
 msgstr "Research budget saved."
+
+#: src/routes/index.tsx
+msgid "Research finished — needs a look"
+msgstr "Research finished — needs a look"
 
 #: src/components/companies/company-fit-section.tsx
 msgid "Research has not weighed this company up yet. Run it to get a verdict and the reasons behind it."

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -38,8 +38,8 @@ import styled from 'styled-components'
 import type {
 	CompanyDetail as CompanyDetailResponse,
 	ContactListItem,
+	TaskListItem,
 } from '@batuda/controllers'
-import type { Task } from '@batuda/domain'
 import { decidesPurchase } from '@batuda/domain'
 import { Sidebar, Stack, Switcher } from '@batuda/ui'
 import {
@@ -254,7 +254,7 @@ type TaskEntry = {
 type DetailPayload = {
 	readonly company: (typeof CompanyDetailResponse)['Type']
 	readonly contacts: PaginatedList<(typeof ContactListItem)['Type']>
-	readonly tasks: PaginatedList<Task>
+	readonly tasks: PaginatedList<TaskListItem>
 }
 
 /**

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -7,6 +7,10 @@ import { LayoutGroup, motion } from 'motion/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
+import {
+	type AttentionFilter,
+	AttentionFilter as AttentionFilterSchema,
+} from '@batuda/domain'
 import { PriButton, PriInput, PriSelect } from '@batuda/ui/pri'
 
 import {
@@ -78,6 +82,10 @@ const validateSearch = validateSearchWith({
 	owner: Schema.NonEmptyString,
 	sort: Schema.NonEmptyString,
 	query: Schema.NonEmptyString,
+	// Set when arriving from a dashboard heading, so the list opens on exactly
+	// what that heading was counting rather than on everything.
+	attention: AttentionFilterSchema,
+	staleDays: Schema.Union([Schema.Number, Schema.NumberFromString]),
 })
 
 /**
@@ -554,6 +562,8 @@ function mergeSearch(
 		owner: string | undefined
 		sort: string | undefined
 		query: string | undefined
+		attention: AttentionFilter | undefined
+		staleDays: number | undefined
 	}>,
 ): CompaniesSearch {
 	const result: {
@@ -564,6 +574,8 @@ function mergeSearch(
 		owner?: string
 		sort?: string
 		query?: string
+		attention?: AttentionFilter
+		staleDays?: number
 	} = {}
 
 	const status = 'status' in next ? next.status : prev.status
@@ -587,6 +599,12 @@ function mergeSearch(
 	const sort = 'sort' in next ? next.sort : prev.sort
 	if (sort !== undefined && sort !== '') result.sort = sort
 
+	const attention = 'attention' in next ? next.attention : prev.attention
+	if (attention !== undefined) result.attention = attention
+
+	const staleDays = 'staleDays' in next ? next.staleDays : prev.staleDays
+	if (staleDays !== undefined) result.staleDays = staleDays
+
 	return result
 }
 
@@ -597,6 +615,7 @@ function hasActiveFilters(search: CompaniesSearch): boolean {
 		search.industry !== undefined ||
 		search.priority !== undefined ||
 		search.owner !== undefined ||
+		search.attention !== undefined ||
 		search.query !== undefined
 	)
 }

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -22,6 +22,7 @@ import { CompanyCard } from '#/components/shared/company-card'
 import { EmptyState } from '#/components/shared/empty-state'
 import { KpiCounter } from '#/components/shared/kpi-counter'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
+import { ReasonChip } from '#/components/shared/reason-chip'
 import { SectionHeader } from '#/components/shared/section-header'
 import {
 	type CompanyStatus,
@@ -88,7 +89,7 @@ async function loadPipelineDataOnServer() {
 				// These two have to match `nextStepsAtom` and `pipelineAtom` exactly:
 				// the browser picks up what the server already fetched by the shape of
 				// the question, so any difference means the page quietly asks again.
-				client.pipeline.nextSteps({ query: {} }),
+				client.pipeline.nextSteps({ query: { limit: ATTENTION_PREVIEW } }),
 				client.pipeline.get(),
 			],
 			{ concurrency: 2 },
@@ -327,7 +328,11 @@ function PipelinePage() {
 				whileInView={{ opacity: 1, y: 0 }}
 				viewport={{ once: true, amount: 0.2 }}
 			>
-				<SectionHeader title={t`Needs attention`} count={attentionTotal} />
+				<SectionHeader
+					title={t`Needs attention`}
+					count={attentionTotal}
+					help={t`Tasks past their due date, companies whose follow-up date has passed, companies mid-deal with no contact in two weeks, and finished research nobody has decided on. Each company is listed once, under its most urgent reason. Closed and dead companies are left out.`}
+				/>
 				{attentionEmpty ? (
 					<EmptyState
 						title={t`All under control`}
@@ -359,23 +364,41 @@ function PipelinePage() {
 								}
 							/>
 						))}
-						{[...overdueCompanies, ...staleCompanies].map(company => (
-							<CompanyCard
-								key={company.id}
-								company={{
-									slug: company.slug,
-									name: company.name,
-									status: company.status,
-									industry: company.industry,
-									location: company.location,
-									country: company.country,
-									priority: company.priority,
-									lastContactedAt: company.lastContactedAt,
-								}}
-								actions={{
-									onLogInteraction: () => handleLogInteraction(company),
-								}}
-							/>
+						{[
+							...overdueCompanies.map(company => ({
+								company,
+								reason: 'overdue' as const,
+							})),
+							...staleCompanies.map(company => ({
+								company,
+								reason: 'stale' as const,
+							})),
+						].map(({ company, reason }) => (
+							<AttentionRow key={company.id}>
+								<ReasonChip
+									reason={reason}
+									since={
+										reason === 'overdue'
+											? company.nextActionAt
+											: company.lastContactedAt
+									}
+								/>
+								<CompanyCard
+									company={{
+										slug: company.slug,
+										name: company.name,
+										status: company.status,
+										industry: company.industry,
+										location: company.location,
+										country: company.country,
+										priority: company.priority,
+										lastContactedAt: company.lastContactedAt,
+									}}
+									actions={{
+										onLogInteraction: () => handleLogInteraction(company),
+									}}
+								/>
+							</AttentionRow>
 						))}
 						{research.map(run => (
 							<ResearchRow key={run.id} data-testid='pipeline-research-row'>
@@ -409,6 +432,7 @@ function PipelinePage() {
 					<SectionHeader
 						title={t`Today`}
 						count={taskCounts?.today ?? todayTasks.length}
+						help={t`Open tasks due today, in your own timezone. Anything already past its due date is under Needs attention instead.`}
 					/>
 					{todayTasks.length === 0 ? (
 						<EmptyState title={t`No tasks for today`} />
@@ -448,6 +472,7 @@ function PipelinePage() {
 					<SectionHeader
 						title={t`This week`}
 						count={taskCounts?.thisWeek ?? weekTasks.length}
+						help={t`Open tasks due in the next seven days, counted from tonight rather than to the end of the calendar week.`}
 					/>
 					{weekTasks.length === 0 ? (
 						<EmptyState title={t`No upcoming due dates`} />
@@ -489,6 +514,7 @@ function PipelinePage() {
 				<SectionHeader
 					title={t`High priority`}
 					count={nextSteps?.counts.highPriority ?? highPriority.length}
+					help={t`Companies marked hot with nothing scheduled at all. One that has also gone quiet is listed above instead, so it is only asked after once.`}
 				/>
 				{highPriority.length === 0 ? (
 					<EmptyState
@@ -674,6 +700,15 @@ const Stack = styled.div.withConfig({ displayName: 'PipelineStack' })`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-sm);
+`
+
+/** A company card with the reason it earned its place sitting above it. */
+const AttentionRow = styled.div.withConfig({
+	displayName: 'PipelineAttentionRow',
+})`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
 `
 
 /**

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -304,19 +304,43 @@ function PipelinePage() {
 
 			<SetPasswordNudge />
 
+			{/* Every counter opens the list it counted. A number nobody can follow
+			    is a dead end: the reader has to go and rebuild the same filter by
+			    hand on another screen, and usually gets a different number. */}
 			<KpiRow>
-				<KpiCounter value={activeCompanyCount} label={t`Active companies`} />
-				<KpiCounter value={openTaskCount} label={t`Open tasks`} />
-				<KpiCounter value={taskCounts?.overdue ?? 0} label={t`Overdue`} />
-				<KpiCounter
-					value={snapshot?.companiesWithoutNextAction ?? 0}
-					label={t`Needs action`}
-				/>
+				<KpiLink>
+					<Link to='/companies' aria-label={t`Active companies`} />
+					<KpiCounter value={activeCompanyCount} label={t`Active companies`} />
+				</KpiLink>
+				<KpiLink>
+					<Link to='/tasks' aria-label={t`Open tasks`} />
+					<KpiCounter value={openTaskCount} label={t`Open tasks`} />
+				</KpiLink>
+				<KpiLink>
+					<Link
+						to='/tasks'
+						search={{ shelf: 'overdue' }}
+						aria-label={t`Overdue`}
+					/>
+					<KpiCounter value={taskCounts?.overdue ?? 0} label={t`Overdue`} />
+				</KpiLink>
+				<KpiLink>
+					<Link
+						to='/companies'
+						search={{ attention: 'no-next-action' }}
+						aria-label={t`Needs action`}
+					/>
+					<KpiCounter
+						value={snapshot?.companiesWithoutNextAction ?? 0}
+						label={t`Needs action`}
+					/>
+				</KpiLink>
 			</KpiRow>
 
 			<StatusStrip>
 				{STATUS_ORDER.map(status => (
 					<StatusChip key={status} data-testid={`pipeline-column-${status}`}>
+						<Link to='/companies' search={{ status }} aria-label={status} />
 						<StatusBadge status={status} size='lg' />
 						<StatusCount>{countFor(status)}</StatusCount>
 					</StatusChip>
@@ -332,6 +356,15 @@ function PipelinePage() {
 					title={t`Needs attention`}
 					count={attentionTotal}
 					help={t`Tasks past their due date, companies whose follow-up date has passed, companies mid-deal with no contact in two weeks, and finished research nobody has decided on. Each company is listed once, under its most urgent reason. Closed and dead companies are left out.`}
+					action={
+						attentionTotal > attentionShown ? (
+							<ShowAll data-testid='pipeline-show-all-attention'>
+								<Link to='/companies' search={{ attention: 'stale' }}>
+									{t`Show all quiet companies`}
+								</Link>
+							</ShowAll>
+						) : undefined
+					}
 				/>
 				{attentionEmpty ? (
 					<EmptyState
@@ -433,6 +466,15 @@ function PipelinePage() {
 						title={t`Today`}
 						count={taskCounts?.today ?? todayTasks.length}
 						help={t`Open tasks due today, in your own timezone. Anything already past its due date is under Needs attention instead.`}
+						action={
+							(taskCounts?.today ?? 0) > todayTasks.length ? (
+								<ShowAll>
+									<Link to='/tasks' search={{ shelf: 'today' }}>
+										{t`Show all`}
+									</Link>
+								</ShowAll>
+							) : undefined
+						}
 					/>
 					{todayTasks.length === 0 ? (
 						<EmptyState title={t`No tasks for today`} />
@@ -473,6 +515,15 @@ function PipelinePage() {
 						title={t`This week`}
 						count={taskCounts?.thisWeek ?? weekTasks.length}
 						help={t`Open tasks due in the next seven days, counted from tonight rather than to the end of the calendar week.`}
+						action={
+							(taskCounts?.thisWeek ?? 0) > weekTasks.length ? (
+								<ShowAll>
+									<Link to='/tasks' search={{ shelf: 'thisWeek' }}>
+										{t`Show all`}
+									</Link>
+								</ShowAll>
+							) : undefined
+						}
 					/>
 					{weekTasks.length === 0 ? (
 						<EmptyState title={t`No upcoming due dates`} />
@@ -515,6 +566,18 @@ function PipelinePage() {
 					title={t`High priority`}
 					count={nextSteps?.counts.highPriority ?? highPriority.length}
 					help={t`Companies marked hot with nothing scheduled at all. One that has also gone quiet is listed above instead, so it is only asked after once.`}
+					action={
+						(nextSteps?.counts.highPriority ?? 0) > highPriority.length ? (
+							<ShowAll>
+								<Link
+									to='/companies'
+									search={{ priority: 1, sort: 'recent_update' }}
+								>
+									{t`Show all`}
+								</Link>
+							</ShowAll>
+						) : undefined
+					}
 				/>
 				{highPriority.length === 0 ? (
 					<EmptyState
@@ -672,10 +735,95 @@ const StatusStrip = styled.div.withConfig({
 	gap: var(--space-sm);
 `
 
-const StatusChip = styled.div.withConfig({ displayName: 'PipelineStatusChip' })`
+/**
+ * A status count that opens the list it counted.
+ *
+ * The link is a bare child stretched over the chip rather than the chip itself:
+ * `styled(Link)` keeps the styling but drops the router's typing of `to` and
+ * `search`, which is what turns a wrong destination into a compile error
+ * instead of a dead click.
+ */
+const StatusChip = styled.div.withConfig({
+	displayName: 'PipelineStatusChip',
+})`
+	position: relative;
 	display: inline-flex;
 	align-items: center;
 	gap: var(--space-2xs);
+	padding: var(--space-3xs) var(--space-2xs);
+	border-radius: var(--shape-2xs);
+	transition: background 140ms ease;
+
+	&:hover {
+		background: var(--color-surface-container-high);
+	}
+
+	&:focus-within {
+		box-shadow: var(--glow-active);
+	}
+
+	> a {
+		position: absolute;
+		inset: 0;
+		text-indent: -9999px;
+		overflow: hidden;
+		border-radius: inherit;
+	}
+
+	> a:focus-visible {
+		outline: none;
+	}
+`
+
+/**
+ * The way out of a section that shows only its first few rows. Without it the
+ * heading states a total the reader has no way of reaching.
+ */
+const ShowAll = styled.span.withConfig({ displayName: 'PipelineShowAll' })`
+	> a {
+		font-family: var(--font-display);
+		font-size: var(--typescale-label-small-size);
+		line-height: var(--typescale-label-small-line);
+		font-weight: var(--font-weight-bold);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--color-primary);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	> a:hover {
+		text-decoration: underline;
+	}
+
+	> a:focus-visible {
+		outline: none;
+		border-radius: var(--shape-2xs);
+		box-shadow: var(--glow-active);
+	}
+`
+
+/** Wraps a counter plate so the whole plate is the target, not just its digits. */
+const KpiLink = styled.div.withConfig({ displayName: 'PipelineKpiLink' })`
+	position: relative;
+	border-radius: var(--shape-2xs);
+
+	&:focus-within {
+		box-shadow: var(--glow-active);
+	}
+
+	> a {
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		text-indent: -9999px;
+		overflow: hidden;
+		border-radius: inherit;
+	}
+
+	> a:focus-visible {
+		outline: none;
+	}
 `
 
 const StatusCount = styled.span.withConfig({

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -691,8 +691,9 @@ function toAttentionTasks(result: unknown): ReadonlyArray<AttentionTask> {
 			title: r['title'],
 			dueAt: dateToIsoOrNull(r['dueAt']),
 			companyId: r['companyId'],
+			// A task with no company of its own is somebody's own to-do.
 			companyName:
-				typeof r['companyName'] === 'string' ? r['companyName'] : 'Company',
+				typeof r['companyName'] === 'string' ? r['companyName'] : 'Personal',
 			companySlug: typeof r['companySlug'] === 'string' ? r['companySlug'] : '',
 		})
 	}

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -310,11 +310,19 @@ function PipelinePage() {
 			<KpiRow>
 				<KpiLink>
 					<Link to='/companies' aria-label={t`Active companies`} />
-					<KpiCounter value={activeCompanyCount} label={t`Active companies`} />
+					<KpiCounter
+						value={activeCompanyCount}
+						label={t`Active companies`}
+						density='compact'
+					/>
 				</KpiLink>
 				<KpiLink>
 					<Link to='/tasks' aria-label={t`Open tasks`} />
-					<KpiCounter value={openTaskCount} label={t`Open tasks`} />
+					<KpiCounter
+						value={openTaskCount}
+						label={t`Open tasks`}
+						density='compact'
+					/>
 				</KpiLink>
 				<KpiLink>
 					<Link
@@ -322,7 +330,11 @@ function PipelinePage() {
 						search={{ shelf: 'overdue' }}
 						aria-label={t`Overdue`}
 					/>
-					<KpiCounter value={taskCounts?.overdue ?? 0} label={t`Overdue`} />
+					<KpiCounter
+						value={taskCounts?.overdue ?? 0}
+						label={t`Overdue`}
+						density='compact'
+					/>
 				</KpiLink>
 				<KpiLink>
 					<Link
@@ -333,6 +345,7 @@ function PipelinePage() {
 					<KpiCounter
 						value={snapshot?.companiesWithoutNextAction ?? 0}
 						label={t`Needs action`}
+						density='compact'
 					/>
 				</KpiLink>
 			</KpiRow>
@@ -717,13 +730,18 @@ const Subtitle = styled.p.withConfig({ displayName: 'PipelineSubtitle' })`
 	font-style: italic;
 `
 
+/**
+ * Two across, never more. Four counters in a three-column grid left the fourth
+ * stranded on a row of its own at every width, and a single column stacked them
+ * into more than a phone screen of counters before any work appeared.
+ */
 const KpiRow = styled.div.withConfig({ displayName: 'PipelineKpiRow' })`
 	display: grid;
-	grid-template-columns: 1fr;
-	gap: var(--space-md);
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--space-sm);
 
-	@media (min-width: 640px) {
-		grid-template-columns: repeat(3, 1fr);
+	@media (min-width: 768px) {
+		gap: var(--space-md);
 	}
 `
 
@@ -936,13 +954,15 @@ const ResearchNote = styled.span.withConfig({
 	color: var(--color-on-surface-variant);
 `
 
+// Splits at the same width the card grid does, so a tablet stops stacking these
+// full-width and pushing everything below them off the screen.
 const TwoColumn = styled.div.withConfig({ displayName: 'PipelineTwoColumn' })`
 	display: grid;
-	grid-template-columns: 1fr;
+	grid-template-columns: minmax(0, 1fr);
 	gap: var(--space-lg);
 
-	@media (min-width: 1024px) {
-		grid-template-columns: 1fr 1fr;
+	@media (min-width: 768px) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 `
 
@@ -950,15 +970,13 @@ const CompanyGrid = styled.div.withConfig({
 	displayName: 'PipelineCompanyGrid',
 })`
 	display: grid;
-	grid-template-columns: 1fr;
+	/* Two at most, matching the companies list, which caps there on purpose: a
+	 * single card already fills a desktop column comfortably. */
+	grid-template-columns: minmax(0, 1fr);
 	gap: var(--space-sm);
 
 	@media (min-width: 768px) {
-		grid-template-columns: 1fr 1fr;
-	}
-
-	@media (min-width: 1024px) {
-		grid-template-columns: 1fr 1fr 1fr;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
 	/* Micro-rotate file cards to break grid rhythm — each card straightens

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -1,19 +1,22 @@
 import { useAtomRefresh, useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { DateTime } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { motion } from 'motion/react'
 import { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
-import type { Company, Task } from '@batuda/domain'
-
 import {
-	companiesListAtom,
-	openTasksAtom,
+	ATTENTION_PREVIEW,
+	nextStepsAtom,
 	pipelineAtom,
 } from '#/atoms/pipeline-atoms'
+import {
+	localDayKey,
+	taskCountsAtom,
+	tasksShelfAtom,
+} from '#/atoms/tasks-atoms'
 import { SetPasswordNudge } from '#/components/profile/set-password-nudge'
 import { CompanyCard } from '#/components/shared/company-card'
 import { EmptyState } from '#/components/shared/empty-state'
@@ -28,17 +31,19 @@ import { TaskItem } from '#/components/shared/task-item'
 import { useQuickCapture } from '#/context/quick-capture-context'
 import { dehydrateAtom } from '#/lib/atom-hydration'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
-import type { PaginatedList } from '#/lib/paginated-list'
-import { countActiveCompanies, countActiveIn } from '#/lib/pipeline-counts'
+import { countActiveCompanies } from '#/lib/pipeline-counts'
 import { getServerCookieHeader } from '#/lib/server-cookie'
-import { rulerUnderRule, stenciledTitle } from '#/lib/workshop-mixins'
+import {
+	agedPaperRow,
+	rulerUnderRule,
+	stenciledTitle,
+} from '#/lib/workshop-mixins'
 
 /**
- * Flat shapes the dashboard renders. The company/task atoms carry the full
- * domain models (dates as `DateTime.Utc`); we narrow them to the handful of
- * fields this view needs, coercing dates back to ISO strings at the boundary.
+ * A company on one of the attention lists, flattened for the card. The server
+ * decides which list it belongs to; this only carries what the card draws.
  */
-type DashboardCompany = {
+type AttentionCompany = {
 	readonly id: string
 	readonly slug: string
 	readonly name: string
@@ -52,27 +57,25 @@ type DashboardCompany = {
 	readonly nextActionAt: string | null
 }
 
-type DashboardTask = {
+type AttentionTask = {
 	readonly id: string
-	readonly companyId: string
-	readonly type: string
 	readonly title: string
 	readonly dueAt: string | null
-	readonly completedAt: string | null
-}
-
-type PipelineData = {
-	readonly companies: PaginatedList<Company>
-	readonly openTasks: PaginatedList<Task>
+	readonly companyId: string
+	readonly companyName: string
+	readonly companySlug: string
 }
 
 /**
- * Server-only pipeline data fetch. Dynamically imports the server client
- * so Vite excludes it from the client bundle, and reads the incoming
- * request cookie via `getRequestHeader` to forward the Better-Auth
- * session on to the API server.
+ * Server-only pipeline fetch. Dynamically imports the server client so Vite
+ * excludes it from the client bundle, and reads the incoming request cookie via
+ * `getRequestHeader` to forward the Better-Auth session on to the API server.
+ *
+ * Only the two lists that do not depend on the reader's clock are fetched here.
+ * The task shelves need the edges of the reader's own day, which the browser
+ * knows and the server does not, so those load on arrival.
  */
-async function loadPipelineDataOnServer(): Promise<PipelineData> {
+async function loadPipelineDataOnServer() {
 	const [{ Effect }, { makeBatudaApiServer }, cookie] = await Promise.all([
 		import('effect'),
 		import('#/lib/batuda-api-server'),
@@ -80,20 +83,17 @@ async function loadPipelineDataOnServer(): Promise<PipelineData> {
 	])
 	const program = Effect.gen(function* () {
 		const client = yield* makeBatudaApiServer(cookie ?? undefined)
-		const [companies, openTasks] = yield* Effect.all(
+		const [nextSteps, pipeline] = yield* Effect.all(
 			[
-				// These two queries have to match `companiesListAtom` and
-				// `openTasksAtom` exactly: the browser picks up what the server
-				// already fetched by the shape of the question, so any difference
-				// means the page quietly asks again on arrival.
-				client.companies.list({ query: { limit: 500, count: 'exact' } }),
-				client.tasks.list({
-					query: { completed: 'false', limit: 500, count: 'exact' },
-				}),
+				// These two have to match `nextStepsAtom` and `pipelineAtom` exactly:
+				// the browser picks up what the server already fetched by the shape of
+				// the question, so any difference means the page quietly asks again.
+				client.pipeline.nextSteps({ query: {} }),
+				client.pipeline.get(),
 			],
 			{ concurrency: 2 },
 		)
-		return { companies, openTasks } as PipelineData
+		return { nextSteps, pipeline }
 	})
 	return Effect.runPromise(program)
 }
@@ -102,25 +102,25 @@ export const Route = createFileRoute('/')({
 	loader: async () => {
 		if (!import.meta.env.SSR) {
 			// Client-side navigation: let the atoms refetch directly via
-			// `BatudaApiAtom` using the browser's session cookie. Returning
-			// an empty dehydration leaves the registry alone and the
-			// component renders the loading state.
+			// `BatudaApiAtom` using the browser's session cookie. Returning an empty
+			// dehydration leaves the registry alone and the component renders the
+			// loading state.
 			return { dehydrated: [] as const }
 		}
 		try {
-			const { companies, openTasks } = await loadPipelineDataOnServer()
+			const { nextSteps, pipeline } = await loadPipelineDataOnServer()
 			return {
 				dehydrated: [
-					dehydrateAtom(companiesListAtom, AsyncResult.success(companies)),
-					dehydrateAtom(openTasksAtom, AsyncResult.success(openTasks)),
+					dehydrateAtom(nextStepsAtom, AsyncResult.success(nextSteps)),
+					dehydrateAtom(pipelineAtom, AsyncResult.success(pipeline)),
 				] as const,
 			}
 		} catch (error) {
-			// Expected in unauthenticated contexts (401 from SessionMiddleware)
-			// or when the API is down. Fall back to empty hydration — the
-			// atoms will land in `Initial`, the component renders the loading
-			// state, and the client-side fetch (with browser cookies) gets
-			// a second chance. See server.log for the underlying cause.
+			// Expected in unauthenticated contexts (401 from SessionMiddleware) or
+			// when the API is down. Fall back to empty hydration — the atoms land in
+			// `Initial`, the component renders the loading state, and the
+			// client-side fetch (with browser cookies) gets a second chance. See
+			// server.log for the underlying cause.
 			console.warn('[PipelineLoader] falling back to empty hydration:', error)
 			return { dehydrated: [] as const }
 		}
@@ -131,165 +131,142 @@ export const Route = createFileRoute('/')({
 
 /**
  * Module-scoped mutation atom. `Atom.family` inside `AtomHttpApi.mutation`
- * caches by the `{ group, endpoint, responseMode }` key, so pulling the
- * atom identity out here guarantees the same instance is used by every
- * render of the dashboard. `useAtomSet` wraps it into a writable setter.
+ * caches by the `{ group, endpoint, responseMode }` key, so pulling the atom
+ * identity out here guarantees the same instance is used by every render of the
+ * dashboard. `useAtomSet` wraps it into a writable setter.
  */
 const completeTaskAtom = BatudaApiAtom.mutation('tasks', 'complete')
 
 /**
  * Pipeline dashboard — answers three questions in under three seconds:
- *   1. What needs my attention right now? (overdue + stale pipeline)
- *   2. What's due today / this week? (task buckets)
- *   3. What does my pipeline look like? (status strip)
+ *   1. What needs my attention right now?
+ *   2. What's due today / this week?
+ *   3. What does my pipeline look like?
  *
- * Data flows via two shared atoms (`companiesListAtom`, `openTasksAtom`)
- * hydrated from the loader's SSR pairs, so first paint has real data.
- * Post-mutation refreshes use `useAtomRefresh` on both atoms.
+ * Every list here is decided by the server: which companies need chasing, in
+ * what order, and how many there are altogether. The page used to work that out
+ * in the browser from an uncounted 500-row fetch, which meant the same company
+ * could land in two sections, the five shown were an arbitrary five, and the
+ * number in a heading did not match the rows under it.
  */
 function PipelinePage() {
 	const { t } = useLingui()
-	const companiesResult = useAtomValue(companiesListAtom)
-	const openTasksResult = useAtomValue(openTasksAtom)
-	const refreshCompanies = useAtomRefresh(companiesListAtom)
-	const refreshTasks = useAtomRefresh(openTasksAtom)
+
+	// Which day it is where the reader is. The shelves only change at midnight,
+	// so keying on the day rather than the moment keeps the atom stable.
+	const dayKey = localDayKey()
+
+	const nextStepsResult = useAtomValue(nextStepsAtom)
 	const pipelineResult = useAtomValue(pipelineAtom)
+	const overdueTasksResult = useAtomValue(tasksShelfAtom('overdue', dayKey))
+	const todayTasksResult = useAtomValue(tasksShelfAtom('today', dayKey))
+	const weekTasksResult = useAtomValue(tasksShelfAtom('thisWeek', dayKey))
+	const taskCountsResult = useAtomValue(taskCountsAtom(dayKey))
+
+	const refreshNextSteps = useAtomRefresh(nextStepsAtom)
 	const refreshPipeline = useAtomRefresh(pipelineAtom)
+	const refreshOverdue = useAtomRefresh(tasksShelfAtom('overdue', dayKey))
+	const refreshToday = useAtomRefresh(tasksShelfAtom('today', dayKey))
+	const refreshWeek = useAtomRefresh(tasksShelfAtom('thisWeek', dayKey))
+	const refreshCounts = useAtomRefresh(taskCountsAtom(dayKey))
+
 	const completeTask = useAtomSet(completeTaskAtom, { mode: 'promiseExit' })
 	const { open: openQuickCapture } = useQuickCapture()
 
+	const handleToggleTask = useCallback(
+		async (taskId: string) => {
+			// Fire-and-forget complete — the task only toggles off-pending, so there
+			// is no "next" argument. Everything that counts it has to be asked again:
+			// the shelf it sat on, the shelf totals, and the company lists, whose
+			// rows can inherit new next-action fields on the server side.
+			await completeTask({ params: { id: taskId } })
+			refreshOverdue()
+			refreshToday()
+			refreshWeek()
+			refreshCounts()
+			refreshNextSteps()
+			refreshPipeline()
+		},
+		[
+			completeTask,
+			refreshCounts,
+			refreshNextSteps,
+			refreshOverdue,
+			refreshPipeline,
+			refreshToday,
+			refreshWeek,
+		],
+	)
+
 	const handleLogInteraction = useCallback(
-		(company: DashboardCompany) => {
-			openQuickCapture({
-				companyId: company.id,
-				companyName: company.name,
-			})
+		(company: { readonly id: string; readonly name: string }) => {
+			openQuickCapture({ companyId: company.id, companyName: company.name })
 		},
 		[openQuickCapture],
 	)
 
-	const handleToggleTask = useCallback(
-		async (taskId: string) => {
-			// Fire-and-forget complete — the task only toggles off-pending,
-			// so we don't need a "next" argument. On success refresh both
-			// atoms (the task disappears from `openTasks`; the company row
-			// may inherit updated next-action fields on the server side).
-			await completeTask({ params: { id: taskId } })
-			refreshTasks()
-			refreshCompanies()
-			refreshPipeline()
-		},
-		[completeTask, refreshCompanies, refreshTasks],
-	)
-
-	const companies = useMemo<ReadonlyArray<DashboardCompany>>(
-		() =>
-			AsyncResult.isSuccess(companiesResult)
-				? narrowCompanies(companiesResult.value.items)
-				: [],
-		[companiesResult],
-	)
-	const openTasks = useMemo<ReadonlyArray<DashboardTask>>(
-		() =>
-			AsyncResult.isSuccess(openTasksResult)
-				? narrowTasks(openTasksResult.value.items)
-				: [],
-		[openTasksResult],
-	)
-
-	// Counting the rows in hand would under-report as soon as someone has more
-	// open tasks than one page holds, so the total comes from the server. The
-	// request asks to be counted, so a missing total means the answer has not
-	// arrived yet rather than that there is nothing.
-	const openTaskCount =
-		(AsyncResult.isSuccess(openTasksResult)
-			? openTasksResult.value.total
-			: null) ?? 0
-
-	const isLoading =
-		AsyncResult.isInitial(companiesResult) ||
-		AsyncResult.isInitial(openTasksResult)
-
-	const now = Date.now()
-	const fourteenDaysAgo = now - 14 * 86400_000
-	const sevenDaysOut = now + 7 * 86400_000
-
-	const statusCounts = useMemo(() => countByStatus(companies), [companies])
-	// Prefer the server pipeline snapshot; fall back to the client aggregate
-	// until it loads so the first paint still shows real numbers.
-	const snapshot = AsyncResult.isSuccess(pipelineResult)
-		? (pipelineResult.value as {
-				statusCounts?: Record<string, number>
-				overdueTaskCount?: number
-				companiesWithoutNextAction?: number
-			})
+	const nextSteps = AsyncResult.isSuccess(nextStepsResult)
+		? nextStepsResult.value
 		: null
-	const countFor = (status: string) =>
-		snapshot?.statusCounts
-			? (snapshot.statusCounts[status] ?? 0)
-			: (statusCounts.get(status) ?? 0)
-
-	// Every company still in play — same fallback-until-loaded rule as the
-	// counters above.
-	const activeCompanyCount = snapshot?.statusCounts
-		? countActiveCompanies(snapshot.statusCounts)
-		: countActiveIn(companies)
-
-	const overdueTasks = useMemo(
-		() =>
-			openTasks
-				.filter(task => task.dueAt !== null && Date.parse(task.dueAt) < now)
-				.sort(
-					(a, b) =>
-						(a.dueAt ? Date.parse(a.dueAt) : 0) -
-						(b.dueAt ? Date.parse(b.dueAt) : 0),
-				),
-		[openTasks, now],
-	)
+	const snapshot = AsyncResult.isSuccess(pipelineResult)
+		? pipelineResult.value
+		: null
+	const taskCounts = AsyncResult.isSuccess(taskCountsResult)
+		? taskCountsResult.value
+		: null
 
 	const overdueCompanies = useMemo(
-		() =>
-			companies.filter(
-				company =>
-					company.nextActionAt !== null &&
-					Date.parse(company.nextActionAt) < now,
-			),
-		[companies, now],
+		() => toAttentionCompanies(nextSteps?.overdueCompanies),
+		[nextSteps],
 	)
-
-	const staleInPipeline = useMemo(
-		() =>
-			companies.filter(company => {
-				if (!STALE_STATUSES.has(company.status)) return false
-				if (company.lastContactedAt === null) return true
-				return Date.parse(company.lastContactedAt) < fourteenDaysAgo
-			}),
-		[companies, fourteenDaysAgo],
+	const staleCompanies = useMemo(
+		() => toAttentionCompanies(nextSteps?.staleCompanies),
+		[nextSteps],
 	)
+	const highPriority = useMemo(
+		() => toAttentionCompanies(nextSteps?.highPriority),
+		[nextSteps],
+	)
+	const research = nextSteps?.researchAwaitingReview ?? []
 
+	// The shelves come back a page at a time — far more than belongs on a summary
+	// — so only the front of each is drawn. The counts beside the headings come
+	// from the server and report every match, not what is on screen.
+	const overdueTasks = useMemo(
+		() => toAttentionTasks(overdueTasksResult).slice(0, ATTENTION_PREVIEW),
+		[overdueTasksResult],
+	)
 	const todayTasks = useMemo(
-		() => openTasks.filter(task => task.dueAt && isSameDay(task.dueAt, now)),
-		[openTasks, now],
+		() => toAttentionTasks(todayTasksResult).slice(0, ATTENTION_PREVIEW),
+		[todayTasksResult],
 	)
 	const weekTasks = useMemo(
-		() =>
-			openTasks.filter(task => {
-				if (!task.dueAt) return false
-				const due = Date.parse(task.dueAt)
-				return due > now && due < sevenDaysOut
-			}),
-		[openTasks, now, sevenDaysOut],
+		() => toAttentionTasks(weekTasksResult).slice(0, ATTENTION_PREVIEW),
+		[weekTasksResult],
 	)
 
-	const topPriorities = useMemo(
-		() =>
-			companies
-				.filter(
-					company => company.priority === 1 && company.nextActionAt === null,
-				)
-				.slice(0, 5),
-		[companies],
-	)
+	// The first paint needs the two server lists; the shelves fill in behind them
+	// rather than holding the whole page on a spinner.
+	const isLoading =
+		AsyncResult.isInitial(nextStepsResult) ||
+		AsyncResult.isInitial(pipelineResult)
+
+	const countFor = (status: string) => snapshot?.statusCounts?.[status] ?? 0
+	const activeCompanyCount = snapshot?.statusCounts
+		? countActiveCompanies(snapshot.statusCounts)
+		: 0
+
+	// Every shelf but the finished one. A task sits on exactly one shelf, so
+	// adding the rest up is the same question as "how many are still open" — and
+	// snoozed still counts, because putting something off is not doing it.
+	const openTaskCount = taskCounts
+		? taskCounts.overdue +
+			taskCounts.today +
+			taskCounts.thisWeek +
+			taskCounts.later +
+			taskCounts.noDue +
+			taskCounts.snoozed
+		: 0
 
 	if (isLoading) {
 		return (
@@ -299,7 +276,19 @@ function PipelinePage() {
 		)
 	}
 
-	const overdueTasksCount = overdueTasks.length
+	// What the section says it holds, counting every match rather than the
+	// handful fetched. The rows below are capped; these are not.
+	const attentionTotal =
+		(taskCounts?.overdue ?? overdueTasks.length) +
+		(nextSteps?.counts.overdueCompanies ?? 0) +
+		(nextSteps?.counts.staleCompanies ?? 0) +
+		(nextSteps?.counts.researchAwaitingReview ?? 0)
+	const attentionShown =
+		overdueTasks.length +
+		overdueCompanies.length +
+		staleCompanies.length +
+		research.length
+	const attentionEmpty = attentionShown === 0
 
 	return (
 		<Page data-testid='pipeline-page'>
@@ -317,10 +306,7 @@ function PipelinePage() {
 			<KpiRow>
 				<KpiCounter value={activeCompanyCount} label={t`Active companies`} />
 				<KpiCounter value={openTaskCount} label={t`Open tasks`} />
-				<KpiCounter
-					value={snapshot?.overdueTaskCount ?? overdueTasksCount}
-					label={t`Overdue`}
-				/>
+				<KpiCounter value={taskCounts?.overdue ?? 0} label={t`Overdue`} />
 				<KpiCounter
 					value={snapshot?.companiesWithoutNextAction ?? 0}
 					label={t`Needs action`}
@@ -341,52 +327,39 @@ function PipelinePage() {
 				whileInView={{ opacity: 1, y: 0 }}
 				viewport={{ once: true, amount: 0.2 }}
 			>
-				<SectionHeader
-					title={t`Needs attention`}
-					count={
-						overdueTasks.length +
-						overdueCompanies.length +
-						staleInPipeline.length
-					}
-				/>
-				{overdueTasks.length === 0 &&
-				overdueCompanies.length === 0 &&
-				staleInPipeline.length === 0 ? (
+				<SectionHeader title={t`Needs attention`} count={attentionTotal} />
+				{attentionEmpty ? (
 					<EmptyState
 						title={t`All under control`}
 						description={t`No overdue tasks, no pending follow-ups, no neglected companies.`}
 					/>
 				) : (
 					<Stack>
-						{overdueTasks.slice(0, 5).map(task => {
-							const company = companies.find(c => c.id === task.companyId)
-							return (
-								<TaskItem
-									key={task.id}
-									task={{
-										id: task.id,
-										title: task.title,
-										dueAt: task.dueAt,
-										companyId: task.companyId,
-										companyName: company?.name ?? t`Company`,
-										...(company?.slug !== undefined
-											? { companySlug: company.slug }
-											: {}),
-									}}
-									completed={false}
-									overdue
-									onToggle={() => {
-										void handleToggleTask(task.id)
-									}}
-									{...(company
-										? {
-												onLogInteraction: () => handleLogInteraction(company),
-											}
-										: {})}
-								/>
-							)
-						})}
-						{overdueCompanies.slice(0, 5).map(company => (
+						{overdueTasks.map(task => (
+							<TaskItem
+								key={task.id}
+								task={{
+									id: task.id,
+									title: task.title,
+									dueAt: task.dueAt,
+									companyId: task.companyId,
+									companyName: task.companyName,
+									companySlug: task.companySlug,
+								}}
+								completed={false}
+								overdue
+								onToggle={() => {
+									void handleToggleTask(task.id)
+								}}
+								onLogInteraction={() =>
+									handleLogInteraction({
+										id: task.companyId,
+										name: task.companyName,
+									})
+								}
+							/>
+						))}
+						{[...overdueCompanies, ...staleCompanies].map(company => (
 							<CompanyCard
 								key={company.id}
 								company={{
@@ -395,6 +368,7 @@ function PipelinePage() {
 									status: company.status,
 									industry: company.industry,
 									location: company.location,
+									country: company.country,
 									priority: company.priority,
 									lastContactedAt: company.lastContactedAt,
 								}}
@@ -403,22 +377,24 @@ function PipelinePage() {
 								}}
 							/>
 						))}
-						{staleInPipeline.slice(0, 5).map(company => (
-							<CompanyCard
-								key={`stale-${company.id}`}
-								company={{
-									slug: company.slug,
-									name: company.name,
-									status: company.status,
-									industry: company.industry,
-									location: company.location,
-									priority: company.priority,
-									lastContactedAt: company.lastContactedAt,
-								}}
-								actions={{
-									onLogInteraction: () => handleLogInteraction(company),
-								}}
-							/>
+						{research.map(run => (
+							<ResearchRow key={run.id} data-testid='pipeline-research-row'>
+								<ResearchLinkOverlay>
+									<Link
+										to='/research/$id'
+										params={{ id: run.id }}
+										aria-label={run.companyName ?? run.query}
+									/>
+								</ResearchLinkOverlay>
+								<ResearchSubject>
+									{run.companyName ?? run.query}
+								</ResearchSubject>
+								<ResearchNote>
+									{run.pendingUpdateCount > 0
+										? t`${run.pendingUpdateCount} changes to review`
+										: t`Research finished — needs a look`}
+								</ResearchNote>
+							</ResearchRow>
 						))}
 					</Stack>
 				)}
@@ -430,38 +406,37 @@ function PipelinePage() {
 					whileInView={{ opacity: 1, y: 0 }}
 					viewport={{ once: true, amount: 0.2 }}
 				>
-					<SectionHeader title={t`Today`} count={todayTasks.length} />
+					<SectionHeader
+						title={t`Today`}
+						count={taskCounts?.today ?? todayTasks.length}
+					/>
 					{todayTasks.length === 0 ? (
 						<EmptyState title={t`No tasks for today`} />
 					) : (
 						<Stack>
-							{todayTasks.map(task => {
-								const company = companies.find(c => c.id === task.companyId)
-								return (
-									<TaskItem
-										key={task.id}
-										task={{
-											id: task.id,
-											title: task.title,
-											dueAt: task.dueAt,
-											companyId: task.companyId,
-											companyName: company?.name ?? t`Company`,
-											...(company?.slug !== undefined
-												? { companySlug: company.slug }
-												: {}),
-										}}
-										completed={false}
-										onToggle={() => {
-											void handleToggleTask(task.id)
-										}}
-										{...(company
-											? {
-													onLogInteraction: () => handleLogInteraction(company),
-												}
-											: {})}
-									/>
-								)
-							})}
+							{todayTasks.map(task => (
+								<TaskItem
+									key={task.id}
+									task={{
+										id: task.id,
+										title: task.title,
+										dueAt: task.dueAt,
+										companyId: task.companyId,
+										companyName: task.companyName,
+										companySlug: task.companySlug,
+									}}
+									completed={false}
+									onToggle={() => {
+										void handleToggleTask(task.id)
+									}}
+									onLogInteraction={() =>
+										handleLogInteraction({
+											id: task.companyId,
+											name: task.companyName,
+										})
+									}
+								/>
+							))}
 						</Stack>
 					)}
 				</Section>
@@ -470,38 +445,37 @@ function PipelinePage() {
 					whileInView={{ opacity: 1, y: 0 }}
 					viewport={{ once: true, amount: 0.2 }}
 				>
-					<SectionHeader title={t`This week`} count={weekTasks.length} />
+					<SectionHeader
+						title={t`This week`}
+						count={taskCounts?.thisWeek ?? weekTasks.length}
+					/>
 					{weekTasks.length === 0 ? (
 						<EmptyState title={t`No upcoming due dates`} />
 					) : (
 						<Stack>
-							{weekTasks.map(task => {
-								const company = companies.find(c => c.id === task.companyId)
-								return (
-									<TaskItem
-										key={task.id}
-										task={{
-											id: task.id,
-											title: task.title,
-											dueAt: task.dueAt,
-											companyId: task.companyId,
-											companyName: company?.name ?? t`Company`,
-											...(company?.slug !== undefined
-												? { companySlug: company.slug }
-												: {}),
-										}}
-										completed={false}
-										onToggle={() => {
-											void handleToggleTask(task.id)
-										}}
-										{...(company
-											? {
-													onLogInteraction: () => handleLogInteraction(company),
-												}
-											: {})}
-									/>
-								)
-							})}
+							{weekTasks.map(task => (
+								<TaskItem
+									key={task.id}
+									task={{
+										id: task.id,
+										title: task.title,
+										dueAt: task.dueAt,
+										companyId: task.companyId,
+										companyName: task.companyName,
+										companySlug: task.companySlug,
+									}}
+									completed={false}
+									onToggle={() => {
+										void handleToggleTask(task.id)
+									}}
+									onLogInteraction={() =>
+										handleLogInteraction({
+											id: task.companyId,
+											name: task.companyName,
+										})
+									}
+								/>
+							))}
 						</Stack>
 					)}
 				</Section>
@@ -512,14 +486,18 @@ function PipelinePage() {
 				whileInView={{ opacity: 1, y: 0 }}
 				viewport={{ once: true, amount: 0.2 }}
 			>
-				<SectionHeader title={t`High priority`} count={topPriorities.length} />
-				{topPriorities.length === 0 ? (
+				<SectionHeader
+					title={t`High priority`}
+					count={nextSteps?.counts.highPriority ?? highPriority.length}
+				/>
+				{highPriority.length === 0 ? (
 					<EmptyState
 						title={t`No high-priority companies without a scheduled follow-up`}
+						description={t`A high-priority company that has gone quiet is listed once, under Needs attention.`}
 					/>
 				) : (
 					<CompanyGrid>
-						{topPriorities.map(company => (
+						{highPriority.map(company => (
 							<CompanyCard
 								key={company.id}
 								company={{
@@ -528,6 +506,7 @@ function PipelinePage() {
 									status: company.status,
 									industry: company.industry,
 									location: company.location,
+									country: company.country,
 									priority: company.priority,
 									lastContactedAt: company.lastContactedAt,
 								}}
@@ -554,33 +533,6 @@ const STATUS_ORDER: ReadonlyArray<CompanyStatus> = [
 	'dead',
 ]
 
-const STALE_STATUSES = new Set<string>([
-	'contacted',
-	'responded',
-	'meeting',
-	'proposal',
-])
-
-function countByStatus(
-	companies: ReadonlyArray<DashboardCompany>,
-): Map<string, number> {
-	const counts = new Map<string, number>()
-	for (const company of companies) {
-		counts.set(company.status, (counts.get(company.status) ?? 0) + 1)
-	}
-	return counts
-}
-
-function isSameDay(isoString: string, reference: number): boolean {
-	const a = new Date(isoString)
-	const b = new Date(reference)
-	return (
-		a.getFullYear() === b.getFullYear() &&
-		a.getMonth() === b.getMonth() &&
-		a.getDate() === b.getDate()
-	)
-}
-
 // Typed date fields decode to DateTime.Utc on the wire; fall back to their
 // string form for anything already an ISO string.
 function dateToIsoOrNull(value: unknown): string | null {
@@ -589,11 +541,11 @@ function dateToIsoOrNull(value: unknown): string | null {
 	return null
 }
 
-function narrowCompanies(
-	rows: ReadonlyArray<unknown>,
-): ReadonlyArray<DashboardCompany> {
-	const out: Array<DashboardCompany> = []
-	for (const row of rows) {
+function toAttentionCompanies(
+	rows: ReadonlyArray<unknown> | undefined,
+): ReadonlyArray<AttentionCompany> {
+	const out: Array<AttentionCompany> = []
+	for (const row of rows ?? []) {
 		if (!row || typeof row !== 'object') continue
 		const r = row as Record<string, unknown>
 		if (typeof r['id'] !== 'string') continue
@@ -617,24 +569,29 @@ function narrowCompanies(
 	return out
 }
 
-function narrowTasks(
-	rows: ReadonlyArray<unknown>,
-): ReadonlyArray<DashboardTask> {
-	const out: Array<DashboardTask> = []
-	for (const row of rows) {
+/**
+ * One shelf's rows, flattened for the row component. A task carries its company
+ * through the join, so nothing here has to look one up.
+ */
+function toAttentionTasks(result: unknown): ReadonlyArray<AttentionTask> {
+	if (!AsyncResult.isAsyncResult(result)) return []
+	if (!AsyncResult.isSuccess(result)) return []
+	const items = (result.value as { items?: ReadonlyArray<unknown> }).items ?? []
+	const out: Array<AttentionTask> = []
+	for (const row of items) {
 		if (!row || typeof row !== 'object') continue
 		const r = row as Record<string, unknown>
 		if (typeof r['id'] !== 'string') continue
-		if (typeof r['companyId'] !== 'string') continue
-		if (typeof r['type'] !== 'string') continue
 		if (typeof r['title'] !== 'string') continue
+		if (typeof r['companyId'] !== 'string') continue
 		out.push({
 			id: r['id'],
-			companyId: r['companyId'],
-			type: r['type'],
 			title: r['title'],
 			dueAt: dateToIsoOrNull(r['dueAt']),
-			completedAt: dateToIsoOrNull(r['completedAt']),
+			companyId: r['companyId'],
+			companyName:
+				typeof r['companyName'] === 'string' ? r['companyName'] : 'Company',
+			companySlug: typeof r['companySlug'] === 'string' ? r['companySlug'] : '',
 		})
 	}
 	return out
@@ -717,6 +674,83 @@ const Stack = styled.div.withConfig({ displayName: 'PipelineStack' })`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-sm);
+`
+
+/**
+ * A finished research run still waiting on somebody. Research takes minutes, so
+ * whoever asked for it has usually moved on — this row is how a run that landed
+ * unattended gets noticed at all.
+ */
+const ResearchRow = styled.div.withConfig({
+	displayName: 'PipelineResearchRow',
+})`
+	${agedPaperRow}
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+	padding: var(--space-sm) var(--space-md);
+	border-left: 3px solid var(--color-secondary);
+
+	&:hover {
+		filter: brightness(1.04);
+	}
+
+	&:focus-within {
+		box-shadow: var(--glow-active);
+	}
+`
+
+// Stretched-link overlay so the whole row navigates. A `styled(Link)` would
+// take the row's styling but lose the router's typing of `params`, which is
+// what makes a wrong route id a compile error rather than a dead link.
+const ResearchLinkOverlay = styled.div.withConfig({
+	displayName: 'PipelineResearchLinkOverlay',
+})`
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+
+	a {
+		display: block;
+		position: absolute;
+		inset: 0;
+		text-indent: -9999px;
+		overflow: hidden;
+	}
+
+	a:focus-visible {
+		outline: none;
+	}
+`
+
+const ResearchSubject = styled.span.withConfig({
+	displayName: 'PipelineResearchSubject',
+})`
+	position: relative;
+	z-index: 1;
+	pointer-events: none;
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-medium-size);
+	line-height: var(--typescale-label-medium-line);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--color-on-surface);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+`
+
+const ResearchNote = styled.span.withConfig({
+	displayName: 'PipelineResearchNote',
+})`
+	position: relative;
+	z-index: 1;
+	pointer-events: none;
+	font-size: var(--typescale-body-small-size);
+	line-height: var(--typescale-body-small-line);
+	color: var(--color-on-surface-variant);
 `
 
 const TwoColumn = styled.div.withConfig({ displayName: 'PipelineTwoColumn' })`

--- a/apps/internal/src/routes/tasks/index.tsx
+++ b/apps/internal/src/routes/tasks/index.tsx
@@ -20,6 +20,7 @@ import {
 	reopenTaskAtom,
 	rescheduleTaskAtom,
 	snoozeTaskAtom,
+	TASK_SHELVES,
 	TASKS_PAGE_SIZE,
 	type TaskShelf,
 	taskCountsAtom,
@@ -207,7 +208,12 @@ const tasksDlgSchema = Schema.Union([
 const ADDRESS_CATCH_UP_MS = 200
 
 export const Route = createFileRoute('/tasks/')({
-	validateSearch: validateSearchWith({ dlg: tasksDlgSchema }),
+	validateSearch: validateSearchWith({
+		dlg: tasksDlgSchema,
+		// Which shelf to open on. The dashboard's sections link straight to the
+		// matching one; without this every link landed on Today whatever it said.
+		shelf: Schema.Literals(TASK_SHELVES),
+	}),
 	loader: async () => {
 		if (!import.meta.env.SSR) {
 			return { dehydrated: [] as const }
@@ -230,7 +236,13 @@ export const Route = createFileRoute('/tasks/')({
 
 function TasksPage() {
 	const { t } = useLingui()
-	const [selectedShelf, setSelectedShelf] = useState<TaskShelf>('today')
+	// The shelf named in the URL only seeds the rail; from then on the reader's
+	// clicks own it, so arriving from a dashboard link opens where it said and
+	// still moves freely afterwards.
+	const { shelf: shelfFromUrl } = Route.useSearch()
+	const [selectedShelf, setSelectedShelf] = useState<TaskShelf>(
+		shelfFromUrl ?? 'today',
+	)
 	// Which day it is where the reader sits. Held in state rather than read on
 	// every render, which would hand every render a different atom to fetch —
 	// but a tab left open overnight would then keep filing work under

--- a/apps/server/src/handlers/pipeline.ts
+++ b/apps/server/src/handlers/pipeline.ts
@@ -14,7 +14,12 @@ export const PipelineLive = HttpApiBuilder.group(
 			return handlers
 				.handle('get', () => svc.getPipeline().pipe(Effect.orDie))
 				.handle('nextSteps', _ =>
-					svc.getNextSteps(_.query.limit).pipe(Effect.orDie),
+					svc
+						.getNextSteps(_.query.limit, {
+							staleDays: _.query.staleDays,
+							priorityAtLeast: _.query.priorityAtLeast,
+						})
+						.pipe(Effect.orDie),
 				)
 		}),
 )

--- a/apps/server/src/lib/sql-pagination.ts
+++ b/apps/server/src/lib/sql-pagination.ts
@@ -54,8 +54,12 @@ export function takePage<R>(
  * along on every row as a `COUNT(*) OVER ()` column, so any one row carries it.
  * Reports `0` when no row carries one, which is only truthful for a page that
  * starts at the beginning and was asked to be counted.
+ *
+ * Exported for lists that only ever start at the beginning — a capped list with
+ * no offset to page through — where {@link resolveTotal}'s fallback query could
+ * never run and asking for one would be dead code.
  */
-function readWindowTotal(
+export function readWindowTotal(
 	rows: ReadonlyArray<{ readonly total?: string | number }>,
 ): number {
 	const first = rows[0]

--- a/apps/server/src/mcp/prompts/daily-briefing.ts
+++ b/apps/server/src/mcp/prompts/daily-briefing.ts
@@ -41,9 +41,13 @@ Produce:
 1. Pipeline health (bottlenecks, status changes)
 2. Urgent: overdue tasks needing immediate action
 3. Research awaiting review, from researchAwaitingReview — name the company each run is about, or quote its query when it belongs to no company; say how many changes are still undecided, and call out any that failed or came back unreliable
-4. Today's priorities
-5. Companies at risk (stale, no recent contact)
+4. Today's priorities, from highPriority — hot companies with nothing scheduled at all
+5. Companies at risk, from staleCompanies — mid-chase and gone quiet, longest silence first
 6. Quick wins
-7. Suggested schedule`
+7. Suggested schedule
+
+Each company appears on one attention list only, so report it once, under that
+heading. Quote totals from counts rather than counting the rows quoted above:
+each list is capped, and the matching *Truncated flag says which were cut short.`
 		}),
 })

--- a/apps/server/src/mcp/tools/pipeline.ts
+++ b/apps/server/src/mcp/tools/pipeline.ts
@@ -1,7 +1,12 @@
 import { Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 
-import { NextSteps, PipelineSnapshot } from '@batuda/controllers'
+import {
+	NextSteps,
+	PipelineSnapshot,
+	PRIORITY_AT_LEAST_BOUNDS,
+	STALE_DAYS_BOUNDS,
+} from '@batuda/controllers'
 
 import { PipelineService } from '../../services/pipeline'
 import { McpPageLimit } from './_result'
@@ -18,9 +23,26 @@ const GetPipeline = Tool.make('get_pipeline', {
 
 const GetNextSteps = Tool.make('get_next_steps', {
 	description:
-		'Get upcoming tasks, companies with overdue next_action_at, and research runs awaiting review. Used for daily planning. researchAwaitingReview lists finished research nobody in the organization has dealt with yet, newest first — pendingUpdateCount is how many of its proposed CRM changes are still undecided (read them with list_research_proposed_updates, then decide each with resolve_research_proposed_update), and a status of failed, no_reliable_data or succeeded_low_confidence means the run itself needs a look. A run leaves this list once its changes are all decided. This is how research started earlier gets noticed: a run takes minutes, so whoever asked for it is rarely still waiting when it lands. companyId, companyName and companySlug are null for a freeform or scan run that belongs to no single company, and completedAt can be null. limit (default 20) caps each of the three lists separately; dueTasksTruncated, overdueCompaniesTruncated and researchAwaitingReviewTruncated say which of them had more rows than were returned, so ask again with a higher limit before reporting a list as complete.',
+		'Get the daily planning lists: upcoming tasks, the three company attention lists, and research runs awaiting review. A company appears on at most ONE of the three company lists, most urgent first, so the same company is never reported twice: overdueCompanies has missed its next_action_at date; staleCompanies is mid-chase (contacted, responded, meeting or proposal) and has not been heard from in staleDays, or never at all; highPriority is priority <= priorityAtLeast with nothing scheduled at all. Companies with status closed or dead appear on none of them. staleDays (default 14) is how long a company may go quiet before it counts — raise it for long sales cycles, lower it for fast-turnaround trades. priorityAtLeast (default 1) reads as importance, not the stored number: 1 is the hottest, so 2 takes priorities 1 and 2. researchAwaitingReview lists finished research nobody in the organization has dealt with yet, newest first — pendingUpdateCount is how many of its proposed CRM changes are still undecided (read them with list_research_proposed_updates, then decide each with resolve_research_proposed_update), and a status of failed, no_reliable_data or succeeded_low_confidence means the run itself needs a look. A run leaves this list once its changes are all decided. This is how research started earlier gets noticed: a run takes minutes, so whoever asked for it is rarely still waiting when it lands. companyId, companyName and companySlug are null for a freeform or scan run that belongs to no single company, and completedAt can be null. counts reports how many rows match each list in total, one entry per list, which is what to quote when summarising; limit (default 20) caps each list separately and the matching *Truncated flag says which lists had more rows than were returned, so ask again with a higher limit before reporting a list as complete.',
 	parameters: Schema.Struct({
 		limit: Schema.optional(McpPageLimit),
+		// Same bounds the HTTP route enforces, taken from it rather than repeated,
+		// so an agent and a browser are never told different limits. The numbers
+		// arrive already parsed here, which is why the schema is not the
+		// from-a-string one the query string needs.
+		staleDays: Schema.optional(
+			Schema.Number.pipe(
+				Schema.check(Schema.isInt(), Schema.isBetween(STALE_DAYS_BOUNDS)),
+			),
+		),
+		priorityAtLeast: Schema.optional(
+			Schema.Number.pipe(
+				Schema.check(
+					Schema.isInt(),
+					Schema.isBetween(PRIORITY_AT_LEAST_BOUNDS),
+				),
+			),
+		),
 	}),
 	success: NextSteps,
 })
@@ -37,7 +59,12 @@ export const PipelineHandlersLive = PipelineTools.toLayer(
 		return {
 			get_pipeline: () => service.getPipeline().pipe(Effect.orDie),
 			get_next_steps: params =>
-				service.getNextSteps(params.limit).pipe(Effect.orDie),
+				service
+					.getNextSteps(params.limit, {
+						staleDays: params.staleDays,
+						priorityAtLeast: params.priorityAtLeast,
+					})
+					.pipe(Effect.orDie),
 		}
 	}),
 )

--- a/apps/server/src/services/companies-attention-filter.integration.test.ts
+++ b/apps/server/src/services/companies-attention-filter.integration.test.ts
@@ -1,0 +1,275 @@
+// Live-DB integration test for the company list's "what needs doing" filter.
+//
+// The point of this filter is that the dashboard can link into it: a heading
+// there reading 65 has to open a list of 65 here. That only holds while both
+// sides ask the database the same question, so these tests compare the two
+// answers directly rather than restating either rule.
+//
+// Prereq: `pnpm cli services up` — the integration runner's globalSetup builds,
+// migrates and seeds the disposable database this suite runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+import type { AttentionFilter } from '@batuda/domain'
+
+import { PgLive } from '../db/client'
+import { applyTestEnv } from '../test-env'
+import { CompanyService } from './companies'
+import { PipelineService } from './pipeline'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+let orgId: string
+
+const TAG = `attnfilter-${randomUUID().slice(0, 8)}`
+
+const insertCompany = async (options: {
+	readonly name: string
+	readonly status: string
+	readonly nextAction?: string | null
+	readonly lastContactedDaysAgo?: number | null
+	readonly nextActionInDays?: number | null
+}): Promise<void> => {
+	const slug = `${TAG}-${options.name}`
+	await pool.query(
+		`INSERT INTO companies (
+			organization_id, slug, name, status, next_action,
+			last_contacted_at, next_action_at
+		 ) VALUES (
+			$1, $2, $2, $3, $4,
+			CASE WHEN $5::int IS NULL THEN NULL ELSE now() - ($5::int * interval '1 day') END,
+			CASE WHEN $6::int IS NULL THEN NULL ELSE now() + ($6::int * interval '1 day') END
+		 )`,
+		[
+			orgId,
+			slug,
+			options.status,
+			options.nextAction ?? null,
+			options.lastContactedDaysAgo ?? null,
+			options.nextActionInDays ?? null,
+		],
+	)
+}
+
+const deps = CompanyService.layer.pipe(
+	Layer.provideMerge(PipelineService.layer),
+	Layer.provideMerge(PgLive),
+)
+
+const asMember = {
+	id: '',
+	name: 'fixture',
+	slug: 'fixture',
+	role: 'member' as const,
+}
+
+// Each read runs the way a request does: role app_user, scoped to this org, so
+// row-level security applies exactly as it would in production. Written out per
+// helper rather than behind one generic wrapper — a wrapper that takes the body
+// as a type parameter loses the success type on the way through, and every
+// assertion below then reads as `never`.
+const filtered = (attention: AttentionFilter, staleDays?: number) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const companies = yield* CompanyService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				return yield* companies
+					.search({
+						attention,
+						...(staleDays === undefined ? {} : { staleDays }),
+						limit: 500,
+						count: 'exact',
+					})
+					.pipe(Effect.provideService(CurrentOrg, { ...asMember, id: orgId }))
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+
+const dashboard = (staleDays?: number) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const pipeline = yield* PipelineService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				return yield* pipeline
+					.getNextSteps(500, staleDays === undefined ? {} : { staleDays })
+					.pipe(Effect.provideService(CurrentOrg, { ...asMember, id: orgId }))
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+
+const snapshot = () =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const pipeline = yield* PipelineService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				return yield* pipeline
+					.getPipeline()
+					.pipe(Effect.provideService(CurrentOrg, { ...asMember, id: orgId }))
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+
+const stalePlusStatus = (status: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const companies = yield* CompanyService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				return yield* companies
+					.search({ attention: 'stale', status, limit: 500, count: 'exact' })
+					.pipe(Effect.provideService(CurrentOrg, { ...asMember, id: orgId }))
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+
+const slugsOf = (rows: ReadonlyArray<{ readonly slug: string }>) =>
+	[...rows.map(row => row.slug)].sort()
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	const org = await pool.query<{ id: string }>(
+		`SELECT id FROM organization LIMIT 1`,
+	)
+	const id = org.rows[0]?.id
+	if (!id) throw new Error('no organization seeded — run the integration setup')
+	orgId = id
+
+	// One company per reason, so each filter has something of its own to find.
+	await insertCompany({
+		name: 'missed',
+		status: 'proposal',
+		nextAction: 'Chase the quote',
+		nextActionInDays: -5,
+	})
+	await insertCompany({
+		name: 'quiet',
+		status: 'contacted',
+		nextAction: 'Send the brochure',
+		lastContactedDaysAgo: 40,
+	})
+	await insertCompany({
+		name: 'nothing-planned',
+		status: 'responded',
+		lastContactedDaysAgo: 1,
+	})
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM companies WHERE slug LIKE $1`, [`${TAG}-%`])
+	await pool.end()
+})
+
+describe('CompanyService attention filter', () => {
+	describe('when the dashboard links into the company list', () => {
+		it('should return exactly the companies the overdue list holds', async () => {
+			// GIVEN the dashboard's own overdue list
+			const listed = await filtered('overdue')
+			const onDashboard = await dashboard()
+
+			// THEN the filter returns the same companies. Comparing the two answers
+			// rather than restating the rule is the point: a heading that says 12
+			// has to open a list of 12, and only agreement proves that
+			expect(slugsOf(listed.items)).toEqual(
+				slugsOf(onDashboard.overdueCompanies),
+			)
+			expect(listed.total).toBe(onDashboard.counts.overdueCompanies)
+		})
+
+		it('should return exactly the companies the quiet list holds', async () => {
+			// GIVEN both sides asked at the same threshold
+			const listed = await filtered('stale')
+			const onDashboard = await dashboard()
+
+			// THEN they agree on every row and on the count
+			expect(slugsOf(listed.items)).toEqual(slugsOf(onDashboard.staleCompanies))
+			expect(listed.total).toBe(onDashboard.counts.staleCompanies)
+		})
+
+		it('should follow the threshold the link carries', async () => {
+			// GIVEN a dashboard showing a two-month idea of quiet
+			const listed = await filtered('stale', 60)
+			const onDashboard = await dashboard(60)
+
+			// THEN the list opened from it uses that same two months, rather than
+			// falling back to the default and showing a different set
+			expect(slugsOf(listed.items)).toEqual(slugsOf(onDashboard.staleCompanies))
+			expect(listed.total).toBe(onDashboard.counts.staleCompanies)
+		})
+
+		it('should match the needs-action counter exactly', async () => {
+			// GIVEN the counter on the dashboard
+			const listed = await filtered('no-next-action')
+			const counter = await snapshot()
+
+			// THEN the list holds precisely that many. This one reads the written
+			// note rather than the follow-up date and leaves signed clients out, so
+			// it is the pairing most likely to drift apart unnoticed
+			expect(listed.total).toBe(counter.companiesWithoutNextAction)
+		})
+	})
+
+	describe('when a filter is asked for on its own', () => {
+		it('should find the company put there for it', async () => {
+			// GIVEN one company per reason, each set up in beforeAll
+			const [overdue, stale, noNext] = await Promise.all([
+				filtered('overdue'),
+				filtered('stale'),
+				filtered('no-next-action'),
+			])
+
+			// THEN each filter finds its own. Without this the agreement checks
+			// above would still pass on three empty lists
+			expect(slugsOf(overdue.items)).toContain(`${TAG}-missed`)
+			expect(slugsOf(stale.items)).toContain(`${TAG}-quiet`)
+			expect(slugsOf(noNext.items)).toContain(`${TAG}-nothing-planned`)
+		})
+
+		it('should leave a company with a plan off the needs-action list', async () => {
+			// GIVEN two companies that do have a next step written down
+			const noNext = await filtered('no-next-action')
+
+			// THEN neither is asked after, because something is already planned for
+			// them — the filter reads the written note, not the date
+			expect(slugsOf(noNext.items)).not.toContain(`${TAG}-missed`)
+			expect(slugsOf(noNext.items)).not.toContain(`${TAG}-quiet`)
+		})
+	})
+
+	describe('when the filter is combined with another', () => {
+		it('should narrow rather than replace', async () => {
+			// GIVEN the quiet list narrowed to one stage of the pipeline
+			const all = await filtered('stale')
+			const contactedOnly = await stalePlusStatus('contacted')
+
+			// THEN the narrowed list is a subset — the two filters stack, so a
+			// reader who arrived from the dashboard can keep filtering from there
+			const wider = new Set(slugsOf(all.items))
+			for (const slug of slugsOf(contactedOnly.items)) {
+				expect(wider).toContain(slug)
+			}
+			expect(contactedOnly.items.length).toBeLessThanOrEqual(all.items.length)
+			expect(slugsOf(contactedOnly.items)).toContain(`${TAG}-quiet`)
+		})
+	})
+})

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -18,6 +18,7 @@ import {
 	splitCompanyChannelFields,
 	writeChannels,
 } from './channels'
+import { type AttentionFilter, attentionCondition } from './company-attention'
 import {
 	findIndustryByName,
 	industryForWrite,
@@ -40,6 +41,13 @@ export interface CompanyFilters {
 	readonly fitCriterionPassed?: string | undefined
 	// Owner id to match, or the literal 'none' to match only unassigned companies.
 	readonly owner?: string | undefined
+	// Narrows to what needs doing: a missed follow-up, a company gone quiet, or
+	// one with nothing written down as the next step. Same rules the dashboard
+	// counts by, so a heading there opens a list of the same size here.
+	readonly attention?: AttentionFilter | undefined
+	// How long counts as gone quiet, for `attention: 'stale'`. Carried on the
+	// link so the list matches the threshold the dashboard was showing.
+	readonly staleDays?: number | undefined
 	// One of the whitelisted sort keys below; anything else falls back to priority.
 	readonly sort?: string | undefined
 	readonly query?: string | undefined
@@ -111,6 +119,10 @@ export class CompanyService extends Context.Service<CompanyService>()(
 									WHERE fc->>'result' = 'pass'
 										AND fc->>'criterion' ILIKE ${`%${filters.fitCriterionPassed}%`}
 								)`,
+							)
+						if (filters.attention)
+							conditions.push(
+								attentionCondition(sql, filters.attention, filters.staleDays),
 							)
 						if (filters.query)
 							conditions.push(sql`name ILIKE ${`%${filters.query}%`}`)

--- a/apps/server/src/services/company-attention.ts
+++ b/apps/server/src/services/company-attention.ts
@@ -1,0 +1,128 @@
+import type { SqlClient, Statement } from 'effect/unstable/sql'
+
+import type { AttentionFilter } from '@batuda/domain'
+
+export type { AttentionFilter }
+
+/**
+ * What makes a company worth someone's attention today.
+ *
+ * Two screens ask this: the dashboard, which shows the urgent handful, and the
+ * company list the dashboard links into when somebody wants all of them. They
+ * have to agree — a heading that says 65 must open a list of 65 — so the rules
+ * are written once here rather than once per screen.
+ */
+
+/**
+ * How long a company still in play may go unheard from before it counts as
+ * having gone quiet, when the caller does not say. Two weeks suits a trade where
+ * a quote turns around in days; anyone selling on a longer cycle passes their
+ * own number rather than living with this one.
+ */
+export const DEFAULT_STALE_DAYS = 14
+
+/** Only the hottest companies lead the high-priority list unless asked otherwise. */
+export const DEFAULT_PRIORITY_AT_LEAST = 1
+
+/**
+ * A company nobody is selling to any more belongs on none of these lists. Named
+ * by what is excluded rather than what is included, so a status added later
+ * lands on the lists by default instead of silently vanishing from them.
+ */
+export const TERMINAL_STATUSES = ['closed', 'dead'] as const
+
+/** The stages where silence is worth flagging — before a deal, not after it. */
+export const CHASING_STATUSES = [
+	'contacted',
+	'responded',
+	'meeting',
+	'proposal',
+] as const
+
+/**
+ * Still being sold to: not deleted, and not at a stage where the answer is
+ * already known. Every rule below starts from this, so a deleted company cannot
+ * reappear through whichever one was written last.
+ */
+export const inPlay = (sql: SqlClient.SqlClient): Statement.Fragment => sql`
+	deleted_at IS NULL
+	AND status NOT IN ${sql.in(TERMINAL_STATUSES)}
+`
+
+/** The follow-up date somebody set has already passed. */
+export const isOverdue = (sql: SqlClient.SqlClient): Statement.Fragment =>
+	sql`next_action_at < now() AND ${inPlay(sql)}`
+
+/**
+ * Mid-chase and not heard from in a while — or ever.
+ *
+ * The last line is what keeps a company off this list once its follow-up date
+ * has already passed: being chased late is the more urgent way of saying the
+ * same thing, so overdue wins the company.
+ *
+ * Kept free of `--` comments on purpose: this fragment gets embedded inside
+ * `NOT (…)` below, where a trailing SQL comment would swallow the bracket.
+ */
+export const isStale = (
+	sql: SqlClient.SqlClient,
+	staleDays: number = DEFAULT_STALE_DAYS,
+): Statement.Fragment => sql`
+	deleted_at IS NULL
+	AND status IN ${sql.in(CHASING_STATUSES)}
+	AND (
+		last_contacted_at IS NULL
+		OR last_contacted_at < now() - (${staleDays} * interval '1 day')
+	)
+	AND (next_action_at IS NULL OR next_action_at >= now())
+`
+
+/** Hot, nothing booked in, and not already answered for by the two above. */
+export const isHighPriority = (
+	sql: SqlClient.SqlClient,
+	options: {
+		readonly staleDays?: number | undefined
+		readonly priorityAtLeast?: number | undefined
+	} = {},
+): Statement.Fragment => sql`
+	priority <= ${options.priorityAtLeast ?? DEFAULT_PRIORITY_AT_LEAST}
+	AND next_action_at IS NULL
+	AND ${inPlay(sql)}
+	AND NOT (${isStale(sql, options.staleDays)})
+`
+
+/**
+ * Nothing written down about what happens next.
+ *
+ * Signed clients are left out, unlike the lists above: a client with no next
+ * step is ordinary, a prospect with none is a lead going nowhere. This reads the
+ * written note rather than the date, and roughly half of any real company list
+ * has one without the other — so the two are not interchangeable, and the
+ * dashboard counter and the page it opens both have to use this one.
+ */
+export const hasNoNextAction = (
+	sql: SqlClient.SqlClient,
+): Statement.Fragment => sql`
+	next_action IS NULL
+	AND deleted_at IS NULL
+	AND status NOT IN ${sql.in([...TERMINAL_STATUSES, 'client'])}
+`
+
+/**
+ * Turn the caller's word into the rule it names. The words themselves live in
+ * the domain, so the screen, the contract and this module cannot disagree about
+ * which ones exist.
+ */
+export const attentionCondition = (
+	sql: SqlClient.SqlClient,
+	attention: AttentionFilter,
+	staleDays?: number | undefined,
+): Statement.Fragment => {
+	switch (attention) {
+		case 'overdue':
+			return isOverdue(sql)
+		case 'stale':
+			return isStale(sql, staleDays)
+		case 'no-next-action':
+			return hasNoNextAction(sql)
+	}
+}

--- a/apps/server/src/services/pipeline-attention-buckets.integration.test.ts
+++ b/apps/server/src/services/pipeline-attention-buckets.integration.test.ts
@@ -1,0 +1,414 @@
+// Live-DB integration test for the company half of the daily-planning list.
+// The three lists exist to be worked top to bottom, so what matters is that a
+// company lands on exactly one of them, that the most urgent leads, and that the
+// number in the heading is the number of rows behind it — all of which are
+// decisions made in SQL and none of which a unit test would catch.
+//
+// Prereq: `pnpm cli services up` — the integration runner's globalSetup builds,
+// migrates and seeds the disposable database this suite runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../db/client'
+import { applyTestEnv } from '../test-env'
+import { PipelineService } from './pipeline'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+let orgId: string
+
+// Every fixture carries this run's tag in its slug, so a suite running beside
+// another worktree's can still tell its own rows from the seeded ones.
+const TAG = `attn-${randomUUID().slice(0, 8)}`
+
+const insertCompany = async (options: {
+	readonly name: string
+	readonly status: string
+	readonly priority?: number | null
+	// Days ago; null means never heard from, which is its own kind of quiet.
+	readonly lastContactedDaysAgo?: number | null
+	// Days from now; negative is a follow-up already missed.
+	readonly nextActionInDays?: number | null
+}): Promise<string> => {
+	const slug = `${TAG}-${options.name}`
+	const row = await pool.query<{ id: string }>(
+		`INSERT INTO companies (
+			organization_id, slug, name, status, priority,
+			last_contacted_at, next_action_at
+		 ) VALUES (
+			$1, $2, $2, $3, $4,
+			CASE WHEN $5::int IS NULL THEN NULL ELSE now() - ($5::int * interval '1 day') END,
+			CASE WHEN $6::int IS NULL THEN NULL ELSE now() + ($6::int * interval '1 day') END
+		 ) RETURNING id`,
+		[
+			orgId,
+			slug,
+			options.status,
+			options.priority ?? null,
+			options.lastContactedDaysAgo ?? null,
+			options.nextActionInDays ?? null,
+		],
+	)
+	return row.rows[0]!.id
+}
+
+// Read the lists as the request path does: role app_user, scoped to this org, so
+// row-level security applies exactly as it would in production.
+const readBuckets = (options?: {
+	readonly limit?: number
+	readonly staleDays?: number
+	readonly priorityAtLeast?: number
+}) => {
+	const deps = PipelineService.layer.pipe(Layer.provideMerge(PgLive))
+	return Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const pipeline = yield* PipelineService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				return yield* pipeline
+					.getNextSteps(options?.limit ?? 200, {
+						staleDays: options?.staleDays,
+						priorityAtLeast: options?.priorityAtLeast,
+					})
+					.pipe(
+						Effect.provideService(CurrentOrg, {
+							id: orgId,
+							name: 'fixture',
+							slug: 'fixture',
+							role: 'member',
+						}),
+					)
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+}
+
+const slugsOf = (rows: ReadonlyArray<{ readonly slug: string }>) =>
+	rows.map(row => row.slug)
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	const org = await pool.query<{ id: string }>(
+		`SELECT id FROM organization LIMIT 1`,
+	)
+	const id = org.rows[0]?.id
+	if (!id) throw new Error('no organization seeded — run the integration setup')
+	orgId = id
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(`DELETE FROM companies WHERE slug LIKE $1`, [`${TAG}-%`])
+	await pool.end()
+})
+
+describe('PipelineService attention buckets', () => {
+	describe('when a company has missed its follow-up date', () => {
+		it('should lead the overdue list with the one missed longest', async () => {
+			// GIVEN two companies past their follow-up, one by a fortnight and one by
+			// a day
+			await insertCompany({
+				name: 'slipped-long',
+				status: 'proposal',
+				nextActionInDays: -14,
+			})
+			await insertCompany({
+				name: 'slipped-short',
+				status: 'proposal',
+				nextActionInDays: -1,
+			})
+
+			// WHEN the planning lists are read
+			const { overdueCompanies } = await readBuckets()
+			const ours = slugsOf(overdueCompanies).filter(s => s.startsWith(TAG))
+
+			// THEN the one left waiting longest comes first, because the list is
+			// meant to be worked from the top. Both are checked to be on the list
+			// before their order is: a missing row also reads as "earlier" once
+			// indexOf answers -1, which would pass an ordering check on its own.
+			expect(ours).toContain(`${TAG}-slipped-long`)
+			expect(ours).toContain(`${TAG}-slipped-short`)
+			expect(ours.indexOf(`${TAG}-slipped-long`)).toBeLessThan(
+				ours.indexOf(`${TAG}-slipped-short`),
+			)
+		})
+
+		it('should keep it off the quiet list as well', async () => {
+			// GIVEN a company that has both missed its follow-up and not been heard
+			// from in months — it qualifies for both lists on the face of it
+			await insertCompany({
+				name: 'both',
+				status: 'meeting',
+				lastContactedDaysAgo: 90,
+				nextActionInDays: -3,
+			})
+
+			// WHEN the lists are read
+			const { overdueCompanies, staleCompanies } = await readBuckets()
+
+			// THEN it appears once, under the more urgent heading — a single company
+			// asking twice for attention reads as a fault in the screen
+			expect(slugsOf(overdueCompanies)).toContain(`${TAG}-both`)
+			expect(slugsOf(staleCompanies)).not.toContain(`${TAG}-both`)
+		})
+	})
+
+	describe('when nobody is selling to the company any more', () => {
+		it('should leave it off every list', async () => {
+			// GIVEN two finished deals, each of which would otherwise earn a place:
+			// one closed with a follow-up date long past, and one dead that is
+			// priority 1 with nothing scheduled — the exact shape the high-priority
+			// list looks for. Each is built to be caught by a different list, so a
+			// missing status check on either one fails this test.
+			await insertCompany({
+				name: 'closed',
+				status: 'closed',
+				nextActionInDays: -30,
+			})
+			await insertCompany({
+				name: 'dead',
+				status: 'dead',
+				priority: 1,
+				lastContactedDaysAgo: 2,
+			})
+
+			// WHEN the lists are read
+			const { overdueCompanies, staleCompanies, highPriority } =
+				await readBuckets()
+			const everywhere = [
+				...slugsOf(overdueCompanies),
+				...slugsOf(staleCompanies),
+				...slugsOf(highPriority),
+			]
+
+			// THEN neither is asked after — chasing a finished deal is the one thing
+			// this list must never put in front of somebody
+			expect(everywhere).not.toContain(`${TAG}-closed`)
+			expect(everywhere).not.toContain(`${TAG}-dead`)
+		})
+	})
+
+	describe('when a company in play has gone quiet', () => {
+		it('should lead with the one never contacted at all', async () => {
+			// GIVEN one company last heard from a month ago and one never contacted
+			await insertCompany({
+				name: 'quiet-month',
+				status: 'contacted',
+				lastContactedDaysAgo: 30,
+			})
+			await insertCompany({
+				name: 'quiet-never',
+				status: 'contacted',
+				lastContactedDaysAgo: null,
+			})
+
+			// WHEN the quiet list is read
+			const { staleCompanies } = await readBuckets()
+			const ours = slugsOf(staleCompanies).filter(s => s.startsWith(TAG))
+
+			// THEN never-contacted leads: no contact at all is the longest silence
+			// there is, and sorting it last would bury the coldest lead on the list.
+			// Presence is asserted first for the same reason as above — a row that
+			// is simply absent would otherwise satisfy the ordering.
+			expect(ours).toContain(`${TAG}-quiet-never`)
+			expect(ours).toContain(`${TAG}-quiet-month`)
+			expect(ours.indexOf(`${TAG}-quiet-never`)).toBeLessThan(
+				ours.indexOf(`${TAG}-quiet-month`),
+			)
+		})
+
+		it('should ignore stages where silence means nothing', async () => {
+			// GIVEN an untouched prospect and a signed client, neither contacted in
+			// months
+			await insertCompany({
+				name: 'prospect-quiet',
+				status: 'prospect',
+				lastContactedDaysAgo: 120,
+			})
+			await insertCompany({
+				name: 'client-quiet',
+				status: 'client',
+				lastContactedDaysAgo: 120,
+			})
+
+			// WHEN the quiet list is read
+			const { staleCompanies } = await readBuckets()
+
+			// THEN neither is on it: silence is only worth flagging mid-chase, and a
+			// list that nagged about every signed client would stop being read
+			expect(slugsOf(staleCompanies)).not.toContain(`${TAG}-prospect-quiet`)
+			expect(slugsOf(staleCompanies)).not.toContain(`${TAG}-client-quiet`)
+		})
+	})
+
+	describe('when the caller sets its own idea of quiet', () => {
+		it('should narrow the list as the threshold lengthens', async () => {
+			// GIVEN a company last heard from three weeks ago
+			await insertCompany({
+				name: 'three-weeks',
+				status: 'responded',
+				lastContactedDaysAgo: 21,
+			})
+
+			// WHEN the list is read at a fortnight and again at two months
+			const fortnight = await readBuckets({ staleDays: 14 })
+			const twoMonths = await readBuckets({ staleDays: 60 })
+
+			// THEN three weeks of silence counts under the shorter threshold and not
+			// the longer one — the number is the caller's to choose, because a trade
+			// quoting in days and one selling on six-month cycles do not mean the
+			// same thing by "quiet"
+			expect(slugsOf(fortnight.staleCompanies)).toContain(`${TAG}-three-weeks`)
+			expect(slugsOf(twoMonths.staleCompanies)).not.toContain(
+				`${TAG}-three-weeks`,
+			)
+		})
+
+		it('should keep a never-contacted company however long the threshold', async () => {
+			// GIVEN a company in play that has never been contacted at all
+			await insertCompany({
+				name: 'never-spoken-to',
+				status: 'proposal',
+				lastContactedDaysAgo: null,
+			})
+
+			// WHEN the list is read at a fortnight and again at ten years
+			const fortnight = await readBuckets({ staleDays: 14 })
+			const decade = await readBuckets({ staleDays: 3650 })
+
+			// THEN it is on both. Silence with no start date is not shorter than any
+			// threshold — it is longer than all of them — so raising the threshold
+			// must never quietly drop the coldest leads on the list
+			expect(slugsOf(fortnight.staleCompanies)).toContain(
+				`${TAG}-never-spoken-to`,
+			)
+			expect(slugsOf(decade.staleCompanies)).toContain(`${TAG}-never-spoken-to`)
+		})
+	})
+
+	describe('when a hot company has nothing booked in', () => {
+		it('should list it only while it is not already being chased', async () => {
+			// GIVEN two priority-1 companies with nothing scheduled: one contacted
+			// last week, one silent for two months
+			await insertCompany({
+				name: 'hot-fresh',
+				status: 'responded',
+				priority: 1,
+				lastContactedDaysAgo: 5,
+			})
+			await insertCompany({
+				name: 'hot-quiet',
+				status: 'responded',
+				priority: 1,
+				lastContactedDaysAgo: 60,
+			})
+
+			// WHEN the lists are read
+			const { staleCompanies, highPriority } = await readBuckets()
+
+			// THEN only the freshly contacted one is called out as high priority; the
+			// silent one is already answered for further up, under gone quiet
+			expect(slugsOf(highPriority)).toContain(`${TAG}-hot-fresh`)
+			expect(slugsOf(highPriority)).not.toContain(`${TAG}-hot-quiet`)
+			expect(slugsOf(staleCompanies)).toContain(`${TAG}-hot-quiet`)
+		})
+
+		it('should reach further down the scale when asked to', async () => {
+			// GIVEN a second-priority company with nothing scheduled
+			await insertCompany({
+				name: 'warm',
+				status: 'responded',
+				priority: 2,
+				lastContactedDaysAgo: 2,
+			})
+
+			// WHEN the list is read at the default reach and again one step down
+			const hottest = await readBuckets()
+			const alsoWarm = await readBuckets({ priorityAtLeast: 2 })
+
+			// THEN it only shows once the caller asks for it, so the default list
+			// stays as short as the word "priority" promises
+			expect(slugsOf(hottest.highPriority)).not.toContain(`${TAG}-warm`)
+			expect(slugsOf(alsoWarm.highPriority)).toContain(`${TAG}-warm`)
+		})
+	})
+
+	describe('when more companies match than the list will hold', () => {
+		it('should count them all and say it was cut short', async () => {
+			// GIVEN four quiet companies and room on the list for two
+			for (const n of [1, 2, 3, 4]) {
+				await insertCompany({
+					name: `capped-${n}`,
+					status: 'contacted',
+					lastContactedDaysAgo: 40 + n,
+				})
+			}
+
+			// WHEN the list is read with a cap of two
+			const capped = await readBuckets({ limit: 2 })
+
+			// THEN two rows come back, the flag says there are more, and the count
+			// reports every match — the heading has to be able to say "2 of 40",
+			// which is the whole reason a screen can show a handful honestly
+			expect(capped.staleCompanies).toHaveLength(2)
+			expect(capped.staleCompaniesTruncated).toBe(true)
+			expect(capped.counts.staleCompanies).toBeGreaterThan(
+				capped.staleCompanies.length,
+			)
+		})
+
+		it('should count exactly what an uncapped read returns', async () => {
+			// GIVEN whatever the org holds right now
+			// WHEN the lists are read with room to spare
+			const full = await readBuckets({ limit: 500 })
+
+			// THEN every count matches the rows beside it, so the number in a heading
+			// and the rows under it can never tell different stories. All five lists
+			// are checked, including the two that carry no companies: a list that
+			// answers "how many?" differently from its neighbours is the asymmetry
+			// this count exists to remove.
+			expect(full.staleCompaniesTruncated).toBe(false)
+			expect(full.counts.staleCompanies).toBe(full.staleCompanies.length)
+			expect(full.counts.overdueCompanies).toBe(full.overdueCompanies.length)
+			expect(full.counts.highPriority).toBe(full.highPriority.length)
+			expect(full.counts.dueTasks).toBe(full.dueTasks.length)
+			expect(full.counts.researchAwaitingReview).toBe(
+				full.researchAwaitingReview.length,
+			)
+		})
+	})
+
+	describe('when a company card is drawn from the list', () => {
+		it('should carry everything the card shows', async () => {
+			// GIVEN a quiet company with a trade, a place and a priority on it
+			await insertCompany({
+				name: 'full-card',
+				status: 'meeting',
+				priority: 2,
+				lastContactedDaysAgo: 45,
+			})
+
+			// WHEN the quiet list is read
+			const { staleCompanies } = await readBuckets()
+			const card = staleCompanies.find(c => c.slug === `${TAG}-full-card`)
+
+			// THEN the row carries the status, priority and last-contact date the
+			// card draws, so the dashboard needs no second request to render it
+			expect(card?.status).toBe('meeting')
+			expect(card?.priority).toBe(2)
+			expect(card?.lastContactedAt).not.toBeNull()
+		})
+	})
+})

--- a/apps/server/src/services/pipeline.ts
+++ b/apps/server/src/services/pipeline.ts
@@ -12,6 +12,14 @@ import {
 	takePage,
 	totalColumn,
 } from '../lib/sql-pagination'
+import {
+	DEFAULT_PRIORITY_AT_LEAST,
+	DEFAULT_STALE_DAYS,
+	hasNoNextAction,
+	isHighPriority,
+	isOverdue,
+	isStale,
+} from './company-attention'
 
 // The extra column `totalColumn` appends. Every list below selects it, so each
 // can report how many rows matched without a second trip to the database.
@@ -61,32 +69,6 @@ const decodeNextStepResearchRuns = Schema.decodeUnknownEffect(
 	Schema.Array(NextStepResearchRunRow),
 )
 
-/**
- * How long a company still in play may go unheard from before it counts as
- * having gone quiet, when the caller does not say. Two weeks suits a trade where
- * a quote turns around in days; anyone selling on a longer cycle passes their
- * own number rather than living with this one.
- */
-const DEFAULT_STALE_DAYS = 14
-
-/** Only the hottest companies lead the high-priority list unless asked otherwise. */
-const DEFAULT_PRIORITY_AT_LEAST = 1
-
-/**
- * A company nobody is selling to any more belongs on none of these lists. Named
- * by what is excluded rather than what is included, so a status added later
- * lands on the lists by default instead of silently vanishing from them.
- */
-const TERMINAL_STATUSES = ['closed', 'dead'] as const
-
-/** The stages where silence is worth flagging — before a deal, not after it. */
-const CHASING_STATUSES = [
-	'contacted',
-	'responded',
-	'meeting',
-	'proposal',
-] as const
-
 export class PipelineService extends Context.Service<PipelineService>()(
 	'PipelineService',
 	{
@@ -112,41 +94,14 @@ export class PipelineService extends Context.Service<PipelineService>()(
 							id, slug, name, status, industry, location, country, priority,
 							last_contacted_at, next_action, next_action_at
 						`
-						// Still being sold to: not deleted, and not at a stage where the
-						// answer is already known. Every list below starts from this, so a
-						// deleted company cannot reappear through whichever rule was
-						// written last.
-						const inPlay = sql`
-							deleted_at IS NULL
-							AND status NOT IN ${sql.in(TERMINAL_STATUSES)}
-						`
-						// The three lists below are cut so that a company falls on exactly
-						// one: being chased late is one thing to do about it, not three.
-						// Written once each and reused by both the page and its count, so
-						// the number in the heading cannot drift from the rows under it.
-						const isOverdue = sql`next_action_at < now() AND ${inPlay}`
-						// The last line is what keeps a company off this list once its
-						// follow-up date has already passed: being chased late is the more
-						// urgent way of saying the same thing, so overdue wins the company.
-						//
-						// Kept as a TypeScript comment rather than a `--` one inside the
-						// query: this fragment gets embedded in `NOT (…)` below, where a
-						// trailing SQL comment would swallow the closing bracket.
-						const isStale = sql`
-							deleted_at IS NULL
-							AND status IN ${sql.in(CHASING_STATUSES)}
-							AND (
-								last_contacted_at IS NULL
-								OR last_contacted_at < now() - (${staleDays} * interval '1 day')
-							)
-							AND (next_action_at IS NULL OR next_action_at >= now())
-						`
-						const isHighPriority = sql`
-							priority <= ${priorityAtLeast}
-							AND next_action_at IS NULL
-							AND ${inPlay}
-							AND NOT (${isStale})
-						`
+						// The three lists are cut so a company falls on exactly one: being
+						// chased late is one thing to do about it, not three. The rules live
+						// in company-attention.ts because the company list filters by the
+						// same ones — a heading here that says 65 opens a list of 65 there
+						// only while both are asking the same question.
+						const overdue = isOverdue(sql)
+						const stale = isStale(sql, staleDays)
+						const hot = isHighPriority(sql, { staleDays, priorityAtLeast })
 
 						// Each list asks to be counted as it is fetched: `COUNT(*) OVER ()`
 						// is worked out before the LIMIT applies, so the full total rides
@@ -172,7 +127,7 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						const overdueCompanies = yield* sql<WindowTotal>`
 							SELECT ${cardColumns}${withTotal}
 							FROM companies
-							WHERE ${isOverdue}
+							WHERE ${overdue}
 							ORDER BY next_action_at, id
 							LIMIT ${probeLimit(limit)}
 						`
@@ -182,7 +137,7 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						const staleCompanies = yield* sql<WindowTotal>`
 							SELECT ${cardColumns}${withTotal}
 							FROM companies
-							WHERE ${isStale}
+							WHERE ${stale}
 							ORDER BY last_contacted_at ASC NULLS FIRST, id
 							LIMIT ${probeLimit(limit)}
 						`
@@ -192,7 +147,7 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						const highPriority = yield* sql<WindowTotal>`
 							SELECT ${cardColumns}${withTotal}
 							FROM companies
-							WHERE ${isHighPriority}
+							WHERE ${hot}
 							ORDER BY updated_at DESC, id
 							LIMIT ${probeLimit(limit)}
 						`
@@ -312,13 +267,13 @@ export class PipelineService extends Context.Service<PipelineService>()(
 								)
 						`
 
+						// The same rule the company list filters by, so the counter and the
+						// page it opens can never disagree about what "needs action" means.
 						const companiesWithoutNextAction = yield* sql<{
 							count: number
 						}>`
 							SELECT count(*)::int as count FROM companies
-							WHERE next_action IS NULL
-								AND deleted_at IS NULL
-								AND status NOT IN ('closed', 'dead', 'client')
+							WHERE ${hasNoNextAction(sql)}
 						`
 
 						return {

--- a/apps/server/src/services/pipeline.ts
+++ b/apps/server/src/services/pipeline.ts
@@ -6,7 +6,16 @@ import {
 	TERMINAL_RESEARCH_STATUSES,
 } from '@batuda/domain'
 
-import { probeLimit, takePage } from '../lib/sql-pagination'
+import {
+	probeLimit,
+	readWindowTotal,
+	takePage,
+	totalColumn,
+} from '../lib/sql-pagination'
+
+// The extra column `totalColumn` appends. Every list below selects it, so each
+// can report how many rows matched without a second trip to the database.
+type WindowTotal = { readonly total?: string | number }
 
 // The next-steps rows carry raw Date timestamps; read them into DateTime.Utc so
 // the wire schemas (NextSteps) re-encode them as ISO strings.
@@ -26,6 +35,12 @@ const NextStepCompanyRow = Schema.Struct({
 	id: Schema.String,
 	slug: Schema.String,
 	name: Schema.String,
+	status: Schema.String,
+	industry: Schema.NullOr(Schema.String),
+	location: Schema.NullOr(Schema.String),
+	country: Schema.NullOr(Schema.String),
+	priority: Schema.NullOr(Schema.Number),
+	lastContactedAt: Schema.NullOr(Schema.DateTimeUtcFromDate),
 	nextAction: Schema.NullOr(Schema.String),
 	nextActionAt: Schema.NullOr(Schema.DateTimeUtcFromDate),
 })
@@ -46,6 +61,32 @@ const decodeNextStepResearchRuns = Schema.decodeUnknownEffect(
 	Schema.Array(NextStepResearchRunRow),
 )
 
+/**
+ * How long a company still in play may go unheard from before it counts as
+ * having gone quiet, when the caller does not say. Two weeks suits a trade where
+ * a quote turns around in days; anyone selling on a longer cycle passes their
+ * own number rather than living with this one.
+ */
+const DEFAULT_STALE_DAYS = 14
+
+/** Only the hottest companies lead the high-priority list unless asked otherwise. */
+const DEFAULT_PRIORITY_AT_LEAST = 1
+
+/**
+ * A company nobody is selling to any more belongs on none of these lists. Named
+ * by what is excluded rather than what is included, so a status added later
+ * lands on the lists by default instead of silently vanishing from them.
+ */
+const TERMINAL_STATUSES = ['closed', 'dead'] as const
+
+/** The stages where silence is worth flagging — before a deal, not after it. */
+const CHASING_STATUSES = [
+	'contacted',
+	'responded',
+	'meeting',
+	'proposal',
+] as const
+
 export class PipelineService extends Context.Service<PipelineService>()(
 	'PipelineService',
 	{
@@ -53,45 +94,106 @@ export class PipelineService extends Context.Service<PipelineService>()(
 			const sql = yield* SqlClient.SqlClient
 
 			return {
-				getCounts: () =>
-					sql`
-						SELECT status, count(*)::int as count FROM companies
-						WHERE deleted_at IS NULL
-						GROUP BY status
-					`,
-
-				getOverdueTasks: (limit = 10) =>
-					sql`
-						SELECT t.id, t.title, t.type, t.due_at,
-							t.company_id, c.name as company_name, c.slug as company_slug
-						FROM tasks t
-						INNER JOIN companies c
-							ON t.company_id = c.id AND c.deleted_at IS NULL
-						WHERE t.completed_at IS NULL AND t.due_at < now()
-						ORDER BY t.due_at
-						LIMIT ${limit}
-					`,
-
-				getNextSteps: (limit = 20) =>
+				getNextSteps: (
+					limit = 20,
+					options: {
+						readonly staleDays?: number | undefined
+						readonly priorityAtLeast?: number | undefined
+					} = {},
+				) =>
 					Effect.gen(function* () {
-						const dueTasks = yield* sql`
+						const staleDays = options.staleDays ?? DEFAULT_STALE_DAYS
+						const priorityAtLeast =
+							options.priorityAtLeast ?? DEFAULT_PRIORITY_AT_LEAST
+
+						// Every attention list draws the same company card, so they all
+						// select the same columns.
+						const cardColumns = sql`
+							id, slug, name, status, industry, location, country, priority,
+							last_contacted_at, next_action, next_action_at
+						`
+						// Still being sold to: not deleted, and not at a stage where the
+						// answer is already known. Every list below starts from this, so a
+						// deleted company cannot reappear through whichever rule was
+						// written last.
+						const inPlay = sql`
+							deleted_at IS NULL
+							AND status NOT IN ${sql.in(TERMINAL_STATUSES)}
+						`
+						// The three lists below are cut so that a company falls on exactly
+						// one: being chased late is one thing to do about it, not three.
+						// Written once each and reused by both the page and its count, so
+						// the number in the heading cannot drift from the rows under it.
+						const isOverdue = sql`next_action_at < now() AND ${inPlay}`
+						// The last line is what keeps a company off this list once its
+						// follow-up date has already passed: being chased late is the more
+						// urgent way of saying the same thing, so overdue wins the company.
+						//
+						// Kept as a TypeScript comment rather than a `--` one inside the
+						// query: this fragment gets embedded in `NOT (…)` below, where a
+						// trailing SQL comment would swallow the closing bracket.
+						const isStale = sql`
+							deleted_at IS NULL
+							AND status IN ${sql.in(CHASING_STATUSES)}
+							AND (
+								last_contacted_at IS NULL
+								OR last_contacted_at < now() - (${staleDays} * interval '1 day')
+							)
+							AND (next_action_at IS NULL OR next_action_at >= now())
+						`
+						const isHighPriority = sql`
+							priority <= ${priorityAtLeast}
+							AND next_action_at IS NULL
+							AND ${inPlay}
+							AND NOT (${isStale})
+						`
+
+						// Each list asks to be counted as it is fetched: `COUNT(*) OVER ()`
+						// is worked out before the LIMIT applies, so the full total rides
+						// back on rows already being read rather than costing a query of its
+						// own. A heading that says "5 of 65" needs the 65 as much as the 5.
+						const withTotal = totalColumn(sql, 'exact')
+
+						const dueTasks = yield* sql<WindowTotal>`
 							SELECT t.id, t.title, t.type, t.due_at,
 								t.company_id, c.name as company_name, c.slug as company_slug
+								${withTotal}
 							FROM tasks t
 							INNER JOIN companies c
 								ON t.company_id = c.id AND c.deleted_at IS NULL
 							WHERE t.completed_at IS NULL
-							ORDER BY t.due_at
+							ORDER BY t.due_at, t.id
 							LIMIT ${probeLimit(limit)}
 						`
 
-						const overdueCompanies = yield* sql`
-							SELECT id, slug, name, next_action, next_action_at
+						// Every ORDER BY here ends on the id. Without it two rows sharing a
+						// timestamp can swap places between one read and the next, and a
+						// company can slip between pages of the list it belongs to.
+						const overdueCompanies = yield* sql<WindowTotal>`
+							SELECT ${cardColumns}${withTotal}
 							FROM companies
-							WHERE next_action_at < now()
-								AND deleted_at IS NULL
-								AND status NOT IN ('closed', 'dead')
-							ORDER BY next_action_at
+							WHERE ${isOverdue}
+							ORDER BY next_action_at, id
+							LIMIT ${probeLimit(limit)}
+						`
+
+						// Longest silence first: the point of the list is who has been left
+						// alone the longest, and a company never contacted at all leads it.
+						const staleCompanies = yield* sql<WindowTotal>`
+							SELECT ${cardColumns}${withTotal}
+							FROM companies
+							WHERE ${isStale}
+							ORDER BY last_contacted_at ASC NULLS FIRST, id
+							LIMIT ${probeLimit(limit)}
+						`
+
+						// Hot, and nothing booked in. Most recently touched first, so the
+						// ones somebody is already thinking about come up first.
+						const highPriority = yield* sql<WindowTotal>`
+							SELECT ${cardColumns}${withTotal}
+							FROM companies
+							WHERE ${isHighPriority}
+							ORDER BY updated_at DESC, id
 							LIMIT ${probeLimit(limit)}
 						`
 
@@ -100,7 +202,7 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						// looked at. Someone who starts research and walks away has no
 						// other way to be told it finished, so it belongs on the same
 						// list as their tasks.
-						const researchAwaitingReview = yield* sql`
+						const researchAwaitingReview = yield* sql<WindowTotal>`
 							WITH finished AS (
 								SELECT r.id, r.query, r.status, r.completed_at,
 									(
@@ -119,6 +221,7 @@ export class PipelineService extends Context.Service<PipelineService>()(
 							)
 							SELECT f.id, f.query, f.status, f.completed_at, f.pending_update_count,
 								c.id AS company_id, c.name AS company_name, c.slug AS company_slug
+								${withTotal}
 							FROM finished f
 							-- A run can point at several companies, or at none. Take one so
 							-- the run stays a single row, and keep the ones pointing at none:
@@ -146,19 +249,38 @@ export class PipelineService extends Context.Service<PipelineService>()(
 						// The spare row each list asked for is dropped here; only the
 						// flag saying that list was cut short leaves.
 						const tasksPage = takePage(dueTasks, limit)
-						const companiesPage = takePage(overdueCompanies, limit)
+						const overduePage = takePage(overdueCompanies, limit)
+						const stalePage = takePage(staleCompanies, limit)
+						const highPriorityPage = takePage(highPriority, limit)
 						const researchPage = takePage(researchAwaitingReview, limit)
 
 						return {
 							dueTasks: yield* decodeNextStepTasks(tasksPage.rows),
 							overdueCompanies: yield* decodeNextStepCompanies(
-								companiesPage.rows,
+								overduePage.rows,
+							),
+							staleCompanies: yield* decodeNextStepCompanies(stalePage.rows),
+							highPriority: yield* decodeNextStepCompanies(
+								highPriorityPage.rows,
 							),
 							researchAwaitingReview: yield* decodeNextStepResearchRuns(
 								researchPage.rows,
 							),
+							// Read off the unsliced rows: the spare probe row carries the same
+							// total, but an empty list has no row to carry one at all, which
+							// the helper reports as 0 — true here, where every list starts at
+							// the beginning.
+							counts: {
+								dueTasks: readWindowTotal(dueTasks),
+								overdueCompanies: readWindowTotal(overdueCompanies),
+								staleCompanies: readWindowTotal(staleCompanies),
+								highPriority: readWindowTotal(highPriority),
+								researchAwaitingReview: readWindowTotal(researchAwaitingReview),
+							},
 							dueTasksTruncated: tasksPage.hasMore,
-							overdueCompaniesTruncated: companiesPage.hasMore,
+							overdueCompaniesTruncated: overduePage.hasMore,
+							staleCompaniesTruncated: stalePage.hasMore,
+							highPriorityTruncated: highPriorityPage.hasMore,
 							researchAwaitingReviewTruncated: researchPage.hasMore,
 						}
 					}),

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -21,6 +21,15 @@ import {
 
 const decodeTask = Schema.decodeUnknownEffect(Task)
 const decodeTasks = Schema.decodeUnknownEffect(Schema.Array(Task))
+const decodeTaskListItems = Schema.decodeUnknownEffect(
+	Schema.Array(
+		Schema.Struct({
+			...Task.fields,
+			companyName: Schema.NullOr(Schema.String),
+			companySlug: Schema.NullOr(Schema.String),
+		}),
+	),
+)
 
 export interface TaskFilters {
 	readonly companyId?: string | undefined
@@ -300,8 +309,26 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 						page.sort === 'recent'
 							? sql`COALESCE(due_at, created_at) DESC`
 							: sql`due_at ASC NULLS LAST, created_at ASC`
+					// The company rides along rather than being looked up afterwards:
+					// a screen showing a handful of tasks was fetching every company
+					// in the organisation to turn an id into a name.
+					//
+					// Looked up per row rather than joined: a join brings the whole
+					// companies table into scope, and the filters below name their
+					// columns bare, so `organization_id` stops meaning one thing.
+					// Both read null for a task that belongs to nobody in particular.
+					const companyName = sql`(
+						SELECT c.name FROM companies c
+						WHERE c.id = tasks.company_id AND c.deleted_at IS NULL
+					) AS company_name`
+					const companySlug = sql`(
+						SELECT c.slug FROM companies c
+						WHERE c.id = tasks.company_id AND c.deleted_at IS NULL
+					) AS company_slug`
 					const probed = yield* sql<{ readonly total?: string | number }>`
-							SELECT *${totalColumn(sql, page.count)} FROM tasks
+							SELECT tasks.*, ${companyName}, ${companySlug}
+								${totalColumn(sql, page.count)}
+							FROM tasks
 							WHERE ${sql.and(conditions)}
 							ORDER BY ${order}
 							LIMIT ${probeLimit(page.limit)} OFFSET ${page.offset}
@@ -318,7 +345,7 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 						`,
 					).pipe(Effect.orDie)
 
-					const items = yield* decodeTasks(rows).pipe(Effect.orDie)
+					const items = yield* decodeTaskListItems(rows).pipe(Effect.orDie)
 					return {
 						items,
 						total,

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -332,6 +332,13 @@ Library primitives at the time of writing: `PriAvatar`, `PriButton`,
 App-local primitives at the time of writing: `PriCombobox`, `PriCopyButton`,
 `PriPasswordInput`, `PriRichText`, `PriTable`.
 
+**Styling a router `Link`.** `styled(Link)` keeps the styling but drops
+TanStack Router's typing of `to`, `params` and `search`, so a wrong destination
+becomes a dead click instead of a compile error. Style a wrapper and put a bare
+`<Link>` inside it — stretched over the box with `position: absolute; inset: 0`
+when the whole row should navigate. `company-card.tsx` and the pipeline's status
+chips both do this.
+
 #### `PriPasswordInput` — uncontrolled only
 
 Use this primitive as **uncontrolled**: omit `value=` / `onChange=` and
@@ -793,11 +800,14 @@ const CardHead = styled.div`
 
 ### Pipeline dashboard (`/`)
 
-- Status lane counts: prospect, contacted, responded, meeting, proposal, client
-- "Overdue" section: tasks past due + companies with `next_action_at` in the past
-- "This week" section: tasks due within 7 days
-- Top 5 priority companies without a scheduled next action
-- Mobile: stacked cards. Desktop: 2-column grid.
+Every list on this page is decided by the server, not assembled in the browser. `nextStepsAtom` (`/v1/pipeline/next-steps`) returns the company lists already sorted by urgency and already counted; the task buckets come from the same shelf atoms `/tasks` uses, which take the edges of the reader's own day from the browser because the server cannot know their timezone.
+
+- Four counters and eight status counts, each a link to the list it counted.
+- **Needs attention** — overdue tasks, companies past their follow-up date, companies mid-deal gone quiet, and finished research awaiting a decision. A company appears on **exactly one** of these; the rules and their precedence live in `apps/server/src/services/company-attention.ts`, shared with the `attention` filter on `/companies` so a count here opens a list of the same size there.
+- **Today** / **This week** — the `today` and `thisWeek` task shelves.
+- **High priority** — hot companies with nothing scheduled, minus any already listed above.
+- Each section shows the first few rows with the true total beside it and a way through to the rest; each row carries a chip saying why it is there.
+- Nothing on the page goes above two columns at any width.
 
 ### Company list (`/companies`)
 

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -54,7 +54,13 @@ export {
 export { HealthGroup } from './routes/health'
 export { InteractionsGroup } from './routes/interactions'
 export { PageSummary, PagesGroup } from './routes/pages'
-export { NextSteps, PipelineGroup, PipelineSnapshot } from './routes/pipeline'
+export {
+	NextSteps,
+	PipelineGroup,
+	PipelineSnapshot,
+	PRIORITY_AT_LEAST_BOUNDS,
+	STALE_DAYS_BOUNDS,
+} from './routes/pipeline'
 export { ProductsGroup } from './routes/products'
 export { ProposalsGroup } from './routes/proposals'
 export {

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -77,6 +77,6 @@ export {
 	ResearchRunSummary,
 	ResearchSpendBucket,
 } from './routes/research-schemas'
-export { BulkCompleteResult, TasksGroup } from './routes/tasks'
+export { BulkCompleteResult, TaskListItem, TasksGroup } from './routes/tasks'
 export { TimelineGroup } from './routes/timeline'
 export { WebhooksGroup } from './routes/webhooks'

--- a/packages/controllers/src/routes/companies.ts
+++ b/packages/controllers/src/routes/companies.ts
@@ -6,6 +6,7 @@ import {
 } from 'effect/unstable/httpapi'
 
 import {
+	ATTENTION_FILTERS,
 	Company,
 	CompanyCountry,
 	CompanyEmail,
@@ -28,6 +29,7 @@ import { NotFound } from '../errors'
 import { OrgMiddleware } from '../middleware/org'
 import { SessionMiddleware } from '../middleware/session'
 import { PaginatedList, pageQuery } from '../pagination'
+import { StaleDays } from './pipeline'
 
 // One research run whose findings were applied to a company, with the pages its
 // citations point at — so a reader can trace a fact on the row back to the run
@@ -143,6 +145,15 @@ export const CompaniesGroup = HttpApiGroup.make('companies')
 				industry: Schema.optional(Schema.String),
 				priority: Schema.optional(Schema.NumberFromString),
 				owner: Schema.optional(Schema.String),
+				// Narrows to what needs doing, in the same words the dashboard uses:
+				// `overdue` missed its follow-up date, `stale` is mid-chase and has
+				// gone quiet, `no-next-action` has nothing written down at all. The
+				// rules are shared with the dashboard's own lists, so a count there
+				// opens a list of the same size here.
+				attention: Schema.optional(Schema.Literals(ATTENTION_FILTERS)),
+				// How long counts as quiet, for `attention=stale`. Rides along on the
+				// link so the list matches whatever the dashboard was showing.
+				staleDays: Schema.optional(StaleDays),
 				fitVerdict: Schema.optional(Schema.String),
 				fitCriterionPassed: Schema.optional(Schema.String),
 				sort: Schema.optional(Schema.String),

--- a/packages/controllers/src/routes/pipeline.ts
+++ b/packages/controllers/src/routes/pipeline.ts
@@ -1,6 +1,8 @@
 import { Schema } from 'effect'
 import { HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
 
+import { COMPANY_PRIORITIES } from '@batuda/domain'
+
 import { OrgMiddleware } from '../middleware/org'
 import { SessionMiddleware } from '../middleware/session'
 import { pageQuery } from '../pagination'
@@ -24,11 +26,20 @@ const NextStepTask = Schema.Struct({
 	companySlug: Schema.String,
 })
 
-// A company whose stored next-action date has slipped past now.
+// A company on one of the attention lists. It carries everything a company card
+// shows, not just the dates that put it on the list — the screen draws the same
+// card here as it does anywhere else, and a name and a date alone would leave it
+// without its status, its trade or its priority.
 const NextStepCompany = Schema.Struct({
 	id: Schema.String,
 	slug: Schema.String,
 	name: Schema.String,
+	status: Schema.String,
+	industry: Schema.NullOr(Schema.String),
+	location: Schema.NullOr(Schema.String),
+	country: Schema.NullOr(Schema.String),
+	priority: Schema.NullOr(Schema.Number),
+	lastContactedAt: Schema.NullOr(Schema.DateTimeUtcFromString),
 	nextAction: Schema.NullOr(Schema.String),
 	nextActionAt: Schema.NullOr(Schema.DateTimeUtcFromString),
 })
@@ -47,18 +58,68 @@ const NextStepResearchRun = Schema.Struct({
 	companySlug: Schema.NullOr(Schema.String),
 })
 
+// How many rows each list would hold if nothing had been cut. A screen showing
+// the urgent handful still has to say how many there are altogether, and the
+// "there is more" flags below can only say that something was left out, not how
+// much. One entry per list, so no list answers the question differently.
+const NextStepCounts = Schema.Struct({
+	dueTasks: Schema.Number,
+	overdueCompanies: Schema.Number,
+	staleCompanies: Schema.Number,
+	highPriority: Schema.Number,
+	researchAwaitingReview: Schema.Number,
+})
+
 export const NextSteps = Schema.Struct({
 	dueTasks: Schema.Array(NextStepTask),
+	// A company belongs to at most one of these three. Someone who has slipped
+	// past their follow-up date is not also listed as having gone quiet, and the
+	// three lists read as one queue rather than as the same company three times.
 	overdueCompanies: Schema.Array(NextStepCompany),
+	staleCompanies: Schema.Array(NextStepCompany),
+	highPriority: Schema.Array(NextStepCompany),
 	researchAwaitingReview: Schema.Array(NextStepResearchRun),
 
-	// One cap covers three separate lists, so "there is more" has to be said
-	// three times: a reader told only that something was cut short cannot tell
-	// which of the three it happened to.
+	counts: NextStepCounts,
+
+	// One cap covers every list, so "there is more" has to be said once per list:
+	// a reader told only that something was cut short cannot tell which.
 	dueTasksTruncated: Schema.Boolean,
 	overdueCompaniesTruncated: Schema.Boolean,
+	staleCompaniesTruncated: Schema.Boolean,
+	highPriorityTruncated: Schema.Boolean,
 	researchAwaitingReviewTruncated: Schema.Boolean,
 })
+
+/**
+ * How long a company in play may go unheard from before it counts as having gone
+ * quiet. Whoever is asking decides: a workshop chasing local trade and a firm
+ * selling machinery on six-month cycles do not mean the same thing by "quiet",
+ * and a number buried in a query would make that a deploy rather than a request.
+ *
+ * A decade is the ceiling — past that the answer is every company that was ever
+ * spoken to, which no list is asking for.
+ */
+export const STALE_DAYS_BOUNDS = { minimum: 1, maximum: 3650 } as const
+
+/**
+ * How far down the priority scale the high-priority list reaches, read as
+ * importance rather than as the stored number — 1 is the hottest, so `2` takes
+ * priorities 1 and 2. The ceiling follows the scale the domain defines, so
+ * widening that scale does not quietly leave this behind.
+ */
+export const PRIORITY_AT_LEAST_BOUNDS = {
+	minimum: Math.min(...COMPANY_PRIORITIES),
+	maximum: Math.max(...COMPANY_PRIORITIES),
+} as const
+
+const StaleDays = Schema.FiniteFromString.pipe(
+	Schema.check(Schema.isInt(), Schema.isBetween(STALE_DAYS_BOUNDS)),
+)
+
+const PriorityAtLeast = Schema.FiniteFromString.pipe(
+	Schema.check(Schema.isInt(), Schema.isBetween(PRIORITY_AT_LEAST_BOUNDS)),
+)
 
 export const PipelineGroup = HttpApiGroup.make('pipeline')
 	.add(
@@ -68,7 +129,11 @@ export const PipelineGroup = HttpApiGroup.make('pipeline')
 	)
 	.add(
 		HttpApiEndpoint.get('nextSteps', '/pipeline/next-steps', {
-			query: { limit: pageQuery.limit },
+			query: {
+				limit: pageQuery.limit,
+				staleDays: Schema.optional(StaleDays),
+				priorityAtLeast: Schema.optional(PriorityAtLeast),
+			},
 			success: NextSteps,
 		}),
 	)

--- a/packages/controllers/src/routes/pipeline.ts
+++ b/packages/controllers/src/routes/pipeline.ts
@@ -113,7 +113,10 @@ export const PRIORITY_AT_LEAST_BOUNDS = {
 	maximum: Math.max(...COMPANY_PRIORITIES),
 } as const
 
-const StaleDays = Schema.FiniteFromString.pipe(
+// Shared with the company list, which takes the same threshold on its own
+// attention filter so a link from the dashboard carries the number it was
+// showing rather than falling back to the default.
+export const StaleDays = Schema.FiniteFromString.pipe(
 	Schema.check(Schema.isInt(), Schema.isBetween(STALE_DAYS_BOUNDS)),
 )
 

--- a/packages/controllers/src/routes/tasks.ts
+++ b/packages/controllers/src/routes/tasks.ts
@@ -100,6 +100,16 @@ const IfMatchHeader = Schema.Struct({
 	'if-match': Schema.optional(Schema.String),
 })
 
+// A task as a list shows it: the stored row plus the name and address of the
+// company it belongs to, which are on another table. Both are null for a task
+// that belongs to nobody in particular.
+export const TaskListItem = Schema.Struct({
+	...Task.json.fields,
+	companyName: Schema.NullOr(Schema.String),
+	companySlug: Schema.NullOr(Schema.String),
+})
+export type TaskListItem = typeof TaskListItem.Type
+
 // ── Route group ──
 
 export const TasksGroup = HttpApiGroup.make('tasks')
@@ -133,7 +143,10 @@ export const TasksGroup = HttpApiGroup.make('tasks')
 				sort: Schema.optional(Schema.Literals(['recent', 'due', 'completed'])),
 				...pageQuery,
 			},
-			success: PaginatedList(Task.json),
+			// The company each task belongs to travels with it. A task row shows
+			// whose task it is, and every screen that draws one was otherwise
+			// fetching the whole company list just to look the name up.
+			success: PaginatedList(TaskListItem),
 		}),
 	)
 	.add(

--- a/packages/domain/src/schema/companies.ts
+++ b/packages/domain/src/schema/companies.ts
@@ -66,6 +66,16 @@ export const COMPANY_PRIORITIES = [1, 2, 3] as const
 export const CompanyPriority = Schema.Literals(COMPANY_PRIORITIES)
 export type CompanyPriority = typeof CompanyPriority.Type
 
+// The reasons a company is worth someone's time today: `overdue` missed the
+// follow-up date somebody set, `stale` is mid-chase and has not been heard from
+// in a while, `no-next-action` has nothing written down as the next step at all.
+// The dashboard groups by these and the company list filters by them, so they are
+// spelled once here and the rules behind them once in the server's
+// company-attention module.
+export const ATTENTION_FILTERS = ['overdue', 'stale', 'no-next-action'] as const
+export const AttentionFilter = Schema.Literals(ATTENTION_FILTERS)
+export type AttentionFilter = typeof AttentionFilter.Type
+
 // The shape each written-in value has to have. They live beside the vocabularies
 // above so every way into a company row checks the same thing, and something that
 // could never be a real address or phone number is turned away where it is typed

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -28,6 +28,8 @@ export {
 	WEBSITE_ADDRESS_PATTERN,
 } from './channel-address'
 export {
+	ATTENTION_FILTERS,
+	AttentionFilter,
 	COMPANY_PRIORITIES,
 	COMPANY_SIZE_RANGES,
 	COMPANY_STATUSES,


### PR DESCRIPTION
## What

The Pipeline page (`/`, in the `internal` web app) is meant to answer "who needs me right now" at a glance. It didn't. Its "Needs attention" heading said **154** above **12 rows**, and those twelve were an arbitrary twelve — the lists behind them were never sorted, so a company overdue by six months and one overdue by a day were equally likely to show. The same company could appear twice on one screen. A deal marked **closed** four months ago was being presented as work still to do. And on a phone the four counters filled more than a screen before any of it, with task rows squeezed so hard they read `COASTAL ...` / `Send au...`.

All of it came from one root cause: the page fetched up to 500 companies and 500 tasks and worked out the answers in the browser, where each list was computed separately and none of them knew about the others. This moves those decisions to the server, where they can be sorted, counted, and made mutually exclusive — and then makes the page say what it knows.

## Changes

- **A company now appears on exactly one list.** A missed follow-up outranks a long silence, which outranks being marked hot with nothing booked. Enforced in SQL, so the three lists behave like one queue rather than three overlapping ones.
- **Finished deals dropped out.** Only the gone-quiet rule ever checked status, so a closed company with an old follow-up date was still being chased.
- **Every list is sorted by urgency and reports a real total** — longest overdue first, longest silence first, never-contacted leading. A heading can now say "5 of 65" instead of a number nothing under it adds up to.
- **How long counts as "gone quiet" is the caller's to set** (`staleDays`, default 14), as is how far down the priority scale to reach (`priorityAtLeast`, default 1). A firm selling machinery on six-month cycles and a workshop quoting in days can't both live with one number baked into a query. **This is the part I'd most like a second opinion on** — see the review guide.
- **The company list can now filter by what needs doing** (`attention=overdue|stale|no-next-action`), which is what gives the dashboard's headings somewhere to link. Both screens read the same rule from one module, so they can't drift.
- **Every number on the page opens the list it counted** — eight status counts, four headline figures, and the section headings, none of which were clickable before.
- **Each row says why it's there** ("Follow-up overdue by 5 months", "Never contacted"), and each heading explains what puts a row on the list and what keeps it off.
- **Finished research awaiting a decision now shows up.** The endpoint had been returning it all along and nothing displayed it, so a run that landed while nobody was watching was never noticed.
- **Task rows and the counter block were rebuilt for small screens.**

## Impact

- **Wire shape — two contracts changed, both consumed by the typed client in `internal`.** `NextSteps` gains `staleCompanies`, `highPriority`, a `counts` object with one entry per list, and company rows widened to what a company card draws. `/v1/tasks` list items gain `companyName` and `companySlug` (additive). **Server and `internal` should deploy together.**
- **MCP and HTTP both get this.** `get_next_steps` shares the service, so the agent surface gains the same buckets, the same one-company-one-list rule, and both new parameters; its description and the daily-briefing prompt were rewritten to match. No parity gap.
- **No migration, no new environment variables, no auth or CORS changes.**
- **Tenant isolation is unchanged.** The new queries carry no `organization_id` clause of their own, exactly like the ones beside them — they rely on the same row-level security, verified by running the new tests as `app_user` with the org set.
- **One behaviour worth knowing:** "High priority" will often be shorter than before, because a hot company that has also gone quiet is now listed once under "Needs attention" instead of in both. That's the intent, and the empty state says so.

## Review guide

- **Start at `apps/server/src/services/company-attention.ts`** — it's short, and it's where every rule in this PR lives. Everything else applies those rules.
- **The riskiest decision is making the thresholds caller-supplied** rather than fixed. I chose it because the current 14 days puts **66 of 107 active companies** in one bucket, which is a backlog rather than a to-do list, and because burying the number in SQL makes tuning it a deploy. The defaults preserve today's behaviour and there's no settings UI, so nothing is exposed to a user yet. Overrule me if you'd rather it stay fixed until a tenant asks.
- **The subtlest thing I found:** the "needs action" counter reads the written next-step *note* and skips signed clients, while the new lists read the follow-up *date* and don't. On seed data those disagree about **50 of 120 companies** — the counter would have said 51 and opened a list of 106. Both now read one shared rule. Separately: half your companies have a note without a date or a date without a note, which suggests the two fields drift apart in real use and may be worth a decision of its own someday.
- **`getCounts` and `getOverdueTasks` are deleted.** Both were called from nowhere before and after this branch, and `getOverdueTasks` returned a list that *included* closed companies, sitting right beside the new query that excludes them.
- **Skip-able:** the Lingui catalog diffs are generated.
- **Not run:** Snyk wasn't available in this session, so no dependency scan. The change adds no new dependency and no new external input.

## Screenshots

Captured at 1440×900 and on an iPhone 16 Pro, since the layout differs by size.

**Desktop — the page, and the section that changed most**

![Pipeline dashboard on desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-411/pr-pipeline-desktop.webp)

![Needs attention, with a reason above each card and a way through to the rest](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-411/pr-pipeline-desktop-attention.webp)

**Mobile — the counter block, and task rows that now fit**

![Pipeline dashboard on a phone](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-411/pr-pipeline-mobile.webp)

![Task rows on a phone, company name and title in full](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-411/pr-pipeline-mobile-rows.webp)

Before this, those mobile rows read `COASTAL ...` / `Send au...` — the title column was squeezed to 55px while the date beside it kept its full width and wrapped over three lines.

## Tests

- **18 new live-database integration tests.** The company buckets get their own file: a company that is both overdue and quiet appears only under overdue; a closed company and a dead one that otherwise fits high-priority appear on none; longest silence leads; never-contacted sorts first and stays on the list at any threshold; truncation fires at the cap while the total still reports every match.
- **7 more for the company filter**, written to compare the filter's answer against the dashboard's own lists rather than restating the rule — a heading that says 65 has to open a list of 65, and only agreement proves that.
- Ordering assertions check the rows are present *before* checking their order; `indexOf` answers −1 for a missing row, which reads as "first" and would otherwise pass on its own.
- I also ran a deliberate mutation — deleting the status filter from the high-priority bucket — to confirm the suite goes red. An earlier version of the fixtures let that through silently.

## Verification

- Gates: `pnpm install` (no lockfile drift) → `check-types` (13/13) + `test` (21/21) → `build` (13/13).
- Suites: 805 server unit, 594 integration across 89 files, 58 domain.
- Live stack in a worktree, signed in against the seeded `taller` org: no company appears twice on the page (two did before), the closed company is gone from "Needs attention", and the reason chips render with real spans.
- **Followed every link and compared the destination's total against the figure clicked** — the contacted chip reads 31 and opens 31, needs-action reads 51 and opens 51, the quiet companies read 65 and open 65, and the overdue tasks link lands on the overdue shelf showing 86.
- Viewport sweep at 375×812, 768×1024, 1280×720 and 1440×620, measuring rather than eyeballing: the counter block went 918px → 284px on mobile and 570px → 327px on a short laptop; the task title went 55px of room against 230px of text → 202px; no horizontal overflow and nothing above two columns at any size.

## Deferred

- The tasks screen still fetches every company in the organisation to label its rows. The task row now carries its own company, so that fetch can go — but removing it touches a screen this PR is otherwise not about.
- "High priority" is arguably a *reason* rather than a section; folding it into "Needs attention" as a third chip would remove a section from a page that is still long on mobile. That's a bigger change to the page's shape than this PR should make.
