### PR TITLE
fix(research): stop an apply writing values nothing could ever read

### DIFF
--- a/apps/server/src/services/channels.ts
+++ b/apps/server/src/services/channels.ts
@@ -105,6 +105,11 @@ export const splitCompanyChannelFields = (
 				const address = entry['value']
 				if (typeof kind !== 'string' || typeof address !== 'string') continue
 				if (kind.trim() === '' || address.trim() === '') continue
+				// An address that could never be one of its kind is stepped over for
+				// the same reason a missing one is: it came out of a model's answer,
+				// and one bad entry should not cost the write. A platform nothing
+				// describes passes, so naming a new one never starts refusing it.
+				if (!channelAddressIsValid(kind.trim(), address.trim())) continue
 				channels.push({ kind: kind.trim(), value: address.trim() })
 			}
 			continue
@@ -115,7 +120,15 @@ export const splitCompanyChannelFields = (
 		}
 		// A blank is a caller clearing the field, which is a removal rather than a
 		// write; nothing to add, and the row it would have written is left alone.
-		if (typeof value === 'string' && value.trim() !== '') {
+		//
+		// An address that could never be one of its kind is left out too. The two
+		// doors that decode a schema have already turned those away, so this only
+		// ever fires on a research run's proposal, where nothing had checked.
+		if (
+			typeof value === 'string' &&
+			value.trim() !== '' &&
+			channelAddressIsValid(key, value.trim())
+		) {
 			channels.push({ kind: key, value: value.trim(), is_primary: true })
 		}
 	}

--- a/apps/server/src/services/research-apply-field-values.integration.test.ts
+++ b/apps/server/src/services/research-apply-field-values.integration.test.ts
@@ -227,3 +227,178 @@ describe("resolveResearchProposedUpdate, on the run's written brief", () => {
 		})
 	})
 })
