### PR TITLE
fix(research): keep vendor answers the response checks were discarding

### DIFF
--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -3544,65 +3544,88 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							) {
 								yield* Effect.gen(function* () {
 									yield* budget.chargeCheap('scrape', SCRAPE_COST_CENTS)
-									const page = yield* scrape.scrape({
-										url: `https://${ownHost}`,
-										formats: ['markdown', 'links'],
-									})
-									if (
-										page.markdown !== undefined &&
-										page.markdown.trim().length > 0
-									) {
-										const hash = urlHashForScrape(page.url)
-										// The company's own domain may 301 to a different host (a
-										// rebrand); the fetch followed it, so the destination is the
-										// same company's official site. Fold that host in as a
-										// strong-match key and put the reached URL in the corpus, so
-										// grounding lands on the live site instead of failing closed
-										// when the rebranded page never names the old domain.
-										const resolvedUrl = page.resolvedUrl ?? page.url
-										const destHost = domainHost(resolvedUrl)
-										const followedRedirect =
-											destHost !== undefined && destHost !== ownHost
-										scrapeCorpus.push({
-											urlHash: hash,
-											text: followedRedirect
-												? `${resolvedUrl}\n${page.markdown}`
-												: page.markdown,
-											host: destHost,
-											kind: 'page',
+									// The homepage fetch keeps its own error handler so a site
+									// that cannot be reached or cannot be read costs only
+									// itself: the about pages and the sitemap walk below still
+									// run, reaching the same site by their own routes.
+									const homepage = yield* Effect.gen(function* () {
+										const page = yield* scrape.scrape({
+											url: `https://${ownHost}`,
+											formats: ['markdown', 'links'],
 										})
-										if (followedRedirect && entityTargets !== null) {
-											entityTargets = withRedirectDomain(
-												entityTargets,
-												destHost,
+										if (
+											page.markdown !== undefined &&
+											page.markdown.trim().length > 0
+										) {
+											const hash = urlHashForScrape(page.url)
+											// The company's own domain may 301 to a different host (a
+											// rebrand); the fetch followed it, so the destination is the
+											// same company's official site. Fold that host in as a
+											// strong-match key and put the reached URL in the corpus, so
+											// grounding lands on the live site instead of failing closed
+											// when the rebranded page never names the old domain.
+											const resolvedUrl = page.resolvedUrl ?? page.url
+											const destHost = domainHost(resolvedUrl)
+											const followedRedirect =
+												destHost !== undefined && destHost !== ownHost
+											scrapeCorpus.push({
+												urlHash: hash,
+												text: followedRedirect
+													? `${resolvedUrl}\n${page.markdown}`
+													: page.markdown,
+												host: destHost,
+												kind: 'page',
+											})
+											if (followedRedirect && entityTargets !== null) {
+												entityTargets = withRedirectDomain(
+													entityTargets,
+													destHost,
+												)
+											}
+											seededAnchorHashes.push(hash)
+											seededTranscriptParts.push(
+												`[scrape_page] ${boundedToolResult({ url: page.url, markdown: page.markdown })}`,
+											)
+											yield* Effect.logInfo(
+												followedRedirect
+													? 'research.anchor.redirect_followed'
+													: 'research.anchor.seeded',
+											).pipe(
+												Effect.annotateLogs({
+													research_id: researchId,
+													host: ownHost,
+													...(followedRedirect
+														? { resolved_host: destHost }
+														: {}),
+												}),
 											)
 										}
-										seededAnchorHashes.push(hash)
-										seededTranscriptParts.push(
-											`[scrape_page] ${boundedToolResult({ url: page.url, markdown: page.markdown })}`,
-										)
-										yield* Effect.logInfo(
-											followedRedirect
-												? 'research.anchor.redirect_followed'
-												: 'research.anchor.seeded',
-										).pipe(
-											Effect.annotateLogs({
-												research_id: researchId,
-												host: ownHost,
-												...(followedRedirect
-													? { resolved_host: destHost }
-													: {}),
-											}),
-										)
-									}
+										return page
+									}).pipe(
+										Effect.catchCause(cause =>
+											Cause.hasInterruptsOnly(cause)
+												? Effect.failCause(cause)
+												: Effect.logWarning('research.anchor.seed_failed').pipe(
+														Effect.annotateLogs({
+															research_id: researchId,
+															host: ownHost,
+															cause: Cause.pretty(cause),
+														}),
+														Effect.as(undefined),
+													),
+										),
+									)
 									// About / contact / team pages carry the location and the named leaders a homepage
 									// rarely spells; fetch a few, chosen from the homepage's own links so no path is
 									// guessed, and let own-host grounding keep what they hold. Each fetch is isolated
 									// so one failure never sinks the rest, and bounded by MAX_ABOUT_PAGES.
 									const reachedHost =
-										domainHost(page.resolvedUrl ?? page.url) ?? ownHost
+										(homepage === undefined
+											? undefined
+											: domainHost(homepage.resolvedUrl ?? homepage.url)) ??
+										ownHost
 									for (const aboutUrl of aboutPageCandidates(
-										page.links ?? [],
+										homepage?.links ?? [],
 										reachedHost,
 										MAX_ABOUT_PAGES,
 									)) {

--- a/packages/research/src/infrastructure/_schema.test.ts
+++ b/packages/research/src/infrastructure/_schema.test.ts
@@ -1,0 +1,153 @@
+import { Option, Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+	firstText,
+	NullableOptional,
+	NullableOptionalTextOrList,
+} from './_schema'
+
+// A vendor field read through each helper, so the assertions run against the
+// same decoding path an adapter uses rather than the helper in the abstract.
+const decodeNullable = Schema.decodeUnknownOption(
+	Schema.Struct({ field: NullableOptional(Schema.String) }),
+)
+const decodeTextOrList = Schema.decodeUnknownOption(
+	Schema.Struct({ field: NullableOptionalTextOrList }),
+)
+
+describe('NullableOptional', () => {
+	describe('when the vendor sends the field', () => {
+		it('should read the value', () => {
+			// GIVEN a response carrying the field
+			// WHEN decoded
+			const decoded = decodeNullable({ field: 'es-ES' })
+
+			// THEN the value comes through untouched
+			expect(Option.getOrUndefined(decoded)?.field).toBe('es-ES')
+		})
+	})
+
+	describe('when the vendor leaves the field out', () => {
+		it('should read a missing key as nothing', () => {
+			// GIVEN a response with no such key at all
+			// WHEN decoded
+			const decoded = decodeNullable({})
+
+			// THEN it carries nothing, and the answer still stands
+			expect(Option.isSome(decoded)).toBe(true)
+			expect(Option.getOrUndefined(decoded)?.field).toBeUndefined()
+		})
+
+		it('should read an explicit null as nothing', () => {
+			// GIVEN a response sending null where a value is documented — the shape
+			// a plain optional rejects, losing an answer the vendor already billed
+			// WHEN decoded
+			const decoded = decodeNullable({ field: null })
+
+			// THEN it reads the same way as a missing key
+			expect(Option.isSome(decoded)).toBe(true)
+			expect(Option.getOrUndefined(decoded)?.field).toBeNull()
+		})
+	})
+
+	describe('when the vendor sends something else entirely', () => {
+		it('should still refuse a value of the wrong type', () => {
+			// GIVEN a field holding a number where text is expected
+			// WHEN decoded
+			// THEN widening has not made the description accept anything at all
+			expect(Option.isNone(decodeNullable({ field: 42 }))).toBe(true)
+		})
+	})
+})
+
+describe('NullableOptionalTextOrList', () => {
+	describe('when the field carries one value', () => {
+		it('should read a single value', () => {
+			// GIVEN a page declaring its language once
+			// WHEN decoded
+			const decoded = decodeTextOrList({ field: 'es-ES' })
+
+			// THEN the value comes through
+			expect(Option.getOrUndefined(decoded)?.field).toBe('es-ES')
+		})
+	})
+
+	describe('when the field carries a list', () => {
+		it('should read a list of values', () => {
+			// GIVEN a page declaring its language in two places at once, which the
+			// vendor reports as a list
+			// WHEN decoded
+			const decoded = decodeTextOrList({ field: ['es-ES', 'ES'] })
+
+			// THEN the whole list survives for the caller to pick from
+			expect(Option.getOrUndefined(decoded)?.field).toEqual(['es-ES', 'ES'])
+		})
+
+		it('should read an empty list', () => {
+			// GIVEN a list with nothing in it
+			// WHEN decoded
+			// THEN that is still a readable answer, not a broken one
+			expect(Option.isSome(decodeTextOrList({ field: [] }))).toBe(true)
+		})
+	})
+
+	describe('when the field is absent or null', () => {
+		it('should read either as nothing', () => {
+			// GIVEN the two ways a vendor omits a field
+			// WHEN decoded
+			// THEN both are accepted
+			expect(Option.isSome(decodeTextOrList({}))).toBe(true)
+			expect(Option.isSome(decodeTextOrList({ field: null }))).toBe(true)
+		})
+	})
+
+	describe('when the list holds something other than text', () => {
+		it('should refuse it', () => {
+			// GIVEN a list of numbers where text is expected
+			// WHEN decoded
+			// THEN the description still holds
+			expect(Option.isNone(decodeTextOrList({ field: [1, 2] }))).toBe(true)
+		})
+	})
+})
+
+describe('firstText', () => {
+	describe('when the field carries one value', () => {
+		it('should return that value', () => {
+			// GIVEN a single value
+			// THEN it is what the field carries
+			expect(firstText('es-ES')).toBe('es-ES')
+		})
+
+		it('should return an empty string as it stands', () => {
+			// GIVEN a vendor sending an empty value rather than omitting the field
+			// THEN it passes through unchanged, exactly as a plain optional field
+			// would have — emptiness is the caller's to judge, not this helper's
+			expect(firstText('')).toBe('')
+		})
+	})
+
+	describe('when the field carries a list', () => {
+		it('should return the first entry', () => {
+			// GIVEN a page that declared its language twice
+			// THEN the first entry is the one the field carries
+			expect(firstText(['es-ES', 'ES'])).toBe('es-ES')
+		})
+
+		it('should return nothing for an empty list', () => {
+			// GIVEN a list with nothing in it
+			// THEN there is no first entry, so the field carries nothing
+			expect(firstText([])).toBeUndefined()
+		})
+	})
+
+	describe('when the field carries nothing', () => {
+		it('should return nothing for null and for undefined alike', () => {
+			// GIVEN the two ways a vendor omits a field
+			// THEN both read as nothing, so a caller never has to tell them apart
+			expect(firstText(null)).toBeUndefined()
+			expect(firstText(undefined)).toBeUndefined()
+		})
+	})
+})

--- a/packages/research/src/infrastructure/_schema.ts
+++ b/packages/research/src/infrastructure/_schema.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared schema helpers for reading vendor responses.
+ *
+ * A description stricter than what the vendor actually sends throws away an
+ * answer that arrived — and was billed — successfully, so every field we do
+ * not strictly need is read as "may be absent, may be null".
+ */
+
+import { Schema } from 'effect'
+
+/**
+ * A field that may be missing entirely or sent as an explicit `null`.
+ * `Schema.optional` on its own accepts a missing key but rejects a `null`,
+ * which a vendor that documents a field as nullable will eventually send.
+ */
+export const NullableOptional = <S extends Schema.Top>(schema: S) =>
+	Schema.optional(Schema.NullOr(schema))
+
+/**
+ * A text field the vendor may send as one value or as a list of them: a page
+ * declaring its language in both an `<html lang>` attribute and a
+ * `<meta name="language">` tag comes back as `["es-ES","ES"]`, and so does a
+ * title the fallback extractor reads twice.
+ */
+export const NullableOptionalTextOrList = NullableOptional(
+	Schema.Union([Schema.String, Schema.Array(Schema.String)]),
+)
+
+/**
+ * The one value a one-or-many text field carries; nothing when it carries none.
+ */
+export const firstText = (
+	value: string | ReadonlyArray<string> | null | undefined,
+): string | undefined =>
+	typeof value === 'string' ? value : (value?.[0] ?? undefined)

--- a/packages/research/src/infrastructure/brave/llm-context.test.ts
+++ b/packages/research/src/infrastructure/brave/llm-context.test.ts
@@ -180,5 +180,56 @@ describe('makeBraveLlmContextSearch', () => {
 			const result = Exit.isSuccess(resolved) ? resolved.value : undefined
 			expect(result?.items).toEqual([])
 		})
+
+		it('should return an empty result when grounding is explicitly null', async () => {
+			// GIVEN a 200 whose grounding block is null rather than missing
+			const { exit } = runSearch(200, { grounding: null })
+
+			// THEN that reads the same way — a zero-hit, not a lost search
+			const resolved = await exit
+			const result = Exit.isSuccess(resolved) ? resolved.value : undefined
+			expect(result?.items).toEqual([])
+		})
+	})
+
+	describe('when an item is missing fields the endpoint does not document', () => {
+		it('should drop an item with no URL and keep the rest', async () => {
+			// GIVEN one source with no address and one with everything. This
+			// endpoint is the last search provider in the chain, so there is nothing
+			// to fall through to — one odd item must not fail the whole search
+			const { exit } = runSearch(200, {
+				grounding: {
+					generic: [
+						{ title: 'No address', snippets: ['Acme was founded in 2011.'] },
+						{
+							url: 'https://acme.com/about',
+							title: null,
+							snippets: ['HQ in Chicago, IL.'],
+						},
+					],
+				},
+			})
+
+			// THEN the addressless item goes, the search itself stands, and the
+			// item with a null title falls back to its own URL
+			const resolved = await exit
+			const result = Exit.isSuccess(resolved) ? resolved.value : undefined
+			expect(result?.items.map(i => i.url)).toEqual(['https://acme.com/about'])
+			expect(result?.items[0]?.title).toBe('https://acme.com/about')
+		})
+
+		it('should drop an item whose snippets are explicitly null', async () => {
+			// GIVEN a source carrying an address but a null passage list
+			const { exit } = runSearch(200, {
+				grounding: {
+					generic: [{ url: 'https://acme.com', title: 'Acme', snippets: null }],
+				},
+			})
+
+			// THEN there is nothing to cite, so the item goes — not the answer
+			const resolved = await exit
+			const result = Exit.isSuccess(resolved) ? resolved.value : undefined
+			expect(result?.items).toEqual([])
+		})
 	})
 })

--- a/packages/research/src/infrastructure/brave/llm-context.ts
+++ b/packages/research/src/infrastructure/brave/llm-context.ts
@@ -29,6 +29,7 @@ import { ProviderError } from '../../domain/errors'
 import { SearchResult, SearchResultItem } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
+import { NullableOptional } from '../_schema'
 
 // Context budget returned per request and per source page. Set to Brave's own
 // defaults (total 8192 of 1024–32768; per-url 4096 of 512–8192): billing is
@@ -43,16 +44,18 @@ const MAX_TOKENS_PER_URL = 4096
 
 // One source's extracted passages. `snippets` may hold plain prose or
 // JSON-serialized structured data (an FAQ block, a table); both read as text.
+// Every field may arrive absent or null, `url` included: one odd source is
+// dropped below rather than sinking a search that was already paid for.
 const GroundingItem = Schema.Struct({
-	url: Schema.String,
-	title: Schema.optional(Schema.String),
-	snippets: Schema.optional(Schema.Array(Schema.String)),
+	url: NullableOptional(Schema.String),
+	title: NullableOptional(Schema.String),
+	snippets: NullableOptional(Schema.Array(Schema.String)),
 })
 
 const LlmContextResponse = Schema.Struct({
-	grounding: Schema.optional(
+	grounding: NullableOptional(
 		Schema.Struct({
-			generic: Schema.optional(Schema.Array(GroundingItem)),
+			generic: NullableOptional(Schema.Array(GroundingItem)),
 		}),
 	),
 })
@@ -144,10 +147,14 @@ export const makeBraveLlmContextSearch = (slot: number) =>
 									.filter(s => s.length > 0)
 									.join('\n\n')
 								if (content.length === 0) return []
+								// Nothing to cite or open later without an address, so the
+								// item goes rather than the whole answer.
+								const url = item.url
+								if (url === undefined || url === null) return []
 								return [
 									new SearchResultItem({
-										url: item.url,
-										title: item.title ?? item.url,
+										url,
+										title: item.title ?? url,
 										snippet: content.slice(0, 300),
 										content,
 									}),

--- a/packages/research/src/infrastructure/brave/search.test.ts
+++ b/packages/research/src/infrastructure/brave/search.test.ts
@@ -235,4 +235,38 @@ describe('makeBraveSearch', () => {
 		expect(result?.items).toEqual([])
 		expect(log.count).toBe(1)
 	})
+
+	it('should return an empty result when the web section is explicitly null', async () => {
+		// GIVEN a 200 whose web section is null rather than missing
+		const { exit } = runSearch(200, { web: null })
+
+		// THEN that reads the same way — a zero-hit, not a lost search
+		const resolved = await exit
+		const result = Exit.isSuccess(resolved) ? resolved.value : undefined
+		expect(result?.items).toEqual([])
+	})
+
+	it('should keep a result whose blurb and title are explicitly null', async () => {
+		// GIVEN a result with no blurb — which Brave documents as optional
+		const { exit } = runSearch(200, {
+			web: {
+				results: [
+					{
+						url: 'https://acme.es',
+						title: null,
+						description: null,
+						extra_snippets: null,
+					},
+				],
+			},
+		})
+
+		// THEN the result keeps its place: the URL alone is worth scraping later
+		const resolved = await exit
+		const result = Exit.isSuccess(resolved) ? resolved.value : undefined
+		expect(result?.items).toHaveLength(1)
+		expect(result?.items[0]?.url).toBe('https://acme.es')
+		expect(result?.items[0]?.title).toBe('')
+		expect(result?.items[0]?.snippet).toBe('')
+	})
 })

--- a/packages/research/src/infrastructure/brave/search.ts
+++ b/packages/research/src/infrastructure/brave/search.ts
@@ -17,23 +17,28 @@ import { ProviderError } from '../../domain/errors'
 import { SearchResult, SearchResultItem } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
+import { NullableOptional } from '../_schema'
 
 // ── Brave API response schema (subset we care about) ──
+// Only the URL is worth failing a whole result over: without it there is
+// nothing to cite or scrape later.
 
 const BraveWebResult = Schema.Struct({
-	title: Schema.String,
+	title: NullableOptional(Schema.String),
 	url: Schema.String,
-	description: Schema.String,
-	page_age: Schema.optional(Schema.String),
+	// Brave documents the blurb as optional, and a result with none is still a
+	// URL worth opening.
+	description: NullableOptional(Schema.String),
+	page_age: NullableOptional(Schema.String),
 	// Up to 5 additional excerpts from the page (requested via extra_snippets) —
 	// richer grounding context than the single description line.
-	extra_snippets: Schema.optional(Schema.Array(Schema.String)),
+	extra_snippets: NullableOptional(Schema.Array(Schema.String)),
 })
 
 const BraveSearchResponse = Schema.Struct({
-	web: Schema.optional(
+	web: NullableOptional(
 		Schema.Struct({
-			results: Schema.Array(BraveWebResult),
+			results: NullableOptional(Schema.Array(BraveWebResult)),
 		}),
 	),
 })
@@ -125,8 +130,8 @@ export const makeBraveSearch = (slot: number) =>
 								const extra = (r.extra_snippets ?? []).join('\n')
 								return new SearchResultItem({
 									url: r.url,
-									title: r.title,
-									snippet: r.description,
+									title: r.title ?? '',
+									snippet: r.description ?? '',
 									...(extra.length > 0 ? { content: extra } : {}),
 								})
 							}),

--- a/packages/research/src/infrastructure/cached-search.test.ts
+++ b/packages/research/src/infrastructure/cached-search.test.ts
@@ -71,4 +71,5 @@ describe('search cache layer (integration)', () => {
 		'should return cached search results on the second identical query within TTL',
 	)
 	it.todo('should refuse to serve rows where expires_at is in the past')
+	it.todo('should run the search for real when a stored row cannot be read')
 })

--- a/packages/research/src/infrastructure/cached-search.ts
+++ b/packages/research/src/infrastructure/cached-search.ts
@@ -20,7 +20,7 @@
 
 import { createHash } from 'node:crypto'
 
-import { Effect, Layer, Schema } from 'effect'
+import { Cause, Effect, Layer, Option, Schema } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { type SearchInput, SearchProvider } from '../application/ports'
@@ -99,14 +99,11 @@ export const makeCachedSearch = () =>
 							}),
 						)
 
