### PR TITLE
fix(cli): point the rehearsal sign-in link at a live address

### DIFF
--- a/.claude/skills/onboard-org/SKILL.md
+++ b/.claude/skills/onboard-org/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: onboard-org
 description: This skill should be used when the user asks to "set up a new org", "create an organization", "onboard a customer", "onboard <name>", "add a member", "add someone to an org", "give <person> access", "create a tenant", or asks what to send a new customer so they can start using Batuda from ChatGPT or Claude.ai. Covers the developer-only `pnpm cli auth` org + first-admin creation (production, rehearsed locally), how members are added afterwards, the one-organization-per-connection rule for people who belong to several orgs, read-only confirmation, and the English getting-started message to hand over.
-allowed-tools: Bash(pnpm:*) Bash(infisical:*) Read
+allowed-tools: Bash(pnpm:*) Bash(nix:*) WebFetch WebSearch Read
 ---
 
 # Onboarding a new organization
@@ -12,10 +12,30 @@ Only a Batuda developer can create an organization. Public signup is off
 database. Everything after the first admin is self-serve: that admin adds their own people
 from the web app.
 
-Four steps, in order: **rehearse → create → confirm → hand over** — §1, §2, §5 and §6. The
-two sections in between are reference for when they come up, not steps. Never skip the
-confirm — an org that reaches a customer half-made costs a support round-trip that a
-two-second read would have prevented.
+**Onboarding means production.** Somebody asking to onboard an org is asking for one a
+customer can sign into, so never stop at the local run and never ask which environment is
+meant. Local is step one of this job, not a destination: it is where the command is
+rehearsed before it touches the real database. Only build a local-only org if the person
+says so in as many words.
+
+Settle the details first (§0), then five steps in order: **rehearse → research → create →
+confirm → hand over** — §1 to §3, §6 and §7. The two sections in between are reference for
+when they come up, not steps. Never skip the confirm — an org that reaches a customer
+half-made costs a support round-trip that a two-second read would have prevented.
+
+## 0. Get the details right first
+
+Three of the values are permanent and customer-visible, and nothing downstream will catch a
+wrong one:
+
+- **The person's full name** — greets them in the app forever. Ask for it. Never build one
+  from the email address: `kobie@…` is not a name, and a guess is visible to them on day one.
+- **The organization name and slug** — take them from whoever asked, not from the email
+  domain. The name is what the customer reads; the slug is permanent.
+- **The email address** — read it back before the production run. A wrong slug aborts with
+  `OrgSlugTaken`, but a wrong email has no guard, no delete anywhere in the CLI, and prints
+  no link in production. A typo becomes an account nobody can sign into, and the first
+  symptom is a customer saying it does not work.
 
 ## 1. Rehearse locally
 
@@ -27,17 +47,59 @@ walks it.
 pnpm cli auth invite-admin --email owner@acme.com --name "Ada Lovelace" --org-name "Acme" --org-slug acme --locale en
 ```
 
-The CLI captures the magic link in-process and prints it. With `pnpm dev:server` running,
-open it and confirm the sign-in lands. (`pnpm cli auth bootstrap-org` is the other local
-path — first admin *and* org on an empty database; it refuses if any `"user"` row exists.)
+The CLI captures the magic link in-process and prints it, already pointing at the host and
+port this checkout is served on — a worktree included. With `pnpm dev:server` running, open
+it as printed and confirm the sign-in lands. (`pnpm cli auth bootstrap-org` is the other
+local path — first admin *and* org on an empty database; it refuses if any `"user"` row
+exists.)
 
-## 2. Create it in production
+Two things this leaves behind, both worth clearing when the rehearsal is done: the dev
+server is still running, and the rehearsal org and user stay in the local database — there
+is no delete for either, so `pnpm cli db reset` (drop and re-migrate) is the only way back,
+and it takes the rest of the local data with it.
+
+## 2. Research the organization and who it sells to
+
+The handover in §7 is not a form letter with a name dropped into it. Four of its lines — the
+standing instructions, the research request, the companies to add and the contact — have to be
+written for this customer, and they cannot be written without knowing who the customer sells
+to. So find that out before going near production.
+
+**Run this research automatically, as part of the job.** Do not ask whether to look them up,
+do not ask the person to describe their own market, and do not wait to be told to search — an
+onboarding request is the instruction. The only thing worth asking about is a company you
+genuinely cannot identify from its domain.
+
+Fetch their own site, then search for what a home page will not tell you — the kinds of
+company that actually buy this, any customers or case studies they publish, and the job title
+that signs off. Both halves are needed: a site states a pitch, and what the examples need is
+the shape of a real prospect list. Two or three searches is usually enough.
+
+Come out of it able to answer, in one sentence each:
+
+- **What they sell, in the words a buyer would use.**
+- **What kind of company buys it** — concrete enough to search for, not "businesses".
+- **Who inside that company decides**, by role.
+- **Where** — one country, a region, or anywhere. Only say a country when their market plainly
+  is one; otherwise say nothing about geography and let it stay worldwide.
+
+That is what the four examples get written from. If the research comes up thin, say so when
+handing the message over rather than padding the examples with guesses.
+
+This is reading and searching public pages to write a better message. Nothing is written to
+their records, nothing is bought, and no guess leaves the message.
+
+## 3. Create it in production
 
 Read the target host first, then pass it back as the confirm:
 
 ```bash
