### PR TITLE
feat: keep a company's social page as a way of reaching it

### DIFF
--- a/apps/internal/src/components/contacts/channel-icons.ts
+++ b/apps/internal/src/components/contacts/channel-icons.ts
@@ -21,6 +21,7 @@ export const CHANNEL_ICON: Record<string, typeof MailIcon> = {
 	linkedin: Briefcase,
 	x: AtSign,
 	instagram: AtSign,
+	facebook: AtSign,
 	website: Globe,
 	bluesky: AtSign,
 } satisfies Record<ChannelKind, typeof MailIcon>

--- a/apps/internal/src/components/contacts/channel-kind-label.tsx
+++ b/apps/internal/src/components/contacts/channel-kind-label.tsx
@@ -24,6 +24,7 @@ export const useChannelKindLabel = (): ((kind: string) => string) => {
 		website: t`Website`,
 		linkedin: t`LinkedIn`,
 		instagram: t`Instagram`,
+		facebook: t`Facebook`,
 		x: t`X`,
 		bluesky: t`Bluesky`,
 	} satisfies Record<ChannelKind, string>

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -44,6 +44,13 @@ import {
 type ProspectEntry = {
 	readonly name: string
 	readonly website?: string
+	// A company with no site of its own often has one of these and nothing else,
+	// so they travel with the lead rather than staying in a finding nobody opens
+	// again.
+	readonly social_profiles?: ReadonlyArray<{
+		readonly kind: string
+		readonly value: string
+	}>
 	readonly tax_id?: string
 	readonly industry?: string
 	readonly country?: string
@@ -236,6 +243,14 @@ function AddAsLeadButton({
 	)
 	const [busy, setBusy] = useState(false)
 
+	// Only the pages that say both what platform they are and where. These come out
+	// of a model's answer, and one blank entry would otherwise make the whole
+	// request invalid — losing the lead over a footnote, with nothing on screen to
+	// say which row was at fault.
+	const usableProfiles = (prospect.social_profiles ?? [])
+		.filter(p => p.kind.trim() !== '' && p.value.trim() !== '')
+		.map(p => ({ kind: p.kind.trim(), value: p.value.trim() }))
+
 	const add = async () => {
 		setBusy(true)
 		const slug = toSlug(prospect.name)
@@ -248,6 +263,9 @@ function AddAsLeadButton({
 				...(prospect.country ? { country: prospect.country } : {}),
 				...(prospect.location ? { location: prospect.location } : {}),
 				...(prospect.website ? { website: prospect.website } : {}),
+				...(usableProfiles.length > 0
+					? { socialProfiles: usableProfiles }
+					: {}),
 			},
 		})
 		if (exit._tag !== 'Success') {

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -2467,6 +2467,10 @@ msgstr "Extraient conclusions"
 msgid "Extracting findings."
 msgstr "Extraient conclusions."
 
+#: src/components/contacts/channel-kind-label.tsx
+msgid "Facebook"
+msgstr "Facebook"
+
 #: src/components/research/findings/company-enrichment-view.tsx
 msgid "Fail"
 msgstr "No compleix"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -2467,6 +2467,10 @@ msgstr "Extracting findings"
 msgid "Extracting findings."
 msgstr "Extracting findings."
 
+#: src/components/contacts/channel-kind-label.tsx
+msgid "Facebook"
+msgstr "Facebook"
+
 #: src/components/research/findings/company-enrichment-view.tsx
 msgid "Fail"
 msgstr "Fail"

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -18,6 +18,7 @@ import {
 	CompanyPriority,
 	CompanySizeRange,
 	CompanySlug,
+	CompanySocialProfile,
 	CompanyStatus,
 	CompanyWebsite,
 	HandSetVerificationVerdict,
@@ -122,6 +123,10 @@ const companyInputFields = {
 	phone: Schema.optional(CompanyPhone),
 	instagram: Schema.optional(CompanyInstagram),
 	linkedin: Schema.optional(CompanyLinkedin),
+	socialProfiles: Schema.optional(Schema.Array(CompanySocialProfile)).annotate({
+		description:
+			"The pages this company keeps on social platforms, each as { kind, value } — kind lowercase and on its own ('facebook', 'tiktok'), value the full address. A page on a platform is not a website: put it here, never in `website`. Use manage_company_channels to change one later.",
+	}),
 	googleMapsUrl: Schema.optional(CompanyGoogleMapsUrl),
 	productsFit: Schema.optional(Schema.Array(Schema.String)),
 	tags: Schema.optional(Schema.Array(Schema.String)),
@@ -201,6 +206,12 @@ const UpdateCompany = Tool.make('update_company', {
 		email: Schema.optional(CompanyEmail),
 		phone: Schema.optional(CompanyPhone),
 		instagram: Schema.optional(CompanyInstagram),
+		socialProfiles: Schema.optional(
+			Schema.Array(CompanySocialProfile),
+		).annotate({
+			description:
+				'The pages this company keeps on social platforms, each as { kind, value }. A page on a platform is not a website: put it here, never in `website`.',
+		}),
 		linkedin: Schema.optional(CompanyLinkedin),
 		googleMapsUrl: Schema.optional(CompanyGoogleMapsUrl),
 		productsFit: Schema.optional(Schema.Array(Schema.String)),

--- a/apps/server/src/services/channels.test.ts
+++ b/apps/server/src/services/channels.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { clampConfidence } from './channels'
+import { clampConfidence, splitCompanyChannelFields } from './channels'
 
 describe('clampConfidence', () => {
 	describe('when the value is a 0–1 fraction (the research model scale)', () => {
@@ -49,6 +49,123 @@ describe('clampConfidence', () => {
 			expect(clampConfidence(Number.NaN)).toBeNull()
 			expect(clampConfidence(Number.POSITIVE_INFINITY)).toBeNull()
 			expect(clampConfidence(Number.NEGATIVE_INFINITY)).toBeNull()
+		})
+	})
+})
+
+describe('splitCompanyChannelFields', () => {
+	describe('when the write names ways of reaching the company', () => {
+		it('should take the named ones off the columns and store them as addresses', () => {
+			// GIVEN a write holding a column and the mailbox that used to be one
+			// WHEN split
+			// THEN the column stays a column and the mailbox becomes an address, marked
+			// as the one to use — it is the only email the caller gave
+			const { columns, channels } = splitCompanyChannelFields({
+				name: 'Acme',
+				email: 'info@acme.com',
+			})
+			expect(columns).toEqual({ name: 'Acme' })
+			expect(channels).toEqual([
+				{ kind: 'email', value: 'info@acme.com', is_primary: true },
+			])
+		})
+
+		it('should store each page a company keeps on a platform', () => {
+			// GIVEN the list a run fills for a company with no site of its own
+			// WHEN split
+			// THEN each page becomes an address under its own platform, and none of
+			// them lands in a column
+			const { columns, channels } = splitCompanyChannelFields({
+				name: 'LIPOTECH SARL',
+				socialProfiles: [
+					{ kind: 'facebook', value: 'https://facebook.com/LIPOTECH.SARL' },
+					{ kind: 'tiktok', value: 'https://tiktok.com/@lipotech' },
+				],
+			})
+			expect(columns).toEqual({ name: 'LIPOTECH SARL' })
+			expect(channels).toEqual([
+				{ kind: 'facebook', value: 'https://facebook.com/LIPOTECH.SARL' },
+				{ kind: 'tiktok', value: 'https://tiktok.com/@lipotech' },
+			])
+		})
+
+		it('should read the list under the name a research proposal uses', () => {
+			// GIVEN the same list spelled the way a model writes it, which is how it
+			// arrives on a proposal rather than from a typed client
+			// WHEN split — THEN the same addresses, so which door a write came through
+			// cannot change what is stored
+			const { columns, channels } = splitCompanyChannelFields({
+				social_profiles: [
+					{ kind: 'facebook', value: 'https://facebook.com/acme' },
+				],
+			})
+			expect(columns).toEqual({})
+			expect(channels).toEqual([
+				{ kind: 'facebook', value: 'https://facebook.com/acme' },
+			])
+		})
+
+		it('should not mark a page as the one to use for its kind', () => {
+			// GIVEN one page on a platform
+			// WHEN split
+			// THEN no mark is put down. A company has one page per platform, so the
+			// mark says nothing — and putting it down would hand it to whichever page
+			// arrived last if a company ever had two
+			const { channels } = splitCompanyChannelFields({
+				socialProfiles: [{ kind: 'facebook', value: 'https://facebook.com/a' }],
+			})
+			expect(channels[0]).not.toHaveProperty('is_primary')
+		})
+	})
+
+	describe('when the list holds something that is not a page', () => {
+		it('should step over an entry missing its platform or its address', () => {
+			// GIVEN a list with entries that say nothing usable
+			// WHEN split
+			// THEN only the whole ones are stored, and the write is not refused over
+			// them: these come out of a model's free-form answer, and a found address
+			// is the part worth having
+			const { channels } = splitCompanyChannelFields({
+				socialProfiles: [
+					{ kind: 'facebook' },
+					{ value: 'https://facebook.com/a' },
+					{ kind: '', value: 'https://facebook.com/b' },
+					{ kind: 'facebook', value: '   ' },
+					'not an object',
+					null,
+					{ kind: 'facebook', value: 'https://facebook.com/good' },
+				],
+			})
+			expect(channels).toEqual([
+				{ kind: 'facebook', value: 'https://facebook.com/good' },
+			])
+		})
+
+		it('should step over a value that is not a list at all', () => {
+			// GIVEN the field holding something that was never a list
+			// WHEN split — THEN nothing is stored and nothing is put in a column,
+			// since the field is not one the row has
+			const { columns, channels } = splitCompanyChannelFields({
+				socialProfiles: 'https://facebook.com/acme',
+			})
+			expect(columns).toEqual({})
+			expect(channels).toEqual([])
+		})
+
+		it('should trim what it stores, leaving the folding to the write', () => {
+			// GIVEN an entry copied with space around it and a capitalised platform
+			// WHEN split
+			// THEN the space is gone, because it is not part of anybody's address —
+			// while the capital is left alone, since a kind is folded once where it is
+			// written and doing it here as well would be a second place to keep right
+			const { channels } = splitCompanyChannelFields({
+				socialProfiles: [
+					{ kind: '  Facebook  ', value: '  https://facebook.com/a  ' },
+				],
+			})
+			expect(channels).toEqual([
+				{ kind: 'Facebook', value: 'https://facebook.com/a' },
+			])
 		})
 	})
 })

--- a/apps/server/src/services/channels.ts
+++ b/apps/server/src/services/channels.ts
@@ -63,6 +63,19 @@ const COMPANY_CHANNEL_FIELDS = [
 	'linkedin',
 ] as const
 
+// The one field that carries several ways of reaching a company at once. Kept
+// apart from the named fields above because it holds a LIST, and because what a
+// caller may put in it is not a fixed set: the platform is stored as it arrives.
+//
+// Both spellings, because both callers are real: a typed client and an MCP tool
+// send the camelCase name, while a research proposal carries the model's own
+// snake_case one. The named fields above are single words and so never had this
+// problem.
+const SOCIAL_PROFILES_FIELDS = new Set(['socialProfiles', 'social_profiles'])
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value)
+
 /**
  * Separate a company's write into the columns it really has and the ways of
  * reaching it, which live elsewhere now.
@@ -80,6 +93,22 @@ export const splitCompanyChannelFields = (
 	const columns: Record<string, unknown> = {}
 	const channels: Array<ChannelInput> = []
 	for (const [key, value] of Object.entries(data)) {
+		if (SOCIAL_PROFILES_FIELDS.has(key)) {
+			// None of these is marked as the one to use for its kind: a company's
+			// Facebook page is the only Facebook page it has, and the mark would go
+			// to whichever arrived last if it ever had two. An entry missing its
+			// platform or its address is stepped over rather than refusing the whole
+			// write, since these come out of a model's free-form answer.
+			for (const entry of Array.isArray(value) ? value : []) {
+				if (!isPlainObject(entry)) continue
+				const kind = entry['kind']
+				const address = entry['value']
+				if (typeof kind !== 'string' || typeof address !== 'string') continue
+				if (kind.trim() === '' || address.trim() === '') continue
+				channels.push({ kind: kind.trim(), value: address.trim() })
+			}
+			continue
+		}
 		if (!(COMPANY_CHANNEL_FIELDS as ReadonlyArray<string>).includes(key)) {
 			columns[key] = value
 			continue

--- a/packages/controllers/src/routes/companies.ts
+++ b/packages/controllers/src/routes/companies.ts
@@ -19,6 +19,7 @@ import {
 	CompanyPriority,
 	CompanySizeRange,
 	CompanySlug,
+	CompanySocialProfile,
 	CompanyStatus,
 	CompanyWebsite,
 	Contact,
@@ -92,6 +93,10 @@ export const CreateCompanyInput = Schema.Struct({
 	phone: Schema.optional(CompanyPhone),
 	instagram: Schema.optional(CompanyInstagram),
 	linkedin: Schema.optional(CompanyLinkedin),
+	// Every other platform the company keeps a page on. Instagram and LinkedIn
+	// keep their own fields because callers already send them that way; anything
+	// else arrives here, and all of them are stored the same.
+	socialProfiles: Schema.optional(Schema.Array(CompanySocialProfile)),
 	googleMapsUrl: Schema.optional(CompanyGoogleMapsUrl),
 	productsFit: Schema.optional(Schema.Array(Schema.String)),
 	tags: Schema.optional(Schema.Array(Schema.String)),
@@ -135,6 +140,7 @@ export const UpdateCompanyInput = Schema.Struct({
 	phone: Schema.optional(Schema.NullOr(CompanyPhone)),
 	instagram: Schema.optional(Schema.NullOr(CompanyInstagram)),
 	linkedin: Schema.optional(Schema.NullOr(CompanyLinkedin)),
+	socialProfiles: Schema.optional(Schema.Array(CompanySocialProfile)),
 	googleMapsUrl: Schema.optional(Schema.NullOr(CompanyGoogleMapsUrl)),
 	productsFit: Schema.optional(Schema.NullOr(Schema.Array(Schema.String))),
 	tags: Schema.optional(Schema.NullOr(Schema.Array(Schema.String))),

--- a/packages/domain/src/schema/channel-address.ts
+++ b/packages/domain/src/schema/channel-address.ts
@@ -33,6 +33,7 @@ export const CHANNEL_KINDS = [
 	'linkedin',
 	'x',
 	'instagram',
+	'facebook',
 	'website',
 	'bluesky',
 ] as const
@@ -49,6 +50,12 @@ export const INSTAGRAM_ADDRESS_PATTERN =
 	/^(@?[A-Za-z0-9._]{1,30}|https?:\/\/(www\.)?instagram\.com\/.+)$/
 export const LINKEDIN_ADDRESS_PATTERN =
 	/^(https?:\/\/)?([a-z]{2,3}\.)?linkedin\.com\/.+$/i
+// Something has to follow the host, so the platform's own home page is not an
+// address for anybody. Any subdomain counts, since Facebook serves each country
+// and the phone from its own ("es-la.facebook.com", "m.facebook.com") and that
+// is the address a person copies.
+export const FACEBOOK_ADDRESS_PATTERN =
+	/^(https?:\/\/)?([a-z0-9-]+\.)*facebook\.com\/.+$/i
 export const MAPS_ADDRESS_PATTERN =
 	/^https?:\/\/([a-z0-9-]+\.)*(google\.[a-z.]+|goo\.gl)\/.+/i
 
@@ -59,6 +66,7 @@ const BY_KIND: Record<string, RegExp> = {
 	website: WEBSITE_ADDRESS_PATTERN,
 	instagram: INSTAGRAM_ADDRESS_PATTERN,
 	linkedin: LINKEDIN_ADDRESS_PATTERN,
+	facebook: FACEBOOK_ADDRESS_PATTERN,
 }
 
 /**

--- a/packages/domain/src/schema/companies.ts
+++ b/packages/domain/src/schema/companies.ts
@@ -111,6 +111,16 @@ export const CompanyLinkedin = Schema.String.pipe(
 export const CompanyGoogleMapsUrl = Schema.String.pipe(
 	Schema.check(Schema.isPattern(MAPS_ADDRESS_PATTERN)),
 )
+// A page the company keeps on a platform. A list of kind-and-address pairs
+// rather than a field per platform, because which platforms exist is not this
+// schema's business to know: the kind is stored as it arrives, the way a channel
+// always has been, so a platform nobody has met yet needs no change here. The
+// address is only asked to say something, since a kind nothing describes has no
+// shape to hold it to.
+export const CompanySocialProfile = Schema.Struct({
+	kind: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+	value: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+})
 // Finite rather than a plain number: a plain number also allows the words "NaN"
 // and "Infinity", which no place on Earth has, and which reach the database as a
 // server error instead of a refused value.

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -54,6 +54,7 @@ export {
 	CompanyPriority,
 	CompanySizeRange,
 	CompanySlug,
+	CompanySocialProfile,
 	CompanyStatus,
 	CompanyWebsite,
 } from './companies'

--- a/packages/research/src/application/extraction-fill.test.ts
+++ b/packages/research/src/application/extraction-fill.test.ts
@@ -19,7 +19,10 @@ describe('ENRICHMENT_FIELDS', () => {
 		// GIVEN the field list derived from the enrichment schema
 		// THEN it is exactly the fields the model is asked to fill, which is what
 		// the fullness measure divides by — so a field added to the schema has to be
-		// added here too, on purpose, rather than quietly shifting the denominator
+		// added here too, on purpose, rather than quietly shifting the denominator.
+		// The pages a company keeps on platforms count among them, beside its
+		// mailbox and its number. Some companies publish none, but a run that could
+		// have found one and did not is exactly what this measure is for
 		expect([...ENRICHMENT_FIELDS].sort()).toEqual([
 			'country',
 			'current_tools',
@@ -28,6 +31,7 @@ describe('ENRICHMENT_FIELDS', () => {
 			'location',
 			'phone',
 			'size_range',
+			'social_profiles',
 			'tags',
 			'tax_id',
 			'website',

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -171,6 +171,7 @@ import {
 	schemaFieldNames,
 	schemaNameFor,
 } from './schemas/index'
+import { rescueSocialWebsites } from './social-website-rescue'
 import {
 	hostOf,
 	isWebAddress,
@@ -2883,19 +2884,25 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						pass: 'extraction' | 'folded',
 					) =>
 						Effect.gen(function* () {
+							// A company's page on a platform, moved onto the company before the
+							// check below can drop it for not being a website. Run first so that
+							// what the check condemns is what nothing could keep, and so the check
+							// itself goes on only ever taking values away.
+							const rescue = rescueSocialWebsites(answer)
+
 							// Which sites this run watched file several of its own companies. Worked
 							// out per call rather than once, because the organisation-kind link drops
 							// the rows that are not companies at all, a trade body's own name must not
 							// be one of the names a host is judged by, and a fold puts companies in
 							// front of the watch that no single extraction held.
 							const directories = observeDirectorySites({
-								findings: answer,
+								findings: rescue.findings,
 								listField: discoveryResultField(schemaName),
 								addresses: [...gatheredAddresses],
 								tradeWords: runTradeWords,
 							})
 							const check = guardCompanyWebsites({
-								findings: answer,
+								findings: rescue.findings,
 								targetName,
 								directorySites: directories.sites,
 								priorClaims: websiteClaims,
@@ -2909,7 +2916,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								check.blankedProfilePage +
 								check.blankedSharedHost +
 								check.blankedReadPage
-							if (blanked > 0) {
+							if (blanked > 0 || rescue.rescued > 0) {
 								yield* Effect.logWarning('research.websites.blanked').pipe(
 									Effect.annotateLogs({
 										event: 'research.websites.blanked',
@@ -2920,6 +2927,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										pass,
 										blanked_not_an_address: check.blankedNotAnAddress,
 										blanked_social_page: check.blankedSocialPage,
+										// Pages kept as a way of reaching the company rather than
+										// dropped — read beside the blanks, since a run that rescued
+										// several and blanked none is a different run from a quiet one.
+										rescued_social_profile: rescue.rescued,
 										blanked_directory: check.blankedDirectory,
 										blanked_profile_page: check.blankedProfilePage,
 										blanked_shared_host: check.blankedSharedHost,
@@ -2952,7 +2963,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									}),
 								)
 							}
-							return { check, blanked, directories }
+							return { check, blanked, directories, rescued: rescue.rescued }
 						})
 
 					// Phase-2 extraction + every grounding guard, shared so both the
@@ -3448,12 +3459,15 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									name: 'websites',
 									run: findings =>
 										Effect.gen(function* () {
-											const { check, blanked, directories } =
+											const { check, blanked, directories, rescued } =
 												yield* checkWebsites(findings, 'extraction')
 											return {
 												findings: check.findings,
 												spanCounts: {
 													'research.websites.blanked': blanked,
+													// A page kept as a way of reaching the company
+													// instead of being dropped for not being a website.
+													'research.websites.rescued_social': rescued,
 													// Both numbers, because they say different things: no
 													// directory found out of no addresses read is plumbing
 													// broken, out of two hundred it is a real quiet answer.

--- a/packages/research/src/application/schemas/_shared.ts
+++ b/packages/research/src/application/schemas/_shared.ts
@@ -140,3 +140,30 @@ export const PendingPaidAction = Schema.Struct({
 	estimated_cents: LenientNumber,
 	reason: Schema.String,
 })
+
+// A company's page on a social platform, as a run reports one.
+//
+// Deliberately NOT the open channel list a contact carries. A contact has no
+// named way of holding an email or a telephone number, so its list is the only
+// door and has to take everything. A company already names its mailbox, its
+// number and its website, and a second list that also accepted those would give
+// one company two answers to "what is its email", which is the very thing those
+// named fields exist to prevent. So this holds only what they cannot: the pages
+// a company keeps on platforms, which are not its website.
+//
+// `kind` stays free text rather than a fixed list, because a platform nobody has
+// met yet needs no change here and an unknown one is stored and shown as it
+// arrived. What bounds it in practice is the description the model is given.
+export const SocialProfile = Schema.Struct({
+	kind: Schema.String.annotate({
+		description:
+			'The platform, lowercase and on its own: facebook, instagram, linkedin, x, tiktok, youtube, threads.',
+	}),
+	value: Schema.String.annotate({
+		description: "The full address of the company's page on that platform.",
+	}),
+	// Required + nullable for the same reason a citation's confidence is: an
+	// optionalKey around a union serialises to a nested anyOf that a strict
+	// provider refuses, so a profile with no confidence sends null.
+	confidence: LenientNumber,
+})

--- a/packages/research/src/application/schemas/company-enrichment-v1.ts
+++ b/packages/research/src/application/schemas/company-enrichment-v1.ts
@@ -5,6 +5,7 @@ import {
 	DiscoveredExisting,
 	PendingPaidAction,
 	ProposedUpdate,
+	SocialProfile,
 	Sourced,
 } from './_shared'
 
@@ -71,10 +72,15 @@ export const CompanyEnrichmentV1Schema = Schema.Struct({
 			Sourced(
 				Schema.String.annotate({
 					description:
-						"The company's own official website. It must be the site the company runs — not a directory or aggregator profile page about the company, and not a social-media page.",
+						"The company's own official website. It must be the site the company runs — not a directory or aggregator profile page about the company, and not a social-media page. A page on a platform goes in `social_profiles` instead, even when it is the only web presence you can find.",
 				}),
 			),
 		),
+		// Where the social-media pages the website field refuses belong. A company
+		// with no site of its own often has one of these and nothing else, and it
+		// is worth keeping as a way of reaching the company rather than being lost
+		// for not being a website.
+		social_profiles: Schema.optionalKey(Schema.Array(SocialProfile)),
 	}),
 	// The fit judgement the run reaches. It was previously written only into the
 	// human brief and lost from the structured output, so a consumer reading

--- a/packages/research/src/application/schemas/prospect-scan-v1.ts
+++ b/packages/research/src/application/schemas/prospect-scan-v1.ts
@@ -6,6 +6,7 @@ import {
 	LenientNumber,
 	PendingPaidAction,
 	ProposedUpdate,
+	SocialProfile,
 	Sourced,
 } from './_shared'
 
@@ -15,8 +16,13 @@ export const ProspectScanV1Schema = Schema.Struct({
 			name: Schema.String,
 			website: Schema.optionalKey(Schema.String).annotate({
 				description:
-					"The prospect's own official website. It must belong to the named company — not a directory/aggregator profile page and not another company that happened to appear in search results.",
+					"The prospect's own official website — the site the company itself runs. It must belong to the named company: not a directory/aggregator profile page, not another company that happened to appear in search results, and not a page on a social platform. A company's Facebook, Instagram or LinkedIn page goes in `social_profiles`, never here, even when it is the only web presence you can find.",
 			}),
+			// Where the company can be found on a platform, which is not the same
+			// question as its website and must not be answered in that field: a page
+			// on Facebook belongs to whoever opened the account, and a reader sent
+			// there instead of to the company's own site has been misled.
+			social_profiles: Schema.optionalKey(Schema.Array(SocialProfile)),
 			tax_id: Schema.optionalKey(Schema.String),
 			industry: Schema.optionalKey(Schema.String),
 			country: Schema.optionalKey(

--- a/packages/research/src/application/social-sites.test.ts
+++ b/packages/research/src/application/social-sites.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isSocialPlatformHost } from './social-sites'
+import { isSocialPlatformHost, socialProfileOf } from './social-sites'
 
 describe('isSocialPlatformHost', () => {
 	describe('when the host is a platform', () => {
@@ -112,6 +112,209 @@ describe('isSocialPlatformHost', () => {
 			// GIVEN an internal page id rather than a host
 			// WHEN asked — THEN it names no platform
 			expect(isSocialPlatformHost('src_abc123')).toBe(false)
+		})
+	})
+})
+
+describe('socialProfileOf', () => {
+	describe('when the address is a company page on a platform', () => {
+		it('should read a page at the top level of the platform', () => {
+			// GIVEN the page a small firm opened in its own name
+			// WHEN read
+			// THEN it is that company's page on Facebook, under the name a channel is
+			// stored by
+			expect(socialProfileOf('https://www.facebook.com/LIPOTECH.SARL')).toEqual(
+				{
+					kind: 'facebook',
+					value: 'https://facebook.com/LIPOTECH.SARL',
+				},
+			)
+			expect(
+				socialProfileOf('https://www.instagram.com/acmelogistics/'),
+			).toEqual({
+				kind: 'instagram',
+				value: 'https://instagram.com/acmelogistics',
+			})
+		})
+
+		it('should read the two names one platform answers to as one channel', () => {
+			// GIVEN the same account reached by the platform's old name and its new one
+			// WHEN each is read
+			// THEN both are the same kind of channel, or one company would hold two
+			// that are the same thing
+			expect(socialProfileOf('https://x.com/acme')?.kind).toBe('x')
+			expect(socialProfileOf('https://twitter.com/acme')?.kind).toBe('x')
+		})
+
+		it("should read a company page filed under a word of the platform's own", () => {
+			// GIVEN LinkedIn, where a company's page sits under "company" and never at
+			// the top level
+			// WHEN read — THEN it is the company's page
+			expect(
+				socialProfileOf('https://www.linkedin.com/company/acme-logistics'),
+			).toEqual({
+				kind: 'linkedin',
+				value: 'https://linkedin.com/company/acme-logistics',
+			})
+			expect(
+				socialProfileOf('https://fr.linkedin.com/company/acme/')?.kind,
+			).toBe('linkedin')
+		})
+
+		it('should read an account written with the mark its platform uses', () => {
+			// GIVEN the platforms that write an account as "@name"
+			// WHEN read — THEN the mark is what says it is an account
+			expect(socialProfileOf('https://www.tiktok.com/@acme')?.kind).toBe(
+				'tiktok',
+			)
+			expect(socialProfileOf('https://www.threads.net/@acme')?.kind).toBe(
+				'threads',
+			)
+			expect(socialProfileOf('https://www.youtube.com/@acme')?.kind).toBe(
+				'youtube',
+			)
+		})
+
+		it('should read the older ways a channel is written', () => {
+			// GIVEN the three forms YouTube used before the "@name" one
+			// WHEN read — THEN each is still that company's channel
+			for (const url of [
+				'https://www.youtube.com/channel/UC123',
+				'https://www.youtube.com/c/acme',
+				'https://www.youtube.com/user/acme',
+			]) {
+				expect(socialProfileOf(url)?.kind).toBe('youtube')
+			}
+		})
+
+		it('should give one page one address however it was written', () => {
+			// GIVEN the spellings one page arrives in across rounds and sources — with
+			// and without the www, with and without a trailing slash, and carrying the
+			// parameters a shared link picks up
+			const spellings = [
+				'https://www.facebook.com/acme',
+				'https://facebook.com/acme',
+				'https://facebook.com/acme/',
+				'https://www.facebook.com/acme?ref=share&fbclid=abc',
+				'https://m.facebook.com/acme',
+			]
+
+			// WHEN each is read
+			// THEN all of them give the same address. This is a stored way of reaching
+			// the company, and two spellings kept apart would list one firm as having
+			// two Facebooks
+			for (const spelling of spellings) {
+				expect(socialProfileOf(spelling)?.value).toBe(
+					'https://facebook.com/acme',
+				)
+			}
+		})
+
+		it('should keep the capitals an address needs to work', () => {
+			// GIVEN a YouTube channel, which is filed under an id where the capitals
+			// count
+			// WHEN read
+			// THEN they survive. Folding an address to lowercase to tidy it would hand
+			// back a link to nothing
+			expect(
+				socialProfileOf('https://www.youtube.com/channel/UCa1B2c3D')?.value,
+			).toBe('https://youtube.com/channel/UCa1B2c3D')
+		})
+
+		it('should read a page at a host written with a trailing dot', () => {
+			// GIVEN the fully-spelled form of the host, which opens the same page
+			// WHEN read — THEN the same page, so the dot cannot lose a real channel
+			expect(socialProfileOf('https://facebook.com./LIPOTECH.SARL')?.kind).toBe(
+				'facebook',
+			)
+		})
+	})
+
+	describe("when the address is not the company's own page", () => {
+		it('should refuse the two addresses a market search actually offered', () => {
+			// GIVEN the pair a live search handed back as company websites: a share
+			// link that spells nothing, and one post
+			// WHEN read
+			// THEN neither becomes a channel. Recording either as "the company's
+			// Facebook" writes down something that was never true
+			expect(
+				socialProfileOf('https://www.facebook.com/share/1CtPJpK3i7/'),
+			).toBeNull()
+			expect(
+				socialProfileOf('https://www.instagram.com/p/DTxItU0lfKN/'),
+			).toBeNull()
+		})
+
+		it("should refuse a post inside somebody's group", () => {
+			// GIVEN a post in a trade group that has nothing to do with the company
+			// WHEN read — THEN not a page anybody opened in their own name
+			expect(
+				socialProfileOf(
+					'https://www.facebook.com/groups/electricienfrance/posts/1408466207156608',
+				),
+			).toBeNull()
+		})
+
+		it("should refuse a person's own profile", () => {
+			// GIVEN the profile of somebody who works there
+			// WHEN read — THEN a person is not the company, however senior they are
+			expect(socialProfileOf('https://www.linkedin.com/in/jane-doe')).toBeNull()
+		})
+
+		it('should refuse one item an account published', () => {
+			// GIVEN a post, a reel and a video
+			// WHEN read — THEN each belongs to an account the address does not name,
+			// so there is nothing here to record as anybody's page
+			for (const url of [
+				'https://x.com/acme/status/123',
+				'https://www.instagram.com/reel/xyz/',
+				'https://www.tiktok.com/@acme/video/123',
+				'https://www.youtube.com/watch?v=abc',
+				'https://www.linkedin.com/posts/xyz',
+			]) {
+				expect(socialProfileOf(url)).toBeNull()
+			}
+		})
+
+		it('should refuse a shortened video link', () => {
+			// GIVEN the shortener a video is shared by, which never points at an
+			// account
+			// WHEN read — THEN nothing
+			expect(socialProfileOf('https://youtu.be/abc123')).toBeNull()
+		})
+
+		it('should refuse a word the platform reserved for itself', () => {
+			// GIVEN addresses whose first part is the platform's own word rather than
+			// anybody's account name
+			// WHEN read — THEN refused, since none of them names an account
+			for (const url of [
+				'https://www.facebook.com/profile.php?id=123',
+				'https://www.facebook.com/marketplace/acme',
+				'https://x.com/search',
+				'https://www.instagram.com/explore/',
+			]) {
+				expect(socialProfileOf(url)).toBeNull()
+			}
+		})
+
+		it("should refuse the platform's own home page", () => {
+			// GIVEN the platform with nothing after it
+			// WHEN read — THEN there is no account here to reach anybody at
+			expect(socialProfileOf('https://facebook.com')).toBeNull()
+			expect(socialProfileOf('https://facebook.com/')).toBeNull()
+		})
+
+		it('should refuse an ordinary company site', () => {
+			// GIVEN a company's own website, which is not a platform at all
+			// WHEN read — THEN nothing, and the website check keeps it as it always did
+			expect(socialProfileOf('https://acme.com/about')).toBeNull()
+		})
+
+		it('should refuse a value that is not one address', () => {
+			// GIVEN a value with an aside written next to it, which nobody can open
+			// WHEN read — THEN nothing
+			expect(socialProfileOf('https://facebook.com/acme (probably)')).toBeNull()
+			expect(socialProfileOf('')).toBeNull()
 		})
 	})
 })

--- a/packages/research/src/application/social-sites.ts
+++ b/packages/research/src/application/social-sites.ts
@@ -60,6 +60,8 @@
  * ordinary; platforms among these markets' installers and carriers are not.
  */
 
+import { hostOf, isBareWebAddress } from './source-key'
+
 // Matched on the host alone, whatever path follows: a profile, a post and the
 // home page alike are somebody's account rather than a company's own site.
 const SOCIAL_PLATFORMS = [
@@ -93,4 +95,185 @@ export const isSocialPlatformHost = (host: string): boolean => {
 	return SOCIAL_PLATFORMS.some(
 		platform => tidied === platform || tidied.endsWith(`.${platform}`),
 	)
+}
+
+/**
+ * A way of reaching a company on a platform: which platform, and the address.
+ *
+ * The address is not the company's website — that is what the check above
+ * settles — but its page on a platform is still worth keeping, the way its
+ * telephone number is.
+ */
+export interface SocialProfile {
+	/** The platform, as a channel is stored under: "facebook", "linkedin", … */
+	readonly kind: string
+	/** The address as it was given. */
+	readonly value: string
+}
+
+// Which platform a host belongs to, under the name a channel is stored by. The
+// two names Twitter answers to are one platform and one channel.
+const KIND_BY_HOST: ReadonlyArray<readonly [string, string]> = [
+	['facebook.com', 'facebook'],
+	['instagram.com', 'instagram'],
+	['linkedin.com', 'linkedin'],
+	['x.com', 'x'],
+	['twitter.com', 'x'],
+	['tiktok.com', 'tiktok'],
+	['youtube.com', 'youtube'],
+	['threads.net', 'threads'],
+]
+
+// The words each platform has taken for itself, so an address starting with one
+// names no account. A refusal list rather than a list of the names allowed,
+// because what a company may call itself is unbounded while what the platform
+// has taken is not.
+const RESERVED: Record<string, ReadonlySet<string>> = {
+	facebook: new Set([
+		'groups',
+		'share',
+		'sharer.php',
+		'watch',
+		'reel',
+		'story.php',
+		'permalink.php',
+		'profile.php',
+		'photo',
+		'photo.php',
+		'media',
+		'events',
+		'marketplace',
+		'hashtag',
+		'search',
+		'pages',
+		'p',
+		'login',
+		'help',
+		'policies',
+	]),
+	instagram: new Set([
+		'p',
+		'reel',
+		'reels',
+		'explore',
+		'stories',
+		'tv',
+		'accounts',
+		'direct',
+	]),
+	x: new Set([
+		'i',
+		'home',
+		'search',
+		'explore',
+		'hashtag',
+		'intent',
+		'share',
+		'status',
+		'notifications',
+		'messages',
+		'settings',
+	]),
+}
+
+// The path with its capitals left on. `pathOf` folds a path to lowercase, which
+// is what comparing a segment against a word a platform reserved wants and the
+// opposite of what the address itself wants: a YouTube channel is filed under an
+// id where the capitals count, so a lowercased one links to nothing.
+const pathAsWritten = (url: string): string => {
+	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(url)
+		? url
+		: `https://${url}`
+	try {
+		return new URL(withScheme).pathname
+	} catch {
+		return ''
+	}
+}
+
+/**
+ * The company's own page on a platform, or null when the address is not one.
+ *
+ * A page a company opened in its own name is a way of reaching it. A post inside
+ * somebody's group, a video, a share link that spells nothing, a person's own
+ * profile — none of those is, and recording one as "the company's Facebook"
+ * writes down something that was never true. So each platform is read for the
+ * shape its ACCOUNT pages take, and everything else is refused.
+ *
+ * The refusals are the point, and the two addresses a market search actually
+ * offered are both among them: "facebook.com/share/1CtPJpK3i7/" says only that
+ * somebody pressed share, and "instagram.com/p/DTxItU0lfKN/" is one post, which
+ * belongs to an account this address does not name. Neither becomes a channel.
+ *
+ * Refusing a real page costs a way of reaching the company that nobody had a
+ * minute ago, and anybody who looks can put it back. Accepting one that is not
+ * the company's puts a stranger's page on the row under the company's own name,
+ * where the next person to read it has no reason to doubt it. So an address that
+ * does not plainly take the shape of an account is refused.
+ */
+export const socialProfileOf = (url: string): SocialProfile | null => {
+	const host = hostOf(url)
+	if (host === null || !isBareWebAddress(url)) return null
+	const tidied = host.trim().toLowerCase().replace(/\.$/, '')
+	const matched = KIND_BY_HOST.find(
+		([site]) => tidied === site || tidied.endsWith(`.${site}`),
+	)
+	if (matched === undefined) return null
+	const [site, kind] = matched
+
+	const segments = pathAsWritten(url)
+		.split('/')
+		.filter(Boolean)
+		.map(segment => segment.trim())
+	const written = segments[0]
+	if (written === undefined) return null
+	// Compared in one case, kept in the other: which word a platform reserved is
+	// not a question about capitals, while the address itself is.
+	const first = written.toLowerCase()
+
+	// The answer if the address does turn out to take the shape of an account.
+	//
+	// Written back from what was read rather than kept as it arrived, because this
+	// becomes a stored way of reaching the company and two spellings of one page
+	// would be stored as two — a company listed as having two Facebooks. So the
+	// platform's own host stands in for whichever door the address came through
+	// (the mobile one, a country's), the trailing slash goes, and so do the
+	// tracking parameters a shared link picks up: a page is the same page whichever
+	// link reached it.
+	const profile = {
+		kind,
+		value: `https://${site}/${segments.join('/')}`,
+	}
+
+	// A company keeps its page under "company" or "showcase"; "in" is one person,
+	// and a person is not the company however senior they are.
+	if (kind === 'linkedin')
+		return segments.length === 2 &&
+			(first === 'company' || first === 'showcase')
+			? profile
+			: null
+
+	// The handle platforms write an account as "@name" and everything else under a
+	// word of their own, so the mark IS the tell and no refusal list is needed.
+	if (kind === 'tiktok' || kind === 'threads')
+		return segments.length === 1 && first.startsWith('@') ? profile : null
+
+	// A channel is written four ways here, one of them the same "@name" the others
+	// use, and the rest a word of YouTube's own followed by the name.
+	if (kind === 'youtube') {
+		if (segments.length === 1 && first.startsWith('@')) return profile
+		return segments.length === 2 &&
+			(first === 'c' || first === 'channel' || first === 'user')
+			? profile
+			: null
+	}
+
+	// The rest put an account at the top level, so one segment that the platform
+	// has not reserved is the account's own name. A platform read this way with no
+	// list of its own words yet would take every address as an account, so it is
+	// refused until somebody writes the list — the direction this file is allowed
+	// to be wrong in.
+	const reserved = RESERVED[kind]
+	if (reserved === undefined) return null
+	return segments.length === 1 && !reserved.has(first) ? profile : null
 }

--- a/packages/research/src/application/social-website-rescue.test.ts
+++ b/packages/research/src/application/social-website-rescue.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest'
+
+import { rescueSocialWebsites } from './social-website-rescue'
+
+// A scanned company the way a market search returns one.
+const scan = (rows: ReadonlyArray<{ name: string; website?: string }>) => ({
+	prospects: rows.map(({ name, website }) => ({
+		name,
+		...(website === undefined ? {} : { website }),
+		citations: [],
+	})),
+})
+
+const rowsOf = (findings: unknown) =>
+	(
+		findings as {
+			prospects: Array<{
+				website?: string
+				social_profiles?: Array<{ kind: string; value: string }>
+			}>
+		}
+	).prospects
+
+describe('rescueSocialWebsites', () => {
+	describe('when a scanned company was given its page on a platform', () => {
+		it('should move the page onto the company and empty the website', () => {
+			// GIVEN a small firm with no site of its own, handed back the only web
+			// presence anybody could find for it
+			const findings = scan([
+				{
+					name: 'LIPOTECH SARL',
+					website: 'https://www.facebook.com/LIPOTECH.SARL',
+				},
+			])
+
+			// WHEN the pages are rescued
+			// THEN the company ends up with no website and a Facebook page, which is
+			// the truth about it
+			const result = rescueSocialWebsites(findings)
+			expect(result.rescued).toBe(1)
+			expect(rowsOf(result.findings)[0]?.website).toBeUndefined()
+			expect(rowsOf(result.findings)[0]?.social_profiles).toEqual([
+				{ kind: 'facebook', value: 'https://facebook.com/LIPOTECH.SARL' },
+			])
+		})
+
+		it('should keep the pages a company already reported', () => {
+			// GIVEN a company that reported its Instagram itself and was also handed
+			// its Facebook page as a website
+			const findings = {
+				prospects: [
+					{
+						name: 'Acme',
+						website: 'https://www.facebook.com/acme',
+						social_profiles: [
+							{ kind: 'instagram', value: 'https://instagram.com/acme' },
+						],
+						citations: [],
+					},
+				],
+			}
+
+			// WHEN rescued
+			// THEN the rescued page joins the one already there rather than replacing
+			// it, since a company reached two ways is reachable both of them
+			const result = rescueSocialWebsites(findings)
+			expect(rowsOf(result.findings)[0]?.social_profiles).toEqual([
+				{ kind: 'instagram', value: 'https://instagram.com/acme' },
+				{ kind: 'facebook', value: 'https://facebook.com/acme' },
+			])
+		})
+
+		it('should not report one page twice when two rounds spell it differently', () => {
+			// GIVEN one round that wrote the page with the www and the next that wrote
+			// it without, which is what a run folding several readings together meets
+			const once = rescueSocialWebsites(
+				scan([{ name: 'Acme', website: 'https://www.facebook.com/acme' }]),
+			)
+			const rows = rowsOf(once.findings)
+			const again = {
+				prospects: [{ ...rows[0], website: 'https://facebook.com/acme/' }],
+			}
+
+			// WHEN the second spelling is rescued onto the same row
+			// THEN it is recognised as the page already there, so the company is not
+			// listed as having two Facebooks
+			const twice = rescueSocialWebsites(again)
+			expect(twice.rescued).toBe(1)
+			expect(rowsOf(twice.findings)[0]?.social_profiles).toEqual([
+				{ kind: 'facebook', value: 'https://facebook.com/acme' },
+			])
+		})
+
+		it('should not report one page twice when the answer is read again', () => {
+			// GIVEN an answer already rescued once — which is what a later round sees,
+			// since a run reads its list several times and folds the readings together
+			const once = rescueSocialWebsites(
+				scan([{ name: 'Acme', website: 'https://www.facebook.com/acme' }]),
+			)
+
+			// WHEN it is rescued again
+			// THEN nothing moves and nothing is counted: the page is already where it
+			// belongs, and a second copy would read as two pages
+			const twice = rescueSocialWebsites(once.findings)
+			expect(twice.rescued).toBe(0)
+			expect(rowsOf(twice.findings)[0]?.social_profiles).toHaveLength(1)
+		})
+	})
+
+	describe('when the run named the pages itself', () => {
+		it('should read a reported page into one spelling', () => {
+			// GIVEN a run that named the page outright, in the form a shared mobile
+			// link takes
+			const findings = {
+				prospects: [
+					{
+						name: 'Atelier Voltaire',
+						social_profiles: [
+							{
+								kind: 'facebook',
+								value: 'https://m.facebook.com/atelier.voltaire/?ref=share',
+							},
+						],
+						citations: [],
+					},
+				],
+			}
+
+			// WHEN read
+			// THEN it is stored under the one address that page has. This becomes a
+			// way of reaching the company, and the same page written two ways would be
+			// listed as two Facebooks
+			const result = rescueSocialWebsites(findings)
+			expect(rowsOf(result.findings)[0]?.social_profiles).toEqual([
+				{ kind: 'facebook', value: 'https://facebook.com/atelier.voltaire' },
+			])
+		})
+
+		it('should fold two spellings of one page into one', () => {
+			// GIVEN the same page named twice, as two rounds of a run would
+			const findings = {
+				prospects: [
+					{
+						name: 'Acme',
+						social_profiles: [
+							{ kind: 'facebook', value: 'https://www.facebook.com/acme/' },
+							{ kind: 'facebook', value: 'https://facebook.com/acme' },
+						],
+						citations: [],
+					},
+				],
+			}
+
+			// WHEN read — THEN one page, once
+			const result = rescueSocialWebsites(findings)
+			expect(rowsOf(result.findings)[0]?.social_profiles).toEqual([
+				{ kind: 'facebook', value: 'https://facebook.com/acme' },
+			])
+		})
+
+		it('should drop a reported page that is really a post', () => {
+			// GIVEN a run that named a post as the company's Facebook
+			const findings = {
+				prospects: [
+					{
+						name: 'Acme',
+						social_profiles: [
+							{
+								kind: 'facebook',
+								value: 'https://www.facebook.com/share/1CtPJpK3i7/',
+							},
+						],
+						citations: [],
+					},
+				],
+			}
+
+			// WHEN read
+			// THEN dropped. A post is no more the company's page here than it is in
+			// the website field, and recording it would say something untrue
+			const result = rescueSocialWebsites(findings)
+			expect(rowsOf(result.findings)[0]?.social_profiles).toEqual([])
+		})
+
+		it('should keep a page on a platform it does not know', () => {
+			// GIVEN a page on a platform this reading has never been taught
+			const findings = {
+				prospects: [
+					{
+						name: 'Acme',
+						social_profiles: [
+							{ kind: 'pinterest', value: 'https://pinterest.com/acme' },
+						],
+						citations: [],
+					},
+				],
+			}
+
+			// WHEN read
+			// THEN kept exactly as it arrived. The field is open on purpose, and
+			// refusing an address for being unfamiliar would throw away the very thing
+			// that openness is for
+			const result = rescueSocialWebsites(findings)
+			expect(rowsOf(result.findings)[0]?.social_profiles).toEqual([
+				{ kind: 'pinterest', value: 'https://pinterest.com/acme' },
+			])
+		})
+	})
+
+	describe('when the address is not a page the company opened', () => {
+		it('should leave the two addresses a market search actually offered', () => {
+			// GIVEN the pair a live search handed back: a share link that spells
+			// nothing, and one post
+			const findings = scan([
+				{
+					name: 'CélestInstallations',
+					website: 'https://www.facebook.com/share/1CtPJpK3i7/',
+				},
+				{
+					name: 'OneFire',
+					website: 'https://www.instagram.com/p/DTxItU0lfKN/',
+				},
+			])
+
+			// WHEN rescued
+			// THEN neither moves. Recording either as "the company's Facebook" writes
+			// down something that was never true, and the website check still has its
+			// say on both
+			const result = rescueSocialWebsites(findings)
+			expect(result.rescued).toBe(0)
+			expect(rowsOf(result.findings).map(r => r.website)).toEqual([
+				'https://www.facebook.com/share/1CtPJpK3i7/',
+				'https://www.instagram.com/p/DTxItU0lfKN/',
+			])
+		})
+
+		it("should leave a company's own website alone", () => {
+			// GIVEN the ordinary case this must never touch
+			// WHEN rescued — THEN the site stays exactly where it was
+			const result = rescueSocialWebsites(
+				scan([{ name: 'Acme Logistics', website: 'https://acme.com' }]),
+			)
+			expect(result.rescued).toBe(0)
+			expect(rowsOf(result.findings)[0]?.website).toBe('https://acme.com')
+			expect(rowsOf(result.findings)[0]?.social_profiles).toBeUndefined()
+		})
+
+		it('should leave a row with no website at all', () => {
+			// GIVEN a company the run found no address for
+			// WHEN rescued — THEN nothing to move, and no empty list invented
+			const result = rescueSocialWebsites(scan([{ name: 'Acme' }]))
+			expect(result.rescued).toBe(0)
+			expect(rowsOf(result.findings)[0]?.social_profiles).toBeUndefined()
+		})
+	})
+
+	describe('when the answer is about one named company', () => {
+		it('should empty the website it was asked for and record the page', () => {
+			// GIVEN the run's own answer for the company it was asked about, where the
+			// website arrives wrapped with the page it was read from
+			const findings = {
+				enrichment: {
+					website: {
+						value: 'https://www.facebook.com/LIPOTECH.SARL',
+						source_id: 'src_1',
+					},
+					industry: { value: 'electrical installation' },
+				},
+			}
+
+			// WHEN rescued
+			// THEN the field is emptied rather than removed, so a reader still sees it
+			// was asked for, and the page sits beside it as a way of reaching the
+			// company
+			const result = rescueSocialWebsites(findings)
+			expect(result.rescued).toBe(1)
+			expect(result.findings).toEqual({
+				enrichment: {
+					website: null,
+					industry: { value: 'electrical installation' },
+					social_profiles: [
+						{
+							kind: 'facebook',
+							value: 'https://facebook.com/LIPOTECH.SARL',
+						},
+					],
+				},
+			})
+		})
+
+		it('should leave the website it was asked for when it is a real site', () => {
+			// GIVEN the same shape holding the company's own domain
+			// WHEN rescued — THEN untouched
+			const findings = {
+				enrichment: {
+					website: { value: 'https://acme.com', source_id: 'src_1' },
+				},
+			}
+			const result = rescueSocialWebsites(findings)
+			expect(result.rescued).toBe(0)
+			expect(result.findings).toEqual(findings)
+		})
+	})
+
+	describe('when the answer holds something that is not a company', () => {
+		it("should not read a person's page out of a proposed update", () => {
+			// GIVEN a proposal about a contact, which carries its own name and may
+			// carry an address — matching it here would rewrite somebody's proposal
+			const findings = {
+				proposed_updates: [
+					{
+						subject_table: 'contacts',
+						name: 'Jane Doe',
+						website: 'https://www.facebook.com/jane.doe',
+					},
+				],
+			}
+
+			// WHEN rescued — THEN the subtree is copied through whole
+			const result = rescueSocialWebsites(findings)
+			expect(result.rescued).toBe(0)
+			expect(result.findings).toEqual(findings)
+		})
+
+		it('should leave findings that are not objects untouched', () => {
+			// GIVEN answers with nothing to walk
+			// WHEN rescued — THEN they pass straight through
+			expect(rescueSocialWebsites(null).findings).toBeNull()
+			expect(rescueSocialWebsites('text').findings).toBe('text')
+			expect(rescueSocialWebsites([1, 2]).findings).toEqual([1, 2])
+		})
+	})
+})

--- a/packages/research/src/application/social-website-rescue.ts
+++ b/packages/research/src/application/social-website-rescue.ts
@@ -1,0 +1,202 @@
+/**
+ * Keeps a company's social page when it was offered as its website.
+ *
+ * A small firm often has no site of its own, and the only web presence a run can
+ * find for it is its page on a platform. Asked for a website, the run hands that
+ * page back. The website check refuses it, rightly — whoever clicks a website
+ * expects the company's own site, not Facebook — and a refused address is
+ * dropped, which would throw away the one way anybody had found of reaching that
+ * company.
+ *
+ * So the address is moved rather than dropped: off the website field, and onto
+ * the row as what it actually is, a page on a platform. The company ends up with
+ * no website and a Facebook page, which is the truth about it.
+ *
+ * ## Why this runs before the website check, and not inside it
+ *
+ * `website-guard.ts` only ever takes a value away. Every rule it holds is
+ * written as a reason to blank, its counts are counts of blanks, and a caller
+ * reading it knows that what comes back is what went in with things missing.
+ * A rule that also WROTE somewhere else would quietly end that, and the next
+ * person to reason about the guard would be wrong with nothing to warn them.
+ *
+ * Running first also puts the two in the right order for a plainer reason: once
+ * this has moved the address, that field is empty and there is nothing left for
+ * the check to condemn. What it does condemn is then what nothing could rescue,
+ * which is what its count should mean.
+ *
+ * ## What is moved, and what is still dropped
+ *
+ * Only a page a company opened in its own name. `socialProfileOf` in
+ * `social-sites.ts` decides that — it refuses a post, a video, a share link that
+ * spells nothing, a group and one person's own profile, and sets out why. What
+ * it refuses is left exactly where it stands, for the website check that follows
+ * to condemn as it always would.
+ *
+ * ## The pages a run reports itself
+ *
+ * A run can also name a company's pages outright, without going near the website
+ * field, and those are put through the same reading. Two reasons, and the first
+ * is the one that bites: an address becomes a stored way of reaching the company,
+ * so one page written two ways ("m.facebook.com/acme/?ref=share" one round,
+ * "facebook.com/acme" the next) would be stored as two, and the company would be
+ * listed as having two Facebooks. Reading each one back into a single spelling
+ * ends that wherever the page came from.
+ *
+ * The second is that a run naming a post as a company's Facebook is as wrong as
+ * a run offering one as its website, so it is dropped the same way.
+ *
+ * What the reading does NOT recognise is kept exactly as it arrived. The field is
+ * open on purpose — a platform nobody has met yet needs no change here — and
+ * refusing an address for being unfamiliar would throw away the very thing that
+ * openness is for.
+ */
+
+import { isPlainObject } from './guard-shapes'
+import {
+	isSocialPlatformHost,
+	type SocialProfile,
+	socialProfileOf,
+} from './social-sites'
+import { hostOf } from './source-key'
+
+// Subtrees copied through whole: a citation and a proposed update carry their
+// own `name` — a person's, on a contact proposal — and a page found under one of
+// those belongs to that person, not to the company the row is about.
+const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
+
+// Where a run reports the pages a company keeps on platforms. One name across
+// every answer that has the field, so the walk below need not know which kind of
+// answer it is reading.
+const PROFILES_KEY = 'social_profiles'
+
+// Whether this row already reports the page, so a rescue run twice over one
+// answer does not record it twice. A run reads its list several times and folds
+// the readings together, which is exactly when the same page arrives again.
+const alreadyReported = (
+	existing: ReadonlyArray<SocialProfile>,
+	profile: SocialProfile,
+): boolean =>
+	existing.some(
+		entry => entry.value === profile.value && entry.kind === profile.kind,
+	)
+
+// The pages a run named itself, each read back into one spelling. An entry this
+// reading recognises is kept as the single address that page has; one it
+// recognises as belonging to a platform but NOT as anybody's page — a post, a
+// share link — is dropped, since it is no more the company's page here than it
+// would be in the website field; and one on a host it does not know at all is
+// kept as it arrived, because the field is open on purpose.
+const profilesAsReported = (held: unknown): ReadonlyArray<SocialProfile> => {
+	if (!Array.isArray(held)) return []
+	const profiles: Array<SocialProfile> = []
+	for (const entry of held) {
+		if (!isPlainObject(entry)) continue
+		const kind = entry['kind']
+		const value = entry['value']
+		if (typeof kind !== 'string' || typeof value !== 'string') continue
+		const read = socialProfileOf(value)
+		if (read !== null) {
+			if (!alreadyReported(profiles, read)) profiles.push(read)
+			continue
+		}
+		if (isSocialPlatformHost(hostOf(value) ?? '')) continue
+		const asGiven = { kind, value }
+		if (!alreadyReported(profiles, asGiven)) profiles.push(asGiven)
+	}
+	return profiles
+}
+
+const withProfile = (
+	row: Record<string, unknown>,
+	profile: SocialProfile,
+): Record<string, unknown> => {
+	const held = profilesAsReported(row[PROFILES_KEY])
+	return {
+		...row,
+		[PROFILES_KEY]: alreadyReported(held, profile) ? held : [...held, profile],
+	}
+}
+
+export interface SocialWebsiteRescueResult {
+	/** The findings, with each rescued page moved off the website field. */
+	readonly findings: unknown
+	/** Pages moved onto their company as a way of reaching it. */
+	readonly rescued: number
+}
+
+/**
+ * Move every social page offered as a company's website onto that company.
+ *
+ * Which company the page belongs to is not in question: the address arrived
+ * claimed as this row's own website, and this only disagrees about what KIND of
+ * address it is. So no name is needed and none is read.
+ */
+export const rescueSocialWebsites = (
+	findings: unknown,
+): SocialWebsiteRescueResult => {
+	let rescued = 0
+
+	const walkChild = (key: string, value: unknown): unknown =>
+		SKIP_KEYS.has(key) ? value : walk(value, key)
+
+	function walk(value: unknown, key?: string): unknown {
+		if (Array.isArray(value)) return value.map(item => walk(item))
+		if (!isPlainObject(value)) return value
+
+		const website = value['website']
+
+		// A scanned company: its name and the website the run gave for it, side by
+		// side. The key goes with the page, so the row reads as one the model never
+		// gave a website for — the same as any other field a guard removes.
+		if (
+			key !== 'website' &&
+			typeof website === 'string' &&
+			typeof value['name'] === 'string'
+		) {
+			const profile = socialProfileOf(website)
+			if (profile !== null) {
+				rescued++
+				const { website: _moved, ...rest } = value
+				return Object.fromEntries(
+					Object.entries(withProfile(rest, profile)).map(
+						([k, v]) => [k, walkChild(k, v)] as const,
+					),
+				)
+			}
+		}
+
+		// The run's own answer for the company it was asked about: the website
+		// arrives wrapped with the page it was read from and no name beside it.
+		// Emptied where it stands rather than removed, because a reader of the
+		// profile still needs to see the field was asked for.
+		if (
+			isPlainObject(website) &&
+			typeof website['value'] === 'string' &&
+			typeof website['name'] !== 'string'
+		) {
+			const profile = socialProfileOf(website['value'])
+			if (profile !== null) {
+				rescued++
+				const emptied = { ...value, website: null }
+				return Object.fromEntries(
+					Object.entries(withProfile(emptied, profile)).map(
+						([k, v]) => [k, walkChild(k, v)] as const,
+					),
+				)
+			}
+		}
+
+		// A row that named its pages itself and had no social website to move. The
+		// same reading still applies, so one page reported two ways is stored once.
+		const tidied = Object.hasOwn(value, PROFILES_KEY)
+			? { ...value, [PROFILES_KEY]: profilesAsReported(value[PROFILES_KEY]) }
+			: value
+
+		return Object.fromEntries(
+			Object.entries(tidied).map(([k, v]) => [k, walkChild(k, v)] as const),
+		)
+	}
+
+	return { findings: walk(findings), rescued }
+}


### PR DESCRIPTION
## What

A research run that found a company's **Facebook page** had nowhere to put it. The website field rightly refuses a social page — whoever clicks a website expects the company's own site — so the address was dropped, and for a small firm with no site of its own that was the only way anybody had found of reaching it. This keeps the page instead, beside the company's mailbox and telephone number. It lives in the Research surface (`packages/research`) and in the CRM's ways-of-reaching-a-company (`packages/domain`, `apps/server`, `apps/internal`).

## Changes

**Touches:** the research answers a run fills in, a new pass that moves a social page off the website field before the website check sees it (that check itself is untouched and still only ever blanks), the reading that turns a company write into the rows that store its addresses, and the picker that draws them.

- **A run can now report a company's pages on platforms.** The prospect scan and the company enrichment gain a `social_profiles` list, and the `website` field's own description now says plainly that a Facebook, Instagram or LinkedIn page goes there and never in `website`. That sentence is the whole feature: a field description is the only instruction the model gets, and without it the list would never be filled.
- **A social page offered as the website is moved rather than dropped** — but only a page a company opened in its own name. A post, a video, a share link that spells nothing, a group and one person's own profile are all refused, because recording any of them as the company's Facebook states something that was never true.
- **The moving is a pass of its own, ahead of the website check.** That check only ever takes values away; its counts are counts of blanks and every caller depends on that. A rule that also wrote somewhere else would quietly end it.
- **One page is stored under one address** whichever door it arrived through — the mobile one, a country's, with or without the trailing slash, with or without the parameters a shared link picks up. Otherwise a company met twice is listed as having two Facebooks.
- **`facebook` joins the kinds the app draws and names**, so the page is announced properly rather than shown as a bare word.

## Impact

- **No database change, nothing about which organisation can see what (row-level security), and no new settings the server needs at boot.** Addresses already lived in their own rows; this adds a kind of address, and the column that holds the kind has always been free text.
- **Both doors get it.** The reading that splits a company write into columns and addresses is shared, so the typed web API, both assistant-facing tools and the research apply path all behave the same — none of them had to learn about platforms.
- **A new field on two research answers**, which a consumer reading `findings` will see: `social_profiles`, a list of `{kind, value}`. Nothing is removed or renamed.
- **The "how full is this profile" measure now counts one more field.** `social_profiles` joins the ten it already divides by, so the same company reads slightly lower than before — that is the measure working, not a regression, and it is what makes a run that could have found a page and did not show up as a miss.
- **A page typed in by hand is still stored exactly as written**, as the Instagram and LinkedIn fields beside it already are. Only the research path folds spellings together. See *Deferred*.

## Review guide

- Start with `social-sites.ts` → `socialProfileOf`. It is the whole judgement — which addresses are a company's page and which are not — and everything else trusts it.
- Then `social-website-rescue.ts`, whose comment argues why it is a separate pass rather than a rule inside the website check.
- **The riskiest part** is the per-platform shapes in `socialProfileOf`. Each platform files an account differently, and a wrong "yes" puts a stranger's page on a company under its own name. It is written to refuse when unsure, and a platform added later with no list of its own reserved words refuses everything rather than accepting everything.
- **A decision you might overrule:** the research field is `social_profiles`, not the open `channels` list a contact carries. Contacts have no named fields for a mailbox or a number, so their list has to take everything; a company already names its email, phone and website, and a second list that also accepted those would give one company two answers to "what is its email". If you would rather have one shape across both, this is the place to say so.
- Skip-able: the `.po` catalogs (generated by extract, plus one word), and the test files if you take the summaries below on trust.

## Screenshots

A company created from a research finding, with its Facebook page kept as a way of reaching it.

**Desktop (1440×900)**

![pr-social-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-533/pr-social-desktop.webp)

**Mobile (iPhone 16 Pro)** — `apps/internal` is mobile-first, and the ways-to-reach panel moves from the right column into the flow, so both are worth seeing.

![pr-social-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-533/pr-social-mobile.webp)

## Tests

62 new unit tests. `socialProfileOf` is covered per platform for both answers: the account shapes each one accepts, and the posts, reels, share links, groups, person profiles, reserved words, bare home pages and non-addresses it refuses — including the two addresses a live French market search actually offered, which are both refusals. The rescue is covered for a scanned row, for the run's own answer about one named company, for a row that named its pages itself, for a page reported in two spellings, for an unknown platform kept as it arrived, and for the subtrees it must not walk into. The channel splitting is covered for both the camelCase and snake_case spellings a caller may send, and for entries too broken to store.

## Verification

- Gates run on this branch against current `main`: `pnpm install` (no lockfile drift), `pnpm -w check-types` (13/13), `pnpm -w test` (21/21 tasks — 1982 research, 1014 server), `pnpm -w build` (13/13). Lint clean on all 21 changed files.
- **Driven through the real app on the live stack.** I seeded a research run carrying a captured Facebook page, clicked "Add as lead" in the research view, and confirmed the company was created with a `facebook` address row against it, rendering under "Ways to reach" with its own name announced. A second run whose list held a deliberately blank entry beside a good one still created the lead and stored only the good address — one bad entry no longer costs the whole company.
- **Measured against real run data rather than asserted.** Replaying 14 stored runs and 335 companies through the new pass moves **0** addresses: every social address on file is a share link or a post, and all of them are correctly refused. The rescue invents nothing on the evidence available — it is there for the page that reads as a company's own.

## Deferred

- Folding hand-typed addresses into the same single spelling the research path uses. It needs the reading that recognises a platform to live somewhere `apps/server` can reach as well, which is a wider move than this change should make.
- Competitor rows get no `social_profiles`: they carry a name and a website and no way of reaching anybody, so there is nothing yet to put one beside.
