### PR TITLE
fix(research): recognise a name however an address spells it out

### DIFF
--- a/packages/research/src/application/directory-sites.test.ts
+++ b/packages/research/src/application/directory-sites.test.ts
@@ -664,4 +664,62 @@ describe('siteVerdict', () => {
 			expect(siteVerdict('anything', new Set())).toBe('unknown')
 		})
 	})
+
+	describe("when one of the run's companies is written with a geminated l", () => {
+		it('should watch the host file it whichever way the slug spells it', () => {
+			// GIVEN two of the run's companies filed on one host, one of them Catalan
+			// WHEN the listing writes the geminate with one l, and when it doubles it
+			// THEN the host is watched filing both companies either way. Read only
+			// the way the name is written, half the listings file the company under a
+			// spelling the run cannot recognise and the listing keeps its standing as
+			// that company's own website
+			for (const filed of ['instalacions-vives', 'installacions-vives']) {
+				const observation = observe(
+					['Instal·lacions Vives SL', 'Fusteria Miquel SL'],
+					[
+						`https://empreses.cat/fitxa/${filed}`,
+						'https://empreses.cat/fitxa/fusteria-miquel',
+					],
+				)
+				expect([...observation.sites]).toEqual(['empreses.cat'])
+			}
+		})
+
+		it('should read its two rows as one company however each spells the name', () => {
+			// GIVEN one firm listed twice, the way a Catalan list writes it — once
+			// under its trade name with the mark, once at more length without it
+			const observation = observe(
+				['Instal·lacions Vives SL', 'Instalacions Vives Serveis SL'],
+				[
+					'https://empreses.cat/fitxa/instalacions-vives',
+					'https://empreses.cat/fitxa/instalacions-vives-serveis',
+				],
+			)
+
+			// WHEN the host is judged
+			// THEN it is no listing: the longer name is the shorter one written at
+			// more length, and one company met twice cannot reach the two it takes.
+			// Compared only as each name is written, the two spellings would hide
+			// that from the rule and a firm's own site would be called a directory
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should count its two spellings as the one company they are', () => {
+			// GIVEN a single Catalan company, filed twice on one host — once under
+			// each spelling of its name
+			const observation = observe(
+				['Instal·lacions Vives SL'],
+				[
+					'https://empreses.cat/fitxa/instalacions-vives',
+					'https://empreses.cat/altres/installacions-vives',
+				],
+			)
+
+			// WHEN the host is judged
+			// THEN it is no listing. It takes two of the run's companies to be one,
+			// and one company written two ways is still one — counted apart, a firm's
+			// own site would reach two on its own and lose the company its website
+			expect([...observation.sites]).toEqual([])
+		})
+	})
 })

