### PR TITLE
fix(research): make the schema registry break the build when it changes

### DIFF
--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -34,7 +34,10 @@ import { formatMoneyCents } from '#/lib/format-money'
 import { taggedFailure } from '#/lib/tagged-failure'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
 
-// Type-only import; adding a schema server-side forces an option here.
+// The registry's own names, so a schema retired or renamed server-side fails the
+// build here until its card goes too. Adding one does not force a card: an
+// option only exists once someone has written what to call it and when to pick
+// it, and until then the schema is simply not offered.
 type SchemaOption = SchemaName
 
 // `msg` so the labels + descriptions extract into the catalog;

--- a/apps/internal/src/components/research/run-actions.tsx
+++ b/apps/internal/src/components/research/run-actions.tsx
@@ -6,6 +6,10 @@ import { useState } from 'react'
 import styled from 'styled-components'
 
 import { isActiveResearchStatus } from '@batuda/domain'
+// Straight from the schemas file rather than the package entry point: that entry
+// point also reaches the services that talk to the database and the outside
+// world, and pulling those into the browser breaks this page outright.
+import { isSchemaName } from '@batuda/research/application/schemas'
 import { PriButton, usePriToast } from '@batuda/ui/pri'
 
 import {
@@ -111,6 +115,16 @@ export function RunActions({
 	}
 
 	const onRerun = async () => {
+		// A run outlives the kind of research it was. Sending the name anyway is
+		// refused, and dropping it would quietly run something else — a brief where
+		// a profile was asked for — so say so instead of doing either.
+		if (run.schemaName !== null && !isSchemaName(run.schemaName)) {
+			toast.add({
+				title: t`This kind of research isn't available any more`,
+				type: 'error',
+			})
+			return
+		}
 		setBusy('rerun')
 		// Repeat the whole setup, not just the question. Sending only the question
 		// and its subjects quietly dropped how thorough the run was, the

--- a/apps/internal/src/components/research/run-detail.tsx
+++ b/apps/internal/src/components/research/run-detail.tsx
@@ -42,7 +42,8 @@ import {
 	stenciledTitle,
 } from '#/lib/workshop-mixins'
 
-// `Record<SchemaName, …>` keeps the dispatch table exhaustive against the schema registry.
+// Keyed by the schema registry's own names, so retiring or renaming one there
+// fails the build here until this table follows.
 type FindingsViewProps = { readonly findings: never }
 const FINDINGS_VIEWS: Record<SchemaName, ComponentType<FindingsViewProps>> = {
 	freeform: FreeformView,
@@ -51,6 +52,13 @@ const FINDINGS_VIEWS: Record<SchemaName, ComponentType<FindingsViewProps>> = {
 	contact_discovery_v1: ContactDiscoveryView,
 	prospect_scan_v1: ProspectScanView,
 }
+
+// The same table, looked up by whatever name a run row happens to carry — which
+// is a plain string, and on a run from a newer bundle may name no view here.
+const findingsViewFor: Record<
+	string,
+	ComponentType<FindingsViewProps> | undefined
+> = FINDINGS_VIEWS
 
 // Localized sentence for each terminal failure reason, keyed by the run's
 // reason_code so the backend stays language-free — it returns the code, the UI
@@ -361,8 +369,7 @@ function FindingsView({
 		)
 	}
 	// `null` predates the schemaName column; treat as freeform.
-	const key = (schemaName ?? 'freeform') as SchemaName
-	const View = FINDINGS_VIEWS[key]
+	const View = findingsViewFor[schemaName ?? 'freeform']
 	if (View) {
 		return <View findings={findings as never} />
 	}

--- a/apps/internal/src/components/research/target-correction.tsx
+++ b/apps/internal/src/components/research/target-correction.tsx
@@ -46,9 +46,13 @@ export function TargetCorrection({
 				void navigate({ to: '/research/$id', params: { id: newId } })
 				return
 			}
-			// The backend rejected the domain (unparseable).
 			setErrorMessage(
-				t`That does not look like a website. Try the company's domain, like acme.com.`,
+				value?.['status'] === 'schema_unavailable'
+					? // The kind of research this run was is no longer one I offer, so
+						// re-running it would only fail. Nothing the domain can fix.
+						t`This kind of research isn't available any more, so it can't be re-run. Start a new one instead.`
+					: // The backend rejected the domain (unparseable).
+						t`That does not look like a website. Try the company's domain, like acme.com.`,
 			)
 			setSubmitting(false)
 			return

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -5910,6 +5910,14 @@ msgstr "Aquest és l'únic moment en què es mostra la clau sencera. Desa-la en 
 msgid "This is what we expect before sending. A bounce is what happened after."
 msgstr "Això és el que esperem abans d'enviar. Un rebot és el que ha passat després."
 
+#: src/components/research/run-actions.tsx
+msgid "This kind of research isn't available any more"
+msgstr "Aquest tipus de recerca ja no està disponible"
+
+#: src/components/research/target-correction.tsx
+msgid "This kind of research isn't available any more, so it can't be re-run. Start a new one instead."
+msgstr "Aquest tipus de recerca ja no està disponible, així que no es pot tornar a executar. Comença'n una de nova."
+
 #: src/routes/reset-password.tsx
 #: src/routes/reset-password.tsx
 msgid "This link is no longer valid"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -5910,6 +5910,14 @@ msgstr "This is the only time the full key is shown. Store it somewhere safe —
 msgid "This is what we expect before sending. A bounce is what happened after."
 msgstr "This is what we expect before sending. A bounce is what happened after."
 
+#: src/components/research/run-actions.tsx
+msgid "This kind of research isn't available any more"
+msgstr "This kind of research isn't available any more"
+
+#: src/components/research/target-correction.tsx
+msgid "This kind of research isn't available any more, so it can't be re-run. Start a new one instead."
+msgstr "This kind of research isn't available any more, so it can't be re-run. Start a new one instead."
+
 #: src/routes/reset-password.tsx
 #: src/routes/reset-password.tsx
 msgid "This link is no longer valid"

--- a/apps/server/src/services/research-subject-scope.integration.test.ts
+++ b/apps/server/src/services/research-subject-scope.integration.test.ts
@@ -399,4 +399,55 @@ describe('research subject scoping', () => {
 				expect(outcome.failure._tag).toBe('SubjectUnavailable')
 		}, 30_000)
 	})
+
+	describe('when re-running a run whose kind of research is gone', () => {
+		it('should refuse it rather than queue a run that can only fail', async () => {
+			// GIVEN a run naming a schema this build no longer has — what every run
+			//   started under a schema becomes once that schema is retired
+			// WHEN somebody re-runs it against a corrected domain
+			// THEN it is refused outright. Copying the name through would queue a run
+			//   that flips to running and announces itself before dying on a name it
+			//   was never going to resolve.
+			const [retired] = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* sql<{ id: string }>`
+						INSERT INTO research_runs (organization_id, query, schema_name, status, context, created_by)
+						VALUES (
+							${ctx.org.id}, 'run under a retired schema', 'retired_shape_v1', 'failed',
+							${JSON.stringify({})}::jsonb,
+							${userId}
+						)
+						RETURNING id
+					`
+				}),
+			)
+			createdRunIds.push(retired!.id)
+
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const sql = yield* SqlClient.SqlClient
+					return yield* enterOrgScope(sql, { org: ctx.org, userId })(
+						svc.rerun(userId, ctx.org.id, retired!.id, 'example.com'),
+					)
+				}).pipe(Effect.provide(ResearchLive), Effect.orDie),
+			)
+
+			expect(outcome.status).toBe('schema_unavailable')
+
+			// AND nothing was written on the way to refusing.
+			const queued = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* sql<{ count: number }>`
+						SELECT count(*)::int AS count FROM research_runs
+						WHERE organization_id = ${ctx.org.id}
+						  AND schema_name = 'retired_shape_v1'
+					`
+				}),
+			)
+			expect(queued[0]?.count).toBe(1)
+		}, 30_000)
+	})
 })

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -21,6 +21,7 @@
 		"@batuda/calendar": "workspace:*",
 		"@batuda/domain": "workspace:*",
 		"@batuda/email": "workspace:*",
