### PR TITLE
fix(research): fold a company's branch offices onto the company itself

### DIFF
--- a/apps/server/src/services/research-scan-dedupe.integration.test.ts
+++ b/apps/server/src/services/research-scan-dedupe.integration.test.ts
@@ -1,0 +1,476 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '4'
+process.env['RESEARCH_MAX_LOOP_PROMPT_TOKENS'] ??= '24000'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	ExtractLanguageModel,
+	MapProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	ScrapeProvider,
+	SearchProvider,
+	SearchResult,
+	SearchResultItem,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+// That a company met twice comes back once, checked on the list a run actually
+// stores rather than on the fold in isolation.
+//
+// A search meets one company under its own name and again for each branch office
+// it publishes a page for — "Terre Solaire" beside "Terre Solaire – agence Lyon".
+// The fold that joins those is covered field-by-field by unit tests next to it;
+// what those cannot show is that it still holds with the whole chain running over
+// the list afterwards, and that it holds for a company found in a *later* round,
+// which is a different route into the list from the first reading.
+//
+// The two cases below are those two routes. Both assert the stored `findings`,
+// because that is what a reader is handed.
+//
+// One shared ResearchService layer drives both (a fresh layer per case would open
+// a fresh dispatcher + connection pool each time and exhaust the CI database's
+// connection cap). Each test sets the module-level `scenario` before it runs, and
+// the stubs read it at call time.
+
+interface Org {
+	id: string
+	name: string
+	slug: string
+}
+
+interface Scenario {
+	/** Page text the one "fetched" search result carries. */
+	readonly evidence: string
+	/**
+	 * What each extraction answers with, in order. The last stands for every
+	 * extraction after it, so a case that only cares about the first reading
+	 * states one.
+	 */
+	readonly readings: ReadonlyArray<Record<string, unknown>>
+}
+
+let scenario: Scenario
+let extractionsSoFar = 0
+
+// The opening line of the extraction prompt, and of nothing else. A scan puts two
+// different questions to the extract model — read the evidence into findings, and
+// audit the fields those findings claim — and only the first is what a reading
+// answers. Telling them apart by the question rather than by counting calls keeps
+// the script right whatever else the pipeline decides to ask along the way.
+const EXTRACTION_OPENER = 'Produce structured findings STRICTLY'
+
+const nextReading = (): Record<string, unknown> => {
+	const at = Math.min(extractionsSoFar, scenario.readings.length - 1)
+	extractionsSoFar++
+	return scenario.readings[at] ?? {}
+}
+
+// A canonical URL hashes to itself, so this matches what the run fiber's
+// source-linking computes for the web_search result below.
+const SEED_URL = 'https://annuaire.test/installateurs'
+const SEED_URL_HASH = createHash('sha256').update(SEED_URL).digest('hex')
+
+// The page a later round's focused search brings back.
+const GAP_URL = 'https://annuaire.test/terre-solaire-lyon'
+const GAP_URL_HASH = createHash('sha256').update(GAP_URL).digest('hex')
+const GAP_EVIDENCE =
+	"Terre Solaire – agence Lyon, l'agence lyonnaise de l'installateur photovoltaïque Terre Solaire."
+
+const usage = {
+	inputTokens: {
+		uncached: undefined,
+		total: 0,
+		cacheRead: undefined,
+		cacheWrite: undefined,
+	},
+	outputTokens: { total: 0, text: undefined, reasoning: undefined },
+}
+
+// Agent pass: hand back one web_search result carrying real page text, and no
+// further tool calls, so each pass gathers the seeded source then stops.
+const agentLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({
+			text: '',
+			content: [],
+			reasoning: [],
+			reasoningText: undefined,
+			toolCalls: [],
+			toolResults: [
+				{
+					name: 'web_search',
+					isFailure: false,
+					encodedResult: undefined,
+					result: { items: [{ url: SEED_URL, content: scenario.evidence }] },
+				},
+			],
+			finishReason: 'stop' as const,
+			usage,
+		}) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const extractLlm: LanguageModel.Service = {
+	generateText: () => Effect.succeed({ text: '', content: [], usage }) as never,
+	// An audit gets an empty verdict list, which passes every field it was asked
+	// about; only a reading advances the script.
+	generateObject: ((options: { readonly prompt: string }) =>
+		Effect.succeed({
+			usage,
+			value: options.prompt.startsWith(EXTRACTION_OPENER)
+				? nextReading()
+				: { verdicts: [] },
+		})) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const writerLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({ text: '## Scan brief', content: [], usage }) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+// Nothing else here is reached: a run whose rows cite no page never fetches one,
+// and neither the site map nor a company register is consulted by a scan.
+const die = 'provider not exercised'
+
+// A later round only re-reads when its focused searches actually brought a page
+// back — with nothing new in the evidence it stops rather than asking the same
+// question twice. So the search answers, and answering is what carries the run
+// as far as the second reading.
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({
+			search: () =>
+				Effect.succeed(
+					new SearchResult({
+						units: 1,
+						items: [
+							new SearchResultItem({
+								url: GAP_URL,
+								title: 'Terre Solaire — agence de Lyon',
+								snippet: 'Agence de Lyon',
+								content: GAP_EVIDENCE,
+							}),
+						],
+					}),
+				),
+		}),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({ scrape: () => Effect.die(die) }),
+	),
+	Layer.succeed(MapProvider)(MapProvider.of({ map: () => Effect.die(die) })),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(die) }),
+	),
+)
+
+const eventSink = Layer.succeed(ResearchEventSink)(
+	ResearchEventSink.of({ fire: () => Effect.void }),
+)
+
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			Layer.succeed(AgentLanguageModel)(agentLlm),
+			Layer.succeed(ExtractLanguageModel)(extractLlm),
+			Layer.succeed(WriterLanguageModel)(writerLlm),
+		),
+	),
+	Layer.provide(providersLayer),
+	Layer.provide(
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test',
+				}),
+		}),
+	),
+	Layer.provide(eventSink),
+	Layer.provideMerge(PgLive),
+)
+
+const runtime = ManagedRuntime.make(ResearchLive)
+const TERMINAL = new Set([
+	'succeeded',
+	'succeeded_low_confidence',
+	'failed',
+	'cancelled',
+	'no_reliable_data',
+])
+
+const systemDefaults = {
+	budgetCents: 1000,
+	paidBudgetCents: 500,
+	autoApprovePaidCents: 500,
+	paidMonthlyCapCents: 2000,
+	hardCeiling: 100_000,
+}
+
+const ctx = { org: undefined as unknown as Org }
+let userId: string
+const createdRunIds: string[] = []
+
+interface StoredRow {
+	readonly name: string
+	readonly location: string | null
+}
+
+// Run one scan to its terminal state and report the list it stored.
+const runScan = async (args: {
+	readonly query: string
+	readonly scenario: Scenario
+}): Promise<{
+	status: string
+	prospects: ReadonlyArray<StoredRow>
+	/** How many readings the run asked for, so a case cannot pass vacuously. */
+	readings: number
+}> => {
+	scenario = args.scenario
+	extractionsSoFar = 0
+	return runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ResearchService
+			const sql = yield* SqlClient.SqlClient
+			const scoped = enterOrgScope(sql, { org: ctx.org, userId })
+			const created = yield* scoped(
+				svc.create(
+					userId,
+					ctx.org.id,
+					{
+						query: args.query,
+						schemaName: 'prospect_scan_v1',
+						forceFresh: true,
+					},
+					systemDefaults,
+				),
+			)
+			// A non-selector input never fans out, so it always carries a run id;
+			// rule out the confirm-required variant to keep the type honest.
+			if (created.status === 'confirm_required')
+				return yield* Effect.die(
+					new Error('scan-dedupe test input should not fan out'),
+				)
+			createdRunIds.push(created.id)
+
+			const poll = (
+				attemptsLeft: number,
+			): Effect.Effect<string, never, never> =>
+				Effect.gen(function* () {
+					const run = (yield* svc.get(created.id).pipe(Effect.orDie)) as {
+						status?: string
+					} | null
+					const status = run?.status ?? 'unknown'
+					if (TERMINAL.has(status) || attemptsLeft <= 0) return status
+					yield* Effect.sleep('250 millis')
+					return yield* poll(attemptsLeft - 1)
+				})
+			const status = yield* poll(120)
+
+			const [stored] = yield* scoped(
+				sql<{ findings: unknown }>`
+					SELECT findings FROM research_runs WHERE id = ${created.id}::uuid
+				`,
+			)
+			const list = (stored?.findings as { prospects?: unknown } | null)
+				?.prospects
+			const prospects = Array.isArray(list)
+				? list.map(row => {
+						const held = row as Record<string, unknown>
+						return {
+							name: String(held['name'] ?? ''),
+							location:
+								typeof held['location'] === 'string' ? held['location'] : null,
+						}
+					})
+				: []
+			return { status, prospects, readings: extractionsSoFar }
+		}),
+	)
+}
+
+// Five more installers beside the one under test, so the list is never thin
+// enough to earn the refined retry — that retry re-reads from scratch and would
+// make which reading answers which pass depend on it.
+const OTHERS = [
+	{ name: 'Voltaïque Nord', website: 'https://voltaiquenord.test' },
+	{ name: 'Soleil Atlantique', website: 'https://soleilatlantique.test' },
+	{ name: 'Énergie Cévennes', website: 'https://energiecevennes.test' },
+	{ name: 'Photon Loire', website: 'https://photonloire.test' },
+	{ name: 'Helios Provence', website: 'https://heliosprovence.test' },
+].map(company => ({
+	...company,
+	why_relevant: 'Solar panel installer working across France.',
+	citations: [],
+}))
+
+const PARENT = {
+	name: 'Terre Solaire',
+	website: 'https://terresolaire.test',
+	why_relevant: 'Solar panel installer working across France.',
+	citations: [],
+}
+
+const branch = (town: string) => ({
+	name: `Terre Solaire – agence ${town}`,
+	location: town,
+	why_relevant: 'Solar panel installer working across France.',
+	citations: [],
+})
+
+// The towns have to appear in the page a run read, or the check that holds a
+// location to the evidence blanks it and the row stops looking like a branch.
+const EVIDENCE = [
+	'Annuaire des installateurs photovoltaïques en France.',
+	'Terre Solaire, installateur photovoltaïque, avec ses agences de Douains, Lyon et Montpellier.',
+	'Voltaïque Nord, Soleil Atlantique, Énergie Cévennes, Photon Loire et Helios Provence sont également des installateurs.',
+].join('\n')
+
+beforeAll(async () => {
+	const seed = await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [org] = yield* sql<Org>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [user] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!org || !user) {
+				throw new Error(
+					"taller org / admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			// The one source every pass "fetches", so the grounding gate passes and
+			// each run reaches the list under test.
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (${`src-${randomUUID()}`}, 'web', 'it-stub', ${SEED_URL}, ${SEED_URL_HASH}, 'annuaire.test', 'seed')
+				ON CONFLICT (url_hash) DO NOTHING
+			`
+			// The page a later round's search brings back, so what that round reads is
+			// linked to the run like any other source.
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (${`src-${randomUUID()}`}, 'web', 'it-stub', ${GAP_URL}, ${GAP_URL_HASH}, 'annuaire.test', 'gap')
+				ON CONFLICT (url_hash) DO NOTHING
+			`
+			return { org, userId: user.id }
+		}),
+	)
+	ctx.org = seed.org
+	userId = seed.userId
+}, 60_000)
+
+afterAll(async () => {
+	await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const id of createdRunIds) {
+				yield* sql`DELETE FROM research_cache WHERE research_id = ${id}::uuid`
+				yield* sql`DELETE FROM research_runs WHERE id = ${id}::uuid`
+			}
+			yield* sql`DELETE FROM sources WHERE url_hash IN (${SEED_URL_HASH}, ${GAP_URL_HASH})`
+		}),
+	)
+	await runtime.dispose()
+})
+
+describe('a company met twice in one scan', () => {
+	describe('when one reading names a company and its branch offices', () => {
+		it('should store the company once, under its own name, with every town', async () => {
+			// GIVEN a reading that names an installer and three of its branch offices,
+			//   each carrying only the town it sits in
+			const result = await runScan({
+				query: 'Find solar panel installers in France',
+				scenario: {
+					evidence: EVIDENCE,
+					readings: [
+						{
+							prospects: [
+								PARENT,
+								branch('Douains'),
+								branch('Lyon'),
+								branch('Montpellier'),
+								...OTHERS,
+							],
+						},
+					],
+				},
+			})
+
+			// THEN the stored list holds one Terre Solaire, named as the company rather
+			//   than as one of its branches, and none of the towns was dropped on the
+			//   way — the whole chain runs over the list after the fold, so this is the
+			//   list a reader is actually handed
+			// A run that died after phase 2 wrote its list would still be read below,
+			// so the list is only worth checking once the run itself stands up.
+			expect(result.status).toBe('succeeded')
+			const terreSolaire = result.prospects.filter(row =>
+				row.name.startsWith('Terre Solaire'),
+			)
+			expect(terreSolaire.map(row => row.name)).toEqual(['Terre Solaire'])
+			expect(terreSolaire[0]?.location).toContain('Douains')
+			expect(terreSolaire[0]?.location).toContain('Lyon')
+			expect(terreSolaire[0]?.location).toContain('Montpellier')
+			expect(result.prospects).toHaveLength(6)
+		}, 60_000)
+	})
+
+	describe('when a later round is what turns up the branch office', () => {
+		it('should still store one company, keeping the town the round found', async () => {
+			// GIVEN a first reading that names six installers and no branch at all, and
+			//   a later round that comes back with one company's Lyon office
+			const result = await runScan({
+				query: 'Find solar panel installation companies across France',
+				scenario: {
+					evidence: EVIDENCE,
+					readings: [
+						{ prospects: [PARENT, ...OTHERS] },
+						{ prospects: [branch('Lyon')] },
+					],
+				},
+			})
+
+			// THEN the branch joins the company it belongs to instead of being appended
+			//   beside it. The fold that ran over the first reading never saw this row,
+			//   so a list that only folded then would hand the reader seven companies
+			//   where there are six
+			// The run has to stand up, and the round has to have happened, for any of
+			// this to mean anything.
+			expect(result.status).toBe('succeeded')
+			expect(result.readings).toBeGreaterThan(1)
+			expect(result.prospects).toHaveLength(6)
+			expect(
+				result.prospects.filter(row => row.name.startsWith('Terre Solaire')),
+			).toHaveLength(1)
+			expect(
+				result.prospects.find(row => row.name === 'Terre Solaire')?.location,
+			).toBe('Lyon')
+		}, 60_000)
+	})
+})

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -160,15 +160,24 @@ const nameEnd = (tokens: ReadonlyArray<string>): number => {
 	return end
 }
 
