### PR TITLE
feat: let a company's own mailbox be unblocked

### DIFF
--- a/apps/internal/src/components/companies/company-channels-section.tsx
+++ b/apps/internal/src/components/companies/company-channels-section.tsx
@@ -1,5 +1,11 @@
 import { Trans, useLingui } from '@lingui/react/macro'
-import { ChevronRight, ExternalLink, Link2, Send } from 'lucide-react'
+import {
+	AlertTriangle,
+	ChevronRight,
+	ExternalLink,
+	Link2,
+	Send,
+} from 'lucide-react'
 import styled from 'styled-components'
 
 import { PriCollapsible } from '@batuda/ui/pri'
@@ -16,7 +22,16 @@ type Props = {
 	readonly channels: ReadonlyArray<DisplayChannel>
 	/** Opens a new message to this address. Only offered for mailboxes. */
 	readonly onEmail: (address: string) => void
+	/** Lets mail go to the company's mailboxes again. */
+	readonly onClearSuppression: () => void
 }
+
+/**
+ * Whether the send gate is holding mail back from this address. Read in both
+ * places that say so, so a mark can never appear without the note explaining it.
+ */
+const isHeldBack = (ch: DisplayChannel): boolean =>
+	ch.kind === 'email' && (ch.status === 'bounced' || ch.status === 'complained')
 
 /**
  * Every way of reaching the company, not just the first of each kind.
@@ -27,10 +42,19 @@ type Props = {
  * listed here under the name somebody gave it, so "orders" and "accounts" can be
  * told apart before one of them is written to.
  */
