### PR TITLE
fix(research): stop a social page shipping as a company's website

### DIFF
--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -940,6 +940,43 @@ describe('reachedOwnSite', () => {
 			expect(reachedOwnSite(targets, [{ host: undefined }])).toBe(false)
 		})
 	})
+
+	describe('when the fetched page is on a social platform', () => {
+		it('should not read a platform page as the company own site', () => {
+			// GIVEN an agency named after the platform it works on, and a page
+			// fetched from that platform
+			const agency: EntityTargets = {
+				cores: ['facebookadsagency'],
+				words: ['facebook'],
+				domains: [],
+				places: [],
+			}
+
+			// WHEN asked whether the run reached the company's own site
+			// THEN no. A page there belongs to whoever opened the account, and
+			// counting it would let a mailbox printed on Facebook be harvested as
+			// this company's own
+			expect(reachedOwnSite(agency, [{ host: 'facebook.com' }])).toBe(false)
+			expect(reachedOwnSite(agency, [{ host: 'es-la.facebook.com' }])).toBe(
+				false,
+			)
+		})
+
+		it('should still read the company own domain as its site', () => {
+			// GIVEN the same agency at the domain it registered itself
+			const agency: EntityTargets = {
+				cores: ['facebookadsagency'],
+				words: ['facebook'],
+				domains: [],
+				places: [],
+			}
+
+			// WHEN asked — THEN yes: the refusal is about the platform, not the word
+			expect(reachedOwnSite(agency, [{ host: 'facebookadsagency.com' }])).toBe(
+				true,
+			)
+		})
+	})
 })
 
 describe('isOwnSiteHost', () => {
@@ -1049,6 +1086,48 @@ describe('isOwnSiteHost', () => {
 			expect(isOwnSiteHost(tiny, 'a-b-c.com')).toBe(false)
 			expect(isOwnSiteHost(tiny, 'abcdirectory.com')).toBe(false)
 			expect(isOwnSiteHost(generic, 'transportes.com')).toBe(false)
+		})
+	})
+
+	describe('when the host is a social platform', () => {
+		it('should reject a platform, however plainly the name spells it', () => {
+			// GIVEN an agency whose name spells a platform's own label
+			const agency: EntityTargets = {
+				cores: ['facebookadsagency'],
+				words: ['facebook'],
+				domains: [],
+				places: [],
+			}
+
+			// WHEN that platform is weighed as the site to go and read
+			// THEN no. A wrong yes here anchors the whole run on Facebook and writes
+			// back whatever it serves as this company's facts
+			expect(isOwnSiteHost(agency, 'facebook.com')).toBe(false)
+			expect(isOwnSiteHost(agency, 'fr.linkedin.com')).toBe(false)
+		})
+
+		it('should reject a platform already stored as the company website', () => {
+			// GIVEN a company whose website on file is a Facebook page, which is how
+			// a row left behind by the old behaviour arrives
+			const stored: EntityTargets = {
+				cores: ['lipotech'],
+				words: ['lipotech'],
+				domains: ['facebook.com'],
+				places: [],
+			}
+
+			// WHEN the run looks for the site to go and read
+			// THEN still no. Honouring it would send every one of that company's runs
+			// off to read Facebook and write back whatever it served
+			expect(isOwnSiteHost(stored, 'facebook.com')).toBe(false)
+		})
+
+		it('should still accept an ordinary host the caller supplied', () => {
+			// GIVEN the host the caller handed over for a company
+			// WHEN asked — THEN yes, as before: the refusal above is about platforms,
+			// not about supplied domains
+			const anchored: EntityTargets = { ...garcia, domains: ['tg.example'] }
+			expect(isOwnSiteHost(anchored, 'tg.example')).toBe(true)
 		})
 	})
 })

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -20,6 +20,7 @@
 import { domainToUnicode } from 'node:url'
 
 import { EQUIVALENT_LETTERS } from './letter-equivalences.generated'
+import { isSocialPlatformHost } from './social-sites'
 
 // Legal-form suffixes dropped before matching, so "Acme Logistics S.L." and a
 // page that writes "Acme Logistica SL" still match on the same name core.
