### PR TITLE
refactor(research): read a value and its page in one place

### DIFF
--- a/apps/internal/src/components/research/field-diff.ts
+++ b/apps/internal/src/components/research/field-diff.ts
@@ -4,6 +4,11 @@
  * only the new value. Kept free of JSX so it can be unit-tested plainly.
  */
 
+// From the module itself, not the package's front door: the front door carries
+// the whole research context — the service, its database client, its providers —
+// and pulling that into a browser bundle stops the page coming alive.
+import { unwrapValue } from '@batuda/research/application/guard-shapes'
+
 /** Handled elsewhere on the row, so they are left out of the value list. */
 const SKIPPED_FIELDS = new Set(['name', 'channels', 'companyId', 'company_id'])
 
@@ -16,22 +21,12 @@ export type FieldChange = {
 	readonly unchanged: boolean
 }
 
-/**
- * A value can arrive on its own, or wrapped together with the page it was read
- * from. Both mean the same thing to a reader, so the wrapper is unwrapped before
- * anything is shown — otherwise the row displays the wrapper itself.
- */
-function unwrap(value: unknown): unknown {
-	if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-		const o = value as Record<string, unknown>
-		if ('value' in o) return o['value']
-	}
-	return value
-}
-
 /** A value as a person would read it, or null when there is nothing to show. */
 export function displayValue(value: unknown): string | null {
-	const v = unwrap(value)
+	// A value can arrive on its own, or paired with the page it was read from.
+	// Both mean the same thing to a reader, so the pairing is read past before
+	// anything is shown — otherwise the row displays the pairing itself.
+	const v = unwrapValue(value)
 	if (v === null || v === undefined) return null
 	if (typeof v === 'string') return v.trim() === '' ? null : v
 	if (typeof v === 'number' || typeof v === 'boolean') return String(v)

--- a/packages/research/package.json
+++ b/packages/research/package.json
@@ -14,6 +14,10 @@
 			"types": "./src/domain/types.ts",
 			"import": "./src/domain/types.ts"
 		},
