### PR TITLE
feat: grade a whole-market search on what its list gets wrong

### DIFF
--- a/.claude/skills/run-research-eval/SKILL.md
+++ b/.claude/skills/run-research-eval/SKILL.md
@@ -29,10 +29,11 @@ Two different things have to be present, and they come from two different places
 If the routing is missing from the run environment, that provider silently falls back to `stub` and the run reports **100% empty** over canned data. So the run has to carry the committed routing in explicitly:
 
 ```bash
-# Every RESEARCH_* setting except the keys, as `NAME=value` arguments to `env`.
+# Every RESEARCH_* setting except the keys, space-separated, as `NAME=value` arguments to `env`.
 ROUTING=$(node -e 'const c=require("./apps/server/config.production.json");
-  for (const [k, v] of Object.entries(c))
-    if (k.startsWith("RESEARCH_") && !k.includes("API_KEY")) process.stdout.write(k + "=" + v + "\n")')
+  const out=[]; for (const [k, v] of Object.entries(c))
+    if (k.startsWith("RESEARCH_") && !k.includes("API_KEY")) out.push(k + "=" + v);
+  process.stdout.write(out.join(" "))')
 ```
 
 Feed it after `infisical run` so it wins over anything the environment carries, together with the worktree's own database (a dev Infisical env ships its own `DATABASE_URL` and would otherwise win):
@@ -45,7 +46,21 @@ infisical run --env=<env> -- env $ROUTING DATABASE_URL="$DB" \
 
 This is the same trick `.github/workflows/model_capability.yml` uses to probe the models: committed routing plus injected keys.
 
-**Turn the registries off for a pass that measures quality** — the two `=none` above. A registry hands back a company's directors, who are named people with titles, so leaving it on feeds the contact numbers from a source the change under test has nothing to do with. It costs money and does not fire on every pass. Keep one registries-on pass separately as the figure that represents production.
+**Expand `$ROUTING` in the shell that runs `env`, never in the one that writes the command.** It holds one `NAME=value` per line, so interpolating it into a double-quoted `sh -c "…"` embeds those newlines and `sh` reads them as command separators: the first line runs `env` with a single variable, the middle lines run as commands of their own, and the *last* line runs the eval — outside `infisical`, with no keys at all. Every provider then falls back to `stub` and the pass reports 100% empty over canned data, which reads as a total quality collapse rather than as a quoting mistake. Export it and single-quote the command so the inner shell does the splitting:
+
+```bash
+export ROUTING="$(node -e '…' )"   # space-separated
+export DB="postgresql://batuda:batuda@localhost:5433/<worktree-db>"
+nix develop --command sh -c 'infisical run --env=dev -- env $ROUTING DATABASE_URL="$DB" … pnpm cli research eval …'
+```
+
+**Turn off every tier the dev environment has no key for**, or config validation refuses to boot with a bare `ConfigError`. The committed routing points `enrich` at `hunter,fullenrich`, `map` at `firecrawl` and `verify` at a vendor, and `RESEARCH_API_KEY_ENRICH`, `_MAP` and `_VERIFY` are absent from dev. A scan uses the search, scrape and LLM tiers, so none of the three is needed:
+
+```bash
+RESEARCH_PROVIDER_ENRICH=none RESEARCH_PROVIDER_MAP=none RESEARCH_PROVIDER_VERIFY=none
+```
+
+**Turn the registries off for a pass that measures quality** — `RESEARCH_PROVIDER_REGISTRY_ES=none RESEARCH_PROVIDER_REGISTRY_GB=none`. A registry hands back a company's directors, who are named people with titles, so leaving it on feeds the contact numbers from a source the change under test has nothing to do with. It costs money and does not fire on every pass. Keep one registries-on pass separately as the figure that represents production.
 
 **Never print a secret.** `infisical secrets` prints values in plain text — it has no redacted mode, and its `--json` output is preceded by the shell banner, so a naive parse returns nothing and tempts you into the plain form. If you need to know which keys exist, list names only:
 
@@ -100,6 +115,21 @@ infisical run --env=dev -- env DATABASE_URL="postgresql://batuda:batuda@localhos
 ```
 
 `STORAGE_*` is genuinely absent from the dev env and comes from the worktree by itself. The eval refuses to start against a non-local database, so a forgotten pin stops the run instead of writing a pass into a shared one.
+
+## A whole-market pass needs the run deadline raised, or it measures a timeout
+
+`RESEARCH_RUN_DEADLINE_SEC` is a hard wall-clock cap on one run, applied inside the pipeline. It defaults to **1200 (20 min)** and `.env.example` sets the same, which is *below* how long a search for a whole market takes — the Spanish installations scan runs 20–32 minutes over ~300 pages. Production sets 2400, but an eval builds the pipeline in-process, so a worktree pass gets the default.
+
+Past that deadline the run is killed and marked `failed`, and a killed run is left out of the market figures rather than counted as a market with nothing in it. So the symptom is not a zero — it is the market's line reading `no run reached an answer`, or `By market` showing fewer runs than you asked for while the figures themselves look untroubled. Read the run count before the rates.
+
+So pass it explicitly, above the longest run you expect, and keep it *below* the CLI's own poll ceiling (45 min) so the poll outlives the run and reads its answer:
+
+```bash
+… -- env $ROUTING DATABASE_URL="$DB" RESEARCH_RUN_DEADLINE_SEC=2400 \
+  pnpm cli research eval --schema prospect_scan_v1 --golden eval/golden-markets.json …
+```
+
+`--schema prospect_scan_v1` is required for a market golden set — only a search shape answers with a list. The eval refuses to start without it rather than scoring every market at zero.
 
 ## Validate one company first, then the full pass
 

--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -33,6 +33,8 @@ import {
 	evalSummaryAttributes,
 	type FramingOutcome,
 	type GoldenExpectation,
+	type MarketExpectation,
+	type MarketScore,
 	type ModelProbeResult,
 	makeResearchLlmLive,
 	makeResearchProvidersLive,
@@ -311,23 +313,40 @@ const pollToTerminal = (runId: string, maxAttempts: number) =>
 		return run
 	})
 
+// How long to wait for one run, in one-second polls: three quarters of an hour. A
+// search for a whole market is a long job — the one this measures ran for 32 minutes
+// over some 300 pages — and a run still going when the poll gives up is read as a
+// run that failed, which would score every market request as having found nothing.
+//
+// This has to stay above `RESEARCH_RUN_DEADLINE_SEC`, which is what actually bounds
+// a run: the run ends itself at that deadline, and waiting past it is what lets the
+// poll read the answer rather than time out alongside it. That setting defaults to
+// twenty minutes, which is *below* a market search's normal length, so a market pass
+// has to raise it — otherwise the run is killed mid-search and the list it had so
+// far is thrown away, which reads as a market with nothing in it.
+const MARKET_RUN_POLL_ATTEMPTS = 2_700
+
+// What a run answering about one company gets. A profile run finishes in minutes, so
+// a market-sized wait here only lengthens how long a wedged one holds its slot.
+const COMPANY_RUN_POLL_ATTEMPTS = 900
+
 // Create a fresh eval run and poll it to a terminal status. A single golden
 // company never fans out, so a confirm-required result is a bug — die on it.
-// A deep run does several search/scrape/LLM rounds, so allow ~15 minutes (900
-// one-second polls). Returns the run id (for source lookups) and the finished run.
+// Returns the run id (for source lookups) and the finished run.
 const createRunToTerminal = (
 	user: string,
 	org: string,
 	input: CreateResearchInput,
 	defaults: SystemDefaults,
-	instructions?: ResolvedInstructions,
+	instructions: ResolvedInstructions | undefined,
+	pollAttempts: number,
 ) =>
 	Effect.gen(function* () {
 		const svc = yield* ResearchService
 		const created = yield* svc.create(user, org, input, defaults, instructions)
 		if (created.status === 'confirm_required')
 			return yield* Effect.die(new Error('eval run should not fan out'))
-		const run = yield* pollToTerminal(created.id, 900)
+		const run = yield* pollToTerminal(created.id, pollAttempts)
 		return { runId: created.id, run }
 	})
 
@@ -351,11 +370,16 @@ const driveOne = (
 			// language — the seam for testing a non-English company end to end.
 			...(lang ? { context: { hints: { language: lang } } } : {}),
 		}
+		// A market request is the long job; anything else answers about one company.
 		const { runId, run } = yield* createRunToTerminal(
 			user,
 			org,
 			input,
 			defaults,
+			undefined,
+			golden.market === undefined
+				? COMPANY_RUN_POLL_ATTEMPTS
+				: MARKET_RUN_POLL_ATTEMPTS,
 		)
 		// Grounding is judged by the pages the run reached, so pull its fetched
 		// source URLs — per-field citations may point at third-party fact-sources.
@@ -375,12 +399,51 @@ const driveOne = (
 		return scoreRun(golden, outcome)
 	})
 
-// Aggregate a company's repeated runs into shares (grounded 3/5, …). Per-run
-// grounding is noisy, so the fraction across runs is the trustworthy signal.
-const formatCompanyRuns = (
+// A market request's repeated runs, as what its list got right. Nothing a company
+// row reports applies — there is no company to have reached and no field of its own
+// to have filled — so this is a separate line rather than the same one with most of
+// it reading "n/a".
+const formatMarketRuns = (
 	id: string,
+	market: MarketExpectation,
 	scores: ReadonlyArray<RunScore>,
 ): string => {
+	const markets = scores.flatMap(score => score.market ?? [])
+	// Every run died or was stopped, so there is nothing to divide. Saying so is the
+	// point: falling through to the company line would report a market request as
+	// having failed to reach a company nobody named.
+	if (markets.length === 0)
+		return `${id.padEnd(20)} market ${market.name.padEnd(6)}  no run reached an answer (${scores.length} attempted)`
+	const total = (pick: (market: MarketScore) => number): number =>
+		markets.reduce((sum, market) => sum + pick(market), 0)
+	const rows = total(market => market.rowsReturned)
+	const share = (matched: number): string =>
+		rows === 0 ? 'n/a' : `${matched}/${rows}`
+	const parts = total(market => market.partsExpected)
+	// The shares divide by their own totals, so summing across repeats is right for
+	// them. The row count is not a share: printing the sum would read 186 rows for one
+	// 62-row list asked for three times, so it is the rows one run came back with.
+	const rowsPerRun = rows / markets.length
+	return [
+		`${id.padEnd(20)} market ${market.name.padEnd(6)}`,
+		`rows ${rowsPerRun.toFixed(0).padStart(3)}`,
+		`right kind ${share(total(market => market.rowsRightKind))}`,
+		`duplicates ${share(total(market => market.rowsDuplicated))}`,
+		`located ${share(total(market => market.rowsLocated))}`,
+		`parts ${parts === 0 ? 'n/a' : `${total(market => market.partsAnswered)}/${parts}`}`,
+	].join('  ')
+}
+
+// Aggregate one golden row's repeated runs into shares (grounded 3/5, …). Per-run
+// grounding is noisy, so the fraction across runs is the trustworthy signal. A row
+// that asked for a market answers none of those questions and prints its own line.
+const formatGoldenRuns = (
+	golden: GoldenExpectation,
+	scores: ReadonlyArray<RunScore>,
+): string => {
+	const id = golden.id
+	if (golden.market !== undefined)
+		return formatMarketRuns(id, golden.market, scores)
 	const total = scores.length
 	const share = (matched: number): string => `${matched}/${total}`
 	const grounded = scores.filter(score => score.grounded).length
@@ -424,6 +487,7 @@ const formatSummary = (summary: EvalSummary): string =>
 		`Field precision:        ${pct(summary.fieldPrecision)}`,
 		`Field recall:           ${pct(summary.fieldRecall)}`,
 		`Titled-contact recall:  ${pct(summary.contactRecall)}`,
+		...formatMarketFigures(summary),
 		`Profile fields filled:  ${decimal(summary.fieldsFilledPerRun)} of ${count(summary.profileFieldsTotal)}`,
 		`People named per run:   ${decimal(summary.contactsNamedPerRun)}`,
 		`  of those, titled:     ${decimal(summary.contactsTitledPerRun)}`,
@@ -438,6 +502,20 @@ const formatSummary = (summary: EvalSummary): string =>
 		`Credits per run:        ${count(summary.creditsPerRun)}`,
 		...formatAnsweringModels(summary),
 	].join('\n')
+
+// What a pass of market requests got right. Silent for a pass of company profiles,
+// which has no list to judge — the figures are all null there, and printing five
+// "n/a" lines on every ordinary pass buries the ones that mean something.
+const formatMarketFigures = (summary: EvalSummary): ReadonlyArray<string> =>
+	summary.rowsPerScan === null
+		? []
+		: [
+				`Rows per market:        ${decimal(summary.rowsPerScan)}`,
+				`  right kind:           ${pct(summary.organisationKindPrecision)}`,
+				`  duplicates:           ${pct(summary.duplicateRate)}`,
+				`  with a location:      ${pct(summary.locationFill)}`,
+				`Request coverage:       ${pct(summary.requestCoverage)}`,
+			]
 
 // Which models actually did the work. A tier is configured with a first choice
 // and a second one for when the first falters, so a pass can quietly be carried
@@ -479,6 +557,51 @@ const formatGroups = (
 			),
 	].join('\n')
 
+// One line per market. This is the breakdown the market figures exist for rather
+// than a nicety: the organisation-kind guard reads Spanish, Catalan and English, so
+// a market answering in one of those scores near 100% while a market answering in
+// French or German scores far lower. Averaged together that difference vanishes,
+// and it is the whole thing worth watching.
+const formatMarketGroups = (groups: Record<string, EvalSummary>): string =>
+	[
+		'',
+		'── By market ──',
+		...Object.entries(groups)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(
+				([key, s]) =>
+					`${key.padEnd(10)} runs ${String(s.runs).padStart(3)}  rows ${decimal(
+						s.rowsPerScan,
+					)}  right kind ${pct(
+						s.organisationKindPrecision,
+					)}  dupes ${pct(s.duplicateRate)}  located ${pct(
+						s.locationFill,
+					)}  coverage ${pct(s.requestCoverage)}  cost ${cents(s.costPerRun)}`,
+			),
+	].join('\n')
+
+// The one shape that answers a market request. Both scan shapes return a list, but
+// only a prospect row carries a place, so a market scored against the competitor
+// shape reads nought location fill for a field that shape never had. Run a market
+// against the profile shape — which is what --schema defaults to — and every row
+// scores nought rows and nought coverage, which looks exactly like a pipeline that
+// found nothing rather than like the wrong flag.
+const MARKET_SCHEMA = 'prospect_scan_v1'
+
+const requireMarketSchema = (
+	golden: ReadonlyArray<GoldenExpectation>,
+	schemaName: string,
+) => {
+	const markets = golden.filter(row => row.market !== undefined).length
+	return markets > 0 && schemaName !== MARKET_SCHEMA
+		? Effect.fail(
+				new Error(
+					`${markets} golden row(s) ask for a whole market, which only ${MARKET_SCHEMA} answers; --schema is "${schemaName}". Re-run with --schema ${MARKET_SCHEMA}.`,
+				),
+			)
+		: Effect.void
+}
+
 /**
  * Run the golden set through the live research pipeline and report the four quality
  * metrics. This drives real runs (LLM + providers + DB), so it needs the research
@@ -510,6 +633,7 @@ export const researchEval = (opts: {
 		if (golden.length === 0) {
 			return yield* Effect.fail(new Error('golden set has no valid rows'))
 		}
+		yield* requireMarketSchema(golden, opts.schemaName)
 		yield* Console.log(`Evaluating ${golden.length} companies…\n`)
 
 		// Tag the run's spans so a drift chart can group quality by which models
@@ -564,8 +688,8 @@ export const researchEval = (opts: {
 
 		for (const company of golden) {
 			yield* Console.log(
-				formatCompanyRuns(
-					company.id,
+				formatGoldenRuns(
+					company,
 					scores.filter(score => score.id === company.id),
 				),
 			)
@@ -576,6 +700,11 @@ export const researchEval = (opts: {
 		if (opts.byBucket) {
 			yield* Console.log(formatGroups('By bucket', report.byBucket))
 			yield* Console.log(formatGroups('By country', report.byCountry))
+		}
+		// Not behind the breakdown flag: a market pass is run to read this, and one
+		// market's figures averaged with another's is the reading it exists to replace.
+		if (Object.keys(report.byMarket).length > 0) {
+			yield* Console.log(formatMarketGroups(report.byMarket))
 		}
 		yield* Effect.annotateCurrentSpan(evalSummaryAttributes(report.summary))
 		yield* Option.match(opts.out, {
@@ -729,6 +858,7 @@ const driveFramed = (
 			input,
 			defaults,
 			instructions,
+			COMPANY_RUN_POLL_ATTEMPTS,
 		)
 		const outcome = outcomeFromRun({
 			status: run?.status ?? 'failed',
@@ -766,6 +896,10 @@ export const researchEvalInvariance = (opts: {
 		if (golden.length === 0) {
 			return yield* Effect.fail(new Error('golden set has no valid rows'))
 		}
+		// This command asks whether two wordings of the same question reach the same
+		// company, which a market request has no answer to — and it would spend two
+		// live runs per row finding that out.
+		yield* requireMarketSchema(golden, opts.schemaName)
 		yield* Console.log(
 			`Framing-invariance eval on ${golden.length} companies (2 runs each)…\n`,
 		)

--- a/eval/README.md
+++ b/eval/README.md
@@ -12,9 +12,13 @@ pnpm cli research probe --api-key <nebius-key>
 
 # Score the golden set. Needs the research env configured (LLM + provider keys, DATABASE_URL) and an org/user to run as.
 pnpm cli research eval --org <org-id> --user <user-id> --golden eval/golden.json --out report.json
+
+# Score a set of whole-market requests instead. Same command, a scan schema, and a golden file of market rows.
+# RESEARCH_RUN_DEADLINE_SEC must be raised: it defaults to 20 minutes, and a market search runs longer.
+RESEARCH_RUN_DEADLINE_SEC=2400 pnpm cli research eval --org <org-id> --user <user-id> --schema prospect_scan_v1 --golden eval/golden-markets.json --out markets.json
 ```
 
