### PR TITLE
fix(research): buy every company a website before anybody a headcount

### DIFF
--- a/packages/research/src/application/existence-verdict.test.ts
+++ b/packages/research/src/application/existence-verdict.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	awaitsConfirmation,
 	existenceOf,
 	isConfirmedRow,
 	markRowsExistence,
 	partitionByExistence,
 	resultNamesCompany,
 	rowExistence,
+	rowsAwaitingConfirmation,
 	withExistence,
 } from './existence-verdict'
 import { runWordsOf } from './run-words'
@@ -783,5 +785,138 @@ describe('partitionByExistence', () => {
 		// GIVEN no rows at all
 		// WHEN split — THEN neither group invents one
 		expect(partitionByExistence([])).toEqual({ confirmed: [], candidates: [] })
+	})
+})
+
+describe('rowsAwaitingConfirmation', () => {
+	// A row the way a scan stores one: its own site, plus the pages it cited.
+	const row = (
+		name: string,
+		website: string | undefined,
+		sources: ReadonlyArray<string>,
+	): Record<string, unknown> => ({
+		name,
+		...(website === undefined ? {} : { website }),
+		citations: sources.map(source_id => ({ source_id })),
+	})
+
+	describe('when some of the list is already settled', () => {
+		it('should count only the companies still to be checked', () => {
+			// GIVEN one company its own site and a paper both name, and two the run
+			// cannot settle from what it has gathered
+			const rows = [
+				row(NAME, OWN, [PAPER]),
+				row('Segona SL', undefined, [PAPER]),
+				row('Tercera SL', 'https://tercera.cat', []),
+			]
+			// WHEN the list is counted
+			// THEN only the two still short are counted — the settled one costs the
+			// confirming step nothing, so holding money back for it would keep money
+			// back for a search that never happens
+			expect(rowsAwaitingConfirmation(rows, NONE, noRunWords)).toBe(2)
+		})
+	})
+
+	describe('when the whole list is already settled', () => {
+		it('should count nothing', () => {
+			// GIVEN every company confirmed on its own site and a second website
+			const rows = [row(NAME, OWN, [PAPER]), row(NAME, OWN, [PAPER])]
+			// WHEN counted
+			// THEN the confirming step has nothing to buy
+			expect(rowsAwaitingConfirmation(rows, NONE, noRunWords)).toBe(0)
+		})
+	})
+
+	describe('when nothing the company cites is its own site', () => {
+		it('should count it as one still to be checked', () => {
+			// GIVEN a company with no site of its own, named only by a listing and
+			// a paper — two websites, but not one of them established as its own
+			const rows = [row(NAME, undefined, [LISTING, PAPER])]
+			// WHEN counted
+			// THEN it is still to be checked: two websites are not enough on their
+			// own, and this is exactly the row a site lookup would go on to settle
+			expect(rowsAwaitingConfirmation(rows, NONE, noRunWords)).toBe(1)
+		})
+	})
+
+	describe('when there is no list', () => {
+		it('should count nothing rather than guess', () => {
+			// GIVEN no companies at all
+			// WHEN counted
+			// THEN nothing is held back
+			expect(rowsAwaitingConfirmation([], NONE, noRunWords)).toBe(0)
+		})
+	})
+
+	describe('when a row names no company', () => {
+		it('should leave it out, because no search can be bought for it', () => {
+			// GIVEN an unnamed row beside one that can be searched for
+			const rows = [row('', undefined, []), row('Segona SL', undefined, [])]
+			// WHEN counted
+			// THEN only the row a search could settle counts: the confirming step
+			// declines to buy for a company it cannot name, so money kept back for
+			// the other is money no step ever spends
+			expect(rowsAwaitingConfirmation(rows, NONE, noRunWords)).toBe(1)
+		})
+	})
+})
+
+describe('awaitsConfirmation', () => {
+	const row = (
+		name: string,
+		website: string | undefined,
+		sources: ReadonlyArray<string>,
+	): Record<string, unknown> => ({
+		name,
+		...(website === undefined ? {} : { website }),
+		citations: sources.map(source_id => ({ source_id })),
+	})
+
+	describe('when the watch turns the clearing site into a listing', () => {
+		it('should go from settled to still to be checked', () => {
+			// GIVEN a company cleared by its own site plus a second website
+			const settled = row(NAME, OWN, [PAPER])
+			// WHEN the same row is read against a run that has since watched that
+			// host file company after company
+			// THEN it is no longer settled: the watch is what the answer turns on,
+			// so a caller handing in the wrong one gets the wrong count
+			expect(awaitsConfirmation(settled, NONE, noRunWords)).toBe(false)
+			expect(
+				awaitsConfirmation(
+					settled,
+					new Set(['fusteriamiquel.cat']),
+					noRunWords,
+				),
+			).toBe(true)
+		})
+	})
+
+	describe('when a row arrives in a shape nothing tidied', () => {
+		it('should read it as still to be checked rather than throwing', () => {
+			// GIVEN rows straight off an extraction: no citations at all, citations
+			// that are not a list, entries with no source, and a website that is
+			// not text
+			// WHEN each is read
+			// THEN each answers, because these are the shapes a model really
+			// returns and a count that threw here would take the run down
+			expect(awaitsConfirmation({ name: NAME }, NONE, noRunWords)).toBe(true)
+			expect(
+				awaitsConfirmation({ name: NAME, citations: 'nope' }, NONE, noRunWords),
+			).toBe(true)
+			expect(
+				awaitsConfirmation(
+					{ name: NAME, citations: [{}, null] },
+					NONE,
+					noRunWords,
+				),
+			).toBe(true)
+			expect(
+				awaitsConfirmation(
+					{ name: NAME, website: { value: OWN }, citations: [] },
+					NONE,
+					noRunWords,
+				),
+			).toBe(true)
+		})
 	})
 })

--- a/packages/research/src/application/existence-verdict.ts
+++ b/packages/research/src/application/existence-verdict.ts
@@ -93,7 +93,7 @@ import {
 	registrableDomain,
 	spellingsWithoutForms,
 } from './entity-guard'
-import { isPlainObject } from './guard-shapes'
+import { citedSourceIds, isPlainObject } from './guard-shapes'
 import { ownSiteVerdict } from './own-site'
 import type { RunWords } from './run-words'
 import { hostOf, isBareWebAddress } from './source-key'
@@ -456,3 +456,45 @@ export const partitionByExistence = (
 	confirmed: rows.filter(isConfirmedRow),
 	candidates: rows.filter(row => !isConfirmedRow(row)),
 })
