### PR TITLE
feat(research): tell a blocked connection from a rejected key

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1096,7 +1096,7 @@ const researchEvalCommand = Command.make(
 		),
 		dryRun: Flag.boolean('dry-run').pipe(
 			Flag.withDescription(
-				'Check everything a pass needs and spend nothing: that the database is local, that no part of the pipeline would answer with canned data, and that every golden row parses. Prints how many runs would execute',
+				'Check everything a pass needs and spend nothing: that the database is local, that no part of the pipeline would answer with canned data, that every golden row parses, and that this machine can reach each vendor a pass would go to. The reachability check sends no key, so it costs nothing and a vendor that turns it away still counts as reached. Prints how many runs would execute',
 			),
 		),
 		priceFrom: Flag.string('price-from').pipe(

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -10,6 +10,7 @@ import { SqlLive } from '../db'
 import { isLocalDatabaseHost, resolveDatabaseHost } from '../lib/database-host'
 import { parseEnvKeys } from '../lib/env-file'
 import { getTarget } from '../lib/load-env'
+import { researchReachabilityChecks } from '../lib/provider-reachability'
 import { execSilent, ROOT } from '../shell'
 import { isLinkedWorktree } from './worktree'
 
@@ -397,6 +398,12 @@ export const doctor = Effect.gen(function* () {
 	for (const check of checks) {
 		const result = yield* check.run
 		results.push({ name: check.name, ...result })
+	}
+	// Reaching a vendor is a question about this machine's connection, and the
+	// cloud tier reaches them from somewhere else entirely, so an answer from here
+	// would say nothing about it.
+	if (target !== 'cloud') {
+		results.push(...(yield* researchReachabilityChecks()))
 	}
 	return results
 })

--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -50,6 +50,7 @@ import {
 	parseContactGoldenSet,
 	parseGoldenSet,
 	probeModelCapabilities,
+	probeReachability,
 	type RawContactGoldenRow,
 	type RawGoldenRow,
 	ResearchEventSink,
@@ -57,6 +58,7 @@ import {
 	type ResolvedInstructions,
 	type RunScore,
 	type RunUsage,
+	researchProviderEndpoints,
 	researchToolkitWireFormat,
 	type SystemDefaults,
 	scoreContactRun,
@@ -66,6 +68,10 @@ import {
 
 import { SqlLive } from '../db'
 import { requireLocalDatabase } from '../lib/confirm-cloud'
+import {
+	NOTHING_TO_REACH,
+	settingWillNotRead,
+} from '../lib/provider-reachability'
 import { requireLiveProviders } from '../lib/require-live-providers'
 
 // `pnpm cli` runs from apps/cli, so resolve a relative --golden/--out against the
@@ -700,6 +706,37 @@ const requireMarketSchema = (
 }
 
 /**
+ * Whether this machine can reach each vendor a pass would go to, found out here
+ * where nothing has been spent rather than hours into a paid pass.
+ *
+ * It answers about the connection only: a vendor that turns a key-less request
+ * away still counts as reached, and `research probe-config` is what says whether
+ * a key works.
+ */
+const reportReachability = Effect.gen(function* () {
+	const { endpoints, unreadable } = yield* researchProviderEndpoints()
+	for (const { part, detail } of unreadable) {
+		// Neither ✓ nor ✗: nothing was checked behind this setting. `doctor` shows
+		// the same fact as an amber row, so the two screens agree on what it is.
+		yield* Console.log(`! ${part}: ${settingWillNotRead(detail)}`)
+	}
+	// Said rather than skipped, so a dry run that checked and found nothing to
+	// reach cannot be read as one that never checked. Only when nothing is broken
+	// either: a part that would not read may well have been pointed at a vendor,
+	// and there is no way from here to say it was not.
+	if (endpoints.length === 0) {
+		if (unreadable.length === 0) yield* Console.log(NOTHING_TO_REACH)
+		return
+	}
+	const results = yield* probeReachability(endpoints)
+	for (const result of results) {
+		yield* Console.log(
+			`${mark(result.verdict === 'reachable')} ${result.detail} Used by: ${result.labels.join(', ')}.`,
+		)
+	}
+}).pipe(Effect.provide(FetchHttpClient.layer))
+
+/**
  * Run the golden set through the live research pipeline and report the four quality
  * metrics. This drives real runs (LLM + providers + DB), so it needs the research
  * env configured and an org/user to run as; it connects under a BYPASS-RLS role and
@@ -737,6 +774,12 @@ export const researchEval = (opts: {
 			Effect.catchTag('StubbedProvidersRefused', error =>
 				opts.dryRun ? Effect.succeed(error.message) : Effect.fail(error),
 			),
+			// A setting that will not read stops a real pass, where it should. A dry
+			// run carries on instead, because the reachability report it prints names
+			// the variable and the values it accepts, which stopping here would not.
+			Effect.catch(error =>
+				opts.dryRun ? Effect.succeed<string | null>(null) : Effect.fail(error),
+			),
 		)
 		const raw = yield* Effect.tryPromise({
 			try: () => readFile(fromRepoRoot(opts.goldenPath), 'utf8'),
@@ -763,6 +806,7 @@ export const researchEval = (opts: {
 			if (routingRefusal !== null) {
 				yield* Console.log(`Would not run: ${routingRefusal}`)
 			}
+			yield* reportReachability
 			const runsTotal = golden.length * opts.runs
 			const price = yield* estimatedPassCents(opts.priceFrom, runsTotal)
 			yield* Console.log(

--- a/apps/cli/src/lib/provider-reachability.ts
+++ b/apps/cli/src/lib/provider-reachability.ts
@@ -1,0 +1,73 @@
+/**
+ * The reachability of each research vendor, as `doctor` rows. `research eval
+ * --dry-run` prints the same probe its own way, so both commands say the same
+ * thing about the same vendors.
+ *
+ * Never `fail`, only `warn`: somebody working on Batuda without research keys is
+ * not doing anything wrong, and a red row would say they were.
+ */
+
+import { Effect } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+
+import {
+	hostOf,
+	probeReachability,
+	researchProviderEndpoints,
+} from '@batuda/research'
+
+import type { CheckResult } from '../commands/doctor'
+
+/**
+ * What both commands say when no part of the pipeline goes to a vendor. It sits
+ * beside the commands rather than in the research package because it is a
+ * finished sentence for a person to read, and it is shared so a reader
+ * comparing the two screens can see they ran the same check.
+ */
+export const NOTHING_TO_REACH =
+	'no part of the research pipeline is pointed at a vendor — nothing to reach'
+
+/** What both commands say about a setting somebody wrote and got wrong. */
+export const settingWillNotRead = (detail: string): string =>
+	`its setting will not read, so nothing was checked — ${detail}`
+
+/**
+ * One row per vendor host, probes already run by the time the rows come back.
+ * They go out together, so a machine cut off from four vendors waits once
+ * rather than four times.
+ */
+export const researchReachabilityChecks = (): Effect.Effect<CheckResult[]> =>
+	Effect.gen(function* () {
+		const { endpoints, unreadable } = yield* researchProviderEndpoints()
+		// A setting somebody wrote and got wrong is worth an amber row: nothing was
+		// checked behind it, and reading that as a pass is how a broken setting
+		// survives to waste a pass.
+		const broken: CheckResult[] = unreadable.map(({ part, detail }) => ({
+			name: `Research ${part}`,
+			status: 'warn' as const,
+			detail: settingWillNotRead(detail),
+		}))
+		// Said rather than left out, so a machine with nothing configured reads as
+		// one that was looked at. Only when nothing is broken either: a part that
+		// would not read may well have been pointed at a vendor, and there is no
+		// way from here to say it was not.
+		if (endpoints.length === 0 && broken.length === 0) {
+			return [
+				{
+					name: 'Research vendors',
+					status: 'ok' as const,
+					detail: NOTHING_TO_REACH,
+				},
+			]
+		}
+		const results = yield* probeReachability(endpoints)
+		return [
+			...broken,
+			...results.map(result => ({
+				name: `Research ${hostOf(result.origin)}`,
+				status:
+					result.verdict === 'reachable' ? ('ok' as const) : ('warn' as const),
+				detail: `${result.detail} Used by: ${result.labels.join(', ')}.`,
+			})),
+		]
+	}).pipe(Effect.provide(FetchHttpClient.layer))

--- a/eval/README.md
+++ b/eval/README.md
@@ -102,11 +102,13 @@ The eval refuses to start against a database that is not on this machine, so a f
 pnpm cli research eval --org <org-id> --user <user-id> --golden eval/golden.json --dry-run --price-from report.json
 ```
 
-`--dry-run` spends nothing and runs every pre-flight a real pass runs: the database is this machine's, no part of the pipeline would answer with canned data, and every golden row parses — each rejected row printed with its reason. It then says how many runs would execute, and with `--price-from <report.json>` prices them from what an earlier pass actually cost per run rather than from a guess. Without that flag it prints the count alone; no earlier pass, no price.
+`--dry-run` spends nothing and runs every pre-flight a real pass runs: the database is this machine's, no part of the pipeline would answer with canned data, every golden row parses — each rejected row printed with its reason — and this machine can reach each vendor a pass would go to. It then says how many runs would execute, and with `--price-from <report.json>` prices them from what an earlier pass actually cost per run rather than from a guess. Without that flag it prints the count alone; no earlier pass, no price.
 
 The pass refuses outright if a part it measures through would answer with canned data (a stub), so a mistyped vendor stops in seconds instead of running for hours and reporting a 100% empty rate. A part set to `none` is not refused — that is switched off, which is a deliberate setting and reads honestly in the result.
 
-Even so, run a one-row golden with `--runs 1` (a few cents) before the full set: the guards prove the routing resolves, not that a key is live or that a provider will answer from this network.
+The reachability line is about the connection and nothing else. It sends no key, so a vendor that turns the check away still counts as reached — being turned away proves the request arrived — and a vendor reported as unreachable is one this machine could not get to at all, which is a VPN, a proxy or a DNS filter rather than anything about a key. `pnpm cli doctor` reports the same thing outside a pass, and `pnpm cli research probe-config` is what says whether a key still works. Reaching a vendor's host does not prove the endpoint a run calls will answer, or that the account behind the key has allowance left.
+
+Even so, run a one-row golden with `--runs 1` (a few cents) before the full set: the guards prove the routing resolves and the vendors are reachable, not that a key is live.
 
 ## The golden file
 

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -219,3 +219,9 @@ export {
 	type ResolvedCapability,
 	resolvedCapabilityVendors,
 } from './infrastructure/providers-live'
+// ── Infrastructure (vendor reachability) ──────────────────────────────────
+export {
+	hostOf,
+	probeReachability,
+	researchProviderEndpoints,
+} from './infrastructure/reachability'

--- a/packages/research/src/infrastructure/llm-live.test.ts
+++ b/packages/research/src/infrastructure/llm-live.test.ts
@@ -5,6 +5,7 @@ import type { LlmTier } from './cached-llm'
 import {
 	type ConfiguredSlot,
 	configuredSlots,
+	configuredSlotsIfSet,
 	resolvedTierVendors,
 } from './llm-live'
 
@@ -192,6 +193,63 @@ describe('which vendor a tier would really answer with', () => {
 			// call reaches; a list that merely mentions a real vendor runs on canned
 			// answers all the same
 			expect(tiers[0]).toEqual({ tier: 'agent', vendor: 'stub' })
+		})
+	})
+})
+
+describe('what silence in a tier’s settings means to each reader', () => {
+	const readIfSet = (env: Record<string, string>, tier: LlmTier) =>
+		Effect.runPromiseExit(
+			configuredSlotsIfSet(tier).pipe(
+				Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))),
+			),
+		)
+
+	describe('when a check needs the models a run uses', () => {
+		it('should stop and name the setting, since a tier a run needs is a fault', async () => {
+			// GIVEN the writer tier left unset while the other two are configured
+			const exit = await read({
+				RESEARCH_LLM_AGENT_PROVIDERS: 'stub',
+				RESEARCH_LLM_EXTRACT_PROVIDERS: 'stub',
+			})
+
+			// WHEN read through the strict reader — THEN it says which setting is
+			// missing, so a check that calls the models cannot go quiet on a machine
+			// whose settings somebody half-wrote
+			expect(reasonOf(exit)).toContain('RESEARCH_LLM_WRITER_PROVIDERS')
+		})
+	})
+
+	describe('when a check only reports on what is configured', () => {
+		it('should come back empty rather than stopping', async () => {
+			// GIVEN nothing said about the writer tier
+			const exit = await readIfSet({}, 'writer')
+
+			// WHEN read through the reporting reader — THEN silence means the tier
+			// reaches no vendor, so a tier nobody set cannot hide the tiers beside it
+			expect(Exit.isSuccess(exit)).toBe(true)
+			if (Exit.isSuccess(exit)) expect(exit.value).toEqual([])
+		})
+
+		it('should still stop when the setting was written and will not read', async () => {
+			// GIVEN a mistyped vendor name — the setting exists and is wrong
+			const exit = await readIfSet(
+				{ RESEARCH_LLM_AGENT_PROVIDERS: 'grok' },
+				'agent',
+			)
+
+			// WHEN read — THEN a typo is a fault rather than silence, which is what
+			// keeps "you never set this" apart from "what you set is wrong"
+			expect(reasonOf(exit)).toContain('RESEARCH_LLM_AGENT_PROVIDERS')
+		})
+
+		it('should list the models when the tier is set', async () => {
+			// GIVEN a tier on a real vendor
+			const exit = await readIfSet(AGENT_ON_GROQ, 'agent')
+
+			// WHEN read — THEN it answers with the same slots the strict reader gives
+			expect(Exit.isSuccess(exit)).toBe(true)
+			if (Exit.isSuccess(exit)) expect(exit.value).toHaveLength(1)
 		})
 	})
 })

--- a/packages/research/src/infrastructure/llm-live.ts
+++ b/packages/research/src/infrastructure/llm-live.ts
@@ -29,7 +29,14 @@
  */
 
 import { OpenAiClient, OpenAiLanguageModel } from '@effect/ai-openai-compat'
-import { Config, type Context, type Duration, Effect, Layer } from 'effect'
+import {
+	Config,
+	type Context,
+	type Duration,
+	Effect,
+	Layer,
+	Option,
+} from 'effect'
 import type { LanguageModel } from 'effect/unstable/ai'
 import { FetchHttpClient } from 'effect/unstable/http'
 
@@ -78,24 +85,16 @@ export interface ConfiguredSlot {
 	readonly apiKeyEnv: string
 }
 
-/**
- * Every model the settings point a tier at.
- *
- * Read the same way a run reads them, so anything checking the settings is
- * looking at what a run would really use. Working this out separately would be
- * a second reading of the same settings, free to drift from the first and
- * report on models nothing runs.
- *
- * Stubbed tiers are left out: they reach no vendor, so there is nothing to ask.
- */
-const LLM_TIERS: ReadonlyArray<{
-	readonly envPrefix: string
-	readonly tier: LlmTier
-}> = [
-	{ envPrefix: 'RESEARCH_LLM_AGENT', tier: 'agent' },
-	{ envPrefix: 'RESEARCH_LLM_EXTRACT', tier: 'extract' },
-	{ envPrefix: 'RESEARCH_LLM_WRITER', tier: 'writer' },
-]
+// Where each tier's settings live, written in the order a run goes through the
+// tiers, because `LLM_TIERS` below takes its order from this table.
+const TIER_ENV_PREFIX: Record<LlmTier, string> = {
+	agent: 'RESEARCH_LLM_AGENT',
+	extract: 'RESEARCH_LLM_EXTRACT',
+	writer: 'RESEARCH_LLM_WRITER',
+}
+
+/** Every model tier, in the order a run goes through them. */
+export const LLM_TIERS = Object.keys(TIER_ENV_PREFIX) as ReadonlyArray<LlmTier>
 
 /** A tier, and the vendor that would really answer for it. */
 export interface ResolvedTier {
@@ -103,6 +102,14 @@ export interface ResolvedTier {
 	/** `stub` means canned answers: nothing live is behind this tier. */
 	readonly vendor: LlmVendor
 }
+
+// The tiers a caller asked about, in the order a run goes through them and each
+// named once: taking the caller's array as it came would read a tier twice when
+// it was named twice, and would let the order somebody happened to type decide
+// the order a refusal names them in.
+const tiersInRunOrder = (
+	tiers: ReadonlyArray<LlmTier>,
+): ReadonlyArray<LlmTier> => LLM_TIERS.filter(tier => tiers.includes(tier))
 
 /**
  * The vendor each tier would really answer with, read the same way the layer that
@@ -113,61 +120,105 @@ export interface ResolvedTier {
  * of the vendor names, which live in one tuple here on purpose.
  */
 export const resolvedTierVendors = (
-	tiers: ReadonlyArray<LlmTier> = LLM_TIERS.map(entry => entry.tier),
+	tiers: ReadonlyArray<LlmTier> = LLM_TIERS,
 ): Effect.Effect<ReadonlyArray<ResolvedTier>, Config.ConfigError> =>
-	Effect.forEach(
-		LLM_TIERS.filter(entry => tiers.includes(entry.tier)),
-		({ envPrefix, tier }) =>
-			providerListConfig(LLM_VENDORS, `${envPrefix}_PROVIDERS`).pipe(
-				Effect.map(vendors => ({ tier, vendor: vendors[0] })),
-			),
+	Effect.forEach(tiersInRunOrder(tiers), tier =>
+		providerListConfig(LLM_VENDORS, `${TIER_ENV_PREFIX[tier]}_PROVIDERS`).pipe(
+			Effect.map(vendors => ({ tier, vendor: vendors[0] })),
+		),
 	)
 
-export const configuredSlots = (
-	tiers: ReadonlyArray<{
-		readonly envPrefix: string
-		readonly tier: LlmTier
-	}> = LLM_TIERS,
+/** Every vendor a tier is pointed at, first choice first — never empty. */
+type NonEmptyVendorList = ReadonlyArray<LlmVendor> & { readonly 0: LlmVendor }
+
+// The models behind a tier's vendor list, once that list is in hand. It sits
+// apart from reading the list so the two readers below differ on what silence
+// means and on nothing else.
+const slotsForVendors = (
+	tier: LlmTier,
+	vendors: NonEmptyVendorList,
 ): Effect.Effect<ReadonlyArray<ConfiguredSlot>, Config.ConfigError> =>
-	Effect.forEach(tiers, ({ envPrefix, tier }) =>
-		Effect.gen(function* () {
-			const vendors = yield* providerListConfig(
-				LLM_VENDORS,
-				`${envPrefix}_PROVIDERS`,
-			)
-			// A tier whose first choice is the stub runs wholly on the stub, and the
-			// layer that builds it decides that on the first choice alone and never
-			// asks for a model. Asking here would fail a tier nobody gave a model to
-			// precisely because it was never going to need one.
-			if (vendors[0] === 'stub') return []
-			const model = yield* Config.string(`${envPrefix}_MODEL`)
-			return yield* Effect.forEach(vendors, (vendor, i) =>
-				Effect.gen(function* () {
-					if (vendor === 'stub') return []
-					const slotModel =
-						i === 0
-							? model
-							: yield* Config.string(keyForSlot(`${envPrefix}_MODEL`, i)).pipe(
-									Config.withDefault(model),
-								)
-					const baseUrl =
-						vendor === 'custom'
-							? yield* Config.string(keyForSlot(`${envPrefix}_BASE_URL`, i))
-							: LLM_BASE_URLS[vendor]
-					return [
-						{
-							tier,
-							slot: i + 1,
-							vendor,
-							model: slotModel,
-							baseUrl,
-							apiKeyEnv: keyForSlot(`${envPrefix}_API_KEY`, i),
-						} satisfies ConfiguredSlot,
-					]
-				}),
-			).pipe(Effect.map(nested => nested.flat()))
-		}),
+	Effect.gen(function* () {
+		const envPrefix = TIER_ENV_PREFIX[tier]
+		// A tier whose first choice is the stub runs wholly on the stub, and the
+		// layer that builds it decides that on the first choice alone and never
+		// asks for a model. Asking here would fail a tier nobody gave a model to
+		// precisely because it was never going to need one.
+		if (vendors[0] === 'stub') return []
+		const model = yield* Config.string(`${envPrefix}_MODEL`)
+		return yield* Effect.forEach(vendors, (vendor, i) =>
+			Effect.gen(function* () {
+				if (vendor === 'stub') return []
+				const slotModel =
+					i === 0
+						? model
+						: yield* Config.string(keyForSlot(`${envPrefix}_MODEL`, i)).pipe(
+								Config.withDefault(model),
+							)
+				const baseUrl =
+					vendor === 'custom'
+						? yield* Config.string(keyForSlot(`${envPrefix}_BASE_URL`, i))
+						: LLM_BASE_URLS[vendor]
+				return [
+					{
+						tier,
+						slot: i + 1,
+						vendor,
+						model: slotModel,
+						baseUrl,
+						apiKeyEnv: keyForSlot(`${envPrefix}_API_KEY`, i),
+					} satisfies ConfiguredSlot,
+				]
+			}),
+		).pipe(Effect.map(nested => nested.flat()))
+	})
+
+/**
+ * Every model the settings point a tier at.
+ *
+ * Read the same way a run reads them, so anything checking the settings is
+ * looking at what a run would really use. Working this out separately would be
+ * a second reading of the same settings, free to drift from the first and
+ * report on models nothing runs.
+ *
+ * Stubbed tiers are left out: they reach no vendor, so there is nothing to ask.
+ * A tier nobody named a vendor for stops the read instead, since a tier a run
+ * needs and nobody set is a fault.
+ */
+export const configuredSlots = (
+	tiers: ReadonlyArray<LlmTier> = LLM_TIERS,
+): Effect.Effect<ReadonlyArray<ConfiguredSlot>, Config.ConfigError> =>
+	Effect.forEach(tiersInRunOrder(tiers), tier =>
+		providerListConfig(LLM_VENDORS, `${TIER_ENV_PREFIX[tier]}_PROVIDERS`).pipe(
+			Effect.flatMap(vendors => slotsForVendors(tier, vendors)),
+		),
 	).pipe(Effect.map(nested => nested.flat()))
+
+/**
+ * `configuredSlots` for one tier, except that a tier nobody named a vendor for
+ * comes back empty instead of stopping the read.
+ *
+ * The two callers want opposite things from silence. A check of the models a run
+ * uses has to say which setting is missing, because a tier a run needs and
+ * nobody set is a fault. A check that only reports on what is configured has to
+ * carry on, because a tier nobody set reaches no vendor — and reading them all
+ * through the strict one would let a single unset tier hide the tiers beside it.
+ *
+ * Empty covers both ways a tier reaches nothing, the unset one and the stubbed
+ * one, because a caller that only reports has no use for the difference.
+ */
+export const configuredSlotsIfSet = (
+	tier: LlmTier,
+): Effect.Effect<ReadonlyArray<ConfiguredSlot>, Config.ConfigError> =>
+	Config.option(
+		providerListConfig(LLM_VENDORS, `${TIER_ENV_PREFIX[tier]}_PROVIDERS`),
+	).pipe(
+		Effect.flatMap(configured =>
+			Option.isNone(configured)
+				? Effect.succeed<ReadonlyArray<ConfiguredSlot>>([])
+				: slotsForVendors(tier, configured.value),
+		),
+	)
 
 // How long one model call may take before it is given up on, per tier. The
 // models these tiers run routinely think for the better part of a minute, so a

--- a/packages/research/src/infrastructure/providers-live.test.ts
+++ b/packages/research/src/infrastructure/providers-live.test.ts
@@ -3,9 +3,14 @@ import { FetchHttpClient } from 'effect/unstable/http'
 import { describe, expect, it } from 'vitest'
 
 import { EnrichmentChain, RegistryRouter } from '../application/ports'
+import type { RegistryCountry } from '../domain/country'
 import { NoRegistry, ProviderError } from '../domain/errors'
 import {
+	type CapabilityEndpoint,
+	configuredCapabilityEndpoints,
+	configuredRegistryEndpoints,
 	enrichmentLayer,
+	type RegistryEndpoint,
 	type ResearchCapability,
 	type ResolvedCapability,
 	registryLayer,
@@ -257,6 +262,205 @@ describe('which vendor a capability would really answer with', () => {
 			// about and the caller never reaches
 			expect(Exit.isSuccess(exit)).toBe(true)
 			expect(vendorOf(exit, 'enrich')).toBe('hunter')
+		})
+	})
+})
+
+describe('where the vendors a capability is pointed at answer', () => {
+	const readEndpoints = (
+		env: Record<string, string>,
+		only?: ReadonlyArray<ResearchCapability>,
+	) =>
+		Effect.runPromiseExit(
+			configuredCapabilityEndpoints(only).pipe(
+				Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))),
+			),
+		)
+
+	const endpointsOf = (
+		exit: Exit.Exit<ReadonlyArray<CapabilityEndpoint>, unknown>,
+	): ReadonlyArray<CapabilityEndpoint> =>
+		Exit.isSuccess(exit) ? exit.value : []
+
+	const LIVE = {
+		RESEARCH_PROVIDER_SEARCH: 'brave',
+		RESEARCH_PROVIDER_SCRAPE: 'firecrawl',
+	}
+
+	describe('when a capability names a real vendor', () => {
+		it('should give the host it answers on, without the API path', async () => {
+			// GIVEN search and scrape pointed at real vendors
+			// WHEN read
+			expect(endpointsOf(await readEndpoints(LIVE))).toEqual([
+				{
+					capability: 'search',
+					slot: 1,
+					vendor: 'brave',
+					origin: 'https://api.search.brave.com',
+				},
+				{
+					capability: 'scrape',
+					slot: 1,
+					vendor: 'firecrawl',
+					origin: 'https://api.firecrawl.dev',
+				},
+			])
+		})
+	})
+
+	describe('when a capability falls back to a second vendor', () => {
+		it('should give both, numbered by the order a call reaches them', async () => {
+			// GIVEN a search cascade of two vendors
+			const found = endpointsOf(
+				await readEndpoints(
+					{ ...LIVE, RESEARCH_PROVIDER_SEARCH: 'firecrawl,brave-context' },
+					['search'],
+				),
+			)
+
+			// WHEN read — THEN the fallback is there too, since a blocked second
+			// vendor stays hidden until the first one is already struggling
+			expect(found.map(entry => [entry.slot, entry.origin])).toEqual([
+				[1, 'https://api.firecrawl.dev'],
+				[2, 'https://api.search.brave.com'],
+			])
+		})
+	})
+
+	describe('when a capability answers from canned data or is switched off', () => {
+		it('should give nothing for it, since it reaches no vendor', async () => {
+			// GIVEN search stubbed and everything with a default left unset
+			const found = endpointsOf(
+				await readEndpoints({
+					RESEARCH_PROVIDER_SEARCH: 'stub',
+					RESEARCH_PROVIDER_SCRAPE: 'firecrawl',
+				}),
+			)
+
+			// WHEN read — THEN only the vendor that would really be called is there;
+			// nothing is probed on behalf of canned data or an off switch
+			expect(found.map(entry => entry.capability)).toEqual(['scrape'])
+		})
+
+		it('should skip a canned first choice and still give the vendor behind it', async () => {
+			// GIVEN a stub ahead of a real vendor
+			const found = endpointsOf(
+				await readEndpoints(
+					{ ...LIVE, RESEARCH_PROVIDER_SCRAPE: 'stub,firecrawl' },
+					['scrape'],
+				),
+			)
+
+			// WHEN read — THEN the stub contributes nothing and the real vendor keeps
+			// the slot number it occupies in the setting
+			expect(found).toEqual([
+				{
+					capability: 'scrape',
+					slot: 2,
+					vendor: 'firecrawl',
+					origin: 'https://api.firecrawl.dev',
+				},
+			])
+		})
+	})
+
+	describe('when a capability was never set at all', () => {
+		it('should give nothing for it rather than failing', async () => {
+			// GIVEN nothing said about search, which carries no default. Unlike
+			// reading its vendor — which guards a run and must refuse — this only
+			// ever reports, and a setting nobody wrote reaches nothing
+			const found = endpointsOf(
+				await readEndpoints({ RESEARCH_PROVIDER_SCRAPE: 'firecrawl' }),
+			)
+
+			// WHEN read — THEN scrape still answers, instead of being lost with it
+			expect(found.map(entry => entry.capability)).toEqual(['scrape'])
+		})
+	})
+
+	describe('when a capability was set to something that will not read', () => {
+		it('should fail naming the setting, so a typo is not read as unset', async () => {
+			// GIVEN a mistyped vendor name — the setting exists and is wrong, which
+			// is a fault rather than a machine nobody configured
+			const exit = await readEndpoints({
+				RESEARCH_PROVIDER_SEARCH: 'firecrwal',
+				RESEARCH_PROVIDER_SCRAPE: 'firecrawl',
+			})
+
+			// WHEN read — THEN it says which setting is at fault
+			expect(Exit.isFailure(exit)).toBe(true)
+			if (Exit.isFailure(exit)) {
+				expect(Cause.pretty(exit.cause)).toContain('RESEARCH_PROVIDER_SEARCH')
+			}
+		})
+	})
+})
+
+describe('where the company register a country is pointed at answers', () => {
+	const readRegistries = (
+		env: Record<string, string>,
+		only?: ReadonlyArray<RegistryCountry>,
+	) =>
+		Effect.runPromiseExit(
+			configuredRegistryEndpoints(only).pipe(
+				Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))),
+			),
+		)
+
+	const registriesOf = (
+		exit: Exit.Exit<ReadonlyArray<RegistryEndpoint>, unknown>,
+	): ReadonlyArray<RegistryEndpoint> => (Exit.isSuccess(exit) ? exit.value : [])
+
+	describe('when countries name real registers', () => {
+		it('should give each one its host, since a country can be blocked alone', async () => {
+			// GIVEN both countries pointed at their national register
+			const found = registriesOf(
+				await readRegistries({
+					RESEARCH_PROVIDER_REGISTRY_ES: 'librebor',
+					RESEARCH_PROVIDER_REGISTRY_GB: 'companies-house',
+				}),
+			)
+
+			// WHEN read — THEN both are there, so reaching the Spanish one says
+			// nothing about the British one
+			expect(found.map(entry => [entry.country, entry.origin])).toEqual([
+				['ES', 'https://api.librebor.me'],
+				['GB', 'https://api.company-information.service.gov.uk'],
+			])
+		})
+	})
+
+	describe('when a country is switched off, stubbed or never set', () => {
+		it('should give nothing for it', async () => {
+			// GIVEN Spain switched off and Britain on canned data
+			const found = registriesOf(
+				await readRegistries({
+					RESEARCH_PROVIDER_REGISTRY_ES: 'none',
+					RESEARCH_PROVIDER_REGISTRY_GB: 'stub',
+				}),
+			)
+
+			// WHEN read — THEN neither reaches a register, so neither is asked about
+			expect(found).toEqual([])
+			// AND a country nobody set at all is the same, rather than a failure
+			expect(registriesOf(await readRegistries({}))).toEqual([])
+		})
+	})
+
+	describe('when a country was set to something that will not read', () => {
+		it('should fail naming the setting, so a typo is not read as switched off', async () => {
+			// GIVEN a mistyped register name for Spain
+			const exit = await readRegistries({
+				RESEARCH_PROVIDER_REGISTRY_ES: 'libreborme',
+			})
+
+			// WHEN read — THEN it says which setting is at fault
+			expect(Exit.isFailure(exit)).toBe(true)
+			if (Exit.isFailure(exit)) {
+				expect(Cause.pretty(exit.cause)).toContain(
+					'RESEARCH_PROVIDER_REGISTRY_ES',
+				)
+			}
 		})
 	})
 })

--- a/packages/research/src/infrastructure/providers-live.ts
+++ b/packages/research/src/infrastructure/providers-live.ts
@@ -123,31 +123,31 @@ export interface ResolvedCapability {
 	readonly vendor: CapabilityVendor
 }
 
-// Search and scrape carry no default, so an unset one stops the boot naming
-// itself. The rest default to off, exactly as their own layers do.
-const CAPABILITY_READERS: Record<
-	ResearchCapability,
-	Effect.Effect<CapabilityVendor, Config.ConfigError>
-> = {
-	search: providerListConfig(SEARCH_VENDORS, 'RESEARCH_PROVIDER_SEARCH').pipe(
-		Effect.map(vendors => vendors[0]),
-	),
-	scrape: providerListConfig(SCRAPE_VENDORS, 'RESEARCH_PROVIDER_SCRAPE').pipe(
-		Effect.map(vendors => vendors[0]),
-	),
-	map: providerListConfig(MAP_VENDORS, 'RESEARCH_PROVIDER_MAP', ['none']).pipe(
-		Effect.map(vendors => vendors[0]),
-	),
-	enrich: providerListConfig(ENRICH_VENDORS, 'RESEARCH_PROVIDER_ENRICH', [
-		'none',
-	]).pipe(Effect.map(vendors => vendors[0])),
-	verify: providerListConfig(VERIFY_VENDORS, 'RESEARCH_PROVIDER_VERIFY', [
-		'none',
-	]).pipe(Effect.map(vendors => vendors[0])),
+/** Every vendor a capability is pointed at, first choice first — never empty. */
+type VendorList = ReadonlyArray<CapabilityVendor> & {
+	readonly 0: CapabilityVendor
 }
 
-const EVERY_CAPABILITY = Object.keys(
-	CAPABILITY_READERS,
+// Search and scrape carry no default, so an unset one stops the boot naming
+// itself. The rest default to off, exactly as their own layers do.
+const CAPABILITY_LISTS: Record<
+	ResearchCapability,
+	Config.Config<VendorList>
+> = {
+	search: providerListConfig(SEARCH_VENDORS, 'RESEARCH_PROVIDER_SEARCH'),
+	scrape: providerListConfig(SCRAPE_VENDORS, 'RESEARCH_PROVIDER_SCRAPE'),
+	map: providerListConfig(MAP_VENDORS, 'RESEARCH_PROVIDER_MAP', ['none']),
+	enrich: providerListConfig(ENRICH_VENDORS, 'RESEARCH_PROVIDER_ENRICH', [
+		'none',
+	]),
+	verify: providerListConfig(VERIFY_VENDORS, 'RESEARCH_PROVIDER_VERIFY', [
+		'none',
+	]),
+}
+
+/** Every capability, in the order a caller reading all of them gets them. */
+export const RESEARCH_CAPABILITIES = Object.keys(
+	CAPABILITY_LISTS,
 ) as ReadonlyArray<ResearchCapability>
 
 /**
@@ -163,13 +163,133 @@ const EVERY_CAPABILITY = Object.keys(
  * which is where a new provider is added.
  */
 export const resolvedCapabilityVendors = (
-	capabilities: ReadonlyArray<ResearchCapability> = EVERY_CAPABILITY,
+	capabilities: ReadonlyArray<ResearchCapability> = RESEARCH_CAPABILITIES,
 ): Effect.Effect<ReadonlyArray<ResolvedCapability>, Config.ConfigError> =>
 	Effect.forEach(capabilities, capability =>
-		CAPABILITY_READERS[capability].pipe(
-			Effect.map(vendor => ({ capability, vendor })),
+		CAPABILITY_LISTS[capability].pipe(
+			Effect.map(vendors => ({ capability, vendor: vendors[0] })),
 		),
 	)
+
+// ── Where each vendor answers ──
+
+/** A vendor that reaches the network, so there is a host to ask about. */
+type ReachableVendor = Exclude<CapabilityVendor, 'stub' | 'none' | 'local'>
+
+// Scheme and host only, because a connection check can honestly claim no more
+// than that the host was reached. Every vendor that goes to the network needs a
+// row here, and the `satisfies` is what makes a new one say where it answers.
+// The three left out reach nothing: two answer from canned data or not at all,
+// and the local page fetcher is not written yet.
+const VENDOR_ORIGINS: Partial<Record<CapabilityVendor, string>> = {
+	brave: 'https://api.search.brave.com',
+	'brave-context': 'https://api.search.brave.com',
+	firecrawl: 'https://api.firecrawl.dev',
+	hunter: 'https://api.hunter.io',
+	fullenrich: 'https://app.fullenrich.com',
+} satisfies Record<ReachableVendor, string>
+
+/** One vendor a capability is configured to reach, and where it answers. */
+export interface CapabilityEndpoint {
+	readonly capability: ResearchCapability
+	/** 1 for a capability's first choice, 2 for what it falls back to. */
+	readonly slot: number
+	readonly vendor: CapabilityVendor
+	/** Scheme and host of the vendor's API. */
+	readonly origin: string
+}
+
+/**
+ * Where every vendor the capability settings name would answer, first choice
+ * first — read from the same settings the layers read, so anything checking a
+ * connection is checking the vendors a run would really reach.
+ *
+ * Fallback slots count too, not just the first choice: a blocked second vendor
+ * only shows up once the first one is already having a bad day. A slot answered
+ * by canned data or switched off reaches nothing, so it is left out rather than
+ * reported with nowhere to go.
+ *
+ * A capability nobody set at all is treated the same way — it reaches nothing,
+ * so it contributes nothing. Only a setting that was written and will not read
+ * fails, which is what keeps "you never configured this" apart from "what you
+ * configured is wrong". Unlike `resolvedCapabilityVendors`, which guards a run
+ * and has to refuse a missing setting outright, this one only ever reports.
+ *
+ * Here rather than at the caller so the vendor names and their addresses stay
+ * together in this file, which is where a new provider is added.
+ */
+export const configuredCapabilityEndpoints = (
+	capabilities: ReadonlyArray<ResearchCapability> = RESEARCH_CAPABILITIES,
+): Effect.Effect<ReadonlyArray<CapabilityEndpoint>, Config.ConfigError> =>
+	Effect.forEach(capabilities, capability =>
+		Config.option(CAPABILITY_LISTS[capability]).pipe(
+			Effect.map(configured =>
+				Option.isNone(configured)
+					? []
+					: configured.value.flatMap((vendor, index) => {
+							const origin = VENDOR_ORIGINS[vendor]
+							return origin === undefined
+								? []
+								: [{ capability, slot: index + 1, vendor, origin }]
+						}),
+			),
+		),
+	).pipe(Effect.map(nested => nested.flat()))
+
+/** Every vendor name a country's register setting can resolve to. */
+type RegistryVendor =
+	(typeof REGISTRY_VENDORS_BY_COUNTRY)[RegistryCountry][number]
+
+// Same rule as the capability table above: a register that goes to the network
+// needs a row here, and the `satisfies` is what makes a new one say where it
+// answers. The paid company reports have no table at all, because the one
+// vendor there is not written yet and so reaches nothing.
+const REGISTRY_VENDOR_ORIGINS: Partial<Record<RegistryVendor, string>> = {
+	librebor: 'https://api.librebor.me',
+	'companies-house': 'https://api.company-information.service.gov.uk',
+} satisfies Record<Exclude<RegistryVendor, 'stub' | 'none'>, string>
+
+/** One company register a country is configured to reach, and where it answers. */
+export interface RegistryEndpoint {
+	readonly country: RegistryCountry
+	/** 1 for a country's first choice, 2 for what it falls back to. */
+	readonly slot: number
+	readonly vendor: RegistryVendor
+	/** Scheme and host of the register's API. */
+	readonly origin: string
+}
+
+/**
+ * Where the company register each country is pointed at would answer.
+ *
+ * Registers sit apart from the capabilities above because they are chosen per
+ * country rather than once for the pipeline, so a machine can reach the Spanish
+ * one and not the British one. Silence means the same as it does there: a
+ * country nobody set reaches nothing and contributes nothing, and only a setting
+ * that was written and will not read fails.
+ */
+export const configuredRegistryEndpoints = (
+	countries: ReadonlyArray<RegistryCountry> = REGISTRY_COUNTRIES,
+): Effect.Effect<ReadonlyArray<RegistryEndpoint>, Config.ConfigError> =>
+	Effect.forEach(countries, country =>
+		Config.option(
+			providerListConfig(
+				REGISTRY_VENDORS_BY_COUNTRY[country],
+				`RESEARCH_PROVIDER_REGISTRY_${country}`,
+			),
+		).pipe(
+			Effect.map(configured =>
+				Option.isNone(configured)
+					? []
+					: configured.value.flatMap((vendor, index) => {
+							const origin = REGISTRY_VENDOR_ORIGINS[vendor]
+							return origin === undefined
+								? []
+								: [{ country, slot: index + 1, vendor, origin }]
+						}),
+			),
+		),
+	).pipe(Effect.map(nested => nested.flat()))
 
 // ── What a provider slot charges ──
 

--- a/packages/research/src/infrastructure/reachability.test.ts
+++ b/packages/research/src/infrastructure/reachability.test.ts
@@ -1,0 +1,844 @@
+import { ConfigProvider, Effect, Exit, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
+import {
+	HttpClient,
+	HttpClientError,
+	type HttpClientRequest,
+	HttpClientResponse,
+} from 'effect/unstable/http'
+import { describe, expect, it } from 'vitest'
+
+import {
+	blockedReasonForCause,
+	originOf,
+	type ProviderEndpoint,
+	probeReachability,
+	type ReachabilityResult,
+	reachableDetail,
+	researchProviderEndpoints,
+	unreachableDetail,
+} from './reachability'
+
+// The shape `fetch` really produces when a connection never arrives: a bland
+// TypeError with the system code one link down. Taken from the errors a live
+// run against an unresolvable name, a closed port and an expired certificate
+// actually raised.
+const fetchFailure = (code: string, message: string): unknown => {
+	const inner = new Error(message)
+	Object.assign(inner, { code })
+	return new TypeError('fetch failed', { cause: inner })
+}
+
+const answeringClient = (
+	sent: HttpClientRequest.HttpClientRequest[],
+	status: number,
+): HttpClient.HttpClient =>
+	HttpClient.makeWith<
+		HttpClientError.HttpClientError,
+		never,
+		HttpClientError.HttpClientError,
+		never
+	>(
+		effect =>
+			Effect.flatMap(effect, request => {
+				sent.push(request)
+				return Effect.succeed(
+					HttpClientResponse.fromWeb(request, new Response(null, { status })),
+				)
+			}),
+		Effect.succeed,
+	)
+
+const failingClient = (
+	cause: unknown,
+	attempts: { count: number } = { count: 0 },
+): HttpClient.HttpClient =>
+	HttpClient.makeWith<
+		HttpClientError.HttpClientError,
+		never,
+		HttpClientError.HttpClientError,
+		never
+	>(
+		effect =>
+			Effect.flatMap(effect, request => {
+				attempts.count += 1
+				return Effect.fail(
+					new HttpClientError.HttpClientError({
+						reason: new HttpClientError.TransportError({ request, cause }),
+					}),
+				)
+			}),
+		Effect.succeed,
+	)
+
+const silentClient: HttpClient.HttpClient = HttpClient.makeWith<
+	HttpClientError.HttpClientError,
+	never,
+	HttpClientError.HttpClientError,
+	never
+>(effect => Effect.flatMap(effect, () => Effect.never), Effect.succeed)
+
+const GROQ: ProviderEndpoint = {
+	label: 'agent slot 1 (groq)',
+	origin: 'https://api.groq.com',
+}
+const BRAVE: ProviderEndpoint = {
+	label: 'search slot 1 (brave)',
+	origin: 'https://api.search.brave.com',
+}
+
+const probe = (
+	endpoints: ReadonlyArray<ProviderEndpoint>,
+	client: HttpClient.HttpClient,
+): Promise<ReadonlyArray<ReachabilityResult>> =>
+	Effect.runPromise(
+		probeReachability(endpoints).pipe(
+			Effect.provideService(HttpClient.HttpClient, client),
+		),
+	)
+
+const resultFor = (
+	results: ReadonlyArray<ReachabilityResult>,
+	origin: string,
+): ReachabilityResult | undefined =>
+	results.find(result => result.origin === origin)
+
+describe('what kept a request from arriving', () => {
+	describe('when the vendor name does not resolve', () => {
+		it('should read as a name lookup, the shape a VPN or DNS filter leaves', () => {
+			// GIVEN the error a lookup that found nothing raises
+			// WHEN read
+			// THEN the operator is pointed at name resolution
+			expect(
+				blockedReasonForCause(
+					fetchFailure('ENOTFOUND', 'getaddrinfo ENOTFOUND api.groq.com'),
+				),
+			).toBe('dns')
+		})
+	})
+
+	describe('when nothing is listening', () => {
+		it('should read as a refused connection', () => {
+			// GIVEN a closed port
+			expect(
+				blockedReasonForCause(
+					fetchFailure('ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:54321'),
+				),
+			).toBe('refused')
+		})
+	})
+
+	describe('when the secure connection could not be set up', () => {
+		it('should read as a handshake, which is what a proxy opening traffic leaves', () => {
+			// GIVEN the certificate a company proxy substitutes for the vendor's
+			expect(
+				blockedReasonForCause(
+					fetchFailure(
+						'SELF_SIGNED_CERT_IN_CHAIN',
+						'self-signed certificate in certificate chain',
+					),
+				),
+			).toBe('tls')
+		})
+	})
+
+	describe('when the transport itself gave up waiting', () => {
+		it('should read as a timeout', () => {
+			// GIVEN a connection that never completed
+			expect(
+				blockedReasonForCause(
+					fetchFailure('UND_ERR_CONNECT_TIMEOUT', 'Connect Timeout Error'),
+				),
+			).toBe('timeout')
+		})
+	})
+
+	describe('when the code is only in the wording', () => {
+		it('should still read it, since not every transport sets a code', () => {
+			// GIVEN an error carrying the reason in its text alone
+			// WHEN read — THEN the text is enough
+			expect(
+				blockedReasonForCause(new Error('read ECONNRESET from the socket')),
+			).toBe('refused')
+		})
+	})
+
+	describe('when nothing about the error is recognisable', () => {
+		it('should say so rather than guess', () => {
+			// GIVEN an error that names no known cause
+			// THEN it is reported as unknown, which still reads as unreachable
+			expect(blockedReasonForCause(new Error('something went wrong'))).toBe(
+				'unknown',
+			)
+		})
+
+		it('should hold up when the error is not an object at all', () => {
+			// GIVEN a thrown string, and nothing thrown
+			expect(blockedReasonForCause('boom')).toBe('unknown')
+			expect(blockedReasonForCause(null)).toBe('unknown')
+			expect(blockedReasonForCause(undefined)).toBe('unknown')
+		})
+	})
+
+	describe('when an error blames itself', () => {
+		it('should stop walking rather than hang', () => {
+			// GIVEN a chain that points back at its own start
+			const looping = new Error('outer')
+			const inner = new Error('inner', { cause: looping })
+			Object.assign(looping, { cause: inner })
+
+			// WHEN read — THEN it finishes, reporting what it could tell
+			expect(blockedReasonForCause(looping)).toBe('unknown')
+		})
+	})
+
+	describe('when the reason is buried several links down', () => {
+		it('should find it', () => {
+			// GIVEN a wrapper around a wrapper around the system error
+			const system = Object.assign(new Error('connect ETIMEDOUT'), {
+				code: 'ETIMEDOUT',
+			})
+			const middle = new Error('socket hang up', { cause: system })
+
+			// WHEN read — THEN the innermost reason decides
+			expect(
+				blockedReasonForCause(new TypeError('fetch failed', { cause: middle })),
+			).toBe('timeout')
+		})
+	})
+})
+
+describe('the address a vendor is asked about', () => {
+	describe('when the setting carries an API path', () => {
+		it('should keep the scheme and host and drop the path', () => {
+			// GIVEN a model vendor's base URL
+			// WHEN reduced to what a reachability check can honestly claim
+			// THEN only the host is left, so nothing implies the API path was tried
+			expect(originOf('https://api.groq.com/openai/v1')).toBe(
+				'https://api.groq.com',
+			)
+		})
+	})
+
+	describe('when the setting carries a port', () => {
+		it('should keep it, since a blocked port is a different address', () => {
+			expect(originOf('https://gateway.internal:8443/v1')).toBe(
+				'https://gateway.internal:8443',
+			)
+		})
+	})
+
+	describe('when the setting is not an address at all', () => {
+		it('should give nothing back rather than invent one', () => {
+			// GIVEN a mistyped base URL
+			// THEN there is no host to ask about, so nothing is probed for it
+			expect(originOf('not a url')).toBeUndefined()
+			expect(originOf('')).toBeUndefined()
+		})
+	})
+})
+
+describe('how an answer is put to the operator', () => {
+	describe('when the vendor turned the key-less probe away', () => {
+		it('should call it reachable and rule the key out in the same breath', () => {
+			// GIVEN the one answer somebody could misread as their key being wrong
+			const detail = reachableDetail('https://api.groq.com', 401)
+
+			// WHEN read
+			// THEN it says the connection got there
+			expect(detail).toContain('reachable')
+			// AND it says the probe carried no key, so the refusal was expected
+			expect(detail).toContain('no key')
+			// AND it says outright that the key is not what this reports on
+			expect(detail).toContain('says nothing about whether your key works')
+		})
+
+		it('should say the same for a forbidden answer', () => {
+			// GIVEN 403, the other answer a key-less request draws
+			expect(reachableDetail('https://api.groq.com', 403)).toContain(
+				'says nothing about whether your key works',
+			)
+		})
+	})
+
+	describe('when the vendor answered anything else', () => {
+		it('should just report the answer', () => {
+			// GIVEN an ordinary answer — no key to rule out, so nothing to explain
+			const detail = reachableDetail('https://api.groq.com', 404)
+			expect(detail).toContain('reachable')
+			expect(detail).toContain('404')
+			expect(detail).not.toContain('key')
+		})
+	})
+
+	describe('when nothing answered', () => {
+		it('should blame the connection and rule the key out', () => {
+			// GIVEN a name that would not resolve
+			const detail = unreachableDetail('https://api.groq.com', 'dns')
+
+			// WHEN read
+			// THEN it names the host and what happened to it
+			expect(detail).toContain('cannot be reached from this machine')
+			expect(detail).toContain('api.groq.com')
+			// AND it names the connection as the thing to go and fix
+			expect(detail).toContain('your connection')
+			expect(detail).toContain('VPN')
+			// AND it forecloses the other reading rather than leaving it open
+			expect(detail).toContain('not your key')
+		})
+	})
+})
+
+describe('asking whether this machine can reach a vendor', () => {
+	describe('when a vendor turns away a request carrying no key', () => {
+		it('should report it reachable — being turned away proves arrival', async () => {
+			// GIVEN a vendor that answers 401 to anything without a key
+			const results = await probe([GROQ], answeringClient([], 401))
+
+			// WHEN asked
+			// THEN the connection is reported as working, and the answer is kept
+			expect(results[0]?.verdict).toBe('reachable')
+			expect(results[0]?.status).toBe(401)
+			expect(results[0]?.blockedReason).toBeUndefined()
+		})
+	})
+
+	describe('when a rejected key and a blocked connection are both in play', () => {
+		it('should tell them apart, since they have nothing in common to fix', async () => {
+			// GIVEN one vendor that refuses a key-less request and one this machine
+			// cannot get to at all — the two failures that look identical once a
+			// pass is under way
+			const refusing = await probe([GROQ], answeringClient([], 401))
+			const unreachable = await probe(
+				[BRAVE],
+				failingClient(fetchFailure('ENOTFOUND', 'getaddrinfo ENOTFOUND')),
+			)
+
+			// WHEN both are asked
+			// THEN the verdicts differ, so no reader has to interpret wording
+			expect(refusing[0]?.verdict).toBe('reachable')
+			expect(unreachable[0]?.verdict).toBe('unreachable')
+
+			// AND only the one that arrived carries an answer from the vendor
+			expect(refusing[0]?.status).toBe(401)
+			expect(unreachable[0]?.status).toBeUndefined()
+
+			// AND only the one that never arrived carries a reason to go and look at
+			expect(refusing[0]?.blockedReason).toBeUndefined()
+			expect(unreachable[0]?.blockedReason).toBe('dns')
+
+			// AND neither line can be read as the other: the refusal says the key is
+			// not what it reports on, and the blocked one rules the key out
+			expect(refusing[0]?.detail).toContain(
+				'says nothing about whether your key works',
+			)
+			expect(unreachable[0]?.detail).toContain('not your key')
+		})
+	})
+
+	describe('when the vendor is having a bad minute', () => {
+		it.each([
+			429, 500, 503,
+		])('should report reachable on %i — the connection still got there', async status => {
+			// GIVEN a vendor rate-limiting or falling over
+			const results = await probe([GROQ], answeringClient([], status))
+
+			// WHEN asked — THEN this check is about the connection, not the vendor's
+			// health, so an answer of any kind is an answer
+			expect(results[0]?.verdict).toBe('reachable')
+			expect(results[0]?.status).toBe(status)
+		})
+	})
+
+	describe('when the vendor answers with a redirect', () => {
+		it('should report reachable without chasing it somewhere else', async () => {
+			// GIVEN a host that redirects, which several real vendors do
+			const sent: HttpClientRequest.HttpClientRequest[] = []
+			const results = await probe([BRAVE], answeringClient(sent, 301))
+
+			// WHEN asked
+			// THEN the redirect is itself the proof the host answered
+			expect(results[0]?.verdict).toBe('reachable')
+			expect(results[0]?.status).toBe(301)
+			// AND it was asked once, so the verdict is about the host named and not
+			// about wherever the redirect points
+			expect(sent).toHaveLength(1)
+		})
+	})
+
+	describe('when something on this network answers in the vendor’s place', () => {
+		it.each([
+			407, 511,
+		])('should report unreachable on %i, not a vendor that answered', async status => {
+			// GIVEN a proxy or a sign-in portal intercepting the request
+			const results = await probe([GROQ], answeringClient([], status))
+
+			// WHEN asked
+			// THEN the request stopped short of the vendor, so a green here would
+			// be a green that is not one
+			expect(results[0]?.verdict).toBe('unreachable')
+			expect(results[0]?.blockedReason).toBe('proxy')
+			expect(results[0]?.status).toBeUndefined()
+		})
+	})
+
+	describe('when the connection is cut in different ways', () => {
+		it.each([
+			['ECONNREFUSED', 'refused'],
+			['CERT_HAS_EXPIRED', 'tls'],
+			['EHOSTUNREACH', 'refused'],
+		])('should carry %s through as %s', async (code, reason) => {
+			// GIVEN each of the shapes a blocked connection takes
+			const results = await probe(
+				[GROQ],
+				failingClient(fetchFailure(code, code)),
+			)
+
+			// WHEN asked — THEN the reason survives to the line the operator reads
+			expect(results[0]?.verdict).toBe('unreachable')
+			expect(results[0]?.blockedReason).toBe(reason)
+		})
+	})
+
+	describe('what the probe actually sends', () => {
+		it('should send a HEAD carrying no key, so there is nothing to bill', async () => {
+			// GIVEN a vendor about to be asked
+			const sent: HttpClientRequest.HttpClientRequest[] = []
+			await probe([GROQ], answeringClient(sent, 200))
+
+			// WHEN the request goes out
+			// THEN it asks for no body, so no page is transferred
+			expect(sent[0]?.method).toBe('HEAD')
+			// AND it carries no key, so there is no account for a vendor to charge
+			// and no answer that could be a verdict on one
+			expect(sent[0]?.headers['authorization']).toBeUndefined()
+			// AND it goes to the host, not to an API path
+			expect(sent[0]?.url).toBe('https://api.groq.com')
+		})
+	})
+
+	describe('when several parts of the pipeline share one vendor', () => {
+		it('should ask that host once and name every part that uses it', async () => {
+			// GIVEN all three model tiers pointed at the same vendor
+			const sent: HttpClientRequest.HttpClientRequest[] = []
+			const results = await probe(
+				[
+					GROQ,
+					{ label: 'extract slot 1 (groq)', origin: 'https://api.groq.com' },
+					{ label: 'writer slot 1 (groq)', origin: 'https://api.groq.com' },
+					BRAVE,
+				],
+				answeringClient(sent, 200),
+			)
+
+			// WHEN asked
+			// THEN each host is asked once rather than once per part
+			expect(sent).toHaveLength(2)
+			expect(results).toHaveLength(2)
+			// AND the one line for that host names everything behind it
+			expect(resultFor(results, 'https://api.groq.com')?.labels).toEqual([
+				'agent slot 1 (groq)',
+				'extract slot 1 (groq)',
+				'writer slot 1 (groq)',
+			])
+		})
+	})
+
+	describe('when nothing is pointed at a vendor', () => {
+		it('should ask nothing', async () => {
+			// GIVEN a machine whose research parts all answer from canned data
+			const sent: HttpClientRequest.HttpClientRequest[] = []
+			const results = await probe([], answeringClient(sent, 200))
+
+			// WHEN asked — THEN there is nothing to reach, so nothing is reached for
+			expect(results).toEqual([])
+			expect(sent).toEqual([])
+		})
+	})
+
+	describe('when a vendor never answers at all', () => {
+		it('should give up and report it unreachable rather than wait', async () => {
+			// GIVEN a host that accepts the connection and then says nothing —
+			// the shape a silent drop on a VPN takes
+			const exit = await Effect.runPromise(
+				Effect.gen(function* () {
+					const fiber = yield* Effect.forkChild(
+						probeReachability([GROQ]).pipe(
+							Effect.provideService(HttpClient.HttpClient, silentClient),
+						),
+					)
+					// Step the clock forward until the probe's patience runs out.
+					for (let elapsed = 0; elapsed < 30_000; elapsed += 500) {
+						if (fiber.pollUnsafe() !== undefined) break
+						yield* Effect.yieldNow
+						yield* TestClock.adjust('500 millis')
+					}
+					return yield* Fiber.await(fiber)
+				}).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+			)
+
+			// WHEN the wait is over
+			// THEN it is reported as unreachable, not left holding up the check
+			expect(Exit.isSuccess(exit)).toBe(true)
+			if (Exit.isSuccess(exit)) {
+				expect(exit.value[0]?.verdict).toBe('unreachable')
+				expect(exit.value[0]?.blockedReason).toBe('timeout')
+			}
+		})
+	})
+})
+
+describe('which vendor hosts a run would reach', () => {
+	const read = (env: Record<string, string>) =>
+		Effect.runPromise(
+			researchProviderEndpoints().pipe(
+				Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))),
+			),
+		)
+
+	const LIVE = {
+		RESEARCH_LLM_AGENT_PROVIDERS: 'groq',
+		RESEARCH_LLM_AGENT_MODEL: 'openai/gpt-oss-120b',
+		RESEARCH_LLM_EXTRACT_PROVIDERS: 'nebius',
+		RESEARCH_LLM_EXTRACT_MODEL: 'Qwen/Qwen3-32B',
+		RESEARCH_LLM_WRITER_PROVIDERS: 'stub',
+		RESEARCH_PROVIDER_SEARCH: 'brave',
+		RESEARCH_PROVIDER_SCRAPE: 'firecrawl',
+	}
+
+	const originsOf = (endpoints: {
+		readonly endpoints: ReadonlyArray<ProviderEndpoint>
+	}): string[] => endpoints.endpoints.map(endpoint => endpoint.origin)
+
+	describe('when the settings point at real vendors', () => {
+		it('should name every host, model tiers and providers alike', async () => {
+			// GIVEN a machine set up for a measuring pass
+			const found = await read(LIVE)
+
+			// WHEN read
+			// THEN each configured vendor's host is there to be asked about
+			expect(originsOf(found)).toEqual([
+				'https://api.groq.com',
+				'https://api.studio.nebius.ai',
+				'https://api.search.brave.com',
+				'https://api.firecrawl.dev',
+			])
+			expect(found.unreadable).toEqual([])
+		})
+
+		it('should label each host with the part that goes to it', async () => {
+			// GIVEN the same settings
+			const found = await read(LIVE)
+
+			// THEN the operator can see which part a blocked host would stop
+			expect(found.endpoints.map(endpoint => endpoint.label)).toContain(
+				'agent slot 1 (groq)',
+			)
+			expect(found.endpoints.map(endpoint => endpoint.label)).toContain(
+				'search slot 1 (brave)',
+			)
+		})
+	})
+
+	describe('when a part answers from canned data or is switched off', () => {
+		it('should leave it out rather than probe it', async () => {
+			// GIVEN search stubbed, site discovery off, and the writer tier stubbed
+			const found = await read({
+				...LIVE,
+				RESEARCH_PROVIDER_SEARCH: 'stub',
+				RESEARCH_PROVIDER_MAP: 'none',
+			})
+
+			// WHEN read — THEN none of them reaches a vendor, so none is asked about
+			expect(originsOf(found)).not.toContain('https://api.search.brave.com')
+			expect(
+				found.endpoints.every(endpoint => !endpoint.label.startsWith('search')),
+			).toBe(true)
+			expect(
+				found.endpoints.every(endpoint => !endpoint.label.startsWith('writer')),
+			).toBe(true)
+		})
+	})
+
+	describe('when a part falls back to a second vendor', () => {
+		it('should name that host too, since a blocked fallback hides until it is needed', async () => {
+			// GIVEN enrichment with a fallback behind it
+			const found = await read({
+				...LIVE,
+				RESEARCH_PROVIDER_ENRICH: 'hunter,fullenrich',
+			})
+
+			// WHEN read — THEN both are there, numbered so the operator knows which
+			// one a run reaches first
+			expect(originsOf(found)).toContain('https://api.hunter.io')
+			expect(originsOf(found)).toContain('https://app.fullenrich.com')
+			expect(found.endpoints.map(endpoint => endpoint.label)).toContain(
+				'enrich slot 2 (fullenrich)',
+			)
+		})
+	})
+
+	describe('when a machine was never set up for research at all', () => {
+		it('should come back empty rather than failing or complaining', async () => {
+			// GIVEN nothing configured — the normal state for somebody who never
+			// runs research, and one `doctor` must survive
+			const found = await read({})
+
+			// WHEN read
+			// THEN there is nothing to probe and nothing is at fault, so the check
+			// has nothing to say rather than something to warn about
+			expect(found.endpoints).toEqual([])
+			expect(found.unreadable).toEqual([])
+		})
+	})
+
+	describe('when only one part of the pipeline is configured', () => {
+		it('should still name that part’s host, not lose it with the unset ones', async () => {
+			// GIVEN enrichment alone, which is what a machine set up for contact
+			// discovery looks like: it is handed a domain and never searches, so
+			// search and scrape are left unset
+			const found = await read({ RESEARCH_PROVIDER_ENRICH: 'hunter' })
+
+			// WHEN read — THEN the vendor that IS configured is reported, instead of
+			// vanishing behind the settings nobody wrote
+			expect(originsOf(found)).toEqual(['https://api.hunter.io'])
+			expect(found.unreadable).toEqual([])
+		})
+
+		it('should keep the model tiers that are set when another tier is not', async () => {
+			// GIVEN the two tiers an eval measures through, with the writer tier —
+			// which nothing here scores — left unset
+			const found = await read({
+				RESEARCH_LLM_AGENT_PROVIDERS: 'groq',
+				RESEARCH_LLM_AGENT_MODEL: 'openai/gpt-oss-120b',
+				RESEARCH_LLM_EXTRACT_PROVIDERS: 'groq',
+				RESEARCH_LLM_EXTRACT_MODEL: 'openai/gpt-oss-120b',
+			})
+
+			// WHEN read — THEN both configured tiers are reported; the unset one
+			// costs only itself
+			expect(found.endpoints.map(endpoint => endpoint.label)).toEqual([
+				'agent slot 1 (groq)',
+				'extract slot 1 (groq)',
+			])
+			expect(found.unreadable).toEqual([])
+		})
+	})
+
+	describe('when a setting was written and will not read', () => {
+		it('should name that part as at fault and keep the rest', async () => {
+			// GIVEN a mistyped vendor name beside settings that are fine
+			const found = await read({
+				...LIVE,
+				RESEARCH_PROVIDER_SEARCH: 'firecrwal',
+			})
+
+			// WHEN read
+			// THEN the broken part is named, so a typo cannot pass for a machine
+			// nobody configured
+			expect(found.unreadable.map(part => part.part)).toEqual([
+				'the search vendor',
+			])
+			expect(found.unreadable[0]?.detail).toContain('RESEARCH_PROVIDER_SEARCH')
+			// AND every other vendor is still reported, so one bad value does not
+			// hide the ones that are right
+			expect(originsOf(found)).toEqual([
+				'https://api.groq.com',
+				'https://api.studio.nebius.ai',
+				'https://api.firecrawl.dev',
+			])
+		})
+
+		it('should name a model tier whose address is not a web address', async () => {
+			// GIVEN a custom vendor pointed at something that will not parse
+			const found = await read({
+				...LIVE,
+				RESEARCH_LLM_WRITER_PROVIDERS: 'custom',
+				RESEARCH_LLM_WRITER_MODEL: 'some-model',
+				RESEARCH_LLM_WRITER_BASE_URL: 'api.example.com/v1',
+			})
+
+			// WHEN read
+			// THEN the slot is called out rather than quietly dropped, or a tier
+			// nobody checked would read as one that passed
+			expect(found.unreadable.map(part => part.part)).toEqual([
+				'the writer model tier (slot 1)',
+			])
+			// AND the address itself stays out of the message, since an operator's
+			// own gateway can carry anything in its query string
+			expect(found.unreadable[0]?.detail).not.toContain('api.example.com')
+		})
+	})
+})
+
+describe('the company registers a run would reach', () => {
+	const read = (env: Record<string, string>) =>
+		Effect.runPromise(
+			researchProviderEndpoints().pipe(
+				Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))),
+			),
+		)
+
+	describe('when a country names a real register', () => {
+		it('should ask about it too, since a register can be blocked on its own', async () => {
+			// GIVEN the Spanish register live, which is how production runs
+			const found = await read({ RESEARCH_PROVIDER_REGISTRY_ES: 'librebor' })
+
+			// WHEN read — THEN its host is there to be asked about, labelled by the
+			// country so a blocked one names the lookups it would stop
+			expect(found.endpoints).toEqual([
+				{
+					label: 'registry ES slot 1 (librebor)',
+					origin: 'https://api.librebor.me',
+				},
+			])
+		})
+	})
+
+	describe('when both registers are switched off', () => {
+		it('should ask about nothing', async () => {
+			// GIVEN both countries switched off, the way a pass that measures quality
+			// is run
+			const found = await read({
+				RESEARCH_PROVIDER_REGISTRY_ES: 'none',
+				RESEARCH_PROVIDER_REGISTRY_GB: 'none',
+			})
+
+			// WHEN read — THEN neither reaches a register, so neither is probed
+			expect(found.endpoints).toEqual([])
+			expect(found.unreadable).toEqual([])
+		})
+	})
+
+	describe('when one country’s setting will not read', () => {
+		it('should name that country and keep the other', async () => {
+			// GIVEN a mistyped register for Spain beside a working British one
+			const found = await read({
+				RESEARCH_PROVIDER_REGISTRY_ES: 'libreborme',
+				RESEARCH_PROVIDER_REGISTRY_GB: 'companies-house',
+			})
+
+			// WHEN read — THEN Spain is named as at fault and Britain still reports
+			expect(found.unreadable.map(part => part.part)).toEqual([
+				'the ES company register',
+			])
+			expect(found.endpoints.map(endpoint => endpoint.origin)).toEqual([
+				'https://api.company-information.service.gov.uk',
+			])
+		})
+	})
+})
+
+describe('asking a vendor host a second time', () => {
+	// One failure and then answers, with the count kept where a test can read it:
+	// how many times the probe asked is the thing being checked.
+	const flakyClient = (
+		attempts: { count: number },
+		firstFailure: unknown,
+	): HttpClient.HttpClient =>
+		HttpClient.makeWith<
+			HttpClientError.HttpClientError,
+			never,
+			HttpClientError.HttpClientError,
+			never
+		>(
+			effect =>
+				Effect.flatMap(effect, request => {
+					attempts.count += 1
+					return attempts.count === 1
+						? Effect.fail(
+								new HttpClientError.HttpClientError({
+									reason: new HttpClientError.TransportError({
+										request,
+										cause: firstFailure,
+									}),
+								}),
+							)
+						: Effect.succeed(
+								HttpClientResponse.fromWeb(
+									request,
+									new Response(null, { status: 200 }),
+								),
+							)
+				}),
+			Effect.succeed,
+		)
+
+	// Steps the clock through the pause between the two tries, so none of it is
+	// waited out in real time.
+	const probeOnTestClock = (client: HttpClient.HttpClient) =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				const fiber = yield* Effect.forkChild(
+					probeReachability([GROQ]).pipe(
+						Effect.provideService(HttpClient.HttpClient, client),
+					),
+				)
+				for (let elapsed = 0; elapsed < 30_000; elapsed += 100) {
+					if (fiber.pollUnsafe() !== undefined) break
+					yield* Effect.yieldNow
+					yield* TestClock.adjust('100 millis')
+				}
+				return yield* Fiber.await(fiber)
+			}).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+		)
+
+	describe('when a vendor drops one connection and then answers', () => {
+		it('should ask again before calling a working vendor blocked', async () => {
+			// GIVEN a host that fails one lookup and answers the next
+			const attempts = { count: 0 }
+			const exit = await probeOnTestClock(
+				flakyClient(
+					attempts,
+					fetchFailure('EAI_AGAIN', 'getaddrinfo EAI_AGAIN'),
+				),
+			)
+
+			// WHEN asked
+			// THEN the second try decides, so a dropped packet does not teach the
+			// operator to ignore a vendor called blocked
+			expect(Exit.isSuccess(exit)).toBe(true)
+			if (Exit.isSuccess(exit)) {
+				expect(exit.value[0]?.verdict).toBe('reachable')
+				expect(exit.value[0]?.status).toBe(200)
+			}
+			expect(attempts.count).toBe(2)
+		})
+	})
+
+	describe('when the first answer will not change between tries', () => {
+		it('should take it at its word and not ask twice', async () => {
+			// GIVEN a certificate that will not verify, which is the certificate a
+			// second try would meet as well
+			const attempts = { count: 0 }
+			const results = await probe(
+				[GROQ],
+				failingClient(
+					fetchFailure('CERT_HAS_EXPIRED', 'certificate has expired'),
+					attempts,
+				),
+			)
+
+			// WHEN asked — THEN it is reported on the first answer, so a refusal that
+			// nothing is going to change costs no extra wait
+			expect(results[0]?.blockedReason).toBe('tls')
+			expect(attempts.count).toBe(1)
+		})
+	})
+
+	describe('when both tries fail', () => {
+		it('should still report the vendor unreachable', async () => {
+			// GIVEN a host that refuses the connection every time
+			const exit = await probeOnTestClock(
+				failingClient(fetchFailure('ECONNREFUSED', 'connect ECONNREFUSED')),
+			)
+
+			// WHEN asked — THEN a real block survives the second try
+			expect(Exit.isSuccess(exit)).toBe(true)
+			if (Exit.isSuccess(exit)) {
+				expect(exit.value[0]?.verdict).toBe('unreachable')
+				expect(exit.value[0]?.blockedReason).toBe('refused')
+			}
+		})
+	})
+})

--- a/packages/research/src/infrastructure/reachability.ts
+++ b/packages/research/src/infrastructure/reachability.ts
@@ -1,0 +1,474 @@
+/**
+ * Can this machine talk to the vendors a research pass is pointed at?
+ *
+ * A pass over the full golden set costs real money and runs for hours, and it
+ * reaches several outside services on the way — the model vendors, the web
+ * search, the page fetcher. On some connections one of them is simply not
+ * reachable: a VPN, a company proxy or a DNS filter drops it, and once a run is
+ * under way that reads exactly like the vendor being down.
+ *
+ * So this check exists to keep apart two failures that look identical from
+ * inside a run and have nothing in common to fix:
+ *
+ *   - the connection cannot get there at all — a VPN, a proxy, a DNS filter;
+ *   - the connection gets there fine and the vendor refuses the key.
+ *
+ * The probe therefore carries **no key**. Any HTTP answer at all counts as
+ * reachable, 401 and 403 included: being turned away proves the request
+ * arrived, and a key-less request is *supposed* to be turned away, so that
+ * answer says nothing whatever about the operator's key. Only a name that will
+ * not resolve, a refused connection, a failed handshake or silence is the
+ * blocked-connection symptom, and only that is reported as one. No key also
+ * means no account for a vendor to bill, so the check is free however often it
+ * runs.
+ *
+ * A green result claims that this machine reached the host and nothing more: a
+ * content delivery network can answer while the API behind it is blocked,
+ * reaching the host does not prove the endpoint a run calls will answer, and
+ * whether a key is valid or has allowance left is a separate question with its
+ * own check.
+ */
+
+import { Cause, type Config, Effect } from 'effect'
+import {
+	FetchHttpClient,
+	HttpClient,
+	HttpClientRequest,
+} from 'effect/unstable/http'
+
+import { REGISTRY_COUNTRIES, type RegistryCountry } from '../domain/country'
+import type { LlmTier } from './cached-llm'
+import {
+	type ConfiguredSlot,
+	configuredSlotsIfSet,
+	LLM_TIERS,
+} from './llm-live'
+import {
+	configuredCapabilityEndpoints,
+	configuredRegistryEndpoints,
+	RESEARCH_CAPABILITIES,
+	type ResearchCapability,
+} from './providers-live'
+
+/** Did the request reach the vendor at all? */
+export type ReachabilityVerdict =
+	/** An HTTP answer came back. Whatever it said, the connection got there. */
+	| 'reachable'
+	/** Nothing answered. This machine's connection is what is in the way. */
+	| 'unreachable'
+
+/** What stopped the request from arriving. */
+export type BlockedReason =
+	/** The vendor's name does not resolve here — the classic VPN/DNS-filter shape. */
+	| 'dns'
+	/** Something answered the socket with a refusal or a reset. */
+	| 'refused'
+	/** Nothing came back before the check gave up. */
+	| 'timeout'
+	/** The secure connection could not be set up — often a proxy opening traffic. */
+	| 'tls'
+	/** Something on this network answered in the vendor's place and stopped there. */
+	| 'proxy'
+	/** A transport failure that fits none of the above. */
+	| 'unknown'
+
+/** One vendor a run is configured to reach, and where it answers. */
+export interface ProviderEndpoint {
+	/** Which part of the pipeline this is, in the operator's words. */
+	readonly label: string
+	/** Scheme and host only — see `originOf`. */
+	readonly origin: string
+}
+
+/** Whether one vendor host can be reached from here, and what says so. */
+export interface ReachabilityResult {
+	readonly origin: string
+	/** Every part of the pipeline that goes to this host. */
+	readonly labels: ReadonlyArray<string>
+	readonly verdict: ReachabilityVerdict
+	/** The HTTP status that proved the connection got there. Reachable only. */
+	readonly status?: number
+	/** What was in the way. Unreachable only. */
+	readonly blockedReason?: BlockedReason
+	/** One line for a human, worded so the two failures cannot be swapped. */
+	readonly detail: string
+}
+
+/** A part whose setting was written and will not read, so nothing was probed. */
+export interface UnreadablePart {
+	/** Which part of the pipeline, in the operator's words. */
+	readonly part: string
+	/** What is wrong with its setting, in the words of whatever refused it. */
+	readonly detail: string
+}
+
+/** The vendor hosts a run would reach, and any settings that would not read. */
+export interface ProviderEndpoints {
+	readonly endpoints: ReadonlyArray<ProviderEndpoint>
+	/**
+	 * A part nobody set at all is not in here: it reaches nothing by design,
+	 * which is the normal state on a machine that never runs research. Only a
+	 * setting somebody wrote and got wrong lands here, which is a fault.
+	 */
+	readonly unreadable: ReadonlyArray<UnreadablePart>
+}
+
+// Long enough that a vendor answering slowly over a busy link is not called
+// blocked, short enough that a machine cut off from four vendors is not left
+// waiting — the probes go out together, so this is the whole wait, not each.
+const PROBE_TIMEOUT = '5 seconds'
+
+// Which system codes mean what. A failed connection reports itself in one of
+// these, either as a `code` on the error or buried in its text, and which one
+// decides what the operator is told to go and look at.
+const BLOCKED_CODES: ReadonlyArray<
+	readonly [BlockedReason, ReadonlyArray<string>]
+> = [
+	[
+		'dns',
+		[
+			'ENOTFOUND',
+			'EAI_AGAIN',
+			'EAI_FAIL',
+			'EAI_NODATA',
+			'ERR_NAME_NOT_RESOLVED',
+		],
+	],
+	[
+		'refused',
+		[
+			'ECONNREFUSED',
+			'ECONNRESET',
+			'ECONNABORTED',
+			'EHOSTUNREACH',
+			'ENETUNREACH',
+			'ENETDOWN',
+			'EPIPE',
+			'UND_ERR_SOCKET',
+		],
+	],
+	[
+		'timeout',
+		[
+			'ETIMEDOUT',
+			'ERR_SOCKET_CONNECTION_TIMEOUT',
+			'UND_ERR_CONNECT_TIMEOUT',
+			'UND_ERR_HEADERS_TIMEOUT',
+			'UND_ERR_BODY_TIMEOUT',
+		],
+	],
+	[
+		'tls',
+		[
+			'EPROTO',
+			'ERR_TLS_CERT_ALTNAME_INVALID',
+			'ERR_SSL_WRONG_VERSION_NUMBER',
+			'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+			'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+			'DEPTH_ZERO_SELF_SIGNED_CERT',
+			'SELF_SIGNED_CERT_IN_CHAIN',
+			'CERT_HAS_EXPIRED',
+		],
+	],
+]
+
+// The error and everything it blames, innermost last. `fetch` reports a dropped
+// connection as a bland "fetch failed" and hides the system code one link down,
+// so the reason is never in the outermost error alone. Bounded, and it stops on
+// a repeat, because an error chain is free to point back at itself.
+const causeChain = (error: unknown): ReadonlyArray<Record<string, unknown>> => {
+	const links: Record<string, unknown>[] = []
+	let current = error
+	while (links.length < 8 && current !== null && typeof current === 'object') {
+		const link = current as Record<string, unknown>
+		if (links.includes(link)) break
+		links.push(link)
+		current = link['cause']
+	}
+	return links
+}
+
+const stringsAt = (
+	links: ReadonlyArray<Record<string, unknown>>,
+	field: string,
+): ReadonlyArray<string> =>
+	links
+		.map(link => link[field])
+		.filter((value): value is string => typeof value === 'string')
+
+/**
+ * What kept the request from arriving, read off the error the transport raised.
+ *
+ * Codes decide first, because a code is the transport stating the reason
+ * outright. Only when there is none does the text get read, which some versions
+ * of `fetch` leave as the sole trace of the same thing.
+ */
+export const blockedReasonForCause = (error: unknown): BlockedReason => {
+	const links = causeChain(error)
+	const codes = new Set(stringsAt(links, 'code'))
+	for (const [reason, known] of BLOCKED_CODES) {
+		if (known.some(code => codes.has(code))) return reason
+	}
+	const text = stringsAt(links, 'message').join(' ')
+	for (const [reason, known] of BLOCKED_CODES) {
+		if (known.some(code => text.includes(code))) return reason
+	}
+	return 'unknown'
+}
+
+/**
+ * Scheme and host of a vendor's address, dropping the path: the check can
+ * honestly claim no more than that the host was reached, so the API path a run
+ * really calls is left out rather than implied.
+ */
+export const originOf = (baseUrl: string): string | undefined => {
+	try {
+		return new URL(baseUrl).origin
+	} catch {
+		return undefined
+	}
+}
+
+/** The bare host, for naming a vendor without the scheme in front of it. */
+export const hostOf = (origin: string): string => {
+	try {
+		return new URL(origin).host
+	} catch {
+		return origin
+	}
+}
+
+const BLOCKED_PHRASES: Record<BlockedReason, (host: string) => string> = {
+	dns: host => `the name ${host} does not resolve on this machine`,
+	refused: host => `the connection to ${host} was refused`,
+	timeout: host => `${host} did not answer within ${PROBE_TIMEOUT}`,
+	tls: host => `the secure connection to ${host} could not be set up`,
+	proxy: host =>
+		`a proxy or a sign-in portal on this network answered in place of ${host}`,
+	unknown: host => `nothing came back from ${host}`,
+}
+
+// 407 is a proxy asking to be signed into and 511 a sign-in portal doing the
+// same: something on this network answering in the vendor's place. Counting
+// either as the vendor answering would report a green that is not one — the very
+// mistake this check exists to prevent.
+const ANSWERED_BY_THE_NETWORK = new Set([407, 511])
+
+/**
+ * A refusal is spelled out rather than merely counted as reachable, because 401
+ * is the one answer somebody could misread as their key being wrong — and the
+ * probe carried no key, so it is the answer it was always going to get.
+ */
+export const reachableDetail = (origin: string, status: number): string =>
+	status === 401 || status === 403
+		? `reachable — ${hostOf(origin)} answered ${status} to a request carrying no key, which is the answer a request carrying no key should get. It says nothing about whether your key works.`
+		: `reachable — ${hostOf(origin)} answered ${status}.`
+
+/**
+ * The connection is named as the thing at fault and the key ruled out in the
+ * same breath, because those are the two an operator has to choose between and
+ * they have nothing in common to fix.
+ */
+export const unreachableDetail = (
+	origin: string,
+	reason: BlockedReason,
+): string =>
+	`cannot be reached from this machine — ${BLOCKED_PHRASES[reason](hostOf(origin))}. No key was sent, so this is your connection (a VPN, a proxy or a DNS filter), not your key.`
+
+const blocked = (
+	origin: string,
+	labels: ReadonlyArray<string>,
+	reason: BlockedReason,
+): ReachabilityResult => ({
+	origin,
+	labels,
+	verdict: 'unreachable',
+	blockedReason: reason,
+	detail: unreachableDetail(origin, reason),
+})
+
+// A HEAD to the host, carrying nothing: no key to bill or to be read as a
+// verdict on one, and no body to drain. Redirects are left unfollowed on
+// purpose — a redirect is itself proof the host answered, and chasing one would
+// report on whichever host it points at instead of the one being asked about.
+const probeOrigin = (
+	origin: string,
+	labels: ReadonlyArray<string>,
+): Effect.Effect<ReachabilityResult, never, HttpClient.HttpClient> =>
+	Effect.gen(function* () {
+		const client = yield* HttpClient.HttpClient
+		const response = yield* client.execute(HttpClientRequest.head(origin))
+		if (ANSWERED_BY_THE_NETWORK.has(response.status)) {
+			return blocked(origin, labels, 'proxy')
+		}
+		return {
+			origin,
+			labels,
+			verdict: 'reachable' as const,
+			status: response.status,
+			detail: reachableDetail(origin, response.status),
+		}
+	}).pipe(
+		Effect.provideService(FetchHttpClient.RequestInit, { redirect: 'manual' }),
+		// Squashed first: the reason lives on the error the transport raised, and
+		// the wrapper around it carries none of it.
+		Effect.catchCause(cause =>
+			Effect.succeed(
+				blocked(origin, labels, blockedReasonForCause(Cause.squash(cause))),
+			),
+		),
+		Effect.timeoutOrElse({
+			duration: PROBE_TIMEOUT,
+			orElse: () => Effect.succeed(blocked(origin, labels, 'timeout')),
+		}),
+	)
+
+// Answers that asking again would only repeat: a proxy answering in the
+// vendor's place and a certificate that will not verify are both decisions
+// something made about this request, not accidents of the moment.
+const SETTLED_REASONS: ReadonlyArray<BlockedReason> = ['proxy', 'tls']
+
+// Long enough for a dropped packet to be past, short enough that nobody notices
+// it on a host that answers.
+const RETRY_PAUSE = '200 millis'
+
+// One dropped connection is not a blocked connection, and a vendor called
+// blocked that is fine on the next look teaches an operator to ignore the
+// answer. The second try only ever runs on a host that has already failed to
+// answer, so a machine whose vendors are all reachable waits no longer for it.
+const probeOriginTwice = (
+	origin: string,
+	labels: ReadonlyArray<string>,
+): Effect.Effect<ReachabilityResult, never, HttpClient.HttpClient> =>
+	probeOrigin(origin, labels).pipe(
+		Effect.flatMap(first =>
+			first.verdict === 'reachable' ||
+			(first.blockedReason !== undefined &&
+				SETTLED_REASONS.includes(first.blockedReason))
+				? Effect.succeed(first)
+				: Effect.sleep(RETRY_PAUSE).pipe(
+						Effect.andThen(probeOrigin(origin, labels)),
+					),
+		),
+	)
+
+/**
+ * Ask each vendor host whether this machine can reach it. Never fails: an
+ * unreachable vendor is the answer, not an error.
+ *
+ * Hosts are asked once each however many parts of the pipeline share one — the
+ * three model tiers commonly sit on the same vendor — and they are asked at the
+ * same time, so a machine cut off from four vendors waits for one timeout
+ * rather than four.
+ */
+export const probeReachability = (
+	endpoints: ReadonlyArray<ProviderEndpoint>,
+): Effect.Effect<
+	ReadonlyArray<ReachabilityResult>,
+	never,
+	HttpClient.HttpClient
+> => {
+	const byOrigin = new Map<string, string[]>()
+	for (const endpoint of endpoints) {
+		const labels = byOrigin.get(endpoint.origin)
+		if (labels === undefined) byOrigin.set(endpoint.origin, [endpoint.label])
+		else labels.push(endpoint.label)
+	}
+	return Effect.forEach(
+		[...byOrigin],
+		([origin, labels]) => probeOriginTwice(origin, labels),
+		{ concurrency: 'unbounded' },
+	)
+}
+
+// Whatever refused the setting is free to lay its complaint out over several
+// lines; `doctor` prints a row per line, so it is folded back into one.
+const nothingFrom = (part: string, detail: string): ProviderEndpoints => ({
+	endpoints: [],
+	unreadable: [{ part, detail: detail.replace(/\s+/g, ' ').trim() }],
+})
+
+const together = (
+	parts: ReadonlyArray<ProviderEndpoints>,
+): ProviderEndpoints => ({
+	endpoints: parts.flatMap(part => part.endpoints),
+	unreadable: parts.flatMap(part => part.unreadable),
+})
+
+const oneEndpoint = (label: string, origin: string): ProviderEndpoints => ({
+	endpoints: [{ label, origin }],
+	unreadable: [],
+})
+
+// A slot whose address will not parse is called out rather than quietly
+// dropped, or the operator would read a tier nobody checked as one that passed.
+// The address itself is left out of the message: an operator's own gateway can
+// carry anything in its query string.
+const fromSlot = (slot: ConfiguredSlot): ProviderEndpoints => {
+	const origin = originOf(slot.baseUrl)
+	return origin === undefined
+		? nothingFrom(
+				`the ${slot.tier} model tier (slot ${slot.slot})`,
+				'its address does not read as a web address',
+			)
+		: oneEndpoint(`${slot.tier} slot ${slot.slot} (${slot.vendor})`, origin)
+}
+
+// Each part is read on its own so a setting somebody got wrong costs only its
+// own row. Read together, one bad value would take down the parts beside it —
+// and the parts a pass leans on hardest are exactly the ones that would go.
+const readPart = <A>(
+	part: string,
+	configured: Effect.Effect<ReadonlyArray<A>, Config.ConfigError>,
+	toEndpoints: (entry: A) => ProviderEndpoints,
+): Effect.Effect<ProviderEndpoints> =>
+	configured.pipe(
+		Effect.map(entries => together(entries.map(toEndpoints))),
+		Effect.catch(error => Effect.succeed(nothingFrom(part, error.message))),
+	)
+
+// A tier nobody named a vendor for reads as reaching nothing rather than as a
+// fault: leaving a tier unset is the ordinary state, so calling it a broken
+// setting would be a false alarm.
+const fromTier = (tier: LlmTier): Effect.Effect<ProviderEndpoints> =>
+	readPart(`the ${tier} model tier`, configuredSlotsIfSet(tier), fromSlot)
+
+const fromCapability = (
+	capability: ResearchCapability,
+): Effect.Effect<ProviderEndpoints> =>
+	readPart(
+		`the ${capability} vendor`,
+		configuredCapabilityEndpoints([capability]),
+		entry =>
+			oneEndpoint(
+				`${entry.capability} slot ${entry.slot} (${entry.vendor})`,
+				entry.origin,
+			),
+	)
+
+const fromRegistry = (
+	country: RegistryCountry,
+): Effect.Effect<ProviderEndpoints> =>
+	readPart(
+		`the ${country} company register`,
+		configuredRegistryEndpoints([country]),
+		entry =>
+			oneEndpoint(
+				`registry ${entry.country} slot ${entry.slot} (${entry.vendor})`,
+				entry.origin,
+			),
+	)
+
+/**
+ * Every vendor host the research settings point at, read the same way a run
+ * reads them so the check is about the vendors a run would really use.
+ *
+ * A part answered by canned data, switched off, or never set reaches nothing,
+ * so it is left out rather than probed.
+ */
+export const researchProviderEndpoints = (): Effect.Effect<ProviderEndpoints> =>
+	Effect.all([
+		...LLM_TIERS.map(fromTier),
+		...RESEARCH_CAPABILITIES.map(fromCapability),
+		...REGISTRY_COUNTRIES.map(fromRegistry),
+	]).pipe(Effect.map(together))


### PR DESCRIPTION
## What

Before a pass that measures how good the research pipeline is — one that costs roughly $10–15 and runs for a few hours — I can now find out whether this machine can actually *talk to* each outside service the pipeline uses: the model vendors, the web search and the page fetcher. On some connections a vendor is simply unreachable (I hit this with Groq on a VPN), and until now that only came to light minutes into a paid pass, as a network error that read like the vendor being down rather than like my own connection being at fault.

The check lives in the research bounded context (`packages/research`) and is surfaced by the command-line tool (`apps/cli`) in two places: `pnpm cli doctor`, beside the existing checks for Docker, the database and storage, and `pnpm cli research eval --dry-run`, the rehearsal that reports everything a pass needs before it spends anything.

The point of the whole thing is that two failures stop looking alike. Once a run is under way, "my connection cannot get out" and "the vendor rejected my key" produce the same shape of error and have completely different fixes. So the probe deliberately carries **no key at all**: any HTTP answer whatsoever counts as reached — 401 and 403 included, because being turned away is exactly what a request carrying no key *should* draw, and the line says so in the same breath. Only a name that will not resolve, a refused connection, a failed secure handshake (TLS) or silence is reported as blocked, and that line names the connection and rules the key out explicitly.

Carrying no key is also what keeps it free: there is no account behind the request for a vendor to bill, and it asks for headers alone rather than a page (an HTTP `HEAD`), so nothing is transferred. **Cost per probe: nothing, at every vendor.**

## Changes

**Touches:** the check itself and the place each vendor's address is read from, both inside the research package, plus the two commands that print it — the local health check and the eval's spend-nothing rehearsal. The guard that runs immediately before every pass (`requireLiveProviders`) is deliberately **not** touched, and neither is any code a real run goes through.

- A vendor's host is asked once, however many parts of the pipeline point at it — the three model tiers commonly share one vendor — and every host is asked at the same time, so a machine cut off from four vendors waits about five seconds in total rather than four times over.
- Something on the local network answering *in the vendor's place* — a proxy asking to be signed into (HTTP 407), or a café's sign-in page (511) — is reported as **not** reached. Counting it as the vendor answering would produce exactly the false green this feature exists to prevent.
- A host that fails to answer is asked once more before it is called unreachable, because one dropped connection is not a blocked connection and a vendor wrongly marked amber teaches the reader to ignore amber. The second try only ever runs on a host that already failed, so a machine whose vendors are all reachable waits no longer for it; a proxy answering in the vendor's place and a certificate that will not verify are taken at their word, since neither changes in a fifth of a second.
- Each part's settings are read on its own, so one value somebody typed wrong is named as a fault instead of quietly taking the parts beside it down with it. A part nobody set at all reaches nothing and is simply left out, which is the ordinary state on a machine that never runs research; a part set to canned test data (a stub) or switched off (`none`) is likewise skipped rather than probed.
- The two national company registers — libreBORME for Spain and Companies House for the UK — are checked alongside everything else, since both are live in production and a country can be blocked on its own. Both turn a key-less request away with a 401, which is the clearest demonstration in this PR that being refused is not the same as being unreachable. The paid company reports are left out: the one vendor there is not written yet, so nothing reaches it.
- Both commands share the same wording for the same fact, so a reader comparing them can see they ran the same check.

What a green result does **not** claim, written into the code and the eval's README so nobody reads more into it: a content delivery network can answer for a vendor's host while the API behind it is blocked; reaching the host does not prove the endpoint a run calls will answer; and it says nothing about whether a key is valid or has allowance left — `pnpm cli research probe-config` is the check for that.

## Impact

- **No migration and no schema change.** Nothing about the database moves, so there is no ordering constraint against a server release.
- **Nothing touching which organisation can see what** (row-level security, `organization_id` scoping, or which Postgres role a path runs under). This is a developer-machine diagnostic; it reads settings and makes one anonymous outbound request.
- **No new environment variables**, so production needs nothing set for this to land.
- **No change to the shape of anything sent over the wire** — `packages/controllers` and `packages/domain` are untouched, so the typed client in `apps/internal` is unaffected.
- **No change to authentication or to which routes are protected**, and nothing about how the tool-calling surface for outside AI clients (MCP) behaves — the two surfaces that share services aren't involved, because nothing here is a service a request reaches.
- **No provider money is spent.** The probe sends no key, so there is no account for a vendor to charge, and it asks for headers only.
- **No behaviour change to any command that existed before this branch.** An earlier revision of this PR widened the helper that reads the model settings, which quietly changed `pnpm cli research probe-config` — a check meant to run on a schedule — from stopping on a half-written config to carrying on and saying "nothing to check". A scheduled alarm that goes quiet exactly when the settings are broken is worse than the problem it was solving, so the strict reading is back and the lenient one lives in its own reader. Confirmed against the live command in both directions.
- **`pnpm cli doctor` can take a few seconds longer** on a machine that has vendors configured and cannot reach them. Bounded, and the probes run together rather than one after another.
- **`research eval --dry-run` no longer stops on a provider setting that will not read.** It reports which variable is at fault and what it accepts, then carries on — a dry run spends nothing, so a broken setting is something for it to report. A real pass still refuses to start, unchanged.

## Review guide

- **Start at [`packages/research/src/infrastructure/reachability.ts`](https://github.com/guillempuche/batuda/blob/research/491-provider-reachability/packages/research/src/infrastructure/reachability.ts).** The file header states the whole idea; if the reasoning there is wrong, everything else follows from it.
- **The riskiest part is `blockedReasonForCause`** — working out *why* a connection failed from whatever the transport threw. `fetch` reports a dropped connection as a bland "fetch failed" and hides the real system code one link down the error chain, so this walks that chain. I did not take that on trust: I ran it against a name that does not resolve, a closed port, an expired certificate, a self-signed certificate, and a host that accepts the connection and then says nothing, and confirmed each lands on the right verdict. I also ran it against all nine real vendor hosts.
- **One decision you might overrule.** I did **not** reuse `doctor`'s existing `urlCheck` helper, which the issue suggested: it turns off certificate checking for self-signed local certificates, which would make every proxy-intercepted connection look reachable and kill one of the five verdicts, and it collapses every failure into a single message with no reason — the exact thing this feature exists to undo.
- **Skip-able:** the `apps/cli` half is thin wiring by design, since this repo does not test command-line code. The thinking is all in the research package where the tests are.
- I ran `/code-review` at extra-high effort twice. The first pass found eight issues, three of which I reproduced as real bugs before fixing — all one root cause: I had been reading every setting in a single go, so one unreadable value silently dropped the vendors that *were* configured, including the two model tiers an eval actually measures through. The second pass, over the fixes, found nine more; the one that mattered was that `--dry-run` died on a mistyped search vendor before its own report could name it, which I also reproduced first. Everything found is fixed and re-checked against the live commands. The readability agent passed over the diff after each round.
- **Two latent regressions from my own refactoring, worth a glance:** `resolvedTierVendors` and `configuredSlots` briefly stopped reading the canonical tier list, and `slotsForVendors` briefly lost its never-empty guarantee. Neither was reachable from any current caller, but both sit on the path that guards a paid pass, so both are restored rather than left as “cannot happen today”.
- I did not run a security review or Snyk: no authentication, tenant-isolation, parser or upload surface is involved, and no user input reaches this code.

## Tests

73 new tests in the research package, all at the service layer per the repo's rule against testing command-line wiring directly:

- **The case that matters most** — a vendor refusing a key-less request and a vendor this machine cannot reach, asserted to be distinguishable *structurally*, not just by wording: the verdicts differ, only one carries an answer from the vendor, only the other carries a reason to go and look at, and neither line can be read as the other.
- Each blocked reason from the error shape `fetch` really produces; a reason buried several links down; an error chain that points back at itself; an error that is not an object at all.
- Reachable on 200, 301, 401, 403, 429, 500, 503; unreachable on 407 and 511; a redirect reported without being followed to a different host.
- The probe sends a `HEAD` with no authorisation header, to one host, at the host's address rather than an API path.
- Several parts sharing one vendor are asked once and all named; nothing configured asks nothing; a vendor that never answers is given up on rather than left holding up the check.
- Reading the settings: one capability configured while the ones with no default are unset; two model tiers set with a third unset; a mistyped vendor name named as a fault while the correct settings still report; a model address that will not parse named rather than dropped, with the address itself kept out of the message since an operator's own gateway can carry anything in its query string.
- The registers: both countries pointed at their national register; both switched off, which is what a quality pass asks for; one country mistyped while the other still reports.
- What silence in a model tier's settings means to each reader — the strict one stops and names the missing variable, the reporting one carries on — so the two cannot drift back together.

## Verification

Gates run on the rebased branch, all green: `pnpm install`, `pnpm check-types` (13/13), `pnpm test` for the research package (1816 passed, 16 todo), `pnpm build` (13/13), and `pnpm check` (biome, no errors).

End-to-end against the live command, not just the test suite:

- `pnpm cli doctor` with vendors configured — every real host probed and reported.
- `pnpm cli doctor` with a vendor pointed at a name that does not resolve — amber, naming the connection and ruling the key out.
- `pnpm cli doctor` with a mistyped vendor name — amber, naming the exact variable and the values it accepts, while the correctly-configured vendor beside it still reports.
- `pnpm cli doctor` on a machine with nothing configured — one quiet green line, no red.
- `pnpm cli research eval --dry-run` with one vendor blocked — the reachability lines appear beside the routing check and the run count, and the pass still costs nothing.
- `pnpm cli research eval --dry-run` with a broken setting the pre-pass guard never reads (enrichment) — surfaced there, where a real run would otherwise have failed on it later.
- `pnpm cli doctor` with both national registers live — each probed, each answering 401 to the key-less request, each line saying that answer means nothing about the key.
- `pnpm cli research probe-config` with a model tier left unset, and again with every tier stubbed — the first stops, the second says "No tier reaches a vendor; nothing to check", matching what the command did before this branch.

No screenshots: this PR touches no web UI.

## Deferred

- The paid company reports are not probed, because the one vendor behind them is not implemented, so nothing ever reaches its host and a green result would report on a road nothing travels.
- The retry is one extra try, not a policy. If a vendor turns out to need more patience than that, the honest fix is a longer wait rather than more attempts, and I would rather see it happen than guess at it now.
- The check runs where somebody asks for it (`doctor`, `--dry-run`) and deliberately nowhere else. Putting it in the path that runs before every pass would add delay and a new way for a correct setup to fail intermittently, which is a worse trade than the problem.

Closes #491
