### PR TITLE
fix(cli): settle refusals before removing, and make teardown repeatable

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -691,14 +691,14 @@ const worktreeUpCommand = Command.make('up', {}, () => worktreeUp).pipe(
 	),
 )
 
-// Whoever asks to drop this worktree's data expects data to be there, so
-// finding none is worth reporting. `worktree done` reads the same answer as a
-// note and carries on.
+// Finding nothing to drop is the state this command exists to produce, so it is
+// reported and not failed over — running it twice, or on a worktree that never
+// had a database, leaves the same nothing behind either way.
 const worktreeDownCommand = Command.make('down', {}, () =>
 	worktreeDown.pipe(
 		Effect.flatMap(outcome =>
 			outcome === 'nothing-provisioned'
-				? Effect.fail(new Error(NOTHING_TO_DROP))
+				? Console.log(NOTHING_TO_DROP)
 				: Effect.void,
 		),
 	),
@@ -715,7 +715,7 @@ const worktreeDoneCommand = Command.make(
 	{
 		force: Flag.boolean('force').pipe(
 			Flag.withDescription(
-				'Ignore a dirty working tree and force branch/worktree removal',
+				'Push past every refusal: discard uncommitted changes (in a linked worktree they are deleted with the directory), and delete the branch even when main carries no copy of its work',
 			),
 			Flag.withDefault(false),
 		),

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -806,9 +806,18 @@ export const worktreeDown = Effect.gen(function* () {
 	return 'removed' as const
 })
 
-/** The wording `worktree down` fails with when it finds nothing to drop. */
+/**
+ * What `worktree down` says when it finds nothing to drop.
+ *
+ * Said rather than failed over, because the state it was asked for — no
+ * database and no bucket for this worktree — is the state it found. Teardown
+ * here is idempotent the same way the rest of it is: databases go with `DROP
+ * DATABASE IF EXISTS`, and the hook that tears a worktree down on removal
+ * always exits happy. A second `down`, or one on a worktree that never had
+ * anything, is worth a word and not an error.
+ */
 export const NOTHING_TO_DROP =
-	'No provisioned .env here — nothing to drop. Run `pnpm cli worktree up` first, or it was already torn down.'
+	'Nothing to drop — this worktree has no database or bucket of its own. Either `pnpm cli worktree up` never ran here, or it has already been torn down.'
 
 /**
  * Whether everything this branch changed is already on main.
@@ -871,26 +880,99 @@ const branchWorkIsOnMain = (root: string, branch: string) =>
 		return (yield* git('cherry', 'main', rolledUp)).startsWith('-')
 	}).pipe(Effect.orElseSucceed(() => false))
 
-/**
- * Delete the branch the finished pull request was on.
- *
- * Whether the work is safe is decided by `branchWorkIsOnMain`, which asks more
- * than `git branch -d` does — see there for why. A branch holding work main has
- * never seen is left standing and named, because deleting it is the one step
- * here nobody can undo.
- */
-const deleteFinishedBranch = (root: string, branch: string, force: boolean) =>
-	Effect.gen(function* () {
-		if (!force && !(yield* branchWorkIsOnMain(root, branch))) {
-			return yield* Effect.fail(
+// Bring main up to date, and only ever by fast-forward.
+//
+// A plain `git pull` writes a merge commit when local main has wandered off
+// from the remote, which is exactly what this repository does not want in its
+// history — and it would do it silently, in the middle of a cleanup nobody
+// asked to change main. Stopping instead leaves the two copies of main for
+// somebody to look at, which is the only way it gets noticed at all.
+const pullMain = (root: string) =>
+	execArgs('git', ['-C', root, 'pull', '--ff-only', '--prune']).pipe(
+		// git has already printed why it could not; what it cannot say is that this
+		// stopped before anything was removed, and where to look.
+		Effect.catch(() =>
+			Effect.fail(
 				new Error(
-					`Branch ${branch} was kept: main carries no copy of its work, in any of the shapes a merge leaves. Look at it with \`git log main..${branch}\`, then delete it yourself with \`git branch -D ${branch}\` if you are happy to lose it.`,
+					'main could not be brought up to date by fast-forward, so nothing has been removed. Local main has most likely wandered off from the remote — compare them with `git log --oneline origin/main..main` and sort that out first.',
 				),
-			)
-		}
+			),
+		),
+	)
+
+/**
+ * Refuse unless main carries a copy of this branch's work.
+ *
+ * Asked before anything is dropped or deleted, so a branch that has to be kept
+ * costs the caller nothing: the worktree, its database and its directory are
+ * all still there to go back to. Deleting a branch is the one step here nobody
+ * can undo, and `branchWorkIsOnMain` is what decides whether main already has
+ * what would be lost.
+ */
+const refuseUnlessWorkIsOnMain = (
+	root: string,
+	branch: string,
+	force: boolean,
+) =>
+	Effect.gen(function* () {
+		if (force || (yield* branchWorkIsOnMain(root, branch))) return
+		return yield* Effect.fail(
+			new Error(
+				`Branch ${branch} holds work main carries no copy of, in any of the shapes a merge leaves. Nothing has been removed. Look at it with \`git log main..${branch}\`, then run again with --force if you are happy to lose it.`,
+			),
+		)
+	})
+
+/**
+ * Delete the branch. Nothing is weighed up here — `refuseUnlessWorkIsOnMain`
+ * has already decided, early enough that a refusal costs nothing.
+ */
+const deleteBranch = (root: string, branch: string) =>
+	Effect.gen(function* () {
 		yield* execArgs('git', ['-C', root, 'branch', '-D', branch])
 		yield* Console.log(`✓ Deleted local branch ${branch}`)
 	})
+
+// The ignored things that come back on their own: build output, and the `.env`
+// `worktree up` writes again. Losing those with the directory costs nobody
+// anything, so they are the ones not worth naming. Matched anywhere in a path,
+// since build output sits at every level of the tree.
+const GENERATED_DIRS: ReadonlyArray<string> = [
+	'node_modules/',
+	'dist/',
+	'.turbo/',
+	'.wrangler/',
+	'.vite/',
+	'coverage/',
+]
+
+// The env file provisioning writes, which `worktree up` makes again. Matched
+// whole: a `.env.cloud` or `.env.local` sitting beside it was written by hand
+// and nothing brings it back, so it still gets named.
+const isProvisionedEnv = (path: string): boolean =>
+	path === '.env' || path.endsWith('/.env')
+
+const handPlacedFiles = (worktreePath: string) =>
+	execSilentArgs('git', [
+		'-C',
+		worktreePath,
+		'status',
+		'--porcelain',
+		'--ignored',
+	]).pipe(
+		Effect.map(out =>
+			out
+				.split('\n')
+				.filter(line => line.startsWith('!! '))
+				.map(line => line.slice(3))
+				.filter(
+					path =>
+						!isProvisionedEnv(path) &&
+						!GENERATED_DIRS.some(known => path.includes(known)),
+				),
+		),
+		Effect.orElseSucceed((): ReadonlyArray<string> => []),
+	)
 
 /**
  * Put back what `--stash` set aside, whether the rest of the run succeeded or
@@ -1000,12 +1082,46 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 
 			if (linked) {
 				const branch = yield* branchName
+				// Take main back and bring it up to date. Git keeps a branch in one
+				// working tree at a time, so when this worktree is the one holding
+				// main, this can only happen once the directory is gone.
+				const catchMainUp = Effect.gen(function* () {
+					yield* execIn(mainRoot, 'git', 'checkout', 'main')
+					yield* pullMain(mainRoot)
+				})
 				const worktreePath = resolve(
 					yield* execSilent('git', 'rev-parse', '--show-toplevel'),
 				)
 				yield* Console.log(
 					`Finishing linked worktree ${worktreePath} (branch ${branch})...`,
 				)
+
+				// A worktree left sitting on main names no branch of its own to finish,
+				// which is what a merge that deletes the branch leaves behind. Its data
+				// and directory still go, and main itself is brought up to date further
+				// down, once this worktree has let go of it.
+				const ownBranch = branch === 'main' ? null : branch
+				if (ownBranch === null) {
+					yield* Console.log(
+						'This worktree is on main, so there is no branch of its own to delete.',
+					)
+				} else {
+					// Done before anything is judged or removed: what counts as
+					// "already on main" depends on it, and a pull that cannot happen —
+					// no network, a main that has wandered off — is a reason to stop
+					// while there is still a worktree to come back to.
+					yield* catchMainUp
+					if (yield* branchExists(ownBranch)) {
+						yield* refuseUnlessWorkIsOnMain(mainRoot, ownBranch, force)
+					}
+				}
+
+				const handPlaced = yield* handPlacedFiles(worktreePath)
+				if (handPlaced.length > 0) {
+					yield* Console.log(
+						`These go when the directory does: ${handPlaced.slice(0, 5).join(', ')}${handPlaced.length > 5 ? `, and ${handPlaced.length - 5} more` : ''}.`,
+					)
+				}
 
 				// A worktree that never had a database is still a worktree to finish —
 				// a change to the command-line tool alone needs no stack — so nothing to
@@ -1019,17 +1135,24 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 				// Move to the main checkout before deleting the worktree directory,
 				// otherwise subsequent git commands would run from a deleted cwd.
 				process.chdir(mainRoot)
-				const removeArgs = force
-					? ['worktree', 'remove', '--force', worktreePath]
-					: ['worktree', 'remove', worktreePath]
-				yield* execIn(mainRoot, 'git', ...removeArgs)
+				yield* execArgs('git', [
+					'-C',
+					mainRoot,
+					'worktree',
+					'remove',
+					...(force ? ['--force'] : []),
+					worktreePath,
+				])
 				yield* Console.log('✓ Removed linked worktree directory')
 
-				yield* execIn(mainRoot, 'git', 'checkout', 'main')
-				yield* execIn(mainRoot, 'git', 'pull', '--prune')
-
-				if (yield* branchExists(branch)) {
-					yield* deleteFinishedBranch(mainRoot, branch, force)
+				if (ownBranch === null) {
+					// Bring main up to date, which had to wait: git keeps a branch in one
+					// working tree at a time, so the main checkout could not take main
+					// back while this worktree still held it.
+					yield* execIn(mainRoot, 'git', 'checkout', 'main')
+					yield* pullMain(mainRoot)
+				} else if (yield* branchExists(ownBranch)) {
+					yield* deleteBranch(mainRoot, ownBranch)
 				}
 			} else {
 				const branch = yield* branchName
@@ -1042,10 +1165,11 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 				}
 				yield* Console.log(`Finishing feature branch ${branch}...`)
 				yield* exec('git', 'checkout', 'main')
-				yield* exec('git', 'pull', '--prune')
+				yield* pullMain(mainRoot)
 
 				if (yield* branchExists(branch)) {
-					yield* deleteFinishedBranch(mainRoot, branch, force)
+					yield* refuseUnlessWorkIsOnMain(mainRoot, branch, force)
+					yield* deleteBranch(mainRoot, branch)
 				}
 			}
 


### PR DESCRIPTION
## What

`pnpm cli worktree done` tidies up after a merged pull request: it drops the worktree's own database and storage bucket, removes the worktree directory, brings `main` up to date, and deletes the local branch. Every one of those is destructive, and the order they happened in meant a refusal at the last step arrived after the first two had already gone — leaving a half-destroyed worktree, no way to re-run, and nothing saying what had happened. This is the developer command-line tool (`apps/cli`); nothing here touches the product or the server.

These are the problems a systematic sweep of the command turned up while I was fixing something else. None was introduced recently; they have all been there for a while, and each one either destroys something before it has decided it should, or stays quiet about something a person would want to know.

## The fix

**Touches:** the order of steps in `worktree done`, the pull that updates `main`, the branch-safety decision, what teardown reports when it finds nothing, and the `--force` description. The database and bucket teardown itself, the branch-safety rule, and the `--stash` handling are unchanged.

- **Nothing is destroyed until every refusal has had its say.** Bringing `main` up to date and deciding whether `main` carries the branch's work both happen first, so a branch that has to be kept costs nothing — the worktree, its data and its directory are all still there. The old order dropped the database and deleted the directory first, then refused. The decision and the act are now separate: one function refuses, another deletes.
- **`main` is only ever fast-forwarded.** A plain `git pull` writes a merge commit when the local copy has wandered off from the remote — silently, during a cleanup nobody asked to change `main`, and against this repo's rebase-only rule. It now stops and points at `git log --oneline origin/main..main`.
- **Ignored files nothing brings back are named before the directory goes** — a `secrets/` folder, a stray log, a hand-written `.env.cloud`. Build output and the `.env` that provisioning writes are left out, so an ordinary worktree prints nothing at all.
- **A worktree sitting on `main` no longer tries to delete `main`.** That is what a merge which deletes the branch leaves behind. The worktree and its data still go, and `main` is taken back and brought up to date once the worktree has let go of it — git keeps a branch in one working tree at a time, so it has to be that way round.
- **Finding nothing to drop is reported, not failed over.** Running `worktree down` twice, or on a worktree that never had a database, leaves the same nothing behind either way; failing broke anything chaining off it. The refusals that guard the shared database still fail.
- **`--force` says what it does**: discard uncommitted changes (in a linked worktree they go with the directory), and delete the branch even when `main` carries no copy of its work.

## Impact

- Developer tooling only. No database migration, no new environment variable, nothing touching which organisation can see what (no row-level security or `organization_id` scoping), no change to the public/protected boundary, and nothing the frontend or the MCP surface reads.
- **One behaviour change worth naming:** `worktree down` now exits 0 where it used to exit non-zero, in the single case where it finds nothing to drop. That matches the teardown hook doing the same job, which already drops with `DROP DATABASE IF EXISTS` and always exits happy.
- The command still refuses in every case it refused before. What changed is *when* it refuses, not *whether*.

## Review guide

- Read the linked-worktree branch of `worktreeDone` first — the order of the steps is the fix, and each position was checked against a real repository rather than reasoned about.
- **The subtlety worth your eye:** `main` is brought up to date in two different places. When the worktree has a branch of its own, it happens first, because deciding whether the work is on `main` depends on it. When the worktree *is* the one holding `main`, it can only happen after the directory is gone. Both go through one named step so they read as one idea.
- `handPlacedFiles` decides what counts as worth mentioning. The list of generated paths is a judgement call — if a build directory is missing from it, an ordinary worktree will name files nobody cares about.
- **Not fixed, still open:** `git stash pop` is no longer used, but `git checkout main` in the main checkout is still never checked for a dirty tree — `worktree done` only ever inspects the worktree you are standing in. Worth its own look.

## Tests

None. This repo does not unit-test CLI commands — the convention is to test the underlying services, and this is a sequence of git calls with no service beneath it. It is covered by the end-to-end runs below.

## Verification

- `pnpm check-types` (13/13), `pnpm test` (21/21), `pnpm build` (13/13).
- Drove the real command through every repaired case:
  - **Refusal:** a branch with unmerged work — the worktree directory, its data, the branch and a hand-placed file were all still there afterwards. Under the old order the first two would have been gone.
  - **Diverged `main`** (one commit ahead and one behind): stopped at the pull, said nothing had been removed, wrote no merge commit, and left the worktree standing.
  - **Hand-placed files:** `secrets/` and `cloud-audit.log` named, `node_modules` and the provisioned `.env` correctly not named. A hand-written `.env.cloud` is named too — it was silently excluded until I fixed the match to whole names.
  - **Worktree holding `main`:** removed, `main` kept, taken back and up to date afterwards.
  - **`worktree down` twice:** exit 0 both times, and `down && …` keeps going. From the main checkout it still refuses, and the shared `batuda` database was confirmed untouched.
- Restored the repository after each test that moved `main` — checked back to `origin/main`, clean tree, no leftover branches or worktrees.