--- a/packages/research/src/application/directory-sites.ts
+++ b/packages/research/src/application/directory-sites.ts
@@ -58,14 +58,13 @@
  */
 
 import {
+	coreSpellings,
 	DISTINCTIVE_NAME_LENGTH,
 	distinctiveWords,
 	type EntityTargets,
 	foldTokens,
 	isOwnSiteHost,
-	nameCore,
-	nameWithoutForms,
-	withoutFormDots,
+	spellingsWithoutForms,
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
@@ -86,12 +85,36 @@ export type SiteVerdict = 'directory' | 'unknown'
 // each of them somewhere of its own.
 const COMPANIES_THAT_MAKE_A_LISTING = 2
 
-// How an address would write this company's name, folded so case, accents and
-// punctuation stop mattering. Empty when nothing distinctive is left to look for.
-const filedAs = (name: string): string => {
-	const core = nameWithoutForms(withoutFormDots(name))
-	return core.length >= DISTINCTIVE_NAME_LENGTH ? core : ''
+// One of the run's companies: the name an address would write it under, and the
+// name it is counted as. They are two things because a Catalan name can be
+// written out two ways — an address may spell either, while the company is still
+// one company and must be counted once.
+interface ListedCompany {
+	readonly countedAs: string
+	readonly writtenAs: ReadonlyArray<string>
 }
+
+// Every way an address would write this company's name, folded so case, accents
+// and punctuation stop mattering. Empty when nothing distinctive is left to look
+// for.
+const filedAs = (name: string): ReadonlyArray<string> =>
+	spellingsWithoutForms(name).filter(
+		spelling => spelling.length >= DISTINCTIVE_NAME_LENGTH,
+	)
+
+// Whether a shorter name already seen is this same company: any way of writing
+// this one starts with any way of writing that one. Compared across spellings and
+// not between the two names as written, because the pair this exists to catch is
+// exactly a firm whose two rows spell one word differently.
+const isTheSameCompanyAgain = (
+	company: ListedCompany,
+	earlier: ReadonlyArray<ListedCompany>,
+): boolean =>
+	earlier.some(seen =>
+		company.writtenAs.some(written =>
+			seen.writtenAs.some(before => written.startsWith(before)),
+		),
+	)
 
 // One company per name, rather than one per spelling. A name that another name
 // starts with is the same company written at more length — "Grupo Ferré" and
@@ -100,13 +123,30 @@ const filedAs = (name: string): string => {
 // that settles spellings for good runs after this check, so it cannot be leant on
 // here.
 const distinctCompanies = (
-	cores: ReadonlyArray<string>,
-): ReadonlyArray<string> =>
-	[...new Set(cores)]
-		.sort((a, b) => a.length - b.length)
-		.filter(
-			(core, at, kept) => !kept.slice(0, at).some(s => core.startsWith(s)),
+	companies: ReadonlyArray<ListedCompany>,
+): ReadonlyArray<ListedCompany> => {
+	const byName = new Map<string, ListedCompany>()
+	for (const company of companies) {
+		const seen = byName.get(company.countedAs)
+		// Every spelling either row was written with, rather than whichever row came
+		// first: two rows of one company can spell it differently, and a listing
+		// filing it under the spelling the other row used still files this company.
+		byName.set(
+			company.countedAs,
+			seen === undefined
+				? company
+				: {
+						countedAs: company.countedAs,
+						writtenAs: [...new Set([...seen.writtenAs, ...company.writtenAs])],
+					},
 		)
+	}
+	return [...byName.values()]
+		.sort((a, b) => a.countedAs.length - b.countedAs.length)
+		.filter(
+			(company, at, kept) => !isTheSameCompanyAgain(company, kept.slice(0, at)),
+		)
+}
 
 // The names of this scan's own companies.
 const listedCompanyNames = (
@@ -279,10 +319,16 @@ export const observeDirectorySites = (args: {
 	if (listField === undefined) return { sites: new Set(), addressesRead }
 
 	const names = listedCompanyNames(findings, listField)
-	const companyCores = distinctCompanies(
-		names.map(filedAs).filter(core => core !== ''),
+	// The name as written leads its spellings, so a company is counted under that
+	// one however an address happens to spell it.
+	const companies = distinctCompanies(
+		names.flatMap(name => {
+			const writtenAs = filedAs(name)
+			const countedAs = writtenAs[0]
+			return countedAs === undefined ? [] : [{ countedAs, writtenAs }]
+		}),
 	)
-	if (companyCores.length < COMPANIES_THAT_MAKE_A_LISTING) {
+	if (companies.length < COMPANIES_THAT_MAKE_A_LISTING) {
 		return { sites: new Set(), addressesRead }
 	}
 	// What it takes for a host to be one of these companies' own site, asked the
@@ -291,7 +337,7 @@ export const observeDirectorySites = (args: {
 	// "acme-directory.com" is not.
 	const ownSiteKeys: EntityTargets = {
 		cores: names
-			.map(name => nameCore(withoutFormDots(name)))
+			.flatMap(coreSpellings)
 			.filter(core => core.length >= DISTINCTIVE_NAME_LENGTH),
 		words: [...new Set(names.flatMap(distinctiveWords))],
 		domains: [],
@@ -319,12 +365,18 @@ export const observeDirectorySites = (args: {
 		const host = hostOf(address) ?? ''
 		if (isOwnSite(host)) continue
 		const segments = filingWords(address)
-		for (const core of companyCores) {
-			if (segments.some(segment => namesTheCompany(segment, core))) {
+		for (const company of companies) {
+			if (
+				segments.some(segment =>
+					company.writtenAs.some(spelling =>
+						namesTheCompany(segment, spelling),
+					),
+				)
+			) {
 				const filed = filedByHost.get(host) ?? new Map<string, Set<string>>()
-				const at = filed.get(core) ?? new Set<string>()
+				const at = filed.get(company.countedAs) ?? new Set<string>()
 				at.add(address)
-				filed.set(core, at)
+				filed.set(company.countedAs, at)
 				filedByHost.set(host, filed)
 			}
 		}

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -4,8 +4,10 @@ import {
 	cityGate,
 	classifyEntityMatch,
 	classifyEntityMatchPerSource,
+	coreSpellings,
 	deriveAnchorHost,
 	deriveEntityTargets,
+	distinctiveWords,
 	domainHost,
 	type EntityTargets,
 	groundedSourceIds,
@@ -13,10 +15,13 @@ import {
 	isConfirmedRegistryMatch,
 	isOwnSiteHost,
 	labelSpellsOneOf,
+	nameSpellings,
+	namesNobodyInParticular,
 	parseQueryDomain,
 	placesCorroborate,
 	queryPlaces,
 	reachedOwnSite,
+	spellingsWithoutForms,
 	withRedirectDomain,
 } from './entity-guard'
 
@@ -1004,6 +1009,329 @@ describe('cityGate', () => {
 					registryConfirmed: false,
 				}),
 			).toBe('keep')
+		})
+	})
+})
+
+describe('nameSpellings', () => {
+	describe('when the name carries no geminate mark', () => {
+		it('should read the name one way only', () => {
+			// GIVEN two different companies whose names differ by a doubled l, and
+			// neither of which marks a geminate
+			// WHEN each is read
+			// THEN each keeps its own single spelling, so nothing brings the two
+			// together. Reading every "ll" as a possible geminate would make one
+			// company of them, and both names are ordinary here
+			expect(nameSpellings('Villa Nova SL')).toEqual(['Villa Nova SL'])
+			expect(nameSpellings('Vila Nova SL')).toEqual(['Vila Nova SL'])
+			expect(spellingsWithoutForms('Villa Nova SL')).toEqual(['villanova'])
+			expect(spellingsWithoutForms('Vila Nova SL')).toEqual(['vilanova'])
+		})
+	})
+
+	describe('when the name carries a geminate mark', () => {
+		it('should read it both ways, the name as written first', () => {
+			// GIVEN a Catalan name written with an interpunct
+			// WHEN it is read
+			// THEN both ways an address may write it come back, and the name as
+			// written leads — that one is the company's identity
+			expect(spellingsWithoutForms('Instal·lacions Vives SL')).toEqual([
+				'installacionsvives',
+				'instalacionsvives',
+			])
+			expect(spellingsWithoutForms('Col·legi Oficial')).toEqual([
+				'collegioficial',
+				'colegioficial',
+			])
+		})
+
+		it('should collapse only the marked l, leaving every other doubled l alone', () => {
+			// GIVEN a name holding both a marked geminate and an ordinary doubled l
+			// WHEN it is read
+			// THEN only the marked pair is written out two ways: "Vallès" keeps its
+			// two l's in both readings, so the second reading can never reach a name
+			// that merely happens to be spelled with one
+			expect(spellingsWithoutForms('Col·legi Vallès SL')).toEqual([
+				'collegivalles',
+				'colegivalles',
+			])
+		})
+
+		it('should read the mark however it was typed, in either case', () => {
+			// GIVEN the mark written as each character a keyboard, a word processor
+			// or a paste leaves behind, and a name in capitals as a register writes it
+			// WHEN each is read
+			// THEN all of them come to the same two spellings
+			for (const mark of ['·', '·', '•', '‧', '∙', '⋅']) {
+				expect(spellingsWithoutForms(`Instal${mark}lacions`)).toEqual([
+					'installacions',
+					'instalacions',
+				])
+			}
+			expect(spellingsWithoutForms('INSTAL·LACIONS SL')).toEqual([
+				'installacions',
+				'instalacions',
+			])
+		})
+
+		it('should read several marks all the same way rather than in every mix', () => {
+			// GIVEN a name carrying two marks
+			// WHEN it is read
+			// THEN two spellings come back and not four: an address is slugged by one
+			// convention, not a different one per word
+			expect(spellingsWithoutForms('Col·legi Instal·ladors')).toEqual([
+				'collegiinstalladors',
+				'colegiinstaladors',
+			])
+		})
+
+		it('should leave a mark that is not between two l s alone', () => {
+			// GIVEN a name using the same character as a separator rather than as a
+			// geminate mark
+			// WHEN it is read
+			// THEN nothing is written out twice, because there is no geminate there
+			expect(nameSpellings('Serveis · Manteniment')).toEqual([
+				'Serveis · Manteniment',
+			])
+		})
+
+		it('should read the mark typed as an ASCII period', () => {
+			// GIVEN the geminate typed with a period, which is how a database that
+			// could not write the interpunct spells it
+			// WHEN it is read
+			// THEN both spellings come back, as for the interpunct. The reading takes
+			// the name before a legal form's dots come out, which is the only order
+			// that leaves a period there to be recognised
+			expect(spellingsWithoutForms('Instal.lacions Vives')).toEqual([
+				'installacionsvives',
+				'instalacionsvives',
+			])
+		})
+
+		it('should not mistake a legal form written in dots for the mark', () => {
+			// GIVEN names whose dots belong to a legal form rather than to a geminate
+			// WHEN each is read
+			// THEN none of them is read twice: the two l's have to touch the mark, so
+			// "S.L." holds no l-dot-l and a space sits at the join in "S.L. Lopez"
+			expect(spellingsWithoutForms('Muñoz S.L.')).toEqual(['munoz'])
+			expect(spellingsWithoutForms('Comercial S.L. Lopez')).toEqual([
+				'comerciallopez',
+			])
+			// Both halves of the Mexican form go, wherever they sit, leaving the word
+			// that joined them — this reading takes forms out rather than reading one
+			// off the end, which is `coreSpellings`' job
+			expect(spellingsWithoutForms('Grupo Ejemplo S.A. de C.V.')).toEqual([
+				'grupoejemplode',
+			])
+			expect(coreSpellings('Grupo Ejemplo S.A. de C.V.')).toEqual([
+				'grupoejemplo',
+			])
+		})
+	})
+
+	describe('when a legal form is written in dots', () => {
+		it('should read the name the same way for every caller', () => {
+			// GIVEN a name whose legal form is written in dots, which is the ordinary
+			// Spanish spelling
+			// WHEN the reading is asked for it
+			// THEN the form is gone. Putting the dots back together belongs to the
+			// reading rather than to each caller: while one caller did it and the
+			// other did not, the same name was "munoz" to the directory watch and
+			// "munozsl" to the website guard, and the guard looking for the longer one
+			// could not find the company on its own munoz.es
+			expect(spellingsWithoutForms('Muñoz S.L.')).toEqual(['munoz'])
+			expect(coreSpellings('Muñoz S.L.')).toEqual(['munoz'])
+		})
+
+		it('should give a run the same keys as the name written without dots', () => {
+			// GIVEN one company written both ways a Spanish list writes it
+			const dotted = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Muñoz S.L.',
+				subjects: [{ table: 'companies', name: 'Muñoz S.L.' }],
+			})
+			const plain = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Muñoz SL',
+				subjects: [{ table: 'companies', name: 'Muñoz SL' }],
+			})
+
+			// WHEN each is turned into match keys
+			// THEN they are the same keys. Two rows of one list spelling the form
+			// differently is the ordinary case, and the dotted one used to carry the
+			// form into its key and land the company under a name of its own
+			expect(dotted?.cores).toEqual(plain?.cores)
+			expect(dotted?.cores).toEqual(['munoz'])
+		})
+
+		it('should keep a Catalan name readable both ways through the dots', () => {
+			// GIVEN a Catalan name carrying both a dotted geminate and a dotted form
+			// WHEN it is read
+			// THEN the geminate is read first and the form's dots come out after, so
+			// neither spelling is lost to the other rule
+			expect(spellingsWithoutForms('Instal.lacions Vives S.L.')).toEqual([
+				'installacionsvives',
+				'instalacionsvives',
+			])
+		})
+	})
+
+	describe('when the name has nothing left after its legal form', () => {
+		it('should offer no key at all', () => {
+			// GIVEN a name that is only a legal form, and an empty one
+			// WHEN read
+			// THEN there is no key to look for, so a caller cannot be handed one that
+			// every address would match
+			expect(spellingsWithoutForms('SL')).toEqual([])
+			expect(spellingsWithoutForms('')).toEqual([])
+			expect(nameSpellings('')).toEqual([''])
+		})
+	})
+})
+
+describe('coreSpellings', () => {
+	describe('when a geminate name closes with a legal form', () => {
+		it('should read both spellings with the form off the end', () => {
+			// GIVEN a Catalan name with a trailing legal form
+			// WHEN its strong-match keys are read
+			// THEN both spellings come back without the form
+			expect(coreSpellings('Instal·lacions Vives SL')).toEqual([
+				'installacionsvives',
+				'instalacionsvives',
+			])
+		})
+	})
+
+	describe('when the name carries no mark', () => {
+		it('should read the one key it always did', () => {
+			// GIVEN an ordinary name
+			// WHEN its keys are read
+			// THEN there is exactly one, unchanged
+			expect(coreSpellings('Acme Logistics Ltd')).toEqual(['acmelogistics'])
+		})
+	})
+})
+
+describe('distinctiveWords', () => {
+	describe('when a word of the name carries a geminate mark', () => {
+		it('should offer that word in both spellings', () => {
+			// GIVEN a name whose distinctive word is geminated
+			// WHEN its distinctive words are read
+			// THEN both spellings are there, so an address writing either is
+			// recognised, and a word carrying no mark still appears once
+			expect(distinctiveWords('Instal·lacions Vives SL')).toEqual([
+				'installacions',
+				'vives',
+				'instalacions',
+			])
+		})
+	})
+
+	describe('when the name is built only from trade and legal words', () => {
+		it('should offer nothing to match on', () => {
+			// GIVEN a name that says a kind of company and a trade and no more
+			// WHEN its distinctive words are read
+			// THEN there are none: a generic word identifies nobody, and matching on
+			// one is the expensive mistake
+			expect(distinctiveWords('Grupo Express SL')).toEqual([])
+		})
+	})
+})
+
+describe('namesNobodyInParticular', () => {
+	describe('when every word of the name names a trade or a legal form', () => {
+		it('should say so', () => {
+			// GIVEN names built only from those words
+			// WHEN each is asked
+			// THEN each says it names nobody in particular
+			expect(namesNobodyInParticular('Grupo Express SL')).toBe(true)
+			expect(namesNobodyInParticular('Transportes Logistica SL')).toBe(true)
+			expect(namesNobodyInParticular('')).toBe(true)
+		})
+	})
+
+	describe('when one word of the name is the company own', () => {
+		it('should say the name identifies somebody', () => {
+			// GIVEN names carrying a word that stands for this company rather than
+			// for its trade — including one whose only such word is geminated, and
+			// one whose word merely resembles a trade word without being one
+			// WHEN each is asked
+			// THEN each identifies somebody
+			expect(namesNobodyInParticular('Fusteria Miquel SL')).toBe(false)
+			expect(namesNobodyInParticular('Instal·lacions Vives SL')).toBe(false)
+			expect(namesNobodyInParticular('Servicios Globales SL')).toBe(false)
+		})
+	})
+})
+
+describe('deriveEntityTargets', () => {
+	describe('when the subject name carries a geminate mark', () => {
+		it('should match evidence that spells the name either way', () => {
+			// GIVEN a run anchored on a Catalan company
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Instal·lacions Vives',
+				subjects: [{ table: 'companies', name: 'Instal·lacions Vives SL' }],
+			}) as EntityTargets
+
+			// WHEN evidence spells the name with one l, and when it spells it with two
+			// THEN both land the run on its target, rather than only the spelling the
+			// name happened to be written in
+			expect(classifyEntityMatch(targets, 'Instalacions Vives, Girona.')).toBe(
+				'strong',
+			)
+			expect(classifyEntityMatch(targets, 'Installacions Vives, Girona.')).toBe(
+				'strong',
+			)
+		})
+
+		it('should still take the whole name to land on the company', () => {
+			// GIVEN the same run
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Instal·lacions Vives',
+				subjects: [{ table: 'companies', name: 'Instal·lacions Vives SL' }],
+			}) as EntityTargets
+
+			// WHEN the evidence is about a different company in the same trade
+			// THEN it never reads as the target. The second spelling writes out one
+			// marked pair of l's and turns no other part of a name into a wildcard,
+			// so the strong bar — which is what lets a run act on its findings —
+			// still takes the whole name
+			expect(
+				classifyEntityMatch(targets, 'Instalacions Puig, Lleida.'),
+			).not.toBe('strong')
+			expect(classifyEntityMatch(targets, 'Vila Nova SL, Girona.')).toBe(
+				'absent',
+			)
+		})
+
+		it('should reach the same verdict whichever way the trade word is spelled', () => {
+			// GIVEN the same run, and a page about a different company whose trade is
+			// written the three ways Catalan writes it
+			const targets = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Instal·lacions Vives',
+				subjects: [{ table: 'companies', name: 'Instal·lacions Vives SL' }],
+			}) as EntityTargets
+
+			// WHEN each is classified
+			// THEN all three are weak — the run is told it never clearly landed, and
+			// its findings wait for somebody to read them.
+			//
+			// This is the cost of reading a name both ways, and it is worth stating
+			// plainly: a page about a stranger in the same trade is weak whichever
+			// way that trade is spelled, because "instal·lacions" counts as a
+			// distinctive word — it is not among the generic ones. Whether it belongs
+			// there is a separate decision about which words name a trade, not about
+			// how a name is folded
+			for (const corpus of [
+				'Instalacions Puig, Lleida.',
+				'Installacions Puig, Lleida.',
+				'Instal·lacions Puig, Lleida.',
+			]) {
+				expect(classifyEntityMatch(targets, corpus)).toBe('weak')
+			}
 		})
 	})
 })

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -130,6 +130,50 @@ export const foldTokens = (value: string): string[] =>
 		.split(/[^a-z0-9]+/)
 		.filter(Boolean)
 
