### PR TITLE
fix(server): judge a send by the address it is going to

### DIFF
--- a/.claude/skills/crm/SKILL.md
+++ b/.claude/skills/crm/SKILL.md
@@ -137,3 +137,4 @@ For detailed field values, workflows, and examples, consult:
 - **`references/contacts.md`** — Correcting and removing one channel, primary election, how far an address is trusted vs whether it bounced
 - **`references/interactions.md`** — Channel/direction/type/outcome values, log_interaction example, next_action workflow
 - **`references/documents.md`** — Document types, research workflow, pages (Tiptap JSON, publish flow), tasks
+- **`references/email.md`** — The three outcomes of a send, which deliverability verdicts stop one and which do not, and how to see a stopped send coming

--- a/.claude/skills/crm/references/contacts.md
+++ b/.claude/skills/crm/references/contacts.md
@@ -60,5 +60,11 @@ a check that settled nothing. Saying an address is good is something a check
 finds out by reaching the mailbox, so `deliverable` is refused from a caller. A
 later check can raise it again.
 
+To get a send out that a verdict is holding back, use `action: "vouch"` rather
+than trying to argue with the verdict. It records that a person stands behind the
+address and leaves the check's own finding alone — the two are different claims,
+and only one of them is something a human can make. It is refused on an address
+that hard-bounced or reported spam; see `references/email.md`.
+
 This is a different thing from a bounce. `status` records what happened *after*
 a send; `clear_email_suppression` on `update_contact` is what resets that.

--- a/.claude/skills/crm/references/email.md
+++ b/.claude/skills/crm/references/email.md
@@ -1,0 +1,73 @@
+# Sending email
+
+`send_email`, `reply_email` and `manage_email_draft(action: "send")` all answer with one of three outcomes.
+Read the `_tag` — none of them throws, so a send that never went out looks like a success unless you look.
+
+| `_tag`       | What happened                                                         |
+| ------------ | --------------------------------------------------------------------- |
+| `sent`       | It went out. Carries `messageId` and `threadId`.                      |
+| `suppressed` | Refused outright: the address once hard-bounced or reported spam.     |
+| `cancelled`  | Nothing was sent, because a confirmation was needed and not obtained. |
+
+## What is a hard block and what is not
+
+`suppressed` is the real block.
+It is asked of the address rather than of whoever holds it, across the whole organisation, and it applies to every way of sending — including a person composing in the web app.
+The only way back is `update_contact` with `clear_email_suppression=true`, after the person confirms their address is good again.
+
+`cancelled` is a soft guard and only ever applies to an assistant.
+It fires when:
+
+- an address being written to carries a deliverability verdict of `undeliverable` or `risky`, or a word the vocabulary does not recognise; or
+- (replies only) the thread already has `EMAIL_AGENT_SOFT_THREAD_LIMIT` outbound messages — three by default — and this reply would be one more.
+
+The `reason` says which of those it was, and says plainly when the client had no way to put the question to anybody at all.
+Neither Claude.ai nor ChatGPT can show a confirmation prompt today, so through those the answer is always the second kind.
+
+## What does not stop a send
+
+A deliverability verdict is not a verdict on the address unless it says something against it:
+
+| Verdict         | Stops a send | Why                                                                      |
+| --------------- | ------------ | ------------------------------------------------------------------------ |
+| `deliverable`   | No           | A mailbox answered.                                                      |
+| `catch_all`     | No           | The domain answers to every name, so the check learned nothing here.     |
+| `unknown`       | No           | A check ran and settled nothing — the same thing no verdict says.        |
+| *(no verdict)*  | No           | Nobody has checked. Most addresses on file are this.                     |
+| `risky`         | Yes          | Something is off: a full mailbox, a disposable domain, a stalled server. |
+| `undeliverable` | Yes          | The mailbox is not there.                                                |
+| anything else   | Yes          | The column takes free text, so an unrecognised word is unvetted.         |
+
+## Getting a held-back send out
+
+When a verdict does stop a send and you know the address is fine, vouch for it:
+
+```
+manage_contact_channels({ action: "vouch", contact_id, channel_id, note: "confirmed on the phone" })
+manage_company_channels({ action: "vouch", company_id, channel_id, note: "..." })
+```
+
+That records a person standing behind the address, and the guard stops asking about it.
+It does not touch what the check found — the two are different claims, and only one of them is something a human can make.
+It settles the address rather than the row, so vouching once covers the same mailbox wherever else it is recorded.
+
+You do not have to hunt for the `channel_id`: a stopped send names the exact call that lifts it in its `reason`.
+
+`action: "unvouch"` takes a vouch back when somebody changes their mind. It only ever lifts a vouch — it never clears a bounce.
+
+A vouch is refused on an address that hard-bounced or reported spam.
+That block is real, it lives in the same place a vouch is written, and lifting it by vouching would quietly re-open the address for the whole organisation.
+Use `update_contact` with `clear_email_suppression=true` once the person confirms the address works again — that returns it to "nobody has checked", not to "somebody vouched".
+
+## The thread message count
+
+`reply_email` also stops when a thread already holds several outbound messages (`EMAIL_AGENT_SOFT_THREAD_LIMIT`, three by default).
+That one is not about an address, so there is nothing to vouch for: pass `acknowledge_thread_length: true` on the reply when the person has said to keep going.
+It answers only the count — an address with something recorded against it still stops the send — and nothing is remembered, so a later reply on the same thread asks again.
+
+## Seeing it coming
+
+Read `verification` on the channels a contact carries (`list_contacts`) before composing, rather than discovering it on the send.
+A batch is where this matters: finding out one address at a time, after writing each message, wastes the writing.
+
+Note that the verdict is read from **the address being written to**, not from the person — so a contact with a cleared default address and a second address marked `risky` will still stop a send addressed to the second one.

--- a/apps/mail-worker/src/bounces.integration.test.ts
+++ b/apps/mail-worker/src/bounces.integration.test.ts
@@ -204,6 +204,49 @@ describe('applyBounce', () => {
 			expect(rows.rows.length).toBe(1)
 			expect(rows.rows[0]?.contact_id).toBeNull()
 		})
