### PR TITLE
fix(research): stop an association's member page shipping as a website

### DIFF
--- a/apps/server/src/services/research-scan-website-fold.integration.test.ts
+++ b/apps/server/src/services/research-scan-website-fold.integration.test.ts
@@ -1,0 +1,451 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '4'
+process.env['RESEARCH_MAX_LOOP_PROMPT_TOKENS'] ??= '24000'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	ExtractLanguageModel,
+	MapProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	ScrapeProvider,
+	SearchProvider,
+	SearchResult,
+	SearchResultItem,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+// The website fold: a trade body's member page must not be stored as a company's
+// website, checked on the list a run really keeps rather than on one reading of it.
+//
+// A trade body gives each of its members a page on its own host. Two members are
+// two companies claiming one host, which the website check condemns — but only
+// when it is looking at both of them, and a run reads its list several times and
+// folds the readings together afterwards. A member met in the first reading is
+// alone on that host while it is judged, so it keeps the address; the round that
+// finds the second member blanks the round's copy of both, and the fold then
+// hands the reader the first reading's copy, address and all.
+//
+// So the run has to remember which company claimed which host, as claimed and
+// before any blanking, and put the folded list back to the check with that
+// memory. The claims and the rule are covered field-by-field by unit tests beside
+// them; what those cannot show is that the run actually carries the claims from
+// one reading to the next and checks the list it stores. This does.
+
+interface Org {
+	id: string
+	name: string
+	slug: string
+}
+
+interface Scenario {
+	readonly evidence: string
+	/**
+	 * What each extraction answers with, in order. The last stands for every
+	 * extraction after it.
+	 */
+	readonly readings: ReadonlyArray<Record<string, unknown>>
+}
+
+let scenario: Scenario
+let extractionsSoFar = 0
+
+// The opening line of the extraction prompt, and of nothing else. A scan puts two
+// different questions to the extract model — read the evidence into findings, and
+// audit the fields those findings claim — and only the first is what a reading
+// answers.
+const EXTRACTION_OPENER = 'Produce structured findings STRICTLY'
+
+const nextReading = (): Record<string, unknown> => {
+	const at = Math.min(extractionsSoFar, scenario.readings.length - 1)
+	extractionsSoFar++
+	return scenario.readings[at] ?? {}
+}
+
+// A canonical URL hashes to itself, so this matches what the run fiber's
+// source-linking computes for the web_search result below.
+const SEED_URL = 'https://directorio.test/instaladores'
+const SEED_URL_HASH = createHash('sha256').update(SEED_URL).digest('hex')
+
+// The page a later round's focused search brings back.
+const GAP_URL = 'https://directorio.test/instalaciones-rubio'
+const GAP_URL_HASH = createHash('sha256').update(GAP_URL).digest('hex')
+const GAP_EVIDENCE =
+	'Instalaciones Rubio, empresa instaladora eléctrica, socia de la asociación.'
+
+const usage = {
+	inputTokens: {
+		uncached: undefined,
+		total: 0,
+		cacheRead: undefined,
+		cacheWrite: undefined,
+	},
+	outputTokens: { total: 0, text: undefined, reasoning: undefined },
+}
+
+// Agent pass: hand back one web_search result carrying real page text, and no
+// further tool calls, so each pass gathers the seeded source then stops.
+const agentLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({
+			text: '',
+			content: [],
+			reasoning: [],
+			reasoningText: undefined,
+			toolCalls: [],
+			toolResults: [
+				{
+					name: 'web_search',
+					isFailure: false,
+					encodedResult: undefined,
+					result: { items: [{ url: SEED_URL, content: scenario.evidence }] },
+				},
+			],
+			finishReason: 'stop' as const,
+			usage,
+		}) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const extractLlm: LanguageModel.Service = {
+	generateText: () => Effect.succeed({ text: '', content: [], usage }) as never,
+	// An audit gets an empty verdict list, which passes every field it was asked
+	// about; only a reading advances the script.
+	generateObject: ((options: { readonly prompt: string }) =>
+		Effect.succeed({
+			usage,
+			value: options.prompt.startsWith(EXTRACTION_OPENER)
+				? nextReading()
+				: { verdicts: [] },
+		})) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+const writerLlm: LanguageModel.Service = {
+	generateText: () =>
+		Effect.succeed({ text: '## Scan brief', content: [], usage }) as never,
+	generateObject: () => Effect.succeed({ usage, value: {} }) as never,
+	streamText: () =>
+		Stream.succeed({ type: 'text-delta' as const, delta: '' }) as never,
+}
+
+// Nothing else here is reached: a run whose rows cite no page never fetches one,
+// and neither the site map nor a company register is consulted by a scan.
+const unused = 'provider not exercised'
+
+// A later round only re-reads when its focused searches actually brought a page
+// back, so the search answers and that is what carries the run to a second
+// reading.
+const providersLayer = Layer.mergeAll(
+	Layer.succeed(SearchProvider)(
+		SearchProvider.of({
+			search: () =>
+				Effect.succeed(
+					new SearchResult({
+						units: 1,
+						items: [
+							new SearchResultItem({
+								url: GAP_URL,
+								title: 'Instalaciones Rubio',
+								snippet: 'Empresa instaladora',
+								content: GAP_EVIDENCE,
+							}),
+						],
+					}),
+				),
+		}),
+	),
+	Layer.succeed(ScrapeProvider)(
+		ScrapeProvider.of({ scrape: () => Effect.die(unused) }),
+	),
+	Layer.succeed(MapProvider)(MapProvider.of({ map: () => Effect.die(unused) })),
+	Layer.succeed(RegistryRouter)(
+		RegistryRouter.of({ lookup: () => Effect.die(unused) }),
+	),
+)
+
+const eventSink = Layer.succeed(ResearchEventSink)(
+	ResearchEventSink.of({ fire: () => Effect.void }),
+)
+
+const ResearchLive = ResearchService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			Layer.succeed(AgentLanguageModel)(agentLlm),
+			Layer.succeed(ExtractLanguageModel)(extractLlm),
+			Layer.succeed(WriterLanguageModel)(writerLlm),
+		),
+	),
+	Layer.provide(providersLayer),
+	Layer.provide(
+		Layer.succeed(ContactDiscovery)({
+			discover: () =>
+				Effect.succeed({
+					status: 'no_reliable_contact' as const,
+					researchId: 'test',
+				}),
+		}),
+	),
+	Layer.provide(eventSink),
+	Layer.provideMerge(PgLive),
+)
+
+const runtime = ManagedRuntime.make(ResearchLive)
+const TERMINAL = new Set([
+	'succeeded',
+	'succeeded_low_confidence',
+	'failed',
+	'cancelled',
+	'no_reliable_data',
+])
+
+const systemDefaults = {
+	budgetCents: 1000,
+	paidBudgetCents: 500,
+	autoApprovePaidCents: 500,
+	paidMonthlyCapCents: 2000,
+	hardCeiling: 100_000,
+}
+
+const ctx = { org: undefined as unknown as Org }
+let userId: string
+const createdRunIds: string[] = []
+
+interface StoredRow {
+	readonly name: string
+	readonly website: string | null
+}
+
+// Run one scan to its terminal state and report the list it stored.
+const runScan = async (args: {
+	readonly query: string
+	readonly scenario: Scenario
+}): Promise<{
+	status: string
+	prospects: ReadonlyArray<StoredRow>
+	/** How many readings the run asked for, so a case cannot pass vacuously. */
+	readings: number
+}> => {
+	scenario = args.scenario
+	extractionsSoFar = 0
+	return runtime.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ResearchService
+			const sql = yield* SqlClient.SqlClient
+			const scoped = enterOrgScope(sql, { org: ctx.org, userId })
+			const created = yield* scoped(
+				svc.create(
+					userId,
+					ctx.org.id,
+					{
+						query: args.query,
+						schemaName: 'prospect_scan_v1',
+						forceFresh: true,
+					},
+					systemDefaults,
+				),
+			)
+			// A non-selector input never fans out, so it always carries a run id;
+			// rule out the confirm-required variant to keep the type honest.
+			if (created.status === 'confirm_required')
+				return yield* Effect.die(
+					new Error('website-fold test input should not fan out'),
+				)
+			createdRunIds.push(created.id)
+
+			const poll = (
+				attemptsLeft: number,
+			): Effect.Effect<string, never, never> =>
+				Effect.gen(function* () {
+					const run = (yield* svc.get(created.id).pipe(Effect.orDie)) as {
+						status?: string
+					} | null
+					const status = run?.status ?? 'unknown'
+					if (TERMINAL.has(status) || attemptsLeft <= 0) return status
+					yield* Effect.sleep('250 millis')
+					return yield* poll(attemptsLeft - 1)
+				})
+			const status = yield* poll(120)
+
+			const [stored] = yield* scoped(
+				sql<{ findings: unknown }>`
+					SELECT findings FROM research_runs WHERE id = ${created.id}::uuid
+				`,
+			)
+			const list = (stored?.findings as { prospects?: unknown } | null)
+				?.prospects
+			const prospects = Array.isArray(list)
+				? list.map(row => {
+						const held = row as Record<string, unknown>
+						return {
+							name: String(held['name'] ?? ''),
+							website:
+								typeof held['website'] === 'string' ? held['website'] : null,
+						}
+					})
+				: []
+			return { status, prospects, readings: extractionsSoFar }
+		}),
+	)
+}
+
+// The trade body's own host. It spells none of its members, so nothing can
+// establish it as any of their sites — what condemns it is two of them claiming
+// it, which is the evidence a single reading cannot hold.
+const MEMBER_HOST = 'aemiat.com'
+
+const installer = (name: string, website: string) => ({
+	name,
+	website,
+	why_relevant: 'Empresa instaladora que trabaja en España.',
+	citations: [],
+})
+
+// Five installers on their own sites beside the two under test, so the list is
+// never thin enough to earn the refined retry — that retry re-reads from scratch
+// and would make which reading answers which pass depend on it. They are also
+// what says the fix costs no real website: every one of them has to survive.
+const OTHERS = [
+	installer('Electroluz Navarra', 'https://electroluznavarra.test'),
+	installer('Climatiza Duero', 'https://climatizaduero.test'),
+	installer('Fontanería Sagasta', 'https://fontaneriasagasta.test'),
+	installer('Ascensores Ebro', 'https://ascensoresebro.test'),
+	installer('Ignífuga Levante', 'https://ignifugalevante.test'),
+]
+
+const MORA = installer('Electricidad Mora', `https://${MEMBER_HOST}/e-mora/`)
+const RUBIO = installer('Instalaciones Rubio', `https://${MEMBER_HOST}/rubio/`)
+
+// Every company has to be named in a page the run read, or the checks that hold a
+// row to the evidence drop it before the website is ever weighed.
+const EVIDENCE = [
+	'Directorio de empresas instaladoras en España.',
+	'Electricidad Mora e Instalaciones Rubio son socias de la asociación.',
+	'Electroluz Navarra, Climatiza Duero, Fontanería Sagasta, Ascensores Ebro e Ignífuga Levante también son empresas instaladoras.',
+].join('\n')
+
+beforeAll(async () => {
+	const seed = await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [org] = yield* sql<Org>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [user] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!org || !user) {
+				throw new Error(
+					"taller org / admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			// The one source every pass "fetches", so the grounding gate passes and
+			// each run reaches the list under test.
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (${`src-${randomUUID()}`}, 'web', 'it-stub', ${SEED_URL}, ${SEED_URL_HASH}, 'directorio.test', 'seed')
+				ON CONFLICT (url_hash) DO NOTHING
+			`
+			// The page a later round's search brings back, so what that round reads is
+			// linked to the run like any other source.
+			yield* sql`
+				INSERT INTO sources (id, kind, provider, url, url_hash, domain, content_hash)
+				VALUES (${`src-${randomUUID()}`}, 'web', 'it-stub', ${GAP_URL}, ${GAP_URL_HASH}, 'directorio.test', 'gap')
+				ON CONFLICT (url_hash) DO NOTHING
+			`
+			return { org, userId: user.id }
+		}),
+	)
+	ctx.org = seed.org
+	userId = seed.userId
+}, 60_000)
+
+afterAll(async () => {
+	await runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const id of createdRunIds) {
+				yield* sql`DELETE FROM research_cache WHERE research_id = ${id}::uuid`
+				yield* sql`DELETE FROM research_runs WHERE id = ${id}::uuid`
+			}
+			yield* sql`DELETE FROM sources WHERE url_hash IN (${SEED_URL_HASH}, ${GAP_URL_HASH})`
+		}),
+	)
+	await runtime.dispose()
+})
+
+describe('two members of a trade body met a round apart', () => {
+	describe('when only a later round names the second member', () => {
+		it('should store neither of them on the trade body host', async () => {
+			// GIVEN a first reading that puts one member on the trade body's host with
+			//   nobody else on it, and a later round that names the second member there
+			const result = await runScan({
+				query: 'Empresas instaladoras en España',
+				scenario: {
+					evidence: EVIDENCE,
+					readings: [
+						{ prospects: [MORA, ...OTHERS] },
+						{ prospects: [MORA, RUBIO, ...OTHERS] },
+					],
+				},
+			})
+
+			// THEN the run itself stood up and did reach the round that names the
+			//   second member — the list below is only worth reading once both are
+			//   true, since a run that died stores no list to find the address in
+			expect(result.status).toBe('succeeded')
+			expect(result.readings).toBeGreaterThan(1)
+
+			// AND both members are still on the list, each of them with no site. The
+			//   sibling failure to this one is the fold reading the shared address as
+			//   proof the two rows are one company and dropping the second, which
+			//   would empty the address check below without anything having been
+			//   checked — so the rows are counted before the addresses are read
+			expect(
+				[MORA, RUBIO].map(
+					member =>
+						result.prospects.find(row => row.name === member.name)?.website,
+				),
+			).toEqual([null, null])
+
+			// AND the address is on no row at all. The first reading had one claimant
+			//   and kept it, the round had two and blanked the round's copy of both —
+			//   so only the claims the run carried from one reading to the next can
+			//   take it off the row the fold handed back
+			expect(
+				result.prospects
+					.filter(row => row.website?.includes(MEMBER_HOST))
+					.map(row => row.name),
+			).toEqual([])
+
+			// AND every installer that gave its own site still has it: carrying the
+			//   claims counts companies, and a host one company claims is still that
+			//   company's
+			expect(
+				OTHERS.map(
+					other =>
+						result.prospects.find(row => row.name === other.name)?.website,
+				),
+			).toEqual(OTHERS.map(other => other.website))
+		}, 60_000)
+	})
+})

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -194,7 +194,7 @@ import { clearFieldOnlyDoubt } from './unconfirmed-mark-guard'
 import { makeUsageMeter, UsageMeter } from './usage-meter'
 import { verifyValueProvenance } from './value-guard'
 import { constrainVocabulary } from './vocabulary-guard'
-import { guardCompanyWebsites } from './website-guard'
+import { guardCompanyWebsites, type HostClaims } from './website-guard'
 
 // Raw Postgres rows carry `Date` timestamp columns; these decoders read each
 // date from a Date (rather than an ISO string) so the decoded value lands as a
@@ -2841,6 +2841,107 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					let citationsSeen = 0
 					let citationsKept = 0
 
+					// The company the run is about, however it is known: the subject's name when
+					// the run was started from a company on file, and the question itself when it
+					// was started from free text. Read once, so every check that weighs an address
+					// against the run's own company weighs it against the same name.
+					const runSubjectSnapshot = subjects[0]?.snapshot as
+						| Record<string, unknown>
+						| undefined
+					const targetName =
+						typeof runSubjectSnapshot?.['name'] === 'string'
+							? runSubjectSnapshot['name']
+							: (run as { query: string }).query
+
+					// Website sanity, and what it remembers between calls.
+					//
+					// Run on every extraction, and again on the list a fold produced. The list a
+					// run ships is several extractions folded together and no extraction ever
+					// sees it, so a check that only ever ran on an extraction has never read the
+					// answer a reader gets.
+					//
+					// `websiteClaims` is what carries across: which company gave which host as
+					// its website, taken as claimed and before any rule blanked anything. The
+					// rule that condemns a host two differently-named companies claim needs both
+					// of them at once — and a trade body's two members can each arrive alone, in
+					// answers a round apart. Re-reading the folded list cannot recover that: the
+					// round that held both already blanked one of them, so the claim the rule
+					// needs is gone before the rule is asked. Remembering it is the only reading
+					// in which the two are ever together.
+					let websiteClaims: HostClaims = new Map()
+					const checkWebsites = (
+						answer: unknown,
+						pass: 'extraction' | 'folded',
+					) =>
+						Effect.gen(function* () {
+							// Which sites this run watched file several of its own companies. Worked
+							// out per call rather than once, because the organisation-kind link drops
+							// the rows that are not companies at all, a trade body's own name must not
+							// be one of the names a host is judged by, and a fold puts companies in
+							// front of the watch that no single extraction held.
+							const directories = observeDirectorySites({
+								findings: answer,
+								listField: discoveryResultField(schemaName),
+								addresses: [...gatheredAddresses],
+							})
+							const check = guardCompanyWebsites(
+								answer,
+								targetName,
+								directories.sites,
+								websiteClaims,
+							)
+							websiteClaims = check.hostClaims
+							const blanked =
+								check.blankedNotAnAddress +
+								check.blankedDirectory +
+								check.blankedProfilePage +
+								check.blankedSharedHost +
+								check.blankedReadPage
+							if (blanked > 0) {
+								yield* Effect.logWarning('research.websites.blanked').pipe(
+									Effect.annotateLogs({
+										event: 'research.websites.blanked',
+										research_id: researchId,
+										// Which answer was judged: one extraction, or the list a fold
+										// produced. A blank on the folded line is one no extraction could
+										// have reached on its own.
+										pass,
+										blanked_not_an_address: check.blankedNotAnAddress,
+										blanked_directory: check.blankedDirectory,
+										blanked_profile_page: check.blankedProfilePage,
+										blanked_shared_host: check.blankedSharedHost,
+										blanked_read_page: check.blankedReadPage,
+									}),
+								)
+							}
+							// And of the addresses that survived, how many of them anything establishes
+							// as the company's own site. Logged whether or not anything was blanked: a
+							// run whose websites all read `unknown` is not a quiet run, it is one whose
+							// companies have nothing vouching for them.
+							if (
+								check.ownSiteEstablished +
+									check.ownSiteUnknown +
+									check.namedNobodyInParticular >
+								0
+							) {
+								yield* Effect.logInfo('research.websites.own_site').pipe(
+									Effect.annotateLogs({
+										event: 'research.websites.own_site',
+										research_id: researchId,
+										pass,
+										established: check.ownSiteEstablished,
+										unknown: check.ownSiteUnknown,
+										// Beside them, because it says how many of these answers were never
+										// reachable: a company named only after its trade has no word of its
+										// own for a domain to spell, so its `unknown` is what the rules can
+										// say rather than what they found.
+										named_nobody_in_particular: check.namedNobodyInParticular,
+									}),
+								)
+							}
+							return { check, blanked, directories }
+						})
+
 					// Phase-2 extraction + every grounding guard, shared so both the
 					// normal path and the discovery-scan retry run the same logic. Returns
 					// the cleaned findings; the caller writes the single phase-2 checkpoint.
@@ -2965,17 +3066,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// The focused rescue passes below aim at one company — the subject's
 							// name + its own domain — so a recovered person or fact is tied to
 							// the right company.
-							const rescueSnapshot = subjects[0]?.snapshot as
-								| Record<string, unknown>
-								| undefined
 							const rescueTarget = {
-								name:
-									typeof rescueSnapshot?.['name'] === 'string'
-										? rescueSnapshot['name']
-										: (run as { query: string }).query,
+								name: targetName,
+								// Worked out here rather than beside `targetName`: a redirect met
+								// while gathering can still settle which domain the run is about.
 								domain:
-									(typeof rescueSnapshot?.['website'] === 'string'
-										? rescueSnapshot['website']
+									(typeof runSubjectSnapshot?.['website'] === 'string'
+										? runSubjectSnapshot['website']
 										: undefined) ?? entityTargets?.domains?.[0],
 							}
 							// Contacts rescue: the broad pass reliably under-delivers the people
@@ -3338,71 +3435,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									name: 'websites',
 									run: findings =>
 										Effect.gen(function* () {
-											// Which sites this run watched file several of its own
-											// companies. Worked out here rather than once for the chain,
-											// because the organisation-kind link drops the rows that are
-											// not companies at all, and a trade body's own name must not
-											// be one of the names a host is judged by.
-											const directories = observeDirectorySites({
-												findings,
-												listField: discoveryResultField(schemaName),
-												addresses: [...gatheredAddresses],
-											})
-											const check = guardCompanyWebsites(
-												findings,
-												rescueTarget.name,
-												directories.sites,
-											)
-											const blanked =
-												check.blankedNotAnAddress +
-												check.blankedDirectory +
-												check.blankedProfilePage +
-												check.blankedSharedHost +
-												check.blankedReadPage
-											if (blanked > 0) {
-												yield* Effect.logWarning(
-													'research.websites.blanked',
-												).pipe(
-													Effect.annotateLogs({
-														event: 'research.websites.blanked',
-														research_id: researchId,
-														blanked_not_an_address: check.blankedNotAnAddress,
-														blanked_directory: check.blankedDirectory,
-														blanked_profile_page: check.blankedProfilePage,
-														blanked_shared_host: check.blankedSharedHost,
-														blanked_read_page: check.blankedReadPage,
-													}),
-												)
-											}
-											// And of the addresses that survived, how many of them
-											// anything establishes as the company's own site. Logged
-											// whether or not anything was blanked: a run whose websites
-											// all read `unknown` is not a quiet run, it is one whose
-											// companies have nothing vouching for them.
-											if (
-												check.ownSiteEstablished +
-													check.ownSiteUnknown +
-													check.namedNobodyInParticular >
-												0
-											) {
-												yield* Effect.logInfo(
-													'research.websites.own_site',
-												).pipe(
-													Effect.annotateLogs({
-														event: 'research.websites.own_site',
-														research_id: researchId,
-														established: check.ownSiteEstablished,
-														unknown: check.ownSiteUnknown,
-														// Beside them, because it says how many of these
-														// answers were never reachable: a company named
-														// only after its trade has no word of its own for
-														// a domain to spell, so its `unknown` is what the
-														// rules can say rather than what they found.
-														named_nobody_in_particular:
-															check.namedNobodyInParticular,
-													}),
-												)
-											}
+											const { check, blanked, directories } =
+												yield* checkWebsites(findings, 'extraction')
 											return {
 												findings: check.findings,
 												spanCounts: {
@@ -3421,10 +3455,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													//
 													// About this extraction, not about the run. Every gap
 													// round extracts again and the results are folded
-													// together afterwards, so a website only one round
-													// produced is counted on that round's line and missing
-													// from the last one. Read the run's own answer for a
-													// figure about the run.
+													// together afterwards; the folded list is checked too,
+													// and that check's own-site figures are on its
+													// `research.websites.own_site` line, not here.
 													'research.websites.own_site_established':
 														check.ownSiteEstablished,
 													'research.websites.own_site_unknown':
@@ -5204,6 +5237,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						// it is asked — without this, those first few would take every round's
 						// searches and the rest of a long list would never be reached at all.
 						const gapsSearched = new Set<string>()
+						// Every address the check took off the list a fold produced, added up
+						// over the whole loop. Counted here rather than reported round by round,
+						// because what it answers is whether the run ever condemned an address
+						// no single extraction had the evidence to condemn — and a round that
+						// took none would otherwise overwrite the round that took one.
+						let blankedAfterFolds = 0
 						for (let gapRound = 1; gapRound <= MAX_GAP_ROUNDS; gapRound++) {
 							// Who the focused searches are about. A company profile searches
 							// under the anchored subject's name, which is the same name the
@@ -5464,12 +5503,24 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								schemaName,
 							)
 							findings = merged.findings
+							// Nothing has judged this list yet: every extraction was judged on
+							// its own and then folded in, so an address one round condemned for
+							// one company can still be standing on a row another round carried
+							// in. Judged here against every claim the run has read, and after
+							// each fold rather than once at the end, so what the next round
+							// searches for is what the list is actually missing.
+							const foldedWebsites = yield* checkWebsites(findings, 'folded')
+							findings = foldedWebsites.check.findings
+							blankedAfterFolds += foldedWebsites.blanked
 							yield* Effect.annotateCurrentSpan({
 								'research.gap_rounds.round': gapRound,
 								'research.per_field_search.fired': perFieldFired,
 								'research.per_field_search.filled': merged.filled,
 								'research.per_field_search.added': merged.added,
 								'research.per_field_search.folded': merged.folded,
+								// What only a folded list could show: an address no single
+								// extraction had the evidence to condemn, over every round so far.
+								'research.websites.blanked_folded': blankedAfterFolds,
 								'research.gap_rounds.contacts_kept':
 									contactFill(findings).named,
 								'research.gap_rounds.titled_kept': contactFill(findings).titled,

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { mergePerFieldSearch } from './per-field-search'
 import { guardCompanyWebsites } from './website-guard'
 
 // A competitor/prospect entry: a name plus the website the model returned for it.
@@ -359,6 +360,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked — THEN nothing to blank, and it is unchanged. There is no
 			// address to establish anything about either, so neither ownership count
 			// moves: a row with no website is not a row whose website is unvouched for
+			// AND nothing is claimed, since a row with no address claims no host
 			const result = guardCompanyWebsites(findings)
 			expect(result).toEqual({
 				findings,
@@ -370,6 +372,7 @@ describe('guardCompanyWebsites', () => {
 				ownSiteEstablished: 0,
 				ownSiteUnknown: 0,
 				namedNobodyInParticular: 0,
+				hostClaims: new Map(),
 			})
 		})
 
@@ -725,6 +728,78 @@ describe('guardCompanyWebsites', () => {
 			expect(result.blankedSharedHost).toBe(0)
 		})
 
+		it('should stand down for a domain spelling the front of a claimant name', () => {
+			// GIVEN one company met under two names on the domain it registered, which
+			// is the front of one of those names and carries neither of them whole
+			const findings = scan([
+				{ name: 'XPO Logistics', website: 'https://xpo.com' },
+				{ name: 'XPO Iberia', website: 'https://xpo.com/es' },
+			])
+
+			// WHEN checked
+			// THEN both keep it. A firm registers the front of its name or the one word
+			// people use it by, so asking only whether the host carries a name whole
+			// would read a company's own domain as a stranger's and take it from both
+			// rows
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://xpo.com',
+				'https://xpo.com/es',
+			])
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
+		it('should keep a site claimed by one company written two ways', () => {
+			// GIVEN one firm on its own site, written with a word in front of its name
+			// on one row and without it on the other, on a domain naming a trade
+			// rather than the firm
+			const findings = scan([
+				{ name: 'SIMIE', website: 'https://www.securiteincendie.fr/' },
+				{ name: 'Groupe SIMIE', website: 'https://www.securiteincendie.fr/' },
+			])
+
+			// WHEN checked
+			// THEN both keep it. The rule counts different companies, and these are one
+			// company met twice — nothing about the address says otherwise, and reading
+			// the two writings as two firms would take a company's own site off both of
+			// its rows
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://www.securiteincendie.fr/',
+				'https://www.securiteincendie.fr/',
+			])
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
+		it('should keep one page two differently-named rows both point at', () => {
+			// GIVEN a firm on the site it publishes, whose domain names the trade it
+			// works in rather than the firm, with a second row naming that trade and
+			// pointing at the very same page
+			const findings = scan([
+				{
+					name: 'France SAV Solaire',
+					website: 'https://www.sav-onduleur-photovoltaique.com',
+				},
+				{
+					name: 'SAV Photovoltaïque',
+					website: 'https://www.sav-onduleur-photovoltaique.com/',
+				},
+			])
+
+			// WHEN checked
+			// THEN both stand. A host that files companies gives each of them a page of
+			// its own; one page written down twice says nothing about who owns the
+			// host, and the two names share no word for the rule to read them as one
+			// company either — so the only thing left is that the site is somebody's
+			// and a blank would take it from them
+			const result = guardCompanyWebsites(findings)
+			expect(websitesOf(result.findings)).toEqual([
+				'https://www.sav-onduleur-photovoltaique.com',
+				'https://www.sav-onduleur-photovoltaique.com/',
+			])
+			expect(result.blankedSharedHost).toBe(0)
+		})
+
 		it('should keep a host only one company in the answer claims', () => {
 			// GIVEN a single company on a host nobody else gives
 			const findings = scan([
@@ -781,6 +856,327 @@ describe('guardCompanyWebsites', () => {
 					.prospects[0]?.website,
 			).toBe('https://acme.es')
 			expect(result.blankedSharedHost).toBe(0)
+		})
+	})
+
+	describe('when the run has read more than one answer', () => {
+		it('should blank a member page another company claimed in an earlier answer', () => {
+			// GIVEN the sequence a run really runs: a first answer holding one member
+			// of a trade body, then a later round holding two, each answer checked on
+			// its own and the two folded together afterwards
+			const held = guardCompanyWebsites(
+				cited([
+					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				]),
+			)
+			const round = guardCompanyWebsites(
+				cited([
+					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+					{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+				]),
+				undefined,
+				new Set(),
+				held.hostClaims,
+			)
+			const folded = mergePerFieldSearch(
+				held.findings,
+				round.findings,
+				'prospect_scan_v1',
+			)
+
+			// WHEN the folded list is checked against everything the run has read
+			const judged = guardCompanyWebsites(
+				folded.findings,
+				undefined,
+				new Set(),
+				round.hostClaims,
+			)
+
+			// THEN nobody keeps the trade body's host. The first answer had one
+			// claimant and kept the address; the round had two and blanked both, which
+			// is what leaves one row standing on it in the folded list. Only the claims
+			// the run carried put the two companies together again
+			expect(prospectWebsites(judged.findings)).toEqual([undefined, undefined])
+			expect(judged.blankedSharedHost).toBe(1)
+		})
+
+		it('should hand back what it read, so a later answer can be judged against it', () => {
+			// GIVEN one answer holding a single company
+			const findings = scan([
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+			])
+
+			// WHEN checked
+			const result = guardCompanyWebsites(findings)
+
+			// THEN the claim it read comes back with it, filed under the host, so the
+			// next answer is weighed against a company that is not in it
+			expect([...(result.hostClaims.get('aemiat.com')?.keys() ?? [])]).toEqual([
+				'electricidadmora',
+			])
+		})
+
+		it('should record a claim before the rule blanks it', () => {
+			// GIVEN one answer holding both members, which the rule condemns outright
+			const findings = scan([
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+			])
+
+			// WHEN checked
+			const result = guardCompanyWebsites(findings)
+
+			// THEN both addresses go — AND both claims survive in what is handed back.
+			// Reading the answer it produced would find one claimant or none, so the
+			// evidence has to be taken before the blanking or a later answer inherits
+			// nothing
+			expect(websitesOf(result.findings)).toEqual([undefined, undefined])
+			expect([...(result.hostClaims.get('aemiat.com')?.keys() ?? [])]).toEqual([
+				'electricidadmora',
+				'instalacionesrubio',
+			])
+		})
+
+		it('should keep a site whose host an earlier answer named its claimant by', () => {
+			// GIVEN one company met under its trade name first, on the site that name
+			// is in, and under its legal name in a later answer
+			const first = guardCompanyWebsites(
+				scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
+			)
+
+			// WHEN the later answer is checked against what the first one read
+			const later = guardCompanyWebsites(
+				scan([
+					{
+						name: 'Sociedad Ibérica de Construcciones Eléctricas',
+						website: 'https://sice.com/es',
+					},
+				]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN the address stands. Carrying the claims makes the two rows two
+			// claimants on one host for the first time — and the host plainly belongs
+			// to one of them, which is the whole reason this rule stands down. Blanking
+			// here would take away the only thing saying the two rows are one company
+			expect(websitesOf(later.findings)).toEqual(['https://sice.com/es'])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should keep a site whose host only a later answer names its claimant by', () => {
+			// GIVEN the same company, met the other way round: the legal name that
+			// spells nothing arrives first, the trade name the domain carries second
+			const first = guardCompanyWebsites(
+				scan([
+					{
+						name: 'Sociedad Ibérica de Construcciones Eléctricas',
+						website: 'https://sice.com/es',
+					},
+				]),
+			)
+
+			// WHEN the answer holding the trade name is checked against it
+			const later = guardCompanyWebsites(
+				scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN it stands too: which answer named the host is not what settles it,
+			// so the rule cannot come out differently for the order the rounds ran in
+			expect(websitesOf(later.findings)).toEqual(['https://www.sice.com'])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should keep a domain spelling a claimant name front across answers', () => {
+			// GIVEN one company met under one name first and under another in a later
+			// answer, both on the domain that is the front of the first name
+			const first = guardCompanyWebsites(
+				scan([{ name: 'XPO Logistics', website: 'https://xpo.com' }]),
+			)
+
+			// WHEN the later answer is checked against what the first read
+			const later = guardCompanyWebsites(
+				scan([{ name: 'XPO Iberia', website: 'https://xpo.com/es' }]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN it stands. Carrying the claims is what puts two names on this host
+			// for the first time, so the reading that recognises an abbreviated domain
+			// as its owner's has to hold across answers too, or the fix for a trade
+			// body's page is paid for with real company sites
+			expect(websitesOf(later.findings)).toEqual(['https://xpo.com/es'])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should keep a site one company claims two ways across answers', () => {
+			// GIVEN a firm met under its short name first and with a word in front of
+			// it in a later answer, on the same site both times
+			const first = guardCompanyWebsites(
+				scan([{ name: 'SIMIE', website: 'https://www.securiteincendie.fr/' }]),
+			)
+
+			// WHEN the later answer is checked against what the first read
+			const later = guardCompanyWebsites(
+				scan([
+					{ name: 'Groupe SIMIE', website: 'https://www.securiteincendie.fr/' },
+				]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN it stands. Carrying the claims is what brings the two writings
+			// together for the first time, so counting companies rather than writings
+			// has to hold across answers too
+			expect(websitesOf(later.findings)).toEqual([
+				'https://www.securiteincendie.fr/',
+			])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should not make a crowd of one company met under two spellings', () => {
+			// GIVEN one company on a host that does not name it, written with the
+			// Catalan geminate mark in the first answer and without it in the second
+			const first = guardCompanyWebsites(
+				scan([
+					{ name: 'Instal·lacions Puig', website: 'https://gremi.cat/puig/' },
+				]),
+			)
+
+			// WHEN the second answer is checked against what the first read
+			const later = guardCompanyWebsites(
+				scan([
+					{ name: 'Instal.lacions Puig', website: 'https://gremi.cat/puig/' },
+				]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN the address stands. A company is held under the one name it is
+			// written by however an answer spells it, so re-reading the same company
+			// every round can never make it two companies claiming one host
+			expect(websitesOf(later.findings)).toEqual(['https://gremi.cat/puig/'])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should not count a name with nothing distinctive as a claimant', () => {
+			// GIVEN a row whose name is nothing but a legal form, on a host a real
+			// company claims in a later answer
+			const first = guardCompanyWebsites(
+				scan([{ name: 'SL', website: 'https://gremi.cat/anon/' }]),
+			)
+
+			// WHEN the later answer is checked against it
+			const later = guardCompanyWebsites(
+				scan([
+					{ name: 'Electricidad Mora', website: 'https://gremi.cat/mora/' },
+				]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN the address stands: a name nothing can be read from says nothing
+			// about who a host belongs to, so it must not be carried as a claimant and
+			// turn one company into two
+			expect(websitesOf(later.findings)).toEqual(['https://gremi.cat/mora/'])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should leave a host alone when only one company ever claimed it', () => {
+			// GIVEN the same single company read again in a later answer
+			const first = guardCompanyWebsites(
+				scan([
+					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				]),
+			)
+
+			// WHEN the later answer is checked against what the first read
+			const later = guardCompanyWebsites(
+				scan([
+					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN it stands. Carrying the claims counts companies, never readings, so
+			// a run that reads the same company every round does not talk itself into
+			// blanking its address
+			expect(websitesOf(later.findings)).toEqual(['https://aemiat.com/e-mora/'])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should not carry a person website in a proposal into what it read', () => {
+			// GIVEN a contact proposal naming a host, read before an answer that puts a
+			// second company on it
+			const first = guardCompanyWebsites({
+				prospects: [
+					{ name: 'Acme Instal', website: 'https://gremi.cat/acme/' },
+				],
+				proposed_updates: [
+					{
+						operation: 'create',
+						fields: { name: 'Ada Lovelace', website: 'https://gremi.cat/ada/' },
+					},
+				],
+			})
+
+			// WHEN the later answer is checked against it
+			const later = guardCompanyWebsites(
+				scan([{ name: 'Acme Instal', website: 'https://gremi.cat/acme/' }]),
+				undefined,
+				new Set(),
+				first.hostClaims,
+			)
+
+			// THEN the company keeps its address: the proposal subtree is skipped when
+			// the claims are gathered, so a person cannot follow the run into a later
+			// round and cost a company its site there
+			expect(websitesOf(later.findings)).toEqual(['https://gremi.cat/acme/'])
+			expect(later.blankedSharedHost).toBe(0)
+		})
+
+		it('should judge an answer the same way when nothing was read before it', () => {
+			// GIVEN one answer with a shared host, a listing shape and an own site in it
+			const findings = scan([
+				{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
+				{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
+				{ name: 'Acme', website: 'https://directorio.es/empresa/acme' },
+				{
+					name: 'XPO Logistics',
+					website: 'https://xpo.com/about-xpo-logistics',
+				},
+			])
+
+			// WHEN checked with no earlier claims, either left out or handed in empty
+			const withoutPrior = guardCompanyWebsites(findings)
+			const withEmptyPrior = guardCompanyWebsites(
+				findings,
+				undefined,
+				new Set(),
+				new Map(),
+			)
+
+			// THEN both read the answer identically: with nothing carried in, an
+			// answer is judged on itself alone
+			expect(websitesOf(withEmptyPrior.findings)).toEqual(
+				websitesOf(withoutPrior.findings),
+			)
+			expect(withEmptyPrior.blankedSharedHost).toBe(
+				withoutPrior.blankedSharedHost,
+			)
+			expect(withEmptyPrior.blankedProfilePage).toBe(
+				withoutPrior.blankedProfilePage,
+			)
 		})
 	})
 

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -16,8 +16,8 @@
  *  - its host does not carry the company's name AND the name sits in a deeper part
  *    of the address — the shape of "someone-else.com/company/<the-company>", which
  *    is a listing, never a company's own home page, or
- *  - its host does not carry the company's name AND other companies in the same
- *    answer claim that host as theirs too, or
+ *  - its host does not carry the company's name AND other companies the run has
+ *    read claim that host as theirs too, or
  *  - nothing in the address names the company anywhere AND the address is the one
  *    page every source the row cites points at — the field holding the page the
  *    claim was read from rather than the site that page sits on.
@@ -41,9 +41,11 @@
  * website, which arrives on its own with no name beside it and so is judged against
  * the target's name passed in. The read-page rule reads one more thing off the same
  * row, the sources it cites, which travel with it. The shared-host rule asks about
- * the whole answer rather than one row, which is why the walk below is preceded by
- * a reading pass that gathers who claims which host; the directory rule asks about
- * the whole RUN, and is handed its answer from outside (see `directory-sites.ts`).
+ * every answer the run has read rather than one row, which is why the walk below is
+ * preceded by a reading pass that gathers who claims which host, and why what it
+ * gathered comes back out with the result so the next call can be handed it; the
+ * directory rule asks about the whole RUN, and is handed its answer from outside
+ * (see `directory-sites.ts`).
  */
 
 import { type DirectorySites, siteVerdict } from './directory-sites'
@@ -55,7 +57,7 @@ import {
 	spellingsWithoutForms,
 } from './entity-guard'
 import { citedSourceIds, isPlainObject } from './guard-shapes'
-import { ownSiteVerdict } from './own-site'
+import { ownSiteHostVerdict, ownSiteVerdict } from './own-site'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
 
 const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
@@ -146,24 +148,50 @@ const citesNothingButThisPage = (
 	citedSources.length > 0 &&
 	citedSources.every(source => samePage(website, source))
 
-// Who claims which host, across a whole answer: a host mapped to every company
-// that gave it as its website. Gathered before anything is rewritten, because
-// "is this host any one company's own?" cannot be answered from one row. A value
-// that is not an address, or a name with nothing distinctive in it, tells us
-// nothing about who a host belongs to and is left out.
-//
-// Each company is held under the one name it is written by, with every spelling
-// an address may use for it alongside. Held that way rather than as a flat set
-// of spellings, because the rule below counts these to ask how many companies
-// claim a host: a Catalan name an address can write two ways would otherwise be
-// two of them on its own, and one company would look like a crowd.
-type HostClaims = ReadonlyMap<
-	string,
-	ReadonlyMap<string, ReadonlyArray<string>>
->
+/**
+ * Who claims which host: a host mapped to every company that gave it as its
+ * website. Gathered before anything is rewritten, because "is this host any one
+ * company's own?" cannot be answered from one row. A value that is not an
+ * address, or a name with nothing distinctive in it, tells us nothing about who
+ * a host belongs to and is left out.
+ *
+ * Each company is held under the one name it is written by, with every writing
+ * of it this host has been claimed under alongside. Held that way rather than as
+ * a flat set of names, because the shared-host rule counts these to ask how many
+ * companies claim a host: a Catalan name an address can write two ways would
+ * otherwise be two of them on its own, and one company would look like a crowd.
+ *
+ * The names are kept as written rather than folded down to what an address would
+ * spell, because the stand-down below puts each of them to `own-site.ts`, and
+ * that reader weighs a name's words and its shorter forms — none of which
+ * survives the folding.
+ *
+ * The pages are kept beside them because where on a host a company was filed is
+ * what tells a listing from a site: a trade body gives each member a page of its
+ * own, while a company met under two names is one page written down twice.
+ *
+ * Exported because a run reads several answers and folds them into one, and the
+ * claims have to outlive each reading — see `guardCompanyWebsites`.
+ */
+export interface HostClaim {
+	/** Every writing of the company this host has been claimed under. */
+	readonly names: ReadonlyArray<string>
+	/** Every page of this host it was given, the site itself being the empty one. */
+	readonly pages: ReadonlyArray<string>
+}
 
-const collectHostClaims = (findings: unknown): HostClaims => {
-	const claims = new Map<string, Map<string, ReadonlyArray<string>>>()
+export type HostClaims = ReadonlyMap<string, ReadonlyMap<string, HostClaim>>
+
+const collectHostClaims = (
+	findings: unknown,
+	prior: HostClaims,
+): HostClaims => {
+	const claims = new Map<string, Map<string, HostClaim>>()
+	// What earlier readings claimed, carried in as if it had been read here. A
+	// company that claimed a host in an earlier reading still claims it: nothing
+	// a later reading says takes that back, and the rule below is the one thing
+	// that needs both claimants at once.
+	for (const [host, claimants] of prior) claims.set(host, new Map(claimants))
 	const visit = (value: unknown): void => {
 		if (Array.isArray(value)) {
 			for (const item of value) visit(item)
@@ -177,16 +205,18 @@ const collectHostClaims = (findings: unknown): HostClaims => {
 			const spellings = spellingsWithoutForms(name)
 			const identity = spellings[0]
 			if (host !== null && identity !== undefined) {
-				const claimants =
-					claims.get(host) ?? new Map<string, ReadonlyArray<string>>()
-				// Every spelling this company has been written with on this host, not
-				// just the last row's. Two rows of one company can spell it differently
-				// — one with the geminate mark and one without — and taking only the
-				// later row would drop the spelling that recognises the company's own
-				// host, which is what stands the rule below down.
-				claimants.set(identity, [
-					...new Set([...(claimants.get(identity) ?? []), ...spellings]),
-				])
+				const claimants = claims.get(host) ?? new Map<string, HostClaim>()
+				// Every writing this company has been claimed under on this host, and
+				// every page of it the company was given — not just the last row's. Two
+				// rows of one company can spell it differently, one with the geminate
+				// mark and one without, and taking only the later row would drop the
+				// writing that recognises the company's own host, which is what stands
+				// the rule below down.
+				const held = claimants.get(identity)
+				claimants.set(identity, {
+					names: [...new Set([...(held?.names ?? []), name])],
+					pages: [...new Set([...(held?.pages ?? []), pageOf(website)])],
+				})
 				claims.set(host, claimants)
 			}
 		}
@@ -198,16 +228,83 @@ const collectHostClaims = (findings: unknown): HostClaims => {
 	return claims
 }
 
-// One company vouching for a host stands the shared-host rule down for every row
-// on it, so a name too short to mean anything would quietly switch the rule off.
+// Whether two claimants are plainly DIFFERENT companies. One host cannot be two
+// different companies' own site, and that is the whole premise of the rule below
+// — but two claimants that are one company written two ways are not two
+// companies, and reading them as such turns a firm's own site into a host nobody
+// owns and takes the address off both its rows.
+//
+// A firm writes its name with a word in front on one page and without it on
+// another — "SIMIE" beside "Groupe SIMIE" — and each writing arrives as its own
+// claimant. So a claimant whose distinctive words all appear in another's is
+// that other one met again rather than somebody new. Read on the words rather
+// than on the letters, because the added word can sit anywhere in the name.
+//
+// A name with no distinctive word in it says nothing about who it is, so it
+// nests into nobody and is counted on its own — the same withholding every
+// reading of a name here makes when it has nothing to read.
+const differentCompanies = (one: HostClaim, other: HostClaim): boolean => {
+	const wordsOf = (claim: HostClaim): ReadonlySet<string> =>
+		new Set(claim.names.flatMap(name => distinctiveWords(name)))
+	const nests = (
+		inner: ReadonlySet<string>,
+		outer: ReadonlySet<string>,
+	): boolean => inner.size > 0 && [...inner].every(word => outer.has(word))
+	const ours = wordsOf(one)
+	const theirs = wordsOf(other)
+	return !nests(ours, theirs) && !nests(theirs, ours)
+}
+
+// Whether the host filed these two apart, which is what a site listing companies
+// does: a trade body gives each member a page of its own ("aemiat.com/e-mora/"
+// beside "aemiat.com/rubio/"). Two claimants on the SAME page are one page
+// written down twice — the ordinary shape of a company met under two names, each
+// row recording the site it publishes — and that is no evidence the host files
+// anybody.
+const filedApart = (one: HostClaim, other: HostClaim): boolean =>
+	one.pages.some(page => !other.pages.includes(page)) ||
+	other.pages.some(page => !one.pages.includes(page))
+
+// Whether a host is filing companies rather than being one company's site: some
+// two of its claimants are different companies AND it gave them different pages.
+const filesSeveralCompanies = (
+	claimants: ReadonlyMap<string, HostClaim>,
+): boolean => {
+	const claims = [...claimants.values()]
+	return claims.some((one, at) =>
+		claims
+			.slice(at + 1)
+			.some(other => differentCompanies(one, other) && filedApart(one, other)),
+	)
+}
+
+// Whether a host plainly belongs to one of the companies claiming it, asked two
+// ways because neither reading contains the other.
+//
+// The host carrying the name is the loose reading: "acme-directory.com" carries
+// "Acme" and belongs to somebody else. It is kept because a wrong yes here only
+// withholds a blank, and a blank costs a real website. A name too short to mean
+// anything is left out of it, or it would quietly switch the rule off for every
+// row on the host.
+//
+// The domain being established as that company's own is the reading the rest of
+// the run uses, and it reaches what the first one cannot: a firm registers the
+// front of its name or the one word people use it by, so "XPO Logistics" is at
+// xpo.com and "Transportes García" at garcia.es — neither of which carries the
+// whole name. Without it, one company met under two names on a domain like that
+// reads as two companies sharing a stranger's host, and both lose a site that
+// really is theirs.
 const hostBelongsTo = (
 	host: string,
-	claimantSpellings: ReadonlyArray<string>,
+	claimantNames: ReadonlyArray<string>,
 ): boolean =>
-	claimantSpellings.some(
-		spelling =>
-			spelling.length >= DISTINCTIVE_NAME_LENGTH &&
-			collapse(host).includes(spelling),
+	claimantNames.some(
+		name =>
+			spellingsWithoutForms(name).some(
+				spelling =>
+					spelling.length >= DISTINCTIVE_NAME_LENGTH &&
+					collapse(host).includes(spelling),
+			) || ownSiteHostVerdict({ name, host }) === 'established',
 	)
 
 type WebsiteVerdict =
@@ -263,23 +360,35 @@ const classifyWebsite = (args: {
 	) {
 		return 'profile_page'
 	}
-	// A host several companies in this answer call their own, and that none of them
-	// is named by. A trade body's member directory gives each member a page at the
-	// top level ("aemiat.com/<member>/"), which the first-segment exemption above
-	// reads as a company describing itself on its own site — right for
-	// "xpo.com/about-xpo", wrong here. What separates the two is not the address but
-	// the companies beside it: one host cannot be four different companies' own
-	// site, and the four names saying so are in the same list.
+	// A host several DIFFERENT companies call their own, and that none of them is
+	// named by. A trade body's member directory gives each member a page at the top
+	// level ("aemiat.com/<member>/"), which the first-segment exemption above reads as a
+	// company describing itself on its own site — right for "xpo.com/about-xpo",
+	// wrong here. What separates the two is not the address but the companies beside
+	// it: one host cannot be four different companies' own site, and a host that is
+	// filing them gives each one a page of its own.
 	//
 	// One of them being named by the host changes the answer completely: the host is
 	// then plainly that company's, and the other rows on it are the same company met
 	// again under its other name — a trade name beside a legal one. Blanking those
 	// would take away the very site that says the two rows are one company.
+	//
+	// The claimants need not have arrived together. A run reads its list several
+	// times and folds the readings into one, so the trade body's two members can
+	// each be alone in the answer they arrive in; what makes them a crowd is the
+	// run having read both, which is what `priorClaims` carries.
+	//
+	// Whose host it is comes from `own-site.ts`, the one answer the rest of the run
+	// uses, with the looser reading beside it — see `hostBelongsTo`. Both only ever
+	// hold this rule back, which is the direction a website check is allowed to be
+	// wrong in.
 	const claimants = hostClaims.get(host)
 	if (
 		claimants !== undefined &&
-		claimants.size > 1 &&
-		![...claimants.values()].some(claimant => hostBelongsTo(host, claimant))
+		filesSeveralCompanies(claimants) &&
+		![...claimants.values()].some(claimant =>
+			hostBelongsTo(host, claimant.names),
+		)
 	) {
 		return 'shared_host'
 	}
@@ -344,6 +453,15 @@ export interface WebsiteGuardResult {
 	 * not be added up as if they were one answer.
 	 */
 	readonly namedNobodyInParticular: number
+	/**
+	 * Who claimed which host — this answer's claims and every earlier call's,
+	 * recorded as claimed and before any rule blanked anything.
+	 *
+	 * Handed back so the next call can be given it, which is what lets the
+	 * shared-host rule weigh two claimants that never appeared in the same
+	 * answer.
+	 */
+	readonly hostClaims: HostClaims
 }
 
 /**
@@ -358,11 +476,21 @@ export interface WebsiteGuardResult {
  * `directorySites` are the hosts the run itself watched behave like a listing. It
  * defaults to none, which costs only that rule: a run that gathered nothing to
  * watch still gets every rule that reads a name and an address.
+ *
+ * `priorClaims` is what earlier calls read — `hostClaims` off their result. It
+ * defaults to none, which is one answer judged on its own. A run that extracts
+ * several times and folds the results together has to pass it, and has to judge
+ * the folded list too: each answer is judged alone and then merged, so a member
+ * page condemned for one company while its neighbour was in another answer is
+ * standing on the list that ships, and no reading of that list can recover the
+ * claim that condemned it. Recorded claims can, because they are taken before
+ * the blanking.
  */
 export const guardCompanyWebsites = (
 	findings: unknown,
 	targetName?: string,
 	directorySites: DirectorySites = new Set(),
+	priorClaims: HostClaims = new Map(),
 ): WebsiteGuardResult => {
 	let blankedNotAnAddress = 0
 	let blankedDirectory = 0
@@ -372,7 +500,7 @@ export const guardCompanyWebsites = (
 	let ownSiteEstablished = 0
 	let ownSiteUnknown = 0
 	let namedNobodyInParticular = 0
-	const hostClaims = collectHostClaims(findings)
+	const hostClaims = collectHostClaims(findings, priorClaims)
 
 	// A name the guard could read, holding no word of the company's own. Counted
 	// as the website is judged rather than by its verdict, because what it records
@@ -485,5 +613,6 @@ export const guardCompanyWebsites = (
 		ownSiteEstablished,
 		ownSiteUnknown,
 		namedNobodyInParticular,
+		hostClaims,
 	}
 }


### PR DESCRIPTION
## What

A company could reach the CRM with a trade association's page written into its `website` field — the page the association gives it in its member list, not a site the company publishes. A person clicking through lands on somebody else's directory. This is the Research context (`packages/research`), on the search that goes looking for a whole market.

Both companies in the reported case are members of the body at `aemiat.com`, which gives each of them a page: `aemiat.com/e-mora/` and `aemiat.com/rubio/`. Neither page belongs to either company. One still shipped.

## The fix

**Touches:** the website check, the memory it now keeps between readings, and the step order in the run that folds several readings into the list a person is handed — plus the shared reading of a company name that decides whether two rows are two companies.

- **The evidence was being destroyed before the rule could weigh it.** The rule that condemns an address blanks it only when two differently-named companies claim it at the same time. A run reads its list several times and folds the readings together afterwards, so each reading holds one member; the reading that happens to hold both blanks its own copies of the address, and the fold then hands back the earlier reading's copy, address and all. Re-checking the folded list afterwards cannot recover this — I measured it, and it reports nothing found, because the claim the rule needs went with the blanking.
- **So the run remembers the claims instead.** Who claimed which address is written down as it is claimed, before any rule blanks anything, and carried from one reading to the next. The folded list — the one a reader is handed, and the one no single reading ever sees — is then put back to the check with that memory. Both halves are load-bearing: switching either one off makes the run store the reported failure again.
- **Reaching across readings costs real websites unless the host is read more carefully.** Two shapes came out of real market lists, each one an address the rule was taking wrongly, and both are now asked for before it fires:
  - **It counts companies, not writings of a name.** A live pass turned up "SIMIE" and "Groupe SIMIE" both on `www.securiteincendie.fr` — which I opened, and it is genuinely Groupe SIMIE's own site. A claimant whose distinctive words all appear in another's is that one met again, not somebody new.
  - **It asks that the host filed them on different pages.** An association gives each member a page of its own (`/e-mora/`, `/rubio/`); a firm's own site is one page written down twice. A sweep of stored lists turned up `France SAV Solaire` and `SAV Photovoltaïque` both on the bare root of `sav-onduleur-photovoltaique.com` — again a real company site, and one the name reading above cannot save, since the two names share no word.
- **The rule also stands down for an address the run establishes as a claimant's own.** The old test only asked whether the host text carried the whole name, which misses the domains firms actually register — `xpo.com` for XPO Logistics, `garcia.es` for Transportes García. Both readings are asked now, and all of these only ever hold the rule back.

## Impact

- **Nothing to run before or after the merge.** No database change, no new setting the server needs at boot, no change to what one organisation can see of another's data (row-level security), and no change to the shape of anything the web app or an outside tool reads back.
- **Both ways in get the fix.** It lives in the research pipeline itself, below the split between the API and the tool surface an outside assistant talks to (MCP), so a search started either way behaves the same.
- **It can now take an address away that used to survive** — that is the point — and the only new blanks are addresses two different companies in the same run both claimed, with nothing saying the address belongs to either. Measured below.
- **Two log lines gain a `pass` field** saying whether a reading or the folded list was judged, and a run's span gains `research.websites.blanked_folded`, counting what only the folded list could show. Nothing reads these today beyond a person grepping.

## Review guide

- **Start at `packages/research/src/application/website-guard.ts`.** The rule's shape is unchanged; what changed is the evidence it is handed (`priorClaims` in, `hostClaims` out) and what it asks of that evidence before firing — `filesSeveralCompanies`, built from `differentCompanies` and `filedApart`, plus the widened `hostBelongsTo`. Those are the risky part, because each one *withholds* a blank, and withholding too much is how a directory's page survives. Each exists because it was measured saving a real website; the numbers are below.
- **Then `research-service.ts`**, which is only two things: a shared `checkWebsites` closure lifted out of the guard chain, and one extra call to it after each fold. The rest of that file's diff is the lift, not new behaviour.
- **A decision you might overrule:** the folded pass re-asks *every* rule, not only the one this issue is about. I judged that right — the folded list is what ships and no reading ever sees it, and the file's own header already asked for it — but it does mean the association-watch reads the run's full company list for the first time. The measurement below is what I'd point at to defend it; if you'd rather it were narrowed to the one rule, say so and I'll scope it.
- **Deliberately not done:** I did not make the website field consult the "is this the company's own site" verdict, which is the move its sibling issue used. Reasoning in the first *Deferred* bullet.
- `apps/server/src/services/research-scan-website-fold.integration.test.ts` is mostly harness copied from the sibling suite next to it — skim it; the case is at the bottom.

## Tests

- Fifteen unit cases in `website-guard.test.ts`: the reported failure end to end across readings, claims recorded before blanking, one company met under two spellings or with a word in front of its name, two rows on one page, a name with nothing distinctive in it, a domain spelling the front of a name, a person's website in a proposal staying out of the claims, and a single reading judged identically to before.
- One service-level case driving the real pipeline with stubbed providers, asserting the list the run *stores*: both members present, neither on the association's host, and every other installer keeping its own site.
- Every new case fails with the relevant half of the change removed — I checked each one rather than assuming.

## Verification

- `pnpm check-types`, `pnpm test` (3,218 unit), `pnpm test:integration` (748, including the new one), `pnpm build` — all green on this branch rebased onto `db1fd7ef4c`.
- **Live market pass against real providers** (ES + FR, the rows in `eval/golden-markets.example.json`), run once on `main`'s code and once on this branch. A market search reaches different pages every time — the two French runs came back with 45 and 37 companies — so comparing the two passes head-on measures the weather, not the change. The honest comparison holds the evidence still: re-check the same stored list under both rules.
- **Seventeen stored market lists, 673 companies, 376 websites** — the three from those live runs plus fourteen from earlier passes sitting in other worktree databases. Under this branch's rules the check takes **four** addresses and **no company site**:

  | what it took | why |
  | --- | --- |
  | a reno.energy guide article about French panel makers | the page the row was read from, naming the company nowhere |
  | an `annuaire-entreprises.data.gouv.fr` register entry | same |
  | a Europages category page for lift maintenance | same |
  | an Instagram post | same |

  All four come from a rule this PR does not touch. The shared-host rule — the one this PR changes — takes **zero**. Remove the company-counting half and it takes two (both halves of Groupe SIMIE); remove the different-pages half and it takes two more (France SAV Solaire and the row beside it). That is how each half earned its place.
- One Spanish run failed early with an internal error on a first attempt; it was on `main`'s own code with this change reverted, and the same query succeeded on the next pass, so it is not from this work.

## Deferred

- **Whether an address nothing establishes as a company's own should be blanked outright** stays open (#477). Its sibling #483 could lean on that verdict because being wrong there costs a duplicate row; here the same verdict would take a value away, and #476 measured the price — eight of twelve such addresses were real company sites. Same verdict, opposite direction of harm, so the two halves answer deliberately differently and both say why in the code.
- **The association-watch still misses a directory that shortens its members' names** — `aemiat.com/electricidad-mora/` reads as a directory, `aemiat.com/e-mora/` does not. Already written down in `directory-sites.ts`; closing it means matching names more loosely, which is a new way to clear a stranger's address and wants its own measurement.
- **Two telemetry rough edges I left alone**, both noted in the review: the count of what a paid round filled in is taken before the folded check runs, so a website filled and then blanked is still counted as filled; and the folded pass re-runs even when a fold changed nothing, which I kept on purpose because the association-watch grows between folds.

Closes #502
