### PR TITLE
fix(server): stop recording a missing route as a crash

### DIFF
--- a/apps/mail-worker/src/lib/live-layer.integration.test.ts
+++ b/apps/mail-worker/src/lib/live-layer.integration.test.ts
@@ -1,0 +1,58 @@
+// The worker's telemetry has to be handed OUT of the layer it runs on, not just
+// used inside it. Kept inside, the worker starts up, prints that sending is on,
+// and then sends nothing at all — with no sign but silence nobody is watching.
+//
+// Nothing else catches it: both spellings compile the same, because the
+// exporter's own type is erased by the branch that turns sending off. Building
+// the layer for real and reading what comes out is the only check there is, and
+// building it for real is why this needs a database.
+
+import { applyTestEnv } from '../test-env.js'
+
+const ENDPOINT = 'OTEL_EXPORTER_OTLP_ENDPOINT'
+const previousEndpoint = process.env[ENDPOINT]
+
+applyTestEnv()
+// Assigned outright, not defaulted: switching sending on IS the test, so an
+// endpoint already in the environment must not decide the outcome. Nothing is
+// ever sent — building the layer is the whole test — so the address only has to
+// parse.
+process.env[ENDPOINT] = 'http://127.0.0.1:4318'
+
+import { type Context, Effect, Layer } from 'effect'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import { Live } from './live-layer.js'
+
+// What a built layer hands out, by name. Read from what the layer produced
+// rather than looked up as a service: a lookup falls back to the built-in
+// tracer and answers "yes" even when nothing came out — the exact failure this
+// test exists to catch.
+const handedOut = (context: Context.Context<never>): ReadonlyArray<string> =>
+	[...context.mapUnsafe.keys()].sort()
+
+describe('the layer the worker loop runs on', () => {
+	afterAll(() => {
+		if (previousEndpoint === undefined) delete process.env[ENDPOINT]
+		else process.env[ENDPOINT] = previousEndpoint
+	})
+
+	describe('when exporting is switched on', () => {
+		it('should hand out the tracer and the logger, not keep them inside', async () => {
+			// GIVEN the layer built the way the worker builds it
+			const names = handedOut(
+				await Effect.runPromise(Effect.scoped(Layer.build(Live))),
+			)
+
+			// THEN a tracer and a logger are among what came out — matched loosely,
+			// so a rename inside the library cannot quietly make this a test that
+			// proves nothing. Kept inside instead, the worker would look healthy and
+			// report nothing.
+			expect(names.some(name => /Tracer/i.test(name))).toBe(true)
+			expect(names.some(name => /Logger/i.test(name))).toBe(true)
+
+			// AND what the loop itself needs still comes out alongside it
+			expect(names).toContain('WorkerEnvVars')
+		})
+	})
+})

--- a/apps/mail-worker/src/lib/live-layer.ts
+++ b/apps/mail-worker/src/lib/live-layer.ts
@@ -1,0 +1,41 @@
+import { Layer } from 'effect'
+
+import { ParticipantMatcher } from '@batuda/email/participant-matcher'
+
+import { PgLive } from '../db.js'
+import { CredentialDecryptor } from '../decrypt.js'
+import { WorkerEnvVars } from '../env.js'
+import { OtlpObservability } from '../observability.js'
+import { RawMessageStorage } from '../storage.js'
+import { ConfigFileLive } from './config-provider.js'
+
+/**
+ * Everything the worker loop runs on.
+ *
+ * Separate from the start-up file so a test can build it without starting the
+ * worker: the telemetry line below is easy to get wrong in a way that shows up
+ * only as silence.
+ */
+export const Live = Layer.mergeAll(
+	CredentialDecryptor.layer,
+	RawMessageStorage.layer,
+	ParticipantMatcher.layer,
+).pipe(
+	// ParticipantMatcher reads contacts/companies via SqlClient, so PgLive must
+	// be PROVIDED to the merged layers — `mergeAll` alongside it leaves that
+	// requirement unsatisfied. provideMerge also hands SqlClient back out, for
+	// the inbox claim and session queries the worker loop runs.
+	Layer.provideMerge(PgLive),
+	Layer.provideMerge(WorkerEnvVars.layer),
+	// Merged, not only provided: the exporter installs itself by putting a logger
+	// and a tracer into what this layer HANDS BACK, which is what the worker loop
+	// runs on. Provided alone it would reach the layers built here and nothing
+	// else — a worker that boots, says sending is on, and sends nothing. Sits
+	// above ConfigFileLive so the export settings are readable by the time it is
+	// built.
+	Layer.provideMerge(OtlpObservability),
+	// Install the baked-file config values before the readers above resolve, so
+	// the env-var layer and the database client can read non-secret settings
+	// that no longer travel on the boot command line.
+	Layer.provide(ConfigFileLive),
+)

