### PR TITLE
fix(cli): finish worktree cleanup without misplacing anyone's work

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -64,12 +64,12 @@ This one command detects whether it is running inside a linked worktree or the m
 - linked worktree: drops DB + bucket, removes the worktree directory, checks out `main`, pulls, and deletes the local branch if it still exists.
 - main checkout: checks out `main`, pulls, and deletes the local feature branch.
 
-It refuses if the working tree is dirty; pass `--stash` to safely stash uncommitted changes and pop them on `main`, or `--force` to discard them.
+It refuses if the working tree is dirty; pass `--stash` to set uncommitted changes aside and put them back in the directory they came from, or `--force` to discard them.
 
 ### What if the local branch still has changes?
 
-- **Uncommitted changes**: `worktree done` stops by default. Use `pnpm cli worktree done --stash` to stash them before cleanup and pop the stash on `main`. Alternatively, stash manually (`git stash`) and run `worktree done`, then `git stash pop` on `main`.
-- **Committed changes after a rebase-merge**: the local branch may no longer be an ancestor of `main` because the merge rewrote commits. `git branch -d` then reports "not fully merged". This is expected — the PR code is already on `main` with new hashes. Use `pnpm cli worktree done --force` (or `git branch -D <branch>`) after confirming you do not need the old local commits.
+- **Uncommitted changes**: `worktree done` stops by default. Use `pnpm cli worktree done --stash` to set them aside before cleanup; they are put back where they came from afterwards, whether or not the rest of the run succeeded. In a linked worktree that directory is deleted, so there the changes stay stashed and the command prints the `git stash apply` line that puts them back.
+- **Committed changes after a rebase- or squash-merge**: the local branch is no longer an ancestor of `main`, because the merge rewrote the commits. `worktree done` handles this on its own — it checks whether `main` carries the branch's work in any of the shapes a merge leaves, and deletes the branch when it does. It refuses only when `main` has no copy of the work at all, and then it says so and leaves the branch alone; `--force` deletes it regardless.
 - **Linked worktree with changes**: the worktree directory is removed, so any uncommitted changes inside it are lost unless stashed or committed first. Prefer `pnpm cli worktree done --stash`.
 
 ### Manual fallback (tools without the CLI)

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -41,6 +41,7 @@ import type { EnvFileResult } from './commands/setup'
 import { setup } from './commands/setup'
 import {
 	accessUrls,
+	NOTHING_TO_DROP,
 	worktreeDoctor,
 	worktreeDone,
 	worktreeDown,
@@ -690,7 +691,18 @@ const worktreeUpCommand = Command.make('up', {}, () => worktreeUp).pipe(
 	),
 )
 