+// A geminate l as Catalan writes it, with every mark that may sit between the
+// two l's spelled by number because several of them draw the same dot and nobody
+// could tell them apart written out: the middle dot is the standard one, the
+// Greek ano teleia is the look-alike a paste leaves behind, the period is what a
+// database that could not write any of them fell back on, and the rest are what
+// a keyboard or a word processor reaches for instead.
+//
+// Both l's have to touch the mark, which is what keeps a legal form out of it:
+// "S.L." holds no l-dot-l, and in "S.L. Lopez" a space sits at the join.
+//
+// Only ever handed to `replace`, which starts from the beginning every time. Ask
+// it `test` instead and it answers from wherever the last call left off, so every
+// other name carrying a mark would come back as carrying none.
+const GEMINATED_L = /l[.\u00B7\u0387\u2022\u2027\u2219\u22C5]l/giu
+
+/**
+ * A name in each way an address may spell it, the name as written first.
+ *
+ * Catalan marks a geminate l with an interpunct — "Instal·lacions", "Col·legi",
+ * "Il·lustració" — and no address carries the mark. Both ways of writing it out
+ * are ordinary: the slug keeps the two l's ("installacions-vives") or keeps one
+ * ("instalacions-vives"). Read a name only one of those ways and it is filed
+ * under a spelling half the addresses never use — and the trade this product
+ * sells into is called "instal·lacions" across half the country.
+ *
+ * ONLY a name carrying the mark is read twice. Reading every "ll" as a possible
+ * geminate would put "Villa Nova" and "Vila Nova" — two different companies,
+ * both ordinary here — under one name, and the rules leaning on this take a
+ * company's website away.
+ *
+ * This runs on the name as it arrived, BEFORE a legal form's dots come out —
+ * which is the only order that lets the period be one of the marks. Take the
+ * dots out first and "Instal.lacions" has already become "Installacions", with
+ * nothing left to say the two l's were ever one sound.
+ *
+ * Several marks in one name are read all the same way rather than in every
+ * combination: an address is slugged by one convention, not one per word.
+ */
+export const nameSpellings = (name: string): ReadonlyArray<string> => {
+	const doubled = name.replace(GEMINATED_L, 'll')
+	const single = name.replace(GEMINATED_L, 'l')
+	return doubled === single ? [doubled] : [doubled, single]
+}
+
 // Words that join two halves of a legal form — "S.A. de C.V.", "Serveis i
 // Manteniments S.L." — skipped over while reading a form off the end, never
 // dropped on their own.
