### PR TITLE
fix(server): stop handing a discovery call an internal crash

### DIFF
--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -40,12 +40,21 @@ const bounded = (value: string) => value.slice(0, 64)
 // session yet, the named revision is dropped and the exchange goes ahead, which
 // is what settles the revision both sides use. After that the client has been
 // told which revision it got, so naming another one is its own mistake to fix
-// and the refusal stands.
+// and the refusal stands. Dropping the revision is only safe where something
+// else can still settle one, which is why a discovery call is excluded below.
 export const withNegotiableProtocolVersion = (
 	request: HttpServerRequest.HttpServerRequest,
 ) => {
 	const named = request.headers[PROTOCOL_VERSION_HEADER]
 	if (named === undefined || request.headers[SESSION_ID_HEADER] !== undefined)
+		return Effect.succeed(request)
+	// The opening handshake names its revision in the body as well, so it can
+	// still settle one with the header gone. A discovery call has nothing to fall
+	// back on: unnamed, it sails past the revision check into an RPC layer with no
+	// handler for it, and that crash comes back to the client as a success it
+	// cannot read. Keeping its revision named earns it the same plain refusal an
+	// established connection already gets.
+	if (request.headers[METHOD_HEADER] === 'server/discover')
 		return Effect.succeed(request)
 	return Effect.as(
 		Effect.logInfo('mcp.protocol_version.deferred_to_negotiation').pipe(

--- a/apps/server/src/mcp/protocol-version.test.ts
+++ b/apps/server/src/mcp/protocol-version.test.ts
@@ -316,6 +316,59 @@ describe('the /mcp route meeting a protocol revision it does not know', () => {
 		})
 	})
 
+	describe('when a client asks what this server speaks, with no session yet', () => {
+		it('should refuse it plainly rather than hand back a crash as a success', async () => {
+			// GIVEN an assistant asking which revisions this server speaks before any
+			//       connection exists, which is how one looks for a newer era
+			lines.length = 0
+			const response = await post(
+				{ jsonrpc: '2.0', id: 8, method: 'server/discover', params: {} },
+				{
+					'mcp-protocol-version': '2026-07-28',
+					'mcp-method': 'server/discover',
+				},
+			)
+
+			// THEN it is turned down the same way an established connection is turned
+			// down, instead of being let through to a layer with no handler for it
+			expect(response.status).toBe(400)
+			const body = Schema.decodeUnknownSync(JsonRpcError)(await response.json())
+			expect(body.error.code).toBe(-32000)
+			expect(body.error.message).toContain('2026-07-28')
+		})
+
+		it("should keep the runtime's own failure shape away from the client", async () => {
+			// GIVEN the same question asked the same way
+			const response = await post(
+				{ jsonrpc: '2.0', id: 9, method: 'server/discover', params: {} },
+				{
+					'mcp-protocol-version': '2026-07-28',
+					'mcp-method': 'server/discover',
+				},
+			)
+
+			// THEN nothing describing how this server fails internally reaches the
+			// caller — it used to receive the crash itself, wrapped in a success
+			const text = await response.text()
+			expect(text).not.toContain('Unknown request tag')
+			expect(text).not.toContain('Die')
+		})
+
+		it('should still let an opening handshake settle a revision', async () => {
+			// GIVEN the negotiation this exclusion sits beside: an opening call naming
+			//       a revision the library does not know, sent as an assistant sends it
+			const response = await initialize({
+				'mcp-protocol-version': '2026-07-28',
+				'mcp-method': 'initialize',
+			})
+
+			// THEN it is still served — that call names its revision in the body too,
+			// so it can settle one with the header gone
+			expect(response.status).toBe(200)
+			expect(response.headers.get('mcp-session-id')).toBeTruthy()
+		})
+	})
+
 	describe('when the body is broken rather than the revision', () => {
 		it('should not blame the revision for it', async () => {
 			// GIVEN a settled connection naming a revision this server DOES know


### PR DESCRIPTION
## What

When an assistant asks Batuda which versions of MCP (Model Context Protocol, the language Claude and ChatGPT use to reach the CRM's tools) this server speaks, it used to get two different answers depending on something unrelated to the question — whether a connection already existed. With one, a plain refusal. Without one, an HTTP 200 carrying an internal crash: an `Unknown request tag` failure serialized straight to the caller, complete with the runtime's own error shape and an error code of `0` that means nothing in this protocol. That crash also produced no log line at all, so it was invisible. This makes both paths answer the same way. It lives in the server app, on the route that serves MCP.

## Changes

**Touches:** the step that lets a brand-new connection agree a shared version, and its tests. The refusal it hands off to is next to it and unchanged.

- That step drops the version an assistant names so a fresh connection can settle one instead of being turned away. Dropping it is only safe for the opening handshake, which also names its version in the message body and can still settle one without the header. A discovery call has nothing to fall back on, so with the header gone it sailed past the version check into a layer with no handler for it and crashed there.
- Discovery calls are now excluded from that dropping, so they meet the version check like every other request and get the same plain refusal an established connection already gets.

## Impact

- **No behaviour change for anything that works today.** Opening handshakes still negotiate, and discovery calls on an established connection already took this path.
- **The crash response stops reaching clients.** Nothing describing how this server fails internally is handed to a caller on this path any more.
- **These requests become visible.** They previously produced no log line; they now leave the ordinary refusal line, at the quiet level shipped earlier today.
- **Logging and routing only.** No database change, no new setting the server needs at boot, nothing touching which organisation can see what (row-level security), and no change to who gets through the door (authentication).

## Review guide

- The whole change is one early return in `withNegotiableProtocolVersion` in `apps/server/src/mcp/http.ts`. Everything else is tests.
- **The risk is the negotiation beside it.** If this exclusion caught the opening handshake by mistake, every new connection would break. There is a test that drives a real handshake naming an unknown version, with the method header an assistant actually sends, and it passes both with and without the fix applied.
- **Known remainder, deliberately not fixed:** a discovery call naming a version this server *does* support, or naming none at all, still reaches the same handler-less path and still crashes. Neither shape has ever appeared in production — all 130 discovery requests observed carried `2026-07-28`, which is unsupported, so they all take the fixed path. Closing that too would mean answering the discovery call directly, which makes the version-refusal path unreachable for it and turns the log-level split released earlier today into dead code. I chose the narrow fix rather than rewrite a path that 124 requests a day currently use successfully.

## Tests

Three cases added to `apps/server/src/mcp/protocol-version.test.ts`: a session-less discovery call is refused plainly with a readable JSON-RPC error, the runtime's internal failure shape does not reach the caller, and an opening handshake still settles a version.

I disabled the fix to confirm the tests catch the real bug rather than passing vacuously — with the exclusion off, the first two fail exactly as the issue describes (the 400 becomes a 200 and the crash shape leaks); with it on, all 11 pass. The handshake guard passes in both states, which is what confirms the negotiation is untouched.

## Verification

Ran in the worktree: `biome check` (clean on both files), `check-types` (13/13), `test` (21/21 tasks, 1,040 server tests), `build` (13/13). The pre-push suite also ran green on this exact commit.

I reproduced the original defect against the in-process server before writing the fix, rather than working from a code read — that is where the crash response quoted above came from.

**Not verified:** I did not drive a real assistant against a running server, for the same reason as the previous change — reaching this path live needs a provisioned organisation and a minted key, and the harness already boots a real server through the real middleware.

Closes #562
