### PR TITLE
fix: store what we send, and read the sent folder without losing mail

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,12 +25,14 @@
 		"better-auth": "1.6.11",
 		"dotenv": "^16.4.7",
 		"effect": "4.0.0-beta.102",
+		"mailparser": "^3.9.8",
 		"nodemailer": "^8.0.7",
 		"pg": "^8.20.0",
 		"pg-connection-string": "^2.14.0",
 		"picocolors": "^1.1.1"
 	},
 	"devDependencies": {
+		"@types/mailparser": "^3.4.6",
 		"@types/node": "^22.15.0",
 		"@types/nodemailer": "^8.0.0",
 		"@types/pg": "^8.20.0",

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -26,7 +26,7 @@ import { companiesBackfillGeocode } from './commands/companies'
 import { dataInspect, ENTITY_NAMES } from './commands/data'
 import { dbMigrate, dbReset } from './commands/db'
 import { doctor } from './commands/doctor'
-import { emailInject } from './commands/email'
+import { emailBackfillBodies, emailInject } from './commands/email'
 import {
 	researchCap,
 	researchEval,
@@ -934,11 +934,33 @@ const emailClearCommand = Command.make('clear', {}, () => emailClear).pipe(
 	),
 )
 
+const emailBackfillBodiesCommand = Command.make(
+	'backfill-bodies',
+	{
+		dryRun: Flag.boolean('dry-run').pipe(
+			Flag.withDescription(
+				'List the messages that would be filled in, without writing anything',
+			),
+			Flag.withDefault(false),
+		),
+	},
+	({ dryRun }) => withDb(emailBackfillBodies({ dryRun })),
+).pipe(
+	Command.withShortDescription('Fill in the body of already-sent messages'),
+	Command.withDescription(
+		'Fill in the body of messages sent before the send path stored one, reading each message back from object storage. Only touches messages that still have no body, so it is safe to run twice; a message whose stored copy is missing is counted and skipped. Needs DATABASE_URL and the STORAGE_* settings for the environment being fixed',
+	),
+)
+
 const emailCommand = Command.make('email').pipe(
 	Command.withDescription(
-		'Email: inject canned messages into the mail catcher, or empty it',
+		'Email: inject canned messages into the mail catcher, empty it, or fill in missing message bodies',
 	),
-	Command.withSubcommands([emailInjectCommand, emailClearCommand]),
+	Command.withSubcommands([
+		emailInjectCommand,
+		emailClearCommand,
+		emailBackfillBodiesCommand,
+	]),
 )
 
 // ── Research ───────────────────────────────────────────────

--- a/apps/cli/src/commands/email.ts
+++ b/apps/cli/src/commands/email.ts
@@ -6,7 +6,10 @@
  * just sits in the catcher.
  */
 
-import { Console, Effect } from 'effect'
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { Config, Console, Effect, Redacted } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { simpleParser } from 'mailparser'
 
 import { injectViaSmtp } from '../lib/smtp-inject'
 
@@ -37,5 +40,162 @@ export const emailInject = (args: InjectArgs) =>
 		yield* Console.log(`injected message-id=${result.messageId}`)
 		yield* Console.log(
 			'Visible via the mail-catcher REST API at http://localhost:8025.',
+		)
+	})
+
+// The object is not there, as opposed to the store refusing to answer. S3
+// says so by name; some gateways only say 404.
+const isObjectMissing = (cause: unknown): boolean => {
+	if (typeof cause !== 'object' || cause === null) return false
+	const name = (cause as { name?: unknown }).name
+	if (name === 'NoSuchKey' || name === 'NotFound') return true
+	const status = (cause as { $metadata?: { httpStatusCode?: unknown } })
+		.$metadata?.httpStatusCode
+	return status === 404
+}
+
+const describe = (cause: unknown): string =>
+	cause instanceof Error ? cause.message : String(cause)
+
+/**
+ * Fill in the body of sent messages that have none stored, so their thread
+ * shows something other than an empty card.
+ *
+ * The wire bytes in object storage are the only copy left on our side, so each
+ * message is read back from there and its text and HTML lifted out. Only rows
+ * that still have no body are touched, so it is safe to run twice.
+ */
+export const emailBackfillBodies = (args: { readonly dryRun: boolean }) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+
+		const pending = yield* sql<{
+			id: string
+			messageId: string
+			rawRfc822Ref: string
+		}>`
+			SELECT id, message_id, raw_rfc822_ref
+			FROM email_messages
+			WHERE direction = 'outbound'
+			  AND text_body IS NULL
+			  AND html_body IS NULL
+			  AND raw_rfc822_ref IS NOT NULL
+			ORDER BY status_updated_at
+		`
+
+		if (pending.length === 0) {
+			yield* Console.log('Nothing to fill in — every sent message has a body.')
+			return
+		}
+		yield* Console.log(
+			`${pending.length} sent message(s) without a body.${
+				args.dryRun ? ' Showing what would change; nothing is written.' : ''
+			}`,
+		)
+
+		const s3 = new S3Client({
+			endpoint: yield* Config.string('STORAGE_ENDPOINT'),
+			region: yield* Config.string('STORAGE_REGION'),
+			credentials: {
+				accessKeyId: yield* Config.string('STORAGE_ACCESS_KEY_ID'),
+				secretAccessKey: Redacted.value(
+					yield* Config.redacted('STORAGE_SECRET_ACCESS_KEY'),
+				),
+			},
+			forcePathStyle: true,
+		})
+		const bucket = yield* Config.string('STORAGE_BUCKET')
+
+		let filled = 0
+		let unreadable = 0
+		let unparseable = 0
+		let empty = 0
+		for (const row of pending) {
+			// Only a genuinely absent object is expected here — storing those
+			// bytes was best-effort, so some rows point at a copy that never
+			// landed. Anything else (a wrong key, a refused bucket, a network
+			// that is down) is a problem with the run itself, and reporting it
+			// as a missing copy would send someone looking in the wrong place.
+			const fetched = yield* Effect.tryPromise({
+				try: async () => {
+					const object = await s3.send(
+						new GetObjectCommand({ Bucket: bucket, Key: row.rawRfc822Ref }),
+					)
+					const body = object.Body
+					if (body === undefined) return null
+					return Buffer.from(await body.transformToByteArray())
+				},
+				catch: cause => cause,
+			}).pipe(
+				Effect.catch(cause =>
+					isObjectMissing(cause)
+						? Effect.succeed(null)
+						: Effect.fail(
+								new Error(
+									`could not read ${row.rawRfc822Ref}: ${describe(cause)}`,
+								),
+							),
+				),
+			)
+
+			if (fetched === null) {
+				unreadable++
+				yield* Console.log(
+					`  no stored copy: ${row.messageId} (${row.rawRfc822Ref})`,
+				)
+				continue
+			}
+
+			// One message that cannot be read must not strand the rest: the run
+			// is idempotent, so stopping here would mean every later message
+			// stays empty until somebody notices and deletes the offender.
+			const mail = yield* Effect.tryPromise({
+				try: () => simpleParser(fetched),
+				catch: cause => cause,
+			}).pipe(Effect.catch(() => Effect.succeed(null)))
+			if (mail === null) {
+				unparseable++
+				yield* Console.log(`  stored copy will not parse: ${row.messageId}`)
+				continue
+			}
+
+			const text = typeof mail.text === 'string' ? mail.text : null
+			const html = mail.html === false ? null : (mail.html ?? null)
+			// Counted apart from an unreadable one: the copy is there, it just
+			// carries nothing to show, and that is a different thing to chase.
+			if (text === null && html === null) {
+				empty++
+				yield* Console.log(`  stored copy has no body: ${row.messageId}`)
+				continue
+			}
+
+			if (!args.dryRun) {
+				yield* sql`
+					UPDATE email_messages
+					SET text_body = ${text},
+					    html_body = ${html},
+					    text_preview = ${text === null ? null : text.slice(0, 200)}
+					WHERE id = ${row.id}
+				`
+			}
+			filled++
+			yield* Console.log(
+				`  ${args.dryRun ? 'would fill' : 'filled'}: ${row.messageId}`,
+			)
+		}
+
+		const skipped = [
+			unreadable > 0 ? `${unreadable} with no stored copy` : null,
+			unparseable > 0
+				? `${unparseable} whose stored copy will not parse`
+				: null,
+			empty > 0 ? `${empty} whose stored copy has no body` : null,
+		]
+			.filter(part => part !== null)
+			.join(', ')
+		yield* Console.log(
+			`${args.dryRun ? 'Would fill' : 'Filled'} ${filled}${
+				skipped === '' ? '.' : `; skipped ${skipped}.`
+			}`,
 		)
 	})

--- a/apps/mail-worker/src/backfill.ts
+++ b/apps/mail-worker/src/backfill.ts
@@ -17,6 +17,7 @@ export const backfillSinceDate = (args: {
 	readonly organizationId: string
 	readonly inboxId: string
 	readonly folder: string
+	readonly direction: 'inbound' | 'outbound'
 	readonly uidvalidity: number
 	readonly sinceDate: Date
 }) =>
