### PR TITLE
fix(internal): put the reason where the address is

### DIFF
--- a/apps/internal/src/components/contacts/manage-channels-dialog.tsx
+++ b/apps/internal/src/components/contacts/manage-channels-dialog.tsx
@@ -303,6 +303,16 @@ export function ManageChannelsDialog({
 														setRowError(null)
 													}}
 												/>
+												{/* The browser checks nothing here, so `match` is what shows the message.
+												    Inside the field is what points a screen reader at it. */}
+												{rowError?.id === ch.id ? (
+													<PriField.Error
+														match={true}
+														data-testid={`channel-error-${ch.id}`}
+													>
+														{rowError.message}
+													</PriField.Error>
+												) : null}
 											</PriField.Root>
 											<PriField.Root>
 												<PriField.Label htmlFor={`channel-label-${ch.id}`}>
@@ -336,14 +346,6 @@ export function ManageChannelsDialog({
 													<Trans>Cancel</Trans>
 												</PriButton>
 											</EditActions>
-											{rowError?.id === ch.id ? (
-												<RowError
-													role='alert'
-													data-testid={`channel-error-${ch.id}`}
-												>
-													{rowError.message}
-												</RowError>
-											) : null}
 										</EditForm>
 									) : (
 										<>
@@ -532,6 +534,11 @@ export function ManageChannelsDialog({
 									setAddError(null)
 								}}
 							/>
+							{addError ? (
+								<PriField.Error match={true} data-testid='channel-add-error'>
+									{addError}
+								</PriField.Error>
+							) : null}
 						</PriField.Root>
 						<PriField.Root>
 							<PriField.Label htmlFor='channel-add-label'>
@@ -552,11 +559,6 @@ export function ManageChannelsDialog({
 						>
 							<Trans>Add</Trans>
 						</PriButton>
-						{addError ? (
-							<RowError role='alert' data-testid='channel-add-error'>
-								{addError}
-							</RowError>
-						) : null}
 					</AddForm>
 				</PriDialog.Popup>
 			</PriDialog.Portal>

--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -290,6 +290,7 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 	const [suppressed, setSuppressed] = useState<
 		ReadonlyArray<SuppressedAddress>
 	>([])
+	const [checkFailed, setCheckFailed] = useState(false)
 
 	const canSend = useMemo(() => {
 		if (sendState === 'sending') return false
@@ -525,6 +526,50 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 				</>
 			)}
 
+			<SuppressionGuard
+				to={form.to}
+				cc={form.cc}
+				bcc={form.bcc}
+				onSuppressedChange={setSuppressed}
+				onCheckFailedChange={setCheckFailed}
+			/>
+
+			{/* Sits by the addresses it names: down by Send it would be off the
+			    bottom of the form, leaving a greyed-out button and no reason for
+			    it. It waits its turn to be read out, since it lands while an
+			    address is still being typed. */}
+			{suppressed.length > 0 ? (
+				<SuppressionBanner
+					role='status'
+					aria-live='polite'
+					data-testid='compose-suppressed'
+				>
+					<AlertTriangle size={14} aria-hidden />
+					<SuppressionList>
+						<SuppressionTitle>
+							{t`Send blocked: these recipients cannot receive email`}
+						</SuppressionTitle>
+						{suppressed.map(s => (
+							<li key={s.email}>
+								<strong>{s.email}</strong>
+								{' — '}
+								{s.reason === 'bounced' ? t`bounced` : t`complained`}
+							</li>
+						))}
+					</SuppressionList>
+				</SuppressionBanner>
+			) : null}
+
+			{checkFailed && suppressed.length === 0 ? (
+				<CheckUnavailable
+					role='status'
+					aria-live='polite'
+					data-testid='compose-check-unavailable'
+				>
+					{t`Couldn't check whether these addresses can receive email. Sending will still be stopped if one of them can't.`}
+				</CheckUnavailable>
+			) : null}
+
 			{!isReply ? (
 				<Field>
 					<FieldLabel htmlFor={`subject-${draft.id}`}>{t`Subject`}</FieldLabel>
@@ -551,31 +596,6 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 					placeholder={t`Write your message…`}
 				/>
 			</BodyField>
-
-			<SuppressionGuard
-				to={form.to}
-				cc={form.cc}
-				bcc={form.bcc}
-				onChange={setSuppressed}
-			/>
-
-			{suppressed.length > 0 ? (
-				<SuppressionBanner role='alert'>
-					<AlertTriangle size={14} aria-hidden />
-					<SuppressionList>
-						<SuppressionTitle>
-							{t`Send blocked: these recipients cannot receive email`}
-						</SuppressionTitle>
-						{suppressed.map(s => (
-							<li key={s.email}>
-								<strong>{s.email}</strong>
-								{' — '}
-								{s.reason === 'bounced' ? t`bounced` : t`complained`}
-							</li>
-						))}
-					</SuppressionList>
-				</SuppressionBanner>
-			) : null}
 
 			{errorMessage !== null ? (
 				<ErrorBanner role='alert'>
@@ -625,18 +645,21 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 // mailbox, a contact's second address, one typed by hand — so it is asked
 // rather than guessed at from whatever this screen happens to have loaded.
 //
-// A check that fails clears the warning instead of raising one: the send is the
-// real refusal, and a warning nobody can explain is worse than none.
+// A check that fails raises no warning but says so, since a screen that could
+// not ask looks exactly like one that asked and found nothing. The send is
+// still the real refusal.
 function SuppressionGuard({
 	to,
 	cc,
 	bcc,
-	onChange,
+	onSuppressedChange,
+	onCheckFailedChange,
 }: {
 	readonly to: string
 	readonly cc: string
 	readonly bcc: string
-	readonly onChange: (next: ReadonlyArray<SuppressedAddress>) => void
+	readonly onSuppressedChange: (next: ReadonlyArray<SuppressedAddress>) => void
+	readonly onCheckFailedChange: (failed: boolean) => void
 }) {
 	const check = useAtomSet(checkSuppressedAtom, { mode: 'promiseExit' })
 
@@ -645,7 +668,8 @@ function SuppressionGuard({
 		// them the same way the send does — one place decides what an address is.
 		const recipientFields = [to, cc, bcc].filter(field => field.trim() !== '')
 		if (recipientFields.length === 0) {
-			onChange([])
+			onSuppressedChange([])
+			onCheckFailedChange(false)
 			return
 		}
 		let cancelled = false
@@ -654,10 +678,12 @@ function SuppressionGuard({
 				const exit = await check({ payload: { recipientFields } })
 				if (cancelled) return
 				if (exit._tag !== 'Success') {
-					onChange([])
+					onSuppressedChange([])
+					onCheckFailedChange(true)
 					return
 				}
-				onChange(
+				onCheckFailedChange(false)
+				onSuppressedChange(
 					exit.value.suppressed.map(row => ({
 						email: row.address,
 						reason: row.status,
@@ -669,7 +695,7 @@ function SuppressionGuard({
 			cancelled = true
 			clearTimeout(timer)
 		}
-	}, [to, cc, bcc, check, onChange])
+	}, [to, cc, bcc, check, onSuppressedChange, onCheckFailedChange])
 
 	return null
 }
@@ -851,6 +877,18 @@ const SuppressionTitle = styled.div.withConfig({
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
 	margin-bottom: var(--space-3xs);
+`
+
+const CheckUnavailable = styled.p.withConfig({
+	displayName: 'ComposeCheckUnavailable',
+})`
+	margin: 0;
+	padding: var(--space-2xs) var(--space-sm);
+	border: 1px dashed var(--color-outline-variant);
+	border-radius: var(--shape-xs);
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-body-small-size);
+	line-height: var(--typescale-body-small-line);
 `
 
 const ErrorBanner = styled.div.withConfig({

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -1707,6 +1707,10 @@ msgstr "No s'ha pogut actualitzar aquesta cerca."
 msgid "Could not update verification"
 msgstr "No s'ha pogut actualitzar la verificació"
 
+#: src/components/emails/compose-form.tsx
+msgid "Couldn't check whether these addresses can receive email. Sending will still be stopped if one of them can't."
+msgstr "No s’ha pogut comprovar si aquestes adreces poden rebre correu. Si alguna no pot, l’enviament es continuarà aturant."
+
 #: src/routes/settings/organization/templates.tsx
 msgid "Couldn't clear the default"
 msgstr "No s’ha pogut esborrar el valor per defecte"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -1707,6 +1707,10 @@ msgstr "Could not update this lookup."
 msgid "Could not update verification"
 msgstr "Could not update verification"
 
+#: src/components/emails/compose-form.tsx
+msgid "Couldn't check whether these addresses can receive email. Sending will still be stopped if one of them can't."
+msgstr "Couldn't check whether these addresses can receive email. Sending will still be stopped if one of them can't."
+
 #: src/routes/settings/organization/templates.tsx
 msgid "Couldn't clear the default"
 msgstr "Couldn't clear the default"

--- a/apps/internal/tests/e2e/contact-channels.test.ts
+++ b/apps/internal/tests/e2e/contact-channels.test.ts
@@ -172,6 +172,19 @@ test.describe('a contact’s ways of being reached', () => {
 			{ timeout: 10_000 },
 		)
 		expect(addressesOf(pep)).toContain(SEEDED_EMAIL)
+
+		// AND the box itself carries the message, so somebody who reaches the
+		// address by keyboard is told why it was refused rather than having to
+		// find the sentence elsewhere on the row
+		const describedBy = await page
+			.getByTestId(`channel-value-${id}`)
+			.getAttribute('aria-describedby')
+		expect(describedBy).not.toBeNull()
+		const errorId = await page
+			.getByTestId(`channel-error-${id}`)
+			.getAttribute('id')
+		expect(errorId).not.toBeNull()
+		expect(describedBy?.split(' ')).toContain(errorId)
 	})
 
 	test('should say an address is already on file rather than quietly relabelling it', async ({

--- a/apps/internal/tests/e2e/send-email.test.ts
+++ b/apps/internal/tests/e2e/send-email.test.ts
@@ -158,9 +158,10 @@ test.describe('compose and send via the mail catcher', () => {
 			// THEN the warning names the bare address and Send stays disabled, the
 			// same as when it was typed bare — the check answers on the address
 			// inside the field, which is the one the send would refuse over
-			await expect(page.getByRole('alert')).toContainText(SUPPRESSED_EMAIL, {
-				timeout: 10_000,
-			})
+			await expect(page.getByTestId('compose-suppressed')).toContainText(
+				SUPPRESSED_EMAIL,
+				{ timeout: 10_000 },
+			)
 			await expect(page.getByTestId('compose-send')).toBeDisabled()
 			await expectNoMessage(SUPPRESSED_EMAIL, blockedSubject)
 		})


### PR DESCRIPTION
## What

Four things about *how* the CRM tells somebody an address cannot be written to. The rules did not change — what changed is whether a person actually receives the message. Web app (`apps/internal`), CRM context: the email compose screen and the manage-channels dialog on a contact.

This came out of reviewing my own recent work against `docs/frontend.md`. Three of the four are defects in code I wrote or made more visible over the last few PRs.

## The fixes

**The reason now sits with the addresses.** The "these recipients cannot receive email" warning rendered after the message body. On a short window that put it below the fold while the greyed-out Send button stayed in view — a dead button with its reason off screen. It renders directly under the recipient fields now.

This matters more than it did a week ago. Before the pre-send check started asking the server, it was guessing from whatever contacts the screen had loaded, so it almost never fired — it missed company mailboxes, second addresses, and anything typed by hand. Making it fire on the real cases without moving it was half a job.

**It stopped interrupting.** `role='alert'` is assertive, and this warning appears while somebody is still typing the address it is about, so a screen reader talked over them mid-word. It is `role='status'` with `aria-live='polite'`, which is the pattern already used a few lines above for the sending-from notice.

**A check that could not run says so.** A failed request cleared the warning and said nothing, which looks identical to a check that ran and found nothing — and only one of those is a reason to press Send. It now says it could not ask, and that the send will still be stopped. The send gate was always the real refusal; this is about not reading as having checked.

**Refusals in the channels dialog are attached to their box.** They were `<p role="alert">` rendered as siblings of the field — visible, but connected to nothing. They are `PriField.Error` inside the matching `PriField.Root` now, which is what `docs/frontend.md:452` prescribes and what makes Base UI wire `aria-describedby` from the address input to the message. Somebody arriving at the box by keyboard is told why it was refused instead of having to find the sentence elsewhere on the row.

## Impact

No schema change, no new environment variables, no wire-shape change, no change to organisation isolation or auth. This is `apps/internal` only, and no server behaviour moves — which verdicts stop a send, and the send gate itself, are untouched.

One deliberate carve-out: the non-edit row keeps its plain `role='alert'`, because that failure (delete, or making an address the main one) is about the row rather than about any one field, and it answers an explicit click rather than arriving while somebody types.

## Review guide

The interesting hunk is the `PriField.Error` wiring in the dialog — `match={true}` is what shows a message the server wrote rather than one the browser's own validation produced, and the message has to render *inside* `PriField.Root` for the id to be registered. Moving it back out to a sibling would silently break the association, so there is an e2e assertion holding it.

**One thing I chose not to do, and would take an argument on:** holding Send disabled while a check is in flight. It closes a narrow race — change a recipient and click within roughly half a second — at the cost of flickering the button on every keystroke burst, and the server's refusal already names the real reason. I judged the cure worse than the disease.

**Left for later:** the banner names the problem and offers no way out. Clearing a suppression lives in the contact's channels dialog, and linking there from compose needs a routing decision I did not want to make alone.

## Screenshots

The warning under the recipient field, in the same frame as the disabled Send. Both sizes, since compose is a sheet on mobile and a window on desktop.

![ux-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-439/ux-mobile.webp)

![ux-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-439/ux-desktop.webp)

And the notice when the check itself cannot run — captured with the browser taken offline:

![ux-offline.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-439/ux-offline.webp)

## Tests

- **e2e** — the address input's `aria-describedby` names the error element. I confirmed this fails against the old structure rather than assuming it, so it pins the association rather than passing alongside it.
- The existing suppression e2e now targets the banner by test id rather than by `role='alert'`, which the role change would otherwise have broken silently.

## Verification

`pnpm -w check-types`, `pnpm -w test` (21 packages) and `pnpm -w build` all green; 12/12 e2e across `contact-channels` and `send-email`.

Driven against the live worktree stack: the warning appears under the recipient boxes at 1440×900 and on an iPhone 16 Pro viewport, and taking the browser offline produces the could-not-check notice, which clears once the check succeeds again.
