### PR TITLE
fix(research): say when a company's name cannot be read, instead of checking nothing

### DIFF
--- a/apps/internal/src/components/research/findings/shared.tsx
+++ b/apps/internal/src/components/research/findings/shared.tsx
@@ -79,6 +79,11 @@ export type CommonFindings = {
 	readonly quality?: {
 		readonly low_confidence?: boolean
 		/**
+		 * Set by a run about a company whose name it could not read, so none of the
+		 * checks that ask whether the pages are that company's ever ran.
+		 */
+		readonly subject_unreadable?: boolean
+		/**
 		 * Which kinds of company the request asked for came back with rows and which
 		 * did not. Only a search that was asked about several carries it.
 		 */
@@ -298,6 +303,12 @@ export function CommonSections({
 	const foundNothing = findings?.reason === 'no_reliable_data'
 	const needsReading =
 		!foundNothing && findings?.quality?.low_confidence === true
+	// Named apart from the caution above: that one says the run wants reading,
+	// this says the single thing about it nobody could check. A reader told only
+	// "read this" has no way to tell it from a run that was checked and came back
+	// unsure, which is a much smaller worry.
+	const subjectUnreadable =
+		!foundNothing && findings?.quality?.subject_unreadable === true
 	// A search asked about several kinds of company can come back with a long list
 	// answering one of them. Naming the ones it came back with nobody for is what
 	// lets a reader tell "this market has none" from "the search stopped early" —
@@ -325,6 +336,16 @@ export function CommonSections({
 				<Section data-testid='research-needs-reading'>
 					<NeedsReadingFlag>
 						<Trans>Read this before it goes into a record</Trans>
+					</NeedsReadingFlag>
+				</Section>
+			) : null}
+			{subjectUnreadable ? (
+				<Section data-testid='research-subject-unreadable'>
+					<NeedsReadingFlag>
+						<Trans>
+							This company's name could not be read, so nothing checked the
+							pages are its own
+						</Trans>
 					</NeedsReadingFlag>
 				</Section>
 			) : null}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -5950,6 +5950,10 @@ msgstr "Aquest assistent treballa a les organitzacions que marquis aquí."
 msgid "This company can't be displayed"
 msgstr "Aquesta empresa no es pot mostrar"
 
+#: src/components/research/findings/shared.tsx
+msgid "This company's name could not be read, so nothing checked the pages are its own"
+msgstr "No s'ha pogut llegir el nom d'aquesta empresa, així que res no ha comprovat que les pàgines siguin seves"
+
 #: src/components/companies/documents-panel.tsx
 msgid "This document is a web page. It opens in a new tab."
 msgstr "Aquest document és una pàgina web. S'obre en una pestanya nova."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -5950,6 +5950,10 @@ msgstr "This assistant works in the organizations you tick here."
 msgid "This company can't be displayed"
 msgstr "This company can't be displayed"
 
+#: src/components/research/findings/shared.tsx
+msgid "This company's name could not be read, so nothing checked the pages are its own"
+msgstr "This company's name could not be read, so nothing checked the pages are its own"
+
 #: src/components/companies/documents-panel.tsx
 msgid "This document is a web page. It opens in a new tab."
 msgstr "This document is a web page. It opens in a new tab."

--- a/apps/server/src/services/research-entity-gate.integration.test.ts
+++ b/apps/server/src/services/research-entity-gate.integration.test.ts
@@ -35,8 +35,9 @@ import { enterOrgScope } from '../middleware/org.js'
 // is about a DIFFERENT company must fail closed to no_reliable_data; one that
 // clearly names the target must still succeed; a run that only glancingly
 // mentions it must keep what it found but finish marked for review rather than
-// presented as certain; and a run whose only scrape FAILS must resolve to
-// no_reliable_data, not failed.
+// presented as certain; a run whose subject's name yields no key at all must say
+// so and finish marked for review, since every one of those checks was skipped;
+// and a run whose only scrape FAILS must resolve to no_reliable_data, not failed.
 //
 // One shared ResearchService layer drives every case (a fresh layer per case
 // would start a fresh dispatcher + connection pool each time and exhaust the CI
@@ -254,7 +255,7 @@ interface RunResult {
 	readonly sourceCount: number
 	readonly findings: {
 		proposed_updates?: unknown[]
-		quality?: { low_confidence?: boolean }
+		quality?: { low_confidence?: boolean; subject_unreadable?: boolean }
 	} | null
 }
 
@@ -425,6 +426,59 @@ describe('ResearchService entity grounding gate', () => {
 			).toBe('succeeded_low_confidence')
 			// AND it says outright that somebody has to read it before acting
 			expect(result.findings?.quality?.low_confidence).toBe(true)
+		}, 30_000)
+	})
+
+	describe("when the subject's name yields no match key at all", () => {
+		it('should say so and finish marked for review, not as a clean success', async () => {
+			// GIVEN an enrichment run for a company written in an alphabet the name
+			//   reading has no plain letters for, whose only scrape returns a page
+			//   about an entirely different company
+			const result = await runScenario({
+				query: '株式会社山田電気',
+				schemaName: 'company_enrichment_v1',
+				url: `https://unread-${randomUUID()}.example/about`,
+				markdown: 'Topia Freight is a load broker based in Denver, Colorado.',
+				isFailure: false,
+			})
+
+			// THEN it does not come back as a clean success. Nothing held those
+			//   pages against the company, so nobody checked this run at all
+			expect(
+				result.status,
+				`unexpected status: ${result.errorMessage ?? '(none)'}`,
+			).toBe('succeeded_low_confidence')
+			// AND the run's own answer says why, so a person reading the result sees
+			//   it without going to the logs
+			expect(result.findings?.quality?.subject_unreadable).toBe(true)
+			expect(result.findings?.quality?.low_confidence).toBe(true)
+			// AND what it found is still handed back — this marks the run for
+			//   reading, it does not throw the work away
+			expect(result.findings?.proposed_updates).toHaveLength(1)
+		}, 30_000)
+	})
+
+	describe('when the subject went unread and the run also found nothing', () => {
+		it('should still say the subject went unread', async () => {
+			// GIVEN an enrichment run for a company written in another alphabet whose
+			//   single scrape_page call fails, so no page is fetched at all
+			const result = await runScenario({
+				query: 'Строймонтаж Иванов',
+				schemaName: 'company_enrichment_v1',
+				url: `https://unread-dead-${randomUUID()}.example/x`,
+				markdown: '',
+				isFailure: true,
+			})
+
+			// THEN it reports no reliable data, because it grounded nothing
+			expect(
+				result.status,
+				`unexpected status: ${result.errorMessage ?? '(none)'}`,
+			).toBe('no_reliable_data')
+			expect(result.sourceCount).toBe(0)
+			// AND the reason the run went unchecked survives on to a run that hands
+			//   back nothing, which is a separate answer from having found nothing
+			expect(result.findings?.quality?.subject_unreadable).toBe(true)
 		}, 30_000)
 	})
 

--- a/packages/research/src/application/contact-entity-guard.test.ts
+++ b/packages/research/src/application/contact-entity-guard.test.ts
@@ -15,7 +15,7 @@ const targets = deriveEntityTargets({
 			website: 'circledelivers.com',
 		},
 	],
-})
+}).targets
 
 const contactsOf = (findings: unknown): Array<{ name: string }> =>
 	(findings as { contacts: Array<{ name: string }> }).contacts

