### PR TITLE
fix(research): tell a business directory by what a run watches it do

### DIFF
--- a/packages/research/src/application/directory-sites.test.ts
+++ b/packages/research/src/application/directory-sites.test.ts
@@ -1,0 +1,596 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	linkedAddresses,
+	observeDirectorySites,
+	siteVerdict,
+} from './directory-sites'
+
+// A prospect scan's list, as the guard chain hands it over.
+const scan = (names: ReadonlyArray<string>) => ({
+	prospects: names.map(name => ({ name })),
+})
+
+const observe = (
+	names: ReadonlyArray<string>,
+	addresses: ReadonlyArray<string>,
+) =>
+	observeDirectorySites({
+		findings: scan(names),
+		listField: 'prospects',
+		addresses,
+	})
+
+describe('observeDirectorySites', () => {
+	describe("when one host files several of the run's own companies", () => {
+		it('should judge it a directory', () => {
+			// GIVEN two of the run's companies each filed at their own address on one
+			// host, and neither named by the host itself
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://aemiat.com/empresa/electricistas-puig',
+					'https://aemiat.com/empresa/instalaciones-ferre',
+				],
+			)
+
+			// WHEN the run's addresses are read
+			// THEN the host is a listing, and it says how much it had to go on
+			expect([...observation.sites]).toEqual(['aemiat.com'])
+			expect(observation.addressesRead).toBe(2)
+		})
+
+		it('should judge it a directory when the name sits in the first segment', () => {
+			// GIVEN a member directory that files each company at the top level,
+			// which for a single address is indistinguishable from a company's own
+			// site describing itself ("xpo.com/about-xpo")
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://aemiat.com/electricistas-puig/',
+					'https://aemiat.com/instalaciones-ferre/',
+				],
+			)
+
+			// WHEN read — THEN what separates the two is the second company, not the
+			// shape of either address
+			expect([...observation.sites]).toEqual(['aemiat.com'])
+		})
+
+		it('should want the whole name, not a shortened trading name', () => {
+			// GIVEN a directory filing each company under the one word it is known by
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				['https://aemiat.com/puig', 'https://aemiat.com/ferre'],
+			)
+
+			// WHEN read — THEN neither address is read as filing the company: asking
+			// for the whole name misses this listing, and the alternative is a name
+			// fragment matching a site that has nothing to do with the company
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should read a name the address spells with its accents', () => {
+			// GIVEN a listing that writes the accent into the address, which arrives
+			// escaped — the ordinary way a Spanish or Catalan site files a name
+			const observation = observe(
+				['Instalaciones Ferré SA', 'Muñoz y Asociados SL'],
+				[
+					'https://listado.example/empresa/instalaciones-ferré',
+					'https://listado.example/empresa/muñoz-y-asociados',
+				],
+			)
+
+			// WHEN read — THEN the escapes are put back into letters first, so the
+			// names are found where they really are
+			expect([...observation.sites]).toEqual(['listado.example'])
+		})
+
+		it('should read accents and punctuation as the address writes them', () => {
+			// GIVEN a directory spelling one name without its accent and the other
+			// with its legal form glued on
+			const observation = observe(
+				['Instalaciones Ferré SA', 'Muñoz y Asociados SL'],
+				[
+					'https://directorio.es/empresa/INSTALACIONES-FERRE-SA.html',
+					'https://directorio.es/empresa/munoz_y_asociados.html',
+				],
+			)
+
+			// WHEN read — THEN spelling does not hide either filing
+			expect([...observation.sites]).toEqual(['directorio.es'])
+		})
+	})
+
+	describe("when a host is seen for only one of the run's companies", () => {
+		it('should leave it unknown — a trade paper naming one company', () => {
+			// GIVEN a regional paper running a piece that names one of the companies,
+			// and a second piece on the same paper naming none of them
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://diaridegirona.cat/economia/electricistas-puig-obre-seu',
+					'https://diaridegirona.cat/economia/el-sector-creix-un-4',
+				],
+			)
+
+			// WHEN read — THEN it is unknown, never cleared: one company is not
+			// evidence of a listing, and nothing here can prove the paper is not one
+			expect([...observation.sites]).toEqual([])
+			expect(siteVerdict('diaridegirona.cat', observation.sites)).toBe(
+				'unknown',
+			)
+		})
+
+		it('should judge a paper that ran a piece on two of them a listing', () => {
+			// GIVEN one paper carrying two sector pieces, each naming a different
+			// company of the run in its own address
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://diaridegirona.cat/economia/electricistas-puig-obre-seu',
+					'https://diaridegirona.cat/economia/instalaciones-ferre-creix',
+				],
+			)
+
+			// WHEN read — THEN the paper is judged a listing, which it is not. A host
+			// is weighed on every address met on it, and two pieces cannot be told
+			// from two filings by the addresses alone. What it costs is the paper's
+			// standing as a source that is not a directory, so a company it is the
+			// only corroboration for goes unconfirmed — the answer is withheld, never
+			// invented
+			expect([...observation.sites]).toEqual(['diaridegirona.cat'])
+		})
+
+		it('should not let one page naming two of them make a listing', () => {
+			// GIVEN a single piece about a deal between two of the run's companies,
+			// naming both in its own address
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://elmundo.es/economia/electricistas-puig-compra-instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN it takes a separate address per company: a site that
+			// files them files each of them somewhere, and one page mentioning both is
+			// what a piece about a deal looks like
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should not count a company named again at more length as two', () => {
+			// GIVEN a firm's own site naming itself both ways it is written
+			const observation = observe(
+				['Grupo Ferré SL', 'Grupo Ferré Instalacions SL'],
+				[
+					'https://gfi.example/grupo-ferre',
+					'https://gfi.example/nosotros/grupo-ferre-instalacions',
+				],
+			)
+
+			// WHEN read — THEN a name another name starts with is that same company
+			// written at more length, so this is one company on its own site
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should not read a short name out of the middle of a word', () => {
+			// GIVEN two short names that sit inside ordinary Catalan and Spanish
+			// words — "roca" inside "barroca", "mont" inside "montcada"
+			const observation = observe(
+				['Roca SL', 'Mont SA'],
+				[
+					'https://lavanguardia.com/economia/barroca-inversiones',
+					'https://lavanguardia.com/local/montcada-i-reixac/obres',
+				],
+			)
+
+			// WHEN read — THEN a name has to be spelled by whole words of the address,
+			// so neither page files anybody and a newspaper survives
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should leave both unknown when two companies sit on two hosts', () => {
+			// GIVEN each company filed on a different host
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://uno.example/electricistas-puig',
+					'https://dos.example/instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN one company each proves nothing about either host
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should not count one company met at two addresses as two', () => {
+			// GIVEN the same company filed twice on one host — a profile page and the
+			// section it sits in
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://listado.example/empresa/electricistas-puig',
+					'https://listado.example/girona/electricistas-puig-sl',
+				],
+			)
+
+			// WHEN read — THEN it is still one company, so the host stays unknown
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should not count one company spelled two ways as two', () => {
+			// GIVEN a list holding the same company under a dotted and an undotted
+			// legal form, which the fold that settles it only reaches later
+			const observation = observe(
+				['Muñoz S.L.', 'MUÑOZ SL'],
+				[
+					'https://listado.example/empresa/munoz-sl',
+					'https://listado.example/g/munoz',
+				],
+			)
+
+			// WHEN read — THEN both spellings are the one company they are, and a host
+			// filing only it is not a listing
+			expect([...observation.sites]).toEqual([])
+		})
+	})
+
+	describe('when the host itself carries one of the company names', () => {
+		it("should never call a company's own site a directory", () => {
+			// GIVEN a company's own site naming two other companies of the run in its
+			// addresses — a page per partner, a page per client
+			const observation = observe(
+				['Instalaciones Ferré SA', 'Electricistas Puig SL', 'Muñoz SL'],
+				[
+					'https://instalacionesferre.es/partners/electricistas-puig',
+					'https://instalacionesferre.es/obras/munoz',
+				],
+			)
+
+			// WHEN read — THEN the host being named by one of them settles it: one
+			// host cannot be a stranger's listing and that company's own site at once
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should recognise the short domain a company usually has', () => {
+			// GIVEN the same shape on a domain that is one word of the name rather
+			// than all of it — "acme.example" for "Acme Instalacions SL", which is how
+			// most firms register
+			const observation = observe(
+				['Acme Instalacions SL', 'Electricistas Puig SL', 'Muñoz SL'],
+				[
+					'https://acme.example/partners/electricistas-puig',
+					'https://acme.example/obras/munoz',
+				],
+			)
+
+			// WHEN read — THEN it is still that company's own site
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should not let a name merely appearing in the host stand the rule down', () => {
+			// GIVEN a listing whose host happens to contain a company's name
+			const observation = observe(
+				['Acme SL', 'Electricistas Puig SL', 'Muñoz y Asociados SL'],
+				[
+					'https://acme-directorio.example/electricistas-puig',
+					'https://acme-directorio.example/munoz-y-asociados',
+				],
+			)
+
+			// WHEN read — THEN the domain has to BE a name, not carry one, so the
+			// listing is still judged one
+			expect([...observation.sites]).toEqual(['acme-directorio.example'])
+		})
+	})
+
+	describe('when a name is too short to look for', () => {
+		it('should ignore a name that is nothing but a legal form', () => {
+			// GIVEN a row whose name leaves no core once the form is taken out, beside
+			// a real one
+			const observation = observe(
+				['SL', 'Instalaciones Ferré SA'],
+				[
+					'https://listado.example/sl-empresa',
+					'https://listado.example/instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN one usable name cannot reach two, so nothing is judged
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should ignore a name shorter than four letters', () => {
+			// GIVEN a three-letter name, which turns up inside an unrelated address by
+			// coincidence
+			const observation = observe(
+				['Vex', 'Instalaciones Ferré SA', 'Electricistas Puig SL'],
+				[
+					'https://listado.example/servicios/vexilla-consulting',
+					'https://listado.example/instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN the short name vouches for nothing and one real filing
+			// is left, which is not enough
+			expect([...observation.sites]).toEqual([])
+		})
+	})
+
+	describe('when the key would be a folded domain', () => {
+		it('should keep a sub-brand verdict off its parent', () => {
+			// GIVEN a business directory run as a subdomain of a real newspaper
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://empresite.eleconomista.es/ELECTRICISTAS-PUIG.html',
+					'https://empresite.eleconomista.es/INSTALACIONES-FERRE.html',
+					'https://eleconomista.es/empresas/electricistas-puig-creix',
+				],
+			)
+
+			// WHEN read — THEN only the sub-brand is a listing; the newspaper it sits
+			// under is untouched, because it is the newspapers that have to survive as
+			// the source that is not a directory
+			expect([...observation.sites]).toEqual(['empresite.eleconomista.es'])
+			expect(siteVerdict('eleconomista.es', observation.sites)).toBe('unknown')
+		})
+
+		it('should keep a parent verdict off its sub-brand', () => {
+			// GIVEN the parent host filing two companies and the subdomain filing one
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://listado.example/electricistas-puig',
+					'https://listado.example/instalaciones-ferre',
+					'https://blog.listado.example/instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN the verdict stops at the host it was earned on
+			expect([...observation.sites]).toEqual(['listado.example'])
+			expect(siteVerdict('blog.listado.example', observation.sites)).toBe(
+				'unknown',
+			)
+		})
+
+		it('should read www as the same site', () => {
+			// GIVEN one filing written with www and the other without
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://www.listado.example/electricistas-puig',
+					'https://listado.example/instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN www is not a different site
+			expect([...observation.sites]).toEqual(['listado.example'])
+		})
+	})
+
+	describe('when an address is not a web address', () => {
+		it('should not count an internal source id as a website', () => {
+			// GIVEN a run's own reference to a page it stored, which parses as the
+			// "host" src_9f2a1b if it is never screened
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				['src_9f2a1b', 'src_4c8d2e'],
+			)
+
+			// WHEN read — THEN neither counts as a site the run met
+			expect([...observation.sites]).toEqual([])
+			expect(observation.addressesRead).toBe(0)
+		})
+
+		it('should skip a mailbox and an unreadable value', () => {
+			// GIVEN an address that is a mailbox and one that was never an address
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'mailto:info@listado.example',
+					'not an address at all',
+					'https://listado.example/electricistas-puig',
+					'https://listado.example/instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN only the two real addresses are read, and they are
+			// enough on their own
+			expect([...observation.sites]).toEqual(['listado.example'])
+			expect(observation.addressesRead).toBe(2)
+		})
+	})
+
+	describe('when a name is only nearly in the address', () => {
+		it('should not splice two segments into one name', () => {
+			// GIVEN a company whose name is spread across a segment boundary, which
+			// reading the path as one string would join up
+			const observation = observe(
+				['Rosa Blanca SL', 'Instalaciones Ferré SA'],
+				[
+					'https://listado.example/rosa/blanca-flores',
+					'https://listado.example/instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN the address does not file Rosa Blanca, so one filing is
+			// left and the host stays unknown
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should not read a name that sits only in the query', () => {
+			// GIVEN an older directory that files a company in a query parameter
+			// rather than in the path
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[
+					'https://listado.example/ficha.php?empresa=electricistas-puig',
+					'https://listado.example/ficha.php?empresa=instalaciones-ferre',
+				],
+			)
+
+			// WHEN read — THEN it is missed: only the path is read, because a query is
+			// also where a search engine carries whatever was typed into it, and a
+			// missed listing costs less than every search page becoming one
+			expect([...observation.sites]).toEqual([])
+		})
+	})
+
+	describe('when the run has no list of its own', () => {
+		it('should observe nothing for a run about one named company', () => {
+			// GIVEN an enrichment run, which has no list field to compare
+			const observation = observeDirectorySites({
+				findings: { enrichment: { name: 'Acme SL' } },
+				listField: undefined,
+				addresses: [
+					'https://listado.example/electricistas-puig',
+					'https://listado.example/instalaciones-ferre',
+				],
+			})
+
+			// WHEN read — THEN one company can never reach two, so nothing is judged —
+			// and it still says how many addresses it had, so a run that gathered
+			// plenty is not reported the same as one that gathered none
+			expect([...observation.sites]).toEqual([])
+			expect(observation.addressesRead).toBe(2)
+		})
+
+		it('should observe nothing when the list holds one company', () => {
+			// GIVEN a scan that returned a single company
+			const observation = observe(
+				['Electricistas Puig SL'],
+				['https://listado.example/electricistas-puig'],
+			)
+
+			// WHEN read — THEN there is nobody to compare it against
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should observe nothing when the list is empty or nameless', () => {
+			// GIVEN a list with no rows, and one whose rows carry no name
+			const empty = observe([], ['https://listado.example/x'])
+			const nameless = observeDirectorySites({
+				findings: { prospects: [{ website: 'https://a.example' }, {}] },
+				listField: 'prospects',
+				addresses: ['https://listado.example/x'],
+			})
+
+			// WHEN read — THEN neither yields a name to look for
+			expect([...empty.sites]).toEqual([])
+			expect([...nameless.sites]).toEqual([])
+		})
+
+		it('should observe nothing when no address was gathered', () => {
+			// GIVEN a resumed run, which skips the phase that gathers addresses
+			const observation = observe(
+				['Electricistas Puig SL', 'Instalaciones Ferré SA'],
+				[],
+			)
+
+			// WHEN read — THEN every host stays unknown, which withholds rather than
+			// invents
+			expect([...observation.sites]).toEqual([])
+			expect(observation.addressesRead).toBe(0)
+		})
+	})
+})
+
+describe('linkedAddresses', () => {
+	describe('when a fetched page links to other addresses', () => {
+		it('should read a listing index page own per-company links', () => {
+			// GIVEN the text of a directory's category page, whose own address names a
+			// trade and a province and no company, with its per-company pages linked
+			// from it the way a fetched page writes them
+			const page = [
+				'# Instalaciones Electricas en Girona (Gerona)',
+				'Hemos encontrado 85 empresas.',
+				'- [Inergi instalaciones energeticas sl.](https://empresite.eleconomista.es/INERGI-INSTALACIONES-ENERGETICAS-GERONA.html)',
+				'- [Imec installacions sl](https://empresite.eleconomista.es/IMEC-INSTAL-LACIONS.html)',
+				'See also https://empresite.eleconomista.es/Actividad/CALEFACCION/.',
+			].join('\n')
+
+			// WHEN the page's links are read
+			const found = linkedAddresses(page)
+
+			// THEN both the bracketed links and the one written into the prose come
+			// back, without the punctuation that ended them
+			expect(found).toContain(
+				'https://empresite.eleconomista.es/INERGI-INSTALACIONES-ENERGETICAS-GERONA.html',
+			)
+			expect(found).toContain(
+				'https://empresite.eleconomista.es/IMEC-INSTAL-LACIONS.html',
+			)
+			expect(found).toContain(
+				'https://empresite.eleconomista.es/Actividad/CALEFACCION/',
+			)
+		})
+
+		it('should read one address once however often the page writes it', () => {
+			// GIVEN a page linking the same address from its list and its footer
+			const page =
+				'[Acme](https://listado.example/acme) and again [Acme](https://listado.example/acme)'
+
+			// WHEN read — THEN it is one address
+			expect(linkedAddresses(page)).toEqual(['https://listado.example/acme'])
+		})
+
+		it('should leave an address the page writes relative to itself', () => {
+			// GIVEN a page whose links are relative, which cannot be resolved without
+			// deciding what they are relative to
+			const page = '[Acme](/EMPRESA-ACME.html) [Ferré](../ferre.html)'
+
+			// WHEN read — THEN nothing is invented
+			expect(linkedAddresses(page)).toEqual([])
+		})
+
+		it('should read nothing out of a page with no links', () => {
+			// GIVEN ordinary prose
+			// WHEN read — THEN there is nothing to read
+			expect(linkedAddresses('Som una empresa de Girona.')).toEqual([])
+			expect(linkedAddresses('')).toEqual([])
+		})
+	})
+
+	describe('when a page links more addresses than are worth reading', () => {
+		it('should stop at the first few hundred', () => {
+			// GIVEN a sitemap-shaped page listing a thousand addresses
+			const page = Array.from(
+				{ length: 1000 },
+				(_, at) => `[${at}](https://listado.example/empresa-${at})`,
+			).join('\n')
+
+			// WHEN read — THEN it stops well before the end, since past a few hundred
+			// they say nothing the earlier ones did not and each is weighed against
+			// every company on the list
+			expect(linkedAddresses(page)).toHaveLength(300)
+		})
+	})
+})
+
+describe('siteVerdict', () => {
+	describe('when the host was watched filing several companies', () => {
+		it('should say directory', () => {
+			// GIVEN a host the run judged a listing
+			// WHEN asked about it — THEN it says so
+			expect(siteVerdict('aemiat.com', new Set(['aemiat.com']))).toBe(
+				'directory',
+			)
+		})
+	})
+
+	describe('when the host was not', () => {
+		it('should say unknown, which is not a clearance', () => {
+			// GIVEN a host the run saw once, and one it never saw at all
+			const sites = new Set(['aemiat.com'])
+
+			// WHEN asked about either
+			// THEN both are unknown — there is no third answer meaning "checked and
+			// cleared", because nothing here can establish that a site is not a
+			// listing, and a caller must not be able to read one out of silence
+			expect(siteVerdict('diaridegirona.cat', sites)).toBe('unknown')
+			expect(siteVerdict('never-seen.example', sites)).toBe('unknown')
+			expect(siteVerdict('anything', new Set())).toBe('unknown')
+		})
+	})
+})