-infisical run --env=prod -- pnpm cli doctor --env cloud
+nix develop -c infisical run --env=prod -- pnpm cli doctor --env cloud
 ```
+
+`infisical` is a package in the flake's dev shell, not a global install, so every production
+command below is prefixed with `nix develop -c`. Without it they all die with
+`command not found`.
 
 That run adds a **Cloud DB host** row the local run does not have, carrying the host the
 connection will actually dial — which is not always the address the connection string
@@ -45,15 +107,15 @@ appears to name. That row's value is what `--confirm-host` wants. The check fail
 than guessing when `DATABASE_URL` is missing or still points at localhost.
 
 ```bash
-infisical run --env=prod -- pnpm cli auth invite-admin --env cloud --email owner@acme.com --name "Ada Lovelace" --org-name "Acme" --org-slug acme --locale en --confirm-host <host from doctor>
+nix develop -c infisical run --env=prod -- pnpm cli auth invite-admin --env cloud --email owner@acme.com --name "Ada Lovelace" --org-name "Acme" --org-slug acme --locale en --confirm-host <host from doctor>
 ```
 
 What each part is doing, and the traps:
 
-- **Two independent halves.** `infisical run --env=prod` injects the secrets into this one
-  process; `--env cloud` layers the non-secret settings from
-  `apps/server/config.production.json`. Neither stands in for the other, and anything
-  already in the environment outranks both.
+- **Three independent parts.** `nix develop -c` puts `infisical` on the path;
+  `infisical run --env=prod` injects the secrets into this one process; `--env cloud` layers
+  the non-secret settings from `apps/server/config.production.json`. None stands in for
+  another, and anything already in the environment outranks the lot.
 - **`--confirm-host` replaces the interactive `y/N`** and refuses if it disagrees with the
   resolved `DATABASE_URL`. That is what makes a forgotten `--env cloud` harmless instead of
   a write to the wrong database. Never guess the value — read it from the `Cloud DB host`
@@ -69,12 +131,15 @@ What each part is doing, and the traps:
 - **The role follows the org**: creating one makes them `owner`, joining an existing one
   makes them `admin`.
 - **`--locale en|ca`** decides the language of their welcome email and their first visit.
-  Omitted leaves it unset.
+  Pass `ca` only for a customer who works in Catalan and `en` for everyone else. Always pass
+  one: omitted leaves the column null, and a null hands the choice to whatever the browser
+  asks for — so a Catalan-configured laptop opens an English customer's account in Catalan.
+  English is only where it lands once the browser offers nothing either.
 
 Secrets never go in argv — pnpm echoes its arguments. Nothing here takes one; keep it that
 way.
 
-## 3. Adding more people
+## 4. Adding more people
 
 - **Another admin, from the CLI** — the same `invite-admin` command with the same
   `--org-slug` plus `--allow-existing-org`. An email that already has an account is reused:
@@ -89,7 +154,7 @@ way.
 Prefer handing that second path — the members form — to the admin over running it for them.
 It is theirs, it is one form, and it keeps a developer out of the customer's daily work.
 
-## 4. People who belong to more than one organization
+## 5. People who belong to more than one organization
 
 An assistant acts in **exactly one organization per call**. A connection authorized for
 several has every call refused, with:
@@ -118,7 +183,7 @@ Reading the state on that page:
 | One organization chip                                  | Working. This is the state to aim for.                                                                                                     |
 | All your organizations                                 | Nobody has chosen. It reaches every org this person belongs to — which is what breaks every call for anyone in more than one organization. |
 | No organization selected                               | Every organization has been cut off from this connection. It reaches nothing.                                                              |
-| An owner removed this one. Ask them to allow it again. | The organization stopped it, so the member cannot tick it back on. §4.1                                                                    |
+| An owner removed this one. Ask them to allow it again. | The organization stopped it, so the member cannot tick it back on. §5.1                                                                    |
 
 Consequences to state in the handover when they apply:
 
@@ -127,7 +192,7 @@ Consequences to state in the handover when they apply:
 - An API key is pinned to one organization for its whole life, so a coding tool needs one
   key per org.
 
-### 4.1 Who can undo a stop, and who cannot
+### 5.1 Who can undo a stop, and who cannot
 
 A stop records who made it, and that record alone decides who can lift it.
 
@@ -150,17 +215,20 @@ not a developer, and not a reconnect.
 Include the multi-org part of the handover **only** for people it actually applies to. For a
 single-org person it is noise that invites them to change a setting that is already right.
 
-## 5. Confirm — read-only
+## 6. Confirm — read-only
 
 Nothing below writes anything or spends anything.
 
 ```bash