-export function CompanyChannelsSection({ channels, onEmail }: Props) {
+export function CompanyChannelsSection({
+	channels,
+	onEmail,
+	onClearSuppression,
+}: Props) {
 	const { t } = useLingui()
 	const kindLabel = useChannelKindLabel()
 	if (channels.length === 0) return null
+
+	// A mailbox nobody is listed under is held back the same as anybody's, and
+	// this is the only place it is shown — so a block left unsaid here is a block
+	// with no way off it.
+	const heldBack = channels.filter(isHeldBack)
 
 	return (
 		<PriCollapsible.Root defaultOpen>
@@ -81,6 +105,17 @@ export function CompanyChannelsSection({ channels, onEmail }: Props) {
 										<Trans>primary</Trans>
 									</Primary>
 								) : null}
+								{isHeldBack(ch) ? (
+									<Held
+										data-testid={`company-channel-held-${ch.id}`}
+										title={ch.statusReason ?? undefined}
+									>
+										<AlertTriangle size={10} aria-hidden />
+										<span>
+											{ch.status === 'bounced' ? t`Bounced` : t`Complained`}
+										</span>
+									</Held>
+								) : null}
 								{ch.kind === 'email' ? (
 									<Compose
 										type='button'
@@ -93,6 +128,20 @@ export function CompanyChannelsSection({ channels, onEmail }: Props) {
 							</Row>
 						)
 					})}
+					{heldBack.length > 0 ? (
+						<HeldNote>
+							<span>
+								{t`Mail to these addresses is being held back. Letting mail through lifts all of them at once, and any that bounces again is held straight back.`}
+							</span>
+							<ClearButton
+								type='button'
+								data-testid='company-clear-suppression'
+								onClick={onClearSuppression}
+							>
+								<Trans>Let mail through again</Trans>
+							</ClearButton>
+						</HeldNote>
+					) : null}
 				</Body>
 			</PriCollapsible.Panel>
 		</PriCollapsible.Root>
@@ -179,6 +228,57 @@ const Primary = styled.span.withConfig({
 	${stenciledTitle}
 	font-size: var(--typescale-label-small-size);
 	color: var(--color-on-surface-variant);
+`
+
+const Held = styled.span.withConfig({
+	displayName: 'CompanyChannelHeld',
+})`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3xs);
+	padding: 0 var(--space-2xs);
+	border-radius: var(--shape-full);
+	background: color-mix(in oklab, var(--color-error) 12%, transparent);
+	color: var(--color-error);
+	font-size: var(--typescale-label-small-size);
+	line-height: var(--typescale-label-small-line);
+	white-space: nowrap;
+`
+
+const HeldNote = styled.div.withConfig({
+	displayName: 'CompanyChannelsHeldNote',
+})`
+	/* Stacked at every width: the panel sits in a narrow column, so even a wide
+	   window leaves the sentence wrapping to two words a line beside the
+	   button. */
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--space-2xs);
+	margin-top: var(--space-2xs);
+	padding: var(--space-2xs) var(--space-xs);
+	border: 1px solid color-mix(in oklab, var(--color-error) 40%, transparent);
+	border-radius: var(--shape-xs);
+	color: var(--color-on-surface-variant);
+	font-size: var(--typescale-body-small-size);
+	line-height: var(--typescale-body-small-line);
+`
+
+const ClearButton = styled.button.withConfig({
+	displayName: 'CompanyClearSuppression',
+})`
+	flex: 0 0 auto;
+	padding: var(--space-3xs) var(--space-xs);
+	border: 1px solid var(--color-outline);
+	border-radius: var(--shape-full);
+	background: transparent;
+	color: var(--color-primary);
+	font-size: var(--typescale-label-medium-size);
+	cursor: pointer;
+
+	&:hover {
+		background: color-mix(in oklab, var(--color-primary) 8%, transparent);
+	}
 `
 
 const Compose = styled.button.withConfig({

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -885,6 +885,7 @@ msgstr "Reserva una reunió des d'una pàgina d'empresa o reenvia una invitació
 msgid "bounced"
 msgstr "rebotat"
 
+#: src/components/companies/company-channels-section.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/$threadId.tsx
 msgid "Bounced"
@@ -1215,6 +1216,7 @@ msgstr "Competidors"
 msgid "complained"
 msgstr "marcat com a brossa"
 
+#: src/components/companies/company-channels-section.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/$threadId.tsx
 msgid "Complained"
@@ -1436,6 +1438,7 @@ msgstr "No s'ha pogut canviar {0}"
 msgid "Could not change owner"
 msgstr "No s'ha pogut canviar el responsable"
 
+#: src/routes/companies/$slug.tsx
 #: src/routes/companies/$slug.tsx
 msgid "Could not clear suppression"
 msgstr "No s'''ha pogut esborrar la supressió"
@@ -2989,6 +2992,10 @@ msgstr "Latitud"
 msgid "Layered after the stack, in order."
 msgstr "S'apliquen després de la pila, en ordre."
 
+#: src/components/companies/company-channels-section.tsx
+msgid "Let mail through again"
+msgstr "Deixa passar el correu"
+
 #: src/components/profile/theme-select.tsx
 msgid "Light"
 msgstr "Clar"
@@ -3144,6 +3151,10 @@ msgstr "Prioritat baixa"
 #: src/components/emails/compose-form.tsx
 msgid "Mail to {0} bounced, so it is blocked."
 msgstr "El correu a {0} ha rebotat, així que està bloquejada."
+
+#: src/components/companies/company-channels-section.tsx
+msgid "Mail to these addresses is being held back. Letting mail through lifts all of them at once, and any that bounces again is held straight back."
+msgstr "El correu cap a aquestes adreces està aturat. Deixar-lo passar les allibera totes alhora, i qualsevol que torni a rebotar queda aturada de seguida."
 
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
@@ -5682,6 +5693,7 @@ msgstr "No s'ha pogut carregar el tauler. Comprova que la sessió sigui vàlida 
 
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/contacts/manage-channels-dialog.tsx
+#: src/routes/companies/$slug.tsx
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "El canvi no s'ha completat. Torna-ho a provar."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -885,6 +885,7 @@ msgstr "Book a meeting from a company page or forward an invitation to your inbo
 msgid "bounced"
 msgstr "bounced"
 
+#: src/components/companies/company-channels-section.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/$threadId.tsx
 msgid "Bounced"
@@ -1215,6 +1216,7 @@ msgstr "Competitors"
 msgid "complained"
 msgstr "complained"
 
+#: src/components/companies/company-channels-section.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/$threadId.tsx
 msgid "Complained"
@@ -1436,6 +1438,7 @@ msgstr "Could not change {0}"
 msgid "Could not change owner"
 msgstr "Could not change owner"
 
+#: src/routes/companies/$slug.tsx
 #: src/routes/companies/$slug.tsx
 msgid "Could not clear suppression"
 msgstr "Could not clear suppression"
@@ -2989,6 +2992,10 @@ msgstr "Latitude"
 msgid "Layered after the stack, in order."
 msgstr "Layered after the stack, in order."
 
+#: src/components/companies/company-channels-section.tsx
+msgid "Let mail through again"
+msgstr "Let mail through again"
+
 #: src/components/profile/theme-select.tsx
 msgid "Light"
 msgstr "Light"
@@ -3144,6 +3151,10 @@ msgstr "Low priority"
 #: src/components/emails/compose-form.tsx
 msgid "Mail to {0} bounced, so it is blocked."
 msgstr "Mail to {0} bounced, so it is blocked."
+
+#: src/components/companies/company-channels-section.tsx
+msgid "Mail to these addresses is being held back. Letting mail through lifts all of them at once, and any that bounces again is held straight back."
+msgstr "Mail to these addresses is being held back. Letting mail through lifts all of them at once, and any that bounces again is held straight back."
 
 #. placeholder {0}: row.email
 #: src/routes/emails/inboxes.tsx
@@ -5682,6 +5693,7 @@ msgstr "The board could not be fetched. Check that the session is valid, then tr
 
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/contacts/manage-channels-dialog.tsx
+#: src/routes/companies/$slug.tsx
 #: src/routes/companies/$slug.tsx
 msgid "The change didn't go through. Try again."
 msgstr "The change didn't go through. Try again."

--- a/apps/internal/src/routes/companies/$slug.tsx
+++ b/apps/internal/src/routes/companies/$slug.tsx
@@ -930,6 +930,26 @@ function DetailBody({
 		[clearSuppression, refreshContacts, toast, t],
 	)
 
+	const clearCompanySuppression = useAtomSet(
+		BatudaApiAtom.mutation('companies', 'clearSuppression'),
+		{ mode: 'promiseExit' },
+	)
+	const handleClearCompanySuppression = useCallback(async () => {
+		const exit = await clearCompanySuppression({
+			params: { id: company.id },
+		} as never)
+		if (exit._tag === 'Success') {
+			refreshCompany()
+			return
+		}
+		toast.add({
+			title: t`Could not clear suppression`,
+			description: t`The change didn't go through. Try again.`,
+			type: 'error',
+		})
+		console.error('[batuda] companies.clearSuppression failed', exit.cause)
+	}, [clearCompanySuppression, company.id, refreshCompany, toast, t])
+
 	// Both the interactions feed and the company row become stale after
 	// Quick Capture submits — the server copies nextAction + lastContactedAt
 	// onto the company in the same transaction as the interaction insert.