-`eval` prints the metrics — grounding accuracy, field precision, field recall, titled-contact recall, profile fullness, wrong-company rate, needs-review rate, empty rate — and writes a full per-run report with `--out`.
+`eval` prints the metrics — grounding accuracy, field precision, field recall, titled-contact recall, profile fullness, wrong-company rate, needs-review rate, empty rate — and writes a full per-run report with `--out`. A pass of whole-market requests is graded on a different set of numbers; see [Market rows](#market-rows-grading-a-search-for-a-whole-market).
 
 Add `--by-bucket` to also print those metrics broken out by the golden rows' size/reach `bucket` (big / small / niche) and by `country`, so a regression that only hits, say, niche companies or one country is visible instead of averaged into the whole-set numbers. The same per-bucket and per-country summaries are always written to the `--out` report as `byBucket` / `byCountry`, and each run's span carries `eval.bucket` / `eval.country` for grouping on the monitoring board.
 
@@ -118,6 +122,66 @@ Two of these are fixed sets, and the value has to be one of them or it can never
 - `email` — the company's own published mailbox, exactly as printed (`info@…`, `hola@…`). Not a named person's address; those belong in `contacts`.
 - `phone` — the company's own published number, in any format (matched on digits)
 - `tax_id` — the registration number, in any format (matched on letters and digits)
+
+## Market rows: grading a search for a whole market
+
+A row can ask for a whole market instead of one company — "installation companies in Spain: electrical, plumbing, solar, fire protection, lifts". That is what a discovery scan answers, and none of the figures above apply to it: there is no one company for the run to have reached, and no profile of its own to have filled.
+
+Counting how many companies came back is not the grade either. A run on 13 August returned 62 rows, of which 23 were trade bodies and 10 were the same company written twice, and four of the five trades asked for were missing entirely — a healthy-looking count over a list nobody could use. A market row is graded on those faults instead.
+
+Copy `golden-markets.example.json` and give the row a `market` block in place of the domains:
+
+```json
+{
+  "id": "es-installations",
+  "query": "Empresas instaladoras en España: instalaciones eléctricas, fontanería…",
+  "expectedOutput": {
+    "market": {
+      "name": "ES",
+      "parts": [
+        { "id": "electrical", "terms": ["instalacion electrica", "electricidad"] },
+        { "id": "lifts", "terms": ["ascensor", "elevador"] }
+      ],
+      "notCompanies": ["FENIE", "Federación Nacional de Empresarios de Instalaciones de España"]
+    }
+  }
+}
+```
+
+- `name` — what the market is called, and the key the `By market` breakdown groups on. Use whatever tells two markets apart for you; a country code is the obvious choice.
+- `parts` — the things the request asks for, each with the wordings that place a returned row in it. **Request coverage** is how many parts came back with at least one row of the right kind of organisation, so a trade body cannot answer for the trade it represents.
+
+Write the terms accent-free and lower-case. A term of five letters or more also matches words that *begin* with it, so `instalacion electrica` finds "instalaciones eléctricas"; a shorter one must match a whole word, so `gas` never matches "gasto".
+
+That reach only runs downward, which is the thing to remember: `fontaneria` does not find "fontanero", because the term is not the start of the row's word. List the shortest stem, then the other forms a trade is named by — the agent noun ("instalador", "instaladora", "electricista"), the other language a market answers in, and the everyday phrasing ("placas solares" beside "fotovoltaic"). Words must also be adjacent: `contra incendios` does not find "protección activa y pasiva contra el fuego".
+
+Terms match loosely and coverage is a "≥ 1 row" figure, so a single unrelated row can carry a whole part — "alquiler de elevadores para obra" answers lifts, "correduría de seguros contra incendios" answers fire protection. Prefer terms that name the trade rather than its subject matter, and avoid one that is an ordinary word in another field (`pci` is a fire-protection term in Spain and a payments standard everywhere else).
+
+- `notCompanies` — the organisations known **not** to be the kind asked for: the trade bodies, federations, guilds and system operators a search for a trade runs straight through on its way to the members. **Organisation-kind precision** is the share of returned rows that are none of them. Required, and an empty array is a legitimate answer that has to be typed out — a market whose bodies nobody has listed scores a perfect 100%, and that reading must be a stated "none known" rather than something a forgotten key produced.
+
+A row counts as one of them when the listed name appears in the row's name as those words, in that order, next to each other. Whole words, not a run of letters — a body is usually known by its initials, and three letters land inside an unrelated name by accident (`RTE` sits inside "No**rte** Instalaciones").
+
+Three rules follow, and each of them bites:
+
+- **List the name the body is actually known by, in full.** Matching runs one way only: the listed name has to fit inside the row's, never the reverse. A golden entry reading "Federación Nacional de Empresarios de Instalaciones **de España**" misses a row that stops at "…Instalaciones", and one extra word inside the row's name ("Asociación **Provincial** de Instaladores…") defeats an entry written without it.
+- **List the initials as an entry of their own**, where the body is known by them. An acronym shares no words with what it stands for, so the spelled-out entry will never catch a row that gives only the initials.
+- **A one-word entry matches only a row whose whole name is that word.** `FENIE` catches a row called `FENIE`, and deliberately not the retailer `FENIE Energía` — likewise `UNEF` against `Grupo Unef Solar`, or `RTE` against `RTE Ascenseurs`. Counting a real company as a trade body overstates the very problem the figure exists to measure.
+
+What no rule about names can settle: a company genuinely trading under a body's initials reads as the body. Asking the model what an organisation is would settle it; a name cannot.
+
+Two figures ride along beside those. **Duplicate rate** is how many rows are another row's company again, folded on the same identity the pipeline itself uses — the name with its legal form off the end, or a shared website host. It reads zero while that fold holds, which makes it a guard on the fold rather than a second opinion about it.
+
+Read it as "no repeats of the kind those keys can tell", not as "no repeats". A live French market search returned one company under its own name and four more times as that name plus the town of a branch office, none of the four carrying a website — no shared name key, no shared host — and the figure read 0% over a list that plainly repeated one company five times. Widening it needs a hand-marked answer to score against, which is a different measurement.
+
+**Location fill** is how many rows say where the company is. The field is asked for a town or a province, but any stated place counts, so a row answering with the country alone still counts as filled.
+
+The **rows per market** count is still reported, as the scale those figures read against rather than as a grade. It is also what checking that every row is a real company would cost, so it needs a reading of its own before such a check exists.
+
+### What this measures, and what it does not
+
+Organisation-kind precision only counts the bodies your golden set names. A trade body nobody has listed passes through unmeasured, exactly as an unlisted expected field value is not scored — a golden set measures what it knows.
+
+That limit is the point of the **`By market`** breakdown, which prints whenever the pass held a market row and is written to the `--out` report as `byMarket`. The shipped check that reads what kind of organisation a row is works off word lists in Spanish, Catalan and English: measured against fifteen European trade bodies it recognised four. So a Spanish market scores near 100% while a French or German one scores far lower, and the two averaged together hide the fact worth watching. Keep at least one market in a language that check does not read.
 
 ## Four kinds of row to include
 

--- a/eval/golden-markets.example.json
+++ b/eval/golden-markets.example.json
@@ -1,0 +1,153 @@
+[
+	{
+		"id": "es-installations",
+		"query": "Empresas instaladoras en España: instalaciones eléctricas, fontanería y climatización, energía solar fotovoltaica, protección contra incendios y ascensores. Para cada empresa, indica la provincia.",
+		"expectedOutput": {
+			"market": {
+				"name": "ES",
+				"parts": [
+					{
+						"id": "electrical",
+						"terms": [
+							"instalacion electrica",
+							"instalaciones electricas",
+							"instalador electrico",
+							"instaladora electrica",
+							"electricista",
+							"electricidad",
+							"installacions electriques",
+							"instal lacions electriques",
+							"electrical",
+							"electrical installation"
+						]
+					},
+					{
+						"id": "plumbing-heating",
+						"terms": [
+							"fontaneria",
+							"fontanero",
+							"lampisteria",
+							"lampista",
+							"climatizacion",
+							"climatitzacio",
+							"calefaccion",
+							"calefaccio",
+							"plumbing",
+							"hvac"
+						]
+					},
+					{
+						"id": "solar",
+						"terms": [
+							"fotovoltaic",
+							"energia solar",
+							"placas solares",
+							"plaques solars",
+							"autoconsum",
+							"solar energy"
+						]
+					},
+					{
+						"id": "fire-protection",
+						"terms": [
+							"contra incendios",
+							"contra incendis",
+							"contra el fuego",
+							"proteccion pasiva",
+							"fire protection"
+						]
+					},
+					{
+						"id": "lifts",
+						"terms": ["ascensor", "elevador", "elevator"]
+					}
+				],
+				"notCompanies": [
+					"FENIE",
+					"Federacion Nacional de Empresarios de Instalaciones",
+					"CONAIF",
+					"Confederacion Nacional de Asociaciones de Empresas de Fontaneria",
+					"AGREMIA",
+					"ASEFOSAM",
+					"UNEF",
+					"Union Espanola Fotovoltaica",
+					"TECNIFUEGO",
+					"Asociacion Espanola de Sociedades de Proteccion contra Incendios",
+					"Asociacion de Instaladores Electricos y Telecomunicaciones de Ourense",
+					"Red Electrica de Espana"
+				]
+			}
+		}
+	},
+	{
+		"id": "fr-installations",
+		"query": "Entreprises d'installation en France : installations électriques, plomberie et chauffage, solaire photovoltaïque, protection incendie et ascenseurs. Pour chaque entreprise, indiquez le département.",
+		"expectedOutput": {
+			"market": {
+				"name": "FR",
+				"parts": [
+					{
+						"id": "electrical",
+						"terms": [
+							"installation electrique",
+							"installations electriques",
+							"genie electrique",
+							"electricien",
+							"electricite",
+							"electrical installation"
+						]
+					},
+					{
+						"id": "plumbing-heating",
+						"terms": [
+							"plomberie",
+							"plombier",
+							"chauffage",
+							"chauffagiste",
+							"climatisation",
+							"plumbing"
+						]
+					},
+					{
+						"id": "solar",
+						"terms": [
+							"photovoltaique",
+							"energie solaire",
+							"panneaux solaires",
+							"solar energy"
+						]
+					},
+					{
+						"id": "fire-protection",
+						"terms": [
+							"protection incendie",
+							"securite incendie",
+							"fire protection"
+						]
+					},
+					{
+						"id": "lifts",
+						"terms": ["ascensoriste", "ascenseur", "elevateur", "elevator"]
+					}
+				],
+				"notCompanies": [
+					"CAPEB",
+					"Confederation de l'Artisanat et des Petites Entreprises du Batiment",
+					"FFB",
+					"Federation Francaise du Batiment",
+					"FFIE",
+					"Federation Francaise des Entreprises de Genie Electrique et Energetique",
+					"SERCE",
+					"Syndicat des Entreprises de Genie Electrique et Climatique",
+					"Enerplan",
+					"FFMI",
+					"Federation Francaise des Metiers de l'Incendie",
+					"Federation des Ascenseurs",
+					"Enedis",
+					"RTE",
+					"Reseau de Transport d'Electricite"
+				]
+			}
+		}
+	}
+]

--- a/packages/research/src/application/eval-golden.test.ts
+++ b/packages/research/src/application/eval-golden.test.ts
@@ -384,3 +384,233 @@ describe('parseGoldenRow for the company shapes this measures', () => {
 		})
 	})
 })