--- a/packages/research/src/application/entity-guard.test.ts
+++ b/packages/research/src/application/entity-guard.test.ts
@@ -47,7 +47,8 @@ describe('deriveEntityTargets', () => {
 				'freeform',
 			]) {
 				expect(
-					deriveEntityTargets({ schemaName, query: 'anything', subjects: [] }),
+					deriveEntityTargets({ schemaName, query: 'anything', subjects: [] })
+						.targets,
 				).toBeNull()
 			}
 		})
@@ -61,7 +62,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'KG Motors Inc.',
 				subjects: [{ table: 'companies', name: 'KG Motors Inc.' }],
-			})
+			}).targets
 
 			// THEN only the trailing form comes off, so the key is the company's own
 			// name. A key of just "motors" would be carried by any page about any car
@@ -82,7 +83,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Grupo Ejemplo SA de CV',
 				subjects: [{ table: 'companies', name: 'Grupo Ejemplo SA de CV' }],
-			})
+			}).targets
 
 			// THEN both halves come off, so a page writing the trading name matches.
 			// The connecting word is only stepped over between two halves of a form —
@@ -96,7 +97,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Acme Logistics SL',
 				subjects: [{ table: 'companies', name: 'Acme Logistics SL' }],
-			})
+			}).targets
 
 			// THEN the form at the end is still dropped, so a page writing the bare
 			// name matches the company as filed
@@ -112,7 +113,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Sunset Transportation, St. Louis MO',
 				subjects: [],
-			})
+			}).targets
 			// THEN the pre-comma company name becomes the strong-match core
 			expect(targets?.cores).toContain('sunsettransportation')
 		})
@@ -125,7 +126,7 @@ describe('deriveEntityTargets', () => {
 				query:
 					'Research "Ascent Global Logistics" (ascentgl.com, Belleville, MI) — a US 3PL. Find headcount.',
 				subjects: [],
-			})
+			}).targets
 			// THEN the quoted name — not the whole sentence — becomes the core, so it
 			// can actually match the company's own pages
 			expect(targets?.cores).toContain('ascentgloballogistics')
@@ -140,7 +141,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Look up “Cohitech”, Balsareny',
 				subjects: [],
-			})
+			}).targets
 			// THEN the curly-quoted phrase is the core
 			expect(targets?.cores).toContain('cohitech')
 		})
@@ -157,7 +158,7 @@ describe('deriveEntityTargets', () => {
 						website: 'https://acme.com',
 					},
 				],
-			})
+			}).targets
 			// THEN the name core is a strong key and the full host is a domain key
 			expect(targets?.cores).toContain('acmewidgets')
 			expect(targets?.domains).toContain('acme.com')
@@ -174,8 +175,192 @@ describe('deriveEntityTargets', () => {
 					schemaName: 'company_enrichment_v1',
 					query: '',
 					subjects: [{ table: 'companies' }],
-				}),
+				}).targets,
 			).toBeNull()
+		})
+
+		it('should say the subject went unread rather than pass as ungated', () => {
+			// GIVEN the same unidentifiable subject
+			const reading = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: '',
+				subjects: [{ table: 'companies' }],
+			})
+			// THEN it is told apart from a run that is about nobody in particular:
+			// there is a company here, and nothing came of trying to read it
+			expect(reading.subjectUnreadable).toBe(true)
+		})
+	})
+})
+
+describe('deriveEntityTargets on a name the fold cannot read', () => {
+	// Each of these folds to nothing, so no key comes out and every check that
+	// would hold a page against the company has nothing to hold it against.
+	const unreadable = [
+		['Greek', 'Ηλεκτρολογικά Παπαδόπουλος'],
+		['Cyrillic', 'Строймонтаж Иванов'],
+		['Arabic', 'شركة الخليج للمقاولات'],
+		['CJK', '株式会社山田電気'],
+		['Korean', '삼성전자'],
+		['Devanagari', 'शर्मा इलेक्ट्रिकल्स'],
+	] as const
+
+	describe('when an entity-grounded run names its subject in another alphabet', () => {
+		for (const [alphabet, name] of unreadable) {
+			it(`should report the ${alphabet} subject as unread, with no keys`, () => {
+				// GIVEN an enrichment run for a company written in this alphabet
+				const reading = deriveEntityTargets({
+					schemaName: 'company_enrichment_v1',
+					query: name,
+					subjects: [{ table: 'companies', name }],
+				})
+				// THEN no key came out — the fold holds plain letters for none of it
+				expect(reading.targets).toBeNull()
+				// AND the run says so, instead of reading as one with nothing to check
+				expect(reading.subjectUnreadable).toBe(true)
+			})
+		}
+
+		it('should say the same for a contact hunt, which is about one company too', () => {
+			// GIVEN a contact_discovery_v1 run — the other schema whose whole job is
+			// its own named subject
+			const reading = deriveEntityTargets({
+				schemaName: 'contact_discovery_v1',
+				query: '株式会社山田電気',
+				subjects: [],
+			})
+			// THEN the subject went unread there as well
+			expect(reading.targets).toBeNull()
+			expect(reading.subjectUnreadable).toBe(true)
+		})
+
+		it('should say the same for a scan anchored to such a company', () => {
+			// GIVEN a scan pinned to a subject whose name is written in Cyrillic —
+			// anchored, so it is held to that subject like an enrichment is
+			const reading = deriveEntityTargets({
+				schemaName: 'prospect_scan_v1',
+				query: 'competitors',
+				subjects: [{ table: 'companies', name: 'Строймонтаж Иванов' }],
+			})
+			// THEN the anchor went unread, and the run is not mistaken for an open
+			// scan that was pinned to nobody
+			expect(reading.targets).toBeNull()
+			expect(reading.subjectUnreadable).toBe(true)
+		})
+	})
+
+	describe('when a Latin name is too short to stand for a company', () => {
+		it('should report it unread, since no key came out of it either', () => {
+			// GIVEN a subject whose whole name is two letters — too short to be
+			// distinctive, so it is refused the same as an unreadable one
+			const reading = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'AB',
+				subjects: [{ table: 'companies', name: 'AB' }],
+			})
+			// THEN the same hole is reported the same way: there is a company here
+			// and no check can be run on it
+			expect(reading.targets).toBeNull()
+			expect(reading.subjectUnreadable).toBe(true)
+		})
+	})
+
+	describe('when the run is about nobody in particular', () => {
+		it('should report no subject to read rather than an unread one', () => {
+			// GIVEN a scan or a freeform brief with no anchored subject — the one
+			// case where the checks genuinely have nothing to check
+			for (const schemaName of [
+				'prospect_scan_v1',
+				'competitor_scan_v1',
+				'freeform',
+			]) {
+				const reading = deriveEntityTargets({
+					schemaName,
+					query: 'anything',
+					subjects: [],
+				})
+				// THEN skipping costs nothing, and nothing is claimed to have gone
+				// unread
+				expect(reading.targets).toBeNull()
+				expect(reading.subjectUnreadable).toBe(false)
+			}
+		})
+	})
+
+	describe('when a name in another alphabet comes with something else to check', () => {
+		it('should read the subject through its own website', () => {
+			// GIVEN a Japanese company whose row carries its website
+			const reading = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: '株式会社山田電気',
+				subjects: [
+					{
+						table: 'companies',
+						name: '株式会社山田電気',
+						website: 'https://yamada-denki.co.jp',
+					},
+				],
+			})
+			// THEN the host is a key of its own, so the checks have something to run
+			// on and nothing went unread
+			expect(reading.targets?.domains).toContain('yamada-denki.co.jp')
+			expect(reading.subjectUnreadable).toBe(false)
+		})
+
+		it('should read the subject through a corrected domain', () => {
+			// GIVEN a re-run that carries the human-supplied official domain
+			const reading = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Строймонтаж Иванов',
+				subjects: [],
+				anchorDomain: 'stroymontazh.ru',
+			})
+			// THEN that domain is the key, and the subject is not reported unread
+			expect(reading.targets?.domains).toContain('stroymontazh.ru')
+			expect(reading.subjectUnreadable).toBe(false)
+		})
+
+		it('should read a name that is only partly in another alphabet', () => {
+			// GIVEN a name whose Latin half spells the company
+			const reading = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: '株式会社 Yamada Denki',
+				subjects: [{ table: 'companies', name: '株式会社 Yamada Denki' }],
+			})
+			// THEN a key comes out of the half that reads, so nothing is reported
+			// unread — a subject counts as unread only when no key at all comes out,
+			// not when part of the name is dropped
+			expect(reading.targets?.cores).toContain('yamadadenki')
+			expect(reading.subjectUnreadable).toBe(false)
+		})
+	})
+
+	describe('when the name reads but names nobody in particular', () => {
+		it('should not report it unread, since a key did come out', () => {
+			// GIVEN a company called nothing but its trade and its legal form
+			const reading = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Grupo Express SL',
+				subjects: [{ table: 'companies', name: 'Grupo Express SL' }],
+			})
+			// THEN it is a different shortfall from this one — the checks do run,
+			// on a key that identifies the trade rather than the firm
+			expect(reading.targets).not.toBeNull()
+			expect(reading.subjectUnreadable).toBe(false)
+		})
+	})
+
+	describe('when the name reads normally', () => {
+		it('should hand back its keys and report nothing unread', () => {
+			// GIVEN a subject named in plain letters, the control for the cases above
+			const reading = deriveEntityTargets({
+				schemaName: 'company_enrichment_v1',
+				query: 'Fusteria Miquel',
+				subjects: [{ table: 'companies', name: 'Fusteria Miquel' }],
+			})
+			// THEN the name reads and its key comes out, so there is nothing to say
+			expect(reading.targets?.cores).toContain('fusteriamiquel')
+			expect(reading.subjectUnreadable).toBe(false)
 		})
 	})
 })
