### PR TITLE
fix(research): reach a person once, whatever roles they are listed under

### DIFF
--- a/packages/research/src/application/contact-discovery.test.ts
+++ b/packages/research/src/application/contact-discovery.test.ts
@@ -8,12 +8,14 @@ import { BudgetExceeded, ProviderError } from '../domain/errors'
 import { EnrichmentResult } from '../domain/types'
 import {
 	buyingRoleFromTitle,
+	compareByBuyingRole,
 	compareContacts,
 	type DiscoveredContact,
 	dedupePeople,
 	emailChannel,
 	estimateDiscoverCostCents,
 	MAX_VERIFICATIONS,
+	peopleToReach,
 	runEnrichmentChain,
 } from './contact-discovery'
 import {
@@ -199,6 +201,113 @@ describe('compareContacts', () => {
 				channels: [{ kind: 'linkedin', value: 'https://linkedin.com/in/x' }],
 			}
 			expect([socialOnly, withEmail].sort(compareContacts)[0]).toBe(withEmail)
+		})
+	})
+})
+
+describe('compareByBuyingRole', () => {
+	const director = {
+		firstName: 'Marta',
+		lastName: 'Ferrer',
+		position: 'Director General',
+	}
+	const clerk = {
+		firstName: 'Pau',
+		lastName: 'Roig',
+		position: 'Administratiu',
+	}
+
+	describe('when one person decides a purchase and the other does not', () => {
+		it('should put the decider first whichever order they arrive in', () => {
+			// GIVEN a director and a clerk, offered in each order. The paid checks stop
+			// at a ceiling, so whoever lands in front is who the money is spent on
+			// THEN the director is reached first either way
+			expect([clerk, director].sort(compareByBuyingRole)[0]).toBe(director)
+			expect([director, clerk].sort(compareByBuyingRole)[0]).toBe(director)
+		})
+	})
+
+	describe('when neither person decides a purchase', () => {
+		it('should leave the order the register gave them', () => {
+			// GIVEN two people whose titles suggest no part in a purchase
+			const other = {
+				firstName: 'Nuria',
+				lastName: 'Sala',
+				position: 'Administrativa',
+			}
+			// THEN nothing is reordered: there is no reason to prefer either
+			expect([clerk, other].sort(compareByBuyingRole)).toEqual([clerk, other])
+		})
+	})
+
+	describe('when both people decide a purchase', () => {
+		it('should leave the order the register gave them', () => {
+			// GIVEN a director and a founder, both of whom can carry a purchase
+			const founder = {
+				firstName: 'Jordi',
+				lastName: 'Vila',
+				seniority: 'founder',
+			}
+			// THEN neither outranks the other, so the order they arrived in stands
+			expect([director, founder].sort(compareByBuyingRole)).toEqual([
+				director,
+				founder,
+			])
+		})
+	})
+
+	describe('when a register named somebody without a position', () => {
+		it('should rank them behind a decider', () => {
+			// GIVEN a person carrying no title at all
+			const nameless = { firstName: 'Anna', lastName: 'Puig' }
+			// THEN the director is still the one worth spending on first
+			expect([nameless, director].sort(compareByBuyingRole)[0]).toBe(director)
+		})
+	})
+})
+
+describe('peopleToReach', () => {
+	// What a Spanish register gives back for one firm: it lists positions, so
+	// Marta is named twice because she holds two of them, and the junior of the
+	// two happens to come first.
+	const fromRegister = [
+		{ firstName: 'Marta', lastName: 'Ferrer', position: 'Consejera Delegada' },
+		{ firstName: 'Jordi', lastName: 'Vila', position: 'Secretario' },
+		{ firstName: 'Marta', lastName: 'Ferrer', position: 'Presidente' },
+	]
+
+	describe('when a register names one person under two roles', () => {
+		it('should keep her once, under the role that can carry a purchase', () => {
+			// GIVEN the register above, where merging on first-seen would keep
+			// 'Consejera Delegada' and throw away the listing that marks her a buyer
+			const reached = peopleToReach(fromRegister)
+			// THEN she appears once, as the president, at the front — so she is the
+			// one the limited address checks are spent on
+			expect(reached).toHaveLength(2)
+			expect(reached[0]).toEqual({
+				firstName: 'Marta',
+				lastName: 'Ferrer',
+				position: 'Presidente',
+			})
+		})
+	})
+
+	describe('when nobody is listed twice', () => {
+		it('should hand back everyone, deciders first', () => {
+			// GIVEN two distinct people, the decider named last
+			const reached = peopleToReach([
+				{ firstName: 'Pau', lastName: 'Roig', position: 'Apoderado' },
+				{ firstName: 'Jordi', lastName: 'Vila', position: 'Presidente' },
+			])
+			// THEN nobody is dropped and the president is asked about first
+			expect(reached.map(p => p.firstName)).toEqual(['Jordi', 'Pau'])
+		})
+	})
+
+	describe('when the register named nobody', () => {
+		it('should hand back an empty list', () => {
+			// GIVEN a company whose register entry lists no active positions
+			expect(peopleToReach([])).toEqual([])
 		})
 	})
 })