@@ -51,6 +52,7 @@ export const backfillSinceDate = (args: {
 				organizationId: args.organizationId,
 				inboxId: args.inboxId,
 				folder: args.folder,
+				direction: args.direction,
 				imapUid: m.uid,
 				imapUidvalidity: args.uidvalidity,
 				raw: new Uint8Array(m.source),

--- a/apps/mail-worker/src/folder-sync.test.ts
+++ b/apps/mail-worker/src/folder-sync.test.ts
@@ -1,0 +1,129 @@
+// Which way a message went is decided once, from the folder it was read from,
+// and then carried down through the sync. These pin the carrying: the decision
+// is made in inbox-session, acted on in persist, and everything between only
+// passes it along — where a wrong hand-off is invisible until mail is filed
+// backwards in production.
+
+import { Buffer } from 'node:buffer'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import type { ImapFlow } from 'imapflow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ParticipantMatcher } from '@batuda/email/participant-matcher'
+
+import { ingestRawMessage } from './ingest.js'
+import { RawMessageStorage } from './storage.js'
+
+vi.mock('./ingest.js', () => ({
+	ingestRawMessage: vi.fn(() => Effect.void),
+}))
+
+const { backfillSinceDate } = await import('./backfill.js')
+const { fetchAndIngestNewerThan } = await import('./folder-sync.js')
+
+const ingestMock = vi.mocked(ingestRawMessage)
+
+// Only the two calls these functions make, answering with one message.
+const clientWith = (uid: number): ImapFlow =>
+	({
+		search: async () => [uid],
+		fetch: async function* () {
+			yield { uid, source: Buffer.from('raw bytes') }
+		},
+	}) as unknown as ImapFlow
+
+// Recording the folder head is the only database work in this path, and it is
+// not what these tests are about. The matcher and the object store are named
+// because storing a message asks for them, but it is stubbed out here, so
+// nothing ever reaches them.
+const stubs = Layer.mergeAll(
+	Layer.succeed(SqlClient.SqlClient, (() => Effect.void) as never),
+	Layer.succeed(ParticipantMatcher, {} as never),
+	Layer.succeed(RawMessageStorage, {} as never),
+)
+
+const run = <A, E>(
+	effect: Effect.Effect<
+		A,
+		E,
+		SqlClient.SqlClient | ParticipantMatcher | RawMessageStorage
+	>,
+) => Effect.runPromise(effect.pipe(Effect.provide(stubs)))
+
+const directionPassedToIngest = () => ingestMock.mock.calls[0]?.[0]?.direction
+
+beforeEach(() => {
+	ingestMock.mockClear()
+})
+
+describe('fetchAndIngestNewerThan', () => {
+	describe('when reading a folder holding mail we sent', () => {
+		it('should carry that down to where the message is stored', async () => {
+			// GIVEN one new message in a folder the caller has settled as outbound
+			// WHEN it is taken in
+			await run(
+				fetchAndIngestNewerThan({
+					client: clientWith(7),
+					organizationId: 'org',
+					inboxId: 'inbox',
+					folder: '[Gmail]/Sent Mail',
+					direction: 'outbound',
+					uidvalidity: 1,
+					sinceUid: 6,
+				}),
+			)
+
+			// THEN the message is stored as one we sent
+			expect(ingestMock).toHaveBeenCalledOnce()
+			expect(directionPassedToIngest()).toBe('outbound')
+		})
+	})
+
+	describe('when reading a folder holding mail that arrived', () => {
+		it('should carry that down unchanged', async () => {
+			// GIVEN one new message in a folder settled as inbound
+			// WHEN it is taken in
+			await run(
+				fetchAndIngestNewerThan({
+					client: clientWith(3),
+					organizationId: 'org',
+					inboxId: 'inbox',
+					folder: 'INBOX',
+					direction: 'inbound',
+					uidvalidity: 1,
+					sinceUid: 2,
+				}),
+			)
+
+			// THEN it is stored as mail that arrived
+			expect(directionPassedToIngest()).toBe('inbound')
+		})
+	})
+})
+
+describe('backfillSinceDate', () => {
+	describe('when first reading a folder holding mail we sent', () => {
+		it('should carry that down too', async () => {
+			// GIVEN a folder being read for the first time — a different path into
+			// the same store, and the one a newly connected mailbox takes
+			// WHEN its recent messages are taken in
+			await run(
+				backfillSinceDate({
+					client: clientWith(11),
+					organizationId: 'org',
+					inboxId: 'inbox',
+					folder: 'Sent Items',
+					direction: 'outbound',
+					uidvalidity: 1,
+					sinceDate: new Date('2026-01-01T00:00:00Z'),
+				}),
+			)
+
+			// THEN those messages are stored as ones we sent
+			expect(ingestMock).toHaveBeenCalledOnce()
+			expect(directionPassedToIngest()).toBe('outbound')
+		})
+	})
+})

--- a/apps/mail-worker/src/folder-sync.ts
+++ b/apps/mail-worker/src/folder-sync.ts
@@ -76,6 +76,7 @@ export const fetchAndIngestNewerThan = (args: {
 	readonly organizationId: string
 	readonly inboxId: string
 	readonly folder: string
+	readonly direction: 'inbound' | 'outbound'
 	readonly uidvalidity: number
 	readonly sinceUid: number
 }) =>
@@ -102,6 +103,7 @@ export const fetchAndIngestNewerThan = (args: {
 				organizationId: args.organizationId,
 				inboxId: args.inboxId,
 				folder: args.folder,
+				direction: args.direction,
 				imapUid: m.uid,
 				imapUidvalidity: args.uidvalidity,
 				raw: new Uint8Array(m.source),

--- a/apps/mail-worker/src/imap-roundtrip.test.ts
+++ b/apps/mail-worker/src/imap-roundtrip.test.ts
@@ -177,6 +177,7 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							organizationId: orgId,
 							inboxId,
 							folder: 'INBOX',
+							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
 						}).pipe(
@@ -236,6 +237,7 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							organizationId: orgId,
 							inboxId,
 							folder: 'INBOX',
+							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
 						}).pipe(
@@ -253,6 +255,7 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							organizationId: orgId,
 							inboxId,
 							folder: 'INBOX',
+							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
 						}).pipe(
@@ -303,6 +306,7 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							organizationId: orgId,
 							inboxId,
 							folder: 'INBOX',
+							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
 						}).pipe(

--- a/apps/mail-worker/src/inbox-session.test.ts
+++ b/apps/mail-worker/src/inbox-session.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { onImapClientError } from './inbox-session.js'
+import { onImapClientError, resolveTrackedFolders } from './inbox-session.js'
 
 // Spy on console.warn so the handler's single JSON line is captured, not printed.
 const captureWarn = () =>
@@ -96,6 +96,120 @@ describe('onImapClientError', () => {
 
 			// THEN Node rethrows — which, without our listener, crashes the worker
 			expect(emit).toThrow('socket hang up')
+		})
+	})
+})
+
+describe('resolveTrackedFolders', () => {
+	describe('when the server only offers an inbox', () => {
+		it('should track it alone, as arriving mail', () => {
+			// GIVEN the dev catcher, which has no sent folder
+			const boxes = [{ path: 'INBOX', specialUse: '\\Inbox' }]
+
+			// WHEN the folders to sync are worked out
+			// THEN only the inbox is synced, and what lands there arrived
+			expect(resolveTrackedFolders(boxes)).toEqual([
+				{ path: 'INBOX', direction: 'inbound' },
+			])
+		})
+	})
+
+	describe('when the server names its folders conventionally', () => {
+		it('should track both by name even with no special-use flags', () => {
+			// GIVEN a server that advertises no purposes at all
+			const boxes = [{ path: 'INBOX' }, { path: 'Sent' }, { path: 'Drafts' }]
+
+			// WHEN the folders are worked out
+			// THEN the two we care about are found by name, and drafts are left alone
+			expect(resolveTrackedFolders(boxes)).toEqual([
+				{ path: 'INBOX', direction: 'inbound' },
+				{ path: 'Sent', direction: 'outbound' },
+			])
+		})
+	})
+
+	describe('when the provider names its sent folder something else', () => {
+		it('should find the Gmail sent folder and skip the copy of everything', () => {
+			// GIVEN Gmail, whose sent folder is not called "Sent" and whose
+			// "All Mail" repeats every message already counted elsewhere
+			const boxes = [
+				{ path: 'INBOX', specialUse: '\\Inbox' },
+				{ path: '[Gmail]/Sent Mail', specialUse: '\\Sent' },
+				{ path: '[Gmail]/All Mail', specialUse: '\\All' },
+				{ path: '[Gmail]/Bin', specialUse: '\\Trash' },
+			]
+
+			// WHEN the folders are worked out
+			// THEN sent mail is found by its purpose, and nothing is counted twice
+			expect(resolveTrackedFolders(boxes)).toEqual([
+				{ path: 'INBOX', direction: 'inbound' },
+				{ path: '[Gmail]/Sent Mail', direction: 'outbound' },
+			])
+		})
+
+		it('should find the Outlook sent folder', () => {
+			// GIVEN Outlook, which calls it "Sent Items"
+			const boxes = [
+				{ path: 'INBOX', specialUse: '\\Inbox' },
+				{ path: 'Sent Items', specialUse: '\\Sent' },
+			]
+
+			// WHEN the folders are worked out
+			// THEN it is still recognised as where sent mail lives
+			expect(resolveTrackedFolders(boxes)).toEqual([
+				{ path: 'INBOX', direction: 'inbound' },
+				{ path: 'Sent Items', direction: 'outbound' },
+			])
+		})
+	})
+
+	describe('when a folder is merely named like one we track', () => {
+		it('should prefer the one the server says is for sent mail', () => {
+			// GIVEN a personal folder someone named "Sent" alongside the real one
+			const boxes = [
+				{ path: 'INBOX', specialUse: '\\Inbox' },
+				{ path: 'Sent' },
+				{ path: 'Sent Items', specialUse: '\\Sent' },
+			]
+
+			// WHEN the folders are worked out
+			// THEN the server's own answer wins over the coincidence of a name
+			expect(resolveTrackedFolders(boxes)).toEqual([
+				{ path: 'INBOX', direction: 'inbound' },
+				{ path: 'Sent Items', direction: 'outbound' },
+			])
+		})
+	})
+
+	describe('when the server offers nothing we recognise', () => {
+		it('should track nothing rather than guess', () => {
+			// GIVEN a mailbox list with no inbox and no sent folder
+			// [runInboxSession fails on an empty result, letting the backoff retry]
+			expect(resolveTrackedFolders([{ path: 'Archive' }])).toEqual([])
+		})
+	})
+
+	describe('when the server offers no folders at all', () => {
+		it('should track nothing', () => {
+			// GIVEN the degenerate empty list
+			expect(resolveTrackedFolders([])).toEqual([])
+		})
+	})
+
+	describe('when one folder answers to two of our roles', () => {
+		it('should sync it once', () => {
+			// GIVEN a server that flags a single folder as both
+			// (malformed, but syncing it twice would double every message)
+			const boxes: ReadonlyArray<{ path: string; specialUse?: string }> = [
+				{ path: 'INBOX', specialUse: '\\Inbox' },
+				{ path: 'INBOX', specialUse: '\\Sent' },
+			]
+
+			// WHEN the folders are worked out
+			// THEN the folder appears once
+			expect(resolveTrackedFolders(boxes)).toEqual([
+				{ path: 'INBOX', direction: 'inbound' },
+			])
 		})
 	})
 })

--- a/apps/mail-worker/src/inbox-session.ts
+++ b/apps/mail-worker/src/inbox-session.ts
@@ -7,6 +7,7 @@ import type { ClaimedInbox } from './claim.js'
 import { CredentialDecryptor } from './decrypt.js'
 import { WorkerEnvVars } from './env.js'
 import {
+	type FolderState,
 	fetchAndIngestNewerThan,
 	markExpunged,
 	readFolderState,
@@ -30,11 +31,46 @@ export const onImapClientError =
 		)
 	}
 
-// Folders we monitor per inbox. Most providers have INBOX + Sent;
+// Folders we monitor per inbox, and what finding a message in one means.
 // Gmail's "All Mail" duplicates everything (covered by IMAP \All
