### PR TITLE
fix(research): ask a scan for breadth, and fill in what it missed

### DIFF
--- a/packages/research/src/application/discovery-scan.test.ts
+++ b/packages/research/src/application/discovery-scan.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	DISCOVERY_THIN_RESULT_COUNT,
 	discoveryResultCount,
+	discoveryResultField,
 	emptyScanFindings,
 	isDiscoveryScan,
 	isDiscoveryScanEmpty,
@@ -313,6 +314,28 @@ describe('emptyScanFindings', () => {
 				/found no companies matching the criteria/i,
 			)
 			expect(findings.error).not.toMatch(/retry/i)
+		})
+	})
+})
+
+describe('discoveryResultField', () => {
+	describe('when the schema is a discovery scan', () => {
+		it('should name the list its companies live in', () => {
+			// GIVEN each of the two scan schemas
+			// THEN anything needing to reach inside a scan's results is told where
+			// they are, rather than naming the list a second time for itself
+			expect(discoveryResultField('prospect_scan_v1')).toBe('prospects')
+			expect(discoveryResultField('competitor_scan_v1')).toBe('competitors')
+		})
+	})
+
+	describe('when the schema is not a discovery scan', () => {
+		it('should name no list', () => {
+			// GIVEN a schema whose answer is not a list of companies, or none at all
+			// THEN there is no list to reach into
+			expect(discoveryResultField('company_enrichment_v1')).toBeUndefined()
+			expect(discoveryResultField('freeform')).toBeUndefined()
+			expect(discoveryResultField('')).toBeUndefined()
 		})
 	})
 })

