### PR TITLE
fix(server): say which companies a create wrote and which it did not

### DIFF
--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -148,7 +148,15 @@ const CompanyInput = Schema.Struct(companyInputFields)
 // version drifted: it offered three statuses the app has never had and a priority
 // range twice the real one, and assistants followed it into rows that show up in
 // no board column. Now the sentence cannot say anything the schema would refuse.
-export const CREATE_COMPANIES_DESCRIPTION = `Create one or more companies in a single call — pass \`companies\` as an array (a single element to create just one, the whole shortlist to load a batch). Slug: unique kebab-case from name. Status: ${COMPANY_STATUSES.join('|')} (default: prospect). ownerId assigns the colleague who will work the company — pass a user id from list_members, or leave it out to create it unowned. It only lands on companies actually created: a skipped duplicate keeps the owner it already had, so re-sending a list is never a way to hand companies over. Use update_company for that. Priority: ${COMPANY_PRIORITIES[0]} (highest) to ${COMPANY_PRIORITIES[COMPANY_PRIORITIES.length - 1]} (lowest, default: 2). Pass taxId whenever you know it: a company is skipped if its slug already exists OR its registration number already does, so the number catches the same firm arriving under a different trading name. Runs in one transaction; a skip is not an error, so re-running an overlapping list is safe. Returns { created, skipped, possible_duplicates }: the rows that landed, for each one left out its slug plus matched_on ("slug" or "tax_id") saying which identity already existed, and any company that looks like one already on file under a different name — reported, not blocked, so check those before treating them as new.`
+export const CREATE_COMPANIES_DESCRIPTION = `Create one or more companies in a single call — pass \`companies\` as an array (a single element to create just one, the whole shortlist to load a batch). Slug: unique kebab-case from name. Status: ${COMPANY_STATUSES.join('|')} (default: prospect). ownerId assigns the colleague who will work the company — pass a user id from list_members, or leave it out to create it unowned. It only lands on companies actually created: a skipped duplicate keeps the owner it already had, so re-sending a list is never a way to hand companies over. Use update_company for that. Priority: ${COMPANY_PRIORITIES[0]} (highest) to ${COMPANY_PRIORITIES[COMPANY_PRIORITIES.length - 1]} (lowest, default: 2). Pass taxId whenever you know it: a company is skipped if its slug already exists OR its registration number already does, so the number catches the same firm arriving under a different trading name. Runs in one transaction; a skip is not an error, so re-running an overlapping list is safe. Returns { created, skipped, created_needs_review }. Read the split this way: created and created_needs_review were both WRITTEN; only skipped was not. \`skipped\` gives each left-out slug plus matched_on — "slug" or "tax_id" when that identity was already on file before this call, "slug_in_request" or "tax_id_in_request" when the same company appeared twice in the list you just sent (a mistake in the list, not a company already in the CRM). \`created_needs_review\` gives companies that DID land but resemble another one: matches_slug and matches_name name the lookalike, matches says whether it is "on_file" (already in the CRM) or "in_request" (another entry in this same call), and matched_on says whether they share a web address or just a similar name — a website match reports confidence 100, which only means the host was identical, never that the row was rejected. Check those before treating them as separate companies.`
+
+// What the service calls a skip, in the words the tool answers with.
+const SKIPPED_BECAUSE = {
+	slug: 'slug',
+	taxId: 'tax_id',
+	slugInRequest: 'slug_in_request',
+	taxIdInRequest: 'tax_id_in_request',
+} as const
 
 const CreateCompanies = Tool.make('create_companies', {
 	description: CREATE_COMPANIES_DESCRIPTION,
@@ -157,19 +165,29 @@ const CreateCompanies = Tool.make('create_companies', {
 	}),
 	success: Schema.Struct({
 		created: Schema.Array(Company.json),
+		// Not written, because something with this identity was there already —
+		// either on file before this call, or earlier in this same request.
 		skipped: Schema.Array(
 			Schema.Struct({
 				slug: Schema.String,
-				matched_on: Schema.Literals(['slug', 'tax_id']),
+				matched_on: Schema.Literals([
+					'slug',
+					'tax_id',
+					'slug_in_request',
+					'tax_id_in_request',
+				]),
 			}),
 		),
-		// Reported rather than refused: only the person adding them knows whether
-		// two similar names are two branches or one company typed twice.
-		possible_duplicates: Schema.Array(
+		// Written, and worth a second look: every company named here landed, and
+		// resembles another one. Reported rather than refused, because only the
+		// person adding them knows whether two similar names are two branches or
+		// one company typed twice.
+		created_needs_review: Schema.Array(
 			Schema.Struct({
 				slug: Schema.String,
-				existing_slug: Schema.String,
-				existing_name: Schema.String,
+				matches_slug: Schema.String,
+				matches_name: Schema.String,
+				matches: Schema.Literals(['on_file', 'in_request']),
 				matched_on: Schema.Literals(['website', 'name']),
 				confidence: Schema.Number,
 			}),
@@ -470,9 +488,10 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 			create_companies: params =>
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
-					// Looked for before the write, so a company is compared against what
-					// was already on file rather than against the rest of this batch.
-					const possibleDuplicates = yield* findDuplicateCompanies(
+					// Looked for before the write: each company is compared against what is
+					// already on file, and — inside — against the entries ahead of it in this
+					// same request.
+					const needsReview = yield* findDuplicateCompanies(
 						sql,
 						currentOrg.id,
 						params.companies.map(c => ({
@@ -486,12 +505,9 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 						created: batch.created,
 						skipped: batch.skipped.map(skip => ({
 							slug: skip.slug,
-							matched_on:
-								skip.matchedOn === 'taxId'
-									? ('tax_id' as const)
-									: ('slug' as const),
+							matched_on: SKIPPED_BECAUSE[skip.matchedOn],
 						})),
-						possible_duplicates: possibleDuplicates,
+						created_needs_review: needsReview,
 					}
 				}).pipe(
 					Effect.catchTag('BadRequest', e =>

--- a/apps/server/src/services/companies-create-tax-id.integration.test.ts
+++ b/apps/server/src/services/companies-create-tax-id.integration.test.ts
@@ -69,7 +69,7 @@ afterAll(async () => {
 })
 
 describe('CompanyService.createMany deduping on the registration number', () => {
-	describe('when the same company is offered twice under different names', () => {
+	describe('when the same company is offered twice in one call, under different names', () => {
 		it('should create it once and say which identity matched', async () => {
 			// GIVEN one firm submitted twice: two different trading names, so two
 			// different slugs, but the same number written two ways
@@ -94,15 +94,16 @@ describe('CompanyService.createMany deduping on the registration number', () => 
 			expect(batch.created[0]?.slug).toBe(`acme-${suffix}`)
 			expect(batch.created[0]?.taxId).toBe(`B-${digits}`)
 
-			// AND the second is reported as already held, by its number rather than
-			// its slug — which is the whole point: its slug was new
+			// AND the second is reported as a repeat inside this very call, by its
+			// number rather than its slug — which is the whole point: its slug was new,
+			// and it was never on file before this call either
 			expect(batch.skipped).toStrictEqual([
-				{ slug: `acme-logistics-${suffix}`, matchedOn: 'taxId' },
+				{ slug: `acme-logistics-${suffix}`, matchedOn: 'taxIdInRequest' },
 			])
 		})
 	})
 
-	describe('when a slug is reused', () => {
+	describe('when a slug is reused inside one call', () => {
 		it('should report the slug as what matched', async () => {
 			// GIVEN two entries sharing a slug and carrying no number at all
 			const suffix = randomUUID().slice(0, 8)
@@ -112,10 +113,11 @@ describe('CompanyService.createMany deduping on the registration number', () => 
 			])
 			createdIds.push(...batch.created.map(company => company.id))
 
-			// THEN one landed and the other is reported against the slug
+			// THEN one landed, and the other is reported as the caller having sent the
+			// same slug twice rather than as a company already in the CRM
 			expect(batch.created).toHaveLength(1)
 			expect(batch.skipped).toStrictEqual([
-				{ slug: `dup-${suffix}`, matchedOn: 'slug' },
+				{ slug: `dup-${suffix}`, matchedOn: 'slugInRequest' },
 			])
 		})
 	})
@@ -150,6 +152,60 @@ describe('CompanyService.createMany deduping on the registration number', () => 
 			// treated as a match between two unrelated firms
 			expect(batch.created).toHaveLength(2)
 			expect(batch.skipped).toStrictEqual([])
+		})
+	})
+})
+
+describe('CompanyService.createMany telling a company already on file from one sent twice', () => {
+	describe('when a later call repeats a number an earlier call created', () => {
+		it('should report it as already on file', async () => {
+			// GIVEN a company created and finished with, then offered again under a
+			// new name in a separate call — the case the in-call repeat is easy to
+			// confuse with, and the one where "already existed" is the truth
+			const suffix = randomUUID().slice(0, 8)
+			const digits = `${Date.now()}`.slice(-8)
+			const first = await createMany([
+				{ name: 'Prior SL', slug: `prior-${suffix}`, taxId: `B-${digits}` },
+			])
+			createdIds.push(...first.created.map(company => company.id))
+
+			const second = await createMany([
+				{
+					name: 'Prior Trading SL',
+					slug: `prior-trading-${suffix}`,
+					taxId: `b${digits}`,
+				},
+			])
+			createdIds.push(...second.created.map(company => company.id))
+
+			// THEN nothing new landed, and the report says the number was on file
+			// rather than sent twice — the caller's list was fine
+			expect(second.created).toHaveLength(0)
+			expect(second.skipped).toStrictEqual([
+				{ slug: `prior-trading-${suffix}`, matchedOn: 'taxId' },
+			])
+		})
+	})
+
+	describe('when a later call repeats a slug an earlier call created', () => {
+		it('should report it as already on file', async () => {
+			// GIVEN a slug created in one call and offered again in the next
+			const suffix = randomUUID().slice(0, 8)
+			const first = await createMany([
+				{ name: 'Held One', slug: `held-${suffix}` },
+			])
+			createdIds.push(...first.created.map(company => company.id))
+
+			const second = await createMany([
+				{ name: 'Held Two', slug: `held-${suffix}` },
+			])
+			createdIds.push(...second.created.map(company => company.id))
+
+			// THEN the slug is reported as one the CRM already held
+			expect(second.created).toHaveLength(0)
+			expect(second.skipped).toStrictEqual([
+				{ slug: `held-${suffix}`, matchedOn: 'slug' },
+			])
 		})
 	})
 })

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -461,13 +461,34 @@ export class CompanyService extends Context.Service<CompanyService>()(
 						const inserted: Array<unknown> = []
 						const skipped: Array<{
 							readonly slug: string
-							readonly matchedOn: 'slug' | 'taxId'
+							readonly matchedOn:
+								| 'slug'
+								| 'taxId'
+								| 'slugInRequest'
+								| 'taxIdInRequest'
 						}> = []
+						// What this very call has written so far. Without it a repeat inside
+						// one request reads exactly like a company that had been on file for
+						// a year: the slug conflict and the tax-id lookup below both find the
+						// row this same call inserted a moment earlier, and the caller is told
+						// it already existed.
+						const slugsWritten = new Set<string>()
+						const taxIdsWritten = new Set<string>()
 						for (const data of items) {
 							const slug = typeof data['slug'] === 'string' ? data['slug'] : ''
 							const taxId =
 								typeof data['taxId'] === 'string' ? data['taxId'] : null
-							if (taxId !== null && normalizeTaxId(taxId) !== '') {
+							const normalizedTaxId =
+								taxId === null ? '' : normalizeTaxId(taxId)
+							if (slugsWritten.has(slug)) {
+								skipped.push({ slug, matchedOn: 'slugInRequest' })
+								continue
+							}
+							if (normalizedTaxId !== '') {
+								if (taxIdsWritten.has(normalizedTaxId)) {
+									skipped.push({ slug, matchedOn: 'taxIdInRequest' })
+									continue
+								}
 								const existing = yield* sql`
 									SELECT id FROM companies
 									WHERE organization_id = ${currentOrg.id}
@@ -478,7 +499,7 @@ export class CompanyService extends Context.Service<CompanyService>()(
 										AND deleted_at IS NULL
 										AND tax_id IS NOT NULL
 										AND upper(regexp_replace(tax_id, '[^A-Za-z0-9]', '', 'g'))
-											= ${normalizeTaxId(taxId)}
+											= ${normalizedTaxId}
 									LIMIT 1
 								`
 								if (existing.length > 0) {
@@ -518,6 +539,8 @@ export class CompanyService extends Context.Service<CompanyService>()(
 										split.channels,
 									)
 								}
+								slugsWritten.add(slug)
+								if (normalizedTaxId !== '') taxIdsWritten.add(normalizedTaxId)
 								inserted.push(row)
 							}
 						}

--- a/apps/server/src/services/company-duplicates.integration.test.ts
+++ b/apps/server/src/services/company-duplicates.integration.test.ts
@@ -85,7 +85,8 @@ describe('finding a company that is already on file', () => {
 			)
 			// THEN the person adding it is told, rather than quietly getting a second row
 			expect(found).toHaveLength(1)
-			expect(found[0]?.existing_name).toBe('Fusteria Vidal')
+			expect(found[0]?.matches_name).toBe('Fusteria Vidal')
+			expect(found[0]?.matches).toBe('on_file')
 			expect(found[0]?.matched_on).toBe('name')
 		})
 	})
@@ -121,7 +122,7 @@ describe('finding a company that is already on file', () => {
 				}),
 			)
 			expect(found).toHaveLength(1)
-			expect(found[0]?.existing_name).toBe('Transports Ferré')
+			expect(found[0]?.matches_name).toBe('Transports Ferré')
 			expect(found[0]?.matched_on).toBe('website')
 		})
 	})
@@ -133,6 +134,56 @@ describe('finding a company that is already on file', () => {
 					const sql = yield* SqlClient.SqlClient
 					return yield* findDuplicateCompanies(sql, ORG, [
 						{ slug: 'forn-sant-jordi', name: 'Forn Sant Jordi' },
+					])
+				}),
+			)
+			expect(found).toEqual([])
+		})
+	})
+})
+
+describe('finding two spellings of one company inside a single request', () => {
+	describe('when two entries in the same call share a web address', () => {
+		it('should report the second against the first', async () => {
+			// GIVEN one call adding what the caller believes are two companies, under
+			// different names and slugs, but on one web address
+			const found = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* findDuplicateCompanies(sql, ORG, [
+						{
+							slug: 'obrador-camps',
+							name: 'Obrador Camps',
+							website: 'https://obradorcamps.cat',
+						},
+						{
+							slug: 'camps-pastisseria',
+							name: 'Camps Pastisseria',
+							website: 'https://www.obradorcamps.cat/botiga',
+						},
+					])
+				}),
+			)
+			// THEN the later one is flagged against the earlier one, and says the
+			// lookalike came in this same call rather than off the CRM — both were
+			// still written, so the caller is the one who decides
+			expect(found).toHaveLength(1)
+			expect(found[0]?.slug).toBe('camps-pastisseria')
+			expect(found[0]?.matches_slug).toBe('obrador-camps')
+			expect(found[0]?.matches).toBe('in_request')
+			expect(found[0]?.matched_on).toBe('website')
+		})
+	})
+
+	describe('when the entries in one call resemble nothing', () => {
+		it('should report nothing', async () => {
+			// GIVEN two plainly different companies sent together
+			const found = await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					return yield* findDuplicateCompanies(sql, ORG, [
+						{ slug: 'forn-sant-jordi', name: 'Forn Sant Jordi' },
+						{ slug: 'clinica-bonavista', name: 'Clinica Bonavista' },
 					])
 				}),
 			)

--- a/apps/server/src/services/company-duplicates.ts
+++ b/apps/server/src/services/company-duplicates.ts
@@ -107,13 +107,21 @@ export const nameOverlap = (
 	return matched / total
 }
 
-/** A company already on file that the one being added may be another spelling of. */
+/**
+ * A company that was created, and the one it may be another spelling of.
+ *
+ * Reported, never refused: only the person adding them knows whether two
+ * similar names are two branches or one company typed twice.
+ */
 export interface PossibleDuplicate {
+	/** The company that was created. */
 	readonly slug: string
-	readonly existing_slug: string
-	readonly existing_name: string
+	readonly matches_slug: string
+	readonly matches_name: string
+	/** Whether the lookalike was already on file or arrived in the same request. */
+	readonly matches: 'on_file' | 'in_request'
 	readonly matched_on: 'website' | 'name'
-	/** 0–100, how much of the new name the existing one accounts for. */
+	/** 0–100, how much of the new name the other one accounts for. */
 	readonly confidence: number
 }
 
@@ -167,7 +175,6 @@ export const findDuplicateCompanies = (
 			WHERE c.organization_id = ${orgId} AND c.deleted_at IS NULL
 			LIMIT ${SAMPLE_CAP}
 		`
-		if (existing.length === 0) return [] as ReadonlyArray<PossibleDuplicate>
 
 		if (existing.length === SAMPLE_CAP) {
 			yield* Effect.logInfo('companies.duplicates.sampled').pipe(
@@ -192,28 +199,54 @@ export const findDuplicateCompanies = (
 			row.website === null ? undefined : hostOf(row.website),
 		)
 
+		// Everything a company being added is weighed against: what is already on
+		// file, and — as the loop goes — the entries that arrived ahead of it in
+		// this same request. Two spellings of one company sent together used to be
+		// written as two rows with nothing said about it.
+		const seen: Array<{
+			readonly slug: string
+			readonly name: string
+			readonly tokens: ReadonlyArray<string>
+			readonly host: string | undefined
+			readonly matches: 'on_file' | 'in_request'
+		}> = existing.map((row, index) => ({
+			slug: row.slug,
+			name: row.name,
+			tokens: tokensByRow[index] ?? [],
+			host: hostsByRow[index],
+			matches: 'on_file' as const,
+		}))
+
 		const found: Array<PossibleDuplicate> = []
 		for (const candidate of incoming) {
 			const tokens = nameTokens(candidate.name)
 			const host =
 				candidate.website === undefined ? undefined : hostOf(candidate.website)
 			let best: PossibleDuplicate | undefined
-			for (const [index, row] of existing.entries()) {
+			for (const other of seen) {
 				// The same web address is the same company, whatever it calls itself.
-				const sameHost = host !== undefined && hostsByRow[index] === host
-				const overlap = nameOverlap(tokens, tokensByRow[index] ?? [], weightOf)
+				const sameHost = host !== undefined && other.host === host
+				const overlap = nameOverlap(tokens, other.tokens, weightOf)
 				if (!sameHost && overlap < REPORT_ABOVE) continue
 				const confidence = sameHost ? 100 : Math.round(overlap * 100)
 				if (best !== undefined && best.confidence >= confidence) continue
 				best = {
 					slug: candidate.slug,
-					existing_slug: row.slug,
-					existing_name: row.name,
+					matches_slug: other.slug,
+					matches_name: other.name,
+					matches: other.matches,
 					matched_on: sameHost ? 'website' : 'name',
 					confidence,
 				}
 			}
 			if (best !== undefined) found.push(best)
+			seen.push({
+				slug: candidate.slug,
+				name: candidate.name,
+				tokens,
+				host,
+				matches: 'in_request',
+			})
 		}
 		return found as ReadonlyArray<PossibleDuplicate>
 	})


### PR DESCRIPTION
## What

`create_companies` is the tool that loads a list of companies into the CRM in one go. Its answer was telling callers things that were not true, in two ways — and both mattered most for the thing the tool is for: loading a prospect list and then acting on what came back.

First, if the same company appeared twice in one list, the second copy was reported as *already on file*. It was not — it was a row that same call had created a moment earlier. Second, the answer put "not written" and "written, please check" side by side with nothing but their names to tell them apart, so a warning read as a rejection. This is in the CRM's company service and the MCP tool over it (`apps/server`).

## The fix

**Touches:** the step that writes a batch of companies, the check that looks for lookalikes before it, and the words the tool answers with — nothing about how a company is stored.

- A repeat inside one call now says so. `skipped` reports `slug_in_request` or `tax_id_in_request` when the same company was sent twice in the list, distinct from `slug` or `tax_id` when it had genuinely been on file beforehand. The first is a mistake in the caller's list; the second is not.
- The warning list is now called `created_needs_review` rather than `possible_duplicates`, so its name says the thing that matters: **these were written.** Only `skipped` was not.
- The lookalike check now compares the companies in one call against each other as well as against what is on file. Two spellings of one company arriving together used to be written as two rows with nothing said about it. Each report also says whether the lookalike is `on_file` or `in_request`.
- The tool's own description now spells the split out where a caller reads it, including that a website match reporting `confidence: 100` only means the host was identical — never that the row was rejected.

## Impact

- **Wire shape.** `possible_duplicates` is gone, replaced by `created_needs_review`; inside it `existing_slug`/`existing_name` are now `matches_slug`/`matches_name` and there is a new `matches` field. `skipped.matched_on` gained two values. Nothing in the web app reads these — I checked — so the only consumer is whatever is driving the tool.
- **Both surfaces.** The in-request tracking lives in the shared `CompanyService`, so an HTTP caller gets it too; the renamed fields are on the MCP tool.
- **A create can now report a lookalike for an organisation with nothing on file.** The check used to return early when the CRM was empty, which is exactly the case where two entries in one list can only be compared against each other. Word weighting handles an empty organisation on its own (every word weighs 1), and the divide-by-zero guard in the overlap scorer was already there.
- No database migration, no change to which organisation can see what (row-level security), no new environment variables, no auth or route changes. Nothing about what gets written changed — a company still lands exactly once. Only the report changed.

## Review guide

Start with `createMany` in `apps/server/src/services/companies.ts`: the two `Set`s and the two guards above the tax-id lookup are the whole of the first fix. The thing worth checking is that both sets are written *after* a successful insert, not before — a company that fails to land must not count as one this call wrote.

Then `findDuplicateCompanies` in `company-duplicates.ts`. The loop now walks a `seen` list that starts as the on-file rows and grows as the request is walked, so an entry is compared against the ones ahead of it and never against itself or ones behind it. I removed the empty-organisation early return deliberately — see Impact.

The decision you might overrule: I renamed `existing_slug`/`existing_name` to `matches_slug`/`matches_name` because "existing" is wrong once the lookalike can be another entry in the same request. That widens the break beyond what the issue asked for. It is pre-production, so a clean break seemed better than a field whose name lies in half its cases.

## Tests

Integration tests against the live database, run and passing (12 across the two files):

- A repeat inside one call reports `slug_in_request` / `tax_id_in_request`. The two existing tests here were asserting the old, wrong values — they sent two entries in **one** call and expected `slug` / `tax_id`, so they were encoding the bug. Updated.
- New: a company created in an *earlier* call and offered again still reports `slug` / `tax_id`. This is the case the fix must not break, and nothing covered it before.
- New: two entries in one call sharing a web address are reported, the later against the earlier, marked `in_request`.
- New: two plainly different companies in one call are reported as nothing.

## Verification

Ran on this branch off current `main`: `pnpm install`, `check-types` (13/13 packages), `test` (21/21 tasks), `build` (13/13), and `biome` + `dprint` — all green. Plus the two integration files above against the local integration database: 12 passed.

I did not drive the MCP tool end to end from a client; the behavior is covered by the integration tests through the real service and the real database, and the renamed fields are pinned by the tool's success schema.

Closes #407