+		"./application/guard-shapes": {
+			"types": "./src/application/guard-shapes.ts",
+			"import": "./src/application/guard-shapes.ts"
+		},
 		"./application/paid-action-tool": {
 			"types": "./src/application/paid-action-tool.ts",
 			"import": "./src/application/paid-action-tool.ts"

--- a/packages/research/src/application/applicability-guard.ts
+++ b/packages/research/src/application/applicability-guard.ts
@@ -38,14 +38,10 @@ export interface ApplicabilityResult {
 // earlier check replaces a value it cannot support with nothing at all, and a field
 // in that state must not travel on: writing it would clear what the record holds.
 const holdsAValue = (value: unknown): boolean => {
-	if (value === null || value === undefined) return false
-	// The per-field shape a value travels in — a value with the page it came from.
-	// The same rule applies one level in, since that is where a check empties it.
-	if (isPlainObject(value) && 'value' in value) {
-		const inner = value['value']
-		return inner !== null && inner !== undefined
-	}
-	return true
+	// Read past the page a value is paired with, since it is the value underneath
+	// that a check empties.
+	const held = unwrapValue(value)
+	return held !== null && held !== undefined
 }
 
 export const filterApplicableProposals = (

--- a/packages/research/src/application/citation-guard.ts
+++ b/packages/research/src/application/citation-guard.ts
@@ -13,6 +13,7 @@
  * in every findings schema, so it filters wherever it finds a `citations` array.
  */
 
+import { isCitedField } from './guard-shapes'
 import { canonicalizeUrl, hostOf } from './source-key'
 
 /**
@@ -120,17 +121,16 @@ export const validateFindingCitations = (
 			// cannot survive. (A descriptive finding's citations array still keeps its
 			// value and drops only the bad citation — that rule is for prose, not a
 			// scalar fact.)
-			const record = value as { source_id?: unknown; value?: unknown }
-			if (typeof record.source_id === 'string' && 'value' in record) {
+			if (isCitedField(value)) {
 				total++
-				if (isGrounded(record.source_id)) {
+				if (isGrounded(value.source_id)) {
 					kept++
 					return value
 				}
 				drops.push({
 					field: key ?? 'field',
-					value: boundDropValue(record.value),
-					sourceId: record.source_id,
+					value: boundDropValue(value.value),
+					sourceId: value.source_id,
 				})
 				return null
 			}

--- a/packages/research/src/application/eval-outcome.ts
+++ b/packages/research/src/application/eval-outcome.ts
@@ -19,6 +19,7 @@ import {
 	type TerminalStatus,
 } from './eval-scoring'
 import { contactFill, enrichmentFill } from './extraction-fill'
+import { unwrapValue } from './guard-shapes'
 import { hostOf } from './source-key'
 
 const TERMINAL_STATUSES: ReadonlySet<string> = new Set<TerminalStatus>([
@@ -42,12 +43,8 @@ const toTerminalStatus = (status: string): TerminalStatus =>
  * scorer behind it — is indifferent to which shape produced the run.
  */
 const readFieldValue = (raw: unknown): string | null => {
-	if (typeof raw === 'string') return raw
-	if (raw !== null && typeof raw === 'object' && 'value' in raw) {
-		const inner = (raw as { value: unknown }).value
-		return typeof inner === 'string' ? inner : null
-	}
-	return null
+	const inner = unwrapValue(raw)
+	return typeof inner === 'string' ? inner : null
 }
 
 const enrichmentOf = (

--- a/packages/research/src/application/value-guard.ts
+++ b/packages/research/src/application/value-guard.ts
@@ -29,7 +29,7 @@
 
 import { EMAIL_ADDRESS_PATTERN } from '@batuda/domain'
 
-import { unwrapValue } from './guard-shapes'
+import { isCitedField, unwrapValue } from './guard-shapes'
 import {
 	isInCorpus,
 	PAGE_LITERAL_FIELDS,
@@ -210,10 +210,9 @@ export const verifyValueProvenance = (
 			// value the same way as a dedicated field, but blank the WHOLE field to
 			// null when the email/phone is invented, rather than leaving a
 			// sourced-but-empty { value: null } behind.
-			const wrapper = value as { value?: unknown; source_id?: unknown }
-			if ('value' in wrapper && typeof wrapper.source_id === 'string') {
-				if (typeof wrapper.value === 'string') {
-					const t = wrapper.value.trim()
+			if (isCitedField(value)) {
+				if (typeof value.value === 'string') {
+					const t = value.value.trim()
 					if (EMAIL_RE.test(t) && !emailSupported(ev, t)) {
 						strippedValues++
 						return null


### PR DESCRIPTION
## What

A research run can attach, to each value it suggests, the page that value was read on — so once somebody accepts the change, the record keeps a note of where the fact came from. That pairing travels from the moment the run extracts it all the way to the moment a person accepts it, and along the way nine different pieces of code had to look inside it to get at the value underneath.

All nine had that check written out by hand, in four different spellings. This replaces them with one shared reader. No behaviour changes; it is 15 fewer lines and one obvious function instead of nine near-copies.

This is Research (`packages/research`), the apply path in `server`, and one file in the `internal` web app.

## Why it is worth doing

A copy that gets it wrong fails silently, which is the whole problem. A value that arrives paired with its page is an object, not text — so a check that reads it flat sees "not text", concludes there is nothing to check, and waves it through. Nothing errors and nothing is logged.

That is not hypothetical. [PR 447](https://github.com/guillempuche/batuda/pull/447) started asking runs for this pairing, and three of the nine copies had to be fixed in that same change or they would have thrown away **every** newly discovered person and let a made-up town reach a company record. Those three are already fixed. This closes the remaining six, so the next check somebody writes gets it right without having to know the trap exists.

## Changes

- One reader, `unwrapValue`, for "the value, whether or not it came paired with a page". Used by the applicability guard, the value guard, the eval adapter and the review screen.
- Two of the nine were **not** asking the same question: they wanted a value that also *names* a page, which is a different test and already existed as `isCitedField`. They now call it by name instead of spelling it out, which is the change I would look at hardest — see below.
- The web app's local copy is deleted in favour of the shared one, imported from the module itself rather than the package's front door — see below, because I got this wrong first time.
- `packages/research` gains a subpath export for that module, matching the three the web app already reaches for the same way.

## Impact

- **No behaviour change**, no schema or migration, no new environment variables, no API or wire-shape change, no auth or RLS change.
- One file in the web app changes, but only to call the shared reader in place of its own identical copy. Nothing rendered differs.
- `packages/research` gains one subpath export. The package's front door is untouched.

## The mistake worth knowing about

My first attempt imported the shared reader from `@batuda/research` — the package's front door — on the reasoning that the web app already depends on the package, so nothing new would come along. That was wrong, and CI caught it: the sign-in page stopped becoming interactive and the end-to-end smoke run failed.

The web app's existing imports encode a rule I had not noticed. Anything it needs at runtime comes from a **specific module** (`@batuda/research/application/schemas`, `/application/paid-action-tool`, `/domain/types`); the front door is only ever imported `as type`, which disappears at compile time and brings nothing with it. Mine was the first runtime import through the front door, which carries the whole research context — the service, its database client, its providers. It put roughly **300kB** of server code into the browser bundle (6.6MB against 6.3MB), and the page stopped coming alive.

Taking it from the module directly fixes it and restores the rule. I am flagging it because the trap is invisible: it type-checks, it builds, and only an end-to-end run notices.

## Review guide

The two `isCitedField` swaps are the only places where a mistake could hide, because they change *what is being asked* rather than *how it is spelled* — a value plus a string `source_id`, rather than just a value. I checked the equivalence in both directions:

- The old inline tests did not exclude arrays, and `isCitedField` does. That would matter, except both sites handle arrays in an earlier branch that returns before this line is reached, so an array can never arrive here. Same behaviour either way.
- The rest are plain unwraps whose old copies already excluded arrays, matching the shared one exactly.

`readSourced` in `research-apply.ts` is deliberately left alone. It looks like a tenth copy but does a different job: it returns the value **and** the citation beside it, which is what the apply path needs to write the note.

## Tests

No new tests. This is a behaviour-preserving consolidation, and the existing suites already cover each of these call sites — the guards, the eval adapter and the review screen all have their own tests, and they exercise the paired shape as well as the plain one. If any swap were not equivalent, they are where it would show.

## Verification

Ran on this branch, rebased on current `main`: `pnpm install`, `pnpm -w check-types` (13 packages), `pnpm -w test` (21 tasks), `pnpm -w build` — all green, plus lint on the changed files. CI is green, including the end-to-end smoke run that caught the bundling mistake above. No UI change to screenshot.

One thing to know while reading CI: the **full** end-to-end suite is currently failing on `main`, on `company-industries` and `company-overview`. That is unrelated to this change and predates it — sign-in passes there, which is how I could tell my own failure apart from it.

## Context

This was meant to be part of [PR 447](https://github.com/guillempuche/batuda/pull/447) and missed the merge by a moment, so it stands on its own. It applies cleanly to current `main`, and the two research changes that landed since touch none of these files.

Refs #435