@@ -861,6 +862,10 @@ export const reachedOwnSite = (
 ): boolean =>
 	pages.some(page => {
 		if (page.host === undefined) return false
+		// A page on a social platform belongs to whoever opened the account, never
+		// to the company — whether its name spells the platform or its stored
+		// website points there.
+		if (isSocialPlatformHost(page.host)) return false
 		if (targets.domains.includes(page.host)) return true
 		const label = domainLabelOf(page.host)
 		if (label === undefined) return false
@@ -903,11 +908,18 @@ export const reachedOwnSite = (
  * The accented spelling is the one reading they do share, since it says what the
  * domain is rather than what may be made of it: `hostLabel`, which both go
  * through, puts a domain registered with an accent back into its own letters.
+ *
+ * A social platform is refused outright — "Facebook Ads Agency" is no reason to
+ * go and read Facebook as that company's site — since a page there belongs to
+ * whoever opened the account. Refused ahead of the domain the caller supplied,
+ * too: a company whose stored website is a Facebook page would otherwise send
+ * every one of its runs off to read Facebook and write back what it found there.
  */
 export const isOwnSiteHost = (
 	targets: EntityTargets,
 	host: string,
 ): boolean => {
+	if (isSocialPlatformHost(host)) return false
 	if (targets.domains.includes(host)) return true
 	const label = domainLabelOf(host)
 	if (label === undefined) return false

--- a/packages/research/src/application/own-site.test.ts
+++ b/packages/research/src/application/own-site.test.ts
@@ -1314,6 +1314,74 @@ describe('ownSiteVerdict', () => {
 			}
 		})
 	})
+
+	describe('when the host is a social platform', () => {
+		it('should refuse a platform page to a company named after it', () => {
+			// GIVEN an agency whose name really does spell the domain of the platform
+			// it works on — the one way a page on Facebook could otherwise be
+			// established as somebody's own site
+			// WHEN each is asked
+			// THEN unknown. A page on a platform belongs to whoever opened the
+			// account, and the letters of a name are no reason to say the company
+			// owns the domain it sits on
+			expect(
+				ownSiteVerdict({
+					name: 'Facebook Ads Agency',
+					website: 'https://www.facebook.com/fbadsagency',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'Instagram Marketing SL',
+					website: 'https://instagram.com/instamarketing',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
+		})
+
+		it('should refuse the platform even to the platform itself', () => {
+			// GIVEN the one company for whom the address really is the site
+			// WHEN asked
+			// THEN unknown, and this is the price rather than a gap. Exempting it
+			// means reading who owns the host, and that reading hands the platform to
+			// every agency named after it — a hole that costs more than the handful
+			// of firms this withholds from
+			expect(
+				ownSiteVerdict({
+					name: 'Facebook',
+					website: 'https://facebook.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
+		})
+
+		it('should refuse a platform subdomain', () => {
+			// GIVEN the door a platform serves one country through
+			// WHEN asked — THEN the same platform, and the same answer
+			expect(
+				ownSiteVerdict({
+					name: 'Linkedin Formacio',
+					website: 'https://fr.linkedin.com/company/linkedin-formacio',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
+		})
+
+		it('should still establish a domain that merely starts with a platform name', () => {
+			// GIVEN the same agency at a domain it registered itself
+			// WHEN asked
+			// THEN established, because the refusal above is about the platform and
+			// not about the word: whoever registered "facebook-ads-agency.com" owns it
+			expect(
+				ownSiteVerdict({
+					name: 'Facebook Ads Agency',
+					website: 'https://facebookadsagency.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('established')
+		})
+	})
 })
 
 describe('ownSiteHostVerdict', () => {
@@ -1439,6 +1507,37 @@ describe('ownSiteHostVerdict', () => {
 					tradeWords: noTrades,
 				}),
 			).toBe('established')
+		})
+	})
+
+	describe('when a social platform host is asked about', () => {
+		it('should refuse the platform however plainly the name spells it', () => {
+			// GIVEN a host asked on its own, for a company whose name spells it
+			// WHEN asked
+			// THEN unknown, the same answer the whole address gets — so a caller that
+			// weighs many addresses sharing one host cannot reach a different verdict
+			// from one that weighs them one at a time
+			expect(
+				ownSiteHostVerdict({
+					name: 'Facebook Ads Agency',
+					host: 'facebook.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteHostVerdict({
+					name: 'Instagram Marketing SL',
+					host: 'instagram.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteHostVerdict({
+					name: 'Tiktok Media Group',
+					host: 'tiktok.com',
+					tradeWords: noTrades,
+				}),
+			).toBe('unknown')
 		})
 	})
 })

--- a/packages/research/src/application/own-site.ts
+++ b/packages/research/src/application/own-site.ts
@@ -77,6 +77,14 @@
  * exempted there so an "about us" page is not mistaken for one. Those are
  * reasons to withhold a blank. None of them is a reason to claim ownership.
  *
+ * **A host that is a social platform.** The one way a page on Facebook could
+ * still be established: an agency named after the platform it works on —
+ * "Instagram Marketing SL", "Facebook Ads Agency" — spells that host's own label,
+ * and the reading above would hand it the platform as its site. A page on a
+ * platform belongs to whoever opened the account, which is no reason to say the
+ * company owns the domain, so such a host is refused before any of its letters
+ * are read (`social-sites.ts`).
+ *
  * **Where the claim was read from.** A row's citations say which pages the run
  * opened, never who owns a domain. Settling ownership on provenance opens a hole
  * for every way a row can cite: one citing nothing, one whose citations a guard
@@ -218,6 +226,7 @@ import {
 	nameWordsWithoutForms,
 	withoutFormDots,
 } from './entity-guard'
+import { isSocialPlatformHost } from './social-sites'
 import { hostOf, isBareWebAddress } from './source-key'
 import { namesATrade, type TradeWords, wasAskedForExactly } from './trade-words'
 
@@ -415,6 +424,7 @@ export const ownSiteHostVerdict = (args: {
 	readonly host: string
 	readonly tradeWords: TradeWords
 }): OwnSiteVerdict =>
+	!isSocialPlatformHost(args.host) &&
 	hostSpellsTheCompany(args.name, args.host, args.tradeWords)
 		? 'established'
 		: 'unknown'

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -2904,6 +2904,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							websiteClaims = check.hostClaims
 							const blanked =
 								check.blankedNotAnAddress +
+								check.blankedSocialPage +
 								check.blankedDirectory +
 								check.blankedProfilePage +
 								check.blankedSharedHost +
@@ -2918,6 +2919,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										// have reached on its own.
 										pass,
 										blanked_not_an_address: check.blankedNotAnAddress,
+										blanked_social_page: check.blankedSocialPage,
 										blanked_directory: check.blankedDirectory,
 										blanked_profile_page: check.blankedProfilePage,
 										blanked_shared_host: check.blankedSharedHost,

--- a/packages/research/src/application/social-sites.test.ts
+++ b/packages/research/src/application/social-sites.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSocialPlatformHost } from './social-sites'
+
+describe('isSocialPlatformHost', () => {
+	describe('when the host is a platform', () => {
+		it('should recognise every platform on the list', () => {
+			// GIVEN each host the list names
+			// WHEN asked
+			// THEN each is a platform. Asked one by one rather than in the round, so a
+			// letter dropped from any single entry fails here instead of quietly
+			// letting that platform's pages ship as websites
+			for (const host of [
+				'facebook.com',
+				'instagram.com',
+				'linkedin.com',
+				'x.com',
+				'twitter.com',
+				'tiktok.com',
+				'youtube.com',
+				'youtu.be',
+				'threads.net',
+			]) {
+				expect(isSocialPlatformHost(host)).toBe(true)
+			}
+		})
+
+		it('should recognise a country or device subdomain', () => {
+			// GIVEN the subdomains a platform serves its own countries and phones from
+			// WHEN asked
+			// THEN each is the same platform. A page is no more the company's own site
+			// for having been reached through the Spanish or the mobile door
+			expect(isSocialPlatformHost('es-la.facebook.com')).toBe(true)
+			expect(isSocialPlatformHost('m.facebook.com')).toBe(true)
+			expect(isSocialPlatformHost('fr.linkedin.com')).toBe(true)
+			expect(isSocialPlatformHost('business.facebook.com')).toBe(true)
+		})
+
+		it('should read a host written in capitals', () => {
+			// GIVEN the same host written the other way
+			// WHEN asked
+			// THEN still a platform: a domain means the same however it was typed
+			expect(isSocialPlatformHost('FACEBOOK.COM')).toBe(true)
+			expect(isSocialPlatformHost('Es-La.Facebook.Com')).toBe(true)
+		})
+
+		it('should read a host with space around it', () => {
+			// GIVEN a host that arrived with whitespace on it
+			// WHEN asked — THEN the space is not part of anybody's domain
+			expect(isSocialPlatformHost(' facebook.com ')).toBe(true)
+		})
+
+		it('should read a host written with the dot a domain may end in', () => {
+			// GIVEN the fully-spelled form of the same domain, which a browser fetches
+			// exactly as it fetches the ordinary one
+			// WHEN asked
+			// THEN still a platform. Missing this is the one way left to hand back a
+			// Facebook page and have it kept — the address opens perfectly well
+			expect(isSocialPlatformHost('facebook.com.')).toBe(true)
+			expect(isSocialPlatformHost('es-la.facebook.com.')).toBe(true)
+		})
+	})
+
+	describe('when the host only resembles a platform', () => {
+		it('should refuse a host that merely ends in the same letters', () => {
+			// GIVEN a domain whose ending reads like a platform's without the dot that
+			// would make it one
+			// WHEN asked
+			// THEN it is somebody else's ordinary site. Whoever registered
+			// "notfacebook.com" owns it outright, and blanking their website would
+			// cost a real company its own address
+			expect(isSocialPlatformHost('notfacebook.com')).toBe(false)
+			expect(isSocialPlatformHost('myyoutu.be')).toBe(false)
+		})
+
+		it('should refuse a host that starts with a platform name', () => {
+			// GIVEN the agencies named after the platform they work on, which are
+			// ordinary companies with ordinary domains
+			// WHEN asked — THEN their own domains are their own
+			expect(isSocialPlatformHost('facebook-ads-agency.com')).toBe(false)
+			expect(isSocialPlatformHost('instagram-marketing.es')).toBe(false)
+		})
+
+		it('should refuse a host carrying a platform name in the middle', () => {
+			// GIVEN a domain that puts a platform's whole name where a subdomain would
+			// read, on a registrable domain of its own
+			// WHEN asked
+			// THEN it belongs to whoever registered "evil.example", not to the platform
+			// its earlier labels spell
+			expect(isSocialPlatformHost('facebook.com.evil.example')).toBe(false)
+		})
+
+		it('should refuse an ordinary company host', () => {
+			// GIVEN the sites this check exists to leave standing
+			// WHEN asked — THEN nothing here is a platform
+			expect(isSocialPlatformHost('acme.com')).toBe(false)
+			expect(isSocialPlatformHost('xpo.com')).toBe(false)
+			expect(isSocialPlatformHost('fusteriamiquel.cat')).toBe(false)
+		})
+	})
+
+	describe('when there is no host to read', () => {
+		it('should refuse an empty host', () => {
+			// GIVEN nothing at all
+			// WHEN asked — THEN nothing is a platform, which is what a caller with no
+			// address to read needs to hear
+			expect(isSocialPlatformHost('')).toBe(false)
+			expect(isSocialPlatformHost('   ')).toBe(false)
+		})
+
+		it('should refuse a bare word that is not a domain', () => {
+			// GIVEN an internal page id rather than a host
+			// WHEN asked — THEN it names no platform
+			expect(isSocialPlatformHost('src_abc123')).toBe(false)
+		})
+	})
+})

--- a/packages/research/src/application/social-sites.ts
+++ b/packages/research/src/application/social-sites.ts
@@ -1,0 +1,96 @@
+/**
+ * Whether a host is a social platform — a site that publishes pages FOR
+ * companies rather than BY them.
+ *
+ * A small firm often has no website at all. Asked for "the company's own
+ * official website", a run hands back the only web presence it could find, and
+ * that is the company's Facebook page. The answer is helpful and it is wrong:
+ * whoever clicks it lands on Facebook.
+ *
+ * Read as an address, "facebook.com/LIPOTECH.SARL" and
+ * "xpo.com/about-xpo-logistics" are the SAME SHAPE — a first-segment page naming
+ * the company on a host that does not — and `website-guard.ts` has to keep the
+ * second, because a company describing itself on its own site is exactly what
+ * that exemption protects. What separates them is what the host IS, which is the
+ * one thing an address cannot say and the one thing this file answers.
+ *
+ * ## Why a fixed list here, when `directory-sites.ts` refuses one
+ *
+ * That file's argument is that no list can name the business directories: every
+ * country has its own, so the ones a Spanish search meets are not the ones a
+ * French one does, and a list written in one market is blind in the next. It is
+ * right, and none of it carries over.
+ *
+ * **The set is bounded, and it is the same set everywhere.** A country can
+ * always add another register, another chamber, another yellow pages, and does.
+ * The platforms are a handful, and it is the same handful in Girona as in
+ * Toulouse.
+ *
+ * **Behaviour cannot answer this.** The watch next door works because a listing
+ * DOES something a run can see: it files more than one of the run's own
+ * companies at pages naming them. A platform holding one company's page behaves
+ * exactly like that company's own site, so the evidence that makes that watch
+ * possible is missing here — and the open-endedness that makes a list unsafe
+ * there is missing here.
+ *
+ * None of that licenses a hand-written list of directories: what carries the
+ * argument is a set fixed and known before any run starts, and a directory list
+ * is never that.
+ *
+ * The list names platforms, not every address that reaches one. No run has yet
+ * handed back a shortened link ("fb.com", "lnkd.in") as a company's website, so
+ * none is listed; add one when a run offers one.
+ *
+ * The hosts are the ones `entity-source-guard.ts` already names, LinkedIn added.
+ * That file asks a narrower question of the same platforms — whether a SOURCE is
+ * a post rather than a record — so it reads the path and lets a company's
+ * LinkedIn page stand as a citation, which is right: a page can be worth reading
+ * and still not be the company's website.
+ *
+ * ## What it costs, on purpose
+ *
+ * A platform loses its own website: asked about LinkedIn or about TikTok, this
+ * blanks the one address that really is the site.
+ *
+ * Paid rather than exempted, because the exemption was measured and it is the
+ * costlier of the two ways to be wrong. Exempting means reading who owns the
+ * host, and ownership is granted by any distinctive word of a name — so
+ * "Instagram Marketing SL" owns instagram.com by that reading, and "Facebook Ads
+ * Agency" owns facebook.com. Agencies named after the platform they work on are
+ * ordinary; platforms among these markets' installers and carriers are not.
+ */
+
+// Matched on the host alone, whatever path follows: a profile, a post and the
+// home page alike are somebody's account rather than a company's own site.
+const SOCIAL_PLATFORMS = [
+	'facebook.com',
+	'instagram.com',
+	'linkedin.com',
+	'x.com',
+	'twitter.com',
+	'tiktok.com',
+	'youtube.com',
+	'youtu.be',
+	'threads.net',
+] as const
+
+/**
+ * Whether this host is a social platform.
+ *
+ * A subdomain counts, since the platforms serve their own countries and their
+ * own devices from one ("es-la.facebook.com", "m.facebook.com"). A host that
+ * merely ends in the same letters does not: "notfacebook.com" and
+ * "facebook-ads-agency.com" are ordinary sites belonging to whoever registered
+ * them.
+ *
+ * Capitals, stray spaces and the dot a domain may end in are all read through: a
+ * domain means the same however it was typed, and one that slipped past would
+ * ship the page this exists to stop. The trailing dot matters most — an address
+ * carrying one is still fetchable, and still spells Facebook.
+ */
+export const isSocialPlatformHost = (host: string): boolean => {
+	const tidied = host.trim().toLowerCase().replace(/\.$/, '')
+	return SOCIAL_PLATFORMS.some(
+		platform => tidied === platform || tidied.endsWith(`.${platform}`),
+	)
+}

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -414,6 +414,7 @@ describe('guardCompanyWebsites', () => {
 			expect(result).toEqual({
 				findings,
 				blankedNotAnAddress: 0,
+				blankedSocialPage: 0,
 				blankedDirectory: 0,
 				blankedProfilePage: 0,
 				blankedSharedHost: 0,
@@ -2062,6 +2063,303 @@ describe('guardCompanyWebsites', () => {
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://directori.cat/empresa/algu',
 			])
+		})
+	})
+
+	describe('when the website is a page on a social platform', () => {
+		it('should blank the company own page on the platform', () => {
+			// GIVEN the row two live French market searches both returned: a small
+			// firm with no site of its own, given the only web presence anybody could
+			// find for it
+			const findings = cited([
+				{
+					name: 'LIPOTECH SARL',
+					website: 'https://www.facebook.com/LIPOTECH.SARL',
+					sources: ['https://www.facebook.com/LIPOTECH.SARL'],
+				},
+			])
+
+			// WHEN checked
+			// THEN the address goes. The page really is the company's, and it is
+			// still not the company's website — whoever opens it lands on Facebook
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should blank a competitor page as readily as a prospect one', () => {
+			// GIVEN the platform page on the other shape a scan answers with
+			const findings = scan([
+				{
+					name: 'LIPOTECH SARL',
+					website: 'https://www.facebook.com/LIPOTECH.SARL',
+				},
+			])
+
+			// WHEN checked — THEN blanked too. Which list a company arrived in says
+			// nothing about whose site the address is
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(websitesOf(result.findings)).toEqual([undefined])
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should blank a host written with the dot a domain may end in', () => {
+			// GIVEN the same page at the fully-spelled form of the host, which opens
+			// in a browser exactly as the ordinary one does
+			const findings = cited([
+				{
+					name: 'LIPOTECH SARL',
+					website: 'https://facebook.com./LIPOTECH.SARL',
+				},
+			])
+
+			// WHEN checked
+			// THEN blanked. An address a reader can open is an address that ships, so
+			// a spelling this check did not recognise would put the page back
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should blank a post inside a group on the platform', () => {
+			// GIVEN the other address the same searches returned — a post inside a
+			// group, which is not the company's page and not any company's site
+			const findings = cited([
+				{
+					name: 'LIPOTECH SARL',
+					website:
+						'https://www.facebook.com/groups/electricienfrance/posts/1408466207156608',
+					sources: ['https://annuaire.fr/lipotech', 'https://societe.com/x'],
+				},
+			])
+
+			// WHEN checked
+			// THEN blanked, whatever else the row cited. A row that cites a second
+			// page stands down the rule that reads citations, and the platform is the
+			// one reading that does not need them
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should blank a row that cites nothing at all', () => {
+			// GIVEN the platform page with no citations behind it
+			// WHEN checked
+			// THEN still blanked. What the host IS holds whether or not the row says
+			// where anything was read
+			const findings = cited([
+				{
+					name: 'LIPOTECH SARL',
+					website: 'https://www.facebook.com/LIPOTECH.SARL',
+				},
+			])
+
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should blank the platform home page given as a website', () => {
+			// GIVEN a row handed the platform itself, with no page under it
+			// WHEN checked
+			// THEN blanked. Elsewhere a bare host is left alone because there is no
+			// page to tell from the site; here the host is the whole answer
+			const findings = cited([
+				{ name: 'LIPOTECH SARL', website: 'https://facebook.com' },
+			])
+
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should blank a company page on any of the platforms', () => {
+			// GIVEN the same company filed on each platform in turn
+			// WHEN checked
+			// THEN every one of them goes. A LinkedIn page is as much the company's
+			// and as little its website as a Facebook one
+			const findings = cited([
+				{
+					name: 'Acme Logistics',
+					website: 'https://www.linkedin.com/company/acme-logistics',
+				},
+				{ name: 'Acme Logistics', website: 'https://x.com/acmelogistics' },
+				{
+					name: 'Acme Logistics',
+					website: 'https://www.instagram.com/acmelogistics/',
+				},
+				{
+					name: 'Acme Logistics',
+					website: 'https://www.youtube.com/@acmelogistics',
+				},
+			])
+
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+			])
+			expect(result.blankedSocialPage).toBe(4)
+		})
+
+		it('should blank the platform even when the company name spells its host', () => {
+			// GIVEN an agency named after the platform it works on, which is an
+			// ordinary kind of company
+			// WHEN checked
+			// THEN the page still goes. The host carrying a company's name is normally
+			// the strongest reason to keep an address, and it is read AFTER this one
+			// so a name cannot talk a platform into being somebody's site
+			const findings = cited([
+				{
+					name: 'Insta Logistics',
+					website: 'https://instagram.com/instalogistics',
+				},
+				{
+					name: 'Facebook Ads Agency',
+					website: 'https://www.facebook.com/fbadsagency',
+				},
+			])
+
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([undefined, undefined])
+			expect(result.blankedSocialPage).toBe(2)
+		})
+
+		it('should blank a row with no readable name beside it', () => {
+			// GIVEN a row named only by a legal form, which leaves every rule that
+			// weighs a name with nothing to weigh
+			// WHEN checked
+			// THEN blanked anyway, because this rule never asked for a name
+			const findings = cited([
+				{ name: 'SL', website: 'https://www.facebook.com/quelquun' },
+			])
+
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([undefined])
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should empty the run own answer for the target company', () => {
+			// GIVEN the run's own answer for the company it was asked about, which
+			// arrives alone with the page it was read from and no name beside it
+			const findings = {
+				website: {
+					value: 'https://www.facebook.com/LIPOTECH.SARL',
+					source_id: 'src_1',
+				},
+			}
+
+			// WHEN checked against the target's name
+			// THEN emptied, so a reader of the profile sees the field was asked for
+			// and not answered rather than seeing Facebook
+			const result = guardCompanyWebsites({
+				findings,
+				targetName: 'LIPOTECH SARL',
+				tradeWords: noTrades,
+			})
+			expect(result.findings).toEqual({ website: null })
+			expect(result.blankedSocialPage).toBe(1)
+		})
+
+		it('should put only the surviving address to the ownership question', () => {
+			// GIVEN a platform page beside a company at its own domain
+			// WHEN checked
+			// THEN an address that is gone has no ownership left to establish, so it
+			// lands in neither column — counting it as unvouched-for would read as a
+			// company whose site nothing backed
+			const findings = cited([
+				{
+					name: 'LIPOTECH SARL',
+					website: 'https://www.facebook.com/LIPOTECH.SARL',
+				},
+				{ name: 'Fusteria Miquel SL', website: 'https://fusteriamiquel.cat' },
+			])
+
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(result.ownSiteEstablished).toBe(1)
+			expect(result.ownSiteUnknown).toBe(0)
+		})
+
+		it('should count the blank under its own reason', () => {
+			// GIVEN one row per reason: a platform page, a listing page filing the
+			// company one level down, and a value that is not an address at all
+			const findings = cited([
+				{
+					name: 'LIPOTECH SARL',
+					website: 'https://www.facebook.com/LIPOTECH.SARL',
+				},
+				{
+					name: 'Redwood Logistics',
+					website: 'https://cbinsights.com/company/redwood-logistics',
+				},
+				{
+					name: 'Acme Freight',
+					website: 'https://acme.es (inferred from the name)',
+				},
+			])
+
+			// WHEN checked
+			// THEN each is counted under its own reason, so a reader of the run's
+			// numbers can tell how often a platform page was offered from how often a
+			// directory was
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(result.blankedSocialPage).toBe(1)
+			expect(result.blankedProfilePage).toBe(1)
+			expect(result.blankedNotAnAddress).toBe(1)
+			expect(result.blankedDirectory).toBe(0)
+			expect(result.blankedSharedHost).toBe(0)
+			expect(result.blankedReadPage).toBe(0)
+		})
+	})
+
+	describe('when a host only resembles a social platform', () => {
+		it('should keep a company own site whose domain starts with a platform name', () => {
+			// GIVEN the agencies named after the platforms they work on, this time at
+			// domains they registered themselves
+			const findings = cited([
+				{
+					name: 'Facebook Ads Agency',
+					website: 'https://facebook-ads-agency.com',
+				},
+				{
+					name: 'Instagram Marketing',
+					website: 'https://instagram-marketing.es',
+				},
+			])
+
+			// WHEN checked
+			// THEN both are kept. A platform's name inside somebody else's domain is
+			// not the platform, and blanking these would cost two real companies the
+			// site they publish
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://facebook-ads-agency.com',
+				'https://instagram-marketing.es',
+			])
+			expect(result.blankedSocialPage).toBe(0)
+		})
+
+		it('should keep a first-segment page on the company own domain', () => {
+			// GIVEN a company describing itself on its own site at the first path
+			// level — the same shape as a platform page and the reason no reading of
+			// an address alone can separate the two
+			const findings = cited([
+				{
+					name: 'XPO Logistics',
+					website: 'https://xpo.com/about-xpo-logistics',
+				},
+			])
+
+			// WHEN checked
+			// THEN kept. What saves it is the host: a company's own domain is no
+			// platform
+			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			expect(prospectWebsites(result.findings)).toEqual([
+				'https://xpo.com/about-xpo-logistics',
+			])
+			expect(result.blankedSocialPage).toBe(0)
 		})
 	})
 })

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -12,6 +12,9 @@
  *
  * The rule blanks a website only when it is clearly not the company's own:
  *  - the value is not a web address at all, or
