### PR TITLE
fix: drop both integration-test databases a worktree can own

### DIFF
--- a/.claude/hooks/worktree-down.sh
+++ b/.claude/hooks/worktree-down.sh
@@ -25,6 +25,28 @@ fi
 # teardown uses; self-guarding and always exits 0.
 bash "${CLAUDE_PROJECT_DIR:-.}/scripts/worktree-stop-procs.sh" "$wt" "$$" 2>/dev/null || true
 
+# The integration-test database named after the worktree itself, which the pre-push
+# suite uses before `up` writes an `.env` (see scripts/integration-db.ts). A worktree
+# can hold one whether or not it was ever provisioned, and its name does not follow
+# from the dev database, so it is dropped here rather than alongside the pair below —
+# an unprovisioned worktree exits at the `.env` check and would otherwise leak it.
+# `.git` in a linked worktree is a file reading `gitdir: <main>/.git/worktrees/<name>`.
+# The name is only built when the sanitized suffix is non-empty, so this can never
+# collapse to the main checkout's bare `batuda_it`.
+before_up_db=""
+if [ -f "$wt/.git" ]; then
+	wt_name="$(sed -nE 's#^gitdir:.*/worktrees/([^/[:space:]]+)/?[[:space:]]*$#\1#p' "$wt/.git" | head -1)"
+	if [ -n "$wt_name" ]; then
+		suffix="$(printf '%s' "$wt_name" | tr '[:upper:]' '[:lower:]' \
+			| sed -E 's#[^a-z0-9]+#_#g; s#^_+##; s#_+$##' | cut -c1-52)"
+		[ -n "$suffix" ] && before_up_db="batuda_it__${suffix}"
+	fi
+fi
+if [ -n "$before_up_db" ]; then
+	docker exec batuda-db psql -U batuda -d postgres \
+		-c "DROP DATABASE IF EXISTS ${before_up_db} WITH (FORCE)" >/dev/null 2>&1 || true
+fi
+
 # Read this worktree's real database + bucket from the `.env` it generated at
 # provision time — never re-derive them from the live branch. `gh pr merge
 # --delete-branch` checks `main` out into the worktree, and switching branches

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -117,8 +117,9 @@ If the directory was removed manually before `worktree down`, run `pnpm cli work
 - **`git worktree remove` does NOT auto-tear-down** — the `WorktreeRemove` hook only fires when
   *Claude* removes the worktree. After a manual `git worktree remove`, the DB + bucket leak; run
   `pnpm cli worktree down` **first**, or `pnpm cli worktree prune` later. `prune` only *lists*
-  orphans by default (pass `--yes` to drop) and keys ownership off each live worktree's `.env`,
-  so it never reaps a live worktree — even one whose branch was switched.
+  orphans by default (pass `--yes` to drop) and keys ownership off each live worktree's `.env`
+  **and its directory name**, so it never reaps a live worktree — even one whose branch was
+  switched, or one that was never provisioned at all.
 - **Teardown stops the worktree's dev server too.** `worktree down`/`done` (and the `WorktreeRemove`
   hook) kill any `pnpm dev` servers running inside the worktree before its data + directory go away,
   so nothing is left serving a deleted checkout and holding its port. The shared portless proxy is
@@ -134,6 +135,10 @@ If the directory was removed manually before `worktree down`, run `pnpm cli work
   `batuda_it__<slug>` (main: `batuda_it`) fresh each run; `worktree down`/`done` and the
   `WorktreeRemove` hook drop it alongside the dev DB, and `prune` reaps it for a worktree that's
   gone. You never manage it by hand — and it never touches another worktree's `batuda_it__…`.
+  Run the suite **before** `worktree up` and the `<slug>` is your worktree's directory name
+  instead, since there is no `.env` to read a dev DB from yet — so one worktree can end up with
+  two of these over its life. Teardown drops both, and `prune` treats both as owned; you still
+  never manage either by hand.
 - **`pnpm cli services down` from a worktree** stops the *shared* stack (every worktree + main),
   so it refuses unless run from the main checkout or given `--force`. To remove just your
   worktree's data, use `worktree down`.

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, resolve } from 'node:path'
@@ -44,6 +44,9 @@ const MAX_DNS_LABEL = 63
 // A bucket name caps at 63 chars and ours carries a `batuda-assets-` (14) prefix, so
 // the shared slug is bounded to 49 — also safe for the `batuda_` database prefix.
 const MAX_SLUG = 49
