### PR TITLE
fix(research): tell a company from the kind of company it says it is

### DIFF
--- a/packages/research/src/application/directory-sites.test.ts
+++ b/packages/research/src/application/directory-sites.test.ts
@@ -5,10 +5,10 @@ import {
 	observeDirectorySites,
 	siteVerdict,
 } from './directory-sites'
-import { tradeWordsOf } from './trade-words'
+import { runWordsOf } from './run-words'
 
 // A run that named no trades, which is a request about one company on file.
-const noTrades = tradeWordsOf([])
+const noRunWords = runWordsOf([])
 
 // A prospect scan's list, as the guard chain hands it over.
 const scan = (names: ReadonlyArray<string>) => ({
@@ -23,7 +23,7 @@ const observe = (
 		findings: scan(names),
 		listField: 'prospects',
 		addresses,
-		tradeWords: noTrades,
+		runWords: noRunWords,
 	})
 
 describe('observeDirectorySites', () => {
@@ -42,7 +42,7 @@ describe('observeDirectorySites', () => {
 					'https://fontaneria.es/fontaneria-garcia',
 					'https://fontaneria.es/fontaneria-lopez',
 				],
-				tradeWords: tradeWordsOf(['fontanería']),
+				runWords: runWordsOf(['fontanería']),
 			})
 
 			expect([...observation.sites]).toEqual(['fontaneria.es'])
@@ -61,7 +61,7 @@ describe('observeDirectorySites', () => {
 					'https://garcia.es/fontaneria-garcia',
 					'https://garcia.es/fontaneria-lopez',
 				],
-				tradeWords: tradeWordsOf(['fontanería']),
+				runWords: runWordsOf(['fontanería']),
 			})
 
 			expect([...observation.sites]).toEqual([])
@@ -601,7 +601,7 @@ describe('observeDirectorySites', () => {
 					'https://listado.example/electricistas-puig',
 					'https://listado.example/instalaciones-ferre',
 				],
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN read — THEN one company can never reach two, so nothing is judged —
@@ -629,7 +629,7 @@ describe('observeDirectorySites', () => {
 				findings: { prospects: [{ website: 'https://a.example' }, {}] },
 				listField: 'prospects',
 				addresses: ['https://listado.example/x'],
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN read — THEN neither yields a name to look for

--- a/packages/research/src/application/directory-sites.ts
+++ b/packages/research/src/application/directory-sites.ts
@@ -94,8 +94,8 @@ import {
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { ownSiteHostVerdict } from './own-site'
+import type { RunWords } from './run-words'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
-import type { TradeWords } from './trade-words'
 
 /** Hosts this run watched file several of its own companies. */
 export type DirectorySites = ReadonlySet<string>
@@ -417,9 +417,9 @@ export const observeDirectorySites = (args: {
 	readonly findings: unknown
 	readonly listField: string | undefined
 	readonly addresses: ReadonlyArray<string>
-	readonly tradeWords: TradeWords
+	readonly runWords: RunWords
 }): DirectoryObservation => {
-	const { findings, listField, addresses, tradeWords } = args
+	const { findings, listField, addresses, runWords } = args
 	const readable = addresses.filter(isBareWebAddress)
 	const addressesRead = readable.length
 	if (listField === undefined) return { sites: new Set(), addressesRead }
@@ -456,7 +456,7 @@ export const observeDirectorySites = (args: {
 		const known = ownSiteAnswers.get(key)
 		if (known !== undefined) return known
 		const own = company.rowNames.some(
-			name => ownSiteHostVerdict({ name, host, tradeWords }) === 'established',
+			name => ownSiteHostVerdict({ name, host, runWords }) === 'established',
 		)
 		ownSiteAnswers.set(key, own)
 		return own

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -29,10 +29,10 @@ import {
 } from './entity-guard'
 import { EQUIVALENT_LETTERS } from './letter-equivalences.generated'
 import { ownSiteVerdict } from './own-site'
-import { tradeWordsOf } from './trade-words'
+import { runWordsOf } from './run-words'
 
 // A run that named no trades, which is a request about one company on file.
-const noTrades = tradeWordsOf([])
+const noRunWords = runWordsOf([])
 
 describe('deriveEntityTargets', () => {
 	describe('when the schema reports third-party companies', () => {
@@ -1682,14 +1682,14 @@ describe('nameSpellings — vowels a company writes two ways', () => {
 				ownSiteVerdict({
 					name: 'Muller SL',
 					website: 'https://mueller.de',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Mueller GmbH',
 					website: 'https://muller.de',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1715,7 +1715,7 @@ describe('nameSpellings — vowels a company writes two ways', () => {
 					ownSiteVerdict({
 						name,
 						website: 'https://mueller-elektro.de',
-						tradeWords: noTrades,
+						runWords: noRunWords,
 					}),
 				).toBe('established')
 			}

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -69,11 +69,16 @@ const LEGAL_SUFFIXES = new Set([
 // finish: it takes every trade in every language a market answers in, and each
 // word written down takes a real distinctive word away from the firms genuinely
 // called it. A run brings the trades it went looking for instead
-// (`trade-words.ts`), which is that market's own vocabulary and needs no
-// upkeep. What is left below is the words for a KIND of company, which work for
-// anybody in any market, and one industry's words that stand only for a run
-// with no market behind it to read — see `own-site.ts` for what they still do
-// and what would let them go.
+// (`run-words.ts`), which is that market's own vocabulary and needs no
+// upkeep. What is left below is the words for a KIND of company and one
+// industry's words that stand only for a run with no market behind it to read.
+//
+// DO NOT ADD ANOTHER LANGUAGE HERE EITHER. The kind-of-company half reads as
+// English and Spanish and is neither: "Sociedad García" is at home on
+// sociedad.es today, and so are Empresa, Corporación and Asociación something,
+// in the market this is measured on. Filling those in finishes nothing, for the
+// reason above — see `own-site.ts` for what these words still do, what was
+// priced to replace them, and which half of the question word order answers.
 const GENERIC_WORDS = new Set([
 	'logistics',
 	'logistica',

--- a/packages/research/src/application/eval-scoring-market.ts
+++ b/packages/research/src/application/eval-scoring-market.ts
@@ -30,8 +30,8 @@ import {
 	hostsEstablishedAsOwn,
 } from './prospect-dedupe-guard'
 import { rowGroups } from './row-groups'
+import type { RunWords } from './run-words'
 import { anyTermAppearsIn, termTokens } from './term-match'
-import type { TradeWords } from './trade-words'
 
 export const partsAnsweredBy = (
 	rows: RunOutcome['companies'],
@@ -124,13 +124,13 @@ const companiesAmong = (
 // name with a note written after it.
 const joinedAsTheFoldDoes = (
 	rows: ReadonlyArray<Record<string, unknown>>,
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): ReadonlyArray<readonly [number, number]> => {
 	const joined: Array<readonly [number, number]> = []
 	// Read over the whole returned list, which is the list the fold read too. Asking
 	// row by row would make this stricter than the fold it measures, and call a list
 	// clean while it still holds the pairs the fold joins on a site.
-	const ownSiteHosts = hostsEstablishedAsOwn(rows, tradeWords)
+	const ownSiteHosts = hostsEstablishedAsOwn(rows, runWords)
 	const rowOfKey = new Map<string, number>()
 	rows.forEach((row, at) => {
 		for (const key of discoveryRowIdentityKeys(row, ownSiteHosts)) {
@@ -295,14 +295,14 @@ export interface RepeatedRows {
 
 export const repeatedRows = (
 	rows: RunOutcome['companies'],
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): RepeatedRows => {
 	const discoveryRows = asDiscoveryRows(rows)
 	// Worked out once and read twice. The loose figure is the strict one's pairs
 	// plus more of them, which is what makes it a superset rather than a second
 	// opinion that could disagree — and it is also why the joins the fold makes are
 	// not worth finding twice over.
-	const asTheFoldDoes = joinedAsTheFoldDoes(discoveryRows, tradeWords)
+	const asTheFoldDoes = joinedAsTheFoldDoes(discoveryRows, runWords)
 	return {
 		duplicated:
 			discoveryRows.length -

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -71,7 +71,7 @@ import {
 	type RunScore,
 	SCORABLE_FIELDS,
 } from './eval-scoring-types'
-import { tradeWordsOf } from './trade-words'
+import { runWordsOf } from './run-words'
 
 export { contactNameMatches } from './eval-scoring-company'
 export {
@@ -258,7 +258,7 @@ export const scoreRun = (
 	// its run read too.
 	const repeats = repeatedRows(
 		outcome.companies,
-		tradeWordsOf(expectedMarket?.parts.flatMap(part => part.terms) ?? []),
+		runWordsOf(expectedMarket?.parts.flatMap(part => part.terms) ?? []),
 	)
 	const market: MarketScore | undefined =
 		expectedMarket === undefined || !endedWithAnAnswer(outcome.status)

--- a/packages/research/src/application/existence-verdict.test.ts
+++ b/packages/research/src/application/existence-verdict.test.ts
@@ -9,10 +9,10 @@ import {
 	rowExistence,
 	withExistence,
 } from './existence-verdict'
-import { tradeWordsOf } from './trade-words'
+import { runWordsOf } from './run-words'
 
 // A run that named no trades, which is a request about one company on file.
-const noTrades = tradeWordsOf([])
+const noRunWords = runWordsOf([])
 
 // A workshop whose own domain spells its name, so `ownSiteVerdict` establishes
 // it — the only thing in the package that can clear a source.
@@ -42,7 +42,7 @@ describe('existenceOf', () => {
 					website: 'https://fontaneria.es',
 					sources: [PAPER],
 					directorySites: NONE,
-					tradeWords: tradeWordsOf(['fontanería']),
+					runWords: runWordsOf(['fontanería']),
 				}).verdict,
 			).toBe('candidate')
 		})
@@ -60,7 +60,7 @@ describe('existenceOf', () => {
 					website: 'https://garcia.es',
 					sources: [PAPER],
 					directorySites: NONE,
-					tradeWords: tradeWordsOf(['fontanería']),
+					runWords: runWordsOf(['fontanería']),
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -78,7 +78,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [PAPER],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -94,7 +94,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [LISTING],
 					directorySites: new Set(['paginas.es']),
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -110,7 +110,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['elpuntavui.cat'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -125,7 +125,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [OWN, PAPER],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -145,7 +145,7 @@ describe('existenceOf', () => {
 					website: 'https://paginas.es',
 					sources: [PAPER],
 					directorySites: new Set(['paginas.es']),
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -163,7 +163,7 @@ describe('existenceOf', () => {
 					website: 'https://instalacionesferre.es',
 					sources: [PAPER],
 					directorySites: new Set(['instalacionesferre.es']),
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -179,7 +179,7 @@ describe('existenceOf', () => {
 					website: 'https://instalacionesferre.es',
 					sources: [PAPER, 'https://instalacionesferre.com'],
 					directorySites: new Set(['instalacionesferre.es']),
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'confirmed', websites: 2 })
 		})
@@ -196,7 +196,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [`${OWN}/contacte`],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -211,7 +211,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['https://blog.fusteriamiquel.cat/obra-nova'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -225,7 +225,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['https://www.fusteriamiquel.cat/contacte'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -241,7 +241,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: ['https://fusteriamiquel.com'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -259,7 +259,7 @@ describe('existenceOf', () => {
 						'https://eleconomista.es/noticia/999',
 					],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -275,7 +275,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [LISTING, 'https://otrodirectorio.es/e/fusteria-miquel'],
 					directorySites: new Set(['paginas.es', 'otrodirectorio.es']),
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -290,7 +290,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [PAPER, 'https://lavanguardia.com/economia/55'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -305,7 +305,7 @@ describe('existenceOf', () => {
 					website: 'https://sice.com',
 					sources: [PAPER],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -321,7 +321,7 @@ describe('existenceOf', () => {
 					website: OWN,
 					sources: [PAPER],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -337,7 +337,7 @@ describe('existenceOf', () => {
 					name: 'Zeta Instal·lacions',
 					sources: ['https://acme.es/x', 'https://acme.de/y'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_own_site', websites: 2 })
 		})
@@ -352,7 +352,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: [],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({
 				verdict: 'candidate',
@@ -371,7 +371,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: ['src_9f2a1b3c', 'src_aa11bb22'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_sources', websites: 0 })
 		})
@@ -387,7 +387,7 @@ describe('existenceOf', () => {
 					website: 'https://fusteriamiquel.cat/ (inferred from the name)',
 					sources: ['https://elpuntavui.cat/ (probably)'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_sources', websites: 0 })
 		})
@@ -401,7 +401,7 @@ describe('existenceOf', () => {
 					website: '   ',
 					sources: [PAPER],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'one_website', websites: 1 })
 		})
@@ -414,7 +414,7 @@ describe('existenceOf', () => {
 					name: NAME,
 					sources: ['info@fusteriamiquel.cat'],
 					directorySites: NONE,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toEqual({ verdict: 'candidate', reason: 'no_sources', websites: 0 })
 		})

--- a/packages/research/src/application/existence-verdict.ts
+++ b/packages/research/src/application/existence-verdict.ts
@@ -95,8 +95,8 @@ import {
 } from './entity-guard'
 import { isPlainObject } from './guard-shapes'
 import { ownSiteVerdict } from './own-site'
+import type { RunWords } from './run-words'
 import { hostOf, isBareWebAddress } from './source-key'
-import type { TradeWords } from './trade-words'
 
 /** Where the row's existence stands. There is no third value. */
 export type ExistenceVerdict = 'confirmed' | 'candidate'
@@ -177,9 +177,9 @@ const sitesOf = (args: {
 	readonly name: string
 	readonly addresses: ReadonlyArray<string>
 	readonly directorySites: DirectorySites
-	readonly tradeWords: TradeWords
+	readonly runWords: RunWords
 }): ReadonlyArray<SourceSite> => {
-	const { name, addresses, directorySites, tradeWords } = args
+	const { name, addresses, directorySites, runWords } = args
 	const byHost = new Map<string, SourceSite>()
 	for (const address of addresses) {
 		const host = hostOf(address)
@@ -188,8 +188,7 @@ const sitesOf = (args: {
 			host,
 			site: registrableDomain(host),
 			own:
-				ownSiteVerdict({ name, website: address, tradeWords }) ===
-				'established',
+				ownSiteVerdict({ name, website: address, runWords }) === 'established',
 			directory: siteVerdict(host, directorySites) === 'directory',
 		})
 	}
@@ -265,9 +264,9 @@ export const existenceOf = (args: {
 	readonly website?: string | undefined
 	readonly sources: ReadonlyArray<string>
 	readonly directorySites: DirectorySites
-	readonly tradeWords: TradeWords
+	readonly runWords: RunWords
 }): RowExistence => {
-	const { name, website, directorySites, tradeWords } = args
+	const { name, website, directorySites, runWords } = args
 	const offered =
 		website === undefined || website.trim() === ''
 			? args.sources
@@ -276,7 +275,7 @@ export const existenceOf = (args: {
 		name,
 		addresses: webAddressesAmong(offered),
 		directorySites,
-		tradeWords,
+		runWords,
 	})
 	const websites = websitesOf(sites)
 	// A site has to be this company's own AND not a host the run watched listing

--- a/packages/research/src/application/own-site.test.ts
+++ b/packages/research/src/application/own-site.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import { ownSiteHostVerdict, ownSiteVerdict } from './own-site'
-import { tradeWordsOf } from './trade-words'
+import { runWordsOf } from './run-words'
 
 // A run that named no trades, which is a request about one company on file:
 // nothing to read, so only the shared list of words for a kind of company
 // stands. Every reading here that does not turn on a market's own vocabulary is
 // held to that, so the list's own work stays visible.
-const noTrades = tradeWordsOf([])
+const noRunWords = runWordsOf([])
 
 // The address the French solar directory files a company at: a slug naming a
 // trade and a role, ending in the listing's own record number, and naming no
@@ -25,7 +25,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Redwood Logistics',
 					website: 'https://redwoodlogistics.com/about',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -38,7 +38,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://acme.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -58,7 +58,7 @@ describe('ownSiteVerdict', () => {
 				['TIBA Group', 'https://tiba-group.com/about-tiba'],
 				['GLS Spain', 'https://gls-spain.es/gls-spain-quienes'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'established',
 				)
 			}
@@ -72,7 +72,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Transportes García',
 					website: 'https://garcia.es/contacto',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -84,7 +84,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Fusteria Miquel',
 					website: 'https://fusteriamiquelsl.cat',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -97,7 +97,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme S.L.',
 					website: 'https://acme.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -109,7 +109,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Grupo Muñoz',
 					website: 'https://munoz.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -123,7 +123,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://botiga.acme.co.uk/contacte',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -141,7 +141,7 @@ describe('ownSiteVerdict', () => {
 				['Lasser', 'https://grupolasser.com'],
 				['CAHORS', 'https://www.groupe-cahors.com/es-espana'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'established',
 				)
 			}
@@ -161,14 +161,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'KGS Fire & Security España',
 					website: 'http://www.grupofire.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Electronic Trafic (ETRA)',
 					website: 'https://grupoetra.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -182,14 +182,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'Lasser',
 					host: 'grupolasser.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 			expect(
 				ownSiteVerdict({
 					name: 'Lasser',
 					website: 'https://grupolasser.com/quienes-somos',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -203,7 +203,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Lasser',
 					website: 'https://grupolasserna.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -218,7 +218,7 @@ describe('ownSiteVerdict', () => {
 				['Penske Logistics', 'https://gopenske.com/logistics'],
 				['Ferré', 'https://miferre.es'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'unknown',
 				)
 			}
@@ -237,7 +237,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme',
 					website: 'https://transportesacme.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 			for (const name of ['Sacme', 'Esacme']) {
@@ -245,7 +245,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name,
 						website: 'https://transportesacme.com',
-						tradeWords: noTrades,
+						runWords: noRunWords,
 					}),
 				).toBe('unknown')
 			}
@@ -260,7 +260,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Cobra Instalaciones',
 					website: 'https://grupotransportescobra.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -275,7 +275,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://grupoacme-directorio.com/acme-logistics',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -290,14 +290,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Cobra Instalaciones y Servicios',
 					website: 'https://grupoetra.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Lasser',
 					website: 'https://grupocobra.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -313,7 +313,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Instalaciones Rubio',
 					website: 'https://grupoins.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -329,14 +329,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Logistics Group',
 					website: 'https://grupologistics.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Grupo Ferré',
 					website: 'https://grupogrupo.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -352,7 +352,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Cobra',
 					website: 'https://grupocobrasa.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -371,7 +371,7 @@ describe('ownSiteVerdict', () => {
 				['Énergie Solaire', 'https://xn--nergie-solaire-9jb.fr'],
 				['Instal·lacions Núñez', 'https://xn--installacionsnez-50a66h4e.es'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'established',
 				)
 			}
@@ -390,7 +390,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name: 'Énergie Solaire',
 						website,
-						tradeWords: noTrades,
+						runWords: noRunWords,
 					}),
 				).toBe('established')
 			}
@@ -410,7 +410,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name: 'Énergie Solaire',
 						website,
-						tradeWords: noTrades,
+						runWords: noRunWords,
 					}),
 				).toBe('established')
 			}
@@ -426,7 +426,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Énergie Solaire',
 					website: 'https://xn--groupe-nergie-solaire-h5b.fr',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -445,7 +445,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Énergie Solaire',
 					website: 'https://xn--groupnergie-solaire-fzb.fr',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -459,7 +459,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Instalaciones Rubio',
 					website: 'https://xn--construccionsgarca-xyb.cat',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -475,7 +475,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Apple',
 					website: 'https://xn--80ak6aa92e.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -491,7 +491,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme',
 					website: 'https://xn--acme-9ta.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -506,7 +506,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme',
 					website: 'http://192.168.1.10/acme',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -528,7 +528,7 @@ describe('ownSiteVerdict', () => {
 				['PPVS Facility Management', 'https://ppvs-fm.com'],
 				['Energetique Sanitaire', 'https://esanit.fr'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'unknown',
 				)
 			}
@@ -543,7 +543,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Servicios Eléctricos y Montajes Industriales',
 					website: 'https://semi.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -567,7 +567,7 @@ describe('ownSiteVerdict', () => {
 				],
 				['Instalaciones Rubio', 'https://grupocobra.com'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'unknown',
 				)
 			}
@@ -585,7 +585,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website: 'https://acme-directory.com/acme-logistics',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -601,7 +601,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Penske Logistics',
 					website: 'https://gopenske.com/logistics',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -618,7 +618,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Grupo Ferré',
 					website: 'https://grupo.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -631,7 +631,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Grupo Ferré',
 					website: 'https://grupoferre.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -647,14 +647,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Grupo Ferré',
 					website: 'https://grupo.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Groupe Roy Énergie',
 					website: 'https://groupe.fr',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -667,7 +667,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'CAHORS',
 					website: 'https://www.groupe-cahors.com/es-espana',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -680,7 +680,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Logistics Group',
 					website: 'https://logistics.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -717,7 +717,7 @@ describe('ownSiteVerdict', () => {
 				['talleres', 'Talleres García', 'https://talleres.es'],
 			] as const) {
 				expect(
-					ownSiteVerdict({ name, website, tradeWords: tradeWordsOf([asked]) }),
+					ownSiteVerdict({ name, website, runWords: runWordsOf([asked]) }),
 				).toBe('unknown')
 			}
 		})
@@ -733,7 +733,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name,
 						website: 'https://fontaneria.es',
-						tradeWords: tradeWordsOf(['fontanería']),
+						runWords: runWordsOf(['fontanería']),
 					}),
 				).toBe('unknown')
 			}
@@ -754,7 +754,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name: 'Fontanería García',
 						website,
-						tradeWords: tradeWordsOf(['fontanería']),
+						runWords: runWordsOf(['fontanería']),
 					}),
 				).toBe('established')
 			}
@@ -771,7 +771,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'García',
 					website: 'https://fontaneriagarcia.es',
-					tradeWords: tradeWordsOf(['fontanería']),
+					runWords: runWordsOf(['fontanería']),
 				}),
 			).toBe('established')
 		})
@@ -787,7 +787,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'García',
 					website: 'https://fontaneriagarcia.es',
-					tradeWords: tradeWordsOf(['fontanería', 'ascensor']),
+					runWords: runWordsOf(['fontanería', 'ascensor']),
 				}),
 			).toBe('established')
 		})
@@ -801,7 +801,7 @@ describe('ownSiteVerdict', () => {
 			// THEN unknown. A word that short in front of a domain says nothing about
 			// what a firm does, and taking it off would cut the label one letter in
 			// and hand Talia a domain somebody else registered
-			const asked = tradeWordsOf([
+			const asked = runWordsOf([
 				'fontanería y climatización',
 				'instalación de gas',
 			])
@@ -809,7 +809,7 @@ describe('ownSiteVerdict', () => {
 				['Talia', 'https://detalia.com'],
 				['Acme', 'https://yacme.com'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: asked })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: asked })).toBe(
 					'unknown',
 				)
 			}
@@ -824,7 +824,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Instalaciones Eléctricas',
 					website: 'https://instalacioneselectricas.es',
-					tradeWords: tradeWordsOf(['instalación eléctrica']),
+					runWords: runWordsOf(['instalación eléctrica']),
 				}),
 			).toBe('unknown')
 		})
@@ -840,7 +840,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Services et installations électriques',
 					website: 'https://services-et-installations-electriques.com',
-					tradeWords: tradeWordsOf(['installations électriques']),
+					runWords: runWordsOf(['installations électriques']),
 				}),
 			).toBe('unknown')
 		})
@@ -861,7 +861,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name,
 						website,
-						tradeWords: tradeWordsOf([
+						runWords: runWordsOf([
 							'solar energy',
 							'plomberie et chauffage',
 							'ascenseurs',
@@ -885,7 +885,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name,
 						website,
-						tradeWords: tradeWordsOf(['energía solar', 'solar energy']),
+						runWords: runWordsOf(['energía solar', 'solar energy']),
 					}),
 				).toBe('established')
 			}
@@ -906,7 +906,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name: 'Instal·lacions Vives',
 						website,
-						tradeWords: tradeWordsOf(['instal·lacions elèctriques']),
+						runWords: runWordsOf(['instal·lacions elèctriques']),
 					}),
 				).toBe('unknown')
 			}
