### PR TITLE
fix: ask one question about a blocked address, not two that disagree

### DIFF
--- a/apps/internal/src/atoms/emails-atoms.ts
+++ b/apps/internal/src/atoms/emails-atoms.ts
@@ -136,6 +136,12 @@ export const createDraftAtom = BatudaApiAtom.mutation('email', 'createDraft')
 export const updateDraftAtom = BatudaApiAtom.mutation('email', 'updateDraft')
 export const deleteDraftAtom = BatudaApiAtom.mutation('email', 'deleteDraft')
 export const sendDraftAtom = BatudaApiAtom.mutation('email', 'sendDraft')
+// Which addresses in a draft a send would be refused over, so the compose
+// screen can warn while the message is being written rather than on send.
+export const checkSuppressedAtom = BatudaApiAtom.mutation(
+	'email',
+	'checkSuppressed',
+)
 
 // ── Footers ──
 export const createFooterAtom = BatudaApiAtom.mutation('email', 'createFooter')

--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -8,8 +8,8 @@ import styled from 'styled-components'
 import type { EmailBlocks } from '@batuda/email/schema'
 import { PriButton, PriInput, PriSelect } from '@batuda/ui/pri'
 
-import { contactsAtomFor } from '#/atoms/company-atoms'
 import {
+	checkSuppressedAtom,
 	createDraftAtom,
 	deleteDraftAtom,
 	emailsSearchAtom,
@@ -18,16 +18,13 @@ import {
 	threadAtomFor,
 	updateDraftAtom,
 } from '#/atoms/emails-atoms'
-import {
-	narrowChannels,
-	primaryEmailChannel,
-} from '#/components/contacts/display-channels'
 import { AttachmentPicker } from '#/components/emails/attachment-picker'
 import { EmailEditor } from '#/components/emails/email-editor'
 import { SrOnly } from '#/components/shared/sr-only'
 import { type Draft, useComposeEmail } from '#/context/compose-email-context'
 import { authClient } from '#/lib/auth-client'
 import type { StagedAttachment } from '#/lib/email-attachments'
+import { badRequestMessage, suppressedRecipient } from '#/lib/tagged-failure'
 
 type InboxOption = {
 	readonly id: string
@@ -55,11 +52,12 @@ type SendState = 'idle' | 'sending' | 'error'
 
 type SuppressedAddress = {
 	readonly email: string
-	readonly name: string
 	readonly reason: 'bounced' | 'complained'
 }
 
 const SAVE_DEBOUNCE_MS = 300
+// Typing an address should not put a request on the wire per keystroke.
+const SUPPRESSION_CHECK_DEBOUNCE_MS = 400
 
 export function ComposeForm({ draft }: { readonly draft: Draft }) {
 	const { t } = useLingui()
@@ -154,11 +152,9 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 	// with paired 200 + 499 (InterruptError) entries. Setting this
 	// flag inside the effect body ensures only one POST goes out.
 	const draftCreationStartedRef = useRef(false)
-	// Reset on every effect run + tear down on cleanup. The previous
-	// "() => () => false" shape only flipped to false in cleanup and
-	// never re-asserted true on the StrictMode re-run, leaving the
-	// createDraft `.then` handler convinced the form had unmounted
-	// and skipping the setServerId call.
+	// Set true on every run, not just the first: StrictMode tears the first
+	// run down, and without re-asserting it the createDraft reply would look
+	// like it arrived after the form closed and its id would be dropped.
 	useEffect(() => {
 		mountedRef.current = true
 		return () => {
@@ -212,13 +208,10 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		updateMeta,
 	])
 
-	// `pendingPatchRef` accumulates every patch issued since the last
-	// timer fire. The previous version captured only the latest patch in
-	// the closure and discarded earlier keys when a new patchForm call
-	// reset the timer — a Send click that landed before the timer fired
-	// would push only the most recent field, leaving `to`/`subject`/body
-	// out of the saved draft and the server rejecting with EENVELOPE
-	// "No recipients defined".
+	// Every field touched since the last save is kept, not only the newest
+	// one: each keystroke restarts the timer, so a Send landing before it
+	// fires would otherwise save one field and leave the recipient, subject
+	// and body behind — and the server refuses a draft with no recipient.
 	const pendingPatchRef = useRef<Partial<DraftForm>>({})
 	const debouncedSave = useCallback(
 		(patch: Partial<DraftForm>) => {
@@ -356,16 +349,29 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 				payload: { inboxId: effectiveInboxId },
 			})
 			if (exit._tag !== 'Success') {
-				throw new Error('Send failed')
+				// With several recipients, only the server knows which one it turned
+				// away and why, so say that rather than a bare "Send failed" the
+				// reader cannot act on.
+				const blocked = suppressedRecipient(exit.cause)
+				if (blocked !== null) {
+					const why =
+						blocked.status === 'bounced'
+							? t`Mail to ${blocked.recipient} bounced, so it is blocked.`
+							: t`${blocked.recipient} reported a message as spam, so it is blocked.`
+					throw new Error(
+						blocked.reason === null
+							? why
+							: `${why} ${t`The receiving server said: ${blocked.reason}`}`,
+					)
+				}
+				throw new Error(badRequestMessage(exit.cause) ?? t`Send failed`)
 			}
 			refreshList()
 			if (draft.threadId) refreshThread()
 			close(draft.id)
 		} catch (error) {
 			setSendState('error')
-			setErrorMessage(
-				error instanceof Error ? error.message : 'Failed to send email',
-			)
+			setErrorMessage(error instanceof Error ? error.message : t`Send failed`)
 		}
 	}, [
 		effectiveInboxId,
@@ -381,6 +387,7 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		close,
 		draft.id,
 		draft.threadId,
+		t,
 	])
 
 	const handleDiscard = useCallback(async () => {
@@ -545,15 +552,12 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 				/>
 			</BodyField>
 
-			{draft.companyId !== undefined ? (
-				<SuppressionGuard
-					companyId={draft.companyId}
-					to={form.to}
-					cc={form.cc}
-					bcc={form.bcc}
-					onChange={setSuppressed}
-				/>
-			) : null}
+			<SuppressionGuard
+				to={form.to}
+				cc={form.cc}
+				bcc={form.bcc}
+				onChange={setSuppressed}
+			/>
 
 			{suppressed.length > 0 ? (
 				<SuppressionBanner role='alert'>
@@ -616,63 +620,58 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 	)
 }
 
+// Warns that an address will be refused while the message is still being
+// written. Only the server knows every blocked address — a company's own
+// mailbox, a contact's second address, one typed by hand — so it is asked
+// rather than guessed at from whatever this screen happens to have loaded.
+//
+// A check that fails clears the warning instead of raising one: the send is the
+// real refusal, and a warning nobody can explain is worse than none.
 function SuppressionGuard({
-	companyId,
 	to,
 	cc,
 	bcc,
 	onChange,
 }: {
-	readonly companyId: string
 	readonly to: string
 	readonly cc: string
 	readonly bcc: string
 	readonly onChange: (next: ReadonlyArray<SuppressedAddress>) => void
 }) {
-	const contactsResult = useAtomValue(contactsAtomFor(companyId))
-	const contacts = useMemo(
-		() =>
-			AsyncResult.isSuccess(contactsResult)
-				? contactsResult.value.items
-				: undefined,
-		[contactsResult],
-	)
+	const check = useAtomSet(checkSuppressedAtom, { mode: 'promiseExit' })
 
 	useEffect(() => {
-		if (contacts === undefined) {
-			onChange([])
-			return
-		}
-		const suppressedMap = new Map<string, SuppressedAddress>()
-		for (const raw of contacts) {
-			if (raw === null || typeof raw !== 'object') continue
-			const r = raw as Record<string, unknown>
-			// A contact's email and suppression state live on its primary email
-			// channel, not as top-level `email`/`emailStatus` fields, so derive
-			// both from that channel.
-			const primaryEmail = primaryEmailChannel(narrowChannels(r['channels']))
-			const email = primaryEmail?.value ?? null
-			const status = primaryEmail?.status
-			if (email === null) continue
-			if (status !== 'bounced' && status !== 'complained') continue
-			const name = typeof r['name'] === 'string' ? r['name'] : email
-			suppressedMap.set(email.toLowerCase(), { email, name, reason: status })
-		}
-		const seen = new Set<string>()
-		const out: SuppressedAddress[] = []
-		for (const raw of [
+		const addresses = [
 			...splitAddresses(to),
 			...splitAddresses(cc),
 			...splitAddresses(bcc),
-		]) {
-			const key = raw.toLowerCase()
-			if (seen.has(key)) continue
-			seen.add(key)
-			const match = suppressedMap.get(key)
-			if (match !== undefined) out.push(match)
+		]
+		if (addresses.length === 0) {
+			onChange([])
+			return
 		}
-		onChange(out)
-	}, [contacts, to, cc, bcc, onChange])
+		let cancelled = false
+		const timer = setTimeout(() => {
+			void (async () => {
+				const exit = await check({ payload: { addresses } })
+				if (cancelled) return
+				if (exit._tag !== 'Success') {
+					onChange([])
+					return
+				}
+				onChange(
+					exit.value.suppressed.map(row => ({
+						email: row.address,
+						reason: row.status,
+					})),
+				)
+			})()
+		}, SUPPRESSION_CHECK_DEBOUNCE_MS)
+		return () => {
+			cancelled = true
+			clearTimeout(timer)
+		}
+	}, [to, cc, bcc, check, onChange])
 
 	return null
 }

--- a/apps/internal/src/lib/tagged-failure.ts
+++ b/apps/internal/src/lib/tagged-failure.ts
@@ -40,3 +40,33 @@ export function badRequestMessage(cause: unknown): string | null {
 	const message = taggedFailure(cause, 'BadRequest')?.['message']
 	return typeof message === 'string' && message !== '' ? message : null
 }
+
+/** Why a send was refused: the address that is blocked, and what it did. */
+export type SuppressedRecipient = {
+	readonly recipient: string
+	readonly status: 'bounced' | 'complained'
+	readonly reason: string | null
+}
+
+/**
+ * The address a send was refused over, or null when the failure was something
+ * else. The server names the address, says whether it bounced or was reported
+ * as spam, and passes on whatever the receiving server said, so a screen can
+ * point at the one recipient at fault instead of blaming the whole send.
+ */
+export function suppressedRecipient(
+	cause: unknown,
+): SuppressedRecipient | null {
+	const error = taggedFailure(cause, 'EmailSuppressed')
+	if (error === null) return null
+	const recipient = error['recipient']
+	const status = error['status']
+	if (typeof recipient !== 'string' || recipient === '') return null
+	if (status !== 'bounced' && status !== 'complained') return null
+	const reason = error['reason']
+	return {
+		recipient,
+		status,
+		reason: typeof reason === 'string' && reason !== '' ? reason : null,
+	}
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -162,6 +162,11 @@ msgstr "{0} ja no permet iniciar la sessió amb contrasenya a les aplicacions de
 msgid "{0} ready to apply, {1} need reading, {attentionTotal} runs need attention."
 msgstr "{0} a punt d’aplicar, {1} per llegir, {attentionTotal} execucions requereixen atenció."
 
+#. placeholder {0}: blocked.recipient
+#: src/components/emails/compose-form.tsx
+msgid "{0} reported a message as spam, so it is blocked."
+msgstr "{0} ha marcat un missatge com a brossa, així que està bloquejada."
+
 #. placeholder {0}: selection.selectedCount
 #: src/components/companies/pipeline-board.tsx
 msgid "{0} selected"
@@ -3131,6 +3136,11 @@ msgstr "Baixa"
 msgid "Low priority"
 msgstr "Prioritat baixa"
 
+#. placeholder {0}: blocked.recipient
+#: src/components/emails/compose-form.tsx
+msgid "Mail to {0} bounced, so it is blocked."
+msgstr "El correu a {0} ha rebotat, així que està bloquejada."
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Make {0} the address you send from"
@@ -5077,6 +5087,11 @@ msgstr "Enviament bloquejat: aquests destinataris no poden rebre correu"
 msgid "Send email"
 msgstr "Envia correu"
 
+#: src/components/emails/compose-form.tsx
+#: src/components/emails/compose-form.tsx
+msgid "Send failed"
+msgstr "No s’ha pogut enviar"
+
 #: src/routes/forgot-password.tsx
 msgid "Send reset link"
 msgstr "Envia l'enllaç"
@@ -5751,6 +5766,11 @@ msgstr "No s'han pogut recuperar les persones d'aquesta empresa. Comprova que la
 #: src/components/companies/proposals-panel.tsx
 msgid "The proposals for this company could not be fetched. Check that the session is valid, then try again."
 msgstr "No s'han pogut recuperar les propostes d'aquesta empresa. Comprova que la sessió sigui vàlida i torna-ho a provar."
+
+#. placeholder {0}: blocked.reason
+#: src/components/emails/compose-form.tsx
+msgid "The receiving server said: {0}"
+msgstr "El servidor que el rep ha dit: {0}"
 
 #: src/routes/companies/$slug.tsx
 msgid "The research runs for this company could not be fetched. Check that the session is valid, then try again."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -162,6 +162,11 @@ msgstr "{0} no longer allows password sign-in for mail apps, so it can't be conn
 msgid "{0} ready to apply, {1} need reading, {attentionTotal} runs need attention."
 msgstr "{0} ready to apply, {1} need reading, {attentionTotal} runs need attention."
 
+#. placeholder {0}: blocked.recipient
+#: src/components/emails/compose-form.tsx
+msgid "{0} reported a message as spam, so it is blocked."
+msgstr "{0} reported a message as spam, so it is blocked."
+
 #. placeholder {0}: selection.selectedCount
 #: src/components/companies/pipeline-board.tsx
 msgid "{0} selected"
@@ -3131,6 +3136,11 @@ msgstr "Low"
 msgid "Low priority"
 msgstr "Low priority"
 
+#. placeholder {0}: blocked.recipient
+#: src/components/emails/compose-form.tsx
+msgid "Mail to {0} bounced, so it is blocked."
+msgstr "Mail to {0} bounced, so it is blocked."
+
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
 msgid "Make {0} the address you send from"
@@ -5077,6 +5087,11 @@ msgstr "Send blocked: these recipients cannot receive email"
 msgid "Send email"
 msgstr "Send email"
 
+#: src/components/emails/compose-form.tsx
+#: src/components/emails/compose-form.tsx
+msgid "Send failed"
+msgstr "Send failed"
+
 #: src/routes/forgot-password.tsx
 msgid "Send reset link"
 msgstr "Send reset link"
@@ -5751,6 +5766,11 @@ msgstr "The people at this company could not be fetched. Check that the session 
 #: src/components/companies/proposals-panel.tsx
 msgid "The proposals for this company could not be fetched. Check that the session is valid, then try again."
 msgstr "The proposals for this company could not be fetched. Check that the session is valid, then try again."
+
+#. placeholder {0}: blocked.reason
+#: src/components/emails/compose-form.tsx
+msgid "The receiving server said: {0}"
+msgstr "The receiving server said: {0}"
 
 #: src/routes/companies/$slug.tsx
 msgid "The research runs for this company could not be fetched. Check that the session is valid, then try again."

--- a/apps/server/src/handlers/contacts.ts
+++ b/apps/server/src/handlers/contacts.ts
@@ -294,7 +294,10 @@ export const ContactsLive = HttpApiBuilder.group(
 				)
 				.handle('clearSuppression', _ =>
 					Effect.gen(function* () {
-						yield* clearEmailSuppression(sql, _.params.id)
+						yield* clearEmailSuppression(sql, {
+							table: 'contacts' as const,
+							id: _.params.id,
+						})
 						const ch = yield* channelsOf(sql, {
 							table: 'contacts' as const,
 							id: _.params.id,

--- a/apps/server/src/handlers/email.ts
+++ b/apps/server/src/handlers/email.ts
@@ -433,6 +433,12 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 						),
 				)
 				.handle('deleteFooter', _ => svc.deleteFooter(_.params.id))
+				.handle('checkSuppressed', _ =>
+					svc.checkSuppressed(_.payload.addresses).pipe(
+						Effect.map(suppressed => ({ suppressed })),
+						Effect.catchTag('SqlError', e => Effect.die(e)),
+					),
+				)
 				.handle('discardStagedAttachment', _ =>
 					staging
 						.discard(_.query.inboxId, _.params.stagingId)

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -263,7 +263,11 @@ export const ContactHandlersLive = ContactTools.toLayer(
 						...(siteId === undefined ? {} : { siteId }),
 						updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 					})} WHERE id = ${id} RETURNING *`
-					if (clear_email_suppression) yield* clearEmailSuppression(sql, id)
+					if (clear_email_suppression)
+						yield* clearEmailSuppression(sql, {
+							table: 'contacts' as const,
+							id,
+						})
 					if (channels && channels.length > 0) {
 						yield* writeChannels(
 							sql,

--- a/apps/server/src/services/channels.ts
+++ b/apps/server/src/services/channels.ts
@@ -540,19 +540,76 @@ export const deleteSubjectChannels = (
 			AND organization_id = ${orgId}
 	`
 
+/** One address the organisation is holding back, and what it did. */
+export interface SuppressedAddress {
+	readonly address: string
+	readonly status: 'bounced' | 'complained'
+	readonly statusReason: string | null
+	/** The person holding it, when one does — a company mailbox answers null. */
+	readonly contactId: string | null
+}
+
 /**
- * Reset a person's email suppression to `unknown` — used after a
- * bounced/complained contact confirms the address is good again, re-enabling
- * outbound mail to it.
+ * Which of these addresses the organisation is holding mail back from.
+ *
+ * Keyed on the address and the organisation, never on a subject: an address that
+ * bounced is the same address whichever record happens to hold it. Asking by
+ * subject instead walks past company mailboxes, second addresses, and anything
+ * typed in by hand.
  */
-export const clearEmailSuppression = (sql: Sql, contactId: string) =>
+export const suppressedAmong = (
+	sql: Sql,
+	orgId: string,
+	addresses: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<SuppressedAddress>, SqlError.SqlError> =>
+	Effect.gen(function* () {
+		const normalised = [
+			...new Set(
+				addresses
+					.map(address => address.trim().toLowerCase())
+					.filter(address => address !== ''),
+			),
+		]
+		if (normalised.length === 0) return []
+
+		// One row per address, not per record holding it: a bounce is recorded
+		// against every record with that address, so a mailbox two people are
+		// listed under would otherwise answer twice and read as two problems. The
+		// most recently updated record is the one that answers.
+		const rows = yield* sql<SuppressedAddress>`
+			SELECT DISTINCT ON (lower(address))
+				lower(address) AS address, status, status_reason,
+				CASE WHEN subject_table = 'contacts' THEN subject_id END AS contact_id
+			FROM channels
+			WHERE organization_id = ${orgId}
+				AND channel = 'email'
+				AND lower(address) = ANY(${normalised})
+				AND status IN ('bounced', 'complained')
+			ORDER BY lower(address), status_updated_at DESC NULLS LAST
+		`
+		return rows
+	})
+
+/**
+ * Let mail go to one company's, branch's or person's addresses again, after a
+ * bounce or a complaint turns out to have been a false alarm.
+ *
+ * Clears one subject's rows, which is narrower than the block it lifts: the send
+ * gate asks whether an address has bounced anywhere in the organisation, and a
+ * bounce is recorded against every record holding it. So an address two people
+ * are both listed under stays blocked until both are cleared.
+ */
+export const clearEmailSuppression = (
+	sql: Sql,
+	subject: { readonly table: ChannelSubject; readonly id: string },
+) =>
 	sql`
 		UPDATE channels
 		SET status = 'unknown',
 		    status_reason = NULL,
 		    status_updated_at = now(),
 		    soft_bounce_count = 0
-		WHERE subject_table = 'contacts'
-			AND subject_id = ${contactId}
+		WHERE subject_table = ${subject.table}
+			AND subject_id = ${subject.id}
 			AND channel = 'email'
 	`

--- a/apps/server/src/services/email-suppression.integration.test.ts
+++ b/apps/server/src/services/email-suppression.integration.test.ts
@@ -5,23 +5,27 @@ process.env['DATABASE_URL'] ??=
 
 import { randomUUID } from 'node:crypto'
 
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
 import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { clearEmailSuppression, suppressedAmong } from './channels'
 
 // SQL-contract test for the question the send gate asks before every email:
 // "has this address hard-bounced or reported spam?"
 //
-// It used to be asked of a *person* — "is this contact's address suppressed?" —
-// and only when the send named one. Two ordinary ways of writing an email name
-// no person at all: replying to a thread that arrived from a shared mailbox
-// (inbound mail deliberately invents nobody for a role address), and the "email
-// this company" button. Both skipped the check entirely, so a company mailbox
-// that hard-bounced was written to again, and again.
+// It is asked of the address, not of whoever holds it. Two ordinary ways of
+// writing an email name no person at all — replying to a thread that arrived
+// from a shared mailbox (inbound mail deliberately invents nobody for a role
+// address), and the "email this company" button — so a check that starts from a
+// person walks straight past a company mailbox that hard-bounced.
 //
-// The rows this seeds are the ones that used to be unreachable: a bounced address
-// belonging to a company rather than to a person. What is pinned is that the
-// address-keyed lookup finds them, that the old contact-keyed one could not, and
-// that the lookup cannot reach across organisations.
+// The rows this seeds are the ones only an address-keyed lookup reaches: a
+// bounced address belonging to a company rather than to a person. What is
+// pinned is that the lookup finds them, and that it cannot reach across
+// organisations.
 //
 // Prereq: `pnpm cli services up` so Postgres is reachable.
 
@@ -186,6 +190,102 @@ describe('suppression keyed on the address rather than on a person', () => {
 		it('should find nothing, so the send proceeds', async () => {
 			const found = await suppressionFor(ORG, ['fine@tallerpuig.example'])
 			expect(found.rows).toHaveLength(0)
+		})
+	})
+})
+
+const run = <A>(effect: Effect.Effect<A, unknown, SqlClient.SqlClient>) =>
+	effect.pipe(Effect.provide(PgLive), Effect.runPromise)
+
+// Everything above runs a hand-written copy of the query. What follows drives
+// the shipped functions, so the copy and the code cannot quietly diverge.
+describe('the lookup the send gate and the pre-send check share', () => {
+	describe('when asked about a mix of addresses', () => {
+		it('should name only the ones being held back', async () => {
+			// GIVEN a company mailbox that bounced, a person's that bounced, and one
+			// that never did — the shape a real recipient list has
+			const found = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* suppressedAmong(sql, ORG, [
+						COMPANY_MAILBOX,
+						'fine@tallerpuig.example',
+						PERSON_ADDRESS,
+					])
+				}),
+			)
+
+			// THEN both blocked ones come back and the good one does not, so a
+			// caller can name exactly which recipient is the problem
+			expect(found.map(row => row.address).sort()).toEqual(
+				[COMPANY_MAILBOX, PERSON_ADDRESS].sort(),
+			)
+		})
+
+		it('should not care how the address was spelled', async () => {
+			// GIVEN the same address typed with capitals and stray spacing, which is
+			// how somebody pastes one in
+			const found = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* suppressedAmong(sql, ORG, [
+						`  ${COMPANY_MAILBOX.toUpperCase()} `,
+					])
+				}),
+			)
+
+			// THEN it is still found — a block a different capitalisation walks past
+			// is not a block
+			expect(found).toHaveLength(1)
+		})
+
+		it('should answer nothing for an empty list without asking the database', async () => {
+			// GIVEN nothing usable to ask about: an empty entry and one that is only
+			// spacing
+			const found = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* suppressedAmong(sql, ORG, ['', '   '])
+				}),
+			)
+
+			// THEN nothing is held back
+			expect(found).toEqual([])
+		})
+	})
+
+	describe('when a company mailbox is cleared', () => {
+		it('should let mail go to it again', async () => {
+			// GIVEN a company mailbox being held back
+			// WHEN the clear is asked for by company rather than by person
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* clearEmailSuppression(sql, {
+						table: 'companies',
+						id: companyId,
+					})
+				}),
+			)
+
+			// THEN the gate stops finding it
+			const found = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* suppressedAmong(sql, ORG, [COMPANY_MAILBOX])
+				}),
+			)
+			expect(found).toEqual([])
+
+			// AND the person's own block is untouched — clearing one subject's
+			// addresses says nothing about anybody else's
+			const others = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* suppressedAmong(sql, ORG, [PERSON_ADDRESS])
+				}),
+			)
+			expect(others).toHaveLength(1)
 		})
 	})
 })

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -48,6 +48,7 @@ const UUID_PATTERN =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 import { CalendarService } from './calendar.js'
+import { suppressedAmong } from './channels.js'
 import { CredentialCrypto } from './credential-crypto.js'
 import type { ResolvedStaging, StagingRef } from './email-attachment-staging.js'
 import { EmailAttachmentStaging } from './email-attachment-staging.js'