@@ -180,6 +224,23 @@ export const nameCoreTokens = (name: string): ReadonlyArray<string> => {
 export const nameCore = (name: string): string => nameCoreTokens(name).join('')
 
 /**
+ * The strong-match key in each spelling an address may use, the name as written
+ * first. A caller holding a LIST of keys asks with all of them; one holding a
+ * single identity for a company takes the first, so two spellings of one name
+ * can never be counted as two companies.
+ *
+ * A form written in dots is put back together here rather than by the caller, so
+ * no caller can forget to — see `spellingsWithoutForms`, which is where forgetting
+ * used to cost something.
+ */
+export const coreSpellings = (name: string): ReadonlyArray<string> =>
+	[
+		...new Set(
+			nameSpellings(name).map(spelling => nameCore(withoutFormDots(spelling))),
+		),
+	].filter(spelling => spelling !== '')
+
+/**
  * The words of a name, every legal-form word taken out wherever it sits — "SARL
  * Transports Dupont" → ["transports", "dupont"]. Exported because a caller
  * asking which FRONT PART of a name a domain could spell has to know where each
@@ -200,6 +261,29 @@ export const nameWordsWithoutForms = (name: string): ReadonlyArray<string> =>
  */
 export const nameWithoutForms = (name: string): string =>
 	nameWordsWithoutForms(name).join('')
+
+/**
+ * The same key in each spelling an address may use, empty ones left out. This is
+ * the reading BOTH the website guard and the directory watch put an address
+ * through, so neither can come to a different answer about whether a piece of
+ * text spells a company. As with `coreSpellings`, the name as written comes
+ * first, and that one is the company's identity.
+ *
+ * A form written in dots — "Muñoz S.L." — is put back together here, inside the
+ * reading, rather than left to each caller. That is the whole point: while one
+ * caller did it and the other did not, the two read that name as "munoz" and
+ * "munozsl", and the guard looking for the longer one could not find the company
+ * on its own munoz.es. Dots the geminate mark claimed are already gone by now,
+ * so a Catalan name written "Instal.lacions" keeps both of its readings.
+ */
+export const spellingsWithoutForms = (name: string): ReadonlyArray<string> =>
+	[
+		...new Set(
+			nameSpellings(name).map(spelling =>
+				nameWithoutForms(withoutFormDots(spelling)),
+			),
+		),
+	].filter(spelling => spelling !== '')
 
 /**
  * Whether a domain's label spells any of these names, allowing the legal form
@@ -253,14 +337,40 @@ export const withoutFormDots = (name: string): string => name.replace(/\./g, '')
  * and they are also how most firms register a domain — "Transportes García" at
  * garcia.es — which is why a caller asking whether a host is a company's own
  * needs them beside its cores.
+ *
+ * A word written with a geminate l comes back once per spelling, since a caller
+ * looking for it has no way of knowing which one it will meet.
  */
-export const distinctiveWords = (name: string): string[] =>
-	foldTokens(name).filter(
-		t =>
-			t.length >= DISTINCTIVE_NAME_LENGTH &&
-			!LEGAL_SUFFIXES.has(t) &&
-			!GENERIC_WORDS.has(t),
-	)
+export const distinctiveWords = (name: string): string[] => [
+	...new Set(
+		nameSpellings(name)
+			.flatMap(foldTokens)
+			.filter(
+				t =>
+					t.length >= DISTINCTIVE_NAME_LENGTH &&
+					!LEGAL_SUFFIXES.has(t) &&
+					!GENERIC_WORDS.has(t),
+			),
+	),
+]
+
+/**
+ * Whether a name holds no word that could stand for THIS company rather than for
+ * anybody in its trade — "Grupo Express SL" is a kind of company and a trade and
+ * nothing else.
+ *
+ * This is the intended trade, not a gap to close: a generic word identifies
+ * nobody, and matching on one is the expensive mistake. But the consequence is
+ * real and worth counting, because such a company is judged on less than
+ * everybody else is. Its own site can never be established — `ownSiteVerdict`
+ * has no word of its own to find in a domain, so even grupoexpress.cat reads
+ * `unknown` — and the rules that hold a website against a name have only the
+ * whole name left, so an address writing any part of it goes unrecognised.
+ * Blanking is the direction that costs, and it is the company's real site that
+ * goes.
+ */
+export const namesNobodyInParticular = (name: string): boolean =>
+	distinctiveWords(name).length === 0
 
 // The bare host of a website — "acme.co.uk" from "https://www.acme.co.uk/about".
 // A page that references this exact host really points at the target's site,
@@ -441,7 +551,9 @@ export const deriveEntityTargets = (args: {
 			),
 		),
 	]
