### PR TITLE
Size dropdown options to their longest name, not to the button

### DIFF
--- a/apps/internal/src/components/primitives/pri-combobox.tsx
+++ b/apps/internal/src/components/primitives/pri-combobox.tsx
@@ -67,8 +67,10 @@ const PriPopup = styled(Autocomplete.Popup).withConfig({
 })`
 	position: relative;
 	/* Never narrower than the field it belongs to, or a suggestion reads as
-	 * belonging to something else on the page. */
+	 * belonging to something else on the page; never wider than the screen has
+	 * room for, or a long trade name would run off the side of a phone. */
 	min-width: var(--anchor-width);
+	max-width: var(--available-width);
 	max-height: min(18rem, var(--available-height));
 	overflow-y: auto;
 	box-sizing: border-box;
@@ -102,9 +104,9 @@ const PriItem = styled(Autocomplete.Item).withConfig({
 })`
 	position: relative;
 	z-index: 1;
-	display: flex;
-	align-items: center;
-	gap: var(--space-2xs);
+	/* A plain block, not a row of parts: a suggestion is one piece of text, and
+	 * only text sitting directly in a block trails off with an ellipsis. */
+	display: block;
 	padding: var(--space-2xs) var(--space-sm);
 	border-radius: var(--shape-2xs);
 	font-family: var(--font-display);
