### PR TITLE
Emit one module per pri component so consumers can shake the rest

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -332,6 +332,14 @@ Library primitives at the time of writing: `PriAvatar`, `PriButton`,
 App-local primitives at the time of writing: `PriCombobox`, `PriCopyButton`,
 `PriPasswordInput`, `PriRichText`, `PriTable`.
 
+#### Importing a library primitive
+
+`@batuda/ui/pri` is what every consumer imports and what they should keep importing. The build emits each file in `src/pri/` as its own module, so the barrel is a re-export and a consumer downloads only the primitives it names — before that a marketing page needing two primitives paid for all twenty-one, 86.7 KB gzipped.
+
+`@batuda/ui/pri/pri-select` reaches a single file directly, for anyone who would rather be explicit than trust the shaking. That subpath is the **file** name, not the component name, and two files carry more than one primitive: `PriToggle` ships from `pri-toggle-group`, `usePriToast` and `createPriToastManager` from `pri-toast`. So `@batuda/ui/pri/pri-toggle` does not resolve.
+
+Adding a primitive needs no build change — `packages/ui/tsdown.config.ts` globs the directory, and `pnpm build` fails if an `exports` path names a module the build did not write. `src/blocks/` and `src/layout/` are emitted per file the same way, though neither exposes a per-file subpath.
+
 **Styling a router `Link`.** `styled(Link)` keeps the styling but drops
 TanStack Router's typing of `to`, `params` and `search`, so a wrong destination
 becomes a dead click instead of a compile error. Style a wrapper and put a bare

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,11 @@
 			"types": "./dist/pri/index.d.mts",
 			"import": "./dist/pri/index.mjs"
 		},
+		"./pri/pri-*": {
+			"development": "./src/pri/pri-*.tsx",
+			"types": "./dist/pri/pri-*.d.mts",
+			"import": "./dist/pri/pri-*.mjs"
+		},
 		"./tokens.css": "./src/tokens.css",
 		"./tailwind.css": "./src/tailwind.css"
 	},
@@ -48,6 +53,7 @@
 	},
 	"devDependencies": {
 		"@types/react": "19.2.17",
+		"publint": "^0.3.24",
 		"tailwindcss": ">=4",
 		"tsdown": "^0.22.7",
 		"tsx": "^4.20.3",
@@ -59,6 +65,7 @@
 		"src/tokens.css",
 		"src/tailwind.css"
 	],
+	"license": "MIT",
 	"publishConfig": {
 		"access": "public",
 		"exports": {
@@ -78,11 +85,15 @@
 				"types": "./dist/pri/index.d.mts",
 				"import": "./dist/pri/index.mjs"
 			},
+			"./pri/pri-*": {
+				"types": "./dist/pri/pri-*.d.mts",
+				"import": "./dist/pri/pri-*.mjs"
+			},
 			"./tokens.css": {
-				"default": "./dist/tokens.css"
+				"default": "./src/tokens.css"
 			},
 			"./tailwind.css": {
-				"default": "./dist/tailwind.css"
+				"default": "./src/tailwind.css"
 			}
 		}
 	},
@@ -90,5 +101,8 @@
 		"type": "git",
 		"url": "git+https://github.com/guillempuche/batuda.git",
 		"directory": "packages/ui"
-	}
+	},
+	"sideEffects": [
+		"*.css"
+	]
 }

