### PR TITLE
fix(research): stop a group's own website being taken for a directory

### DIFF
--- a/packages/research/src/application/directory-sites.test.ts
+++ b/packages/research/src/application/directory-sites.test.ts
@@ -218,6 +218,24 @@ describe('observeDirectorySites', () => {
 			expect([...observation.sites]).toEqual([])
 		})
 
+		it('should follow a chain of spellings through a row it drops', () => {
+			// GIVEN one company under three names, where the middle one reads two
+			// ways — "Møller" gives both "moller" and "moeller" — so the last name
+			// repeats the middle one and spells nothing the first one does
+			const observation = observe(
+				['Moll', 'Møller Transport', 'Moeller Transport Nord'],
+				[
+					'https://directorio.example/empresa/moll',
+					'https://directorio.example/empresa/moeller-transport-nord',
+				],
+			)
+
+			// WHEN read — THEN the chain has to run through the row that was dropped,
+			// or the last name is counted as a second company and a host filing one
+			// firm twice reaches the two it takes to be a listing
+			expect([...observation.sites]).toEqual([])
+		})
+
 		it('should not count one company spelled two ways as two', () => {
 			// GIVEN a list holding the same company under a dotted and an undotted
 			// legal form, which the fold that settles it only reaches later
@@ -235,10 +253,44 @@ describe('observeDirectorySites', () => {
 		})
 	})
 
