### PR TITLE
fix: stop telemetry double-counting, hiding refusals, and going missing

### DIFF
--- a/apps/mail-worker/src/backfill.ts
+++ b/apps/mail-worker/src/backfill.ts
@@ -1,6 +1,8 @@
 import { Effect } from 'effect'
 import type { ImapFlow } from 'imapflow'
 
+import { boundedCause } from '@batuda/observability'
+
 import { ingestRawMessage } from './ingest.js'
 
 // Initial backfill — runs once per (folder, inbox) when folder_state is
@@ -60,7 +62,7 @@ export const backfillSinceDate = (args: {
 				Effect.catchCause(cause =>
 					Effect.logWarning(
 						`mail-worker: backfill ingest failed inbox=${args.inboxId} uid=${m.uid}`,
-					).pipe(Effect.andThen(Effect.logError(cause))),
+					).pipe(Effect.andThen(Effect.logError(boundedCause(cause)))),
 				),
 			)
 			if (m.uid > highest) highest = m.uid

--- a/apps/mail-worker/src/inbox-session.ts
+++ b/apps/mail-worker/src/inbox-session.ts
@@ -2,6 +2,8 @@ import { Effect, Result, Schedule } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import { ImapFlow } from 'imapflow'
 
+import { boundedCause } from '@batuda/observability'
+
 import { backfillSinceDate } from './backfill.js'
 import type { ClaimedInbox } from './claim.js'
 import { CredentialDecryptor } from './decrypt.js'
@@ -140,7 +142,7 @@ const syncOneFolderTick = (args: {
 				inboxId: args.inbox.id,
 				imapUidvalidity: e.uidValidity,
 				imapUid: e.uid,
-			}).pipe(Effect.catchCause(cause => Effect.logError(cause)))
+			}).pipe(Effect.catchCause(cause => Effect.logError(boundedCause(cause))))
 		}
 
 		const known = args.progress.get(args.folder.path) ?? null
@@ -332,7 +334,7 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 						Effect.catchCause(cause =>
 							Effect.logWarning(
 								`mail-worker: folder tick failed inbox=${claimed.id} folder=${folder.path}`,
-							).pipe(Effect.andThen(Effect.logError(cause))),
+							).pipe(Effect.andThen(Effect.logError(boundedCause(cause)))),
 						),
 					)
 				}
@@ -351,7 +353,9 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 						new Error(
 							`mailboxOpen(${folderToWaitOn.path}) failed: ${String(err)}`,
 						),
-				}).pipe(Effect.catchCause(cause => Effect.logError(cause)))
+				}).pipe(
+					Effect.catchCause(cause => Effect.logError(boundedCause(cause))),
+				)
 				yield* Effect.sync(() => {
 					void client.idle().catch(() => {})
 				})

--- a/apps/mail-worker/src/main.ts
+++ b/apps/mail-worker/src/main.ts
@@ -2,7 +2,7 @@ import { NodeRuntime } from '@effect/platform-node'
 import { DateTime, Effect, type Fiber, Layer, Ref, Schedule } from 'effect'
 
 import { ParticipantMatcher } from '@batuda/email/participant-matcher'
-import { makeOtlpObservability } from '@batuda/observability'
+import { boundedCause } from '@batuda/observability'
 
 import { type ClaimedInbox, claimAvailableInboxes } from './claim.js'
 import { installCrashGuards } from './crash-guards.js'
@@ -11,6 +11,7 @@ import { CredentialDecryptor } from './decrypt.js'
 import { WorkerEnvVars } from './env.js'
 import { runInboxSession } from './inbox-session.js'
 import { ConfigFileLive } from './lib/config-provider.js'
+import { OtlpObservability } from './observability.js'
 import { RawMessageStorage } from './storage.js'
 
 // Top-level program: scan for unclaimed inboxes on a tick, fork a