-infisical run --env=prod -- pnpm cli data orgs --env cloud
+nix develop -c infisical run --env=prod -- pnpm cli data orgs --env cloud
 ```
 
 ```bash
-infisical run --env=prod -- pnpm cli data members --env cloud
+nix develop -c infisical run --env=prod -- pnpm cli data members --env cloud
 ```
+
+Every command here prints the flake's shell banner and a couple of deprecation warnings from
+the database driver before its table. That is normal output, not a failure — read the table.
 
 What a healthy result looks like:
 
@@ -168,23 +236,45 @@ What a healthy result looks like:
 - `data members` — the person's email against that org slug, with the role that was
   intended (`owner` for a new org, `admin` for a joined one). One row per membership, so
   this is also where a multi-org person shows up as two rows.
-- `infisical run --env=prod -- pnpm cli auth list-users --env cloud` — the account itself,
-  if the email needs checking. Both halves are needed here too; without them it reads the
-  local database and reports a healthy-looking absence.
+- `nix develop -c infisical run --env=prod -- pnpm cli auth list-users --env cloud` — the
+  account itself, if the email needs checking. Every part is needed here too; without them it
+  reads the local database and reports a healthy-looking absence.
 
 If the org row exists with a member count of 0, the membership did not land. Re-run the same
 `invite-admin` with `--allow-existing-org` — without it the slug that already exists aborts
 with `OrgSlugTaken` — rather than creating a second org under a new slug. The account is
 reused, and the role lands as `admin` rather than `owner`, because the org is no longer new.
 
-## 6. Hand over the getting-started message
+**Then read the same output for your own account.** Adding yourself for support is what tips
+a developer's own address past one organization, and §5 applies to you exactly as it does to
+a customer: from the next call, every request through your own connection is refused until
+you pick one organization at `https://batuda.co/settings/mcp/connections`. Count your own
+rows in `data members` before moving on — the cost of missing it is your own tooling
+breaking later, somewhere that looks unrelated.
+
+## 7. Hand over the getting-started message
 
 Read `references/handover-message.md`, fill the placeholders, and **print the finished
 message in the conversation** in English, ready to paste into an email or a chat. Do not
 write it to a file unless asked for one.
 
-Fill in: the organization name, the person's first name, `https://batuda.co`,
-`https://api.batuda.co/mcp`. Keep or drop the multi-organization block per §4.
+Fill in: the organization name, the person's first name, `https://batuda.co`, and
+`https://api.batuda.co/mcp`.
+
+**Then write the four example prompts from the §2 research** — the standing instructions, the
+research request, the companies to add and the contact. The template carries no wording for
+these on purpose: they are the part a new customer reads to decide whether this tool
+understands their work, and somebody else's prospects answer that badly. The reference file
+says what each one has to do; the worked illustration in it is there to show the shape and is
+never pasted.
+
+**Keep or drop the multi-organization block** on the evidence already in front of you rather
+than on a guess: count that person's rows in the §6 `data members` output. Two or more means
+keep it, one means drop it, for the reason §5 gives.
+
+**Say who sends it.** Production emails nothing, so until somebody writes to them the
+customer does not know the account exists. Print the message and say plainly that it still
+needs sending, and from whose address.
 
 The message is customer-facing copy, so it follows `docs/brand-voice.md`:
 
