### PR TITLE
feat(server): let an assistant unblock a company's own mailbox

### DIFF
--- a/apps/server/src/main.boot.test.ts
+++ b/apps/server/src/main.boot.test.ts
@@ -14,13 +14,42 @@
 
 import { type ChildProcess, spawn } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { createServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-const PORT = 34_040
+/**
+ * A port nothing else on this machine is listening on.
+ *
+ * Asking the operating system beats naming a number: a fixed one is taken by
+ * whatever else happens to be up — another run of this suite, a dev server, an
+ * unrelated job sharing a CI runner — and the server then boots, fails to bind,
+ * and sits there saying nothing until the health wait gives up twenty seconds
+ * later. That reads as a slow boot rather than as the collision it is.
+ *
+ * The port is released before the server claims it, so something else could in
+ * principle take it in that gap. That window is a moment wide, against a fixed
+ * number that clashes for as long as the other holder is up.
+ */
+const freePort = (): Promise<number> =>
+	new Promise((resolve, reject) => {
+		const probe = createServer()
+		probe.on('error', reject)
+		probe.listen(0, '127.0.0.1', () => {
+			const found = probe.address()
+			if (found === null || typeof found === 'string') {
+				probe.close()
+				reject(new Error('the operating system named no port'))
+				return
+			}
+			probe.close(() => resolve(found.port))
+		})
+	})
+
+const PORT = await freePort()
 
 // The env the deployed instance actually boots with is the union of two
 // sources: the non-secret config baked into `config.production.json`, and the

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -25,6 +25,7 @@ import {
 
 import {
 	addChannel,
+	clearEmailSuppression,
 	deleteChannel,
 	deleteSubjectChannels,
 	patchChannel,
@@ -176,9 +177,10 @@ const CreateCompanies = Tool.make('create_companies', {
 
 const UpdateCompany = Tool.make('update_company', {
 	description:
-		'Update one or more fields on an existing company by UUID. Only include fields to change; omitted fields stay unchanged.',
+		"Update one or more fields on an existing company by UUID. Only include fields to change; omitted fields stay unchanged. Set clear_email_suppression=true to let mail go to the company's own mailboxes again after a bounce or a spam report turns out to have been wrong — a role address like info@ or orders@ has nobody listed under it, so nothing on a contact can lift its block. It frees every one of the company's own mailboxes at once, and any that bounces again is held straight back. A branch's mailbox — one added with site_id — is held separately and is not freed by this; there is no way to lift one yet.",
 	parameters: Schema.Struct({
 		id: Schema.String,
+		clear_email_suppression: Schema.optional(Schema.Boolean),
 		name: Schema.optional(Schema.String),
 		taxId: Schema.optional(Schema.String).annotate({
 			description:
@@ -280,7 +282,7 @@ const ManageCompanySites = Tool.make('manage_company_sites', {
 // switchboard only by `site_id`, so a second tool would duplicate the lot.
 const ManageCompanyChannels = Tool.make('manage_company_channels', {
 	description:
-		"The ways of reaching a company — its mailboxes, phones, website, social handles. A company can hold several of a kind, which is the point of this tool: `update_company` writes one email and one phone, and a firm with an orders mailbox, an accounts mailbox and a switchboard needs all of them kept apart. Give each one a `label` in the words somebody would actually use — 'orders', 'accounts', 'Girona shop' — because two addresses with no labels are indistinguishable a month later. Pass `site_id` to hang the channel off one branch instead of the company as a whole. action: 'list' (all of them; add site_id to see one branch's), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). An address the company already holds is refused rather than merged, so correcting one onto another means removing the spare instead. kind is open — email, phone, linkedin, instagram, website, x, bluesky, … — and `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind. `verification` only ever lowers how far an address is trusted, and only on 'update' — pass null to take a verdict back off entirely, which says nobody has checked rather than that a check came back doubtful. A later check can raise it again. 'vouch' (by channel_id, email only) is the way to get a held-back send out: it records that a person stands behind the address, so send_email stops asking about it, while leaving what a deliverability check found on file — unlike clearing the verdict, which lifts the stop by throwing the finding away. Pass `note` to say what that rests on. It is refused on an address that hard-bounced or reported spam, which no vouch lifts. 'unvouch' takes a vouch back; it only ever lifts a vouch and never clears a bounce.",
+		"The ways of reaching a company — its mailboxes, phones, website, social handles. A company can hold several of a kind, which is the point of this tool: `update_company` writes one email and one phone, and a firm with an orders mailbox, an accounts mailbox and a switchboard needs all of them kept apart. Give each one a `label` in the words somebody would actually use — 'orders', 'accounts', 'Girona shop' — because two addresses with no labels are indistinguishable a month later. Pass `site_id` to hang the channel off one branch instead of the company as a whole. action: 'list' (all of them; add site_id to see one branch's), 'add' (kind plus value, and a label whenever there is more than one of that kind), 'update' (by channel_id, only the fields to change), 'remove' (by channel_id). An address the company already holds is refused rather than merged, so correcting one onto another means removing the spare instead. kind is open — email, phone, linkedin, instagram, website, x, bluesky, … — and `is_primary` marks the one to use when nothing says otherwise; the primary email is the address mail is sent to, and removing it hands that over to the oldest one left of the same kind. `verification` only ever lowers how far an address is trusted, and only on 'update' — pass null to take a verdict back off entirely, which says nobody has checked rather than that a check came back doubtful. A later check can raise it again. 'vouch' (by channel_id, email only) is the way to get a held-back send out: it records that a person stands behind the address, so send_email stops asking about it, while leaving what a deliverability check found on file — unlike clearing the verdict, which lifts the stop by throwing the finding away. Pass `note` to say what that rests on. It is refused on an address that hard-bounced or reported spam — that block is real, and lifting it is update_company's clear_email_suppression, which reaches the company's own mailboxes but not a branch's. 'unvouch' takes a vouch back; it only ever lifts a vouch and never clears a bounce.",
 	parameters: Schema.Struct({
 		action: Schema.Literals([
 			'list',
@@ -482,7 +484,7 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 					),
 					Effect.orDie,
 				),
-			update_company: ({ id, ...fields }) =>
+			update_company: ({ id, clear_email_suppression, ...fields }) =>
 				Effect.gen(function* () {
 					// Capture the stage before the write so an agent-driven change
 					// is recorded on the timeline too (actor unknown → null).
@@ -513,6 +515,13 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 						to: fields.status,
 						actorUserId: null,
 					}).pipe(Effect.provideService(TimelineActivityService, timeline))
+					// Runs after the update, so an edit that fails lifts nothing.
+					if (clear_email_suppression) {
+						yield* clearEmailSuppression(sql, {
+							table: 'companies' as const,
+							id,
+						})
+					}
 					return result
 				}).pipe(
 					Effect.catchTag('BadRequest', e =>

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -177,7 +177,7 @@ const CreateCompanies = Tool.make('create_companies', {
 
 const UpdateCompany = Tool.make('update_company', {
 	description:
-		"Update one or more fields on an existing company by UUID. Only include fields to change; omitted fields stay unchanged. Set clear_email_suppression=true to let mail go to the company's own mailboxes again after a bounce or a spam report turns out to have been wrong — a role address like info@ or orders@ has nobody listed under it, so nothing on a contact can lift its block. It frees every one of the company's own mailboxes at once, and any that bounces again is held straight back. A branch's mailbox — one added with site_id — is held separately and is not freed by this; there is no way to lift one yet.",
+		"Update one or more fields on an existing company by UUID. Only include fields to change; omitted fields stay unchanged. Set clear_email_suppression=true to let mail go to the company's own mailboxes again after a bounce or a spam report turns out to have been wrong — a role address like info@ or orders@ has nobody listed under it, so nothing on a contact can lift its block. It frees all of the company's own held-back mailboxes in one go, and any that bounces again is held straight back. An address somebody has vouched for is left as it is — that is not a block, and this does not throw the vouch away. A block is recorded against every record in the organisation holding that address, and this speaks only for the company's own — so if a contact or a branch holds the same address, their copy goes on refusing the send until it is cleared too. A branch's copy cannot be cleared at all yet.",
 	parameters: Schema.Struct({
 		id: Schema.String,
 		clear_email_suppression: Schema.optional(Schema.Boolean),
@@ -722,10 +722,15 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 									'Only an email address is ever held back by a verdict, so only one can be vouched for.',
 								),
 							)
+						// A caller acts on the answer it just got rather than on the tool's
+						// description, so the refusal names the way out — and a branch's
+						// mailbox has none yet.
 						if (outcome === 'suppressed')
 							return yield* Effect.die(
 								new ToolMessage(
-									'That address hard-bounced or reported spam, which no vouch lifts.',
+									subject.table === 'companies'
+										? 'That address hard-bounced or reported spam, which no vouch lifts. Use update_company with clear_email_suppression=true once the mailbox works again.'
+										: "That address hard-bounced or reported spam, which no vouch lifts. It belongs to a branch, and nothing can lift a branch's block yet. Say so rather than trying another way round: the block follows the address itself, so putting the same one somewhere else stays blocked too.",
 								),
 							)
 					}

--- a/apps/server/src/mcp/tools/company-suppression.integration.test.ts
+++ b/apps/server/src/mcp/tools/company-suppression.integration.test.ts
@@ -54,10 +54,10 @@ let org: Org
 let actorId: string
 
 const toolMessageOf = (cause: Cause.Cause<unknown>): string => {
-	const spoken = Cause.squash(cause)
-	return isToolMessage(spoken)
-		? spoken.message
-		: `not a message written for the caller: ${String(spoken)}`
+	const failure = Cause.squash(cause)
+	return isToolMessage(failure)
+		? failure.message
+		: `not a message written for the caller: ${String(failure)}`
 }
 
 const runInOrg = <A, E>(
@@ -86,19 +86,53 @@ const updateCompany = (params: Record<string, unknown>): Promise<void> =>
 		}).pipe(
 			Effect.provideService(CurrentUser, actor()),
 			Effect.provide(Handlers),
-			// Surfaces what the tool said rather than the whole cause, which carries
-			// stack frames and SQL and would make any failure read alike.
+			// Keeps what the tool said rather than the whole cause, so a failing test
+			// names the refusal instead of stack frames and SQL.
 			Effect.catchCause(cause => Effect.die(new Error(toolMessageOf(cause)))),
 		),
 	)
 
+// Hands back the sentence the tool refused with, which is the part a caller
+// acts on.
+const vouchRefusal = (companyId: string, channelId: string): Promise<string> =>
+	runInOrg(
+		Effect.gen(function* () {
+			const toolkit = yield* CompanyTools
+			const stream = yield* toolkit.handle('manage_company_channels', {
+				action: 'vouch',
+				company_id: companyId,
+				channel_id: channelId,
+			} as never)
+			yield* Stream.runCollect(stream)
+			throw new Error('expected the vouch to be refused, but it was accepted')
+		}).pipe(
+			Effect.provideService(CurrentUser, actor()),
+			Effect.provide(Handlers),
+			Effect.catchCause(cause => Effect.succeed(toolMessageOf(cause))),
+		),
+	)
+
 const seedCompany = async (suffix: string): Promise<string> => {
-	const r = await pool.query<{ id: string }>(
+	const inserted = await pool.query<{ id: string }>(
 		`INSERT INTO companies (organization_id, slug, name, status)
 		 VALUES ($1, $2, $3, 'prospect') RETURNING id`,
 		[org.id, `${MARKER}-${suffix}`, `${MARKER} ${suffix}`],
 	)
-	return r.rows[0]!.id
+	return inserted.rows[0]!.id
+}
+
+// A vouch shares a column with a bounce, which is what puts it in reach of a
+// call meant only to lift blocks.
+const seedVouchedMailbox = async (
+	companyId: string,
+	address: string,
+): Promise<void> => {
+	await pool.query(
+		`INSERT INTO channels
+		   (organization_id, subject_table, subject_id, channel, address, status, status_reason, soft_bounce_count)
+		 VALUES ($1, 'companies', $2, 'email', $3, 'valid', 'Confirmed by the office manager', 2)`,
+		[org.id, companyId, address],
+	)
 }
 
 const seedHeldMailbox = async (
@@ -114,23 +148,24 @@ const seedHeldMailbox = async (
 	)
 }
 
-const heldStateOf = async (
+const mailboxStateOf = async (
+	companyId: string,
 	address: string,
 ): Promise<{
 	status: string
 	statusReason: string | null
 	softBounceCount: number
 } | null> => {
-	const r = await pool.query<{
+	const found = await pool.query<{
 		status: string
 		status_reason: string | null
 		soft_bounce_count: number
 	}>(
 		`SELECT status, status_reason, soft_bounce_count FROM channels
-		 WHERE subject_table = 'companies' AND address = $1`,
-		[address],
+		 WHERE subject_table = 'companies' AND subject_id = $1 AND address = $2`,
+		[companyId, address],
 	)
-	const row = r.rows[0]
+	const row = found.rows[0]
 	return row === undefined
 		? null
 		: {
@@ -140,18 +175,23 @@ const heldStateOf = async (
 			}
 }
 
-const statusOf = async (address: string): Promise<string | null> =>
-	(await heldStateOf(address))?.status ?? null
+const statusOf = async (
+	companyId: string,
+	address: string,
+): Promise<string | null> =>
+	(await mailboxStateOf(companyId, address))?.status ?? null
 
 beforeAll(async () => {
 	pool = new pg.Pool({ connectionString: DATABASE_URL })
 	runtime = makeRuntime()
+
 	const orgs = await pool.query<Org>(
 		`SELECT id, name, slug FROM organization WHERE slug = 'taller' LIMIT 1`,
 	)
 	const taller = orgs.rows[0]
 	if (!taller) throw new Error("taller org missing — run 'pnpm cli seed'")
 	org = taller
+
 	const members = await pool.query<{ userId: string }>(
 		'SELECT "userId" FROM member WHERE "organizationId" = $1 LIMIT 1',
 		[org.id],
@@ -185,9 +225,9 @@ describe('update_company with clear_email_suppression', () => {
 			await updateCompany({ id: companyId, clear_email_suppression: true })
 
 			// THEN the address is back to nobody having judged it, which is the
-			// state the send gate lets through — and nothing of the old block is
-			// left behind, or the next soft bounce would tip it straight back
-			expect(await heldStateOf(address)).toEqual({
+			// state the send gate lets through, and nothing of the old block is left
+			// behind for the next soft bounce to count from
+			expect(await mailboxStateOf(companyId, address)).toEqual({
 				status: 'unknown',
 				statusReason: null,
 				softBounceCount: 0,
@@ -208,11 +248,37 @@ describe('update_company with clear_email_suppression', () => {
 			// WHEN the block is lifted once
 			await updateCompany({ id: companyId, clear_email_suppression: true })
 
-			// THEN both are freed, which is what the description promises. Free only
-			// one and a caller that trusts it goes on writing to an address still
-			// held back.
-			expect(await statusOf(orders)).toBe('unknown')
-			expect(await statusOf(accounts)).toBe('unknown')
+			// THEN both are freed, which is what the tool description promises a
+			// caller that goes on to write to either of them
+			expect(await statusOf(companyId, orders)).toBe('unknown')
+			expect(await statusOf(companyId, accounts)).toBe('unknown')
+		})
+	})
+
+	describe('when one of the company mailboxes was vouched for, not blocked', () => {
+		it('should lift the block and leave the vouch standing', async () => {
+			// GIVEN a company holding both: one mailbox held back after a bounce, and
+			// another somebody put their name to. Both states live in the same
+			// column, which is what makes this worth pinning.
+			const companyId = await seedCompany('vouched')
+			const blocked = `info-blocked@${MARKER}.example`
+			const vouched = `orders-vouched@${MARKER}.example`
+			await seedHeldMailbox(companyId, blocked, 'bounced')
+			await seedVouchedMailbox(companyId, vouched)
+
+			// WHEN the block is lifted
+			await updateCompany({ id: companyId, clear_email_suppression: true })
+
+			// THEN the blocked one is freed and the vouch stands, note and all — a
+			// vouch is somebody's word on an address, and only 'unvouch' takes it
+			// back. Its soft-bounce tally stands with it, this call reaching only
+			// the addresses a block holds back.
+			expect(await statusOf(companyId, blocked)).toBe('unknown')
+			expect(await mailboxStateOf(companyId, vouched)).toEqual({
+				status: 'valid',
+				statusReason: 'Confirmed by the office manager',
+				softBounceCount: 2,
+			})
 		})
 	})
 
@@ -228,7 +294,32 @@ describe('update_company with clear_email_suppression', () => {
 
 			// THEN the block stands. Lifting one is somebody deciding the address
 			// works again, never a side effect of editing the company.
-			expect(await statusOf(address)).toBe('bounced')
+			expect(await statusOf(companyId, address)).toBe('bounced')
+		})
+	})
+})
+
+describe('manage_company_channels vouching', () => {
+	describe('when somebody vouches for a mailbox a bounce holds back', () => {
+		it('should name the way out, not just the refusal', async () => {
+			// GIVEN a company mailbox held back after a bounce
+			const companyId = await seedCompany('refusal')
+			const address = `info-refusal@${MARKER}.example`
+			await seedHeldMailbox(companyId, address, 'bounced')
+			const heldMailbox = await pool.query<{ id: string }>(
+				`SELECT id FROM channels WHERE subject_table = 'companies' AND address = $1`,
+				[address],
+			)
+			const channelId = heldMailbox.rows[0]!.id
+
+			// WHEN somebody tries to vouch for it, which no vouch can lift
+			const refusal = await vouchRefusal(companyId, channelId)
+
+			// THEN the refusal names where the way out is, a caller acting on the
+			// answer it just got rather than on the tool's description
+			expect(refusal).toContain('no vouch lifts')
+			expect(refusal).toContain('update_company')
+			expect(refusal).toContain('clear_email_suppression')
 		})
 	})
 })

--- a/apps/server/src/mcp/tools/company-suppression.integration.test.ts
+++ b/apps/server/src/mcp/tools/company-suppression.integration.test.ts
@@ -1,0 +1,234 @@
+// Live-DB integration test for letting mail go to a company's own mailboxes
+// again, driven through the real toolkit handler the way a `tools/call` would,
+// inside the same org RLS scope (`enterOrgScope`) the /mcp middleware applies.
+//
+// A role address — info@, orders@ — has nobody listed under it, so nothing that
+// speaks for a person can lift its block. That is the whole reason this sits on
+// `update_company` rather than on a contact.
+//
+// Prereq: `pnpm cli services up` — the integration runner's globalSetup builds,
+// migrates and seeds the disposable database this suite runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Cause, Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../../db/client'
+import { EnvVars } from '../../lib/env'
+import { enterOrgScope } from '../../middleware/org'
+import { CompanyService } from '../../services/companies'
+import { Geocoder } from '../../services/geocoder'
+import { TimelineActivityService } from '../../services/timeline-activity'
+import { applyTestEnv } from '../../test-env'
+import { CurrentUser } from '../current-user'
+import { isToolMessage } from '../tool-message'
+import { CompanyHandlersLive, CompanyTools } from './companies'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+// Namespaces every row this suite creates so cleanup never touches seed data.
+const MARKER = `unblock-${randomUUID()}`
+
+type Org = { id: string; name: string; slug: string }
+
+const Handlers = CompanyHandlersLive.pipe(
+	Layer.provide(CompanyService.layer),
+	Layer.provide(TimelineActivityService.layer),
+	Layer.provide(Geocoder.layer),
+	Layer.provide(FetchHttpClient.layer),
+)
+
+const makeRuntime = () =>
+	ManagedRuntime.make(PgLive.pipe(Layer.provide(EnvVars.layer)))
+
+let pool: pg.Pool
+let runtime: ReturnType<typeof makeRuntime>
+let org: Org
+let actorId: string
+
+const toolMessageOf = (cause: Cause.Cause<unknown>): string => {
+	const spoken = Cause.squash(cause)
+	return isToolMessage(spoken)
+		? spoken.message
+		: `not a message written for the caller: ${String(spoken)}`
+}
+
+const runInOrg = <A, E>(
+	body: Effect.Effect<A, E, CurrentOrg | SqlClient.SqlClient>,
+): Promise<A> =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org, userId: actorId })(body)
+		}),
+	)
+
+const actor = () => ({
+	userId: actorId,
+	email: `${actorId}@unblock.local`,
+	name: 'Unblocker',
+	isAgent: true,
+})
+
+const updateCompany = (params: Record<string, unknown>): Promise<void> =>
+	runInOrg(
+		Effect.gen(function* () {
+			const toolkit = yield* CompanyTools
+			const stream = yield* toolkit.handle('update_company', params as never)
+			yield* Stream.runCollect(stream)
+		}).pipe(
+			Effect.provideService(CurrentUser, actor()),
+			Effect.provide(Handlers),
+			// Surfaces what the tool said rather than the whole cause, which carries
+			// stack frames and SQL and would make any failure read alike.
+			Effect.catchCause(cause => Effect.die(new Error(toolMessageOf(cause)))),
+		),
+	)
+
+const seedCompany = async (suffix: string): Promise<string> => {
+	const r = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name, status)
+		 VALUES ($1, $2, $3, 'prospect') RETURNING id`,
+		[org.id, `${MARKER}-${suffix}`, `${MARKER} ${suffix}`],
+	)
+	return r.rows[0]!.id
+}
+
+const seedHeldMailbox = async (
+	companyId: string,
+	address: string,
+	status: 'bounced' | 'complained',
+): Promise<void> => {
+	await pool.query(
+		`INSERT INTO channels
+		   (organization_id, subject_table, subject_id, channel, address, status, status_reason, soft_bounce_count)
+		 VALUES ($1, 'companies', $2, 'email', $3, $4, '550 mailbox unavailable', 3)`,
+		[org.id, companyId, address, status],
+	)
+}
+
+const heldStateOf = async (
+	address: string,
+): Promise<{
+	status: string
+	statusReason: string | null
+	softBounceCount: number
+} | null> => {
+	const r = await pool.query<{
+		status: string
+		status_reason: string | null
+		soft_bounce_count: number
+	}>(
+		`SELECT status, status_reason, soft_bounce_count FROM channels
+		 WHERE subject_table = 'companies' AND address = $1`,
+		[address],
+	)
+	const row = r.rows[0]
+	return row === undefined
+		? null
+		: {
+				status: row.status,
+				statusReason: row.status_reason,
+				softBounceCount: row.soft_bounce_count,
+			}
+}
+
+const statusOf = async (address: string): Promise<string | null> =>
+	(await heldStateOf(address))?.status ?? null
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	runtime = makeRuntime()
+	const orgs = await pool.query<Org>(
+		`SELECT id, name, slug FROM organization WHERE slug = 'taller' LIMIT 1`,
+	)
+	const taller = orgs.rows[0]
+	if (!taller) throw new Error("taller org missing — run 'pnpm cli seed'")
+	org = taller
+	const members = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 LIMIT 1',
+		[org.id],
+	)
+	const member = members.rows[0]
+	if (!member) throw new Error("taller has no members — run 'pnpm cli seed'")
+	actorId = member.userId
+})
+
+afterAll(async () => {
+	await pool.query(
+		`DELETE FROM channels WHERE subject_id IN
+		 (SELECT id FROM companies WHERE slug LIKE $1)`,
+		[`${MARKER}%`],
+	)
+	await pool.query('DELETE FROM companies WHERE slug LIKE $1', [`${MARKER}%`])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('update_company with clear_email_suppression', () => {
+	describe('when a company mailbox nobody is listed under is held back', () => {
+		it('should let mail go to it again', async () => {
+			// GIVEN a role address held back after a hard bounce — no contact holds
+			// it, so nothing speaking for a person could lift the block
+			const companyId = await seedCompany('single')
+			const address = `info@${MARKER}.example`
+			await seedHeldMailbox(companyId, address, 'bounced')
+
+			// WHEN an assistant asks for the block to be lifted
+			await updateCompany({ id: companyId, clear_email_suppression: true })
+
+			// THEN the address is back to nobody having judged it, which is the
+			// state the send gate lets through — and nothing of the old block is
+			// left behind, or the next soft bounce would tip it straight back
+			expect(await heldStateOf(address)).toEqual({
+				status: 'unknown',
+				statusReason: null,
+				softBounceCount: 0,
+			})
+		})
+	})
+
+	describe('when the company holds more than one held-back address', () => {
+		it('should free every one of them, as the tool says it does', async () => {
+			// GIVEN two of the company's own mailboxes held back for different
+			// reasons
+			const companyId = await seedCompany('several')
+			const orders = `orders@${MARKER}.example`
+			const accounts = `accounts@${MARKER}.example`
+			await seedHeldMailbox(companyId, orders, 'bounced')
+			await seedHeldMailbox(companyId, accounts, 'complained')
+
+			// WHEN the block is lifted once
+			await updateCompany({ id: companyId, clear_email_suppression: true })
+
+			// THEN both are freed, which is what the description promises. Free only
+			// one and a caller that trusts it goes on writing to an address still
+			// held back.
+			expect(await statusOf(orders)).toBe('unknown')
+			expect(await statusOf(accounts)).toBe('unknown')
+		})
+	})
+
+	describe('when an ordinary edit is made without asking to lift anything', () => {
+		it('should leave the block exactly where it was', async () => {
+			// GIVEN a held-back mailbox on a company being edited for another reason
+			const companyId = await seedCompany('untouched')
+			const address = `info-untouched@${MARKER}.example`
+			await seedHeldMailbox(companyId, address, 'bounced')
+
+			// WHEN a field unrelated to any of this is changed
+			await updateCompany({ id: companyId, industry: 'fusteria' })
+
+			// THEN the block stands. Lifting one is somebody deciding the address
+			// works again, never a side effect of editing the company.
+			expect(await statusOf(address)).toBe('bounced')
+		})
+	})
+})

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -89,7 +89,7 @@ const CreateContact = Tool.make('create_contact', {
 
 const UpdateContact = Tool.make('update_contact', {
 	description:
-		'Update one or more fields on an existing contact by UUID. Only include fields to change. channels[] only adds an address or refreshes one already on file — it never removes or replaces one, so correcting an address here leaves the old one behind and the person ends up holding both. Use manage_contact_channels to correct, remove, label or re-elect a single channel. Set clear_email_suppression=true to reset the email channel to "unknown" (use after a bounced/complained contact confirms their address is good again — this re-enables outbound mail to that address).',
+		'Update one or more fields on an existing contact by UUID. Only include fields to change. channels[] only adds an address or refreshes one already on file — it never removes or replaces one, so correcting an address here leaves the old one behind and the person ends up holding both. Use manage_contact_channels to correct, remove, label or re-elect a single channel. Set clear_email_suppression=true to let mail go again to every held-back address on this contact, after a bounce or a spam report turns out to have been wrong — it lifts blocks and nothing else, so an address somebody has vouched for is left as it is. A block is recorded against every record in the organisation holding that address, and this speaks only for the rows on this contact — so if a company or a branch holds the same address, the block stays in place until those are cleared too.',
 	parameters: Schema.Struct({
 		id: Schema.String,
 		site_id: Schema.optional(Schema.NullOr(Schema.String)).annotate({

--- a/apps/server/src/services/channels.ts
+++ b/apps/server/src/services/channels.ts
@@ -718,6 +718,11 @@ export const suppressedAmong = (
  * gate asks whether an address has bounced anywhere in the organisation, and a
  * bounce is recorded against every record holding it. So an address two people
  * are both listed under stays blocked until both are cleared.
+ *
+ * Only an address a bounce or a complaint holds back is touched. A vouch —
+ * somebody standing behind an address a check doubted — sits in this same
+ * column, and one company or person often holds several mailboxes, so the vouch
+ * on one stays put while the block on another is lifted.
  */
 export const clearEmailSuppression = (
 	sql: Sql,
@@ -732,4 +737,5 @@ export const clearEmailSuppression = (
 		WHERE subject_table = ${subject.table}
 			AND subject_id = ${subject.id}
 			AND channel = 'email'
+			AND status IN ('bounced', 'complained')
 	`


### PR DESCRIPTION
## What

An assistant working through the agent tools could see that a company's own mailbox was blocked from receiving mail, and had nothing to do about it.

A role address — `info@`, `orders@` — has nobody listed under it, and every way of lifting a send-block spoke for a *person*: `update_contact`'s `clear_email_suppression`. [PR 444](https://github.com/guillempuche/batuda/pull/444) gave a person at a keyboard the way out. This is the same door for the agent surface (`apps/server`, MCP tools, CRM context), and it closes the last hole in that trap for a company.

## The fix

`update_company` takes `clear_email_suppression`, exactly as `update_contact` does. The underlying service call was already subject-generic; nothing new happens in the database.

It runs **after** the field update, so an edit that fails never reports having lifted anything.

`manage_company_channels` also stops being a dead end. Its description already refused a vouch on a hard-bounced address — "which no vouch lifts" — with nowhere to send the caller. It now points at where the way out is, the way the contact tool's description already does.

## Impact

No schema change, no new environment variables, no wire-shape change, no change to organisation isolation — the tool runs inside the same org scope as every sibling, and the test drives it through `enterOrgScope` to prove it.

**MCP and HTTP now agree** on this capability: the route landed in PR 444, the tool lands here.

**Two tool descriptions changed**, which is a behavioural change for any model reading them. That is the point of the second one, and worth a careful read — see below.

## Review guide

The whole diff is a parameter, five lines of handler, and a test. The part worth your attention is the wording.

**I had this wrong and it is worth seeing why.** My first version told the model that lifting "frees every one of the company's addresses at once". A *branch* mailbox — one added through `manage_company_channels` with `site_id` — is stored under a different subject (`sites`, not `companies`), so the clear does not reach it. A model reading the original sentence would have believed it had unblocked an address it had not, then written to it and been refused. Both descriptions now say plainly what lifting reaches and what it does not.

**A real gap this surfaces rather than closes:** a branch mailbox is the same trap one level down, and it has no surface at all — no panel, no route, no tool. I did not fold it in because it needs a question answered first about where branch channels are shown to a person, and I did not want to invent that here. The tool descriptions say so out loud rather than leaving it to be discovered.

## Tests

Three integration cases, driven through the real toolkit handler inside org scope the way a `tools/call` would be:

- A held mailbox is freed — and the reason and the soft-bounce counter go with it, not just the status. A clear that left those behind would read as cleared and tip straight back on the next soft bounce.
- Two held addresses on one company are both freed, which is what the description promises. Free one and a caller that trusts the sentence keeps writing to an address still held.
- An ordinary edit with no such request leaves the block exactly where it was — lifting is somebody deciding the address works again, never a side effect of editing the company.

I confirmed the first two fail without the wiring rather than assuming they cover it. The third passes either way by design: it guards against clearing ever becoming a side effect.

## Verification

`pnpm install`, `pnpm -w check-types`, `pnpm -w test` (21 packages) and `pnpm -w build` all green, re-run after rebasing onto current `main`. Server integration 98 files / 688 tests, including the three new ones. The MCP annotation invariants (`_annotations`, 564 checks) pass with the new parameter.

## Deferred

Lifting a block on a **branch** mailbox, which no surface can do — see the Review guide. Same shape as the gap this PR closes, one level down.

---

## Added after review

A code review of this branch found two defects in it, both fixed here.

**A vouch was being thrown away.** `clearEmailSuppression` reset every email row of a subject, and a vouch — somebody standing behind an address — is written to the same `status` column. Lifting one address's bounce discarded the word given for another, on companies especially, which routinely hold several mailboxes. It now touches only an address actually held back. This reaches the contact path too, which had the same bug, so both tool descriptions were corrected.

One deliberate consequence: a soft-bounce tally on an address that was never blocked is left alone. That is pinned by a test and carried in the follow-up issue below.

**The refusal pointed nowhere.** This PR's description promised `update_company`'s `clear_email_suppression` as the way out of a refused vouch, while the runtime message only closed the door. It names the way out now, and says plainly that a branch's mailbox has none.

**And the descriptions over-promised.** Both said mail would go again after a clear. A bounce is recorded against every record in the organisation holding that address; a clear speaks for one. They now say the block stays until the other copies are cleared.

## Deferred

Everything the review surfaced that is bigger than this PR is in #451 — clearing being narrower than blocking, the two different facts sharing `channels.status`, branch mailboxes having no way out, and the soft-bounce tally reset path.

## Also here: the boot test named its own port

CI failed twice on this branch in the deploy-boot-parity job, and I called it a flake the first time on thin evidence. It is not one.

`main.boot.test.ts` hard-coded port 34040. Anything already listening on it — another run of the same suite, a dev server, an unrelated job sharing a runner — leaves the server booting normally, failing to bind, and then saying nothing until the health wait gives up twenty seconds later. Nothing crashes, so stderr is empty and it reads as a slow boot. The real cause sits in the `BOOT STDOUT` the test prints for exactly this purpose: `listen EADDRINUSE: address already in use :::34040`.

I reproduced it by holding that port locally: the suite failed identically, six skipped and the same twenty-second timeout. With the port still held and the fix applied, it passes six of six.

The port now comes from the operating system, which is what four other server tests here already do. It is released before the server claims it, so a collision remains possible in that moment — against a fixed number that clashes for as long as the other holder is up. The comment says so rather than implying otherwise.

Unrelated to the rest of this PR, so it rides as its own commit; it was blocking this branch and costing re-runs on others.