--- a/packages/research/src/application/discovery-scan.ts
+++ b/packages/research/src/application/discovery-scan.ts
@@ -30,6 +30,14 @@ export const isDiscoveryScan = (schemaName: string): boolean =>
 	schemaName in DISCOVERY_RESULT_FIELD
 
 /**
+ * Which list holds a discovery scan's companies, or undefined for a schema that
+ * is not a scan. Anything that needs to reach inside a scan's results asks here,
+ * so the mapping above stays the only place the two schemas are named.
+ */
+export const discoveryResultField = (schemaName: string): string | undefined =>
+	DISCOVERY_RESULT_FIELD[schemaName]
+
+/**
  * How many results a discovery scan's primary list carries. Null for a schema
  * that is not a discovery scan, whose result count is a different question its
  * own guards answer; zero when the list is missing, unusable, or empty.

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -1,3 +1,4 @@
+import { Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -8,8 +9,10 @@ import {
 	needsPerFieldSearch,
 	perFieldSearchCap,
 	perFieldSearchQuery,
-	SCAN_ROW_FIELDS,
+	scanRowFields,
 } from './per-field-search'
+import { CompetitorScanV1Schema } from './schemas/competitor-scan-v1'
+import { ProspectScanV1Schema } from './schemas/prospect-scan-v1'
 
 // A per-field-citation value the way the enrichment schema stores one.
 const sourced = (value: string) => ({ value, source_id: 'https://x.test' })
@@ -109,14 +112,15 @@ describe('needsPerFieldSearch', () => {
 			])
 		})
 
-		it('should read a competitor scan the same way as a prospect scan', () => {
+		it('should reach a competitor list, but only for facts it can hold', () => {
 			// GIVEN a competitor scan's own list
 			const findings = { competitors: [{ name: 'Rival' }] }
 			// WHEN computed
-			// THEN it is reached exactly as a prospect list is
+			// THEN the list is reached exactly as a prospect list is, but a headcount
+			// is never asked about: a competitor row has no place to put one, so the
+			// search would be paid for and the answer thrown away
 			expect(forScan(findings, COMPETITORS)).toEqual([
 				{ name: 'Rival', field: 'website' },
-				{ name: 'Rival', field: 'employee_estimate' },
 			])
 		})
 
@@ -470,6 +474,27 @@ describe('mergePerFieldSearch', () => {
 			expect(merged.added).toBe(0)
 		})
 
+		it('should fold two spellings that differ only by an accent', () => {
+			// GIVEN a Catalan company name carrying its accent and legal suffix
+			const findings = { prospects: [{ name: 'Transports Munné, S.L.' }] }
+			// AND a second look that read the same company off a page that dropped both
+			const refreshed = {
+				prospects: [
+					{ name: 'Transports Munne SL', website: 'https://munne.test' },
+				],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN it is still one company — most of the market this searches writes
+			// names with accents, and matching on the letters alone would have listed
+			// the same firm twice and counted the duplicate as a new find
+			expect(rows).toHaveLength(1)
+			expect(rows[0]?.['name']).toBe('Transports Munné, S.L.')
+			expect(rows[0]?.['website']).toBe('https://munne.test')
+			expect(merged.added).toBe(0)
+		})
+
 		it('should not fold two genuinely different companies together', () => {
 			// GIVEN a company whose name is a prefix of another's
 			const findings = { prospects: [{ name: 'Acme' }] }
@@ -484,6 +509,25 @@ describe('mergePerFieldSearch', () => {
 			// smaller harm than a website on the wrong company
 			expect(rows[0]?.['website']).toBeUndefined()
 			expect(rows.map(row => row['name'])).toEqual(['Acme', 'Acme Holding'])
+			expect(merged.added).toBe(1)
+		})
+
+		it('should append a company the second look names twice only once', () => {
+			// GIVEN a re-extraction that names the same NEW company in two rows
+			const findings = { prospects: [{ name: 'Zeta' }] }
+			const refreshed = {
+				prospects: [
+					{ name: 'Acme', website: 'https://a.test' },
+					{ name: 'Acme', website: 'https://b.test' },
+				],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN it joins the list once — the list's length decides whether a scan
+			// came back too thin to trust, so counting one company twice would pass a
+			// thin scan off as a healthy one
+			expect(rows.map(row => row['name'])).toEqual(['Zeta', 'Acme'])
 			expect(merged.added).toBe(1)
 		})
 
@@ -608,16 +652,54 @@ describe('mergePerFieldSearch', () => {
 })
 
 describe('the fields each shape rescues', () => {
-	it('should name the facts a profile and a scan are each worth searching for', () => {
-		// GIVEN the two field lists the rescue works from
-		// THEN a profile rescues its firmographics, and a scan rescues what makes a
-		// company on a list reachable and worth reaching
-		expect(HIGH_VALUE_FIELDS).toEqual([
-			'country',
-			'industry',
-			'location',
-			'size_range',
-		])
-		expect(SCAN_ROW_FIELDS).toEqual(['website', 'employee_estimate'])
+	describe('when a run goes looking for what it left empty', () => {
+		it('should name the facts a profile and a scan are each worth searching for', () => {
+			// GIVEN the two field lists the rescue works from
+			// WHEN a run of either shape reaches the gap rounds
+			// THEN a profile rescues its firmographics, and a scan rescues what makes
+			// a company on a list reachable and worth reaching
+			expect(HIGH_VALUE_FIELDS).toEqual([
+				'country',
+				'industry',
+				'location',
+				'size_range',
+			])
+			expect(scanRowFields(SCAN)).toEqual(['website', 'employee_estimate'])
+			expect(scanRowFields(COMPETITORS)).toEqual(['website'])
+			expect(scanRowFields('freeform')).toEqual([])
+		})
+
+		it('should only name facts the scan schema can actually carry', () => {
+			// GIVEN a company row carrying every fact the rescue would search for,
+			// put through the very schema the model fills
+			const sample: Record<string, unknown> = {
+				name: 'Acme',
+				website: 'https://acme.test',
+				employee_estimate: {
+					value: 42,
+					source_id: 'https://acme.test',
+					confidence: null,
+				},
+				why_relevant: 'matches',
+				description: 'a rival',
+				citations: [],
+			}
+			for (const [schemaName, schema, listField] of [
+				[SCAN, ProspectScanV1Schema, 'prospects'],
+				[COMPETITORS, CompetitorScanV1Schema, 'competitors'],
+			] as const) {
+				const decoded = Schema.decodeUnknownSync(schema)({
+					[listField]: [sample],
+				}) as Record<string, ReadonlyArray<Record<string, unknown>>>
+				const row = decoded[listField]?.[0] ?? {}
+				// WHEN each fact the rescue searches for is looked for on the way out
+				// THEN it survived — a fact the schema drops would be searched for
+				// every round and merged back nowhere, which is the same waste this
+				// rescue was rewritten to stop doing on a company profile
+				for (const field of scanRowFields(schemaName)) {
+					expect(row).toHaveProperty(field)
+				}
+			}
+		})
 	})
 })

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -2,17 +2,34 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	HIGH_VALUE_FIELDS,
+	MAX_PER_FIELD_SEARCHES,
+	MAX_SCAN_ROW_SEARCHES,
 	mergePerFieldSearch,
 	needsPerFieldSearch,
+	perFieldSearchCap,
 	perFieldSearchQuery,
+	SCAN_ROW_FIELDS,
 } from './per-field-search'
 
 // A per-field-citation value the way the enrichment schema stores one.
 const sourced = (value: string) => ({ value, source_id: 'https://x.test' })
 
+const SCAN = 'prospect_scan_v1'
+const COMPETITORS = 'competitor_scan_v1'
+const PROFILE = 'company_enrichment_v1'
+
+const forProfile = (findings: unknown, subjectName = 'Acme Corp') =>
+	needsPerFieldSearch({ findings, schemaName: PROFILE, subjectName })
+
+const forScan = (findings: unknown, schemaName: string = SCAN) =>
+	needsPerFieldSearch({ findings, schemaName, subjectName: 'unused by a scan' })
+
+const prospectsOf = (findings: unknown) =>
+	(findings as { prospects: ReadonlyArray<Record<string, unknown>> }).prospects
+
 describe('needsPerFieldSearch', () => {
-	describe('when every high-value field is already filled', () => {
-		it('should return no fields to search', () => {
+	describe('when the run is a company profile', () => {
+		it('should return no fields when every high-value one is filled', () => {
 			// GIVEN findings whose country/industry/location/size_range all carry a value
 			const findings = {
 				enrichment: {
@@ -24,11 +41,9 @@ describe('needsPerFieldSearch', () => {
 			}
 			// WHEN the still-empty high-value fields are computed
 			// THEN there is nothing to search for
-			expect(needsPerFieldSearch(findings)).toEqual([])
+			expect(forProfile(findings)).toEqual([])
 		})
-	})
 
-	describe('when some high-value fields are empty', () => {
 		it('should return only the empty ones, in HIGH_VALUE_FIELDS order', () => {
 			// GIVEN industry + size_range filled, country + location empty
 			const findings = {
@@ -39,8 +54,11 @@ describe('needsPerFieldSearch', () => {
 				},
 			}
 			// WHEN computed
-			// THEN the two empty high-value fields come back in a stable order
-			expect(needsPerFieldSearch(findings)).toEqual(['country', 'location'])
+			// THEN the two empty high-value fields come back against the subject's name
+			expect(forProfile(findings)).toEqual([
+				{ name: 'Acme Corp', field: 'country' },
+				{ name: 'Acme Corp', field: 'location' },
+			])
 		})
 
 		it('should ignore non-high-value fields that are empty', () => {
@@ -55,17 +73,149 @@ describe('needsPerFieldSearch', () => {
 			}
 			// WHEN computed
 			// THEN only high-value fields are ever searched, so nothing is returned
-			expect(needsPerFieldSearch(findings)).toEqual([])
+			expect(forProfile(findings)).toEqual([])
 		})
 	})
 
-	describe('when findings have no enrichment block', () => {
-		it('should return all high-value fields', () => {
-			// GIVEN a degenerate findings object with nothing filled
+	describe('when a company profile has no profile block at all', () => {
+		it('should ask for nothing, because a recovered value has nowhere to go', () => {
+			// GIVEN findings carrying no enrichment block — the shape a run lands in
+			// when extraction returned nothing usable
 			// WHEN computed
-			// THEN every high-value field is a search candidate
-			expect(needsPerFieldSearch({})).toEqual([...HIGH_VALUE_FIELDS])
-			expect(needsPerFieldSearch(null)).toEqual([...HIGH_VALUE_FIELDS])
+			// THEN no search is proposed: the merge could not fold an answer back in,
+			// so firing paid searches would only buy an answer to throw away
+			expect(forProfile({})).toEqual([])
+			expect(forProfile(null)).toEqual([])
+			expect(forProfile({ enrichment: null })).toEqual([])
+			expect(forProfile('not an object')).toEqual([])
+		})
+	})
+
+	describe('when the run is a discovery scan', () => {
+		it('should ask about every company that is missing a fact', () => {
+			// GIVEN one company with a website and one with nothing but a name
+			const findings = {
+				prospects: [
+					{ name: 'Acme', website: 'https://acme.test' },
+					{ name: 'Beta' },
+				],
+			}
+			// WHEN computed
+			// THEN each company is asked about by its own name, never the request's
+			expect(forScan(findings)).toEqual([
+				{ name: 'Acme', field: 'employee_estimate' },
+				{ name: 'Beta', field: 'website' },
+				{ name: 'Beta', field: 'employee_estimate' },
+			])
+		})
+
+		it('should read a competitor scan the same way as a prospect scan', () => {
+			// GIVEN a competitor scan's own list
+			const findings = { competitors: [{ name: 'Rival' }] }
+			// WHEN computed
+			// THEN it is reached exactly as a prospect list is
+			expect(forScan(findings, COMPETITORS)).toEqual([
+				{ name: 'Rival', field: 'website' },
+				{ name: 'Rival', field: 'employee_estimate' },
+			])
+		})
+
+		it('should count a headcount paired with its source as filled', () => {
+			// GIVEN a headcount stored as a number beside the page that stated it
+			const findings = {
+				prospects: [
+					{
+						name: 'Acme',
+						website: 'https://acme.test',
+						employee_estimate: { value: 42, source_id: 'https://acme.test' },
+					},
+				],
+			}
+			// WHEN computed
+			// THEN nothing is missing — a number is a value even though it is not text
+			expect(forScan(findings)).toEqual([])
+		})
+
+		it('should treat a blanked or absent value as still missing', () => {
+			// GIVEN a website blanked by a guard, one that is only whitespace, and a
+			// headcount whose value was nulled
+			const findings = {
+				prospects: [
+					{ name: 'A', website: '   ', employee_estimate: { value: null } },
+					{ name: 'B', website: null, employee_estimate: { value: 7 } },
+				],
+			}
+			// WHEN computed
+			// THEN each of those reads as a gap worth searching for
+			expect(forScan(findings)).toEqual([
+				{ name: 'A', field: 'website' },
+				{ name: 'A', field: 'employee_estimate' },
+				{ name: 'B', field: 'website' },
+			])
+		})
+
+		it('should skip a row that names no company', () => {
+			// GIVEN rows with a blank name, no name, and a non-string name
+			const findings = {
+				prospects: [
+					{ name: '   ' },
+					{ website: 'https://x.test' },
+					{ name: 42 },
+					{ name: 'Real' },
+				],
+			}
+			// WHEN computed
+			// THEN only the company that can actually be searched for is asked about —
+			// a quoted blank would search for nothing
+			expect(forScan(findings)).toEqual([
+				{ name: 'Real', field: 'website' },
+				{ name: 'Real', field: 'employee_estimate' },
+			])
+		})
+
+		it('should ask for nothing when the scan found nobody', () => {
+			// GIVEN a scan whose list is empty, missing, or not a list at all
+			// WHEN computed
+			// THEN there is no company to search about, and the profile fields are
+			// never fallen back on
+			expect(forScan({ prospects: [] })).toEqual([])
+			expect(forScan({})).toEqual([])
+			expect(forScan({ prospects: 'nope' })).toEqual([])
+			expect(forScan(null)).toEqual([])
+		})
+
+		it('should never fall back to profile fields when a scan carries a profile block', () => {
+			// GIVEN a scan whose findings somehow also carry an enrichment block
+			const findings = {
+				prospects: [],
+				enrichment: { country: { value: null } },
+			}
+			// WHEN computed
+			// THEN the schema decides the shape, so no profile field is searched for —
+			// a scan has nowhere to put one
+			expect(forScan(findings)).toEqual([])
+		})
+	})
+})
+
+describe('perFieldSearchCap', () => {
+	describe('when the run is a company profile', () => {
+		it('should cap at the per-fact allowance', () => {
+			// GIVEN a profile, whose gaps are facts about one company
+			// THEN the cap is the smaller per-fact one
+			expect(perFieldSearchCap(PROFILE)).toBe(MAX_PER_FIELD_SEARCHES)
+			expect(perFieldSearchCap('freeform')).toBe(MAX_PER_FIELD_SEARCHES)
+		})
+	})
+
+	describe('when the run is a discovery scan', () => {
+		it('should cap at the larger per-company allowance', () => {
+			// GIVEN a scan, whose gaps are whole companies rather than facts
+			// THEN the cap is raised, since three searches across a list would
+			// recover almost nothing
+			expect(perFieldSearchCap(SCAN)).toBe(MAX_SCAN_ROW_SEARCHES)
+			expect(perFieldSearchCap(COMPETITORS)).toBe(MAX_SCAN_ROW_SEARCHES)
+			expect(MAX_SCAN_ROW_SEARCHES).toBeGreaterThan(MAX_PER_FIELD_SEARCHES)
 		})
 	})
 })
@@ -89,6 +239,27 @@ describe('perFieldSearchQuery', () => {
 				'"Acme Corp" head office country',
 			)
 		})
+
+		it('should treat a blank city as no city', () => {
+			// GIVEN a city that is only whitespace
+			expect(perFieldSearchQuery('Acme', '   ', 'country')).toBe(
+				'"Acme" head office country',
+			)
+		})
+	})
+
+	describe('when the fact wanted is one only a scan asks for', () => {
+		it('should phrase the website and headcount searches', () => {
+			// GIVEN the two facts a scan's list most often comes back missing
+			// WHEN the queries are built
+			// THEN each is phrased for search rather than named as a field
+			expect(perFieldSearchQuery('Acme', undefined, 'website')).toBe(
+				'"Acme" official website',
+			)
+			expect(perFieldSearchQuery('Acme', 'Girona', 'employee_estimate')).toBe(
+				'"Acme" Girona number of employees',
+			)
+		})
 	})
 
 	describe('when the field has no known intent', () => {
@@ -102,7 +273,7 @@ describe('perFieldSearchQuery', () => {
 })
 
 describe('mergePerFieldSearch', () => {
-	describe('when the re-extraction recovered an empty field', () => {
+	describe('when the re-extraction recovered an empty profile field', () => {
 		it('should fill only the empty high-value fields and count them', () => {
 			// GIVEN findings with country empty and industry already grounded
 			const findings = {
@@ -122,6 +293,7 @@ describe('mergePerFieldSearch', () => {
 			const { findings: next, filled } = mergePerFieldSearch(
 				findings,
 				refreshed,
+				PROFILE,
 			)
 			// THEN the empty country is filled but the grounded industry is untouched
 			expect(filled).toBe(1)
@@ -138,9 +310,14 @@ describe('mergePerFieldSearch', () => {
 			const findings = { enrichment: { country: sourced('ES') } }
 			// AND a refreshed extraction with no enrichment block
 			// WHEN merged
-			const { findings: next, filled } = mergePerFieldSearch(findings, {})
+			const {
+				findings: next,
+				filled,
+				added,
+			} = mergePerFieldSearch(findings, {}, PROFILE)
 			// THEN nothing is filled and the same findings come back
 			expect(filled).toBe(0)
+			expect(added).toBe(0)
 			expect(next).toBe(findings)
 		})
 	})
@@ -165,6 +342,7 @@ describe('mergePerFieldSearch', () => {
 			const { findings: next, contactsChanged } = mergePerFieldSearch(
 				findings,
 				refreshed,
+				PROFILE,
 			)
 
 			// THEN the second person is kept, the first not duplicated
@@ -189,6 +367,7 @@ describe('mergePerFieldSearch', () => {
 			const { findings: next, contactsChanged } = mergePerFieldSearch(
 				findings,
 				refreshed,
+				PROFILE,
 			)
 			expect(contactsChanged).toBe(false)
 			expect(next).toBe(findings)
@@ -210,6 +389,7 @@ describe('mergePerFieldSearch', () => {
 			const { findings: next, contactsChanged } = mergePerFieldSearch(
 				findings,
 				refreshed,
+				PROFILE,
 			)
 
 			// THEN the title is kept, even though the list is exactly as long as it
@@ -221,5 +401,223 @@ describe('mergePerFieldSearch', () => {
 			).contacts
 			expect(contacts[0]?.role?.value).toBe('CEO')
 		})
+	})
+
+	describe("when the re-extraction re-reads a scan's list", () => {
+		it('should fill the right company even though the order changed', () => {
+			// GIVEN three companies, one already carrying a website
+			const findings = {
+				prospects: [
+					{ name: 'Acme', why_relevant: 'x' },
+					{ name: 'Beta', website: 'https://beta.test' },
+					{ name: 'Gamma' },
+				],
+			}
+			// AND a wider read that returns them in a different order, with a worse
+			// website for Beta and a company nobody had named
+			const refreshed = {
+				prospects: [
+					{ name: 'Delta', website: 'https://delta.test' },
+					{ name: 'Gamma', website: 'https://gamma.test' },
+					{
+						name: 'Acme',
+						website: 'https://acme.test',
+						employee_estimate: { value: 42, source_id: 'https://acme.test' },
+					},
+					{ name: 'Beta', website: 'https://wrong.test' },
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+
+			// THEN each recovered value lands on the company it belongs to, the
+			// grounded website is left alone, nobody is dropped, and the new company
+			// is appended
+			expect(rows.map(row => row['name'])).toEqual([
+				'Acme',
+				'Beta',
+				'Gamma',
+				'Delta',
+			])
+			expect(rows[0]?.['website']).toBe('https://acme.test')
+			expect(rows[0]?.['employee_estimate']).toEqual({
+				value: 42,
+				source_id: 'https://acme.test',
+			})
+			expect(rows[1]?.['website']).toBe('https://beta.test')
+			expect(rows[2]?.['website']).toBe('https://gamma.test')
+			expect(merged.filled).toBe(3)
+			expect(merged.added).toBe(1)
+			expect(merged.contactsChanged).toBe(false)
+		})
+
+		it('should fold two spellings of one company together', () => {
+			// GIVEN a company written with its legal suffix punctuated
+			const findings = { prospects: [{ name: 'Acme S.L.' }] }
+			// AND a second look that writes the same company differently
+			const refreshed = {
+				prospects: [{ name: 'acme sl', website: 'https://acme.test' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN one company stays one company, keeping the name first written
+			expect(rows).toHaveLength(1)
+			expect(rows[0]?.['name']).toBe('Acme S.L.')
+			expect(rows[0]?.['website']).toBe('https://acme.test')
+			expect(merged.added).toBe(0)
+		})
+
+		it('should not fold two genuinely different companies together', () => {
+			// GIVEN a company whose name is a prefix of another's
+			const findings = { prospects: [{ name: 'Acme' }] }
+			const refreshed = {
+				prospects: [{ name: 'Acme Holding', website: 'https://holding.test' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN Acme keeps its blank rather than inheriting another company's site,
+			// and the other company is listed in its own right — a duplicate is a far
+			// smaller harm than a website on the wrong company
+			expect(rows[0]?.['website']).toBeUndefined()
+			expect(rows.map(row => row['name'])).toEqual(['Acme', 'Acme Holding'])
+			expect(merged.added).toBe(1)
+		})
+
+		it('should take the first mention when the second look names one company twice', () => {
+			// GIVEN a re-extraction that lists the same company twice
+			const findings = { prospects: [{ name: 'Acme' }] }
+			const refreshed = {
+				prospects: [
+					{ name: 'Acme', website: 'https://first.test' },
+					{ name: 'Acme', website: 'https://second.test' },
+				],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN one of them is taken and the fold stays stable, with no duplicate
+			// appended for the company already known
+			expect(rows).toHaveLength(1)
+			expect(rows[0]?.['website']).toBe('https://first.test')
+			expect(merged.added).toBe(0)
+		})
+
+		it('should add companies to a list that came back empty', () => {
+			// GIVEN a first pass that found nobody
+			const findings = { prospects: [] }
+			const refreshed = {
+				prospects: [{ name: 'Acme', website: 'https://acme.test' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			// THEN the wider read's find is kept — an empty list is exactly the one
+			// with the most to gain from looking again
+			expect(prospectsOf(merged.findings).map(row => row['name'])).toEqual([
+				'Acme',
+			])
+			expect(merged.added).toBe(1)
+		})
+
+		it('should ignore a company the second look cannot name', () => {
+			// GIVEN a re-extraction carrying a row with no usable name
+			const findings = { prospects: [{ name: 'Acme' }] }
+			const refreshed = {
+				prospects: [{ website: 'https://nameless.test' }, { name: '  ' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			// THEN nothing is appended, since a company with no name cannot be worked
+			// with or told apart from another
+			expect(merged.added).toBe(0)
+			expect(merged.findings).toBe(findings)
+		})
+
+		it('should keep a company the second look no longer names', () => {
+			// GIVEN a company found first time round that the wider read missed
+			const findings = {
+				prospects: [{ name: 'Acme' }, { name: 'Beta' }],
+			}
+			const refreshed = {
+				prospects: [{ name: 'Beta', website: 'https://beta.test' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			// THEN a second look only ever adds — it never shortens the list
+			expect(prospectsOf(merged.findings).map(row => row['name'])).toEqual([
+				'Acme',
+				'Beta',
+			])
+		})
+
+		it('should leave the findings untouched when nothing was gained', () => {
+			// GIVEN a second look that fills nothing and names nobody new
+			const findings = {
+				prospects: [{ name: 'Acme', website: 'https://acme.test' }],
+			}
+			const refreshed = {
+				prospects: [{ name: 'Acme', website: 'https://other.test' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			// THEN the very same findings come back, which is what stops the rounds
+			expect(merged.findings).toBe(findings)
+			expect(merged.filled).toBe(0)
+			expect(merged.added).toBe(0)
+		})
+
+		it('should leave the findings alone when there is nowhere to write', () => {
+			// GIVEN findings that are not an object at all
+			const refreshed = { prospects: [{ name: 'Acme' }] }
+			// WHEN merged
+			// THEN nothing is invented around them
+			expect(mergePerFieldSearch(null, refreshed, SCAN).findings).toBe(null)
+			expect(mergePerFieldSearch('x', refreshed, SCAN).findings).toBe('x')
+		})
+
+		it('should leave the findings alone when the second look holds no list', () => {
+			// GIVEN a re-extraction that came back with nothing usable
+			const findings = { prospects: [{ name: 'Acme' }] }
+			// WHEN merged
+			// THEN the list is untouched
+			expect(mergePerFieldSearch(findings, {}, SCAN).findings).toBe(findings)
+			expect(mergePerFieldSearch(findings, null, SCAN).findings).toBe(findings)
+		})
+
+		it('should carry the rest of the findings across untouched', () => {
+			// GIVEN findings holding more than the list of companies
+			const findings = {
+				prospects: [{ name: 'Acme' }],
+				pending_paid_actions: [{ tool: 'lookup_registry' }],
+			}
+			const refreshed = {
+				prospects: [{ name: 'Acme', website: 'https://acme.test' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			// THEN everything beside the list survives the fold
+			expect(
+				(merged.findings as { pending_paid_actions: unknown })
+					.pending_paid_actions,
+			).toEqual([{ tool: 'lookup_registry' }])
+		})
+	})
+})
+
+describe('the fields each shape rescues', () => {
+	it('should name the facts a profile and a scan are each worth searching for', () => {
+		// GIVEN the two field lists the rescue works from
+		// THEN a profile rescues its firmographics, and a scan rescues what makes a
+		// company on a list reachable and worth reaching
+		expect(HIGH_VALUE_FIELDS).toEqual([
+			'country',
+			'industry',
+			'location',
+			'size_range',
+		])
+		expect(SCAN_ROW_FIELDS).toEqual(['website', 'employee_estimate'])
 	})
 })

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -1,25 +1,33 @@
 /**
- * A last-resort recovery for the high-value firmographics the broad pass and the
- * focused rescues both left empty.
+ * A last-resort recovery for the high-value facts the broad pass and the focused
+ * rescues both left empty.
  *
  * The rescues re-read the evidence the run already gathered; this step goes
- * further and fetches new evidence: for each still-empty high-value field it
- * fires one focused web search, so a fact that was simply not on any page the run
- * reached (a company's headquarters country, its sector, its city, its size) still
- * has a chance to be found. It fires only for fields that are still blank and is
- * capped, so a complete run pays nothing and an all-empty one cannot loop.
+ * further and fetches new evidence: for each still-empty high-value fact it fires
+ * one focused web search, so a fact that was simply not on any page the run
+ * reached still has a chance to be found. It fires only for facts that are still
+ * blank and is capped, so a complete run pays nothing and an all-empty one cannot
+ * loop.
  *
- * This module is the pure part — which fields to search for and the query to fire.
- * The search, source linking, and re-extraction happen in the research service,
- * where a recovered value passes the same grounding guards as any other.
+ * A run has one or many subjects. A company profile is one subject — the company
+ * the run is about. A discovery scan is one subject per company it found, each
+ * with its own blanks. Both are read the same way here, so a scan's list of
+ * prospects gets the same recovery a single profile does.
+ *
+ * This module is the pure part — which subjects to search for, which fact, and
+ * the query to fire. The search, source linking, and re-extraction happen in the
+ * research service, where a recovered value passes the same grounding guards as
+ * any other.
  */
 
 import { mergeContacts } from './contacts-rescue'