@@ -545,6 +654,22 @@ describe('dedupePeople', () => {
 			// THEN the first wins — there is nothing better to prefer
 			expect(merged).toHaveLength(1)
 			expect(merged[0]?.email).toBe('first@acme.example')
+		})
+	})
+
+	describe('when a register lists one person under two roles', () => {
+		it('should collapse them to one', () => {
+			// GIVEN a company register that lists positions rather than people, so a
+			// director holding two active roles arrives twice under the same name
+			const merged = dedupePeople([
+				somePerson('Marta', 'Ferrer'),
+				somePerson('Marta', 'Ferrer'),
+			])
+			// THEN she is one person. Left doubled, her two entries guess the same
+			// address and reach the verifier under one key, so one is turned away as
+			// already bought — coming back unreachable, stamping the run as resumed,
+			// and spending one of the ten checks on nothing
+			expect(merged).toHaveLength(1)
 		})
 	})
 

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -49,7 +49,7 @@ import {
 // A person from either name source (registry directors or the enrichment
 // vendor). Registry directors arrive with just a name + role; enrichment adds
 // emails, seniority, and other channels. Only the fields the pipeline reads.
-interface SourcePerson {
+export interface SourcePerson {
 	readonly firstName: string
 	readonly lastName: string
 	readonly position?: string | undefined
@@ -369,6 +369,31 @@ export const compareContacts = (
 	return (emailB?.confidence ?? 0) - (emailA?.confidence ?? 0)
 }
 
+// Whoever can carry a purchase forward is reached first. The paid checks in
+// discovery stop at a ceiling, so this decides who the money is spent on. It
+// asks the same question `compareContacts` sorts the finished list by, so the
+// two cannot drift apart.
+export const compareByBuyingRole = (
+	a: SourcePerson,
+	b: SourcePerson,
+): number => {
+	const aDecides = decidesPurchase(buyingRoleFromTitle(a.position, a.seniority))
+	const bDecides = decidesPurchase(buyingRoleFromTitle(b.position, b.seniority))
+	if (aDecides === bDecides) return 0
+	return aDecides ? -1 : 1
+}
+
+// The list the paid checks work through: one person once, and whoever can
+// carry a purchase forward at the front.
+//
+// Sorted before the merge, not after. The merge keeps the first copy of a
+// person, so a director the register happens to list under a junior title
+// first would otherwise survive as the junior one — losing both the title
+// that says they can buy and their place at the front of the queue.
+export const peopleToReach = (
+	people: ReadonlyArray<SourcePerson>,
+): SourcePerson[] => dedupePeople([...people].sort(compareByBuyingRole))
+
 export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 	'ContactDiscovery',
 	{
@@ -633,8 +658,16 @@ export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 								}),
 							)
 
+						// A register lists a position, not a person, so a director holding two
+						// roles arrives twice. Both copies guess the same address and go to the
+						// verifier under the same key, so one pays and the other is turned away
+						// as already bought: it comes back with no address, the run stamps itself
+						// as having resumed paid work, and one of the ten checks a call may make
+						// is spent buying nothing. Settled before any money moves.
+						const toReach = peopleToReach(people)
+
 						const built = yield* Effect.forEach(
-							people,
+							toReach,
 							person =>
 								Effect.gen(function* () {
 									const channels: ContactChannel[] = []


### PR DESCRIPTION
## What

When research looks for people to contact at a company, it asks the public company register (in Spain, libreBORME) who the directors are. That register lists **positions, not people** — so somebody holding two roles at the same firm comes back twice. Until now nothing noticed, and the same person was treated as two.

That cost more than a tidy list: the duplicate spent one of the ten paid address checks a call is allowed and bought nothing with it, so on a long board the real directors at the back went unchecked. This is in the research engine (`packages/research`), behind the `discover_contacts` tool.

## The fix

**Touches:** the step that decides which people from a company register are worth paying to reach, and the order it works through them — everything downstream of it, including how the finished list is sorted for the caller, is unchanged.

- One person appears once, however many roles the register lists them under.
- Whoever can carry a purchase forward goes to the front, because the paid checks stop at a fixed ceiling and take whoever is in front. Before, that ceiling went to whoever the register happened to name first.
- The merge happens *after* that sort, not before. The merge keeps the first copy of a person, so a director listed under a junior title first would otherwise survive as the junior one — losing both the mark saying they can sign off and their place in the queue.

### What it looked like

A firm whose register lists four positions but only three people, because Marta holds two:

Before — four rows for three people, and the last is Marta again with nothing on it:

```
1. Marta Ferrer — Presidente            can sign off: yes   marta.ferrer@… (checked)
2. Jordi Vila   — Secretario            can sign off: no    jordi.vila@…   (checked)
3. Pau Roig     — Apoderado             can sign off: no    pau.roig@…     (checked)
4. Marta Ferrer — Consejera Delegada    can sign off: no    no way to reach her
```

After — three rows for three people:

```
1. Marta Ferrer — Presidente            can sign off: yes   marta.ferrer@… (checked)
2. Jordi Vila   — Secretario            can sign off: no    jordi.vila@…   (checked)
3. Pau Roig     — Apoderado             can sign off: no    pau.roig@…     (checked)
```

## Impact

- **Money spent with outside providers.** This is the point of the change. The duplicate's address check was refused as already-bought, so it paid nothing — but it still used up one of the ten checks a call may make, because that counter moves before the charge is attempted. Fewer wasted checks means more of the real board gets reached.
- **A false "resumed" mark on the run.** The refusal also stamped the run as having resumed work paid for earlier, which was untrue — the same person had simply been asked about twice in one call. That stops.
- **Both surfaces get it.** The change is in the shared `ContactDiscovery` service, so the tool behaves the same over MCP and over HTTP.
- **Fewer rows come back**, but no field is added, removed or renamed — nothing reading the result needs to change.
- No database migration, no change to which organisation can see what (row-level security), no new environment variables, no auth or route changes.

## Review guide

Start at `peopleToReach` in `packages/research/src/application/contact-discovery.ts` — it is three lines and it is the whole change. The order inside it is the part worth a second look: sorting *before* merging rather than after is load-bearing, and getting it backwards silently drops the senior listing. I had it backwards in my first version; `peopleToReach > when a register names one person under two roles` is the test that catches it, and I confirmed that test fails against the wrong order.

`compareByBuyingRole` deliberately asks the same question `compareContacts` (just above it) already asks of the finished list, so the order money is spent in cannot drift from the order results are read in. Today those are the same question either way — `buyingRoleFromTitle` only ever returns `economic_buyer` or nothing — but its own comment says it keeps that guess deliberately narrow, and widening it later would have split the two.

Exporting `SourcePerson` is only because the two new functions name it in their signatures.

## Tests

Unit tests in `contact-discovery.test.ts` for both new functions: the duplicate-under-two-roles case, deciders-first in both input orders, ties left in register order, a person with no title, and an empty register. I checked the duplicate test fails against the merge-then-sort order, so it guards the actual bug rather than just describing it.

## Verification

Re-ran on this branch after #416 landed under it, so these are the numbers for the base it now sits on: `pnpm install`, `check-types` (13/13 packages), `test` (21/21 tasks; 2100 tests in `packages/research`), `build` (13/13), and `biome` + `dprint`. All green.

I did **not** exercise `discover_contacts` against the live stack. Doing so calls the paid providers (Hunter, FullEnrich) and bills per person looked up, and the change is pure list logic with direct tests either side of it — including one verified to fail without the fix. Say if you'd rather I spend the money to see it end to end.

## Deferred

The register adapter itself still produces one entry per position (`packages/research/src/infrastructure/librebor/registry.ts`). Fixing it there would be tidier, but the engine should not depend on every register in every country behaving — so the merge belongs where it is now, and the adapter can stay as it is.

