### PR TITLE
test(internal): hold the company specs to the page as it is today

### DIFF
--- a/apps/internal/src/components/companies/about-section.tsx
+++ b/apps/internal/src/components/companies/about-section.tsx
@@ -38,10 +38,11 @@ export type AboutCompany = {
 }
 
 /**
- * "About" — the long tail of editable fields the user only touches when
- * setting up or qualifying a company. Collapsed by default so the
- * Overview leads with deal-driving signals (next action, cadence,
- * tasks, timeline). Three subsections:
+ * "About" — the editable fields a user fills in when setting up or qualifying
+ * a company. Open by default, since whether a lead is qualified is the question
+ * it answers and that is worth seeing beside the deal-driving signals (next
+ * action, cadence, tasks, timeline) rather than behind a click. Three
+ * subsections:
  *
  *   - Sales context (industry, country, location, size)
  *   - Discovery (pain points, current tools)
@@ -59,9 +60,8 @@ export function AboutSection({
 }) {
 	const { t } = useLingui()
 	const { labels, labelFor } = useCompanyIndustries()
-	// How much of this is actually filled in. Whether a lead is qualified is the
-	// question this section answers, and it used to be shut with nothing on the
-	// outside to say whether there was anything behind it.
+	// How much of this is actually filled in, shown on the header so the count
+	// still says whether there is anything behind it once the section is shut.
 	const filled = [
 		company.industry,
 		company.country,

--- a/apps/internal/tests/e2e/company-industries.test.ts
+++ b/apps/internal/tests/e2e/company-industries.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 
+import { openAboutSection } from './helpers/about-section'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // The organisation's own list of trades, from both ends: writing one on a
@@ -25,7 +26,7 @@ test.describe('company industries', () => {
 
 			// GIVEN a company whose About panel is open
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			const field = page.getByTestId('company-industry')
 			await expect(field).toBeVisible()
 			const before = (await field.innerText()).trim()
@@ -46,7 +47,7 @@ test.describe('company industries', () => {
 			await page.goto('/companies/ferros-baix-llobregat', {
 				waitUntil: 'networkidle',
 			})
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			const other = page.getByTestId('company-industry')
 			await other.click()
 			await other.fill(trade.slice(0, 8))
@@ -57,7 +58,7 @@ test.describe('company industries', () => {
 
 			// Put the first company back where it started.
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			await page.getByTestId('company-industry').click()
 			await page.getByTestId('company-industry').fill(before)
 			await page.getByTestId('company-industry').press('Enter')
@@ -74,7 +75,7 @@ test.describe('company industries', () => {
 			// GIVEN a trade written onto a company and then taken off again, so
 			// the organisation has one nothing is on
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			const field = page.getByTestId('company-industry')
 			await expect(field).toBeVisible()
 			const before = (await field.innerText()).trim()
@@ -124,7 +125,7 @@ test.describe('company industries', () => {
 
 			// GIVEN two companies given two different trades
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			const first = page.getByTestId('company-industry')
 			await expect(first).toBeVisible()
 			const firstBefore = (await first.innerText()).trim()
@@ -138,7 +139,7 @@ test.describe('company industries', () => {
 			await page.goto('/companies/ferros-baix-llobregat', {
 				waitUntil: 'networkidle',
 			})
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			const second = page.getByTestId('company-industry')
 			await expect(second).toBeVisible()
 			const secondBefore = (await second.innerText()).trim()
@@ -172,7 +173,7 @@ test.describe('company industries', () => {
 			await page.goto('/companies/ferros-baix-llobregat', {
 				waitUntil: 'networkidle',
 			})
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			await expect(page.getByTestId('company-industry')).toHaveText(kept, {
 				timeout: 10_000,
 			})
@@ -186,7 +187,7 @@ test.describe('company industries', () => {
 				{ timeout: 10_000 },
 			)
 			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
-			await page.getByTestId('company-about-trigger').click()
+			await openAboutSection(page)
 			await page.getByTestId('company-industry').click()
 			await page.getByTestId('company-industry').fill(firstBefore)
 			await page.getByTestId('company-industry').press('Enter')

--- a/apps/internal/tests/e2e/company-overview.test.ts
+++ b/apps/internal/tests/e2e/company-overview.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from '@playwright/test'
 
+import { closeAboutSection, openAboutSection } from './helpers/about-section'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // Asserts the redesigned company-detail Overview tab — Slice 1 of the
 // company-detail UX overhaul. The Overview replaces the flat 11-field
 // Profile tab with a deal dashboard: Next action / Cadence / Upcoming
 // at a glance; Open tasks + Timeline as the activity column; Research
-// summary + About (collapsed) as the sidebar column.
+// summary + About as the sidebar column.
 //
 // Selectors verified against:
 //   apps/internal/src/components/companies/next-action-card.tsx
@@ -105,42 +106,22 @@ test.describe('company-detail Overview tab', () => {
 		})
 	})
 
-	test.describe('when the user opens the About section', () => {
-		test('should reveal the nine editable fields grouped by concern', async ({
+	test.describe('when the Overview shows the About section', () => {
+		test('should show the eight editable fields grouped by concern', async ({
 			page,
 		}) => {
-			// GIVEN the Overview rendered with About collapsed by default
-			//   [components/companies/about-section.tsx — PriCollapsible.Root, no defaultOpen]
-			const trigger = page.getByTestId('company-about-trigger')
-			await expect(trigger).toBeVisible()
-			// AND the panel content is not visible before the trigger is clicked,
-			// but is still on the page — marked so the browser's Find can reach it.
-			// Checking the mark too: "hidden" alone would also pass if the panel
-			// were not rendered at all. The mark sits on the parent, because the
-			// test id is on the inner body.
+			// GIVEN the Overview as it renders, nothing clicked
 			const panel = page.getByTestId('company-about-panel')
-			await expect(panel).toBeHidden()
-			await expect(panel.locator('xpath=..')).toHaveAttribute(
-				'hidden',
-				'until-found',
-			)
 
-			// WHEN the user clicks the About trigger.
-			// The header runs a shared-layout animation and the dev server applies
-			// styles after first paint, so the trigger slides roughly 900px over the
-			// first second and a click sent mid-flight lands on empty space. Retry
-			// until it lands, and only while still closed so a click that did
-			// register is never undone by the next attempt.
-			await expect(async () => {
-				if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
-					await trigger.click()
-				}
-				await expect(panel).toBeVisible({ timeout: 1_000 })
-			}).toPass({ timeout: 15_000 })
+			// WHEN the user reads down the sidebar column
+			// THEN the section is already open — whether this lead is qualified is
+			// the question it answers, so it is not worth a click to find out.
+			// Asserted here rather than through the helper, which tolerates either
+			// state: this is the one place that holds the default to what it is.
+			//   [components/companies/about-section.tsx — PriCollapsible.Root defaultOpen]
+			await expect(panel).toBeVisible()
 
-			// THEN the panel becomes visible
-
-			// AND every grouped field label is reachable inside the panel
+			// AND every grouped field label is reachable inside it
 			//   Sales context (4)
 			await expect(panel.getByText('Industry', { exact: true })).toBeVisible()
 			await expect(panel.getByText('Country', { exact: true })).toBeVisible()
@@ -158,6 +139,27 @@ test.describe('company-detail Overview tab', () => {
 			await expect(
 				panel.getByText('Products fit', { exact: true }),
 			).toBeVisible()
+		})
+
+		test('should hide the fields when shut but keep them where the browser can find them', async ({
+			page,
+		}) => {
+			// GIVEN the About section open, as the Overview renders it
+			await openAboutSection(page)
+
+			// WHEN the user shuts it
+			const panel = await closeAboutSection(page)
+
+			// THEN the fields go off screen but stay on the page, marked so the
+			// browser's own find can reach them and open the section back up.
+			// Checking the mark as well as the hiding: hidden on its own would pass
+			// just as well if the panel had been dropped from the page. The mark
+			// sits on the parent, because the test id is on the inner body.
+			await expect(panel).toBeHidden()
+			await expect(panel.locator('xpath=..')).toHaveAttribute(
+				'hidden',
+				'until-found',
+			)
 		})
 	})
 })

--- a/apps/internal/tests/e2e/documents-on-company.test.ts
+++ b/apps/internal/tests/e2e/documents-on-company.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from '@playwright/test'
 
 import { DATABASE_URL } from './helpers/database-url'
 import { waitForInteractive } from './helpers/hydration'
+import { chooseSelectOption } from './helpers/pri-select'
 import { setActiveOrgBySlug } from './helpers/set-active-org'
 
 // Covers the documents panel on the company Files tab: list, read, create and
@@ -300,7 +301,11 @@ test.describe('documents on the company Files tab', () => {
 
 			// AND fills in every field the form offers
 			await page.getByTestId('document-title').fill(CREATED_TITLE)
-			await page.getByTestId('document-type').selectOption('visit_notes')
+			await chooseSelectOption(
+				page,
+				'document-type',
+				'document-type-option-visit_notes',
+			)
 			await page
 				.getByTestId('document-content')
 				.fill('Notes taken during the e2e visit.')

--- a/apps/internal/tests/e2e/helpers/about-section.ts
+++ b/apps/internal/tests/e2e/helpers/about-section.ts
@@ -1,0 +1,38 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+// Reaching the About section on a company page. Specs ask for the state they
+// need rather than for a click, so they read the same whether the section
+// starts open or shut.
+async function setAboutSection(
+	page: Page,
+	shouldBeOpen: boolean,
+): Promise<Locator> {
+	const trigger = page.getByTestId('company-about-trigger')
+	await expect(trigger).toBeVisible()
+	const panel = page.getByTestId('company-about-panel')
+
+	// The header animates on first paint and drags the trigger across the page
+	// for about a second, so a click can land on empty space. Wait only a moment
+	// for the panel, then let the retry send another click.
+	await expect(async () => {
+		const isOpen = (await trigger.getAttribute('aria-expanded')) === 'true'
+		if (isOpen !== shouldBeOpen) {
+			await trigger.click()
+		}
+		await (shouldBeOpen
+			? expect(panel).toBeVisible({ timeout: 1_000 })
+			: expect(panel).toBeHidden({ timeout: 1_000 }))
+	}).toPass({ timeout: 15_000 })
+
+	return panel
+}
+
+// Leaves the About section open, and hands back its panel.
+export function openAboutSection(page: Page): Promise<Locator> {
+	return setAboutSection(page, true)
+}
+
+// Leaves the About section shut, and hands back its panel.
+export function closeAboutSection(page: Page): Promise<Locator> {
+	return setAboutSection(page, false)
+}

--- a/apps/internal/tests/e2e/helpers/add-member-panel.ts
+++ b/apps/internal/tests/e2e/helpers/add-member-panel.ts
@@ -1,9 +1,10 @@
 import { expect, type Page } from '@playwright/test'
 
+import { chooseSelectOption } from './pri-select'
+
 // Helpers for the inline add-member panel on /settings/organization/members.
 // The form is folded into the members page behind an "Add member" CTA, and the
-// role and language controls are Base UI PriSelects (a button trigger + a
-// portalled popup), not native <select>s — so `selectOption` does not work.
+// role and language controls are Base UI PriSelects.
 
 // Opens the panel from the CTA and waits for the form to be visible.
 export async function openAddMemberPanel(page: Page): Promise<void> {
@@ -14,30 +15,12 @@ export async function openAddMemberPanel(page: Page): Promise<void> {
 	await expect(page.getByTestId('add-member-form')).toBeVisible()
 }
 
-// Opens one of the panel's selects and picks an option. The popup is
-// portalled and animates in, so the option resolves before it can be clicked —
-// wait for it to be visible first, then choose it with the keyboard. Enter on
-// a focused option is what a keyboard user does anyway, so this also covers
-// the path a mouse click would skip.
-async function chooseOption(
-	page: Page,
-	triggerTestId: string,
-	optionTestId: string,
-): Promise<void> {
-	await page.getByTestId(triggerTestId).click()
-	const option = page.getByTestId(optionTestId)
-	await option.waitFor({ state: 'visible' })
-	await option.hover()
-	await page.keyboard.press('Enter')
-	await option.waitFor({ state: 'hidden' })
-}
-
 // Picks a role. Default is 'member', so callers only need this for an admin.
 export async function selectMemberRole(
 	page: Page,
 	role: 'member' | 'admin',
 ): Promise<void> {
-	await chooseOption(
+	await chooseSelectOption(
 		page,
 		'add-member-role-trigger',
 		`add-member-role-option-${role}`,
@@ -49,7 +32,7 @@ export async function selectMemberLocale(
 	page: Page,
 	locale: 'en' | 'ca',
 ): Promise<void> {
-	await chooseOption(
+	await chooseSelectOption(
 		page,
 		'add-member-locale-trigger',
 		`add-member-locale-option-${locale}`,

--- a/apps/internal/tests/e2e/helpers/pri-select.ts
+++ b/apps/internal/tests/e2e/helpers/pri-select.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test'
+
+// Driving Base UI PriSelects, which are a button trigger plus a popup that
+// lives elsewhere on the page rather than a native <select>, so Playwright's
+// `selectOption` cannot work them.
+
+// The popup animates in, so the option is on the page a moment before it can be
+// clicked — wait for it to show, then press Enter on it, which is what a
+// keyboard user does anyway and covers the path a mouse click would skip.
+export async function chooseSelectOption(
+	page: Page,
+	triggerTestId: string,
+	optionTestId: string,
+): Promise<void> {
+	await page.getByTestId(triggerTestId).click()
+	const option = page.getByTestId(optionTestId)
+	await option.waitFor({ state: 'visible' })
+	await option.hover()
+	await page.keyboard.press('Enter')
+	await option.waitFor({ state: 'hidden' })
+}


### PR DESCRIPTION
## What

The full end-to-end suite that runs on every push to `main` has been failing since 5 August — nine days, roughly twenty commits, no green run. Nothing is broken in the product: five browser tests describe a company page that has since changed, and nobody noticed because the smaller suite that runs on pull requests does not cover them.

This brings those five back in line with the page as it is, and closes the gap that let them drift silently. Internal web app only, no product change.

## The fix

Two independent causes, both "the app moved, the test did not".

**The About section on a company page opens on its own now.** Three tests clicked its header to open it — which shut it instead, hiding the field they were about to read — and a fourth asserted it starts shut. They now ask for the state they need rather than for a click, through a small shared helper, so the next change of mind does not break them the same way.

One test still holds the default to what it is, deliberately and without the helper. That is the coverage that was missing: the default flipping is precisely what broke these tests, and after the change above nothing else would notice it happening again.

**The document type is no longer a plain dropdown.** It is a Base UI select — a button plus a popup — which Playwright's `selectOption` cannot drive, because that only works on a real `<select>`. The wait-then-Enter sequence written for the member form covers this exactly, so it moved out of that form's helper into a shared one and both now use it.

While in there: the About component's own docblock still described it as collapsed by default, twenty lines above the code that opens it. That is the sentence these tests were trusting, so it goes with them.

## Impact

None on the product. Six of the seven changed files are tests; the seventh is a comment.

Worth a decision, though not fixed here: **the pull-request suite does not cover these five tests**, which is why `main` could stay red for nine days while every PR went green. Whichever way that gap gets closed — widening the PR subset, or making a red `main` visible — it is the reason this went unnoticed rather than the reason it broke.

## Review guide

Start with `apps/internal/tests/e2e/helpers/about-section.ts` — it is the whole idea, and the eight call sites in `company-industries.test.ts` are a mechanical swap after it.

Two judgment calls you might overrule:

1. **A helper rather than deleting the now-wrong clicks.** Deleting them is a smaller diff and would pass today. It also breaks again the moment the default flips back, which is the failure this PR exists to fix. The helper costs a file; asking for a state instead of a click is what makes the tests durable.
2. **Lifting `chooseSelectOption` out of `add-member-panel.ts`.** The alternative was copying six lines of hover-then-Enter into the documents test. The pitfall it guards is subtle enough — and now proven costly enough — to be worth one home.

## Verification

- The **full Playwright suite against a live local stack: 140 passed, 6 skipped, 0 failed** (8.5 min). That reconciles exactly with the last CI run — 132 passed, 5 failed, 2 flaky, plus the one test this adds. The two that CI reports as flaky (`attachment`, `rich-compose`) passed here without needing their retry.
- I ran it twice: once on the change, then again on the final code after review, so what is certified is what is committed.
- `pnpm -w check-types` (13 tasks), `pnpm -w test` (21 tasks), `pnpm -w build` (13 tasks) all green. Biome clean on every changed file; the one warning in `helpers/dev-inbox.ts` is pre-existing and untouched.
- Two things I got wrong on the way, both caught by running it rather than reading it: my first version of the collapse test used a bare click and failed, because the page header animates and a click sent mid-flight lands on empty space — which is why the helper retries in both directions. And I had added an `aria-expanded` assertion to the shared select helper that the original sequence never had; I could not justify it, so it is gone rather than kept with an invented reason.

## Deferred

Nothing about these five. The `main`-versus-PR coverage gap above is the open question, and it is a decision rather than a fix.