+
+/**
+ * Whether the run cannot yet stand behind this company.
+ *
+ * The one rule, so that whoever sets money aside for the confirming step and the
+ * step itself cannot come to different answers about the same row.
+ */
+export const awaitsConfirmation = (
+	row: Record<string, unknown>,
+	directorySites: DirectorySites,
+	runWords: RunWords,
+): boolean =>
+	existenceOf({
+		name: typeof row['name'] === 'string' ? row['name'] : '',
+		website: typeof row['website'] === 'string' ? row['website'] : undefined,
+		sources: citedSourceIds(row),
+		directorySites,
+		runWords,
+	}).verdict !== 'confirmed'
+
+/**
+ * How many searches confirming this list still has to buy.
+ *
+ * A company already settled by what the run has gathered is settled for nothing.
+ * A company the list never names is left out, because a search cannot help one:
+ * the query would be a quoted blank, and the confirming step declines to buy it.
+ *
+ * Read as an estimate, not a promise. It is struck while the run is still
+ * gathering, and a site that later turns out to file company after company can
+ * take a company back out of settled after the counting is done — so the true
+ * figure can come out either side of this one.
+ */
+export const rowsAwaitingConfirmation = (
+	rows: ReadonlyArray<Record<string, unknown>>,
+	directorySites: DirectorySites,
+	runWords: RunWords,
+): number =>
+	rows.filter(row => {
+		const name = row['name']
+		if (typeof name !== 'string' || name.trim() === '') return false
+		return awaitsConfirmation(row, directorySites, runWords)
+	}).length

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { discoveryRows } from './discovery-scan'
 import {
 	HIGH_VALUE_FIELDS,
 	MAX_PER_FIELD_SEARCHES,
@@ -8,9 +9,15 @@ import {
 	mergePerFieldSearch,
 	needsPerFieldSearch,
 	perFieldSearchCap,
+	perFieldSearchKey,
 	perFieldSearchQuery,
+	perFieldSearchRound,
+	type RescueTarget,
+	rowsMissing,
 	scanRowFields,
+	scanRowFoldFields,
 } from './per-field-search'
+import { MAX_GAP_ROUNDS } from './research-service'
 import { runWordsOf } from './run-words'
 import { CompetitorScanV1Schema } from './schemas/competitor-scan-v1'
 import { ProspectScanV1Schema } from './schemas/prospect-scan-v1'
@@ -25,11 +32,23 @@ const SCAN = 'prospect_scan_v1'
 const COMPETITORS = 'competitor_scan_v1'
 const PROFILE = 'company_enrichment_v1'
 
+// The rounds a run really gets, read from the service rather than copied, so the
+// reach these tests claim cannot drift away from the reach production delivers.
+const ROUNDS_A_RUN_GETS = MAX_GAP_ROUNDS
+
+// A budget big enough that money never decides the outcome, for the cases about
+// something other than affordability.
+const PLENTY = 10_000
+
 const forProfile = (findings: unknown, subjectName = 'Acme Corp') =>
 	needsPerFieldSearch({ findings, schemaName: PROFILE, subjectName })
 
 const forScan = (findings: unknown, schemaName: string = SCAN) =>
 	needsPerFieldSearch({ findings, schemaName, subjectName: 'unused by a scan' })
+
+// The rows a caller hands in, read the way the service reads them.
+const rowsOf = (findings: unknown, schemaName: string = SCAN) =>
+	discoveryRows(schemaName, findings)
 
 const prospectsOf = (findings: unknown) =>
 	(findings as { prospects: ReadonlyArray<Record<string, unknown>> }).prospects
@@ -108,13 +127,95 @@ describe('needsPerFieldSearch', () => {
 				],
 			}
 			// WHEN computed
-			// THEN each company is asked about by its own name, never the request's
+			// THEN each company is asked about by its own name, never the request's,
+			// AND the whole list's most useful blank is asked about first: the company
+			// with no website is reached before either company's headcount
 			expect(forScan(findings)).toEqual([
-				{ name: 'Acme', field: 'employee_estimate' },
-				{ name: 'Acme', field: 'location' },
 				{ name: 'Beta', field: 'website' },
+				{ name: 'Acme', field: 'employee_estimate' },
 				{ name: 'Beta', field: 'employee_estimate' },
+				{ name: 'Acme', field: 'location' },
 				{ name: 'Beta', field: 'location' },
+			])
+		})
+
+		it('should buy no company a headcount while any company still lacks a website', () => {
+			// GIVEN a list the length a market search really comes back with, every
+			// company named and nothing else known about any of them
+			const listed = 29
+			const findings = {
+				prospects: Array.from({ length: listed }, (_, at) => ({
+					name: `Company ${at + 1}`,
+				})),
+			}
+			// WHEN computed
+			const targets = forScan(findings)
+			// THEN every company is asked for its website, and all of those come
+			// before the first headcount: a round takes the front of this list, so a
+			// headcount bought ahead of a website leaves a company nobody can reach
+			expect(targets.filter(target => target.field === 'website')).toHaveLength(
+				listed,
+			)
+			expect(targets.slice(0, listed).map(target => target.field)).toEqual(
+				Array(listed).fill('website'),
+			)
+			// AND a single round's whole allowance goes to websites
+			expect(
+				targets
+					.slice(0, perFieldSearchCap(SCAN))
+					.every(target => target.field === 'website'),
+			).toBe(true)
+		})
+
+		it('should reach the last company on the list before the first one is asked for a headcount', () => {
+			// GIVEN the first company already has a website and the last has nothing
+			const findings = {
+				prospects: [
+					{ name: 'First', website: 'https://first.test' },
+					{ name: 'Last' },
+				],
+			}
+			// WHEN computed
+			// THEN the company at the end is served first, because what it is missing
+			// is worth more than what the one at the front is missing — where a
+			// company sits on the list does not decide whether it is helped
+			expect(forScan(findings)[0]).toEqual({ name: 'Last', field: 'website' })
+		})
+
+		it('should keep the field groups whole when a row in the middle names nobody', () => {
+			// GIVEN a nameless row sitting between two named ones
+			const findings = {
+				prospects: [
+					{ name: 'A' },
+					{ website: 'https://ghost.test' },
+					{ name: 'B' },
+				],
+			}
+			// WHEN computed
+			// THEN the row that cannot be searched for drops out without splitting the
+			// groups: both websites still come before either headcount
+			expect(forScan(findings)).toEqual([
+				{ name: 'A', field: 'website' },
+				{ name: 'B', field: 'website' },
+				{ name: 'A', field: 'employee_estimate' },
+				{ name: 'B', field: 'employee_estimate' },
+				{ name: 'A', field: 'location' },
+				{ name: 'B', field: 'location' },
+			])
+		})
+
+		it('should ask about each of two rows that carry the same name', () => {
+			// GIVEN a list naming one company twice, which the fold that runs before
+			// these searches would normally have joined into one row
+			const findings = { prospects: [{ name: 'Acme' }, { name: 'Acme' }] }
+			// WHEN computed
+			// THEN each row is reported: deciding which rows are one company is the
+			// fold's job, not this step's
+			expect(
+				forScan(findings).filter(target => target.field === 'website'),
+			).toEqual([
+				{ name: 'Acme', field: 'website' },
+				{ name: 'Acme', field: 'website' },
 			])
 		})
 
@@ -167,11 +268,12 @@ describe('needsPerFieldSearch', () => {
 				],
 			}
 			// WHEN computed
-			// THEN each of those reads as a gap worth searching for
+			// THEN each of those reads as a gap worth searching for, both websites
+			// ahead of the headcount and the town
 			expect(forScan(findings)).toEqual([
 				{ name: 'A', field: 'website' },
-				{ name: 'A', field: 'employee_estimate' },
 				{ name: 'B', field: 'website' },
+				{ name: 'A', field: 'employee_estimate' },
 				{ name: 'B', field: 'location' },
 			])
 		})