@@ -137,17 +138,6 @@ export const retrySmtpSend = <A, E>(
 // PgClient.transformResultNames in apps/server/src/db/client.ts converts
 // snake_case columns to camelCase on read, so every row type in this file
 // is camelCase even though the SQL selects use snake_case.
-// The suppression query filters to these two, so the row type narrows to them.
-// The contact is whoever happens to hold the address, and is null when it is a
-// company's own mailbox — which is exactly the case the check used to miss.
-type SuppressionRow = {
-	status: 'bounced' | 'complained'
-	statusReason: string | null
-	contactId: string | null
-}
-
-const firstRecipient = (to: string | string[]): string =>
-	Array.isArray(to) ? (to[0] ?? '') : to
 
 const encodeClientId = (ctx: {
 	companyId?: string
@@ -494,9 +484,8 @@ export class EmailService extends Context.Service<EmailService>()(
 			 * That matters because two ways of writing an email name no person at
 			 * all: a reply to a thread that arrived from a shared mailbox — inbound
 			 * mail deliberately invents nobody for a role address — and the "email
-			 * this company" button, which opens on a company. Both used to skip the
-			 * check entirely, so a company mailbox that hard-bounced was written to
-			 * again, and again, by design.
+			 * this company" button, which opens on a company. A check that started
+			 * from a person would let both write to a hard-bounced mailbox.
 			 *
 			 * It is asked of every recipient, and of the whole organisation's
 			 * addresses rather than one record's: an address that bounced is the
@@ -513,21 +502,17 @@ export class EmailService extends Context.Service<EmailService>()(
 						.map(r => r.trim().toLowerCase())
 						.filter(r => r !== '')
 					if (recipients.length === 0) return
-					const rows = yield* sql<SuppressionRow>`
-						SELECT status, status_reason,
-							CASE WHEN subject_table = 'contacts' THEN subject_id END AS contact_id
-						FROM channels
-						WHERE organization_id = ${currentOrg.id}
-						  AND channel = 'email'
-						  AND lower(address) = ANY(${recipients})
-						  AND status IN ('bounced', 'complained')
-						LIMIT 1
-					`
+					// The same lookup `checkSuppressed` answers with, so a warning given
+					// beforehand and the refusal here cannot disagree.
+					const rows = yield* suppressedAmong(sql, currentOrg.id, recipients)
 					const row = rows[0]
 					if (row) {
 						return yield* new EmailSuppressed({
 							contactId: row.contactId,
-							recipient: firstRecipient(recipient),
+							// Name the blocked address, not the first recipient: with several
+							// recipients they are rarely the same, and the wrong name sends
+							// somebody off to fix an address that is fine.
+							recipient: row.address,
 							status: row.status,
 							reason: row.statusReason,
 						})
@@ -1895,6 +1880,22 @@ export class EmailService extends Context.Service<EmailService>()(
 						return yield* decodeMessage(
 							projectAttachmentsForWire(rows[0] as Record<string, unknown>),
 						).pipe(Effect.orDie)
+					}),
+
+				/**
+				 * Which of these addresses a send would be refused over — the same
+				 * question `assertRecipientsNotSuppressed` asks, so a caller can warn
+				 * while a message is being written rather than after it is sent.
+				 */
+				checkSuppressed: (addresses: ReadonlyArray<string>) =>
+					Effect.gen(function* () {
+						const currentOrg = yield* CurrentOrg
+						const rows = yield* suppressedAmong(sql, currentOrg.id, addresses)
+						return rows.map(row => ({
+							address: row.address,
+							status: row.status,
+							reason: row.statusReason,
+						}))
 					}),
 
 				// ── Inbox CRUD ────────────────────────────────────────────────

--- a/packages/controllers/src/routes/email.ts
+++ b/packages/controllers/src/routes/email.ts
@@ -568,6 +568,36 @@ export const EmailGroup = HttpApiGroup.make('email')
 			success: Schema.Void,
 		}),
 	)
+	.add(
+		// Which of these addresses a send would be refused over, so a caller can say
+		// so while a message is being written rather than after it is sent. The same
+		// question the send path asks, answered by the same query, so the warning
+		// and the refusal cannot disagree.
+		//
+		// A POST for a read, because the addresses are somebody's personal data and
+		// a query string is the one place they would be logged and cached.
+		HttpApiEndpoint.post('checkSuppressed', '/email/suppressed', {
+			payload: Schema.Struct({
+				// 320 is as long as one address gets: 64 before the @, 255 after. The
+				// list is capped because a caller may ask on every keystroke and every
+				// address in it costs another index lookup on the connection other
+				// requests are waiting for. A list longer than this is a mail-merge,
+				// which is a different feature.
+				addresses: Schema.Array(
+					Schema.String.pipe(Schema.check(Schema.isMaxLength(320))),
+				).pipe(Schema.check(Schema.isMaxLength(200))),
+			}),
+			success: Schema.Struct({
+				suppressed: Schema.Array(
+					Schema.Struct({
+						address: Schema.String,
+						status: Schema.Literals(['bounced', 'complained']),
+						reason: Schema.NullOr(Schema.String),
+					}),
+				),
+			}),
+		}),
+	)
 	.middleware(SessionMiddleware)
 	.middleware(OrgMiddleware)
 	.prefix('/v1')


### PR DESCRIPTION
The warning that says "you can't send to this address" and the refusal that actually stops the send were two different pieces of code answering the same question, and they disagreed.

## The screen was guessing

`SuppressionGuard` worked the answer out client-side, from whatever contacts the compose screen happened to have loaded. Three ordinary addresses are not in that list:

- **A company's own mailbox.** `info@…`, `reserves@…` — nobody is listed under it, so it never appears among the loaded contacts. The "email this company" button opens straight onto one.
- **A person's second address.** Only the primary one gets carried into the compose screen's view of a contact.
- **Anything typed by hand.** No contact behind it at all, so nothing to match against.

In all three the screen showed no warning, Send stayed enabled, and the refusal only arrived after the message was written and sent. It asks the server now, debounced so typing doesn't put a request on the wire per keystroke.

## The question now has one home

`suppressedAmong(sql, orgId, addresses)` in `channels.ts` is the only place that asks it. The send gate calls it instead of the inline copy it carried, and the new `POST /v1/email/suppressed` answers it for the screen — same function, same rows, so the warning and the refusal cannot drift apart.

It is keyed on the address and the organisation, never on whoever holds the address: an address that bounced is the same address whichever record happens to hold it. `DISTINCT ON (lower(address))` means a mailbox two people are both listed under answers once — the bounce handler marks every record holding it, so without that it reads as two separate problems.

`POST` rather than `GET` for a read because the addresses are personal data, and a query string ends up in server logs, proxy caches, and browser history. Bounded at 200 addresses of 320 characters each (64 before the `@`, 255 after).

## Two things that were wrong regardless

**The refusal named the wrong address.** With several recipients it reported whichever was typed first, not the one that was actually blocked — sending the reader off to check an address that is perfectly fine.

**A company mailbox could not have a block lifted.** `clearEmailSuppression` spoke only for a person, while the gate blocks by address whoever holds it. A company's or a branch's own mailbox that hard-bounced was stuck permanently, with nothing in any surface able to release it. It takes a subject now, like everything else in that file.

Worth knowing: clearing is narrower than the block it lifts. It clears one subject's rows, and the gate asks whether the address has bounced anywhere in the organisation — so an address two people are both listed under stays blocked until both are cleared. That is intended, not a bug to file when a cleared address is still refused.

## What a person sees

A refused send now says which address was turned away and why, and repeats what the receiving server said, instead of reporting that sending failed. The one English string still hardcoded in that banner is translated with the rest.

## Verification

Driven against the live stack, signed in as a real user:

- A **company-only mailbox** marked bounced — no contact holds it — raises the warning and disables Send. This is the case the old guard could never see.
- With a good and a bad recipient together, the banner names **only the blocked one**.
- An address bounced in **another organisation** correctly raises nothing.

830 server unit tests, 660 integration (95 files), type-check clean, both catalogs complete at 1464/1464.

`pnpm check` exits 1 on this branch — every diagnostic is in files it does not touch (`.opencode/plugins`, `apps/cli`, `pipeline-board.tsx`, `packages/research`), so it fails identically on `main`.

## Not here

The bounce handler still only marks a **contact's** channels — it joins `FROM contacts c` — so a company mailbox that hard-bounces is recorded nowhere in the first place. This PR makes sure such a record is *found* and *clearable*; writing it is the other half, and belongs with the company channel panel.
