### PR TITLE
fix(research): report what a run actually did

### DIFF
--- a/apps/server/src/services/research-scan-reporting.integration.test.ts
+++ b/apps/server/src/services/research-scan-reporting.integration.test.ts
@@ -1,0 +1,354 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '4'
+process.env['RESEARCH_MAX_LOOP_PROMPT_TOKENS'] ??= '24000'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	ExtractLanguageModel,
+	MapProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	ScrapeProvider,
+	SearchProvider,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+// What a discovery scan reports about itself, end to end. A scan that comes back
+// with a handful of companies must not read as green as one that came back with
+// a list; and a scan pinned to a company — "find this company's competitors" —
+// must earn the same refined retry and the same honest "found nothing" as an
+// open-ended one, rather than reporting success over an empty list.
+//
+// One shared ResearchService layer drives every case (a fresh layer per case
+// would start a fresh dispatcher + connection pool each time and exhaust the CI
+// database's connection cap). Each test sets the module-level `scenario` before
+// it runs, and the Agent/Extract stubs read it at call time.
+
+interface Org {
+	id: string
+	name: string
+	slug: string
+}
+
+interface Scenario {
+	/** Page text the one "fetched" search result carries. */
+	readonly evidence: string
+	/** Structured findings the extractor returns on every call. */
+	readonly findings: Record<string, unknown>
+}
+
+let scenario: Scenario
+
+// A canonical URL hashes to itself, so this matches what the run fiber's
+// source-linking computes for the web_search result below.
+const SEED_URL = 'https://directory.test/scan-reporting'
+const SEED_URL_HASH = createHash('sha256').update(SEED_URL).digest('hex')
+
+// The company an anchored scan is launched from. Its name is distinctive enough
+// that evidence naming it clears the entity gate — otherwise the run would fail
+// closed there and never reach the reporting under test.
+const ANCHOR_NAME = 'Marbrera Puigcerdà Pedra Natural'
+
+const usage = {
+	inputTokens: {
+		uncached: undefined,
+		total: 0,
+		cacheRead: undefined,
+		cacheWrite: undefined,
+	},
+	outputTokens: { total: 0, text: undefined, reasoning: undefined },
+}
+
+// Agent pass: hand back one web_search result carrying real page text, and no
+// further tool calls, so each pass gathers the seeded source then stops.
+const agentLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({
+			text: '',
+			content: [],
+			reasoning: [],
+			reasoningText: undefined,
+			toolCalls: [],
+			toolResults: [
+				{
+					name: 'web_search',
+					isFailure: false,
+					encodedResult: undefined,
+					result: { items: [{ url: SEED_URL, content: scenario.evidence }] },
+				},
+			],
+			finishReason: 'stop' as const,
+			usage,
+		}) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const extractLlm: LanguageModel.Service = {
+	generateText: () => Effect.succeed({ text: '', content: [], usage }) as never,
+	generateObject: () =>
+		Effect.succeed({ usage, value: scenario.findings }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const writerLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({ text: '## Scan brief', content: [], usage }) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const die = 'provider not exercised'
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({ search: () => Effect.die(die) }),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({ scrape: () => Effect.die(die) }),
+	),
+	Layer.succeed(MapProvider)(MapProvider.of({ map: () => Effect.die(die) })),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(die) }),
+	),
+)
+
+// Every event a run fires, so a test can assert the refined retry ran.
+let firedEvents: string[] = []
+const eventSink = Layer.succeed(ResearchEventSink)(
+	ResearchEventSink.of({
+		fire: (event: string) =>
+			Effect.sync(() => {
+				firedEvents.push(event)
+			}),
+	}),
+)
+
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			Layer.succeed(AgentLanguageModel)(agentLlm),
+			Layer.succeed(ExtractLanguageModel)(extractLlm),
+			Layer.succeed(WriterLanguageModel)(writerLlm),
+		),
+	),
+	Layer.provide(providersLayer),
+	Layer.provide(
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test',
+				}),
+		}),
+	),
+	Layer.provide(eventSink),
+	Layer.provideMerge(PgLive),
+)
+
+const runtime = ManagedRuntime.make(ResearchLive)
+const TERMINAL = new Set([
+	'succeeded',
+	'succeeded_low_confidence',
+	'failed',
+	'cancelled',
+	'no_reliable_data',
+])
+
+const systemDefaults = {
+	budgetCents: 1000,
+	paidBudgetCents: 500,
+	autoApprovePaidCents: 500,
+	paidMonthlyCapCents: 2000,
+	hardCeiling: 100_000,
+}
+
+const ctx = { org: undefined as unknown as Org }
+let userId: string
+let anchorCompanyId: string
+const createdRunIds: string[] = []
+
+// Run one scan to its terminal state and report how it finished.
+const runScan = async (args: {
+	readonly schemaName: string
+	readonly query: string
+	readonly scenario: Scenario
+	readonly subjectId?: string
+}): Promise<{ status: string; refined: boolean }> => {
+	scenario = args.scenario
+	firedEvents = []
+	return runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ResearchService
+			const sql = yield* SqlClient.SqlClient
+			const created = yield* enterOrgScope(sql, { org: ctx.org, userId })(
+				svc.create(
+					userId,
+					ctx.org.id,
+					{
+						query: args.query,
+						schemaName: args.schemaName,
+						forceFresh: true,
+						...(args.subjectId
+							? {
+									context: {
+										subjects: [{ table: 'companies', id: args.subjectId }],
+									},
+								}
+							: {}),
+					},
+					systemDefaults,
+				),
+			)
+			// A non-selector input never fans out, so it always carries a run id;
+			// rule out the confirm-required variant to keep the type honest.
+			if (created.status === 'confirm_required')
+				return yield* Effect.die(
+					new Error('scan-reporting test input should not fan out'),
+				)
+			createdRunIds.push(created.id)
+
+			const poll = (
+				attemptsLeft: number,
+			): Effect.Effect<string, never, never> =>
+				Effect.gen(function* () {
+					const run = (yield* svc.get(created.id).pipe(Effect.orDie)) as {
+						status?: string
+					} | null
+					const status = run?.status ?? 'unknown'
+					if (TERMINAL.has(status) || attemptsLeft <= 0) return status
+					yield* Effect.sleep('250 millis')
+					return yield* poll(attemptsLeft - 1)
+				})
+			const status = yield* poll(120)
+			return { status, refined: firedEvents.includes('research.refining') }
+		}),
+	)
+}
+
+beforeAll(async () => {
+	const seed = await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [org] = yield* sql<Org>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [user] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!org || !user) {
+				throw new Error(
+					"taller org / admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			const [anchor] = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, slug, name)
+				VALUES (${org.id}, ${`scan-anchor-${randomUUID()}`}, ${ANCHOR_NAME})
+				RETURNING id
+			`
+			// The one source both passes "fetch", so the grounding gate passes and
+			// each run reaches the reporting under test.
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (${`src-${randomUUID()}`}, 'web', 'it-stub', ${SEED_URL}, ${SEED_URL_HASH}, 'directory.test', 'seed')
+				ON CONFLICT (url_hash) DO NOTHING
+			`
+			return { org, userId: user.id, anchorId: anchor?.id ?? '' }
+		}),
+	)
+	ctx.org = seed.org
+	userId = seed.userId
+	anchorCompanyId = seed.anchorId
+}, 60_000)
+
+afterAll(async () => {
+	await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const id of createdRunIds) {
+				yield* sql`DELETE FROM research_cache WHERE research_id = ${id}::uuid`
+				yield* sql`DELETE FROM research_runs WHERE id = ${id}::uuid`
+			}
+			yield* sql`DELETE FROM companies WHERE id = ${anchorCompanyId}::uuid`
+			yield* sql`DELETE FROM sources WHERE url_hash = ${SEED_URL_HASH}`
+		}),
+	)
+	await runtime.dispose()
+})
+
+describe('what a discovery scan reports about itself', () => {
+	describe('when an open-ended scan comes back with only a handful', () => {
+		it('should search again and finish marked for a read, not plain succeeded', async () => {
+			// GIVEN a prospect scan that finds two companies — a real answer, but far
+			//   short of the list it was asked for
+			const result = await runScan({
+				schemaName: 'prospect_scan_v1',
+				query: 'Find midsize US freight brokerage prospects',
+				scenario: {
+					evidence: 'A directory listing of US freight brokerage firms.',
+					findings: {
+						prospects: [
+							{
+								name: 'Ridgeline Freight',
+								why_relevant: 'Midsize US broker',
+								citations: [],
+							},
+							{
+								name: 'Copperline Logistics',
+								why_relevant: 'Midsize US broker',
+								citations: [],
+							},
+						],
+					},
+				},
+			})
+
+			// THEN the run took its one refined retry and, still thin, finished in
+			//   the status that asks for a human read rather than as green as a run
+			//   that came back with forty
+			expect(result.refined).toBe(true)
+			expect(result.status).toBe('succeeded_low_confidence')
+		}, 60_000)
+	})
+
+	describe('when a scan pinned to a company finds nobody', () => {
+		it('should search again and report having found nothing', async () => {
+			// GIVEN a competitor scan launched from a company on file, whose evidence
+			//   clearly names that company (so the entity gate passes) but whose
+			//   competitor list comes back empty every time
+			const result = await runScan({
+				schemaName: 'competitor_scan_v1',
+				query: `Find competitors of ${ANCHOR_NAME}`,
+				subjectId: anchorCompanyId,
+				scenario: {
+					evidence: `${ANCHOR_NAME} is a natural stone workshop in Puigcerdà, Girona.`,
+					findings: { competitors: [] },
+				},
+			})
+
+			// THEN being pinned to a company costs it neither the retry nor the
+			//   honest answer: it says it found nothing instead of reporting success
+			//   over an empty list
+			expect(result.refined).toBe(true)
+			expect(result.status).toBe('no_reliable_data')
+		}, 60_000)
+	})
+})

