### PR TITLE
fix(research): say why a page fetch was refused

### DIFF
--- a/.github/actions/integration-db/action.yml
+++ b/.github/actions/integration-db/action.yml
@@ -1,0 +1,89 @@
+name: Integration database
+description: >-
+  Stand up the Postgres + MinIO the integration suite needs — the same compose
+  services dev uses — then migrate and seed them. Running the database on the
+  runner keeps every query on localhost instead of paying an internet round-trip
+  to a remote host, which is what used to make this phase run near 15 minutes.
+
+  Extracted so the pull-request gate and the post-merge backstop stand the
+  database up the same way. Two copies drift, and a backstop that drifts from
+  the gate reports breaks the gate never had.
+
+runs:
+  using: composite
+  steps:
+    # Bring up Postgres + MinIO from the same docker-compose file dev uses.
+    # `--wait` blocks until `db` reports healthy (its pg_isready healthcheck)
+    # and `storage` is up.
+    #
+    # The bucket is created by a container that stops as soon as it's done, and
+    # `--wait` treats a stopped container as a failure — listing it alongside the
+    # others passed or failed on timing alone. `run` waits and reports whether it
+    # worked.
+    - name: Start Postgres + MinIO via docker compose
+      shell: bash
+      run: |
+        # Fetching the images is the one step here that reaches outside the
+        # runner, so it gets a few tries: a slow minute at the registry
+        # should cost a wait, not a red build on an unrelated change.
+        pull_attempt=1
+        until docker compose -f docker/docker-compose.yml pull --quiet db storage storage-init; do
+          if [ "$pull_attempt" -ge 3 ]; then
+            echo "Could not fetch the container images after 3 tries." >&2
+            exit 1
+          fi
+          echo "Image pull failed (attempt $pull_attempt) — retrying shortly."
+          sleep $((pull_attempt * 10))
+          pull_attempt=$((pull_attempt + 1))
+        done
+        docker compose -f docker/docker-compose.yml up -d --wait db storage
+        docker compose -f docker/docker-compose.yml run --rm --no-deps storage-init
+
+    # The local container above. Its `batuda` superuser owns the schema, and
+    # integration tests SET ROLE into the app_user / app_service roles that the
+    # 0001 migration creates — exactly as every developer's local stack does.
+    - name: Apply migrations
+      shell: bash
+      env:
+        DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
+      run: pnpm db:migrate
+
+    # Seed fixtures (notably the `taller` / `restaurant` orgs) that
+    # several integration tests rely on. EMAIL_CREDENTIAL_KEY is base64
+    # of 32 zero bytes — fine for a throwaway CI database. STORAGE_*
+    # points at the MinIO container started above; the seedDemoEmails
+    # stage PUTs raw RFC822 bytes there.
+    - name: Seed
+      shell: bash
+      env:
+        DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
+        BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci
+        EMAIL_CREDENTIAL_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+        STORAGE_ENDPOINT: http://localhost:9000
+        STORAGE_REGION: us-east-1
+        STORAGE_ACCESS_KEY_ID: batuda
+        STORAGE_SECRET_ACCESS_KEY: batuda-secret
+        STORAGE_BUCKET: batuda-assets
+        EMAIL_PROVIDER: local-inbox
+        GEOCODER_PROVIDER: nominatim
+      run: pnpm cli seed
+
+    # --concurrency=1 forces the workspaces' test:integration tasks to
+    # run one at a time. multi-org-isolation (server) TRUNCATEs the
+    # email tables in beforeAll; if mail-worker's threading runs in
+    # parallel, its INSERT loses the race to that TRUNCATE. Within each
+    # workspace, vitest's fileParallelism: false already serializes
+    # files. The proper fix (per-test transactions in multi-org) is
+    # tracked as a follow-up CI-perf slice.
+    - name: Test (integration)
+      shell: bash
+      env:
+        DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
+        BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci
+        EMAIL_CREDENTIAL_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+        STORAGE_ENDPOINT: http://localhost:9000
+        STORAGE_REGION: us-east-1
+        STORAGE_ACCESS_KEY_ID: batuda
+        STORAGE_SECRET_ACCESS_KEY: batuda-secret
+        STORAGE_BUCKET: batuda-assets
+      run: pnpm exec turbo test:integration --concurrency=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,81 +104,10 @@ jobs:
         run: pnpm test
 
       # Integration phase: a local Postgres + MinIO on the runner, seed, and the