-// special-use), so we skip it. Outbound rows we APPEND to "Sent" still
-// land here on the next sync — `idx_email_messages_msgid` dedupes.
-const TRACKED_FOLDERS: readonly string[] = ['INBOX', 'Sent']
+// special-use), so we skip it.
+//
+// Providers disagree on names — Gmail calls its sent folder
+// "[Gmail]/Sent Mail" and Outlook "Sent Items", so matching on the name alone
+// finds no sent mail on either. We ask the server which folder serves which
+// purpose and only fall back to the conventional name.
+const FOLDER_ROLES = [
+	{ specialUse: '\\Inbox', fallbackPath: 'INBOX', direction: 'inbound' },
+	{ specialUse: '\\Sent', fallbackPath: 'Sent', direction: 'outbound' },
+] as const
+
+export type TrackedFolder = {
+	readonly path: string
+	// Settled once from the folder's purpose and handed down, so nothing
+	// further along has to read it back out of a folder name.
+	readonly direction: 'inbound' | 'outbound'
+}
+
+// Pure so it can be tested without a server: the dev catcher (GreenMail) has
+// only INBOX, and a provider's real folder list is awkward to stand up.
+export const resolveTrackedFolders = (
+	boxes: ReadonlyArray<{
+		readonly path: string
+		readonly specialUse?: string | undefined
+	}>,
+): ReadonlyArray<TrackedFolder> => {
+	const tracked: Array<TrackedFolder> = []
+	for (const role of FOLDER_ROLES) {
+		const bySpecialUse = boxes.find(box => box.specialUse === role.specialUse)
+		const box =
+			bySpecialUse ?? boxes.find(entry => entry.path === role.fallbackPath)
+		if (box === undefined) continue
+		// A server that flags one folder twice would otherwise be synced twice.
+		if (tracked.some(entry => entry.path === box.path)) continue
+		tracked.push({ path: box.path, direction: role.direction })
+	}
+	return tracked
+}
 
 // Flip an inbox's grant_status when authentication or connection
 // proves broken across retries. Worker writes this; UI surfaces it via
