### PR TITLE
feat: say when a company was only ever a name in a list

### DIFF
--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -5,6 +5,7 @@ import { Plus } from 'lucide-react'
 import { useId, useState } from 'react'
 import styled from 'styled-components'
 
+import { NAME_ONLY_EVIDENCE } from '@batuda/research/application/name-only-guard'
 import { PriButton, usePriToast } from '@batuda/ui/pri'
 
 import { SafeLink } from '#/components/research/safe-link'
@@ -49,6 +50,9 @@ type ProspectEntry = {
 	readonly location?: string
 	readonly why_relevant: string
 	readonly unconfirmed_reason?: string
+	// Doubt the run did not put into words but the engine established on its own, so
+	// the wording belongs here rather than in the finding.
+	readonly unconfirmed_evidence?: string
 	readonly citations?: ReadonlyArray<Citation>
 }
 
@@ -93,12 +97,18 @@ export function ProspectScanView({
 // write a company nobody has vouched for.
 function ProspectRow({ prospect }: { readonly prospect: ProspectEntry }) {
 	const doubtId = useId()
+	const { t } = useLingui()
 	// A reason with nothing written in it is not a doubt anybody can weigh, and runs
 	// stored before the engine started taking those back still carry them. Read as a
 	// mark it would badge the row and hold back the vouching step while naming no
 	// cause at all.
 	const doubt = prospect.unconfirmed_reason?.trim()
-	const unconfirmed = doubt !== undefined && doubt !== ''
+	// The engine's own finding: every page this row cites was a page listing many
+	// companies, and it carries neither a site nor a place. Told here rather than
+	// stored as a sentence, so it reads in the language the reader is using.
+	const nameOnly = prospect.unconfirmed_evidence === NAME_ONLY_EVIDENCE
+	const spoken = doubt !== undefined && doubt !== ''
+	const unconfirmed = spoken || nameOnly
 
 	return (
 		<ListItem>
@@ -119,7 +129,9 @@ function ProspectRow({ prospect }: { readonly prospect: ProspectEntry }) {
 					<ReasonLabel>
 						<Trans>Could not be confirmed:</Trans>
 					</ReasonLabel>{' '}
-					{doubt}
+					{spoken
+						? doubt
+						: t`Only found named in a list of companies, with no website and no location of its own.`}
 				</Reason>
 			) : null}
 			<FieldsTable>

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -3990,6 +3990,10 @@ msgstr "Només un administrador de l'organització pot canviar aquesta pila."
 msgid "Only an owner or an admin can add members."
 msgstr "Només un propietari o un administrador pot afegir membres."
 
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Only found named in a list of companies, with no website and no location of its own."
+msgstr "Només s'ha trobat anomenada en una llista d'empreses, sense web ni ubicació pròpies."
+
 #: src/routes/settings/organization/policy.tsx
 msgid "Only machine-verified values apply on their own; free-text always waits for review."
 msgstr "Només els valors verificats per màquina s'apliquen sols; el text lliure sempre espera revisió."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -3990,6 +3990,10 @@ msgstr "Only an organization admin can change this stack."
 msgid "Only an owner or an admin can add members."
 msgstr "Only an owner or an admin can add members."
 
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Only found named in a list of companies, with no website and no location of its own."
+msgstr "Only found named in a list of companies, with no website and no location of its own."
+
 #: src/routes/settings/organization/policy.tsx
 msgid "Only machine-verified values apply on their own; free-text always waits for review."
 msgstr "Only machine-verified values apply on their own; free-text always waits for review."

--- a/packages/research/package.json
+++ b/packages/research/package.json
@@ -18,6 +18,10 @@
 			"types": "./src/application/guard-shapes.ts",
 			"import": "./src/application/guard-shapes.ts"
 		},
+		"./application/name-only-guard": {
+			"types": "./src/application/name-only-guard.ts",
+			"import": "./src/application/name-only-guard.ts"
+		},
 		"./application/paid-action-tool": {
 			"types": "./src/application/paid-action-tool.ts",
 			"import": "./src/application/paid-action-tool.ts"

--- a/packages/research/src/application/name-only-guard.test.ts
+++ b/packages/research/src/application/name-only-guard.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+
+import { markNameOnlyRows, NAME_ONLY_EVIDENCE } from './name-only-guard'
+
+const scan = (
+	prospects: ReadonlyArray<Record<string, unknown>>,
+): Record<string, unknown> => ({ prospects })
+
+const cite = (page: string): Record<string, unknown> => ({
+	source_id: page,
+	quote: 'Liste des professionnels',
+})
+
+const marksOf = (findings: unknown): Array<unknown> =>
+	(
+		findings as { prospects: Array<Record<string, unknown> | null> }
+	).prospects.map(row => row?.['unconfirmed_evidence'])
+
+describe('markNameOnlyRows', () => {
+	describe('when a row is a name off a page that lists many companies', () => {
+		it('should mark it, because there is nothing else the page could give', () => {
+			// GIVEN one directory index cited for three rows, none of which carries a
+			// site or a place — the shape a live French market search came back with
+			const findings = scan([
+				{ name: 'DAMAD', citations: [cite('https://pj.example/ascensoriste')] },
+				{
+					name: 'Ascenseurs de Paris',
+					citations: [cite('https://pj.example/ascensoriste')],
+				},
+				{
+					name: 'Ariane',
+					citations: [cite('https://pj.example/ascensoriste')],
+				},
+			])
+
+			// WHEN checked
+			// THEN all three are marked. A page cited for company after company is a
+			// list of names, and a row built from one is a name
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([
+				NAME_ONLY_EVIDENCE,
+				NAME_ONLY_EVIDENCE,
+				NAME_ONLY_EVIDENCE,
+			])
+			expect(result.marked).toBe(3)
+		})
+
+		it('should mark a row that cites nothing at all, which is the same case', () => {
+			// GIVEN a row with no evidence behind it whatsoever
+			const findings = scan([{ name: 'Asc' }, { name: 'Beta', citations: [] }])
+
+			// WHEN checked — THEN both are marked: a row citing nothing has even less
+			// standing than one citing a list
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([
+				NAME_ONLY_EVIDENCE,
+				NAME_ONLY_EVIDENCE,
+			])
+		})
+
+		it('should mark it only when every page it cites is a shared one', () => {
+			// GIVEN a row citing both a directory index and a page about itself
+			const findings = scan([
+				{
+					name: 'Ariane',
+					citations: [
+						cite('https://pj.example/ascensoriste'),
+						cite('https://news.example/ariane-profile'),
+					],
+				},
+				{ name: 'DAMAD', citations: [cite('https://pj.example/ascensoriste')] },
+			])
+
+			// WHEN checked
+			// THEN only the second is marked. One page about this company alone is the
+			// run having looked into it, whatever else it also read
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined, NAME_ONLY_EVIDENCE])
+		})
+	})
+
+	describe('when the row has somewhere to go or somewhere to be', () => {
+		it('should leave a row with a site of its own alone', () => {
+			// GIVEN two rows off the same market report, one naming its own site
+			const findings = scan([
+				{
+					name: 'Otis',
+					website: 'https://otis.com',
+					citations: [cite('https://report.example/lifts')],
+				},
+				{ name: 'KONE', citations: [cite('https://report.example/lifts')] },
+			])
+
+			// WHEN checked — THEN only the second. A site is somewhere a reader can go
+			// and find out more, which is exactly what the marked row lacks
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined, NAME_ONLY_EVIDENCE])
+		})
+
+		it('should leave a row alone when the shared page printed its place', () => {
+			// GIVEN a directory page that lists companies WITH their towns, so two rows
+			// share it and both come away with somewhere to be
+			const findings = scan([
+				{
+					name: 'Skrzypczak',
+					location: 'Nord (59)',
+					citations: [cite('https://pj.example/departement/nord-59')],
+				},
+				{
+					name: 'Dupont',
+					location: 'Lille',
+					citations: [cite('https://pj.example/departement/nord-59')],
+				},
+			])
+
+			// WHEN checked — THEN neither is marked. Sharing a page is only half of it:
+			// these rows came away with something, so the page was not a bare list
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined, undefined])
+			expect(result.marked).toBe(0)
+		})
+
+		it('should treat a blank site or place as not having one', () => {
+			// GIVEN the fields present but empty, which is not the same as filled
+			const findings = scan([
+				{
+					name: 'Acme',
+					website: '   ',
+					location: '',
+					citations: [cite('https://pj.example/list')],
+				},
+				{ name: 'Beta', citations: [cite('https://pj.example/list')] },
+			])
+
+			// WHEN checked — THEN the blanks count as absent and the row is marked
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([
+				NAME_ONLY_EVIDENCE,
+				NAME_ONLY_EVIDENCE,
+			])
+		})
+	})
+
+	describe('when the run already said something about the company', () => {
+		it('should leave its own words in place', () => {
+			// GIVEN a row the run itself marked, in its own words
+			const findings = scan([
+				{
+					name: 'DAMAD',
+					unconfirmed_reason: 'no trace in any register',
+					citations: [cite('https://pj.example/list')],
+				},
+				{ name: 'Ariane', citations: [cite('https://pj.example/list')] },
+			])
+
+			// WHEN checked
+			// THEN the run's own reason stands and only the silent row is marked —
+			// replacing "no trace in any register" with this would say less
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined, NAME_ONLY_EVIDENCE])
+			expect(
+				(result.findings as { prospects: Array<Record<string, unknown>> })
+					.prospects[0]?.['unconfirmed_reason'],
+			).toBe('no trace in any register')
+		})
+
+		it('should not treat a blank reason as the run having spoken', () => {
+			// GIVEN a reason present but empty, which says nothing
+			const findings = scan([
+				{
+					name: 'DAMAD',
+					unconfirmed_reason: '  ',
+					citations: [cite('https://pj.example/list')],
+				},
+				{ name: 'Ariane', citations: [cite('https://pj.example/list')] },
+			])
+
+			// WHEN checked — THEN it is marked like any other silent row
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([
+				NAME_ONLY_EVIDENCE,
+				NAME_ONLY_EVIDENCE,
+			])
+		})
+	})
+
+	describe('when a field says nothing rather than being absent', () => {
+		it('should read a null site or place as not having one', () => {
+			// GIVEN the fields written as null, which is a model saying it has none
+			const findings = scan([
+				{
+					name: 'DAMAD',
+					website: null,
+					location: null,
+					citations: [cite('https://pj.example/list')],
+				},
+				{ name: 'Ariane', citations: [cite('https://pj.example/list')] },
+			])
+
+			// WHEN checked — THEN null counts as absent, so the row is marked. Reading
+			// it as a site would let the very rows this looks for slip past
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([
+				NAME_ONLY_EVIDENCE,
+				NAME_ONLY_EVIDENCE,
+			])
+		})
+	})
+
+	describe('when there is no list to read', () => {
+		it('should hand back what it was given for a shape that is not a scan', () => {
+			// GIVEN no list field, which is every run that answers about one company
+			const findings = scan([{ name: 'DAMAD' }])
+
+			// WHEN checked with no field named — THEN nothing is touched
+			const result = markNameOnlyRows(findings, undefined)
+			expect(result.findings).toBe(findings)
+			expect(result.marked).toBe(0)
+		})
+
+		it('should hand back findings whose list is missing or the wrong shape', () => {
+			// GIVEN a scan whose list never arrived, and one where it is not a list
+			// WHEN checked — THEN both come back untouched rather than throwing
+			expect(markNameOnlyRows({}, 'prospects').marked).toBe(0)
+			expect(markNameOnlyRows({ prospects: 'none' }, 'prospects').marked).toBe(
+				0,
+			)
+			expect(markNameOnlyRows(null, 'prospects').marked).toBe(0)
+		})
+
+		it('should hand back the same findings when nothing is marked', () => {
+			// GIVEN a list where every row has somewhere to go
+			const findings = scan([{ name: 'Otis', website: 'https://otis.com' }])
+
+			// WHEN checked — THEN the original object comes back, so a run that changed
+			// nothing does not rewrite its own findings
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(result.findings).toBe(findings)
+		})
+
+		it('should step over a row that is not an object', () => {
+			// GIVEN a list holding something that is not a row, beside two that share
+			// a page
+			const findings = scan([
+				null as unknown as Record<string, unknown>,
+				{ name: 'Ariane', citations: [cite('https://pj.example/list')] },
+				{ name: 'DAMAD', citations: [cite('https://pj.example/list')] },
+			])
+
+			// WHEN checked — THEN the stray entry survives untouched and the real rows
+			// are judged as if it were not there
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([
+				undefined,
+				NAME_ONLY_EVIDENCE,
+				NAME_ONLY_EVIDENCE,
+			])
+		})
+
+		it('should leave a lone row citing one page alone', () => {
+			// GIVEN a single row citing a single page, which is all there is to go on
+			const findings = scan([
+				{ name: 'Ariane', citations: [cite('https://pj.example/list')] },
+			])
+
+			// WHEN checked
+			// THEN it is not marked. A page cited once is a page about that company as
+			// far as anything here can tell — it takes a second row off the same page
+			// to show it was a list, and being wrong the other way would put doubt on
+			// a company the run did look into
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([undefined])
+		})
+	})
+
+	describe('when a citation is malformed', () => {
+		it('should ignore one that names no page', () => {
+			// GIVEN citations with a missing, blank, and non-string page
+			const findings = scan([
+				{
+					name: 'DAMAD',
+					citations: [
+						{ quote: 'named' },
+						{ source_id: '  ' },
+						{ source_id: 7 },
+					],
+				},
+			])
+
+			// WHEN checked
+			// THEN the row counts as citing nothing, which is the case it belongs in —
+			// a citation pointing nowhere is not a page the run read
+			const result = markNameOnlyRows(findings, 'prospects')
+			expect(marksOf(result.findings)).toEqual([NAME_ONLY_EVIDENCE])
+		})
+	})
+})

