### PR TITLE
fix: read a recipient before deciding whether it can be written to

### DIFF
--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -641,19 +641,17 @@ function SuppressionGuard({
 	const check = useAtomSet(checkSuppressedAtom, { mode: 'promiseExit' })
 
 	useEffect(() => {
-		const addresses = [
-			...splitAddresses(to),
-			...splitAddresses(cc),
-			...splitAddresses(bcc),
-		]
-		if (addresses.length === 0) {
+		// The fields go over as typed, and the server takes the addresses out of
+		// them the same way the send does — one place decides what an address is.
+		const recipientFields = [to, cc, bcc].filter(field => field.trim() !== '')
+		if (recipientFields.length === 0) {
 			onChange([])
 			return
 		}
 		let cancelled = false
 		const timer = setTimeout(() => {
 			void (async () => {
-				const exit = await check({ payload: { addresses } })
+				const exit = await check({ payload: { recipientFields } })
 				if (cancelled) return
 				if (exit._tag !== 'Success') {
 					onChange([])
@@ -676,6 +674,9 @@ function SuppressionGuard({
 	return null
 }
 
+// Shapes the cc and bcc fields into the list a saved draft holds. Not an
+// address reader: a recipient written the way a mail client shows it comes
+// apart here into pieces that are not addresses.
 function splitAddresses(raw: string): ReadonlyArray<string> {
 	if (raw.trim() === '') return []
 	return raw

--- a/apps/internal/tests/e2e/send-email.test.ts
+++ b/apps/internal/tests/e2e/send-email.test.ts
@@ -136,5 +136,33 @@ test.describe('compose and send via the mail catcher', () => {
 			await expect(page.getByTestId('compose-send')).toBeDisabled()
 			await expectNoMessage(SUPPRESSED_EMAIL, blockedSubject)
 		})
+
+		test('should disable Send when the address carries a display name', async ({
+			page,
+		}) => {
+			// GIVEN Alice opens compose from Pep Casals' company, as above
+			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
+			await openCompose(page, 'action-compose-email')
+
+			// WHEN she writes the same blocked address with a display name around
+			// it, the way a recipient arrives when it is copied out of another
+			// message — the comma inside the quoted name is what a plain split on
+			// separators breaks apart
+			const blockedSubject = `blocked display name ${Date.now()}`
+			await page
+				.getByTestId('compose-to')
+				.fill(`"Casals, Pep" <${SUPPRESSED_EMAIL}>`)
+			await page.getByTestId('compose-subject').fill(blockedSubject)
+			await fillBody(page, 'should not arrive')
+
+			// THEN the warning names the bare address and Send stays disabled, the
+			// same as when it was typed bare — the check answers on the address
+			// inside the field, which is the one the send would refuse over
+			await expect(page.getByRole('alert')).toContainText(SUPPRESSED_EMAIL, {
+				timeout: 10_000,
+			})
+			await expect(page.getByTestId('compose-send')).toBeDisabled()
+			await expectNoMessage(SUPPRESSED_EMAIL, blockedSubject)
+		})
 	})
 })

--- a/apps/server/src/handlers/email.ts
+++ b/apps/server/src/handlers/email.ts
@@ -434,7 +434,7 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 				)
 				.handle('deleteFooter', _ => svc.deleteFooter(_.params.id))
 				.handle('checkSuppressed', _ =>
-					svc.checkSuppressed(_.payload.addresses).pipe(
+					svc.checkSuppressed(_.payload.recipientFields).pipe(
 						Effect.map(suppressed => ({ suppressed })),
 						Effect.catchTag('SqlError', e => Effect.die(e)),
 					),

--- a/apps/server/src/services/email-suppression.integration.test.ts
+++ b/apps/server/src/services/email-suppression.integration.test.ts
@@ -12,6 +12,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { PgLive } from '../db/client'
 import { clearEmailSuppression, suppressedAmong } from './channels'
+import { recipientAddresses } from './recipient-address'
 
 // SQL-contract test for the question the send gate asks before every email:
 // "has this address hard-bounced or reported spam?"
@@ -220,6 +221,36 @@ describe('the lookup the send gate and the pre-send check share', () => {
 			expect(found.map(row => row.address).sort()).toEqual(
 				[COMPANY_MAILBOX, PERSON_ADDRESS].sort(),
 			)
+		})
+
+		it('should read a recipient field the way the send reads it', async () => {
+			// GIVEN a recipient field as somebody actually pastes it — a display
+			// name around the address, a comma inside the quoted name, and a second
+			// recipient after it
+			const written = `"Pla, Núria" <${COMPANY_MAILBOX}>, fine@tallerpuig.example`
+
+			// WHEN the pre-send check is asked about it
+			const found = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* suppressedAmong(sql, ORG, recipientAddresses(written))
+				}),
+			)
+
+			// THEN the blocked mailbox inside it comes back, the same one the send
+			// gate refuses over
+			expect(found.map(row => row.address)).toEqual([COMPANY_MAILBOX])
+
+			// AND the field compared whole finds nothing: a stored address is bare,
+			// so a check that skipped the reading would say a blocked recipient is
+			// fine and leave the refusal to the send
+			const comparedWhole = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* suppressedAmong(sql, ORG, [written])
+				}),
+			)
+			expect(comparedWhole).toEqual([])
 		})
 
 		it('should not care how the address was spelled', async () => {

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -1892,14 +1892,22 @@ export class EmailService extends Context.Service<EmailService>()(
 					}),
 
 				/**
-				 * Which of these addresses a send would be refused over — the same
-				 * question `assertRecipientsNotSuppressed` asks, so a caller can warn
-				 * while a message is being written rather than after it is sent.
+				 * Which of the addresses named in these recipient fields a send would
+				 * be refused over — the same question `assertRecipientsNotSuppressed`
+				 * asks, so a caller can warn while a message is being written rather
+				 * than after it is sent.
 				 */
-				checkSuppressed: (addresses: ReadonlyArray<string>) =>
+				checkSuppressed: (recipientFields: ReadonlyArray<string>) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const rows = yield* suppressedAmong(sql, currentOrg.id, addresses)
+						// The addresses come out of the fields the same way the send
+						// takes them out — judging a different set from the send is
+						// worse than not warning at all.
+						const rows = yield* suppressedAmong(
+							sql,
+							currentOrg.id,
+							recipientAddresses(...recipientFields),
+						)
 						return rows.map(row => ({
 							address: row.address,
 							status: row.status,

--- a/packages/controllers/src/routes/email.ts
+++ b/packages/controllers/src/routes/email.ts
@@ -578,14 +578,16 @@ export const EmailGroup = HttpApiGroup.make('email')
 		// a query string is the one place they would be logged and cached.
 		HttpApiEndpoint.post('checkSuppressed', '/email/suppressed', {
 			payload: Schema.Struct({
-				// 320 is as long as one address gets: 64 before the @, 255 after. The
-				// list is capped because a caller may ask on every keystroke and every
-				// address in it costs another index lookup on the connection other
-				// requests are waiting for. A list longer than this is a mail-merge,
-				// which is a different feature.
-				addresses: Schema.Array(
-					Schema.String.pipe(Schema.check(Schema.isMaxLength(320))),
-				).pipe(Schema.check(Schema.isMaxLength(200))),
+				// One entry per recipient field, however the sender wrote it: the
+				// server takes the addresses out of them the same way the send does,
+				// so a name written the way a mail client shows it ("Núria Pla
+				// <nuria@…>") is judged here exactly as it is judged there. The bound
+				// is on the text a field can hold, not on how many addresses it comes
+				// to — the send puts no limit on recipients, and a check that stopped
+				// short of one would leave the refusal to the send.
+				recipientFields: Schema.Array(
+					Schema.String.pipe(Schema.check(Schema.isMaxLength(8_000))),
+				).pipe(Schema.check(Schema.isMaxLength(8))),
 			}),
 			success: Schema.Struct({
 				suppressed: Schema.Array(


### PR DESCRIPTION
## What

When you write an email in the CRM's compose screen, a warning appears if a recipient can't receive mail — an address that hard-bounced or reported spam. It missed a whole class of recipient: anyone written the way a mail client shows them, `Núria Pla <nuria@example.cat>`. No warning appeared, Send stayed enabled, and the refusal only arrived after the message was written.

The check compared the recipient fields exactly as they arrived, while the send gate parses them first. So the two answered the same question differently. This makes the check read them the way the send reads them. Server (`apps/server`, `packages/controllers`) and the compose screen (`apps/internal`), CRM context.

## The fix

`checkSuppressed` runs `recipientAddresses` — the parser the send gate already uses — before looking anything up. That is the whole behavioural change; the rest follows from it.

The compose screen no longer splits the fields before sending them, so one place decides what a recipient is instead of two that have to agree. **This is a simplification, not the fix** — I verified by reverting each half separately: with the screen still splitting, the case passes; with the server parse removed, it fails. The angle-bracketed piece survived a naive split, so the screen was never what hid it. Worth knowing before reviewing that hunk as if it were load-bearing.

The cap on how many addresses one check may ask about is gone. The send applies none, and a check that stops short of what the send reads is the same disagreement in another form. The payload is bounded instead by what a person can type into three fields.

## Impact

**Wire shape changed.** The payload field is now `recipientFields` (was `addresses`), and it carries whole fields rather than one address per entry. `packages/controllers` is consumed by both the server and the typed client in `apps/internal`.

**The two targets deploy independently, and either order degrades safely.** A new server with an old screen — or the reverse — means the field name doesn't match, the check returns 400, and the guard falls back to showing no warning. That is exactly today's behaviour, and the send gate still refuses the message. So no coordinated deploy is required; the warning is simply absent until both sides are out.

**Not affected:** no migration or schema change, no new environment variables, no change to organisation isolation (the lookup is still scoped by `organization_id` and unchanged), and no auth or CORS change. `checkSuppressed` is HTTP-only by design — it exists for a screen — while the send gate it now matches is the shared one, so MCP and HTTP still judge a send identically.

## Review guide

Start at `checkSuppressed` in `apps/server/src/services/email.ts` — one line, and the only behavioural change. Everything else is naming and bounds.

**The decision you might overrule:** removing the address cap. It was 200; a caller can now ask about whatever fits in the payload. My argument is consistency with the send gate, but it does mean a larger array in one indexed lookup, on an authenticated and debounced path. Easy to put back.

The compose-screen hunk is the one most likely to be misread as the fix — see above. `splitAddresses` stays because it still builds the `cc`/`bcc` lists a draft is stored as; its comment now says it is not an address reader, since that is precisely the mistake this PR corrects.

I did not run Snyk (not available in this session).

## Screenshots

The recipient as pasted, the warning naming the bare address inside it, Send disabled. Mobile first — `apps/internal` is mobile-first, and the compose sheet shows the typed field and the warning in one frame.

![pr-recipient-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-430/pr-recipient-mobile.webp)

Same on desktop, where compose is a window rather than a sheet:

![pr-recipient-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-430/pr-recipient-desktop.webp)

## Tests

- **e2e** — pastes `"Casals, Pep" <pep@calpepfonda.cat>` into the compose screen and asserts the warning names the bare address and Send stays disabled. I confirmed this test fails without the server change, so it pins the fix rather than passing alongside it.
- **Integration** — the same field found through the parser, and the assertion that handing it over unparsed finds nothing, which is what makes the parse a requirement rather than a tidy-up.

## Verification

Gates run on this branch after rebasing onto current `main`: `pnpm install`, `pnpm -w check-types`, `pnpm -w test` (21 packages), `pnpm -w build` — all green. Server integration 96 files / 682 tests. `send-email` e2e 5/5.

Driven against the live worktree stack, signed in as a real user: the display-name form raises the warning and disables Send, a plain comma-separated list still does, and a clean address raises nothing.

## Deferred

The compose screen still splits `cc` and `bcc` into a list when it stores a draft, so a copied recipient carrying a display name is broken into pieces before the server ever sees it — pieces that are then stored and attempted at send time. That predates this PR and touches what actually gets delivered, so it wants its own change rather than riding along here.
