### PR TITLE
fix: make the research dialog work on a phone, and stop dropdowns zooming iOS

### DIFF
--- a/apps/internal/src/components/interactions/quick-capture-dialog.tsx
+++ b/apps/internal/src/components/interactions/quick-capture-dialog.tsx
@@ -4,7 +4,7 @@ import { msg } from '@lingui/core/macro'
 import { useLingui as useLinguiCore } from '@lingui/react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import { X } from 'lucide-react'
+import { ChevronsUpDown, X } from 'lucide-react'
 import type { FormEvent } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
@@ -14,6 +14,7 @@ import {
 	PriDialog,
 	PriInput,
 	PriNumberField,
+	PriSelect,
 	PriToggleGroup,
 	usePriToast,
 } from '@batuda/ui/pri'
@@ -105,6 +106,11 @@ export function QuickCaptureDialog() {
 		}
 		return result.sort((a, b) => a.name.localeCompare(b.name, 'ca'))
 	}, [companiesResult])
+	const companyItems = useMemo(
+		() =>
+			companyOptions.map(option => ({ value: option.id, label: option.name })),
+		[companyOptions],
+	)
 
 	useEffect(() => {
 		if (!isOpen) return
@@ -208,22 +214,30 @@ export function QuickCaptureDialog() {
 								<Label htmlFor='qc-company'>
 									<Trans>Company</Trans>
 								</Label>
-								<Select
-									id='qc-company'
-									data-testid='quick-capture-company'
+								<PriSelect.Root
+									items={companyItems}
 									value={companyId}
-									onChange={event => setCompanyId(event.target.value)}
-									required
+									onValueChange={next => {
+										const picked = companyItems.find(
+											item => item.value === next,
+										)
+										if (picked) setCompanyId(picked.value)
+									}}
 								>
-									<option value='' disabled>
-										{t`— Select a company —`}
-									</option>
-									{companyOptions.map(option => (
-										<option key={option.id} value={option.id}>
-											{option.name}
-										</option>
-									))}
-								</Select>
+									<CompanyTrigger
+										id='qc-company'
+										data-testid='quick-capture-company'
+									>
+										<CompanyValue placeholder={t`— Select a company —`} />
+										<PriSelect.Icon>
+											<ChevronsUpDown size={12} aria-hidden />
+										</PriSelect.Icon>
+									</CompanyTrigger>
+									<PriSelect.Options
+										items={companyItems}
+										optionTestId={value => `quick-capture-company-${value}`}
+									/>
+								</PriSelect.Root>
 							</Field>
 						)}
 
@@ -514,24 +528,30 @@ const Label = styled.label.withConfig({ displayName: 'QuickCaptureLabel' })`
 	font-size: var(--typescale-label-small-size);
 `
 
-const Select = styled.select.withConfig({ displayName: 'QuickCaptureSelect' })`
-	display: block;
+// Sized like the text fields beside it, and at the body size rather than
+// smaller: below 16px an iPhone zooms the page the moment the control is
+// tapped, which on a full-screen sheet is hard to get back from.
+const CompanyTrigger = styled(PriSelect.Trigger).withConfig({
+	displayName: 'QuickCaptureCompanyTrigger',
+})`
+	justify-content: space-between;
 	width: 100%;
+	min-width: 0;
 	padding: var(--space-2xs) var(--space-sm);
-	min-height: 2.25rem;
-	border: none;
-	border-bottom: 2px solid var(--color-outline);
-	background: var(--color-paper-aged);
-	color: var(--color-on-surface);
 	font-family: var(--font-body);
-	font-size: var(--typescale-body-medium-size);
-	line-height: var(--typescale-body-medium-line);
-	border-radius: 0;
+	font-size: var(--typescale-body-large-size);
+	font-weight: var(--font-weight-regular);
+	letter-spacing: var(--typescale-body-large-tracking);
+	text-transform: none;
+`
 
-	&:focus-visible {
-		outline: none;
-		border-bottom-color: var(--color-primary);
-	}
+const CompanyValue = styled(PriSelect.Value).withConfig({
+	displayName: 'QuickCaptureCompanyValue',
+})`
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 `
 
 const Textarea = styled.textarea.withConfig({

--- a/apps/internal/src/components/research/inbox/research-inbox.tsx
+++ b/apps/internal/src/components/research/inbox/research-inbox.tsx
@@ -3,12 +3,12 @@ import type { MessageDescriptor } from '@lingui/core'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import { ArrowRight, Microscope, Search } from 'lucide-react'
+import { ArrowRight, ChevronsUpDown, Microscope, Search } from 'lucide-react'
 import { type ReactNode, useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { ATTENTION_RESEARCH_STATUSES } from '@batuda/domain'
-import { PriButton, PriInput, usePriToast } from '@batuda/ui/pri'
+import { PriButton, PriInput, PriSelect, usePriToast } from '@batuda/ui/pri'
 
 import {
 	type PendingProposal,
@@ -131,6 +131,15 @@ export function ResearchInbox() {
 	const [search, setSearch] = useState('')
 	const [minConfidence, setMinConfidence] = useState(0)
 	const [machineOnly, setMachineOnly] = useState(false)
+	const confidenceItems = useMemo(
+		() => [
+			{ value: '0', label: t`Any confidence` },
+			{ value: '50', label: t`50%+` },
+			{ value: '70', label: t`70%+` },
+			{ value: '90', label: t`90%+` },
+		],
+		[t],
+	)
 
 	// Filtering happens where the rows live. Sifting a fetched page in the browser
 	// only ever searched the newest hundred, so a matching change beyond that was
@@ -434,17 +443,28 @@ export function ResearchInbox() {
 						data-testid='research-inbox-search'
 						onChange={e => setSearch(e.target.value)}
 					/>
-					<FilterSelect
+					<PriSelect.Root
+						items={confidenceItems}
 						value={String(minConfidence)}
-						aria-label={t`Minimum confidence`}
-						data-testid='research-inbox-min-confidence'
-						onChange={e => setMinConfidence(Number(e.target.value))}
+						onValueChange={next => {
+							const picked = confidenceItems.find(item => item.value === next)
+							if (picked) setMinConfidence(Number(picked.value))
+						}}
 					>
-						<option value='0'>{t`Any confidence`}</option>
-						<option value='50'>{t`50%+`}</option>
-						<option value='70'>{t`70%+`}</option>
-						<option value='90'>{t`90%+`}</option>
-					</FilterSelect>
+						<FilterTrigger
+							aria-label={t`Minimum confidence`}
+							data-testid='research-inbox-min-confidence'
+						>
+							<PriSelect.Value />
+							<PriSelect.Icon>
+								<ChevronsUpDown size={11} aria-hidden />
+							</PriSelect.Icon>
+						</FilterTrigger>
+						<PriSelect.Options
+							items={confidenceItems}
+							optionTestId={value => `research-inbox-min-confidence-${value}`}
+						/>
+					</PriSelect.Root>
 					<ToggleLabel>
 						<input
 							type='checkbox'
@@ -983,19 +1003,16 @@ const Filters = styled.div`
 	gap: var(--space-2xs);
 `
 
-const FilterSelect = styled.select`
-	font-family: var(--font-body);
-	font-size: var(--typescale-body-small-size);
+// A compact filter chip, kept at the body size rather than smaller: below 16px
+// an iPhone zooms the page the moment the control is tapped.
+const FilterTrigger = styled(PriSelect.Trigger)`
+	gap: var(--space-3xs);
 	padding: var(--space-3xs) var(--space-2xs);
-	border-radius: var(--shape-2xs);
-	border: 1px solid color-mix(in oklab, var(--color-on-surface) 24%, transparent);
-	background: var(--color-surface);
-	color: var(--color-on-surface);
-
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
-	}
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-large-size);
+	font-weight: var(--font-weight-regular);
+	letter-spacing: var(--typescale-body-large-tracking);
+	text-transform: none;
 `
 
 const ToggleLabel = styled.label`

--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -6,7 +6,7 @@ import { msg } from '@lingui/core/macro'
 import { Plural, Trans, useLingui } from '@lingui/react/macro'
 import { Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import { Check, ChevronsUpDown, X } from 'lucide-react'
+import { ChevronsUpDown, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -577,7 +577,7 @@ export function ResearchDialog({
 										<ChevronsUpDown size={12} aria-hidden />
 									</PriSelect.Icon>
 								</PriSelect.Trigger>
-								<SelectOptions items={stackItems} />
+								<PriSelect.Options items={stackItems} />
 							</PriSelect.Root>
 						</Field>
 
@@ -718,33 +718,6 @@ type SelectItem<T extends string> = {
 	readonly label: string
 }
 
-// The list half of a dropdown, shared by every selector in this dialog so the
-// options look and behave the same wherever they are opened from.
-function SelectOptions<T extends string>({
-	items,
-}: {
-	readonly items: ReadonlyArray<SelectItem<T>>
-}) {
-	return (
-		<PriSelect.Portal>
-			<PriSelect.Positioner alignItemWithTrigger={false} sideOffset={6}>
-				<PriSelect.Popup>
-					<PriSelect.List>
-						{items.map(item => (
-							<PriSelect.Item key={item.value} value={item.value}>
-								<PriSelect.ItemIndicator>
-									<Check size={12} aria-hidden />
-								</PriSelect.ItemIndicator>
-								<PriSelect.ItemText>{item.label}</PriSelect.ItemText>
-							</PriSelect.Item>
-						))}
-					</PriSelect.List>
-				</PriSelect.Popup>
-			</PriSelect.Positioner>
-		</PriSelect.Portal>
-	)
-}
-
 // A dropdown in the scope grid. The trigger is a button, which a `<label for>`
 // may point at, so each field keeps the same label markup as the text fields
 // around it. What comes back is matched against the options rather than trusted,
@@ -777,7 +750,7 @@ function ScopeSelect<T extends string>({
 					<ChevronsUpDown size={12} aria-hidden />
 				</PriSelect.Icon>
 			</ScopeTrigger>
-			<SelectOptions items={items} />
+			<PriSelect.Options items={items} />
 		</PriSelect.Root>
 	)
 }

--- a/apps/internal/src/components/research/research-dialog.tsx
+++ b/apps/internal/src/components/research/research-dialog.tsx
@@ -7,8 +7,8 @@ import { Plural, Trans, useLingui } from '@lingui/react/macro'
 import { Link } from '@tanstack/react-router'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { Check, ChevronsUpDown, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import styled from 'styled-components'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import styled, { css } from 'styled-components'
 
 import type { SchemaName } from '@batuda/research'
 import {
@@ -24,7 +24,10 @@ import {
 	instructionTemplatesAtom,
 } from '#/atoms/instruction-atoms'
 import { createResearchAtom } from '#/atoms/research-atoms'
-import { narrowStacks } from '#/components/instructions/instruction-shapes'
+import {
+	narrowStacks,
+	narrowTemplates,
+} from '#/components/instructions/instruction-shapes'
 import {
 	type StackOption,
 	StackPicker,
@@ -33,6 +36,7 @@ import { STATUS_ORDER, statusLabels } from '#/components/shared/status-badge'
 import { formatMoneyCents } from '#/lib/format-money'
 import { taggedFailure } from '#/lib/tagged-failure'
 import { brushedMetalPlate, stenciledTitle } from '#/lib/workshop-mixins'
+import { buildResearchContext, researchRequestKey } from './research-request'
 
 // The registry's own names, so a schema retired or renamed server-side fails the
 // build here until its card goes too. Adding one does not force a card: an
@@ -89,10 +93,8 @@ const defaultSchema = (isDiscovery: boolean): SchemaOption =>
 const QUERY_MAX_LENGTH = 2000
 const FILTER_MAX_LENGTH = 120
 
-// Stages come from the one list the rest of the app shares. Keeping a private
-// copy here left out "closed" and "dead", so companies in those stages could
-// never be covered by a run at all — and it showed the reader the raw stored
-// words rather than their proper names.
+// '' leaves the sources unrestricted; the rest name one language to read in.
+type SourcesLanguage = '' | 'ca' | 'es' | 'en'
 
 export function ResearchDialog({
 	open,
@@ -120,22 +122,26 @@ export function ResearchDialog({
 	// Discovery-only scope fields: hints steer a net-new search, the selector
 	// filters fan the run out over existing companies.
 	const [location, setLocation] = useState('')
-	const [language, setLanguage] = useState<'' | 'ca' | 'es' | 'en'>('')
+	const [language, setLanguage] = useState<SourcesLanguage>('')
 	const [filterStatus, setFilterStatus] = useState('')
 	const [filterIndustry, setFilterIndustry] = useState('')
 	const [filterCountry, setFilterCountry] = useState('')
 	const [filterTags, setFilterTags] = useState('')
 	// Set once a selector fan-out returns needing confirmation, so the footer
-	// swaps to a cost prompt instead of starting straight away.
+	// swaps to a cost prompt instead of starting straight away. `requestKey` is
+	// the form as it stood when the price was quoted: a quote only answers for
+	// the question it was asked, so editing anything below puts the prompt away
+	// rather than letting one run be approved and a bigger one started.
 	const [pendingConfirm, setPendingConfirm] = useState<{
 		readonly subjectCount: number
 		readonly estimatedCostCents: number
+		readonly requestKey: string
 	} | null>(null)
 	const templatesResult = useAtomValue(instructionTemplatesAtom)
 	const templateOptions = useMemo<ReadonlyArray<StackOption>>(
 		() =>
 			AsyncResult.isSuccess(templatesResult)
-				? narrowOptions(templatesResult.value)
+				? narrowTemplates(templatesResult.value)
 				: [],
 		[templatesResult],
 	)
@@ -166,8 +172,12 @@ export function ResearchDialog({
 		]
 	}, [stacksResult, t])
 
+	// Emptied on the way out rather than on the way in. This component outlives
+	// the popup, so whatever was typed last time is still in hand when it opens
+	// again — and clearing it then happens a frame too late to stop the old
+	// question being painted first.
 	useEffect(() => {
-		if (!open) return
+		if (open) return
 		setQuery('')
 		setSchema(defaultSchema(isDiscovery))
 		setSubmitting(false)
@@ -185,46 +195,95 @@ export function ResearchDialog({
 
 	const canSubmit = query.trim().length > 0 && !submitting
 
-	const buildContext = useCallback((): Record<string, unknown> | undefined => {
-		const context: Record<string, unknown> = {}
-		if (companyId !== undefined) {
-			context['subjects'] = [{ table: 'companies', id: companyId }]
+	const languageItems = useMemo<ReadonlyArray<SelectItem<SourcesLanguage>>>(
+		() => [
+			{ value: '', label: t`Any` },
+			{ value: 'ca', label: t`Catalan` },
+			{ value: 'es', label: t`Spanish` },
+			{ value: 'en', label: t`English` },
+		],
+		[t],
+	)
+
+	const stageItems = useMemo<ReadonlyArray<SelectItem<string>>>(
+		() => [
+			{ value: '', label: t`Find net-new` },
+			...STATUS_ORDER.map(stage => ({
+				value: stage,
+				label: i18n._(statusLabels[stage]),
+			})),
+		],
+		[i18n, t],
+	)
+
+	const context = useMemo(
+		() =>
+			buildResearchContext({
+				companyId,
+				location,
+				language,
+				filterStatus,
+				filterIndustry,
+				filterCountry,
+				filterTags,
+			}),
+		[
+			companyId,
+			filterStatus,
+			filterIndustry,
+			filterCountry,
+			filterTags,
+			language,
+			location,
+		],
+	)
+
+	const requestKey = useMemo(
+		() => researchRequestKey({ query, schema, stackId, templateIds, context }),
+		[query, schema, stackId, templateIds, context],
+	)
+
+	// The prompt stands only while the form still asks what was priced. Anything
+	// edited after the quote arrives leaves this null, so the ordinary Start
+	// button comes back and the next run is quoted afresh.
+	const confirming =
+		pendingConfirm !== null && pendingConfirm.requestKey === requestKey
+			? pendingConfirm
+			: null
+
+	// The button that asked for a price is gone once the prompt takes its place,
+	// and the prompt's own buttons go when it is put away, so a keyboard reader
+	// would be left standing nowhere at both ends. Focus follows the prompt in
+	// and comes back to the button that raised it on the way out.
+	//
+	// This watches the answer itself, not whether the prompt happens to be
+	// showing: editing a field and typing it back would put the prompt up again,
+	// and pulling the caret out of the field at that moment is the last thing
+	// anybody wants.
+	const confirmPanelRef = useRef<HTMLDivElement>(null)
+	const startButtonRef = useRef<HTMLButtonElement>(null)
+	const promptWasUpRef = useRef(false)
+	useEffect(() => {
+		// A dialog on its way out returns focus wherever it was opened from, so
+		// there is nothing to put right here.
+		if (!open) {
+			promptWasUpRef.current = false
+			return
 		}
-		if (isDiscovery) {
-			const filter: Record<string, unknown> = {}
-			if (filterStatus) filter['status'] = filterStatus
-			if (filterIndustry.trim()) filter['industry'] = filterIndustry.trim()
-			if (filterCountry.trim()) filter['country'] = filterCountry.trim()
-			const tags = filterTags
-				.split(',')
-				.map(s => s.trim())
-				.filter(Boolean)
-			if (tags.length > 0) filter['tags'] = tags
-			if (Object.keys(filter).length > 0) {
-				context['selector'] = { table: 'companies', filter }
-			}
-			const hints: Record<string, unknown> = {}
-			if (language) hints['language'] = language
-			if (location.trim()) hints['location'] = location.trim()
-			if (Object.keys(hints).length > 0) context['hints'] = hints
+		if (pendingConfirm !== null) {
+			promptWasUpRef.current = true
+			confirmPanelRef.current?.focus()
+			return
 		}
-		return Object.keys(context).length > 0 ? context : undefined
-	}, [
-		companyId,
-		isDiscovery,
-		filterStatus,
-		filterIndustry,
-		filterCountry,
-		filterTags,
-		language,
-		location,
-	])
+		if (!promptWasUpRef.current) return
+		promptWasUpRef.current = false
+		startButtonRef.current?.focus()
+	}, [open, pendingConfirm])
 
 	const submit = useCallback(
 		async (confirm: boolean) => {
 			setSubmitting(true)
 			setErrorMessage(null)
-			const context = buildContext()
 			const exit = await createResearch({
 				payload: {
 					query: query.trim(),
@@ -237,8 +296,11 @@ export function ResearchDialog({
 			})
 
 			if (exit._tag === 'Success') {
-				const value = exit.value as Record<string, unknown> | null
-				const newId = typeof value?.['id'] === 'string' ? value['id'] : null
+				const reply =
+					typeof exit.value === 'object' && exit.value !== null
+						? (exit.value as Record<string, unknown>)
+						: null
+				const newId = typeof reply?.['id'] === 'string' ? reply['id'] : null
 				// A reply with no run to open means nothing was queued. Closing here
 				// would leave the reader believing their research had started.
 				if (newId === null) {
@@ -267,10 +329,14 @@ export function ResearchDialog({
 						typeof confirmErr['estimatedCostCents'] === 'number'
 							? confirmErr['estimatedCostCents']
 							: 0,
+					requestKey,
 				})
 				setSubmitting(false)
 				return
 			}
+			// Whatever went wrong, the quote on screen is spent: leaving it up would
+			// offer a price the server has just declined to honour.
+			setPendingConfirm(null)
 			const budgetErr = taggedFailure(exit.cause, 'InsufficientBudget')
 			// A saved set of instructions that has since been deleted, or belongs to
 			// someone else, is refused outright rather than quietly swapped.
@@ -285,12 +351,13 @@ export function ResearchDialog({
 			setSubmitting(false)
 		},
 		[
-			buildContext,
+			context,
 			createResearch,
 			query,
 			schema,
 			stackId,
 			templateIds,
+			requestKey,
 			onCreated,
 			onOpenChange,
 			t,
@@ -427,37 +494,25 @@ export function ResearchDialog({
 										<ScopeLabel htmlFor='discovery-language'>
 											<Trans>Sources language</Trans>
 										</ScopeLabel>
-										<SelectInput
+										<ScopeSelect
 											id='discovery-language'
-											data-testid='discovery-language'
+											testId='discovery-language'
 											value={language}
-											onChange={e =>
-												setLanguage(e.target.value as '' | 'ca' | 'es' | 'en')
-											}
-										>
-											<option value=''>{t`Any`}</option>
-											<option value='ca'>{t`Catalan`}</option>
-											<option value='es'>{t`Spanish`}</option>
-											<option value='en'>{t`English`}</option>
-										</SelectInput>
+											onValueChange={setLanguage}
+											items={languageItems}
+										/>
 									</ScopeField>
 									<ScopeField>
 										<ScopeLabel htmlFor='discovery-status'>
 											<Trans>Across companies in stage</Trans>
 										</ScopeLabel>
-										<SelectInput
+										<ScopeSelect
 											id='discovery-status'
-											data-testid='discovery-status'
+											testId='discovery-status'
 											value={filterStatus}
-											onChange={e => setFilterStatus(e.target.value)}
-										>
-											<option value=''>{t`Find net-new`}</option>
-											{STATUS_ORDER.map(stage => (
-												<option key={stage} value={stage}>
-													{i18n._(statusLabels[stage])}
-												</option>
-											))}
-										</SelectInput>
+											onValueChange={setFilterStatus}
+											items={stageItems}
+										/>
 									</ScopeField>
 									<ScopeField>
 										<ScopeLabel htmlFor='discovery-industry'>
@@ -522,27 +577,7 @@ export function ResearchDialog({
 										<ChevronsUpDown size={12} aria-hidden />
 									</PriSelect.Icon>
 								</PriSelect.Trigger>
-								<PriSelect.Portal>
-									<PriSelect.Positioner
-										alignItemWithTrigger={false}
-										sideOffset={6}
-									>
-										<PriSelect.Popup>
-											<PriSelect.List>
-												{stackItems.map(item => (
-													<PriSelect.Item key={item.value} value={item.value}>
-														<PriSelect.ItemIndicator>
-															<Check size={12} aria-hidden />
-														</PriSelect.ItemIndicator>
-														<PriSelect.ItemText>
-															{item.label}
-														</PriSelect.ItemText>
-													</PriSelect.Item>
-												))}
-											</PriSelect.List>
-										</PriSelect.Popup>
-									</PriSelect.Positioner>
-								</PriSelect.Portal>
+								<SelectOptions items={stackItems} />
 							</PriSelect.Root>
 						</Field>
 
@@ -578,23 +613,41 @@ export function ResearchDialog({
 							<ErrorBanner role='alert'>{errorMessage}</ErrorBanner>
 						) : null}
 
-						{pendingConfirm !== null ? (
-							<ConfirmPanel role='alert' data-testid='research-confirm'>
-								<ConfirmText>
+						{confirming !== null ? (
+							<ConfirmPanel
+								ref={confirmPanelRef}
+								tabIndex={-1}
+								// Deliberately not a dialog role: nothing here traps focus or
+								// makes the rest inert, so claiming one would announce a modal
+								// the reader can tab straight out of while the real dialog is
+								// still open. Focus lands here and the price is named twice —
+								// once as this group's name, once on the button that spends
+								// the money — so it is heard either way round.
+								role='group'
+								aria-labelledby='research-confirm-text'
+								data-testid='research-confirm'
+							>
+								<ConfirmText id='research-confirm-text'>
 									<Trans>
-										This runs research on {pendingConfirm.subjectCount}{' '}
-										companies, up to about{' '}
-										{formatMoneyCents(pendingConfirm.estimatedCostCents, {
+										This runs research on{' '}
+										<Plural
+											value={confirming.subjectCount}
+											one='# company'
+											other='# companies'
+										/>
+										, up to about{' '}
+										{formatMoneyCents(confirming.estimatedCostCents, {
 											locale: i18n.locale,
 										})}{' '}
 										in paid data. Start the batch?
 									</Trans>
 								</ConfirmText>
-								<Footer>
+								<ConfirmActions>
 									<PriButton
 										type='button'
 										$variant='filled'
 										data-testid='research-confirm-start'
+										aria-describedby='research-confirm-text'
 										disabled={submitting}
 										onClick={() => {
 											void submit(true)
@@ -604,7 +657,7 @@ export function ResearchDialog({
 											<Trans>Starting…</Trans>
 										) : (
 											<Plural
-												value={pendingConfirm.subjectCount}
+												value={confirming.subjectCount}
 												one='Start # run'
 												other='Start # runs'
 											/>
@@ -619,11 +672,12 @@ export function ResearchDialog({
 									>
 										<Trans>Back</Trans>
 									</PriButton>
-								</Footer>
+								</ConfirmActions>
 							</ConfirmPanel>
 						) : (
 							<Footer>
 								<PriButton
+									ref={startButtonRef}
 									type='submit'
 									$variant='filled'
 									data-testid='research-dialog-submit'
@@ -658,23 +712,74 @@ export function ResearchDialog({
 	)
 }
 
-function narrowOptions(value: unknown): ReadonlyArray<StackOption> {
-	if (!Array.isArray(value)) return []
-	const out: Array<StackOption> = []
-	for (const row of value) {
-		if (!row || typeof row !== 'object') continue
-		const r = row as Record<string, unknown>
-		const id = typeof r['id'] === 'string' ? r['id'] : null
-		const name = typeof r['name'] === 'string' ? r['name'] : null
-		if (id === null || name === null) continue
-		out.push({
-			id,
-			name,
-			ownerUserId:
-				typeof r['ownerUserId'] === 'string' ? r['ownerUserId'] : null,
-		})
-	}
-	return out
+// One option in a dropdown: the value that gets stored, and what to call it.
+type SelectItem<T extends string> = {
+	readonly value: T
+	readonly label: string
+}
+
+// The list half of a dropdown, shared by every selector in this dialog so the
+// options look and behave the same wherever they are opened from.
+function SelectOptions<T extends string>({
+	items,
+}: {
+	readonly items: ReadonlyArray<SelectItem<T>>
+}) {
+	return (
+		<PriSelect.Portal>
+			<PriSelect.Positioner alignItemWithTrigger={false} sideOffset={6}>
+				<PriSelect.Popup>
+					<PriSelect.List>
+						{items.map(item => (
+							<PriSelect.Item key={item.value} value={item.value}>
+								<PriSelect.ItemIndicator>
+									<Check size={12} aria-hidden />
+								</PriSelect.ItemIndicator>
+								<PriSelect.ItemText>{item.label}</PriSelect.ItemText>
+							</PriSelect.Item>
+						))}
+					</PriSelect.List>
+				</PriSelect.Popup>
+			</PriSelect.Positioner>
+		</PriSelect.Portal>
+	)
+}
+
+// A dropdown in the scope grid. The trigger is a button, which a `<label for>`
+// may point at, so each field keeps the same label markup as the text fields
+// around it. What comes back is matched against the options rather than trusted,
+// so the caller is handed one of its own values and needs no cast.
+function ScopeSelect<T extends string>({
+	id,
+	testId,
+	value,
+	onValueChange,
+	items,
+}: {
+	readonly id: string
+	readonly testId: string
+	readonly value: T
+	readonly onValueChange: (next: T) => void
+	readonly items: ReadonlyArray<SelectItem<T>>
+}) {
+	return (
+		<PriSelect.Root
+			items={items}
+			value={value}
+			onValueChange={next => {
+				const picked = items.find(item => item.value === next)
+				if (picked) onValueChange(picked.value)
+			}}
+		>
+			<ScopeTrigger id={id} data-testid={testId}>
+				<ScopeValue />
+				<PriSelect.Icon>
+					<ChevronsUpDown size={12} aria-hidden />
+				</PriSelect.Icon>
+			</ScopeTrigger>
+			<SelectOptions items={items} />
+		</PriSelect.Root>
+	)
 }
 
 const HelpText = styled.p`
@@ -715,6 +820,12 @@ const CloseButton = styled.button`
 	width: 1.75rem;
 	height: 1.75rem;
 	padding: 0;
+
+	/* Bigger tap target on touch, matching the other sheet dialogs. */
+	@media (pointer: coarse) {
+		width: 2.75rem;
+		height: 2.75rem;
+	}
 	border: none;
 	border-radius: var(--shape-2xs);
 	background: transparent;
@@ -731,6 +842,14 @@ const Form = styled.form`
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-md);
+
+	/* The phone sheet is a fixed height and this form is far taller than it, so
+	 * the fields scroll here and the actions below them stay put. */
+	@media (max-width: 40rem) {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
 `
 
 const Field = styled.div`
@@ -747,14 +866,19 @@ const Label = styled.label`
 	color: var(--color-on-surface-variant);
 `
 
+// Columns follow the room there is: fields sit side by side wherever two fit at
+// a readable width and drop to one where they don't, with no screen width named
+// anywhere. `min()` keeps the single column from overflowing a very narrow
+// phone, where 13rem is already wider than the dialog.
+const FIELD_MIN_WIDTH = '13rem'
+
 const ScopeGrid = styled.div`
 	display: grid;
-	grid-template-columns: 1fr;
+	grid-template-columns: repeat(
+		auto-fit,
+		minmax(min(${FIELD_MIN_WIDTH}, 100%), 1fr)
+	);
 	gap: var(--space-sm);
-
-	@media (min-width: 32rem) {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
 `
 
 const ScopeField = styled.div`
@@ -769,19 +893,27 @@ const ScopeLabel = styled.label`
 	color: var(--color-on-surface-variant);
 `
 
-const SelectInput = styled.select`
+// Sized like the text fields it sits beside in the grid, rather than like the
+// compact metal selectors elsewhere, so a row of scope fields lines up.
+const ScopeTrigger = styled(PriSelect.Trigger)`
+	justify-content: space-between;
+	width: 100%;
+	min-width: 0;
+	padding: var(--space-xs) var(--space-sm);
 	font-family: var(--font-body);
-	font-size: var(--typescale-body-medium-size);
-	padding: var(--space-2xs) var(--space-xs);
-	border-radius: var(--shape-2xs);
-	border: 1px solid color-mix(in oklab, var(--color-on-surface) 24%, transparent);
-	background: var(--color-surface);
-	color: var(--color-on-surface);
+	font-size: var(--typescale-body-large-size);
+	font-weight: var(--font-weight-regular);
+	letter-spacing: var(--typescale-body-large-tracking);
+	text-transform: none;
+`
 
-	&:focus-visible {
-		outline: none;
-		box-shadow: var(--glow-active);
-	}
+// A label longer than the field trails off rather than shouldering the chevron
+// out of the trigger.
+const ScopeValue = styled(PriSelect.Value)`
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 `
 
 const ErrorBanner = styled.div`
@@ -801,6 +933,27 @@ const ConfirmPanel = styled.div`
 	border: 1px solid var(--color-primary);
 	border-radius: var(--shape-2xs);
 	background: color-mix(in oklab, var(--color-primary) 8%, transparent);
+
+	/* Takes focus when it appears, so it says where the reader has been sent. */
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+
+	/* Held at the bottom of the phone sheet the way the ordinary actions are, so
+	 * the decision that spends money does not scroll away while the fields above
+	 * it are being checked over. The tint goes opaque here — left translucent it
+	 * would have the scrolling text sliding through it. */
+	@media (max-width: 40rem) {
+		position: sticky;
+		bottom: 0;
+		background: color-mix(
+			in oklab,
+			var(--color-primary) 8%,
+			var(--color-paper-aged)
+		);
+		box-shadow: 0 -0.75rem 0.75rem -0.5rem var(--shadow-color-deep);
+	}
 `
 
 const ConfirmText = styled.p`
@@ -810,20 +963,53 @@ const ConfirmText = styled.p`
 	margin: 0;
 `
 
-const Footer = styled.div`
+// Side by side on a desk, full width and stacked within thumb reach on a phone,
+// the button that acts on top.
+const actionRow = css`
 	display: flex;
 	gap: var(--space-sm);
 	justify-content: flex-end;
+
+	@media (max-width: 40rem) {
+		flex-direction: column;
+		align-items: stretch;
+		gap: var(--space-2xs);
+
+		& > * {
+			width: 100%;
+		}
+	}
+`
+
+// The form's own actions, held at the bottom of the phone sheet while the
+// fields scroll behind them. The paper fill and the shadow above it keep that
+// scrolling text readable as it passes underneath.
+const Footer = styled.div`
+	${actionRow}
+
+	@media (max-width: 40rem) {
+		position: sticky;
+		bottom: 0;
+		padding-top: var(--space-2xs);
+		background: var(--color-paper-aged);
+		box-shadow: 0 -0.75rem 0.75rem -0.5rem var(--shadow-color-deep);
+	}
+`
+
+// The cost prompt's own actions. Stacked like the form's, but never held to the
+// bottom: the prompt is short and already in view, and a paper fill here would
+// cut a pale slab across the prompt's tint.
+const ConfirmActions = styled.div`
+	${actionRow}
 `
 
 const SchemaGrid = styled(RadioGroup)`
 	display: grid;
-	grid-template-columns: 1fr;
+	grid-template-columns: repeat(
+		auto-fit,
+		minmax(min(${FIELD_MIN_WIDTH}, 100%), 1fr)
+	);
 	gap: var(--space-2xs);
-
-	@media (min-width: 32rem) {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
 `
 
 // `<label>` so a click anywhere on the card toggles the embedded

--- a/apps/internal/src/components/research/research-request.test.ts
+++ b/apps/internal/src/components/research/research-request.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	buildResearchContext,
+	type ResearchRequest,
+	type ResearchScope,
+	researchRequestKey,
+} from './research-request'
+
+const emptyScope: ResearchScope = {
+	location: '',
+	language: '',
+	filterStatus: '',
+	filterIndustry: '',
+	filterCountry: '',
+	filterTags: '',
+}
+
+const request = (over: Partial<ResearchRequest> = {}): ResearchRequest => ({
+	query: 'bakeries in Barcelona',
+	schema: 'prospect_scan_v1',
+	stackId: '',
+	templateIds: [],
+	context: undefined,
+	...over,
+})
+
+describe('buildResearchContext', () => {
+	describe('when the run is pinned to a company', () => {
+		it('should name that company as the subject', () => {
+			// GIVEN a run pinned to one company
+			// THEN the context names it and nothing else
+			expect(
+				buildResearchContext({ ...emptyScope, companyId: 'company-1' }),
+			).toEqual({ subjects: [{ table: 'companies', id: 'company-1' }] })
+		})
+
+		it('should fall back to a discovery run when the id is empty', () => {
+			// GIVEN a company id that is present but blank, which names nobody
+			// THEN it is read as no subject at all, and the filters decide the scope
+			expect(
+				buildResearchContext({
+					...emptyScope,
+					companyId: '',
+					filterStatus: 'lead',
+				}),
+			).toEqual({
+				selector: { table: 'companies', filter: { status: 'lead' } },
+			})
+		})
+
+		it('should ignore discovery scope fields', () => {
+			// GIVEN a pinned run that also carries stale discovery filters
+			// WHEN the context is built
+			// THEN the filters are left out — the subject decides the scope
+			expect(
+				buildResearchContext({
+					...emptyScope,
+					companyId: 'company-1',
+					filterStatus: 'lead',
+					location: 'Catalonia',
+				}),
+			).toEqual({ subjects: [{ table: 'companies', id: 'company-1' }] })
+		})
+	})
+
+	describe('when the run is a discovery run', () => {
+		it('should be undefined with nothing filled in', () => {
+			// GIVEN no scope at all
+			// THEN there is no context to send
+			expect(buildResearchContext(emptyScope)).toBeUndefined()
+		})
+
+		it('should carry a selector for the filters that were filled in', () => {
+			// GIVEN a stage and an industry
+			// THEN both land under the selector filter
+			expect(
+				buildResearchContext({
+					...emptyScope,
+					filterStatus: 'lead',
+					filterIndustry: 'hospitality',
+				}),
+			).toEqual({
+				selector: {
+					table: 'companies',
+					filter: { status: 'lead', industry: 'hospitality' },
+				},
+			})
+		})
+
+		it('should carry hints for location and language', () => {
+			// GIVEN steering hints but no filters
+			// THEN only the hints section is present
+			expect(
+				buildResearchContext({
+					...emptyScope,
+					location: 'Catalonia',
+					language: 'ca',
+				}),
+			).toEqual({ hints: { language: 'ca', location: 'Catalonia' } })
+		})
+
+		it('should split tags on commas and drop the blanks', () => {
+			// GIVEN a tag list with padding and empty entries
+			// THEN each tag is trimmed and the empties disappear
+			expect(
+				buildResearchContext({ ...emptyScope, filterTags: ' vip , , warm ,' }),
+			).toEqual({
+				selector: { table: 'companies', filter: { tags: ['vip', 'warm'] } },
+			})
+		})
+
+		it('should leave out a tag list that is only separators', () => {
+			// GIVEN a tag field holding nothing but commas and spaces
+			// THEN no filter survives, so there is no context
+			expect(
+				buildResearchContext({ ...emptyScope, filterTags: ' , , ' }),
+			).toBeUndefined()
+		})
+
+		it('should trim whitespace around free-text filters', () => {
+			// GIVEN padded free text
+			// THEN the padding is not sent
+			expect(
+				buildResearchContext({
+					...emptyScope,
+					filterIndustry: '  hospitality  ',
+					filterCountry: ' ES ',
+				}),
+			).toEqual({
+				selector: {
+					table: 'companies',
+					filter: { industry: 'hospitality', country: 'ES' },
+				},
+			})
+		})
+
+		it('should ignore free-text filters that are only whitespace', () => {
+			// GIVEN fields that look filled but hold only spaces
+			// THEN they count as empty
+			expect(
+				buildResearchContext({
+					...emptyScope,
+					filterIndustry: '   ',
+					location: '   ',
+				}),
+			).toBeUndefined()
+		})
+	})
+})
+
+describe('researchRequestKey', () => {
+	describe('when the same scope is built twice', () => {
+		// The key is a JSON string, so it answers to the order the context puts its
+		// keys in. Pinning the exact text here means reordering how the context is
+		// assembled fails this test instead of quietly withdrawing quotes that
+		// are still good.
+		it('should lay the context out in a fixed order', () => {
+			// GIVEN every filter and hint filled in
+			// THEN the context serialises exactly this way, every time
+			expect(
+				JSON.stringify(
+					buildResearchContext({
+						companyId: undefined,
+						location: 'Barcelona',
+						language: 'ca',
+						filterStatus: 'lead',
+						filterIndustry: 'hospitality',
+						filterCountry: 'ES',
+						filterTags: 'vip',
+					}),
+				),
+			).toBe(
+				'{"selector":{"table":"companies","filter":{"status":"lead","industry":"hospitality","country":"ES","tags":["vip"]}},"hints":{"language":"ca","location":"Barcelona"}}',
+			)
+		})
+
+		it('should not depend on the order the scope fields are written in', () => {
+			// GIVEN the same values supplied through differently ordered objects
+			// THEN both price the same request
+			const one = researchRequestKey(
+				request({
+					context: buildResearchContext({
+						...emptyScope,
+						filterStatus: 'lead',
+						filterIndustry: 'hospitality',
+					}),
+				}),
+			)
+			const other = researchRequestKey(
+				request({
+					context: buildResearchContext({
+						filterIndustry: 'hospitality',
+						filterStatus: 'lead',
+						location: '',
+						language: '',
+						filterCountry: '',
+						filterTags: '',
+					}),
+				}),
+			)
+			expect(one).toBe(other)
+		})
+	})
+
+	describe('when nothing about the request has changed', () => {
+		it('should be the same for two identical requests', () => {
+			// GIVEN the same request assembled twice
+			// THEN a quote taken against one still answers for the other
+			expect(researchRequestKey(request())).toBe(researchRequestKey(request()))
+		})
+
+		it('should ignore whitespace around the question', () => {
+			// GIVEN the same question with padding, which is trimmed before sending
+			// THEN the quote still stands
+			expect(
+				researchRequestKey(request({ query: '  bakeries in Barcelona ' })),
+			).toBe(researchRequestKey(request()))
+		})
+	})
+
+	describe('when something that moves the price changes', () => {
+		it('should change when the question changes', () => {
+			// GIVEN a different question
+			// THEN the earlier quote no longer applies
+			expect(
+				researchRequestKey(request({ query: 'butchers in Girona' })),
+			).not.toBe(researchRequestKey(request()))
+		})
+
+		it('should change when the kind of research changes', () => {
+			// GIVEN a different schema, which prices differently
+			expect(
+				researchRequestKey(request({ schema: 'company_enrichment_v1' })),
+			).not.toBe(researchRequestKey(request()))
+		})
+
+		it('should change when the selector widens to more companies', () => {
+			// GIVEN a stage filter covering a different set of companies — the case
+			// that would otherwise start a bigger batch than the one approved
+			const quoted = request({
+				context: buildResearchContext({ ...emptyScope, filterStatus: 'lead' }),
+			})
+			const widened = request({
+				context: buildResearchContext({
+					...emptyScope,
+					filterStatus: 'client',
+				}),
+			})
+			expect(researchRequestKey(widened)).not.toBe(researchRequestKey(quoted))
+		})
+
+		it('should change when a filter is added to an existing selector', () => {
+			// GIVEN the same stage plus an extra industry filter
+			const quoted = request({
+				context: buildResearchContext({ ...emptyScope, filterStatus: 'lead' }),
+			})
+			const narrowed = request({
+				context: buildResearchContext({
+					...emptyScope,
+					filterStatus: 'lead',
+					filterIndustry: 'hospitality',
+				}),
+			})
+			expect(researchRequestKey(narrowed)).not.toBe(researchRequestKey(quoted))
+		})
+
+		it('should change when the run is pinned to a different company', () => {
+			// GIVEN a different subject
+			const first = request({
+				context: buildResearchContext({ ...emptyScope, companyId: 'a' }),
+			})
+			const second = request({
+				context: buildResearchContext({ ...emptyScope, companyId: 'b' }),
+			})
+			expect(researchRequestKey(second)).not.toBe(researchRequestKey(first))
+		})
+
+		it('should change when the instructions stack changes', () => {
+			// GIVEN a different saved stack, which changes what the run does
+			expect(researchRequestKey(request({ stackId: 'stack-9' }))).not.toBe(
+				researchRequestKey(request()),
+			)
+		})
+
+		it('should change when a template is added', () => {
+			// GIVEN an extra template layered onto the run
+			expect(researchRequestKey(request({ templateIds: ['t1'] }))).not.toBe(
+				researchRequestKey(request()),
+			)
+		})
+
+		it('should change when templates are reordered', () => {
+			// GIVEN the same templates in a different order — order is the order the
+			// instructions are layered in, so it is part of the request
+			expect(
+				researchRequestKey(request({ templateIds: ['t2', 't1'] })),
+			).not.toBe(researchRequestKey(request({ templateIds: ['t1', 't2'] })))
+		})
+
+		it('should tell a scoped run apart from an unscoped one', () => {
+			// GIVEN a request that gained a selector where it had none
+			const unscoped = request({ context: undefined })
+			const scoped = request({
+				context: buildResearchContext({ ...emptyScope, filterStatus: 'lead' }),
+			})
+			expect(researchRequestKey(scoped)).not.toBe(researchRequestKey(unscoped))
+		})
+	})
+
+	describe('when the same scope is reached by a different route', () => {
+		it('should match a scope typed with padding', () => {
+			// GIVEN one person typing a padded industry and another typing it clean,
+			// THEN both are the same request, because both are sent the same way
+			const padded = request({
+				context: buildResearchContext({
+					...emptyScope,
+					filterIndustry: '  hospitality ',
+				}),
+			})
+			const clean = request({
+				context: buildResearchContext({
+					...emptyScope,
+					filterIndustry: 'hospitality',
+				}),
+			})
+			expect(researchRequestKey(padded)).toBe(researchRequestKey(clean))
+		})
+
+		it('should match when a filter is cleared back to empty', () => {
+			// GIVEN a filter typed and then removed again — the case where a
+			// withdrawn quote should come back rather than stay withdrawn
+			const before = request({ context: buildResearchContext(emptyScope) })
+			const after = request({
+				context: buildResearchContext({ ...emptyScope, filterIndustry: '' }),
+			})
+			expect(researchRequestKey(after)).toBe(researchRequestKey(before))
+		})
+	})
+})

--- a/apps/internal/src/components/research/research-request.ts
+++ b/apps/internal/src/components/research/research-request.ts
@@ -1,0 +1,91 @@
+/**
+ * The shape of a research request as the dialog assembles it, and a comparable
+ * fingerprint of one.
+ *
+ * The server prices a fan-out before it starts, answers with a quote, and then
+ * trusts a later `confirm: true` without re-checking what it quoted. So the one
+ * thing standing between an approved small run and a much larger one starting is
+ * the caller noticing that the request changed underneath the quote. That check
+ * lives here, away from the dialog, so it can be tested.
+ */
+
+/** Everything the discovery scope fields contribute to a request. */
+export type ResearchScope = {
+	// Present for a run pinned to one company; absent for a discovery run.
+	readonly companyId?: string | undefined
+	readonly location: string
+	readonly language: string
+	readonly filterStatus: string
+	readonly filterIndustry: string
+	readonly filterCountry: string
+	readonly filterTags: string
+}
+
+/** A request as it goes to the server, minus the confirm flag. */
+export type ResearchRequest = {
+	readonly query: string
+	readonly schema: string
+	readonly stackId: string
+	readonly templateIds: ReadonlyArray<string>
+	readonly context: Record<string, unknown> | undefined
+}
+
+/**
+ * Turn the scope fields into the `context` the create endpoint reads. A company
+ * id pins the run to that company; otherwise the filters pick out companies
+ * already tracked and the hints steer a search for new ones. Blank fields are
+ * left out entirely rather than sent empty, and a section that ends up with
+ * nothing in it is dropped, so two ways of saying "no scope" produce one shape.
+ */
+export function buildResearchContext(
+	scope: ResearchScope,
+): Record<string, unknown> | undefined {
+	const context: Record<string, unknown> = {}
+	// An id that is there but empty names no company, so it is read the same way
+	// a missing one is rather than sent as a lookup that cannot succeed.
+	if (scope.companyId !== undefined && scope.companyId.length > 0) {
+		context['subjects'] = [{ table: 'companies', id: scope.companyId }]
+		return context
+	}
+
+	const filter: Record<string, unknown> = {}
+	if (scope.filterStatus) filter['status'] = scope.filterStatus
+	if (scope.filterIndustry.trim())
+		filter['industry'] = scope.filterIndustry.trim()
+	if (scope.filterCountry.trim()) filter['country'] = scope.filterCountry.trim()
+	const tags = scope.filterTags
+		.split(',')
+		.map(tag => tag.trim())
+		.filter(Boolean)
+	if (tags.length > 0) filter['tags'] = tags
+	if (Object.keys(filter).length > 0) {
+		context['selector'] = { table: 'companies', filter }
+	}
+
+	const hints: Record<string, unknown> = {}
+	if (scope.language) hints['language'] = scope.language
+	if (scope.location.trim()) hints['location'] = scope.location.trim()
+	if (Object.keys(hints).length > 0) context['hints'] = hints
+
+	return Object.keys(context).length > 0 ? context : undefined
+}
+
+/**
+ * A comparable string covering everything the server reads to decide how many
+ * runs a request starts and what they cost. Two requests that would be priced
+ * the same produce the same key; change anything that moves the price and the
+ * key moves with it, which is what withdraws a quote that no longer applies.
+ *
+ * The query is trimmed because that is how it is sent, so trailing whitespace
+ * is not treated as a different question. Template order is kept because it is
+ * the order the instructions are layered in, and so part of the request.
+ */
+export function researchRequestKey(request: ResearchRequest): string {
+	return JSON.stringify([
+		request.query.trim(),
+		request.schema,
+		request.stackId,
+		request.templateIds,
+		request.context ?? null,
+	])
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -95,7 +95,7 @@ msgstr "{0, plural, one {# tasca} other {# tasques}}"
 msgid "{0, plural, one {# template} other {# templates}}"
 msgstr "{0, plural, one {# plantilla} other {# plantilles}}"
 
-#. placeholder {0}: pendingConfirm.subjectCount
+#. placeholder {0}: confirming.subjectCount
 #: src/components/research/research-dialog.tsx
 msgid "{0, plural, one {Start # run} other {Start # runs}}"
 msgstr "{0, plural, one {Inicia # execució} other {Inicia # execucions}}"
@@ -6022,11 +6022,11 @@ msgstr "Aquesta execució no ha trobat cap canvi per revisar."
 msgid "This run has finished."
 msgstr "Aquesta execució ha acabat."
 
-#. placeholder {0}: pendingConfirm.subjectCount
-#. placeholder {1}: formatMoneyCents(pendingConfirm.estimatedCostCents, { locale: i18n.locale, })
+#. placeholder {0}: confirming.subjectCount
+#. placeholder {1}: formatMoneyCents(confirming.estimatedCostCents, { locale: i18n.locale, })
 #: src/components/research/research-dialog.tsx
-msgid "This runs research on {0} companies, up to about {1} in paid data. Start the batch?"
-msgstr "Això farà recerca sobre {0} empreses, fins a uns {1} en dades de pagament. Vols iniciar el lot?"
+msgid "This runs research on {0, plural, one {# company} other {# companies}}, up to about {1} in paid data. Start the batch?"
+msgstr "Això farà recerca sobre {0, plural, one {# empresa} other {# empreses}}, fins a uns {1} en dades de pagament. Vols iniciar el lot?"
 
 #: src/components/instructions/stack-editor.tsx
 msgid "This stack no longer exists."

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -95,7 +95,7 @@ msgstr "{0, plural, one {# task} other {# tasks}}"
 msgid "{0, plural, one {# template} other {# templates}}"
 msgstr "{0, plural, one {# template} other {# templates}}"
 
-#. placeholder {0}: pendingConfirm.subjectCount
+#. placeholder {0}: confirming.subjectCount
 #: src/components/research/research-dialog.tsx
 msgid "{0, plural, one {Start # run} other {Start # runs}}"
 msgstr "{0, plural, one {Start # run} other {Start # runs}}"
@@ -6022,11 +6022,11 @@ msgstr "This run found no changes to review."
 msgid "This run has finished."
 msgstr "This run has finished."
 
-#. placeholder {0}: pendingConfirm.subjectCount
-#. placeholder {1}: formatMoneyCents(pendingConfirm.estimatedCostCents, { locale: i18n.locale, })
+#. placeholder {0}: confirming.subjectCount
+#. placeholder {1}: formatMoneyCents(confirming.estimatedCostCents, { locale: i18n.locale, })
 #: src/components/research/research-dialog.tsx
-msgid "This runs research on {0} companies, up to about {1} in paid data. Start the batch?"
-msgstr "This runs research on {0} companies, up to about {1} in paid data. Start the batch?"
+msgid "This runs research on {0, plural, one {# company} other {# companies}}, up to about {1} in paid data. Start the batch?"
+msgstr "This runs research on {0, plural, one {# company} other {# companies}}, up to about {1} in paid data. Start the batch?"
 
 #: src/components/instructions/stack-editor.tsx
 msgid "This stack no longer exists."

--- a/apps/internal/src/routes/pages/index.tsx
+++ b/apps/internal/src/routes/pages/index.tsx
@@ -2,11 +2,12 @@ import { Trans, useLingui } from '@lingui/react/macro'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { DateTime, Schema } from 'effect'
 import { AsyncResult } from 'effect/unstable/reactivity'
-import { ExternalLink } from 'lucide-react'
+import { ChevronsUpDown, ExternalLink } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import type { PageSummary } from '@batuda/controllers'
+import { PriSelect } from '@batuda/ui/pri'
 
 import {
 	canonicalKey,
@@ -118,6 +119,14 @@ function PagesListPage() {
 	const isFailure = list.isError
 
 	const [statusFilter, setStatusFilter] = useState(search.status ?? '')
+	const statusItems = useMemo(
+		() => [
+			{ value: '', label: t`All statuses` },
+			{ value: 'draft', label: t`Draft` },
+			{ value: 'published', label: t`Published` },
+		],
+		[t],
+	)
 
 	// Keeps the dropdown in step with the address bar, since going back or
 	// forward in the browser changes the status in the URL but not the
@@ -133,11 +142,13 @@ function PagesListPage() {
 					<Trans>Pages</Trans>
 				</Title>
 				<HeaderActions>
-					<StatusFilter
-						data-testid='pages-status-filter'
+					<PriSelect.Root
+						items={statusItems}
 						value={statusFilter}
-						onChange={e => {
-							const nextStatus = e.target.value
+						onValueChange={next => {
+							const picked = statusItems.find(item => item.value === next)
+							if (!picked) return
+							const nextStatus = picked.value
 							setStatusFilter(nextStatus)
 							if (nextStatus) {
 								void navigate({ search: { ...search, status: nextStatus } })
@@ -150,10 +161,17 @@ function PagesListPage() {
 							}
 						}}
 					>
-						<option value=''>{t`All statuses`}</option>
-						<option value='draft'>{t`Draft`}</option>
-						<option value='published'>{t`Published`}</option>
-					</StatusFilter>
+						<StatusFilterTrigger data-testid='pages-status-filter'>
+							<PriSelect.Value />
+							<PriSelect.Icon>
+								<ChevronsUpDown size={12} aria-hidden />
+							</PriSelect.Icon>
+						</StatusFilterTrigger>
+						<PriSelect.Options
+							items={statusItems}
+							optionTestId={value => `pages-status-filter-${value || 'all'}`}
+						/>
+					</PriSelect.Root>
 				</HeaderActions>
 			</Header>
 
@@ -290,15 +308,18 @@ const HeaderActions = styled.div.withConfig({
 	gap: var(--space-sm);
 `
 
-const StatusFilter = styled.select.withConfig({
-	displayName: 'PagesListStatusFilter',
+// Kept at the body size rather than smaller: below 16px an iPhone zooms the
+// page the moment the control is tapped.
+const StatusFilterTrigger = styled(PriSelect.Trigger).withConfig({
+	displayName: 'PagesListStatusFilterTrigger',
 })`
+	gap: var(--space-2xs);
 	padding: var(--space-xs) var(--space-sm);
-	border-radius: 6px;
-	border: 1px solid var(--color-outline);
-	background: var(--color-surface);
-	color: var(--color-on-surface);
-	font-size: var(--typescale-body-medium-size);
+	font-family: var(--font-body);
+	font-size: var(--typescale-body-large-size);
+	font-weight: var(--font-weight-regular);
+	letter-spacing: var(--typescale-body-large-tracking);
+	text-transform: none;
 `
 
 const Table = styled.table.withConfig({ displayName: 'PagesListTable' })`

--- a/apps/internal/tests/e2e/quick-capture.test.ts
+++ b/apps/internal/tests/e2e/quick-capture.test.ts
@@ -45,18 +45,27 @@ test.describe('quick capture', () => {
 			// THEN the dialog is visible
 			await expect(page.getByTestId('quick-capture-form')).toBeVisible()
 
-			// AND when she selects a seeded company and fills subject + summary
+			// AND when she selects a seeded company and fills subject + summary.
+			// The picker is a PriSelect — a button plus a popup that lives elsewhere
+			// on the page — so the option is opened and pressed rather than set the
+			// way a plain select would be.
 			const companySelect = page.getByTestId('quick-capture-company')
 			await expect(companySelect).toBeVisible()
-			const firstCompanyId = await companySelect
-				.locator('option:not([value=""])')
+			await companySelect.click()
+			const firstOption = page
+				.locator('[data-testid^="quick-capture-company-"]')
 				.first()
-				.getAttribute('value')
+			await firstOption.waitFor({ state: 'visible' })
+			const firstCompanyId = (
+				await firstOption.getAttribute('data-testid')
+			)?.replace('quick-capture-company-', '')
 			expect(
 				firstCompanyId,
 				'seed should provide at least one company',
-			).not.toBeNull()
-			await companySelect.selectOption(firstCompanyId as string)
+			).toBeTruthy()
+			await firstOption.hover()
+			await page.keyboard.press('Enter')
+			await firstOption.waitFor({ state: 'hidden' })
 			await page
 				.getByTestId('quick-capture-subject')
 				.fill('e2e — quick capture smoke')

--- a/packages/ui/src/pri/pri-dialog.tsx
+++ b/packages/ui/src/pri/pri-dialog.tsx
@@ -113,6 +113,11 @@ const StyledPopup = styled(Dialog.Popup).withConfig({
 	 * tracks the visual viewport (--pri-dialog-vh, set from window.visualViewport)
 	 * so the on-screen keyboard shrinks the sheet instead of hiding the footer.
 	 * 40rem is the app's phone breakpoint.
+	 *
+	 * The sheet is a fixed height, so anything taller has to scroll somewhere.
+	 * A dialog that wants a footer standing still while the fields move builds
+	 * its own scrolling area inside; this scrolls whatever is left over, so a
+	 * form can never grow past the bottom edge and strand its buttons.
 	 */
 	&[data-mobile='sheet'] {
 		@media (max-width: 40rem) {
@@ -124,7 +129,11 @@ const StyledPopup = styled(Dialog.Popup).withConfig({
 			height: var(--pri-dialog-vh, 100dvh);
 			max-height: var(--pri-dialog-vh, 100dvh);
 			border-radius: 0;
-			overflow: hidden;
+			/* Sideways is still clipped — a stray wide element should not turn the
+			 * whole sheet into something that slides left and right under a thumb. */
+			overflow-x: hidden;
+			overflow-y: auto;
+			overscroll-behavior: contain;
 			padding: calc(env(safe-area-inset-top, 0px) + var(--space-lg))
 				var(--space-lg)
 				calc(env(safe-area-inset-bottom, 0px) + var(--space-md));

--- a/packages/ui/src/pri/pri-select.tsx
+++ b/packages/ui/src/pri/pri-select.tsx
@@ -1,4 +1,5 @@
 import { Select } from '@base-ui/react/select'
+import type { ComponentProps } from 'react'
 import styled from 'styled-components'
 
 /**
@@ -252,8 +253,78 @@ const PriScrollDownArrow = styled(Select.ScrollDownArrow).withConfig({
 	}
 `
 
+// Drawn here rather than pulled from an icon set: this package ships to other
+// projects, and one tick is not worth making every one of them install a
+// library for.
+function CheckMark() {
+	return (
+		<svg
+			width='12'
+			height='12'
+			viewBox='0 0 24 24'
+			fill='none'
+			stroke='currentColor'
+			strokeWidth='2'
+			strokeLinecap='round'
+			strokeLinejoin='round'
+			aria-hidden='true'
+		>
+			<path d='M20 6 9 17l-5-5' />
+		</svg>
+	)
+}
+
+/**
+ * The list half of a dropdown: the portal, the positioning, the popup and the
+ * options inside it, which are the same everywhere and are the part that gets
+ * copied when a new selector is written.
+ *
+ * A selector whose options need their own look keeps composing the pieces by
+ * hand — this covers the ordinary case, not every case.
+ */
+function PriOptions<T extends string>({
+	items,
+	optionTestId,
+	...positioner
+}: ComponentProps<typeof Select.Positioner> & {
+	readonly items: ReadonlyArray<{ readonly value: T; readonly label: string }>
+	// Each option needs its own hook for tests to press, since a popup that
+	// lives outside the trigger cannot be driven the way a plain select is.
+	readonly optionTestId?: (value: T) => string
+}) {
+	return (
+		<Select.Portal>
+			<Select.Positioner
+				alignItemWithTrigger={false}
+				sideOffset={6}
+				{...positioner}
+			>
+				<PriPopup>
+					<Select.List>
+						{items.map(item => (
+							<PriItem
+								key={item.value}
+								value={item.value}
+								{...(optionTestId
+									? { 'data-testid': optionTestId(item.value) }
+									: {})}
+							>
+								<PriItemIndicator>
+									<CheckMark />
+								</PriItemIndicator>
+								<Select.ItemText>{item.label}</Select.ItemText>
+							</PriItem>
+						))}
+					</Select.List>
+				</PriPopup>
+			</Select.Positioner>
+		</Select.Portal>
+	)
+}
+
 export const PriSelect = {
 	Root: Select.Root,
+	Options: PriOptions,
 	Portal: Select.Portal,
 	Backdrop: Select.Backdrop,
 	Positioner: Select.Positioner,


### PR DESCRIPTION
## What

Opening **Find companies** or **Run new research** on a phone gave you a form you could fill in but never submit — the button that starts the run sat below the bottom edge of the screen, with no way to scroll down to it. This makes that dialog work on a phone, and fixes the things I found in the same surface along the way: one that could have spent real money, and one that turned out to affect three other screens too.

The surfaces are the internal CRM web app (`apps/internal`) and the shared design-system pieces it is built on (`packages/ui`).

## Changes

**Touches:** the New Research dialog, the shared full-screen-dialog behaviour it sits inside, and the dropdowns in four screens — the research dialog's scope fields, the quick-capture company picker, the research inbox's confidence filter and the pages status filter.

- **The research dialog can be submitted on a phone.** The form now scrolls inside itself and the actions stay pinned at the bottom within thumb reach. Measured at 375×812 before the change: 1049px of the form — including the Start button — was cut off with no way to reach it.
- **A cost estimate is now tied to the exact request it priced.** Before, the estimate stayed on screen while the filters underneath it stayed editable, and confirming sent whatever the form said *at that moment*. Approving "50 companies, €12.00" and then widening the stage filter would have started a run across every company that matched, at whatever that cost. The server keeps no memory of what it quoted — `confirm: true` simply bypasses the check — so this had to be caught in the browser.
- **Five dropdowns stop zooming the page on an iPhone.** Safari zooms whenever a browser-native dropdown under 16px is tapped, and these were 12px and 14px. They now use the app's own dropdown, which is a button rather than a native control, so there is nothing for Safari to zoom to. Two were in the research dialog; the other three are the quick-capture company picker (worst case — it sits in a full-screen sheet you then cannot pan back from), the research inbox confidence filter and the pages status filter.
- **The confirmation prompt no longer loses the keyboard's place** when it appears or is dismissed, and it names the price both as its own label and on the button that spends the money.

## Impact

- **Nothing changes on desktop.** The centred dialog keeps its width, its two-column card grid and its compact close button; only the phone layout moves.
- **The shared dialog behaviour changes for three other dialogs.** `PriDialog`'s full-screen phone layout was a fixed height that silently cut off anything taller. Three of its four users — this one, the follow-up dialog and the quick-capture dialog — never built their own scrolling area, so their overflow was unreachable too. They now scroll.
- **Four screens get a visibly different dropdown.** Same behaviour and same options, but the app's own control rather than the browser's, so they now match every other selector in the app. Worth a look if you have an opinion on how they sit in each layout — screenshots below.
- **`packages/ui` gains one export and no new dependency.** `PriSelect.Options` bundles the portal, positioning, popup and options that every selector was spelling out by hand. Its tick is drawn inline rather than imported from an icon set, because this package is published and one glyph is not worth making every consumer install a library.
- **No change to which organisation can see what** (row-level security), no database migration, no new environment variables, no change to the shape of anything sent between the server and the app, and no change to the tools the AI assistants call (MCP).
- **One user-facing sentence changed**, so its Catalan translation was rewritten: the prompt used to read "1 companies" and now inflects properly in both languages. Catalan is fully translated (0 missing).

## Review guide

- **Start with `research-request.ts`.** It is new, small, and holds the money-guard: a fingerprint of everything the server reads to decide how many runs a request starts and what they cost. The prompt only stands while the form still matches the fingerprint it was quoted against. `research-request.test.ts` covers it, including one test that pins the exact serialisation — the fingerprint is a JSON string, so it depends on the order the context puts its keys in, and a tidy-up that reordered them would otherwise withdraw good estimates silently.
- **The riskiest line is the `13rem` in `research-dialog.tsx`.** Both card grids use `repeat(auto-fit, minmax(min(13rem, 100%), 1fr))` — that number is how narrow a card may get before its description stops being readable. I first tried naming a screen width instead, and it silently dropped the desktop dialog from two columns to one, so this is deliberately the only number in play. Measured across seven widths: 375/430/480 give one column, 600/900/1280/1600 give two.
- **A decision you might overrule:** the confirmation prompt is `role="group"`, not `role="alertdialog"`. I tried `alertdialog` and backed it out — nothing there traps focus or makes the rest of the dialog inert, so it would announce a modal the reader can tab straight out of while the real dialog is still open. Instead the price is named twice, once as the prompt's own label and once as a description on the Start button, so it is heard whichever of the two a given screen reader announces.
- **A judgement call on scope:** I converted the dropdowns that actually had the zoom bug and left the documents list filter alone — it uses `font: inherit` and the page body is 16px, so it was never affected, and changing it would have been cosmetics in an unrelated route. Separately, fifteen files still compose `PriSelect` by hand; when I read them they genuinely differ (custom popups, custom items, some without a list wrapper, different positioner options), so forcing them through one component would be over-abstraction rather than a cleanup. `PriSelect.Options` covers the ordinary case and nothing more.
- **What I could not verify:** I have not put any of this through a real screen reader. Focus movement I checked directly in a browser; the announcements are reasoned from the ARIA spec, not observed. If you have VoiceOver to hand, the confirmation prompt is the thing worth listening to — it is the moment someone approves a charge.
- **Skip:** the two `.po` catalogue files are produced by the message extractor.

## Screenshots

The research dialog on a phone (375×812) — the form scrolls and the actions stay pinned at the bottom; before this change everything from the fourth card down, Start included, was unreachable.

![pr-phone.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-551/pr-phone.webp)

The same dialog on desktop (1280×800) — unchanged: same width, same two-column card grid, same compact close button.

![pr-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-551/pr-desktop.webp)

The three converted dropdowns, all on a phone — quick capture, the research inbox filter, and the pages status filter.

![pr-quick-capture.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-551/pr-quick-capture.webp)

![pr-inbox.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-551/pr-inbox.webp)

![pr-pages.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-551/pr-pages.webp)

## Tests

- New unit tests for building a research request and for the fingerprint that protects the cost estimate: identical requests match, a widened stage filter does not, template order counts, clearing a filter back to empty restores the original, and a blank company id falls back to a discovery run instead of naming a company that cannot exist.
- The quick-capture end-to-end test was reworked to drive the new picker by opening it and pressing the option, since a popup that lives outside its trigger cannot be set the way a plain dropdown is.

## Verification

- `pnpm check-types`, `pnpm check`, `pnpm test` and `pnpm build` all green.
- Drove the research dialog in a real browser at 375×812, 430×932, 480×900, 600×900, 900×900, 1280×800 and 1600×1000, checking the clipped height, sideways overflow, column count, close-button target size and the dropdown's control type and font size at each.
- Triggered the real cost-confirmation path against seeded companies and confirmed by hand: editing a priced filter withdraws the estimate and brings the ordinary Start button back; undoing that edit restores the estimate without stealing the caret out of the field; pressing Back returns focus to the button that raised the prompt.
- Checked each converted dropdown in the running app at 375×812: all three are now a button at 16px rather than a native control at 12–14px.
- Ran the `@smoke` end-to-end suite (8 of 8 passing), which exercises the converted quick-capture picker.

## Deferred

Nothing — the follow-ups I first listed here were fixes, so they are in the PR. The two judgement calls I made instead of doing (the documents filter, and the fifteen hand-composed selectors) are explained in the review guide, and the screen-reader check is a verification only you can run.
