### PR TITLE
fix(cli): let worktree cleanup finish on a squash-merged branch

### DIFF
--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -790,6 +790,82 @@ export const worktreeDown = Effect.gen(function* () {
 	yield* Console.log(`✓ Removed ${db} and ${bucket} (shared stack untouched).`)
 })
 
+// Whether everything this branch changed is already on main.
+//
+// Asked by rolling the branch up into a single commit sitting on the point it
+// forked from, then letting git say whether that patch is already in main. That
+// is the shape a squash merge leaves behind, and comparing commit by commit
+// cannot see it. Any git failure here reads as "not already there", so a doubt
+// keeps the branch rather than deleting it.
+const branchWorkIsOnMain = (root: string, branch: string) =>
+	Effect.gen(function* () {
+		const git = (...args: ReadonlyArray<string>) =>
+			execSilentArgs('git', ['-C', root, ...args])
+		const forkedAt = yield* git('merge-base', 'main', branch)
+		const content = yield* git('rev-parse', `${branch}^{tree}`)
+		// A loose commit that is never referenced, so it costs one object git
+		// collects on its own; nothing points at it once this answer is read.
+		const rolledUp = yield* git(
+			'commit-tree',
+			content,
+			'-p',
+			forkedAt,
+			'-m',
+			'rolled up to compare against main',
+		)
+		// `git cherry` marks a patch main already carries with "-", and one it is
+		// missing with "+".
+		return (yield* git('cherry', 'main', rolledUp)).startsWith('-')
+	}).pipe(Effect.orElseSucceed(() => false))
+
+// Delete the branch the finished PR was on, leaving git's own refusal as the
+// first word.
+//
+// `git branch -d` asks whether the branch's commits are reachable from main. A
+// squash merge replays the whole branch as one new commit, so none of the
+// commits the branch actually holds is reachable and a branch whose work is
+// safely on main still reads as unmerged — which is most of this repo's PRs.
+// When that is why the delete was refused, ask the question git did not: is the
+// content already there? Only then insist. A branch holding work main has never
+// seen is left alone and named, because deleting it is the one step here nobody
+// can undo.
+const deleteFinishedBranch = (root: string, branch: string, force: boolean) =>
+	Effect.gen(function* () {
+		const insist = execArgs('git', ['-C', root, 'branch', '-D', branch])
+		if (force) {
+			yield* insist
+			yield* Console.log(`✓ Deleted local branch ${branch}`)
+			return
+		}
+		// Asked quietly, because a refusal here is the ordinary case rather than a
+		// fault: git printing "not fully merged" and the run then reporting success
+		// reads as something having gone wrong. A refusal that survives the content
+		// check below is reported in this command's own words instead.
+		const wentQuietly = yield* execSilentArgs('git', [
+			'-C',
+			root,
+			'branch',
+			'-d',
+			branch,
+		]).pipe(
+			Effect.map(() => true),
+			Effect.orElseSucceed(() => false),
+		)
+		if (wentQuietly) {
+			yield* Console.log(`✓ Deleted local branch ${branch}`)
+			return
+		}
+		if (!(yield* branchWorkIsOnMain(root, branch))) {
+			return yield* Effect.fail(
+				new Error(
+					`Branch ${branch} was kept: git would not delete it, and its work is not on main either. Look at it, then delete it yourself with \`git branch -D ${branch}\` — that will also name any other reason git had.`,
+				),
+			)
+		}
+		yield* insist
+		yield* Console.log(`✓ Deleted local branch ${branch} (squashed into main)`)
+	})
+
 export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 	Effect.gen(function* () {
 		const { force, stash } = options
@@ -836,11 +912,7 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 			yield* execIn(mainRoot, 'git', 'pull', '--prune')
 
 			if (yield* branchExists(branch)) {
-				const deleteArgs = force
-					? ['branch', '-D', branch]
-					: ['branch', '-d', branch]
-				yield* execIn(mainRoot, 'git', ...deleteArgs)
-				yield* Console.log(`✓ Deleted local branch ${branch}`)
+				yield* deleteFinishedBranch(mainRoot, branch, force)
 			}
 		} else {
 			const branch = yield* branchName
@@ -856,11 +928,7 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 			yield* exec('git', 'pull', '--prune')
 
 			if (yield* branchExists(branch)) {
-				const deleteArgs = force
-					? ['branch', '-D', branch]
-					: ['branch', '-d', branch]
-				yield* exec('git', ...deleteArgs)
-				yield* Console.log(`✓ Deleted local branch ${branch}`)
+				yield* deleteFinishedBranch(mainRoot, branch, force)
 			}
 		}
 


### PR DESCRIPTION
## What

`pnpm cli worktree done` is the command that tidies up after a merged pull request: it drops the worktree's own database and storage bucket, removes the worktree directory, brings `main` up to date, and finally deletes the local feature branch. That last step never worked for a squash-merged branch — which is one of the two ways this repo merges — so the command reliably exited with an error after doing everything else, leaving a stale branch behind. This is in the developer command-line tool (`apps/cli`); nothing here touches the product or the server.

The reason is that `git branch -d` asks a narrower question than it appears to: *can `main` reach this branch's commits?* A squash merge replays the whole branch as one brand-new commit, so none of the commits the branch actually holds is reachable, and a branch whose work is safely on `main` still reads as unmerged. We hit this an hour ago cleaning up after PR #501: the command dropped the database, removed the worktree, pulled `main`, then failed on the last line and left the branch.

## The fix

**Touches:** the branch-deletion step of `worktree done`, which both the linked-worktree path and the plain-feature-branch path now share. The database and bucket teardown, the worktree removal, and the `--stash` handling are unchanged.

- Git's own refusal stays the first word. Only when `git branch -d` declines does the command ask the question git did not — is the branch's *content* already on `main`? — by rolling the branch up into a single commit on the point it forked from and letting `git cherry` say whether that patch is already there. That is exactly the shape a squash merge leaves behind.
- A branch holding work `main` has never seen is left standing and named, rather than deleted. Deleting it is the one step in this command nobody can undo, so the check fails closed: any git error while answering reads as "not already there".
- The two paths had identical copies of the delete logic; they now call one helper, so the two cannot drift.
- Branch names no longer go through a shell. Both delete calls built a command string with the branch name in it, so a branch named with shell punctuation would have been read as syntax rather than as a name. The array forms this file already documents (`execArgs` / `execSilentArgs`) pass it as a single argument instead.

## Impact

- Only the developer tool changes. No database migration, no new environment variable, nothing touching which organisation can see what (no row-level security or `organization_id` scoping), no change to the public/protected boundary, and no change to any shape the frontend or the MCP surface reads.
- The one behavioural risk is the obvious one — this deletes branches — so the guard is deliberately asymmetric: it will refuse a branch it is unsure about and never delete one whose work it cannot find on `main`. `--force` is unchanged and still deletes unconditionally.

## Review guide

- The whole change is two small helpers in `apps/cli/src/commands/worktree.ts` plus two call sites that lost their duplicated block. Read `deleteFinishedBranch` first; `branchWorkIsOnMain` is the content check it leans on.
- **The riskiest line** is `git cherry` returning `-`, which is what authorises the `-D`. If a squash merge resolved conflicts, or `main` moved in a way that changes the patch, `git cherry` returns `+` and the branch is kept — conservative in the direction that cannot lose work.
- **A known conservative case:** a branch whose commits cancel out (a change and its revert) is refused rather than deleted, because its rolled-up patch is not on `main` either. `--force` covers it.
- **What I did not fix, deliberately:** `--stash` combined with a refused delete leaves the stash unpopped, because the pop sits after the delete on the success path. That hole already exists for every other way this command can fail, but a refusal is now a routine outcome rather than an accident, so it will be met more often. Fixing it means moving the pop into a finalizer that also runs on failure — a restructure of the command's cleanup, which I did not want to fold into a bug fix about branch deletion. Happy to do it as a follow-up.

## Tests

None. This repo does not unit-test CLI commands — the convention is to test the underlying services instead, and this logic is a sequence of git calls with no service beneath it. It is covered by the end-to-end runs below instead.

## Verification

- `pnpm check-types` (13/13), `pnpm test` (21/21), `pnpm build` (13/13).
- Ran the real command in both directions, driving the fixed CLI against actual branches rather than testing the logic in the abstract:
  - **A branch duplicating a commit already on `main`** (the squash shape — same content, different sha): `git branch -d` refused, the content check passed, and the branch was deleted, reporting `✓ Deleted local branch … (squashed into main)` with the command exiting cleanly.
  - **A branch with a genuine unmerged commit:** refused, the branch survived with its commit intact, and the command said why.
- Also confirmed the underlying git behaviour in a scratch repository: a squash-merged branch reports `-` from `git cherry`, and a genuinely unmerged one reports `+`.
