### PR TITLE
fix(research): make a scan's list one usable row per company

### DIFF
--- a/.claude/skills/debug-apps/SKILL.md
+++ b/.claude/skills/debug-apps/SKILL.md
@@ -104,6 +104,8 @@ Auth spans server + internal. Both must be running.
 4. Verify seed user exists: `pnpm cli seed --preset minimal` (idempotent)
 5. **Active org:** logging in does not set an active organization. If org-scoped pages (companies, emails, templates…) render "Couldn't load … Refresh to try again." and the switcher shows "NO ACTIVE ORGANIZATION", select one: `agent-browser find testid "org-switcher" click` then `find testid "org-switcher-option-<slug>" click` (Better Auth `setActive` + reload). The available `<slug>`s are the `org-switcher-option-*` entries in the open switcher's snapshot — one per membership, or run `pnpm cli data members`.
 
+**Sign in with the seeded password, and leave it alone.** It is `batuda-dev-2026`. Resetting it — for a screenshot session, say — breaks the next `git push`: the pre-push `e2e-smoke` hook signs in with that exact literal (`apps/internal/tests/e2e/auth.setup.ts`), so the hook fails on a login it cannot explain and the push is refused with no mention of a password. Resetting it also invalidates every live session, so a browser you already had open starts 404-ing on org-scoped routes until you sign in again and re-pick the org.
+
 ### Local dev email
 
 When `EMAIL_PROVIDER=local-inbox`, all outgoing email is written to `apps/server/.dev-inbox/` as markdown files with YAML frontmatter instead of hitting the network. Each file is named `<YYYYMMDD-HHMMSS-mmm>__<recipient>__<subject>.md`.

--- a/.claude/skills/run-research-eval/SKILL.md
+++ b/.claude/skills/run-research-eval/SKILL.md
@@ -59,6 +59,36 @@ Reading a key is never necessary: `infisical run` injects them into the child pr
 
 **`infisical` lives in the nix shell**, not on the plain PATH. Prefix everything with `nix develop --command sh -c '…'`.
 
