### PR TITLE
fix(research): stop a search dropping a company for sharing an address

### DIFF
--- a/packages/research/src/application/eval-scoring-market.ts
+++ b/packages/research/src/application/eval-scoring-market.ts
@@ -15,6 +15,7 @@ import type { MarketPart, RunOutcome } from './eval-scoring-types'
 import {
 	branchOfficeParents,
 	discoveryRowIdentityKeys,
+	hostsEstablishedAsOwn,
 } from './prospect-dedupe-guard'
 import { anyTermAppearsIn, termTokens } from './term-match'
 
@@ -85,8 +86,9 @@ export const isKnownNonCompany = (
  * companies they turn out to be.
  *
  * Two rows are one company when they share a name with the legal form off the end,
- * share a site host, or one reads as the other's branch office — the same three ways
- * the scan itself folds rows, and sameness carries across all of them.
+ * share a site host once the domain spells one of them, or one reads as the other's
+ * branch office — the same three ways the scan itself folds rows, and sameness
+ * carries across all of them.
  *
  * Reusing what the fold uses is what this number is worth and what bounds it. The
  * list it reads has already been folded that way, so nothing it can see should be
@@ -109,6 +111,10 @@ export const duplicatedRows = (rows: RunOutcome['companies']): number => {
 		...(row.location === null ? {} : { location: row.location }),
 	}))
 	const parentOfBranch = branchOfficeParents(asDiscoveryRows)
+	// Read over the whole returned list, which is the list the fold read too. Asking
+	// row by row would make this stricter than the fold it measures, and call a list
+	// clean while it still holds the pairs the fold joins on a site.
+	const ownSiteHosts = hostsEstablishedAsOwn(asDiscoveryRows)
 
 	// Each company found so far, as the keys its rows filed under. A row meeting one
 	// of them is that company again; a row meeting two proves those two were one