-	describe('when the host itself carries one of the company names', () => {
-		it("should never call a company's own site a directory", () => {
-			// GIVEN a company's own site naming two other companies of the run in its
-			// addresses — a page per partner, a page per client
+	describe("when the host is a listed company's own site", () => {
+		it("should not brand a group's own domain for carrying a page per part", () => {
+			// GIVEN a search that returned a parent and its subsidiary as two rows,
+			// and the group's own site with a page for each of them — the two names
+			// share a front part and diverge right after it
+			const observation = observe(
+				['D-Sécurité (groupe)', 'D-Sécurité Incendie'],
+				[
+					'https://www.d-securite.com/d-securite-groupe/',
+					'https://www.d-securite.com/d-securite-incendie/',
+				],
+			)
+
+			// WHEN read — THEN the domain spells the front of both names, so it is
+			// established as each one's own site and files neither of them
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should recognise the short domain a company usually has', () => {
+			// GIVEN a group at a domain that is one word of the name rather than all
+			// of it — "acme.example", which is how most firms register — with a page
+			// for each part of the group
+			const observation = observe(
+				['Acme Instalacions SL', 'Acme Serveis SL'],
+				[
+					'https://acme.example/acme-instalacions',
+					'https://acme.example/acme-serveis',
+				],
+			)
+
+			// WHEN read — THEN the front of a name is enough to own the domain, so
+			// both pages are the group writing about itself
+			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should still judge it for filing companies it does not name', () => {
+			// GIVEN a firm's own site with a page for each of two OTHER companies on
+			// the run's list — a page per partner, a page per client
 			const observation = observe(
 				['Instalaciones Ferré SA', 'Electricistas Puig SL', 'Muñoz SL'],
 				[
@@ -247,25 +299,81 @@ describe('observeDirectorySites', () => {
 				],
 			)
 
-			// WHEN read — THEN the host being named by one of them settles it: one
-			// host cannot be a stranger's listing and that company's own site at once
-			expect([...observation.sites]).toEqual([])
+			// WHEN read — THEN owning the domain excuses only the owner's own pages.
+			// These name two other companies whose site it is not, which is what a
+			// listing is. The firm keeps its own website, since the website guard
+			// settles whose a host is before it asks about listings; what it pays is
+			// standing to vouch for itself, which a second site of its own restores.
+			expect([...observation.sites]).toEqual(['instalacionesferre.es'])
 		})
 
-		it('should recognise the short domain a company usually has', () => {
-			// GIVEN the same shape on a domain that is one word of the name rather
-			// than all of it — "acme.example" for "Acme Instalacions SL", which is how
-			// most firms register
+		it("should judge a franchise's domain that files its affiliates", () => {
+			// GIVEN a franchise on its own list, filing affiliates it does not name
 			const observation = observe(
-				['Acme Instalacions SL', 'Electricistas Puig SL', 'Muñoz SL'],
+				['Grupelec Instal·lacions SL', 'Electricistas Puig SL', 'Muñoz SL'],
 				[
-					'https://acme.example/partners/electricistas-puig',
-					'https://acme.example/obras/munoz',
+					'https://grupelec.example/qui-som',
+					'https://grupelec.example/associats/electricistas-puig',
+					'https://grupelec.example/associats/munoz',
 				],
 			)
 
-			// WHEN read — THEN it is still that company's own site
+			// WHEN read — THEN the page about itself is stepped over and the two
+			// affiliate pages are not, so a franchise on its own list cannot clear
+			// itself the way asking once for the whole list would have let it
+			expect([...observation.sites]).toEqual(['grupelec.example'])
+		})
+
+		it('should let a company own the domain that spells its longer name', () => {
+			// GIVEN one company returned under two names, the shorter of which is the
+			// one it is counted under, on the domain that spells the LONGER — and one
+			// other company filed on that same host
+			const observation = observe(
+				['Grup Blau', 'Grup Blau Instal·lacions', 'Electricistas Puig SL'],
+				[
+					'https://grupblauinstallacions.cat/grup-blau',
+					'https://grupblauinstallacions.cat/electricistas-puig',
+				],
+			)
+
+			// WHEN read — THEN folding the two rows into one company must not throw
+			// away the name that recognises its own domain, or a firm's own site is
+			// branded a listing for having a page about somebody else
 			expect([...observation.sites]).toEqual([])
+		})
+
+		it('should stand the watch down only for the company that owns the host', () => {
+			// GIVEN a real listing whose domain a company on the list happens to
+			// spell, and two other companies filed on it
+			const observation = observe(
+				['Paginas Instalaciones SL', 'Electricistas Puig SL', 'Muñoz SL'],
+				[
+					'https://paginas.example/empresa/paginas-instalaciones',
+					'https://paginas.example/empresa/electricistas-puig',
+					'https://paginas.example/empresa/munoz',
+				],
+			)
+
+			// WHEN read — THEN only that company's own page is stepped over, and the
+			// two the host does not name still make it a listing. Asked once for the
+			// whole list, one coinciding name would have cleared the whole host.
+			expect([...observation.sites]).toEqual(['paginas.example'])
+		})
+
+		it('should let no host be owned by a name of nothing but trade words', () => {
+			// GIVEN a company named after its trade and nothing else, filed on the
+			// host its trade word spells
+			const observation = observe(
+				['Grupo Express SL', 'Electricistas Puig SL'],
+				[
+					'https://grupo.example/empresa/grupo-express',
+					'https://grupo.example/empresa/electricistas-puig',
+				],
+			)
+
+			// WHEN read — THEN a name identifying nobody cannot own a domain, so it
+			// cannot quietly excuse a listing either
+			expect([...observation.sites]).toEqual(['grupo.example'])
 		})
 
 		it('should not let a name merely appearing in the host stand the rule down', () => {

--- a/packages/research/src/application/directory-sites.ts
+++ b/packages/research/src/application/directory-sites.ts
@@ -9,6 +9,36 @@
  * own companies at an address carrying that company's name. A host doing that for
  * two of them is a listing.
  *
+ * A company's OWN site is stepped over, one company at a time. A group's own
+ * domain carries a page for the group and a page for each part of it, so a list
+ * holding two parts of one group would otherwise watch that domain file two
+ * companies and brand it a listing — which costs the group its website, and then
+ * its standing to vouch for itself. Whose site a host is comes from
+ * `own-site.ts`, the single answer the rest of the run uses, so the watch cannot
+ * reach a different one.
+ *
+ * Asking one company at a time is what keeps a franchise caught. A franchise's
+ * domain is established as the franchise's own, so its pages about itself are
+ * stepped over — while its pages filing affiliates it does NOT name are weighed
+ * as usual, and two of those still make it a listing. Asking once for the whole
+ * list instead would step over every address on the host the moment any one
+ * company owned the domain, and a franchise on its own list would clear itself.
+ *
+ * The other side of that is a firm's own site with a page for each of its
+ * partners, which reads as a listing. Those pages really are about companies
+ * whose site it is not, so the reading is right — and it is paid for by the firm
+ * itself, which loses that host as its website and as the thing that vouches for
+ * it. That is the known price of the rule below, and the reason
+ * `COMPANIES_THAT_MAKE_A_LISTING` is not lowered.
+ *
+ * The price is NOT bought off by telling `website-guard.ts` to keep a website
+ * whenever `own-site.ts` says the company owns the host. That was tried and it
+ * fails wide open: ownership there is granted by any distinctive word of a name,
+ * so "Instalaciones Eléctricas Girona" owns girona.cat and every company named
+ * after its town or its trade would keep a directory's page as its website — in
+ * exactly the markets this is for. Ownership is a positive claim safe to COUNT
+ * and to clear a company with; it is not safe to overrule a blank with.
+ *
  * What it watches is every address the run met — each result its searches returned,
  * each page it fetched, and the addresses those pages link to. That last one is not
  * an extra: a search hands back a listing's category page, which names a trade and
@@ -58,15 +88,12 @@
  */
 
 import {
-	coreSpellings,
 	DISTINCTIVE_NAME_LENGTH,
-	distinctiveWords,
-	type EntityTargets,
 	foldTokens,
-	isOwnSiteHost,
 	spellingsWithoutForms,
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
+import { ownSiteHostVerdict } from './own-site'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
 
 /** Hosts this run watched file several of its own companies. */
@@ -86,17 +113,43 @@ export type SiteVerdict = 'directory' | 'unknown'
 const COMPANIES_THAT_MAKE_A_LISTING = 2
 
 // One of the run's companies: the name an address would write it under, and the
-// name it is counted as. They are two things because a Catalan name can be
+// name it is counted as. Those two are separate because a Catalan name can be
 // written out two ways — an address may spell either, while the company is still
 // one company and must be counted once.
 interface ListedCompany {
 	readonly countedAs: string
 	readonly writtenAs: ReadonlyArray<string>
+	// Kept unfolded beside the spellings because the own-site reading below takes a
+	// name and folds it its own way. Handing it a spelling folded here would be a
+	// second answer to a question that already has one.
+	readonly rowNames: ReadonlyArray<string>
 }
 
 // Every way an address would write this company's name, folded so case, accents
 // and punctuation stop mattering. Empty when nothing distinctive is left to look
 // for.
+//
+// Four letters, where `own-site.ts` reads a domain from three. The two floors
+// answer different questions and the gap is deliberate: a three-letter run found
+// in a path turns up by coincidence — a language code, a section name — and would
+// file the wrong company, while a domain that IS three letters is the whole of
+// what a large carrier registered (dsv.com, xpo.com).
+//
+// What it costs is a listing that files companies named in three letters: they
+// have no filable spelling, so a site filing "DSV" and "XPO" is never watched
+// filing anybody and goes unnoticed. That is a miss and not a deleted website,
+// which is the direction to be wrong in — and a three-letter company is no worse
+// off on its own domain than a longer-named one, since its own pages cannot be
+// filed against it either.
+//
+// Lowering it to three was measured rather than argued, and is not worth it. It
+// does catch that missed listing. It also files any row whose name folds to an
+// ordinary three-letter part of an address — a language code, a region, a
+// section — so a firm's own site with pages at "/sud" and "/est", beside two
+// rows named for those regions, is branded a listing and loses real websites.
+// Over three live market runs the lower floor changed nothing at all: the same
+// hosts branded, no website kept or lost. A broad new way to be wrong, bought
+// for a benefit that did not appear.
 const filedAs = (name: string): ReadonlyArray<string> =>
 	spellingsWithoutForms(name).filter(
 		spelling => spelling.length >= DISTINCTIVE_NAME_LENGTH,
@@ -107,13 +160,11 @@ const filedAs = (name: string): ReadonlyArray<string> =>
 // not between the two names as written, because the pair this exists to catch is
 // exactly a firm whose two rows spell one word differently.
 const isTheSameCompanyAgain = (
-	company: ListedCompany,
-	earlier: ReadonlyArray<ListedCompany>,
+	company: { readonly writtenAs: ReadonlyArray<string> },
+	earlier: { readonly writtenAs: ReadonlyArray<string> },
 ): boolean =>
-	earlier.some(seen =>
-		company.writtenAs.some(written =>
-			seen.writtenAs.some(before => written.startsWith(before)),
-		),
+	company.writtenAs.some(written =>
+		earlier.writtenAs.some(before => written.startsWith(before)),
 	)
 
 // One company per name, rather than one per spelling. A name that another name
@@ -138,14 +189,59 @@ const distinctCompanies = (
 				: {
 						countedAs: company.countedAs,
 						writtenAs: [...new Set([...seen.writtenAs, ...company.writtenAs])],
+						rowNames: [...new Set([...seen.rowNames, ...company.rowNames])],
 					},
 		)
 	}
-	return [...byName.values()]
-		.sort((a, b) => a.countedAs.length - b.countedAs.length)
-		.filter(
-			(company, at, kept) => !isTheSameCompanyAgain(company, kept.slice(0, at)),
+	// Spelled out with the row names writable, rather than leaning on an
+	// intersection to strip the `readonly` off `ListedCompany`, because they really
+	// are rewritten below: a company only learns the rest of its names as the
+	// longer rows that fold into it arrive.
+	interface Absorbing {
+		readonly countedAs: string
+		readonly writtenAs: ReadonlyArray<string>
+		rowNames: ReadonlyArray<string>
+	}
+	const ordered = [...byName.values()].sort(
+		(a, b) => a.countedAs.length - b.countedAs.length,
+	)
+	const kept: Array<Absorbing> = []
+	// Which surviving company each row ends up under, the dropped rows included.
+	// A row repeats an EARLIER row whether or not that earlier one survived, and
+	// the difference matters: a name can be written several ways, so the chain
+	// from one row to the next may run through a row that was itself dropped.
+	// "Moll", "Møller Transport" — which reads both "moller…" and "moeller…" —
+	// and "Moeller Transport Nord" are one company, though the last spells
+	// nothing the first does. Comparing only against survivors breaks that chain
+	// and counts one company as two, which is the whole thing this prevents.
+	const survivorOf: Array<Absorbing> = []
+	for (const [at, company] of ordered.entries()) {
+		const repeatsAt = ordered.findIndex(
+			(seen, before) => before < at && isTheSameCompanyAgain(company, seen),
 		)
+		const survivor = repeatsAt === -1 ? undefined : survivorOf[repeatsAt]
+		if (survivor === undefined) {
+			const entry = { ...company }
+			kept.push(entry)
+			survivorOf[at] = entry
+			continue
+		}
+		// The longer row is this company written at more length. Its row is dropped
+		// and its NAME is not: a firm whose two rows read "Grup Blau" and "Grup Blau
+		// Instal·lacions" may have registered the longer one, and only that spelling
+		// recognises its own domain.
+		//
+		// The spellings a host files it under are deliberately not merged the same
+		// way. A longer name reaches more addresses, and every extra address a host
+		// is read as filing takes some company's website away, while an extra name a
+		// company may own only ever withholds a branding — so each list is generous
+		// in the direction that costs nothing.
+		survivorOf[at] = survivor
+		survivor.rowNames = [
+			...new Set([...survivor.rowNames, ...company.rowNames]),
+		]
+	}
+	return kept
 }
 
 // The names of this scan's own companies.
@@ -333,47 +429,47 @@ export const observeDirectorySites = (args: {
 		names.flatMap(name => {
 			const writtenAs = filedAs(name)
 			const countedAs = writtenAs[0]
-			return countedAs === undefined ? [] : [{ countedAs, writtenAs }]
+			return countedAs === undefined
+				? []
+				: [{ countedAs, writtenAs, rowNames: [name] }]
 		}),
 	)
 	if (companies.length < COMPANIES_THAT_MAKE_A_LISTING) {
 		return { sites: new Set(), addressesRead }
-	}
-	// What it takes for a host to be one of these companies' own site, asked the
-	// way the rest of the run asks it: the domain has to BE a name, not merely
-	// carry one, so "acme.example" is Acme Instalacions' own and
-	// "acme-directory.com" is not.
-	const ownSiteKeys: EntityTargets = {
-		cores: names
-			.flatMap(coreSpellings)
-			.filter(core => core.length >= DISTINCTIVE_NAME_LENGTH),
-		words: [...new Set(names.flatMap(distinctiveWords))],
-		domains: [],
-		places: [],
 	}
 
 	// Which of the run's companies each host files, and where. The addresses are
 	// held rather than counted, because one page naming two of them is a piece
 	// about both — it takes a separate address per company to be a listing.
 	const filedByHost = new Map<string, Map<string, Set<string>>>()
-	// A host that is a listed company's own site is that company's, whatever else
-	// sits on it: a firm's own page for each partner would otherwise read as a
-	// listing of them. Answered once per host, since hundreds of addresses read off
-	// one index page all share theirs.
-	const ownSiteHosts = new Map<string, boolean>()
-	const isOwnSite = (host: string): boolean => {
-		const known = ownSiteHosts.get(host)
+	// A host that is established as a company's own site files nothing for THAT
+	// company: a firm's own site names itself, and a group's own site carries a
+	// page for each part of the group. Answered once per company and host, since
+	// hundreds of addresses read off one index page all share theirs.
+	const ownSiteAnswers = new Map<string, boolean>()
+	const isOwnSiteOf = (company: ListedCompany, host: string): boolean => {
+		// Joined with a line break, which neither a folded name nor a host can hold,
+		// so no two pairs can fall on one key.
+		const key = `${company.countedAs}\n${host}`
+		const known = ownSiteAnswers.get(key)
 		if (known !== undefined) return known
-		const own = isOwnSiteHost(ownSiteKeys, host)
-		ownSiteHosts.set(host, own)
+		const own = company.rowNames.some(
+			name => ownSiteHostVerdict({ name, host }) === 'established',
+		)
+		ownSiteAnswers.set(key, own)
 		return own
 	}
 	for (const address of readable) {
 		// Non-null: the screen above already parsed every address that got here.
 		const host = hostOf(address) ?? ''
-		if (isOwnSite(host)) continue
+		// Read once for the address and only when some company still needs it: a
+		// group's own index page hands over hundreds of addresses that every company
+		// on the list steps over, and putting each of them back into letters before
+		// asking would be the whole page's work for nothing.
+		if (companies.every(company => isOwnSiteOf(company, host))) continue
 		const segments = filingWords(address)
 		for (const company of companies) {
+			if (isOwnSiteOf(company, host)) continue
 			if (
 				segments.some(segment =>
 					company.writtenAs.some(spelling =>

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -810,6 +810,16 @@ export const reachedOwnSite = (
  * The name has to BE the domain, not merely appear inside it: "Acme Logistics" is
  * at home on acmelogistics.com and on the shorter acme.com, since a company often
  * registers less than its full name, but not on acme-directory.com.
+ *
+ * Not the same reading as `ownSiteVerdict` in `own-site.ts`, and deliberately so.
+ * That one is asked about an address a run already holds, where a wrong yes costs
+ * one field, so it accepts the FRONT of a name — "D-Sécurité (groupe)" at
+ * d-securite.com. This one picks a site to go and read and then grounds a whole
+ * row on it, where a wrong yes writes a stranger's revenue, chief executive and
+ * telephone number onto the company, so it wants a whole name and would hand
+ * "Grupo Cobra Instalaciones" nothing at grupocobra.com. Every caller weighing an
+ * address already in hand asks `own-site.ts`; this is only for choosing what to
+ * fetch. Loosening it to match would fail open across the whole grounding path.
  */
 export const isOwnSiteHost = (
 	targets: EntityTargets,

--- a/packages/research/src/application/existence-verdict.test.ts
+++ b/packages/research/src/application/existence-verdict.test.ts
@@ -16,8 +16,10 @@ const OWN = 'https://fusteriamiquel.cat'
 const NAME = 'Fusteria Miquel'
 // A regional paper: never watched filing anybody, so it reads `unknown`.
 const PAPER = 'https://elpuntavui.cat/noticia/12345'
-// A listing the run watched file several of its own companies.
+// A business directory's page about the company, on a host that spells no part
+// of its name.
 const LISTING = 'https://paginas.es/empresa/fusteria-miquel'
+// A run that watched nothing behave like a listing.
 const NONE: ReadonlySet<string> = new Set()
 
 describe('existenceOf', () => {
@@ -40,8 +42,8 @@ describe('existenceOf', () => {
 		it('should let a directory be the second website', () => {
 			// GIVEN the company's own site, and a listing that files it
 			// WHEN asked
-			// THEN the listing counts toward the two — it is barred from CLEARING
-			// the company, not from being one of the websites that name it
+			// THEN the listing counts toward the two — what it cannot do is CLEAR
+			// the company, and nothing here asks it to
 			expect(
 				existenceOf({
 					name: NAME,
@@ -77,6 +79,57 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [OWN, PAPER],
 					directorySites: NONE,
+				}),
+			).toEqual({ verdict: 'confirmed', websites: 2 })
+		})
+	})
+
+	describe('when the site is one the run watched filing other companies', () => {
+		it('should refuse to let a watched listing clear a company it is named for', () => {
+			// GIVEN a listing whose own domain happens to spell the company's name,
+			// which the domain reading alone takes for that company's own site
+			// WHEN asked
+			// THEN watching the host file company after company is the one thing that
+			// catches the coincidence, so it clears nobody — including the row whose
+			// name it seems to carry
+			expect(
+				existenceOf({
+					name: 'Paginas',
+					website: 'https://paginas.es',
+					sources: [PAPER],
+					directorySites: new Set(['paginas.es']),
+				}),
+			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
+		})
+
+		it('should hold back a firm whose own site files its partners — the cost', () => {
+			// GIVEN a firm at the domain its name spells, which gives each of its
+			// partners a page, so the watch reads that host as a listing
+			// WHEN asked
+			// THEN it is held back although it plainly exists: the price of the rule
+			// above, paid because a wrongly-confirmed company is the dearer mistake.
+			// A second website that is not this host still clears it.
+			expect(
+				existenceOf({
+					name: 'Instalaciones Ferré',
+					website: 'https://instalacionesferre.es',
+					sources: [PAPER],
+					directorySites: new Set(['instalacionesferre.es']),
+				}),
+			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
+		})
+
+		it('should still clear that firm from a second site of its own', () => {
+			// GIVEN the same firm, cited also on the other ending it registered
+			// WHEN asked
+			// THEN the branding costs it that one host, never the company: a site of
+			// its own that nothing watched still establishes it
+			expect(
+				existenceOf({
+					name: 'Instalaciones Ferré',
+					website: 'https://instalacionesferre.es',
+					sources: [PAPER, 'https://instalacionesferre.com'],
+					directorySites: new Set(['instalacionesferre.es']),
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -172,7 +225,7 @@ describe('existenceOf', () => {
 		})
 
 		it('should hold back a company known only to newspapers', () => {
-			// GIVEN two papers, neither watched filing anybody, so both `unknown`
+			// GIVEN two papers, neither of them a domain the company's name spells
 			// WHEN asked
 			// THEN `unknown` is not a clearance — that is the whole fail-closed
 			// property, and two of them do not add up to one
@@ -181,22 +234,6 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [PAPER, 'https://lavanguardia.com/economia/55'],
 					directorySites: NONE,
-				}),
-			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
-		})
-
-		it('should refuse to let a watched listing clear a company it is named for', () => {
-			// GIVEN a listing whose own domain happens to spell the company's name,
-			// which would otherwise read as the company's own site
-			// WHEN asked
-			// THEN being a watched listing bars it from clearing, so the row falls
-			// back to having no established site
-			expect(
-				existenceOf({
-					name: 'Paginas',
-					website: 'https://paginas.es',
-					sources: [PAPER],
-					directorySites: new Set(['paginas.es']),
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -252,7 +289,11 @@ describe('existenceOf', () => {
 			// WHEN asked — THEN there is nothing to count
 			expect(
 				existenceOf({ name: NAME, sources: [], directorySites: NONE }),
-			).toEqual({ verdict: 'candidate', reason: 'no_sources', websites: 0 })
+			).toEqual({
+				verdict: 'candidate',
+				reason: 'no_sources',
+				websites: 0,
+			})
 		})
 
 		it('should never read an internal source id as a website', () => {

--- a/packages/research/src/application/existence-verdict.ts
+++ b/packages/research/src/application/existence-verdict.ts
@@ -16,12 +16,13 @@
  *
  * ## Why the second condition is stricter than it reads
  *
- * "At least one source is not a directory" sounds like it should admit a trade
- * paper. It cannot, and the reason is the shape of the verdicts this package
- * owns rather than a preference. `siteVerdict` answers `directory` or `unknown`
- * and has no third value meaning cleared — deliberately, so that a caller
- * cannot answer "is one of these not a listing?" out of silence. A newspaper is
- * therefore `unknown`, which is not a clearance.
+ * "At least one source is not a directory" sounds like it should be enough, and
+ * would admit a trade paper. It is not the rule, and the reason is the shape of
+ * the verdicts this package owns rather than a preference. `siteVerdict`
+ * (`directory-sites.ts`) answers `directory` or `unknown` and has no third value
+ * meaning cleared — deliberately, so that a caller cannot answer "is one of
+ * these not a listing?" out of silence. A newspaper is therefore `unknown`,
+ * which is not a clearance.
  *
  * So the only positive verdict available is `ownSiteVerdict` (`own-site.ts`),
  * and the rule comes out as: the company's own site, established as its own,
@@ -29,11 +30,36 @@
  * Never "the website guard did not blank it" — that means nothing condemned the
  * address, which is a different statement from the company owning it.
  *
- * What an `unknown` site still does is COUNT. A newspaper naming the company is
- * one of the two websites; it just cannot be the one that clears. A host watched
- * filing several of the run's companies is a `directory`: it counts toward the
- * two as well, and is barred from clearing. Reading either as "so the company is
+ * What a site that clears nothing still does is COUNT. A newspaper naming the
+ * company is one of the two websites; it just cannot be the one that clears. A
+ * host watched filing several of the run's companies counts toward the two as
+ * well, and is barred from clearing. Reading either as "so the company is
  * unproven, drop the source" would be a second, quieter way of failing closed.
+ *
+ * ## Why a watched listing clears nobody, even its apparent owner
+ *
+ * Ownership is read off the domain alone, so a company named after the very word
+ * a business directory registered — "Paginas" at paginas.es — reads as owning
+ * that directory. Nothing in the name or the address can tell that apart from a
+ * firm genuinely at its own domain, which is a cost `own-site.ts` names and
+ * accepts, having nothing better to go on.
+ *
+ * Here there IS something better: whether the run watched that host file company
+ * after company. A site listing the market is a listings site whatever its domain
+ * spells, so it clears nobody — including the row whose name it seems to carry.
+ * That is the one check able to catch the coincidence, and it fails closed, which
+ * is the direction this file is allowed to be wrong in.
+ *
+ * What it costs is a firm whose own site gives a page to each of its partners.
+ * The watch steps over the pages it finds a company owns, so such a host is
+ * usually branded on the PARTNERS' pages — and the firm, which plainly exists,
+ * is held back for keeping a partner list. Only usually: the watch weighs the
+ * names it was handed, and a row it never saw under that name, or a run where it
+ * watched nothing, can reach here branded for some other reason. So this rule
+ * cannot be relaxed on the strength of "branded means it lists partners".
+ *
+ * Paid knowingly: a wrongly-confirmed company is the more expensive mistake, and
+ * a second website that is not the branded host still clears this firm.
  *
  * ## Two states, never three
  *
@@ -46,11 +72,12 @@
  *
  * ## What must not be folded
  *
- * The independence count folds subdomains. The directory verdict must NOT — it
- * keys on the raw host, because `empresite.eleconomista.es` is a listing while
- * `eleconomista.es` is a newspaper, and folding the first into the second labels
- * a newspaper a directory. The two keys are computed side by side below and are
- * never swapped.
+ * The independence count folds subdomains, so two pages of one site cannot be
+ * two witnesses. The listing verdict must NOT be read off that folded key: it
+ * keys on the host as met, because `empresite.eleconomista.es` is a listing
+ * while `eleconomista.es` is a newspaper, and folding the first into the second
+ * labels a newspaper a directory. The two keys are computed side by side below
+ * and are never swapped.
  */
 
 import {
@@ -111,9 +138,11 @@ export interface RowExistence {
 /** The field a verdict is written to, so one spelling is read and written. */
 const EXISTENCE_KEY = 'existence'
 
-// One source address, read once. `own` and `directory` are asked of the RAW
-// host and `site` folds it, so the two keys travel together and neither can be
-// mistaken for the other further down.
+// One source address, read once. `host` is the address as met and `site` the
+// domain it is registered under, so the two travel together and neither can be
+// mistaken for the other further down. The listing verdict keys on the host as
+// met, since `empresite.eleconomista.es` is a listing and `eleconomista.es` is a
+// newspaper.
 interface SourceSite {
 	readonly host: string
 	readonly site: string
@@ -137,7 +166,7 @@ const webAddressesAmong = (
 
 // Every distinct host among these addresses, each read for the two questions
 // that decide what it can do: is it this company's own site, and is it a
-// listing. Held by raw host, since that is what the directory verdict keys on.
+// listing. Held by the host as met, so two pages of one site are read once.
 const sitesOf = (
 	name: string,
 	addresses: ReadonlyArray<string>,
@@ -234,20 +263,11 @@ export const existenceOf = (args: {
 			: [website, ...args.sources]
 	const sites = sitesOf(name, webAddressesAmong(offered), directorySites)
 	const websites = websitesOf(sites)
-	// A company's own site that is also a watched listing clears nothing, because a
-	// rule reading only one of the two verdicts would answer a narrower question
-	// than it claims to.
-	//
-	// They do disagree, and in a way that costs a real company its confirmation.
-	// The directory watch means to step over a listed company's own site, but it
-	// asks whose site it is with a stricter reading than this one: it wants the
-	// domain to spell a whole name, while this accepts the front of one. So a
-	// group's own domain that carries a page for the group and a page for its
-	// subsidiary — both on the same list — is counted as filing two companies and
-	// branded a listing, and the group then cannot be cleared by its own site.
-	// Withholding is the safe direction to be wrong in, so it stays this way until
-	// the two readings are reconciled, which is a change to the watch rather than
-	// to this rule.
+	// A site has to be this company's own AND not a host the run watched listing
+	// the market. Ownership is read off the domain alone, so a company named after
+	// a directory reads as owning it; watching that host file company after company
+	// is the one thing that catches the coincidence, and a listings site clears
+	// nobody however its domain reads.
 	const cleared = websites.some(group =>
 		group.some(site => site.own && !site.directory),
 	)

--- a/packages/research/src/application/own-site.test.ts
+++ b/packages/research/src/application/own-site.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { ownSiteVerdict } from './own-site'
+import { ownSiteHostVerdict, ownSiteVerdict } from './own-site'
 
 // The address the French solar directory files a company at: a slug naming a
 // trade and a role, ending in the listing's own record number, and naming no
@@ -461,6 +461,93 @@ describe('ownSiteVerdict', () => {
 			] as const) {
 				expect(ownSiteVerdict({ name, website })).toBe('unknown')
 			}
+		})
+	})
+})
+
+describe('ownSiteHostVerdict', () => {
+	describe('when a host is asked about directly', () => {
+		it('should establish a domain that spells the front of the name', () => {
+			// GIVEN a group's domain, and the group and its subsidiary as two rows
+			// WHEN each name is asked about the host
+			// THEN the front of a name is enough, so the domain is established as
+			// each of their own — which is what the directory watch steps over
+			expect(
+				ownSiteHostVerdict({
+					name: 'D-Sécurité (groupe)',
+					host: 'd-securite.com',
+				}),
+			).toBe('established')
+			expect(
+				ownSiteHostVerdict({
+					name: 'D-Sécurité Incendie',
+					host: 'd-securite.com',
+				}),
+			).toBe('established')
+		})
+
+		it('should leave a host that merely carries the name unknown', () => {
+			// GIVEN a listing whose domain has a company's name inside it
+			// WHEN asked
+			// THEN the label has to BE the name, never merely contain it
+			expect(
+				ownSiteHostVerdict({ name: 'Acme', host: 'acme-directorio.example' }),
+			).toBe('unknown')
+		})
+
+		it('should leave a host unknown for a name of nothing but trade words', () => {
+			// GIVEN a name holding no word of the company's own
+			// WHEN asked
+			// THEN there is no word of its own for a domain to spell
+			expect(
+				ownSiteHostVerdict({ name: 'Grupo Express SL', host: 'grupo.example' }),
+			).toBe('unknown')
+		})
+
+		it('should establish nothing without a name to compare', () => {
+			// GIVEN a run with no company name
+			// WHEN asked
+			// THEN an empty name must not be spelled by every host there is
+			expect(ownSiteHostVerdict({ name: '', host: 'acme.com' })).toBe('unknown')
+		})
+	})
+
+	describe('when the same site is asked about both ways', () => {
+		it('should answer a host exactly as it answers an address on it', () => {
+			// GIVEN one company's own site, and several addresses on it
+			// WHEN the host is asked directly and each address is asked
+			// THEN the two agree, which is what lets a caller weighing many
+			// addresses on one host ask once for the host
+			const name = 'Fusteria Miquel'
+			const host = 'fusteriamiquel.cat'
+			for (const website of [
+				'https://fusteriamiquel.cat',
+				'https://www.fusteriamiquel.cat/qui-som',
+				'https://fusteriamiquel.cat/obra/2024/cuina',
+			]) {
+				expect(ownSiteVerdict({ name, website })).toBe(
+					ownSiteHostVerdict({ name, host }),
+				)
+			}
+		})
+
+		it('should not screen a host the way an address is screened', () => {
+			// GIVEN a website value with words written beside the address
+			// WHEN put to each
+			// THEN the address reading refuses it, while the host reading trusts its
+			// caller to have read a host off an address already
+			expect(
+				ownSiteVerdict({
+					name: 'Fusteria Miquel',
+					website: 'https://fusteriamiquel.cat/ (inferred from the name)',
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteHostVerdict({
+					name: 'Fusteria Miquel',
+					host: 'fusteriamiquel.cat',
+				}),
+			).toBe('established')
 		})
 	})
 })

--- a/packages/research/src/application/own-site.ts
+++ b/packages/research/src/application/own-site.ts
@@ -77,6 +77,24 @@
  * Whether the host is a business directory is a separate question with a
  * separate answer (`directory-sites.ts`), and a caller weighing a company's
  * sources asks both.
+ *
+ * ## The one reading that stays apart
+ *
+ * `isOwnSiteHost` in `entity-guard.ts` asks something that sounds the same and
+ * is not: which single site a run should GO AND READ as the company's. A wrong
+ * yes there sends the run off to read a stranger's pages and then writes that
+ * stranger's revenue, chief executive and telephone number onto the row, so it
+ * wants the domain to spell a WHOLE name and will not read the front of one —
+ * "Grupo Cobra Instalaciones" must not be handed grupocobra.com, a large
+ * unrelated group. This file is asked about an address a run already holds,
+ * where a wrong yes costs one field, so the front of a name is enough.
+ *
+ * The difference is in what each answer is then spent on, never in how a name is
+ * read, and it is written down at both definitions so neither drifts. Every
+ * caller weighing an address the run already has asks THIS file — the directory
+ * watch included, where asking the stricter one brands a group's own domain a
+ * listing for carrying a page for the group and a page for its subsidiary, and
+ * costs the group its website.
  */
 
 import {
@@ -170,6 +188,20 @@ const hostSpellsTheCompany = (name: string, host: string): boolean => {
 }
 
 /**
+ * Whether this host is established as the company's own site.
+ *
+ * The same question as `ownSiteVerdict`, asked of a host already read off an
+ * address. A caller weighing many addresses that share a host asks it once for
+ * the host rather than once per address, and gets the same answer either way,
+ * since the path is deliberately never read.
+ */
+export const ownSiteHostVerdict = (args: {
+	readonly name: string
+	readonly host: string
+}): OwnSiteVerdict =>
+	hostSpellsTheCompany(args.name, args.host) ? 'established' : 'unknown'
+
+/**
  * Whether this website is established as the company's own site.
  *
  * `name` is the company the address is claimed for — the row's own name on a
@@ -188,5 +220,5 @@ export const ownSiteVerdict = (args: {
 	const host = hostOf(website)
 	if (host === null) return 'unknown'
 
-	return hostSpellsTheCompany(name, host) ? 'established' : 'unknown'
+	return ownSiteHostVerdict({ name, host })
 }


### PR DESCRIPTION
A search for a market often returns a parent and one of its parts as two rows — "D‑Sécurité (groupe)" and "D‑Sécurité Incendie". The group's own website naturally carries a page for each. The watch that spots business directories reads that as one host filing two of the run's companies, brands the group's own address a listing, and deletes it from the row. Since §4.8 (#486), a branded site may also vouch for nobody, so the group cannot be confirmed either.

The watch does try to step over a company's own site. It just asks *whose website is this?* with a stricter test than the rest of the run uses, so the protection misses. **That mismatch is the bug, not the watch.**

## The two readings

`own-site.ts` accepts the **front** of a name, so `d-securite.com` is D‑Sécurité's. The watch went through `isOwnSiteHost`, which wants the address to spell a **whole** name — and `dsecurite` is neither `dsecuritegroupe` nor `dsecuriteincendie`, because the two names diverge right after the part they share.

Reproduced before touching anything:

```
cores the directory watch builds: ["dsecuritegroupe","dsecuriteincendie"]
ownSiteVerdict says the group owns it: established
isOwnSiteHost (what the watch asked):  false
branded a directory?                   directory
```

## What changed

**The watch asks `own-site.ts` — the single answer the rest of the run uses — one company at a time.** That is the whole fix. `website-guard.ts` is untouched; `existence-verdict.ts` is documentation only.

Asking per company is the load-bearing part. Pooling every name and asking once was one of the four fixes the issue rules out, because it fails open: a franchise's domain spells the franchise, so one match would excuse every address on the host and each affiliate would keep the franchise's listing page as its own website. Per company, the franchise's pages about itself are stepped over while its pages filing affiliates it does *not* name still count — and two of those still make it a listing.

Verified end to end on the reported case: the host is **not branded**, both rows **keep their websites**, and both reach **confirmed**.

`isOwnSiteHost` keeps its stricter reading and is now used only for choosing which site a run goes and *reads*, where a wrong yes writes a stranger's revenue and telephone number onto the row. `grupocobra.com` is still refused for a differently-named small company; the fetching and grounding path is untouched. Why the two differ is written down at **both** definitions so neither drifts.

## What this deliberately does NOT do, and why

Two earlier versions of this PR also changed `website-guard.ts`, so that a company's own domain survived the directory rule. **Both were wrong, and both were caught by measurement rather than by review.**

1. **Ownership checked before the deeper-path rule** kept a *press release* on a parent's domain — a live row, `EDF ENR` with an `edf.fr` press-release URL, which `main` blanks. A reader clicking that lands on a press release, not a website.
2. **Ownership exempting the directory rule** let an affiliate named after its franchise keep the franchise's listing page: `Grupelec Girona SL` on `grupelec.example/grupelec-girona`, because `grupelec` is a front-run of `grupelecgirona`. That is the exact fail-open the issue rules out as fix #1.

Chasing the second uncovered why the whole approach was unsound. `ownSiteVerdict` grants ownership on **any distinctive word of a name, anywhere in it** — not just a front-run — and the generic-word list holds about thirty English and Spanish trade words. Measured:

```
"Instalaciones Eléctricas Girona SL"
  distinctive words   -> ["instalaciones", "electricas", "girona"]
  owns girona.cat?    -> established
  with the exemption, keeps https://girona.cat/instalaciones-electricas-girona
```

Every company carrying its town or its trade in its name would own any directory registered under that word — in exactly the Spanish and Catalan markets this is for. It also put `website-guard.ts` and `existence-verdict.ts` on **opposite** precedence for the same pair of readings, which is the one-question-two-answers disease this issue is about.

So ownership is a positive claim safe to COUNT with and to clear a company with — where the directory brand backstops it — and **not** safe to overrule a blank with. The exemption is gone and the reasoning is recorded in `directory-sites.ts` so it is not tried a fourth time.

The price, stated plainly: a firm whose own site gives a page to each of its partners reads as a listing and loses that host as its website and as the thing that vouches for it. A second site of its own still clears it.

## Measured

Three live FR market runs (the market the bug was reported from), plus a deterministic replay of both versions over **identical evidence** — each run's stored rows and stored source addresses — which avoids the confound that makes a live A/B void when the two sides reach different pages.

| run | rows | hosts branded, `main` → branch | websites kept | rows confirmed |
|---|---|---|---|---|
| 3919d048 | 43 | 8 → 8 | 18 → 18 | 19 → 19 |
| 5bd0aee8 | 37 | 5 → 5 | 20 → 20 | 17 → 17 |
| cbc1d273 | 41 | 4 → 4 | 18 → 18 | 23 → 23 |

**Zero difference on all three.** The honest headline: on this evidence the change is a no-op. The bug's trigger — a group's own domain filing two of the run's companies at name-bearing addresses — did not occur; every host the watch branded was a genuine third-party directory (`pappers.fr`, `linkedin.com`, `zoominfo.com`, `crunchbase.com`, `kompass`, `annuaire-entreprises.data.gouv.fr`). The watch behaved correctly throughout and there was nothing to save.

What the change buys is therefore **not visible in these runs**. It is the failure it prevents — reproduced deterministically from the production row in the issue — plus the rows sitting one branding away from it: across the three runs the two readings disagreed on exactly one row each, a different company every time (`EDF ENR → edf.fr`, `C‑2E → c-2e.com`, `ACAL BFI FRANCE → acalbfi.fr`), always with the shared reading more generous and **never** the reverse.

Limits, plainly: no live `main` baseline (the replay is the stronger comparison for this question, but it is a replay); FR only; and the replay sees only the ~130 stored source URLs per run, not the up-to-983 addresses the live watch weighs including links read inside fetched pages — which is exactly where the trigger would live. An instrumented run to close that gap was blocked by the scrape provider returning `success=false` and the LLM fallback returning 403.

## Also fixed here

A defect I introduced, caught by an adversarial audit: rewriting the company fold changed `distinctCompanies` from comparing each row against **all earlier rows** to comparing against **survivors only**. Prefix-matching over *sets* of spellings is not transitive — accents give `Møller Transport` both `mollertransport` and `moellertransport` — so a chain can run through a row that was itself dropped, and one company got counted as two. That brands hosts `main` leaves alone, which deletes websites. Restored, with a regression test.

Two existence tests that a scripted edit had weakened (real watched-listing sets replaced by the empty set) are restored — they were the only assertions that a watched listing still counts toward the two websites while being barred from clearing.

## Left open — measured, and deliberately not closed

A company named in **three letters** cannot be filed by the watch, whose floor is four (`own-site.ts` reads a domain from three), so a site listing several such companies goes unnoticed. I measured whether to close it rather than argue about it.

| case | floor 4 (shipped) | floor 3 |
|---|---|---|
| directory filing `DSV` and `XPO` | missed | **caught** |
| firm's own site with `/sud` and `/est`, beside rows named `Sud`/`Est` | not branded | **firm's own site branded** |
| site with `/fra/` and `/deu/`, beside rows named `Fra`/`Deu` | not branded | **branded** |
| three-letter firm's own domain, its own pages | not branded | not branded |
| the three live FR runs | — | **no change at all**: same hosts branded, no website kept or lost |

Lowering the floor buys the missed listing and pays for it by filing any row whose name folds to an ordinary three-letter part of an address — a language code, a region, a section — which brands innocent hosts and deletes real websites. One row in 121 across the three runs had a name that short (`Asc`), and the lower floor changed nothing on that evidence.

So the four-letter floor stays: the two floors answer different questions, and the asymmetry is correctly priced. A domain that IS three letters is the whole of what a large carrier registered; a three-letter run inside a path is a coincidence waiting to happen. The reasoning and the measurement are recorded in `filedAs`.

## Not subsumed

- **#502** (a trade body's member page kept as a company's website) needs claims accumulated *across rounds*; `aemiat.com/e-mora/` still reads `unknown` because the address shortens the name.
- **#477** (a social-media page kept as one) — `ownSiteVerdict('LIPOTECH SARL', 'facebook.com/LIPOTECH.SARL')` is `unknown`, so nothing here fires on it.

## Verification

- 1694 unit tests, workspace `check-types`, `pnpm test`, `pnpm build` — green, rebased on `bad6ab4668`.
- Three `/code-review xhigh` passes plus three adversarial agents, each required to prove claims by running code against a `main` baseline rather than by reading. Between them they found the `edf.fr` regression, the `Grupelec` regression, the town/trade looseness that sank the whole approach, and the fold defect above.

Closes #494