@@ -117,7 +119,11 @@ const PriItem = styled(Autocomplete.Item).withConfig({
 	cursor: pointer;
 	user-select: none;
 	outline: none;
+	/* One line each, so the list widens to its longest suggestion rather than
+	 * wrapping them all; past the width it may reach, a name trails off. */
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 
 	&[data-highlighted] {
 		background: color-mix(in srgb, var(--color-highlight-amber), transparent);

--- a/apps/internal/tests/e2e/dropdown-options.test.ts
+++ b/apps/internal/tests/e2e/dropdown-options.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test'
+
+import { openAboutSection } from './helpers/about-section'
+import { setActiveOrgBySlug } from './helpers/set-active-org'
+
+// How wide a dropdown opens, and where the names inside it start.
+//
+// A tick is drawn on the chosen option and on no other, so the room for one is
+// kept on every row: the names all start in the same place, and the list grows
+// to its longest option rather than stopping at the button that opened it.
+
+// Reset Alice to Taller before every scenario — sibling files flip her active
+// org, and the trades offered here are whichever org is active.
+test.beforeEach(async ({ page }) => {
+	await page.goto('/', { waitUntil: 'commit' })
+	await setActiveOrgBySlug(page, 'taller')
+})
+
+test.describe('dropdown options', () => {
+	test.describe('when only the chosen option carries a tick', () => {
+		test('should start every name in the same place', async ({ page }) => {
+			// GIVEN the companies list, whose trade filter starts on "All trades"
+			await page.goto('/companies', { waitUntil: 'networkidle' })
+			const trigger = page.getByTestId('companies-filter-industry')
+			await expect(trigger).toBeVisible()
+
+			// WHEN it is opened, so the first option is ticked and the rest are not
+			await trigger.click()
+			// A shut list still holds its options, every one of them at no size at
+			// all — which would read as all the names lining up.
+			await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+			const options = page.locator(
+				'[data-testid^="companies-filter-industry-option-"]',
+			)
+			await expect(options.first()).toBeVisible()
+
+			// THEN every name begins the same distance from the left, tick or no tick
+			const nameStarts = await options.evaluateAll(rows =>
+				rows.map(row => {
+					const name = row.lastElementChild
+					// -1 stands for a row with no name, caught by the check below.
+					return name === null
+						? -1
+						: Math.round(name.getBoundingClientRect().left)
+				}),
+			)
+			expect(nameStarts.length).toBeGreaterThan(1)
+			expect(Math.min(...nameStarts)).toBeGreaterThan(0)
+			expect(new Set(nameStarts).size).toBe(1)
+		})
+	})
+
+	test.describe('when an option is longer than the button that opens it', () => {
+		test('should open wide enough to read the whole name', async ({ page }) => {
+			// A name far longer than the filter button, and its own so parallel
+			// workers and repeated runs never fight over the same row.
+			const trade = `Maquinaria agricola i manteniment de vehicles industrials ${Date.now()}`
+
+			// GIVEN that trade is one the organisation offers — written onto a
+			// company, then taken off again so the seeded data is as it was
+			await page.goto('/companies/cal-pep-fonda', { waitUntil: 'networkidle' })
+			await openAboutSection(page)
+			const field = page.getByTestId('company-industry')
+			await expect(field).toBeVisible()
+			const before = (await field.innerText()).trim()
+			await field.click()
+			await field.fill(trade)
+			await field.press('Enter')
+			await expect(field).toHaveText(trade, { timeout: 10_000 })
+
+			await field.click()
+			await field.fill(before)
+			await field.press('Enter')
+			await expect(field).toHaveText(before, { timeout: 10_000 })
+
+			// WHEN the trade filter on the companies list is opened
+			await page.goto('/companies', { waitUntil: 'networkidle' })
+			const trigger = page.getByTestId('companies-filter-industry')
+			await expect(trigger).toBeVisible()
+			await trigger.click()
+			const option = page.getByRole('option', { name: trade })
+			await expect(option).toBeVisible({ timeout: 10_000 })
+
+			// THEN the whole name is on screen, and the list has grown past the
+			// button rather than cutting the name off at it
+			const measured = await option.evaluate(row => {
+				const popup = row.parentElement
+				return {
+					nameFullyShown: row.scrollWidth <= row.clientWidth,
+					popupWidth: popup === null ? 0 : popup.getBoundingClientRect().width,
+				}
+			})
+			const triggerWidth = await trigger.evaluate(
+				button => button.getBoundingClientRect().width,
+			)
+			expect(measured.nameFullyShown).toBe(true)
+			expect(measured.popupWidth).toBeGreaterThan(triggerWidth)
+
+			// Leave the organisation's trades as they were found.
+			await page.keyboard.press('Escape')
+			await page.goto('/settings/organization/industries', {
+				waitUntil: 'networkidle',
+			})
+			const remove = page.getByRole('button', { name: `Remove ${trade}` })
+			await remove.scrollIntoViewIfNeeded()
+			await remove.click()
+			await expect(
+				page.getByRole('button', { name: `Rename ${trade}` }),
+			).toHaveCount(0, { timeout: 10_000 })
+		})
+	})
+})

--- a/packages/ui/src/pri/pri-menu.tsx
+++ b/packages/ui/src/pri/pri-menu.tsx
@@ -110,14 +110,22 @@ const PriCheckboxItem = styled(Menu.CheckboxItem).withConfig({
 	displayName: 'PriMenuCheckboxItem',
 })`
 	${itemStyles}
-	display: grid;
-	grid-template-columns: 1rem 1fr;
+	position: relative;
+	/* Only the rows that are on carry a tick, so the room for one is kept on
+	 * every row — otherwise the names would not line up. */
+	padding-inline-start: calc(var(--space-sm) + 1rem + var(--space-2xs));
 `
 
 const PriCheckboxItemIndicator = styled(Menu.CheckboxItemIndicator).withConfig({
 	displayName: 'PriMenuCheckboxItemIndicator',
 })`
-	grid-column-start: 1;
+	/* Sits in the room the row keeps for it, outside the row's own layout, so
+	 * only the name decides how wide the menu opens. */
+	position: absolute;
+	inset-inline-start: var(--space-sm);
+	top: 0;
+	bottom: 0;
+	width: 1rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/packages/ui/src/pri/pri-select.tsx
+++ b/packages/ui/src/pri/pri-select.tsx
@@ -68,8 +68,11 @@ const PriPopup = styled(Select.Popup).withConfig({
 	displayName: 'PriSelectPopup',
 })`
 	position: relative;
-	/* Match the popup to at least the trigger width so options never look narrower than the selector. */
+	/* Never narrower than the selector, or the options read as belonging to
+	 * something else; never wider than the screen has room for, or the longest
+	 * option would open off the edge. */
 	min-width: var(--anchor-width);
+	max-width: var(--available-width);
 	box-sizing: border-box;
 	background-color: var(--color-metal);
 	background-image:
@@ -135,11 +138,13 @@ const PriItem = styled(Select.Item).withConfig({
 })`
 	position: relative;
 	z-index: 1;
-	display: grid;
-	grid-template-columns: 1rem 1fr;
+	display: flex;
 	align-items: center;
 	gap: var(--space-2xs);
 	padding: var(--space-2xs) var(--space-sm);
+	/* Only the chosen option carries a tick, so the room for one is kept on
+	 * every row — otherwise the names would not line up. */
+	padding-inline-start: calc(var(--space-sm) + 1rem + var(--space-2xs));
 	border-radius: var(--shape-2xs);
 	font-family: var(--font-display);
 	font-size: var(--typescale-label-medium-size);
@@ -164,10 +169,27 @@ const PriItem = styled(Select.Item).withConfig({
 const PriItemIndicator = styled(Select.ItemIndicator).withConfig({
 	displayName: 'PriSelectItemIndicator',
 })`
+	/* Sits in the room the row keeps for it, outside the row's own layout, so
+	 * only the name decides how wide the list opens. */
+	position: absolute;
+	inset-inline-start: var(--space-sm);
+	top: 0;
+	bottom: 0;
+	width: 1rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	color: var(--color-primary);
+`
+
+const PriItemText = styled(Select.ItemText).withConfig({
+	displayName: 'PriSelectItemText',
+})`
+	/* Once the list has grown as wide as it may, a name too long for it trails
+	 * off; the zero minimum is what lets it shrink inside the row at all. */
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 `
 
 const PriGroupLabel = styled(Select.GroupLabel).withConfig({
@@ -312,7 +334,7 @@ function PriOptions<T extends string>({
 								<PriItemIndicator>
 									<CheckMark />
 								</PriItemIndicator>
-								<Select.ItemText>{item.label}</Select.ItemText>
+								<PriItemText>{item.label}</PriItemText>
 							</PriItem>
 						))}
 					</Select.List>
@@ -341,6 +363,6 @@ export const PriSelect = {
 	GroupLabel: PriGroupLabel,
 	Separator: PriSeparator,
 	Item: PriItem,
-	ItemText: Select.ItemText,
+	ItemText: PriItemText,
 	ItemIndicator: PriItemIndicator,
 }


### PR DESCRIPTION
## What

Every dropdown in the app — the filters on the companies list, the pickers on a company page, the selects in settings — showed most of its options cut off. A trade name like "Instal·lacions elèctriques" ran past the edge of the list and stopped mid-word, and the list never opened any wider than the button that had been pressed, however long its options were. Worse, the names didn't line up: the option you had already chosen sat further right than all the others. This makes those lists readable again — a list now opens as wide as its longest option, and every name reads in full and starts in the same place. It lives in the shared design-system package (`ui`) and the internal web app (`internal`).

## The fix

Touches: the row layout shared by every dropdown option, the tick that marks the chosen one, and the suggestion list under a free-text field — the popup positioning itself, which Base UI handles, is untouched.

- A row used to be laid out as two columns: a fixed 16px column for the tick, and the rest for the name. Base UI only ever draws a tick on the option already chosen, so on every other row there was nothing to put in the first column and the name fell into it — squeezed to the width of a tick, spilling out sideways, and clipped at the edge of the list. The list stayed narrow because, as far as it could measure, its rows were only as wide as a tick.
- Rows now keep a gap at their start on every row, and the tick is painted into that gap without taking part in the row's layout, so the name is the only thing deciding how wide a row is. The toggle menus had the same two-column layout and the same defect, so they get the same treatment.
- Lists are now capped at the width the screen has room for, and a name longer than that trails off with an ellipsis rather than being cut mid-word.
- The suggestion list under a free-text field — the one that offers existing trades on a company page — could open wider than a phone screen and run off the side of it. It is now held to that same width.

## Impact

Presentation only. Nothing touching which organisation can see what (row-level security), no database schema change or migration to run, no new environment variables, no change to the shape of any API response, and nothing touching the AI-tool surface (MCP) or the HTTP one.

Two things worth knowing:

- **A published-package change.** `PriSelect.ItemText` used to be Base UI's own component re-exported unchanged; it is now a styled wrapper around it. `@batuda/ui` goes to npm, so anyone consuming it picks up the new trimming behaviour on that piece.
- **Wide but uniform blast radius.** Every dropdown in `apps/internal` renders through these components, so this touches roughly twenty call sites at once. I scanned all of them: each is the same `[tick, name]` shape, so none is affected differently.

## Review guide

- Start with `packages/ui/src/pri/pri-select.tsx`; the other two files are the same idea applied to the toggle menus and to the suggestion list.
- **The riskiest part** is `PriItem` changing from a grid to a flex row with a reserved start gutter. If a call site ever put something other than a tick and a name inside an option, the absolutely-positioned tick would sit underneath it. I scanned every `PriSelect.Item` and `MetalItem` in the app for unexpected children and found none — but that is the thing to re-check if a new kind of option is added later.
- **A decision you might overrule:** I did *not* add the width cap to `PriMenu.Popup`, even though it's the same family. Its items are fixed strings from the codebase (column names, card actions), not user-entered data of unbounded length, so nothing there can grow past the screen the way a trade name can. Say so and I'll make it uniform.
- `pri-combobox.tsx` turning its option from `flex` to `block` looks arbitrary but isn't: an ellipsis is only ever drawn for text sitting directly inside a block, never for the anonymous box a bare string becomes inside a flex row. Both call sites pass bare text, so the flex row was doing nothing for them anyway.

## Screenshots

Same seeded organisation, same data, before and after. Captured by checking the pre-fix files out into the running dev server, so the "before" is the real previous code rather than simulated styling.

### Desktop — 1440×900

| Before | After |
| --- | --- |
| ![before, desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-565/pr-before-desktop.webp) | ![after, desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-565/pr-after-desktop.webp) |

### Mobile — iPhone 14 Pro

| Before | After |
| --- | --- |
| ![before, mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-565/pr-before-mobile.webp) | ![after, mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-565/pr-after-mobile.webp) |

In the "before" frames the ticked option sits further right than every other name, and the list is no wider than the button behind it. In the "after" frames every name starts in the same place and the list has grown to fit its longest option.

## Tests

`apps/internal/tests/e2e/dropdown-options.test.ts` covers two behaviours: every name starts in the same place whether or not its row carries a tick, and an option longer than the button that opens it makes the list grow wide enough to read it.

Both fail on the code as it was — the first because the names sit at two different offsets rather than one, the second because the option reports more content than it shows — and both pass after. The first also guards against a false pass: a closed list keeps its options in the page at zero size, where every name trivially "lines up", so the test asserts the list is actually open first.

## Verification

- Reproduced the defect in a browser before changing anything, and separately again for the toggle menus and the suggestion list rather than assuming they shared it.
- Pre-commit gates: `check-deps`, `check-types` across all 13 packages, `format-packages`, `i18n-check`, `lint`. Builds for `@batuda/ui` and `@batuda/internal`.
- Full end-to-end suite on this branch: **149 passed, 6 skipped, 0 failed**.
- Confirmed the ellipsis is actually painted rather than just assuming the CSS took, after finding that an earlier measurement of mine only proved the text overflowed.