@@ -256,7 +441,7 @@ describe('classifyEntityMatch', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Cafés Ordóñez',
 				subjects: [],
-			})
+			}).targets
 			// WHEN a corpus writes the same name without the accents
 			// THEN folding makes the two equal and the match is strong
 			expect(classifyEntityMatch(targets!, 'the cafes ordonez brand')).toBe(
@@ -293,7 +478,7 @@ describe('classifyEntityMatch', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Zxqvon Interstellar Freight Brokerage LLC',
 				subjects: [],
-			})
+			}).targets
 			// WHEN its keys are classified against a corpus about other freight firms
 			// THEN the run is absent (its distinctive words appear nowhere)
 			expect(
@@ -308,7 +493,7 @@ describe('isConfirmedRegistryMatch', () => {
 		schemaName: 'company_enrichment_v1',
 		query: 'Acme Logistics, Barcelona',
 		subjects: [],
-	})
+	}).targets
 
 	describe('when the lookup resolved the target company', () => {
 		it('should confirm on a legal name that strongly matches the target', () => {
@@ -378,7 +563,7 @@ describe('classifyEntityMatchPerSource', () => {
 				website: 'https://acme.es',
 			},
 		],
-	})
+	}).targets
 
 	describe('when the sources mix the target and a look-alike', () => {
 		it('should tag each source on its own', () => {
@@ -443,7 +628,7 @@ describe('deriveEntityTargets with an anchor domain', () => {
 				query: 'Acme',
 				subjects: [{ table: 'companies', name: 'Acme Widgets' }],
 				anchorDomain: 'https://www.acme.com/contact',
-			})
+			}).targets
 			// THEN the anchor host is a strong-match domain key, its label a weak word
 			expect(targets?.domains).toContain('acme.com')
 			expect(targets?.words).toContain('acme')
@@ -456,7 +641,7 @@ describe('deriveEntityTargets with an anchor domain', () => {
 				query: 'some company',
 				subjects: [],
 				anchorDomain: 'monzo.com',
-			})
+			}).targets
 			// THEN the host still becomes a domain key
 			expect(targets?.domains).toContain('monzo.com')
 		})
@@ -468,12 +653,12 @@ describe('deriveEntityTargets with an anchor domain', () => {
 				query: 'Acme',
 				subjects: [{ table: 'companies', name: 'Acme Widgets' }],
 				anchorDomain: 'not a domain',
-			})
+			}).targets
 			const without = deriveEntityTargets({
 				schemaName: 'company_enrichment_v1',
 				query: 'Acme',
 				subjects: [{ table: 'companies', name: 'Acme Widgets' }],
-			})
+			}).targets
 			// THEN it is dropped and the result matches the no-anchor derivation
 			expect(withJunk?.domains).toEqual(without?.domains)
 		})
@@ -488,7 +673,7 @@ describe('deriveEntityTargets with a domain in the query', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Sunset Transportation (sunsettrans.com)',
 				subjects: [],
-			})
+			}).targets
 			// THEN a page referencing that host will strong-match the target
 			expect(targets?.domains).toContain('sunsettrans.com')
 		})
@@ -1350,12 +1535,12 @@ describe('nameSpellings', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Muñoz S.L.',
 				subjects: [{ table: 'companies', name: 'Muñoz S.L.' }],
-			})
+			}).targets
 			const plain = deriveEntityTargets({
 				schemaName: 'company_enrichment_v1',
 				query: 'Muñoz SL',
 				subjects: [{ table: 'companies', name: 'Muñoz SL' }],
-			})
+			}).targets
 
 			// WHEN each is turned into match keys
 			// THEN they are the same keys. Two rows of one list spelling the form
