### PR TITLE
fix(research): keep vendor API keys out of our tracing data

### DIFF
--- a/packages/research/src/infrastructure/hunter/_client.ts
+++ b/packages/research/src/infrastructure/hunter/_client.ts
@@ -1,8 +1,11 @@
 /**
  * Shared HTTP plumbing for the Hunter.io v2 endpoints (Domain Search, Email
- * Verifier). Auth is the API key as a `?api_key=` query parameter — NOT HTTP
- * Basic like libreBORME. 429/5xx are transient (retried by the harness); any
- * other non-2xx status is terminal for the request.
+ * Verifier). Auth is the API key in the `X-API-KEY` header — Hunter also takes
+ * it as an `?api_key=` query parameter, but the HTTP client records the whole
+ * URL on the trace and blanks out only a few header names, `x-api-key` among
+ * them, so the header is the one place the key stays private. 429/5xx are
+ * transient (retried by the harness); any other non-2xx status is terminal for
+ * the request.
  *
  * @see https://hunter.io/api-documentation/v2
  */
@@ -69,11 +72,16 @@ export const makeHunterClient = (envBase: string, slot: number) =>
 		const key = Redacted.value(apiKey)
 
 		// One authenticated GET, decoded against `schema`. `query` is the
-		// endpoint-specific querystring (already encoded); the api_key is appended.
+		// endpoint-specific querystring (already encoded) and never the key.
 		const getJson = <A>(path: string, query: string, schema: Schema.Codec<A>) =>
 			Effect.gen(function* () {
-				const url = `${HUNTER_BASE_URL}/${path}?${query}&api_key=${encodeURIComponent(key)}`
-				const response = yield* client.execute(HttpClientRequest.get(url)).pipe(
+				const url = `${HUNTER_BASE_URL}/${path}?${query}`
+				const request = HttpClientRequest.setHeader(
+					HttpClientRequest.get(url),
+					'X-API-KEY',
+					key,
+				)
+				const response = yield* client.execute(request).pipe(
 					Effect.mapError(
 						e =>
 							new ProviderError({

--- a/packages/research/src/infrastructure/hunter/hunter.test.ts
+++ b/packages/research/src/infrastructure/hunter/hunter.test.ts
@@ -1,7 +1,63 @@
+import { ConfigProvider, Effect } from 'effect'
+import {
+	HttpClient,
+	type HttpClientError,
+	type HttpClientRequest,
+	type HttpClientResponse,
+	HttpClientResponse as HttpClientResponseNs,
+} from 'effect/unstable/http'
 import { describe, expect, it } from 'vitest'
 
 import { hunterStatusToVerdict } from './_client'
+import { makeHunterEnrichment } from './enrichment'
 import { toVerdict } from './verifier'
+
+const API_KEY = 'secret-hunter-key'
+
+interface CapturedCall {
+	request: HttpClientRequest.HttpClientRequest | undefined
+}
+
+// Captures the one request the provider makes, answering with an empty but
+// well-formed Domain Search body so decoding succeeds.
+const capturingClient = (captured: CapturedCall): HttpClient.HttpClient =>
+	HttpClient.makeWith<
+		HttpClientError.HttpClientError,
+		never,
+		HttpClientError.HttpClientError,
+		never
+	>(
+		effect =>
+			Effect.flatMap(effect, request => {
+				captured.request = request
+				const response: HttpClientResponse.HttpClientResponse =
+					HttpClientResponseNs.fromWeb(
+						request,
+						new Response(JSON.stringify({ data: { emails: [] } }), {
+							status: 200,
+							headers: { 'content-type': 'application/json' },
+						}),
+					)
+				return Effect.succeed(response)
+			}),
+		Effect.succeed,
+	)
+
+const runDomainSearch = (captured: CapturedCall) =>
+	Effect.gen(function* () {
+		const provider = yield* makeHunterEnrichment(0)
+		yield* provider.findPeople({ domain: 'example.com' })
+	}).pipe(
+		Effect.provideService(HttpClient.HttpClient, capturingClient(captured)),
+		Effect.provide(
+			ConfigProvider.layer(
+				ConfigProvider.fromEnv({
+					env: { RESEARCH_API_KEY_ENRICH: API_KEY },
+				}),
+			),
+		),
+		Effect.runPromise,
+	)
 
 describe('hunterStatusToVerdict', () => {
 	describe('when Domain Search carries a definitive status', () => {
@@ -53,6 +109,34 @@ describe('toVerdict', () => {
 			// GIVEN a result outside the known set
 			// THEN it is unknown, never silently deliverable
 			expect(toVerdict('weird', false)).toBe('unknown')
+		})
+	})
+})
+
+describe('makeHunterEnrichment', () => {
+	describe('when it authenticates a request', () => {
+		it('should keep the key out of the URL the trace records', async () => {
+			// GIVEN a configured Hunter key
+			const captured: CapturedCall = { request: undefined }
+
+			// WHEN the provider looks a domain up
+			await runDomainSearch(captured)
+
+			// THEN neither the key nor an `api_key` parameter is in the URL, which
+			// goes on the trace verbatim
+			expect(captured.request?.url).not.toContain(API_KEY)
+			expect(captured.request?.url).not.toContain('api_key')
+		})
+
+		it('should send the key in a header the client redacts', async () => {
+			// GIVEN a configured Hunter key
+			const captured: CapturedCall = { request: undefined }
+
+			// WHEN the provider looks a domain up
+			await runDomainSearch(captured)
+
+			// THEN it rides in `X-API-KEY`, one of the names blanked out on the trace
+			expect(captured.request?.headers['x-api-key']).toBe(API_KEY)
 		})
 	})
 })

--- a/packages/research/src/infrastructure/providers-live.ts
+++ b/packages/research/src/infrastructure/providers-live.ts
@@ -10,6 +10,7 @@
  */
 
 import { Config, Effect, Layer, Option, Schema } from 'effect'
+import { Headers } from 'effect/unstable/http'
 
 import { priceUnitsMicrocents } from '../application/cost-rates'
 import {
@@ -552,6 +553,18 @@ const reportLayer = Layer.effect(
 
 // ── Merged layer ──
 
+// The HTTP client blanks these header names out before it records a request on
+// the trace. Brave's API key rides in `X-Subscription-Token`, which the client
+// does not know about; the four names above it are the client's own defaults,
+// repeated because setting this list replaces them rather than adds to them.
+const redactedHeadersLayer = Layer.succeed(Headers.CurrentRedactedNames)([
+	'authorization',
+	'cookie',
+	'set-cookie',
+	'x-api-key',
+	'x-subscription-token',
+])
+
 export const makeResearchProvidersLive = Layer.mergeAll(
 	cachedSearchLayer,
 	cachedScrapeLayer.pipe(Layer.provide(scrapeLayer)),
@@ -561,4 +574,5 @@ export const makeResearchProvidersLive = Layer.mergeAll(
 	MxResolverLive,
 	registryLayer,
 	reportLayer,
+	redactedHeadersLayer,
 )


### PR DESCRIPTION
## What

Two of the outside services the research engine pays for — Hunter (finding people's work email addresses) and Brave (web search) — were having their secret API keys copied into our tracing data on every single call. Tracing data is what we send to Honeycomb, the third-party service we use to see what the server is doing; anyone who can read that workspace could read the keys and spend our credits. This stops it at the source.

It lives in the Research bounded context (`packages/research`), in the adapters that talk to each vendor.

## The fix

- Hunter's key was in the web address of the request (`?api_key=…`). Our HTTP client writes both the full address and its query string onto every trace, so the key was captured twice per call. Hunter also accepts the key in an `X-API-KEY` header, and the client already blanks that header name out before recording — so the key now rides there and never reaches the trace.
- Brave's key was already in a header, but a name Brave invented (`X-Subscription-Token`). The client only blanks a handful of well-known names, which doesn't include that one, so the key was written out in full. The research providers now declare the list of header names to blank, with Brave's added.
- I chose moving Hunter to a header over scrubbing the address. Scrubbing means a redaction rule that has to stay in step with whatever the vendor names its parameter; a header the client already blanks has nothing to keep in step with.

## Impact

**Both keys need rotating once this is deployed** — `RESEARCH_API_KEY_ENRICH` and `RESEARCH_API_KEY_VERIFY` for Hunter, and the Brave key. Every value sent so far is in the trace store and should be treated as spent. Rotating *before* this ships would just leak the new key on the next call, so the order matters.

Nothing else ripples: no migration, no schema or wire-shape change, no new environment variables, no change to what any endpoint returns, and no effect on tenant isolation or auth. The MCP and HTTP surfaces both reach these providers through the same adapters, so both are covered by the same change.

The header list is declared where the research providers are assembled rather than in the server, so it travels with the bounded context — the CLI composes the same providers and gets the same protection.

## Review guide

Start with `providers-live.ts`. The thing worth checking is that `Headers.CurrentRedactedNames` is a reference with a **default** value, so providing our own list *replaces* the defaults rather than adding to them. That's why the four standard names are repeated alongside Brave's — dropping them would silently start leaking `authorization` for every other provider. The comment says so, but it's the one place a well-meaning tidy-up could do damage.

A decision you might overrule: I put the list in `packages/research` rather than at the server's composition root. It covers more callers there, but it does mean a future non-research provider with a custom auth header wouldn't be covered by it.

The six `noNonNullAssertion` warnings Biome reports on `providers-live.ts` are pre-existing on `main` at lines I didn't touch — I confirmed by checking the file unchanged.

## Tests

Two unit tests on the Hunter adapter, driving it through a stub HTTP client that captures the outgoing request: one asserts the key is absent from the URL and its query string, the other that it's present in the `X-API-KEY` header. They lock the property that matters rather than the implementation, so a future change back to query-param auth fails loudly.

Brave has no equivalent test — the redaction happens inside the HTTP client, not in our adapter, so there's no seam to assert on without testing the framework.

## Verification

Ran and green: `pnpm install`, `pnpm -w check-types` (13 packages), `pnpm -w test` (1,931 tests across 21 tasks), `pnpm -w build`.

**Not verified:** that Hunter accepts `X-API-KEY` in practice. The tests prove the request we send; they don't prove the vendor honours it. That claim comes from Hunter's published API documentation. One live `discover_contacts` call against a real domain would settle it, and I'd suggest doing that before this reaches production rather than after.

## Deferred

The rest of issue #404 — the discovery-scan grounding problems — follows in later PRs stacked on this one. This is split out because a live credential shouldn't wait behind a long review.

Addresses #404