@@ -201,10 +291,11 @@ their email will be in Catalan even though this message is English.
 
 | Symptom                                    | Cause and fix                                                                                                       |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `infisical: command not found`             | The `nix develop -c` prefix is missing — it is a flake dev-shell package, not a global install. §3.                 |
 | `UsersAlreadyExist`                        | `bootstrap-org` ran against a database that already has users. Use `invite-admin`.                                  |
 | `OrgSlugTaken`                             | The slug exists. Check for a typo; add `--allow-existing-org` only if joining it is the intent.                     |
 | The command refuses the host               | `--confirm-host` disagrees with the resolved `DATABASE_URL` — the target is not what was assumed. Re-read `doctor`. |
-| Customer says every request is refused     | Multi-organization connection. §4.                                                                                  |
+| Customer says every request is refused     | Multi-organization connection. §5.                                                                                  |
 | Customer signed in but sees 403 everywhere | Signed in with no organization. Check `data members` for a membership row.                                          |
 
 ## Additional resources

--- a/.claude/skills/onboard-org/references/handover-message.md
+++ b/.claude/skills/onboard-org/references/handover-message.md
@@ -1,16 +1,21 @@
 # The getting-started message
 
 The message a new organization's first admin receives once their account exists. English
-only. Print it in the conversation, filled in and ready to paste — never send it anywhere.
+only. Print it in the conversation, filled in and ready to paste — never send it anywhere,
+and say when handing it over that it still needs sending, since production emails nothing.
 
 Placeholders to replace:
 
-| Placeholder      | Value                                                    |
-| ---------------- | -------------------------------------------------------- |
-| `{{FIRST_NAME}}` | The person's first name                                  |
-| `{{ORG_NAME}}`   | The organization display name, exactly as it was created |
-| `{{APP_URL}}`    | `https://batuda.co`                                      |
-| `{{MCP_URL}}`    | `https://api.batuda.co/mcp`                              |
+| Placeholder                | Value                                                    |
+| -------------------------- | -------------------------------------------------------- |
+| `{{FIRST_NAME}}`           | The person's first name                                  |
+| `{{ORG_NAME}}`             | The organization display name, exactly as it was created |
+| `{{APP_URL}}`              | `https://batuda.co`                                      |
+| `{{MCP_URL}}`              | `https://api.batuda.co/mcp`                              |
+| `{{INSTRUCTIONS_EXAMPLE}}` | Written per customer — see *Writing the four examples*   |
+| `{{RESEARCH_EXAMPLE}}`     | Written per customer — see *Writing the four examples*   |
+| `{{COMPANIES_EXAMPLE}}`    | Written per customer — see *Writing the four examples*   |
+| `{{CONTACT_EXAMPLE}}`      | Written per customer — see *Writing the four examples*   |
 
 Keep the **If you work in more than one place** section only when that person actually
 belongs to more than one organization (`pnpm cli data members`). Drop it otherwise.
@@ -18,6 +23,45 @@ belongs to more than one organization (`pnpm cli data members`). Drop it otherwi
 Trim rather than pad. If they only bought research, cut the companies-and-people section;
 if they are not connecting a chat yet, cut everything after sign-in and say so when handing
 the message over.
+
+## Writing the four examples
+
+**There is no stock wording for these.** The four `{{…}}_EXAMPLE` slots are written fresh for
+each customer out of the §2 research, and a message that reaches somebody with generic
+examples in it has failed at the one thing it is for. A new customer judges whether this tool
+understands their work by whether the sample prompts look like something they would type. A
+prospecting tool that opens with somebody else's prospects answers that question badly.
+
+Write all four in the customer's own market — the companies they sell to, the roles they sell
+to, the words they would use:
+
+- **`{{INSTRUCTIONS_EXAMPLE}}`** — the thing they would want said about *every* company, every
+  time. A standing want, not a filter: "always tell me X and Y", not "only companies under 50
+  people". End it with "Save that." so the example teaches the habit.
+- **`{{RESEARCH_EXAMPLE}}`** — a request for **many companies, not one**. This is the one that
+  matters most. It has to read as a search for a set worth talking to, not a lookup of a
+  company they already knew about. No invented limits on size or revenue: say what kind of
+  company they want and leave the rest open. Name a country only when their market plainly is
+  one country; when they sell anywhere, say nothing about geography.
+- **`{{COMPANIES_EXAMPLE}}`** — three real companies that would genuinely be on their list.
+  Not their existing customers, which reads as careless, and not household names picked for
+  recognition.
+- **`{{CONTACT_EXAMPLE}}`** — a person at one of those three, with the job title that actually
+  decides in their market, and an email in that company's domain. The person is a stand-in; the
+  role and the company are not.
+
+Worked illustration for a company that sells cleaning supplies to restaurants in Girona —
+included to show the shape, **never to paste**:
+
+> Instructions: "Whenever you research a company, always tell me how many covers they do and
+> whether they have their own kitchen. Save that."
+> Research: "Find restaurants and hotel kitchens around Girona that cook on site. Tell me who
+> handles buying at each."
+> Companies: "Add these three as prospects: Can Roca, Hotel Ultònia, Fonda Bruguera."
+> Contact: "Add Marta Puig as head chef at Fonda Bruguera, marta@fondabruguera.cat."
+
+If §2 came up too thin to write these honestly, say so when handing the message over instead
+of inventing companies — a made-up prospect list is worse than none.
 
 ---
 
