### PR TITLE
Make Base UI and styled-components peer dependencies

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -340,6 +340,12 @@ App-local primitives at the time of writing: `PriCombobox`, `PriCopyButton`,
 
 Adding a primitive needs no build change — `packages/ui/tsdown.config.ts` globs the directory, and `pnpm build` fails if an `exports` path names a module the build did not write. `src/blocks/` and `src/layout/` are emitted per file the same way, though neither exposes a per-file subpath.
 
+#### What a consumer has to install
+
+`@base-ui/react` and `styled-components` are **peer** dependencies, not bundled ones. Both keep state in React context — Base UI's hooks and styled-components' stylesheet registry — so two copies in one tree produce "Invalid hook call" inside a `Select.Root`, or styles that render server-side and vanish on hydration. A peer makes the consumer's copy the only copy. The declared ranges track what this package is built against rather than the oldest version that happens to work, so a consumer behind on either has to catch up. Both are optional, because `@batuda/ui/blocks` needs neither.
+
+`effect` and `@tiptap/core` are still ordinary dependencies, so `blocks` carries its own. That is a deliberate trade and it has a sharp edge: `blocks` exports `TiptapDocument` and `BlockNode` as `Schema` instances, and a consumer that composes one into its own `Schema.Struct` is mixing two copies of `effect`. When the versions differ the inferred type silently collapses to `{}` and every field access on it fails to compile — it does not error at the import, it errors pages away in whatever consumed the type. A consumer of `blocks` should pin the same `effect` version this package does.
+
 **Styling a router `Link`.** `styled(Link)` keeps the styling but drops
 TanStack Router's typing of `to`, `params` and `search`, so a wrong destination
 becomes a dead click instead of a compile error. Style a wrapper and put a bare

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,20 +40,22 @@
 		"check-contrast": "tsx scripts/check-contrast.ts"
 	},
 	"dependencies": {
-		"@base-ui/react": "1.6.0",
 		"@tiptap/core": "^3.28.0",
 		"@tiptap/pm": "^3.28.0",
-		"effect": "4.0.0-beta.102",
-		"styled-components": "6.3.12"
+		"effect": "4.0.0-beta.102"
 	},
 	"peerDependencies": {
+		"@base-ui/react": "^1.6.0",
 		"react": "^19",
 		"react-dom": "^19",
+		"styled-components": "^6.3.12",
 		"tailwindcss": ">=4"
 	},
 	"devDependencies": {
+		"@base-ui/react": "1.6.0",
 		"@types/react": "19.2.17",
 		"publint": "^0.3.24",
+		"styled-components": "6.3.12",
 		"tailwindcss": ">=4",
 		"tsdown": "^0.22.7",
 		"tsx": "^4.20.3",
@@ -66,6 +68,14 @@
 		"src/tailwind.css"
 	],
 	"license": "MIT",