@@ -119,8 +125,10 @@ export const duplicatedRows = (rows: RunOutcome['companies']): number => {
 		const parent = parentOfBranch.get(at)
 		const parentRow = parent === undefined ? undefined : asDiscoveryRows[parent]
 		const keys = [
-			...discoveryRowIdentityKeys(row),
-			...(parentRow === undefined ? [] : discoveryRowIdentityKeys(parentRow)),
+			...discoveryRowIdentityKeys(row, ownSiteHosts),
+			...(parentRow === undefined
+				? []
+				: discoveryRowIdentityKeys(parentRow, ownSiteHosts)),
 		]
 		const matched = companies.filter(company =>
 			keys.some(key => company.has(key)),

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -857,8 +857,33 @@ describe('scoring a run that answered for a whole market', () => {
 				}),
 			)
 
-			// WHEN scored — THEN the shared site is enough
+			// WHEN scored — THEN the shared site is enough, because the domain spells
+			// one of the two names and so says whose site it is
 			expect(score.market?.rowsDuplicated).toBe(1)
+		})
+
+		it('should count two rows on a website neither of them is named by as two companies', () => {
+			// GIVEN two installers each given a page on a trade body's member list
+			const score = scoreRun(
+				marketGolden(),
+				outcome({
+					companies: [
+						company({
+							name: 'Electricidad Mora',
+							website: 'https://aemiat.example/e-mora/',
+						}),
+						company({
+							name: 'Instalaciones Rubio',
+							website: 'https://aemiat.example/rubio/',
+						}),
+					],
+				}),
+			)
+
+			// WHEN scored — THEN neither is a duplicate of the other, which is what the
+			// fold decided too. A count reading the list more loosely than the fold
+			// would report duplicates the fold is right to have left standing
+			expect(score.market?.rowsDuplicated).toBe(0)
 		})
 
 		it('should carry sameness across a chain of rows', () => {

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -613,22 +613,28 @@ describe('mergePerFieldSearch', () => {
 		})
 
 		it('should fold a company the round gave the site of one already listed', () => {
-			// GIVEN a company with its site, and a round that names it again under a
-			// different name and hands it the same site — the shape a live run returned
-			// as two rows both on aeroxsense.com
+			// GIVEN a company at the domain that spells its name, and a round that names
+			// it again under a longer name and hands it the same site — the shape a live
+			// run returned as two rows both on aeroxsense.com
 			const findings = {
-				prospects: [{ name: 'AeroXsense', website: 'https://www.aero.test/' }],
+				prospects: [
+					{ name: 'AeroXsense', website: 'https://www.aeroxsense.test/' },
+				],
 			}
 			const refreshed = {
 				prospects: [
-					{ name: 'AeroXsense (Fire Safety)', website: 'https://aero.test/' },
+					{
+						name: 'AeroXsense (Fire Safety)',
+						website: 'https://aeroxsense.test/',
+					},
 				],
 			}
 			// WHEN merged
 			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
 			const rows = prospectsOf(merged.findings)
-			// THEN the shared host settles it here too. A row appended by a round is
-			// never put in front of the fold again unless this step folds it
+			// THEN the shared host settles it here too, because the domain says whose it
+			// is. A row appended by a round is never put in front of the fold again
+			// unless this step folds it
 			expect(rows).toHaveLength(1)
 			expect(merged.added).toBe(0)
 		})
@@ -749,6 +755,194 @@ describe('mergePerFieldSearch', () => {
 			// with or told apart from another
 			expect(merged.added).toBe(0)
 			expect(merged.findings).toBe(findings)
+		})
+
+		it('should keep a company a round met on the trade body page a listed one was given', () => {
+			// GIVEN a company already on the list, standing on the page a trade body's
+			// member list gave it
+			const findings = {
+				prospects: [
+					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				],
+			}
+			// AND a round that names a different installer and hands it a page on that
+			// same member list — one claimant each time, so nothing before this fold
+			// ever sees the two of them together
+			const refreshed = {
+				prospects: [
+					{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+
+			// THEN both companies ship. The domain spells neither of them, so it is
+			// nobody's own site and is no reason to call them one company
+			expect(rows.map(row => row['name'])).toEqual([
+				'Electricidad Mora',
+				'Instalaciones Rubio',
+			])
+			// AND the round is credited with the find, or the rounds stop a round early
+			// on the reading that it turned up nobody
+			expect(merged.added).toBe(1)
+			// AND the fold reports that it joined no row to another, which is the
+			// number that would show this company going missing
+			expect(merged.folded).toBe(0)
+		})
+
+		it('should report the row it folds when a round shows two listed companies are one', () => {
+			// GIVEN two rows the list holds under different names, one of them on the
+			// domain that spells the other
+			const findings = {
+				prospects: [
+					{ name: 'Terre Solaire', why_relevant: 'Installer.' },
+					{
+						name: 'Soleil du Sud',
+						website: 'https://terresolaire.test/mentions-legales',
+					},
+				],
+			}
+			// AND a round that brings the first row the site it had been missing
+			const refreshed = {
+				prospects: [
+					{ name: 'Terre Solaire', website: 'https://terresolaire.test' },
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+
+			// THEN one company, and the fold says it joined a row — a real fold, for
+			// the good reason that the site now says the two rows are one company
+			expect(prospectsOf(merged.findings).map(row => row['name'])).toEqual([
+				'Terre Solaire',
+			])
+			expect(merged.folded).toBe(1)
+			// AND nothing is credited as found, because nobody new was
+			expect(merged.added).toBe(0)
+		})
+
+		it('should keep every company a run of rounds meets on one trade body host', () => {
+			// GIVEN a first list of one company on a member page
+			let findings: unknown = {
+				prospects: [
+					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				],
+			}
+			// AND three more rounds, each naming one more installer on that same host
+			const rounds = [
+				{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+				{ name: 'Montajes Tejero', website: 'https://aemiat.com/tejero/' },
+				{ name: 'Climatización Sanz', website: 'https://aemiat.com/sanz/' },
+			]
+
+			// WHEN each round is folded in as the run folds it
+			for (const found of rounds) {
+				findings = mergePerFieldSearch(
+					findings,
+					{ prospects: [found] },
+					SCAN,
+				).findings
+			}
+
+			// THEN four rows went in and four come out. Each round is innocent on its
+			// own, and it is only what they add up to that could shorten the list
+			expect(prospectsOf(findings).map(row => row['name'])).toEqual([
+				'Electricidad Mora',
+				'Instalaciones Rubio',
+				'Montajes Tejero',
+				'Climatización Sanz',
+			])
+		})
+
+		it('should fold a round onto the listed company whose name the domain spells', () => {
+			// GIVEN a company on the list at the domain that spells its name
+			const findings = {
+				prospects: [
+					{ name: 'Terre Solaire', website: 'https://terresolaire.test' },
+				],
+			}
+			// AND a round meeting it again under a legal name the domain says nothing of
+			const refreshed = {
+				prospects: [
+					{
+						name: 'SAS Soleil du Sud',
+						website: 'https://terresolaire.test/mentions-legales',
+						location: 'Lyon',
+					},
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+
+			// THEN one company, which gained the town the round found. Who owns the
+			// domain is read over both sides at once, so the listed row's name settles
+			// the site for the round's row as well — the trade name beside the legal
+			// one, which is what this fold is for
+			expect(rows.map(row => row['name'])).toEqual(['Terre Solaire'])
+			expect(rows[0]?.['location']).toBe('Lyon')
+			expect(merged.added).toBe(0)
+			// AND the join is reported, because a website joined two names on its own
+			// — rightly this time, but that is the shape that can go wrong
+			expect(merged.folded).toBe(1)
+		})
+
+		it('should not report a round that meets listed companies by their names', () => {
+			// GIVEN a list of two companies and a round that re-reads both of them,
+			// which is what every round ordinarily does
+			const findings = {
+				prospects: [
+					{ name: 'Acme Instal' },
+					{ name: 'Beta Muntatges', website: 'https://beta.test' },
+				],
+			}
+			const refreshed = {
+				prospects: [
+					{ name: 'Acme Instal SL', location: 'Girona' },
+					{ name: 'Beta Muntatges', location: 'Reus' },
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+
+			// THEN nothing is reported as joined. The rows met by name, which is the
+			// reason the rounds run at all — counting those would bury the one join
+			// this number exists to show
+			expect(prospectsOf(merged.findings)).toHaveLength(2)
+			expect(merged.folded).toBe(0)
+		})
+
+		it('should keep a round company that meets a listed one on neither a name nor a site', () => {
+			// GIVEN a company first met under a legal name, with no site
+			const findings = {
+				prospects: [{ name: 'Soleil du Sud SAS', why_relevant: 'Installer.' }],
+			}
+			// AND a round that names what is really the same firm under its trading
+			// name, bringing the domain that spells that one
+			const refreshed = {
+				prospects: [
+					{ name: 'Terre Solaire', website: 'https://terresolaire.test' },
+				],
+			}
+
+			// WHEN merged
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const rows = prospectsOf(merged.findings)
+
+			// THEN two rows, because nothing yet ties the two names together: the listed
+			// row carries no site to be met on. The cost of this fold's care is a
+			// duplicate the reader sorts out, never a company taken off the list
+			expect(rows.map(row => row['name'])).toEqual([
+				'Soleil du Sud SAS',
+				'Terre Solaire',
+			])
+			expect(merged.added).toBe(1)
+			expect(merged.folded).toBe(0)
 		})
 
 		it('should keep a company the second look no longer names', () => {

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -27,6 +27,8 @@ import { isPlainObject, isValueWrapper, unwrapValue } from './guard-shapes'
 import {
 	dedupeDiscoveryRows,
 	discoveryRowIdentityKeys,
+	hostsEstablishedAsOwn,
+	isSiteKey,
 } from './prospect-dedupe-guard'
 
 // The company-profile facts worth spending an extra search on. `size_range` is
@@ -224,6 +226,22 @@ export interface PerFieldMerge {
 	 * list, and has found nobody.
 	 */
 	readonly added: number
+	/**
+	 * How many companies went into this fold and did not come out as a row of
+	 * their own, other than by carrying a name the list already held. Usually none.
+	 *
+	 * Not a count of mistakes — a round that fills in the site showing two listed
+	 * companies were always one folds a row away for a good reason. It is reported
+	 * because nothing else shows the opposite case: a company a round found, taken
+	 * for one already listed on a website belonging to neither, and gone from the
+	 * answer with nothing said. The duplicate figure cannot show that, since a row
+	 * that was dropped is not a duplicate.
+	 *
+	 * A round that re-reads companies already listed is not counted, however many
+	 * it re-reads: they meet by name, which is the ordinary case and the reason
+	 * the rounds run at all.
+	 */
+	readonly folded: number
 }
 
 /**
@@ -256,7 +274,7 @@ const mergeScanRows = (
 		findings === null ||
 		typeof findings !== 'object'
 	) {
-		return { findings, filled: 0, contactsChanged: false, added: 0 }
+		return { findings, filled: 0, contactsChanged: false, added: 0, folded: 0 }
 	}
 	// Rows are matched on what identifies the company — its name with the legal
 	// form off the end, or its site — not on the name as written. A second look
@@ -264,17 +282,23 @@ const mergeScanRows = (
 	// legal name, so matching the name as written files it as somebody new: the
 	// list grows a second copy instead of the first copy gaining what the round
 	// went looking for.
+	//
+	// Who owns which site is read off both sides at once. A round meets a company
+	// under a name that does not spell its domain while the list already holds it
+	// under one that does — and asking each side on its own would leave the site
+	// speaking for the row that has it and silent for the row that needs it.
+	const ownSiteHosts = hostsEstablishedAsOwn([...known, ...found])
 	const foundByKey = new Map<string, Record<string, unknown>>()
 	for (const row of found) {
 		// First mention wins: a later duplicate of the same company in the same
 		// re-extraction has no better claim, and picking one keeps the fold stable.
-		for (const key of discoveryRowIdentityKeys(row)) {
+		for (const key of discoveryRowIdentityKeys(row, ownSiteHosts)) {
 			if (!foundByKey.has(key)) foundByKey.set(key, row)
 		}
 	}
 	let filled = 0
 	const merged = known.map(row => {
-		const match = discoveryRowIdentityKeys(row)
+		const match = discoveryRowIdentityKeys(row, ownSiteHosts)
 			.map(key => foundByKey.get(key))
 			.find(found => found !== undefined)
 		if (match === undefined) return row
@@ -293,19 +317,38 @@ const mergeScanRows = (
 	// company twice appends it once. A duplicate would not only read badly — the
 	// list's length is what decides whether a scan came back too thin to trust,
 	// so counting one company twice can pass a scan off as healthier than it is.
-	const taken = new Set(known.flatMap(row => discoveryRowIdentityKeys(row)))
+	const taken = new Set(
+		known.flatMap(row => discoveryRowIdentityKeys(row, ownSiteHosts)),
+	)
+	// Companies this round named that a site alone joined to one already listed.
+	// Counted here because this is where such a row stops being a row: it is not
+	// appended, and no later step sees it to fold or to report.
+	let joinedOnSite = 0
 	const additions = found.filter(row => {
 		// Matching an existing company takes any of the keys; becoming a new row in
 		// the list takes a name. A company nobody can name is one nobody can work
 		// with, whatever else is known about it.
 		if (rowName(row) === undefined) return false
-		const keys = discoveryRowIdentityKeys(row)
-		if (keys.some(key => taken.has(key))) return false
+		const keys = discoveryRowIdentityKeys(row, ownSiteHosts)
+		const metOn = keys.filter(key => taken.has(key))
+		if (metOn.length > 0) {
+			// A round re-reading a company it already found meets it by name, which
+			// is the ordinary case and says nothing. A round whose company only ever
+			// met a listed one through a website is the case worth watching.
+			if (metOn.every(isSiteKey)) joinedOnSite++
+			return false
+		}
 		for (const key of keys) taken.add(key)
 		return true
 	})
 	if (filled === 0 && additions.length === 0) {
-		return { findings, filled: 0, contactsChanged: false, added: 0 }
+		return {
+			findings,
+			filled: 0,
+			contactsChanged: false,
+			added: 0,
+			folded: joinedOnSite,
+		}
 	}
 	// This round has just moved the ground under the fold that ran before the rounds
 	// began: it appends companies that fold never saw, and fills in the website of a
@@ -345,6 +388,14 @@ const mergeScanRows = (
 			before === undefined || after === undefined
 				? additions.length
 				: Math.max(0, after - before),
+		// The companies a site joined to one already listed, plus the rows this fold
+		// then joined to another — rows in, less rows out. A company the round
+		// simply did not name again is not in either: it stays on the list.
+		folded:
+			joinedOnSite +
+			(after === undefined
+				? 0
+				: Math.max(0, merged.length + additions.length - after)),
 	}
 }
 
@@ -370,7 +421,7 @@ export const mergePerFieldSearch = (
 	const enrichment = enrichmentOf(findings)
 	const refreshedEnrichment = enrichmentOf(refreshed)
 	if (enrichment === undefined || refreshedEnrichment === undefined) {
-		return { findings, filled: 0, contactsChanged: false, added: 0 }
+		return { findings, filled: 0, contactsChanged: false, added: 0, folded: 0 }
 	}
 	let filled = 0
 	const nextEnrichment: Record<string, unknown> = { ...enrichment }
@@ -391,7 +442,7 @@ export const mergePerFieldSearch = (
 		contacts.length !== known.length ||
 		contacts.some((contact, index) => contact !== known[index])
 	if (filled === 0 && !contactsChanged) {
-		return { findings, filled: 0, contactsChanged: false, added: 0 }
+		return { findings, filled: 0, contactsChanged: false, added: 0, folded: 0 }
 	}
 	return {
 		findings: {
@@ -402,5 +453,6 @@ export const mergePerFieldSearch = (
 		filled,
 		contactsChanged,
 		added: 0,
+		folded: 0,
 	}
 }

--- a/packages/research/src/application/prospect-dedupe-guard.test.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest'
 import {
 	branchOfficeParents,
 	dedupeDiscoveryRows,
+	discoveryRowIdentityKeys,
+	hostsEstablishedAsOwn,
+	isSiteKey,
 } from './prospect-dedupe-guard'
 
 const scan = (
@@ -256,6 +259,88 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN no host can be read, so neither row lends one
 			const result = dedupeDiscoveryRows(findings, 'prospects')
 			expect(rowsOf(result.findings)).toHaveLength(2)
+		})
+
+		it('should keep two companies handed a page each on a host neither is named by', () => {
+			// GIVEN two installers each given their page in a trade body's member list
+			const findings = scan([
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+			])
+
+			// WHEN de-duplicated
+			// THEN both stay. The domain spells neither of them, so it is nobody's own
+			// site and says nothing about whether these are one company
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings).map(row => row['name'])).toEqual([
+				'Electricidad Mora',
+				'Instalaciones Rubio',
+			])
+			expect(result.merged).toBe(0)
+		})
+
+		it("should not carry sameness through a host that is nobody's own", () => {
+			// GIVEN A and B meeting by name, and C sharing only the trade body's host
+			const findings = scan([
+				{ name: 'Electricidad Mora SL', why_relevant: 'A.' },
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+			])
+
+			// WHEN de-duplicated
+			// THEN the two spellings of one name still meet, and the third company is
+			// not dragged in behind them by an address none of the three owns
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings).map(row => row['name'])).toEqual([
+				'Electricidad Mora SL',
+				'Instalaciones Rubio',
+			])
+			expect(result.merged).toBe(1)
+		})
+	})
+
+	describe('when a host belongs to one of the rows standing on it', () => {
+		it('should fold a row given a page on a company site that spells that company', () => {
+			// GIVEN a company at the domain that spells its name, and a second row the
+			// run put on a page of that same site under a name of its own
+			const findings = scan([
+				{ name: 'Terre Solaire', website: 'https://terresolaire.com/' },
+				{
+					name: 'SAS Soleil du Sud',
+					website: 'https://terresolaire.com/qui-sommes-nous',
+				},
+			])
+
+			// WHEN de-duplicated
+			// THEN one company. The domain says whose site it is, so the row beside it
+			// is that company again under another name — the trade name beside the
+			// legal one, which is the pair this fold exists for
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(rowsOf(result.findings)[0]?.['name']).toBe('Terre Solaire')
+		})
+
+		it('should let a third row establish the host the other two stand on', () => {
+			// GIVEN two rows on a host neither of their names spells, and a third row
+			// whose name does
+			const findings = scan([
+				{
+					name: 'Sociedad Ibérica de Construcciones Eléctricas',
+					website: 'https://sice.com/es',
+				},
+				{
+					name: 'Ibérica de Señalización Vial',
+					website: 'https://sice.com/senalizacion',
+				},
+				{ name: 'SICE', website: 'https://www.sice.com' },
+			])
+
+			// WHEN de-duplicated
+			// THEN all three are one company. Who owns a domain is read across the whole
+			// list, so the row that spells it settles the host for every row on it
+			const result = dedupeDiscoveryRows(findings, 'prospects')
+			expect(rowsOf(result.findings)).toHaveLength(1)
+			expect(result.merged).toBe(2)
 		})
 	})
 
@@ -748,6 +833,131 @@ describe('branchOfficeParents', () => {
 			// GIVEN nothing to read
 			// WHEN the branches are worked out — THEN there are none
 			expect(branchOfficeParents([])).toEqual(new Map())
+		})
+	})
+})
+
+describe('hostsEstablishedAsOwn', () => {
+	describe('when a row stands at the domain that spells it', () => {
+		it("should read the host as that company's own", () => {
+			// GIVEN a workshop at the domain carrying its name
+			const rows = [
+				{
+					name: 'Fusteria Miquel',
+					website: 'https://fusteriamiquel.cat/qui-som',
+				},
+			]
+
+			// WHEN the owned hosts are worked out — THEN the host is one of them
+			expect(hostsEstablishedAsOwn(rows)).toEqual(
+				new Set(['fusteriamiquel.cat']),
+			)
+		})
+
+		it('should file the host the way a row files it, with the www off', () => {
+			// GIVEN one row writing the address with www and another without
+			const rows = [
+				{ name: 'SICE', website: 'https://www.sice.com' },
+				{
+					name: 'Sociedad Ibérica de Construcciones',
+					website: 'https://sice.com/es',
+				},
+			]
+
+			// WHEN the owned hosts are worked out
+			// THEN one host, spelled the way the identity keys spell it — otherwise the
+			// row that establishes a site and the row that needs it never meet
+			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set(['sice.com']))
+		})
+	})
+
+	describe('when nothing establishes who a host belongs to', () => {
+		it('should leave out a host that spells neither company on it', () => {
+			// GIVEN two installers on a trade body's member pages
+			const rows = [
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+			]
+
+			// WHEN the owned hosts are worked out — THEN there are none
+			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+		})
+
+		it('should leave out a host merely carrying a word of the name', () => {
+			// GIVEN a listing site whose own domain happens to open with the name
+			const rows = [
+				{ name: 'Acme', website: 'https://acme-directory.com/acme' },
+			]
+
+			// WHEN the owned hosts are worked out
+			// THEN none. A domain has to BE the name, or every listing filed under a
+			// company would clear itself as that company's site
+			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+		})
+
+		it('should pass over a row with no name to judge the domain against', () => {
+			// GIVEN a row that gives a site and never says whose it is
+			const rows = [{ website: 'https://terresolaire.com/' }]
+
+			// WHEN the owned hosts are worked out — THEN nothing is established, which
+			// is the answer rather than a missing one
+			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+		})
+
+		it('should pass over a row whose name is empty', () => {
+			// GIVEN a row whose name field came back blank
+			const rows = [{ name: '   ', website: 'https://terresolaire.com/' }]
+
+			// WHEN the owned hosts are worked out — THEN a blank spells no domain, so
+			// the site is left standing for nobody
+			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+		})
+
+		it('should pass over a row whose website is not an address', () => {
+			// GIVEN a row answering the website question in words
+			const rows = [
+				{
+					name: 'Terre Solaire',
+					website: 'https://terresolaire.com (inferred)',
+				},
+			]
+
+			// WHEN the owned hosts are worked out — THEN there is no domain to read
+			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+		})
+
+		it('should pass over list entries that are not rows', () => {
+			// GIVEN a list holding a null beside a real row
+			const rows = [
+				null,
+				'not a row',
+				{ name: 'SICE', website: 'https://sice.com' },
+			]
+
+			// WHEN the owned hosts are worked out — THEN only the real row is read
+			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set(['sice.com']))
+		})
+
+		it('should find nothing in an empty list', () => {
+			// GIVEN nothing to read
+			// WHEN the owned hosts are worked out — THEN there are none
+			expect(hostsEstablishedAsOwn([])).toEqual(new Set())
+		})
+	})
+})
+
+describe('isSiteKey', () => {
+	describe('when asked which of the two keys joined a pair of rows', () => {
+		it('should tell a key filed under a site from one filed under a name', () => {
+			// GIVEN the keys a row with both a name and its own site files under
+			const keys = discoveryRowIdentityKeys(
+				{ name: 'SICE', website: 'https://sice.com' },
+				new Set(['sice.com']),
+			)
+
+			// WHEN each is asked — THEN only the site key says yes, so a caller can
+			// count the joins a website made without taking a key apart itself
+			expect(keys.map(isSiteKey)).toEqual([false, true])
 		})
 	})
 })

--- a/packages/research/src/application/prospect-dedupe-guard.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.ts
@@ -12,7 +12,8 @@
  * Two rows are the same company when either their names or their sites say so:
  *  - the same name once its legal form is off the end, so "…y Servicios" and
  *    "…Y SERVICIOS SA" meet, and accents fold on the way;
- *  - the same site host, which catches the pair a rename or a trade name hides.
+ *  - the same site host, once the domain spells one of them, which catches the pair
+ *    a rename or a trade name hides.
  * Either alone is enough, and sameness carries: A meeting B by name and B meeting C
  * by host makes all three one company, which is what they are.
  *
@@ -40,8 +41,23 @@
  * others rather than the first arrival standing for all of them — a company working
  * from four towns is worth knowing about, and four towns is what the run found.
  *
- * It runs after the website check, so a member-directory address several rows shared
- * is already gone by the time a host counts as evidence two rows are one company.
+ * A shared host only counts once something establishes it as one of the rows' own
+ * site. The website check ahead of this does blank an address several rows claim and
+ * none of them is named by — but it weighs one reading at a time, and a search that
+ * looks again round after round hands it a single claimant each time. A trade body's
+ * member page given to one company this round and to another the next is never two
+ * claims at once, so it survives every pass and arrives here looking like a site two
+ * rows share. What tells that apart from a real shared site is whether the domain
+ * spells either company: a host that is nobody's own is no evidence that two
+ * companies are one. Where it is somebody's own, the rows beside them on it are that
+ * company again under another name, which is the pair this fold exists for.
+ *
+ * What that costs, on purpose: one company written twice at a domain that spells
+ * neither writing of it — an acronym, a name with a word in front — stays two rows,
+ * and the reader sorts it out. That is the direction to be wrong in. A duplicate is
+ * a nuisance on a list somebody reads; a wrong fold takes a real company off it with
+ * nothing said, and — since a row is confirmed by the websites naming it — hands the
+ * survivor evidence gathered about somebody else.
  */
 
 import {
@@ -53,7 +69,12 @@ import {
 	withoutFormDots,
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
+import { ownSiteVerdict } from './own-site'
 import { hostOf, isBareWebAddress } from './source-key'
+
+// What marks a key as filing a row under its site. Written once, because a caller
+// asking which key joined two rows reads the same mark this writes.
+const SITE_KEY_PREFIX = 'host:'
 
 // The host of a row's own site, or null when the field holds nothing an address can
 // be read from. Null is also what a branch page looks like: it is the head office
@@ -66,9 +87,51 @@ const siteHostOf = (row: Record<string, unknown>): string | null => {
 }
 
 /**
+ * The hosts among these rows that a row is established as owning — the domain
+ * spells that company, so the site is plainly its own.
+ *
+ * Read across the whole list at once rather than row by row, because the pair this
+ * answers for is a company met under two names: "SICE" on sice.com beside
+ * "Sociedad Ibérica de Construcciones Eléctricas" on the same host, where only the
+ * first name spells the domain. One row establishing the host settles who it
+ * belongs to for every row standing on it — the same reasoning the website check
+ * makes when it stands its shared-host rule down.
+ *
+ * Nothing here clears a host, and nothing needs to: a host no row establishes is
+ * `unknown`, which is not a verdict that two rows are different companies. It is
+ * only the absence of a reason to say they are the same one, and the names still
+ * have their say.
+ */
+export const hostsEstablishedAsOwn = (
+	rows: ReadonlyArray<unknown>,
+): ReadonlySet<string> => {
+	const hosts = new Set<string>()
+	for (const row of rows) {
+		if (!isPlainObject(row)) continue
+		const website = row['website']
+		const name = row['name']
+		// Nothing to read: no address, or no company for a domain to spell. Either
+		// way nothing is established, which is the answer rather than a missing one.
+		if (typeof website !== 'string' || typeof name !== 'string') continue
+		// Filed under the host the identity key would file it under, so the row that
+		// establishes a site and the row that needs it meet on the same spelling.
+		const host = siteHostOf(row)
+		if (host === null) continue
+		if (ownSiteVerdict({ name, website }) === 'established') hosts.add(host)
+	}
+	return hosts
+}
+
+/**
  * What a row is filed under: its name with the legal form off the end, and the host
- * of its site. Either identifies the company on its own. A key nothing can be read
- * from is left out rather than becoming a key every thin row shares.
+ * of its site when that host is one of `ownSiteHosts`. Either identifies the company
+ * on its own. A key nothing can be read from is left out rather than becoming a key
+ * every thin row shares.
+ *
+ * `ownSiteHosts` comes from `hostsEstablishedAsOwn`, over every row this key is
+ * about to be compared against — both sides of a fold, not one. It is asked for
+ * rather than worked out here so a caller cannot compare keys read from two
+ * different readings of who owns what.
  *
  * Exported because the fold here is not the only place one company can arrive
  * twice: a later round that looks again for a company's missing fields matches what
@@ -77,6 +140,7 @@ const siteHostOf = (row: Record<string, unknown>): string | null => {
  */
 export const discoveryRowIdentityKeys = (
 	row: Record<string, unknown>,
+	ownSiteHosts: ReadonlySet<string>,
 ): ReadonlyArray<string> => {
 	const keys: Array<string> = []
 	const name = row['name']
@@ -89,9 +153,21 @@ export const discoveryRowIdentityKeys = (
 		if (filedAs !== '') keys.push(`name:${filedAs}`)
 	}
 	const host = siteHostOf(row)
-	if (host !== null) keys.push(`host:${host}`)
+	if (host !== null && ownSiteHosts.has(host))
+		keys.push(`${SITE_KEY_PREFIX}${host}`)
 	return keys
 }
+
+/**
+ * Whether a key files a row under its site rather than its name.
+ *
+ * Exported so a caller can tell which of the two joined two rows without taking
+ * the key apart itself. A join two names made is the ordinary one; a join a site
+ * made on its own is the one worth counting, and it is what the fold is asked to
+ * be careful about.
+ */
+export const isSiteKey = (key: string): boolean =>
+	key.startsWith(SITE_KEY_PREFIX)
 
 // Whether one name says another name and then more, word for word — "Terre Solaire"
 // starts "Terre Solaire – agence Lyon". Whole words, because the letters alone would
@@ -315,10 +391,12 @@ export const dedupeDiscoveryRows = (
 			// them in however the two rows turn out to be joined up.
 			companyOfRow[Math.max(one, other)] = Math.min(one, other)
 		}
+
+		const ownSiteHosts = hostsEstablishedAsOwn(rows)
 		const rowOfKey = new Map<string, number>()
 		rows.forEach((row, at) => {
 			if (!isPlainObject(row)) return
-			for (const key of discoveryRowIdentityKeys(row)) {
+			for (const key of discoveryRowIdentityKeys(row, ownSiteHosts)) {
 				const seen = rowOfKey.get(key)
 				if (seen === undefined) rowOfKey.set(key, at)
 				else sameCompany(seen, at)

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -5428,6 +5428,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								'research.per_field_search.fired': perFieldFired,
 								'research.per_field_search.filled': merged.filled,
 								'research.per_field_search.added': merged.added,
+								'research.per_field_search.folded': merged.folded,
 								'research.gap_rounds.contacts_kept':
 									contactFill(findings).named,
 								'research.gap_rounds.titled_kept': contactFill(findings).titled,
@@ -5441,6 +5442,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									fired: perFieldFired,
 									filled: merged.filled,
 									added: merged.added,
+									// Ordinarily none, and not every one is a mistake — but a
+									// company this round found and never shipped is counted here
+									// and nowhere else.
+									folded: merged.folded,
 								}),
 							)
 							// This round put new evidence in front of the model and it still


### PR DESCRIPTION
## What

A search for a whole market does not write its list of companies once. It writes a first list, then runs up to four more rounds hunting for whatever is still missing, and folds each round's result into the list it already has. When it folds, it decided two entries were the same company if they shared a web address.

That is usually right, and it is the only thing that joins one firm found twice under two spellings of its name. But when the address they share belongs to **neither** of them — a trade body's member page that the model handed to both of its members — the fold read it as proof they were one company, kept the first and dropped the second. A real company disappeared from the answer and nothing said so. This is in the research pipeline (the Research bounded context, `packages/research`), and it reaches both the MCP and the HTTP surface, since both run the same service.

The check meant to catch exactly that address could not help. It condemns a host only when two differently-named companies claim it **at the same time**, and across rounds it never sees two — each round is checked on its own, with one claimant, so the address survives and is then used as identity evidence.

## The fix

**Touches:** the fold that decides two rows are one company, the step that merges each extra round into the list, and the eval's own duplicate count that reads a finished list with the same eyes. The website check that blanks obviously-wrong addresses is unchanged, and so is the order the steps run in.

- A shared web address now counts as identity only where something establishes it as one of the rows' **own** site, using the verdict #476 shipped (`ownSiteVerdict`: the domain spells the company, or it is `unknown` — and `unknown` is not a clearance).
- Who owns a domain is read **across the whole list at once**, not row by row. Reading it per row would break the case the fold exists for: "SICE" beside "Sociedad Ibérica de Construcciones Eléctricas" on `sice.com`, where only the first name spells the domain. One row establishing a host settles it for every row standing on it — the same reasoning the website check already makes when it stands its shared-host rule down.
- The note at the top of the fold said such an address "is already gone by the time a host counts as evidence two rows are one company". Across rounds it is not gone, and the note now says what actually holds.
- The eval's duplicate count reads the same rule, so the number that watches the fold cannot quietly drift from the fold it watches.
- Each round now reports how many companies a website alone joined to one already on the list. The duplicate figure cannot show this, because a row that was dropped is not a duplicate — and nothing else showed it either.

## Impact

- **What ships changes**, which is the point: a company a later round finds is no longer deleted for standing on an address that belongs to neither it nor anyone already listed. On the two markets I re-ran live, nothing changed — 51 Spanish and 30 French companies, no duplicates, all five trades answered — so the change is not costing recall on real lists.
- **It matters more than when the issue was filed.** Now that a company is confirmed by the websites naming it (#486), a wrongly joined pair does not merely shorten the list: the surviving row inherits the other's citations, so it can be confirmed on sources that were never about it. I checked that path in the code rather than assuming it — the fold merges citations, and the existence verdict counts websites from the row's citations.
- **The cost, taken deliberately.** One company written twice at a domain that spells neither writing of it — an acronym, or a name with a word in front, both blind spots `own-site.ts` already documents — now stays two rows. That is the safe direction, and it is the failure #480 already tracks: a duplicate is a nuisance a reader sorts out by hand, while a wrong join takes a real company off the list silently.
- No database migration, no new environment variable, no change to which organisation can see what (nothing touching row-level security or `organization_id` scoping), no change to the public/protected boundary, and no change to the shape of anything the frontend reads.

## Review guide

- Start at `prospect-dedupe-guard.ts` — the new `hostsEstablishedAsOwn`, and the one line in `discoveryRowIdentityKeys` that now gates the host key. Everything else follows from those.
- **The riskiest decision, and the one to overrule if you disagree:** ownership is read across the whole list, so a host one row establishes vouches for *every* row standing on it. That preserves the trade-name/legal-name join, and it also means a company the model puts on a page of somebody else's real site still joins that company. I chose it because it matches what the website check already does; the stricter per-row reading would break the pinned `SICE` case.
- **What I could not verify:** the live re-run did not independently reproduce the bug. Of the rows that shipped, only 21 of 51 Spanish and 6 of 30 French carry a site at all, and no host is shared by two rows in either list — so the pattern simply did not arise in that sample. The bug rests on the deterministic reproduction, which I ran against current `main` before changing anything: `Instalaciones Rubio` dropped, `added: 0`.
- `eval-scoring-market.ts` and `research-service.ts` are small and mechanical — skim them.

## Tests

Unit, in the BDD shape. The important ones cover the **fold**, not each half of it, since every half here is innocent on its own: a company a later round meets on the trade body's page survives; four rounds on one trade-body host ship four companies; and the ordinary join — one firm under two names, joined by the site that really is its own — still folds. I confirmed the four behaviour tests fail with the gate removed, so they pin the fix rather than passing either way.

## Verification

- `pnpm check-types` (13/13), `pnpm test` (21/21 — research 1680, server 865), `pnpm build` (13/13), all re-run after rebasing onto current `main`.
- Live market eval on both rows of `eval/golden-markets.example.json`, against this branch's code: ES 51 rows / FR 30 rows, duplicates 0%, request coverage 5 of 5 parts, empty rate 0%, 14.5c per run. The Spanish run's three extra rounds reported one or two site-made joins each, so the fold's legitimate work is intact and the new counter fires on real data.
- I reproduced the bug on `main` first, and re-checked the counter by toggling the gate off — it reports the swallowed company.

## Deferred

The issue also notes a milder disagreement I have not fixed: when a round returns both companies, the website check blanks both of that round's copies, while the row carried over from an earlier round keeps the very address just condemned for the other. That is the website check's per-round scope rather than the fold's identity rule, and closing it means accumulating claims across rounds — a change with its own risk of blanking real websites. Worth its own issue if you want it.

Closes #483