+/**
+ * The words of a name minus its legal form — "Acme Logistics S.L." → ["acme",
+ * "logistics"]. Exported because a caller comparing two names has to compare
+ * them word by word rather than as one run of letters: telling whether one name
+ * is another name and then some needs to know where each word ends, and the
+ * collapsed "acmelogistics" no longer says.
+ */
+export const nameCoreTokens = (name: string): ReadonlyArray<string> => {
+	const tokens = foldTokens(name)
+	return tokens.slice(0, nameEnd(tokens))
+}
+
 // The whole name minus its legal form, collapsed — "Acme Logistics S.L." →
 // "acmelogistics". This is the strong-match key: it appears verbatim on the
 // company's own pages but is long enough not to hit by coincidence. A key that
 // is only an industry word would match any page in that industry, so the form is
 // read off the end rather than picked out wherever it appears.
-export const nameCore = (name: string): string => {
-	const tokens = foldTokens(name)
-	return tokens.slice(0, nameEnd(tokens)).join('')
-}
+export const nameCore = (name: string): string => nameCoreTokens(name).join('')
 
 /**
  * The name with every legal-form word taken out, wherever it sits — "SARL

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -933,6 +933,92 @@ describe('scoring a run that answered for a whole market', () => {
 			expect(score.market?.rowsDuplicated).toBe(2)
 		})
 
+		it('should count a branch office left on the list as its company again', () => {
+			// GIVEN a company and two rows named after it plus the town each sits in,
+			// neither carrying a site — the shape the fold is meant to have removed
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({
+							name: 'Terre Solaire',
+							website: 'https://terresolaire.example',
+						}),
+						company({ name: 'Terre Solaire – agence Lyon', location: 'Lyon' }),
+						company({
+							name: 'Terre Solaire – agence Douains',
+							location: 'Douains',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored
+			// THEN two rows are counted as repeats. Reading them by name or site alone
+			// would call this a clean list of three companies
+			expect(score.market?.rowsDuplicated).toBe(2)
+		})
+
+		it('should count a branch office whose company came after it', () => {
+			// GIVEN the branch listed above the company it belongs to
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({ name: 'Terre Solaire – agence Lyon', location: 'Lyon' }),
+						company({
+							name: 'Terre Solaire',
+							website: 'https://terresolaire.example',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN they still meet, whichever came first
+			expect(score.market?.rowsDuplicated).toBe(1)
+		})
+
+		it('should count a branch of a branch as the same company still', () => {
+			// GIVEN a company, a branch of it, and a sub-office of that branch
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({
+							name: 'Acme Solar',
+							website: 'https://acmesolar.example',
+						}),
+						company({ name: 'Acme Solar Lyon', location: 'Lyon' }),
+						company({ name: 'Acme Solar Lyon Sud', location: 'Lyon Sud' }),
+					],
+				}),
+			)
+
+			// WHEN scored
+			// THEN one company, not three — each row is filed under the one above it, so
+			// sameness carries the whole way up the chain
+			expect(score.market?.rowsDuplicated).toBe(2)
+		})
+
+		it('should count two companies sharing an opening word as two', () => {
+			// GIVEN a company and a genuinely different one whose name starts with it
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({
+							name: 'Terre Solaire',
+							website: 'https://terresolaire.example',
+						}),
+						company({ name: 'Terre Solaire Energie', location: 'Lyon' }),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN no repeat is claimed over two separate companies
+			expect(score.market?.rowsDuplicated).toBe(0)
+		})
+
 		it('should count no duplicates in a list of distinct companies', () => {
 			// GIVEN three unrelated companies
 			const score = scoreRun(

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -44,7 +44,10 @@
 
 import { foldLabel } from '@batuda/domain'
 
-import { discoveryRowIdentityKeys } from './prospect-dedupe-guard'
+import {
+	branchOfficeParents,
+	discoveryRowIdentityKeys,
+} from './prospect-dedupe-guard'
 
 /**
  * The enrichment scalars we can check against an objective golden answer. Free-text
@@ -814,38 +817,44 @@ const isKnownNonCompany = (
  * How many rows are another row's company a second time: the rows, less the
  * companies they turn out to be.
  *
- * Two rows are one company when they share a name with the legal form off the end or
- * share a site host, and sameness carries — the same keys the scan itself folds rows
- * on.
+ * Two rows are one company when they share a name with the legal form off the end,
+ * share a site host, or one reads as the other's branch office — the same three ways
+ * the scan itself folds rows, and sameness carries across all of them.
  *
- * Reusing those keys is what this number is worth and what bounds it. The list it
- * reads has already been folded on them, so nothing it can see should be left: it
- * answers "is that fold still running and still doing its job", and it moves the
- * moment the answer is no. It cannot answer whether the keys are the right ones.
- *
- * That bound is wider than it sounds, and a live market search shows it: a company
- * came back once under its own name and four more times as that name plus the town
- * of a branch office, none of the four carrying a site. Neither key sees them — the
- * name is not the same name and there is no host to share — so the fold leaves all
- * five and this reads zero duplicates over a list that plainly repeats one company.
- * Reading it as "no repeats in this list" is wrong; it means "no repeats of the kind
- * these keys can tell". Counting those needs a hand-marked answer to score against,
- * which is a different measurement from this one.
+ * Reusing what the fold uses is what this number is worth and what bounds it. The
+ * list it reads has already been folded that way, so nothing it can see should be
+ * left: it answers "is that fold still running and still doing its job", and it moves
+ * the moment the answer is no. It cannot answer whether those three ways are the
+ * right ones — a repeat of a shape none of them describes reads here as two
+ * companies, and counting that needs a hand-marked answer to score against, which is
+ * a different measurement from this one.
  *
  * A row nothing can be read from — a name that is all punctuation, no address —
  * files under no key and so counts as its own company. That is the safe direction:
  * it never claims a duplicate it cannot show.
  */
 const duplicatedRows = (rows: RunOutcome['companies']): number => {
+	// The fields the fold reads a row by, in the shape it reads them: the name, the
+	// site, and the place — a branch is told by its name ending on the town it gives.
+	const asDiscoveryRows = rows.map(row => ({
+		name: row.name,
+		...(row.website === null ? {} : { website: row.website }),
+		...(row.location === null ? {} : { location: row.location }),
+	}))
+	const parentOfBranch = branchOfficeParents(asDiscoveryRows)
+
 	// Each company found so far, as the keys its rows filed under. A row meeting one
 	// of them is that company again; a row meeting two proves those two were one
-	// company all along, so they merge.
+	// company all along, so they merge. A branch is filed under the company it hangs
+	// off as well as itself, which is how it meets it whichever of the two came first.
 	const companies: Array<Set<string>> = []
-	for (const row of rows) {
-		const keys = discoveryRowIdentityKeys({
-			name: row.name,
-			...(row.website === null ? {} : { website: row.website }),
-		})
+	for (const [at, row] of asDiscoveryRows.entries()) {
+		const parent = parentOfBranch.get(at)
+		const parentRow = parent === undefined ? undefined : asDiscoveryRows[parent]
+		const keys = [
+			...discoveryRowIdentityKeys(row),
+			...(parentRow === undefined ? [] : discoveryRowIdentityKeys(parentRow)),
+		]
 		const matched = companies.filter(company =>
 			keys.some(key => company.has(key)),
 		)

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -587,6 +587,102 @@ describe('mergePerFieldSearch', () => {
 			expect(merged.added).toBe(1)
 		})
 
+		it('should fold a branch office the round found onto the company listed', () => {
+			// GIVEN a company on the list, and a second look that names one of its
+			// branch offices — its name and then the town the branch sits in, with no
+			// site of its own
+			const findings = {
+				prospects: [
+					{ name: 'Terre Solaire', website: 'https://terresolaire.test' },
+				],
+			}
+			const refreshed = {
+				prospects: [
+					{ name: 'Terre Solaire – agence Nantes', location: 'Nantes' },
+				],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN one company, keeping the town the branch brought. The fold that runs
+			// before these rounds cannot see a company found after it, so a round that
+			// leaves a branch standing puts the duplicate straight into the answer
+			expect(rows.map(row => row['name'])).toEqual(['Terre Solaire'])
+			expect(rows[0]?.['location']).toBe('Nantes')
+			expect(merged.added).toBe(0)
+		})
+
+		it('should fold a company the round gave the site of one already listed', () => {
+			// GIVEN a company with its site, and a round that names it again under a
+			// different name and hands it the same site — the shape a live run returned
+			// as two rows both on aeroxsense.com
+			const findings = {
+				prospects: [{ name: 'AeroXsense', website: 'https://www.aero.test/' }],
+			}
+			const refreshed = {
+				prospects: [
+					{ name: 'AeroXsense (Fire Safety)', website: 'https://aero.test/' },
+				],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN the shared host settles it here too. A row appended by a round is
+			// never put in front of the fold again unless this step folds it
+			expect(rows).toHaveLength(1)
+			expect(merged.added).toBe(0)
+		})
+
+		it('should still count a genuinely new company as one the list gained', () => {
+			// GIVEN a round that names a company sharing an opening word with a listed
+			// one, in a town its name does not end on
+			const findings = {
+				prospects: [
+					{ name: 'Terre Solaire', website: 'https://terresolaire.test' },
+				],
+			}
+			const refreshed = {
+				prospects: [{ name: 'Terre Solaire Energie', location: 'Nantes' }],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN both are listed and the round is credited with the find — sharing an
+			// opening word is not being somebody's branch
+			expect(rows.map(row => row['name'])).toEqual([
+				'Terre Solaire',
+				'Terre Solaire Energie',
+			])
+			expect(merged.added).toBe(1)
+		})
+
+		it('should still credit a find when the round also joins two already listed', () => {
+			// GIVEN two rows that are one company nobody could yet tell apart — one
+			// carrying the site, the other only the name
+			const findings = {
+				prospects: [
+					{ name: 'Acme' },
+					{ name: 'Acme Group', website: 'https://acme.test' },
+				],
+			}
+			// AND a round that hands the first row that same site, which shows the two
+			// were always one, and names a company nobody had
+			const refreshed = {
+				prospects: [
+					{ name: 'Acme', website: 'https://acme.test' },
+					{ name: 'Delta Systems', website: 'https://delta.test' },
+				],
+			}
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+			// THEN the list holds the one company and the new one, and the round is
+			// credited with the find. Counting the length instead would read nothing
+			// gained — two rows in, two rows out — and stop the rounds a round early
+			expect(rows).toHaveLength(2)
+			expect(merged.added).toBe(1)
+		})
+
 		it('should append a company the second look names twice only once', () => {
 			// GIVEN a re-extraction that names the same NEW company in two rows
 			const findings = { prospects: [{ name: 'Zeta' }] }

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -24,7 +24,10 @@ import { mergeContacts } from './contacts-rescue'
 import { discoveryResultField, isDiscoveryScan } from './discovery-scan'
 import { enrichmentFill } from './extraction-fill'
 import { isPlainObject, isValueWrapper, unwrapValue } from './guard-shapes'
-import { discoveryRowIdentityKeys } from './prospect-dedupe-guard'
+import {
+	dedupeDiscoveryRows,
+	discoveryRowIdentityKeys,
+} from './prospect-dedupe-guard'
 
 // The company-profile facts worth spending an extra search on. `size_range` is
 // also nudged during the loop (headcount is rarely on the homepage); for the
@@ -215,18 +218,26 @@ export interface PerFieldMerge {
 	readonly filled: number
 	/** Whether the people list gained anyone, or gained a detail about anyone. */
 	readonly contactsChanged: boolean
-	/** How many companies the second look added that the first pass never named. */
+	/**
+	 * How many companies the list gained — not how many rows were appended. A row
+	 * naming a company already on the list joins it instead of lengthening the
+	 * list, and has found nobody.
+	 */
 	readonly added: number
 }
 
 /**
  * Fold a re-extraction over the enlarged evidence back into a scan's list.
  *
- * A company already found keeps everything it already had — a second look may
- * only fill a blank, never overwrite a grounded value, and never remove a company
- * from the list. A company the re-extraction names that the first pass did not is
- * appended: the enlarged evidence is a wider read of the same question, so what it
- * turns up is a find rather than a contradiction.
+ * A company already found keeps everything it already had — a second look may only
+ * fill a blank, and never overwrite a grounded value. A company the re-extraction
+ * names that the first pass did not is appended: the enlarged evidence is a wider
+ * read of the same question, so what it turns up is a find rather than a
+ * contradiction.
+ *
+ * The list can still come back shorter, and only ever for one reason: two rows of it
+ * turn out to be one company. That is a company written twice becoming a company
+ * written once, never a company dropped.
  */
 const mergeScanRows = (
 	schemaName: string,
@@ -296,14 +307,44 @@ const mergeScanRows = (
 	if (filled === 0 && additions.length === 0) {
 		return { findings, filled: 0, contactsChanged: false, added: 0 }
 	}
+	// This round has just moved the ground under the fold that ran before the rounds
+	// began: it appends companies that fold never saw, and fills in the website of a
+	// row that had none. Two rows that looked nothing alike then can be one company
+	// now — the same site under two spellings of the name, or a branch office found
+	// on a later page. Folding here, rather than once when the rounds are over, is
+	// what keeps that from depending on where a call sits: the step that disturbs
+	// the list is the step that settles it, so nothing later has to remember to.
+	const settle = (rows: ReadonlyArray<unknown>): number | undefined => {
+		const held = (
+			dedupeDiscoveryRows({ ...(findings as object), [field]: rows }, field)
+				.findings as Record<string, unknown>
+		)[field]
+		return Array.isArray(held) ? held.length : undefined
+	}
+	const settled = dedupeDiscoveryRows(
+		{ ...(findings as object), [field]: [...merged, ...additions] },
+		field,
+	)
+	const held = (settled.findings as Record<string, unknown>)[field]
+	// What the list gained, counted in companies rather than rows. A row that joined
+	// a company already on the list is not a find, and calling it one would buy
+	// another paid round of searches for somebody no reader ever sees.
+	//
+	// Measured against the rows already held, folded on their own, rather than
+	// against how many there were. This round can also have filled in the website
+	// that shows two companies already on the list were always one — that shortens
+	// it for a reason that is not a find, and letting it count against the gain
+	// would report a real find as nothing and stop the rounds a round early.
+	const before = settle(merged)
+	const after = Array.isArray(held) ? held.length : undefined
 	return {
-		findings: {
-			...(findings as object),
-			[field]: [...merged, ...additions],
-		},
+		findings: settled.findings,
 		filled,
 		contactsChanged: false,
-		added: additions.length,
+		added:
+			before === undefined || after === undefined
+				? additions.length
+				: Math.max(0, after - before),
 	}
 }
 

--- a/packages/research/src/application/prospect-dedupe-guard.test.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { dedupeDiscoveryRows } from './prospect-dedupe-guard'
+import {
+	branchOfficeParents,
+	dedupeDiscoveryRows,
+} from './prospect-dedupe-guard'
 
 const scan = (
 	prospects: ReadonlyArray<Record<string, unknown>>,
@@ -256,6 +259,262 @@ describe('dedupeDiscoveryRows', () => {
 		})
 	})
 
+	describe('when a company arrives again for each of its branch offices', () => {
+		it('should fold a market list down to the company the branches belong to', () => {
+			// GIVEN the rows a French market search came back with: the company once
+			// with its site, and four branch offices carrying only their town
+			const findings = scan([
+				{
+					name: 'Terre Solaire',
+					website: 'https://terresolaire.com/',
+					why_relevant: 'Solar installer.',
+				},
+				{ name: 'Terre Solaire – agence Douains', location: 'Douains' },
+				{ name: 'Terre Solaire – agence Longueau', location: 'Longueau' },
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{ name: 'Terre Solaire – agence Montpellier', location: 'Montpellier' },
+			])
+
+			// WHEN de-duplicated
+			// THEN one company comes back, under its own name
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(rowsOf(result.findings)[0]?.['name']).toBe('Terre Solaire')
+			expect(result.merged).toBe(4)
+		})
+
+		it('should keep every town the branches work from', () => {
+			// GIVEN a company stating no place of its own and three branches that each
+			// state the only one they have
+			const findings = scan([
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire – agence Douains', location: 'Douains' },
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{ name: 'Terre Solaire – agence Montpellier', location: 'Montpellier' },
+			])
+
+			// WHEN de-duplicated
+			// THEN all three towns survive on the row that stays — taking whichever
+			// arrived first would drop the other two with nothing said
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['location']).toBe(
+				'Douains; Lyon; Montpellier',
+			)
+		})
+
+		it('should name a town once when two branches share it', () => {
+			// GIVEN two branches of one company sitting in the same town
+			const findings = scan([
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{ name: 'Terre Solaire – bureau Lyon', location: 'Lyon' },
+			])
+
+			// WHEN de-duplicated — THEN the town is stated once, not twice
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
+		})
+
+		it('should report the company under its own name when a branch arrived first', () => {
+			// GIVEN a list that ranked a branch page above the company's own
+			const findings = scan([
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{
+					name: 'Terre Solaire',
+					website: 'https://terresolaire.com/',
+					why_relevant: 'Solar installer.',
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN the reader is told the company's name, not one branch's. Which row a
+			// search happened to rank first is no reason to call it something else
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(rowsOf(result.findings)[0]).toMatchObject({
+				name: 'Terre Solaire',
+				website: 'https://terresolaire.com/',
+				location: 'Lyon',
+			})
+		})
+
+		it('should reach the same answer whatever order the branches arrive in', () => {
+			// GIVEN the same five rows with the company's own row buried in the middle
+			const findings = scan([
+				{ name: 'Terre Solaire – agence Montpellier', location: 'Montpellier' },
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire – agence Douains', location: 'Douains' },
+				{ name: 'Terre Solaire – agence Longueau', location: 'Longueau' },
+			])
+
+			// WHEN de-duplicated
+			// THEN one company under its own name, with every town still on it
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(rowsOf(result.findings)[0]).toMatchObject({
+				name: 'Terre Solaire',
+				website: 'https://terresolaire.com/',
+				location: 'Montpellier; Lyon; Douains; Longueau',
+			})
+		})
+
+		it('should still fold a branch whose website field holds prose', () => {
+			// GIVEN a branch row that answered the website question in words
+			const findings = scan([
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{
+					name: 'Terre Solaire – agence Lyon',
+					website: 'not provided',
+					location: 'Lyon',
+				},
+			])
+
+			// WHEN de-duplicated — THEN no address can be read from it, so it is still a
+			// row with no site of its own
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+		})
+
+		it('should keep a branch that claims a site of its own', () => {
+			// GIVEN a row that names a second host
+			const findings = scan([
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{
+					name: 'Terre Solaire – agence Lyon',
+					website: 'https://terresolaire-lyon.fr',
+					location: 'Lyon',
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN both stay: a row claiming its own web presence is claiming to be
+			// somebody, and two hosts are the strongest evidence of two of them
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(2)
+		})
+
+		it("should keep the head office's own town beside its branches", () => {
+			// GIVEN a branch met first and the company itself, each stating its own town
+			const findings = scan([
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{
+					name: 'Terre Solaire',
+					website: 'https://terresolaire.com/',
+					location: 'Paris',
+				},
+			])
+
+			// WHEN de-duplicated — THEN both towns are named, whichever arrived first
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon; Paris')
+		})
+
+		it("should not add a second reading of the same branch's town", () => {
+			// GIVEN a branch, its company, and the branch met again on the company's own
+			// site — which joins on the host rather than as a branch of its own
+			const findings = scan([
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{
+					name: 'Agence Terre Solaire Lyon',
+					website: 'https://terresolaire.com/agences/lyon',
+					location: 'Lyon, Rhône',
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN the first reading of that town stands. Only a row speaking about
+			// somewhere else adds a place; another reading of one branch is not that
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
+		})
+
+		it('should name one town once when two branches write it at different detail', () => {
+			// GIVEN two branch rows in the same town, one naming the province too
+			const findings = scan([
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{ name: 'Terre Solaire – bureau Lyon', location: 'Lyon, Rhône' },
+			])
+
+			// WHEN de-duplicated
+			// THEN one town, not two. A place that holds one already named is the same
+			// place written at more detail, and listing both would invent a branch
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
+		})
+
+		it('should keep two towns whose names merely read inside one another', () => {
+			// GIVEN branches in Roa and in Roanne — two real towns, one spelled inside
+			// the other letter for letter
+			const findings = scan([
+				{ name: 'Acme Solar', website: 'https://acmesolar.fr' },
+				{ name: 'Acme Solar Roa', location: 'Roa' },
+				{ name: 'Acme Solar Roanne', location: 'Roanne' },
+			])
+
+			// WHEN de-duplicated
+			// THEN both towns are named. Places are compared word by word, so one town
+			// reading inside another is not the same town written at more detail
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Roa; Roanne')
+		})
+
+		it('should keep a town written in a script the folding cannot read', () => {
+			// GIVEN a branch in a town spelled in Latin letters, and the company itself
+			// stating a town this code's folding comes apart into no words at all
+			const findings = scan([
+				{ name: 'Acme Solar Osaka', location: 'Osaka' },
+				{
+					name: 'Acme Solar',
+					website: 'https://acmesolar.example',
+					location: '東京',
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN the unreadable town is kept beside the readable one. A place the
+			// code cannot read is a place it must not throw away for that reason
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Osaka; 東京')
+		})
+
+		it('should ignore a company that names nowhere when it joins its branch', () => {
+			// GIVEN a branch met first, and the company itself whose place is only spaces
+			const findings = scan([
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+				{
+					name: 'Terre Solaire',
+					website: 'https://terresolaire.com/',
+					location: '   ',
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN the branch's town stands alone. A row naming nowhere adds nowhere,
+			// rather than a blank reading trailing the one place the run did find
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
+		})
+
+		it('should not join the places of two rows that are one company met twice', () => {
+			// GIVEN one company met twice, each meeting reading its place differently
+			const findings = scan([
+				{ name: 'Instalaciones Rubio SL', location: 'Vigo' },
+				{ name: 'Instalaciones Rubio', location: 'Vigo, Pontevedra' },
+			])
+
+			// WHEN de-duplicated
+			// THEN the first reading stands. Two readings of one place are not two
+			// places, and only a branch speaks about somewhere else
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(rowsOf(result.findings)[0]?.['location']).toBe('Vigo')
+		})
+	})
+
 	describe('when the answer is not a list of companies', () => {
 		it('should pass a run through untouched when it has no list', () => {
 			// GIVEN a run about one named company
@@ -281,6 +540,214 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN they pass straight through
 			expect(dedupeDiscoveryRows(null, 'prospects').findings).toBeNull()
 			expect(dedupeDiscoveryRows('text', 'prospects').findings).toBe('text')
+		})
+	})
+})
+
+describe('branchOfficeParents', () => {
+	describe("when a row reads as another row's branch office", () => {
+		it("should read a row ending on the town it gives as that company's branch", () => {
+			// GIVEN a company and a row named after it plus the town that row sits in
+			const rows = [
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN the second belongs to the first — read off the shape alone, with no
+			// need to know that "agence" is French for a branch office
+			expect(branchOfficeParents(rows)).toEqual(new Map([[1, 0]]))
+		})
+
+		it('should read the legal form off both names before comparing them', () => {
+			// GIVEN a company carrying its legal form and a branch that does not
+			const rows = [
+				{ name: 'Terre Solaire SARL', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire – agence Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out — THEN the form is no obstacle
+			expect(branchOfficeParents(rows)).toEqual(new Map([[1, 0]]))
+		})
+
+		it('should follow a branch that hangs off another branch', () => {
+			// GIVEN a company, a branch of it, and a sub-office of that branch
+			const rows = [
+				{ name: 'Acme Solar', website: 'https://acmesolar.fr' },
+				{ name: 'Acme Solar Lyon', location: 'Lyon' },
+				{ name: 'Acme Solar Lyon Sud', location: 'Lyon Sud' },
+			]
+
+			// WHEN the branches are worked out — THEN each hangs off the one above it
+			expect(branchOfficeParents(rows)).toEqual(
+				new Map([
+					[1, 0],
+					[2, 1],
+				]),
+			)
+		})
+
+		it('should hang a branch off the longest name it could hang off', () => {
+			// GIVEN two companies whose names open the same way, and a branch of the
+			// longer one
+			const rows = [
+				{ name: 'Acme', website: 'https://acme.fr' },
+				{ name: 'Acme Solar', website: 'https://acmesolar.fr' },
+				{ name: 'Acme Solar Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN the branch belongs to "Acme Solar" alone. Letting it belong to both
+			// would drag those two companies into one through it
+			expect(branchOfficeParents(rows)).toEqual(new Map([[2, 1]]))
+		})
+	})
+
+	describe('when two rows merely open with the same word', () => {
+		it('should keep two different companies whose names share an opening word', () => {
+			// GIVEN one company and a genuinely different one whose name starts with it
+			const rows = [
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire Energie', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN neither belongs to the other. "One name starts the other" is not
+			// enough on its own — "Energie" is not where anybody is
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it('should keep them separate through the fold as well', () => {
+			// GIVEN those same two companies going through the whole de-duplication
+			const findings = scan([
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire Energie', location: 'Lyon' },
+			])
+
+			// WHEN de-duplicated — THEN two companies come back, as they should
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(2)
+			expect(result.merged).toBe(0)
+		})
+
+		it('should compare whole words rather than letters', () => {
+			// GIVEN a name that starts with the other's letters but not its words
+			const rows = [
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terres Solaires Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN no branch: "terresolaire" opening "terressolaireslyon" is a trick of
+			// the spelling, and these are two companies
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it('should not take a joiner the place happens to share for the town', () => {
+			// GIVEN a row whose trailing words hold "del", which its place holds too
+			const rows = [
+				{ name: 'Acme Servicios', website: 'https://acme.es' },
+				{ name: 'Acme Servicios del Norte', location: 'Puerto del Rosario' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN no branch. The name has to END on the town, so a joiner sitting in
+			// the middle of both cannot pass for one
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it('should pass over an anchor too short to stand for a company', () => {
+			// GIVEN a two-letter name that every longer name would open with
+			const rows = [
+				{ name: 'AB', website: 'https://ab.fr' },
+				{ name: 'AB Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN nothing hangs off it: a name that short turns up inside unrelated
+			// ones by coincidence, so it anchors nobody
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+	})
+
+	describe('when a row cannot be read as a branch at all', () => {
+		it('should leave a row that states no place', () => {
+			// GIVEN a longer name with nothing saying where it is
+			const rows = [
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire agence Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN no branch: the town is what the row has to tell us before its own
+			// name can be checked against it
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it('should leave a row whose place is not written as text', () => {
+			// GIVEN a place that arrived as something other than a string
+			const rows = [
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire agence Lyon', location: { city: 'Lyon' } },
+			]
+
+			// WHEN the branches are worked out — THEN there is no town to read
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it('should leave a row whose name is nothing a word can be read from', () => {
+			// GIVEN a name of pure punctuation
+			const rows = [
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: '– —', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out — THEN it hangs off nobody
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it("should leave a row that is no company's name and then some", () => {
+			// GIVEN a row named after its town alone, with no company above it
+			const rows = [
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Solaire Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out — THEN there is nothing to hang it off
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it('should leave two rows carrying exactly the same name', () => {
+			// GIVEN one name twice, the second stating the town it ends on
+			const rows = [
+				{ name: 'Acme Lyon', website: 'https://acme.fr' },
+				{ name: 'Acme Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN neither is the other's branch — they are the same name, which the
+			// name key already folds
+			expect(branchOfficeParents(rows)).toEqual(new Map())
+		})
+
+		it('should leave list entries that are not rows alone', () => {
+			// GIVEN a list holding a null and a row with no name
+			const rows = [
+				null,
+				{ website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{ name: 'Terre Solaire agence Lyon', location: 'Lyon' },
+			]
+
+			// WHEN the branches are worked out
+			// THEN only the real rows are read, and the branch still finds its company
+			expect(branchOfficeParents(rows)).toEqual(new Map([[3, 2]]))
+		})
+
+		it('should find no branches in an empty list', () => {
+			// GIVEN nothing to read
+			// WHEN the branches are worked out — THEN there are none
+			expect(branchOfficeParents([])).toEqual(new Map())
 		})
 	})
 })

--- a/packages/research/src/application/prospect-dedupe-guard.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.ts
@@ -16,6 +16,17 @@
  * Either alone is enough, and sameness carries: A meeting B by name and B meeting C
  * by host makes all three one company, which is what they are.
  *
+ * A branch office is the third route, and neither of those two can see it. A company
+ * publishes a page per branch, and the scan brings back the company once and each
+ * branch again — "Terre Solaire" beside "Terre Solaire – agence Lyon". The names are
+ * not the same name, and a branch page rarely carries a site of its own, so there is
+ * no host either. What the run can see is the shape: a row whose name is another
+ * row's name and then some, ending in the very town this row says it sits in. That
+ * reads as one company's own branch, and it reads that way in any language, without
+ * knowing what "agence" means. See `branchOfficeParents` for why the shape has to be
+ * that tight — "one name starts the other" alone would fold two real companies that
+ * merely open with the same word.
+ *
  * The first row stays and the later ones fill its gaps — a tax id one meeting found
  * and the other did not, the site only the ranking printed — with their citations
  * added to its own. Nothing is overwritten: where both rows state a field, the first
@@ -23,13 +34,36 @@
  * rows outright would throw away everything the run paid to find on them, which is
  * the reason this merges instead of filtering.
  *
+ * Branches are the one exception to both of those, because they are the one case
+ * where the later rows are about somewhere else. The company's own name survives
+ * even when the list met a branch first, and every branch's town is kept beside the
+ * others rather than the first arrival standing for all of them — a company working
+ * from four towns is worth knowing about, and four towns is what the run found.
+ *
  * It runs after the website check, so a member-directory address several rows shared
  * is already gone by the time a host counts as evidence two rows are one company.
  */
 
-import { collapse, nameCore, withoutFormDots } from './entity-guard'
+import {
+	collapse,
+	DISTINCTIVE_NAME_LENGTH,
+	foldTokens,
+	nameCore,
+	nameCoreTokens,
+	withoutFormDots,
+} from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { hostOf, isBareWebAddress } from './source-key'
+
+// The host of a row's own site, or null when the field holds nothing an address can
+// be read from. Null is also what a branch page looks like: it is the head office
+// that registers the domain, and the branch is a page on it at most.
+const siteHostOf = (row: Record<string, unknown>): string | null => {
+	const website = row['website']
+	return typeof website === 'string' && isBareWebAddress(website)
+		? hostOf(website)
+		: null
+}
 
 /**
  * What a row is filed under: its name with the legal form off the end, and the host
@@ -54,12 +88,95 @@ export const discoveryRowIdentityKeys = (
 		const filedAs = core === '' ? collapse(name) : core
 		if (filedAs !== '') keys.push(`name:${filedAs}`)
 	}
-	const website = row['website']
-	if (typeof website === 'string' && isBareWebAddress(website)) {
-		const host = hostOf(website)
-		if (host !== null) keys.push(`host:${host}`)
-	}
+	const host = siteHostOf(row)
+	if (host !== null) keys.push(`host:${host}`)
 	return keys
+}
+
+// Whether one name says another name and then more, word for word — "Terre Solaire"
+// starts "Terre Solaire – agence Lyon". Whole words, because the letters alone would
+// also have "Terre Solaire" start "Terres Solaires", which is a different company.
+const saysThenMore = (
+	name: ReadonlyArray<string>,
+	opening: ReadonlyArray<string>,
+): boolean =>
+	opening.length < name.length && opening.every((word, at) => name[at] === word)
+
+/**
+ * For each row that reads as another row's branch office, which row it belongs to,
+ * both named by their place in the list.
+ *
+ * A row is one of another's branches when all four hold:
+ *  - its name says that row's name and then more;
+ *  - it carries no site of its own, so it is not claiming a separate presence — and
+ *    a branch that gives the head office's address has already met it on the host;
+ *  - it says where it is;
+ *  - and its name **ends** on a word of that place. This is the whole of the rule's
+ *    safety. "One name starts the other" would fold "Terre Solaire" into a real and
+ *    different "Terre Solaire Energie"; asking that the name end on the town the row
+ *    itself claims does not, because "Energie" is not where anyone is. It is also
+ *    the reason there is no list of the words a branch is announced with — "agence",
+ *    "sucursal", "Niederlassung" — which would only be the languages somebody
+ *    thought of: the row tells us its own town, so nothing has to be known in
+ *    advance. It is the last word rather than any word, so that a joiner the place
+ *    happens to share — "Acme del Norte" sitting in "Puerto del Rosario" — cannot
+ *    pass for the town.
+ *
+ * A branch hangs off the longest name it could hang off, never every one of them.
+ * With "Acme", "Acme Solar" and "Acme Solar Lyon" on one list, the last belongs to
+ * "Acme Solar"; letting it belong to both would drag "Acme" and "Acme Solar" into
+ * one company through it, and those two are exactly the pair this must keep apart.
+ *
+ * A name too short to stand for a company on its own is no anchor for anybody's
+ * branches, so it is passed over rather than collecting every longer name on the
+ * list.
+ *
+ * What this still cannot tell apart: a company whose whole name is the trade it
+ * works in, sitting on a list beside unrelated firms called that trade and a town.
+ * "Electricidad" would take "Electricidad Madrid" and "Electricidad Barcelona" for
+ * its branches. Requiring the row above to be present at all is what bounds it —
+ * the pattern alone folds nothing — and going further means judging a name generic,
+ * which is a list of trade words in whichever languages somebody thought of.
+ *
+ * Exported because the measurement of how many duplicates a list still holds reads
+ * a returned list with the same eyes the fold does. A shape the fold acts on and
+ * the count cannot see would report a clean list every time.
+ */
+export const branchOfficeParents = (
+	rows: ReadonlyArray<unknown>,
+): ReadonlyMap<number, number> => {
+	const names = rows.map(row =>
+		isPlainObject(row) && typeof row['name'] === 'string'
+			? nameCoreTokens(withoutFormDots(row['name']))
+			: null,
+	)
+	// Long enough to stand for a company, worked out once per row rather than again
+	// for every longer name it is held up against.
+	const anchors = names.map(
+		name => name !== null && name.join('').length >= DISTINCTIVE_NAME_LENGTH,
+	)
+	const parents = new Map<number, number>()
+	rows.forEach((row, at) => {
+		const name = names[at]
+		if (!isPlainObject(row) || name == null) return
+		if (siteHostOf(row) !== null) return
+		const place = row['location']
+		if (typeof place !== 'string') return
+		const town = new Set(foldTokens(place))
+		const trailing = name[name.length - 1]
+		if (trailing === undefined || !town.has(trailing)) return
+
+		let hangsOff: number | undefined
+		let longest = 0
+		names.forEach((opening, openingAt) => {
+			if (opening === null || !anchors[openingAt]) return
+			if (!saysThenMore(name, opening) || opening.length <= longest) return
+			hangsOff = openingAt
+			longest = opening.length
+		})
+		if (hangsOff !== undefined) parents.set(at, hangsOff)
+	})
+	return parents
 }
 
 // What tells two citations apart: the page each names, as written. Only the case
@@ -87,17 +204,65 @@ const mergeCitations = (kept: unknown, added: unknown): unknown => {
 	return extra.length === 0 ? kept : [...kept, ...extra]
 }
 
+// Whether a place is one of those already named, allowing for one of the two being
+// written at more detail — "Lyon" beside "Lyon, Rhône" is one town said twice, and
+// listing both would invent a branch the company has not got. Every word of one has
+// to appear in the other, rather than one address merely reading inside the other:
+// "Roa" sits inside "Roanne" letter for letter, and those are two towns.
+const alreadyNamed = (places: string, place: string): boolean => {
+	const words = foldTokens(place)
+	return places.split(';').some(named => {
+		const already = foldTokens(named)
+		// One of the two comes apart into no words at all — a place written in a
+		// script this folding drops, like "東京". Fall back to the text as written, so
+		// a place the code cannot read is added rather than quietly lost: a town
+		// stated twice is a small harm beside a town the run found and threw away.
+		if (words.length === 0 || already.length === 0)
+			return named.trim().toLowerCase() === place.trim().toLowerCase()
+		return (
+			already.every(word => words.includes(word)) ||
+			words.every(word => already.includes(word))
+		)
+	})
+}
+
+// The places already named, plus one more when it is not among them. When a fold puts
+// a company's branches onto the row that stays, each branch states the only place it
+// has, and keeping whichever arrived first would drop the rest with nothing said.
+// Semicolons separate them because a single place is written with commas in it
+// already ("Alcobendas, Madrid"), and joining on those would read as one long address.
+const alsoAt = (places: unknown, added: string): string => {
+	const held = typeof places === 'string' ? places : ''
+	const place = added.trim()
+	if (place === '') return held
+	if (held.trim() === '') return place
+	return alreadyNamed(held, place) ? held : `${held}; ${place}`
+}
+
 // Fold a later meeting of the same company into the row that stays: fields it never
 // filled get filled, and the pages behind the later row are added to its own.
+//
+// `alsoElsewhere` says this fold is a branch joining its company rather than one
+// company met twice. It is the only case where the later row speaks about somewhere
+// else, so it is the only one whose place is added to what the row already names
+// instead of filling a gap and nothing more.
 const foldInto = (
 	kept: Record<string, unknown>,
 	later: Record<string, unknown>,
+	alsoElsewhere: boolean,
 ): Record<string, unknown> => {
 	const merged: Record<string, unknown> = { ...kept }
 	for (const [field, value] of Object.entries(later)) {
 		if (value === undefined || value === null) continue
 		if (field === 'citations') {
 			merged['citations'] = mergeCitations(kept['citations'], value)
+			continue
+		}
+		if (field === 'location' && alsoElsewhere && typeof value === 'string') {
+			// A row that names nowhere leaves the field as it found it, rather than
+			// putting an empty reading where there was no field at all.
+			const places = alsoAt(merged['location'], value)
+			if (places !== '') merged['location'] = places
 			continue
 		}
 		const held = merged[field]
@@ -159,8 +324,26 @@ export const dedupeDiscoveryRows = (
 				else sameCompany(seen, at)
 			}
 		})
+		const parentOfBranch = branchOfficeParents(rows)
+		for (const [branch, parent] of parentOfBranch) sameCompany(parent, branch)
 
-		// One row per company, in the order the list first met it.
+		// The company a branch belongs to, following the chain up when a branch hangs
+		// off a branch. Every step shortens the name, so this always comes to a stop.
+		const companyItself = (at: number): number => {
+			let row = at
+			let parent = parentOfBranch.get(row)
+			while (parent !== undefined) {
+				row = parent
+				parent = parentOfBranch.get(row)
+			}
+			return row
+		}
+
+		// One row per company, in the order the list first met it — under the company's
+		// own name, even where the list met one of its branches first. A reader given
+		// "Terre Solaire – agence Lyon" for a company working from five towns has been
+		// told the wrong thing about it, and which row a search happened to rank first
+		// is no reason to say it.
 		const keptAt = new Map<number, number>()
 		const kept: Array<unknown> = []
 		rows.forEach((row, at) => {
@@ -172,11 +355,24 @@ export const dedupeDiscoveryRows = (
 			const index = keptAt.get(company)
 			if (index === undefined) {
 				keptAt.set(company, kept.length)
-				kept.push(row)
+				const headOffice = rows[companyItself(at)]
+				const headOfficeName = isPlainObject(headOffice)
+					? headOffice['name']
+					: undefined
+				kept.push(
+					typeof headOfficeName === 'string' && headOfficeName !== row['name']
+						? { ...row, name: headOfficeName }
+						: row,
+				)
 				return
 			}
+			// This row speaks about somewhere else than the one it is joining when it is
+			// a branch, or when it is the company itself arriving after one of its
+			// branches took the place that stays. Another reading of the same branch is
+			// neither, and its place fills a gap like any other field.
 			const held = kept[index]
-			kept[index] = isPlainObject(held) ? foldInto(held, row) : row
+			const elsewhere = parentOfBranch.has(at) || companyItself(company) === at
+			kept[index] = isPlainObject(held) ? foldInto(held, row, elsewhere) : row
 			merged++
 		})
 		return kept

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -3448,9 +3448,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								{
 									// Same company twice: a broad search meets one company on a
 									// directory, in a ranking and in a news piece, and each meeting can
-									// spell it differently. Fold those rows into one — after the website
-									// check, so an address several rows shared is already gone before a
-									// host counts as evidence two rows are the same company.
+									// spell it differently. It also meets a company once under its own
+									// name and again for each branch office, named after the town the
+									// branch sits in. Fold all of those into one row — after the
+									// website check, so an address several rows shared is already gone
+									// before a host counts as evidence two rows are one company.
 									name: 'prospect-dedupe',
 									run: findings =>
 										Effect.gen(function* () {


### PR DESCRIPTION
## What

A search for a whole market was handing back one company several times over — once under its own name, and again for every branch office that company publishes a page for. A French run returned `Terre Solaire` five times: the company, plus its agencies in Douains, Longueau, Lyon and Montpellier. The step that is supposed to join repeated rows together saw nothing wrong with any of it, so the reader got a list that looks longer than the number of companies actually in it. This is in the research engine (`packages/research`), on the path that answers a market search.

## The fix

**Touches:** the step that joins two rows of one company into one, the shared name-folding every guard reads names through, the merge that folds a later round of searching back into the list, and the duplicate figure the market measurement reports — plus the website check that runs before all of it, untouched here.

- **A branch office is told by its shape, not by its words.** A row belongs to another row when its name says that row's name *and then more*, it carries no website of its own, and its name **ends on the town it says it sits in**. So `Terre Solaire – agence Lyon`, sitting in Lyon, joins `Terre Solaire`.
- **That is what keeps it safe.** "One name starts the other" on its own would fold a real and different `Terre Solaire Energie` into `Terre Solaire` — asking that the name end on the town the row itself claims does not, because "Energie" is not where anybody is. There is a test that says so, and it was written before the rule.
- **No vocabulary of branch words.** No list of `agence` / `sucursal` / `Niederlassung`, which would only ever be the languages somebody thought of. The row states its own town and its own name is checked against that. This matters because §7 of #456 already carries seven such lists as acknowledged debt, and I did not want to add an eighth.
- **The company's name survives, and so do all its towns.** The row that stays is named for the company even when the search ranked a branch first, and it keeps every town its branches work from (`Douains; Longueau; Lyon; Montpellier`) rather than whichever arrived first.
- **The joining moved to where the list is actually assembled.** It now runs inside the step that folds a later round of searching back into the list, rather than once when the rounds are over. This came out of measuring, not from the issue — see Impact.

## Impact

- **A live run was returning duplicates that the existing rules could already see.** Two rows both on `aeroxsense.com` survived into the answer, because the joining step ran before the extra rounds of searching that fill in a row's website. By the time the second row had an address to compare, the joining had already happened. Pre-existing since #459, same symptom as this issue, different cause. Moving the join into the merge closes it — and means there is no free-floating call whose position can drift out of order again.
- **The `location` field can now hold more than one place**, separated by semicolons. Where a company works from four towns, that is what it says. When such a row is applied to the CRM, `research-apply` hands that value to the geocoder, which will not resolve a four-town string — it logs a warning and moves on, so the company gets no coordinates. The issue explicitly forbids dropping the extra towns, so I kept them; if you would rather have coordinates than completeness, that is a decision to take here.
- **The number that reports how many duplicates a list still holds** (from #466) reads a list the same way the join does, so a company repeated as its own branches now counts as a repeat instead of reporting a clean list.
- **Nothing touching which organisation can see what** (row-level security), no database migration, no new environment variable, no change to the shape of anything the web app or the assistant tools receive.

## Review guide

Start at `branchOfficeParents` in `packages/research/src/application/prospect-dedupe-guard.ts` — its docblock carries the whole argument, including what the rule deliberately cannot do. Then `mergeScanRows` in `per-field-search.ts`, which is the riskiest part: it changes what `added` means (companies gained, not rows appended), and that number decides whether another paid round of searching runs.

**Two decisions you might overrule:**

1. **The residual false positive.** A company whose whole name is its trade — a row literally named `Electricidad` — would take `Electricidad Madrid` and `Electricidad Barcelona` for its branches. Bounding that further means judging a name "generic", which is a list of trade words per language, so I documented it in the docblock instead of building it.
2. **`KBE Energy (Annuaire Tecsol entry)` still does not fold.** The issue calls the parenthetical "separate from the branch question", so I left it alone.

**What I could not verify:** the issue's acceptance asks for this to be measured on a live re-run of the French market row. I ran that row three times (9c/11c/13c, caches cleared between) and got **5, 14 and 15 rows** — none containing a branch office. The 42-row list the issue captured did not recur, and a five-row pass was not truncated (it spent 9c of a 100c budget and closed its rounds normally). So the live re-run cannot confirm this fix; what it did do was surface the `aeroxsense.com` duplicate above. Evidence is in Verification instead.

Skip-able: the test files are long but mechanical.

## Tests

- **Unit** — the branch rule and the join, covering the trap (two companies sharing an opening word), whole-word rather than letter comparison, a joiner the place happens to share (`Acme del Norte` in `Puerto del Rosario`), a branch of a branch, an anchor too short to stand for a company, a town written at two levels of detail, and a town in a script the folding cannot read (kept rather than dropped).
- **Integration** — `apps/server/src/services/research-scan-dedupe.integration.test.ts` drives a real run end to end, with only the model and the providers stubbed, and asserts the list the run actually stores. Two cases, one per route into the list: a single reading naming a company and its branches, and a branch that only a later round turns up.
- I disabled each mechanism in turn and confirmed the matching case fails (4 Terre Solaire rows; 7 companies instead of 6), then restored — a test that passed either way would have been worse than none.

## Verification

- Gates run on this branch, rebased onto `91b85b4d49`: `pnpm install`, `pnpm -w check-types`, `pnpm -w test` (1416 passing), `pnpm -w build` — all green. Full integration suite also run: 99 files, 700 passing.
- Three live runs of the `fr-installations` market row against the real pipeline (real scraping and real model calls), as described in Review guide.
- The issue's own captured rows replayed through the shipped code: **9 rows in, 5 out, 4 joined** — the five `Terre Solaire` rows become one, under the company's name, carrying `Douains; Longueau; Lyon; Montpellier`.
- The 15 rows the second live run returned, replayed the same way: **14 in, 13 out** — the `aeroxsense.com` pair joins.

## Deferred

- The parenthetical case (`KBE Energy (Annuaire Tecsol entry)`), per the issue's own scoping.
- `HELLIO` / `Hellio Solutions`, which the issue lists as unverified — it may be a subsidiary rather than a second row for one company.

Closes #470