--- a/packages/research/src/application/name-only-guard.ts
+++ b/packages/research/src/application/name-only-guard.ts
@@ -1,0 +1,111 @@
+/**
+ * Marks a scan row whose evidence is a name off a list and nothing else.
+ *
+ * A search for a whole market meets pages that print many companies at once — a
+ * directory's index of a trade, a market report naming who leads it. Those pages
+ * give a name and stop there: no address, no site, nothing about the company beyond
+ * its being on the list. A row built from one is a name, and reading the finished
+ * answer there is no way to tell it from a row the run actually looked into.
+ *
+ * Measured on eight live market searches, this marks 15 of 168 French rows and 3 of
+ * 167 Spanish ones — eight lift companies lifted off a single directory index
+ * whose whole cited quote was "Liste des professionnels · DAMAD · Ascenseurs de
+ * Paris · …", and four multinationals off a market report's sentence about who leads
+ * the trade. None carried a site, a place, or a mark of any kind.
+ *
+ * The mark is what already exists for this: the evidence names the company but does
+ * not establish that it exists and trades. Nothing was inventing anything — there
+ * was simply no more to be had from the page — so this says so rather than trying to
+ * fill the blanks, which on a name alone could only be guesswork.
+ *
+ * Three things together say a row is that:
+ *  - no site of its own, so there is nowhere to go and read more;
+ *  - no place, so it cannot even be put on a map;
+ *  - nothing cited that is about this company alone — every page it cites, this run
+ *    also cited for some other company, which is what a page listing many companies
+ *    looks like from here. A row citing nothing at all is the same case, more so.
+ *
+ * All three, because each alone is ordinary. A real company can go without a site,
+ * and a row off a shared page can still carry the address printed beside its name —
+ * the Spanish lists are full of both. It is the three together that leave a name.
+ *
+ * Runs after the mark is taken back off rows that only read their own blanks back,
+ * so that step cannot undo this one. See `unconfirmed-mark-guard.ts` — it clears a
+ * reason built from field names, and this deliberately says nothing about fields.
+ */
+
+import { isPlainObject } from './guard-shapes'
+
+/** What this leaves on a row, for the reader to be told in their own language. */
+export const NAME_ONLY_EVIDENCE = 'name_only_listing'
+
+export interface NameOnlyResult {
+	readonly findings: unknown
+	/** How many rows were marked, for the run's own telemetry. */
+	readonly marked: number
+}
+
+/**
+ * A field that holds something, as opposed to being absent or blank. A null counts
+ * as absent: a model writing `"website": null` is saying it has none, and reading
+ * that as a site would let the very rows this looks for slip past unmarked.
+ */
+const isFilled = (value: unknown): boolean =>
+	typeof value === 'string'
+		? value.trim() !== ''
+		: value !== undefined && value !== null
+
+/** The pages one row cites, without repeats. */
+const citedPages = (row: Record<string, unknown>): ReadonlySet<string> => {
+	const citations = row['citations']
+	if (!Array.isArray(citations)) return new Set()
+	const pages = new Set<string>()
+	for (const citation of citations) {
+		if (!isPlainObject(citation)) continue
+		const page = citation['source_id']
+		if (typeof page === 'string' && page.trim() !== '') pages.add(page.trim())
+	}
+	return pages
+}
+
+/**
+ * Mark the rows of one discovery scan that are a name off a list.
+ *
+ * A row already carrying doubt is left as it is: the run said something about that
+ * company in its own words, and replacing it with this would say less.
+ */
+export const markNameOnlyRows = (
+	findings: unknown,
+	listField: string | undefined,
+): NameOnlyResult => {
+	if (listField === undefined) return { findings, marked: 0 }
+	if (!isPlainObject(findings)) return { findings, marked: 0 }
+	const rows = findings[listField]
+	if (!Array.isArray(rows)) return { findings, marked: 0 }
+
+	// How many rows of this answer each page was cited for. A page cited for one row
+	// is evidence about that company; a page cited for several is a list of them.
+	const rowsPerPage = new Map<string, number>()
+	for (const row of rows) {
+		if (!isPlainObject(row)) continue
+		for (const page of citedPages(row)) {
+			rowsPerPage.set(page, (rowsPerPage.get(page) ?? 0) + 1)
+		}
+	}
+
+	let marked = 0
+	const kept = rows.map(row => {
+		if (!isPlainObject(row)) return row
+		if (isFilled(row['unconfirmed_reason'])) return row
+		if (isFilled(row['website']) || isFilled(row['location'])) return row
+		const pages = citedPages(row)
+		const ownPage = [...pages].some(page => (rowsPerPage.get(page) ?? 0) < 2)
+		if (ownPage) return row
+		marked += 1
+		return { ...row, unconfirmed_evidence: NAME_ONLY_EVIDENCE }
+	})
+
+	return marked === 0
+		? { findings, marked: 0 }
+		: { findings: { ...findings, [listField]: kept }, marked }
+}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -105,6 +105,7 @@ import {
 	withRoleMailbox,
 } from './generic-emails'
 import { type GuardLink, runGuardChain } from './guard-chain'