@@ -1395,6 +1415,7 @@ function DetailBody({
 									)}
 									<CompanyChannelsSection
 										channels={company.channels}
+										onClearSuppression={handleClearCompanySuppression}
 										onEmail={address =>
 											openCompose({
 												mode: 'new',

--- a/apps/internal/tests/e2e/bounce-visibility.test.ts
+++ b/apps/internal/tests/e2e/bounce-visibility.test.ts
@@ -7,7 +7,8 @@ import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // Bounce visibility on the contact page: the suppression banner (and inline
 // badge) render on company → Contacts when a contact's primary email channel
-// carries a `bounced` or `complained` status.
+// carries a `bounced` or `complained` status. A company's own mailbox carries
+// the same status and is shown, and cleared, in the channels panel instead.
 //
 // We seed the bounced state directly via psql instead of driving the
 // mail-worker's DSN parser end-to-end — the worker is a separate process
@@ -19,10 +20,16 @@ import { setActiveOrgBySlug } from './helpers/set-active-org'
 // Selectors verified against:
 //   apps/internal/src/routes/companies/$slug.tsx (suppression banner +
 //   badge + clear action; testids: contact-suppression-{badge,banner,clear}-{id})
+//   apps/internal/src/components/companies/company-channels-section.tsx
+//   (held-back badge + clear action; testids: company-channel-held-{id},
+//   company-clear-suppression)
 
 const TARGET_EMAIL = 'pep@calpepfonda.cat'
 const TARGET_REASON = '550 5.1.1 mailbox not found (e2e fixture)'
 const COMPANY_SLUG = 'cal-pep-fonda'
+// The company's own mailbox: nobody is listed under it, so no contact row can
+// speak for it.
+const COMPANY_MAILBOX = 'info@calpepfonda.cat'
 
 const psql = (sqlText: string): string =>
 	execSync(`psql "${DATABASE_URL}" -tA -c "${sqlText.replace(/"/g, '\\"')}"`, {
@@ -101,5 +108,59 @@ test.describe('contact suppression banner', () => {
 			`SELECT status FROM channels WHERE channel='email' AND address='${TARGET_EMAIL}'`,
 		)
 		expect(row).toBe('unknown')
+	})
+})
+
+test.describe('a company mailbox nobody is listed under', () => {
+	test.beforeEach(async ({ page }) => {
+		// GIVEN Alice's session is active and pointed at Taller (where the seed
+		// puts Cal Pep Fonda).
+		await page.goto('/', { waitUntil: 'commit' })
+		await setActiveOrgBySlug(page, 'taller')
+
+		// AND the company's own mailbox is forced to bounced state.
+		psql(
+			`UPDATE channels SET status='bounced', status_reason='${TARGET_REASON}', status_updated_at=now() WHERE channel='email' AND subject_table='companies' AND address='${COMPANY_MAILBOX}'`,
+		)
+	})
+
+	test.afterEach(() => {
+		// Revert the seeded bounce so other runs and suites don't see leftover
+		// state.
+		psql(
+			`UPDATE channels SET status='unknown', status_reason=NULL, status_updated_at=now(), soft_bounce_count=0 WHERE channel='email' AND subject_table='companies' AND address='${COMPANY_MAILBOX}'`,
+		)
+	})
+
+	test('should say it is held back, and let mail through again', async ({
+		page,
+	}) => {
+		// GIVEN the company page is open. `networkidle` rather than `commit`: the
+		// panel renders from the server, so a click can land before React has
+		// attached anything to the button and quietly do nothing.
+		await page.goto(`/companies/${COMPANY_SLUG}`, { waitUntil: 'networkidle' })
+
+		// THEN the badge should say so beside the address in the channels panel.
+		const heldBadge = page.getByTestId(/^company-channel-held-/).first()
+		await expect(heldBadge).toBeVisible({ timeout: 15_000 })
+
+		// WHEN the user lifts the block from that same panel.
+		const cleared = page.waitForResponse(
+			r =>
+				r.url().includes('/email-suppression/clear') &&
+				r.request().method() === 'POST',
+		)
+		await page.getByTestId('company-clear-suppression').click()
+		expect((await cleared).status()).toBe(200)
+
+		// THEN the badge should go, and the channel row should be back to nobody
+		// having judged the address — which is what makes the send gate let mail
+		// through again.
+		await expect(heldBadge).toBeHidden({ timeout: 10_000 })
+		expect(
+			psql(
+				`SELECT status FROM channels WHERE channel='email' AND subject_table='companies' AND address='${COMPANY_MAILBOX}'`,
+			),
+		).toBe('unknown')
 	})
 })

--- a/apps/server/src/handlers/companies.ts
+++ b/apps/server/src/handlers/companies.ts
@@ -1,8 +1,10 @@
 import { DateTime, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
+import { SqlClient } from 'effect/unstable/sql'
 
 import { BatudaApi, NotFound, SessionContext } from '@batuda/controllers'
 
+import { channelsJsonFor, clearEmailSuppression } from '../services/channels'
 import { CompanyService } from '../services/companies'
 import {
 	geocodeCompany,
@@ -24,6 +26,7 @@ export const CompaniesLive = HttpApiBuilder.group(
 			const svc = yield* CompanyService
 			const geocoder = yield* Geocoder
 			const timeline = yield* TimelineActivityService
+			const sql = yield* SqlClient.SqlClient
 			return handlers
 				.handle('list', _ => svc.search(_.query).pipe(Effect.orDie))
 				.handle('countries', () => svc.countries().pipe(Effect.orDie))
@@ -221,6 +224,33 @@ export const CompaniesLive = HttpApiBuilder.group(
 								: Effect.die(e),
 						),
 					),
+				)
+				.handle('clearSuppression', _ =>
+					Effect.gen(function* () {
+						yield* clearEmailSuppression(sql, {
+							table: 'companies' as const,
+							id: _.params.id,
+						})
+
+						// Built into JSON by Postgres, like every other channel answer:
+						// reading the rows straight back brings their dates along, and a
+						// date is not something this answer knows how to write out.
+						const rows = yield* sql<{
+							readonly channels: ReadonlyArray<unknown>
+						}>`
+							SELECT ${channelsJsonFor(sql, 'companies')} AS channels
+							FROM companies c
+							WHERE c.id = ${_.params.id}::uuid
+						`
+
+						yield* Effect.logInfo('Company suppression cleared').pipe(
+							Effect.annotateLogs({
+								event: 'company.suppression_cleared',
+								companyId: _.params.id,
+							}),
+						)
+						return { id: _.params.id, channels: rows[0]?.channels ?? [] }
+					}).pipe(Effect.orDie),
 				)
 		}),
 )

