### PR TITLE
fix(research): stop a run with no surviving citations reading as clean

### DIFF
--- a/packages/research/src/application/research-quality.test.ts
+++ b/packages/research/src/application/research-quality.test.ts
@@ -11,6 +11,8 @@ describe('computeRunQuality', () => {
 			sourcesFirstParty: 3,
 			fieldsGrounded: 4,
 			fieldsTotal: 6,
+			citationsSeen: 4,
+			citationsKept: 4,
 		} as const
 
 		it('should not flag a strong, well-grounded run', () => {
@@ -47,35 +49,93 @@ describe('computeRunQuality', () => {
 	})
 
 	describe('for a prospect scan', () => {
+		const scan = {
+			schemaName: 'prospect_scan_v1',
+			entityMatch: null,
+			rounds: 3,
+			sourcesTotal: 6,
+			sourcesFirstParty: 0,
+			fieldsGrounded: 0,
+			fieldsTotal: 0,
+			citationsSeen: 10,
+			citationsKept: 10,
+		} as const
+
 		it('should flag a scan vetted against a single source', () => {
 			// GIVEN the bad scan from the sample: one search, one source
 			const quality = computeRunQuality({
-				schemaName: 'prospect_scan_v1',
-				entityMatch: null,
+				...scan,
 				rounds: 1,
 				sourcesTotal: 1,
-				sourcesFirstParty: 0,
-				fieldsGrounded: 0,
-				fieldsTotal: 0,
 			})
-			// THEN it is low confidence, and the ratio is 0 without dividing by zero
+			// THEN it is low confidence
 			expect(quality.low_confidence).toBe(true)
-			expect(quality.grounding_ratio).toBe(0)
 		})
 
 		it('should not flag a scan vetted against several sources', () => {
 			// GIVEN a scan that pulled from many sources
-			const quality = computeRunQuality({
-				schemaName: 'prospect_scan_v1',
-				entityMatch: null,
-				rounds: 3,
-				sourcesTotal: 6,
-				sourcesFirstParty: 0,
-				fieldsGrounded: 0,
-				fieldsTotal: 0,
-			})
+			const quality = computeRunQuality(scan)
 			// THEN it is trusted — this scan was pinned to no company, so there is
 			// no entity verdict to weigh
+			expect(quality.low_confidence).toBe(false)
+		})
+
+		it('should leave out the profile numbers a scan cannot have', () => {
+			// GIVEN any scan, which fills no company profile
+			const quality = computeRunQuality(scan)
+			// THEN the profile measures are absent rather than reported as zero, which
+			// would read as a failing grade on every scan ever run
+			expect(quality.grounding_ratio).toBeUndefined()
+			expect(quality.fields_grounded).toBeUndefined()
+		})
+	})
+
+	describe('when the citation guard weighed what a run cited', () => {
+		const scanBase = {
+			schemaName: 'prospect_scan_v1',
+			entityMatch: null,
+			rounds: 5,
+			sourcesTotal: 2,
+			sourcesFirstParty: 0,
+			fieldsGrounded: 0,
+			fieldsTotal: 0,
+		} as const
+
+		it('should flag a run whose citations were all rejected', () => {
+			// GIVEN a scan that offered 31 citations and had every one rejected as
+			// pointing at a page it never reached
+			const quality = computeRunQuality({
+				...scanBase,
+				citationsSeen: 31,
+				citationsKept: 0,
+			})
+			// THEN nothing stands behind the findings, so they are not safe to act
+			// on unread
+			expect(quality.low_confidence).toBe(true)
+			expect(quality.citations_seen).toBe(31)
+			expect(quality.citations_kept).toBe(0)
+		})
+
+		it('should not flag a run that cited nothing at all', () => {
+			// GIVEN a scan that offered no citations, so the guard rejected none
+			const quality = computeRunQuality({
+				...scanBase,
+				citationsSeen: 0,
+				citationsKept: 0,
+			})
+			// THEN this signal stays quiet — citing nothing is a different shortfall,
+			// and the source and entity checks are what judge it
+			expect(quality.low_confidence).toBe(false)
+		})
+
+		it('should not flag a run that kept even one citation', () => {
+			// GIVEN a scan where most citations were rejected but one resolved
+			const quality = computeRunQuality({
+				...scanBase,
+				citationsSeen: 12,
+				citationsKept: 1,
+			})
+			// THEN it is not flagged by this signal: the run did reach a page it cited
 			expect(quality.low_confidence).toBe(false)
 		})
 	})
@@ -90,6 +150,8 @@ describe('computeRunQuality', () => {
 				sourcesFirstParty: 2,
 				fieldsGrounded: 0,
 				fieldsTotal: 0,
+				citationsSeen: 8,
+				citationsKept: 8,
 			}).low_confidence
 
 		it('should flag one that never clearly reached that company', () => {

--- a/packages/research/src/application/research-quality.ts
+++ b/packages/research/src/application/research-quality.ts
@@ -8,12 +8,14 @@
  * run already produced. The flag is deliberately conservative: it should catch the
  * clearly-thin runs, not second-guess a solid one.
  *
- * Two signals raise it. Whenever a run was pinned to one company, anything short
+ * Three signals raise it. Whenever a run was pinned to one company, anything short
  * of clearly reaching that company counts — which covers an enrichment filling
  * that company's profile and equally a scan launched from it, since a scan can be
  * pinned to a subject too and a wrong one there is just as misleading. On top of
  * that, a prospect scan reports a list of third parties, so vetting that list
- * against a single source is thin however well the company itself was found.
+ * against a single source is thin however well the company itself was found. And
+ * a run whose every citation was rejected reached none of the pages it claimed to
+ * read, whatever else it did.
  */
 
 export interface RunQualityInput {
@@ -34,15 +36,27 @@ export interface RunQualityInput {
 	readonly fieldsGrounded: number
 	/** Enrichment: profile fields in scope (0 for a scan). */
 	readonly fieldsTotal: number
+	/** Citations the run offered for its findings. */
+	readonly citationsSeen: number
+	/** Of those, how many resolved to a page the run actually reached. */
+	readonly citationsKept: number
 }
 
 export interface RunQuality {
 	readonly rounds: number
 	/** Sources on the company's own domain — the ones most trusted to speak for it. */
 	readonly sources_matched: number
-	readonly fields_grounded: number
-	/** Share of the profile that is grounded, 0–1 (0 when nothing was in scope). */
-	readonly grounding_ratio: number
+	/** Profile fields that survived the guards with a value; absent for a scan. */
+	readonly fields_grounded?: number
+	/**
+	 * Share of the profile that is grounded, 0–1. Absent for a scan, as is
+	 * `fields_grounded`: a scan fills no profile, so both would read 0 on every
+	 * scan ever run and look like a failing grade rather than "does not apply".
+	 */
+	readonly grounding_ratio?: number
+	readonly citations_seen: number
+	/** Of those, how many pointed at a page the run actually reached. */
+	readonly citations_kept: number
 	/** True when the result is thin enough that an automation should not act on it unreviewed. */
 	readonly low_confidence: boolean
 }
@@ -63,13 +77,25 @@ export const computeRunQuality = (input: RunQualityInput): RunQuality => {
 	// And a scan that vetted its list of other firms against a single source
 	// hasn't done enough to act on unread, however well it found the company.
 	const thinlyVetted = isScan && input.sourcesTotal <= 1
-	const lowConfidence = unsureOfTheCompany || thinlyVetted
+	// The findings may well be right, but every page the run cited is one it never
+	// reached, so nothing it did backs them. Citing nothing at all is a different
+	// shortfall, left to the two signals above.
+	const nothingStandsBehindIt =
+		input.citationsSeen > 0 && input.citationsKept === 0
+	const lowConfidence =
+		unsureOfTheCompany || thinlyVetted || nothingStandsBehindIt
 
 	return {
 		rounds: input.rounds,
 		sources_matched: input.sourcesFirstParty,
-		fields_grounded: input.fieldsGrounded,
-		grounding_ratio: Math.round(groundingRatio * 100) / 100,
+		...(isScan
+			? {}
+			: {
+					fields_grounded: input.fieldsGrounded,
+					grounding_ratio: Math.round(groundingRatio * 100) / 100,
+				}),
+		citations_seen: input.citationsSeen,
+		citations_kept: input.citationsKept,
 		low_confidence: lowConfidence,
 	}
 }

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -2314,6 +2314,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						)
 					}
 
+					// How the citation guard fared on the last extraction. A run can extract
+					// more than once — a discovery scan retries, gap rounds re-extract — and
+					// what matters is the tally behind the findings that actually ship, so
+					// the guard overwrites them each time rather than adding them up.
+					let citationsSeen = 0
+					let citationsKept = 0
+
 					// Phase-2 extraction + every grounding guard, shared so both the
 					// normal path and the discovery-scan retry run the same logic. Returns
 					// the cleaned findings; the caller writes the single phase-2 checkpoint.
@@ -2613,6 +2620,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													...searchResultHosts,
 												]),
 											)
+											citationsSeen = check.total
+											citationsKept = check.kept
 											if (check.total > check.kept) {
 												yield* Effect.logWarning(
 													'research.citations.dropped',
@@ -4599,6 +4608,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						sourcesFirstParty,
 						fieldsGrounded: fill.filled,
 						fieldsTotal: fill.total,
+						citationsSeen,
+						citationsKept,
 					})
 					const findingsWithQuality = {
 						...withRegistryFlag(findings as Record<string, unknown>),


### PR DESCRIPTION
## What

When the research engine reports findings, it cites the web pages it read. A guard then checks each citation against the pages the run *actually* fetched, and throws away any that point somewhere the run never went. Three of the six runs in the benchmark behind this work had **every single citation thrown away** — every page they claimed to have read was one they never reached — and still finished as an ordinary success, the kind an automation applies to the CRM without anyone looking.

The guard was already counting this and discarding the count. Now that count decides whether the run is marked as needing review.

This is in the Research bounded context (`packages/research`), in the run-quality signal that decides a finished run's final status.

## The fix

- A run that offered citations and kept none of them is now marked low confidence. The findings may still be right, but nothing the run did stands behind them, so they are not safe to apply unread. A run that cited *nothing at all* is deliberately left alone — that is a different shortfall, and the existing source and entity checks are what judge it.
- Two numbers in the quality block, `grounding_ratio` and `fields_grounded`, divide by a count of company-profile fields. A discovery scan fills no profile, so that count is always zero and both numbers read `0` on every scan ever run — indistinguishable from a total failure. They are now left out for a scan rather than reported as a failing grade. This also removes the temptation to gate on `grounding_ratio`, which would flag every scan forever.
- The citation tally is carried out of the guard on two counters rather than threaded through four extraction call sites. A run can extract more than once — a discovery scan retries, gap rounds re-extract — so the guard overwrites them each pass, leaving the tally behind whichever findings actually ship.

## Impact

**`low_confidence` is not a label — it maps straight to the run's terminal status**, so a run this newly catches becomes `succeeded_low_confidence` rather than `succeeded`. Four consequences follow, and all four are intended:

- **Not cached.** Only `succeeded` runs land in the research cache, so a repeated scan re-runs and re-spends instead of replaying a thin result.
- **Fan-out groups.** One low-confidence child marks its whole parent group as needing review.
- **Batch auto-apply refuses it.** Consistent with the documented rule that auto-apply only ever runs for a fully succeeded run.
- **It appears in the review inbox**, and the MCP tool description already tells agents this status means the run needs a look.

No migration, no new environment variables, no change to tenant isolation or auth. The quality block lives inside the run's `findings` JSON, so there is no schema change; `grounding_ratio` and `fields_grounded` becoming optional breaks no reader — I checked every consumer, and the only one outside this module reads `low_confidence` through optional chaining.

Both the MCP and HTTP surfaces reach this through the same run fiber, so both get the behavior.

## Review guide

Start with `research-quality.ts` — the whole decision is one predicate and the docblock explaining why it is conservative.

The part worth a second look is in `research-service.ts`: the two counters live in the run-fiber scope and are assigned inside the citations guard link, which sits about 2,000 lines away inside `extractStructuredFindings`. That distance is real and I considered threading the tally through the extractor's return value instead — but it has four call sites across the normal path, the discovery retry, gap-round refresh, and the scan branch, and every one of them would need to forward it. The counters are the smaller change; the comment states the overwrite-not-accumulate rule that makes them correct.

A decision you might overrule: I left `groundingRatio` computed unconditionally even though a scan discards it. Restructuring that is behavior-adjacent and buys nothing a reader notices.

One fragility worth knowing: the two negative tests in the citation block isolate the new signal only because their fixture keeps the other two signals quiet (`sourcesTotal: 2`, `entityMatch: null`). Correct as written, but a future edit to that fixture could mask a regression.

## Tests

Four new unit tests on `computeRunQuality`: all citations rejected flags the run; citing nothing does not; keeping even one does not; and a scan omits the two profile numbers. Existing fixtures gained citation counts that keep the other signals quiet, so each test exercises one signal at a time.

## Verification

Ran and green: `pnpm -w check-types` (13 packages), `pnpm -w test` (944 research tests, 4 new), `pnpm -w build`.

**Not verified against a live run.** The change is a pure function plus two counters, and reproducing the condition end-to-end means a research run whose citations all fail to ground — which is what the benchmark did by accident and I cannot conjure cheaply. The unit tests cover the predicate; what they do not prove is that the counters are populated on every extraction path in practice. If you want that confirmed before merging, one scan against a thin query with the `research.citations.total`/`kept` span attributes checked in Honeycomb would do it.

## Deferred

The remaining engine defects from the closed #404 — the unguarded scan `website`, `parseCountryAlpha2` accepting any two letters, contact verdict provenance, Hunter's inverted 403/429, and fan-out scans reporting success over nothing — follow in later PRs. There is currently no issue tracking them; say the word and I will open one.