@@ -217,6 +319,337 @@ describe('needsPerFieldSearch', () => {
 			// THEN the schema decides the shape, so no profile field is searched for —
 			// a scan has nowhere to put one
 			expect(forScan(findings)).toEqual([])
+		})
+	})
+})
+
+describe('rowsMissing', () => {
+	describe('when a scan came back with a list', () => {
+		it('should count the companies still short of the fact', () => {
+			// GIVEN three companies, one of which carries a website
+			const findings = {
+				prospects: [
+					{ name: 'A', website: 'https://a.test' },
+					{ name: 'B' },
+					{ name: 'C', website: '   ' },
+				],
+			}
+			// WHEN the list is counted
+			// THEN the blank and the whitespace-only one are both still short
+			expect(rowsMissing(rowsOf(findings), 'website')).toBe(2)
+		})
+
+		it('should count a company it cannot even search for', () => {
+			// GIVEN a row with no name and no website
+			const findings = { prospects: [{ website: 'https://a.test' }, {}] }
+			// WHEN counted
+			// THEN the nameless row still counts — it is a company the list is short
+			// on, and leaving it out would report the list as better served than it is
+			expect(rowsMissing(rowsOf(findings), 'website')).toBe(1)
+		})
+
+		it('should read a headcount stored as a number as filled', () => {
+			// GIVEN one headcount paired with its source and one nulled
+			const findings = {
+				prospects: [
+					{ name: 'A', employee_estimate: { value: 42, source_id: 'x' } },
+					{ name: 'B', employee_estimate: { value: null } },
+				],
+			}
+			// WHEN counted
+			// THEN only the nulled one is short
+			expect(rowsMissing(rowsOf(findings), 'employee_estimate')).toBe(1)
+		})
+	})
+
+	describe('when there is no list to count', () => {
+		it('should count nothing rather than guess', () => {
+			// GIVEN findings with an empty list, no list, an unusable list, and a
+			// schema that is not a scan at all
+			// WHEN counted
+			// THEN each answers zero
+			expect(rowsMissing(rowsOf({ prospects: [] }), 'website')).toBe(0)
+			expect(rowsMissing(rowsOf({}), 'website')).toBe(0)
+			expect(rowsMissing(rowsOf({ prospects: 'nope' }), 'website')).toBe(0)
+			expect(rowsMissing(rowsOf(null), 'website')).toBe(0)
+			expect(rowsMissing(rowsOf({ prospects: [{}] }, PROFILE), 'website')).toBe(
+				0,
+			)
+		})
+	})
+})
+
+describe('perFieldSearchRound', () => {
+	// What a whole run of rounds buys: each round takes what it may, and what it
+	// took is remembered so the next round moves on. Nothing here fills a blank, so
+	// the list of what is missing never shrinks and these figures are the most a
+	// run of rounds can ask after — the service also stops early when a round
+	// turns up nothing at all, which only ever asks after fewer.
+	const overRounds = (listed: number, rounds = ROUNDS_A_RUN_GETS) => {
+		const findings = {
+			prospects: Array.from({ length: listed }, (_, at) => ({
+				name: `Company ${at + 1}`,
+			})),
+		}
+		const bought = new Set<string>()
+		const fired: RescueTarget[] = []
+		for (let round = 1; round <= rounds; round++) {
+			const taken = perFieldSearchRound(
+				SCAN,
+				needsPerFieldSearch({
+					findings,
+					schemaName: SCAN,
+					subjectName: 'unused by a scan',
+				}),
+				bought,
+				PLENTY,
+			)
+			for (const target of taken) {
+				bought.add(perFieldSearchKey(target))
+				fired.push(target)
+			}
+		}
+		return {
+			fired: fired.length,
+			websites: fired.filter(target => target.field === 'website').length,
+			companiesAskedForASite: new Set(
+				fired
+					.filter(target => target.field === 'website')
+					.map(target => target.name),
+			).size,
+		}
+	}
+
+	describe('when a market search comes back with a full list', () => {
+		it('should ask every company for a site when the rounds can cover the list', () => {
+			// GIVEN a list of the length the shorter market really comes back with,
+			// which the rounds have room to reach the whole of
+			const listed = 34
+			// WHEN the rounds a run gets are played out
+			const spent = overRounds(listed)
+			// THEN not one company is left unasked, and only once every company has
+			// been asked does anything go to a headcount or a town
+			expect(spent.companiesAskedForASite).toBe(listed)
+			expect(spent.websites).toBe(listed)
+			expect(spent.fired).toBeGreaterThan(listed)
+			// AND the allowance really did have room to spare, so this is the
+			// covered case rather than a list that merely happened to fit
+			expect(MAX_SCAN_ROW_SEARCHES * ROUNDS_A_RUN_GETS).toBeGreaterThan(listed)
+		})
+
+		it('should spend every search on sites when the list outruns the rounds', () => {
+			// GIVEN a market list longer than the rounds can get through — the
+			// longest a market search has really come back with
+			const listed = 67
+			// WHEN the rounds are played out
+			const spent = overRounds(listed)
+			// THEN nothing at all goes to a headcount or a town: the rounds run out
+			// of searches before they run out of companies with no site
+			expect(spent.websites).toBe(spent.fired)
+			expect(spent.companiesAskedForASite).toBe(spent.fired)
+			// AND the list really did outrun the rounds, so this is that case
+			expect(spent.fired).toBeLessThan(listed)
+		})
+
+		it('should never spend a round on a fact it has already bought', () => {
+			// GIVEN a list short enough that the rounds finish it
+			// WHEN played out over twice as many rounds as a run gets
+			const spent = overRounds(4, ROUNDS_A_RUN_GETS * 2)
+			// THEN each company is asked for each of its three facts exactly once —
+			// a fact a search failed to fill is not re-bought round after round
+			expect(spent.fired).toBe(4 * 3)
+			expect(spent.websites).toBe(4)
+		})
+	})
+
+	describe('when the list names one company twice', () => {
+		it('should buy the answer once rather than pay twice for it', () => {
+			// GIVEN two rows carrying the same name, which ask the same question
+			const gaps: ReadonlyArray<RescueTarget> = [
+				{ name: 'Acme', field: 'website' },
+				{ name: 'Acme', field: 'website' },
+				{ name: 'Beta', field: 'website' },
+			]
+			// WHEN a round takes what it may
+			// THEN the repeat is passed over, so the slot it would have taken goes to
+			// a company that has not been asked about at all
+			expect(perFieldSearchRound(SCAN, gaps, new Set(), PLENTY)).toEqual([
+				{ name: 'Acme', field: 'website' },
+				{ name: 'Beta', field: 'website' },
+			])
+		})
+	})
+
+	describe('when the run has already bought some of what is missing', () => {
+		it('should skip those and fill the round from what is left', () => {
+			// GIVEN a website already bought in an earlier round
+			const gaps: ReadonlyArray<RescueTarget> = [
+				{ name: 'Acme', field: 'website' },
+				{ name: 'Beta', field: 'website' },
+			]
+			const bought = new Set([
+				perFieldSearchKey({ name: 'Acme', field: 'website' }),
+			])
+			// WHEN the next round takes what it may
+			// THEN only the company still short is bought for
+			expect(perFieldSearchRound(SCAN, gaps, bought, PLENTY)).toEqual([
+				{ name: 'Beta', field: 'website' },
+			])
+		})
+
+		it('should leave the set it was handed untouched', () => {
+			// GIVEN a set of what the run has bought so far
+			const bought = new Set<string>()
+			// WHEN a round takes from the gaps
+			perFieldSearchRound(
+				SCAN,
+				[{ name: 'Acme', field: 'website' }],
+				bought,
+				PLENTY,
+			)
+			// THEN the caller's own record is not written to behind its back — it
+			// decides for itself what counts as bought once the searches have fired
+			expect(bought.size).toBe(0)
+		})
+	})
+
+	describe('when there is nothing left to buy', () => {
+		it('should take nothing', () => {
+			// GIVEN no gaps at all, and gaps that were all bought already
+			// WHEN a round takes what it may
+			// THEN it takes nothing, so the caller can close the loop
+			expect(perFieldSearchRound(SCAN, [], new Set(), PLENTY)).toEqual([])
+			expect(
+				perFieldSearchRound(
+					SCAN,
+					[{ name: 'Acme', field: 'website' }],
+					new Set([perFieldSearchKey({ name: 'Acme', field: 'website' })]),
+					PLENTY,
+				),
+			).toEqual([])
+		})
+	})
+
+	describe('when the money runs down as the rounds go', () => {
+		it('should take less each round and then nothing', () => {
+			// GIVEN twenty companies with no site, and a purse that the rounds eat
+			// into as they spend — the way the service re-reads it every round
+			const gaps: ReadonlyArray<RescueTarget> = Array.from(
+				{ length: 20 },
+				(_, at) => ({ name: `Company ${at + 1}`, field: 'website' }),
+			)
+			const bought = new Set<string>()
+			let purse = 18
+			const perRound: number[] = []
+			for (let round = 1; round <= ROUNDS_A_RUN_GETS; round++) {
+				const taken = perFieldSearchRound(SCAN, gaps, bought, purse)
+				for (const target of taken) bought.add(perFieldSearchKey(target))
+				purse -= taken.length
+				perRound.push(taken.length)
+			}
+			// THEN the allowance binds while there is money, the purse binds once
+			// there is not, and a spent run buys nothing rather than going over
+			expect(perRound).toEqual([14, 4, 0, 0])
+			expect(purse).toBe(0)
+		})
+	})
+
+	describe('when the money left is not an ordinary figure', () => {
+		it('should buy nothing rather than the whole list', () => {
+			// GIVEN gaps and an affordability that arithmetic has turned into
+			// nonsense — a budget that was never a number, say
+			const gaps: ReadonlyArray<RescueTarget> = Array.from(
+				{ length: 30 },
+				(_, at) => ({ name: `Company ${at + 1}`, field: 'website' }),
+			)
+			// WHEN a round asks what it may take
+			// THEN it takes nothing: every comparison against such a figure is
+			// false, so an unguarded cap would let the round buy the entire list
+			expect(perFieldSearchRound(SCAN, gaps, new Set(), Number.NaN)).toEqual([])
+		})
+
+		it('should still hold to the allowance when the money is boundless', () => {
+			// GIVEN gaps and no ceiling on spending at all
+			const gaps: ReadonlyArray<RescueTarget> = Array.from(
+				{ length: 30 },
+				(_, at) => ({ name: `Company ${at + 1}`, field: 'website' }),
+			)
+			// WHEN a round asks what it may take
+			// THEN the allowance binds and the round still buys: a figure with no
+			// ceiling in it is not a broken one, and turning it away as if it were
+			// would leave a run that can pay for everything buying nothing
+			expect(
+				perFieldSearchRound(SCAN, gaps, new Set(), Number.POSITIVE_INFINITY),
+			).toHaveLength(MAX_SCAN_ROW_SEARCHES)
+		})
+	})
+
+	describe('when the run cannot pay for a whole round', () => {
+		it('should buy only what is left rather than the whole allowance', () => {
+			// GIVEN more companies short of a site than the run can still pay for
+			const gaps: ReadonlyArray<RescueTarget> = Array.from(
+				{ length: 20 },
+				(_, at) => ({ name: `Company ${at + 1}`, field: 'website' }),
+			)
+			// WHEN a round runs with only three searches' worth of money left
+			const taken = perFieldSearchRound(SCAN, gaps, new Set(), 3)
+			// THEN it takes three: the allowance says what a round may spend when
+			// there is money for it, never that there is
+			expect(taken).toHaveLength(3)
+		})
+
+		it('should buy nothing at all when there is nothing left', () => {
+			// GIVEN companies still short of a site and an exhausted budget
+			const gaps: ReadonlyArray<RescueTarget> = [
+				{ name: 'Acme', field: 'website' },
+			]
+			// WHEN a round runs with nothing left, or past exhausted
+			// THEN it buys nothing, and the caller closes the loop rather than
+			// spending money the run does not have
+			expect(perFieldSearchRound(SCAN, gaps, new Set(), 0)).toEqual([])
+			expect(perFieldSearchRound(SCAN, gaps, new Set(), -5)).toEqual([])
+		})
+
+		it('should still hold to the allowance when money is plentiful', () => {
+			// GIVEN far more money than a round is allowed to spend
+			const gaps: ReadonlyArray<RescueTarget> = Array.from(
+				{ length: 40 },
+				(_, at) => ({ name: `Company ${at + 1}`, field: 'website' }),
+			)
+			// WHEN a round runs
+			// THEN the allowance still binds: a full purse is not a licence to spend
+			// a whole list in one round and leave the later rounds nothing to read
+			expect(perFieldSearchRound(SCAN, gaps, new Set(), PLENTY)).toHaveLength(
+				MAX_SCAN_ROW_SEARCHES,
+			)
+		})
+	})
+
+	describe('when the run is a company profile', () => {
+		it('should hold to the smaller per-fact allowance', () => {
+			// GIVEN a profile missing all four of its high-value facts
+			const gaps: ReadonlyArray<RescueTarget> = HIGH_VALUE_FIELDS.map(
+				field => ({ name: 'Acme Corp', field }),
+			)
+			// WHEN a round takes what it may
+			// THEN it takes the profile's cap, not the scan's
+			expect(
+				perFieldSearchRound(PROFILE, gaps, new Set(), PLENTY),
+			).toHaveLength(MAX_PER_FIELD_SEARCHES)
+		})
+	})
+})
+
+describe('perFieldSearchKey', () => {
+	describe('when two pairs run together as the same letters', () => {
+		it('should tell them apart', () => {
+			// GIVEN a company whose name ends where a field name would begin
+			// WHEN each pair is keyed
+			// THEN the two keys differ, so one is never mistaken for the other and a
+			// fact bought for one company never reads as bought for another
+			expect(perFieldSearchKey({ name: 'Acme', field: 'website' })).not.toBe(
+				perFieldSearchKey({ name: 'Acmeweb', field: 'site' }),
+			)
 		})
 	})
 })