--- a/apps/mail-worker/src/main.ts
+++ b/apps/mail-worker/src/main.ts
@@ -1,18 +1,13 @@
 import { NodeRuntime } from '@effect/platform-node'
-import { DateTime, Effect, type Fiber, Layer, Ref, Schedule } from 'effect'
+import { DateTime, Effect, type Fiber, Ref, Schedule } from 'effect'
 
-import { ParticipantMatcher } from '@batuda/email/participant-matcher'
 import { boundedCause } from '@batuda/observability'
 
 import { type ClaimedInbox, claimAvailableInboxes } from './claim.js'
 import { installCrashGuards } from './crash-guards.js'
-import { PgLive } from './db.js'
-import { CredentialDecryptor } from './decrypt.js'
 import { WorkerEnvVars } from './env.js'
 import { runInboxSession } from './inbox-session.js'
-import { ConfigFileLive } from './lib/config-provider.js'
-import { OtlpObservability } from './observability.js'
-import { RawMessageStorage } from './storage.js'
+import { Live } from './lib/live-layer.js'
 
 // Top-level program: scan for unclaimed inboxes on a tick, fork a
 // session fiber per newly-claimed inbox, and let session fibers retry
@@ -106,36 +101,6 @@ const program = Effect.gen(function* () {
 	// shutdown sequence, which interrupts everything cleanly.
 	yield* Effect.never
 })
-
-const Live = Layer.mergeAll(
-	CredentialDecryptor.layer,
-	RawMessageStorage.layer,
-	ParticipantMatcher.layer,
-).pipe(
-	// ParticipantMatcher reads contacts/companies via SqlClient, so PgLive must
-	// be PROVIDED to the merged layers — `mergeAll` alongside it leaves that
-	// requirement unsatisfied. provideMerge also re-exposes SqlClient for the
-	// inbox claim/session queries run by `program`.
-	Layer.provideMerge(PgLive),
-	Layer.provideMerge(WorkerEnvVars.layer),
-	// Export traces, logs, and metrics to the batuda-mail-worker Honeycomb
-	// dataset when OTEL_EXPORTER_OTLP_ENDPOINT is set. Without this the worker's
-	// IMAP disconnects, credential failures, and session-fiber deaths die in the
-	// console ring-buffer. Sits above ConfigFileLive so it can read NODE_ENV +
-	// the OTEL_* settings; merges with the default console logger, not replacing it.
-	//
-	// Merged rather than only provided: the exporter installs itself by putting a
-	// logger and a tracer into the context it is built into, and `program` below
-	// runs on what this layer HANDS BACK. Provided alone it reaches the layers
-	// built here and nothing else, which leaves a worker that boots, says export
-	// is enabled, and sends nothing — every line it writes goes to the console
-	// logger it still has.
-	Layer.provideMerge(OtlpObservability),
-	// Install the baked-file config values before the readers above resolve, so
-	// the env-var layer and the database client can read non-secret settings
-	// that no longer travel on the boot command line.
-	Layer.provide(ConfigFileLive),
-)
 
 // Turn on the crash safety net before the worker starts: a rare low-level error
 // (e.g. a dropped email connection) must be logged and the worker auto-restarted,

--- a/apps/mail-worker/src/observability.ts
+++ b/apps/mail-worker/src/observability.ts
@@ -5,9 +5,9 @@ import { makeOtlpObservability } from '@batuda/observability'
  * metrics to the `batuda-mail-worker` Honeycomb dataset when
  * OTEL_EXPORTER_OTLP_ENDPOINT is set; otherwise a no-op (local dev).
  *