+
+describe('parseGoldenRow — a row that asks for a whole market', () => {
+	const marketRow = (market: unknown): RawGoldenRow =>
+		row({
+			id: 'es-installations',
+			query: 'Empresas instaladoras en España',
+			expectedOutput: { market },
+		})
+
+	const validMarket = {
+		name: 'ES',
+		parts: [{ id: 'electrical', terms: ['instalacion electrica'] }],
+		notCompanies: ['FENIE'],
+	}
+
+	describe('when the answer carries a well-formed market block', () => {
+		it('should accept it without any company address', () => {
+			// GIVEN a market request, which names no company and so no site to reach
+			const result = parseGoldenRow(marketRow(validMarket))
+
+			// WHEN parsed — THEN it is a golden row, with no domain demanded of it
+			expect(result).toEqual({
+				ok: true,
+				value: {
+					id: 'es-installations',
+					query: 'Empresas instaladoras en España',
+					officialDomain: null,
+					fields: {},
+					market: validMarket,
+				},
+			})
+		})
+	})
+
+	describe('when the answer names neither a company nor a market', () => {
+		it('should reject it and name a market block as one way to be valid', () => {
+			// GIVEN an answer with no domain, no alt domains and no market
+			const result = parseGoldenRow(row({ expectedOutput: { fields: {} } }))
+
+			// WHEN parsed
+			// THEN it fails loudly, and the reason names every way a row can be valid
+			expect(result.ok).toBe(false)
+			if (!result.ok) {
+				expect(result.error).toContain('officialDomain')
+				expect(result.error).toContain('market')
+			}
+		})
+	})
+
+	describe('when the market block is malformed', () => {
+		it.each([
+			['not an object', 'a market', 'market must be a JSON object'],
+			[
+				'missing a name',
+				{ ...validMarket, name: undefined },
+				'market needs a name',
+			],
+			['a blank name', { ...validMarket, name: '  ' }, 'market needs a name'],
+			[
+				'no parts',
+				{ ...validMarket, parts: undefined },
+				'non-empty parts array',
+			],
+			['an empty parts array', { ...validMarket, parts: [] }, 'parts array'],
+			[
+				'a part with no id',
+				{ ...validMarket, parts: [{ terms: ['x'] }] },
+				'each market part needs an id',
+			],
+			[
+				'a part with no terms',
+				{ ...validMarket, parts: [{ id: 'electrical', terms: [] }] },
+				'needs a non-empty terms array',
+			],
+			[
+				'a part whose terms are not strings',
+				{ ...validMarket, parts: [{ id: 'electrical', terms: [7] }] },
+				'needs a non-empty terms array',
+			],
+			[
+				'no notCompanies key',
+				{ ...validMarket, notCompanies: undefined },
+				'notCompanies',
+			],
+			[
+				'notCompanies that is not a list of names',
+				{ ...validMarket, notCompanies: 'FENIE' },
+				'notCompanies',
+			],
+		])('should reject a market with %s', (_case, market, reason) => {
+			// GIVEN a market block with something wrong with it
+			const result = parseGoldenRow(marketRow(market))
+
+			// WHEN parsed
+			// THEN it fails with a reason naming the part at fault. Every market figure
+			// divides by something this block states, so a mis-typed key would not make
+			// one number wrong in a visible way — it would score a whole market clean
+			// for want of anything to check against
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.error).toContain(reason)
+		})
+	})
+
+	describe('when a market knows of no trade bodies yet', () => {
+		it('should accept an empty list, because it has to be stated', () => {
+			// GIVEN a market whose bodies nobody has written down
+			const result = parseGoldenRow(
+				marketRow({ ...validMarket, notCompanies: [] }),
+			)
+
+			// WHEN parsed
+			// THEN it is accepted. That market scores a perfect organisation-kind
+			// precision, and typing the empty list is what makes that a stated "none
+			// known" rather than something a forgotten key produced
+			expect(result.ok).toBe(true)
+			if (result.ok) expect(result.value.market?.notCompanies).toEqual([])
+		})
+	})
+
+	describe('when a row names both a company and a market', () => {
+		it.each([
+			['officialDomain', { officialDomain: 'acme.es' }],
+			['altDomains', { altDomains: ['librebor.es'] }],
+			['fields', { fields: { country: 'ES' } }],
+			['contacts', { contacts: ['Ada Lovelace'] }],
+		])('should refuse a market row that also carries %s', (key, extra) => {
+			// GIVEN a market row that also carries a key which grades a run against one
+			// named company
+			const result = parseGoldenRow(
+				row({ expectedOutput: { market: validMarket, ...extra } }),
+			)
+
+			// WHEN parsed
+			// THEN it fails, naming the key. Each of these turns a correct "does not
+			// apply" into a wrong number: an address makes the scan graded on reaching a
+			// company nobody named, so it reports nought grounding, and a country field
+			// written beside a market already called ES reports nought field recall.
+			// Both read as a pipeline failing rather than as a mistyped row
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.error).toContain(key)
+		})
+	})
+})
+
+describe('parseGoldenSet — the shipped market example', () => {
+	describe('when parsing golden-markets.example.json', () => {
+		it('should parse every row and cover a language the kind check cannot read', () => {
+			// GIVEN the market golden set the eval CLI ships
+			const raw = JSON.parse(
+				readFileSync(
+					new URL(
+						'../../../../eval/golden-markets.example.json',
+						import.meta.url,
+					),
+					'utf8',
+				),
+			) as ReadonlyArray<RawGoldenRow>
+
+			// WHEN parsed
+			const result = parseGoldenSet(raw)
+
+			// THEN nothing is rejected, AND the set holds a market answering in a
+			// language the shipped organisation-kind check reads and one answering in a
+			// language it does not — which is the whole point of a per-market figure.
+			// One market alone would report a healthy number and hide the gap
+			expect(result.errors).toEqual([])
+			const markets = result.golden.map(g => g.market?.name)
+			expect(markets).toContain('ES')
+			expect(markets).toContain('FR')
+			for (const golden of result.golden) {
+				expect(golden.market?.parts.length).toBeGreaterThan(0)
+				expect(golden.market?.notCompanies.length).toBeGreaterThan(0)
+			}
+		})
+	})
+})
+
+describe('parseGoldenRow — a market entry that says nothing', () => {
+	const marketWith = (over: Record<string, unknown>): RawGoldenRow =>
+		row({
+			id: 'es-installations',
+			query: 'Empresas instaladoras en España',
+			expectedOutput: {
+				market: {
+					name: 'ES',
+					parts: [{ id: 'electrical', terms: ['instalacion electrica'] }],
+					notCompanies: ['FENIE'],
+					...over,
+				},
+			},
+		})
+
+	describe('when a part carries a blank term', () => {
+		it('should refuse it rather than accept a part nothing can answer', () => {
+			// GIVEN a term of whitespace, and one of punctuation that survives a blank
+			// check yet still folds to nothing the scorer can match on
+			const result = parseGoldenRow(
+				marketWith({ parts: [{ id: 'solar', terms: ['fotovoltaica', '  '] }] }),
+			)
+			const punctuation = parseGoldenRow(
+				marketWith({ parts: [{ id: 'solar', terms: ['—'] }] }),
+			)
+			expect(punctuation.ok).toBe(false)
+
+			// WHEN parsed
+			// THEN it fails. A blank term can never place a row, so the part would read
+			// unanswered for good and the coverage figure would sit low for a reason
+			// nobody could see in the numbers
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.error).toContain('no words in it')
+		})
+	})
+
+	describe('when a known non-company is blank', () => {
+		it('should refuse it rather than accept a body nobody named', () => {
+			// GIVEN a blank entry, and a punctuation one that folds to nothing
+			const result = parseGoldenRow(marketWith({ notCompanies: ['FENIE', ''] }))
+			const punctuation = parseGoldenRow(
+				marketWith({ notCompanies: ['FENIE', '·'] }),
+			)
+			expect(punctuation.ok).toBe(false)
+
+			// WHEN parsed
+			// THEN it fails. A blank entry matches nothing, so it quietly raises the very
+			// figure it was typed in to lower
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.error).toContain('no words in it')
+		})
+	})
+})

--- a/packages/research/src/application/eval-golden.ts
+++ b/packages/research/src/application/eval-golden.ts
@@ -9,14 +9,24 @@
  * reason per bad row — a typo in the golden data (a mis-spelled field, a missing
  * official domain) has to fail loudly, because a wrong "correct answer" silently
  * poisons every number the harness reports.
+ *
+ * A row asks for a company or for a market, and the answer says which. A company row
+ * names the company's own address, which is the proof a run reached the right one. A
+ * market row names a whole market instead — the parts it asks for and the
+ * organisations known not to be companies there — and needs no address, because there
+ * is no single company for the run to have reached. A row that asks for neither
+ * still fails.
  */
 
 import {
 	GOLDEN_BUCKETS,
 	type GoldenBucket,
 	type GoldenExpectation,
+	type MarketExpectation,
+	type MarketPart,
 	SCORABLE_FIELDS,
 	type ScorableField,
+	termTokens,
 } from './eval-scoring'
 
 /**
@@ -55,6 +65,81 @@ const parseExpectedOutput = (raw: unknown): Record<string, unknown> | null => {
 const isStringArray = (value: unknown): value is ReadonlyArray<string> =>
 	Array.isArray(value) && value.every(item => typeof item === 'string')
 
+type MarketParseResult =
+	| { readonly ok: true; readonly value: MarketExpectation }
+	| { readonly ok: false; readonly error: string }
+
+/**
+ * Validate the block that makes a row a request for a whole market rather than for
+ * one company: what the market is called, the parts it asks for, and the
+ * organisations known not to be companies there.
+ *
+ * As strict as the rest of this file, and for the same reason. Every figure a market
+ * is graded on divides by something this block states, so a mis-typed key does not
+ * make a number wrong in a way anyone would notice — it makes a whole market's
+ * organisation-kind score read a clean 100% for want of anything to check against.
+ */
+const parseMarket = (raw: unknown): MarketParseResult => {
+	const market = asRecord(raw)
+	if (market === null)
+		return { ok: false, error: 'market must be a JSON object' }
+
+	const name = market['name']
+	if (typeof name !== 'string' || name.trim() === '') {
+		return { ok: false, error: 'market needs a name' }
+	}
+
+	const rawParts = market['parts']
+	if (!Array.isArray(rawParts) || rawParts.length === 0) {
+		return { ok: false, error: 'market needs a non-empty parts array' }
+	}
+	const parts: Array<MarketPart> = []
+	for (const item of rawParts) {
+		const part = asRecord(item)
+		const id = part?.['id']
+		if (typeof id !== 'string' || id.trim() === '') {
+			return { ok: false, error: 'each market part needs an id' }
+		}
+		const terms = part?.['terms']
+		if (!isStringArray(terms) || terms.length === 0) {
+			return {
+				ok: false,
+				error: `market part "${id}" needs a non-empty terms array`,
+			}
+		}
+		// Held to the words the scorer reads, not to whether the string looks empty: a
+		// term of punctuation alone survives a blank check and still folds to nothing,
+		// so it could never place a row and the part would read unanswered for good.
+		if (terms.some(term => termTokens(term).length === 0)) {
+			return {
+				ok: false,
+				error: `market part "${id}" has a term with no words in it`,
+			}
+		}
+		parts.push({ id, terms })
+	}
+
+	// Required, not optional, and empty is a legitimate answer that has to be typed
+	// out. A market whose trade bodies nobody has listed yet scores a perfect
+	// organisation-kind precision, and that reading has to be a stated "none known"
+	// rather than something a forgotten key produces by accident.
+	const notCompanies = market['notCompanies']
+	if (!isStringArray(notCompanies)) {
+		return {
+			ok: false,
+			error:
+				'market needs a notCompanies array of the organisations known not to be companies (empty if none are known yet)',
+		}
+	}
+	// Same reading as the terms above. An entry that folds to no words matches
+	// nothing, so it quietly raises the very figure it was typed in to lower.
+	if (notCompanies.some(entry => termTokens(entry).length === 0)) {
+		return { ok: false, error: 'a notCompanies entry has no words in it' }
+	}
+
+	return { ok: true, value: { name, parts, notCompanies } }
+}
+
 /** Validate one raw row into a `GoldenExpectation`, or explain why it can't be. */
 export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 	if (row.query.trim().length === 0) {
@@ -65,9 +150,48 @@ export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 		return { ok: false, error: 'expected output is not a JSON object' }
 	}
 
+	// Which question this row asks is settled before anything else is checked, so a
+	// row that asks the wrong two at once is told that first rather than being sent
+	// away to correct the spelling of a key it should not carry at all.
+	//
+	// A row asks about one company or about a market, never both. Every company key
+	// beside a market block turns a correct "does not apply" into a wrong number: an
+	// address makes the search graded on reaching a company nobody named, so it
+	// reports nought grounding, and a `fields: { country: "ES" }` written next to a
+	// market already called ES reports nought field recall and invents a country
+	// group. Both read as the pipeline failing, which is why this refuses rather than
+	// picking one meaning. A key present but carrying nothing claims nothing, so it
+	// is not the conflict.
+	const rawMarket = answer['market']
+	const claimsSomething = (value: unknown): boolean =>
+		value !== undefined && (!Array.isArray(value) || value.length > 0)
+	if (rawMarket !== undefined) {
+		const alsoNamed = [
+			'officialDomain',
+			'altDomains',
+			'fields',
+			'contacts',
+		].filter(key => claimsSomething(answer[key]))
+		if (alsoNamed.length > 0) {
+			return {
+				ok: false,
+				error: `a market row cannot also carry ${alsoNamed.join(', ')} — those grade a run against one named company`,
+			}
+		}
+	}
+
 	const rawAltDomains = answer['altDomains']
 	if (rawAltDomains !== undefined && !isStringArray(rawAltDomains)) {
 		return { ok: false, error: 'altDomains must be an array of strings' }
+	}
+
+	// A row asking for a whole market names no one company, so there is no company
+	// site for the run to have reached and no address to demand of it below.
+	let market: MarketExpectation | undefined
+	if (rawMarket !== undefined) {
+		const parsed = parseMarket(rawMarket)
+		if (!parsed.ok) return { ok: false, error: parsed.error }
+		market = parsed.value
 	}
 
 	// A row has to name at least one address that proves the run reached the right
@@ -82,11 +206,15 @@ export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 			? rawOfficialDomain
 			: null
 	const altDomains = rawAltDomains ?? []
-	if (officialDomain === null && altDomains.length === 0) {
+	if (
+		market === undefined &&
+		officialDomain === null &&
+		altDomains.length === 0
+	) {
 		return {
 			ok: false,
 			error:
-				'expected output needs an officialDomain, or altDomains for a company with no website of its own',
+				'expected output needs an officialDomain, or altDomains for a company with no website of its own, or a market block for a request that asks for a whole market',
 		}
 	}
 
@@ -155,6 +283,7 @@ export const parseGoldenRow = (row: RawGoldenRow): GoldenParseResult => {
 			fields,
 			...(contacts.length > 0 ? { contacts } : {}),
 			...(rawBucket !== undefined ? { bucket: rawBucket as GoldenBucket } : {}),
+			...(market !== undefined ? { market } : {}),
 		},
 	}
 }

--- a/packages/research/src/application/eval-outcome.test.ts
+++ b/packages/research/src/application/eval-outcome.test.ts
@@ -162,6 +162,23 @@ describe('outcomeFromRun', () => {
 		})
 	})
 
+	describe('when a run never came back at all', () => {
+		it('should adapt it rather than throwing', () => {
+			// GIVEN a run the poll gave up on, which reaches here with no findings —
+			// the path a long market search ends on when it outlives its time limit
+			const outcome = outcomeFromRun({
+				status: 'failed',
+				findings: null,
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN it scores as a failed run instead of ending the pass
+			expect(outcome.status).toBe('failed')
+			expect(outcome.contacts).toEqual([])
+			expect(outcome.companies).toEqual([])
+		})
+	})
+
 	describe('when the run answered with a list of companies', () => {
 		it('should read the companies a scan found, and whether each has a site', () => {
 			// GIVEN a prospect scan that came back with three companies, two of them
@@ -185,9 +202,19 @@ describe('outcomeFromRun', () => {
 			// profile block made every scan look like a run that found nothing, which
 			// is why no scan could ever be measured
 			expect(outcome.companies).toEqual([
-				{ name: 'Acme', hasWebsite: true },
-				{ name: 'Beta', hasWebsite: false },
-				{ name: 'Gamma', hasWebsite: true },
+				{
+					name: 'Acme',
+					website: 'https://acme.test',
+					location: null,
+					describedAs: '',
+				},
+				{ name: 'Beta', website: null, location: null, describedAs: '' },
+				{
+					name: 'Gamma',
+					website: 'https://gamma.test',
+					location: null,
+					describedAs: '',
+				},
 			])
 		})
 
@@ -202,6 +229,156 @@ describe('outcomeFromRun', () => {
 
 			// WHEN adapted — THEN there is no list to read, and the shape decides that
 			expect(outcome.companies).toEqual([])
+		})
+
+		it('should measure profile fullness only on a shape that was given a profile', () => {
+			// GIVEN the same findings read as a search and as a profile run
+			const asScan = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: { prospects: [{ name: 'Alfa SL' }] },
+				fetchedUrls: [],
+			})
+			const asProfile = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'company_enrichment_v1',
+				findings: { enrichment: {} },
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted
+			// THEN only the profile run carries one. A search is never given a profile,
+			// so counting it reports every search as having filled none of a shape
+			// nobody asked it for; a profile run that came back empty is a real nought
+			// and still counts
+			expect(asScan.profile).toBeUndefined()
+			expect(asProfile.profile).toBeDefined()
+			expect(asProfile.profile?.fieldsFilled).toBe(0)
+		})
+
+		it('should keep a row whose name arrives wrapped with its source', () => {
+			// GIVEN a row whose name carries its citation, the shape a field takes once
+			// citations travel per field
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: { prospects: [{ name: { value: 'Alfa SL' } }] },
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN the row is read rather than skipped for its shape
+			expect(outcome.companies[0]?.name).toBe('Alfa SL')
+		})
+	})
+})
+
+describe('outcomeFromRun — what a scan row carries for the market figures', () => {
+	describe('when a prospect row describes itself', () => {
+		it('should carry every field the row says what it does in', () => {
+			// GIVEN a prospect row filled the way the scan shape asks for it
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: {
+					prospects: [
+						{
+							name: 'Instalaciones Alfa SL',
+							website: 'https://alfa.example',
+							industry: 'Instalaciones eléctricas',
+							why_relevant: 'Instalador eléctrico industrial en Córdoba',
+							location: 'Córdoba',
+						},
+					],
+				},
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted
+			// THEN the trade and the relevance note are run together. The note is read
+			// even though it is where a row can repeat the request back, because it is
+			// the only one of the three a prospect must fill — leaving it out silenced
+			// every row that stated its trade nowhere else
+			expect(outcome.companies).toEqual([
+				{
+					name: 'Instalaciones Alfa SL',
+					website: 'https://alfa.example',
+					location: 'Córdoba',
+					describedAs:
+						'Instalaciones eléctricas Instalador eléctrico industrial en Córdoba',
+				},
+			])
+		})
+	})
+
+	describe('when a competitor row describes itself', () => {
+		it('should read the description that shape uses instead', () => {
+			// GIVEN a competitor row, whose own words live under a different field name
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'competitor_scan_v1',
+				findings: {
+					competitors: [
+						{ name: 'Beta SL', description: 'Ascensores y elevadores' },
+					],
+				},
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN it is read too, so neither shape goes unattributed to
+			// the part of a request it answers for the want of a field name
+			expect(outcome.companies[0]?.describedAs).toBe('Ascensores y elevadores')
+		})
+	})
+
+	describe('when a row states a field but leaves it blank', () => {
+		it('should read it as absent rather than as a value', () => {
+			// GIVEN a row whose location and website are whitespace
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: {
+					prospects: [{ name: 'Alfa SL', website: '  ', location: '\t' }],
+				},
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN neither counts as stated, so a blank never inflates
+			// the share of rows that say where the company is
+			expect(outcome.companies[0]?.website).toBeNull()
+			expect(outcome.companies[0]?.location).toBeNull()
+		})
+	})
+
+	describe('when a field arrives wrapped with its source', () => {
+		it('should read the value inside', () => {
+			// GIVEN a location carried as a { value } wrapper, the shape a field takes
+			// once its citation travels with it
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: {
+					prospects: [{ name: 'Alfa SL', location: { value: 'Málaga' } }],
+				},
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN the adapter is indifferent to which shape produced it
+			expect(outcome.companies[0]?.location).toBe('Málaga')
+		})
+	})
+
+	describe('when a row describes itself in none of the three fields', () => {
+		it('should leave its words empty rather than absent', () => {
+			// GIVEN a row with a name and nothing else
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: { prospects: [{ name: 'Alfa SL' }] },
+				fetchedUrls: [],
+			})
+
+			// WHEN adapted — THEN there is a string to search, holding nothing
+			expect(outcome.companies[0]?.describedAs).toBe('')
 		})
 	})
 })

