### PR TITLE
feat: record each request and research run on one line

### DIFF
--- a/apps/server/src/handlers/auth.ts
+++ b/apps/server/src/handlers/auth.ts
@@ -7,6 +7,7 @@ import { HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
 import { BatudaApi } from '@batuda/controllers'
+import { recordFacts } from '@batuda/observability'
 
 import { Auth } from '../lib/auth'
 import { EnvVars } from '../lib/env'
@@ -33,12 +34,12 @@ const proxyToAuth = Effect.gen(function* () {
 	const response = yield* Effect.promise(() => instance.handler(fetchRequest))
 
 	// The MCP OAuth-drop bug shows up as failures on the token endpoint, which
-	// Better Auth serves opaquely. Tag the request span with the grant outcome
-	// (response status) so a refresh failure is visible in Honeycomb without a
-	// console grep. The request body is already streamed to Better Auth, so
-	// grant_type isn't read here (would need teeing the stream).
+	// Better Auth serves opaquely. Record the grant outcome (response status) so
+	// a refresh failure is visible in Honeycomb without a console grep. The
+	// request body is already streamed to Better Auth, so grant_type isn't read
+	// here (would need teeing the stream).
 	if (url.pathname.endsWith('/oauth2/token')) {
-		yield* Effect.annotateCurrentSpan({
+		yield* recordFacts({
 			'auth.endpoint': 'oauth2/token',
 			'auth.token_response_status': response.status,
 		})

--- a/apps/server/src/lib/global-middleware-order.ts
+++ b/apps/server/src/lib/global-middleware-order.ts
@@ -1,0 +1,38 @@
+import { Layer } from 'effect'
+
+import { CorsLive } from './cors'
+import { ObservabilityLive } from './observability-middleware'
+
+/**
+ * Puts the router-wide middleware in the order it has to run in.
+ *
+ * Router-wide middleware wraps a request in REVERSE registration order, so
+ * whichever registers first ends up outermost — and registration order is layer
+ * build order, which `Layer.mergeAll` performs concurrently. Listed alongside
+ * everything else, these two would land wherever the build happened to put them,
+ * and that position could change with nobody editing either of them.
+ *
+ * Providing them states the order as a dependency the build has to respect:
+ * observability is built first and so registers first, then CORS, then whatever
+ * the caller passes in.
+ *
+ * The order matters because a middleware that answers a caller itself, without
+ * passing the request on, hides everything registered after it:
+ *
+ * - **Observability outermost.** The MCP sign-in check refuses a caller
+ *   directly, so anything after it never runs for a refusal — and a refused MCP
+ *   connection would leave no record of the request at all. That is the case an
+ *   MCP client shows as a silent retry loop rather than a visible error, so it
+ *   is the one that most needs a record.
+ * - **CORS above the sign-in check.** Otherwise a refusal is answered before
+ *   CORS can add its headers, and a browser client cannot read the challenge
+ *   telling it how to authenticate — nor can a preflight, which carries no
+ *   credentials and would be refused rather than answered.
+ *
+ * This lives apart from `main.ts` so the ordering can be tested: importing
+ * `main.ts` starts the server, so a test can only reach the arrangement if the
+ * arrangement is somewhere else.
+ */
+export const withGlobalMiddlewareOrder = <A, E, R>(
+	routes: Layer.Layer<A, E, R>,
+) => routes.pipe(Layer.provide(CorsLive), Layer.provide(ObservabilityLive))

--- a/apps/server/src/lib/middleware-order.test.ts
+++ b/apps/server/src/lib/middleware-order.test.ts
@@ -1,0 +1,155 @@
+// Router-wide middleware wraps a request in REVERSE registration order, and
+// registration order is layer build order — which `Layer.mergeAll` performs
+// concurrently. So the order among them is not something a merge list decides.
+//
+// It matters because a middleware that answers a caller itself, without passing
+// the request on, hides everything registered after it. The MCP sign-in check
+// does exactly that for a refused caller, so anything below it never runs for a
+// refusal: observability would write no record of the request, and CORS would
+// add no headers to the challenge telling a browser client how to authenticate.
+//
+// These drive a real in-process server through `withGlobalMiddlewareOrder` —
+// the same function `main.ts` uses, rather than a copy of it, so re-flattening
+// the arrangement there fails here.
+
+import { createServer } from 'node:http'
+
+import { NodeHttpServer } from '@effect/platform-node'
+import { Effect, Layer, Logger, ManagedRuntime, References } from 'effect'
+import {
+	HttpMiddleware,
+	HttpRouter,
+	HttpServer,
+	HttpServerRequest,
+	HttpServerResponse,
+} from 'effect/unstable/http'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { applyTestEnv, TEST_ENV } from '../test-env'
+import { EnvVars } from './env'
+import { withGlobalMiddlewareOrder } from './global-middleware-order'
+
+// Reading the settings only parses them, so no service has to be up for this.
+applyTestEnv()
+const allowedOrigin = TEST_ENV['ALLOWED_ORIGINS'] as string
+
+const lines: Array<Record<string, unknown>> = []
+
+const CaptureLogs = Logger.layer([
+	Logger.make(options => {
+		lines.push({
+			...options.fiber.getRef(References.CurrentLogAnnotations),
+		})
+	}),
+]).pipe(Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')))
+
+// Stands in for the MCP sign-in check, in the same shape: refuse this route by
+// answering the caller directly, and pass anything else on untouched. What it
+// authenticates is beside the point — answering without calling onward is what
+// hides every middleware registered after it.
+const RefusingMiddleware = HttpRouter.middleware(
+	HttpMiddleware.make(app =>
+		Effect.gen(function* () {
+			const request = yield* HttpServerRequest.HttpServerRequest
+			if (!request.url.startsWith('/refused')) return yield* app
+			// Rendering the body is not what is under test, so a failure to render
+			// one dies rather than widening the middleware's declared errors.
+			return yield* HttpServerResponse.json(
+				{ error: 'refused' },
+				{ status: 401 },
+			).pipe(Effect.orDie)
+		}),
+	),
+	{ global: true },
+)
+
+const RoutesLive = HttpRouter.add(
+	'GET',
+	'/allowed',
+	HttpServerResponse.text('ok'),
+)
+
+const ServerLive = HttpRouter.serve(
+	withGlobalMiddlewareOrder(Layer.mergeAll(RoutesLive, RefusingMiddleware)),
+	{ disableListenLog: true, disableLogger: true },
+).pipe(
+	Layer.provideMerge(NodeHttpServer.layer(createServer, { port: 0 })),
+	Layer.provide(EnvVars.layer),
+	Layer.provideMerge(CaptureLogs),
+)
+
+const runtime = ManagedRuntime.make(ServerLive)
+let baseUrl: string
+
+const completions = () =>
+	lines.filter(
+		line =>
+			line['event'] === 'http.request' || line['event'] === 'http.server_error',
+	)
+
+describe('a request refused by a middleware that never passes it on', () => {
+	beforeAll(async () => {
+		const address = await runtime.runPromise(
+			Effect.gen(function* () {
+				const server = yield* HttpServer.HttpServer
+				return server.address
+			}),
+		)
+		if (address._tag !== 'TcpAddress')
+			throw new Error('expected a TCP address for the test server')
+		baseUrl = `http://127.0.0.1:${address.port}`
+	}, 30_000)
+
+	afterAll(() => runtime.dispose())
+
+	beforeEach(() => {
+		lines.length = 0
+	})
+
+	describe('when the refusal answers before the route is reached', () => {
+		it('should leave exactly one record of the request', async () => {
+			// GIVEN a request a middleware refuses outright
+			const response = await fetch(`${baseUrl}/refused`)
+
+			// WHEN it is answered without ever reaching the route
+			expect(response.status).toBe(401)
+
+			// THEN the request still leaves its record, carrying the route and the
+			// status — and exactly one, since a middleware registered twice would
+			// quietly double every request's logging
+			expect(completions()).toHaveLength(1)
+			const completion = completions()[0]
+			expect(completion?.['http.status']).toBe(401)
+			expect(completion?.['http.path_pattern']).toBe('/refused')
+			expect(completion?.['request.id']).toEqual(expect.any(String))
+		})
+
+		it('should still tell a browser client it may read the answer', async () => {
+			// GIVEN the same refusal, asked for by a page on an allowed origin
+			const response = await fetch(`${baseUrl}/refused`, {
+				headers: { origin: allowedOrigin },
+			})
+
+			// THEN the answer carries its cross-origin headers. Refused before CORS
+			// could add them, a browser client would be told it was refused and be
+			// unable to read why — which is the difference between a client that
+			// re-authenticates and one that retries forever
+			expect(response.status).toBe(401)
+			expect(response.headers.get('access-control-allow-origin')).toBe(
+				allowedOrigin,
+			)
+		})
+	})
+
+	describe('when nothing refuses the request', () => {
+		it('should reach the route and still record it', async () => {
+			// GIVEN a route the refusing middleware passes through
+			const response = await fetch(`${baseUrl}/allowed`)
+
+			// THEN the route answers and the request is recorded all the same
+			expect(response.status).toBe(200)
+			expect(completions()).toHaveLength(1)
+			expect(completions()[0]?.['http.status']).toBe(200)
+		})
+	})
+})

--- a/apps/server/src/lib/observability-middleware.test.ts
+++ b/apps/server/src/lib/observability-middleware.test.ts
@@ -1,6 +1,57 @@
+import { Cause, Effect, Layer, Logger, References } from 'effect'
+import { HttpServerRequest } from 'effect/unstable/http'
 import { describe, expect, it } from 'vitest'
 
-import { httpPathPattern } from './observability-middleware.js'
+import { recordFacts } from '@batuda/observability'
+
+import {
+	boundedCause,
+	httpPathPattern,
+	withRequestRecord,
+} from './observability-middleware.js'
+
+// Drives the middleware with a stub request and reads back the annotations on
+// each line it wrote. Annotations live on the fiber, not on the log options, so
+// they are read the way the built-in formatters read them.
+const runRequest = async <A extends { readonly status: number }, E>(
+	app: Effect.Effect<A, E, never>,
+	request?: { readonly url?: string; readonly method?: string },
+) => {
+	const lines: Array<{
+		readonly level: string
+		readonly message: unknown
+		readonly annotations: Record<string, unknown>
+	}> = []
+	const capture = Layer.provideMerge(
+		Layer.succeed(References.MinimumLogLevel, 'Debug'),
+	)(
+		Logger.layer([
+			Logger.make(options => {
+				lines.push({
+					level: String(options.logLevel),
+					message: options.message,
+					annotations: {
+						...options.fiber.getRef(References.CurrentLogAnnotations),
+					},
+				})
+			}),
+		]),
+	)
+	const stub = {
+		url: request?.url ?? '/v1/companies',
+		method: request?.method ?? 'GET',
+		headers: {},
+	} as unknown as HttpServerRequest.HttpServerRequest
+
+	const exit = await Effect.runPromise(
+		withRequestRecord(app).pipe(
+			Effect.provideService(HttpServerRequest.HttpServerRequest, stub),
+			Effect.provide(capture),
+			Effect.exit,
+		),
+	)
+	return { lines, exit }
+}
 
 // Locks in how request URLs are normalised before they become span attributes
 // and log fields: record ids collapse to :id so errors group by route, and the
@@ -85,6 +136,148 @@ describe('httpPathPattern', () => {
 			// THEN the fragment is dropped
 			// [split('#')]
 			expect(httpPathPattern('/pages/about#section')).toBe('/pages/about')
+		})
+	})
+})
+
+// The whole point of the work record is that a fact learned mid-request ends up
+// on the SAME line as the outcome, because two lines cannot be grouped as one.
+// These pin that, and pin that the request's own identity always wins.
+describe('withRequestRecord', () => {
+	describe('when the request records a fact on the way through', () => {
+		it('should put the fact on the same line as the outcome', async () => {
+			// GIVEN a request that learns how the caller signed in, deep inside
+			const { lines } = await runRequest(
+				recordFacts({ 'auth.method': 'api_key' }).pipe(
+					Effect.as({ status: 200 }),
+				),
+			)
+
+			// WHEN it completes
+			const completion = lines.find(
+				line => line.annotations['event'] === 'http.request',
+			)
+
+			// THEN the fact, the outcome and the route are all on one line — this is
+			// what makes "how long did it take, split by how they signed in" a
+			// question with an answer
+			expect(completion?.annotations['auth.method']).toBe('api_key')
+			expect(completion?.annotations['http.status']).toBe(200)
+			expect(completion?.annotations['http.path_pattern']).toBe('/v1/companies')
+			expect(completion?.annotations['request.id']).toEqual(expect.any(String))
+		})
+
+		it('should not let a recorded fact shadow which request the line is for', async () => {
+			// GIVEN a request that records keys clashing with the request's identity
+			const { lines } = await runRequest(
+				recordFacts({
+					'request.id': 'IMPOSTOR',
+					'http.path_pattern': '/impostor',
+					event: 'impostor',
+				}).pipe(Effect.as({ status: 200 })),
+			)
+
+			// WHEN it completes
+			const completion = lines.find(
+				line => line.annotations['event'] === 'http.request',
+			)
+
+			// THEN the middleware's own values win — a wrong request id or route
+			// silently breaks tying a request's lines together
+			expect(completion).toBeDefined()
+			expect(completion?.annotations['request.id']).not.toBe('IMPOSTOR')
+			expect(completion?.annotations['http.path_pattern']).toBe('/v1/companies')
+		})
+	})
+
+	describe('when the response is a server error', () => {
+		it('should log at error level and name it as one', async () => {
+			// GIVEN a handler answering 500
+			const { lines } = await runRequest(
+				recordFacts({ 'org.id': 'org_1' }).pipe(Effect.as({ status: 503 })),
+			)
+
+			// WHEN it completes
+			const completion = lines.find(
+				line => line.annotations['event'] !== undefined,
+			)
+
+			// THEN it surfaces as an error and still carries the gathered facts
+			expect(completion?.annotations['event']).toBe('http.server_error')
+			expect(completion?.annotations['http.status']).toBe(503)
+			expect(completion?.annotations['org.id']).toBe('org_1')
+			expect(completion?.level).toBe('Error')
+		})
+	})
+
+	describe('when the request dies without producing a response', () => {
+		it('should still leave one findable line carrying the facts', async () => {
+			// GIVEN a request that records a fact and then dies
+			const { lines } = await runRequest(
+				recordFacts({ 'org.id': 'org_1' }).pipe(
+					Effect.andThen(Effect.die(new Error('boom'))),
+				) as Effect.Effect<{ readonly status: number }, never, never>,
+			)
+
+			// WHEN the defect escapes
+			const defect = lines.find(
+				line => line.annotations['event'] === 'http.defect',
+			)
+
+			// THEN the crash is still findable by event and still says which tenant
+			// and which route it happened on — the completion line never runs, so
+			// without this a hard failure would leave nothing groupable
+			expect(defect).toBeDefined()
+			expect(defect?.annotations['org.id']).toBe('org_1')
+			expect(defect?.annotations['http.path_pattern']).toBe('/v1/companies')
+			expect(defect?.level).toBe('Error')
+		})
+	})
+
+	describe('when the client disconnects', () => {
+		it('should not log an error, because that is not a failure', async () => {
+			// GIVEN a request interrupted part-way, as a closed tab does
+			const { lines } = await runRequest(
+				Effect.interrupt as Effect.Effect<
+					{ readonly status: number },
+					never,
+					never
+				>,
+			)
+
+			// THEN nothing is logged at error level — an interrupt tripping error
+			// alerts would make every closed tab look like an outage
+			expect(lines.filter(line => line.level === 'Error')).toHaveLength(0)
+		})
+	})
+})
+
+describe('boundedCause', () => {
+	describe('when the cause is enormous', () => {
+		it('should cap it and say how much was cut', () => {
+			// GIVEN a defect whose message carries a whole payload
+			const cause = Cause.die(new Error('x'.repeat(20_000)))
+
+			// WHEN it is rendered for the log line
+			const text = boundedCause(cause)
+
+			// THEN it is bounded — an unbounded one would ship the payload to the
+			// exporter, which flushes every second
+			expect(text.length).toBeLessThan(4_200)
+			expect(text).toContain('more characters')
+		})
+	})
+
+	describe('when the cause is ordinary', () => {
+		it('should keep it whole', () => {
+			// GIVEN a normal failure
+			const cause = Cause.die(new Error('connection refused'))
+
+			// WHEN rendered
+			// THEN nothing is cut — the cause is the most useful thing a crash
+			// leaves behind
+			expect(boundedCause(cause)).toContain('connection refused')
+			expect(boundedCause(cause)).not.toContain('more characters')
 		})
 	})
 })

--- a/apps/server/src/lib/observability-middleware.ts
+++ b/apps/server/src/lib/observability-middleware.ts
@@ -5,10 +5,46 @@ import {
 	HttpServerRequest,
 } from 'effect/unstable/http'
 
+import { makeWorkRecord, WorkRecord } from '@batuda/observability'
+
 // Collapse record-identifying URL segments so errors group by route, not by
 // individual record. UUIDs → :id; the query string and fragment are dropped so
 // a token in `?code=…`/`?token=…` never lands in a span attribute or log line.
 const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+
+// A crash's cause is the most useful thing it leaves behind, so it is kept in
+// full rather than summarised — but bounded. A cause wrapping a driver error can
+// carry the failing statement and the values in it, and an unbounded one would
+// ship a whole request payload to the log exporter, which flushes every second.
+// Note this bounds the size, not the content: error text can still name business
+// data incidentally, which is why observability retention is short.
+const MAX_CAUSE_CHARS = 4000
+
+export const boundedCause = (cause: Cause.Cause<unknown>): string => {
+	const text = Cause.pretty(cause)
+	if (text.length <= MAX_CAUSE_CHARS) return text
+	return `${text.slice(0, MAX_CAUSE_CHARS)}… (${text.length - MAX_CAUSE_CHARS} more characters)`
+}
+
+/**
+ * A request that says nothing beyond "the poller is still polling".
+ *
+ * The uptime checker hits `/health` constantly, and a browser asks permission
+ * before a cross-origin call — so between them they can outnumber the requests
+ * a person actually made. Tracing already spares `/health` for exactly this
+ * reason; the record it leaves deserves the same treatment, or the thing that
+ * says least fills the most space.
+ *
+ * Only when it went fine. A health check that fails, or a permission request
+ * that is refused, is the moment both exist for, so those stay at their usual
+ * level and a failure is never quieted.
+ */
+const isRoutinePoll = (
+	method: string,
+	pathPattern: string,
+	status: number,
+): boolean =>
+	status < 400 && (pathPattern === '/health' || method === 'OPTIONS')
 
 export const httpPathPattern = (url: string): string => {
 	const path = url.split('?')[0]?.split('#')[0] ?? url
@@ -26,6 +62,12 @@ export const httpPathPattern = (url: string): string => {
  * last line of defence so no API error escapes unlogged (and therefore
  * unexported once OTLP is on). Attached globally like `CorsLive`.
  *
+ * It also opens the request's work record, so anything the request learns on the
+ * way — how the caller signed in, which org it resolved to — can be written with
+ * `recordFacts` and comes back out on that one completion line. Facts gathered
+ * that way sit on the SAME line as the status and the time taken, which is what
+ * makes "how long did it take, split by how they signed in" answerable at all.
+ *
  * It REPLACES Effect's built-in request logger, which is disabled at `serve`
  * (`disableLogger: true`): that logger annotates `http.url` with the RAW request
  * URL, so a magic-link/reset token in the URL would export verbatim to OTLP.
@@ -34,53 +76,87 @@ export const httpPathPattern = (url: string): string => {
  * `OrgMiddleware` runs after this one and adds `org.id` to the same request
  * span once the org resolves.
  */
-export const ObservabilityLive = HttpRouter.middleware(
-	HttpMiddleware.make(app =>
-		Effect.gen(function* () {
-			const request = yield* HttpServerRequest.HttpServerRequest
-			// Reuse an upstream correlation id when the edge supplies one, else mint
-			// one so a single request's logs and span share a key.
-			const requestId = request.headers['x-request-id'] ?? crypto.randomUUID()
-			const pathPattern = httpPathPattern(request.url)
-			const context = {
-				'request.id': requestId,
-				'http.method': request.method,
-				'http.path_pattern': pathPattern,
-			}
+/**
+ * The middleware's whole behaviour, as a function of the app it wraps, so a test
+ * can drive it with a stub request and read the line it produces. Registering it
+ * as router middleware is all `ObservabilityLive` adds.
+ */
+export const withRequestRecord = <A extends { readonly status: number }, E, R>(
+	app: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R | HttpServerRequest.HttpServerRequest> =>
+	Effect.gen(function* () {
+		const request = yield* HttpServerRequest.HttpServerRequest
+		// Reuse an upstream correlation id when the edge supplies one, else mint
+		// one so a single request's logs and span share a key.
+		const requestId = request.headers['x-request-id'] ?? crypto.randomUUID()
+		const pathPattern = httpPathPattern(request.url)
+		const context = {
+			'request.id': requestId,
+			'http.method': request.method,
+			'http.path_pattern': pathPattern,
+		}
 
-			yield* Effect.annotateCurrentSpan(context)
+		yield* Effect.annotateCurrentSpan(context)
+		const record = yield* makeWorkRecord
 
-			return yield* app.pipe(
-				// One completion log per request (replacing the disabled built-in one),
-				// at error level for a 5xx so it surfaces, info otherwise. The route is
-				// the sanitized path_pattern from `context` below — never the raw URL.
-				Effect.tap(response =>
-					response.status >= 500
-						? Effect.logError('HTTP server error response').pipe(
+		return yield* app.pipe(
+			// One completion log per request (replacing the disabled built-in one),
+			// at error level for a 5xx so it surfaces, info otherwise. The route is
+			// the sanitized path_pattern from `context` below — never the raw URL.
+			// Everything the request recorded on the way rides out on this same
+			// line, so one row holds the whole story of the request.
+			Effect.tap(response =>
+				Effect.flatMap(record.read, facts => {
+					const failed = response.status >= 500
+					return (
+						failed
+							? Effect.logError('HTTP server error response')
+							: isRoutinePoll(request.method, pathPattern, response.status)
+								? Effect.logDebug('HTTP request completed')
+								: Effect.logInfo('HTTP request completed')
+					).pipe(
+						Effect.annotateLogs({
+							...facts,
+							event: failed ? 'http.server_error' : 'http.request',
+							'http.status': response.status,
+							// Last, so a recorded fact can never shadow the fields that
+							// say WHICH request this line belongs to — a wrong request id
+							// or route silently breaks tying a request's lines together.
+							...context,
+						}),
+					)
+				}),
+			),
+			// Defects (and any failure cause reaching here) carry the real stack;
+			// log the whole cause so it is queryable instead of dying in the
+			// console ring-buffer. A pure interrupt is a client disconnect or
+			// shutdown, NOT an error — skip it so it doesn't trip error alerts.
+			Effect.tapCause(cause =>
+				Cause.hasInterruptsOnly(cause)
+					? Effect.void
+					: Effect.flatMap(record.read, facts =>
+							Effect.logError(boundedCause(cause)).pipe(
 								Effect.annotateLogs({
-									event: 'http.server_error',
-									'http.status': response.status,
-								}),
-							)
-						: Effect.logInfo('HTTP request completed').pipe(
-								Effect.annotateLogs({
-									event: 'http.request',
-									'http.status': response.status,
+									...facts,
+									// A defect never becomes a response, so the completion log
+									// above never runs and THIS is the only line the request
+									// leaves. Name it so a request that failed this hard is
+									// still findable by event, like every other one.
+									event: 'http.defect',
+									...context,
 								}),
 							),
-				),
-				// Defects (and any failure cause reaching here) carry the real stack;
-				// log the whole cause so it is queryable instead of dying in the
-				// console ring-buffer. A pure interrupt is a client disconnect or
-				// shutdown, NOT an error — skip it so it doesn't trip error alerts.
-				Effect.tapCause(cause =>
-					Cause.hasInterruptsOnly(cause)
-						? Effect.void
-						: Effect.logError(Cause.pretty(cause)),
-				),
-				Effect.annotateLogs(context),
-			)
-		}),
-	),
+						),
+			),
+			// Inside the request, so `recordFacts` anywhere below finds this
+			// request's record. Work forked off the request outlives this scope
+			// and keeps its own story; it needs a record of its own, not this one.
+			Effect.provideService(WorkRecord, record),
+			Effect.annotateLogs(context),
+		)
+	})
+
+export const ObservabilityLive = HttpRouter.middleware(
+	HttpMiddleware.make(withRequestRecord),
 	{ global: true },
 )

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -48,12 +48,11 @@ import { WebhooksLive } from './handlers/webhooks'
 import { CalcomWebhookLive } from './handlers/webhooks-calcom'
 import { Auth } from './lib/auth'
 import { ConfigFileLive } from './lib/config-provider'
-import { CorsLive } from './lib/cors'
 import { installCrashGuards } from './lib/crash-guards'
 import { EnvVars } from './lib/env'
+import { withGlobalMiddlewareOrder } from './lib/global-middleware-order'
 import { LoggerLive } from './lib/logger'
 import { OtlpObservability } from './lib/observability'
-import { ObservabilityLive } from './lib/observability-middleware'
 import { WellKnownLive } from './lib/well-known'
 import { McpHttpLive } from './mcp/http'
 import { OrgMiddlewareLive, resolveSystemOrg } from './middleware/org'
@@ -429,15 +428,19 @@ const TracerDisabledLive = Layer.succeed(HttpMiddleware.TracerDisabledWhen)(
 	},
 )
 
-const AppLive = Layer.mergeAll(
-	ApiLive,
-	McpHttpLive,
-	CorsLive,
-	ObservabilityLive,
-	TracerDisabledLive,
-	DocsLive,
-	OpenApiJsonLive,
-	WellKnownLive,
+// Observability and CORS are NOT in this list on purpose: a merge decides no
+// order between router-wide middleware, and these two have to run outside the
+// MCP sign-in check. `withGlobalMiddlewareOrder` explains why and is where that
+// order is pinned and tested.
+const AppLive = withGlobalMiddlewareOrder(
+	Layer.mergeAll(
+		ApiLive,
+		McpHttpLive,
+		TracerDisabledLive,
+		DocsLive,
+		OpenApiJsonLive,
+		WellKnownLive,
+	),
 )
 
 // `CurrentOrg` is request-scoped — provided per request by OrgMiddleware

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -12,6 +12,7 @@ import {
 import { SqlClient } from 'effect/unstable/sql'
 
 import { SessionContext } from '@batuda/controllers'
+import { recordFacts } from '@batuda/observability'
 
 import { Auth } from '../lib/auth'
 import { EnvVars } from '../lib/env'
@@ -66,8 +67,19 @@ const rejectAuth = <A, E, R>(
 	reason: string,
 	response: Effect.Effect<A, E, R>,
 ) =>
-	Effect.logWarning('MCP auth rejected').pipe(
-		Effect.annotateLogs({ event: 'mcp.auth.rejected', reason }),
+	// The reason goes on the request's own line as well as on its own, so a
+	// refused connection can be read off the request record without first
+	// knowing to look for the refusal line beside it. One name on both lines, so
+	// filtering for why connections are being refused needs one field, not two.
+	recordFacts({ 'mcp.auth_rejected_reason': reason }).pipe(
+		Effect.andThen(
+			Effect.logWarning('MCP auth rejected').pipe(
+				Effect.annotateLogs({
+					event: 'mcp.auth.rejected',
+					'mcp.auth_rejected_reason': reason,
+				}),
+			),
+		),
 		Effect.andThen(response),
 	)
 
@@ -157,11 +169,13 @@ const McpAuthMiddleware = HttpRouter.middleware(
 						readonly role: string | null
 					},
 				) =>
-					// Tag the request span with how the caller authenticated and the
-					// org it resolved to BEFORE running the tool — the tool-call context
-					// needed to debug an MCP "disconnection" (silent 401 loop) from
-					// Honeycomb alone, present even if the tool then fails.
-					Effect.annotateCurrentSpan({
+					// Record how the caller signed in and the org it resolved to BEFORE
+					// running the tool — the tool-call context needed to debug an MCP
+					// "disconnection" (silent 401 loop) from Honeycomb alone, present
+					// even if the tool then fails. This lands on the request's line as
+					// well as its span, which works because the observability middleware
+					// is registered ahead of this one and has already opened the record.
+					recordFacts({
 						'mcp.auth_method': authMethod,
 						'mcp.org_id': org.id,
 						'mcp.principal_is_agent': principal.isAgent,

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -10,6 +10,7 @@ import {
 	OrgMiddleware,
 	Unauthorized,
 } from '@batuda/controllers'
+import { recordFacts } from '@batuda/observability'
 
 import { Auth } from '../lib/auth'
 
@@ -247,10 +248,11 @@ export const OrgMiddlewareLive = Layer.effect(
 					})
 				}
 
-				// Tag the request span with the resolved org so errors and traces
-				// can be filtered to one tenant. ObservabilityMiddleware runs before
-				// this and already set request id + route on the same span.
-				yield* Effect.annotateCurrentSpan({ 'org.id': row.id })
+				// Put the resolved org on the request's span and row so errors and
+				// traces can be filtered to one tenant. ObservabilityMiddleware runs
+				// before this and already set request id + route on the same span,
+				// and opened the row this joins.
+				yield* recordFacts({ 'org.id': row.id })
 
 				// Enter the org scope (role + both GUCs + CurrentOrg) for the
 				// rest of the request via the shared combinator, keeping the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,310 +1,104 @@
 # Observability & Analytics Guide
 
-<https://loggingsucks.com/>
+Further reading: <https://loggingsucks.com/> and [All you need is wide events](https://isburmistrov.substack.com/p/all-you-need-is-wide-events-not-metrics).
 
 Practical observability for a small team building a CRM. Focus on what helps you ship faster and debug production issues.
 
-## The Three Pillars
+This guide holds the **rules and the reasons**. It deliberately does not mirror the code: file names and function signatures drift, so where something is implemented is a pointer, not a copy.
 
-| Pillar      | What It Captures             | When to Use                                        | Example                                           |
-| ----------- | ---------------------------- | -------------------------------------------------- | ------------------------------------------------- |
-| **Logs**    | Discrete events with context | Always - primary debugging tool                    | `company:abc status changed prospect → contacted` |
-| **Metrics** | Aggregated numbers over time | When you need dashboards or alerts                 | `interactions_total{channel="email"}: 47`         |
-| **Traces**  | Request flow across services | When debugging slow/failing multi-service requests | `API → email service → webhook fan-out (234ms)`   |
+## One record per unit of work
 
-## Pillar 1: Structured Logging
-
-**This is your foundation.** Good logs make metrics and traces optional for MVP.
+The unit of observability is **one wide record per piece of work** — carrying every fact known about it on a single line.
 
-### Log Levels
-
-| Level   | When to Use                     | Example                            |
-| ------- | ------------------------------- | ---------------------------------- |
-| `error` | Something failed that shouldn't | Webhook delivery failed            |
-| `warn`  | Degraded but working            | Resend API key not set             |
-| `info`  | Business events worth tracking  | Interaction logged, page published |
-| `debug` | Development details             | SQL query executed, cache hit/miss |
-
-### Required Context Fields
-
-Every log entry should include:
+Two kinds of work open a record today: an **HTTP request**, closed by `http.request` / `http.server_error` / `http.defect`, and a **research run**, closed by `research.run` with what it spent split by model, provider and kind of work. A run is not part of any request — it keeps working on a forked fiber long after the request that asked for it returned — so it opens a record of its own rather than borrowing one.
 
-```typescript
-{
-  // WHO
-  companyId: "uuid",            // Which company (if known)
+Everything else is a view over those records:
 
-  // WHAT
-  event: "interaction.logged",  // Dot-notation event name
+| View        | What it really is                                       |
+| ----------- | ------------------------------------------------------- |
+| **Logs**    | The records themselves                                  |
+| **Traces**  | Records that carry a trace id, parent id and a duration |
+| **Metrics** | Records counted up at query time                        |
 
-  // WHERE
-  service: "server",            // server | internal
+The reason to keep them together is that **a question can only be answered from facts that share a line**. "How long did it take, split by how the caller signed in" needs the duration and the sign-in method on the same record. If the duration is on one line and the sign-in method on another, both facts were written down and the question is still unanswerable.
 
-  // WHEN
-  timestamp: "ISO-8601",        // Automatic in most loggers
-
-  // HOW
-  traceId: "uuid",              // Request correlation ID
-}
-```
-
-### Event Naming Convention
-
-Use dot-notation for consistent filtering:
+So the rule is: when work learns something, it puts that fact on the work's record rather than on a line of its own.
 
-```
-{domain}.{action}[.{result}]
-```
+### What every record carries
 
-**Examples:**
+| Field               | Why                                               |
+| ------------------- | ------------------------------------------------- |
+| `request.id`        | Ties everything from one request together         |
+| `event`             | Dot-notation name, so records filter by kind      |
+| `http.path_pattern` | The route, with ids collapsed — never the raw URL |
+| `org.id`            | Which tenant, once resolved                       |
+| `service`           | Which process emitted it                          |
 
-| Event                    | Description                      |
-| ------------------------ | -------------------------------- |
-| `company.created`        | New company added to CRM         |
-| `company.status_changed` | Pipeline status transition       |
-| `interaction.logged`     | Interaction recorded             |
-| `document.created`       | Research/notes document added    |
-| `email.sent`             | Outbound email via Resend        |
-| `email.received`         | Inbound reply via Resend webhook |
-| `email.failed`           | Email delivery failed            |
-| `webhook.fired`          | Webhook fan-out triggered        |
-| `webhook.failed`         | Webhook delivery failed          |
-| `page.published`         | Sales page made public           |
-| `page.viewed`            | Prospect viewed a sales page     |
-| `task.completed`         | CRM task marked done             |
-| `proposal.sent`          | Proposal delivered to prospect   |
-| `mcp.tool_called`        | MCP tool invoked by agent        |
+Timestamps and trace ids are added by the framework.
 
-### Structured Log Examples
+### Event names
 
-**Good - Structured with context:**
+`{domain}.{action}[.{result}]` — so a filter on one prefix gets a whole area.
 
-```typescript
-logger.info({
-  event: "interaction.logged",
-  companyId: "abc-123",
-  channel: "visit",
-  direction: "outbound",
-  outcome: "interested",
-  latencyMs: 45,
-})
-```
+| Event                    | Description                                 |
+| ------------------------ | ------------------------------------------- |
+| `http.request`           | A request completed                         |
+| `http.server_error`      | A request ended 5xx                         |
+| `http.defect`            | A request died without producing a response |
+| `company.created`        | New company added to CRM                    |
+| `company.status_changed` | Pipeline status transition                  |
+| `interaction.logged`     | Interaction recorded                        |
+| `document.created`       | Research/notes document added               |
+| `email.sent`             | Outbound email                              |
+| `email.received`         | Inbound reply                               |
+| `email.failed`           | Email delivery failed                       |
+| `webhook.fired`          | Webhook fan-out triggered                   |
+| `webhook.failed`         | Webhook delivery failed                     |
+| `page.published`         | Sales page made public                      |
+| `page.viewed`            | Prospect viewed a sales page                |
+| `task.created`           | CRM task raised                             |
+| `research.run`           | A research run finished, with what it spent |
+| `mcp.tool_called`        | MCP tool invoked by agent                   |
+| `mcp.auth.rejected`      | An MCP call was refused, and why            |
 
-**Bad - Unstructured string:**
+A request leaves exactly one of `http.request`, `http.server_error` or `http.defect`, so "every request that ended badly" is those last two.
 
-```typescript
-logger.info("Logged visit interaction for company abc-123, outcome interested in 45ms")
-```
+### Levels
 
-### Effect Logging
+| Level   | When to Use                     |
+| ------- | ------------------------------- |
+| `error` | Something failed that shouldn't |
+| `warn`  | Degraded but working            |
+| `info`  | Business events worth tracking  |
+| `debug` | Development details             |
 
-The project uses Effect's built-in logging. Key patterns:
+`MIN_LOG_LEVEL` sets the floor per process. In production it comes from `config.production.json`, which is copied into the image — so changing it means a rebuild and a redeploy, not a live switch. Worth knowing before an incident, when the instinct is to turn the detail up and read more.
 
-```typescript
-import { Effect } from "effect"
+## Counters: the narrow exception
 
-// Simple info log
-Effect.log("Company created")
+A counter is a running total. Bumping one throws away everything about the thing being counted, which is why almost nothing here is a counter.
 
-// With annotations (adds context to all logs in scope)
-Effect.logInfo("Interaction logged").pipe(
-  Effect.annotateLogs({
-    companyId: company.id,
-    channel: "email",
-    direction: "outbound",
-  })
-)
+**The rule:** a counter may carry only tags with a handful of possible values. The store keeps a separate total for every combination of tags, so tagging by organization, run or query grows without limit. Anything per-tenant or per-request belongs on a record or in the database instead.
 
-// Error with cause
-Effect.logError("Webhook delivery failed").pipe(
-  Effect.annotateLogs({ endpointUrl: endpoint.url, error: error.message })
-)
+In practice that leaves counters for money — tokens and spend, where a running total is exactly the question — and nothing else. Business questions ("how many companies did we add?") are answered by counting records at query time, and by the database, which is the real source of truth for business facts anyway.
 
-// Duration tracking with log spans
-Effect.logInfo("Webhook fan-out complete").pipe(
-  Effect.withLogSpan("webhook-fanout")
-)
-```
+Do not add a counter speculatively. A counter added "so we have the number later" is a dimension deleted in advance.
 
-### Logger Configuration
+## How much to keep
 
-Effect v4 provides structured logger formatters:
+Records are cheap and detail is expensive, so the two are thinned differently.
 
-```typescript
-import { Logger } from "effect"
+- **Every unit of work keeps its record.** One line per request is small and it is the thing you search. Never sample these away.
+- **Except a poll that went fine.** A successful `/health` check and a successful permission check (the `OPTIONS` a browser sends before a cross-origin call) drop to `debug`, so they are gone at the production level. Between them they can outnumber the requests a person actually made, and they say only that the poller is still polling. A failing one stays at its usual level — that is the moment they exist for.
+- **Traces can be thinned.** `OTEL_TRACES_KEEP_RATE` (0..1, default 1) keeps a share of traces. The decision is made once, when the trace starts, and every span below inherits it — so a trace is kept or dropped whole, never half-exported.
 
-// Structured JSON output (recommended for production)
-Logger.formatStructured
+Because the decision happens at the start, it cannot preferentially keep the traces that went on to fail. Keeping every failure means holding spans until the work ends and deciding then, which is a job for a collector in front of the vendor, not for the app. Until traffic justifies that, keep everything.
 
-// Batched logging (reduces I/O)
-Logger.batched(Logger.formatStructured, {
-  window: "1 second",
-  flush: Effect.fn(function*(batch) {
-    // Send batch to log aggregator
-  })
-})
+Routes whose URL itself carries a secret are exempt from tracing entirely rather than sampled — see Privacy.
 
-// Pretty output for development
-Logger.consolePretty()
-```
+## What to track
 
-## Pillar 2: Metrics
-
-**Add metrics when you need to answer aggregate questions.** Don't add metrics speculatively.
-
-### When to Add a Metric
-
-| Question Type           | Metric Type | Example                        |
-| ----------------------- | ----------- | ------------------------------ |
-| "How many X happened?"  | Counter     | `interactions_total`           |
-| "What's the current X?" | Gauge       | `pipeline_companies_by_status` |
-| "How long does X take?" | Histogram   | `api_request_duration_seconds` |
-
-### MVP Metrics (Start Here)
-
-Only track what directly impacts product success:
-
-**Business Metrics (most important):**
-
-| Metric               | Type    | Labels                 | Why                          |
-| -------------------- | ------- | ---------------------- | ---------------------------- |
-| `companies_total`    | Counter | `source`, `status`     | Are we adding prospects?     |
-| `interactions_total` | Counter | `channel`, `direction` | Are we engaging?             |
-| `pages_published`    | Counter | `lang`                 | Are we creating sales pages? |
-| `emails_total`       | Counter | `direction`, `status`  | Email activity               |
-
-**System Health:**
-
-| Metric                         | Type      | Labels               | Why                |
-| ------------------------------ | --------- | -------------------- | ------------------ |
-| `api_request_duration_seconds` | Histogram | `endpoint`, `status` | API performance    |
-| `webhook_delivery_total`       | Counter   | `event`, `status`    | Webhook health     |
-| `mcp_tool_duration_seconds`    | Histogram | `tool`               | MCP responsiveness |
-
-### Metric Naming Convention
-
-Follow Prometheus conventions:
-
-```
-{namespace}_{name}_{unit}
-```
-
-**Examples:**
-
-- `batuda_interactions_total`
-- `batuda_api_request_duration_seconds`
-- `batuda_webhook_delivery_total`
-
-### Implementation Options
-
-**Option 1: Log-based metrics (MVP recommended)**
-
-Extract metrics from structured logs using your log aggregator (Loki, CloudWatch, etc.):
-
-```
-count_over_time({event="interaction.logged"}[1h])
-```
-
-Pros: No additional code, single source of truth
-Cons: Less efficient for high-cardinality queries
-
-**Option 2: Native metrics (when needed)**
-
-Use Effect's Metrics module:
-
-```typescript
-import { Metric } from "effect"
-
-const interactionsLogged = Metric.counter("interactions_total", {
-  description: "Total interactions logged"
-})
-
-// Record a value
-Effect.succeed(interaction).pipe(
-  Effect.tap(() => Metric.update(interactionsLogged, 1))
-)
-
-// With attributes (labels)
-const emailsSent = Metric.counter("emails_total")
-yield* Metric.update(
-  Metric.withAttributes(emailsSent, {
-    direction: "outbound",
-    status: "sent",
-  }),
-  1
-)
-
-// Histogram for latency
-const apiLatency = Metric.histogram("api_request_duration_seconds", {
-  description: "API request duration",
-  boundaries: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5]
-})
-
-// Prometheus export
-import { PrometheusMetrics } from "effect/unstable/observability"
-const formatted = yield* PrometheusMetrics.format({ prefix: "batuda" })
-```
-
-## Pillar 3: Distributed Tracing
-
-**For MVP, correlation IDs in logs are usually sufficient.** Add full tracing when:
-
-- Requests regularly span 3+ services
-- You can't debug performance issues with logs alone
-- You need flame graphs for optimization
-
-### Correlation IDs (MVP Approach)
-
-Pass a `traceId` through the entire request:
-
-```typescript
-// API receives request
-const traceId = crypto.randomUUID()
-
-// Pass through Effect context
-Effect.provideService(TraceId, traceId)
-
-// All logs include traceId
-logger.info({ traceId, event: "company.created" })
-```
-
-This lets you grep all logs for a single request:
-
-```bash
-grep "traceId=abc-123" logs.json
-```
-
-### Effect Spans (Built-in Tracing)
-
-Effect has built-in span support. Use `Effect.withSpan` to create named spans:
-
-```typescript
-const processWebhook = Effect.fn("Webhooks.process")(function*(event, payload) {
-  yield* Effect.logInfo("Processing webhook")
-
-  yield* deliverToEndpoints(payload).pipe(
-    Effect.withSpan("webhook.deliver"),
-    Effect.annotateSpans({
-      "webhook.event": event,
-      "webhook.endpoint_count": endpoints.length,
-    })
-  )
-})
-```
-
-Spans nest automatically — child spans inherit parent context. Use `Effect.currentSpan` to access the active span for adding attributes mid-flight.
-
-### Full Tracing (Later)
-
-When you need it, Effect v4 has built-in OTLP export (see Implementation Details):
-
-- **Honeycomb** — excellent for wide events and exploration
-- **Jaeger/Zipkin** — open source trace visualization
-- **Grafana Tempo** — integrates with Loki and Prometheus
-
-## What to Track: Batuda-Specific
-
-### Critical Paths to Instrument
+### Critical paths
 
 | Flow                     | Key Events                             | Why Critical               |
 | ------------------------ | -------------------------------------- | -------------------------- |
@@ -314,28 +108,13 @@ When you need it, Effect v4 has built-in OTLP export (see Implementation Details
 | **Email Inbound**        | `email.received`, `interaction.logged` | Reply tracking             |
 | **Webhook Fan-out**      | `webhook.fired`, `webhook.failed`      | Integration reliability    |
 | **Page Publishing**      | `page.published`, `page.viewed`        | Sales page effectiveness   |
-| **MCP Tool Calls**       | `mcp.tool_called`                      | Agent workflow reliability |
+| **MCP Tool Calls**       | `mcp.tool_called`, `mcp.auth.rejected` | Agent workflow reliability |
 
-### Error Tracking
+### Errors
 
-Track every error with enough context to debug:
+Every error carries enough context to debug without reproducing it: what was being looked up, on which route, for which tenant, and the full cause with its stack. An error whose record says only that something failed costs a reproduction.
 
-```typescript
-Effect.logError("Webhook delivery failed").pipe(
-  Effect.annotateLogs({
-    event: "webhook.failed",
-    endpointId: endpoint.id,
-    endpointUrl: endpoint.url,
-    webhookEvent: "company.status_changed",
-    httpStatus: response.status,
-    retryCount: 2,
-  })
-)
-```
-
-### Performance Tracking
-
-Track latency for user-facing operations:
+### Performance targets
 
 | Operation          | Target      | Alert Threshold |
 | ------------------ | ----------- | --------------- |
@@ -345,29 +124,9 @@ Track latency for user-facing operations:
 | Webhook delivery   | < 1s p95    | > 5s            |
 | Page render (SSR)  | < 300ms p95 | > 1s            |
 
-## Alerting Strategy
+## Monitoring philosophy: the four golden signals
 
-**Start with few, high-signal alerts.** Alert fatigue is worse than no alerts.
-
-### MVP Alerts (5 maximum)
-
-| Alert                | Condition                             | Severity |
-| -------------------- | ------------------------------------- | -------- |
-| **API Down**         | Health check fails for > 2 min        | Critical |
-| **High Error Rate**  | > 10% API 5xx responses in 15 min     | High     |
-| **Email Failures**   | > 5 consecutive email send failures   | High     |
-| **Webhook Failures** | > 20% webhook 5xx responses in 15 min | High     |
-
-### Alert Design Principles
-
-1. **Alert on symptoms, not causes** — "API returning errors" > "Database connection failed"
-2. **Include runbook link** — What to do when this fires
-3. **Test your alerts** — Trigger them intentionally
-4. **Review monthly** — Delete alerts that never fire or always fire
-
-## Monitoring Philosophy: The Four Golden Signals
-
-Follow Google's **Four Golden Signals** from the [Site Reliability Engineering](https://sre.google/sre-book/monitoring-distributed-systems/) book. These are the minimum signals you need to know if a system is healthy:
+Follow Google's **Four Golden Signals** from the [Site Reliability Engineering](https://sre.google/sre-book/monitoring-distributed-systems/) book — the minimum set that says whether a system is healthy:
 
 | Signal         | Question                 | Batuda Example                                    |
 | -------------- | ------------------------ | ------------------------------------------------- |
@@ -376,14 +135,7 @@ Follow Google's **Four Golden Signals** from the [Site Reliability Engineering](
 | **Latency**    | Is it fast enough?       | API P95, MCP tool duration, SSR render time       |
 | **Saturation** | Is anything at capacity? | Effect fiber health (proxy for resource pressure) |
 
-### Why Four Signals, Not Dozens of Graphs
-
-As a small team, you don't have an on-call rotation or a war room. You need boards that answer two questions:
-
-1. **"Is everything working?"** → Key Metrics board (daily glance)
-2. **"What exactly is broken?"** → Deep Dive board (investigation)
-
-The Key Metrics board maps directly to the Four Golden Signals. If a signal looks wrong, drill into the Deep Dive board which breaks down by product layer (pipeline, interactions, email), infrastructure layer (webhooks, MCP, DB), and runtime (Effect fibers, logs).
+As a solo operation there is no on-call rotation or war room. Two questions matter: *"is everything working?"* (a daily glance) and *"what exactly is broken?"* (an investigation). The golden signals answer the first. The second is answered by filtering and grouping records, not by a board built in advance — a board can only show the question someone already thought to ask.
 
 ### Targets
 
@@ -393,87 +145,27 @@ The Key Metrics board maps directly to the Four Golden Signals. If a signal look
 | Error rate      | < 1%    | Expect occasional webhook endpoint failures    |
 | Email success   | > 95%   | Invalid addresses are expected, not failures   |
 
-## Analytics vs Observability
+## Alerting
 
-| Aspect        | Observability           | Analytics                       |
-| ------------- | ----------------------- | ------------------------------- |
-| **Purpose**   | Debug production issues | Understand user behavior        |
-| **Audience**  | Engineers               | Product/Business                |
-| **Latency**   | Real-time               | Can be delayed                  |
-| **Retention** | Days to weeks           | Months to years                 |
-| **Examples**  | Error rates, latency    | Pipeline conversion, page views |
+**Start with few, high-signal alerts.** Alert fatigue is worse than no alerts.
 
-### Product Analytics (Separate Concern)
+| Alert                | Condition                             | Severity |
+| -------------------- | ------------------------------------- | -------- |
+| **API Down**         | Health check fails for > 2 min        | Critical |
+| **High Error Rate**  | > 10% API 5xx responses in 15 min     | High     |
+| **Email Failures**   | > 5 consecutive email send failures   | High     |
+| **Webhook Failures** | > 20% webhook 5xx responses in 15 min | High     |
 
-For business behavior tracking, consider dedicated tools:
+1. **Alert on symptoms, not causes** — "API returning errors" > "Database connection failed"
+2. **Include runbook link** — What to do when this fires
+3. **Test your alerts** — Trigger them intentionally
+4. **Review monthly** — Delete alerts that never fire or always fire
 
-| Tool          | Use Case                     | Cost               |
-| ------------- | ---------------------------- | ------------------ |
-| **PostHog**   | Full-featured, self-hostable | Free tier, then $$ |
-| **Plausible** | Privacy-focused, simple      | $9/mo              |
-| **Custom**    | Log events, query later      | Free (your time)   |
+## Privacy in observability
 
-**MVP recommendation:** Start with structured logs. Extract analytics later.
+This is a CRM holding other people's customer data, so what never gets written down is a hard rule rather than a preference. The trade is real: a problem can only be found in facts that were kept. The answer is to record **more harmless** facts — plan tier, feature flag, provider, model, retry count, cache hit — not more personal ones.
 
-## Tool Recommendations
-
-### Small Team, Low Budget
-
-| Need                | Recommendation       | Why                              |
-| ------------------- | -------------------- | -------------------------------- |
-| **Log aggregation** | Loki + Grafana       | Free, powerful, good with Effect |
-| **Metrics**         | Log-based initially  | No additional infra              |
-| **Alerting**        | Grafana alerts       | Integrated with logs             |
-| **Error tracking**  | Sentry (free tier)   | Great DX, source maps            |
-| **Uptime**          | Better Uptime (free) | Simple, reliable                 |
-
-### Hosting Options
-
-| Provider          | Logs     | Metrics    | Alerts  | Cost               |
-| ----------------- | -------- | ---------- | ------- | ------------------ |
-| **Grafana Cloud** | Loki     | Prometheus | Yes     | Free tier generous |
-| **Honeycomb**     | Built-in | Built-in   | Yes     | Free tier generous |
-| **Self-hosted**   | Loki     | Prometheus | Grafana | Your infra         |
-
-## Quick Reference
-
-### Log This
-
-```typescript
-// Business events
-Effect.logInfo("Company created").pipe(
-  Effect.annotateLogs({ companyId, source: "firecrawl", slug })
-)
-
-// Interactions
-Effect.logInfo("Interaction logged").pipe(
-  Effect.annotateLogs({ companyId, channel: "visit", direction: "outbound", outcome: "interested" })
-)
-
-// Errors (always with context)
-Effect.logError("Email send failed").pipe(
-  Effect.annotateLogs({
-    companyId,
-    contactEmail: email.slice(0, 3) + "***", // Partial only
-    error: error.message,
-    resendErrorCode: code,
-  })
-)
-```
-
-### Don't Log This
-
-- API keys, tokens, or secrets
-- Full email addresses (partial or use contactId)
-- Document content (only type and length)
-- Database credentials
-- Full webhook secrets (use endpointId)
-- High-frequency debug logs in production
-- Success logs for every DB query
-
-## Privacy in Observability
-
-### What We Collect
+### What we collect
 
 | Data Type             | Collected | Purpose                          |
 | --------------------- | --------- | -------------------------------- |
@@ -486,40 +178,52 @@ Effect.logError("Email send failed").pipe(
 | Document content      | **No**    | Business data                    |
 | Page content          | **No**    | Business data                    |
 
-### Safe Logging Patterns
+### Never record
 
-**Good - Privacy preserved:**
+- API keys, tokens, or secrets
+- Full email addresses (use contactId, or the domain alone)
+- Document, page or message content (only type and length)
+- Database credentials
+- Full webhook secrets (use endpointId)
+
+### Three rules that are easy to get wrong
+
+**Raw URLs never get recorded.** A URL can carry a single-use secret — a magic-link token in the query, a reset-password token in the path. Records carry a sanitized route with ids collapsed instead. Routes whose URL is itself a credential are exempt from tracing altogether, because the tracer records the full URL unredacted (headers like `authorization` and `cookie` are redacted by default; the URL is not).
+
+**Whole argument bags are scrubbed, not the fields that look sensitive.** Tool-call arguments are recorded verbatim by the AI toolkit and include mailbox passwords and whole attached files. Any list of sensitive-looking field names holds only until someone adds a field nobody thought to name — and that field would be secret exactly when it mattered. So the whole value goes, and anything worth tracing gets its own deliberate attribute.
+
+**Scrubbing happens centrally, on the way out — on both routes out.** The recording happens inside third-party libraries, so it is caught centrally rather than at each call site. There are two ways out of the process, and both are filtered: span attributes, via the wrapped tracer, and facts gathered onto a record, which leave on a log line instead. Filtering only the first would leave the second as a way around it.
+
+**Error text is the one accepted exception.** A crash's cause is the most useful thing it leaves behind, so it is logged in full rather than summarised — and a database error can name business data incidentally, in a failing statement or a constraint violation. The cause is bounded in size so a failure cannot ship a whole payload, but not in content. This is why observability retention is days-to-weeks rather than months.
+
+### Safe patterns
 
 ```typescript
 // Metadata instead of content
-span.attribute('document.type', 'research')
-span.attribute('document.content_length', content.length)
+{ 'document.type': 'research', 'document.content_length': content.length }
 
-// Partial email for debugging
-span.attribute('contact.email_domain', email.split('@')[1])
+// Domain instead of address
+{ 'contact.email_domain': domain }
 
-// Company by ID, not name
-Effect.annotateLogs({ companyId: company.id })
+// Tenant by id, never by name
+{ 'org.id': org.id }
 ```
 
-**Bad - Business data exposed:**
+## Analytics vs observability
 
-```typescript
-// NO: Company details in logs
-span.attribute('company.name', company.name)
+| Aspect        | Observability           | Analytics                       |
+| ------------- | ----------------------- | ------------------------------- |
+| **Purpose**   | Debug production issues | Understand user behavior        |
+| **Audience**  | Engineers               | Product/Business                |
+| **Latency**   | Real-time               | Can be delayed                  |
+| **Retention** | Days to weeks           | Months to years                 |
+| **Examples**  | Error rates, latency    | Pipeline conversion, page views |
 
-// NO: Full email
-span.attribute('contact.email', contact.email)
-
-// NO: Document content
-span.attribute('document.content', content)
-```
+For business behaviour, the database is the source of truth, not the telemetry. Records are for debugging what the system did; the CRM tables are for what the business did. If a product question needs a dedicated tool later, PostHog (self-hostable) or Plausible (privacy-focused) are the candidates.
 
 ## Local development with otel-tui
 
 The Nix flake provides [`otel-tui`](https://github.com/ymtdzzz/otel-tui) — a terminal OpenTelemetry receiver + viewer. It listens on the standard OTLP ports (`:4317` gRPC, `:4318` HTTP/JSON) and renders traces, logs, and metrics inline, so you can inspect them without running Jaeger/Grafana/Honeycomb locally.
-
-**Daily workflow:**
 
 ```bash
 # Terminal 1 — start the viewer (empty until traffic arrives)
@@ -529,7 +233,7 @@ pnpm dev:otel
 pnpm dev:server
 ```
 
-Effect's `Otlp.layerJson` appends `/v1/traces`, `/v1/logs`, and `/v1/metrics` to the base URL — the same convention otel-tui and every vendor (Honeycomb, Grafana, Tempo) expect. Swapping environments is a pure env-var change:
+Swapping environments is a pure env-var change:
 
 | Environment      | `OTEL_EXPORTER_OTLP_ENDPOINT`               | `OTEL_EXPORTER_OTLP_HEADERS` |
 | ---------------- | ------------------------------------------- | ---------------------------- |
@@ -537,137 +241,54 @@ Effect's `Otlp.layerJson` appends `/v1/traces`, `/v1/logs`, and `/v1/metrics` to
 | Honeycomb        | `https://api.honeycomb.io`                  | `x-honeycomb-team=KEY`       |
 | Grafana Cloud    | `https://otlp-gateway-....grafana.net/otlp` | `Authorization=Basic ...`    |
 
-## Implementation Details
+## Configuration
 
-### Shared OTLP layer: `@batuda/observability`
+| Variable                      | Meaning                                                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base URL. **Also the on/off switch** — unset means no export at all.                                          |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | Comma-separated `key=value`. Carries the vendor key, so it's a secret.                                        |
+| `OTEL_TRACES_KEEP_RATE`       | Share of traces to keep, 0..1. Default 1. An unusable value falls back to 1 rather than stopping the process. |
+| `MIN_LOG_LEVEL`               | Level floor per process.                                                                                      |
+| `SERVICE_VERSION`             | CalVer version, injected by CI.                                                                               |
+| `GIT_SHA`                     | Full commit SHA; short SHA derived at runtime.                                                                |
+| `REGION`                      | Deployment region.                                                                                            |
 
-Both processes (server, mail-worker) export through one tiny workspace package, `packages/observability`. It owns the build metadata (version/commit/region read from `process.env`) and a per-process exporter factory, `makeOtlpObservability({ serviceName })`. Effect v4 ships OTLP in `effect/unstable/observability` — no separate `@effect/opentelemetry` package, and the HTTP client comes from `effect/unstable/http`, not `@effect/platform`.
+The endpoint is non-secret, so it lives in each app's `config.production.json` alongside the other endpoints — not a CI secret. It is deliberately left out until a vendor is set up, so export stays dark by default.
 
-```typescript
-// packages/observability/src/otlp.ts (shape — see the file for the full version)
-import { Config, Duration, Effect, Layer } from "effect"
-import { FetchHttpClient } from "effect/unstable/http"
-import { Otlp } from "effect/unstable/observability"
-import { buildMeta } from "./build-meta"
+**Per-service datasets.** Traces route to a Honeycomb dataset named after `service.name`, so each process separates on its own. Logs and metrics route by the `x-honeycomb-dataset` header instead, so each deploy workflow appends its own dataset name to the shared team-key secret. One environment-scoped API key covers every process.
 
-export const makeOtlpObservability = (options: { readonly serviceName: string }) =>
-  Layer.unwrap(
-    Effect.gen(function* () {
-      const baseUrl = yield* Config.string("OTEL_EXPORTER_OTLP_ENDPOINT").pipe(Config.withDefault(""))
-      const headersRaw = yield* Config.string("OTEL_EXPORTER_OTLP_HEADERS").pipe(Config.withDefault(""))
-      const environment = yield* Config.string("NODE_ENV")
-      // The endpoint is the on/off switch: no endpoint → no export (local dev).
-      if (!baseUrl) return Layer.empty
-      return Otlp.layerJson({
-        baseUrl,
-        resource: {
-          serviceName: options.serviceName, // batuda-server | batuda-mail-worker
-          serviceVersion: buildMeta.version,
-          attributes: {
-            "deployment.environment": environment,
-            "deployment.id": `${buildMeta.version}-${buildMeta.commitShort}`,
-            "vcs.revision": buildMeta.commit,
-            "cloud.region": buildMeta.region,
-          },
-        },
-        headers: parseOtlpHeaders(headersRaw),
-        tracerExportInterval: Duration.seconds(5),
-        loggerExportInterval: Duration.seconds(1),
-        metricsExportInterval: Duration.seconds(60),
-        metricsTemporality: "cumulative",
-      }).pipe(Layer.provide(FetchHttpClient.layer))
-    }),
-  )
-```
+Note the consequence: logs and traces from the same request land in different datasets. That is the vendor's routing, not a choice — it is why the per-request record has to be self-sufficient rather than something you assemble by joining a log to a trace.
 
-`Otlp.layerJson` registers a tracer, a metrics reader, AND an OTLP logger; the logger's `mergeWithExisting` defaults to `true`, so it adds to whatever console logger the process already has rather than replacing it. The server provides it in `apps/server/src/lib/observability.ts` (`serviceName: 'batuda-server'`); the mail-worker provides it around its `Live` layer in `apps/mail-worker/src/main.ts` (`serviceName: 'batuda-mail-worker'`).
+## Health endpoint
 
-**Configuration:**
+`/health` returns build metadata for uptime checks and deploy verification: CalVer version, short commit SHA, region.
 
-- `OTEL_EXPORTER_OTLP_ENDPOINT` — OTLP endpoint base URL (`https://api.honeycomb.io`). Non-secret, so it lives in each app's `config.production.json` alongside the other endpoints (`STORAGE_ENDPOINT`, the LLM base URLs) — NOT a CI secret. **It is also the on/off switch**: unset → export disabled. It is deliberately left OUT of `config.production.json` until Honeycomb is set up, so OTLP stays dark by default; adding the one line (plus the secret below) is what turns it on. Locally it comes from `.env` (`http://localhost:4318` for otel-tui).
-- `OTEL_EXPORTER_OTLP_HEADERS` — comma-separated `key=value` pairs. This DOES carry a secret (the Honeycomb team key), so it stays a CI secret holding the team key only (`x-honeycomb-team=KEY`); each deploy workflow appends its own non-secret `,x-honeycomb-dataset=…` (see below).
-- `SERVICE_VERSION` — CalVer version (injected by CI)
-- `GIT_SHA` — full commit SHA (short SHA derived at runtime)
-- `REGION` — Unikraft metro / deployment region
+**Security note:** only those. No framework or dependency versions, no internal paths, no stack traces. It is also exempt from tracing — an uptime checker polls it constantly and would drown the real traces.
 
-**Per-service datasets + the metrics-routing gotcha.** Traces auto-route to a Honeycomb dataset named after the resource `service.name`, so `batuda-server` and `batuda-mail-worker` separate on their own. Logs and metrics, however, route by the `x-honeycomb-dataset` header — so each deploy workflow appends `x-honeycomb-dataset=batuda-server` / `batuda-mail-worker` to the shared team-key secret. One Honeycomb API key (environment-scoped) is enough for both.
+## Where this lives in the code
 
-### Catch-all error logging + request tracing
+Pointers, not copies — read the files for detail.
 
-`apps/server/src/lib/observability-middleware.ts` (`ObservabilityLive`) is a global router middleware — attached in `AppLive` exactly like `CorsLive`. Per request it annotates the span and logs with `request.id` (reusing an upstream `x-request-id` when present), `http.method`, and `http.path_pattern` (UUIDs → `:id`, query/fragment dropped so a token in `?code=…` never lands in a span or log). It then logs the **full cause** of any defect (`Effect.tapCause`) or 5xx response at error level — the last line of defence so no API error escapes unlogged. `OrgMiddleware` adds `org.id` to the same span once the org resolves.
+| Concern                                                       | Where                                              |
+| ------------------------------------------------------------- | -------------------------------------------------- |
+| Shared exporter, sampling, span scrubbing                     | `packages/observability`                           |
+| Per-request record, route sanitizing, catch-all error logging | `apps/server/src/lib/observability-middleware.ts`  |
+| Logger set and level                                          | `apps/server/src/lib/logger.ts`                    |
+| Tracing exemptions for secret-carrying routes                 | `apps/server/src/main.ts`                          |
+| Spend counters                                                | `packages/research/src/application/usage-meter.ts` |
 
-`HttpMiddleware.tracer` is added to the `serve` chain in `apps/server/src/main.ts` so every request gets a span (Effect's `serve` adds only the request logger by default). A `TracerDisabledWhen` predicate exempts a few routes: `/health` (the uptime checker polls it constantly and would drown the real traces) and the routes whose URL itself carries a secret — magic-link verify (token in the query) and reset-password (token in the path). This matters because the tracer records `url.full`/`url.query` **unredacted** (header values like `authorization`/`cookie`/`x-api-key` are redacted by default, but the URL is not), so tracing those routes would export a single-use token to Honeycomb.
+Three structural notes worth knowing before changing any of it:
 
-### Better Auth error bridge
+**Effect's annotations flow downward, not upward.** An annotation set at the edge reaches every log written inside the request, which is why request id and route ride along for free. But a fact learned deep inside does *not* flow back out to the closing line — that is what the work record exists for.
 
-Better Auth runs its callbacks outside the Effect fiber, so its internal errors (adapter failures, OAuth/OIDC) would be console-only. `apps/server/src/lib/auth.ts` captures the layer's services and forwards Better Auth's `logger.log` (warn+error) and `onAPIError.onError` onto that runtime via `Effect.runForkWith`, so they export through OTLP like every other log.
+**The built-in request logger is deliberately disabled.** It annotates the raw request URL, which would export magic-link and reset tokens verbatim. The middleware emits a sanitized completion line in its place. Re-enabling it would reintroduce that leak.
 
-### Auth-sensitive spans (added per-surface, not blanket)
+**Better Auth's errors need a bridge to be seen at all.** Better Auth runs its callbacks outside the Effect fiber, so its internal failures — adapter errors, OAuth/OIDC problems — reach the console and nothing else. They are forwarded onto the Effect runtime deliberately; without that they never export, and an auth outage looks like silence rather than errors.
 
-Per the scoping below, spans are added only where the MCP-drop class of bug needs them, not across every endpoint:
+**Two auth surfaces are instrumented on purpose, not by blanket rule.** The MCP sign-in path and the OAuth token endpoint each carry extra facts because of one bug class: an MCP client shows a refused or expired credential as a silent retry loop, never a visible error. So how the caller signed in, which org they resolved to, and the grant outcome are recorded — enough to tell a dropped connection from a rejected one without reproducing it. Facts elsewhere are added where a question actually needs them, not across every endpoint.
 
-- MCP auth chokepoint (`apps/server/src/mcp/http.ts`) — the request span gets `mcp.auth_method` (`api_key`/`oauth`/`cookie`), `mcp.org_id`, and `mcp.principal_is_agent`. Every 401/403 path also logs a `mcp.auth.rejected` reason.
-- `/auth/oauth2/token` (`apps/server/src/handlers/auth.ts`) — the span gets `auth.token_response_status` (the grant outcome) when the proxied path is the token endpoint.
+**Global middleware order has to be stated, not assumed.** Router-wide middleware wraps a request in reverse registration order, and registration order is layer build order — which `Layer.mergeAll` performs concurrently. Left in a merge list, the observability middleware lands wherever the build happens to put it, and that position can change without anyone editing it.
 
-### Wide Events Pattern
+It has to be outermost, because a middleware that answers a caller itself — the MCP sign-in check refusing a connection — hides everything registered after it. Registered later, the observability middleware would never run for a refusal, and a refused MCP connection would leave no record of the request at all. That is the case an MCP client shows as a silent retry loop rather than a visible error, so it is the one that most needs a record.
 
-Effect spans accumulate context throughout the request lifecycle:
-
-```typescript
-const span = yield* Effect.currentSpan
-span.attribute('company.id', companyId)
-span.attribute('interaction.channel', channel)
-span.attribute('interaction.direction', direction)
-span.event('interaction.logged', DateTime.nowUnsafe(), { outcome: "interested" })
-```
-
-This produces a single rich event with all business context — ideal for exploration in Honeycomb or similar tools.
-
-### Health Endpoint
-
-Add a `/health` endpoint for Unikraft health checks:
-
-| Endpoint  | Purpose                       | Response                                                                |
-| --------- | ----------------------------- | ----------------------------------------------------------------------- |
-| `/health` | Health check + build metadata | `{ message: "OK", version: "1.0.0", commit: "a3b2b23", region: "fra" }` |
-
-**Security note:** Only expose CalVer version (no framework/dependency versions), short commit SHA, and region. No secrets, no internal paths, no stack traces.
-
-### Self-Documenting Errors
-
-The project uses Effect's `TaggedErrorClass` for typed errors:
-
-```typescript
-// apps/server/src/errors.ts
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()('NotFound', {
-  entity: Schema.String,
-  id: Schema.String,
-}) {}
-```
-
-Enrich error logs with enough context to debug without reproduction:
-
-```typescript
-Effect.logError("Company not found").pipe(
-  Effect.annotateLogs({
-    entity: "company",
-    lookupKey: slug,
-    route: "/companies/:slug",
-  })
-)
-```
-
-## Summary
-
-| Priority | Action                       | Effort |
-| -------- | ---------------------------- | ------ |
-| **1**    | Structured logs with context | Low    |
-| **2**    | Health endpoint              | Low    |
-| **3**    | Correlation IDs              | Low    |
-| **4**    | Basic alerts (4 max)         | Medium |
-| **5**    | Log aggregation              | Medium |
-| **6**    | Dashboard                    | Medium |
-| **7**    | Native metrics               | High   |
-| **8**    | Distributed tracing          | High   |
-
-**Remember:** The best observability system is the one you actually use. Start simple, add complexity when you feel pain.
+So it is *provided* to the rest of the app rather than merged alongside it, which states the order as a dependency the build has to respect. The regression guard is the middleware-order test, which drives a real server through a refusing middleware and fails if the two are registered the other way round.

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -4,3 +4,9 @@
 
 export { buildMeta } from './build-meta'
 export { makeOtlpObservability } from './otlp'
+export {
+	makeWorkRecord,
+	recordFacts,
+	WorkRecord,
+	type WorkRecordService,
+} from './work-record'

--- a/packages/observability/src/otlp.ts
+++ b/packages/observability/src/otlp.ts
@@ -4,6 +4,7 @@ import { Otlp } from 'effect/unstable/observability'
 
 import { buildMeta } from './build-meta'
 import { redactingTracer } from './redact-spans'
+import { parseKeepRate, samplingTracer } from './sampling'
 
 /**
  * Parse OTLP headers from the standard comma-separated format.
@@ -32,6 +33,7 @@ const parseOtlpHeaders = (raw: string): Record<string, string> => {
  * Config:
  * - OTEL_EXPORTER_OTLP_ENDPOINT — base URL (e.g. https://api.honeycomb.io)
  * - OTEL_EXPORTER_OTLP_HEADERS — comma-separated key=value pairs
+ * - OTEL_TRACES_KEEP_RATE — share of traces to keep, 0..1 (default 1, keep all)
  * - NODE_ENV — deployment environment attribute
  */
 export const makeOtlpObservability = (options: {
@@ -58,6 +60,12 @@ export const makeOtlpObservability = (options: {
 			const environment = yield* Config.string('NODE_ENV').pipe(
 				Config.withDefault('development'),
 			)
+			// Read as text and parsed by `parseKeepRate`, which explains why: see
+			// there for what an unusable or out-of-range value does.
+			const keepRate = yield* Config.string('OTEL_TRACES_KEEP_RATE').pipe(
+				Config.withDefault('1'),
+				Config.map(parseKeepRate),
+			)
 
 			yield* Effect.logInfo('OTLP export enabled').pipe(
 				Effect.annotateLogs({
@@ -67,13 +75,18 @@ export const makeOtlpObservability = (options: {
 					commit: buildMeta.commitShort,
 					region: buildMeta.region,
 					environment,
+					tracesKeepRate: keepRate,
 				}),
 			)
 
-			// The exporter's own tracer, wrapped, so caller-supplied attributes are
-			// scrubbed on the way out whichever library recorded them.
-			const RedactedTracer = Layer.effect(Tracer.Tracer)(
-				Effect.map(Effect.service(Tracer.Tracer), redactingTracer),
+			// The exporter's own tracer, wrapped twice: sampling decides which traces
+			// are worth sending, redaction scrubs caller-supplied attributes on the
+			// way out whichever library recorded them. Sampling sits outside so it
+			// settles `sampled` before a span is built.
+			const ExportTracer = Layer.effect(Tracer.Tracer)(
+				Effect.map(Effect.service(Tracer.Tracer), inner =>
+					samplingTracer(redactingTracer(inner), keepRate),
+				),
 			)
 
 			return Otlp.layerJson({
@@ -99,7 +112,7 @@ export const makeOtlpObservability = (options: {
 				Layer.provide(FetchHttpClient.layer),
 				// Merged, not provided: the exporter's flusher, logger and metrics
 				// still have to reach the process; only the tracer is swapped.
-				layer => RedactedTracer.pipe(Layer.provideMerge(layer)),
+				layer => ExportTracer.pipe(Layer.provideMerge(layer)),
 			)
 		}),
 	)

--- a/packages/observability/src/redact-spans.test.ts
+++ b/packages/observability/src/redact-spans.test.ts
@@ -6,7 +6,7 @@
 import { Option, type Tracer } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { redactingTracer } from './redact-spans'
+import { redactFacts, redactingTracer } from './redact-spans'
 
 // A tracer that keeps what it was told, so a test can read it back.
 const recordingTracer = () => {
@@ -98,6 +98,52 @@ describe('redactingTracer', () => {
 			expect(recorded.get('tool')).toBe('manage_email_inbox')
 			expect(recorded.get('mcp.org_id')).toBe('org_123')
 			expect(recorded.get('mcp.auth_method')).toBe('api_key')
+		})
+	})
+})
+
+// Wrapping the tracer protects span attributes only. Facts gathered onto a log
+// line leave by a different door, so the same rule has to apply there or the
+// wrapper is a door with a hole beside it.
+describe('redactFacts', () => {
+	describe('when a fact holds whatever a caller sent', () => {
+		it('should replace the whole value', () => {
+			// GIVEN facts carrying the catch-all argument bag
+			const facts = {
+				tool: 'manage_email_inbox',
+				parameters: { email: 'someone@example.com', password: 'hunter2' },
+			}
+
+			// WHEN filtered
+			const safe = redactFacts(facts)
+
+			// THEN nothing of the bag survives, and the deliberate attribute does
+			expect(JSON.stringify(safe)).not.toContain('hunter2')
+			expect(JSON.stringify(safe)).not.toContain('someone@example.com')
+			expect(safe['tool']).toBe('manage_email_inbox')
+		})
+
+		it('should leave the caller their original object', () => {
+			// GIVEN facts the caller may still be using
+			const facts = { parameters: { password: 'hunter2' } }
+
+			// WHEN filtered
+			redactFacts(facts)
+
+			// THEN the input is untouched — filtering returns a copy rather than
+			// reaching back into the caller's object
+			expect(JSON.stringify(facts)).toContain('hunter2')
+		})
+	})
+
+	describe('when no fact needs filtering', () => {
+		it('should hand back the same object rather than a copy', () => {
+			// GIVEN ordinary facts, which is nearly every call
+			const facts = { 'org.id': 'org_1', 'auth.method': 'api_key' }
+
+			// WHEN filtered
+			// THEN the common case costs no copy at all
+			expect(redactFacts(facts)).toBe(facts)
 		})
 	})
 })

--- a/packages/observability/src/redact-spans.ts
+++ b/packages/observability/src/redact-spans.ts
@@ -14,6 +14,27 @@ const OPAQUE_ATTRIBUTES = new Set(['parameters'])
 const REDACTED = '<redacted>'
 
 /**
+ * Applies the same rule to a plain bag of facts, for the paths that do not go
+ * through a span. Wrapping the tracer only protects span attributes, so any
+ * other route out of the process — a fact gathered onto a log line — has to be
+ * filtered here or the wrapper is a door with a hole beside it.
+ *
+ * Returns the original object untouched when nothing matches, so the common case
+ * costs one lookup per key and no copy.
+ */
+export const redactFacts = (
+	facts: Record<string, unknown>,
+): Record<string, unknown> => {
+	let redacted: Record<string, unknown> | undefined
+	for (const key of Object.keys(facts)) {
+		if (!OPAQUE_ATTRIBUTES.has(key)) continue
+		redacted ??= { ...facts }
+		redacted[key] = REDACTED
+	}
+	return redacted ?? facts
+}
+
+/**
  * Wraps a tracer so those attributes are replaced on the way out — the recording
  * happens inside a library, so it is caught here rather than there. Every other
  * attribute passes through untouched.

--- a/packages/observability/src/sampling.test.ts
+++ b/packages/observability/src/sampling.test.ts
@@ -1,0 +1,203 @@
+// Thinning traces is only safe if a trace is kept or dropped whole. These pin
+// that: half a trace exported is worse to read than none of it, and a route
+// exempted for carrying a secret in its URL must never be revived here.
+
+import { Option, type Tracer } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { parseKeepRate, samplingTracer } from './sampling'
+
+// A tracer that keeps the options it was handed, so a test can read the
+// decision back.
+const recordingTracer = () => {
+	const seen: Array<{ sampled: boolean }> = []
+	const tracer = {
+		span: (options: { sampled: boolean }) => {
+			seen.push({ sampled: options.sampled })
+			return { sampled: options.sampled } as unknown as Tracer.Span
+		},
+	} as unknown as Tracer.Tracer
+	return { tracer, seen }
+}
+
+const parentSpan = (sampled: boolean) =>
+	({
+		_tag: 'Span',
+		spanId: 'parent',
+		traceId: 'trace',
+		sampled,
+	}) as unknown as Tracer.AnySpan
+
+const newSpan = (
+	tracer: Tracer.Tracer,
+	options?: {
+		readonly parent?: Tracer.AnySpan
+		readonly root?: boolean
+		readonly sampled?: boolean
+	},
+) =>
+	tracer.span({
+		name: 'test',
+		parent:
+			options?.parent === undefined
+				? Option.none()
+				: Option.some(options.parent),
+		annotations: undefined as never,
+		links: [],
+		startTime: 0n,
+		kind: 'internal',
+		root: options?.root ?? false,
+		sampled: options?.sampled ?? true,
+	})
+
+describe('samplingTracer', () => {
+	describe('when every trace is meant to be kept', () => {
+		it('should keep a trace that starts here', () => {
+			// GIVEN the default keep rate, which changes nothing
+			const { tracer, seen } = recordingTracer()
+
+			// WHEN a trace starts
+			newSpan(samplingTracer(tracer, 1))
+
+			// THEN it is kept
+			expect(seen[0]?.sampled).toBe(true)
+		})
+
+		it('should still drop one something upstream already dropped', () => {
+			// GIVEN a route exempted from tracing because its URL carries a token,
+			// which reaches the tracer already marked as not to be sent
+			const { tracer, seen } = recordingTracer()
+
+			// WHEN it starts a span
+			newSpan(samplingTracer(tracer, 1), { sampled: false })
+
+			// THEN the keep rate does not revive it — the token must not be exported
+			expect(seen[0]?.sampled).toBe(false)
+		})
+	})
+
+	describe('when no trace is meant to be kept', () => {
+		it('should drop a trace that starts here', () => {
+			// GIVEN a keep rate of nothing
+			const { tracer, seen } = recordingTracer()
+
+			// WHEN a trace starts
+			newSpan(samplingTracer(tracer, 0))
+
+			// THEN it is dropped
+			expect(seen[0]?.sampled).toBe(false)
+		})
+	})
+
+	describe('when a span hangs below one already decided', () => {
+		it('should keep a child of a kept trace even at a keep rate of nothing', () => {
+			// GIVEN a trace already being kept
+			const { tracer, seen } = recordingTracer()
+
+			// WHEN a span opens below it, under a rate that would drop a new trace
+			newSpan(samplingTracer(tracer, 0), { parent: parentSpan(true) })
+
+			// THEN it is kept anyway — a kept trace missing its middle reads as a
+			// gap in the work rather than as a span nobody sent
+			expect(seen[0]?.sampled).toBe(true)
+		})
+
+		it('should drop a child of a dropped trace even when keeping everything', () => {
+			// GIVEN a trace already dropped
+			const { tracer, seen } = recordingTracer()
+
+			// WHEN a span opens below it, under a rate that keeps everything
+			newSpan(samplingTracer(tracer, 1), { parent: parentSpan(false) })
+
+			// THEN it is dropped too, so no orphan arrives without its parent
+			expect(seen[0]?.sampled).toBe(false)
+		})
+
+		it('should decide afresh when the span asks to start its own trace', () => {
+			// GIVEN a kept parent in scope, but a span that asks to be a root
+			const { tracer, seen } = recordingTracer()
+
+			// WHEN it opens under a keep rate of nothing
+			newSpan(samplingTracer(tracer, 0), {
+				parent: parentSpan(true),
+				root: true,
+			})
+
+			// THEN it takes its own decision rather than the parent's, because it is
+			// a separate piece of work and not part of that trace
+			expect(seen[0]?.sampled).toBe(false)
+		})
+	})
+
+	describe('when only a share of traces is meant to be kept', () => {
+		it('should keep some and drop some', () => {
+			// GIVEN a rate that keeps half
+			const { tracer, seen } = recordingTracer()
+			const sampling = samplingTracer(tracer, 0.5)
+
+			// WHEN many traces start
+			for (let index = 0; index < 2000; index++) newSpan(sampling)
+
+			// THEN the decision actually varies — an all-or-nothing outcome here
+			// would mean the rate was being ignored
+			const kept = seen.filter(span => span.sampled).length
+			expect(kept).toBeGreaterThan(0)
+			expect(kept).toBeLessThan(seen.length)
+		})
+	})
+})
+
+// The keep rate is read from an env var, so what a typo does matters more than
+// what a correct value does. These pin that nothing unusable can either stop the
+// process or silently switch tracing off.
+describe('parseKeepRate', () => {
+	describe('when the value is usable', () => {
+		it('should keep it as given', () => {
+			// GIVEN a share written properly
+			// WHEN parsed
+			// THEN it is used as-is
+			expect(parseKeepRate('0.25')).toBe(0.25)
+			expect(parseKeepRate('1')).toBe(1)
+			expect(parseKeepRate(' 0.5 ')).toBe(0.5)
+		})
+
+		it('should honour a deliberate zero', () => {
+			// GIVEN someone turning tracing off on purpose
+			// WHEN parsed
+			// THEN it means nothing is kept — this is a real setting, not a typo
+			expect(parseKeepRate('0')).toBe(0)
+		})
+	})
+
+	describe('when the value is out of range', () => {
+		it('should pull it back into range', () => {
+			// GIVEN a share above one or below zero
+			// WHEN parsed
+			// THEN it is clamped rather than refused
+			expect(parseKeepRate('5')).toBe(1)
+			expect(parseKeepRate('-1')).toBe(0)
+		})
+	})
+
+	describe('when the value cannot be used at all', () => {
+		it('should fall back to keeping everything', () => {
+			// GIVEN a typo — a comma decimal, a word, an infinity
+			// WHEN parsed
+			// THEN everything is kept. A knob that only thins traces must never
+			// stop the process, and `Config.number` would fail the whole config
+			expect(parseKeepRate('0,25')).toBe(1)
+			expect(parseKeepRate('half')).toBe(1)
+			expect(parseKeepRate('Infinity')).toBe(1)
+			expect(parseKeepRate('NaN')).toBe(1)
+		})
+
+		it('should treat blank as unset rather than as zero', () => {
+			// GIVEN a var set to nothing, or to spaces
+			// WHEN parsed
+			// THEN everything is kept — `Number('')` is 0, so leaving this to
+			// `Number` would switch tracing off without saying so
+			expect(parseKeepRate('')).toBe(1)
+			expect(parseKeepRate('   ')).toBe(1)
+		})
+	})
+})

--- a/packages/observability/src/sampling.ts
+++ b/packages/observability/src/sampling.ts
@@ -1,0 +1,63 @@
+import { Option, type Tracer } from 'effect'
+
+/**
+ * Turns the configured keep rate into a usable share, 0..1.
+ *
+ * Parsed here rather than with `Config.number` because that fails on anything
+ * unparseable, and a failed config stops the process booting — `withDefault`
+ * only covers a value that is missing, not one that is malformed. A typo in a
+ * knob that merely thins traces must never take the server down, so anything
+ * unusable falls back to keeping everything.
+ *
+ * A blank string is spelled out because `Number('')` is 0, which would switch
+ * tracing off silently — the one outcome a mistyped knob must not cause.
+ */
+export const parseKeepRate = (text: string): number => {
+	const trimmed = text.trim()
+	const value = trimmed === '' ? Number.NaN : Number(trimmed)
+	return Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 1
+}
+
+/**
+ * Wraps a tracer so only a share of traces is kept. `OtlpTracer` drops a span
+ * whose `sampled` is false at export time, so an unsampled trace costs a little
+ * memory and nothing else.
+ *
+ * Only traces thin out — never logs. Every request still writes its one closing
+ * line, so the record of what happened stays complete; what gets thinner is the
+ * tree of detail hanging off it, which is the expensive part.
+ *
+ * The decision is made once, on the span that starts the trace, and every span
+ * below inherits it. Deciding per span would send half a trace and leave the
+ * other half as orphans, which is worse to read than either keeping or dropping
+ * the whole thing.
+ *
+ * This decides at the START of a trace, before the outcome is known, so it
+ * cannot preferentially keep the ones that failed. Keeping every failure means
+ * holding spans until the work ends and deciding then — that is a job for a
+ * collector in front of the vendor, not for this process.
+ */
+export const samplingTracer = (
+	inner: Tracer.Tracer,
+	keepRate: number,
+): Tracer.Tracer => ({
+	...inner,
+	span(options) {
+		const parent = Option.getOrUndefined(options.parent)
+		// `options.root` asks for a fresh trace even when a parent is in scope, so
+		// it gets its own decision rather than the parent's.
+		const inheriting = parent !== undefined && !options.root
+		return inner.span({
+			...options,
+			// Never revives a span something upstream already dropped — a route
+			// exempted by `TracerDisabledWhen` arrives here with `sampled: false`.
+			// Both ends of the range answer without drawing a number, so turning
+			// tracing fully on or fully off costs nothing per span.
+			sampled:
+				options.sampled &&
+				(inheriting
+					? parent.sampled
+					: keepRate >= 1 || (keepRate > 0 && Math.random() < keepRate)),
+		})
+	},
+})

--- a/packages/observability/src/work-record.test.ts
+++ b/packages/observability/src/work-record.test.ts
@@ -1,0 +1,222 @@
+// A question like "how long did it take, split by how they signed in" can only
+// be answered when both facts sit on one line. These pin that facts reported
+// from anywhere in a piece of work reach its record — and that code reporting a
+// fact with nobody gathering it carries on quietly instead of failing.
+
+import { Effect, Option, Tracer } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { makeWorkRecord, recordFacts, WorkRecord } from './work-record'
+
+describe('work record', () => {
+	describe('when facts are reported from several places', () => {
+		it('should hold all of them together', async () => {
+			// GIVEN an open record
+			const facts = await Effect.runPromise(
+				Effect.gen(function* () {
+					const record = yield* makeWorkRecord
+
+					// WHEN separate parts of the work each report what they learned
+					yield* record.add({ 'http.method': 'GET' })
+					yield* record.add({ 'auth.method': 'api_key' })
+					yield* record.add({ 'org.id': 'org_123' })
+
+					return yield* record.read
+				}),
+			)
+
+			// THEN one read gives back the whole story, not three fragments
+			expect(facts).toEqual({
+				'http.method': 'GET',
+				'auth.method': 'api_key',
+				'org.id': 'org_123',
+			})
+		})
+
+		it('should keep the newest value when the same fact is reported twice', async () => {
+			// GIVEN a fact that is refined as the work goes on
+			const facts = await Effect.runPromise(
+				Effect.gen(function* () {
+					const record = yield* makeWorkRecord
+
+					// WHEN it is reported again with a better value
+					yield* record.add({ 'research.model': 'guess' })
+					yield* record.add({ 'research.model': 'the-one-that-answered' })
+
+					return yield* record.read
+				}),
+			)
+
+			// THEN the later value wins, so the line says what actually happened
+			expect(facts['research.model']).toBe('the-one-that-answered')
+		})
+	})
+
+	describe('when two pieces of work run at once', () => {
+		it('should keep their facts apart', async () => {
+			// GIVEN two records, as two requests in flight would have
+			const [first, second] = await Effect.runPromise(
+				Effect.gen(function* () {
+					const one = yield* makeWorkRecord
+					const other = yield* makeWorkRecord
+
+					// WHEN each records its own org
+					yield* one.add({ 'org.id': 'org_one' })
+					yield* other.add({ 'org.id': 'org_other' })
+
+					return [yield* one.read, yield* other.read] as const
+				}),
+			)
+
+			// THEN neither sees the other's tenant — a leak here would put one
+			// customer's id on another customer's line
+			expect(first).toEqual({ 'org.id': 'org_one' })
+			expect(second).toEqual({ 'org.id': 'org_other' })
+		})
+	})
+
+	describe('when code reports a fact', () => {
+		it('should reach the record that is open around it', async () => {
+			// GIVEN an open record provided to the work below it
+			const facts = await Effect.runPromise(
+				Effect.gen(function* () {
+					const record = yield* makeWorkRecord
+
+					// WHEN code deep in the call chain reports a fact, without being
+					// handed the record itself
+					yield* recordFacts({ 'auth.method': 'oauth' }).pipe(
+						Effect.provideService(WorkRecord, record),
+					)
+
+					return yield* record.read
+				}),
+			)
+
+			// THEN it lands on the record anyway
+			expect(facts).toEqual({ 'auth.method': 'oauth' })
+		})
+
+		it('should do nothing when no record is open', async () => {
+			// GIVEN work running outside any record — a background fiber, a boot
+			// task, a test — where nobody is gathering
+
+			// WHEN it reports a fact anyway
+			const outcome = await Effect.runPromise(
+				recordFacts({ 'auth.method': 'oauth' }).pipe(Effect.exit),
+			)
+
+			// THEN it carries on quietly, because code deep in a call chain cannot
+			// know whether anyone upstream opened a record
+			expect(outcome._tag).toBe('Success')
+		})
+	})
+})
+
+describe('recordFacts filtering', () => {
+	describe('when a fact holds whatever a caller sent', () => {
+		it('should keep none of it on the record either', async () => {
+			// GIVEN a record open around code that reports the catch-all argument bag
+			const facts = await Effect.runPromise(
+				Effect.gen(function* () {
+					const record = yield* makeWorkRecord
+
+					// WHEN it is reported
+					yield* recordFacts({
+						tool: 'manage_email_inbox',
+						parameters: { password: 'hunter2' },
+					}).pipe(Effect.provideService(WorkRecord, record))
+
+					return yield* record.read
+				}),
+			)
+
+			// THEN the record is filtered the same way a span is — the record leaves
+			// on a log line, so without this it would be a way around the scrubbing
+			expect(JSON.stringify(facts)).not.toContain('hunter2')
+			expect(facts['tool']).toBe('manage_email_inbox')
+		})
+	})
+})
+
+describe('work record size', () => {
+	describe('when work reports a fact per item instead of per request', () => {
+		it('should stop growing and say how many it turned away', async () => {
+			// GIVEN a loop reporting a distinct fact many times over
+			const facts = await Effect.runPromise(
+				Effect.gen(function* () {
+					const record = yield* makeWorkRecord
+					for (let index = 0; index < 500; index++) {
+						yield* record.add({ [`item.${index}`]: index })
+					}
+					return yield* record.read
+				}),
+			)
+
+			// THEN the record stays small and admits what is missing — an unbounded
+			// one would put a huge line in front of an exporter that flushes every
+			// second, and the real fields would go down with it
+			expect(Object.keys(facts).length).toBeLessThanOrEqual(65)
+			expect(facts['record.dropped_facts']).toBeGreaterThan(400)
+		})
+
+		it('should still let a fact already on the record be refined', async () => {
+			// GIVEN a record already filled to the cap
+			const facts = await Effect.runPromise(
+				Effect.gen(function* () {
+					const record = yield* makeWorkRecord
+					for (let index = 0; index < 500; index++) {
+						yield* record.add({ [`item.${index}`]: index })
+					}
+
+					// WHEN a fact that is already there gets a better value
+					yield* record.add({ 'item.0': 'refined' })
+
+					return yield* record.read
+				}),
+			)
+
+			// THEN the refinement lands — refining is not growing, so a full record
+			// must not freeze the values already on it
+			expect(facts['item.0']).toBe('refined')
+		})
+	})
+})
+
+describe('recordFacts on the span', () => {
+	describe('when a fact is reported inside a span', () => {
+		it('should reach the span as well as the record', async () => {
+			// GIVEN a tracer that keeps what it was told
+			const recorded = new Map<string, unknown>()
+			const span = {
+				_tag: 'Span',
+				spanId: 'span',
+				traceId: 'trace',
+				name: 'test',
+				sampled: true,
+				parent: Option.none(),
+				status: { _tag: 'Started', startTime: 0n },
+				attributes: recorded,
+				links: [],
+				kind: 'internal',
+				attribute: (key: string, value: unknown) => recorded.set(key, value),
+				event: () => {},
+				end: () => {},
+				addLinks: () => {},
+			} as unknown as Tracer.Span
+			const tracer = { span: () => span } as unknown as Tracer.Tracer
+
+			// WHEN a fact is reported inside a span
+			await Effect.runPromise(
+				recordFacts({ 'org.id': 'org_1' }).pipe(
+					Effect.withSpan('unit-of-work'),
+					Effect.provideService(Tracer.Tracer, tracer),
+				),
+			)
+
+			// THEN the span carries it too — three call sites moved off
+			// annotateCurrentSpan on the promise that the span half keeps working,
+			// so filtering a trace by tenant must not have silently stopped
+			expect(recorded.get('org.id')).toBe('org_1')
+		})
+	})
+})

--- a/packages/observability/src/work-record.ts
+++ b/packages/observability/src/work-record.ts
@@ -1,0 +1,107 @@
+import { Context, Effect, Option, Ref } from 'effect'
+
+import { redactFacts } from './redact-spans'
+
+// A record holds facts about one piece of work, so it stays small by nature —
+// how the caller signed in, which tenant, which model. The cap is here for the
+// case that is not that: a loop recording something per item. Without it, the
+// record grows with the work and the whole thing lands on one log line, which
+// the exporter then rejects and takes the real fields down with it.
+const MAX_FACTS = 64
+
+// Names how many facts were turned away, so a record that hit the cap says so
+// instead of looking complete.
+const DROPPED_KEY = 'record.dropped_facts'
+
+/**
+ * The facts gathered while one unit of work runs, so they can all be written
+ * out together on a single line when it ends.
+ *
+ * Without this, a fact learned halfway through — how the caller signed in, which
+ * tenant it resolved to — lands on whatever log line happened to be nearby, on a
+ * different line from the outcome and the time taken. Two lines cannot be
+ * grouped as one, so "how long did it take, split by how they signed in" has no
+ * answer even though both facts were written down. Gathering them onto one line
+ * is what makes that question answerable.
+ *
+ * Two kinds of work open a record: an HTTP request, and a research run. A run is
+ * not part of any request — it runs on a forked fiber long after the request
+ * that asked for it returned — so it opens one of its own rather than borrowing.
+ */
+export interface WorkRecordService {
+	/** Merge facts into the open record. A repeated key keeps the newest value. */
+	readonly add: (facts: Record<string, unknown>) => Effect.Effect<void>
+	/** Everything gathered so far. */
+	readonly read: Effect.Effect<Record<string, unknown>>
+}
+
+export class WorkRecord extends Context.Service<
+	WorkRecord,
+	WorkRecordService
+>()('observability/WorkRecord') {}
+
+/** Opens an empty record. Give it to the work whose facts it should gather. */
+export const makeWorkRecord: Effect.Effect<WorkRecordService> = Effect.gen(
+	function* () {
+		const facts = yield* Ref.make<Record<string, unknown>>({})
+		return {
+			add: next =>
+				Ref.update(facts, prev => {
+					const merged: Record<string, unknown> = { ...prev }
+					const previouslyDropped = merged[DROPPED_KEY]
+					let dropped =
+						typeof previouslyDropped === 'number' ? previouslyDropped : 0
+					for (const [key, value] of Object.entries(next)) {
+						// A fact already on the record is refined, not added, so refining
+						// one is always allowed however full the record is.
+						if (Object.hasOwn(merged, key)) {
+							merged[key] = value
+							continue
+						}
+						if (Object.keys(merged).length >= MAX_FACTS) {
+							dropped++
+							continue
+						}
+						merged[key] = value
+					}
+					if (dropped > 0) merged[DROPPED_KEY] = dropped
+					return merged
+				}),
+			read: Ref.get(facts),
+		}
+	},
+)
+
+/**
+ * Writes facts to the current span AND to the open work record.
+ *
+ * The record is read through `serviceOption`, so work running outside one —
+ * a background fiber, a boot-time task, a test — simply keeps the span
+ * attributes and drops the rest instead of failing to typecheck or blowing up.
+ * That is what lets code deep in a call chain report a fact without knowing
+ * whether anyone upstream is gathering it. The flip side is that a fact
+ * reported where no record is open is lost silently, so opening one is the
+ * caller's job to get right.
+ *
+ * Note that a route exempted from tracing is NOT exempted from this: the span
+ * half goes nowhere but the record half still reaches the logs. Exempt routes
+ * are exempt because their URL is a credential, so nothing read off such a URL
+ * belongs in a fact here either.
+ *
+ * Facts are filtered before either half is written. Wrapping the tracer scrubs
+ * span attributes only, and the record goes out on a log line rather than a
+ * span, so it has to be filtered here too — otherwise this function would be a
+ * way around the very thing the wrapper exists to stop.
+ */
+export const recordFacts = (
+	facts: Record<string, unknown>,
+): Effect.Effect<void> => {
+	const safe = redactFacts(facts)
+	return Effect.annotateCurrentSpan(safe).pipe(
+		Effect.andThen(
+			Effect.flatMap(Effect.serviceOption(WorkRecord), record =>
+				Option.isNone(record) ? Effect.void : record.value.add(safe),
+			),
+		),
+	)
+}

--- a/packages/research/package.json
+++ b/packages/research/package.json
@@ -39,6 +39,7 @@
 	},
 	"dependencies": {
 		"@batuda/domain": "workspace:*",
+		"@batuda/observability": "workspace:*",
 		"@effect/ai-openai-compat": "4.0.0-beta.102",
 		"effect": "4.0.0-beta.102"
 	},

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -288,7 +288,12 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 				}).pipe(
 					Effect.tap(() =>
 						Effect.logDebug('budget.chargePaid').pipe(
-							Effect.annotateLogs({ provider, tool, cents }),
+							Effect.annotateLogs({
+								event: 'budget.chargePaid',
+								provider,
+								tool,
+								cents,
+							}),
 						),
 					),
 				)
@@ -321,7 +326,11 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 						),
 						Effect.tap(() =>
 							Effect.logDebug('budget.chargeCheap').pipe(
-								Effect.annotateLogs({ provider, cents }),
+								Effect.annotateLogs({
+									event: 'budget.chargeCheap',
+									provider,
+									cents,
+								}),
 							),
 						),
 					),

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -21,6 +21,7 @@ import { Prompt } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { ResearchRun } from '@batuda/domain'
+import { makeWorkRecord, WorkRecord } from '@batuda/observability'
 
 import {
 	AcceptedCountry,
@@ -1669,6 +1670,7 @@ export const cloneCacheHitRun = (params: {
 		}
 		yield* Effect.logInfo('research.cache_hit').pipe(
 			Effect.annotateLogs({
+				event: 'research.cache_hit',
 				user_id: userId,
 				research_id: clonedId,
 				source_research_id: cachedId,
@@ -1830,7 +1832,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 				if (pending.length > 0) {
 					yield* Effect.logInfo(
 						'research.dispatch: re-offered queued runs',
-					).pipe(Effect.annotateLogs({ count: pending.length }))
+					).pipe(
+						Effect.annotateLogs({
+							event: 'research.dispatch.requeued',
+							count: pending.length,
+						}),
+					)
 				}
 			})
 
@@ -2294,6 +2301,66 @@ export class ResearchService extends Context.Service<ResearchService>()(
 			// itself — `AND organization_id = …`, taken off the run row. The rest of
 			// what this reads is keyed on the run's own id, which belongs to one
 			// organization already and never comes from a caller.
+			// Spreads a tally into one field per entry, e.g. `model_calls.agent@x: 3`.
+			// Spreads a tally into one field per entry, e.g. `model_calls.agent@x: 3`.
+			//
+			// Bounded, because these go straight onto the line rather than through the
+			// work record, so the record's own size cap does not reach them: a run
+			// touching many models and vendors would otherwise widen the line by a
+			// field per combination. The biggest go on and the rest are counted, so
+			// what survives is what the spending was actually on.
+			const MAX_TALLY_FIELDS = 24
+			const prefixed = (prefix: string, totals: Record<string, number>) => {
+				const ranked = Object.entries(totals).sort(([, a], [, b]) => b - a)
+				const kept = ranked.slice(0, MAX_TALLY_FIELDS)
+				const line: Record<string, number> = Object.fromEntries(
+					kept.map(([key, value]) => [`${prefix}.${key}`, value]),
+				)
+				if (ranked.length > kept.length)
+					line[`${prefix}.other_count`] = ranked.length - kept.length
+				return line
+			}
+
+			// One line per run, carrying everything the run learned on the way plus
+			// what it spent. A run is long and expensive, and its story is otherwise
+			// spread over dozens of lines that cannot be grouped as one — so
+			// "what did a run cost, split by which model answered it" has no answer
+			// unless the facts and the totals share a row. Identity fields go last so
+			// a fact recorded during the run cannot shadow which run the line is for.
+			const closeRunRecord = (
+				researchId: string,
+				userId: string,
+				outcome: 'succeeded' | 'failed',
+			) =>
+				Effect.gen(function* () {
+					const { run_claimed: ranHere, ...facts } = yield* (yield* WorkRecord)
+						.read
+					// A run already claimed by another worker leaves this fiber straight
+					// away. Writing a line for it would invent a run that never happened
+					// here, and its zero cost would drag every average down.
+					if (!ranHere) return
+					const usage = yield* (yield* UsageMeter).snapshot()
+					yield* Effect.logInfo('research.run').pipe(
+						Effect.annotateLogs({
+							...facts,
+							event: 'research.run',
+							outcome,
+							tokens_in: usage.tokensIn,
+							tokens_out: usage.tokensOut,
+							cost_cents: usage.costCents,
+							// Flattened one key per model / provider / kind of work, rather
+							// than nested: grouping works on a field, so a nested object
+							// would have to be picked apart before it could answer "cost,
+							// split by the model that actually produced the run".
+							...prefixed('cost_cents', usage.costByBucket),
+							...prefixed('units', usage.unitsByProvider),
+							...prefixed('model_calls', usage.callsByModel),
+							research_id: researchId,
+							user_id: userId,
+						}),
+					)
+				})
+
 			const runFiber = (researchId: string, userId: string) =>
 				Effect.gen(function* () {
 					// Claim the run: proceed only if it is still queued. The consumer
@@ -2308,6 +2375,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						RETURNING id
 					`
 					if (!claimed) return
+					// Mark the record so the closing line knows this worker really ran
+					// the run, rather than finding it already taken and stepping aside.
+					yield* (yield* WorkRecord).add({ run_claimed: true })
 
 					// Refresh the heartbeat while this run works, so the sweep can
 					// tell a live long-running job from one whose worker died. Forked
@@ -2673,6 +2743,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								? Effect.failCause(cause)
 								: Effect.logWarning('research.progress.write_failed').pipe(
 										Effect.annotateLogs({
+											event: 'research.progress.write_failed',
 											research_id: researchId,
 											cause: Cause.pretty(cause),
 										}),
@@ -2902,6 +2973,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														'research.contacts.rescue_failed',
 													).pipe(
 														Effect.annotateLogs({
+															event: 'research.contacts.rescue_failed',
 															research_id: researchId,
 															cause: Cause.pretty(cause),
 														}),
@@ -2927,6 +2999,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									result = { ...(result as object), contacts: merged }
 									yield* Effect.logInfo('research.contacts.rescued').pipe(
 										Effect.annotateLogs({
+											event: 'research.contacts.rescued',
 											research_id: researchId,
 											before: broadContacts.length,
 											after: merged.length,
@@ -2961,6 +3034,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									result = fMerged.findings
 									yield* Effect.logInfo('research.firmographics.rescued').pipe(
 										Effect.annotateLogs({
+											event: 'research.firmographics.rescued',
 											research_id: researchId,
 											filled: fMerged.filled,
 										}),
@@ -2994,6 +3068,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									result = sMerged.findings
 									yield* Effect.logInfo('research.size.rescued').pipe(
 										Effect.annotateLogs({
+											event: 'research.size.rescued',
 											research_id: researchId,
 											filled: sMerged.filled,
 										}),
@@ -3054,6 +3129,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.prospects.not_a_company',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.prospects.not_a_company',
 														research_id: researchId,
 														name: row.name,
 														kind: row.kind,
@@ -3089,6 +3165,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.citations.dropped',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.citations.dropped',
 														research_id: researchId,
 														total: check.total,
 														kept: check.kept,
@@ -3104,6 +3181,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											)) {
 												yield* Effect.logInfo('research.field.dropped').pipe(
 													Effect.annotateLogs({
+														event: 'research.field.dropped',
 														research_id: researchId,
 														guard: 'citation',
 														field: fieldDrop.field,
@@ -3139,6 +3217,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.contacts.wrong_entity',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.contacts.wrong_entity',
 														research_id: researchId,
 														dropped: check.dropped,
 													}),
@@ -3167,6 +3246,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.fields.ungrounded',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.fields.ungrounded',
 														research_id: researchId,
 														dropped_placeholder: check.droppedPlaceholder,
 														dropped_wrong_kind: check.droppedWrongKind,
@@ -3184,6 +3264,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											)) {
 												yield* Effect.logInfo('research.field.dropped').pipe(
 													Effect.annotateLogs({
+														event: 'research.field.dropped',
 														research_id: researchId,
 														guard: 'scalar',
 														field: fieldDrop.field,
@@ -3251,6 +3332,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.websites.blanked',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.websites.blanked',
 														research_id: researchId,
 														blanked_not_an_address: check.blankedNotAnAddress,
 														blanked_directory: check.blankedDirectory,
@@ -3275,6 +3357,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.websites.own_site',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.websites.own_site',
 														research_id: researchId,
 														established: check.ownSiteEstablished,
 														unknown: check.ownSiteUnknown,
@@ -3346,6 +3429,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.values.unsupported',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.values.unsupported',
 														research_id: researchId,
 														dropped_proposals: check.droppedProposals,
 														stripped_values: check.strippedValues,
@@ -3373,6 +3457,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.fit.unsupported',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.fit.unsupported',
 														research_id: researchId,
 														dropped_disqualifiers: check.droppedDisqualifiers,
 														unverified_checks: check.unverifiedChecks,
@@ -3397,6 +3482,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.vocabulary.normalized',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.vocabulary.normalized',
 														research_id: researchId,
 														mapped: check.mapped,
 														blanked: check.blanked,
@@ -3464,6 +3550,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.proposals.unappliable',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.proposals.unappliable',
 														research_id: researchId,
 														dropped: check.dropped,
 														// Fields an earlier check had emptied, taken out
@@ -3546,6 +3633,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.discovered_existing.unresolved',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.discovered_existing.unresolved',
 														research_id: researchId,
 														dropped: check.dropped,
 													}),
@@ -3582,6 +3670,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.prospects.off_criteria',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.prospects.off_criteria',
 														research_id: researchId,
 														dropped: check.dropped,
 													}),
@@ -3610,6 +3699,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.prospects.deduplicated',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.prospects.deduplicated',
 														research_id: researchId,
 														merged: check.merged,
 													}),
@@ -3643,6 +3733,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.prospects.doubt_cleared',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.prospects.doubt_cleared',
 														research_id: researchId,
 														cleared: check.cleared,
 													}),
@@ -3674,6 +3765,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.prospects.name_only',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.prospects.name_only',
 														research_id: researchId,
 														marked: check.marked,
 													}),
@@ -3754,6 +3846,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.critic.dropped',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.critic.dropped',
 														research_id: researchId,
 														criticised: check.criticised,
 														dropped: check.dropped,
@@ -3807,6 +3900,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.entity_source.blocked',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.entity_source.blocked',
 														research_id: researchId,
 														dropped_fields: check.droppedCompanyFields,
 														dropped_off_entity: check.droppedOffEntity,
@@ -3835,6 +3929,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.source_tier.capped',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.source_tier.capped',
 														research_id: researchId,
 														capped: check.capped,
 													}),
@@ -3895,6 +3990,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						researchText = cachedResearchText
 						yield* Effect.logInfo('research.phase1.resume').pipe(
 							Effect.annotateLogs({
+								event: 'research.phase1.resume',
 								research_id: researchId,
 								text_length: researchText.length,
 							}),
@@ -4009,6 +4105,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														'research.request_parts.skipped',
 													).pipe(
 														Effect.annotateLogs({
+															event: 'research.request_parts.skipped',
 															research_id: researchId,
 															cause: Cause.pretty(cause),
 														}),
@@ -4019,6 +4116,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								if (requestParts.length > 0) {
 									yield* Effect.logInfo('research.request_parts').pipe(
 										Effect.annotateLogs({
+											event: 'research.request_parts',
 											research_id: researchId,
 											parts: requestParts.map(part => part.label),
 										}),
@@ -4086,6 +4184,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 															'research.anchor.search_failed',
 														).pipe(
 															Effect.annotateLogs({
+																event: 'research.anchor.search_failed',
 																research_id: researchId,
 																cause: Cause.pretty(cause),
 															}),
@@ -4115,6 +4214,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								}
 								yield* Effect.logInfo('research.anchor.host_found').pipe(
 									Effect.annotateLogs({
+										event: 'research.anchor.host_found',
 										research_id: researchId,
 										host: searchedOwnHost,
 									}),
@@ -4180,6 +4280,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													: 'research.anchor.seeded',
 											).pipe(
 												Effect.annotateLogs({
+													event: followedRedirect
+														? 'research.anchor.redirect_followed'
+														: 'research.anchor.seeded',
 													research_id: researchId,
 													host: ownHost,
 													...(followedRedirect
@@ -4195,6 +4298,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												? Effect.failCause(cause)
 												: Effect.logWarning('research.anchor.seed_failed').pipe(
 														Effect.annotateLogs({
+															event: 'research.anchor.seed_failed',
 															research_id: researchId,
 															host: ownHost,
 															cause: Cause.pretty(cause),
@@ -4243,6 +4347,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.anchor.about_seeded',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.anchor.about_seeded',
 														research_id: researchId,
 														url: aboutUrl,
 													}),
@@ -4256,6 +4361,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 															'research.anchor.about_skipped',
 														).pipe(
 															Effect.annotateLogs({
+																event: 'research.anchor.about_skipped',
 																research_id: researchId,
 																url: aboutUrl,
 																cause: Cause.pretty(cause),
@@ -4291,6 +4397,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										if (discovered.length > 0) {
 											yield* Effect.logInfo('research.discovery.mapped').pipe(
 												Effect.annotateLogs({
+													event: 'research.discovery.mapped',
 													research_id: researchId,
 													mapped: mapped.links.length,
 													fetching: discovered.length,
@@ -4324,6 +4431,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														'research.discovery.page_seeded',
 													).pipe(
 														Effect.annotateLogs({
+															event: 'research.discovery.page_seeded',
 															research_id: researchId,
 															url,
 														}),
@@ -4337,6 +4445,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 																'research.discovery.page_skipped',
 															).pipe(
 																Effect.annotateLogs({
+																	event: 'research.discovery.page_skipped',
 																	research_id: researchId,
 																	url,
 																	cause: Cause.pretty(cause),
@@ -4351,6 +4460,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												? Effect.failCause(cause)
 												: Effect.logInfo('research.discovery.skipped').pipe(
 														Effect.annotateLogs({
+															event: 'research.discovery.skipped',
 															research_id: researchId,
 															host: reachedHost,
 															cause: Cause.pretty(cause),
@@ -4364,6 +4474,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											? Effect.failCause(cause)
 											: Effect.logWarning('research.anchor.seed_failed').pipe(
 													Effect.annotateLogs({
+														event: 'research.anchor.seed_failed',
 														research_id: researchId,
 														host: ownHost,
 														cause: Cause.pretty(cause),
@@ -4452,6 +4563,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									}
 									yield* Effect.logInfo('research.registry.seeded').pipe(
 										Effect.annotateLogs({
+											event: 'research.registry.seeded',
 											research_id: researchId,
 											country: registryCountry,
 										}),
@@ -4467,6 +4579,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.registry.seed_skipped',
 												).pipe(
 													Effect.annotateLogs({
+														event: 'research.registry.seed_skipped',
 														research_id: researchId,
 														country: registryCountry,
 														cause: Cause.pretty(cause),
@@ -4755,6 +4868,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									refined = true
 									yield* Effect.logInfo('research.refining').pipe(
 										Effect.annotateLogs({
+											event: 'research.refining',
 											research_id: researchId,
 											schema: schemaName,
 										}),
@@ -4791,6 +4905,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										if (coverage.uncovered.length > 0) {
 											yield* Effect.logInfo('research.covering.stopped').pipe(
 												Effect.annotateLogs({
+													event: 'research.covering.stopped',
 													research_id: researchId,
 													reason: verdict,
 													uncovered: coverage.uncovered,
@@ -4802,6 +4917,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 
 									yield* Effect.logInfo('research.covering').pipe(
 										Effect.annotateLogs({
+											event: 'research.covering',
 											research_id: researchId,
 											uncovered: coverage.uncovered,
 										}),
@@ -4903,7 +5019,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								'research.entity.city_downgraded': true,
 							})
 							yield* Effect.logInfo('research.entity.city_downgraded').pipe(
-								Effect.annotateLogs({ research_id: researchId }),
+								Effect.annotateLogs({
+									event: 'research.entity.city_downgraded',
+									research_id: researchId,
+								}),
 							)
 							entityMatch = 'absent'
 						}
@@ -4955,7 +5074,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					if (checkpointPhase >= 2 && existingFindingsHasValue) {
 						findings = existingFindings
 						yield* Effect.logInfo('research.phase2.resume').pipe(
-							Effect.annotateLogs({ research_id: researchId }),
+							Effect.annotateLogs({
+								event: 'research.phase2.resume',
+								research_id: researchId,
+							}),
 						)
 						// Same as the gathering checkpoint above: reusing the earlier
 						// attempt's findings skips the work that would otherwise report,
@@ -5000,7 +5122,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								entityMatch = 'weak'
 								yield* Effect.logWarning(
 									'research.entity.downgraded_source',
-								).pipe(Effect.annotateLogs({ research_id: researchId }))
+								).pipe(
+									Effect.annotateLogs({
+										event: 'research.entity.downgraded_source',
+										research_id: researchId,
+									}),
+								)
 							}
 						}
 						// Gap rounds: for each high-value fact the broad pass and the
@@ -5085,6 +5212,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							if (thinDeadline || thinBudget) {
 								yield* Effect.logInfo('research.gap_rounds.stopped').pipe(
 									Effect.annotateLogs({
+										event: 'research.gap_rounds.stopped',
 										research_id: researchId,
 										round: gapRound,
 										reason: thinDeadline ? 'deadline_margin' : 'budget_margin',
@@ -5142,6 +5270,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														'research.gap_rounds.cited_scrape_skipped',
 													).pipe(
 														Effect.annotateLogs({
+															event: 'research.gap_rounds.cited_scrape_skipped',
 															research_id: researchId,
 															url: citedUrl,
 															cause: Cause.pretty(cause),
@@ -5176,6 +5305,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										'research.gap_rounds.cited_voided',
 									).pipe(
 										Effect.annotateLogs({
+											event: 'research.gap_rounds.cited_voided',
 											research_id: researchId,
 											dropped: recheck.droppedOffEntity,
 										}),
@@ -5277,6 +5407,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										: Effect.logWarning('research.gap_rounds.refresh_failed')
 												.pipe(
 													Effect.annotateLogs({
+														event: 'research.gap_rounds.refresh_failed',
 														research_id: researchId,
 														round: gapRound,
 														cause: Cause.pretty(cause),
@@ -5303,6 +5434,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							})
 							yield* Effect.logInfo('research.gap_rounds.closed').pipe(
 								Effect.annotateLogs({
+									event: 'research.gap_rounds.closed',
 									research_id: researchId,
 									round: gapRound,
 									cited_fetched: citedUnscraped.length,
@@ -5437,6 +5569,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							if (worthSearching.length > searchable.length) {
 								yield* Effect.logInfo('research.existence.allowance').pipe(
 									Effect.annotateLogs({
+										event: 'research.existence.allowance',
 										research_id: researchId,
 										short: stillShort.length,
 										searchable: worthSearching.length,
@@ -5496,6 +5629,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														: Effect.logInfo('research.existence.search_failed')
 																.pipe(
 																	Effect.annotateLogs({
+																		event: 'research.existence.search_failed',
 																		research_id: researchId,
 																		cause: Cause.pretty(cause),
 																	}),
@@ -5532,6 +5666,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							if (stoppedAtDeadline) {
 								yield* Effect.logInfo('research.existence.stopped').pipe(
 									Effect.annotateLogs({
+										event: 'research.existence.stopped',
 										research_id: researchId,
 										reason: 'deadline_margin',
 									}),
@@ -5594,6 +5729,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									'research.existence.settled_then_lost',
 								).pipe(
 									Effect.annotateLogs({
+										event: 'research.existence.settled_then_lost',
 										research_id: researchId,
 										rows: settledThenLost,
 									}),
@@ -5612,6 +5748,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							})
 							yield* Effect.logInfo('research.existence.verified').pipe(
 								Effect.annotateLogs({
+									event: 'research.existence.verified',
 									research_id: researchId,
 									confirmed: verifiedGroups.confirmed.length,
 									candidates: verifiedGroups.candidates.length,
@@ -5639,6 +5776,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						if (requestCoverage.uncovered.length > 0) {
 							yield* Effect.logWarning('research.request_parts.uncovered').pipe(
 								Effect.annotateLogs({
+									event: 'research.request_parts.uncovered',
 									research_id: researchId,
 									uncovered: requestCoverage.uncovered,
 								}),
@@ -5907,6 +6045,16 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					// Scope the run so the heartbeat fiber (forked above) is
 					// interrupted the moment the run finishes, fails, or is cancelled.
 					Effect.scoped,
+					// Close the run's record here, ABOVE the catch below: that catch
+					// turns a failed run into a normal return, so after it a success
+					// and a failure look the same and the outcome could not be told
+					// apart. A cancel is not a failure, so it writes no line.
+					Effect.tap(() => closeRunRecord(researchId, userId, 'succeeded')),
+					Effect.tapCause(cause =>
+						Cause.hasInterruptsOnly(cause)
+							? Effect.void
+							: closeRunRecord(researchId, userId, 'failed'),
+					),
 					Effect.catchCause(cause => {
 						if (shouldMarkRunFailed(cause)) {
 							return Effect.gen(function* () {
@@ -5962,7 +6110,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						event: 'research.fiber',
 					}),
 					// One record of spend per run, wrapping everything the run does, so
-					// every phase adds into the same tally.
+					// every phase adds into the same tally. The work record wraps the
+					// same way and for the same reason: one run, one tally, one row.
+					Effect.provideServiceEffect(WorkRecord, makeWorkRecord),
 					Effect.provideServiceEffect(UsageMeter, makeUsageMeter),
 				)
 
@@ -5977,7 +6127,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 			yield* reofferQueued.pipe(
 				Effect.catchCause(cause =>
 					Effect.logError('research.dispatch: reconcile failed').pipe(
-						Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+						Effect.annotateLogs({
+							event: 'research.dispatch.reconcile_failed',
+							cause: Cause.pretty(cause),
+						}),
 					),
 				),
 				Effect.repeat(Schedule.spaced('2 seconds')),
@@ -5990,6 +6143,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						'research.sweepOrphans: failed runs orphaned mid-run',
 					).pipe(
 						Effect.annotateLogs({
+							event: 'research.orphans.swept',
 							running_count: swept.running.length,
 							running_ids: swept.running.map(r => r.id),
 						}),
@@ -5998,7 +6152,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 			}).pipe(
 				Effect.catchCause(cause =>
 					Effect.logError('research.dispatch: sweep failed').pipe(
-						Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+						Effect.annotateLogs({
+							event: 'research.dispatch.sweep_failed',
+							cause: Cause.pretty(cause),
+						}),
 					),
 				),
 				Effect.repeat(Schedule.spaced(`${orphanSweepIntervalSeconds} seconds`)),
@@ -6025,7 +6182,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 				),
 				Effect.catchCause(cause =>
 					Effect.logError('research.dispatch: failed to start run').pipe(
-						Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+						Effect.annotateLogs({
+							event: 'research.dispatch.start_failed',
+							cause: Cause.pretty(cause),
+						}),
 					),
 				),
 				Effect.forever,
@@ -6049,6 +6209,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						const schemaName = schemaNameFor(input)
 						yield* Effect.logInfo('research.create').pipe(
 							Effect.annotateLogs({
+								event: 'research.create',
 								user_id: userId,
 								organization_id: organizationId,
 								query_length: input.query.length,
@@ -6073,6 +6234,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									'research.create.subject_unavailable',
 								).pipe(
 									Effect.annotateLogs({
+										event: 'research.create.subject_unavailable',
 										user_id: userId,
 										organization_id: organizationId,
 										missing_count: missing.length,
@@ -6190,6 +6352,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							if (capped) {
 								yield* Effect.logWarning('research.selector.capped').pipe(
 									Effect.annotateLogs({
+										event: 'research.selector.capped',
 										user_id: userId,
 										matched: matched.length,
 										cap: selectorMax,
@@ -6219,6 +6382,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									'research.selector.confirm_required',
 								).pipe(
 									Effect.annotateLogs({
+										event: 'research.selector.confirm_required',
 										user_id: userId,
 										subject_count: targets.length,
 									}),
@@ -6299,6 +6463,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 
 							yield* Effect.logInfo('research.selector.fanout').pipe(
 								Effect.annotateLogs({
+									event: 'research.selector.fanout',
 									user_id: userId,
 									group_id: groupId,
 									leaves: targets.length,
@@ -6621,7 +6786,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 				cancel: (researchId: string) =>
 					Effect.gen(function* () {
 						yield* Effect.logInfo('research.cancel').pipe(
-							Effect.annotateLogs({ research_id: researchId }),
+							Effect.annotateLogs({
+								event: 'research.cancel',
+								research_id: researchId,
+							}),
 						)
 						const map = yield* Ref.get(activeFibers)
 						const maybeFiber = HashMap.get(map, researchId)

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -320,6 +320,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 			(toolName: string) => (e: { readonly remaining: number }) =>
 				Effect.logWarning('research.tool.budget_exhausted').pipe(
 					Effect.annotateLogs({
+						event: 'research.tool.budget_exhausted',
 						tool: toolName,
 						'research.run_id': researchId,
 						remaining_cents: e.remaining,
@@ -342,6 +343,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 			<E>(cause: Cause.Cause<E>) =>
 				Effect.logError('research.tool.failed').pipe(
 					Effect.annotateLogs({
+						event: 'research.tool.failed',
 						tool: toolName,
 						'research.run_id': researchId,
 						cause: Cause.pretty(cause),
@@ -361,6 +363,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 		const skipUnsupportedScrape = (url: string) =>
 			Effect.logInfo('research.scrape.skipped_unsupported').pipe(
 				Effect.annotateLogs({
+					event: 'research.scrape.skipped_unsupported',
 					tool: 'scrape_page',
 					'research.run_id': researchId,
 					url,
@@ -379,7 +382,12 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					if (stripped !== params.query) {
 						yield* Effect.logWarning(
 							'research.search.placeholder_site_stripped',
-						).pipe(Effect.annotateLogs({ tool: 'web_search' }))
+						).pipe(
+							Effect.annotateLogs({
+								event: 'research.search.placeholder_site_stripped',
+								tool: 'web_search',
+							}),
+						)
 					}
 					// Re-anchor a query that dropped the company name to the run's target,
 					// so the provider stays on it instead of returning off-company pages
@@ -393,6 +401,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					if (query !== stripped) {
 						yield* Effect.logInfo('research.search.scoped_to_entity').pipe(
 							Effect.annotateLogs({
+								event: 'research.search.scoped_to_entity',
 								tool: 'web_search',
 								'research.run_id': researchId,
 							}),

--- a/packages/research/src/application/usage-meter.ts
+++ b/packages/research/src/application/usage-meter.ts
@@ -87,6 +87,13 @@ export class UsageMeter extends Context.Service<
 // keeps a separate running total for every combination of tags, so tagging by
 // organization, run or query would create an endless number of them. Those
 // belong on a span or in the database instead.
+//
+// This meter and `WorkRecord` in @batuda/observability are the same shape on
+// purpose-adjacent problems: both gather facts about one piece of work through
+// `serviceOption`, so work running outside one carries on quietly. They are kept
+// apart because this one prices and buckets as it goes, which a plain bag of
+// facts does not do. If a research run ever opens a record of its own, these
+// totals are what it should carry.
 const llmTokens = Metric.counter('batuda_research_llm_tokens_total', {
 	description: 'Model tokens billed by the research pipeline',
 	incremental: true,

--- a/packages/research/src/infrastructure/cached-llm.ts
+++ b/packages/research/src/infrastructure/cached-llm.ts
@@ -246,7 +246,10 @@ export const makeCachedLanguageModel = (
 					: yield* Cache.getOption(memCache, keyHash)
 				if (Option.isSome(cached)) {
 					yield* Effect.logDebug('cache.hit').pipe(
-						Effect.annotateLogs({ ...baseAttrs, layer: 'mem' }),
+						Effect.annotateLogs({
+							...baseAttrs,
+							layer: 'mem',
+						}),
 					)
 					return cached.value as A
 				}
@@ -261,7 +264,10 @@ export const makeCachedLanguageModel = (
 					const response = rehydrateCachedResponse(method, hit.response)
 					yield* Cache.set(memCache, keyHash, response)
 					yield* Effect.logDebug('cache.hit').pipe(
-						Effect.annotateLogs({ ...baseAttrs, layer: 'pg' }),
+						Effect.annotateLogs({
+							...baseAttrs,
+							layer: 'pg',
+						}),
 					)
 					return response as A
 				}

--- a/packages/research/src/infrastructure/llm-live.ts
+++ b/packages/research/src/infrastructure/llm-live.ts
@@ -239,7 +239,13 @@ const buildTierLayer = <Self>(
 				LLM_VENDORS,
 				`${envPrefix}_PROVIDERS`,
 			)
-			yield* Effect.logInfo(`${envPrefix.toLowerCase()}: ${vendors.join(',')}`)
+			yield* Effect.logInfo('research.providers.configured').pipe(
+				Effect.annotateLogs({
+					event: 'research.providers.configured',
+					port: envPrefix.toLowerCase(),
+					vendors,
+				}),
+			)
 
 			if (vendors[0] === 'stub') {
 				return Layer.succeed(Tag)(stubLanguageModelService)

--- a/packages/research/src/infrastructure/providers-live.ts
+++ b/packages/research/src/infrastructure/providers-live.ts
@@ -354,7 +354,13 @@ const searchLayer = Layer.effect(
 			SEARCH_VENDORS,
 			'RESEARCH_PROVIDER_SEARCH',
 		)
-		yield* Effect.logInfo(`research.search: ${vendors.join(',')}`)
+		yield* Effect.logInfo('research.providers.configured').pipe(
+			Effect.annotateLogs({
+				event: 'research.providers.configured',
+				port: 'search',
+				vendors,
+			}),
+		)
 		const instances = yield* Effect.all(
 			vendors.map((vendor, slot) =>
 				Effect.gen(function* () {
@@ -400,7 +406,13 @@ const scrapeLayer = Layer.effect(
 			SCRAPE_VENDORS,
 			'RESEARCH_PROVIDER_SCRAPE',
 		)
-		yield* Effect.logInfo(`research.scrape: ${vendors.join(',')}`)
+		yield* Effect.logInfo('research.providers.configured').pipe(
+			Effect.annotateLogs({
+				event: 'research.providers.configured',
+				port: 'scrape',
+				vendors,
+			}),
+		)
 		const instances = yield* Effect.all(
 			vendors.map((vendor, slot) =>
 				Effect.gen(function* () {
@@ -444,7 +456,13 @@ const mapLayer = Layer.effect(
 			'RESEARCH_PROVIDER_MAP',
 			['none'] as const,
 		)
-		yield* Effect.logInfo(`research.map: ${vendors.join(',')}`)
+		yield* Effect.logInfo('research.providers.configured').pipe(
+			Effect.annotateLogs({
+				event: 'research.providers.configured',
+				port: 'map',
+				vendors,
+			}),
+		)
 		const instances = yield* Effect.all(
 			vendors.map((vendor, slot) =>
 				Effect.gen(function* () {
@@ -482,7 +500,14 @@ export const enrichmentLayer = Layer.effect(
 			Schema.Literals(['fallback', 'union']),
 			'RESEARCH_ENRICH_MODE',
 		).pipe(Config.withDefault('fallback' as const))
-		yield* Effect.logInfo(`research.enrich: ${vendors.join(',')} (${mode})`)
+		yield* Effect.logInfo('research.providers.configured').pipe(
+			Effect.annotateLogs({
+				event: 'research.providers.configured',
+				port: 'enrich',
+				vendors,
+				mode,
+			}),
+		)
 		// A 'none'/empty slot contributes no attempt — no charge, no call. The
 		// original list index stays the slot so RESEARCH_API_KEY_ENRICH_2 keeps
 		// naming the second vendor even when a 'none' precedes it.
@@ -514,7 +539,13 @@ const verifierLayer = Layer.effect(
 			'RESEARCH_PROVIDER_VERIFY',
 			['none'] as const,
 		)
-		yield* Effect.logInfo(`research.verify: ${vendors.join(',')}`)
+		yield* Effect.logInfo('research.providers.configured').pipe(
+			Effect.annotateLogs({
+				event: 'research.providers.configured',
+				port: 'verify',
+				vendors,
+			}),
+		)
 		const instances = yield* Effect.all(
 			vendors.map((vendor, slot) => verifierInstance(vendor, slot)),
 		)
@@ -539,7 +570,14 @@ const buildRegistryDispatcher = (cc: RegistryCountry) =>
 			`RESEARCH_PROVIDER_REGISTRY_${cc}`,
 			['none'] as const,
 		)
-		yield* Effect.logInfo(`research.registry.${cc}: ${vendors.join(',')}`)
+		yield* Effect.logInfo('research.providers.configured').pipe(
+			Effect.annotateLogs({
+				event: 'research.providers.configured',
+				port: 'registry',
+				country: cc,
+				vendors,
+			}),
+		)
 		const instances = yield* Effect.all(
 			vendors.map((vendor, slot) => REGISTRY_BUILDERS[cc](vendor, slot)),
 		)
@@ -564,7 +602,14 @@ const buildReportDispatcher = (cc: RegistryCountry) =>
 			`RESEARCH_PROVIDER_REPORT_${cc}`,
 			['none'] as const,
 		)
-		yield* Effect.logInfo(`research.report.${cc}: ${vendors.join(',')}`)
+		yield* Effect.logInfo('research.providers.configured').pipe(
+			Effect.annotateLogs({
+				event: 'research.providers.configured',
+				port: 'report',
+				country: cc,
+				vendors,
+			}),
+		)
 		const instances = yield* Effect.all(
 			vendors.map((vendor, slot) => REPORT_BUILDERS[cc](vendor, slot)),
 		)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,6 +713,9 @@ importers:
       '@batuda/domain':
         specifier: workspace:*
         version: link:../domain
+      '@batuda/observability':
+        specifier: workspace:*
+        version: link:../observability
       '@effect/ai-openai-compat':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)


### PR DESCRIPTION
## What

When something goes wrong in production, the answer usually needs two facts at once — how long a request took *and* how the caller signed in; what a research run cost *and* which model actually produced it. Until now those facts were written down in different places: one on the line where it was learned, another on the line where the work finished. Two separate lines can't be grouped together, so questions like that had no answer even though nothing was missing.

This makes each piece of work leave **one line that holds its whole story**. It covers two surfaces: an HTTP request in `server`, and a research run in the Research context (which runs on its own, long after the request that asked for it has returned). It also adds a way to thin out the detailed traces without touching those lines, since the lines are the cheap part and the detail is the expensive part.

The prompt for it was [All you need is wide events](https://isburmistrov.substack.com/p/all-you-need-is-wide-events-not-metrics), and `docs/observability.md` is rewritten around it.

## Changes

**Touches:** the catch-all middleware every request passes through, the research run's start-and-finish path, the shared exporter package that ships all of it to a vendor, and the observability guide — plus the sign-in and tenant-resolution steps, which now report what they learned instead of only tagging a trace.

- Work can report a fact from anywhere inside it, and the facts come back out together on the closing line. Code that reports a fact with nobody gathering it carries on quietly, so a background job or a test doesn't break.
- Facts are filtered on the way in, the same way values recorded on a trace already were. The gathered facts leave on a log line rather than on a trace, so filtering only the trace would have left a way straight around the scrubbing that exists to stop a mailbox password or an attached file being sent to a tracing vendor.
- A request that dies without ever producing a response now leaves a named line as well. Before, the hardest failures were the only ones with no name to filter on.
- `OTEL_TRACES_KEEP_RATE` keeps a share of traces. The decision is taken once when a trace starts and inherited by everything under it, so a trace is kept or dropped whole rather than arriving with its middle missing.
- Every research log line now carries a name in a field rather than in its message text, so they can be grouped by kind instead of matched on words. The lines written at start-up used to spell the chosen providers into a sentence; they now carry the port and the vendor list as fields.
- A research run ends with one line holding what it spent, split by the model that actually answered it — which matters because a run that falls back partway is not the model it was configured with.

## Impact

- **A new setting, but nothing to set.** `OTEL_TRACES_KEEP_RATE` defaults to keeping every trace, so production does not have to set it and the server boots fine without it. If it is ever set to something unusable — a comma instead of a dot, a stray word — it falls back to keeping everything rather than refusing to start. That fallback is deliberate: reading it as a plain number would have failed the whole settings load and stopped the process over a typo in a knob that only thins traces.
- **Both ways in are now equal (MCP and HTTP).** Requests over MCP — how an AI client talks to the CRM — get their record too, including refused ones, and a refusal now says *why* on the request's own line. Getting there needed the middleware order pinned: router-wide middleware wraps in reverse registration order, registration order is layer build order, and Effect builds merged layers **concurrently**, so the position was incidental and could change with nobody editing it.
- **A refused MCP call now answers a browser properly.** The same unpinned ordering also governed CORS: refused before it ran, a 401 carried no cross-origin headers, so a browser client was told it was refused and could not read the challenge saying how to authenticate — and a preflight, which carries no credentials, was refused rather than answered. Both orderings now live in one named place (`withGlobalMiddlewareOrder`) that the server and its test share, so re-flattening the arrangement fails a test rather than only changing production.
- **Routine polls no longer fill the logs.** A successful health check or preflight drops to `debug` and is gone at the production level; the uptime checker and browsers between them can outnumber real requests. Anything that failed keeps its usual level.
- **More lands in the logs than before, on purpose.** Which tenant a request resolved to, how the caller signed in, and the outcome of a sign-in token exchange now appear on a log line rather than only on a trace. All of it is ids and fixed words — no names, no addresses, no content — and the scrubbing covers this route too.
- **Nothing about who can see what changed.** No database change, no migration, no change to the rules that keep one customer's rows away from another (row-level security), no change to which database role any path runs under.
- **No change to what anything costs.** The research run's line reads the existing spend tally at the end; it does not change what gets bought or how it is priced.
- **No shape change** to anything the frontend consumes.

## Review guide

- **Start here:** `apps/server/src/lib/observability-middleware.ts` — it's the whole idea in one file. Then `packages/observability/src/work-record.ts` for the thing it opens.
- **Riskiest part:** `packages/observability/src/work-record.ts`. If the filtering there is wrong, a caller-supplied value reaches the logs. That is the one thing I'd re-read rather than trust — the tests around it are the ones I'd trust least to be complete, because they test the rule I wrote rather than the rule I might have missed.
- **A decision you might overrule:** the research event-name pass leaves each message as it was and adds the name as a field, so message and field often read the same. The alternative was rewriting 49 messages into prose, which risked describing the code slightly wrong 49 times. I chose the boring one.
- **Mostly mechanical, skim it:** the bulk of `packages/research` is one added field per log call. The parts worth actual reading are the run's closing line and the guard next to `if (!claimed) return`.
- **Worth a second opinion:** `apps/server/src/lib/global-middleware-order.ts` — the two middlewares that must run outermost are *provided* to the rest of the app rather than merged alongside it, purely to force them to build first. It works and is covered by tests, but it uses a dependency edge to express ordering, which is a slightly unusual thing to do. If you'd rather see the registration written out explicitly instead, say so.
- **Deliberately not fixed:** the guard next to `if (!claimed) return` exists because without it a worker that steps aside would write a line claiming a run succeeded for nothing, dragging every cost average down. I only found that because I ran a real run rather than trusting the types.
- `docs/observability.md` is a rewrite, not a diff worth reading line by line — about a third of the old file was a copy of code that had already drifted from it.
- I did not run Snyk; the tool wasn't available in this session.

## Tests

- The work record: facts gathered from several places, newest value winning, two pieces of work not mixing, filtering applied, the size cap and its counter, and the fact reaching the trace as well as the line.
- The keep rate: kept/dropped whole, a child following its parent, a fresh decision for a span that starts its own trace, a route already exempted never revived, and every way the setting can be mistyped.
- The middleware order, through the same function the server uses rather than a copy: a request refused before it reaches its route still leaves exactly one record, and still carries its cross-origin headers; a request nothing refuses reaches its route and is recorded too. **Mutation-checked** — merging either middleware instead of providing it fails the matching test.
- The middleware: a fact from deep inside landing on the closing line, the request's own identity winning a name collision, a 5xx logging as an error, and a crash still leaving a named line. **I checked these tests actually fail when the behaviour is removed** — deleting the line that opens the record fails 3 of them, deleting the collision guard fails 1, deleting the crash line's name fails 1.

## Verification

- Gates, all run on the rebased branch: `pnpm install` (no lockfile drift), `pnpm -w check-types` 13/13, `pnpm -w test` 21/21, `pnpm -w build` 13/13.
- Against the live local stack: sent a request and read its closing line back from `apps/server/server.log`, confirming a fact recorded deep inside a handler arrived on the same line as the outcome.
- Queued a real research run against stub providers and read its `research.run` line back; also confirmed a run inserted as already-taken writes no line at all.
- Booted the exporter layer across seven keep-rate values — including a comma decimal, a word, and blank — confirming each either applies or falls back, and never stops the process.
- Confirmed the start-up provider lines now come out as fields rather than a sentence.
- Confirmed a successful health poll now records at `debug` while a real request still records at `info`.
- Sent an unauthenticated MCP request from a browser origin and confirmed the refusal carries `access-control-allow-origin`, alongside its record — `http.path_pattern=/mcp mcp.auth_rejected_reason=no_session event=http.request http.status=401` — where before it produced no record at all.
- After rebasing onto current `main`, I re-ran the coverage check and found six log lines the newly-landed commits had added with no name; those are fixed here, and both live checks were repeated on the new base.

## Deferred

- Proving the per-model cost split against a real run. Stub providers spend nothing, so the split is type-checked and its plumbing verified, but I have not watched a real model name appear in one.
- A way to force a particular trace to be kept when chasing a report. Not needed while the default keeps everything.
- Folding the research spend tally and the work record into one mechanism. They are the same shape, but the tally prices and buckets as it goes, and merging money-critical code into a brand-new mechanism did not belong in this change.
