### PR TITLE
fix(research): stop a website being the page its claim was read from

### DIFF
--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -3121,11 +3121,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								{
 									// Website sanity: a scanned competitor or prospect sometimes comes
 									// back with a directory's profile page ("cbinsights.com/company/…")
-									// where its own site belongs, with a note glued to the address, or
-									// with the page a trade body gives it in its member list. Blank all
-									// of those, so nothing but a company's own site lands in the CRM's
-									// website field. Deterministic and evidence-free, so it runs here
-									// among the plain checks, ahead of the model critics.
+									// where its own site belongs, with a note glued to the address,
+									// with the page a trade body gives it in its member list, or with
+									// the very page its claim was read from. Blank all of those, so
+									// nothing but a company's own site lands in the CRM's website
+									// field. Deterministic and evidence-free, so it runs here among the
+									// plain checks, ahead of the model critics.
 									name: 'websites',
 									run: findings =>
 										Effect.gen(function* () {
@@ -3148,7 +3149,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												check.blankedNotAnAddress +
 												check.blankedDirectory +
 												check.blankedProfilePage +
-												check.blankedSharedHost
+												check.blankedSharedHost +
+												check.blankedReadPage
 											if (blanked > 0) {
 												yield* Effect.logWarning(
 													'research.websites.blanked',
@@ -3159,6 +3161,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														blanked_directory: check.blankedDirectory,
 														blanked_profile_page: check.blankedProfilePage,
 														blanked_shared_host: check.blankedSharedHost,
+														blanked_read_page: check.blankedReadPage,
 													}),
 												)
 											}

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -14,6 +14,36 @@ const websitesOf = (findings: unknown): Array<string | undefined> =>
 		c => c.website,
 	)
 