+// Postgres caps identifiers at 63 bytes and `batuda_it__` takes 11, leaving 52 for a
+// worktree-name-derived integration database. Mirrors scripts/integration-db.ts.
+const MAX_IT_SUFFIX = 52
 
 const dnsLabel = (raw: string, max: number): string => {
 	const sane = raw
@@ -103,6 +106,43 @@ const bucketName = (slug: string) => `batuda-assets-${slug}`
 // colliding with real dev data.
 const integrationDbFromDevDb = (db: string): string =>
 	db === 'batuda' ? 'batuda_it' : db.replace(/^batuda_/, 'batuda_it__')
+
+// The other integration-test database a worktree can own. Before `up` writes an
+// `.env` there is no dev database to derive from, so the pre-push suite names the
+// database after the worktree's own directory instead — and a directory is only
+// conventionally named for its branch, so that name and the `.env`-derived one
+// above are usually different. A worktree that ran the suite before it was
+// provisioned therefore has one of each: `down` drops both, and `prune` counts both
+// as owned so it never reaps the database a live worktree is still testing against.
+// Mirrors integrationDbFromWorktreeName in scripts/integration-db.ts.
+const integrationDbFromWorktreeName = (name: string): string => {
+	const suffix = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.slice(0, MAX_IT_SUFFIX)
+	return suffix ? `batuda_it__${suffix}` : 'batuda_it'
+}
+
+// A linked worktree's `.git` is a file reading `gitdir: <main>/.git/worktrees/<name>`.
+// That registered name is what the suite keys off, and it is not always the directory
+// basename — git appends a suffix when two worktrees would collide — so it is read
+// here rather than guessed. Returns null for the main checkout, whose `.git` is a
+// directory and whose integration database is the shared `batuda_it`.
+const worktreeIntegrationDb = (worktreePath: string): string | null => {
+	const dotGit = resolve(worktreePath, '.git')
+	if (!existsSync(dotGit) || !statSync(dotGit).isFile()) return null
+	const name = readFileSync(dotGit, 'utf-8').match(
+		/\/worktrees\/([^/\s]+)\/?\s*$/,
+	)?.[1]
+	if (!name) return null
+	const db = integrationDbFromWorktreeName(name)
+	// A name with nothing alphanumeric in it sanitizes away to the bare
+	// `batuda_it`, which is the MAIN checkout's integration-test database. Teardown
+	// drops what this returns, so hand back nothing rather than a name that would
+	// destroy another checkout's data.
+	return db === 'batuda_it' ? null : db
+}
 
 // Last path segment of a `.env` DATABASE_URL — the database name, any `?sslmode=…`
 // query stripped. The one place worktree.ts parses that URL; `identityFromEnv` and
@@ -413,6 +453,12 @@ const liveOwnedResources = execSilent(
 			// `identityFromEnv` null, but the integration sibling must stay owned.
 			const devDb = dbFromEnv(envPath)
 			if (devDb?.startsWith('batuda')) dbs.add(integrationDbFromDevDb(devDb))
+			// And the one it uses before it is provisioned, which is named after the
+			// worktree rather than the dev database. Without this a live worktree that
+			// ran the suite before `up` — or that never runs `up` at all — has its
+			// integration database reported as orphaned and reaped out from under it.
+			const beforeUp = worktreeIntegrationDb(entry.path)
+			if (beforeUp) dbs.add(beforeUp)
 		}
 		return { dbs, buckets }
 	}),