--- a/packages/research/src/application/discovery-scan.test.ts
+++ b/packages/research/src/application/discovery-scan.test.ts
@@ -1,19 +1,32 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	DISCOVERY_THIN_RESULT_COUNT,
+	discoveryResultCount,
+	emptyScanFindings,
+	isDiscoveryScan,
 	isDiscoveryScanEmpty,
-	isRetryEligible,
+	isDiscoveryScanThin,
 	REFINE_HINT,
 } from './discovery-scan'
 
-describe('isRetryEligible', () => {
+// A list long enough that no thinness check reads it as short, whatever the
+// threshold is set to.
+const fullList = (field: string): Record<string, unknown> => ({
+	[field]: Array.from({ length: DISCOVERY_THIN_RESULT_COUNT + 3 }, (_, i) => ({
+		name: `Company ${i}`,
+	})),
+})
+
+describe('isDiscoveryScan', () => {
 	describe('when the schema is an open-ended discovery scan', () => {
 		it('should be true for prospect_scan_v1 and competitor_scan_v1', () => {
 			// GIVEN the two open-ended scan schemas
-			// WHEN checked for retry eligibility
-			// THEN both qualify
-			expect(isRetryEligible('prospect_scan_v1')).toBe(true)
-			expect(isRetryEligible('competitor_scan_v1')).toBe(true)
+			// WHEN checked
+			// THEN both qualify — a competitor scan is a scan exactly as a prospect
+			// scan is, which is what the two hand-written lists once disagreed on
+			expect(isDiscoveryScan('prospect_scan_v1')).toBe(true)
+			expect(isDiscoveryScan('competitor_scan_v1')).toBe(true)
 		})
 	})
 
@@ -21,11 +34,74 @@ describe('isRetryEligible', () => {
 		it('should be false — those are not open-ended scans', () => {
 			// GIVEN the entity-grounded and freeform schemas
 			// WHEN checked
-			// THEN none qualify for the discovery retry
-			expect(isRetryEligible('company_enrichment_v1')).toBe(false)
-			expect(isRetryEligible('contact_discovery_v1')).toBe(false)
-			expect(isRetryEligible('freeform')).toBe(false)
-			expect(isRetryEligible('unknown_schema')).toBe(false)
+			// THEN none is a discovery scan
+			expect(isDiscoveryScan('company_enrichment_v1')).toBe(false)
+			expect(isDiscoveryScan('contact_discovery_v1')).toBe(false)
+			expect(isDiscoveryScan('freeform')).toBe(false)
+			expect(isDiscoveryScan('unknown_schema')).toBe(false)
+		})
+	})
+})
+
+describe('discoveryResultCount', () => {
+	describe('when the schema is not a discovery scan', () => {
+		it('should be null, however empty the findings look', () => {
+			// GIVEN a non-discovery schema
+			// WHEN counted
+			// THEN there is no scan list to count — null, never 0, so a caller
+			// cannot mistake "does not apply" for "found nothing"
+			expect(discoveryResultCount('company_enrichment_v1', {})).toBeNull()
+			expect(
+				discoveryResultCount('contact_discovery_v1', { contacts: [] }),
+			).toBeNull()
+			expect(discoveryResultCount('freeform', null)).toBeNull()
+		})
+	})
+
+	describe('when a scan carries its primary list', () => {
+		it('should count its entries', () => {
+			// GIVEN each scan schema with results in its own primary list
+			// WHEN counted
+			// THEN each reads its own field
+			expect(
+				discoveryResultCount('prospect_scan_v1', {
+					prospects: [{ name: 'Acme 3PL' }, { name: 'Bolt Logistics' }],
+				}),
+			).toBe(2)
+			expect(
+				discoveryResultCount('competitor_scan_v1', {
+					competitors: [{ name: 'Rival Co' }],
+				}),
+			).toBe(1)
+		})
+
+		it('should not count another scan schema’s list', () => {
+			// GIVEN a competitor scan whose findings carry a prospects list instead
+			// WHEN counted
+			// THEN the field it does not own counts for nothing
+			expect(
+				discoveryResultCount('competitor_scan_v1', {
+					prospects: [{ name: 'Acme 3PL' }],
+				}),
+			).toBe(0)
+		})
+	})
+
+	describe('when the primary list is missing or unusable', () => {
+		it('should be zero', () => {
+			// GIVEN a scan whose list is absent, of the wrong type, or whose
+			// findings are not an object at all
+			// WHEN counted
+			// THEN nothing countable is nothing found
+			expect(
+				discoveryResultCount('prospect_scan_v1', { discovered_existing: [] }),
+			).toBe(0)
+			expect(
+				discoveryResultCount('prospect_scan_v1', { prospects: 'Acme 3PL' }),
+			).toBe(0)
+			expect(discoveryResultCount('prospect_scan_v1', null)).toBe(0)
+			expect(discoveryResultCount('prospect_scan_v1', [])).toBe(0)
+			expect(discoveryResultCount('prospect_scan_v1', 'nope')).toBe(0)
 		})
 	})
 })
@@ -61,12 +137,12 @@ describe('isDiscoveryScanEmpty', () => {
 	})
 
 	describe('when a prospect scan found prospects', () => {
-		it('should be false', () => {
-			// GIVEN a prospect scan with at least one result
+		it('should be false for even a single result', () => {
+			// GIVEN a prospect scan with one result — thin, but not nothing
 			const findings = { prospects: [{ name: 'Acme 3PL' }] }
 
 			// WHEN checked
-			// THEN it is not empty
+			// THEN it is not empty: a real result is never reported as nothing found
 			expect(isDiscoveryScanEmpty('prospect_scan_v1', findings)).toBe(false)
 		})
 	})
@@ -101,15 +177,142 @@ describe('isDiscoveryScanEmpty', () => {
 	})
 })
 
+describe('isDiscoveryScanThin', () => {
+	const listOf = (field: string, count: number): Record<string, unknown> => ({
+		[field]: Array.from({ length: count }, (_, i) => ({ name: `Co ${i}` })),
+	})
+
+	describe('when a scan came back with fewer results than a list needs', () => {
+		it('should be true one short of the threshold', () => {
+			// GIVEN the reported run: a handful of companies where a list was asked
+			// for, which used to finish as green as a full one
+			const findings = listOf('prospects', DISCOVERY_THIN_RESULT_COUNT - 1)
+
+			// WHEN checked for thinness
+			// THEN it is thin
+			expect(isDiscoveryScanThin('prospect_scan_v1', findings)).toBe(true)
+		})
+
+		it('should be true for a single result', () => {
+			// GIVEN one company found
+			// WHEN checked
+			// THEN one result is as thin as a result gets while still being one
+			expect(
+				isDiscoveryScanThin('prospect_scan_v1', listOf('prospects', 1)),
+			).toBe(true)
+		})
+
+		it('should be true when the scan found nothing at all', () => {
+			// GIVEN an empty, missing, or unusable list
+			// WHEN checked
+			// THEN nothing found is the thinnest result there is
+			expect(isDiscoveryScanThin('prospect_scan_v1', { prospects: [] })).toBe(
+				true,
+			)
+			expect(isDiscoveryScanThin('competitor_scan_v1', {})).toBe(true)
+			expect(isDiscoveryScanThin('prospect_scan_v1', null)).toBe(true)
+		})
+	})
+
+	describe('when a scan came back with a full list', () => {
+		it('should be false at exactly the threshold', () => {
+			// GIVEN a scan holding exactly as many results as the threshold asks for
+			const findings = listOf('prospects', DISCOVERY_THIN_RESULT_COUNT)
+
+			// WHEN checked
+			// THEN the threshold is the point at which a list stops being thin, so
+			// this one is not flagged
+			expect(isDiscoveryScanThin('prospect_scan_v1', findings)).toBe(false)
+		})
+
+		it('should be false well above it', () => {
+			// GIVEN a scan with a long list
+			// WHEN checked
+			// THEN it is a list, not a lead or two
+			expect(
+				isDiscoveryScanThin('prospect_scan_v1', fullList('prospects')),
+			).toBe(false)
+		})
+	})
+
+	describe('when a competitor scan is checked', () => {
+		it('should read its own primary list, exactly as a prospect scan does', () => {
+			// GIVEN thin and full competitor scans
+			// WHEN checked
+			// THEN the competitors list drives the verdict, so a competitor scan is
+			// graded like a prospect scan rather than escaping the check
+			expect(
+				isDiscoveryScanThin('competitor_scan_v1', listOf('competitors', 2)),
+			).toBe(true)
+			expect(
+				isDiscoveryScanThin('competitor_scan_v1', fullList('competitors')),
+			).toBe(false)
+		})
+	})
+
+	describe('when the schema is not a discovery scan', () => {
+		it('should always be false, however little it holds', () => {
+			// GIVEN an enrichment or freeform run, which was never asked for a list
+			// WHEN checked
+			// THEN thinness is not this helper's concern → false
+			expect(isDiscoveryScanThin('company_enrichment_v1', {})).toBe(false)
+			expect(isDiscoveryScanThin('freeform', null)).toBe(false)
+			expect(
+				isDiscoveryScanThin('contact_discovery_v1', { contacts: [] }),
+			).toBe(false)
+		})
+	})
+})
+
 describe('REFINE_HINT', () => {
 	describe('when steering a refined retry', () => {
 		it('should push toward directories and forbid placeholder site: filters', () => {
-			// GIVEN the refinement hint appended on an empty retry
+			// GIVEN the refinement hint appended on a thin retry
 			// WHEN inspected
 			// THEN it names authoritative sources and bans placeholder filters
 			expect(REFINE_HINT).toMatch(/director/i)
 			expect(REFINE_HINT).toMatch(/registr/i)
 			expect(REFINE_HINT).toMatch(/placeholder site:/i)
+		})
+
+		it('should describe the previous pass as too few results, not none', () => {
+			// GIVEN a retry that now also fires on a handful of results
+			// WHEN the model reads why it is searching again
+			// THEN it is not told the previous pass found nothing, which would be
+			// untrue of every thin-but-not-empty retry
+			expect(REFINE_HINT).toMatch(/too few relevant results/i)
+			expect(REFINE_HINT).not.toMatch(/no relevant results/i)
+		})
+	})
+})
+
+describe('emptyScanFindings', () => {
+	describe('when the refined retry fired and still found nothing', () => {
+		it('should say the search was refined and still came up empty', () => {
+			// GIVEN a scan that searched twice and named no company either time
+			const findings = emptyScanFindings(true)
+
+			// WHEN the run reports
+			// THEN it says a second, refined pass was made
+			expect(findings.reason).toBe('no_reliable_data')
+			expect(findings.error).toMatch(/even after a refined retry/i)
+		})
+	})
+
+	describe('when no retry was ever made', () => {
+		it('should not claim one', () => {
+			// GIVEN a scan that finished its first pass with too little budget left
+			// for a second
+			const findings = emptyScanFindings(false)
+
+			// WHEN the run reports
+			// THEN it still reports nothing found, but does not claim to have tried
+			// twice — the retry it never got is exactly what a reader would look for
+			expect(findings.reason).toBe('no_reliable_data')
+			expect(findings.error).toMatch(
+				/found no companies matching the criteria/i,
+			)
+			expect(findings.error).not.toMatch(/retry/i)
 		})
 	})
 })

--- a/packages/research/src/application/discovery-scan.ts
+++ b/packages/research/src/application/discovery-scan.ts
@@ -1,8 +1,12 @@
 /**
  * Helpers for the open-ended discovery scans (prospect / competitor). These are
- * the only schemas whose empty primary list means the search — not the data —
- * came up short, so they alone earn a refined retry and, if still empty, an
+ * the only schemas where a short primary list says the search fell short rather
+ * than the data, so they alone earn a refined retry and, if still empty, an
  * honest terminal status instead of a green "succeeded" over nothing.
+ *
+ * The list of scan schemas below is the only one: every question asked about a
+ * scan — here and in the quality signal — reads it, so no second copy can name
+ * one scan schema and quietly grade the other as having found nothing.
  */
 
 // The primary result array for each discovery-scan schema. A schema absent here
@@ -12,9 +16,39 @@ const DISCOVERY_RESULT_FIELD: Record<string, string> = {
 	competitor_scan_v1: 'competitors',
 }
 
-/** Whether a schema is an open-ended discovery scan eligible for the retry. */
-export const isRetryEligible = (schemaName: string): boolean =>
+/**
+ * How many results a scan has to come back with before its list reads as a list.
+ * A scan is asked for breadth — a set of companies to work through — so anything
+ * under a handful is a lead or two, and far more often the search fell short than
+ * the market did. Below this a scan earns the refined retry and finishes marked
+ * for a read; only an outright empty list is reported as nothing found.
+ */
+export const DISCOVERY_THIN_RESULT_COUNT = 5
+
+/** Whether a schema is an open-ended discovery scan. */
+export const isDiscoveryScan = (schemaName: string): boolean =>
 	schemaName in DISCOVERY_RESULT_FIELD
+
+/**
+ * How many results a discovery scan's primary list carries. Null for a schema
+ * that is not a discovery scan, whose result count is a different question its
+ * own guards answer; zero when the list is missing, unusable, or empty.
+ */
+export const discoveryResultCount = (
+	schemaName: string,
+	findings: unknown,
+): number | null => {
+	const field = DISCOVERY_RESULT_FIELD[schemaName]
+	if (field === undefined) return null
+	if (
+		findings == null ||
+		typeof findings !== 'object' ||
+		Array.isArray(findings)
+	)
+		return 0
+	const value = (findings as Record<string, unknown>)[field]
+	return Array.isArray(value) ? value.length : 0
+}
 
 /**
  * Whether a discovery scan's findings carry no results — an empty or missing
@@ -24,22 +58,41 @@ export const isRetryEligible = (schemaName: string): boolean =>
 export const isDiscoveryScanEmpty = (
 	schemaName: string,
 	findings: unknown,
+): boolean => discoveryResultCount(schemaName, findings) === 0
+
+/**
+ * Whether a discovery scan came back with too few results to read as the list it
+ * was asked for. True of an empty scan as well: nothing found is the thinnest
+ * result there is.
+ */
+export const isDiscoveryScanThin = (
+	schemaName: string,
+	findings: unknown,
 ): boolean => {
-	const field = DISCOVERY_RESULT_FIELD[schemaName]
-	if (field === undefined) return false
-	if (
-		findings == null ||
-		typeof findings !== 'object' ||
-		Array.isArray(findings)
-	)
-		return true
-	const value = (findings as Record<string, unknown>)[field]
-	return !Array.isArray(value) || value.length === 0
+	const count = discoveryResultCount(schemaName, findings)
+	return count !== null && count < DISCOVERY_THIN_RESULT_COUNT
 }
 
 // Appended to the query for a single refined retry after a discovery scan comes
-// back empty, steering the model toward useful sources and away from the social /
+// back thin, steering the model toward useful sources and away from the social /
 // glossary noise that empties an open-ended search — while holding it to the
 // request's own size, place, and niche so "refine" widens the wording, not the bar.
+// It says "too few" rather than "none" because the retry also fires on a handful
+// of results, and the first pass's results are kept alongside whatever it adds.
 export const REFINE_HINT =
-	'The previous search returned no relevant results. Refine your approach: search business directories, industry association member lists, and sector-specific registries for companies that match the criteria; combine specific location and industry keywords; and ignore social-media posts, forums, and glossary pages. Do not use placeholder site: filters. Keep every qualifier the request made — size, place, and niche: widen the wording, never the criteria. A "top N" or "largest" ranking is not a shortcut past them; it lists the biggest firms in the sector, which is rarely what was asked.'
+	'The previous search returned too few relevant results. Refine your approach: search business directories, industry association member lists, and sector-specific registries for companies that match the criteria; combine specific location and industry keywords; and ignore social-media posts, forums, and glossary pages. Do not use placeholder site: filters. Keep every qualifier the request made — size, place, and niche: widen the wording, never the criteria. A "top N" or "largest" ranking is not a shortcut past them; it lists the biggest firms in the sector, which is rarely what was asked.'
+
+/**
+ * What a discovery scan that found nothing reports in place of findings. The
+ * refined retry is mentioned only when the run actually got one — a scan can
+ * finish its first pass with too little budget left for a second — so a run that
+ * searched once never reads as though it had tried twice and given up.
+ */
+export const emptyScanFindings = (
+	refined: boolean,
+): { readonly error: string; readonly reason: 'no_reliable_data' } => ({
+	error: refined
+		? 'The search found no companies matching the criteria, even after a refined retry, so there are no reliable findings to report.'
+		: 'The search found no companies matching the criteria, so there are no reliable findings to report.',
+	reason: 'no_reliable_data',
+})

--- a/packages/research/src/application/research-quality.test.ts
+++ b/packages/research/src/application/research-quality.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
+import { DISCOVERY_THIN_RESULT_COUNT } from './discovery-scan'
 import { computeRunQuality } from './research-quality'
+
+// Enough results that the thin-list signal stays quiet, so a test about some
+// other signal is measuring only that one.
+const FULL_LIST = DISCOVERY_THIN_RESULT_COUNT + 7
 
 describe('computeRunQuality', () => {
 	describe('for an enrichment run', () => {
@@ -13,6 +18,8 @@ describe('computeRunQuality', () => {
 			fieldsTotal: 6,
 			citationsSeen: 4,
 			citationsKept: 4,
+			scanResults: null,
+			refined: false,
 		} as const
 
 		it('should not flag a strong, well-grounded run', () => {
@@ -46,11 +53,18 @@ describe('computeRunQuality', () => {
 			expect(quality.low_confidence).toBe(false)
 			expect(quality.grounding_ratio).toBeCloseTo(0.17)
 		})
+
+		it('should leave out the retry marker a run with no retry cannot have', () => {
+			// GIVEN an enrichment run, which is never given the discovery retry
+			const quality = computeRunQuality({ ...base, entityMatch: 'strong' })
+			// THEN `refined` is absent rather than reported false on every run that
+			// was never eligible for it
+			expect(quality.refined).toBeUndefined()
+		})
 	})
 
-	describe('for a prospect scan', () => {
+	describe('for a discovery scan', () => {
 		const scan = {
-			schemaName: 'prospect_scan_v1',
 			entityMatch: null,
 			rounds: 3,
 			sourcesTotal: 6,
@@ -59,12 +73,15 @@ describe('computeRunQuality', () => {
 			fieldsTotal: 0,
 			citationsSeen: 10,
 			citationsKept: 10,
+			scanResults: FULL_LIST,
+			refined: false,
 		} as const
 
 		it('should flag a scan vetted against a single source', () => {
 			// GIVEN the bad scan from the sample: one search, one source
 			const quality = computeRunQuality({
 				...scan,
+				schemaName: 'prospect_scan_v1',
 				rounds: 1,
 				sourcesTotal: 1,
 			})
@@ -73,8 +90,11 @@ describe('computeRunQuality', () => {
 		})
 
 		it('should not flag a scan vetted against several sources', () => {
-			// GIVEN a scan that pulled from many sources
-			const quality = computeRunQuality(scan)
+			// GIVEN a scan that pulled from many sources and came back with a list
+			const quality = computeRunQuality({
+				...scan,
+				schemaName: 'prospect_scan_v1',
+			})
 			// THEN it is trusted — this scan was pinned to no company, so there is
 			// no entity verdict to weigh
 			expect(quality.low_confidence).toBe(false)
@@ -82,11 +102,119 @@ describe('computeRunQuality', () => {
 
 		it('should leave out the profile numbers a scan cannot have', () => {
 			// GIVEN any scan, which fills no company profile
-			const quality = computeRunQuality(scan)
+			const quality = computeRunQuality({
+				...scan,
+				schemaName: 'prospect_scan_v1',
+			})
 			// THEN the profile measures are absent rather than reported as zero, which
 			// would read as a failing grade on every scan ever run
 			expect(quality.grounding_ratio).toBeUndefined()
 			expect(quality.fields_grounded).toBeUndefined()
+		})
+
+		it('should grade a competitor scan exactly as it grades a prospect scan', () => {
+			// GIVEN the same thinly-vetted run under each scan schema
+			const thinlyVetted = { ...scan, rounds: 1, sourcesTotal: 1 } as const
+			const prospect = computeRunQuality({
+				...thinlyVetted,
+				schemaName: 'prospect_scan_v1',
+			})
+			const competitor = computeRunQuality({
+				...thinlyVetted,
+				schemaName: 'competitor_scan_v1',
+			})
+
+			// THEN the competitor scan is flagged like the prospect scan, and neither
+			// reports a profile it never filled — a competitor scan used to escape
+			// the single-source check and report a grounding ratio of zero, which
+			// read as a failing grade on every competitor scan ever run
+			expect(competitor.low_confidence).toBe(prospect.low_confidence)
+			expect(competitor.low_confidence).toBe(true)
+			expect(competitor.grounding_ratio).toBeUndefined()
+			expect(competitor.fields_grounded).toBeUndefined()
+		})
+
+		it('should report whether the refined retry fired', () => {
+			// GIVEN two finished scans, one of which was given the refined retry
+			const withRetry = computeRunQuality({
+				...scan,
+				schemaName: 'competitor_scan_v1',
+				refined: true,
+			})
+			const withoutRetry = computeRunQuality({
+				...scan,
+				schemaName: 'competitor_scan_v1',
+			})
+
+			// THEN each says so on the run itself, so how much the retry is worth can
+			// be read off finished runs rather than reconstructed from logs
+			expect(withRetry.refined).toBe(true)
+			expect(withoutRetry.refined).toBe(false)
+		})
+	})
+
+	describe('when a scan came back with too few results', () => {
+		const scan = {
+			schemaName: 'prospect_scan_v1',
+			entityMatch: null,
+			rounds: 4,
+			sourcesTotal: 6,
+			sourcesFirstParty: 0,
+			fieldsGrounded: 0,
+			fieldsTotal: 0,
+			citationsSeen: 10,
+			citationsKept: 10,
+			refined: true,
+		} as const
+
+		it('should flag a well-sourced scan that still found only a handful', () => {
+			// GIVEN the reported run: four companies found, several sources read,
+			// every citation kept — nothing else about it looks thin
+			const quality = computeRunQuality({
+				...scan,
+				scanResults: DISCOVERY_THIN_RESULT_COUNT - 1,
+			})
+
+			// THEN it is marked for a read rather than reported as green as a run
+			// that came back with forty
+			expect(quality.low_confidence).toBe(true)
+		})
+
+		it('should flag a single result', () => {
+			// GIVEN a scan that named one company
+			const quality = computeRunQuality({ ...scan, scanResults: 1 })
+			// THEN one result is not a list
+			expect(quality.low_confidence).toBe(true)
+		})
+
+		it('should not flag a scan holding exactly the threshold', () => {
+			// GIVEN a scan whose list is just long enough
+			const quality = computeRunQuality({
+				...scan,
+				scanResults: DISCOVERY_THIN_RESULT_COUNT,
+			})
+			// THEN the threshold is where a list stops being thin, so it stays trusted
+			expect(quality.low_confidence).toBe(false)
+		})
+
+		it('should never raise the signal for a run that was asked for no list', () => {
+			// GIVEN an enrichment run, which reports no scan list at all
+			const quality = computeRunQuality({
+				schemaName: 'company_enrichment_v1',
+				entityMatch: 'strong',
+				rounds: 6,
+				sourcesTotal: 5,
+				sourcesFirstParty: 3,
+				fieldsGrounded: 4,
+				fieldsTotal: 6,
+				citationsSeen: 4,
+				citationsKept: 4,
+				scanResults: null,
+				refined: false,
+			})
+			// THEN the thin-list signal stays quiet — a missing list is "does not
+			// apply", not "found nothing"
+			expect(quality.low_confidence).toBe(false)
 		})
 	})
 
@@ -99,6 +227,8 @@ describe('computeRunQuality', () => {
 			sourcesFirstParty: 0,
 			fieldsGrounded: 0,
 			fieldsTotal: 0,
+			scanResults: FULL_LIST,
+			refined: false,
 		} as const
 
 		it('should flag a run whose citations were all rejected', () => {
@@ -152,6 +282,8 @@ describe('computeRunQuality', () => {
 				fieldsTotal: 0,
 				citationsSeen: 8,
 				citationsKept: 8,
+				scanResults: FULL_LIST,
+				refined: false,
 			}).low_confidence
 
 		it('should flag one that never clearly reached that company', () => {

--- a/packages/research/src/application/research-quality.ts
+++ b/packages/research/src/application/research-quality.ts
@@ -8,15 +8,18 @@
  * run already produced. The flag is deliberately conservative: it should catch the
  * clearly-thin runs, not second-guess a solid one.
  *
- * Three signals raise it. Whenever a run was pinned to one company, anything short
+ * Four signals raise it. Whenever a run was pinned to one company, anything short
  * of clearly reaching that company counts — which covers an enrichment filling
  * that company's profile and equally a scan launched from it, since a scan can be
  * pinned to a subject too and a wrong one there is just as misleading. On top of
- * that, a prospect scan reports a list of third parties, so vetting that list
- * against a single source is thin however well the company itself was found. And
- * a run whose every citation was rejected reached none of the pages it claimed to
- * read, whatever else it did.
+ * that, a scan reports a list of third parties, so vetting that list against a
+ * single source is thin however well the company itself was found, and coming
+ * back with a handful of results where a list was asked for is thin whatever it
+ * was vetted against. And a run whose every citation was rejected reached none of
+ * the pages it claimed to read, whatever else it did.
  */
+
+import { DISCOVERY_THIN_RESULT_COUNT, isDiscoveryScan } from './discovery-scan'
 
 export interface RunQualityInput {
 	readonly schemaName: string
@@ -40,6 +43,10 @@ export interface RunQualityInput {
 	readonly citationsSeen: number
 	/** Of those, how many resolved to a page the run actually reached. */
 	readonly citationsKept: number
+	/** Scan: how many results its primary list carries (null for a non-scan). */
+	readonly scanResults: number | null
+	/** Whether the one refined retry fired after a thin first pass. */
+	readonly refined: boolean
 }
 
 export interface RunQuality {
@@ -54,6 +61,12 @@ export interface RunQuality {
 	 * scan ever run and look like a failing grade rather than "does not apply".
 	 */
 	readonly grounding_ratio?: number
+	/**
+	 * Whether the scan's one refined retry fired; absent for a non-scan, which
+	 * never has one. Reported so the retry's worth can be read off finished runs
+	 * rather than reconstructed from logs — it is the main lever on a thin list.
+	 */
+	readonly refined?: boolean
 	readonly citations_seen: number
 	/** Of those, how many pointed at a page the run actually reached. */
 	readonly citations_kept: number
@@ -64,7 +77,7 @@ export interface RunQuality {
 export const computeRunQuality = (input: RunQualityInput): RunQuality => {
 	const groundingRatio =
 		input.fieldsTotal > 0 ? input.fieldsGrounded / input.fieldsTotal : 0
-	const isScan = input.schemaName === 'prospect_scan_v1'
+	const isScan = isDiscoveryScan(input.schemaName)
 
 	// Anything short of clearly reaching the company the run was pinned to. Asked
 	// of every run kind on purpose: a scan launched from one company is pinned to
@@ -77,19 +90,28 @@ export const computeRunQuality = (input: RunQualityInput): RunQuality => {
 	// And a scan that vetted its list of other firms against a single source
 	// hasn't done enough to act on unread, however well it found the company.
 	const thinlyVetted = isScan && input.sourcesTotal <= 1
+	// A scan asked for a list that came back a handful long has searched too
+	// narrowly far more often than it has found a small market, so one result
+	// must not finish as green as forty.
+	const thinResultList =
+		input.scanResults !== null &&
+		input.scanResults < DISCOVERY_THIN_RESULT_COUNT
 	// The findings may well be right, but every page the run cited is one it never
 	// reached, so nothing it did backs them. Citing nothing at all is a different
-	// shortfall, left to the two signals above.
+	// shortfall, left to the signals above.
 	const nothingStandsBehindIt =
 		input.citationsSeen > 0 && input.citationsKept === 0
 	const lowConfidence =
-		unsureOfTheCompany || thinlyVetted || nothingStandsBehindIt
+		unsureOfTheCompany ||
+		thinlyVetted ||
+		thinResultList ||
+		nothingStandsBehindIt
 
 	return {
 		rounds: input.rounds,
 		sources_matched: input.sourcesFirstParty,
 		...(isScan
-			? {}
+			? { refined: input.refined }
 			: {
 					fields_grounded: input.fieldsGrounded,
 					grounding_ratio: Math.round(groundingRatio * 100) / 100,

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -59,8 +59,11 @@ import {
 	readDiscoveredEntry,
 } from './discovered-existing-guard'
 import {
+	discoveryResultCount,
+	emptyScanFindings,
+	isDiscoveryScan,
 	isDiscoveryScanEmpty,
-	isRetryEligible,
+	isDiscoveryScanThin,
 	REFINE_HINT,
 } from './discovery-scan'
 import {
@@ -2323,6 +2326,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					// Findings the discovery-scan retry path extracts under the shared
 					// budget; undefined on every other path (which extracts in phase 2).
 					let retryFindings: unknown
+					// Whether the scan's one refined retry fired. Carried out of phase 1
+					// so every terminal path can say so, rather than leaving the retry —
+					// the main lever on a thin list — to be reconstructed from logs.
+					let refinedRetry = false
 					// What the run's spending limit was charged for cheap work in phase 1,
 					// read off the budget once phase 1 ends. Feeds the gap rounds' check
 					// that there is still room for another one. Stays 0 on a resume that
@@ -4082,15 +4089,23 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								`${systemPrompt}\n\n${query}${anchorInstruction}`,
 							)
 
-							// A non-anchored discovery scan (prospect / competitor) that comes
-							// back empty gets ONE refined retry before we accept "found
-							// nothing": only here does an empty primary list mean the search —
-							// not the data — fell short, and only here is the entity gate a
-							// no-op. Extraction runs now so the emptiness check sees real
+							// A discovery scan (prospect / competitor) that comes back with too
+							// few results gets ONE refined retry before we accept the list:
+							// only here does a short primary list mean the search — not the
+							// data — fell short. Extraction runs now so that check sees real
 							// structured findings; the retry reuses this pass's budget.
+							//
+							// A scan pinned to a company earns the retry just as an open-ended
+							// one does — "find this company's competitors" that finds none has
+							// searched badly, not proved the company has no rivals — but it
+							// keeps phase 2's own extraction, which orders its own site first,
+							// re-judges the pages it cited, and can downgrade the entity
+							// verdict. So the findings below are handed on only when there is
+							// no anchor; an anchored scan probes for thinness here and extracts
+							// again there, over everything both passes gathered.
 							let findings: unknown
 							let refined = false
-							if (isRetryEligible(schemaName) && entityTargets === null) {
+							if (isDiscoveryScan(schemaName)) {
 								yield* linkRunSources(loop.scrapedUrlHashes)
 								let extracted = yield* extractStructuredFindings(
 									loop.researchText,
@@ -4102,7 +4117,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								)
 								findings = extracted.findings
 								if (
-									isDiscoveryScanEmpty(schemaName, findings) &&
+									isDiscoveryScanThin(schemaName, findings) &&
 									canAffordAnotherRound(yield* budget.snapshot())
 								) {
 									refined = true
@@ -4115,8 +4130,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									yield* publishEvent(researchId, 'run.refining', {
 										schema: schemaName,
 									})
+									// Carries the anchor instruction the first pass had: a
+									// re-search that drops it looks for anyone's competitors.
 									const retryLoop = yield* runPass(
-										`${systemPrompt}\n\n${query}\n\n${REFINE_HINT}`,
+										`${systemPrompt}\n\n${query}${anchorInstruction}\n\n${REFINE_HINT}`,
 									)
 									loop = {
 										researchText: [loop.researchText, retryLoop.researchText]
@@ -4152,7 +4169,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							const cheapCents = (yield* budget.snapshot()).cheapSpent
 							return {
 								loop,
-								findings,
+								// Only an unanchored scan hands its findings on; an anchored one
+								// extracted here to measure the list and lets phase 2 do the
+								// grounded extraction it needs.
+								findings: entityTargets === null ? findings : undefined,
 								refined,
 								cheapCents,
 							}
@@ -4178,10 +4198,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						// Why the searching stopped. A run that ran out of room to think,
 						// rather than finishing what it set out to do, had more it wanted
 						// to read — so a thin profile there is a ceiling to raise, not a
-						// prompt to reword.
+						// prompt to reword. Whether the refined retry fired rides along:
+						// it is the main lever on a thin list, and a run that ends with
+						// nothing to report keeps no findings to record it in.
 						yield* Effect.annotateCurrentSpan({
 							'research.phase1.stop_reason': loopResult.stopReason,
 							'research.phase1.rounds': loopResult.rounds,
+							'research.phase1.refined': phaseOutcome.refined,
 						})
 						// Prepend the anchor site's content so phase-2 extraction reads the
 						// official page first; empty when nothing was seeded.
@@ -4190,6 +4213,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							.join('\n\n')
 						evidenceText = loopResult.evidenceText
 						retryFindings = phaseOutcome.findings
+						refinedRetry = phaseOutcome.refined
 						cheapSpentCents = phaseOutcome.cheapCents
 
 						// Entity grounding gate: from the fetched evidence alone (never the
@@ -4668,12 +4692,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						return
 					}
 
-					// An open-ended discovery scan that came back empty even after a
-					// refined retry has no reliable findings to report — mark it
-					// no_reliable_data instead of a green success over an empty list.
+					// A discovery scan that came back empty has no reliable findings to
+					// report — mark it no_reliable_data instead of a green success over
+					// an empty list. A scan pinned to a company is no exception: "find
+					// this company's competitors" that names none has found nothing,
+					// whatever it learned about the company it started from.
 					if (
-						entityTargets === null &&
-						isRetryEligible(schemaName) &&
+						isDiscoveryScan(schemaName) &&
 						isDiscoveryScanEmpty(schemaName, findings)
 					) {
 						yield* sql`
@@ -4681,11 +4706,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							SET status = 'no_reliable_data',
 								reason_code = ${'no_sources' satisfies ReasonCode},
 								phase = 3,
-								findings = ${JSON.stringify({
-									error:
-										'The search found no companies matching the criteria, even after a refined retry, so there are no reliable findings to report.',
-									reason: 'no_reliable_data',
-								})},
+								findings = ${JSON.stringify(emptyScanFindings(refinedRetry))},
 								tool_log = ${JSON.stringify(finalToolLog)},
 								completed_at = now(),
 								updated_at = now()
@@ -4735,6 +4756,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						fieldsTotal: fill.total,
 						citationsSeen,
 						citationsKept,
+						scanResults: discoveryResultCount(schemaName, findings),
+						refined: refinedRetry,
 					})
 					const findingsWithQuality = {
 						...withRegistryFlag(findings as Record<string, unknown>),

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -1,7 +1,13 @@
-import { Effect, Layer, Schema, Stream } from 'effect'
+import { Effect, Layer, Logger, Schema, Stream } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { NoRegistry, ProviderError, UnsupportedSite } from '../domain/errors'
+import {
+	BudgetExceeded,
+	MonthlyCapExceeded,
+	NoRegistry,
+	ProviderError,
+	UnsupportedSite,
+} from '../domain/errors'
 import { RegistryRecord, ScrapedPage, SearchResult } from '../domain/types'
 import { StubRegistryEsProvider } from '../infrastructure/stub/registry-es'
 import { StubScrapeProvider } from '../infrastructure/stub/scrape'
@@ -1367,5 +1373,271 @@ describe('looking up a country Batuda has no register for', () => {
 		expect(charged).toEqual([])
 		expect(asked).toBe(0)
 		expect(JSON.stringify(results[results.length - 1])).toContain('no_registry')
+	})
+})
+
+describe('a run that spends its budget', () => {
+	// Running out of budget is how a run is meant to stop, so it must be reported
+	// as the ordinary stop it is: at warning, and with the tool named once. Catch
+	// it as an expected stop and then again as a failure and the telemetry fills
+	// with errors for something normal, while the model reads
+	// "web_search: web_search: cheap budget exhausted".
+
+	// Every log line written while a tool runs, so what was recorded — and at what
+	// level — can be asserted rather than inferred.
+	const capturedLogs = (
+		lines: Array<{ level: string; message: string }>,
+	): Layer.Layer<never> =>
+		Logger.layer([
+			Logger.make(options => {
+				lines.push({
+					level: String(options.logLevel),
+					message: String(options.message),
+				})
+			}),
+		])
+
+	// A budget with nothing left in either tier, so any tool that charges before
+	// calling its vendor is refused.
+	const spentBudget = (remaining: number) =>
+		Layer.succeed(Budget)(
+			Budget.of({
+				chargeCheap: (_provider, cents) =>
+					Effect.fail(
+						new BudgetExceeded({
+							tier: 'cheap',
+							needed: cents,
+							remaining,
+						}),
+					),
+				chargePaid: () => Effect.succeed(true),
+				withPaidCharge: (_provider, cents) => () =>
+					Effect.fail(
+						new BudgetExceeded({
+							tier: 'paid-run',
+							needed: cents,
+							remaining,
+						}),
+					),
+				snapshot: () =>
+					Effect.succeed({
+						cheapBudget: 1000,
+						cheapSpent: 1000 - remaining,
+						cheapRemaining: remaining,
+						paidBudget: 1000,
+						paidSpent: 1000 - remaining,
+						paidRemaining: remaining,
+					}),
+			}),
+		)
+
+	// Drive one tool against a spent budget and report both what the model was
+	// handed and everything that was logged on the way.
+	const exhausted = async (
+		tool: 'web_search' | 'scrape_page' | 'registry_lookup',
+		params: Record<string, unknown>,
+		budget: Layer.Layer<Budget> = spentBudget(7),
+	): Promise<{
+		description: string
+		isFailure: boolean
+		logs: ReadonlyArray<{ level: string; message: string }>
+	}> => {
+		const logs: Array<{ level: string; message: string }> = []
+		const ports = Layer.mergeAll(
+			StubSearchProvider,
+			StubScrapeProvider,
+			StubRegistryEsProvider,
+			budget,
+			stubRunContext,
+			Layer.succeed(ContactDiscovery)({
+				discover: () =>
+					Effect.succeed({
+						status: 'no_reliable_contact' as const,
+						researchId: 'test-run',
+					}),
+			}),
+		)
+		const results = await Effect.runPromise(
+			Effect.gen(function* () {
+				const toolkit = yield* researchToolkit
+				const stream = yield* toolkit.handle(tool, params as never)
+				return yield* Stream.runCollect(stream)
+			}).pipe(
+				Effect.provide(researchToolkitLayer.pipe(Layer.provide(ports))),
+				Effect.provide(capturedLogs(logs)),
+			),
+		)
+		const last = results[results.length - 1]
+		return {
+			description: (last?.result as { reason?: { description?: string } })
+				?.reason?.description as string,
+			isFailure: last?.isFailure ?? false,
+			logs,
+		}
+	}
+
+	describe('when the cheap budget refuses a search', () => {
+		it('should tell the model to stop, naming the tool once', async () => {
+			// GIVEN a run with 7¢ of cheap budget left and a search to make
+			const { description, isFailure } = await exhausted('web_search', {
+				query: 'acme corp',
+				limit: null,
+				recency_days: null,
+				location: null,
+			})
+
+			// THEN the model reads one tool name in front of one sentence
+			expect(isFailure).toBe(true)
+			expect(description).toBe(
+				'web_search: cheap budget exhausted (7¢ left) — stop searching and summarize what you have',
+			)
+		})
+
+		it('should record the stop at warning and not as a failure', async () => {
+			// GIVEN the same refused search
+			const { logs } = await exhausted('web_search', {
+				query: 'acme corp',
+				limit: null,
+				recency_days: null,
+				location: null,
+			})
+
+			// THEN it is logged once, at warning — an investigation into error-level
+			// tool failures never has to sift ordinary budget stops out of them
+			expect(logs).toContainEqual({
+				level: 'Warn',
+				message: 'research.tool.budget_exhausted',
+			})
+			expect(
+				logs.filter(line => line.message.includes('research.tool.failed')),
+			).toEqual([])
+		})
+	})
+
+	describe('when the cheap budget refuses a page fetch', () => {
+		it('should report it the same way it reports a refused search', async () => {
+			// GIVEN a run with 7¢ left and a page to fetch
+			const { description, isFailure, logs } = await exhausted('scrape_page', {
+				url: 'https://acme.example',
+			})
+
+			// THEN the message names scrape_page once and the stop is a warning
+			expect(isFailure).toBe(true)
+			expect(description).toBe(
+				'scrape_page: cheap budget exhausted (7¢ left) — stop searching and summarize what you have',
+			)
+			expect(logs).toContainEqual({
+				level: 'Warn',
+				message: 'research.tool.budget_exhausted',
+			})
+			expect(
+				logs.filter(line => line.message.includes('research.tool.failed')),
+			).toEqual([])
+		})
+	})
+
+	describe('when the paid budget refuses a register lookup', () => {
+		it('should name the tool once', async () => {
+			// GIVEN a run whose paid tier has 7¢ left and a register to ask
+			const { description, isFailure } = await exhausted('registry_lookup', {
+				country: 'ES',
+				query: 'Acme SL',
+				tax_id: null,
+			})
+
+			// THEN the model reads the tool's name once, as it does on the cheap tier
+			expect(isFailure).toBe(true)
+			expect(description).toBe(
+				'registry_lookup: paid budget exhausted (7¢ left) — stop using registry_lookup',
+			)
+		})
+	})
+
+	describe('when the month’s paid cap is reached', () => {
+		it('should name the tool once', async () => {
+			// GIVEN an organization that has spent its whole monthly paid allowance
+			const cappedBudget = Layer.succeed(Budget)(
+				Budget.of({
+					chargeCheap: () => Effect.void,
+					chargePaid: () => Effect.succeed(true),
+					withPaidCharge: () => () =>
+						Effect.fail(
+							new MonthlyCapExceeded({ capCents: 5000, spentCents: 5000 }),
+						),
+					snapshot: () =>
+						Effect.succeed({
+							cheapBudget: 1000,
+							cheapSpent: 0,
+							cheapRemaining: 1000,
+							paidBudget: 1000,
+							paidSpent: 0,
+							paidRemaining: 1000,
+						}),
+				}),
+			)
+			const { description, isFailure } = await exhausted(
+				'registry_lookup',
+				{ country: 'ES', query: 'Acme SL', tax_id: null },
+				cappedBudget,
+			)
+
+			// THEN the cap is reported like every other stop: one tool name
+			expect(isFailure).toBe(true)
+			expect(description).toBe(
+				'registry_lookup: monthly paid cap reached (5000/5000¢) — stop using registry_lookup',
+			)
+		})
+	})
+
+	describe('when a vendor genuinely fails', () => {
+		it('should still be logged as a failure, named once', async () => {
+			// GIVEN a search provider that returns a 422 while the budget is healthy
+			const logs: Array<{ level: string; message: string }> = []
+			const ports = Layer.mergeAll(
+				Layer.succeed(SearchProvider)(
+					SearchProvider.of({
+						search: () =>
+							Effect.fail(
+								new ProviderError({
+									provider: 'brave',
+									message: 'search failed: HTTP 422',
+									recoverable: false,
+								}),
+							),
+					}),
+				),
+				StubScrapeProvider,
+				StubRegistryEsProvider,
+				testInfra,
+			)
+			const results = await Effect.runPromise(
+				Effect.gen(function* () {
+					const toolkit = yield* researchToolkit
+					const stream = yield* toolkit.handle('web_search', {
+						query: 'acme corp',
+						limit: null,
+						recency_days: null,
+						location: null,
+					})
+					return yield* Stream.runCollect(stream)
+				}).pipe(
+					Effect.provide(researchToolkitLayer.pipe(Layer.provide(ports))),
+					Effect.provide(capturedLogs(logs)),
+				),
+			)
+
+			// THEN letting the budget stop past the failure logger has not made it
+			// blind to a real failure, and the message still names the tool once
+			const last = results[results.length - 1]
+			expect(last?.isFailure).toBe(true)
+			expect(
+				(last?.result as { reason?: { description?: string } })?.reason
+					?.description,
+			).toBe('web_search: search failed: HTTP 422')
+			expect(logs).toContainEqual({
+				level: 'Error',
+				message: 'research.tool.failed',
+			})
+		})
 	})
 })

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -29,6 +29,7 @@ import { AcceptedCountry, isRegistryCountry } from '../domain/country'
 import {
 	alreadyLookedUpResult,
 	approvalRequiredResult,
+	BudgetExceeded,
 	noRegistryResult,
 } from '../domain/errors'
 import { ScrapedPage } from '../domain/types'
@@ -303,6 +304,12 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 			entityName,
 		} = yield* ResearchRunContext
 
+		// Each tool below reports a failure in three steps, in this order: log an
+		// unexpected one, turn an expected stop into the sentence the model should
+		// read, then put the tool's name in front of whatever is left. Only that
+		// last step names the tool, so a message an earlier step wrote reaches the
+		// model with its tool named once.
+
 		// Charged against the run before each vendor call (cheap tier for
 		// search/scrape, paid tier for the registry). When the budget
 		// refuses, the refusal is handed back to the model as a tool result so it
@@ -318,7 +325,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 						remaining_cents: e.remaining,
 					}),
 					Effect.andThen(
-						mapToolError(toolName)(
+						Effect.fail(
 							`cheap budget exhausted (${e.remaining}¢ left) — stop searching and summarize what you have`,
 						),
 					),
@@ -331,15 +338,22 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 		// tool result, so it shows up in Honeycomb regardless of what kind of
 		// failure it was.
 		const logToolFailure =
-			(toolName: string) => (cause: Cause.Cause<unknown>) =>
+			(toolName: string) =>
+			<E>(cause: Cause.Cause<E>) =>
 				Effect.logError('research.tool.failed').pipe(
 					Effect.annotateLogs({
 						tool: toolName,
 						'research.run_id': researchId,
 						cause: Cause.pretty(cause),
 					}),
-					Effect.andThen(mapToolError(toolName)(cause)),
 				)
+
+		// Which causes that logger is for. The budget refusing a call is the run
+		// working as intended and is reported at warning by the handler above, so
+		// logging it here as well would send every ordinary budget stop to the
+		// telemetry as an error.
+		const isUnexpectedFailure = <E>(cause: Cause.Cause<E>): boolean =>
+			!(Cause.squash(cause) instanceof BudgetExceeded)
 
 		// A scrape the provider refuses (or one of the known people directories) is
 		// logged as a skip, not a failure, so it stays queryable without the
@@ -398,8 +412,9 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 						languages: hintLanguage ? [hintLanguage] : undefined,
 					})
 				}).pipe(
+					Effect.tapCauseIf(isUnexpectedFailure, logToolFailure('web_search')),
 					Effect.catchTag('BudgetExceeded', cheapExhausted('web_search')),
-					Effect.catchCause(logToolFailure('web_search')),
+					Effect.catchCause(mapToolError('web_search')),
 					Effect.withSpan('research.tool.web_search', {
 						attributes: {
 							'research.tool': 'web_search',
@@ -433,8 +448,9 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					// skip the URL and let the loop keep going, rather than logging a
 					// failure and handing the model an error it can't act on.
 					Effect.catchTag('UnsupportedSite', e => skipUnsupportedScrape(e.url)),
+					Effect.tapCauseIf(isUnexpectedFailure, logToolFailure('scrape_page')),
 					Effect.catchTag('BudgetExceeded', cheapExhausted('scrape_page')),
-					Effect.catchCause(logToolFailure('scrape_page')),
+					Effect.catchCause(mapToolError('scrape_page')),
 					Effect.withSpan('research.tool.scrape_page', {
 						attributes: {
 							'research.tool': 'scrape_page',
@@ -479,13 +495,16 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					Effect.catchTag('NoRegistry', e =>
 						Effect.succeed(noRegistryResult(e.country)),
 					),
+					// Both stops fail with the bare sentence and let the catch-all below
+					// put the tool's name in front of it, so the model reads that name
+					// once rather than once from here and again from there.
 					Effect.catchTag('BudgetExceeded', e =>
-						mapToolError('registry_lookup')(
+						Effect.fail(
 							`paid budget exhausted (${e.remaining}¢ left) — stop using registry_lookup`,
 						),
 					),
 					Effect.catchTag('MonthlyCapExceeded', e =>
-						mapToolError('registry_lookup')(
+						Effect.fail(
 							`monthly paid cap reached (${e.spentCents}/${e.capCents}¢) — stop using registry_lookup`,
 						),
 					),


### PR DESCRIPTION
## What

When Batuda researches something for you, the run tells you how it went — succeeded, needs a look, found nothing. Five of those reports were saying things that were not true. A scan that found four companies when it should have found forty reported plain success and stopped. Every "who are this company's competitors" scan was quietly graded as having found nothing, whatever it actually found. A scan launched from a company on file could report success over an empty list. And an ordinary "you've used up this run's budget" — the intended way a run stops spending — was recorded as a system error, with the message handed to the model naming its own tool twice.

This fixes all five. It is backend only, in the Research context (`packages/research`, the part of the system that goes and reads the web); nothing in the CRM, the web app, or the API surface changes.

## The fix

- **A thin result no longer reports as a full one.** The retry and the honest "found nothing" both keyed on the list being *exactly* empty, so one result was accepted as readily as forty. A thin threshold now sits beside that check: under five results a scan takes its one refined retry, and if it is still thin it finishes as `succeeded_low_confidence` — the status that means "a person should read this". Only an outright empty list is still reported as nothing found, because four real companies are a thin answer, not no answer.
- **Competitor scans are graded like prospect scans.** The check for "is this run a scan?" named `prospect_scan_v1` alone. A competitor scan therefore escaped the vetted-against-one-source check, *and* was measured against a company profile it never fills — so it reported a grounding score of zero on every run, which is precisely the false failing grade the module's own comment says it avoids for scans. There is now one list of scan kinds, and every question about a scan reads it.
- **A scan pinned to a company gets the same treatment as an open-ended one.** Both the retry and the honest empty outcome were additionally gated on the run having no anchor company, so "find this company's competitors" — the live path — got neither. It gets both now. It keeps phase 2's own grounded extraction (which reads the company's own site first, re-checks the pages the run cited, and can downgrade the entity verdict), so the retry measures the list in phase 1 and hands its findings on only when there is no anchor. The retry prompt also carries the anchor instruction the first pass had; without it, a second search goes looking for *anyone's* competitors.
- **Whether the retry fired is recorded.** It was computed, returned, and then read by nothing. It now lands on the run's `quality` block and on the phase-1 trace, so how much the retry is worth can be measured without scraping logs — it is the main lever on a thin result. An empty scan that never got a retry also stops claiming "even after a refined retry".
- **Running out of budget is reported as the ordinary stop it is.** It was caught as an expected stop, logged at warning — and then caught *again* by the failure handler, which logged it at error and re-prefixed the message. Every budget-exhausted run therefore emitted error-level telemetry for something entirely normal, and the model read `web_search: web_search: cheap budget exhausted (7¢ left)`. Each tool now logs an unexpected failure, turns an expected stop into the sentence the model should read, and names the tool exactly once at the end. The register's paid-budget and monthly-cap messages named it twice for the same reason and now name it once.

## Impact

- **No migration, no schema change, no new env vars.** Nothing to run before or after the server tag.
- **More runs will finish `succeeded_low_confidence` than before** — a thin scan now asks to be read. That status already exists and is already handled everywhere (research inbox "Needs review", run detail, the apply flow, `get_pipeline`'s `researchAwaitingReview`), so nothing new has to learn about it. It also means a thin scan is no longer written to the research cache, since only a full `succeeded` run is cached — an identical repeat gets a fresh attempt instead of a cached thin one.
- **Wire shape:** the `quality` block inside a run's findings gains an optional `refined` boolean on scan runs. Purely additive; the frontend reads `quality.low_confidence` and ignores the rest.
- **Cost:** a scan that comes back thin now spends one more agent pass, where before only an outright empty one did — still capped at one retry, and still only when the budget affords it. An anchored discovery scan also pays one extra extraction call, which is what buys it the ability to notice it came back thin before the budget scope closes.
- **Both MCP and HTTP** get this identically — it is inside the shared research service, below either transport.
- No change to tenant isolation, `organization_id` scoping, RLS roles, auth, CORS, webhooks, or paid-provider selection.

## Review guide

- **Start at `packages/research/src/application/research-service.ts`, the phase-1 block around the discovery-scan retry.** That is the riskiest hunk: removing the anchor gate changes routing on a live path. The thing to check is the `findings: entityTargets === null ? findings : undefined` on the phase's return — that is what keeps an anchored scan on phase 2's grounded extraction instead of short-circuiting to the probe's findings, which would have cost it the cited-page re-check and the entity downgrade.
- **`packages/research/src/application/tools.ts`** is the other one worth reading closely: the handler order per tool is now log → expected-stop → name-once, and the order matters. `isUnexpectedFailure` is what lets a budget stop past the failure logger.
- `discovery-scan.ts` and `research-quality.ts` are small and self-contained; the test files are long but mechanical.
- **A decision you might overrule:** five as the thin threshold is my call — the issue asked for a threshold without naming one. It catches the reported four-result run and costs at most one extra retry pass on a genuinely small market. Three would be more conservative and would let that four-result run through.
- **What I could not verify:** I did not execute a research run against the real vendors, because that spends real money on Firecrawl / Brave / libreBORME. The pipeline is covered end-to-end with stub providers instead (below). Snyk was not run — this change touches no external input, parser, or auth boundary.

## Tests

- Unit: the thin threshold and result count (including the boundary at exactly five, a list of the wrong type, and a scan reading another scan's field), competitor-vs-prospect grading parity, the `refined` marker, and the empty-scan message with and without a retry.
- Unit, through the real toolkit layer: a spent cheap budget on `web_search` and `scrape_page` yields one tool name and a warning-level log with no `research.tool.failed`; the register's paid-budget and monthly-cap messages name the tool once; and a genuine vendor failure is *still* logged at error and still named once — the regression that letting budget stops past could have introduced.
- Integration, driving the whole run fiber against real Postgres with stub providers and stub models (`apps/server/src/services/research-scan-reporting.integration.test.ts`): a thin open-ended scan retries and finishes `succeeded_low_confidence`; a competitor scan pinned to a company, finding nobody, retries and finishes `no_reliable_data`. **Both fail on `main`** — I ran them against the pre-change research package to confirm they actually pin the behavior rather than passing either way.

## Verification

- `pnpm install`, `pnpm -w check-types` (13/13), `pnpm -w test` (21/21 packages), `pnpm -w build` (13/13) — all run, all green.
- `pnpm --filter @batuda/server test:integration` against this worktree's Postgres: 97 files, 685 tests, all passing.
- Booted the server against the worktree's stack (`pnpm dev:server`) and confirmed `/health` returns ok, so the research layer graph still builds at runtime.
- No UI in this change, so no screenshots.

Closes #437