+import { discoveryResultField, isDiscoveryScan } from './discovery-scan'
 import { enrichmentFill } from './extraction-fill'
+import { isValueWrapper, unwrapValue } from './guard-shapes'
 
-// The firmographic scalars worth spending an extra search on. `size_range` is also
-// nudged during the loop (headcount is rarely on the homepage); the other three
-// have no search-backed recovery until now, so an empty one simply stayed empty.
+// The company-profile facts worth spending an extra search on. `size_range` is
+// also nudged during the loop (headcount is rarely on the homepage); for the
+// other three this step is the only search that goes looking for them.
 export const HIGH_VALUE_FIELDS: ReadonlyArray<string> = [
 	'country',
 	'industry',
@@ -27,30 +35,158 @@ export const HIGH_VALUE_FIELDS: ReadonlyArray<string> = [
 	'size_range',
 ]
 
-// At most this many extra searches per run: an all-empty profile would otherwise
-// fire one per field. Any missing field beyond the cap is left for the operator to
-// see in the fill telemetry rather than silently searched.
+// The facts worth an extra search on one company a scan found. A scan is asked
+// for a list to work through, and a name alone cannot be worked with: the site is
+// how someone reaches the company, and the headcount is how they decide whether
+// it is worth reaching. Website comes first because it is the one a scan is most
+// often asked for and most often misses.
+export const SCAN_ROW_FIELDS: ReadonlyArray<string> = [
+	'website',
+	'employee_estimate',
+]
+
+// At most this many extra searches per round for a company profile: an all-empty
+// profile would otherwise fire one per field. Any missing field beyond the cap is
+// left for the operator to see in the fill telemetry rather than silently searched.
 export const MAX_PER_FIELD_SEARCHES = 3
 
-/** The still-empty high-value fields, in a stable order — the ones a per-field
- * search should try to recover. Empty when the profile is already complete. */
-export const needsPerFieldSearch = (
-	findings: unknown,
-): ReadonlyArray<string> => {
-	const missing = new Set(enrichmentFill(findings).missing)
-	return HIGH_VALUE_FIELDS.filter(field => missing.has(field))
+// At most this many extra searches per round for a discovery scan. A scan spreads
+// its searches over a whole list of companies rather than the few facts of one,
+// so the profile's cap would recover almost nothing; this is larger and still
+// bounded, with the round loop's own budget and deadline margins as the real
+// governor.
+export const MAX_SCAN_ROW_SEARCHES = 8
+
+/** One fact to go looking for, on one of the run's subjects. */
+export interface RescueTarget {
+	/** The company name to search for. */
+	readonly name: string
+	/** Which fact to look for. */
+	readonly field: string
 }
 
-// A short, human-readable label per field, used to phrase the search.
-const FIELD_INTENT: Record<string, string> = {
-	country: 'head office country',
-	industry: 'industry sector',
-	location: 'headquarters city address',
-	size_range: 'number of employees',
+// A profile field holds something usable only when it carries a non-empty string
+// value. The wrapper is required, not incidental: this has to agree with the fill
+// measurement next door, which reads a bare value as no value at all.
+const hasValue = (fieldValue: unknown): boolean =>
+	isValueWrapper(fieldValue) &&
+	typeof fieldValue.value === 'string' &&
+	fieldValue.value.trim() !== ''
+
+/**
+ * Whether one company's field in a scan carries a real value.
+ *
+ * A scan's fields are not shaped like a profile's: most are plain strings, and
+ * the headcount is a number paired with the page it was read on. Reading past
+ * that pairing keeps a headcount of 40 from being mistaken for a blank simply
+ * because it is not a string.
+ */
+const hasRowValue = (fieldValue: unknown): boolean => {
+	const held = unwrapValue(fieldValue)
+	if (typeof held === 'string') return held.trim() !== ''
+	return typeof held === 'number' && Number.isFinite(held)
+}
+
+const enrichmentOf = (
+	findings: unknown,
+): Record<string, unknown> | undefined => {
+	if (findings === null || typeof findings !== 'object') return undefined
+	const enrichment = (findings as { enrichment?: unknown }).enrichment
+	return enrichment !== null && typeof enrichment === 'object'
+		? (enrichment as Record<string, unknown>)
+		: undefined
+}
+
+/** The companies a scan found, or none when the findings hold no usable list. */
+const scanRowsOf = (
+	schemaName: string,
+	findings: unknown,
+): ReadonlyArray<Record<string, unknown>> => {
+	const field = discoveryResultField(schemaName)
+	if (field === undefined) return []
+	if (findings === null || typeof findings !== 'object') return []
+	const rows = (findings as Record<string, unknown>)[field]
+	if (!Array.isArray(rows)) return []
+	return rows.filter(
+		(row): row is Record<string, unknown> =>
+			row !== null && typeof row === 'object' && !Array.isArray(row),
+	)
+}
+
+/** The name a scan row goes by, or undefined when it names no company. */
+const rowName = (row: Record<string, unknown>): string | undefined => {
+	const name = (row as { name?: unknown }).name
+	return typeof name === 'string' && name.trim() !== ''
+		? name.trim()
+		: undefined
 }
 
 /**
- * A focused web-search query for one missing field: the company name (quoted so
+ * The key two mentions of the same company share.
+ *
+ * A re-extraction reads the same company off a different page and writes the name
+ * with different spacing or punctuation — `Acme S.L.` against `Acme S.L`. Folding
+ * those together keeps one company from becoming two rows. It stops at
+ * punctuation and case on purpose: dropping a legal suffix would fold `Acme` and
+ * `Acme Holding` into one, and putting a recovered website on the wrong company
+ * is far worse than listing it twice.
+ */
+const nameKey = (name: string): string =>
+	name.toLowerCase().replace(/[.,]/g, '').replace(/\s+/g, ' ').trim()
+
+/**
+ * The still-empty high-value facts worth a focused search, in a stable order.
+ *
+ * For a company profile that is the one subject's empty fields; for a discovery
+ * scan it is one entry per company that is missing one. Empty when there is
+ * nothing left to recover.
+ */
+export const needsPerFieldSearch = (args: {
+	readonly findings: unknown
+	readonly schemaName: string
+	/** The subject's own name, used for a company profile's single subject. */
+	readonly subjectName: string
+}): ReadonlyArray<RescueTarget> => {
+	// The schema decides which shape to read, not whether a list happens to hold
+	// anything: a scan that came back with nothing is still a scan, and reading it
+	// as a profile would search for facts it has nowhere to put.
+	if (isDiscoveryScan(args.schemaName)) {
+		const targets: RescueTarget[] = []
+		for (const row of scanRowsOf(args.schemaName, args.findings)) {
+			const name = rowName(row)
+			if (name === undefined) continue
+			for (const field of SCAN_ROW_FIELDS) {
+				if (!hasRowValue(row[field])) targets.push({ name, field })
+			}
+		}
+		return targets
+	}
+	// No profile block means no slot to write a recovered value into, so a search
+	// would only pay for an answer with nowhere to go.
+	if (enrichmentOf(args.findings) === undefined) return []
+	const missing = new Set(enrichmentFill(args.findings).missing)
+	return HIGH_VALUE_FIELDS.filter(field => missing.has(field)).map(field => ({
+		name: args.subjectName,
+		field,
+	}))
+}
+
+/** How many searches one round may fire for this shape of run. */
+export const perFieldSearchCap = (schemaName: string): number =>
+	isDiscoveryScan(schemaName) ? MAX_SCAN_ROW_SEARCHES : MAX_PER_FIELD_SEARCHES
+
+// A short, human-readable label per fact, used to phrase the search.
+const FIELD_INTENT: Record<string, string> = {
+	country: 'head office country',
+	employee_estimate: 'number of employees',
+	industry: 'industry sector',
+	location: 'headquarters city address',
+	size_range: 'number of employees',
+	website: 'official website',
+}
+
+/**
+ * A focused web-search query for one missing fact: the company name (quoted so
  * search treats it as a phrase), the city if one was queried, and the fact wanted.
  * Example: `"Acme Corp" Barcelona number of employees`.
  */
@@ -64,24 +200,6 @@ export const perFieldSearchQuery = (
 	return `"${name.trim()}"${cityPart} ${intent}`
 }
 
-// A field is present only when it carries a non-empty string value; a missing key
-// or a `{ value: null }` a guard blanked still counts as empty.
-const hasValue = (fieldValue: unknown): boolean =>
-	fieldValue !== null &&
-	typeof fieldValue === 'object' &&
-	typeof (fieldValue as { value?: unknown }).value === 'string' &&
-	(fieldValue as { value: string }).value.trim() !== ''
-
-const enrichmentOf = (
-	findings: unknown,
-): Record<string, unknown> | undefined => {
-	if (findings === null || typeof findings !== 'object') return undefined
-	const enrichment = (findings as { enrichment?: unknown }).enrichment
-	return enrichment !== null && typeof enrichment === 'object'
-		? (enrichment as Record<string, unknown>)
-		: undefined
-}
-
 // The people a set of findings names, or none when it names nobody.
 const contactsOf = (
 	findings: unknown,
@@ -91,6 +209,93 @@ const contactsOf = (
 	return Array.isArray(contacts)
 		? (contacts as ReadonlyArray<Record<string, unknown>>)
 		: []
+}
+
+export interface PerFieldMerge {
+	readonly findings: unknown
+	/** How many empty facts the second look filled in. */
+	readonly filled: number
+	/** Whether the people list gained anyone, or gained a detail about anyone. */
+	readonly contactsChanged: boolean
+	/** How many companies the second look added that the first pass never named. */
+	readonly added: number
+}
+
+/**
+ * Fold a re-extraction over the enlarged evidence back into a scan's list.
+ *
+ * A company already found keeps everything it already had — a second look may
+ * only fill a blank, never overwrite a grounded value, and never remove a company
+ * from the list. A company the re-extraction names that the first pass did not is
+ * appended: the enlarged evidence is a wider read of the same question, so what it
+ * turns up is a find rather than a contradiction.
+ */
+const mergeScanRows = (
+	schemaName: string,
+	findings: unknown,
+	refreshed: unknown,
+): PerFieldMerge => {
+	const field = discoveryResultField(schemaName)
+	const known = scanRowsOf(schemaName, findings)
+	const found = scanRowsOf(schemaName, refreshed)
+	// An empty list of known companies is still worth folding into — the wider read
+	// can name companies the first pass missed entirely, which is the whole point
+	// of looking again. Only findings with nowhere to write are left alone.
+	if (
+		field === undefined ||
+		found.length === 0 ||
+		findings === null ||
+		typeof findings !== 'object'
+	) {
+		return { findings, filled: 0, contactsChanged: false, added: 0 }
+	}
+	const foundByName = new Map<string, Record<string, unknown>>()
+	for (const row of found) {
+		const name = rowName(row)
+		// First mention wins: a later duplicate of the same company in the same
+		// re-extraction has no better claim, and picking one keeps the fold stable.
+		if (name !== undefined && !foundByName.has(nameKey(name)))
+			foundByName.set(nameKey(name), row)
+	}
+	let filled = 0
+	const merged = known.map(row => {
+		const name = rowName(row)
+		const match =
+			name === undefined ? undefined : foundByName.get(nameKey(name))
+		if (match === undefined) return row
+		const next: Record<string, unknown> = { ...row }
+		let filledHere = 0
+		for (const key of SCAN_ROW_FIELDS) {
+			if (!hasRowValue(row[key]) && hasRowValue(match[key])) {
+				next[key] = match[key]
+				filledHere++
+			}
+		}
+		filled += filledHere
+		return filledHere === 0 ? row : next
+	})
+	const knownNames = new Set(
+		known.flatMap(row => {
+			const name = rowName(row)
+			return name === undefined ? [] : [nameKey(name)]
+		}),
+	)
+	const additions = found.filter(row => {
+		const name = rowName(row)
+		return name !== undefined && !knownNames.has(nameKey(name))
+	})
+	if (filled === 0 && additions.length === 0) {
+		return { findings, filled: 0, contactsChanged: false, added: 0 }
+	}
+	return {
+		findings: {
+			...(findings as object),
+			[field]: [...merged, ...additions],
+		},
+		filled,
+		contactsChanged: false,
+		added: additions.length,
+	}
 }
 
 /**
@@ -107,16 +312,15 @@ const contactsOf = (
 export const mergePerFieldSearch = (
 	findings: unknown,
 	refreshed: unknown,
-): {
-	readonly findings: unknown
-	readonly filled: number
-	/** Whether the people list gained anyone, or gained a detail about anyone. */
-	readonly contactsChanged: boolean
-} => {
+	schemaName: string,
+): PerFieldMerge => {
+	if (isDiscoveryScan(schemaName)) {
+		return mergeScanRows(schemaName, findings, refreshed)
+	}
 	const enrichment = enrichmentOf(findings)
 	const refreshedEnrichment = enrichmentOf(refreshed)
 	if (enrichment === undefined || refreshedEnrichment === undefined) {
-		return { findings, filled: 0, contactsChanged: false }
+		return { findings, filled: 0, contactsChanged: false, added: 0 }
 	}
 	let filled = 0
 	const nextEnrichment: Record<string, unknown> = { ...enrichment }
@@ -137,7 +341,7 @@ export const mergePerFieldSearch = (
 		contacts.length !== known.length ||
 		contacts.some((contact, index) => contact !== known[index])
 	if (filled === 0 && !contactsChanged) {
-		return { findings, filled: 0, contactsChanged: false }
+		return { findings, filled: 0, contactsChanged: false, added: 0 }
 	}
 	return {
 		findings: {
@@ -147,5 +351,6 @@ export const mergePerFieldSearch = (
 		},
 		filled,
 		contactsChanged,
+		added: 0,
 	}
 }

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -22,8 +22,9 @@
 
 import { mergeContacts } from './contacts-rescue'
 import { discoveryResultField, isDiscoveryScan } from './discovery-scan'
+import { collapse } from './entity-guard'
 import { enrichmentFill } from './extraction-fill'
-import { isValueWrapper, unwrapValue } from './guard-shapes'
+import { isPlainObject, isValueWrapper, unwrapValue } from './guard-shapes'
 
 // The company-profile facts worth spending an extra search on. `size_range` is
 // also nudged during the loop (headcount is rarely on the homepage); for the
@@ -35,15 +36,23 @@ export const HIGH_VALUE_FIELDS: ReadonlyArray<string> = [
 	'size_range',
 ]
 
-// The facts worth an extra search on one company a scan found. A scan is asked
-// for a list to work through, and a name alone cannot be worked with: the site is
-// how someone reaches the company, and the headcount is how they decide whether
-// it is worth reaching. Website comes first because it is the one a scan is most
-// often asked for and most often misses.
-export const SCAN_ROW_FIELDS: ReadonlyArray<string> = [
-	'website',
-	'employee_estimate',
-]
+// The facts worth an extra search on one company a scan found, per kind of scan.
+// A scan is asked for a list to work through, and a name alone cannot be worked
+// with: the site is how someone reaches the company, and the headcount is how
+// they decide whether it is worth reaching.
+//
+// Each field named here has to exist on that scan's own schema, or the search is
+// paid for and the answer has nowhere to land — a competitor is never asked for a
+// headcount, so asking the web for one would buy nothing. The test next door
+// checks each name against the real schema so the two cannot drift apart.
+const SCAN_ROW_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
+	prospect_scan_v1: ['website', 'employee_estimate'],
+	competitor_scan_v1: ['website'],
+}
+
+/** The facts worth searching for on one company this kind of scan found. */
+export const scanRowFields = (schemaName: string): ReadonlyArray<string> =>
+	SCAN_ROW_FIELDS_BY_SCHEMA[schemaName] ?? []
 
 // At most this many extra searches per round for a company profile: an all-empty
 // profile would otherwise fire one per field. Any missing field beyond the cap is
@@ -107,10 +116,7 @@ const scanRowsOf = (
 	if (findings === null || typeof findings !== 'object') return []
 	const rows = (findings as Record<string, unknown>)[field]
 	if (!Array.isArray(rows)) return []
-	return rows.filter(
-		(row): row is Record<string, unknown> =>
-			row !== null && typeof row === 'object' && !Array.isArray(row),
-	)
+	return rows.filter(isPlainObject)
 }
 
 /** The name a scan row goes by, or undefined when it names no company. */
@@ -125,14 +131,13 @@ const rowName = (row: Record<string, unknown>): string | undefined => {
  * The key two mentions of the same company share.
  *
  * A re-extraction reads the same company off a different page and writes the name
- * with different spacing or punctuation — `Acme S.L.` against `Acme S.L`. Folding
- * those together keeps one company from becoming two rows. It stops at
- * punctuation and case on purpose: dropping a legal suffix would fold `Acme` and
- * `Acme Holding` into one, and putting a recovered website on the wrong company
- * is far worse than listing it twice.
+ * differently — `Transports Munné, S.L.` against `Transports Munne SL`. Folding
+ * those together keeps one company from becoming two rows. The fold keeps the
+ * legal suffix, which is what has to happen here: dropping it would fold `Acme`
+ * and `Acme Holding` into one, and putting a recovered website on the wrong
+ * company is far worse than listing it twice.
  */
-const nameKey = (name: string): string =>
-	name.toLowerCase().replace(/[.,]/g, '').replace(/\s+/g, ' ').trim()
+const nameKey = (name: string): string => collapse(name)
 
 /**
  * The still-empty high-value facts worth a focused search, in a stable order.
@@ -155,7 +160,7 @@ export const needsPerFieldSearch = (args: {
 		for (const row of scanRowsOf(args.schemaName, args.findings)) {
 			const name = rowName(row)
 			if (name === undefined) continue
-			for (const field of SCAN_ROW_FIELDS) {
+			for (const field of scanRowFields(args.schemaName)) {
 				if (!hasRowValue(row[field])) targets.push({ name, field })
 			}
 		}
@@ -265,7 +270,7 @@ const mergeScanRows = (
 		if (match === undefined) return row
 		const next: Record<string, unknown> = { ...row }
 		let filledHere = 0
-		for (const key of SCAN_ROW_FIELDS) {
+		for (const key of scanRowFields(schemaName)) {
 			if (!hasRowValue(row[key]) && hasRowValue(match[key])) {
 				next[key] = match[key]
 				filledHere++
@@ -274,7 +279,11 @@ const mergeScanRows = (
 		filled += filledHere
 		return filledHere === 0 ? row : next
 	})
-	const knownNames = new Set(
+	// Grows as companies are taken, so one re-extraction naming the same new
+	// company twice appends it once. A duplicate would not only read badly — the
+	// list's length is what decides whether a scan came back too thin to trust,
+	// so counting one company twice can pass a scan off as healthier than it is.
+	const takenNames = new Set(
 		known.flatMap(row => {
 			const name = rowName(row)
 			return name === undefined ? [] : [nameKey(name)]
@@ -282,7 +291,9 @@ const mergeScanRows = (
 	)
 	const additions = found.filter(row => {
 		const name = rowName(row)
-		return name !== undefined && !knownNames.has(nameKey(name))
+		if (name === undefined || takenNames.has(nameKey(name))) return false
+		takenNames.add(nameKey(name))
+		return true
 	})
 	if (filled === 0 && additions.length === 0) {
 		return { findings, filled: 0, contactsChanged: false, added: 0 }

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -290,6 +290,38 @@ describe('buildResearchSystemPrompt', () => {
 		})
 	})
 
+	describe('when the run is a discovery scan', () => {
+		it('should tell it to break a many-part request up and work through it', () => {
+			// GIVEN a prospect scan, a competitor scan, and a run that is neither
+			const scan = buildResearchSystemPrompt({
+				schemaName: 'prospect_scan_v1',
+				subjectContext: '',
+				hintsContext: '',
+				segments: [],
+			})
+			const competitors = buildResearchSystemPrompt({
+				schemaName: 'competitor_scan_v1',
+				subjectContext: '',
+				hintsContext: '',
+				segments: [],
+			})
+			const profile = buildResearchSystemPrompt({
+				schemaName: 'company_enrichment_v1',
+				subjectContext: '',
+				hintsContext: '',
+				segments: [],
+			})
+
+			// THEN a scan is told to list the request's parts up front and to check
+			// them off before finishing, so it has a way to tell when it is done
+			expect(scan).toContain('break the request into its parts')
+			expect(scan).toContain('where a part has no companies yet')
+			expect(competitors).toContain('break the request into its parts')
+			// AND a run that is not a scan is not given a plan it has no use for
+			expect(profile).not.toContain('break the request into its parts')
+		})
+	})
+
 	describe('when segments are present', () => {
 		it('should place them below the invariants, each fenced', () => {
 			// GIVEN two resolved segments
@@ -407,6 +439,49 @@ describe('buildExtractionPrompt', () => {
 			expect(withVerdict).toContain('set `verdict`')
 			expect(withVerdict).toContain('disqualifiers')
 			expect(withoutVerdict).not.toContain('set `verdict`')
+		})
+
+		it('should ask a scan for breadth, as it already asks for every person', () => {
+			// GIVEN a discovery scan versus a run that profiles one company
+			const scan = buildExtractionPrompt({
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+				discoveryScan: true,
+			})
+			const profile = buildExtractionPrompt({
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+			})
+
+			// THEN the scan is pushed to list every company the evidence names, and to
+			// cover each part of a request that named several — nothing else in the
+			// pipeline ever asks a scan for breadth
+			expect(scan).toContain('List EVERY company')
+			expect(scan).toContain('not a small market')
+			expect(scan).toContain('Cover every part of the request')
+			// AND it is told to keep a company it could not find a website for, so
+			// asking for the site cannot quietly shorten the list
+			expect(scan).toContain('Never drop a company for want of a website')
+			// AND a run that profiles one company is still asked for its people
+			expect(profile).toContain('Name EVERY person')
+			expect(profile).not.toContain('List EVERY company')
+		})
+
+		it('should not ask a scan to fill a people list it does not have', () => {
+			// GIVEN a discovery scan, whose schema holds companies and no contacts
+			const scan = buildExtractionPrompt({
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+				discoveryScan: true,
+			})
+
+			// THEN it is never told that leaving the people list empty is incomplete —
+			// there is no such list on a scan, and saying so invites an invented one
+			expect(scan).not.toContain('Name EVERY person')
+			expect(scan).not.toContain('Leaving the people list empty')
 		})
 
 		it('should carry the anti-fabrication rules the guards depend on', () => {
@@ -1273,6 +1348,8 @@ describe('openedPages', () => {
 
 describe('citedUnscrapedSources', () => {
 	const hasNone = () => false
+	const PROFILE = 'company_enrichment_v1'
+	const SCAN = 'prospect_scan_v1'
 
 	describe('when company fields cite pages the run never fetched', () => {
 		it('should return each ordinary citation once, up to the cap', () => {
@@ -1286,11 +1363,11 @@ describe('citedUnscrapedSources', () => {
 			}
 
 			// WHEN collected — THEN deduped, in field order, and capped
-			expect(citedUnscrapedSources(findings, hasNone, 3)).toEqual([
+			expect(citedUnscrapedSources(PROFILE, findings, hasNone, 3)).toEqual([
 				'https://a.com/x',
 				'https://b.com/y',
 			])
-			expect(citedUnscrapedSources(findings, hasNone, 1)).toEqual([
+			expect(citedUnscrapedSources(PROFILE, findings, hasNone, 1)).toEqual([
 				'https://a.com/x',
 			])
 		})
@@ -1316,6 +1393,7 @@ describe('citedUnscrapedSources', () => {
 			// WHEN collected — THEN none qualify for a fetch
 			expect(
 				citedUnscrapedSources(
+					PROFILE,
 					findings,
 					hash => hash === urlHashForScrape('https://fetched.com/p'),
 					5,
@@ -1324,10 +1402,75 @@ describe('citedUnscrapedSources', () => {
 		})
 	})
 
-	describe('when findings are not an enrichment object', () => {
+	describe('when a discovery scan cites pages the run never fetched', () => {
+		it('should reach the pages the companies it found were read from', () => {
+			// GIVEN a scan whose companies cite pages, one of them twice
+			const findings = {
+				prospects: [
+					{
+						name: 'Acme',
+						citations: [
+							{ source_id: 'https://dir.test/acme' },
+							{ source_id: 'https://dir.test/list' },
+						],
+					},
+					{ name: 'Beta', citations: [{ source_id: 'https://dir.test/list' }] },
+				],
+			}
+
+			// WHEN collected
+			// THEN a scan's cited pages are reachable exactly as a profile's are,
+			// each one offered once
+			expect(citedUnscrapedSources(SCAN, findings, hasNone, 5)).toEqual([
+				'https://dir.test/acme',
+				'https://dir.test/list',
+			])
+		})
+
+		it('should ignore rows and citations that hold no source', () => {
+			// GIVEN a list carrying a row that is not an object, a row with no
+			// citations, a citations value that is not a list, and a citation with no id
+			const findings = {
+				prospects: [
+					'not a row',
+					{ name: 'A' },
+					{ name: 'B', citations: 'nope' },
+					{ name: 'C', citations: [{ quote: 'no id here' }, null] },
+					{ name: 'D', citations: [{ source_id: 'https://ok.test' }] },
+				],
+			}
+
+			// WHEN collected — THEN only the real citation survives
+			expect(citedUnscrapedSources(SCAN, findings, hasNone, 5)).toEqual([
+				'https://ok.test',
+			])
+		})
+	})
+
+	describe('when the schema is not a scan', () => {
+		it('should not read a list the schema does not have', () => {
+			// GIVEN a profile run whose findings happen to carry a prospects list
+			const findings = {
+				prospects: [
+					{ name: 'A', citations: [{ source_id: 'https://stray.test' }] },
+				],
+			}
+			// WHEN collected under the profile schema
+			// THEN the stray list is not read — the schema says which shape this is
+			expect(citedUnscrapedSources(PROFILE, findings, hasNone, 5)).toEqual([])
+		})
+	})
+
+	describe('when findings hold nothing to cite', () => {
 		it('should return nothing', () => {
-			expect(citedUnscrapedSources({ error: 'x' }, hasNone, 3)).toEqual([])
-			expect(citedUnscrapedSources(null, hasNone, 3)).toEqual([])
+			expect(
+				citedUnscrapedSources(PROFILE, { error: 'x' }, hasNone, 3),
+			).toEqual([])
+			expect(citedUnscrapedSources(PROFILE, null, hasNone, 3)).toEqual([])
+			expect(citedUnscrapedSources(SCAN, null, hasNone, 3)).toEqual([])
+			expect(
+				citedUnscrapedSources(SCAN, { prospects: 'x' }, hasNone, 3),
+			).toEqual([])
 		})
 	})
 })

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -2315,9 +2315,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						(run as { entityMatch?: EntityMatch | null }).entityMatch ?? null
 
 					// The target's display name, to re-anchor a web search that dropped it:
-					// an anchored subject's own name, else the name read from the query. Used
-					// only when `entityTargets` is set (an enrichment/contact run with one
-					// subject); a scan/freeform run never scopes its searches to a name.
+					// an anchored subject's own name, else the name read from the query. It
+					// is what a run with one subject searches under. A scan is handed it too
+					// and ignores it, since every company a scan found carries its own name.
 					const entityName =
 						subjectTargets
 							.map(s => s.name)
@@ -4543,6 +4543,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						// so one that yields nothing is not re-fetched every round — otherwise
 						// it never enters the corpus and keeps reappearing as cited-but-unscraped.
 						const citedAttempted = new Set<string>()
+						// Every gap already searched for, so a round moves on to the
+						// companies behind it. A round takes the first few gaps it finds, and
+						// a headcount a small firm never publishes stays a gap however often
+						// it is asked — without this, those first few would take every round's
+						// searches and the rest of a long list would never be reached at all.
+						const gapsSearched = new Set<string>()
 						for (let gapRound = 1; gapRound <= MAX_GAP_ROUNDS; gapRound++) {
 							// Who the focused searches are about. A company profile searches
 							// under the anchored subject's name, which is the same name the
@@ -4553,10 +4559,14 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								schemaName,
 								subjectName: entityName,
 							})
-							const perFieldTargets = perFieldGaps.slice(
-								0,
-								perFieldSearchCap(schemaName),
-							)
+							const perFieldTargets = perFieldGaps
+								.filter(
+									target => !gapsSearched.has(`${target.name} ${target.field}`),
+								)
+								.slice(0, perFieldSearchCap(schemaName))
+							for (const target of perFieldTargets) {
+								gapsSearched.add(`${target.name} ${target.field}`)
+							}
 							const openedHashes = new Set(
 								openedPages(scrapeCorpus).map(page => page.urlHash),
 							)
@@ -4732,20 +4742,56 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// as absent and the quality signal reports the thinness.
 							if (roundHashes.length === 0) break
 							yield* linkRunSources(roundHashes)
-							const perFieldAnchorFirst = [...scrapeCorpus].sort(
-								(a, b) =>
-									(anchorHashes.has(a.urlHash) ? 0 : 1) -
-									(anchorHashes.has(b.urlHash) ? 0 : 1),
-							)
+							// What this round just bought goes to the front, then the
+							// company's own pages. The extraction prompt fills to a character
+							// budget and stops, and a broad scan's corpus reaches that budget
+							// on the pages phase 1 already gathered — so evidence appended at
+							// the end is paid for and then never read.
+							const roundFirst = new Set(roundHashes)
+							const perFieldAnchorFirst = [...scrapeCorpus].sort((a, b) => {
+								const rank = (page: (typeof scrapeCorpus)[number]): number =>
+									roundFirst.has(page.urlHash)
+										? 0
+										: anchorHashes.has(page.urlHash)
+											? 1
+											: 2
+								return rank(a) - rank(b)
+							})
+							// A scan's answer is a list of other companies, so holding its
+							// evidence against the anchor's name would drop exactly the pages
+							// these searches went and bought — a competitor's own site does not
+							// mention the company it competes with.
+							const roundTargets = isDiscoveryScan(schemaName)
+								? null
+								: entityTargets
 							const refreshed = yield* extractStructuredFindings(
 								researchText,
 								[
 									evidenceText,
 									...seededEvidenceParts,
-									...groundedPageTexts(entityTargets, scrapeCorpus),
+									...groundedPageTexts(roundTargets, scrapeCorpus),
 								].join('\n'),
-								labelledGroundedPages(entityTargets, perFieldAnchorFirst),
+								labelledGroundedPages(roundTargets, perFieldAnchorFirst),
+							).pipe(
+								// A round is a best-effort extra. A vendor that times out on the
+								// enlarged evidence must not take the run down with it: what the
+								// run already found is worth keeping, and it is what a person
+								// asked for. A cancel or a deploy still unwinds the run.
+								Effect.catchCause(cause =>
+									Cause.hasInterruptsOnly(cause)
+										? Effect.failCause(cause)
+										: Effect.logWarning('research.gap_rounds.refresh_failed')
+												.pipe(
+													Effect.annotateLogs({
+														research_id: researchId,
+														round: gapRound,
+														cause: Cause.pretty(cause),
+													}),
+												)
+												.pipe(Effect.as(null)),
+								),
 							)
+							if (refreshed === null) break
 							const merged = mergePerFieldSearch(
 								findings,
 								refreshed.findings,
@@ -4771,15 +4817,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									added: merged.added,
 								}),
 							)
-							// A round that filled nothing, found nobody new and resolved no
-							// cited page has stopped closing gaps — stop before burning the
-							// remaining rounds on the same result.
-							if (
-								merged.filled === 0 &&
-								merged.added === 0 &&
-								citedUnscraped.length === 0
-							)
-								break
+							// This round put new evidence in front of the model and it still
+							// filled nothing and found nobody — so the gaps that are left are
+							// not going to close, and another round would buy the same
+							// nothing. A scan cites a page or three per company, so waiting
+							// for the cited pages to run out first would never stop it.
+							if (merged.filled === 0 && merged.added === 0) break
 						}
 						yield* Ref.update(toolLog, log => [
 							...log,

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -60,6 +60,7 @@ import {
 } from './discovered-existing-guard'
 import {
 	discoveryResultCount,
+	discoveryResultField,
 	emptyScanFindings,
 	isDiscoveryScan,
 	isDiscoveryScanEmpty,
@@ -104,9 +105,9 @@ import {
 import { type GuardLink, runGuardChain } from './guard-chain'
 import { normalizePaidActionTool } from './paid-action-tool'
 import {
-	MAX_PER_FIELD_SEARCHES,
 	mergePerFieldSearch,
 	needsPerFieldSearch,
+	perFieldSearchCap,
 	perFieldSearchQuery,
 } from './per-field-search'
 import { resolvePolicy, type SystemDefaults } from './policy'
@@ -394,27 +395,58 @@ export const openedPages = <
 	corpus: ReadonlyArray<Entry>,
 ): ReadonlyArray<Entry> => corpus.filter(entry => entry.kind === 'page')
 
-// The cited-but-never-fetched sources of an enrichment's company fields — the
-// citations the per-source entity check had to fail open on. A gap round
-// scrapes these first: fetching the cited page turns fail-open into a real
-// verdict, and the page often carries the very facts still missing. Blocked
-// namespaces (posts, person pages) are skipped — fetching one changes nothing —
-// and so is anything that is not a web address, such as an internal id naming a
-// page the run already holds.
+/**
+ * Every source a set of findings leans on, in the order it cites them. A company
+ * profile cites one source per field; a discovery scan cites them per company it
+ * found, and both shapes are read here.
+ */
+const citedSourceIds = (
+	schemaName: string,
+	findings: unknown,
+): ReadonlyArray<string> => {
+	if (findings === null || typeof findings !== 'object') return []
+	const out: string[] = []
+	const enrichment = (findings as { enrichment?: unknown }).enrichment
+	if (enrichment !== null && typeof enrichment === 'object') {
+		for (const value of Object.values(enrichment as Record<string, unknown>)) {
+			if (value === null || typeof value !== 'object') continue
+			const id = (value as { source_id?: unknown }).source_id
+			if (typeof id === 'string') out.push(id)
+		}
+	}
+	const listField = discoveryResultField(schemaName)
+	if (listField === undefined) return out
+	const rows = (findings as Record<string, unknown>)[listField]
+	if (!Array.isArray(rows)) return out
+	for (const row of rows) {
+		if (row === null || typeof row !== 'object') continue
+		const citations = (row as { citations?: unknown }).citations
+		if (!Array.isArray(citations)) continue
+		for (const citation of citations) {
+			if (citation === null || typeof citation !== 'object') continue
+			const id = (citation as { source_id?: unknown }).source_id
+			if (typeof id === 'string') out.push(id)
+		}
+	}
+	return out
+}
+
+// The cited sources the run never fetched — the citations the per-source entity
+// check had to fail open on. A gap round scrapes these first: fetching the cited
+// page turns fail-open into a real verdict, and the page often carries the very
+// facts still missing. Blocked namespaces (posts, person pages) are skipped —
+// fetching one changes nothing — and so is anything that is not a web address,
+// such as an internal id naming a page the run already holds.
 export const citedUnscrapedSources = (
+	schemaName: string,
 	findings: unknown,
 	hasPage: (urlHash: string) => boolean,
 	cap: number,
 ): ReadonlyArray<string> => {
-	if (findings === null || typeof findings !== 'object') return []
-	const enrichment = (findings as { enrichment?: unknown }).enrichment
-	if (enrichment === null || typeof enrichment !== 'object') return []
 	const out: string[] = []
 	const seen = new Set<string>()
-	for (const value of Object.values(enrichment as Record<string, unknown>)) {
-		if (value === null || typeof value !== 'object') continue
-		const id = (value as { source_id?: unknown }).source_id
-		if (typeof id !== 'string' || id.trim() === '') continue
+	for (const id of citedSourceIds(schemaName, findings)) {
+		if (id.trim() === '') continue
 		if (seen.has(id)) continue
 		seen.add(id)
 		if (classifyNamespace(id) !== null) continue
@@ -1069,6 +1101,16 @@ export const computeResearchCacheKey = (args: {
 	)
 }
 
+// What a discovery scan is told about covering a request that has several parts
+// to it. A request naming five trades across seventeen regions is roughly eighty
+// searches; handed no plan, a scan fires a handful and stops of its own accord
+// with rounds still unspent, because nothing tells it what finished looks like.
+// The rounds and the budget are not the constraint, so this is guidance rather
+// than machinery: the loop lets the model choose each search, and this gives it a
+// reason to keep choosing.
+const DISCOVERY_PLAN_DIRECTIVE =
+	'Before searching, break the request into its parts — each sector, trade, speciality, region, or country it names — and hold that list for the whole run. Work through it: a request naming several parts is not answered by results for one or two of them, however many companies those turn up. Prefer a search aimed at one part over a single broad search meant to cover them all, since a broad one returns the same well-known names every time. Before you finish, check the list: where a part has no companies yet, search for that part specifically rather than stopping.'
+
 // Assemble the phase-1 system prompt. Resolved instruction segments are fenced
 // and placed BELOW the invariants (never fabricate sources, etc.) so a template
 // can't override them — fencing is mitigation, not a guarantee.
@@ -1094,6 +1136,7 @@ export const buildResearchSystemPrompt = (args: {
 		'Name the people who run the company — each with the exact title they are given — and treat that as part of the job, not an extra. They are listed on a team, leadership, management or "equipo" page, almost never on the homepage, so open one when the site has it. When reading the pages turns up nobody with a title, discover_contacts is the tool that finds them.',
 		'A search result quotes only the one sentence of a page that matched your query. When a page looks like it holds more than that sentence, open it with scrape_page rather than settling for the snippet.',
 		'For discovery or prospecting queries, prefer authoritative sources — business directories, industry association member lists, and sector registries — over social media, forums, or glossary pages. Treat such a page as somewhere to find candidates, not as the answer: a "top N" or "largest" ranking lists the biggest firms in a sector, which is the opposite of what most prospecting asks for. Carry every qualifier in the request — size, place, and niche — into each search, and check each candidate against all of them before returning it; leave out one that fails any, however prominently a directory listed it.',
+		...(isDiscoveryScan(args.schemaName) ? [DISCOVERY_PLAN_DIRECTIVE] : []),
 		schemaFields.length === 0
 			? `Output schema: ${args.schemaName}`
 			: `Output schema: ${args.schemaName}. Come back with everything it holds, not only the facts named above: ${schemaFields.join(', ')}. Leave a field out when the evidence does not support it — never fill one by guessing.`,
@@ -1182,6 +1225,23 @@ const proposeContactDirective = (companyId: string): string =>
 		'Offer a person even when no address for them can be found: the name and the job title are the useful part on their own. Still list them in the people list as well — the offer is in addition to that list, not instead of it. Never offer somebody the evidence describes as a client, a partner, a supplier, or a competitor.',
 	].join('\n')
 
+// The breadth ask for a discovery scan. A scan is asked for a list to work
+// through, and nothing else in the pipeline says so — the other discovery-shaped
+// lines all narrow. It names the source kinds that carry many companies at once,
+// and asks for the website and headcount by name, since those are what a list is
+// asked for and what it most often comes back missing. The closing line carries
+// as much weight as the opening one: a company whose site the evidence never
+// gives must still be listed, or asking for the site would quietly shrink the
+// list.
+const DISCOVERY_BREADTH_DIRECTIVE =
+	'List EVERY company the evidence identifies that matches the request — every one named on a directory page, an association or trade-body member list, a sector ranking, a news article, a register extract, or a search result — not only the ones the evidence describes at length. The evidence routinely names far more companies than a first pass returns, and coming back with a handful while it names dozens is an incomplete extraction, not a small market. Cover every part of the request: where it asks about several sectors, trades, regions, or countries, each one needs its own companies in the list rather than whichever the evidence happened to describe first. For each company give its own official website wherever the evidence states one, and its employee count wherever a source states one. Never drop a company for want of a website or a headcount — list it by name with the fields the evidence does support.'
+
+// Asks the model to land the fit judgement in the structured output, not only in
+// the brief. Applies only to the enrichment schema, which is the one that
+// carries the verdict/disqualifiers/fit_checks fields.
+const FIT_VERDICT_DIRECTIVE =
+	'Decide whether this company fits the target customer profile using the fit rules in the instructions above, and record it: set `verdict` (strong_fit / possible_fit / weak_fit / no_fit) with a short `verdict_rationale`; for a company that fails a rule, list each failure in `disqualifiers` with the rule and the evidence quote that shows it. Also fill `fit_checks` with one row per fit rule in the instructions — every rule, including the ones the company passes — each marked pass, fail, or unknown per the evidence, with the quote and source URL that decide it.'
+
 /**
  * The instruction for the structured-extraction pass: read the gathered evidence
  * and fill the output schema from it.
@@ -1199,29 +1259,34 @@ const proposeContactDirective = (companyId: string): string =>
  * an instruction to propose a correction wherever the evidence disagrees — the only
  * way a run turns up an edit for a company it was handed rather than one it found.
  */
-// Asks the model to land the fit judgement in the structured output, not only in
-// the brief. Applies only to the enrichment schema, which is the one that
-// carries the verdict/disqualifiers/fit_checks fields.
-const FIT_VERDICT_DIRECTIVE =
-	'Decide whether this company fits the target customer profile using the fit rules in the instructions above, and record it: set `verdict` (strong_fit / possible_fit / weak_fit / no_fit) with a short `verdict_rationale`; for a company that fails a rule, list each failure in `disqualifiers` with the rule and the evidence quote that shows it. Also fill `fit_checks` with one row per fit rule in the instructions — every rule, including the ones the company passes — each marked pass, fail, or unknown per the evidence, with the quote and source URL that decide it.'
-
 export const buildExtractionPrompt = (args: {
 	readonly citationInstruction: string
 	readonly evidenceBlock: string
 	readonly subjects: ReadonlyArray<SubjectForPrompt>
 	readonly fitVerdict?: boolean
+	/** Whether this run is a discovery scan, whose answer is a list of companies. */
+	readonly discoveryScan?: boolean
 }): string => {
 	const lines = [
 		'Produce structured findings STRICTLY from the evidence below (the fetched pages and the research transcript).',
 		'',
 		"Read ALL of the evidence to the end — every fetched page and every search result in the transcript — and report every fact it states; the evidence routinely states far more than a first pass returns. Report the industry, employee-count band, location, country, and the company's own operational software wherever the evidence states them — including on a third-party page rather than the company's own site.",
 		'',
-		"Name EVERY person the evidence identifies as this company's own leader or employee — a titled executive on the team page, a quoted founder, a signed author — each with the exact job title the evidence gives them. Leaving the people list empty while the evidence names the company's own staff is an incomplete extraction.",
+	]
+	// The breadth ask, addressed to whichever list this run's answer actually is.
+	// A scan is asked for companies and has no people list to fill; saying both
+	// would push it to invent one.
+	lines.push(
+		args.discoveryScan
+			? DISCOVERY_BREADTH_DIRECTIVE
+			: "Name EVERY person the evidence identifies as this company's own leader or employee — a titled executive on the team page, a quoted founder, a signed author — each with the exact job title the evidence gives them. Leaving the people list empty while the evidence names the company's own staff is an incomplete extraction.",
 		'',
+	)
+	lines.push(
 		"Report ONLY what the evidence states. If it does not support a field, omit it or leave it null — never fill a field from prior knowledge, never guess, and never put a placeholder or the field's own name as its value. Leaving a field empty is always better than inventing a value for it.",
 		'',
 		"When sources disagree on a time-sensitive fact (employee count, tools in use, leadership), fill the field from the most recently published reading among sources of equal standing — the company's own site still outranks an aggregator — and record each reading the field did not take in `conflicts`, with its value and the URL of the source that stated it.",
-	]
+	)
 	if (args.subjects.length > 0) {
 		lines.push(
 			'',
@@ -2594,6 +2659,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									evidenceBlock,
 									subjects: subjectsForPrompt(subjects),
 									fitVerdict: schemaName === 'company_enrichment_v1',
+									discoveryScan: isDiscoveryScan(schemaName),
 								}),
 							})
 							// Fold the harvested role mailbox in before the ids are stamped, so
@@ -4409,6 +4475,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						// so tick once to show the run is moving.
 						yield* recordProgress
 					} else {
+						// The company's own (anchor-seeded) pages. Both the first extraction
+						// and the gap rounds below put them ahead of everything else, so the
+						// set is built once here rather than inside either.
+						const anchorHashes = new Set(seededAnchorHashes)
 						if (retryFindings !== undefined) {
 							// The discovery-scan retry path already ran extraction under the
 							// shared budget — reuse those findings.
@@ -4417,7 +4487,6 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// Fill the phase-2 page budget with the company's own
 							// (anchor-seeded) pages first, so if the budget truncates it drops
 							// third-party pages, never the official site the run grounds on.
-							const anchorHashes = new Set(seededAnchorHashes)
 							const anchorFirstCorpus = [...scrapeCorpus].sort(
 								(a, b) =>
 									(anchorHashes.has(a.urlHash) ? 0 : 1) -
@@ -4446,247 +4515,271 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									'research.entity.downgraded_source',
 								).pipe(Effect.annotateLogs({ research_id: researchId }))
 							}
-							// Gap rounds: for each high-value firmographic the broad pass and
-							// the focused rescues still left empty, first fetch the cited
-							// pages the run never opened (turning the per-source check's
-							// fail-open into a real verdict on the cited page), then fire one
-							// focused web search per missing field, and re-extract over the
-							// enlarged evidence. Loops while the gaps keep closing —
-							// hard-capped, and every round first checks the wall-clock and
-							// budget margin, because finishing low-confidence is a result
-							// while riding into the terminal run deadline loses the run.
-							// Phase-2 runs outside the loop's Budget scope, so each round
-							// tallies its scrape/search cost into gapSpentCents to keep the
-							// margin check and the stamped cost honest.
-							const gapSearch = yield* SearchProvider
-							const gapScrape = yield* ScrapeProvider
-							const perFieldTargetName =
-								(run as { query: string }).query.split(',')[0]?.trim() ||
-								(run as { query: string }).query
-							// Cited pages already attempted this run (fetched, empty, or errored),
-							// so one that yields nothing is not re-fetched every round — otherwise
-							// it never enters the corpus and keeps reappearing as cited-but-unscraped.
-							const citedAttempted = new Set<string>()
-							for (let gapRound = 1; gapRound <= MAX_GAP_ROUNDS; gapRound++) {
-								const perFieldMissing = needsPerFieldSearch(findings).slice(
-									0,
-									MAX_PER_FIELD_SEARCHES,
-								)
-								const openedHashes = new Set(
-									openedPages(scrapeCorpus).map(page => page.urlHash),
-								)
-								const citedUnscraped = citedUnscrapedSources(
-									findings,
-									hash => openedHashes.has(hash) || citedAttempted.has(hash),
-									MAX_CITED_SCRAPES_PER_ROUND,
-								)
-								// Grounded and fully fetched — nothing left to close.
-								if (perFieldMissing.length === 0 && citedUnscraped.length === 0)
-									break
-								const elapsedMs =
-									DateTime.toEpochMillis(DateTime.nowUnsafe()) - runStartedAtMs
-								const thinDeadline =
-									elapsedMs >
-									runDeadlineSeconds * 1000 * GAP_ROUND_DEADLINE_FRACTION
-								// Phase 2 has no live budget scope; the margin reads the run's
-								// policy budget less everything spent so far — phase 1 plus the
-								// gap rounds already run — so it actually tightens each round.
-								const gapPolicy = (run as { paidPolicy: ResolvedPolicy | null })
-									.paidPolicy
-								const thinBudget =
-									(gapPolicy?.budgetCents ?? 0) -
-										cheapSpentCents -
-										gapSpentCents <
-									SCRAPE_COST_CENTS * 2
-								if (thinDeadline || thinBudget) {
-									yield* Effect.logInfo('research.gap_rounds.stopped').pipe(
-										Effect.annotateLogs({
-											research_id: researchId,
-											round: gapRound,
-											reason: thinDeadline
-												? 'deadline_margin'
-												: 'budget_margin',
-										}),
-									)
-									break
-								}
-								// Counted here, past both stop checks: the body below can leave
-								// by several different exits, so a round counted at the end
-								// would go unreported whenever it takes one of them.
-								yield* recordProgress
-								const roundHashes: string[] = []
-								// Fetch the cited pages first: cheap certainty about sources
-								// the run already leans on.
-								yield* Effect.forEach(
-									citedUnscraped,
-									citedUrl =>
-										Effect.gen(function* () {
-											// Mark the attempt (fetched, empty, or errored) so a page that
-											// yields nothing is not re-fetched next round.
-											citedAttempted.add(urlHashForScrape(citedUrl))
-											if (isUnsupportedScrapeUrl(citedUrl)) return
-											const cited = yield* gapScrape.scrape({
-												url: citedUrl,
-												formats: ['markdown'],
-											})
-											// Charged once the fetch is back, so a URL that errors out
-											// leaves the round's remaining budget intact.
-											gapSpentCents += SCRAPE_COST_CENTS
-											if (
-												cited.markdown !== undefined &&
-												cited.markdown.trim().length > 0
-											) {
-												const citedHash = urlHashForScrape(cited.url)
-												roundHashes.push(citedHash)
-												scrapeCorpus.push({
-													urlHash: citedHash,
-													text: cited.markdown,
-													host: domainHost(cited.resolvedUrl ?? cited.url),
-													kind: 'page',
-												})
-											}
-										}).pipe(
-											// Let a pure interruption (cancel/deploy) unwind the run instead of
-											// being logged as a skip while the loop keeps spending.
-											Effect.catchCause(cause =>
-												Cause.hasInterruptsOnly(cause)
-													? Effect.failCause(cause)
-													: Effect.logInfo(
-															'research.gap_rounds.cited_scrape_skipped',
-														).pipe(
-															Effect.annotateLogs({
-																research_id: researchId,
-																url: citedUrl,
-																cause: Cause.pretty(cause),
-															}),
-														),
-											),
-										),
-									{ concurrency: GAP_ROUND_CONCURRENCY },
-								)
-								// Cited pages fetched: re-judge the kept fields against them
-								// right away — the point of fetching is that a wrong-company
-								// page can now void the field it sourced, no LLM call needed.
-								if (roundHashes.length > 0 && entityTargets) {
-									const gapOpenedByHash = new Map(
-										openedPages(scrapeCorpus).map(
-											page =>
-												[
-													page.urlHash,
-													{ text: page.text, host: page.host },
-												] as const,
-										),
-									)
-									const recheck = guardEntitySources(
-										findings,
-										entityTargets,
-										sourceId => gapOpenedByHash.get(urlHashForScrape(sourceId)),
-									)
-									findings = recheck.findings
-									if (recheck.droppedOffEntity > 0) {
-										if (entityMatch === 'strong') entityMatch = 'weak'
-										yield* Effect.logWarning(
-											'research.gap_rounds.cited_voided',
-										).pipe(
-											Effect.annotateLogs({
-												research_id: researchId,
-												dropped: recheck.droppedOffEntity,
-											}),
-										)
-									}
-								}
-								// Nothing missing: the cited fetches were the whole round —
-								// link them and let the next round's top check close the loop.
-								if (perFieldMissing.length === 0) {
-									if (roundHashes.length > 0) yield* linkRunSources(roundHashes)
-									continue
-								}
-								const perFieldFired = perFieldMissing.length
-								yield* Effect.forEach(
-									perFieldMissing,
-									field =>
-										Effect.gen(function* () {
-											gapSpentCents += SEARCH_COST_CENTS
-											const searched = yield* gapSearch
-												.search({
-													query: perFieldSearchQuery(
-														perFieldTargetName,
-														hintLocation,
-														field,
-													),
-													limit: 3,
-													location: hintLocation,
-												})
-												.pipe(
-													// Let a pure interruption (cancel/deploy) unwind the run instead of
-													// being swallowed as an empty result while the loop keeps spending.
-													Effect.catchCause(cause =>
-														Cause.hasInterruptsOnly(cause)
-															? Effect.failCause(cause)
-															: Effect.succeed(null),
-													),
-												)
-											for (const item of searched?.items ?? []) {
-												const host = domainHost(item.url)
-												if (host !== undefined) searchResultHosts.add(host)
-												if (item.content && item.content.trim().length > 0) {
-													const hash = urlHashForScrape(item.url)
-													roundHashes.push(hash)
-													scrapeCorpus.push({
-														urlHash: hash,
-														text: item.content,
-														host,
-														kind: 'passage',
-													})
-												}
-											}
-										}),
-									{ concurrency: GAP_ROUND_CONCURRENCY },
-								)
-								// Nothing new reached the evidence — more rounds would only
-								// repeat the same searches, so the remaining gaps are treated
-								// as absent and the quality signal reports the thinness.
-								if (roundHashes.length === 0) break
-								yield* linkRunSources(roundHashes)
-								const perFieldAnchorFirst = [...scrapeCorpus].sort(
-									(a, b) =>
-										(anchorHashes.has(a.urlHash) ? 0 : 1) -
-										(anchorHashes.has(b.urlHash) ? 0 : 1),
-								)
-								const refreshed = yield* extractStructuredFindings(
-									researchText,
-									[
-										evidenceText,
-										...seededEvidenceParts,
-										...groundedPageTexts(entityTargets, scrapeCorpus),
-									].join('\n'),
-									labelledGroundedPages(entityTargets, perFieldAnchorFirst),
-								)
-								const merged = mergePerFieldSearch(findings, refreshed.findings)
-								findings = merged.findings
-								yield* Effect.annotateCurrentSpan({
-									'research.gap_rounds.round': gapRound,
-									'research.per_field_search.fired': perFieldFired,
-									'research.per_field_search.filled': merged.filled,
-									'research.gap_rounds.contacts_kept':
-										contactFill(findings).named,
-									'research.gap_rounds.titled_kept':
-										contactFill(findings).titled,
-								})
-								yield* Effect.logInfo('research.gap_rounds.closed').pipe(
+						}
+						// Gap rounds: for each high-value fact the broad pass and the
+						// focused rescues still left empty, first fetch the cited
+						// pages the run never opened (turning the per-source check's
+						// fail-open into a real verdict on the cited page), then fire one
+						// focused web search per missing fact, and re-extract over the
+						// enlarged evidence.
+						//
+						// The gaps are read per subject, so a scan's list is reached the
+						// same way a single company profile is: one company missing its
+						// website is a gap exactly as a profile missing its country is.
+						// This sits outside the branch above so a scan that came back thin
+						// gets its rounds too — it takes the refined-retry path, and it is
+						// the run with the most left to fill in.
+						//
+						// Loops while the gaps keep closing — hard-capped, and every round
+						// first checks the wall-clock and budget margin, because finishing
+						// low-confidence is a result while riding into the terminal run
+						// deadline loses the run. Phase-2 runs outside the loop's Budget
+						// scope, so each round tallies its scrape/search cost into
+						// gapSpentCents to keep the margin check and the stamped cost
+						// honest.
+						const gapSearch = yield* SearchProvider
+						const gapScrape = yield* ScrapeProvider
+						// Cited pages already attempted this run (fetched, empty, or errored),
+						// so one that yields nothing is not re-fetched every round — otherwise
+						// it never enters the corpus and keeps reappearing as cited-but-unscraped.
+						const citedAttempted = new Set<string>()
+						for (let gapRound = 1; gapRound <= MAX_GAP_ROUNDS; gapRound++) {
+							// Who the focused searches are about. A company profile searches
+							// under the anchored subject's name, which is the same name the
+							// entity guard holds the run's evidence to. A scan is handed it
+							// and ignores it: every company it found carries its own name.
+							const perFieldGaps = needsPerFieldSearch({
+								findings,
+								schemaName,
+								subjectName: entityName,
+							})
+							const perFieldTargets = perFieldGaps.slice(
+								0,
+								perFieldSearchCap(schemaName),
+							)
+							const openedHashes = new Set(
+								openedPages(scrapeCorpus).map(page => page.urlHash),
+							)
+							const citedUnscraped = citedUnscrapedSources(
+								schemaName,
+								findings,
+								hash => openedHashes.has(hash) || citedAttempted.has(hash),
+								MAX_CITED_SCRAPES_PER_ROUND,
+							)
+							// Grounded and fully fetched — nothing left to close.
+							if (perFieldTargets.length === 0 && citedUnscraped.length === 0)
+								break
+							const elapsedMs =
+								DateTime.toEpochMillis(DateTime.nowUnsafe()) - runStartedAtMs
+							const thinDeadline =
+								elapsedMs >
+								runDeadlineSeconds * 1000 * GAP_ROUND_DEADLINE_FRACTION
+							// Phase 2 has no live budget scope; the margin reads the run's
+							// policy budget less everything spent so far — phase 1 plus the
+							// gap rounds already run — so it actually tightens each round.
+							const gapPolicy = (run as { paidPolicy: ResolvedPolicy | null })
+								.paidPolicy
+							const thinBudget =
+								(gapPolicy?.budgetCents ?? 0) -
+									cheapSpentCents -
+									gapSpentCents <
+								SCRAPE_COST_CENTS * 2
+							if (thinDeadline || thinBudget) {
+								yield* Effect.logInfo('research.gap_rounds.stopped').pipe(
 									Effect.annotateLogs({
 										research_id: researchId,
 										round: gapRound,
-										cited_fetched: citedUnscraped.length,
-										fired: perFieldFired,
-										filled: merged.filled,
+										reason: thinDeadline ? 'deadline_margin' : 'budget_margin',
 									}),
 								)
-								// A round that filled nothing and resolved no cited page has
-								// stopped closing gaps — stop before burning the remaining
-								// rounds on the same result.
-								if (merged.filled === 0 && citedUnscraped.length === 0) break
+								break
 							}
+							// Counted here, past both stop checks: the body below can leave
+							// by several different exits, so a round counted at the end
+							// would go unreported whenever it takes one of them.
+							yield* recordProgress
+							const roundHashes: string[] = []
+							// Fetch the cited pages first: cheap certainty about sources
+							// the run already leans on.
+							yield* Effect.forEach(
+								citedUnscraped,
+								citedUrl =>
+									Effect.gen(function* () {
+										// Mark the attempt (fetched, empty, or errored) so a page that
+										// yields nothing is not re-fetched next round.
+										citedAttempted.add(urlHashForScrape(citedUrl))
+										if (isUnsupportedScrapeUrl(citedUrl)) return
+										const cited = yield* gapScrape.scrape({
+											url: citedUrl,
+											formats: ['markdown'],
+										})
+										// Charged once the fetch is back, so a URL that errors out
+										// leaves the round's remaining budget intact.
+										gapSpentCents += SCRAPE_COST_CENTS
+										if (
+											cited.markdown !== undefined &&
+											cited.markdown.trim().length > 0
+										) {
+											const citedHash = urlHashForScrape(cited.url)
+											roundHashes.push(citedHash)
+											scrapeCorpus.push({
+												urlHash: citedHash,
+												text: cited.markdown,
+												host: domainHost(cited.resolvedUrl ?? cited.url),
+												kind: 'page',
+											})
+										}
+									}).pipe(
+										// Let a pure interruption (cancel/deploy) unwind the run instead of
+										// being logged as a skip while the loop keeps spending.
+										Effect.catchCause(cause =>
+											Cause.hasInterruptsOnly(cause)
+												? Effect.failCause(cause)
+												: Effect.logInfo(
+														'research.gap_rounds.cited_scrape_skipped',
+													).pipe(
+														Effect.annotateLogs({
+															research_id: researchId,
+															url: citedUrl,
+															cause: Cause.pretty(cause),
+														}),
+													),
+										),
+									),
+								{ concurrency: GAP_ROUND_CONCURRENCY },
+							)
+							// Cited pages fetched: re-judge the kept fields against them
+							// right away — the point of fetching is that a wrong-company
+							// page can now void the field it sourced, no LLM call needed.
+							if (roundHashes.length > 0 && entityTargets) {
+								const gapOpenedByHash = new Map(
+									openedPages(scrapeCorpus).map(
+										page =>
+											[
+												page.urlHash,
+												{ text: page.text, host: page.host },
+											] as const,
+									),
+								)
+								const recheck = guardEntitySources(
+									findings,
+									entityTargets,
+									sourceId => gapOpenedByHash.get(urlHashForScrape(sourceId)),
+								)
+								findings = recheck.findings
+								if (recheck.droppedOffEntity > 0) {
+									if (entityMatch === 'strong') entityMatch = 'weak'
+									yield* Effect.logWarning(
+										'research.gap_rounds.cited_voided',
+									).pipe(
+										Effect.annotateLogs({
+											research_id: researchId,
+											dropped: recheck.droppedOffEntity,
+										}),
+									)
+								}
+							}
+							// Nothing missing: the cited fetches were the whole round —
+							// link them and let the next round's top check close the loop.
+							if (perFieldTargets.length === 0) {
+								if (roundHashes.length > 0) yield* linkRunSources(roundHashes)
+								continue
+							}
+							const perFieldFired = perFieldTargets.length
+							yield* Effect.forEach(
+								perFieldTargets,
+								target =>
+									Effect.gen(function* () {
+										gapSpentCents += SEARCH_COST_CENTS
+										const searched = yield* gapSearch
+											.search({
+												query: perFieldSearchQuery(
+													target.name,
+													hintLocation,
+													target.field,
+												),
+												limit: 3,
+												location: hintLocation,
+											})
+											.pipe(
+												// Let a pure interruption (cancel/deploy) unwind the run instead of
+												// being swallowed as an empty result while the loop keeps spending.
+												Effect.catchCause(cause =>
+													Cause.hasInterruptsOnly(cause)
+														? Effect.failCause(cause)
+														: Effect.succeed(null),
+												),
+											)
+										for (const item of searched?.items ?? []) {
+											const host = domainHost(item.url)
+											if (host !== undefined) searchResultHosts.add(host)
+											if (item.content && item.content.trim().length > 0) {
+												const hash = urlHashForScrape(item.url)
+												roundHashes.push(hash)
+												scrapeCorpus.push({
+													urlHash: hash,
+													text: item.content,
+													host,
+													kind: 'passage',
+												})
+											}
+										}
+									}),
+								{ concurrency: GAP_ROUND_CONCURRENCY },
+							)
+							// Nothing new reached the evidence — more rounds would only
+							// repeat the same searches, so the remaining gaps are treated
+							// as absent and the quality signal reports the thinness.
+							if (roundHashes.length === 0) break
+							yield* linkRunSources(roundHashes)
+							const perFieldAnchorFirst = [...scrapeCorpus].sort(
+								(a, b) =>
+									(anchorHashes.has(a.urlHash) ? 0 : 1) -
+									(anchorHashes.has(b.urlHash) ? 0 : 1),
+							)
+							const refreshed = yield* extractStructuredFindings(
+								researchText,
+								[
+									evidenceText,
+									...seededEvidenceParts,
+									...groundedPageTexts(entityTargets, scrapeCorpus),
+								].join('\n'),
+								labelledGroundedPages(entityTargets, perFieldAnchorFirst),
+							)
+							const merged = mergePerFieldSearch(
+								findings,
+								refreshed.findings,
+								schemaName,
+							)
+							findings = merged.findings
+							yield* Effect.annotateCurrentSpan({
+								'research.gap_rounds.round': gapRound,
+								'research.per_field_search.fired': perFieldFired,
+								'research.per_field_search.filled': merged.filled,
+								'research.per_field_search.added': merged.added,
+								'research.gap_rounds.contacts_kept':
+									contactFill(findings).named,
+								'research.gap_rounds.titled_kept': contactFill(findings).titled,
+							})
+							yield* Effect.logInfo('research.gap_rounds.closed').pipe(
+								Effect.annotateLogs({
+									research_id: researchId,
+									round: gapRound,
+									cited_fetched: citedUnscraped.length,
+									fired: perFieldFired,
+									filled: merged.filled,
+									added: merged.added,
+								}),
+							)
+							// A round that filled nothing, found nobody new and resolved no
+							// cited page has stopped closing gaps — stop before burning the
+							// remaining rounds on the same result.
+							if (
+								merged.filled === 0 &&
+								merged.added === 0 &&
+								citedUnscraped.length === 0
+							)
+								break
 						}
 						yield* Ref.update(toolLog, log => [
 							...log,


### PR DESCRIPTION
## What

Ask Batuda to go and find companies in a sector and it came back with a handful — four, on the request that prompted this — and none of them carried a website, even though the request asked for one. Not because the information was unavailable, but because nothing in the pipeline ever asked for a broad list, and the step that fills in missing details could not see inside a list of companies at all.

This is backend only, in the Research context (`packages/research`, the part that goes and reads the web). Nothing in the CRM, the web app, the API surface, or the database changes.

## The fix

**Nothing asked a scan for breadth.** The extraction prompt does push hard for completeness — but only about *people* ("Name EVERY person…"). There was no equivalent for the companies a scan exists to find, and the two discovery-related lines both *narrow* the search rather than widen it. A scan is now asked to list every company the evidence names, to keep one whose website it could not find rather than dropping it, and to give the website and headcount wherever a source states them. A scan no longer receives the people instruction at all: its answer holds no people, so asking only invited it to invent some.

**A many-part request was never planned for.** Five trades across seventeen regions is roughly eighty natural searches; the run fired four and stopped of its own accord with a round still unspent. The issue asked me to decide whether this should be a search plan in code or prompt guidance — **I chose prompt guidance**, and the run's own numbers are why: the rounds and the budget were never the constraint, so the model had room it did not use. A planner in code would need a model to parse the prose into dimensions anyway, and would then fire dozens of unfiltered paid searches. A scan is now told, before it searches, to break the request into its parts and work through them.

**The step that fills in what a run missed could only read one company.** When a run ends with fields empty, a "gap round" goes back and searches for them. It was built entirely around the single-company-profile shape — in **four** places, not the two the issue names: the missing-field check, the merge, the list of fields worth searching for, and the fetch of cited pages (which returned nothing whatsoever for a scan). So `prospects[].website` and `employee_estimate` had no recovery path at all.

I generalised the existing step rather than giving scans their own. Two things decided it: the search-query builder already takes a company name and does not care where it came from, and the re-extraction already runs under the run's own schema, so its *refresh* half worked for scans today — only the fold-back was profile-shaped. A separate path would have duplicated the budget-margin, deadline, cited-page and source-linking logic, which is the part most likely to rot apart. The step now reads a run's **subjects**: one for a company profile, one per company for a scan. A profile behaves exactly as before.

**It was also unreachable on the path that needed it most.** The step sat inside a branch that a scan coming back thin never takes — and since #437 landed, a thin scan is precisely the run that takes the refined-retry path. So the four-company case skipped it entirely. It now sits one level out, so both paths reach it.

**Two smaller fixes.** The focused search was built from `run.query.split(',')[0]` — literally the opening words of the request treated as a company name; it now uses `entityName`, the same name the rest of the run grounds on, which also repairs anchored enrichment runs phrased as prose. And a run whose findings carry no profile block reported all four profile fields as missing, firing paid searches whose answers the merge would discard by construction; it now asks for nothing.

## Impact

- **Cost — the one thing worth pausing on.** A discovery scan can now fire focused searches it previously never fired (the block was unreachable for scans), up to 8 per round against the profile path's 3, because a scan's gaps are whole companies rather than facts about one. It is still bounded by the existing 4-round cap, and every round already checks the wall-clock and remaining-budget margins before spending. A scan also pays one re-extraction per round that closes a gap. If 8 reads too rich, it is a single constant.
- **Wire shape: additive only.** A scan's findings can gain companies during a gap round and gain `website` / `employee_estimate` on companies already listed. Same schema, no new or renamed fields, nothing removed. A `research.per_field_search.added` counter joins the existing telemetry.
- **No migration, no schema change, no new environment variables.** Nothing to run before or after the server tag.
- **Both MCP and HTTP** get this identically — it is inside the shared research service, below either transport.
- **No change** to tenant isolation, `organization_id` scoping, RLS roles, which Postgres role a path runs under, auth, CORS, webhooks, or paid-provider selection.
- **A company profile is untouched in behaviour.** It is read as a one-subject list, which is what it always effectively was.

## Review guide

- **Start at `needsPerFieldSearch` and `mergePerFieldSearch` in `packages/research/src/application/per-field-search.ts`** — that is the whole decision, and the rest is call sites.
- **The riskiest hunk is the fold-back.** Putting a recovered website on the wrong company would be a real data fault, so: companies match by name with case and punctuation ignored, a value already grounded is never overwritten, a company is never dropped, and a company the wider read names that the first pass did not is appended. I deliberately do **not** strip legal suffixes when matching — that would fold `Acme` and `Acme Holding` into one, and listing a company twice is far less harmful than mis-attributing its website. That is a judgement you might overrule.
- **The other risky part is structural:** the gap-round block moved out of the retry branch, so it now runs for a scan that came back thin. That is the point of the change, but it does alter which runs reach paid searches. Most of the diff's line count in `research-service.ts` is that block shifting one indent level, not logic.
- **A decision you might overrule:** `MAX_SCAN_ROW_SEARCHES = 8`. The issue asked for a recovery path without naming a budget; three (the profile figure) would recover almost nothing across a list of forty.
- **What I could not verify.** The live re-run of the original request was still in flight when I opened this — I will post the result here. I did not run `/security-review`: this touches no auth, RLS, parser, crypto, or external-input boundary. Snyk was not available.

## Tests

Unit, covering every branch and degenerate input: which companies a scan asks about and which facts; a headcount stored as a number beside its source counting as filled where a plain string check would call it blank; rows with a blank, missing, or non-string name; an empty, missing, or non-list result list; a scan that also carries a profile block; the profile path unchanged, including the no-profile-block case that used to report four fields missing; the two per-shape caps; the new website and headcount query phrasings; and the fold-back across a reordered re-extraction, punctuation-different spellings of one company, two genuinely different companies with a shared prefix, a duplicate inside one re-extraction, an empty starting list, an unnamed company, and a round that gained nothing.

Also: a scan's cited pages now reaching the cited-page fetch (which returned nothing for a scan before), a profile run not reading a stray list it does not own, both prompt directives appearing only for the shape they belong to, and the schema-to-list-name lookup.

## Verification

Ran, in the worktree, forcing real runs rather than Turbo cache replays (a linked worktree reports `FULL TURBO` over changed files):

- `pnpm install` — clean, no lockfile drift
- `turbo run check-types --force` — 13/13 tasks, 30.6s
- `turbo run test --force` — 21/21 tasks, all green (`@batuda/research` 1145 passed, `@batuda/server` 855 passed)
- `turbo run build --force` — 13/13 tasks, 19.1s
- Biome clean on all six changed files; pre-commit gates green

Rebased onto `75c832e6fc` and adopted its new `unwrapValue` / `isValueWrapper` readers instead of hand-rolling the "value paired with its page" shape — that commit's stated purpose is that a check written later gets it right, and this is a check written later.

The live re-run of the original request is running against real Firecrawl and Brave as I open this; result to follow in a comment. Worth knowing for anyone reproducing it: a worktree's stack runs the research providers as stubs, and Turbo's strict env mode strips `RESEARCH_*`, so a live run needs the server started outside Turbo with the committed routing and only the provider keys taken from the vault.

## Deferred

Nothing from #438 is left out. The issue's remaining acceptance item is the live re-run above.

Closes #438