+	"peerDependenciesMeta": {
+		"@base-ui/react": {
+			"optional": true
+		},
+		"styled-components": {
+			"optional": true
+		}
+	},
 	"publishConfig": {
 		"access": "public",
 		"exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -738,9 +738,6 @@ importers:
 
   packages/ui:
     dependencies:
-      '@base-ui/react':
-        specifier: 1.6.0
-        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tiptap/core':
         specifier: 3.28.0
         version: 3.28.0(@tiptap/pm@3.28.0)
@@ -756,16 +753,19 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.7(react@19.2.7)
-      styled-components:
-        specifier: 6.3.12
-        version: 6.3.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
+      '@base-ui/react':
+        specifier: 1.6.0
+        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
       publint:
         specifier: ^0.3.24
         version: 0.3.24
+      styled-components:
+        specifier: 6.3.12
+        version: 6.3.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwindcss:
         specifier: '>=4'
         version: 4.2.2

--- a/syncpack.config.js
+++ b/syncpack.config.js
@@ -3,6 +3,17 @@ export default {
 	indent: '\t',
 	versionGroups: [
 		{
+			// A peer range says what a consumer is allowed to bring; a dependency
+			// pin says what we install. `@batuda/ui` accepts `@base-ui/react`
+			// `^1.3.0` so a consumer on 1.3.0 keeps one copy, while this repo
+			// installs 1.6.0. Holding both to one string would force either a
+			// hostile exact peer or a loose install pin.
+			label: 'Peer ranges, which are broader than install pins',
+			dependencies: ['**'],
+			dependencyTypes: ['peer'],
+			isIgnored: true,
+		},
+		{
 			label: 'TypeScript',
 			dependencies: ['typescript'],
 		},


### PR DESCRIPTION
`@batuda/ui` shipped `@base-ui/react` as an ordinary dependency, so a consumer that also depends on it installs two copies. Marketing does, and on `2026.8.30` it has `1.3.0` (its own) and `1.6.0` (via `@batuda/ui`).

Both `@base-ui/react` and `styled-components` are now optional peer dependencies. Both keep state in React context — Base UI's hooks, styled-components' stylesheet registry — so two copies in one tree is the "Invalid hook call" inside `Select.Root` and styles-that-vanish-on-hydration class of bug. Marketing's `vite.config.ts` already carries `dedupe: ['react','react-dom','@base-ui/react','@base-ui/utils']` with a comment about exactly that.

The declared ranges are `^1.6.0` and `^6.3.12` — what this package is actually built and tested against. A consumer behind on either has to catch up; the alternative was declaring `^1.3.0` (which does build and typecheck here) and quietly supporting versions CI never exercises.

Verified in a clone of `engranatge` with both versions bumped: one copy of `@base-ui/react`, one of `styled-components`, and marketing's `check-types` at zero errors.

Syncpack needed a new version group. It treats a peer range and an install pin as one value to reconcile, and its pre-commit `fix` silently rewrote the peer range to the exact pin. Peer ranges are now ignored; the exact pins in `apps/internal` are untouched.

## `effect` and `@tiptap/core` stay dependencies

Deliberate, and against my first instinct.

Marketing imports `@batuda/ui/blocks` in 15 places (versus 2 for `pri`) and declares neither Tiptap package, so peers there would break its install and force it to pin an exact Effect beta. Neither has a duplicate-instance hazard the way a React library does.

The workspace also pins `effect` through `overrides` in `pnpm-workspace.yaml`, with a comment recording a production crash caused by that version drifting across the `pnpm deploy` boundary. Handing each consumer its own copy is the wrong direction for that invariant.

What that leaves is documented in `docs/frontend.md`: `blocks` exports `TiptapDocument` as an Effect `Schema`, so a consumer composing it into its own `Schema.Struct` mixes two copies of `effect`.

## The reported type errors have a different cause

This PR does **not** fix them, and it is worth knowing why.

The `loaderData is possibly undefined` errors in marketing's `src/routes/$lang/$.tsx` come from the duplicate **`effect`**, not the duplicate `@base-ui/react`. Controlled runs against a clone:

| `@batuda/ui` | base-ui copies | effect copies | type errors |
| --- | --- | --- | --- |
| `2026.6.18` | 1 | 1 | **0** |
| `2026.8.30` | 2 | 2 | **29** |
| `2026.8.30` + this PR | **1** | 2 | **29** |
| `2026.8.30`, marketing `effect` → `beta.102` | 2 | **1** | **0** |

`apps/web/src/lib/pages-api.ts` builds `PublicPage` by composing marketing's own `Schema` with `TiptapDocument` from `@batuda/ui/blocks`. When the two `effect` copies differ, `Schema.Schema.Type<typeof PublicPage>` collapses to `{}` — which is why the errors read as missing `ogImage`/`ogTitle` properties and an undefined `loaderData`, several steps away from any import of `@batuda/ui`.

`2026.6.18` depended on `effect@4.0.0-beta.43` and `@base-ui/react@1.3.0` — exactly marketing's pins. It was never correct, only coincidentally aligned; the `2026.8.30` bump moved both and split both.

Marketing needs `effect` at `4.0.0-beta.102` and `@base-ui/react` at `1.6.0`, in its own change. Until then it keeps the 29 errors and, once this ships, gains an unmet peer warning.

## Verified

`pnpm --filter @batuda/ui build` still emits 22 `dist/pri/*.mjs`, `dist/pri/index.mjs` at exactly 1,394 bytes with zero `@base-ui` imports, and every peer stays a bare import rather than being inlined. `check-types` green across all 13 packages, `pnpm test` 21/21, `pnpm build` 13/13, `check-effect-pins` agrees at 54 places, publint clean.

I also built the server's production tree with `pnpm deploy --filter=@batuda/server --prod`, since that image is built without devDependencies: the server bundles `@batuda/ui` at build time and its `dist` carries no import of `@batuda/ui`, `@tiptap/*`, `@base-ui/react` or `styled-components`, so the deploy path is untouched.
