### PR TITLE
fix(server): hold an address's verdict to the five words it can be

### DIFF
--- a/apps/server/src/db/migrations/0064_channel_kind_and_primary.ts
+++ b/apps/server/src/db/migrations/0064_channel_kind_and_primary.ts
@@ -15,9 +15,8 @@ import { SqlClient } from 'effect/unstable/sql'
 // picks a different address, and a different one again on the next load.
 //
 // The app now folds a kind on the way in and hands the mark on when it is put
-// down. This puts right what was stored before that, and adds the index so the
-// pair cannot come back — a unique index as a race guard is one of the two things
-// docs/backend.md allows the database to decide.
+// down. This puts right what was stored before that. Nothing yet holds a kind to
+// a single mark — the note at the end of the file says why.
 
 export default Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient

--- a/apps/server/src/db/migrations/0065_channel_verdict_and_indexes.ts
+++ b/apps/server/src/db/migrations/0065_channel_verdict_and_indexes.ts
@@ -1,0 +1,31 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// A backstop under the five words an address's verdict can be, and two indexes
+// nothing needs.
+//
+// Nothing still running can write anything but these five, and the words that
+// predate that were put right by 0063, which is already live — so the check
+// cannot fail on what is on file. What it adds is that the column stays that way
+// through the next hand-run repair or one-off script, which is how the wrong
+// words got in.
+//
+// The two indexes are each the leading columns of a wider one that is already
+// there, so every lookup they served is served without them. They cost a write
+// on every insert and update to answer nothing that is asked.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		ALTER TABLE channels ADD CONSTRAINT channels_verification_chk
+			CHECK (verification IS NULL OR verification IN
+				('deliverable','risky','catch_all','undeliverable','unknown'))
+	`
+
+	// Covered by channels_subject_address_idx (subject_table, subject_id, channel, address).
+	yield* sql`DROP INDEX IF EXISTS channels_subject_idx`
+
+	// Covered by channels_org_address_idx (organization_id, channel, lower(address)).
+	yield* sql`DROP INDEX IF EXISTS idx_channels_org`
+})

--- a/apps/server/src/services/channel-verdict.integration.test.ts
+++ b/apps/server/src/services/channel-verdict.integration.test.ts
@@ -10,6 +10,8 @@ import { SqlClient } from 'effect/unstable/sql'
 import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+import type { VerificationVerdict } from '@batuda/domain'
+
 import { PgLive } from '../db/client'
 import repairVerdicts from '../db/migrations/0063_channel_verification_vocabulary'
 import { writeChannels } from './channels'
@@ -39,7 +41,7 @@ const subject = () => ({ table: 'companies' as const, id: company })
 const write = (channel: {
 	kind: string
 	value: string
-	verification?: 'deliverable' | 'risky' | 'undeliverable' | 'unknown'
+	verification?: VerificationVerdict
 	confidence?: number
 }) =>
 	run(
@@ -143,28 +145,47 @@ describe('putting stored verdicts right', () => {
 	let orphan: string
 
 	beforeAll(async () => {
-		// Words that reached the column while it was free text, plus the two that
-		// must come through untouched.
+		// Nothing can write a wrong word while the check is on, so it comes off to
+		// build the state the repair exists to put right. Test files run one at a
+		// time, so nothing else is writing while it is off.
 		await pool.query(
-			`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, verification, confidence)
-			 VALUES
-			   ($1, 'companies', $2, 'email', 'a@repair.cat', 'inferred', 55),
-			   ($1, 'companies', $2, 'email', 'b@repair.cat', 'Deliverable', 80),
-			   ($1, 'companies', $2, 'email', 'c@repair.cat', NULL, NULL),
-			   ($1, 'companies', $2, 'email', 'd@repair.cat', 'risky', 30)`,
-			[ORG, company],
+			`ALTER TABLE channels DROP CONSTRAINT channels_verification_chk`,
 		)
-		// A channel whose contact is already gone — what deleting somebody used to
-		// leave behind.
-		const gone = randomUUID()
-		const o = await pool.query<{ id: string }>(
-			`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, status)
-			 VALUES ($1, 'contacts', $2, 'email', 'orfe@repair.cat', 'bounced') RETURNING id`,
-			[ORG, gone],
-		)
-		orphan = o.rows[0]!.id
 
-		await run(repairVerdicts)
+		try {
+			// Words that reached the column while it was free text, plus the two
+			// that must come through untouched.
+			await pool.query(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, verification, confidence)
+				 VALUES
+				   ($1, 'companies', $2, 'email', 'a@repair.cat', 'inferred', 55),
+				   ($1, 'companies', $2, 'email', 'b@repair.cat', 'Deliverable', 80),
+				   ($1, 'companies', $2, 'email', 'c@repair.cat', NULL, NULL),
+				   ($1, 'companies', $2, 'email', 'd@repair.cat', 'risky', 30)`,
+				[ORG, company],
+			)
+			// A channel whose contact is already gone — what deleting somebody
+			// leaves behind, since nothing cascades off a polymorphic key.
+			const gone = randomUUID()
+			const o = await pool.query<{ id: string }>(
+				`INSERT INTO channels (organization_id, subject_table, subject_id, channel, address, status)
+				 VALUES ($1, 'contacts', $2, 'email', 'orfe@repair.cat', 'bounced') RETURNING id`,
+				[ORG, gone],
+			)
+			orphan = o.rows[0]!.id
+
+			await run(repairVerdicts)
+		} finally {
+			// Back on whatever happened above, so a throw midway cannot leave the
+			// database open for every suite that runs after this one. Putting it
+			// back is itself a check that the repair left nothing it refuses — and
+			// failing here still fails the suite.
+			await pool.query(
+				`ALTER TABLE channels ADD CONSTRAINT channels_verification_chk
+				 CHECK (verification IS NULL OR verification IN
+				   ('deliverable','risky','catch_all','undeliverable','unknown'))`,
+			)
+		}
 	})
 
 	describe('when a verdict is only mis-spelled', () => {
@@ -230,6 +251,56 @@ describe('putting stored verdicts right', () => {
 				[ORG],
 			)
 			expect(live.rowCount).toBeGreaterThan(0)
+		})
+	})
+})
+
+describe('a word the vocabulary does not contain', () => {
+	describe('when something writes one straight to the table', () => {
+		it('should be refused by the database, not stored', async () => {
+			// GIVEN an address with a verdict on it
+			await write({
+				kind: 'email',
+				value: 'backstop@cristalls.cat',
+				verification: 'risky',
+			})
+
+			// WHEN a verdict outside the five words is written past the app — a
+			// hand-run repair or a one-off script, which is how the wrong words the
+			// repair had to clean up got in
+			const badWrite = pool.query(
+				`UPDATE channels SET verification = 'Deliverable'
+				 WHERE subject_id = $1 AND address = $2`,
+				[company, 'backstop@cristalls.cat'],
+			)
+
+			// THEN it does not land, and the verdict already there is untouched
+			await expect(badWrite).rejects.toThrow(
+				/channels_verification_chk|check constraint/i,
+			)
+			expect(await stored('backstop@cristalls.cat')).toEqual({
+				verification: 'risky',
+				confidence: null,
+			})
+		})
+	})
+
+	describe('when the verdict is taken off entirely', () => {
+		it('should allow it, since no verdict is a state an address can be in', async () => {
+			// GIVEN the same address, still carrying a verdict
+			// WHEN the verdict is cleared
+			await pool.query(
+				`UPDATE channels SET verification = NULL
+				 WHERE subject_id = $1 AND address = $2`,
+				[company, 'backstop@cristalls.cat'],
+			)
+
+			// THEN nothing objects — "nobody has checked" is not a bad word, it is
+			// the absence of one, and the check has to leave room for it
+			expect(await stored('backstop@cristalls.cat')).toEqual({
+				verification: null,
+				confidence: null,
+			})
 		})
 	})
 })