+## Running ONE live query, not the eval
+
+To watch a single research request go end to end — the usual way to check a change against a real run — the same routing-vs-keys rule applies, but the run happens inside the **server**, so the environment has to reach that process. Three things stop it, and each fails in a way that looks like something else:
+
+1. **Turbo strips the injected secrets.** `infisical run --env=dev -- pnpm dev` hands them to Turbo, whose strict env mode drops anything not declared in `turbo.json`, so the server boots with no provider keys. Nothing errors — the run just finishes in under a second with `no_reliable_data` and "No pages were fetched", which reads exactly like a search that found nothing. Start the server directly instead of through Turbo.
+2. **Infisical's shared values displace this worktree's.** Bypass Turbo and the dev environment's own `BETTER_AUTH_SECRET` (and `DATABASE_URL`) win over the worktree's, and the server refuses to boot on a `ConfigError`. Re-source the worktree's `.env` *inside* the Infisical child so local values land on top, then apply the committed routing last.
+3. **The dev environment has no key for every tier.** `RESEARCH_API_KEY_ENRICH`, `_MAP` and `_VERIFY` are absent, and config validation refuses to boot without them. Set those providers to `none` — the search, scrape and LLM tiers are what a scan actually uses.
+
+```bash
+export ROOT=/path/to/worktree
+cd "$ROOT"
+export ROUTING=$(node -e 'const c=require("./apps/server/config.production.json");
+  for (const [k, v] of Object.entries(c))
+    if (k.startsWith("RESEARCH_") && !k.includes("API_KEY")) process.stdout.write(k + "=" + v + "\n")')
+nix develop --command infisical run --env=dev -- sh -c '
+  cd "$ROOT"; set -a; . ./.env; set +a
+  cd "$ROOT/apps/server"
+  exec env $ROUTING \
+    RESEARCH_PROVIDER_REGISTRY_ES=none RESEARCH_PROVIDER_REGISTRY_GB=none \
+    RESEARCH_PROVIDER_ENRICH=none RESEARCH_PROVIDER_MAP=none RESEARCH_PROVIDER_VERIFY=none \
+    "$ROOT/node_modules/.bin/portless" run --name api.batuda node --watch --import tsx src/main.ts
+'
+```
+
+Then start the run over MCP with an org-scoped API key (`pnpm cli auth create-key` does **not** set the org metadata the MCP endpoint requires — add `organizationId` + `createdByUserId` to the key's `metadata` in the dev database, or the handshake fails with "API key is not org-scoped"). Clear `research_cache` between runs of the same query, or the second one replays the first.
+
+**Do not edit a source file while a run is in flight** — `node --watch` restarts the server and the run dies mid-flight, leaving its row stuck at `running`.
+
+**A single run is billable**: the Spanish installations scan costs ~18¢ and takes ~20 minutes over ~300 sources.
+
 ## Infra stays local, never cloud
 
 `DATABASE_URL` and `STORAGE_*` must resolve to the worktree's own DB + bucket, never prod.

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -3,6 +3,7 @@ import { Trans, useLingui } from '@lingui/react/macro'
 import { useNavigate } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
+import styled from 'styled-components'
 
 import { PriButton, usePriToast } from '@batuda/ui/pri'
 
@@ -29,7 +30,14 @@ import {
 
 /**
  * Renders a `prospect_scan_v1` research finding. Each prospect carries
- * a `why_relevant` rationale + optional industry/country/tax_id + citations.
+ * a `why_relevant` rationale + optional industry/country/location/tax_id +
+ * citations.
+ *
+ * A prospect the run could not confirm as a real trading company still belongs on
+ * the list — the small firms a scan is really for are the ones with the thinnest
+ * trail — so it arrives carrying the reason it could not be confirmed. That reason
+ * is shown beside the name, and it is what holds back the one-click handoff from
+ * vouching for the company on somebody's behalf.
  */
 
 type ProspectEntry = {
@@ -38,7 +46,9 @@ type ProspectEntry = {
 	readonly tax_id?: string
 	readonly industry?: string
 	readonly country?: string
+	readonly location?: string
 	readonly why_relevant: string
+	readonly unconfirmed_reason?: string
 	readonly citations?: ReadonlyArray<Citation>
 }
 
@@ -65,12 +75,28 @@ export function ProspectScanView({
 							<ListItem key={`${p.name}|${p.tax_id ?? p.website ?? ''}`}>
 								<RowHead>
 									<Pill>{p.name}</Pill>
+									{p.unconfirmed_reason !== undefined ? (
+										<CandidatePill data-testid='prospect-candidate'>
+											<Trans>Unconfirmed</Trans>
+										</CandidatePill>
+									) : null}
 									{p.website !== undefined ? (
 										<SafeLink href={p.website}>{p.website}</SafeLink>
 									) : null}
 								</RowHead>
 								<Reason>{p.why_relevant}</Reason>
+								{p.unconfirmed_reason !== undefined ? (
+									<Reason>{p.unconfirmed_reason}</Reason>
+								) : null}
 								<FieldsTable>
+									{p.location !== undefined ? (
+										<FieldRow>
+											<FieldKey>
+												<Trans>Location</Trans>
+											</FieldKey>
+											<FieldValue>{p.location}</FieldValue>
+										</FieldRow>
+									) : null}
 									{p.industry !== undefined ? (
 										<FieldRow>
 											<FieldKey>
@@ -109,9 +135,21 @@ export function ProspectScanView({
 	)
 }
 
-// One-click handoff: turn a discovered prospect into a verified lead (a new
-// company at the `prospect` stage, marked verified and sourced from research)
-// and open it, so a research result flows straight into the pipeline.
+// The same shape as Pill, in the warning colour: a row the run could not confirm
+// reads as a lead like any other until something on it says otherwise.
+const CandidatePill = styled(Pill)`
+	background: color-mix(in oklab, var(--color-warning) 16%, transparent);
+	color: var(--color-warning);
+`
+
+// One-click handoff: turn a discovered prospect into a lead (a new company at the
+// `prospect` stage, sourced from research) and open it, so a research result flows
+// straight into the pipeline.
+//
+// It is marked verified on the way in — but only for a prospect the run confirmed.
+// Verified means a person vouched for this being a real lead, and stamping it on a
+// company the run itself said it could not confirm would launder the doubt away at
+// the one step where it still shows.
 function AddAsLeadButton({ prospect }: { readonly prospect: ProspectEntry }) {
 	const { t } = useLingui()
 	const toast = usePriToast()
@@ -136,6 +174,7 @@ function AddAsLeadButton({ prospect }: { readonly prospect: ProspectEntry }) {
 				status: 'prospect',
 				...(prospect.industry ? { industry: prospect.industry } : {}),
 				...(prospect.country ? { country: prospect.country } : {}),
+				...(prospect.location ? { location: prospect.location } : {}),
 				...(prospect.website ? { website: prospect.website } : {}),
 			},
 		})
@@ -147,13 +186,19 @@ function AddAsLeadButton({ prospect }: { readonly prospect: ProspectEntry }) {
 		const row = exit.value as Record<string, unknown>
 		const id = typeof row['id'] === 'string' ? row['id'] : null
 		const newSlug = typeof row['slug'] === 'string' ? row['slug'] : slug
-		if (id !== null) {
+		const confirmed = prospect.unconfirmed_reason === undefined
+		if (id !== null && confirmed) {
 			await verifyCompany({
 				params: { id },
 				payload: { verified: true },
 			})
 		}
-		toast.add({ title: t`Added as a verified lead`, type: 'success' })
+		toast.add({
+			title: confirmed
+				? t`Added as a verified lead`
+				: t`Added as an unverified lead`,
+			type: 'success',
+		})
 		void navigate({ to: '/companies/$slug', params: { slug: newSlug } })
 	}
 

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -93,7 +93,12 @@ export function ProspectScanView({
 // write a company nobody has vouched for.
 function ProspectRow({ prospect }: { readonly prospect: ProspectEntry }) {
 	const doubtId = useId()
-	const unconfirmed = prospect.unconfirmed_reason !== undefined
+	// A reason with nothing written in it is not a doubt anybody can weigh, and runs
+	// stored before the engine started taking those back still carry them. Read as a
+	// mark it would badge the row and hold back the vouching step while naming no
+	// cause at all.
+	const doubt = prospect.unconfirmed_reason?.trim()
+	const unconfirmed = doubt !== undefined && doubt !== ''
 
 	return (
 		<ListItem>
@@ -114,7 +119,7 @@ function ProspectRow({ prospect }: { readonly prospect: ProspectEntry }) {
 					<ReasonLabel>
 						<Trans>Could not be confirmed:</Trans>
 					</ReasonLabel>{' '}
-					{prospect.unconfirmed_reason}
+					{doubt}
 				</Reason>
 			) : null}
 			<FieldsTable>
@@ -154,6 +159,7 @@ function ProspectRow({ prospect }: { readonly prospect: ProspectEntry }) {
 			<CitationList citations={prospect.citations} />
 			<AddAsLeadButton
 				prospect={prospect}
+				unconfirmed={unconfirmed}
 				describedBy={unconfirmed ? doubtId : undefined}
 			/>
 		</ListItem>
@@ -196,9 +202,12 @@ const ReasonLabel = styled.strong`
 // the one step where it still shows.
 function AddAsLeadButton({
 	prospect,
+	unconfirmed,
 	describedBy,
 }: {
 	readonly prospect: ProspectEntry
+	/** Whether the run left a real reason it could not confirm this company. */
+	readonly unconfirmed: boolean
 	/** The reason this company could not be confirmed, for a reader to be pointed at. */
 	readonly describedBy?: string | undefined
 }) {
@@ -237,7 +246,7 @@ function AddAsLeadButton({
 		const row = exit.value as Record<string, unknown>
 		const id = typeof row['id'] === 'string' ? row['id'] : null
 		const newSlug = typeof row['slug'] === 'string' ? row['slug'] : slug
-		const confirmed = prospect.unconfirmed_reason === undefined
+		const confirmed = !unconfirmed
 		if (id !== null && confirmed) {
 			await verifyCompany({
 				params: { id },
@@ -261,9 +270,9 @@ function AddAsLeadButton({
 			// Every row carries this button, so the visible words alone leave a reader
 			// moving between them with no idea which company each one adds.
 			aria-label={
-				prospect.unconfirmed_reason === undefined
-					? t`Add ${prospect.name} as lead`
-					: t`Add ${prospect.name} as an unverified lead`
+				unconfirmed
+					? t`Add ${prospect.name} as an unverified lead`
+					: t`Add ${prospect.name} as lead`
 			}
 			{...(describedBy === undefined
 				? {}

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -2,7 +2,7 @@ import { useAtomSet } from '@effect/atom-react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { useNavigate } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import styled from 'styled-components'
 
 import { PriButton, usePriToast } from '@batuda/ui/pri'
@@ -35,9 +35,9 @@ import {
  *
  * A prospect the run could not confirm as a real trading company still belongs on
  * the list — the small firms a scan is really for are the ones with the thinnest
- * trail — so it arrives carrying the reason it could not be confirmed. That reason
- * is shown beside the name, and it is what holds back the one-click handoff from
- * vouching for the company on somebody's behalf.
+ * trail — so it arrives carrying the reason it could not be confirmed. The row is
+ * badged, the reason is spelled out under it, and it is what holds back the
+ * one-click handoff from vouching for the company on somebody's behalf.
  */
 
 type ProspectEntry = {
@@ -72,59 +72,10 @@ export function ProspectScanView({
 					</SectionTitle>
 					<List>
 						{prospects.map(p => (
-							<ListItem key={`${p.name}|${p.tax_id ?? p.website ?? ''}`}>
-								<RowHead>
-									<Pill>{p.name}</Pill>
-									{p.unconfirmed_reason !== undefined ? (
-										<CandidatePill data-testid='prospect-candidate'>
-											<Trans>Unconfirmed</Trans>
-										</CandidatePill>
-									) : null}
-									{p.website !== undefined ? (
-										<SafeLink href={p.website}>{p.website}</SafeLink>
-									) : null}
-								</RowHead>
-								<Reason>{p.why_relevant}</Reason>
-								{p.unconfirmed_reason !== undefined ? (
-									<Reason>{p.unconfirmed_reason}</Reason>
-								) : null}
-								<FieldsTable>
-									{p.location !== undefined ? (
-										<FieldRow>
-											<FieldKey>
-												<Trans>Location</Trans>
-											</FieldKey>
-											<FieldValue>{p.location}</FieldValue>
-										</FieldRow>
-									) : null}
-									{p.industry !== undefined ? (
-										<FieldRow>
-											<FieldKey>
-												<Trans>Industry</Trans>
-											</FieldKey>
-											<FieldValue>{p.industry}</FieldValue>
-										</FieldRow>
-									) : null}
-									{p.country !== undefined ? (
-										<FieldRow>
-											<FieldKey>
-												<Trans>Country</Trans>
-											</FieldKey>
-											<FieldValue>{p.country}</FieldValue>
-										</FieldRow>
-									) : null}
-									{p.tax_id !== undefined ? (
-										<FieldRow>
-											<FieldKey>
-												<Trans>Tax ID</Trans>
-											</FieldKey>
-											<FieldValue>{p.tax_id}</FieldValue>
-										</FieldRow>
-									) : null}
-								</FieldsTable>
-								<CitationList citations={p.citations} />
-								<AddAsLeadButton prospect={p} />
-							</ListItem>
+							<ProspectRow
+								key={`${p.name}|${p.tax_id ?? p.website ?? ''}`}
+								prospect={p}
+							/>
 						))}
 					</List>
 				</Section>
@@ -135,11 +86,104 @@ export function ProspectScanView({
 	)
 }
 
-// The same shape as Pill, in the warning colour: a row the run could not confirm
-// reads as a lead like any other until something on it says otherwise.
+// One company in the list. It is its own component so the reason it could not be
+// confirmed can carry an id, which the row's button points at — a reader moving
+// button to button otherwise meets a column of identical "Add as lead" controls
+// with nothing saying which company each belongs to, let alone which of them will
+// write a company nobody has vouched for.
+function ProspectRow({ prospect }: { readonly prospect: ProspectEntry }) {
+	const doubtId = useId()
+	const unconfirmed = prospect.unconfirmed_reason !== undefined
+
+	return (
+		<ListItem>
+			<RowHead>
+				<Pill>{prospect.name}</Pill>
+				{unconfirmed ? (
+					<CandidatePill data-testid='prospect-candidate'>
+						<Trans>Unconfirmed company</Trans>
+					</CandidatePill>
+				) : null}
+				{prospect.website !== undefined ? (
+					<SafeLink href={prospect.website}>{prospect.website}</SafeLink>
+				) : null}
+			</RowHead>
+			<Reason>{prospect.why_relevant}</Reason>
+			{unconfirmed ? (
+				<Reason id={doubtId}>
+					<ReasonLabel>
+						<Trans>Could not be confirmed:</Trans>
+					</ReasonLabel>{' '}
+					{prospect.unconfirmed_reason}
+				</Reason>
+			) : null}
+			<FieldsTable>
+				{prospect.location !== undefined ? (
+					<FieldRow>
+						<FieldKey>
+							<Trans>Location</Trans>
+						</FieldKey>
+						<FieldValue>{prospect.location}</FieldValue>
+					</FieldRow>
+				) : null}
+				{prospect.industry !== undefined ? (
+					<FieldRow>
+						<FieldKey>
+							<Trans>Industry</Trans>
+						</FieldKey>
+						<FieldValue>{prospect.industry}</FieldValue>
+					</FieldRow>
+				) : null}
+				{prospect.country !== undefined ? (
+					<FieldRow>
+						<FieldKey>
+							<Trans>Country</Trans>
+						</FieldKey>
+						<FieldValue>{prospect.country}</FieldValue>
+					</FieldRow>
+				) : null}
+				{prospect.tax_id !== undefined ? (
+					<FieldRow>
+						<FieldKey>
+							<Trans>Tax ID</Trans>
+						</FieldKey>
+						<FieldValue>{prospect.tax_id}</FieldValue>
+					</FieldRow>
+				) : null}
+			</FieldsTable>
+			<CitationList citations={prospect.citations} />
+			<AddAsLeadButton
+				prospect={prospect}
+				describedBy={unconfirmed ? doubtId : undefined}
+			/>
+		</ListItem>
+	)
+}
+
+// The same shape as Pill, in the warning colour, with an outline so it is not just
+// a differently-tinted twin of the name chip beside it. The fill is mixed into a
+// surface rather than into transparency: mixed into transparency it takes the
+// colour of whatever it lands on, and what it lands on is the section's metal
+// plate, which in the light theme is the same amber-beige as the warning colour —
+// the badge came out at 1:1 against it, which is to say invisible in the theme
+// most people use.
 const CandidatePill = styled(Pill)`
-	background: color-mix(in oklab, var(--color-warning) 16%, transparent);
-	color: var(--color-warning);
+	background: color-mix(
+		in oklab,
+		var(--color-warning) 18%,
+		var(--color-surface-container-lowest)
+	);
+	color: var(--color-on-warning-container);
+	border: 1px solid color-mix(in oklab, var(--color-warning) 45%, transparent);
+`
+
+// The label on the reason a company could not be confirmed. Without it the reason
+// is a second italic paragraph directly under the first, and nothing — not the
+// wording, which the model writes, nor the styling, which is identical — says which
+// one is why the company matches and which is why nobody could vouch for it.
+const ReasonLabel = styled.strong`
+	font-style: normal;
+	color: var(--color-on-warning-container);
 `
 
 // One-click handoff: turn a discovered prospect into a lead (a new company at the
@@ -150,7 +194,14 @@ const CandidatePill = styled(Pill)`
 // Verified means a person vouched for this being a real lead, and stamping it on a
 // company the run itself said it could not confirm would launder the doubt away at
 // the one step where it still shows.
-function AddAsLeadButton({ prospect }: { readonly prospect: ProspectEntry }) {
+function AddAsLeadButton({
+	prospect,
+	describedBy,
+}: {
+	readonly prospect: ProspectEntry
+	/** The reason this company could not be confirmed, for a reader to be pointed at. */
+	readonly describedBy?: string | undefined
+}) {
 	const { t } = useLingui()
 	const toast = usePriToast()
 	const navigate = useNavigate()
@@ -207,7 +258,22 @@ function AddAsLeadButton({ prospect }: { readonly prospect: ProspectEntry }) {
 			type='button'
 			$variant='outlined'
 			data-testid='prospect-add-lead'
+			// Every row carries this button, so the visible words alone leave a reader
+			// moving between them with no idea which company each one adds.
+			aria-label={
+				prospect.unconfirmed_reason === undefined
+					? t`Add ${prospect.name} as lead`
+					: t`Add ${prospect.name} as an unverified lead`
+			}
+			{...(describedBy === undefined
+				? {}
+				: { 'aria-describedby': describedBy })}
 			disabled={busy}
+			// Kept reachable while it works: a natively disabled button drops focus to
+			// nowhere mid-click, so the label changing to "Adding…" is announced to
+			// nobody.
+			focusableWhenDisabled
+			aria-busy={busy}
 			onClick={() => void add()}
 		>
 			<Plus size={14} aria-hidden />

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -480,6 +480,10 @@ msgid "Added as a verified lead"
 msgstr "Afegit com a oportunitat verificada"
 
 #: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added as an unverified lead"
+msgstr "Afegit com a oportunitat sense verificar"
+
+#: src/components/research/findings/prospect-scan-view.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Adding…"
 msgstr "S'està afegint…"
@@ -3092,6 +3096,7 @@ msgstr "Localitzant…"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/research-dialog.tsx
 #: src/components/research/run-labels.ts
 #: src/routes/calendar/index.tsx
@@ -6094,6 +6099,10 @@ msgstr "Desassigna"
 #: src/routes/companies/index.tsx
 msgid "Unassigned"
 msgstr "Sense assignar"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Unconfirmed"
+msgstr "Sense confirmar"
 
 #: src/components/research/trust-badge.tsx
 msgid "Undeliverable"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -1128,6 +1128,7 @@ msgstr "Client"
 #: src/components/instructions/template-dialog.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/research-dialog.tsx
+#: src/routes/__root.tsx
 #: src/routes/calendar/index.tsx
 #: src/routes/emails/$threadId.tsx
 #: src/routes/emails/inboxes.tsx
@@ -3964,6 +3965,10 @@ msgstr "Res a mostrar en aquest interval."
 #: src/routes/documents/index.tsx
 msgid "Nothing written down matches that."
 msgstr "No hi ha res escrit que hi coincideixi."
+
+#: src/routes/__root.tsx
+msgid "Notifications"
+msgstr "Notificacions"
 
 #: src/components/primitives/pri-rich-text.tsx
 msgid "Numbered list"

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -399,6 +399,16 @@ msgstr "Afegeix"
 msgid "Add {0}"
 msgstr "Afegeix {0}"
 
+#. placeholder {0}: prospect.name
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Add {0} as an unverified lead"
+msgstr "Afegeix {0} com a oportunitat sense verificar"
+
+#. placeholder {0}: prospect.name
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Add {0} as lead"
+msgstr "Afegeix {0} com a oportunitat"
+
 #: src/components/shared/editable-field.tsx
 msgid "Add {label}"
 msgstr "Afegeix {label}"
@@ -1428,6 +1438,10 @@ msgstr "No s’ha pogut tornar a permetre"
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Could not apply the batch."
 msgstr "No s'ha pogut aplicar el lot."
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Could not be confirmed:"
+msgstr "No s'ha pogut confirmar:"
 
 #: src/components/research/run-actions.tsx
 msgid "Could not cancel the run"
@@ -6101,8 +6115,8 @@ msgid "Unassigned"
 msgstr "Sense assignar"
 
 #: src/components/research/findings/prospect-scan-view.tsx
-msgid "Unconfirmed"
-msgstr "Sense confirmar"
+msgid "Unconfirmed company"
+msgstr "Empresa sense confirmar"
 
 #: src/components/research/trust-badge.tsx
 msgid "Undeliverable"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -1128,6 +1128,7 @@ msgstr "Client"
 #: src/components/instructions/template-dialog.tsx
 #: src/components/interactions/quick-capture-dialog.tsx
 #: src/components/research/research-dialog.tsx
+#: src/routes/__root.tsx
 #: src/routes/calendar/index.tsx
 #: src/routes/emails/$threadId.tsx
 #: src/routes/emails/inboxes.tsx
@@ -3964,6 +3965,10 @@ msgstr "Nothing to show in this range."
 #: src/routes/documents/index.tsx
 msgid "Nothing written down matches that."
 msgstr "Nothing written down matches that."
+
+#: src/routes/__root.tsx
+msgid "Notifications"
+msgstr "Notifications"
 
 #: src/components/primitives/pri-rich-text.tsx
 msgid "Numbered list"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -399,6 +399,16 @@ msgstr "Add"
 msgid "Add {0}"
 msgstr "Add {0}"
 
+#. placeholder {0}: prospect.name
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Add {0} as an unverified lead"
+msgstr "Add {0} as an unverified lead"
+
+#. placeholder {0}: prospect.name
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Add {0} as lead"
+msgstr "Add {0} as lead"
+
 #: src/components/shared/editable-field.tsx
 msgid "Add {label}"
 msgstr "Add {label}"
@@ -1428,6 +1438,10 @@ msgstr "Could not allow it again"
 #: src/components/research/review/proposed-updates-review.tsx
 msgid "Could not apply the batch."
 msgstr "Could not apply the batch."
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Could not be confirmed:"
+msgstr "Could not be confirmed:"
 
 #: src/components/research/run-actions.tsx
 msgid "Could not cancel the run"
@@ -6101,8 +6115,8 @@ msgid "Unassigned"
 msgstr "Unassigned"
 
 #: src/components/research/findings/prospect-scan-view.tsx
-msgid "Unconfirmed"
-msgstr "Unconfirmed"
+msgid "Unconfirmed company"
+msgstr "Unconfirmed company"
 
 #: src/components/research/trust-badge.tsx
 msgid "Undeliverable"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -480,6 +480,10 @@ msgid "Added as a verified lead"
 msgstr "Added as a verified lead"
 
 #: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added as an unverified lead"
+msgstr "Added as an unverified lead"
+
+#: src/components/research/findings/prospect-scan-view.tsx
 #: src/routes/settings/organization/members.tsx
 msgid "Adding…"
 msgstr "Adding…"
@@ -3092,6 +3096,7 @@ msgstr "Locating…"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/components/research/findings/prospect-scan-view.tsx
 #: src/components/research/research-dialog.tsx
 #: src/components/research/run-labels.ts
 #: src/routes/calendar/index.tsx
@@ -6094,6 +6099,10 @@ msgstr "Unassign"
 #: src/routes/companies/index.tsx
 msgid "Unassigned"
 msgstr "Unassigned"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Unconfirmed"
+msgstr "Unconfirmed"
 
 #: src/components/research/trust-badge.tsx
 msgid "Undeliverable"

--- a/apps/internal/src/routes/__root.tsx
+++ b/apps/internal/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { HydrationBoundary, RegistryProvider } from '@effect/atom-react'
+import { useLingui } from '@lingui/react/macro'
 import {
 	createRootRoute,
 	HeadContent,
@@ -250,7 +251,7 @@ function RootComponent() {
 												</ComposeEmailProvider>
 											</QuickCaptureProvider>
 										)}
-										<PriToast.Viewport />
+										<ToastChrome />
 									</PriToast.Provider>
 								</LayoutGroup>
 							</BatudaMotionConfig>
@@ -276,6 +277,19 @@ var m=document.querySelector('meta[name="theme-color"]')
 var s=getComputedStyle(r).getPropertyValue('--color-surface').trim()
 if(m&&s)m.setAttribute('content',s)
 }catch(e){}})()`
+
+// The raised toasts, and the two labels Base UI would otherwise write in English
+// on its own. It is a component rather than markup inline above because the
+// translations only exist inside the language provider, which the root renders
+// below itself — reading them any higher gets a hook with no provider.
+function ToastChrome() {
+	const { t } = useLingui()
+	return (
+		<PriToast.Viewport aria-label={t`Notifications`}>
+			<PriToast.List closeLabel={t`Close`} />
+		</PriToast.Viewport>
+	)
+}
 
 function RootDocument({
 	lang,

--- a/packages/research/src/application/organisation-kind-guard.test.ts
+++ b/packages/research/src/application/organisation-kind-guard.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from 'vitest'
+
+import { dropNonCompanies } from './organisation-kind-guard'
+
+// A scan's answer: the list of organisations it came back with.
+const scan = (
+	prospects: ReadonlyArray<Record<string, unknown>>,
+): Record<string, unknown> => ({ prospects })
+
+const namesOf = (findings: unknown): Array<unknown> =>
+	(findings as { prospects: Array<{ name?: unknown }> }).prospects.map(
+		row => row.name,
+	)
+
+describe('dropNonCompanies', () => {
+	describe('when a row names itself as a body of another kind', () => {
+		it('should drop a trade association that says so in its own name', () => {
+			// GIVEN a list holding a real installer and the association that lists it
+			const findings = scan([
+				{ name: 'Electricidad Mora SL', why_relevant: 'Installer in Ourense.' },
+				{
+					name: 'Asociación Provincial de Instaladores Eléctricos de Ourense',
+					why_relevant: 'Matches the sector and the province asked for.',
+				},
+			])
+
+			// WHEN the kinds are checked
+			// THEN the body goes and the company stays, with the words that decided it
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual(['Electricidad Mora SL'])
+			expect(result.dropped).toEqual([
+				{
+					name: 'Asociación Provincial de Instaladores Eléctricos de Ourense',
+					kind: 'asociacion',
+				},
+			])
+		})
+
+		it('should drop a body that says what it is in its rationale', () => {
+			// GIVEN a row whose name gives nothing away but whose rationale opens with
+			// what the organisation is
+			const findings = scan([
+				{
+					name: 'AEMIAT',
+					why_relevant:
+						'Regional association representing 212 installation companies.',
+				},
+			])
+
+			// WHEN checked — THEN the rationale is enough on its own
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual([])
+			expect(result.dropped[0]?.kind).toBe('association')
+		})
+
+		it('should drop a kind that only a phrase pins down', () => {
+			// GIVEN the grid operator, which no single word identifies
+			const findings = scan([
+				{
+					name: 'Red Eléctrica de España',
+					why_relevant: 'Operador del sistema eléctrico (TSO).',
+				},
+			])
+
+			// WHEN checked — THEN the run of words is matched, not "operador" alone
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual([])
+			expect(result.dropped[0]?.kind).toBe('operador del sistema')
+		})
+
+		it('should drop a body filed under a trade that names the kind', () => {
+			// GIVEN a row that says what it is only in its industry
+			const findings = scan([
+				{
+					name: 'FENIE',
+					industry: 'Federación nacional de empresarios de instalaciones',
+					why_relevant: 'Covers the whole of the sector asked about.',
+				},
+			])
+
+			// WHEN checked — THEN the trade is read the same way the rationale is
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual([])
+			expect(result.dropped[0]?.kind).toBe('federacion')
+		})
+
+		it('should read a plural and an accent the same as the singular form', () => {
+			// GIVEN the same kinds written in the plural, and with the accents a
+			// Spanish page prints
+			const findings = scan([
+				{ name: 'Confederación Española de Gremios', why_relevant: 'Sector.' },
+				{ name: 'Unión de Asociaciones de Instaladores', why_relevant: 'Sec.' },
+			])
+
+			// WHEN checked — THEN both go: folding happens before the words are read
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual([])
+		})
+
+		it('should read a Catalan name whose word carries an interpunct', () => {
+			// GIVEN "Col·legi Oficial", where the dot sits inside the word
+			const findings = scan([
+				{
+					name: "Col·legi Oficial d'Enginyers Tècnics",
+					why_relevant: 'Professional body for the trade.',
+				},
+			])
+
+			// WHEN checked — THEN the punctuation inside the word is removed rather
+			// than split on, so the phrase still reads as one
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual([])
+			expect(result.dropped[0]?.kind).toBe('collegi oficial')
+		})
+	})
+
+	describe('when a row only mentions a body it belongs to', () => {
+		it('should keep a company introduced as a member of one', () => {
+			// GIVEN an installer whose rationale names the association it belongs to
+			const findings = scan([
+				{
+					name: 'Instalaciones Ruiz SL',
+					why_relevant:
+						'Miembro de la Asociación de Instaladores de Ourense; 14 empleados.',
+				},
+			])
+
+			// WHEN checked — THEN the membership word governs what follows it, so this
+			// says who it belongs to, not what it is
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual(['Instalaciones Ruiz SL'])
+			expect(result.dropped).toEqual([])
+		})
+
+		it('should keep a company whose membership is written the long way round', () => {
+			// GIVEN the longest ordinary way of saying it, with four words in between
+			const findings = scan([
+				{
+					name: 'Montajes Tejero',
+					why_relevant: 'Member of the Spanish association of installers.',
+				},
+			])
+
+			// WHEN checked — THEN the lookback still reaches the membership word
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual(['Montajes Tejero'])
+		})
+
+		it('should keep a company whose own name says it is a member', () => {
+			// GIVEN a membership word inside the name itself
+			const findings = scan([
+				{
+					name: 'Instalaciones Ruiz, miembro de la Asociación Gallega',
+					why_relevant: 'Installer in Ourense.',
+				},
+			])
+
+			// WHEN checked — THEN the name is read the same way the rationale is
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(result.dropped).toEqual([])
+		})
+
+		it('should keep a company that took a body word for its brand', () => {
+			// GIVEN companies whose trading name borrows the word — a taberna, a
+			// software house — with no trade after it to cover
+			const findings = scan([
+				{ name: 'El Gremio Taberna SL', why_relevant: 'Bar in Madrid.' },
+				{ name: 'Guild Software Ltd', why_relevant: 'Software vendor.' },
+			])
+
+			// WHEN checked
+			// THEN both stay. A body's name gives the trade it covers — "Gremio de
+			// Instaladores" — and a company that merely liked the word names none,
+			// because it is not covering one
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual([
+				'El Gremio Taberna SL',
+				'Guild Software Ltd',
+			])
+		})
+
+		it('should keep a company a body word only describes', () => {
+			// GIVEN a description where the word modifies what follows it
+			const findings = scan([
+				{
+					name: 'Instalaciones Vega',
+					description: 'Association-backed installer with 30 staff.',
+				},
+			])
+
+			// WHEN checked — THEN it stays: an association-backed installer is an
+			// installer, and the word is describing the next one, not the organisation
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual(['Instalaciones Vega'])
+		})
+
+		it('should keep a company whose name merely looks like a membership word', () => {
+			// GIVEN "Asociados", what a partnership calls itself — not "Asociación"
+			const findings = scan([
+				{ name: 'García y Asociados SL', why_relevant: 'Electrical fitter.' },
+			])
+
+			// WHEN checked — THEN each spelling is listed rather than matched by its
+			// opening, so a member's own word never reads as the body
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual(['García y Asociados SL'])
+		})
+
+		it('should keep a company that gets to the body only late in its rationale', () => {
+			// GIVEN a company that says what it does first and mentions the sector body
+			// well after
+			const findings = scan([
+				{
+					name: 'Electro Vigo',
+					why_relevant:
+						'Instaladora eléctrica de Vigo con 12 empleados que colabora con la asociación del sector.',
+				},
+			])
+
+			// WHEN checked — THEN only the opening of a rationale settles the kind: a
+			// body leads with what it is, a company gets there afterwards
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual(['Electro Vigo'])
+		})
+	})
+
+	describe('when a row says nothing about its kind', () => {
+		it('should keep a company the run could not confirm', () => {
+			// GIVEN a thinly-documented small firm the run marked as a candidate
+			const findings = scan([
+				{
+					name: 'Instalaciones Barreiro',
+					why_relevant: 'Named on a municipal tender list.',
+					unconfirmed_reason: 'No website or register entry found.',
+				},
+			])
+
+			// WHEN checked
+			// THEN it stays: not being able to prove a company exists is not proof it
+			// does not, and only a stated kind is ever a reason to drop
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual(['Instalaciones Barreiro'])
+			expect(result.dropped).toEqual([])
+		})
+
+		it('should keep a row whose only clue is a word that means something else', () => {
+			// GIVEN "cámara", which is refrigeration equipment far more often than it
+			// is a chamber of commerce
+			const findings = scan([
+				{ name: 'Cámaras Frigoríficas del Norte', why_relevant: 'Cold rooms.' },
+			])
+
+			// WHEN checked — THEN the word alone is not enough; only the full phrase is
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(namesOf(result.findings)).toEqual([
+				'Cámaras Frigoríficas del Norte',
+			])
+		})
+
+		it('should keep a row with no name and no rationale at all', () => {
+			// GIVEN a row the model returned all but empty
+			const findings = scan([{ citations: [] }])
+
+			// WHEN checked — THEN there is nothing stated to drop it on
+			const result = dropNonCompanies(findings, 'prospects')
+			expect(result.dropped).toEqual([])
+			expect(
+				(result.findings as { prospects: Array<unknown> }).prospects,
+			).toHaveLength(1)
+		})
+	})
+
+	describe('when the answer is not a list of organisations', () => {
+		it('should pass a run through untouched when it has no list', () => {
+			// GIVEN a run about one named company, which was told who to research
+			const findings = { enrichment: { industry: 'Asociación profesional' } }
+
+			// WHEN checked with no list field
+			// THEN nothing is read and nothing is dropped
+			const result = dropNonCompanies(findings, undefined)
+			expect(result.findings).toBe(findings)
+			expect(result.dropped).toEqual([])
+		})
+
+		it('should read a competitor list the same way as a prospect list', () => {
+			// GIVEN the other scan schema's list, whose rows carry a description where
+			// a prospect carries a rationale
+			const findings = {
+				competitors: [
+					{ name: 'Gremio de Instaladores de Madrid', description: 'Sector.' },
+					{
+						name: 'AEMIAT',
+						description: 'Regional association of installation firms.',
+					},
+					{ name: 'Elecnor', description: 'Contractor.' },
+				],
+			}
+
+			// WHEN checked against that list's own key
+			// THEN both bodies go — the one that says what it is in its name and the one
+			// that says it in its description — so neither scan goes unchecked for the
+			// want of a field name
+			const result = dropNonCompanies(findings, 'competitors')
+			expect(
+				(
+					result.findings as { competitors: Array<{ name: string }> }
+				).competitors.map(row => row.name),
+			).toEqual(['Elecnor'])
+		})
+
+		it('should leave a list entry that is not an object alone', () => {
+			// GIVEN a list holding something that is not a row
+			const findings = scan([])
+			const withJunk = { prospects: [null, 'Asociación', { name: 'Elecnor' }] }
+
+			// WHEN checked — THEN only real rows are judged
+			expect(dropNonCompanies(findings, 'prospects').dropped).toEqual([])
+			const result = dropNonCompanies(withJunk, 'prospects')
+			expect(
+				(result.findings as { prospects: Array<unknown> }).prospects,
+			).toEqual([null, 'Asociación', { name: 'Elecnor' }])
+		})
+
+		it('should leave findings that are null or a bare value untouched', () => {
+			// GIVEN non-object findings
+			// WHEN checked — THEN they pass straight through
+			expect(dropNonCompanies(null, 'prospects').findings).toBeNull()
+			expect(dropNonCompanies('text', 'prospects').findings).toBe('text')
+		})
+	})
+})

--- a/packages/research/src/application/organisation-kind-guard.ts
+++ b/packages/research/src/application/organisation-kind-guard.ts
@@ -1,0 +1,319 @@
+/**
+ * Drops a row of a discovery scan that is not a company at all — an association,
+ * a federation, a guild, an employers' body, a chamber of commerce, a professional
+ * college, or the sector's own system operator.
+ *
+ * A search for companies in a trade runs straight through those bodies' pages,
+ * because that is where the companies are named — the breadth ask sends it there on
+ * purpose. What comes back is the members AND the body that published the list, and
+ * nothing else in the chain can tell them apart: the size and place filter only
+ * drops what states a size or place the request ruled out, and a federation states
+ * neither.
+ *
+ * Two states, and only one of them is a dropped row:
+ *  - the run could not confirm a company exists → it stays, marked as a candidate
+ *    with its reason. Absence of proof is not proof of absence, and the small firms
+ *    a scan is really for are exactly the ones with the thinnest trail.
+ *  - the run states the organisation is a body of another kind → it goes. The
+ *    question was asked and answered.
+ * So this drops only on what a row says about itself, never on a guess: the rows
+ * that need dropping name what they are unprompted ("Asociación de instaladores
+ * eléctricos de Ourense", "Regional association representing 212 installation
+ * companies", "Operador del sistema eléctrico"), and a row that says nothing about
+ * its kind is kept.
+ *
+ * Two things keep a real company that merely belongs to a body from being read as
+ * one. A body says what it is first — it is the whole of what it is — so only the
+ * opening of a row's own description counts, while a member gets there after saying
+ * what it does. And a kind word introduced by a membership word ("miembro de la
+ * asociación") describes who the company belongs to, not what it is.
+ *
+ * It reads Spanish, Catalan and English, which is what the runs are written in, and
+ * Galician comes free because it spells the words the same way. It does NOT read
+ * French, German, Portuguese, Italian, Dutch or Basque: measured against fifteen
+ * European trade bodies it recognised four. A body in one of the others reaches the
+ * list as a company. The words and the distances below are read off the phrasings
+ * that actually came back, not derived from anything, so each one is a guess that
+ * held rather than a rule — which is why the whole approach is a stopgap. Asking
+ * the model what kind of organisation a row is would need none of it: it reads
+ * every one of those languages, and a body describes itself as one in its own
+ * words already. That is the version to build; this is the one that works today
+ * for the market being sold to.
+ */
+
+import { isPlainObject } from './guard-shapes'
+
+// Words a body of this kind calls itself by, each spelling listed rather than
+// matched by prefix so that "asociado" and "asociadas" — what a MEMBER calls
+// itself — can never be read as the body it belongs to.
+const BODY_WORDS = new Set([
+	'asociacion',
+	'asociaciones',
+	'associacio',
+	'associacions',
+	'association',
+	'associations',
+	'federacion',
+	'federaciones',
+	'federacio',
+	'federacions',
+	'federation',
+	'federations',
+	'confederacion',
+	'confederaciones',
+	'confederacio',
+	'confederacions',
+	'confederation',
+	'gremio',
+	'gremios',
+	'gremi',
+	'gremis',
+	'guild',
+	'guilds',
+	'patronal',
+	'patronales',
+	'patronals',
+])
+
+// Kinds that only a phrase pins down. Each word on its own is something else
+// entirely — a "cámara frigorífica" is refrigeration equipment, a "colegio" is a
+// school, an "operador" is any operator — so these are matched as a run of
+// consecutive words instead.
+const BODY_PHRASES: ReadonlyArray<ReadonlyArray<string>> = [
+	['colegio', 'oficial'],
+	['colegios', 'oficiales'],
+	['colegio', 'profesional'],
+	['collegi', 'oficial'],
+	['collegi', 'professional'],
+	['camara', 'de', 'comercio'],
+	['cambra', 'de', 'comerc'],
+	['chamber', 'of', 'commerce'],
+	['operador', 'del', 'sistema'],
+	['operadora', 'del', 'sistema'],
+	['gestor', 'de', 'la', 'red'],
+	['gestor', 'de', 'red'],
+	['system', 'operator'],
+	['grid', 'operator'],
+]
+
+// What a body's name puts between the kind and the trade it covers — "Gremio DE
+// instaladores", "Chamber OF commerce". A company that merely borrowed the word for
+// its brand has no trade to name, so it never reaches for one of these.
+const LINKING_WORDS = new Set(['de', 'del', 'dels', 'd', 'of'])
+
+// How far past the kind word that link may sit: far enough for the adjective a
+// body usually carries ("Asociación Provincial de…", "Federación Nacional de…").
+const LINK_REACH_WORDS = 3
+
+// Words that turn the kind word before them into a description of something else —
+// "association-backed installer" is an installer. A body is never any of these.
+const MODIFIER_FOLLOWERS = new Set([
+	'backed',
+	'led',
+	'owned',
+	'run',
+	'managed',
+	'approved',
+	'certified',
+	'accredited',
+	'registered',
+	'affiliated',
+	'endorsed',
+	'respaldado',
+	'respaldada',
+	'avalado',
+	'avalada',
+	'certificado',
+	'certificada',
+])
+
+// Words that turn what follows into somebody the company belongs to rather than
+// what the company is.
+const MEMBERSHIP_WORDS = new Set([
+	'miembro',
+	'miembros',
+	'membre',
+	'membres',
+	'member',
+	'members',
+	'membership',
+	'socio',
+	'socios',
+	'socia',
+	'socias',
+	'asociado',
+	'asociados',
+	'asociada',
+	'asociadas',
+	'associat',
+	'associada',
+	'afiliado',
+	'afiliada',
+	'afiliados',
+	'afiliadas',
+	'afiliat',
+	'pertenece',
+	'pertenecen',
+	'pertany',
+	'integrante',
+	'integrantes',
+	'belongs',
+	'affiliated',
+])
+
+// How far into a row's own description a kind word still describes the row itself.
+// A body leads with what it is — "Asociación de instaladores…", "Regional
+// association representing 212 installation companies" — while a company that
+// belongs to one first says what it does and gets there later.
+const KIND_WINDOW_WORDS = 6
+
+// How far back a membership word still governs the kind word after it: far enough
+// for the longest ordinary way of saying it ("member of the Spanish association").
+const MEMBERSHIP_LOOKBACK_WORDS = 5
+
+// Accent-folded words, with the Catalan interpunct removed rather than split on so
+// "Col·legi" reads as one word. An apostrophe is left to split, because the one it
+// writes is an elided link — "d'Enginyers" is "de Enginyers", and that link is what
+// tells a body's name from a company that borrowed the word.
+const wordsOf = (value: string): ReadonlyArray<string> =>
+	value
+		.normalize('NFKD')
+		.replace(/\p{Diacritic}/gu, '')
+		.toLowerCase()
+		.replace(/·/g, '')
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean)
+
+// Whether a membership word governs the kind word at this position.
+const isGoverned = (words: ReadonlyArray<string>, at: number): boolean =>
+	words
+		.slice(Math.max(0, at - MEMBERSHIP_LOOKBACK_WORDS), at)
+		.some(word => MEMBERSHIP_WORDS.has(word))
+
+// The phrase starting at this position, if one does.
+const phraseAt = (
+	words: ReadonlyArray<string>,
+	at: number,
+): string | undefined => {
+	for (const phrase of BODY_PHRASES) {
+		const matches = phrase.every((word, offset) => words[at + offset] === word)
+		if (matches) return phrase.join(' ')
+	}
+	return undefined
+}
+
+// Whether a link to the trade the body covers follows the kind word here.
+const linksAfter = (words: ReadonlyArray<string>, at: number): boolean =>
+	words
+		.slice(at + 1, at + 1 + LINK_REACH_WORDS)
+		.some(word => LINKING_WORDS.has(word))
+
+/**
+ * What kind of body this text says the organisation is, or nothing when it says
+ * none.
+ *
+ * `windowWords` bounds how far in a kind word still describes the organisation
+ * itself — a name is short and says what it is throughout, a description only at
+ * its opening.
+ *
+ * `needsLink` is what separates a body's name from a company that took the word
+ * for its brand. A body's name gives the trade it covers — "Gremio de Instaladores
+ * de Madrid" — while "El Gremio Taberna" and "Guild Software" name no trade,
+ * because they are not covering one. A description is not held to this: a body
+ * writing about itself has no reason to phrase it that way. A phrase is not held
+ * to it either — nobody trades under "cámara de comercio".
+ */
+const bodyKindIn = (
+	text: string | undefined,
+	windowWords: number,
+	needsLink: boolean,
+): string | undefined => {
+	if (typeof text !== 'string') return undefined
+	const words = wordsOf(text)
+	for (let at = 0; at < Math.min(words.length, windowWords); at++) {
+		if (isGoverned(words, at)) continue
+		// The kind word is describing the next word rather than the organisation.
+		if (MODIFIER_FOLLOWERS.has(words[at + 1] ?? '')) continue
+		const word = words[at] ?? ''
+		if (BODY_WORDS.has(word) && (!needsLink || linksAfter(words, at)))
+			return word
+		const phrase = phraseAt(words, at)
+		if (phrase !== undefined) return phrase
+	}
+	return undefined
+}
+
+// Where a row describes itself in its own words. A prospect gives its rationale and
+// the trade it was filed under; a competitor gives a description instead. Both lists
+// are read, so neither can quietly go unchecked for the want of a field name.
+const DESCRIPTION_FIELDS = ['why_relevant', 'description', 'industry'] as const
+
+const textAt = (
+	row: Record<string, unknown>,
+	field: string,
+): string | undefined =>
+	typeof row[field] === 'string' ? row[field] : undefined
+
+// What kind of body a row states it is, or nothing when it states none.
+const statedBodyKind = (row: Record<string, unknown>): string | undefined => {
+	// A name is short and is what the organisation calls itself throughout, so it
+	// counts wherever the word sits — but only where it names a trade to cover.
+	const named = bodyKindIn(textAt(row, 'name'), Number.POSITIVE_INFINITY, true)
+	if (named !== undefined) return named
+	for (const field of DESCRIPTION_FIELDS) {
+		const stated = bodyKindIn(textAt(row, field), KIND_WINDOW_WORDS, false)
+		if (stated !== undefined) return stated
+	}
+	return undefined
+}
+
+/** One dropped row, for the log: who it was and the words that decided it. */
+export interface DroppedOrganisation {
+	readonly name: string
+	readonly kind: string
+}
+
+export interface OrganisationKindResult {
+	readonly findings: unknown
+	readonly dropped: ReadonlyArray<DroppedOrganisation>
+}
+
+/**
+ * `listField` is the key holding this scan's companies — `prospects` or
+ * `competitors`. Anything else passes through untouched: only a scan produces a
+ * list of organisations nobody vouched for, and a run about one named company was
+ * told which company to research.
+ */
+export const dropNonCompanies = (
+	findings: unknown,
+	listField: string | undefined,
+): OrganisationKindResult => {
+	if (listField === undefined) return { findings, dropped: [] }
+
+	const dropped: Array<DroppedOrganisation> = []
+	const walk = (value: unknown, key?: string): unknown => {
+		if (Array.isArray(value)) {
+			if (key === listField) {
+				return value.filter(row => {
+					if (!isPlainObject(row)) return true
+					const kind = statedBodyKind(row)
+					if (kind === undefined) return true
+					dropped.push({
+						name: typeof row['name'] === 'string' ? row['name'] : '',
+						kind,
+					})
+					return false
+				})
+			}
+			return value.map(item => walk(item))
+		}
+		if (isPlainObject(value)) {
+			return Object.fromEntries(
+				Object.entries(value).map(([k, v]) => [k, walk(v, k)] as const),
+			)
+		}
+		return value
+	}
+
+	return { findings: walk(findings), dropped }
+}

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -107,8 +107,10 @@ describe('needsPerFieldSearch', () => {
 			// THEN each company is asked about by its own name, never the request's
 			expect(forScan(findings)).toEqual([
 				{ name: 'Acme', field: 'employee_estimate' },
+				{ name: 'Acme', field: 'location' },
 				{ name: 'Beta', field: 'website' },
 				{ name: 'Beta', field: 'employee_estimate' },
+				{ name: 'Beta', field: 'location' },
 			])
 		})
 
@@ -132,6 +134,7 @@ describe('needsPerFieldSearch', () => {
 						name: 'Acme',
 						website: 'https://acme.test',
 						employee_estimate: { value: 42, source_id: 'https://acme.test' },
+						location: 'Valencia',
 					},
 				],
 			}
@@ -145,8 +148,18 @@ describe('needsPerFieldSearch', () => {
 			// headcount whose value was nulled
 			const findings = {
 				prospects: [
-					{ name: 'A', website: '   ', employee_estimate: { value: null } },
-					{ name: 'B', website: null, employee_estimate: { value: 7 } },
+					{
+						name: 'A',
+						website: '   ',
+						employee_estimate: { value: null },
+						location: 'Valencia',
+					},
+					{
+						name: 'B',
+						website: null,
+						employee_estimate: { value: 7 },
+						location: '  ',
+					},
 				],
 			}
 			// WHEN computed
@@ -155,6 +168,7 @@ describe('needsPerFieldSearch', () => {
 				{ name: 'A', field: 'website' },
 				{ name: 'A', field: 'employee_estimate' },
 				{ name: 'B', field: 'website' },
+				{ name: 'B', field: 'location' },
 			])
 		})
 
@@ -174,6 +188,7 @@ describe('needsPerFieldSearch', () => {
 			expect(forScan(findings)).toEqual([
 				{ name: 'Real', field: 'website' },
 				{ name: 'Real', field: 'employee_estimate' },
+				{ name: 'Real', field: 'location' },
 			])
 		})
 
@@ -474,6 +489,66 @@ describe('mergePerFieldSearch', () => {
 			expect(merged.added).toBe(0)
 		})
 
+		it('should fold a company the second look met under its fuller legal name', () => {
+			// GIVEN a company first met under the name it trades as
+			const findings = {
+				prospects: [
+					{ name: 'Civera Electrificaciones', why_relevant: 'Installer.' },
+				],
+			}
+			// AND a second look that met it through a register, which prints the legal
+			// form on the end
+			const refreshed = {
+				prospects: [
+					{
+						name: 'Civera Electrificaciones, S.L.',
+						website: 'https://civeraelectrificaciones.com/',
+						location: 'Valencia',
+					},
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+
+			// THEN it is one company that gained a site and a place, not two rows. A
+			// register or a directory is exactly where a second look goes, and the
+			// fuller name it prints there is the ordinary case, not an unusual one
+			expect(rows).toHaveLength(1)
+			expect(rows[0]?.['name']).toBe('Civera Electrificaciones')
+			expect(rows[0]?.['website']).toBe('https://civeraelectrificaciones.com/')
+			expect(rows[0]?.['location']).toBe('Valencia')
+			expect(merged.added).toBe(0)
+		})
+
+		it('should fold a company the second look met under a different name entirely', () => {
+			// GIVEN a company first met under its trading name, with its site
+			const findings = {
+				prospects: [{ name: 'Asenel', website: 'https://www.asenel.net/' }],
+			}
+			// AND a second look that names it in full, on the same site
+			const refreshed = {
+				prospects: [
+					{
+						name: 'ASENEL (Asistencia Energética Eléctrica S.L.U.)',
+						website: 'https://www.asenel.net',
+						location: 'Valencia',
+					},
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+
+			// THEN the shared site settles it, as it does for the fold that runs over
+			// the list itself — the two names have nothing in common to match on
+			expect(rows).toHaveLength(1)
+			expect(rows[0]?.['location']).toBe('Valencia')
+			expect(merged.added).toBe(0)
+		})
+
 		it('should fold two spellings that differ only by an accent', () => {
 			// GIVEN a Catalan company name carrying its accent and legal suffix
 			const findings = { prospects: [{ name: 'Transports Munné, S.L.' }] }
@@ -664,7 +739,11 @@ describe('the fields each shape rescues', () => {
 				'location',
 				'size_range',
 			])
-			expect(scanRowFields(SCAN)).toEqual(['website', 'employee_estimate'])
+			expect(scanRowFields(SCAN)).toEqual([
+				'website',
+				'employee_estimate',
+				'location',
+			])
 			expect(scanRowFields(COMPETITORS)).toEqual(['website'])
 			expect(scanRowFields('freeform')).toEqual([])
 		})
@@ -680,6 +759,7 @@ describe('the fields each shape rescues', () => {
 					source_id: 'https://acme.test',
 					confidence: null,
 				},
+				location: 'Valencia',
 				why_relevant: 'matches',
 				description: 'a rival',
 				citations: [],

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -22,9 +22,9 @@
 
 import { mergeContacts } from './contacts-rescue'
 import { discoveryResultField, isDiscoveryScan } from './discovery-scan'
-import { collapse } from './entity-guard'
 import { enrichmentFill } from './extraction-fill'
 import { isPlainObject, isValueWrapper, unwrapValue } from './guard-shapes'
+import { discoveryRowIdentityKeys } from './prospect-dedupe-guard'
 
 // The company-profile facts worth spending an extra search on. `size_range` is
 // also nudged during the loop (headcount is rarely on the homepage); for the
@@ -44,9 +44,14 @@ export const HIGH_VALUE_FIELDS: ReadonlyArray<string> = [
 // Each field named here has to exist on that scan's own schema, or the search is
 // paid for and the answer has nowhere to land — a competitor is never asked for a
 // headcount, so asking the web for one would buy nothing. The test next door
-// checks each name against the real schema so the two cannot drift apart.
+// checks each name against the real schema so the two cannot drift apart. This
+// list also decides what a wider read is allowed to fill in, so a field left out
+// of it is one whose value is thrown away even when a round does turn it up.
+//
+// Listed in the order they are worth going after, since a round's cap can cut the
+// list short.
 const SCAN_ROW_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
-	prospect_scan_v1: ['website', 'employee_estimate'],
+	prospect_scan_v1: ['website', 'employee_estimate', 'location'],
 	competitor_scan_v1: ['website'],
 }
 
@@ -126,18 +131,6 @@ const rowName = (row: Record<string, unknown>): string | undefined => {
 		? name.trim()
 		: undefined
 }
-
-/**
- * The key two mentions of the same company share.
- *
- * A re-extraction reads the same company off a different page and writes the name
- * differently — `Transports Munné, S.L.` against `Transports Munne SL`. Folding
- * those together keeps one company from becoming two rows. The fold keeps the
- * legal suffix, which is what has to happen here: dropping it would fold `Acme`
- * and `Acme Holding` into one, and putting a recovered website on the wrong
- * company is far worse than listing it twice.
- */
-const nameKey = (name: string): string => collapse(name)
 
 /**
  * The still-empty high-value facts worth a focused search, in a stable order.
@@ -254,19 +247,25 @@ const mergeScanRows = (
 	) {
 		return { findings, filled: 0, contactsChanged: false, added: 0 }
 	}
-	const foundByName = new Map<string, Record<string, unknown>>()
+	// Rows are matched on what identifies the company — its name with the legal
+	// form off the end, or its site — not on the name as written. A second look
+	// meets a company through a register or a directory, which prints the fuller
+	// legal name, so matching the name as written files it as somebody new: the
+	// list grows a second copy instead of the first copy gaining what the round
+	// went looking for.
+	const foundByKey = new Map<string, Record<string, unknown>>()
 	for (const row of found) {
-		const name = rowName(row)
 		// First mention wins: a later duplicate of the same company in the same
 		// re-extraction has no better claim, and picking one keeps the fold stable.
-		if (name !== undefined && !foundByName.has(nameKey(name)))
-			foundByName.set(nameKey(name), row)
+		for (const key of discoveryRowIdentityKeys(row)) {
+			if (!foundByKey.has(key)) foundByKey.set(key, row)
+		}
 	}
 	let filled = 0
 	const merged = known.map(row => {
-		const name = rowName(row)
-		const match =
-			name === undefined ? undefined : foundByName.get(nameKey(name))
+		const match = discoveryRowIdentityKeys(row)
+			.map(key => foundByKey.get(key))
+			.find(found => found !== undefined)
 		if (match === undefined) return row
 		const next: Record<string, unknown> = { ...row }
 		let filledHere = 0
@@ -283,16 +282,15 @@ const mergeScanRows = (
 	// company twice appends it once. A duplicate would not only read badly — the
 	// list's length is what decides whether a scan came back too thin to trust,
 	// so counting one company twice can pass a scan off as healthier than it is.
-	const takenNames = new Set(
-		known.flatMap(row => {
-			const name = rowName(row)
-			return name === undefined ? [] : [nameKey(name)]
-		}),
-	)
+	const taken = new Set(known.flatMap(row => discoveryRowIdentityKeys(row)))
 	const additions = found.filter(row => {
-		const name = rowName(row)
-		if (name === undefined || takenNames.has(nameKey(name))) return false
-		takenNames.add(nameKey(name))
+		// Matching an existing company takes any of the keys; becoming a new row in
+		// the list takes a name. A company nobody can name is one nobody can work
+		// with, whatever else is known about it.
+		if (rowName(row) === undefined) return false
+		const keys = discoveryRowIdentityKeys(row)
+		if (keys.some(key => taken.has(key))) return false
+		for (const key of keys) taken.add(key)
 		return true
 	})
 	if (filled === 0 && additions.length === 0) {

--- a/packages/research/src/application/prospect-criteria-guard.test.ts
+++ b/packages/research/src/application/prospect-criteria-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	countryFromPlaceHint,
 	filterProspectsByCriteria,
 	prospectCriteriaFromHints,
 } from './prospect-criteria-guard'
@@ -202,6 +203,44 @@ describe('prospectCriteriaFromHints', () => {
 			expect(criteria.minEmployees).toBeUndefined()
 			expect(criteria.maxEmployees).toBeUndefined()
 			expect(criteria.countries).toEqual(['GB'])
+		})
+	})
+})
+
+describe('countryFromPlaceHint', () => {
+	describe('when the hint is already a country code', () => {
+		it('should read it as that country', () => {
+			// GIVEN the shape a caller most often sends
+			// THEN it is used as it stands
+			expect(countryFromPlaceHint('ES')).toBe('ES')
+			expect(countryFromPlaceHint('es-ES')).toBe('ES')
+		})
+	})
+
+	describe('when the hint names the country in words', () => {
+		it('should still reach the country, in either language', () => {
+			// GIVEN a request that says the country the way a person writes it
+			// THEN the filter runs. Read as a code alone this yields nothing, and a
+			// request that plainly said Spain gets no country filter at all — with the
+			// check reporting nothing dropped, which reads exactly like a clean run
+			expect(countryFromPlaceHint('Spain')).toBe('ES')
+			expect(countryFromPlaceHint('España')).toBe('ES')
+			expect(countryFromPlaceHint('United Kingdom')).toBe('GB')
+		})
+	})
+
+	describe('when the hint is not a country', () => {
+		it('should yield nothing for a town, so nothing is filtered on', () => {
+			// GIVEN a place hint that is somewhere inside a country
+			// THEN no country comes back: a town is not a country to hold a prospect
+			// to, and inventing one would drop companies the request never ruled out
+			expect(countryFromPlaceHint('Barcelona')).toBeUndefined()
+			expect(countryFromPlaceHint('the north of the country')).toBeUndefined()
+		})
+
+		it('should yield nothing when there is no hint at all', () => {
+			expect(countryFromPlaceHint(undefined)).toBeUndefined()
+			expect(countryFromPlaceHint('')).toBeUndefined()
 		})
 	})
 })

--- a/packages/research/src/application/prospect-criteria-guard.ts
+++ b/packages/research/src/application/prospect-criteria-guard.ts
@@ -16,6 +16,7 @@
 
 import { parseCountryAlpha2 } from '../domain/country'
 import { isPlainObject } from './guard-shapes'
+import { mapCountry } from './vocabulary-guard'
 
 // A country read as a canonical two-letter code, or nothing when it is not clearly
 // a country. Both the request's countries and a prospect's stated country pass
@@ -126,6 +127,26 @@ export const filterProspectsByCriteria = (
 	}
 
 	return { findings: walk(findings), dropped }
+}
+
+/**
+ * The country a caller's place hint names, or nothing when it names none.
+ *
+ * A hint is free text about where to search — "ES", "Spain", "España",
+ * "Barcelona" — and only the first of those is a country code. Reading it as a
+ * code alone means a request that plainly said Spain gets no country filter at
+ * all, and the check reports nothing dropped and looks healthy while never having
+ * run. A place that is a town and not a country still yields nothing, which is
+ * right: a town is not a country to hold a prospect to.
+ */
+export const countryFromPlaceHint = (
+	raw: string | undefined,
+): string | undefined => {
+	if (raw === undefined) return undefined
+	const code = parseCountryAlpha2(raw)
+	if (code !== undefined) return code
+	const named = mapCountry(raw)
+	return named === null ? undefined : parseCountryAlpha2(named)
 }
 
 /** The size and place a run's stored hints amount to; empty when it asked for none. */

--- a/packages/research/src/application/prospect-dedupe-guard.test.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest'
+
+import { dedupeDiscoveryRows } from './prospect-dedupe-guard'
+
+const scan = (
+	prospects: ReadonlyArray<Record<string, unknown>>,
+): Record<string, unknown> => ({ prospects })
+
+const rowsOf = (findings: unknown): Array<Record<string, unknown>> =>
+	(findings as { prospects: Array<Record<string, unknown>> }).prospects
+
+// The pages the surviving row ends up citing, in order.
+const citedPagesOf = (findings: unknown): Array<unknown> => {
+	const citations = rowsOf(findings)[0]?.['citations']
+	return Array.isArray(citations)
+		? citations.map(citation => (citation as { source_id: string }).source_id)
+		: []
+}
+
+describe('dedupeDiscoveryRows', () => {
+	describe('when two rows are the same company under different spellings', () => {
+		it('should fold a row that only differs by its legal form', () => {
+			// GIVEN one company met twice, once with the form on the end
+			const findings = scan([
+				{
+					name: 'Cobra Instalaciones y Servicios',
+					why_relevant: 'Contractor.',
+				},
+				{ name: 'COBRA INSTALACIONES Y SERVICIOS SA', why_relevant: 'Ranked.' },
+			])
+
+			// WHEN the list is de-duplicated
+			// THEN one row survives — the form comes off the end of the name key, so
+			// the two spellings meet
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(rowsOf(result.findings)[0]?.['name']).toBe(
+				'Cobra Instalaciones y Servicios',
+			)
+			expect(result.merged).toBe(1)
+		})
+
+		it('should fold a row that only differs by its accents', () => {
+			// GIVEN the same company written with and without accents
+			const findings = scan([
+				{ name: 'Eléctricas Muñoz SL', why_relevant: 'Installer.' },
+				{ name: 'Electricas Munoz SL', why_relevant: 'Directory entry.' },
+			])
+
+			// WHEN de-duplicated — THEN accents fold before the names are compared
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+		})
+
+		it('should fold a row whose legal form is written with dots', () => {
+			// GIVEN the two ways a Spanish company writes the same form
+			const findings = scan([
+				{ name: 'Eléctricas Muñoz SL', why_relevant: 'Installer.' },
+				{ name: 'Electricas Munoz, S.L.', why_relevant: 'Register extract.' },
+			])
+
+			// WHEN de-duplicated
+			// THEN the dots come out before the form is read off the end, so it is one
+			// company rather than one whose form reads as two more words of its name
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+		})
+
+		it('should fold two rows sharing a site even when the names do not meet', () => {
+			// GIVEN a company met once under its trade name and once under its legal one
+			const findings = scan([
+				{ name: 'SICE', website: 'https://www.sice.com', why_relevant: 'A.' },
+				{
+					name: 'Sociedad Ibérica de Construcciones Eléctricas',
+					website: 'https://sice.com/es',
+					why_relevant: 'B.',
+				},
+			])
+
+			// WHEN de-duplicated — THEN the site settles it: the host is the same one
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+		})
+
+		it('should carry sameness across rows that meet by different keys', () => {
+			// GIVEN A and B meeting by name, and B and C meeting by site
+			const findings = scan([
+				{ name: 'Elecnor SA', why_relevant: 'A.' },
+				{ name: 'Elecnor', website: 'https://elecnor.com', why_relevant: 'B.' },
+				{ name: 'Grupo Elecnor Servicios', website: 'https://elecnor.com/es' },
+			])
+
+			// WHEN de-duplicated
+			// THEN all three become one company, which is what they are
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(result.merged).toBe(2)
+		})
+
+		it('should reach the same answer whatever order the rows arrive in', () => {
+			// GIVEN the same three rows with the one that bridges them — matching the
+			// first by name and the second by site — arriving last instead of between
+			const findings = scan([
+				{ name: 'Elecnor SA', why_relevant: 'A.' },
+				{ name: 'Grupo Elecnor Servicios', website: 'https://elecnor.com/es' },
+				{ name: 'Elecnor', website: 'https://elecnor.com', why_relevant: 'B.' },
+			])
+
+			// WHEN de-duplicated
+			// THEN still one company. The bridge row joins two rows that were until
+			// then separate, and a list arrives in whatever order the model wrote it —
+			// so an answer that changed with the order would be no answer at all
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(result.merged).toBe(2)
+		})
+	})
+
+	describe('when the rows being folded hold different facts', () => {
+		it('should fill the gaps in the row that stays from the later one', () => {
+			// GIVEN a first meeting with no tax id and a second that found one
+			const findings = scan([
+				{ name: 'Instalaciones Rubio SL', why_relevant: 'Installer in Vigo.' },
+				{
+					name: 'Instalaciones Rubio',
+					tax_id: 'B36123456',
+					location: 'Vigo, Pontevedra',
+					why_relevant: 'Register extract.',
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN the later row's findings survive on the row that stays — dropping it
+			// outright would throw away what the run paid to find
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]).toMatchObject({
+				name: 'Instalaciones Rubio SL',
+				tax_id: 'B36123456',
+				location: 'Vigo, Pontevedra',
+				why_relevant: 'Installer in Vigo.',
+			})
+		})
+
+		it('should never overwrite a field the surviving row already states', () => {
+			// GIVEN both rows stating a different industry
+			const findings = scan([
+				{ name: 'Acme SL', industry: 'electrical', why_relevant: 'First.' },
+				{ name: 'ACME S.L.', industry: 'construction', why_relevant: 'Later.' },
+			])
+
+			// WHEN de-duplicated
+			// THEN the first reading stays: it is the one the checks upstream weighed
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['industry']).toBe('electrical')
+		})
+
+		it('should treat a null or absent field as a gap to fill', () => {
+			// GIVEN a first row whose website came back blanked by an earlier check
+			const findings = scan([
+				{ name: 'Acme SL', website: null, why_relevant: 'First.' },
+				{ name: 'ACME SA', website: 'https://acme.es', why_relevant: 'Later.' },
+			])
+
+			// WHEN de-duplicated — THEN the blank is a gap, so the later value lands
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['website']).toBe('https://acme.es')
+		})
+
+		it('should add the pages of the later row without repeating one already cited', () => {
+			// GIVEN two rows citing one page in common and one page each
+			const findings = scan([
+				{
+					name: 'Acme SL',
+					why_relevant: 'First.',
+					citations: [
+						{ source_id: 'https://acme.es', confidence: 0.9 },
+						{ source_id: 'https://ranking.es', confidence: 0.6 },
+					],
+				},
+				{
+					name: 'ACME SA',
+					why_relevant: 'Later.',
+					citations: [
+						{ source_id: 'https://acme.es', confidence: 0.5 },
+						{ source_id: 'https://registro.es', confidence: 0.8 },
+					],
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN the surviving row keeps everything the run read, each page once
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(citedPagesOf(result.findings)).toEqual([
+				'https://acme.es',
+				'https://ranking.es',
+				'https://registro.es',
+			])
+		})
+
+		it('should take the pages of the later row when the row that stays cited none', () => {
+			// GIVEN a first row with no citations at all
+			const findings = scan([
+				{ name: 'Acme SL', why_relevant: 'First.' },
+				{
+					name: 'ACME SA',
+					why_relevant: 'Later.',
+					citations: [{ source_id: 'https://acme.es', confidence: 0.9 }],
+				},
+			])
+
+			// WHEN de-duplicated — THEN the evidence still reaches the row that stays
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(citedPagesOf(result.findings)).toEqual(['https://acme.es'])
+		})
+	})
+
+	describe('when the rows are different companies', () => {
+		it('should keep two companies that share neither a name nor a site', () => {
+			// GIVEN two genuinely different installers
+			const findings = scan([
+				{ name: 'Electricidad Mora', website: 'https://mora.es' },
+				{ name: 'Montajes Tejero', website: 'https://tejero.es' },
+			])
+
+			// WHEN de-duplicated — THEN both stay and nothing is counted as merged
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(2)
+			expect(result.merged).toBe(0)
+		})
+
+		it('should still fold two rows whose names are only a legal form', () => {
+			// GIVEN two rows named nothing but a legal form, which leaves no core
+			const findings = scan([
+				{ name: 'SL', why_relevant: 'One.' },
+				{ name: 'S.L.', why_relevant: 'Another.' },
+			])
+
+			// WHEN de-duplicated
+			// THEN they still meet, on the name as written. Neither is a company anyone
+			// can work with, but leaving them with no key at all would let the list
+			// keep every copy of the same useless row
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+		})
+
+		it('should not group two rows on a website that is not an address', () => {
+			// GIVEN two rows carrying prose where a site belongs
+			const findings = scan([
+				{ name: 'Alpha Instal', website: 'not provided', why_relevant: 'One.' },
+				{ name: 'Beta Instal', website: 'not provided', why_relevant: 'Two.' },
+			])
+
+			// WHEN de-duplicated — THEN no host can be read, so neither row lends one
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(2)
+		})
+	})
+
+	describe('when the answer is not a list of companies', () => {
+		it('should pass a run through untouched when it has no list', () => {
+			// GIVEN a run about one named company
+			const findings = { enrichment: { industry: 'electrical' } }
+
+			// WHEN de-duplicated with no list field — THEN nothing is compared
+			const result = dedupeDiscoveryRows(findings, undefined)
+			expect(result.findings).toBe(findings)
+			expect(result.merged).toBe(0)
+		})
+
+		it('should leave a list entry that is not a row alone', () => {
+			// GIVEN a list holding something that is not an object
+			const findings = { prospects: [null, { name: 'Elecnor' }] }
+
+			// WHEN de-duplicated — THEN only real rows are compared
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toEqual([null, { name: 'Elecnor' }])
+		})
+
+		it('should leave findings that are null or a bare value untouched', () => {
+			// GIVEN non-object findings
+			// WHEN de-duplicated — THEN they pass straight through
+			expect(dedupeDiscoveryRows(null, 'prospects').findings).toBeNull()
+			expect(dedupeDiscoveryRows('text', 'prospects').findings).toBe('text')
+		})
+	})
+})

--- a/packages/research/src/application/prospect-dedupe-guard.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.ts
@@ -1,0 +1,205 @@
+/**
+ * Folds the rows of one discovery scan that are the same company into one row.
+ *
+ * A broad search meets a company on a directory, again in a ranking, and again in a
+ * news piece, and each meeting can spell it differently — "Cobra Instalaciones y
+ * Servicios" and "COBRA INSTALACIONES Y SERVICIOS SA" are one company written twice.
+ * Nothing else in the chain catches it: the other duplicate check compares a row
+ * against companies already on file, never against another row of the same answer.
+ * A list of 62 that is 52 companies is the reader's problem to sort out by hand,
+ * and it is the same work every time the scan runs.
+ *
+ * Two rows are the same company when either their names or their sites say so:
+ *  - the same name once its legal form is off the end, so "…y Servicios" and
+ *    "…Y SERVICIOS SA" meet, and accents fold on the way;
+ *  - the same site host, which catches the pair a rename or a trade name hides.
+ * Either alone is enough, and sameness carries: A meeting B by name and B meeting C
+ * by host makes all three one company, which is what they are.
+ *
+ * The first row stays and the later ones fill its gaps — a tax id one meeting found
+ * and the other did not, the site only the ranking printed — with their citations
+ * added to its own. Nothing is overwritten: where both rows state a field, the first
+ * one's reading is the one the checks upstream already weighed. Dropping the later
+ * rows outright would throw away everything the run paid to find on them, which is
+ * the reason this merges instead of filtering.
+ *
+ * It runs after the website check, so a member-directory address several rows shared
+ * is already gone by the time a host counts as evidence two rows are one company.
+ */
+
+import { collapse, nameCore } from './entity-guard'
+import { isPlainObject } from './guard-shapes'
+import { hostOf, isBareWebAddress } from './source-key'
+
+// A legal form written with dots — "Muñoz S.L." — comes apart into single letters
+// that read as two more words of the name, so "Muñoz SL" and "Muñoz S.L." end up
+// under different keys. Taking the dots out first puts the form back together. Two
+// Spanish rows spelling the form differently is the ordinary case here, not an
+// exotic one.
+const withoutFormDots = (name: string): string => name.replace(/\./g, '')
+
+/**
+ * What a row is filed under: its name with the legal form off the end, and the host
+ * of its site. Either identifies the company on its own. A key nothing can be read
+ * from is left out rather than becoming a key every thin row shares.
+ *
+ * Exported because the fold here is not the only place one company can arrive
+ * twice: a later round that looks again for a company's missing fields matches what
+ * it finds against the list, and matching on anything looser would file the same
+ * company under its fuller legal name as somebody new.
+ */
+export const discoveryRowIdentityKeys = (
+	row: Record<string, unknown>,
+): ReadonlyArray<string> => {
+	const keys: Array<string> = []
+	const name = row['name']
+	if (typeof name === 'string') {
+		// A name that is nothing but a legal form leaves no core to file under. It
+		// still has to file under something, or two rows carrying the same useless
+		// name have no key to meet on and the list keeps every copy of it.
+		const core = nameCore(withoutFormDots(name))
+		const filedAs = core === '' ? collapse(name) : core
+		if (filedAs !== '') keys.push(`name:${filedAs}`)
+	}
+	const website = row['website']
+	if (typeof website === 'string' && isBareWebAddress(website)) {
+		const host = hostOf(website)
+		if (host !== null) keys.push(`host:${host}`)
+	}
+	return keys
+}
+
+// What tells two citations apart: the page each names, as written. Only the case
+// and the space around it are ignored — every other character of an address does
+// real work, and folding them away would file "/about-us" and "/aboutus" as one
+// page and quietly drop the second one's evidence.
+const citationKey = (citation: unknown): string =>
+	isPlainObject(citation) && typeof citation['source_id'] === 'string'
+		? citation['source_id'].trim().toLowerCase()
+		: JSON.stringify(citation)
+
+// The citations of both rows, with a page cited twice kept once. A row's evidence is
+// the reason to believe it, so a merge that dropped half of it would leave the
+// surviving row looking thinner than the run's actual reading.
+const mergeCitations = (kept: unknown, added: unknown): unknown => {
+	if (!Array.isArray(kept)) return Array.isArray(added) ? added : kept
+	if (!Array.isArray(added)) return kept
+	const seen = new Set(kept.map(citationKey))
+	const extra = added.filter(citation => {
+		const key = citationKey(citation)
+		if (seen.has(key)) return false
+		seen.add(key)
+		return true
+	})
+	return extra.length === 0 ? kept : [...kept, ...extra]
+}
+
+// Fold a later meeting of the same company into the row that stays: fields it never
+// filled get filled, and the pages behind the later row are added to its own.
+const foldInto = (
+	kept: Record<string, unknown>,
+	later: Record<string, unknown>,
+): Record<string, unknown> => {
+	const merged: Record<string, unknown> = { ...kept }
+	for (const [field, value] of Object.entries(later)) {
+		if (value === undefined || value === null) continue
+		if (field === 'citations') {
+			merged['citations'] = mergeCitations(kept['citations'], value)
+			continue
+		}
+		const held = merged[field]
+		if (held === undefined || held === null) merged[field] = value
+	}
+	return merged
+}
+
+export interface DedupeResult {
+	readonly findings: unknown
+	/** How many rows were folded into an earlier row for being the same company. */
+	readonly merged: number
+}
+
+/**
+ * `listField` is the key holding this scan's companies — `prospects` or
+ * `competitors`. Anything else passes through untouched: a run about one named
+ * company has no list of its own to compare.
+ */
+export const dedupeDiscoveryRows = (
+	findings: unknown,
+	listField: string | undefined,
+): DedupeResult => {
+	if (listField === undefined) return { findings, merged: 0 }
+
+	let merged = 0
+	const dedupe = (rows: ReadonlyArray<unknown>): ReadonlyArray<unknown> => {
+		// Which company each row belongs to, named by the earliest row of that
+		// company. Worked out in full before anything is folded, because a row can
+		// join two rows that were until then separate — one by name, the other by
+		// site — and folding as it goes would settle on whichever of the two it
+		// happened to meet first, leaving the other behind as a duplicate. The list
+		// arrives in whatever order the model wrote it, so that would make the answer
+		// depend on the order.
+		const companyOfRow = rows.map((_, at) => at)
+		const companyOf = (at: number): number => {
+			let row = at
+			let of = companyOfRow[row]
+			while (of !== undefined && of !== row) {
+				row = of
+				of = companyOfRow[row]
+			}
+			return row
+		}
+		const sameCompany = (a: number, b: number): void => {
+			const one = companyOf(a)
+			const other = companyOf(b)
+			if (one === other) return
+			// The earlier row names the company, so the list keeps the order it met
+			// them in however the two rows turn out to be joined up.
+			companyOfRow[Math.max(one, other)] = Math.min(one, other)
+		}
+		const rowOfKey = new Map<string, number>()
+		rows.forEach((row, at) => {
+			if (!isPlainObject(row)) return
+			for (const key of discoveryRowIdentityKeys(row)) {
+				const seen = rowOfKey.get(key)
+				if (seen === undefined) rowOfKey.set(key, at)
+				else sameCompany(seen, at)
+			}
+		})
+
+		// One row per company, in the order the list first met it.
+		const keptAt = new Map<number, number>()
+		const kept: Array<unknown> = []
+		rows.forEach((row, at) => {
+			if (!isPlainObject(row)) {
+				kept.push(row)
+				return
+			}
+			const company = companyOf(at)
+			const index = keptAt.get(company)
+			if (index === undefined) {
+				keptAt.set(company, kept.length)
+				kept.push(row)
+				return
+			}
+			const held = kept[index]
+			kept[index] = isPlainObject(held) ? foldInto(held, row) : row
+			merged++
+		})
+		return kept
+	}
+
+	const walk = (value: unknown, key?: string): unknown => {
+		if (Array.isArray(value)) {
+			return key === listField ? dedupe(value) : value.map(item => walk(item))
+		}
+		if (isPlainObject(value)) {
+			return Object.fromEntries(
+				Object.entries(value).map(([k, v]) => [k, walk(v, k)] as const),
+			)
+		}
+		return value
+	}
+
+	return { findings: walk(findings), merged }
+}

--- a/packages/research/src/application/research-service.test.ts
+++ b/packages/research/src/application/research-service.test.ts
@@ -404,6 +404,7 @@ describe('buildExtractionPrompt', () => {
 		it('should keep the grounding rule ahead of the citation guidance and the evidence', () => {
 			// GIVEN the two parts the extraction pass composes around
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: 'CITE-GUIDANCE',
 				evidenceBlock: 'THE-EVIDENCE',
 				subjects: [],
@@ -423,12 +424,14 @@ describe('buildExtractionPrompt', () => {
 		it('should ask for a fit verdict only when the schema carries the fields', () => {
 			// GIVEN an enrichment run (fitVerdict on) versus any other schema (off)
 			const withVerdict = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
 				fitVerdict: true,
 			})
 			const withoutVerdict = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
@@ -444,12 +447,14 @@ describe('buildExtractionPrompt', () => {
 		it('should ask a scan for breadth, as it already asks for every person', () => {
 			// GIVEN a discovery scan versus a run that profiles one company
 			const scan = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
 				discoveryScan: true,
 			})
 			const profile = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
@@ -469,9 +474,83 @@ describe('buildExtractionPrompt', () => {
 			expect(profile).not.toContain('List EVERY company')
 		})
 
+		it('should show extraction the request it is answering', () => {
+			// GIVEN a request that asks for a field by name and says what to do with a
+			// company it cannot confirm
+			const prompt = buildExtractionPrompt({
+				query:
+					'Empresas instaladoras en España; dame la provincia de cada una y escribe "no confirmado" en vez de descartar la empresa.',
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+				discoveryScan: true,
+			})
+
+			// THEN the request reaches the step that writes the rows, which is the only
+			// place that can act on an ask like this — shaping the search alone leaves
+			// it one step short
+			expect(prompt).toContain('dame la provincia de cada una')
+			expect(prompt).toContain('no confirmado')
+			// AND it is bounded: answering the request never licenses an invented fact
+			expect(prompt).toContain(
+				'It never licenses a fact the evidence does not state',
+			)
+		})
+
+		it('should tell a scan that a trade body is not one of the companies', () => {
+			// GIVEN a discovery scan versus a run that profiles one company
+			const scan = buildExtractionPrompt({
+				query: '',
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+				discoveryScan: true,
+				marksUnconfirmed: true,
+			})
+			const profile = buildExtractionPrompt({
+				query: '',
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+			})
+
+			// THEN the scan is told to read a member list without listing the body that
+			// published it — the breadth ask above sends it to those pages on purpose,
+			// and nothing else anywhere says the body is not an answer
+			expect(scan).toContain('A list holds companies and nothing else')
+			expect(scan).toContain('read its member list to find them')
+			// AND it is told to mark a company it could not confirm rather than drop it,
+			// which is the other half: strictness alone quietly removes the small firms
+			// a scan is for
+			expect(scan).toContain('`unconfirmed_reason`')
+			expect(scan).toContain('is not proof that it does not')
+			// AND a run that profiles one named company was told who to research, so it
+			// gets neither
+			expect(profile).not.toContain('A list holds companies and nothing else')
+			expect(profile).not.toContain('`unconfirmed_reason`')
+		})
+
+		it('should name the unconfirmed field only to a schema that carries one', () => {
+			// GIVEN the other discovery scan, whose rows have nowhere to record a doubt
+			const scan = buildExtractionPrompt({
+				query: '',
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+				discoveryScan: true,
+			})
+
+			// THEN it is still told a trade body is not one of the companies — that
+			// holds for any list — but never asked to fill a field its answer has
+			// nowhere to put
+			expect(scan).toContain('A list holds companies and nothing else')
+			expect(scan).not.toContain('`unconfirmed_reason`')
+		})
+
 		it('should not ask a scan to fill a people list it does not have', () => {
 			// GIVEN a discovery scan, whose schema holds companies and no contacts
 			const scan = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
@@ -487,6 +566,7 @@ describe('buildExtractionPrompt', () => {
 		it('should carry the anti-fabrication rules the guards depend on', () => {
 			// GIVEN any extraction prompt
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
@@ -504,6 +584,7 @@ describe('buildExtractionPrompt', () => {
 		it('should push the model to read all the evidence and report every fact', () => {
 			// GIVEN any extraction prompt
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
@@ -527,6 +608,7 @@ describe('buildExtractionPrompt', () => {
 			// instruction channel at all, so a framing can steer where the agent
 			// searches but never what counts as evidence
 			const extraction = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: 'EVIDENCE',
 				subjects: [],
@@ -540,6 +622,7 @@ describe('buildExtractionPrompt', () => {
 		it('should not push exhaustiveness on the fields no guard can check', () => {
 			// GIVEN any extraction prompt
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],
@@ -561,6 +644,7 @@ describe('buildExtractionPrompt', () => {
 		it('should show the on-file values and ask for a correction where the evidence disagrees', () => {
 			// GIVEN a company already on file that the run was handed
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [
@@ -585,6 +669,7 @@ describe('buildExtractionPrompt', () => {
 		it('should tell the model the stored value is not itself evidence', () => {
 			// GIVEN any run with a subject on file
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [
@@ -607,6 +692,7 @@ describe('buildExtractionPrompt', () => {
 			// shape, an accepted change reaches the record with no note of where its
 			// value came from
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [
@@ -632,6 +718,7 @@ describe('buildExtractionPrompt', () => {
 			// GIVEN a run that only ever sees its pages by address — no stored page
 			// id reaches any prompt, so asking for one could only invite an invention
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [
@@ -653,6 +740,7 @@ describe('buildExtractionPrompt', () => {
 			// GIVEN the assembled prompt, where the list of fetched pages is part of
 			// the citation guidance and lands after the proposal rules
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: 'THE-FETCHED-PAGES',
 				evidenceBlock: '',
 				subjects: [
@@ -676,6 +764,7 @@ describe('buildExtractionPrompt', () => {
 			// GIVEN a run holding the company, which is the only run offered a new
 			// person to add — and so the only one told how to name them
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [
@@ -706,6 +795,7 @@ describe('buildExtractionPrompt', () => {
 		it('should add no on-file block at all', () => {
 			// GIVEN a run with no subject (a free-text or scan run)
 			const prompt = buildExtractionPrompt({
+				query: '',
 				citationInstruction: '',
 				evidenceBlock: '',
 				subjects: [],

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -103,6 +103,7 @@ import {
 	withRoleMailbox,
 } from './generic-emails'
 import { type GuardLink, runGuardChain } from './guard-chain'
+import { dropNonCompanies } from './organisation-kind-guard'
 import { normalizePaidActionTool } from './paid-action-tool'
 import {
 	mergePerFieldSearch,
@@ -127,6 +128,7 @@ import {
 	filterProspectsByCriteria,
 	prospectCriteriaFromHints,
 } from './prospect-criteria-guard'
+import { dedupeDiscoveryRows } from './prospect-dedupe-guard'
 import { computeRunQuality } from './research-quality'
 import { guardScalarFields } from './scalar-field-guard'
 import {
@@ -155,6 +157,7 @@ import {
 	researchToolkit,
 	researchToolkitLayer,
 } from './tools'
+import { clearFieldOnlyDoubt } from './unconfirmed-mark-guard'
 import { makeUsageMeter, UsageMeter } from './usage-meter'
 import { verifyValueProvenance } from './value-guard'
 import { constrainVocabulary } from './vocabulary-guard'
@@ -1236,6 +1239,29 @@ const proposeContactDirective = (companyId: string): string =>
 const DISCOVERY_BREADTH_DIRECTIVE =
 	'List EVERY company the evidence identifies that matches the request — every one named on a directory page, an association or trade-body member list, a sector ranking, a news article, a register extract, or a search result — not only the ones the evidence describes at length. The evidence routinely names far more companies than a first pass returns, and coming back with a handful while it names dozens is an incomplete extraction, not a small market. Cover every part of the request: where it asks about several sectors, trades, regions, or countries, each one needs its own companies in the list rather than whichever the evidence happened to describe first. For each company give its own official website wherever the evidence states one, and its employee count wherever a source states one. Never drop a company for want of a website or a headcount — list it by name with the fields the evidence does support.'
 
+// What a scan's list is not allowed to hold. The breadth directive above sends the
+// search onto association and federation pages on purpose, because that is where a
+// trade's companies are named — and what comes back is the members AND the body that
+// published the list. Nothing anywhere else says the body is not an answer, and from
+// the fields alone nothing can tell: a federation states neither a size nor a place
+// for the size-and-place filter to catch. So the ask is made here, and each row is
+// asked to say what it is, which is what the check downstream reads.
+const DISCOVERY_ORGANISATION_KIND_DIRECTIVE =
+	"A list holds companies and nothing else. An association, a federation, a guild, an employers' body, a chamber of commerce, a professional college, a regulator or the sector's own system operator is not a company however squarely it sits in the subject — it represents or oversees the companies being asked for, so read its member list to find them and never list the body itself. The same goes for a public administration and for a trade magazine or directory that merely writes about the trade."
+
+// The other half of not listing a body: a company the run could not confirm still
+// belongs on the list. Left unsaid, a run told to be strict about what it reports
+// answers by quietly dropping the thinly-documented small firms a scan is actually
+// for, which is the opposite of the ask — so the field to record the doubt in is
+// named, and the instruction not to drop is spelled out beside it.
+//
+// The doubt it records is about the company, not about any one field. A request
+// often asks for a marker on a field it expects to be hard to pin down, and the
+// nearest-looking field wins unless the difference is spelled out — which would
+// mark every row and leave the mark saying nothing.
+const DISCOVERY_UNCONFIRMED_DIRECTIVE =
+	'Never leave a company out because you could not confirm it exists: list it and fill `unconfirmed_reason` with what is missing, in a few words. Not being able to prove a company exists is not proof that it does not. That field is only ever about whether the company is real and trading — a company the evidence confirms leaves it out, and a FIELD you could not confirm is not a reason to fill it: leave that field empty instead, whatever wording the request asks you to put in an unconfirmed field.'
+
 // Asks the model to land the fit judgement in the structured output, not only in
 // the brief. Applies only to the enrichment schema, which is the one that
 // carries the verdict/disqualifiers/fit_checks fields.
@@ -1258,17 +1284,32 @@ const FIT_VERDICT_DIRECTIVE =
  * When the run already holds the subjects on file, they are shown to the model with
  * an instruction to propose a correction wherever the evidence disagrees — the only
  * way a run turns up an edit for a company it was handed rather than one it found.
+ *
+ * The request itself is shown too. A request that names a field to fill, or says what
+ * to do with a company that cannot be confirmed, is only acted on by the step that
+ * writes the rows, so telling that step what to read and what shape to answer in is
+ * one step short of what it needs.
  */
 export const buildExtractionPrompt = (args: {
+	readonly query: string
 	readonly citationInstruction: string
 	readonly evidenceBlock: string
 	readonly subjects: ReadonlyArray<SubjectForPrompt>
 	readonly fitVerdict?: boolean
 	/** Whether this run is a discovery scan, whose answer is a list of companies. */
 	readonly discoveryScan?: boolean
+	/**
+	 * Whether this run's schema carries a field for marking a company the evidence
+	 * did not confirm. Only a schema that has one can be asked to fill it; asking
+	 * the rest would name a field their answer has nowhere to put.
+	 */
+	readonly marksUnconfirmed?: boolean
 }): string => {
 	const lines = [
 		'Produce structured findings STRICTLY from the evidence below (the fetched pages and the research transcript).',
+		'',
+		`The request you are answering, in the requester's own words:\n${args.query}`,
+		'Answer that request: where it asks for something in particular, report it in the field that holds it; where it says what to do with a company you cannot confirm, do that. It never licenses a fact the evidence does not state.',
 		'',
 		"Read ALL of the evidence to the end — every fetched page and every search result in the transcript — and report every fact it states; the evidence routinely states far more than a first pass returns. Report the industry, employee-count band, location, country, and the company's own operational software wherever the evidence states them — including on a third-party page rather than the company's own site.",
 		'',
@@ -1276,12 +1317,16 @@ export const buildExtractionPrompt = (args: {
 	// The breadth ask, addressed to whichever list this run's answer actually is.
 	// A scan is asked for companies and has no people list to fill; saying both
 	// would push it to invent one.
-	lines.push(
-		args.discoveryScan
-			? DISCOVERY_BREADTH_DIRECTIVE
-			: "Name EVERY person the evidence identifies as this company's own leader or employee — a titled executive on the team page, a quoted founder, a signed author — each with the exact job title the evidence gives them. Leaving the people list empty while the evidence names the company's own staff is an incomplete extraction.",
-		'',
-	)
+	if (args.discoveryScan) {
+		lines.push(DISCOVERY_BREADTH_DIRECTIVE, '')
+		lines.push(DISCOVERY_ORGANISATION_KIND_DIRECTIVE, '')
+		if (args.marksUnconfirmed) lines.push(DISCOVERY_UNCONFIRMED_DIRECTIVE, '')
+	} else {
+		lines.push(
+			"Name EVERY person the evidence identifies as this company's own leader or employee — a titled executive on the team page, a quoted founder, a signed author — each with the exact job title the evidence gives them. Leaving the people list empty while the evidence names the company's own staff is an incomplete extraction.",
+			'',
+		)
+	}
 	lines.push(
 		"Report ONLY what the evidence states. If it does not support a field, omit it or leave it null — never fill a field from prior knowledge, never guess, and never put a placeholder or the field's own name as its value. Leaving a field empty is always better than inventing a value for it.",
 		'',
@@ -2659,11 +2704,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							const structuredResponse = yield* extractLlm.generateObject({
 								schema: outputSchema as typeof FreeformSchema,
 								prompt: buildExtractionPrompt({
+									query: (run as { query: string }).query,
 									citationInstruction,
 									evidenceBlock,
 									subjects: subjectsForPrompt(subjects),
 									fitVerdict: schemaName === 'company_enrichment_v1',
 									discoveryScan: isDiscoveryScan(schemaName),
+									marksUnconfirmed: schemaName === 'prospect_scan_v1',
 								}),
 							})
 							// Fold the harvested role mailbox in before the ids are stamped, so
@@ -2882,6 +2929,48 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								.organizationId
 							const guardChain: ReadonlyArray<GuardLink> = [
 								{
+									// Organisation kind: a search for a trade's companies runs through
+									// that trade's association and federation pages, because that is
+									// where the companies are named — and the body that published the
+									// list comes back as one of the answers. Drop a row whose own words
+									// say it is a body of another kind, and only then: a row that says
+									// nothing about its kind is kept, unconfirmed or not.
+									//
+									// First in the chain, because it reads a row's own words and the
+									// links below rewrite them — the vocabulary link blanks an industry
+									// it reads as a sentence, which is how a body most often names
+									// itself there. Everything after it also works on a shorter list.
+									name: 'organisation-kind',
+									run: findings =>
+										Effect.gen(function* () {
+											const check = dropNonCompanies(
+												findings,
+												discoveryResultField(schemaName),
+											)
+											for (const row of check.dropped.slice(
+												0,
+												MAX_LOGGED_FIELD_DROPS,
+											)) {
+												yield* Effect.logWarning(
+													'research.prospects.not_a_company',
+												).pipe(
+													Effect.annotateLogs({
+														research_id: researchId,
+														name: row.name,
+														kind: row.kind,
+													}),
+												)
+											}
+											return {
+												findings: check.findings,
+												spanCounts: {
+													'research.prospects.not_a_company':
+														check.dropped.length,
+												},
+											}
+										}),
+								},
+								{
 									// Drop citations the model invented: keep only source_ids that
 									// map to a page this run actually fetched. A proposed CRM update
 									// left with no valid citation is dropped whole.
@@ -3023,9 +3112,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								{
 									// Website sanity: a scanned competitor or prospect sometimes comes
 									// back with a directory's profile page ("cbinsights.com/company/…")
-									// where its own site belongs. Blank that, so a stranger's URL never
-									// lands in the CRM's website field. Deterministic and evidence-free,
-									// so it runs here among the plain checks, ahead of the model critics.
+									// where its own site belongs, with a note glued to the address, or
+									// with the page a trade body gives it in its member list. Blank all
+									// of those, so nothing but a company's own site lands in the CRM's
+									// website field. Deterministic and evidence-free, so it runs here
+									// among the plain checks, ahead of the model critics.
 									name: 'websites',
 									run: findings =>
 										Effect.gen(function* () {
@@ -3033,25 +3124,28 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												findings,
 												rescueTarget.name,
 											)
-											if (
-												check.blankedDirectory > 0 ||
-												check.blankedProfilePage > 0
-											) {
+											const blanked =
+												check.blankedNotAnAddress +
+												check.blankedDirectory +
+												check.blankedProfilePage +
+												check.blankedSharedHost
+											if (blanked > 0) {
 												yield* Effect.logWarning(
 													'research.websites.blanked',
 												).pipe(
 													Effect.annotateLogs({
 														research_id: researchId,
+														blanked_not_an_address: check.blankedNotAnAddress,
 														blanked_directory: check.blankedDirectory,
 														blanked_profile_page: check.blankedProfilePage,
+														blanked_shared_host: check.blankedSharedHost,
 													}),
 												)
 											}
 											return {
 												findings: check.findings,
 												spanCounts: {
-													'research.websites.blanked':
-														check.blankedDirectory + check.blankedProfilePage,
+													'research.websites.blanked': blanked,
 												},
 											}
 										}),
@@ -3319,6 +3413,70 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												)
 											}
 											return { findings: check.findings }
+										}),
+								},
+								{
+									// Same company twice: a broad search meets one company on a
+									// directory, in a ranking and in a news piece, and each meeting can
+									// spell it differently. Fold those rows into one — after the website
+									// check, so an address several rows shared is already gone before a
+									// host counts as evidence two rows are the same company.
+									name: 'prospect-dedupe',
+									run: findings =>
+										Effect.gen(function* () {
+											const check = dedupeDiscoveryRows(
+												findings,
+												discoveryResultField(schemaName),
+											)
+											if (check.merged > 0) {
+												yield* Effect.logInfo(
+													'research.prospects.deduplicated',
+												).pipe(
+													Effect.annotateLogs({
+														research_id: researchId,
+														merged: check.merged,
+													}),
+												)
+											}
+											return {
+												findings: check.findings,
+												spanCounts: {
+													'research.prospects.deduplicated': check.merged,
+												},
+											}
+										}),
+								},
+								{
+									// The "could not confirm" mark means one thing: the evidence does
+									// not establish this is a real, trading company. A run asked for
+									// it beside a request wanting that wording on some hard-to-pin
+									// field writes "no website, no employee figure" instead, which is
+									// the row reading its own blanks back. Take those marks away, so
+									// the ones left mean what they say. Last, because whether a field
+									// is empty is only settled once every link above has had its say.
+									name: 'unconfirmed-mark',
+									run: findings =>
+										Effect.gen(function* () {
+											const check = clearFieldOnlyDoubt(
+												findings,
+												discoveryResultField(schemaName),
+											)
+											if (check.cleared > 0) {
+												yield* Effect.logInfo(
+													'research.prospects.doubt_cleared',
+												).pipe(
+													Effect.annotateLogs({
+														research_id: researchId,
+														cleared: check.cleared,
+													}),
+												)
+											}
+											return {
+												findings: check.findings,
+												spanCounts: {
+													'research.prospects.doubt_cleared': check.cleared,
+												},
+											}
 										}),
 								},
 							]

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -125,6 +125,7 @@ import {
 	WriterLanguageModel,
 } from './ports'
 import {
+	countryFromPlaceHint,
 	filterProspectsByCriteria,
 	prospectCriteriaFromHints,
 } from './prospect-criteria-guard'
@@ -3391,7 +3392,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									run: findings =>
 										Effect.gen(function* () {
 											if (schemaName !== 'prospect_scan_v1') return { findings }
-											const hintCountry = parseCountryAlpha2(hints?.location)
+											const hintCountry = countryFromPlaceHint(hints?.location)
 											const prospectCriteria = prospectCriteriaFromHints(
 												hints as
 													| { min_employees?: number; max_employees?: number }

--- a/packages/research/src/application/schemas/prospect-scan-v1.ts
+++ b/packages/research/src/application/schemas/prospect-scan-v1.ts
@@ -24,6 +24,16 @@ export const ProspectScanV1Schema = Schema.Struct({
 					description: 'ISO 3166-1 alpha-2 country code, e.g. US, ES, DE.',
 				}),
 			),
+			// A request confined to one country puts the same code on every row, which
+			// tells a reader working through the list nothing; the town and the
+			// province are what decide who to call first, and a search that turns up a
+			// company almost always turns those up with it.
+			location: Schema.optionalKey(
+				Schema.String.annotate({
+					description:
+						'Where the company is, written the way the evidence writes it — the town, the province, or both ("Córdoba", "Alcobendas, Madrid"). Only when a source states it for this company.',
+				}),
+			),
 			employee_estimate: Schema.optionalKey(
 				Sourced(
 					LenientNumber.annotate({
@@ -32,7 +42,25 @@ export const ProspectScanV1Schema = Schema.Struct({
 					}),
 				),
 			),
-			why_relevant: Schema.String,
+			// The one field every row has to fill, so it is where a row is asked to say
+			// what the organisation IS before saying why it matches. That is what lets
+			// a check downstream tell a company from the trade body that represents
+			// companies — the two are indistinguishable from the other fields, and a
+			// body states neither a size nor a place to be filtered on.
+			why_relevant: Schema.String.annotate({
+				description:
+					'What this organisation is in its own right first — an installer, a manufacturer, a distributor, and roughly how big — and then why it matches the request.',
+			}),
+			// The marked-candidate half of "keep what you could not confirm". Without
+			// somewhere to record the doubt, a run asked not to drop an unconfirmed
+			// company has only two ways to answer: drop it anyway, or report it as
+			// solid. Both lose the one thing the reader needs to know.
+			unconfirmed_reason: Schema.optionalKey(
+				Schema.String.annotate({
+					description:
+						'Only about whether this is a real, trading company: fill it when the evidence names the company but does not establish that it exists and trades, saying in a few words what is missing. Never drop a company for want of that — list it with this instead. A field you could not confirm is not a reason to fill this: leave that field out and this one too.',
+				}),
+			),
 			citations: Schema.Array(Citation),
 		}),
 	),

--- a/packages/research/src/application/source-key.test.ts
+++ b/packages/research/src/application/source-key.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	canonicalizeUrl,
 	hostOf,
+	isBareWebAddress,
 	isWebAddress,
 	pathOf,
 	sourceIdFor,
@@ -258,6 +259,60 @@ describe('isWebAddress', () => {
 			expect(isWebAddress('https://192.168.1.1/x')).toBe(false)
 			expect(isWebAddress('https://acme-.es')).toBe(false)
 			expect(isWebAddress('https://acme.e')).toBe(false)
+		})
+
+		it('should keep reading an address with an aside next to it as an address', () => {
+			// GIVEN a citation a model wrote with its own note glued on the end
+			// THEN it is still an address here. Saying no would mean the page skips the
+			// third-party confidence cap and the user-posted-content block, which is
+			// the unsafe direction for grading a citation — `isBareWebAddress` is what
+			// a website field asks instead
+			expect(
+				isWebAddress('https://acme.es/about (approximate, from the register)'),
+			).toBe(true)
+		})
+	})
+})
+
+describe('isBareWebAddress', () => {
+	describe('when the value is one address and nothing else', () => {
+		it('should accept it, padded with blank space or carrying an escape', () => {
+			// GIVEN one address typed with space either side — sloppy formatting, not
+			// something written next to it
+			expect(isBareWebAddress('  https://acme.es/contact  ')).toBe(true)
+			// AND an escaped space inside a real path is part of the address
+			expect(isBareWebAddress('https://acme.es/quienes%20somos')).toBe(true)
+			expect(isBareWebAddress('acme.es')).toBe(true)
+		})
+	})
+
+	describe('when something is written beside the address', () => {
+		it('should reject it, however clean the host reads', () => {
+			// GIVEN what a model hands back when it is unsure of a website: the address
+			// with its own aside attached
+			// THEN neither is one address. The parser folds the trailing words into the
+			// path as escapes and yields a clean hostname, so a check that weighs the
+			// host passes something nobody can open
+			expect(
+				isBareWebAddress(
+					'https://adime.org/ (not directly provided, inferred from name)',
+				),
+			).toBe(false)
+			expect(
+				isBareWebAddress(
+					'https://sea.es/ (derived from SEA Empresas Alavesas page)',
+				),
+			).toBe(false)
+			expect(isBareWebAddress('Website: https://acme.es')).toBe(false)
+			expect(isBareWebAddress('acme.es or acme.com')).toBe(false)
+		})
+
+		it('should still reject everything a web address is not', () => {
+			// GIVEN the values the looser question already turns down
+			expect(isBareWebAddress('info@acme.es')).toBe(false)
+			expect(isBareWebAddress('ftp://acme.es/pub')).toBe(false)
+			expect(isBareWebAddress('localhost')).toBe(false)
+			expect(isBareWebAddress('')).toBe(false)
 		})
 	})
 })

--- a/packages/research/src/application/source-key.ts
+++ b/packages/research/src/application/source-key.ts
@@ -101,3 +101,26 @@ export const isWebAddress = (value: string): boolean => {
 	// unreadable.
 	return DOMAIN_NAME.test(parsed.hostname.toLowerCase().replace(/\.$/, ''))
 }
+
+/**
+ * Whether a string is ONE web address and nothing written beside it.
+ *
+ * Ask this — not `isWebAddress` — where a value is offered as a company's own
+ * website. A model unsure of a site hands back its aside along with it,
+ * "https://adime.org/ (not directly provided, inferred from name)", and the
+ * parser hides that completely: it folds the trailing words into the path as
+ * escapes and yields a clean hostname, so a check that weighs the host passes
+ * something nobody can open. An address carries no spaces, which makes a space
+ * inside the value the whole tell.
+ *
+ * The two questions want opposite answers when they are unsure. Grading a
+ * citation, "not an address" means a page skips the third-party confidence cap,
+ * so being generous is the safe direction and `isWebAddress` stays that way.
+ * Filling a website field, "not an address" only empties a field, while being
+ * generous puts prose where a reader expects a link.
+ */
+export const isBareWebAddress = (value: string): boolean => {
+	const trimmed = value.trim()
+	if (/\s/.test(trimmed)) return false
+	return isWebAddress(trimmed)
+}

--- a/packages/research/src/application/unconfirmed-mark-guard.test.ts
+++ b/packages/research/src/application/unconfirmed-mark-guard.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+
+import { clearFieldOnlyDoubt } from './unconfirmed-mark-guard'
+
+const scan = (
+	prospects: ReadonlyArray<Record<string, unknown>>,
+): Record<string, unknown> => ({ prospects })
+
+const marksOf = (findings: unknown): Array<unknown> =>
+	(findings as { prospects: Array<Record<string, unknown>> }).prospects.map(
+		row => row['unconfirmed_reason'],
+	)
+
+describe('clearFieldOnlyDoubt', () => {
+	describe('when the reason names nothing but the blank columns', () => {
+		it('should take the mark back, in whichever language it was written', () => {
+			// GIVEN the two shapes a run actually came back with
+			const findings = scan([
+				{ name: 'Acme', unconfirmed_reason: 'no website, no employee figure' },
+				{
+					name: 'Beta',
+					unconfirmed_reason: 'Número de empleados no confirmado',
+				},
+			])
+
+			// WHEN checked
+			// THEN both marks go. Naming a blank column is not doubt about whether the
+			// company is real, and a mark on nearly every row tells a reader nothing
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined, undefined])
+			expect(result.cleared).toBe(2)
+		})
+
+		it('should take it back when every part of a long list is a blank field', () => {
+			// GIVEN a reason listing three gaps at once
+			const findings = scan([
+				{
+					name: 'Acme',
+					unconfirmed_reason:
+						'no website, no location, no employee figure and no autonomous community',
+				},
+			])
+
+			// WHEN checked — THEN the joining words break the list up as the commas do
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined])
+		})
+
+		it('should drop the mark rather than leave it empty', () => {
+			// GIVEN a marked row carrying its other fields
+			const findings = scan([
+				{
+					name: 'Acme',
+					why_relevant: 'Installer.',
+					unconfirmed_reason: 'no website',
+				},
+			])
+
+			// WHEN checked
+			// THEN the row reads as one nobody ever marked, and nothing else moves
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(
+				(result.findings as { prospects: Array<Record<string, unknown>> })
+					.prospects[0],
+			).toEqual({ name: 'Acme', why_relevant: 'Installer.' })
+		})
+	})
+
+	describe('when the reason is about the company itself', () => {
+		it('should keep a mark that no field word accounts for', () => {
+			// GIVEN doubt of the kind the mark exists for
+			const findings = scan([
+				{
+					name: 'Instalaciones Barreiro',
+					unconfirmed_reason:
+						'named only on a municipal tender list, no trace in any register',
+				},
+			])
+
+			// WHEN checked — THEN it stays: this is doubt about the company, which is
+			// the one thing the mark is for
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([
+				'named only on a municipal tender list, no trace in any register',
+			])
+			expect(result.cleared).toBe(0)
+		})
+
+		it('should keep a mark where only part of it reads as a blank field', () => {
+			// GIVEN a reason that names a gap AND says something about the company
+			const findings = scan([
+				{
+					name: 'Acme',
+					unconfirmed_reason:
+						'no website, and the address on the directory belongs to another company',
+				},
+			])
+
+			// WHEN checked
+			// THEN it stays whole. One part being a blank column does not make the rest
+			// of it so, and taking the mark away would take the rest with it
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(result.cleared).toBe(0)
+		})
+	})
+
+	describe('when a later round has filled the column the reason names', () => {
+		it('should still take the mark back', () => {
+			// GIVEN rows whose reason names a gap that has since been closed — the
+			// commonest shape there is, because a round that goes looking for a
+			// company's missing facts runs after the reason was written
+			const findings = scan([
+				{
+					name: 'Acme',
+					website: 'https://acme.es',
+					unconfirmed_reason: 'no website',
+				},
+				{
+					name: 'Beta',
+					employee_estimate: { value: 42, source_id: 'https://beta.es' },
+					unconfirmed_reason: 'no employee figure',
+				},
+			])
+
+			// WHEN checked
+			// THEN both go. A reason describing a gap that is no longer there was never
+			// about whether the company is real, and leaving it would hold back the
+			// vouching step over a column that is now filled in
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined, undefined])
+			expect(result.cleared).toBe(2)
+		})
+	})
+
+	describe('when there is no mark to judge', () => {
+		it('should leave a row that carries none alone', () => {
+			// GIVEN a confirmed company
+			const findings = scan([{ name: 'Acme', website: 'https://acme.es' }])
+
+			// WHEN checked — THEN nothing changes
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(result.cleared).toBe(0)
+			expect(marksOf(result.findings)).toEqual([undefined])
+		})
+
+		it('should keep a mark that says nothing at all', () => {
+			// GIVEN a reason that is blank or only punctuation
+			const findings = scan([
+				{ name: 'Acme', unconfirmed_reason: '   ' },
+				{ name: 'Beta', unconfirmed_reason: '—' },
+			])
+
+			// WHEN checked
+			// THEN both stay. Nothing in them names a field, so there is no ground to
+			// call them the row reading itself back
+			const result = clearFieldOnlyDoubt(findings, 'prospects')
+			expect(result.cleared).toBe(0)
+		})
+
+		it('should pass a run through untouched when it has no list', () => {
+			// GIVEN a run about one named company
+			const findings = { enrichment: { industry: 'electrical' } }
+
+			// WHEN checked with no list field — THEN nothing is read
+			const result = clearFieldOnlyDoubt(findings, undefined)
+			expect(result.findings).toBe(findings)
+			expect(result.cleared).toBe(0)
+		})
+
+		it('should leave findings that are null or a bare value untouched', () => {
+			// GIVEN non-object findings
+			// WHEN checked — THEN they pass straight through
+			expect(clearFieldOnlyDoubt(null, 'prospects').findings).toBeNull()
+			expect(clearFieldOnlyDoubt('text', 'prospects').findings).toBe('text')
+		})
+	})
+})

--- a/packages/research/src/application/unconfirmed-mark-guard.test.ts
+++ b/packages/research/src/application/unconfirmed-mark-guard.test.ts
@@ -143,18 +143,21 @@ describe('clearFieldOnlyDoubt', () => {
 			expect(marksOf(result.findings)).toEqual([undefined])
 		})
 
-		it('should keep a mark that says nothing at all', () => {
-			// GIVEN a reason that is blank or only punctuation
+		it('should take back a mark that says nothing at all', () => {
+			// GIVEN a reason that is blank or only punctuation — a shape real runs do
+			// produce, having filled the field and then written nothing in it
 			const findings = scan([
 				{ name: 'Acme', unconfirmed_reason: '   ' },
 				{ name: 'Beta', unconfirmed_reason: '—' },
 			])
 
 			// WHEN checked
-			// THEN both stay. Nothing in them names a field, so there is no ground to
-			// call them the row reading itself back
+			// THEN both go. A mark with no cause behind it is the worst of both: the
+			// row is flagged and held back from being vouched for, and the reader is
+			// given nothing to weigh
 			const result = clearFieldOnlyDoubt(findings, 'prospects')
-			expect(result.cleared).toBe(0)
+			expect(marksOf(result.findings)).toEqual([undefined, undefined])
+			expect(result.cleared).toBe(2)
 		})
 
 		it('should pass a run through untouched when it has no list', () => {

--- a/packages/research/src/application/unconfirmed-mark-guard.ts
+++ b/packages/research/src/application/unconfirmed-mark-guard.ts
@@ -1,0 +1,253 @@
+/**
+ * Takes back a prospect's "could not confirm" mark when the reason it gives does
+ * nothing but name the row's own blank columns.
+ *
+ * The mark answers one question: does the evidence establish that this is a real,
+ * trading company? Asked for it beside a request that wants a "no confirmado"
+ * marker on some hard-to-pin-down field, a run reaches for the nearest thing that
+ * looks like one and writes "no website, no employee figure". That is not doubt
+ * about the company — it is the row restating which of its columns are blank,
+ * which anyone can already see. Left alone it lands on almost every row, so the
+ * mark stops telling a reader anything, and it holds back the vouching step on
+ * leads whose only fault is a blank column.
+ *
+ * The reason is taken back only when every part of it is a column named and
+ * nothing else. One word the row's own columns and the ordinary wording around a
+ * blank cannot account for — "no trace in any register", "the address belongs to
+ * another company" — is the run saying something about the company, and the mark
+ * stays whole. Whether the column named is still empty by the time this runs makes
+ * no difference: a later round often fills it, which leaves the reason describing
+ * a gap that has since closed, and that is if anything a plainer case of a mark
+ * that was never about the company at all.
+ */
+
+import { isPlainObject } from './guard-shapes'
+
+// What a row's own fields get called in a reason, in the languages a run writes
+// one in. Only fields a scan row actually has: a word for something the row cannot
+// hold is not the row reading itself back.
+const FIELD_WORDS: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
+	[
+		'website',
+		['website', 'web', 'webpage', 'site', 'url', 'sitio', 'pagina', 'lloc'],
+	],
+	[
+		'employee_estimate',
+		[
+			'employee',
+			'employees',
+			'headcount',
+			'staff',
+			'workforce',
+			'empleado',
+			'empleados',
+			'plantilla',
+			'trabajadores',
+			'treballadors',
+		],
+	],
+	[
+		'location',
+		[
+			'location',
+			'address',
+			'city',
+			'town',
+			'province',
+			'region',
+			'autonomous',
+			'ubicacion',
+			'ubicacio',
+			'localizacion',
+			'direccion',
+			'provincia',
+			'ciudad',
+			'municipio',
+			'poblacion',
+			'sede',
+			'comunidad',
+			'community',
+		],
+	],
+	['tax_id', ['cif', 'nif', 'vat', 'fiscal']],
+	['industry', ['industry', 'sector', 'actividad', 'activitat']],
+]
+
+// Where one part of a reason ends and the next begins: the punctuation and the
+// joining words a run writes a list of gaps with.
+const CLAUSE_BREAK = /[,;/()]|\b(?:and|or|y|e|o|u|i|ni|nor)\b/i
+
+// The ordinary wording that surrounds a named blank — "no exact employee figure",
+// "número de empleados no confirmado". Listing it is what separates a part that is
+// only pointing at an empty column from one that happens to mention a column while
+// saying something about the company.
+const FILLER_WORDS = new Set([
+	'no',
+	'not',
+	'non',
+	'none',
+	'nor',
+	'without',
+	'sin',
+	'ni',
+	'exact',
+	'exacta',
+	'exacto',
+	'precise',
+	'precisa',
+	'single',
+	'unico',
+	'unica',
+	'figure',
+	'figures',
+	'count',
+	'number',
+	'numero',
+	'cifra',
+	'xifra',
+	'data',
+	'dato',
+	'datos',
+	'dades',
+	'information',
+	'informacion',
+	'info',
+	'confirmed',
+	'confirmado',
+	'confirmada',
+	'confirmat',
+	'unconfirmed',
+	'published',
+	'publicado',
+	'publicada',
+	'publicat',
+	'found',
+	'encontrado',
+	'encontrada',
+	'trobat',
+	'available',
+	'disponible',
+	'official',
+	'oficial',
+	'specific',
+	'especifico',
+	'especifica',
+	'listed',
+	'listado',
+	'in',
+	'evidence',
+	'evidencia',
+	'evidencias',
+	'aparece',
+	'aparecen',
+	'stated',
+	'indicado',
+	'provided',
+	'proporcionado',
+	'given',
+	'dado',
+	'the',
+	'a',
+	'an',
+	'its',
+	'su',
+	'sus',
+	'de',
+	'del',
+	'la',
+	'el',
+	'los',
+	'las',
+	'un',
+	'una',
+	'en',
+	'on',
+	'for',
+	'of',
+	'any',
+	'alguna',
+	'alguno',
+	'ningun',
+	'ninguna',
+])
+
+// Whether a word is either one of the row's own field names or the ordinary
+// wording around a blank. Anything else is the run saying something the row's
+// columns do not account for.
+const isAccountedFor = (word: string): boolean =>
+	FILLER_WORDS.has(word) ||
+	FIELD_WORDS.some(([, names]) => names.includes(word))
+
+const wordsOf = (value: string): ReadonlyArray<string> =>
+	value
+		.normalize('NFKD')
+		.replace(/\p{Diacritic}/gu, '')
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean)
+
+// Whether this part of the reason names one of the row's own columns at all. A
+// part naming none of them is about something else, whatever else it says.
+const namesAField = (clause: string): boolean => {
+	const words = new Set(wordsOf(clause))
+	return FIELD_WORDS.some(([, names]) => names.some(name => words.has(name)))
+}
+
+// Whether the whole reason is the row reading its own columns back.
+const readsOwnGaps = (reason: string): boolean => {
+	const clauses = reason
+		.split(CLAUSE_BREAK)
+		.filter(clause => clause !== undefined && wordsOf(clause).length > 0)
+	if (clauses.length === 0) return false
+	return clauses.every(
+		clause =>
+			namesAField(clause) &&
+			wordsOf(clause).every(word => isAccountedFor(word)),
+	)
+}
+
+export interface UnconfirmedMarkResult {
+	readonly findings: unknown
+	/** Marks taken back for naming the row's own columns and nothing else. */
+	readonly cleared: number
+}
+
+/**
+ * `listField` is the key holding this scan's companies. Anything else passes
+ * through: only a scan's row carries a mark of this kind.
+ */
+export const clearFieldOnlyDoubt = (
+	findings: unknown,
+	listField: string | undefined,
+): UnconfirmedMarkResult => {
+	if (listField === undefined) return { findings, cleared: 0 }
+
+	let cleared = 0
+	const walk = (value: unknown, key?: string): unknown => {
+		if (Array.isArray(value)) {
+			if (key === listField) {
+				return value.map(row => {
+					if (!isPlainObject(row)) return row
+					const reason = row['unconfirmed_reason']
+					if (typeof reason !== 'string' || !readsOwnGaps(reason)) {
+						return row
+					}
+					cleared++
+					// Dropped rather than emptied, so the row reads as one the model
+					// never marked — the same as any other field a guard removes.
+					const { unconfirmed_reason: _taken, ...rest } = row
+					return rest
+				})
+			}
+			return value.map(item => walk(item))
+		}
+		if (isPlainObject(value)) {
+			return Object.fromEntries(
+				Object.entries(value).map(([k, v]) => [k, walk(v, k)] as const),
+			)
+		}
+		return value
+	}
+
+	return { findings: walk(findings), cleared }
+}

--- a/packages/research/src/application/unconfirmed-mark-guard.ts
+++ b/packages/research/src/application/unconfirmed-mark-guard.ts
@@ -193,12 +193,14 @@ const namesAField = (clause: string): boolean => {
 	return FIELD_WORDS.some(([, names]) => names.some(name => words.has(name)))
 }
 
-// Whether the whole reason is the row reading its own columns back.
+// Whether the whole reason is the row reading its own columns back — or says
+// nothing at all, which is the same for a reader and worse for the row: it wears
+// the mark, loses the vouching step, and names no cause anybody can weigh.
 const readsOwnGaps = (reason: string): boolean => {
 	const clauses = reason
 		.split(CLAUSE_BREAK)
 		.filter(clause => clause !== undefined && wordsOf(clause).length > 0)
-	if (clauses.length === 0) return false
+	if (clauses.length === 0) return true
 	return clauses.every(
 		clause =>
 			namesAField(clause) &&

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -195,13 +195,15 @@ describe('guardCompanyWebsites', () => {
 	})
 
 	describe('when the input is degenerate', () => {
-		it('should keep an unparseable website rather than guess', () => {
+		it('should blank a website that is not a URL at all', () => {
 			// GIVEN a website that is not a URL at all
 			const findings = scan([{ name: 'Acme', website: 'not a url' }])
 
-			// WHEN checked — THEN with no host to read, it is left alone
+			// WHEN checked — THEN it goes: a website field nobody can open is worse
+			// than an empty one, because it reads as a real site downstream
 			const result = guardCompanyWebsites(findings)
-			expect(websitesOf(result.findings)).toEqual(['not a url'])
+			expect(websitesOf(result.findings)).toEqual([undefined])
+			expect(result.blankedNotAnAddress).toBe(1)
 		})
 
 		it('should keep a website when the name is empty', () => {
@@ -225,8 +227,10 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites(findings)
 			expect(result).toEqual({
 				findings,
+				blankedNotAnAddress: 0,
 				blankedDirectory: 0,
 				blankedProfilePage: 0,
+				blankedSharedHost: 0,
 			})
 		})
 
@@ -345,6 +349,223 @@ describe('guardCompanyWebsites', () => {
 			// THEN the pair rule wins for a named company, so the site is kept
 			expect(result.findings).toEqual(findings)
 			expect(result.blankedDirectory + result.blankedProfilePage).toBe(0)
+		})
+	})
+
+	describe('when the value is not a web address', () => {
+		it('should blank a website with an aside written next to it', () => {
+			// GIVEN the two shapes a scan actually came back with: an address with the
+			// model's own note glued on the end
+			const findings = scan([
+				{
+					name: 'ADIME',
+					website:
+						'https://adime.org/ (not directly provided, inferred from name)',
+				},
+				{
+					name: 'SEA Empresas Alavesas',
+					website: 'https://sea.es/ (derived from SEA Empresas Alavesas page)',
+				},
+			])
+
+			// WHEN checked
+			// THEN both go. The parser folds the trailing words into the path and hands
+			// back a clean host, so nothing that reads the host alone can catch this
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([undefined, undefined])
+			expect(result.blankedNotAnAddress).toBe(2)
+		})
+
+		it('should keep an address whose spaces are properly escaped', () => {
+			// GIVEN a real page whose path holds an escaped space
+			const findings = scan([
+				{ name: 'Acme', website: 'https://acme.es/quienes%20somos' },
+			])
+
+			// WHEN checked — THEN it is one address and nothing else, so it stands
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://acme.es/quienes%20somos',
+			])
+		})
+
+		it("should blank the run's own answer for the target when it carries an aside", () => {
+			// GIVEN the profile's website field holding an address plus a note
+			const findings = {
+				enrichment: {
+					website: {
+						value: 'https://acme.es (inferred from the company name)',
+						source_id: 'src_a',
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN checked — THEN the same rule reaches the field that arrives alone
+			const result = guardCompanyWebsites(findings, 'Acme')
+			expect(
+				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
+					'website'
+				],
+			).toBeNull()
+			expect(result.blankedNotAnAddress).toBe(1)
+		})
+	})
+
+	describe('when several companies in one answer claim the same host', () => {
+		it('should blank a trade body member-directory page given as a company site', () => {
+			// GIVEN four installers each handed the page an association gives them in
+			// its member list, at the top level of the association's own host
+			const findings = scan([
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+				{ name: 'Montajes Tejero', website: 'https://aemiat.com/tejero/' },
+				{ name: 'Clima Alavesa', website: 'https://aemiat.com/clima-alavesa/' },
+			])
+
+			// WHEN checked
+			// THEN all four go. The listing sits in the first path segment, which the
+			// deeper-path rule deliberately exempts — what settles it is that one host
+			// cannot be four different companies' own site
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+			])
+			expect(result.blankedSharedHost).toBe(4)
+		})
+
+		it('should keep a company describing itself in the first path segment', () => {
+			// GIVEN the shape the first-segment exemption exists to protect: companies
+			// whose own site describes them right there
+			const findings = scan([
+				{
+					name: 'XPO Logistics',
+					website: 'https://xpo.com/about-xpo-logistics',
+				},
+				{ name: 'SEUR', website: 'https://seur.com/sobre-seur' },
+				{ name: 'DSV', website: 'https://dsv.com/about-dsv' },
+				{
+					name: 'GLS Spain',
+					website: 'https://gls-spain.es/gls-spain-quienes',
+				},
+			])
+
+			// WHEN checked — THEN every one stands: each host carries its own company's
+			// name, and no host is claimed by anybody else
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://xpo.com/about-xpo-logistics',
+				'https://seur.com/sobre-seur',
+				'https://dsv.com/about-dsv',
+				'https://gls-spain.es/gls-spain-quienes',
+			])
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
+		it('should stand down entirely once the host names one of the claimants', () => {
+			// GIVEN a company's own site, handed to a differently-named row as well
+			const findings = scan([
+				{ name: 'Acme SL', website: 'https://acme.es' },
+				{ name: 'Instalaciones Rubio', website: 'https://acme.es/rubio' },
+			])
+
+			// WHEN checked
+			// THEN both keep it, including the row the host does not name. From the
+			// addresses alone this is the same shape as one company met under two
+			// names, and blanking on the difference would blank that case too — so a
+			// host that belongs to somebody here takes this rule out of play, and what
+			// the two rows are to each other is settled by the de-duplication after it
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://acme.es',
+				'https://acme.es/rubio',
+			])
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
+		it('should keep a site the host names, for every row claiming it', () => {
+			// GIVEN one company met twice — under its trade name and its legal one —
+			// both correctly citing the site the trade name is in
+			const findings = scan([
+				{ name: 'SICE', website: 'https://www.sice.com' },
+				{
+					name: 'Sociedad Ibérica de Construcciones Eléctricas',
+					website: 'https://sice.com/es',
+				},
+			])
+
+			// WHEN checked
+			// THEN both keep it. The host plainly belongs to somebody in the list, so
+			// this is one company met twice rather than a directory — and the shared
+			// site is the only thing that says the two rows are the same company, so
+			// blanking it would leave them as two
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://www.sice.com',
+				'https://sice.com/es',
+			])
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
+		it('should keep a host only one company in the answer claims', () => {
+			// GIVEN a single company on a host nobody else gives
+			const findings = scan([
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				{ name: 'Montajes Tejero', website: 'https://tejero.es' },
+			])
+
+			// WHEN checked
+			// THEN it stands: one row claiming a host is not evidence the host is
+			// somebody else's, and a blank costs a real website
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://aemiat.com/e-mora/',
+				'https://tejero.es',
+			])
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
+		it('should still report a listing shape as the profile page it is', () => {
+			// GIVEN two companies filed one level down on a shared directory host
+			const findings = scan([
+				{ name: 'Acme', website: 'https://directorio.es/empresa/acme' },
+				{
+					name: 'Beta Instal',
+					website: 'https://directorio.es/empresa/beta-instal',
+				},
+			])
+
+			// WHEN checked — THEN the more exact diagnosis wins, so the counters keep
+			// telling apart a listing from a host several rows merely share
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([undefined, undefined])
+			expect(result.blankedProfilePage).toBe(2)
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
+		it('should not count a person website in a proposal as a claim on the host', () => {
+			// GIVEN a company on a host, and a contact proposal naming the same host
+			const findings = {
+				prospects: [{ name: 'Acme', website: 'https://acme.es' }],
+				proposed_updates: [
+					{
+						operation: 'create',
+						fields: { name: 'Ada Lovelace', website: 'https://acme.es/ada' },
+					},
+				],
+			}
+
+			// WHEN checked — THEN the proposal subtree is skipped when the claims are
+			// gathered too, so a person never costs a company its site
+			const result = guardCompanyWebsites(findings)
+			expect(
+				(result.findings as { prospects: Array<{ website?: string }> })
+					.prospects[0]?.website,
+			).toBe('https://acme.es')
+			expect(result.blankedSharedHost).toBe(0)
 		})
 	})
 

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -11,23 +11,29 @@
  * other guard to weigh.
  *
  * The rule blanks a website only when it is clearly not the company's own:
+ *  - the value is not a web address at all, or
  *  - its host is a directory we already know (a short, evidence-driven list), or
  *  - its host does not carry the company's name AND the name sits in a deeper part
  *    of the address — the shape of "someone-else.com/company/<the-company>", which
- *    is a listing, never a company's own home page.
+ *    is a listing, never a company's own home page, or
+ *  - its host does not carry the company's name AND other companies in the same
+ *    answer claim that host as theirs too.
  * Anything else is kept: a company's own site names it in the host ("acme.com") or
  * describes itself in the first path segment ("xpo.com/about-xpo-logistics"), and a
  * blank costs a real website, so the bar to blank is deliberately high.
  *
- * It reads only a name and a website, so it needs no evidence corpus and no
- * database. It fires on any object carrying both — a scanned competitor or prospect
- * — and on the run's own answer for the target's website, which arrives on its own
- * with no name beside it and so is judged against the target's name passed in.
+ * All but the last rule read only a name and a website, so they need no evidence
+ * corpus and no database. They fire on any object carrying both — a scanned
+ * competitor or prospect — and on the run's own answer for the target's website,
+ * which arrives on its own with no name beside it and so is judged against the
+ * target's name passed in. The last rule is the only one that asks about the whole
+ * answer rather than one row, which is why the walk below is preceded by a reading
+ * pass that gathers who claims which host.
  */
 
 import { collapse, nameWithoutForms } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
-import { hostOf } from './source-key'
+import { hostOf, isBareWebAddress } from './source-key'
 
 // Directories whose company-profile pages a model most often mistakes for a
 // company's own site. This is a shortcut, not the defence: an unlisted directory
@@ -68,13 +74,70 @@ const pathSegmentsOf = (website: string): ReadonlyArray<string> => {
 	}
 }
 
-type WebsiteVerdict = 'keep' | 'directory' | 'profile_page'
+// Who claims which host, across a whole answer: a host mapped to the name cores of
+// every company that gave it as its website. Gathered before anything is rewritten,
+// because "is this host any one company's own?" cannot be answered from one row.
+// A value that is not an address, or a name with nothing distinctive in it, tells
+// us nothing about who a host belongs to and is left out.
+type HostClaims = ReadonlyMap<string, ReadonlySet<string>>
+
+const collectHostClaims = (findings: unknown): HostClaims => {
+	const claims = new Map<string, Set<string>>()
+	const visit = (value: unknown): void => {
+		if (Array.isArray(value)) {
+			for (const item of value) visit(item)
+			return
+		}
+		if (!isPlainObject(value)) return
+		const name = value['name']
+		const website = value['website']
+		if (typeof name === 'string' && typeof website === 'string') {
+			const host = isBareWebAddress(website) ? hostOf(website) : null
+			const core = nameWithoutForms(name)
+			if (host !== null && core !== '') {
+				const claimants = claims.get(host) ?? new Set<string>()
+				claimants.add(core)
+				claims.set(host, claimants)
+			}
+		}
+		for (const [childKey, child] of Object.entries(value)) {
+			if (!SKIP_KEYS.has(childKey)) visit(child)
+		}
+	}
+	visit(findings)
+	return claims
+}
+
+// The shortest name that can vouch for a host on its own. Two or three letters
+// turn up inside an unrelated address by coincidence — "it" sits inside
+// "digital.es" — and one company vouching for a host is what stands the
+// shared-host rule down for every row on it, so a coincidence there would quietly
+// switch the rule off. Four matches the bar the entity checks already set for a
+// word distinctive enough to go on.
+const VOUCHING_NAME_LENGTH = 4
+
+const hostBelongsTo = (host: string, claimant: string): boolean =>
+	claimant.length >= VOUCHING_NAME_LENGTH && collapse(host).includes(claimant)
+
+type WebsiteVerdict =
+	| 'keep'
+	| 'not_an_address'
+	| 'directory'
+	| 'profile_page'
+	| 'shared_host'
 
 // Where a website really points, for a company by this name.
-const classifyWebsite = (name: string, website: string): WebsiteVerdict => {
+const classifyWebsite = (
+	name: string,
+	website: string,
+	hostClaims: HostClaims,
+): WebsiteVerdict => {
 	const host = hostOf(website)
-	// An address we cannot even read the host of is left alone — nothing to judge.
-	if (host === null) return 'keep'
+	// Not an address at all: a value with words written next to it ("https://acme.es
+	// (inferred from the name)"), or something that was never a URL. A website field
+	// holding prose is worse than an empty one — nobody can open it, and it reads as
+	// a real site to everything downstream.
+	if (host === null || !isBareWebAddress(website)) return 'not_an_address'
 	if (isAggregatorHost(host)) return 'directory'
 	// The name as an address would write it: a directory files a company under its
 	// trading name and leaves the legal form out, so the form is taken out here
@@ -95,16 +158,40 @@ const classifyWebsite = (name: string, website: string): WebsiteVerdict => {
 	if (deeperSegments.some(segment => collapse(segment).includes(core))) {
 		return 'profile_page'
 	}
+	// A host several companies in this answer call their own, and that none of them
+	// is named by. A trade body's member directory gives each member a page at the
+	// top level ("aemiat.com/<member>/"), which the first-segment exemption above
+	// reads as a company describing itself on its own site — right for
+	// "xpo.com/about-xpo", wrong here. What separates the two is not the address but
+	// the companies beside it: one host cannot be four different companies' own
+	// site, and the four names saying so are in the same list.
+	//
+	// One of them being named by the host changes the answer completely: the host is
+	// then plainly that company's, and the other rows on it are the same company met
+	// again under its other name — a trade name beside a legal one. Blanking those
+	// would take away the very site that says the two rows are one company.
+	const claimants = hostClaims.get(host)
+	if (
+		claimants !== undefined &&
+		claimants.size > 1 &&
+		![...claimants].some(claimant => hostBelongsTo(host, claimant))
+	) {
+		return 'shared_host'
+	}
 	return 'keep'
 }
 
 export interface WebsiteGuardResult {
-	/** The findings, with any directory or profile-page website removed. */
+	/** The findings, with every website that is not the company's own removed. */
 	readonly findings: unknown
+	/** Websites blanked because the value was not a web address. */
+	readonly blankedNotAnAddress: number
 	/** Websites blanked because their host is a known directory. */
 	readonly blankedDirectory: number
 	/** Websites blanked because the name sat in a deeper path of another host. */
 	readonly blankedProfilePage: number
+	/** Websites blanked because other companies in the answer claim the same host. */
+	readonly blankedSharedHost: number
 }
 
 /**
@@ -119,12 +206,17 @@ export const guardCompanyWebsites = (
 	findings: unknown,
 	targetName?: string,
 ): WebsiteGuardResult => {
+	let blankedNotAnAddress = 0
 	let blankedDirectory = 0
 	let blankedProfilePage = 0
+	let blankedSharedHost = 0
+	const hostClaims = collectHostClaims(findings)
 
 	const count = (verdict: Exclude<WebsiteVerdict, 'keep'>): void => {
-		if (verdict === 'directory') blankedDirectory++
-		else blankedProfilePage++
+		if (verdict === 'not_an_address') blankedNotAnAddress++
+		else if (verdict === 'directory') blankedDirectory++
+		else if (verdict === 'profile_page') blankedProfilePage++
+		else blankedSharedHost++
 	}
 
 	// Walk one child, honouring the key it sits under: the proposed-update and
@@ -144,7 +236,11 @@ export const guardCompanyWebsites = (
 			typeof value['value'] === 'string' &&
 			typeof value['name'] !== 'string'
 		) {
-			const verdict = classifyWebsite(targetName ?? '', value['value'])
+			const verdict = classifyWebsite(
+				targetName ?? '',
+				value['value'],
+				hostClaims,
+			)
 			if (verdict !== 'keep') {
 				count(verdict)
 				// Emptied rather than removed: the field is the whole object here, and
@@ -157,7 +253,7 @@ export const guardCompanyWebsites = (
 		const name = value['name']
 		const website = value['website']
 		if (typeof name === 'string' && typeof website === 'string') {
-			const verdict = classifyWebsite(name, website)
+			const verdict = classifyWebsite(name, website, hostClaims)
 			if (verdict !== 'keep') {
 				count(verdict)
 				// Drop the key entirely, so the value reads as one the model never
@@ -174,5 +270,11 @@ export const guardCompanyWebsites = (
 		)
 	}
 
-	return { findings: walk(findings), blankedDirectory, blankedProfilePage }
+	return {
+		findings: walk(findings),
+		blankedNotAnAddress,
+		blankedDirectory,
+		blankedProfilePage,
+		blankedSharedHost,
+	}
 }

--- a/packages/ui/src/pri/pri-toast.tsx
+++ b/packages/ui/src/pri/pri-toast.tsx
@@ -5,8 +5,10 @@ import styled from 'styled-components'
  * Workshop toast — clipboard note: aged paper card with a masking tape
  * corner + a binder clip up top. Slides in from the bottom-right.
  *
- * Mount `<PriToast.Provider>` high in the tree and one `<PriToast.Viewport>`
- * somewhere at app chrome. Fire toasts via `useToastManager()` from Base UI.
+ * Mount `<PriToast.Provider>` high in the tree and one viewport holding the list
+ * at app chrome — `<PriToast.Viewport><PriToast.List closeLabel={…} /></…>`. The
+ * viewport alone draws an empty frame, so a toast raised into it is never seen.
+ * Fire toasts via `usePriToast()`.
  */
 const PriViewport = styled(Toast.Viewport).withConfig({
 	displayName: 'PriToastViewport',
@@ -125,11 +127,39 @@ const PriClose = styled(Toast.Close).withConfig({
 	}
 `
 
+/**
+ * The toasts currently raised, as cards. Put it inside the viewport:
+ * `<PriToast.Viewport><PriToast.List closeLabel={…} /></PriToast.Viewport>`.
+ *
+ * The viewport draws only the frame — without something turning the manager's
+ * queue into cards, `toast.add()` fills a queue nobody reads and every message
+ * the app raises is silently dropped. Nothing announces them either, so a
+ * screen-reader user is told nothing at all.
+ *
+ * The close button's label is passed in rather than written here, because this
+ * package holds no translations and the apps that use it do.
+ */
+export function PriToastList({ closeLabel }: { readonly closeLabel: string }) {
+	const { toasts } = Toast.useToastManager()
+	return (
+		<>
+			{toasts.map(toast => (
+				<PriRoot key={toast.id} toast={toast}>
+					<PriTitle />
+					<PriDescription />
+					<PriClose aria-label={closeLabel}>×</PriClose>
+				</PriRoot>
+			))}
+		</>
+	)
+}
+
 export const PriToast: {
 	Provider: typeof Toast.Provider
 	Portal: typeof Toast.Portal
 	Positioner: typeof Toast.Positioner
 	Viewport: typeof PriViewport
+	List: typeof PriToastList
 	Root: typeof PriRoot
 	Title: typeof PriTitle
 	Description: typeof PriDescription
@@ -139,6 +169,7 @@ export const PriToast: {
 	Portal: Toast.Portal,
 	Positioner: Toast.Positioner,
 	Viewport: PriViewport,
+	List: PriToastList,
 	Root: PriRoot,
 	Title: PriTitle,
 	Description: PriDescription,


### PR DESCRIPTION
## What

A prospect scan — the research run that answers "find me companies like this" with a list rather than a profile — came back on 13 August with 62 rows that nobody could work from. This makes that list usable: it stops containing organisations that are not companies, stops listing the same company twice, can finally say what town each company is in, and never puts prose where a clickable website belongs. All of it lands in the research engine (`packages/research`), with the list's own screen in the internal app (`apps/internal`) updated to show what the engine now knows.

The measure of the change is a re-run of that same request against live providers, not an argument.

| | 13 August | after |
| --- | --- | --- |
| rows that are trade bodies, not companies | 23 of 62 | **0** |
| rows carrying a province or city | 0 — nowhere to put one | **25 of 41** |
| duplicate rows | 10 of 62 | **0** |
| `website` values that are not a web address | 2 | **0** |

## Changes

- **A trade body is no longer one of the companies.** A search for a trade's companies runs through that trade's association and federation pages on purpose — that is where the companies are named — so what came back was the members *and* the body that published the list. Nothing could tell them apart: the size-and-place filter only drops a row that *states* a size or place the request ruled out, and a federation states neither. A new check drops a row whose own words say it is an association, a federation, a guild, a chamber of commerce, a professional college or the sector's system operator — and only then. A company that merely *belongs* to one is kept, and so is a company that simply took the word for its brand.
- **A company nobody could confirm is kept and marked, not dropped.** Absence of proof is not proof of absence, and the small firms a scan exists to find are exactly the ones with the thinnest paper trail. The row carries the reason, the screen shows it, and the one-click handoff stops short of stamping it "verified" — because verified means a person vouched for it.
- **A prospect can carry a place, and the request reaches the step that fills the fields in.** `country: "ES"` on every row of a Spain-scoped request says nothing; the town is what decides who to call first. Separately, the extraction step was told what to read and what shape to answer in, but never what was *asked* — so a request naming a field to fill shaped the search and then stopped one step short of the only step that could act on it.
- **The same company appears once.** Rows are folded on the name with its legal form taken off the end, or on a shared website. The later round that looks again for a company's missing facts now matches on that same identity, so a register's fuller legal name lands on the row already there instead of adding a second one.
- **A website is one address and nothing else.** A note written beside a URL is refused, and an address that several differently-named companies all claim — and that names none of them — is read as somebody's member directory rather than as each of their own sites.
- **Toasts appear at all.** Every message the app raised — added, saved, could not do that — went into a queue nobody read: the frame was on screen but nothing turned the queue into cards. No toast had ever appeared, in any part of the app, and nothing was announced to a screen reader either.
- **A request confining a search to a country is understood when it says the country in words.** Only the two-letter code worked; "Spain" applied no filter at all, silently, with the check reporting nothing dropped — which reads exactly like a clean run.

## Impact

- **No migration, no new environment variable, no schema change.** Nothing to run before deploying, and nothing production must be told.
- **Wire shape:** `prospect_scan_v1` gains two optional fields, `location` and `unconfirmed_reason`. Both are additive, so an older consumer is unaffected; `apps/internal` reads both.
- **MCP and HTTP both get this**, because it all sits in the shared research service and its guard chain rather than in either transport.
- **Behaviour change worth knowing:** "Add as lead" no longer marks every prospect verified — only the ones the run confirmed. On the re-run that is a minority of rows, which is the point.
- **One shared predicate widened, deliberately narrowly.** `isWebAddress` grades citations, where answering "not an address" makes a page skip the third-party confidence cap — the unsafe direction. So it is unchanged, and the stricter question lives in a new `isBareWebAddress` that only the website field asks.

## Review guide

Start with `packages/research/src/application/organisation-kind-guard.ts` — it is the one that *drops* rows, so it is where a mistake costs a real lead. Its docblock states its own limits.

**The decision I would most like overruled.** When a host is claimed by several differently-named rows and one of those names is in the host, the shared-host rule now stands down entirely and de-duplication decides what the rows are to each other. That is what lets a trade name and a legal name meet on their shared site — without it, de-duplication by domain never fires, and the issue says the domain alone catches 7 of the 9 duplicate groups. The cost is that a row wrongly handed another listed company's domain gets merged into it rather than just losing the URL. From the addresses alone the two cases are identical, so this is a judgement, not a deduction. `website-guard.test.ts` pins both readings.

**Known limitation, deliberately not fixed here.** Reading what kind of organisation a row is relies on word lists covering Spanish, Catalan and English. Measured against fifteen European trade bodies it recognises four — a body writing in French, German, Portuguese, Italian, Dutch or Basque still reaches the list as a company. That is squarely what #456 §4.1 prescribes solving by asking the model for the kind instead, and its settled decision #1 ("no hand-typed vocabularies") is the rule this stopgap breaks. I raised it and we agreed to defer; the guard says so in its own docblock so nobody has to rediscover it. Note for #456's §7 inventory: this adds five such lists here plus two in `unconfirmed-mark-guard.ts`.

Skip the `.po` catalogues — generated, plus four hand-written Catalan strings.

## Screenshots

The prospect list on a real run, showing the new place row, the badge and the labelled reason.

_Desktop (1440×1000), dark theme:_

![Prospect list, desktop, dark theme](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-464/pr-459-prospects-desktop.webp)

_The same list in the light theme — the theme where the badge was previously invisible:_

![Prospect list, desktop, light theme](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-464/pr-459-prospects-light.webp)

_Mobile (iPhone 16 Pro):_

![Prospect list, mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-464/pr-459-prospects-mobile.webp)

## Tests

Unit tests ride with the logic they cover: 1,224 in `packages/research` (up from 1,174), including the four new guards' own suites and regression cases for every defect the reviews turned up — the order-dependent merge, the shared-host/de-duplication conflict, the citation-key collision, and the brand-name false positive.

## Verification

- **Live end-to-end, three times.** The original Spanish installations request, re-run against real search, scrape and LLM providers on this worktree's stack. The final run (`ec0d0a5a`) succeeded in 18¢ over 309 sources and 41 prospects; the table at the top is measured off its stored findings.
- The first two live runs each found a real defect that the unit tests could not: duplicates surviving because the gap rounds merge rows *after* the guard chain, and the unconfirmed mark landing on every row. Both are fixed and covered.
- Gates run on the rebased branch: `pnpm check-types` (13/13), `pnpm test` (21/21), `pnpm build` (13/13).
- `/code-review` twice, which found seven real bugs in my own work — all fixed, each with a regression test.
- The two items this PR originally deferred are now fixed and verified in the browser: a toast raised by "Add as lead" renders (the viewport was empty before), and the three rows whose stored reason is an empty string no longer wear the badge.
- Accessibility review of the changed component. It found the new badge was **invisible in the default light theme** — the warning colour mixed into transparency took the colour of the panel behind it, measuring 1:1 against its own background. Fixed and re-measured in the browser: 5.74:1 light, 11.53:1 dark, 16.79:1 high-contrast.
- Screenshots captured on the live stack at both sizes, against a real run's data.

## Deferred

- Reading an organisation's kind still depends on word lists, as set out in the Review guide. That is #456 §4.1's to solve properly.

Closes #459
