### PR TITLE
fix(research): say when a website is established as the company's own

### DIFF
--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -9,8 +9,10 @@ import {
 	domainHost,
 	type EntityTargets,
 	groundedSourceIds,
+	hostLabel,
 	isConfirmedRegistryMatch,
 	isOwnSiteHost,
+	labelSpellsOneOf,
 	parseQueryDomain,
 	placesCorroborate,
 	queryPlaces,
@@ -597,6 +599,89 @@ describe('domainHost', () => {
 			// GIVEN text with no dot, or too short to be a host
 			expect(domainHost('localhost')).toBeUndefined()
 			expect(domainHost('a.b')).toBeUndefined()
+		})
+	})
+})
+
+describe('labelSpellsOneOf', () => {
+	describe('when the label is one of the names', () => {
+		it('should accept it whole and with the legal form after it', () => {
+			// GIVEN a workshop's domain written both ways
+			// WHEN read against the name — THEN a form on the end is the company
+			// still writing itself, so both spell it
+			expect(labelSpellsOneOf('fusteriamiquel', ['fusteriamiquel'])).toBe(true)
+			expect(labelSpellsOneOf('fusteriamiquelsl', ['fusteriamiquel'])).toBe(
+				true,
+			)
+		})
+
+		it('should read any one of the names offered', () => {
+			// GIVEN several ways the company could have registered
+			// WHEN read — THEN one of them spelling the label is enough
+			expect(labelSpellsOneOf('acme', ['acmelogistics', 'acme'])).toBe(true)
+		})
+	})
+
+	describe('when the label carries more than the name', () => {
+		it('should refuse anything appended that is not a legal form', () => {
+			// GIVEN a review site named after the company
+			// WHEN read — THEN whoever registered it writes ABOUT the company
+			expect(labelSpellsOneOf('acmelogisticsreviews', ['acmelogistics'])).toBe(
+				false,
+			)
+		})
+
+		it('should refuse a name the label merely contains', () => {
+			// GIVEN a domain with a word in front of the name
+			// WHEN read — THEN the name has to BE the label, not sit inside it
+			expect(labelSpellsOneOf('grupoacme', ['acme'])).toBe(false)
+		})
+	})
+
+	describe('when there is no name to read', () => {
+		it('should refuse an empty list', () => {
+			// GIVEN a caller whose names came back empty
+			// WHEN read — THEN no, rather than yes out of having nothing to compare
+			expect(labelSpellsOneOf('acme', [])).toBe(false)
+		})
+
+		it('should refuse an empty name among real ones', () => {
+			// GIVEN a name with nothing in it, which every label starts with
+			// WHEN read
+			// THEN it spells nothing. Left in, it would hand every domain a yes — and
+			// a label that happens to be a legal form ("sl") would get one twice over
+			expect(labelSpellsOneOf('acme', [''])).toBe(false)
+			expect(labelSpellsOneOf('sl', ['', 'acme'])).toBe(false)
+		})
+	})
+})
+
+describe('hostLabel', () => {
+	describe('when given a host with a label to read', () => {
+		it('should return the label the domain is registered under', () => {
+			// GIVEN hosts with a subdomain, a plain domain, and a country second level
+			// WHEN read — THEN what is left is the label somebody registered
+			expect(hostLabel('annuaire.tecsol.fr')).toBe('tecsol')
+			expect(hostLabel('acme.com')).toBe('acme')
+			expect(hostLabel('shop.acme.co.uk')).toBe('acme')
+		})
+
+		it('should keep a label too short to stand on its own', () => {
+			// GIVEN the large carriers' three-letter domains
+			// WHEN read
+			// THEN they come back whole. Whether three letters mean anything depends
+			// on the question asked of them, so the floor belongs to the caller
+			expect(hostLabel('xpo.com')).toBe('xpo')
+			expect(hostLabel('dsv.com')).toBe('dsv')
+		})
+	})
+
+	describe('when given something with no label', () => {
+		it('should return an empty string', () => {
+			// GIVEN a bare word, which is all the top level with nothing under it
+			// WHEN read — THEN nothing, rather than the top level read as a name
+			expect(hostLabel('localhost')).toBe('')
+			expect(hostLabel('')).toBe('')
 		})
 	})
 })

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -180,6 +180,15 @@ export const nameCoreTokens = (name: string): ReadonlyArray<string> => {
 export const nameCore = (name: string): string => nameCoreTokens(name).join('')
 
 /**
+ * The words of a name, every legal-form word taken out wherever it sits — "SARL
+ * Transports Dupont" → ["transports", "dupont"]. Exported because a caller
+ * asking which FRONT PART of a name a domain could spell has to know where each
+ * word ends, and the joined "transportsdupont" no longer says.
+ */
+export const nameWordsWithoutForms = (name: string): ReadonlyArray<string> =>
+	foldTokens(name).filter(t => !LEGAL_SUFFIXES.has(t))
+
+/**
  * The name with every legal-form word taken out, wherever it sits — "SARL
  * Transports Dupont" → "transportsdupont".
  *
@@ -190,9 +199,36 @@ export const nameCore = (name: string): string => nameCoreTokens(name).join('')
  * it does is spot the company's name in one more place.
  */
 export const nameWithoutForms = (name: string): string =>
-	foldTokens(name)
-		.filter(t => !LEGAL_SUFFIXES.has(t))
-		.join('')
+	nameWordsWithoutForms(name).join('')
+
+/**
+ * Whether a domain's label spells any of these names, allowing the legal form
+ * after it — "fusteriamiquel" and "fusteriamiquelsl" both spell "fusteriamiquel",
+ * and "fusteriamiquelreviews" spells somebody writing about it.
+ *
+ * The one place two callers have to agree: picking the site a run goes and reads
+ * asks this, and so does deciding whether a website is the company's own. Two
+ * copies of it would let a host be one company's site to one caller and not to
+ * the other.
+ */
+export const labelSpellsOneOf = (
+	label: string,
+	names: ReadonlyArray<string>,
+): boolean =>
+	names.some(name => {
+		// A name with nothing in it is spelled by every label, so a caller whose
+		// name list came back empty would have every domain answer yes.
+		if (name === '' || !label.startsWith(name)) return false
+		const rest = label.slice(name.length)
+		return rest === '' || LEGAL_SUFFIXES.has(rest)
+	})
+
+/**
+ * Whether a word names a trade rather than a company — "logistics", "grupo",
+ * "solutions". Exported alongside `distinctiveWords` for a caller that needs the
+ * judgement on a word it did not get from there.
+ */
+export const isGenericWord = (word: string): boolean => GENERIC_WORDS.has(word)
 
 /**
  * The shortest run of letters that may stand for a company on its own. Two or
@@ -239,16 +275,29 @@ export const domainHost = (website: string): string | undefined => {
 	return host.includes('.') && host.length >= 4 ? host : undefined
 }
 
-// The distinctive label inside a host — "acme" from "acme.co.uk" — used only as a
-// weak signal alongside the name's own words.
-const domainLabelOf = (host: string): string | undefined => {
+/**
+ * The label a domain is registered under — "acme" from "acme.co.uk", "tecsol"
+ * from "annuaire.tecsol.fr". Empty when the host has no label to read.
+ *
+ * Exported without the four-letter floor `domainLabelOf` puts on it, because the
+ * floor belongs to the question rather than to the reading: a fragment found
+ * INSIDE a longer host needs the length to mean anything, while a label that IS
+ * the whole name is just as telling at three letters ("dsv.com", "xpo.com").
+ */
+export const hostLabel = (host: string): string => {
 	const labels = host.split('.').filter(Boolean)
 	labels.pop() // drop the TLD
 	if (labels.length >= 2 && SECOND_LEVEL.has(labels[labels.length - 1] ?? '')) {
 		labels.pop() // drop a second-level public suffix (co.uk, com.au…)
 	}
-	const label = labels[labels.length - 1]
-	return label && label.length >= 4 ? label : undefined
+	return labels[labels.length - 1] ?? ''
+}
+
+// The distinctive label inside a host — "acme" from "acme.co.uk" — used only as a
+// weak signal alongside the name's own words.
+const domainLabelOf = (host: string): string | undefined => {
+	const label = hostLabel(host)
+	return label.length >= 4 ? label : undefined
 }
 
 // A caller often wraps the company name in quotes inside a longer instruction
@@ -540,11 +589,10 @@ export const isOwnSiteHost = (
 	// — "Fusteria Miquel" at fusteriamiquel.cat or fusteriamiquelsl.cat. Anything
 	// else appended is somebody writing about the company rather than the company
 	// itself: acmelogisticsreviews.com is a review site.
-	const spellsOutTheName = targets.cores.some(core => {
-		if (core.length < 4 || !folded.startsWith(core)) return false
-		const rest = folded.slice(core.length)
-		return rest === '' || LEGAL_SUFFIXES.has(rest)
-	})
+	const spellsOutTheName = labelSpellsOneOf(
+		folded,
+		targets.cores.filter(core => core.length >= DISTINCTIVE_NAME_LENGTH),
+	)
 	// Or the domain is one distinctive word of the name, which is how most firms
 	// register: "Transportes García" lives at garcia.es. Only a distinctive word
 	// counts, so the trade a company is in — which identifies nobody — cannot

--- a/packages/research/src/application/own-site.test.ts
+++ b/packages/research/src/application/own-site.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'vitest'
+
+import { ownSiteVerdict } from './own-site'
+
+// The address the French solar directory files a company at: a slug naming a
+// trade and a role, ending in the listing's own record number, and naming no
+// company.
+const TECSOL_LISTING =
+	'https://annuaire.tecsol.fr/liste-fournisseur-solaire-installateurs-epc-339615/'
+
+describe('ownSiteVerdict', () => {
+	describe('when the domain spells the company name', () => {
+		it('should establish a domain carrying the whole name', () => {
+			// GIVEN a company at the domain its full name spells
+			// WHEN asked whose site it is
+			// THEN the domain itself is the answer, whatever page the address points at
+			expect(
+				ownSiteVerdict({
+					name: 'Redwood Logistics',
+					website: 'https://redwoodlogistics.com/about',
+				}),
+			).toBe('established')
+		})
+
+		it('should establish a domain carrying the front of the name', () => {
+			// GIVEN a company that registered less than its full name, which is how a
+			// firm usually shortens one
+			// WHEN asked — THEN the front part it kept spells it just as well
+			expect(
+				ownSiteVerdict({
+					name: 'Acme Logistics',
+					website: 'https://acme.com',
+				}),
+			).toBe('established')
+		})
+
+		it('should establish a three-letter domain the name opens with', () => {
+			// GIVEN the large carriers, whose names open with an initialism too short
+			// for any check that goes on a fragment
+			// WHEN asked
+			// THEN each is at home on its own domain. A label that IS the whole front
+			// of the name is exact, so it says as much at three letters as at ten —
+			// and losing these would take the biggest names in the market with it
+			for (const [name, website] of [
+				['XPO Logistics', 'https://xpo.com/about-xpo-logistics'],
+				['DSV', 'https://dsv.com/about-dsv'],
+				['SEUR', 'https://seur.com/sobre-seur'],
+				['ASM', 'https://asm.es/quienes-somos'],
+				['TIBA Group', 'https://tiba-group.com/about-tiba'],
+				['GLS Spain', 'https://gls-spain.es/gls-spain-quienes'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website })).toBe('established')
+			}
+		})
+
+		it('should establish a domain that is one distinctive word of the name', () => {
+			// GIVEN the way most small firms register: the one word of the name
+			// people actually use, which is not the front of it
+			// WHEN asked — THEN that word standing alone is the company
+			expect(
+				ownSiteVerdict({
+					name: 'Transportes García',
+					website: 'https://garcia.es/contacto',
+				}),
+			).toBe('established')
+		})
+
+		it('should establish a domain with the legal form tacked on', () => {
+			// GIVEN a Catalan workshop whose domain writes its form after its name
+			// WHEN asked — THEN a form on the end is the company still writing itself
+			expect(
+				ownSiteVerdict({
+					name: 'Fusteria Miquel',
+					website: 'https://fusteriamiquelsl.cat',
+				}),
+			).toBe('established')
+		})
+
+		it('should read a name whose form is written with dots', () => {
+			// GIVEN the same company written the other Spanish way, form in dots
+			// WHEN asked — THEN the dots are taken out before the name is read, so one
+			// company spelled two ways is not two answers
+			expect(
+				ownSiteVerdict({ name: 'Acme S.L.', website: 'https://acme.com' }),
+			).toBe('established')
+		})
+
+		it('should read a name whose accents the domain drops', () => {
+			// GIVEN an accented name and the unaccented domain a registrar hands out
+			// WHEN asked — THEN accents are folded away on both sides
+			expect(
+				ownSiteVerdict({ name: 'Grupo Muñoz', website: 'https://munoz.es' }),
+			).toBe('established')
+		})
+
+		it('should read past a subdomain and a country second level', () => {
+			// GIVEN the company's site reached at a subdomain, and at a country domain
+			// with a public second level in it
+			// WHEN asked — THEN the label the domain is registered under is what is
+			// read, so neither hides the company
+			expect(
+				ownSiteVerdict({
+					name: 'Acme Logistics',
+					website: 'https://botiga.acme.co.uk/contacte',
+				}),
+			).toBe('established')
+		})
+	})
+
+	describe('when the domain merely contains the name', () => {
+		it('should not establish a domain with something else appended', () => {
+			// GIVEN a site whose domain carries the company's name and then some
+			// WHEN asked
+			// THEN nothing is established. Whoever registered "acme-directory" writes
+			// ABOUT Acme, and a listing whose domain happens to carry a word of the
+			// name would otherwise clear itself
+			expect(
+				ownSiteVerdict({
+					name: 'Acme Logistics',
+					website: 'https://acme-directory.com/acme-logistics',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a domain the name sits inside', () => {
+			// GIVEN a company's real site at a domain that puts a word of its own in
+			// front of the name
+			// WHEN asked
+			// THEN unknown, and this is the price rather than a bug: the address is
+			// still kept, what it loses is standing as the thing that vouches for the
+			// company. Pinned so the cost stays visible instead of being met in a run
+			expect(
+				ownSiteVerdict({
+					name: 'Penske Logistics',
+					website: 'https://gopenske.com/logistics',
+				}),
+			).toBe('unknown')
+		})
+	})
+
+	describe('when only a trade word would match', () => {
+		it('should not establish a domain spelling the trade a name opens with', () => {
+			// GIVEN a company whose name opens with the word for what it does
+			// WHEN asked
+			// THEN unknown: "grupo" identifies nobody, and grupo.es belongs to
+			// whoever registered it rather than to every company called Grupo
+			// something
+			expect(
+				ownSiteVerdict({ name: 'Grupo Ferré', website: 'https://grupo.es' }),
+			).toBe('unknown')
+		})
+
+		it('should establish the same name once its own word is in the domain', () => {
+			// GIVEN the same company at the domain that adds the family name
+			// WHEN asked — THEN the run that carries a word of the company's own is
+			// the company
+			expect(
+				ownSiteVerdict({
+					name: 'Grupo Ferré',
+					website: 'https://grupoferre.es',
+				}),
+			).toBe('established')
+		})
+
+		it('should not establish anything for a name that is only trade words', () => {
+			// GIVEN a name with nothing in it but what the company does
+			// WHEN asked — THEN there is no name to look for, so no domain can spell
+			// it
+			expect(
+				ownSiteVerdict({
+					name: 'Logistics Group',
+					website: 'https://logistics.com',
+				}),
+			).toBe('unknown')
+		})
+	})
+
+	describe('when the address is a page rather than a site', () => {
+		it('should not establish a listing page naming the company in its path', () => {
+			// GIVEN a directory's page about the company
+			// WHEN asked — THEN a path names a PAGE about the company, and who
+			// publishes a page about a company is the question, not the answer
+			expect(
+				ownSiteVerdict({
+					name: 'Redwood Logistics',
+					website: 'https://cbinsights.com/company/redwood-logistics',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a page naming the company in the first segment', () => {
+			// GIVEN the shape the website guard exempts from blanking, on a host that
+			// is nobody's: a social platform's page for the company
+			// WHEN asked
+			// THEN unknown. From the address alone this is the same shape as a
+			// company's own "about us" page, so the exemption that protects the
+			// carriers there is no reason to claim ownership here — what saves them
+			// is their own domain, which this host is not
+			expect(
+				ownSiteVerdict({
+					name: 'LIPOTECH SARL',
+					website: 'https://www.facebook.com/LIPOTECH.SARL',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a bare host that names the company nowhere', () => {
+			// GIVEN a directory's home page handed back as a company's website
+			// WHEN asked — THEN with no path there is nothing to condemn either, which
+			// is exactly why "not condemned" cannot stand in for "owned"
+			expect(
+				ownSiteVerdict({
+					name: 'KBE Energy',
+					website: 'https://annuaire.tecsol.fr',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a slug that happens to carry a word of the name', () => {
+			// GIVEN a listing whose trade slug coincidentally spells a word of the
+			// company's name
+			// WHEN asked — THEN the coincidence buys nothing, because the path is not
+			// read at all
+			expect(
+				ownSiteVerdict({
+					name: 'KBE Energy',
+					website: 'https://annuaire.fr/energy-installateurs-12345',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a listing page whose address names no company', () => {
+			// GIVEN a French solar directory's listing page recorded as a company's
+			// own site
+			// WHEN asked — THEN unknown, and neither the page nor anything the row
+			// cites could change that, since neither is read
+			expect(
+				ownSiteVerdict({ name: 'KBE Energy', website: TECSOL_LISTING }),
+			).toBe('unknown')
+		})
+	})
+
+	describe('when what came in is a question rather than a name', () => {
+		it('should establish nothing from a word of a whole market question', () => {
+			// GIVEN the question a market search is launched with, handed down as the
+			// company's name — which is what a run with no company on file passes
+			const question =
+				'Empresas instaladoras en España: instalaciones eléctricas, ' +
+				'fontanería y climatización, energía solar fotovoltaica'
+
+			// WHEN a website is asked about against it
+			// THEN unknown. Every long word of a question would otherwise be a word a
+			// domain could be cleared by, and a run that does not know the company's
+			// name cannot say whose site anything is
+			expect(
+				ownSiteVerdict({ name: question, website: 'https://fontaneria.es' }),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({ name: question, website: 'https://empresas.es' }),
+			).toBe('unknown')
+		})
+
+		it('should still establish a long name that is genuinely a name', () => {
+			// GIVEN one of the longest names a real company carries
+			// WHEN asked — THEN the bar sits well clear of it, so a company is not
+			// refused for being called something long
+			expect(
+				ownSiteVerdict({
+					name: 'Sociedad Española de Montajes Industriales SA',
+					website: 'https://sociedadespanola.es',
+				}),
+			).toBe('established')
+		})
+	})
+
+	describe('when the domain is shorter than a name', () => {
+		it('should not establish a domain matching a single initial', () => {
+			// GIVEN a company whose name opens with an initial
+			// WHEN asked — THEN one letter is an initial rather than a name, and a
+			// domain that short belongs to whoever paid for it
+			expect(
+				ownSiteVerdict({ name: 'A. Martín', website: 'https://a.com' }),
+			).toBe('unknown')
+		})
+
+		it('should establish a three-letter domain, which the carriers register', () => {
+			// GIVEN the shortest domain a real company here is at
+			// WHEN asked — THEN three letters stand, so the floor cannot be raised
+			expect(
+				ownSiteVerdict({ name: 'Fer Corporation', website: 'https://fer.org' }),
+			).toBe('established')
+		})
+	})
+
+	describe('when the domain writes a legal form after the name', () => {
+		it('should establish it after a distinctive word, not only after the front', () => {
+			// GIVEN a company known by an acronym its own name carries, at the domain
+			// that writes that acronym and its form
+			// WHEN asked
+			// THEN established. The form is allowed after whichever part of the name
+			// the domain spells — reading it after the front of a name but not after
+			// one of its words would be the same rule answering two ways
+			expect(
+				ownSiteVerdict({
+					name: 'Sociedad Española de Montajes Industriales SA (SEMI)',
+					website: 'https://www.semi-sa.com',
+				}),
+			).toBe('established')
+		})
+	})
+
+	describe('when there is nothing to read', () => {
+		it('should not establish anything without a name to compare', () => {
+			// GIVEN a real company site and no name beside it — an open-ended run, or
+			// a target the run was never told the name of
+			// WHEN asked — THEN unknown rather than missing: a run with no name
+			// establishes nothing, which is an answer
+			expect(ownSiteVerdict({ name: '', website: 'https://acme.com' })).toBe(
+				'unknown',
+			)
+		})
+
+		it('should not establish anything for a name that is only a legal form', () => {
+			// GIVEN a row whose whole name is the form
+			// WHEN asked — THEN the form is taken out and nothing is left to look for
+			expect(ownSiteVerdict({ name: 'S.L.', website: 'https://sl.com' })).toBe(
+				'unknown',
+			)
+		})
+
+		it('should not establish a value with words written beside the address', () => {
+			// GIVEN the model's aside glued onto the address, which the URL parser
+			// hides by folding the words into the path
+			// WHEN asked — THEN unknown: there is no single domain to read, and
+			// nobody could open the value either
+			expect(
+				ownSiteVerdict({
+					name: 'ADIME',
+					website: 'https://adime.org/ (not directly provided, inferred)',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a value that is not an address', () => {
+			// GIVEN values no reader could open
+			// WHEN asked — THEN each is unknown
+			for (const website of ['not a url', '', 'info@acme.es', 'src_9f2a1b3c']) {
+				expect(ownSiteVerdict({ name: 'Acme', website })).toBe('unknown')
+			}
+		})
+
+		it('should not establish a numeric host', () => {
+			// GIVEN a site given by its address on the network rather than by name
+			// WHEN asked — THEN nothing in the numbers spells a company
+			expect(
+				ownSiteVerdict({ name: 'Acme', website: 'http://192.168.1.10/acme' }),
+			).toBe('unknown')
+		})
+	})
+
+	describe('when the same address is judged for a different company', () => {
+		it('should establish it only for the company the domain names', () => {
+			// GIVEN one company's own site, offered as two different companies'
+			// WHEN each is asked
+			// THEN the domain answers for its own company and for nobody else, so a
+			// row handed somebody else's site gets no clearance from it
+			const website = 'https://acme.com/quienes-somos'
+			expect(ownSiteVerdict({ name: 'Acme Logistics', website })).toBe(
+				'established',
+			)
+			expect(ownSiteVerdict({ name: 'Instalaciones Rubio', website })).toBe(
+				'unknown',
+			)
+		})
+	})
+})

--- a/packages/research/src/application/own-site.ts
+++ b/packages/research/src/application/own-site.ts
@@ -1,0 +1,180 @@
+/**
+ * Whether a website is established as the company's OWN — the positive claim,
+ * which nothing else in this package makes.
+ *
+ * `website-guard.ts` answers the opposite question: is this address clearly NOT
+ * the company's? Its rules only ever blank, and a blank costs a real website, so
+ * its bar is deliberately high and it keeps whatever it cannot condemn. That
+ * makes "kept" mean "not condemned", which is not the same statement as "the
+ * company owns it" — and a caller asking "is at least one of this company's
+ * sources not a directory, its own site included?" reads the first and hears the
+ * second. It then answers yes out of silence, which is exactly the fail-open the
+ * directory watch refuses to allow itself (see `directory-sites.ts`).
+ *
+ * So this asks the question the other way round, with the same two-valued shape
+ * the directory watch gives itself: `established`, or `unknown` — and `unknown`
+ * is not a clearance. There is no third value meaning cleared, because there is
+ * nothing here to answer yes with when the evidence is thin.
+ *
+ * ## What establishes it
+ *
+ * One thing, read off the address: THE DOMAIN SPELLS THE COMPANY. A firm
+ * registers its own name, or the front of it, or the one word of it people use —
+ * "Fusteria Miquel" at fusteriamiquel.cat, "XPO Logistics" at xpo.com,
+ * "Transportes García" at garcia.es. The label has to BE one of those, never
+ * merely contain it: "acme-directory.com" contains "acme" and belongs to
+ * somebody else, and a listing whose own domain happens to carry a word of the
+ * name would otherwise clear itself.
+ *
+ * ## What deliberately does NOT establish it
+ *
+ * **The path.** "facebook.com/Some-Company" and "xpo.com/about-xpo-logistics"
+ * are the same shape — a page naming the company on a host that does not — and
+ * from the address alone nothing separates them. A directory files a company at
+ * a path; so does a social platform; so, sometimes, does the company itself. A
+ * path names a PAGE about the company, and who publishes a page about a company
+ * is the very thing in question. `website-guard.ts` reads paths, and must: a
+ * name in a deeper segment is the listing signature, and the first segment is
+ * exempted there so an "about us" page is not mistaken for one. Those are
+ * reasons to withhold a blank. None of them is a reason to claim ownership.
+ *
+ * **Where the claim was read from.** A row's citations say which pages the run
+ * opened, never who owns a domain. Settling ownership on provenance opens a hole
+ * for every way a row can cite: one citing nothing, one whose citations a guard
+ * ahead has already dropped, one with a second citation about the COMPANY but
+ * not about the address, one citing by an opaque `src_…` id with no host in it,
+ * and the target's own `website` field, which carries exactly one source and so
+ * can never have a second. Reading no citations at all closes every one of them
+ * together. It also holds a scanned row and the run's own answer to one bar,
+ * and the run's own answer is where a rule that reads citations has the least
+ * to go on.
+ *
+ * **A second page that prints the address.** Tempting, and the one clause
+ * considered and dropped: a footer or a link roll prints "facebook.com" on
+ * pages that have nothing to do with whose site it is, so a mention on another
+ * page manufactures `established` out of ordinary web furniture — the failure
+ * this verdict exists to prevent, arriving by a different door.
+ *
+ * ## What it costs, on purpose
+ *
+ * A company at a domain that spells its name with something in front of it —
+ * "Penske Logistics" at gopenske.com, "Grupo Cobra" at grupocobra.com — reads
+ * `unknown`, as does one at an acronym its name never spells (SICE at sice.com).
+ * So does any company at a domain registered with an accent, which arrives in
+ * the punycode spelling and folds to letters that spell nothing: a blind spot
+ * in exactly the markets this work is for, and the reason it is written down
+ * here rather than met in a run.
+ *
+ * In every one of those the website is still kept, since keeping is not this
+ * verdict's decision; what it loses is standing as the source that vouches for
+ * the company. That is a withholding, and withholding is the direction this
+ * file is allowed to be wrong in.
+ *
+ * Closing any of them means loosening — reading past a word in front, or
+ * matching initials — and each loosening is a new way to clear a stranger's
+ * address. Measure the cost before paying it.
+ *
+ * Whether the host is a business directory is a separate question with a
+ * separate answer (`directory-sites.ts`), and a caller weighing a company's
+ * sources asks both.
+ */
+
+import {
+	collapse,
+	distinctiveWords,
+	hostLabel,
+	isGenericWord,
+	labelSpellsOneOf,
+	nameWordsWithoutForms,
+	withoutFormDots,
+} from './entity-guard'
+import { hostOf, isBareWebAddress } from './source-key'
+
+/**
+ * What is known about a company's website. `unknown` is not "cleared". Spelled
+ * as a value rather than left as the absence of one, so a caller has to name it
+ * before acting on it.
+ */
+export type OwnSiteVerdict = 'established' | 'unknown'
+
+// How many words a company's name runs to before what came in is a brief rather
+// than a name. A run started from free text with no company on file passes its
+// whole question down as the name, and every long word of a question would then
+// be a word a domain could be cleared by — "Acme Corp Barcelona" clearing
+// barcelona.cat. A run that does not know the company's name cannot say whose
+// site anything is. Set well clear of the longest real names, which run to six
+// ("Sociedad Española de Montajes Industriales"), because what sits on the other
+// side of this is a paragraph rather than a seventh word.
+const MOST_WORDS_A_NAME_RUNS_TO = 8
+
+// The shortest front part a domain may be read as spelling. The large carriers
+// register three letters — dsv.com, xpo.com — so the floor cannot be four; but
+// one or two letters is an initial rather than a name, and a domain that short
+// belongs to whoever paid for it regardless of whose initials it matches.
+const SHORTEST_NAME_A_DOMAIN_SPELLS = 3
+
+// Every name a company's own domain could plausibly be registered under: the
+// whole name and each shorter run of its words from the front — "XPO Logistics"
+// gives "xpo" and "xpologistics". Front-anchored, because a firm shortens its
+// name by dropping the end ("Acme Logistics" at acme.com) and not by dropping
+// the start, and a run taken from anywhere would let a listing filed under any
+// word of the name clear itself.
+const namesTheDomainCouldCarry = (
+	words: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+	const runs: Array<string> = []
+	let run = ''
+	let identifiesSomebody = false
+	for (const word of words) {
+		run += word
+		// A front part made of nothing but trade words identifies nobody, so
+		// "Grupo Ferré" must not be at home on grupo.es and "Transportes García"
+		// not on transportes.com. Once a word of the company's own has arrived,
+		// every longer run carries it.
+		identifiesSomebody = identifiesSomebody || !isGenericWord(word)
+		if (identifiesSomebody && run.length >= SHORTEST_NAME_A_DOMAIN_SPELLS) {
+			runs.push(run)
+		}
+	}
+	return runs
+}
+
+/**
+ * Whether a host is this company's own domain.
+ *
+ * The label has to spell the company: one of the names a domain could carry, or
+ * one distinctive word of the name on its own — which is how most small firms
+ * register. Either may have the legal form after it, and nothing else:
+ * "fusteriamiquelsl.cat" is the workshop, "fusteriamiquelreviews.com" is
+ * somebody writing about it.
+ */
+const hostSpellsTheCompany = (name: string, host: string): boolean => {
+	const words = nameWordsWithoutForms(withoutFormDots(name))
+	if (words.length > MOST_WORDS_A_NAME_RUNS_TO) return false
+	return labelSpellsOneOf(collapse(hostLabel(host)), [
+		...namesTheDomainCouldCarry(words),
+		...distinctiveWords(name),
+	])
+}
+
+/**
+ * Whether this website is established as the company's own site.
+ *
+ * `name` is the company the address is claimed for — the row's own name on a
+ * scanned company, and the company the run is about for the one `website` field
+ * that arrives with no name beside it. A run with no name to compare establishes
+ * nothing, which is the right answer rather than a missing one.
+ */
+export const ownSiteVerdict = (args: {
+	readonly name: string
+	readonly website: string
+}): OwnSiteVerdict => {
+	const { name, website } = args
+	// A value with words written next to it is not one address, so there is no
+	// domain to read — and a reader cannot open it either.
+	if (!isBareWebAddress(website)) return 'unknown'
+	const host = hostOf(website)
+	if (host === null) return 'unknown'
+
+	return hostSpellsTheCompany(name, host) ? 'established' : 'unknown'
+}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -3127,6 +3127,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									// nothing but a company's own site lands in the CRM's website
 									// field. Deterministic and evidence-free, so it runs here among the
 									// plain checks, ahead of the model critics.
+									//
+									// Blanking is only half the answer: an address nobody could
+									// condemn is not thereby the company's. So each survivor is also
+									// asked whether anything establishes that it is, and the two
+									// numbers are reported apart.
 									name: 'websites',
 									run: findings =>
 										Effect.gen(function* () {
@@ -3165,6 +3170,22 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													}),
 												)
 											}
+											// And of the addresses that survived, how many of them
+											// anything establishes as the company's own site. Logged
+											// whether or not anything was blanked: a run whose websites
+											// all read `unknown` is not a quiet run, it is one whose
+											// companies have nothing vouching for them.
+											if (check.ownSiteEstablished + check.ownSiteUnknown > 0) {
+												yield* Effect.logInfo(
+													'research.websites.own_site',
+												).pipe(
+													Effect.annotateLogs({
+														research_id: researchId,
+														established: check.ownSiteEstablished,
+														unknown: check.ownSiteUnknown,
+													}),
+												)
+											}
 											return {
 												findings: check.findings,
 												spanCounts: {
@@ -3176,6 +3197,21 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														directories.sites.size,
 													'research.directories.addresses_read':
 														directories.addressesRead,
+													// Kept apart from the blanked count on purpose: an
+													// address that went and one nothing vouches for are
+													// different answers, and reading them as one total is
+													// how "not blanked" gets read as "owned".
+													//
+													// About this extraction, not about the run. Every gap
+													// round extracts again and the results are folded
+													// together afterwards, so a website only one round
+													// produced is counted on that round's line and missing
+													// from the last one. Read the run's own answer for a
+													// figure about the run.
+													'research.websites.own_site_established':
+														check.ownSiteEstablished,
+													'research.websites.own_site_unknown':
+														check.ownSiteUnknown,
 												},
 											}
 										}),

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -356,7 +356,9 @@ describe('guardCompanyWebsites', () => {
 			// GIVEN a competitor the model gave no website
 			const findings = scan([{ name: 'Acme Logistics' }])
 
-			// WHEN checked — THEN nothing to blank, and it is unchanged
+			// WHEN checked — THEN nothing to blank, and it is unchanged. There is no
+			// address to establish anything about either, so neither ownership count
+			// moves: a row with no website is not a row whose website is unvouched for
 			const result = guardCompanyWebsites(findings)
 			expect(result).toEqual({
 				findings,
@@ -365,6 +367,8 @@ describe('guardCompanyWebsites', () => {
 				blankedProfilePage: 0,
 				blankedSharedHost: 0,
 				blankedReadPage: 0,
+				ownSiteEstablished: 0,
+				ownSiteUnknown: 0,
 			})
 		})
 
@@ -1118,6 +1122,211 @@ describe('guardCompanyWebsites', () => {
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.blankedReadPage).toBe(0)
+		})
+	})
+
+	describe('when a website survives every rule', () => {
+		it("should say whether anything establishes it as the company's own site", () => {
+			// GIVEN two companies that both keep their address: one at the domain its
+			// name spells, one at a host that spells nothing
+			const findings = scan([
+				{ name: 'Redwood Logistics', website: 'https://redwoodlogistics.com' },
+				{ name: 'KBE Energy', website: 'https://annuaire.tecsol.fr' },
+			])
+
+			// WHEN checked
+			// THEN both are kept and the two are told apart anyway, which is the whole
+			// point: surviving the rules is not the same statement as owning the site
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://redwoodlogistics.com',
+				'https://annuaire.tecsol.fr',
+			])
+			expect(result.ownSiteEstablished).toBe(1)
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+
+		it('should count nothing for a website it blanked', () => {
+			// GIVEN an address the deeper-path rule takes away
+			const findings = scan([
+				{
+					name: 'Redwood Logistics',
+					website: 'https://cbinsights.com/company/redwood-logistics',
+				},
+			])
+
+			// WHEN checked — THEN an address that is gone has no ownership left to
+			// establish, so it lands in neither column rather than swelling the
+			// unvouched-for one
+			const result = guardCompanyWebsites(findings)
+			expect(result.blankedProfilePage).toBe(1)
+			expect(result.ownSiteEstablished + result.ownSiteUnknown).toBe(0)
+		})
+	})
+
+	describe('when a kept address gives the rules nothing to work with', () => {
+		it('should read a bare host on an unrelated domain as unestablished', () => {
+			// GIVEN a listing's home page, cited as the page read. With no path there
+			// is no page to tell apart from the site, so the read-page rule stands
+			// down by design
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: 'https://annuaire.tecsol.fr',
+					sources: ['https://annuaire.tecsol.fr'],
+				},
+			])
+
+			// WHEN checked — THEN it is kept, and unvouched for
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://annuaire.tecsol.fr',
+			])
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+
+		it('should read a row citing nothing as unestablished', () => {
+			// GIVEN a row whose citations a guard ahead of this one already dropped,
+			// which leaves the read-page rule with no provenance to weigh
+			const findings = cited([
+				{ name: 'KBE Energy', website: TECSOL_LISTING, sources: [] },
+			])
+
+			// WHEN checked — THEN silence about where a claim came from is not a
+			// reason to call the address the company's
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+
+		it('should read a row with a second source elsewhere as unestablished', () => {
+			// GIVEN a listing address on a row something else also mentioned, which
+			// stands the read-page rule down
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: [TECSOL_LISTING, 'https://www.lemoniteur.fr/kbe-energy'],
+				},
+			])
+
+			// WHEN checked — THEN a second source about the COMPANY says nothing about
+			// who owns the ADDRESS, so it buys the address no standing
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+
+		it('should read a slug carrying a word of the name as unestablished', () => {
+			// GIVEN a listing whose trade slug happens to spell a word of the name,
+			// which reads to the read-page rule as the address naming the company
+			const listing = 'https://annuaire.fr/energy-installateurs-12345'
+			const findings = cited([
+				{ name: 'KBE Energy', website: listing, sources: [listing] },
+			])
+
+			// WHEN checked — THEN the coincidence buys nothing here, because a path
+			// names a page about the company rather than the company's site
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([listing])
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+
+		it('should read a row citing an opaque source id as unestablished', () => {
+			// GIVEN a row citing its page by the id the run stored it under, which
+			// carries no host for the read-page rule to compare
+			const findings = cited([
+				{
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					sources: ['src_9f2a1b3c4d5e6f70'],
+				},
+			])
+
+			// WHEN checked — THEN a citation nothing can be read off is not a
+			// clearance
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+	})
+
+	describe("when ownership is asked of the run's own answer for the target", () => {
+		it('should hold that field to the same bar as a scanned row', () => {
+			// GIVEN one address on a host that spells no part of the name, put twice:
+			// as the run's own answer for the target, whose single source is a page
+			// elsewhere, and as an ordinary scanned row
+			const website = 'https://kbe-groupe.example/nos-activites'
+			const target = guardCompanyWebsites(
+				{
+					enrichment: {
+						website: {
+							value: website,
+							source_id: 'https://www.lemoniteur.fr/kbe-energy',
+							confidence: null,
+						},
+					},
+				},
+				'KBE Energy',
+			)
+			const row = guardCompanyWebsites(
+				cited([
+					{
+						name: 'KBE Energy',
+						website,
+						sources: [website, 'https://www.lemoniteur.fr/kbe-energy'],
+					},
+				]),
+			)
+
+			// WHEN both are checked
+			// THEN both keep the address and both read it as unestablished. That field
+			// carries exactly one source and can never carry a second, so a rule that
+			// stands down once a row has two is weaker there than anywhere else — and
+			// this question reads no sources at all, so the bar is the same
+			expect(target.ownSiteEstablished).toBe(0)
+			expect(target.ownSiteUnknown).toBe(1)
+			expect(row.ownSiteEstablished).toBe(0)
+			expect(row.ownSiteUnknown).toBe(1)
+		})
+
+		it("should establish the target's own site against the name it was told", () => {
+			// GIVEN the company's real domain as the run's answer for the target
+			const findings = {
+				enrichment: {
+					website: {
+						value: 'https://redwoodlogistics.com/about',
+						source_id: 'src_a',
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN checked against the company the run is about
+			// THEN the name told from outside is what the domain is read against, so
+			// the field that arrives with no name beside it can still be established
+			const result = guardCompanyWebsites(findings, 'Redwood Logistics')
+			expect(result.ownSiteEstablished).toBe(1)
+			expect(result.ownSiteUnknown).toBe(0)
+		})
+
+		it('should establish nothing for that field when no name was told', () => {
+			// GIVEN the same real domain on a run that was given no target name
+			const findings = {
+				enrichment: {
+					website: {
+						value: 'https://redwoodlogistics.com/about',
+						source_id: 'src_a',
+						confidence: null,
+					},
+				},
+			}
+
+			// WHEN checked with nothing to compare — THEN unknown, because there is no
+			// company for the domain to be the company's own site OF
+			const result = guardCompanyWebsites(findings)
+			expect(result.ownSiteEstablished).toBe(0)
+			expect(result.ownSiteUnknown).toBe(1)
 		})
 	})
 

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -25,6 +25,16 @@
  * describes itself in the first path segment ("xpo.com/about-xpo-logistics"), and a
  * blank costs a real website, so the bar to blank is deliberately high.
  *
+ * Every one of those rules only ever BLANKS. None of them can say a website is
+ * the company's own, so "kept" means "not condemned" and a caller reading it as
+ * ownership answers yes out of silence. That question has its own answer next
+ * door — `ownSiteVerdict` in `own-site.ts` — and every website this leaves
+ * standing is put to it, so the counts below say not only how many addresses
+ * went but how many of the survivors anything actually establishes. Like the
+ * blank counts beside them, they describe the answer handed to THIS call. A run
+ * that extracts several times and folds the results together has to put the
+ * folded answer to the verdict itself.
+ *
  * The address rule and the deeper-path rule read only a name and a website, so they
  * need no evidence corpus and no database. They fire on any object carrying both —
  * a scanned competitor or prospect — and on the run's own answer for the target's
@@ -44,6 +54,7 @@ import {
 	nameWithoutForms,
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
+import { ownSiteVerdict } from './own-site'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
 
 const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
@@ -294,6 +305,14 @@ export interface WebsiteGuardResult {
 	readonly blankedSharedHost: number
 	/** Websites blanked because they were the page the row's claim was read from. */
 	readonly blankedReadPage: number
+	/** Websites left standing that are established as the company's own site. */
+	readonly ownSiteEstablished: number
+	/**
+	 * Websites left standing that nothing establishes as the company's own. Kept,
+	 * because keeping is not that verdict's decision — but a caller weighing a
+	 * company's sources may not count one of these as its own site.
+	 */
+	readonly ownSiteUnknown: number
 }
 
 /**
@@ -319,7 +338,18 @@ export const guardCompanyWebsites = (
 	let blankedProfilePage = 0
 	let blankedSharedHost = 0
 	let blankedReadPage = 0
+	let ownSiteEstablished = 0
+	let ownSiteUnknown = 0
 	const hostClaims = collectHostClaims(findings)
+
+	// Ask the survivor the question none of the rules above can answer, and keep
+	// the answer beside their counts. Asked only of a website that is staying,
+	// since one already gone has no ownership left to establish.
+	const countOwnSite = (name: string, website: string): void => {
+		if (ownSiteVerdict({ name, website }) === 'established')
+			ownSiteEstablished++
+		else ownSiteUnknown++
+	}
 
 	const count = (verdict: Exclude<WebsiteVerdict, 'keep'>): void => {
 		if (verdict === 'not_an_address') blankedNotAnAddress++
@@ -370,6 +400,7 @@ export const guardCompanyWebsites = (
 				// a reader of the profile still needs to see the key was asked for.
 				return null
 			}
+			countOwnSite(targetName ?? '', value['value'])
 			return value
 		}
 
@@ -392,6 +423,7 @@ export const guardCompanyWebsites = (
 					Object.entries(rest).map(([k, v]) => [k, walkChild(k, v)] as const),
 				)
 			}
+			countOwnSite(name, website)
 		}
 
 		return Object.fromEntries(
@@ -406,5 +438,7 @@ export const guardCompanyWebsites = (
 		blankedProfilePage,
 		blankedSharedHost,
 		blankedReadPage,
+		ownSiteEstablished,
+		ownSiteUnknown,
 	}
 }


### PR DESCRIPTION
## What

When a market search comes back with a list of companies, each row can carry a
website. Some of those addresses are the company's own site; some are a page
about the company on somebody else's — a business directory's listing, a
Facebook post. Until now the research pipeline (the Research bounded context,
`packages/research`) could only ever say "this address is clearly **not** the
company's" and blank it. It had no way to say the opposite. So anything asking
"does this company have a source that isn't a directory, counting its own site?"
had to read *the checks stayed quiet* as *the company owns this* — which is a
yes given out of silence, not out of evidence.

This adds the missing positive answer. A website is now either **established** as
the company's own or **unknown**, and `unknown` carries no clearance. Nothing
that ships changes today; what changes is that the next step to be built —
verifying a company actually exists — can ask a question that has an honest
answer instead of inferring one from a silence.

The neighbouring module `directory-sites.ts` already holds itself to exactly
this discipline, in its own words: *"a caller asking 'is at least one of these
sources not a directory?' must not be able to answer yes out of silence."* The
website field had no such discipline. It has one now.

## The fix

**Touches:** a new module that answers "is this website the company's own", the
website check that already blanks the obviously-wrong ones (which keeps doing
exactly what it did), and the shared name-and-domain folding all the guards use.
The step order in the run is unchanged, and so is the duplicate-row fold that
comes after it.

- A verdict with two values and no third one meaning cleared, shaped after the
  directory watch it mirrors: `established` or `unknown`.
- A website is `established` when **the domain spells the company** — the
  registrable label is the whole name, a run of its words from the front, or one
  distinctive word of it, each optionally with the legal form after it
  ("fusteriamiquelsl.cat") and nothing else. The label has to *be* one of those,
  never merely contain one, or "acme-directory.com" would clear itself.
- It reads **no path and no citations**, and that is the whole design rather than
  an omission. Five of the six holes the issue lists are one mistake — settling
  ownership on where a claim was read from, when a row's citations only say which
  pages a run opened. The sixth is a path coincidence, and a path names a page
  *about* a company. Reading neither closes all six together and stops the run's
  own answer for its target being held to a lower bar than a scanned row, which
  is where it was weakest.
- Blanking is untouched. No rule moved, and the exemption that lets a company
  describe itself in the first part of its address ("xpo.com/about-xpo-logistics")
  stays exactly where it is.
- The "this domain spells this name" test now lives once in the entity guard and
  is shared with the check that picks a company's site to go and read, instead of
  a second copy drifting from the first.

## Impact

- **Nothing that ships changes.** The website check returns the same findings it
  did before; only two counters are added. That is deliberate, and it is why the
  measurement below is a straight reading rather than a before/after.
- **No change to which organisation can see what** (no row-level-security or
  `organization_id` scoping touched), no database migration, no new environment
  variable, no change to the public/protected boundary, and no change to the
  shape of anything the frontend or an assistant reads over MCP.
- **Two new run measurements** appear on the research span:
  `research.websites.own_site_established` and `…_unknown`, plus a
  `research.websites.own_site` log line. Like the blanked counts beside them they
  describe **one extraction pass**, not the whole run — a run extracts several
  times and folds the results together afterwards. Both comments say so.
- **`isOwnSiteHost` in the entity guard was re-expressed**, not changed. It picks
  which site a run goes and reads, so it is worth saying explicitly: the extracted
  helper is the same test line for line, and its existing tests pass unmodified.

## Measured

Six live passes over the two market rows in `eval/golden-markets.example.json`
(`fr-installations` ×4, `es-installations` ×2) via `/run-research-eval`, caches
cleared between passes. One French pass died with `internal_error`; it was
re-run cleanly and the re-run succeeded (15 rows, 100% right kind, 100%
coverage), so the failure was transient rather than the change. That pass is
excluded below.

**Five runs, 80 rows, 43 carrying a website: 31 established, 12 unknown.**

So 12 companies — 28% of those with a website, 15% of all rows — stop counting
their own site as the non-directory source. That is the number §9.3 of #456
asked for.

Reading the 12 one by one, four are a third party's page, which is the bug:

| company | address |
|---|---|
| Eiffage Énergie Systèmes Aquitaine | `societe.com/societe/eiffage-…-401070891.html` — a French business directory |
| Schneider Electric France | `facebook.com/SchneiderElectricFR/posts/…` — a Facebook post |
| Aeronaval de Construcciones e Instalaciones | `idae.es/en/company/aeronaval-…` — the Spanish energy agency's company directory |
| TORRES SISTEMAS ELECTRICOS, S.L. | `aselec.es` — spells neither word of the name; `aselec` is another firm's brand |

The other eight are real own sites the verdict withholds on, and they fall into
two shapes:

- **a trade word in front of the name on the domain** — `grupocobra.com` (Cobra),
  `grupoetra.com` (Electronic Trafic), `grupolasser.com` (Lasser);
- **an acronym or abbreviation the name never spells** — `sice.com`, `semi.es`,
  `ppvs-fm.com`, `esanit.fr`; plus `begi.fr` (BJ 56 Broceliande), which I could
  not place either way.

Both shapes could be closed and both are **loosenings** — each one is a new way
to clear a stranger's address — so I have left them as a decision for you rather
than paying for them unmeasured. Closing the trade-word-in-front shape alone
would recover 3 of the 12.

One pair worth seeing side by side: `semi-sa.com` reads **established** for
"Sociedad Española de Montajes Industriales SA (SEMI)" while `semi.es` reads
**unknown** for the same company written without the parenthetical acronym. The
verdict can only use what the name gives it.

## §9.1 of #456 — I think it can now be closed

The question was whether a company's own website satisfies "at least one
non-directory source". It was blocked because "the company's own website" meant
"whatever the checks did not blank", so a directory listing satisfied it — the
exact fail-open the decision exists to prevent.

A directory's listing page can no longer read `established`, because its domain
spells the directory rather than the company. Measured live: `societe.com`,
`idae.es` and `facebook.com` all read `unknown`. So the answer is **yes, with the
wording tightened** — an `established` own site satisfies it; an `unknown` one
does not count at all. Verifying a company exists (§4.8) should consume
`established` and never "was not blanked".

## #477 — I would keep it open, narrowed

Its shape **is** subsumed. `facebook.com/…` reads `unknown`, in tests and on a
real run (Schneider Electric France above), and for the same root cause: the
address was being judged on its path, and a path names a page about a company.
So #477 is not a separate mechanism to design.

But #477's acceptance is that the value not be **kept**, and this deliberately
does not blank on `unknown` — eight of the twelve unknowns measured are real own
sites, and blanking would destroy them. #477 also asks two things this does not
answer: whether a fixed list of social hosts is defensible against
`directory-sites.ts`'s argument against fixed host lists, and whether a Facebook
page belongs in `manage_company_channels` rather than nowhere. I would keep it
open with its question narrowed to those.

## Review guide

- Start with the module comment at the top of
  `packages/research/src/application/own-site.ts` — it is the argument, and the
  rest of the file is short. The section "What deliberately does NOT establish
  it" is where I would most expect you to disagree.
- The riskiest judgement is **reading no citations at all**. It is what turns six
  fixes into one, but it also means a genuine second source vouching for an
  address buys nothing. I considered a clause for that and dropped it, with the
  reasoning written down in the module: a footer or a link roll prints
  "facebook.com" on pages that have nothing to do with whose site it is, so a
  mention on another page would manufacture `established` out of ordinary web
  furniture.
- Two named constants are judgement calls: the longest a name may run to before
  it is treated as a question rather than a name (a run started from free text
  passes its whole question down as the name), and the shortest domain that may
  spell one. Both are measured — across the 65 live rows the longest real name
  is six words and the shortest own domain is three letters.
- `packages/research/src/application/entity-guard.ts` is the one file where I
  touched existing behaviour-bearing code. The extracted helper is line-for-line
  the old test; its tests pass unmodified.
- The test files are long but mechanical to read — one case per behaviour.
- I did not run `/security-review` or a Snyk scan: this change reads no external
  input, crosses no trust boundary and touches no authentication or tenant
  scoping. Say if you want it run anyway.

## Tests

- `own-site.test.ts` — 30 cases: what the domain may spell, what it may not, the
  six shapes from the issue, a question handed in where a name belongs, and the
  degenerate inputs.
- `website-guard.test.ts` — the 67 existing behaviour cases pass **unmodified**,
  which is the regression evidence that blanking did not move; plus 11 new cases
  for the counters and each shape.
- `entity-guard.test.ts` — the extracted helper and the domain-label reader.

## Verification

- Gates run and green: `pnpm install` (no lockfile drift), `pnpm -w check-types`
  (13/13), `pnpm -w test` (21/21 tasks, 1199 research tests), `pnpm -w build`
  (13/13).
- End-to-end against the live stack: six market runs through the real pipeline
  (live scraping and models) on this worktree's own database, five of which
  succeeded; the counters and the log line were read off those runs, and the
  numbers above were computed from the findings each run actually stored.
- No UI in this change, so no screenshots.

## Deferred

- The website check's whole-answer rule — the one that blanks a host two
  differently-named rows both claim — only ever sees a single extraction, never
  the merged list a run ships. Every individual value that ships was checked, so
  nothing unchecked lands, but a pair of rows that only share a host after the
  merge is never caught. Not fixed here because fixing it changes what ships and
  needs its own measurement.
- Whether an `unknown` website should be blanked rather than merely uncounted.
  That is #477's remaining question and the eight real own sites above are its
  cost.

Closes #476
