### PR TITLE
fix(research): tell a company apart by its own name, not its trade

### DIFF
--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -368,6 +368,7 @@ const driveOne = (
 		const outcome = outcomeFromRun({
 			status: run?.status ?? 'failed',
 			findings: run?.findings,
+			schemaName,
 			fetchedUrls: sourceRows.map(row => row.url),
 			...(run ? { usage: usageOf(run) } : {}),
 		})
@@ -732,6 +733,7 @@ const driveFramed = (
 		const outcome = outcomeFromRun({
 			status: run?.status ?? 'failed',
 			findings: run?.findings,
+			schemaName,
 			fetchedUrls: [],
 		})
 		// entity_match is a top-level run column (camelCased by the client), never

--- a/packages/research/src/application/discovery-scan.ts
+++ b/packages/research/src/application/discovery-scan.ts
@@ -38,6 +38,28 @@ export const discoveryResultField = (schemaName: string): string | undefined =>
 	DISCOVERY_RESULT_FIELD[schemaName]
 
 /**
+ * The companies a discovery scan came back with, as rows to read fields off.
+ * Empty for anything that is not a scan, and for a scan whose list is missing or
+ * unusable — so a caller reads a scan's answer without naming the list itself,
+ * which keeps the mapping above the only place the two schemas are named.
+ */
+export const discoveryRows = (
+	schemaName: string | undefined,
+	findings: unknown,
+): ReadonlyArray<Record<string, unknown>> => {
+	const field =
+		schemaName === undefined ? undefined : DISCOVERY_RESULT_FIELD[schemaName]
+	if (field === undefined) return []
+	if (findings === null || typeof findings !== 'object') return []
+	const rows = (findings as Record<string, unknown>)[field]
+	if (!Array.isArray(rows)) return []
+	return rows.filter(
+		(row): row is Record<string, unknown> =>
+			row !== null && typeof row === 'object' && !Array.isArray(row),
+	)
+}
+
+/**
  * How many results a discovery scan's primary list carries. Null for a schema
  * that is not a discovery scan, whose result count is a different question its
  * own guards answer; zero when the list is missing, unusable, or empty.

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -37,6 +37,57 @@ describe('deriveEntityTargets', () => {
 		})
 	})
 
+	describe('when a legal form opens the name instead of closing it', () => {
+		it('should keep it, so the key is more than an industry word', () => {
+			// GIVEN a company whose name opens with two letters that also spell a
+			// legal form, and closes with a real one
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'KG Motors Inc.',
+				subjects: [{ table: 'companies', name: 'KG Motors Inc.' }],
+			})
+
+			// THEN only the trailing form comes off, so the key is the company's own
+			// name. A key of just "motors" would be carried by any page about any car
+			// maker, and the run would confirm one of those as readily as this company
+			expect(targets?.cores).toContain('kgmotors')
+			expect(targets?.cores).not.toContain('motors')
+			expect(
+				classifyEntityMatch(
+					targets as EntityTargets,
+					'General Motors reported record sales in Detroit.',
+				),
+			).not.toBe('strong')
+		})
+
+		it('should read a form written in two halves off the end', () => {
+			// GIVEN a Mexican company whose form is joined by a connecting word
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Grupo Ejemplo SA de CV',
+				subjects: [{ table: 'companies', name: 'Grupo Ejemplo SA de CV' }],
+			})
+
+			// THEN both halves come off, so a page writing the trading name matches.
+			// The connecting word is only stepped over between two halves of a form —
+			// on its own it stays, or "Serveis i Manteniments" would lose its middle
+			expect(targets?.cores).toContain('grupoejemplo')
+		})
+
+		it('should still drop a trailing form so both spellings agree', () => {
+			// GIVEN the same company written with and without its legal form
+			const withForm = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Acme Logistics SL',
+				subjects: [{ table: 'companies', name: 'Acme Logistics SL' }],
+			})
+
+			// THEN the form at the end is still dropped, so a page writing the bare
+			// name matches the company as filed
+			expect(withForm?.cores).toContain('acmelogistics')
+		})
+	})
+
 	describe('when the run is entity-centric', () => {
 		it('should derive keys from the query for a query-only enrichment', () => {
 			// GIVEN a company_enrichment_v1 run identified only by a free-text query
@@ -647,6 +698,42 @@ describe('reachedOwnSite', () => {
 			// GIVEN a page on a country domain the caller never supplied
 			// THEN the "deliveroo" label still identifies the company's own site
 			expect(reachedOwnSite(targets, [{ host: 'deliveroo.co.uk' }])).toBe(true)
+		})
+	})
+
+	describe('when the host is the trade the company is named after', () => {
+		it('should not read a trade domain as the company own site', () => {
+			// GIVEN a company whose name opens with its trade, and the trade's own
+			// domain — a company Batuda has never heard of owns that address
+			const named: EntityTargets = {
+				cores: ['transportesgarcia'],
+				words: ['garcia'],
+				domains: [],
+				places: [],
+			}
+
+			// WHEN the trade's domain is offered as a page the run reached
+			// THEN it is not the company's site. The name contains the word, not the
+			// other way round, and reading it either way handed every company named
+			// after its trade the trade's own address — which the mailbox harvester
+			// then read a stranger's email off
+			expect(reachedOwnSite(named, [{ host: 'transportes.com' }])).toBe(false)
+			expect(isOwnSiteHost(named, 'transportes.com')).toBe(false)
+		})
+
+		it('should still recognise a host that carries the whole name', () => {
+			// GIVEN the same company and a domain that spells its full name
+			const named: EntityTargets = {
+				cores: ['transportesgarcia'],
+				words: ['garcia'],
+				domains: [],
+				places: [],
+			}
+
+			// WHEN checked — THEN the company's own site is unaffected
+			expect(reachedOwnSite(named, [{ host: 'transportesgarcia.es' }])).toBe(
+				true,
+			)
 		})
 	})
 

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -49,6 +49,10 @@ const LEGAL_SUFFIXES = new Set([
 	'as',
 	'nv',
 	'kft',
+	// The second half of "S.A. de C.V.", which is how a Mexican company writes its
+	// form. Without it the connector rule below has nothing to start from and the
+	// whole form stays in the name.
+	'cv',
 ])
 
 // Generic words that do not prove a page is about the target — a page about any
@@ -121,10 +125,57 @@ const foldTokens = (value: string): string[] =>
 		.split(/[^a-z0-9]+/)
 		.filter(Boolean)
 
-// The whole name minus its legal suffix, collapsed — "Acme Logistics S.L." →
+// Words that join two halves of a legal form — "S.A. de C.V.", "Serveis i
+// Manteniments S.L." — skipped over while reading a form off the end, never
+// dropped on their own.
+const FORM_CONNECTORS = new Set(['de', 'y', 'i', 'and'])
+
+// Where a name's legal form ends and the name itself begins, read from the right.
+// A form sits at the end of a name, so anything before the trailing run is the
+// company's own name and stays in the key — two letters at the front that happen
+// to spell a legal form ("KG Motors") are part of what the company is called.
+const nameEnd = (tokens: ReadonlyArray<string>): number => {
+	let end = tokens.length
+	let at = tokens.length
+	while (at > 0) {
+		const token = tokens[at - 1] ?? ''
+		if (LEGAL_SUFFIXES.has(token)) {
+			at--
+			end = at
+			continue
+		}
+		// A connector counts only between two halves of one form, which is why it
+		// moves the cursor and never the end.
+		if (end < tokens.length && FORM_CONNECTORS.has(token)) {
+			at--
+			continue
+		}
+		break
+	}
+	return end
+}
+
+// The whole name minus its legal form, collapsed — "Acme Logistics S.L." →
 // "acmelogistics". This is the strong-match key: it appears verbatim on the
-// company's own pages but is long enough not to hit by coincidence.
-export const nameCore = (name: string): string =>
+// company's own pages but is long enough not to hit by coincidence. A key that
+// is only an industry word would match any page in that industry, so the form is
+// read off the end rather than picked out wherever it appears.
+export const nameCore = (name: string): string => {
+	const tokens = foldTokens(name)
+	return tokens.slice(0, nameEnd(tokens)).join('')
+}
+
+/**
+ * The name with every legal-form word taken out, wherever it sits — "SARL
+ * Transports Dupont" → "transportsdupont".
+ *
+ * This answers a different question from `nameCore`: not "who is this company"
+ * but "does this piece of text name it". A directory writes the trading name
+ * into its address and leaves the form out, so a key that keeps the form finds
+ * nothing there. Being loose is the safe direction for that question — the worst
+ * it does is spot the company's name in one more place.
+ */
+export const nameWithoutForms = (name: string): string =>
 	foldTokens(name)
 		.filter(t => !LEGAL_SUFFIXES.has(t))
 		.join('')
@@ -418,9 +469,13 @@ export const reachedOwnSite = (
 		const label = domainLabelOf(page.host)
 		if (label === undefined) return false
 		const folded = collapse(label)
+		// The host's label has to carry the whole name, not merely be carried by it.
+		// A company named after its trade contains the trade as a word, so reading
+		// the test the other way would hand it the trade's own domain — and whoever
+		// really owns that domain would have their mailbox read as this company's.
 		return (
 			targets.words.includes(label) ||
-			targets.cores.some(core => core.includes(folded) || folded.includes(core))
+			targets.cores.some(core => folded.includes(core))
 		)
 	})
 

--- a/packages/research/src/application/eval-outcome.test.ts
+++ b/packages/research/src/application/eval-outcome.test.ts
@@ -161,4 +161,47 @@ describe('outcomeFromRun', () => {
 			expect(outcome.registryConfirmed).toBe(false)
 		})
 	})