-const worktreeDownCommand = Command.make('down', {}, () => worktreeDown).pipe(
+// Whoever asks to drop this worktree's data expects data to be there, so
+// finding none is worth reporting. `worktree done` reads the same answer as a
+// note and carries on.
+const worktreeDownCommand = Command.make('down', {}, () =>
+	worktreeDown.pipe(
+		Effect.flatMap(outcome =>
+			outcome === 'nothing-provisioned'
+				? Effect.fail(new Error(NOTHING_TO_DROP))
+				: Effect.void,
+		),
+	),
+).pipe(
 	Command.withShortDescription('Drop this worktree’s database + bucket'),
 	Command.withDescription(
 		'Drop this worktree’s Postgres database and MinIO bucket from the shared ' +
@@ -709,7 +721,7 @@ const worktreeDoneCommand = Command.make(
 		),
 		stash: Flag.boolean('stash').pipe(
 			Flag.withDescription(
-				'Stash uncommitted changes before cleanup, then pop them on main',
+				'Stash uncommitted changes before cleanup. They go back where they came from — but a linked worktree is deleted by this command, so there they stay stashed and are named for you to apply',
 			),
 			Flag.withDefault(false),
 		),

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -724,6 +724,19 @@ const stopWorktreeDevServers = (worktreePath: string) =>
 		`bash "${resolve(ROOT, 'scripts/worktree-stop-procs.sh')}" "${worktreePath}" ${process.pid}`,
 	).pipe(Effect.catch(() => Effect.void))
 
+/**
+ * Drop this worktree's database and bucket, and say what was found here.
+ *
+ * Finding nothing to drop is an answer rather than a failure, because the two
+ * callers want opposite things from it — `down` reports it, since asking to
+ * drop data that is not there leaves the command with nothing it was asked for;
+ * `done` notes it and keeps tidying, since a worktree that never needed a
+ * database is still a worktree to finish.
+ *
+ * Two things still fail outright: a checkout that is not a worktree at all, and
+ * one whose `.env` points at the shared data. Neither is an answer for a caller
+ * to weigh up.
+ */
 export const worktreeDown = Effect.gen(function* () {
 	if (!(yield* isLinkedWorktree)) {
 		return yield* Effect.fail(
@@ -744,23 +757,25 @@ export const worktreeDown = Effect.gen(function* () {
 		// database behind. Drop that rather than refusing and leaking it. Checked
 		// for existence first so the line below reports what actually happened
 		// instead of naming a database that was never there.
+		//
+		// Docker being off is not a reason to refuse either — a worktree that
+		// provisioned nothing needs no shared stack to be finished. The cost is not
+		// knowing whether a stray test database is sitting there, and `worktree
+		// prune` comes back for one anyway.
+		const databases = yield* listDatabases.pipe(
+			Effect.orElseSucceed((): ReadonlyArray<string> => []),
+		)
 		const leftover =
-			beforeUpDb && (yield* listDatabases).includes(beforeUpDb)
-				? beforeUpDb
-				: null
+			beforeUpDb && databases.includes(beforeUpDb) ? beforeUpDb : null
 		if (leftover) {
 			yield* stopWorktreeDevServers(ROOT)
 			yield* dropDatabase(leftover)
 			yield* Console.log(
 				`✓ Removed ${leftover} (never provisioned — no dev database or bucket to drop).`,
 			)
-			return
+			return 'removed' as const
 		}
-		return yield* Effect.fail(
-			new Error(
-				'No provisioned .env here — nothing to drop. Run `pnpm cli worktree up` first, or it was already torn down.',
-			),
-		)
+		return 'nothing-provisioned' as const
 	}
 	const { db, bucket } = identity
 	if (!isWorktreeOwned(db, bucket)) {
@@ -788,19 +803,59 @@ export const worktreeDown = Effect.gen(function* () {
 		Effect.catch(() => Effect.void),
 	)
 	yield* Console.log(`✓ Removed ${db} and ${bucket} (shared stack untouched).`)
+	return 'removed' as const
 })
 
-// Whether everything this branch changed is already on main.
-//
-// Asked by rolling the branch up into a single commit sitting on the point it
-// forked from, then letting git say whether that patch is already in main. That
-// is the shape a squash merge leaves behind, and comparing commit by commit
-// cannot see it. Any git failure here reads as "not already there", so a doubt
-// keeps the branch rather than deleting it.
+/** The wording `worktree down` fails with when it finds nothing to drop. */
+export const NOTHING_TO_DROP =
+	'No provisioned .env here — nothing to drop. Run `pnpm cli worktree up` first, or it was already torn down.'
+
+/**
+ * Whether everything this branch changed is already on main.
+ *
+ * Asked in three ways, because a merge leaves three different traces and each
+ * one hides the others:
+ *  - main can simply reach the branch, which is an ordinary merge or a
+ *    fast-forward, and the only shape where the commits themselves survive;
+ *  - every commit is on main under a new name, which is what replaying them one
+ *    by one leaves — a rebase merge;
+ *  - the whole branch is on main as a single commit, which is what squashing
+ *    leaves.
+ *
+ * `git branch -d` answers only the first, so it refuses both of the others even
+ * though the work is safe, and this repo merges by all three. It is also asked
+ * a question nobody wants here: it accepts a branch merged into its own remote
+ * copy, which says the work was pushed, not that it reached main.
+ *
+ * Any git failure while answering reads as "not already there", so a doubt
+ * keeps the branch rather than deleting it.
+ */
 const branchWorkIsOnMain = (root: string, branch: string) =>
 	Effect.gen(function* () {
 		const git = (...args: ReadonlyArray<string>) =>
 			execSilentArgs('git', ['-C', root, ...args])
+		const mainReachesIt = yield* git(
+			'merge-base',
+			'--is-ancestor',
+			branch,
+			'main',
+		).pipe(
+			Effect.map(() => true),
+			Effect.orElseSucceed(() => false),
+		)
+		if (mainReachesIt) return true
+		// `git cherry` marks a patch main already carries with "-", and one it is
+		// missing with "+". Empty output means no commits to judge, which the
+		// reachability question above has already settled.
+		const oneByOne = yield* git('cherry', 'main', branch)
+		if (
+			oneByOne !== '' &&
+			oneByOne.split('\n').every(line => line.startsWith('-'))
+		) {
+			return true
+		}
+		// The whole branch rolled up into one commit sitting where it forked, which
+		// is the shape a squash merge leaves.
 		const forkedAt = yield* git('merge-base', 'main', branch)
 		const content = yield* git('rev-parse', `${branch}^{tree}`)
 		// A loose commit that is never referenced, so it costs one object git
@@ -813,69 +868,123 @@ const branchWorkIsOnMain = (root: string, branch: string) =>
 			'-m',
 			'rolled up to compare against main',
 		)
-		// `git cherry` marks a patch main already carries with "-", and one it is
-		// missing with "+".
 		return (yield* git('cherry', 'main', rolledUp)).startsWith('-')
 	}).pipe(Effect.orElseSucceed(() => false))
 
-// Delete the branch the finished PR was on, leaving git's own refusal as the
-// first word.
-//
-// `git branch -d` asks whether the branch's commits are reachable from main. A
-// squash merge replays the whole branch as one new commit, so none of the
-// commits the branch actually holds is reachable and a branch whose work is
-// safely on main still reads as unmerged — which is most of this repo's PRs.
-// When that is why the delete was refused, ask the question git did not: is the
-// content already there? Only then insist. A branch holding work main has never
-// seen is left alone and named, because deleting it is the one step here nobody
-// can undo.
+/**
+ * Delete the branch the finished pull request was on.
+ *
+ * Whether the work is safe is decided by `branchWorkIsOnMain`, which asks more
+ * than `git branch -d` does — see there for why. A branch holding work main has
+ * never seen is left standing and named, because deleting it is the one step
+ * here nobody can undo.
+ */
 const deleteFinishedBranch = (root: string, branch: string, force: boolean) =>
 	Effect.gen(function* () {
-		const insist = execArgs('git', ['-C', root, 'branch', '-D', branch])
-		if (force) {
-			yield* insist
-			yield* Console.log(`✓ Deleted local branch ${branch}`)
+		if (!force && !(yield* branchWorkIsOnMain(root, branch))) {
+			return yield* Effect.fail(
+				new Error(
+					`Branch ${branch} was kept: main carries no copy of its work, in any of the shapes a merge leaves. Look at it with \`git log main..${branch}\`, then delete it yourself with \`git branch -D ${branch}\` if you are happy to lose it.`,
+				),
+			)
+		}
+		yield* execArgs('git', ['-C', root, 'branch', '-D', branch])
+		yield* Console.log(`✓ Deleted local branch ${branch}`)
+	})
+
+/**
+ * Put back what `--stash` set aside, whether the rest of the run succeeded or
+ * not. Anything that stops the run part-way otherwise leaves the changes in the
+ * stash with nothing said, and a clean working tree reads as work that vanished.
+ *
+ * `entry` is the commit this run's stash was saved as, and it is applied by that
+ * name rather than by taking whatever sits on top. The stash is shared by every
+ * worktree of the repository, so with several sessions running at once the top
+ * entry is often somebody else's — taking it would drop one branch's unfinished
+ * work into another's tree and leave the owner's own entry behind.
+ *
+ * `stashedIn` is the directory the changes came from, which the linked-worktree
+ * path deletes on its way through. Putting them back then would land one
+ * branch's edits in the main checkout, so where the directory is gone they are
+ * named and left where they are.
+ */
+const restoreStashed = (args: {
+	readonly stashedIn: string
+	readonly entry: string
+}) =>
+	Effect.gen(function* () {
+		const { stashedIn, entry } = args
+		if (!existsSync(stashedIn)) {
+			yield* Console.log(
+				`Uncommitted changes are still stashed — the worktree they came from is gone. Put them where you want them with \`git stash apply ${entry}\`.`,
+			)
 			return
 		}
-		// Asked quietly, because a refusal here is the ordinary case rather than a
-		// fault: git printing "not fully merged" and the run then reporting success
-		// reads as something having gone wrong. A refusal that survives the content
-		// check below is reported in this command's own words instead.
-		const wentQuietly = yield* execSilentArgs('git', [
+		const applied = yield* execArgs('git', [
 			'-C',
-			root,
-			'branch',
-			'-d',
-			branch,
+			stashedIn,
+			'stash',
+			'apply',
+			entry,
 		]).pipe(
 			Effect.map(() => true),
 			Effect.orElseSucceed(() => false),
 		)
-		if (wentQuietly) {
-			yield* Console.log(`✓ Deleted local branch ${branch}`)
-			return
-		}
-		if (!(yield* branchWorkIsOnMain(root, branch))) {
+		if (!applied) {
+			// Half-applied: git writes what it can and leaves the rest as conflicts,
+			// so saying the changes are merely "still saved" would describe a working
+			// tree the caller does not have. The entry is deliberately left in place.
 			return yield* Effect.fail(
 				new Error(
-					`Branch ${branch} was kept: git would not delete it, and its work is not on main either. Look at it, then delete it yourself with \`git branch -D ${branch}\` — that will also name any other reason git had.`,
+					`The stashed changes would not go back on cleanly — this working tree now holds the conflicts. They are still saved as ${entry}: sort the conflicts out, or reset and re-apply with \`git stash apply ${entry}\`.`,
 				),
 			)
 		}
-		yield* insist
-		yield* Console.log(`✓ Deleted local branch ${branch} (squashed into main)`)
+		// Dropping takes a place in the list (`stash@{n}`), never a commit, so this
+		// run's entry is looked up by the commit it was saved as: another session's
+		// entry may have arrived on top since, and dropping the top one would throw
+		// away their work.
+		const stashList = yield* execSilentArgs('git', [
+			'-C',
+			stashedIn,
+			'stash',
+			'list',
+			'--format=%H %gd',
+		])
+		const position = stashList
+			.split('\n')
+			.find(line => line.startsWith(entry))
+			?.split(' ')[1]
+		if (position !== undefined) {
+			yield* execArgs('git', ['-C', stashedIn, 'stash', 'drop', position])
+		}
+		yield* Console.log('✓ Popped stash')
 	})
 
 export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 	Effect.gen(function* () {
 		const { force, stash } = options
-		let didStash = false
+		// Where the stash came from and what it was saved as, both read while this
+		// run is still standing in the worktree — the linked-worktree path moves to
+		// the main checkout and deletes that directory, so by the end there is
+		// nobody left to ask, and the shared stash may have gained another session's
+		// entry on top.
+		let stashed: { readonly stashedIn: string; readonly entry: string } | null =
+			null
 		const clean = yield* workingTreeClean
 
 		if (!clean) {
 			if (stash) {
+				const takenFrom = resolve(
+					yield* execSilent('git', 'rev-parse', '--show-toplevel'),
+				)
 				yield* exec('git', 'stash', 'push', '-u', '-m', 'batuda-worktree-done')
-				didStash = true
+				// Read only once the push went through, so a stash that was never made
+				// leaves nothing to put back.
+				stashed = {
+					stashedIn: takenFrom,
+					entry: yield* execSilent('git', 'rev-parse', 'refs/stash'),
+				}
 				yield* Console.log('✓ Stashed uncommitted changes')
 			} else if (!force) {
 				return yield* Effect.fail(
@@ -886,58 +995,66 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 			}
 		}
 
-		const { isLinked: linked, main: mainRoot } = yield* worktreeContext
+		const finish = Effect.gen(function* () {
+			const { isLinked: linked, main: mainRoot } = yield* worktreeContext
 
-		if (linked) {
-			const branch = yield* branchName
-			const worktreePath = resolve(
-				yield* execSilent('git', 'rev-parse', '--show-toplevel'),
-			)
-			yield* Console.log(
-				`Finishing linked worktree ${worktreePath} (branch ${branch})...`,
-			)
-
-			yield* worktreeDown
-
-			// Move to the main checkout before deleting the worktree directory,
-			// otherwise subsequent git commands would run from a deleted cwd.
-			process.chdir(mainRoot)
-			const removeArgs = force
-				? ['worktree', 'remove', '--force', worktreePath]
-				: ['worktree', 'remove', worktreePath]
-			yield* execIn(mainRoot, 'git', ...removeArgs)
-			yield* Console.log('✓ Removed linked worktree directory')
-
-			yield* execIn(mainRoot, 'git', 'checkout', 'main')
-			yield* execIn(mainRoot, 'git', 'pull', '--prune')
-
-			if (yield* branchExists(branch)) {
-				yield* deleteFinishedBranch(mainRoot, branch, force)
-			}
-		} else {
-			const branch = yield* branchName
-			if (branch === 'main') {
-				return yield* Effect.fail(
-					new Error(
-						'Already on the main branch. Run this from a feature branch or linked worktree.',
-					),
+			if (linked) {
+				const branch = yield* branchName
+				const worktreePath = resolve(
+					yield* execSilent('git', 'rev-parse', '--show-toplevel'),
 				)
+				yield* Console.log(
+					`Finishing linked worktree ${worktreePath} (branch ${branch})...`,
+				)
+
+				// A worktree that never had a database is still a worktree to finish —
+				// a change to the command-line tool alone needs no stack — so nothing to
+				// drop is a note, not the end of the run.
+				if ((yield* worktreeDown) === 'nothing-provisioned') {
+					yield* Console.log(
+						'No database or bucket provisioned here — nothing to drop.',
+					)
+				}
+
+				// Move to the main checkout before deleting the worktree directory,
+				// otherwise subsequent git commands would run from a deleted cwd.
+				process.chdir(mainRoot)
+				const removeArgs = force
+					? ['worktree', 'remove', '--force', worktreePath]
+					: ['worktree', 'remove', worktreePath]
+				yield* execIn(mainRoot, 'git', ...removeArgs)
+				yield* Console.log('✓ Removed linked worktree directory')
+
+				yield* execIn(mainRoot, 'git', 'checkout', 'main')
+				yield* execIn(mainRoot, 'git', 'pull', '--prune')
+
+				if (yield* branchExists(branch)) {
+					yield* deleteFinishedBranch(mainRoot, branch, force)
+				}
+			} else {
+				const branch = yield* branchName
+				if (branch === 'main') {
+					return yield* Effect.fail(
+						new Error(
+							'Already on the main branch. Run this from a feature branch or linked worktree.',
+						),
+					)
+				}
+				yield* Console.log(`Finishing feature branch ${branch}...`)
+				yield* exec('git', 'checkout', 'main')
+				yield* exec('git', 'pull', '--prune')
+
+				if (yield* branchExists(branch)) {
+					yield* deleteFinishedBranch(mainRoot, branch, force)
+				}
 			}
-			yield* Console.log(`Finishing feature branch ${branch}...`)
-			yield* exec('git', 'checkout', 'main')
-			yield* exec('git', 'pull', '--prune')
 
-			if (yield* branchExists(branch)) {
-				yield* deleteFinishedBranch(mainRoot, branch, force)
-			}
-		}
+			yield* Console.log('✓ Done')
+		})
 
-		yield* Console.log('✓ Done')
-
-		if (didStash) {
-			yield* exec('git', 'stash', 'pop')
-			yield* Console.log('✓ Popped stash')
-		}
+		yield* stashed === null
+			? finish
+			: finish.pipe(Effect.onExit(() => restoreStashed(stashed)))
 	})
 
 // Reap dev servers left behind by crashed sessions — those whose owning CLI is


### PR DESCRIPTION
## What

`pnpm cli worktree done` is the developer command that tidies up after a merged pull request: it drops the worktree's own database and storage bucket, removes the worktree directory, brings `main` up to date, and deletes the local feature branch. It gave up part-way in ordinary situations, and in one case it could move somebody else's unfinished work into your files. This is the command-line tool (`apps/cli`) — nothing here touches the product or the server.

I found the first two by hitting them while cleaning up after PR #501 and PR #503. The rest came out of a systematic sweep of the command's use cases before committing, which is also how I learned that the fix I merged as #503 only covered half of what it claimed.

## The fix

**Touches:** the branch-deletion step, the database/bucket teardown it calls first, the `--stash` handling that wraps the whole run, and the worktree skill's description of all three. The worktree removal itself and the `--force` flag are unchanged.

- **A worktree that never had a database can now be finished.** Teardown treated "nothing to drop" as a failure, and finishing a branch yields it, so the run aborted with the directory and the branch still there. A change to the command-line tool alone needs no stack, so that is an ordinary case, not a fault. Finding nothing is now an answer the two callers read differently: asked to drop data, `worktree down` still reports it; asked to finish a branch, `worktree done` notes it and carries on.
- **A merged branch is judged by whether `main` actually carries its work.** `git branch -d` answers only "can `main` reach these commits", so it refused both rebase merges and squash merges — the two ways this repo merges — and it *accepts* a branch merged into nothing but its own remote copy, which says the work was pushed, not that it landed. The command now asks all three questions a merge can leave: `main` reaches the branch, every commit is on `main` under a new name, or the whole branch is there as one commit.
- **Stashed work always comes back, and only ever yours.** `git stash pop` takes the newest entry in the *repository*, and the stash is shared by every worktree — so with several sessions running, that entry is often somebody else's. It is now applied by the name this run saved it under, and only that entry is dropped.
- **A restore that will not apply cleanly says so.** It used to be reported as "still saved", which described a working tree the caller did not have; the changes are half-applied with conflict markers, and the suggested `git stash pop` refuses on an unmerged index.
- **A stopped Docker no longer blocks a worktree that never used it**, which was quietly defeating the first item.

## Impact

- Developer tooling only. No database migration, no new environment variable, nothing touching which organisation can see what (no row-level security or `organization_id` scoping), no change to the public/protected boundary, and nothing the frontend or the MCP surface reads.
- **This corrects PR #503, which is already merged.** That change made squash-merged branches deletable but left rebase-merged ones failing, and — by silencing the probe — hid a git warning that used to be visible when a branch was merged only into its own upstream. Both are fixed here.
- The branch guard is deliberately asymmetric: every error while answering reads as "not on main", so it keeps a branch it is unsure about and never deletes one whose work it cannot find. `--force` is unchanged and still deletes unconditionally.

## Review guide

- Read `branchWorkIsOnMain` and `deleteFinishedBranch` first — they are the part that deletes things. Then `restoreStashed`. The rest is small.
- **Most of the line count is indentation**: the body of `worktreeDone` moved inside a `finish` block so the stash restore can be a finalizer that runs on failure too. `git diff -w` shows how little actually changed there.
- **A judgement call worth checking:** I removed `git branch -d` as the first authority rather than keeping it as a pre-check. It answers a different question in both directions — too narrow for rebase and squash, too generous for upstream-only — so leaving it in front would have kept the false-success case. Our own check is now the sole authority, and it fails closed.
- **What I deliberately did not fix**, all pre-existing and each worth its own change: the database is dropped before anything else, so a failure later leaves no way to resume and no message says what already happened; `--force` means three different destructive things and its help text says none of them; ignored files (`.env`, `secrets/`) are deleted with no prompt on the path users think is safe; a bare `git pull` on `main` can write a merge commit against the repo's rebase-only rule; and the linked path has no guard against a branch called `main`. Happy to take any of these next.

## Tests

None. This repo does not unit-test CLI commands — the convention is to test the underlying services, and this is a sequence of git calls with no service beneath it. It is covered by the end-to-end runs below.

## Verification

- `pnpm check-types` (13/13), `pnpm test` (21/21), `pnpm build` (13/13), re-run after rebasing onto current `main`.
- Drove the real command through each repaired path rather than reasoning about it:
  - **Unprovisioned worktree:** finished completely — note printed, directory removed, branch deleted, clean exit. It used to abort here.
  - **Rebase-merged branch with two commits:** deleted. Under #503 this failed and told the user their merged work was not on main.
  - **Genuinely unmerged branch:** refused, branch and commit intact, with a message naming `git log main..<branch>`.
  - **`--stash` with the run failing part-way:** the changes were named with the exact entry to apply, and the main checkout was left untouched.
  - **`--stash` where the directory survives:** the work came back, file contents intact.
- Checked the four merge shapes against real repositories — reachable, rebase-replayed, squashed, and merged-only-into-upstream — confirming the new check answers each correctly where `git branch -d` does not.
- Reproduced the stash hazard directly: with a rival entry on top, a bare `git stash pop` materialised **the rival's file**, while applying by recorded id restored the right one and left the rival's entry on the stack.