- * Whoever builds this in has to MERGE it, not only provide it — see the note at
- * the use site in `main.ts`. The worker ran for months provided-only: booting,
- * announcing that export was enabled, and sending nothing.
+ * Whoever builds this in has to MERGE it, not only provide it: provided alone,
+ * the process keeps its own logger and tracer, announces that export is enabled,
+ * and sends nothing.
  */
 export const OtlpObservability = makeOtlpObservability({
 	serviceName: 'batuda-mail-worker',

--- a/apps/mail-worker/src/test-env.ts
+++ b/apps/mail-worker/src/test-env.ts
@@ -1,0 +1,22 @@
+// Shared start-up settings for the mail worker's integration tests. The worker
+// reads every one of these before it gets anywhere and none carry a default, so
+// a suite that sets only some stops on the first one missing — with an error
+// about that setting rather than about what it was testing. `??=` so CI or a
+// caller can own any single value outright.
+
+export const TEST_ENV: Record<string, string> = {
+	NODE_ENV: 'test',
+	MIN_LOG_LEVEL: 'Info',
+	DATABASE_URL: 'postgresql://batuda:batuda@localhost:5433/batuda',
+	STORAGE_ENDPOINT: 'http://localhost:9000',
+	STORAGE_REGION: 'auto',
+	STORAGE_ACCESS_KEY_ID: 'batuda',
+	STORAGE_SECRET_ACCESS_KEY: 'batuda-secret',
+	STORAGE_BUCKET: 'batuda-assets',
+	EMAIL_CREDENTIAL_KEY: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+}
+
+export const applyTestEnv = (): void => {
+	for (const [key, value] of Object.entries(TEST_ENV))
+		process.env[key] ??= value
+}

--- a/apps/server/src/lib/observability-middleware.test.ts
+++ b/apps/server/src/lib/observability-middleware.test.ts
@@ -1,5 +1,5 @@
 import { Cause, Effect, Layer, Logger, References } from 'effect'
-import { HttpServerRequest } from 'effect/unstable/http'
+import { HttpServerError, HttpServerRequest } from 'effect/unstable/http'
 import { describe, expect, it } from 'vitest'
 
 import { boundedCause, recordFacts } from '@batuda/observability'
@@ -215,7 +215,7 @@ describe('withRequestRecord', () => {
 			const { lines } = await runRequest(
 				recordFacts({ 'org.id': 'org_1' }).pipe(
 					Effect.andThen(Effect.die(new Error('boom'))),
-				) as Effect.Effect<{ readonly status: number }, never, never>,
+				),
 			)
 
 			// WHEN the defect escapes
@@ -236,17 +236,91 @@ describe('withRequestRecord', () => {
 	describe('when the client disconnects', () => {
 		it('should not log an error, because that is not a failure', async () => {
 			// GIVEN a request interrupted part-way, as a closed tab does
-			const { lines } = await runRequest(
-				Effect.interrupt as Effect.Effect<
-					{ readonly status: number },
-					never,
-					never
-				>,
-			)
+			const { lines } = await runRequest(Effect.interrupt)
 
 			// THEN nothing is logged at error level — an interrupt tripping error
 			// alerts would make every closed tab look like an outage
 			expect(lines.filter(line => line.level === 'Error')).toHaveLength(0)
+		})
+	})
+
+	// A route that does not exist is the caller's mistake, not ours. Recorded as a
+	// crash, every bot probing for /robots.txt leaves an error-level stack trace,
+	// and anything real is buried underneath the crawlers.
+	describe('when the router finds no match', () => {
+		it('should record it as a completed request, not a crash', async () => {
+			// GIVEN a request the router cannot match
+			const { lines } = await runRequest(
+				Effect.fail(
+					new HttpServerError.HttpServerError({
+						reason: new HttpServerError.RouteNotFound({
+							request: {} as never,
+						}),
+					}),
+				),
+			)
+
+			// THEN it leaves an ordinary record carrying a 404, at info
+			const line = lines.find(
+				entry => entry.annotations['event'] === 'http.not_found',
+			)
+			expect(line).toBeDefined()
+			expect(line?.annotations['http.status']).toBe(404)
+			expect(line?.annotations['http.path_pattern']).toBe('/v1/companies')
+			expect(line?.level).toBe('Info')
+
+			// AND nothing is logged as an error or named a crash
+			expect(lines.filter(entry => entry.level === 'Error')).toHaveLength(0)
+			expect(
+				lines.filter(entry => entry.annotations['event'] === 'http.defect'),
+			).toHaveLength(0)
+		})
+	})
+
+	describe('when something crashed alongside the missing route', () => {
+		it('should record the crash rather than write it off as a 404', async () => {
+			// GIVEN a request that failed for a missing route AND crashed — a
+			// finalizer or a forked child dying while the request was failing
+			const { lines } = await runRequest(
+				Effect.failCause(
+					Cause.combine(
+						Cause.fail(
+							new HttpServerError.HttpServerError({
+								reason: new HttpServerError.RouteNotFound({
+									request: {} as never,
+								}),
+							}),
+						),
+						Cause.die(new Error('boom')),
+					),
+				),
+			)
+
+			// THEN it is recorded as the crash it also was — called a 404, the crash
+			// would leave no line at all
+			const defect = lines.find(
+				entry => entry.annotations['event'] === 'http.defect',
+			)
+			expect(defect).toBeDefined()
+			expect(defect?.level).toBe('Error')
+			expect(
+				lines.filter(entry => entry.annotations['event'] === 'http.not_found'),
+			).toHaveLength(0)
+		})
+	})
+
+	describe('when the request dies for any other reason', () => {
+		it('should still record it as a crash', async () => {
+			// GIVEN a genuine defect rather than a missing route
+			const { lines } = await runRequest(Effect.die(new Error('boom')))
+
+			// THEN it keeps the crash treatment — only a missing route is quieted,
+			// never a real failure
+			const defect = lines.find(
+				entry => entry.annotations['event'] === 'http.defect',
+			)
+			expect(defect).toBeDefined()
+			expect(defect?.level).toBe('Error')
 		})
 	})
 })

--- a/apps/server/src/lib/observability-middleware.ts
+++ b/apps/server/src/lib/observability-middleware.ts
@@ -1,7 +1,8 @@
-import { Cause, Effect } from 'effect'
+import { Cause, Effect, Option } from 'effect'
 import {
 	HttpMiddleware,
 	HttpRouter,
+	HttpServerError,
 	HttpServerRequest,
 } from 'effect/unstable/http'
 
@@ -31,6 +32,25 @@ const isRoutinePoll = (
 	status: number,
 ): boolean =>
 	status < 400 && (pathPattern === '/health' || method === 'OPTIONS')
+
+/**
+ * A request for an address the server does not have — the caller's mistake, not
+ * the server going wrong. Recorded as a crash, every bot probing for
+ * `/robots.txt` leaves an error-level stack trace and buries the failures that
+ * matter.
+ */
+const isMissingRoute = (cause: Cause.Cause<unknown>): boolean => {
+	// A request can miss its route AND crash at the same time — a cleanup step or
+	// a forked child dying alongside it. Only the missing route is looked at
+	// below, so calling that pair an ordinary 404 would throw the crash away.
+	if (Cause.hasDies(cause)) return false
+	const error = Cause.findErrorOption(cause)
+	return (
+		Option.isSome(error) &&
+		HttpServerError.isHttpServerError(error.value) &&
+		error.value.reason._tag === 'RouteNotFound'
+	)
+}
 
 export const httpPathPattern = (url: string): string => {
 	const path = url.split('?')[0]?.split('#')[0] ?? url
@@ -120,19 +140,29 @@ export const withRequestRecord = <A extends { readonly status: number }, E, R>(
 			Effect.tapCause(cause =>
 				Cause.hasInterruptsOnly(cause)
 					? Effect.void
-					: Effect.flatMap(record.read, facts =>
-							Effect.logError(boundedCause(cause)).pipe(
+					: Effect.flatMap(record.read, facts => {
+							// A missing route is the caller's mistake and stays at info,
+							// where a rise in them still shows a scan; anything else crashed
+							// and keeps the full cause at error level. Either way this is the
+							// only line the request leaves, since neither ever becomes a
+							// response and the completion log above never runs.
+							const missing = isMissingRoute(cause)
+							return (
+								missing
+									? Effect.logInfo('HTTP route not found')
+									: Effect.logError(boundedCause(cause))
+							).pipe(
 								Effect.annotateLogs({
 									...facts,
-									// A defect never becomes a response, so the completion log
-									// above never runs and THIS is the only line the request
-									// leaves. Name it so a request that failed this hard is
-									// still findable by event, like every other one.
-									event: 'http.defect',
+									event: missing ? 'http.not_found' : 'http.defect',
+									// Written by hand: the 404 is answered further out and never
+									// passes back through here. Only the missing route carries
+									// one, so it cannot land on a crash.
+									...(missing ? { 'http.status': 404 } : {}),
 									...context,
 								}),
-							),
-						),
+							)
+						}),
 			),
 			// Inside the request, so `recordFacts` anywhere below finds this
 			// request's record. Work forked off the request outlives this scope

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -10,7 +10,7 @@ This guide holds the **rules and the reasons**. It deliberately does not mirror 
 
 The unit of observability is **one wide record per piece of work** — carrying every fact known about it on a single line.
 
-Two kinds of work open a record today: an **HTTP request**, closed by `http.request` / `http.server_error` / `http.defect`, and a **research run**, closed by `research.run` with what it spent split by model, provider and kind of work. A run is not part of any request — it keeps working on a forked fiber long after the request that asked for it returned — so it opens a record of its own rather than borrowing one.
+Two kinds of work open a record today: an **HTTP request**, closed by `http.request` / `http.server_error` / `http.defect` / `http.not_found`, and a **research run**, closed by `research.run` with what it spent split by model, provider and kind of work. A run is not part of any request — it keeps working on a forked fiber long after the request that asked for it returned — so it opens a record of its own rather than borrowing one.
 
 Everything else is a view over those records:
 
@@ -45,6 +45,7 @@ Timestamps and trace ids are added by the framework.
 | `http.request`                 | A request completed                                        |
 | `http.server_error`            | A request ended 5xx                                        |
 | `http.defect`                  | A request died without producing a response                |
+| `http.not_found`               | A request asked for a route that does not exist            |
 | `company.created`              | New company added to CRM                                   |
 | `company.status_changed`       | Pipeline status transition                                 |
 | `interaction.logged`           | Interaction recorded                                       |
@@ -62,7 +63,7 @@ Timestamps and trace ids are added by the framework.
 | `mcp.auth.rejected`            | An MCP call was refused, and why                           |
 | `mcp.protocol_version.refused` | A call named a protocol revision this server does not know |
 
-A request leaves exactly one of `http.request`, `http.server_error` or `http.defect`, so "every request that ended badly" is those last two.
+A request leaves exactly one of `http.request`, `http.server_error`, `http.defect` or `http.not_found`. "Every request that ended badly" is the middle two: a route that does not exist is the caller's mistake rather than a fault of ours, and it is kept out of the error channel on purpose — recorded as a crash, every bot probing for `/robots.txt` leaves a stack trace at error level and buries the failures that matter.
 
 A request also leaves exactly **one span**, not two. The platform opens that span itself, so the server passes no tracer of its own when it starts serving; passing one as well used to open a second span per request, and every count taken from the traces read double until 2026-08-18. A trace older than that carries the twins.
 
@@ -291,6 +292,10 @@ Three structural notes worth knowing before changing any of it:
 **Better Auth's errors need a bridge to be seen at all.** Better Auth runs its callbacks outside the Effect fiber, so its internal failures — adapter errors, OAuth/OIDC problems — reach the console and nothing else. They are forwarded onto the Effect runtime deliberately; without that they never export, and an auth outage looks like silence rather than errors.
 
 **Two auth surfaces are instrumented on purpose, not by blanket rule.** The MCP sign-in path and the OAuth token endpoint each carry extra facts because of one bug class: an MCP client shows a refused or expired credential as a silent retry loop, never a visible error. So how the caller signed in, which org they resolved to, and the grant outcome are recorded — enough to tell a dropped connection from a rejected one without reproducing it. Facts elsewhere are added where a question actually needs them, not across every endpoint.
+
+**Telemetry has to be handed out of a layer, not just used inside it.** A layer can pass a service down to the layers it builds, or hand it back to whoever builds on top; those are two different things and they look the same to the compiler. The mail worker's loop is handed its layer from outside, so telemetry passed only downward reached the layers named in the stack and never the loop that writes every line. The worker started up, said exporting was enabled, and sent nothing — for months. Its dataset was never created, so the only sign was a gap nobody was watching.
+
+Nothing catches this on its own. The exporter's own type is erased by the branch that turns exporting off, so both spellings typecheck identically, and the process looks healthy either way. The guard is the mail worker's layer test, which builds the real layer and checks a logger and a tracer are among what comes out. It needs a database, because building the real layer means building all of it — so it lives in the integration suite and does not run under `pnpm test`.
 
 **Global middleware order has to be stated, not assumed.** Router-wide middleware wraps a request in reverse registration order, and registration order is layer build order — which `Layer.mergeAll` performs concurrently. Left in a merge list, the observability middleware lands wherever the build happens to put it, and that position can change without anyone editing it.
 


### PR DESCRIPTION
## What

Right now, every single error the server reports in production is a bot. Not most — all of them. Crawlers ask for pages that don't exist (`/robots.txt`, `/.git/config`, WordPress paths), and each one gets written down as if the server crashed: an error-level line with a full stack trace. Anything that actually breaks sits underneath that pile.

This makes a request for a page that doesn't exist get written down as what it is — a finished request that answered 404. It lives in `server`, in the catch-all step every request passes through.

It also adds the guard we didn't have for the mail worker, which sent nothing for months without anyone noticing.

## Changes

**Touches:** the catch-all step every request passes through, plus the block that sets the mail worker up and the list of settings its tests need — the worker's behaviour itself is untouched, since that fix already shipped.

- A request for a page that doesn't exist is recorded as a finished request carrying a 404, not as a crash. A request that dies any other way keeps the crash treatment, so real failures aren't quieted along with the bots.
- A crash sitting *beside* a missing page is still recorded as a crash. A single failure can carry more than one thing — a cleanup step or a background job dying while the request fails — and treating that as an ordinary 404 would have thrown the crash away entirely.
- The mail worker's set-up block moved into its own file so a test can build it and check the telemetry really comes out the other side. Nothing about how it runs changed.
- The settings the worker reads at start-up are now one shared list, in the same shape the server already uses.

## Impact

- **What "error" means in production changes, deliberately.** Today bots make up every error the server reports. After this they stop, so the error channel finally shows things worth looking at. If you have anything watching the error count, expect it to drop to roughly nothing — that is the fix working, not a signal going dark.
- **A new name to search by.** Requests for pages that don't exist come back under `http.not_found`. They were previously mixed in with genuine crashes under `http.defect`, so a search for crashes gets much quieter and a search for missing pages becomes possible.
- **Both ways in are covered.** The change is in the step every request passes through, so it applies to browser and API traffic and to the way an AI client talks to the CRM alike.
- **The mail worker is unchanged.** Its fix is already live and reporting — its data started arriving a couple of hours ago. This only stops the fault coming back unnoticed.
- **Nothing else moves.** No database change, no migration, no new settings for production to set, no change to who can see what, no change to what anything costs, and nothing the frontend consumes.

## Review guide

- **Start here:** `apps/server/src/lib/observability-middleware.ts` — the whole change is one branch and the small check above it.
- **Riskiest part:** that check. It decides whether something counts as a missing page or a crash, and getting it wrong in the generous direction means a real crash is silently downgraded and never recorded. That is why it refuses to call anything a missing page if the failure also carried a crash. If you read one thing, read that.
- **A decision you might overrule:** the not-found line records a 404 that this step never actually sees — the answer is rendered above it. I kept it because dropping it would leave a request with no status at all, and the branch is scoped to the one reason that always renders 404. The assumption is written at the line rather than left implied.
- **Mostly mechanical, skim it:** the mail-worker files. The set-up block moved verbatim; the only new thinking is the test.
- **Worth knowing before you touch the worker test:** a layer build is remembered for the rest of the process, so the setting that switches sending on has to be in place before the first build. My first attempt built the layer twice to compare on against off and got identical results, because the second build reused the first.
- **A known gap:** the worker test covers sending switched on, not switched off. The off path is the local-dev one, and covering it needs a second file — the same memory of the first build makes both cases impossible to exercise in one.
- I did not run Snyk; the tool wasn't available in this session.

## Tests

- A request for a page that doesn't exist records as a finished 404 at info, with no error line and nothing named a crash.
- A crash beside a missing page still records as a crash — the case the check exists for.
- A request that dies any other way still records as a crash.
- The mail worker's set-up hands out a logger and a tracer. This one needs a database, so it lives in the integration suite and does not run under `pnpm test`.

Every one of these was confirmed by deliberately breaking the code and watching the right test fail: forcing everything to count as a crash fails 1, forcing everything to count as a missing page fails 2, removing the crash-beside-404 guard fails 1, and putting the worker's telemetry fault back fails the worker test.

## Verification

- Gates: `pnpm install` (no lockfile drift), `pnpm -w check-types` 13/13, `pnpm -w test` 21/21, `pnpm -w build` 13/13, plus the mail worker's integration suite 27/27.
- Against a running server: asked for `/robots.txt`, `/` and `/.git/config` — all recorded as `http.not_found` at info with **zero error-level lines**, where the same three record as crashes in production today.
- Sent a browser permission check for a page that doesn't exist: it never reaches this path at all, because the cross-origin step answers it first. I had originally added a rule to quiet those, then found it could never run — the quiet rule only applies below 400 and this path is always a 404 — so the rule is gone rather than left as code that reads as if it does something.
- Read production telemetry directly to confirm the premise: every error on the live release is one of three bot paths, and the mail worker's data began arriving after its own fix shipped.

## Deferred

- Nothing here. The two things this branch set out to do are done, and the mail-worker half turned out to be already fixed on `main` while I was working — only its guard survived.
