### PR TITLE
test(research): say what the quality tests check, not what they used to catch

### DIFF
--- a/packages/research/src/application/research-quality.test.ts
+++ b/packages/research/src/application/research-quality.test.ts
@@ -150,7 +150,7 @@ describe('computeRunQuality', () => {
 				schemaName: 'prospect_scan_v1',
 			})
 			// THEN there is no own domain to hold a source against, so the count is
-			// absent rather than the 0 it read on every search ever run
+			// absent rather than the 0 it could only ever read on such a search
 			expect(quality.sources_matched).toBeUndefined()
 		})
 
@@ -167,9 +167,9 @@ describe('computeRunQuality', () => {
 			})
 
 			// THEN the competitor scan is flagged like the prospect scan, and neither
-			// reports a profile it never filled — a competitor scan used to escape
-			// the single-source check and report a grounding ratio of zero, which
-			// read as a failing grade on every competitor scan ever run
+			// reports a profile it never filled — the two are one kind of run as far
+			// as grading goes, so neither escapes the single-source check the other
+			// is held to, and neither is graded on a profile it was never asked for
 			expect(competitor.low_confidence).toBe(prospect.low_confidence)
 			expect(competitor.low_confidence).toBe(true)
 			expect(competitor.grounding_ratio).toBeUndefined()


### PR DESCRIPTION
## What

Two comments in the research quality tests explained what a check is for by describing the bug it was originally written to catch, in the past tense — "a competitor scan used to escape the single-source check", "the 0 it read on every search ever run". A reader a year from now has no way to tell whether that past behavior is still around, so the comment stops being an explanation and has to be re-derived from the code it was supposed to explain. Both now state what the check holds true today.

Comments only, in the `research` package. No test, assertion, or line of logic changed.

## Changes

- The competitor-scan comparison test says what it pins: the two scan kinds are one kind of run as far as grading goes, so neither escapes a check the other is held to.
- The own-site count test says the count can only ever be zero on a search about no one company, rather than reporting what it did read before.

## Impact

None. No behavior, no wire shape, no schema, no environment variable.

## Review guide

Read the diff — it is four lines. I swept both files in the module for the same pattern (`used to`, `previously`, `no longer`, past-tense claims about what a number "read") and these were the only two. The two remaining past-tense phrases are legitimate: one is a conditional ("would read as a failing grade"), the other is about how many sources a run actually read.

One of the two was mine, from #458; the other predates it. I fixed both rather than only the one I flagged, since leaving a matching violation in the same file would be odd.

## Verification

`tsc --noEmit` and the 30 quality tests green in `packages/research`; biome clean. Comments only, so there is nothing further to exercise.