-	const cores = names.map(nameCore).filter(c => c.length >= 4)
+	const cores = [
+		...new Set(names.flatMap(coreSpellings).filter(c => c.length >= 4)),
+	]
 	const words = [
 		...new Set([
 			...names.flatMap(distinctiveWords),

--- a/packages/research/src/application/own-site.test.ts
+++ b/packages/research/src/application/own-site.test.ts
@@ -373,4 +373,41 @@ describe('ownSiteVerdict', () => {
 			)
 		})
 	})
+
+	describe('when the name is written with a geminated l', () => {
+		it('should establish the domain whichever way it spells the name', () => {
+			// GIVEN a Catalan company and the two domains it might have registered
+			// WHEN each is asked
+			// THEN both are its own. A firm registers the spelling it prefers, and
+			// the run must not decide the other one belongs to somebody else
+			for (const website of [
+				'https://installacionsvives.cat',
+				'https://instalacionsvives.cat/contacte',
+			]) {
+				expect(
+					ownSiteVerdict({ name: 'Instal·lacions Vives SL', website }),
+				).toBe('established')
+			}
+		})
+
+		it('should not hand one company a look-alike name s domain', () => {
+			// GIVEN two different companies whose names differ only by a doubled l,
+			// neither of which marks a geminate
+			// WHEN each is offered the other's domain
+			// THEN neither is established. Only a name that carries the mark is read
+			// two ways, so an ordinary doubled l keeps the two apart
+			expect(
+				ownSiteVerdict({
+					name: 'Vila Nova SL',
+					website: 'https://villanova.cat',
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'Villa Nova SL',
+					website: 'https://vilanova.cat',
+				}),
+			).toBe('unknown')
+		})
+	})
 })

--- a/packages/research/src/application/own-site.ts
+++ b/packages/research/src/application/own-site.ts
@@ -85,6 +85,7 @@ import {
 	hostLabel,
 	isGenericWord,
 	labelSpellsOneOf,
+	nameSpellings,
 	nameWordsWithoutForms,
 	withoutFormDots,
 } from './entity-guard'
