### PR TITLE
fix(research): settle the shape of an answer instead of assuming a brief

### DIFF
--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -76,6 +76,15 @@ const SCHEMA_CARDS: ReadonlyArray<SchemaCard> = [
 	},
 ]
 
+// Which card is already chosen when the dialog opens, read the same way the
+// server reads a request that names no kind: pinned to a company means the
+// question is about that company, pinned to nothing means it is asking for
+// companies we do not have yet. The two are kept in step so the same question
+// asked here and over the API does not start two different kinds of run — and
+// it is one function so opening the dialog and reopening it cannot disagree.
+const defaultSchema = (isDiscovery: boolean): SchemaOption =>
+	isDiscovery ? 'prospect_scan_v1' : 'company_enrichment_v1'
+
 // Keep free-text inputs to sane lengths so a runaway paste can't be submitted.
 const QUERY_MAX_LENGTH = 2000
 const FILTER_MAX_LENGTH = 120
@@ -102,9 +111,7 @@ export function ResearchDialog({
 	const isDiscovery = companyId === undefined
 	const createResearch = useAtomSet(createResearchAtom, { mode: 'promiseExit' })
 	const [query, setQuery] = useState('')
-	const [schema, setSchema] = useState<SchemaOption>(
-		isDiscovery ? 'prospect_scan_v1' : 'freeform',
-	)
+	const [schema, setSchema] = useState<SchemaOption>(defaultSchema(isDiscovery))
 	const [submitting, setSubmitting] = useState(false)
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
 	const [templateIds, setTemplateIds] = useState<ReadonlyArray<string>>([])
@@ -162,7 +169,7 @@ export function ResearchDialog({
 	useEffect(() => {
 		if (!open) return
 		setQuery('')
-		setSchema(isDiscovery ? 'prospect_scan_v1' : 'freeform')
+		setSchema(defaultSchema(isDiscovery))
 		setSubmitting(false)
 		setErrorMessage(null)
 		setTemplateIds([])

--- a/apps/server/src/handlers/research-cache-clone.integration.test.ts
+++ b/apps/server/src/handlers/research-cache-clone.integration.test.ts
@@ -112,6 +112,7 @@ describe('cloneCacheHitRun', () => {
 								mode: 'deep',
 								schemaName: 'company_enrichment_v1',
 							},
+							schemaName: 'company_enrichment_v1',
 							templateIds: [],
 							templateNames: [],
 							templateFingerprint: '',
@@ -121,11 +122,13 @@ describe('cloneCacheHitRun', () => {
 							eq: boolean
 							cloneText: string
 							kind: string
+							schemaName: string | null
 						}>`
 							SELECT
 								(c.findings = s.findings) AS eq,
 								c.findings::text AS clone_text,
-								c.kind AS kind
+								c.kind AS kind,
+								c.schema_name AS schema_name
 							FROM research_runs c, research_runs s
 							WHERE c.id = ${cloned.id} AND s.id = ${sourceId}
 						`
@@ -142,6 +145,11 @@ describe('cloneCacheHitRun', () => {
 			// The clone is recorded as a cache_hit and its findings are jsonb-equal.
 			expect(cmp.kind).toBe('cache_hit')
 			expect(cmp.eq).toBe(true)
+
+			// AND it is filed under the kind it was reused for. A reused answer that
+			// went down as a different kind from the one that was asked for would be
+			// read back through the wrong shape, and shown through the wrong view.
+			expect(cmp.schemaName).toBe('company_enrichment_v1')
 
 			// The stored keys survive the clone exactly as written.
 			const findings = JSON.parse(cmp.cloneText) as Record<string, unknown>

--- a/apps/server/src/mcp/tools/_research-shared.test.ts
+++ b/apps/server/src/mcp/tools/_research-shared.test.ts
@@ -110,14 +110,14 @@ describe('SchemaNameParam', () => {
 
 	describe('when a client reads the parameter on its own', () => {
 		it('should say what the parameter is for beside the names it accepts', () => {
-			// GIVEN the list of names, which tells a caller the five words exist and
-			// nothing about which to pick
+			// GIVEN a client that shows the parameter without the tool description
+			// around it
 			const published = Tool.getJsonSchemaFromSchema(SchemaNameParam) as {
 				description?: string
 			}
 
-			// THEN the parameter says what it decides, so the choice is an informed
-			// one rather than a guess between five words
+			// THEN the parameter itself says what it decides, so the choice is an
+			// informed one rather than a guess between five words
 			expect(published.description).toContain('freeform')
 		})
 	})
@@ -135,9 +135,9 @@ describe('SCHEMA_GUIDANCE', () => {
 		})
 
 		it('should warn what a brief leaves out', () => {
-			// GIVEN freeform, the one kind with no list of companies in it — picking
-			// it for a question about which companies exist is what produced a run
-			// that found nothing and called itself a success
+			// GIVEN freeform, the one kind with no list of companies in it — picked
+			// for a question about which companies exist, it comes back holding none
+			// and still reports success
 			// THEN the guidance says so rather than describing it as one of five
 			// equal choices
 			expect(SCHEMA_GUIDANCE).toContain('no structured list')
@@ -155,9 +155,10 @@ describe('the research tools that start a run', () => {
 		it('should make them say which kind of run they want', () => {
 			// GIVEN a caller who names no kind
 			// WHEN the call is validated
-			// THEN it is refused. Omitting it used to mean a brief, so a question
-			// about which companies exist came back as prose with nowhere to put
-			// them — and every check for a thin result reads that missing list
+			// THEN it is refused, because no kind is safe to assume on their behalf:
+			// answered as a brief, a question about which companies exist comes back
+			// with nowhere to put them, and every check for a thin result reads that
+			// missing list
 			for (const tool of starters) {
 				const published = Tool.getJsonSchemaFromSchema(
 					tool.parametersSchema,

--- a/apps/server/src/mcp/tools/_research-shared.test.ts
+++ b/apps/server/src/mcp/tools/_research-shared.test.ts
@@ -1,17 +1,21 @@
 import { Cause, Effect, Exit, Schema } from 'effect'
+import { Tool } from 'effect/unstable/ai'
 import { SqlError } from 'effect/unstable/sql'
 import { describe, expect, it } from 'vitest'
 
 import { TERMINAL_RESEARCH_STATUSES } from '@batuda/domain'
+import { schemaNames } from '@batuda/research/application/schemas'
 
 import {
 	MaxWaitSeconds,
 	pollAfterMs,
 	ResearchQuery,
 	redactDbErrors,
+	SCHEMA_GUIDANCE,
 	SchemaNameParam,
 	Uuid,
 } from './_research-shared'
+import { ResearchMcpTools } from './research-mcp'
 
 // True when the value passes the schema's validation (refinement checks included).
 const accepts = (schema: Schema.Codec<unknown>, value: unknown): boolean =>
@@ -101,6 +105,74 @@ describe('SchemaNameParam', () => {
 			// GIVEN a schema name the registry does not define
 			// THEN it is refused at the boundary
 			expect(accepts(SchemaNameParam, 'bogus_schema_v9')).toBe(false)
+		})
+	})
+
+	describe('when a client reads the parameter on its own', () => {
+		it('should say what the parameter is for beside the names it accepts', () => {
+			// GIVEN the list of names, which tells a caller the five words exist and
+			// nothing about which to pick
+			const published = Tool.getJsonSchemaFromSchema(SchemaNameParam) as {
+				description?: string
+			}
+
+			// THEN the parameter says what it decides, so the choice is an informed
+			// one rather than a guess between five words
+			expect(published.description).toContain('freeform')
+		})
+	})
+})
+
+describe('SCHEMA_GUIDANCE', () => {
+	describe('when a caller reads a research tool description', () => {
+		it('should say what each kind of run is for, one sentence each', () => {
+			// GIVEN the five kinds a run can come back in
+			// WHEN a caller reads the guidance to choose between them
+			// THEN each is named and described, so none is picked blind
+			for (const name of schemaNames) {
+				expect(SCHEMA_GUIDANCE).toContain(`\`${name}\``)
+			}
+		})
+
+		it('should warn what a brief leaves out', () => {
+			// GIVEN freeform, the one kind with no list of companies in it — picking
+			// it for a question about which companies exist is what produced a run
+			// that found nothing and called itself a success
+			// THEN the guidance says so rather than describing it as one of five
+			// equal choices
+			expect(SCHEMA_GUIDANCE).toContain('no structured list')
+		})
+	})
+})
+
+describe('the research tools that start a run', () => {
+	const starters = [
+		ResearchMcpTools.tools.start_research,
+		ResearchMcpTools.tools.research_sync,
+	]
+
+	describe('when a caller starts a run', () => {
+		it('should make them say which kind of run they want', () => {
+			// GIVEN a caller who names no kind
+			// WHEN the call is validated
+			// THEN it is refused. Omitting it used to mean a brief, so a question
+			// about which companies exist came back as prose with nowhere to put
+			// them — and every check for a thin result reads that missing list
+			for (const tool of starters) {
+				const published = Tool.getJsonSchemaFromSchema(
+					tool.parametersSchema,
+				) as { required?: ReadonlyArray<string> }
+				expect(published.required).toContain('schema_name')
+			}
+		})
+
+		it('should tell them what each kind is for in the same words', () => {
+			// GIVEN two tools that start the same run and face the same choice
+			// THEN both carry the guidance, and neither can come to describe the
+			// choice differently from the other
+			for (const tool of starters) {
+				expect(tool.description).toContain(SCHEMA_GUIDANCE)
+			}
 		})
 	})
 })

--- a/apps/server/src/mcp/tools/_research-shared.ts
+++ b/apps/server/src/mcp/tools/_research-shared.ts
@@ -9,9 +9,25 @@ import { SchemaNameSchema } from '@batuda/research'
 // would otherwise surface a raw Postgres error to the caller.
 export const Uuid = Schema.String.check(Schema.isUUID())
 
+// What each kind of run is for, in the words the web app already offers a
+// person picking between them. Written once so the two research tools cannot
+// come to describe the same choice differently.
+export const SCHEMA_GUIDANCE =
+	'Pick schema_name for the shape of answer you need. ' +
+	'`prospect_scan_v1` finds companies matching a profile — industry, size, location — when you want net-new companies to add as leads. ' +
+	'`company_enrichment_v1` fills industry, size, location, contacts, competitors and proposed CRM updates for a company you already have. ' +
+	'`contact_discovery_v1` finds decision-makers and operational contacts at one company, when you need names, emails, phones and roles to reach out. ' +
+	'`competitor_scan_v1` maps direct competitors with strengths, weaknesses, and a market-maturity summary. ' +
+	'`freeform` writes an open-ended brief and returns no structured list — pick it only when the question fits no fixed shape, such as a history, a market trend, or an opinion piece.'
+
 // schema_name constrained to the server's closed set, so an unknown name is
 // rejected up front instead of creating a run that only fails at phase 0.
-export const SchemaNameParam = SchemaNameSchema
+// Required, not optional: a caller who said nothing used to get a brief, and a
+// question about which companies exist has nowhere to put them in one.
+export const SchemaNameParam = SchemaNameSchema.annotate({
+	description:
+		'The shape of answer this run produces; see the tool description for what each one is for. There is no default — a question about which companies exist, answered as `freeform`, comes back as prose with no list of companies in it.',
+})
 
 // A research query: present and length-bounded. Stops empty prompts from
 // creating junk runs and caps oversized input that would otherwise waste spend

--- a/apps/server/src/mcp/tools/_research-shared.ts
+++ b/apps/server/src/mcp/tools/_research-shared.ts
@@ -10,8 +10,8 @@ import { SchemaNameSchema } from '@batuda/research'
 export const Uuid = Schema.String.check(Schema.isUUID())
 
 // What each kind of run is for, in the words the web app already offers a
-// person picking between them. Written once so the two research tools cannot
-// come to describe the same choice differently.
+// person picking between them. Written once so the two tools that start a run
+// cannot drift into describing the same choice differently.
 export const SCHEMA_GUIDANCE =
 	'Pick schema_name for the shape of answer you need. ' +
 	'`prospect_scan_v1` finds companies matching a profile — industry, size, location — when you want net-new companies to add as leads. ' +
@@ -22,8 +22,9 @@ export const SCHEMA_GUIDANCE =
 
 // schema_name constrained to the server's closed set, so an unknown name is
 // rejected up front instead of creating a run that only fails at phase 0.
-// Required, not optional: a caller who said nothing used to get a brief, and a
-// question about which companies exist has nowhere to put them in one.
+// Required, not optional: the choice decides whether the answer can hold a list
+// of companies at all, so a caller states it rather than leaving it to be
+// guessed from the question.
 export const SchemaNameParam = SchemaNameSchema.annotate({
 	description:
 		'The shape of answer this run produces; see the tool description for what each one is for. There is no default — a question about which companies exist, answered as `freeform`, comes back as prose with no list of companies in it.',

--- a/apps/server/src/mcp/tools/research-mcp.ts
+++ b/apps/server/src/mcp/tools/research-mcp.ts
@@ -28,6 +28,7 @@ import {
 	pollAfterMs,
 	ResearchQuery,
 	redactDbErrors,
+	SCHEMA_GUIDANCE,
 	SchemaNameParam,
 	Uuid,
 } from './_research-shared'
@@ -143,11 +144,13 @@ const ResearchSyncResult = Schema.Union([
 
 const StartResearch = Tool.make('start_research', {
 	description:
-		"Start a research run; returns {_tag:'started', id, status, applied_instructions, poll_after_ms?} immediately — then call get_research for results. Fresh research takes 2-5 minutes, so status comes back 'queued' and poll_after_ms says how many milliseconds to wait before the first check; unless the same question was answered before, in which case status is already 'succeeded' and poll_after_ms is absent, meaning the findings are ready and there is nothing to wait for. applied_instructions lists the instruction templates that shaped the run. The user's default research instructions apply automatically; pass `stack` (a named stack, by name or id) to run a specific saved stack, and/or `instructions` (template names or ids) to layer extra templates after it for this run. An unknown or ambiguous `stack`/`instructions` ref returns {_tag:'instruction_clarification'} with candidates instead of starting. A `context.selector` — shaped `{ table: \"companies\", filter: { status?, industry?, country?, tags? } }` — researches every matching company (one run each); without `confirm:true` it returns {_tag:'confirm_required', subject_count, estimated_cost_cents} first so you can preview the scale — re-submit with confirm:true to launch (or narrow the filter). A malformed context returns {_tag:'invalid_context', error} without starting a run. If the user states a new standing preference, save it with manage_instructions.",
+		"Start a research run; returns {_tag:'started', id, status, applied_instructions, poll_after_ms?} immediately — then call get_research for results. Fresh research takes 2-5 minutes, so status comes back 'queued' and poll_after_ms says how many milliseconds to wait before the first check; unless the same question was answered before, in which case status is already 'succeeded' and poll_after_ms is absent, meaning the findings are ready and there is nothing to wait for. " +
+		SCHEMA_GUIDANCE +
+		" applied_instructions lists the instruction templates that shaped the run. The user's default research instructions apply automatically; pass `stack` (a named stack, by name or id) to run a specific saved stack, and/or `instructions` (template names or ids) to layer extra templates after it for this run. An unknown or ambiguous `stack`/`instructions` ref returns {_tag:'instruction_clarification'} with candidates instead of starting. A `context.selector` — shaped `{ table: \"companies\", filter: { status?, industry?, country?, tags? } }` — researches every matching company (one run each); without `confirm:true` it returns {_tag:'confirm_required', subject_count, estimated_cost_cents} first so you can preview the scale — re-submit with confirm:true to launch (or narrow the filter). A malformed context returns {_tag:'invalid_context', error} without starting a run. If the user states a new standing preference, save it with manage_instructions.",
 	parameters: Schema.Struct({
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
-		schema_name: Schema.optional(SchemaNameParam),
+		schema_name: SchemaNameParam,
 		stack: Schema.optional(Schema.String),
 		instructions: Schema.optional(InstructionsOverride),
 		confirm: Schema.optional(Schema.Boolean),
@@ -198,11 +201,13 @@ const GetResearch = Tool.make('get_research', {
 
 const ResearchSync = Tool.make('research_sync', {
 	description:
-		"Run research and return full findings inline when it finishes quickly; best for a question likely asked before, since only a cached answer comes back inline. Waits up to ~10s: a cached run returns completed findings; anything else returns the run still going — status 'queued' or 'running' — with poll_after_ms, for you to call get_research after that many milliseconds. The run keeps going regardless and is never lost. Prefer start_research when you expect fresh research: a real run takes 2-5 minutes and will never finish inside this wait, so expect no findings and a null progressSteps here. Pass max_wait_seconds (whole seconds, 1-10; larger values are treated as 10) to wait less if your own request timeout is shorter. The returned run includes applied_instructions — the instruction templates that shaped it. The user's default research instructions apply automatically; pass `stack` (a named stack, by name or id) to run a specific saved stack, and/or `instructions` (template names or ids) to layer extra templates after it for this run. An unknown or ambiguous `stack`/`instructions` ref returns {_tag:'instruction_clarification'} with candidates instead of running. A `context.selector` — shaped `{ table: \"companies\", filter: { status?, industry?, country?, tags? } }` — fans out one run per matching company; without `confirm:true` it returns {_tag:'confirm_required', subject_count, estimated_cost_cents} first. A malformed context returns {_tag:'invalid_context', error} without starting a run.",
+		"Run research and return full findings inline when it finishes quickly; best for a question likely asked before, since only a cached answer comes back inline. Waits up to ~10s: a cached run returns completed findings; anything else returns the run still going — status 'queued' or 'running' — with poll_after_ms, for you to call get_research after that many milliseconds. The run keeps going regardless and is never lost. Prefer start_research when you expect fresh research: a real run takes 2-5 minutes and will never finish inside this wait, so expect no findings and a null progressSteps here. Pass max_wait_seconds (whole seconds, 1-10; larger values are treated as 10) to wait less if your own request timeout is shorter. " +
+		SCHEMA_GUIDANCE +
+		" The returned run includes applied_instructions — the instruction templates that shaped it. The user's default research instructions apply automatically; pass `stack` (a named stack, by name or id) to run a specific saved stack, and/or `instructions` (template names or ids) to layer extra templates after it for this run. An unknown or ambiguous `stack`/`instructions` ref returns {_tag:'instruction_clarification'} with candidates instead of running. A `context.selector` — shaped `{ table: \"companies\", filter: { status?, industry?, country?, tags? } }` — fans out one run per matching company; without `confirm:true` it returns {_tag:'confirm_required', subject_count, estimated_cost_cents} first. A malformed context returns {_tag:'invalid_context', error} without starting a run.",
 	parameters: Schema.Struct({
 		query: ResearchQuery,
 		context: Schema.optional(Schema.Unknown),
-		schema_name: Schema.optional(SchemaNameParam),
+		schema_name: SchemaNameParam,
 		stack: Schema.optional(Schema.String),
 		instructions: Schema.optional(InstructionsOverride),
 		max_wait_seconds: Schema.optional(MaxWaitSeconds),

--- a/apps/server/src/services/research-grounding.integration.test.ts
+++ b/apps/server/src/services/research-grounding.integration.test.ts
@@ -220,6 +220,10 @@ const systemDefaults: SystemDefaults = {
 
 const researchInput: CreateResearchInput = {
 	query: 'Acme Logistics grounding test',
+	// A brief, which is what this has always exercised: the proposed updates it
+	// checks are plumbing every kind of run carries, and asking for a list of
+	// companies instead would end the run on the empty list it never fills.
+	schemaName: 'freeform',
 	// Skip the outer research_cache lookup so a fresh fiber always runs.
 	forceFresh: true,
 }

--- a/apps/server/src/services/research-grounding.integration.test.ts
+++ b/apps/server/src/services/research-grounding.integration.test.ts
@@ -220,9 +220,9 @@ const systemDefaults: SystemDefaults = {
 
 const researchInput: CreateResearchInput = {
 	query: 'Acme Logistics grounding test',
-	// A brief, which is what this has always exercised: the proposed updates it
-	// checks are plumbing every kind of run carries, and asking for a list of
-	// companies instead would end the run on the empty list it never fills.
+	// A brief keeps this to the point: the proposed updates it checks are
+	// plumbing every kind of run carries, and asking for a list of companies
+	// instead would end the run on the empty list it never fills.
 	schemaName: 'freeform',
 	// Skip the outer research_cache lookup so a fresh fiber always runs.
 	forceFresh: true,

--- a/apps/server/src/services/research-heartbeat.integration.test.ts
+++ b/apps/server/src/services/research-heartbeat.integration.test.ts
@@ -136,6 +136,9 @@ const systemDefaults: SystemDefaults = {
 
 const researchInput: CreateResearchInput = {
 	query: 'heartbeat advance test',
+	// Whether the run reports it is still alive has nothing to do with the shape
+	// of its answer; a brief is the cheapest one to get there.
+	schemaName: 'freeform',
 	forceFresh: true,
 }
 

--- a/apps/server/src/services/research-run-deadline.integration.test.ts
+++ b/apps/server/src/services/research-run-deadline.integration.test.ts
@@ -140,6 +140,9 @@ const systemDefaults: SystemDefaults = {
 
 const researchInput: CreateResearchInput = {
 	query: 'run deadline test',
+	// When a run runs out of time has nothing to do with the shape of its
+	// answer; a brief is the cheapest one to get there.
+	schemaName: 'freeform',
 	forceFresh: true,
 }
 

--- a/apps/server/src/services/research-selector-fanout.integration.test.ts
+++ b/apps/server/src/services/research-selector-fanout.integration.test.ts
@@ -141,13 +141,14 @@ const seedCompany = () =>
 		`
 	})
 
-const createSelectorRun = (tag: string) =>
+// `asked` carries whatever the caller states; leaving schemaName out of it is
+// how a request that names no kind of run is exercised.
+const createSelectorRun = (tag: string, asked: CreateResearchInput) =>
 	Effect.gen(function* () {
 		const svc = yield* ResearchService
 		const sql = yield* SqlClient.SqlClient
 		const input: CreateResearchInput = {
-			query: 'fan-out',
-			schemaName: 'company_enrichment_v1',
+			...asked,
 			// Confirm up front so the fan-out actually launches; the unconfirmed
 			// path (which returns a cost estimate instead) is covered separately.
 			confirm: true,
@@ -178,9 +179,20 @@ const createSelectorRun = (tag: string) =>
 				return yield* poll(attemptsLeft - 1)
 			})
 
-		return yield* poll(60)
+		const settled = yield* poll(60)
+		// The kind written onto the group and onto every company it fanned out to.
+		const rows = yield* enterOrgScope(sql, { org: ctx.org, userId })(
+			sql<{ kind: string; schemaName: string | null }>`
+				SELECT kind, schema_name AS "schemaName" FROM research_runs
+				WHERE id = ${created.id} OR parent_id = ${created.id}
+			`,
+		)
+		return {
+			...settled,
+			kinds: rows.map(row => `${row.kind}:${row.schemaName}`),
+		}
 	}).pipe(Effect.provide(ResearchLive)) as Effect.Effect<
-		{ status: string; children: number },
+		{ status: string; children: number; kinds: Array<string> },
 		never,
 		never
 	>
@@ -388,7 +400,12 @@ describe('selector fan-out', () => {
 		it('should create a leaf per company and roll the group up when none succeed', async () => {
 			// GIVEN two companies matching the selector tag
 			// WHEN a selector run is created and its leaves run to completion
-			const result = await Effect.runPromise(createSelectorRun(TAG))
+			const result = await Effect.runPromise(
+				createSelectorRun(TAG, {
+					query: 'fan-out',
+					schemaName: 'company_enrichment_v1',
+				}),
+			)
 
 			// THEN the group has a leaf per company
 			expect(result.children).toBe(2)
@@ -396,6 +413,27 @@ describe('selector fan-out', () => {
 			// leaf ended no_reliable_data under the stub) — the rollup fired on a
 			// non-success terminal, not only on success.
 			expect(result.status).toBe('failed')
+		})
+	})
+
+	describe('when a selector request names no kind of run', () => {
+		it('should settle on one kind and write it onto the group and every leaf', async () => {
+			// GIVEN a filtered request that says nothing about the shape of answer
+			// it wants
+			// WHEN it is created and fans out
+			const result = await Effect.runPromise(
+				createSelectorRun(TAG, { query: 'fan-out naming no kind' }),
+			)
+
+			// THEN the group and each company it covers were all written down as the
+			// same kind of run — the kind the request settled on is what the answer
+			// is filed under and what the lookup for it is built from, so a leaf
+			// disagreeing with its group would put an answer somewhere nothing looks
+			expect([...result.kinds].sort()).toEqual([
+				'group:company_enrichment_v1',
+				'leaf:company_enrichment_v1',
+				'leaf:company_enrichment_v1',
+			])
 		})
 	})
 
@@ -443,7 +481,12 @@ describe('selector fan-out', () => {
 		it('should resolve the group immediately with no leaves', async () => {
 			// GIVEN a selector tag no company carries
 			// WHEN the run is created
-			const result = await Effect.runPromise(createSelectorRun(EMPTY_TAG))
+			const result = await Effect.runPromise(
+				createSelectorRun(EMPTY_TAG, {
+					query: 'fan-out',
+					schemaName: 'company_enrichment_v1',
+				}),
+			)
 
 			// THEN the group has no children and completes right away
 			expect(result.children).toBe(0)

--- a/apps/server/src/services/research-selector-fanout.integration.test.ts
+++ b/apps/server/src/services/research-selector-fanout.integration.test.ts
@@ -141,14 +141,19 @@ const seedCompany = () =>
 		`
 	})
 
-// `asked` carries whatever the caller states; leaving schemaName out of it is
-// how a request that names no kind of run is exercised.
-const createSelectorRun = (tag: string, asked: CreateResearchInput) =>
+// Takes the caller's request whole, so a case can leave schemaName out of it
+// and exercise a request that names no kind of run. The selector and the
+// confirmation are this helper's own, so they are kept out of what a case may
+// state — passing either would read as taking effect when it cannot.
+const createSelectorRun = (
+	tag: string,
+	request: Omit<CreateResearchInput, 'context' | 'confirm'>,
+) =>
 	Effect.gen(function* () {
 		const svc = yield* ResearchService
 		const sql = yield* SqlClient.SqlClient
 		const input: CreateResearchInput = {
-			...asked,
+			...request,
 			// Confirm up front so the fan-out actually launches; the unconfirmed
 			// path (which returns a cost estimate instead) is covered separately.
 			confirm: true,
@@ -193,6 +198,34 @@ const createSelectorRun = (tag: string, asked: CreateResearchInput) =>
 		}
 	}).pipe(Effect.provide(ResearchLive)) as Effect.Effect<
 		{ status: string; children: number; kinds: Array<string> },
+		never,
+		never
+	>
+
+// Create an ordinary run — no filter, no fan-out — and read back the kind
+// written onto its row, so the plain write path is held to the same rule the
+// fan-out is.
+const createPlainRun = (request: Omit<CreateResearchInput, 'context'>) =>
+	Effect.gen(function* () {
+		const svc = yield* ResearchService
+		const sql = yield* SqlClient.SqlClient
+		const created = yield* enterOrgScope(sql, { org: ctx.org, userId })(
+			svc.create(userId, ctx.org.id, request, systemDefaults),
+		)
+		if (created.status === 'confirm_required')
+			return yield* Effect.die(
+				new Error('a run with no filter should never need confirmation'),
+			)
+		groupIds.push(created.id)
+		const [row] = yield* enterOrgScope(sql, { org: ctx.org, userId })(
+			sql<{ schemaName: string | null }>`
+				SELECT schema_name AS "schemaName" FROM research_runs
+				WHERE id = ${created.id}
+			`,
+		)
+		return row?.schemaName ?? null
+	}).pipe(Effect.provide(ResearchLive)) as Effect.Effect<
+		string | null,
 		never,
 		never
 	>
@@ -434,6 +467,22 @@ describe('selector fan-out', () => {
 				'leaf:company_enrichment_v1',
 				'leaf:company_enrichment_v1',
 			])
+		})
+	})
+
+	describe('when an ordinary request names no kind of run', () => {
+		it('should write the kind it settled on rather than leave the row blank', async () => {
+			// GIVEN a question with nothing pinned to it and no kind named — the
+			// shape of the request behind the 2026-08-10 incident
+			// WHEN the run is created
+			const schemaName = await Effect.runPromise(
+				createPlainRun({ query: 'companies in a sector, no kind named' }),
+			)
+
+			// THEN the row says it is going looking for companies. A blank here is
+			// what let the answer come back as prose with nowhere to put them, and
+			// it is also what the findings view reads to choose how to show it
+			expect(schemaName).toBe('prospect_scan_v1')
 		})
 	})
 

--- a/packages/controllers/src/routes/research.test.ts
+++ b/packages/controllers/src/routes/research.test.ts
@@ -128,7 +128,8 @@ describe('CreateResearchInput', () => {
 		})
 
 		it('should accept a request that names no schema at all', () => {
-			// GIVEN schema_name left out, which the service reads as freeform
+			// GIVEN schema_name left out, which the service settles from the shape of
+			// the request rather than turning away at the door
 			const exit = decodeExit(CreateResearchInput, { query: 'a question' })
 			expect(exit._tag).toBe('Success')
 		})

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -133,6 +133,7 @@ import {
 	isSchemaName,
 	resolveSchema,
 	schemaFieldNames,
+	schemaNameFor,
 } from './schemas/index'
 import {
 	hostOf,
@@ -1341,7 +1342,7 @@ export const cloneCacheHitRun = (params: {
 				${organizationId},
 				${input.query},
 				${input.mode ?? 'deep'},
-				${input.schemaName ?? null},
+				${schemaNameFor(input)},
 				'cache_hit',
 				'succeeded',
 				${JSON.stringify(input.context ?? {})}::jsonb,
@@ -2055,8 +2056,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							.templateFingerprint ?? ''
 
 					const context = run['context'] as CreateResearchInput['context']
-					const schemaName =
-						(run as { schemaName: string | null }).schemaName ?? 'freeform'
+					// A run created here always carries the kind it was resolved to;
+					// only a row written before that did could arrive with nothing, and
+					// its own shape says what it was asking for.
+					const schemaName = schemaNameFor({
+						schemaName: (run as { schemaName: string | null }).schemaName,
+						context,
+					})
 
 					// ── Checkpoint state from any prior partial run ──
 					// `phase` + `research_text` + `findings` are persisted after each
@@ -4990,12 +4996,17 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					instructions?: ResolvedInstructions,
 				) =>
 					Effect.gen(function* () {
+						// Settled once, here, and then written onto every row this
+						// creates: the key looked up below and the key the finished run
+						// writes back are built from it separately, and a run whose two
+						// keys disagree can never be served from the cache again.
+						const schemaName = schemaNameFor(input)
 						yield* Effect.logInfo('research.create').pipe(
 							Effect.annotateLogs({
 								user_id: userId,
 								organization_id: organizationId,
 								query_length: input.query.length,
-								schema: input.schemaName ?? 'freeform',
+								schema: schemaName,
 								mode: input.mode ?? 'deep',
 								has_subjects: !!input.context?.subjects?.length,
 								has_selector: !!input.context?.selector,
@@ -5037,12 +5048,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						const templateFingerprint = instructions?.fingerprint ?? ''
 						const templateIds = instructions?.templateIds ?? []
 						const templateNames = instructions?.templateNames ?? []
-						const schemaNameForKey = input.schemaName ?? 'freeform'
 						const cacheKey = computeResearchCacheKey({
 							userId,
 							query: input.query,
-							schemaName: schemaNameForKey,
-							schemaVersion: schemaVersionFor(schemaNameForKey),
+							schemaName,
+							schemaVersion: schemaVersionFor(schemaName),
 							subjects: input.context?.subjects,
 							hints: input.context?.hints,
 							templateFingerprint,
@@ -5186,7 +5196,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									template_fingerprint, instruction_segments
 								) VALUES (
 									${organizationId}, ${input.query}, ${input.mode ?? 'deep'},
-									${input.schemaName ?? null}, 'group', 'running',
+									${schemaName}, 'group', 'running',
 									${JSON.stringify(input.context ?? {})},
 									${policy.budgetCents}, ${policy.paidBudgetCents},
 									${JSON.stringify(policy)}, ${userId},
@@ -5213,7 +5223,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											template_fingerprint, instruction_segments
 										) VALUES (
 											${organizationId}, ${groupId}, ${input.query},
-											${input.mode ?? 'deep'}, ${input.schemaName ?? null},
+											${input.mode ?? 'deep'}, ${schemaName},
 											'leaf', 'queued', ${JSON.stringify(leafContext)},
 											${policy.budgetCents}, ${policy.paidBudgetCents},
 											${JSON.stringify(policy)}, ${userId},
@@ -5263,7 +5273,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								${organizationId},
 								${input.query},
 								${input.mode ?? 'deep'},
-								${input.schemaName ?? null},
+								${schemaName},
 								'queued',
 								${JSON.stringify(input.context ?? {})},
 								${policy.budgetCents},

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1312,6 +1312,10 @@ export const cloneCacheHitRun = (params: {
 	readonly organizationId: string
 	readonly userId: string
 	readonly input: CreateResearchInput
+	// The kind of run, already settled by the caller. Passed in rather than worked
+	// out again here: the clone has to be filed under the same kind the answer was
+	// found under, and two places settling it apart is how they come to disagree.
+	readonly schemaName: string
 	readonly templateIds: ReadonlyArray<string>
 	readonly templateNames: ReadonlyArray<string>
 	readonly templateFingerprint: string
@@ -1323,6 +1327,7 @@ export const cloneCacheHitRun = (params: {
 			organizationId,
 			userId,
 			input,
+			schemaName,
 			templateIds,
 			templateNames,
 			templateFingerprint,
@@ -1342,7 +1347,7 @@ export const cloneCacheHitRun = (params: {
 				${organizationId},
 				${input.query},
 				${input.mode ?? 'deep'},
-				${schemaNameFor(input)},
+				${schemaName},
 				'cache_hit',
 				'succeeded',
 				${JSON.stringify(input.context ?? {})}::jsonb,
@@ -2056,9 +2061,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							.templateFingerprint ?? ''
 
 					const context = run['context'] as CreateResearchInput['context']
-					// A run created here always carries the kind it was resolved to;
-					// only a row written before that did could arrive with nothing, and
-					// its own shape says what it was asking for.
+					// Every run is written down with the kind it settled on, so only an
+					// older row arrives with nothing named — and its own shape says what
+					// it was asking for.
 					const schemaName = schemaNameFor({
 						schemaName: (run as { schemaName: string | null }).schemaName,
 						context,
@@ -4996,10 +5001,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					instructions?: ResolvedInstructions,
 				) =>
 					Effect.gen(function* () {
-						// Settled once, here, and then written onto every row this
-						// creates: the key looked up below and the key the finished run
-						// writes back are built from it separately, and a run whose two
-						// keys disagree can never be served from the cache again.
+						// Settled once and written onto every row this creates, so the
+						// cache key built below and the one the finished run writes back
+						// agree: a run filed under one kind and looked up under another is
+						// never found again.
 						const schemaName = schemaNameFor(input)
 						yield* Effect.logInfo('research.create').pipe(
 							Effect.annotateLogs({
@@ -5077,6 +5082,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									organizationId,
 									userId,
 									input,
+									schemaName,
 									templateIds,
 									templateNames,
 									templateFingerprint,
@@ -5781,6 +5787,16 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							anchorDomain: host,
 						}
 
+						// An older origin can carry no kind at all, and copying that
+						// straight across would put a run on the table saying it is a
+						// brief while it goes on to run as something else — filed under
+						// one kind and looked up under another. Settled from the same
+						// shape every other new run is settled from.
+						const schemaName = schemaNameFor({
+							schemaName: origin.schemaName,
+							context: mergedContext as CreateResearchInput['context'],
+						})
+
 						const [row] = yield* sql<{ id: string }>`
 							INSERT INTO research_runs (
 								organization_id,
@@ -5793,7 +5809,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								${organizationId},
 								${origin.query},
 								${origin.mode ?? 'deep'},
-								${origin.schemaName},
+								${schemaName},
 								'queued',
 								${JSON.stringify(mergedContext)},
 								${origin.budgetCents},

--- a/packages/research/src/application/schemas/index.test.ts
+++ b/packages/research/src/application/schemas/index.test.ts
@@ -188,10 +188,10 @@ describe('schemaNameFor', () => {
 		})
 
 		it('should still let a brief be asked for outright', () => {
-			// GIVEN a question that fits no fixed shape, asked with nothing pinned —
-			// the exact combination that used to happen by accident
-			// THEN asking for it on purpose still works, because only silence is
-			// being reinterpreted
+			// GIVEN a question that fits no fixed shape, asked for by name with
+			// nothing pinned
+			// THEN it still runs as a brief: only silence is filled in, never a
+			// stated choice
 			expect(schemaNameFor({ schemaName: 'freeform' })).toBe('freeform')
 		})
 	})
@@ -243,9 +243,9 @@ describe('schemaNameFor', () => {
 			// GIVEN a question with nothing pinned to it — go and find companies in
 			// a sector
 			// WHEN no kind was named
-			// THEN it goes looking for them. Answering as a brief left the companies
-			// nowhere to go, and every check for a thin result reads that list, so
-			// an answer holding nothing reported itself a success
+			// THEN it goes looking for them: a brief leaves the companies nowhere to
+			// go, and every check for a thin result reads that list, so an answer
+			// holding nothing would report itself a success
 			expect(schemaNameFor({})).toBe('prospect_scan_v1')
 		})
 
@@ -269,12 +269,37 @@ describe('schemaNameFor', () => {
 
 	describe('when the request names no kind', () => {
 		it('should read every way of saying nothing as saying nothing', () => {
-			// GIVEN the field left out, sent as nothing, or sent empty — an empty
-			// name resolves to no schema, so treating it as a name would leave a run
-			// that starts and then dies
-			for (const schemaName of [undefined, null, '']) {
+			// GIVEN the field left out, sent as nothing, sent empty, or holding only
+			// blank space — none of them is a name, and treating one as a name would
+			// leave a run that starts, announces itself, and only then finds there is
+			// no such kind
+			for (const schemaName of [undefined, null, '', '   ', '\t\n']) {
 				expect(schemaNameFor({ schemaName })).toBe('prospect_scan_v1')
 			}
+		})
+
+		it('should still read a pinned request as being about what it pinned', () => {
+			// GIVEN a blank name alongside a company
+			// THEN the blank is ignored and the company decides, the same as if the
+			// field had been left out entirely
+			expect(
+				schemaNameFor({
+					schemaName: '  ',
+					context: { subjects: [{ table: 'companies', id: 'a' }] },
+				}),
+			).toBe('company_enrichment_v1')
+		})
+	})
+
+	describe('when the kind named is padded with space', () => {
+		it('should take the name inside it', () => {
+			// GIVEN a name that arrived with space around it — off a hand-edited row,
+			// or a caller that trimmed nothing
+			// THEN the name inside is what runs, rather than a string no schema
+			// registry will ever match
+			expect(schemaNameFor({ schemaName: ' prospect_scan_v1 ' })).toBe(
+				'prospect_scan_v1',
+			)
 		})
 	})
 

--- a/packages/research/src/application/schemas/index.test.ts
+++ b/packages/research/src/application/schemas/index.test.ts
@@ -6,6 +6,7 @@ import {
 	resolveSchema,
 	SchemaNameSchema,
 	schemaFieldNames,
+	schemaNameFor,
 	schemaNames,
 	schemaRegistry,
 } from './index'
@@ -163,6 +164,137 @@ describe('resolveSchema', () => {
 		it('should return nothing for a name every object carries', () => {
 			expect(resolveSchema('toString')).toBeUndefined()
 			expect(resolveSchema('__proto__')).toBeUndefined()
+		})
+	})
+})
+
+describe('schemaNameFor', () => {
+	describe('when the request says which kind of run it wants', () => {
+		it('should take the caller at their word for every kind', () => {
+			// GIVEN each kind a caller can ask for, alongside a shape that would have
+			// implied a different one
+			// WHEN the kind is settled
+			// THEN what was asked for is what runs — the shape of the request never
+			// overrules it
+			for (const name of schemaNames) {
+				expect(schemaNameFor({ schemaName: name })).toBe(name)
+				expect(
+					schemaNameFor({
+						schemaName: name,
+						context: { subjects: [{ table: 'companies', id: 'a' }] },
+					}),
+				).toBe(name)
+			}
+		})
+
+		it('should still let a brief be asked for outright', () => {
+			// GIVEN a question that fits no fixed shape, asked with nothing pinned —
+			// the exact combination that used to happen by accident
+			// THEN asking for it on purpose still works, because only silence is
+			// being reinterpreted
+			expect(schemaNameFor({ schemaName: 'freeform' })).toBe('freeform')
+		})
+	})
+
+	describe('when the request asks about records already held', () => {
+		it('should fill in the profile of a company that was named', () => {
+			// GIVEN a request pinned to a company
+			// THEN it is a question about that company, so its own card is what gets
+			// filled in
+			expect(
+				schemaNameFor({
+					context: { subjects: [{ table: 'companies', id: 'a' }] },
+				}),
+			).toBe('company_enrichment_v1')
+		})
+
+		it('should treat a filter over existing companies the same as naming them', () => {
+			// GIVEN a filter, which picks out companies already here and researches
+			// one at a time rather than asking for new ones
+			// THEN it lands on the same kind naming them outright would
+			expect(
+				schemaNameFor({
+					context: { selector: { table: 'companies', filter: {} } },
+				}),
+			).toBe('company_enrichment_v1')
+		})
+
+		it('should settle a filter and the companies it picks out on one kind', () => {
+			// GIVEN the two shapes one filtered request passes through: the request
+			// as it arrives, and each company it fans out to
+			const asked = schemaNameFor({
+				context: {
+					selector: { table: 'companies', filter: { country: 'ES' } },
+				},
+			})
+			const fannedOut = schemaNameFor({
+				context: { subjects: [{ table: 'companies', id: 'a' }] },
+			})
+
+			// THEN both settle on the same kind. One of these keys the answer put
+			// away for reuse and the other keys the lookup that finds it again, so
+			// were they to disagree the run would never be reused at all
+			expect(asked).toBe(fannedOut)
+		})
+	})
+
+	describe('when the request asks for companies not held yet', () => {
+		it('should go looking for companies rather than write about none', () => {
+			// GIVEN a question with nothing pinned to it — go and find companies in
+			// a sector
+			// WHEN no kind was named
+			// THEN it goes looking for them. Answering as a brief left the companies
+			// nowhere to go, and every check for a thin result reads that list, so
+			// an answer holding nothing reported itself a success
+			expect(schemaNameFor({})).toBe('prospect_scan_v1')
+		})
+
+		it('should read an empty list of records as pinning nothing', () => {
+			// GIVEN a request carrying the field but nothing in it
+			// THEN it pins no company, so it is asking for ones not held yet
+			expect(schemaNameFor({ context: { subjects: [] } })).toBe(
+				'prospect_scan_v1',
+			)
+		})
+
+		it('should read a context that says nothing at all the same way', () => {
+			// GIVEN each way a request can carry no shape — absent, empty, or
+			// explicitly nothing
+			// THEN none of them pins anything, so all land together
+			for (const context of [undefined, null, {}, { subjects: undefined }]) {
+				expect(schemaNameFor({ context })).toBe('prospect_scan_v1')
+			}
+		})
+	})
+
+	describe('when the request names no kind', () => {
+		it('should read every way of saying nothing as saying nothing', () => {
+			// GIVEN the field left out, sent as nothing, or sent empty — an empty
+			// name resolves to no schema, so treating it as a name would leave a run
+			// that starts and then dies
+			for (const schemaName of [undefined, null, '']) {
+				expect(schemaNameFor({ schemaName })).toBe('prospect_scan_v1')
+			}
+		})
+	})
+
+	describe('when the kind named is not one this build has', () => {
+		it('should hand the name back rather than quietly run something else', () => {
+			// GIVEN a run queued under a kind that has since been retired, its name
+			// still on the row
+			// WHEN the kind is settled
+			// THEN the name survives untouched, so the run still stops and says the
+			// kind is gone — swapping in a working one would answer a question
+			// nobody asked
+			expect(schemaNameFor({ schemaName: 'retired_shape_v1' })).toBe(
+				'retired_shape_v1',
+			)
+			expect(
+				schemaNameFor({
+					schemaName: 'retired_shape_v1',
+					context: { subjects: [{ table: 'companies', id: 'a' }] },
+				}),
+			).toBe('retired_shape_v1')
 		})
 	})
 })

--- a/packages/research/src/application/schemas/index.ts
+++ b/packages/research/src/application/schemas/index.ts
@@ -49,6 +49,48 @@ export const isSchemaName = (name: string): name is SchemaName =>
 export const resolveSchema = (name: string): Schema.Top | undefined =>
 	isSchemaName(name) ? schemaRegistry[name] : undefined
 
+/**
+ * The kind of research a request asked for, or — when it did not say — the kind
+ * its own shape implies.
+ *
+ * Saying nothing used to mean a brief, the one shape with no list of companies
+ * in it. Every check that catches a thin result looks for that list, so a
+ * request to go and find companies came back holding none and still called
+ * itself a success.
+ *
+ * A request pinned to records we already hold is asking about those; one pinned
+ * to nothing is asking for companies we do not have yet. A brief is neither, and
+ * stays something a caller has to ask for by name.
+ *
+ * A name we do not recognise is handed back untouched rather than swapped for a
+ * guess, so a run asking for a kind of research this build no longer has still
+ * stops and says so.
+ */
+export const schemaNameFor = (request: {
+	readonly schemaName?: string | null | undefined
+	readonly context?:
+		| {
+				readonly subjects?: ReadonlyArray<unknown> | undefined
+				readonly selector?: unknown
+		  }
+		| null
+		| undefined
+}): string => {
+	if (request.schemaName) return request.schemaName
+	const context = request.context
+	// A filter counts as pinned as much as a list of ids does: it picks out
+	// companies already here, one run each, rather than asking for new ones.
+	const pinned =
+		(context?.subjects?.length ?? 0) > 0 ||
+		(context?.selector !== undefined && context.selector !== null)
+	// Named as a registry key on the way out, so a typo here is a build error
+	// rather than a run that starts and then finds no such schema.
+	const inferred: SchemaName = pinned
+		? 'company_enrichment_v1'
+		: 'prospect_scan_v1'
+	return inferred
+}
+
 // Fields every schema carries that are not something to go and find out: they
 // are how a run hands work back to the CRM, and the prompt covers them where it
 // explains that work.

--- a/packages/research/src/application/schemas/index.ts
+++ b/packages/research/src/application/schemas/index.ts
@@ -53,18 +53,17 @@ export const resolveSchema = (name: string): Schema.Top | undefined =>
  * The kind of research a request asked for, or — when it did not say — the kind
  * its own shape implies.
  *
- * Saying nothing used to mean a brief, the one shape with no list of companies
- * in it. Every check that catches a thin result looks for that list, so a
- * request to go and find companies came back holding none and still called
- * itself a success.
- *
  * A request pinned to records we already hold is asking about those; one pinned
- * to nothing is asking for companies we do not have yet. A brief is neither, and
- * stays something a caller has to ask for by name.
+ * to nothing is asking for companies we do not have yet. A brief is neither, so
+ * it stays something a caller has to ask for by name: it is the one shape with
+ * no list of companies in it, and every check that catches a thin result reads
+ * that list, so a hunt for companies answered as a brief comes back holding none
+ * and still calls itself a success.
  *
  * A name we do not recognise is handed back untouched rather than swapped for a
  * guess, so a run asking for a kind of research this build no longer has still
- * stops and says so.
+ * stops and says so. A blank one is not a name at all, so it counts as saying
+ * nothing rather than as a kind that has been retired.
  */
 export const schemaNameFor = (request: {
 	readonly schemaName?: string | null | undefined
@@ -76,15 +75,16 @@ export const schemaNameFor = (request: {
 		| null
 		| undefined
 }): string => {
-	if (request.schemaName) return request.schemaName
+	const asked = request.schemaName?.trim()
+	if (asked) return asked
 	const context = request.context
 	// A filter counts as pinned as much as a list of ids does: it picks out
 	// companies already here, one run each, rather than asking for new ones.
 	const pinned =
 		(context?.subjects?.length ?? 0) > 0 ||
 		(context?.selector !== undefined && context.selector !== null)
-	// Named as a registry key on the way out, so a typo here is a build error
-	// rather than a run that starts and then finds no such schema.
+	// Typed as a registry key, so a typo here is a build error rather than a run
+	// that starts and then finds no such schema.
 	const inferred: SchemaName = pinned
 		? 'company_enrichment_v1'
 		: 'prospect_scan_v1'


### PR DESCRIPTION
## What

Ask an assistant to go and find companies and it calls `start_research`. If it doesn't say what shape of answer it wants, the server quietly picked the one shape that cannot hold companies — an open-ended written brief — and the run still reported success. On 2026-08-10 a request for Spanish installation companies came back as four bare names, no websites, no employee counts, marked `succeeded`.

The brief has no list of prospects in it, and every check that catches a thin result is keyed on that list. With no list at all, the "came back empty, try once more" retry never ran and neither did the honest "nothing could be grounded" outcome. Both were unreachable, so an answer holding nothing looked exactly like an answer holding everything.

This makes the shape a deliberate choice. It lives in the research bounded context (`packages/research`), the MCP tool surface (`apps/server`), and the new-research dialog (`apps/internal`).

## The fix

- **The two research tools now require `schema_name`.** A caller can no longer fall into a brief by saying nothing — over MCP, omitting it is a validation error rather than a silent default.
- **Everywhere else the request's own shape decides.** The HTTP route and re-runs may legitimately omit it, so the old `freeform` fallback is gone there too: a request pinned to companies already held resolves to a company profile, one pinned to nothing resolves to a prospect scan. A brief is now something you ask for by name.
- **Both tool descriptions say what each of the five shapes is for**, one sentence each, reusing the wording the web app already shows a person choosing between them. The parameter itself carries a short description too, since that's what sits next to the list of names in a client's view.
- **The shape is settled in one shared function** and written onto every row a run creates, so no two places can decide it apart.
- **The dialog reads a request the same way the server does.** It defaulted a run pinned to a company to a brief, so the same question asked in the app and over the API started two different kinds of run.

## Impact

- **MCP wire-shape contract (breaking, by design).** `schema_name` moves from optional to required on `start_research` and `research_sync`. Any existing caller that omitted it now gets `Invalid parameters … Missing key at ["schema_name"]` instead of a run id. Pre-production, so a clean break rather than a shim — but it is a real change for anything already calling these tools.
- **Behaviour change for callers that omit it elsewhere.** A schema-less `POST /v1/research` used to produce a brief and now produces a prospect scan (or a company profile when pinned). This only moves callers that said nothing.
- **A schema-less answer is now cached for 30 days instead of 7.** `researchCacheTtlDaysFor` gives a brief 7 days and every structured shape 30, so a request that used to land on a brief now keeps its answer four times longer. Correct in the sense that it matches an explicitly-requested scan, but it means an identical repeat inside a month is served the stored company list rather than searching again. Worth knowing before it surprises someone.
- **An anchored schema-less run now triggers the post-run geocode.** `main.ts` fires `geocodeCompany` for a succeeded `company_enrichment_v1` run whose linked company has a written location and no coordinates. Such a run previously stored no shape at all and never reached that gate. The run really is an enrichment now, so this is the gate working as intended — but it is an external lookup that a default change switched on, and it is best-effort and swallowed on failure.
- **The research cache is why the settling had to happen in one place.** One key looks an answer up, another files the finished run under it. They read the same input today, so a fix touching only one would have made them disagree — and a run whose two keys disagree can never be served from the cache again. Settling once and writing the result onto the row removes the possibility rather than relying on both sites staying in step.
- **A filtered fan-out counts as pinned, not as discovery.** This is the case where the two keys could actually have diverged: such a request arrives carrying a filter and executes carrying company ids, so inferring separately at each site would have given different answers.
- **No migration, no new env vars, no auth or RLS change.** `schema_name` was already a nullable text column; rows this build writes now always fill it, and a row written before still resolves from its own shape. Nothing touches tenant isolation or which Postgres role a path runs under.
- **MCP and HTTP diverge here on purpose.** Both reach the same service and get the same inference; MCP additionally refuses to let a caller stay silent, because that's the surface where an assistant is choosing on someone's behalf.

## Review guide

- **Start at `schemaNameFor` in `packages/research/src/application/schemas/index.ts`** — it's the whole decision, and the rest is call sites.
- **A decision you might overrule.** The issue pointed at the dialog's one-liner (`isDiscovery ? 'prospect_scan_v1' : 'freeform'`) as the thing to port. I didn't port it literally: an anchored request resolves to a company profile, not a brief, and I changed the dialog to match rather than leave the two surfaces disagreeing. A brief is precisely the shape where every thin-result guard is dead, so it seemed wrong to keep it as the thing you land on by default anywhere. If you'd rather the anchored case stay `freeform`, it's one function in each place.
- **An unrecognised name is handed back untouched**, not swapped for a guess. That keeps PR #440's behaviour intact: a run queued under a retired schema still stops and says the schema is gone. A *blank* name is treated as silence instead, since it was never a name.
- **Three integration tests changed for a reason worth knowing.** `research-grounding` actually failed on this branch — a schema-less run now reaches the refined retry and the honest empty outcome that a brief bypassed, which is the fix proving itself. It and two others were leaning on the old default without saying so; all three now name the shape they mean to exercise, chosen to keep their previous behaviour exactly.
- **Second commit is the review pass.** I ran `/code-review` at extra-high effort over the first commit and it found two write paths I had missed — the domain-correction re-run still copied a possibly-blank shape from the origin row, and the cache-hit clone re-derived the shape instead of taking the settled one. Both are fixed there, with coverage for the two row-writes that had none. Reviewing that commit on its own is probably the fastest way in.
- **What I did not run:** `/security-review` was not invoked. The change tightens an input boundary and touches no auth, RLS, parser, or crypto path. Snyk was not available. Flagging it rather than leaving it silent.
- **Accessibility:** no new interactive elements, no layout change. The dialog's radio group is untouched — only which option starts selected.

## Screenshots

Which card the dialog starts on. Captured at 1440×900 and on an iPhone 16 Pro, since `apps/internal` renders the dialog differently by size.

**Pinned to a company — now Company enrichment (was Freeform):**

![pr-schema-anchored-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-449/pr-schema-anchored-desktop.webp)

![pr-schema-anchored-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-449/pr-schema-anchored-mobile.webp)

**Pinned to nothing — Prospect scan, unchanged:**

![pr-schema-discovery-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-449/pr-schema-discovery-desktop.webp)

## Tests

- **Unit (`packages/research`)** — an explicit shape always wins, including when the request's own shape implies a different one; a brief can still be asked for outright; every way of saying nothing (absent, null, empty, blank space) is read as nothing; a padded name is taken as the name inside it; an empty list of records pins nothing; a filter and the companies it fans out to settle on the same shape; an unrecognised name survives untouched.
- **Unit (`apps/server`)** — both tools publish `schema_name` as required, both carry the same guidance text, and the parameter carries a description of its own.
- **Integration (`apps/server`, real database)** — an ordinary request naming no shape writes the settled shape onto its row rather than leaving it blank; a filtered request writes one shape onto the group and onto every company it fans out to; a cache-hit clone is filed under the shape it was reused for.

## Verification

- Gates run on this branch: `pnpm install`, `pnpm check-types`, `pnpm turbo test` (21 tasks), `pnpm test:integration` (97 files, 687 tests), `pnpm build` — all green. `biome check` shows the same 59 warnings as `main`, none new.
- **Live stack, real providers.** I ran the 2026-08-10 request verbatim against the worktree stack wired to the committed production routing (Firecrawl search + scrape, Nebius LLM) rather than the local stubs. With `schema_name` omitted it stored and ran as `prospect_scan_v1`, finished `succeeded` at 2¢, and returned **six prospects** — a populated list, not a prose brief. The same query on the incident run is recorded as `freeform`.
- **Live MCP surface.** The served `tools/list` reports `required: ['query','schema_name']` for both tools with the five-value enum and the guidance intact, and calling `start_research` without `schema_name` is refused rather than started.
- **The dialog** was driven in a browser at both viewports; the screenshots above are from that run, and I read the checked radio back from the DOM in each case rather than judging by eye.

## Deferred

- **The prospects mostly have no website and no employee count.** That is #438 — the extraction never asks for breadth, and the rescue step that fills missing fields cannot see a list of prospects at all. This PR is what unblocks measuring it, since discovery questions were until now running as briefs.
- **The `research-designer` MCP prompt still lists bare schema names** and asks the model to explain trade-offs it isn't given. It's now redundant rather than wrong, since a model calling either tool has the guidance in front of it. Left alone as out of scope.

Closes #433