+
+		it('should suppress a company mailbox, which belongs to nobody', async () => {
+			// GIVEN a company's own orders mailbox — no person holds it — and a
+			// message to it that came back undelivered. Marking only the addresses
+			// belonging to contacts left this one unsuppressed, so mail kept going
+			// to a mailbox the far end had already said was not there.
+			const orders = `comandes@${DOMAIN}`
+			await pool.query(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address)
+				 VALUES ($1, 'companies', $2, 'email', $3)`,
+				[ORG_ID, companyId, orders],
+			)
+			const messageId = await seedOutbound()
+
+			// WHEN the bounce is applied
+			await apply(bounceFor(messageId, [orders]))
+
+			// THEN the address is suppressed, so the send path refuses it from now
+			// on — the same question it asks of a person's address
+			const row = await pool.query<{ status: string; reason: string }>(
+				`SELECT status, status_reason AS reason FROM channels
+				 WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG_ID, orders],
+			)
+			expect(row.rows[0]?.status).toBe('bounced')
+			expect(row.rows[0]?.reason).not.toBeNull()
+		})
+
+		it('should count only people as contacts touched', async () => {
+			// GIVEN a company mailbox bouncing, with no person holding it
+			const depot = `depot@${DOMAIN}`
+			await pool.query(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address)
+				 VALUES ($1, 'companies', $2, 'email', $3)`,
+				[ORG_ID, companyId, depot],
+			)
+			const messageId = await seedOutbound()
+
+			// THEN suppressing it touches nobody's timeline, and says so, rather
+			// than reporting a person who was never involved
+			const result = await apply(bounceFor(messageId, [depot]))
+			expect(result.contactsTouched).toBe(0)
+		})
 	})
 
 	describe('when the bounce names nothing we sent', () => {

--- a/apps/mail-worker/src/bounces.ts
+++ b/apps/mail-worker/src/bounces.ts
@@ -174,7 +174,18 @@ export const applyBounce = (args: {
 		const recipients = bounce.recipients as unknown as string[]
 		// Suppression lives on the email channel now; match by address and
 		// scope to this org explicitly (the worker runs BYPASSRLS).
-		const updatedContacts = yield* sql<{ id: string; companyId: string }>`
+		//
+		// Asked of the address, not of whoever holds it. A company's orders
+		// mailbox and a branch's own address bounce exactly like a person's, and
+		// while this only marked the rows belonging to contacts, those never came
+		// back suppressed — so mail kept going to a mailbox the far end had
+		// already said was not there. The send gate looks a bounced address up
+		// across the whole organisation without asking whose it is, so marking
+		// them all is what it was expecting to find.
+		const suppressed = yield* sql<{
+			subjectTable: string
+			subjectId: string
+		}>`
 			UPDATE channels ch
 			SET status = ${isHard ? 'bounced' : sql.literal('status')},
 			    status_reason = ${bounce.diagnostic},
@@ -183,14 +194,26 @@ export const applyBounce = (args: {
 			      WHEN ${isHard} THEN ch.soft_bounce_count
 			      ELSE ch.soft_bounce_count + 1
 			    END
-			FROM contacts c
-			WHERE ch.subject_table = 'contacts'
-			  AND ch.subject_id = c.id
-			  AND ch.channel = 'email'
+			WHERE ch.channel = 'email'
 			  AND ch.organization_id = ${organizationId}
 			  AND lower(ch.address) = ANY(${recipients})
-			RETURNING c.id, c.company_id
+			RETURNING ch.subject_table, ch.subject_id
 		`
+
+		// A bounce shows on a person's timeline, so the people among them are
+		// picked out here. An address belonging to a company or a branch is
+		// suppressed just the same and simply has no personal timeline to appear
+		// on; the contact-less row below is what carries it.
+		const bouncedContactIds = suppressed
+			.filter(row => row.subjectTable === 'contacts')
+			.map(row => row.subjectId)
+		const updatedContacts =
+			bouncedContactIds.length === 0
+				? []
+				: yield* sql<{ id: string; companyId: string }>`
+						SELECT c.id, c.company_id FROM contacts c
+						WHERE c.id = ANY(${bouncedContactIds as unknown as string[]})
+					`
 
 		// Soft-bounce promotion: if the rolling 7-day soft bounce count
 		// crosses 3, promote to hard bounce. Threshold is checked here

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -232,6 +232,11 @@ export const persistMessage = (args: {
 				${args.parsed.textBody}, ${args.parsed.htmlBody}, ${args.parsed.textPreview},
 				${args.rawRfc822Ref},
 				${JSON.stringify({
+					// Who it came from, kept alongside who it went to. A reply is
+					// addressed to the sender of what it answers, and on an inbound
+					// message the `to` is our own mailbox — so without this the only
+					// address on file to reply to is ours.
+					from: args.parsed.fromAddress,
 					to: args.parsed.toAddresses,
 					cc: args.parsed.ccAddresses,
 					bcc: args.parsed.bccAddresses,

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -29,6 +29,8 @@ import {
 	deleteSubjectChannels,
 	patchChannel,
 	subjectChannelsOf,
+	vouchForChannel,
+	withdrawVouch,
 } from '../../services/channels'
 import { CompanyService } from '../../services/companies'
 import { findDuplicateCompanies } from '../../services/company-duplicates'
@@ -278,9 +280,16 @@ const ManageCompanySites = Tool.make('manage_company_sites', {
 // switchboard only by `site_id`, so a second tool would duplicate the lot.
 const ManageCompanyChannels = Tool.make('manage_company_channels', {
 	description:
-		"The ways of reaching a company — its mailboxes, phones, website, social handles. A company can hold several of a kind, which is the point of this tool: `update_company` writes one email and one phone, and a firm with an orders mailbox, an accounts mailbox and a switchboard needs all of them kept apart. Give each one a `label` in the words somebody would actually use — 'orders', 'accounts', 'Girona shop' — because two addresses with no labels are indistinguishable a month later. Pass `site_id` to hang the channel off one branch instead of the company as a whole. action: 'list' (all of them; add site_id to see one branch's), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). An address the company already holds is refused rather than merged, so correcting one onto another means removing the spare instead. kind is open — email, phone, linkedin, instagram, website, x, bluesky, … — and `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind. `verification` only ever lowers how far an address is trusted, and only on 'update' — pass null to take a verdict back off entirely, which says nobody has checked rather than that a check came back doubtful. A later check can raise it again.",
+		"The ways of reaching a company — its mailboxes, phones, website, social handles. A company can hold several of a kind, which is the point of this tool: `update_company` writes one email and one phone, and a firm with an orders mailbox, an accounts mailbox and a switchboard needs all of them kept apart. Give each one a `label` in the words somebody would actually use — 'orders', 'accounts', 'Girona shop' — because two addresses with no labels are indistinguishable a month later. Pass `site_id` to hang the channel off one branch instead of the company as a whole. action: 'list' (all of them; add site_id to see one branch's), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). An address the company already holds is refused rather than merged, so correcting one onto another means removing the spare instead. kind is open — email, phone, linkedin, instagram, website, x, bluesky, … — and `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind. `verification` only ever lowers how far an address is trusted, and only on 'update' — pass null to take a verdict back off entirely, which says nobody has checked rather than that a check came back doubtful. A later check can raise it again. 'vouch' (by channel_id, email only) is the way to get a held-back send out: it records that a person stands behind the address, so send_email stops asking about it, while leaving what a deliverability check found on file — unlike clearing the verdict, which lifts the stop by throwing the finding away. Pass `note` to say what that rests on. It is refused on an address that hard-bounced or reported spam, which no vouch lifts. 'unvouch' takes a vouch back; it only ever lifts a vouch and never clears a bounce.",
 	parameters: Schema.Struct({
-		action: Schema.Literals(['list', 'add', 'update', 'remove']),
+		action: Schema.Literals([
+			'list',
+			'add',
+			'update',
+			'remove',
+			'vouch',
+			'unvouch',
+		]),
 		company_id: Schema.String,
 		site_id: Schema.optional(Schema.String),
 		channel_id: Schema.optional(Schema.String),
@@ -294,6 +303,9 @@ const ManageCompanyChannels = Tool.make('manage_company_channels', {
 			description:
 				"How far this address is trusted, and only ever downwards: 'risky' or 'undeliverable' to record doubt, 'unknown' for a check that settled nothing, or null to take a verdict back off entirely. An address is only ever called deliverable by a check that reached the mailbox.",
 		}),
+		// Why somebody stands behind the address, kept with the vouch so a later
+		// reader knows what it rested on.
+		note: Schema.optional(Schema.String),
 	}),
 	success: Schema.Struct({
 		channels: Schema.Array(Schema.Unknown),
@@ -647,6 +659,66 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 					}
 					if (params.action === 'remove' && params.channel_id !== undefined) {
 						yield* deleteChannel(sql, currentOrg.id, subject, params.channel_id)
+					}
+					if (params.action === 'unvouch') {
+						if (params.channel_id === undefined)
+							return yield* Effect.die(
+								new ToolMessage('channel_id is required to take back a vouch.'),
+							)
+						const outcome = yield* withdrawVouch(
+							sql,
+							currentOrg.id,
+							subject,
+							params.channel_id,
+						)
+						if (outcome === 'not_found')
+							return yield* Effect.die(
+								new ToolMessage(
+									`No channel ${params.channel_id} on this company.`,
+								),
+							)
+						if (outcome === 'not_vouched')
+							return yield* Effect.die(
+								new ToolMessage(
+									'Nobody had vouched for that address, so there is nothing to take back. A bounce is not a vouch and is not cleared from here.',
+								),
+							)
+					}
+					// Vouching is the documented way past a held-back send, so a call
+					// that names no channel must say so rather than hand back a normal
+					// list the caller reads as success before being stopped again.
+					if (params.action === 'vouch' && params.channel_id === undefined)
+						return yield* Effect.die(
+							new ToolMessage(
+								'channel_id is required to vouch for an address.',
+							),
+						)
+					if (params.action === 'vouch' && params.channel_id !== undefined) {
+						const outcome = yield* vouchForChannel(
+							sql,
+							currentOrg.id,
+							subject,
+							params.channel_id,
+							params.note,
+						)
+						if (outcome === 'not_found')
+							return yield* Effect.die(
+								new ToolMessage(
+									`No channel ${params.channel_id} on this company.`,
+								),
+							)
+						if (outcome === 'not_email')
+							return yield* Effect.die(
+								new ToolMessage(
+									'Only an email address is ever held back by a verdict, so only one can be vouched for.',
+								),
+							)
+						if (outcome === 'suppressed')
+							return yield* Effect.die(
+								new ToolMessage(
+									'That address hard-bounced or reported spam, which no vouch lifts.',
+								),
+							)
 					}
 					return { channels: yield* subjectChannelsOf(sql, subject) }
 				}).pipe(

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -21,6 +21,8 @@ import {
 	deleteChannel,
 	deleteSubjectChannels,
 	patchChannel,
+	vouchForChannel,
+	withdrawVouch,
 	writeChannels,
 } from '../../services/channels'
 import { requireLiveCompany } from '../../services/company-liveness'
@@ -128,9 +130,16 @@ const DeleteContact = Tool.make('delete_contact', {
 // union serialises to.
 const ManageContactChannels = Tool.make('manage_contact_channels', {
 	description:
-		"The ways of reaching one person — their mailboxes, phones, social handles — one at a time. This is where a wrong address is put right: update_contact's channels[] only ever adds, so an address corrected there leaves the old one sitting beside it, and deleting the person to start over detaches every email, meeting and interaction ever logged against them. action: 'list' (all of them), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). Renaming an address onto one this person already holds is refused rather than merged — remove the spare instead. `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind. `verification` only ever lowers how far an address is trusted, and only on 'update' — pass null to take a verdict back off entirely, which says nobody has checked rather than that a check came back doubtful. A later check can raise it again. Leaving somebody with no email address at all means a later research run or an inbound reply will not recognise them and may create a second copy of the same person.",
+		"The ways of reaching one person — their mailboxes, phones, social handles — one at a time. This is where a wrong address is put right: update_contact's channels[] only ever adds, so an address corrected there leaves the old one sitting beside it, and deleting the person to start over detaches every email, meeting and interaction ever logged against them. action: 'list' (all of them), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). Renaming an address onto one this person already holds is refused rather than merged — remove the spare instead. `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind. `verification` only ever lowers how far an address is trusted, and only on 'update' — pass null to take a verdict back off entirely, which says nobody has checked rather than that a check came back doubtful. A later check can raise it again. Leaving somebody with no email address at all means a later research run or an inbound reply will not recognise them and may create a second copy of the same person. action: 'vouch' (by channel_id, email only) is the way to get a held-back send out: it records that a person stands behind the address, so send_email stops asking about it, while leaving the check's own finding on file — unlike clearing the verdict, which lifts the stop by throwing the finding away. Pass `note` to say what that rests on. It is refused on an address that hard-bounced or reported spam — that block is real, and clearing it is update_contact's clear_email_suppression. action: 'unvouch' takes a vouch back; it only ever lifts a vouch and never clears a bounce.",
 	parameters: Schema.Struct({
-		action: Schema.Literals(['list', 'add', 'update', 'remove']),
+		action: Schema.Literals([
+			'list',
+			'add',
+			'update',
+			'remove',
+			'vouch',
+			'unvouch',
+		]),
 		contact_id: Schema.String,
 		channel_id: Schema.optional(Schema.String),
 		kind: Schema.optional(Schema.String),
@@ -139,6 +148,9 @@ const ManageContactChannels = Tool.make('manage_contact_channels', {
 		label: Schema.optional(Schema.NullOr(Schema.String)),
 		is_primary: Schema.optional(Schema.Boolean),
 		verification: Schema.optional(Schema.NullOr(HandSetVerificationVerdict)),
+		// Why somebody stands behind the address, kept with the vouch so a later
+		// reader knows what it rested on.
+		note: Schema.optional(Schema.String),
 	}),
 	success: Schema.Struct({
 		channels: Schema.Array(ContactChannel.json),
@@ -412,6 +424,57 @@ export const ContactHandlersLive = ContactTools.toLayer(
 							return yield* Effect.die(
 								new ToolMessage(
 									`No channel ${params.channel_id} on this contact.`,
+								),
+							)
+					}
+					if (params.action === 'vouch' && params.channel_id !== undefined) {
+						const outcome = yield* vouchForChannel(
+							sql,
+							currentOrg.id,
+							subject,
+							params.channel_id,
+							params.note,
+						)
+						if (outcome === 'not_found')
+							return yield* Effect.die(
+								new ToolMessage(
+									`No channel ${params.channel_id} on this contact.`,
+								),
+							)
+						if (outcome === 'not_email')
+							return yield* Effect.die(
+								new ToolMessage(
+									'Only an email address is ever held back by a verdict, so only one can be vouched for.',
+								),
+							)
+						if (outcome === 'suppressed')
+							return yield* Effect.die(
+								new ToolMessage(
+									'That address hard-bounced or reported spam, which no vouch lifts. Use update_contact with clear_email_suppression=true once the person confirms it works again.',
+								),
+							)
+					}
+					if (params.action === 'unvouch') {
+						if (params.channel_id === undefined)
+							return yield* Effect.die(
+								new ToolMessage('channel_id is required to take back a vouch.'),
+							)
+						const outcome = yield* withdrawVouch(
+							sql,
+							currentOrg.id,
+							subject,
+							params.channel_id,
+						)
+						if (outcome === 'not_found')
+							return yield* Effect.die(
+								new ToolMessage(
+									`No channel ${params.channel_id} on this contact.`,
+								),
+							)
+						if (outcome === 'not_vouched')
+							return yield* Effect.die(
+								new ToolMessage(
+									'Nobody had vouched for that address, so there is nothing to take back. A bounce is not a vouch and is not cleared from here.',
 								),
 							)
 					}

--- a/apps/server/src/mcp/tools/email.test.ts
+++ b/apps/server/src/mcp/tools/email.test.ts
@@ -3,37 +3,68 @@ import { describe, expect, it } from 'vitest'
 import { isRiskyEmailVerdict } from './email'
 
 describe('isRiskyEmailVerdict', () => {
-	describe('when the email channel is confirmed deliverable', () => {
-		it('should not gate the send', () => {
-			// GIVEN a deliverable verdict
-			// WHEN the agent send guard checks it
-			// THEN no confirmation is needed
+	describe('when the verdict says something against the address', () => {
+		it('should stop a send to ask first', () => {
+			// GIVEN the two verdicts that carry evidence — the mailbox is not there,
+			// or something about it is off
+			// WHEN the agent send guard checks them
+			// THEN each one stops the send
+			expect(isRiskyEmailVerdict('undeliverable')).toBe(true)
+			expect(isRiskyEmailVerdict('risky')).toBe(true)
+		})
+	})
+
+	describe('when a check ran but settled nothing', () => {
+		it('should let a catch-all domain through', () => {
+			// GIVEN a domain that answers to every name, so the check learned nothing
+			// about this particular mailbox — an ordinary arrangement, not a fault
+			// THEN there is nothing to stop the send for
+			expect(isRiskyEmailVerdict('catch_all')).toBe(false)
+		})
+
+		it('should let an inconclusive check through', () => {
+			// GIVEN a check that ran and settled nothing
+			// THEN it says exactly what no verdict says, so it is treated the same
+			expect(isRiskyEmailVerdict('unknown')).toBe(false)
+			expect(isRiskyEmailVerdict('unknown')).toBe(isRiskyEmailVerdict(null))
+		})
+	})
+
+	describe('when the address is confirmed deliverable', () => {
+		it('should not stop the send', () => {
+			// GIVEN a mailbox that answered
 			expect(isRiskyEmailVerdict('deliverable')).toBe(false)
 		})
 	})
 
-	describe('when the verdict is anything other than deliverable', () => {
-		it('should gate risky / catch_all / undeliverable / unknown', () => {
-			// GIVEN the non-deliverable verdicts the pipeline produces
-			// THEN each asks the agent to confirm first
-			expect(isRiskyEmailVerdict('risky')).toBe(true)
-			expect(isRiskyEmailVerdict('catch_all')).toBe(true)
-			expect(isRiskyEmailVerdict('undeliverable')).toBe(true)
-			expect(isRiskyEmailVerdict('unknown')).toBe(true)
-		})
-
-		it('should gate an unrecognised value conservatively', () => {
-			// GIVEN a verdict outside the known set (legacy / bad data)
-			// THEN it is treated as risky rather than silently trusted
-			expect(isRiskyEmailVerdict('weird')).toBe(true)
+	describe('when there is no verdict at all', () => {
+		it('should not stop a send to an address nobody has checked', () => {
+			// GIVEN null — nobody ever checked, which is most addresses on file
+			// THEN the guard stays out of the way; there is no evidence against it
+			expect(isRiskyEmailVerdict(null)).toBe(false)
 		})
 	})
 
-	describe('when there is no verdict at all', () => {
-		it('should not gate a contact with no email-channel verification', () => {
-			// GIVEN null — the contact was never verified
-			// THEN the guard stays out of the way (no evidence the address is bad)
-			expect(isRiskyEmailVerdict(null)).toBe(false)
+	describe('when the word is not one this knows', () => {
+		it('should stop the send rather than trust it', () => {
+			// GIVEN a value the column accepted but nothing here recognises — the
+			// column takes free text, so nobody vetted this one
+			// THEN it stops the send, because letting it through is the costly way
+			// to be wrong
+			expect(isRiskyEmailVerdict('weird')).toBe(true)
+			expect(isRiskyEmailVerdict('inferred')).toBe(true)
+		})
+
+		it('should not be fooled by a known word in another case', () => {
+			// GIVEN a verdict stored with a capital
+			// THEN it is not read as the word it resembles
+			expect(isRiskyEmailVerdict('Deliverable')).toBe(true)
+			expect(isRiskyEmailVerdict('CATCH_ALL')).toBe(true)
+		})
+
+		it('should stop the send on an empty word', () => {
+			// GIVEN an empty string, which is not the same as no verdict
+			expect(isRiskyEmailVerdict('')).toBe(true)
 		})
 	})
 })

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -1,5 +1,6 @@
 import { Config, Effect, Schema } from 'effect'
 import { McpSchema, Tool, Toolkit } from 'effect/unstable/ai'
+import type { SqlError } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
@@ -17,6 +18,10 @@ import {
 	EmailAttachmentStaging,
 	type StagingRef,
 } from '../../services/email-attachment-staging'
+import {
+	recipientAddresses,
+	replyAddressees,
+} from '../../services/recipient-address'
 import { ToolMessage } from '../tool-message'
 import { requireApproval } from './_elicit'
 import {
@@ -117,7 +122,7 @@ const AttachmentRef = Schema.Struct({
 
 const SendEmail = Tool.make('send_email', {
 	description:
-		'Send a new email. The body is a structured block tree (paragraph / heading / list / quote / divider / image) — not raw html/text. Omit inbox_id to use the calling member’s primary inbox in the active org. Attachments reference staging_ids returned by stage_email_attachment; set inline=true for cid-referenced inline images. Before composing, read the member’s standing email instructions (writing style, sign-off, do/don’t rules) from the batuda://instructions/email resource and write the body to follow them. Returns {_tag:"sent"} on success or {_tag:"suppressed"} if a recipient is suppressed. Set skip_footer=true to omit the inbox default footer.',
+		'Send a new email. The body is a structured block tree (paragraph / heading / list / quote / divider / image) — not raw html/text. Omit inbox_id to use the calling member’s primary inbox in the active org. Attachments reference staging_ids returned by stage_email_attachment; set inline=true for cid-referenced inline images. Before composing, read the member’s standing email instructions (writing style, sign-off, do/don’t rules) from the batuda://instructions/email resource and write the body to follow them. Returns {_tag:"sent"} on success; {_tag:"suppressed"} if a recipient once hard-bounced or reported spam, which is a hard block on every path; or {_tag:"cancelled"} if an address being written to carries a deliverability verdict of "undeliverable" or "risky" and nobody confirmed it — either the answer was no, or this client cannot put a question to anybody, and the reason says which. Verdicts of "catch_all" and "unknown", and addresses nobody has checked, are not gated. Read `verification` on a contact\'s channels (list_contacts) before composing to see this coming; when a send is stopped, the reason names the exact call that lifts it. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		inbox_id: Schema.optional(Schema.String),
 		to: Recipients,
@@ -141,7 +146,7 @@ const SendEmail = Tool.make('send_email', {
 
 const ReplyEmail = Tool.make('reply_email', {
 	description:
-		'Reply to the latest message in an existing email thread. Body is a structured block tree — if you want the parent quoted, emit a `quote` block wrapping sanitized parent blocks (you can read the parent via get_email_thread). Optional Cc/Bcc extend the thread. Attachments reference staging_ids from stage_email_attachment. Before composing, read the member’s standing email instructions from the batuda://instructions/email resource and write the reply to follow them. Returns {_tag:"sent"} or {_tag:"suppressed"}. Set skip_footer=true to omit the inbox default footer.',
+		'Reply to the latest message in an existing email thread. Body is a structured block tree — if you want the parent quoted, emit a `quote` block wrapping sanitized parent blocks (you can read the parent via get_email_thread). Optional Cc/Bcc extend the thread. Attachments reference staging_ids from stage_email_attachment. Before composing, read the member’s standing email instructions from the batuda://instructions/email resource and write the reply to follow them. Returns {_tag:"sent"}; {_tag:"suppressed"} if a recipient once hard-bounced or reported spam; or {_tag:"cancelled"} when a confirmation was needed and not obtained — because the contact\'s address (or one added in cc/bcc) carries an "undeliverable" or "risky" verdict, or because the thread already has EMAIL_AGENT_SOFT_THREAD_LIMIT outbound messages (default 3) and this reply would be one more. The reason names which, and says when the client had no way to ask anybody — and for an address it names the call that lifts the stop. Pass acknowledge_thread_length: true to answer the message-count reason without a prompt; an address with something recorded against it is answered by vouching for it instead. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		thread_id: Schema.String,
 		body_json: EmailBlocks,
@@ -150,6 +155,10 @@ const ReplyEmail = Tool.make('reply_email', {
 		bcc: Schema.optional(Schema.Array(Schema.String)),
 		attachments: Schema.optional(Schema.Array(AttachmentRef)),
 		skip_footer: Schema.optional(Schema.Boolean),
+		acknowledge_thread_length: Schema.optional(Schema.Boolean).annotate({
+			description:
+				'Set true to go ahead on a thread that already holds several outbound messages, when the person has said to keep going. It answers only that count — an address with something recorded against it still stops the send, and an address that bounced is still refused outright. Nothing is remembered: a later reply on the same thread asks again.',
+		}),
 	}),
 	success: SendEmailResult,
 	dependencies: REQUEST_DEPENDENCIES,
@@ -420,7 +429,7 @@ const ManageEmailInbox = Tool.make('manage_email_inbox', {
 
 const ManageEmailDraft = Tool.make('manage_email_draft', {
 	description:
-		'Manage an email draft a human can review before sending. action=create makes a new draft (optionally linked to CRM via company_id/contact_id/mode); update changes fields on an existing draft_id; send dispatches draft_id through the same thread-link/interaction/message pipeline as a direct send (returns {_tag:"sent"} or {_tag:"suppressed"}); delete permanently removes draft_id. body_json is the typed block tree preserved for lossless editor re-hydration.',
+		'Manage an email draft a human can review before sending. action=create makes a new draft (optionally linked to CRM via company_id/contact_id/mode); update changes fields on an existing draft_id; send dispatches draft_id through the same thread-link/interaction/message pipeline as a direct send, and runs the same deliverability guard on the addresses, so writing a message down first is not a way past that (it does not re-count how many outbound messages a thread already holds, which only reply_email does) (returns {_tag:"sent"}, {_tag:"suppressed"}, or {_tag:"cancelled"} — see send_email for what each means); delete permanently removes draft_id. body_json is the typed block tree preserved for lossless editor re-hydration.',
 	parameters: Schema.Struct({
 		action: Schema.Literals(['create', 'update', 'send', 'delete']),
 		inbox_id: Schema.String,
@@ -562,12 +571,92 @@ export const EmailTools = Toolkit.make(
 	ManageInboxFooter,
 )
 
-// The soft send guard fires when an email channel has a verdict that isn't a
-// confirmed `deliverable` (risky / catch_all / undeliverable / unknown, or any
-// unrecognised value). A missing verdict (null) is not gated — there is no
-// evidence the address is bad.
+// The verdicts that make an assistant's send stop and ask first: the two that
+// say something against the address. `catch_all` means the domain answers to
+// every name, so the check learned nothing about this particular mailbox, and
+// `unknown` means a check ran and settled nothing — which is what having no
+// verdict at all already says, and that has never been gated.
+//
+// A word outside the list still stops a send. The column takes free text, so
+// anything unrecognised is something nobody vetted, and letting it through is
+// the costly way to be wrong.
+const NEVER_GATED = new Set(['deliverable', 'catch_all', 'unknown'])
+
 export const isRiskyEmailVerdict = (verification: string | null): boolean =>
-	verification !== null && verification !== 'deliverable'
+	verification !== null && !NEVER_GATED.has(verification)
+
+/**
+ * An address a message is going to that carries a verdict worth stopping for
+ * and that nobody has stood behind.
+ *
+ * The question is put to the addresses, the way the block on bounced addresses
+ * puts it, rather than to whoever they belong to. Naming a contact is optional
+ * and names a person, not the mailbox — so a message to somebody's second
+ * address used to be judged by the verdict on their first, and a message that
+ * named nobody was never judged at all.
+ *
+ * A vouch settles the address rather than the row it was written on, since the
+ * same mailbox commonly sits on a person and on their company, and somebody
+ * standing behind it meant the address either way.
+ *
+ * Answers with one address when several are doubtful, since the send stops on
+ * the first thing wrong with it either way. Which one is settled by address so
+ * two calls about the same message say the same thing.
+ */
+export const riskyRecipientFor = (
+	sql: SqlClient.SqlClient,
+	orgId: string,
+	addresses: ReadonlyArray<string>,
+): Effect.Effect<
+	{
+		id: string
+		address: string
+		subjectTable: string
+		subjectId: string
+		verification: string | null
+		owningCompanyId: string | null
+	} | null,
+	SqlError.SqlError
+> =>
+	addresses.length === 0
+		? Effect.succeed(null)
+		: Effect.gen(function* () {
+				const rows = yield* sql<{
+					id: string
+					address: string
+					subjectTable: string
+					subjectId: string
+					verification: string | null
+					status: string
+					owningCompanyId: string | null
+				}>`
+					SELECT c.id, lower(c.address) AS address, c.subject_table,
+						c.subject_id, c.verification, c.status,
+						-- A branch's address is managed through the company that owns
+						-- it, so the answer has to name the company as well as the
+						-- branch. Without this the caller is handed a branch id where a
+						-- company id belongs, and the call it was told to make fails.
+						s.company_id AS owning_company_id
+					FROM channels c
+					LEFT JOIN sites s
+						ON c.subject_table = 'sites' AND s.id = c.subject_id
+					WHERE c.organization_id = ${orgId}
+						AND c.channel = 'email'
+						AND lower(c.address) = ANY(${addresses})
+						AND (c.verification IS NOT NULL OR c.status = 'valid')
+					ORDER BY lower(c.address), c.verification
+				`
+				const vouchedFor = new Set(
+					rows.filter(row => row.status === 'valid').map(row => row.address),
+				)
+				return (
+					rows.find(
+						row =>
+							!vouchedFor.has(row.address) &&
+							isRiskyEmailVerdict(row.verification),
+					) ?? null
+				)
+			})
 
 export const EmailHandlersLive = EmailTools.toLayer(
 	Effect.gen(function* () {
@@ -579,25 +668,15 @@ export const EmailHandlersLive = EmailTools.toLayer(
 			'EMAIL_AGENT_SOFT_THREAD_LIMIT',
 		).pipe(Config.withDefault(3))
 
-		// A known-risky deliverability verdict on the contact's primary email
-		// channel (catch-all / undeliverable / unknown). null when the email is
-		// deliverable or has no verdict to act on.
-		const riskyEmailVerdict = (contactId: string) =>
-			sql<{ verification: string | null }>`
-				SELECT verification FROM channels
-				WHERE subject_table = 'contacts'
-					AND subject_id = ${contactId}
-					AND channel = 'email'
-				ORDER BY is_primary DESC NULLS LAST
-				LIMIT 1
-			`.pipe(
-				Effect.map(rows => {
-					const v = rows[0]?.verification ?? null
-					return isRiskyEmailVerdict(v) ? v : null
-				}),
-			)
+		// The same question as `riskyRecipientFor`, with the organisation the
+		// request resolved to filled in.
+		const riskyRecipient = (addresses: ReadonlyArray<string>) =>
+			Effect.gen(function* () {
+				const currentOrg = yield* CurrentOrg
+				return yield* riskyRecipientFor(sql, currentOrg.id, addresses)
+			})
 
-		// Outbound count + linked contact for a thread, for the reply guard.
+		// Outbound count + where a reply lands, for the reply guard.
 		const threadSendState = (threadLinkId: string, orgId: string) =>
 			Effect.gen(function* () {
 				const links = yield* sql<{
@@ -609,14 +688,39 @@ export const EmailHandlersLive = EmailTools.toLayer(
 					LIMIT 1
 				`
 				const link = links[0]
-				if (!link) return { count: 0, contactId: null as string | null }
+				if (!link) return { count: 0, replyingTo: [] as string[] }
 				const counts = yield* sql<{ n: number }>`
 					SELECT count(*)::int AS n FROM email_messages
 					WHERE direction = 'outbound' AND organization_id = ${orgId}
 					AND (message_id = ${link.externalThreadId}
 					     OR ${link.externalThreadId} = ANY("references"))
 				`
-				return { count: counts[0]?.n ?? 0, contactId: link.contactId }
+				// Where a reply will actually land. This has to pick the same
+				// addresses the send itself picks, or the guard judges one mailbox
+				// while the message goes to another — so it repeats the send path's
+				// choice: the sender of an inbound message, the addressees of an
+				// outbound one, ordered the same way.
+				//
+				// Judging the linked person's default address instead answered about
+				// a different mailbox whenever the conversation was with any other
+				// one of theirs, and left a vouched address still blocked, since a
+				// vouch is recorded against an address and that lookup never saw one.
+				const latest = yield* sql<{
+					direction: string
+					recipients: { from?: string | null; to?: string[] } | null
+				}>`
+					SELECT direction, recipients FROM email_messages
+					WHERE organization_id = ${orgId}
+						AND (message_id = ${link.externalThreadId}
+						     OR ${link.externalThreadId} = ANY("references"))
+					ORDER BY received_at DESC NULLS LAST, status_updated_at DESC
+					LIMIT 1
+				`
+				const newest = latest[0]
+				return {
+					count: counts[0]?.n ?? 0,
+					replyingTo: newest ? replyAddressees(newest) : [],
+				}
 			})
 
 		// Ask the agent to confirm. Nothing is sent unless the answer is yes, but
@@ -627,6 +731,36 @@ export const EmailHandlersLive = EmailTools.toLayer(
 
 		// Why nothing was sent, in the caller's words. A client with no way to ask
 		// says so, rather than reporting a refusal nobody gave.
+		// What was wrong, and enough to act on it. The address alone leaves a
+		// caller stuck: nothing on this surface turns an address back into the
+		// record holding it, so without the channel named here the one way past
+		// the stop cannot be reached at all.
+		const vouchCall = (risky: {
+			id: string
+			subjectTable: string
+			subjectId: string
+			owningCompanyId: string | null
+		}): string => {
+			if (risky.subjectTable === 'contacts')
+				return `manage_contact_channels(action:"vouch", contact_id:"${risky.subjectId}", channel_id:"${risky.id}")`
+			// A branch's address is reached through its company, naming the branch
+			// as well; the branch id alone is not a company id and the call fails.
+			if (risky.subjectTable === 'sites' && risky.owningCompanyId !== null)
+				return `manage_company_channels(action:"vouch", company_id:"${risky.owningCompanyId}", site_id:"${risky.subjectId}", channel_id:"${risky.id}")`
+			return `manage_company_channels(action:"vouch", company_id:"${risky.subjectId}", channel_id:"${risky.id}")`
+		}
+
+		const riskyReason = (risky: {
+			id: string
+			address: string
+			subjectTable: string
+			subjectId: string
+			verification: string | null
+			owningCompanyId: string | null
+		}): string =>
+			`${risky.address} is not confirmed deliverable (verification: ${risky.verification}). ` +
+			`If you know the address is good, vouch for it: ${vouchCall(risky)}`
+
 		const notSentReason = (
 			answer: 'declined' | 'unaskable',
 			reasons: string,
@@ -638,18 +772,20 @@ export const EmailHandlersLive = EmailTools.toLayer(
 		return {
 			send_email: params =>
 				Effect.gen(function* () {
-					// Soft guard (agent-only): a known-risky recipient asks first.
-					if (params.contact_id) {
-						const risky = yield* riskyEmailVerdict(params.contact_id)
-						if (risky) {
-							const answer = yield* confirmSend(
-								`This contact's email is not confirmed deliverable (verification: ${risky})`,
-							)
-							if (answer !== 'confirmed') {
-								return {
-									_tag: 'cancelled' as const,
-									reason: notSentReason(answer, `email verification: ${risky}`),
-								}
+					// Soft guard (agent-only): an address with something recorded
+					// against it asks first.
+					const risky = yield* riskyRecipient(
+						recipientAddresses(params.to, params.cc, params.bcc),
+					)
+					if (risky) {
+						const answer = yield* confirmSend(riskyReason(risky))
+						if (answer !== 'confirmed') {
+							return {
+								_tag: 'cancelled' as const,
+								reason: notSentReason(
+									answer,
+									`email verification for ${risky.address}: ${risky.verification}`,
+								),
 							}
 						}
 					}
@@ -699,22 +835,27 @@ export const EmailHandlersLive = EmailTools.toLayer(
 					// Soft guards (agent-only): risky recipient and/or an
 					// over-the-soft-limit thread ask for confirmation first.
 					const org = yield* CurrentOrg
-					const { count, contactId } = yield* threadSendState(
+					const { count, replyingTo } = yield* threadSendState(
 						params.thread_id,
 						org.id,
 					)
 					const reasons: string[] = []
-					if (contactId) {
-						const risky = yield* riskyEmailVerdict(contactId)
-						if (risky) {
-							reasons.push(
-								`the contact's email is not confirmed deliverable (verification: ${risky})`,
-							)
-						}
+					// Everyone this reply reaches, judged the same way: where the
+					// thread already goes, plus anybody added to this message.
+					const risky = yield* riskyRecipient(
+						recipientAddresses(replyingTo, params.cc, params.bcc),
+					)
+					if (risky) {
+						reasons.push(riskyReason(risky))
 					}
-					if (count >= softThreadLimit) {
+					// A count is not evidence about anybody, so unlike a verdict there
+					// is nothing to record against an address and nothing to carry to
+					// the next reply. Saying so on the call is the whole of it, and it
+					// answers only this: an address with something against it still
+					// stops the send.
+					if (count >= softThreadLimit && !params.acknowledge_thread_length) {
 						reasons.push(
-							`this thread already has ${count} outbound messages (soft limit ${softThreadLimit})`,
+							`this thread already has ${count} outbound messages (soft limit ${softThreadLimit}); pass acknowledge_thread_length: true to go ahead`,
 						)
 					}
 					if (reasons.length > 0) {
@@ -1080,15 +1221,49 @@ export const EmailHandlersLive = EmailTools.toLayer(
 						return svc
 							.updateDraft(params.inbox_id, params.draft_id, fields)
 							.pipe(Effect.catchTag('NotFound', dieNotFound), Effect.orDie)
-					case 'send':
+					case 'send': {
 						if (params.draft_id === undefined)
 							return dieMissing('draft_id is required to send a draft')
-						return svc.sendDraft(params.inbox_id, params.draft_id).pipe(
-							Effect.map(r => ({
-								_tag: 'sent' as const,
-								messageId: r.messageId,
-								threadId: r.threadId,
-							})),
+						const draftId = params.draft_id
+						return Effect.gen(function* () {
+							// The same guard the direct sends run. A draft dispatched from
+							// here is an assistant sending, so writing the message down
+							// first and posting it afterwards must not be the way past a
+							// question the direct path would have asked.
+							const draft = yield* svc
+								.getDraft(params.inbox_id, draftId)
+								.pipe(Effect.catchTag('NotFound', asNothing))
+							if (draft) {
+								const risky = yield* riskyRecipient(
+									recipientAddresses(
+										[...draft.to],
+										[...draft.cc],
+										[...draft.bcc],
+									),
+								)
+								if (risky) {
+									const answer = yield* confirmSend(riskyReason(risky))
+									if (answer !== 'confirmed')
+										return {
+											_tag: 'cancelled' as const,
+											reason: notSentReason(
+												answer,
+												`email verification for ${risky.address}: ${risky.verification}`,
+											),
+										}
+								}
+							}
+							return yield* svc.sendDraft(params.inbox_id, draftId)
+						}).pipe(
+							Effect.map(r =>
+								'_tag' in r
+									? r
+									: {
+											_tag: 'sent' as const,
+											messageId: r.messageId,
+											threadId: r.threadId,
+										},
+							),
 							Effect.catchTag('EmailSuppressed', e =>
 								Effect.succeed({
 									_tag: 'suppressed' as const,
@@ -1100,6 +1275,7 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							Effect.catchTag('NotFound', dieNotFound),
 							Effect.orDie,
 						)
+					}
 					case 'delete':
 						if (params.draft_id === undefined)
 							return dieMissing('draft_id is required to delete a draft')

--- a/apps/server/src/services/channels.ts
+++ b/apps/server/src/services/channels.ts
@@ -396,8 +396,9 @@ export const patchChannel = (
 			channel: string
 			address: string
 			isPrimary: boolean
+			status: string
 		}>`
-			SELECT channel, address, is_primary FROM channels
+			SELECT channel, address, is_primary, status FROM channels
 			WHERE id = ${channelId} AND subject_table = ${subject.table}
 				AND subject_id = ${subject.id} AND organization_id = ${orgId}
 			LIMIT 1
@@ -448,6 +449,19 @@ export const patchChannel = (
 			data['statusReason'] = null
 			data['statusUpdatedAt'] = now
 			data['softBounceCount'] = 0
+		}
+		// Somebody vouching stood behind one address, not behind this row for
+		// good. Correcting the address is exactly the moment that stops being
+		// true, and the send path reads a vouch by address across the whole
+		// organisation — so carrying it over would quietly clear whatever a check
+		// had found about the new address, wherever else it is on file.
+		const addressChanged =
+			patch.value !== undefined &&
+			patch.value.trim().toLowerCase() !== stored.address.trim().toLowerCase()
+		if (addressChanged && !leavingEmail && stored.status === 'valid') {
+			data['status'] = 'unknown'
+			data['statusReason'] = null
+			data['statusUpdatedAt'] = now
 		}
 
 		// One address of a kind per subject, so renaming onto one already on file
@@ -548,6 +562,112 @@ export interface SuppressedAddress {
 	/** The person holding it, when one does — a company mailbox answers null. */
 	readonly contactId: string | null
 }
+
+/**
+ * Record that somebody stands behind an address, so an assistant stops asking
+ * about it.
+ *
+ * A deliverability verdict is what a check found, and nobody at a keyboard can
+ * obtain one — which is why a caller may only ever lower it. This is the other
+ * half of that: a person who knows the address is good says so here, and it is
+ * kept apart from the verdict rather than overwriting it. The check's finding
+ * stays on file and stays true; what changes is whether it stops a send.
+ *
+ * Refused on an address that hard-bounced or reported spam. That state is the
+ * one real block, and it is keyed on exactly the column this writes — so
+ * vouching for such an address would not merely disagree with the bounce, it
+ * would silently lift it for the whole organisation. Whoever wants that wants
+ * `clearEmailSuppression`, which says so plainly and returns the address to
+ * "nobody has checked" rather than to "somebody vouched".
+ *
+ * Answers what happened, so the caller can tell a refusal from a wrong id
+ * rather than reporting a success nobody got.
+ */
+export const vouchForChannel = (
+	sql: Sql,
+	orgId: string,
+	subject: { readonly table: ChannelSubject; readonly id: string },
+	channelId: string,
+	reason?: string | undefined,
+): Effect.Effect<
+	'vouched' | 'suppressed' | 'not_email' | 'not_found',
+	SqlError.SqlError
+> =>
+	Effect.gen(function* () {
+		const rows = yield* sql<{ channel: string; status: string }>`
+			SELECT channel, status FROM channels
+			WHERE id = ${channelId} AND subject_table = ${subject.table}
+				AND subject_id = ${subject.id} AND organization_id = ${orgId}
+			LIMIT 1
+		`
+		const stored = rows[0]
+		if (stored === undefined) return 'not_found' as const
+		// Only an email address is ever held back by a verdict, so vouching for a
+		// phone number would write a state nothing reads.
+		if (stored.channel !== 'email') return 'not_email' as const
+		if (stored.status === 'bounced' || stored.status === 'complained')
+			return 'suppressed' as const
+
+		yield* sql`
+			UPDATE channels
+			SET status = 'valid',
+			    status_reason = ${reason ?? null},
+			    status_updated_at = now()
+			WHERE id = ${channelId} AND organization_id = ${orgId}
+				AND status NOT IN ('bounced', 'complained')
+		`
+		// The check above and this write are two statements, and a bounce landing
+		// between them commits in that gap — so the condition is repeated here
+		// rather than trusted from a moment ago. Without it the write would lift a
+		// block that arrived while the request was in flight, for the whole
+		// organisation, and overwrite the mail server's own reason with this note.
+		const updated = yield* sql<{ status: string }>`
+			SELECT status FROM channels WHERE id = ${channelId}
+		`
+		if (updated[0]?.status !== 'valid') return 'suppressed' as const
+		return 'vouched' as const
+	})
+
+/**
+ * Take back a vouch, returning the address to nobody having stood behind it.
+ *
+ * Somebody changing their mind is ordinary, and until this existed there was no
+ * way back: a vouch is written to the same column a bounce uses, and the only
+ * other thing that clears it is correcting the address itself. Left without a
+ * door, the way out would have been to write a verdict nobody earned.
+ *
+ * Only ever lifts a vouch. A bounce sits in the same column and is not a thing
+ * a caller may clear from here — that is `clearEmailSuppression`, which says so
+ * — and an address nobody vouched for is left exactly as it is rather than
+ * quietly stamped.
+ */
+export const withdrawVouch = (
+	sql: Sql,
+	orgId: string,
+	subject: { readonly table: ChannelSubject; readonly id: string },
+	channelId: string,
+): Effect.Effect<
+	'withdrawn' | 'not_vouched' | 'not_found',
+	SqlError.SqlError
+> =>
+	Effect.gen(function* () {
+		const rows = yield* sql<{ status: string }>`
+			SELECT status FROM channels
+			WHERE id = ${channelId} AND subject_table = ${subject.table}
+				AND subject_id = ${subject.id} AND organization_id = ${orgId}
+			LIMIT 1
+		`
+		const stored = rows[0]
+		if (stored === undefined) return 'not_found' as const
+		if (stored.status !== 'valid') return 'not_vouched' as const
+		yield* sql`
+			UPDATE channels
+			SET status = 'unknown', status_reason = NULL, status_updated_at = now()
+			WHERE id = ${channelId} AND organization_id = ${orgId}
+				AND status = 'valid'
+		`
+		return 'withdrawn' as const
+	})
 
 /**
  * Which of these addresses the organisation is holding mail back from.

--- a/apps/server/src/services/email-verdict-gate.integration.test.ts
+++ b/apps/server/src/services/email-verdict-gate.integration.test.ts
@@ -1,0 +1,490 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { riskyRecipientFor } from '../mcp/tools/email'
+import { patchChannel, vouchForChannel, withdrawVouch } from './channels'
+import { recipientAddresses } from './recipient-address'
+
+// The second question an assistant's send asks: "is there anything recorded
+// against an address this is going to, that nobody has stood behind?"
+//
+// It used to be asked of a *person*, and only of the one address they send from
+// by default — so a message to somebody's second address was judged by the
+// verdict on their first, and a message that named nobody was never judged at
+// all. Naming a contact is optional, so that last case is an ordinary send.
+//
+// The guard is called here rather than copied. A test that re-states the query
+// passes just as happily once the code it protects stops matching it.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+const ORG = `verdict-org-${randomUUID()}`
+const OTHER_ORG = `verdict-other-${randomUUID()}`
+
+const COMPANY_MAILBOX = 'comandes@fustespla.example'
+const PRIMARY_ADDRESS = 'nuria@fustespla.example'
+const SECOND_ADDRESS = 'n.pla@fustespla.example'
+const CATCH_ALL_ADDRESS = 'info@grupmarti.example'
+const OTHER_ORG_ADDRESS = 'shared@agency.example'
+
+let companyId: string
+let contactId: string
+
+const run = <A>(effect: Effect.Effect<A, unknown, SqlClient.SqlClient>) =>
+	effect.pipe(Effect.provide(PgLive), Effect.runPromise)
+
+// What the send path does: fold whatever the caller wrote into bare addresses,
+// then ask the guard about them.
+const stopsTheSend = (org: string, ...written: ReadonlyArray<string>) =>
+	run(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* riskyRecipientFor(sql, org, recipientAddresses(...written))
+		}),
+	)
+
+const seedChannel = (
+	org: string,
+	subjectTable: 'companies' | 'contacts',
+	subjectId: string,
+	address: string,
+	verification: string | null,
+	isPrimary = false,
+) =>
+	pool.query(
+		`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, verification, is_primary)
+		 VALUES ($1, $2, $3, 'email', $4, $5, $6)`,
+		[org, subjectTable, subjectId, address, verification, isPrimary],
+	)
+
+const channelIdFor = async (address: string, subject = 'contacts') => {
+	const r = await pool.query<{ id: string }>(
+		`SELECT id FROM channels WHERE organization_id = $1 AND lower(address) = $2 AND subject_table = $3`,
+		[ORG, address.toLowerCase(), subject],
+	)
+	return r.rows[0]!.id
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+
+	const company = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, 'Fustes Pla') RETURNING id`,
+		[ORG, `fustes-pla-${randomUUID()}`],
+	)
+	companyId = company.rows[0]!.id
+
+	const contact = await pool.query<{ id: string }>(
+		`INSERT INTO contacts (organization_id, company_id, name)
+		 VALUES ($1, $2, 'Núria Pla') RETURNING id`,
+		[ORG, companyId],
+	)
+	contactId = contact.rows[0]!.id
+
+	// A company mailbox nobody owns, with the mailbox reported missing.
+	await seedChannel(
+		ORG,
+		'companies',
+		companyId,
+		COMPANY_MAILBOX,
+		'undeliverable',
+	)
+	// The person's default address, cleared by a check…
+	await seedChannel(
+		ORG,
+		'contacts',
+		contactId,
+		PRIMARY_ADDRESS,
+		'deliverable',
+		true,
+	)
+	// …and a second one of theirs that a check found wanting.
+	await seedChannel(ORG, 'contacts', contactId, SECOND_ADDRESS, 'risky')
+	// An address on a domain that answers to every name.
+	await seedChannel(ORG, 'companies', companyId, CATCH_ALL_ADDRESS, 'catch_all')
+
+	// The same-looking address, carrying a verdict, but for somebody else.
+	const otherCompany = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, 'Other Co') RETURNING id`,
+		[OTHER_ORG, `other-co-${randomUUID()}`],
+	)
+	await seedChannel(
+		OTHER_ORG,
+		'companies',
+		otherCompany.rows[0]!.id,
+		OTHER_ORG_ADDRESS,
+		'undeliverable',
+	)
+}, 30_000)
+
+afterAll(async () => {
+	for (const org of [ORG, OTHER_ORG]) {
+		for (const table of ['channels', 'contacts', 'sites', 'companies']) {
+			await pool.query(`DELETE FROM ${table} WHERE organization_id = $1`, [org])
+		}
+	}
+	await pool.end()
+})
+
+describe('judging a send by the address it is going to', () => {
+	describe('when the address belongs to a company rather than a person', () => {
+		it('should stop the send, though no contact could have named it', async () => {
+			expect((await stopsTheSend(ORG, COMPANY_MAILBOX))?.verification).toBe(
+				'undeliverable',
+			)
+		})
+
+		it('should have been invisible to a lookup that needed a contact', async () => {
+			// GIVEN the same address, asked for the old way: by contact
+			const oldWay = await pool.query(
+				`SELECT verification FROM channels
+				 WHERE subject_table = 'contacts'
+				   AND organization_id = $1
+				   AND channel = 'email'
+				   AND lower(address) = $2`,
+				[ORG, COMPANY_MAILBOX],
+			)
+
+			// THEN nothing came back — a send to a company mailbox went unjudged
+			expect(oldWay.rows).toHaveLength(0)
+		})
+	})
+
+	describe('when the message goes to a person’s second address', () => {
+		it('should read that address, not their default one', async () => {
+			expect((await stopsTheSend(ORG, SECOND_ADDRESS))?.verification).toBe(
+				'risky',
+			)
+		})
+
+		it('should have been judged by the wrong address before', async () => {
+			// GIVEN the old lookup: whichever address is default, regardless of
+			// where the message was going
+			const oldWay = await pool.query<{ verification: string }>(
+				`SELECT verification FROM channels
+				 WHERE subject_table = 'contacts' AND subject_id = $1 AND channel = 'email'
+				 ORDER BY is_primary DESC NULLS LAST
+				 LIMIT 1`,
+				[contactId],
+			)
+
+			// THEN it answered for the default address — clearing a send to the
+			// second one on evidence about a different mailbox entirely
+			expect(oldWay.rows[0]?.verification).toBe('deliverable')
+		})
+	})
+
+	describe('when the caller writes the recipient the way a mail client shows it', () => {
+		it('should still recognise the address', async () => {
+			// GIVEN a display name wrapped around a mailbox that is missing. The
+			// mail server delivers this form; compared whole it matched nothing, so
+			// the message went out unjudged.
+			const stopped = await stopsTheSend(
+				ORG,
+				`Comandes Fustes Pla <${COMPANY_MAILBOX.toUpperCase()}>`,
+			)
+			expect(stopped?.address).toBe(COMPANY_MAILBOX)
+		})
+
+		it('should recognise each address in a comma-separated list', async () => {
+			const stopped = await stopsTheSend(
+				ORG,
+				`ningu@fustespla.example, ${COMPANY_MAILBOX}`,
+			)
+			expect(stopped?.address).toBe(COMPANY_MAILBOX)
+		})
+	})
+
+	describe('when only the verdicts that settle nothing are present', () => {
+		it('should let the send go out unremarked', async () => {
+			// GIVEN a catch-all domain and a cleared address: one learned nothing
+			// about the mailbox, the other answered
+			expect(
+				await stopsTheSend(ORG, CATCH_ALL_ADDRESS, PRIMARY_ADDRESS),
+			).toBeNull()
+		})
+	})
+
+	describe('when the verdict was recorded for a different organisation', () => {
+		it('should not be reachable from this one', async () => {
+			expect(await stopsTheSend(ORG, OTHER_ORG_ADDRESS)).toBeNull()
+		})
+	})
+
+	describe('when nobody has checked the address', () => {
+		it('should find nothing, so the send goes out', async () => {
+			expect(await stopsTheSend(ORG, 'fresc@fustespla.example')).toBeNull()
+		})
+	})
+
+	describe('when the address belongs to a branch rather than the company', () => {
+		it('should name the company that owns it, not just the branch', async () => {
+			// GIVEN a branch with its own mailbox that a check ruled out
+			const branchMailbox = 'girona@fustespla.example'
+			const site = await pool.query<{ id: string }>(
+				`INSERT INTO sites (organization_id, company_id, name)
+				 VALUES ($1, $2, 'Girona') RETURNING id`,
+				[ORG, companyId],
+			)
+			await pool.query(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, verification)
+				 VALUES ($1, 'sites', $2, 'email', $3, 'undeliverable')`,
+				[ORG, site.rows[0]!.id, branchMailbox],
+			)
+
+			// THEN the stop carries the company as well as the branch. A branch is
+			// managed through its company, so the branch id alone is not enough to
+			// name the call that lifts this — and a caller handed only that makes a
+			// call that fails.
+			const stopped = await stopsTheSend(ORG, branchMailbox)
+			expect(stopped?.subjectTable).toBe('sites')
+			expect(stopped?.subjectId).toBe(site.rows[0]!.id)
+			expect(stopped?.owningCompanyId).toBe(companyId)
+		})
+	})
+})
+
+describe('an address somebody has stood behind', () => {
+	describe('when the verdict would otherwise stop the send', () => {
+		it('should let it through once vouched, without touching the verdict', async () => {
+			expect(await stopsTheSend(ORG, COMPANY_MAILBOX)).not.toBeNull()
+
+			await pool.query(
+				`UPDATE channels SET status = 'valid', status_updated_at = now()
+				 WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, COMPANY_MAILBOX],
+			)
+
+			// THEN the send goes out — and what the check found is still on file,
+			// because a person standing behind an address does not turn a failed
+			// probe into a successful one
+			expect(await stopsTheSend(ORG, COMPANY_MAILBOX)).toBeNull()
+			const after = await pool.query<{ verification: string }>(
+				`SELECT verification FROM channels WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, COMPANY_MAILBOX],
+			)
+			expect(after.rows[0]?.verification).toBe('undeliverable')
+		})
+	})
+
+	describe('when the same address sits on two records and one is vouched', () => {
+		it('should settle the address, not just the row', async () => {
+			// GIVEN the vouched company mailbox recorded a second time against a
+			// person, still carrying the verdict that stops a send
+			await seedChannel(
+				ORG,
+				'contacts',
+				contactId,
+				COMPANY_MAILBOX,
+				'undeliverable',
+			)
+
+			// THEN the vouch on the other row still clears it: it is one mailbox,
+			// and somebody stood behind the address rather than behind a row
+			expect(await stopsTheSend(ORG, COMPANY_MAILBOX)).toBeNull()
+		})
+	})
+
+	describe('when the address is then corrected to a different one', () => {
+		it('should not carry the vouch onto the new address', async () => {
+			// GIVEN a vouched address, and a different address that a check found
+			// wanting somewhere else in the organisation
+			const vouched = 'renamed@fustespla.example'
+			await seedChannel(ORG, 'contacts', contactId, vouched, null)
+			await pool.query(
+				`UPDATE channels SET status = 'valid' WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, vouched],
+			)
+
+			// WHEN the address is put right — the very flow the tool advertises
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* patchChannel(
+						sql,
+						ORG,
+						{ table: 'contacts', id: contactId },
+						yield* Effect.promise(() => channelIdFor(vouched)),
+						{ value: SECOND_ADDRESS.replace('n.pla', 'n.pla2') },
+					)
+				}),
+			)
+
+			// THEN the vouch does not follow. Somebody stood behind one mailbox,
+			// not behind this row for good, and carrying it over would clear
+			// whatever a check had found about the new address.
+			const moved = await pool.query<{ status: string }>(
+				`SELECT status FROM channels WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, SECOND_ADDRESS.replace('n.pla', 'n.pla2')],
+			)
+			expect(moved.rows[0]?.status).toBe('unknown')
+		})
+	})
+})
+
+describe('what a vouch will not do', () => {
+	const vouch = (channelId: string, reason?: string) =>
+		run(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				return yield* vouchForChannel(
+					sql,
+					ORG,
+					{ table: 'contacts', id: contactId },
+					channelId,
+					reason,
+				)
+			}),
+		)
+
+	describe('when the address hard-bounced', () => {
+		it('should refuse, and leave the block exactly where it was', async () => {
+			// GIVEN a person's address that hard-bounced. The bounce lives in the
+			// same column a vouch writes, so writing one here would not merely
+			// disagree with the bounce — it would lift it for the whole organisation
+			const bounced = 'retornat@fustespla.example'
+			await seedChannel(ORG, 'contacts', contactId, bounced, 'deliverable')
+			await pool.query(
+				`UPDATE channels SET status = 'bounced', status_reason = 'mailbox unavailable'
+				 WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, bounced],
+			)
+
+			expect(await vouch(await channelIdFor(bounced))).toBe('suppressed')
+
+			// AND the bounce is untouched, so the send path still refuses outright
+			const after = await pool.query<{ status: string; reason: string }>(
+				`SELECT status, status_reason AS reason FROM channels
+				 WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, bounced],
+			)
+			expect(after.rows[0]?.status).toBe('bounced')
+			expect(after.rows[0]?.reason).toBe('mailbox unavailable')
+		})
+	})
+
+	describe('when the channel is not an email address', () => {
+		it('should refuse, since nothing holds a phone number back', async () => {
+			await pool.query(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address)
+				 VALUES ($1, 'contacts', $2, 'phone', '+34600111222')`,
+				[ORG, contactId],
+			)
+			const r = await pool.query<{ id: string }>(
+				`SELECT id FROM channels WHERE organization_id = $1 AND channel = 'phone'`,
+				[ORG],
+			)
+			expect(await vouch(r.rows[0]!.id)).toBe('not_email')
+		})
+	})
+
+	describe('when the channel belongs to somebody else', () => {
+		it('should answer as if it were not there', async () => {
+			// GIVEN a channel id that is real but hangs off the company, not this
+			// person — an id alone only proves a row exists, not whose it is
+			const r = await pool.query<{ id: string }>(
+				`SELECT id FROM channels WHERE organization_id = $1 AND subject_table = 'companies' LIMIT 1`,
+				[ORG],
+			)
+			expect(await vouch(r.rows[0]!.id)).toBe('not_found')
+		})
+	})
+
+	describe('when somebody changes their mind', () => {
+		it('should take the vouch back and let the verdict stop the send again', async () => {
+			// GIVEN an address a check ruled out, that somebody then vouched for
+			const reconsidered = 'reconsidered@fustespla.example'
+			await seedChannel(
+				ORG,
+				'contacts',
+				contactId,
+				reconsidered,
+				'undeliverable',
+			)
+			const id = await channelIdFor(reconsidered)
+			expect(await vouch(id, 'they said it was fine')).toBe('vouched')
+			expect(await stopsTheSend(ORG, reconsidered)).toBeNull()
+
+			// WHEN the vouch is taken back
+			const outcome = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* withdrawVouch(
+						sql,
+						ORG,
+						{ table: 'contacts', id: contactId },
+						id,
+					)
+				}),
+			)
+
+			// THEN the address is back to nobody having stood behind it, and the
+			// check's finding — which was never overwritten — stops the send again
+			expect(outcome).toBe('withdrawn')
+			expect((await stopsTheSend(ORG, reconsidered))?.verification).toBe(
+				'undeliverable',
+			)
+		})
+
+		it('should refuse to dress up a bounce as a withdrawn vouch', async () => {
+			// GIVEN an address that hard-bounced — nobody vouched for it, so there
+			// is nothing here to take back, and this must not become a second way
+			// to clear a block
+			const bounced = 'retornat@fustespla.example'
+			const outcome = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* withdrawVouch(
+						sql,
+						ORG,
+						{ table: 'contacts', id: contactId },
+						yield* Effect.promise(() => channelIdFor(bounced)),
+					)
+				}),
+			)
+			expect(outcome).toBe('not_vouched')
+
+			const after = await pool.query<{ status: string }>(
+				`SELECT status FROM channels WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, bounced],
+			)
+			expect(after.rows[0]?.status).toBe('bounced')
+		})
+	})
+
+	describe('when the address is merely unproven', () => {
+		it('should record the vouch and what it rested on', async () => {
+			const unproven = 'provisional@fustespla.example'
+			await seedChannel(ORG, 'contacts', contactId, unproven, 'risky')
+			expect(
+				await vouch(
+					await channelIdFor(unproven),
+					'confirmed on the phone with Núria',
+				),
+			).toBe('vouched')
+
+			const after = await pool.query<{ status: string; reason: string }>(
+				`SELECT status, status_reason AS reason FROM channels
+				 WHERE organization_id = $1 AND lower(address) = $2`,
+				[ORG, unproven],
+			)
+			expect(after.rows[0]?.status).toBe('valid')
+			expect(after.rows[0]?.reason).toBe('confirmed on the phone with Núria')
+		})
+	})
+})

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -62,6 +62,7 @@ import type {
 	OutboundMessage,
 } from './mail-transport.js'
 import { MailTransport } from './mail-transport.js'
+import { recipientAddresses, replyAddressees } from './recipient-address.js'
 import { StorageProvider } from './storage-provider.js'
 import { EmailSent, TimelineActivityService } from './timeline-activity.js'
 
@@ -493,14 +494,25 @@ export class EmailService extends Context.Service<EmailService>()(
 			 * organisation both by its own condition and by row-level security, so
 			 * one company's bounce can never speak for another's.
 			 */
-			const assertRecipientsNotSuppressed = (recipient: string | string[]) =>
+			const assertRecipientsNotSuppressed = (
+				recipient: string | string[],
+				also?: {
+					readonly cc?: ReadonlyArray<string> | undefined
+					readonly bcc?: ReadonlyArray<string> | undefined
+				},
+			) =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
-					const recipients = (
-						Array.isArray(recipient) ? recipient : [recipient]
-					)
-						.map(r => r.trim().toLowerCase())
-						.filter(r => r !== '')
+					// Copied and blind-copied addresses are delivered to exactly like
+					// the ones in `to`, so a block that only read `to` let a bounced
+					// address be reached by writing it in `bcc` instead — on every
+					// path, including a person composing in the web app.
+					//
+					// The addresses are pulled out of whatever form the caller wrote
+					// them in, because a recipient written the way a mail client shows
+					// it ("Núria <nuria@…>") is delivered to just the same and matched
+					// nothing at all when compared whole.
+					const recipients = recipientAddresses(recipient, also?.cc, also?.bcc)
 					if (recipients.length === 0) return
 					// The same lookup `checkSuppressed` answers with, so a warning given
 					// beforehand and the refusal here cannot disagree.
@@ -1058,7 +1070,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							: yield* resolveDefaultInboxForCurrentUser()
 						yield* assertInboxUsable(inbox)
 
-						yield* assertRecipientsNotSuppressed(to)
+						yield* assertRecipientsNotSuppressed(to, { cc, bcc })
 
 						const staged = yield* staging.resolve(inbox.id, attachmentRefs)
 						let blocks: EmailBlocks = bodyJson
@@ -1205,9 +1217,10 @@ export class EmailService extends Context.Service<EmailService>()(
 						// `external_thread_id = ANY(references)` (any reply).
 						const lastMessages = yield* sql<{
 							messageId: string
-							recipients: { from?: string; to?: string[] }
+							direction: string
+							recipients: { from?: string | null; to?: string[] }
 						}>`
-							SELECT message_id, recipients
+							SELECT message_id, direction, recipients
 							FROM email_messages
 							WHERE organization_id = ${currentOrg.id}
 							  AND (
@@ -1224,13 +1237,9 @@ export class EmailService extends Context.Service<EmailService>()(
 							})
 						}
 
-						// The reply addressee list is whatever sat on the most recent
-						// inbound. For now we keep it conservative (anyone listed in the
-						// recipients snapshot's `to`); refining once mail-worker stores
-						// parsed From/To/Cc separately.
-						const replyRecipients = lastMessage.recipients?.to ?? []
+						const replyRecipients = [...replyAddressees(lastMessage)]
 
-						yield* assertRecipientsNotSuppressed(replyRecipients)
+						yield* assertRecipientsNotSuppressed(replyRecipients, { cc, bcc })
 
 						const staged = yield* staging.resolve(inbox.id, attachmentRefs)
 						let blocks: EmailBlocks = bodyJson
@@ -2686,7 +2695,13 @@ export class EmailService extends Context.Service<EmailService>()(
 						const draft = yield* reachableDraft(inboxId, draftId)
 						const ctx = parseClientId(draft.clientId ?? undefined)
 
-						yield* assertRecipientsNotSuppressed(draft.toAddresses as string[])
+						yield* assertRecipientsNotSuppressed(
+							draft.toAddresses as string[],
+							{
+								cc: draft.ccAddresses as string[],
+								bcc: draft.bccAddresses as string[],
+							},
+						)
 
 						// Reply path needs the parent thread's external_thread_id +
 						// references chain so the new message lands inside that

--- a/apps/server/src/services/recipient-address.test.ts
+++ b/apps/server/src/services/recipient-address.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+
+import { recipientAddresses, replyAddressees } from './recipient-address'
+
+describe('replyAddressees', () => {
+	describe('when replying to something that came in', () => {
+		it('should answer the sender, not ourselves', () => {
+			// GIVEN a message somebody sent us. Its `to` is our own mailbox — that
+			// is what being the recipient means — so replying to the `to` would
+			// send the message straight back to us.
+			expect(
+				replyAddressees({
+					direction: 'inbound',
+					recipients: {
+						from: 'nuria@fustespla.example',
+						to: ['admin@taller.cat'],
+					},
+				}),
+			).toEqual(['nuria@fustespla.example'])
+		})
+
+		it('should fall back to the addressees when no sender was stored', () => {
+			// GIVEN a message recorded before the sender was written down. Wrong,
+			// but no more wrong than it already was, and a reply with nobody to go
+			// to is worse than one that goes to the wrong place.
+			expect(
+				replyAddressees({
+					direction: 'inbound',
+					recipients: { to: ['admin@taller.cat'] },
+				}),
+			).toEqual(['admin@taller.cat'])
+		})
+	})
+
+	describe('when replying after something we sent', () => {
+		it('should answer the people it went to', () => {
+			// GIVEN the last thing on the thread is ours — it already went to the
+			// right people, and the sender would be our own mailbox
+			expect(
+				replyAddressees({
+					direction: 'outbound',
+					recipients: {
+						from: 'admin@taller.cat',
+						to: ['nuria@fustespla.example'],
+					},
+				}),
+			).toEqual(['nuria@fustespla.example'])
+		})
+	})
+
+	describe('when the message carries nothing at all', () => {
+		it('should answer with nobody rather than inventing a recipient', () => {
+			expect(
+				replyAddressees({ direction: 'inbound', recipients: null }),
+			).toEqual([])
+		})
+	})
+})
+
+describe('recipientAddresses', () => {
+	describe('when the caller writes a plain address', () => {
+		it('should hand it back as the database stores it', () => {
+			// GIVEN the ordinary form
+			expect(recipientAddresses('nuria@example.cat')).toEqual([
+				'nuria@example.cat',
+			])
+		})
+
+		it('should fold case and trim, since that is the same mailbox', () => {
+			expect(recipientAddresses('  NURIA@Example.CAT ')).toEqual([
+				'nuria@example.cat',
+			])
+		})
+	})
+
+	describe('when the caller writes it the way a mail client shows it', () => {
+		it('should read the address out of the display-name form', () => {
+			// GIVEN a recipient with a name attached — which the mail server accepts
+			// and delivers, and which matched no stored address when compared whole
+			expect(recipientAddresses('Núria Pla <nuria@example.cat>')).toEqual([
+				'nuria@example.cat',
+			])
+		})
+
+		it('should cope with a quoted name holding a comma', () => {
+			// GIVEN the form a client produces for a surname-first name, where a
+			// naive split on commas would invent two broken recipients
+			expect(recipientAddresses('"Pla, Núria" <nuria@example.cat>')).toEqual([
+				'nuria@example.cat',
+			])
+		})
+	})
+
+	describe('when several addresses arrive in one string', () => {
+		it('should treat each as its own recipient', () => {
+			expect(recipientAddresses('a@example.cat, b@example.cat')).toEqual([
+				'a@example.cat',
+				'b@example.cat',
+			])
+		})
+
+		it('should split a mixture of forms', () => {
+			expect(
+				recipientAddresses('Núria <a@example.cat>, b@example.cat'),
+			).toEqual(['a@example.cat', 'b@example.cat'])
+		})
+	})
+
+	describe('when lists are combined', () => {
+		it('should gather every list given and drop repeats', () => {
+			// GIVEN a message addressed to somebody who is also copied in
+			expect(
+				recipientAddresses(
+					'a@example.cat',
+					['B@example.cat'],
+					['a@example.cat'],
+				),
+			).toEqual(['a@example.cat', 'b@example.cat'])
+		})
+
+		it('should ignore lists that were never given', () => {
+			expect(recipientAddresses('a@example.cat', undefined, undefined)).toEqual(
+				['a@example.cat'],
+			)
+		})
+
+		it('should answer with nothing when there is nobody to write to', () => {
+			// GIVEN only empty entries, which match no stored address and would
+			// only widen the query
+			expect(recipientAddresses('', ['  ', ''], undefined)).toEqual([])
+		})
+	})
+})

--- a/apps/server/src/services/recipient-address.ts
+++ b/apps/server/src/services/recipient-address.ts
@@ -1,0 +1,95 @@
+/**
+ * The bare mailboxes a message is going to, however the caller wrote them.
+ *
+ * Both email gates — the block on addresses that bounced, and the question an
+ * assistant is asked about a doubtful one — compare what the caller passed
+ * against `channels.address`, which holds a bare address and nothing else. A
+ * caller may perfectly reasonably write a recipient the way a mail client shows
+ * it, and the mail server accepts every one of these:
+ *
+ *     Núria Pla <nuria@example.cat>
+ *     "Pla, Núria" <nuria@example.cat>
+ *     a@example.cat, b@example.cat
+ *
+ * Compared as written, none of them matches a stored address, so the message
+ * goes out with neither gate having recognised the recipient — including to a
+ * mailbox that hard-bounced. Pulling the address out of each form is what makes
+ * the two gates see what the mail server will actually deliver to.
+ *
+ * Everything is folded to one spelling, since an address differing only by case
+ * is the same mailbox and must not read as a different one.
+ */
+
+// Anything inside angle brackets is the address; the rest is a display name.
+// Mail clients quote a name containing a comma, so the split below has to look
+// past quoted sections or "Pla, Núria" <a@b> becomes two broken recipients.
+const splitOnUnquotedCommas = (value: string): string[] => {
+	const parts: string[] = []
+	let current = ''
+	let inQuotes = false
+	let inAngles = false
+	for (const char of value) {
+		if (char === '"') inQuotes = !inQuotes
+		else if (char === '<') inAngles = true
+		else if (char === '>') inAngles = false
+		if (char === ',' && !inQuotes && !inAngles) {
+			parts.push(current)
+			current = ''
+			continue
+		}
+		current += char
+	}
+	parts.push(current)
+	return parts
+}
+
+const bareAddress = (value: string): string => {
+	const angled = value.match(/<([^>]*)>/)
+	return (angled?.[1] ?? value).trim().toLowerCase()
+}
+
+/**
+ * Where a reply to this message goes.
+ *
+ * A reply is addressed to whoever wrote the thing it answers. On a message that
+ * came in, that is the sender — the `to` on such a row is our own mailbox, so
+ * replying to it would send the message back to ourselves. On one we sent, the
+ * people it went to are already the right ones.
+ *
+ * Both the send and the check that runs before it ask this, and they have to
+ * agree: a guard that judges one mailbox while the message goes to another is
+ * worse than no guard, because it reads as having checked.
+ *
+ * Falling back to `to` covers messages stored before the sender was written
+ * down — wrong for those, but no more wrong than it already was, and it never
+ * leaves a reply with nobody to go to.
+ */
+export const replyAddressees = (message: {
+	readonly direction: string
+	readonly recipients: {
+		readonly from?: string | null
+		readonly to?: ReadonlyArray<string>
+	} | null
+}): ReadonlyArray<string> =>
+	message.direction === 'inbound' && message.recipients?.from
+		? [message.recipients.from]
+		: (message.recipients?.to ?? [])
+
+/**
+ * Every distinct mailbox named across the lists given, in the form the database
+ * stores. Empty entries are dropped rather than compared, since an empty string
+ * matches nothing and only widens the query.
+ */
+export const recipientAddresses = (
+	...lists: ReadonlyArray<string | ReadonlyArray<string> | undefined>
+): string[] => [
+	...new Set(
+		lists
+			.flatMap(list =>
+				list === undefined ? [] : typeof list === 'string' ? [list] : [...list],
+			)
+			.flatMap(splitOnUnquotedCommas)
+			.map(bareAddress)
+			.filter(address => address !== ''),
+	),
+]


### PR DESCRIPTION
## What

Sending email through an assistant stopped far too often, and when it stopped there was no way to answer it.

Out of one real batch of sixteen sends, seven were refused. Every one of those refusals was over a word that says nothing bad about the address, and none of them could be answered, because the assistants actually in use — Claude.ai and ChatGPT — cannot display a confirmation prompt. The work then had to be handed back to a person to click through a risk they had already accepted, in words, before the send was attempted.

So: the guard now fires only when there is something to fire about, and every way it can stop has an answer that needs no prompt. Reviewing it turned up several more ways an email could go somewhere it should not, and one where replies were going to the wrong place entirely — those are here too. CRM, in `server`, plus one line in `mail-worker`.

## The fix

**Which sends stop**

- **Only `undeliverable` and `risky` stop a send.** A "catch-all" domain accepts every name thrown at it, so a check against one learns nothing about the specific mailbox — the verification vendor collapses even a *good* result to `catch_all` when the domain behaves that way. "Inconclusive" states exactly what having no verdict states, which has always been let through. A word the vocabulary does not recognise still stops a send, since the column takes free text and anything off-list is unvetted.
- **The question is asked of the addresses, not of the person.** Naming a contact is optional, so a send that named nobody was never judged; and one that did name somebody was judged by the verdict on their default address, which is not necessarily where the message was going.
- **Every assistant send path runs it** — including `manage_email_draft(action:"send")`, which ran no check at all, so writing a message down first was a complete way around.

**How a stop is answered**

- **`action:"vouch"`** on `manage_contact_channels` / `manage_company_channels` records that somebody stands behind an address, and the guard stops asking. It does not overwrite the deliverability verdict: what a probe found and what a person will vouch for are different claims, and only one of them is something a human can make. It settles the address rather than the row, since the same mailbox commonly sits on both a person and their company — and it is dropped if the address is later corrected.
- **`action:"unvouch"`** takes it back, and only ever lifts a vouch.
- **A stopped send names the call that lifts it.** Nothing on this surface turns an address back into the record holding it, so without that the one way past the stop was unreachable.
- **`acknowledge_thread_length: true`** on `reply_email` answers the message-count stop. That one is not about an address, so there is nothing to record and nothing to carry forward — the per-call flag the issue originally asked for, in the one place it genuinely fits.

**Ways mail reached somewhere it should not**

- **Replies went to your own inbox.** `mail-worker` read the sender and threw it away, and the reply fell back to the newest message's `To:` — which on a message that came in is you. Now stored, and the send and the guard read it through one place so they cannot disagree.
- **`cc` and `bcc` were never checked against the block on bounced addresses**, though they were delivered to — on every path, the web app included.
- **`Núria <nuria@…>` and comma-lists matched nothing on file**, so a recipient written the way a mail client shows it went out unjudged by either check.
- **A vouch could be lifted from under a bounce** that landed mid-request, since the write did not re-check what the guard had just read.

## Impact

- **No migration and no schema change.** `channels.status` already declared `valid`; nothing had written it.
- **No new environment variables.**
- **Tool surface:** both channel tools gain `vouch` / `unvouch` and a `note`; `reply_email` gains `acknowledge_thread_length`. No tool added or removed.
- **`mail-worker` writes one more key** into the stored `recipients` JSON. Old rows have no sender and fall back to the previous behaviour, so nothing breaks and nothing is backfilled — threads that pre-date this keep replying the way they did.
- **Behaviour change on the human path:** a `cc`/`bcc` to a hard-bounced address is now refused in the web app too. Correct, but it is the one change here a person could notice.
- **Multi-org:** the address lookup is scoped by `organization_id` explicitly and sits behind row-level security, exactly as the bounce check beside it does. It is index-backed by `channels_org_address_idx`.
- **The hard block is untouched and now reaches further.** An address that hard-bounced is still refused outright everywhere, and no vouch lifts it.

## Review guide

Start at `isRiskyEmailVerdict` and `riskyRecipientFor` in `apps/server/src/mcp/tools/email.ts`, then `vouchForChannel` in `apps/server/src/services/channels.ts`.

**The riskiest hunk is the vouch/suppression interaction.** A bounce is recorded in `channels.status` — the exact column a vouch writes. Unguarded, vouching for a hard-bounced address would not merely disagree with the bounce, it would lift it for the whole organisation, silently, through a tool whose description says nothing about bounces. So the write refuses on `bounced`/`complained`, re-checks in its own `WHERE` against a bounce landing mid-request, and points at `clear_email_suppression` instead. There is a test asserting the bounce *and its reason* survive a refused vouch untouched.

**Second: the reply change alters who replies are addressed to.** It is a correction — they were going to your own mailbox — but it is the sharpest behaviour change here.

**Calls you might overrule:**
- The lookup matches an address anywhere in the organisation rather than on the one contact named. Same scope the bounce check has always used, and for the same reason: an address is the same mailbox whichever record holds it. That is also why a vouch settles the address rather than the row.
- A vouch records a note and a timestamp but **not who made it** — `channels` has no actor column, and I would rather claim nothing than bolt on half an audit trail. An assistant can therefore vouch without a human in the loop, the same as every other write on this surface. If that is not good enough, the fix is a column or a timeline event, and it wants its own decision.

**Not run:** I did not drive a live send — the MCP tools available to me point at the real organisation. The SQL contract and the verdict rules are covered by tests; the wiring between them is not.

Skip the skill markdown; it is documentation, not behaviour.

## Tests

`recipient-address.test.ts` covers the address forms and the reply-addressee choice, including that an inbound message answers the sender rather than us. `email.test.ts` covers the verdict rules, including that `unknown` and "no verdict at all" answer identically — the equivalence the whole change rests on.

`email-verdict-gate.integration.test.ts` runs against live Postgres and **calls the guard rather than restating its query** — an earlier version re-implemented the SQL, which would have passed just as happily once the real one broke. It pins the two old holes as tests (the contact-keyed lookup returning nothing for a company mailbox, and returning the wrong answer for a second address), plus cross-organisation isolation, the display-name form, and every way a vouch is refused, honoured, dropped on rename, or withdrawn.

## Verification

After rebasing onto current `main`: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (21/21 — 847 server, 154 internal, 54 controllers, 38 cli), `pnpm -w build` (13/13), and the full server integration suite (96 files, 667 tests) against live Postgres. The pre-push hook ran the suite again.

No UI touched, so there is nothing to screenshot.

## A note on clearing a verdict

While this was in review, `feat: let a verdict be taken back off an address, not only lowered` landed on main, letting a caller clear a verdict to null — deliberately, so a guess somebody wrote down is recorded as nothing rather than as a check that came back doubtful.

I had gone the other way here, removing `unknown` from the hand-settable words because, once `unknown` stopped holding a send back, writing it silenced the guard in one call and destroyed the finding. **I have dropped that**: `packages/domain/src/schema` is now identical to main. With null-clearing in place my removal bought nothing — the same door is simply spelled differently — and the web app now offers clearing to a person too, so an assistant doing it is the product working rather than a hole.

What remains true, and is why `vouch` is still worth using: clearing lifts a stop by throwing the finding away, while vouching lifts it and keeps the finding, refuses on a bounce, and records what it rested on. The tool descriptions now say exactly that, so the cheaper path is not the better-documented one.

## Deferred

- **Recording who vouched**, which needs a column or a timeline event.
- **A bounced company mailbox has no remedy** — `clear_email_suppression` is contacts-only. Pre-existing, and now more visible since a company address can be vouched for but not un-bounced.
- **Company and site addresses can never reach `bounced`** at all: the bounce handler joins contacts only. So the vouch refusal on the company tool is currently unreachable.
- **The web app neither shows nor sets a vouch.** Only assistants are held back today, but a person looking at a contact cannot see that somebody vouched.

Closes #408