+
+	describe('when the run answered with a list of companies', () => {
+		it('should read the companies a scan found, and whether each has a site', () => {
+			// GIVEN a prospect scan that came back with three companies, two of them
+			// carrying a website
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: {
+					prospects: [
+						{ name: 'Acme', website: 'https://acme.test' },
+						{ name: 'Beta', website: '   ' },
+						{ name: 'Gamma', website: 'https://gamma.test' },
+						{ website: 'https://nameless.test' },
+					],
+				},
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted
+			// THEN the scan's own answer is visible to the scorer. Reading only the
+			// profile block made every scan look like a run that found nothing, which
+			// is why no scan could ever be measured
+			expect(outcome.companies).toEqual([
+				{ name: 'Acme', hasWebsite: true },
+				{ name: 'Beta', hasWebsite: false },
+				{ name: 'Gamma', hasWebsite: true },
+			])
+		})
+
+		it('should read no companies when the run answers with a profile', () => {
+			// GIVEN an enrichment run, whose answer is a profile rather than a list
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'company_enrichment_v1',
+				findings: { enrichment: { industry: 'transport' } },
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN there is no list to read, and the shape decides that
+			expect(outcome.companies).toEqual([])
+		})
+	})
 })

--- a/packages/research/src/application/eval-outcome.ts
+++ b/packages/research/src/application/eval-outcome.ts
@@ -11,6 +11,7 @@
  * so a per-field-citation schema change lands here and the scorer's metrics stay put.
  */
 