@@ -688,7 +734,28 @@ export const worktreeDown = Effect.gen(function* () {
 	// live branch — after a `gh pr merge --delete-branch` the branch is `main`,
 	// so a branch-derived slug would miss the real database (or hit main's).
 	const identity = identityFromEnv(resolve(ROOT, '.env'))
+	// The integration-test database named after this worktree rather than its dev
+	// database — what the pre-push suite uses before `up` has written an `.env`.
+	// Dropped on both paths below, because a worktree can hold one whether or not
+	// it was ever provisioned, and nothing else will ever come back for it.
+	const beforeUpDb = worktreeIntegrationDb(ROOT)
 	if (!identity) {
+		// Never provisioned, but the suite may still have run here and left its
+		// database behind. Drop that rather than refusing and leaking it. Checked
+		// for existence first so the line below reports what actually happened
+		// instead of naming a database that was never there.
+		const leftover =
+			beforeUpDb && (yield* listDatabases).includes(beforeUpDb)
+				? beforeUpDb
+				: null
+		if (leftover) {
+			yield* stopWorktreeDevServers(ROOT)
+			yield* dropDatabase(leftover)
+			yield* Console.log(
+				`✓ Removed ${leftover} (never provisioned — no dev database or bucket to drop).`,
+			)
+			return
+		}
 		return yield* Effect.fail(
 			new Error(
 				'No provisioned .env here — nothing to drop. Run `pnpm cli worktree up` first, or it was already torn down.',
@@ -708,9 +775,14 @@ export const worktreeDown = Effect.gen(function* () {
 	yield* stopWorktreeDevServers(ROOT)
 	yield* Effect.logInfo(`Dropping database ${db} + bucket ${bucket}…`)
 	yield* dropDatabase(db)
-	// Drop this worktree's integration-test database too — the pre-push suite creates
-	// it lazily (never recorded in `.env`); `IF EXISTS` no-ops if it never ran here.
+	// Drop this worktree's integration-test databases too — the pre-push suite creates
+	// them lazily (never recorded in `.env`); `IF EXISTS` no-ops if it never ran here.
+	// Both names, because a worktree that ran the suite before it was provisioned owns
+	// one keyed off its own directory as well as one keyed off its dev database.
 	yield* dropDatabase(integrationDbFromDevDb(db))
+	if (beforeUpDb && beforeUpDb !== integrationDbFromDevDb(db)) {
+		yield* dropDatabase(beforeUpDb)
+	}
 	// The bucket may already be gone (or never created) — don't fail teardown on it.
 	yield* mc(`mc rb --force local/${bucket}`).pipe(
 		Effect.catch(() => Effect.void),

--- a/scripts/integration-db.ts
+++ b/scripts/integration-db.ts
@@ -60,9 +60,24 @@ const devDbFromEnv = (): string | null => {
 // capped tighter); only the bare-worktree fallback below needs trimming.
 const MAX_SUFFIX = 52
 
+// The integration database a worktree uses before it is provisioned, keyed off its
+// registered git-worktree name (`<main>/.git/worktrees/<name>`) and sanitized to a
+// valid, collision-free identifier. A worktree directory is usually named for its
+// branch but need not be, so this name and the `.env`-derived one above are
+// generally DIFFERENT — a worktree that ran the suite before `pnpm cli worktree up`
+// therefore owns one of each over its life, and teardown has to drop both. apps/cli's
+// worktree.ts and .claude/hooks/worktree-down.sh mirror this for exactly that reason.
+export const integrationDbFromWorktreeName = (name: string): string => {
+	const suffix = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.slice(0, MAX_SUFFIX)
+	return suffix ? `batuda_it__${suffix}` : 'batuda_it'
+}
+
 // A bare `git worktree add` (never `pnpm cli worktree up`) has no `.env`, so key the
-// name off the registered git-worktree name instead — `<main>/.git/worktrees/<name>`
-// — sanitized to a valid, collision-free identifier so even an unprovisioned
+// name off the registered git-worktree name instead, so even an unprovisioned
 // worktree stays off the main checkout's `batuda_it`. The main checkout's git dir
 // has no `/worktrees/` segment, so it falls through to the shared `batuda_it`.
 const nameFromGitWorktree = (): string => {
@@ -72,13 +87,7 @@ const nameFromGitWorktree = (): string => {
 		'--absolute-git-dir',
 	)
 	const name = gitDir?.match(/\/worktrees\/([^/]+)\/?$/)?.[1]
-	if (!name) return 'batuda_it'
-	const suffix = name
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, '_')
-		.replace(/^_+|_+$/g, '')
-		.slice(0, MAX_SUFFIX)
-	return suffix ? `batuda_it__${suffix}` : 'batuda_it'
+	return name ? integrationDbFromWorktreeName(name) : 'batuda_it'
 }
 
 // The integration database name for the current checkout.


### PR DESCRIPTION
## What

Every git worktree runs the pre-push integration suite against its own disposable Postgres database, so two worktrees testing at once don't wipe each other's rows. That database turns out to be named two different ways depending on when the suite first ran, and the cleanup code only ever knew one of them. The result was a database left behind on every affected teardown, and — worse — `pnpm cli worktree prune` offering to delete a database a live worktree was still using.

This is local developer tooling only (`apps/cli`, the pre-push scripts, and the Claude worktree hook). Nothing here ships to production.

## The fix

- **Teardown now drops both names.** `worktree down`/`done` and the `WorktreeRemove` hook each drop the directory-derived database alongside the dev-database-derived one.
- **`prune` now counts both as owned**, so it can no longer report a live worktree's database as orphaned.
- **`worktree down` no longer refuses on a never-provisioned worktree.** It drops the leftover suite database when one is actually there. That also unblocks `worktree done` on those worktrees, which previously aborted because `down` failed.
- **The skill's promise is corrected.** It stated that `prune` "never reaps a live worktree", which wasn't true for a worktree that had run the suite before being provisioned.

## Why there were two names

`scripts/integration-db.ts` resolves the database from the checkout's `.env` `DATABASE_URL`. Before `pnpm cli worktree up` has written that file there is nothing to read, so it falls back to naming the database after the worktree's registered git name instead. A worktree directory is only *conventionally* named for its branch, so the two names routinely disagree — and a worktree that ran the suite before provisioning ends up owning one of each.

Concretely, in this branch's own worktree: directory `cli-worktree-slug` gave `batuda_it__cli_worktree_slug`, and after `up` the same worktree resolved to `batuda_it__worktree_integration_db_slug`.

I want to correct something I said while first reporting this: I originally blamed branch names containing a slash. That was wrong, and it matters, because it would have sent a reader looking in the wrong place. Slashes are irrelevant — it is directory-name vs dev-database-name. `claude --worktree foo` reproduces it with no slash anywhere, since it creates directory `foo` on branch `worktree-foo`.

## Impact

- **Destructive-operation safety.** A worktree name with nothing alphanumeric in it sanitizes away to the bare `batuda_it` — the *main* checkout's integration database. Since teardown drops whatever the lookup returns, the CLI lookup now returns nothing in that case. The bash hook builds its name only from a non-empty suffix, so it never could. I verified `batuda_it` survives every teardown path.
- **No production surface.** No migration, no env vars, no auth/RLS, no API shape. Nothing outside local dev tooling.
- **Pre-existing stragglers are not migrated.** Databases already orphaned by this bug on a given machine stay until `prune --yes` is run. That is what `prune` is for, and it is now safe to run — but it is a manual step, not something this PR does for you.
- **The rule is stated in three places** (the script, the CLI, the bash hook) because it can't be shared across the `rootDir`/TypeScript/bash boundaries. Each copy points at the canonical one. I verified all three agree rather than assuming.

## Review guide

- **Start at `scripts/integration-db.ts`** — the two-names situation is the whole bug, and that file is where both are produced.
- **The riskiest line is the `batuda_it` guard** in `worktreeIntegrationDb`. Without it this PR would have made teardown capable of dropping the main checkout's integration database — a bug I introduced and caught while re-reviewing. Worth a second pair of eyes.
- **A judgment call you might overrule:** I changed `worktree down` to succeed on a never-provisioned worktree instead of erroring. It only does so when a leftover database actually exists, so the "nothing to drop" error still fires when there is genuinely nothing. I did this because the old error made `worktree done` unusable on exactly the worktrees that leak. Say the word if you'd rather it kept refusing.
- **Skip-able:** the SKILL.md hunks are documentation catching up with the behavior.
- **No tests.** `scripts/` has no test setup and the repo convention is not to unit-test CLI code, so I verified behaviorally instead — see below. If you'd rather I add a harness for the pure string derivations, I can.

## Verification

Everything below I ran against the live shared Docker stack, in a worktree deliberately named so its directory and branch slug disagree.

- **Reproduced the bug first**: directory `cli-worktree-slug` resolved to `batuda_it__cli_worktree_slug`; after `worktree up` the same worktree resolved to `batuda_it__worktree_integration_db_slug`. Before the fix, `prune` listed the live worktree's database as orphaned.
- **After the fix**: `prune` no longer lists it. `worktree down` on the provisioned worktree dropped all three databases (dev + both integration). With no `.env` and a leftover present, `down` dropped it and said so; with no `.env` and nothing there, it kept the original "nothing to drop" error rather than claiming a false removal.
- **Ran the `WorktreeRemove` hook for real** with a synthetic payload — it dropped the leftover, exited 0, and left `batuda_it` intact. It is side-effect-only and always exits 0, so a silent bug there would never surface on its own.
- **Compared the TypeScript and bash derivations** on six inputs including mixed case, punctuation runs, leading/trailing separators, and over-length names. They agree. The single divergence is the intended safety guard. My first comparison run reported a false mismatch that turned out to be my test harness — node was eating a leading `--` as a flag — so I re-ran it against the real exported function passing values through the environment.
- **Gates**: `pnpm check-types` (13 tasks), `pnpm test` (21 tasks), `pnpm build` (13 tasks), all green, and `bash -n` on the hook.

## Deferred

- `shellcheck` isn't installed on this machine, so the hook got `bash -n` plus a real execution rather than a lint pass.