@@ -73,7 +74,7 @@ const program = Effect.gen(function* () {
 		yield* reapFinished
 		const claimed: readonly ClaimedInbox[] = yield* claimAvailableInboxes.pipe(
 			Effect.catchCause(cause =>
-				Effect.logError(cause).pipe(
+				Effect.logError(boundedCause(cause)).pipe(
 					Effect.andThen(Effect.succeed([] as readonly ClaimedInbox[])),
 				),
 			),
@@ -122,7 +123,14 @@ const Live = Layer.mergeAll(
 	// IMAP disconnects, credential failures, and session-fiber deaths die in the
 	// console ring-buffer. Sits above ConfigFileLive so it can read NODE_ENV +
 	// the OTEL_* settings; merges with the default console logger, not replacing it.
-	Layer.provide(makeOtlpObservability({ serviceName: 'batuda-mail-worker' })),
+	//
+	// Merged rather than only provided: the exporter installs itself by putting a
+	// logger and a tracer into the context it is built into, and `program` below
+	// runs on what this layer HANDS BACK. Provided alone it reaches the layers
+	// built here and nothing else, which leaves a worker that boots, says export
+	// is enabled, and sends nothing — every line it writes goes to the console
+	// logger it still has.
+	Layer.provideMerge(OtlpObservability),
 	// Install the baked-file config values before the readers above resolve, so
 	// the env-var layer and the database client can read non-secret settings
 	// that no longer travel on the boot command line.

--- a/apps/mail-worker/src/observability.ts
+++ b/apps/mail-worker/src/observability.ts
@@ -1,0 +1,14 @@
+import { makeOtlpObservability } from '@batuda/observability'
+
+/**
+ * OTLP observability layer for the mail worker. Exports traces, logs, and
+ * metrics to the `batuda-mail-worker` Honeycomb dataset when
+ * OTEL_EXPORTER_OTLP_ENDPOINT is set; otherwise a no-op (local dev).
+ *
+ * Whoever builds this in has to MERGE it, not only provide it — see the note at
+ * the use site in `main.ts`. The worker ran for months provided-only: booting,
+ * announcing that export was enabled, and sending nothing.
+ */
+export const OtlpObservability = makeOtlpObservability({
+	serviceName: 'batuda-mail-worker',
+})

--- a/apps/server/src/lib/observability-middleware.test.ts
+++ b/apps/server/src/lib/observability-middleware.test.ts
@@ -2,10 +2,9 @@ import { Cause, Effect, Layer, Logger, References } from 'effect'
 import { HttpServerRequest } from 'effect/unstable/http'
 import { describe, expect, it } from 'vitest'
 
-import { recordFacts } from '@batuda/observability'
+import { boundedCause, recordFacts } from '@batuda/observability'
 
 import {
-	boundedCause,
 	httpPathPattern,
 	withRequestRecord,
 } from './observability-middleware.js'

--- a/apps/server/src/lib/observability-middleware.ts
+++ b/apps/server/src/lib/observability-middleware.ts
@@ -5,26 +5,12 @@ import {
 	HttpServerRequest,
 } from 'effect/unstable/http'
 
-import { makeWorkRecord, WorkRecord } from '@batuda/observability'
+import { boundedCause, makeWorkRecord, WorkRecord } from '@batuda/observability'
 
 // Collapse record-identifying URL segments so errors group by route, not by
 // individual record. UUIDs → :id; the query string and fragment are dropped so
 // a token in `?code=…`/`?token=…` never lands in a span attribute or log line.
 const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
-
-// A crash's cause is the most useful thing it leaves behind, so it is kept in
-// full rather than summarised — but bounded. A cause wrapping a driver error can
-// carry the failing statement and the values in it, and an unbounded one would
-// ship a whole request payload to the log exporter, which flushes every second.
-// Note this bounds the size, not the content: error text can still name business
-// data incidentally, which is why observability retention is short.
-const MAX_CAUSE_CHARS = 4000
-
-export const boundedCause = (cause: Cause.Cause<unknown>): string => {
-	const text = Cause.pretty(cause)
-	if (text.length <= MAX_CAUSE_CHARS) return text
-	return `${text.slice(0, MAX_CAUSE_CHARS)}… (${text.length - MAX_CAUSE_CHARS} more characters)`
-}
 
 /**
  * A request that says nothing beyond "the poller is still polling".

--- a/apps/server/src/lib/request-span.test.ts
+++ b/apps/server/src/lib/request-span.test.ts
@@ -1,0 +1,106 @@
+// Covers the arrangement `main.ts` relies on but cannot state in code: it passes
+// no middleware to `HttpRouter.serve`, because the platform opens the request
+// span on its own. Passing one as well opened a second span for every request —
+// a bare twin beside each real one, doubling every count read from the traces.
+//
+// Both directions matter here. Passing a tracer again makes the count 2, and a
+// platform release that stops opening the span makes it 0 — which would end
+// tracing silently, with nothing failing anywhere else.
+
+import { createServer } from 'node:http'
+
+import { NodeHttpServer } from '@effect/platform-node'
+import { Effect, Layer, ManagedRuntime, Tracer } from 'effect'
+import {
+	HttpRouter,
+	HttpServer,
+	HttpServerResponse,
+} from 'effect/unstable/http'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// Names of the spans opened for an incoming request, in the order they opened.
+// A module-level array because the tracer is built once, with the server.
+const serverSpans: Array<string> = []
+
+const countingTracer = (inner: Tracer.Tracer): Tracer.Tracer => ({
+	...inner,
+	span(options) {
+		if (options.kind === 'server') serverSpans.push(options.name)
+		return inner.span(options)
+	},
+})
+
+const CountingTracerLive = Layer.effect(Tracer.Tracer)(
+	Effect.map(Effect.service(Tracer.Tracer), countingTracer),
+)
+
+const RoutesLive = Layer.mergeAll(
+	HttpRouter.add('GET', '/ok', HttpServerResponse.text('ok')),
+	// Dies rather than fails, which is the harder case: the defect reaches the
+	// platform after the response has gone out.
+	HttpRouter.add('GET', '/boom', Effect.die(new Error('boom'))),
+)
+
+// The live arrangement: no `middleware` option, so the platform's own span is
+// the only one.
+const ServerLive = HttpRouter.serve(RoutesLive, {
+	disableListenLog: true,
+	disableLogger: true,
+}).pipe(
+	Layer.provide(CountingTracerLive),
+	Layer.provideMerge(NodeHttpServer.layer(createServer, { port: 0 })),
+)
+
+const runtime = ManagedRuntime.make(ServerLive)
+let baseUrl: string
+
+describe('the span a request leaves behind', () => {
+	beforeAll(async () => {
+		const address = await runtime.runPromise(
+			Effect.gen(function* () {
+				const server = yield* HttpServer.HttpServer
+				return server.address
+			}),
+		)
+		if (address._tag !== 'TcpAddress')
+			throw new Error('expected a TCP address for the test server')
+		baseUrl = `http://127.0.0.1:${address.port}`
+	}, 30_000)
+
+	afterAll(() => runtime.dispose())
+
+	describe('when a request is served', () => {
+		it('should open exactly one span for it', async () => {
+			// GIVEN a server arranged the way main.ts arranges it
+			serverSpans.length = 0
+
+			// WHEN one request is served
+			const response = await fetch(`${baseUrl}/ok`)
+
+			// THEN one span was opened, not two
+			expect(response.status).toBe(200)
+			expect(serverSpans).toEqual(['http.server GET'])
+		})
+	})
+
+	describe('when the route dies', () => {
+		it('should answer 500, leave one span, and keep serving', async () => {
+			// GIVEN a route that dies mid-request
+			serverSpans.length = 0
+
+			// WHEN it is called
+			const response = await fetch(`${baseUrl}/boom`)
+
+			// THEN the caller is answered and the request left one span
+			expect(response.status).toBe(500)
+			expect(serverSpans).toEqual(['http.server GET'])
+
+			// AND the server is still there for the next caller — nothing about the
+			// defect reached the scope holding the server
+			serverSpans.length = 0
+			const next = await fetch(`${baseUrl}/ok`)
+			expect(next.status).toBe(200)
+			expect(serverSpans).toEqual(['http.server GET'])
+		})
+	})
+})

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -465,12 +465,14 @@ const AppLive = withGlobalMiddlewareOrder(
 // out-of-request-scope Defect" case in main.boot.test.ts, which runs under
 // `pnpm --filter @batuda/server test:boot` rather than `pnpm test`.
 
-// `HttpMiddleware.tracer` wraps the whole server chain in a per-request span so
-// traces export to OTLP and per-route span annotations (request id, org id, tool
-// name) have a span to attach to. `serve` already adds the request logger; this
-// adds the missing tracer. `/health` is exempted from tracing inside AppLive.
+// No tracer is passed here. The platform opens a per-request span itself,
+// whether middleware is given or not, and that span is what per-route
+// annotations (request id, org id, tool name) attach to. Passing one as well
+// wraps every request twice and leaves a bare duplicate span beside each real
+// one — two rows per request, so every count reads double. The routes exempt
+// from tracing are the ones `TracerDisabledLive` names above; the platform's own
+// wrapping reads that same list.
 const program = HttpRouter.serve(AppLive, {
-	middleware: HttpMiddleware.tracer,
 	// Disable Effect's built-in request logger: in this version it annotates
 	// `http.url` with the RAW request URL, so a magic-link/reset token in the URL
 	// would export verbatim to OTLP. ObservabilityLive emits a sanitized

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -23,6 +23,15 @@ import { McpToolsLive } from './server'
 
 const PROTOCOL_VERSION_HEADER = 'mcp-protocol-version'
 const SESSION_ID_HEADER = 'mcp-session-id'
+// Which JSON-RPC call this request carries. A header rather than the body, so it
+// can be read without touching a stream the route still needs — Claude's client
+// sets it, and a client that doesn't simply leaves the field off its line.
+const METHOD_HEADER = 'mcp-method'
+
+// The revision and the method a request names are the caller's own words, so they
+// are cut short before landing on a log line: one client sending something long
+// should not stretch every record it touches.
+const bounded = (value: string) => value.slice(0, 64)
 
 // A client opening a connection names the newest protocol revision it speaks,
 // and the route refuses anything past the newest the library knows with an empty
@@ -58,6 +67,72 @@ const jsonRpcError = (
 		{ jsonrpc: '2.0', id: null, error: { code, message } },
 		{ status, ...(headers ? { headers } : {}) },
 	)
+
+/**
+ * Names the call on the request's own line, before anything can refuse it.
+ *
+ * A refused MCP request is the one hardest to read after the fact: the client
+ * shows a silent retry, and the line left behind says only which route and which
+ * status. Naming the call and the revision it asked for turns that line into an
+ * explanation, and it has to be recorded up front — a request refused later
+ * never reaches the code that would have known.
+ *
+ * Read from the request as it arrived, not the one handed onward, so the line
+ * says what the client actually asked for even where negotiation drops the
+ * revision it named.
+ */
+export const recordCall = (request: HttpServerRequest.HttpServerRequest) => {
+	const method = request.headers[METHOD_HEADER]
+	const named = request.headers[PROTOCOL_VERSION_HEADER]
+	return recordFacts({
+		...(method !== undefined && { 'mcp.method': bounded(method) }),
+		...(named !== undefined && {
+			'mcp.protocol_version.named': bounded(named),
+		}),
+	})
+}
+
+/**
+ * Gives a refused revision a reason to read.
+ *
+ * A request naming a revision the library does not know is answered with an
+ * empty 400: no body for the client to act on, and a line that says 400 without
+ * saying why. This says why in both directions — a warning line naming the
+ * revision, and a JSON-RPC error body telling the client what to do instead.
+ *
+ * Only a response the route RETURNED is looked at, and the one empty 400 the
+ * route returns is that refusal — the RPC layer under it returns none. A request
+ * the route FAILED on (a broken body, say) also ends in an empty 400, but that
+ * one is built further out, past this, so a bad body is never blamed on the
+ * revision. The revision is read from the request the route itself saw, since
+ * that is what it decided on.
+ */
+export const explainRefusedVersion = <E, R>(
+	app: Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>,
+	request: HttpServerRequest.HttpServerRequest,
+) =>
+	Effect.flatMap(app, response => {
+		const named = request.headers[PROTOCOL_VERSION_HEADER]
+		if (
+			named === undefined ||
+			response.status !== 400 ||
+			response.body._tag !== 'Empty'
+		)
+			return Effect.succeed(response)
+		return Effect.logWarning('MCP protocol version refused').pipe(
+			Effect.annotateLogs({
+				event: 'mcp.protocol_version.refused',
+				'mcp.protocol_version.named': bounded(named),
+			}),
+			Effect.andThen(
+				jsonRpcError(
+					400,
+					-32000,
+					`Unsupported MCP protocol version: ${bounded(named)}. Open a new connection to settle a supported revision, or send the one this connection settled.`,
+				),
+			),
+		)
+	})
 
 // MCP clients (ChatGPT, Claude.ai) surface an auth rejection as a silent retry
 // loop, not a visible error — so every 401/403 path logs why it fired. `reason`
@@ -145,6 +220,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					return yield* httpEffect
 				}
 				const req = yield* withNegotiableProtocolVersion(incoming)
+				yield* recordCall(incoming)
 
 				const incomingMessage = NodeHttpServerRequest.toIncomingMessage(req)
 				const headers = fromNodeHeaders(incomingMessage.headers)
@@ -205,7 +281,7 @@ const McpAuthMiddleware = HttpRouter.middleware(
 										userAgent: headers.get('user-agent'),
 									})
 								}
-								return yield* httpEffect
+								return yield* explainRefusedVersion(httpEffect, req)
 							}).pipe(
 								// The very request the body was read from: a request remembers
 								// its body and a copy does not, so handing the route the other

--- a/apps/server/src/mcp/protocol-version.test.ts
+++ b/apps/server/src/mcp/protocol-version.test.ts
@@ -3,21 +3,69 @@
 // cannot recover from.
 //
 // These drive a real in-process MCP server through a middleware shaped like the
-// live one — normalise the request, read its body, hand the same one onward —
-// because the worst failure here is invisible to the header logic alone: a
-// request remembers the body it read and a copy does not, so handing the route
-// the other one leaves it waiting on a drained stream, with no error, no
-// timeout, and no response ever. Only the round trip catches that.
+// live one — open the record, normalise the request, name the call, read its
+// body, hand the same one onward — because the worst failure here is invisible to
+// the header logic alone: a request remembers the body it read and a copy does
+// not, so handing the route the other one leaves it waiting on a drained stream,
+// with no error, no timeout, and no response ever. Only the round trip catches
+// that.
+//
+// The refusal a settled connection still gets is covered here too: it is the
+// library's own answer, so only a real server produces it, and what a client and
+// a reader can learn from it is the whole point of the cases below.
 
 import { createServer } from 'node:http'
 
 import { NodeHttpServer } from '@effect/platform-node'
-import { Effect, Layer, ManagedRuntime, Schema } from 'effect'
+import {
+	Effect,
+	Layer,
+	Logger,
+	ManagedRuntime,
+	References,
+	Schema,
+} from 'effect'
 import { McpServer, Tool, Toolkit } from 'effect/unstable/ai'
 import { HttpRouter, HttpServer, HttpServerRequest } from 'effect/unstable/http'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { withNegotiableProtocolVersion } from './http'
+import { withRequestRecord } from '../lib/observability-middleware'
+import {
+	explainRefusedVersion,
+	recordCall,
+	withNegotiableProtocolVersion,
+} from './http'
+
+// Every line the server wrote, read the way the built-in formatters read them:
+// annotations live on the fiber, not on the log options.
+const lines: Array<{
+	readonly level: string
+	readonly annotations: Record<string, unknown>
+}> = []
+
+const CaptureLogsLive = Layer.provideMerge(
+	Layer.succeed(References.MinimumLogLevel, 'Debug'),
+)(
+	Logger.layer([
+		Logger.make(options => {
+			lines.push({
+				level: String(options.logLevel),
+				annotations: {
+					...options.fiber.getRef(References.CurrentLogAnnotations),
+				},
+			})
+		}),
+	]),
+)
+
+const lineFor = (event: string) =>
+	lines.find(line => line.annotations['event'] === event)
+
+// What a client should be able to read off a refusal.
+const JsonRpcError = Schema.Struct({
+	jsonrpc: Schema.String,
+	error: Schema.Struct({ code: Schema.Number, message: Schema.String }),
+})
 
 const Ping = Tool.make('ping', { success: Schema.String })
 const PingTools = Toolkit.make(Ping)
@@ -30,17 +78,22 @@ const PingHandlersLive = PingTools.toLayer(
 const NegotiationMiddleware = HttpRouter.middleware(
 	Effect.gen(function* () {
 		return httpEffect =>
-			Effect.gen(function* () {
-				const incoming = yield* HttpServerRequest.HttpServerRequest
-				if (!incoming.url.startsWith('/mcp')) return yield* httpEffect
-				const req = yield* withNegotiableProtocolVersion(incoming)
-				// The live middleware reads the body here, to record which client
-				// called; doing the same is the point of this harness.
-				yield* req.json.pipe(Effect.orElseSucceed(() => null))
-				return yield* httpEffect.pipe(
-					Effect.provideService(HttpServerRequest.HttpServerRequest, req),
-				)
-			})
+			// The request record is opened outermost in the live server, which is
+			// what lets the steps below write facts onto the request's own line.
+			withRequestRecord(
+				Effect.gen(function* () {
+					const incoming = yield* HttpServerRequest.HttpServerRequest
+					if (!incoming.url.startsWith('/mcp')) return yield* httpEffect
+					const req = yield* withNegotiableProtocolVersion(incoming)
+					yield* recordCall(incoming)
+					// The live middleware reads the body here, to record which client
+					// called; doing the same is the point of this harness.
+					yield* req.json.pipe(Effect.orElseSucceed(() => null))
+					return yield* explainRefusedVersion(httpEffect, req).pipe(
+						Effect.provideService(HttpServerRequest.HttpServerRequest, req),
+					)
+				}),
+			)
 	}),
 	{ global: true },
 )
@@ -56,7 +109,11 @@ const McpHttpLive = Layer.mergeAll(
 
 const ServerLive = HttpRouter.serve(McpHttpLive, {
 	disableListenLog: true,
-}).pipe(Layer.provideMerge(NodeHttpServer.layer(createServer, { port: 0 })))
+	disableLogger: true,
+}).pipe(
+	Layer.provide(CaptureLogsLive),
+	Layer.provideMerge(NodeHttpServer.layer(createServer, { port: 0 })),
+)
 
 const runtime = ManagedRuntime.make(ServerLive)
 let baseUrl: string
@@ -147,10 +204,11 @@ describe('the /mcp route meeting a protocol revision it does not know', () => {
 	})
 
 	describe('when a client names a bad revision after one was agreed', () => {
-		it('should still refuse it, since it was told what to send', async () => {
+		it('should refuse it with something the client can read', async () => {
 			// GIVEN a connection that already settled a revision
 			const opening = await initialize()
 			const sessionId = opening.headers.get('mcp-session-id') as string
+			lines.length = 0
 
 			// WHEN a later request names one the library does not know
 			const response = await post(
@@ -160,12 +218,82 @@ describe('the /mcp route meeting a protocol revision it does not know', () => {
 					method: 'tools/call',
 					params: { name: 'ping', arguments: {} },
 				},
-				{ 'mcp-session-id': sessionId, 'mcp-protocol-version': '2026-07-28' },
+				{
+					'mcp-session-id': sessionId,
+					'mcp-protocol-version': '2026-07-28',
+					'mcp-method': 'server/discover',
+				},
 			)
 
 			// THEN the refusal stands — the client was told which revision this is,
 			// so naming another one is its own mistake to fix
 			expect(response.status).toBe(400)
+
+			// AND it carries a JSON-RPC error naming the revision, rather than the
+			// empty body a client can do nothing with. Decoding is half the
+			// assertion: a body of another shape fails here.
+			const body = Schema.decodeUnknownSync(JsonRpcError)(await response.json())
+			expect(body.error.code).toBe(-32000)
+			expect(body.error.message).toContain('2026-07-28')
+		})
+
+		it('should leave a warning naming the refusal', async () => {
+			// GIVEN the same refused request
+			const opening = await initialize()
+			const sessionId = opening.headers.get('mcp-session-id') as string
+			lines.length = 0
+			await post(
+				{ jsonrpc: '2.0', id: 4, method: 'tools/call', params: {} },
+				{
+					'mcp-session-id': sessionId,
+					'mcp-protocol-version': '2026-07-28',
+					'mcp-method': 'server/discover',
+				},
+			)
+
+			// THEN the refusal is a warning, not another routine info line, and it
+			// names the revision that was turned down
+			const refusal = lineFor('mcp.protocol_version.refused')
+			expect(refusal?.level).toBe('Warn')
+			expect(refusal?.annotations['mcp.protocol_version.named']).toBe(
+				'2026-07-28',
+			)
+
+			// AND the request's own line says which call it was, so the 400 explains
+			// itself without hunting for the line beside it
+			const request = lineFor('http.request')
+			expect(request?.annotations['mcp.method']).toBe('server/discover')
+			expect(request?.annotations['mcp.protocol_version.named']).toBe(
+				'2026-07-28',
+			)
+			expect(request?.annotations['http.status']).toBe(400)
+		})
+	})
+
+	describe('when the body is broken rather than the revision', () => {
+		it('should not blame the revision for it', async () => {
+			// GIVEN a settled connection naming a revision this server DOES know
+			const opening = await initialize()
+			const sessionId = opening.headers.get('mcp-session-id') as string
+			lines.length = 0
+
+			// WHEN the body it sends is not valid JSON
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					accept: 'application/json, text/event-stream',
+					'mcp-session-id': sessionId,
+					'mcp-protocol-version': '2025-06-18',
+				},
+				body: '{"jsonrpc":"2.0","id":5,"method":',
+			})
+
+			// THEN nothing claims the revision was the problem — a bad body and a
+			// refused revision both end in 400, and telling a client to re-open its
+			// connection would send it chasing the wrong thing
+			expect(await response.text()).not.toContain('Unsupported MCP protocol')
+			expect(lineFor('mcp.protocol_version.refused')).toBeUndefined()
 		})
 	})
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -40,28 +40,31 @@ Timestamps and trace ids are added by the framework.
 
 `{domain}.{action}[.{result}]` — so a filter on one prefix gets a whole area.
 
-| Event                    | Description                                 |
-| ------------------------ | ------------------------------------------- |
-| `http.request`           | A request completed                         |
-| `http.server_error`      | A request ended 5xx                         |
-| `http.defect`            | A request died without producing a response |
-| `company.created`        | New company added to CRM                    |
-| `company.status_changed` | Pipeline status transition                  |
-| `interaction.logged`     | Interaction recorded                        |
-| `document.created`       | Research/notes document added               |
-| `email.sent`             | Outbound email                              |
-| `email.received`         | Inbound reply                               |
-| `email.failed`           | Email delivery failed                       |
-| `webhook.fired`          | Webhook fan-out triggered                   |
-| `webhook.failed`         | Webhook delivery failed                     |
-| `page.published`         | Sales page made public                      |
-| `page.viewed`            | Prospect viewed a sales page                |
-| `task.created`           | CRM task raised                             |
-| `research.run`           | A research run finished, with what it spent |
-| `mcp.tool_called`        | MCP tool invoked by agent                   |
-| `mcp.auth.rejected`      | An MCP call was refused, and why            |
+| Event                          | Description                                                |
+| ------------------------------ | ---------------------------------------------------------- |
+| `http.request`                 | A request completed                                        |
+| `http.server_error`            | A request ended 5xx                                        |
+| `http.defect`                  | A request died without producing a response                |
+| `company.created`              | New company added to CRM                                   |
+| `company.status_changed`       | Pipeline status transition                                 |
+| `interaction.logged`           | Interaction recorded                                       |
+| `document.created`             | Research/notes document added                              |
+| `email.sent`                   | Outbound email                                             |
+| `email.received`               | Inbound reply                                              |
+| `email.failed`                 | Email delivery failed                                      |
+| `webhook.fired`                | Webhook fan-out triggered                                  |
+| `webhook.failed`               | Webhook delivery failed                                    |
+| `page.published`               | Sales page made public                                     |
+| `page.viewed`                  | Prospect viewed a sales page                               |
+| `task.created`                 | CRM task raised                                            |
+| `research.run`                 | A research run finished, with what it spent                |
+| `mcp.tool_called`              | MCP tool invoked by agent                                  |
+| `mcp.auth.rejected`            | An MCP call was refused, and why                           |
+| `mcp.protocol_version.refused` | A call named a protocol revision this server does not know |
 
 A request leaves exactly one of `http.request`, `http.server_error` or `http.defect`, so "every request that ended badly" is those last two.
+
+A request also leaves exactly **one span**, not two. The platform opens that span itself, so the server passes no tracer of its own when it starts serving; passing one as well used to open a second span per request, and every count taken from the traces read double until 2026-08-18. A trace older than that carries the twins.
 
 ### Levels
 
@@ -257,6 +260,8 @@ The endpoint is non-secret, so it lives in each app's `config.production.json` a
 
 **Per-service datasets.** Traces route to a Honeycomb dataset named after `service.name`, so each process separates on its own. Logs and metrics route by the `x-honeycomb-dataset` header instead, so each deploy workflow appends its own dataset name to the shared team-key secret. One environment-scoped API key covers every process.
 
+A process only reports if it **merges** the observability layer into the layer it runs on. Provided without merging, it boots, says export is enabled, runs the exporter's own flushers — and sends none of its own lines, because the logger and tracer the exporter installs never reach the code that writes them. The mail-worker ran that way until 2026-08-18: alive, logging, and absent from the vendor. `packages/observability/src/otlp.test.ts` holds that line.
+
 Note the consequence: logs and traces from the same request land in different datasets. That is the vendor's routing, not a choice — it is why the per-request record has to be self-sufficient rather than something you assemble by joining a log to a trace.
 
 ## Health endpoint
@@ -271,7 +276,7 @@ Pointers, not copies — read the files for detail.
 
 | Concern                                                       | Where                                              |
 | ------------------------------------------------------------- | -------------------------------------------------- |
-| Shared exporter, sampling, span scrubbing                     | `packages/observability`                           |
+| Shared exporter, sampling, span scrubbing, cause bounding     | `packages/observability`                           |
 | Per-request record, route sanitizing, catch-all error logging | `apps/server/src/lib/observability-middleware.ts`  |
 | Logger set and level                                          | `apps/server/src/lib/logger.ts`                    |
 | Tracing exemptions for secret-carrying routes                 | `apps/server/src/main.ts`                          |

--- a/packages/observability/src/bounded-cause.ts
+++ b/packages/observability/src/bounded-cause.ts
@@ -1,0 +1,24 @@
+import type { Cause } from 'effect'
+import { Cause as CauseModule } from 'effect'
+
+// A crash's cause is the most useful thing it leaves behind, so it is kept in
+// full rather than summarised — but bounded. A cause wrapping a driver error can
+// carry the failing statement and the values in it, and an unbounded one would
+// ship a whole request payload, or a whole email, to the log exporter — which
+// flushes every second.
+//
+// Note this bounds the size, not the content: error text can still name business
+// data incidentally, which is why observability retention is short.
+const MAX_CAUSE_CHARS = 4000
+
+/**
+ * Renders a cause for a log line, cut to a length a log exporter can carry.
+ *
+ * Lives in the shared package because every process that exports logs needs it,
+ * not just the one that happened to need it first.
+ */
+export const boundedCause = (cause: Cause.Cause<unknown>): string => {
+	const text = CauseModule.pretty(cause)
+	if (text.length <= MAX_CAUSE_CHARS) return text
+	return `${text.slice(0, MAX_CAUSE_CHARS)}… (${text.length - MAX_CAUSE_CHARS} more characters)`
+}

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -2,6 +2,7 @@
 // (version/commit/region) surfaced on the health endpoint and the OTLP resource,
 // plus the per-process exporter layer factory.
 
+export { boundedCause } from './bounded-cause'
 export { buildMeta } from './build-meta'
 export { makeOtlpObservability } from './otlp'
 export {

--- a/packages/observability/src/otlp.test.ts
+++ b/packages/observability/src/otlp.test.ts
@@ -1,0 +1,89 @@
+// Covers the one thing about this layer that can be got wrong without anything
+// failing: how a process composes it.
+//
+// The exporter installs itself by putting a logger and a tracer into the context
+// it is built into. A process that provides it without merging it back still
+// boots, still says export is enabled, and still runs its own background
+// flushers — but every line the process writes afterwards goes to the logger it
+// already had, so nothing is ever sent. The mail-worker sat like that: alive,
+// logging every few seconds, and absent from the vendor for good.
+//
+// So this asserts the whole path for real, against a local sink rather than a
+// vendor: compose it the way a process must, write one line, and watch the line
+// leave.
+
+import { createServer, type Server } from 'node:http'
+
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { makeOtlpObservability } from './otlp'
+
+const paths: Array<string> = []
+let server: Server
+let endpoint: string
+
+const sink = () =>
+	new Promise<Server>(resolve => {
+		const created = createServer((request, response) => {
+			request.resume()
+			request.on('end', () => {
+				if (request.url !== undefined) paths.push(request.url)
+				response.writeHead(200, { 'content-type': 'application/json' })
+				response.end('{}')
+			})
+		})
+		created.listen(0, '127.0.0.1', () => resolve(created))
+	})
+
+const reached = async (path: string, within: number) => {
+	const deadline = Date.now() + within
+	while (Date.now() < deadline) {
+		if (paths.includes(path)) return true
+		await new Promise(resolve => setTimeout(resolve, 50))
+	}
+	return paths.includes(path)
+}
+
+describe('the OTLP observability layer', () => {
+	beforeAll(async () => {
+		server = await sink()
+		const address = server.address()
+		if (address === null || typeof address === 'string')
+			throw new Error('expected a TCP address for the sink')
+		endpoint = `http://127.0.0.1:${address.port}`
+		// Read by the layer as it builds, so it has to be set before that happens.
+		process.env['OTEL_EXPORTER_OTLP_ENDPOINT'] = endpoint
+	}, 30_000)
+
+	afterAll(async () => {
+		delete process.env['OTEL_EXPORTER_OTLP_ENDPOINT']
+		// The exporter's client keeps its socket alive, and `close` on its own waits
+		// for open sockets — which would hang teardown rather than fail it.
+		server.closeAllConnections()
+		await new Promise(resolve => server.close(resolve))
+	})
+
+	describe('when a process merges it into the layer it runs on', () => {
+		it('should send the lines that process writes', async () => {
+			// GIVEN the layer composed the way a process has to compose it: merged
+			//       back, so what the process runs on carries the exporter's logger
+			const Live = Layer.empty.pipe(
+				Layer.provideMerge(
+					makeOtlpObservability({ serviceName: 'observability-test' }),
+				),
+			)
+			const runtime = ManagedRuntime.make(Live)
+			paths.length = 0
+
+			// WHEN the process writes a line
+			await runtime.runPromise(Effect.logInfo('a line worth exporting'))
+			// Shutting down flushes what is still batched, so the test does not wait
+			// on an export interval.
+			await runtime.dispose()
+
+			// THEN the line reaches the endpoint
+			expect(await reached('/v1/logs', 5_000)).toBe(true)
+		}, 30_000)
+	})
+})


### PR DESCRIPTION
## What

A day after [#498](https://github.com/guillempuche/batuda/pull/498) went live I read what it was actually producing in Honeycomb, the service the system reports to, and found three things wrong with what the system says about itself. Every request was being counted twice. An AI client's calls were being turned away without anything saying why. And one whole program — the mail worker, which watches inboxes for incoming email — had never reported a single line in its life.

None of them break a feature; all three break the ability to answer "what happened?" when something does. This fixes all three, across `server`, `mail-worker`, and the shared `observability` package.

## The fix

**Touches:** the line where the server starts serving, the sign-in step every AI-client request passes through, the layer stack the mail worker boots on, and the shared exporter package they all use — plus the observability guide.

- **Each request is counted once.** The platform already opens a span — a timing record — for every request, whether or not it is handed one. The server was handing it a second, so every request left two rows: one carrying the route and request id, one bare beside it. Every count taken from the traces read double, on every build since at least 2026-08-10. The server now passes none.
- **A turned-away call says why.** An AI client that names a version of the protocol this server does not know is refused with an empty answer: nothing in it for the client to read, and a line in the logs that says only "400". In one three-minute burst that was 24 refusals, one for every tool the client actually ran, all filed as ordinary traffic. The refusal stands — it is the right answer — but it now leaves a warning naming the version, and answers with an error the client can act on. Every request through that route also carries the name of the call it was making, so the line explains itself.
- **The mail worker reports at all.** It handed its exporter to the parts it builds rather than to itself, so it booted, announced "OTLP export enabled", and then sent nothing. Its telemetry is now merged into what the worker runs on, and its layer is named in its own file the way the server's is, with the "merge me" requirement written where the next person will meet it.

## Impact

- **Numbers taken from traces before this read double.** Anything counted per request — volume, error rate, latency buckets — was 2× on the span side. Nothing downstream breaks: the `prod` environment has no alerts and no dashboards, so nothing was reading those numbers automatically. Log-based numbers were always right.
- **The mail worker starts sending data it never sent.** Its lines and traces now leave the machine for the first time. Because a database failure can carry the failing statement and the values in it — a message body, or the encrypted credential blob stored on the inbox row — I moved the size limit the server already puts on a crash report into the shared package and applied it to the worker's five reporting points. It bounds the size, not the content; that is the same trade the server made, and it is why observability data is kept only briefly.
- **A refused MCP call now gets a body it did not get before.** MCP is the protocol an AI app like Claude uses to reach the CRM. Clients that treated an empty refusal as "retry" will now see a message; this is strictly more information, not a changed status code.
- **No database change, no migration.** Nothing touching which organisation can see what (row-level security), no change to the database role any path runs under, and no change to the shape of anything the frontend reads.
- **No new settings.** Nothing to add in production for this to work.
- **It may not be enough for the worker in production.** See `## Deferred`.

## Review guide

- **Start here:** `apps/server/src/main.ts` — one option removed, and a comment that said the opposite of what the library does. Then `apps/server/src/mcp/http.ts` for the refusal.
- **Riskiest part:** `explainRefusedVersion` in `apps/server/src/mcp/http.ts`. It decides from the shape of a response — an empty 400 — that the version was the reason. I checked that nothing else on that route produces one: the MCP server has exactly one 400, the layer under it has none, and a request that *fails* (a broken body, say) gets its 400 built further out, past this. There is a test for that last case specifically, because it is the one that would quietly blame the wrong thing.
- **A decision you might overrule:** I did not add a blanket rule that every 4xx logs as a warning. It would have caught this class automatically, but logged-out browsers hitting `/auth/get-session` would fill the logs with warnings. Instead the refusal names itself, the way the sign-in refusals already do. Say the word and I'll switch it.
- **Deliberately not done:** `makeOtlpObservability` still allows the shape that made the worker silent — provide it without merging and a process reports nothing while announcing that it does. A helper that merges internally would remove the trap, but the server's layer order is delicate (the exporter has to sit above the logger set, and that ordering is commented for a reason), so I left it documented and pinned by a test rather than reshaped.
- **Mostly mechanical, skim it:** the five `boundedCause(cause)` wraps in `apps/mail-worker`, and the table realignment in `docs/observability.md`.
- I did not run Snyk; the tool wasn't available in this session.

## Tests

- One span per request, driven through a real in-process server with a counting tracer: a plain request, and a route that dies — which still answers 500, still leaves one span, and does not stop the next request being served.
- The refusal, through the same real MCP server the live route uses: it still refuses, now with a readable error naming the version; it leaves a warning; the request's own line carries the call name; and a broken body is *not* blamed on the version.
- The exporter's composition, against a local sink: a program built the way a process has to build it sends its lines.
- **Every one mutation-checked** — putting the tracer back makes the span count 2, removing the refusal handling fails two cases, and going back to provide-without-merge empties the sink.

## Verification

- Gates on the rebased branch: `pnpm install` (no lockfile drift), `pnpm -w check-types` 13/13, `pnpm -w test` 21/21, `pnpm -w build` 13/13.
- Against the live local stack, with the server exporting to a throwaway local endpoint: four request shapes (a POST, a plain GET, a GET carrying an incoming trace header, and a browser preflight) produced four traces with exactly one span each — including the trace-header case, which is what produced the twin rows in production. The surviving span carries both the platform's fields and ours (`request.id`, `http.route`, `http.path_pattern`).
- Sent an unauthenticated MCP request to the running server and read its line back from `apps/server/server.log`: `mcp.method=server/discover mcp.protocol_version.named=2026-07-28 ... http.status=401`.
- Booted the mail worker against the same kind of local endpoint before and after the change: silent before (through ~20 seconds of logging every five), then `/v1/logs` and `/v1/traces` after. Re-ran it after moving the layer into its own file, since that could have quietly undone the fix.
- Read the current production data to size each problem: 38 requests → 76 spans on the new build, 24 refusals in the 19:37–19:40 burst, and no `batuda-mail-worker` dataset in any environment.

## Deferred

- **Whether the worker actually reports in production.** Not even its measurements ever arrived, and those export by a different path than logs and traces — which points at the deployment (the worker not running, or the vendor headers not reaching it) on top of the bug fixed here. Checking that needs the `unikraft` CLI and production access. After this deploys, the test is simple: a `batuda-mail-worker` dataset should appear within a minute of the worker's first line. If it doesn't, the cause is on that side and I'll chase it separately.
- **Making the exporter impossible to misuse** rather than documented — see `## Review guide`.