@@ -149,12 +150,23 @@ const namesTheDomainCouldCarry = (
  * somebody writing about it.
  */
 const hostSpellsTheCompany = (name: string, host: string): boolean => {
-	const words = nameWordsWithoutForms(withoutFormDots(name))
-	if (words.length > MOST_WORDS_A_NAME_RUNS_TO) return false
-	return labelSpellsOneOf(collapse(hostLabel(host)), [
-		...namesTheDomainCouldCarry(words),
-		...distinctiveWords(name),
-	])
+	const label = collapse(hostLabel(host))
+	// The distinctive words are read off the name itself, which already offers
+	// each of them in every spelling.
+	const words = distinctiveWords(name)
+	// Every spelling of the name, since a domain writes a Catalan geminate l
+	// whichever way its owner chose and both are the same company's. The dots of a
+	// legal form come out after the spellings are read, never before, or a name
+	// written "Instal.lacions" would lose its second reading to them.
+	return nameSpellings(name).some(spelling => {
+		const spelled = nameWordsWithoutForms(withoutFormDots(spelling))
+		// A brief rather than a name, which no spelling of it can rescue.
+		if (spelled.length > MOST_WORDS_A_NAME_RUNS_TO) return false
+		return labelSpellsOneOf(label, [
+			...namesTheDomainCouldCarry(spelled),
+			...words,
+		])
+	})
 }
 
 /**

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -3220,7 +3220,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											// whether or not anything was blanked: a run whose websites
 											// all read `unknown` is not a quiet run, it is one whose
 											// companies have nothing vouching for them.
-											if (check.ownSiteEstablished + check.ownSiteUnknown > 0) {
+											if (
+												check.ownSiteEstablished +
+													check.ownSiteUnknown +
+													check.namedNobodyInParticular >
+												0
+											) {
 												yield* Effect.logInfo(
 													'research.websites.own_site',
 												).pipe(
@@ -3228,6 +3233,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														research_id: researchId,
 														established: check.ownSiteEstablished,
 														unknown: check.ownSiteUnknown,
+														// Beside them, because it says how many of these
+														// answers were never reachable: a company named
+														// only after its trade has no word of its own for
+														// a domain to spell, so its `unknown` is what the
+														// rules can say rather than what they found.
+														named_nobody_in_particular:
+															check.namedNobodyInParticular,
 													}),
 												)
 											}
@@ -3257,6 +3269,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														check.ownSiteEstablished,
 													'research.websites.own_site_unknown':
 														check.ownSiteUnknown,
+													// How many of those websites were weighed against a
+													// name holding no word of the company's own. The
+													// unknown count above is read against this one: a run
+													// whose companies are all called after their trade
+													// cannot establish a single site however well it went.
+													'research.websites.named_nobody_in_particular':
+														check.namedNobodyInParticular,
 												},
 											}
 										}),

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -369,6 +369,7 @@ describe('guardCompanyWebsites', () => {
 				blankedReadPage: 0,
 				ownSiteEstablished: 0,
 				ownSiteUnknown: 0,
+				namedNobodyInParticular: 0,
 			})
 		})
 
@@ -1350,6 +1351,206 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites(findings)
 			expect(result.findings).toEqual(findings)
 			expect(result.blankedDirectory + result.blankedProfilePage).toBe(0)
+		})
+	})
+
+	describe('when the company name is written with a geminated l', () => {
+		it('should keep the site whichever way the host spells it', () => {
+			// GIVEN a Catalan company whose only source is the page on its own site,
+			// so the address naming the company is the only thing holding the value,
+			// and whose domain writes the geminate with a single l as a slug does
+			const findings = cited([
+				{
+					name: 'Il·lusions SL',
+					website: 'https://ilusions.cat/contacte',
+					sources: ['https://ilusions.cat/contacte'],
+				},
+			])
+
+			// WHEN checked
+			// THEN the site stays and is established as the company's own. Read only
+			// the way the name is written, the host spelled nothing the run knew and
+			// the company lost the very page it published
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://ilusions.cat/contacte',
+			])
+			expect(result.blankedReadPage).toBe(0)
+			expect(result.ownSiteEstablished).toBe(1)
+		})
+
+		it('should keep the site when the host doubles the l instead', () => {
+			// GIVEN the same company at the domain that keeps both l's
+			const findings = cited([
+				{
+					name: 'Il·lusions SL',
+					website: 'https://illusions.cat/contacte',
+					sources: ['https://illusions.cat/contacte'],
+				},
+			])
+
+			// WHEN checked — THEN it is kept too, so reading the name both ways costs
+			// the spelling that already worked nothing
+			const result = guardCompanyWebsites(findings)
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://illusions.cat/contacte',
+			])
+			expect(result.blankedReadPage).toBe(0)
+		})
+
+		it('should still blank a listing page that files it under either spelling', () => {
+			// GIVEN the same company on somebody else's host, filed one level down
+			// under each spelling in turn
+			// WHEN checked
+			// THEN both are blanked as the profile pages they are. Reading a name
+			// more ways sharpens this rule as much as it softens the one above —
+			// the loosening is not one-directional
+			for (const website of [
+				'https://directori.cat/empresa/ilusions',
+				'https://directori.cat/empresa/illusions',
+			]) {
+				const result = guardCompanyWebsites(
+					cited([{ name: 'Il·lusions SL', website, sources: [website] }]),
+				)
+				expect(prospectWebsites(result.findings)).toEqual([undefined])
+				expect(result.blankedProfilePage).toBe(1)
+			}
+		})
+
+		it('should keep every spelling a repeated company was written with', () => {
+			// GIVEN one Catalan company listed twice on its own host — once with the
+			// mark and once without, which is how one list writes one firm twice —
+			// beside two other companies that also gave that host
+			const findings = cited([
+				{ name: 'Il·lusions SL', website: 'https://ilusions.cat' },
+				{ name: 'Illusions SL', website: 'https://ilusions.cat' },
+				{ name: 'Fusteria Miquel SL', website: 'https://ilusions.cat' },
+				{ name: 'Serralleria Roca SL', website: 'https://ilusions.cat' },
+			])
+
+			// WHEN checked
+			// THEN nothing is blanked: the host is plainly the Catalan company's, and
+			// the reading that says so came from the row with the mark. Keeping only
+			// the later row's spellings would lose it and blank all four
+			const result = guardCompanyWebsites(findings)
+			expect(result.blankedSharedHost).toBe(0)
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://ilusions.cat',
+				'https://ilusions.cat',
+				'https://ilusions.cat',
+				'https://ilusions.cat',
+			])
+		})
+
+		it('should count one company claiming a host as one claimant, not two', () => {
+			// GIVEN one Catalan company and one other company on the same host, which
+			// the Catalan company's name is carried by
+			const findings = cited([
+				{ name: 'Il·lusions SL', website: 'https://ilusions.cat' },
+				{ name: 'Fusteria Miquel SL', website: 'https://ilusions.cat' },
+			])
+
+			// WHEN checked
+			// THEN the host is plainly the Catalan company's and nothing is blanked
+			// as a shared host. Its two spellings must count as the one company they
+			// are — counted apart, a single company would look like a crowd and the
+			// rule would fire on a host it owns
+			const result = guardCompanyWebsites(findings)
+			expect(result.blankedSharedHost).toBe(0)
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://ilusions.cat',
+				'https://ilusions.cat',
+			])
+		})
+	})
+
+	describe('when the run own target is written with a geminated l', () => {
+		it('should keep the target site whichever way its host spells the name', () => {
+			// GIVEN the run's own answer for its target's website — a value with the
+			// page it came from and no company name beside it, so the name is told
+			// from outside — at each spelling of the company's domain in turn
+			// WHEN checked against the company the run is about
+			// THEN the host carries the name either way and the site stands. This
+			// field is the strict path: it can never have a second source to stand
+			// the read-page rule down, so a host the run cannot read the name in is
+			// the whole of what holds the value
+			for (const value of [
+				'https://instalacionsvives.cat/contacte',
+				'https://installacionsvives.cat/contacte',
+			]) {
+				const findings = {
+					enrichment: {
+						website: { value, source_id: value, confidence: null },
+					},
+				}
+				const result = guardCompanyWebsites(findings, 'Instal·lacions Vives SL')
+				expect(
+					(result.findings as { enrichment: Record<string, unknown> })
+						.enrichment['website'],
+				).toEqual({ value, source_id: value, confidence: null })
+				expect(result.blankedReadPage + result.blankedProfilePage).toBe(0)
+			}
+		})
+
+		it('should still blank a listing filing the target under either spelling', () => {
+			// GIVEN a directory filing the target one level down, spelled each way
+			// WHEN checked against the company the run is about
+			// THEN both are caught as the profile pages they are
+			for (const value of [
+				'https://empreses.example.org/empresa/instalacions-vives',
+				'https://empreses.example.org/empresa/installacions-vives',
+			]) {
+				const findings = {
+					enrichment: {
+						website: { value, source_id: 'src_a', confidence: null },
+					},
+				}
+				const result = guardCompanyWebsites(findings, 'Instal·lacions Vives SL')
+				expect(
+					(result.findings as { enrichment: Record<string, unknown> })
+						.enrichment['website'],
+				).toBeNull()
+				expect(result.blankedProfilePage).toBe(1)
+			}
+		})
+	})
+
+	describe('when the company name holds no word of its own', () => {
+		it('should count the row as judged on the whole name alone', () => {
+			// GIVEN a company named only after a kind of company and a trade, beside
+			// one whose name carries a word of its own
+			const findings = cited([
+				{ name: 'Grupo Express SL', website: 'https://grupoexpress.cat' },
+				{ name: 'Fusteria Miquel SL', website: 'https://fusteriamiquel.cat' },
+			])
+
+			// WHEN checked
+			// THEN one row is recorded as named after nobody in particular, and its
+			// own exact domain still reads as unestablished — there is no word of the
+			// company's for a domain to spell, so `unknown` here means the rules could
+			// never have said anything else, not that nothing vouched for it
+			const result = guardCompanyWebsites(findings)
+			expect(result.namedNobodyInParticular).toBe(1)
+			expect(result.ownSiteEstablished).toBe(1)
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+
+		it('should not count a row whose name reads as nothing at all', () => {
+			// GIVEN a row whose name is only a legal form, so there is no name to
+			// judge the address against in the first place
+			const findings = cited([
+				{ name: 'SL', website: 'https://directori.cat/empresa/algu' },
+			])
+
+			// WHEN checked
+			// THEN the website is kept, and the count stays at zero: a name that
+			// reads as nothing is a different miss from a name that reads as a trade,
+			// and adding the two together would hide both
+			const result = guardCompanyWebsites(findings)
+			expect(result.namedNobodyInParticular).toBe(0)
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://directori.cat/empresa/algu',
+			])
 		})
 	})
 })

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -51,7 +51,8 @@ import {
 	collapse,
 	DISTINCTIVE_NAME_LENGTH,
 	distinctiveWords,
-	nameWithoutForms,
+	namesNobodyInParticular,
+	spellingsWithoutForms,
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { ownSiteVerdict } from './own-site'
@@ -104,11 +105,11 @@ const addressNamesCompany = (
 	segments: ReadonlyArray<string>,
 ): boolean => {
 	const parts = [collapse(host), ...segments.map(collapse)]
-	const core = nameWithoutForms(name)
+	const spellings = spellingsWithoutForms(name)
 	const words = distinctiveWords(name)
 	return parts.some(
 		part =>
-			(core !== '' && part.includes(core)) ||
+			spellings.some(spelling => part.includes(spelling)) ||
 			words.some(word => part.includes(word)),
 	)
 }
@@ -159,15 +160,24 @@ const citedSourcesOf = (
 	)
 }
 
-// Who claims which host, across a whole answer: a host mapped to the name cores of
-// every company that gave it as its website. Gathered before anything is rewritten,
-// because "is this host any one company's own?" cannot be answered from one row.
-// A value that is not an address, or a name with nothing distinctive in it, tells
-// us nothing about who a host belongs to and is left out.
-type HostClaims = ReadonlyMap<string, ReadonlySet<string>>
+// Who claims which host, across a whole answer: a host mapped to every company
+// that gave it as its website. Gathered before anything is rewritten, because
+// "is this host any one company's own?" cannot be answered from one row. A value
+// that is not an address, or a name with nothing distinctive in it, tells us
+// nothing about who a host belongs to and is left out.
+//
+// Each company is held under the one name it is written by, with every spelling
+// an address may use for it alongside. Held that way rather than as a flat set
+// of spellings, because the rule below counts these to ask how many companies
+// claim a host: a Catalan name an address can write two ways would otherwise be
+// two of them on its own, and one company would look like a crowd.
+type HostClaims = ReadonlyMap<
+	string,
+	ReadonlyMap<string, ReadonlyArray<string>>
+>
 
 const collectHostClaims = (findings: unknown): HostClaims => {
-	const claims = new Map<string, Set<string>>()
+	const claims = new Map<string, Map<string, ReadonlyArray<string>>>()
 	const visit = (value: unknown): void => {
 		if (Array.isArray(value)) {
 			for (const item of value) visit(item)
@@ -178,10 +188,19 @@ const collectHostClaims = (findings: unknown): HostClaims => {
 		const website = value['website']
 		if (typeof name === 'string' && typeof website === 'string') {
 			const host = isBareWebAddress(website) ? hostOf(website) : null
-			const core = nameWithoutForms(name)
-			if (host !== null && core !== '') {
-				const claimants = claims.get(host) ?? new Set<string>()
-				claimants.add(core)
+			const spellings = spellingsWithoutForms(name)
+			const identity = spellings[0]
+			if (host !== null && identity !== undefined) {
+				const claimants =
+					claims.get(host) ?? new Map<string, ReadonlyArray<string>>()
+				// Every spelling this company has been written with on this host, not
+				// just the last row's. Two rows of one company can spell it differently
+				// — one with the geminate mark and one without — and taking only the
+				// later row would drop the spelling that recognises the company's own
+				// host, which is what stands the rule below down.
+				claimants.set(identity, [
+					...new Set([...(claimants.get(identity) ?? []), ...spellings]),
+				])
 				claims.set(host, claimants)
 			}
 		}
@@ -195,9 +214,15 @@ const collectHostClaims = (findings: unknown): HostClaims => {
 
 // One company vouching for a host stands the shared-host rule down for every row
 // on it, so a name too short to mean anything would quietly switch the rule off.
-const hostBelongsTo = (host: string, claimant: string): boolean =>
-	claimant.length >= DISTINCTIVE_NAME_LENGTH &&
-	collapse(host).includes(claimant)
+const hostBelongsTo = (
+	host: string,
+	claimantSpellings: ReadonlyArray<string>,
+): boolean =>
+	claimantSpellings.some(
+		spelling =>
+			spelling.length >= DISTINCTIVE_NAME_LENGTH &&
+			collapse(host).includes(spelling),
+	)
 
 type WebsiteVerdict =
 	| 'keep'
@@ -230,19 +255,26 @@ const classifyWebsite = (args: {
 	// trading name and leaves the legal form out, so the form is taken out here
 	// too, wherever in the name it sits. This asks whether the address names the
 	// company, which is a looser question than who the company is.
-	const core = nameWithoutForms(name)
+	const spellings = spellingsWithoutForms(name)
 	// With no distinctive name to look for, there is no way to tell a listing from
 	// the company's own site, so keep it.
-	if (core === '') return 'keep'
+	if (spellings.length === 0) return 'keep'
 	// The host itself carries the company's name — its own site, whatever the path.
-	if (collapse(host).includes(core)) return 'keep'
+	if (spellings.some(spelling => collapse(host).includes(spelling)))
+		return 'keep'
 	// The name appears only in a deeper path segment of a host that is not the
 	// company's: the signature of a directory's page about it. The first segment is
 	// excluded, because a company's own site describes itself right there
 	// ("xpo.com/about-xpo-logistics") while a directory files it one level down
 	// ("company/<name>").
 	const segments = pathSegmentsOf(website)
-	if (segments.slice(1).some(segment => collapse(segment).includes(core))) {
+	if (
+		segments
+			.slice(1)
+			.some(segment =>
+				spellings.some(spelling => collapse(segment).includes(spelling)),
+			)
+	) {
 		return 'profile_page'
 	}
 	// A host several companies in this answer call their own, and that none of them
@@ -261,7 +293,7 @@ const classifyWebsite = (args: {
 	if (
 		claimants !== undefined &&
 		claimants.size > 1 &&
-		![...claimants].some(claimant => hostBelongsTo(host, claimant))
+		![...claimants.values()].some(claimant => hostBelongsTo(host, claimant))
 	) {
 		return 'shared_host'
 	}
@@ -313,6 +345,19 @@ export interface WebsiteGuardResult {
 	 * company's sources may not count one of these as its own site.
 	 */
 	readonly ownSiteUnknown: number
+	/**
+	 * Websites judged against a name holding no word of the company's own —
+	 * "Grupo Express SL", which says a kind of company and a trade and no more.
+	 *
+	 * Counted so the numbers above can be read honestly, because these rows were
+	 * judged on less than the rest: nothing can establish their site (there is no
+	 * word for a domain to spell, so even grupoexpress.cat lands in
+	 * `ownSiteUnknown`), and the rules that weigh an address against a name have
+	 * only the whole name to go on. Their `unknown` therefore means "could never
+	 * have been anything else", not "nothing vouched for it", and the two must
+	 * not be added up as if they were one answer.
+	 */
+	readonly namedNobodyInParticular: number
 }
 
 /**
@@ -340,7 +385,18 @@ export const guardCompanyWebsites = (
 	let blankedReadPage = 0
 	let ownSiteEstablished = 0
 	let ownSiteUnknown = 0
+	let namedNobodyInParticular = 0
 	const hostClaims = collectHostClaims(findings)
+
+	// A name the guard could read, holding no word of the company's own. Counted
+	// as the website is judged rather than by its verdict, because what it records
+	// is how much the rules had to go on — which is the same whichever way they
+	// then went. A name with nothing readable in it at all is a different miss and
+	// is not counted here.
+	const countNamedNobodyInParticular = (name: string): void => {
+		if (spellingsWithoutForms(name).length > 0 && namesNobodyInParticular(name))
+			namedNobodyInParticular++
+	}
 
 	// Ask the survivor the question none of the rules above can answer, and keep
 	// the answer beside their counts. Asked only of a website that is staying,
@@ -386,6 +442,7 @@ export const guardCompanyWebsites = (
 			typeof value['value'] === 'string' &&
 			typeof value['name'] !== 'string'
 		) {
+			countNamedNobodyInParticular(targetName ?? '')
 			const verdict = classifyWebsite({
 				name: targetName ?? '',
 				website: value['value'],
@@ -407,6 +464,7 @@ export const guardCompanyWebsites = (
 		const name = value['name']
 		const website = value['website']
 		if (typeof name === 'string' && typeof website === 'string') {
+			countNamedNobodyInParticular(name)
 			const verdict = classifyWebsite({
 				name,
 				website,
@@ -440,5 +498,6 @@ export const guardCompanyWebsites = (
 		blankedReadPage,
 		ownSiteEstablished,
 		ownSiteUnknown,
+		namedNobodyInParticular,
 	}
 }


### PR DESCRIPTION
## What

Two ordinary ways of writing a Spanish or Catalan company's name made that company invisible to every rule in the research context that reads a name — so a firm's real website was thrown away as a stranger's, and a business directory filing it was never spotted. This fixes the reading itself, in `packages/research`, so every rule that asks "does this address name this company?" now answers the same way.

The company names in question are not exotic. Catalan writes a doubled l with a raised dot between the two l's — `Instal·lacions`, `Col·legi`, `Il·lustració` — and the trade this product sells into is literally called `instal·lacions` across half the country. The other is `Muñoz S.L.`: a legal form written with dots, which is how most Spanish company lists write one.

## The fix

**Touches:** the check that decides whether a website really belongs to a company, the watch that spots business directories, the verdict that says a site is a company's own, and the shared name-folding all three read a name with — plus the counters the run reports afterwards.

- **The raised dot.** A name is now read in both ways an address may spell it out. `Instal·lacions Vives` folded to `installacionsvives` with two l's, but a web address as often writes `instalacionsvives` with one, so the company was filed under a spelling no address matched. Measured on the code before this change: a real company site (`ilusions.cat/contacte`) was deleted outright, and a directory filing two companies under single-l slugs was not recognised as a directory at all.
- **The dots in a legal form.** Taking those dots out moved *inside* the shared reading instead of being each caller's job. One caller did it and another didn't, so the same `Muñoz S.L.` was `munoz` to the directory watch and `munozsl` to the website check — and the check looking for the longer spelling could not find the company on its own `munoz.es`. This was already true before this branch; it is fixed here because the issue asks for both rules to read a name identically, and they didn't.
- **Names that identify nobody.** A name built only from a kind of company and a trade — `Grupo Express SL` — yields no word that stands for *this* firm, so several protections are simply weaker for it. That stays deliberate (matching on a trade word would be the expensive mistake), but the run now counts those rows, because nothing recorded that they were judged on less than everyone else.

## Impact

- **No database change, and nothing to run before deploying.** No new settings either — nothing has to be set in production for the server to start.
- **Nothing touching which organisation can see what** (the row-by-row database permissions, "row-level security"), no change to sign-in or to which routes are public, and no change to the shape of any API response.
- **Both ways into the product get this**, since the change sits in the shared research code that the normal web API and the AI-assistant connection (MCP) both call — there is no path that keeps the old reading.
- **One new number in the run's monitoring**, `research.websites.named_nobody_in_particular`, alongside the existing own-site counts. Read the "unknown" count against it: a run whose companies are all named after their trade cannot establish a single website however well it went, and previously that looked identical to a run where nothing vouched for anything.
- **This makes more things match, which is the fail-open direction.** Deliberately narrow: only a name that actually carries the mark is read two ways, so `Villa Nova` and `Vila Nova` stay two different companies. See the loosening I did accept, below.

## Review guide

Start at `packages/research/src/application/entity-guard.ts` — `nameSpellings` and the two readings layered on it (`coreSpellings`, `spellingsWithoutForms`). Everything else follows from those.

- **The riskiest part is the ordering**, and it is easy to miss: the spellings are read *before* a legal form's dots come out. That is the only order in which a period can be one of the marks — take the dots out first and `Instal.lacions` has already become `Installacions`, with nothing left to say the two l's were ever one sound. If you reorder those two steps, the tests catch it.
- **A loosening I accepted, and you may want to overrule.** A page about a *different* company in the same trade now reaches the middle verdict ("somebody should read this") where it used to fail closed. The cause is not this change: the word `instal·lacions` is missing from the hand-typed list of generic trade words (`GENERIC_WORDS`), so it counts as identifying a particular company whichever way it is spelled — the other two spellings already reached that verdict before this branch. Pinned in a test that states the cost plainly.
- **I am deliberately not adding the word to that list.** §7 of #456 has it deleted, not grown, and names this exact failure: "it holds only English and Spanish, so a German, French or Italian company's trade word is treated as distinctive today." Catalan is one more instance of the gap the epic already records, so topping the list up would deepen a debt against Decision 1 rather than pay it. The replacement is Decision 3's structural distinctiveness, starting from overlap with what the caller asked for — and this market's own request contains "instalaciones", so that replacement settles this case with no list at all.
- **Deliberately not fixed:** I did not make generic words identifying again. Issue #468's comment explains why that is the expensive mistake.
- `directory-sites.ts` is the fiddliest read: a company is now held as the one name it is *counted* as plus every way an address may *write* it, because two spellings of one company must never count as the two companies it takes to call a host a directory — that would take a real firm's website away.
- Skip-able: the test files are long but repetitive.

## Tests

Unit tests across the four files (1544 in `packages/research`, up from 1509). The ones worth reading:

- The loosening cannot merge two companies — `Villa Nova` / `Vila Nova` stay apart, and in `Col·legi Vallès` only the marked pair of l's collapses while `Vallès` keeps both of its own.
- One company written two ways is still one company, for both the directory watch and the shared-host rule. I checked this by reverting the fix and confirming the test fails.
- A dotted name and its undotted twin produce identical match keys.
- The cost is pinned, not hidden: a test asserts the same-trade page reaches the middle verdict, and says in its comment why.

## Verification

- Ran `pnpm install`, `pnpm -w check-types` (13/13), `pnpm -w test` (21/21 tasks — research 1544, server 855, controllers 59, cli 38, internal 154), `pnpm -w build` (13/13). All green.
- Ran the research quality eval live against real providers on the Spanish installations market row, twice — once before this branch's behaviour change and once on the final code. Final run: 36 companies, 100% of the right kind, no duplicates, all 5 trades answered, 100% request coverage, 0% empty, 10.0¢.
- **The sharper check:** I replayed two real live results (46 rows and 36 rows) through the guards on both `origin/main` and this branch. Verdicts were **identical** on both sets, dotted legal forms included — so this does not disturb what already worked on real Spanish data.

**Two limits I want to be honest about:**

1. **The Catalan half is not measured live.** Both eval runs returned Castilian companies only — no name with a raised dot appeared — so that half rests on unit tests, not on a live row. The market row can't currently prove it.
2. **The two eval runs are not a before/after.** The caches were cleared between them, so they reached different pages (46 vs 36 companies) and the numbers aren't comparable. The deterministic replay above is the regression evidence; the eval runs show the pipeline is healthy end to end.

## Deferred

- **The loosening in the Review guide, which closes when the generic trade-word list is deleted rather than extended.** #456 §7 already schedules that deletion, tied to its replacement — distinctiveness decided structurally instead of by a hand-typed vocabulary — and this PR pays nothing into the list either way.
- The reading is per-word, not script-aware; the broader rewrite that #456 §4.6 schedules last is untouched here, and existence verification (§4.8) is still what would catch a confident-wrong match.

Nothing here adds a list of countries, languages or trades. The marks this reads are the ones Catalan writes a doubled l with, which is spelling rather than a claim about which markets were expected — the same category as the word-joiners ("i", "de") that #456 §7 keeps for exactly that reason. The new "this name identifies nobody in particular" check asks whether *any* distinctive word survives, so it keeps working unchanged once what counts as distinctive stops coming from a list.

Closes #478