+// A prospect row the way a scan really returns one: a name, the website the model
+// gave for it, and the sources it cited for the company.
+const cited = (
+	rows: ReadonlyArray<{
+		name: string
+		website?: string
+		sources?: ReadonlyArray<unknown>
+	}>,
+) => ({
+	prospects: rows.map(({ name, website, sources }) => ({
+		name,
+		...(website === undefined ? {} : { website }),
+		citations: (sources ?? []).map(source =>
+			typeof source === 'string'
+				? { source_id: source, confidence: 0.6 }
+				: source,
+		),
+	})),
+})
+
+const prospectWebsites = (findings: unknown): Array<string | undefined> =>
+	(findings as { prospects: Array<{ website?: string }> }).prospects.map(
+		p => p.website,
+	)
+
+// The address the French solar directory files a company at: a slug naming a trade
+// and a role, ending in the listing's own record number, and naming no company.
+const TECSOL_LISTING =
+	'https://annuaire.tecsol.fr/liste-fournisseur-solaire-installateurs-epc-339615/'
+
 describe('guardCompanyWebsites', () => {
 	describe('when the run watched the host file several of its companies', () => {
 		it('should blank the website and count it as a directory', () => {
@@ -96,6 +126,63 @@ describe('guardCompanyWebsites', () => {
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.blankedDirectory).toBe(0)
+		})
+
+		it('should find a name the address writes with escaped accents', () => {
+			// GIVEN a Spanish directory filing a company whose name carries an accent,
+			// which the address spells as an escape the way such a site does
+			const findings = scan([
+				{
+					name: 'Grupo Muñoz',
+					website: 'https://directorio.es/empresa/grupo-mu%C3%B1oz',
+				},
+			])
+
+			// WHEN checked
+			// THEN it is caught. The address is put back into letters before the name is
+			// looked for, so the escaping does not hide the listing — and a run over a
+			// Spanish or Catalan market meets this spelling constantly
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([undefined])
+			expect(result.blankedProfilePage).toBe(1)
+		})
+
+		it('should read a part whose escaping was never valid as it stands', () => {
+			// GIVEN a listing path carrying a stray percent sign, which is not escaping
+			// anything
+			const findings = scan([
+				{
+					name: 'Redwood Logistics',
+					website: 'https://dir.example/empresa/redwood-logistics%zz',
+				},
+			])
+
+			// WHEN checked — THEN the part is read as written rather than thrown away,
+			// so a path that was never valid escaping still gets judged
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([undefined])
+			expect(result.blankedProfilePage).toBe(1)
+		})
+
+		it('should not let an escaped slash invent a deeper part', () => {
+			// GIVEN a company's own first-level page whose name holds an escaped slash
+			const findings = scan([
+				{
+					name: 'XPO Logistics',
+					website: 'https://xpo.com/about%2Fxpo-logistics',
+				},
+			])
+
+			// WHEN checked
+			// THEN it stands. The address has one part, and putting it back into letters
+			// must not split it into two — read the other way round, the name would land
+			// in a "deeper" part that the address never had, and the company would lose
+			// its own page
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://xpo.com/about%2Fxpo-logistics',
+			])
+			expect(result.blankedProfilePage).toBe(0)
 		})
 
 		it('should blank one even when the company name is short', () => {
@@ -277,6 +364,7 @@ describe('guardCompanyWebsites', () => {
 				blankedDirectory: 0,
 				blankedProfilePage: 0,
 				blankedSharedHost: 0,
+				blankedReadPage: 0,
 			})
 		})
 
@@ -383,6 +471,77 @@ describe('guardCompanyWebsites', () => {
 				],
 			).toEqual(website)
 			expect(result.blankedDirectory + result.blankedProfilePage).toBe(0)
+		})
+
+		it('should blank the answer when it is the page it was read from', () => {
+			// GIVEN the profile's website field holding a listing page, with the source
+			// beside it naming that same page — the field is its own citation list
+			const findings = {
+				enrichment: {
+					website: {
+						value: TECSOL_LISTING,
+						source_id: TECSOL_LISTING,
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN checked against the company the run is about
+			const result = guardCompanyWebsites(findings, 'KBE Energy')
+
+			// THEN the same reading reaches the field that arrives alone: nothing in
+			// the address names the company, and its source is the address itself
+			expect(
+				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
+					'website'
+				],
+			).toBeNull()
+			expect(result.blankedReadPage).toBe(1)
+		})
+
+		it('should blank the target own deep page when nothing names it — the cost', () => {
+			// GIVEN a real company page on a domain that spells no part of its name, read
+			// and recorded as the one page behind the answer
+			const url = 'https://gd-holding.fr/qui-sommes-nous'
+			const findings = {
+				enrichment: {
+					website: { value: url, source_id: url, confidence: null },
+				},
+			}
+
+			// WHEN checked against the company the run is about
+			const result = guardCompanyWebsites(findings, 'Groupe Dupont SA')
+
+			// THEN it goes, and this is the price of the rule rather than a bug: the
+			// field carries one source and can never carry a second, so nothing here can
+			// tell this apart from a listing page recorded the same way. Pinned so the
+			// cost stays visible instead of being discovered in a run
+			expect(
+				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
+					'website'
+				],
+			).toBeNull()
+			expect(result.blankedReadPage).toBe(1)
+		})
+
+		it('should keep the answer when it was read from another page', () => {
+			// GIVEN the run's answer for the target's site, read from a page elsewhere
+			const website = {
+				value: 'https://kbe-groupe.example/nos-activites',
+				source_id: 'https://www.lemoniteur.fr/kbe-energy',
+				confidence: null,
+			}
+			const findings = { enrichment: { website } }
+
+			// WHEN checked — THEN the address is not where the claim came from, so this
+			// rule has nothing to say about it
+			const result = guardCompanyWebsites(findings, 'KBE Energy')
+			expect(
+				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
+					'website'
+				],
+			).toEqual(website)
+			expect(result.blankedReadPage).toBe(0)
 		})
 
 		it('should leave a competitor website judged against its own name', () => {
@@ -617,6 +776,348 @@ describe('guardCompanyWebsites', () => {
 					.prospects[0]?.website,
 			).toBe('https://acme.es')
 			expect(result.blankedSharedHost).toBe(0)
+		})
+	})
+
+	describe('when the website is the page the row claim was read from', () => {
+		it('should blank a listing page that names the company nowhere', () => {
+			// GIVEN a French solar directory's listing page handed back as a company's
+			// own website, cited as the one page the company was read on — the shape
+			// every other rule here misses: one company on the host, and a slug in the
+			// first path segment that names a trade instead of a company
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [TECSOL_LISTING],
+				},
+			])
+
+			// WHEN checked
+			const result = guardCompanyWebsites(findings)
+
+			// THEN the address goes: nothing in it names the company, and its own
+			// citation says only that the run read the page
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedReadPage).toBe(1)
+			// AND no other rule claims it, so the counters stay diagnostic
+			expect(
+				result.blankedDirectory +
+					result.blankedProfilePage +
+					result.blankedSharedHost +
+					result.blankedNotAnAddress,
+			).toBe(0)
+		})
+
+		it('should leave the rest of the row it blanks alone', () => {
+			// GIVEN the same row, carrying the fields that are not the website
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [TECSOL_LISTING],
+				},
+			])
+
+			// WHEN checked
+			// THEN only the website key is dropped — the company and its evidence stay,
+			// because what was wrong was the address, not the company
+			expect(guardCompanyWebsites(findings).findings).toEqual({
+				prospects: [
+					{
+						name: 'KBE Energy',
+						citations: [{ source_id: TECSOL_LISTING, confidence: 0.6 }],
+					},
+				],
+			})
+		})
+
+		it('should keep a company own site read from that very page', () => {
+			// GIVEN the ordinary case this rule must never touch: a company's own site,
+			// with the run having read the claim from that same page
+			const own = 'https://redwoodlogistics.com/about-us'
+			const findings = cited([
+				{ name: 'Redwood Logistics', website: own, sources: [own] },
+			])
+
+			// WHEN checked — THEN the host carries the name, which settles it long
+			// before the page it was read from is asked about
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([own])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should keep an about-us page in the first segment read from itself', () => {
+			// GIVEN the exemption that protects the large carriers: a company
+			// describing itself in the first path segment of its own host, cited as the
+			// page it was read on
+			const own = 'https://xpo.com/about-xpo-logistics'
+			const findings = cited([
+				{ name: 'XPO Logistics', website: own, sources: [own] },
+			])
+
+			// WHEN checked
+			// THEN it stands. The host names nobody and the page is the one that was
+			// read, so what separates this from the listing above is the single thing
+			// this rule adds: the first segment spells the company out
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([own])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should keep a host carrying one distinctive word of the name', () => {
+			// GIVEN a company whose own domain holds part of its name rather than all
+			// of it, on the page the claim was read from
+			const own = 'https://gopenske.com/logistics'
+			const findings = cited([
+				{ name: 'Penske Logistics', website: own, sources: [own] },
+			])
+
+			// WHEN checked — THEN one distinctive word inside the host is a mention,
+			// and a mention anywhere withholds the blank
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([own])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should keep a bare host even when that is the page that was read', () => {
+			// GIVEN a plain host given as a website and cited as the page read, naming
+			// the company nowhere
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: 'https://annuaire.tecsol.fr',
+					sources: ['https://annuaire.tecsol.fr'],
+				},
+			])
+
+			// WHEN checked
+			// THEN it stays. With no path there is no page to tell apart from the site,
+			// so the tell this rule reads is absent and what is left is the ordinary
+			// case — a run that read a home page and wrote the site down
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://annuaire.tecsol.fr',
+			])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should keep a page whose accented name the address writes as escapes', () => {
+			// GIVEN a company's own page filed under its accented name, which the
+			// address spells in escapes the way a Spanish or Catalan site does
+			const own = 'https://serveis.example/grupo-mu%C3%B1oz'
+			const findings = cited([
+				{ name: 'Grupo Muñoz', website: own, sources: [own] },
+			])
+
+			// WHEN checked — THEN the name is found through the escaping, so the page
+			// is read as naming the company and kept
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([own])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should blank when every citation the row has is that one page', () => {
+			// GIVEN a row citing the listing page three times, once per quote it took
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [TECSOL_LISTING, TECSOL_LISTING, TECSOL_LISTING],
+				},
+			])
+
+			// WHEN checked — THEN the same page cited repeatedly is still one page, and
+			// still the only thing that mentioned the company
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedReadPage).toBe(1)
+		})
+
+		it('should keep the address when another source mentions the company too', () => {
+			// GIVEN a row backed by a second, separate page as well
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [TECSOL_LISTING, 'https://www.lemoniteur.fr/kbe-energy'],
+				},
+			])
+
+			// WHEN checked
+			// THEN it stands. This rule speaks only for a row whose whole evidence is
+			// the address itself; once something else has mentioned the company, what
+			// the address is stops being a question this rule can answer
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should keep an address the row cites nothing at all for', () => {
+			// GIVEN the same listing address on a row with no citations
+			const findings = cited([
+				{ name: 'KBE Energy', website: TECSOL_LISTING, sources: [] },
+			])
+
+			// WHEN checked — THEN a row citing nothing says nothing either way, so
+			// there is no provenance to read and the address is left alone
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should read a citation written without a scheme as the same page', () => {
+			// GIVEN the website with its scheme and the citation without one, and a
+			// trailing slash on only one of the two
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [
+						'annuaire.tecsol.fr/liste-fournisseur-solaire-installateurs-epc-339615',
+					],
+				},
+			])
+
+			// WHEN checked — THEN the two spellings are one page, so tidying the
+			// citation does not hide where the claim came from
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedReadPage).toBe(1)
+		})
+
+		it('should read past a tracking parameter on the citation', () => {
+			// GIVEN the citation carrying the parameters of the link that reached it
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [`${TECSOL_LISTING}?utm_source=serp`],
+				},
+			])
+
+			// WHEN checked — THEN a page is the same page whichever link led to it
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedReadPage).toBe(1)
+		})
+
+		it('should keep an address cited at the same path on another host', () => {
+			// GIVEN a citation whose path matches but whose host does not
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [
+						'https://autre-annuaire.fr/liste-fournisseur-solaire-installateurs-epc-339615/',
+					],
+				},
+			])
+
+			// WHEN checked — THEN a matching path on a different site is a different
+			// page, so the website is not where the claim came from
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should keep an address whose only citation is an internal source id', () => {
+			// GIVEN a row citing a page by the id the run stored it under
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: ['src_9f2a1b3c4d5e6f70'],
+				},
+			])
+
+			// WHEN checked
+			// THEN nothing fires: an opaque id names no host, so it can neither match
+			// the address nor be mistaken for it. The rule reads a citation only when
+			// the model wrote it as the address it is
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should skip a citation entry that names no source', () => {
+			// GIVEN a row whose citations are a quote with no source beside it and the
+			// listing page itself
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [
+						{ quote: 'KBE Energy, installateur EPC', confidence: 0.4 },
+						TECSOL_LISTING,
+					],
+				},
+			])
+
+			// WHEN checked — THEN an entry naming no source has mentioned the company
+			// nowhere, so it neither counts as another source nor blocks the rule
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedReadPage).toBe(1)
+		})
+
+		it('should keep an address on a row whose citations are not a list', () => {
+			// GIVEN a malformed row whose `citations` is a string
+			const findings = {
+				prospects: [
+					{
+						name: 'KBE Energy',
+						website: TECSOL_LISTING,
+						citations: 'annuaire.tecsol.fr',
+					},
+				],
+			}
+
+			// WHEN checked — THEN there is no citation to read, so the row is judged
+			// with nothing and its address stands
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should report a host several rows claim as the shared host it is', () => {
+			// GIVEN two companies each given their page on a trade body's host, each
+			// citing the page it was read on
+			const findings = cited([
+				{
+					name: 'Electricidad Mora',
+					website: 'https://aemiat.com/e-mora/',
+					sources: ['https://aemiat.com/e-mora/'],
+				},
+				{
+					name: 'Instalaciones Rubio',
+					website: 'https://aemiat.com/rubio/',
+					sources: ['https://aemiat.com/rubio/'],
+				},
+			])
+
+			// WHEN checked — THEN both go, counted under the rule that knows more about
+			// why: several rows claiming one host says it belongs to none of them
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([undefined, undefined])
+			expect(result.blankedSharedHost).toBe(2)
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should report a listing shape as the profile page it is', () => {
+			// GIVEN a directory filing the company one level down, cited as the page
+			// the claim was read from
+			const listing = 'https://directorio.es/empresa/acme-instal'
+			const findings = cited([
+				{ name: 'Acme Instal', website: listing, sources: [listing] },
+			])
+
+			// WHEN checked — THEN the address shape is the more exact diagnosis and
+			// keeps the count
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedProfilePage).toBe(1)
+			expect(result.blankedReadPage).toBe(0)
 		})
 	})
 

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -17,7 +17,10 @@
  *    of the address — the shape of "someone-else.com/company/<the-company>", which
  *    is a listing, never a company's own home page, or
  *  - its host does not carry the company's name AND other companies in the same