--- a/packages/research/src/application/eval-outcome.ts
+++ b/packages/research/src/application/eval-outcome.ts
@@ -11,7 +11,7 @@
  * so a per-field-citation schema change lands here and the scorer's metrics stay put.
  */
 
-import { discoveryRows } from './discovery-scan'
+import { discoveryRows, isDiscoveryScan } from './discovery-scan'
 import {
 	type RunOutcome,
 	type RunUsage,
@@ -47,6 +47,37 @@ const readFieldValue = (raw: unknown): string | null => {
 	const inner = unwrapValue(raw)
 	return typeof inner === 'string' ? inner : null
 }
+
+/** A field's value, or null when it is missing or says nothing. */
+const readFilled = (raw: unknown): string | null => {
+	const value = readFieldValue(raw)
+	return value === null || value.trim() === '' ? null : value.trim()
+}
+
+/**
+ * Where a scan's row says what it does, run together so a row counts towards its
+ * trade whichever field the run wrote that trade into. A prospect gives the trade it
+ * was filed under and why it matched; a competitor gives a description instead.
+ *
+ * The relevance note is read even though it is the field most likely to repeat the
+ * request back, because leaving it out measured something worse. It is the only one
+ * of the three a prospect must fill: on a live pass 24 of 53 rows stated a trade and
+ * every other row said what it did only there, so without it more than half the list
+ * counted for nothing and the coverage figure turned into a reading of how often an
+ * optional field got filled.
+ *
+ * What that costs is stated plainly: a row naming several trades counts towards each
+ * one. That is right for an installer who genuinely does them all — the live pass has
+ * rows authorised for four — and generous towards a row that merely lists back what
+ * was asked for. The failure this figure has to catch survives either way, because a
+ * trade no row mentions at all still reads unanswered.
+ */
+const TRADE_FIELDS = ['industry', 'why_relevant', 'description'] as const
+
+const describedAs = (row: Record<string, unknown>): string =>
+	TRADE_FIELDS.map(field => readFilled(row[field]))
+		.filter(value => value !== null)
+		.join(' ')
 
 const enrichmentOf = (
 	findings: unknown,
@@ -85,7 +116,10 @@ export const outcomeFromRun = (input: {
 	// title it found or null — so the scorer can measure how many known contacts
 	// came back with a title.
 	const contacts: Array<{ name: string; role: string | null }> = []
-	const rawContacts = (findings as { contacts?: unknown }).contacts
+	const rawContacts =
+		findings !== null && typeof findings === 'object'
+			? (findings as { contacts?: unknown }).contacts
+			: undefined
 	if (Array.isArray(rawContacts)) {
 		for (const contact of rawContacts) {
 			if (contact === null || typeof contact !== 'object') continue
@@ -112,20 +146,30 @@ export const outcomeFromRun = (input: {
 		(findings as { registry_confirmed?: unknown }).registry_confirmed === true
 
 	// The companies a scan came back with, which is the whole of a scan's answer
-	// and so the only thing a scan can be scored on.
-	const companies: Array<{ name: string; hasWebsite: boolean }> = []
+	// and so the only thing a scan can be scored on. A row with no name is left out:
+	// there is nothing to tell it from another row, so counting it would make every
+	// nameless row a company of its own.
+	const companies: Array<{
+		name: string
+		website: string | null
+		location: string | null
+		describedAs: string
+	}> = []
 	for (const row of discoveryRows(input.schemaName, findings)) {
-		const name = (row as { name?: unknown }).name
-		if (typeof name !== 'string' || name.trim() === '') continue
-		const website = (row as { website?: unknown }).website
+		const name = readFieldValue(row['name'])
+		if (name === null || name.trim() === '') continue
 		companies.push({
 			name: name.trim(),
-			hasWebsite: typeof website === 'string' && website.trim() !== '',
+			website: readFilled(row['website']),
+			location: readFilled(row['location']),
+			describedAs: describedAs(row),
 		})
 	}
 
 	const profileFill = enrichmentFill(findings)
 	const people = contactFill(findings)
+	const isScan =
+		input.schemaName !== undefined && isDiscoveryScan(input.schemaName)
 
 	return {
 		status: toTerminalStatus(input.status),
@@ -134,12 +178,23 @@ export const outcomeFromRun = (input: {
 		contacts,
 		companies,
 		registryConfirmed,
-		profile: {
-			fieldsTotal: profileFill.total,
-			fieldsFilled: profileFill.filled,
-			contactsNamed: people.named,
-			contactsTitled: people.titled,
-		},
+		// Only a run that was asked for a profile is measured on how full it came back.
+		// A search answers with a list and is never given one, so counting it reports
+		// every search as having filled none of a shape nobody asked it for — a failing
+		// grade where the honest answer is that it does not apply. What decides it is
+		// the shape the run answered in, not whether the findings happen to carry a
+		// profile: a run that was asked and came back with nothing has no block either,
+		// and dropping it would lift the average by hiding the worst runs.
+		...(isScan
+			? {}
+			: {
+					profile: {
+						fieldsTotal: profileFill.total,
+						fieldsFilled: profileFill.filled,
+						contactsNamed: people.named,
+						contactsTitled: people.titled,
+					},
+				}),
 		...(input.usage !== undefined ? { usage: input.usage } : {}),
 	}
 }

--- a/packages/research/src/application/eval-report.test.ts
+++ b/packages/research/src/application/eval-report.test.ts
@@ -6,11 +6,12 @@ import {
 	evalSummaryAttributes,
 	scorePayloadsForRun,
 } from './eval-report'
-import type { RunScore } from './eval-scoring'
+import type { EvalSummary, RunScore } from './eval-scoring'
 
 const score = (over: Partial<RunScore>): RunScore => ({
 	id: 'r',
 	grounded: true,
+	groundable: true,
 	wrongCompany: false,
 	wrongCompanyAutoApplicable: false,
 	lowConfidence: false,
@@ -171,6 +172,11 @@ describe('evalSummaryAttributes', () => {
 				contactsTitledPerRun: null,
 				lowConfidenceRate: 0,
 				wrongCompanyAutoApplicableRate: 0,
+				organisationKindPrecision: null,
+				requestCoverage: null,
+				duplicateRate: null,
+				locationFill: null,
+				rowsPerScan: null,
 				callsByModel: {},
 				cascadedRunRate: 0,
 			})
@@ -208,6 +214,11 @@ describe('evalSummaryAttributes', () => {
 				contactsTitledPerRun: null,
 				lowConfidenceRate: 0,
 				wrongCompanyAutoApplicableRate: 0,
+				organisationKindPrecision: null,
+				requestCoverage: null,
+				duplicateRate: null,
+				locationFill: null,
+				rowsPerScan: null,
 				callsByModel: {},
 				cascadedRunRate: null,
 			})
@@ -263,6 +274,226 @@ describe('buildEvalReport', () => {
 			// THEN it falls into the explicit fallback groups, never dropped
 			expect(Object.keys(report.byBucket)).toEqual(['untagged'])
 			expect(Object.keys(report.byCountry)).toEqual(['unknown'])
+		})
+	})
+})
+
+describe('reporting a pass that held market requests', () => {
+	const marketScore = (over: Partial<RunScore['market']> = {}): RunScore =>
+		score({
+			groundable: false,
+			grounded: false,
+			market: {
+				name: 'ES',
+				rowsReturned: 62,
+				rowsRightKind: 39,
+				rowsLocated: 25,
+				rowsDuplicated: 10,
+				partsExpected: 5,
+				partsAnswered: 1,
+				...over,
+			},
+		})
+
+	describe('when a market run is turned into per-run scores', () => {
+		it('should score the list and leave out the questions it was never asked', () => {
+			// GIVEN a market request, which names no company to have reached
+			const payloads = byName(scorePayloadsForRun(marketScore()))
+
+			// WHEN mapped
+			// THEN the list is graded on what was wrong with it, and grounding is
+			// absent rather than scored nought — a market run cannot fail to reach a
+			// company nobody named
+			expect(payloads.get('organisation_kind_precision')).toMatchObject({
+				value: 39 / 62,
+				passed: false,
+			})
+			expect(payloads.get('request_coverage')).toMatchObject({
+				value: 0.2,
+				passed: false,
+			})
+			expect(payloads.get('not_duplicated')).toMatchObject({
+				value: 1 - 10 / 62,
+				passed: false,
+			})
+			expect(payloads.get('location_fill')).toMatchObject({ value: 25 / 62 })
+			expect(payloads.has('grounding')).toBe(false)
+			expect(payloads.has('not_wrong_company')).toBe(false)
+		})
+
+		it('should still score a clean list as passed', () => {
+			// GIVEN a market whose every row is a company, located, and unique
+			const payloads = byName(
+				scorePayloadsForRun(
+					marketScore({
+						rowsReturned: 10,
+						rowsRightKind: 10,
+						rowsLocated: 10,
+						rowsDuplicated: 0,
+						partsAnswered: 5,
+					}),
+				),
+			)
+
+			// WHEN mapped — THEN every market metric is 1 and passed, the same
+			// direction as every other metric here
+			for (const name of [
+				'organisation_kind_precision',
+				'request_coverage',
+				'not_duplicated',
+				'location_fill',
+			]) {
+				expect(payloads.get(name)).toMatchObject({ value: 1, passed: true })
+			}
+		})
+	})
+
+	describe('when a market came back with no rows', () => {
+		it('should still report the coverage and leave out the per-row scores', () => {
+			// GIVEN a market request that returned nothing
+			const payloads = byName(
+				scorePayloadsForRun(
+					marketScore({
+						rowsReturned: 0,
+						rowsRightKind: 0,
+						rowsLocated: 0,
+						rowsDuplicated: 0,
+						partsAnswered: 0,
+					}),
+				),
+			)
+
+			// WHEN mapped
+			// THEN "none of the five parts was answered" is a reading worth sending;
+			// the other three have nothing to divide by, so they are absent rather
+			// than a zero that reads as a quality collapse
+			expect(payloads.get('request_coverage')).toMatchObject({ value: 0 })
+			expect(payloads.has('organisation_kind_precision')).toBe(false)
+			expect(payloads.has('not_duplicated')).toBe(false)
+			expect(payloads.has('location_fill')).toBe(false)
+		})
+	})
+
+	describe('when a market run becomes span attributes', () => {
+		it('should carry the market and its counts for grouping', () => {
+			// GIVEN a market run's score
+			const attrs = evalSpanAttributes(marketScore())
+
+			// WHEN flattened — THEN a chart can group by market and read both the
+			// counts and the rates off one span
+			expect(attrs['eval.market']).toBe('ES')
+			expect(attrs['eval.rows_returned']).toBe(62)
+			expect(attrs['eval.rows_right_kind']).toBe(39)
+			expect(attrs['eval.rows_duplicated']).toBe(10)
+			expect(attrs['eval.rows_located']).toBe(25)
+			expect(attrs['eval.parts_answered']).toBe(1)
+			expect(attrs['eval.request_coverage']).toBe(0.2)
+		})
+
+		it('should carry no market attributes for a company run', () => {
+			// GIVEN an ordinary company run
+			const attrs = evalSpanAttributes(score({}))
+
+			// WHEN flattened — THEN nothing about a market rides along
+			expect('eval.market' in attrs).toBe(false)
+			expect('eval.rows_returned' in attrs).toBe(false)
+		})
+	})
+
+	describe('when the whole-pass summary becomes span attributes', () => {
+		const summary = (over: Partial<EvalSummary>): EvalSummary => ({
+			runs: 2,
+			groundingAccuracy: null,
+			wrongCompanyRate: 0,
+			wrongCompanyAutoApplicableRate: 0,
+			lowConfidenceRate: 0,
+			emptyRate: 0,
+			fieldPrecision: null,
+			fieldRecall: null,
+			contactRecall: null,
+			organisationKindPrecision: null,
+			requestCoverage: null,
+			duplicateRate: null,
+			locationFill: null,
+			rowsPerScan: null,
+			fieldsFilledPerRun: null,
+			profileFieldsTotal: null,
+			contactsNamedPerRun: null,
+			contactsTitledPerRun: null,
+			costPerRun: null,
+			costPerGroundedRun: null,
+			paidCostPerRun: null,
+			tokensPerRun: null,
+			creditsPerRun: null,
+			callsByModel: {},
+			cascadedRunRate: null,
+			...over,
+		})
+
+		it('should omit grounding accuracy when no run was asked to reach a company', () => {
+			// GIVEN a pass made only of market requests
+			const attrs = evalSummaryAttributes(summary({ groundingAccuracy: null }))
+
+			// WHEN flattened — THEN grounding is left off rather than charted as a nought
+			expect('eval.grounding_accuracy' in attrs).toBe(false)
+		})
+
+		it('should carry each market rate that has a reading', () => {
+			// GIVEN a market pass with figures
+			const attrs = evalSummaryAttributes(
+				summary({
+					organisationKindPrecision: 0.63,
+					requestCoverage: 0.2,
+					duplicateRate: 0.16,
+					locationFill: 0.4,
+					rowsPerScan: 62,
+				}),
+			)
+
+			// WHEN flattened — THEN the drift chart has every market figure
+			expect(attrs['eval.organisation_kind_precision']).toBe(0.63)
+			expect(attrs['eval.request_coverage']).toBe(0.2)
+			expect(attrs['eval.duplicate_rate']).toBe(0.16)
+			expect(attrs['eval.location_fill']).toBe(0.4)
+			expect(attrs['eval.rows_per_scan']).toBe(62)
+		})
+
+		it('should omit every market rate on a pass that held no market', () => {
+			// GIVEN an ordinary pass of company profiles
+			const attrs = evalSummaryAttributes(summary({ groundingAccuracy: 1 }))
+
+			// WHEN flattened — THEN no market figure is charted as a zero
+			expect('eval.organisation_kind_precision' in attrs).toBe(false)
+			expect('eval.request_coverage' in attrs).toBe(false)
+			expect('eval.duplicate_rate' in attrs).toBe(false)
+			expect('eval.location_fill' in attrs).toBe(false)
+			expect('eval.rows_per_scan' in attrs).toBe(false)
+		})
+	})
+
+	describe('when the report is built', () => {
+		it('should break the figures out per market', () => {
+			// GIVEN two markets in one pass, one of which the shipped kind check reads
+			// and one of which it does not
+			const report = buildEvalReport([
+				marketScore({ name: 'ES', rowsReturned: 10, rowsRightKind: 10 }),
+				marketScore({ name: 'FR', rowsReturned: 10, rowsRightKind: 4 }),
+			])
+
+			// WHEN built
+			// THEN each market keeps its own reading. Averaged together they read 70%
+			// and the gap that matters — a check that reads three languages — disappears
+			expect(report.byMarket['ES']?.organisationKindPrecision).toBe(1)
+			expect(report.byMarket['FR']?.organisationKindPrecision).toBe(0.4)
+		})
+
+		it('should hold no markets for a pass of company profiles', () => {
+			// GIVEN an ordinary pass
+			const report = buildEvalReport([score({}), score({})])
+
+			// WHEN built — THEN there is no market breakdown at all, rather than one
+			// bucket of company rows pretending to be a market
+			expect(report.byMarket).toEqual({})
 		})
 	})
 })

--- a/packages/research/src/application/eval-report.ts
+++ b/packages/research/src/application/eval-report.ts
@@ -36,24 +36,13 @@ const boolPayload = (
 })
 
 /**
- * The scores for one run: the three yes/no checks as 0/1, plus precision and recall
- * only where there was something to judge (a run that filled nothing has no
- * precision, a company with no known fields has no recall).
+ * The scores for one run: the yes/no checks as 0/1, plus a rate only where there was
+ * something to judge (a run that filled nothing has no precision, a company with no
+ * known fields has no recall, a market that came back with no rows has nothing to
+ * judge row by row).
  */
 export const scorePayloadsForRun = (score: RunScore): ScorePayload[] => {
 	const payloads: ScorePayload[] = [
-		boolPayload(
-			'grounding',
-			score.grounded,
-			'reached the target company',
-			'did not reach the target company',
-		),
-		boolPayload(
-			'not_wrong_company',
-			!score.wrongCompany,
-			'data came from the target',
-			'returned another company as a success',
-		),
 		boolPayload(
 			'not_empty',
 			!score.empty,
@@ -61,6 +50,25 @@ export const scorePayloadsForRun = (score: RunScore): ScorePayload[] => {
 			'returned no usable data',
 		),
 	]
+	// Both of these ask about the one company the run was sent after, so a market
+	// request has no answer to give. Sending them anyway would file every market run
+	// as having failed to reach a company nobody named.
+	if (score.groundable) {
+		payloads.push(
+			boolPayload(
+				'grounding',
+				score.grounded,
+				'reached the target company',
+				'did not reach the target company',
+			),
+			boolPayload(
+				'not_wrong_company',
+				!score.wrongCompany,
+				'data came from the target',
+				'returned another company as a success',
+			),
+		)
+	}
 	if (score.fieldsScored > 0) {
 		payloads.push({
 			name: 'field_precision',
@@ -88,17 +96,63 @@ export const scorePayloadsForRun = (score: RunScore): ScorePayload[] => {
 			feedback: `${score.contactsFound}/${score.contactsExpected} known contacts found with a title`,
 		})
 	}
+	// What a market request is graded on. Coverage rides on the parts asked for, so
+	// it reports even when the list came back empty — nothing found is the answer
+	// there, not the absence of one. The other three divide by the rows, so they only
+	// ride when there were rows to judge.
+	const market = score.market
+	if (market !== undefined) {
+		if (market.partsExpected > 0) {
+			payloads.push({
+				name: 'request_coverage',
+				value: market.partsAnswered / market.partsExpected,
+				passed: market.partsAnswered === market.partsExpected,
+				feedback: `${market.partsAnswered}/${market.partsExpected} requested parts answered`,
+			})
+		}
+		if (market.rowsReturned > 0) {
+			payloads.push(
+				{
+					name: 'organisation_kind_precision',
+					value: market.rowsRightKind / market.rowsReturned,
+					passed: market.rowsRightKind === market.rowsReturned,
+					feedback: `${market.rowsRightKind}/${market.rowsReturned} rows are the kind of organisation asked for`,
+				},
+				{
+					name: 'not_duplicated',
+					value: 1 - market.rowsDuplicated / market.rowsReturned,
+					passed: market.rowsDuplicated === 0,
+					feedback: `${market.rowsDuplicated}/${market.rowsReturned} rows are another row's company again`,
+				},
+				{
+					name: 'location_fill',
+					value: market.rowsLocated / market.rowsReturned,
+					passed: market.rowsLocated === market.rowsReturned,
+					feedback: `${market.rowsLocated}/${market.rowsReturned} rows say what town or province the company is in`,
+				},
+			)
+		}
+	}
 	return payloads
 }
 
 /** The offline baseline report: the aggregate rates plus every run's raw score,
- * and the same rates broken out by size/reach bucket and by country so a
+ * and the same rates broken out by size/reach bucket, by country and by market so a
  * regression confined to one segment is visible rather than averaged away. */
 export interface EvalReport {
 	readonly summary: EvalSummary
 	readonly runs: ReadonlyArray<RunScore>
 	readonly byBucket: Record<string, EvalSummary>
 	readonly byCountry: Record<string, EvalSummary>
+	/**
+	 * The market figures per market, which is the breakdown they exist for: the
+	 * organisation-kind guard reads Spanish, Catalan and English, so a market
+	 * answering in one of those scores near 100% while one answering in French or
+	 * German scores far lower. Averaged across markets that difference disappears,
+	 * which is exactly the fact worth watching. Empty for a pass that held no market
+	 * request.
+	 */
+	readonly byMarket: Record<string, EvalSummary>
 }
 
 export const buildEvalReport = (
@@ -108,6 +162,10 @@ export const buildEvalReport = (
 	runs: scores,
 	byBucket: groupSummaries(scores, score => score.bucket ?? 'untagged'),
 	byCountry: groupSummaries(scores, score => score.country ?? 'unknown'),
+	byMarket: groupSummaries(
+		scores.filter(score => score.market !== undefined),
+		score => score.market?.name ?? 'unknown',
+	),
 })
 
 /**
@@ -122,14 +180,20 @@ export const evalSpanAttributes = (
 ): Record<string, string | number | boolean> => {
 	const attributes: Record<string, string | number | boolean> = {
 		'eval.company_id': score.id,
-		'eval.grounded': score.grounded,
-		'eval.wrong_company': score.wrongCompany,
 		'eval.empty': score.empty,
 		'eval.fields_expected': score.fieldsExpected,
 		'eval.fields_scored': score.fieldsScored,
 		'eval.fields_correct': score.fieldsCorrect,
 		'eval.contacts_expected': score.contactsExpected,
 		'eval.contacts_found': score.contactsFound,
+	}
+	// These two ask about the one company the run was sent after, and a chart
+	// averages them. A market request has no such company, so charting it as a false
+	// on both drags the board's grounding line down for runs that were never asked
+	// the question — the same rule the rates below already follow.
+	if (score.groundable) {
+		attributes['eval.grounded'] = score.grounded
+		attributes['eval.wrong_company'] = score.wrongCompany
 	}
 	if (score.bucket !== undefined) attributes['eval.bucket'] = score.bucket
 	if (score.country !== undefined) attributes['eval.country'] = score.country
@@ -143,6 +207,33 @@ export const evalSpanAttributes = (
 	if (score.contactsExpected > 0) {
 		attributes['eval.contact_recall'] =
 			score.contactsFound / score.contactsExpected
+	}
+	// A market request's own counts, so a chart can group by market and watch the
+	// figure that says whether a change reached a language the checks cannot read.
+	// The rates ride only where there was something to divide by, the same rule as
+	// above, so a market that came back with nothing charts no precision rather than
+	// a zero that reads as a quality collapse.
+	const market = score.market
+	if (market !== undefined) {
+		attributes['eval.market'] = market.name
+		attributes['eval.rows_returned'] = market.rowsReturned
+		attributes['eval.rows_right_kind'] = market.rowsRightKind
+		attributes['eval.rows_located'] = market.rowsLocated
+		attributes['eval.rows_duplicated'] = market.rowsDuplicated
+		attributes['eval.parts_expected'] = market.partsExpected
+		attributes['eval.parts_answered'] = market.partsAnswered
+		if (market.partsExpected > 0) {
+			attributes['eval.request_coverage'] =
+				market.partsAnswered / market.partsExpected
+		}
+		if (market.rowsReturned > 0) {
+			attributes['eval.organisation_kind_precision'] =
+				market.rowsRightKind / market.rowsReturned
+			attributes['eval.duplicate_rate'] =
+				market.rowsDuplicated / market.rowsReturned
+			attributes['eval.location_fill'] =
+				market.rowsLocated / market.rowsReturned
+		}
 	}
 	return attributes
 }
@@ -158,12 +249,21 @@ export const evalSummaryAttributes = (
 ): Record<string, string | number | boolean> => {
 	const attributes: Record<string, string | number | boolean> = {
 		'eval.runs': summary.runs,
-		'eval.grounding_accuracy': summary.groundingAccuracy,
-		'eval.wrong_company_rate': summary.wrongCompanyRate,
-		'eval.wrong_company_auto_applicable_rate':
-			summary.wrongCompanyAutoApplicableRate,
 		'eval.low_confidence_rate': summary.lowConfidenceRate,
 		'eval.empty_rate': summary.emptyRate,
+	}
+	// Grounding and the two look-alike rates are all about the one company a run was
+	// sent after, so a pass of market requests has no reading for any of them and
+	// charts none rather than a nought that reads as a collapse.
+	if (summary.groundingAccuracy !== null) {
+		attributes['eval.grounding_accuracy'] = summary.groundingAccuracy
+	}
+	if (summary.wrongCompanyRate !== null) {
+		attributes['eval.wrong_company_rate'] = summary.wrongCompanyRate
+	}
+	if (summary.wrongCompanyAutoApplicableRate !== null) {
+		attributes['eval.wrong_company_auto_applicable_rate'] =
+			summary.wrongCompanyAutoApplicableRate
 	}
 	if (summary.fieldsFilledPerRun !== null) {
 		attributes['eval.fields_filled_per_run'] = summary.fieldsFilledPerRun
@@ -185,6 +285,22 @@ export const evalSummaryAttributes = (
 	}
 	if (summary.contactRecall !== null) {
 		attributes['eval.contact_recall'] = summary.contactRecall
+	}
+	if (summary.organisationKindPrecision !== null) {
+		attributes['eval.organisation_kind_precision'] =
+			summary.organisationKindPrecision
+	}
+	if (summary.requestCoverage !== null) {
+		attributes['eval.request_coverage'] = summary.requestCoverage
+	}
+	if (summary.duplicateRate !== null) {
+		attributes['eval.duplicate_rate'] = summary.duplicateRate
+	}
+	if (summary.locationFill !== null) {
+		attributes['eval.location_fill'] = summary.locationFill
+	}
+	if (summary.rowsPerScan !== null) {
+		attributes['eval.rows_per_scan'] = summary.rowsPerScan
 	}
 	if (summary.costPerRun !== null) {
 		attributes['eval.cost_cents_per_run'] = summary.costPerRun

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	type GoldenExpectation,
 	groupSummaries,
+	type MarketExpectation,
 	type RunOutcome,
 	type RunScore,
 	scoreRun,
@@ -27,6 +28,35 @@ const outcome = (over: Partial<RunOutcome>): RunOutcome => ({
 	contacts: [],
 	companies: [],
 	...over,
+})
+
+// One row of a scan's list. Named and otherwise blank by default, so each test
+// states only the field it is about.
+const company = (
+	over: Partial<RunOutcome['companies'][number]> & { name: string },
+): RunOutcome['companies'][number] => ({
+	website: null,
+	location: null,
+	describedAs: '',
+	...over,
+})
+
+// A golden row that asks for a whole market rather than one company: no site of its
+// own to have been reached, and a list of parts and known non-companies instead.
+const marketGolden = (
+	market: Partial<MarketExpectation> = {},
+): GoldenExpectation => ({
+	id: 'es-installations',
+	query: 'Empresas instaladoras en España',
+	officialDomain: null,
+	fields: {},
+	market: {
+		name: market.name ?? 'ES',
+		parts: market.parts ?? [
+			{ id: 'electrical', terms: ['instalacion electrica'] },
+		],
+		notCompanies: market.notCompanies ?? [],
+	},
 })
 
 describe('scoreRun', () => {
@@ -508,10 +538,501 @@ describe('scoreRun', () => {
 	})
 })
 
+describe('scoring a run that answered for a whole market', () => {
+	describe('when the golden row names a market rather than a company', () => {
+		it('should not count reaching a company as a question it failed', () => {
+			// GIVEN a market request, which names no company to reach
+			const score = scoreRun(
+				marketGolden(),
+				outcome({ reachedDomains: [], companies: [company({ name: 'Alfa' })] }),
+			)
+
+			// WHEN scored
+			// THEN grounding is marked as not asked rather than not achieved. Counting
+			// it would report a whole market pass at nought for answering the question
+			// it was actually given
+			expect(score.groundable).toBe(false)
+			expect(score.grounded).toBe(false)
+		})
+
+		it('should count the rows the scan came back with', () => {
+			// GIVEN a scan that returned two rows
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [company({ name: 'Alfa' }), company({ name: 'Beta' })],
+				}),
+			)
+
+			// WHEN scored — THEN the row count is carried, which is the scale every
+			// other market figure reads against
+			expect(score.market?.rowsReturned).toBe(2)
+			expect(score.market?.name).toBe('ES')
+		})
+	})
+
+	describe('when the golden row names a company', () => {
+		it('should count reaching it as a question that was asked', () => {
+			// GIVEN an ordinary company row, which names the site that proves the run
+			// reached the right one
+			const score = scoreRun(acme, outcome({}))
+
+			// WHEN scored — THEN grounding still counts, unchanged
+			expect(score.groundable).toBe(true)
+			expect(score.market).toBeUndefined()
+		})
+	})
+
+	describe('when a returned row is an organisation the golden knows is not a company', () => {
+		it('should not count a row whose name carries every word of a listed body', () => {
+			// GIVEN a trade body the golden names, returned under a longer name than
+			// the golden gives it
+			const score = scoreRun(
+				marketGolden({
+					notCompanies: ['Federación Nacional de Empresarios de Instalaciones'],
+				}),
+				outcome({
+					companies: [
+						company({
+							name: 'FENIE — Federación Nacional de Empresarios de Instalaciones',
+						}),
+						company({ name: 'Instalaciones Alfa SL' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN one of the two rows is the kind of organisation asked
+			// for. This is the fault that made a 62-row list unusable
+			expect(score.market?.rowsRightKind).toBe(1)
+		})
+
+		it('should match a body a row gives only by its initials', () => {
+			// GIVEN the initials listed as an entry of their own
+			const score = scoreRun(
+				marketGolden({ notCompanies: ['CONAIF', 'FENIE'] }),
+				outcome({ companies: [company({ name: 'CONAIF' })] }),
+			)
+
+			// WHEN scored — THEN the row is not counted as a company
+			expect(score.market?.rowsRightKind).toBe(0)
+		})
+
+		it('should not read a body into a name that merely contains its letters', () => {
+			// GIVEN a body known by three initials, and a real company whose name
+			// happens to spell them: "RTE" sits inside "Norte"
+			const score = scoreRun(
+				marketGolden({ notCompanies: ['RTE', 'FFB'] }),
+				outcome({
+					companies: [
+						company({ name: 'Norte Instalaciones' }),
+						company({ name: 'Groupe FFBat' }),
+					],
+				}),
+			)
+
+			// WHEN scored
+			// THEN both are still companies. A body counted where there is none marks a
+			// real company as the wrong kind, which overstates the problem being measured
+			expect(score.market?.rowsRightKind).toBe(2)
+		})
+
+		it('should not read a body into a company named after the trade it works in', () => {
+			// GIVEN a listed body whose name is made of the trade's ordinary words, and
+			// a real installer whose whole name sits inside it
+			const score = scoreRun(
+				marketGolden({
+					notCompanies: [
+						'Asociación de Empresas del Sector de las Instalaciones y la Energía',
+					],
+				}),
+				outcome({
+					companies: [company({ name: 'Instalaciones y Energía' })],
+				}),
+			)
+
+			// WHEN scored
+			// THEN it stays a company. Reading the words the other way round — the row's
+			// name sitting inside the listed one — would call every installer named after
+			// its own trade a trade body, which overstates the problem being measured
+			expect(score.market?.rowsRightKind).toBe(1)
+		})
+
+		it('should count every row when the golden names no bodies at all', () => {
+			// GIVEN a market whose trade bodies nobody has written down yet
+			const score = scoreRun(
+				marketGolden({ notCompanies: [] }),
+				outcome({
+					companies: [
+						company({ name: 'Asociación de Instaladores de Ourense' }),
+						company({ name: 'Instalaciones Alfa SL' }),
+					],
+				}),
+			)
+
+			// WHEN scored
+			// THEN it reads a clean 2 of 2 — which is the honest limit of this figure,
+			// and why an empty list has to be typed out rather than left off
+			expect(score.market?.rowsRightKind).toBe(2)
+		})
+
+		it('should leave a row with no readable name counted as a company', () => {
+			// GIVEN a row whose name is punctuation only, so there are no words to
+			// compare against anything
+			const score = scoreRun(
+				marketGolden({ notCompanies: ['FENIE'] }),
+				outcome({ companies: [company({ name: '—' })] }),
+			)
+
+			// WHEN scored — THEN it is not called a body on the strength of nothing
+			expect(score.market?.rowsRightKind).toBe(1)
+		})
+	})
+
+	describe('when the request named several parts', () => {
+		const fiveParts: MarketExpectation['parts'] = [
+			{ id: 'electrical', terms: ['instalacion electrica'] },
+			{ id: 'plumbing', terms: ['fontaneria'] },
+			{ id: 'solar', terms: ['fotovoltaica'] },
+			{ id: 'fire', terms: ['contra incendios'] },
+			{ id: 'lifts', terms: ['ascensor'] },
+		]
+
+		it('should count only the parts a row came back for', () => {
+			// GIVEN five trades asked for and rows for one of them, which is what the
+			// 13 August run actually did
+			const score = scoreRun(
+				marketGolden({ parts: fiveParts }),
+				outcome({
+					companies: [
+						company({
+							name: 'Alfa SL',
+							describedAs: 'Instalaciones eléctricas para industria',
+						}),
+						company({ name: 'Beta SL', describedAs: 'Instalación eléctrica' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN one of five, rather than a healthy-looking row count
+			expect(score.market?.partsExpected).toBe(5)
+			expect(score.market?.partsAnswered).toBe(1)
+		})
+
+		it('should count a row that answers two parts for both of them', () => {
+			// GIVEN one company that does two of the trades asked for
+			const score = scoreRun(
+				marketGolden({ parts: fiveParts }),
+				outcome({
+					companies: [
+						company({
+							name: 'Alfa SL',
+							describedAs: 'Fontanería y energía fotovoltaica',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN both parts are answered
+			expect(score.market?.partsAnswered).toBe(2)
+		})
+
+		it('should read a trade named in the row name alone', () => {
+			// GIVEN a row that says what it does only in its name
+			const score = scoreRun(
+				marketGolden({ parts: fiveParts }),
+				outcome({ companies: [company({ name: 'Ascensores del Sur SL' })] }),
+			)
+
+			// WHEN scored — THEN the part still counts as answered
+			expect(score.market?.partsAnswered).toBe(1)
+		})
+
+		it('should hold a short term to a whole word', () => {
+			// GIVEN a three-letter trade term, which is the opening of many unrelated
+			// words
+			const score = scoreRun(
+				marketGolden({ parts: [{ id: 'gas', terms: ['gas'] }] }),
+				outcome({
+					companies: [
+						company({ name: 'Alfa SL', describedAs: 'Control del gasto' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN "gasto" does not answer the gas part
+			expect(score.market?.partsAnswered).toBe(0)
+		})
+
+		it('should require a term of several words to appear as those words in order', () => {
+			// GIVEN a two-word term whose words both appear, but with another between
+			const score = scoreRun(
+				marketGolden({
+					parts: [{ id: 'fire', terms: ['proteccion incendios'] }],
+				}),
+				outcome({
+					companies: [
+						company({
+							name: 'Alfa SL',
+							describedAs: 'Protección contra incendios',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored
+			// THEN it is not answered. The golden has to write the wording a row would
+			// actually use, and under-reading is the safe direction for a measurement
+			expect(score.market?.partsAnswered).toBe(0)
+		})
+
+		it('should not let a trade body answer the part it represents', () => {
+			// GIVEN a market whose only solar row is the solar trade body, which names
+			// the trade in its own title
+			const score = scoreRun(
+				marketGolden({
+					parts: [{ id: 'solar', terms: ['fotovoltaica'] }],
+					notCompanies: ['Union Espanola Fotovoltaica'],
+				}),
+				outcome({
+					companies: [
+						company({
+							name: 'Unión Española Fotovoltaica',
+							describedAs: 'Asociación del sector fotovoltaico',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored
+			// THEN the part is not answered. A list holding the trade's federation and
+			// no company that does the work is the answer this figure exists to catch,
+			// and the body names the trade as surely as a company would
+			expect(score.market?.rowsRightKind).toBe(0)
+			expect(score.market?.partsAnswered).toBe(0)
+		})
+
+		it('should report no coverage when the request named no parts', () => {
+			// GIVEN a market row that lists no parts at all
+			const score = scoreRun(
+				marketGolden({ parts: [] }),
+				outcome({ companies: [company({ name: 'Alfa SL' })] }),
+			)
+
+			// WHEN scored — THEN there is nothing to divide by, so both read zero
+			expect(score.market?.partsExpected).toBe(0)
+			expect(score.market?.partsAnswered).toBe(0)
+		})
+	})
+
+	describe('when the same company came back more than once', () => {
+		it('should count a row whose name differs only by its legal form', () => {
+			// GIVEN the pair the 13 August list actually carried
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({ name: 'Cobra Instalaciones y Servicios' }),
+						company({ name: 'COBRA INSTALACIONES Y SERVICIOS SA' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN two rows are one company
+			expect(score.market?.rowsDuplicated).toBe(1)
+		})
+
+		it('should count two differently-named rows sharing a website', () => {
+			// GIVEN a rename or a trading name hiding one company behind two names
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({ name: 'Alfa SL', website: 'https://alfa.example' }),
+						company({
+							name: 'Instalaciones Alfa',
+							website: 'https://alfa.example/es',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN the shared site is enough
+			expect(score.market?.rowsDuplicated).toBe(1)
+		})
+
+		it('should carry sameness across a chain of rows', () => {
+			// GIVEN A meeting B by name and B meeting C by website
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({ name: 'Alfa Instalaciones' }),
+						company({
+							name: 'Alfa Instalaciones SL',
+							website: 'https://alfa.example',
+						}),
+						company({ name: 'Grupo Beta', website: 'https://alfa.example' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN all three are one company, which is what they are
+			expect(score.market?.rowsDuplicated).toBe(2)
+		})
+
+		it('should not fold two rows on a website that is not an address', () => {
+			// GIVEN two rows whose website field carries prose beside the URL
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({
+							name: 'Alfa SL',
+							website: 'https://alfa.example (inferred from name)',
+						}),
+						company({
+							name: 'Beta SL',
+							website: 'https://alfa.example (inferred from name)',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN nothing is folded on a value that is not an address
+			expect(score.market?.rowsDuplicated).toBe(0)
+		})
+
+		it('should leave rows nothing can be read from as companies of their own', () => {
+			// GIVEN two rows with no readable name and no address
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [company({ name: '—' }), company({ name: '···' })],
+				}),
+			)
+
+			// WHEN scored — THEN no duplicate is claimed, because none can be shown
+			expect(score.market?.rowsDuplicated).toBe(0)
+		})
+
+		it('should fold a row that meets two companies already found', () => {
+			// GIVEN a row that shares its name with the first row and its site with the
+			// second, which proves those two were one company all along
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({ name: 'Alfa SL' }),
+						company({ name: 'Beta SL', website: 'https://beta.example' }),
+						company({ name: 'Alfa SL', website: 'https://beta.example' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN all three are one company, not two
+			expect(score.market?.rowsDuplicated).toBe(2)
+		})
+
+		it('should count no duplicates in a list of distinct companies', () => {
+			// GIVEN three unrelated companies
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({ name: 'Alfa SL' }),
+						company({ name: 'Beta SL' }),
+						company({ name: 'Gamma SL' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN the list is what it says it is
+			expect(score.market?.rowsDuplicated).toBe(0)
+		})
+	})
+
+	describe('when the run never reached an answer', () => {
+		it.each([
+			'failed',
+			'cancelled',
+		] as const)('should score no market at all for a %s run', status => {
+			// GIVEN a market request whose run died — an outage, or the time limit
+			// cutting a long search short — so it returned nothing for that reason
+			const score = scoreRun(
+				marketGolden({
+					parts: [
+						{ id: 'electrical', terms: ['instalacion electrica'] },
+						{ id: 'solar', terms: ['fotovoltaica'] },
+					],
+				}),
+				outcome({ status, companies: [] }),
+			)
+
+			// WHEN scored
+			// THEN there is no market reading to fold into the pass. Counting it
+			// would put the parts it was asked for into the denominator with
+			// nothing above the line, so one crashed run in two would halve the
+			// coverage figure and read as a regression the research never had
+			expect(score.market).toBeUndefined()
+		})
+	})
+
+	describe('when rows say where the company is', () => {
+		it('should count only the rows that state a town or province', () => {
+			// GIVEN three rows, one located, one blank, one absent
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({ name: 'Alfa SL', location: 'Alcobendas, Madrid' }),
+						company({ name: 'Beta SL', location: '   ' }),
+						company({ name: 'Gamma SL' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN the field the request asked for on every company is
+			// counted where it actually arrived
+			expect(score.market?.rowsLocated).toBe(1)
+		})
+	})
+
+	describe('when the scan came back with nothing', () => {
+		it('should report an answered-nothing market rather than dropping out', () => {
+			// GIVEN a market request that looked and found no rows at all, which the
+			// pipeline ends as no reliable data rather than as a success
+			const score = scoreRun(
+				marketGolden({
+					parts: [
+						{ id: 'electrical', terms: ['instalacion electrica'] },
+						{ id: 'solar', terms: ['fotovoltaica'] },
+					],
+				}),
+				outcome({ status: 'no_reliable_data', companies: [] }),
+			)
+
+			// WHEN scored
+			// THEN every count reads zero and coverage says none of the two parts was
+			// answered — the answer, rather than the absence of one
+			expect(score.market).toEqual({
+				name: 'ES',
+				rowsReturned: 0,
+				rowsRightKind: 0,
+				rowsLocated: 0,
+				rowsDuplicated: 0,
+				partsExpected: 2,
+				partsAnswered: 0,
+			})
+			expect(score.empty).toBe(true)
+		})
+	})
+})
+
 describe('summarizeScores', () => {
 	const score = (over: Partial<RunScore>): RunScore => ({
 		id: 'r',
 		grounded: true,
+		groundable: true,
 		wrongCompany: false,
 		wrongCompanyAutoApplicable: false,
 		lowConfidence: false,
@@ -533,14 +1054,19 @@ describe('summarizeScores', () => {
 			// would need a run to divide by stays null rather than reading as zero
 			expect(summary).toEqual({
 				runs: 0,
-				groundingAccuracy: 0,
-				wrongCompanyRate: 0,
-				wrongCompanyAutoApplicableRate: 0,
+				groundingAccuracy: null,
+				wrongCompanyRate: null,
+				wrongCompanyAutoApplicableRate: null,
 				lowConfidenceRate: 0,
 				emptyRate: 0,
 				fieldPrecision: null,
 				fieldRecall: null,
 				contactRecall: null,
+				organisationKindPrecision: null,
+				requestCoverage: null,
+				duplicateRate: null,
+				locationFill: null,
+				rowsPerScan: null,
 				fieldsFilledPerRun: null,
 				profileFieldsTotal: null,
 				contactsNamedPerRun: null,
@@ -787,6 +1313,167 @@ describe('summarizeScores', () => {
 	})
 })
 
+describe('summarizing a pass that held market requests', () => {
+	const score = (over: Partial<RunScore>): RunScore => ({
+		id: 'r',
+		grounded: true,
+		groundable: true,
+		wrongCompany: false,
+		wrongCompanyAutoApplicable: false,
+		lowConfidence: false,
+		empty: false,
+		fieldsExpected: 0,
+		fieldsScored: 0,
+		fieldsCorrect: 0,
+		contactsExpected: 0,
+		contactsFound: 0,
+		...over,
+	})
+
+	const marketScore = (
+		over: Partial<RunScore['market']> = {},
+		alsoOnScore: Partial<RunScore> = {},
+	): RunScore =>
+		score({
+			groundable: false,
+			grounded: false,
+			...alsoOnScore,
+			market: {
+				name: 'ES',
+				rowsReturned: 10,
+				rowsRightKind: 10,
+				rowsLocated: 10,
+				rowsDuplicated: 0,
+				partsExpected: 5,
+				partsAnswered: 5,
+				...over,
+			},
+		})
+
+	describe('when no run in the pass was asked to reach a company', () => {
+		it('should report no grounding accuracy rather than nought', () => {
+			// GIVEN a pass made only of market requests
+			const summary = summarizeScores([marketScore(), marketScore()])
+
+			// WHEN summarized
+			// THEN all three are absent, not failed. Nought would say the pass failed at
+			// three things nobody asked it to do
+			expect(summary.groundingAccuracy).toBeNull()
+			expect(summary.wrongCompanyRate).toBeNull()
+			expect(summary.wrongCompanyAutoApplicableRate).toBeNull()
+		})
+	})
+
+	describe('when a pass mixes market requests with company rows', () => {
+		it('should judge grounding only over the runs it was a question for', () => {
+			// GIVEN one company row that reached its target, and one market request
+			const summary = summarizeScores([
+				score({ grounded: true, groundable: true }),
+				marketScore(),
+			])
+
+			// WHEN summarized — THEN grounding reads 1 of 1, not 1 of 2
+			expect(summary.groundingAccuracy).toBe(1)
+
+			// AND a market run carrying a look-alike verdict stays out of that count
+			// too, which would otherwise put a rate above 1 on the board
+			const withStrayVerdict = summarizeScores([
+				score({ grounded: true, groundable: true }),
+				marketScore(
+					{},
+					{ wrongCompany: true, wrongCompanyAutoApplicable: true },
+				),
+			])
+			expect(withStrayVerdict.wrongCompanyRate).toBe(0)
+			expect(withStrayVerdict.wrongCompanyAutoApplicableRate).toBe(0)
+
+			// AND the row count is per scan, not per run of the pass
+			expect(summary.rowsPerScan).toBe(10)
+		})
+	})
+
+	describe('when the pass held no market request at all', () => {
+		it('should report nothing for every market figure', () => {
+			// GIVEN an ordinary pass of company profiles
+			const summary = summarizeScores([score({}), score({})])
+
+			// WHEN summarized
+			// THEN each market figure is absent rather than a flattering full marks
+			expect(summary.organisationKindPrecision).toBeNull()
+			expect(summary.requestCoverage).toBeNull()
+			expect(summary.duplicateRate).toBeNull()
+			expect(summary.locationFill).toBeNull()
+			expect(summary.rowsPerScan).toBeNull()
+		})
+	})
+
+	describe('when two markets came back with lists of different sizes', () => {
+		it('should weigh each market by the rows it actually returned', () => {
+			// GIVEN a sixty-row market where 30 rows are the right kind, and a six-row
+			// market where all six are
+			const summary = summarizeScores([
+				marketScore({
+					name: 'ES',
+					rowsReturned: 60,
+					rowsRightKind: 30,
+					rowsLocated: 15,
+					rowsDuplicated: 6,
+				}),
+				marketScore({
+					name: 'FR',
+					rowsReturned: 6,
+					rowsRightKind: 6,
+					rowsLocated: 6,
+					rowsDuplicated: 0,
+				}),
+			])
+
+			// WHEN summarized
+			// THEN the figures are per row across the pass (36 of 66), not the mean of
+			// the two markets' own rates, which would read a far kinder 75%
+			expect(summary.organisationKindPrecision).toBeCloseTo(36 / 66)
+			expect(summary.duplicateRate).toBeCloseTo(6 / 66)
+			expect(summary.locationFill).toBeCloseTo(21 / 66)
+			expect(summary.rowsPerScan).toBe(33)
+		})
+
+		it('should divide coverage by the parts the pass asked for', () => {
+			// GIVEN two markets of five parts each, answering one and four
+			const summary = summarizeScores([
+				marketScore({ partsExpected: 5, partsAnswered: 1 }),
+				marketScore({ name: 'FR', partsExpected: 5, partsAnswered: 4 }),
+			])
+
+			// WHEN summarized — THEN five of the ten parts asked for were answered
+			expect(summary.requestCoverage).toBe(0.5)
+		})
+	})
+
+	describe('when every market in the pass came back empty', () => {
+		it('should report no per-row figures but a coverage of nought', () => {
+			// GIVEN a market request that returned nothing
+			const summary = summarizeScores([
+				marketScore({
+					rowsReturned: 0,
+					rowsRightKind: 0,
+					rowsLocated: 0,
+					rowsDuplicated: 0,
+					partsAnswered: 0,
+				}),
+			])
+
+			// WHEN summarized
+			// THEN there is nothing to judge per row, but "none of the five parts was
+			// answered" is a reading, and the empty scan still counts as a scan
+			expect(summary.organisationKindPrecision).toBeNull()
+			expect(summary.duplicateRate).toBeNull()
+			expect(summary.locationFill).toBeNull()
+			expect(summary.requestCoverage).toBe(0)
+			expect(summary.rowsPerScan).toBe(0)
+		})
+	})
+})
+
 describe('scoreRun — bucket and country', () => {
 	describe('when the golden row is tagged with a bucket', () => {
 		it('should carry the bucket and expected country onto the score', () => {
@@ -985,8 +1672,8 @@ describe('scoring a run that answered with a list of companies', () => {
 					status: 'succeeded',
 					fields: {},
 					companies: [
-						{ name: 'Acme', hasWebsite: true },
-						{ name: 'Beta', hasWebsite: false },
+						company({ name: 'Acme', website: 'https://acme.example' }),
+						company({ name: 'Beta' }),
 					],
 				}),
 			)

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -17,6 +17,22 @@
  *                        is judged against the golden rather than counted here.
  *   empty rate           did it return no usable data at all?
  *
+ * A search for a whole market answers with a list rather than a profile, so none of
+ * the above is the question it should be graded on. Counting how many companies came
+ * back would have called a 62-row list healthy when 23 of the rows were trade bodies,
+ * 10 were the same company twice, and four of the five trades asked for were missing.
+ * A market is graded on what was actually wrong with that list instead:
+ *
+ *   organisation kind    how many rows are the kind of organisation that was asked for
+ *   request coverage     how many of the parts the request named came back with a row
+ *   duplicate rate       whether the fold that joins two rows of one company still
+ *                        holds — see its own note for what it cannot see
+ *   location fill        how many rows say what town or province the company is in
+ *
+ * The row count is still reported, as the scale those four read against rather than
+ * as the grade — it is also what checking that every row is a real company would
+ * cost, so it needs a reading of its own before that check exists.
+ *
  * Grounding is judged by which pages the run *fetched*, not which its findings cite:
  * once per-field citations point at whichever page stated each fact, a run that
  * correctly reached the target's own site still cites third-party pages per field,
@@ -27,6 +43,8 @@
  */
 
 import { foldLabel } from '@batuda/domain'
+
+import { discoveryRowIdentityKeys } from './prospect-dedupe-guard'
 
 /**
  * The enrichment scalars we can check against an objective golden answer. Free-text
@@ -82,6 +100,57 @@ export const isSucceeded = (status: TerminalStatus): boolean =>
 	status === 'succeeded' || status === 'succeeded_low_confidence'
 
 /**
+ * Whether the run got far enough to say something about what it was asked.
+ *
+ * Wider than succeeding. A search that looked and found nothing ends as no
+ * reliable data, and that is an answer about the market — the one a change that
+ * empties a search has to be caught by. A run that died or was stopped never
+ * reached an answer, and reading its empty hands as "this market has nothing in
+ * it" would blame the market for an outage.
+ */
+const endedWithAnAnswer = (status: TerminalStatus): boolean =>
+	status !== 'failed' && status !== 'cancelled'
+
+/**
+ * One part of a request that asks for several — a trade, a service, a segment —
+ * with the wordings that place a returned row in it.
+ *
+ * The wordings are golden data, never a list in here. Which trades a market has is
+ * a fact about the world, so no list of the trades or countries expected of a run
+ * belongs in code. A golden set is where the expected answers already live, so they
+ * cost nothing there.
+ */
+export interface MarketPart {
+	readonly id: string
+	/** Wordings that place a row in this part, in whichever languages the market answers in. */
+	readonly terms: ReadonlyArray<string>
+}
+
+/**
+ * What a request for a whole market asks for, when a golden row is a market rather
+ * than one company. A scan answers with a list, so nothing a profile is graded on —
+ * reaching one company's site, filling that company's fields — is a question here.
+ */
+export interface MarketExpectation {
+	/** What this market is called, and the key a per-market breakdown groups on. */
+	readonly name: string
+	/** The parts the request names; coverage is how many came back with a row. */
+	readonly parts: ReadonlyArray<MarketPart>
+	/**
+	 * Organisations known not to be companies in this market — the trade bodies,
+	 * federations and system operators a search for a trade runs straight through
+	 * on its way to the members.
+	 *
+	 * Naming them is what makes the count evidence rather than an opinion, and it is
+	 * the only thing that can see past the organisation-kind guard's own languages:
+	 * that guard reads Spanish, Catalan and English, so asking it again here would
+	 * agree with itself and report every market clean. A body this list does not name
+	 * still passes unmeasured, which is the honest limit of the figure.
+	 */
+	readonly notCompanies: ReadonlyArray<string>
+}
+
+/**
  * One company's known-correct answer. This lives in code as a type; the actual
  * rows live in the eval dataset (Latitude), so a new company is added there, not
  * here.
@@ -106,6 +175,12 @@ export interface GoldenExpectation {
 	readonly contacts?: ReadonlyArray<{ readonly name: string }>
 	/** Size/reach segment, so quality can be reported per bucket, not just overall. */
 	readonly bucket?: GoldenBucket
+	/**
+	 * Present when this row asks for a market rather than one company. The two are
+	 * one type because a pass runs one or the other and every figure below already
+	 * reports nothing when it had nothing to judge.
+	 */
+	readonly market?: MarketExpectation
 }
 
 /**
@@ -150,13 +225,20 @@ export interface RunOutcome {
 		readonly role: string | null
 	}>
 	/**
-	 * The companies a discovery scan came back with, and whether each carries a
-	 * website. Empty for a run that answers with a profile rather than a list.
-	 * This is what a scan is asked for, so it is what a scan has to be scored on.
+	 * The companies a discovery scan came back with. Empty for a run that answers
+	 * with a profile rather than a list. This is what a scan is asked for, so it is
+	 * what a scan has to be scored on — each row carrying the four things the market
+	 * figures read: who it is, where it is, what it says it does, and its web
+	 * address, which is one of the two things that tell two rows apart.
 	 */
 	readonly companies: ReadonlyArray<{
 		readonly name: string
-		readonly hasWebsite: boolean
+		/** The address the row carries, as written, or null when it carries none. */
+		readonly website: string | null
+		/** The town or province the row states, or null when it states none. */
+		readonly location: string | null
+		/** The row's own words about what it is and why it matched, run together. */
+		readonly describedAs: string
 	}>
 	/**
 	 * Whether an official-registry lookup this run resolved the target company by
@@ -188,11 +270,51 @@ export interface RunUsage {
 	readonly callsByModel?: Record<string, number>
 }
 
+/**
+ * What one scan's list got right, counted against the market it was asked for.
+ *
+ * Counts rather than rates, so a pass adds them up and then divides once: a market
+ * that came back with sixty rows then weighs sixty rows against a six-row market's
+ * six, instead of each contributing one equal rate to an average.
+ */
+export interface MarketScore {
+	/** Which market this run answered for — the key a per-market breakdown groups on. */
+	readonly name: string
+	/**
+	 * Rows the scan came back with. The scale the figures below read against, and
+	 * what checking that every row is a real company would cost, so it is reported
+	 * in its own right rather than only as a denominator.
+	 */
+	readonly rowsReturned: number
+	/** Of those, how many are not an organisation the golden names as not a company. */
+	readonly rowsRightKind: number
+	/**
+	 * Of the rows returned — every one of them, including any the golden names as not
+	 * a company — how many say where the company is. The field is asked for a town or
+	 * a province, but any stated place counts here — a row answering with the country
+	 * alone is filled as far as this can tell, and the request having named that
+	 * country is not something a count of rows can know.
+	 */
+	readonly rowsLocated: number
+	/** How many rows are another row's company written a second time. */
+	readonly rowsDuplicated: number
+	/** Parts the request named — the trades, services or segments it asked for. */
+	readonly partsExpected: number
+	/** Of those, how many came back with at least one row. */
+	readonly partsAnswered: number
+}
+
 export interface RunScore {
 	readonly id: string
 	/** What this run cost, carried through so a pass can be totalled and compared. */
 	readonly usage?: RunUsage
 	readonly grounded: boolean
+	/**
+	 * Whether reaching a particular company was a question for this row at all. A
+	 * market names no company to reach, so counting it as a grounding failure would
+	 * report a whole scan pass at zero for answering the question it was asked.
+	 */
+	readonly groundable: boolean
 	readonly wrongCompany: boolean
 	/**
 	 * Whether a wrong company got as far as finishing clean — the most that could
@@ -223,18 +345,31 @@ export interface RunScore {
 	readonly country?: string
 	/** How full the profile came back, independent of the golden answers. */
 	readonly profile?: ProfileFullness
+	/** What the list got right, present only for a row that asked for a market. */
+	readonly market?: MarketScore
 }
 
 export interface EvalSummary {
 	readonly runs: number
-	readonly groundingAccuracy: number
-	readonly wrongCompanyRate: number
+	/**
+	 * Of the runs that were asked to reach a particular company, the share that
+	 * reached it. Null for a pass of market requests, which name no company to reach
+	 * — the alternative reads zero and says the pass failed at something nobody asked
+	 * it to do.
+	 */
+	readonly groundingAccuracy: number | null
+	/**
+	 * The look-alike figures, over the same runs as grounding and null for the same
+	 * reason: a market request answers with a list, so there is no other company it
+	 * could have come back with instead.
+	 */
+	readonly wrongCompanyRate: number | null
 	/**
 	 * Share of runs that shipped another company's data and finished clean — the
 	 * most that could ever be written with nobody looking. An upper bound: see
 	 * `wrongCompanyAutoApplicable` for the conditions it cannot see.
 	 */
-	readonly wrongCompanyAutoApplicableRate: number
+	readonly wrongCompanyAutoApplicableRate: number | null
 	/** Share of runs that finished flagged as needing somebody to read them. */
 	readonly lowConfidenceRate: number
 	readonly emptyRate: number
@@ -246,6 +381,27 @@ export interface EvalSummary {
 	 * runs; null when no golden row listed expected contacts. */
 	readonly contactRecall: number | null
 	/**
+	 * The four market figures, each micro-averaged over every market request in the
+	 * pass rather than averaged across markets, so a sixty-row market weighs sixty
+	 * rows against a six-row one's six.
+	 *
+	 * Null means there was nothing to divide by, which happens two ways, and the row
+	 * count below tells them apart: no market request in the pass at all, where the
+	 * row count is null too, or markets that ran and came back with no rows, where it
+	 * is nought. Coverage is the exception — it divides by the parts a request named,
+	 * so a market that found nothing still reads nought rather than nothing.
+	 */
+	readonly organisationKindPrecision: number | null
+	readonly requestCoverage: number | null
+	readonly duplicateRate: number | null
+	readonly locationFill: number | null
+	/**
+	 * Rows one market request came back with on average. Not a quality figure —
+	 * it is the scale the four above read against, and the reading that says what
+	 * a change bought or cost in results.
+	 */
+	readonly rowsPerScan: number | null
+	/**
 	 * Profile fields filled per run, averaged over the runs that reported it, and
 	 * the shape's own field count to read it against.
 	 */
@@ -256,8 +412,13 @@ export interface EvalSummary {
 	readonly contactsTitledPerRun: number | null
 	/** What one run cost on average, in cents; null when no run reported a cost. */
 	readonly costPerRun: number | null
-	/** What one usable run cost — the total spread over the runs that grounded,
-	 * so the runs that found nothing are counted as waste rather than ignored. */
+	/**
+	 * What one usable run cost: what the runs asked to reach a company spent, over
+	 * how many of them reached it, so the ones that found nothing count as waste
+	 * rather than being ignored. A market request is outside both halves — it is not
+	 * asked to reach anybody, and its spend billed to the company runs would read as
+	 * a cost blow-up rather than as the different job it is.
+	 */
 	readonly costPerGroundedRun: number | null
 	/** Of the average run cost, what the metered per-call lookups accounted for. */
 	readonly paidCostPerRun: number | null
@@ -533,6 +694,175 @@ const specificLocationAgrees = (
 	return fieldMatches('location', goldenLocation, actual)
 }
 
+/**
+ * A value's words with the accents taken off, so "Instalación" and "instalacion" are
+ * one word and punctuation between two words never runs them into one.
+ *
+ * Exported so the golden data can be held to the same reading: a wording that folds
+ * to no words can never place a row or name an organisation, and refusing it where it
+ * is written beats accepting it and silently measuring nothing.
+ */
+export const termTokens = (value: string): ReadonlyArray<string> =>
+	foldDiacritics(value)
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(token => token.length > 0)
+
+// Below this length a term's word has to match a whole word. A three-letter word is
+// the opening of far too many unrelated ones — "gas" starts "gasto" — while a longer
+// one is long enough that only its own endings follow it, so "instalacion electrica"
+// reaches "instalaciones eléctricas" without the golden listing every ending of
+// every trade in every language.
+const TERM_PREFIX_MIN_CHARS = 5
+
+// Whether a term's words appear among a row's words, in order and next to each
+// other. A long enough word matches as an opening, because Spanish, Catalan and
+// French put an ending on every word of a phrase, not only on the last one.
+const termAppearsIn = (
+	term: ReadonlyArray<string>,
+	words: ReadonlyArray<string>,
+): boolean => {
+	if (term.length === 0) return false
+	for (let at = 0; at + term.length <= words.length; at++) {
+		const matches = term.every((token, offset) => {
+			const word = words[at + offset] ?? ''
+			return token.length >= TERM_PREFIX_MIN_CHARS
+				? word.startsWith(token)
+				: word === token
+		})
+		if (matches) return true
+	}
+	return false
+}
+
+/**
+ * How many of a request's parts came back with at least one row that answers them.
+ *
+ * Only rows that are the kind of organisation asked for are read. A trade's own
+ * federation names that trade in its title, so counting it would mark the part
+ * answered by the very body that has no work to sell — and a list holding the solar
+ * association and no solar company is the answer this figure exists to catch.
+ */
+const partsAnsweredBy = (
+	rows: RunOutcome['companies'],
+	parts: ReadonlyArray<MarketPart>,
+): number => {
+	const rowWords = rows.map(row => termTokens(`${row.name} ${row.describedAs}`))
+	return parts.filter(part =>
+		part.terms.some(term => {
+			const tokens = termTokens(term)
+			return rowWords.some(words => termAppearsIn(tokens, words))
+		}),
+	).length
+}
+
+/**
+ * Whether a row is one of the organisations the golden names as not a company.
+ *
+ * The listed name has to appear in the row's name as those words, in that order,
+ * next to each other. A run writes a body's name longer than the golden does —
+ * "FENIE — Federación Nacional de Empresarios de Instalaciones" — so the listed name
+ * sitting inside the row's is what catches it.
+ *
+ * Whole words rather than a run of letters, because a body is usually known by its
+ * initials and three letters land inside an unrelated name by accident: "RTE" sits
+ * in the middle of "Norte Instalaciones", and "FFB" inside "Groupe FFBat".
+ *
+ * Next to each other rather than merely present, because the words of a body's name
+ * are the trade's ordinary words scattered through many a company's: an unordered
+ * test reads "Eléctrica del Norte, Red de Instaladores" as the grid operator. Order
+ * does not save every case — a listed name short enough to sit inside a real company
+ * name still matches it — which is why the golden lists the name a body is known by
+ * rather than a fragment of it. And only in that direction — asking whether the row's words all
+ * sit inside the listed name marks any company named after its own trade as a body,
+ * from "Instalaciones y Energía" to a French "Génie Électrique et Climatique".
+ * Counting a body where there is none marks a real company as the wrong kind, which
+ * overstates the very problem being measured.
+ *
+ * Two rules on the golden data follow. List the name a body is actually known by,
+ * specific enough to be its own — "Red Eléctrica" alone names half the installers in
+ * the country — and list its initials as an entry of their own, because an acronym
+ * shares no words with what it stands for.
+ *
+ * What is left over, and cannot be read off a name: a company trading under a body's
+ * initials, like the retailer FENIE Energía beside the federation FENIE. It reads as
+ * the body. Asking the model what an organisation is would settle it; a name cannot.
+ */
+const isKnownNonCompany = (
+	name: string,
+	notCompanies: ReadonlyArray<string>,
+): boolean => {
+	const words = termTokens(name)
+	return notCompanies.some(listed => {
+		const listedWords = termTokens(listed)
+		if (listedWords.length === 0) return false
+		// A body known by its initials shares that word with the companies trading
+		// under it — the retailer FENIE Energía beside the federation FENIE, Grupo
+		// Unef Solar beside UNEF, RTE Ascenseurs beside the grid operator. One word
+		// on its own is only conclusive when it is the whole of what the row is
+		// called; spelled-out names carry enough words to be found inside a longer
+		// one safely.
+		if (listedWords.length === 1)
+			return words.length === 1 && words[0] === listedWords[0]
+		return words.some((_, at) =>
+			listedWords.every((word, offset) => words[at + offset] === word),
+		)
+	})
+}
+
+/**
+ * How many rows are another row's company a second time: the rows, less the
+ * companies they turn out to be.
+ *
+ * Two rows are one company when they share a name with the legal form off the end or
+ * share a site host, and sameness carries — the same keys the scan itself folds rows
+ * on.
+ *
+ * Reusing those keys is what this number is worth and what bounds it. The list it
+ * reads has already been folded on them, so nothing it can see should be left: it
+ * answers "is that fold still running and still doing its job", and it moves the
+ * moment the answer is no. It cannot answer whether the keys are the right ones.
+ *
+ * That bound is wider than it sounds, and a live market search shows it: a company
+ * came back once under its own name and four more times as that name plus the town
+ * of a branch office, none of the four carrying a site. Neither key sees them — the
+ * name is not the same name and there is no host to share — so the fold leaves all
+ * five and this reads zero duplicates over a list that plainly repeats one company.
+ * Reading it as "no repeats in this list" is wrong; it means "no repeats of the kind
+ * these keys can tell". Counting those needs a hand-marked answer to score against,
+ * which is a different measurement from this one.
+ *
+ * A row nothing can be read from — a name that is all punctuation, no address —
+ * files under no key and so counts as its own company. That is the safe direction:
+ * it never claims a duplicate it cannot show.
+ */
+const duplicatedRows = (rows: RunOutcome['companies']): number => {
+	// Each company found so far, as the keys its rows filed under. A row meeting one
+	// of them is that company again; a row meeting two proves those two were one
+	// company all along, so they merge.
+	const companies: Array<Set<string>> = []
+	for (const row of rows) {
+		const keys = discoveryRowIdentityKeys({
+			name: row.name,
+			...(row.website === null ? {} : { website: row.website }),
+		})
+		const matched = companies.filter(company =>
+			keys.some(key => company.has(key)),
+		)
+		const mergeInto = matched[0]
+		if (mergeInto === undefined) {
+			companies.push(new Set(keys))
+			continue
+		}
+		for (const key of keys) mergeInto.add(key)
+		for (const other of matched.slice(1)) {
+			for (const key of other) mergeInto.add(key)
+			companies.splice(companies.indexOf(other), 1)
+		}
+	}
+	return rows.length - companies.length
+}
+
 /** Score one run against its golden expectation. */
 export const scoreRun = (
 	expected: GoldenExpectation,
@@ -627,9 +957,46 @@ export const scoreRun = (
 	const lowConfidence = outcome.status === 'succeeded_low_confidence'
 	const wrongCompanyAutoApplicable = wrongCompany && !lowConfidence
 
+	// What the list got right, for a row that asked for a market.
+	//
+	// Only a run that reached an answer is measured. A run that died — a provider
+	// outage, or the whole-run time limit cutting a long search short — returns no
+	// rows, and counting it would put the parts it was asked for into the denominator
+	// with nothing in the numerator: one crashed run out of two halves the coverage
+	// figure and reads as a regression the research never had.
+	//
+	// A search that looked and found nothing is the opposite case and has to count.
+	// It ends as no reliable data rather than a success, so asking only whether the
+	// run succeeded would throw away the very reading that catches a change which
+	// empties a market — and with one run per market, throw away the whole market
+	// with it.
+	const expectedMarket = expected.market
+	const rightKindRows = outcome.companies.filter(
+		row =>
+			expectedMarket === undefined ||
+			!isKnownNonCompany(row.name, expectedMarket.notCompanies),
+	)
+	const market: MarketScore | undefined =
+		expectedMarket === undefined || !endedWithAnAnswer(outcome.status)
+			? undefined
+			: {
+					name: expectedMarket.name,
+					rowsReturned: outcome.companies.length,
+					rowsRightKind: rightKindRows.length,
+					rowsLocated: outcome.companies.filter(row => isFilled(row.location))
+						.length,
+					rowsDuplicated: duplicatedRows(outcome.companies),
+					partsExpected: expectedMarket.parts.length,
+					// Coverage counts the parts the request named rather than the rows, so
+					// a market that came back with nothing still reports it — none of them
+					// answered — instead of dropping out of the figure.
+					partsAnswered: partsAnsweredBy(rightKindRows, expectedMarket.parts),
+				}
+
 	return {
 		id: expected.id,
 		grounded,
+		groundable: expected.market === undefined,
 		wrongCompany,
 		wrongCompanyAutoApplicable,
 		lowConfidence,
@@ -641,6 +1008,7 @@ export const scoreRun = (
 		contactsFound,
 		...(outcome.profile !== undefined ? { profile: outcome.profile } : {}),
 		...(outcome.usage !== undefined ? { usage: outcome.usage } : {}),
+		...(market !== undefined ? { market } : {}),
 		...(expected.bucket !== undefined ? { bucket: expected.bucket } : {}),
 		...(expected.fields.country !== undefined
 			? { country: expected.fields.country }
@@ -656,14 +1024,19 @@ export const summarizeScores = (
 	if (runs === 0) {
 		return {
 			runs: 0,
-			groundingAccuracy: 0,
-			wrongCompanyRate: 0,
-			wrongCompanyAutoApplicableRate: 0,
+			groundingAccuracy: null,
+			wrongCompanyRate: null,
+			wrongCompanyAutoApplicableRate: null,
 			lowConfidenceRate: 0,
 			emptyRate: 0,
 			fieldPrecision: null,
 			fieldRecall: null,
 			contactRecall: null,
+			organisationKindPrecision: null,
+			requestCoverage: null,
+			duplicateRate: null,
+			locationFill: null,
+			rowsPerScan: null,
 			fieldsFilledPerRun: null,
 			profileFieldsTotal: null,
 			contactsNamedPerRun: null,
@@ -679,6 +1052,7 @@ export const summarizeScores = (
 	}
 
 	let grounded = 0
+	let groundable = 0
 	let wrong = 0
 	let wrongAutoApplicable = 0
 	let lowConfidence = 0
@@ -699,14 +1073,41 @@ export const summarizeScores = (
 	// never read them back shows no figure rather than a misleadingly low one.
 	let runsWithUsage = 0
 	let totalCostCents = 0
+	let groundableCostCents = 0
+	let groundedRunsWithUsage = 0
 	let totalPaidCostCents = 0
 	let totalTokensIn = 0
 	let totalTokensOut = 0
 	let totalCredits = 0
+	// The market figures, totalled as counts and divided once at the end, so a
+	// sixty-row market weighs sixty rows against a six-row one's six.
+	let scansScored = 0
+	let totalRowsReturned = 0
+	let totalRowsRightKind = 0
+	let totalRowsLocated = 0
+	let totalRowsDuplicated = 0
+	let totalPartsExpected = 0
+	let totalPartsAnswered = 0
 	for (const score of scores) {
-		if (score.grounded) grounded++
-		if (score.wrongCompany) wrong++
-		if (score.wrongCompanyAutoApplicable) wrongAutoApplicable++
+		// Only a run that was asked to reach a particular company can be counted for
+		// having reached it.
+		if (score.groundable) {
+			groundable++
+			if (score.grounded) grounded++
+		}
+		// The cost figure below divides by this rather than by every grounded run,
+		// so that a run whose spend was never read back cannot sit in the divisor
+		// with nothing above the line and drag the figure under the plain per-run cost.
+		if (score.groundable && score.grounded && score.usage !== undefined)
+			groundedRunsWithUsage++
+		// The look-alike counts ask the same question grounding does — was this the
+		// company we sent it after — so a market request is outside them too. It can
+		// never be a look-alike, and leaving it in the denominator quietly waters the
+		// rate down with runs that had no way to fail it.
+		if (score.groundable) {
+			if (score.wrongCompany) wrong++
+			if (score.wrongCompanyAutoApplicable) wrongAutoApplicable++
+		}
 		if (score.lowConfidence) lowConfidence++
 		if (score.empty) empty++
 		if (score.profile !== undefined) {
@@ -719,6 +1120,15 @@ export const summarizeScores = (
 			totalContactsNamed += score.profile.contactsNamed
 			totalContactsTitled += score.profile.contactsTitled
 		}
+		if (score.market !== undefined) {
+			scansScored++
+			totalRowsReturned += score.market.rowsReturned
+			totalRowsRightKind += score.market.rowsRightKind
+			totalRowsLocated += score.market.rowsLocated
+			totalRowsDuplicated += score.market.rowsDuplicated
+			totalPartsExpected += score.market.partsExpected
+			totalPartsAnswered += score.market.partsAnswered
+		}
 		totalExpected += score.fieldsExpected
 		totalScored += score.fieldsScored
 		totalCorrect += score.fieldsCorrect
@@ -727,6 +1137,11 @@ export const summarizeScores = (
 		if (score.usage !== undefined) {
 			runsWithUsage++
 			totalCostCents += score.usage.costCents
+			// What a usable run cost divides by the runs that grounded, so only what
+			// those runs spent belongs on top of it. A market request grounds nothing
+			// and can cost more than a profile run, so counting its spend here would
+			// bill it to the handful of company runs and read as a cost blow-up.
+			if (score.groundable) groundableCostCents += score.usage.costCents
 			totalPaidCostCents += score.usage.paidCostCents
 			totalTokensIn += score.usage.tokensIn
 			totalTokensOut += score.usage.tokensOut
@@ -746,11 +1161,18 @@ export const summarizeScores = (
 		}
 	}
 
+	// A market that came back with no rows at all has nothing to judge per row, but
+	// its coverage still reads — none of the parts was answered, which is the whole
+	// point of the figure.
+	const perRow = (total: number): number | null =>
+		totalRowsReturned === 0 ? null : total / totalRowsReturned
+
 	return {
 		runs,
-		groundingAccuracy: grounded / runs,
-		wrongCompanyRate: wrong / runs,
-		wrongCompanyAutoApplicableRate: wrongAutoApplicable / runs,
+		groundingAccuracy: groundable === 0 ? null : grounded / groundable,
+		wrongCompanyRate: groundable === 0 ? null : wrong / groundable,
+		wrongCompanyAutoApplicableRate:
+			groundable === 0 ? null : wrongAutoApplicable / groundable,
 		lowConfidenceRate: lowConfidence / runs,
 		emptyRate: empty / runs,
 		fieldPrecision: totalScored === 0 ? null : totalCorrect / totalScored,
@@ -759,6 +1181,12 @@ export const summarizeScores = (
 			totalContactsExpected === 0
 				? null
 				: totalContactsFound / totalContactsExpected,
+		organisationKindPrecision: perRow(totalRowsRightKind),
+		requestCoverage:
+			totalPartsExpected === 0 ? null : totalPartsAnswered / totalPartsExpected,
+		duplicateRate: perRow(totalRowsDuplicated),
+		locationFill: perRow(totalRowsLocated),
+		rowsPerScan: scansScored === 0 ? null : totalRowsReturned / scansScored,
 		fieldsFilledPerRun:
 			runsWithProfile === 0 ? null : totalFieldsFilled / runsWithProfile,
 		profileFieldsTotal: runsWithProfile === 0 ? null : profileFieldsTotal,
@@ -768,7 +1196,9 @@ export const summarizeScores = (
 			runsWithProfile === 0 ? null : totalContactsTitled / runsWithProfile,
 		costPerRun: runsWithUsage === 0 ? null : totalCostCents / runsWithUsage,
 		costPerGroundedRun:
-			runsWithUsage === 0 || grounded === 0 ? null : totalCostCents / grounded,
+			groundedRunsWithUsage === 0
+				? null
+				: groundableCostCents / groundedRunsWithUsage,
 		paidCostPerRun:
 			runsWithUsage === 0 ? null : totalPaidCostCents / runsWithUsage,
 		tokensPerRun:

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -66,6 +66,9 @@ export {
 export {
 	type EvalSummary,
 	type GoldenExpectation,
+	type MarketExpectation,
+	type MarketPart,
+	type MarketScore,
 	type RunOutcome,
 	type RunScore,
 	type RunUsage,


### PR DESCRIPTION
## What

When you ask Batuda for a whole market — "installation companies in Spain: electrical, plumbing, solar, fire protection, lifts" — it answers with a list. Until now the quality harness that grades those answers effectively counted how many companies came back. The run on 13 August proves that grades the wrong thing: 62 rows, of which 23 were trade bodies and 10 were the same company written twice, with four of the five trades missing entirely, is a *healthy-looking count*. The harness would have called it green, which is exactly what the run itself did.

This makes the harness grade what was actually wrong with the list. It changes no product behaviour — it is a developer tool (`packages/research`'s eval, driven from `apps/cli`) — but it is what lets the next changes in #456 be judged instead of guessed. That plan's ordering rule is that anything with a known cost in results lands *after* the measurement that would show it, and existence verification (§4.8) deliberately trades results for certainty. Without this there is no before-number.

## Changes

- A golden row — one line of the known-correct answers every run is scored against — can now describe a **market** rather than one company: the parts it asks for, and the organisations known not to be companies there. It names no company address, because there is no one company for the run to have reached.
- A market is graded on four things: how many rows are the **kind of organisation** asked for, how many of the request's **parts** got an answer, how many rows **repeat** another, and how many say **where** the company is. The row count is still reported, as the scale those read against — and because it is the number existence verification will cost.
- Every figure that asks about the one company a run was sent after now reports **"does not apply"** rather than zero for a market search: reaching the target, the two look-alike rates, and how full a profile came back. Zero was a failing grade on five questions nobody asks a market search, and it dragged the monitoring board's own averages down with it.
- Three ways a market pass could measure nothing without saying so are closed: the pipeline's own twenty-minute cap killed a long search mid-way and left its half-built list reading as an empty market; a market golden set run against the profile shape scored every market at zero; and a search that looked and honestly found nothing was dropped from the figures instead of counted as the answer it is.
- The two figures that can read clean when the list is not carry their bounds in writing, at the definition rather than in a doc nobody opens.

## Impact

- **No production behaviour changes.** Nothing here runs on the server. `packages/research/src/index.ts` gains type exports; `apps/cli`'s `research eval` and `research eval-invariance` change their output and their input validation.
- **No migration, no new env var, no auth or RLS surface, no wire-shape change** to `packages/controllers` or `packages/domain`. MCP/HTTP parity is untouched — no service changed.
- **One operational note that will bite whoever runs this next:** `RESEARCH_RUN_DEADLINE_SEC` defaults to 1200 (20 minutes), and a market search runs 20–32. Past that the run is killed and the eval sees a market that answered nothing. A market pass must raise it (2400), and the CLI now waits 45 minutes so the poll outlives the run. This is recorded in the `/run-research-eval` skill.
- **Two commands now refuse input they used to accept**, both to stop a silently-wrong measurement: a market golden set requires `--schema prospect_scan_v1`, and a golden row may not carry both a market block and company keys (an address, expected fields, expected contacts).

## Review guide

Start with `packages/research/src/application/eval-scoring.ts` — it holds the four figures and their bounds. `eval-outcome.ts` is next: it decides what a scan's row carries.

**The riskiest judgement, and the one to overrule if you disagree.** Request coverage reads a row's `industry`, `why_relevant` and `description` to decide which trade it answers. `why_relevant` is the field most likely to repeat the request back — but on the live pass only **24 of 53 rows** carried an `industry` at all, and `why_relevant` is the only one of the three a prospect row must fill. Excluding it made coverage a reading of how often an optional field got filled: the same Spanish market scored **40%** without it and **100%** with it, on identical data. I chose the reading that doesn't silence half the list, and wrote down what it costs — a row naming several trades counts for each, which is right for a genuine multi-trade installer and generous towards one listing back what was asked. If you'd rather have the strict reading, this is the line to change.

**Two limits I documented rather than engineered around**, both because reading them wrong is worse than the limit itself:

- **Duplicate rate reuses the identity the pipeline itself folds rows on.** So it answers "is that fold still working", never "are those keys wide enough". The French run makes this concrete: one company came back once under its own name and four more times as that name plus a branch town, none of the four with a website — no shared name key, no shared host — and the figure read 0%. The product-side fix is out of scope here; I've flagged it separately.
- **Location fill counts any stated place**, a bare country included, though the field is asked for a town or province. Separating them needs country data the scorer deliberately doesn't carry.

**What I could not demonstrate.** The headline claim of this slice is that a per-market number makes the organisation-kind guard's language gap visible — it reads Spanish, Catalan and English, and recognised four of fifteen European trade bodies. The French run returned **no trade bodies at all**, so the gap was never exercised. Both markets read 100% on organisation kind. The measurement is in place and would show it; this pass didn't trigger it.

`eval/golden-markets.example.json` is data — skim it. The `notCompanies` entries follow two rules the README now spells out, because getting them wrong fails silently as a perfect score.

## Tests

1311 unit tests in `packages/research`, of which this adds coverage for: the four figures and their roll-up; a market row parsed and rejected; a search that found nothing counting while a run that died does not; the transitive merge in the duplicate fold; a trade body not answering for the trade it represents; and every figure reporting "does not apply" on a market pass.

A review round mutation-tested the suite — changing the implementation to confirm tests actually fail — which found seven assertions that held under both the right and the wrong behaviour. Those are now pinned.

## Verification

- Gates run on this branch: `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test` (21 tasks), `pnpm -w build` — all green.
- **Two live billable passes** against the local stack with production routing and the two-slot cascade, registries off: Spanish market (11 rows, 12¢) and French market (42 rows, 9¢). The French pass fell back to a second extract model, so read its numbers with that in mind.
- Both passes re-scored offline against the final code, so the reported numbers match what is on this branch rather than what was on it at run time.
- Not a UI change — no screenshots. Nothing in `apps/internal` or `packages/ui` is touched.

## Deferred

- Folding branch-office rows onto their parent company in the pipeline's own de-duplication — found by this work, but a product defect rather than a measurement one.
- Telling a town or province from a bare country in location fill.

Closes #466