+import { markNameOnlyRows } from './name-only-guard'
 import { dropNonCompanies } from './organisation-kind-guard'
 import { normalizePaidActionTool } from './paid-action-tool'
 import {
@@ -3607,6 +3608,37 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												findings: check.findings,
 												spanCounts: {
 													'research.prospects.doubt_cleared': check.cleared,
+												},
+											}
+										}),
+								},
+								{
+									// A row can survive every check above and still be nothing but a
+									// name somebody's directory printed in a list. Say so, rather
+									// than leave it looking like a company the run looked into.
+									// After the link above, which takes marks away — running before
+									// it would hand this one straight to it.
+									name: 'name-only-evidence',
+									run: findings =>
+										Effect.gen(function* () {
+											const check = markNameOnlyRows(
+												findings,
+												discoveryResultField(schemaName),
+											)
+											if (check.marked > 0) {
+												yield* Effect.logInfo(
+													'research.prospects.name_only',
+												).pipe(
+													Effect.annotateLogs({
+														research_id: researchId,
+														marked: check.marked,
+													}),
+												)
+											}
+											return {
+												findings: check.findings,
+												spanCounts: {
+													'research.prospects.name_only': check.marked,
 												},
 											}
 										}),


### PR DESCRIPTION
## What

When you ask Batuda to find you companies across a whole market, some of what comes back is not a company it looked into — it is a name it read on a page that listed many companies at once, with nothing else attached. A directory's index of a trade prints eighty names and no addresses; a market report names the four firms that lead a sector. A row built from one of those has a name and a trade and nothing more, and until now the finished list gave the reader no way to tell it apart from a company the run had actually researched.

This makes the run say so. Such a row now carries the "could not confirm" mark that already exists for exactly this — the evidence names the company but does not establish that it exists and trades — so the reader sees it flagged rather than presented as a lead worth calling. It changes the research engine (`packages/research`) and the findings panel that shows a run's results (`apps/internal`).

Nothing is invented and nothing is dropped. The row stays in the list, because a name off a directory is still a lead somebody may want to chase; it just stops pretending to be more than it is.

## Changes

**Touches:** the phase-2 checks that run over a scan's rows after extraction, the order they run in, and the findings panel that shows a run's results — plus, unchanged but load-bearing here, the check immediately before this one, which *takes marks back* off rows that only read their own blank columns back.

- A row is marked when three things hold together: no website, no place, and nothing cited that is about this company alone — every page it cites is one this run also cited for some other company, which is what a listing page looks like from the row's side. A row citing nothing at all is the same case.
- All three, because each alone is ordinary. A real company can go without a website, and a row off a shared page can still carry the address printed beside its name — the Spanish lists are full of both. It is the three together that leave a name.
- The mark is a fixed value the engine sets, not a sentence it composes, and the panel turns it into words in the reader's own language. A row the model already marked in its own words keeps those words — replacing "no trace in any register" with this would say less.
- It runs last of the deterministic checks, **after** the step that clears marks. Ordered the other way, this mark would be handed straight to the thing that strips marks.

## Impact

- **No schema change and no migration.** The mark rides inside the run's existing findings JSON, so nothing to apply before the server tag.
- **Nothing touching which organisation can see what** (row-level security), no change to authentication or route protection, no new environment variables, and no change to the shape of anything crossing the wire between server and web app.
- **Both ways in get it.** The check sits in the shared research pipeline rather than in a route, so a run started from the web app and one started by an assistant over MCP behave the same.
- **No extra cost.** It reads what the run already gathered — no search, no scrape, no model call.
- **Older runs are unaffected**, and read exactly as they do today: they carry no marker, so the panel renders them unchanged.
- One reading does shift: **runs will show more flagged rows than before** — measured at 9% of French market rows and 2% of Spanish. That is the point, but it is worth knowing before it looks like a regression on a dashboard.

## Review guide

Start with `packages/research/src/application/name-only-guard.ts` — the docblock carries the reasoning and the measured numbers; the function is short.

**The riskiest part is the order**, not the logic: this runs after the link that clears marks, and swapping the two would silently undo it. The comment at the call site in `research-service.ts` says so, and `unconfirmed-mark-guard.ts` is the neighbour to read if that ordering looks arbitrary.

**A decision you might overrule:** a row citing a single page, cited only once, is *not* marked — from one row there is no way to tell a listing page from a page about that company, and being wrong in that direction would put doubt on a company the run did look into. So a scan returning one row off a directory index escapes. I chose the false-negative over the false-positive; the test `should leave a lone row citing one page alone` pins it, and it is a one-line change if you disagree.

**What I could not verify:** the live effect on a fresh run. I measured against eight market runs already stored locally from the #472 measurement pass rather than paying for new ones — the numbers below come from replaying the shipped function over those stored findings, not from a new search.

Skip-able: the two catalog files are `i18n:extract` output plus one Catalan translation.

## Screenshots

> Screenshots skipped (approved): no new visual design — the row reuses the existing "Unconfirmed company" badge and reason line, which already render for a model-written `unconfirmed_reason`. The only change is that they now also fire on the engine's own marker.

## Tests

Twelve unit tests over the new check, covering each of the three conditions on its own and together, a page cited once versus shared, a row that cites nothing, blank and null fields, a row the model already marked, a blank mark, and the malformed shapes (no list, wrong-typed list, a non-object row, a citation naming no page).

## Verification

- `pnpm check-types` — 13/13 green.
- `pnpm test` — 21/21 packages green; 1,559 tests in `packages/research`.
- `pnpm build` — 13/13 green.
- `pnpm biome check` on every changed file — clean.
- Replayed the shipped function over the eight market runs stored from #472: **15 of 168 French rows marked (9%) and 3 of 167 Spanish (2%)**, including the eight lift companies taken off a single Pages Jaunes trade index.

I did not drive the running app for this one — see the screenshots note above.

## Deferred

The wider question of whether such a row should be *returned* at all belongs to #453, which owns rows that are really just entries on a page the scan searched. This only makes the existing behaviour honest.

Closes #493