-      # integration suite. CI runs only on pull requests, so this phase runs on
-      # every CI run.
-      #
-      # Bring up Postgres + MinIO from the same docker-compose file dev uses.
-      # `--wait` blocks until `db` reports healthy (its pg_isready healthcheck)
-      # and `storage` is up. Running the database on the runner keeps every query
-      # on localhost instead of paying an internet round-trip to a remote host —
-      # the whole reason this phase used to run near 15 minutes.
-      #
-      # The bucket is created by a container that stops as soon as it's done, and
-      # `--wait` treats a stopped container as a failure — listing it above passed
-      # or failed on timing alone. `run` waits and reports whether it worked.
-      - name: Start Postgres + MinIO via docker compose
-        run: |
-          # Fetching the images is the one step here that reaches outside the
-          # runner, so it gets a few tries: a slow minute at the registry
-          # should cost a wait, not a red build on an unrelated change.
-          pull_attempt=1
-          until docker compose -f docker/docker-compose.yml pull --quiet db storage storage-init; do
-            if [ "$pull_attempt" -ge 3 ]; then
-              echo "Could not fetch the container images after 3 tries." >&2
-              exit 1
-            fi
-            echo "Image pull failed (attempt $pull_attempt) — retrying shortly."
-            sleep $((pull_attempt * 10))
-            pull_attempt=$((pull_attempt + 1))
-          done
-          docker compose -f docker/docker-compose.yml up -d --wait db storage
-          docker compose -f docker/docker-compose.yml run --rm --no-deps storage-init
-
-      # The local container above. Its `batuda` superuser owns the schema, and
-      # integration tests SET ROLE into the app_user / app_service roles that the
-      # 0001 migration creates — exactly as every developer's local stack does.
-      - name: Apply migrations
-        env:
-          DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
-        run: pnpm db:migrate
-
-      # Seed fixtures (notably the `taller` / `restaurant` orgs) that
-      # several integration tests rely on. EMAIL_CREDENTIAL_KEY is base64
-      # of 32 zero bytes — fine for a throwaway CI database. STORAGE_*
-      # points at the MinIO container started above; the seedDemoEmails
-      # stage PUTs raw RFC822 bytes there.
-      - name: Seed
-        env:
-          DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
-          BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci
-          EMAIL_CREDENTIAL_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-          STORAGE_ENDPOINT: http://localhost:9000
-          STORAGE_REGION: us-east-1
-          STORAGE_ACCESS_KEY_ID: batuda
-          STORAGE_SECRET_ACCESS_KEY: batuda-secret
-          STORAGE_BUCKET: batuda-assets
-          EMAIL_PROVIDER: local-inbox
-          GEOCODER_PROVIDER: nominatim
-        run: pnpm cli seed
-
-      # --concurrency=1 forces the workspaces' test:integration tasks to
-      # run one at a time. multi-org-isolation (server) TRUNCATEs the
-      # email tables in beforeAll; if mail-worker's threading runs in
-      # parallel, its INSERT loses the race to that TRUNCATE. Within each
-      # workspace, vitest's fileParallelism: false already serializes
-      # files. The proper fix (per-test transactions in multi-org) is
-      # tracked as a follow-up CI-perf slice.
-      - name: Test (integration)
-        env:
-          DATABASE_URL: postgresql://batuda:batuda@localhost:5433/batuda
-          BETTER_AUTH_SECRET: ci-only-not-prod-ci-only-not-prod-ci
-          EMAIL_CREDENTIAL_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-          STORAGE_ENDPOINT: http://localhost:9000
-          STORAGE_REGION: us-east-1
-          STORAGE_ACCESS_KEY_ID: batuda
-          STORAGE_SECRET_ACCESS_KEY: batuda-secret
-          STORAGE_BUCKET: batuda-assets
-        run: pnpm exec turbo test:integration --concurrency=1
+      # integration suite. Shared with the post-merge backstop in e2e-main.yml so
+      # both stand the database up the same way — see the action for why.
+      - name: Integration suite against a local Postgres
+        uses: ./.github/actions/integration-db
 
       # Boot the built server against the REAL config.production.json + the
       # deploy workflow's exact `-e` secret list (dummy values), so a release

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -45,3 +45,41 @@ jobs:
         uses: ./.github/actions/e2e-stack
         with:
           with-mail: "true"
