### PR TITLE
fix(research): tell a stored page's id apart from a web address

### DIFF
--- a/packages/research/src/application/entity-source-guard.test.ts
+++ b/packages/research/src/application/entity-source-guard.test.ts
@@ -128,6 +128,56 @@ describe('guardEntitySources', () => {
 		})
 	})
 
+	describe('when a contact is cited to a user post AND to a first-party page', () => {
+		it('should keep them — a post is only disqualifying as the sole tie', () => {
+			// GIVEN a named executive the company lists on its own team page and also
+			// announces on its Instagram, so their sources are one of each
+			const findings = {
+				contacts: [
+					{
+						name: 'Scott Barbour',
+						role: sourced('CEO', 'https://acmefreight.com/team'),
+						citations: [
+							{ source_id: 'https://acmefreight.com/team' },
+							{ source_id: 'https://www.instagram.com/reel/DavToL1gq3i/' },
+						],
+					},
+				],
+			}
+
+			// WHEN the guard runs
+			const out = guardEntitySources(findings, targets)
+
+			// THEN the contact survives, and nothing is reported as a drop — the post
+			// is not what the contact rests on
+			const contacts = (out.findings as { contacts: { name: string }[] })
+				.contacts
+			expect(contacts).toHaveLength(1)
+			expect(contacts[0]?.name).toBe('Scott Barbour')
+			expect(out.droppedContacts).toBe(0)
+			expect(out.droppedUncited).toBe(0)
+		})
+
+		it('should still drop a contact whose every source is a post', () => {
+			// GIVEN a contact cited to two posts and nothing else — different hosts,
+			// but not one page the company stands behind
+			const findings = {
+				contacts: [
+					{
+						name: 'Reel Person',
+						role: sourced('CEO', 'https://www.instagram.com/reel/DavToL1gq3i/'),
+						citations: [{ source_id: 'https://x.com/acme/status/1789' }],
+					},
+				],
+			}
+
+			// WHEN the guard runs — THEN it goes, counted as the drop it is
+			const out = guardEntitySources(findings, targets)
+			expect((out.findings as { contacts: unknown[] }).contacts).toHaveLength(0)
+			expect(out.droppedContacts).toBe(1)
+		})
+	})
+
 	describe('when a contact is cited to their own professional profile', () => {
 		it('should keep it (a person page is fine for that person)', () => {
 			// GIVEN a contact whose role is cited to their own LinkedIn profile

--- a/packages/research/src/application/entity-source-guard.ts
+++ b/packages/research/src/application/entity-source-guard.ts
@@ -40,7 +40,7 @@
 import type { EntityTargets } from './entity-guard'
 import { classifyEntityMatchPerSource } from './entity-guard'
 import { isPlainObject, isValueWrapper } from './guard-shapes'
-import { hostOf, pathOf } from './source-key'
+import { hostOf, isWebAddress, pathOf } from './source-key'
 
 type NamespaceTier = 'ugc' | 'profile' | null
 
@@ -53,7 +53,9 @@ const hostMatches = (host: string, site: string): boolean =>
 // only); null is an ordinary page, left alone here — the tier and entity guards
 // judge it on its merits.
 export const classifyNamespace = (sourceId: string): NamespaceTier => {
-	const host = hostOf(sourceId)
+	// Only a real web address has a namespace to read: a bare word, or an internal
+	// id for a page the run already holds, is nothing anybody posted.
+	const host = isWebAddress(sourceId) ? hostOf(sourceId) : null
 	if (host === null) return null
 	const path = pathOf(sourceId) ?? ''
 
@@ -205,12 +207,15 @@ export const guardEntitySources = (
 	if (Array.isArray(contacts)) {
 		out['contacts'] = contacts.filter(contact => {
 			const ids = contactSourceIds(contact)
-			if (ids.some(id => classifyNamespace(id) === 'ugc')) {
-				droppedContacts++
-				return false
-			}
 			if (ids.length === 0) {
 				droppedUncited++
+				return false
+			}
+			// Every tie, not any one of them: a person the company also names on its
+			// own team page is a real contact whom a post happens to mention too, and
+			// the post is not what we are leaning on.
+			if (ids.every(id => classifyNamespace(id) === 'ugc')) {
+				droppedContacts++
 				return false
 			}
 			return true

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -953,8 +953,10 @@ describe('citedUnscrapedSources', () => {
 	})
 
 	describe('when a citation is already fetched or cannot help', () => {
-		it('should skip fetched pages, blocked namespaces, and unparseable ids', () => {
-			// GIVEN a fetched page, a person profile, and a junk citation id
+		it('should skip fetched pages, blocked namespaces, and ids that are not addresses', () => {
+			// GIVEN a fetched page, a person profile, a junk citation id, and one of
+			// our own source ids — the mailbox harvested off a company's contact page
+			// is cited to exactly that, and no amount of paying can fetch it
 			const findings = {
 				enrichment: {
 					industry: { value: 't', source_id: 'https://fetched.com/p' },
@@ -963,6 +965,7 @@ describe('citedUnscrapedSources', () => {
 						source_id: 'https://www.zoominfo.com/p/Someone/1',
 					},
 					location: { value: 'x', source_id: 'not a url' },
+					email: { value: 'info@acme.es', source_id: 'src_1f7b0e8ff733b5d2' },
 				},
 			}
 

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -130,7 +130,12 @@ import {
 	schemaFieldNames,
 	schemaRegistry,
 } from './schemas/index'
-import { hostOf, sourceIdFor, urlHashForScrape } from './source-key'
+import {
+	hostOf,
+	isWebAddress,
+	sourceIdFor,
+	urlHashForScrape,
+} from './source-key'
 import { recordSeenSource } from './source-record'
 import { enforceSourceTier, isFirstPartyHost } from './source-tier-guard'
 import { stripReasoning } from './strip-reasoning'
@@ -370,7 +375,9 @@ export const openedPages = <
 // citations the per-source entity check had to fail open on. A gap round
 // scrapes these first: fetching the cited page turns fail-open into a real
 // verdict, and the page often carries the very facts still missing. Blocked
-// namespaces (posts, person pages) are skipped — fetching one changes nothing.
+// namespaces (posts, person pages) are skipped — fetching one changes nothing —
+// and so is anything that is not a web address, such as an internal id naming a
+// page the run already holds.
 export const citedUnscrapedSources = (
 	findings: unknown,
 	hasPage: (urlHash: string) => boolean,
@@ -388,7 +395,7 @@ export const citedUnscrapedSources = (
 		if (seen.has(id)) continue
 		seen.add(id)
 		if (classifyNamespace(id) !== null) continue
-		if (hostOf(id) === null) continue
+		if (!isWebAddress(id)) continue
 		if (hasPage(urlHashForScrape(id))) continue
 		out.push(id)
 		if (out.length >= cap) break
@@ -4367,15 +4374,16 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									citedUrl =>
 										Effect.gen(function* () {
 											// Mark the attempt (fetched, empty, or errored) so a page that
-											// yields nothing is not re-fetched next round; charge only a real
-											// fetch against the gap budget.
+											// yields nothing is not re-fetched next round.
 											citedAttempted.add(urlHashForScrape(citedUrl))
 											if (isUnsupportedScrapeUrl(citedUrl)) return
-											gapSpentCents += SCRAPE_COST_CENTS
 											const cited = yield* gapScrape.scrape({
 												url: citedUrl,
 												formats: ['markdown'],
 											})
+											// Charged once the fetch is back, so a URL that errors out
+											// leaves the round's remaining budget intact.
+											gapSpentCents += SCRAPE_COST_CENTS
 											if (
 												cited.markdown !== undefined &&
 												cited.markdown.trim().length > 0

--- a/packages/research/src/application/source-key.test.ts
+++ b/packages/research/src/application/source-key.test.ts
@@ -2,7 +2,14 @@ import { createHash } from 'node:crypto'
 
 import { describe, expect, it } from 'vitest'
 
-import { canonicalizeUrl, hostOf, pathOf, urlHashForScrape } from './source-key'
+import {
+	canonicalizeUrl,
+	hostOf,
+	isWebAddress,
+	pathOf,
+	sourceIdFor,
+	urlHashForScrape,
+} from './source-key'
 
 describe('canonicalizeUrl', () => {
 	it('should lowercase the hostname', () => {
@@ -175,6 +182,82 @@ describe('pathOf', () => {
 
 		it('should return null for text that is not a URL', () => {
 			expect(pathOf('just a title')).toBeNull()
+		})
+	})
+})
+
+describe('isWebAddress', () => {
+	describe('when the string is a page somebody could open', () => {
+		it('should accept it however the model tidied it', () => {
+			// GIVEN the same site written with a scheme, without one, and with www
+			// THEN each is an address worth fetching and worth placing by host
+			expect(isWebAddress('https://acme.es/contact')).toBe(true)
+			expect(isWebAddress('acme.es')).toBe(true)
+			expect(isWebAddress('www.acme.es/careers')).toBe(true)
+			expect(isWebAddress('HTTP://ACME.es/a/b?x=1')).toBe(true)
+			expect(isWebAddress('https://careers.acme.co.uk:8443/x')).toBe(true)
+		})
+
+		it('should accept a non-Latin address, ending and all', () => {
+			// GIVEN domains the parser hands back as punycode — one with a Latin
+			// ending, one whose ending is non-Latin too
+			expect(isWebAddress('ñandú.es')).toBe(true)
+			expect(isWebAddress('пример.рф')).toBe(true)
+			expect(isWebAddress('https://例え.テスト')).toBe(true)
+			// The punycode is what the check actually sees, either way
+			expect(isWebAddress('https://xn--e1afmkfd.xn--p1ai')).toBe(true)
+		})
+
+		it('should accept hosts spelled unusually rather than call them unreadable', () => {
+			// GIVEN two legal but uncommon spellings — saying "not an address" here
+			// would let a third party's page skip the confidence cap
+			expect(isWebAddress('https://acme.es./about')).toBe(true)
+			expect(isWebAddress('https://my_data.example.com/acme')).toBe(true)
+		})
+	})
+
+	describe('when the string is one of our own source ids', () => {
+		it('should reject it, so no run pays to fetch a page it already holds', () => {
+			// GIVEN the id a harvested contact page is cited to
+			const sourceId = sourceIdFor(urlHashForScrape('https://acme.es/contact'))
+
+			// WHEN asked whether it is a web address
+			// THEN no — even though gluing a scheme on the front parses it as a host
+			expect(sourceId).toMatch(/^src_/)
+			expect(isWebAddress(sourceId)).toBe(false)
+			expect(hostOf(sourceId)).not.toBeNull()
+		})
+	})
+
+	describe('when the string is not a web address', () => {
+		it('should reject prose, empty text, and a bare word', () => {
+			// GIVEN citations a model wrote as a title or left blank
+			expect(isWebAddress('Monzo Bank plc')).toBe(false)
+			expect(isWebAddress('')).toBe(false)
+			expect(isWebAddress('   ')).toBe(false)
+			// A single label is nothing on the public web
+			expect(isWebAddress('localhost')).toBe(false)
+			expect(isWebAddress('intranet')).toBe(false)
+		})
+
+		it('should reject a mailbox, so a gap round never fetches an address', () => {
+			// GIVEN an email written bare and with its scheme — both would otherwise
+			// read as the site acme.es
+			expect(isWebAddress('info@acme.es')).toBe(false)
+			expect(isWebAddress('mailto:info@acme.es')).toBe(false)
+		})
+
+		it('should reject a scheme no scraper opens', () => {
+			// GIVEN a file or transfer URL rather than a page
+			expect(isWebAddress('ftp://acme.es/pub')).toBe(false)
+			expect(isWebAddress('file:///etc/hosts')).toBe(false)
+		})
+
+		it('should reject hosts that are not domain names', () => {
+			// GIVEN a numeric host and a malformed one — neither is a site to judge
+			expect(isWebAddress('https://192.168.1.1/x')).toBe(false)
+			expect(isWebAddress('https://acme-.es')).toBe(false)
+			expect(isWebAddress('https://acme.e')).toBe(false)
 		})
 	})
 })

--- a/packages/research/src/application/source-key.ts
+++ b/packages/research/src/application/source-key.ts
@@ -37,24 +37,30 @@ export const urlHashForScrape = (url: string): string =>
 export const sourceIdFor = (urlHash: string): string =>
 	`src_${urlHash.slice(0, 16)}`
 
+// Parse a URL, retrying with a scheme glued on the front — a scheme-less
+// "monzo.com" or "www.acme.es/x", the tidied form a model often emits, throws on
+// the first attempt. Null when neither form parses.
+const parseUrl = (url: string): URL | null => {
+	try {
+		return new URL(url)
+	} catch {
+		try {
+			return new URL(`https://${url}`)
+		} catch {
+			return null
+		}
+	}
+}
+
 /**
  * The `www.`-stripped, lowercased host of a URL, or null if it doesn't parse — for
  * comparing two URLs by the SITE they belong to rather than the exact page.
  */
 export const hostOf = (url: string): string | null => {
-	try {
-		return new URL(url).hostname.toLowerCase().replace(/^www\./, '')
-	} catch {
-		// A scheme-less "monzo.com" or "www.acme.es/x" — the tidied form a model
-		// often emits — throws above; retry with a scheme so it still resolves.
-		try {
-			return new URL(`https://${url}`).hostname
-				.toLowerCase()
-				.replace(/^www\./, '')
-		} catch {
-			return null
-		}
-	}
+	const parsed = parseUrl(url)
+	return parsed === null
+		? null
+		: parsed.hostname.toLowerCase().replace(/^www\./, '')
 }
 
 /**
@@ -63,13 +69,35 @@ export const hostOf = (url: string): string | null => {
  * person) from `/company/`, or ZoomInfo's `/p/` (a person) from a company record.
  */
 export const pathOf = (url: string): string | null => {
-	try {
-		return new URL(url).pathname.toLowerCase()
-	} catch {
-		try {
-			return new URL(`https://${url}`).pathname.toLowerCase()
-		} catch {
-			return null
-		}
-	}
+	const parsed = parseUrl(url)
+	return parsed === null ? null : parsed.pathname.toLowerCase()
+}
+
+// A host that is really a domain name: dot-separated labels ending in a top-level one
+// of letters, or the `xn--` form the parser turns a non-Latin ending like `.рф` into.
+// Rules out the bare words the scheme retry above happily accepts, and the numeric
+// hosts nobody cites. Deliberately generous about what a label may hold, because
+// saying "not an address" about a real site is the costlier mistake: it would let a
+// third party's page skip the confidence cap.
+const DOMAIN_NAME =
+	/^(?:[a-z0-9_](?:[a-z0-9_-]*[a-z0-9_])?\.)+(?:[a-z]{2,}|xn--[a-z0-9-]+)$/
+
+/**
+ * Whether a string is an address that could actually be fetched off the web.
+ *
+ * Ask this — not `hostOf(x) !== null` — whenever the question is "is this a web
+ * address?". `hostOf` answers with a host for any bare word, so an internal
+ * `src_…` id for a page already stored reads as the site "src_…": a run pays to
+ * fetch it, and it never matches the company's own domain.
+ */
+export const isWebAddress = (value: string): boolean => {
+	const parsed = parseUrl(value)
+	if (parsed === null) return false
+	// Only what a browser or a scraper could open, and never a mailbox: an
+	// "info@acme.es" would otherwise parse as the site acme.es.
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false
+	if (parsed.username !== '' || parsed.password !== '') return false
+	// A trailing dot spells the same domain, so it is no reason to call a real site
+	// unreadable.
+	return DOMAIN_NAME.test(parsed.hostname.toLowerCase().replace(/\.$/, ''))
 }

--- a/packages/research/src/application/source-tier-guard.test.ts
+++ b/packages/research/src/application/source-tier-guard.test.ts
@@ -13,6 +13,7 @@ interface SourcedView {
 interface EnrichmentView {
 	size_range: SourcedView
 	location: SourcedView
+	email: SourcedView
 }
 const enrichment = (findings: unknown): EnrichmentView =>
 	(findings as { enrichment: EnrichmentView }).enrichment
@@ -141,6 +142,30 @@ describe('enforceSourceTier', () => {
 		})
 	})
 
+	describe('when a value is cited to a page the run already holds', () => {
+		it('should keep its confidence — an internal id is not an outside host', () => {
+			// GIVEN the mailbox harvested off the company's own contact page, which is
+			// cited to our source id for that page rather than to its URL
+			const findings = {
+				enrichment: {
+					email: {
+						value: 'info@acme.com',
+						source_id: 'src_1f7b0e8ff733b5d2',
+						confidence: 1,
+					},
+				},
+			}
+
+			// WHEN tiered against the target host
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN it is not read as a third-party host and keeps the full confidence
+			// it was harvested with
+			expect(enrichment(result.findings).email.confidence).toBe(1)
+			expect(result.capped).toBe(0)
+		})
+	})
+
 	describe('when the run has no single target', () => {
 		it('should be a no-op for an empty target list (a discovery scan)', () => {
 			// GIVEN findings from a scan with no anchored company
@@ -163,32 +188,127 @@ describe('enforceSourceTier', () => {
 		})
 	})
 
-	describe('when the shape holds subtrees that are not scalar fields', () => {
-		it('should not walk into citations or proposed_updates', () => {
-			// GIVEN a proposed-update blob whose fields could look field-ish
-			const findings = {
-				enrichment: {},
-				proposed_updates: [
-					{
-						subject_id: 'c1',
-						fields: {
-							value: 'x',
-							source_id: 'https://datanyze.com/x',
-							confidence: 0.9,
-						},
-						citations: [{ source_id: 'https://datanyze.com/x' }],
-					},
-				],
-			}
+	describe('when a value sits in a proposed update', () => {
+		// The shape the pipeline stores: one address written twice — into the company
+		// profile, and into the change a person is offered to accept.
+		const withProposal = (email: SourcedView & { source_id: string }) => ({
+			enrichment: { email },
+			proposed_updates: [
+				{
+					subject_table: 'companies',
+					subject_id: 'c1',
+					expected_version: 3,
+					fields: { email },
+					reason: 'Get in touch: info@acme.com',
+					citations: [{ source_id: email.source_id, confidence: 1 }],
+				},
+			],
+		})
+		const proposal = (findings: unknown) =>
+			(findings as ReturnType<typeof withProposal>).proposed_updates[0]
+
+		it('should cap a third-party one, since a proposal is what reaches the record', () => {
+			// GIVEN an aggregator-sourced address offered as a change to accept
+			const findings = withProposal({
+				value: 'hello@acme.com',
+				source_id: 'https://www.datanyze.com/companies/acme',
+				confidence: 0.9,
+			})
 
 			// WHEN tiered
 			const result = enforceSourceTier(findings, TARGETS)
 
-			// THEN the freeform subtree is untouched
+			// THEN the offer carries the held-back confidence, not the model's claim
+			expect(proposal(result.findings)?.fields.email.confidence).toBe(
+				THIRD_PARTY_CONFIDENCE_CAP,
+			)
+		})
+
+		it('should keep one cited to a page the run already holds', () => {
+			// GIVEN the mailbox harvested off the company's own contact page, cited by
+			// our source id for that page
+			const findings = withProposal({
+				value: 'info@acme.com',
+				source_id: 'src_1f7b0e8ff733b5d2',
+				confidence: 1,
+			})
+
+			// WHEN tiered — THEN full confidence stands; an internal id is not an
+			// outside host
+			const result = enforceSourceTier(findings, TARGETS)
+			expect(proposal(result.findings)?.fields.email.confidence).toBe(1)
 			expect(result.capped).toBe(0)
-			expect(
-				(result.findings as { proposed_updates: unknown[] }).proposed_updates,
-			).toEqual(findings.proposed_updates)
+		})
+
+		it('should record one confidence for one fact, not two', () => {
+			// GIVEN the same aggregator-sourced address in the profile and the offer
+			const findings = withProposal({
+				value: 'hello@acme.com',
+				source_id: 'https://www.datanyze.com/companies/acme',
+				confidence: 0.9,
+			})
+
+			// WHEN tiered
+			const result = enforceSourceTier(findings, TARGETS)
+
+			// THEN both copies read the same, so nothing downstream can pick the
+			// friendlier number
+			expect(enrichment(result.findings).email.confidence).toBe(
+				proposal(result.findings)?.fields.email.confidence,
+			)
+			expect(result.capped).toBe(2)
+		})
+
+		it('should leave the citation list beside the fields alone', () => {
+			// GIVEN a proposal whose citations name the aggregator the value came from
+			const findings = withProposal({
+				value: 'hello@acme.com',
+				source_id: 'https://www.datanyze.com/companies/acme',
+				confidence: 0.9,
+			})
+
+			// WHEN tiered — THEN only the fields are graded; a citation records where a
+			// claim came from and is not itself a claim
+			const result = enforceSourceTier(findings, TARGETS)
+			expect(proposal(result.findings)?.citations).toEqual(
+				findings.proposed_updates[0]?.citations,
+			)
+		})
+
+		it('should leave an entry that carries no provenance', () => {
+			// GIVEN a proposal field that is a bare value with no source, quote, or
+			// confidence — the freeform content the walk must not mistake for a field
+			const findings = {
+				enrichment: {},
+				proposed_updates: [
+					{ subject_id: 'c1', fields: { note: { value: 'call reception' } } },
+				],
+			}
+
+			// WHEN tiered — THEN it is untouched, and nothing is counted as capped
+			const result = enforceSourceTier(findings, TARGETS)
+			expect(result.findings).toEqual(findings)
+			expect(result.capped).toBe(0)
+		})
+	})
+
+	describe('when the findings hold a block-level citation array', () => {
+		it('should leave it alone', () => {
+			// GIVEN a citation list whose entries carry a source and a confidence, so
+			// each one could pass for a field
+			const findings = {
+				enrichment: {},
+				citations: [
+					{ value: 'x', source_id: 'https://datanyze.com/x', confidence: 0.9 },
+				],
+			}
+
+			// WHEN tiered — THEN the list stands; a citation is provenance, not a value
+			const result = enforceSourceTier(findings, TARGETS)
+			expect(result.capped).toBe(0)
+			expect((result.findings as typeof findings).citations).toEqual(
+				findings.citations,
+			)
 		})
 	})
 })

--- a/packages/research/src/application/source-tier-guard.ts
+++ b/packages/research/src/application/source-tier-guard.ts
@@ -15,12 +15,21 @@
  * It never drops a value — third-party data is still useful — it just stops the
  * caller from trusting an outside estimate like the company's own word.
  *
+ * A citation that is not a web address at all sits on neither side of that line and
+ * is left alone: an internal id for a page the run already holds is not somebody
+ * else's site, and a value read off such a page keeps the confidence it came with.
+ *
+ * The change a person is offered to accept — a proposed update — is graded like
+ * everything else. Its confidence is the one written to the record on approval, so
+ * it is held to the same line as the copy in the company profile; one set of
+ * findings never states two different confidences for a single fact.
+ *
  * It applies only when the run has a known target (an entity-grounded run with
  * target domains); a discovery scan with no single subject is left untouched.
  */
 
 import { isSourcedField } from './guard-shapes'
-import { hostOf } from './source-key'
+import { hostOf, isWebAddress } from './source-key'
 
 // Confidence a third-party-sourced value is held to: kept and usable, but marked
 // no better than medium so it reads as "reported elsewhere", not "the company says
@@ -35,9 +44,9 @@ export const THIRD_PARTY_CONFIDENCE_CAP = 0.6
  */
 export const AUTO_APPLY_CONFIDENCE_FLOOR = THIRD_PARTY_CONFIDENCE_CAP + 0.05
 
-// Subtrees that are not per-field values: block-level citation arrays and the
-// freeform proposed-update blob, whose contents could otherwise look like a field.
-const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
+// A block-level citation array is not a per-field value: an entry there records
+// where a claim came from, not a claim to grade.
+const SKIP_KEYS = new Set(['citations'])
 
 // The value came from one of the target's own hosts — the company's own domain or
 // a subdomain of it. A look-alike or aggregator host never ends with ".<target>".
@@ -76,7 +85,14 @@ export const enforceSourceTier = (
 				source_id?: unknown
 				confidence?: unknown
 			}
-			if (typeof wrapper.source_id === 'string') {
+			// Only a citation that is a web address has a host to place on one side of
+			// the line or the other. An internal id for a page the run already holds —
+			// what a mailbox read off the company's own contact page is cited to — is
+			// left at the confidence it arrived with.
+			if (
+				typeof wrapper.source_id === 'string' &&
+				isWebAddress(wrapper.source_id)
+			) {
 				const host = hostOf(wrapper.source_id)
 				if (host !== null && !isFirstPartyHost(host, targetHosts)) {
 					const current =


### PR DESCRIPTION
A research run cites each fact to where it read it. Usually that is a web address. Sometimes it is Batuda's own id for a page the run already stored — `src_1f7b0e8ff733b5d2` — and one of those reaches the pipeline by an ordinary route: the mailbox harvested off a company's own contact page is cited that way.

Three places in `packages/research` asked "is this a web address?" by parsing the string and checking the answer was not empty. The parser they used glues `https://` onto anything that fails to parse first, so for a bare word it answers "yes — the site `src_1f7b0e8ff733b5d2`". Everything below follows from that one answer, except the third heading, which is a separate bug in a file this change already touches.

## A run paid to fetch a page that cannot be fetched

A later round of a run re-reads the pages a fact was cited to but never opened. Its "is this fetchable?" check passed on a `src_…` id, and the cost was charged *before* the attempt — so the money went out, the fetch failed, the failure was swallowed into a `cited_scrape_skipped` log line, and one of the three fetch slots that round had was spent on something that could never work. It also stopped the round from finishing early. Not a loop — the id is marked attempted — but once per affected run.

Two changes: the check now asks the real predicate, so the id never enters the list; and the charge moved to after the page comes back, so any URL that errors out costs the round nothing.

## The most first-party fact the pipeline produces was marked untrustworthy

The same parser feeds the guard that decides whether a fact came from the company's own site or from someone else's. A `src_…` id parsed as a hostname, never matched the company's domain, and so was ruled third-party — cutting the mailbox's confidence from 100% to 60%.

That mailbox is kept **only** when its domain is the company's own, read verbatim off the company's own contact page. It was the one value the guard should trust most.

## A contact was dropped when any of its sources was a social post

Unrelated to the parser, same file. The contact filter used `some`, so a person was thrown away if *any* citation was a user post:

```ts
if (ids.some(id => classifyNamespace(id) === 'ugc')) { droppedContacts++; return false }
```

The module's own documentation and the comment five lines above both say the intent is to drop a contact *whose only tie to the company is a post*. So a named executive listed on the company's own team page was discarded because the company also announced them on Instagram — and the drop was counted in `droppedContacts`, whose log line reads "only tie was a user post", so the logs made it look correct.

Now `every`, with the uncited check moved above it (`every` on an empty list is true). The counter becomes true to its own name; no separate telemetry change was needed.

## One fact, one number

The confidence guard deliberately skipped `proposed_updates` — the change a person is offered to accept. That left the same fact carrying two numbers: 60% in the company profile, whatever the model claimed inside the proposal. Nothing reconciled them, and [research-apply.ts:115](apps/server/src/services/research-apply.ts:115) shows the proposal's number is the one written to the record on approval — so the ungraded one was the one that stuck.

This was the issue's open decision rather than a specified fix, and it is folded in here: the guard now walks proposals too. `citations` stays skipped at every depth — a citation records where a claim came from, it is not itself a claim.

## The predicate

`isWebAddress` requires a parse, an `http`/`https` scheme, no embedded credentials, and a host that is a real domain name — dot-separated labels ending in a top-level one of letters, or the `xn--` form a non-Latin ending punycodes to.

It is deliberately generous about what a label may contain, because the two failure directions are not symmetric: calling a real site "not an address" makes the guard *skip* the confidence cap, which is the unsafe direction. So a trailing dot (`acme.es.`), an underscore in a label, and a non-Latin ending like `.рф` are all accepted. None of them lets a `src_…` id back in — it has no dot, so the label group cannot match whatever the ending rule allows.

`http` is accepted beside `https` for the same reason: small company sites are still often http-only, and an http-only aggregator that stopped reading as a host would ship its estimate uncapped.

## Impact

- **Confidence values change.** A mailbox harvested from a company's own contact page now reads 100% instead of 60%. An outside-sourced field inside a proposed update now reads 60% instead of the model's claim. No wire shape changed — only the numbers inside `confidence`.
- **Nothing becomes eligible for an unattended write that was not already.** Auto-apply gates on a minimum, and capping only lowers a number, so the new capping can only stop writes, never allow them. The harvested mailbox's number is unchanged at the point auto-apply reads it (it was already 1 there, inside the proposal); this change makes the profile copy agree rather than raising the number the gate sees.
- **Slightly cheaper, slightly more productive gap rounds.** A failed fetch no longer debits the round's budget margin, and a slot is no longer spent on an unfetchable id.
- **Both surfaces get it.** These are pipeline-internal guards, so the MCP and HTTP paths behave identically; neither is called directly.
- No migration, no schema change, no new environment variable, no change to org scoping or route protection.

## Review guide

- Start at [source-key.ts:83](packages/research/src/application/source-key.ts:83) — the predicate is the whole change; the three call sites are one line each.
- The riskiest judgement is the regex, for the reason under *The predicate*: too strict is the unsafe direction. If you would rather it were stricter, that is the line to argue with.
- [source-tier-guard.ts:47](packages/research/src/application/source-tier-guard.ts:47) is the behaviour change you might overrule — walking proposals was a decision, not a specified fix.
- `hostOf` and `pathOf` now share a `parseUrl` helper. Same behaviour, deduplicated try/catch; skim it.
- I did the readability and code-review passes by reading the diff myself rather than spawning the reviewer agents — this session is configured not to launch agents unprompted. Snyk was not run.

## Tests

971 unit tests in `packages/research`, 16 new. Each new test was checked against the pre-fix code: the three that pin the original bugs fail there with the expected assertion (`expected [] to have a length of 1`, `expected [ 'src_1f7b0e8ff733b5d2' ] to deeply equal []`, `expected 0.6 to be 1`), so they bite rather than merely pass.

I also ran the predicate against a written-out inventory of sixteen host shapes rather than trusting the regex by eye. That is how the `.рф` case was caught: a non-Latin ending arrives punycoded as `xn--p1ai`, whose digits and hyphen failed a letters-only rule, so an aggregator on such a domain would have skipped the cap. Also covered there: prose, blank, a single label, a mailbox with and without its scheme, a non-`http` scheme, IPv4 — including the decimal form the parser quietly normalises to `127.0.0.1` — an IPv6 literal, an empty label, a dash at either edge of a label, and a one-letter top-level name.

## Verification

`check-types` (13/13), `test` (21/21), `build` (13/13) and a clean `install` with no lockfile drift, all green on the final tree.

Beyond the unit tests, I replayed the issue's own scenarios through the real unmocked modules — `harvestGenericEmails` → `withRoleMailbox` → `enforceSourceTier` → `citedUnscrapedSources` → `guardEntitySources` — and read the results directly: the harvested mailbox reads 1 in the profile and 1 in the proposal, the Datanyze headcount beside it still caps to 0.6, the gap round now offers only the real URL, and the mixed-citation contact survives while a post-only one is still dropped.

Not run: the paid research eval. These are pure functions with no I/O, and a live run costs provider spend that this change does not need — say the word if you want a run against the golden set before merge.

Closes #434