@@ -1055,6 +1488,31 @@ describe('the fields each shape rescues', () => {
 			expect(scanRowFields('freeform')).toEqual([])
 		})
 
+		it('should let a wider read keep more than it would go looking for', () => {
+			// GIVEN the two lists, one for what is bought and one for what may be
+			// folded back in
+			// WHEN a round meets a company's page on a platform without being sent
+			// after it
+			// THEN there is somewhere to put it, because a fact left off the fold
+			// list is thrown away even when a round does turn it up — and a company
+			// with no site of its own may have nothing else anybody can reach it by
+			expect(scanRowFoldFields(SCAN)).toContain('social_profiles')
+			expect(scanRowFields(SCAN)).not.toContain('social_profiles')
+			expect(scanRowFoldFields('freeform')).toEqual([])
+		})
+
+		it('should let a wider read keep everything it goes looking for', () => {
+			// GIVEN both lists for each kind of scan
+			// WHEN a round buys a fact
+			// THEN the fold can write it back: a fact searched for but missing from
+			// the fold list would be paid for and dropped on the way home
+			for (const schemaName of [SCAN, COMPETITORS]) {
+				for (const field of scanRowFields(schemaName)) {
+					expect(scanRowFoldFields(schemaName)).toContain(field)
+				}
+			}
+		})
+
 		it('should only name facts the scan schema can actually carry', () => {
 			// GIVEN a company row carrying every fact the rescue would search for,
 			// put through the very schema the model fills
@@ -1067,6 +1525,13 @@ describe('the fields each shape rescues', () => {
 					confidence: null,
 				},
 				location: 'Valencia',
+				social_profiles: [
+					{
+						kind: 'facebook',
+						value: 'https://facebook.com/acme',
+						confidence: null,
+					},
+				],
 				why_relevant: 'matches',
 				description: 'a rival',
 				citations: [],
@@ -1083,7 +1548,7 @@ describe('the fields each shape rescues', () => {
 				// THEN it survived — a fact the schema drops would be searched for
 				// every round and merged back nowhere, which is the same waste this
 				// rescue was rewritten to stop doing on a company profile
-				for (const field of scanRowFields(schemaName)) {
+				for (const field of scanRowFoldFields(schemaName)) {
 					expect(row).toHaveProperty(field)
 				}
 			}

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -13,6 +13,7 @@ import {
 	perFieldSearchQuery,
 	perFieldSearchRound,
 	type RescueTarget,
+	roundChangedNothing,
 	rowsMissing,
 	scanRowFields,
 	scanRowFoldFields,
@@ -1552,6 +1553,56 @@ describe('the fields each shape rescues', () => {
 					expect(row).toHaveProperty(field)
 				}
 			}
+		})
+	})
+})
+
+describe('roundChangedNothing', () => {
+	// A round that bought searches and came back with the answer untouched.
+	const untouched = {
+		filled: 0,
+		added: 0,
+		folded: 0,
+		contactsChanged: false,
+		websitesBlanked: 0,
+		fieldsVoided: 0,
+	}
+
+	describe('when the round left the answer exactly as it found it', () => {
+		it('should say so, so the run stops rather than buying the same silence', () => {
+			// GIVEN a round that filled nothing, found nobody, joined nobody, named
+			// nobody new and took nothing away
+			// WHEN the round is judged
+			// THEN there is nothing left for another round to buy
+			expect(roundChangedNothing(untouched)).toBe(true)
+		})
+	})
+
+	describe.each([
+		['filled a blank', { filled: 1 }],
+		['found a company the list did not hold', { added: 1 }],
+		['joined two rows into one company', { folded: 1 }],
+		['named somebody new', { contactsChanged: true }],
+		['took an address off the list', { websitesBlanked: 1 }],
+		['took away a field belonging to another company', { fieldsVoided: 1 }],
+	])('when the round has %s and nothing else', (_what, change) => {
+		it('should not read as a round that did nothing', () => {
+			// GIVEN a round whose only mark on the answer is this one
+			// WHEN the round is judged
+			// THEN the run carries on: judged on what it gained alone this reads as
+			// a spent round, and the rest of the list would go unasked
+			expect(roundChangedNothing({ ...untouched, ...change })).toBe(false)
+		})
+	})
+
+	describe('when a round both gained and gave up ground', () => {
+		it('should still count as a round that changed something', () => {
+			// GIVEN a round that filled two blanks and took one wrong address away
+			// WHEN judged
+			// THEN it changed the answer, whichever direction each change went in
+			expect(
+				roundChangedNothing({ ...untouched, filled: 2, websitesBlanked: 1 }),
+			).toBe(false)
 		})
 	})
 })

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -54,8 +54,11 @@ export const HIGH_VALUE_FIELDS: ReadonlyArray<string> = [
 // list also decides what a wider read is allowed to fill in, so a field left out
 // of it is one whose value is thrown away even when a round does turn it up.
 //
-// Listed in the order they are worth going after, since a round's cap can cut the
-// list short.
+// Listed in the order they are worth going after, since a round's cap cuts the
+// list short and whatever falls past the cut is never bought. The gap between the
+// first and the rest is wide: a missing headcount is a nuisance, while a company
+// with no site of its own is one somebody has to go and find another way of
+// reaching before they can do anything with it at all.
 const SCAN_ROW_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
 	prospect_scan_v1: ['website', 'employee_estimate', 'location'],
 	competitor_scan_v1: ['website'],
@@ -64,6 +67,26 @@ const SCAN_ROW_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
 /** The facts worth searching for on one company this kind of scan found. */
 export const scanRowFields = (schemaName: string): ReadonlyArray<string> =>
 	SCAN_ROW_FIELDS_BY_SCHEMA[schemaName] ?? []
+
+// What a wider read is allowed to fill in on a company the list already holds.
+// Everything worth going out and searching for, plus what a run turns up without
+// being asked: a company's pages on the platforms are never searched for, but a
+// round that meets one has found the only way anybody has of reaching a company
+// with no site of its own, and a field left off this list is one whose value is
+// thrown away even when a round does turn it up.
+const SCAN_ROW_FOLD_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
+	prospect_scan_v1: [
+		'website',
+		'employee_estimate',
+		'location',
+		'social_profiles',
+	],
+	competitor_scan_v1: ['website'],
+}
+
+/** The facts a wider read may fill in on one company this kind of scan found. */
+export const scanRowFoldFields = (schemaName: string): ReadonlyArray<string> =>
+	SCAN_ROW_FOLD_FIELDS_BY_SCHEMA[schemaName] ?? []
 
 // At most this many extra searches per round for a company profile: an all-empty
 // profile would otherwise fire one per field. Any missing field beyond the cap is
