### PR TITLE
feat(research): read a trade word written in front of a company's name

### DIFF
--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -694,6 +694,41 @@ describe('hostLabel', () => {
 			expect(hostLabel('')).toBe('')
 		})
 	})
+
+	describe('when the label was registered with an accent', () => {
+		it('should hand back the name its owner registered', () => {
+			// GIVEN domains whose names hold an accent, which a web address cannot
+			// carry — so they travel in a code opening "xn--"
+			// WHEN each is read
+			// THEN the name comes back rather than the code, which folds to letters
+			// spelling nothing any company is called
+			expect(hostLabel('xn--construccionsgarca-xyb.cat')).toBe(
+				'construccionsgarcía',
+			)
+			expect(hostLabel('xn--nergie-solaire-9jb.fr')).toBe('énergie-solaire')
+			expect(hostLabel('www.xn--nergie-solaire-9jb.fr')).toBe('énergie-solaire')
+		})
+
+		it('should keep a code it cannot make sense of', () => {
+			// GIVEN a label wearing that opening over something that is not one
+			// WHEN read
+			// THEN the code itself comes back. A reader hands back nothing for a code
+			// it cannot read, and an empty label would throw away the only text there
+			// was
+			expect(hostLabel('xn--acme-9ta.com')).toBe('xn--acme-9ta')
+		})
+
+		it('should leave a label that was never in that code alone', () => {
+			// GIVEN ordinary labels, one of them all digits
+			// WHEN each is read
+			// THEN each comes back untouched. Only a label wearing the opening is put
+			// back, because a reader asked about a plain one also tries to read it as
+			// a machine address and answers "0.0.0.1" for the "1" read below
+			expect(hostLabel('192.168.1.10')).toBe('1')
+			expect(hostLabel('acme.com')).toBe('acme')
+			expect(hostLabel('my_host.example.com')).toBe('example')
+		})
+	})
 })
 
 describe('registrableDomain', () => {
@@ -929,6 +964,26 @@ describe('isOwnSiteHost', () => {
 
 		it('should accept the whole name spelled out', () => {
 			expect(isOwnSiteHost(garcia, 'transportesgarcia.com')).toBe(true)
+		})
+
+		it("should accept the company's own domain written with an accent", () => {
+			// GIVEN a French firm whose domain holds an accent, so it travels in the
+			// code a web address can carry, and a second firm's accented domain
+			// WHEN this reading — the stricter of the two, which picks the ONE site a
+			// run then goes and reads — is asked about each
+			// THEN the company's own is its own and the stranger's is not. Left in
+			// the code the label spells nothing, and the run would decline to open
+			// the company's own site at all
+			const energie: EntityTargets = {
+				cores: ['energiesolaire'],
+				words: ['energie', 'solaire'],
+				domains: [],
+				places: [],
+			}
+			expect(isOwnSiteHost(energie, 'xn--nergie-solaire-9jb.fr')).toBe(true)
+			expect(isOwnSiteHost(energie, 'xn--construccionsgarca-xyb.cat')).toBe(
+				false,
+			)
 		})
 
 		it('should accept the whole name with the legal form tacked on', () => {

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -17,6 +17,8 @@
  *              and fails closed as no_reliable_data.
  */
 
+import { domainToUnicode } from 'node:url'
+
 import { EQUIVALENT_LETTERS } from './letter-equivalences.generated'
 
 // Legal-form suffixes dropped before matching, so "Acme Logistics S.L." and a
@@ -78,6 +80,17 @@ const GENERIC_WORDS = new Set([
 	'express',
 	'group',
 	'grupo',
+	// The French spelling belongs beside the other two: without it "groupe" counts
+	// as a word of a company's own, so groupe.fr reads as the site of every firm
+	// called Groupe something — the very thing grupo.es is refused for, left open
+	// in one of the two markets this is measured on.
+	//
+	// A word added here that EXTENDS one already on the list also moves where
+	// `own-site.ts` cuts a domain, since it reads past the longest of these a label
+	// opens with: "groupe" hides "group", so groupexpress.fr is cut to "xpress"
+	// rather than to the "express" the shorter word leaves standing. Worth checking
+	// a new word against the ones it spells the front of.
+	'groupe',
 	'holding',
 	'holdings',
 	'services',
@@ -475,6 +488,57 @@ export const domainHost = (website: string): string | undefined => {
 	return host.includes('.') && host.length >= 4 ? host : undefined
 }
 
+// What the owner of a domain actually registered. A web address carries only the
+// letters a–z, so a name holding anything else — an accent, or a whole alphabet
+// of its own — is written into the address in a code that begins "xn--", and the
+// reader hands that code back rather than the name: "xn--construccionsgarca-xyb"
+// for construccionsgarcía. Folded as it stands, the code spells nothing any
+// company is called, so the firm's own site reads as a stranger's — in exactly
+// the markets this work is for.
+//
+// Putting the name back is not the same as clearing it. A domain written in
+// another alphabet comes back in that alphabet, and the fold has plain letters
+// only for the ones it holds a spelling for, so a name merely made to LOOK like
+// the company's still spells nothing.
+//
+// Only a label wearing that opening is put back, so an ordinary one is never
+// touched: asked about a plain label the reader also tries to read it as a
+// machine address, and hands back "0.0.0.192" for "192". A code the reader
+// cannot make sense of comes back empty, and handing back an empty label would
+// throw away the only text there was, so the code itself is kept.
+const CODED_LABEL_OPENING = 'xn--'
+
+// The marks that join two parts of a name rather than spell any of it, which the
+// fold drops on purpose: the hyphen a domain writes between words, and the dots
+// Catalan writes between a geminate l.
+const JOINS_TWO_PARTS = /[-.\u00B7\u0387\u2022\u2027\u2219\u22C5]/u
+
+// Whether the fold has a plain spelling for every letter of a name. The fold
+// DROPS what it cannot spell, so a name that is the company's own followed by a
+// word in an alphabet the table has no answer for comes out as the company's own
+// alone: "fusteriamiquelотзывы" reads as "fusteriamiquel", and a site writing
+// reviews of the workshop is established as the workshop's. Reading only the
+// names the fold can spell whole keeps that door shut, and costs nothing a
+// company registered — an accent has a plain spelling, which is the whole reason
+// this reads the name at all.
+const spelledWhole = (registered: string): boolean =>
+	[...registered].every(
+		letter =>
+			JOINS_TWO_PARTS.test(letter) ||
+			/^[a-z0-9]+$/.test(inPlainLetters(letter)),
+	)
+
+// What it still cannot tell apart: a name spelled in plain letters and a domain
+// that spells it with an accent are one name here, so a firm called Acme is at
+// home on ácme.com as well as on acme.com. That is the same equivalence that
+// puts Muñoz at munoz.es, read from the other side, and refusing it here would
+// have the fold answer two ways about one pair of spellings.
+const asRegistered = (label: string): string => {
+	if (!label.toLowerCase().startsWith(CODED_LABEL_OPENING)) return label
+	const registered = domainToUnicode(label)
+	return registered === '' || !spelledWhole(registered) ? label : registered
+}
+
 /**
  * The label a domain is registered under — "acme" from "acme.co.uk", "tecsol"
  * from "annuaire.tecsol.fr". Empty when the host has no label to read.
@@ -490,7 +554,7 @@ export const hostLabel = (host: string): string => {
 	if (labels.length >= 2 && SECOND_LEVEL.has(labels[labels.length - 1] ?? '')) {
 		labels.pop() // drop a second-level public suffix (co.uk, com.au…)
 	}
-	return labels[labels.length - 1] ?? ''
+	return asRegistered(labels[labels.length - 1] ?? '')
 }
 
 /**
@@ -812,14 +876,23 @@ export const reachedOwnSite = (
  * registers less than its full name, but not on acme-directory.com.
  *
  * Not the same reading as `ownSiteVerdict` in `own-site.ts`, and deliberately so.
- * That one is asked about an address a run already holds, where a wrong yes costs
- * one field, so it accepts the FRONT of a name — "D-Sécurité (groupe)" at
- * d-securite.com. This one picks a site to go and read and then grounds a whole
+ * That one is asked about an address a run already holds, where a wrong yes
+ * cannot send a run off to read anything: what it costs is a false voucher for
+ * the company's existence, an exemption from the directory watch, and a key
+ * that folds two rows into one company. So it accepts the FRONT of a name —
+ * "D-Sécurité (groupe)" at d-securite.com — and one word for a trade written in
+ * front of it, so that "Cobra Instalaciones y Servicios" is at home on
+ * grupocobra.com. This one picks a site to go and read and then grounds a whole
  * row on it, where a wrong yes writes a stranger's revenue, chief executive and
- * telephone number onto the company, so it wants a whole name and would hand
- * "Grupo Cobra Instalaciones" nothing at grupocobra.com. Every caller weighing an
- * address already in hand asks `own-site.ts`; this is only for choosing what to
- * fetch. Loosening it to match would fail open across the whole grounding path.
+ * telephone number onto the company, so it wants the name to BE the domain with
+ * nothing in front of it, and would hand "Grupo Cobra Instalaciones" nothing at
+ * grupocobra.com. Every caller weighing an address already in hand asks
+ * `own-site.ts`; this is only for choosing what to fetch. Loosening it to match
+ * would fail open across the whole grounding path.
+ *
+ * The accented spelling is the one reading they do share, since it says what the
+ * domain is rather than what may be made of it: `hostLabel`, which both go
+ * through, puts a domain registered with an accent back into its own letters.
  */
 export const isOwnSiteHost = (
 	targets: EntityTargets,

--- a/packages/research/src/application/own-site.test.ts
+++ b/packages/research/src/application/own-site.test.ts
@@ -107,6 +107,393 @@ describe('ownSiteVerdict', () => {
 		})
 	})
 
+	describe('when the domain writes a trade word in front of the name', () => {
+		it('should establish the real companies a market search turned up', () => {
+			// GIVEN the companies five market searches turned up whose domain says
+			// what they do before saying who they are, and then the front of the name
+			// WHEN each is asked
+			// THEN each is its own site: the word in front identifies nobody, so what
+			// follows it is still the domain spelling the company
+			for (const [name, website] of [
+				['Cobra Instalaciones y Servicios', 'https://grupocobra.com'],
+				['Lasser', 'https://grupolasser.com'],
+				['CAHORS', 'https://www.groupe-cahors.com/es-espana'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website })).toBe('established')
+			}
+		})
+
+		it('should leave a domain naming a word from the middle of the name', () => {
+			// GIVEN a company a market search met, at the domain of a company that
+			// shares one word with it, and a second whose name carries an acronym in
+			// brackets rather than at its front
+			// WHEN each is asked
+			// THEN unknown, and the second is a real company losing its own site. The
+			// label spends its own front on the trade word, so a word matched after
+			// that is one the domain CONTAINS rather than one it spells — and reading
+			// those hands "grupofire.com", which is Grupo FIRE's, to every firm with
+			// "fire" somewhere in its name
+			expect(
+				ownSiteVerdict({
+					name: 'KGS Fire & Security España',
+					website: 'http://www.grupofire.com',
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'Electronic Trafic (ETRA)',
+					website: 'https://grupoetra.com',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should answer the host exactly as it answers an address on it', () => {
+			// GIVEN the same domain asked both ways
+			// WHEN each is asked
+			// THEN they agree, so a caller weighing many addresses on one host still
+			// gets one answer for the host
+			expect(
+				ownSiteHostVerdict({ name: 'Lasser', host: 'grupolasser.com' }),
+			).toBe('established')
+			expect(
+				ownSiteVerdict({
+					name: 'Lasser',
+					website: 'https://grupolasser.com/quienes-somos',
+				}),
+			).toBe('established')
+		})
+
+		it('should not establish a domain that only shares the front of the name', () => {
+			// GIVEN a different company whose name opens with the same letters
+			// WHEN asked against the first one's name
+			// THEN unknown. Reading past the trade word does not lower the bar behind
+			// it: what is left still has to BE the name rather than begin with it
+			expect(
+				ownSiteVerdict({
+					name: 'Lasser',
+					website: 'https://grupolasserna.com',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not read past a word that names no trade', () => {
+			// GIVEN domains that put something else in front of the name
+			// WHEN each is asked
+			// THEN unknown, and this is the cost that stays paid: only a word from
+			// the trade list the checks already share may be read past, so no run can
+			// invent one to reach a name with
+			for (const [name, website] of [
+				['Penske Logistics', 'https://gopenske.com/logistics'],
+				['Ferré', 'https://miferre.es'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website })).toBe('unknown')
+			}
+		})
+
+		it('should take off the longest trade word, not a stem of one', () => {
+			// GIVEN a domain writing the Spanish plural of a trade and then a name,
+			// where the singular is on the same shared list and is the stem of it
+			// WHEN the company the domain names is asked, and two whose names are the
+			// letters a cut at the stem would leave behind
+			// THEN only the first is established. A label keeps no spaces to say
+			// where its first word ends, so cutting at every trade word it opens with
+			// would read "transportesacme" from after "transporte" too and hand a
+			// firm called Sacme a domain that says Acme
+			expect(
+				ownSiteVerdict({
+					name: 'Acme',
+					website: 'https://transportesacme.com',
+				}),
+			).toBe('established')
+			for (const name of ['Sacme', 'Esacme']) {
+				expect(
+					ownSiteVerdict({ name, website: 'https://transportesacme.com' }),
+				).toBe('unknown')
+			}
+		})
+
+		it('should not read past two words to reach the name', () => {
+			// GIVEN a domain with two trade words stacked in front
+			// WHEN asked
+			// THEN unknown: every word read past is one more way a stranger's domain
+			// can be reached, so exactly one comes off
+			expect(
+				ownSiteVerdict({
+					name: 'Cobra Instalaciones',
+					website: 'https://grupotransportescobra.com',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a listing that writes the name and then its own', () => {
+			// GIVEN a directory whose domain opens with a trade word and carries the
+			// company's name inside it
+			// WHEN asked
+			// THEN unknown. Taking the word off leaves "acmedirectorio", which
+			// carries the name rather than being it
+			expect(
+				ownSiteVerdict({
+					name: 'Acme Logistics',
+					website: 'https://grupoacme-directorio.com/acme-logistics',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not hand one company the group domain of another', () => {
+			// GIVEN two of the companies above, each offered the group domain of
+			// another
+			// WHEN each is asked
+			// THEN neither is established: the word comes off for both, and what is
+			// underneath still has to spell the company being asked about
+			expect(
+				ownSiteVerdict({
+					name: 'Cobra Instalaciones y Servicios',
+					website: 'https://grupoetra.com',
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({ name: 'Lasser', website: 'https://grupocobra.com' }),
+			).toBe('unknown')
+		})
+
+		it('should not establish a domain holding only a fragment of the name', () => {
+			// GIVEN a domain whose remainder is the first letters of a word rather
+			// than a word
+			// WHEN asked
+			// THEN unknown. Three letters are a whole label's worth of evidence only
+			// when a firm registered exactly them ("dsv.com"); left over inside a
+			// longer label they are a fragment, so an abbreviation buys nothing
+			expect(
+				ownSiteVerdict({
+					name: 'Instalaciones Rubio',
+					website: 'https://grupoins.com',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not rescue a name that is only trade words', () => {
+			// GIVEN a company named after nothing but its trade, and a domain that
+			// writes a trade word twice
+			// WHEN each is asked
+			// THEN unknown either way: the first has no word of its own for a label
+			// to spell, and taking the front word off the second leaves another trade
+			// word rather than the family name
+			expect(
+				ownSiteVerdict({
+					name: 'Logistics Group',
+					website: 'https://grupologistics.com',
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'Grupo Ferré',
+					website: 'https://grupogrupo.es',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should still read a legal form after the word it read past', () => {
+			// GIVEN a domain writing a trade word, the name, and then the legal form
+			// WHEN asked
+			// THEN established — the same rule that lets "cobrasa.com" stand for
+			// Cobra, reached once the trade word in front has come off. Pinned
+			// because it is where the two readings meet, and the furthest a label may
+			// sit from the name and still spell it
+			expect(
+				ownSiteVerdict({ name: 'Cobra', website: 'https://grupocobrasa.com' }),
+			).toBe('established')
+		})
+	})
+
+	describe('when the domain is registered with an accent', () => {
+		it('should establish the company at the domain it registered', () => {
+			// GIVEN companies whose domain holds an accent, which a web address
+			// cannot carry — so the reader hands back the code it is written in
+			// WHEN each is asked
+			// THEN each is its own. Read as it arrives the code spells nothing any
+			// company is called, which would lose a firm its own site in exactly the
+			// markets this work is for
+			for (const [name, website] of [
+				['Construccions García', 'https://xn--construccionsgarca-xyb.cat'],
+				['Énergie Solaire', 'https://xn--nergie-solaire-9jb.fr'],
+				['Instal·lacions Núñez', 'https://xn--installacionsnez-50a66h4e.es'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website })).toBe('established')
+			}
+		})
+
+		it('should read the accented domain wherever the address points', () => {
+			// GIVEN the same domain reached at a page and behind a subdomain
+			// WHEN each is asked
+			// THEN the domain is put back into its own spelling before anything is
+			// read, so neither hides the company
+			for (const website of [
+				'https://xn--nergie-solaire-9jb.fr/nos-realisations',
+				'https://www.xn--nergie-solaire-9jb.fr',
+			]) {
+				expect(ownSiteVerdict({ name: 'Énergie Solaire', website })).toBe(
+					'established',
+				)
+			}
+		})
+
+		it('should establish the accented and the plain domain alike', () => {
+			// GIVEN the two domains a company with an accent in its name might have
+			// registered
+			// WHEN each is asked
+			// THEN both are its own, since a firm picks one when it registers and the
+			// run must not decide the other belongs to somebody else
+			for (const website of [
+				'https://xn--nergie-solaire-9jb.fr',
+				'https://energie-solaire.fr',
+			]) {
+				expect(ownSiteVerdict({ name: 'Énergie Solaire', website })).toBe(
+					'established',
+				)
+			}
+		})
+
+		it('should read a trade word in front of an accented name', () => {
+			// GIVEN a domain doing both at once — a word for the trade, then the name
+			// with its accent
+			// WHEN asked
+			// THEN established: the domain is put back into letters first, and the
+			// word in front comes off the letters
+			expect(
+				ownSiteVerdict({
+					name: 'Énergie Solaire',
+					website: 'https://xn--groupe-nergie-solaire-h5b.fr',
+				}),
+			).toBe('established')
+		})
+
+		it('should withhold when a word and its stem both fit the letters', () => {
+			// GIVEN a domain whose letters can be split two ways, because one trade
+			// word on the shared list is the stem of another — "groupénergie-solaire"
+			// reads as "group" then the name, and as "groupe" then a name nobody has
+			// WHEN asked
+			// THEN unknown. Only the longer word is taken off, so a label that spells
+			// the company solely under the shorter reading is let go. That is the
+			// price of not letting one domain answer for two companies, and it falls
+			// on a spelling that elides the trade word's own last letter, never on the
+			// ordinary "groupe-énergie-solaire"
+			expect(
+				ownSiteVerdict({
+					name: 'Énergie Solaire',
+					website: 'https://xn--groupnergie-solaire-fzb.fr',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish an accented domain for a different company', () => {
+			// GIVEN one company's accented domain offered as another company's
+			// WHEN asked
+			// THEN unknown: putting the domain back into its own letters says what it
+			// spells, never who else may claim it
+			expect(
+				ownSiteVerdict({
+					name: 'Instalaciones Rubio',
+					website: 'https://xn--construccionsgarca-xyb.cat',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not establish a domain in letters the fold has no answer for', () => {
+			// GIVEN a domain written in letters that merely look like the company's —
+			// the shape somebody registers to be mistaken for somebody else
+			// WHEN asked
+			// THEN unknown. Only letters the fold has a plain spelling for survive
+			// it, and these are not among them, so the label spells nothing rather
+			// than spelling the company
+			expect(
+				ownSiteVerdict({
+					name: 'Apple',
+					website: 'https://xn--80ak6aa92e.com',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should keep a domain whose code cannot be read as it stands', () => {
+			// GIVEN a label wearing the opening of an accented domain over something
+			// that is not one
+			// WHEN asked
+			// THEN unknown, because the unreadable code is kept rather than swapped
+			// for the empty string a reader hands back — and an empty label would be
+			// no label at all
+			expect(
+				ownSiteVerdict({ name: 'Acme', website: 'https://xn--acme-9ta.com' }),
+			).toBe('unknown')
+		})
+
+		it('should leave an address given by numbers alone', () => {
+			// GIVEN a site named by its address on the network
+			// WHEN asked
+			// THEN unknown, and the numbers are not touched on the way: asked to read
+			// a plain label as an accented one, a reader also tries it as a machine
+			// address and hands back something longer than it was given
+			expect(
+				ownSiteVerdict({ name: 'Acme', website: 'http://192.168.1.10/acme' }),
+			).toBe('unknown')
+		})
+	})
+
+	describe('when the domain shortens the name to its initials', () => {
+		it('should leave every shortening a market search met unknown', () => {
+			// GIVEN the four companies whose domain shortens their name, in three
+			// different shapes between them
+			// WHEN each is asked
+			// THEN unknown, on purpose and after measuring it. The rule that would
+			// clear them reads initials, and a handful of initials is spelled by
+			// every firm whose words start the same way — so it would hand a company
+			// a stranger's site to vouch for it. Their website is still kept; what
+			// they lose is standing as the source that vouches for them
+			for (const [name, website] of [
+				['Sociedad Ibérica de Construcciones Eléctricas', 'https://sice.com'],
+				['Sociedad Española de Montajes Industriales', 'https://semi.es'],
+				['PPVS Facility Management', 'https://ppvs-fm.com'],
+				['Energetique Sanitaire', 'https://esanit.fr'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website })).toBe('unknown')
+			}
+		})
+
+		it('should not clear one company at the initials of another', () => {
+			// GIVEN a second company whose words start with the same letters as the
+			// first — which is what makes reading initials expensive
+			// WHEN it is offered the first one's domain
+			// THEN unknown, and it stays unknown for as long as initials go unread
+			expect(
+				ownSiteVerdict({
+					name: 'Servicios Eléctricos y Montajes Industriales',
+					website: 'https://semi.es',
+				}),
+			).toBe('unknown')
+		})
+	})
+
+	describe('when the addresses a market search rightly caught are asked', () => {
+		it('should still refuse every one of them', () => {
+			// GIVEN the four addresses that read `unknown` because the check was
+			// working: a directory's listing page, a social post, a government
+			// agency's company record, and one company handed another's address
+			// WHEN each is asked
+			// THEN each is still unknown. These are what every loosening is measured
+			// against — a rule that recovers real companies and moves one of these
+			// with them has bought nothing
+			for (const [name, website] of [
+				['KBE Energy', TECSOL_LISTING],
+				['LIPOTECH SARL', 'https://www.facebook.com/LIPOTECH.SARL'],
+				[
+					'Lipotech',
+					'https://annuaire-entreprises.data.gouv.fr/entreprise/lipotech-812345678',
+				],
+				['Instalaciones Rubio', 'https://grupocobra.com'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website })).toBe('unknown')
+			}
+		})
+	})
+
 	describe('when the domain merely contains the name', () => {
 		it('should not establish a domain with something else appended', () => {
 			// GIVEN a site whose domain carries the company's name and then some
@@ -158,6 +545,36 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Grupo Ferré',
 					website: 'https://grupoferre.es',
+				}),
+			).toBe('established')
+		})
+
+		it('should refuse the trade word in every language the list spells it', () => {
+			// GIVEN two companies named after the same trade in two languages, each
+			// at the bare domain of that word
+			// WHEN each is asked
+			// THEN neither is established. The list spells the word in all three
+			// languages, so groupe.fr is no more the site of every firm called Groupe
+			// something than grupo.es is of every Grupo
+			expect(
+				ownSiteVerdict({ name: 'Grupo Ferré', website: 'https://grupo.es' }),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'Groupe Roy Énergie',
+					website: 'https://groupe.fr',
+				}),
+			).toBe('unknown')
+		})
+
+		it('should establish a French name once its own word is in the domain', () => {
+			// GIVEN a company a market search met, at the domain that writes the
+			// French trade word and then its name
+			// WHEN asked — THEN the word comes off and the company is underneath
+			expect(
+				ownSiteVerdict({
+					name: 'CAHORS',
+					website: 'https://www.groupe-cahors.com/es-espana',
 				}),
 			).toBe('established')
 		})
@@ -509,6 +926,26 @@ describe('ownSiteHostVerdict', () => {
 			// WHEN asked
 			// THEN an empty name must not be spelled by every host there is
 			expect(ownSiteHostVerdict({ name: '', host: 'acme.com' })).toBe('unknown')
+		})
+
+		it('should read an accented host the same way an address is read', () => {
+			// GIVEN a company's own accented domain, and the same domain offered as
+			// another company's
+			// WHEN each is asked of the host directly — which is the door the
+			// directory watch knocks on, where a wrong no costs a group its website
+			// THEN the domain answers for its own company and for nobody else
+			expect(
+				ownSiteHostVerdict({
+					name: 'Énergie Solaire',
+					host: 'xn--nergie-solaire-9jb.fr',
+				}),
+			).toBe('established')
+			expect(
+				ownSiteHostVerdict({
+					name: 'Instalaciones Rubio',
+					host: 'xn--nergie-solaire-9jb.fr',
+				}),
+			).toBe('unknown')
 		})
 	})
 

--- a/packages/research/src/application/own-site.ts
+++ b/packages/research/src/application/own-site.ts
@@ -26,6 +26,14 @@
  * somebody else, and a listing whose own domain happens to carry a word of the
  * name would otherwise clear itself.
  *
+ * Two ways of writing a domain are read for what they are on the way there, and
+ * neither of them is a way of naming a company. A firm often puts what it does
+ * in front of what it is called — "Cobra Instalaciones y Servicios" at
+ * grupocobra.com — so one word for a trade comes off the front of the label, on
+ * the terms `withoutLeadingTradeWord` sets. And a domain registered with an accent
+ * travels in a code that spells nothing, which `hostLabel` puts back into the
+ * letters its owner registered before any of this reads it.
+ *
  * ## What deliberately does NOT establish it
  *
  * **The path.** "facebook.com/Some-Company" and "xpo.com/about-xpo-logistics"
@@ -57,22 +65,65 @@
  *
  * ## What it costs, on purpose
  *
- * A company at a domain that spells its name with something in front of it —
- * "Penske Logistics" at gopenske.com, "Grupo Cobra" at grupocobra.com — reads
- * `unknown`, as does one at an acronym its name never spells (SICE at sice.com).
- * So does any company at a domain registered with an accent, which arrives in
- * the punycode spelling and folds to letters that spell nothing: a blind spot
- * in exactly the markets this work is for, and the reason it is written down
- * here rather than met in a run.
+ * A company at a domain that puts something in front of its name which names no
+ * trade — "Penske Logistics" at gopenske.com — reads `unknown`, as does one at
+ * an initialism its own name never spells: "Sociedad Ibérica de Construcciones
+ * Eléctricas" at sice.com.
  *
- * In every one of those the website is still kept, since keeping is not this
- * verdict's decision; what it loses is standing as the source that vouches for
- * the company. That is a withholding, and withholding is the direction this
- * file is allowed to be wrong in.
+ * In both the website is still kept, since keeping is not this verdict's
+ * decision; what it loses is standing as the source that vouches for the
+ * company. That is a withholding, and withholding is the direction this file is
+ * allowed to be wrong in.
  *
- * Closing any of them means loosening — reading past a word in front, or
- * matching initials — and each loosening is a new way to clear a stranger's
- * address. Measure the cost before paying it.
+ * ## The shortening that was measured and refused
+ *
+ * Five market searches turned up four real companies whose domain shortens
+ * their name, and there is no single way they shorten it: sice.com and semi.es
+ * take the first letter of each word; ppvs-fm.com writes the first word whole
+ * and then the initials of the rest; esanit.fr takes one letter of the first
+ * word and part of the second. Four rows, three shapes, and the last of them
+ * cuts a word wherever it pleases.
+ *
+ * They stay `unknown`, and that is the answer rather than a gap left for later.
+ * What the reading above matches on is letters the company itself wrote, in the
+ * order it wrote them, which is why a longer name is HARDER to land on by
+ * accident. Initials turn that around: the name is spent down to one letter a
+ * word, so the more words a firm has the fewer letters it is judged on, and
+ * every other firm whose words open the same way spells the same domain.
+ * Take a firm called "Servicios Eléctricos y Montajes Industriales", invented
+ * here to make the point where the four above were met in a run: it spells
+ * semi.es exactly as well as the owner of that domain does, and would be handed
+ * a stranger's site to vouch for it — the failure this file exists to prevent,
+ * walking in through the door that letting those four rows in would open.
+ *
+ * The floor `SHORTEST_NAME_A_DOMAIN_SPELLS` sets below already says this about
+ * the same letters: one or two letters is an initial rather than a name. Reading
+ * initials would leave that floor standing and make it mean nothing.
+ *
+ * ## What reading past a trade word still gets wrong
+ *
+ * A domain that writes a trade word and then the front of a name answers for
+ * every company whose name starts the same way, and one of them registered it.
+ * "Cobra Formación" is at home on grupocobra.com by this reading, and the group
+ * that owns it is not that company. Reading only the FRONT of a name is what
+ * keeps this to companies that genuinely start alike rather than to every
+ * company sharing any word — a market pass over 138 companies with a website
+ * cleared no stranger under this reading, and one under the looser one.
+ *
+ * The other half of the price is a firm whose domain writes a trade word and
+ * then a word from the MIDDLE of its name, which is refused with them: an
+ * acronym a name carries in brackets, "Electronic Trafic (ETRA)" at
+ * grupoetra.com, reads `unknown` though the domain is the company's own.
+ *
+ * ## What is left to close, and the rule for closing it
+ *
+ * Every rule here that lets more addresses through is a new way to clear a
+ * stranger's address, so each is bought one at a time against rows a run
+ * actually met, and each keeps its own list of what it still cannot clear.
+ * A trade word may be read past because the words come from the list the checks
+ * already share and cannot be invented for a case; an initialism may not,
+ * because nothing bounds who else spells it. Measure the cost before paying it,
+ * and take the withholding when the measurement does not settle it.
  *
  * Whether the host is a business directory is a separate question with a
  * separate answer (`directory-sites.ts`), and a caller weighing a company's
@@ -84,21 +135,36 @@
  * is not: which single site a run should GO AND READ as the company's. A wrong
  * yes there sends the run off to read a stranger's pages and then writes that
  * stranger's revenue, chief executive and telephone number onto the row, so it
- * wants the domain to spell a WHOLE name and will not read the front of one —
- * "Grupo Cobra Instalaciones" must not be handed grupocobra.com, a large
- * unrelated group. This file is asked about an address a run already holds,
- * where a wrong yes costs one field, so the front of a name is enough.
+ * wants the name to BE the domain — the whole of it, or one word of it standing
+ * alone, with nothing in front of either — so "Grupo Cobra Instalaciones" must
+ * not be handed grupocobra.com, a large unrelated group. This file is asked
+ * about an address a run already holds, where a wrong yes cannot send a run off
+ * to read anything, so the front of a name is enough and so is a trade word
+ * ahead of it.
  *
- * The difference is in what each answer is then spent on, never in how a name is
- * read, and it is written down at both definitions so neither drifts. Every
- * caller weighing an address the run already has asks THIS file — the directory
- * watch included, where asking the stricter one brands a group's own domain a
- * listing for carrying a page for the group and a page for its subsidiary, and
- * costs the group its website.
+ * What a wrong yes DOES cost here is worth naming, because it is more than the
+ * field: an established site is the one thing that vouches for a company's
+ * existence, it exempts its host from the directory watch, and it becomes a key
+ * that folds two rows into one company. Cheaper than sending a run off to write
+ * a stranger's revenue onto a row, which is what buys the asymmetry — but not
+ * one field, and the loosenings above were weighed against the larger figure.
+ *
+ * Reading the accented spelling is the one thing they do share, because it is
+ * not a rule about names at all: it is what the domain says, and a check that
+ * read the code instead would be reading a different address from the one
+ * somebody registered. It sits in `hostLabel`, which both go through.
+ *
+ * The difference in what each answer is spent on is what sets how far each may
+ * read, and both halves are written down at both definitions so neither drifts.
+ * Every caller weighing an address the run already has asks THIS file — the
+ * directory watch included, where asking the stricter one brands a group's own
+ * domain a listing for carrying a page for the group and a page for its
+ * subsidiary, and costs the group its website.
  */
 
 import {
 	collapse,
+	DISTINCTIVE_NAME_LENGTH,
 	distinctiveWords,
 	hostLabel,
 	isGenericWord,
@@ -121,9 +187,9 @@ export type OwnSiteVerdict = 'established' | 'unknown'
 // whole question down as the name, and every long word of a question would then
 // be a word a domain could be cleared by — "Acme Corp Barcelona" clearing
 // barcelona.cat. A run that does not know the company's name cannot say whose
-// site anything is. Set well clear of the longest real names, which run to six
+// site anything is. Set well clear of the longest real names, which run to five
 // ("Sociedad Española de Montajes Industriales"), because what sits on the other
-// side of this is a paragraph rather than a seventh word.
+// side of this is a paragraph rather than a sixth word.
 const MOST_WORDS_A_NAME_RUNS_TO = 8
 
 // The shortest front part a domain may be read as spelling. The large carriers
@@ -158,6 +224,33 @@ const namesTheDomainCouldCarry = (
 	return runs
 }
 
+// What is left of a label once the trade word it opens with is taken off, or null
+// when it opens with none. A firm often writes what it does in front of what it
+// is called, and grupocobra.com is Cobra's.
+//
+// One word, and only a word the shared trade list already holds, so a run may not
+// invent one to reach a name with — "gopenske.com" keeps its "go", because "go"
+// names no trade. A label keeps no spaces to say where its first word ends, so
+// the LONGEST trade word it opens with is the one taken off: several of the
+// shared words are the stem of another — "transporte" of "transportes" — and
+// cutting at every one of them would read "transportesacme" from after the stem
+// as well, handing a firm called Sacme a domain that says Acme.
+//
+// What is left has to be long enough to stand for somebody. Three letters are a
+// whole label's worth of evidence when a firm registered exactly them
+// ("dsv.com"), but here they are a fragment inside a longer label, which is the
+// coincidence `DISTINCTIVE_NAME_LENGTH` exists to price: without the floor
+// "grupoacs.com" answers for every firm called ACS and groupama.fr for every one
+// called AMA.
+const withoutLeadingTradeWord = (label: string): string | null => {
+	for (let taken = label.length - 1; taken > 0; taken--) {
+		if (!isGenericWord(label.slice(0, taken))) continue
+		const rest = label.slice(taken)
+		return rest.length >= DISTINCTIVE_NAME_LENGTH ? rest : null
+	}
+	return null
+}
+
 /**
  * Whether a host is this company's own domain.
  *
@@ -165,10 +258,12 @@ const namesTheDomainCouldCarry = (
  * one distinctive word of the name on its own — which is how most small firms
  * register. Either may have the legal form after it, and nothing else:
  * "fusteriamiquelsl.cat" is the workshop, "fusteriamiquelreviews.com" is
- * somebody writing about it.
+ * somebody writing about it. A trade word in front of the name is read past, on
+ * the terms `withoutLeadingTradeWord` sets.
  */
 const hostSpellsTheCompany = (name: string, host: string): boolean => {
 	const label = collapse(hostLabel(host))
+	const pastTheTrade = withoutLeadingTradeWord(label)
 	// The distinctive words are read off the name itself, which already offers
 	// each of them in every spelling.
 	const words = distinctiveWords(name)
@@ -180,10 +275,14 @@ const hostSpellsTheCompany = (name: string, host: string): boolean => {
 		const spelled = nameWordsWithoutForms(withoutFormDots(spelling))
 		// A brief rather than a name, which no spelling of it can rescue.
 		if (spelled.length > MOST_WORDS_A_NAME_RUNS_TO) return false
-		return labelSpellsOneOf(label, [
-			...namesTheDomainCouldCarry(spelled),
-			...words,
-		])
+		const couldCarry = namesTheDomainCouldCarry(spelled)
+		if (labelSpellsOneOf(label, [...couldCarry, ...words])) return true
+		// Past a trade word, only the front of the name is read, never one word
+		// taken from the middle of it. The label has already spent its own front on
+		// the trade word, so a word matched here is a word the domain CONTAINS
+		// rather than one it spells — and "grupofire.com" is Grupo FIRE's, not the
+		// site of every firm with "fire" somewhere in its name.
+		return pastTheTrade !== null && labelSpellsOneOf(pastTheTrade, couldCarry)
 	})
 }
 


### PR DESCRIPTION
## What

When a market search finds a company, it also finds a web address for it, and something has to decide whether that address is really the company's **own site** rather than a directory listing or somebody else's page. Until now it said yes only when the address spelled the company's name outright. That is deliberately strict, and `own-site.ts` writes down what the strictness costs, ending "Measure the cost before paying it."

This is that measurement arriving. It pays for two of the three costs and refuses the third in writing. It matters because since existence verification landed (#486), an address that reads `unknown` cannot vouch for the company at all — so a real firm at an address the check couldn't read lands in the list as a *candidate* rather than *confirmed*, and somebody has to check it by hand.

This lives in the research area (`packages/research`), and touches no user interface.

## Changes

**Touches:** the check that says a website is the company's own, the shared way every guard reads a web address into letters, and the shared list of trade words those guards share — plus the stricter sibling check that picks which single site a run goes and *reads*, which this leaves as strict as it was.

- **A trade word written in front of the name is read past.** A firm often registers what it does before what it is called — "Cobra Instalaciones y Servicios" at `grupocobra.com`. One word comes off, and only a word from the list the guards already share, so nothing can be invented for a single case. `gopenske.com` keeps its "go", because "go" names no trade.
- **Past that word, only the front of a name is read** — never a word from its middle. The address has spent its own front on the trade word, so a word matched after it is one the address *carries* rather than one it *spells*. This is the part that keeps `grupofire.com`, which belongs to Grupo FIRE, from answering for every firm with "fire" somewhere in its name.
- **A domain registered with an accent is read as its owner wrote it.** A web address carries only the letters a–z, so such a name travels in a code beginning `xn--`, which folded to letters spelling nothing. It is put back in the one place both readings of an address meet, so the two cannot drift apart.
- **A domain that shortens a name to its initials stays unrecognised, on purpose.** Four real companies do this and no two do it the same way. Initials spend a name down to one letter per word, so the *more* words a firm has the *fewer* letters it is judged on — and every other firm whose words start alike spells the same address. The argument is written into the file, because that is where the next person will argue against it.
- **Added the French spelling of "group" to the shared trade words.** The list held the Spanish and English spellings and not the French one, so `groupe.fr` counted as a word of a company's own and read as the site of every firm called Groupe something — the one thing `grupo.es` is correctly refused for.

## Impact

- **Nothing touching which organisation can see what** (row-level security), no database schema or migration, no new environment variables, no change to login or route protection, and no change to the shape of any API response.
- **The stricter sibling check changes too, and only for the better.** `isOwnSiteHost` picks the one site a run goes and fetches, and it shares the address-reading this fixes. On `main` it *refused a company's own accented domain*, so a run declined to open the company's own site; it now opens its own and still refuses a stranger's. Its rule for names is untouched.
- **A recognised own site is spent on four things, not one**, and the docblock said "one field" until this PR corrected it: it is the only thing that vouches for a company's existence, it exempts a host from being branded a business directory, it stops the website being blanked, and it becomes a key that folds two rows into one company. Both loosenings were weighed against that larger figure, which is why the second bullet above exists.
- **It meets `217327c8e5` head-on.** That commit makes the website check "stand down for an address the run establishes as a claimant's own", so it now leans on the very verdict this PR changes. Rebased onto it: its 451-line integration test and 396-line guard test both pass unchanged.
- **Both transports get it** — this is a shared check under the services, so the assistant-facing tools and the HTTP surface behave the same.
- Adding a word to the shared trade list is a tightening everywhere it is read: `groupe` stops being a word a French company can be identified by. That is intended — it was a poor key, matching any French page carrying the word.

## Review guide

Start with the docblock at the top of [`own-site.ts`](packages/research/src/application/own-site.ts) — it is the contract, and the argument for the refusal lives there. Then `withoutLeadingTradeWord` and `hostSpellsTheCompany` just below it; everything else follows from those.

The riskiest part is the second bullet under Changes, and it is the one I would most like overruled if you disagree. Reading only the front of a name after a trade word **costs a real recovery**: `grupoetra.com` is genuinely Electronic Trafic (ETRA)'s own site, and it now reads `unknown`, because "etra" sits in a bracket in the name rather than at its front. I took that trade because the file says withholding is the direction it may be wrong in, and because it is what took the measured stranger-clearing to zero — but the looser rule recovers one more real company, and that is a judgement call, not a fact.

Two things I decided to keep rather than close, both named in the code:

- `ácme.com` reads as Acme's. That is the same accent-equivalence that puts Muñoz at `munoz.es`, read from the other side; refusing it here would have the fold answer two ways about one pair of spellings.
- Adding `groupe` makes it hide `group`, so `groupexpress.fr` is read as "xpress". Narrower than the `groupe.fr` hole it closes. There is a note at the list warning that a word extending another moves where the address is cut.

Skip-able: the test files are long but mechanical — table-driven cases in the file's existing style.

I ran `/code-review` at maximum effort on this diff. It found real defects, all folded in; the ones I consciously did not act on are the two above. No Snyk scan — the tool is not available in this session, and this diff has no external input, parser, or credential path.

## Tests

Unit, in the two files' existing suites. Beyond the happy path, each loosening pins what it still **cannot** clear: a stranger's domain sharing only a prefix, a word that names no trade, two trade words stacked, a listing that writes the name then its own, a fragment rather than a name, a word from the middle of a name, a domain written in letters the fold has no spelling for, and an `xn--` code that cannot be read. The four addresses the check was right to refuse — a directory listing, a social post, a government agency's record, and one company handed another's address — are pinned as a group.

## Verification

- `pnpm install`, `pnpm check-types` (13/13), `pnpm test` (21/21 — 1875 research, 973 server), `pnpm build` (13/13), all after rebasing onto `896ee00866`.
- Each of the two commits type-checks standalone.
- **Five live market searches** against the real pipeline (Spanish and French installations, caches cleared between passes), $1.30. Not a mock — this is the same eval the issue measured with.
- No screenshots: this changes no user interface.

**The twelve addresses the issue named**, judged by both readings — deterministic, so it does not depend on a live pass turning up the same firms again:

| | before | after |
|---|---|---|
| `grupocobra.com`, `grupolasser.com` | unknown | **established** |
| `grupoetra.com` | unknown | unknown *(the price above)* |
| `sice.com`, `semi.es`, `ppvs-fm.com`, `esanit.fr` | unknown | unknown *(refused)* |
| `begi.fr` (unplaceable) | unknown | unknown |
| the four the check was right to refuse | unknown | **unknown** |

**12 → 10. Two moved; none of the four moved with them.**

**Live corpus**, 204 companies, 138 with a website: **35 read `unknown` before, 33 after.** Two recovered — `grupocobra.com` for Cobra Instalaciones y Servicios (the issue's own row, turning up again on its own) and `groupe-cahors.com` for CAHORS. Nothing regressed.

**The stranger test.** Asking each of the 138 companies' verdict against every *other* company's address — 18,906 pairs — is the direct question: does the loosening let one firm's site vouch for another?

| | one firm cleared at another's address |
|---|---|
| `main` | 13 |
| reading any word of the name past a trade word | **14** |
| reading only the front of the name (this PR) | **13** |

The one new case was *KGS Fire & Security España* at `grupofire.com`. It is what the second Changes bullet exists to prevent, and it is why `grupoetra.com` was given up.

Accented domains appear **zero** times in this data, as the issue's own comment recorded — that shape closes a named blind spot forward rather than moving today's figure.

## Deferred

- **The shared list of trade words is stocked for one industry only.** Of its 31 words, 17 are sector-neutral (group, holding, services, solutions, company, international, global, consulting, partners, associates, industries) and work for anybody; the other 14 are all freight — logistics, transport, trucking, cargo, shipping, freight, brokerage, delivery. No other industry is present. The architecture is sector-agnostic; this one piece of data is not, and `own-site.ts` states the rule as "'Transportes García' not on transportes.com", which holds only because transport is the one industry on the list. Measured on the same company shape across sectors — "«trade» García" offered the bare domain of its own trade, where the right answer is always `unknown` — freight and the corporate words refuse 6 of 6, and installations, construction, hospitality, professional services, health, retail and manufacturing wrongly clear 14 of 14. So `fontaneria.es`, `abogados.es`, `clinica.es` and `talleres.es` each read as the own site of every firm in that trade. Entirely pre-existing; this PR only makes the list load-bearing in one more place. Filed separately — it needs its own measurement, and which trades belong on a shared list is a product decision.
- Two shapes from the issue's own comment are untouched: an address that abbreviates part of a name (`cegelec-tertiaireidf.com`), and one that adds a place or descriptor *after* it (`sisdeconmalaga.com`, `orona-group.com`). The second is the mirror of what this reads and is the cheaper of the two if it is worth taking next.
- #494 (a group's own domain branded a business directory) is left alone; this reduces its blast radius without fixing it.

Closes #484

