### PR TITLE
fix(research): stop grading a run on a profile it was never asked to fill

### DIFF
--- a/packages/research/src/application/research-quality.test.ts
+++ b/packages/research/src/application/research-quality.test.ts
@@ -374,27 +374,72 @@ describe('computeRunQuality', () => {
 		})
 	})
 
-	describe('for a freeform brief', () => {
+	describe('for a run that was asked for no company profile', () => {
+		// Every schema but an enrichment arrives with 0 of 0 profile fields.
+		const noProfile = {
+			entityMatch: null,
+			rounds: 2,
+			gapRounds: 0,
+			sourcesTotal: 4,
+			sourcesFirstParty: 0,
+			ownDomainKnown: false,
+			fieldsGrounded: 0,
+			fieldsTotal: 0,
+			citationsSeen: 3,
+			citationsKept: 3,
+			scanResults: null,
+			refined: false,
+		} as const
+
+		it('should leave out the profile numbers a brief never fills', () => {
+			// GIVEN a brief, which writes prose and fills no profile at all
+			const quality = computeRunQuality({
+				...noProfile,
+				schemaName: 'freeform',
+			})
+			// THEN neither is reported: with no fields to fill, a 0 would grade the
+			// run for work it was never asked to do
+			expect(quality.fields_grounded).toBeUndefined()
+			expect(quality.grounding_ratio).toBeUndefined()
+		})
+
+		it('should leave out the profile numbers a hunt for contacts never fills', () => {
+			// GIVEN a contact search, which comes back with people rather than a
+			// filled-in company profile
+			const quality = computeRunQuality({
+				...noProfile,
+				schemaName: 'contact_discovery_v1',
+			})
+			// THEN the same holds: what leaves the numbers meaningless is the missing
+			// profile, not which kind of run went looking
+			expect(quality.fields_grounded).toBeUndefined()
+			expect(quality.grounding_ratio).toBeUndefined()
+		})
+
 		it('should leave out the own-site count as an open-ended search does', () => {
 			// GIVEN a brief, which is pinned to no company and asked for no list
 			const quality = computeRunQuality({
+				...noProfile,
 				schemaName: 'freeform',
-				entityMatch: null,
-				rounds: 2,
-				gapRounds: 0,
-				sourcesTotal: 4,
-				sourcesFirstParty: 0,
-				ownDomainKnown: false,
-				fieldsGrounded: 0,
-				fieldsTotal: 0,
-				citationsSeen: 3,
-				citationsKept: 3,
-				scanResults: null,
-				refined: false,
 			})
 			// THEN it is left out here too: a brief has no company to hold a source
 			// against, as squarely as an open-ended search has none
 			expect(quality.sources_matched).toBeUndefined()
+		})
+
+		it('should keep the retry marker on a scan that fills no profile', () => {
+			// GIVEN a scan, which fills no profile either but was given the refined
+			// retry
+			const quality = computeRunQuality({
+				...noProfile,
+				schemaName: 'prospect_scan_v1',
+				scanResults: FULL_LIST,
+				refined: true,
+			})
+			// THEN the marker still stands: it says whether the scan went back for
+			// more, which has nothing to do with a profile
+			expect(quality.refined).toBe(true)
+			expect(quality.fields_grounded).toBeUndefined()
 		})
 	})
 

--- a/packages/research/src/application/research-quality.ts
+++ b/packages/research/src/application/research-quality.ts
@@ -45,7 +45,7 @@ export interface RunQualityInput {
 	readonly ownDomainKnown: boolean
 	/** Enrichment: profile fields that survived the guards with a value. */
 	readonly fieldsGrounded: number
-	/** Enrichment: profile fields in scope (0 for a scan). */
+	/** Profile fields in scope — 0 for any run that fills no company profile. */
 	readonly fieldsTotal: number
 	/** Citations the run offered for its findings. */
 	readonly citationsSeen: number
@@ -74,12 +74,16 @@ export interface RunQuality {
 	 * rather than "does not apply".
 	 */
 	readonly sources_matched?: number
-	/** Profile fields that survived the guards with a value; absent for a scan. */
+	/**
+	 * Profile fields that survived the guards with a value. Reported on the same
+	 * runs as `grounding_ratio`.
+	 */
 	readonly fields_grounded?: number
 	/**
-	 * Share of the profile that is grounded, 0–1. Absent for a scan, as is
-	 * `fields_grounded`: a scan fills no profile, so both would read 0 on every
-	 * scan ever run and look like a failing grade rather than "does not apply".
+	 * Share of the profile that is grounded, 0–1. This and `fields_grounded` are
+	 * reported only when the run had profile fields to fill: a scan, a brief and
+	 * a hunt for contacts have none, so both would read 0 on every one of those
+	 * runs and look like a failing grade rather than "does not apply".
 	 */
 	readonly grounding_ratio?: number
 	/**
@@ -96,8 +100,6 @@ export interface RunQuality {
 }
 
 export const computeRunQuality = (input: RunQualityInput): RunQuality => {
-	const groundingRatio =
-		input.fieldsTotal > 0 ? input.fieldsGrounded / input.fieldsTotal : 0
 	const isScan = isDiscoveryScan(input.schemaName)
 
 	// Anything short of clearly reaching the company the run was pinned to. Asked
@@ -134,12 +136,14 @@ export const computeRunQuality = (input: RunQualityInput): RunQuality => {
 		...(input.ownDomainKnown
 			? { sources_matched: input.sourcesFirstParty }
 			: {}),
-		...(isScan
-			? { refined: input.refined }
-			: {
+		...(input.fieldsTotal > 0
+			? {
 					fields_grounded: input.fieldsGrounded,
-					grounding_ratio: Math.round(groundingRatio * 100) / 100,
-				}),
+					grounding_ratio:
+						Math.round((input.fieldsGrounded / input.fieldsTotal) * 100) / 100,
+				}
+			: {}),
+		...(isScan ? { refined: input.refined } : {}),
 		citations_seen: input.citationsSeen,
 		citations_kept: input.citationsKept,
 		low_confidence: lowConfidence,


### PR DESCRIPTION
## What

When a research run finishes it publishes a small `quality` block — a handful of numbers saying how well it went, which an automation reads to decide whether the result is safe to act on unreviewed. Two of those numbers say how much of a company profile the run managed to fill in. A run that was never asked for a company profile reported 0 for both, which reads as a failing grade when the honest answer is "does not apply". This is the follow-up deferred out of #458.

Research context, `research` package only.

## The fix

The two measures were already left out for a company search, and the commit that did it ([`bee79e5`](https://github.com/guillempuche/batuda/commit/bee79e5285867e7ca5868123d4c48e7efdc1bbb5)) gave the reason in its own words: a search *"fills no company profile, so the two profile measures divided by zero fields and reported 0 on every scan ever run"*. But it implemented that reason as a test for *being a company search*, which is narrower than the reason it was written for. A freeform brief fills no company profile either. Neither does a hunt for contacts, which comes back with people. Both kept reporting 0.

What decides it now is whether the run had any profile fields to fill at all — the thing that actually makes the numbers meaningless.

## Impact

- **Wire shape.** Two fields already declared optional stop appearing on two of the five run kinds. A run that does fill a profile is byte-for-byte unchanged, which is the only kind the web app renders these for — and that reader already defaults a missing value to 0.
- **Nothing else.** No migration, no schema change, no new environment variable, no change to tenant isolation, no effect on the low-confidence flag that gates automation: these two numbers are reported, never read, when deciding whether a run is thin.
- The retry marker a search carries is now its own condition rather than the other half of a two-way branch, so it still appears on exactly the runs it did before.

## Review guide

The whole change is one condition in `computeRunQuality`. Worth knowing while reading it:

- **The new condition is exactly equivalent to "is an enrichment", today.** The service hands these measures `0 of 0` for every schema except `company_enrichment_v1`, and for that one `enrichmentFill` returns a constant field count that is never 0. So nothing but the two intended schemas changes behavior — I checked both ends rather than assuming.
- **I confirmed this was a defect and not a deliberate choice** before touching it: I read the originating commit (quoted above), ran the function across all five schemas to see the zeros, and checked that no consumer anywhere reads these fields except the enrichment view.
- A dead `groundingRatio` const went with it — its divide-by-zero fallback is now structural, inside the branch that only runs when the divisor is above zero.

## Tests

Four cases in the block for a run asked for no company profile: a brief and a contact hunt each leave both measures out; a search still reports whether its one retry fired, so the retry marker didn't get swept up with the profile numbers; and the existing enrichment cases still assert both measures present with real values.

## Verification

- `pnpm -w test` (21 tasks) and `pnpm -w build` (13 tasks) green; `check-types` run directly in `research` and `internal` rather than through Turbo, which reports false cache hits in a worktree.
- I ran `computeRunQuality` across all five schemas before and after: before, `freeform` and `contact_discovery_v1` returned `fields_grounded=0 grounding_ratio=0`; after, both are absent, while `prospect_scan_v1` still omits them and still reports `refined`, and `company_enrichment_v1` still returns `fields_grounded=4 grounding_ratio=0.67`.
- Not run: a live research run. This is a pure function with no I/O, and its one caller passes it values I traced by reading.

## Noted, not fixed

`research-quality.test.ts` has a pre-existing comment saying a competitor scan *"used to escape"* a check — refactoring language the house rules forbid in comments. It is untouched by this change, so I left it rather than widening the diff.