@@ -1473,7 +1658,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Instal·lacions Vives',
 				subjects: [{ table: 'companies', name: 'Instal·lacions Vives SL' }],
-			}) as EntityTargets
+			}).targets as EntityTargets
 
 			// WHEN evidence spells the name with one l, and when it spells it with two
 			// THEN both land the run on its target, rather than only the spelling the
@@ -1492,7 +1677,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Instal·lacions Vives',
 				subjects: [{ table: 'companies', name: 'Instal·lacions Vives SL' }],
-			}) as EntityTargets
+			}).targets as EntityTargets
 
 			// WHEN the evidence is about a different company in the same trade
 			// THEN it never reads as the target. The second spelling writes out one
@@ -1514,7 +1699,7 @@ describe('deriveEntityTargets', () => {
 				schemaName: 'company_enrichment_v1',
 				query: 'Instal·lacions Vives',
 				subjects: [{ table: 'companies', name: 'Instal·lacions Vives SL' }],
-			}) as EntityTargets
+			}).targets as EntityTargets
 
 			// WHEN each is classified
 			// THEN all three are weak — the run is told it never clearly landed, and

--- a/packages/research/src/application/entity-guard.ts
+++ b/packages/research/src/application/entity-guard.ts
@@ -723,9 +723,47 @@ export const isEntityGroundedSchema = (schemaName: string): boolean =>
 	ENTITY_GROUNDED_SCHEMAS.has(schemaName)
 
 /**
- * Builds the match keys for a run's target, or null when the run should not be
- * entity-gated (a scan/freeform run with no anchored subject, or a target with no
- * usable name or domain).
+ * What reading a run's own subject came back with.
+ *
+ * Two facts rather than one, because having no keys covers two situations a
+ * caller has to tell apart: "this run is about no one company" and "it is about
+ * a company whose name nothing here could read". A check may be skipped when
+ * there is nothing to check; skipping it because the reading failed is how a run
+ * nobody checked reports itself as clean.
+ */
+export interface EntitySubjectReading {
+	/** The keys the evidence is held against, or null when none came out. */
+	readonly targets: EntityTargets | null
+	/**
+	 * True when the run IS about one company and not one key came out of its name
+	 * or its website — so every check that asks "are these pages this company's?"
+	 * has nothing to ask with.
+	 *
+	 * The usual cause is a name written in an alphabet the fold has no plain
+	 * letters for: Japanese, Greek, Cyrillic, Arabic, Korean, Devanagari all come
+	 * back empty. A name of two or three letters and nothing else reaches the same
+	 * place, since a fragment that short turns up inside unrelated text by
+	 * coincidence and is refused for it. Both leave the same hole, so both are
+	 * reported the same way.
+	 *
+	 * False for a run that has no subject at all — an open scan, a freeform brief.
+	 * There the checks genuinely have nothing to check, which is the one case
+	 * skipping them costs nothing.
+	 *
+	 * Not the same question as `foldReadsEveryLetter`, which asks whether the fold
+	 * spelled every letter of a name. The two part company on a name half written
+	 * in another alphabet: "株式会社 Yamada Denki" loses letters, so that one
+	 * answers no, while a key still comes out of the half that reads, so this one
+	 * is false. Ask that one to file a name under a key, and this one to find out
+	 * whether any check could run at all.
+	 */
+	readonly subjectUnreadable: boolean
+}
+
+/**
+ * Builds the match keys for a run's target, and says which of the two reasons
+ * there are none: a scan/freeform run with no anchored subject to check, or a
+ * subject whose name and website yielded no usable key.
  */
 export const deriveEntityTargets = (args: {
 	schemaName: string
@@ -741,9 +779,13 @@ export const deriveEntityTargets = (args: {
 	/** The run's location hint, folded into the place keys alongside the query's
 	 * own "…, City" tail. */
 	location?: string | undefined
-}): EntityTargets | null => {
+}): EntitySubjectReading => {
 	const anchored = args.subjects.length > 0
-	if (!isEntityGroundedSchema(args.schemaName) && !anchored) return null
+	// Nothing to check: a scan reports third parties and a freeform brief is
+	// about no one company, so neither has a subject whose pages these keys
+	// would be proving.
+	if (!isEntityGroundedSchema(args.schemaName) && !anchored)
+		return { targets: null, subjectUnreadable: false }
 
 	const names = anchored
 		? args.subjects
@@ -776,10 +818,16 @@ export const deriveEntityTargets = (args: {
 		]),
 	]
 
+	// Something to check, and no way to check it. Said out loud rather than
+	// handed back as the "nothing to check" above, so the run can report that it
+	// went unchecked instead of finishing as clean as one that passed.
 	if (cores.length === 0 && words.length === 0 && domains.length === 0)
-		return null
+		return { targets: null, subjectUnreadable: true }
 	const places = queryPlaces(args.query, args.location)
-	return { cores, words, domains, places }
+	return {
+		targets: { cores, words, domains, places },
+		subjectUnreadable: false,
+	}
 }
 
 /**

--- a/packages/research/src/application/research-quality.test.ts
+++ b/packages/research/src/application/research-quality.test.ts
@@ -16,6 +16,7 @@ describe('computeRunQuality', () => {
 			sourcesTotal: 5,
 			sourcesFirstParty: 3,
 			ownDomainKnown: true,
+			subjectUnreadable: false,
 			fieldsGrounded: 4,
 			fieldsTotal: 6,
 			citationsSeen: 4,
@@ -81,6 +82,7 @@ describe('computeRunQuality', () => {
 				entityMatch: 'strong',
 				sourcesFirstParty: 0,
 				ownDomainKnown: false,
+				subjectUnreadable: false,
 			})
 			// THEN it is left out: with no site anyone could have read, the count can
 			// only ever be 0, exactly as on a search about no one company
@@ -104,6 +106,7 @@ describe('computeRunQuality', () => {
 			sourcesTotal: 6,
 			sourcesFirstParty: 0,
 			ownDomainKnown: false,
+			subjectUnreadable: false,
 			fieldsGrounded: 0,
 			fieldsTotal: 0,
 			citationsSeen: 10,
@@ -212,6 +215,7 @@ describe('computeRunQuality', () => {
 			sourcesTotal: 6,
 			sourcesFirstParty: 0,
 			ownDomainKnown: false,
+			subjectUnreadable: false,
 			fieldsGrounded: 0,
 			fieldsTotal: 0,
 			citationsSeen: 10,
@@ -263,6 +267,7 @@ describe('computeRunQuality', () => {
 				sourcesTotal: 5,
 				sourcesFirstParty: 3,
 				ownDomainKnown: true,
+				subjectUnreadable: false,
 				fieldsGrounded: 4,
 				fieldsTotal: 6,
 				citationsSeen: 4,
@@ -291,6 +296,7 @@ describe('computeRunQuality', () => {
 			sourcesTotal: 131,
 			sourcesFirstParty: 0,
 			ownDomainKnown: false,
+			subjectUnreadable: false,
 			fieldsGrounded: 0,
 			fieldsTotal: 0,
 			citationsSeen: 60,
@@ -424,6 +430,7 @@ describe('computeRunQuality', () => {
 			sourcesTotal: 2,
 			sourcesFirstParty: 0,
 			ownDomainKnown: false,
+			subjectUnreadable: false,
 			fieldsGrounded: 0,
 			fieldsTotal: 0,
 			scanResults: FULL_LIST,
@@ -483,6 +490,7 @@ describe('computeRunQuality', () => {
 				sourcesTotal: 6,
 				sourcesFirstParty: 2,
 				ownDomainKnown: true,
+				subjectUnreadable: false,
 				fieldsGrounded: 0,
 				fieldsTotal: 0,
 				citationsSeen: 8,
@@ -520,6 +528,7 @@ describe('computeRunQuality', () => {
 				sourcesTotal: 6,
 				sourcesFirstParty: 2,
 				ownDomainKnown: true,
+				subjectUnreadable: false,
 				fieldsGrounded: 0,
 				fieldsTotal: 0,
 				citationsSeen: 8,
@@ -546,6 +555,7 @@ describe('computeRunQuality', () => {
 			sourcesTotal: 4,
 			sourcesFirstParty: 0,
 			ownDomainKnown: false,
+			subjectUnreadable: false,
 			fieldsGrounded: 0,
 			fieldsTotal: 0,
 			citationsSeen: 3,
@@ -617,6 +627,7 @@ describe('computeRunQuality', () => {
 			sourcesTotal: 131,
 			sourcesFirstParty: 0,
 			ownDomainKnown: false,
+			subjectUnreadable: false,
 			fieldsGrounded: 0,
 			fieldsTotal: 0,
 			citationsSeen: 60,
@@ -653,6 +664,7 @@ describe('computeRunQuality', () => {
 				sourcesTotal: 5,
 				sourcesFirstParty: 3,
 				ownDomainKnown: true,
+				subjectUnreadable: false,
 				fieldsGrounded: 6,
 				fieldsTotal: 6,
 				citationsSeen: 4,
@@ -713,6 +725,7 @@ describe('computeRunQuality — how the list split', () => {
 		sourcesTotal: 8,
 		sourcesFirstParty: 0,
 		ownDomainKnown: false,
+		subjectUnreadable: false,
 		fieldsGrounded: 0,
 		fieldsTotal: 0,
 		citationsSeen: 20,
@@ -759,6 +772,108 @@ describe('computeRunQuality — how the list split', () => {
 			// THEN the question does not arise, which is not the same answer as
 			// "it confirmed none"
 			expect('existence' in quality).toBe(false)
+		})
+	})
+})
+
+describe('computeRunQuality — when the run could not read its own subject', () => {
+	// An enrichment run that went well by every other measure: rounds, sources,
+	// citations, a full profile. The only thing wrong with it is that nobody ever
+	// checked the pages were this company's.
+	const healthy = {
+		schemaName: 'company_enrichment_v1',
+		entityMatch: null,
+		rounds: 6,
+		gapRounds: 1,
+		sourcesTotal: 5,
+		sourcesFirstParty: 0,
+		ownDomainKnown: false,
+		subjectUnreadable: false,
+		fieldsGrounded: 5,
+		fieldsTotal: 6,
+		citationsSeen: 4,
+		citationsKept: 4,
+		scanResults: null,
+		refined: false,
+		coverage: null,
+		coverageStopped: null,
+		coverageLastMissing: [],
+		existence: null,
+	} as const
+
+	describe('when the subject name yielded no key', () => {
+		it('should refuse the run a clean finish', () => {
+			// GIVEN a run that is thin in no other way
+			const quality = computeRunQuality({ ...healthy, subjectUnreadable: true })
+			// THEN it cannot come back as a clean success: every check that asks
+			// whether these pages are this company's was skipped
+			expect(quality.low_confidence).toBe(true)
+		})
+
+		it("should state the reason in the run's own answer", () => {
+			// GIVEN the same run
+			const quality = computeRunQuality({ ...healthy, subjectUnreadable: true })
+			// THEN a person reading the result is told why, rather than having to
+			// find it in the logs
+			expect(quality.subject_unreadable).toBe(true)
+		})
+
+		it('should say it of a scan pinned to such a company too', () => {
+			// GIVEN an anchored scan whose list is long and well vetted
+			const quality = computeRunQuality({
+				...healthy,
+				schemaName: 'prospect_scan_v1',
+				scanResults: FULL_LIST,
+				fieldsGrounded: 0,
+				fieldsTotal: 0,
+				subjectUnreadable: true,
+			})
+			// THEN it is flagged as well — a scan built from a company nobody
+			// checked is no safer to act on unread than a profile of one
+			expect(quality.low_confidence).toBe(true)
+			expect(quality.subject_unreadable).toBe(true)
+		})
+	})
+
+	describe('when the subject was read', () => {
+		it('should leave the reason out rather than report it false', () => {
+			// GIVEN a run whose subject name yielded keys
+			const quality = computeRunQuality({
+				...healthy,
+				entityMatch: 'strong',
+			})
+			// THEN the question does not arise, so nothing is said — its presence
+			// is the whole signal, and is what makes the count meaningful
+			expect('subject_unreadable' in quality).toBe(false)
+			expect(quality.low_confidence).toBe(false)
+		})
+
+		it('should stay quiet on a run that is flagged for some other reason', () => {
+			// GIVEN a readable subject the evidence only glancingly mentioned
+			const quality = computeRunQuality({
+				...healthy,
+				entityMatch: 'weak',
+			})
+			// THEN the run is flagged, but not for a reason that did not happen
+			expect(quality.low_confidence).toBe(true)
+			expect('subject_unreadable' in quality).toBe(false)
+		})
+	})
+
+	describe('when the run was about nobody in particular', () => {
+		it('should say nothing, since there was no subject to read', () => {
+			// GIVEN an open scan, pinned to no company
+			const quality = computeRunQuality({
+				...healthy,
+				schemaName: 'prospect_scan_v1',
+				scanResults: FULL_LIST,
+				fieldsGrounded: 0,
+				fieldsTotal: 0,
+			})
+			// THEN the checks had nothing to check, which costs nothing and is not
+			// this reason
+			expect('subject_unreadable' in quality).toBe(false)
+			expect(quality.low_confidence).toBe(false)
 		})
 	})
 })

--- a/packages/research/src/application/research-quality.ts
+++ b/packages/research/src/application/research-quality.ts
@@ -2,13 +2,13 @@
  * Turns a finished run's shape into a small quality signal, so an automation can
  * tell a well-grounded result from a thin one without inspecting every run by hand.
  *
- * Every run reported `succeeded` before, whether it did six grounded rounds on the
- * company's own site or one search on a nonsense query — nothing to gate on. This
- * derives a compact `quality` block and a `low_confidence` flag from signals the
- * run already produced. The flag is deliberately conservative: it should catch the
+ * Without it a run that did six grounded rounds on the company's own site and one
+ * that ran a single search on a nonsense query both report `succeeded`, and there
+ * is nothing to gate on. This derives a compact `quality` block and a
+ * `low_confidence` flag from signals the run already produced. The flag is deliberately conservative: it should catch the
  * clearly-thin runs, not second-guess a solid one.
  *
- * Five signals raise it. Whenever a run was pinned to one company, anything short
+ * Six signals raise it. Whenever a run was pinned to one company, anything short
  * of clearly reaching that company counts — which covers an enrichment filling
  * that company's profile and equally a scan launched from it, since a scan can be
  * pinned to a subject too and a wrong one there is just as misleading. On top of
@@ -22,6 +22,12 @@
  * naming five trades that comes back with sixty companies for one of them passes
  * every count above — sixty is not thin — while answering a fifth of the question,
  * so a part of the request nothing came back for raises the flag on its own.
+ *
+ * The sixth is about the checks themselves rather than about the result. A run
+ * pinned to a company whose name nothing here could read had none of the checks
+ * that ask whether its pages are that company's — not weaker checks, no checks —
+ * and every one of them was skipped in silence. That is exactly what this flag
+ * is for, so it says so and the run is read before it is acted on.
  */
 
 import { DISCOVERY_THIN_RESULT_COUNT, isDiscoveryScan } from './discovery-scan'
