### PR TITLE
fix: keep a conversation whole, and stop a removed attachment sending

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # with-mail because one of the smoke specs is a mail one: a follow-up
+      # written as a reply to nothing is refused before it reaches the wire.
+      # A batch of those went out to real prospects, so it is worth the mail
+      # catcher's start-up here rather than finding out after the merge.
       - name: Stand up the stack and run the smoke subset
         uses: ./.github/actions/e2e-stack
         with:
           grep: "@smoke"
+          with-mail: "true"

--- a/apps/internal/src/components/emails/attachment-picker.tsx
+++ b/apps/internal/src/components/emails/attachment-picker.tsx
@@ -1,9 +1,10 @@
 import { useLingui } from '@lingui/react/macro'
 import { AlertTriangle, Loader2, Paperclip, X } from 'lucide-react'
-import { useCallback, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import {
+	discardAttachment,
 	formatBytes,
 	type StagedAttachment,
 	uploadAttachment,
@@ -30,12 +31,19 @@ type PendingUpload = {
 export function AttachmentPicker({
 	value,
 	onChange,
+	onUploadingChange,
 	disabled,
 	inboxId,
 	draftId,
 }: {
 	readonly value: ReadonlyArray<StagedAttachment>
 	readonly onChange: (next: ReadonlyArray<StagedAttachment>) => void
+	/**
+	 * Called while a file is not yet on the message — still on its way up, or
+	 * stopped on an error the sender has not cleared. The sender has to know:
+	 * sending now sends the message without it, and nothing afterwards says so.
+	 */
+	readonly onUploadingChange?: (uploading: boolean) => void
 	readonly disabled?: boolean
 	readonly inboxId: string | null
 	readonly draftId?: string
@@ -44,6 +52,30 @@ export function AttachmentPicker({
 	const inputId = useId()
 	const inputRef = useRef<HTMLInputElement | null>(null)
 	const [pending, setPending] = useState<ReadonlyArray<PendingUpload>>([])
+
+	// The list as it stands after every change dispatched so far, which is not
+	// the same as the list last rendered: files chosen together finish in the
+	// same tick, and each would otherwise be added to the list as it was before
+	// any of them began, so all but one would vanish from the window.
+	//
+	// Seeded once and written only here, which is sound because nothing else
+	// writes it — the parent sets this list from this component and from
+	// nowhere else.
+	const settled = useRef(value)
+	const replaceValue = useCallback(
+		(next: ReadonlyArray<StagedAttachment>) => {
+			settled.current = next
+			onChange(next)
+		},
+		[onChange],
+	)
+
+	// An upload stopped on an error is not on the message either, and clearing
+	// it is the sender's to do — so it holds Send just as an in-flight one does.
+	const unfinished = pending.length > 0
+	useEffect(() => {
+		onUploadingChange?.(unfinished)
+	}, [unfinished, onUploadingChange])
 
 	const startUpload = useCallback(
 		(file: File) => {
@@ -65,7 +97,7 @@ export function AttachmentPicker({
 			})
 				.then(result => {
 					setPending(prev => prev.filter(p => p.id !== id))
-					onChange([...value, result])
+					replaceValue([...settled.current, result])
 				})
 				.catch((error: unknown) => {
 					if (controller.signal.aborted) {
@@ -81,7 +113,7 @@ export function AttachmentPicker({
 					)
 				})
 		},
-		[onChange, value, inboxId, draftId],
+		[replaceValue, inboxId, draftId],
 	)
 
 	const handleFiles = useCallback(
@@ -104,9 +136,17 @@ export function AttachmentPicker({
 
 	const handleRemove = useCallback(
 		(stagingId: string) => {
-			onChange(value.filter(v => v.stagingId !== stagingId))
+			replaceValue(settled.current.filter(v => v.stagingId !== stagingId))
+			// The send reads every file staged against the draft, not this list —
+			// so dropping the chip alone leaves the file on the message and it
+			// goes out after somebody took it off on purpose. Nothing to do if
+			// the call fails: the chip is already gone, and the sweep that
+			// expires staged files will catch the row.
+			if (inboxId !== null) {
+				void discardAttachment(stagingId, { inboxId }).catch(() => {})
+			}
 		},
-		[onChange, value],
+		[replaceValue, inboxId],
 	)
 
 	const hasAny = value.length > 0 || pending.length > 0

--- a/apps/internal/src/components/emails/compose-form.tsx
+++ b/apps/internal/src/components/emails/compose-form.tsx
@@ -290,6 +290,7 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 
 	const [ccBccOpen, setCcBccOpen] = useState(false)
 	const [sendState, setSendState] = useState<SendState>('idle')
+	const [attachmentsUnfinished, setAttachmentsUnfinished] = useState(false)
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
 	const [suppressed, setSuppressed] = useState<
 		ReadonlyArray<SuppressedAddress>
@@ -298,6 +299,10 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 
 	const canSend = useMemo(() => {
 		if (sendState === 'sending') return false
+		// A file still on its way up, or stopped on an error nobody has cleared,
+		// is not on the message. Sending now would send it without the
+		// attachment and say nothing about it.
+		if (attachmentsUnfinished) return false
 		if (form.bodyText.trim() === '') return false
 		if (suppressed.length > 0) return false
 		if (serverId === null) return false
@@ -309,6 +314,7 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 		return true
 	}, [
 		sendState,
+		attachmentsUnfinished,
 		form.bodyText,
 		form.to,
 		suppressed,
@@ -624,6 +630,7 @@ export function ComposeForm({ draft }: { readonly draft: Draft }) {
 				onChange={next => {
 					patchForm({ attachments: next })
 				}}
+				onUploadingChange={setAttachmentsUnfinished}
 				inboxId={effectiveInboxId}
 				{...(serverIdRef.current !== null && { draftId: serverIdRef.current })}
 			/>

--- a/apps/internal/src/lib/email-attachments.ts
+++ b/apps/internal/src/lib/email-attachments.ts
@@ -50,6 +50,31 @@ export async function uploadAttachment(
 	}
 }
 
+/**
+ * Take a staged file back off the message.
+ *
+ * The send reads every file staged against the draft, not the list the compose
+ * window is showing — so dropping the chip on its own leaves the file on the
+ * message, and it goes out after somebody took it off on purpose.
+ */
+export async function discardAttachment(
+	stagingId: string,
+	options: { readonly inboxId: string },
+): Promise<void> {
+	const url = new URL(
+		`${apiBaseUrl()}/v1/email/attachments/staging/${encodeURIComponent(stagingId)}`,
+	)
+	url.searchParams.set('inboxId', options.inboxId)
+	const response = await fetch(url, {
+		method: 'DELETE',
+		credentials: 'include',
+	})
+	// Already gone is the outcome the caller wanted, not a failure.
+	if (!response.ok && response.status !== 404) {
+		throw new Error(await extractError(response))
+	}
+}
+
 export function downloadUrlFor(
 	messageId: string,
 	attachmentId: string,

--- a/apps/internal/src/routes/emails/$threadId.tsx
+++ b/apps/internal/src/routes/emails/$threadId.tsx
@@ -21,6 +21,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled, { css } from 'styled-components'
 
+import { withReplyPrefix } from '@batuda/email/subject'
 import { PriButton } from '@batuda/ui/pri'
 
 import {
@@ -256,7 +257,7 @@ function ThreadDetailPage() {
 							...seed.cc,
 						].filter(addr => addr.toLowerCase() !== selfEmail)
 					: []
-			const subject = prefixSubject(detail.subject ?? '', 'Re: ')
+			const subject = prefixSubject(detail.subject ?? '')
 			const quoteSeed = seed
 			const attribution = {
 				withDate: t`On {date}, {who} wrote:`,
@@ -882,12 +883,7 @@ function findLastInbound(
 	return null
 }
 
-// Mail clients write the reply prefix several ways — "RE:", "re:", and (with
-// French typography) "Re :". Any of them already marks a reply, so none of them
-// should be stacked on top of. The server reads it the same way.
-const REPLY_PREFIX = /^re\s*:/i
-
-function prefixSubject(subject: string, prefix: string): string {
+function prefixSubject(subject: string): string {
 	const trimmed = subject.trim()
 	// A conversation with nothing to borrow leaves this empty rather than
 	// answering with a bare "Re:". The server turns an empty one away and says
@@ -895,8 +891,7 @@ function prefixSubject(subject: string, prefix: string): string {
 	// "Re:" here would make the browser the one place a message with no real
 	// subject still went out.
 	if (trimmed === '') return ''
-	if (REPLY_PREFIX.test(trimmed)) return trimmed
-	return `${prefix}${trimmed}`
+	return withReplyPrefix(trimmed)
 }
 
 // ── Styled components ─────────────────────────────────────────────

--- a/apps/internal/tests/e2e/attachment.test.ts
+++ b/apps/internal/tests/e2e/attachment.test.ts
@@ -112,7 +112,60 @@ test.describe('compose with attachment', () => {
 			expect(att?.ContentType).toBe('application/pdf')
 			expect(att?.Size).toBeGreaterThan(0)
 		})
+	})
 
+	test.describe('when the user attaches several files at once', () => {
+		test('should send every one of them, not just the last to finish', async ({
+			page,
+		}) => {
+			// GIVEN two files chosen in a single pick, the way a file dialog
+			// hands them over
+			const testId = `e2e-attach-many-${Date.now()}`
+			const recipient = `${testId}@catcher.local`
+			const first = `${testId}-first.pdf`
+			const second = `${testId}-second.pdf`
+
+			await page.goto('/emails', { waitUntil: 'networkidle' })
+			await openCompose(page, 'emails-compose')
+			await page.getByTestId('compose-to').fill(recipient)
+			await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
+			await fillBody(page, `Body ${testId}`)
+
+			// WHEN both are picked together
+			await page
+				.getByTestId('compose-form')
+				.locator('input[type="file"]')
+				.setInputFiles([
+					{ name: first, mimeType: 'application/pdf', buffer: PDF_BYTES },
+					{ name: second, mimeType: 'application/pdf', buffer: PDF_BYTES },
+				])
+
+			await expect(
+				page.getByTestId('compose-form').getByText(first),
+			).toBeVisible()
+			await expect(
+				page.getByTestId('compose-form').getByText(second),
+			).toBeVisible()
+			await expect(page.getByTestId('compose-send')).toBeEnabled({
+				timeout: 15_000,
+			})
+			await page.getByTestId('compose-send').click()
+
+			// THEN both are on the message that goes out
+			// AND this is the case that used to lose one: each upload finished
+			// against the list as it was before either began, so whichever
+			// landed second replaced the first — silently, on a message that
+			// still sent
+			const summary = await waitForMessage(recipient, {
+				subject: `Subj ${testId}`,
+			})
+			const detail = await getMessage(summary)
+			const names = detail.Attachments.map(a => a.FileName).sort()
+			expect(names).toEqual([first, second].sort())
+		})
+	})
+
+	test.describe('after a send succeeds', () => {
 		test('should purge email_attachment_staging on success', async ({
 			page,
 		}) => {
@@ -136,10 +189,20 @@ test.describe('compose with attachment', () => {
 			await expect(page.getByTestId('compose-send')).toBeEnabled({
 				timeout: 10_000,
 			})
-			await page.getByTestId('compose-send').click()
 
-			// Wait for the send to land in the catcher before reading the
-			// staging row — the post-send purge runs after the SMTP ack.
+			// Wait for the send request itself to come back, not just for the
+			// message to reach the catcher. The catcher has it the moment SMTP
+			// delivers, and the purge runs after that — so reading the staging
+			// row on the catcher's timing reads it before the purge has run.
+			const sent = page.waitForResponse(
+				resp =>
+					resp.url().includes('/email/drafts/') &&
+					resp.url().endsWith('/send') &&
+					resp.request().method() === 'POST',
+				{ timeout: 20_000 },
+			)
+			await page.getByTestId('compose-send').click()
+			expect((await sent).status()).toBe(200)
 			await waitForMessage(recipient, { subject: `Subj ${testId}` })
 
 			// THEN the staging row is gone — markSentAndCleanup deletes it
@@ -150,5 +213,51 @@ test.describe('compose with attachment', () => {
 			)
 			expect(remaining).toBe('')
 		})
+	})
+})
+
+test.describe('removing an attachment before sending', () => {
+	test('should leave it off the message that goes out', async ({ page }) => {
+		// GIVEN a file attached and then taken off again, the way somebody
+		// corrects a mistake before sending
+		const testId = `e2e-attach-removed-${Date.now()}`
+		const recipient = `${testId}@catcher.local`
+		const filename = `${testId}.pdf`
+
+		psql(
+			`UPDATE inboxes SET grant_status='connected' WHERE email='admin@taller.cat'`,
+		)
+		await page.goto('/', { waitUntil: 'commit' })
+		await setActiveOrgBySlug(page, 'taller')
+		await page.goto('/emails', { waitUntil: 'networkidle' })
+		await openCompose(page, 'emails-compose')
+		await page.getByTestId('compose-to').fill(recipient)
+		await page.getByTestId('compose-subject').fill(`Subj ${testId}`)
+		await fillBody(page, `Body ${testId}`)
+		await page
+			.getByTestId('compose-form')
+			.locator('input[type="file"]')
+			.setInputFiles({
+				name: filename,
+				mimeType: 'application/pdf',
+				buffer: PDF_BYTES,
+			})
+		await expect(page.getByTestId('compose-send')).toBeEnabled({
+			timeout: 10_000,
+		})
+
+		// WHEN the chip is removed and the message sent
+		await page.getByRole('button', { name: `Remove ${filename}` }).click()
+		await expect(
+			page.getByTestId('compose-form').getByText(filename),
+		).toBeHidden()
+		await page.getByTestId('compose-send').click()
+
+		// THEN the message carries no attachment
+		const summary = await waitForMessage(recipient, {
+			subject: `Subj ${testId}`,
+		})
+		const detail = await getMessage(summary)
+		expect(detail.Attachments.map(a => a.FileName)).toEqual([])
 	})
 })

--- a/apps/internal/tests/e2e/send-email.test.ts
+++ b/apps/internal/tests/e2e/send-email.test.ts
@@ -102,9 +102,13 @@ test.describe('compose and send via the mail catcher', () => {
 	})
 
 	test.describe('when a new message is written as if it were a reply', () => {
-		test('should refuse it and leave the compose window open', async ({
-			page,
-		}) => {
+		// Tagged so it gates a pull request: CI's smoke subset is `--grep @smoke`,
+		// and an untagged spec only ever runs on main, after the merge it should
+		// have stopped. A batch of these forged replies reached real prospects,
+		// so this is one worth catching before the merge rather than after.
+		test('should refuse it and leave the compose window open', {
+			tag: '@smoke',
+		}, async ({ page }) => {
 			// GIVEN a brand-new message — this path threads nothing — written
 			// under a "Re: " subject, the way a follow-up gets written. That
 			// pairing is the classic forged-reply shape, and mail filters test

--- a/apps/mail-worker/src/backfill.ts
+++ b/apps/mail-worker/src/backfill.ts
@@ -60,9 +60,15 @@ export const backfillSinceDate = (args: {
 				raw: new Uint8Array(m.source),
 			}).pipe(
 				Effect.catchCause(cause =>
-					Effect.logWarning(
-						`mail-worker: backfill ingest failed inbox=${args.inboxId} uid=${m.uid}`,
-					).pipe(Effect.andThen(Effect.logError(boundedCause(cause)))),
+					Effect.logWarning('Ingesting an older message failed').pipe(
+						Effect.andThen(Effect.logError(boundedCause(cause))),
+						Effect.annotateLogs({
+							event: 'email.ingest_failed',
+							inboxId: args.inboxId,
+							folder: args.folder,
+							imapUid: m.uid,
+						}),
+					),
 				),
 			)
 			if (m.uid > highest) highest = m.uid

--- a/apps/mail-worker/src/folder-sync.ts
+++ b/apps/mail-worker/src/folder-sync.ts
@@ -2,6 +2,8 @@ import { Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import type { ImapFlow } from 'imapflow'
 
+import { boundedCause } from '@batuda/observability'
+
 import { ingestRawMessage } from './ingest.js'
 
 // Per-folder sync state stored under inboxes.folder_state JSONB:
@@ -113,9 +115,15 @@ export const fetchAndIngestNewerThan = (args: {
 				// successes. The dedupe index makes a re-fetch on next sync
 				// idempotent if the cause was transient.
 				Effect.catchCause(cause =>
-					Effect.logWarning(
-						`mail-worker: ingest failed inbox=${args.inboxId} uid=${m.uid}`,
-					).pipe(Effect.andThen(Effect.logError(cause))),
+					Effect.logWarning('Ingesting a message failed').pipe(
+						Effect.andThen(Effect.logError(boundedCause(cause))),
+						Effect.annotateLogs({
+							event: 'email.ingest_failed',
+							inboxId: args.inboxId,
+							folder: args.folder,
+							imapUid: m.uid,
+						}),
+					),
 				),
 			)
 			if (m.uid > highest) highest = m.uid

--- a/apps/mail-worker/src/inbox-session.ts
+++ b/apps/mail-worker/src/inbox-session.ts
@@ -332,9 +332,14 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 						progress,
 					}).pipe(
 						Effect.catchCause(cause =>
-							Effect.logWarning(
-								`mail-worker: folder tick failed inbox=${claimed.id} folder=${folder.path}`,
-							).pipe(Effect.andThen(Effect.logError(boundedCause(cause)))),
+							Effect.logWarning('Reading a folder failed').pipe(
+								Effect.andThen(Effect.logError(boundedCause(cause))),
+								Effect.annotateLogs({
+									event: 'email.folder_read_failed',
+									inboxId: claimed.id,
+									folder: folder.path,
+								}),
+							),
 						),
 					)
 				}

--- a/apps/mail-worker/src/persist.integration.test.ts
+++ b/apps/mail-worker/src/persist.integration.test.ts
@@ -467,23 +467,82 @@ describe('persistMessage — the conversation keeps a subject', () => {
 		})
 	})
 
-	describe('when the conversation starts with a message we sent', () => {
-		it('should put its subject on the conversation too', async () => {
-			// GIVEN our own message, read back from the sent folder
+	describe('when the conversation started with a message we sent ourselves', () => {
+		it('should leave the subject the send already recorded', async () => {
+			// GIVEN a message this app sent: the row and the conversation are
+			// written at send time, before the mail server has ever been read,
+			// and the row has no folder position yet
 			const rootMessageId = `<subject-outbound-${randomUUID()}@example>`
+			await pool.query(
+				`INSERT INTO email_thread_links (organization_id, inbox_id, external_thread_id, subject, status)
+				 VALUES ($1, $2, $3, 'your pallet pools', 'open')`,
+				[ORG_ID, inboxId, rootMessageId],
+			)
+			await pool.query(
+				`INSERT INTO email_messages (organization_id, inbox_id, folder, message_id,
+				   "references", subject, received_at, recipients, attachments,
+				   status, status_updated_at, direction, raw_rfc822_ref)
+				 VALUES ($1, $2, 'Sent', $3, ARRAY[]::text[], 'your pallet pools', now(),
+				   '{}'::jsonb, '[]'::jsonb, 'normal', now(), 'outbound', 'sentinel')`,
+				[ORG_ID, inboxId, rootMessageId],
+			)
+
+			// WHEN the same message comes back to us out of the sent folder
 			await runIngest(
 				persistIn(
 					buildParsed({
 						messageId: rootMessageId,
+						subject: 'a different subject entirely',
+					}),
+					{ folder: 'Sent', direction: 'outbound' },
+				),
+			)
+
+			// THEN the conversation keeps what the send recorded
+			// AND this is the path production takes: the row already exists, so
+			// the arriving copy fills in where it now lives rather than being
+			// stored a second time, and never reaches the conversation at all
+			const link = await fetchThreadLink(rootMessageId)
+			expect(link?.subject).toBe('your pallet pools')
+
+			// AND only one row exists for it, rather than a duplicate
+			// AND that row now says where on the server it lives, which is the
+			// whole reason the arriving copy is worth reading at all
+			const rows = await pool.query<{
+				n: string
+				imap_uid: number | null
+				folder: string
+			}>(
+				`SELECT count(*) OVER () AS n, imap_uid, folder FROM email_messages
+				 WHERE organization_id = $1 AND message_id = $2`,
+				[ORG_ID, rootMessageId],
+			)
+			expect(Number(rows.rows[0]?.n)).toBe(1)
+			expect(rows.rows[0]?.imap_uid).not.toBeNull()
+			expect(rows.rows[0]?.folder).toBe('Sent')
+		})
+	})
+
+	describe('when a message we sent arrives with no record of it here', () => {
+		it('should start the conversation and give it the subject', async () => {
+			// GIVEN a message sent from the account's own mail client, so this
+			// app never wrote a row for it — the path issue #520 describes
+			// WHEN it is read out of the sent folder
+			const strayMessageId = `<subject-stray-${randomUUID()}@example>`
+			await runIngest(
+				persistIn(
+					buildParsed({
+						messageId: strayMessageId,
 						subject: 'your pallet pools',
 					}),
 					{ folder: 'Sent', direction: 'outbound' },
 				),
 			)
 
-			// THEN the conversation carries it, so a later reply has a subject
-			// to borrow whichever way the conversation began
-			const link = await fetchThreadLink(rootMessageId)
+			// THEN the conversation it starts carries that subject
+			// AND without it a reply has none to borrow and goes out with no
+			// subject line at all, which is the bug this began as
+			const link = await fetchThreadLink(strayMessageId)
 			expect(link?.subject).toBe('your pallet pools')
 		})
 	})
@@ -535,6 +594,110 @@ describe('persistMessage — a message can be found in its conversation', () => 
 			expect(rows.rows.map(r => r.message_id).sort()).toEqual(
 				[root, middle, last].sort(),
 			)
+		})
+	})
+
+	describe('when the reply is taken in before the message it answers', () => {
+		it('should end up as one conversation, not two halves', async () => {
+			// GIVEN a message sent from the account's own mail client, and the
+			// answer to it — and the answer read first, because the inbox is
+			// read before the sent folder on every sweep
+			const sent = `<split-sent-${randomUUID()}@example>`
+			const answer = `<split-answer-${randomUUID()}@example>`
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: answer,
+						inReplyTo: sent,
+						references: [sent],
+						subject: 'Re: your pallet pools',
+					}),
+				),
+			)
+
+			// WHEN the message it answers is read out of the sent folder
+			await runIngest(
+				persistIn(
+					buildParsed({ messageId: sent, subject: 'your pallet pools' }),
+					{ folder: 'Sent', direction: 'outbound' },
+				),
+			)
+
+			// THEN there is one conversation holding both, rather than the
+			// contact being left with two halves of one exchange
+			const links = await pool.query<{
+				id: string
+				external_thread_id: string
+			}>(
+				`SELECT id, external_thread_id FROM email_thread_links
+				 WHERE organization_id = $1 AND external_thread_id IN ($2, $3)`,
+				[ORG_ID, sent, answer],
+			)
+			expect(links.rows).toHaveLength(1)
+
+			// AND the conversation is keyed on the message it starts with,
+			// not on the reply that happened to arrive first
+			expect(links.rows[0]?.external_thread_id).toBe(sent)
+
+			// AND neither row was made to name the other as its ancestor. The
+			// stored chain is what the sender wrote: the answer names what it
+			// answers, and the message it answers names nothing.
+			const chains = await pool.query<{
+				message_id: string
+				references: string[]
+			}>(
+				`SELECT message_id, "references" FROM email_messages
+				 WHERE organization_id = $1 AND message_id IN ($2, $3)`,
+				[ORG_ID, sent, answer],
+			)
+			const byId = new Map(chains.rows.map(r => [r.message_id, r.references]))
+			expect(byId.get(answer)).toEqual([sent])
+			expect(byId.get(sent)).toEqual([])
+
+			// AND both messages are in it
+			const members = await pool.query<{ message_id: string }>(
+				`SELECT em.message_id FROM email_messages em
+				 JOIN email_thread_links tl
+				   ON tl.organization_id = em.organization_id
+				  AND (em.message_id = tl.external_thread_id
+				       OR em."references" @> ARRAY[tl.external_thread_id]::text[])
+				 WHERE em.organization_id = $1 AND tl.id = $2`,
+				[ORG_ID, links.rows[0]?.id],
+			)
+			expect(members.rows.map(r => r.message_id).sort()).toEqual(
+				[sent, answer].sort(),
+			)
+		})
+	})
+
+	describe('when the message starts a conversation of its own', () => {
+		it('should store the chain it arrived with, untouched', async () => {
+			// GIVEN a message that answers something we do not hold, so it
+			// starts a conversation of its own
+			const absent = `<absent-${randomUUID()}@example>`
+			const starter = `<starter-${randomUUID()}@example>`
+			await runIngest(
+				persist(
+					buildParsed({
+						messageId: starter,
+						inReplyTo: absent,
+						references: [absent],
+						subject: 'Re: q',
+					}),
+				),
+			)
+
+			// THEN nothing is added to what the sender wrote
+			// AND in particular not the message's own id: it is found by that
+			// already, and putting it first would leave the newest id where the
+			// oldest belongs — which is the order the resolver reads to tell
+			// which of two conversations a message is in
+			const rows = await pool.query<{ references: string[] }>(
+				`SELECT "references" FROM email_messages
+				 WHERE organization_id = $1 AND message_id = $2`,
+				[ORG_ID, starter],
+			)
+			expect(rows.rows[0]?.references).toEqual([absent])
 		})
 	})
 })

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -182,9 +182,16 @@ export const persistMessage = (args: {
 		// chain back to the start, leaves it out. So does a sender that trims a
 		// long chain. Both are ordinary. The id goes in front, where the oldest
 		// ancestor belongs.
-		const storedReferences = args.parsed.references.includes(externalThreadId)
-			? args.parsed.references
-			: [externalThreadId, ...args.parsed.references]
+		//
+		// Except when the conversation is this message's own: it is found by its
+		// own id already, and putting that first would leave the newest id where
+		// the oldest belongs — the order the resolver reads to tell which of two
+		// conversations a message is in.
+		const startsItsOwn = externalThreadId === args.parsed.messageId
+		const storedReferences =
+			startsItsOwn || args.parsed.references.includes(externalThreadId)
+				? args.parsed.references
+				: [externalThreadId, ...args.parsed.references]
 
 		// Whose conversation this is comes from the other side of it: who wrote
 		// to us, or who we wrote to. Reading the sender of a message we sent
@@ -371,6 +378,22 @@ export const persistMessage = (args: {
 					updated_at = now()
 				WHERE id = ${companyId} AND deleted_at IS NULL
 			`
+		}
+
+		// One line per message taken in, so "is mail still arriving, and whose"
+		// can be answered at all. Counts and ids only: who wrote, what they
+		// wrote and what they called it are the contents of the message, and
+		// none of it belongs in a log.
+		if (args.direction === 'inbound') {
+			yield* Effect.logInfo('Email received').pipe(
+				Effect.annotateLogs({
+					event: 'email.received',
+					inboxId: args.inboxId,
+					folder: args.folder,
+					companyId,
+					attachments: args.attachments.length,
+				}),
+			)
 		}
 
 		return { messageId: messageDbId }

--- a/apps/mail-worker/src/threading.integration.test.ts
+++ b/apps/mail-worker/src/threading.integration.test.ts
@@ -74,6 +74,7 @@ describe('resolveThreadId', () => {
 			readonly messageId: string
 			readonly externalThreadId: string
 			readonly references?: readonly string[]
+			readonly inReplyTo?: string
 		},
 	) => {
 		// Both rows live under the same org so the JOIN in resolveThreadId
@@ -86,11 +87,11 @@ describe('resolveThreadId', () => {
 		)
 		await pool.query(
 			`INSERT INTO email_messages
-			   (organization_id, message_id, "references",
+			   (organization_id, message_id, "references", in_reply_to,
 			    direction, folder, raw_rfc822_ref, status)
-			 VALUES ($1, $2, $3,
+			 VALUES ($1, $2, $3, $4,
 			         'inbound', 'INBOX', 'sentinel', 'normal')`,
-			[orgId, opts.messageId, opts.references ?? []],
+			[orgId, opts.messageId, opts.references ?? [], opts.inReplyTo ?? null],
 		)
 	}
 
@@ -184,6 +185,157 @@ describe('resolveThreadId', () => {
 				}).pipe(Effect.provide(PgLive)),
 			)
 			expect(result).toBe('<new@x>')
+		})
+	})
+
+	// Looking forward: a message we already hold names the arriving one as an
+	// ancestor. This is the ordinary order for a conversation the account also
+	// takes part in from its own mail client — the inbox is read before the
+	// sent folder, so the reply is taken in first.
+	describe('when a message we already hold answers the arriving one', () => {
+		it('should join that conversation instead of starting a second one', async () => {
+			// GIVEN a reply taken in first, which started a conversation of its
+			// own because what it answers had not arrived yet
+			// WHEN the message it answers arrives
+			// THEN it joins the reply's conversation
+			// AND without this the contact is left holding two halves of one
+			// exchange, neither of which shows the whole thing
+			const orgId = freshOrg()
+			await insertParent(orgId, {
+				messageId: '<reply@x>',
+				externalThreadId: '<reply@x>',
+				references: ['<root@x>'],
+			})
+
+			const result = await runWithSql(
+				resolveThreadId({
+					organizationId: orgId,
+					messageId: '<root@x>',
+					inReplyTo: null,
+					references: [],
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			// AND the conversation is keyed on this message, the one it starts
+			// with — the reply only held the key because it arrived first
+			expect(result).toBe('<root@x>')
+
+			// AND it is still one conversation, moved rather than duplicated
+			const links = await pool.query<{ external_thread_id: string }>(
+				`SELECT external_thread_id FROM email_thread_links WHERE organization_id = $1`,
+				[orgId],
+			)
+			expect(links.rows.map(r => r.external_thread_id)).toEqual(['<root@x>'])
+		})
+
+		it('should find it by In-Reply-To when the sender trimmed the chain', async () => {
+			// GIVEN a reply that names what it answers only in In-Reply-To —
+			// ordinary for a sender that does not carry the whole chain
+			// WHEN the message it answers arrives
+			// THEN it is still found, via the other half of the lookup
+			const orgId = freshOrg()
+			await insertParent(orgId, {
+				messageId: '<trimmed-reply@x>',
+				externalThreadId: '<trimmed-reply@x>',
+				references: [],
+				inReplyTo: '<trimmed-root@x>',
+			})
+
+			const result = await runWithSql(
+				resolveThreadId({
+					organizationId: orgId,
+					messageId: '<trimmed-root@x>',
+					inReplyTo: null,
+					references: [],
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			expect(result).toBe('<trimmed-root@x>')
+		})
+
+		it('should still start its own when several conversations answer it', async () => {
+			// GIVEN two people who each replied to a message we never held, so
+			// their replies are filed as two separate conversations
+			// WHEN the message they both answer finally arrives
+			// THEN it starts a conversation of its own rather than joining one
+			// AND this is the case that matters: joining either would file it,
+			// and every later reply to it, under whichever person answered
+			// first — one company's mail under another company's name
+			const orgId = freshOrg()
+			await insertParent(orgId, {
+				messageId: '<acme-reply@x>',
+				externalThreadId: '<acme-reply@x>',
+				references: ['<shared@x>'],
+			})
+			await insertParent(orgId, {
+				messageId: '<beta-reply@x>',
+				externalThreadId: '<beta-reply@x>',
+				references: ['<shared@x>'],
+			})
+
+			const result = await runWithSql(
+				resolveThreadId({
+					organizationId: orgId,
+					messageId: '<shared@x>',
+					inReplyTo: null,
+					references: [],
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			expect(result).toBe('<shared@x>')
+		})
+
+		it('should not reach into another organisation for the answer', async () => {
+			// GIVEN a reply held by one organisation
+			// WHEN a message it answers arrives for a different organisation
+			// THEN the lookup does not cross the boundary
+			const orgId = freshOrg()
+			const otherOrgId = freshOrg()
+			await insertParent(otherOrgId, {
+				messageId: '<other-org-reply@x>',
+				externalThreadId: '<other-org-reply@x>',
+				references: ['<crossing@x>'],
+			})
+
+			const result = await runWithSql(
+				resolveThreadId({
+					organizationId: orgId,
+					messageId: '<crossing@x>',
+					inReplyTo: null,
+					references: [],
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			expect(result).toBe('<crossing@x>')
+		})
+
+		it('should prefer what the arriving message itself names', async () => {
+			// GIVEN both directions available: the arriving message names a
+			// known ancestor, and a held reply names the arriving message
+			// WHEN it is filed
+			// THEN the ancestor it names wins — looking forward is the last
+			// resort, not a competing answer
+			const orgId = freshOrg()
+			await insertParent(orgId, {
+				messageId: '<known-ancestor@x>',
+				externalThreadId: '<known-ancestor@x>',
+			})
+			await insertParent(orgId, {
+				messageId: '<later-reply@x>',
+				externalThreadId: '<later-reply@x>',
+				references: ['<middle@x>'],
+			})
+
+			const result = await runWithSql(
+				resolveThreadId({
+					organizationId: orgId,
+					messageId: '<middle@x>',
+					inReplyTo: '<known-ancestor@x>',
+					references: ['<known-ancestor@x>'],
+				}).pipe(Effect.provide(PgLive)),
+			)
+
+			expect(result).toBe('<known-ancestor@x>')
 		})
 	})
 })

--- a/apps/mail-worker/src/threading.ts
+++ b/apps/mail-worker/src/threading.ts
@@ -8,7 +8,11 @@ import { SqlClient } from 'effect/unstable/sql'
 //     `external_thread_id`.
 //  2. Else walk `references` newest-to-oldest looking for a known
 //     ancestor in this org → reuse.
-//  3. Else this is a thread root → its `external_thread_id` is its
+//  3. Else look forward instead of back: if exactly one conversation
+//     already holds a message that names this one as an ancestor, join
+//     it, and move its key onto this message — the one it starts with.
+//     More than one such conversation and it joins none.
+//  4. Else this is a thread root → its `external_thread_id` is its
 //     own `messageId`.
 //
 // The unique index on `email_thread_links(organization_id,
@@ -80,16 +84,72 @@ export const resolveThreadId = (args: {
 			if (hit) return hit
 		}
 
-		// Nothing on file to hang this on, so this message starts a conversation
-		// of its own.
+		// Nothing this message names is on file. Before it starts a
+		// conversation of its own, look the other way down the chain: a message
+		// we already hold may name THIS one as an ancestor.
 		//
-		// The oldest id it names looks like the better answer — it would let a
-		// reply taken in before the message it answers join that one later,
-		// instead of leaving the contact with two. It is not: several people
-		// replying to one message we do not hold all name the same id, so they
-		// would land in a single conversation, and a conversation belongs to
-		// whoever is on the first message to reach it. The second company's
-		// mail would then sit under the first company's. Measured both ways —
-		// a duplicate conversation costs less than mixing two customers.
-		return args.messageId
+		// That is the ordinary case, not a rare one. Mail is read inbox first
+		// and sent folder second (`inbox-session.ts`, FOLDER_ROLES), so a reply
+		// to something sent from the account's own mail client is taken in
+		// before the message it answers. Without this the reply starts a
+		// conversation, the message it answers starts a second one, and the
+		// contact is left with two halves of one exchange for good.
+		const descendants = yield* sql<{ id: string; externalThreadId: string }>`
+			SELECT DISTINCT etl.id, etl.external_thread_id AS "externalThreadId"
+			FROM email_messages em
+			JOIN email_thread_links etl
+			  ON etl.organization_id = em.organization_id
+			 AND (
+			   etl.external_thread_id = em.message_id
+			   OR etl.external_thread_id = ANY(em."references")
+			 )
+			WHERE em.organization_id = ${args.organizationId}
+			  AND (
+			    em."references" @> ARRAY[${args.messageId}]::text[]
+			    -- A sender that trims the chain away sends only this one.
+			    OR em.in_reply_to = ${args.messageId}
+			  )
+			-- Two is all this needs to know: one conversation to join, or more
+			-- than one and it joins none of them.
+			LIMIT 2
+		`
+
+		// Exactly one, or none. Several means several people replied to a
+		// message we do not hold, and their replies are already filed apart —
+		// joining one of them would put this message, and every later reply to
+		// it, under whichever contact happened to answer first. That is one
+		// company's mail under another company's name, which is worse than the
+		// duplicate this is trying to avoid.
+		const only = descendants.length === 1 ? descendants[0] : undefined
+		if (!only) return args.messageId
+
+		// The conversation is keyed on the id of the message it starts with, and
+		// that is this one — the reply only held the key because it arrived
+		// first. Moving it over is what keeps the stored chain honest: a message
+		// is found in its conversation by that key appearing in its list, so
+		// leaving the reply as the key would mean writing the reply into the
+		// list of the message it answers, and the two rows would name each other
+		// as ancestors.
+		//
+		// Nothing outside points at this key: a conversation is addressed by its
+		// row id everywhere a person or a tool names one, and every message
+		// already on it names the arriving one, which is how it was found.
+		const rerooted = yield* sql<{ id: string }>`
+			UPDATE email_thread_links
+			SET external_thread_id = ${args.messageId}
+			WHERE id = ${only.id}
+			  AND organization_id = ${args.organizationId}
+			  -- Another conversation already answering to this key means two
+			  -- replicas took the same message in at once. Leave it alone and
+			  -- join under the old key rather than fail the whole batch on the
+			  -- uniqueness rule.
+			  AND NOT EXISTS (
+			    SELECT 1 FROM email_thread_links other
+			    WHERE other.organization_id = ${args.organizationId}
+			      AND other.external_thread_id = ${args.messageId}
+			  )
+			RETURNING id
+		`
+
+		return rerooted.length === 1 ? args.messageId : only.externalThreadId
 	})

--- a/apps/server/src/db/migrations/0067_email_messages_in_reply_to_index.ts
+++ b/apps/server/src/db/migrations/0067_email_messages_in_reply_to_index.ts
@@ -1,0 +1,29 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Let the mail worker ask who answered a message.
+//
+// Filing an arriving message into a conversation used to look only backwards,
+// at what the message itself names. That leaves a conversation in two halves
+// whenever a reply is taken in before the message it answers — which is the
+// ordinary order, not a rare one, because mail is read inbox first and sent
+// folder second.
+//
+// So the worker now also looks forward: does a message we already hold name
+// this one as an ancestor? Most of that question is answered by the existing
+// GIN index over `references`. The rest is this one — a sender that trims the
+// chain away sends only `In-Reply-To`, and without an index that half of the
+// lookup reads every message in the table on every arrival.
+//
+// Partial, because a message that answers nothing stores NULL here and is never
+// what the lookup is searching for.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS idx_email_messages_in_reply_to
+			ON email_messages (organization_id, in_reply_to)
+			WHERE in_reply_to IS NOT NULL
+	`
+})

--- a/apps/server/src/mcp/tools/email.ts
+++ b/apps/server/src/mcp/tools/email.ts
@@ -13,7 +13,7 @@ import {
 import { EmailDraft, Inbox, InboxFooter } from '@batuda/domain'
 import { EmailBlocks } from '@batuda/email/schema'
 
-import { EmailService } from '../../services/email'
+import { EmailService, smtpFailureReason } from '../../services/email'
 import {
 	EmailAttachmentStaging,
 	type StagingRef,
@@ -122,6 +122,21 @@ const AttachmentRef = Schema.Struct({
 // What a refused send is told, in the words the caller can act on. The service
 // answers with the reason alone so each surface can say it its own way; this is
 // the one an assistant reads.
+// What to tell the caller when the mail server would not take the message.
+//
+// Written here on purpose. A fault that is not deliberately worded is replaced
+// with a fixed, uninformative sentence on the way out, because a raw one can
+// carry database text and internal paths — so a reason worth reading has to be
+// marked as such where it is raised. The mail server names the recipient in a
+// refusal, and telling the caller which of their own addresses bounced is the
+// point of saying anything at all.
+const sendFailureMessage = (cause: unknown): string => {
+	const reason = smtpFailureReason(cause)
+	return reason === ''
+		? 'The mail server would not take the message, and gave no reason. Check the mailbox settings and try again.'
+		: `The mail server would not take the message: ${reason}`
+}
+
 const refusalMessage = (reason: 'no_subject' | 'forged_reply'): string =>
 	reason === 'no_subject'
 		? 'Refused: the message has no subject, so it would arrive as "(no subject)" and be treated as spam. Pass a subject and send again.'
@@ -902,6 +917,9 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							// A refused send names why. The wording lives here, on the
 							// surface that speaks to the caller, so the service can
 							// answer with the reason alone.
+							Effect.catchTag('SmtpSendFailed', e =>
+								Effect.die(new ToolMessage(sendFailureMessage(e.cause))),
+							),
 							Effect.catchTag('EmailNotSendable', e =>
 								Effect.die(new ToolMessage(refusalMessage(e.reason))),
 							),
@@ -979,6 +997,9 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							// A refused send names why. The wording lives here, on the
 							// surface that speaks to the caller, so the service can
 							// answer with the reason alone.
+							Effect.catchTag('SmtpSendFailed', e =>
+								Effect.die(new ToolMessage(sendFailureMessage(e.cause))),
+							),
 							Effect.catchTag('EmailNotSendable', e =>
 								Effect.die(new ToolMessage(refusalMessage(e.reason))),
 							),
@@ -1372,6 +1393,9 @@ export const EmailHandlersLive = EmailTools.toLayer(
 							// A refused send names why. The wording lives here, on the
 							// surface that speaks to the caller, so the service can
 							// answer with the reason alone.
+							Effect.catchTag('SmtpSendFailed', e =>
+								Effect.die(new ToolMessage(sendFailureMessage(e.cause))),
+							),
 							Effect.catchTag('EmailNotSendable', e =>
 								Effect.die(new ToolMessage(refusalMessage(e.reason))),
 							),

--- a/apps/server/src/services/email-harness.ts
+++ b/apps/server/src/services/email-harness.ts
@@ -1,0 +1,202 @@
+// Shared harness for the EmailService integration suites: the stand-ins a send
+// path needs, the organisation a request runs as, and the transaction that puts
+// the database role and the organisation id on the connection.
+//
+// Not a test file itself; imported by the `*.integration.test.ts` suites.
+//
+// One SqlClient throughout, deliberately. `enterOrgScope` sets the role and
+// `app.current_org_id` on the connection it is handed, so a service built over
+// a second `PgLive` would run its queries on a different connection and neither
+// would apply — the suite would read as though it runs inside the
+// organisation's own scope while actually running as the owner, and would go
+// green on a query that had lost its organisation filter. So `PgLive` is
+// provided once, at the top, and everything below builds over it.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+import {
+	BadRequest,
+	CurrentOrg,
+	GrantConnectFailed,
+	SessionContext,
+} from '@batuda/controllers'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+import { CalendarService } from './calendar.js'
+import { CredentialCrypto } from './credential-crypto.js'
+import { EmailService } from './email.js'
+import {
+	EmailAttachmentStaging,
+	type ResolvedStaging,
+} from './email-attachment-staging.js'
+import { DraftStore } from './email-draft-store.js'
+import { EmailProvider } from './email-provider.js'
+import { MailTransport, type OutboundMessage } from './mail-transport.js'
+import { StorageProvider } from './storage-provider.js'
+import { TimelineActivityService } from './timeline-activity.js'
+
+/** What the transport was handed, for suites that assert on the wire message. */
+export type SentMessage = OutboundMessage
+
+/**
+ * What the email service is built over here: stand-ins for everything a send
+ * path reaches outside the database, and the real draft store, which is worth
+ * exercising because these suites send drafts.
+ *
+ * `onSend` sees each outgoing message and answers with the Message-ID the
+ * transport should report, the way SMTP does. A suite that only reads never
+ * passes one, and gets a fresh id each time — two sends answering with the
+ * same id would collide on the unique index over (organisation, message id).
+ */
+export interface HarnessOptions {
+	/** Sees each outgoing message and answers with the Message-ID to report. */
+	readonly onSend?: (message: SentMessage) => string
+	/**
+	 * What the staging service answers with at send time. Empty by default, so
+	 * nothing downstream of it runs — set it to reach the attachment paths.
+	 */
+	readonly stagedAttachments?: readonly ResolvedStaging[]
+	/**
+	 * Makes the post-send purge fail with this message, for asserting what a
+	 * failed purge leaves behind. The send itself must still succeed.
+	 */
+	readonly purgeFailure?: string
+	/**
+	 * Makes the transport refuse the message, with this as the reason the mail
+	 * server gave. Note the send path retries before giving up, so a test using
+	 * this needs a generous timeout.
+	 */
+	readonly sendFailure?: string
+}
+
+export const emailDependencies = (options?: HarnessOptions) =>
+	Layer.mergeAll(
+		Layer.succeed(CredentialCrypto, {
+			encryptPassword: () => ({
+				ciphertext: new Uint8Array([0]),
+				nonce: new Uint8Array([0]),
+				tag: new Uint8Array([0]),
+			}),
+			decryptPassword: () => 'stubbed-password',
+		} as never),
+		Layer.succeed(MailTransport, {
+			probe: () => Effect.void,
+			send: (_credentials: unknown, message: SentMessage) =>
+				options?.sendFailure === undefined
+					? Effect.sync(() => ({
+							messageId:
+								options?.onSend?.(message) ??
+								`<harness-sent-${randomUUID()}@taller.test>`,
+							raw: new Uint8Array([0]),
+						}))
+					: // The shape the transport actually fails with: the reason lives
+						// in `detail` and the error carries no message of its own, so a
+						// test built on a plain Error would pass on text production
+						// never produces.
+						Effect.fail(
+							new GrantConnectFailed({
+								inboxId: 'harness-inbox',
+								detail: options.sendFailure,
+							}),
+						),
+			appendToSent: () => Effect.void,
+		} as never),
+		Layer.succeed(StorageProvider, { put: () => Effect.void } as never),
+		Layer.succeed(EmailAttachmentStaging, {
+			resolve: () => Effect.succeed(options?.stagedAttachments ?? []),
+			markSentAndCleanup: () =>
+				options?.purgeFailure === undefined
+					? Effect.void
+					: Effect.fail(new BadRequest({ message: options.purgeFailure })),
+		} as never),
+		Layer.succeed(TimelineActivityService, {
+			record: () => Effect.void,
+		} as never),
+		Layer.succeed(EmailProvider, {} as never),
+		Layer.succeed(CalendarService, {} as never),
+		DraftStore.layer,
+	)
+
+/** The email service over those, still wanting a SqlClient from above. */
+export const emailServiceLayer = (options?: HarnessOptions) =>
+	EmailService.layer.pipe(Layer.provide(emailDependencies(options)))
+
+/** Who the request is from, as the middleware would have established it. */
+export const actingAs = (args: {
+	readonly orgId: string
+	readonly orgName: string
+	readonly orgSlug: string
+	readonly userId: string
+}) =>
+	Layer.mergeAll(
+		Layer.succeed(CurrentOrg, {
+			id: args.orgId,
+			name: args.orgName,
+			slug: args.orgSlug,
+			role: 'owner',
+		}),
+		Layer.succeed(SessionContext, {
+			userId: args.userId,
+			email: `${args.userId}@test.local`,
+			name: undefined,
+			isAgent: false,
+		}),
+	)
+
+export interface AsOrg extends HarnessOptions {
+	readonly orgId: string
+	readonly orgName: string
+	readonly orgSlug: string
+	readonly userId: string
+}
+
+/**
+ * A suite's runtime: the database client, the email service over its stand-ins,
+ * and the session, all built once and shared by every test in the file.
+ *
+ * Built once because building it opens a connection pool. Wrapping each call in
+ * `Effect.provide` instead would stand a fresh pool up and tear it down per
+ * assertion, which on a suite of fifty is fifty pools for one file's worth of
+ * queries. Call `dispose()` in `afterAll`.
+ */
+export const makeOrgRuntime = (args: AsOrg) =>
+	ManagedRuntime.make(
+		Layer.mergeAll(actingAs(args), emailServiceLayer(args)).pipe(
+			// provideMerge, not provide: PgLive both feeds the service layer and
+			// stays visible to the caller, so the connection the org scope is
+			// entered on is the one the service queries through. Two builds would
+			// put the role and the organisation id on a connection nothing uses.
+			Layer.provideMerge(PgLive),
+		),
+	)
+
+export type OrgRuntime = ReturnType<typeof makeOrgRuntime>
+
+/**
+ * An effect wrapped the way a request wraps one: inside the organisation's own
+ * database scope. Left as an effect so a caller can take the failure as an Exit.
+ */
+export const scopedAsOrg = <A, E>(
+	args: AsOrg,
+	effect: Effect.Effect<
+		A,
+		E,
+		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
+	>,
+) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		return yield* enterOrgScope(sql, {
+			org: {
+				id: args.orgId,
+				name: args.orgName,
+				slug: args.orgSlug,
+			} as never,
+			userId: args.userId,
+			role: 'owner',
+		})(effect)
+	})

--- a/apps/server/src/services/email-search.integration.test.ts
+++ b/apps/server/src/services/email-search.integration.test.ts
@@ -11,15 +11,20 @@ process.env['DATABASE_URL'] ??=
 
 import { randomUUID } from 'node:crypto'
 
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
 import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { EmailService } from './email.js'
+import { makeOrgRuntime, scopedAsOrg } from './email-harness.js'
 
 const DATABASE_URL =
 	process.env['DATABASE_URL'] ??
 	'postgresql://batuda:batuda@localhost:5433/batuda'
 
-const ORG_ID = `test-org-${randomUUID()}`
-const ACME_DOMAIN = `acme-${randomUUID()}.example`
+const ORG_ID = 'email-search-test-org'
+const ACME_DOMAIN = 'acme-search.test'
 
 let pool: pg.Pool
 let inboxId: string
@@ -28,36 +33,31 @@ let subjectOnlyThreadId: string
 let recipientOnlyThreadId: string
 let accentedThreadId: string
 
-// Mirrors the FTS WHERE branch in apps/server/src/services/email.ts:listThreads.
-// Returns the matched thread_link ids for `q` scoped to ORG_ID.
-const searchThreads = async (q: string): Promise<string[]> => {
-	const rows = await pool.query<{ id: string }>(
-		`
-		SELECT tl.id
-		FROM email_thread_links tl
-		WHERE tl.organization_id = $1
-		  AND (
-		    EXISTS (
-		      SELECT 1 FROM email_messages em
-		      WHERE em.organization_id = tl.organization_id
-		        AND (em.message_id = tl.external_thread_id
-		             OR em."references" @> ARRAY[tl.external_thread_id]::text[])
-		        AND em.search_vector @@ plainto_tsquery('simple', $2)
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM email_messages em2
-		      JOIN message_participants mp ON mp.email_message_id = em2.id
-		      WHERE em2.organization_id = tl.organization_id
-		        AND (em2.message_id = tl.external_thread_id
-		             OR em2."references" @> ARRAY[tl.external_thread_id]::text[])
-		        AND mp.email_address ILIKE $3
-		    )
-		  )
-		`,
-		[ORG_ID, q, `%${q}%`],
+// The search the app actually runs, not a copy of it. This file used to hold
+// its own transcription of that query, which meant it kept passing while the
+// real one changed underneath — the test could not fail for the thing it was
+// written to protect. Everything below goes through the service instead, inside
+// the same organisation scope a request runs in.
+const asOrg = {
+	orgId: ORG_ID,
+	orgName: 'Search Test',
+	orgSlug: 'search-test',
+	userId: 'search-user',
+} as const
+
+const runtime = makeOrgRuntime(asOrg)
+
+const searchThreads = (q: string): Promise<string[]> =>
+	runtime.runPromise(
+		scopedAsOrg(
+			asOrg,
+			Effect.gen(function* () {
+				const emails = yield* EmailService
+				const page = yield* emails.listThreads({ query: q })
+				return page.items.map(t => t.id)
+			}),
+		),
 	)
-	return rows.rows.map(r => r.id)
-}
 
 const insertThreadWithMessage = async (args: {
 	externalThreadId: string
@@ -168,6 +168,37 @@ afterAll(async () => {
 	)
 	await pool.query(`DELETE FROM inboxes WHERE organization_id = $1`, [ORG_ID])
 	await pool.end()
+	await runtime.dispose()
+})
+
+describe('the scope these searches run in', () => {
+	describe('when the harness enters an organisation', () => {
+		it('should put the role and the organisation on the connection the query uses', async () => {
+			// GIVEN the harness, which runs an effect the way a request runs
+			// WHEN it asks the database who it is and which organisation it is in
+			const identity = await runtime.runPromise(
+				scopedAsOrg(
+					asOrg,
+					Effect.gen(function* () {
+						const sql = yield* SqlClient.SqlClient
+						const rows = yield* sql<{
+							who: string
+							org: string
+						}>`SELECT current_user AS who, current_setting('app.current_org_id', true) AS org`
+						return rows[0]
+					}).pipe(Effect.orDie),
+				),
+			)
+
+			// THEN both are set, on the same connection the searches below run on
+			// AND this is what makes row-level security real here rather than
+			// decorative: built over a second client, the scope would be set on a
+			// connection nothing queries, and a search that had lost its
+			// organisation filter would still look correct
+			expect(identity?.who).toBe('app_user')
+			expect(identity?.org).toBe(ORG_ID)
+		})
+	})
 })
 
 describe('email search — full-text', () => {

--- a/apps/server/src/services/email-send-retry.test.ts
+++ b/apps/server/src/services/email-send-retry.test.ts
@@ -2,7 +2,7 @@ import { Cause, Effect, Exit, Fiber, Ref } from 'effect'
 import { TestClock } from 'effect/testing'
 import { describe, expect, it } from 'vitest'
 
-import { retrySmtpSend, type SmtpSendFailed } from './email'
+import { retrySmtpSend, type SmtpSendFailed, smtpFailureReason } from './email'
 
 const extractFailure = <E>(cause: Cause.Cause<E>): E | null => {
 	let found: E | null = null
@@ -109,5 +109,50 @@ describe('retrySmtpSend', () => {
 				Effect.provide(TestClock.layer()),
 				Effect.runPromise,
 			))
+	})
+})
+
+describe('smtpFailureReason', () => {
+	describe('when the mail server gave a reason', () => {
+		it('should hand back that reason and nothing else', () => {
+			// GIVEN the shape the transport fails with: the reason lives in a
+			// field of its own and the error carries no message
+			// WHEN the reason is read off it
+			// THEN it comes back on its own — no error name, and above all no
+			// stack, which is what would otherwise reach a person or an
+			// assistant reading why their message did not go
+			const reason = smtpFailureReason({
+				_tag: 'GrantConnectFailed',
+				inboxId: 'i',
+				detail: 'code=ECONNREFUSED response=550 mailbox not found',
+			})
+			expect(reason).toBe('code=ECONNREFUSED response=550 mailbox not found')
+			expect(reason).not.toContain('\n')
+			expect(reason).not.toContain('    at ')
+		})
+	})
+
+	describe('when it gave none', () => {
+		it('should say so with an empty answer rather than invent one', () => {
+			// GIVEN a failure with nothing in that field, and something that is
+			// not a classified failure at all
+			// THEN both come back empty, so the caller picks its own stand-in —
+			// a log line wants the cause and its frames, a sentence written for
+			// somebody to read wants neither
+			expect(smtpFailureReason({ detail: null })).toBe('')
+			expect(smtpFailureReason({ detail: '   ' })).toBe('')
+			expect(smtpFailureReason(new Error('boom'))).toBe('')
+			expect(smtpFailureReason(undefined)).toBe('')
+		})
+	})
+
+	describe('when the reason runs long', () => {
+		it('should cut it so one refusal cannot fill the log', () => {
+			// GIVEN a mail server that answers with far more than it should
+			// THEN what comes back is bounded, and says it was cut
+			const reason = smtpFailureReason({ detail: 'x'.repeat(5_000) })
+			expect(reason.length).toBeLessThan(600)
+			expect(reason.endsWith('…')).toBe(true)
+		})
 	})
 })

--- a/apps/server/src/services/email-threading.integration.test.ts
+++ b/apps/server/src/services/email-threading.integration.test.ts
@@ -14,19 +14,12 @@ import { Cause, Effect, Exit, Layer, Logger, References } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
-import { CurrentOrg, SessionContext } from '@batuda/controllers'
+import type { CurrentOrg, SessionContext } from '@batuda/controllers'
 
 import { PgLive } from '../db/client.js'
-import { enterOrgScope } from '../middleware/org.js'
-import { CalendarService } from './calendar.js'
-import { CredentialCrypto } from './credential-crypto.js'
 import { EmailService } from './email.js'
-import { EmailAttachmentStaging } from './email-attachment-staging.js'
-import { DraftStore } from './email-draft-store.js'
-import { EmailProvider } from './email-provider.js'
-import { MailTransport, type OutboundMessage } from './mail-transport.js'
-import { StorageProvider } from './storage-provider.js'
-import { TimelineActivityService } from './timeline-activity.js'
+import { makeOrgRuntime, scopedAsOrg } from './email-harness.js'
+import type { OutboundMessage } from './mail-transport.js'
 
 const ORG = 'threading-test-org'
 // A second tenant, so "the conversation belongs to somebody else" is a real
@@ -38,93 +31,26 @@ const USER = 'threading-user'
 let lastOutbound: OutboundMessage | null = null
 let sentCount = 0
 
-const stubCrypto = Layer.succeed(CredentialCrypto, {
-	encryptPassword: () => ({
-		ciphertext: new Uint8Array([0]),
-		nonce: new Uint8Array([0]),
-		tag: new Uint8Array([0]),
-	}),
-	decryptPassword: () => 'stubbed-password',
-} as never)
+// One harness, shared with the other EmailService suites — see
+// `email-harness.ts` for why the SqlClient has to be the same one the org
+// scope is entered on.
+const asOrg = {
+	orgId: ORG,
+	orgName: 'Threading Test',
+	orgSlug: 'threading-test',
+	userId: USER,
+	// Records the outgoing message and answers with a Message-ID the way SMTP
+	// does. Numbered, so two sends in one test cannot collide on the unique
+	// index over (organisation, message id).
+	onSend: (message: OutboundMessage) => {
+		lastOutbound = message
+		sentCount += 1
+		return `<threading-sent-${sentCount}@taller.test>`
+	},
+} as const
 
-// Records the outgoing message instead of sending it, and hands back a
-// Message-ID the way SMTP does.
-const stubTransport = Layer.succeed(MailTransport, {
-	probe: () => Effect.void,
-	send: (_creds: unknown, message: OutboundMessage) =>
-		Effect.sync(() => {
-			lastOutbound = message
-			sentCount += 1
-			return {
-				messageId: `<threading-sent-${sentCount}@taller.test>`,
-				raw: new Uint8Array([0]),
-			}
-		}),
-	appendToSent: () => Effect.void,
-} as never)
-
-const stubStorage = Layer.succeed(StorageProvider, {
-	put: () => Effect.void,
-} as never)
-
-const stubStaging = Layer.succeed(EmailAttachmentStaging, {
-	resolve: () => Effect.succeed([]),
-	markSentAndCleanup: () => Effect.void,
-} as never)
-
-const stubTimeline = Layer.succeed(TimelineActivityService, {
-	record: () => Effect.void,
-} as never)
-
-const serviceLayer = EmailService.layer.pipe(
-	Layer.provide([
-		stubCrypto,
-		stubTransport,
-		stubStorage,
-		stubStaging,
-		stubTimeline,
-		Layer.succeed(EmailProvider, {} as never),
-		DraftStore.layer.pipe(Layer.provide(PgLive)),
-		Layer.succeed(CalendarService, {} as never),
-	]),
-	Layer.provide(PgLive),
-)
-
-const actingAs = Layer.mergeAll(
-	Layer.succeed(CurrentOrg, {
-		id: ORG,
-		name: 'Threading Test',
-		slug: 'threading-test',
-		role: 'owner',
-	}),
-	Layer.succeed(SessionContext, {
-		userId: USER,
-		email: `${USER}@test.local`,
-		name: undefined,
-		isAgent: false,
-	}),
-)
-
-// Run the way a request does, inside the organization's own database scope.
-const scoped = <A, E>(
-	effect: Effect.Effect<
-		A,
-		E,
-		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
-	>,
-) =>
-	Effect.gen(function* () {
-		const sql = yield* SqlClient.SqlClient
-		return yield* enterOrgScope(sql, {
-			org: {
-				id: ORG,
-				name: 'Threading Test',
-				slug: 'threading-test',
-			} as never,
-			userId: USER,
-			role: 'owner',
-		})(effect.pipe(Effect.provide(serviceLayer), Effect.provide(actingAs)))
-	}).pipe(Effect.provide(PgLive))
+// Built once for the file; disposed in afterAll.
+const runtime = makeOrgRuntime(asOrg)
 
 const run = <A, E>(
 	effect: Effect.Effect<
@@ -132,7 +58,7 @@ const run = <A, E>(
 		E,
 		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
 	>,
-) => Effect.runPromise(scoped(effect))
+) => runtime.runPromise(scopedAsOrg(asOrg, effect))
 
 const runExit = <A, E>(
 	effect: Effect.Effect<
@@ -140,7 +66,7 @@ const runExit = <A, E>(
 		E,
 		EmailService | SqlClient.SqlClient | CurrentOrg | SessionContext
 	>,
-) => Effect.runPromiseExit(scoped(effect))
+) => runtime.runPromiseExit(scopedAsOrg(asOrg, effect))
 
 const sqlOnly = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
 	Effect.runPromise(effect.pipe(Effect.provide(PgLive)))
@@ -412,6 +338,7 @@ afterAll(async () => {
 			yield* sql`DELETE FROM organization WHERE id IN (${ORG}, ${OTHER_ORG})`
 		}),
 	)
+	await runtime.dispose()
 })
 
 describe('EmailService.reply', () => {
@@ -1063,11 +990,16 @@ describe('replying twice on the same conversation', () => {
 		// GIVEN a conversation that has already been answered once, so the
 		// message being answered now is our own
 		const threadId = await seedTwoMessageThread(null)
-		await reply(threadId)
+		// Both sends are checked before anything is read off the transport.
+		// `reply` hands back an Exit rather than throwing, and the assertions
+		// below read the last message the transport was given — so a send that
+		// failed would leave the previous one in place and be reported as a
+		// chain that did not grow, which says nothing about why.
+		expect(await reply(threadId)).toSatisfy(Exit.isSuccess)
 		const firstSent = lastOutbound?.references ?? []
 
 		// WHEN a second reply goes out
-		await reply(threadId)
+		expect(await reply(threadId)).toSatisfy(Exit.isSuccess)
 
 		// THEN it carries everything the first one did, plus the first reply
 		// itself — the chain grows rather than resetting to two entries
@@ -1081,10 +1013,11 @@ describe('replying twice on the same conversation', () => {
 	})
 
 	it('should store the headers each message actually carried', async () => {
-		// GIVEN two replies on one conversation
+		// GIVEN two replies on one conversation, both checked before the rows
+		// they wrote are read — see the test above for why
 		const threadId = await seedTwoMessageThread(null)
-		await reply(threadId)
-		await reply(threadId)
+		expect(await reply(threadId)).toSatisfy(Exit.isSuccess)
+		expect(await reply(threadId)).toSatisfy(Exit.isSuccess)
 
 		// THEN each stored row says what went on the wire, not a shorter chain
 		// invented afterwards — the next reply reads these back
@@ -1187,6 +1120,172 @@ describe('a conversation whose subject is only blank space', () => {
 	})
 })
 
+describe('the record a send that never got through leaves', () => {
+	// "Are messages reaching people" cannot be answered without this line. It
+	// is also the one the doc's email-failure alert counts, and until it
+	// existed a send that never got through left nothing on the outbound path
+	// at all — only whatever status the caller's request happened to end on.
+	const REFUSAL = '550 5.1.1 <pep@calpepfonda.cat> mailbox not found'
+	const FAILING_ORG = {
+		orgId: ORG,
+		orgName: 'Threading Test',
+		orgSlug: 'threading-test',
+		userId: USER,
+		sendFailure: REFUSAL,
+	} as const
+
+	const failingSend = makeOrgRuntime(FAILING_ORG)
+	afterAll(async () => {
+		await failingSend.dispose()
+	})
+
+	it('should name it, and keep the address off the fields it files it under', async () => {
+		// GIVEN a mail server that refuses the message, naming the recipient
+		// the way a mail server does
+		const threadId = await seedThread({
+			linkSubject: 'your pallet pools',
+			messages: [{ messageId: ROOT_ID, subject: 'your pallet pools' }],
+		})
+
+		const lines: Array<{
+			level: string
+			message: string
+			annotations: Record<string, unknown>
+		}> = []
+		const capture = Logger.layer([
+			Logger.make(options => {
+				lines.push({
+					level: String(options.logLevel),
+					message: String(options.message),
+					annotations: options.fiber.getRef(
+						References.CurrentLogAnnotations,
+					) as Record<string, unknown>,
+				})
+			}),
+		]).pipe(
+			Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
+		)
+
+		// WHEN the send is attempted
+		const exit = await failingSend.runPromiseExit(
+			scopedAsOrg(
+				FAILING_ORG,
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.reply(threadId, body)
+				}),
+			).pipe(Effect.provide(capture)) as Effect.Effect<unknown, unknown, never>,
+		)
+
+		// THEN the send failed
+		expect(Exit.isFailure(exit)).toBe(true)
+
+		// AND it is on a line of its own, named, at error level
+		const failed = lines.find(l => l.annotations['event'] === 'email.failed')
+		expect(failed).toBeDefined()
+		expect(failed?.level).toBe('Error')
+		expect(failed?.annotations['inboxId']).toBeDefined()
+
+		// AND the line says WHY. The classified error keeps its reason in a
+		// field of its own and carries no message, so rendering the cause alone
+		// gives the error's name and a stack — a line saying a send failed and
+		// not what the mail server said, which is the whole of what is needed
+		// to fix it.
+		expect(failed?.message).toContain('mailbox not found')
+
+		// AND no field it is filed under carries the recipient. A mail server
+		// names the address in its refusal, and that text is the one thing kept
+		// verbatim — but it must not become a field anything is grouped by,
+		// which is how an address ends up in a dashboard.
+		const fields = JSON.stringify(failed?.annotations ?? {})
+		expect(fields).not.toContain('pep@calpepfonda.cat')
+		expect(fields).not.toContain('@')
+	}, 30_000)
+})
+
+describe('the record a failed clean-up leaves', () => {
+	// The message is already on its way when the clean-up runs, so a clean-up
+	// that fails must not fail the send. Swallowing it whole left nothing to
+	// count by, and rows and bytes accumulate with no signal at all.
+	const PURGE_ORG = {
+		orgId: ORG,
+		orgName: 'Threading Test',
+		orgSlug: 'threading-test',
+		userId: USER,
+		onSend: (message: OutboundMessage) => {
+			lastOutbound = message
+			sentCount += 1
+			return `<threading-purge-${sentCount}@taller.test>`
+		},
+		stagedAttachments: [
+			{
+				stagingId: 'staged-1',
+				inline: false,
+				cid: null,
+				filename: 'quote.pdf',
+				contentType: 'application/pdf',
+				contentBase64: 'JVBERi0=',
+			},
+		],
+		purgeFailure: 'storage unreachable',
+	} as const
+
+	const failingPurge = makeOrgRuntime(PURGE_ORG)
+	afterAll(async () => {
+		await failingPurge.dispose()
+	})
+
+	it('should still send, and say so on a line telemetry can count', async () => {
+		// GIVEN a message with an attachment, whose clean-up will fail
+		const threadId = await seedThread({
+			linkSubject: 'your pallet pools',
+			messages: [{ messageId: ROOT_ID, subject: 'your pallet pools' }],
+		})
+
+		const lines: Array<{
+			level: string
+			annotations: Record<string, unknown>
+		}> = []
+		const capture = Logger.layer([
+			Logger.make(options => {
+				lines.push({
+					level: String(options.logLevel),
+					annotations: options.fiber.getRef(
+						References.CurrentLogAnnotations,
+					) as Record<string, unknown>,
+				})
+			}),
+		]).pipe(
+			Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
+		)
+
+		// WHEN it is sent
+		const exit = await failingPurge.runPromiseExit(
+			scopedAsOrg(
+				PURGE_ORG,
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.reply(threadId, body)
+				}),
+			).pipe(Effect.provide(capture)) as Effect.Effect<unknown, unknown, never>,
+		)
+
+		// THEN the send succeeded — the recipient already has it, so failing
+		// here would report a message undelivered that was in fact delivered
+		expect(Exit.isSuccess(exit)).toBe(true)
+
+		// AND the failure is on a line of its own, named, with enough on it to
+		// tell which mailbox and how much was left behind
+		const warned = lines.find(
+			l => l.annotations['event'] === 'email.staging_purge_failed',
+		)
+		expect(warned).toBeDefined()
+		expect(warned?.level).toBe('Warn')
+		expect(warned?.annotations['staged']).toBe(1)
+		expect(warned?.annotations['inboxId']).toBeDefined()
+	})
+})
+
 describe('the record a refused send leaves', () => {
 	// A message that never went out is still something that happened on the
 	// outbound path, so it says so on a line of its own — the way a send that
@@ -1209,8 +1308,8 @@ describe('the record a refused send leaves', () => {
 		]).pipe(
 			Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
 		)
-		await Effect.runPromiseExit(
-			scoped(effect).pipe(Effect.provide(capture)) as Effect.Effect<
+		await runtime.runPromiseExit(
+			scopedAsOrg(asOrg, effect).pipe(Effect.provide(capture)) as Effect.Effect<
 				unknown,
 				unknown,
 				never

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import {
+	Cause,
 	Context,
 	Data,
 	DateTime,
@@ -31,6 +32,8 @@ import {
 import { EmailDraft, Inbox, InboxFooter, isOrgManager } from '@batuda/domain'
 import { renderBlocks, type StagedAttachmentRef } from '@batuda/email/render'
 import type { EmailBlocks } from '@batuda/email/schema'
+import { isReplySubject, withReplyPrefix } from '@batuda/email/subject'
+import { boundedCause } from '@batuda/observability'
 
 import {
 	type CountMode,
@@ -129,6 +132,35 @@ export const smtpRetrySchedule = Schedule.exponential('1 second', 2).pipe(
 	Schedule.upTo({ times: 3 }),
 )
 
+// Long enough for any reason a mail server gives, short enough that a hostile
+// one cannot fill the log exporter.
+const MAX_REASON_CHARS = 500
+
+/**
+ * What the mail server said, or an empty string when it said nothing.
+ *
+ * The classified failure keeps its reason in `detail` and carries no message of
+ * its own, so anything rendering the error alone gets its name and a stack —
+ * which says a send failed and not why, which is the whole of what somebody
+ * needs to fix it. Callers decide how to stand in for an absent reason: a log
+ * line wants the cause and its frames, a sentence for the caller wants neither.
+ */
+export const smtpFailureReason = (cause: unknown): string => {
+	const detail =
+		typeof cause === 'object' &&
+		cause !== null &&
+		'detail' in cause &&
+		typeof cause.detail === 'string'
+			? cause.detail.trim()
+			: ''
+	// Kept as plain text. Handing it to the cause renderer instead would wrap it
+	// in an error raised here, and print this function's own stack under every
+	// failed send — frames that point at the reporting, not at the failure.
+	return detail.length <= MAX_REASON_CHARS
+		? detail
+		: `${detail.slice(0, MAX_REASON_CHARS)}…`
+}
+
 export const retrySmtpSend = <A, E>(
 	send: Effect.Effect<A, E>,
 	inboxId: string,
@@ -149,15 +181,6 @@ export const retrySmtpSend = <A, E>(
 // the most recent links rather than letting the header grow without end, which
 // is what mail clients do.
 const MAX_REFERENCES = 20
-
-// One rule for "does this subject already read as a reply", used everywhere a
-// subject is prefixed or judged. Three slightly different spellings of it used
-// to disagree: a subject written "Re : quote" was left alone on one send path
-// and stacked into "Re: Re : quote" on another.
-const REPLY_PREFIX = /^\s*re\s*:/i
-
-const withReplyPrefix = (subject: string): string =>
-	REPLY_PREFIX.test(subject) ? subject : `Re: ${subject}`
 
 export const buildReferences = (args: {
 	readonly root: string
@@ -218,7 +241,7 @@ export const assertSendable = (message: {
 		// and filters test for exactly this pairing.
 		const answersNothing =
 			!message.inReplyTo && (message.references?.length ?? 0) === 0
-		if (REPLY_PREFIX.test(subject) && answersNothing) {
+		if (isReplySubject(subject) && answersNothing) {
 			return yield* new EmailNotSendable({ reason: 'forged_reply' })
 		}
 	})
@@ -993,9 +1016,27 @@ export class EmailService extends Context.Service<EmailService>()(
 						),
 					)
 					const creds = yield* loadDecryptedCreds(inbox)
+					// A send that never got through is the one thing the outbound
+					// path most needs counted — "are messages reaching people" is
+					// unanswerable without it, and the failure otherwise shows up
+					// only as whatever status the caller's request ended on.
 					const sent = yield* retrySmtpSend(
 						transport.send(creds, message),
 						inbox.id,
+					).pipe(
+						Effect.tapError(failure =>
+							Effect.logError(
+								`Sending a message failed: ${
+									smtpFailureReason(failure.cause) ||
+									boundedCause(Cause.fail(failure.cause))
+								}`,
+							).pipe(
+								Effect.annotateLogs({
+									event: 'email.failed',
+									inboxId: inbox.id,
+								}),
+							),
+						),
 					)
 					const messageId = sent.messageId
 					const key = sentRawKey(inbox.organizationId, inbox.id)
@@ -1004,8 +1045,14 @@ export class EmailService extends Context.Service<EmailService>()(
 						.pipe(
 							Effect.catchCause(cause =>
 								Effect.logWarning(
-									`outbound raw upload failed inbox=${inbox.id} key=${key}`,
-								).pipe(Effect.andThen(Effect.logError(cause))),
+									'Keeping a copy of a sent message failed',
+								).pipe(
+									Effect.andThen(Effect.logError(boundedCause(cause))),
+									Effect.annotateLogs({
+										event: 'email.sent_copy_failed',
+										inboxId: inbox.id,
+									}),
+								),
 							),
 						)
 					yield* transport
@@ -1280,9 +1327,23 @@ export class EmailService extends Context.Service<EmailService>()(
 						})
 
 						if (staged.length > 0) {
+							// The message is already gone, so a purge that fails must not
+							// fail the send — but it leaves rows and bytes behind, and
+							// swallowing it whole left nothing to count that by.
 							yield* staging
 								.markSentAndCleanup(staged.map(s => s.stagingId))
-								.pipe(Effect.ignore)
+								.pipe(
+									Effect.ignore({
+										log: 'Warn',
+										message:
+											'Staged attachments outlived the message they went with',
+									}),
+									Effect.annotateLogs({
+										event: 'email.staging_purge_failed',
+										inboxId: inbox.id,
+										staged: staged.length,
+									}),
+								)
 						}
 
 						yield* Effect.logInfo('Email sent').pipe(
@@ -1447,19 +1508,18 @@ export class EmailService extends Context.Service<EmailService>()(
 						// whose messages never carried a subject to borrow: without it
 						// this would be empty, and the guard in `dispatchOutbound`
 						// would refuse the send with nothing the caller could do.
-						const chosenSubject = extras?.subject
-						const borrowedSubject = link.subject
-							? withReplyPrefix(link.subject)
-							: ''
-						const fallbackSubject = extras?.fallbackSubject
-						const replySubject =
-							chosenSubject && chosenSubject.trim() !== ''
-								? chosenSubject
-								: borrowedSubject !== ''
-									? borrowedSubject
-									: fallbackSubject && fallbackSubject.trim() !== ''
-										? withReplyPrefix(fallbackSubject)
-										: ''
+						// Each one trimmed before it is judged, or a subject of nothing
+						// but spaces reads as a real one and goes out as a bare "Re:".
+						const chosenSubject = extras?.subject?.trim()
+						const borrowedSubject = link.subject?.trim()
+						const fallbackSubject = extras?.fallbackSubject?.trim()
+						const replySubject = chosenSubject
+							? chosenSubject
+							: borrowedSubject
+								? withReplyPrefix(borrowedSubject)
+								: fallbackSubject
+									? withReplyPrefix(fallbackSubject)
+									: ''
 
 						const outbound: OutboundMessage = {
 							from: inbox.email,
@@ -1511,9 +1571,23 @@ export class EmailService extends Context.Service<EmailService>()(
 						})
 
 						if (staged.length > 0) {
+							// The message is already gone, so a purge that fails must not
+							// fail the send — but it leaves rows and bytes behind, and
+							// swallowing it whole left nothing to count that by.
 							yield* staging
 								.markSentAndCleanup(staged.map(s => s.stagingId))
-								.pipe(Effect.ignore)
+								.pipe(
+									Effect.ignore({
+										log: 'Warn',
+										message:
+											'Staged attachments outlived the message they went with',
+									}),
+									Effect.annotateLogs({
+										event: 'email.staging_purge_failed',
+										inboxId: inbox.id,
+										staged: staged.length,
+									}),
+								)
 						}
 
 						yield* Effect.logInfo('Email reply sent').pipe(
@@ -3072,13 +3146,14 @@ export class EmailService extends Context.Service<EmailService>()(
 						// A draft answering a thread borrows that thread's subject when
 						// the writer left it blank, so it goes out as "Re: …" rather
 						// than with no subject line at all.
-						const threadSubject = existingThreadLink?.subject ?? null
-						const draftSubject =
-							draft.subject && draft.subject.trim() !== ''
-								? draft.subject
-								: threadSubject
-									? withReplyPrefix(threadSubject)
-									: ''
+						// Both trimmed before they are judged, or a subject of nothing
+						// but spaces reads as a real one and goes out as a bare "Re:".
+						const threadSubject = existingThreadLink?.subject?.trim()
+						const draftSubject = draft.subject?.trim()
+							? draft.subject.trim()
+							: threadSubject
+								? withReplyPrefix(threadSubject)
+								: ''
 
 						const outbound: OutboundMessage = {
 							from: inbox.email,
@@ -3139,9 +3214,23 @@ export class EmailService extends Context.Service<EmailService>()(
 						})
 
 						if (staged.length > 0) {
+							// The message is already gone, so a purge that fails must not
+							// fail the send — but it leaves rows and bytes behind, and
+							// swallowing it whole left nothing to count that by.
 							yield* staging
 								.markSentAndCleanup(staged.map(s => s.stagingId))
-								.pipe(Effect.ignore)
+								.pipe(
+									Effect.ignore({
+										log: 'Warn',
+										message:
+											'Staged attachments outlived the message they went with',
+									}),
+									Effect.annotateLogs({
+										event: 'email.staging_purge_failed',
+										inboxId: inbox.id,
+										staged: staged.length,
+									}),
+								)
 						}
 
 						yield* drafts.remove(draftId)

--- a/packages/controllers/src/routes/email.ts
+++ b/packages/controllers/src/routes/email.ts
@@ -463,7 +463,9 @@ export const EmailGroup = HttpApiGroup.make('email')
 				inReplyTo: Schema.optional(Schema.String),
 				companyId: Schema.optional(Schema.String),
 				contactId: Schema.optional(Schema.String),
-				mode: Schema.optional(Schema.String),
+				// The same two values the MCP tool accepts and the database
+				// constrains the column to; the two surfaces disagreed before.
+				mode: Schema.optional(Schema.Literals(['new', 'reply'])),
 				threadLinkId: Schema.optional(Schema.String),
 			}),
 			success: EmailDraft.json,

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -10,6 +10,10 @@
 			"types": "./src/index.ts",
 			"import": "./src/index.ts"
 		},
+		"./subject": {
+			"types": "./src/subject.ts",
+			"import": "./src/subject.ts"
+		},
 		"./schema": {
 			"types": "./src/schema.ts",
 			"import": "./src/schema.ts"

--- a/packages/email/src/subject.test.ts
+++ b/packages/email/src/subject.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { isReplySubject, withReplyPrefix } from './subject'
+
+// One rule, read by the server when it sends and by the web app when it fills
+// the compose window. They each had their own copy before and the copies
+// disagreed: a subject written "Re : quote" was left alone by one and stacked
+// into "Re: Re : quote" by the other.
+
+describe('isReplySubject', () => {
+	describe('when the subject already answers something', () => {
+		it('should recognise every spelling mail clients write', () => {
+			// GIVEN the prefix as it actually arrives
+			// WHEN each is judged
+			// THEN all of them count as a reply
+			// AND "Re :" is the French-typography one the copies disagreed on
+			for (const subject of [
+				'Re: quote',
+				're: quote',
+				'RE: quote',
+				'rE: quote',
+				'Re : quote',
+				'Re\t: quote',
+				'  Re: quote',
+				'Re:',
+			]) {
+				expect(isReplySubject(subject)).toBe(true)
+			}
+		})
+
+		it('should recognise the prefix in the languages clients write it in', () => {
+			// GIVEN the same marker as a German, Dutch, Scandinavian or Polish
+			// client writes it
+			// WHEN each is judged
+			// THEN all count as replies
+			// AND otherwise each gets an English prefix stacked on top of it,
+			// and each slips past the check that refuses a reply answering
+			// nothing — the shape a spam filter reads as forged
+			for (const subject of [
+				'AW: Angebot',
+				'aw: Angebot',
+				'Antw: offerte',
+				'SV: offert',
+				'Odp: oferta',
+			]) {
+				expect(isReplySubject(subject)).toBe(true)
+			}
+		})
+	})
+
+	describe('when the marker doubles as an ordinary word', () => {
+		it('should leave it alone rather than refuse a real message', () => {
+			// GIVEN markers some clients do write, which also read as plain text
+			// WHEN each is judged
+			// THEN none counts as a reply
+			// AND that is the deliberate trade: counting these would refuse
+			// somebody's real message, which costs more than missing a prefix
+			// that is rare in the languages this writes to anyway
+			for (const subject of ['R: Barcelona', 'VS: Barcelona']) {
+				expect(isReplySubject(subject)).toBe(false)
+			}
+		})
+	})
+
+	describe('when the subject only looks like one', () => {
+		it('should not mistake an ordinary word for the prefix', () => {
+			// GIVEN words that begin "re" with no colon straight after
+			// WHEN each is judged
+			// THEN none counts as a reply
+			// AND a false positive here would stack a prefix onto ordinary mail
+			for (const subject of [
+				'Reminder: pay the invoice',
+				'Renewal quote',
+				'Ref: 2026-0114',
+				're',
+				're the pallet pools',
+				'Score: Re: last match',
+			]) {
+				expect(isReplySubject(subject)).toBe(false)
+			}
+		})
+	})
+})
+
+describe('withReplyPrefix', () => {
+	describe('when the subject does not answer anything yet', () => {
+		it('should add the prefix once', () => {
+			// GIVEN a plain subject
+			// THEN it comes back prefixed
+			expect(withReplyPrefix('your pallet pools')).toBe('Re: your pallet pools')
+		})
+	})
+
+	describe('when the subject already answers something', () => {
+		it('should leave it exactly as it is', () => {
+			// GIVEN subjects already marked as replies, however spelled
+			// THEN none is stacked on
+			// AND the spacing the sender chose is preserved rather than rewritten
+			expect(withReplyPrefix('Re: quote')).toBe('Re: quote')
+			expect(withReplyPrefix('re: quote')).toBe('re: quote')
+			expect(withReplyPrefix('Re : quote')).toBe('Re : quote')
+		})
+	})
+})

--- a/packages/email/src/subject.ts
+++ b/packages/email/src/subject.ts
@@ -1,0 +1,26 @@
+// How a subject line says "this answers something".
+//
+// Mail clients write the prefix several ways — "RE:", "re:", and with French
+// typography "Re :" — and every one of them already marks a reply. Reading it
+// one way in one place and another way somewhere else is how a subject ends up
+// stacked into "Re: Re : quote", or how one send path refuses what another
+// allows. So the rule lives here, and the server and the web app both read it.
+//
+// Not every client writes it in English. A German one writes "AW:", a Dutch one
+// "Antw:", a Scandinavian one "SV:", a Polish one "Odp:" — each already a reply,
+// each stacked into "Re: AW: …" by a rule that only knows the English one, and
+// each invisible to the check that refuses a reply answering nothing.
+//
+// The list stays short on purpose. Every entry added is a subject that can no
+// longer be sent as an ordinary message, so a prefix that doubles as a normal
+// word ("R:", "VS:") is left out: refusing somebody's real message costs more
+// than missing a rare prefix.
+const REPLY_PREFIX = /^\s*(?:re|aw|antw|sv|odp)\s*:/i
+
+/** Whether this subject already reads as a reply. */
+export const isReplySubject = (subject: string): boolean =>
+	REPLY_PREFIX.test(subject)
+
+/** The subject a reply goes out under: prefixed once, never twice. */
+export const withReplyPrefix = (subject: string): string =>
+	isReplySubject(subject) ? subject : `Re: ${subject}`


### PR DESCRIPTION
## What

Follow-ups to the send fixes in #528, the findings from reviewing them, and one bug that turned up while verifying: **a conversation could split into two halves that never rejoined**, and **an attachment taken off a message still went out**.

It lives in the CRM's email surface — the mail worker that files arriving messages, the send paths in `server`, and the compose window in `internal`.

## The fix

**A conversation was left as two halves.** A reply that reaches us before the message it answers has nothing on file to hang on, so it starts a conversation of its own; the message it answers then starts a second. This is the ordinary order, not a race: mail is read inbox first and sent folder second (`inbox-session.ts`, `FOLDER_ROLES`), so a reply to anything sent from the account's own mail client arrives first. That is the Infomaniak path issue #520 described.

Filing now looks forward as well as back: if exactly one conversation already holds a message naming the arriving one as an ancestor, it joins that one — and the conversation's key moves onto the arriving message, the one it starts with. That second half matters: membership is read out of the `References` list, so leaving the reply as the key would mean writing the reply into the list of the message it answers, and the two rows would name each other as ancestors. With the key moved, each row stores what its sender actually wrote. **When more than one does, it joins none.** That case is several people replying to a message we do not hold, and joining one of them would file this message — and every later reply to it — under whichever contact answered first. I attempted this fix once before and reverted it for exactly that reason; the difference here is that the ambiguity is visible at the moment it matters, so it can be refused rather than guessed at.

**An attachment taken off a message still went out.** Removing the chip only dropped it from the compose window. Sending reads every file staged against the draft (`email.ts` — `WHERE draft_id = … AND sent_at IS NULL`) rather than that list, so the file still shipped. Reproduced end to end before fixing, and the reproduction is kept as a regression test.

**Two subjects that went out wrong.** A stored subject of nothing but spaces read as a real one and went out as a bare `Re:`. And a reply a German, Dutch, Scandinavian or Polish client had already marked as one (`AW:`, `Antw:`, `SV:`, `Odp:`) got an English prefix stacked on top, and slipped past the check that refuses a reply answering nothing.

**Two ways an email could reach the logs.** A failed ingest wrote its cause down whole — `bounded-cause.ts`'s own comment names this case: "an unbounded one would ship … a whole email to the log exporter". The two neighbouring paths already bounded theirs; this one did not. Same on the outbound copy-to-sent failure.

**A failed send left no record, and told nobody why.** `email.failed` is in the observability guide's event table, its critical-paths table, and its alerting table — and nothing emitted it, so the alert it describes could not have been built. The reason was lost too: the classified failure keeps it in a field of its own and carries no message, so anything rendering the error got its name and a stack. It now reaches both the log and the assistant that asked for the send. That is the whole of #509.

**An arriving message left no record either.** `email.received` is in the same tables and was never emitted, and two of the worker's failure lines carried no event name, so they could not be filtered by kind.

## Impact

- **A database migration.** `0067` adds an index on `email_messages(organization_id, in_reply_to)`, for the half of the new lookup that serves senders who trim the chain to just `In-Reply-To`. **Run migrations before tagging the server.**
- **The pull-request gate now starts the mail catcher.** The forged-reply spec was tagged `@smoke` so it gates a merge, and the smoke job stood the stack up without GreenMail — every PR would have gone red. `with-mail: "true"` is the trade: the catcher's start-up cost on each PR, for a spec covering a shape that reached real prospects.
- **Nothing touching which organisation can see what (row-level security).** Every query keeps its `organization_id` scope, and the Postgres role each path runs under is unchanged.
- **New log lines, no new fields carrying personal data.** `email.received`, `email.failed`, `email.ingest_failed`, `email.folder_read_failed`, `email.staging_purge_failed` and `email.sent_copy_failed`. A mail server names the recipient in its refusal, so that text stays in the line's message — where the guide accepts it — and deliberately does not become a field records get grouped by.
- **No new environment variables, no wire-shape change, no paid-provider change.**

## Review guide

Start with `apps/mail-worker/src/threading.ts`. The forward lookup and the refusal to join when more than one conversation answers are the whole of the conversation fix; everything else is independent.

**The riskiest part is that refusal.** It is what stops one company's mail being filed under another's, and it is the thing my earlier attempt got wrong. `threading.integration.test.ts` covers it directly, including the cross-company case that must *not* join.

**`persist.ts` stopped putting a message's own id at the front of its own `References`.** That looks cosmetic and is not: `threading.ts` orders candidate conversations by where each one appears in that list, oldest first, and prepending the newest id defeated the ordering its own comment describes.

**Skip-able:** `email-harness.ts` is the two suites' layer setup, extracted from `email-threading.integration.test.ts` and now shared. Doing that fixed a real problem — the organisation scope was being entered on one database connection while the service queried on another, so it was decorative. A test now asserts `current_user` and `app.current_org_id` on the connection the queries actually run on.

**A decision you might overrule:** the reply-prefix list deliberately leaves out `R:` and `VS:`, which double as ordinary words. Counting them would refuse somebody's real message, which costs more than missing a prefix that is rare in the languages this writes to.

## Tests

- **Unit:** the reply-prefix rule, including the false positives that matter (`Reminder:`, `Ref:`, `Renewal`) and the prefixes deliberately left out.
- **Integration (real Postgres):** the conversation split end to end — reply first, then the message it answers, one conversation holding both; the cross-company case that must not join; a trimmed `References` chain; the failed clean-up and the failed send, each asserted on the line it leaves and on the fields carrying no address.
- **End-to-end (real browser, real SMTP):** two files attached in one pick both arrive; a file removed before sending does not.
- Each fix was mutation-checked: reverting it fails the tests that name it, including the privacy assertion — putting the recipient into a log field fails it.

## Verification

Rebased onto `origin/main` (`bbf0ab0e61`) and run there:

- `pnpm install` — no lockfile drift
- `pnpm -w check-types` — 13/13
- `pnpm -w test` — 21/21
- `pnpm -w build` — 13/13
- `pnpm test:integration` — 779 server, 41 mail-worker
- `pnpm check` (lint) — clean on every changed file
- Live stack + GreenMail: 16 e2e across attachment, compose, reply, rich-compose and footer
- Live IMAP round-trip through the real parser and ingest path

**A flake on the way in, not mine:** the first CI run failed `research-subject-scope.integration.test.ts`, which this branch does not touch — it passes locally and passed on a re-run. Both jobs are green.

**What I could not settle:** early in the session the full integration suite failed twice in `replying twice on the same conversation` — a test this branch does not touch. It has passed 12 consecutive runs since and I could not reproduce it again; `main` was 4/4 clean, a smaller sample. What I did find and fix is why it presented so badly: `reply()` hands back an `Exit` rather than throwing, so a failed send left the previous message in place and the failure read as "the chain did not grow". Both tests now assert the send succeeded, so a recurrence names the real error. Worth watching on CI.

## Deferred

**Conversations already split in the data are not repaired.** New mail stops splitting, and the key now lands on the right message, but a pair that split before this stays two rows.

This is the one deferred item I deliberately did not solve here, and the reason is the same one that made me revert an earlier attempt: merging two conversations is not the hard part, deciding whether they *may* be merged is. It needs a guard on the mailbox as well as the company — the privacy gate is per-mailbox, so merging across one either hides a conversation from the person who owns it or exposes a private one to everybody. It needs row locks, because two workers can take one organisation's mail in at once. It needs the winner chosen by when the messages arrived rather than when the rows were written, since the split exists precisely because the first message came late. And four separate things hold a conversation's id — a draft, a task, a timeline entry, and the address the web app routes on — so deleting the loser strands all four.

Doing that carefully is a slice of its own. Doing it quickly is how one company's mail ends up under another's name.

Closes #509
