### PR TITLE
fix(cli): leave the main checkout where somebody left it

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -715,7 +715,7 @@ const worktreeDoneCommand = Command.make(
 	{
 		force: Flag.boolean('force').pipe(
 			Flag.withDescription(
-				'Push past every refusal: discard uncommitted changes (in a linked worktree they are deleted with the directory), and delete the branch even when main carries no copy of its work',
+				'Push past every refusal: in a linked worktree uncommitted changes are deleted with the directory, in the main checkout they come across to main with you where git can carry them, and the branch is deleted even when main carries no copy of its work',
 			),
 			Flag.withDefault(false),
 		),

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -880,25 +880,120 @@ const branchWorkIsOnMain = (root: string, branch: string) =>
 		return (yield* git('cherry', 'main', rolledUp)).startsWith('-')
 	}).pipe(Effect.orElseSucceed(() => false))
 
-// Bring main up to date, and only ever by fast-forward.
-//
-// A plain `git pull` writes a merge commit when local main has wandered off
-// from the remote, which is exactly what this repository does not want in its
-// history — and it would do it silently, in the middle of a cleanup nobody
-// asked to change main. Stopping instead leaves the two copies of main for
-// somebody to look at, which is the only way it gets noticed at all.
-const pullMain = (root: string) =>
-	execArgs('git', ['-C', root, 'pull', '--ff-only', '--prune']).pipe(
-		// git has already printed why it could not; what it cannot say is that this
-		// stopped before anything was removed, and where to look.
-		Effect.catch(() =>
-			Effect.fail(
-				new Error(
-					'main could not be brought up to date by fast-forward, so nothing has been removed. Local main has most likely wandered off from the remote — compare them with `git log --oneline origin/main..main` and sort that out first.',
+// Which working tree has main checked out, or null when none has. Git keeps a
+// branch in one of them at a time, and that is what decides whether main's ref
+// can be moved from here at all.
+const worktreeHoldingMain = (root: string) =>
+	execSilentArgs('git', ['-C', root, 'worktree', 'list', '--porcelain']).pipe(
+		Effect.map(out => {
+			let at: string | null = null
+			for (const line of out.split('\n')) {
+				if (line.startsWith('worktree ')) at = line.slice('worktree '.length)
+				else if (line.trim() === 'branch refs/heads/main') return at
+			}
+			return null
+		}),
+		Effect.orElseSucceed((): string | null => null),
+	)
+
+// The remote main follows, so a clone that calls it something other than
+// `origin` is still read from the place its own configuration names.
+const remoteForMain = (root: string) =>
+	execSilentArgs('git', [
+		'-C',
+		root,
+		'config',
+		'--get',
+		'branch.main.remote',
+	]).pipe(
+		Effect.map(name => (name.trim() === '' ? 'origin' : name.trim())),
+		Effect.orElseSucceed(() => 'origin'),
+	)
+
+/**
+ * Bring main up to date without moving anybody's checkout.
+ *
+ * The main checkout is somewhere a person may be standing with work of their
+ * own, and finishing a worktree is no reason to disturb it. Checking main out
+ * there does one of two unhelpful things: git carries uncommitted edits across
+ * when the two branches agree on the file, so the work quietly follows onto
+ * main; or the branches differ, git refuses, and this run stops over something
+ * that has nothing to do with the worktree being finished.
+ *
+ * So the remote is read the same way whatever the checkout is doing, and only
+ * the last step differs: where main is the branch in hand it is moved forward
+ * in place, and where it is not, its ref is moved on its own and no working
+ * tree is touched at all.
+ *
+ * Every way of stopping says which one it was. Refusing to merge a main that
+ * has wandered off from the remote is the whole point — a plain pull would
+ * write a merge commit, silently, in the middle of a cleanup nobody asked to
+ * change main — but being told that when the real trouble is a remote that
+ * cannot be reached, or a main another worktree is holding, sends somebody
+ * looking for a divergence that is not there.
+ */
+const catchMainUp = (root: string) =>
+	Effect.gen(function* () {
+		const wanderedOff = Effect.fail(
+			new Error(
+				'main could not be brought up to date by fast-forward, so nothing has been removed. Local main has most likely wandered off from the remote — compare them with `git log --oneline origin/main..main` and sort that out first.',
+			),
+		)
+		const branchInHand = yield* execSilentArgs('git', [
+			'-C',
+			root,
+			'rev-parse',
+			'--abbrev-ref',
+			'HEAD',
+		]).pipe(Effect.orElseSucceed(() => ''))
+
+		// Asked before anything is fetched, because a branch another working tree
+		// holds cannot be moved however the fetch goes.
+		if (branchInHand !== 'main') {
+			const heldAt = yield* worktreeHoldingMain(root)
+			if (heldAt !== null) {
+				return yield* Effect.fail(
+					new Error(
+						`main is checked out at ${heldAt}, and git keeps a branch in one working tree at a time, so it cannot be moved from here. Nothing has been removed. Finish that worktree, or move it off main, and run this again.`,
+					),
+				)
+			}
+		}
+
+		const remote = yield* remoteForMain(root)
+		// The ordinary fetch, which brings every remote-tracking branch up to date
+		// and drops the ones whose branches are gone. Naming a single branch here
+		// instead would narrow what pruning covers to that branch, and the stale
+		// ones would quietly pile up.
+		yield* execArgs('git', ['-C', root, 'fetch', remote, '--prune']).pipe(
+			Effect.catch(() =>
+				Effect.fail(
+					new Error(
+						`${remote} could not be reached to bring main up to date, so nothing has been removed.`,
+					),
 				),
 			),
-		),
-	)
+		)
+		yield* (
+			branchInHand === 'main'
+				? execArgs('git', [
+						'-C',
+						root,
+						'merge',
+						'--ff-only',
+						`refs/remotes/${remote}/main`,
+					])
+				: // Moved from the copy just fetched, so there is no second trip to the
+					// remote, and it stops rather than forcing when it cannot.
+					execArgs('git', [
+						'-C',
+						root,
+						'fetch',
+						'.',
+						`refs/remotes/${remote}/main:main`,
+					])
+		).pipe(Effect.catch(() => wanderedOff))
+	})
 
 /**
  * Refuse unless main carries a copy of this branch's work.
@@ -1082,13 +1177,6 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 
 			if (linked) {
 				const branch = yield* branchName
-				// Take main back and bring it up to date. Git keeps a branch in one
-				// working tree at a time, so when this worktree is the one holding
-				// main, this can only happen once the directory is gone.
-				const catchMainUp = Effect.gen(function* () {
-					yield* execIn(mainRoot, 'git', 'checkout', 'main')
-					yield* pullMain(mainRoot)
-				})
 				const worktreePath = resolve(
 					yield* execSilent('git', 'rev-parse', '--show-toplevel'),
 				)
@@ -1110,7 +1198,7 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 					// "already on main" depends on it, and a pull that cannot happen —
 					// no network, a main that has wandered off — is a reason to stop
 					// while there is still a worktree to come back to.
-					yield* catchMainUp
+					yield* catchMainUp(mainRoot)
 					if (yield* branchExists(ownBranch)) {
 						yield* refuseUnlessWorkIsOnMain(mainRoot, ownBranch, force)
 					}
@@ -1146,11 +1234,10 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 				yield* Console.log('✓ Removed linked worktree directory')
 
 				if (ownBranch === null) {
-					// Bring main up to date, which had to wait: git keeps a branch in one
-					// working tree at a time, so the main checkout could not take main
-					// back while this worktree still held it.
-					yield* execIn(mainRoot, 'git', 'checkout', 'main')
-					yield* pullMain(mainRoot)
+					// Bringing main up to date had to wait: git keeps a branch in one
+					// working tree at a time, so nothing could move it while this
+					// worktree still held it.
+					yield* catchMainUp(mainRoot)
 				} else if (yield* branchExists(ownBranch)) {
 					yield* deleteBranch(mainRoot, ownBranch)
 				}
@@ -1165,7 +1252,7 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 				}
 				yield* Console.log(`Finishing feature branch ${branch}...`)
 				yield* exec('git', 'checkout', 'main')
-				yield* pullMain(mainRoot)
+				yield* catchMainUp(mainRoot)
 
 				if (yield* branchExists(branch)) {
 					yield* refuseUnlessWorkIsOnMain(mainRoot, branch, force)

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -910,6 +910,12 @@ const remoteForMain = (root: string) =>
 		Effect.orElseSucceed(() => 'origin'),
 	)
 
+// The failure in its own words, so git's account of what it could not do
+// survives into the message wrapped around it. Checked rather than assumed,
+// since what arrives here need not be an Error.
+const reasonOf = (failure: unknown): string =>
+	failure instanceof Error ? failure.message : String(failure)
+
 /**
  * Bring main up to date without moving anybody's checkout.
  *
@@ -1214,33 +1220,51 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 				// A worktree that never had a database is still a worktree to finish —
 				// a change to the command-line tool alone needs no stack — so nothing to
 				// drop is a note, not the end of the run.
-				if ((yield* worktreeDown) === 'nothing-provisioned') {
+				const dropped = (yield* worktreeDown) === 'removed'
+				if (!dropped) {
 					yield* Console.log(
 						'No database or bucket provisioned here — nothing to drop.',
 					)
 				}
 
-				// Move to the main checkout before deleting the worktree directory,
-				// otherwise subsequent git commands would run from a deleted cwd.
-				process.chdir(mainRoot)
-				yield* execArgs('git', [
-					'-C',
-					mainRoot,
-					'worktree',
-					'remove',
-					...(force ? ['--force'] : []),
-					worktreePath,
-				])
-				yield* Console.log('✓ Removed linked worktree directory')
+				const finishRemoving = Effect.gen(function* () {
+					// Move to the main checkout before deleting the worktree directory,
+					// otherwise subsequent git commands would run from a deleted cwd.
+					process.chdir(mainRoot)
+					yield* execArgs('git', [
+						'-C',
+						mainRoot,
+						'worktree',
+						'remove',
+						...(force ? ['--force'] : []),
+						worktreePath,
+					])
+					yield* Console.log('✓ Removed linked worktree directory')
 
-				if (ownBranch === null) {
-					// Bringing main up to date had to wait: git keeps a branch in one
-					// working tree at a time, so nothing could move it while this
-					// worktree still held it.
-					yield* catchMainUp(mainRoot)
-				} else if (yield* branchExists(ownBranch)) {
-					yield* deleteBranch(mainRoot, ownBranch)
-				}
+					if (ownBranch === null) {
+						// Bringing main up to date had to wait: git keeps a branch in one
+						// working tree at a time, so nothing could move it while this
+						// worktree still held it.
+						yield* catchMainUp(mainRoot)
+					} else if (yield* branchExists(ownBranch)) {
+						yield* deleteBranch(mainRoot, ownBranch)
+					}
+				})
+
+				// The data is gone by now and nothing brings it back, so a step that
+				// fails from here has to say so: git names what it could not do, and
+				// cannot know that a database went first.
+				yield* dropped
+					? finishRemoving.pipe(
+							Effect.catch(failure =>
+								Effect.fail(
+									new Error(
+										`${reasonOf(failure)}\n\nThis worktree's data was dropped before that, and is not coming back: \`pnpm cli worktree up\` makes a fresh database and bucket if you carry on here.${ownBranch === null ? '' : ` The branch ${ownBranch} is untouched.`}`,
+									),
+								),
+							),
+						)
+					: finishRemoving
 			} else {
 				const branch = yield* branchName
 				if (branch === 'main') {
@@ -1252,6 +1276,15 @@ export const worktreeDone = (options: { force: boolean; stash: boolean }) =>
 				}
 				yield* Console.log(`Finishing feature branch ${branch}...`)
 				yield* exec('git', 'checkout', 'main')
+				// The main checkout is the working tree being kept, so there is no
+				// directory to take uncommitted changes away with: git carries them onto
+				// main when both branches agree on the file. The work is safe, but it
+				// now sits on a branch it was not written for, which nothing else says.
+				if (!(yield* workingTreeClean)) {
+					yield* Console.log(
+						`Uncommitted changes came across to main with you — they were written on ${branch}. Set them aside with \`git stash\` if main is not where they belong.`,
+					)
+				}
 				yield* catchMainUp(mainRoot)
 
 				if (yield* branchExists(branch)) {


### PR DESCRIPTION
## What

`pnpm cli worktree done` finishes a git worktree after its pull request merges. To work out whether the branch's work is safely on `main`, it first brings `main` up to date — and it did that by checking `main` out **in the main checkout**, which is a directory somebody may be standing in, on another branch, with unsaved work. This is the developer command-line tool (`apps/cli`); nothing here touches the product or the server.

Measured against this repository's real remote, that does one of two unhelpful things depending on the file:

- the two branches **agree** on a file you have edited — git carries the edit across, so your unsaved work silently follows onto `main`;
- they **differ** — git refuses, and the whole run dies over something that has nothing to do with the worktree being finished.

I reproduced the first one directly: the current code moved my checkout from `tmp/sidework` to `main` and `SIDEWORK.txt` went with it.

## The fix

**Touches:** the one step that brings `main` up to date, and the messages it fails with. Every other step, and the order they run in, is unchanged.

- **`main` is only checked out where it is already the branch in hand.** Then it is moved forward in place, and no switch happens, so a dirty tree there is harmless. Anywhere else, only the ref moves and no working tree is touched at all. The single remaining `git checkout main` is in the path where you are standing in the main checkout on the very branch about to be deleted — there it is genuinely required.
- **Stopping still means stopping.** Both routes refuse a `main` that has wandered off from the remote rather than merging it, so tidying up still cannot write a merge commit into `main`.
- **Each way of stopping now says which one it was.** Flattening every failure into "main has wandered off" sent people to compare two copies of `main` that were identical. A remote that cannot be reached says so. A `main` that another working tree is holding names that worktree and what to do about it — which matters here, because with ten worktrees open at once that is an ordinary state rather than a corner case.
- **The remote is read from what `main` follows** instead of being assumed to be called `origin`, so both routes read the same place.
- **Pruning is a step of its own.** Naming a single branch in a fetch narrows what pruning covers to that branch, so the remote-tracking branches of merged work would have quietly piled up.

## Impact

- Developer tooling only. No database migration, no new environment variable, nothing touching which organisation can see what (no row-level security or `organization_id` scoping), no change to the public/protected boundary, and nothing the frontend or the MCP surface reads.
- **One behaviour change worth naming:** after finishing a linked worktree, the main checkout stays on whatever branch it was on, instead of being switched to `main`. I read the old switch as an accident rather than a feature — your shell was inside the worktree that just got deleted either way — but it is a change, and it is the one thing here worth disagreeing with.
- The command refuses in every case it refused before. What changed is which reason it gives.

## Review guide

- The whole change is one function, `catchMainUp`, plus the two call sites that used to check `main` out first. Read the function top to bottom; the rest of the diff is the call sites losing a line each.
- **The order inside it matters:** whether another working tree holds `main` is asked *before* anything is fetched, because a branch somebody else holds cannot be moved however the fetch goes — and asking first means the answer costs no network round trip.
- **A judgement call:** `git fetch . refs/remotes/<remote>/main:main` moves the local ref from the copy just fetched. It is a second fetch from the repository itself rather than the remote, so there is no extra network trip, and it fast-forwards or refuses — it never forces.

## Tests

None. This repo does not unit-test CLI commands — the convention is to test the underlying services, and this is a sequence of git calls with no service beneath it. It is covered by the runs below.

## Verification

- `pnpm check-types` (13/13), `pnpm test` (21/21), `pnpm build` (13/13), re-run after rebasing onto current `main`.
- Every git behaviour this leans on was measured rather than assumed, in throwaway repositories: that `git checkout main` carries a dirty file when the branches agree on it and refuses when they differ; that fetching straight into a ref fast-forwards it, refuses a non-fast-forward with a non-zero exit, and updates the remote-tracking ref too; that `--prune` is inert once an explicit refspec is given; and that a branch another worktree holds cannot be moved (exit 128).
- Drove the real command against this repository's real remote, in each shape:
  - **Main checkout parked on another branch with unsaved work:** it stayed on that branch, the file was untouched, and `main` still fast-forwarded. The current code, run in the same setup, switched the checkout and took the file with it.
  - **Main checkout on `main`:** moved forward in place, still on `main` afterwards.
  - **`main` held by another worktree:** refused, named the holding worktree's path, and removed nothing.
  - **Genuinely diverged `main`:** refused, said nothing had been removed, wrote no merge commit, and left the worktree standing.
- Restored the repository after each run that moved `main` — checked back to `origin/main`, clean tree, no leftover branches or worktrees.

## Also in this pull request

Two more places where the command said something that was not so. They landed here rather than in a pull request of their own because they touch the same function, and two open branches editing it would have left an ordering puzzle to merge.

- **`--force` described itself wrongly.** It said it discards uncommitted changes. In a linked worktree that is true — the directory is deleted and they go with it. In the main checkout there is no directory to delete, so git brings them along to main instead, where they sit on a branch they were not written for. Verified by running it: a staged file survived and landed on main. The description now says what happens in each place, and the command says it out loud as it happens, naming the branch the work came from.
- **A failure after teardown explained nothing.** The database and bucket are dropped before the directory is removed, so a later refusal — a locked worktree, say — showed git's error alone, with no sign that data had already gone. Git's own words are kept and what already happened is added, including that `pnpm cli worktree up` provisions afresh.

Verified end to end: with a provisioned worktree locked so removal refuses, the run drops the data, keeps git's `exited with code 128`, and adds that the data went and the branch is untouched.

One overstatement was caught in review before this shipped: the appended line first claimed "database and bucket were dropped", which is untrue on the path where a worktree was never provisioned and only a stray test database went — contradicting the line printed seconds earlier. It now says "data", which is true of both.