@@ -39,6 +45,13 @@ export interface RunQualityInput {
 	 * so there was never an entity to match.
 	 */
 	readonly entityMatch: 'strong' | 'weak' | 'absent' | null
+	/**
+	 * Whether the run is about one company whose name yielded no match key at all,
+	 * so every check that asks whether a page is that company's had nothing to ask
+	 * with. Told apart from `entityMatch: null`, which is a run about no one
+	 * company: there the checks have nothing to check, which costs nothing.
+	 */
+	readonly subjectUnreadable: boolean
 	/** Reflect-loop rounds phase 1 ran (0 on a resume). */
 	readonly rounds: number
 	/** Gap-closing rounds phase 2 ran after the first extraction (0 on a resume). */
@@ -175,6 +188,17 @@ export interface RunQuality {
 		readonly confirmed: number
 		readonly candidates: number
 	}
+	/**
+	 * Present, and only ever true, when the run's own subject could not be read,
+	 * so the checks that hold its pages against it never ran. Written down as the
+	 * run's own stated reason rather than left in the logs, because a reader
+	 * otherwise sees a result that looks exactly like a checked one.
+	 *
+	 * Left out entirely where the question does not arise — a run whose subject
+	 * was read, and a run that has no subject — so its presence is the whole
+	 * signal, and how often it happens can be counted off finished runs.
+	 */
+	readonly subject_unreadable?: true
 	/** True when the result is thin enough that an automation should not act on it unreviewed. */
 	readonly low_confidence: boolean
 }
