### PR TITLE
cicd(internal): refuse a focused browser test in CI

### DIFF
--- a/apps/internal/playwright.config.ts
+++ b/apps/internal/playwright.config.ts
@@ -137,6 +137,12 @@ export default defineConfig({
 	// from `pnpm cli db reset && pnpm cli seed` between manual runs, not from parallelism.
 	fullyParallel: false,
 	workers: 1,
+	// A stray `test.only` narrows the run to that one test and still exits green,
+	// which is the worst thing that can happen to a gate: it keeps reporting
+	// success while covering almost nothing. In CI that is a failure instead, so
+	// the mistake shows up on the pull request that made it rather than months
+	// later. Left off locally, where narrowing the run to one test is the point.
+	forbidOnly: !!process.env['CI'],
 	// One retry in CI so a single transient blip (a slow mount, a network
 	// hiccup) doesn't fail a PR on the smoke gate; a test that only passes on
 	// retry still surfaces in the report and gets triaged (docs/runbooks.md).


### PR DESCRIPTION
The browser smoke suite is meant to be the un-skippable gate — the check that proves the app still signs in, reads and writes before a change lands. Chasing an unrelated CI hang turned up three ways it was weaker than it looks. This closes the one that is a code change; the other two are settings decisions and are written up below rather than touched.

## What this changes

`forbidOnly: !!process.env['CI']` in `apps/internal/playwright.config.ts`.

A stray `test.only` left in a spec narrows the whole run to that one test and still exits **green**. That is the worst failure a gate can have: it keeps reporting success while covering almost nothing, and nothing in the output looks wrong — the run is simply shorter. In CI that is now a failure, so the mistake surfaces on the pull request that made it instead of months later. It stays permissive locally, where narrowing the run to one test is exactly what `.only` is for.

Proved rather than assumed, with a throwaway spec containing `test.only` (`--list`, so no browser or stack needed):

```
CI=1   -> EXIT=1
         Error: item focused with '.only' is not allowed due to the
         'forbidOnly' option ... "zz-only-probe.test.ts probe @smoke"
local  -> EXIT=0
         Total: 8 tests in 8 files
```

## What I checked and did NOT need to change

**A vanished `@smoke` tag already fails.** The gate selects its subset with `--grep @smoke`, so a renamed or dropped tag could in principle empty the run and pass. Playwright 1.59.1 refuses:

```
$ playwright test --grep @definitelynotatag --list
Error: No tests found          EXIT=1
```

So that one is covered by the tool, and no assertion of our own is needed.

## Two weaknesses left, both settings rather than code

Neither is mine to change, and the second has an ordering constraint worth respecting.

**1. The smoke check does not block a merge.** `.github/workflows/ci.yml` says it should:

> Make this a required status check so a red smoke run blocks the merge — the whole point of the suite is to be the un-skippable browser gate

Branch protection does not implement it:

```
$ gh api repos/guillempuche/batuda/branches/main/protection \
    --jq '.required_status_checks.contexts'
["Lint, Build, Type Check, Test"]
```

So the comment describes a gate that is not gating. **Order matters here:** #515 fixes a hang that was cancelling this job outright, and making the check required before that merges would block every pull request on a job that was failing for reasons unrelated to the change under test. Merge #515 first, then add `E2E smoke (Playwright)` to the required contexts.

**2. It is skipped on draft pull requests** (`if: github.event.pull_request.draft == false`). This is defensible — a draft is work in progress and CI minutes are real — and it is not a merge hole, because a draft cannot be merged and flipping to ready re-triggers the workflow. Worth knowing rather than fixing: it means a draft's green tick history says nothing about the browser gate.

## Verification

- `tsc --noEmit` clean for `@batuda/internal`; pre-commit hooks (check-types, lint, format, syncpack) passed.
- One file changed, six lines added, nothing else touched.