+
+  # The pull-request gate runs the integration suite against the merge GitHub
+  # builds from the branch and main. That answers "does this change work", not
+  # "does main work": two pull requests can each be green on their own merge and
+  # red once both have landed, and nothing looked at main afterwards. This does.
+  #
+  # A backstop rather than a gate — it cannot block a merge that already
+  # happened, and its job is to name the commit that broke main while the change
+  # is still fresh in somebody's head.
+  integration-main:
+    name: Integration suite (post-merge)
+    runs-on: ubuntu-latest
+    # The suite takes ~2 minutes; the rest is pulling images, migrating and
+    # seeding. Matches the pull-request gate's own budget for the same work.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The integration suite imports several workspace packages from their
+      # built `dist/`, the same way the dev server does.
+      - name: Build
+        run: pnpm build
+
+      - name: Integration suite against a local Postgres
+        uses: ./.github/actions/integration-db

--- a/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
+++ b/packages/research/src/infrastructure/firecrawl/firecrawl.test.ts
@@ -468,6 +468,55 @@ describe('makeFirecrawlScrape', () => {
 		expect(log.count).toBe(3)
 	})
 
+	it('should carry the reason the provider gave for the refusal', async () => {
+		// GIVEN a 2xx refusal that says why, the way Firecrawl does
+		const { exit } = runScrape(200, {
+			success: false,
+			code: 'SCRAPE_TIMEOUT',
+			error: 'The page took too long to load',
+		})
+
+		// WHEN it settles — THEN the message names both, because "success=false" on
+		// its own reads the same whether the page blocked the fetch, the account ran
+		// out, or their side timed out, and those want different responses
+		const resolved = await exit
+		expect(errorOf(resolved)?.message).toBe(
+			'scrape failed: SCRAPE_TIMEOUT: The page took too long to load',
+		)
+	})
+
+	it('should cut a reason that runs to a paragraph', async () => {
+		// GIVEN the shape a real refusal arrives in: a short name, then several
+		// hundred characters of advice
+		const { exit } = runScrape(200, {
+			success: false,
+			code: 'SCRAPE_DNS_RESOLUTION_ERROR',
+			error: `DNS resolution failed for that hostname. ${'Possible causes to check. '.repeat(20)}`,
+		})
+
+		// WHEN it settles — THEN the name and the opening sentence survive, and the
+		// rest does not, so a run losing a dozen fetches cannot bury the log
+		const resolved = await exit
+		const message = errorOf(resolved)?.message ?? ''
+		expect(message).toContain('SCRAPE_DNS_RESOLUTION_ERROR')
+		expect(message).toContain('DNS resolution failed for that hostname.')
+		expect(message.endsWith('…')).toBe(true)
+		// The cap plus the wrapper, nowhere near the 500-odd that arrived.
+		expect(message.length).toBeLessThan(230)
+	})
+
+	it('should say plainly when the provider refused without a reason', async () => {
+		// GIVEN a refusal carrying no words at all
+		const { exit } = runScrape(200, { success: false })
+
+		// WHEN it settles — THEN the message says the reason is missing rather than
+		// implying none was asked for
+		const resolved = await exit
+		expect(errorOf(resolved)?.message).toBe(
+			'scrape failed: provider reported success=false, with no reason given',
+		)
+	})
+
 	it('should fail non-recoverably on a body it cannot read at all', async () => {
 		// GIVEN a 2xx whose `data` is not a page block
 		const { exit, log } = runScrape(200, { data: 'nonsense' })

--- a/packages/research/src/infrastructure/firecrawl/scrape.ts
+++ b/packages/research/src/infrastructure/firecrawl/scrape.ts
@@ -33,10 +33,27 @@ import { cleanScrapedMarkdown } from './clean-scraped-markdown'
 
 const SCRAPE_URL = 'https://api.firecrawl.dev/v2/scrape'
 
+// A real DNS refusal runs to 450-odd characters, nearly all of it a numbered
+// list of advice, and a run that loses a dozen fetches would bury the rest of
+// the log in it. The opening sentence carries the answer.
+const LONGEST_REASON_WORTH_LOGGING = 160
+
+const shortened = (reason: string): string =>
+	reason.length > LONGEST_REASON_WORTH_LOGGING
+		? `${reason.slice(0, LONGEST_REASON_WORTH_LOGGING)}…`
+		: reason
+
 // Subset of the Firecrawl scrape response we read. Unknown fields are ignored.
 const ScrapeResponse = Schema.Struct({
 	// Firecrawl's own verdict on the fetch, which a 2xx does not guarantee.
 	success: NullableOptional(Schema.Boolean),
+	// Why Firecrawl says the fetch did not work, in its own words, and the short
+	// name it files that reason under (SCRAPE_TIMEOUT, SCRAPE_DNS_RESOLUTION_ERROR
+	// and the like). Read only to put them in the message below: without them a
+	// refusal reads as "it did not work" and nothing separates a page that blocks
+	// robots from an account that has run out, which is hours of the wrong guess.
+	error: NullableOptional(Schema.String),
+	code: NullableOptional(Schema.String),
 	// The credits Firecrawl says this fetch consumed. Optional because the field
 	// is not on every response shape; a fetch that stays quiet counts as one.
 	creditsUsed: NullableOptional(Schema.Number),
@@ -170,10 +187,21 @@ export const makeFirecrawlScrape = (slot: number) =>
 						// work. That is their side failing and worth another try, so it
 						// surfaces as an error rather than as a page that came back empty.
 						if (body.success === false) {
+							// Carry Firecrawl's own words through. A refusal with nothing but
+							// "success=false" reads the same whether the page blocked the
+							// fetch, the account ran dry, or their side timed out, and the
+							// three want completely different responses from whoever reads
+							// the log.
+							const said = [body.code, body.error && shortened(body.error)]
+								.filter((part): part is string => part != null && part !== '')
+								.join(': ')
 							return yield* Effect.fail(
 								new ProviderError({
 									provider: 'firecrawl',
-									message: 'scrape failed: provider reported success=false',
+									message:
+										said === ''
+											? 'scrape failed: provider reported success=false, with no reason given'
+											: `scrape failed: ${said}`,
 									recoverable: true,
 								}),
 							)


### PR DESCRIPTION
## What

Two loose ends from the work on #494, neither of which changes what a research run produces.

The first makes a failed page fetch say **why** it failed. When the page-fetching service (Firecrawl) refuses, the log said only "it did not work", which reads identically whether the page blocked the fetch, the account ran out of credits, or the service timed out. Those want completely different responses from whoever is reading, and telling them apart cost me about an hour of chasing the wrong cause during #494.

The second makes `main` run its database-backed tests (the integration suite) **after** a merge, so a break that only appears once two changes are both on `main` is reported against the commit that caused it instead of surfacing days later on somebody else's pull request.

Touches the research bounded context (`packages/research`, the Firecrawl adapter) and the CI configuration. No product surface, no database schema, no API shape.

## Changes

**Touches:** the page-fetching adapter and the message it hands back when a fetch is refused, plus the two GitHub workflows and a new shared step they both call.

- Read the reason the fetching service sends. It answers some refusals with a success code and puts the cause in the body — a short name like `SCRAPE_DNS_RESOLUTION_ERROR` and a sentence of prose. Only the "did it work" flag was being read; the two fields carrying the answer were dropped on the floor.
- Cut that prose at 160 characters. A real refusal arrives as roughly 450, nearly all of it a numbered list of things to check, and a run that loses a dozen fetches would bury the rest of the log in it. The short name and the opening sentence carry the whole answer.
- Added a post-merge run of the integration suite on `main`, as a backstop rather than a gate — it cannot block a merge that already happened; its job is to name the commit that broke `main` while the change is still fresh in somebody's head.
- Moved the database setup (Postgres and object storage, migrate, seed) into a shared step both the pull-request check and the new post-merge one call, rather than copying fifty lines into a second workflow.

## Impact

- **Nothing touching which organisation can see what (row-level security), no database schema change, no change to the shape of any API response.** The only production behaviour that moves is the wording of one error message in a log.
- **No new environment variables**, so nothing extra for production to set.
- **Both transports are unaffected** — this is below the service layer, so the two ways the app is reached (HTTP and the tool interface, MCP) see no difference.
- **The pull-request check now calls a shared step instead of running the setup inline.** That is the one piece of real risk here: a composite action only truly runs on a GitHub runner, so this pull request's own required check is what proves it. If the extraction is wrong, this pull request goes red rather than `main`.
- **Cost:** one extra CI run per merge to `main`, roughly the length of the existing pull-request check.

## Review guide

Start with `packages/research/src/infrastructure/firecrawl/scrape.ts` — it is small, and the interesting question is whether 160 characters is the right cut. I picked it by driving a real refusal through the adapter and reading what came out (below); the code and the opening sentence survive, the advice paragraph does not.

Then `.github/actions/integration-db/action.yml`, which is the extracted step, and the two workflows that call it. The extraction is a straight move — same commands, same environment variables, same order — so the thing to check is that I did not drop a step rather than that the steps are right.

Two judgement calls you might overrule:

- I made the post-merge run a **backstop, not a required gate**. It reports; it does not block. Making it block would mean a red `main` stops unrelated pull requests from merging, which trades one problem for a worse one.
- I capped the provider's prose rather than logging it whole. If you would rather have the full text and accept the noise, that is a one-line change.

I could not verify the CI extraction locally — a composite action needs a runner. See Verification for exactly what I did and did not run.

## Tests

Three new unit tests on the Firecrawl adapter: the reason is carried through with its short name, a reason that runs to a paragraph is cut with the opening sentence intact, and a refusal that carries no reason at all says so plainly rather than implying none was asked for.

## Verification

- `pnpm install`, `pnpm -w check-types`, `pnpm -w test` (21 workspaces), `pnpm -w build` (13 workspaces) — all green, re-run after the final rebase.
- Server integration suite locally: **99 files, 702 tests**, all passing.
- **Live, against the real service, not a mock**: confirmed the field names first with a direct request, then drove a host that cannot resolve through the adapter itself. Before the change the message was `scrape failed: provider reported success=false`; after it, and after the cap:

  ```
  scrape failed: SCRAPE_DNS_RESOLUTION_ERROR: DNS resolution failed for hostname
  "…". This means the domain name could not be translated to an IP address. Possible …
  ```

  490 characters uncapped, 205 with the cap.
- **Not verified locally:** the CI changes. A composite action only runs on a GitHub runner, so this pull request's own required check is the first real test of it.

## Deferred

- `E2E smoke (Playwright)` is still absent from the required checks on `main`, so a red browser run does not block a merge — despite `ci.yml` describing it as the un-skippable browser gate. That is a repository settings change rather than code, so it is not in this pull request. It is now safe to add, since the hang that was cancelling that job is fixed and merged.
- `research-subject-scope.integration.test.ts` races a soft-delete against a queued run and fails occasionally in CI. It passed five times out of five locally, so I left it rather than guess at a fix that could make it weaker; it wants a proper seam in the run lifecycle.