@@ -210,12 +234,18 @@ export const computeRunQuality = (input: RunQualityInput): RunQuality => {
 	// it goes to them rather than passing as a full answer.
 	const partsWentUnanswered =
 		input.coverage !== null && input.coverage.uncovered.length > 0
+	// And a run whose subject's name yielded no key was never held against that
+	// company at all. `unsureOfTheCompany` cannot see this one: with no keys there
+	// is no verdict to be unsure of, so the run arrives here carrying the same
+	// empty verdict as a scan that was about nobody in particular.
+	const subjectWentUnchecked = input.subjectUnreadable
 	const lowConfidence =
 		unsureOfTheCompany ||
 		thinlyVetted ||
 		thinResultList ||
 		nothingStandsBehindIt ||
-		partsWentUnanswered
+		partsWentUnanswered ||
+		subjectWentUnchecked
 
 	return {
 		rounds: input.rounds,
@@ -246,6 +276,7 @@ export const computeRunQuality = (input: RunQualityInput): RunQuality => {
 				}
 			: {}),
 		...(input.existence !== null ? { existence: input.existence } : {}),
+		...(subjectWentUnchecked ? { subject_unreadable: true as const } : {}),
 		low_confidence: lowConfidence,
 	}
 }

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -392,7 +392,9 @@ interface SourcedPage {
 // Feed extraction only the fetched pages that concern the target, so a look-alike
 // company's page pulled in alongside it cannot leak into the extracted fields.
 // Falls back to every page when the per-source check grounds none, so a run that
-// matched only through a search snippet still has something to extract from. The
+// matched only through a search snippet still has something to extract from. With
+// no targets at all every page goes through — for a run whose subject went unread
+// that is a filter that never ran, and the run says so in its own answer. The
 // company's own pages come first, so a fact stated on both the official site and an
 // aggregator is extracted from — and attributed to — the official one, instead of
 // the aggregator that happened to sit earlier in the fetch order.
@@ -2525,16 +2527,23 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					const hintLocation = (
 						context?.hints as { location?: string } | undefined
 					)?.location
-					// `let`, not `const`: when the seeded anchor domain redirects to a
-					// different host (a rebrand), the seed below folds that destination
-					// in as a strong-match key so the run grounds on the live site.
-					let entityTargets = deriveEntityTargets({
+					const subjectReading = deriveEntityTargets({
 						schemaName,
 						anchorDomain: context?.anchorDomain,
 						query: (run as { query: string }).query,
 						subjects: subjectTargets,
 						location: hintLocation,
 					})
+					// `let`, not `const`: when the seeded anchor domain redirects to a
+					// different host (a rebrand), the seed below folds that destination
+					// in as a strong-match key so the run grounds on the live site.
+					let entityTargets = subjectReading.targets
+					// True when the run is about one company and nothing could read its
+					// name, so every check below that holds a page against it has nothing
+					// to hold it against. Carried through the run so it can say so at the
+					// end, rather than finishing as clean as one that was checked and
+					// passed.
+					const subjectUnreadable = subjectReading.subjectUnreadable
 					let entityMatch: EntityMatch | null =
 						(run as { entityMatch?: EntityMatch | null }).entityMatch ?? null
 
@@ -2547,6 +2556,24 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							.map(s => s.name)
 							.find((n): n is string => n != null && n.trim() !== '') ??
 						queryName((run as { query: string }).query)
+
+					// Said once an attempt, so a starved market shows up in the telemetry
+					// rather than being guessed at. A resumed run comes back through here
+					// and says it again, so counting HOW MANY RUNS goes by the stored
+					// `quality.subject_unreadable`, which is written once per run; this
+					// pair is for watching the rate and for finding the run afterwards.
+					if (subjectUnreadable) {
+						yield* Effect.annotateCurrentSpan({
+							'research.entity.subject_unreadable': true,
+						})
+						yield* Effect.logWarning('research.entity.subject_unreadable').pipe(
+							Effect.annotateLogs({
+								event: 'research.entity.subject_unreadable',
+								research_id: researchId,
+								subject_name: entityName,
+							}),
+						)
+					}
 
 					// The company's own official site to fetch up front, when the caller
 					// gave its domain — a target-correction re-run's anchor, an anchored
@@ -2806,8 +2833,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					//
 					// Only pages the run opened count, and only ones that read as this
 					// company's: the single sentence a search quotes is too little to tell
-					// whose page it came from, and an address is worth having only when we
-					// know whose it is.
+					// whose page it came from, and an address is worth having only when its
+					// owner is known.
+					//
+					// With no key for the subject, nothing can say whose page it is, so no
+					// mailbox is harvested at all — that loses a real address rather than
+					// handing back a stranger's.
 					const harvestRoleMailboxes = (): ReadonlyArray<GenericEmail> => {
 						if (
 							schemaName !== 'company_enrichment_v1' ||
@@ -3381,6 +3412,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									name: 'contact-entity',
 									run: findings =>
 										Effect.gen(function* () {
+											// Passes every person through when there are no keys: with
+											// nothing to hold a quote against, one naming another
+											// company cannot be told from one naming this company.
 											const check = bindContactsToEntity(
 												findings,
 												entityTargets,
@@ -3980,7 +4014,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									// while a citation the run never fetched keeps its field. Runs
 									// before the source-tier cap so a blocked field is gone, not merely
 									// down-weighted. Only an enrichment run has a single subject to
-									// check against; any other run passes through.
+									// check against; any other run passes through — as does one whose
+									// subject's name yielded no key, since there is nothing to judge a
+									// cited page against. That run says so in its own answer rather
+									// than passing as one that was judged: see
+									// `quality.subject_unreadable`.
 									name: 'entity-sources',
 									run: findings =>
 										Effect.gen(function* () {
@@ -4628,6 +4666,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							const registrySnapshot = subjects[0]?.snapshot as
 								| Record<string, unknown>
 								| undefined
+							// A subject whose name went unread is left out here for a reason of
+							// its own, not as one more skipped check: the register is searched
+							// BY that name, and a hit cannot be confirmed against keys that do
+							// not exist, so the lookup would only spend money.
 							const registryCountry =
 								entityTargets !== null && isEntityGroundedSchema(schemaName)
 									? resolveRegistryCountry({
@@ -4886,6 +4928,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													: classifyEntityMatch(entityTargets, corpus)
 											// Grounding gate: reach the target's own site before answering; bounded
 											// so a run that still cannot ground fails closed rather than looping.
+											// With no keys there is no verdict to fall short of, so the
+											// nudge never fires and the run answers without ever having
+											// reached a page anyone held against the company.
 											if (
 												entityTargets !== null &&
 												verdict !== 'strong' &&
@@ -5081,7 +5126,18 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								// Only an unanchored scan hands its findings on; an anchored one
 								// extracted here to measure the list and lets phase 2 do the
 								// grounded extraction it needs.
-								findings: entityTargets === null ? findings : undefined,
+								//
+								// Asked of the anchor rather than of the keys: a scan anchored to
+								// a company whose name went unread has an anchor all the same, and
+								// going by the keys would send it down the unanchored path for the
+								// one reason that should never buy a run less care. It costs that
+								// scan a second extraction, and buys the two things phase 2 does
+								// without any keys at all: each page labelled with the host it sits
+								// on, and the anchor's own pages read first.
+								findings:
+									entityTargets === null && !subjectUnreadable
+										? findings
+										: undefined,
 								refined,
 								cheapCents,
 							}
@@ -5135,6 +5191,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							evidenceText,
 							...scrapeCorpus.map(page => page.text),
 						].join('\n')
+						// Null for a run with no keys — whether because it is about nobody
+						// in particular or because its subject's name went unread. The two
+						// are told apart in the quality block, which is where the second one
+						// costs the run its clean finish; here there is simply no verdict to
+						// reach.
 						entityMatch = entityTargets
 							? classifyEntityMatch(entityTargets, entityCorpus)
 							: null
@@ -5501,6 +5562,9 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// field away is work the round did, and a round judged on what it
 							// gained alone would read as having done nothing.
 							let voidedThisRound = 0
+							// Same as the per-source guard above: with no keys there is nothing
+							// to re-judge the fetched pages against, so the round voids no
+							// field and the run's own answer says the check was skipped.
 							if (roundHashes.length > 0 && entityTargets) {
 								const gapOpenedByHash = new Map(
 									openedPages(scrapeCorpus).map(
@@ -6129,8 +6193,14 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								date: briefDate,
 								// Only a run that scoped itself to one subject has a subject to
 								// name; a scan or a market question has none, and inventing one
-								// is what puts a stand-in in the heading.
-								subjectName: entityTargets === null ? undefined : entityName,
+								// is what puts a stand-in in the heading. A subject whose name
+								// went unread is still a subject, and it is still what the run
+								// was asked about — leaving it out because no key came of it
+								// would take the company off its own brief.
+								subjectName:
+									entityTargets === null && !subjectUnreadable
+										? undefined
+										: entityName,
 								findings,
 								transcript: researchText,
 								// Only the trades a pass actually went out for. The wording
@@ -6195,6 +6265,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					const nothingFoundQuality = computeRunQuality({
 						schemaName,
 						entityMatch,
+						subjectUnreadable,
 						rounds: runRounds,
 						gapRounds,
 						sourcesTotal: sources?.n ?? 0,
@@ -6304,6 +6375,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					const quality = computeRunQuality({
 						schemaName,
 						entityMatch,
+						subjectUnreadable,
 						rounds: runRounds,
 						gapRounds,
 						sourcesTotal: sources?.n ?? 0,


### PR DESCRIPTION
## What

When a company's name is written in an alphabet the name-reading cannot handle — Japanese, Greek, Cyrillic, Arabic, Korean, Hindi — the reading comes back empty. With no name to match on, every check that asks *"are these pages really about this company?"* is skipped, and the run still reports plain success. Not a weaker check: **no check, reported as clean.** So for those markets a run that scraped an entirely different company's pages has nothing standing between what it found and the customer's records.

This makes such a run **say so**. It reports the reason in its own answer, that reason costs it its clean finish, and the person reading the result is told which of the two things happened — "nobody checked this" rather than "checked, and unsure". It lives in the Research context (`packages/research`, its test harness in `server`, and the run view in `internal`).

**This deliberately does not teach the reading to handle other alphabets.** That is a much larger change with a real risk of its own — a reading that matches more things also lets a short non-Latin name match pages that are not about it — and it is scheduled behind existence verification (#486) for that reason. This is the cheap half that does not depend on it: saying *"I could not read this"* makes nothing match more.

This is §2 of #456 — the rule the whole plan turns on, and the last piece of it still unbuilt: *a check may be skipped only when there is nothing to check, never when there is something to check and the code could not read it.* §4.6 carried it originally because the third answer and the script-aware fold were the same change; the fold has slipped behind §4.9, so this ships alone, as §6 anticipated.

## Changes

**Touches:** the reading that turns a company's name into match keys, the run-quality signal that decides whether a result is safe to act on unread, the places in the research pipeline that skipped a check when there were no keys, and the run view that shows a finished result — plus the name-folding itself, which is **not** changed here and is what keeps this risk-free.

- **The reading now gives two facts instead of one.** "No keys" used to mean both *"this run is about no one company"* — an open market scan, where skipping costs nothing — and *"it is about a company whose name nothing could read"*, where skipping costs everything. Those are now told apart, so the second can be reported.
- **The run's answer carries the reason.** A finished run whose subject went unread reports it in its quality block, which forces the low-confidence flag. The run therefore ends as *needs review* rather than *succeeded* — and that status already blocks the automatic write into the CRM.
- **Two places were confusing "no keys" with "no subject", and are fixed.** The written brief was dropping the company from its own heading, and a market scan pinned to such a company was taking the less careful of two extraction paths. Both now ask whether there is a subject, which is the question they meant.
- **The other six places stay skipped, and each now says why in a line of its own** — with no key there is genuinely nothing to filter, harvest, or re-judge with, and every one of them fails towards keeping less rather than admitting more. The audit is in the Review guide below.
- **The run view names the reason.** Before, such a run showed the same unexplained "Read this before it goes into a record" as a run that *was* checked and came back unsure — the two most different cases looking identical.
- **A count, so this stops being guesswork.** A warning log and a span attribute give the rate; the stored field gives the per-run number.

## Impact

- **Nothing changes about which names can be read.** The name-folding is untouched, so a name that matches today still matches, and no run that succeeds today starts failing. What changes is only what a run *says about itself*.
- **Some runs that reported success will now report "needs review".** Specifically: runs about a company whose name yields no match key. That is the point of the change — those runs were never checked — but it means a market where such names are common (Japan, Greece, Russia, the Arab world, Korea, India) will show more runs waiting for a person. Nothing is thrown away; the findings are all still there.
- **Automatic writing into customer records (auto-apply) now declines these runs.** It already gates on the run's status, and these runs no longer come back as a clean success. This is the intended teeth of the change — it is the reason it is worth doing before the fold — but it is a real behaviour change for anyone relying on unattended enrichment in those markets.
- **The stored result grows one optional field** (`quality.subject_unreadable`, present only when true). The web app reads it; nothing else needs to.
- **A market scan pinned to a company whose name went unread now pays for one extra extraction pass** — it takes the same path an ordinary anchored scan already takes. It buys two things that work without any keys: each page labelled with the site it came from, and the company's own pages read first.
- **None of the usual sharp edges are touched:** no database migration, nothing about which organisation can see what (row-level security), no change to the shape of anything the web app or the assistant integration (MCP) receives beyond that one added field, no new environment variables, no change to sign-in or route protection, no new webhooks, and no coordinated deploy — the two commits ship independently.

## Review guide

**Start with `packages/research/src/application/entity-guard.ts`** — the whole change turns on `deriveEntityTargets` returning `{ targets, subjectUnreadable }` instead of `EntityTargets | null`. That signature change is what forced every other edit into view.

**Then `research-quality.ts`** — a sixth low-confidence signal, and the new reported field.

**The riskiest part is the audit in `research-service.ts`**, because it is where I made judgement calls you might overrule. Eight places branched on "no keys". Here is each, one by one:

| Place | Verdict |
|---|---|
| per-source evidence filter | stays skipped — no key, nothing to judge a cited page against |
| gap-round re-judge of cited pages | stays skipped — same reason |
| grounding retry gate | stays skipped — no verdict to be short of, so the nudge has no trigger |
| company mailbox harvesting | stays skipped — **fails towards keeping none**, so it costs a real mailbox rather than admitting a stranger's |
| national register lookup | stays skipped — the register is searched *by* that name, and a hit could not be confirmed against keys that do not exist, so it would only spend money |
| feeding pages to the extraction | passes every page through — the only thing left to do, and the run reports that the filter never ran |
| the written brief's heading | **fixed** — it was dropping the company from its own brief |
| phase-1 hand-off for an anchored scan | **fixed** — it was taking the less careful path |

Two more sit outside the pipeline and are safe by construction: `ownSiteVerdict` can only answer *unknown*, which per §4.7 of #456 can withhold a confirmation but never manufacture one; and `scopeSearchQuery` declines to narrow a search to the company name, which makes the run search more broadly rather than report more cleanly. Neither is changed.

**A decision you might overrule:** I treat a two- or three-letter Latin name the same as an unreadable one. Both produce no key, so both leave the identical hole — but it does mean a genuinely tiny name is reported as "could not read", which is not quite what happened.

**Skip-able:** the `.targets` suffix across ~25 existing test call sites is mechanical fallout from the signature change.

I did not run Snyk — the tool is not available in this session. Nothing here parses external input or touches a security boundary.

## Screenshots

A finished run whose company name could not be read, showing the new reason under the existing caution. Desktop and mobile, because `internal` is mobile-first and the sentence wraps differently.

**Desktop**

![pr-499-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-543/pr-499-desktop.webp)

**Mobile**

![pr-499-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-543/pr-499-mobile.webp)

## Tests

- **Unit** — the reading, across every alphabet in #499's table plus a Latin control; a too-short Latin name; a run with no subject at all (which must *not* be reported unread); and the three ways a name in another alphabet still yields a key — its own website, a human-corrected domain, and a name half-written in Latin. Plus the quality signal, including that the field is left out rather than reported false.
- **End-to-end, against a real run through the service and database** — a Japanese-named enrichment run that scrapes a different company's page finishes *needs review* with the reason stated and its findings intact; and the reason survives on to a run that also found nothing at all.
- I checked both new end-to-end tests actually discriminate, by neutralising the flag and watching the run come back `succeeded` — the reported symptom, reproduced.

## Verification

- `pnpm install` (no lockfile drift) → `check-types` 13/13 → `test` 21/21 → `build` 13/13, re-run after rebasing onto current `main`.
- 39 research integration test files, 169 tests, against live Postgres.
- Catalan and English catalogues complete (`i18n:check`).
- Pre-push suite green, including all 8 end-to-end smoke tests.
- Screenshots taken by driving the running app in this worktree, signed in, against its own database.

## Deferred

- The script-aware fold itself (§4.6 of #456) — it must land after existence verification (#486) and per-company trust (§4.9), because a fold that keeps every writing system opens a new way to be confidently wrong and those are what catch it.
- Nothing tells a caller *which* name could not be read except the log; the stored field is a yes/no. Worth revisiting if the rate turns out high.

Closes #499