+ *  - its host is a social platform, which publishes pages FOR companies rather
+ *    than BY them, so a page there is somebody else's site however plainly it
+ *    names the company (see `social-sites.ts`), or
  *  - its host is one this run watched file several of its own companies, or
  *  - its host does not carry the company's name AND the name sits in a deeper part
  *    of the address — the shape of "someone-else.com/company/<the-company>", which
@@ -58,6 +61,7 @@ import {
 } from './entity-guard'
 import { citedSourceIds, isPlainObject } from './guard-shapes'
 import { ownSiteHostVerdict, ownSiteVerdict } from './own-site'
+import { isSocialPlatformHost } from './social-sites'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
 import type { TradeWords } from './trade-words'
 
@@ -312,6 +316,7 @@ const hostBelongsTo = (
 type WebsiteVerdict =
 	| 'keep'
 	| 'not_an_address'
+	| 'social_page'
 	| 'directory'
 	| 'profile_page'
 	| 'shared_host'
@@ -340,6 +345,11 @@ const classifyWebsite = (args: {
 	// holding prose is worse than an empty one — nobody can open it, and it reads as
 	// a real site to everything downstream.
 	if (host === null || !isBareWebAddress(website)) return 'not_an_address'
+	// A page on a social platform. Asked before any rule that reads the company's
+	// name, or "Insta Logistics" keeps instagram.com as its own — and before the
+	// rules that turn on what else the run happened to meet, so the same page is
+	// blanked for the same stated reason every time.
+	if (isSocialPlatformHost(host)) return 'social_page'
 	// A host this run watched file several of its own companies. Any other host is
 	// `unknown`, which is no reason to blank a website and no clearance either — the
 	// rules below still have their say.
@@ -434,6 +444,8 @@ export interface WebsiteGuardResult {
 	readonly findings: unknown
 	/** Websites blanked because the value was not a web address. */
 	readonly blankedNotAnAddress: number
+	/** Websites blanked because their host was a social platform. */
+	readonly blankedSocialPage: number
 	/** Websites blanked because their host was watched filing several companies. */
 	readonly blankedDirectory: number
 	/** Websites blanked because the name sat in a deeper path of another host. */
@@ -517,6 +529,7 @@ export const guardCompanyWebsites = (args: {
 		tradeWords,
 	} = args
 	let blankedNotAnAddress = 0
+	let blankedSocialPage = 0
 	let blankedDirectory = 0
 	let blankedProfilePage = 0
 	let blankedSharedHost = 0
@@ -547,6 +560,7 @@ export const guardCompanyWebsites = (args: {
 
 	const count = (verdict: Exclude<WebsiteVerdict, 'keep'>): void => {
 		if (verdict === 'not_an_address') blankedNotAnAddress++
+		else if (verdict === 'social_page') blankedSocialPage++
 		else if (verdict === 'directory') blankedDirectory++
 		else if (verdict === 'profile_page') blankedProfilePage++
 		else if (verdict === 'shared_host') blankedSharedHost++
@@ -632,6 +646,7 @@ export const guardCompanyWebsites = (args: {
 	return {
 		findings: walk(findings),
 		blankedNotAnAddress,
+		blankedSocialPage,
 		blankedDirectory,
 		blankedProfilePage,
 		blankedSharedHost,


### PR DESCRIPTION
## What

A research run was putting a company's **Facebook page** into its `website` field, so anyone who clicked it landed on Facebook instead of the company. It happened to `LIPOTECH SARL` in two separate live French market searches, and while measuring this I found a third company doing the same in stored run data. This is in the Research surface (`packages/research`), in the guards that decide whether an address really belongs to the company a row is about.

## The fix

**Touches:** the website check that decides whether to keep an address, the ownership reading it and its neighbours share, and the two readings that pick which single page a run goes off to fetch — plus one new file holding the list they all consult.

- A page on a social platform is never a company's own website, so the website check now blanks one outright. This is checked before any rule that reads the company's name — otherwise a firm called "Insta Logistics" would keep `instagram.com` as its own — and before the rules that turn on whatever else the run happened to meet, so the same page is always blanked for the same stated reason.
- The ownership reading (`ownSiteHostVerdict` in `own-site.ts`) no longer treats a platform as a company's own site. Without this the two would contradict each other: one blanking the address while the other called it established, which is the thing this file family writes long comments to prevent.
- The two readings in `entity-guard.ts` that choose the one site a run goes and **reads** (`isOwnSiteHost`, `reachedOwnSite`) refuse a platform too — including for a company whose stored website already points at one. Otherwise the run anchors on Facebook and writes whatever it finds there onto the company row.

## Why nothing caught it before

`own-site.ts` already read the address correctly: `facebook.com/LIPOTECH.SARL` is `unknown`, and it is one of four cases that file documents as working. But `unknown` is not a blank, and every existing rule that could blank needs something this address withholds — the host does not carry the company's name, the name sits in the **first** path segment (deliberately exempted so a company's own "about us" page survives), only one row claims the host so the shared-host rule has no second claimant, and the rule that condemns a row citing nothing but the page itself cannot fire on a row citing anything else — and should not, since that address *does* name the company and that rule's whole logic is "nothing here names the company".

Read as an address, `facebook.com/LIPOTECH.SARL` and `xpo.com/about-xpo-logistics` are the **same shape**. Nothing in the address separates them. What separates them is what the host *is*: a platform publishes pages **for** companies rather than **by** them.

## The fixed-list decision, made in writing

`directory-sites.ts` argues against exactly this kind of hand-written list — "No fixed list of hosts can name them: every country has its own." That argument is right, and none of it carries over, which is written into `social-sites.ts` so it is not copied back onto directories:

- **The set is bounded and the same everywhere.** A country can always add another register, chamber or yellow pages, and does. The platforms are a handful, and it is the same handful in Girona as in Toulouse.
- **Watching behaviour cannot answer this one.** The directory watch works because a listing *does* something a run can see — it files several of the run's own companies at pages naming them. A platform holding one company's page behaves exactly like that company's own site, so there is nothing to observe.

**The obvious alternative was measured and rejected.** Exempting a company that "owns" the platform host fails wide open: `ownSiteHostVerdict` already answers `established` for "Instagram Marketing SL" at `instagram.com` and for "Facebook Ads Agency" at `facebook.com`, and agencies named after the platform they work on are ordinary. The cost of having no exemption — a platform loses its own website — is written down instead of paid for with that hole.

**Gating the website on the ownership verdict was also deliberately not done.** That verdict reads `unknown` for many genuine company sites, so using it to blank would take real websites away.

## Where such a value should go instead

Checked, as the issue asked: there is nowhere to put it. The scan schemas (`prospect-scan-v1`, `competitor-scan-v1`) carry only `website`; company enrichment carries `email`, `phone` and `website`. `facebook` is not one of the channel kinds either. Capturing a company's social page as a way of reaching it needs a schema field and an apply path, so it is left out of this change rather than half-built.

## Impact

- **Nothing about which organisation can see what (row-level security), no database change, no new settings the server needs at boot.** Purely a change to what a research run is allowed to write into one field.
- **Both the AI-tool surface and the ordinary HTTP one get it**, since the change sits in the shared guard, not in either transport.
- **The run's own log line gains one number** — `blanked_social_page` beside the existing per-reason counts — so how often this fires is visible without reading run output.
- **Some companies will now come back with no website where they previously came back with a Facebook page.** That is the point, and an empty field is honest where the old one was not, but it does mean the count of rows carrying a website drops slightly.
- Anything reading the guard's result gains a required `blankedSocialPage` field; the only reader is the research service, updated here.

## Review guide

- Start with `social-sites.ts` — it is the whole idea, and its comment carries the reasoning above.
- The riskiest line is the placement of the new check in `classifyWebsite` (`website-guard.ts`): it must sit **before** the rule that keeps an address whose host carries the company's name. A test pins this ("Insta Logistics" at `instagram.com`).
- **A decision you might overrule:** `isOwnSiteHost` now refuses a platform even when the company's stored website points at one, so a human who deliberately recorded a Facebook page as a company's site is overruled. I judged that right — by this change's own logic that stored value is the bug — but it is a judgement call.
- **Left alone deliberately:** a platform can now be branded a listing by the run's own directory watch, since it is no longer stepped over as anybody's own site. Its citations get graded down, which seems right, but nothing pins it.
- **Not healed:** company rows whose website was already set to a Facebook page keep that value in the database. This stops new ones being written; it does not clean up old ones.

## Tests

44 new unit tests across the four files, in the `/test-bdd` shape. Edge cases covered: subdomains a platform serves its own countries and phones from, capitals, stray whitespace, the trailing dot a domain may legally end in, a host that merely ends in the same letters (`notfacebook.com`), an agency at its own domain (`facebook-ads-agency.com`), a platform name buried in somebody else's domain (`facebook.com.evil.example`), a row with no readable name, a bare platform home page, a company page on each platform, both the prospect and competitor shapes, and the run's own answer for the company it was asked about.

Both must-not-regress cases are pinned and pass: the four addresses `own-site.ts` documents as correctly `unknown`, and the first-path-segment exemption that keeps `xpo.com/about-xpo-logistics`.

## Verification

- Gates run on this branch after rebasing onto current `main`: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (1950 research + 973 server), `pnpm -w build` (13/13).
- **Measured before/after over stored runs** — 13 real runs, 159 websites that actually shipped, identical input both sides. On `main`, `CélestInstallations` ships `facebook.com/share/1CtPJpK3i7/`; with this change it is removed. `OneFire` at `instagram.com/p/…` was already caught by an existing rule. **Zero** non-social websites are affected — the three directory blanks are byte-identical on both sides. Re-run after the rebase with the same result.
- **Live French market pass** (`fr-installations`, 11 rows, 14c, real scraping and LLM calls): no social address in any `website` field. The run met a Facebook **group post** — the exact shape from the issue — and handled it correctly: `B.I. Plomberie & Chauffage` cites that post as its *only* source and ships `https://biplomberie.fr`, its own domain. A page can be worth reading and still not be the company's website.

## Deferred

- Recording a company's social page as a way of reaching it, rather than dropping it — needs a schema field and an apply path (see above).
- Cleaning up company rows whose website already holds a social page.

Closes #477
