### PR TITLE
fix(research): tell a company's trade from its name by asking the run

### DIFF
--- a/packages/research/src/application/directory-sites.test.ts
+++ b/packages/research/src/application/directory-sites.test.ts
@@ -5,6 +5,10 @@ import {
 	observeDirectorySites,
 	siteVerdict,
 } from './directory-sites'
+import { tradeWordsOf } from './trade-words'
+
+// A run that named no trades, which is a request about one company on file.
+const noTrades = tradeWordsOf([])
 
 // A prospect scan's list, as the guard chain hands it over.
 const scan = (names: ReadonlyArray<string>) => ({
@@ -19,9 +23,51 @@ const observe = (
 		findings: scan(names),
 		listField: 'prospects',
 		addresses,
+		tradeWords: noTrades,
 	})
 
 describe('observeDirectorySites', () => {
+	describe('when the run names the trade its companies are called after', () => {
+		it('should watch a host no company is established as owning', () => {
+			// GIVEN two firms named after one trade, each filed at its own address on
+			// the bare domain of that trade, in a run that asked for that trade
+			// WHEN the run's addresses are watched
+			// THEN the host is a listing. Neither firm is established as owning
+			// fontaneria.es, so neither steps over it, and the watch sees it file two
+			// of the run's own companies
+			const observation = observeDirectorySites({
+				findings: scan(['Fontanería García', 'Fontanería López']),
+				listField: 'prospects',
+				addresses: [
+					'https://fontaneria.es/fontaneria-garcia',
+					'https://fontaneria.es/fontaneria-lopez',
+				],
+				tradeWords: tradeWordsOf(['fontanería']),
+			})
+
+			expect([...observation.sites]).toEqual(['fontaneria.es'])
+		})
+
+		it('should still step over a host the company own name spells', () => {
+			// GIVEN the same two firms, one of them filed on the domain that spells
+			// its own word
+			// WHEN watched
+			// THEN garcia.es is stepped over for García, so it is seen filing only one
+			// company and is no listing
+			const observation = observeDirectorySites({
+				findings: scan(['Fontanería García', 'Fontanería López']),
+				listField: 'prospects',
+				addresses: [
+					'https://garcia.es/fontaneria-garcia',
+					'https://garcia.es/fontaneria-lopez',
+				],
+				tradeWords: tradeWordsOf(['fontanería']),
+			})
+
+			expect([...observation.sites]).toEqual([])
+		})
+	})
+
 	describe("when one host files several of the run's own companies", () => {
 		it('should judge it a directory', () => {
 			// GIVEN two of the run's companies each filed at their own address on one
@@ -555,6 +601,7 @@ describe('observeDirectorySites', () => {
 					'https://listado.example/electricistas-puig',
 					'https://listado.example/instalaciones-ferre',
 				],
+				tradeWords: noTrades,
 			})
 
 			// WHEN read — THEN one company can never reach two, so nothing is judged —
@@ -582,6 +629,7 @@ describe('observeDirectorySites', () => {
 				findings: { prospects: [{ website: 'https://a.example' }, {}] },
 				listField: 'prospects',
 				addresses: ['https://listado.example/x'],
+				tradeWords: noTrades,
 			})
 
 			// WHEN read — THEN neither yields a name to look for

--- a/packages/research/src/application/directory-sites.ts
+++ b/packages/research/src/application/directory-sites.ts
@@ -95,6 +95,7 @@ import {
 import { isPlainObject } from './guard-shapes'
 import { ownSiteHostVerdict } from './own-site'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
+import type { TradeWords } from './trade-words'
 
 /** Hosts this run watched file several of its own companies. */
 export type DirectorySites = ReadonlySet<string>
@@ -416,8 +417,9 @@ export const observeDirectorySites = (args: {
 	readonly findings: unknown
 	readonly listField: string | undefined
 	readonly addresses: ReadonlyArray<string>
+	readonly tradeWords: TradeWords
 }): DirectoryObservation => {
-	const { findings, listField, addresses } = args
+	const { findings, listField, addresses, tradeWords } = args
 	const readable = addresses.filter(isBareWebAddress)
 	const addressesRead = readable.length
 	if (listField === undefined) return { sites: new Set(), addressesRead }
@@ -454,7 +456,7 @@ export const observeDirectorySites = (args: {
 		const known = ownSiteAnswers.get(key)
 		if (known !== undefined) return known
 		const own = company.rowNames.some(
-			name => ownSiteHostVerdict({ name, host }) === 'established',
+			name => ownSiteHostVerdict({ name, host, tradeWords }) === 'established',
 		)
 		ownSiteAnswers.set(key, own)
 		return own

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -29,6 +29,10 @@ import {
 } from './entity-guard'
 import { EQUIVALENT_LETTERS } from './letter-equivalences.generated'
 import { ownSiteVerdict } from './own-site'
+import { tradeWordsOf } from './trade-words'
+
+// A run that named no trades, which is a request about one company on file.
+const noTrades = tradeWordsOf([])
 
 describe('deriveEntityTargets', () => {
 	describe('when the schema reports third-party companies', () => {
@@ -1596,10 +1600,18 @@ describe('nameSpellings — vowels a company writes two ways', () => {
 			expect(nameSpellings('Mueller GmbH')).toEqual(['Mueller GmbH'])
 			expect(nameSpellings('Muller SL')).toEqual(['Muller SL'])
 			expect(
-				ownSiteVerdict({ name: 'Muller SL', website: 'https://mueller.de' }),
+				ownSiteVerdict({
+					name: 'Muller SL',
+					website: 'https://mueller.de',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 			expect(
-				ownSiteVerdict({ name: 'Mueller GmbH', website: 'https://muller.de' }),
+				ownSiteVerdict({
+					name: 'Mueller GmbH',
+					website: 'https://muller.de',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -1621,7 +1633,11 @@ describe('nameSpellings — vowels a company writes two ways', () => {
 					'muellerelektro',
 				])
 				expect(
-					ownSiteVerdict({ name, website: 'https://mueller-elektro.de' }),
+					ownSiteVerdict({
+						name,
+						website: 'https://mueller-elektro.de',
+						tradeWords: noTrades,
+					}),
 				).toBe('established')
 			}
 		})

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -63,6 +63,16 @@ const LEGAL_SUFFIXES = new Set([
 // freight company contains "logistics"/"transport". A name reduced to only these
 // yields no distinctive word, so the run cannot reach a weak (let alone strong)
 // match on an industry term alone.
+//
+// DO NOT ADD ANOTHER INDUSTRY HERE. Writing down the words of a trade can never
+// finish: it takes every trade in every language a market answers in, and each
+// word written down takes a real distinctive word away from the firms genuinely
+// called it. A run brings the trades it went looking for instead
+// (`trade-words.ts`), which is that market's own vocabulary and needs no
+// upkeep. What is left below is the words for a KIND of company, which work for
+// anybody in any market, and one industry's words that stand only for a run
+// with no market behind it to read — see `own-site.ts` for what they still do
+// and what would let them go.
 const GENERIC_WORDS = new Set([
 	'logistics',
 	'logistica',

--- a/packages/research/src/application/eval-scoring-market.ts
+++ b/packages/research/src/application/eval-scoring-market.ts
@@ -31,6 +31,7 @@ import {
 } from './prospect-dedupe-guard'
 import { rowGroups } from './row-groups'
 import { anyTermAppearsIn, termTokens } from './term-match'
+import type { TradeWords } from './trade-words'
 
 export const partsAnsweredBy = (
 	rows: RunOutcome['companies'],
@@ -123,12 +124,13 @@ const companiesAmong = (
 // name with a note written after it.
 const joinedAsTheFoldDoes = (
 	rows: ReadonlyArray<Record<string, unknown>>,
+	tradeWords: TradeWords,
 ): ReadonlyArray<readonly [number, number]> => {
 	const joined: Array<readonly [number, number]> = []
 	// Read over the whole returned list, which is the list the fold read too. Asking
 	// row by row would make this stricter than the fold it measures, and call a list
 	// clean while it still holds the pairs the fold joins on a site.
-	const ownSiteHosts = hostsEstablishedAsOwn(rows)
+	const ownSiteHosts = hostsEstablishedAsOwn(rows, tradeWords)
 	const rowOfKey = new Map<string, number>()
 	rows.forEach((row, at) => {
 		for (const key of discoveryRowIdentityKeys(row, ownSiteHosts)) {
@@ -280,19 +282,27 @@ const joinedByOneNameSayingAnother = (
  * direction: neither claims a duplicate it cannot show.
  */
 export interface RepeatedRows {
-	/** Read with the keys the pipeline's own fold uses. */
+	/**
+	 * Read with the keys the pipeline's own fold uses, and with the trades the
+	 * golden file names rather than the ones the run split out of its request —
+	 * so a row whose host only one of those two vocabularies establishes is
+	 * counted differently here from how the run folded it.
+	 */
 	readonly duplicated: number
 	/** Read loosely enough to see what those keys cannot. Never the smaller of the two. */
 	readonly possiblyDuplicated: number
 }
 
-export const repeatedRows = (rows: RunOutcome['companies']): RepeatedRows => {
+export const repeatedRows = (
+	rows: RunOutcome['companies'],
+	tradeWords: TradeWords,
+): RepeatedRows => {
 	const discoveryRows = asDiscoveryRows(rows)
 	// Worked out once and read twice. The loose figure is the strict one's pairs
 	// plus more of them, which is what makes it a superset rather than a second
 	// opinion that could disagree — and it is also why the joins the fold makes are
 	// not worth finding twice over.
-	const asTheFoldDoes = joinedAsTheFoldDoes(discoveryRows)
+	const asTheFoldDoes = joinedAsTheFoldDoes(discoveryRows, tradeWords)
 	return {
 		duplicated:
 			discoveryRows.length -

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -71,6 +71,7 @@ import {
 	type RunScore,
 	SCORABLE_FIELDS,
 } from './eval-scoring-types'
+import { tradeWordsOf } from './trade-words'
 
 export { contactNameMatches } from './eval-scoring-company'
 export {
@@ -244,7 +245,21 @@ export const scoreRun = (
 	const rightKindRows = outcome.companies.filter(
 		(_, index) => kinds[index]?.isCompany ?? true,
 	)
-	const repeats = repeatedRows(outcome.companies)
+	// Read with the trades the golden file wrote down for this market, which is the
+	// nearest thing the eval holds to the words the run itself went looking for. A
+	// reading with no trades at all would establish more sites than the run's fold
+	// did and then report as duplicates the rows the fold was right to leave apart.
+	//
+	// The golden wordings rather than the ones the run split its own request into,
+	// though those are closer to what the fold read: the run's are written afresh
+	// every pass, so a duplicate count read off them would move between two passes
+	// of one market for reasons that have nothing to do with the change under
+	// measurement. A company row names no market and so no trades, which is what
+	// its run read too.
+	const repeats = repeatedRows(
+		outcome.companies,
+		tradeWordsOf(expectedMarket?.parts.flatMap(part => part.terms) ?? []),
+	)
 	const market: MarketScore | undefined =
 		expectedMarket === undefined || !endedWithAnAnswer(outcome.status)
 			? undefined

--- a/packages/research/src/application/existence-verdict.test.ts
+++ b/packages/research/src/application/existence-verdict.test.ts
@@ -9,6 +9,10 @@ import {
 	rowExistence,
 	withExistence,
 } from './existence-verdict'
+import { tradeWordsOf } from './trade-words'
+
+// A run that named no trades, which is a request about one company on file.
+const noTrades = tradeWordsOf([])
 
 // A workshop whose own domain spells its name, so `ownSiteVerdict` establishes
 // it — the only thing in the package that can clear a source.
@@ -23,6 +27,45 @@ const LISTING = 'https://paginas.es/empresa/fusteria-miquel'
 const NONE: ReadonlySet<string> = new Set()
 
 describe('existenceOf', () => {
+	describe('when the run names the trade the company is called after', () => {
+		it('should not confirm a company on the bare domain of its trade', () => {
+			// GIVEN a firm named after its trade, offering the bare domain of that
+			// trade as its website, in a run that asked for that trade
+			// AND a second, unrelated website that names it
+			// WHEN asked whether it exists
+			// THEN it is a candidate: fontaneria.es is not established as anybody's
+			// own, so nothing here vouches for the company and the two websites alone
+			// are not enough
+			expect(
+				existenceOf({
+					name: 'Fontanería García',
+					website: 'https://fontaneria.es',
+					sources: [PAPER],
+					directorySites: NONE,
+					tradeWords: tradeWordsOf(['fontanería']),
+				}).verdict,
+			).toBe('candidate')
+		})
+
+		it('should confirm the same company at the domain spelling its own word', () => {
+			// GIVEN the same firm and the same run, at the domain that carries the
+			// word only it has
+			// WHEN asked
+			// THEN confirmed. Reading the run's trades takes away the trade, not the
+			// company, so a firm named after what it does is not judged more harshly
+			// than anybody else
+			expect(
+				existenceOf({
+					name: 'Fontanería García',
+					website: 'https://garcia.es',
+					sources: [PAPER],
+					directorySites: NONE,
+					tradeWords: tradeWordsOf(['fontanería']),
+				}),
+			).toEqual({ verdict: 'confirmed', websites: 2 })
+		})
+	})
+
 	describe("when the company's own site and a second website name it", () => {
 		it('should confirm the company', () => {
 			// GIVEN a company at the domain its name spells
@@ -35,6 +78,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [PAPER],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -50,6 +94,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [LISTING],
 					directorySites: new Set(['paginas.es']),
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -65,6 +110,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['elpuntavui.cat'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -79,6 +125,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [OWN, PAPER],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -98,6 +145,7 @@ describe('existenceOf', () => {
 					website: 'https://paginas.es',
 					sources: [PAPER],
 					directorySites: new Set(['paginas.es']),
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -115,6 +163,7 @@ describe('existenceOf', () => {
 					website: 'https://instalacionesferre.es',
 					sources: [PAPER],
 					directorySites: new Set(['instalacionesferre.es']),
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -130,6 +179,7 @@ describe('existenceOf', () => {
 					website: 'https://instalacionesferre.es',
 					sources: [PAPER, 'https://instalacionesferre.com'],
 					directorySites: new Set(['instalacionesferre.es']),
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -146,6 +196,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [`${OWN}/contacte`],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -160,6 +211,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['https://blog.fusteriamiquel.cat/obra-nova'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -173,6 +225,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['https://www.fusteriamiquel.cat/contacte'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -188,6 +241,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['https://fusteriamiquel.com'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -205,6 +259,7 @@ describe('existenceOf', () => {
 						'https://eleconomista.es/noticia/999',
 					],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -220,6 +275,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [LISTING, 'https://otrodirectorio.es/e/fusteria-miquel'],
 					directorySites: new Set(['paginas.es', 'otrodirectorio.es']),
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -234,6 +290,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [PAPER, 'https://lavanguardia.com/economia/55'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -248,6 +305,7 @@ describe('existenceOf', () => {
 					website: 'https://sice.com',
 					sources: [PAPER],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -263,6 +321,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [PAPER],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -278,6 +337,7 @@ describe('existenceOf', () => {
 					name: 'Zeta Instal·lacions',
 					sources: ['https://acme.es/x', 'https://acme.de/y'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -288,7 +348,12 @@ describe('existenceOf', () => {
 			// GIVEN a row citing nothing and holding no website
 			// WHEN asked — THEN there is nothing to count
 			expect(
-				existenceOf({ name: NAME, sources: [], directorySites: NONE }),
+				existenceOf({
+					name: NAME,
+					sources: [],
+					directorySites: NONE,
+					tradeWords: noTrades,
+				}),
 			).toEqual({
 				verdict: 'candidate',
 				reason: 'no_sources',
@@ -306,6 +371,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: ['src_9f2a1b3c', 'src_aa11bb22'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_sources', websites: 0 })
 		})
@@ -321,6 +387,7 @@ describe('existenceOf', () => {
 					website: 'https://fusteriamiquel.cat/ (inferred from the name)',
 					sources: ['https://elpuntavui.cat/ (probably)'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_sources', websites: 0 })
 		})
@@ -334,6 +401,7 @@ describe('existenceOf', () => {
 					website: '   ',
 					sources: [PAPER],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -346,6 +414,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: ['info@fusteriamiquel.cat'],
 					directorySites: NONE,
+					tradeWords: noTrades,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_sources', websites: 0 })
 		})

--- a/packages/research/src/application/existence-verdict.ts
+++ b/packages/research/src/application/existence-verdict.ts
@@ -96,6 +96,7 @@ import {
 import { isPlainObject } from './guard-shapes'
 import { ownSiteVerdict } from './own-site'
 import { hostOf, isBareWebAddress } from './source-key'
+import type { TradeWords } from './trade-words'
 
 /** Where the row's existence stands. There is no third value. */
 export type ExistenceVerdict = 'confirmed' | 'candidate'
@@ -167,11 +168,18 @@ const webAddressesAmong = (
 // Every distinct host among these addresses, each read for the two questions
 // that decide what it can do: is it this company's own site, and is it a
 // listing. Held by the host as met, so two pages of one site are read once.
-const sitesOf = (
-	name: string,
-	addresses: ReadonlyArray<string>,
-	directorySites: DirectorySites,
-): ReadonlyArray<SourceSite> => {
+//
+// Named rather than in a row, because the hosts a run watched listing and the
+// trades it went looking for are both a set of words and neither reader could
+// tell it had been handed the other: every host would read as a listing and no
+// trade would be recognised, with nothing to say so.
+const sitesOf = (args: {
+	readonly name: string
+	readonly addresses: ReadonlyArray<string>
+	readonly directorySites: DirectorySites
+	readonly tradeWords: TradeWords
+}): ReadonlyArray<SourceSite> => {
+	const { name, addresses, directorySites, tradeWords } = args
 	const byHost = new Map<string, SourceSite>()
 	for (const address of addresses) {
 		const host = hostOf(address)
@@ -179,7 +187,9 @@ const sitesOf = (
 		byHost.set(host, {
 			host,
 			site: registrableDomain(host),
-			own: ownSiteVerdict({ name, website: address }) === 'established',
+			own:
+				ownSiteVerdict({ name, website: address, tradeWords }) ===
+				'established',
 			directory: siteVerdict(host, directorySites) === 'directory',
 		})
 	}
@@ -255,13 +265,19 @@ export const existenceOf = (args: {
 	readonly website?: string | undefined
 	readonly sources: ReadonlyArray<string>
 	readonly directorySites: DirectorySites
+	readonly tradeWords: TradeWords
 }): RowExistence => {
-	const { name, website, directorySites } = args
+	const { name, website, directorySites, tradeWords } = args
 	const offered =
 		website === undefined || website.trim() === ''
 			? args.sources
 			: [website, ...args.sources]
-	const sites = sitesOf(name, webAddressesAmong(offered), directorySites)
+	const sites = sitesOf({
+		name,
+		addresses: webAddressesAmong(offered),
+		directorySites,
+		tradeWords,
+	})
 	const websites = websitesOf(sites)
 	// A site has to be this company's own AND not a host the run watched listing
 	// the market. Ownership is read off the domain alone, so a company named after

--- a/packages/research/src/application/own-site.test.ts
+++ b/packages/research/src/application/own-site.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import { ownSiteHostVerdict, ownSiteVerdict } from './own-site'
+import { tradeWordsOf } from './trade-words'
+
+// A run that named no trades, which is a request about one company on file:
+// nothing to read, so only the shared list of words for a kind of company
+// stands. Every reading here that does not turn on a market's own vocabulary is
+// held to that, so the list's own work stays visible.
+const noTrades = tradeWordsOf([])
 
 // The address the French solar directory files a company at: a slug naming a
 // trade and a role, ending in the listing's own record number, and naming no
@@ -18,6 +25,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Redwood Logistics',
 					website: 'https://redwoodlogistics.com/about',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -30,6 +38,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://acme.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -49,7 +58,9 @@ describe('ownSiteVerdict', () => {
 				['TIBA Group', 'https://tiba-group.com/about-tiba'],
 				['GLS Spain', 'https://gls-spain.es/gls-spain-quienes'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('established')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'established',
+				)
 			}
 		})
 
@@ -61,6 +72,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Transportes García',
 					website: 'https://garcia.es/contacto',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -72,6 +84,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Fusteria Miquel',
 					website: 'https://fusteriamiquelsl.cat',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -81,7 +94,11 @@ describe('ownSiteVerdict', () => {
 			// WHEN asked — THEN the dots are taken out before the name is read, so one
 			// company spelled two ways is not two answers
 			expect(
-				ownSiteVerdict({ name: 'Acme S.L.', website: 'https://acme.com' }),
+				ownSiteVerdict({
+					name: 'Acme S.L.',
+					website: 'https://acme.com',
+					tradeWords: noTrades,
+				}),
 			).toBe('established')
 		})
 
@@ -89,7 +106,11 @@ describe('ownSiteVerdict', () => {
 			// GIVEN an accented name and the unaccented domain a registrar hands out
 			// WHEN asked — THEN accents are folded away on both sides
 			expect(
-				ownSiteVerdict({ name: 'Grupo Muñoz', website: 'https://munoz.es' }),
+				ownSiteVerdict({
+					name: 'Grupo Muñoz',
+					website: 'https://munoz.es',
+					tradeWords: noTrades,
+				}),
 			).toBe('established')
 		})
 
@@ -102,6 +123,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://botiga.acme.co.uk/contacte',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -119,7 +141,9 @@ describe('ownSiteVerdict', () => {
 				['Lasser', 'https://grupolasser.com'],
 				['CAHORS', 'https://www.groupe-cahors.com/es-espana'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('established')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'established',
+				)
 			}
 		})
 
@@ -137,12 +161,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'KGS Fire & Security España',
 					website: 'http://www.grupofire.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Electronic Trafic (ETRA)',
 					website: 'https://grupoetra.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -153,12 +179,17 @@ describe('ownSiteVerdict', () => {
 			// THEN they agree, so a caller weighing many addresses on one host still
 			// gets one answer for the host
 			expect(
-				ownSiteHostVerdict({ name: 'Lasser', host: 'grupolasser.com' }),
+				ownSiteHostVerdict({
+					name: 'Lasser',
+					host: 'grupolasser.com',
+					tradeWords: noTrades,
+				}),
 			).toBe('established')
 			expect(
 				ownSiteVerdict({
 					name: 'Lasser',
 					website: 'https://grupolasser.com/quienes-somos',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -172,6 +203,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Lasser',
 					website: 'https://grupolasserna.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -186,7 +218,9 @@ describe('ownSiteVerdict', () => {
 				['Penske Logistics', 'https://gopenske.com/logistics'],
 				['Ferré', 'https://miferre.es'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('unknown')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'unknown',
+				)
 			}
 		})
 
@@ -203,11 +237,16 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme',
 					website: 'https://transportesacme.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 			for (const name of ['Sacme', 'Esacme']) {
 				expect(
-					ownSiteVerdict({ name, website: 'https://transportesacme.com' }),
+					ownSiteVerdict({
+						name,
+						website: 'https://transportesacme.com',
+						tradeWords: noTrades,
+					}),
 				).toBe('unknown')
 			}
 		})
@@ -221,6 +260,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Cobra Instalaciones',
 					website: 'https://grupotransportescobra.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -235,6 +275,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://grupoacme-directorio.com/acme-logistics',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -249,10 +290,15 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Cobra Instalaciones y Servicios',
 					website: 'https://grupoetra.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 			expect(
-				ownSiteVerdict({ name: 'Lasser', website: 'https://grupocobra.com' }),
+				ownSiteVerdict({
+					name: 'Lasser',
+					website: 'https://grupocobra.com',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -267,6 +313,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Instalaciones Rubio',
 					website: 'https://grupoins.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -282,12 +329,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Logistics Group',
 					website: 'https://grupologistics.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Grupo Ferré',
 					website: 'https://grupogrupo.es',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -300,7 +349,11 @@ describe('ownSiteVerdict', () => {
 			// because it is where the two readings meet, and the furthest a label may
 			// sit from the name and still spell it
 			expect(
-				ownSiteVerdict({ name: 'Cobra', website: 'https://grupocobrasa.com' }),
+				ownSiteVerdict({
+					name: 'Cobra',
+					website: 'https://grupocobrasa.com',
+					tradeWords: noTrades,
+				}),
 			).toBe('established')
 		})
 	})
@@ -318,7 +371,9 @@ describe('ownSiteVerdict', () => {
 				['Énergie Solaire', 'https://xn--nergie-solaire-9jb.fr'],
 				['Instal·lacions Núñez', 'https://xn--installacionsnez-50a66h4e.es'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('established')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'established',
+				)
 			}
 		})
 
@@ -331,9 +386,13 @@ describe('ownSiteVerdict', () => {
 				'https://xn--nergie-solaire-9jb.fr/nos-realisations',
 				'https://www.xn--nergie-solaire-9jb.fr',
 			]) {
-				expect(ownSiteVerdict({ name: 'Énergie Solaire', website })).toBe(
-					'established',
-				)
+				expect(
+					ownSiteVerdict({
+						name: 'Énergie Solaire',
+						website,
+						tradeWords: noTrades,
+					}),
+				).toBe('established')
 			}
 		})
 
@@ -347,9 +406,13 @@ describe('ownSiteVerdict', () => {
 				'https://xn--nergie-solaire-9jb.fr',
 				'https://energie-solaire.fr',
 			]) {
-				expect(ownSiteVerdict({ name: 'Énergie Solaire', website })).toBe(
-					'established',
-				)
+				expect(
+					ownSiteVerdict({
+						name: 'Énergie Solaire',
+						website,
+						tradeWords: noTrades,
+					}),
+				).toBe('established')
 			}
 		})
 
@@ -363,6 +426,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Énergie Solaire',
 					website: 'https://xn--groupe-nergie-solaire-h5b.fr',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -381,6 +445,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Énergie Solaire',
 					website: 'https://xn--groupnergie-solaire-fzb.fr',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -394,6 +459,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Instalaciones Rubio',
 					website: 'https://xn--construccionsgarca-xyb.cat',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -409,6 +475,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Apple',
 					website: 'https://xn--80ak6aa92e.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -421,7 +488,11 @@ describe('ownSiteVerdict', () => {
 			// for the empty string a reader hands back — and an empty label would be
 			// no label at all
 			expect(
-				ownSiteVerdict({ name: 'Acme', website: 'https://xn--acme-9ta.com' }),
+				ownSiteVerdict({
+					name: 'Acme',
+					website: 'https://xn--acme-9ta.com',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -432,7 +503,11 @@ describe('ownSiteVerdict', () => {
 			// a plain label as an accented one, a reader also tries it as a machine
 			// address and hands back something longer than it was given
 			expect(
-				ownSiteVerdict({ name: 'Acme', website: 'http://192.168.1.10/acme' }),
+				ownSiteVerdict({
+					name: 'Acme',
+					website: 'http://192.168.1.10/acme',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 	})
@@ -453,7 +528,9 @@ describe('ownSiteVerdict', () => {
 				['PPVS Facility Management', 'https://ppvs-fm.com'],
 				['Energetique Sanitaire', 'https://esanit.fr'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('unknown')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'unknown',
+				)
 			}
 		})
 
@@ -466,6 +543,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Servicios Eléctricos y Montajes Industriales',
 					website: 'https://semi.es',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -489,7 +567,9 @@ describe('ownSiteVerdict', () => {
 				],
 				['Instalaciones Rubio', 'https://grupocobra.com'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('unknown')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'unknown',
+				)
 			}
 		})
 	})
@@ -505,6 +585,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://acme-directory.com/acme-logistics',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -520,6 +601,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Penske Logistics',
 					website: 'https://gopenske.com/logistics',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -533,7 +615,11 @@ describe('ownSiteVerdict', () => {
 			// whoever registered it rather than to every company called Grupo
 			// something
 			expect(
-				ownSiteVerdict({ name: 'Grupo Ferré', website: 'https://grupo.es' }),
+				ownSiteVerdict({
+					name: 'Grupo Ferré',
+					website: 'https://grupo.es',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -545,6 +631,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Grupo Ferré',
 					website: 'https://grupoferre.es',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -557,12 +644,17 @@ describe('ownSiteVerdict', () => {
 			// languages, so groupe.fr is no more the site of every firm called Groupe
 			// something than grupo.es is of every Grupo
 			expect(
-				ownSiteVerdict({ name: 'Grupo Ferré', website: 'https://grupo.es' }),
+				ownSiteVerdict({
+					name: 'Grupo Ferré',
+					website: 'https://grupo.es',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Groupe Roy Énergie',
 					website: 'https://groupe.fr',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -575,6 +667,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'CAHORS',
 					website: 'https://www.groupe-cahors.com/es-espana',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -587,8 +680,286 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Logistics Group',
 					website: 'https://logistics.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
+		})
+	})
+
+	describe('when the run names the trade a company is called after', () => {
+		it('should refuse the bare domain of that trade in every sector', () => {
+			// GIVEN one company shape — a trade and a family name — across the sectors
+			// a search can be launched for, each offered the bare domain of its own
+			// trade, and each judged inside a run that asked for that trade
+			// WHEN each is asked
+			// THEN none of them: a trade identifies nobody, so fontaneria.es belongs
+			// to whoever registered it rather than to every firm called Fontanería
+			// something. Nothing here is a word anybody wrote down — each run brought
+			// its own trade with it
+			for (const [asked, name, website] of [
+				['fontanería', 'Fontanería García', 'https://fontaneria.es'],
+				['instalaciones', 'Instalaciones García', 'https://instalaciones.es'],
+				['ascensor', 'Ascensores García', 'https://ascensores.com'],
+				['plomberie', 'Plomberie García', 'https://plomberie.fr'],
+				[
+					'construcciones',
+					'Construcciones García',
+					'https://construcciones.es',
+				],
+				['reformas', 'Reformas García', 'https://reformas.es'],
+				['panadería', 'Panadería García', 'https://panaderia.es'],
+				['restaurante', 'Restaurante García', 'https://restaurante.es'],
+				['abogados', 'Abogados García', 'https://abogados.es'],
+				['asesoría', 'Asesoría García', 'https://asesoria.es'],
+				['clínica', 'Clínica García', 'https://clinica.es'],
+				['farmacia', 'Farmacia García', 'https://farmacia.es'],
+				['ferretería', 'Ferretería García', 'https://ferreteria.es'],
+				['talleres', 'Talleres García', 'https://talleres.es'],
+			] as const) {
+				expect(
+					ownSiteVerdict({ name, website, tradeWords: tradeWordsOf([asked]) }),
+				).toBe('unknown')
+			}
+		})
+
+		it('should refuse it whichever end of the name the trade sits at', () => {
+			// GIVEN the same company written the two ways a name is written — trade
+			// first, as Spanish does, and trade last, as English does
+			// WHEN each is asked for the bare trade domain
+			// THEN neither. What settles it is which word names the trade, never
+			// where in the name it was written
+			for (const name of ['Fontanería García', 'García Fontanería']) {
+				expect(
+					ownSiteVerdict({
+						name,
+						website: 'https://fontaneria.es',
+						tradeWords: tradeWordsOf(['fontanería']),
+					}),
+				).toBe('unknown')
+			}
+		})
+
+		it("should still establish the domain carrying the company's own word", () => {
+			// GIVEN the same company at the domain that spells the word only it has,
+			// and at the one spelling its whole name
+			// WHEN each is asked
+			// THEN both are its own site. Reading the run's trade takes the trade
+			// away, never the company — which is what keeps this from costing every
+			// firm named after what it does its own address
+			for (const website of [
+				'https://garcia.es',
+				'https://fontaneriagarcia.es',
+			]) {
+				expect(
+					ownSiteVerdict({
+						name: 'Fontanería García',
+						website,
+						tradeWords: tradeWordsOf(['fontanería']),
+					}),
+				).toBe('established')
+			}
+		})
+
+		it("should read past the run's trade word written in front of a domain", () => {
+			// GIVEN a firm that wrote what it does before what it is called, where
+			// what it does is a trade this run asked for rather than a word for a
+			// kind of company
+			// WHEN asked
+			// THEN the word comes off and the company is underneath, exactly as it
+			// does for "grupo"
+			expect(
+				ownSiteVerdict({
+					name: 'García',
+					website: 'https://fontaneriagarcia.es',
+					tradeWords: tradeWordsOf(['fontanería']),
+				}),
+			).toBe('established')
+		})
+
+		it('should cut a domain at the word the request wrote and no deeper', () => {
+			// GIVEN a domain whose trade word is followed by the company name, so the
+			// trade plus that name's first letter reads as the trade with an ending
+			// WHEN asked
+			// THEN the company is still found. The front of a domain is cut only at a
+			// word the request actually wrote, so the ending that reaches
+			// "fontanerías" in a NAME cannot eat into the name behind a domain
+			expect(
+				ownSiteVerdict({
+					name: 'García',
+					website: 'https://fontaneriagarcia.es',
+					tradeWords: tradeWordsOf(['fontanería', 'ascensor']),
+				}),
+			).toBe('established')
+		})
+
+		it('should not take a joining word off the front of a domain', () => {
+			// GIVEN a request naming its trades in phrases, which carry the little
+			// words that join them — "fontanería y climatización" — so those are words
+			// the run asked for like any other
+			// AND a stranger's domain that happens to open with one of them
+			// WHEN asked
+			// THEN unknown. A word that short in front of a domain says nothing about
+			// what a firm does, and taking it off would cut the label one letter in
+			// and hand Talia a domain somebody else registered
+			const asked = tradeWordsOf([
+				'fontanería y climatización',
+				'instalación de gas',
+			])
+			for (const [name, website] of [
+				['Talia', 'https://detalia.com'],
+				['Acme', 'https://yacme.com'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website, tradeWords: asked })).toBe(
+					'unknown',
+				)
+			}
+		})
+
+		it("should establish nothing for a name that is only the run's trades", () => {
+			// GIVEN a name with nothing in it but what the company does, in a run
+			// that asked for exactly that
+			// WHEN asked — THEN there is no company left to look for, so no domain
+			// can spell one
+			expect(
+				ownSiteVerdict({
+					name: 'Instalaciones Eléctricas',
+					website: 'https://instalacioneselectricas.es',
+					tradeWords: tradeWordsOf(['instalación eléctrica']),
+				}),
+			).toBe('unknown')
+		})
+
+		it('should not let a joining word stand for a company', () => {
+			// GIVEN a firm a market search met whose name is nothing but its trade and
+			// the word joining two halves of it, at the bare domain of that trade
+			// WHEN asked with the trades that run went looking for
+			// THEN unknown. Without this the two letters of "et" are the one word of
+			// the name left standing as the company's own, and the firm is handed the
+			// domain of its whole trade
+			expect(
+				ownSiteVerdict({
+					name: 'Services et installations électriques',
+					website: 'https://services-et-installations-electriques.com',
+					tradeWords: tradeWordsOf(['installations électriques']),
+				}),
+			).toBe('unknown')
+		})
+
+		it('should still keep the two letters a firm calls itself by', () => {
+			// GIVEN firms a market search met whose own name is an initialism of two
+			// letters, beside a word the same run asked for
+			// WHEN each is asked
+			// THEN each is at home on its own domain. Two letters can be a company's
+			// name, which is why what settles a joining word is the word itself and
+			// never how short it is
+			for (const [name, website] of [
+				['VS ENERGY', 'https://vsenergy.fr'],
+				['TK Elevator', 'http://tkelevator.fr/'],
+				['Plomberie DS', 'https://www.plomberie-ds.fr/'],
+			] as const) {
+				expect(
+					ownSiteVerdict({
+						name,
+						website,
+						tradeWords: tradeWordsOf([
+							'solar energy',
+							'plomberie et chauffage',
+							'ascenseurs',
+						]),
+					}),
+				).toBe('established')
+			}
+		})
+
+		it('should keep a coined name that merely opens with a trade word', () => {
+			// GIVEN two firms a market search met whose names open with the trade the
+			// run asked for and then carry on
+			// WHEN each is asked
+			// THEN each is at home on its own domain. Reading those as the trade
+			// would leave them with no word of their own and take away a real site
+			for (const [name, website] of [
+				['Solarock', 'https://solarock.fr'],
+				['Solartec Group', 'https://solartecgroup.com'],
+			] as const) {
+				expect(
+					ownSiteVerdict({
+						name,
+						website,
+						tradeWords: tradeWordsOf(['energía solar', 'solar energy']),
+					}),
+				).toBe('established')
+			}
+		})
+
+		it('should refuse the trade in both spellings of a geminated l', () => {
+			// GIVEN a Catalan trade, which is written two ways, and the bare domain of
+			// each spelling
+			// WHEN each is asked
+			// THEN neither, whichever way the request wrote it. A request matched
+			// against one spelling only would leave the other looking like a word of
+			// the company's own
+			for (const website of [
+				'https://installacions.cat',
+				'https://instalacions.cat',
+			]) {
+				expect(
+					ownSiteVerdict({
+						name: 'Instal·lacions Vives',
+						website,
+						tradeWords: tradeWordsOf(['instal·lacions elèctriques']),
+					}),
+				).toBe('unknown')
+			}
+		})
+
+		it('should leave alone a company whose trade the run never named', () => {
+			// GIVEN a firm whose trade this run never asked about, met on the same
+			// list as the ones it did
+			// WHEN asked — THEN its own name still spells its domain: the run's
+			// trades take words away, and a word the run never named is not one
+			expect(
+				ownSiteVerdict({
+					name: 'Panadería García',
+					website: 'https://panaderia-garcia.es',
+					tradeWords: tradeWordsOf(['fontanería']),
+				}),
+			).toBe('established')
+		})
+	})
+
+	describe('when the run names no trades', () => {
+		it('should still refuse a word for a kind of company', () => {
+			// GIVEN a run about one company on file, which brings no trades with it
+			// WHEN the bare domain of a word for a kind of company is asked
+			// THEN unknown still: those words come from the short shared list, which
+			// works for anybody in any market and needs no run behind it
+			for (const [name, website] of [
+				['Grupo Ferré', 'https://grupo.es'],
+				['Groupe Roy Énergie', 'https://groupe.fr'],
+				['Servicios García', 'https://servicios.es'],
+				['Consulting García', 'https://consulting.es'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'unknown',
+				)
+			}
+		})
+
+		it('should leave a trade the shared list never held', () => {
+			// GIVEN the same shape in a trade the list does not carry, with no run to
+			// read one from
+			// WHEN asked
+			// THEN it clears, and that is the known cost rather than an oversight:
+			// with nothing naming the trade, no reading of the address tells
+			// "Fontanería" from "García". What closes it is a run with a market
+			// behind it, which is every run that can meet this shape on a list
+			expect(
+				ownSiteVerdict({
+					name: 'Fontanería García',
+					website: 'https://fontaneria.es',
+					tradeWords: noTrades,
+				}),
+			).toBe('established')
 		})
 	})
 
@@ -601,6 +972,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Redwood Logistics',
 					website: 'https://cbinsights.com/company/redwood-logistics',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -617,6 +989,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'LIPOTECH SARL',
 					website: 'https://www.facebook.com/LIPOTECH.SARL',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -629,6 +1002,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'KBE Energy',
 					website: 'https://annuaire.tecsol.fr',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -642,6 +1016,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'KBE Energy',
 					website: 'https://annuaire.fr/energy-installateurs-12345',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -652,7 +1027,11 @@ describe('ownSiteVerdict', () => {
 			// WHEN asked — THEN unknown, and neither the page nor anything the row
 			// cites could change that, since neither is read
 			expect(
-				ownSiteVerdict({ name: 'KBE Energy', website: TECSOL_LISTING }),
+				ownSiteVerdict({
+					name: 'KBE Energy',
+					website: TECSOL_LISTING,
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 	})
@@ -670,10 +1049,18 @@ describe('ownSiteVerdict', () => {
 			// domain could be cleared by, and a run that does not know the company's
 			// name cannot say whose site anything is
 			expect(
-				ownSiteVerdict({ name: question, website: 'https://fontaneria.es' }),
+				ownSiteVerdict({
+					name: question,
+					website: 'https://fontaneria.es',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 			expect(
-				ownSiteVerdict({ name: question, website: 'https://empresas.es' }),
+				ownSiteVerdict({
+					name: question,
+					website: 'https://empresas.es',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -685,6 +1072,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Sociedad Española de Montajes Industriales SA',
 					website: 'https://sociedadespanola.es',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -696,7 +1084,11 @@ describe('ownSiteVerdict', () => {
 			// WHEN asked — THEN one letter is an initial rather than a name, and a
 			// domain that short belongs to whoever paid for it
 			expect(
-				ownSiteVerdict({ name: 'A. Martín', website: 'https://a.com' }),
+				ownSiteVerdict({
+					name: 'A. Martín',
+					website: 'https://a.com',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -704,7 +1096,11 @@ describe('ownSiteVerdict', () => {
 			// GIVEN the shortest domain a real company here is at
 			// WHEN asked — THEN three letters stand, so the floor cannot be raised
 			expect(
-				ownSiteVerdict({ name: 'Fer Corporation', website: 'https://fer.org' }),
+				ownSiteVerdict({
+					name: 'Fer Corporation',
+					website: 'https://fer.org',
+					tradeWords: noTrades,
+				}),
 			).toBe('established')
 		})
 	})
@@ -721,6 +1117,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Sociedad Española de Montajes Industriales SA (SEMI)',
 					website: 'https://www.semi-sa.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -732,17 +1129,25 @@ describe('ownSiteVerdict', () => {
 			// a target the run was never told the name of
 			// WHEN asked — THEN unknown rather than missing: a run with no name
 			// establishes nothing, which is an answer
-			expect(ownSiteVerdict({ name: '', website: 'https://acme.com' })).toBe(
-				'unknown',
-			)
+			expect(
+				ownSiteVerdict({
+					name: '',
+					website: 'https://acme.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
 		})
 
 		it('should not establish anything for a name that is only a legal form', () => {
 			// GIVEN a row whose whole name is the form
 			// WHEN asked — THEN the form is taken out and nothing is left to look for
-			expect(ownSiteVerdict({ name: 'S.L.', website: 'https://sl.com' })).toBe(
-				'unknown',
-			)
+			expect(
+				ownSiteVerdict({
+					name: 'S.L.',
+					website: 'https://sl.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
 		})
 
 		it('should not establish a value with words written beside the address', () => {
@@ -754,6 +1159,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'ADIME',
 					website: 'https://adime.org/ (not directly provided, inferred)',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -762,7 +1168,9 @@ describe('ownSiteVerdict', () => {
 			// GIVEN values no reader could open
 			// WHEN asked — THEN each is unknown
 			for (const website of ['not a url', '', 'info@acme.es', 'src_9f2a1b3c']) {
-				expect(ownSiteVerdict({ name: 'Acme', website })).toBe('unknown')
+				expect(
+					ownSiteVerdict({ name: 'Acme', website, tradeWords: noTrades }),
+				).toBe('unknown')
 			}
 		})
 
@@ -770,7 +1178,11 @@ describe('ownSiteVerdict', () => {
 			// GIVEN a site given by its address on the network rather than by name
 			// WHEN asked — THEN nothing in the numbers spells a company
 			expect(
-				ownSiteVerdict({ name: 'Acme', website: 'http://192.168.1.10/acme' }),
+				ownSiteVerdict({
+					name: 'Acme',
+					website: 'http://192.168.1.10/acme',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 	})
@@ -782,12 +1194,20 @@ describe('ownSiteVerdict', () => {
 			// THEN the domain answers for its own company and for nobody else, so a
 			// row handed somebody else's site gets no clearance from it
 			const website = 'https://acme.com/quienes-somos'
-			expect(ownSiteVerdict({ name: 'Acme Logistics', website })).toBe(
-				'established',
-			)
-			expect(ownSiteVerdict({ name: 'Instalaciones Rubio', website })).toBe(
-				'unknown',
-			)
+			expect(
+				ownSiteVerdict({
+					name: 'Acme Logistics',
+					website,
+					tradeWords: noTrades,
+				}),
+			).toBe('established')
+			expect(
+				ownSiteVerdict({
+					name: 'Instalaciones Rubio',
+					website,
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
 		})
 	})
 
@@ -802,7 +1222,11 @@ describe('ownSiteVerdict', () => {
 				'https://instalacionsvives.cat/contacte',
 			]) {
 				expect(
-					ownSiteVerdict({ name: 'Instal·lacions Vives SL', website }),
+					ownSiteVerdict({
+						name: 'Instal·lacions Vives SL',
+						website,
+						tradeWords: noTrades,
+					}),
 				).toBe('established')
 			}
 		})
@@ -817,12 +1241,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Vila Nova SL',
 					website: 'https://villanova.cat',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Villa Nova SL',
 					website: 'https://vilanova.cat',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -844,7 +1270,9 @@ describe('ownSiteVerdict', () => {
 				['Þór Raflagnir', 'https://thor-raflagnir.is'],
 				['Işık Elektrik', 'https://isik-elektrik.com.tr'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('established')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'established',
+				)
 			}
 		})
 
@@ -858,9 +1286,13 @@ describe('ownSiteVerdict', () => {
 				'https://muller-elektro.de',
 				'https://mueller-elektro.de',
 			]) {
-				expect(ownSiteVerdict({ name: 'Müller Elektro GmbH', website })).toBe(
-					'established',
-				)
+				expect(
+					ownSiteVerdict({
+						name: 'Müller Elektro GmbH',
+						website,
+						tradeWords: noTrades,
+					}),
+				).toBe('established')
 			}
 		})
 
@@ -876,7 +1308,9 @@ describe('ownSiteVerdict', () => {
 				['Rose GmbH', 'https://rosse.de'],
 				['Sander AS', 'https://sonder.no'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website })).toBe('unknown')
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					'unknown',
+				)
 			}
 		})
 	})
@@ -893,12 +1327,14 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'D-Sécurité (groupe)',
 					host: 'd-securite.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 			expect(
 				ownSiteHostVerdict({
 					name: 'D-Sécurité Incendie',
 					host: 'd-securite.com',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})
@@ -908,7 +1344,11 @@ describe('ownSiteHostVerdict', () => {
 			// WHEN asked
 			// THEN the label has to BE the name, never merely contain it
 			expect(
-				ownSiteHostVerdict({ name: 'Acme', host: 'acme-directorio.example' }),
+				ownSiteHostVerdict({
+					name: 'Acme',
+					host: 'acme-directorio.example',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -917,7 +1357,11 @@ describe('ownSiteHostVerdict', () => {
 			// WHEN asked
 			// THEN there is no word of its own for a domain to spell
 			expect(
-				ownSiteHostVerdict({ name: 'Grupo Express SL', host: 'grupo.example' }),
+				ownSiteHostVerdict({
+					name: 'Grupo Express SL',
+					host: 'grupo.example',
+					tradeWords: noTrades,
+				}),
 			).toBe('unknown')
 		})
 
@@ -925,7 +1369,13 @@ describe('ownSiteHostVerdict', () => {
 			// GIVEN a run with no company name
 			// WHEN asked
 			// THEN an empty name must not be spelled by every host there is
-			expect(ownSiteHostVerdict({ name: '', host: 'acme.com' })).toBe('unknown')
+			expect(
+				ownSiteHostVerdict({
+					name: '',
+					host: 'acme.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
 		})
 
 		it('should read an accented host the same way an address is read', () => {
@@ -938,12 +1388,14 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'Énergie Solaire',
 					host: 'xn--nergie-solaire-9jb.fr',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 			expect(
 				ownSiteHostVerdict({
 					name: 'Instalaciones Rubio',
 					host: 'xn--nergie-solaire-9jb.fr',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 		})
@@ -962,8 +1414,8 @@ describe('ownSiteHostVerdict', () => {
 				'https://www.fusteriamiquel.cat/qui-som',
 				'https://fusteriamiquel.cat/obra/2024/cuina',
 			]) {
-				expect(ownSiteVerdict({ name, website })).toBe(
-					ownSiteHostVerdict({ name, host }),
+				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+					ownSiteHostVerdict({ name, host, tradeWords: noTrades }),
 				)
 			}
 		})
@@ -977,12 +1429,14 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteVerdict({
 					name: 'Fusteria Miquel',
 					website: 'https://fusteriamiquel.cat/ (inferred from the name)',
+					tradeWords: noTrades,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteHostVerdict({
 					name: 'Fusteria Miquel',
 					host: 'fusteriamiquel.cat',
+					tradeWords: noTrades,
 				}),
 			).toBe('established')
 		})

--- a/packages/research/src/application/own-site.ts
+++ b/packages/research/src/application/own-site.ts
@@ -34,6 +34,37 @@
  * travels in a code that spells nothing, which `hostLabel` puts back into the
  * letters its owner registered before any of this reads it.
  *
+ * ## Which words identify nobody
+ *
+ * A company named after its trade is not identified by the trade: fontaneria.es
+ * belongs to whoever registered it, not to every firm called Fontanería
+ * something. So a word that names a trade is worth nothing here, whichever end
+ * of the name it sits at, and everything below turns on which words those are.
+ *
+ * Two answers, asked in that order. A word that names a KIND of company — group,
+ * holding, servicios — comes from the short list `entity-guard.ts` shares; those
+ * work for anybody in any market, so no run has to bring them. A word that names
+ * a TRADE comes from the run itself: it was launched for a market and its
+ * request names the trades it wants, which is that market's own vocabulary in
+ * the languages that market answers in (`trade-words.ts`).
+ *
+ * Reading the run is what makes this sector-agnostic. A list can only ever do
+ * the first job: whichever trades somebody writes down are identified, and every
+ * other trade in every other language reads as a word of a company's own name.
+ * The shared one carries freight's vocabulary, so on its own it would hand the
+ * bare trade domain of plumbers, builders, bakers, lawyers, clinics, shops and
+ * workshops to whichever firm is named after it. No amount of filling in
+ * finishes that, and each word filled in takes a real distinctive word away from
+ * the firms genuinely called it.
+ *
+ * What the list still carries is one industry's words, which the run answers for
+ * as well. They stay because a run about ONE COMPANY ON FILE names no trades at
+ * all: there is nothing to read, and dropping them would hand transportes.com
+ * back to every firm called Transportes something — the failure this file exists
+ * to prevent, reappearing in the one market the list is right about. They go
+ * when a run with no market behind it has some other way to say what a company
+ * does, and not before.
+ *
  * ## What deliberately does NOT establish it
  *
  * **The path.** "facebook.com/Some-Company" and "xpo.com/about-xpo-logistics"
@@ -74,6 +105,19 @@
  * decision; what it loses is standing as the source that vouches for the
  * company. That is a withholding, and withholding is the direction this file is
  * allowed to be wrong in.
+ *
+ * Reading the run's trades costs the same way, and was measured before it was
+ * paid for: over 159 rows with a website that eight market searches returned, it
+ * changed exactly one answer, and that one was a domain spelling nothing but a
+ * trade being taken away from a company named after it. A firm that really did
+ * register its trade's bare domain reads `unknown` — it is refused with the rest
+ * of its trade, since no reading of the address can tell it apart from them.
+ *
+ * The same measurement prices the reading in the other direction. A word the
+ * request wrote comes off the front of a domain as a word for a kind of company
+ * does, which is one more way to reach a name and so one more way to reach the
+ * wrong one; over those 159 rows it cleared nothing the rest of the reading did
+ * not already clear.
  *
  * ## The shortening that was measured and refused
  *
@@ -120,10 +164,11 @@
  * Every rule here that lets more addresses through is a new way to clear a
  * stranger's address, so each is bought one at a time against rows a run
  * actually met, and each keeps its own list of what it still cannot clear.
- * A trade word may be read past because the words come from the list the checks
- * already share and cannot be invented for a case; an initialism may not,
- * because nothing bounds who else spells it. Measure the cost before paying it,
- * and take the withholding when the measurement does not settle it.
+ * A trade word may be read past because the words come from what the run asked
+ * for and the list it shares, neither of which can be invented for a case; an
+ * initialism may not, because nothing bounds who else spells it. Measure the
+ * cost before paying it, and take the withholding when the measurement does not
+ * settle it.
  *
  * Whether the host is a business directory is a separate question with a
  * separate answer (`directory-sites.ts`), and a caller weighing a company's
@@ -174,6 +219,7 @@ import {
 	withoutFormDots,
 } from './entity-guard'
 import { hostOf, isBareWebAddress } from './source-key'
+import { namesATrade, type TradeWords, wasAskedForExactly } from './trade-words'
 
 /**
  * What is known about a company's website. `unknown` is not "cleared". Spelled
@@ -198,6 +244,28 @@ const MOST_WORDS_A_NAME_RUNS_TO = 8
 // belongs to whoever paid for it regardless of whose initials it matches.
 const SHORTEST_NAME_A_DOMAIN_SPELLS = 3
 
+// The words that join two halves of a name rather than being any of it — "Cobra
+// Instalaciones Y Servicios", "Services ET installations électriques". Written
+// out because a name made of nothing but its trade still carries one of these,
+// and a joining word left standing as the company's own hands that firm the bare
+// domain of its own trade: the failure this reading exists to prevent, walking in
+// behind a word nobody would call a name.
+//
+// Safe to write down where a trade is not, because these are the whole of a
+// closed class a language barely adds to, and no company is identified by one —
+// unlike the two letters a firm really does call itself by ("VS Energy" at
+// vsenergy.fr), which is why the length of a word settles nothing here.
+const JOINS_TWO_HALVES_OF_A_NAME = new Set([
+	'de',
+	'del',
+	'y',
+	'i',
+	'e',
+	'et',
+	'and',
+	'und',
+])
+
 // Every name a company's own domain could plausibly be registered under: the
 // whole name and each shorter run of its words from the front — "XPO Logistics"
 // gives "xpo" and "xpologistics". Front-anchored, because a firm shortens its
@@ -206,6 +274,7 @@ const SHORTEST_NAME_A_DOMAIN_SPELLS = 3
 // word of the name clear itself.
 const namesTheDomainCouldCarry = (
 	words: ReadonlyArray<string>,
+	identifiesNobody: (word: string) => boolean,
 ): ReadonlyArray<string> => {
 	const runs: Array<string> = []
 	let run = ''
@@ -216,7 +285,9 @@ const namesTheDomainCouldCarry = (
 		// "Grupo Ferré" must not be at home on grupo.es and "Transportes García"
 		// not on transportes.com. Once a word of the company's own has arrived,
 		// every longer run carries it.
-		identifiesSomebody = identifiesSomebody || !isGenericWord(word)
+		identifiesSomebody =
+			identifiesSomebody ||
+			(!identifiesNobody(word) && !JOINS_TWO_HALVES_OF_A_NAME.has(word))
 		if (identifiesSomebody && run.length >= SHORTEST_NAME_A_DOMAIN_SPELLS) {
 			runs.push(run)
 		}
@@ -228,13 +299,16 @@ const namesTheDomainCouldCarry = (
 // when it opens with none. A firm often writes what it does in front of what it
 // is called, and grupocobra.com is Cobra's.
 //
-// One word, and only a word the shared trade list already holds, so a run may not
+// One word, and only a word already known to identify nobody, so a run may not
 // invent one to reach a name with — "gopenske.com" keeps its "go", because "go"
 // names no trade. A label keeps no spaces to say where its first word ends, so
-// the LONGEST trade word it opens with is the one taken off: several of the
-// shared words are the stem of another — "transporte" of "transportes" — and
-// cutting at every one of them would read "transportesacme" from after the stem
-// as well, handing a firm called Sacme a domain that says Acme.
+// the LONGEST such word it opens with is the one taken off: one of them is often
+// the stem of another — "transporte" of "transportes" — and cutting at every one
+// of them would read "transportesacme" from after the stem as well, handing a
+// firm called Sacme a domain that says Acme. The price is that a label whose
+// longest such word leaves too little behind gives up rather than trying the
+// shorter one underneath, and a run brings far more of these words than the
+// shared list holds — so it is a withholding that grows with the vocabulary.
 //
 // What is left has to be long enough to stand for somebody. Three letters are a
 // whole label's worth of evidence when a firm registered exactly them
@@ -242,9 +316,30 @@ const namesTheDomainCouldCarry = (
 // coincidence `DISTINCTIVE_NAME_LENGTH` exists to price: without the floor
 // "grupoacs.com" answers for every firm called ACS and groupama.fr for every one
 // called AMA.
-const withoutLeadingTradeWord = (label: string): string | null => {
-	for (let taken = label.length - 1; taken > 0; taken--) {
-		if (!isGenericWord(label.slice(0, taken))) continue
+//
+// The word taken off needs a floor of its own, because a request names its trades
+// in phrases and a phrase carries the little words that join it — "fontanería Y
+// climatización", "instalación DE gas" — which are then words the run asked for
+// like any other. One of those in front of a domain says nothing about what a
+// firm does, and letting it come off cuts a stranger's label one or two letters
+// in: detalia.com would be Talia's and yacme.com would be Acme's.
+//
+// Set above them rather than at the shortest word for a trade, which costs a
+// three-letter one: a run asking about "gas" never reads past the "gas" in
+// gasgarcia.es. That is a withholding, and it buys a floor no joining word in
+// the languages these markets answer in can reach over.
+const SHORTEST_WORD_A_DOMAIN_WRITES_IN_FRONT = 4
+
+const withoutLeadingTradeWord = (
+	label: string,
+	identifiesNobody: (word: string) => boolean,
+): string | null => {
+	for (
+		let taken = label.length - 1;
+		taken >= SHORTEST_WORD_A_DOMAIN_WRITES_IN_FRONT;
+		taken--
+	) {
+		if (!identifiesNobody(label.slice(0, taken))) continue
 		const rest = label.slice(taken)
 		return rest.length >= DISTINCTIVE_NAME_LENGTH ? rest : null
 	}
@@ -261,12 +356,33 @@ const withoutLeadingTradeWord = (label: string): string | null => {
  * somebody writing about it. A trade word in front of the name is read past, on
  * the terms `withoutLeadingTradeWord` sets.
  */
-const hostSpellsTheCompany = (name: string, host: string): boolean => {
+const hostSpellsTheCompany = (
+	name: string,
+	host: string,
+	tradeWords: TradeWords,
+): boolean => {
+	// A word identifies nobody when it names a kind of company — the shared list —
+	// or a trade this run went looking for.
+	const identifiesNobody = (word: string): boolean =>
+		isGenericWord(word) || namesATrade(word, tradeWords)
+	// The word in front of a domain is judged more strictly than a word of a name:
+	// the request has to have written it exactly. A label says nowhere where its
+	// first word ends, so a reading that allowed an ending would cut into the name
+	// behind it — see `wasAskedForExactly`.
+	const identifiesNobodyAsWritten = (word: string): boolean =>
+		isGenericWord(word) || wasAskedForExactly(word, tradeWords)
+
 	const label = collapse(hostLabel(host))
-	const pastTheTrade = withoutLeadingTradeWord(label)
+	const pastTheTrade = withoutLeadingTradeWord(label, identifiesNobodyAsWritten)
 	// The distinctive words are read off the name itself, which already offers
-	// each of them in every spelling.
-	const words = distinctiveWords(name)
+	// each of them in every spelling. The trade the run asked about comes out of
+	// them here rather than in `entity-guard.ts`, because a word that identifies
+	// nobody is still a word a page naming the company may write, and the guard
+	// that reads pages needs it — this is the one reading where a word standing
+	// alone is spent claiming a domain.
+	const words = distinctiveWords(name).filter(
+		word => !namesATrade(word, tradeWords),
+	)
 	// Every spelling of the name, since a domain writes a Catalan geminate l
 	// whichever way its owner chose and both are the same company's. The dots of a
 	// legal form come out after the spellings are read, never before, or a name
@@ -275,7 +391,7 @@ const hostSpellsTheCompany = (name: string, host: string): boolean => {
 		const spelled = nameWordsWithoutForms(withoutFormDots(spelling))
 		// A brief rather than a name, which no spelling of it can rescue.
 		if (spelled.length > MOST_WORDS_A_NAME_RUNS_TO) return false
-		const couldCarry = namesTheDomainCouldCarry(spelled)
+		const couldCarry = namesTheDomainCouldCarry(spelled, identifiesNobody)
 		if (labelSpellsOneOf(label, [...couldCarry, ...words])) return true
 		// Past a trade word, only the front of the name is read, never one word
 		// taken from the middle of it. The label has already spent its own front on
@@ -297,8 +413,11 @@ const hostSpellsTheCompany = (name: string, host: string): boolean => {
 export const ownSiteHostVerdict = (args: {
 	readonly name: string
 	readonly host: string
+	readonly tradeWords: TradeWords
 }): OwnSiteVerdict =>
-	hostSpellsTheCompany(args.name, args.host) ? 'established' : 'unknown'
+	hostSpellsTheCompany(args.name, args.host, args.tradeWords)
+		? 'established'
+		: 'unknown'
 
 /**
  * Whether this website is established as the company's own site.
@@ -307,17 +426,24 @@ export const ownSiteHostVerdict = (args: {
  * scanned company, and the company the run is about for the one `website` field
  * that arrives with no name beside it. A run with no name to compare establishes
  * nothing, which is the right answer rather than a missing one.
+ *
+ * `tradeWords` is what the run itself went looking for (`trade-words.ts`). Asked
+ * for rather than reached from here, and asked for on every call rather than
+ * defaulted to none, because a caller that quietly left it out would judge the
+ * same address by a different reading from the rest of the run — and would clear
+ * the addresses this exists to refuse.
  */
 export const ownSiteVerdict = (args: {
 	readonly name: string
 	readonly website: string
+	readonly tradeWords: TradeWords
 }): OwnSiteVerdict => {
-	const { name, website } = args
+	const { name, website, tradeWords } = args
 	// A value with words written next to it is not one address, so there is no
 	// domain to read — and a reader cannot open it either.
 	if (!isBareWebAddress(website)) return 'unknown'
 	const host = hostOf(website)
 	if (host === null) return 'unknown'
 
-	return ownSiteHostVerdict({ name, host })
+	return ownSiteHostVerdict({ name, host, tradeWords })
 }

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -13,6 +13,10 @@ import {
 } from './per-field-search'
 import { CompetitorScanV1Schema } from './schemas/competitor-scan-v1'
 import { ProspectScanV1Schema } from './schemas/prospect-scan-v1'
+import { tradeWordsOf } from './trade-words'
+
+// A run that named no trades, which is a request about one company on file.
+const noTrades = tradeWordsOf([])
 
 // A per-field-citation value the way the enrichment schema stores one.
 const sourced = (value: string) => ({ value, source_id: 'https://x.test' })
@@ -313,6 +317,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
+				noTrades,
 			)
 			// THEN the empty country is filled but the grounded industry is untouched
 			expect(filled).toBe(1)
@@ -333,7 +338,7 @@ describe('mergePerFieldSearch', () => {
 				findings: next,
 				filled,
 				added,
-			} = mergePerFieldSearch(findings, {}, PROFILE)
+			} = mergePerFieldSearch(findings, {}, PROFILE, noTrades)
 			// THEN nothing is filled and the same findings come back
 			expect(filled).toBe(0)
 			expect(added).toBe(0)
@@ -362,6 +367,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
+				noTrades,
 			)
 
 			// THEN the second person is kept, the first not duplicated
@@ -387,6 +393,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
+				noTrades,
 			)
 			expect(contactsChanged).toBe(false)
 			expect(next).toBe(findings)
@@ -409,6 +416,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
+				noTrades,
 			)
 
 			// THEN the title is kept, even though the list is exactly as long as it
@@ -448,7 +456,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN each recovered value lands on the company it belongs to, the
@@ -480,7 +488,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'acme sl', website: 'https://acme.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN one company stays one company, keeping the name first written
 			expect(rows).toHaveLength(1)
@@ -509,7 +517,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN it is one company that gained a site and a place, not two rows. A
@@ -539,7 +547,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN the shared site settles it, as it does for the fold that runs over
@@ -559,7 +567,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN it is still one company — most of the market this searches writes
 			// names with accents, and matching on the letters alone would have listed
@@ -577,7 +585,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme Holding', website: 'https://holding.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN Acme keeps its blank rather than inheriting another company's site,
 			// and the other company is listed in its own right — a duplicate is a far
@@ -602,7 +610,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN one company, keeping the town the branch brought. The fold that runs
 			// before these rounds cannot see a company found after it, so a round that
@@ -630,7 +638,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN the shared host settles it here too, because the domain says whose it
 			// is. A row appended by a round is never put in front of the fold again
@@ -651,7 +659,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Terre Solaire Energie', location: 'Nantes' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN both are listed and the round is credited with the find — sharing an
 			// opening word is not being somebody's branch
@@ -680,7 +688,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN the list holds the one company and the new one, and the round is
 			// credited with the find. Counting the length instead would read nothing
@@ -699,7 +707,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN it joins the list once — the list's length decides whether a scan
 			// came back too thin to trust, so counting one company twice would pass a
@@ -718,7 +726,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 			// THEN one of them is taken and the fold stays stable, with no duplicate
 			// appended for the company already known
@@ -734,7 +742,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme', website: 'https://acme.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			// THEN the wider read's find is kept — an empty list is exactly the one
 			// with the most to gain from looking again
 			expect(prospectsOf(merged.findings).map(row => row['name'])).toEqual([
@@ -750,7 +758,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ website: 'https://nameless.test' }, { name: '  ' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			// THEN nothing is appended, since a company with no name cannot be worked
 			// with or told apart from another
 			expect(merged.added).toBe(0)
@@ -775,7 +783,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN both companies ship. The domain spells neither of them, so it is
@@ -812,7 +820,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 
 			// THEN one company, and the fold says it joined a row — a real fold, for
 			// the good reason that the site now says the two rows are one company
@@ -844,6 +852,7 @@ describe('mergePerFieldSearch', () => {
 					findings,
 					{ prospects: [found] },
 					SCAN,
+					noTrades,
 				).findings
 			}
 
@@ -876,7 +885,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN one company, which gained the town the round found. Who owns the
@@ -908,7 +917,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 
 			// THEN nothing is reported as joined. The rows met by name, which is the
 			// reason the rounds run at all — counting those would bury the one join
@@ -931,7 +940,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN two rows, because nothing yet ties the two names together: the listed
@@ -954,7 +963,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Beta', website: 'https://beta.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			// THEN a second look only ever adds — it never shortens the list
 			expect(prospectsOf(merged.findings).map(row => row['name'])).toEqual([
 				'Acme',
@@ -971,7 +980,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme', website: 'https://other.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			// THEN the very same findings come back, which is what stops the rounds
 			expect(merged.findings).toBe(findings)
 			expect(merged.filled).toBe(0)
@@ -983,8 +992,12 @@ describe('mergePerFieldSearch', () => {
 			const refreshed = { prospects: [{ name: 'Acme' }] }
 			// WHEN merged
 			// THEN nothing is invented around them
-			expect(mergePerFieldSearch(null, refreshed, SCAN).findings).toBe(null)
-			expect(mergePerFieldSearch('x', refreshed, SCAN).findings).toBe('x')
+			expect(
+				mergePerFieldSearch(null, refreshed, SCAN, noTrades).findings,
+			).toBe(null)
+			expect(mergePerFieldSearch('x', refreshed, SCAN, noTrades).findings).toBe(
+				'x',
+			)
 		})
 
 		it('should leave the findings alone when the second look holds no list', () => {
@@ -992,8 +1005,12 @@ describe('mergePerFieldSearch', () => {
 			const findings = { prospects: [{ name: 'Acme' }] }
 			// WHEN merged
 			// THEN the list is untouched
-			expect(mergePerFieldSearch(findings, {}, SCAN).findings).toBe(findings)
-			expect(mergePerFieldSearch(findings, null, SCAN).findings).toBe(findings)
+			expect(mergePerFieldSearch(findings, {}, SCAN, noTrades).findings).toBe(
+				findings,
+			)
+			expect(mergePerFieldSearch(findings, null, SCAN, noTrades).findings).toBe(
+				findings,
+			)
 		})
 
 		it('should carry the rest of the findings across untouched', () => {
@@ -1006,7 +1023,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme', website: 'https://acme.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
 			// THEN everything beside the list survives the fold
 			expect(
 				(merged.findings as { pending_paid_actions: unknown })

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -30,6 +30,7 @@ import {
 	hostsEstablishedAsOwn,
 	isSiteKey,
 } from './prospect-dedupe-guard'
+import type { TradeWords } from './trade-words'
 
 // The company-profile facts worth spending an extra search on. `size_range` is
 // also nudged during the loop (headcount is rarely on the homepage); for the
@@ -261,6 +262,7 @@ const mergeScanRows = (
 	schemaName: string,
 	findings: unknown,
 	refreshed: unknown,
+	tradeWords: TradeWords,
 ): PerFieldMerge => {
 	const field = discoveryResultField(schemaName)
 	const known = scanRowsOf(schemaName, findings)
@@ -287,7 +289,7 @@ const mergeScanRows = (
 	// under a name that does not spell its domain while the list already holds it
 	// under one that does — and asking each side on its own would leave the site
 	// speaking for the row that has it and silent for the row that needs it.
-	const ownSiteHosts = hostsEstablishedAsOwn([...known, ...found])
+	const ownSiteHosts = hostsEstablishedAsOwn([...known, ...found], tradeWords)
 	const foundByKey = new Map<string, Record<string, unknown>>()
 	for (const row of found) {
 		// First mention wins: a later duplicate of the same company in the same
@@ -359,14 +361,18 @@ const mergeScanRows = (
 	// the list is the step that settles it, so nothing later has to remember to.
 	const settle = (rows: ReadonlyArray<unknown>): number | undefined => {
 		const held = (
-			dedupeDiscoveryRows({ ...(findings as object), [field]: rows }, field)
-				.findings as Record<string, unknown>
+			dedupeDiscoveryRows(
+				{ ...(findings as object), [field]: rows },
+				field,
+				tradeWords,
+			).findings as Record<string, unknown>
 		)[field]
 		return Array.isArray(held) ? held.length : undefined
 	}
 	const settled = dedupeDiscoveryRows(
 		{ ...(findings as object), [field]: [...merged, ...additions] },
 		field,
+		tradeWords,
 	)
 	const held = (settled.findings as Record<string, unknown>)[field]
 	// What the list gained, counted in companies rather than rows. A row that joined
@@ -414,9 +420,10 @@ export const mergePerFieldSearch = (
 	findings: unknown,
 	refreshed: unknown,
 	schemaName: string,
+	tradeWords: TradeWords,
 ): PerFieldMerge => {
 	if (isDiscoveryScan(schemaName)) {
-		return mergeScanRows(schemaName, findings, refreshed)
+		return mergeScanRows(schemaName, findings, refreshed, tradeWords)
 	}
 	const enrichment = enrichmentOf(findings)
 	const refreshedEnrichment = enrichmentOf(refreshed)

--- a/packages/research/src/application/prospect-dedupe-guard.test.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.test.ts
@@ -8,6 +8,10 @@ import {
 	hostsEstablishedAsOwn,
 	isSiteKey,
 } from './prospect-dedupe-guard'
+import { tradeWordsOf } from './trade-words'
+
+// A run that named no trades, which is a request about one company on file.
+const noTrades = tradeWordsOf([])
 
 const scan = (
 	prospects: ReadonlyArray<Record<string, unknown>>,
@@ -39,7 +43,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN the list is de-duplicated
 			// THEN one row survives — the form comes off the end of the name key, so
 			// the two spellings meet
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe(
 				'Cobra Instalaciones y Servicios',
@@ -55,7 +59,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN accents fold before the names are compared
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -69,7 +73,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the dots come out before the form is read off the end, so it is one
 			// company rather than one whose form reads as two more words of its name
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -85,7 +89,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the site settles it: the host is the same one
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -99,7 +103,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN all three become one company, which is what they are
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(result.merged).toBe(2)
 		})
@@ -117,7 +121,7 @@ describe('dedupeDiscoveryRows', () => {
 			// THEN still one company. The bridge row joins two rows that were until
 			// then separate, and a list arrives in whatever order the model wrote it —
 			// so an answer that changed with the order would be no answer at all
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(result.merged).toBe(2)
 		})
@@ -139,7 +143,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the later row's findings survive on the row that stays — dropping it
 			// outright would throw away what the run paid to find
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]).toMatchObject({
 				name: 'Instalaciones Rubio SL',
 				tax_id: 'B36123456',
@@ -157,7 +161,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN the first reading stays: it is the one the checks upstream weighed
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['industry']).toBe('electrical')
 		})
 
@@ -169,7 +173,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the blank is a gap, so the later value lands
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['website']).toBe('https://acme.es')
 		})
 
@@ -196,7 +200,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN the surviving row keeps everything the run read, each page once
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(citedPagesOf(result.findings)).toEqual([
 				'https://acme.es',
 				'https://ranking.es',
@@ -216,7 +220,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the evidence still reaches the row that stays
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(citedPagesOf(result.findings)).toEqual(['https://acme.es'])
 		})
 	})
@@ -230,7 +234,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN both stay and nothing is counted as merged
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -246,7 +250,7 @@ describe('dedupeDiscoveryRows', () => {
 			// THEN they still meet, on the name as written. Neither is a company anyone
 			// can work with, but leaving them with no key at all would let the list
 			// keep every copy of the same useless row
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -258,7 +262,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN no host can be read, so neither row lends one
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -272,7 +276,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN both stay. The domain spells neither of them, so it is nobody's own
 			// site and says nothing about whether these are one company
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings).map(row => row['name'])).toEqual([
 				'Electricidad Mora',
 				'Instalaciones Rubio',
@@ -291,7 +295,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the two spellings of one name still meet, and the third company is
 			// not dragged in behind them by an address none of the three owns
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings).map(row => row['name'])).toEqual([
 				'Electricidad Mora SL',
 				'Instalaciones Rubio',
@@ -316,7 +320,7 @@ describe('dedupeDiscoveryRows', () => {
 			// THEN one company. The domain says whose site it is, so the row beside it
 			// is that company again under another name — the trade name beside the
 			// legal one, which is the pair this fold exists for
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('Terre Solaire')
 		})
@@ -339,7 +343,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN all three are one company. Who owns a domain is read across the whole
 			// list, so the row that spells it settles the host for every row on it
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(result.merged).toBe(2)
 		})
@@ -363,7 +367,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN one company comes back, under its own name
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('Terre Solaire')
 			expect(result.merged).toBe(4)
@@ -382,7 +386,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN all three towns survive on the row that stays — taking whichever
 			// arrived first would drop the other two with nothing said
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe(
 				'Douains; Lyon; Montpellier',
 			)
@@ -397,7 +401,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the town is stated once, not twice
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
 
@@ -415,7 +419,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the reader is told the company's name, not one branch's. Which row a
 			// search happened to rank first is no reason to call it something else
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]).toMatchObject({
 				name: 'Terre Solaire',
@@ -436,7 +440,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN one company under its own name, with every town still on it
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]).toMatchObject({
 				name: 'Terre Solaire',
@@ -458,7 +462,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN no address can be read from it, so it is still a
 			// row with no site of its own
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -476,7 +480,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN both stay: a row claiming its own web presence is claiming to be
 			// somebody, and two hosts are the strongest evidence of two of them
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -492,7 +496,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN both towns are named, whichever arrived first
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon; Paris')
 		})
 
@@ -512,7 +516,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the first reading of that town stands. Only a row speaking about
 			// somewhere else adds a place; another reading of one branch is not that
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
@@ -528,7 +532,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN one town, not two. A place that holds one already named is the same
 			// place written at more detail, and listing both would invent a branch
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
 
@@ -544,7 +548,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN both towns are named. Places are compared word by word, so one town
 			// reading inside another is not the same town written at more detail
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Roa; Roanne')
 		})
 
@@ -563,7 +567,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the unreadable town is kept beside the readable one. A place the
 			// code cannot read is a place it must not throw away for that reason
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Osaka; 東京')
 		})
 
@@ -581,7 +585,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the branch's town stands alone. A row naming nowhere adds nowhere,
 			// rather than a blank reading trailing the one place the run did find
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
 
@@ -595,7 +599,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the first reading stands. Two readings of one place are not two
 			// places, and only a branch speaks about somewhere else
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Vigo')
 		})
@@ -615,7 +619,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN the list is de-duplicated
 			// THEN one row survives, under the name without the note
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('KBE Energy')
 			expect(result.merged).toBe(1)
@@ -634,7 +638,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN one row, and the note row's town fills nothing
 			// it already answered: this is one company written twice, not a second
 			// place the company works from
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe("Val-d'Oise (95)")
 		})
@@ -648,7 +652,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN the company keeps its own name, and what the
 			// noted row knew is not thrown away with the brackets
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('KBE Energy')
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Paris')
@@ -661,7 +665,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN both survive. Taking brackets off every name
 			// before filing it would have folded these two, which is why the plain
 			// name has to be on the list for a note to read as a note
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -676,7 +680,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN three rows: folding either arm onto the bare
 			// row would drag the other in through it
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(3)
 		})
 
@@ -691,7 +695,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the surviving row is backed by both
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(citedPagesOf(result.findings)).toEqual(['src_own', 'src_tecsol'])
 		})
 	})
@@ -711,7 +715,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN both survive, and that is not an oversight.
 			// Joining them needs to know that "Groupe" adds nothing to a name, which
 			// is a list of words per language
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -723,7 +727,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN both survive
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -743,7 +747,7 @@ describe('dedupeDiscoveryRows', () => {
 			// smaller half: grant it and what is left is one name being the other plus
 			// a trailing word, with no town stated to check that word against, which is
 			// the case above and closed for the same reason
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -758,7 +762,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN both survive, which is the right answer here
 			// and the wrong one above, and nothing on the rows says which is which
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -770,7 +774,7 @@ describe('dedupeDiscoveryRows', () => {
 			const findings = { enrichment: { industry: 'electrical' } }
 
 			// WHEN de-duplicated with no list field — THEN nothing is compared
-			const result = dedupeDiscoveryRows(findings, undefined)
+			const result = dedupeDiscoveryRows(findings, undefined, noTrades)
 			expect(result.findings).toBe(findings)
 			expect(result.merged).toBe(0)
 		})
@@ -780,15 +784,19 @@ describe('dedupeDiscoveryRows', () => {
 			const findings = { prospects: [null, { name: 'Elecnor' }] }
 
 			// WHEN de-duplicated — THEN only real rows are compared
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toEqual([null, { name: 'Elecnor' }])
 		})
 
 		it('should leave findings that are null or a bare value untouched', () => {
 			// GIVEN non-object findings
 			// WHEN de-duplicated — THEN they pass straight through
-			expect(dedupeDiscoveryRows(null, 'prospects').findings).toBeNull()
-			expect(dedupeDiscoveryRows('text', 'prospects').findings).toBe('text')
+			expect(
+				dedupeDiscoveryRows(null, 'prospects', noTrades).findings,
+			).toBeNull()
+			expect(dedupeDiscoveryRows('text', 'prospects', noTrades).findings).toBe(
+				'text',
+			)
 		})
 	})
 })
@@ -874,7 +882,7 @@ describe('branchOfficeParents', () => {
 			])
 
 			// WHEN de-duplicated — THEN two companies come back, as they should
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -1013,7 +1021,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read
 			// THEN the noted row belongs to the plain one
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1027,7 +1035,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN the plain row is still the one it belongs
 			// to, because which row a search ranked first says nothing about the name
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([[0, 1]])
 		})
 
@@ -1040,7 +1048,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN the form comes off before the names meet
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1053,7 +1061,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN the padding is not what tells them apart
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1068,7 +1076,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN both belong to the plain row: the
 			// brackets are not telling the two rows apart, they say the same thing
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([
 				[1, 0],
 				[2, 0],
@@ -1084,7 +1092,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN nothing folds: neither row is the plain
 			// name the other is a second reading of
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
@@ -1100,7 +1108,7 @@ describe('bracketedNoteParents', () => {
 			// name are distinguishing the rows, and folding either onto the bare row
 			// would drag all three together through it
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
@@ -1122,7 +1130,7 @@ describe('bracketedNoteParents', () => {
 			// a note apart from its name only when each is established as that row's
 			// own; a host nobody is named by says nothing about who anybody is
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1137,7 +1145,7 @@ describe('bracketedNoteParents', () => {
 			// strongest thing on a row for saying these are two companies, and it
 			// outranks a bracket
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
@@ -1150,7 +1158,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN one host is no reason to hold them apart
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([[1, 0]])
 		})
 	})
@@ -1162,7 +1170,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN the brackets alone fold nothing
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
@@ -1173,7 +1181,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN it names no company for another row to be
 			// a second reading of
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
@@ -1183,7 +1191,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN this is a longer name, not a noted one
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
@@ -1193,7 +1201,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN there is no company to be the same one as
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 	})
@@ -1205,7 +1213,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN only rows are read
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
@@ -1215,21 +1223,50 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN nothing is read off it
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
 			]).toEqual([])
 		})
 
 		it('should find no notes in an empty list', () => {
 			// GIVEN nothing to read
 			// WHEN the notes are read — THEN there is nothing to belong to anything
-			expect([...bracketedNoteParents([], hostsEstablishedAsOwn([]))]).toEqual(
-				[],
-			)
+			expect([
+				...bracketedNoteParents([], hostsEstablishedAsOwn([], noTrades)),
+			]).toEqual([])
 		})
 	})
 })
 
 describe('hostsEstablishedAsOwn', () => {
+	describe('when the run names the trade the rows are called after', () => {
+		it('should not read the bare domain of that trade as anybody own', () => {
+			// GIVEN two different plumbers, each offering the bare domain of the trade
+			// they are named after, in a run that asked for that trade
+			const rows = [
+				{ name: 'Fontanería García', website: 'https://fontaneria.es' },
+				{ name: 'Fontanería López', website: 'https://fontaneria.es' },
+			]
+
+			// WHEN the owned hosts are worked out
+			// THEN none: fontaneria.es belongs to whoever registered it. Reading it as
+			// owned would make it a key both rows share, and two unrelated firms would
+			// be folded into one company
+			expect(hostsEstablishedAsOwn(rows, tradeWordsOf(['fontanería']))).toEqual(
+				new Set(),
+			)
+		})
+
+		it('should still read the host of a row that spells its own name', () => {
+			// GIVEN the same run and a row at the domain carrying the word only it has
+			const rows = [{ name: 'Fontanería García', website: 'https://garcia.es' }]
+
+			// WHEN the owned hosts are worked out — THEN that host is one of them
+			expect(hostsEstablishedAsOwn(rows, tradeWordsOf(['fontanería']))).toEqual(
+				new Set(['garcia.es']),
+			)
+		})
+	})
+
 	describe('when a row stands at the domain that spells it', () => {
 		it("should read the host as that company's own", () => {
 			// GIVEN a workshop at the domain carrying its name
@@ -1241,7 +1278,7 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN the host is one of them
-			expect(hostsEstablishedAsOwn(rows)).toEqual(
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(
 				new Set(['fusteriamiquel.cat']),
 			)
 		})
@@ -1259,7 +1296,9 @@ describe('hostsEstablishedAsOwn', () => {
 			// WHEN the owned hosts are worked out
 			// THEN one host, spelled the way the identity keys spell it — otherwise the
 			// row that establishes a site and the row that needs it never meet
-			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set(['sice.com']))
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(
+				new Set(['sice.com']),
+			)
 		})
 	})
 
@@ -1279,7 +1318,7 @@ describe('hostsEstablishedAsOwn', () => {
 			// THEN the directory is nobody's own site. Reading the note as part of the
 			// name would have the directory's own words spell the company, and every
 			// other firm listed there would then file under it as the same company
-			expect([...hostsEstablishedAsOwn(rows)]).toEqual([])
+			expect([...hostsEstablishedAsOwn(rows, noTrades)]).toEqual([])
 		})
 
 		it('should keep two companies on one directory apart through the fold', () => {
@@ -1294,7 +1333,7 @@ describe('hostsEstablishedAsOwn', () => {
 
 			// WHEN de-duplicated — THEN both survive, because a shared directory is no
 			// evidence that two companies are one
-			const result = dedupeDiscoveryRows(findings, 'prospects')
+			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -1307,7 +1346,7 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN there are none
-			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
 		})
 
 		it('should leave out a host merely carrying a word of the name', () => {
@@ -1319,7 +1358,7 @@ describe('hostsEstablishedAsOwn', () => {
 			// WHEN the owned hosts are worked out
 			// THEN none. A domain has to BE the name, or every listing filed under a
 			// company would clear itself as that company's site
-			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
 		})
 
 		it('should pass over a row with no name to judge the domain against', () => {
@@ -1328,7 +1367,7 @@ describe('hostsEstablishedAsOwn', () => {
 
 			// WHEN the owned hosts are worked out — THEN nothing is established, which
 			// is the answer rather than a missing one
-			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
 		})
 
 		it('should pass over a row whose name is empty', () => {
@@ -1337,7 +1376,7 @@ describe('hostsEstablishedAsOwn', () => {
 
 			// WHEN the owned hosts are worked out — THEN a blank spells no domain, so
 			// the site is left standing for nobody
-			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
 		})
 
 		it('should pass over a row whose website is not an address', () => {
@@ -1350,7 +1389,7 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN there is no domain to read
-			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
 		})
 
 		it('should pass over list entries that are not rows', () => {
@@ -1362,13 +1401,15 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN only the real row is read
-			expect(hostsEstablishedAsOwn(rows)).toEqual(new Set(['sice.com']))
+			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(
+				new Set(['sice.com']),
+			)
 		})
 
 		it('should find nothing in an empty list', () => {
 			// GIVEN nothing to read
 			// WHEN the owned hosts are worked out — THEN there are none
-			expect(hostsEstablishedAsOwn([])).toEqual(new Set())
+			expect(hostsEstablishedAsOwn([], noTrades)).toEqual(new Set())
 		})
 	})
 })

--- a/packages/research/src/application/prospect-dedupe-guard.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.ts
@@ -105,6 +105,7 @@ import { isPlainObject } from './guard-shapes'
 import { ownSiteVerdict } from './own-site'
 import { rowGroups } from './row-groups'
 import { hostOf, isBareWebAddress } from './source-key'
+import type { TradeWords } from './trade-words'
 
 // What marks a key as filing a row under its site. Written once, because a caller
 // asking which key joined two rows reads the same mark this writes.
@@ -151,9 +152,15 @@ const withoutTrailingNote = (name: string): string =>
  * `unknown`, which is not a verdict that two rows are different companies. It is
  * only the absence of a reason to say they are the same one, and the names still
  * have their say.
+ *
+ * `tradeWords` are the trades the run went looking for, handed down so this reads
+ * an address exactly as the rest of the run reads it. Without them two firms named
+ * after one trade would both own that trade's bare domain, and the key that folds
+ * rows by site would make them one company.
  */
 export const hostsEstablishedAsOwn = (
 	rows: ReadonlyArray<unknown>,
+	tradeWords: TradeWords,
 ): ReadonlySet<string> => {
 	const hosts = new Set<string>()
 	for (const row of rows) {
@@ -174,8 +181,11 @@ export const hostsEstablishedAsOwn = (
 		// other row on that directory would then be filed under it as the same
 		// company, which merges firms that have nothing to do with each other.
 		if (
-			ownSiteVerdict({ name: withoutTrailingNote(name), website }) ===
-			'established'
+			ownSiteVerdict({
+				name: withoutTrailingNote(name),
+				website,
+				tradeWords,
+			}) === 'established'
 		)
 			hosts.add(host)
 	}
@@ -520,6 +530,7 @@ export interface DedupeResult {
 export const dedupeDiscoveryRows = (
 	findings: unknown,
 	listField: string | undefined,
+	tradeWords: TradeWords,
 ): DedupeResult => {
 	if (listField === undefined) return { findings, merged: 0 }
 
@@ -534,7 +545,7 @@ export const dedupeDiscoveryRows = (
 		// depend on the order.
 		const { groupOf: companyOf, join: sameCompany } = rowGroups(rows.length)
 
-		const ownSiteHosts = hostsEstablishedAsOwn(rows)
+		const ownSiteHosts = hostsEstablishedAsOwn(rows, tradeWords)
 		const rowOfKey = new Map<string, number>()
 		rows.forEach((row, at) => {
 			if (!isPlainObject(row)) return

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -190,6 +190,7 @@ import {
 	researchToolkit,
 	researchToolkitLayer,
 } from './tools'
+import { type TradeWords, tradeWordsOf } from './trade-words'
 import { clearFieldOnlyDoubt } from './unconfirmed-mark-guard'
 import { makeUsageMeter, UsageMeter } from './usage-meter'
 import { verifyValueProvenance } from './value-guard'
@@ -2728,6 +2729,14 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					// there is no list then, so the run says nothing about coverage rather
 					// than reporting that it covered none of it.
 					let requestParts: ReadonlyArray<RequestPart> = []
+					// The words those parts use for the trades, which is how every check
+					// that weighs an address against a name tells the trade in the name
+					// from the company (`trade-words.ts`). Held beside the parts so the two
+					// cannot say different things, and empty wherever they are — a run
+					// about one company on file names no trades, and so does a resume that
+					// skipped the phase they are split in. Both then read a name with only
+					// the shared list behind them.
+					let runTradeWords: TradeWords = new Set()
 					// Which of those parts a pass actually went back out for. Carried
 					// alongside the list because the rows cannot say whether the run
 					// looked: a part answered by phase 1's reading can be empty in
@@ -2883,13 +2892,15 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								findings: answer,
 								listField: discoveryResultField(schemaName),
 								addresses: [...gatheredAddresses],
+								tradeWords: runTradeWords,
 							})
-							const check = guardCompanyWebsites(
-								answer,
+							const check = guardCompanyWebsites({
+								findings: answer,
 								targetName,
-								directories.sites,
-								websiteClaims,
-							)
+								directorySites: directories.sites,
+								priorClaims: websiteClaims,
+								tradeWords: runTradeWords,
+							})
 							websiteClaims = check.hostClaims
 							const blanked =
 								check.blankedNotAnAddress +
@@ -3758,6 +3769,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											const check = dedupeDiscoveryRows(
 												findings,
 												discoveryResultField(schemaName),
+												runTradeWords,
 											)
 											if (check.merged > 0) {
 												yield* Effect.logInfo(
@@ -4178,6 +4190,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													),
 										),
 									)
+								runTradeWords = tradeWordsOf(
+									requestParts.flatMap(part => [part.label, ...part.terms]),
+								)
 								if (requestParts.length > 0) {
 									yield* Effect.logInfo('research.request_parts').pipe(
 										Effect.annotateLogs({
@@ -5501,6 +5516,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								findings,
 								refreshed.findings,
 								schemaName,
+								runTradeWords,
 							)
 							findings = merged.findings
 							// Nothing has judged this list yet: every extraction was judged on
@@ -5611,6 +5627,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									findings,
 									listField: verificationListField,
 									addresses: [...gatheredAddresses],
+									tradeWords: runTradeWords,
 								}).sites
 							// What each row has to stand on, beyond its own citations.
 							const foundSources: Array<Array<string>> = verificationRows.map(
@@ -5631,6 +5648,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									website: rowWebsite(row),
 									sources: rowCitedSourceIds(row),
 									directorySites: watchedBefore,
+									tradeWords: runTradeWords,
 								}).verdict === 'confirmed'
 									? []
 									: [at],
@@ -5791,6 +5809,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											...(foundSources[at] ?? []),
 										],
 										directorySites: watchedAfter,
+										tradeWords: runTradeWords,
 									})
 									const unchecked = notChecked[at]
 									// The count stays even when the run never got to the row: how

--- a/packages/research/src/application/trade-words.test.ts
+++ b/packages/research/src/application/trade-words.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+
+import { namesATrade, tradeWordsOf, wasAskedForExactly } from './trade-words'
+
+// The trades a Spanish installations request asks for, written the way the
+// request itself writes them.
+const INSTALLATIONS = tradeWordsOf([
+	'instalación eléctrica',
+	'fontanería',
+	'ascensor',
+	'energía solar',
+	'gas',
+])
+
+describe('tradeWordsOf', () => {
+	describe('when a request names its trades', () => {
+		it('should read a wording as the separate words it is made of', () => {
+			// GIVEN a trade written as a phrase
+			// WHEN read
+			// THEN each word of it stands on its own, since a company writes one of
+			// them into its name without the rest
+			expect([...tradeWordsOf(['instalación eléctrica'])]).toEqual([
+				'instalacion',
+				'electrica',
+			])
+		})
+
+		it('should fold accents and case away, as a name is folded', () => {
+			// GIVEN the same trade written with accents and in capitals
+			// WHEN read
+			// THEN one word comes back, so a request and a company's name meet in one
+			// spelling rather than missing each other over an accent
+			expect([...tradeWordsOf(['Fontanería', 'FONTANERIA'])]).toEqual([
+				'fontaneria',
+			])
+		})
+
+		it('should read a Catalan geminate l both ways it is written', () => {
+			// GIVEN a trade written with the geminate l Catalan uses
+			// WHEN read
+			// THEN both spellings come back. A company's name is read both ways too,
+			// and a request matched against only one of them leaves the other
+			// spelling looking like a word of the company's own
+			expect([...tradeWordsOf(['instal·lacions'])]).toEqual([
+				'installacions',
+				'instalacions',
+			])
+		})
+
+		it('should read a name written with the geminate as dots the same way', () => {
+			// GIVEN the spelling a database that could not write the middle dot fell
+			// back on
+			// WHEN read — THEN it is the same two words
+			expect([...tradeWordsOf(['instal.lacions'])]).toEqual([
+				'installacions',
+				'instalacions',
+			])
+		})
+	})
+
+	describe('when there is nothing to read', () => {
+		it('should name no trades for a request that asked for none', () => {
+			// GIVEN a run about one company on file, which names no trades
+			// WHEN read — THEN nothing, so every word of a name reads as its own
+			expect([...tradeWordsOf([])]).toEqual([])
+		})
+
+		it('should name no trades for a wording holding no letters', () => {
+			// GIVEN wordings that are empty or nothing but spaces and punctuation
+			// WHEN read
+			// THEN nothing comes back — an empty word would otherwise be a word every
+			// name is made of
+			expect([...tradeWordsOf(['', '   ', '—', '·'])]).toEqual([])
+		})
+	})
+})
+
+describe('namesATrade', () => {
+	describe('when the request wrote the word', () => {
+		it('should read a word the request wrote as the trade', () => {
+			// GIVEN a company word that is exactly what the request asked for
+			// WHEN asked — THEN it says what the company does, not who it is
+			expect(namesATrade('fontaneria', INSTALLATIONS)).toBe(true)
+		})
+
+		it('should reach the word with an ending on it', () => {
+			// GIVEN a request for "ascensor" and a firm called "Ascensores"
+			// WHEN asked
+			// THEN the ending is read past, because Spanish, Catalan and French put
+			// one on every word of a phrase and no request writes them all out
+			expect(namesATrade('ascensores', INSTALLATIONS)).toBe(true)
+			expect(namesATrade('solares', INSTALLATIONS)).toBe(true)
+		})
+
+		it("should reach two letters past the request's word and no further", () => {
+			// GIVEN one word two letters longer than the request's and one three
+			// letters longer
+			// WHEN each is asked
+			// THEN only the first is an ending. Past that a firm has coined a name of
+			// its own that happens to open the same way
+			expect(namesATrade('solares', INSTALLATIONS)).toBe(true)
+			expect(namesATrade('solarock', INSTALLATIONS)).toBe(false)
+		})
+
+		it('should leave a coined name that merely opens with a trade word', () => {
+			// GIVEN the two firms a market search met whose names open with "solar"
+			// WHEN each is asked
+			// THEN neither is the trade. Reading them as one would leave those firms
+			// with no word of their own at all, and no domain able to spell them
+			expect(namesATrade('solarock', INSTALLATIONS)).toBe(false)
+			expect(namesATrade('solartec', INSTALLATIONS)).toBe(false)
+		})
+	})
+
+	describe("when the request's word is short", () => {
+		it('should spell a short word whole', () => {
+			// GIVEN a three-letter trade the request asked for
+			// WHEN the word itself is asked — THEN it is the trade
+			expect(namesATrade('gas', INSTALLATIONS)).toBe(true)
+		})
+
+		it('should not read a short word as the opening of a longer one', () => {
+			// GIVEN a family name that opens with that three-letter trade
+			// WHEN asked
+			// THEN it is not the trade: three letters open far too many unrelated
+			// words to be read as an opening
+			expect(namesATrade('gasol', INSTALLATIONS)).toBe(false)
+		})
+	})
+
+	describe('when there is nothing to compare', () => {
+		it('should name no trade when the run asked for none', () => {
+			// GIVEN a run that named no trades
+			// WHEN any word is asked — THEN nothing is a trade, so every word of a
+			// name is left standing as the company's own
+			expect(namesATrade('fontaneria', tradeWordsOf([]))).toBe(false)
+		})
+
+		it('should name no trade for a word with nothing in it', () => {
+			// GIVEN an empty word
+			// WHEN asked — THEN no, so an empty run of letters cannot be read as
+			// every trade at once
+			expect(namesATrade('', INSTALLATIONS)).toBe(false)
+		})
+
+		it('should not read a word shorter than the trade as that trade', () => {
+			// GIVEN the opening of a trade word rather than the word
+			// WHEN asked — THEN no: the request's word has to be spelled, not started
+			expect(namesATrade('fon', INSTALLATIONS)).toBe(false)
+		})
+	})
+})
+
+describe('wasAskedForExactly', () => {
+	describe('when a run of letters might be a word', () => {
+		it('should say yes only to the word the request wrote', () => {
+			// GIVEN the trade exactly as the request wrote it
+			// WHEN asked — THEN yes
+			expect(wasAskedForExactly('fontaneria', INSTALLATIONS)).toBe(true)
+		})
+
+		it('should refuse the same word with an ending on it', () => {
+			// GIVEN the trade with an ending, which `namesATrade` does read
+			// WHEN asked here — THEN no. This is asked of the front of a domain,
+			// where nothing says where the first word ends, so an ending offered
+			// here is really the first letters of the name behind it
+			expect(namesATrade('ascensores', INSTALLATIONS)).toBe(true)
+			expect(wasAskedForExactly('ascensores', INSTALLATIONS)).toBe(false)
+		})
+
+		it("should refuse the trade with the next word's first letter stuck to it", () => {
+			// GIVEN a domain's opening letters, which are the trade plus the start of
+			// the company name after it
+			// WHEN asked
+			// THEN no — reading it as the trade would cut fontaneriagarcia.es one
+			// letter too deep and never find García underneath
+			expect(wasAskedForExactly('fontaneriag', INSTALLATIONS)).toBe(false)
+		})
+	})
+})

--- a/packages/research/src/application/trade-words.ts
+++ b/packages/research/src/application/trade-words.ts
@@ -1,0 +1,138 @@
+/**
+ * The words a run's own request uses for the trades it asked about, so a check
+ * reading a company's name can tell the trade in it from the company.
+ *
+ * "Fontanería García" is a plumber called García. A check that cannot see which
+ * of those two words is the trade treats both as the company's own, and then
+ * fontaneria.es — which belongs to whoever registered it, not to every plumber in
+ * Spain — reads as this firm's own site.
+ *
+ * ## Why the words are not written down anywhere
+ *
+ * A list of words that identify nobody can only hold the trades somebody thought
+ * of, so it carries one industry's vocabulary and treats every other industry's
+ * as a company's own name. Filling it in is not a matter of finishing the job: it
+ * needs every trade in every language a market answers in, and each word added
+ * takes a real distinctive word away from the firms genuinely called that.
+ *
+ * A run does not need the list, because it already knows: it was launched for a
+ * market and the request names the trades it wants. Those words are that market's
+ * own vocabulary, in the languages that market answers in, written by the person
+ * who asked — and nothing has to be kept up to date for a trade nobody has
+ * searched for yet. `request-parts.ts` already splits a request into its trades
+ * and `term-match.ts` already reads their wordings against a page; this reads the
+ * same wordings against a name.
+ *
+ * It is the reading `directory-sites.ts` takes for a different question — what a
+ * site IS comes from watching what the run sees it do, never from a list of
+ * hosts — and the one `eval-scoring-market.ts` takes for a third.
+ *
+ * ## How a word is read
+ *
+ * A name's word names a trade when one of the request's own words spells it. A
+ * request word of some length is read as an OPENING, because Spanish, Catalan and
+ * French put an ending on every word of a phrase: a request for "ascensor"
+ * reaches a firm called "Ascensores", and one for "instalación eléctrica" reaches
+ * "Instalaciones Eléctricas", without every ending of every trade being written
+ * out.
+ *
+ * An opening may run at most `LONGEST_ENDING` letters short of the word it
+ * reaches, because that is as long as one of those endings gets. A firm coins a
+ * name by writing a trade word and carrying on — "Solarock", "Solartec" — and
+ * without the cap the request's "solar" swallows both, leaving those firms with
+ * no word of their own at all and no domain able to spell them. Over 159 rows
+ * with a website that eight market searches returned, the uncapped reading took
+ * exactly those two away and gave nothing back.
+ *
+ * The cap does not save a name coined only two letters past a trade word: a firm
+ * called Solaris, met by a run asking about solar energy, has no word of its own
+ * left and cannot establish solaris.es. That is the price of reading endings at
+ * all, paid in the direction this package is allowed to be wrong in, and it is
+ * why the cap is as tight as a real ending allows rather than looser.
+ *
+ * A short request word is matched whole instead, since three or four letters are
+ * the opening of far too many unrelated ones. `term-match.ts` draws its own line
+ * in the same place for the same reason; the two are set apart because that one
+ * needs no cap, reading phrases against whole pages where a word that runs on is
+ * another word of the page rather than the name a company chose for itself.
+ *
+ * ## What it does not answer
+ *
+ * A run that asked about one company on file names no trades, and hands back
+ * nothing. Every word of that company's name then reads as its own, which is
+ * where the shared list in `entity-guard.ts` is still the only thing standing —
+ * see `own-site.ts` for what that costs and what would let the list go.
+ */
+
+import { foldTokens, nameSpellings } from './entity-guard'
+
+/** The words a run's request used for the trades it asked about, folded to letters. */
+export type TradeWords = ReadonlySet<string>
+
+// Below this length a request's word has to spell a name's word exactly. Three or
+// four letters open far too many unrelated words — "gas" opens "gasol" — while a
+// longer one is long enough that mostly its own endings follow it.
+const SHORTEST_WORD_READ_AS_AN_OPENING = 5
+
+// How much longer than the request's word the name's word may run and still be
+// the same word with an ending on it. Two letters covers what Spanish, Catalan
+// and French add — "-s", "-es", "-as", "-os" — and stops there, so a coined name
+// that merely starts with a trade word stays the company's own.
+const LONGEST_ENDING = 2
+
+/**
+ * The trade words of a run, read off every wording its request used for the
+ * trades it asked about.
+ *
+ * Wordings rather than the parts they came in, because the two callers hold them
+ * in different shapes: a run has the parts its request was split into, and the
+ * eval has the ones the golden file wrote down. Both hand over the same thing —
+ * phrases naming a trade — and a caller with a part gives the label too, since
+ * the trade in the words the request itself used is as much the market's
+ * vocabulary as the wordings offered beside it.
+ *
+ * Folded the way a name is folded, and read in every spelling a name is read in
+ * (`nameSpellings`, then `foldTokens`). Catalan writes a geminate l two ways and
+ * a request may use either, while a company's name is read BOTH ways — so a
+ * request written one way and matched against only that way leaves the other
+ * spelling of the same word looking like a word of the company's own, and the
+ * trade slips through under it. Folding it any other way here is also how two
+ * checks start disagreeing about whether a piece of text spells a trade.
+ */
+export const tradeWordsOf = (wordings: ReadonlyArray<string>): TradeWords =>
+	new Set(wordings.flatMap(nameSpellings).flatMap(foldTokens))
+
+/**
+ * Whether the request wrote this word, exactly as it stands.
+ *
+ * What a caller asks when it is reading a run of letters that MIGHT be a word
+ * rather than a word it already has — the front of a domain, where nothing says
+ * where the first word ends. The ending `namesATrade` reads past must not be
+ * offered there: a request for "fontanería" would then also spell "fontaneriag",
+ * the trade plus the first letter of the name after it, and a caller taking the
+ * longest word a domain opens with would cut fontaneriagarcia.es one letter too
+ * deep and never find García underneath.
+ */
+export const wasAskedForExactly = (
+	word: string,
+	tradeWords: TradeWords,
+): boolean => tradeWords.has(word)
+
+/**
+ * Whether this word of a name says what the company does rather than who it is.
+ *
+ * The word arrives already folded and as a whole word, since every caller reads
+ * it off a name that has been through the same fold.
+ */
+export const namesATrade = (word: string, tradeWords: TradeWords): boolean => {
+	if (tradeWords.has(word)) return true
+	for (const asked of tradeWords) {
+		if (
+			asked.length >= SHORTEST_WORD_READ_AS_AN_OPENING &&
+			word.startsWith(asked) &&
+			word.length - asked.length <= LONGEST_ENDING
+		)
+			return true
+	}
+	return false
+}

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { mergePerFieldSearch } from './per-field-search'
+import { tradeWordsOf } from './trade-words'
 import { guardCompanyWebsites } from './website-guard'
+
+// A run that named no trades, which is a request about one company on file.
+const noTrades = tradeWordsOf([])
 
 // A competitor/prospect entry: a name plus the website the model returned for it.
 const scan = (
@@ -46,6 +50,49 @@ const TECSOL_LISTING =
 	'https://annuaire.tecsol.fr/liste-fournisseur-solaire-installateurs-epc-339615/'
 
 describe('guardCompanyWebsites', () => {
+	describe('when the run names the trade a company is called after', () => {
+		it('should count its trade domain as vouching for nobody', () => {
+			// GIVEN a firm whose name is nothing but its trade, at the bare domain of
+			// that trade, in a run that asked for that trade
+			const findings = scan([
+				{
+					name: 'Services et installations électriques',
+					website: 'https://services-et-installations-electriques.com',
+				},
+			])
+
+			// WHEN checked with the trades the run went looking for
+			const result = guardCompanyWebsites({
+				findings,
+				tradeWords: tradeWordsOf(['installations électriques']),
+			})
+
+			// THEN the website is kept — nothing here condemns it — but nothing
+			// establishes it either, so it vouches for no company
+			expect(websitesOf(result.findings)).toEqual([
+				'https://services-et-installations-electriques.com',
+			])
+			expect(result.ownSiteEstablished).toBe(0)
+			expect(result.ownSiteUnknown).toBe(1)
+		})
+
+		it('should still vouch for the same firm at its own name domain', () => {
+			// GIVEN the same run and a firm at the domain spelling the word only it has
+			const findings = scan([
+				{ name: 'Fontanería García', website: 'https://garcia.es' },
+			])
+
+			// WHEN checked — THEN its own site is established and counted
+			const result = guardCompanyWebsites({
+				findings,
+				tradeWords: tradeWordsOf(['fontanería']),
+			})
+
+			expect(result.ownSiteEstablished).toBe(1)
+			expect(result.ownSiteUnknown).toBe(0)
+		})
+	})
+
 	describe('when the run watched the host file several of its companies', () => {
 		it('should blank the website and count it as a directory', () => {
 			// GIVEN a company whose "website" is its page on a host the run itself
@@ -55,11 +102,11 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN the websites are checked against what the run observed
-			const result = guardCompanyWebsites(
+			const result = guardCompanyWebsites({
 				findings,
-				undefined,
-				new Set(['research.owler.com']),
-			)
+				directorySites: new Set(['research.owler.com']),
+				tradeWords: noTrades,
+			})
 
 			// THEN the listing is removed, which the rules reading only this one
 			// address could not have done: nothing here names the company
@@ -75,11 +122,11 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked
-			const result = guardCompanyWebsites(
+			const result = guardCompanyWebsites({
 				findings,
-				undefined,
-				new Set(['aemiat.com']),
-			)
+				directorySites: new Set(['aemiat.com']),
+				tradeWords: noTrades,
+			})
 
 			// THEN it is kept: an unwatched host is unknown, and unknown is no reason
 			// to take a website away
@@ -100,7 +147,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked with no observation to go on
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 
 			// THEN the address naming the company one level down is enough on its
 			// own, so losing the list of known directories costs this case nothing
@@ -123,7 +170,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is still caught, by the address shape alone
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.blankedDirectory).toBe(0)
@@ -143,7 +190,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it is caught. The address is put back into letters before the name is
 			// looked for, so the escaping does not hide the listing — and a run over a
 			// Spanish or Catalan market meets this spelling constantly
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 		})
@@ -160,7 +207,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the part is read as written rather than thrown away,
 			// so a path that was never valid escaping still gets judged
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 		})
@@ -179,7 +226,7 @@ describe('guardCompanyWebsites', () => {
 			// must not split it into two — read the other way round, the name would land
 			// in a "deeper" part that the address never had, and the company would lose
 			// its own page
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com/about%2Fxpo-logistics',
 			])
@@ -193,7 +240,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN a short name is no reason to let a listing through
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 		})
 	})
@@ -214,9 +261,11 @@ describe('guardCompanyWebsites', () => {
 			// form out, so the name is matched with every form taken out wherever it
 			// sits — which is a looser question than who the company is, and the safe
 			// direction for a guard whose job is spotting listings
-			expect(websitesOf(guardCompanyWebsites(findings).findings)).toEqual([
-				undefined,
-			])
+			expect(
+				websitesOf(
+					guardCompanyWebsites({ findings, tradeWords: noTrades }).findings,
+				),
+			).toEqual([undefined])
 		})
 	})
 
@@ -231,7 +280,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is left untouched
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://redwoodlogistics.com/about',
 			])
@@ -249,7 +298,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a first-segment mention is a company describing
 			// itself, not a directory filing it away
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com/about-xpo-logistics',
 			])
@@ -262,7 +311,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is kept: the name is in no deeper path segment
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://gopenske.com/logistics',
 			])
@@ -273,7 +322,7 @@ describe('guardCompanyWebsites', () => {
 			const findings = scan([{ name: 'DSV', website: 'https://dsv.com' }])
 
 			// WHEN checked — THEN nothing to file it away, so it stays
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual(['https://dsv.com'])
 		})
 
@@ -287,7 +336,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN the host naming the company is the deciding signal
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://acmelogistics.com/company/acme-logistics',
 			])
@@ -305,7 +354,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN the missing scheme does not hide the listing
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 		})
@@ -318,11 +367,11 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN the observed verdict is found without a scheme too
-			const result = guardCompanyWebsites(
+			const result = guardCompanyWebsites({
 				findings,
-				undefined,
-				new Set(['owler.com']),
-			)
+				directorySites: new Set(['owler.com']),
+				tradeWords: noTrades,
+			})
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedDirectory).toBe(1)
 		})
@@ -335,7 +384,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN it goes: a website field nobody can open is worse
 			// than an empty one, because it reads as a real site downstream
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedNotAnAddress).toBe(1)
 		})
@@ -347,7 +396,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it cannot be judged, so it stays
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://some-directory.io/company/acme',
 			])
@@ -361,7 +410,7 @@ describe('guardCompanyWebsites', () => {
 			// address to establish anything about either, so neither ownership count
 			// moves: a row with no website is not a row whose website is unvouched for
 			// AND nothing is claimed, since a row with no address claims no host
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result).toEqual({
 				findings,
 				blankedNotAnAddress: 0,
@@ -379,9 +428,17 @@ describe('guardCompanyWebsites', () => {
 		it('should leave findings that are null or a bare value untouched', () => {
 			// GIVEN non-object findings
 			// WHEN checked — THEN they pass straight through
-			expect(guardCompanyWebsites(null).findings).toBeNull()
-			expect(guardCompanyWebsites('text').findings).toBe('text')
-			expect(guardCompanyWebsites([1, 2]).findings).toEqual([1, 2])
+			expect(
+				guardCompanyWebsites({ findings: null, tradeWords: noTrades }).findings,
+			).toBeNull()
+			expect(
+				guardCompanyWebsites({ findings: 'text', tradeWords: noTrades })
+					.findings,
+			).toBe('text')
+			expect(
+				guardCompanyWebsites({ findings: [1, 2], tradeWords: noTrades })
+					.findings,
+			).toEqual([1, 2])
 		})
 	})
 
@@ -398,7 +455,7 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked — THEN the walk fires on the shape, not the schema name
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(
 				(result.findings as { prospects: Array<{ website?: string }> })
 					.prospects[0]?.website,
@@ -420,11 +477,11 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked with no target name supplied
-			const result = guardCompanyWebsites(
+			const result = guardCompanyWebsites({
 				findings,
-				undefined,
-				new Set(['crunchbase.com']),
-			)
+				directorySites: new Set(['crunchbase.com']),
+				tradeWords: noTrades,
+			})
 
 			// THEN the directory rule still fires, which is the whole point: it is the
 			// one rule that needs no name beside the address
@@ -449,7 +506,11 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked against the company the run is about
-			const result = guardCompanyWebsites(findings, 'Redwood Logistics')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'Redwood Logistics',
+				tradeWords: noTrades,
+			})
 
 			// THEN the name-in-a-deeper-path rule catches it
 			expect(
@@ -470,7 +531,11 @@ describe('guardCompanyWebsites', () => {
 			const findings = { enrichment: { website } }
 
 			// WHEN checked against the company the run is about
-			const result = guardCompanyWebsites(findings, 'Redwood Logistics')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'Redwood Logistics',
+				tradeWords: noTrades,
+			})
 
 			// THEN the host carries the name, so it stands
 			expect(
@@ -495,7 +560,11 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked against the company the run is about
-			const result = guardCompanyWebsites(findings, 'KBE Energy')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'KBE Energy',
+				tradeWords: noTrades,
+			})
 
 			// THEN the same reading reaches the field that arrives alone: nothing in
 			// the address names the company, and its source is the address itself
@@ -518,7 +587,11 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked against the company the run is about
-			const result = guardCompanyWebsites(findings, 'Groupe Dupont SA')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'Groupe Dupont SA',
+				tradeWords: noTrades,
+			})
 
 			// THEN it goes, and this is the price of the rule rather than a bug: the
 			// field carries one source and can never carry a second, so nothing here can
@@ -543,7 +616,11 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the address is not where the claim came from, so this
 			// rule has nothing to say about it
-			const result = guardCompanyWebsites(findings, 'KBE Energy')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'KBE Energy',
+				tradeWords: noTrades,
+			})
 			expect(
 				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
 					'website'
@@ -562,7 +639,11 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked while the run is about a different company
-			const result = guardCompanyWebsites(findings, 'Redwood Logistics')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'Redwood Logistics',
+				tradeWords: noTrades,
+			})
 
 			// THEN the pair rule wins for a named company, so the site is kept
 			expect(result.findings).toEqual(findings)
@@ -589,7 +670,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN both go. The parser folds the trailing words into the path and hands
 			// back a clean host, so nothing that reads the host alone can catch this
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined, undefined])
 			expect(result.blankedNotAnAddress).toBe(2)
 		})
@@ -601,7 +682,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is one address and nothing else, so it stands
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://acme.es/quienes%20somos',
 			])
@@ -620,7 +701,11 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked — THEN the same rule reaches the field that arrives alone
-			const result = guardCompanyWebsites(findings, 'Acme')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'Acme',
+				tradeWords: noTrades,
+			})
 			expect(
 				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
 					'website'
@@ -645,7 +730,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN all four go. The listing sits in the first path segment, which the
 			// deeper-path rule deliberately exempts — what settles it is that one host
 			// cannot be four different companies' own site
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				undefined,
 				undefined,
@@ -673,7 +758,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN every one stands: each host carries its own company's
 			// name, and no host is claimed by anybody else
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com/about-xpo-logistics',
 				'https://seur.com/sobre-seur',
@@ -696,7 +781,7 @@ describe('guardCompanyWebsites', () => {
 			// names, and blanking on the difference would blank that case too — so a
 			// host that belongs to somebody here takes this rule out of play, and what
 			// the two rows are to each other is settled by the de-duplication after it
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://acme.es',
 				'https://acme.es/rubio',
@@ -720,7 +805,7 @@ describe('guardCompanyWebsites', () => {
 			// this is one company met twice rather than a directory — and the shared
 			// site is the only thing that says the two rows are the same company, so
 			// blanking it would leave them as two
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://www.sice.com',
 				'https://sice.com/es',
@@ -741,7 +826,7 @@ describe('guardCompanyWebsites', () => {
 			// people use it by, so asking only whether the host carries a name whole
 			// would read a company's own domain as a stranger's and take it from both
 			// rows
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com',
 				'https://xpo.com/es',
@@ -763,7 +848,7 @@ describe('guardCompanyWebsites', () => {
 			// company met twice — nothing about the address says otherwise, and reading
 			// the two writings as two firms would take a company's own site off both of
 			// its rows
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://www.securiteincendie.fr/',
 				'https://www.securiteincendie.fr/',
@@ -792,7 +877,7 @@ describe('guardCompanyWebsites', () => {
 			// host, and the two names share no word for the rule to read them as one
 			// company either — so the only thing left is that the site is somebody's
 			// and a blank would take it from them
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://www.sav-onduleur-photovoltaique.com',
 				'https://www.sav-onduleur-photovoltaique.com/',
@@ -810,7 +895,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN it stands: one row claiming a host is not evidence the host is
 			// somebody else's, and a blank costs a real website
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://aemiat.com/e-mora/',
 				'https://tejero.es',
@@ -830,7 +915,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the more exact diagnosis wins, so the counters keep
 			// telling apart a listing from a host several rows merely share
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([undefined, undefined])
 			expect(result.blankedProfilePage).toBe(2)
 			expect(result.blankedSharedHost).toBe(0)
@@ -850,7 +935,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the proposal subtree is skipped when the claims are
 			// gathered too, so a person never costs a company its site
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(
 				(result.findings as { prospects: Array<{ website?: string }> })
 					.prospects[0]?.website,
@@ -864,33 +949,33 @@ describe('guardCompanyWebsites', () => {
 			// GIVEN the sequence a run really runs: a first answer holding one member
 			// of a trade body, then a later round holding two, each answer checked on
 			// its own and the two folded together afterwards
-			const held = guardCompanyWebsites(
-				cited([
+			const held = guardCompanyWebsites({
+				findings: cited([
 					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
 				]),
-			)
-			const round = guardCompanyWebsites(
-				cited([
+				tradeWords: noTrades,
+			})
+			const round = guardCompanyWebsites({
+				findings: cited([
 					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
 					{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
 				]),
-				undefined,
-				new Set(),
-				held.hostClaims,
-			)
+				priorClaims: held.hostClaims,
+				tradeWords: noTrades,
+			})
 			const folded = mergePerFieldSearch(
 				held.findings,
 				round.findings,
 				'prospect_scan_v1',
+				noTrades,
 			)
 
 			// WHEN the folded list is checked against everything the run has read
-			const judged = guardCompanyWebsites(
-				folded.findings,
-				undefined,
-				new Set(),
-				round.hostClaims,
-			)
+			const judged = guardCompanyWebsites({
+				findings: folded.findings,
+				priorClaims: round.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN nobody keeps the trade body's host. The first answer had one
 			// claimant and kept the address; the round had two and blanked both, which
@@ -907,7 +992,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 
 			// THEN the claim it read comes back with it, filed under the host, so the
 			// next answer is weighed against a company that is not in it
@@ -924,7 +1009,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 
 			// THEN both addresses go — AND both claims survive in what is handed back.
 			// Reading the answer it produced would find one claimant or none, so the
@@ -940,22 +1025,22 @@ describe('guardCompanyWebsites', () => {
 		it('should keep a site whose host an earlier answer named its claimant by', () => {
 			// GIVEN one company met under its trade name first, on the site that name
 			// is in, and under its legal name in a later answer
-			const first = guardCompanyWebsites(
-				scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
-			)
+			const first = guardCompanyWebsites({
+				findings: scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
+				tradeWords: noTrades,
+			})
 
 			// WHEN the later answer is checked against what the first one read
-			const later = guardCompanyWebsites(
-				scan([
+			const later = guardCompanyWebsites({
+				findings: scan([
 					{
 						name: 'Sociedad Ibérica de Construcciones Eléctricas',
 						website: 'https://sice.com/es',
 					},
 				]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN the address stands. Carrying the claims makes the two rows two
 			// claimants on one host for the first time — and the host plainly belongs
@@ -968,22 +1053,22 @@ describe('guardCompanyWebsites', () => {
 		it('should keep a site whose host only a later answer names its claimant by', () => {
 			// GIVEN the same company, met the other way round: the legal name that
 			// spells nothing arrives first, the trade name the domain carries second
-			const first = guardCompanyWebsites(
-				scan([
+			const first = guardCompanyWebsites({
+				findings: scan([
 					{
 						name: 'Sociedad Ibérica de Construcciones Eléctricas',
 						website: 'https://sice.com/es',
 					},
 				]),
-			)
+				tradeWords: noTrades,
+			})
 
 			// WHEN the answer holding the trade name is checked against it
-			const later = guardCompanyWebsites(
-				scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+			const later = guardCompanyWebsites({
+				findings: scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN it stands too: which answer named the host is not what settles it,
 			// so the rule cannot come out differently for the order the rounds ran in
@@ -994,17 +1079,17 @@ describe('guardCompanyWebsites', () => {
 		it('should keep a domain spelling a claimant name front across answers', () => {
 			// GIVEN one company met under one name first and under another in a later
 			// answer, both on the domain that is the front of the first name
-			const first = guardCompanyWebsites(
-				scan([{ name: 'XPO Logistics', website: 'https://xpo.com' }]),
-			)
+			const first = guardCompanyWebsites({
+				findings: scan([{ name: 'XPO Logistics', website: 'https://xpo.com' }]),
+				tradeWords: noTrades,
+			})
 
 			// WHEN the later answer is checked against what the first read
-			const later = guardCompanyWebsites(
-				scan([{ name: 'XPO Iberia', website: 'https://xpo.com/es' }]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+			const later = guardCompanyWebsites({
+				findings: scan([{ name: 'XPO Iberia', website: 'https://xpo.com/es' }]),
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN it stands. Carrying the claims is what puts two names on this host
 			// for the first time, so the reading that recognises an abbreviated domain
@@ -1017,19 +1102,21 @@ describe('guardCompanyWebsites', () => {
 		it('should keep a site one company claims two ways across answers', () => {
 			// GIVEN a firm met under its short name first and with a word in front of
 			// it in a later answer, on the same site both times
-			const first = guardCompanyWebsites(
-				scan([{ name: 'SIMIE', website: 'https://www.securiteincendie.fr/' }]),
-			)
+			const first = guardCompanyWebsites({
+				findings: scan([
+					{ name: 'SIMIE', website: 'https://www.securiteincendie.fr/' },
+				]),
+				tradeWords: noTrades,
+			})
 
 			// WHEN the later answer is checked against what the first read
-			const later = guardCompanyWebsites(
-				scan([
+			const later = guardCompanyWebsites({
+				findings: scan([
 					{ name: 'Groupe SIMIE', website: 'https://www.securiteincendie.fr/' },
 				]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN it stands. Carrying the claims is what brings the two writings
 			// together for the first time, so counting companies rather than writings
@@ -1043,21 +1130,21 @@ describe('guardCompanyWebsites', () => {
 		it('should not make a crowd of one company met under two spellings', () => {
 			// GIVEN one company on a host that does not name it, written with the
 			// Catalan geminate mark in the first answer and without it in the second
-			const first = guardCompanyWebsites(
-				scan([
+			const first = guardCompanyWebsites({
+				findings: scan([
 					{ name: 'Instal·lacions Puig', website: 'https://gremi.cat/puig/' },
 				]),
-			)
+				tradeWords: noTrades,
+			})
 
 			// WHEN the second answer is checked against what the first read
-			const later = guardCompanyWebsites(
-				scan([
+			const later = guardCompanyWebsites({
+				findings: scan([
 					{ name: 'Instal.lacions Puig', website: 'https://gremi.cat/puig/' },
 				]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN the address stands. A company is held under the one name it is
 			// written by however an answer spells it, so re-reading the same company
@@ -1069,19 +1156,19 @@ describe('guardCompanyWebsites', () => {
 		it('should not count a name with nothing distinctive as a claimant', () => {
 			// GIVEN a row whose name is nothing but a legal form, on a host a real
 			// company claims in a later answer
-			const first = guardCompanyWebsites(
-				scan([{ name: 'SL', website: 'https://gremi.cat/anon/' }]),
-			)
+			const first = guardCompanyWebsites({
+				findings: scan([{ name: 'SL', website: 'https://gremi.cat/anon/' }]),
+				tradeWords: noTrades,
+			})
 
 			// WHEN the later answer is checked against it
-			const later = guardCompanyWebsites(
-				scan([
+			const later = guardCompanyWebsites({
+				findings: scan([
 					{ name: 'Electricidad Mora', website: 'https://gremi.cat/mora/' },
 				]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN the address stands: a name nothing can be read from says nothing
 			// about who a host belongs to, so it must not be carried as a claimant and
@@ -1092,21 +1179,21 @@ describe('guardCompanyWebsites', () => {
 
 		it('should leave a host alone when only one company ever claimed it', () => {
 			// GIVEN the same single company read again in a later answer
-			const first = guardCompanyWebsites(
-				scan([
+			const first = guardCompanyWebsites({
+				findings: scan([
 					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
 				]),
-			)
+				tradeWords: noTrades,
+			})
 
 			// WHEN the later answer is checked against what the first read
-			const later = guardCompanyWebsites(
-				scan([
+			const later = guardCompanyWebsites({
+				findings: scan([
 					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
 				]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN it stands. Carrying the claims counts companies, never readings, so
 			// a run that reads the same company every round does not talk itself into
@@ -1119,24 +1206,31 @@ describe('guardCompanyWebsites', () => {
 			// GIVEN a contact proposal naming a host, read before an answer that puts a
 			// second company on it
 			const first = guardCompanyWebsites({
-				prospects: [
-					{ name: 'Acme Instal', website: 'https://gremi.cat/acme/' },
-				],
-				proposed_updates: [
-					{
-						operation: 'create',
-						fields: { name: 'Ada Lovelace', website: 'https://gremi.cat/ada/' },
-					},
-				],
+				findings: {
+					prospects: [
+						{ name: 'Acme Instal', website: 'https://gremi.cat/acme/' },
+					],
+					proposed_updates: [
+						{
+							operation: 'create',
+							fields: {
+								name: 'Ada Lovelace',
+								website: 'https://gremi.cat/ada/',
+							},
+						},
+					],
+				},
+				tradeWords: noTrades,
 			})
 
 			// WHEN the later answer is checked against it
-			const later = guardCompanyWebsites(
-				scan([{ name: 'Acme Instal', website: 'https://gremi.cat/acme/' }]),
-				undefined,
-				new Set(),
-				first.hostClaims,
-			)
+			const later = guardCompanyWebsites({
+				findings: scan([
+					{ name: 'Acme Instal', website: 'https://gremi.cat/acme/' },
+				]),
+				priorClaims: first.hostClaims,
+				tradeWords: noTrades,
+			})
 
 			// THEN the company keeps its address: the proposal subtree is skipped when
 			// the claims are gathered, so a person cannot follow the run into a later
@@ -1158,13 +1252,15 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked with no earlier claims, either left out or handed in empty
-			const withoutPrior = guardCompanyWebsites(findings)
-			const withEmptyPrior = guardCompanyWebsites(
+			const withoutPrior = guardCompanyWebsites({
 				findings,
-				undefined,
-				new Set(),
-				new Map(),
-			)
+				tradeWords: noTrades,
+			})
+			const withEmptyPrior = guardCompanyWebsites({
+				findings,
+				priorClaims: new Map(),
+				tradeWords: noTrades,
+			})
 
 			// THEN both read the answer identically: with nothing carried in, an
 			// answer is judged on itself alone
@@ -1195,7 +1291,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 
 			// THEN the address goes: nothing in it names the company, and its own
 			// citation says only that the run read the page
@@ -1223,7 +1319,9 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN only the website key is dropped — the company and its evidence stay,
 			// because what was wrong was the address, not the company
-			expect(guardCompanyWebsites(findings).findings).toEqual({
+			expect(
+				guardCompanyWebsites({ findings, tradeWords: noTrades }).findings,
+			).toEqual({
 				prospects: [
 					{
 						name: 'KBE Energy',
@@ -1243,7 +1341,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the host carries the name, which settles it long
 			// before the page it was read from is asked about
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1261,7 +1359,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it stands. The host names nobody and the page is the one that was
 			// read, so what separates this from the listing above is the single thing
 			// this rule adds: the first segment spells the company out
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1276,7 +1374,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN one distinctive word inside the host is a mention,
 			// and a mention anywhere withholds the blank
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1296,7 +1394,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it stays. With no path there is no page to tell apart from the site,
 			// so the tell this rule reads is absent and what is left is the ordinary
 			// case — a run that read a home page and wrote the site down
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://annuaire.tecsol.fr',
 			])
@@ -1313,7 +1411,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the name is found through the escaping, so the page
 			// is read as naming the company and kept
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1330,7 +1428,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the same page cited repeatedly is still one page, and
 			// still the only thing that mentioned the company
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1349,7 +1447,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it stands. This rule speaks only for a row whose whole evidence is
 			// the address itself; once something else has mentioned the company, what
 			// the address is stops being a question this rule can answer
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1362,7 +1460,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a row citing nothing says nothing either way, so
 			// there is no provenance to read and the address is left alone
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1382,7 +1480,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the two spellings are one page, so tidying the
 			// citation does not hide where the claim came from
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1398,7 +1496,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN a page is the same page whichever link led to it
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1417,7 +1515,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a matching path on a different site is a different
 			// page, so the website is not where the claim came from
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1436,7 +1534,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN nothing fires: an opaque id names no host, so it can neither match
 			// the address nor be mistaken for it. The rule reads a citation only when
 			// the model wrote it as the address it is
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1457,7 +1555,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN an entry naming no source has mentioned the company
 			// nowhere, so it neither counts as another source nor blocks the rule
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1476,7 +1574,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN there is no citation to read, so the row is judged
 			// with nothing and its address stands
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1499,7 +1597,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN both go, counted under the rule that knows more about
 			// why: several rows claiming one host says it belongs to none of them
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([undefined, undefined])
 			expect(result.blankedSharedHost).toBe(2)
 			expect(result.blankedReadPage).toBe(0)
@@ -1515,7 +1613,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the address shape is the more exact diagnosis and
 			// keeps the count
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.blankedReadPage).toBe(0)
@@ -1534,7 +1632,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN both are kept and the two are told apart anyway, which is the whole
 			// point: surviving the rules is not the same statement as owning the site
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://redwoodlogistics.com',
 				'https://annuaire.tecsol.fr',
@@ -1555,7 +1653,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked — THEN an address that is gone has no ownership left to
 			// establish, so it lands in neither column rather than swelling the
 			// unvouched-for one
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.ownSiteEstablished + result.ownSiteUnknown).toBe(0)
 		})
@@ -1575,7 +1673,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is kept, and unvouched for
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://annuaire.tecsol.fr',
 			])
@@ -1591,7 +1689,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN silence about where a claim came from is not a
 			// reason to call the address the company's
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1609,7 +1707,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a second source about the COMPANY says nothing about
 			// who owns the ADDRESS, so it buys the address no standing
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1624,7 +1722,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the coincidence buys nothing here, because a path
 			// names a page about the company rather than the company's site
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([listing])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1642,7 +1740,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a citation nothing can be read off is not a
 			// clearance
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1654,8 +1752,8 @@ describe('guardCompanyWebsites', () => {
 			// as the run's own answer for the target, whose single source is a page
 			// elsewhere, and as an ordinary scanned row
 			const website = 'https://kbe-groupe.example/nos-activites'
-			const target = guardCompanyWebsites(
-				{
+			const target = guardCompanyWebsites({
+				findings: {
 					enrichment: {
 						website: {
 							value: website,
@@ -1664,17 +1762,19 @@ describe('guardCompanyWebsites', () => {
 						},
 					},
 				},
-				'KBE Energy',
-			)
-			const row = guardCompanyWebsites(
-				cited([
+				targetName: 'KBE Energy',
+				tradeWords: noTrades,
+			})
+			const row = guardCompanyWebsites({
+				findings: cited([
 					{
 						name: 'KBE Energy',
 						website,
 						sources: [website, 'https://www.lemoniteur.fr/kbe-energy'],
 					},
 				]),
-			)
+				tradeWords: noTrades,
+			})
 
 			// WHEN both are checked
 			// THEN both keep the address and both read it as unestablished. That field
@@ -1702,7 +1802,11 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked against the company the run is about
 			// THEN the name told from outside is what the domain is read against, so
 			// the field that arrives with no name beside it can still be established
-			const result = guardCompanyWebsites(findings, 'Redwood Logistics')
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'Redwood Logistics',
+				tradeWords: noTrades,
+			})
 			expect(result.ownSiteEstablished).toBe(1)
 			expect(result.ownSiteUnknown).toBe(0)
 		})
@@ -1721,7 +1825,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked with nothing to compare — THEN unknown, because there is no
 			// company for the domain to be the company's own site OF
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result.ownSiteEstablished).toBe(0)
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1744,7 +1848,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the proposed-updates subtree is left untouched, so a
 			// person's website is never blanked as if it were a company's
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result.findings).toEqual(findings)
 			expect(result.blankedDirectory + result.blankedProfilePage).toBe(0)
 		})
@@ -1767,7 +1871,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN the site stays and is established as the company's own. Read only
 			// the way the name is written, the host spelled nothing the run knew and
 			// the company lost the very page it published
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://ilusions.cat/contacte',
 			])
@@ -1787,7 +1891,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN it is kept too, so reading the name both ways costs
 			// the spelling that already worked nothing
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://illusions.cat/contacte',
 			])
@@ -1805,9 +1909,12 @@ describe('guardCompanyWebsites', () => {
 				'https://directori.cat/empresa/ilusions',
 				'https://directori.cat/empresa/illusions',
 			]) {
-				const result = guardCompanyWebsites(
-					cited([{ name: 'Il·lusions SL', website, sources: [website] }]),
-				)
+				const result = guardCompanyWebsites({
+					findings: cited([
+						{ name: 'Il·lusions SL', website, sources: [website] },
+					]),
+					tradeWords: noTrades,
+				})
 				expect(prospectWebsites(result.findings)).toEqual([undefined])
 				expect(result.blankedProfilePage).toBe(1)
 			}
@@ -1828,7 +1935,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN nothing is blanked: the host is plainly the Catalan company's, and
 			// the reading that says so came from the row with the mark. Keeping only
 			// the later row's spellings would lose it and blank all four
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result.blankedSharedHost).toBe(0)
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://ilusions.cat',
@@ -1851,7 +1958,7 @@ describe('guardCompanyWebsites', () => {
 			// as a shared host. Its two spellings must count as the one company they
 			// are — counted apart, a single company would look like a crowd and the
 			// rule would fire on a host it owns
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result.blankedSharedHost).toBe(0)
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://ilusions.cat',
@@ -1879,7 +1986,11 @@ describe('guardCompanyWebsites', () => {
 						website: { value, source_id: value, confidence: null },
 					},
 				}
-				const result = guardCompanyWebsites(findings, 'Instal·lacions Vives SL')
+				const result = guardCompanyWebsites({
+					findings,
+					targetName: 'Instal·lacions Vives SL',
+					tradeWords: noTrades,
+				})
 				expect(
 					(result.findings as { enrichment: Record<string, unknown> })
 						.enrichment['website'],
@@ -1901,7 +2012,11 @@ describe('guardCompanyWebsites', () => {
 						website: { value, source_id: 'src_a', confidence: null },
 					},
 				}
-				const result = guardCompanyWebsites(findings, 'Instal·lacions Vives SL')
+				const result = guardCompanyWebsites({
+					findings,
+					targetName: 'Instal·lacions Vives SL',
+					tradeWords: noTrades,
+				})
 				expect(
 					(result.findings as { enrichment: Record<string, unknown> })
 						.enrichment['website'],
@@ -1925,7 +2040,7 @@ describe('guardCompanyWebsites', () => {
 			// own exact domain still reads as unestablished — there is no word of the
 			// company's for a domain to spell, so `unknown` here means the rules could
 			// never have said anything else, not that nothing vouched for it
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result.namedNobodyInParticular).toBe(1)
 			expect(result.ownSiteEstablished).toBe(1)
 			expect(result.ownSiteUnknown).toBe(1)
@@ -1942,7 +2057,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN the website is kept, and the count stays at zero: a name that
 			// reads as nothing is a different miss from a name that reads as a trade,
 			// and adding the two together would hide both
-			const result = guardCompanyWebsites(findings)
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
 			expect(result.namedNobodyInParticular).toBe(0)
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://directori.cat/empresa/algu',

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -59,6 +59,7 @@ import {
 import { citedSourceIds, isPlainObject } from './guard-shapes'
 import { ownSiteHostVerdict, ownSiteVerdict } from './own-site'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
+import type { TradeWords } from './trade-words'
 
 const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
 
@@ -297,6 +298,7 @@ const filesSeveralCompanies = (
 const hostBelongsTo = (
 	host: string,
 	claimantNames: ReadonlyArray<string>,
+	tradeWords: TradeWords,
 ): boolean =>
 	claimantNames.some(
 		name =>
@@ -304,7 +306,7 @@ const hostBelongsTo = (
 				spelling =>
 					spelling.length >= DISTINCTIVE_NAME_LENGTH &&
 					collapse(host).includes(spelling),
-			) || ownSiteHostVerdict({ name, host }) === 'established',
+			) || ownSiteHostVerdict({ name, host, tradeWords }) === 'established',
 	)
 
 type WebsiteVerdict =
@@ -322,8 +324,16 @@ const classifyWebsite = (args: {
 	readonly citedSources: ReadonlyArray<string>
 	readonly hostClaims: HostClaims
 	readonly directorySites: DirectorySites
+	readonly tradeWords: TradeWords
 }): WebsiteVerdict => {
-	const { name, website, citedSources, hostClaims, directorySites } = args
+	const {
+		name,
+		website,
+		citedSources,
+		hostClaims,
+		directorySites,
+		tradeWords,
+	} = args
 	const host = hostOf(website)
 	// Not an address at all: a value with words written next to it ("https://acme.es
 	// (inferred from the name)"), or something that was never a URL. A website field
@@ -387,7 +397,7 @@ const classifyWebsite = (args: {
 		claimants !== undefined &&
 		filesSeveralCompanies(claimants) &&
 		![...claimants.values()].some(claimant =>
-			hostBelongsTo(host, claimant.names),
+			hostBelongsTo(host, claimant.names, tradeWords),
 		)
 	) {
 		return 'shared_host'
@@ -485,13 +495,27 @@ export interface WebsiteGuardResult {
  * standing on the list that ships, and no reading of that list can recover the
  * claim that condemned it. Recorded claims can, because they are taken before
  * the blanking.
+ *
+ * `tradeWords` are the trades the run went looking for (`trade-words.ts`), which
+ * is how the ownership reading tells the trade in a company's name from the
+ * company. Asked for on every call rather than defaulted to none, unlike the
+ * three above: leaving it out does not merely stand a rule down, it makes this
+ * guard read the same address differently from the rest of the run.
  */
-export const guardCompanyWebsites = (
-	findings: unknown,
-	targetName?: string,
-	directorySites: DirectorySites = new Set(),
-	priorClaims: HostClaims = new Map(),
-): WebsiteGuardResult => {
+export const guardCompanyWebsites = (args: {
+	readonly findings: unknown
+	readonly targetName?: string | undefined
+	readonly directorySites?: DirectorySites | undefined
+	readonly priorClaims?: HostClaims | undefined
+	readonly tradeWords: TradeWords
+}): WebsiteGuardResult => {
+	const {
+		findings,
+		targetName,
+		directorySites = new Set<string>(),
+		priorClaims = new Map(),
+		tradeWords,
+	} = args
 	let blankedNotAnAddress = 0
 	let blankedDirectory = 0
 	let blankedProfilePage = 0
@@ -516,7 +540,7 @@ export const guardCompanyWebsites = (
 	// the answer beside their counts. Asked only of a website that is staying,
 	// since one already gone has no ownership left to establish.
 	const countOwnSite = (name: string, website: string): void => {
-		if (ownSiteVerdict({ name, website }) === 'established')
+		if (ownSiteVerdict({ name, website, tradeWords }) === 'established')
 			ownSiteEstablished++
 		else ownSiteUnknown++
 	}
@@ -564,6 +588,7 @@ export const guardCompanyWebsites = (
 					typeof value['source_id'] === 'string' ? [value['source_id']] : [],
 				hostClaims,
 				directorySites,
+				tradeWords,
 			})
 			if (verdict !== 'keep') {
 				count(verdict)
@@ -585,6 +610,7 @@ export const guardCompanyWebsites = (
 				citedSources: citedSourceIds(value),
 				hostClaims,
 				directorySites,
+				tradeWords,
 			})
 			if (verdict !== 'keep') {
 				count(verdict)


### PR DESCRIPTION
## What

When Batuda researches a market it has to decide whether a website really belongs to a company, and it does that by checking whether the web address spells the company's name. That only works if it can tell which words in a name are the company and which just say what it does for a living — "García" identifies a firm, "Fontanería" (plumbing) identifies every plumber in Spain. Until now that judgement came from a list of words typed into the code by hand, and the list held one industry's vocabulary — freight — and nothing else. So in every other line of work a firm named after its trade was treated as identified BY its trade, and the bare web address of that trade was handed to it as its own site.

That matters more than a wrong link. Since existence verification landed (#486), an established own site is the one thing that proves a company exists, so a wrong yes manufactures a **confirmed** company out of a stranger's domain — in every sector except the one the list happened to cover.

This changes where the judgement comes from. A research run is launched for a market, and the request it was launched with already names the trades it wants. Those words are that market's own vocabulary, written by the person who asked, in whatever languages the market answers in — so the run brings its own list and there is nothing to keep up to date. This lives entirely in the Research context (`packages/research`); no other surface changes.

## The fix

**Touches:** the verdict that says a website is a company's own, the four readings that spend that verdict (does this company exist, is this host a business directory, should this website be blanked, are these two rows the same company), the step that splits a request into the trades it asks for — which already existed and is only being read from — and the eval's duplicate count.

- Which words say what a company *does* now comes from the run's own request (`trade-words.ts`), read with the same folding a name goes through, so a request writing "instal·lacions" and a company writing it another way meet as one word.
- The hand-written list keeps only its other job: words for a *kind* of company (group, holding, servicios), which work for anybody in any market. **No words were added to it**, which is the whole point — extending it to plumbing, then building, then to French and German would never finish. `entity-guard.ts` now carries a note saying not to add another industry, and why.
- A request names its trades in phrases, so the little joining words come along with them ("fontanería **y** climatización"). Two things follow: a domain's leading word must be one the request wrote *exactly* (otherwise `fontaneriagarcia.es` gets cut one letter too deep and García is never found underneath), and a joining word can no longer be the one word left standing as a company's own — without that, a firm called "Services et installations électriques" is handed the bare address of its whole trade.
- A request word is read as an opening so "ascensor" reaches a firm called "Ascensores", but only two letters further, because a firm coins a name by writing a trade word and carrying on — `Solarock` and `Solartec` are their own companies, not solar.

## Impact

- **Fewer companies confirmed in market searches, on purpose.** A company whose only evidence was owning its trade's bare address now reads as a candidate rather than confirmed. That is the bug being fixed, and it is the direction `own-site.ts` is allowed to be wrong in — the website is still kept, it just no longer vouches for the company.
- **The eval's duplicate figure is measured slightly differently.** It reads the trades the golden file names, while a run reads the ones it split out of its own request; the two can disagree on one row. Kept deliberately — a run writes its trades afresh every pass, so a duplicate count read off those would move between two passes of one market for reasons unrelated to whatever is being measured. Worth knowing before comparing `rowsDuplicated` across this commit.
- **Nothing else moves.** No database migration, no change to which organisation can see what (row-level security), no new environment variables, no change to the public API shape or to what the MCP and HTTP surfaces each expose, no change to what the run spends at paid providers. Every signature I changed is internal to `packages/research`.

## Review guide

Start at `own-site.ts` — the long comment at the top is where the reasoning lives, and the section "Which words identify nobody" is the actual decision this PR makes. Then `trade-words.ts`, which is small and where the two predicates that look alike (`namesATrade`, `wasAskedForExactly`) explain why they are not the same question.

**The riskiest part** is that more words can now come off the front of a web address than before, which is a new way to reach a name and therefore a new way to reach the *wrong* one. I measured it: over 159 rows it cleared nothing that was not already cleared. The guard is that a leading word must be one the request wrote exactly, plus a four-letter floor.

**Two decisions you might overrule:**

1. **I did not delete the freight words**, so §7 of #456 ("the list goes — with its replacement, never before it") is only half paid. The replacement exists for trades, but a run about a single company on file — and a resume that skipped the phase where the request is split — names no trades at all, and dropping the freight words there would hand `transportes.com` back to every firm called Transportes something. Written down at both files with what would let them go.
2. **There are now two sets of joining words in the package** — `FORM_CONNECTORS` in `entity-guard.ts`, for reading a legal form off the end of a name, and `JOINS_TWO_HALVES_OF_A_NAME` in `own-site.ts`. Same class of word, different jobs. I kept them apart because extending the first would change how every name's legal form is read, which is outside this change — but it is a duplication that could drift. §7 explicitly sanctions this kind of set ("the small word-joiners used for folding names, which are spelling, not a market list").

**Skip-able:** the test diffs are mostly mechanical — every call site that asks who owns an address now passes the run's trades, and `guardCompanyWebsites` moved from four positional arguments to a named object (which is why `website-guard.test.ts` looks large). The new behaviour is tested in `trade-words.test.ts` and in the two new `describe` blocks in `own-site.test.ts`.

## Tests

1577 unit tests in `packages/research` (up 40). The new ones cover: the issue's own table across fourteen sectors, each judged inside a run that asked for that trade; a trade read from either end of a name; coined names that merely open with a trade word; both spellings of a Catalan geminate l; joining words; two-letter initialisms that really are company names (`VS Energy`, `TK Elevator`, `Plomberie DS`); and the pass-through in the two places where a wrong yes costs most — a company not being confirmed on its trade's bare domain, and two firms of one trade not being folded into a single company.

## Verification

Gates run in order, all green: `pnpm install` (no lockfile drift) → `pnpm -w check-types` + `pnpm -w test` (21 tasks) → `pnpm -w build`. `pnpm check` reports 0 errors and 59 warnings, the same as `main`.

Beyond the gates, three measurements:

- **The issue's reproduction**, each row judged inside a run for its own market: 14 of 20 wrongly cleared before, **0 of 20** after.
- **Replayed over real data** — 159 rows with a website from eight stored Spanish and French market passes: 115 established before, **114** after; the single change is `Instalaciones contra incendios` losing `instalacionescontraincendios.com`, which is the bug. Nothing was newly cleared. The freight rows, the corporate rows, and #526's `grupocobra.com` all still answer as they did.
- **Two live market runs** through the real pipeline against this worktree's own stack, with the committed production routing and real search/scrape/LLM providers. The French run returned 30 rows and caught a real instance: `Services et installations électriques` at `services-et-installations-electriques.com`, which on `main` establishes as its own site and is **confirmed**, stored as `no_own_site` / `candidate` instead. The Spanish run returned 53 rows, 100% right kind, 75% confirmed, 0% duplicates, 100% request coverage; no row in it had the failing shape, so nothing changed there. It took three attempts to get a completed Spanish run — the dev environment's second LLM slot returns 403 and the first attempt also hit a schema error with no fallback. Both failures were infrastructure, not this change.

I also ran `/code-review xhigh` and the readability agent over the branch and folded all findings in. Two of them were real defects I had introduced and could only find by running the code, not by reading it.

No UI in this change, so no screenshots.

## Deferred

- **#529** — the other half of the same list. The words for a *kind* of company hold English and Spanish plus one French word, so `grup.cat`, `serveis.cat`, `gruppe.de`, `gruppo.it`, `groep.nl`, `servicos.pt` and `grupa.pl` all still clear wrongly: 11 of 13 measured. A run's request can't reach these, because it names trades and never says "group". Filed as a sub-issue of #456 with the reproduction and the options.
- A resumed run that skipped the phase where the request is split reads a name with only the shared list behind it, exactly as every run did before this change. Noted where the trades are held rather than worked around.

Closes #527