@@ -921,9 +921,311 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Panadería García',
 					website: 'https://panaderia-garcia.es',
-					tradeWords: tradeWordsOf(['fontanería']),
+					runWords: runWordsOf(['fontanería']),
 				}),
 			).toBe('established')
+		})
+	})
+
+	describe('when the name says what kind of company it is', () => {
+		it('should refuse the bare domain of a word for a kind of company written last', () => {
+			// GIVEN a firm whose name says what kind of company it is, in each
+			// language that writes that word at the END of a name, each offered the
+			// bare domain of it
+			// WHEN each is asked
+			// THEN none of them. gruppe.de belongs to whoever registered it and not to
+			// every German firm called something Gruppe — and the name had already
+			// spelled somebody by the time that word arrived
+			for (const [name, website] of [
+				['Müller Gruppe', 'https://gruppe.de'],
+				['Müller Dienstleistungen', 'https://dienstleistungen.de'],
+				['De Vries Groep', 'https://groep.nl'],
+				['De Vries Diensten', 'https://diensten.nl'],
+				['Kowalski Grupa', 'https://grupa.pl'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
+					'unknown',
+				)
+			}
+		})
+
+		it('should refuse it in languages nothing here was written for', () => {
+			// GIVEN the same shape of name in languages no list in this package
+			// holds a word of
+			// WHEN each is asked
+			// THEN none of them, and not one of these words had to be known. What is
+			// read is not what the word means but that it came second, so a market
+			// nobody has searched yet is covered on the day it is
+			for (const [name, website] of [
+				['Nilsson Gruppen', 'https://gruppen.se'],
+				['Novák Skupina', 'https://skupina.cz'],
+				['Nagy Csoport', 'https://csoport.hu'],
+				['Yılmaz Grubu', 'https://grubu.com.tr'],
+				['Hansen Koncern', 'https://koncern.dk'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
+					'unknown',
+				)
+			}
+		})
+
+		it('should still establish the company at the word its name opens with', () => {
+			// GIVEN the same firms at the domain of their own word, and at their whole
+			// name written out
+			// WHEN each is asked
+			// THEN established: what is taken away is the kind-of-company word, never
+			// the company
+			for (const [name, website] of [
+				['Müller Gruppe', 'https://mueller.de'],
+				['Müller Gruppe', 'https://muellergruppe.de'],
+				['De Vries Groep', 'https://vries.nl'],
+				['Kowalski Grupa', 'https://kowalski.pl'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
+					'established',
+				)
+			}
+		})
+
+		it('should still clear that word where a language writes it first', () => {
+			// GIVEN the same word written at the FRONT of a name, the word this
+			// reading was written for among them, turned round
+			// WHEN each is asked
+			// THEN established, which is the half deliberately left open. Read off an
+			// address, "Gruppe Müller" and "Schindler France" are one shape — a word
+			// nothing places and a family name — and which of the two is the company is
+			// the question rather than something the address answers
+			for (const [name, website] of [
+				['Gruppe Müller', 'https://gruppe.de'],
+				['Grup Puig', 'https://grup.cat'],
+				['Gruppo Rossi', 'https://gruppo.it'],
+				['Serveis Puig', 'https://serveis.cat'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
+					'established',
+				)
+			}
+		})
+
+		it('should refuse the bare domain of a place written after the name', () => {
+			// GIVEN a carrier written with the market it works in, offered that market's
+			// own domain and then its own
+			// WHEN each is asked
+			// THEN france.fr is nobody's and schindler.fr is Schindler's. Nothing here
+			// knows "France" is a place; it is refused for coming second
+			expect(
+				ownSiteVerdict({
+					name: 'Schindler France',
+					website: 'https://france.fr',
+					runWords: noRunWords,
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'Schindler France',
+					website: 'https://schindler.fr',
+					runWords: noRunWords,
+				}),
+			).toBe('established')
+		})
+
+		it('should step over a joining word to reach the word that stands alone', () => {
+			// GIVEN a Dutch firm whose name opens with the word joining its two halves
+			// WHEN asked about that word's own domain, and about the name's
+			// THEN de.nl is nobody's and vries.nl is the firm's: a word that joins two
+			// halves of a name is never the word a company is called by
+			expect(
+				ownSiteVerdict({
+					name: 'De Vries Groep',
+					website: 'https://de.nl',
+					runWords: noRunWords,
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'De Vries Groep',
+					website: 'https://vries.nl',
+					runWords: noRunWords,
+				}),
+			).toBe('established')
+		})
+
+		it('should step over a word too short to stand for anybody', () => {
+			// GIVEN a firm whose name carries two initials in front of the family name
+			// WHEN asked
+			// THEN established. Two letters are initials rather than a name, so they are
+			// not the word a domain dropped on its way to the company, and stepping over
+			// them leaves the family name able to stand where it always did
+			expect(
+				ownSiteVerdict({
+					name: 'Transportes JM Puig',
+					website: 'https://puig.cat',
+					runWords: noRunWords,
+				}),
+			).toBe('established')
+		})
+
+		it('should scan past a legal form written at the front of a name', () => {
+			// GIVEN a French firm writing its form first, at its family name's domain
+			// WHEN asked
+			// THEN established: a form comes out wherever it sits before the words are
+			// read, so the first word weighed is what the firm does and Dupont is left
+			// standing as the word it is called by
+			expect(
+				ownSiteVerdict({
+					name: 'SARL Transports Dupont',
+					website: 'https://dupont.fr',
+					runWords: noRunWords,
+				}),
+			).toBe('established')
+		})
+
+		it('should turn on whether the run named the trade the name opens with', () => {
+			// GIVEN one plumber called García, judged by a run that asked about
+			// plumbing and by a run about one company on file, which asks for nothing
+			// WHEN each is asked about the family name's domain
+			// THEN the run that named the trade reaches García and the run that named
+			// nothing does not — an unread trade word stands in front of the name and
+			// spends the one place a word may stand alone
+			expect(
+				ownSiteVerdict({
+					name: 'Fontanería García',
+					website: 'https://garcia.es',
+					runWords: runWordsOf(['fontanería']),
+				}),
+			).toBe('established')
+			expect(
+				ownSiteVerdict({
+					name: 'Fontanería García',
+					website: 'https://garcia.es',
+					runWords: noRunWords,
+				}),
+			).toBe('unknown')
+		})
+
+		it('should refuse every word of a name but the one it is called by', () => {
+			// GIVEN names of every shape a market search meets — a trade behind the
+			// company, a place behind it, two family names, a brief of a name — each
+			// offered the bare domain of a word that is not the one the name is called
+			// by
+			// WHEN each is asked
+			// THEN none of them. Whatever a word turns out to mean, only the one a name
+			// first names somebody with may stand on its own, so a reading that let a
+			// second word through would have to answer for every row here
+			for (const [name, website] of [
+				['Cobra Instalaciones y Servicios', 'https://instalaciones.com'],
+				[
+					'Sociedad Española de Montajes Industriales SA',
+					'https://montajes.es',
+				],
+				['Acme Barcelona', 'https://barcelona.cat'],
+				['Talleres Roca Vidal', 'https://vidal.cat'],
+				['Cuatrecasas Gonçalves Pereira', 'https://goncalves.com'],
+			] as const) {
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
+					'unknown',
+				)
+			}
+		})
+
+		it('should refuse the bare domain of that word once the run brings it', () => {
+			// GIVEN one company shape per market — a word for a kind of company beside a
+			// family name — each offered the bare domain of that word, inside a run whose
+			// request was written in that market's language and which brought that
+			// language's words for a kind of company back with it
+			// WHEN each is asked
+			// THEN none of them, across seven languages, and not one of these words is
+			// written down anywhere here. grup.cat belongs to whoever registered it, not
+			// to every Catalan firm called Grup something
+			for (const [name, website, kinds] of [
+				['Grupo García', 'https://grupo.es', ['grupo', 'servicios']],
+				['Servicios García', 'https://servicios.es', ['grupo', 'servicios']],
+				['Müller Gruppe', 'https://gruppe.de', ['gruppe', 'gesellschaft']],
+				[
+					'Müller Gesellschaft',
+					'https://gesellschaft.de',
+					['gruppe', 'gesellschaft'],
+				],
+				['Gruppo Rossi', 'https://gruppo.it', ['gruppo', 'servizi']],
+				['Servizi Rossi', 'https://servizi.it', ['gruppo', 'servizi']],
+				['De Vries Groep', 'https://groep.nl', ['groep', 'diensten']],
+				['De Vries Diensten', 'https://diensten.nl', ['groep', 'diensten']],
+				['Serviços Silva', 'https://servicos.pt', ['grupo', 'serviços']],
+				['Grup Puig', 'https://grup.cat', ['grup', 'serveis']],
+				['Serveis Puig', 'https://serveis.cat', ['grup', 'serveis']],
+				['Kowalski Grupa', 'https://grupa.pl', ['grupa', 'usługi']],
+			] as const) {
+				expect(
+					ownSiteVerdict({ name, website, runWords: runWordsOf([...kinds]) }),
+				).toBe('unknown')
+			}
+		})
+
+		it('should establish each of them at the word it is really called by', () => {
+			// GIVEN the same firms at their own domains, in the same runs
+			// WHEN each is asked
+			// THEN established. Telling the run which word says what kind of company it
+			// is gives the firm its own word back, wherever in the name that word sits —
+			// puig.cat is Puig's whether the name opens with Grup or closes with it
+			for (const [name, website, kinds] of [
+				['Grup Puig', 'https://puig.cat', ['grup', 'serveis']],
+				['Serveis Puig', 'https://puig.cat', ['grup', 'serveis']],
+				['Gruppo Rossi', 'https://rossi.it', ['gruppo', 'servizi']],
+				['Müller Gruppe', 'https://mueller.de', ['gruppe', 'gesellschaft']],
+				['Serviços Silva', 'https://silva.pt', ['grupo', 'serviços']],
+			] as const) {
+				expect(
+					ownSiteVerdict({ name, website, runWords: runWordsOf([...kinds]) }),
+				).toBe('established')
+			}
+		})
+
+		it('should not take a word for a kind of company off the front of a domain', () => {
+			// GIVEN a run whose splitter offered a family name among the words for a
+			// kind of company, which is the way that reading goes wrong: those words
+			// come from a model's knowledge of a language rather than from anything a
+			// person typed
+			// WHEN a firm called Acme is offered a domain opening with that name
+			// THEN unknown. A word offered as a kind of company is spent only on saying
+			// a name's word identifies nobody, which withholds; letting it come off the
+			// front as well would hand garciaacme.es to every firm called Acme
+			expect(
+				ownSiteVerdict({
+					name: 'Acme',
+					website: 'https://garciaacme.es',
+					runWords: runWordsOf(['fontanería'], ['grupo', 'garcia']),
+				}),
+			).toBe('unknown')
+			// AND a word the request itself wrote still comes off the front, as it did
+			expect(
+				ownSiteVerdict({
+					name: 'García',
+					website: 'https://fontaneriagarcia.es',
+					runWords: runWordsOf(['fontanería'], ['grupo']),
+				}),
+			).toBe('established')
+		})
+
+		it('should answer the same asked of a host as asked of an address on it', () => {
+			// GIVEN the kind-of-company word's own domain, asked both ways — the door
+			// the directory watch knocks on, where a wrong yes lets a stranger's host
+			// off the watch
+			// WHEN asked of the host and of a page on it
+			// THEN unknown both times, since the path is never read
+			expect(
+				ownSiteHostVerdict({
+					name: 'Müller Gruppe',
+					host: 'gruppe.de',
+					runWords: noRunWords,
+				}),
+			).toBe('unknown')
+			expect(
+				ownSiteVerdict({
+					name: 'Müller Gruppe',
+					website: 'https://gruppe.de/impressum',
+					runWords: noRunWords,
+				}),
+			).toBe('unknown')
 		})
 	})
 
@@ -939,7 +1241,7 @@ describe('ownSiteVerdict', () => {
 				['Servicios García', 'https://servicios.es'],
 				['Consulting García', 'https://consulting.es'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'unknown',
 				)
 			}
@@ -957,7 +1259,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Fontanería García',
 					website: 'https://fontaneria.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -972,7 +1274,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Redwood Logistics',
 					website: 'https://cbinsights.com/company/redwood-logistics',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -989,7 +1291,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'LIPOTECH SARL',
 					website: 'https://www.facebook.com/LIPOTECH.SARL',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1002,7 +1304,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'KBE Energy',
 					website: 'https://annuaire.tecsol.fr',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1016,7 +1318,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'KBE Energy',
 					website: 'https://annuaire.fr/energy-installateurs-12345',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1030,7 +1332,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'KBE Energy',
 					website: TECSOL_LISTING,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1052,14 +1354,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: question,
 					website: 'https://fontaneria.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: question,
 					website: 'https://empresas.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1072,7 +1374,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Sociedad Española de Montajes Industriales SA',
 					website: 'https://sociedadespanola.es',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -1087,7 +1389,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'A. Martín',
 					website: 'https://a.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1099,7 +1401,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Fer Corporation',
 					website: 'https://fer.org',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -1107,19 +1409,36 @@ describe('ownSiteVerdict', () => {
 
 	describe('when the domain writes a legal form after the name', () => {
 		it('should establish it after a distinctive word, not only after the front', () => {
-			// GIVEN a company known by an acronym its own name carries, at the domain
-			// that writes that acronym and its form
+			// GIVEN a firm at the domain of the one word of its name people use, with
+			// its form written after that word rather than after the whole name
 			// WHEN asked
 			// THEN established. The form is allowed after whichever part of the name
 			// the domain spells — reading it after the front of a name but not after
 			// one of its words would be the same rule answering two ways
 			expect(
 				ownSiteVerdict({
-					name: 'Sociedad Española de Montajes Industriales SA (SEMI)',
-					website: 'https://www.semi-sa.com',
-					tradeWords: noTrades,
+					name: 'Transportes García',
+					website: 'https://garciasl.es',
+					runWords: noRunWords,
 				}),
 			).toBe('established')
+		})
+
+		it('should refuse a domain writing an acronym the name carries at its end', () => {
+			// GIVEN a company whose name ends in the short form people call it by, at
+			// the domain that writes that short form and its legal form
+			// WHEN asked
+			// THEN unknown, and this is a real company losing its own site. A firm
+			// registers by dropping the END of its name, so a word reached by dropping
+			// the START is one the address contains rather than one it spells — and
+			// the word sitting there is as often what a company IS as who it is
+			expect(
+				ownSiteVerdict({
+					name: 'Sociedad Española de Montajes Industriales SA (SEMI)',
+					website: 'https://www.semi-sa.com',
+					runWords: noRunWords,
+				}),
+			).toBe('unknown')
 		})
 	})
 
@@ -1133,7 +1452,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: '',
 					website: 'https://acme.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1145,7 +1464,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'S.L.',
 					website: 'https://sl.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1159,7 +1478,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'ADIME',
 					website: 'https://adime.org/ (not directly provided, inferred)',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1169,7 +1488,7 @@ describe('ownSiteVerdict', () => {
 			// WHEN asked — THEN each is unknown
 			for (const website of ['not a url', '', 'info@acme.es', 'src_9f2a1b3c']) {
 				expect(
-					ownSiteVerdict({ name: 'Acme', website, tradeWords: noTrades }),
+					ownSiteVerdict({ name: 'Acme', website, runWords: noRunWords }),
 				).toBe('unknown')
 			}
 		})
@@ -1181,7 +1500,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme',
 					website: 'http://192.168.1.10/acme',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1198,14 +1517,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Acme Logistics',
 					website,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 			expect(
 				ownSiteVerdict({
 					name: 'Instalaciones Rubio',
 					website,
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1225,7 +1544,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name: 'Instal·lacions Vives SL',
 						website,
-						tradeWords: noTrades,
+						runWords: noRunWords,
 					}),
 				).toBe('established')
 			}
@@ -1241,14 +1560,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Vila Nova SL',
 					website: 'https://villanova.cat',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Villa Nova SL',
 					website: 'https://vilanova.cat',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1270,7 +1589,7 @@ describe('ownSiteVerdict', () => {
 				['Þór Raflagnir', 'https://thor-raflagnir.is'],
 				['Işık Elektrik', 'https://isik-elektrik.com.tr'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'established',
 				)
 			}
@@ -1290,7 +1609,7 @@ describe('ownSiteVerdict', () => {
 					ownSiteVerdict({
 						name: 'Müller Elektro GmbH',
 						website,
-						tradeWords: noTrades,
+						runWords: noRunWords,
 					}),
 				).toBe('established')
 			}
@@ -1308,7 +1627,7 @@ describe('ownSiteVerdict', () => {
 				['Rose GmbH', 'https://rosse.de'],
 				['Sander AS', 'https://sonder.no'],
 			] as const) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
 					'unknown',
 				)
 			}
@@ -1328,14 +1647,14 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Facebook Ads Agency',
 					website: 'https://www.facebook.com/fbadsagency',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteVerdict({
 					name: 'Instagram Marketing SL',
 					website: 'https://instagram.com/instamarketing',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1351,7 +1670,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Facebook',
 					website: 'https://facebook.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1363,7 +1682,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Linkedin Formacio',
 					website: 'https://fr.linkedin.com/company/linkedin-formacio',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1377,7 +1696,7 @@ describe('ownSiteVerdict', () => {
 				ownSiteVerdict({
 					name: 'Facebook Ads Agency',
 					website: 'https://facebookadsagency.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -1395,14 +1714,14 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'D-Sécurité (groupe)',
 					host: 'd-securite.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 			expect(
 				ownSiteHostVerdict({
 					name: 'D-Sécurité Incendie',
 					host: 'd-securite.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -1415,7 +1734,7 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'Acme',
 					host: 'acme-directorio.example',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1428,7 +1747,7 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'Grupo Express SL',
 					host: 'grupo.example',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1441,7 +1760,7 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: '',
 					host: 'acme.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1456,14 +1775,14 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'Énergie Solaire',
 					host: 'xn--nergie-solaire-9jb.fr',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 			expect(
 				ownSiteHostVerdict({
 					name: 'Instalaciones Rubio',
 					host: 'xn--nergie-solaire-9jb.fr',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})
@@ -1482,8 +1801,8 @@ describe('ownSiteHostVerdict', () => {
 				'https://www.fusteriamiquel.cat/qui-som',
 				'https://fusteriamiquel.cat/obra/2024/cuina',
 			]) {
-				expect(ownSiteVerdict({ name, website, tradeWords: noTrades })).toBe(
-					ownSiteHostVerdict({ name, host, tradeWords: noTrades }),
+				expect(ownSiteVerdict({ name, website, runWords: noRunWords })).toBe(
+					ownSiteHostVerdict({ name, host, runWords: noRunWords }),
 				)
 			}
 		})
@@ -1497,14 +1816,14 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteVerdict({
 					name: 'Fusteria Miquel',
 					website: 'https://fusteriamiquel.cat/ (inferred from the name)',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteHostVerdict({
 					name: 'Fusteria Miquel',
 					host: 'fusteriamiquel.cat',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('established')
 		})
@@ -1521,21 +1840,21 @@ describe('ownSiteHostVerdict', () => {
 				ownSiteHostVerdict({
 					name: 'Facebook Ads Agency',
 					host: 'facebook.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteHostVerdict({
 					name: 'Instagram Marketing SL',
 					host: 'instagram.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 			expect(
 				ownSiteHostVerdict({
 					name: 'Tiktok Media Group',
 					host: 'tiktok.com',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				}),
 			).toBe('unknown')
 		})

--- a/packages/research/src/application/own-site.ts
+++ b/packages/research/src/application/own-site.ts
@@ -46,7 +46,7 @@
  * work for anybody in any market, so no run has to bring them. A word that names
  * a TRADE comes from the run itself: it was launched for a market and its
  * request names the trades it wants, which is that market's own vocabulary in
- * the languages that market answers in (`trade-words.ts`).
+ * the languages that market answers in (`run-words.ts`).
  *
  * Reading the run is what makes this sector-agnostic. A list can only ever do
  * the first job: whichever trades somebody writes down are identified, and every
@@ -64,6 +64,54 @@
  * to prevent, reappearing in the one market the list is right about. They go
  * when a run with no market behind it has some other way to say what a company
  * does, and not before.
+ *
+ * ## The words for a kind of company
+ *
+ * The list's other half names a KIND of company — group, holding, servicios. It
+ * is not the English and Spanish it looks like: "Sociedad García" is at home on
+ * sociedad.es on that list alone, as are Empresa, Corporación and Asociación
+ * something, in the market this is measured on. A list that misses the commonest
+ * company word in the language it supposedly covers is not a list with gaps, it
+ * is the wrong shape of answer.
+ *
+ * The run answers for these too, the same way it answers for trades. Its request
+ * names the trades outright and never says "group" — but the language that
+ * request is written in says which language its companies name themselves in, so
+ * the one reading that splits a request into its trades is asked for that
+ * language's words for a kind of company beside them (`request-parts.ts`). Both
+ * arrive as one vocabulary (`run-words.ts`), because a word for a kind of company
+ * answers "does this identify anybody" exactly as a trade does.
+ *
+ * Three other replacements were priced against the rows eight market searches
+ * returned, and none of them stands. A PUBLISHED LIST OF LEGAL FORMS does not hold
+ * these words: it carries "Gesellschaft" and not one of Gruppe, Grup, Groep,
+ * Grupa, Serveis, Servizi or Serviços, because a legal form is a closed class a
+ * country defines and a word for a kind of company is not one — and feeding its
+ * words in takes Crédit Agricole and Mutua Madrileña off their own sites. WORDS
+ * MANY COMPANIES IN ONE RUN SHARE catch none of them and cost real ones: ranked
+ * by how many differently-named companies carry them, a run's shared words are
+ * its trades and its places — "ascenseurs" nine, "france" six — while a
+ * kind-of-company word peaks at three, level with the surnames, and most of what
+ * looks like sharing is ONE company written twice. REFUSING A NAME'S WORD
+ * WHENEVER ANOTHER WORD COULD BE THE COMPANY answers every case and takes 26
+ * firms in 238 off sites that really are theirs — Schindler at schindler.fr, KONE
+ * at kone.fr, Naturgy at naturgy.com.
+ *
+ * ## Where the word sits, for the run that brings nothing
+ *
+ * A run about ONE COMPANY ON FILE has no market behind it and so brings no words
+ * at all, which is where the shared list is still the only thing standing. WHERE
+ * THE WORD SITS answers half of what the list misses there, and needs nothing
+ * brought: a firm drops the front of its name to register it and not the end, so
+ * the word that may stand alone is the first one that identifies anybody — see
+ * `theWordThatMayStandAlone`. Where a language writes the kind-of-company word
+ * last it settles it, and Müller Gruppe is Müller's while gruppe.de is nobody's,
+ * without "gruppe" being known to anything.
+ *
+ * Where a language writes that word first it settles nothing, and a run with
+ * nothing brought keeps grup.cat for Grup Puig, because "Grup Puig" and
+ * "Schindler France" are one shape to anything reading an address. That is what
+ * the run's own words close when there is a run to ask.
  *
  * ## What deliberately does NOT establish it
  *
@@ -126,6 +174,30 @@
  * does, which is one more way to reach a name and so one more way to reach the
  * wrong one; over those 159 rows it cleared nothing the rest of the reading did
  * not already clear.
+ *
+ * Reading only the FIRST word that identifies anybody costs where a word for a
+ * trade goes unrecognised, because that word then stands in front of the name
+ * and takes the one place a word may stand alone. Over the same rows it changed
+ * one answer, and that one was a lift maker's domain being taken off a company
+ * the scan had written its name after; it cleared nothing it had not cleared
+ * before.
+ *
+ * A run with no trades to read pays more, and pays it the wrong way round.
+ * "Fontanería García" keeps fontaneria.es, which is the known cost above, and
+ * loses garcia.es, which was the right answer — so of the two the one left
+ * standing is the worse. Both were cleared before and the withholding is the
+ * safe direction, but a word missing from the shared list costs twice over: it
+ * fails to refuse the trade's own domain AND it spends the place the company's
+ * word would have stood in. Over the same rows one company paid it,
+ * "Instalaciones Eléctricas Comuval" at comuval.com. It is the run's trades that
+ * buy this back, so the runs that pay are the ones with no market behind them —
+ * the same runs the shared list was kept for.
+ *
+ * It costs the same where a request names a trade in a longer wording than the
+ * name uses — a request for "restaurants" does not reach a firm called
+ * "Restaurant Sumat", so "restaurant" stands in front of the name and sumat.cat
+ * reads `unknown`. The wording is `run-words.ts`'s to widen, and widening it
+ * is measured there rather than worked around here.
  *
  * ## The shortening that was measured and refused
  *
@@ -218,7 +290,6 @@
 import {
 	collapse,
 	DISTINCTIVE_NAME_LENGTH,
-	distinctiveWords,
 	hostLabel,
 	isGenericWord,
 	labelSpellsOneOf,
@@ -226,9 +297,9 @@ import {
 	nameWordsWithoutForms,
 	withoutFormDots,
 } from './entity-guard'
+import { namesNobody, type RunWords, runWroteExactly } from './run-words'
 import { isSocialPlatformHost } from './social-sites'
 import { hostOf, isBareWebAddress } from './source-key'
-import { namesATrade, type TradeWords, wasAskedForExactly } from './trade-words'
 
 /**
  * What is known about a company's website. `unknown` is not "cleared". Spelled
@@ -281,28 +352,73 @@ const JOINS_TWO_HALVES_OF_A_NAME = new Set([
 // name by dropping the end ("Acme Logistics" at acme.com) and not by dropping
 // the start, and a run taken from anywhere would let a listing filed under any
 // word of the name clear itself.
+// Whether this word of a name says WHO the company is, rather than what it does,
+// what kind of thing it is, or joining the two halves of a name.
+//
+// Written once because both readings below turn on it — which front runs a
+// domain could carry, and which single word may stand for the company — and a
+// name whose front names somebody to one of them and nobody to the other is the
+// same rule answering two ways.
+const identifiesSomebody = (
+	word: string,
+	identifiesNobody: (word: string) => boolean,
+): boolean => !identifiesNobody(word) && !JOINS_TWO_HALVES_OF_A_NAME.has(word)
+
 const namesTheDomainCouldCarry = (
 	words: ReadonlyArray<string>,
 	identifiesNobody: (word: string) => boolean,
 ): ReadonlyArray<string> => {
 	const runs: Array<string> = []
 	let run = ''
-	let identifiesSomebody = false
+	let hasNamedSomebody = false
 	for (const word of words) {
 		run += word
 		// A front part made of nothing but trade words identifies nobody, so
 		// "Grupo Ferré" must not be at home on grupo.es and "Transportes García"
 		// not on transportes.com. Once a word of the company's own has arrived,
 		// every longer run carries it.
-		identifiesSomebody =
-			identifiesSomebody ||
-			(!identifiesNobody(word) && !JOINS_TWO_HALVES_OF_A_NAME.has(word))
-		if (identifiesSomebody && run.length >= SHORTEST_NAME_A_DOMAIN_SPELLS) {
+		hasNamedSomebody =
+			hasNamedSomebody || identifiesSomebody(word, identifiesNobody)
+		if (hasNamedSomebody && run.length >= SHORTEST_NAME_A_DOMAIN_SPELLS) {
 			runs.push(run)
 		}
 	}
 	return runs
 }
+
+// The one word of a name that may stand for the company on its own: the first
+// that identifies anybody. A firm registers the word people call it by, and the
+// front it drops on the way there is what it is rather than who — "Transportes
+// García" at garcia.es.
+//
+// Only the first, because past it nothing tells a word for a KIND of company
+// from the company. "Müller Gruppe" and "Schindler France" are the same two
+// words to this reading — a word it can place and a word it cannot — and the
+// shared list places neither "gruppe" nor "france". Letting any word stand
+// alone hands gruppe.de to every German firm called something Gruppe; letting
+// only the first clears no address it did not clear before, because a name's
+// own word comes first whenever the kind-of-company word is written last.
+//
+// It buys nothing where that word is written FIRST — "Gruppe Müller" offers
+// "gruppe" as its first word and this takes it. Nothing HERE can close that:
+// read off an address, "Gruppe Müller" and "Schindler France" are one shape, and
+// which of the two words names the company is the question rather than something
+// to read off it. What closes it is the run saying the word names a kind of
+// company, which leaves this reading nothing to take. So the half that stays open
+// is exactly the half where no run said anything.
+//
+// A word too short to stand for anybody is stepped over rather than spending the
+// place: "Transportes JM Puig" is Puig's, and two letters of a name are initials
+// that could not have been the word a domain dropped.
+const theWordThatMayStandAlone = (
+	spelled: ReadonlyArray<string>,
+	identifiesNobody: (word: string) => boolean,
+): string | undefined =>
+	spelled.find(
+		word =>
+			identifiesSomebody(word, identifiesNobody) &&
+			word.length >= DISTINCTIVE_NAME_LENGTH,
+	)
 
 // What is left of a label once the trade word it opens with is taken off, or null
 // when it opens with none. A firm often writes what it does in front of what it
@@ -368,30 +484,25 @@ const withoutLeadingTradeWord = (
 const hostSpellsTheCompany = (
 	name: string,
 	host: string,
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): boolean => {
 	// A word identifies nobody when it names a kind of company — the shared list —
-	// or a trade this run went looking for.
+	// or a trade this run went looking for. The trade comes out of a name's words
+	// here rather than in `entity-guard.ts`, because a word that identifies nobody
+	// is still a word a page naming the company may write, and the guard that
+	// reads pages needs it — this is the one reading where a word standing alone
+	// is spent claiming a domain.
 	const identifiesNobody = (word: string): boolean =>
-		isGenericWord(word) || namesATrade(word, tradeWords)
+		isGenericWord(word) || namesNobody(word, runWords)
 	// The word in front of a domain is judged more strictly than a word of a name:
 	// the request has to have written it exactly. A label says nowhere where its
 	// first word ends, so a reading that allowed an ending would cut into the name
-	// behind it — see `wasAskedForExactly`.
+	// behind it — see `runWroteExactly`.
 	const identifiesNobodyAsWritten = (word: string): boolean =>
-		isGenericWord(word) || wasAskedForExactly(word, tradeWords)
+		isGenericWord(word) || runWroteExactly(word, runWords)
 
 	const label = collapse(hostLabel(host))
 	const pastTheTrade = withoutLeadingTradeWord(label, identifiesNobodyAsWritten)
-	// The distinctive words are read off the name itself, which already offers
-	// each of them in every spelling. The trade the run asked about comes out of
-	// them here rather than in `entity-guard.ts`, because a word that identifies
-	// nobody is still a word a page naming the company may write, and the guard
-	// that reads pages needs it — this is the one reading where a word standing
-	// alone is spent claiming a domain.
-	const words = distinctiveWords(name).filter(
-		word => !namesATrade(word, tradeWords),
-	)
 	// Every spelling of the name, since a domain writes a Catalan geminate l
 	// whichever way its owner chose and both are the same company's. The dots of a
 	// legal form come out after the spellings are read, never before, or a name
@@ -401,7 +512,11 @@ const hostSpellsTheCompany = (
 		// A brief rather than a name, which no spelling of it can rescue.
 		if (spelled.length > MOST_WORDS_A_NAME_RUNS_TO) return false
 		const couldCarry = namesTheDomainCouldCarry(spelled, identifiesNobody)
-		if (labelSpellsOneOf(label, [...couldCarry, ...words])) return true
+		// Read off this spelling rather than off the whole name, so the word that
+		// comes first is the one that comes first as the domain writes it.
+		const oneWord = theWordThatMayStandAlone(spelled, identifiesNobody)
+		const standingAlone = oneWord === undefined ? [] : [oneWord]
+		if (labelSpellsOneOf(label, [...couldCarry, ...standingAlone])) return true
 		// Past a trade word, only the front of the name is read, never one word
 		// taken from the middle of it. The label has already spent its own front on
 		// the trade word, so a word matched here is a word the domain CONTAINS
@@ -422,10 +537,10 @@ const hostSpellsTheCompany = (
 export const ownSiteHostVerdict = (args: {
 	readonly name: string
 	readonly host: string
-	readonly tradeWords: TradeWords
+	readonly runWords: RunWords
 }): OwnSiteVerdict =>
 	!isSocialPlatformHost(args.host) &&
-	hostSpellsTheCompany(args.name, args.host, args.tradeWords)
+	hostSpellsTheCompany(args.name, args.host, args.runWords)
 		? 'established'
 		: 'unknown'
 
@@ -437,7 +552,7 @@ export const ownSiteHostVerdict = (args: {
  * that arrives with no name beside it. A run with no name to compare establishes
  * nothing, which is the right answer rather than a missing one.
  *
- * `tradeWords` is what the run itself went looking for (`trade-words.ts`). Asked
+ * `runWords` is what the run itself went looking for (`run-words.ts`). Asked
  * for rather than reached from here, and asked for on every call rather than
  * defaulted to none, because a caller that quietly left it out would judge the
  * same address by a different reading from the rest of the run — and would clear
@@ -446,14 +561,14 @@ export const ownSiteHostVerdict = (args: {
 export const ownSiteVerdict = (args: {
 	readonly name: string
 	readonly website: string
-	readonly tradeWords: TradeWords
+	readonly runWords: RunWords
 }): OwnSiteVerdict => {
-	const { name, website, tradeWords } = args
+	const { name, website, runWords } = args
 	// A value with words written next to it is not one address, so there is no
 	// domain to read — and a reader cannot open it either.
 	if (!isBareWebAddress(website)) return 'unknown'
 	const host = hostOf(website)
 	if (host === null) return 'unknown'
 
-	return ownSiteHostVerdict({ name, host, tradeWords })
+	return ownSiteHostVerdict({ name, host, runWords })
 }

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -11,12 +11,12 @@ import {
 	perFieldSearchQuery,
 	scanRowFields,
 } from './per-field-search'
+import { runWordsOf } from './run-words'
 import { CompetitorScanV1Schema } from './schemas/competitor-scan-v1'
 import { ProspectScanV1Schema } from './schemas/prospect-scan-v1'
-import { tradeWordsOf } from './trade-words'
 
 // A run that named no trades, which is a request about one company on file.
-const noTrades = tradeWordsOf([])
+const noRunWords = runWordsOf([])
 
 // A per-field-citation value the way the enrichment schema stores one.
 const sourced = (value: string) => ({ value, source_id: 'https://x.test' })
@@ -317,7 +317,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
-				noTrades,
+				noRunWords,
 			)
 			// THEN the empty country is filled but the grounded industry is untouched
 			expect(filled).toBe(1)
@@ -338,7 +338,7 @@ describe('mergePerFieldSearch', () => {
 				findings: next,
 				filled,
 				added,
-			} = mergePerFieldSearch(findings, {}, PROFILE, noTrades)
+			} = mergePerFieldSearch(findings, {}, PROFILE, noRunWords)
 			// THEN nothing is filled and the same findings come back
 			expect(filled).toBe(0)
 			expect(added).toBe(0)
@@ -367,7 +367,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
-				noTrades,
+				noRunWords,
 			)
 
 			// THEN the second person is kept, the first not duplicated
@@ -393,7 +393,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
-				noTrades,
+				noRunWords,
 			)
 			expect(contactsChanged).toBe(false)
 			expect(next).toBe(findings)
@@ -416,7 +416,7 @@ describe('mergePerFieldSearch', () => {
 				findings,
 				refreshed,
 				PROFILE,
-				noTrades,
+				noRunWords,
 			)
 
 			// THEN the title is kept, even though the list is exactly as long as it
@@ -456,7 +456,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN each recovered value lands on the company it belongs to, the
@@ -488,7 +488,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'acme sl', website: 'https://acme.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN one company stays one company, keeping the name first written
 			expect(rows).toHaveLength(1)
@@ -517,7 +517,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN it is one company that gained a site and a place, not two rows. A
@@ -547,7 +547,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN the shared site settles it, as it does for the fold that runs over
@@ -567,7 +567,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN it is still one company — most of the market this searches writes
 			// names with accents, and matching on the letters alone would have listed
@@ -585,7 +585,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme Holding', website: 'https://holding.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN Acme keeps its blank rather than inheriting another company's site,
 			// and the other company is listed in its own right — a duplicate is a far
@@ -610,7 +610,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN one company, keeping the town the branch brought. The fold that runs
 			// before these rounds cannot see a company found after it, so a round that
@@ -638,7 +638,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN the shared host settles it here too, because the domain says whose it
 			// is. A row appended by a round is never put in front of the fold again
@@ -659,7 +659,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Terre Solaire Energie', location: 'Nantes' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN both are listed and the round is credited with the find — sharing an
 			// opening word is not being somebody's branch
@@ -688,7 +688,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN the list holds the one company and the new one, and the round is
 			// credited with the find. Counting the length instead would read nothing
@@ -707,7 +707,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN it joins the list once — the list's length decides whether a scan
 			// came back too thin to trust, so counting one company twice would pass a
@@ -726,7 +726,7 @@ describe('mergePerFieldSearch', () => {
 				],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 			// THEN one of them is taken and the fold stays stable, with no duplicate
 			// appended for the company already known
@@ -742,7 +742,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme', website: 'https://acme.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			// THEN the wider read's find is kept — an empty list is exactly the one
 			// with the most to gain from looking again
 			expect(prospectsOf(merged.findings).map(row => row['name'])).toEqual([
@@ -758,7 +758,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ website: 'https://nameless.test' }, { name: '  ' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			// THEN nothing is appended, since a company with no name cannot be worked
 			// with or told apart from another
 			expect(merged.added).toBe(0)
@@ -783,7 +783,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN both companies ship. The domain spells neither of them, so it is
@@ -820,7 +820,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 
 			// THEN one company, and the fold says it joined a row — a real fold, for
 			// the good reason that the site now says the two rows are one company
@@ -852,7 +852,7 @@ describe('mergePerFieldSearch', () => {
 					findings,
 					{ prospects: [found] },
 					SCAN,
-					noTrades,
+					noRunWords,
 				).findings
 			}
 
@@ -885,7 +885,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN one company, which gained the town the round found. Who owns the
@@ -917,7 +917,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 
 			// THEN nothing is reported as joined. The rows met by name, which is the
 			// reason the rounds run at all — counting those would bury the one join
@@ -940,7 +940,7 @@ describe('mergePerFieldSearch', () => {
 			}
 
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			const rows = prospectsOf(merged.findings)
 
 			// THEN two rows, because nothing yet ties the two names together: the listed
@@ -963,7 +963,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Beta', website: 'https://beta.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			// THEN a second look only ever adds — it never shortens the list
 			expect(prospectsOf(merged.findings).map(row => row['name'])).toEqual([
 				'Acme',
@@ -980,7 +980,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme', website: 'https://other.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			// THEN the very same findings come back, which is what stops the rounds
 			expect(merged.findings).toBe(findings)
 			expect(merged.filled).toBe(0)
@@ -993,11 +993,11 @@ describe('mergePerFieldSearch', () => {
 			// WHEN merged
 			// THEN nothing is invented around them
 			expect(
-				mergePerFieldSearch(null, refreshed, SCAN, noTrades).findings,
+				mergePerFieldSearch(null, refreshed, SCAN, noRunWords).findings,
 			).toBe(null)
-			expect(mergePerFieldSearch('x', refreshed, SCAN, noTrades).findings).toBe(
-				'x',
-			)
+			expect(
+				mergePerFieldSearch('x', refreshed, SCAN, noRunWords).findings,
+			).toBe('x')
 		})
 
 		it('should leave the findings alone when the second look holds no list', () => {
@@ -1005,12 +1005,12 @@ describe('mergePerFieldSearch', () => {
 			const findings = { prospects: [{ name: 'Acme' }] }
 			// WHEN merged
 			// THEN the list is untouched
-			expect(mergePerFieldSearch(findings, {}, SCAN, noTrades).findings).toBe(
+			expect(mergePerFieldSearch(findings, {}, SCAN, noRunWords).findings).toBe(
 				findings,
 			)
-			expect(mergePerFieldSearch(findings, null, SCAN, noTrades).findings).toBe(
-				findings,
-			)
+			expect(
+				mergePerFieldSearch(findings, null, SCAN, noRunWords).findings,
+			).toBe(findings)
 		})
 
 		it('should carry the rest of the findings across untouched', () => {
@@ -1023,7 +1023,7 @@ describe('mergePerFieldSearch', () => {
 				prospects: [{ name: 'Acme', website: 'https://acme.test' }],
 			}
 			// WHEN merged
-			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noTrades)
+			const merged = mergePerFieldSearch(findings, refreshed, SCAN, noRunWords)
 			// THEN everything beside the list survives the fold
 			expect(
 				(merged.findings as { pending_paid_actions: unknown })

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -30,7 +30,7 @@ import {
 	hostsEstablishedAsOwn,
 	isSiteKey,
 } from './prospect-dedupe-guard'
-import type { TradeWords } from './trade-words'
+import type { RunWords } from './run-words'
 
 // The company-profile facts worth spending an extra search on. `size_range` is
 // also nudged during the loop (headcount is rarely on the homepage); for the
@@ -262,7 +262,7 @@ const mergeScanRows = (
 	schemaName: string,
 	findings: unknown,
 	refreshed: unknown,
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): PerFieldMerge => {
 	const field = discoveryResultField(schemaName)
 	const known = scanRowsOf(schemaName, findings)
@@ -289,7 +289,7 @@ const mergeScanRows = (
 	// under a name that does not spell its domain while the list already holds it
 	// under one that does — and asking each side on its own would leave the site
 	// speaking for the row that has it and silent for the row that needs it.
-	const ownSiteHosts = hostsEstablishedAsOwn([...known, ...found], tradeWords)
+	const ownSiteHosts = hostsEstablishedAsOwn([...known, ...found], runWords)
 	const foundByKey = new Map<string, Record<string, unknown>>()
 	for (const row of found) {
 		// First mention wins: a later duplicate of the same company in the same
@@ -364,7 +364,7 @@ const mergeScanRows = (
 			dedupeDiscoveryRows(
 				{ ...(findings as object), [field]: rows },
 				field,
-				tradeWords,
+				runWords,
 			).findings as Record<string, unknown>
 		)[field]
 		return Array.isArray(held) ? held.length : undefined
@@ -372,7 +372,7 @@ const mergeScanRows = (
 	const settled = dedupeDiscoveryRows(
 		{ ...(findings as object), [field]: [...merged, ...additions] },
 		field,
-		tradeWords,
+		runWords,
 	)
 	const held = (settled.findings as Record<string, unknown>)[field]
 	// What the list gained, counted in companies rather than rows. A row that joined
@@ -420,10 +420,10 @@ export const mergePerFieldSearch = (
 	findings: unknown,
 	refreshed: unknown,
 	schemaName: string,
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): PerFieldMerge => {
 	if (isDiscoveryScan(schemaName)) {
-		return mergeScanRows(schemaName, findings, refreshed, tradeWords)
+		return mergeScanRows(schemaName, findings, refreshed, runWords)
 	}
 	const enrichment = enrichmentOf(findings)
 	const refreshedEnrichment = enrichmentOf(refreshed)

--- a/packages/research/src/application/prospect-dedupe-guard.test.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.test.ts
@@ -8,10 +8,10 @@ import {
 	hostsEstablishedAsOwn,
 	isSiteKey,
 } from './prospect-dedupe-guard'
-import { tradeWordsOf } from './trade-words'
+import { runWordsOf } from './run-words'
 
 // A run that named no trades, which is a request about one company on file.
-const noTrades = tradeWordsOf([])
+const noRunWords = runWordsOf([])
 
 const scan = (
 	prospects: ReadonlyArray<Record<string, unknown>>,
@@ -43,7 +43,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN the list is de-duplicated
 			// THEN one row survives — the form comes off the end of the name key, so
 			// the two spellings meet
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe(
 				'Cobra Instalaciones y Servicios',
@@ -59,7 +59,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN accents fold before the names are compared
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -73,7 +73,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the dots come out before the form is read off the end, so it is one
 			// company rather than one whose form reads as two more words of its name
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -89,7 +89,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the site settles it: the host is the same one
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -103,7 +103,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN all three become one company, which is what they are
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(result.merged).toBe(2)
 		})
@@ -121,7 +121,7 @@ describe('dedupeDiscoveryRows', () => {
 			// THEN still one company. The bridge row joins two rows that were until
 			// then separate, and a list arrives in whatever order the model wrote it —
 			// so an answer that changed with the order would be no answer at all
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(result.merged).toBe(2)
 		})
@@ -143,7 +143,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the later row's findings survive on the row that stays — dropping it
 			// outright would throw away what the run paid to find
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]).toMatchObject({
 				name: 'Instalaciones Rubio SL',
 				tax_id: 'B36123456',
@@ -161,7 +161,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN the first reading stays: it is the one the checks upstream weighed
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['industry']).toBe('electrical')
 		})
 
@@ -173,7 +173,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the blank is a gap, so the later value lands
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['website']).toBe('https://acme.es')
 		})
 
@@ -200,7 +200,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN the surviving row keeps everything the run read, each page once
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(citedPagesOf(result.findings)).toEqual([
 				'https://acme.es',
 				'https://ranking.es',
@@ -220,7 +220,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the evidence still reaches the row that stays
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(citedPagesOf(result.findings)).toEqual(['https://acme.es'])
 		})
 	})
@@ -234,7 +234,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN both stay and nothing is counted as merged
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -250,7 +250,7 @@ describe('dedupeDiscoveryRows', () => {
 			// THEN they still meet, on the name as written. Neither is a company anyone
 			// can work with, but leaving them with no key at all would let the list
 			// keep every copy of the same useless row
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -262,7 +262,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN no host can be read, so neither row lends one
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -276,7 +276,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN both stay. The domain spells neither of them, so it is nobody's own
 			// site and says nothing about whether these are one company
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings).map(row => row['name'])).toEqual([
 				'Electricidad Mora',
 				'Instalaciones Rubio',
@@ -295,7 +295,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the two spellings of one name still meet, and the third company is
 			// not dragged in behind them by an address none of the three owns
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings).map(row => row['name'])).toEqual([
 				'Electricidad Mora SL',
 				'Instalaciones Rubio',
@@ -320,7 +320,7 @@ describe('dedupeDiscoveryRows', () => {
 			// THEN one company. The domain says whose site it is, so the row beside it
 			// is that company again under another name — the trade name beside the
 			// legal one, which is the pair this fold exists for
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('Terre Solaire')
 		})
@@ -343,7 +343,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN all three are one company. Who owns a domain is read across the whole
 			// list, so the row that spells it settles the host for every row on it
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(result.merged).toBe(2)
 		})
@@ -367,7 +367,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN one company comes back, under its own name
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('Terre Solaire')
 			expect(result.merged).toBe(4)
@@ -386,7 +386,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN all three towns survive on the row that stays — taking whichever
 			// arrived first would drop the other two with nothing said
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe(
 				'Douains; Lyon; Montpellier',
 			)
@@ -401,7 +401,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the town is stated once, not twice
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
 
@@ -419,7 +419,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the reader is told the company's name, not one branch's. Which row a
 			// search happened to rank first is no reason to call it something else
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]).toMatchObject({
 				name: 'Terre Solaire',
@@ -440,7 +440,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated
 			// THEN one company under its own name, with every town still on it
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]).toMatchObject({
 				name: 'Terre Solaire',
@@ -462,7 +462,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN no address can be read from it, so it is still a
 			// row with no site of its own
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 		})
 
@@ -480,7 +480,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN both stay: a row claiming its own web presence is claiming to be
 			// somebody, and two hosts are the strongest evidence of two of them
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -496,7 +496,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN both towns are named, whichever arrived first
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon; Paris')
 		})
 
@@ -516,7 +516,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the first reading of that town stands. Only a row speaking about
 			// somewhere else adds a place; another reading of one branch is not that
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
@@ -532,7 +532,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN one town, not two. A place that holds one already named is the same
 			// place written at more detail, and listing both would invent a branch
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
 
@@ -548,7 +548,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN both towns are named. Places are compared word by word, so one town
 			// reading inside another is not the same town written at more detail
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Roa; Roanne')
 		})
 
@@ -567,7 +567,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the unreadable town is kept beside the readable one. A place the
 			// code cannot read is a place it must not throw away for that reason
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Osaka; 東京')
 		})
 
@@ -585,7 +585,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the branch's town stands alone. A row naming nowhere adds nowhere,
 			// rather than a blank reading trailing the one place the run did find
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Lyon')
 		})
 
@@ -599,7 +599,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated
 			// THEN the first reading stands. Two readings of one place are not two
 			// places, and only a branch speaks about somewhere else
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Vigo')
 		})
@@ -619,7 +619,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN the list is de-duplicated
 			// THEN one row survives, under the name without the note
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('KBE Energy')
 			expect(result.merged).toBe(1)
@@ -638,7 +638,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN one row, and the note row's town fills nothing
 			// it already answered: this is one company written twice, not a second
 			// place the company works from
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['location']).toBe("Val-d'Oise (95)")
 		})
@@ -652,7 +652,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN the company keeps its own name, and what the
 			// noted row knew is not thrown away with the brackets
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(1)
 			expect(rowsOf(result.findings)[0]?.['name']).toBe('KBE Energy')
 			expect(rowsOf(result.findings)[0]?.['location']).toBe('Paris')
@@ -665,7 +665,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN both survive. Taking brackets off every name
 			// before filing it would have folded these two, which is why the plain
 			// name has to be on the list for a note to read as a note
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -680,7 +680,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN three rows: folding either arm onto the bare
 			// row would drag the other in through it
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(3)
 		})
 
@@ -695,7 +695,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN the surviving row is backed by both
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(citedPagesOf(result.findings)).toEqual(['src_own', 'src_tecsol'])
 		})
 	})
@@ -715,7 +715,7 @@ describe('dedupeDiscoveryRows', () => {
 			// WHEN de-duplicated — THEN both survive, and that is not an oversight.
 			// Joining them needs to know that "Groupe" adds nothing to a name, which
 			// is a list of words per language
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -727,7 +727,7 @@ describe('dedupeDiscoveryRows', () => {
 			])
 
 			// WHEN de-duplicated — THEN both survive
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -747,7 +747,7 @@ describe('dedupeDiscoveryRows', () => {
 			// smaller half: grant it and what is left is one name being the other plus
 			// a trailing word, with no town stated to check that word against, which is
 			// the case above and closed for the same reason
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 		})
 
@@ -762,7 +762,7 @@ describe('dedupeDiscoveryRows', () => {
 
 			// WHEN de-duplicated — THEN both survive, which is the right answer here
 			// and the wrong one above, and nothing on the rows says which is which
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -774,7 +774,7 @@ describe('dedupeDiscoveryRows', () => {
 			const findings = { enrichment: { industry: 'electrical' } }
 
 			// WHEN de-duplicated with no list field — THEN nothing is compared
-			const result = dedupeDiscoveryRows(findings, undefined, noTrades)
+			const result = dedupeDiscoveryRows(findings, undefined, noRunWords)
 			expect(result.findings).toBe(findings)
 			expect(result.merged).toBe(0)
 		})
@@ -784,7 +784,7 @@ describe('dedupeDiscoveryRows', () => {
 			const findings = { prospects: [null, { name: 'Elecnor' }] }
 
 			// WHEN de-duplicated — THEN only real rows are compared
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toEqual([null, { name: 'Elecnor' }])
 		})
 
@@ -792,11 +792,11 @@ describe('dedupeDiscoveryRows', () => {
 			// GIVEN non-object findings
 			// WHEN de-duplicated — THEN they pass straight through
 			expect(
-				dedupeDiscoveryRows(null, 'prospects', noTrades).findings,
+				dedupeDiscoveryRows(null, 'prospects', noRunWords).findings,
 			).toBeNull()
-			expect(dedupeDiscoveryRows('text', 'prospects', noTrades).findings).toBe(
-				'text',
-			)
+			expect(
+				dedupeDiscoveryRows('text', 'prospects', noRunWords).findings,
+			).toBe('text')
 		})
 	})
 })
@@ -882,7 +882,7 @@ describe('branchOfficeParents', () => {
 			])
 
 			// WHEN de-duplicated — THEN two companies come back, as they should
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -1021,7 +1021,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read
 			// THEN the noted row belongs to the plain one
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1035,7 +1035,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN the plain row is still the one it belongs
 			// to, because which row a search ranked first says nothing about the name
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([[0, 1]])
 		})
 
@@ -1048,7 +1048,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN the form comes off before the names meet
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1061,7 +1061,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN the padding is not what tells them apart
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1076,7 +1076,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN both belong to the plain row: the
 			// brackets are not telling the two rows apart, they say the same thing
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([
 				[1, 0],
 				[2, 0],
@@ -1092,7 +1092,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN nothing folds: neither row is the plain
 			// name the other is a second reading of
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1108,7 +1108,7 @@ describe('bracketedNoteParents', () => {
 			// name are distinguishing the rows, and folding either onto the bare row
 			// would drag all three together through it
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1130,7 +1130,7 @@ describe('bracketedNoteParents', () => {
 			// a note apart from its name only when each is established as that row's
 			// own; a host nobody is named by says nothing about who anybody is
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([[1, 0]])
 		})
 
@@ -1145,7 +1145,7 @@ describe('bracketedNoteParents', () => {
 			// strongest thing on a row for saying these are two companies, and it
 			// outranks a bracket
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1158,7 +1158,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN one host is no reason to hold them apart
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([[1, 0]])
 		})
 	})
@@ -1170,7 +1170,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN the brackets alone fold nothing
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1181,7 +1181,7 @@ describe('bracketedNoteParents', () => {
 			// WHEN the notes are read — THEN it names no company for another row to be
 			// a second reading of
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1191,7 +1191,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN this is a longer name, not a noted one
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1201,7 +1201,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN there is no company to be the same one as
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 	})
@@ -1213,7 +1213,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN only rows are read
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1223,7 +1223,7 @@ describe('bracketedNoteParents', () => {
 
 			// WHEN the notes are read — THEN nothing is read off it
 			expect([
-				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noTrades)),
+				...bracketedNoteParents(rows, hostsEstablishedAsOwn(rows, noRunWords)),
 			]).toEqual([])
 		})
 
@@ -1231,7 +1231,7 @@ describe('bracketedNoteParents', () => {
 			// GIVEN nothing to read
 			// WHEN the notes are read — THEN there is nothing to belong to anything
 			expect([
-				...bracketedNoteParents([], hostsEstablishedAsOwn([], noTrades)),
+				...bracketedNoteParents([], hostsEstablishedAsOwn([], noRunWords)),
 			]).toEqual([])
 		})
 	})
@@ -1251,7 +1251,7 @@ describe('hostsEstablishedAsOwn', () => {
 			// THEN none: fontaneria.es belongs to whoever registered it. Reading it as
 			// owned would make it a key both rows share, and two unrelated firms would
 			// be folded into one company
-			expect(hostsEstablishedAsOwn(rows, tradeWordsOf(['fontanería']))).toEqual(
+			expect(hostsEstablishedAsOwn(rows, runWordsOf(['fontanería']))).toEqual(
 				new Set(),
 			)
 		})
@@ -1261,7 +1261,7 @@ describe('hostsEstablishedAsOwn', () => {
 			const rows = [{ name: 'Fontanería García', website: 'https://garcia.es' }]
 
 			// WHEN the owned hosts are worked out — THEN that host is one of them
-			expect(hostsEstablishedAsOwn(rows, tradeWordsOf(['fontanería']))).toEqual(
+			expect(hostsEstablishedAsOwn(rows, runWordsOf(['fontanería']))).toEqual(
 				new Set(['garcia.es']),
 			)
 		})
@@ -1278,7 +1278,7 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN the host is one of them
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(
 				new Set(['fusteriamiquel.cat']),
 			)
 		})
@@ -1296,7 +1296,7 @@ describe('hostsEstablishedAsOwn', () => {
 			// WHEN the owned hosts are worked out
 			// THEN one host, spelled the way the identity keys spell it — otherwise the
 			// row that establishes a site and the row that needs it never meet
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(
 				new Set(['sice.com']),
 			)
 		})
@@ -1318,7 +1318,7 @@ describe('hostsEstablishedAsOwn', () => {
 			// THEN the directory is nobody's own site. Reading the note as part of the
 			// name would have the directory's own words spell the company, and every
 			// other firm listed there would then file under it as the same company
-			expect([...hostsEstablishedAsOwn(rows, noTrades)]).toEqual([])
+			expect([...hostsEstablishedAsOwn(rows, noRunWords)]).toEqual([])
 		})
 
 		it('should keep two companies on one directory apart through the fold', () => {
@@ -1333,7 +1333,7 @@ describe('hostsEstablishedAsOwn', () => {
 
 			// WHEN de-duplicated — THEN both survive, because a shared directory is no
 			// evidence that two companies are one
-			const result = dedupeDiscoveryRows(findings, 'prospects', noTrades)
+			const result = dedupeDiscoveryRows(findings, 'prospects', noRunWords)
 			expect(rowsOf(result.findings)).toHaveLength(2)
 			expect(result.merged).toBe(0)
 		})
@@ -1346,7 +1346,7 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN there are none
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(new Set())
 		})
 
 		it('should leave out a host merely carrying a word of the name', () => {
@@ -1358,7 +1358,7 @@ describe('hostsEstablishedAsOwn', () => {
 			// WHEN the owned hosts are worked out
 			// THEN none. A domain has to BE the name, or every listing filed under a
 			// company would clear itself as that company's site
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(new Set())
 		})
 
 		it('should pass over a row with no name to judge the domain against', () => {
@@ -1367,7 +1367,7 @@ describe('hostsEstablishedAsOwn', () => {
 
 			// WHEN the owned hosts are worked out — THEN nothing is established, which
 			// is the answer rather than a missing one
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(new Set())
 		})
 
 		it('should pass over a row whose name is empty', () => {
@@ -1376,7 +1376,7 @@ describe('hostsEstablishedAsOwn', () => {
 
 			// WHEN the owned hosts are worked out — THEN a blank spells no domain, so
 			// the site is left standing for nobody
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(new Set())
 		})
 
 		it('should pass over a row whose website is not an address', () => {
@@ -1389,7 +1389,7 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN there is no domain to read
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(new Set())
 		})
 
 		it('should pass over list entries that are not rows', () => {
@@ -1401,7 +1401,7 @@ describe('hostsEstablishedAsOwn', () => {
 			]
 
 			// WHEN the owned hosts are worked out — THEN only the real row is read
-			expect(hostsEstablishedAsOwn(rows, noTrades)).toEqual(
+			expect(hostsEstablishedAsOwn(rows, noRunWords)).toEqual(
 				new Set(['sice.com']),
 			)
 		})
@@ -1409,7 +1409,7 @@ describe('hostsEstablishedAsOwn', () => {
 		it('should find nothing in an empty list', () => {
 			// GIVEN nothing to read
 			// WHEN the owned hosts are worked out — THEN there are none
-			expect(hostsEstablishedAsOwn([], noTrades)).toEqual(new Set())
+			expect(hostsEstablishedAsOwn([], noRunWords)).toEqual(new Set())
 		})
 	})
 })

--- a/packages/research/src/application/prospect-dedupe-guard.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.ts
@@ -104,8 +104,8 @@ import {
 import { isPlainObject } from './guard-shapes'
 import { ownSiteVerdict } from './own-site'
 import { rowGroups } from './row-groups'
+import type { RunWords } from './run-words'
 import { hostOf, isBareWebAddress } from './source-key'
-import type { TradeWords } from './trade-words'
 
 // What marks a key as filing a row under its site. Written once, because a caller
 // asking which key joined two rows reads the same mark this writes.
@@ -153,14 +153,14 @@ const withoutTrailingNote = (name: string): string =>
  * only the absence of a reason to say they are the same one, and the names still
  * have their say.
  *
- * `tradeWords` are the trades the run went looking for, handed down so this reads
+ * `runWords` are the trades the run went looking for, handed down so this reads
  * an address exactly as the rest of the run reads it. Without them two firms named
  * after one trade would both own that trade's bare domain, and the key that folds
  * rows by site would make them one company.
  */
 export const hostsEstablishedAsOwn = (
 	rows: ReadonlyArray<unknown>,
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): ReadonlySet<string> => {
 	const hosts = new Set<string>()
 	for (const row of rows) {
@@ -184,7 +184,7 @@ export const hostsEstablishedAsOwn = (
 			ownSiteVerdict({
 				name: withoutTrailingNote(name),
 				website,
-				tradeWords,
+				runWords,
 			}) === 'established'
 		)
 			hosts.add(host)
@@ -530,7 +530,7 @@ export interface DedupeResult {
 export const dedupeDiscoveryRows = (
 	findings: unknown,
 	listField: string | undefined,
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): DedupeResult => {
 	if (listField === undefined) return { findings, merged: 0 }
 
@@ -545,7 +545,7 @@ export const dedupeDiscoveryRows = (
 		// depend on the order.
 		const { groupOf: companyOf, join: sameCompany } = rowGroups(rows.length)
 
-		const ownSiteHosts = hostsEstablishedAsOwn(rows, tradeWords)
+		const ownSiteHosts = hostsEstablishedAsOwn(rows, runWords)
 		const rowOfKey = new Map<string, number>()
 		rows.forEach((row, at) => {
 			if (!isPlainObject(row)) return

--- a/packages/research/src/application/request-parts.test.ts
+++ b/packages/research/src/application/request-parts.test.ts
@@ -4,10 +4,12 @@ import {
 	coveragePassVerdict,
 	coverRequestParts,
 	MAX_COVERAGE_PASSES,
+	MAX_KINDS_OF_COMPANY,
 	MAX_PART_TERMS,
 	MAX_REQUEST_PARTS,
 	MAX_WORDING_CHARS,
 	type RequestPart,
+	readKindsOfCompany,
 	readRequestParts,
 	requestPartsDirective,
 	requestPartsPrompt,
@@ -277,6 +279,80 @@ describe('readRequestParts', () => {
 // What a run that never went back out for anything hands in. The cases below
 // turn on which rows place which part, not on what was searched for.
 const NOTHING_SEARCHED: ReadonlySet<string> = new Set()
+
+describe('readKindsOfCompany', () => {
+	describe('when the splitter answers with words for a kind of company', () => {
+		it('should keep them as written', () => {
+			// GIVEN a Catalan market's words for what a company calls itself
+			// WHEN read — THEN kept, and it is these that tell "Grup Puig" is a firm
+			// called Puig rather than a firm called Grup
+			expect(
+				readKindsOfCompany({ kindsOfCompany: ['grup', 'serveis', 'societat'] }),
+			).toEqual(['grup', 'serveis', 'societat'])
+		})
+
+		it('should keep one of a word the splitter listed twice', () => {
+			// GIVEN the same word back in two spellings of the same letters
+			// WHEN read — THEN once, since a word repeated says nothing twice
+			expect(
+				readKindsOfCompany({ kindsOfCompany: ['Grupo', 'grupo', 'servicios'] }),
+			).toEqual(['Grupo', 'servicios'])
+		})
+
+		it('should drop a word too short to spend on a name', () => {
+			// GIVEN a two- and a three-letter word among the real ones
+			// WHEN read
+			// THEN only the words long enough to be words. These are spent saying a
+			// name's word identifies nobody, and a short one reaches far more names
+			// than it was meant to — "sa" would take the front off half a French list
+			expect(
+				readKindsOfCompany({ kindsOfCompany: ['sa', 'cie', 'groupe'] }),
+			).toEqual(['groupe'])
+		})
+
+		it('should keep no more than a language actually uses', () => {
+			// GIVEN a splitter listing every word it can think of
+			// WHEN read — THEN cut, because past this it is reaching beyond what the
+			// language uses and each word takes a real name away from somebody
+			expect(
+				readKindsOfCompany({
+					kindsOfCompany: Array.from(
+						{ length: MAX_KINDS_OF_COMPANY + 6 },
+						(_, at) => `kindword${at}`,
+					),
+				}).length,
+			).toBe(MAX_KINDS_OF_COMPANY)
+		})
+	})
+
+	describe('when the answer carries no words for a kind of company', () => {
+		it('should come back empty rather than refusing the answer', () => {
+			// GIVEN answers with the list missing, wrongly shaped, or not an answer
+			// WHEN each is read
+			// THEN empty every time. A run that cannot read them still has its trades
+			// and the shared list, which is a worse reading rather than no run at all
+			for (const raw of [
+				{ parts: [] },
+				{ kindsOfCompany: 'grupo' },
+				{ kindsOfCompany: null },
+				null,
+				'grupo',
+			]) {
+				expect(readKindsOfCompany(raw)).toEqual([])
+			}
+		})
+
+		it('should drop an entry that is not a word', () => {
+			// GIVEN a list carrying blanks and things that are not words at all
+			// WHEN read — THEN only what a name could actually be written with
+			expect(
+				readKindsOfCompany({
+					kindsOfCompany: ['grupo', '', '   ', 42, null, '...', 'servicios'],
+				}),
+			).toEqual(['grupo', 'servicios'])
+		})
+	})
+})
 
 describe('coverRequestParts', () => {
 	describe('when the request named too few parts to work through', () => {

--- a/packages/research/src/application/request-parts.ts
+++ b/packages/research/src/application/request-parts.ts
@@ -81,6 +81,28 @@ export const MAX_REQUEST_PARTS = 12
 export const MAX_PART_TERMS = 12
 
 /**
+ * How many words for a KIND of company are kept. A language has a handful — group,
+ * holding, services, and the local words beside them. A list longer than this is a
+ * model reaching past what its language actually uses, and every word on it takes a
+ * real word away from the firms genuinely called it.
+ */
+export const MAX_KINDS_OF_COMPANY = 16
+
+/**
+ * Shortest a word for a kind of company may be, counted in the letters a web address
+ * carries. These words are spent saying a name word identifies nobody, and a two- or
+ * three-letter one strips far more names than it was meant to — "sa" would take the
+ * front off half a French list. Set where a word is long enough to be a word rather
+ * than an initial.
+ *
+ * It is a floor on LETTERS, which is the only thing the fold these words are read
+ * against keeps ("集团" is a whole word in two characters). That costs nothing today,
+ * because a name written in those characters folds to nothing and no reading here
+ * reaches it either way — see `entity-guard.ts`.
+ */
+export const SHORTEST_KIND_OF_COMPANY = 4
+
+/**
  * Longest a wording may be. A trade is named in a few words; anything past this is
  * a paragraph where a name was asked for. It matters because these words go into
  * every searching pass's prompt — an unbounded one would fill the prompt on its own
@@ -145,6 +167,7 @@ export const RequestPartsSchema = Schema.Struct({
 			terms: Schema.Array(Schema.String),
 		}),
 	),
+	kindsOfCompany: Schema.Array(Schema.String),
 })
 
 /**
@@ -166,7 +189,11 @@ export const requestPartsPrompt = (query: string): string =>
 		'- terms: other wordings that would place a company in this part — the ordinary word for the trade, and for someone who does it — in the language of the request, in the language of the country it is about, and in English. Between 3 and 10 of them. A wording that would fit a company in another part just as well belongs to neither: leave it out.',
 		'',
 		'Return the parts in the order the request names them.',
-		'Return {"parts": [{"label": "...", "terms": ["...", "..."]}]} and nothing else.',
+		'',
+		'Separately, list the words a COMPANY NAME uses to say what kind of company it is rather than which company it is — group, holding, services, associates and the like. Give them in the language of the request, in the language of the country it is about, and in English, in the plural and singular forms a name actually writes. "Grup Puig" is a firm called Puig, so "grup" belongs on this list; "Puig" never does.',
+		'These are words for a KIND of company, never for a trade and never for a place: plumbing, lifts, Barcelona and France are all wrong here. A family name, a coined name or a brand is wrong here too, and putting one on this list takes its own name away from every firm called it — so leave out anything you are not sure of. Between 4 and 12 words. Return an empty list rather than guessing at a language you cannot place.',
+		'',
+		'Return {"parts": [{"label": "...", "terms": ["...", "..."]}], "kindsOfCompany": ["...", "..."]} and nothing else.',
 		'',
 		`Request:\n${query}`,
 	].join('\n')
@@ -250,6 +277,45 @@ export const readRequestParts = (raw: unknown): ReadonlyArray<RequestPart> => {
 	}
 
 	return dropSharedWordings(parts)
+}
+
+/**
+ * The words the run was told name a KIND of company, read off the same answer the
+ * parts come from.
+ *
+ * Read apart from the parts because a part is something the run goes looking for and
+ * these are not: nothing searches for "group". They are spent on one thing, telling
+ * a company's own word from the word saying what sort of thing it is, so a request
+ * that came back without them leaves that reading exactly as the shared list had it.
+ *
+ * Short words are dropped rather than trusted. These are spent saying a name's word
+ * identifies nobody, so a wrong one costs a real firm its own name — and the shorter
+ * the word, the more names it reaches. A wrong one can only ever withhold, never
+ * reach a name: `run-words.ts` keeps these out of the reading that cuts the front off
+ * a domain, because they come from a model reading a language rather than from
+ * anything the person who asked actually wrote.
+ *
+ * A word in a writing system the fold has no letters for is dropped with them, and
+ * silently, because nothing downstream could have used it: a name in that writing
+ * folds to nothing too, so there would be nothing for the word to be read against.
+ */
+export const readKindsOfCompany = (raw: unknown): ReadonlyArray<string> => {
+	if (raw === null || typeof raw !== 'object') return []
+	const listed = (raw as { kindsOfCompany?: unknown }).kindsOfCompany
+	if (!Array.isArray(listed)) return []
+
+	const kinds: Array<string> = []
+	const seen = new Set<string>()
+	for (const entry of listed) {
+		if (kinds.length >= MAX_KINDS_OF_COMPANY) break
+		const word = readWording(entry)
+		if (word === null || word.length < SHORTEST_KIND_OF_COMPANY) continue
+		const key = foldLabel(word)
+		if (seen.has(key)) continue
+		seen.add(key)
+		kinds.push(word)
+	}
+	return kinds
 }
 
 /**

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -156,6 +156,7 @@ import {
 	type RequestCoverage,
 	type RequestPart,
 	RequestPartsSchema,
+	readKindsOfCompany,
 	readRequestParts,
 	requestPartsDirective,
 	requestPartsPrompt,
@@ -163,6 +164,7 @@ import {
 	uncoveredPartsDirective,
 } from './request-parts'
 import { computeRunQuality } from './research-quality'
+import { type RunWords, runWordsOf } from './run-words'
 import { guardScalarFields } from './scalar-field-guard'
 import {
 	type FreeformSchema,
@@ -190,7 +192,6 @@ import {
 	researchToolkit,
 	researchToolkitLayer,
 } from './tools'
-import { type TradeWords, tradeWordsOf } from './trade-words'
 import { clearFieldOnlyDoubt } from './unconfirmed-mark-guard'
 import { makeUsageMeter, UsageMeter } from './usage-meter'
 import { verifyValueProvenance } from './value-guard'
@@ -2731,12 +2732,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					let requestParts: ReadonlyArray<RequestPart> = []
 					// The words those parts use for the trades, which is how every check
 					// that weighs an address against a name tells the trade in the name
-					// from the company (`trade-words.ts`). Held beside the parts so the two
+					// from the company (`run-words.ts`). Held beside the parts so the two
 					// cannot say different things, and empty wherever they are — a run
 					// about one company on file names no trades, and so does a resume that
 					// skipped the phase they are split in. Both then read a name with only
 					// the shared list behind them.
-					let runTradeWords: TradeWords = new Set()
+					let wordsTheRunBrings: RunWords = runWordsOf([])
 					// Which of those parts a pass actually went back out for. Carried
 					// alongside the list because the rows cannot say whether the run
 					// looked: a part answered by phase 1's reading can be empty in
@@ -2892,14 +2893,14 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								findings: answer,
 								listField: discoveryResultField(schemaName),
 								addresses: [...gatheredAddresses],
-								tradeWords: runTradeWords,
+								runWords: wordsTheRunBrings,
 							})
 							const check = guardCompanyWebsites({
 								findings: answer,
 								targetName,
 								directorySites: directories.sites,
 								priorClaims: websiteClaims,
-								tradeWords: runTradeWords,
+								runWords: wordsTheRunBrings,
 							})
 							websiteClaims = check.hostClaims
 							const blanked =
@@ -3771,7 +3772,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											const check = dedupeDiscoveryRows(
 												findings,
 												discoveryResultField(schemaName),
-												runTradeWords,
+												wordsTheRunBrings,
 											)
 											if (check.merged > 0) {
 												yield* Effect.logInfo(
@@ -4170,13 +4171,21 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// search that refused to start because the split came back badly
 							// would be a worse run than one that searches without it.
 							if (isDiscoveryScan(schemaName)) {
-								requestParts = yield* extractLlm
+								// One answer, two things read off it: the parts the run works
+								// through, and the words that say what KIND of company a name is
+								// naming. The second is asked here because this is the one place a
+								// run reads its own request, and a request written in a market's
+								// language is what says which language those words are in.
+								const split = yield* extractLlm
 									.generateObject({
 										schema: RequestPartsSchema,
 										prompt: requestPartsPrompt(query),
 									})
 									.pipe(
-										Effect.map(response => readRequestParts(response.value)),
+										Effect.map(response => ({
+											parts: readRequestParts(response.value),
+											kinds: readKindsOfCompany(response.value),
+										})),
 										Effect.catchCause(cause =>
 											Cause.hasInterruptsOnly(cause)
 												? Effect.failCause(cause)
@@ -4188,12 +4197,21 @@ export class ResearchService extends Context.Service<ResearchService>()(
 															research_id: researchId,
 															cause: Cause.pretty(cause),
 														}),
-														Effect.as([] as ReadonlyArray<RequestPart>),
+														Effect.as({
+															parts: [] as ReadonlyArray<RequestPart>,
+															kinds: [] as ReadonlyArray<string>,
+														}),
 													),
 										),
 									)
-								runTradeWords = tradeWordsOf(
-									requestParts.flatMap(part => [part.label, ...part.terms]),
+								requestParts = split.parts
+								// Both answer the one question every reading asks of a word — does
+								// it identify anybody — so both go into one vocabulary. They are
+								// handed over apart because only the request's own wordings are
+								// trusted to come off the front of a domain: see `RunWords`.
+								wordsTheRunBrings = runWordsOf(
+									split.parts.flatMap(part => [part.label, ...part.terms]),
+									split.kinds,
 								)
 								if (requestParts.length > 0) {
 									yield* Effect.logInfo('research.request_parts').pipe(
@@ -5518,7 +5536,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								findings,
 								refreshed.findings,
 								schemaName,
-								runTradeWords,
+								wordsTheRunBrings,
 							)
 							findings = merged.findings
 							// Nothing has judged this list yet: every extraction was judged on
@@ -5629,7 +5647,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									findings,
 									listField: verificationListField,
 									addresses: [...gatheredAddresses],
-									tradeWords: runTradeWords,
+									runWords: wordsTheRunBrings,
 								}).sites
 							// What each row has to stand on, beyond its own citations.
 							const foundSources: Array<Array<string>> = verificationRows.map(
@@ -5650,7 +5668,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									website: rowWebsite(row),
 									sources: rowCitedSourceIds(row),
 									directorySites: watchedBefore,
-									tradeWords: runTradeWords,
+									runWords: wordsTheRunBrings,
 								}).verdict === 'confirmed'
 									? []
 									: [at],
@@ -5811,7 +5829,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											...(foundSources[at] ?? []),
 										],
 										directorySites: watchedAfter,
-										tradeWords: runTradeWords,
+										runWords: wordsTheRunBrings,
 									})
 									const unchecked = notChecked[at]
 									// The count stays even when the run never got to the row: how

--- a/packages/research/src/application/run-words.test.ts
+++ b/packages/research/src/application/run-words.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { namesATrade, tradeWordsOf, wasAskedForExactly } from './trade-words'
+import { namesNobody, runWordsOf, runWroteExactly } from './run-words'
 
 // The trades a Spanish installations request asks for, written the way the
 // request itself writes them.
-const INSTALLATIONS = tradeWordsOf([
+const INSTALLATIONS = runWordsOf([
 	'instalación eléctrica',
 	'fontanería',
 	'ascensor',
@@ -12,14 +12,14 @@ const INSTALLATIONS = tradeWordsOf([
 	'gas',
 ])
 
-describe('tradeWordsOf', () => {
+describe('runWordsOf', () => {
 	describe('when a request names its trades', () => {
 		it('should read a wording as the separate words it is made of', () => {
 			// GIVEN a trade written as a phrase
 			// WHEN read
 			// THEN each word of it stands on its own, since a company writes one of
 			// them into its name without the rest
-			expect([...tradeWordsOf(['instalación eléctrica'])]).toEqual([
+			expect([...runWordsOf(['instalación eléctrica']).words]).toEqual([
 				'instalacion',
 				'electrica',
 			])
@@ -30,7 +30,7 @@ describe('tradeWordsOf', () => {
 			// WHEN read
 			// THEN one word comes back, so a request and a company's name meet in one
 			// spelling rather than missing each other over an accent
-			expect([...tradeWordsOf(['Fontanería', 'FONTANERIA'])]).toEqual([
+			expect([...runWordsOf(['Fontanería', 'FONTANERIA']).words]).toEqual([
 				'fontaneria',
 			])
 		})
@@ -41,7 +41,7 @@ describe('tradeWordsOf', () => {
 			// THEN both spellings come back. A company's name is read both ways too,
 			// and a request matched against only one of them leaves the other
 			// spelling looking like a word of the company's own
-			expect([...tradeWordsOf(['instal·lacions'])]).toEqual([
+			expect([...runWordsOf(['instal·lacions']).words]).toEqual([
 				'installacions',
 				'instalacions',
 			])
@@ -51,7 +51,7 @@ describe('tradeWordsOf', () => {
 			// GIVEN the spelling a database that could not write the middle dot fell
 			// back on
 			// WHEN read — THEN it is the same two words
-			expect([...tradeWordsOf(['instal.lacions'])]).toEqual([
+			expect([...runWordsOf(['instal.lacions']).words]).toEqual([
 				'installacions',
 				'instalacions',
 			])
@@ -62,7 +62,7 @@ describe('tradeWordsOf', () => {
 		it('should name no trades for a request that asked for none', () => {
 			// GIVEN a run about one company on file, which names no trades
 			// WHEN read — THEN nothing, so every word of a name reads as its own
-			expect([...tradeWordsOf([])]).toEqual([])
+			expect([...runWordsOf([]).words]).toEqual([])
 		})
 
 		it('should name no trades for a wording holding no letters', () => {
@@ -70,17 +70,17 @@ describe('tradeWordsOf', () => {
 			// WHEN read
 			// THEN nothing comes back — an empty word would otherwise be a word every
 			// name is made of
-			expect([...tradeWordsOf(['', '   ', '—', '·'])]).toEqual([])
+			expect([...runWordsOf(['', '   ', '—', '·']).words]).toEqual([])
 		})
 	})
 })
 
-describe('namesATrade', () => {
+describe('namesNobody', () => {
 	describe('when the request wrote the word', () => {
 		it('should read a word the request wrote as the trade', () => {
 			// GIVEN a company word that is exactly what the request asked for
 			// WHEN asked — THEN it says what the company does, not who it is
-			expect(namesATrade('fontaneria', INSTALLATIONS)).toBe(true)
+			expect(namesNobody('fontaneria', INSTALLATIONS)).toBe(true)
 		})
 
 		it('should reach the word with an ending on it', () => {
@@ -88,8 +88,8 @@ describe('namesATrade', () => {
 			// WHEN asked
 			// THEN the ending is read past, because Spanish, Catalan and French put
 			// one on every word of a phrase and no request writes them all out
-			expect(namesATrade('ascensores', INSTALLATIONS)).toBe(true)
-			expect(namesATrade('solares', INSTALLATIONS)).toBe(true)
+			expect(namesNobody('ascensores', INSTALLATIONS)).toBe(true)
+			expect(namesNobody('solares', INSTALLATIONS)).toBe(true)
 		})
 
 		it("should reach two letters past the request's word and no further", () => {
@@ -98,8 +98,8 @@ describe('namesATrade', () => {
 			// WHEN each is asked
 			// THEN only the first is an ending. Past that a firm has coined a name of
 			// its own that happens to open the same way
-			expect(namesATrade('solares', INSTALLATIONS)).toBe(true)
-			expect(namesATrade('solarock', INSTALLATIONS)).toBe(false)
+			expect(namesNobody('solares', INSTALLATIONS)).toBe(true)
+			expect(namesNobody('solarock', INSTALLATIONS)).toBe(false)
 		})
 
 		it('should leave a coined name that merely opens with a trade word', () => {
@@ -107,8 +107,8 @@ describe('namesATrade', () => {
 			// WHEN each is asked
 			// THEN neither is the trade. Reading them as one would leave those firms
 			// with no word of their own at all, and no domain able to spell them
-			expect(namesATrade('solarock', INSTALLATIONS)).toBe(false)
-			expect(namesATrade('solartec', INSTALLATIONS)).toBe(false)
+			expect(namesNobody('solarock', INSTALLATIONS)).toBe(false)
+			expect(namesNobody('solartec', INSTALLATIONS)).toBe(false)
 		})
 	})
 
@@ -116,7 +116,7 @@ describe('namesATrade', () => {
 		it('should spell a short word whole', () => {
 			// GIVEN a three-letter trade the request asked for
 			// WHEN the word itself is asked — THEN it is the trade
-			expect(namesATrade('gas', INSTALLATIONS)).toBe(true)
+			expect(namesNobody('gas', INSTALLATIONS)).toBe(true)
 		})
 
 		it('should not read a short word as the opening of a longer one', () => {
@@ -124,7 +124,7 @@ describe('namesATrade', () => {
 			// WHEN asked
 			// THEN it is not the trade: three letters open far too many unrelated
 			// words to be read as an opening
-			expect(namesATrade('gasol', INSTALLATIONS)).toBe(false)
+			expect(namesNobody('gasol', INSTALLATIONS)).toBe(false)
 		})
 	})
 
@@ -133,39 +133,39 @@ describe('namesATrade', () => {
 			// GIVEN a run that named no trades
 			// WHEN any word is asked — THEN nothing is a trade, so every word of a
 			// name is left standing as the company's own
-			expect(namesATrade('fontaneria', tradeWordsOf([]))).toBe(false)
+			expect(namesNobody('fontaneria', runWordsOf([]))).toBe(false)
 		})
 
 		it('should name no trade for a word with nothing in it', () => {
 			// GIVEN an empty word
 			// WHEN asked — THEN no, so an empty run of letters cannot be read as
 			// every trade at once
-			expect(namesATrade('', INSTALLATIONS)).toBe(false)
+			expect(namesNobody('', INSTALLATIONS)).toBe(false)
 		})
 
 		it('should not read a word shorter than the trade as that trade', () => {
 			// GIVEN the opening of a trade word rather than the word
 			// WHEN asked — THEN no: the request's word has to be spelled, not started
-			expect(namesATrade('fon', INSTALLATIONS)).toBe(false)
+			expect(namesNobody('fon', INSTALLATIONS)).toBe(false)
 		})
 	})
 })
 
-describe('wasAskedForExactly', () => {
+describe('runWroteExactly', () => {
 	describe('when a run of letters might be a word', () => {
 		it('should say yes only to the word the request wrote', () => {
 			// GIVEN the trade exactly as the request wrote it
 			// WHEN asked — THEN yes
-			expect(wasAskedForExactly('fontaneria', INSTALLATIONS)).toBe(true)
+			expect(runWroteExactly('fontaneria', INSTALLATIONS)).toBe(true)
 		})
 
 		it('should refuse the same word with an ending on it', () => {
-			// GIVEN the trade with an ending, which `namesATrade` does read
+			// GIVEN the trade with an ending, which `namesNobody` does read
 			// WHEN asked here — THEN no. This is asked of the front of a domain,
 			// where nothing says where the first word ends, so an ending offered
 			// here is really the first letters of the name behind it
-			expect(namesATrade('ascensores', INSTALLATIONS)).toBe(true)
-			expect(wasAskedForExactly('ascensores', INSTALLATIONS)).toBe(false)
+			expect(namesNobody('ascensores', INSTALLATIONS)).toBe(true)
+			expect(runWroteExactly('ascensores', INSTALLATIONS)).toBe(false)
 		})
 
 		it("should refuse the trade with the next word's first letter stuck to it", () => {
@@ -174,7 +174,33 @@ describe('wasAskedForExactly', () => {
 			// WHEN asked
 			// THEN no — reading it as the trade would cut fontaneriagarcia.es one
 			// letter too deep and never find García underneath
-			expect(wasAskedForExactly('fontaneriag', INSTALLATIONS)).toBe(false)
+			expect(runWroteExactly('fontaneriag', INSTALLATIONS)).toBe(false)
+		})
+	})
+})
+
+describe('the words a run brings and the ones it was asked for', () => {
+	describe('when a run brings words for a kind of company beside its trades', () => {
+		it('should read both as identifying nobody', () => {
+			// GIVEN a run whose request named a trade and whose splitter gave the
+			// market's words for a kind of company
+			// WHEN each is asked
+			// THEN both identify nobody, because the two answer the same question
+			const words = runWordsOf(['fontanería'], ['grup', 'serveis'])
+			expect(namesNobody('fontaneria', words)).toBe(true)
+			expect(namesNobody('grup', words)).toBe(true)
+			expect(namesNobody('puig', words)).toBe(false)
+		})
+
+		it('should let only the words the request wrote come off a domain', () => {
+			// GIVEN the same run
+			// WHEN asked which words a domain may be cut at
+			// THEN only the ones the request itself wrote. The rest come from a
+			// model reading a language rather than from anything a person typed, so
+			// they are spent on withholding and never on reaching a name
+			const words = runWordsOf(['fontanería'], ['grup', 'serveis'])
+			expect(runWroteExactly('fontaneria', words)).toBe(true)
+			expect(runWroteExactly('grup', words)).toBe(false)
 		})
 	})
 })

--- a/packages/research/src/application/run-words.ts
+++ b/packages/research/src/application/run-words.ts
@@ -1,27 +1,37 @@
 /**
- * The words a run's own request uses for the trades it asked about, so a check
- * reading a company's name can tell the trade in it from the company.
+ * The words a run brings for what a company's name SAYS about it rather than
+ * which company it is, so a check reading a name can tell those words from the
+ * company.
  *
- * "Fontanería García" is a plumber called García. A check that cannot see which
- * of those two words is the trade treats both as the company's own, and then
- * fontaneria.es — which belongs to whoever registered it, not to every plumber in
- * Spain — reads as this firm's own site.
+ * Two kinds, and a name usually carries one of each. "Fontanería García" is a
+ * plumber called García; "Grup Puig" is a firm called Puig. A check that cannot
+ * see which of the two words is the company treats both as its own, and then
+ * fontaneria.es and grup.cat — which belong to whoever registered them, not to
+ * every plumber in Spain or every Catalan firm called Grup something — read as
+ * these firms' own sites.
  *
  * ## Why the words are not written down anywhere
  *
- * A list of words that identify nobody can only hold the trades somebody thought
- * of, so it carries one industry's vocabulary and treats every other industry's
- * as a company's own name. Filling it in is not a matter of finishing the job: it
- * needs every trade in every language a market answers in, and each word added
+ * A list of words that identify nobody can only hold what somebody thought of, so
+ * it carries one industry's vocabulary and one or two languages, and treats every
+ * other industry's and every other language's as a company's own name. Filling it
+ * in is not a matter of finishing the job: it needs every trade and every word for
+ * a kind of company in every language a market answers in, and each word added
  * takes a real distinctive word away from the firms genuinely called that.
  *
- * A run does not need the list, because it already knows: it was launched for a
- * market and the request names the trades it wants. Those words are that market's
- * own vocabulary, in the languages that market answers in, written by the person
- * who asked — and nothing has to be kept up to date for a trade nobody has
- * searched for yet. `request-parts.ts` already splits a request into its trades
- * and `term-match.ts` already reads their wordings against a page; this reads the
- * same wordings against a name.
+ * A run does not need the list, because it already knows what market it was
+ * launched for. Its request names the trades it wants outright, and the language
+ * that request is written in says which language its companies name themselves in
+ * — so the same reading of the request that splits it into trades is asked for
+ * that language's words for a kind of company too (`request-parts.ts`). Both are
+ * that market's own vocabulary, and nothing has to be kept up to date for a trade
+ * or a language nobody has searched in yet.
+ *
+ * They are held as ONE set because every reading that asks who owns an address
+ * asks one question of a word — does it identify anybody — and a word for a kind
+ * of company answers it exactly as a trade does. Two sets would be two chances for
+ * two callers to answer from different words. `term-match.ts` already reads these
+ * wordings against a page; this reads them against a name.
  *
  * It is the reading `directory-sites.ts` takes for a different question — what a
  * site IS comes from watching what the run sees it do, never from a list of
@@ -66,8 +76,23 @@
 
 import { foldTokens, nameSpellings } from './entity-guard'
 
-/** The words a run's request used for the trades it asked about, folded to letters. */
-export type TradeWords = ReadonlySet<string>
+/**
+ * The words a run brings for what a name says rather than who it names, folded to
+ * letters.
+ *
+ * Two readings, because the two are not equally sure of themselves. `words` is
+ * everything the run brought. `asked` is only what the REQUEST itself wrote, which
+ * is the half a person typed rather than the half a model supplied from its own
+ * knowledge of a language — and that half alone is trusted to come off the front of
+ * a domain. A word wrongly called a kind of company can then only withhold, which
+ * this package is allowed to be wrong in; left in `asked` it would also cut
+ * garciaacme.es down to "acme" and hand a stranger's domain to every firm called
+ * Acme, which it is not.
+ */
+export interface RunWords {
+	readonly words: ReadonlySet<string>
+	readonly asked: ReadonlySet<string>
+}
 
 // Below this length a request's word has to spell a name's word exactly. Three or
 // four letters open far too many unrelated words — "gas" opens "gasol" — while a
@@ -81,8 +106,8 @@ const SHORTEST_WORD_READ_AS_AN_OPENING = 5
 const LONGEST_ENDING = 2
 
 /**
- * The trade words of a run, read off every wording its request used for the
- * trades it asked about.
+ * The words of a run, read off every wording its request used for the trades it
+ * asked about and every word it gave for a kind of company.
  *
  * Wordings rather than the parts they came in, because the two callers hold them
  * in different shapes: a run has the parts its request was split into, and the
@@ -99,34 +124,40 @@ const LONGEST_ENDING = 2
  * trade slips through under it. Folding it any other way here is also how two
  * checks start disagreeing about whether a piece of text spells a trade.
  */
-export const tradeWordsOf = (wordings: ReadonlyArray<string>): TradeWords =>
-	new Set(wordings.flatMap(nameSpellings).flatMap(foldTokens))
+export const runWordsOf = (
+	wordings: ReadonlyArray<string>,
+	kindsOfCompany: ReadonlyArray<string> = [],
+): RunWords => {
+	const fold = (given: ReadonlyArray<string>): Set<string> =>
+		new Set(given.flatMap(nameSpellings).flatMap(foldTokens))
+	const asked = fold(wordings)
+	return { words: new Set([...asked, ...fold(kindsOfCompany)]), asked }
+}
 
 /**
  * Whether the request wrote this word, exactly as it stands.
  *
  * What a caller asks when it is reading a run of letters that MIGHT be a word
  * rather than a word it already has — the front of a domain, where nothing says
- * where the first word ends. The ending `namesATrade` reads past must not be
+ * where the first word ends. The ending `namesNobody` reads past must not be
  * offered there: a request for "fontanería" would then also spell "fontaneriag",
  * the trade plus the first letter of the name after it, and a caller taking the
  * longest word a domain opens with would cut fontaneriagarcia.es one letter too
  * deep and never find García underneath.
  */
-export const wasAskedForExactly = (
-	word: string,
-	tradeWords: TradeWords,
-): boolean => tradeWords.has(word)
+export const runWroteExactly = (word: string, runWords: RunWords): boolean =>
+	runWords.asked.has(word)
 
 /**
- * Whether this word of a name says what the company does rather than who it is.
+ * Whether this word of a name says what the company does or what kind of thing it
+ * is, rather than who it is.
  *
  * The word arrives already folded and as a whole word, since every caller reads
  * it off a name that has been through the same fold.
  */
-export const namesATrade = (word: string, tradeWords: TradeWords): boolean => {
-	if (tradeWords.has(word)) return true
-	for (const asked of tradeWords) {
+export const namesNobody = (word: string, runWords: RunWords): boolean => {
+	if (runWords.words.has(word)) return true
+	for (const asked of runWords.words) {
 		if (
 			asked.length >= SHORTEST_WORD_READ_AS_AN_OPENING &&
 			word.startsWith(asked) &&

--- a/packages/research/src/application/website-guard.test.ts
+++ b/packages/research/src/application/website-guard.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { mergePerFieldSearch } from './per-field-search'
-import { tradeWordsOf } from './trade-words'
+import { runWordsOf } from './run-words'
 import { guardCompanyWebsites } from './website-guard'
 
 // A run that named no trades, which is a request about one company on file.
-const noTrades = tradeWordsOf([])
+const noRunWords = runWordsOf([])
 
 // A competitor/prospect entry: a name plus the website the model returned for it.
 const scan = (
@@ -64,7 +64,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked with the trades the run went looking for
 			const result = guardCompanyWebsites({
 				findings,
-				tradeWords: tradeWordsOf(['installations électriques']),
+				runWords: runWordsOf(['installations électriques']),
 			})
 
 			// THEN the website is kept — nothing here condemns it — but nothing
@@ -85,7 +85,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked — THEN its own site is established and counted
 			const result = guardCompanyWebsites({
 				findings,
-				tradeWords: tradeWordsOf(['fontanería']),
+				runWords: runWordsOf(['fontanería']),
 			})
 
 			expect(result.ownSiteEstablished).toBe(1)
@@ -105,7 +105,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				directorySites: new Set(['research.owler.com']),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the listing is removed, which the rules reading only this one
@@ -125,7 +125,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				directorySites: new Set(['aemiat.com']),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN it is kept: an unwatched host is unknown, and unknown is no reason
@@ -147,7 +147,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked with no observation to go on
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 
 			// THEN the address naming the company one level down is enough on its
 			// own, so losing the list of known directories costs this case nothing
@@ -170,7 +170,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is still caught, by the address shape alone
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.blankedDirectory).toBe(0)
@@ -190,7 +190,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it is caught. The address is put back into letters before the name is
 			// looked for, so the escaping does not hide the listing — and a run over a
 			// Spanish or Catalan market meets this spelling constantly
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 		})
@@ -207,7 +207,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the part is read as written rather than thrown away,
 			// so a path that was never valid escaping still gets judged
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 		})
@@ -226,7 +226,7 @@ describe('guardCompanyWebsites', () => {
 			// must not split it into two — read the other way round, the name would land
 			// in a "deeper" part that the address never had, and the company would lose
 			// its own page
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com/about%2Fxpo-logistics',
 			])
@@ -240,7 +240,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN a short name is no reason to let a listing through
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 		})
 	})
@@ -263,7 +263,7 @@ describe('guardCompanyWebsites', () => {
 			// direction for a guard whose job is spotting listings
 			expect(
 				websitesOf(
-					guardCompanyWebsites({ findings, tradeWords: noTrades }).findings,
+					guardCompanyWebsites({ findings, runWords: noRunWords }).findings,
 				),
 			).toEqual([undefined])
 		})
@@ -280,7 +280,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is left untouched
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://redwoodlogistics.com/about',
 			])
@@ -298,7 +298,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a first-segment mention is a company describing
 			// itself, not a directory filing it away
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com/about-xpo-logistics',
 			])
@@ -311,7 +311,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is kept: the name is in no deeper path segment
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://gopenske.com/logistics',
 			])
@@ -322,7 +322,7 @@ describe('guardCompanyWebsites', () => {
 			const findings = scan([{ name: 'DSV', website: 'https://dsv.com' }])
 
 			// WHEN checked — THEN nothing to file it away, so it stays
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual(['https://dsv.com'])
 		})
 
@@ -336,7 +336,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN the host naming the company is the deciding signal
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://acmelogistics.com/company/acme-logistics',
 			])
@@ -354,7 +354,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN the missing scheme does not hide the listing
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 		})
@@ -370,7 +370,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				directorySites: new Set(['owler.com']),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedDirectory).toBe(1)
@@ -384,7 +384,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN it goes: a website field nobody can open is worse
 			// than an empty one, because it reads as a real site downstream
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedNotAnAddress).toBe(1)
 		})
@@ -396,7 +396,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it cannot be judged, so it stays
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://some-directory.io/company/acme',
 			])
@@ -410,7 +410,7 @@ describe('guardCompanyWebsites', () => {
 			// address to establish anything about either, so neither ownership count
 			// moves: a row with no website is not a row whose website is unvouched for
 			// AND nothing is claimed, since a row with no address claims no host
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result).toEqual({
 				findings,
 				blankedNotAnAddress: 0,
@@ -430,14 +430,14 @@ describe('guardCompanyWebsites', () => {
 			// GIVEN non-object findings
 			// WHEN checked — THEN they pass straight through
 			expect(
-				guardCompanyWebsites({ findings: null, tradeWords: noTrades }).findings,
+				guardCompanyWebsites({ findings: null, runWords: noRunWords }).findings,
 			).toBeNull()
 			expect(
-				guardCompanyWebsites({ findings: 'text', tradeWords: noTrades })
+				guardCompanyWebsites({ findings: 'text', runWords: noRunWords })
 					.findings,
 			).toBe('text')
 			expect(
-				guardCompanyWebsites({ findings: [1, 2], tradeWords: noTrades })
+				guardCompanyWebsites({ findings: [1, 2], runWords: noRunWords })
 					.findings,
 			).toEqual([1, 2])
 		})
@@ -456,7 +456,7 @@ describe('guardCompanyWebsites', () => {
 			}
 
 			// WHEN checked — THEN the walk fires on the shape, not the schema name
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(
 				(result.findings as { prospects: Array<{ website?: string }> })
 					.prospects[0]?.website,
@@ -481,7 +481,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				directorySites: new Set(['crunchbase.com']),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the directory rule still fires, which is the whole point: it is the
@@ -510,7 +510,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'Redwood Logistics',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the name-in-a-deeper-path rule catches it
@@ -535,7 +535,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'Redwood Logistics',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the host carries the name, so it stands
@@ -564,7 +564,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'KBE Energy',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the same reading reaches the field that arrives alone: nothing in
@@ -591,7 +591,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'Groupe Dupont SA',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN it goes, and this is the price of the rule rather than a bug: the
@@ -620,7 +620,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'KBE Energy',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			expect(
 				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
@@ -643,7 +643,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'Redwood Logistics',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the pair rule wins for a named company, so the site is kept
@@ -671,7 +671,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN both go. The parser folds the trailing words into the path and hands
 			// back a clean host, so nothing that reads the host alone can catch this
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined, undefined])
 			expect(result.blankedNotAnAddress).toBe(2)
 		})
@@ -683,7 +683,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is one address and nothing else, so it stands
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://acme.es/quienes%20somos',
 			])
@@ -705,7 +705,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'Acme',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			expect(
 				(result.findings as { enrichment: Record<string, unknown> }).enrichment[
@@ -731,7 +731,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN all four go. The listing sits in the first path segment, which the
 			// deeper-path rule deliberately exempts — what settles it is that one host
 			// cannot be four different companies' own site
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				undefined,
 				undefined,
@@ -759,7 +759,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN every one stands: each host carries its own company's
 			// name, and no host is claimed by anybody else
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com/about-xpo-logistics',
 				'https://seur.com/sobre-seur',
@@ -782,7 +782,7 @@ describe('guardCompanyWebsites', () => {
 			// names, and blanking on the difference would blank that case too — so a
 			// host that belongs to somebody here takes this rule out of play, and what
 			// the two rows are to each other is settled by the de-duplication after it
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://acme.es',
 				'https://acme.es/rubio',
@@ -806,7 +806,7 @@ describe('guardCompanyWebsites', () => {
 			// this is one company met twice rather than a directory — and the shared
 			// site is the only thing that says the two rows are the same company, so
 			// blanking it would leave them as two
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://www.sice.com',
 				'https://sice.com/es',
@@ -827,7 +827,7 @@ describe('guardCompanyWebsites', () => {
 			// people use it by, so asking only whether the host carries a name whole
 			// would read a company's own domain as a stranger's and take it from both
 			// rows
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://xpo.com',
 				'https://xpo.com/es',
@@ -849,7 +849,7 @@ describe('guardCompanyWebsites', () => {
 			// company met twice — nothing about the address says otherwise, and reading
 			// the two writings as two firms would take a company's own site off both of
 			// its rows
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://www.securiteincendie.fr/',
 				'https://www.securiteincendie.fr/',
@@ -878,7 +878,7 @@ describe('guardCompanyWebsites', () => {
 			// host, and the two names share no word for the rule to read them as one
 			// company either — so the only thing left is that the site is somebody's
 			// and a blank would take it from them
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://www.sav-onduleur-photovoltaique.com',
 				'https://www.sav-onduleur-photovoltaique.com/',
@@ -896,7 +896,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN it stands: one row claiming a host is not evidence the host is
 			// somebody else's, and a blank costs a real website
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://aemiat.com/e-mora/',
 				'https://tejero.es',
@@ -916,7 +916,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the more exact diagnosis wins, so the counters keep
 			// telling apart a listing from a host several rows merely share
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined, undefined])
 			expect(result.blankedProfilePage).toBe(2)
 			expect(result.blankedSharedHost).toBe(0)
@@ -936,7 +936,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the proposal subtree is skipped when the claims are
 			// gathered too, so a person never costs a company its site
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(
 				(result.findings as { prospects: Array<{ website?: string }> })
 					.prospects[0]?.website,
@@ -954,7 +954,7 @@ describe('guardCompanyWebsites', () => {
 				findings: cited([
 					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
 				]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			const round = guardCompanyWebsites({
 				findings: cited([
@@ -962,20 +962,20 @@ describe('guardCompanyWebsites', () => {
 					{ name: 'Instalaciones Rubio', website: 'https://aemiat.com/rubio/' },
 				]),
 				priorClaims: held.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			const folded = mergePerFieldSearch(
 				held.findings,
 				round.findings,
 				'prospect_scan_v1',
-				noTrades,
+				noRunWords,
 			)
 
 			// WHEN the folded list is checked against everything the run has read
 			const judged = guardCompanyWebsites({
 				findings: folded.findings,
 				priorClaims: round.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN nobody keeps the trade body's host. The first answer had one
@@ -993,7 +993,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 
 			// THEN the claim it read comes back with it, filed under the host, so the
 			// next answer is weighed against a company that is not in it
@@ -1010,7 +1010,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 
 			// THEN both addresses go — AND both claims survive in what is handed back.
 			// Reading the answer it produced would find one claimant or none, so the
@@ -1028,7 +1028,7 @@ describe('guardCompanyWebsites', () => {
 			// is in, and under its legal name in a later answer
 			const first = guardCompanyWebsites({
 				findings: scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the later answer is checked against what the first one read
@@ -1040,7 +1040,7 @@ describe('guardCompanyWebsites', () => {
 					},
 				]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the address stands. Carrying the claims makes the two rows two
@@ -1061,14 +1061,14 @@ describe('guardCompanyWebsites', () => {
 						website: 'https://sice.com/es',
 					},
 				]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the answer holding the trade name is checked against it
 			const later = guardCompanyWebsites({
 				findings: scan([{ name: 'SICE', website: 'https://www.sice.com' }]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN it stands too: which answer named the host is not what settles it,
@@ -1082,14 +1082,14 @@ describe('guardCompanyWebsites', () => {
 			// answer, both on the domain that is the front of the first name
 			const first = guardCompanyWebsites({
 				findings: scan([{ name: 'XPO Logistics', website: 'https://xpo.com' }]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the later answer is checked against what the first read
 			const later = guardCompanyWebsites({
 				findings: scan([{ name: 'XPO Iberia', website: 'https://xpo.com/es' }]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN it stands. Carrying the claims is what puts two names on this host
@@ -1107,7 +1107,7 @@ describe('guardCompanyWebsites', () => {
 				findings: scan([
 					{ name: 'SIMIE', website: 'https://www.securiteincendie.fr/' },
 				]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the later answer is checked against what the first read
@@ -1116,7 +1116,7 @@ describe('guardCompanyWebsites', () => {
 					{ name: 'Groupe SIMIE', website: 'https://www.securiteincendie.fr/' },
 				]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN it stands. Carrying the claims is what brings the two writings
@@ -1135,7 +1135,7 @@ describe('guardCompanyWebsites', () => {
 				findings: scan([
 					{ name: 'Instal·lacions Puig', website: 'https://gremi.cat/puig/' },
 				]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the second answer is checked against what the first read
@@ -1144,7 +1144,7 @@ describe('guardCompanyWebsites', () => {
 					{ name: 'Instal.lacions Puig', website: 'https://gremi.cat/puig/' },
 				]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the address stands. A company is held under the one name it is
@@ -1159,7 +1159,7 @@ describe('guardCompanyWebsites', () => {
 			// company claims in a later answer
 			const first = guardCompanyWebsites({
 				findings: scan([{ name: 'SL', website: 'https://gremi.cat/anon/' }]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the later answer is checked against it
@@ -1168,7 +1168,7 @@ describe('guardCompanyWebsites', () => {
 					{ name: 'Electricidad Mora', website: 'https://gremi.cat/mora/' },
 				]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the address stands: a name nothing can be read from says nothing
@@ -1184,7 +1184,7 @@ describe('guardCompanyWebsites', () => {
 				findings: scan([
 					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
 				]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the later answer is checked against what the first read
@@ -1193,7 +1193,7 @@ describe('guardCompanyWebsites', () => {
 					{ name: 'Electricidad Mora', website: 'https://aemiat.com/e-mora/' },
 				]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN it stands. Carrying the claims counts companies, never readings, so
@@ -1221,7 +1221,7 @@ describe('guardCompanyWebsites', () => {
 						},
 					],
 				},
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN the later answer is checked against it
@@ -1230,7 +1230,7 @@ describe('guardCompanyWebsites', () => {
 					{ name: 'Acme Instal', website: 'https://gremi.cat/acme/' },
 				]),
 				priorClaims: first.hostClaims,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN the company keeps its address: the proposal subtree is skipped when
@@ -1255,12 +1255,12 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked with no earlier claims, either left out or handed in empty
 			const withoutPrior = guardCompanyWebsites({
 				findings,
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			const withEmptyPrior = guardCompanyWebsites({
 				findings,
 				priorClaims: new Map(),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// THEN both read the answer identically: with nothing carried in, an
@@ -1292,7 +1292,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 
 			// THEN the address goes: nothing in it names the company, and its own
 			// citation says only that the run read the page
@@ -1321,7 +1321,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN only the website key is dropped — the company and its evidence stay,
 			// because what was wrong was the address, not the company
 			expect(
-				guardCompanyWebsites({ findings, tradeWords: noTrades }).findings,
+				guardCompanyWebsites({ findings, runWords: noRunWords }).findings,
 			).toEqual({
 				prospects: [
 					{
@@ -1342,7 +1342,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the host carries the name, which settles it long
 			// before the page it was read from is asked about
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1360,7 +1360,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it stands. The host names nobody and the page is the one that was
 			// read, so what separates this from the listing above is the single thing
 			// this rule adds: the first segment spells the company out
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1375,7 +1375,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN one distinctive word inside the host is a mention,
 			// and a mention anywhere withholds the blank
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1395,7 +1395,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it stays. With no path there is no page to tell apart from the site,
 			// so the tell this rule reads is absent and what is left is the ordinary
 			// case — a run that read a home page and wrote the site down
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://annuaire.tecsol.fr',
 			])
@@ -1412,7 +1412,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the name is found through the escaping, so the page
 			// is read as naming the company and kept
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([own])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1429,7 +1429,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the same page cited repeatedly is still one page, and
 			// still the only thing that mentioned the company
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1448,7 +1448,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN it stands. This rule speaks only for a row whose whole evidence is
 			// the address itself; once something else has mentioned the company, what
 			// the address is stops being a question this rule can answer
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1461,7 +1461,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a row citing nothing says nothing either way, so
 			// there is no provenance to read and the address is left alone
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1481,7 +1481,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the two spellings are one page, so tidying the
 			// citation does not hide where the claim came from
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1497,7 +1497,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN a page is the same page whichever link led to it
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1516,7 +1516,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a matching path on a different site is a different
 			// page, so the website is not where the claim came from
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1535,7 +1535,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN nothing fires: an opaque id names no host, so it can neither match
 			// the address nor be mistaken for it. The rule reads a citation only when
 			// the model wrote it as the address it is
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1556,7 +1556,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN an entry naming no source has mentioned the company
 			// nowhere, so it neither counts as another source nor blocks the rule
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedReadPage).toBe(1)
 		})
@@ -1575,7 +1575,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN there is no citation to read, so the row is judged
 			// with nothing and its address stands
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.blankedReadPage).toBe(0)
 		})
@@ -1598,7 +1598,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN both go, counted under the rule that knows more about
 			// why: several rows claiming one host says it belongs to none of them
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined, undefined])
 			expect(result.blankedSharedHost).toBe(2)
 			expect(result.blankedReadPage).toBe(0)
@@ -1614,7 +1614,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the address shape is the more exact diagnosis and
 			// keeps the count
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.blankedReadPage).toBe(0)
@@ -1633,7 +1633,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN both are kept and the two are told apart anyway, which is the whole
 			// point: surviving the rules is not the same statement as owning the site
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([
 				'https://redwoodlogistics.com',
 				'https://annuaire.tecsol.fr',
@@ -1654,7 +1654,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked — THEN an address that is gone has no ownership left to
 			// establish, so it lands in neither column rather than swelling the
 			// unvouched-for one
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.ownSiteEstablished + result.ownSiteUnknown).toBe(0)
 		})
@@ -1674,7 +1674,7 @@ describe('guardCompanyWebsites', () => {
 			])
 
 			// WHEN checked — THEN it is kept, and unvouched for
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://annuaire.tecsol.fr',
 			])
@@ -1690,7 +1690,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN silence about where a claim came from is not a
 			// reason to call the address the company's
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1708,7 +1708,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a second source about the COMPANY says nothing about
 			// who owns the ADDRESS, so it buys the address no standing
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1723,7 +1723,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the coincidence buys nothing here, because a path
 			// names a page about the company rather than the company's site
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([listing])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1741,7 +1741,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN a citation nothing can be read off is not a
 			// clearance
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([TECSOL_LISTING])
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1764,7 +1764,7 @@ describe('guardCompanyWebsites', () => {
 					},
 				},
 				targetName: 'KBE Energy',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			const row = guardCompanyWebsites({
 				findings: cited([
@@ -1774,7 +1774,7 @@ describe('guardCompanyWebsites', () => {
 						sources: [website, 'https://www.lemoniteur.fr/kbe-energy'],
 					},
 				]),
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 
 			// WHEN both are checked
@@ -1806,7 +1806,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'Redwood Logistics',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			expect(result.ownSiteEstablished).toBe(1)
 			expect(result.ownSiteUnknown).toBe(0)
@@ -1826,7 +1826,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked with nothing to compare — THEN unknown, because there is no
 			// company for the domain to be the company's own site OF
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.ownSiteEstablished).toBe(0)
 			expect(result.ownSiteUnknown).toBe(1)
 		})
@@ -1849,7 +1849,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN the proposed-updates subtree is left untouched, so a
 			// person's website is never blanked as if it were a company's
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.findings).toEqual(findings)
 			expect(result.blankedDirectory + result.blankedProfilePage).toBe(0)
 		})
@@ -1872,7 +1872,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN the site stays and is established as the company's own. Read only
 			// the way the name is written, the host spelled nothing the run knew and
 			// the company lost the very page it published
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://ilusions.cat/contacte',
 			])
@@ -1892,7 +1892,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN it is kept too, so reading the name both ways costs
 			// the spelling that already worked nothing
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://illusions.cat/contacte',
 			])
@@ -1914,7 +1914,7 @@ describe('guardCompanyWebsites', () => {
 					findings: cited([
 						{ name: 'Il·lusions SL', website, sources: [website] },
 					]),
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				})
 				expect(prospectWebsites(result.findings)).toEqual([undefined])
 				expect(result.blankedProfilePage).toBe(1)
@@ -1936,7 +1936,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN nothing is blanked: the host is plainly the Catalan company's, and
 			// the reading that says so came from the row with the mark. Keeping only
 			// the later row's spellings would lose it and blank all four
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.blankedSharedHost).toBe(0)
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://ilusions.cat',
@@ -1959,7 +1959,7 @@ describe('guardCompanyWebsites', () => {
 			// as a shared host. Its two spellings must count as the one company they
 			// are — counted apart, a single company would look like a crowd and the
 			// rule would fire on a host it owns
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.blankedSharedHost).toBe(0)
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://ilusions.cat',
@@ -1990,7 +1990,7 @@ describe('guardCompanyWebsites', () => {
 				const result = guardCompanyWebsites({
 					findings,
 					targetName: 'Instal·lacions Vives SL',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				})
 				expect(
 					(result.findings as { enrichment: Record<string, unknown> })
@@ -2016,7 +2016,7 @@ describe('guardCompanyWebsites', () => {
 				const result = guardCompanyWebsites({
 					findings,
 					targetName: 'Instal·lacions Vives SL',
-					tradeWords: noTrades,
+					runWords: noRunWords,
 				})
 				expect(
 					(result.findings as { enrichment: Record<string, unknown> })
@@ -2041,7 +2041,7 @@ describe('guardCompanyWebsites', () => {
 			// own exact domain still reads as unestablished — there is no word of the
 			// company's for a domain to spell, so `unknown` here means the rules could
 			// never have said anything else, not that nothing vouched for it
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.namedNobodyInParticular).toBe(1)
 			expect(result.ownSiteEstablished).toBe(1)
 			expect(result.ownSiteUnknown).toBe(1)
@@ -2058,7 +2058,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN the website is kept, and the count stays at zero: a name that
 			// reads as nothing is a different miss from a name that reads as a trade,
 			// and adding the two together would hide both
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.namedNobodyInParticular).toBe(0)
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://directori.cat/empresa/algu',
@@ -2082,7 +2082,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN the address goes. The page really is the company's, and it is
 			// still not the company's website — whoever opens it lands on Facebook
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedSocialPage).toBe(1)
 		})
@@ -2098,7 +2098,7 @@ describe('guardCompanyWebsites', () => {
 
 			// WHEN checked — THEN blanked too. Which list a company arrived in says
 			// nothing about whose site the address is
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(websitesOf(result.findings)).toEqual([undefined])
 			expect(result.blankedSocialPage).toBe(1)
 		})
@@ -2116,7 +2116,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN blanked. An address a reader can open is an address that ships, so
 			// a spelling this check did not recognise would put the page back
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedSocialPage).toBe(1)
 		})
@@ -2137,7 +2137,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN blanked, whatever else the row cited. A row that cites a second
 			// page stands down the rule that reads citations, and the platform is the
 			// one reading that does not need them
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedSocialPage).toBe(1)
 		})
@@ -2154,7 +2154,7 @@ describe('guardCompanyWebsites', () => {
 				},
 			])
 
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedSocialPage).toBe(1)
 		})
@@ -2168,7 +2168,7 @@ describe('guardCompanyWebsites', () => {
 				{ name: 'LIPOTECH SARL', website: 'https://facebook.com' },
 			])
 
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedSocialPage).toBe(1)
 		})
@@ -2194,7 +2194,7 @@ describe('guardCompanyWebsites', () => {
 				},
 			])
 
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([
 				undefined,
 				undefined,
@@ -2222,7 +2222,7 @@ describe('guardCompanyWebsites', () => {
 				},
 			])
 
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined, undefined])
 			expect(result.blankedSocialPage).toBe(2)
 		})
@@ -2236,7 +2236,7 @@ describe('guardCompanyWebsites', () => {
 				{ name: 'SL', website: 'https://www.facebook.com/quelquun' },
 			])
 
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([undefined])
 			expect(result.blankedSocialPage).toBe(1)
 		})
@@ -2257,7 +2257,7 @@ describe('guardCompanyWebsites', () => {
 			const result = guardCompanyWebsites({
 				findings,
 				targetName: 'LIPOTECH SARL',
-				tradeWords: noTrades,
+				runWords: noRunWords,
 			})
 			expect(result.findings).toEqual({ website: null })
 			expect(result.blankedSocialPage).toBe(1)
@@ -2277,7 +2277,7 @@ describe('guardCompanyWebsites', () => {
 				{ name: 'Fusteria Miquel SL', website: 'https://fusteriamiquel.cat' },
 			])
 
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.ownSiteEstablished).toBe(1)
 			expect(result.ownSiteUnknown).toBe(0)
 		})
@@ -2304,7 +2304,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN each is counted under its own reason, so a reader of the run's
 			// numbers can tell how often a platform page was offered from how often a
 			// directory was
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(result.blankedSocialPage).toBe(1)
 			expect(result.blankedProfilePage).toBe(1)
 			expect(result.blankedNotAnAddress).toBe(1)
@@ -2333,7 +2333,7 @@ describe('guardCompanyWebsites', () => {
 			// THEN both are kept. A platform's name inside somebody else's domain is
 			// not the platform, and blanking these would cost two real companies the
 			// site they publish
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://facebook-ads-agency.com',
 				'https://instagram-marketing.es',
@@ -2355,7 +2355,7 @@ describe('guardCompanyWebsites', () => {
 			// WHEN checked
 			// THEN kept. What saves it is the host: a company's own domain is no
 			// platform
-			const result = guardCompanyWebsites({ findings, tradeWords: noTrades })
+			const result = guardCompanyWebsites({ findings, runWords: noRunWords })
 			expect(prospectWebsites(result.findings)).toEqual([
 				'https://xpo.com/about-xpo-logistics',
 			])

--- a/packages/research/src/application/website-guard.ts
+++ b/packages/research/src/application/website-guard.ts
@@ -61,9 +61,9 @@ import {
 } from './entity-guard'
 import { citedSourceIds, isPlainObject } from './guard-shapes'
 import { ownSiteHostVerdict, ownSiteVerdict } from './own-site'
+import type { RunWords } from './run-words'
 import { isSocialPlatformHost } from './social-sites'
 import { hostOf, isBareWebAddress, pathOf } from './source-key'
-import type { TradeWords } from './trade-words'
 
 const SKIP_KEYS = new Set(['citations', 'proposed_updates'])
 
@@ -302,7 +302,7 @@ const filesSeveralCompanies = (
 const hostBelongsTo = (
 	host: string,
 	claimantNames: ReadonlyArray<string>,
-	tradeWords: TradeWords,
+	runWords: RunWords,
 ): boolean =>
 	claimantNames.some(
 		name =>
@@ -310,7 +310,7 @@ const hostBelongsTo = (
 				spelling =>
 					spelling.length >= DISTINCTIVE_NAME_LENGTH &&
 					collapse(host).includes(spelling),
-			) || ownSiteHostVerdict({ name, host, tradeWords }) === 'established',
+			) || ownSiteHostVerdict({ name, host, runWords }) === 'established',
 	)
 
 type WebsiteVerdict =
@@ -329,16 +329,10 @@ const classifyWebsite = (args: {
 	readonly citedSources: ReadonlyArray<string>
 	readonly hostClaims: HostClaims
 	readonly directorySites: DirectorySites
-	readonly tradeWords: TradeWords
+	readonly runWords: RunWords
 }): WebsiteVerdict => {
-	const {
-		name,
-		website,
-		citedSources,
-		hostClaims,
-		directorySites,
-		tradeWords,
-	} = args
+	const { name, website, citedSources, hostClaims, directorySites, runWords } =
+		args
 	const host = hostOf(website)
 	// Not an address at all: a value with words written next to it ("https://acme.es
 	// (inferred from the name)"), or something that was never a URL. A website field
@@ -407,7 +401,7 @@ const classifyWebsite = (args: {
 		claimants !== undefined &&
 		filesSeveralCompanies(claimants) &&
 		![...claimants.values()].some(claimant =>
-			hostBelongsTo(host, claimant.names, tradeWords),
+			hostBelongsTo(host, claimant.names, runWords),
 		)
 	) {
 		return 'shared_host'
@@ -508,7 +502,7 @@ export interface WebsiteGuardResult {
  * claim that condemned it. Recorded claims can, because they are taken before
  * the blanking.
  *
- * `tradeWords` are the trades the run went looking for (`trade-words.ts`), which
+ * `runWords` are the trades the run went looking for (`run-words.ts`), which
  * is how the ownership reading tells the trade in a company's name from the
  * company. Asked for on every call rather than defaulted to none, unlike the
  * three above: leaving it out does not merely stand a rule down, it makes this
@@ -519,14 +513,14 @@ export const guardCompanyWebsites = (args: {
 	readonly targetName?: string | undefined
 	readonly directorySites?: DirectorySites | undefined
 	readonly priorClaims?: HostClaims | undefined
-	readonly tradeWords: TradeWords
+	readonly runWords: RunWords
 }): WebsiteGuardResult => {
 	const {
 		findings,
 		targetName,
 		directorySites = new Set<string>(),
 		priorClaims = new Map(),
-		tradeWords,
+		runWords,
 	} = args
 	let blankedNotAnAddress = 0
 	let blankedSocialPage = 0
@@ -553,7 +547,7 @@ export const guardCompanyWebsites = (args: {
 	// the answer beside their counts. Asked only of a website that is staying,
 	// since one already gone has no ownership left to establish.
 	const countOwnSite = (name: string, website: string): void => {
-		if (ownSiteVerdict({ name, website, tradeWords }) === 'established')
+		if (ownSiteVerdict({ name, website, runWords }) === 'established')
 			ownSiteEstablished++
 		else ownSiteUnknown++
 	}
@@ -602,7 +596,7 @@ export const guardCompanyWebsites = (args: {
 					typeof value['source_id'] === 'string' ? [value['source_id']] : [],
 				hostClaims,
 				directorySites,
-				tradeWords,
+				runWords,
 			})
 			if (verdict !== 'keep') {
 				count(verdict)
@@ -624,7 +618,7 @@ export const guardCompanyWebsites = (args: {
 				citedSources: citedSourceIds(value),
 				hostClaims,
 				directorySites,
-				tradeWords,
+				runWords,
 			})
 			if (verdict !== 'keep') {
 				count(verdict)


### PR DESCRIPTION
## What was wrong

A company named after its legal shape was identified BY that shape, so the bare domain of that word read as the firm's own site. `gruppe.de` was Müller Gruppe's, `grup.cat` was Grup Puig's, `grupa.pl` was Kowalski Grupa's — domains that belong to whoever registered them, not to every firm called Gruppe something.

That verdict is spent on four things: it is the only positive signal that a company exists, it exempts a host from the business-directory watch, it stops the website being blanked, and it becomes the key that folds two rows into one company. So two different firms both offered `grup.cat` were folded into one company and confirmed on a stranger's domain.

The list of words that "identify nobody" reads as English and Spanish and is neither — it is seventeen words somebody happened to think of. `Sociedad García` was at home on `sociedad.es` on `main` today, and so were Empresa, Corporación and Asociación something, in the market this is measured on. A list that misses the commonest company word in the language it supposedly covers is not a list with gaps; it is the wrong shape of answer.

## What I priced before choosing

`#527` replaced the trade half of that list by reading the trades from the run's own request. That has no obvious sibling here, because a request names trades and never says "group". I measured four replacements against 318 rows with a website from thirteen stored market searches, and three of them do not stand:

| replacement | closes | costs |
| --- | --- | --- |
| a published list of legal forms (ISO 20275 / GLEIF) | 3 of 11 | 6 real firms in 20 lose their own site |
| words many companies in one run share | 0 of 13 | ~17 real identities stripped |
| refusing a word whenever another could be the company | 13 of 13 | 26 of 238 real verdicts |
| **asking the run, plus where the word sits** | **13 of 13** | **nothing that was right** |

The legal-form authority actively says these are not legal forms: it carries `Gesellschaft` and not one of Gruppe, Grup, Groep, Grupa, Serveis, Servizi or Serviços. Ranked by how many differently-named companies carry them, a run's shared words are its trades and its places — `ascenseurs` nine, `france` six — while a kind-of-company word peaks at three, level with the surnames; there is no line with a gap in it, and most of what looks like sharing is one company written twice.

## What shipped

**The run answers for these, the same way it answers for its trades.** A request never says "group", but the language it is written in says which language its companies name themselves in — so the one call that already splits a request into parts now returns that language's words for a kind of company beside them. Both arrive as one vocabulary, because a word for a kind of company answers "does this identify anybody" exactly as a trade does.

**Where the word sits carries the run that brings nothing.** A request about one company on file has no market behind it, and there the shared list was all there was. A firm drops the front of its name to register it and not the end — the file already said so about its front-anchored reading, and the single-word path quietly ignored it. So the one word that may stand alone is the first that identifies anybody. That needs no vocabulary at all, and refuses `gruppen.se`, `skupina.cz`, `csoport.hu`, `grubu.com.tr` and `koncern.dk` without any of those words being written down.

**A word a model supplied can only ever withhold.** Words the request itself wrote are trusted to come off the front of a domain; words a model supplied from its knowledge of a language are not. A family name wrongly offered as a kind of company would otherwise cut `garciaacme.es` down to `acme` and hand a stranger's domain to every firm called Acme. It is capped at 16 words, floored at 4 letters, and an unreadable answer leaves the reading exactly as the shared list had it.

## Measured

| | result |
| --- | --- |
| reproduction, run brings its market's words | **13/13 refused** (was 2/13) |
| reproduction, run brings nothing | **8/13 refused** (was 2/13) |
| 318 rows with a website, 13 stored market searches | 238 → **236** established |
| addresses newly cleared | **0** — strictly narrowing |

Both losses are correct refusals: a `societe.com` directory listing that was being kept as a company's own site, and `otis.com` on a row the scan had named after another company.

It also gives back what word order alone had cost — `Grup Puig` reads `established` on `puig.cat` again, because once the run says "grup" names a kind of company, Puig is the word left standing.

## What it costs, on purpose

A run with no trades to read pays the wrong way round: `Fontanería García` keeps `fontaneria.es`, which is the cost this file already carried, and loses `garcia.es`, which was the right answer. Both were cleared before and withholding is the direction this package is allowed to be wrong in, but a word missing from the shared list now costs twice. The run's own words buy this back, so the runs that pay are the ones with no market behind them.

## Renaming

`trade-words.ts` became `run-words.ts`, and `tradeWords` became `runWords`. A set called "trade words" holding `grup` is a wrong name at the one boundary that decides who owns an address. It is mechanical and compiler-checked, and it is most of the diff.

## Not fixed here

- `bracketedNoteParents` holds two same-cored companies apart only while both carry an established own site, so a narrowing can collapse that guard and merge two real companies. Measured on these rows it produces 7 folds either way — unchanged by this — but it fails open and deserves a guard of its own.
- A request naming a trade in a longer wording than a name uses ("restaurants" against "Restaurant Sumat") does not reach it, and that unread word now also spends the standing-alone place. Widening belongs in `run-words.ts`, measured there.
- Non-Latin writing systems are untouched and unreachable by any of this — filed as `#534`.

## Verification

- `pnpm --filter @batuda/research check-types` and `--filter @batuda/server check-types` clean
- research: 1973 tests pass (84 files); server unit tests: 1007 pass (39 files)
- Biome clean on all 21 changed files
- Rebased on `main` at `236c0db1b9`, which landed the social-page fix mid-flight; its new tests are included and green

Closes #529
