### PR TITLE
fix(research): keep every office a register lists a person under

### DIFF
--- a/apps/server/src/services/research-discover-no-domain.integration.test.ts
+++ b/apps/server/src/services/research-discover-no-domain.integration.test.ts
@@ -35,12 +35,16 @@ let mxCalls: string[] = []
 let verifyCalls: string[] = []
 let charges: string[] = []
 
+// Three listings, two people: a register records an office, so Dolors holding
+// two of them is named twice. The junior office comes first, as a register is
+// under no obligation to order them.
 const registryDirectors = [
 	{ name: 'Dolors Puig', role: 'Administradora única' },
 	{ name: 'Jordi Serra', role: 'Apoderat' },
+	{ name: 'Dolors Puig', role: 'Presidenta' },
 ]
 
-// A registry that names two officers and no addresses, which is what a national
+// A registry that names its officers and no addresses, which is what a national
 // business register actually holds.
 const registryLayer = Layer.succeed(RegistryRouter)(
 	RegistryRouter.of({
@@ -166,8 +170,11 @@ describe('discover_contacts for a company with no website', () => {
 			// AND each carries their role but no way of reaching them — which is the
 			// whole point: a name and a job title beat reporting nobody was found
 			expect(contacts.every(c => c.channels.length === 0)).toBe(true)
+			// Both her offices, the one that can carry a purchase first, and she is
+			// one row rather than two — the register listed an office twice, not a
+			// person twice
 			expect(contacts.find(c => c.name === 'Dolors Puig')?.role).toBe(
-				'Administradora única',
+				'Presidenta, Administradora única',
 			)
 
 			// AND no enrichment vendor was asked or charged for a lookup keyed on a

--- a/packages/research/src/application/contact-discovery.test.ts
+++ b/packages/research/src/application/contact-discovery.test.ts
@@ -141,6 +141,23 @@ describe('buyingRoleFromTitle', () => {
 			)
 		})
 	})
+
+	describe('when a person holds several offices joined into one line', () => {
+		it('should read the buying office whichever end of the line it sits at', () => {
+			// GIVEN one director's offices carried as a single line, in both orders —
+			// the shape `peopleToReach` now hands on for a register that named them
+			// twice
+			// THEN the line still reads as somebody who can carry a purchase: the
+			// separator cannot hide the office, and cannot invent one either
+			expect(
+				buyingRoleFromTitle('Presidente, Consejera Delegada', undefined),
+			).toBe('economic_buyer')
+			expect(
+				buyingRoleFromTitle('Consejera Delegada, Presidente', undefined),
+			).toBe('economic_buyer')
+			expect(buyingRoleFromTitle('Secretario, Apoderado', undefined)).toBeNull()
+		})
+	})
 })
 
 describe('compareContacts', () => {
@@ -276,19 +293,92 @@ describe('peopleToReach', () => {
 		{ firstName: 'Marta', lastName: 'Ferrer', position: 'Presidente' },
 	]
 
-	describe('when a register names one person under two roles', () => {
-		it('should keep her once, under the role that can carry a purchase', () => {
-			// GIVEN the register above, where merging on first-seen would keep
-			// 'Consejera Delegada' and throw away the listing that marks her a buyer
+	describe('when a register names one person under two offices', () => {
+		it('should keep her once, carrying both, the buying one first', () => {
+			// GIVEN the register above, where keeping only the first listing would
+			// throw away the office that marks her a buyer
 			const reached = peopleToReach(fromRegister)
-			// THEN she appears once, as the president, at the front — so she is the
-			// one the limited address checks are spent on
+			// THEN she appears once, holding both offices with the president first —
+			// so she is who the limited address checks are spent on, and neither
+			// office the register recorded is lost
 			expect(reached).toHaveLength(2)
 			expect(reached[0]).toEqual({
 				firstName: 'Marta',
 				lastName: 'Ferrer',
-				position: 'Presidente',
+				position: 'Presidente, Consejera Delegada',
 			})
+		})
+	})
+
+	describe('when a register names one person under many offices', () => {
+		it('should carry every one of them', () => {
+			// GIVEN a director holding four offices at the same company
+			const reached = peopleToReach([
+				{ firstName: 'Nuria', lastName: 'Sala', position: 'Secretaria' },
+				{ firstName: 'Nuria', lastName: 'Sala', position: 'Consejera' },
+				{ firstName: 'Nuria', lastName: 'Sala', position: 'Apoderada' },
+				{ firstName: 'Nuria', lastName: 'Sala', position: 'Presidenta' },
+			])
+			// THEN none is dropped: what a register recorded about a person is not
+			// ours to trim, and the buying office still reads first
+			expect(reached).toHaveLength(1)
+			expect(reached[0]?.position).toBe(
+				'Presidenta, Secretaria, Consejera, Apoderada',
+			)
+		})
+	})
+
+	describe('when the same office is listed twice', () => {
+		it('should carry it once, however it was spelled', () => {
+			// GIVEN one office recorded twice, once in capitals and once padded
+			const reached = peopleToReach([
+				{ firstName: 'Pau', lastName: 'Roig', position: 'Administrador' },
+				{ firstName: 'Pau', lastName: 'Roig', position: '  ADMINISTRADOR ' },
+			])
+			// THEN it reads once — the same office spelled two ways is one office
+			expect(reached[0]?.position).toBe('Administrador')
+		})
+	})
+
+	describe('when one office sits inside the name of another', () => {
+		it('should keep both, because a register nests real offices', () => {
+			// GIVEN a director recorded as both, which Spanish company law treats as
+			// two distinct appointments rather than one restated
+			const reached = peopleToReach([
+				{ firstName: 'Marta', lastName: 'Ferrer', position: 'Administrador' },
+				{
+					firstName: 'Marta',
+					lastName: 'Ferrer',
+					position: 'Administrador Solidario',
+				},
+			])
+			// THEN neither is swallowed by the other
+			expect(reached[0]?.position).toBe(
+				'Administrador, Administrador Solidario',
+			)
+		})
+	})
+
+	describe('when only one of a person’s listings carries an office', () => {
+		it('should carry the one there is', () => {
+			// GIVEN the same person listed twice, once with no office recorded
+			const reached = peopleToReach([
+				{ firstName: 'Jordi', lastName: 'Vila' },
+				{ firstName: 'Jordi', lastName: 'Vila', position: 'Presidente' },
+			])
+			// THEN the office that was recorded survives the merge
+			expect(reached).toHaveLength(1)
+			expect(reached[0]?.position).toBe('Presidente')
+		})
+	})
+
+	describe('when a register named somebody with no office at all', () => {
+		it('should leave the office unset rather than blank', () => {
+			// GIVEN a person the register names without a position
+			const reached = peopleToReach([{ firstName: 'Anna', lastName: 'Puig' }])
+			// THEN it stays absent: an empty string would read as an office recorded
+			// as nothing, which is not what the register said
+			expect(reached[0]?.position).toBeUndefined()
 		})
 	})
 
@@ -657,10 +747,10 @@ describe('dedupePeople', () => {
 		})
 	})
 
-	describe('when a register lists one person under two roles', () => {
+	describe('when two vendors both name the same person', () => {
 		it('should collapse them to one', () => {
-			// GIVEN a company register that lists positions rather than people, so a
-			// director holding two active roles arrives twice under the same name
+			// GIVEN two paid finders that both return the same person, which is what
+			// union mode is for — this merge is the vendor one, not the register one
 			const merged = dedupePeople([
 				somePerson('Marta', 'Ferrer'),
 				somePerson('Marta', 'Ferrer'),

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -62,6 +62,17 @@ export interface SourcePerson {
 	readonly phone?: string | undefined
 }
 
+// Who a record is about. Named rather than written inline because two things
+// have to agree on it exactly: the merge that folds a person's duplicate
+// listings together, and the gathering of the offices those listings named.
+// Group by one rule and merge by another and a person's offices end up
+// attached to somebody else.
+const personKey = (person: SourcePerson): string =>
+	`${person.firstName} ${person.lastName}`.trim().toLowerCase() ||
+	person.email?.toLowerCase() ||
+	person.linkedin ||
+	''
+
 // Merge people gathered from more than one enrichment vendor into one entry per
 // person (union mode). Keyed by name — so the same person from two vendors
 // collapses to a single contact — with a record that carries an email winning
@@ -71,11 +82,7 @@ export const dedupePeople = (
 ): SourcePerson[] => {
 	const byPerson = new Map<string, SourcePerson>()
 	for (const person of people) {
-		const key =
-			`${person.firstName} ${person.lastName}`.trim().toLowerCase() ||
-			person.email?.toLowerCase() ||
-			person.linkedin ||
-			''
+		const key = personKey(person)
 		const existing = byPerson.get(key)
 		if (
 			existing === undefined ||
@@ -383,16 +390,58 @@ export const compareByBuyingRole = (
 	return aDecides ? -1 : 1
 }
 
-// The list the paid checks work through: one person once, and whoever can
-// carry a purchase forward at the front.
+// Every distinct office one person is listed under, as one line. The register's
+// own words in its own language — the separator is the only text added here, so
+// the line can still be split back apart.
 //
-// Sorted before the merge, not after. The merge keeps the first copy of a
-// person, so a director the register happens to list under a junior title
-// first would otherwise survive as the junior one — losing both the title
-// that says they can buy and their place at the front of the queue.
+// A title is dropped only when the very same title is listed twice. Never
+// because one sits inside another: a register's offices genuinely nest, and
+// "Administrador Solidario" is a different office from "Administrador", not a
+// longer way of writing it.
+const joinPositions = (
+	positions: ReadonlyArray<string>,
+): string | undefined => {
+	const seen = new Set<string>()
+	const kept: string[] = []
+	for (const raw of positions) {
+		const title = raw.trim().replace(/\s+/g, ' ')
+		if (title === '' || seen.has(title.toLowerCase())) continue
+		seen.add(title.toLowerCase())
+		kept.push(title)
+	}
+	return kept.length === 0 ? undefined : kept.join(', ')
+}
+
+// The list the paid checks work through: one person once, carrying every office
+// the register lists them under, whoever can carry a purchase forward first.
+//
+// Sorted before the merge, for two reasons that outlast the merge. The paid
+// checks below stop at a ceiling and take whoever is in front, so this order
+// decides who the money is spent on. And it settles the order inside the joined
+// title, so the office that can sign off reads first.
+//
+// The joining lives here rather than inside the merge, because the merge is also
+// what folds two paid vendors' answers together — and those two describe the
+// same job in different words. "CTO" beside "Chief Technology Officer" is one
+// office written twice, not two offices, and joining them there would say a
+// person holds both.
 export const peopleToReach = (
 	people: ReadonlyArray<SourcePerson>,
-): SourcePerson[] => dedupePeople([...people].sort(compareByBuyingRole))
+): SourcePerson[] => {
+	const sorted = [...people].sort(compareByBuyingRole)
+	const heldBy = new Map<string, string[]>()
+	for (const person of sorted) {
+		if (person.position === undefined) continue
+		const key = personKey(person)
+		const held = heldBy.get(key)
+		if (held === undefined) heldBy.set(key, [person.position])
+		else held.push(person.position)
+	}
+	return dedupePeople(sorted).map(person => {
+		const position = joinPositions(heldBy.get(personKey(person)) ?? [])
+		return position === undefined ? person : { ...person, position }
+	})
+}
 
 export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 	'ContactDiscovery',


### PR DESCRIPTION
## What

When research reads a company's directors from a public register, it reads **offices, not people**. Somebody holding two posts at the same firm is listed twice. [PR 544](https://github.com/guillempuche/batuda/pull/544) folds those repeats into one contact — but it kept one office and threw the rest away.

So the woman a register records as both *Presidenta* and *Administradora Única* came back as just the president. The fact that she is also the sole administrator — often the most senior thing anyone can say about a small Spanish firm — was gone. This is in the research engine (`packages/research`), behind the `discover_contacts` tool.

> Was stacked on [#544](https://github.com/guillempuche/batuda/pull/544), which introduced the fold this builds on. That has merged, so this now targets `main` directly and carries only its own commit.

## The fix

**Touches:** the step that decides which people from a register are worth paying to reach — not how a contact is stored, and not the check that decides who can sign off a purchase.

- Every distinct office a person is listed under is carried, as one line, with the office that can carry a purchase first.
- A repeat is dropped only when it is **the very same office** spelled differently (`Administrador` / `ADMINISTRADOR`). Never because one name sits inside another: a register's offices genuinely nest, and `Administrador Solidario` is a distinct legal appointment from `Administrador`, not a longer way of writing it.
- No cap on how many are carried. What a register recorded about a person is not ours to trim.

Before and after, for a director a Spanish register lists twice:

```
before   role: "Presidenta"
after    role: "Presidenta, Administradora Única"
```

## Where the joining does *not* happen

The fold that merges duplicates is also what merges what **two paid vendors** found. Those two describe *the same* job in different words — Hunter says `CTO`, FullEnrich says `Chief Technology Officer`. Joining there would report one job as two.

So the joining sits one level up, in `peopleToReach`, where we know we are looking at a register. That is the load-bearing decision in this PR; everything else follows from it.

## Impact

- **What a contact says about a person gets longer.** `contacts.role` is free text and already holds the register's own Spanish verbatim, so nothing needed a migration. The company page renders it with no truncation, so a director with many offices makes a taller contact card. The contact edit dialog caps typed input at 200 characters (`contact-edit-dialog.tsx:131`); a realistic three-office line ("Presidenta, Administradora Única, Consejera Delegada") is 53, so editing one back is not blocked — but nothing enforces that ceiling on what research writes.
- **Who can sign off a purchase does not change.** `buying_role` is worked out by matching words in the title. I checked the pattern against 25 real Spanish and Catalan register titles and all 625 joined pairs of them: no join ever turns a decider into a non-decider or the reverse. There is a test pinning both orders now.
- **One thing to watch.** A later run that reads a web page naming only one of the offices may read the stored line as a contradiction and propose changing it back — a diff somebody has to dismiss. It is not visible in the eval (contact scoring reads the expected role, never the run's), so it would show up in `research_proposed_updates` on live runs, not in a number. Flagging rather than pre-solving.
- No database migration, no change to which organisation can see what (row-level security), no new environment variables, no auth or route changes.

## Review guide

`peopleToReach` in `packages/research/src/application/contact-discovery.ts` is the whole change — it gathers each person's offices while walking the sorted list, then merges. The thing worth checking is that it groups by exactly what the merge merges by; that is why `personKey` was lifted out of `dedupePeople` rather than copied. Group by one rule and merge by another and a person's offices attach to somebody else.

The sort is still there and now does two jobs: it decides who the capped paid checks are spent on, and it settles which office reads first in the line.

Deliberately not fixed here, and worth knowing while reviewing: the title pattern is an English word list, so most Spanish register titles (`Consejera Delegada`, `Administradora Única`, `Apoderado`) are not recognised as decision-makers at all. That is why the example above puts `Presidenta` first and not `Administradora Única`. It belongs with #456 / #534, not in this PR.

## Tests

`contact-discovery.test.ts` — a person under two offices carrying both with the buying one first; four offices all carried; the same office spelled two ways collapsing; one office name sitting inside another and both surviving; a person whose second listing has no office; a person with no office staying unset rather than blank; and both orders of a joined line still reading as a decision-maker.

`research-discover-no-domain.integration.test.ts` now gives one stub director a second office, so the join is covered end to end through the real service and the real database rather than only as a pure function.

## Verification

`pnpm install`, `check-types` (13/13 packages), `test` (21/21 tasks), `build` (13/13), `biome` + `dprint`, `syncpack` — all green. Plus the discover integration test against the local integration database: 3 passed.

I did not run the research eval. Contact scoring reads the expected role from the golden set and never the run's, so no eval number moves on this change.