- *    answer claim that host as theirs too.
+ *    answer claim that host as theirs too, or
+ *  - nothing in the address names the company anywhere AND the address is the one
+ *    page every source the row cites points at — the field holding the page the
+ *    claim was read from rather than the site that page sits on.
  * Anything else is kept: a company's own site names it in the host ("acme.com") or
  * describes itself in the first path segment ("xpo.com/about-xpo-logistics"), and a
  * blank costs a real website, so the bar to blank is deliberately high.
@@ -26,22 +29,37 @@
  * need no evidence corpus and no database. They fire on any object carrying both —
  * a scanned competitor or prospect — and on the run's own answer for the target's
  * website, which arrives on its own with no name beside it and so is judged against
- * the target's name passed in. The shared-host rule asks about the whole answer
- * rather than one row, which is why the walk below is preceded by a reading pass
- * that gathers who claims which host; the directory rule asks about the whole RUN,
- * and is handed its answer from outside (see `directory-sites.ts`).
+ * the target's name passed in. The read-page rule reads one more thing off the same
+ * row, the sources it cites, which travel with it. The shared-host rule asks about
+ * the whole answer rather than one row, which is why the walk below is preceded by
+ * a reading pass that gathers who claims which host; the directory rule asks about
+ * the whole RUN, and is handed its answer from outside (see `directory-sites.ts`).
  */
 
 import { type DirectorySites, siteVerdict } from './directory-sites'
 import {
 	collapse,
 	DISTINCTIVE_NAME_LENGTH,
+	distinctiveWords,
 	nameWithoutForms,
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
-import { hostOf, isBareWebAddress } from './source-key'
+import { hostOf, isBareWebAddress, pathOf } from './source-key'
 
 const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
+
+// A part of an address put back into letters. A Spanish or Catalan listing writes
+// the accents of a name it files as escapes, and a name looked for through them
+// spells nothing; a part that was never valid escaping is read as it stands rather
+// than dropped. Decoded part by part, so an escaped slash cannot invent a part
+// that was never there.
+const withoutEscapes = (segment: string): string => {
+	try {
+		return decodeURIComponent(segment)
+	} catch {
+		return segment
+	}
+}
 
 // The parts of the address after the host — ["company", "redwood-logistics"] from
 // "cbinsights.com/company/redwood-logistics". A scheme is added when missing, since
@@ -51,10 +69,83 @@ const pathSegmentsOf = (website: string): ReadonlyArray<string> => {
 		? website
 		: `https://${website}`
 	try {
-		return new URL(withScheme).pathname.split('/').filter(Boolean)
+		return new URL(withScheme).pathname
+			.split('/')
+			.filter(Boolean)
+			.map(withoutEscapes)
 	} catch {
 		return []
 	}
+}
+
+// Whether the address mentions the company anywhere in it — in the host or in any
+// part of the path, the first part included. Read as loosely as anything here reads
+// a name: the whole name with its legal form taken out, or any one distinctive word
+// of it, found anywhere inside. Loose on purpose, because a mention only ever
+// withholds the blank below: reading it loosely costs that rule its reach, never a
+// company its site.
+//
+// The host and the parts are handed in rather than read again, so this cannot come
+// to a different reading of the same address than the rules above did.
+const addressNamesCompany = (
+	name: string,
+	host: string,
+	segments: ReadonlyArray<string>,
+): boolean => {
+	const parts = [collapse(host), ...segments.map(collapse)]
+	const core = nameWithoutForms(name)
+	const words = distinctiveWords(name)
+	return parts.some(
+		part =>
+			(core !== '' && part.includes(core)) ||
+			words.some(word => part.includes(word)),
+	)
+}
+
+// A page, told from the site it sits on: the path with any trailing slash off. The
+// query is left out, because a page is the same page whichever tracking parameters
+// were on the link that reached it.
+const pageOf = (url: string): string => (pathOf(url) ?? '').replace(/\/+$/, '')
+
+// Whether two addresses are the same page, however each side spelled it — a model
+// writes the site with a scheme and cites it without one, or one of the two keeps
+// its trailing slash.
+//
+// Not `canonicalizeUrl`, which is how the rest of the package settles whether two
+// addresses are one: it hands back the string untouched when the address has no
+// scheme, so a citation tidied down to "acme.es/x" would never be found to be the
+// same page as "https://acme.es/x" — the very spelling a model reaches for. Reading
+// the host and the path apart handles both spellings, because both readers add a
+// scheme when one is missing.
+const samePage = (one: string, other: string): boolean => {
+	const host = hostOf(one)
+	return (
+		host !== null && host === hostOf(other) && pageOf(one) === pageOf(other)
+	)
+}
+
+// Whether the row cites nothing but this one page: the website field holding where
+// the claim came from, with nothing else having mentioned the company at all. A row
+// that cites nothing says nothing either way.
+const citesNothingButThisPage = (
+	website: string,
+	citedSources: ReadonlyArray<string>,
+): boolean =>
+	citedSources.length > 0 &&
+	citedSources.every(source => samePage(website, source))
+
+// The sources a row cites, as the model wrote them. Read off the row here because
+// the walk below copies the citation subtree through untouched.
+const citedSourcesOf = (
+	value: Record<string, unknown>,
+): ReadonlyArray<string> => {
+	const citations = value['citations']
+	if (!Array.isArray(citations)) return []
+	return citations.flatMap(entry =>
+		isPlainObject(entry) && typeof entry['source_id'] === 'string'
+			? [entry['source_id']]
+			: [],
+	)
 }
 
 // Who claims which host, across a whole answer: a host mapped to the name cores of
@@ -103,14 +194,17 @@ type WebsiteVerdict =
 	| 'directory'
 	| 'profile_page'
 	| 'shared_host'
+	| 'read_page'
 
 // Where a website really points, for a company by this name.
-const classifyWebsite = (
-	name: string,
-	website: string,
-	hostClaims: HostClaims,
-	directorySites: DirectorySites,
-): WebsiteVerdict => {
+const classifyWebsite = (args: {
+	readonly name: string
+	readonly website: string
+	readonly citedSources: ReadonlyArray<string>
+	readonly hostClaims: HostClaims
+	readonly directorySites: DirectorySites
+}): WebsiteVerdict => {
+	const { name, website, citedSources, hostClaims, directorySites } = args
 	const host = hostOf(website)
 	// Not an address at all: a value with words written next to it ("https://acme.es
 	// (inferred from the name)"), or something that was never a URL. A website field
@@ -136,8 +230,8 @@ const classifyWebsite = (
 	// excluded, because a company's own site describes itself right there
 	// ("xpo.com/about-xpo-logistics") while a directory files it one level down
 	// ("company/<name>").
-	const deeperSegments = pathSegmentsOf(website).slice(1)
-	if (deeperSegments.some(segment => collapse(segment).includes(core))) {
+	const segments = pathSegmentsOf(website)
+	if (segments.slice(1).some(segment => collapse(segment).includes(core))) {
 		return 'profile_page'
 	}
 	// A host several companies in this answer call their own, and that none of them
@@ -160,6 +254,30 @@ const classifyWebsite = (
 	) {
 		return 'shared_host'
 	}
+	// A page on somebody's host, which is the very page this row's claim was read
+	// from, and which names the company nowhere. Reading a page and writing down the
+	// site it sits on is the ordinary case — "acme.com/about" read, "acme.com"
+	// recorded — and what is missing here is exactly that step: what was recorded is
+	// the reading material itself, on a host that says nothing about who owns it. So
+	// nothing in the row establishes that the company owns the address, and its own
+	// citation says only that the run read the page.
+	//
+	// That is what a directory's listing page looks like from inside the answer, and
+	// every rule above needs something it withholds: one company on the host, a slug
+	// naming a trade instead of a company, and the first-segment
+	// exemption letting that slug through without ever asking whether it names the
+	// company at all. This asks.
+	//
+	// A bare host is left alone even when it is the page that was read. With no path
+	// there is no page to tell apart from the site, so the tell is absent and what
+	// is left is the ordinary case again.
+	if (
+		segments.length > 0 &&
+		citesNothingButThisPage(website, citedSources) &&
+		!addressNamesCompany(name, host, segments)
+	) {
+		return 'read_page'
+	}
 	return 'keep'
 }
 
@@ -174,15 +292,17 @@ export interface WebsiteGuardResult {
 	readonly blankedProfilePage: number
 	/** Websites blanked because other companies in the answer claim the same host. */
 	readonly blankedSharedHost: number
+	/** Websites blanked because they were the page the row's claim was read from. */
+	readonly blankedReadPage: number
 }
 
 /**
  * `targetName` is the company the run is about, for the one website that is the
  * run's own answer for it rather than a scanned stranger's. That field sits alone —
  * a value with the page it came from and no company name beside it — so without the
- * name told from outside, the two name-based rules have nothing to compare and only
- * the address rule and the directory rule are left. Pass it: a run about one named
- * company observes no directories either, since telling one takes a list of
+ * name told from outside, every rule that reads a name has nothing to compare and
+ * only the address rule and the directory rule are left. Pass it: a run about one
+ * named company observes no directories either, since telling one takes a list of
  * companies to watch a host file, and such a run has one company.
  *
  * `directorySites` are the hosts the run itself watched behave like a listing. It
@@ -198,13 +318,17 @@ export const guardCompanyWebsites = (
 	let blankedDirectory = 0
 	let blankedProfilePage = 0
 	let blankedSharedHost = 0
+	let blankedReadPage = 0
 	const hostClaims = collectHostClaims(findings)
 
 	const count = (verdict: Exclude<WebsiteVerdict, 'keep'>): void => {
 		if (verdict === 'not_an_address') blankedNotAnAddress++
 		else if (verdict === 'directory') blankedDirectory++
 		else if (verdict === 'profile_page') blankedProfilePage++
-		else blankedSharedHost++
+		else if (verdict === 'shared_host') blankedSharedHost++
+		// Named rather than left as the remaining case, so a verdict added later is
+		// not quietly added to this one's total.
+		else if (verdict === 'read_page') blankedReadPage++
 	}
 
 	// Walk one child, honouring the key it sits under: the proposed-update and
@@ -218,18 +342,28 @@ export const guardCompanyWebsites = (
 		if (!isPlainObject(value)) return value
 
 		// The run's own answer for the target's website: a value carrying the page it
-		// was read from, under the `website` key, with no company name beside it.
+		// was read from, under the `website` key, with no company name beside it. The
+		// page it came from is that one source, so the field is its own citation list.
+		//
+		// Which makes the read-page rule stricter here than it is on a scanned row: a
+		// row with a second source elsewhere stands that rule down, and this field can
+		// never have one, so the address naming the company is the only thing holding
+		// the value. A company whose own domain spells no part of its name loses a real
+		// page it published — the cost this file keeps paying for a high bar elsewhere,
+		// and the one place the bar is lower than the rest.
 		if (
 			key === 'website' &&
 			typeof value['value'] === 'string' &&
 			typeof value['name'] !== 'string'
 		) {
-			const verdict = classifyWebsite(
-				targetName ?? '',
-				value['value'],
+			const verdict = classifyWebsite({
+				name: targetName ?? '',
+				website: value['value'],
+				citedSources:
+					typeof value['source_id'] === 'string' ? [value['source_id']] : [],
 				hostClaims,
 				directorySites,
-			)
+			})
 			if (verdict !== 'keep') {
 				count(verdict)
 				// Emptied rather than removed: the field is the whole object here, and
@@ -242,7 +376,13 @@ export const guardCompanyWebsites = (
 		const name = value['name']
 		const website = value['website']
 		if (typeof name === 'string' && typeof website === 'string') {
-			const verdict = classifyWebsite(name, website, hostClaims, directorySites)
+			const verdict = classifyWebsite({
+				name,
+				website,
+				citedSources: citedSourcesOf(value),
+				hostClaims,
+				directorySites,
+			})
 			if (verdict !== 'keep') {
 				count(verdict)
 				// Drop the key entirely, so the value reads as one the model never
@@ -265,5 +405,6 @@ export const guardCompanyWebsites = (
 		blankedDirectory,
 		blankedProfilePage,
 		blankedSharedHost,
+		blankedReadPage,
 	}
 }


### PR DESCRIPTION
## What

When you ask Batuda for a whole market, some of the companies it finds come back with a web address that is not theirs. A French search returned `KBE Energy` whose website was a page on `annuaire.tecsol.fr` — a solar-trade directory. Click it and you land on somebody else's catalogue of installers, not on the company. The field's own description forbids exactly that, and a wrong address is worse than an empty one: it reads as a real site to everything downstream, and to whoever calls the company.

This closes the one shape of that fault that nothing in the chain could see. It is research-side only (`packages/research` — the checks that run over a search's answer before it is saved), and it changes what a search returns: an address that nothing establishes as the company's own is now dropped instead of kept.

## Changes

**Touches:** the check that decides whether a website really belongs to the company it sits beside, the shared reading of a web address that check and the directory watch both use, and the step in the run that calls it — which still runs before the step that folds duplicate rows together, untouched here.

- **A website is dropped when it is the page a claim was read from rather than the site that page sits on.** Reading `acme.com/about` and writing down `acme.com` is the ordinary, correct case — a run reads a page and records the site. What is different here is that the recording step never happened: what was written down is the reading material itself, on a host that says nothing about who owns it. Three things must all hold before anything is dropped: the address is a page rather than a bare site, it is the one page every source that row cites points at, and nothing anywhere in the address names the company.
- **The first part of an address is no longer waved through unasked.** That exemption exists so a company describing itself on its own site survives — `xpo.com/about-xpo-logistics` is XPO's. It used to exempt *any* first part, including a directory's category slug, which is how this fault reached the field. It now asks whether that part actually names the company. XPO survives; `liste-fournisseur-solaire-installateurs-epc-339615` does not.
- **A name written with escaped accents is now found.** A Spanish or Catalan listing writes `Garcés` in an address as `garc%C3%A9s`, and a name looked for through that spelling matched nothing. Addresses are now read with those escapes turned back into letters, which also widens the existing check for a name buried deeper in an address. Each part is decoded on its own, never the whole address at once — the other way round splits `about%2Fxpo-logistics` into two parts and blanks XPO's own page.

## Impact

- **A search's answer can now come back without a `website` where it previously carried one.** This is the point of the change, but it is the thing that ripples: the research inbox and the apply flow both read that field, and a company that had an address now has none. No shape changed — the key is simply absent, the same way every other guard removes a field it rejects.
- **Both ways in get the behaviour.** The check runs inside the shared research pipeline, so a run started over MCP (an assistant like Claude or ChatGPT) and one started over HTTP behave identically. No service boundary moved.
- **One monitoring number quietly widens.** `research.websites.blanked` — the count on the run's span — now includes this new reason alongside the four that already fed it, and the matching log line gains a `blanked_read_page` field. A board reading the total will show a step up that is a new category, not a regression.
- **Nothing else.** No database migration and no schema change; nothing touching which organisation can see what (row-level security), and no change to the Postgres role a path runs under; no new environment variable, so nothing extra to set before production boots; no change to the public/protected boundary or to sign-in; no shared-shape change in `packages/controllers` or `packages/domain`, so the frontend's typed client is untouched; no webhook, fan-out or paid-provider spend behaviour.

## Review guide

Start at `classifyWebsite` in `packages/research/src/application/website-guard.ts` and read the last rule in it. The three helpers above it (`addressNamesCompany`, `samePage`, `citesNothingButThisPage`) are only worth reading once you have the rule's shape. `research-service.ts` is three lines of plumbing — skip it.

**The §9.1 question you asked me to answer: no, I don't think it is safe to close.** §9.1 is a decision rather than a work item, so nothing here closes it — this only removes the counterexample that was gating it. But the honest answer to the decision itself is still *no*. A directory listing can still reach the website field six ways this rule deliberately does not cover: as a bare host with no path (18 of the 23 rows that reached the rule on live data were bare hosts, so this is the broad case rather than a corner); on a row with no citations, or whose citations were removed as ungrounded; on a row with a second citation elsewhere; when the slug happens to carry a distinctive word of the name; when the citation is written as an internal `src_…` id; and on the single-company path described below. So "at least one non-directory source, and the own site counts" can still be satisfied by a directory listing — the fail-open that decision exists to prevent is reachable. What would make "yes" safe is asking the question the other way round: *is this established as the company's own site?* rather than *did the check decline to drop it?*. Reading "not dropped" as clearance repeats precisely the mistake `directory-sites.ts` argues against at length — `unknown` is not `cleared`, and it deliberately has no value meaning cleared. Filed as #476.

**The decision most worth overruling.** On a single-company run, the website field carries exactly one source by construction, so the second of the three conditions — "nothing else mentioned the company" — is true automatically and filters nothing. The bar there is two conditions rather than three, which is lower than this file holds itself to everywhere else, and a real company at a domain spelling no part of its name (`gd-holding.fr/qui-sommes-nous` for "Groupe Dupont SA") loses a page it published. I shipped it applying there, for consistency with every other rule in the file, with the cost written into the code and pinned by a test rather than hidden. My live measurement covered market searches only, so this path is **unmeasured**. Narrowing it to list rows is a one-line change if you'd rather.

**A limit worth knowing before trusting this.** The check that removes ungrounded citations runs *before* this one. In one of the three live runs the model invented all five of its citations and that check correctly removed every one, which left this rule with no provenance to read for the entire run. It only works when a run's citations are grounded.

**What I could not do.** Snyk's code scan was not available in this session, so the new code has not been through it.

## Tests

1378 unit tests in `packages/research`, of which this adds 24 in `website-guard.test.ts`: the reported row itself, on its verbatim address; both shapes that must not regress (a company's own site read from that same page, and an "about us" page at the first path level); the bare-host exemption; the spellings of "the same page" a model actually produces (no scheme, a differing trailing slash, a tracking parameter); an internal `src_…` id, which must not match; rows citing nothing, citing one page several times, and citing a second source; a citation entry naming no source; malformed escaping; an escaped slash that must not invent a deeper part; and the order the five reasons take precedence in, so the counters stay diagnostic.

Two of those pin behaviour I would otherwise have changed silently: the accented-name catch in the pre-existing deeper-path check, and the cost on the single-company path above.

## Verification

- Gates run on this branch: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13 packages), `pnpm -w test`, `pnpm -w build` (13 packages) — all green.
- **Two live billable French market passes** against the local stack with production routing and the two-slot cascade, registries off, via `/run-research-eval` (a third died on a transient internal error with no rows; roughly 20¢ across every run this session). Pass one returned 21 rows, all the right kind of organisation, no duplicates, all five trades covered.
- The findings each run handed the check were captured, and **both the shipped check and this one were replayed over those same real rows**, so the before/after is read off live data rather than asserted. Of 73 rows carrying a website, 50 were settled by a rule that already existed, 23 reached the new rule, and **none was dropped** — `annuaire.tecsol.fr` did not recur, so the reported row is held by a unit test rather than by a live re-fire. With no drops, precision is undefined: that zero says the change destroyed nothing, which is a safety result and not an accuracy one. One live row, `Proquest Engineering` at `proquest.fr/fr/`, was a real company site recorded as the page it was read from and was held back **only** by the "address names the company" condition — without it, this run would have destroyed it.
- Not a UI change — no screenshots. Nothing in `apps/internal` or `packages/ui` is touched.
- `/code-review` at extra-high effort: seven findings, six fixed, the seventh shipped as the judgement call above. Readability pass applied.

## Deferred

- Asking whether a website is *established* as the company's own, rather than only whether it isn't — the root cause behind all six remaining shapes, and what would let §9.1 be answered. #476
- A social-media page kept as a company's website. Both live runs returned one, and no rule here can catch it: `facebook.com/LIPOTECH.SARL` *does* name the company, so every rule that reads a name correctly stands down, and from the address alone it is the same shape as `xpo.com/about-xpo-logistics`. It needs a different signal — the host publishes pages *for* companies rather than *by* them. #477
- Two name shapes that make a listing invisible to every rule that reads a name: Catalan's geminated l (`Instal·lacions` folds to `installacions`, so a slug spelling it `instalacions` never matches), and a name built only from generic words. #478

Closes #471