+import { discoveryRows } from './discovery-scan'
 import {
 	type RunOutcome,
 	type RunUsage,
@@ -65,6 +66,11 @@ export const outcomeFromRun = (input: {
 	readonly fetchedUrls: ReadonlyArray<string>
 	/** What the run was billed, read off its own row; absent when not read back. */
 	readonly usage?: RunUsage
+	/**
+	 * Which shape the run answered in. A scan keeps its answer in a list of
+	 * companies rather than a profile, and the shape is what says where to look.
+	 */
+	readonly schemaName?: string
 }): RunOutcome => {
 	const findings = input.findings
 	const enrichment = enrichmentOf(findings)
@@ -105,6 +111,19 @@ export const outcomeFromRun = (input: {
 		typeof findings === 'object' &&
 		(findings as { registry_confirmed?: unknown }).registry_confirmed === true
 
+	// The companies a scan came back with, which is the whole of a scan's answer
+	// and so the only thing a scan can be scored on.
+	const companies: Array<{ name: string; hasWebsite: boolean }> = []
+	for (const row of discoveryRows(input.schemaName, findings)) {
+		const name = (row as { name?: unknown }).name
+		if (typeof name !== 'string' || name.trim() === '') continue
+		const website = (row as { website?: unknown }).website
+		companies.push({
+			name: name.trim(),
+			hasWebsite: typeof website === 'string' && website.trim() !== '',
+		})
+	}
+
 	const profileFill = enrichmentFill(findings)
 	const people = contactFill(findings)
 
@@ -113,6 +132,7 @@ export const outcomeFromRun = (input: {
 		reachedDomains,
 		fields,
 		contacts,
+		companies,
 		registryConfirmed,
 		profile: {
 			fieldsTotal: profileFill.total,

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -25,6 +25,7 @@ const outcome = (over: Partial<RunOutcome>): RunOutcome => ({
 	reachedDomains: ['acme.es'],
 	fields: {},
 	contacts: [],
+	companies: [],
 	...over,
 })
 
@@ -969,6 +970,46 @@ describe('scoreRun for the company shapes this measures', () => {
 			expect(result.fieldsExpected).toBe(3)
 			expect(result.fieldsScored).toBe(3)
 			expect(result.fieldsCorrect).toBe(3)
+		})
+	})
+})
+
+describe('scoring a run that answered with a list of companies', () => {
+	describe('when a scan came back with companies but no profile fields', () => {
+		it('should not be counted as a run that found nothing', () => {
+			// GIVEN a scan that returned companies, which is what a scan is asked for,
+			// and no profile scalars, which a scan never fills
+			const score = scoreRun(
+				acme,
+				outcome({
+					status: 'succeeded',
+					fields: {},
+					companies: [
+						{ name: 'Acme', hasWebsite: true },
+						{ name: 'Beta', hasWebsite: false },
+					],
+				}),
+			)
+
+			// WHEN scored
+			// THEN it is not empty. Counting only profile fields filed every scan
+			// alongside the runs that found nothing — and an empty run is excused from
+			// the wrong-company measure, so the shape returning the most companies
+			// could never be measured at all
+			expect(score.empty).toBe(false)
+		})
+	})
+
+	describe('when a scan came back with nothing', () => {
+		it('should still count as a run that found nothing', () => {
+			// GIVEN a scan with neither companies nor fields
+			const score = scoreRun(
+				acme,
+				outcome({ status: 'succeeded', fields: {}, companies: [] }),
+			)
+
+			// WHEN scored — THEN nothing found is still nothing found
+			expect(score.empty).toBe(true)
 		})
 	})
 })

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -150,6 +150,15 @@ export interface RunOutcome {
 		readonly role: string | null
 	}>
 	/**
+	 * The companies a discovery scan came back with, and whether each carries a
+	 * website. Empty for a run that answers with a profile rather than a list.
+	 * This is what a scan is asked for, so it is what a scan has to be scored on.
+	 */
+	readonly companies: ReadonlyArray<{
+		readonly name: string
+		readonly hasWebsite: boolean
+	}>
+	/**
 	 * Whether an official-registry lookup this run resolved the target company by
 	 * its legal name. Independent of the fetched pages: a company confirmed in the
 	 * register was reached even if its own site was never scraped.
@@ -566,7 +575,12 @@ export const scoreRun = (
 	const anyFilled = SCORABLE_FIELDS.some(field =>
 		isFilled(outcome.fields[field]),
 	)
-	const empty = !isSucceeded(outcome.status) || !anyFilled
+	// A run has found something when it filled a profile field OR came back with
+	// companies: a scan answers with a list and never fills a profile, so asking
+	// only about fields files every scan alongside the runs that found nothing.
+	const empty =
+		!isSucceeded(outcome.status) ||
+		(!anyFilled && outcome.companies.length === 0)
 
 	// Contact recall: of the people we know the company publishes, how many the run
 	// returned WITH a title — a named person with no title doesn't count, since a
@@ -594,8 +608,18 @@ export const scoreRun = (
 	// a global capital is too generic to qualify.
 	const agreesWithGolden =
 		anyContactMatched || specificLocationAgrees(expected, outcome)
+	// Only a run that answered about one company can have answered about the wrong
+	// one. Both halves of the test below — reaching the golden domain, and matching
+	// its contacts or its city — are written against a single expected company, so
+	// a scan's list of others has nothing here to be judged against and would read
+	// as wrong simply for being a list.
+	const aboutOneCompany = outcome.companies.length === 0
 	const wrongCompany =
-		isSucceeded(outcome.status) && !empty && !grounded && !agreesWithGolden
+		aboutOneCompany &&
+		isSucceeded(outcome.status) &&
+		!empty &&
+		!grounded &&
+		!agreesWithGolden
 
 	// The same look-alike, narrowed to the runs that finished clean. A run marked
 	// as needing review is caught by the person reading it, so it cannot be in the

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -4561,11 +4561,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							})
 							const perFieldTargets = perFieldGaps
 								.filter(
-									target => !gapsSearched.has(`${target.name} ${target.field}`),
+									target =>
+										!gapsSearched.has(`${target.name}\u001F${target.field}`),
 								)
 								.slice(0, perFieldSearchCap(schemaName))
 							for (const target of perFieldTargets) {
-								gapsSearched.add(`${target.name} ${target.field}`)
+								gapsSearched.add(`${target.name}\u001F${target.field}`)
 							}
 							const openedHashes = new Set(
 								openedPages(scrapeCorpus).map(page => page.urlHash),

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -81,6 +81,28 @@ describe('guardCompanyWebsites', () => {
 		})
 	})
 
+	describe('when the company legal form leads its name', () => {
+		it('should still catch a listing that files it under its trading name', () => {
+			// GIVEN a French company whose form opens the name, on a directory that
+			// files it under the trading name alone
+			const findings = scan([
+				{
+					name: 'SARL Transports Dupont',
+					website: 'https://dir.example/company/transports-dupont',
+				},
+			])
+
+			// WHEN checked
+			// THEN it is blanked. A directory writes the trading name and leaves the
+			// form out, so the name is matched with every form taken out wherever it
+			// sits — which is a looser question than who the company is, and the safe
+			// direction for a guard whose job is spotting listings
+			expect(websitesOf(guardCompanyWebsites(findings).findings)).toEqual([
+				undefined,
+			])
+		})
+	})
+
 	describe('when the website is the company own site', () => {
 		it('should keep a host that carries the company name', () => {
 			// GIVEN the company's own domain

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -25,7 +25,7 @@
  * with no name beside it and so is judged against the target's name passed in.
  */
 
-import { collapse, nameCore } from './entity-guard'
+import { collapse, nameWithoutForms } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { hostOf } from './source-key'
 
@@ -76,7 +76,11 @@ const classifyWebsite = (name: string, website: string): WebsiteVerdict => {
 	// An address we cannot even read the host of is left alone — nothing to judge.
 	if (host === null) return 'keep'
 	if (isAggregatorHost(host)) return 'directory'
-	const core = nameCore(name)
+	// The name as an address would write it: a directory files a company under its
+	// trading name and leaves the legal form out, so the form is taken out here
+	// too, wherever in the name it sits. This asks whether the address names the
+	// company, which is a looser question than who the company is.
+	const core = nameWithoutForms(name)
 	// With no distinctive name to look for, there is no way to tell a listing from
 	// the company's own site, so keep it.
 	if (core === '') return 'keep'


### PR DESCRIPTION
## What

Three fixes to how Batuda decides it has found the right company, and to whether anyone can measure that.

The first is the important one. When a run checks that the pages it read are really about the company it was asked about, it compares the company's name against the text. Stripping the legal form out of that name wherever it appeared meant a company like **KG Motors Inc.** was checked as just **"motors"** — a word on any page about any car maker. So a run reading a General Motors page reported it had confidently found KG Motors, with no flag, no lowered confidence, and its suggestions eligible to be written to the CRM unattended. That is live on `main` today.

This is backend only, in the Research context (`packages/research`), plus one dev-tool change in the CLI. Nothing in the CRM, the web app or the API surface changes.

## The fix

- **A company's legal form is read off the end of its name, not picked out wherever it appears.** Two letters at the front that happen to spell a form — `KG`, `AS`, `AG`, `AB` — are part of what the company is called. `KG Motors Inc.` now keys on `kgmotors` and no longer matches a General Motors page as its own site. A form written in two halves (`S.A. de C.V.`) comes off as one form, with the connecting word stepped over only between the halves — so `Serveis i Manteniments` keeps its middle word.
- **The website check got its own, looser reading of a name.** It asks a different question — does this address name this company — and a directory files a company under its trading name with the form left off. Sharing one key with the identity check meant that tightening the identity key opened a hole in the website check for every company whose form leads its name (`SARL Transports Dupont` on a directory listing). They are now separate, and each is documented with the question it answers.
- **A web address has to carry the whole company name before it counts as that company's own site.** Reading the test in both directions handed *Transportes García* the domain `transportes.com` — because its name contains the word — and the role-mailbox step then read whoever really owns that domain as this company's address.
- **A search is scored on the companies it returned.** The eval only ever read the company-profile block, so a search — which answers with a list and never fills a profile — was filed alongside runs that found nothing. That also excused searches from the wrong-company measure, so the shape returning the most companies was the one shape nobody could measure.
- **The control character is out of `research-service.ts`.** It made plain `grep` treat a 6,300-line file as binary and return nothing, silently — for a person and for any tool.

## Impact

- **No migration, no schema change, no new environment variables.** Nothing to run before or after the server tag.
- **Fewer runs will report a confident match, and that is the point.** A name whose key is a bare industry word now lands on `weak` instead of `strong`: the findings are kept and the run is marked for a person to read, rather than passing silently. Expect more runs marked for review, and correspondingly fewer auto-applied suggestions.
- **Fewer role mailboxes will be harvested.** `reachedOwnSite` has exactly one caller — building the host list the mailbox step reads — so narrowing it narrows that and nothing else. It gates no retry and no spend.
- **A recall cost I have not measured.** Keeping a leading form makes a key longer, so a page writing only the trading name no longer strong-matches. `SARL Transports Dupont` is the shape that moves. The eval change in this PR is the first step toward being able to put a number on that; today it cannot be measured per market, which is exactly why it is here.
- **Both MCP and HTTP** get this identically — it is inside the shared research package, below either transport.
- **No change** to tenant isolation, `organization_id` scoping, RLS roles, auth, CORS, webhooks or paid-provider selection.

## Review guide

- **Start at `nameCore` and `nameWithoutForms` in `entity-guard.ts`.** The whole change turns on those being two different questions rather than one function. If you disagree with that split, everything else follows from it.
- **The riskiest hunk is `reachedOwnSite`.** Removing one direction of a substring test is what closes the `transportes.com` leak, but it also means a host whose label is a sub-token of the name no longer counts. I traced every caller: there is exactly one, and it feeds the mailbox harvest.
- **A decision you might overrule:** `Closes #454` sits on the second commit, but the fix moves that case from `strong` to `weak`, not to `absent` — `motors` is still a weak key. The false confidence is gone; the company is not fully rejected. If you would rather #454 stay open until the distinctiveness work lands, drop the trailer.
- **`cv` is a new entry in `LEGAL_SUFFIXES`.** It is needed for the two-halves rule to have something to start from. It is a hand-typed list entry, which cuts against where we want this to go — flagging it rather than burying it.
- **`S.A. de C.V.` written with dots is still not stripped.** The fold splits it into single letters, which is a pre-existing gap this PR deliberately does not open.
- **What I did not run:** `/security-review` — this touches no auth, RLS, parser, crypto or external-input boundary. Snyk was not available.

## Tests

Unit, covering the branches each fix turns on: a leading form kept and a trailing one dropped; a form in two halves taken off while a lone connecting word survives; a name of only industry words no longer reaching a strong match against a same-industry page; a trade domain refused as a company's own site while the company's real domain is still accepted; a directory listing still caught for a company whose form leads its name; a search's companies read off the findings, including rows with no name and a run that answers with a profile instead; and a search with companies no longer counting as a run that found nothing.

## Verification

Ran in the worktree, forcing real runs rather than Turbo cache replays (a linked worktree reports `FULL TURBO` over changed files):

- `turbo run check-types --force` — 13/13
- `turbo run test --force` — 21/21, `@batuda/research` 1158 passed, `@batuda/server` 855 passed
- `turbo run build --force` — 13/13
- `biome check` clean on all eleven changed files
- Re-based on `origin/main`; nothing landed underneath

Each fix was also reproduced against the real modules before and after — the General Motors match, the `transportes.com` handover, the `SARL` listing, and the two-halves form.

I ran `/code-review` at extra-high effort over this diff and it found ten issues, all in code added here — including that the eval change did nothing at all, because neither production caller passed the new argument. All ten are resolved in this branch: eight fixed, two traced and confirmed to need no change.

## Deferred

- The dotted `S.A. de C.V.` spelling, which needs the name-folding rewrite.
- Reducing a bare-industry-word name to `absent` rather than `weak`.
- Precision on a search's results — the directories, marketplaces and trade bodies that come back as companies — tracked in #453.

Closes #454