@@ -46,21 +90,22 @@ Either way it asks you to approve it once, in your own browser, with your own si
 you also code, {{APP_URL}}/settings/mcp has ready-made snippets for Claude Code, Cursor, VS
 Code and the rest.
 
-**Telling it how you work.** Say your standing rules once and ask it to remember them:
+**Telling it how you work.** Say once what you always want, and ask it to remember:
 
-> "From now on, when you research a company, I only care about firms under 50 people in
-> Catalonia, and I always want the owner's email if you can find it. Save that."
+> {{INSTRUCTIONS_EXAMPLE}}
 
-It keeps those rules and applies them to later work without being reminded. To see what it
-is following, just ask — *"what rules are you using for research?"* You can read or edit the
-same list at {{APP_URL}}/settings/organization/templates, shared with your team. A rule that
-is only yours lives at {{APP_URL}}/settings/profile/templates.
+It keeps that and applies it to later work without being reminded. The same works for email
+— tell it how you want messages written once and it follows that from then on. To see what
+it is following, just ask — *"what are you following for research?"* You can read or edit the
+same list at {{APP_URL}}/settings/organization/templates, shared with your team, so anything
+you change there changes it for everyone. Something that is only yours lives at
+{{APP_URL}}/settings/profile/templates.
 
-**Asking it to research.** Name a company and say what you want to know:
+**Asking it to research.** Point it at a whole set of companies, not one at a time:
 
-> "Research Forn Sant Jordi in Girona. Do they fit what I sell, and who decides?"
+> {{RESEARCH_EXAMPLE}}
 
-It goes off and reads the company's own site, public records where a country keeps them, and
+It goes off and reads each company's own site, public records where a country keeps them, and
 the web. That takes a few minutes — you can keep working. It comes back with what it
 found and where each fact came from, and it never changes your records on its own: it
 proposes, you accept. The proposals are waiting for you under Research at {{APP_URL}}
@@ -68,10 +113,9 @@ whenever you want to look.
 
 **Adding companies and people.** Plain language works:
 
-> "Add these three as prospects: Cal Met, Forn Sant Jordi, Vins del Ter. All bakeries in
-> Girona."
+> {{COMPANIES_EXAMPLE}}
 
-> "Add Marta Puig as the owner at Cal Met, marta@calmet.cat."
+> {{CONTACT_EXAMPLE}}
 
 **If you work in more than one place.** An assistant works in one organization at a time.
 When you approve the connector it ticks every organization you belong to, and then nothing

