### PR TITLE
fix: send follow-ups with a subject and the right threading headers

### DIFF
--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -24,7 +24,11 @@ import { SrOnly } from '#/components/shared/sr-only'
 import { type Draft, useComposeEmail } from '#/context/compose-email-context'
 import { authClient } from '#/lib/auth-client'
 import type { StagedAttachment } from '#/lib/email-attachments'
-import { badRequestMessage, suppressedRecipient } from '#/lib/tagged-failure'
+import {
+	badRequestMessage,
+	notSendableReason,
+	suppressedRecipient,
+} from '#/lib/tagged-failure'
 
 type InboxOption = {
 	readonly id: string
@@ -363,6 +367,17 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 						blocked.reason === null
 							? why
 							: `${why} ${t`The receiving server said: ${blocked.reason}`}`,
+					)
+				}
+				// Turned away over the shape of the message rather than who it is
+				// going to. The server sends the reason; the sentence is written here
+				// so it is in the reader's language.
+				const unsendable = notSendableReason(exit.cause)
+				if (unsendable !== null) {
+					throw new Error(
+						unsendable === 'no_subject'
+							? t`Without a subject this arrives as "(no subject)" and is likely to be treated as spam.`
+							: t`A "Re:" on a message that answers nothing reads as a forged reply. Reply from the conversation, or drop the "Re:".`,
 					)
 				}
 				throw new Error(badRequestMessage(exit.cause) ?? t`Send failed`)

--- a/apps/internal/src/lib/tagged-failure.test.ts
+++ b/apps/internal/src/lib/tagged-failure.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { badRequestMessage, taggedFailure } from './tagged-failure'
+import {
+	badRequestMessage,
+	notSendableReason,
+	taggedFailure,
+} from './tagged-failure'
 
 const causeWith = (error: unknown) => ({ reasons: [{ error }] })
 
@@ -81,6 +85,43 @@ describe('the sentence the server sent when it turned a write away', () => {
 				badRequestMessage(causeWith({ _tag: 'BadRequest', message: 7 })),
 			).toBe(null)
 			expect(badRequestMessage(causeWith({ _tag: 'NotFound' }))).toBe(null)
+		})
+	})
+})
+
+describe('notSendableReason', () => {
+	describe('when the server turned a send away over the message itself', () => {
+		it('should read back the reason it named', () => {
+			// GIVEN the cause shape the API client hands back
+			// WHEN the reason is read out
+			// THEN it is the one the server sent, so the screen can word it
+			// in the reader's language rather than showing backend prose
+			expect(
+				notSendableReason({
+					reasons: [
+						{ error: { _tag: 'EmailNotSendable', reason: 'no_subject' } },
+					],
+				}),
+			).toBe('no_subject')
+		})
+	})
+
+	describe('when the failure was something else', () => {
+		it('should answer with nothing', () => {
+			// GIVEN a different tagged failure, a malformed one, and a reason
+			// this build does not know
+			// THEN none of them is mistaken for a refusal
+			expect(
+				notSendableReason({ reasons: [{ error: { _tag: 'BadRequest' } }] }),
+			).toBeNull()
+			expect(notSendableReason(null)).toBeNull()
+			expect(
+				notSendableReason({
+					reasons: [
+						{ error: { _tag: 'EmailNotSendable', reason: 'invented' } },
+					],
+				}),
+			).toBeNull()
 		})
 	})
 })

--- a/apps/internal/src/lib/tagged-failure.ts
+++ b/apps/internal/src/lib/tagged-failure.ts
@@ -70,3 +70,17 @@ export function suppressedRecipient(
 		reason: typeof reason === 'string' && reason !== '' ? reason : null,
 	}
 }
+
+/** Why a send was turned away over the shape of the message itself. */
+export type NotSendableReason = 'no_subject' | 'forged_reply'
+
+/**
+ * The reason a send was refused, or null when the failure was something else.
+ *
+ * The server answers with the reason alone rather than a sentence, so the
+ * wording is written here, in the reader's language.
+ */
+export function notSendableReason(cause: unknown): NotSendableReason | null {
+	const reason = taggedFailure(cause, 'EmailNotSendable')?.['reason']
+	return reason === 'no_subject' || reason === 'forged_reply' ? reason : null
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -313,6 +313,10 @@ msgstr "70%+"
 msgid "90%+"
 msgstr "90%+"
 
+#: src/components/emails/compose-form.tsx
+msgid "A \"Re:\" on a message that answers nothing reads as a forged reply. Reply from the conversation, or drop the \"Re:\"."
+msgstr "Un \"Re:\" en un missatge que no respon res es llegeix com una resposta falsificada. Respon des de la conversa, o treu-li el \"Re:\"."
+
 #: src/routes/index.tsx
 msgid "A high-priority company that has gone quiet is listed once, under Needs attention."
 msgstr "Una empresa prioritària que ha quedat en silenci apareix un sol cop, a Necessita atenció."
@@ -6424,6 +6428,10 @@ msgstr "Qui"
 #: src/routes/emails/inboxes.tsx
 msgid "Who's your email provider?"
 msgstr "Quin és el teu proveïdor de correu?"
+
+#: src/components/emails/compose-form.tsx
+msgid "Without a subject this arrives as \"(no subject)\" and is likely to be treated as spam."
+msgstr "Sense assumpte, arriba com a \"(sense assumpte)\" i és probable que es tracti com a brossa."
 
 #: src/components/research/inbox/paid-action-queue.tsx
 msgid "Working…"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -313,6 +313,10 @@ msgstr "70%+"
 msgid "90%+"
 msgstr "90%+"
 
+#: src/components/emails/compose-form.tsx
+msgid "A \"Re:\" on a message that answers nothing reads as a forged reply. Reply from the conversation, or drop the \"Re:\"."
+msgstr "A \"Re:\" on a message that answers nothing reads as a forged reply. Reply from the conversation, or drop the \"Re:\"."
+
 #: src/routes/index.tsx
 msgid "A high-priority company that has gone quiet is listed once, under Needs attention."
 msgstr "A high-priority company that has gone quiet is listed once, under Needs attention."
@@ -6424,6 +6428,10 @@ msgstr "Who"
 #: src/routes/emails/inboxes.tsx
 msgid "Who's your email provider?"
 msgstr "Who's your email provider?"
+
+#: src/components/emails/compose-form.tsx
+msgid "Without a subject this arrives as \"(no subject)\" and is likely to be treated as spam."
+msgstr "Without a subject this arrives as \"(no subject)\" and is likely to be treated as spam."
 
 #: src/components/research/inbox/paid-action-queue.tsx
 msgid "Working…"

--- a/apps/internal/src/routes/emails/$threadId.tsx
+++ b/apps/internal/src/routes/emails/$threadId.tsx
@@ -882,12 +882,20 @@ function findLastInbound(
 	return null
 }
 
+// Mail clients write the reply prefix several ways — "RE:", "re:", and (with
+// French typography) "Re :". Any of them already marks a reply, so none of them
+// should be stacked on top of. The server reads it the same way.
+const REPLY_PREFIX = /^re\s*:/i
+
 function prefixSubject(subject: string, prefix: string): string {
 	const trimmed = subject.trim()
-	if (trimmed === '') return prefix.trim()
-	if (trimmed.toLowerCase().startsWith(prefix.trim().toLowerCase())) {
-		return trimmed
-	}
+	// A conversation with nothing to borrow leaves this empty rather than
+	// answering with a bare "Re:". The server turns an empty one away and says
+	// why, which is what every other way of replying already does — answering
+	// "Re:" here would make the browser the one place a message with no real
+	// subject still went out.
+	if (trimmed === '') return ''
+	if (REPLY_PREFIX.test(trimmed)) return trimmed
 	return `${prefix}${trimmed}`
 }
 

--- a/apps/internal/tests/e2e/reply.test.ts
+++ b/apps/internal/tests/e2e/reply.test.ts
@@ -19,6 +19,13 @@ import { setActiveOrgBySlug } from './helpers/set-active-org'
 //     (thread-reply, thread-reply-all)
 //   apps/internal/src/components/emails/compose-form.tsx
 //     (compose-{form,to,subject,send})
+//
+// A reply's subject is not covered here beyond asserting one arrives: the
+// composer works it out itself from the thread and renders no subject field on
+// a reply (compose-form.tsx, `!isReply`), so there is no way from the browser
+// to send a reply without one. What the server does when it has to choose the
+// subject is covered in
+// apps/server/src/services/email-threading.integration.test.ts.
 
 const psql = (sqlText: string): string =>
 	execSync(`psql "${DATABASE_URL}" -tA -c "${sqlText.replace(/"/g, '\\"')}"`, {
@@ -85,6 +92,9 @@ test.describe('reply on a seeded thread', () => {
 			const raw = getRawMessage(summary)
 			expect(raw).toMatch(/in-reply-to:\s*<[^>]+>/i)
 			expect(raw).toMatch(/references:\s*<[^>]+>/i)
+			// AND a Subject line, which the headers above do not imply: a reply
+			// once went out with these two correct and no Subject at all.
+			expect(raw).toMatch(/^subject:\s*Re: Quote for the booking module\s*$/im)
 		})
 	})
 

--- a/apps/internal/tests/e2e/send-email.test.ts
+++ b/apps/internal/tests/e2e/send-email.test.ts
@@ -101,6 +101,84 @@ test.describe('compose and send via the mail catcher', () => {
 		})
 	})
 
+	test.describe('when a new message is written as if it were a reply', () => {
+		test('should refuse it and leave the compose window open', async ({
+			page,
+		}) => {
+			// GIVEN a brand-new message — this path threads nothing — written
+			// under a "Re: " subject, the way a follow-up gets written. That
+			// pairing is the classic forged-reply shape, and mail filters test
+			// for it; a batch of these reached real prospects.
+			const testId = `e2e-fake-reply-${Date.now()}`
+			const recipient = `${testId}@catcher.local`
+			const subject = `Re: pallet pools ${testId}`
+
+			await page.goto('/emails')
+			await openCompose(page, 'emails-compose')
+			await page.getByTestId('compose-to').fill(recipient)
+			await page.getByTestId('compose-subject').fill(subject)
+			await fillBody(page, `should not arrive ${testId}`)
+
+			// WHEN Alice clicks Send
+			await expect(page.getByTestId('compose-send')).toBeEnabled()
+			const sendResponse = page.waitForResponse(
+				resp =>
+					resp.url().includes('/email/drafts/') &&
+					resp.url().endsWith('/send') &&
+					resp.request().method() === 'POST',
+				{ timeout: 15_000 },
+			)
+			await page.getByTestId('compose-send').click()
+
+			// THEN the server turns it away with the reason named, not a bare
+			// failure. Asserted on the reason the wire carries rather than on
+			// the sentence shown: the sentence is written per language, so
+			// pinning it here would tie this test to one wording and to one
+			// locale, and would go green on the wrong refusal.
+			const refusal = await sendResponse
+			expect(refusal.status()).toBe(400)
+			const refusalBody = (await refusal.json()) as {
+				_tag?: string
+				reason?: string
+			}
+			expect(refusalBody._tag).toBe('EmailNotSendable')
+			expect(refusalBody.reason).toBe('forged_reply')
+
+			// AND nothing reaches the catcher
+			await expectNoMessage(recipient, subject)
+
+			// AND the sender is told something they can act on, whatever the
+			// wording, and the window stays open so the message can be fixed
+			await expect(page.getByRole('alert')).toBeVisible({ timeout: 10_000 })
+			await expect(page.getByTestId('compose-window')).toBeVisible()
+		})
+
+		test('should send the same message once the "Re: " is dropped', async ({
+			page,
+		}) => {
+			// GIVEN the same message under an ordinary subject
+			// AND this is the pair to the test above: it proves the refusal
+			// turns on the subject, not on anything else about the message
+			const testId = `e2e-plain-followup-${Date.now()}`
+			const recipient = `${testId}@catcher.local`
+			const subject = `pallet pools ${testId}`
+
+			await page.goto('/emails')
+			await openCompose(page, 'emails-compose')
+			await page.getByTestId('compose-to').fill(recipient)
+			await page.getByTestId('compose-subject').fill(subject)
+			await fillBody(page, `plain follow-up ${testId}`)
+
+			// WHEN Alice clicks Send
+			await expect(page.getByTestId('compose-send')).toBeEnabled()
+			await page.getByTestId('compose-send').click()
+
+			// THEN it goes out
+			const msg = await waitForMessage(recipient, { subject })
+			expect(msg.Subject).toBe(subject)
+		})
+	})
+
 	test.describe('when the recipient is suppressed', () => {
 		test.beforeEach(() => {
 			// AND Pep Casals' email channel is forced into bounced state so

--- a/apps/mail-worker/src/persist.integration.test.ts
+++ b/apps/mail-worker/src/persist.integration.test.ts
@@ -197,8 +197,9 @@ const fetchThreadLink = async (externalThreadId: string) => {
 	const rows = await pool.query<{
 		company_id: string | null
 		contact_id: string | null
+		subject: string | null
 	}>(
-		`SELECT company_id, contact_id FROM email_thread_links WHERE external_thread_id = $1`,
+		`SELECT company_id, contact_id, subject FROM email_thread_links WHERE external_thread_id = $1`,
 		[externalThreadId],
 	)
 	return rows.rows[0]
@@ -334,7 +335,7 @@ describe('persistMessage — CRM auto-link', () => {
 			// THEN the thread link still points at Acme (ON CONFLICT DO UPDATE preserves company_id)
 			const link = await fetchThreadLink(rootMessageId)
 			expect(link?.company_id).toBe(acmeCompanyId)
-			// [apps/mail-worker/src/persist.ts — DO UPDATE clause only touches updated_at]
+			// [DO UPDATE clause leaves company_id alone]
 		})
 	})
 
@@ -355,6 +356,185 @@ describe('persistMessage — CRM auto-link', () => {
 			expect(row?.company_id).toBeNull()
 			expect(row?.contact_id).toBeNull()
 			// [apps/mail-worker/src/persist.ts — `args.parsed.fromAddress ? matcher.match(…) : new NoMatch(…)` null-guard]
+		})
+	})
+})
+
+// Replies are sent under the conversation's subject, so a conversation that
+// never got one sends a message with no subject line at all — which arrives as
+// "(no subject)" and scores as spam.
+describe('persistMessage — the conversation keeps a subject', () => {
+	describe('when the first message on a conversation arrives', () => {
+		it('should put its subject on the conversation', async () => {
+			// GIVEN an arriving message with a subject
+			const rootMessageId = `<subject-root-${randomUUID()}@example>`
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: rootMessageId,
+						subject: 'your pallet pools',
+					}),
+				),
+			)
+
+			// THEN the conversation carries it
+			const link = await fetchThreadLink(rootMessageId)
+			expect(link?.subject).toBe('your pallet pools')
+		})
+	})
+
+	describe('when a later message arrives on the same conversation', () => {
+		it('should not rename the conversation', async () => {
+			// GIVEN a conversation started under one subject
+			const rootMessageId = `<subject-keep-${randomUUID()}@example>`
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: rootMessageId,
+						subject: 'your pallet pools',
+					}),
+				),
+			)
+
+			// WHEN a reply arrives with the subject rewritten
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: `<subject-keep-reply-${randomUUID()}@example>`,
+						inReplyTo: rootMessageId,
+						subject: 'Re: your pallet pools — revised',
+					}),
+				),
+			)
+
+			// THEN the conversation keeps the subject it started with
+			// AND replies keep going out under a stable subject
+			const link = await fetchThreadLink(rootMessageId)
+			expect(link?.subject).toBe('your pallet pools')
+		})
+	})
+
+	describe('when the first message had no subject', () => {
+		it('should fill one in from the next message that has one', async () => {
+			// GIVEN a conversation started by a message with no subject
+			const rootMessageId = `<subject-backfill-${randomUUID()}@example>`
+			await runIngest(
+				persist(buildParsed({ messageId: rootMessageId, subject: null })),
+			)
+			const before = await fetchThreadLink(rootMessageId)
+			expect(before?.subject).toBeNull()
+
+			// WHEN a later message on it does have one
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: `<subject-backfill-reply-${randomUUID()}@example>`,
+						inReplyTo: rootMessageId,
+						subject: 'your pallet pools',
+					}),
+				),
+			)
+
+			// THEN the conversation picks it up rather than staying blank
+			// [COALESCE(NULLIF(subject, ''), EXCLUDED.subject)]
+			const after = await fetchThreadLink(rootMessageId)
+			expect(after?.subject).toBe('your pallet pools')
+		})
+
+		it('should fill one in when the first message had an empty one', async () => {
+			// GIVEN a first message whose subject is present but empty, which
+			// sends just as badly as none at all
+			const rootMessageId = `<subject-empty-${randomUUID()}@example>`
+			await runIngest(
+				persist(buildParsed({ messageId: rootMessageId, subject: '' })),
+			)
+
+			// WHEN a later message on it carries a real one
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: `<subject-empty-reply-${randomUUID()}@example>`,
+						inReplyTo: rootMessageId,
+						subject: 'your pallet pools',
+					}),
+				),
+			)
+
+			// THEN the empty one is replaced rather than kept
+			// [NULLIF(subject, '')]
+			const link = await fetchThreadLink(rootMessageId)
+			expect(link?.subject).toBe('your pallet pools')
+		})
+	})
+
+	describe('when the conversation starts with a message we sent', () => {
+		it('should put its subject on the conversation too', async () => {
+			// GIVEN our own message, read back from the sent folder
+			const rootMessageId = `<subject-outbound-${randomUUID()}@example>`
+			await runIngest(
+				persistIn(
+					buildParsed({
+						messageId: rootMessageId,
+						subject: 'your pallet pools',
+					}),
+					{ folder: 'Sent', direction: 'outbound' },
+				),
+			)
+
+			// THEN the conversation carries it, so a later reply has a subject
+			// to borrow whichever way the conversation began
+			const link = await fetchThreadLink(rootMessageId)
+			expect(link?.subject).toBe('your pallet pools')
+		})
+	})
+})
+
+describe('persistMessage — a message can be found in its conversation', () => {
+	describe('when a reply names only the message it answers', () => {
+		it('should still show up in the conversation it belongs to', async () => {
+			// GIVEN a conversation of three: a first message, a reply to it, and
+			// a reply to THAT one which names only its immediate parent — the
+			// shape a client sends when it writes In-Reply-To and no References,
+			// and the shape a client that trims a long chain sends too
+			const root = `<find-root-${randomUUID()}@example>`
+			const middle = `<find-middle-${randomUUID()}@example>`
+			const last = `<find-last-${randomUUID()}@example>`
+			await runIngest(persist(buildParsed({ messageId: root, subject: 'q' })))
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: middle,
+						inReplyTo: root,
+						references: [root],
+						subject: 'Re: q',
+					}),
+				),
+			)
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: last,
+						inReplyTo: middle,
+						references: [middle],
+						subject: 'Re: q',
+					}),
+				),
+			)
+
+			// THEN all three are in the conversation
+			// AND without the conversation's own id on the last one it would be
+			// filed correctly and then never shown, counted, or marked unread —
+			// which is how a customer's answer goes missing
+			const rows = await pool.query<{ message_id: string }>(
+				`SELECT message_id FROM email_messages
+				 WHERE organization_id = $1
+				   AND (message_id = $2 OR "references" @> ARRAY[$2]::text[])
+				 ORDER BY received_at`,
+				[ORG_ID, root],
+			)
+			expect(rows.rows.map(r => r.message_id).sort()).toEqual(
+				[root, middle, last].sort(),
+			)
 		})
 	})
 })