@@ -67,29 +103,31 @@ const markHealthy = (inboxId: string) =>
 		`
 	})
 
-// Open a single mailbox, sync from folder_state.lastUid forward (or
-// backfill if we have no resume point / uidvalidity drifted), drain
-// any EXPUNGE events accumulated since the last tick, then idle until
-// the server reports a change. Returns when idle resolves; the caller
-// loops.
+// Open a single mailbox, sync forward from where `progress` says this
+// folder was last read (or backfill if we have no resume point /
+// uidvalidity drifted) and drain any EXPUNGE events accumulated since
+// the last tick. Waiting for the server to report a change happens once
+// per pass, in the caller.
 const syncOneFolderTick = (args: {
 	readonly client: ImapFlow
 	readonly inbox: ClaimedInbox
-	readonly folder: string
+	readonly folder: TrackedFolder
 	readonly backfillDays: number
 	readonly expungedQueue: Array<{ uid: number; uidValidity: number }>
-	readonly waitForChange: Effect.Effect<void>
+	readonly progress: Map<string, FolderState>
 }) =>
 	Effect.gen(function* () {
 		const opened = yield* Effect.tryPromise({
-			try: () => args.client.mailboxOpen(args.folder),
+			try: () => args.client.mailboxOpen(args.folder.path),
 			catch: err =>
-				new Error(`mailboxOpen(${args.folder}) failed: ${String(err)}`),
+				new Error(`mailboxOpen(${args.folder.path}) failed: ${String(err)}`),
 		})
 		const serverUidvalidity = Number(opened.uidValidity)
 		if (!Number.isFinite(serverUidvalidity)) {
 			return yield* Effect.fail(
-				new Error(`bad uidvalidity from ${args.folder}: ${opened.uidValidity}`),
+				new Error(
+					`bad uidvalidity from ${args.folder.path}: ${opened.uidValidity}`,
+				),
 			)
 		}
 
@@ -105,49 +143,46 @@ const syncOneFolderTick = (args: {
 			}).pipe(Effect.catchCause(cause => Effect.logError(cause)))
 		}
 
-		const known = readFolderState(args.inbox.folderState, args.folder)
+		const known = args.progress.get(args.folder.path) ?? null
 		const needsBackfill =
 			known === null || known.uidvalidity !== serverUidvalidity
 
+		const highest = needsBackfill
+			? yield* backfillSinceDate({
+					client: args.client,
+					organizationId: args.inbox.organizationId,
+					inboxId: args.inbox.id,
+					folder: args.folder.path,
+					direction: args.folder.direction,
+					uidvalidity: serverUidvalidity,
+					sinceDate: new Date(
+						Date.now() - args.backfillDays * 24 * 60 * 60 * 1000,
+					),
+				})
+			: yield* fetchAndIngestNewerThan({
+					client: args.client,
+					organizationId: args.inbox.organizationId,
+					inboxId: args.inbox.id,
+					folder: args.folder.path,
+					direction: args.folder.direction,
+					uidvalidity: serverUidvalidity,
+					sinceUid: known.lastUid,
+				})
+
 		if (needsBackfill) {
-			const sinceDate = new Date(
-				Date.now() - args.backfillDays * 24 * 60 * 60 * 1000,
-			)
-			const highest = yield* backfillSinceDate({
-				client: args.client,
-				organizationId: args.inbox.organizationId,
-				inboxId: args.inbox.id,
-				folder: args.folder,
-				uidvalidity: serverUidvalidity,
-				sinceDate,
-			})
 			yield* recordFolderHead({
 				inboxId: args.inbox.id,
-				folder: args.folder,
+				folder: args.folder.path,
 				uidvalidity: serverUidvalidity,
 				lastUid: highest,
 			})
-		} else {
-			yield* fetchAndIngestNewerThan({
-				client: args.client,
-				organizationId: args.inbox.organizationId,
-				inboxId: args.inbox.id,
-				folder: args.folder,
-				uidvalidity: serverUidvalidity,
-				sinceUid: known.lastUid,
-			})
 		}
 
-		// Hold IMAP IDLE so the server can push `exists`/`expunge` mid-IDLE.
-		// imapflow surfaces those as events rather than resolving idle(), so we
-		// start it fire-and-forget — the promise settles when the next tick's
-		// mailboxOpen breaks IDLE — and park until an event wakes us, or the
-		// poll timeout elapses. The poll is the reliable re-sync floor; the
-		// event is a low-latency optimization where the server delivers it.
-		yield* Effect.sync(() => {
-			void args.client.idle().catch(() => {})
+		args.progress.set(args.folder.path, {
+			uidvalidity: serverUidvalidity,
+			lastUid: highest,
+			syncedAt: null,
 		})
-		yield* args.waitForChange
 	})
 
 // One inbox = one IMAP connection per tracked folder. We keep things
@@ -248,22 +283,40 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 		// Per inbox we sync each tracked folder in a round-robin, parking on
 		// server change-events (or a poll timeout) between passes.
 		//
-		// Only sync folders the server actually exposes. Providers vary —
-		// the dev catcher (GreenMail) has just INBOX, Gmail names Sent
-		// "[Gmail]/Sent Mail" — so opening a hardcoded "Sent" would error
-		// every tick. INBOX is guaranteed by the IMAP spec; bail if even
-		// that is missing so the retry backoff handles it, not a hot loop.
+		// Only sync folders the server actually exposes, and take each one's
+		// purpose from the server rather than its name. The dev catcher
+		// (GreenMail) has just INBOX, so a missing sent folder is normal.
+		// Recognising none of them means we cannot usefully read this mailbox
+		// at all, so we give up and let the retry backoff handle it rather
+		// than spinning.
 		const available = yield* Effect.tryPromise({
 			try: () => client.list(),
 			catch: err => new Error(`list mailboxes failed: ${String(err)}`),
 		})
-		const availablePaths = new Set(available.map(box => box.path))
-		const folders = TRACKED_FOLDERS.filter(f => availablePaths.has(f))
-		if (folders.length === 0) {
+		const folders = resolveTrackedFolders(available)
+		const [firstFolder] = folders
+		if (firstFolder === undefined) {
 			return yield* Effect.fail(
 				new Error(`no tracked folders available for inbox=${claimed.id}`),
 			)
 		}
+
+		// How far each folder has been read, carried across passes. Seeded from
+		// where the last session left off and kept up to date as we go, so a
+		// pass resumes rather than starting the window again.
+		const progress = new Map<string, FolderState>()
+		for (const folder of folders) {
+			const known = readFolderState(claimed.folderState, folder.path)
+			if (known !== null) progress.set(folder.path, known)
+		}
+
+		// The server can only tell us about the folder we are holding open, so
+		// the one we wait on is the one that decides how quickly arriving mail
+		// is noticed. We wait on the inbox: a message we sent is already ours
+		// and can be picked up on the next pass, but one that arrives is
+		// somebody waiting for an answer.
+		const folderToWaitOn =
+			folders.find(folder => folder.direction === 'inbound') ?? firstFolder
 
 		yield* Effect.gen(function* () {
 			while (true) {
@@ -274,16 +327,35 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 						folder,
 						backfillDays: env.EMAIL_WORKER_BACKFILL_DAYS,
 						expungedQueue,
-						waitForChange,
+						progress,
 					}).pipe(
 						Effect.catchCause(cause =>
 							Effect.logWarning(
-								`mail-worker: folder tick failed inbox=${claimed.id} folder=${folder}`,
+								`mail-worker: folder tick failed inbox=${claimed.id} folder=${folder.path}`,
 							).pipe(Effect.andThen(Effect.logError(cause))),
 						),
 					)
 				}
 				yield* markHealthy(claimed.id)
+
+				// Hold IMAP IDLE so the server can push `exists`/`expunge` mid-IDLE.
+				// imapflow surfaces those as events rather than resolving idle(), so
+				// we start it fire-and-forget — the promise settles when the next
+				// pass's mailboxOpen breaks IDLE — and park until an event wakes us,
+				// or the poll timeout elapses. The poll is the reliable re-sync
+				// floor; the event is a low-latency optimization where the server
+				// delivers it.
+				yield* Effect.tryPromise({
+					try: () => client.mailboxOpen(folderToWaitOn.path),
+					catch: err =>
+						new Error(
+							`mailboxOpen(${folderToWaitOn.path}) failed: ${String(err)}`,
+						),
+				}).pipe(Effect.catchCause(cause => Effect.logError(cause)))
+				yield* Effect.sync(() => {
+					void client.idle().catch(() => {})
+				})
+				yield* waitForChange
 			}
 		}).pipe(
 			Effect.ensuring(

--- a/apps/mail-worker/src/ingest.ts
+++ b/apps/mail-worker/src/ingest.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
 
 import { Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
@@ -8,9 +9,16 @@ import { applyBounce, parseBounce } from './bounces.js'
 import {
 	type AttachmentMetadata,
 	fromParsedMail,
-	persistInboundMessage,
+	persistMessage,
 } from './persist.js'
 import { attachmentKey, RawMessageStorage, rawMessageKey } from './storage.js'
+
+// Taken from the message itself rather than from where it was found, so the
+// same message read again — after a folder is re-numbered, or from a second
+// mailbox — is recognised as the one already stored. Shaped like a real
+// Message-ID so nothing downstream has to tell them apart.
+const syntheticMessageId = (raw: Uint8Array): string =>
+	`<${createHash('sha256').update(raw).digest('hex').slice(0, 40)}@no-message-id.batuda>`
 
 // One transactional ingest step per fetched UID. Wraps:
 //  1. mailparser.simpleParser → ParsedMail
@@ -29,6 +37,7 @@ export const ingestRawMessage = (args: {
 	readonly organizationId: string
 	readonly inboxId: string
 	readonly folder: string
+	readonly direction: 'inbound' | 'outbound'
 	readonly imapUid: number
 	readonly imapUidvalidity: number
 	readonly raw: Uint8Array
@@ -44,6 +53,7 @@ export const ingestRawMessage = (args: {
 		const key = rawMessageKey({
 			organizationId: args.organizationId,
 			inboxId: args.inboxId,
+			folder: args.folder,
 			uidValidity: args.imapUidvalidity,
 			uid: args.imapUid,
 		})
@@ -63,6 +73,7 @@ export const ingestRawMessage = (args: {
 			const aKey = attachmentKey({
 				organizationId: args.organizationId,
 				inboxId: args.inboxId,
+				folder: args.folder,
 				uidValidity: args.imapUidvalidity,
 				uid: args.imapUid,
 				index: i,
@@ -81,7 +92,16 @@ export const ingestRawMessage = (args: {
 			})
 		}
 
+		// A message is known by its Message-ID everywhere below: threads are
+		// pivoted on it, bounces are matched on it, and one is allowed per
+		// organization. A message that arrives without one would take the empty
+		// string, so the first such message claims it and every later one is
+		// turned away.
 		const parsed = fromParsedMail(mail)
+		const withMessageId =
+			parsed.messageId === ''
+				? { ...parsed, messageId: syntheticMessageId(args.raw) }
+				: parsed
 
 		yield* sql.withTransaction(
 			Effect.gen(function* () {
@@ -105,14 +125,15 @@ export const ingestRawMessage = (args: {
 					})
 				}
 
-				yield* persistInboundMessage({
+				yield* persistMessage({
 					organizationId: args.organizationId,
 					inboxId: args.inboxId,
 					folder: args.folder,
+					direction: args.direction,
 					imapUid: args.imapUid,
 					imapUidvalidity: args.imapUidvalidity,
 					rawRfc822Ref: key,
-					parsed,
+					parsed: withMessageId,
 					attachments: attachmentsMeta,
 				})
 			}),

--- a/apps/mail-worker/src/persist.integration.test.ts
+++ b/apps/mail-worker/src/persist.integration.test.ts
@@ -1,5 +1,5 @@
 // Live-DB integration test for the matcher → persist auto-link wiring.
-// Verifies that `persistInboundMessage` populates `company_id` and
+// Verifies that `persistMessage` populates `company_id` and
 // `contact_id` on both `email_messages` and `email_thread_links` based
 // on the inbound sender address.
 //
@@ -19,7 +19,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { ParticipantMatcher } from '@batuda/email/participant-matcher'
 
-import { type ParsedInbound, persistInboundMessage } from './persist.js'
+import { type ParsedInbound, persistMessage } from './persist.js'
 
 const DATABASE_URL =
 	process.env['DATABASE_URL'] ??
@@ -106,20 +106,31 @@ const buildParsed = (overrides: Partial<ParsedInbound>): ParsedInbound => ({
 	...overrides,
 })
 
-// Per-test imap_uid so the (inbox_id, uidvalidity, uid) dedupe index
+// Per-test imap_uid so the (inbox_id, folder, uidvalidity, uid) dedupe index
 // doesn't swallow inserts. uidvalidity stays constant for the suite.
 let nextUid = 1
-const persist = (parsed: ParsedInbound) =>
-	persistInboundMessage({
+const persistIn = (
+	parsed: ParsedInbound,
+	where: {
+		folder: string
+		direction: 'inbound' | 'outbound'
+		imapUid?: number
+	},
+) =>
+	persistMessage({
 		organizationId: ORG_ID,
 		inboxId,
-		folder: 'INBOX',
-		imapUid: nextUid++,
+		folder: where.folder,
+		direction: where.direction,
+		imapUid: where.imapUid ?? nextUid++,
 		imapUidvalidity: 100,
 		rawRfc822Ref: 'sentinel',
 		parsed,
 		attachments: [],
 	}).pipe(Effect.provide(ParticipantMatcher.layer), Effect.provide(PgLive))
+
+const persist = (parsed: ParsedInbound) =>
+	persistIn(parsed, { folder: 'INBOX', direction: 'inbound' })
 
 beforeAll(async () => {
 	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
@@ -171,10 +182,12 @@ afterAll(async () => {
 
 const fetchMessage = async (messageId: string) => {
 	const rows = await pool.query<{
+		id: string
 		company_id: string | null
 		contact_id: string | null
+		direction: string
 	}>(
-		`SELECT company_id, contact_id FROM email_messages WHERE message_id = $1`,
+		`SELECT id, company_id, contact_id, direction FROM email_messages WHERE message_id = $1`,
 		[messageId],
 	)
 	return rows.rows[0]
@@ -191,7 +204,7 @@ const fetchThreadLink = async (externalThreadId: string) => {
 	return rows.rows[0]
 }
 
-describe('persistInboundMessage — CRM auto-link', () => {
+describe('persistMessage — CRM auto-link', () => {
 	describe('when the sender matches an existing contact', () => {
 		it('should populate company_id and contact_id on email_messages', async () => {
 			// GIVEN an inbound email from alice@acme (a seeded contact)
@@ -342,6 +355,235 @@ describe('persistInboundMessage — CRM auto-link', () => {
 			expect(row?.company_id).toBeNull()
 			expect(row?.contact_id).toBeNull()
 			// [apps/mail-worker/src/persist.ts — `args.parsed.fromAddress ? matcher.match(…) : new NoMatch(…)` null-guard]
+		})
+	})
+})
+
+describe('persistMessage — which way a message went', () => {
+	const historyRowsFor = async (messageDbId: string) =>
+		(
+			await pool.query<{ kind: string; direction: string }>(
+				`SELECT kind, direction FROM timeline_activity WHERE entity_id = $1`,
+				[messageDbId],
+			)
+		).rows
+
+	describe('when the message was found in the sent folder', () => {
+		it('should record it as one we sent', async () => {
+			// GIVEN a message sitting in the sent folder — one we sent, whatever
+			// the address it came from happens to match
+			const messageId = `<sent-${randomUUID()}@example>`
+			const parsed = buildParsed({
+				messageId,
+				fromAddress: `alice@${ACME_DOMAIN}`,
+			})
+
+			// WHEN it is taken in from that folder
+			await runIngest(
+				persistIn(parsed, { folder: 'Sent', direction: 'outbound' }),
+			)
+
+			// THEN it is stored as outbound, so the thread does not show our own
+			// message as something the company said to us
+			const row = await fetchMessage(messageId)
+			expect(row?.direction).toBe('outbound')
+		})
+
+		it('should stay out of the company history', async () => {
+			// GIVEN a sent message whose address does match a company
+			// [apps/mail-worker/src/persist.ts — the timeline insert is skipped
+			// unless the message arrived]
+			const messageId = `<sent-history-${randomUUID()}@example>`
+			const parsed = buildParsed({
+				messageId,
+				fromAddress: `alice@${ACME_DOMAIN}`,
+			})
+
+			// WHEN it is taken in from the sent folder
+			await runIngest(
+				persistIn(parsed, { folder: 'Sent', direction: 'outbound' }),
+			)
+
+			// THEN nothing is filed as mail that arrived
+			const row = await fetchMessage(messageId)
+			expect(await historyRowsFor(row!.id)).toEqual([])
+		})
+	})
+
+	describe('when the message arrived in the inbox', () => {
+		it('should be filed as mail that arrived', async () => {
+			// GIVEN a message from a known company landing in the inbox
+			const messageId = `<received-${randomUUID()}@example>`
+			const parsed = buildParsed({
+				messageId,
+				fromAddress: `alice@${ACME_DOMAIN}`,
+			})
+
+			// WHEN it is taken in
+			await runIngest(persist(parsed))
+
+			// THEN it is inbound, and it shows on the company's history
+			const row = await fetchMessage(messageId)
+			expect(row?.direction).toBe('inbound')
+			expect(await historyRowsFor(row!.id)).toEqual([
+				{ kind: 'email_received', direction: 'inbound' },
+			])
+		})
+	})
+})
+
+describe('persistMessage — a message we already hold', () => {
+	const rowsFor = async (messageId: string) =>
+		(
+			await pool.query<{
+				id: string
+				direction: string
+				folder: string
+				imap_uid: number | null
+				text_body: string | null
+			}>(
+				`SELECT id, direction, folder, imap_uid, text_body FROM email_messages WHERE message_id = $1`,
+				[messageId],
+			)
+		).rows
+
+	describe('when our own sent message comes back from the sent folder', () => {
+		it('should fill in where it lives rather than store it again', async () => {
+			// GIVEN a message already recorded because we sent it — no folder
+			// position yet, because it had not been read back from the server
+			const messageId = `<ours-${randomUUID()}@example>`
+			await pool.query(
+				`INSERT INTO email_messages
+				 (organization_id, inbox_id, message_id, direction, folder, raw_rfc822_ref,
+				  status, text_body, imap_uid, imap_uidvalidity)
+				 VALUES ($1, $2, $3, 'outbound', 'Sent', 'sent-ref', 'normal', $4, NULL, NULL)`,
+				[ORG_ID, inboxId, messageId, 'What we actually sent.'],
+			)
+
+			// WHEN the sent folder is read and the same message is found there
+			await runIngest(
+				persistIn(
+					buildParsed({ messageId, textBody: 'What we actually sent.' }),
+					{
+						folder: 'Sent',
+						direction: 'outbound',
+						imapUid: 4242,
+					},
+				),
+			)
+
+			// THEN it is still the one message, still ours, now knowing where it
+			// sits on the server — rather than being turned away for reusing a
+			// Message-ID, which would undo everything read alongside it
+			const rows = await rowsFor(messageId)
+			expect(rows).toHaveLength(1)
+			expect(rows[0]?.direction).toBe('outbound')
+			expect(rows[0]?.imap_uid).toBe(4242)
+			expect(rows[0]?.text_body).toBe('What we actually sent.')
+		})
+	})
+
+	describe('when the same folder position is read twice', () => {
+		it('should keep one copy', async () => {
+			// GIVEN a message taken in from the inbox
+			const messageId = `<twice-${randomUUID()}@example>`
+			const parsed = buildParsed({ messageId })
+			await runIngest(
+				persistIn(parsed, {
+					folder: 'INBOX',
+					direction: 'inbound',
+					imapUid: 5150,
+				}),
+			)
+
+			// WHEN the same position is read again, as it is after a restart
+			await runIngest(
+				persistIn(parsed, {
+					folder: 'INBOX',
+					direction: 'inbound',
+					imapUid: 5150,
+				}),
+			)
+
+			// THEN it is stored once
+			expect(await rowsFor(messageId)).toHaveLength(1)
+		})
+	})
+
+	describe('when two folders number their messages the same', () => {
+		it('should keep both, because they are different messages', async () => {
+			// GIVEN two genuinely different messages that happen to sit at the same
+			// position in two folders — which a server is free to do
+			const inboxMessage = `<inbox-${randomUUID()}@example>`
+			const sentMessage = `<sent-${randomUUID()}@example>`
+
+			// WHEN both are taken in
+			await runIngest(
+				persistIn(buildParsed({ messageId: inboxMessage }), {
+					folder: 'INBOX',
+					direction: 'inbound',
+					imapUid: 9001,
+				}),
+			)
+			await runIngest(
+				persistIn(buildParsed({ messageId: sentMessage }), {
+					folder: 'Sent',
+					direction: 'outbound',
+					imapUid: 9001,
+				}),
+			)
+
+			// THEN neither is mistaken for the other and lost
+			expect(await rowsFor(inboxMessage)).toHaveLength(1)
+			expect(await rowsFor(sentMessage)).toHaveLength(1)
+		})
+	})
+})
+
+describe('persistMessage — whose conversation it is', () => {
+	describe('when we wrote to a company', () => {
+		it('should file it under whom we wrote to, not under ourselves', async () => {
+			// GIVEN a message we sent to a known contact, found in the sent folder.
+			// Its sender is our own mailbox, which belongs to no company.
+			const messageId = `<to-acme-${randomUUID()}@example>`
+			const parsed = buildParsed({
+				messageId,
+				fromAddress: `inbox@${ACME_DOMAIN}`,
+				toAddresses: [`alice@${ACME_DOMAIN}`],
+			})
+
+			// WHEN it is taken in
+			await runIngest(
+				persistIn(parsed, { folder: 'Sent', direction: 'outbound' }),
+			)
+
+			// THEN it belongs to the company we wrote to, and so does the
+			// conversation it opens — which is never re-homed later, so getting
+			// this wrong would keep the whole thread off their page for good
+			const row = await fetchMessage(messageId)
+			expect(row?.company_id).toBe(acmeCompanyId)
+			expect(row?.contact_id).toBe(aliceContactId)
+			expect((await fetchThreadLink(messageId))?.company_id).toBe(acmeCompanyId)
+		})
+	})
+
+	describe('when a company wrote to us', () => {
+		it('should still file it under the sender', async () => {
+			// GIVEN a message that arrived from that contact
+			const messageId = `<from-acme-${randomUUID()}@example>`
+			const parsed = buildParsed({
+				messageId,
+				fromAddress: `alice@${ACME_DOMAIN}`,
+				toAddresses: [`inbox@${ACME_DOMAIN}`],
+			})
+
+			// WHEN it is taken in
+			await runIngest(persist(parsed))
+
+			// THEN it is filed under them
+			const row = await fetchMessage(messageId)
+			expect(row?.company_id).toBe(acmeCompanyId)
+			expect(row?.contact_id).toBe(aliceContactId)
 		})
 	})
 })

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -81,15 +81,18 @@ export interface AttachmentMetadata {
 	readonly storageKey: string
 }
 
-// Insert a parsed inbound message + its participants + (re)link to a
-// thread. Caller is responsible for `SET LOCAL app.current_org_id`
-// inside the surrounding transaction; the worker connects as
-// `app_service` (BYPASSRLS) and resolves org from the inbox row before
-// each insert batch.
-export const persistInboundMessage = (args: {
+// Insert a parsed message + its participants + (re)link to a thread.
+// Caller is responsible for `SET LOCAL app.current_org_id` inside the
+// surrounding transaction; the worker connects as `app_service`
+// (BYPASSRLS) and resolves org from the inbox row before each insert batch.
+//
+// Which way the message went is the caller's to say, because only it knows
+// what the folder it was read from is for.
+export const persistMessage = (args: {
 	readonly organizationId: string
 	readonly inboxId: string
 	readonly folder: string
+	readonly direction: 'inbound' | 'outbound'
 	readonly imapUid: number
 	readonly imapUidvalidity: number
 	readonly rawRfc822Ref: string
@@ -100,6 +103,38 @@ export const persistInboundMessage = (args: {
 		const sql = yield* SqlClient.SqlClient
 		const matcher = yield* ParticipantMatcher
 
+		// A message we sent, coming back to us out of the sent folder. It is
+		// already recorded, with no folder position yet, and all that is new is
+		// where it now lives on the server, so we fill that in rather than
+		// storing it a second time. Trying to insert it would be turned away
+		// for reusing a Message-ID, and that refusal would undo the whole
+		// batch, not just this message.
+		//
+		// Such a row already has its participants and its place in the
+		// company's history, so this stops here.
+		const enriched = yield* sql<{ id: string }>`
+			UPDATE email_messages
+			SET imap_uid = ${args.imapUid},
+			    imap_uidvalidity = ${args.imapUidvalidity},
+			    folder = ${args.folder},
+			    attachments = CASE
+			      WHEN attachments = '[]'::jsonb
+			      THEN ${JSON.stringify(args.attachments)}::jsonb
+			      ELSE attachments
+			    END,
+			    text_body = COALESCE(text_body, ${args.parsed.textBody}),
+			    html_body = COALESCE(html_body, ${args.parsed.htmlBody}),
+			    text_preview = COALESCE(text_preview, ${args.parsed.textPreview})
+			WHERE organization_id = ${args.organizationId}
+			  AND message_id = ${args.parsed.messageId}
+			  AND inbox_id = ${args.inboxId}
+			  AND direction = 'outbound'
+			  AND imap_uid IS NULL
+			RETURNING id
+		`
+		const enrichedId = enriched[0]?.id
+		if (enrichedId !== undefined) return { messageId: enrichedId }
+
 		const externalThreadId = yield* resolveThreadId({
 			organizationId: args.organizationId,
 			messageId: args.parsed.messageId,
@@ -107,16 +142,26 @@ export const persistInboundMessage = (args: {
 			references: args.parsed.references,
 		})
 
-		// Resolve sender → contact/company once, then carry the IDs onto
+		// Whose conversation this is comes from the other side of it: who wrote
+		// to us, or who we wrote to. Reading the sender of a message we sent
+		// would only ever find ourselves, and a conversation that starts
+		// unmatched is never re-homed — so a thread first seen in the sent
+		// folder would stay off that company's page even after they reply.
+		const counterpartAddress =
+			args.direction === 'outbound'
+				? (args.parsed.toAddresses[0] ?? null)
+				: args.parsed.fromAddress
+
+		// Resolve that address → contact/company once, then carry the IDs onto
 		// both the thread link and the message row. `createPolicy: 'never'`
-		// keeps inbound passive: an unknown sender stays an orphan, never
+		// keeps this passive: an unknown address stays an orphan, never
 		// auto-creates a contact. The matcher only reads `currentOrg.id`
 		// (not name/slug), so a thin record is sufficient — providing the
 		// full org would mean a second round-trip we don't need.
-		const match = args.parsed.fromAddress
+		const match = counterpartAddress
 			? yield* matcher
 					.match({
-						email: args.parsed.fromAddress,
+						email: counterpartAddress,
 						createPolicy: 'never',
 					})
 					.pipe(
@@ -164,9 +209,12 @@ export const persistInboundMessage = (args: {
 		`
 		const threadLinkId = threadLinks[0]?.id ?? null
 