--- a/packages/ui/tsdown.config.ts
+++ b/packages/ui/tsdown.config.ts
@@ -3,10 +3,21 @@ import { defineConfig } from 'tsdown'
 export default defineConfig({
 	entry: {
 		index: 'src/index.ts',
+		/* One entry per component file, not just the barrel. A barrel emitted as
+		 * a single module cannot be tree-shaken — every `styled()` call in it
+		 * reads as side-effectful — so naming two components pulls all of them.
+		 * Separate modules leave each barrel a thin re-export a consumer can
+		 * shake. Globbed, not listed, so a new file needs no change here. */
 		'blocks/index': 'src/blocks/index.ts',
+		'blocks/*': ['src/blocks/*.ts', '!src/blocks/index.ts'],
 		'layout/index': 'src/layout/index.ts',
+		'layout/*': 'src/layout/*.tsx',
 		'pri/index': 'src/pri/index.ts',
+		'pri/*': 'src/pri/*.tsx',
 	},
 	format: ['esm'],
 	dts: true,
+	/* Holds `exports` to what the build actually wrote — otherwise a published
+	 * subpath can name a module that is not in the tarball. */
+	publint: true,
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
         version: 8.20.0
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
@@ -422,7 +422,7 @@ importers:
         version: 8.0.7
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
@@ -513,7 +513,7 @@ importers:
         version: 8.20.0
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
@@ -550,7 +550,7 @@ importers:
         version: 8.20.0
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -569,7 +569,7 @@ importers:
         version: 22.19.15
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -603,7 +603,7 @@ importers:
         version: 22.19.15
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -622,7 +622,7 @@ importers:
         version: 22.19.15
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -662,7 +662,7 @@ importers:
         version: 19.2.17
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -681,7 +681,7 @@ importers:
         version: 22.19.15
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -700,7 +700,7 @@ importers:
         version: 22.19.15
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -728,7 +728,7 @@ importers:
         version: 22.19.15
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -763,12 +763,15 @@ importers:
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
+      publint:
+        specifier: ^0.3.24
+        version: 0.3.24
       tailwindcss:
         specifier: '>=4'
         version: 4.2.2
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.21.0)(typescript@5.9.3)
+        version: 0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
@@ -2738,6 +2741,10 @@ packages:
     resolution: {integrity: sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==}
     peerDependencies:
       preact: '>= 10.25.0 || >=11.0.0-0'
+
+  '@publint/pack@0.1.7':
+    resolution: {integrity: sha512-4EDEmvxWtgsCnnVeBvtFIFZtUhPPt1+bA9JrSwU4Sa//6oKtzCSlGGXYJr44OD9aGISymbieJ4mCKHUygUDU+g==}
+    engines: {node: '>=18'}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -6515,6 +6522,10 @@ packages:
       react-dom:
         optional: true
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -6654,6 +6665,9 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -6971,6 +6985,11 @@ packages:
     engines: {node: '>=16.0.0'}
     hasBin: true
 
+  publint@0.3.24:
+    resolution: {integrity: sha512-9zS56KrKBoqi5Qt8h92uMP8TTM9AYZSgnmCo4u2priMqkOZvQnTsziZ2p5LJ2ywbYkAjoCDp2jda9u4cgFefIw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -7186,6 +7205,10 @@ packages:
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -7519,6 +7542,10 @@ packages:
 
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -9965,6 +9992,10 @@ snapshots:
     dependencies:
       '@preact/signals-core': 1.14.4
       preact: 10.29.1
+
+  '@publint/pack@0.1.7':
+    dependencies:
+      tinyexec: 1.3.0
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -14129,6 +14160,8 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   msgpackr-extract@3.0.4:
@@ -14279,6 +14312,8 @@ snapshots:
       quickjs-wasi: 0.0.1
 
   package-manager-detector@1.6.0: {}
+
+  package-manager-detector@1.8.0: {}
 
   parse-entities@4.0.2:
     dependencies:
@@ -14633,6 +14668,13 @@ snapshots:
     dependencies:
       commander: 10.0.1
 
+  publint@0.3.24:
+    dependencies:
+      '@publint/pack': 0.1.7
+      package-manager-detector: 1.8.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
@@ -14938,6 +14980,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   rw@1.3.3: {}
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.2.1: {}
 
@@ -15301,6 +15347,8 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15356,7 +15404,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.7(tsx@4.21.0)(typescript@5.9.3):
+  tsdown@0.22.7(publint@0.3.24)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -15374,6 +15422,7 @@ snapshots:
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
     optionalDependencies:
+      publint: 0.3.24
       tsx: 4.21.0
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
`@batuda/ui/pri` ships every Base UI component to every consumer, whatever they import. On the marketing site that is **86.7 KB gzipped, 26% of the homepage JavaScript**, for two components: a footer language picker behind a click, and a scroll area that CSS gates to `min-width: 768px` — so mobile hydrates it and never lets it do anything.

## Why the usual fixes could not work

`sideEffects: false` on the consumer side was tried and produced byte-identical output. So did `treeshake.moduleSideEffects` returning false for the package, and the same via `environments.client`. The hook was instrumented to confirm it fired with the right id.

None of them could have worked. `dist/pri/index.mjs` was a **single 50 KB module**: `sideEffects` tells a bundler which modules it may skip, and there was only ever one. Inside it, ~60 `styled(...)` calls read as side-effectful, so nothing was droppable.

`src/pri/` was already one file per component. Only the build flattened them.

## The change

One build entry per source file instead of per barrel, globbed rather than listed, plus `sideEffects` and a `./pri/pri-*` subpath.

```
pri-select.mjs        8,623 B  →  @base-ui/react/select only
pri-scroll-area.mjs   3,697 B  →  @base-ui/react/scroll-area only
pri/index.mjs         1,394 B  →  thin re-export, 0 @base-ui imports
```

**Consumers need no change.** The barrel becoming a re-export across 21 modules is what makes the existing `import { PriScrollArea } from '@batuda/ui/pri'` shakeable. `./pri/pri-*` is there for anyone who prefers to be explicit.

Nothing inside this package imports the barrel, so no internal consumer is affected.

### `blocks` and `layout` had the same defect

`dist/blocks/index.mjs` was a re-export of one 11 KB chunk carrying all 13 Tiptap node extensions and `effect`'s `Schema`; `dist/layout` of a 5.7 KB chunk. A page importing only `Hero` paid for all of it. Both are now emitted per file — the two monolithic chunks are gone and every barrel is thin:

```
index.mjs           741 B
blocks/index.mjs  2,190 B
layout/index.mjs    296 B
pri/index.mjs     1,394 B
```

### The published stylesheet exports were broken

Unrelated to tree-shaking, but in the map this PR edits. `publishConfig.exports` pointed `./tokens.css` and `./tailwind.css` into `dist/`, where the build writes no CSS — confirmed against the live `@batuda/ui@2026.8.25` tarball, which ships `src/*.css` and has zero `.css` under `dist/`. So `@import "@batuda/ui/tailwind.css"` has never resolved for an npm consumer, which is exactly what the marketing site does. They now point at the `src/` copies `files` actually ships.

### A guard, because nothing here is exercised in-repo

`customConditions: ["development"]` and the ungated `conditions` in `apps/internal/vite.config.ts` route every in-repo consumer to `src/`, so no test, type-check or build ever loads `dist/`. A typo in either exports block would ship green.

`publint` now runs as part of `pnpm build`, which CI already does. Verified by putting the `dist/tokens.css` path back: the build exits 1 with `pkg.exports["./tokens.css"].default is ./dist/tokens.css but the file does not exist`. It also wanted a `license` field, so the package now declares MIT to match the repository's `LICENSE` — npm has been showing `@batuda/ui` as unlicensed.

The build entries are globbed (`'pri/*': 'src/pri/*.tsx'`), so a new primitive cannot be forgotten and silently fall back into the barrel.

## One sharp edge

The subpath is the **file** name, not the component name, and two files carry more than one primitive. `PriToggle` ships from `pri-toggle-group`, `usePriToast` and `createPriToastManager` from `pri-toast` — so `@batuda/ui/pri/pri-toggle` does not resolve. Documented in `docs/frontend.md` rather than fixed by splitting the file, which would change its styled-components component ids.

## Verified

The emitted module graph above; that each component pulls only its own Base UI subpath and every barrel carries none; that the packed tarball's 10 concrete export targets and 42 wildcard matches all exist, and that `@batuda/ui/pri/index` is now refused identically from source and from `dist` (it previously resolved from one and not the other); `check-types` across all 13 workspace packages; the full pre-push suite, including 798 integration tests, green from an isolated worktree.

## Not verified, and worth knowing before merging

**I could not measure the saving in the consumer.** Marketing runs `@batuda/ui@2026.6.18` and this repo is at `2026.8.25`; installing the packed tarball there fails on an unresolvable `@tiptap/core` peer, so any measurement would carry two versions of unrelated change alongside the packaging one.

The 86.7 KB figure comes from a different method — aliasing `@batuda/ui/pri` to a local stub holding only the two components — so treat it as the expectation rather than a measurement. The real number needs this published and marketing bumped, and I would take a median of several PageSpeed runs rather than one, having already been fooled twice by single-run variance on that site.