@@ -75,7 +98,18 @@ export const MAX_PER_FIELD_SEARCHES = 3
 // so the profile's cap would recover almost nothing; this is larger and still
 // bounded, with the round loop's own budget and deadline margins as the real
 // governor.
-export const MAX_SCAN_ROW_SEARCHES = 8
+//
+// Sized to the list rather than picked: a market search comes back with anywhere
+// from twenty-five to seventy companies, and over the rounds a run gets, this
+// asks after most of them. A cap of eight would reach thirty-two over those same
+// rounds, which on a list of fifty-five leaves twenty-three companies never asked
+// about anything.
+//
+// This is what a round may spend, not a promise the money is there. A run's
+// allowance is a hundred or two hundred of these searches and scrapes together,
+// and the step that confirms the list draws on the same purse, so the round loop
+// keeps back what that step will need and takes what is left.
+export const MAX_SCAN_ROW_SEARCHES = 14
 
 /** One fact to go looking for, on one of the run's subjects. */
 export interface RescueTarget {
@@ -104,6 +138,9 @@ const hasValue = (fieldValue: unknown): boolean =>
 const hasRowValue = (fieldValue: unknown): boolean => {
 	const held = unwrapValue(fieldValue)
 	if (typeof held === 'string') return held.trim() !== ''
+	// A fact that holds a list of things — the pages a company opened in its own
+	// name — has something as soon as it holds one of them.
+	if (Array.isArray(held)) return held.length > 0
 	return typeof held === 'number' && Number.isFinite(held)
 }
 
@@ -142,8 +179,9 @@ const rowName = (row: Record<string, unknown>): string | undefined => {
  * The still-empty high-value facts worth a focused search, in a stable order.
  *
  * For a company profile that is the one subject's empty fields; for a discovery
- * scan it is one entry per company that is missing one. Empty when there is
- * nothing left to recover.
+ * scan it is one entry per company that is missing one, most useful fact first
+ * across the whole list — every company's website before anybody's headcount.
+ * Empty when there is nothing left to recover.
  */
 export const needsPerFieldSearch = (args: {
 	readonly findings: unknown
@@ -155,11 +193,19 @@ export const needsPerFieldSearch = (args: {
 	// anything: a scan that came back with nothing is still a scan, and reading it
 	// as a profile would search for facts it has nowhere to put.
 	if (isDiscoveryScan(args.schemaName)) {
-		const targets: RescueTarget[] = []
-		for (const row of scanRowsOf(args.schemaName, args.findings)) {
+		// Only companies a search can actually be run for: with no name the query is
+		// a quoted blank, and nothing an answer said could be tied back to the row.
+		const named = scanRowsOf(args.schemaName, args.findings).flatMap(row => {
 			const name = rowName(row)
-			if (name === undefined) continue
-			for (const field of scanRowFields(args.schemaName)) {
+			return name === undefined ? [] : [{ name, row }]
+		})
+		// A round buys the front of this list and leaves the rest for a later round,
+		// so the fields go on the outside: every company gets a site before anybody
+		// gets a headcount. Company by company would hand a whole round to whoever
+		// the list happens to name first.
+		const targets: RescueTarget[] = []
+		for (const field of scanRowFields(args.schemaName)) {
+			for (const { name, row } of named) {
 				if (!hasRowValue(row[field])) targets.push({ name, field })
 			}
 		}
@@ -175,9 +221,74 @@ export const needsPerFieldSearch = (args: {
 	}))
 }
 
+/**
+ * How many of these companies are still missing one fact.
+ *
+ * Takes the rows rather than the findings, so a caller reporting both a total and
+ * a shortfall reads one list for both and cannot end up with a shortfall larger
+ * than the list it is counted against.
+ *
+ * Every row counts, named or not — a row nobody can search for is still a row the
+ * list is short on, and leaving it out would report a list as better served than
+ * it is.
+ */
+export const rowsMissing = (
+	rows: ReadonlyArray<Record<string, unknown>>,
+	field: string,
+): number => rows.filter(row => !hasRowValue(row[field])).length
+
 /** How many searches one round may fire for this shape of run. */
 export const perFieldSearchCap = (schemaName: string): number =>
 	isDiscoveryScan(schemaName) ? MAX_SCAN_ROW_SEARCHES : MAX_PER_FIELD_SEARCHES
+
+/**
+ * What one fact about one company is remembered under once it has been bought.
+ *
+ * The two halves are held apart by a character no company name carries, so a name
+ * running into a field name cannot read as some other pair.
+ */
+export const perFieldSearchKey = (target: RescueTarget): string =>
+	`${target.name}\u001F${target.field}`
+
+/**
+ * What one round buys, taken from the front of what is still missing.
+ *
+ * The front is where the worth is, so a round spends on sites until every company
+ * has been asked for one and only then moves down to headcounts. What a run has
+ * already bought is passed over, and so is a repeat inside this same round: two
+ * rows carrying one name ask the same question, and asking it twice buys one
+ * answer for two of the round's few slots.
+ *
+ * Never more than the run can still pay for: a round that took its fill out of a
+ * thinner budget would overspend, and the step that confirms the list afterwards
+ * is what goes without.
+ */
+export const perFieldSearchRound = (
+	schemaName: string,
+	gaps: ReadonlyArray<RescueTarget>,
+	alreadyBought: ReadonlySet<string>,
+	affordableSearches: number,
+): ReadonlyArray<RescueTarget> => {
+	// A figure that is not a number buys nothing: every comparison against one is
+	// false, so a cap that trusted it would let a round take the whole list in one
+	// go.
+	const affordable = Math.max(0, affordableSearches)
+	const cap = Number.isNaN(affordable)
+		? 0
+		: Math.min(perFieldSearchCap(schemaName), affordable)
+	// Copied rather than added to: what the run has bought is the caller's to
+	// record, once the searches have actually fired.
+	const bought = new Set(alreadyBought)
+	const taken: RescueTarget[] = []
+	for (const target of gaps) {
+		if (taken.length >= cap) break
+		const key = perFieldSearchKey(target)
+		if (bought.has(key)) continue
+		bought.add(key)
+		taken.push(target)
+	}
+	return taken
+}
 
 // A short, human-readable label per fact, used to phrase the search.
 const FIELD_INTENT: Record<string, string> = {
@@ -306,7 +417,7 @@ const mergeScanRows = (
 		if (match === undefined) return row
 		const next: Record<string, unknown> = { ...row }
 		let filledHere = 0
-		for (const key of scanRowFields(schemaName)) {
+		for (const key of scanRowFoldFields(schemaName)) {
 			if (!hasRowValue(row[key]) && hasRowValue(match[key])) {
 				next[key] = match[key]
 				filledHere++

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -356,6 +356,46 @@ export interface PerFieldMerge {
 	readonly folded: number
 }
 
+/** Everything one gap round can change about a run's answer. */
+export interface RoundChange {
+	/** Blanks the round filled in. */
+	readonly filled: number
+	/** Companies the round found that the list did not hold. */
+	readonly added: number
+	/** Companies that went in and came out joined to one already listed. */
+	readonly folded: number
+	/** Whether the people the run names gained anyone, or gained a detail. */
+	readonly contactsChanged: boolean
+	/** Addresses the round took off the list once it could see the whole of it. */
+	readonly websitesBlanked: number
+	/** Fields the round took away as belonging to some other company. */
+	readonly fieldsVoided: number
+}
+
+/**
+ * Whether a round left the answer exactly as it found it.
+ *
+ * A round that changed nothing has bought all it is going to: the next one would
+ * pay for the same silence. But a round changes the answer in more ways than it
+ * gains things by, and every one of them counts here.
+ *
+ * Two companies written once are not a company lost, and the row that stays keeps
+ * what both of them knew. A run about a single company can gain people and never
+ * a company. And a round that takes an address away because it belongs to somebody
+ * else has opened a blank the next round can go and fill — the round after a
+ * correction is the one most worth having.
+ *
+ * Read the wrong way round, each of those is a working round mistaken for a spent
+ * one, and the rest of the list goes unasked.
+ */
+export const roundChangedNothing = (change: RoundChange): boolean =>
+	change.filled === 0 &&
+	change.added === 0 &&
+	change.folded === 0 &&
+	!change.contactsChanged &&
+	change.websitesBlanked === 0 &&
+	change.fieldsVoided === 0
+
 /**
  * Fold a re-extraction over the enlarged evidence back into a scan's list.
  *

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -131,6 +131,7 @@ import {
 	perFieldSearchKey,
 	perFieldSearchQuery,
 	perFieldSearchRound,
+	roundChangedNothing,
 	rowsMissing,
 } from './per-field-search'
 import { resolvePolicy, type SystemDefaults } from './policy'
@@ -5495,6 +5496,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// Cited pages fetched: re-judge the kept fields against them
 							// right away — the point of fetching is that a wrong-company
 							// page can now void the field it sourced, no LLM call needed.
+							// Fields this round took away because a page it fetched turned out
+							// to be about somebody else. Held for the round's end: taking a
+							// field away is work the round did, and a round judged on what it
+							// gained alone would read as having done nothing.
+							let voidedThisRound = 0
 							if (roundHashes.length > 0 && entityTargets) {
 								const gapOpenedByHash = new Map(
 									openedPages(scrapeCorpus).map(
@@ -5511,6 +5517,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									sourceId => gapOpenedByHash.get(urlHashForScrape(sourceId)),
 								)
 								findings = recheck.findings
+								voidedThisRound = recheck.droppedOffEntity
 								if (recheck.droppedOffEntity > 0) {
 									if (entityMatch === 'strong') entityMatch = 'weak'
 									yield* Effect.logWarning(
@@ -5597,6 +5604,29 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// as absent and the quality signal reports the thinness.
 							if (roundHashes.length === 0) break
 							yield* linkRunSources(roundHashes)
+							// The read below is the long part of a round, and nothing inside
+							// it watches the clock. Started too late it does not come back
+							// with less — it takes the whole run down with it, because the
+							// run's answer is written after this loop and a run past its
+							// deadline is failed rather than finished. What this round bought
+							// keeps: the evidence is held for the rest of the run, so the
+							// reading of it is what is given up, not the buying.
+							const beforeReadMs =
+								DateTime.toEpochMillis(DateTime.nowUnsafe()) - runStartedAtMs
+							if (
+								beforeReadMs >
+								runDeadlineSeconds * 1000 * GAP_ROUND_DEADLINE_FRACTION
+							) {
+								yield* Effect.logInfo('research.gap_rounds.stopped').pipe(
+									Effect.annotateLogs({
+										event: 'research.gap_rounds.stopped',
+										research_id: researchId,
+										round: gapRound,
+										reason: 'deadline_margin',
+									}),
+								)
+								break
+							}
 							// What this round just bought goes to the front, then the
 							// company's own pages. The extraction prompt fills to a character
 							// budget and stops, and a broad scan's corpus reaches that budget
@@ -5692,12 +5722,32 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									folded: merged.folded,
 								}),
 							)
-							// This round put new evidence in front of the model and it still
-							// filled nothing and found nobody — so the gaps that are left are
-							// not going to close, and another round would buy the same
-							// nothing. A scan cites a page or three per company, so waiting
-							// for the cited pages to run out first would never stop it.
-							if (merged.filled === 0 && merged.added === 0) break
+							// This round put new evidence in front of the model and nothing
+							// about the answer moved at all — so the gaps that are left are not
+							// going to close, and another round would buy the same nothing. A
+							// scan cites a page or three per company, so waiting for the cited
+							// pages to run out first would never stop it.
+							//
+							// Every way a round can change the answer counts here, not only
+							// the two that read as gains. A company written twice becoming a
+							// company written once carries the blanks of both onto the row
+							// that stays; a run about a single company can only ever gain
+							// people, never companies; and a round that takes away an address
+							// belonging to somebody else has opened a gap the next round can
+							// go and fill. Judged on gains alone, each of those reads as a
+							// round that did nothing, and the run stops with the rest of the
+							// list never asked about.
+							if (
+								roundChangedNothing({
+									filled: merged.filled,
+									added: merged.added,
+									folded: merged.folded,
+									contactsChanged: merged.contactsChanged,
+									websitesBlanked: foldedWebsites.blanked,
+									fieldsVoided: voidedThisRound,
+								})
+							)
+								break
 						}
 						// How far the rounds reached, counted in companies: a cap on searches
 						// says nothing about how much of the list was served, and a company

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -93,12 +93,14 @@ import {
 } from './entity-guard'
 import { classifyNamespace, guardEntitySources } from './entity-source-guard'
 import {
+	awaitsConfirmation,
 	type CandidateReason,
 	existenceOf,
 	isConfirmedRow,
 	markRowsExistence,
 	partitionByExistence,
 	resultNamesCompany,
+	rowsAwaitingConfirmation,
 	verificationQuery,
 } from './existence-verdict'
 import { contactFill, enrichmentFill } from './extraction-fill'
@@ -126,8 +128,10 @@ import { normalizePaidActionTool } from './paid-action-tool'
 import {
 	mergePerFieldSearch,
 	needsPerFieldSearch,
-	perFieldSearchCap,
+	perFieldSearchKey,
 	perFieldSearchQuery,
+	perFieldSearchRound,
+	rowsMissing,
 } from './per-field-search'
 import { resolvePolicy, type SystemDefaults } from './policy'
 import {
@@ -326,7 +330,7 @@ const MAX_DISCOVERY_PAGES = 6
 // Hard cap on the gap-closing rounds after phase 2 — each re-searches only what
 // is still missing, so a thin run earns its grounding instead of shipping on
 // the first pass.
-const MAX_GAP_ROUNDS = 4
+export const MAX_GAP_ROUNDS = 4
 // Cited-but-never-fetched pages scraped per round, turning the per-source
 // entity check's fail-open into a real verdict on the cited page.
 const MAX_CITED_SCRAPES_PER_ROUND = 3
@@ -5306,7 +5310,62 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						// no single extraction had the evidence to condemn — and a round that
 						// took none would otherwise overwrite the round that took one.
 						let blankedAfterFolds = 0
+						// Companies the rounds set out to ask for a site. Held apart from
+						// how many end up without one: a company never asked about and one
+						// asked about whose search found nothing want opposite fixes, and a
+						// single figure covering both cannot tell an operator which they have.
+						let websiteSearchesAsked = 0
+						const gapPolicy = (run as { paidPolicy: ResolvedPolicy | null })
+							.paidPolicy
+						// How many searches the step that confirms the list still has to buy.
+						// It runs last and spends whatever these rounds leave, so its share is
+						// set aside before they spend: a round that took the lot would turn
+						// companies the run could have stood behind into ones reported as
+						// unchecked for want of money, which says nothing about the company.
+						// Counted by the rule that step uses, so the two cannot disagree.
+						const searchesHeldForConfirming = (): number => {
+							const listField = discoveryResultField(schemaName)
+							if (listField === undefined) return 0
+							return rowsAwaitingConfirmation(
+								discoveryRows(schemaName, findings),
+								observeDirectorySites({
+									findings,
+									listField,
+									addresses: [...gatheredAddresses],
+									runWords: wordsTheRunBrings,
+								}).sites,
+								wordsTheRunBrings,
+							)
+						}
+						// What this round may spend at all, on anything. Both a fetch and a
+						// search come out of this one figure, so neither can quietly eat what
+						// was set aside for the other or for the confirming step. The margin
+						// that step keeps back for the brief comes off here too: left in, the
+						// rounds would spend it and that step would come up exactly that far
+						// short of the companies it was counting on.
+						const spendableThisRound = (): number =>
+							Math.max(
+								0,
+								(gapPolicy?.budgetCents ?? 0) -
+									cheapSpentCents -
+									gapSpentCents -
+									searchesHeldForConfirming() * SEARCH_COST_CENTS -
+									VERIFICATION_BUDGET_MARGIN_CENTS,
+							)
 						for (let gapRound = 1; gapRound <= MAX_GAP_ROUNDS; gapRound++) {
+							const openedHashes = new Set(
+								openedPages(scrapeCorpus).map(page => page.urlHash),
+							)
+							// Worked out before anything is bought, so what the round spends
+							// on fetches is known rather than assumed: reserving a fixed three
+							// would starve the searches on every round that has no cited page
+							// left to fetch, which is most of the later ones.
+							const citedWaiting = citedUnscrapedSources(
+								schemaName,
+								findings,
+								hash => openedHashes.has(hash) || citedAttempted.has(hash),
+								MAX_CITED_SCRAPES_PER_ROUND,
+							)
 							// Who the focused searches are about. A company profile searches
 							// under the anchored subject's name, which is the same name the
 							// entity guard holds the run's evidence to. A scan is handed it
@@ -5316,63 +5375,73 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								schemaName,
 								subjectName: entityName,
 							})
-							const perFieldTargets = perFieldGaps
-								.filter(
-									target =>
-										!gapsSearched.has(`${target.name}\u001F${target.field}`),
-								)
-								.slice(0, perFieldSearchCap(schemaName))
-							for (const target of perFieldTargets) {
-								gapsSearched.add(`${target.name}\u001F${target.field}`)
-							}
-							const openedHashes = new Set(
-								openedPages(scrapeCorpus).map(page => page.urlHash),
+							const unbought = perFieldGaps.filter(
+								target => !gapsSearched.has(perFieldSearchKey(target)),
 							)
-							const citedUnscraped = citedUnscrapedSources(
+
+							const spendable = spendableThisRound()
+							// Fetches are bought before searches, so they are taken off first.
+							const citedToFetch = citedWaiting.slice(
+								0,
+								Math.floor(spendable / SCRAPE_COST_CENTS),
+							)
+							const perFieldTargets = perFieldSearchRound(
 								schemaName,
-								findings,
-								hash => openedHashes.has(hash) || citedAttempted.has(hash),
-								MAX_CITED_SCRAPES_PER_ROUND,
+								unbought,
+								gapsSearched,
+								Math.floor(
+									(spendable - citedToFetch.length * SCRAPE_COST_CENTS) /
+										SEARCH_COST_CENTS,
+								),
 							)
+
 							// Grounded and fully fetched — nothing left to close.
-							if (perFieldTargets.length === 0 && citedUnscraped.length === 0)
-								break
-							const elapsedMs =
-								DateTime.toEpochMillis(DateTime.nowUnsafe()) - runStartedAtMs
-							const thinDeadline =
-								elapsedMs >
-								runDeadlineSeconds * 1000 * GAP_ROUND_DEADLINE_FRACTION
-							// Phase 2 has no live budget scope; the margin reads the run's
-							// policy budget less everything spent so far — phase 1 plus the
-							// gap rounds already run — so it actually tightens each round.
-							const gapPolicy = (run as { paidPolicy: ResolvedPolicy | null })
-								.paidPolicy
-							const thinBudget =
-								(gapPolicy?.budgetCents ?? 0) -
-									cheapSpentCents -
-									gapSpentCents <
-								SCRAPE_COST_CENTS * 2
-							if (thinDeadline || thinBudget) {
+							if (unbought.length === 0 && citedWaiting.length === 0) break
+							// Something left to buy and nothing to buy it with. Said out loud:
+							// a run stopped for want of money leaves the same silence as one
+							// that closed every gap, and only the first is worth acting on.
+							if (perFieldTargets.length === 0 && citedToFetch.length === 0) {
 								yield* Effect.logInfo('research.gap_rounds.stopped').pipe(
 									Effect.annotateLogs({
 										event: 'research.gap_rounds.stopped',
 										research_id: researchId,
 										round: gapRound,
-										reason: thinDeadline ? 'deadline_margin' : 'budget_margin',
+										reason: 'budget_margin',
 									}),
 								)
 								break
 							}
-							// Counted here, past both stop checks: the body below can leave
-							// by several different exits, so a round counted at the end
-							// would go unreported whenever it takes one of them.
+							const elapsedMs =
+								DateTime.toEpochMillis(DateTime.nowUnsafe()) - runStartedAtMs
+							const thinDeadline =
+								elapsedMs >
+								runDeadlineSeconds * 1000 * GAP_ROUND_DEADLINE_FRACTION
+							if (thinDeadline) {
+								yield* Effect.logInfo('research.gap_rounds.stopped').pipe(
+									Effect.annotateLogs({
+										event: 'research.gap_rounds.stopped',
+										research_id: researchId,
+										round: gapRound,
+										reason: 'deadline_margin',
+									}),
+								)
+								break
+							}
+							// Counted here, past every stop check: the body below can leave by
+							// several different exits, so a round counted at the end would go
+							// unreported whenever it takes one of them. What the round set out
+							// to buy is remembered here for the same reason, so a later round
+							// moves on rather than asking the same question again.
+							for (const target of perFieldTargets) {
+								gapsSearched.add(perFieldSearchKey(target))
+							}
 							gapRounds++
 							yield* recordProgress
 							const roundHashes: string[] = []
 							// Fetch the cited pages first: cheap certainty about sources
 							// the run already leans on.
 							yield* Effect.forEach(
-								citedUnscraped,
+								citedToFetch,
 								citedUrl =>
 									Effect.gen(function* () {
 										// Mark the attempt (fetched, empty, or errored) so a page that
@@ -5461,11 +5530,30 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								if (roundHashes.length > 0) yield* linkRunSources(roundHashes)
 								continue
 							}
-							const perFieldFired = perFieldTargets.length
+							// Counted as they fire rather than from the batch's length: the
+							// clock check below turns searches away once the batch is drawn
+							// up, and reporting the length would say the run went looking for
+							// companies it never reached.
+							let perFieldFired = 0
 							yield* Effect.forEach(
 								perFieldTargets,
 								target =>
 									Effect.gen(function* () {
+										// Checked per search, not once for the batch: a round of
+										// these is long enough to cross the whole-run deadline
+										// part way through, and crossing it does not degrade the
+										// run, it destroys it — the timeout fails the run and its
+										// findings are replaced with an error.
+										const searchElapsedMs =
+											DateTime.toEpochMillis(DateTime.nowUnsafe()) -
+											runStartedAtMs
+										if (
+											searchElapsedMs >
+											runDeadlineSeconds * 1000 * GAP_ROUND_DEADLINE_FRACTION
+										)
+											return
+										perFieldFired++
+										if (target.field === 'website') websiteSearchesAsked++
 										gapSpentCents += SEARCH_COST_CENTS
 										const searched = yield* gapSearch
 											.search({
@@ -5594,7 +5682,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									event: 'research.gap_rounds.closed',
 									research_id: researchId,
 									round: gapRound,
-									cited_fetched: citedUnscraped.length,
+									cited_fetched: citedToFetch.length,
 									fired: perFieldFired,
 									filled: merged.filled,
 									added: merged.added,
@@ -5610,6 +5698,25 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// nothing. A scan cites a page or three per company, so waiting
 							// for the cited pages to run out first would never stop it.
 							if (merged.filled === 0 && merged.added === 0) break
+						}
+						// How far the rounds reached, counted in companies: a cap on searches
+						// says nothing about how much of the list was served, and a company
+						// left with no site of its own has to be reached some other way
+						// before anybody can use it. Silent when the rounds served the whole
+						// list, which has nothing to report.
+						const listedRows = discoveryRows(schemaName, findings)
+						const withoutWebsite = rowsMissing(listedRows, 'website')
+						if (withoutWebsite > 0) {
+							yield* Effect.logInfo('research.gap_rounds.unreached').pipe(
+								Effect.annotateLogs({
+									event: 'research.gap_rounds.unreached',
+									research_id: researchId,
+									listed: listedRows.length,
+									without_website: withoutWebsite,
+									asked: websiteSearchesAsked,
+									rounds: gapRounds,
+								}),
+							)
 						}
 						yield* Ref.update(toolLog, log => [
 							...log,
@@ -5691,15 +5798,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// spent on the companies that need it.
 							const watchedBefore = watchedSites()
 							const stillShort = verificationRows.flatMap((row, at) =>
-								existenceOf({
-									name: rowName(row),
-									website: rowWebsite(row),
-									sources: rowCitedSourceIds(row),
-									directorySites: watchedBefore,
-									runWords: wordsTheRunBrings,
-								}).verdict === 'confirmed'
-									? []
-									: [at],
+								awaitsConfirmation(row, watchedBefore, wordsTheRunBrings)
+									? [at]
+									: [],
 							)
 
 							const verifyPolicy = (


### PR DESCRIPTION
Closes #496.

A market search comes back with a list of companies, and a later step buys extra web searches to fill in what the first pass left blank — a company's website, its headcount, the town it is in. It reached about the first third of the list, and spent two thirds of what it bought on the two facts that matter least.

Two separate faults, fixed separately.

## Priority: what the money is spent on

`needsPerFieldSearch` walked the list company by company and took each company's three blanks together, so it bought row 1's headcount and row 1's town before it bought row 4's website. It now walks the facts on the outside, so every company on the list is asked for its site before anybody is asked for a headcount.

This costs nothing. A full pass — one site lookup for every company — needs **29 lookups instead of 85** on a 29-row list, and **44 instead of 130** on a 44-row one, because reaching the last company's site no longer means buying every earlier company's headcount and town on the way.

## Reach: how much of the list is served

Eight searches a round over four rounds is thirty-two lookups, against market lists that came back between 27 and 68 companies long. On a 55-row list, 23 companies were never asked about anything.

A round may now buy fourteen. That is not simply a bigger number — it came with a budget rework, because the first attempt at it did real harm.

**A run's allowance is one purse.** It is a hundred searches and page-fetches together, or two hundred in production, and the step that confirms each company exists (#486) runs last and spends whatever these rounds leave. Raising the allowance without regard to that turned confirmations into "could not check": measured at fourteen a round, the confirming step wanted 37 companies and could afford 21, so **16 companies came back unchecked for want of money the rounds had already spent** — which says nothing about those companies at all, and is a worse answer than a blank site.

So each round now works out **one figure it may spend on anything**, with the confirming step's share and its margin taken off the top. Page-fetches come out of it first, because they are bought first; searches get what is left. Neither spender can eat what was set aside for the other. A round with work outstanding and nothing to pay for it now says `budget_margin` out loud instead of leaving through the "nothing left to close" exit, which reported a run that ran out of money as one that had finished.

What the confirming step needs is asked of the same rule that step uses (`awaitsConfirmation`, shared by both) rather than guessed at. Both guesses that suggest themselves are badly wrong: the list length over-reserves by about 45%, the count of companies with no site under-reserves by about 46%.

## Reported in companies, not in searches

`research.gap_rounds.unreached` says how many companies a run ended with no site, how many it went and asked, and over how many rounds. Asked and unserved are kept apart on purpose — a company never asked about and one asked about whose search found nothing want opposite fixes.

## Measured

Live re-runs of both market rows through `/run-research-eval`, on this commit, at production's two-hundred-point budget.

| market | listed | with a site | with a social page | cost |
| --- | --- | --- | --- | --- |
| ES | 66 | 47 (71%) | 4 | 7 |
| FR | 36 | 28 (78%) | 15 | 12 |

```
rounds fired: 14 14 14 14  ·  14 14 14 5
budget or deadline stops: 0      confirming ran short: 0
listed: 66, without_website: 19, asked: 51, rounds: 4
listed: 36, without_website:  8, asked: 15, rounds: 4
```

Every round spent its full allowance and the confirming step bought every search it wanted (40 and 25) — no starvation, which is what the rework was for. France's fourth round fired 5 of its 14 because the rounds ran out of companies to ask about rather than out of money.

The new figures earn their place immediately: Spain asked 51 companies and 19 still ended with no site, so that is a finding problem rather than a reach one; France asked 15 because that was all that needed asking. One number would have made the two look the same.

**Coverage is reported but not leaned on.** The same Spanish query has returned 34, 40, 66, 67 and 68 rows across passes, and French 27 to 55. That variance is far larger than anything this change does, so no coverage claim is supportable from it in either direction. The deterministic reach figures above are the claim.

## Alongside the social-page work

`social-website-rescue.ts` keeps a company's page on a platform when it was offered as its website. That lands directly on top of this change: these searches surface exactly those pages — `profile_page` blankings are 38 in the run above — and they are now kept instead of dropped. **19 companies in this pass carry a social page** that would previously have been thrown away.

A wider read may now also fold one in when a round turns one up without being sent after it. No search is ever spent going after a social page; the field was simply missing from the list of what a fold may write, so a page a round did find had nowhere to land.

## What this costs

Towns and headcounts are bought only once every company has been asked for a website, so on a list longer than the rounds can serve they may not be bought at all. Two guards read the town: the branch-office fold (`prospect-dedupe-guard.ts`) needs it to join "Acme SL" to "Acme SL Girona", and the name-only mark (`name-only-guard.ts`) uses it as its second escape hatch. Long lists will therefore fold fewer branches and mark more rows as name-only. A wider read can still fill the town from evidence the run already holds.

## Left for later

The loop still stops when a round fills nothing and finds nobody. That guard predates this change and its premise is weaker now — a fruitless round says less about the next one when each round asks about different companies. It never fired in any of the six live passes, so it is a spending decision rather than a defect, and it belongs with the shared-purse work rather than here.