--- a/packages/research/src/application/directory-sites.test.ts
+++ b/packages/research/src/application/directory-sites.test.ts
@@ -535,6 +535,55 @@ describe('linkedAddresses', () => {
 			expect(linkedAddresses(page)).toEqual(['https://listado.example/acme'])
 		})
 
+		it('should read two links written with nothing between them', () => {
+			// GIVEN the shape a listing's pager really has — one link straight after
+			// another, no space, no newline
+			const page =
+				'1[2](https://listado.example/empresa/uno)[3](https://listado.example/empresa/dos)'
+
+			// WHEN read — THEN they are two addresses. Letting a square bracket carry
+			// on the match would run them together into one that is neither, and both
+			// pages would be lost
+			expect(linkedAddresses(page)).toEqual([
+				'https://listado.example/empresa/uno',
+				'https://listado.example/empresa/dos',
+			])
+		})
+
+		it('should read a scheme the page wrote in capitals', () => {
+			// GIVEN an older page spelling the scheme the way it once was written
+			const page = '[Acme](HTTP://acme.es/empresa/acme-sl)'
+
+			// WHEN read — THEN the address is still an address
+			expect(linkedAddresses(page)).toEqual(['HTTP://acme.es/empresa/acme-sl'])
+		})
+
+		it('should read a listing own counter as the one address it is', () => {
+			// GIVEN a listing that sends its outbound links through a counter, with
+			// the company it points at inside the question mark
+			const page = '[Acme](https://listado.example/out.php?u=http://acme.es)'
+
+			// WHEN read — THEN it is one address on the listing's host, not two, so
+			// nothing invents a visit to a site the run never met
+			expect(linkedAddresses(page)).toEqual([
+				'https://listado.example/out.php?u=http://acme.es',
+			])
+		})
+
+		it('should keep a bracket the address itself opened', () => {
+			// GIVEN one address that ends in a bracket of its own — how an
+			// encyclopaedia tells two things of the same name apart — and one that
+			// only ends in the bracket markdown wrapped it in
+			const page =
+				'[Acme](https://es.wikipedia.org/wiki/Acme_(empresa)) and [Ferré](https://listado.example/ferre)'
+
+			// WHEN read — THEN each keeps what was its own
+			expect(linkedAddresses(page)).toEqual([
+				'https://es.wikipedia.org/wiki/Acme_(empresa)',
+				'https://listado.example/ferre',
+			])
+		})
+
 		it('should leave an address the page writes relative to itself', () => {
 			// GIVEN a page whose links are relative, which cannot be resolved without
 			// deciding what they are relative to
@@ -553,7 +602,7 @@ describe('linkedAddresses', () => {
 	})
 
 	describe('when a page links more addresses than are worth reading', () => {
-		it('should stop at the first few hundred', () => {
+		it('should stop at the first few hundred different ones', () => {
 			// GIVEN a sitemap-shaped page listing a thousand addresses
 			const page = Array.from(
 				{ length: 1000 },
@@ -564,6 +613,28 @@ describe('linkedAddresses', () => {
 			// they say nothing the earlier ones did not and each is weighed against
 			// every company on the list
 			expect(linkedAddresses(page)).toHaveLength(300)
+		})
+
+		it('should not let a repeated menu link crowd out the companies', () => {
+			// GIVEN a listing page shaped the way real ones are: its filters and
+			// navigation repeated far more times than the cap allows, and the
+			// companies it files listed underneath them
+			const page = [
+				...Array.from(
+					{ length: 400 },
+					() => '[Inici](https://listado.example/home)',
+				),
+				'[Electricistas Puig SL](https://listado.example/electricistas-puig)',
+				'[Instalaciones Ferré SA](https://listado.example/instalaciones-ferre)',
+			].join('\n')
+
+			// WHEN read — THEN the repeats count once between them, so the companies
+			// are still reached: counting raw matches instead would spend the whole
+			// budget on one menu link and read none of what the page is for
+			const found = linkedAddresses(page)
+			expect(found).toContain('https://listado.example/electricistas-puig')
+			expect(found).toContain('https://listado.example/instalaciones-ferre')
+			expect(found).toHaveLength(3)
 		})
 	})
 })

--- a/packages/research/src/application/directory-sites.ts
+++ b/packages/research/src/application/directory-sites.ts
@@ -39,11 +39,12 @@
  *
  * A host is judged on every address met on it together, so a local paper that ran
  * two pieces, each naming a different one of the run's companies in its address,
- * reads like a listing. That is the sharpest edge left. It costs the paper's
- * standing as a source that is not a directory rather than any company's own site,
- * since no company's website is a newspaper — but it is a real cost to the check
- * that will lean on this, and it stays only until there is a measurement to set
- * something finer against.
+ * reads like a listing. That is the sharpest edge left, and reading a page's links
+ * makes it sharper rather than blunter: one fetched section page hands over every
+ * article on it at once, so two such pieces is ordinary rather than unlucky. What
+ * it costs is the paper's standing as a source that is not a directory, never a
+ * company's own site — no company's website is a newspaper — and it stays only
+ * until there is a measurement to set something finer against.
  *
  * Counting how many of a host's addresses sit under one path is NOT the way to
  * sharpen it, however much it looks like the same idea. That was measured correct
@@ -60,6 +61,7 @@ import {
 	DISTINCTIVE_NAME_LENGTH,
 	distinctiveWords,
 	type EntityTargets,
+	foldTokens,
 	isOwnSiteHost,
 	nameCore,
 	nameWithoutForms,
@@ -134,16 +136,41 @@ const listedCompanyNames = (
 	return names
 }
 
-// How many of one page's links are read. A sitemap or an A-to-Z index can carry
-// thousands, and past the first few hundred they say nothing the earlier ones did
-// not — while every one of them is weighed against every company on the list.
+// How many of one page's DIFFERENT links are read. A sitemap or an A-to-Z index
+// can carry thousands, and past the first few hundred they say nothing the earlier
+// ones did not — while every one of them is weighed against every company on the
+// list. Counted after repeats are folded away, because a listing page puts its
+// filters and its navigation above its companies: cap the raw matches instead and
+// a few hundred copies of one menu link eat the whole budget before the first
+// company is reached.
 const MAX_LINKS_PER_PAGE = 300
 
 // Addresses written as ordinary links, "https://…", picked out of a fetched page's
-// text. Trailing punctuation is shaved off because markdown wraps a link in
-// brackets and prose ends it with a full stop.
-const LINK_IN_PAGE = /https?:\/\/[^\s<>"'`]+/g
-const TRAILING_PUNCTUATION = /[).,;:\]}>'"]+$/
+// text. The characters a link cannot hold end the match; what a link CAN hold but
+// prose also puts after one is shaved off below. Square brackets end it too, even
+// though an address may technically hold them: markdown writes one link straight
+// after another with nothing between them, and without that the two run together
+// into a single address that is neither. The scheme is read whichever case the
+// page wrote it in.
+const LINK_IN_PAGE = /https?:\/\/[^\s<>"'`[\]]+/gi
+const TRAILING_PUNCTUATION = /[.,;:}]+$/
+
+// Markdown writes a link inside brackets, so a closing bracket at the end is the
+// markdown's and not the address's — unless the address opened one itself, which
+// is how an encyclopaedia tells two things of the same name apart
+// ("/wiki/Acme_(empresa)"). Shave only the unmatched ones, so the address that
+// keeps its bracket is the one that had it.
+const withoutWrappingBrackets = (link: string): string => {
+	let end = link.length
+	let depth = 0
+	for (let at = link.length - 1; at >= 0 && link[at] === ')'; at--) depth++
+	for (const character of link) if (character === '(') depth--
+	while (depth > 0 && end > 0 && link[end - 1] === ')') {
+		end--
+		depth--
+	}
+	return link.slice(0, end)
+}
 
 /**
  * The addresses a page the run fetched links to.
@@ -158,14 +185,20 @@ const TRAILING_PUNCTUATION = /[).,;:\]}>'"]+$/
  * Only whole addresses are read. A page that writes its links relative to itself
  * ("/EMPRESA.html") is missed rather than guessed at, since resolving them means
  * deciding what they are relative to and getting that wrong invents addresses.
+ *
+ * A listing that sends every outbound link through a counter of its own
+ * ("…/out.php?u=…") is read as the one address it is, on the listing's host. The
+ * company it points at is inside the question mark, which nothing here reads, so
+ * such a listing files nobody and goes unnoticed — a miss, in the safe direction.
  */
-export const linkedAddresses = (pageText: string): ReadonlyArray<string> => [
-	...new Set(
-		(pageText.match(LINK_IN_PAGE) ?? [])
-			.map(link => link.replace(TRAILING_PUNCTUATION, ''))
-			.slice(0, MAX_LINKS_PER_PAGE),
-	),
-]
+export const linkedAddresses = (pageText: string): ReadonlyArray<string> =>
+	[
+		...new Set(
+			(pageText.match(LINK_IN_PAGE) ?? []).map(link =>
+				withoutWrappingBrackets(link).replace(TRAILING_PUNCTUATION, ''),
+			),
+		),
+	].slice(0, MAX_LINKS_PER_PAGE)
 
 // The words of each part of an address after the host — [["empresa"], ["acme",
 // "s", "l"]] from "directorio.es/empresa/ACME-S.L.". A path arrives with its
@@ -185,14 +218,7 @@ const filingWords = (address: string): ReadonlyArray<ReadonlyArray<string>> => {
 	})()
 	return spelled
 		.split('/')
-		.map(segment =>
-			segment
-				.normalize('NFKD')
-				.replace(/\p{Diacritic}/gu, '')
-				.toLowerCase()
-				.split(/[^a-z0-9]+/)
-				.filter(Boolean),
-		)
+		.map(foldTokens)
 		.filter(words => words.length > 0)
 }
 
@@ -276,13 +302,22 @@ export const observeDirectorySites = (args: {
 	// held rather than counted, because one page naming two of them is a piece
 	// about both — it takes a separate address per company to be a listing.
 	const filedByHost = new Map<string, Map<string, Set<string>>>()
+	// A host that is a listed company's own site is that company's, whatever else
+	// sits on it: a firm's own page for each partner would otherwise read as a
+	// listing of them. Answered once per host, since hundreds of addresses read off
+	// one index page all share theirs.
+	const ownSiteHosts = new Map<string, boolean>()
+	const isOwnSite = (host: string): boolean => {
+		const known = ownSiteHosts.get(host)
+		if (known !== undefined) return known
+		const own = isOwnSiteHost(ownSiteKeys, host)
+		ownSiteHosts.set(host, own)
+		return own
+	}
 	for (const address of readable) {
-		const host = hostOf(address)
-		if (host === null) continue
-		// A host that is a listed company's own site is that company's, whatever
-		// else sits on it: a firm's own page for each partner would otherwise read
-		// as a listing of them.
-		if (isOwnSiteHost(ownSiteKeys, host)) continue
+		// Non-null: the screen above already parsed every address that got here.
+		const host = hostOf(address) ?? ''
+		if (isOwnSite(host)) continue
 		const segments = filingWords(address)
 		for (const core of companyCores) {
 			if (segments.some(segment => namesTheCompany(segment, core))) {

--- a/packages/research/src/application/directory-sites.ts
+++ b/packages/research/src/application/directory-sites.ts
@@ -1,0 +1,314 @@
+/**
+ * Which websites this run watched behave like a business directory.
+ *
+ * A directory is a site that exists to list other companies — a trade body's
+ * member pages, a chamber's register, a yellow-pages site. No fixed list of hosts
+ * can name them: every country has its own, so the directories a Spanish search
+ * meets are not the ones an American list holds. This decides it from behaviour
+ * instead, inside the run: watch which hosts file MORE THAN ONE of this search's
+ * own companies at an address carrying that company's name. A host doing that for
+ * two of them is a listing.
+ *
+ * What it watches is every address the run met — each result its searches returned,
+ * each page it fetched, and the addresses those pages link to. That last one is not
+ * an extra: a search hands back a listing's category page, which names a trade and
+ * a place and no company at all, and the addresses that name companies are the ones
+ * it links to. Reading them costs nothing, since the text is already fetched.
+ *
+ * This only ever produces the NEGATIVE verdict. A host seen for a single company
+ * is `unknown`, never "not a directory": nothing here can establish that a site
+ * ISN'T a listing, only that it is. So a thin sample can withhold a confirmation
+ * and can never manufacture one, which is the whole point — a caller asking "is
+ * at least one of these sources not a directory?" must not be able to answer yes
+ * out of silence. That is why the verdict has two values and no third one meaning
+ * "cleared": there is no value here to answer yes with.
+ *
+ * The key is the RAW host as met, never folded to a registrable domain.
+ * `empresite.eleconomista.es` is a directory and `eleconomista.es` is a real
+ * newspaper; folding the first into the second would label the newspaper, and
+ * newspapers are exactly the sites that have to survive as the non-directory
+ * source. The cost is a directory that gives each company its own subdomain,
+ * which is then several sites seen once each — a miss, in the safe direction.
+ *
+ * A name is looked for whole and on whole words, so a directory filing companies
+ * under a one-word trading name ("/puig") is missed. Catching that means deciding
+ * which fragment of a name a site may be filed under, and a fragment matches
+ * addresses that have nothing to do with the company — which is the expensive
+ * mistake, not the cheap one. Saying "directory" is not a withholding: it takes a
+ * company's website away.
+ *
+ * A host is judged on every address met on it together, so a local paper that ran
+ * two pieces, each naming a different one of the run's companies in its address,
+ * reads like a listing. That is the sharpest edge left. It costs the paper's
+ * standing as a source that is not a directory rather than any company's own site,
+ * since no company's website is a newspaper — but it is a real cost to the check
+ * that will lean on this, and it stays only until there is a measurement to set
+ * something finer against.
+ *
+ * Counting how many of a host's addresses sit under one path is NOT the way to
+ * sharpen it, however much it looks like the same idea. That was measured correct
+ * on eleven sites across four countries and wrong on the twelfth: on a regional
+ * newspaper the busiest path holds 0.285 of the addresses when 200 are looked at
+ * and 0.696 when 700 are, because a date archive grows without limit while a
+ * section list does not. The number tracks how hard the site was looked at rather
+ * than what it is, and at the larger sample a newspaper scores like a business
+ * directory. It also needs a crawl of each site, which the runs that most need
+ * this answer cannot afford.
+ */
+
+import {
+	DISTINCTIVE_NAME_LENGTH,
+	distinctiveWords,
+	type EntityTargets,
+	isOwnSiteHost,
+	nameCore,
+	nameWithoutForms,
+	withoutFormDots,
+} from './entity-guard'
+import { isPlainObject } from './guard-shapes'
+import { hostOf, isBareWebAddress, pathOf } from './source-key'
+
+/** Hosts this run watched file several of its own companies. */
+export type DirectorySites = ReadonlySet<string>
+
+/**
+ * What is known about a site. `unknown` is not "cleared". Spelled as a value
+ * rather than left as the absence of one, so a caller has to name it before
+ * acting on it.
+ */
+export type SiteVerdict = 'directory' | 'unknown'
+
+// How many of the run's own companies a host must file before it is a listing, and
+// how many separate addresses those filings must sit at. Both are two: one page
+// naming two companies is a piece about a deal between them, not a site that files
+// each of them somewhere of its own.
+const COMPANIES_THAT_MAKE_A_LISTING = 2
+
+// How an address would write this company's name, folded so case, accents and
+// punctuation stop mattering. Empty when nothing distinctive is left to look for.
+const filedAs = (name: string): string => {
+	const core = nameWithoutForms(withoutFormDots(name))
+	return core.length >= DISTINCTIVE_NAME_LENGTH ? core : ''
+}
+
+// One company per name, rather than one per spelling. A name that another name
+// starts with is the same company written at more length — "Grupo Ferré" and
+// "Grupo Ferré Instalacions" — and counting both would let a firm's own site,
+// which names itself in two ways, reach the two it takes to be a listing. The fold
+// that settles spellings for good runs after this check, so it cannot be leant on
+// here.
+const distinctCompanies = (
+	cores: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+	[...new Set(cores)]
+		.sort((a, b) => a.length - b.length)
+		.filter(
+			(core, at, kept) => !kept.slice(0, at).some(s => core.startsWith(s)),
+		)
+
+// The names of this scan's own companies.
+const listedCompanyNames = (
+	findings: unknown,
+	listField: string,
+): ReadonlyArray<string> => {
+	const names: Array<string> = []
+	const visit = (value: unknown, key?: string): void => {
+		if (Array.isArray(value)) {
+			if (key === listField) {
+				for (const row of value) {
+					if (isPlainObject(row) && typeof row['name'] === 'string') {
+						names.push(row['name'])
+					}
+				}
+				return
+			}
+			for (const item of value) visit(item)
+			return
+		}
+		if (!isPlainObject(value)) return
+		for (const [childKey, child] of Object.entries(value)) {
+			visit(child, childKey)
+		}
+	}
+	visit(findings)
+	return names
+}
+
+// How many of one page's links are read. A sitemap or an A-to-Z index can carry
+// thousands, and past the first few hundred they say nothing the earlier ones did
+// not — while every one of them is weighed against every company on the list.
+const MAX_LINKS_PER_PAGE = 300
+
+// Addresses written as ordinary links, "https://…", picked out of a fetched page's
+// text. Trailing punctuation is shaved off because markdown wraps a link in
+// brackets and prose ends it with a full stop.
+const LINK_IN_PAGE = /https?:\/\/[^\s<>"'`]+/g
+const TRAILING_PUNCTUATION = /[).,;:\]}>'"]+$/
+
+/**
+ * The addresses a page the run fetched links to.
+ *
+ * A listing's own index page is where its per-company addresses are: the search
+ * that found the listing returns its category page — "…/INSTALACIONES-ELECTRICAS/
+ * localidad/GIRONA-GERONA/", which names a trade and a province and no company —
+ * and the addresses that name companies are one level in, linked from it. Reading
+ * them out of text the run already fetched puts them in front of the watch below
+ * without paying to fetch a single one.
+ *
+ * Only whole addresses are read. A page that writes its links relative to itself
+ * ("/EMPRESA.html") is missed rather than guessed at, since resolving them means
+ * deciding what they are relative to and getting that wrong invents addresses.
+ */
+export const linkedAddresses = (pageText: string): ReadonlyArray<string> => [
+	...new Set(
+		(pageText.match(LINK_IN_PAGE) ?? [])
+			.map(link => link.replace(TRAILING_PUNCTUATION, ''))
+			.slice(0, MAX_LINKS_PER_PAGE),
+	),
+]
+
+// The words of each part of an address after the host — [["empresa"], ["acme",
+// "s", "l"]] from "directorio.es/empresa/ACME-S.L.". A path arrives with its
+// accents written as escapes, which is how a Spanish or Catalan listing spells
+// most of its names, so it is put back into letters before anything is read off
+// it; a path that was never valid escaping is read as it stands rather than
+// dropped.
+const filingWords = (address: string): ReadonlyArray<ReadonlyArray<string>> => {
+	const path = pathOf(address)
+	if (path === null) return []
+	const spelled = (() => {
+		try {
+			return decodeURIComponent(path)
+		} catch {
+			return path
+		}
+	})()
+	return spelled
+		.split('/')
+		.map(segment =>
+			segment
+				.normalize('NFKD')
+				.replace(/\p{Diacritic}/gu, '')
+				.toLowerCase()
+				.split(/[^a-z0-9]+/)
+				.filter(Boolean),
+		)
+		.filter(words => words.length > 0)
+}
+
+// Whether one part of an address is this company filed under its name: some run of
+// whole words spells the name exactly. Asking only whether the name appears
+// somewhere inside would file "Roca" under "/barroca-inversiones" and "Mont" under
+// "/montcada-i-reixac", and two such names in one list are enough to call a
+// newspaper a listing.
+const namesTheCompany = (
+	segment: ReadonlyArray<string>,
+	core: string,
+): boolean => {
+	for (let from = 0; from < segment.length; from++) {
+		let run = ''
+		for (let to = from; to < segment.length; to++) {
+			run += segment[to]
+			if (run === core) return true
+			if (run.length >= core.length) break
+		}
+	}
+	return false
+}
+
+export interface DirectoryObservation {
+	/** The hosts that filed several of this run's companies. */
+	readonly sites: DirectorySites
+	/**
+	 * How many of the addresses handed in were real, readable web addresses —
+	 * counted whether or not there were companies to weigh them against, because
+	 * what it exists to answer is whether the run gathered anything at all.
+	 */
+	readonly addressesRead: number
+}
+
+/**
+ * Watch the addresses this run gathered and say which of their hosts are listings.
+ *
+ * `addresses` are the pages the run actually met — its searches' results and the
+ * pages it fetched. They are screened as web addresses first: an internal source
+ * id like `src_9f2a1b` would otherwise yield the "host" `src_9f2a1b` and count as
+ * a website. The screen is the strict one, `isBareWebAddress`: saying yes here
+ * adds a filing that can end with a company's site taken away, so the generous
+ * reading — which lets a value with prose after the address through, its words
+ * escaped into the path where they read as more names — is the costly direction.
+ *
+ * `listField` is the key holding this scan's companies — `prospects` or
+ * `competitors`. A run about one named company has no list to compare and so
+ * observes nothing: one company can never reach two.
+ */
+export const observeDirectorySites = (args: {
+	readonly findings: unknown
+	readonly listField: string | undefined
+	readonly addresses: ReadonlyArray<string>
+}): DirectoryObservation => {
+	const { findings, listField, addresses } = args
+	const readable = addresses.filter(isBareWebAddress)
+	const addressesRead = readable.length
+	if (listField === undefined) return { sites: new Set(), addressesRead }
+
+	const names = listedCompanyNames(findings, listField)
+	const companyCores = distinctCompanies(
+		names.map(filedAs).filter(core => core !== ''),
+	)
+	if (companyCores.length < COMPANIES_THAT_MAKE_A_LISTING) {
+		return { sites: new Set(), addressesRead }
+	}
+	// What it takes for a host to be one of these companies' own site, asked the
+	// way the rest of the run asks it: the domain has to BE a name, not merely
+	// carry one, so "acme.example" is Acme Instalacions' own and
+	// "acme-directory.com" is not.
+	const ownSiteKeys: EntityTargets = {
+		cores: names
+			.map(name => nameCore(withoutFormDots(name)))
+			.filter(core => core.length >= DISTINCTIVE_NAME_LENGTH),
+		words: [...new Set(names.flatMap(distinctiveWords))],
+		domains: [],
+		places: [],
+	}
+
+	// Which of the run's companies each host files, and where. The addresses are
+	// held rather than counted, because one page naming two of them is a piece
+	// about both — it takes a separate address per company to be a listing.
+	const filedByHost = new Map<string, Map<string, Set<string>>>()
+	for (const address of readable) {
+		const host = hostOf(address)
+		if (host === null) continue
+		// A host that is a listed company's own site is that company's, whatever
+		// else sits on it: a firm's own page for each partner would otherwise read
+		// as a listing of them.
+		if (isOwnSiteHost(ownSiteKeys, host)) continue
+		const segments = filingWords(address)
+		for (const core of companyCores) {
+			if (segments.some(segment => namesTheCompany(segment, core))) {
+				const filed = filedByHost.get(host) ?? new Map<string, Set<string>>()
+				const at = filed.get(core) ?? new Set<string>()
+				at.add(address)
+				filed.set(core, at)
+				filedByHost.set(host, filed)
+			}
+		}
+	}
+
+	const sites = new Set<string>()
+	for (const [host, filed] of filedByHost) {
+		if (filed.size < COMPANIES_THAT_MAKE_A_LISTING) continue
+		const addressesFiledAt = new Set([...filed.values()].flatMap(at => [...at]))
+		if (addressesFiledAt.size >= COMPANIES_THAT_MAKE_A_LISTING) sites.add(host)
+	}
+	return { sites, addressesRead }
+}
+
+/**
+ * What is known about a host. Anything this run did not watch file several of its
+ * companies is `unknown`, which is not a clearance.
+ */
+export const siteVerdict = (
+	host: string,
+	sites: DirectorySites,
+): SiteVerdict => (sites.has(host) ? 'directory' : 'unknown')

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -116,8 +116,13 @@ export const collapse = (value: string): string =>
 		.toLowerCase()
 		.replace(/[^a-z0-9]/g, '')
 
-// Accent-folded word tokens of a name, punctuation split out.
-const foldTokens = (value: string): string[] =>
+/**
+ * Accent-folded word tokens of a name, punctuation split out. Exported because
+ * the same folding has to read a web address the same way it reads a name — a
+ * second copy of it is how two checks start disagreeing about whether a piece of
+ * text spells a company.
+ */
+export const foldTokens = (value: string): string[] =>
 	value
 		.normalize('NFKD')
 		.replace(/\p{Diacritic}/gu, '')

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -180,11 +180,36 @@ export const nameWithoutForms = (name: string): string =>
 		.filter(t => !LEGAL_SUFFIXES.has(t))
 		.join('')
 
-// The distinctive words of a name: each ≥4 chars and neither a legal suffix nor a
-// generic industry term. These drive the weak match.
-const distinctiveWords = (name: string): string[] =>
+/**
+ * The shortest run of letters that may stand for a company on its own. Two or
+ * three turn up inside unrelated text by coincidence — "it" sits inside
+ * "digital.es", "roca" inside "barroca" — and every check that goes on a name
+ * fragment pays for that coincidence in the same way.
+ */
+export const DISTINCTIVE_NAME_LENGTH = 4
+
+/**
+ * A legal form written with dots — "Muñoz S.L." — comes apart into single letters
+ * that read as two more words of the name, so the same company written both ways
+ * lands under two different keys. Taking the dots out first puts the form back
+ * together. Two rows of one Spanish list spelling the form differently is the
+ * ordinary case here, not an exotic one.
+ */
+export const withoutFormDots = (name: string): string => name.replace(/\./g, '')
+
+/**
+ * The distinctive words of a name: each long enough to stand for the company and
+ * neither a legal suffix nor a generic industry term. These drive the weak match,
+ * and they are also how most firms register a domain — "Transportes García" at
+ * garcia.es — which is why a caller asking whether a host is a company's own
+ * needs them beside its cores.
+ */
+export const distinctiveWords = (name: string): string[] =>
 	foldTokens(name).filter(
-		t => t.length >= 4 && !LEGAL_SUFFIXES.has(t) && !GENERIC_WORDS.has(t),
+		t =>
+			t.length >= DISTINCTIVE_NAME_LENGTH &&
+			!LEGAL_SUFFIXES.has(t) &&
+			!GENERIC_WORDS.has(t),
 	)
 
 // The bare host of a website — "acme.co.uk" from "https://www.acme.co.uk/about".

--- a/packages/research/src/application/prospect-dedupe-guard.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.ts
@@ -27,16 +27,9 @@
  * is already gone by the time a host counts as evidence two rows are one company.
  */
 
-import { collapse, nameCore } from './entity-guard'
+import { collapse, nameCore, withoutFormDots } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { hostOf, isBareWebAddress } from './source-key'
-
-// A legal form written with dots — "Muñoz S.L." — comes apart into single letters
-// that read as two more words of the name, so "Muñoz SL" and "Muñoz S.L." end up
-// under different keys. Taking the dots out first puts the form back together. Two
-// Spanish rows spelling the form differently is the ordinary case here, not an
-// exotic one.
-const withoutFormDots = (name: string): string => name.replace(/\./g, '')
 
 /**
  * What a row is filed under: its name with the legal form off the end, and the host

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -53,6 +53,7 @@ import {
 	criticPrompt,
 	critiqueFieldSupport,
 } from './critic-guard'
+import { linkedAddresses, observeDirectorySites } from './directory-sites'
 import {
 	discoveredEntryKey,
 	filterDiscoveredExisting,
@@ -2523,6 +2524,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					// was never fetched — the scalar/value guards still hold each value to the
 					// gathered evidence, so this recovers real facts without loosening truth.
 					const searchResultHosts = new Set<string>()
+					// Every address this run met, as written — each result its searches
+					// returned, each page it fetched, and the addresses those pages link to.
+					// Full addresses rather than hosts, because what says a site is a
+					// directory is which companies it files and where, and only the path
+					// shows that. Empty on a resume that skips phase 1, which leaves every
+					// host unknown — the safe direction.
+					const gatheredAddresses = new Set<string>()
 					// The anchor site fetched up front (see below): its url hash to link as
 					// a source, and its capped rendered text to prepend to the transcript so
 					// phase-2 extraction reads the official site even if the model never did.
@@ -3121,9 +3129,20 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									name: 'websites',
 									run: findings =>
 										Effect.gen(function* () {
+											// Which sites this run watched file several of its own
+											// companies. Worked out here rather than once for the chain,
+											// because the organisation-kind link drops the rows that are
+											// not companies at all, and a trade body's own name must not
+											// be one of the names a host is judged by.
+											const directories = observeDirectorySites({
+												findings,
+												listField: discoveryResultField(schemaName),
+												addresses: [...gatheredAddresses],
+											})
 											const check = guardCompanyWebsites(
 												findings,
 												rescueTarget.name,
+												directories.sites,
 											)
 											const blanked =
 												check.blankedNotAnAddress +
@@ -3147,6 +3166,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												findings: check.findings,
 												spanCounts: {
 													'research.websites.blanked': blanked,
+													// Both numbers, because they say different things: no
+													// directory found out of no addresses read is plumbing
+													// broken, out of two hundred it is a real quiet answer.
+													'research.directories.observed':
+														directories.sites.size,
+													'research.directories.addresses_read':
+														directories.addressesRead,
 												},
 											}
 										}),
@@ -4261,6 +4287,16 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														typeof page.markdown === 'string' &&
 														page.markdown.trim().length > 0
 													) {
+														gatheredAddresses.add(page.url)
+														// And where this page points. A listing found by a
+														// search is met at its category page, which names no
+														// company; the addresses that do are the ones it links
+														// to, and they are already in the text.
+														for (const linked of linkedAddresses(
+															page.markdown,
+														)) {
+															gatheredAddresses.add(linked)
+														}
 														scrapeUrlHashes.push(urlHashForScrape(page.url))
 														scrapeCorpus.push({
 															urlHash: urlHashForScrape(page.url),
@@ -4290,6 +4326,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														const resultHost = domainHost(item.url)
 														if (resultHost !== undefined)
 															searchResultHosts.add(resultHost)
+														// A result the search returned without any text still
+														// shows WHERE a site filed a company, which is all the
+														// directory check reads, so it is gathered here even
+														// though it grounds nothing.
+														gatheredAddresses.add(item.url)
 														if (
 															typeof item.content === 'string' &&
 															item.content.trim().length > 0
@@ -4795,6 +4836,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											cited.markdown !== undefined &&
 											cited.markdown.trim().length > 0
 										) {
+											gatheredAddresses.add(cited.url)
+											for (const linked of linkedAddresses(cited.markdown)) {
+												gatheredAddresses.add(linked)
+											}
 											const citedHash = urlHashForScrape(cited.url)
 											roundHashes.push(citedHash)
 											scrapeCorpus.push({
@@ -4888,6 +4933,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										for (const item of searched?.items ?? []) {
 											const host = domainHost(item.url)
 											if (host !== undefined) searchResultHosts.add(host)
+											gatheredAddresses.add(item.url)
 											if (item.content && item.content.trim().length > 0) {
 												const hash = urlHashForScrape(item.url)
 												roundHashes.push(hash)

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -15,9 +15,52 @@ const websitesOf = (findings: unknown): Array<string | undefined> =>
 	)
 
 describe('guardCompanyWebsites', () => {
-	describe('when the website is a known directory', () => {
-		it('should blank a company-profile page and count it as a directory', () => {
-			// GIVEN a competitor whose "website" is a CB Insights profile page
+	describe('when the run watched the host file several of its companies', () => {
+		it('should blank the website and count it as a directory', () => {
+			// GIVEN a company whose "website" is its page on a host the run itself
+			// judged a listing, filed under a name the address does not spell out
+			const findings = scan([
+				{ name: 'Acme Freight', website: 'https://research.owler.com/c/8812' },
+			])
+
+			// WHEN the websites are checked against what the run observed
+			const result = guardCompanyWebsites(
+				findings,
+				undefined,
+				new Set(['research.owler.com']),
+			)
+
+			// THEN the listing is removed, which the rules reading only this one
+			// address could not have done: nothing here names the company
+			expect(websitesOf(result.findings)).toEqual([undefined])
+			expect(result.blankedDirectory).toBe(1)
+			expect(result.blankedProfilePage).toBe(0)
+		})
+
+		it('should leave a host the run never watched alone', () => {
+			// GIVEN the same address, with the run having observed a different host
+			const findings = scan([
+				{ name: 'Acme Freight', website: 'https://research.owler.com/c/8812' },
+			])
+
+			// WHEN checked
+			const result = guardCompanyWebsites(
+				findings,
+				undefined,
+				new Set(['aemiat.com']),
+			)
+
+			// THEN it is kept: an unwatched host is unknown, and unknown is no reason
+			// to take a website away
+			expect(websitesOf(result.findings)).toEqual([
+				'https://research.owler.com/c/8812',
+			])
+			expect(result.blankedDirectory).toBe(0)
+		})
+
+		it('should still blank a profile page with nothing observed at all', () => {
+			// GIVEN a directory's page about the company, and a run that watched
+			// nothing — a resume, or a run whose searches met each host once
 			const findings = scan([
 				{
 					name: 'Redwood Logistics',
@@ -25,28 +68,14 @@ describe('guardCompanyWebsites', () => {
 				},
 			])
 
-			// WHEN the websites are checked
+			// WHEN checked with no observation to go on
 			const result = guardCompanyWebsites(findings)
 
-			// THEN the directory URL is removed and the reason is recorded
+			// THEN the address naming the company one level down is enough on its
+			// own, so losing the list of known directories costs this case nothing
 			expect(websitesOf(result.findings)).toEqual([undefined])
-			expect(result.blankedDirectory).toBe(1)
-			expect(result.blankedProfilePage).toBe(0)
-		})
-
-		it('should blank a page on a subdomain of a known directory', () => {
-			// GIVEN a research subdomain of a listed aggregator
-			const findings = scan([
-				{
-					name: 'Acme Freight',
-					website: 'https://research.owler.com/company/acme',
-				},
-			])
-
-			// WHEN checked — THEN the subdomain is treated as the directory it is
-			const result = guardCompanyWebsites(findings)
-			expect(websitesOf(result.findings)).toEqual([undefined])
-			expect(result.blankedDirectory).toBe(1)
+			expect(result.blankedProfilePage).toBe(1)
+			expect(result.blankedDirectory).toBe(0)
 		})
 	})
 
@@ -187,8 +216,25 @@ describe('guardCompanyWebsites', () => {
 				},
 			])
 
-			// WHEN checked — THEN the missing scheme does not hide the directory
+			// WHEN checked — THEN the missing scheme does not hide the listing
 			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([undefined])
+			expect(result.blankedProfilePage).toBe(1)
+		})
+
+		it('should match an observed host with no scheme written', () => {
+			// GIVEN a bare host the run judged a listing, filed under an address that
+			// names nobody
+			const findings = scan([
+				{ name: 'Acme Freight', website: 'owler.com/c/8' },
+			])
+
+			// WHEN checked — THEN the observed verdict is found without a scheme too
+			const result = guardCompanyWebsites(
+				findings,
+				undefined,
+				new Set(['owler.com']),
+			)
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedDirectory).toBe(1)
 		})
@@ -265,8 +311,8 @@ describe('guardCompanyWebsites', () => {
 	})
 
 	describe('when the run answers with the target company own website', () => {
-		it('should blank a known directory even with no name to compare', () => {
-			// GIVEN the profile's website field pointing at an aggregator listing
+		it('should blank an observed directory even with no name to compare', () => {
+			// GIVEN the profile's website field pointing at a listing the run watched
 			const findings = {
 				enrichment: {
 					website: {
@@ -278,9 +324,14 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked with no target name supplied
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites(
+				findings,
+				undefined,
+				new Set(['crunchbase.com']),
+			)
 
-			// THEN the known-directory rule still fires, which is the whole point
+			// THEN the directory rule still fires, which is the whole point: it is the
+			// one rule that needs no name beside the address
 			expect(
 				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
 					'website'

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -12,7 +12,7 @@
  *
  * The rule blanks a website only when it is clearly not the company's own:
  *  - the value is not a web address at all, or
- *  - its host is a directory we already know (a short, evidence-driven list), or
+ *  - its host is one this run watched file several of its own companies, or
  *  - its host does not carry the company's name AND the name sits in a deeper part
  *    of the address — the shape of "someone-else.com/company/<the-company>", which
  *    is a listing, never a company's own home page, or
@@ -22,43 +22,26 @@
  * describes itself in the first path segment ("xpo.com/about-xpo-logistics"), and a
  * blank costs a real website, so the bar to blank is deliberately high.
  *
- * All but the last rule read only a name and a website, so they need no evidence
- * corpus and no database. They fire on any object carrying both — a scanned
- * competitor or prospect — and on the run's own answer for the target's website,
- * which arrives on its own with no name beside it and so is judged against the
- * target's name passed in. The last rule is the only one that asks about the whole
- * answer rather than one row, which is why the walk below is preceded by a reading
- * pass that gathers who claims which host.
+ * The address rule and the deeper-path rule read only a name and a website, so they
+ * need no evidence corpus and no database. They fire on any object carrying both —
+ * a scanned competitor or prospect — and on the run's own answer for the target's
+ * website, which arrives on its own with no name beside it and so is judged against
+ * the target's name passed in. The shared-host rule asks about the whole answer
+ * rather than one row, which is why the walk below is preceded by a reading pass
+ * that gathers who claims which host; the directory rule asks about the whole RUN,
+ * and is handed its answer from outside (see `directory-sites.ts`).
  */
 
-import { collapse, nameWithoutForms } from './entity-guard'
+import { type DirectorySites, siteVerdict } from './directory-sites'
+import {
+	collapse,
+	DISTINCTIVE_NAME_LENGTH,
+	nameWithoutForms,
+} from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { hostOf, isBareWebAddress } from './source-key'
 
-// Directories whose company-profile pages a model most often mistakes for a
-// company's own site. This is a shortcut, not the defence: an unlisted directory
-// is still caught by the name-in-a-deeper-path rule below, so adding a host here
-// only makes the common cases cheaper — it is never the thing standing between a
-// listing and the CRM.
-const AGGREGATOR_HOSTS = new Set([
-	'cbinsights.com',
-	'crunchbase.com',
-	'zoominfo.com',
-	'owler.com',
-	'dnb.com',
-	'dun-bradstreet.com',
-	'pitchbook.com',
-	'datanyze.com',
-])
-
 const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
-
-// The site sits on a known directory's host, or a subdomain of one
-// ("research.owler.com").
-const isAggregatorHost = (host: string): boolean =>
-	[...AGGREGATOR_HOSTS].some(
-		aggregator => host === aggregator || host.endsWith(`.${aggregator}`),
-	)
 
 // The parts of the address after the host — ["company", "redwood-logistics"] from
 // "cbinsights.com/company/redwood-logistics". A scheme is added when missing, since
@@ -108,16 +91,11 @@ const collectHostClaims = (findings: unknown): HostClaims => {
 	return claims
 }
 
-// The shortest name that can vouch for a host on its own. Two or three letters
-// turn up inside an unrelated address by coincidence — "it" sits inside
-// "digital.es" — and one company vouching for a host is what stands the
-// shared-host rule down for every row on it, so a coincidence there would quietly
-// switch the rule off. Four matches the bar the entity checks already set for a
-// word distinctive enough to go on.
-const VOUCHING_NAME_LENGTH = 4
-
+// One company vouching for a host stands the shared-host rule down for every row
+// on it, so a name too short to mean anything would quietly switch the rule off.
 const hostBelongsTo = (host: string, claimant: string): boolean =>
-	claimant.length >= VOUCHING_NAME_LENGTH && collapse(host).includes(claimant)
+	claimant.length >= DISTINCTIVE_NAME_LENGTH &&
+	collapse(host).includes(claimant)
 
 type WebsiteVerdict =
 	| 'keep'
@@ -131,6 +109,7 @@ const classifyWebsite = (
 	name: string,
 	website: string,
 	hostClaims: HostClaims,
+	directorySites: DirectorySites,
 ): WebsiteVerdict => {
 	const host = hostOf(website)
 	// Not an address at all: a value with words written next to it ("https://acme.es
@@ -138,7 +117,10 @@ const classifyWebsite = (
 	// holding prose is worse than an empty one — nobody can open it, and it reads as
 	// a real site to everything downstream.
 	if (host === null || !isBareWebAddress(website)) return 'not_an_address'
-	if (isAggregatorHost(host)) return 'directory'
+	// A host this run watched file several of its own companies. Any other host is
+	// `unknown`, which is no reason to blank a website and no clearance either — the
+	// rules below still have their say.
+	if (siteVerdict(host, directorySites) === 'directory') return 'directory'
 	// The name as an address would write it: a directory files a company under its
 	// trading name and leaves the legal form out, so the form is taken out here
 	// too, wherever in the name it sits. This asks whether the address names the
@@ -186,7 +168,7 @@ export interface WebsiteGuardResult {
 	readonly findings: unknown
 	/** Websites blanked because the value was not a web address. */
 	readonly blankedNotAnAddress: number
-	/** Websites blanked because their host is a known directory. */
+	/** Websites blanked because their host was watched filing several companies. */
 	readonly blankedDirectory: number
 	/** Websites blanked because the name sat in a deeper path of another host. */
 	readonly blankedProfilePage: number
@@ -199,12 +181,18 @@ export interface WebsiteGuardResult {
  * run's own answer for it rather than a scanned stranger's. That field sits alone —
  * a value with the page it came from and no company name beside it — so without the
  * name told from outside, the two name-based rules have nothing to compare and only
- * the known-directory rule can fire. Leave it out and that is exactly what happens,
- * which is still the check this guard exists for.
+ * the address rule and the directory rule are left. Pass it: a run about one named
+ * company observes no directories either, since telling one takes a list of
+ * companies to watch a host file, and such a run has one company.
+ *
+ * `directorySites` are the hosts the run itself watched behave like a listing. It
+ * defaults to none, which costs only that rule: a run that gathered nothing to
+ * watch still gets every rule that reads a name and an address.
  */
 export const guardCompanyWebsites = (
 	findings: unknown,
 	targetName?: string,
+	directorySites: DirectorySites = new Set(),
 ): WebsiteGuardResult => {
 	let blankedNotAnAddress = 0
 	let blankedDirectory = 0
@@ -240,6 +228,7 @@ export const guardCompanyWebsites = (
 				targetName ?? '',
 				value['value'],
 				hostClaims,
+				directorySites,
 			)
 			if (verdict !== 'keep') {
 				count(verdict)
@@ -253,7 +242,7 @@ export const guardCompanyWebsites = (
 		const name = value['name']
 		const website = value['website']
 		if (typeof name === 'string' && typeof website === 'string') {
-			const verdict = classifyWebsite(name, website, hostClaims)
+			const verdict = classifyWebsite(name, website, hostClaims, directorySites)
 			if (verdict !== 'keep') {
 				count(verdict)
 				// Drop the key entirely, so the value reads as one the model never


### PR DESCRIPTION
## What

When a research scan looks for companies, it meets a lot of websites that exist only to list other companies — a chamber's member register, a trade body's member pages, a yellow-pages site. Those are not a company's own website, and putting one in the CRM's website field means shipping a stranger's URL as if it were the company's. Until now the way to tell them apart was a hardcoded list of eight hosts. All eight are American, two of them are the same firm under two names, and not one of the directories a Spanish search actually returns is on it.

This replaces the list with something the run works out for itself: watch which websites file **more than one of this search's own companies** at an address that carries that company's name. Do that for two companies, and the site is a listing. This is §4.7 of #456, in the Research context (`packages/research`).

## Changes

- A scan decides what a directory is from behaviour inside the run rather than from a list of names, so a directory nobody wrote down is caught in any country and any language.
- The evidence is addresses the run already has: every search result, every page it fetched, and the addresses those pages link to. That last part is not a nicety — see *Verification*.
- A site seen for a single company is `unknown`, and `unknown` is never readable as "not a directory". The verdict has exactly two values and no third one meaning "checked and cleared", because nothing here can establish that. A thin sample can withhold a confirmation; it can never manufacture one. That is the whole safety property, and #456 §4.8 will lean on it.
- The key is the raw host as met, never folded to a registrable domain. `empresite.eleconomista.es` is a directory and `eleconomista.es` is a real newspaper — and newspapers are exactly what has to survive as the source that *isn't* a directory.
- `AGGREGATOR_HOSTS` and `isAggregatorHost` are gone.
- Three helpers that had been copied or were about to be — the dots-in-a-legal-form fold, the four-letter "distinctive enough to go on" bar, and the distinctive-words reader — now have one home in `entity-guard.ts`, which is where the repo already keeps name folding.

## Impact

**What ends up in the CRM's website field changes, in both directions.**

- **Now kept, where it used to be dropped:** a directory page whose web address holds a number instead of the company's name — a bare `crunchbase.com`, or `pitchbook.com/profiles/company/12345-42`. The old list of eight hosts caught these. The new check cannot: it works by spotting a company's name in the address, and there is no name here to spot. The one other rule that might have caught it needs the name too. So this is a real loss, and I would rather say it plainly than let it slip by. Tracked in #471.
- **Now dropped, where it used to be kept:** any site the run watched file two or more of its own companies. That is the point of the change.

**Nothing extra is fetched and nothing extra is paid for.** Everything read is already in the run's hands — the links inside a page come out of text it already fetched.

**Both ways into the system behave the same.** The check sits in the research pipeline that the assistant tools (MCP) and the web API (HTTP) share, so neither has a path of its own.

**Two new numbers on the run's trace**, `research.directories.observed` and `research.directories.addresses_read`. Both, because they answer different questions: nothing found out of nothing read means the plumbing is broken, while nothing found out of two hundred read is a real, quiet "no".

Nothing else moves: no database migration, no change to the database shape, no new environment variable, nothing touching which organisation can see what, and no change to the shape of any API.

## Review guide

**Read `directory-sites.ts` top to bottom** — the module docblock carries the reasoning, including what it gets wrong on purpose. Then the one call site in `website-guard.ts` (`classifyWebsite`), then the four collection points in `research-service.ts`, which are one line each.

**The riskiest part is a false positive**, not a false negative. Saying "directory" is not a withholding — it deletes a company's website. Two independent reviewers flagged that my first version got this backwards in its own reasoning, and four concrete defects came out of it, all fixed and pinned by tests: one page naming two companies could mint a directory on its own; accented paths (`/instalaciones-ferré`) never matched, because they arrive percent-escaped and `%` was being stripped; short names matched inside ordinary words (`Roca` inside `barroca`); and `addressesRead` reported 0 in exactly the two cases it existed to tell apart.

**A second review pass then caught a real bug in the link harvesting itself** (second commit). The per-page link ceiling was applied *before* de-duplicating, so a listing's repeated filter and navigation links — the empresite Girona page front-loads about a hundred locality filters above its company entries — could consume the whole allowance and leave every per-company link unread. Reproduced at 1 address recovered where 3 were expected, now fixed and covered by a fixture with that shape. The same pass fixed a truncation of addresses ending in a genuine bracket (`…/wiki/Acme_(empresa)`), folded a duplicated word-folding helper back into `entity-guard`, and memoised the own-site check per host. Four findings I left, each with a reason: the id-keyed profile pages above; the own-site exemption widening as the list grows (the obvious narrowing reintroduces a false positive I had just fixed, and this one fails toward missing a directory rather than deleting a website); the observation being rebuilt per guard-chain pass (not cacheable — the company list differs between passes); and the link ceiling still truncating silently (much less likely to bite now that it counts distinct links).

**The decision you might overrule.** #456 §4.7 says the signal is gathered "while the verification searches run" — but those searches are §4.8, which does not exist. Taken literally §4.7 can't be built until §4.8 is, and §4.8 needs §4.7's answer. I broke the circle by building over what a run gathers today. Then I measured it, found it barely fires on search results alone, and you chose to also read the addresses linked from fetched pages — which is what makes it work now. Both halves of that are worth a second look.

**One limitation I did not fix.** A local paper that ran two pieces, each naming a different one of the run's companies in its address, reads as a listing. #456 claims this can't happen; it can, because a host is weighed on all its addresses together. It costs that paper's standing as a corroborating source, never a company's own website — no company's website is a newspaper. Fixing it means deciding how much of an address a name has to account for, which is an unmeasured threshold, and unmeasured thresholds are what sank the rejected alternative. It's documented in the module and pinned by a test.

**Not done**: no `/security-review` (no auth, RLS, parser or external-input surface), no a11y pass (no UI), no Snyk (tool not available in this session).

## Tests

71 unit tests across the two guards, in the `/test-bdd` shape. They cover the mechanism (two companies on one host, first segment and deeper), everything that must *not* fire (one company, one page naming two, two spellings of one company, a name nested inside another, a short name inside an ordinary word, a company's own site on a short domain), the raw-host rule in both directions, the citation screen (`src_9f2a1b` must not read as a website), accented and percent-escaped addresses, link harvesting including both the repeated-menu case and the ceiling, and the two documented costs.

## Verification

`pnpm install`, `pnpm -w check-types` (13 packages), `pnpm -w test` (21 tasks, 1,280 research tests), `pnpm -w build` — all green. No UI change, so no screenshots.

I also ran the finished mechanism against **real data** rather than only fixtures, because the alternative this replaces was refuted by exactly that kind of check. Two live searches (`empresas instalaciones eléctricas Girona`, `instaladores fontanería y climatización Tarragona` — 38 result URLs) plus the real per-company addresses `empresite.eleconomista.es` links from its own Girona index:

| Given | Directories found |
|---|---|
| The 38 search results alone | none |
| Plus the per-company pages one level in | `empresite.eleconomista.es`, `eleconomista.es` untouched |
| The companies' own websites alone | none |
| The 38 results plus the links read out of the fetched index page | `empresite.eleconomista.es` |

The first row is why the link-harvesting is in this PR at all: at search-result level every directory in that set — empresite, Páginas Amarillas, habitissimo, Expansión, Informa, ProntoPro, Wallapop, Doméstiko — comes back as a *category* page whose address carries a trade and a province and no company. Full working in the [issue comment](https://github.com/guillempuche/batuda/issues/467#issuecomment-5290505487).

## Deferred

- Some directory pages put a number in the web address instead of the company's name — `pitchbook.com/profiles/company/12345-42`. Nothing left in the code can spot those, because there is no name in the address to read. That needs its own decision: either keep a small list of those sites after all, or wait and see whether the next piece of the plan — the check that a company really exists (§4.8 of #456) — already covers it. Tracked in #471.
- Measuring what this does to a real scan's numbers belongs with #466, which is the measurement work.

Closes #467