-		// `idx_email_messages_imap_dedupe` makes the (inbox_id,
-		// uidvalidity, uid) tuple unique, so re-fetches of the same UID
-		// after a worker restart are no-ops.
+		// A message we already hold is left alone. Which rule says so is
+		// deliberately not named: reading the same folder position twice is one
+		// way, and meeting a Message-ID the organization already has is another
+		// — the same address on two mailboxes, say. Naming one of them would
+		// mean the other is refused instead, and a refusal here undoes the
+		// whole batch rather than skipping the one message.
 		const inserted = yield* sql<{ id: string }>`
 			INSERT INTO email_messages (
 				organization_id, inbox_id, folder, imap_uid, imap_uidvalidity,
@@ -190,11 +238,9 @@ export const persistInboundMessage = (args: {
 				})}::jsonb,
 				${JSON.stringify(args.attachments)}::jsonb,
 				'normal', now(),
-				'inbound', ${companyId}, ${contactId}
+				${args.direction}, ${companyId}, ${contactId}
 			)
-			ON CONFLICT (inbox_id, imap_uidvalidity, imap_uid)
-			  WHERE imap_uid IS NOT NULL
-			DO NOTHING
+			ON CONFLICT DO NOTHING
 			RETURNING id
 		`
 		const messageDbId = inserted[0]?.id
