### PR TITLE
cicd: stop the browser install stalling on Ubuntu's package mirror

### DIFF
--- a/.github/actions/e2e-stack/action.yml
+++ b/.github/actions/e2e-stack/action.yml
@@ -83,9 +83,31 @@ runs:
         pnpm db:migrate
         pnpm cli seed
 
+    # Only the browser binary comes from here. `--with-deps` hands the job to
+    # apt-get, and the runner's Ubuntu mirror stalls badly enough on the package
+    # indexes to swallow the whole time budget before a single test starts. It
+    # earns nothing in exchange: every shared library Chromium needs is already
+    # on the image, which ships Chrome, Chromium and Edge of its own. The only
+    # thing apt adds on top is CJK, Thai and Cyrillic fonts, and no spec here
+    # renders text in any of them.
+    #
+    # Fetching the browser still reaches outside the runner, so it gets the same
+    # treatment as the image pull above. The time bound is the part that counts:
+    # a stalled download never returns an error for a retry to act on, it just
+    # sits there until the runner kills the job.
     - name: Install Playwright browser
       shell: bash
-      run: pnpm --filter @batuda/internal exec playwright install --with-deps chromium
+      run: |
+        install_attempt=1
+        until timeout 120 pnpm --filter @batuda/internal exec playwright install chromium; do
+          if [ "$install_attempt" -ge 3 ]; then
+            echo "Could not fetch the Playwright browser after 3 tries." >&2
+            exit 1
+          fi
+          echo "Browser download failed (attempt $install_attempt) — retrying shortly."
+          sleep $((install_attempt * 10))
+          install_attempt=$((install_attempt + 1))
+        done
 
     # Serve the stack under portless. A plain `actions/checkout` is not a linked
     # worktree, so portless serves the bare `batuda.localhost` /


### PR DESCRIPTION
The `E2E smoke (Playwright)` check on pull requests and the `E2E full suite (Playwright)` run on main intermittently died with `##[error]The operation was canceled` — the job's `timeout-minutes` expiring with **zero tests executed**.

## What was happening

Every failure died inside `Install Playwright browser`, and the step after it (`Serve under portless + run Playwright`) reported `outcome=skipped`. Playwright never started.

`--with-deps` makes `playwright install` shell out to `apt-get`. On the runner, `azure.archive.ubuntu.com` returns `Ign:` for every index, apt falls back to `archive.ubuntu.com`, and that fetch stalls. From the cancelled job `96230320129`:

| Time | Event |
| --- | --- |
| `21:20:29` | step starts |
| `21:20:30` | Microsoft + Google indexes fetched fine |
| `21:20:30 → 21:22:44` | 2m14s gap, `Ign:` on every `azure.archive.ubuntu.com` line |
| `21:22:45` | falls back to `archive.ubuntu.com` |
| `21:22:46 → 21:29:13` | 6m27s of silence, then the job is killed |

It is not tied to any one change — `b0d7ab3f1f` passed and `9ea912c079` (an unrelated CLI commit) was cancelled the same way.

## Why dropping `--with-deps` is the right fix, not just the cheapest

The runner's own logs prove apt installs **no libraries at all**. Playwright 1.59.1 lists 21 apt packages for `chromium` on `ubuntu24.04-x64`; in green run `96232355220` CI reported every one of them as already present:

```
libasound2t64 is already the newest version (1.2.11-1ubuntu0.3).
libatk-bridge2.0-0t64 is already the newest version (2.52.0-1build1).
...
libxrandr2 is already the newest version (2:1.5.2-2build1).
0 upgraded, 9 newly installed, 0 to remove and 23 not upgraded.
```

The 9 it did install are **fonts only** — `fonts-freefont-ttf`, `fonts-ipafont-gothic`, `fonts-tlwg-loma-otf`, `fonts-unifont`, `fonts-wqy-zenhei`, `xfonts-cyrillic`, `xfonts-encodings`, `xfonts-scalable`, `xfonts-utils`. CJK, Thai and Cyrillic coverage. The suite has no `toHaveScreenshot` or `toMatchSnapshot` anywhere and asserts on roles and text, so none of it is load-bearing.

That is consistent with the image: `ubuntu-24.04` ships Google Chrome 151, Chromium 151 and Microsoft Edge 151, which pull in that library set as dependencies.

So the apt call spent up to **6m35s** refreshing package indexes to conclude there was nothing to do.

## Options considered

- **Cache the browser (`actions/cache`)** — rejected as a fix. It cannot help the apt step, which is where the time went. The download itself is minor: in `96232355220` the three downloads (Chromium, FFmpeg, headless shell) started at `21:29:25` and the step finished at `21:29:33`.
- **Run the job in Playwright's container image** — rejected. The stack stands up `docker compose` services and serves them through portless on the host; moving the job into a container reworks that networking for no gain here.
- **Retry alone** — insufficient by itself, as the failure is a hang, not an error. Kept as a bound, below.

## The change

`--with-deps` is gone, and the browser download is bounded by `timeout 120` with three backing-off tries, matching the `docker compose pull` step above it. The bound is the part that matters: a stalled fetch never returns an error for a retry to act on.

## Measured before and after

`Install Playwright browser`, measured from its `##[group]` line to the next step's:

| Job | | Step duration | Tests executed |
| --- | --- | --- | --- |
| `96230320129` | before, cancelled | 8m44s, then killed | **0** |
| `96222999769` | before, green | 6m34.9s | 7 passed |
| `96232355220` | before, green | 1m27.9s | 7 passed |
| `96335610467` | after, attempt 1 | **9.9s** | 7 passed |
| `96337026723` | after, attempt 2 | **9.6s** | 7 passed |
| `96337692050` | after, attempt 3 | **9.5s** | 7 passed |

Even passing runs previously swung between 1m28s and 6m35s inside a 10-minute budget; the three runs here sat within 0.4s of each other. None of them logged a single `archive.ubuntu.com` or `already the newest version` line, so apt never ran, and none needed a retry. The whole smoke job now finishes in about 2m54s.

---

## Follow-up for a human — the smoke gate is not actually required

`ci.yml` around line 202 says:

> Make this a required status check so a red smoke run blocks the merge — the whole point of the suite is to be the un-skippable browser gate

Branch protection does not implement that:

```
$ gh api repos/guillempuche/batuda/branches/main/protection --jq '.required_status_checks.contexts'
["Lint, Build, Type Check, Test"]
```

`E2E smoke (Playwright)` is not in the list, so a red smoke run does **not** block a merge today. The comment states an intent the settings do not carry out. Changing branch protection is a repo-settings decision, so it is left here rather than done — either add the context, or soften the comment to match reality.

Worth noting alongside it: `e2e-smoke` carries `if: github.event.pull_request.draft == false`, so the gate does not run on draft PRs at all.