+
+// A proposal is written by a model. The two doors a person or an assistant come
+// through decode a schema first, so a value that could never be what it claims to
+// be never reaches a row from there. Applying was a third door and checked almost
+// nothing: an empty company name, a map link that was not one, and addresses
+// nobody could ever write to all landed, and the apply reported success.
+describe('resolveResearchProposedUpdate, on values that could never be right', () => {
+	const seedRunWith = async (
+		companyId: string,
+		fields: Record<string, unknown>,
+	) => {
+		const proposalId = randomUUID()
+		const r = await pool.query<{ id: string }>(
+			`INSERT INTO research_runs
+				(organization_id, query, status, created_by, findings)
+			 VALUES ($1, 'q', 'succeeded', 'u1', $2::jsonb) RETURNING id`,
+			[
+				ORG,
+				JSON.stringify({
+					proposed_updates: [
+						{
+							id: proposalId,
+							status: 'pending',
+							subject_table: 'companies',
+							operation: 'update',
+							subject_id: companyId,
+							expected_version: 0,
+							fields,
+							citations: [],
+						},
+					],
+				}),
+			],
+		)
+		return { runId: r.rows[0]!.id, proposalId }
+	}
+
+	const addressesOn = async (subjectId: string) => {
+		const r = await pool.query<{ channel: string; address: string }>(
+			`SELECT channel, address FROM channels WHERE subject_id = $1 ORDER BY channel`,
+			[subjectId],
+		)
+		return r.rows
+	}
+
+	describe('when a run proposes an address nobody could ever write to', () => {
+		it('should leave it out and still write the rest', async () => {
+			// GIVEN a run offering three addresses, none of them possible
+			const companyId = await seedCompany()
+			const { runId, proposalId } = await seedRunWith(companyId, {
+				industry: 'logistics',
+				email: 'not-an-email',
+				phone: 'banana',
+				website: 'nope',
+			})
+
+			// WHEN a person applies it
+			await apply(runId, proposalId)
+
+			// THEN none of them reached the company
+			expect(await addressesOn(companyId)).toEqual([])
+			// AND what was fine still landed, so one bad address did not cost the
+			// run everything else it found
+			expect((await companyRow(companyId))?.industry).toBe('logistics')
+		})
+	})
+
+	describe('when a run proposes addresses that are possible', () => {
+		it('should write them', async () => {
+			// GIVEN a run offering two well-formed addresses
+			const companyId = await seedCompany()
+			const { runId, proposalId } = await seedRunWith(companyId, {
+				email: 'hola@acme.es',
+				website: 'https://acme.es',
+			})
+
+			// WHEN a person applies it
+			await apply(runId, proposalId)
+
+			// THEN both are on the company
+			expect(await addressesOn(companyId)).toEqual([
+				{ channel: 'email', address: 'hola@acme.es' },
+				{ channel: 'website', address: 'https://acme.es' },
+			])
+		})
+	})
+
+	describe('when a run proposes a company with no name', () => {
+		it('should refuse the change rather than blank the name', async () => {
+			// GIVEN a run proposing to empty the company's name
+			const companyId = await seedCompany()
+			const { runId, proposalId } = await seedRunWith(companyId, {
+				name: '   ',
+			})
+
+			// WHEN a person applies it
+			const outcome = await apply(runId, proposalId)
+
+			// THEN it is refused, and said why
+			expect(outcome).toMatchObject({ outcome: 'invalid' })
+			expect((outcome as { reason: string }).reason).toContain('name')
+		})
+	})
+
+	describe('when a run proposes a map link that is not one', () => {
+		it('should refuse the change', async () => {
+			// GIVEN a run offering prose where a map link belongs
+			const companyId = await seedCompany()
+			const { runId, proposalId } = await seedRunWith(companyId, {
+				googleMapsUrl: 'definitely not a url',
+			})
+
+			// WHEN a person applies it
+			const outcome = await apply(runId, proposalId)
+
+			// THEN it is refused, and said why
+			expect(outcome).toMatchObject({ outcome: 'invalid' })
+			expect((outcome as { reason: string }).reason).toContain('googleMapsUrl')
+		})
+	})
+
+	// A discovered person arrives by a different road than a company's own
+	// addresses — a list on the proposal rather than named fields — so the two
+	// need holding to the rule separately.
+	describe('when a run discovers a person reachable at an impossible address', () => {
+		it('should keep the person and leave the address out', async () => {
+			// GIVEN a run proposing somebody real with one made-up mailbox, one
+			// number that is not a number, and one page that is fine
+			const companyId = await seedCompany()
+			const proposalId = randomUUID()
+			const run = await pool.query<{ id: string }>(
+				`INSERT INTO research_runs (organization_id, query, status, created_by, findings)
+				 VALUES ($1, 'q', 'succeeded', 'u1', $2::jsonb) RETURNING id`,
+				[
+					ORG,
+					JSON.stringify({
+						proposed_updates: [
+							{
+								id: proposalId,
+								status: 'pending',
+								operation: 'create',
+								subject_table: 'contacts',
+								citations: [],
+								fields: {
+									name: 'Mar Soler',
+									company_id: companyId,
+									channels: [
+										{ kind: 'email', value: 'not-an-email' },
+										{ kind: 'phone', value: 'banana' },
+										{ kind: 'linkedin', value: 'https://linkedin.com/in/mar' },
+									],
+								},
+							},
+						],
+					}),
+				],
+			)
+
+			// WHEN a person applies it
+			await apply(run.rows[0]!.id, proposalId)
+
+			// THEN the person is on file
+			const people = await pool.query<{ id: string }>(
+				`SELECT id FROM contacts WHERE company_id = $1 AND name = 'Mar Soler'`,
+				[companyId],
+			)
+			expect(people.rows).toHaveLength(1)
+
+			// AND only the address that could be one was kept
+			expect(await addressesOn(people.rows[0]!.id)).toEqual([
+				{ channel: 'linkedin', address: 'https://linkedin.com/in/mar' },
+			])
+		})
+	})
+})

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -7,7 +7,9 @@ import {
 	COMPANY_PRIORITIES,
 	COMPANY_SIZE_RANGES,
 	COMPANY_STATUSES,
+	channelAddressIsValid,
 	isVerificationVerdict,
+	MAPS_ADDRESS_PATTERN,
 } from '@batuda/domain'
 import {
 	canonicalizeUrl,
@@ -249,6 +251,27 @@ type FieldVocabulary = {
 	readonly allowed: ReadonlyArray<string | number>
 }
 
+// Fields whose value has to look like something, as opposed to being one of a
+// handful of allowed words. Held here rather than left to the column, because a
+// proposal is written by a model and the two doors a person or an assistant
+// comes through already turn these away — this is the third door.
+const COMPANY_FIELD_SHAPES: ReadonlyArray<{
+	readonly field: string
+	readonly ok: (value: string) => boolean
+	readonly wanted: string
+}> = [
+	{
+		field: 'name',
+		ok: value => value.trim() !== '',
+		wanted: 'a name with something in it',
+	},
+	{
+		field: 'googleMapsUrl',
+		ok: value => MAPS_ADDRESS_PATTERN.test(value),
+		wanted: 'a Google Maps link',
+	},
+]
+
 const COMPANY_FIELD_VOCABULARIES: ReadonlyArray<FieldVocabulary> = [
 	{ field: 'status', allowed: COMPANY_STATUSES },
 	{ field: 'priority', allowed: COMPANY_PRIORITIES },
@@ -290,6 +313,16 @@ export const checkFieldValues = (
 			continue
 		return `${field} must be one of ${allowed.join(', ')} — got ${JSON.stringify(raw)}`
 	}
+	if (table === 'companies')
+		for (const { field, ok, wanted } of COMPANY_FIELD_SHAPES) {
+			if (!(field in fields)) continue
+			const raw = fields[field]
+			// Left out and cleared are both a caller not setting it, which the
+			// column already answers for; only a value actually offered is checked.
+			if (raw === null || raw === undefined) continue
+			if (typeof raw === 'string' && ok(raw)) continue
+			return `${field} must be ${wanted} — got ${JSON.stringify(raw)}`
+		}
 	return null
 }
 
@@ -347,6 +380,11 @@ const parseChannels = (raw: unknown): ReadonlyArray<ChannelInput> => {
 		const kind = record['kind']
 		const value = record['value']
 		if (typeof kind !== 'string' || typeof value !== 'string') continue
+		// An address nobody could ever write to is stepped over, the same way the
+		// company side does it: a person discovered this way is still worth having,
+		// and a made-up mailbox beside a real name should not cost the whole row.
+		// A platform nothing describes passes, so a new one is never turned away.
+		if (!channelAddressIsValid(kind, value)) continue
 		const verification = record['verification']
 		const confidence = record['confidence']
 		const isPrimary = record['is_primary']

--- a/packages/controllers/src/routes/companies.ts
+++ b/packages/controllers/src/routes/companies.ts
@@ -75,10 +75,15 @@ const CompanySuppressionCleared = Schema.Struct({
 	channels: Schema.Array(Schema.Unknown),
 })
 
-// What a caller may write. The shapes come from the domain so the browser, the
-// agent tools and the research apply path all turn away the same values — and
-// they sit here rather than on `Company`, which has to keep reading rows written
-// before any of this existed.
+// What a caller may write. The shapes come from the domain so the browser and
+// the agent tools turn away the same values — and they sit here rather than on
+// `Company`, which has to keep reading rows written before any of this existed.
+//
+// A research run's apply is a third door and a deliberately looser one: it holds
+// the closed word lists, refuses a name or a map link that could never be one,
+// and steps over an address nobody could ever write to rather than losing
+// everything else the run found. It does not decode these shapes, so do not read
+// this as covering it.
 export const CreateCompanyInput = Schema.Struct({
 	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 	slug: CompanySlug,


### PR DESCRIPTION
Closes #557.

A research proposal is written by a model. The web app and the agent tools both decode a schema before anything reaches a row, so a value that could never be what it claims to be never gets in from there. Applying a proposal was a third door, and it checked almost nothing.

## What was getting through

Seeded one proposal and applied it. Every one of these landed, and the apply reported success:

| field | stored |
| --- | --- |
| `name` | `''` |
| `google_maps_url` | `definitely not a url` |
| email | `not-an-email` |
| phone | `banana` |
| website | `nope` |

The addresses are the part that costs something. `email` is what the mail path sends to, and `website` feeds back into research as the company's own site. The same values are refused at both other doors — `CompanyEmail` **is** `EMAIL_ADDRESS_PATTERN`, the same pattern the channel check looks up. One definition, three doors, and only two of them consulted it.

## What changed

**Addresses are stepped over, not refused.** On both roads they arrive by: a company's own `email`/`phone`/`website`/`instagram`/`linkedin` fields, and a discovered person's `channels` list. One invented mailbox beside a real name should not cost the run the person, or everything else it found about the company. This extends the policy `splitCompanyChannelFields` already documented for social profiles — *"stepped over rather than refusing the whole write, since these come out of a model's free-form answer"* — one step further, from "missing" to "could never be one".

A platform nothing describes still passes, so naming a new one never starts refusing it.

**A name or a map link that could never be one refuses the change.** Those are the row's own columns rather than something added beside it, and a company with no name is a broken suggestion worth telling somebody about. This sits with the closed word lists `checkFieldValues` already held, and refuses the same way.

**The schema comment says what is true.** It had claimed all three doors turn away the same values. It now says the apply path is a third door and a deliberately looser one, and where it stops.

## What this does not do

A run can still *produce* a malformed address; this only stops it landing. Whether the pipeline should refuse to write one into a proposal in the first place is a separate question — `value-guard.ts` checks proposed emails against the pages a run actually read, and I have not established whether it covers shape. Not folded in here.

## Verification

Five cases, and I disabled the fix to confirm four of them go red — the fifth is the guard against over-filtering and passes either way by design.

Ran the whole integration suite rather than the touched specs, because `splitCompanyChannelFields` is on the web app's path too and a regression there would not have shown up locally otherwise.

- 796 integration tests, all 102 files
- 1035 unit tests
- types across 13 packages, lint clean

## A note on how this landed

My first design would have asserted inside `writeChannels`. That would have started refusing social-profile values both other doors accept today, because `CompanySocialProfile` has no pattern check — a regression, found only by going back over my own claims. The second version fixed the company path and I reported it done; a review pass found contact channels going through a different function entirely, which is the larger half. Both are in the diff; neither was in the first attempt.
