### PR TITLE
test(server): catch a server that has stopped running research

### DIFF
--- a/apps/server/src/main.boot.test.ts
+++ b/apps/server/src/main.boot.test.ts
@@ -204,6 +204,24 @@ describe('apps/server program boot', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('should say it carries queued research runs out', () => {
+		// GIVEN the deployed server is the process that drains the research
+		//       queue — the local command-line MCP server deliberately does not
+		// WHEN reading what it announced at boot
+		const combined = `${output.stdout}\n${output.stderr}`
+		// THEN it said so. Nothing else would notice if it stopped: the daemons
+		//      that do the work announce nothing until they find some, so a
+		//      server that had quietly stopped dispatching looks exactly like
+		//      one with an empty queue, and the runs pile up waiting for a
+		//      worker that never comes.
+		//
+		//      Read off the record's own fields rather than its wording, the way
+		//      anything else querying these lines would — see observability.md.
+		expect(combined).toMatch(/"event":"research\.dispatch\.configured"/)
+		expect(combined).toMatch(/"dispatches":true/)
+		expect(combined).not.toMatch(/"dispatches":false/)
+	})
+
 	it('should not surface a missing-service Defect during boot', () => {
 		// GIVEN the program reached the listening state
 		// WHEN we inspect the merged stderr+stdout

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -6231,6 +6231,17 @@ export class ResearchService extends Context.Service<ResearchService>()(
 			// it creates is left queued for whichever process does dispatch.
 			const layerScope = yield* Effect.scope
 			const dispatches = yield* ResearchDispatch
+			// Said out loud at boot, both ways, alongside the providers this run
+			// would use. Whether a process carries runs out is otherwise invisible:
+			// the daemons below announce nothing until they find work, so a server
+			// that had quietly stopped dispatching would look exactly like one with
+			// an empty queue, and runs would sit there with nobody wondering why.
+			yield* Effect.logInfo('research.dispatch.configured').pipe(
+				Effect.annotateLogs({
+					event: 'research.dispatch.configured',
+					dispatches,
+				}),
+			)
 			if (dispatches) {
 				yield* reofferQueued.pipe(
 					Effect.catchCause(cause =>


### PR DESCRIPTION
## What

Closes the one gap left open by #517. That PR gave each process a yes/no setting — **do you carry out research jobs?** The deployed web server says yes and drains the queue; the local command-line MCP server says no, so an editor left connected never competes with `pnpm dev` for the same work.

The **no** side was verified. The **yes** side was covered by nothing, and the decision was invisible: no log line either way. So a server that had quietly stopped dispatching looked exactly like one with an empty queue — no error, no failing test, just runs piling up waiting for a worker that never comes. You would find out when somebody asked why their research never finished.

## Changes

**Touches:** where the dispatch decision is made (`packages/research`), and the production boot test that already boots the real build and reads its output.

- **The decision is said out loud at boot**, both ways: `research.dispatch: on — this process carries queued runs out`, or `off — this process leaves queued runs to another`, annotated `research.dispatch.mode`.
- **The boot test asserts the deployed server said `on`** — and that it did not say `off`.

## Impact

None at runtime beyond one extra INFO line per process at startup. No behaviour change, no new configuration, no migration, nothing touching which organisation can see what.

## Review guide

Two hunks, both small. The thing worth your judgement is whether a log line plus a boot-test assertion is the right level of protection here, versus a test that drives a real run through the worker end to end. I went this way deliberately: the end-to-end shape needs the live daemon, which has hung CI to the 15-minute job timeout with no output before, and the standing rule is not to test dispatch that way. This checks what the process *intends*, which is the thing that silently breaks, without any queue, timing or flakiness.

It also earns its keep outside the test: you can now look at any running server's logs and see what it thinks it is doing.

## Tests

The existing production boot test gains one case (6 → 7). It builds the bundle, boots it in production mode against the real `config.production.json`, and reads what it printed.

## Verification

Gates: `pnpm -w check-types` 13/13, `pnpm -w test` 21/21, `pnpm -w build` 13/13. Boot test 7/7.

Confirmed the new assertion has teeth rather than assuming it: with the switch flipped to `false` in `main.ts`, the boot test goes red — and the failure prints the offending line, so whoever breaks it is told what happened rather than left guessing.

```
× should say it carries queued research runs out
  {"message":"research.dispatch: off — this process leaves queued runs to another", …}
```

Restored and re-ran green afterwards.