-					const hits = yield* lookup(keyHash)
-					if (hits[0]) {
-						yield* sql`
-							UPDATE search_cache
-							SET hit_count = hit_count + 1
-							WHERE key_hash = ${keyHash}
-						`
-						const decoded = yield* decodeSearchResult(hits[0].items).pipe(
+					// The vendor fallback sits inside this wrapper, so a stored row we
+					// can no longer read would sink the whole run without a single
+					// vendor being asked. Both reads below go through here.
+					const readCachedRow = (items: unknown) =>
+						decodeSearchResult(items).pipe(
 							Effect.mapError(
 								e =>
 									new ProviderError({
@@ -115,35 +112,61 @@ export const makeCachedSearch = () =>
 										recoverable: false,
 									}),
 							),
+							Effect.map(Option.some),
+							Effect.catchCause(cause =>
+								// A cancelled run stays cancelled — only a row we cannot read
+								// falls through to a live search.
+								Cause.hasInterruptsOnly(cause)
+									? Effect.failCause(cause)
+									: Effect.logWarning('cache.read_failed').pipe(
+											Effect.annotateLogs({
+												event: 'cache.read_failed',
+												port: 'search',
+												cache_table: 'search_cache',
+												key_hash: keyHash,
+												cause: Cause.pretty(cause),
+											}),
+											Effect.as(Option.none<SearchResult>()),
+										),
+							),
 						)
-						yield* Effect.logDebug('cache.hit').pipe(
-							Effect.annotateLogs({
-								event: 'cache.hit',
-								port: 'search',
-								cache_table: 'search_cache',
-								key_hash: keyHash,
-							}),
-						)
-						yield* recordResultSources(decoded)
-						return new SearchResult({ items: decoded.items, units: 0 })
+
+					const hits = yield* lookup(keyHash)
+					const cachedRow = hits[0]
+					if (cachedRow) {
+						const cached = yield* readCachedRow(cachedRow.items)
+						if (Option.isSome(cached)) {
+							yield* sql`
+								UPDATE search_cache
+								SET hit_count = hit_count + 1
+								WHERE key_hash = ${keyHash}
+							`
+							yield* Effect.logDebug('cache.hit').pipe(
+								Effect.annotateLogs({
+									event: 'cache.hit',
+									port: 'search',
+									cache_table: 'search_cache',
+									key_hash: keyHash,
+								}),
+							)
+							yield* recordResultSources(cached.value)
+							return new SearchResult({ items: cached.value.items, units: 0 })
+						}
 					}
 
 					return yield* Effect.gen(function* () {
 						yield* sql`SELECT pg_advisory_xact_lock(hashtext(${`search:${keyHash}`}))`
 						const rehits = yield* lookup(keyHash)
-						if (rehits[0]) {
-							const decoded = yield* decodeSearchResult(rehits[0].items).pipe(
-								Effect.mapError(
-									e =>
-										new ProviderError({
-											provider: 'cache',
-											message: `search_cache decode failed: ${String(e)}`,
-											recoverable: false,
-										}),
-								),
-							)
-							yield* recordResultSources(decoded)
-							return new SearchResult({ items: decoded.items, units: 0 })
+						const rehitRow = rehits[0]
+						if (rehitRow) {
+							const decoded = yield* readCachedRow(rehitRow.items)
+							if (Option.isSome(decoded)) {
+								yield* recordResultSources(decoded.value)
+								return new SearchResult({
+									items: decoded.value.items,
+									units: 0,
+								})
+							}
 						}
 
 						const result = yield* inner.search(input)

--- a/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
+++ b/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
@@ -211,6 +211,20 @@ describe('firecrawl map', () => {
 				limit: 50,
 			})
 		})
+
+		it('should read a walk that returns an explicitly null link list', async () => {
+			// GIVEN a map response whose links are null rather than missing
+			const { exit } = runMap(200, { creditsUsed: null, links: null })
+
+			// WHEN it settles — THEN it is a site with nothing found, not a failure,
+			// and the unreported credits count as one
+			const settled = await exit
+			expect(Exit.isSuccess(settled)).toBe(true)
+			if (Exit.isSuccess(settled)) {
+				expect(settled.value.links).toEqual([])
+				expect(settled.value.units).toBe(1)
+			}
+		})
 	})
 
 	describe('when the API rejects the request', () => {
@@ -386,9 +400,77 @@ describe('makeFirecrawlScrape', () => {
 		expect(err).toBeInstanceOf(UnsupportedSite)
 	})
 
-	it('should fail non-recoverably on a malformed body', async () => {
-		// GIVEN a 2xx response missing the `data` envelope
-		const { exit, log } = runScrape(200, { wrong: 'shape' })
+	it('should read a response carrying no `data` block as an empty page', async () => {
+		// GIVEN a 2xx answer with no page block at all — a shape Firecrawl really
+		// sends, and one whose fetch was already paid for
+		const { exit, log } = runScrape(200, { success: true })
+
+		// WHEN it settles
+		const settled = await exit
+
+		// THEN the answer stands, as a page with no content rather than a failure
+		expect(Exit.isSuccess(settled)).toBe(true)
+		if (Exit.isSuccess(settled)) expect(settled.value.markdown).toBe('')
+		expect(log.count).toBe(1)
+	})
+
+	it('should keep a page whose metadata fields are explicitly null', async () => {
+		// GIVEN a page whose metadata sends null where a string is documented
+		const { exit } = runScrape(200, {
+			data: {
+				markdown: '# Acme',
+				metadata: { title: null, language: null, url: null },
+			},
+		})
+
+		// WHEN it settles
+		const settled = await exit
+
+		// THEN the page is read, with the null fields simply carrying nothing
+		expect(Exit.isSuccess(settled)).toBe(true)
+		if (Exit.isSuccess(settled)) {
+			expect(settled.value.markdown).toBe('# Acme')
+			expect(settled.value.title).toBeUndefined()
+			expect(settled.value.language).toBeUndefined()
+			expect(settled.value.resolvedUrl).toBeUndefined()
+		}
+	})
+
+	it('should take the first entry when a page declares its language twice', async () => {
+		// GIVEN a Spanish page declaring its language in both an <html lang>
+		// attribute and a <meta name="language"> tag, which Firecrawl reports as a
+		// list rather than as one value — ordinary markup, not an oddity
+		const { exit } = runScrape(200, {
+			data: {
+				markdown: '# Acme',
+				metadata: { language: ['es-ES', 'ES'], title: ['Acme', 'Acme SL'] },
+			},
+		})
+
+		// WHEN it settles
+		const settled = await exit
+
+		// THEN the page is read and the first entry is what it carries
+		expect(Exit.isSuccess(settled)).toBe(true)
+		if (Exit.isSuccess(settled)) {
+			expect(settled.value.language).toBe('es-ES')
+			expect(settled.value.title).toBe('Acme')
+		}
+	})
+
+	it('should retry when the provider reports the fetch itself did not work', async () => {
+		// GIVEN a 2xx whose body says the fetch failed on Firecrawl's side
+		const { exit, log } = runScrape(200, { success: false })
+
+		// WHEN it settles — THEN that is worth another try, so it retries to the max
+		const resolved = await exit
+		expect(errorOf(resolved)?.recoverable).toBe(true)
+		expect(log.count).toBe(3)
+	})
+
+	it('should fail non-recoverably on a body it cannot read at all', async () => {
+		// GIVEN a 2xx whose `data` is not a page block
+		const { exit, log } = runScrape(200, { data: 'nonsense' })
 
 		// THEN the decode error is non-recoverable and not retried
 		const resolved = await exit
@@ -588,9 +670,54 @@ describe('makeFirecrawlSearch', () => {
 		expect(errorOf(resolved)?.recoverable).toBe(false)
 	})
 
-	it('should fail non-recoverably on a malformed body', async () => {
-		// GIVEN a 2xx response missing the `data` envelope
-		const { exit, log } = runSearch(200, { wrong: 'shape' })
+	it('should read a response carrying no `data` block as zero hits', async () => {
+		// GIVEN a 2xx answer with no data block — a search that turned nothing up,
+		// not a broken response
+		const { exit, log } = runSearch(200, { success: true })
+
+		// WHEN it settles
+		const settled = await exit
+
+		// THEN the search succeeds with nothing found
+		expect(Exit.isSuccess(settled)).toBe(true)
+		if (Exit.isSuccess(settled)) expect(settled.value.items).toEqual([])
+		expect(log.count).toBe(1)
+	})
+
+	it('should keep a result whose title and passage are explicitly null', async () => {
+		// GIVEN a result sending null where a string is documented
+		const { exit } = runSearch(200, {
+			data: {
+				web: [{ url: 'https://acme.es', title: null, description: null }],
+			},
+		})
+
+		// WHEN it settles
+		const settled = await exit
+
+		// THEN the result keeps its place: the URL alone is worth scraping later
+		expect(Exit.isSuccess(settled)).toBe(true)
+		if (Exit.isSuccess(settled)) {
+			expect(settled.value.items).toHaveLength(1)
+			expect(settled.value.items[0]?.url).toBe('https://acme.es')
+			expect(settled.value.items[0]?.title).toBe('')
+			expect(settled.value.items[0]?.snippet).toBe('')
+		}
+	})
+
+	it('should retry when the provider reports the search itself did not work', async () => {
+		// GIVEN a 2xx whose body says the search failed on Firecrawl's side
+		const { exit, log } = runSearch(200, { success: false })
+
+		// WHEN it settles — THEN that is worth another try, so it retries to the max
+		const resolved = await exit
+		expect(errorOf(resolved)?.recoverable).toBe(true)
+		expect(log.count).toBe(3)
+	})
+
+	it('should fail non-recoverably on a body it cannot read at all', async () => {
+		// GIVEN a 2xx whose `data` is not a result block
+		const { exit, log } = runSearch(200, { data: 'nonsense' })
 
 		// THEN the decode error is non-recoverable and not retried
 		const resolved = await exit

--- a/packages/research/src/infrastructure/firecrawl/map.ts
+++ b/packages/research/src/infrastructure/firecrawl/map.ts
@@ -22,6 +22,7 @@ import { MapProvider, type SiteMapInput } from '../../application/ports'
 import { ProviderError } from '../../domain/errors'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
+import { NullableOptional } from '../_schema'
 import { statusRecoverable } from './scrape'
 
 const MAP_URL = 'https://api.firecrawl.dev/v2/map'
@@ -29,8 +30,8 @@ const MAP_URL = 'https://api.firecrawl.dev/v2/map'
 // The API has answered with both bare URL strings and {url} objects across
 // versions; accept either so a format change doesn't break discovery.
 const MapResponse = Schema.Struct({
-	creditsUsed: Schema.optional(Schema.Number),
-	links: Schema.optional(
+	creditsUsed: NullableOptional(Schema.Number),
+	links: NullableOptional(
 		Schema.Array(
 			Schema.Union([Schema.String, Schema.Struct({ url: Schema.String })]),
 		),

--- a/packages/research/src/infrastructure/firecrawl/scrape.ts
+++ b/packages/research/src/infrastructure/firecrawl/scrape.ts
@@ -24,30 +24,41 @@ import { ProviderError, UnsupportedSite } from '../../domain/errors'
 import { ScrapedPage } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
+import {
+	firstText,
+	NullableOptional,
+	NullableOptionalTextOrList,
+} from '../_schema'
 import { cleanScrapedMarkdown } from './clean-scraped-markdown'
 
 const SCRAPE_URL = 'https://api.firecrawl.dev/v2/scrape'
 
 // Subset of the Firecrawl scrape response we read. Unknown fields are ignored.
 const ScrapeResponse = Schema.Struct({
+	// Firecrawl's own verdict on the fetch, which a 2xx does not guarantee.
+	success: NullableOptional(Schema.Boolean),
 	// The credits Firecrawl says this fetch consumed. Optional because the field
 	// is not on every response shape; a fetch that stays quiet counts as one.
-	creditsUsed: Schema.optional(Schema.Number),
-	data: Schema.Struct({
-		markdown: Schema.optional(Schema.String),
-		html: Schema.optional(Schema.String),
-		links: Schema.optional(Schema.Array(Schema.String)),
-		metadata: Schema.optional(
-			Schema.Struct({
-				title: Schema.optional(Schema.String),
-				language: Schema.optional(Schema.String),
-				// The address the page finally resolved to after Firecrawl followed
-				// any redirects; `sourceURL` is what we asked for. They differ when
-				// the requested domain 301s elsewhere (a rebrand).
-				url: Schema.optional(Schema.String),
-			}),
-		),
-	}),
+	creditsUsed: NullableOptional(Schema.Number),
+	// Firecrawl can answer successfully with no `data` at all. That is an empty
+	// page, not a broken response, so it must not sink the whole answer.
+	data: NullableOptional(
+		Schema.Struct({
+			markdown: NullableOptional(Schema.String),
+			html: NullableOptional(Schema.String),
+			links: NullableOptional(Schema.Array(Schema.String)),
+			metadata: NullableOptional(
+				Schema.Struct({
+					title: NullableOptionalTextOrList,
+					language: NullableOptionalTextOrList,
+					// The address the page finally resolved to after Firecrawl followed
+					// any redirects; `sourceURL` is what we asked for. They differ when
+					// the requested domain 301s elsewhere (a rebrand).
+					url: NullableOptional(Schema.String),
+				}),
+			),
+		}),
+	),
 })
 
 const sha256Hex = (input: string): string =>
@@ -155,18 +166,32 @@ export const makeFirecrawlScrape = (slot: number) =>
 									}),
 							),
 						)
+						// Firecrawl can answer 2xx while saying the fetch itself did not
+						// work. That is their side failing and worth another try, so it
+						// surfaces as an error rather than as a page that came back empty.
+						if (body.success === false) {
+							return yield* Effect.fail(
+								new ProviderError({
+									provider: 'firecrawl',
+									message: 'scrape failed: provider reported success=false',
+									recoverable: true,
+								}),
+							)
+						}
+						const page = body.data
+						const metadata = page?.metadata
 						// Clean page-builder markup out of the fetched markdown; an empty
 						// result means the page was mostly scaffolding, so it carries no
 						// content and the loop's grounding check skips it.
-						const markdown = cleanScrapedMarkdown(body.data.markdown ?? '')
+						const markdown = cleanScrapedMarkdown(page?.markdown ?? '')
 						return new ScrapedPage({
 							url: input.url,
-							resolvedUrl: body.data.metadata?.url,
+							resolvedUrl: metadata?.url ?? undefined,
 							markdown,
-							html: body.data.html,
-							links: body.data.links,
-							title: body.data.metadata?.title,
-							language: body.data.metadata?.language,
+							html: page?.html ?? undefined,
+							links: page?.links ?? undefined,
+							title: firstText(metadata?.title),
+							language: firstText(metadata?.language),
 							contentHash: sha256Hex(markdown),
 							// The credits Firecrawl charged, not a flat one per fetch.
 							units: body.creditsUsed ?? 1,

--- a/packages/research/src/infrastructure/firecrawl/search.ts
+++ b/packages/research/src/infrastructure/firecrawl/search.ts
@@ -28,27 +28,34 @@ import { ProviderError } from '../../domain/errors'
 import { SearchResult, SearchResultItem } from '../../domain/types'
 import { keyForSlot } from '../_config'
 import { hardenHttp } from '../_http-harden'
+import { NullableOptional } from '../_schema'
 
 const SEARCH_URL = 'https://api.firecrawl.dev/v2/search'
 
 // Subset of the Firecrawl search response we read. Unknown fields are ignored.
 const SearchResponse = Schema.Struct({
-	data: Schema.Struct({
-		web: Schema.optional(
-			Schema.Array(
-				Schema.Struct({
-					url: Schema.String,
-					title: Schema.optional(Schema.String),
-					// The passage of the page that matched the query, picked by
-					// Firecrawl. Falls back to the site's own blurb when the page has
-					// no matching passage.
-					description: Schema.optional(Schema.String),
-				}),
+	// Firecrawl's own verdict on the search, which a 2xx does not guarantee.
+	success: NullableOptional(Schema.Boolean),
+	// A search that turned nothing up can answer with no `data` block at all.
+	// That is zero hits, not a broken response.
+	data: NullableOptional(
+		Schema.Struct({
+			web: NullableOptional(
+				Schema.Array(
+					Schema.Struct({
+						url: Schema.String,
+						title: NullableOptional(Schema.String),
+						// The passage of the page that matched the query, picked by
+						// Firecrawl. Falls back to the site's own blurb when the page has
+						// no matching passage.
+						description: NullableOptional(Schema.String),
+					}),
+				),
 			),
-		),
-	}),
+		}),
+	),
 	// Total credits this call actually cost.
-	creditsUsed: Schema.optional(Schema.Number),
+	creditsUsed: NullableOptional(Schema.Number),
 })
 
 // 429 + 5xx are transient (retry); other 4xx are auth/quota/bad-request (fail fast).
@@ -131,8 +138,19 @@ export const makeFirecrawlSearch = (slot: number) =>
 									}),
 							),
 						)
+						// A 2xx that says the search itself did not work is their side
+						// failing and worth another try, not a clean zero-hit answer.
+						if (body.success === false) {
+							return yield* Effect.fail(
+								new ProviderError({
+									provider: 'firecrawl',
+									message: 'search failed: provider reported success=false',
+									recoverable: true,
+								}),
+							)
+						}
 						return new SearchResult({
-							items: (body.data.web ?? []).map(r => {
+							items: (body.data?.web ?? []).map(r => {
 								// The passage is real text off the page, so the run can cite
 								// it and count it as evidence without paying to open the
 								// page. A result with no passage still keeps its place: the

--- a/packages/research/src/infrastructure/librebor/registry.test.ts
+++ b/packages/research/src/infrastructure/librebor/registry.test.ts
@@ -228,6 +228,49 @@ describe('makeLibreborRegistry', () => {
 		expect(log.count).toBe(1)
 	})
 
+	it('should read a search carrying no company list as no match', async () => {
+		// GIVEN a search whose company list is absent rather than empty
+		const { exit, log } = runLookup(
+			{ country: 'ES', query: 'Nonexistent' },
+			() => ({ status: 200, body: {} }),
+		)
+
+		// THEN that reads the same way as an empty list, not as a broken response
+		const resolved = await exit
+		expect(errorOf(resolved)?.message).toContain('no company matched')
+		expect(log.count).toBe(1)
+	})
+
+	it('should keep a paid record whose company name is null', async () => {
+		// GIVEN a register answer with everything but the company's own name
+		const { exit } = runLookup({ country: 'ES', query: 'Mercadona' }, url =>
+			url.includes('/company/search/')
+				? { status: 200, body: { companies: [{ slug: 'mercadona' }] } }
+				: { status: 200, body: companyBody({ name: null }) },
+		)
+
+		// THEN the record stands, with the searched name standing in for the one
+		// the register left out, so the tax id and directors are not thrown away
+		const rec = recordOf(await exit)
+		expect(rec?.legalName).toBe('Mercadona')
+		expect(rec?.taxId).toBe('A46103834')
+		expect(rec?.directors?.[0]?.name).toBe('ROIG ALFONSO JUAN')
+	})
+
+	it('should fail when there is no name in the record nor in the request', async () => {
+		// GIVEN a by-NIF lookup — no searched name to stand in — whose record has
+		// no company name either
+		const { exit } = runLookup({ country: 'ES', taxId: 'A46103834' }, () => ({
+			status: 200,
+			body: companyBody({ name: null }),
+		}))
+
+		// THEN it says so plainly rather than failing as an unreadable response
+		const resolved = await exit
+		expect(errorOf(resolved)?.message).toContain('carries no company name')
+		expect(errorOf(resolved)?.recoverable).toBe(false)
+	})
+
 	it('should fail non-recoverably with neither taxId nor query', async () => {
 		// GIVEN an input missing both selectors
 		const { exit, log } = runLookup({ country: 'ES' }, () => ({

--- a/packages/research/src/infrastructure/librebor/registry.ts
+++ b/packages/research/src/infrastructure/librebor/registry.ts
@@ -33,7 +33,7 @@ const BASE_URL = 'https://api.librebor.me/v2'
 const NullableString = Schema.optional(Schema.NullOr(Schema.String))
 
 const Company = Schema.Struct({
-	name: Schema.String,
+	name: NullableString,
 	nif: NullableString,
 	status: NullableString,
 	capital: Schema.optional(Schema.NullOr(Schema.Number)),
@@ -55,7 +55,11 @@ const Company = Schema.Struct({
 
 const CompanyResponse = Schema.Struct({ company: Company })
 const SearchResponse = Schema.Struct({
-	companies: Schema.Array(Schema.Struct({ slug: Schema.String })),
+	// An answer with no list at all is a search that matched nothing, not a
+	// broken response.
+	companies: Schema.optional(
+		Schema.NullOr(Schema.Array(Schema.Struct({ slug: Schema.String }))),
+	),
 })
 
 // 429 + 5xx are transient (retry); 401/402 (bad key / no credit), 404 (not
@@ -113,25 +117,44 @@ export const makeLibreborRegistry = (slot: number) =>
 				)
 			})
 
-		const toRecord = (company: Schema.Schema.Type<typeof Company>) =>
-			new RegistryRecord({
-				legalName: company.name,
-				taxId: company.nif ?? undefined,
-				status: company.status ?? undefined,
-				incorporationDate: company.date_creation ?? undefined,
-				capital: company.capital != null ? `${company.capital}` : undefined,
-				address: company.address ?? undefined,
-				municipality: company.municipality ?? undefined,
-				province: company.province ?? undefined,
-				sector: company.cnae ?? undefined,
-				directors: (company.active_positions ?? []).map(p => ({
-					name: p.name_person ?? '',
-					role: p.role ?? undefined,
-					since: p.date_from ?? undefined,
-				})),
-				sourceUrl: `https://libreborme.net/borme/empresa/${company.nif ?? ''}`,
-				units: 1,
-			})
+		// The register sometimes leaves the company name off a record, so the name
+		// the caller searched for stands in rather than waste a paid lookup that
+		// brought back the tax id, address and directors.
+		const toRecord = (
+			company: Schema.Schema.Type<typeof Company>,
+			searchedName: string | undefined,
+		) => {
+			const legalName = company.name ?? searchedName
+			if (legalName === undefined) {
+				return Effect.fail(
+					new ProviderError({
+						provider: 'librebor',
+						message: 'registry record carries no company name',
+						recoverable: false,
+					}),
+				)
+			}
+			return Effect.succeed(
+				new RegistryRecord({
+					legalName,
+					taxId: company.nif ?? undefined,
+					status: company.status ?? undefined,
+					incorporationDate: company.date_creation ?? undefined,
+					capital: company.capital != null ? `${company.capital}` : undefined,
+					address: company.address ?? undefined,
+					municipality: company.municipality ?? undefined,
+					province: company.province ?? undefined,
+					sector: company.cnae ?? undefined,
+					directors: (company.active_positions ?? []).map(p => ({
+						name: p.name_person ?? '',
+						role: p.role ?? undefined,
+						since: p.date_from ?? undefined,
+					})),
+					sourceUrl: `https://libreborme.net/borme/empresa/${company.nif ?? ''}`,
+					units: 1,
+				}),
+			)
+		}
 
 		return RegistryRouter.of({
 			lookup: (input: RegistryInput) =>
@@ -144,14 +167,14 @@ export const makeLibreborRegistry = (slot: number) =>
 								`${BASE_URL}/company/by-nif/${encodeURIComponent(input.taxId)}/`,
 								CompanyResponse,
 							)
-							return toRecord(body.company)
+							return yield* toRecord(body.company, input.query)
 						}
 						if (input.query) {
 							const search = yield* getJson(
 								`${BASE_URL}/company/search/?query=${encodeURIComponent(input.query)}&page=1`,
 								SearchResponse,
 							)
-							const top = search.companies[0]
+							const top = (search.companies ?? [])[0]
 							if (!top) {
 								return yield* new ProviderError({
 									provider: 'librebor',
@@ -163,7 +186,7 @@ export const makeLibreborRegistry = (slot: number) =>
 								`${BASE_URL}/company/by-slug/${encodeURIComponent(top.slug)}/`,
 								CompanyResponse,
 							)
-							return toRecord(body.company)
+							return yield* toRecord(body.company, input.query)
 						}
 						return yield* new ProviderError({
 							provider: 'librebor',


### PR DESCRIPTION
## What

When Batuda researches a company it asks outside services for web pages, search results and company records, then checks each answer against a description of what that service is allowed to send back. Those descriptions were written tighter than what the services actually send, so a perfectly good answer was thrown away — and because the answer had arrived successfully, the vendor still billed for it. This had already happened in production five times in ninety days.

This widens those descriptions across the Research context (`packages/research`, no other app touched), and fixes a second, costlier problem in the same area: when a company's own homepage failed, the run also skipped every other page of that company's site.

## The fix

- **Absent and `null` now read the same.** Every field the Firecrawl and Brave adapters read tolerates being missing *or* explicitly `null`. `Schema.optional` on its own accepts a missing key but rejects `null`, which is why a documented-nullable field could lose a whole page. A new shared helper puts this in one place, matching the convention Hunter, FullEnrich, libreBORME and Companies House already follow.
- **A page may name its language twice.** A Spanish site that declares its language in both an `<html lang>` attribute and a `<meta name="language">` tag comes back as `["es-ES","ES"]` rather than one value. Both `language` and `title` now accept either shape and take the first entry.
- **A reply with no page block is an empty page, not a broken answer.** Firecrawl can answer successfully with no `data` at all — the single most common failure of the five. Both the scrape and search adapters now also read Firecrawl's own `success` flag, and a `2xx` that says the fetch didn't work is reported as *worth retrying* rather than passing for a page that came back empty.
- **The last search provider can no longer be sunk by one odd result.** In the Brave LLM-context adapter, a source with no address is dropped instead of failing the whole search. That endpoint is the last provider in the production chain, so there is nothing to fall through to.
- **A bad homepage no longer costs the company's whole site.** The homepage fetch, the about-page loop and the sitemap walk shared one error handler, so an unreadable homepage skipped up to ten fetches and the entire own-site evidence base — the best source a run has. The homepage now has its own handler and the two site walks still run.
- **The Spanish register keeps a paid answer that omits a name.** libreBORME demanded a company name and a list of matches where every other field in that file already tolerated missing and null.
- **An unreadable cached search runs for real.** The search cache sits *outside* the cross-vendor fallback, so a stored row that no longer decodes failed the whole run without a single vendor being asked. It now falls through to a live search, the way the page cache already does.

## Impact

- **No migration, no schema change, no new env vars, no RLS or tenant-scoping change, and no wire-shape change** — everything is inside `packages/research`; `packages/controllers` and `packages/domain` are untouched, so the typed client in `apps/internal` is unaffected.
- **MCP and HTTP both get this.** Research runs through the same service on both transports, so neither surface is ahead of the other.
- **Two deliberate changes to spend behaviour.** A Firecrawl `success:false` is now recoverable, so the retry harness makes up to three attempts where it previously failed on the first — more calls in that case, but a page recovered instead of lost. And an unreadable cached search row now costs one real search instead of failing the run.
- **Widening cannot reject anything the old descriptions accepted**, so no vendor answer that works today stops working.
- **One judgement call worth your eye:** when the Spanish register returns a record with no company name, it now uses the name that was searched for. That keeps the tax id, address and directors of a paid lookup, but the legal name is then something matched rather than read off the register. You chose this over failing outright; I'd have taken the stricter route, so overrule me if you'd rather.

## Review guide

- **Start with** `packages/research/src/infrastructure/_schema.ts` — three small helpers; every adapter change is a mechanical application of them and can be skimmed.
- **The riskiest hunk is** the anchor-seeding restructure in `research-service.ts`. It looks large because a ~50-line block gained one level of nesting; the only real changes are that the homepage fetch has its own handler, and `homepage` may now be undefined. The budget charge deliberately stayed in the *outer* block so a run with nothing left to spend still stops before walking the site — without that, an exhausted budget would have triggered an unbilled map call.
- **Second look at** `cached-search.ts`: both the plain read and the locked re-check go through one reader now. My first pass only fixed the first read, which would have left a row written by a parallel run still able to sink the whole run.
- The interrupt guards (`Cause.hasInterruptsOnly`) in both files are deliberate — a cancelled run must stay cancelled rather than degrade into a fresh fetch.
- No UI, auth, parser or crypto surface, so no a11y or security review was warranted; the changes only ever *widen* what is accepted, never what is executed.

## Tests

32 tests added, covering the exact shapes the issue reported: a `null` field on every widened adapter, a list-valued `language` and `title`, a response with no `data` block, a `success:false` reply, a grounding item with no URL, and a register record with no company name.

The shared helpers in `_schema.ts` are covered directly as well as through the adapters, which pins the one branch the adapter tests never reach — an *empty* list, where the helper must answer with nothing rather than a first entry that isn't there — and asserts that "tolerates absent and null" hasn't quietly become "tolerates anything": a value of the wrong type is still refused.

One case is left as `it.todo`: an unreadable row in the *database-backed* search cache. The research package has no harness for the cache layer — its two existing cache behaviours are already `it.todo` for the same reason — and building one was out of proportion to the fix.

## Verification

- `pnpm check-types` (13/13), `pnpm test` (21/21 — 1011 passing in `packages/research`), `pnpm build` (13/13), all re-run after rebasing onto current `main`.
- Each of the four commits type-checks on its own, so a later `git bisect` never lands on a broken revision.
- `pnpm biome check` — 6 warnings, all pre-existing and identical in count on `main`.
- **Live end-to-end against the local stack**, forcing the homepage fetch to fail on a seeded company, to prove the anchor fix rather than assume it:
  - *Before:* `research.anchor.seed_failed` — and nothing after it.
  - *After:* `research.anchor.seed_failed` → `research.discovery.mapped` → three `research.discovery.page_seeded`.
  - The unmodified happy path also still produces `research.anchor.seeded` followed by the sitemap walk.

No screenshots: this PR changes no UI.

## Deferred

- **A second scrape provider.** The issue suggests configuring one to restore the fallback cascade. There is nothing to configure: the only other vendor, `local`, is unimplemented (`notYetImplementedError`), and a second Firecrawl key slot cascades across accounts of the same vendor — for a decode failure it asks the same service for the same page and gets the same body back. You've chosen to leave `local` unbuilt for now.
- **The per-file `NullableString` in `librebor`, `companies-house` and `fullenrich`** could now use the shared helper. Out of scope here.

Closes #431 — the second-scrape-provider task is deliberately left undone rather than pending; the reasoning is recorded in a comment on the issue.