+		"@batuda/research": "workspace:*",
 		"@batuda/ui": "workspace:*",
 		"effect": "4.0.0-beta.102"
 	},

--- a/packages/controllers/src/routes/research.test.ts
+++ b/packages/controllers/src/routes/research.test.ts
@@ -1,7 +1,9 @@
 import { Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { ContextInput } from './research'
+import { schemaNames } from '@batuda/research/application/schemas'
+
+import { ContextInput, CreateResearchInput } from './research'
 
 // Decode through the canonical JSON codec so the check mirrors what the MCP tool
 // and HTTP route actually run on a caller's payload.
@@ -104,6 +106,63 @@ describe('ContextInput', () => {
 			// GIVEN a selector aimed at contacts (only companies fan out)
 			const exit = decodeExit(ContextInput, {
 				selector: { table: 'contacts', filter: {} },
+			})
+			expect(exit._tag).toBe('Failure')
+		})
+	})
+})
+
+describe('CreateResearchInput', () => {
+	describe('when schema_name is one the server can resolve', () => {
+		it('should accept every name the registry holds', () => {
+			// GIVEN each shape a run can be asked to come back in
+			// WHEN decode runs
+			// THEN none of them is turned away at the door
+			for (const name of schemaNames) {
+				const exit = decodeExit(CreateResearchInput, {
+					query: 'who are their competitors',
+					schema_name: name,
+				})
+				expect(exit._tag).toBe('Success')
+			}
+		})
+
+		it('should accept a request that names no schema at all', () => {
+			// GIVEN schema_name left out, which the service reads as freeform
+			const exit = decodeExit(CreateResearchInput, { query: 'a question' })
+			expect(exit._tag).toBe('Success')
+		})
+	})
+
+	describe('when schema_name is not one the server can resolve', () => {
+		it('should refuse it, so no run row is written for a doomed request', () => {
+			// GIVEN a name the registry does not hold. Decoding is what the route
+			// runs before the handler, so refusing here is refusing before the run
+			// exists — rather than after it has flipped to running and said so.
+			const exit = decodeExit(CreateResearchInput, {
+				query: 'a question',
+				schema_name: 'bogus_schema_v9',
+			})
+			expect(exit._tag).toBe('Failure')
+		})
+
+		it('should refuse a fan-out too, so one bad name creates no runs', () => {
+			// GIVEN a selector, which would otherwise write a batch row plus one run
+			// per matched company before any of them reached the point of failing
+			const exit = decodeExit(CreateResearchInput, {
+				query: 'find me freight brokers',
+				schema_name: 'prospect_scan_v2',
+				context: {
+					selector: { table: 'companies', filter: { country: 'US' } },
+				},
+			})
+			expect(exit._tag).toBe('Failure')
+		})
+
+		it('should refuse an empty name rather than read it as freeform', () => {
+			const exit = decodeExit(CreateResearchInput, {
+				query: 'a question',
+				schema_name: '',
 			})
 			expect(exit._tag).toBe('Failure')
 		})

--- a/packages/controllers/src/routes/research.ts
+++ b/packages/controllers/src/routes/research.ts
@@ -6,6 +6,10 @@ import {
 } from 'effect/unstable/httpapi'
 
 import { ResearchSubjectTable } from '@batuda/domain'
+// Straight from the schemas file rather than the package entry point: that entry
+// point also reaches the research service and the providers it talks to, and this
+// spec is what the browser builds its API client from.
+import { SchemaNameSchema } from '@batuda/research/application/schemas'
 
 import {
 	ConfirmRequired,
@@ -70,11 +74,17 @@ export const ContextInput = Schema.Struct({
 	hints: Schema.optional(Hints),
 })
 
-const CreateResearchInput = Schema.Struct({
+// Exported for the test next door, which pins schema_name to the closed set —
+// widening it back to a bare string is what let a doomed run be created.
+export const CreateResearchInput = Schema.Struct({
 	query: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 	mode: Schema.optional(Schema.String),
 	context: Schema.optional(ContextInput),
-	schema_name: Schema.optional(Schema.String),
+	// The closed set, not a bare string: an unknown name is refused as a bad
+	// request before the handler runs, so nothing is written. A selector request
+	// would otherwise write a batch row and one run per matched company, every
+	// one of them doomed.
+	schema_name: Schema.optional(SchemaNameSchema),
 	budget_cents: Schema.optional(Schema.Number),
 	paid_budget_cents: Schema.optional(Schema.Number),
 	auto_approve_paid_cents: Schema.optional(Schema.Number),

--- a/packages/research/package.json
+++ b/packages/research/package.json
@@ -17,6 +17,10 @@
 		"./application/paid-action-tool": {
 			"types": "./src/application/paid-action-tool.ts",
 			"import": "./src/application/paid-action-tool.ts"
+		},
+		"./application/schemas": {
+			"types": "./src/application/schemas/index.ts",
+			"import": "./src/application/schemas/index.ts"
 		}
 	},
 	"scripts": {

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -127,8 +127,9 @@ import { computeRunQuality } from './research-quality'
 import { guardScalarFields } from './scalar-field-guard'
 import {
 	type FreeformSchema,
+	isSchemaName,
+	resolveSchema,
 	schemaFieldNames,
-	schemaRegistry,
 } from './schemas/index'
 import { hostOf, sourceIdFor, urlHashForScrape } from './source-key'
 import { recordSeenSource } from './source-record'
@@ -2173,8 +2174,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						return
 					}
 
-					// Resolve the schema
-					const outputSchema = schemaRegistry[schemaName]
+					// Resolve the schema. The name comes off the run row, so it is only
+					// a string here however tightly the boundaries checked it — a run
+					// queued before a schema was retired still names it.
+					const outputSchema = resolveSchema(schemaName)
 					if (!outputSchema) {
 						yield* sql`
 							UPDATE research_runs
@@ -5669,6 +5672,18 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							LIMIT 1
 						`
 						if (!origin) return { status: 'run_not_found' as const }
+
+						// The origin's schema name is copied into the new run as it was
+						// stored, and a run outlives the schema it was started under. Left
+						// unchecked, a retired name would be queued again and only die once
+						// the run had flipped to running and announced itself, so it is
+						// refused here while nothing has been written.
+						if (
+							origin.schemaName !== null &&
+							!isSchemaName(origin.schemaName)
+						) {
+							return { status: 'schema_unavailable' as const }
+						}
 
 						const originContext =
 							origin.context != null && typeof origin.context === 'object'

--- a/packages/research/src/application/schemas/index.test.ts
+++ b/packages/research/src/application/schemas/index.test.ts
@@ -1,6 +1,20 @@
+import { Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { schemaFieldNames } from './index'
+import {
+	isSchemaName,
+	resolveSchema,
+	SchemaNameSchema,
+	schemaFieldNames,
+	schemaNames,
+	schemaRegistry,
+} from './index'
+
+// Decode through the canonical JSON codec, the way the HTTP route and the MCP
+// tools run a caller's schema_name.
+const accepts = (name: unknown): boolean =>
+	Schema.decodeUnknownExit(Schema.toCodecJson(SchemaNameSchema))(name)._tag ===
+	'Success'
 
 describe('schemaFieldNames', () => {
 	describe('when a run fills in a company profile', () => {
@@ -62,6 +76,93 @@ describe('schemaFieldNames', () => {
 	describe('when the schema is not one we know', () => {
 		it('should return nothing rather than fail a run', () => {
 			expect(schemaFieldNames('made_up_v9')).toEqual([])
+		})
+	})
+})
+
+describe('SchemaNameSchema', () => {
+	describe('when a name is offered to the API boundary', () => {
+		it('should accept every name a run can actually be resolved through', () => {
+			// GIVEN the boundary is what refuses unknown names, while the registry is
+			// what a run is resolved through
+			// THEN a name accepted here but absent there would be a run that starts,
+			// says so, and only then dies on a schema that was never going to resolve
+			for (const name of schemaNames) {
+				expect(accepts(name)).toBe(true)
+				expect(resolveSchema(name)).toBeDefined()
+			}
+		})
+
+		it('should hold every schema the registry defines, so none ships dark', () => {
+			// GIVEN a schema the registry can resolve but the boundary refuses — it
+			// runs over HTTP and is rejected over MCP, which is the drift a
+			// hand-copied list allowed
+			for (const name of Object.keys(schemaRegistry)) {
+				expect(accepts(name)).toBe(true)
+			}
+		})
+
+		it('should refuse a name the registry does not hold', () => {
+			expect(accepts('bogus_schema_v9')).toBe(false)
+			expect(accepts('')).toBe(false)
+			expect(accepts('toString')).toBe(false)
+		})
+	})
+})
+
+describe('isSchemaName', () => {
+	describe('when the name is one the registry holds', () => {
+		it('should recognise every registered name', () => {
+			// GIVEN the five shapes a run can come back in
+			for (const name of schemaNames) {
+				expect(isSchemaName(name)).toBe(true)
+			}
+		})
+	})
+
+	describe('when the name is not in the registry', () => {
+		it('should reject a name that was never there', () => {
+			expect(isSchemaName('made_up_v9')).toBe(false)
+		})
+
+		it('should reject the empty name', () => {
+			expect(isSchemaName('')).toBe(false)
+		})
+
+		it('should not mistake a name every object carries for a schema', () => {
+			// GIVEN names that live on every object rather than in the registry
+			// THEN they are not schemas, so a run named after one is refused like any
+			// other unknown name instead of resolving to a function
+			expect(isSchemaName('toString')).toBe(false)
+			expect(isSchemaName('constructor')).toBe(false)
+			expect(isSchemaName('__proto__')).toBe(false)
+		})
+	})
+})
+
+describe('resolveSchema', () => {
+	describe('when the name is one the registry holds', () => {
+		it('should hand back the schema the registry stores under it', () => {
+			// GIVEN a name read off a run row
+			// THEN the run is shaped by exactly the schema that name refers to
+			expect(resolveSchema('company_enrichment_v1')).toBe(
+				schemaRegistry.company_enrichment_v1,
+			)
+			expect(resolveSchema('freeform')).toBe(schemaRegistry.freeform)
+		})
+	})
+
+	describe('when the name no longer resolves', () => {
+		it('should return nothing, so a retired schema is caught rather than run', () => {
+			// GIVEN a run queued under a schema that has since been retired — the
+			// name survives on its row long after the schema is gone
+			// THEN the caller is handed nothing to run, rather than a stand-in
+			expect(resolveSchema('retired_shape_v1')).toBeUndefined()
+		})
+
+		it('should return nothing for a name every object carries', () => {
+			expect(resolveSchema('toString')).toBeUndefined()
+			expect(resolveSchema('__proto__')).toBeUndefined()
 		})
 	})
 })

--- a/packages/research/src/application/schemas/index.ts
+++ b/packages/research/src/application/schemas/index.ts
@@ -7,33 +7,47 @@ import { FreeformSchema } from './freeform'
 import { ProspectScanV1Schema } from './prospect-scan-v1'
 
 // Closed set of server-compiled Effect Schemas. Versioned so schemas can
-// evolve without breaking old runs. Callers pass schema_name as a string;
-// the service resolves it here for LanguageModel.generateObject.
-export const schemaRegistry: Record<string, Schema.Top> = {
+// evolve without breaking old runs. The service resolves a name here for
+// LanguageModel.generateObject.
+//
+// `satisfies` rather than a `Record<string, …>` annotation: the annotation
+// checks the same thing but throws the five names away afterwards, leaving
+// every table keyed by them free to fall out of step with this one silently.
+export const schemaRegistry = {
 	freeform: FreeformSchema,
 	company_enrichment_v1: CompanyEnrichmentV1Schema,
 	competitor_scan_v1: CompetitorScanV1Schema,
 	contact_discovery_v1: ContactDiscoveryV1Schema,
 	prospect_scan_v1: ProspectScanV1Schema,
-}
+} satisfies Record<string, Schema.Top>
 
 export type SchemaName = keyof typeof schemaRegistry
 
-// Runtime tuple of the registry's keys, so the API boundary can reject an
+// Runtime list of the registry's keys, so the API boundary can reject an
 // unknown schema_name up front instead of letting a doomed run be created.
-// Kept in sync with schemaRegistry above (a closed, rarely-changing set).
-export const schemaNames = [
-	'freeform',
-	'company_enrichment_v1',
-	'competitor_scan_v1',
-	'contact_discovery_v1',
-	'prospect_scan_v1',
-] as const
+// Read off the registry, so the two cannot disagree; reading an object's keys
+// only ever promises strings, and the cast names them back.
+export const schemaNames = Object.keys(
+	schemaRegistry,
+) as ReadonlyArray<SchemaName>
 
 // The same closed set as an Effect Schema, so HTTP/MCP boundaries can validate
-// schema_name with one import instead of re-deriving the literal union (which
-// widens to plain string when the tuple is read across a package boundary).
+// schema_name with one import instead of writing the names out again.
 export const SchemaNameSchema = Schema.Literals(schemaNames)
+
+/** Whether a name, from wherever it arrived, is one this build still has. */
+export const isSchemaName = (name: string): name is SchemaName =>
+	Object.hasOwn(schemaRegistry, name)
+
+/**
+ * The schema behind a name, or nothing when there is no such schema here.
+ *
+ * Names reach this from outside the type system — off a run row written months
+ * ago, or from a caller — so a name that has been retired since has to come
+ * back as nothing rather than as a schema that is not there.
+ */
+export const resolveSchema = (name: string): Schema.Top | undefined =>
+	isSchemaName(name) ? schemaRegistry[name] : undefined
 
 // Fields every schema carries that are not something to go and find out: they
 // are how a run hands work back to the CRM, and the prompt covers them where it
@@ -87,7 +101,7 @@ const innerFields = (field: unknown): Record<string, unknown> | undefined => {
  * output is shaped. Empty for a run that writes a brief rather than a profile.
  */
 export const schemaFieldNames = (schemaName: string): ReadonlyArray<string> => {
-	const schema = schemaRegistry[schemaName]
+	const schema = resolveSchema(schemaName)
 	const fields = (schema as { fields?: Record<string, unknown> } | undefined)
 		?.fields
 	if (fields === undefined) return []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,9 @@ importers:
       '@batuda/email':
         specifier: workspace:*
         version: link:../email
+      '@batuda/research':
+        specifier: workspace:*
+        version: link:../research
       '@batuda/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## What

Research can come back in five different shapes — a company profile, a list of prospects, a list of competitors, a list of people, or an open-ended written brief. Which one a run produces is picked by name from a fixed list called the schema registry. Two comments in the code promised that adding or removing a name from that list would break the build until every place handling it was updated. Neither promise was true, so changing the list quietly rotted the web app instead of stopping the build.

This makes the promise real, and closes the three holes that were only survivable because nobody has ever retired a schema. It lives in the research bounded context (`packages/research`), the shared API spec (`packages/controllers`), and the web app (`apps/internal`).

## The fix

- **The registry keeps its names now.** It was annotated `Record<string, Schema.Top>`, which checks that each entry is a schema but throws the five names away afterwards — so the name type was plain text, and any table keyed by it could drift silently. `satisfies` checks the same thing and keeps the names.
- **The list of names is no longer written down twice.** The runtime list the API boundary validates against was hand-copied beneath the registry, held in step only by a comment saying to keep them in sync. It is now read off the registry's own keys.
- **The HTTP route takes the closed set** instead of free text. It previously accepted any string while the tool surface checked against the list, so an unknown name created a run that flipped to `running`, published a started event, and only then died.
- **Re-running refuses** a run whose schema no longer resolves, rather than copying the stored name into a fresh queued run that could only fail.
- **Two lookups added** for the places where a name arrives from outside the type system — off a run row written months ago, or from a caller.
- **The three inaccurate comments are corrected**, including the registry's own, which blamed the name list widening across a package boundary. It didn't; the annotation was the cause.

## Impact

- **API wire-shape contract (breaking for bad input, by design).** `POST /v1/research` now rejects an unrecognised `schema_name` with a 400 instead of accepting it. Any caller sending a name outside the five gets a bad-request error where it previously got a run id and a run that failed minutes later. The served OpenAPI spec changes from `"type": "string"` to a five-value enum, so the typed client and any MCP-side consumer see the closed set.
- **Fan-out cost.** A selector request wrote a batch row plus one run per matched company *before* any of them reached the point of failing, so a single bad name created N doomed runs. It now creates none.
- **`packages/controllers` gains a dependency on `packages/research`** — via a new `./application/schemas` subpath, not the package entry point. The entry point reaches the research service and the providers it talks to, and this spec is what the browser builds its API client from, so pulling it in would drag all of that into the bundle. `apps/internal` imports the same subpath for the same reason (the existing `@batuda/research/domain/types` import is the precedent).
- **No migration, no new env vars, no auth or RLS change.** Nothing touches tenant isolation or which Postgres role a path runs under.
- **MCP parity unchanged** — the MCP tools already validated against this list; this brings HTTP up to match, so both surfaces now behave the same.

## Review guide

- **Start at `packages/research/src/application/schemas/index.ts`** — everything else follows from the `satisfies` change on the registry.
- **The one cast worth your eye** is `Object.keys(schemaRegistry) as ReadonlyArray<SchemaName>`. Reading an object's keys only ever promises `string[]` in TypeScript, so there is no cast-free way to derive the list; the cast just names them back. If you'd rather invert it — declare the names tuple first and make the registry satisfy it — say so and I'll flip it. I went the direction the issue asked for, with the registry as the single source of truth.
- **A decision you might overrule:** the new-research dialog's card list is an array, so retiring or renaming a schema breaks the build there, but *adding* one does not force a card. I left it that way — a card needs a label and a description someone has to write, and the issue's acceptance only asks for removal/rename to break — and rewrote the comment to say so instead of repeating the old false promise. Making adds break too would mean keying the cards by name and deriving display order separately, which felt worse than the honest comment.
- **`run-detail.tsx` reads as a behaviour change but isn't.** The old code cast the run's schema name to the name type and indexed the table; that cast was harmless while the type was plain text and becomes a lie once it's a real union. It now looks the table up by plain string, which is what the run row actually carries. The existing runtime guard and JSON-dump fallback are untouched.
- **Skip-able:** the two `.po` catalog files (generated by `i18n:extract`, plus the two Catalan strings) and the lockfile line.
- **What I did not run:** `/code-review` and `/security-review` were not invoked (agent tools are off in this session). The change tightens an input boundary rather than adding a parser, and touches no auth, RLS, or crypto path. Snyk was not available either. Flagging it rather than leaving it silent.
- **Accessibility:** no new interactive elements or layout. The two new strings render through the existing toast and the existing error banner, both already wired with `role="alert"`.

## Screenshots

> Screenshots skipped (approved): the only visible changes are two error strings inside existing toast/banner components — no new elements and no layout change. Neither state is reachable in this build, since they fire only once a schema has been retired and none ever has; capturing them would mean deliberately deleting a registry entry.

## Tests

- **Unit (`packages/research`)** — the boundary schema accepts exactly what the registry can resolve, in both directions; the two lookups reject unknown names, the empty name, and names every object inherits (`toString`, `constructor`, `__proto__`), so a run named after one is refused rather than resolving to a function.
- **Unit (`packages/controllers`)** — the create payload accepts every registry name and no schema at all, and refuses an unknown name, an unknown name on a fan-out request, and the empty string.
- **Integration (`apps/server`, real database)** — re-running a run stored under a retired schema is refused and queues nothing.

## Verification

- `pnpm install`, `pnpm -w check-types` (13 tasks), `pnpm -w test` (21 tasks), `pnpm -w build` (13 tasks) — all green, re-run after rebasing onto current `main`.
- `pnpm test:integration research-subject-scope` — 5 passed, including the new re-run case, against the worktree's Postgres.
- **Compiler probes.** A probe asserting `string extends SchemaName` compiled clean before and now fails, alongside a deliberate control error proving the probe was live. Removing `prospect_scan_v1` from the registry then breaks **both** dispatch tables — the findings-view table and the dialog's card list. Restoring the old `Record<string, Schema.Top>` annotation with the same entry removed compiles clean, which is the contrast the issue describes.
- **Live stack.** Against the running worktree server: the served OpenAPI spec now declares `schema_name` as the five-value enum; an unknown name returns **400** and a fan-out with an unknown name returns **400**, both leaving zero rows in `research_runs`; a valid name returns **200** and queues a run. Probe rows and the probe API key were cleaned up afterwards.

## Deferred

- Nothing from this issue. The related eval/seed work in #345 stays where it is — that issue exists because these views could break on an unexpected schema name, which this makes a compile error instead.

Closes #432