@@ -240,7 +286,11 @@ export const persistInboundMessage = (args: {
 		// matched no company: the history is read one company at a time, and
 		// a thread that starts unmatched is never re-homed, so nobody could
 		// ever reach such a row. The message itself is still stored.
-		if (companyId) {
+		//
+		// Only for mail that arrived: the sender of a message in the sent
+		// folder is us, so filing it here would show our own message as
+		// something the company said to us.
+		if (companyId && args.direction === 'inbound') {
 			yield* sql`
 				INSERT INTO timeline_activity (
 					organization_id, kind, entity_type, entity_id, company_id, contact_id,

--- a/apps/mail-worker/src/storage.test.ts
+++ b/apps/mail-worker/src/storage.test.ts
@@ -10,18 +10,56 @@ import { attachmentKey, rawMessageKey } from './storage'
 
 describe('rawMessageKey', () => {
 	describe('when given canonical inputs', () => {
-		it('should produce messages/<org>/<inbox>/<uidv>/<uid>.eml', () => {
+		it('should produce messages/<org>/<inbox>/<folder>/<uidv>/<uid>.eml', () => {
 			// GIVEN canonical inputs
 			// WHEN rawMessageKey runs
 			const key = rawMessageKey({
 				organizationId: 'org-1',
 				inboxId: 'inbox-1',
+				folder: 'INBOX',
 				uidValidity: 12345,
 				uid: 67,
 			})
 			// THEN the format is the worker contract
-			// [storage.ts:18]
-			expect(key).toBe('messages/org-1/inbox-1/12345/67.eml')
+			expect(key).toBe('messages/org-1/inbox-1/INBOX/12345/67.eml')
+		})
+	})
+
+	describe('when two folders hand out the same numbering', () => {
+		it('should keep their messages apart', () => {
+			// GIVEN the same message number in two folders of one mailbox — which
+			// a server is free to do, since a number only means anything within
+			// its own folder
+			const shared = {
+				organizationId: 'org-1',
+				inboxId: 'inbox-1',
+				uidValidity: 12345,
+				uid: 67,
+			}
+
+			// WHEN each is named for storage
+			const inbox = rawMessageKey({ ...shared, folder: 'INBOX' })
+			const sent = rawMessageKey({ ...shared, folder: 'Sent' })
+
+			// THEN they are stored apart, so neither is written over the other
+			expect(inbox).not.toBe(sent)
+		})
+	})
+
+	describe('when the folder name is not safe to put in a key', () => {
+		it('should reduce it to something that is', () => {
+			// GIVEN a provider whose folder name carries separators and spaces
+			// WHEN it is named for storage
+			const key = rawMessageKey({
+				organizationId: 'org-1',
+				inboxId: 'inbox-1',
+				folder: '[Gmail]/Sent Mail',
+				uidValidity: 1,
+				uid: 2,
+			})
+
+			// THEN the name cannot open a path of its own inside the key
+			expect(key).toBe('messages/org-1/inbox-1/_Gmail__Sent_Mail/1/2.eml')
 		})
 	})
 })
@@ -34,13 +72,13 @@ describe('attachmentKey', () => {
 			const key = attachmentKey({
 				organizationId: 'org-1',
 				inboxId: 'inbox-1',
+				folder: 'INBOX',
 				uidValidity: 12345,
 				uid: 67,
 				index: 0,
 			})
 			// THEN the key sits under the same message prefix as rawMessageKey
-			// [storage.ts:30]
-			expect(key).toBe('messages/org-1/inbox-1/12345/67/attachment-0.bin')
+			expect(key).toBe('messages/org-1/inbox-1/INBOX/12345/67/attachment-0.bin')
 		})
 
 		it('should use the supplied index for the suffix', () => {
@@ -51,11 +89,31 @@ describe('attachmentKey', () => {
 			const key = attachmentKey({
 				organizationId: 'org-1',
 				inboxId: 'inbox-1',
+				folder: 'INBOX',
 				uidValidity: 12345,
 				uid: 67,
 				index: 2,
 			})
 			expect(key).toContain('attachment-2.bin')
+		})
+	})
+
+	describe('when two folders hand out the same numbering', () => {
+		it('should keep their attachments apart', () => {
+			// GIVEN the same message number and position in two folders
+			const shared = {
+				organizationId: 'org-1',
+				inboxId: 'inbox-1',
+				uidValidity: 12345,
+				uid: 67,
+				index: 0,
+			}
+
+			// WHEN each is named for storage
+			// THEN neither attachment is written over the other
+			expect(attachmentKey({ ...shared, folder: 'INBOX' })).not.toBe(
+				attachmentKey({ ...shared, folder: 'Sent' }),
+			)
 		})
 	})
 })

--- a/apps/mail-worker/src/storage.ts
+++ b/apps/mail-worker/src/storage.ts
@@ -5,17 +5,27 @@ import { Context, Effect, Layer, Redacted } from 'effect'
 
 import { WorkerEnvVars } from './env.js'
 
+// A message's number is only its own within one folder, and two folders on the
+// same server can be handed the same starting point — so the folder has to be
+// part of what names a message here. Without it, message 7 of the sent folder
+// is stored over message 7 of the inbox, and one of them is gone for good.
+// Folder names travel over the wire and can hold anything, so they are reduced
+// to what is safe in a key before use.
+const folderSegment = (folder: string): string =>
+	folder.replace(/[^a-zA-Z0-9._-]/g, '_')
+
 // S3-compatible object store (R2 in prod, MinIO in dev). The worker
-// uploads raw RFC822 bytes under a stable key derived from inbox +
+// uploads raw RFC822 bytes under a stable key derived from inbox + folder +
 // uidvalidity + uid so a re-fetch of the same UID overwrites in place
 // (the bytes are identical) without spawning a duplicate object.
 export const rawMessageKey = (args: {
 	readonly organizationId: string
 	readonly inboxId: string
+	readonly folder: string
 	readonly uidValidity: number
 	readonly uid: number
 }): string =>
-	`messages/${args.organizationId}/${args.inboxId}/${args.uidValidity}/${args.uid}.eml`
+	`messages/${args.organizationId}/${args.inboxId}/${folderSegment(args.folder)}/${args.uidValidity}/${args.uid}.eml`
 
 // Per-attachment object key. Sibling of the raw RFC822 under the same
 // message prefix, so a download is one GET (the read path never reaches
@@ -25,11 +35,12 @@ export const rawMessageKey = (args: {
 export const attachmentKey = (args: {
 	readonly organizationId: string
 	readonly inboxId: string
+	readonly folder: string
 	readonly uidValidity: number
 	readonly uid: number
 	readonly index: number
 }): string =>
-	`messages/${args.organizationId}/${args.inboxId}/${args.uidValidity}/${args.uid}/attachment-${args.index}.bin`
+	`messages/${args.organizationId}/${args.inboxId}/${folderSegment(args.folder)}/${args.uidValidity}/${args.uid}/attachment-${args.index}.bin`
 
 export class RawMessageStorage extends Context.Service<RawMessageStorage>()(
 	'RawMessageStorage',

--- a/apps/server/src/db/migrations/0061_email_dedupe_per_folder.ts
+++ b/apps/server/src/db/migrations/0061_email_dedupe_per_folder.ts
@@ -1,0 +1,37 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Tell two folders' messages apart when they are numbered the same.
+//
+// A message's number is only its own within one folder. Two folders on the same
+// server are free to hand out the same numbers, and often do: the number a
+// server starts a folder at is commonly taken from the clock when the folder was
+// made, and a mailbox's folders are usually made in the same second.
+//
+// The rule that stops the same message being stored twice was written without
+// the folder, so message 7 of the sent folder counted as message 7 of the inbox
+// already stored — and was dropped. Nothing said so; the message was simply
+// never there. This became reachable when the sent folder started being read on
+// providers that do not call it "Sent".
+//
+// The old rule is replaced rather than kept alongside: while both exist the old
+// one still refuses the second folder's message, which is the whole problem.
+// Nothing in the application names this index when it stores a message — it asks
+// only that a message it already holds be left alone, whichever rule says so —
+// so replacing it needs no matching change to shipped code, in either order.
+//
+// expand-contract: the drop and the replacement sit in one migration, and in the
+// moment between them two folders could both store a message that is really one.
+// That window is a single statement wide and costs a duplicate row, where
+// leaving the old rule in place costs a message.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_email_messages_imap_dedupe_folder
+		ON email_messages(inbox_id, folder, imap_uidvalidity, imap_uid)
+		WHERE imap_uid IS NOT NULL
+	`
+	yield* sql`DROP INDEX IF EXISTS idx_email_messages_imap_dedupe`
+})

--- a/apps/server/src/services/email-outbound-body.integration.test.ts
+++ b/apps/server/src/services/email-outbound-body.integration.test.ts
@@ -1,0 +1,372 @@
+// What we sent has to be readable afterwards. The wire bytes go to object
+// storage and everything else only exists in the recipient's mailbox, so if the
+// send path does not write the body to the message row, the thread shows an
+// empty card and nothing anywhere can fill it back in.
+
+// PgLive reads DATABASE_URL at layer-build time (no default). Set it so the
+// suite runs without a loaded .env, matching the other integration tests.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { CurrentOrg, SessionContext } from '@batuda/controllers'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+import { CalendarService } from './calendar.js'
+import { CredentialCrypto } from './credential-crypto.js'
+import { EmailService } from './email.js'
+import { EmailAttachmentStaging } from './email-attachment-staging.js'
+import { DraftStore } from './email-draft-store.js'
+import { EmailProvider } from './email-provider.js'
+import { MailTransport } from './mail-transport.js'
+import { StorageProvider } from './storage-provider.js'
+import { TimelineActivityService } from './timeline-activity.js'
+
+const ORG = 'outbound-body-test-org'
+const USER = 'outbound-body-user'
+const SENT_MESSAGE_ID = '<outbound-body-test@taller.test>'
+
+const stubCrypto = Layer.succeed(CredentialCrypto, {
+	encryptPassword: () => ({
+		ciphertext: new Uint8Array([0]),
+		nonce: new Uint8Array([0]),
+		tag: new Uint8Array([0]),
+	}),
+	decryptPassword: () => 'stubbed-password',
+} as never)
+
+// Accepts the message and hands back a Message-ID the way SMTP does, so the
+// row under test is keyed the same way production keys it.
+const stubTransport = Layer.succeed(MailTransport, {
+	probe: () => Effect.void,
+	send: () =>
+		Effect.succeed({
+			messageId: SENT_MESSAGE_ID,
+			raw: new Uint8Array([0]),
+		}),
+	appendToSent: () => Effect.void,
+} as never)
+
+const stubStorage = Layer.succeed(StorageProvider, {
+	put: () => Effect.void,
+} as never)
+
+const stubStaging = Layer.succeed(EmailAttachmentStaging, {
+	resolve: () => Effect.succeed([]),
+	markSentAndCleanup: () => Effect.void,
+} as never)
+
+const stubTimeline = Layer.succeed(TimelineActivityService, {
+	record: () => Effect.void,
+} as never)
+
+const serviceLayer = EmailService.layer.pipe(
+	Layer.provide([
+		stubCrypto,
+		stubTransport,
+		stubStorage,
+		stubStaging,
+		stubTimeline,
+		Layer.succeed(EmailProvider, {} as never),
+		DraftStore.layer.pipe(Layer.provide(PgLive)),
+		Layer.succeed(CalendarService, {} as never),
+	]),
+	Layer.provide(PgLive),
+)
+
+const actingAs = Layer.mergeAll(
+	Layer.succeed(CurrentOrg, {
+		id: ORG,
+		name: 'Outbound Body Test',
+		slug: 'outbound-body-test',
+		role: 'owner',
+	}),
+	Layer.succeed(SessionContext, {
+		userId: USER,
+		email: `${USER}@test.local`,
+		name: undefined,
+		isAgent: false,
+	}),
+)
+
+// Run the way a request does, inside the organization's own database scope.
+const run = <A, E>(
+	effect: Effect.Effect<
+		A,
+		E,
+		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
+	>,
+) =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, {
+				org: {
+					id: ORG,
+					name: 'Outbound Body Test',
+					slug: 'outbound-body-test',
+				} as never,
+				userId: USER,
+				role: 'owner',
+			})(effect.pipe(Effect.provide(serviceLayer), Effect.provide(actingAs)))
+		}).pipe(Effect.provide(PgLive)),
+	)
+
+const placeholder = new Uint8Array([0])
+
+const sqlOnly = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
+	Effect.runPromise(effect.pipe(Effect.provide(PgLive)))
+
+let inboxId = ''
+let companyId = ''
+
+const storedMessage = () =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<{
+				direction: string
+				textBody: string | null
+				htmlBody: string | null
+				textPreview: string | null
+			}>`
+				SELECT direction, text_body, html_body, text_preview
+				FROM email_messages
+				WHERE organization_id = ${ORG} AND message_id = ${SENT_MESSAGE_ID}
+			`
+			return rows[0]
+		}),
+	)
+
+beforeAll(async () => {
+	await sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			// Better Auth owns this table, so its columns are camelCase.
+			yield* sql`
+				INSERT INTO organization (id, name, slug, "createdAt")
+				VALUES (${ORG}, 'Outbound Body Test', 'outbound-body-test', now())
+				ON CONFLICT (id) DO NOTHING
+			`
+			const companies = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, name, slug)
+				VALUES (${ORG}, 'Recipient Co', 'recipient-co')
+				ON CONFLICT (organization_id, slug) DO UPDATE SET name = EXCLUDED.name
+				RETURNING id
+			`
+			companyId = companies[0]!.id
+			const inboxes = yield* sql<{ id: string }>`
+				INSERT INTO inboxes (
+					organization_id, email, owner_user_id, is_default, is_private,
+					imap_host, imap_port, imap_security,
+					smtp_host, smtp_port, smtp_security, username,
+					password_ciphertext, password_nonce, password_tag,
+					grant_status, active
+				) VALUES (
+					${ORG}, 'sender@taller.test', ${USER}, true, false,
+					'imap.test', 993, 'tls', 'smtp.test', 465, 'tls', 'sender@taller.test',
+					${placeholder}, ${placeholder}, ${placeholder},
+					'connected', true
+				)
+				RETURNING id
+			`
+			inboxId = inboxes[0]!.id
+		}),
+	)
+})
+
+// A conversation already under way, so replying has something to answer.
+// Written straight to the database: how it got there is not what is under test.
+const PARENT_MESSAGE_ID = '<outbound-body-parent@client.test>'
+
+const seedThreadToReplyTo = () =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const links = yield* sql<{ id: string }>`
+				INSERT INTO email_thread_links (
+					organization_id, inbox_id, external_thread_id, company_id, subject, status
+				) VALUES (
+					${ORG}, ${inboxId}, ${PARENT_MESSAGE_ID}, ${companyId},
+					'Quote for the booking module', 'open'
+				)
+				RETURNING id
+			`
+			yield* sql`
+				INSERT INTO email_messages (
+					organization_id, inbox_id, folder, message_id, "references",
+					subject, received_at, recipients, attachments,
+					status, status_updated_at, direction, raw_rfc822_ref
+				) VALUES (
+					${ORG}, ${inboxId}, 'INBOX', ${PARENT_MESSAGE_ID}, ${[] as string[]},
+					'Quote for the booking module', now(),
+					${JSON.stringify({ to: ['client@example.com'], cc: [], bcc: [] })}::jsonb,
+					'[]'::jsonb, 'normal', now(), 'inbound', 'sentinel'
+				)
+			`
+			return links[0]!.id
+		}),
+	)
+
+beforeEach(async () => {
+	await sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`DELETE FROM email_messages WHERE organization_id = ${ORG}`
+			yield* sql`DELETE FROM email_thread_links WHERE organization_id = ${ORG}`
+		}),
+	)
+})
+
+afterAll(async () => {
+	await sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`DELETE FROM email_messages WHERE organization_id = ${ORG}`
+			yield* sql`DELETE FROM email_thread_links WHERE organization_id = ${ORG}`
+			yield* sql`DELETE FROM inboxes WHERE organization_id = ${ORG}`
+			yield* sql`DELETE FROM companies WHERE organization_id = ${ORG}`
+			yield* sql`DELETE FROM organization WHERE id = ${ORG}`
+		}),
+	)
+})
+
+describe('EmailService.send', () => {
+	describe('when a message is sent', () => {
+		it('should store what the recipient was sent, so the thread can be read back', async () => {
+			// GIVEN a message with a sentence someone will want to re-read
+			// WHEN it is sent
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.send(
+						inboxId,
+						'client@example.com',
+						'Quote for the booking module',
+						[
+							{
+								type: 'paragraph',
+								spans: [{ kind: 'text', value: 'The quote is attached.' }],
+							},
+						],
+						companyId,
+					)
+				}),
+			)
+
+			// THEN the row carries the body in both forms, and a summary line
+			const stored = await storedMessage()
+			expect(stored?.direction).toBe('outbound')
+			expect(stored?.textBody).toContain('The quote is attached.')
+			expect(stored?.htmlBody).toContain('The quote is attached.')
+			expect(stored?.textPreview).toContain('The quote is attached.')
+		})
+
+		it('should cut the summary to the same length arriving mail uses', async () => {
+			// GIVEN a body longer than the 200-character summary
+			// [persist.ts — inbound uses text.slice(0, 200)]
+			const long = 'x'.repeat(500)
+
+			// WHEN it is sent
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.send(
+						inboxId,
+						'client@example.com',
+						'Long one',
+						[{ type: 'paragraph', spans: [{ kind: 'text', value: long }] }],
+						companyId,
+					)
+				}),
+			)
+
+			// THEN the stored summary stops at 200 characters while the body keeps
+			// everything
+			const stored = await storedMessage()
+			expect(stored?.textPreview).toHaveLength(200)
+			expect(stored?.textBody).toContain(long)
+		})
+	})
+})
+
+// Replying is the commonest way a message goes out, and a draft is what the
+// compose form sends. Each writes the row through its own call, so a body kept
+// on one says nothing about the others.
+
+describe('EmailService.reply', () => {
+	describe('when a reply is sent', () => {
+		it('should store what the recipient was sent', async () => {
+			// GIVEN a thread already carrying a message to reply to
+			const threadId = await seedThreadToReplyTo()
+
+			// WHEN a reply goes out on it
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.reply(threadId, [
+						{
+							type: 'paragraph',
+							spans: [{ kind: 'text', value: 'Sending the revised figure.' }],
+						},
+					])
+				}),
+			)
+
+			// THEN the reply is readable afterwards, not an empty card
+			const stored = await storedMessage()
+			expect(stored?.direction).toBe('outbound')
+			expect(stored?.textBody).toContain('Sending the revised figure.')
+			expect(stored?.htmlBody).toContain('Sending the revised figure.')
+			expect(stored?.textPreview).toContain('Sending the revised figure.')
+		})
+	})
+})
+
+describe('EmailService.sendDraft', () => {
+	describe('when a saved draft is sent', () => {
+		it('should store what the recipient was sent', async () => {
+			// GIVEN a draft someone wrote and saved
+			const draftId = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					const draft = yield* svc.createDraft(
+						inboxId,
+						{
+							to: ['client@example.com'],
+							subject: 'From a draft',
+							bodyJson: [
+								{
+									type: 'paragraph',
+									spans: [
+										{ kind: 'text', value: 'Written earlier, sent now.' },
+									],
+								},
+							],
+						},
+						{ companyId },
+					)
+					return draft.draftId
+				}),
+			)
+
+			// WHEN it is sent
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.sendDraft(inboxId, draftId)
+				}),
+			)
+
+			// THEN the sent draft is readable afterwards
+			const stored = await storedMessage()
+			expect(stored?.direction).toBe('outbound')
+			expect(stored?.textBody).toContain('Written earlier, sent now.')
+			expect(stored?.htmlBody).toContain('Written earlier, sent now.')
+		})
+	})
+})

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -915,6 +915,11 @@ export class EmailService extends Context.Service<EmailService>()(
 					externalThreadId: string
 				} | null
 				rawRfc822Ref: string
+				// What the recipient was sent. Kept on the row because the only
+				// other copies are the wire bytes in object storage and whatever
+				// sits in their mailbox.
+				textBody: string | null
+				htmlBody: string | null
 			}) =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
@@ -970,9 +975,12 @@ export class EmailService extends Context.Service<EmailService>()(
 									rawRfc822Ref: args.rawRfc822Ref,
 									subject: args.subject,
 									receivedAt: sentAt,
-									textPreview: null,
-									textBody: null,
-									htmlBody: null,
+									// Same 200-character cut arriving mail uses, so a message
+									// summarises the same way whichever way it went.
+									textPreview:
+										args.textBody === null ? null : args.textBody.slice(0, 200),
+									textBody: args.textBody,
+									htmlBody: args.htmlBody,
 									companyId: args.companyId,
 									contactId: args.contactId,
 									recipients: JSON.stringify({
@@ -1128,6 +1136,8 @@ export class EmailService extends Context.Service<EmailService>()(
 							bcc,
 							existingThreadLink: null,
 							rawRfc822Ref: dispatched.rawRef,
+							textBody: rendered.text,
+							htmlBody: rendered.html,
 						})
 
 						if (staged.length > 0) {
@@ -1308,6 +1318,8 @@ export class EmailService extends Context.Service<EmailService>()(
 								externalThreadId: link.externalThreadId,
 							},
 							rawRfc822Ref: dispatched.rawRef,
+							textBody: rendered.text,
+							htmlBody: rendered.html,
 						})
 
 						if (staged.length > 0) {
@@ -2783,6 +2795,8 @@ export class EmailService extends Context.Service<EmailService>()(
 							bcc: draft.bccAddresses as string[],
 							existingThreadLink,
 							rawRfc822Ref: dispatched.rawRef,
+							textBody: rendered.text,
+							htmlBody: rendered.html,
 						})
 
 						if (staged.length > 0) {

--- a/apps/server/src/services/mail-transport.ts
+++ b/apps/server/src/services/mail-transport.ts
@@ -244,22 +244,23 @@ export class MailTransport extends Context.Service<MailTransport>()(
 					})
 					yield* Effect.tryPromise({
 						try: async () => {
-							// Most providers expose a "Sent" mailbox; Gmail uses
-							// "[Gmail]/Sent Mail" — imapflow's special-use lookup
-							// resolves either via the SPECIAL-USE attribute. Dev mail
-							// catchers (GreenMail) and providers without a Sent folder
-							// resolve neither; skip the APPEND (the message already went
-							// out over SMTP) instead of erroring.
-							const box =
-								(await imap
-									.getMailboxLock('Sent', { readOnly: false })
-									.catch(() => null)) ??
-								(await imap
-									.getMailboxLock('[Gmail]/Sent Mail', { readOnly: false })
-									.catch(() => null))
+							// Ask the server which of its folders holds sent mail rather
+							// than guessing at the name: Gmail calls it
+							// "[Gmail]/Sent Mail" and Outlook "Sent Items". Dev mail
+							// catchers (GreenMail) and providers without one have no
+							// answer; skip the APPEND (the message already went out over
+							// SMTP) instead of erroring.
+							const boxes = await imap.list().catch(() => [])
+							const sentPath =
+								boxes.find(entry => entry.specialUse === '\\Sent')?.path ??
+								boxes.find(entry => entry.path === 'Sent')?.path
+							if (sentPath === undefined) return
+							const box = await imap
+								.getMailboxLock(sentPath, { readOnly: false })
+								.catch(() => null)
 							if (!box) return
 							try {
-								await imap.append('Sent', Buffer.from(raw), ['\\Seen'])
+								await imap.append(sentPath, Buffer.from(raw), ['\\Seen'])
 							} finally {
 								box.release()
 							}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -735,6 +735,10 @@ Sign-in is unaffected: `POST /auth/sign-in/email` still works for any existing u
 
 Outbound email (outreach, follow-ups, replies) goes through a bring-your-own IMAP/SMTP mailbox — `nodemailer` over SMTP for the send, then an IMAP `APPEND` into the Sent folder. Inbound + bounce handling runs in `apps/mail-worker` (one IMAP `IDLE` per inbox); per-inbox credentials are AES-256-GCM-encrypted on the `inboxes` row. Authoring on both ends — humans in the web app's compose form, AI agents via MCP — converges on a single typed block tree, rendered through shared primitives in `packages/email`. SMTP carries the final MIME; Batuda owns the authoring surface and the rendering pipeline.
 
+The send path stores the rendered `text` and `html` on the `email_messages` row alongside the wire bytes it puts in object storage. It has to: SMTP is one-way, so a message whose body is only in the recipient's mailbox cannot be read back here, and the thread view would show an empty card. `pnpm cli email backfill-bodies` fills in messages sent before this was true, reading each one back from storage.
+
+The worker syncs two folders per inbox, and which one a message came from decides its direction — inbox means it arrived, sent folder means we sent it. Folders are matched on the IMAP special-use flags the server reports (`\Inbox`, `\Sent`) rather than their names, because Gmail calls its sent folder `[Gmail]/Sent Mail` and Outlook `Sent Items`; matching by name syncs no sent mail at all on either. `resolveTrackedFolders` in `apps/mail-worker/src/inbox-session.ts` settles this once per session and hands the answer down, so nothing lower has to re-derive it from a folder name. Only mail that arrived is written to a company's history — what we send is recorded where it is sent from.
+
 ### Package layout — `packages/email`
 
 Shared Node+browser library, consumed by `apps/server` (render at send time), `apps/internal` (compose + footer editors), and `packages/controllers` (HTTP schema).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102
+      mailparser:
+        specifier: ^3.9.8
+        version: 3.9.8
       nodemailer:
         specifier: ^8.0.7
         version: 8.0.7
@@ -145,6 +148,9 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
+      '@types/mailparser':
+        specifier: ^3.4.6
+        version: 3.4.6
       '@types/node':
         specifier: ^22.15.0
         version: 22.19.15


### PR DESCRIPTION
## What

Emails I send were showing as empty cards. Opening a sent message in `/emails` gave the sender, the recipient and the date, and then nothing — the message itself was gone. It had never been kept: the send path composed the message, handed it to the mail server, and wrote only its headers to our own record. Since sending is one-way, and the raw bytes we keep in object storage are not what the reader reads, nothing anywhere could fill that gap in. On my own organization, twelve sent messages are blank right now.

Working on that turned up a second, larger problem in the same area. The mail worker reads two folders per mailbox — the inbox, and the folder the server keeps sent mail in — and it was mishandling the second one in six separate ways, from mislabelling messages to silently overwriting one message's stored copy with another's. This PR fixes the reported bug and all six.

Surfaces: `server` (the send path), `mail-worker` (reading folders), `cli` (a one-off repair command).

## The fix

- **What we send is now kept.** All three ways of sending write the message body to the record, including sending a saved draft — the path the compose form actually uses. As a side effect, sent mail becomes searchable for the first time, since search reads that column.
- **Which way a message went is settled from the folder's purpose**, as the server reports it, rather than assumed. Everything read over IMAP was previously recorded as having arrived, so mail sent from a phone or webmail appeared in the thread as though the other side had written it — and made the conversation look unread. Purpose comes from the server because Gmail calls its sent folder `[Gmail]/Sent Mail` and Outlook `Sent Items`; matching on the name alone finds neither.
- **Two folders can no longer stand in for each other.** A message's number only means anything inside its own folder, and two folders on one server are free to hand out the same ones — commonly do, since the number a folder starts at is usually taken from the clock when it was made. The stored copy of message 7 in the sent folder was written over message 7 of the inbox, and the database counted the second as the first and dropped it. One message lost, and another's archived copy replaced by a stranger's.
- **A message we already hold no longer costs the whole batch.** Our own sent message, met again in the sent folder, was refused for reusing its Message-ID — and that refusal rolled back every message read alongside it, not just the one. It is now filled in where it already stands.
- **A message arriving without a Message-ID gets one taken from its own bytes.** They all shared the empty string before, so the first to arrive claimed it and every later one was turned away.
- **Whose conversation a message belongs to comes from the other side of it.** Reading the sender of a message we sent only ever found ourselves. A conversation that starts unmatched is never re-homed, so a thread first seen in the sent folder stayed off that company's page permanently — even after they replied.
- **Arriving mail is noticed promptly again.** A server can only report on the folder being held open, and we held whichever was read last. While that was the sent folder, nothing arriving was seen until the poll timeout — up to 29 minutes. How far each folder has been read is also carried across passes now; it was read from a snapshot taken at connect time that never changed, so every pass re-fetched the entire backfill window and re-uploaded every message and attachment before reaching the database.
- **The copy of a sent message goes to the folder the server actually has**, rather than to one named `Sent` regardless — on Gmail and Outlook that folder does not exist, so the copy was lost.
- **A repair command**, `pnpm cli email backfill-bodies`, reads already-sent messages back from object storage and fills in their bodies. Idempotent, with `--dry-run`.

## Impact

- **A migration must run before the server tag.** `0061_email_dedupe_per_folder` replaces the rule that decides when two stored messages are the same one. The deploy does not run migrations, and new server code on the old schema would keep dropping the second folder's messages. Nothing in the application names this index when storing a message, so the code and the schema are not coupled in either direction — but the fix is not real until the migration is applied.
- **Ship `mail-worker` and `server` together, migration first.** They are separate CalVer targets and the change spans both.
- **My production data is not repaired by merging this.** Twelve sent messages are still blank and need the new command run against production — which means pointing a local CLI at the production database *and* production storage credentials. Nineteen rows sitting in the sent folder are still labelled as having arrived and need a one-off update. I'd rather do both deliberately, with you, than fold them into a deploy.
- **Unread counts will change**, in two ways. Sent-folder messages stopped counting as arriving mail, so threads that were unread only because of your own sent mail become read. And the MCP agent guard that counts outbound messages per thread will see higher counts, which can start asking for confirmation before sending. Both are the correct state; both are visible.
- **No wire-shape or contract change**, no new environment variables, and no change to who can see what. The one new database predicate is bounded by organization and mailbox, and the new index is per-mailbox, so tenant isolation is unchanged.
- **Both transports get the send fix.** It lives in the shared email service, so HTTP and MCP behave the same.

## Review guide

Read in this order:

1. `apps/mail-worker/src/persist.ts` — the riskiest file. The `UPDATE … RETURNING` at the top is what stops a repeat message costing the batch; note it is scoped by organization *and* mailbox, and returns early because everything else was already done when the message was sent.
2. `apps/server/src/db/migrations/0061_email_dedupe_per_folder.ts` — the header explains why the old rule is replaced rather than kept alongside. Keeping both would leave the old one still refusing the second folder's message, which is the whole problem.
3. `apps/mail-worker/src/inbox-session.ts` — `resolveTrackedFolders`, then the session loop. The waiting moved out of the per-folder step into the caller.

Two decisions you might overrule:

- **Storing a message no longer names which uniqueness rule it expects.** A bare `ON CONFLICT DO NOTHING` catches any of them. Naming one meant any other refusing instead, and a refusal there costs the batch rather than the message — but it does mean a genuine duplicate is skipped silently.
- **Folder discovery by purpose is in this PR**, not held back. It means a Gmail or Outlook mailbox starts syncing its sent folder for the first time. Everything that made that unsafe is fixed here, which is why I kept them together — but it is a real widening, and your own mailboxes were already syncing theirs.

Skip-able: the test files are additive, and `storage.test.ts` is mechanical.

Not run: Snyk was not available in this session.

## Tests

Nine new cases in the mail worker covering folder resolution across GreenMail, Gmail and Outlook layouts; the sent-vs-arrived split; a message we already hold; two folders numbering the same; and attribution from the other side of the conversation. Four in the server covering all three send paths.

I checked the important ones actually catch a regression by reverting the code and watching them fail — the two send-path tests, the direction hand-off, and the enrich. My first attempt at that check was too weak to prove anything, so I redid it.

The session-loop change (waiting on the inbox, carrying folder progress) has **no test** — it needs an IMAP client stub I did not build. It is verified by reading and against the live stack only.

## Verification

- `pnpm install`, `pnpm check-types`, `pnpm test`, `pnpm build` — all green after rebasing onto current `origin/main`.
- 24 mail-worker integration tests and 74 server integration tests, including the multi-organization isolation suite that pins the Message-ID rule.
- Migration applied to a worktree database; confirmed the old index is gone and the folder-scoped one is in.
- Sent a real message through the running stack afterwards and confirmed the body is stored, and that the thread reads back through the API.
- Ran the repair command against a genuinely empty message: filled it, reported nothing left on a second run, reported a missing stored copy softly, and failed loudly with the real reason on a bad credential.

No screenshots: this PR touches no UI.

## Deferred

- Read state, filed as #415 — Batuda never reads or writes the mail server's own read marker, and its record of what is read has no notion of *who* read it, so one person opening a shared thread clears it for everyone.
- Three surfaces (`list_email_messages`, `get_email_message`, `download_email_attachment`) are scoped by organization but ignore whether a mailbox is private, so marking one private does not hide its bodies or attachments. Pre-existing, worth its own issue before any privacy work.
- Sent attachments still show no chips, and an inline image in a sent message renders broken rather than blank, because the stored copy points at parts the browser cannot resolve.