### PR DESCRIPTION
Two changes to the shape of the `channels` table, both fallout from the verdict work that just landed.

## The five words, held at the database

An address's verdict can be one of `deliverable`, `risky`, `catch_all`, `undeliverable`, `unknown` — or nothing at all, which now means "nobody has checked".

Words that were never on that list reached the column anyway: `inferred`, `Deliverable`. Migration `0063` repaired them and is deployed, and every way in narrows the verdict in TypeScript — down to the vendor's own answer, which is decoded against the same list before it can reach a write. So nothing running can put a wrong word there today.

`channels_verification_chk` is what keeps that true through the next hand-run repair or one-off script, which is how the wrong words got in to begin with. `docs/backend.md:408` names this exact shape as one of the two things the database is allowed to decide — *a CHECK on a closed vocabulary, added only after the existing rows have been put right* — with `companies_status_chk` as the model. Both conditions hold.

## Two indexes that answer nothing

| Dropped | Already covered by |
| --- | --- |
| `channels_subject_idx (subject_table, subject_id)` | `channels_subject_address_idx (subject_table, subject_id, channel, address)` |
| `idx_channels_org (organization_id)` | `channels_org_address_idx (organization_id, channel, lower(address))` |

Each is the leading columns of a wider index already present, so every lookup they served is served without them. They cost a write on every insert and update in exchange for nothing.

## Rolling-deploy safety

Migrations run before the new build ships and the old instance keeps serving, so both statements have to be safe against the version already running.

Dropping an index changes which plan a query gets, never whether it works. And the old instance is running the same narrowed code, so it cannot write a value the check refuses — a `channels` table this size validates instantly. `check-migration-safety` passes.

## Two things found on the way

**A comment that said the opposite of its own code.** `0064`'s header claimed it "adds the index so the pair cannot come back"; the closing comment in the same file explains at length why it deliberately does *not*. Corrected to point at that note.

**The check broke the test that proves the repair works** — that suite has to build the state `0063` exists to fix, which the check now forbids. It takes the constraint off around the seeding and puts it back in a `finally`. That reads as a workaround but is stronger than what it replaces: re-adding the constraint is itself an assertion that the repair left nothing the check refuses, and the `finally` means a throw midway cannot leave the database open for every suite that runs after it. Test files run one at a time (`fileParallelism: false`), so nothing else is writing while it is off.

While there: the test helper's hand-written verdict list had drifted from the real vocabulary — it was missing `catch_all` — so it reads the domain type now instead of repeating it.

## Verification

830 server unit, 662 integration (95 files), type-check, lint and `check-migration-safety` all green. Applied to both the worktree and integration databases, and checked by hand afterwards: `'Deliverable'` is rejected, `'risky'` and `NULL` are accepted, and the constraint is back on with both indexes gone.