--- a/packages/controllers/src/routes/companies.ts
+++ b/packages/controllers/src/routes/companies.ts
@@ -67,6 +67,13 @@ export const CompanyDetail = Schema.Struct({
 	researchRuns: Schema.Array(CompanyResearchRun),
 })
 
+// The company's channels as they read once the block is lifted, so a caller can
+// update what it holds without asking for the whole company again.
+const CompanySuppressionCleared = Schema.Struct({
+	id: Schema.String,
+	channels: Schema.Array(Schema.Unknown),
+})
+
 // What a caller may write. The shapes come from the domain so the browser, the
 // agent tools and the research apply path all turn away the same values — and
 // they sit here rather than on `Company`, which has to keep reading rows written
@@ -231,6 +238,20 @@ export const CompaniesGroup = HttpApiGroup.make('companies')
 			success: DeleteCompanyResult,
 			error: NotFound.pipe(HttpApiSchema.status(404)),
 		}),
+	)
+	.add(
+		// Let mail go to the company's own mailbox again, after a bounce or a spam
+		// report turns out to have been wrong. An `info@` or `orders@` belongs to
+		// nobody, so the way back cannot run through a person. Only ever lifts the
+		// block: no status can be set from here.
+		HttpApiEndpoint.post(
+			'clearSuppression',
+			'/companies/:id/email-suppression/clear',
+			{
+				params: { id: Schema.String },
+				success: CompanySuppressionCleared,
+			},
+		),
 	)
 	.add(
 		// Put one back, with the people that deletion hid. Answers 400 when the


### PR DESCRIPTION
## What

A company's own mailbox — an `info@` or `orders@` that nobody in particular is listed under — could be blocked forever, by anybody, with no way back.

Everything leading up to that block works. The mail worker records a hard bounce on the address. The send gate holds mail back from it whoever holds it. The compose screen warns before a message is written. What was missing was the exit: every path to lifting a block spoke for a *person*, and a role mailbox has no person behind it. One transient bounce on `info@` and that address was unreachable for good.

Web app and API (`apps/internal`, `apps/server`, `packages/controllers`), CRM context.

## The fix

A `POST /v1/companies/:id/email-suppression/clear` endpoint, mirroring the one contacts already have, and the company's "Ways to reach" panel — read-only until now — showing which of its addresses are held back and offering the way off.

The service function needed no change: `clearEmailSuppression` already takes a subject rather than a person. Nothing had ever called it with a company. This is mostly fitting a door to a room that was already built.

**Lifting frees every one of that company's addresses at once**, because the underlying update is scoped to the subject, not to one address. The wording says so rather than leaving somebody to discover it — I found this while checking the SQL against copy I had already written, and the copy was wrong.

## Impact

No schema change, no new environment variables, no change to auth. Organisation isolation is unchanged: the new route sits behind the same session and org middleware as every sibling, and both the update and the read-back are scoped by row-level security exactly as the contact equivalent is.

**New endpoint on a shared contract.** `packages/controllers` is consumed by the server and by `apps/internal`'s typed client, so this is additive to the wire — nothing renamed, nothing removed.

**MCP does not get this.** `update_contact`'s `clear_email_suppression` still speaks only for a person, so an assistant cannot lift a company block. Worth knowing, and worth a follow-up; I did not want to add a tool parameter in the same change that adds the screen.

**Not a security boundary change**, but adjacent to one: this lifts a send-blocking state. It only ever sets `unknown` — no arbitrary status can be written through it — which is the same restriction the contact route carries.

## Review guide

Start at the handler in `apps/server/src/handlers/companies.ts`. The one non-obvious line is reading the channels back through `channelsJsonFor` rather than the row reader: a raw row carries `Date` objects that the response schema cannot write out, which is a real 400 I hit and fixed rather than a stylistic choice.

In the panel, `isHeldBack` is deliberately shared between the per-address mark and the note. They were two copies of the same predicate that disagreed about whether the kind mattered, so a mark could in principle appear with nothing explaining it.

**Three things the live check caught that types and unit tests did not** — worth knowing, because they are the reason this took longer than the diff suggests:

- The first response was a 400. The clear worked; encoding the reply did not.
- The e2e clicked before React had attached anything to the button — the panel renders from the server, so the button was present and dead. `waitUntil: 'networkidle'`, which the working test in that same file already uses.
- The note wrapped to two words a line, because I had reached for a viewport media query for a component that lives in a ~320px sidebar. How wide the window is says nothing about the room that column has.

## Screenshots

The company's own panel: the mark sits on the address it applies to, and the way off it sits under them.

![company-held-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-444/company-held-mobile.webp)

![company-held-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-444/company-held-desktop.webp)

Both sizes because the panel is a full-width card on mobile and a narrow sidebar column on desktop — which is where the wrapping bug above showed up.

## Tests

An e2e covering the whole point: the block is visible on the company's own panel, and pressing the button lifts it. It asserts the response status rather than inferring success from the mark disappearing, so a silent client-side failure cannot pass it.

## Verification

`pnpm install`, `pnpm -w check-types`, `pnpm -w test` (21 packages) and `pnpm -w build` all green, re-run after rebasing onto current `main`. Server integration 96 files / 683 tests. 4/4 e2e in `bounce-visibility`.

Driven against the live worktree stack signed in as a real user: a bounced company mailbox shows the mark, the button lifts it, the mark goes, and the stored row returns to `unknown`.

## Deferred

An assistant still cannot lift a company block over MCP — `clear_email_suppression` is a parameter on `update_contact`. The same gap, one surface along.