--- a/apps/mail-worker/src/persist.test.ts
+++ b/apps/mail-worker/src/persist.test.ts
@@ -76,6 +76,91 @@ describe('fromParsedMail', () => {
 		})
 	})
 
+	describe('when a reply names its parent only in In-Reply-To', () => {
+		it('should stand that in for the missing chain', async () => {
+			// GIVEN a reply with no References header, which some clients send
+			const mail = await parse(
+				rfc822({
+					from: 'a@x',
+					to: 'b@x',
+					subject: 'Re: r',
+					messageId: '<2@x>',
+					inReplyTo: '<1@x>',
+				}),
+			)
+
+			// WHEN it is read
+			const parsed = fromParsedMail(mail)
+
+			// THEN the parent it names becomes its chain
+			// AND without this the message belongs to no conversation: which
+			// conversation a message is in is read from this list, so it would
+			// be filed correctly and then never shown, counted, or marked unread
+			expect(parsed.references).toEqual(['<1@x>'])
+		})
+
+		it('should leave the header chain alone when there is one', async () => {
+			// GIVEN a reply carrying both headers
+			const mail = await parse(
+				rfc822({
+					from: 'a@x',
+					to: 'b@x',
+					subject: 'Re: r',
+					messageId: '<3@x>',
+					inReplyTo: '<2@x>',
+					references: '<1@x> <2@x>',
+				}),
+			)
+
+			// WHEN it is read
+			// THEN the header wins — the stand-in is only for when there is none
+			const parsed = fromParsedMail(mail)
+			expect(parsed.references).toEqual(['<1@x>', '<2@x>'])
+		})
+	})
+
+	describe('when the parent id a message names is not usable', () => {
+		it('should not stand a meaningless one in for the chain', async () => {
+			// GIVEN a reply whose In-Reply-To is an empty pair of brackets, which
+			// senders do emit
+			const mail = await parse(
+				rfc822({
+					from: 'a@x',
+					to: 'b@x',
+					subject: 'Re: r',
+					messageId: '<4@x>',
+					inReplyTo: '<>',
+				}),
+			)
+
+			// WHEN it is read
+			const parsed = fromParsedMail(mail)
+
+			// THEN nothing stands in — an id every mangled message shares is not
+			// an identifier, and keying conversations on it would gather
+			// unrelated people's mail into one
+			expect(parsed.references).toEqual([])
+		})
+
+		it('should not stand in a header the sender wrote as prose', async () => {
+			// GIVEN the shape older clients emit
+			const mail = await parse(
+				rfc822({
+					from: 'a@x',
+					to: 'b@x',
+					subject: 'Re: r',
+					messageId: '<5@x>',
+					inReplyTo: 'Your message of Tue <1@x>',
+				}),
+			)
+
+			// WHEN it is read
+			// THEN it is passed over rather than taken as an id
+			const parsed = fromParsedMail(mail)
+			expect(parsed.references).toEqual([])
+		})
+	})
+
 	describe('when text body is longer than 200 characters', () => {
 		it('should clamp the preview to 200 characters', async () => {
 			const long = 'x'.repeat(500)

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -7,6 +7,25 @@ import { NoMatch, ParticipantMatcher } from '@batuda/email/participant-matcher'
 
 import { resolveThreadId } from './threading.js'
 
+// Whether an id is one a conversation can be keyed on.
+//
+// A conversation is identified by a single id, and there is one row per id per
+// organisation — so an id that many unrelated messages share is not an
+// identifier at all, it is a bucket they all fall into. Senders emit plenty of
+// those: an empty `<>`, a header mangled into prose ("Your message of Tue…"),
+// two ids run together by a stray comma. Adopting one of those would put every
+// message in the organisation carrying the same junk into a single
+// conversation, mixing unrelated people's mail together.
+//
+// So the shape is checked before it is trusted: something inside the brackets,
+// nothing that belongs to more than one id, and the `@` that RFC 5322 requires.
+// Anything failing that is passed over for the next candidate.
+const isUsableMessageId = (id: string | null | undefined): id is string => {
+	if (typeof id !== 'string') return false
+	const core = id.trim().replace(/^</, '').replace(/>$/, '').trim()
+	return core !== '' && !/[\s<>,]/.test(core) && core.includes('@')
+}
+
 // Parsed-mail subset the worker reads. Decouples persist from any
 // specific parser so a future swap (e.g. mailparser → letterparser) is
 // localized.
@@ -45,11 +64,23 @@ const collectAddresses = (
 export const fromParsedMail = (mail: ParsedMail): ParsedInbound => {
 	const messageId = mail.messageId ?? ''
 	const inReplyTo = mail.inReplyTo ?? null
-	const references = mail.references
+	const headerReferences = mail.references
 		? Array.isArray(mail.references)
 			? mail.references
 			: [mail.references]
 		: []
+	// A message that answers something but carries no References header stands
+	// its In-Reply-To in for the chain, which is what RFC 5322 says to do and
+	// what mail clients do. Without it the row belongs to no conversation at
+	// all: which conversation a message is in is read from this list, so a
+	// reply that arrives this way is filed correctly and then never shown,
+	// never counted, and never marks the thread unread.
+	const references =
+		headerReferences.length > 0
+			? headerReferences
+			: isUsableMessageId(inReplyTo)
+				? [inReplyTo]
+				: []
 	const text = typeof mail.text === 'string' ? mail.text : null
 	const preview = text ? text.slice(0, 200) : null
 	return {
@@ -142,6 +173,19 @@ export const persistMessage = (args: {
 			references: args.parsed.references,
 		})
 
+		// Which conversation a message is in is read back out of this list, so
+		// the conversation's own id has to be in it or the message belongs
+		// nowhere a reader looks — filed correctly and then never shown, never
+		// counted, never marking the conversation unread.
+		//
+		// A sender that names only the message it answers, and not the whole
+		// chain back to the start, leaves it out. So does a sender that trims a
+		// long chain. Both are ordinary. The id goes in front, where the oldest
+		// ancestor belongs.
+		const storedReferences = args.parsed.references.includes(externalThreadId)
+			? args.parsed.references
+			: [externalThreadId, ...args.parsed.references]
+
 		// Whose conversation this is comes from the other side of it: who wrote
 		// to us, or who we wrote to. Reading the sender of a message we sent
 		// would only ever find ourselves, and a conversation that starts
@@ -197,14 +241,17 @@ export const persistMessage = (args: {
 		// `(organization_id, external_thread_id)` index. The DO UPDATE
 		// clause deliberately leaves `company_id`/`contact_id` alone —
 		// the first message on a thread sets the link, later messages
-		// from a different sender don't re-home the whole thread. The id comes
-		// back so the history entry can point at the conversation this message
-		// belongs to.
+		// from a different sender don't re-home the whole thread. The subject
+		// is filled in only when the thread hasn't got one, so a later message
+		// can't rename the conversation — replies to it are sent with this
+		// subject, so it has to stay put. The id comes back so the history
+		// entry can point at the conversation this message belongs to.
 		const threadLinks = yield* sql<{ id: string }>`
-			INSERT INTO email_thread_links (organization_id, inbox_id, external_thread_id, company_id, contact_id, updated_at)
-			VALUES (${args.organizationId}, ${args.inboxId}, ${externalThreadId}, ${companyId}, ${contactId}, now())
+			INSERT INTO email_thread_links (organization_id, inbox_id, external_thread_id, company_id, contact_id, subject, updated_at)
+			VALUES (${args.organizationId}, ${args.inboxId}, ${externalThreadId}, ${companyId}, ${contactId}, ${args.parsed.subject}, now())
 			ON CONFLICT (organization_id, external_thread_id)
-			DO UPDATE SET updated_at = now()
+			DO UPDATE SET updated_at = now(),
+			              subject = COALESCE(NULLIF(btrim(email_thread_links.subject), ''), NULLIF(btrim(EXCLUDED.subject), ''))
 			RETURNING id
 		`
 		const threadLinkId = threadLinks[0]?.id ?? null
@@ -227,7 +274,7 @@ export const persistMessage = (args: {
 				${args.organizationId}, ${args.inboxId}, ${args.folder},
 				${args.imapUid}, ${args.imapUidvalidity},
 				${args.parsed.messageId}, ${args.parsed.inReplyTo},
-				${args.parsed.references as unknown as string[]},
+				${storedReferences as unknown as string[]},
 				${args.parsed.subject}, ${args.parsed.receivedAt},
 				${args.parsed.textBody}, ${args.parsed.htmlBody}, ${args.parsed.textPreview},
 				${args.rawRfc822Ref},

--- a/apps/mail-worker/src/threading.ts
+++ b/apps/mail-worker/src/threading.ts
@@ -35,6 +35,15 @@ export const resolveThreadId = (args: {
 				 )
 				WHERE em.organization_id = ${args.organizationId}
 				  AND em.message_id = ${args.inReplyTo}
+				-- A conversation can hold more than one of these rows when its
+				-- first message was taken in after a reply that named it, so pick
+				-- deterministically rather than whichever comes back first. A
+				-- references chain runs oldest first, so the earliest entry that
+				-- has a conversation is the conversation — the message's own id
+				-- would name the later split instead, which holds only the tail.
+				ORDER BY array_position(em."references", etl.external_thread_id)
+				           ASC NULLS LAST,
+				         etl.created_at ASC, etl.id ASC
 				LIMIT 1
 			`
 			const hit = rows[0]?.externalThreadId
@@ -56,11 +65,31 @@ export const resolveThreadId = (args: {
 				 )
 				WHERE em.organization_id = ${args.organizationId}
 				  AND em.message_id = ${ref}
+				-- A conversation can hold more than one of these rows when its
+				-- first message was taken in after a reply that named it, so pick
+				-- deterministically rather than whichever comes back first. A
+				-- references chain runs oldest first, so the earliest entry that
+				-- has a conversation is the conversation — the message's own id
+				-- would name the later split instead, which holds only the tail.
+				ORDER BY array_position(em."references", etl.external_thread_id)
+				           ASC NULLS LAST,
+				         etl.created_at ASC, etl.id ASC
 				LIMIT 1
 			`
 			const hit = rows[0]?.externalThreadId
 			if (hit) return hit
 		}
 
+		// Nothing on file to hang this on, so this message starts a conversation
+		// of its own.
+		//
+		// The oldest id it names looks like the better answer — it would let a
+		// reply taken in before the message it answers join that one later,
+		// instead of leaving the contact with two. It is not: several people
+		// replying to one message we do not hold all name the same id, so they
+		// would land in a single conversation, and a conversation belongs to
+		// whoever is on the first message to reach it. The second company's
+		// mail would then sit under the first company's. Measured both ways —
+		// a duplicate conversation costs less than mixing two customers.
 		return args.messageId
 	})

--- a/apps/server/src/handlers/email.ts
+++ b/apps/server/src/handlers/email.ts
@@ -2,7 +2,7 @@ import { Effect, Stream } from 'effect'
 import { HttpServerResponse, Multipart } from 'effect/unstable/http'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
-import { BadRequest, BatudaApi } from '@batuda/controllers'
+import { BatudaApi } from '@batuda/controllers'
 
 import { EmailService } from '../services/email'
 import {
@@ -69,7 +69,9 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 						)
 						.pipe(
 							// Surface the inbox-state failures as the route's declared
-							// 409s; collapse internal errors to die().
+							// 409s; collapse internal errors to die(). A refused send is
+							// declared separately and travels on its own, so the reader
+							// is told what to fix while a real fault still reads as one.
 							Effect.catchTag('EmailError', e => Effect.die(e)),
 							Effect.catchTag('SqlError', e => Effect.die(e)),
 							Effect.catchTag('SmtpSendFailed', e => Effect.die(e)),
@@ -84,6 +86,9 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 							}),
 							...(_.payload.preview !== undefined && {
 								preview: _.payload.preview,
+							}),
+							...(_.payload.subject !== undefined && {
+								subject: _.payload.subject,
 							}),
 							...(_.payload.attachments !== undefined && {
 								attachmentRefs: toStagingRefs(_.payload.attachments),
@@ -380,8 +385,9 @@ export const EmailLive = HttpApiBuilder.group(BatudaApi, 'email', handlers =>
 				.handle('sendDraft', _ =>
 					svc.sendDraft(_.payload.inboxId, _.params.draftId).pipe(
 						Effect.catchTags({
-							EmailError: e =>
-								Effect.fail(new BadRequest({ message: e.message })),
+							// A refused send is declared on the route and travels out on
+							// its own; only real faults are collapsed here.
+							EmailError: e => Effect.die(e),
 							NotFound: e => Effect.fail(e),
 							InboxInactive: e => Effect.die(e),
 							GrantUnavailable: e => Effect.die(e),

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -119,11 +119,19 @@ const AttachmentRef = Schema.Struct({
 	cid: Schema.optional(Schema.String),
 })
 
+// What a refused send is told, in the words the caller can act on. The service
+// answers with the reason alone so each surface can say it its own way; this is
+// the one an assistant reads.
+const refusalMessage = (reason: 'no_subject' | 'forged_reply'): string =>
+	reason === 'no_subject'
+		? 'Refused: the message has no subject, so it would arrive as "(no subject)" and be treated as spam. Pass a subject and send again.'
+		: 'Refused: the subject starts with "Re:" but the message answers nothing, which receiving servers read as a forged reply. Answer the thread with reply_email, or pass thread_link_id on the draft, or drop the "Re:".'
+
 // ── Compose tools ────────────────────────────────────────────────
 
 const SendEmail = Tool.make('send_email', {
 	description:
-		'Send a new email. The body is a structured block tree (paragraph / heading / list / quote / divider / image) — not raw html/text. Omit inbox_id to use the calling member’s primary inbox in the active org. Attachments reference staging_ids returned by stage_email_attachment; set inline=true for cid-referenced inline images. Before composing, read the member’s standing email instructions (writing style, sign-off, do/don’t rules) from the batuda://instructions/email resource and write the body to follow them. Returns {_tag:"sent"} on success; {_tag:"suppressed"} if a recipient once hard-bounced or reported spam, which is a hard block on every path; or {_tag:"cancelled"} if an address being written to carries a deliverability verdict of "undeliverable" or "risky" and nobody confirmed it — either the answer was no, or this client cannot put a question to anybody, and the reason says which. Verdicts of "catch_all" and "unknown", and addresses nobody has checked, are not gated. Read `verification` on a contact\'s channels (list_contacts) before composing to see this coming; when a send is stopped, the reason names the exact call that lifts it. Set skip_footer=true to omit the inbox default footer.',
+		'Send a new email, starting a new conversation. To answer or follow up on a conversation that already exists use reply_email instead, or a draft carrying thread_link_id — this tool sets no threading headers, so a "Re: " subject here would reach the recipient as a forged reply and is refused. The body is a structured block tree (paragraph / heading / list / quote / divider / image) — not raw html/text. Omit inbox_id to use the calling member’s primary inbox in the active org. Attachments reference staging_ids returned by stage_email_attachment; set inline=true for cid-referenced inline images. Before composing, read the member’s standing email instructions (writing style, sign-off, do/don’t rules) from the batuda://instructions/email resource and write the body to follow them. Returns {_tag:"sent"} on success; {_tag:"suppressed"} if a recipient once hard-bounced or reported spam, which is a hard block on every path; or {_tag:"cancelled"} if an address being written to carries a deliverability verdict of "undeliverable" or "risky" and nobody confirmed it — either the answer was no, or this client cannot put a question to anybody, and the reason says which. Verdicts of "catch_all" and "unknown", and addresses nobody has checked, are not gated. Read `verification` on a contact\'s channels (list_contacts) before composing to see this coming; when a send is stopped, the reason names the exact call that lifts it. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		inbox_id: Schema.optional(Schema.String).annotate({
 			description:
@@ -150,11 +158,15 @@ const SendEmail = Tool.make('send_email', {
 
 const ReplyEmail = Tool.make('reply_email', {
 	description:
-		'Reply to the latest message in an existing email thread. Body is a structured block tree — if you want the parent quoted, emit a `quote` block wrapping sanitized parent blocks (you can read the parent via get_email_thread). Optional Cc/Bcc extend the thread. Attachments reference staging_ids from stage_email_attachment. Before composing, read the member’s standing email instructions from the batuda://instructions/email resource and write the reply to follow them. Returns {_tag:"sent"}; {_tag:"suppressed"} if a recipient once hard-bounced or reported spam; or {_tag:"cancelled"} when a confirmation was needed and not obtained — because the contact\'s address (or one added in cc/bcc) carries an "undeliverable" or "risky" verdict, or because the thread already has EMAIL_AGENT_SOFT_THREAD_LIMIT outbound messages (default 3) and this reply would be one more. The reason names which, and says when the client had no way to ask anybody — and for an address it names the call that lifts the stop. Pass acknowledge_thread_length: true to answer the message-count reason without a prompt; an address with something recorded against it is answered by vouching for it instead. Set skip_footer=true to omit the inbox default footer.',
+		'Reply to the latest message in an existing email thread. The thread\'s own subject is used, prefixed "Re: ", so leave subject out unless you mean to change it — or unless the thread\'s messages never carried one, where there is nothing to borrow and a subject is required. Body is a structured block tree — if you want the parent quoted, emit a `quote` block wrapping sanitized parent blocks (you can read the parent via get_email_thread). Optional Cc/Bcc extend the thread. Attachments reference staging_ids from stage_email_attachment. Before composing, read the member’s standing email instructions from the batuda://instructions/email resource and write the reply to follow them. Returns {_tag:"sent"}; {_tag:"suppressed"} if a recipient once hard-bounced or reported spam; or {_tag:"cancelled"} when a confirmation was needed and not obtained — because the contact\'s address (or one added in cc/bcc) carries an "undeliverable" or "risky" verdict, or because the thread already has EMAIL_AGENT_SOFT_THREAD_LIMIT outbound messages (default 3) and this reply would be one more. The reason names which, and says when the client had no way to ask anybody — and for an address it names the call that lifts the stop. Pass acknowledge_thread_length: true to answer the message-count reason without a prompt; an address with something recorded against it is answered by vouching for it instead. Set skip_footer=true to omit the inbox default footer.',
 	parameters: Schema.Struct({
 		thread_id: EmailThreadIdParam,
 		body_json: EmailBlocks,
 		preview: Schema.optional(Schema.String),
+		subject: Schema.optional(Schema.String).annotate({
+			description:
+				'Subject line. Leave it out and the thread\'s own subject is used, prefixed "Re: " — that is what you want almost always. Pass one to change the subject mid-thread, or to answer a thread whose messages never carried a subject: there is nothing to borrow there, and a send with no subject is refused because it would arrive as "(no subject)".',
+		}),
 		cc: Schema.optional(Schema.Array(Schema.String)),
 		bcc: Schema.optional(Schema.Array(Schema.String)),
 		attachments: Schema.optional(Schema.Array(AttachmentRef)),
@@ -445,7 +457,7 @@ const ManageEmailInbox = Tool.make('manage_email_inbox', {
 
 const ManageEmailDraft = Tool.make('manage_email_draft', {
 	description:
-		'Manage an email draft a human can review before sending. Omit inbox_id: a new draft is written in the calling member’s primary inbox in the active org, the same rule send_email follows, and update / send / delete act on the mailbox the draft already lives in. action=create makes a new draft (optionally linked to CRM via company_id/contact_id/mode); update changes fields on an existing draft_id; send dispatches draft_id through the same thread-link/interaction/message pipeline as a direct send, and runs the same deliverability guard on the addresses, so writing a message down first is not a way past that (it does not re-count how many outbound messages a thread already holds, which only reply_email does) (returns {_tag:"sent"}, {_tag:"suppressed"}, or {_tag:"cancelled"} — see send_email for what each means); delete permanently removes draft_id. body_json is the typed block tree preserved for lossless editor re-hydration.',
+		'Manage an email draft a human can review before sending. Omit inbox_id: a new draft is written in the calling member’s primary inbox in the active org, the same rule send_email follows, and update / send / delete act on the mailbox the draft already lives in. action=create makes a new draft (optionally linked to CRM via company_id/contact_id, and to an existing conversation via thread_link_id or in_reply_to — pass one of those whenever the draft answers a thread, or it goes out as a brand-new conversation); update changes fields on an existing draft_id; send dispatches draft_id through the same thread-link/interaction/message pipeline as a direct send, and runs the same deliverability guard on the addresses, so writing a message down first is not a way past that (it does not re-count how many outbound messages a thread already holds, which only reply_email does) (returns {_tag:"sent"}, {_tag:"suppressed"}, or {_tag:"cancelled"} — see send_email for what each means); delete permanently removes draft_id. body_json is the typed block tree preserved for lossless editor re-hydration.',
 	parameters: Schema.Struct({
 		action: Schema.Literals(['create', 'update', 'send', 'delete']),
 		inbox_id: Schema.optional(Schema.String).annotate({
@@ -459,13 +471,25 @@ const ManageEmailDraft = Tool.make('manage_email_draft', {
 		to: Schema.optional(Recipients),
 		cc: Schema.optional(Schema.Array(Schema.String)),
 		bcc: Schema.optional(Schema.Array(Schema.String)),
-		subject: Schema.optional(Schema.String),
+		subject: Schema.optional(Schema.String).annotate({
+			description:
+				'Subject line. Leave it out on a draft that answers an existing thread and the thread\'s own subject is used, prefixed "Re: ". On a draft that starts a new conversation a subject is required — a send with none is refused, because a message with no subject line arrives as "(no subject)".',
+		}),
 		body_json: Schema.optional(EmailBlocks),
-		in_reply_to: Schema.optional(Schema.String),
+		in_reply_to: Schema.optional(Schema.String).annotate({
+			description:
+				'Message-ID of the message this one answers, angle brackets and all. An alternative to thread_link_id when you have the parent message but not the thread: the thread it belongs to is looked up from it. Ignored when thread_link_id is given.',
+		}),
 		company_id: Schema.optional(Schema.String),
 		contact_id: Schema.optional(Schema.String),
-		mode: Schema.optional(Schema.String),
-		thread_link_id: Schema.optional(Schema.String),
+		mode: Schema.optional(Schema.Literals(['new', 'reply'])).annotate({
+			description:
+				'What kind of message this is, recorded for the composer that re-opens the draft. It does not decide threading: a draft is threaded when it carries thread_link_id or in_reply_to, whichever mode says.',
+		}),
+		thread_link_id: Schema.optional(Schema.String).annotate({
+			description:
+				'The thread this draft answers, as returned by list_email_threads or get_email_thread. This is what attaches the sent message to an existing conversation — with it the message carries In-Reply-To and References and lands in the same thread for the recipient; without it the message starts a new conversation, and a "Re: " subject on a message that starts a new conversation is refused, because that pairing reads as a forged reply.',
+		}),
 	}),
 	// create / update return the draft; send returns the send result; delete
 	// returns the deleted marker.
@@ -742,13 +766,17 @@ export const EmailHandlersLive = EmailTools.toLayer(
 					SELECT count(*)::int AS n FROM email_messages
 					WHERE direction = 'outbound' AND organization_id = ${orgId}
 					AND (message_id = ${link.externalThreadId}
-					     OR ${link.externalThreadId} = ANY("references"))
+					     OR "references" @> ARRAY[${link.externalThreadId}]::text[])
+					AND deleted_at IS NULL
 				`
 				// Where a reply will actually land. This has to pick the same
 				// addresses the send itself picks, or the guard judges one mailbox
 				// while the message goes to another — so it repeats the send path's
 				// choice: the sender of an inbound message, the addressees of an
-				// outbound one, ordered the same way.
+				// outbound one, ordered the same way, skipping messages the server
+				// has since dropped and settling ties on the same column. Change
+				// the one in `EmailService.reply` and this has to move with it;
+				// they have drifted apart before.
 				//
 				// Judging the linked person's default address instead answered about
 				// a different mailbox whenever the conversation was with any other
@@ -761,8 +789,10 @@ export const EmailHandlersLive = EmailTools.toLayer(
 					SELECT direction, recipients FROM email_messages
 					WHERE organization_id = ${orgId}
 						AND (message_id = ${link.externalThreadId}
-						     OR ${link.externalThreadId} = ANY("references"))
-					ORDER BY received_at DESC NULLS LAST, status_updated_at DESC
+						     OR "references" @> ARRAY[${link.externalThreadId}]::text[])
+						AND deleted_at IS NULL
+					ORDER BY received_at DESC NULLS LAST,
+					         status_updated_at DESC, message_id DESC
 					LIMIT 1
 				`
 				const newest = latest[0]
@@ -869,6 +899,12 @@ export const EmailHandlersLive = EmailTools.toLayer(
 								messageId: r.messageId,
 								threadId: r.threadId,
 							})),
+							// A refused send names why. The wording lives here, on the
+							// surface that speaks to the caller, so the service can
+							// answer with the reason alone.
+							Effect.catchTag('EmailNotSendable', e =>
+								Effect.die(new ToolMessage(refusalMessage(e.reason))),
+							),
 							Effect.catchTag('EmailSuppressed', e =>
 								Effect.succeed({
 									_tag: 'suppressed' as const,
@@ -924,6 +960,9 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							...(params.preview !== undefined && {
 								preview: params.preview,
 							}),
+							...(params.subject !== undefined && {
+								subject: params.subject,
+							}),
 							...(params.attachments !== undefined && {
 								attachmentRefs: toStagingRefs(params.attachments),
 							}),
@@ -937,6 +976,12 @@ export const EmailHandlersLive = EmailTools.toLayer(
 								messageId: r.messageId,
 								threadId: r.threadId,
 							})),
+							// A refused send names why. The wording lives here, on the
+							// surface that speaks to the caller, so the service can
+							// answer with the reason alone.
+							Effect.catchTag('EmailNotSendable', e =>
+								Effect.die(new ToolMessage(refusalMessage(e.reason))),
+							),
 							Effect.catchTag('EmailSuppressed', e =>
 								Effect.succeed({
 									_tag: 'suppressed' as const,
@@ -1323,6 +1368,12 @@ export const EmailHandlersLive = EmailTools.toLayer(
 											messageId: r.messageId,
 											threadId: r.threadId,
 										},
+							),
+							// A refused send names why. The wording lives here, on the
+							// surface that speaks to the caller, so the service can
+							// answer with the reason alone.
+							Effect.catchTag('EmailNotSendable', e =>
+								Effect.die(new ToolMessage(refusalMessage(e.reason))),
 							),
 							Effect.catchTag('EmailSuppressed', e =>
 								Effect.succeed({

--- a/apps/server/src/services/calendar-rsvp-dispatch.ts
+++ b/apps/server/src/services/calendar-rsvp-dispatch.ts
@@ -39,13 +39,18 @@ export const dispatchRsvpReply = (args: {
 		// and move on rather than failing the RSVP.
 		const eventRows = yield* sql<{
 			metadata: Record<string, unknown> | null
+			title: string | null
 		}>`
-			SELECT metadata
+			SELECT metadata, title
 			FROM calendar_events
 			WHERE id = ${args.calendarEventId}
 			LIMIT 1
 		`
 		const meta = eventRows[0]?.metadata ?? null
+		// An invitation thread nearly always carries a subject to answer under,
+		// but this reply has to go out either way — an accept nobody receives
+		// reads to the organiser as no answer at all.
+		const eventTitle = eventRows[0]?.title ?? null
 		const sourceEmailMessageId =
 			meta && typeof meta === 'object' && 'sourceEmailMessageId' in meta
 				? (meta as { sourceEmailMessageId?: unknown }).sourceEmailMessageId
@@ -79,6 +84,15 @@ export const dispatchRsvpReply = (args: {
 			 )
 			WHERE em.id = ${sourceEmailMessageId}
 			  AND em.organization_id = ${currentOrg.id}
+			-- A conversation can hold more than one of these rows when its
+			-- first message was taken in after a reply that named it, so pick
+			-- deterministically rather than whichever comes back first. A
+			-- references chain runs oldest first, so the earliest entry that
+			-- has a conversation is the conversation — the message's own id
+			-- would name the later split instead, which holds only the tail.
+			ORDER BY array_position(em."references", etl.external_thread_id)
+			           ASC NULLS LAST,
+			         etl.created_at ASC, etl.id ASC
 			LIMIT 1
 		`
 		const threadLinkId = linkRows[0]?.id
@@ -112,6 +126,8 @@ export const dispatchRsvpReply = (args: {
 		yield* email
 			.reply(threadLinkId, body, {
 				skipFooter: true,
+				...(eventTitle !== null &&
+					eventTitle.trim() !== '' && { fallbackSubject: eventTitle }),
 				rawAttachments: [
 					{
 						filename: 'invite.ics',

--- a/apps/server/src/services/email-references.test.ts
+++ b/apps/server/src/services/email-references.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildReferences } from './email'
+
+// The References header is how a mail client hangs a reply under the message it
+// answers. Two things have to hold at once: the last entry must be the message
+// being answered, and the id the conversation is filed under must be somewhere
+// in the list, because that is how this system finds a message's conversation
+// again. Getting the first wrong scrambles the reader's view; getting the
+// second wrong makes our own messages vanish from the thread.
+
+const ROOT = '<root@client.test>'
+const PARENT = '<parent@client.test>'
+
+describe('buildReferences', () => {
+	describe('when the conversation starts where we do', () => {
+		it('should list the first message first and the answered one last', () => {
+			// GIVEN a parent whose own chain starts at the root
+			// WHEN the header is built
+			// THEN it reads oldest to newest
+			expect(
+				buildReferences({
+					root: ROOT,
+					parentReferences: [ROOT, '<mid@client.test>'],
+					parentMessageId: PARENT,
+				}),
+			).toEqual([ROOT, '<mid@client.test>', PARENT])
+		})
+
+		it('should name a single message once when it is the whole conversation', () => {
+			// GIVEN a conversation holding only its first message
+			// WHEN a reply answers it
+			// THEN that id appears once, not twice
+			expect(
+				buildReferences({
+					root: ROOT,
+					parentReferences: [],
+					parentMessageId: ROOT,
+				}),
+			).toEqual([ROOT])
+		})
+	})
+
+	describe('when we joined the conversation midway', () => {
+		it('should keep the answered message last rather than hoisting it', () => {
+			// GIVEN a conversation we were copied into: the first message we hold
+			// is itself a reply, so it becomes the id we file under while
+			// carrying older ancestors we never saw
+			// WHEN a reply is built
+			// THEN the ancestors stay in front and the answered message stays last
+			// AND putting the filed-under id first here would tell the reader the
+			// newest message is the oldest
+			expect(
+				buildReferences({
+					root: '<D@client.test>',
+					parentReferences: [
+						'<A@client.test>',
+						'<B@client.test>',
+						'<C@client.test>',
+					],
+					parentMessageId: '<D@client.test>',
+				}),
+			).toEqual([
+				'<A@client.test>',
+				'<B@client.test>',
+				'<C@client.test>',
+				'<D@client.test>',
+			])
+		})
+
+		it('should stay stable when its own output is fed back in', () => {
+			// GIVEN the chain a first reply sent, now stored on that reply's row
+			const first = buildReferences({
+				root: '<D@client.test>',
+				parentReferences: ['<A@client.test>', '<B@client.test>'],
+				parentMessageId: '<D@client.test>',
+			})
+
+			// WHEN a second reply answers that first one
+			const second = buildReferences({
+				root: '<D@client.test>',
+				parentReferences: first,
+				parentMessageId: '<reply-1@taller.test>',
+			})
+
+			// THEN the earlier order is preserved and only the new message is added
+			// AND nothing is re-hoisted on each round
+			expect(second).toEqual([
+				'<A@client.test>',
+				'<B@client.test>',
+				'<D@client.test>',
+				'<reply-1@taller.test>',
+			])
+		})
+	})
+
+	describe('when the parent chain is untidy', () => {
+		it('should drop repeats, keeping the earliest place each id appeared', () => {
+			// GIVEN an id repeated in the parent's chain
+			// WHEN the header is built
+			// THEN it appears once
+			expect(
+				buildReferences({
+					root: ROOT,
+					parentReferences: [ROOT, ROOT, '<mid@client.test>'],
+					parentMessageId: PARENT,
+				}),
+			).toEqual([ROOT, '<mid@client.test>', PARENT])
+		})
+
+		it('should move a parent that names itself to the end', () => {
+			// GIVEN a parent whose own chain already includes its own id, which
+			// some mailing-list software emits
+			// WHEN the header is built
+			// THEN it is answered last rather than left mid-list
+			expect(
+				buildReferences({
+					root: ROOT,
+					parentReferences: [ROOT, PARENT],
+					parentMessageId: PARENT,
+				}),
+			).toEqual([ROOT, PARENT])
+		})
+
+		it('should drop entries that are not usable ids', () => {
+			// GIVEN blanks and nulls, which the column this is read from allows
+			// WHEN the header is built
+			// THEN none of them reach it
+			// AND a null would otherwise be written out as the word "null"
+			expect(
+				buildReferences({
+					root: ROOT,
+					parentReferences: [
+						'',
+						'   ',
+						null as unknown as string,
+						undefined as unknown as string,
+					],
+					parentMessageId: PARENT,
+				}),
+			).toEqual([ROOT, PARENT])
+		})
+
+		it('should add the filed-under id when the parent never carried it', () => {
+			// GIVEN a parent chain with no trace of the conversation's own id
+			// WHEN the header is built
+			// THEN it is put in front, so the conversation stays findable
+			expect(
+				buildReferences({
+					root: ROOT,
+					parentReferences: ['<stranger@elsewhere.test>'],
+					parentMessageId: PARENT,
+				}),
+			).toEqual([ROOT, '<stranger@elsewhere.test>', PARENT])
+		})
+	})
+
+	describe('when the conversation is longer than a header should carry', () => {
+		const chainOf = (n: number) =>
+			Array.from({ length: n }, (_, i) => `<m${i}@client.test>`)
+
+		it('should send a long chain whole while it still fits', () => {
+			// GIVEN a chain exactly at the limit
+			// WHEN the header is built
+			// THEN nothing is dropped
+			const refs = [ROOT, ...chainOf(18)]
+			const built = buildReferences({
+				root: ROOT,
+				parentReferences: refs,
+				parentMessageId: PARENT,
+			})
+			expect(built).toHaveLength(20)
+			expect(built.at(-1)).toBe(PARENT)
+		})
+
+		it('should keep the newest links and the answered message', () => {
+			// GIVEN a conversation far past the limit
+			const built = buildReferences({
+				root: ROOT,
+				parentReferences: [ROOT, ...chainOf(60)],
+				parentMessageId: PARENT,
+			})
+
+			// THEN the header is bounded
+			expect(built).toHaveLength(20)
+			// AND still answers the right message
+			expect(built.at(-1)).toBe(PARENT)
+			// AND the oldest links are the ones given up
+			expect(built).not.toContain('<m0@client.test>')
+			expect(built).toContain('<m59@client.test>')
+		})
+
+		it('should keep the filed-under id even when it is the oldest thing left', () => {
+			// GIVEN a conversation long enough that the first message falls
+			// outside the window of newest links
+			const built = buildReferences({
+				root: ROOT,
+				parentReferences: [ROOT, ...chainOf(60)],
+				parentMessageId: PARENT,
+			})
+
+			// THEN it is kept anyway, and kept in front
+			// AND without it our own message stops being findable in its own
+			// conversation, because that id is what the lookup searches for
+			expect(built[0]).toBe(ROOT)
+			expect(built).toContain(ROOT)
+		})
+
+		it('should not grow one entry longer on every reply', () => {
+			// GIVEN a chain already at the limit
+			let refs = buildReferences({
+				root: ROOT,
+				parentReferences: [ROOT, ...chainOf(60)],
+				parentMessageId: PARENT,
+			})
+
+			// WHEN five more replies are sent on it
+			for (let i = 0; i < 5; i++) {
+				refs = buildReferences({
+					root: ROOT,
+					parentReferences: refs,
+					parentMessageId: `<later-${i}@taller.test>`,
+				})
+				// THEN it stays bounded, keeps the filed-under id, and answers
+				// the newest message each time
+				expect(refs).toHaveLength(20)
+				expect(refs[0]).toBe(ROOT)
+				expect(refs.at(-1)).toBe(`<later-${i}@taller.test>`)
+			}
+		})
+	})
+})

--- a/apps/server/src/services/email-search.integration.test.ts
+++ b/apps/server/src/services/email-search.integration.test.ts
@@ -41,7 +41,7 @@ const searchThreads = async (q: string): Promise<string[]> => {
 		      SELECT 1 FROM email_messages em
 		      WHERE em.organization_id = tl.organization_id
 		        AND (em.message_id = tl.external_thread_id
-		             OR tl.external_thread_id = ANY(em."references"))
+		             OR em."references" @> ARRAY[tl.external_thread_id]::text[])
 		        AND em.search_vector @@ plainto_tsquery('simple', $2)
 		    )
 		    OR EXISTS (
@@ -49,7 +49,7 @@ const searchThreads = async (q: string): Promise<string[]> => {
 		      JOIN message_participants mp ON mp.email_message_id = em2.id
 		      WHERE em2.organization_id = tl.organization_id
 		        AND (em2.message_id = tl.external_thread_id
-		             OR tl.external_thread_id = ANY(em2."references"))
+		             OR em2."references" @> ARRAY[tl.external_thread_id]::text[])
 		        AND mp.email_address ILIKE $3
 		    )
 		  )

--- a/apps/server/src/services/email-send-guard.test.ts
+++ b/apps/server/src/services/email-send-guard.test.ts
@@ -1,0 +1,265 @@
+import { Cause, Effect, Exit } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { assertSendable } from './email'
+
+// Every way of sending a message funnels through `dispatchOutbound`, which
+// calls this first. The two shapes it refuses both get a message scored as
+// spam by the receiving server, and we only learn that much later — so the
+// cost of a wrong answer here is asymmetric, and the false-positive cases
+// (a subject that merely starts with the letters "re") matter as much as the
+// true ones: a wrong refusal blocks ordinary mail nobody can send another way.
+
+const failureOf = (message: {
+	subject: string
+	inReplyTo?: string | undefined
+	references?: readonly string[] | undefined
+}) => {
+	const exit = Effect.runSyncExit(assertSendable(message))
+	if (Exit.isSuccess(exit)) return null
+	for (const reason of exit.cause.reasons) {
+		if (Cause.isFailReason(reason)) return reason.error
+	}
+	return null
+}
+
+// Why the send was refused, or null when it was allowed. The guard answers
+// with a reason rather than a sentence, so each surface can word it its own
+// way — and so telemetry can count the reasons apart.
+const refusalOf = (message: {
+	subject: string
+	inReplyTo?: string | undefined
+	references?: readonly string[] | undefined
+}): string | null => failureOf(message)?.reason ?? null
+
+const PARENT = '<parent@mail.infomaniak.com>'
+
+describe('assertSendable', () => {
+	describe('when the message has an ordinary subject', () => {
+		it('should allow a new message that threads nothing', () => {
+			// GIVEN a plain subject and no threading headers
+			// WHEN the guard runs
+			// THEN the send is allowed
+			expect(refusalOf({ subject: 'your pallet pools' })).toBeNull()
+		})
+
+		it('should allow an ordinary subject that does thread', () => {
+			// GIVEN a reply whose writer changed the subject rather than
+			// keeping the parent's
+			// WHEN the guard runs
+			// THEN the send is allowed
+			// AND threading headers are never on their own a reason to refuse
+			expect(
+				refusalOf({ subject: 'new quote attached', inReplyTo: PARENT }),
+			).toBeNull()
+		})
+
+		it('should allow a subject that is not written in English', () => {
+			// GIVEN accented and non-Latin subjects
+			// WHEN the guard runs
+			// THEN none of them are refused
+			expect(refusalOf({ subject: 'Pressupost per als palets' })).toBeNull()
+			expect(refusalOf({ subject: 'Presupuesto — envío' })).toBeNull()
+			expect(refusalOf({ subject: '見積書' })).toBeNull()
+		})
+
+		it('should succeed with no value rather than a result to inspect', () => {
+			// GIVEN an allowable message
+			// WHEN the guard runs
+			// THEN it completes without producing anything
+			// AND callers use it for its failure alone
+			const exit = Effect.runSyncExit(assertSendable({ subject: 'pools' }))
+			expect(Exit.isSuccess(exit)).toBe(true)
+		})
+	})
+
+	describe('when the subject only looks like a reply prefix', () => {
+		it('should allow a word that merely starts with the letters "re"', () => {
+			// GIVEN words beginning "re" with no colon straight after
+			// WHEN the guard runs
+			// THEN none of them are refused
+			// AND a false positive here blocks ordinary mail
+			expect(refusalOf({ subject: 'Reminder: pay the invoice' })).toBeNull()
+			expect(refusalOf({ subject: 'Renewal quote attached' })).toBeNull()
+			expect(refusalOf({ subject: 'Rescheduling Thursday' })).toBeNull()
+		})
+
+		it('should allow a "Ref:" reference prefix', () => {
+			// GIVEN the reference prefix ordinary business mail uses
+			// WHEN the guard runs
+			// THEN it is not mistaken for a reply prefix
+			expect(refusalOf({ subject: 'Ref: 2026-0114' })).toBeNull()
+		})
+
+		it('should allow "re" with no colon at all', () => {
+			// GIVEN the bare letters and nothing else
+			// WHEN the guard runs
+			// THEN the send is allowed
+			expect(refusalOf({ subject: 're' })).toBeNull()
+			expect(refusalOf({ subject: 're the pallet pools' })).toBeNull()
+		})
+
+		it('should allow "Re:" appearing somewhere other than the start', () => {
+			// GIVEN the prefix buried mid-subject
+			// WHEN the guard runs
+			// THEN only a leading one counts
+			expect(refusalOf({ subject: 'Score: Re: last match' })).toBeNull()
+		})
+	})
+
+	describe('when the subject is missing', () => {
+		it('should refuse an empty subject', () => {
+			// GIVEN nothing in the subject
+			// WHEN the guard runs
+			// THEN the send is refused
+			// AND the reason says what the recipient would have seen
+			expect(refusalOf({ subject: '' })).toBe('no_subject')
+		})
+
+		it('should refuse a subject that is only blank space', () => {
+			// GIVEN spaces, tabs and newlines but no text
+			// WHEN the guard runs
+			// THEN each counts as empty
+			// [trim()]
+			for (const subject of ['   ', '\t', '\n', ' \t\n ']) {
+				expect(refusalOf({ subject })).toBe('no_subject')
+			}
+		})
+
+		it('should refuse an empty subject even when the message threads correctly', () => {
+			// GIVEN correct threading headers but no subject
+			// WHEN the guard runs
+			// THEN the send is still refused
+			// AND this is the exact shape the reply path used to send
+			expect(
+				refusalOf({
+					subject: '',
+					inReplyTo: PARENT,
+					references: [PARENT],
+				}),
+			).toBe('no_subject')
+		})
+	})
+
+	describe('when the subject claims to be a reply but answers nothing', () => {
+		it('should refuse it', () => {
+			// GIVEN a reply prefix and nothing for it to answer
+			// WHEN the guard runs
+			// THEN the send is refused
+			// AND it names which of the two shapes it was
+			expect(refusalOf({ subject: 'Re: your pallet pools' })).toBe(
+				'forged_reply',
+			)
+		})
+
+		it('should refuse however the prefix is capitalised or spaced', () => {
+			// GIVEN the prefix written the ways mail clients write it
+			// WHEN the guard runs
+			// THEN each one is refused
+			// [/^re\s*:/i]
+			for (const subject of [
+				'RE: pools',
+				're: pools',
+				'rE: pools',
+				'Re : pools',
+				'Re\t: pools',
+				'Re:',
+				'Re: Re: pools',
+			]) {
+				expect(refusalOf({ subject })).toBe('forged_reply')
+			}
+		})
+
+		it('should refuse a prefix hidden behind leading blank space', () => {
+			// GIVEN blank space before the prefix
+			// WHEN the guard runs
+			// THEN it is still recognised
+			// AND trimming happens before the prefix is looked for
+			expect(refusalOf({ subject: '   Re: pools' })).toBe('forged_reply')
+		})
+
+		it('should refuse when references is present but empty', () => {
+			// GIVEN an empty references array rather than an absent one
+			// WHEN the guard runs
+			// THEN it counts as answering nothing
+			expect(refusalOf({ subject: 'Re: pools', references: [] })).toBe(
+				'forged_reply',
+			)
+		})
+
+		it('should refuse when in-reply-to is present but blank', () => {
+			// GIVEN an empty-string parent id
+			// WHEN the guard runs
+			// THEN it counts as answering nothing
+			expect(refusalOf({ subject: 'Re: pools', inReplyTo: '' })).toBe(
+				'forged_reply',
+			)
+		})
+
+		it('should refuse when both threading headers are blank or empty', () => {
+			// GIVEN both present but carrying nothing
+			// WHEN the guard runs
+			// THEN the send is refused
+			expect(
+				refusalOf({ subject: 'Re: pools', inReplyTo: '', references: [] }),
+			).toBe('forged_reply')
+		})
+	})
+
+	describe('when the subject claims to be a reply and answers something', () => {
+		it('should allow a message naming its parent', () => {
+			// GIVEN a reply prefix and an In-Reply-To header
+			// WHEN the guard runs
+			// THEN the send is allowed
+			expect(
+				refusalOf({ subject: 'Re: your pallet pools', inReplyTo: PARENT }),
+			).toBeNull()
+		})
+
+		it('should allow a message carrying only a references chain', () => {
+			// GIVEN references but no In-Reply-To
+			// WHEN the guard runs
+			// THEN the send is allowed
+			// AND either header alone is enough to make it a real reply
+			expect(
+				refusalOf({ subject: 'Re: your pallet pools', references: [PARENT] }),
+			).toBeNull()
+		})
+
+		it('should allow a message carrying both headers', () => {
+			// GIVEN the shape the reply path now produces
+			// WHEN the guard runs
+			// THEN the send is allowed
+			expect(
+				refusalOf({
+					subject: 'Re: your pallet pools',
+					inReplyTo: PARENT,
+					references: ['<root@client.test>', PARENT],
+				}),
+			).toBeNull()
+		})
+
+		it('should treat a references entry it cannot use as an answer anyway', () => {
+			// GIVEN a references array holding one empty string
+			// WHEN the guard runs
+			// THEN the send is allowed, because the guard counts entries
+			// rather than reading them
+			// AND this pins what the guard does today: it is a cheap check on
+			// the two shapes filters punish, not a validator of header contents
+			expect(refusalOf({ subject: 'Re: pools', references: [''] })).toBeNull()
+		})
+	})
+
+	describe('when a caller needs to map the refusal to a response', () => {
+		it('should fail with an EmailError the handlers can catch by tag', () => {
+			// GIVEN a refused message
+			// WHEN the failure is inspected
+			// THEN it carries a tag of its own, separate from the one used for
+			// genuine faults — that separation is what lets a refusal come back
+			// as a 400 the sender can act on while a fault still reads as a fault
+			// [catchTag('EmailNotSendable')]
+			expect(failureOf({ subject: '' })?._tag).toBe('EmailNotSendable')
+			expect(failureOf({ subject: 'Re: pools' })?._tag).toBe('EmailNotSendable')
+		})
+	})
+})

--- a/apps/server/src/services/email-threading.integration.test.ts
+++ b/apps/server/src/services/email-threading.integration.test.ts
@@ -1,0 +1,1380 @@
+// A follow-up has to reach the recipient inside the conversation it answers,
+// carrying that conversation's subject. Get either half wrong and the message
+// scores as spam: no subject line at all arrives as "(no subject)", and a
+// "Re: " subject with nothing to answer is the classic forged-reply shape.
+// These assert on what is handed to the transport, because that — not the row
+// we write afterwards — is what the recipient's mail server judges.
+
+// PgLive reads DATABASE_URL at layer-build time (no default). Set it so the
+// suite runs without a loaded .env, matching the other integration tests.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { Cause, Effect, Exit, Layer, Logger, References } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { CurrentOrg, SessionContext } from '@batuda/controllers'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+import { CalendarService } from './calendar.js'
+import { CredentialCrypto } from './credential-crypto.js'
+import { EmailService } from './email.js'
+import { EmailAttachmentStaging } from './email-attachment-staging.js'
+import { DraftStore } from './email-draft-store.js'
+import { EmailProvider } from './email-provider.js'
+import { MailTransport, type OutboundMessage } from './mail-transport.js'
+import { StorageProvider } from './storage-provider.js'
+import { TimelineActivityService } from './timeline-activity.js'
+
+const ORG = 'threading-test-org'
+// A second tenant, so "the conversation belongs to somebody else" is a real
+// row rather than an id that matches nothing.
+const OTHER_ORG = 'threading-test-other-org'
+const USER = 'threading-user'
+
+// What the transport was handed on the most recent send — the wire message.
+let lastOutbound: OutboundMessage | null = null
+let sentCount = 0
+
+const stubCrypto = Layer.succeed(CredentialCrypto, {
+	encryptPassword: () => ({
+		ciphertext: new Uint8Array([0]),
+		nonce: new Uint8Array([0]),
+		tag: new Uint8Array([0]),
+	}),
+	decryptPassword: () => 'stubbed-password',
+} as never)
+
+// Records the outgoing message instead of sending it, and hands back a
+// Message-ID the way SMTP does.
+const stubTransport = Layer.succeed(MailTransport, {
+	probe: () => Effect.void,
+	send: (_creds: unknown, message: OutboundMessage) =>
+		Effect.sync(() => {
+			lastOutbound = message
+			sentCount += 1
+			return {
+				messageId: `<threading-sent-${sentCount}@taller.test>`,
+				raw: new Uint8Array([0]),
+			}
+		}),
+	appendToSent: () => Effect.void,
+} as never)
+
+const stubStorage = Layer.succeed(StorageProvider, {
+	put: () => Effect.void,
+} as never)
+
+const stubStaging = Layer.succeed(EmailAttachmentStaging, {
+	resolve: () => Effect.succeed([]),
+	markSentAndCleanup: () => Effect.void,
+} as never)
+
+const stubTimeline = Layer.succeed(TimelineActivityService, {
+	record: () => Effect.void,
+} as never)
+
+const serviceLayer = EmailService.layer.pipe(
+	Layer.provide([
+		stubCrypto,
+		stubTransport,
+		stubStorage,
+		stubStaging,
+		stubTimeline,
+		Layer.succeed(EmailProvider, {} as never),
+		DraftStore.layer.pipe(Layer.provide(PgLive)),
+		Layer.succeed(CalendarService, {} as never),
+	]),
+	Layer.provide(PgLive),
+)
+
+const actingAs = Layer.mergeAll(
+	Layer.succeed(CurrentOrg, {
+		id: ORG,
+		name: 'Threading Test',
+		slug: 'threading-test',
+		role: 'owner',
+	}),
+	Layer.succeed(SessionContext, {
+		userId: USER,
+		email: `${USER}@test.local`,
+		name: undefined,
+		isAgent: false,
+	}),
+)
+
+// Run the way a request does, inside the organization's own database scope.
+const scoped = <A, E>(
+	effect: Effect.Effect<
+		A,
+		E,
+		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
+	>,
+) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		return yield* enterOrgScope(sql, {
+			org: {
+				id: ORG,
+				name: 'Threading Test',
+				slug: 'threading-test',
+			} as never,
+			userId: USER,
+			role: 'owner',
+		})(effect.pipe(Effect.provide(serviceLayer), Effect.provide(actingAs)))
+	}).pipe(Effect.provide(PgLive))
+
+const run = <A, E>(
+	effect: Effect.Effect<
+		A,
+		E,
+		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
+	>,
+) => Effect.runPromise(scoped(effect))
+
+const runExit = <A, E>(
+	effect: Effect.Effect<
+		A,
+		E,
+		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
+	>,
+) => Effect.runPromiseExit(scoped(effect))
+
+const sqlOnly = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
+	Effect.runPromise(effect.pipe(Effect.provide(PgLive)))
+
+// Why the send was turned away, so a test that expects a refusal can't be
+// satisfied by some unrelated failure earlier in the call. A refusal carries a
+// tag of its own and names its reason; anything else answers with neither.
+const refusalReason = (exit: Exit.Exit<unknown, unknown>): string => {
+	if (Exit.isSuccess(exit)) return ''
+	for (const reason of exit.cause.reasons) {
+		if (!Cause.isFailReason(reason)) continue
+		const error = reason.error as { _tag?: unknown; reason?: unknown }
+		if (error?._tag !== 'EmailNotSendable') continue
+		return typeof error.reason === 'string' ? error.reason : ''
+	}
+	return ''
+}
+
+const placeholder = new Uint8Array([0])
+const body = [
+	{
+		type: 'paragraph' as const,
+		spans: [{ kind: 'text' as const, value: 'Following up on this.' }],
+	},
+]
+
+let inboxId = ''
+let otherInboxId = ''
+let companyId = ''
+
+const ROOT_ID = '<threading-root@client.test>'
+const LATEST_ID = '<threading-latest@client.test>'
+
+interface SeedMessage {
+	readonly messageId: string
+	readonly subject: string | null
+	// Empty for the conversation's first message; the root's id for later ones.
+	readonly references?: readonly string[]
+	// Older messages sort first, so "the latest" is a real choice.
+	readonly daysAgo?: number
+	// Arrived at a fixed instant, so two messages can share one.
+	readonly receivedAt?: string
+	// Dropped from the server since; still on file, but not a message to
+	// answer.
+	readonly deleted?: boolean
+	// A mailbox other than the suite's default one.
+	readonly inboxId?: string
+}
+
+// A conversation, seeded straight into the database: how it got there is not
+// what is under test. `linkSubject` null is the shape the mail worker used to
+// leave behind, and still the shape of every conversation created before this
+// fix.
+const seedThread = (opts: {
+	linkSubject?: string | null
+	messages?: readonly SeedMessage[]
+	orgId?: string
+	externalThreadId?: string
+	inboxId?: string
+}) =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const org = opts.orgId ?? ORG
+			const rootId = opts.externalThreadId ?? ROOT_ID
+			const links = yield* sql<{ id: string }>`
+				INSERT INTO email_thread_links (
+					organization_id, inbox_id, external_thread_id, company_id, subject, status
+				) VALUES (
+					${org}, ${org === ORG ? (opts.inboxId ?? inboxId) : null}, ${rootId},
+					${org === ORG ? companyId : null},
+					${opts.linkSubject ?? null}, 'open'
+				)
+				RETURNING id
+			`
+			for (const message of opts.messages ?? []) {
+				yield* sql`
+					INSERT INTO email_messages (
+						organization_id, inbox_id, folder, message_id, "references",
+						subject, received_at, recipients, attachments,
+						status, status_updated_at, direction, raw_rfc822_ref,
+						deleted_at
+					) VALUES (
+						${org}, ${org === ORG ? (message.inboxId ?? inboxId) : null}, 'INBOX',
+						${message.messageId},
+						${(message.references ?? []) as unknown as string[]},
+						${message.subject},
+						COALESCE(
+							${message.receivedAt ?? null}::timestamptz,
+							now() - make_interval(days => ${message.daysAgo ?? 0})
+						),
+						${JSON.stringify({ from: 'client@example.com', to: ['sender@taller.test'], cc: [], bcc: [] })}::jsonb,
+						'[]'::jsonb, 'normal', now(), 'inbound', 'sentinel',
+						${message.deleted ? new Date().toISOString() : null}::timestamptz
+					)
+				`
+			}
+			return links[0]!.id
+		}),
+	)
+
+// The everyday conversation: a root and a later message, both with subjects.
+const seedTwoMessageThread = (linkSubject: string | null) =>
+	seedThread({
+		linkSubject,
+		messages: [
+			{ messageId: ROOT_ID, subject: 'your pallet pools', daysAgo: 2 },
+			{
+				messageId: LATEST_ID,
+				subject: 'Re: your pallet pools',
+				references: [ROOT_ID],
+			},
+		],
+	})
+
+const threadLinkCount = (org = ORG) =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<{ n: number }>`
+				SELECT count(*)::int AS n FROM email_thread_links
+				WHERE organization_id = ${org}
+			`
+			return rows[0]!.n
+		}),
+	)
+
+const outboundRows = () =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* sql<{
+				subject: string | null
+				messageId: string
+				inReplyTo: string | null
+				references: string[] | null
+			}>`
+				SELECT subject, message_id, in_reply_to, "references"
+				FROM email_messages
+				WHERE organization_id = ${ORG} AND direction = 'outbound'
+				ORDER BY received_at ASC, message_id ASC
+			`
+		}),
+	)
+
+const createDraft = (
+	params: {
+		to?: string | undefined
+		subject?: string | undefined
+		bodyJson?: typeof body | undefined
+		inReplyTo?: string | undefined
+	},
+	context?: {
+		companyId?: string
+		contactId?: string
+		mode?: string
+		threadLinkId?: string
+	},
+) =>
+	run(
+		Effect.gen(function* () {
+			const svc = yield* EmailService
+			return yield* svc.createDraft(inboxId, params, context)
+		}),
+	)
+
+const sendDraft = (draftId: string) =>
+	runExit(
+		Effect.gen(function* () {
+			const svc = yield* EmailService
+			return yield* svc.sendDraft(inboxId, draftId)
+		}),
+	)
+
+const reply = (
+	threadId: string,
+	extras?: { subject?: string; fallbackSubject?: string },
+) =>
+	runExit(
+		Effect.gen(function* () {
+			const svc = yield* EmailService
+			return yield* svc.reply(threadId, body, extras)
+		}),
+	)
+
+beforeAll(async () => {
+	await sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			// Better Auth owns this table, so its columns are camelCase.
+			yield* sql`
+				INSERT INTO organization (id, name, slug, "createdAt")
+				VALUES (${ORG}, 'Threading Test', 'threading-test', now())
+				ON CONFLICT (id) DO NOTHING
+			`
+			yield* sql`
+				INSERT INTO organization (id, name, slug, "createdAt")
+				VALUES (${OTHER_ORG}, 'Threading Other', 'threading-other', now())
+				ON CONFLICT (id) DO NOTHING
+			`
+			const companies = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, name, slug)
+				VALUES (${ORG}, 'Pallet Co', 'pallet-co')
+				ON CONFLICT (organization_id, slug) WHERE deleted_at IS NULL
+				DO UPDATE SET name = EXCLUDED.name
+				RETURNING id
+			`
+			companyId = companies[0]!.id
+			const inboxes = yield* sql<{ id: string }>`
+				INSERT INTO inboxes (
+					organization_id, email, owner_user_id, is_default, is_private,
+					imap_host, imap_port, imap_security,
+					smtp_host, smtp_port, smtp_security, username,
+					password_ciphertext, password_nonce, password_tag,
+					grant_status, active
+				) VALUES (
+					${ORG}, 'sender@taller.test', ${USER}, true, false,
+					'imap.test', 993, 'tls', 'smtp.test', 465, 'tls', 'sender@taller.test',
+					${placeholder}, ${placeholder}, ${placeholder},
+					'connected', true
+				)
+				RETURNING id
+			`
+			inboxId = inboxes[0]!.id
+			const others = yield* sql<{ id: string }>`
+				INSERT INTO inboxes (
+					organization_id, email, owner_user_id, is_default, is_private,
+					imap_host, imap_port, imap_security,
+					smtp_host, smtp_port, smtp_security, username,
+					password_ciphertext, password_nonce, password_tag,
+					grant_status, active
+				) VALUES (
+					${ORG}, 'other@taller.test', ${USER}, false, false,
+					'imap.test', 993, 'tls', 'smtp.test', 465, 'tls', 'other@taller.test',
+					${placeholder}, ${placeholder}, ${placeholder},
+					'connected', true
+				)
+				RETURNING id
+			`
+			otherInboxId = others[0]!.id
+		}),
+	)
+})
+
+const wipe = () =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const org of [ORG, OTHER_ORG]) {
+				yield* sql`DELETE FROM email_drafts WHERE organization_id = ${org}`
+				yield* sql`DELETE FROM email_messages WHERE organization_id = ${org}`
+				yield* sql`DELETE FROM email_thread_links WHERE organization_id = ${org}`
+			}
+		}),
+	)
+
+beforeEach(async () => {
+	lastOutbound = null
+	await wipe()
+})
+
+afterAll(async () => {
+	await wipe()
+	await sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`DELETE FROM inboxes WHERE organization_id = ${ORG}`
+			yield* sql`DELETE FROM companies WHERE organization_id = ${ORG}`
+			yield* sql`DELETE FROM organization WHERE id IN (${ORG}, ${OTHER_ORG})`
+		}),
+	)
+})
+
+describe('EmailService.reply', () => {
+	describe('when the conversation carries no subject of its own', () => {
+		it('should send the first message\'s subject, prefixed "Re: "', async () => {
+			// GIVEN a conversation the mail worker created, whose row has no subject
+			const threadId = await seedTwoMessageThread(null)
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN the message goes out with a real subject line
+			// AND this is the case that used to arrive as "(no subject)"
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should treat an empty subject on the row the same as none', async () => {
+			// GIVEN a conversation whose subject column holds an empty string
+			// WHEN a reply is sent
+			// THEN it borrows the first message's subject just the same
+			// [NULLIF(tl.subject, '')]
+			const threadId = await seedTwoMessageThread('')
+			await reply(threadId)
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should skip messages that have no subject when borrowing one', async () => {
+			// GIVEN the earliest message carries no subject and a later one does
+			const threadId = await seedThread({
+				linkSubject: null,
+				messages: [
+					{ messageId: ROOT_ID, subject: null, daysAgo: 3 },
+					{
+						messageId: '<threading-blank@client.test>',
+						subject: '',
+						references: [ROOT_ID],
+						daysAgo: 2,
+					},
+					{
+						messageId: LATEST_ID,
+						subject: 'your pallet pools',
+						references: [ROOT_ID],
+						daysAgo: 1,
+					},
+				],
+			})
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN it borrows the earliest one that actually has a subject
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should refuse when no message on the conversation has a subject', async () => {
+			// GIVEN nothing anywhere to borrow a subject from
+			const threadId = await seedThread({
+				linkSubject: null,
+				messages: [{ messageId: ROOT_ID, subject: null }],
+			})
+
+			// WHEN a reply is sent
+			const exit = await reply(threadId)
+
+			// THEN it is refused rather than delivered with no subject line
+			expect(refusalReason(exit)).toBe('no_subject')
+			expect(lastOutbound).toBeNull()
+		})
+
+		it('should send when the caller supplies the subject itself', async () => {
+			// GIVEN the same conversation, with nothing to borrow
+			const threadId = await seedThread({
+				linkSubject: null,
+				messages: [{ messageId: ROOT_ID, subject: null }],
+			})
+
+			// WHEN a reply names its own subject
+			await reply(threadId, { subject: 'Re: the pallet pools' })
+
+			// THEN it goes out under that subject
+			// AND this is the way out of a conversation that has no subject to
+			// borrow, so the refusal above is something the caller can act on
+			expect(lastOutbound?.subject).toBe('Re: the pallet pools')
+			expect(lastOutbound?.inReplyTo).toBe(ROOT_ID)
+		})
+
+		it('should still refuse when the supplied subject is blank', async () => {
+			// GIVEN nothing to borrow and a subject of only spaces
+			const threadId = await seedThread({
+				linkSubject: null,
+				messages: [{ messageId: ROOT_ID, subject: null }],
+			})
+
+			// WHEN a reply is sent
+			const exit = await reply(threadId, { subject: '   ' })
+
+			// THEN a blank one counts for nothing and the send is still refused
+			expect(refusalReason(exit)).toBe('no_subject')
+			expect(lastOutbound).toBeNull()
+		})
+	})
+
+	describe('when the caller chooses the subject', () => {
+		it("should use it instead of the conversation's own", async () => {
+			// GIVEN a conversation that has a subject of its own
+			const threadId = await seedTwoMessageThread('your pallet pools')
+
+			// WHEN a reply names a different one, the way a mail client lets
+			// you edit the line before sending
+			await reply(threadId, { subject: 'Revised quote' })
+
+			// THEN the chosen one goes out untouched, with no prefix added
+			expect(lastOutbound?.subject).toBe('Revised quote')
+		})
+
+		it('should still thread the message', async () => {
+			// GIVEN a conversation and a reply under a changed subject
+			const threadId = await seedTwoMessageThread('your pallet pools')
+
+			// WHEN it is sent
+			await reply(threadId, { subject: 'Revised quote' })
+
+			// THEN it is still a reply: the headers put it in the conversation
+			// AND the recipient's mail client threads on those, not the subject
+			expect(lastOutbound?.inReplyTo).toBe(LATEST_ID)
+			expect(lastOutbound?.references).toContain(ROOT_ID)
+		})
+
+		it('should record the subject that went out', async () => {
+			// GIVEN a reply under a chosen subject
+			const threadId = await seedTwoMessageThread('your pallet pools')
+
+			// WHEN it is sent
+			await reply(threadId, { subject: 'Revised quote' })
+
+			// THEN the stored row says what the recipient saw
+			const rows = await outboundRows()
+			expect(rows[0]?.subject).toBe('Revised quote')
+		})
+	})
+
+	describe('when the conversation already carries a subject', () => {
+		it('should prefix a plain one once', async () => {
+			// GIVEN a conversation whose row holds a plain subject
+			const threadId = await seedTwoMessageThread('your pallet pools')
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN it goes out prefixed
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should not prefix one that already reads as a reply', async () => {
+			// GIVEN a subject that already carries the prefix
+			const threadId = await seedTwoMessageThread('Re: your pallet pools')
+
+			// WHEN a reply is sent
+			// THEN it is left alone rather than stacked into "Re: Re: "
+			await reply(threadId)
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should not prefix one whose existing prefix is lower case', async () => {
+			// GIVEN the prefix as some mail clients write it
+			// WHEN a reply is sent
+			// THEN it is still recognised as already prefixed
+			// [toLowerCase().startsWith('re:')]
+			const threadId = await seedTwoMessageThread('re: your pallet pools')
+			await reply(threadId)
+			expect(lastOutbound?.subject).toBe('re: your pallet pools')
+		})
+	})
+
+	describe('when the reply goes out', () => {
+		it('should answer the most recent message and reach back to the first', async () => {
+			// GIVEN a conversation with a root and a later message
+			const threadId = await seedTwoMessageThread(null)
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN it answers the latest message
+			// AND the chain reaches back to the conversation's first message
+			expect(lastOutbound?.inReplyTo).toBe(LATEST_ID)
+			expect(lastOutbound?.references).toContain(ROOT_ID)
+		})
+
+		it('should not repeat the same id when the conversation holds only one message', async () => {
+			// GIVEN a conversation whose only message is its root, so the
+			// message being answered and the conversation root are the same id
+			const threadId = await seedThread({
+				linkSubject: null,
+				messages: [{ messageId: ROOT_ID, subject: 'your pallet pools' }],
+			})
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN References names it once rather than twice
+			expect(lastOutbound?.inReplyTo).toBe(ROOT_ID)
+			expect(lastOutbound?.references).toEqual([ROOT_ID])
+		})
+
+		it('should record what the recipient actually saw', async () => {
+			// GIVEN a conversation with no subject of its own
+			const threadId = await seedTwoMessageThread(null)
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN the stored row carries the subject that went out, "Re: " and all
+			const rows = await outboundRows()
+			expect(rows[0]?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should stay in the same conversation', async () => {
+			// GIVEN an existing conversation
+			const threadId = await seedTwoMessageThread(null)
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN no second conversation appears for the contact
+			expect(await threadLinkCount()).toBe(1)
+		})
+	})
+})
+
+describe('EmailService.send', () => {
+	describe('when a new conversation is started', () => {
+		it('should send under the subject it was given', async () => {
+			// GIVEN a plain subject
+			// WHEN a new message is sent
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.send(
+						inboxId,
+						'client@example.com',
+						'your pallet pools',
+						body,
+						companyId,
+					)
+				}),
+			)
+
+			// THEN it goes out with that subject and no threading headers
+			expect(lastOutbound?.subject).toBe('your pallet pools')
+			expect(lastOutbound?.inReplyTo).toBeUndefined()
+		})
+
+		it('should refuse a "Re: " subject, because this path threads nothing', async () => {
+			// GIVEN a follow-up written as a reply on the path that starts new
+			// conversations — the shape that reached real prospects as a
+			// forged reply
+			const exit = await runExit(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.send(
+						inboxId,
+						'client@example.com',
+						'Re: your pallet pools',
+						body,
+						companyId,
+					)
+				}),
+			)
+
+			// THEN the send is refused, and nothing reached the transport
+			expect(refusalReason(exit)).toBe('forged_reply')
+			expect(lastOutbound).toBeNull()
+		})
+
+		it('should refuse an empty subject', async () => {
+			// GIVEN no subject
+			const exit = await runExit(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.send(
+						inboxId,
+						'client@example.com',
+						'',
+						body,
+						companyId,
+					)
+				}),
+			)
+
+			// THEN the send is refused rather than arriving as "(no subject)"
+			expect(refusalReason(exit)).toBe('no_subject')
+			expect(lastOutbound).toBeNull()
+		})
+
+		it('should leave no conversation behind when the send is refused', async () => {
+			// GIVEN a refused send
+			await runExit(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.send(
+						inboxId,
+						'client@example.com',
+						'Re: your pallet pools',
+						body,
+						companyId,
+					)
+				}),
+			)
+
+			// THEN no conversation row was created for a message never sent
+			expect(await threadLinkCount()).toBe(0)
+		})
+	})
+})
+
+describe('EmailService.sendDraft', () => {
+	describe('when the draft names the conversation it answers', () => {
+		it('should thread it without being told the draft is a reply', async () => {
+			// GIVEN a draft carrying a thread but no mode — the shape every
+			// agent produced, and the one that used to open a second
+			// conversation and go out looking like a forged reply
+			const threadId = await seedTwoMessageThread(null)
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Re: your pallet pools',
+					bodyJson: body,
+				},
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN the message answers the latest message in the conversation
+			expect(lastOutbound?.inReplyTo).toBe(LATEST_ID)
+			expect(lastOutbound?.references).toContain(ROOT_ID)
+		})
+
+		it('should not open a second conversation', async () => {
+			// GIVEN the same draft
+			const threadId = await seedTwoMessageThread(null)
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Re: your pallet pools',
+					bodyJson: body,
+				},
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN the contact still has one conversation, not two
+			expect(await threadLinkCount()).toBe(1)
+		})
+
+		it('should keep a subject the writer chose', async () => {
+			// GIVEN a draft that answers a thread under its own subject
+			const threadId = await seedTwoMessageThread('your pallet pools')
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Revised quote',
+					bodyJson: body,
+				},
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN the thread's subject does not overwrite it
+			expect(lastOutbound?.subject).toBe('Revised quote')
+		})
+
+		it("should borrow the conversation's subject when the draft has none", async () => {
+			// GIVEN a draft with no subject on a conversation that has one
+			const threadId = await seedTwoMessageThread(null)
+			const draft = await createDraft(
+				{ to: 'client@example.com', bodyJson: body },
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN it goes out under the conversation's subject
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should treat a blank-space subject as none', async () => {
+			// GIVEN a draft whose subject is only spaces
+			const threadId = await seedTwoMessageThread(null)
+			const draft = await createDraft(
+				{ to: 'client@example.com', subject: '   ', bodyJson: body },
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			// THEN it borrows the conversation's subject rather than sending blank
+			// [draft.subject.trim() !== '']
+			await sendDraft(draft.draftId)
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should not stack a prefix on a conversation subject that has one', async () => {
+			// GIVEN a conversation already named "Re: …" and a draft with no subject
+			const threadId = await seedTwoMessageThread('Re: your pallet pools')
+			const draft = await createDraft(
+				{ to: 'client@example.com', bodyJson: body },
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			// THEN the borrowed subject is used as-is
+			await sendDraft(draft.draftId)
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+
+		it('should fall back to the conversation root when it holds no messages', async () => {
+			// GIVEN a conversation row with nothing under it yet
+			const threadId = await seedThread({
+				linkSubject: 'your pallet pools',
+				messages: [],
+			})
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Re: your pallet pools',
+					bodyJson: body,
+				},
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN there is no parent message to name, so the conversation's own
+			// id answers for it and the message still threads
+			expect(lastOutbound?.inReplyTo).toBe(ROOT_ID)
+			expect(lastOutbound?.references).toEqual([ROOT_ID])
+		})
+	})
+
+	describe('when the draft names its parent by Message-ID', () => {
+		it('should find the conversation from it and thread the message', async () => {
+			// GIVEN a draft carrying in_reply_to and no thread link — a value
+			// that was being written down and never read
+			await seedTwoMessageThread(null)
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Re: your pallet pools',
+					bodyJson: body,
+					inReplyTo: LATEST_ID,
+				},
+				{ companyId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN the message threads, and no second conversation appears
+			expect(lastOutbound?.references).toContain(ROOT_ID)
+			expect(await threadLinkCount()).toBe(1)
+		})
+
+		it('should let an explicit thread link win over it', async () => {
+			// GIVEN a draft naming one conversation by link and a message on a
+			// different conversation by Message-ID
+			const threadId = await seedTwoMessageThread(null)
+			const otherRoot = '<threading-other-root@client.test>'
+			await seedThread({
+				linkSubject: 'a different conversation',
+				externalThreadId: otherRoot,
+				messages: [{ messageId: otherRoot, subject: 'a different one' }],
+			})
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Re: your pallet pools',
+					bodyJson: body,
+					inReplyTo: otherRoot,
+				},
+				{ companyId, threadLinkId: threadId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN the link decides, and the Message-ID is not consulted
+			// [!threadLinkId && draft.inReplyTo]
+			expect(lastOutbound?.references).toContain(ROOT_ID)
+			expect(lastOutbound?.references).not.toContain(otherRoot)
+		})
+
+		it('should start a new conversation when the parent is unknown', async () => {
+			// GIVEN a Message-ID nothing on file matches
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'a fresh start',
+					bodyJson: body,
+					inReplyTo: '<nobody-has-this@elsewhere.test>',
+				},
+				{ companyId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN nothing is threaded, and the message opens its own conversation
+			expect(lastOutbound).not.toBeNull()
+			expect(lastOutbound?.inReplyTo).toBeUndefined()
+			expect(await threadLinkCount()).toBe(1)
+		})
+
+		it('should not reach a parent belonging to another organization', async () => {
+			// GIVEN the parent message sits in a different tenant
+			const foreignRoot = '<threading-foreign@client.test>'
+			await seedThread({
+				orgId: OTHER_ORG,
+				linkSubject: 'somebody else’s conversation',
+				externalThreadId: foreignRoot,
+				messages: [{ messageId: foreignRoot, subject: 'theirs' }],
+			})
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'a fresh start',
+					bodyJson: body,
+					inReplyTo: foreignRoot,
+				},
+				{ companyId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN the message goes out threading nothing, rather than joining
+			// their conversation
+			expect(lastOutbound).not.toBeNull()
+			expect(lastOutbound?.inReplyTo).toBeUndefined()
+			expect(lastOutbound?.references).toBeUndefined()
+			// AND it opens a conversation of our own, leaving theirs alone
+			expect(await threadLinkCount()).toBe(1)
+			expect(await threadLinkCount(OTHER_ORG)).toBe(1)
+		})
+	})
+
+	describe('when the draft names a conversation it may not touch', () => {
+		it("should not thread onto another organization's conversation", async () => {
+			// GIVEN a thread link id that belongs to a different tenant
+			const foreignRoot = '<threading-foreign-link@client.test>'
+			const foreignThreadId = await seedThread({
+				orgId: OTHER_ORG,
+				linkSubject: 'somebody else’s conversation',
+				externalThreadId: foreignRoot,
+				messages: [{ messageId: foreignRoot, subject: 'theirs' }],
+			})
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'a fresh start',
+					bodyJson: body,
+				},
+				{ companyId, threadLinkId: foreignThreadId },
+			)
+
+			// WHEN it is sent
+			await sendDraft(draft.draftId)
+
+			// THEN the lookup finds nothing and the message goes out fresh
+			expect(lastOutbound).not.toBeNull()
+			expect(lastOutbound?.inReplyTo).toBeUndefined()
+			expect(lastOutbound?.references).toBeUndefined()
+			// AND it opens a conversation of our own, leaving theirs alone
+			expect(await threadLinkCount()).toBe(1)
+			expect(await threadLinkCount(OTHER_ORG)).toBe(1)
+		})
+	})
+
+	describe('when the draft starts a new conversation', () => {
+		it('should refuse a "Re: " subject that answers nothing', async () => {
+			// GIVEN a draft with a reply subject and no conversation behind it
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Re: your pallet pools',
+					bodyJson: body,
+				},
+				{ companyId },
+			)
+
+			// WHEN it is sent
+			const exit = await sendDraft(draft.draftId)
+
+			// THEN the send is refused rather than delivered as a forged reply
+			// AND nothing went to the transport
+			expect(refusalReason(exit)).toBe('forged_reply')
+			expect(lastOutbound).toBeNull()
+		})
+
+		it('should refuse a draft with no subject at all', async () => {
+			// GIVEN a draft nobody gave a subject, and no conversation to
+			// borrow one from
+			const draft = await createDraft(
+				{ to: 'client@example.com', bodyJson: body },
+				{ companyId },
+			)
+
+			// WHEN it is sent
+			const exit = await sendDraft(draft.draftId)
+
+			// THEN the send is refused rather than arriving as "(no subject)"
+			expect(refusalReason(exit)).toBe('no_subject')
+			expect(lastOutbound).toBeNull()
+		})
+
+		it('should keep the draft when the send is refused', async () => {
+			// GIVEN a refused draft
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'Re: your pallet pools',
+					bodyJson: body,
+				},
+				{ companyId },
+			)
+			await sendDraft(draft.draftId)
+
+			// THEN it is still there to be corrected and sent again, rather
+			// than deleted along with the message that never went
+			const found = await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.getDraft(inboxId, draft.draftId)
+				}),
+			)
+			expect(found).not.toBeNull()
+		})
+	})
+})
+
+describe('replying twice on the same conversation', () => {
+	it('should build the second chain on what the first one sent', async () => {
+		// GIVEN a conversation that has already been answered once, so the
+		// message being answered now is our own
+		const threadId = await seedTwoMessageThread(null)
+		await reply(threadId)
+		const firstSent = lastOutbound?.references ?? []
+
+		// WHEN a second reply goes out
+		await reply(threadId)
+
+		// THEN it carries everything the first one did, plus the first reply
+		// itself — the chain grows rather than resetting to two entries
+		for (const id of firstSent) {
+			expect(lastOutbound?.references).toContain(id)
+		}
+		expect(lastOutbound?.references?.length ?? 0).toBeGreaterThan(
+			firstSent.length,
+		)
+		expect(lastOutbound?.references?.at(-1)).toBe(lastOutbound?.inReplyTo)
+	})
+
+	it('should store the headers each message actually carried', async () => {
+		// GIVEN two replies on one conversation
+		const threadId = await seedTwoMessageThread(null)
+		await reply(threadId)
+		await reply(threadId)
+
+		// THEN each stored row says what went on the wire, not a shorter chain
+		// invented afterwards — the next reply reads these back
+		const rows = await outboundRows()
+		expect(rows).toHaveLength(2)
+		expect(rows[0]?.inReplyTo).toBe(LATEST_ID)
+		expect(rows[1]?.references).toContain(ROOT_ID)
+		expect(rows[1]?.references?.length ?? 0).toBeGreaterThan(
+			rows[0]?.references?.length ?? 0,
+		)
+	})
+
+	it('should keep the conversation findable from every message it sent', async () => {
+		// GIVEN two replies
+		const threadId = await seedTwoMessageThread(null)
+		await reply(threadId)
+		await reply(threadId)
+
+		// THEN both rows still name the conversation's first message, which is
+		// what every lookup searches for
+		const rows = await outboundRows()
+		for (const row of rows) {
+			expect(row.references).toContain(ROOT_ID)
+		}
+	})
+})
+
+describe('a subject already written as a reply', () => {
+	it('should not be stacked on, however the prefix is spaced', async () => {
+		// GIVEN a conversation whose subject uses the spacing French clients
+		// write, which is still a reply prefix
+		const threadId = await seedTwoMessageThread('Re : your pallet pools')
+
+		// WHEN a reply is sent
+		await reply(threadId)
+
+		// THEN it is left alone rather than stacked into "Re: Re : ..."
+		expect(lastOutbound?.subject).toBe('Re : your pallet pools')
+	})
+
+	it('should read the same way when a draft borrows it', async () => {
+		// GIVEN the same conversation, answered by a draft with no subject
+		const threadId = await seedTwoMessageThread('Re : your pallet pools')
+		const draft = await createDraft(
+			{ to: 'client@example.com', bodyJson: body },
+			{ companyId, threadLinkId: threadId },
+		)
+
+		// WHEN it is sent
+		await sendDraft(draft.draftId)
+
+		// THEN both send paths agree on what already counts as a reply
+		expect(lastOutbound?.subject).toBe('Re : your pallet pools')
+	})
+})
+
+describe('a draft on a conversation with no subject anywhere', () => {
+	it('should be refused rather than sent blank', async () => {
+		// GIVEN a conversation with nothing to borrow and a draft with no
+		// subject of its own
+		const threadId = await seedThread({
+			linkSubject: null,
+			messages: [{ messageId: ROOT_ID, subject: null }],
+		})
+		const draft = await createDraft(
+			{ to: 'client@example.com', bodyJson: body },
+			{ companyId, threadLinkId: threadId },
+		)
+
+		// WHEN it is sent
+		const exit = await sendDraft(draft.draftId)
+
+		// THEN it is refused, the same way the reply path refuses it
+		expect(refusalReason(exit)).toBe('no_subject')
+		expect(lastOutbound).toBeNull()
+	})
+})
+
+describe('a conversation whose subject is only blank space', () => {
+	it('should not be treated as a subject to borrow', async () => {
+		// GIVEN a subject that looks present but says nothing
+		const threadId = await seedThread({
+			linkSubject: '   ',
+			messages: [
+				{ messageId: ROOT_ID, subject: '   ', daysAgo: 2 },
+				{
+					messageId: LATEST_ID,
+					subject: 'your pallet pools',
+					references: [ROOT_ID],
+				},
+			],
+		})
+
+		// WHEN a reply is sent
+		await reply(threadId)
+
+		// THEN the blank one is passed over for a real one, rather than going
+		// out as "Re:    "
+		expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+	})
+})
+
+describe('the record a refused send leaves', () => {
+	// A message that never went out is still something that happened on the
+	// outbound path, so it says so on a line of its own — the way a send that
+	// went through does. Without it, "how often are we refusing sends, and
+	// over what" cannot be answered at all.
+	const runCapturingLogs = async (effect: Parameters<typeof runExit>[0]) => {
+		const lines: Array<{
+			level: string
+			annotations: Record<string, unknown>
+		}> = []
+		const capture = Logger.layer([
+			Logger.make(options => {
+				lines.push({
+					level: String(options.logLevel),
+					annotations: options.fiber.getRef(
+						References.CurrentLogAnnotations,
+					) as Record<string, unknown>,
+				})
+			}),
+		]).pipe(
+			Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
+		)
+		await Effect.runPromiseExit(
+			scoped(effect).pipe(Effect.provide(capture)) as Effect.Effect<
+				unknown,
+				unknown,
+				never
+			>,
+		)
+		return lines
+	}
+
+	it('should name the reason it was refused', async () => {
+		// GIVEN a follow-up written as a reply on the path that threads nothing
+		const lines = await runCapturingLogs(
+			Effect.gen(function* () {
+				const svc = yield* EmailService
+				return yield* svc.send(
+					inboxId,
+					'client@example.com',
+					'Re: your pallet pools',
+					body,
+					companyId,
+				)
+			}),
+		)
+
+		// THEN a record says so, and says which of the two shapes it was
+		const refused = lines.find(l => l.annotations['event'] === 'email.refused')
+		expect(refused).toBeDefined()
+		expect(refused?.annotations['reason']).toBe('forged_reply')
+	})
+
+	it('should say it at a level that is read in production', async () => {
+		// GIVEN the same refused send
+		const lines = await runCapturingLogs(
+			Effect.gen(function* () {
+				const svc = yield* EmailService
+				return yield* svc.send(
+					inboxId,
+					'client@example.com',
+					'',
+					body,
+					companyId,
+				)
+			}),
+		)
+
+		// THEN it is a warning: nothing of ours failed, but a message did not go
+		// AND debug would be dropped by the production floor, which is Info
+		const refused = lines.find(l => l.annotations['event'] === 'email.refused')
+		expect(refused?.annotations['reason']).toBe('no_subject')
+		expect(refused?.level).toBe('Warn')
+	})
+
+	it('should not write down what the message said', async () => {
+		// GIVEN a refused send whose subject is the customer's own words
+		const lines = await runCapturingLogs(
+			Effect.gen(function* () {
+				const svc = yield* EmailService
+				return yield* svc.send(
+					inboxId,
+					'client@example.com',
+					'Re: pressupost pallets Barcelona',
+					body,
+					companyId,
+				)
+			}),
+		)
+
+		// THEN neither the subject nor the recipient reaches the record
+		const refused = lines.find(l => l.annotations['event'] === 'email.refused')
+		const written = JSON.stringify(refused)
+		expect(written).not.toContain('pressupost')
+		expect(written).not.toContain('client@example.com')
+	})
+})
+
+describe('the message a reply answers', () => {
+	describe('when the newest message has been dropped from the server', () => {
+		it('should answer the newest one still there', async () => {
+			// GIVEN a conversation whose most recent message has since been
+			// deleted on the mail server
+			const threadId = await seedThread({
+				linkSubject: 'your pallet pools',
+				messages: [
+					{ messageId: ROOT_ID, subject: 'your pallet pools', daysAgo: 2 },
+					{
+						messageId: LATEST_ID,
+						subject: 'Re: your pallet pools',
+						references: [ROOT_ID],
+						daysAgo: 1,
+						deleted: true,
+					},
+				],
+			})
+
+			// WHEN a reply is sent
+			await reply(threadId)
+
+			// THEN it answers the message that is still there
+			// AND naming a deleted one would point the recipient's mail client
+			// at something nobody can see
+			expect(lastOutbound?.inReplyTo).toBe(ROOT_ID)
+		})
+	})
+})
+
+describe('a reply on a conversation with no subject to borrow', () => {
+	describe('when the caller offers one to fall back on', () => {
+		it('should send under it rather than being refused', async () => {
+			// GIVEN a conversation with nothing to borrow — the shape an
+			// invitation thread can have — and a caller that must get its
+			// message out, as the calendar reply does
+			const threadId = await seedThread({
+				linkSubject: null,
+				messages: [{ messageId: ROOT_ID, subject: null }],
+			})
+
+			// WHEN a reply offers a subject to fall back on
+			await reply(threadId, { fallbackSubject: 'Quarterly planning' })
+
+			// THEN it goes out under that, prefixed like any other reply
+			expect(lastOutbound?.subject).toBe('Re: Quarterly planning')
+		})
+
+		it('should still prefer a subject the conversation has', async () => {
+			// GIVEN a conversation that does have one
+			const threadId = await seedTwoMessageThread('your pallet pools')
+
+			// WHEN a reply also offers a fallback
+			await reply(threadId, { fallbackSubject: 'Quarterly planning' })
+
+			// THEN the conversation's own wins — the fallback is only for
+			// having nothing at all
+			expect(lastOutbound?.subject).toBe('Re: your pallet pools')
+		})
+	})
+})
+
+describe('a draft answering a conversation in another mailbox', () => {
+	describe('when the conversation belongs to a different mailbox of the same organization', () => {
+		it('should not be filed onto it', async () => {
+			// GIVEN a conversation that lives in a colleague's mailbox
+			const foreignRoot = '<other-mailbox@client.test>'
+			const foreignThreadId = await seedThread({
+				linkSubject: 'their conversation',
+				externalThreadId: foreignRoot,
+				inboxId: otherInboxId,
+				messages: [{ messageId: foreignRoot, subject: 'theirs' }],
+			})
+			const draft = await createDraft(
+				{
+					to: 'client@example.com',
+					subject: 'a fresh start',
+					bodyJson: body,
+				},
+				{ companyId, threadLinkId: foreignThreadId },
+			)
+
+			// WHEN it is sent from this mailbox
+			await sendDraft(draft.draftId)
+
+			// THEN it starts its own conversation instead
+			// AND a message going out from one mailbox never joins a
+			// conversation belonging to another
+			expect(lastOutbound).not.toBeNull()
+			expect(lastOutbound?.inReplyTo).toBeUndefined()
+		})
+	})
+})

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -17,6 +17,7 @@ import {
 	CurrentOrg,
 	EmailError,
 	EmailMessageRecord,
+	EmailNotSendable,
 	EmailSuppressed,
 	EmailThreadDetail,
 	EmailThreadList,
@@ -135,6 +136,91 @@ export const retrySmtpSend = <A, E>(
 		Effect.retry(smtpRetrySchedule),
 		Effect.mapError(cause => new SmtpSendFailed({ cause, inboxId })),
 	)
+
+// A reply carries the conversation it answers in its `References` header: the
+// parent's own chain with the parent's Message-ID added on the end. That is
+// what a mail client reads to hang the message under the right one — sending
+// only the first and last links leaves it guessing, and strict readers lose
+// the middle of the conversation.
+//
+// The first message stays at the front, because a conversation is found here
+// by looking for it in this list. A very long conversation keeps that one plus
+// the most recent links rather than letting the header grow without end, which
+// is what mail clients do.
+const MAX_REFERENCES = 20
+
+// One rule for "does this subject already read as a reply", used everywhere a
+// subject is prefixed or judged. Three slightly different spellings of it used
+// to disagree: a subject written "Re : quote" was left alone on one send path
+// and stacked into "Re: Re : quote" on another.
+const REPLY_PREFIX = /^\s*re\s*:/i
+
+const withReplyPrefix = (subject: string): string =>
+	REPLY_PREFIX.test(subject) ? subject : `Re: ${subject}`
+
+export const buildReferences = (args: {
+	readonly root: string
+	readonly parentReferences: readonly string[]
+	readonly parentMessageId: string
+}): string[] => {
+	// A stored chain comes back from a text column that can hold blanks and
+	// nulls; anything that is not a usable id is dropped before it reaches the
+	// header, where a null would otherwise be written as the word "null".
+	const usable = (id: unknown): id is string =>
+		typeof id === 'string' && id.trim() !== ''
+	// The parent's own ancestors, oldest first, with the parent itself taken
+	// out so it can sit on the end — a reader takes the last entry to be the
+	// message this one answers.
+	const ancestors = args.parentReferences
+		.filter(usable)
+		.filter((id, idx, all) => all.indexOf(id) === idx)
+		.filter(id => id !== args.parentMessageId)
+	const chain = usable(args.parentMessageId)
+		? [...ancestors, args.parentMessageId]
+		: ancestors
+	// A conversation is found by looking for its first message in this list, so
+	// that id has to be present. It nearly always already is, because the
+	// parent was picked out by carrying it. Putting it in front unconditionally
+	// would be wrong on a conversation joined midway, where the first message we
+	// hold is the newest one and belongs last.
+	const full =
+		!usable(args.root) || chain.includes(args.root)
+			? chain
+			: [args.root, ...chain]
+	if (full.length <= MAX_REFERENCES) return full
+	// Too long to send whole: keep the most recent links, and keep the first
+	// message whatever happens, or the conversation stops being findable.
+	const newest = full.slice(1 - MAX_REFERENCES)
+	return newest.includes(args.root)
+		? full.slice(-MAX_REFERENCES)
+		: [args.root, ...newest]
+}
+
+// Two shapes that receiving mail servers score as spam, refused here rather
+// than put on the wire. Every way of sending a message funnels through
+// `dispatchOutbound`, which calls this first, so no route can skip it.
+//
+// A message we refuse costs one loud failure; a message we send in either of
+// these shapes costs the sender's reputation with that recipient's provider,
+// and we only find out much later.
+export const assertSendable = (message: {
+	readonly subject: string
+	readonly inReplyTo?: string | undefined
+	readonly references?: readonly string[] | undefined
+}): Effect.Effect<void, EmailNotSendable> =>
+	Effect.gen(function* () {
+		const subject = message.subject.trim()
+		if (subject === '') {
+			return yield* new EmailNotSendable({ reason: 'no_subject' })
+		}
+		// A "Re:" that answers nothing is the classic forged-reply signature,
+		// and filters test for exactly this pairing.
+		const answersNothing =
+			!message.inReplyTo && (message.references?.length ?? 0) === 0
+		if (REPLY_PREFIX.test(subject) && answersNothing) {
+			return yield* new EmailNotSendable({ reason: 'forged_reply' })
+		}
+	})
 
 // PgClient.transformResultNames in apps/server/src/db/client.ts converts
 // snake_case columns to camelCase on read, so every row type in this file
@@ -885,10 +971,24 @@ export class EmailService extends Context.Service<EmailService>()(
 				message: OutboundMessage,
 			): Effect.Effect<
 				{ messageId: string; rawRef: string },
-				SmtpSendFailed,
+				SmtpSendFailed | EmailNotSendable,
 				never
 			> =>
 				Effect.gen(function* () {
+					// A refused send is a message that did not go out, so it says so
+					// on a line of its own the way `email.sent` does. Only the reason
+					// is recorded — never the subject, which is the customer's text.
+					yield* assertSendable(message).pipe(
+						Effect.tapError(refusal =>
+							Effect.logWarning('Email refused before sending').pipe(
+								Effect.annotateLogs({
+									event: 'email.refused',
+									reason: refusal.reason,
+									inboxId: inbox.id,
+								}),
+							),
+						),
+					)
 					const creds = yield* loadDecryptedCreds(inbox)
 					const sent = yield* retrySmtpSend(
 						transport.send(creds, message),
@@ -936,6 +1036,12 @@ export class EmailService extends Context.Service<EmailService>()(
 					id: string
 					externalThreadId: string
 				} | null
+				// The threading headers this message actually carried. Stored as
+				// sent, so the next reply builds its chain on what the recipient
+				// saw rather than on a shorter one we invented afterwards.
+				wireThreading?:
+					| { inReplyTo: string; references: readonly string[] }
+					| undefined
 				rawRfc822Ref: string
 				// What the recipient was sent. Kept on the row because the only
 				// other copies are the wire bytes in object storage and whatever
@@ -957,10 +1063,18 @@ export class EmailService extends Context.Service<EmailService>()(
 							let threadLinkId: string | null
 
 							if (args.existingThreadLink) {
-								// Reply: reuse the link's root id, append it to References.
+								// Reply: the conversation keeps its root id, and the row
+								// records the headers the message went out with. The root
+								// stays first in that chain, which is what the lookups
+								// that pivot from any reply back to the conversation
+								// search for.
 								externalThreadId = args.existingThreadLink.externalThreadId
-								inReplyTo = args.existingThreadLink.externalThreadId
-								referencesArr = [args.existingThreadLink.externalThreadId]
+								inReplyTo =
+									args.wireThreading?.inReplyTo ??
+									args.existingThreadLink.externalThreadId
+								referencesArr = args.wireThreading
+									? [...args.wireThreading.references]
+									: [args.existingThreadLink.externalThreadId]
 								threadLinkId = args.existingThreadLink.id
 							} else {
 								// Brand-new thread: provider's threadId IS the root msg id.
@@ -1190,6 +1304,10 @@ export class EmailService extends Context.Service<EmailService>()(
 						cc?: string[] | undefined
 						bcc?: string[] | undefined
 						preview?: string | undefined
+						subject?: string | undefined
+						// Used only when the conversation has no subject to borrow,
+						// for a caller that always has to get its message out.
+						fallbackSubject?: string | undefined
 						attachmentRefs?: readonly StagingRef[] | undefined
 						rawAttachments?: readonly SendAttachmentInput[] | undefined
 						skipFooter?: boolean | undefined
@@ -1210,10 +1328,29 @@ export class EmailService extends Context.Service<EmailService>()(
 							contactId: string | null
 							subject: string | null
 						}>`
-							SELECT id, external_thread_id, inbox_id, company_id, contact_id, subject
-							FROM email_thread_links
-							WHERE id = ${threadId}
-							  AND organization_id = ${currentOrg.id}
+							SELECT tl.id, tl.external_thread_id, tl.inbox_id, tl.company_id,
+							       tl.contact_id,
+							       -- Threads that began with an arriving message have no
+							       -- subject of their own, so borrow the first message's
+							       -- one. Without this the reply goes out with an empty
+							       -- subject, which the mail library sends as no Subject
+							       -- line at all — it arrives as "(no subject)".
+							       COALESCE(
+							         NULLIF(btrim(tl.subject), ''),
+							         (
+							           SELECT sm.subject FROM email_messages sm
+							           WHERE sm.organization_id = tl.organization_id
+							             AND (sm.message_id = tl.external_thread_id
+							                  OR sm."references" @> ARRAY[tl.external_thread_id]::text[])
+							             AND sm.subject IS NOT NULL
+							             AND btrim(sm.subject) <> ''
+							           ORDER BY sm.received_at ASC, sm.message_id ASC
+							           LIMIT 1
+							         )
+							       ) AS subject
+							FROM email_thread_links tl
+							WHERE tl.id = ${threadId}
+							  AND tl.organization_id = ${currentOrg.id}
 							LIMIT 1
 						`.pipe(Effect.orDie)
 						if (links.length === 0) {
@@ -1238,21 +1375,29 @@ export class EmailService extends Context.Service<EmailService>()(
 						yield* assertInboxUsable(inbox)
 
 						// Most recent message in the thread anchors the reply. We
-						// match on `message_id = external_thread_id` (root) OR
-						// `external_thread_id = ANY(references)` (any reply).
+						// match the root by its own id, or any later message by the
+						// root sitting in its references — written as `@>` so the
+						// index over that column is the one that answers.
 						const lastMessages = yield* sql<{
 							messageId: string
+							references: string[] | null
 							direction: string
 							recipients: { from?: string | null; to?: string[] }
 						}>`
-							SELECT message_id, direction, recipients
+							SELECT message_id, "references", direction, recipients
 							FROM email_messages
 							WHERE organization_id = ${currentOrg.id}
 							  AND (
 							    message_id = ${link.externalThreadId}
-							    OR ${link.externalThreadId} = ANY("references")
+							    OR "references" @> ARRAY[${link.externalThreadId}]::text[]
 							  )
-							ORDER BY received_at DESC NULLS LAST, status_updated_at DESC
+							  AND deleted_at IS NULL
+							-- The arrival time comes from the Date header, which counts
+							-- in whole seconds, so two messages can share one. The id
+							-- settles it, or which message is answered changes between
+							-- two otherwise identical replies.
+							ORDER BY received_at DESC NULLS LAST,
+							         status_updated_at DESC, message_id DESC
 							LIMIT 1
 						`.pipe(Effect.orDie)
 						const lastMessage = lastMessages[0]
@@ -1291,14 +1436,27 @@ export class EmailService extends Context.Service<EmailService>()(
 						]
 
 						// Subject convention: "Re:" prefix on first reply, leave alone
-						// thereafter (matches MUA defaults). Empty subject is allowed
-						// — providers will accept it.
-						const replySubject = link.subject
-							? link.subject.startsWith('Re:') ||
-								link.subject.toLowerCase().startsWith('re:')
-								? link.subject
-								: `Re: ${link.subject}`
+						// thereafter (matches MUA defaults).
+						//
+						// A subject the caller chose wins, the way it does on a draft
+						// and the way a mail client lets you edit the line before
+						// sending. It is also the only way to answer a conversation
+						// whose messages never carried a subject to borrow: without it
+						// this would be empty, and the guard in `dispatchOutbound`
+						// would refuse the send with nothing the caller could do.
+						const chosenSubject = extras?.subject
+						const borrowedSubject = link.subject
+							? withReplyPrefix(link.subject)
 							: ''
+						const fallbackSubject = extras?.fallbackSubject
+						const replySubject =
+							chosenSubject && chosenSubject.trim() !== ''
+								? chosenSubject
+								: borrowedSubject !== ''
+									? borrowedSubject
+									: fallbackSubject && fallbackSubject.trim() !== ''
+										? withReplyPrefix(fallbackSubject)
+										: ''
 
 						const outbound: OutboundMessage = {
 							from: inbox.email,
@@ -1309,9 +1467,11 @@ export class EmailService extends Context.Service<EmailService>()(
 							...(cc.length > 0 && { cc }),
 							...(bcc.length > 0 && { bcc }),
 							inReplyTo: lastMessage.messageId,
-							references: [link.externalThreadId, lastMessage.messageId].filter(
-								(value, idx, arr) => arr.indexOf(value) === idx,
-							),
+							references: buildReferences({
+								root: link.externalThreadId,
+								parentReferences: lastMessage.references ?? [],
+								parentMessageId: lastMessage.messageId,
+							}),
 							...(sendAttachments.length > 0 && {
 								attachments: toOutboundAttachments(sendAttachments),
 							}),
@@ -1328,13 +1488,19 @@ export class EmailService extends Context.Service<EmailService>()(
 							inbox,
 							companyId: link.companyId,
 							contactId: link.contactId,
-							subject: link.subject,
+							// What the recipient actually saw, "Re:" and all — not the
+							// thread's own subject.
+							subject: replySubject,
 							to: replyRecipients,
 							cc,
 							bcc,
 							existingThreadLink: {
 								id: link.id,
 								externalThreadId: link.externalThreadId,
+							},
+							wireThreading: {
+								inReplyTo: lastMessage.messageId,
+								references: outbound.references ?? [],
 							},
 							rawRfc822Ref: dispatched.rawRef,
 							textBody: rendered.text,
@@ -1401,15 +1567,15 @@ export class EmailService extends Context.Service<EmailService>()(
 								-- empty, so fall back to the earliest message's subject to
 								-- avoid showing "(no subject)" when the messages have one.
 								COALESCE(
-									NULLIF(tl.subject, ''),
+									NULLIF(btrim(tl.subject), ''),
 									(
 										SELECT sm.subject FROM email_messages sm
 										WHERE sm.organization_id = tl.organization_id
 										  AND (sm.message_id = tl.external_thread_id
-										       OR tl.external_thread_id = ANY(sm."references"))
+										       OR sm."references" @> ARRAY[tl.external_thread_id]::text[])
 										  AND sm.subject IS NOT NULL
-										  AND sm.subject <> ''
-										ORDER BY sm.received_at ASC
+										  AND btrim(sm.subject) <> ''
+										ORDER BY sm.received_at ASC, sm.message_id ASC
 										LIMIT 1
 									)
 								) AS subject,
@@ -1502,7 +1668,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							WHERE em.organization_id = ${currentOrg.id}
 							  AND (
 							    em.message_id = ${link.externalThreadId}
-							    OR ${link.externalThreadId} = ANY(em."references")
+							    OR em."references" @> ARRAY[${link.externalThreadId}]::text[]
 							  )
 							ORDER BY em.received_at ASC NULLS LAST, em.status_updated_at ASC
 						`.pipe(Effect.orDie)
@@ -1668,7 +1834,7 @@ export class EmailService extends Context.Service<EmailService>()(
 										SELECT 1 FROM email_messages em
 										WHERE em.organization_id = tl.organization_id
 										  AND (em.message_id = tl.external_thread_id
-										       OR tl.external_thread_id = ANY(em."references"))
+										       OR em."references" @> ARRAY[tl.external_thread_id]::text[])
 										  AND em.search_vector @@ plainto_tsquery('simple', ${trimmedQuery})
 									)
 									OR EXISTS (
@@ -1676,7 +1842,7 @@ export class EmailService extends Context.Service<EmailService>()(
 										JOIN message_participants mp ON mp.email_message_id = em2.id
 										WHERE em2.organization_id = tl.organization_id
 										  AND (em2.message_id = tl.external_thread_id
-										       OR tl.external_thread_id = ANY(em2."references"))
+										       OR em2."references" @> ARRAY[tl.external_thread_id]::text[])
 										  AND mp.email_address ILIKE ${`%${trimmedQuery}%`}
 									)
 								)`)
@@ -1721,15 +1887,15 @@ export class EmailService extends Context.Service<EmailService>()(
 								-- empty, so fall back to the earliest message's subject to
 								-- avoid showing "(no subject)" when the messages have one.
 								COALESCE(
-									NULLIF(tl.subject, ''),
+									NULLIF(btrim(tl.subject), ''),
 									(
 										SELECT sm.subject FROM email_messages sm
 										WHERE sm.organization_id = tl.organization_id
 										  AND (sm.message_id = tl.external_thread_id
-										       OR tl.external_thread_id = ANY(sm."references"))
+										       OR sm."references" @> ARRAY[tl.external_thread_id]::text[])
 										  AND sm.subject IS NOT NULL
-										  AND sm.subject <> ''
-										ORDER BY sm.received_at ASC
+										  AND btrim(sm.subject) <> ''
+										ORDER BY sm.received_at ASC, sm.message_id ASC
 										LIMIT 1
 									)
 								) AS subject,
@@ -1744,19 +1910,19 @@ export class EmailService extends Context.Service<EmailService>()(
 									SELECT COUNT(*) FROM email_messages m
 									WHERE m.organization_id = tl.organization_id
 									  AND (m.message_id = tl.external_thread_id
-									       OR tl.external_thread_id = ANY(m."references"))
+									       OR m."references" @> ARRAY[tl.external_thread_id]::text[])
 								) AS message_count,
 								(
 									SELECT MAX(m.status_updated_at) FROM email_messages m
 									WHERE m.organization_id = tl.organization_id
 									  AND (m.message_id = tl.external_thread_id
-									       OR tl.external_thread_id = ANY(m."references"))
+									       OR m."references" @> ARRAY[tl.external_thread_id]::text[])
 								) AS last_message_at,
 								(
 									SELECT m.direction FROM email_messages m
 									WHERE m.organization_id = tl.organization_id
 									  AND (m.message_id = tl.external_thread_id
-									       OR tl.external_thread_id = ANY(m."references"))
+									       OR m."references" @> ARRAY[tl.external_thread_id]::text[])
 									ORDER BY m.status_updated_at DESC
 									LIMIT 1
 								) AS last_message_direction,
@@ -1764,14 +1930,14 @@ export class EmailService extends Context.Service<EmailService>()(
 									SELECT MAX(m.status_updated_at) FROM email_messages m
 									WHERE m.organization_id = tl.organization_id
 									  AND (m.message_id = tl.external_thread_id
-									       OR tl.external_thread_id = ANY(m."references"))
+									       OR m."references" @> ARRAY[tl.external_thread_id]::text[])
 									  AND m.direction = 'inbound'
 								) AS last_inbound_at,
 								(
 									SELECT m.inbound_classification FROM email_messages m
 									WHERE m.organization_id = tl.organization_id
 									  AND (m.message_id = tl.external_thread_id
-									       OR tl.external_thread_id = ANY(m."references"))
+									       OR m."references" @> ARRAY[tl.external_thread_id]::text[])
 									  AND m.direction = 'inbound'
 									ORDER BY m.status_updated_at DESC
 									LIMIT 1
@@ -1781,7 +1947,7 @@ export class EmailService extends Context.Service<EmailService>()(
 										SELECT MAX(m.status_updated_at) FROM email_messages m
 										WHERE m.organization_id = tl.organization_id
 										  AND (m.message_id = tl.external_thread_id
-										       OR tl.external_thread_id = ANY(m."references"))
+										       OR m."references" @> ARRAY[tl.external_thread_id]::text[])
 										  AND m.direction = 'inbound'
 									) > COALESCE(tl.last_read_at, 'epoch'::timestamptz),
 									false
@@ -2752,28 +2918,108 @@ export class EmailService extends Context.Service<EmailService>()(
 							},
 						)
 
-						// Reply path needs the parent thread's external_thread_id +
-						// references chain so the new message lands inside that
-						// thread instead of opening a fresh one. Prefer the column
-						// on the draft row; fall back to the parsed clientId for
-						// rows created before the schema change.
-						const threadLinkId = draft.threadLinkId ?? ctx.threadLinkId
+						// Which conversation this draft answers, if any — the message
+						// needs its external_thread_id and references chain to land
+						// inside it instead of opening a fresh one. Three ways of
+						// naming it, in order: the column on the draft row, the parsed
+						// clientId for rows written before that column existed, and
+						// `in_reply_to`, which names the parent by its Message-ID.
+						// That last one was being written down and never read, so a
+						// caller who threaded a draft the obvious way was ignored; hop
+						// from the id to the conversation the way arriving mail does.
+						let threadLinkId = draft.threadLinkId ?? ctx.threadLinkId
+						if (!threadLinkId && draft.inReplyTo) {
+							const parentRows = yield* sql<{ id: string }>`
+								SELECT tl.id
+								FROM email_messages em
+								JOIN email_thread_links tl
+								  ON tl.organization_id = em.organization_id
+								 AND (
+								   tl.external_thread_id = em.message_id
+								   OR tl.external_thread_id = ANY(em."references")
+								 )
+								WHERE em.organization_id = ${currentOrg.id}
+								  AND em.message_id = ${draft.inReplyTo}
+								  -- Same mailbox the draft is going out from: this send
+								  -- goes out from the draft's mailbox, so filing it under
+								  -- another one's conversation would put a message in a
+								  -- thread it was never part of.
+								  AND tl.inbox_id = ${inbox.id}
+								-- Same tie-break as the mail worker uses: oldest known
+								-- ancestor wins, so a split conversation always answers
+								-- with the same half.
+								ORDER BY array_position(em."references", tl.external_thread_id)
+								           ASC NULLS LAST,
+								         tl.created_at ASC, tl.id ASC
+								LIMIT 1
+							`.pipe(Effect.orDie)
+							threadLinkId = parentRows[0]?.id ?? null
+						}
 						let existingThreadLink: {
 							id: string
 							externalThreadId: string
+							subject: string | null
 						} | null = null
-						if (draft.mode === 'reply' && threadLinkId) {
+						// The message this one answers. `In-Reply-To` names it so the
+						// recipient's mail client hangs the message under it rather
+						// than at the top of the conversation.
+						let parentMessageId: string | null = null
+						let parentReferences: readonly string[] = []
+						// A draft that names a thread is answering it, whatever else it
+						// says. This used to also insist on `mode` being the literal
+						// string "reply" — an undocumented parameter nobody set — so
+						// every draft opened a second conversation and, whenever the
+						// writer had prefixed the subject "Re:", went out looking like
+						// a forged reply.
+						if (threadLinkId) {
 							const linkRows = yield* sql<{
 								id: string
 								externalThreadId: string
+								subject: string | null
 							}>`
-								SELECT id, external_thread_id
-								FROM email_thread_links
-								WHERE id = ${threadLinkId}
-								  AND organization_id = ${currentOrg.id}
+								SELECT tl.id, tl.external_thread_id,
+								       COALESCE(
+								         NULLIF(btrim(tl.subject), ''),
+								         (
+								           SELECT sm.subject FROM email_messages sm
+								           WHERE sm.organization_id = tl.organization_id
+								             AND (sm.message_id = tl.external_thread_id
+								                  OR sm."references" @> ARRAY[tl.external_thread_id]::text[])
+								             AND sm.subject IS NOT NULL
+								             AND btrim(sm.subject) <> ''
+								           ORDER BY sm.received_at ASC, sm.message_id ASC
+								           LIMIT 1
+								         )
+								       ) AS subject
+								FROM email_thread_links tl
+								WHERE tl.id = ${threadLinkId}
+								  AND tl.organization_id = ${currentOrg.id}
+								  -- Same rule as the hop above: a draft only answers a
+								  -- conversation in the mailbox it is going out from.
+								  AND tl.inbox_id = ${inbox.id}
 								LIMIT 1
 							`.pipe(Effect.orDie)
 							existingThreadLink = linkRows[0] ?? null
+							if (existingThreadLink) {
+								const lastRows = yield* sql<{
+									messageId: string
+									references: string[] | null
+								}>`
+									SELECT message_id, "references"
+									FROM email_messages
+									WHERE organization_id = ${currentOrg.id}
+									  AND (
+									    message_id = ${existingThreadLink.externalThreadId}
+									    OR "references" @> ARRAY[${existingThreadLink.externalThreadId}]::text[]
+									  )
+									  AND deleted_at IS NULL
+									ORDER BY received_at DESC NULLS LAST,
+									         status_updated_at DESC, message_id DESC
+									LIMIT 1
+								`.pipe(Effect.orDie)
+								parentMessageId = lastRows[0]?.messageId ?? null
+								parentReferences = lastRows[0]?.references ?? []
+							}
 						}
 
 						// Resolve staged attachments for this draft + render the
@@ -2820,10 +3066,21 @@ export class EmailService extends Context.Service<EmailService>()(
 								}),
 						})
 
+						// A draft answering a thread borrows that thread's subject when
+						// the writer left it blank, so it goes out as "Re: …" rather
+						// than with no subject line at all.
+						const threadSubject = existingThreadLink?.subject ?? null
+						const draftSubject =
+							draft.subject && draft.subject.trim() !== ''
+								? draft.subject
+								: threadSubject
+									? withReplyPrefix(threadSubject)
+									: ''
+
 						const outbound: OutboundMessage = {
 							from: inbox.email,
 							to: draft.toAddresses as string[],
-							subject: draft.subject ?? '',
+							subject: draftSubject,
 							text: rendered.text,
 							html: rendered.html,
 							...(draft.ccAddresses.length > 0 && {
@@ -2833,8 +3090,14 @@ export class EmailService extends Context.Service<EmailService>()(
 								bcc: draft.bccAddresses as string[],
 							}),
 							...(existingThreadLink && {
-								inReplyTo: existingThreadLink.externalThreadId,
-								references: [existingThreadLink.externalThreadId],
+								inReplyTo:
+									parentMessageId ?? existingThreadLink.externalThreadId,
+								references: buildReferences({
+									root: existingThreadLink.externalThreadId,
+									parentReferences,
+									parentMessageId:
+										parentMessageId ?? existingThreadLink.externalThreadId,
+								}),
 							}),
 							...(staged.length > 0 && {
 								attachments: toOutboundAttachments(toSendAttachments(staged)),
@@ -2854,11 +3117,19 @@ export class EmailService extends Context.Service<EmailService>()(
 							inbox,
 							companyId: ctx.companyId,
 							contactId: ctx.contactId,
-							subject: draft.subject ?? null,
+							// What the recipient actually saw, not what the draft held.
+							subject: draftSubject,
 							to: draft.toAddresses as string[],
 							cc: draft.ccAddresses as string[],
 							bcc: draft.bccAddresses as string[],
 							existingThreadLink,
+							...(existingThreadLink && {
+								wireThreading: {
+									inReplyTo:
+										parentMessageId ?? existingThreadLink.externalThreadId,
+									references: outbound.references ?? [],
+								},
+							}),
 							rawRfc822Ref: dispatched.rawRef,
 							textBody: rendered.text,
 							htmlBody: rendered.html,

--- a/packages/controllers/src/errors.ts
+++ b/packages/controllers/src/errors.ts
@@ -56,6 +56,20 @@ export class EmailError extends Schema.TaggedErrorClass<EmailError>()(
 	{ message: Schema.String },
 ) {}
 
+/**
+ * A message that was not put on the wire because of the shape it was in, not
+ * because anything failed. Both shapes it names are read as spam by receiving
+ * servers, and both are the sender's to fix.
+ *
+ * It carries the reason rather than a sentence, so the side facing the reader
+ * writes the wording in their language and telemetry can count the reasons
+ * apart. Returned as 400.
+ */
+export class EmailNotSendable extends Schema.TaggedErrorClass<EmailNotSendable>()(
+	'EmailNotSendable',
+	{ reason: Schema.Literals(['no_subject', 'forged_reply']) },
+) {}
+
 // ── Inbox lifecycle errors (route-level, status-mapped) ──
 
 /** No default inbox configured for the calling member. Returned as 409. */

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -4,6 +4,7 @@ export {
 	ConfirmRequired,
 	Conflict,
 	EmailError,
+	EmailNotSendable,
 	EmailSendError,
 	EmailSendErrorKind,
 	EmailSuppressed,

--- a/packages/controllers/src/routes/email.ts
+++ b/packages/controllers/src/routes/email.ts
@@ -10,6 +10,7 @@ import { EmailBlocks } from '@batuda/email/schema'
 
 import {
 	BadRequest,
+	EmailNotSendable,
 	EmailSuppressed,
 	GrantAuthFailed,
 	GrantConnectFailed,
@@ -175,6 +176,7 @@ export const EmailGroup = HttpApiGroup.make('email')
 			}),
 			error: [
 				EmailSuppressed.pipe(HttpApiSchema.status(409)),
+				EmailNotSendable.pipe(HttpApiSchema.status(400)),
 				BadRequest.pipe(HttpApiSchema.status(400)),
 				...InboxOpFailures,
 			],
@@ -186,6 +188,10 @@ export const EmailGroup = HttpApiGroup.make('email')
 				threadId: Schema.String,
 				bodyJson: EmailBlocks,
 				preview: Schema.optional(Schema.String),
+				// Omitted, the thread's own subject is used, prefixed "Re: ".
+				// Supplied, it wins — the only way to answer a thread whose
+				// messages never carried a subject to borrow.
+				subject: Schema.optional(Schema.String),
 				cc: Schema.optional(Schema.Array(Schema.String)),
 				bcc: Schema.optional(Schema.Array(Schema.String)),
 				attachments: Schema.optional(Schema.Array(SendAttachmentRef)),
@@ -197,6 +203,7 @@ export const EmailGroup = HttpApiGroup.make('email')
 			}),
 			error: [
 				EmailSuppressed.pipe(HttpApiSchema.status(409)),
+				EmailNotSendable.pipe(HttpApiSchema.status(400)),
 				BadRequest.pipe(HttpApiSchema.status(400)),
 				NotFound.pipe(HttpApiSchema.status(404)),
 				...InboxOpFailures,
@@ -518,6 +525,7 @@ export const EmailGroup = HttpApiGroup.make('email')
 			}),
 			error: [
 				EmailSuppressed.pipe(HttpApiSchema.status(409)),
+				EmailNotSendable.pipe(HttpApiSchema.status(400)),
 				BadRequest.pipe(HttpApiSchema.status(400)),
 				NotFound.pipe(HttpApiSchema.status(404)),
 			],


### PR DESCRIPTION
## What

Sending a follow-up on an existing email conversation was broken in two ways, and both produced messages that receiving mail servers score as spam. 28 messages had already gone out to real prospects: 16 with no subject line at all, 12 as what a spam filter reads as a forged reply. This fixes both, and refuses to send either shape again.

It lives in the CRM's email surface — the send paths in `server`, the IMAP ingest in `mail-worker`, and the compose window in `internal`.

## The fix

**Touches:** the two ways a message goes out (a direct reply, and a draft a person writes first), the part of the mail worker that files an arriving message into a conversation, and the compose window that reports a refused send.

- **A reply arrived as "(no subject)".** A conversation begun by an arriving message never had its subject recorded, so a reply had none to borrow and went out with the header missing entirely. The worker now records it, and a reply with nothing of its own borrows the first message's.
- **A follow-up written as a draft went out as a forged reply.** Threading was gated behind an undocumented `mode` parameter nobody set, so the message carried a "Re: " subject with nothing tying it to the conversation — and opened a second conversation for the same contact. A draft now threads whenever it names a conversation, and `in_reply_to` (previously stored and never read) works too.
- **Both shapes are now refused before they reach the wire**, on every path that sends. The refusal carries a reason rather than a sentence, so each surface words it for its own reader and telemetry can count the reasons apart.
- **A reply could go missing from the conversation it belongs to.** Which conversation a message is in is read out of its `References` list, so a sender that names only the message it answers — or that trims a long chain — left the conversation's own id out, and the message was filed correctly and then never shown, never counted, never marking the thread unread. Every arriving message now carries that id, and a missing `References` header falls back to `In-Reply-To` as RFC 5322 prescribes.

## Impact

- **No database migration.** `email_thread_links.subject` has existed since the first migration; the worker simply starts filling it. Nothing to run before the server tag.
- **Nothing touching which organisation can see what (row-level security).** Every query added or changed keeps its existing `organization_id` scope, and the Postgres role each path runs under is unchanged.
- **Both transports get the behaviour.** The guard sits at the single point every send funnels through, so the MCP tools and the HTTP routes are covered by one check rather than two.
- **New error on the wire (`EmailNotSendable`).** Three send endpoints — send, reply, send-draft — can now return 400 with `{_tag, reason}` where `reason` is `no_subject` or `forged_reply`. The typed client in `internal` consumes it; no field was removed or renamed.
- **One MCP parameter narrowed.** `manage_email_draft`'s `mode` went from any string to `new | reply`. The database has constrained the column to those two since the first migration and the web app only ever sends `reply` or omits it, so nothing in the repo can send anything else.
- **A send can now fail that previously succeeded.** A message with no subject, or a "Re: " that answers nothing, is refused rather than delivered. That is the point, but it is a behaviour change: a caller that relied on either shape going out will now get a 400. Transactional mail (magic links, invitations) uses a different provider and is untouched.
- **No new environment variables, no CORS or cross-app coupling, no webhook or paid-provider change.**

## Review guide

Start with `apps/server/src/services/email.ts` — the guard (`assertSendable`), the References chain builder (`buildReferences`), and the subject selection on the reply and draft paths. That is where the behaviour lives; everything else follows from it.

**The riskiest part is `buildReferences`.** It decides the header that tells a mail client where to hang a reply, and it has a subtle rule: the message being answered must be last, the conversation's own id must survive truncation (our own thread lookups search for it there), and neither is obvious from reading it. `apps/server/src/services/email-references.test.ts` is the specification — read it before the function.

**A decision you might overrule:** a caller-supplied subject now wins over the conversation's own on a reply, matching what a draft already did and what a mail client does by letting you edit the line. The alternative was to use it only as a fallback.

**Skip-able:** the `= ANY(...)` → `@>` rewrites across the SQL are mechanical. They exist because the existing GIN index on `references` cannot serve `= ANY`; measured on 50k messages, a thread lookup went from a 20 ms sequential scan to a 0.33 ms index scan. Four sites deliberately keep `= ANY` — there the scan is over the thread table and the array comes from an already-pinned message, where the old form is the one that uses an index. A comment at each says so.

**What I could not verify:** Snyk was not available in this session, so the new code has not been scanned. Two e2e tests fail on this branch and both fail identically on base `main` — `attachment.test.ts` (staging rows not purged after a send) and a flaky `superadmin.test.ts`; I confirmed by stashing every change and re-running. Both are filed separately.

## Screenshots

The one user-visible state this adds: a send refused because the subject says "Re:" but the message answers nothing.

_Mobile (the composer is a bottom sheet — the message renders in full):_

![Refused send on mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-528/pr-520-refusal-mobile.webp)

_Desktop (the composer is a floating panel):_

![Refused send on desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-528/pr-520-refusal-desktop.webp)

On desktop the banner shows about one line before the pinned footer covers the rest. That is a pre-existing constraint of the floating composer — `ErrorBanner` is untouched here and any multi-line error clips the same way — but this change makes it visible, so I shortened the wording to two lines. Worth a follow-up.

## Tests

- **Unit:** 22 cases on the guard (including the false positives that matter — "Reminder:", "Ref:", "Renewal" must not be mistaken for a reply prefix), 12 on the References chain, and the reason-reader in the web app.
- **Integration (real Postgres):** 45 on the send paths — subject borrowing, threading headers, a second reply building on the first, cross-organisation isolation, and that a refusal leaves a record naming its reason without writing down the subject or the recipient.
- **End-to-end (real browser, real SMTP):** the refusal is asserted on the reason the wire carries, not on the sentence shown, so the test survives a rewording or a locale change.
- Each fix was mutation-checked: reverting it fails the tests that name it.

## Verification

Run on this branch after rebasing onto current `main`:

- `pnpm install` — no lockfile drift
- `pnpm -w check-types` — 13/13
- `pnpm -w test` — 21/21 tasks
- `pnpm -w build` — 13/13
- `pnpm test:integration` — 766 server, 32 mail-worker
- `pnpm check` (lint) — exit 0
- Live stack: reset + seed, then 16 e2e specs across reply, compose, ingest round-trip, thread render and inbox listing
- Live SMTP into the local mail catcher, confirming the old shape emits no `Subject` header and the fixed one emits all three

## Deferred

- **Conversations split into two threads** when a reply is ingested before the message it answers. I attempted a fix here and reverted it: rooting at the oldest named ancestor does merge them, but several people replying to one message we do not hold then land in a single conversation homed to whoever replied first — one company's mail filed under another. The reasoning is recorded in a comment at the code. Filed separately with the cross-company case named as the thing any fix must be tested against.
- **Membership is still derived from the `References` list rather than stored.** This PR makes every arriving message carry its conversation's id, which closes the gap in practice, but a `thread_link_id` column on `email_messages` is the clean end state and would remove the derivation entirely.

Closes #520
