### PR TITLE
fix(server): log a refused version probe as routine, not a warning

### DIFF
--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -97,8 +97,9 @@ export const recordCall = (request: HttpServerRequest.HttpServerRequest) => {
  *
  * A request naming a revision the library does not know is answered with an
  * empty 400: no body for the client to act on, and a line that says 400 without
- * saying why. This says why in both directions — a warning line naming the
- * revision, and a JSON-RPC error body telling the client what to do instead.
+ * saying why. This says why in both directions — a line naming the revision,
+ * written loudly only where a real call was turned down rather than a discovery
+ * probe, and a JSON-RPC error body telling the client what to do instead.
  *
  * Only a response the route RETURNED is looked at, and the one empty 400 the
  * route returns is that refusal — the RPC layer under it returns none. A request
@@ -119,7 +120,15 @@ export const explainRefusedVersion = <E, R>(
 			response.body._tag !== 'Empty'
 		)
 			return Effect.succeed(response)
-		return Effect.logWarning('MCP protocol version refused').pipe(
+		// A refused discovery probe is the exchange working — that call exists to
+		// ask which revisions a server speaks, so "no" is its ordinary answer. A
+		// refused real call means work the client wanted did not happen, and keeps
+		// the louder level. The method is the caller's own word: fine for choosing
+		// how loudly to write a line, never for deciding what a caller may do. A
+		// client that names no method leaves no way to tell, so it stays a warning.
+		const probing = request.headers[METHOD_HEADER] === 'server/discover'
+		const write = probing ? Effect.logInfo : Effect.logWarning
+		return write('MCP protocol version refused').pipe(
 			Effect.annotateLogs({
 				event: 'mcp.protocol_version.refused',
 				'mcp.protocol_version.named': bounded(named),

--- a/apps/server/src/mcp/protocol-version.test.ts
+++ b/apps/server/src/mcp/protocol-version.test.ts
@@ -237,8 +237,9 @@ describe('the /mcp route meeting a protocol revision it does not know', () => {
 			expect(body.error.message).toContain('2026-07-28')
 		})
 
-		it('should leave a warning naming the refusal', async () => {
-			// GIVEN the same refused request
+		it('should leave an ordinary line when only a probe was refused', async () => {
+			// GIVEN a client probing for a newer era on a settled connection, which
+			//       is how a client finds out which revisions a server speaks
 			const opening = await initialize()
 			const sessionId = opening.headers.get('mcp-session-id') as string
 			lines.length = 0
@@ -251,10 +252,11 @@ describe('the /mcp route meeting a protocol revision it does not know', () => {
 				},
 			)
 
-			// THEN the refusal is a warning, not another routine info line, and it
-			// names the revision that was turned down
+			// THEN the refusal reads as routine: a probe being told "no" is the answer
+			// it went looking for, and warning about it would bury the refusals that
+			// do mean something
 			const refusal = lineFor('mcp.protocol_version.refused')
-			expect(refusal?.level).toBe('Warn')
+			expect(refusal?.level).toBe('Info')
 			expect(refusal?.annotations['mcp.protocol_version.named']).toBe(
 				'2026-07-28',
 			)
@@ -267,6 +269,50 @@ describe('the /mcp route meeting a protocol revision it does not know', () => {
 				'2026-07-28',
 			)
 			expect(request?.annotations['http.status']).toBe(400)
+		})
+
+		it('should warn when the refused call was real work', async () => {
+			// GIVEN a client naming an unknown revision on a call meant to do
+			//       something, rather than on a probe
+			const opening = await initialize()
+			const sessionId = opening.headers.get('mcp-session-id') as string
+			lines.length = 0
+			await post(
+				{
+					jsonrpc: '2.0',
+					id: 6,
+					method: 'tools/call',
+					params: { name: 'ping', arguments: {} },
+				},
+				{
+					'mcp-session-id': sessionId,
+					'mcp-protocol-version': '2026-07-28',
+					'mcp-method': 'tools/call',
+				},
+			)
+
+			// THEN it is worth a warning — the client asked for work and did not get
+			// it, which is a client to fix rather than one looking around
+			expect(lineFor('mcp.protocol_version.refused')?.level).toBe('Warn')
+		})
+
+		it('should warn when the client names no call at all', async () => {
+			// GIVEN a client that sends no method header, as one that does not
+			//       implement the newer routing headers will not
+			const opening = await initialize()
+			const sessionId = opening.headers.get('mcp-session-id') as string
+			lines.length = 0
+			await post(
+				{ jsonrpc: '2.0', id: 7, method: 'tools/call', params: {} },
+				{
+					'mcp-session-id': sessionId,
+					'mcp-protocol-version': '2026-07-28',
+				},
+			)
+
+			// THEN the louder level stands: nothing here says this was a probe, and
+			// guessing that it was would silence the case worth hearing about
+			expect(lineFor('mcp.protocol_version.refused')?.level).toBe('Warn')
 		})
 	})
 


### PR DESCRIPTION
## What

Assistants reach Batuda over MCP — the Model Context Protocol, the shared language Claude and ChatGPT use to call the CRM's tools. When one connects it asks whether the server speaks the newest version of that language. Batuda does not yet, so it says no, and the assistant falls back to a version both sides do speak. Nothing is broken by this: in the last day, every tool call an assistant made succeeded. But each refusal was written to the log as a warning, so a day leaves a couple of hundred warnings describing something working exactly as designed (226 in one 24-hour window, 124 in another — it tracks assistant traffic) — and warnings are what I scan when something is genuinely wrong. This makes the refusal write an ordinary line when it was only that question being asked, and keep the warning for a call that actually wanted work done. It lives in the server app, on the route that serves MCP.

## Changes

**Touches:** the piece of the MCP route that explains a turned-down protocol version, and its tests. The negotiation that lets a brand-new connection settle on a shared version sits right beside it and is untouched.

- A refused version now takes its loudness from what was being refused. A discovery call (`server/discover`), which exists purely to ask what a server speaks, writes an ordinary line; anything else keeps the warning. A request naming no call at all also keeps the warning — there is nothing to judge on, and the louder default is the safer one.
- The name these lines are filed under (`event`) and the revision they report are unchanged, so anything already querying them keeps working. Only the level moves.

## Impact

- **Logging only.** No database change, no new setting the server needs at boot, nothing touching which organisation can see what (row-level security), and no change to who gets through the door (authentication).
- **Only the assistant-facing surface.** The two ways into the CRM — MCP for assistants, the ordinary HTTP API for the web app — share their underlying services, but this sits in the MCP route itself, so the HTTP side is untouched.
- **Anything watching how often warnings appear will see a drop** on the order of a hundred or two a day, varying with assistant traffic. That is the point of the change, but worth knowing before it reads as a signal.
- Production's minimum log level is `Info` (`apps/server/config.production.json`), so the quieter line still ships. Were that ever raised above `Info`, these refusals would vanish entirely rather than merely quieten.

## Review guide

- The whole change is one branch inside `explainRefusedVersion` in `apps/server/src/mcp/http.ts`. Everything else is tests.
- **The judgment call worth overruling me on:** I take the level from the `Mcp-Method` header, which the client sends and could therefore lie about. I think that is fine here — it decides how loudly to write a log line, never what a caller may do — and I left that reasoning in a comment beside it so nobody later reaches for the same header to make an access decision. If you would rather not read a client-supplied value at all, the alternative is dropping every refusal to `Info`, which loses the genuinely-broken-client signal.
- I did not run `/code-review` or `/security-review` here — one branch changed and no authorisation logic moved. Say if you would like either.

## Tests

Three cases in `apps/server/src/mcp/protocol-version.test.ts`, replacing one that asserted the old always-warn behaviour: a refused discovery probe writes an ordinary line, a refused real call warns, and a request naming no call warns.

The existing harness drives a real in-process MCP server over HTTP and reads log levels the way the built-in formatters do, so these assert through the actual round trip rather than by calling the function directly.

I broke the code deliberately to check the tests are not vacuous: forcing always-warn fails the probe case, forcing always-info fails both warn cases. I re-ran both mutations after a later tidy-up, since that tidy-up was then the least-reviewed code on the branch.

## Verification

Ran in the worktree: `biome check` (clean on both files), `check-types` (13/13), `test` (21/21 tasks, 1,037 server tests), `build` (13/13), and `test:integration` (102 files, 791 tests).

Worth flagging: the pre-push run of the integration suite failed 7 tests on its first attempt and passed all 791 when re-run on its own. None of the failures were in MCP code — they read as contention under the concurrent pre-push load rather than anything on this branch.

**Not verified:** I did not drive a real assistant against a running server. Reaching this line live needs a provisioned organisation and a minted key, and the harness already boots a real server through the real middleware. Flagging it because it departs from my usual habit of confirming against the live stack.

## Deferred

A related defect, now filed as #562: the same discovery probe gets two different answers depending on whether a session already exists. With a session it is refused cleanly; without one it gets an HTTP 200 carrying a serialized Effect defect (`code: 0`, an `Unknown request tag` crash with the internal `Cause` shape exposed), and that crash produces no error telemetry at all — it never reaches our logging. I reproduced both paths against the in-process server rather than only reading the code. It is single digits to low tens of requests a day, nothing user-visible breaks, and the fix touches the negotiation path that currently makes every session work, so it deserves its own change with its own verification rather than riding along here.