--- a/apps/cli/src/commands/auth-invite-admin.ts
+++ b/apps/cli/src/commands/auth-invite-admin.ts
@@ -9,6 +9,7 @@ import {
 import { acquireAuthAdapter } from '../lib/auth-adapter'
 import { confirmCloud } from '../lib/confirm-cloud'
 import { isLocalDatabase } from '../lib/database-host'
+import { reachableSignInLink } from '../lib/dev-sign-in-link'
 
 export interface AuthInviteAdminInput {
 	readonly email: string
@@ -123,7 +124,7 @@ export const authInviteAdmin = (input: AuthInviteAdminInput) =>
 
 		yield* Console.log('Magic link (valid for 5 minutes):')
 		yield* Console.log('')
-		yield* Console.log(`  ${link.url}`)
+		yield* Console.log(`  ${reachableSignInLink(link.url)}`)
 		yield* Console.log('')
 		yield* Console.log(
 			'Start the server (`pnpm dev:server`) and open the link to complete sign-in.',

--- a/apps/cli/src/commands/auth-invite.ts
+++ b/apps/cli/src/commands/auth-invite.ts
@@ -10,6 +10,7 @@ import {
 import { acquireAuthAdapter } from '../lib/auth-adapter'
 import { confirmCloud } from '../lib/confirm-cloud'
 import { isLocalDatabase } from '../lib/database-host'
+import { reachableSignInLink } from '../lib/dev-sign-in-link'
 
 export interface AuthInviteInput {
 	readonly email: string
@@ -105,7 +106,7 @@ export const authInvite = (input: AuthInviteInput) =>
 
 		yield* Console.log('Magic link (valid for 5 minutes):')
 		yield* Console.log('')
-		yield* Console.log(`  ${link.url}`)
+		yield* Console.log(`  ${reachableSignInLink(link.url)}`)
 		yield* Console.log('')
 		yield* Console.log(
 			'Start the server (`pnpm dev:server`) and open the link to complete sign-in.',

--- a/apps/cli/src/lib/dev-sign-in-link.test.ts
+++ b/apps/cli/src/lib/dev-sign-in-link.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { onProxyOrigin, serviceNameFor } from './dev-sign-in-link'
+
+const MINTED =
+	'https://api.batuda.localhost/auth/magic-link/verify?token=ABC123&callbackURL=%2F'
+
+describe('serviceNameFor', () => {
+	describe('when the proxy serves the host', () => {
+		it.each([
+			['api.batuda.localhost', 'api.batuda'],
+			// A worktree is served under a host of its own, and the whole thing is
+			// still one name as far as the proxy is concerned.
+			[
+				'onboard-org-fixes.api.batuda.localhost',
+				'onboard-org-fixes.api.batuda',
+			],
+		])('should read %s as %s', (hostname, expected) => {
+			// GIVEN a host the local proxy serves
+			// WHEN its service name is read
+			// THEN it is the host with the local suffix taken off
+			expect(serviceNameFor(hostname)).toBe(expected)
+		})
+	})
+
+	describe('when the proxy serves no such host', () => {
+		// Anything here must leave the link alone, so a deployment's link is
+		// printed exactly as minted and a lookalike host is never trusted.
+		it.each([
+			['a deployment', 'api.batuda.co'],
+			['a lookalike host', 'api.batuda.localhost.evil.com'],
+			['a bare localhost with no name in front', 'localhost'],
+			['nothing at all', ''],
+		])('should read %s as no service', (_label, hostname) => {
+			// GIVEN a host that is not a named local service
+			// WHEN its service name is read
+			// THEN there is none
+			expect(serviceNameFor(hostname)).toBeNull()
+		})
+	})
+})
+
+describe('onProxyOrigin', () => {
+	describe('when the proxy answers on a different address', () => {
+		it('should move the link there', () => {
+			// GIVEN a link minted against the plain host
+			// WHEN it is moved onto the address the proxy reported
+			const link = onProxyOrigin(
+				MINTED,
+				'https://onboard-org-fixes.api.batuda.localhost:1355',
+			)
+
+			// THEN it points at the server that holds the token
+			expect(link).toBe(
+				'https://onboard-org-fixes.api.batuda.localhost:1355/auth/magic-link/verify?token=ABC123&callbackURL=%2F',
+			)
+		})
+
+		it('should keep the token and callback exactly', () => {
+			// GIVEN a link whose callback is percent-encoded
+			// WHEN it is moved onto another address
+			const link = onProxyOrigin(MINTED, 'https://wt.api.batuda.localhost:1355')
+
+			// THEN both survive verbatim — re-encoding either would break sign-in
+			expect(link).toContain('token=ABC123')
+			expect(link).toContain('callbackURL=%2F')
+		})
+
+		it('should take the port from the address, including dropping one', () => {
+			// GIVEN a link that already names a port
+			const url = 'https://api.batuda.localhost:8443/auth'
+
+			// WHEN the proxy reports it holds the standard port instead
+			// THEN the link follows the proxy, since that is what is listening
+			expect(onProxyOrigin(url, 'https://api.batuda.localhost')).toBe(
+				'https://api.batuda.localhost/auth',
+			)
+		})
+	})
+
+	describe('when either side cannot be read', () => {
+		it.each([
+			['the link is not a URL', 'not-a-url', 'https://x.localhost:1355'],
+			['the link is empty', '', 'https://x.localhost:1355'],
+			['the address is not a URL', MINTED, 'nonsense'],
+			['the address is empty', MINTED, ''],
+		])('should return the link unchanged when %s', (_label, url, origin) => {
+			// GIVEN text that cannot be parsed on one side or the other
+			// WHEN the move is attempted
+			// THEN the link comes back untouched rather than throwing mid-command
+			expect(onProxyOrigin(url, origin)).toBe(url)
+		})
+	})
+})

--- a/apps/cli/src/lib/dev-sign-in-link.ts
+++ b/apps/cli/src/lib/dev-sign-in-link.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from 'node:child_process'
+
+// Every address the local proxy serves sits under this suffix, and what comes
+// before it is the name it knows the service by.
+const LOCAL_SUFFIX = '.localhost'
+
+/**
+ * The name the local proxy knows a host by, or nothing when it serves no such
+ * host — a deployment, or a bare `localhost` with no name in front of it.
+ */
+export const serviceNameFor = (hostname: string): string | null => {
+	if (!hostname.endsWith(LOCAL_SUFFIX)) return null
+	const service = hostname.slice(0, -LOCAL_SUFFIX.length)
+	return service === '' ? null : service
+}
+
+/**
+ * The address the local proxy serves a named service on, or nothing when it
+ * cannot be asked.
+ *
+ * It answers from its own naming rule rather than from anything running, so this
+ * works before the server is started, and the answer already accounts for the
+ * port it managed to bind and for a worktree being served under a host of its
+ * own. Asking it beats working the same answer out here: the rules are its to
+ * change, and a copy of them here would drift the first time they did.
+ */
+const proxyOrigin = (service: string): string | null => {
+	try {
+		const printed = execFileSync('pnpm', ['exec', 'portless', 'get', service], {
+			encoding: 'utf-8',
+			timeout: 15_000,
+			stdio: ['ignore', 'pipe', 'ignore'],
+		}).trim()
+		return printed.startsWith('https://') || printed.startsWith('http://')
+			? printed
+			: null
+	} catch {
+		// No proxy to ask, so the link stands as it was minted.
+		return null
+	}
+}
+
+/**
+ * Move a link onto a given address, keeping everything that identifies it.
+ *
+ * Only the scheme, host and port are replaced: the path, the token and the
+ * callback have to survive exactly, since re-encoding any of them would break
+ * the sign-in the link exists for.
+ */
+export const onProxyOrigin = (url: string, origin: string): string => {
+	try {
+		const parsed = new URL(url)
+		const proxy = new URL(origin)
+		parsed.protocol = proxy.protocol
+		parsed.host = proxy.host
+		// Assigning a host with no port of its own leaves any port already on the
+		// link in place, so the port is set on its own to follow the proxy either
+		// way — an empty one clears it.
+		parsed.port = proxy.port
+		return parsed.toString()
+	} catch {
+		return url
+	}
+}
+
+/**
+ * A sign-in link the developer can open as printed.
+ *
+ * The link is minted from `BETTER_AUTH_BASE_URL`, which names no port and no
+ * worktree on purpose. The server fills both in from `PORTLESS_URL` at boot, but
+ * this command runs on its own and never sees it, so it asks the proxy directly.
+ * A link for a deployment is left exactly as minted.
+ */
+export const reachableSignInLink = (url: string): string => {
+	let hostname: string
+	try {
+		hostname = new URL(url).hostname
+	} catch {
+		return url
+	}
+
+	const service = serviceNameFor(hostname)
+	if (service === null) return url
+
+	const origin = proxyOrigin(service)
+	return origin === null ? url : onProxyOrigin(url, origin)
+}


### PR DESCRIPTION
## What

Onboarding a new customer organization is a developer-only job driven by the `/onboard-org` skill and the `pnpm cli auth` commands. Two things made it slower and more error-prone than it should be, and this fixes both. First, every production step in the skill was missing a prefix it needs to run at all, so the documented commands failed outright. Second, the local rehearsal printed a sign-in link pointing at an address nothing was listening on, so it had to be hand-edited before it could be opened. Alongside those, the getting-started message handed to a new customer shipped with fixed examples from one market — Catalan bakeries — which reads as somebody else's onboarding doc to everyone else; those examples are now written per customer from research. This touches the command-line tool (`cli`) and the skill; no product surface changes.

## Changes

**Touches:** the sign-in link the rehearsal prints, and the onboarding skill plus the customer message it hands over.

- The printed sign-in link now names the address that actually answers. It is minted from `BETTER_AUTH_BASE_URL`, which deliberately records neither a port nor a worktree name, because the local proxy (portless) takes port 443 when it can and a high port when it cannot, and it serves each worktree under a host derived from the branch. The server learns the real address from `PORTLESS_URL` at boot; this command runs on its own and never sees it, so it now asks the proxy directly via `portless get <service>`, which answers from its own naming rule and so works before the server is running. A link for a real deployment is printed exactly as minted.
- Every production command in the skill gained the `nix develop -c` prefix that puts Infisical — the tool holding the production secrets — on the path. It is a package in the project's Nix dev shell rather than a global install, so all five commands previously died with `command not found`. A sibling skill already did this correctly; this one had drifted.
- The skill now states that onboarding means production, so it stops treating the local run as a possible destination or asking which environment was meant.
- Added a research step that runs automatically: fetch the customer's own site and search for who actually buys from them, without asking permission or asking the customer to describe their own market.
- The handover message is no longer static. Its four example prompts — the standing instructions, the research request, the companies to add and the contact — are placeholders with no shipped wording, written per customer from that research. The research example now asks for a set of companies rather than one, and carries no invented size or country limits. A worked illustration stays in the reference file, marked never to paste.
- Added a section on getting the permanent details right first: the person's real name, the organization name and slug, and the email read back before the run. A wrong slug is caught (`OrgSlugTaken`); a wrong email is caught by nothing, cannot be deleted through the CLI, and produces an account nobody can sign into.
- The message now also mentions that saved instructions apply to email as well as research, which it never said, and warns that adding your own account for support is what pushes a developer past one organization — which refuses every call through their own assistant connection until they pick one.

## Impact

- **Nothing touching which organization can see what (row-level security), the shared HTTP and assistant surfaces, the data shapes the web app consumes, or the database schema.** No migration, no new environment variable, no change to how anyone signs in or what they can reach.
- **The link change affects only addresses the local proxy serves** — a host ending in `.localhost` with a name in front of it. Anything else, including every production link, is returned exactly as it came in, and the token, its expiry and the callback survive untouched.
- **The skill is instructions, not code.** It changes what a developer is told to run, not what any deployed service does.

## Review guide

Start with `apps/cli/src/lib/dev-sign-in-link.ts` — under 90 lines, and the only real logic. The thing worth checking is the decision behind it: an earlier version worked the answer out locally by inspecting git and the proxy's port file, and I replaced it with a single call to `portless get`. Re-deriving another tool's naming rules meant keeping a copy of them in step, and I had already got that copy wrong in two ways before deleting it. Asking the tool that owns the rules removed both bugs and shrank the file.

`serviceNameFor` and `onProxyOrigin` are pure and fully covered. `proxyOrigin` shells out and is covered by the live check below rather than by unit tests.

The skill diff is prose. Two things worth an opinion: whether production-by-default is the behavior you want, and whether making the four customer-facing examples mandatory-to-write (rather than shipping wording that could be pasted) is the right trade — it costs a research step on every onboarding.

## Tests

Fifteen cases across the two pure functions: reading a service name from plain and worktree hosts, refusing deployment hosts, lookalike hosts and a bare `localhost`; moving a link onto a reported address while preserving the token and the percent-encoded callback; taking the port from that address including clearing one; and returning the link untouched when either side cannot be parsed.

One of these caught a real bug while being written: assigning a URL's `host` when the new host names no port leaves the old port in place, so a link could have kept a stale one. The port is now set separately.

## Verification

- `pnpm check-types`, `pnpm test` (21 tasks, including 1,029 server tests and 56 in the command-line tool) and `pnpm build` all green from the worktree; lint and formatting clean.
- Ran the actual rehearsal against a live worktree stack and opened the printed link with no hand-editing: 302 with a session cookie. Before this change the same link returned a connection failure, and inside a worktree a 404.
- Ran the skill's own production `doctor` command from the worktree to confirm the `nix develop -c` form is copy-pasteable and reports the expected database host.
- Confirmed `portless get` answers correctly in both the main checkout and a worktree, and with the server stopped.
- Confirmed every placeholder in the message body is declared in the template's table, and that the message carries no leftover stock company names.

## Notes

The local rehearsal still leaves its organization and user in the local database, since there is no delete for either. The skill now says so and points at `pnpm cli db reset` as the way back, noting it takes the rest of the local data with it.
