### PR TITLE
fix(mail-worker): stop a message that failed to load being skipped

### DIFF
--- a/apps/mail-worker/src/folder-sync.test.ts
+++ b/apps/mail-worker/src/folder-sync.test.ts
@@ -35,6 +35,27 @@ const clientWith = (uid: number): ImapFlow =>
 		},
 	}) as unknown as ImapFlow
 
+// A folder holding several messages, answered in uid order.
+const clientWithAll = (uids: readonly number[]): ImapFlow =>
+	({
+		search: async () => [...uids],
+		fetch: async function* () {
+			for (const uid of uids) {
+				yield { uid, source: Buffer.from('raw bytes') }
+			}
+		},
+	}) as unknown as ImapFlow
+
+// Makes exactly one message refuse to be taken in, the way a database error
+// during ingest does.
+const failingOn = (badUid: number) => {
+	ingestMock.mockImplementation((a: { imapUid: number }) =>
+		a.imapUid === badUid
+			? (Effect.fail(new Error('ingest failed')) as never)
+			: Effect.void,
+	)
+}
+
 // Recording the folder head is the only database work in this path, and it is
 // not what these tests are about. The matcher and the object store are named
 // because storing a message asks for them, but it is stubbed out here, so
@@ -61,6 +82,116 @@ const directionPassedToIngest = () => ingestMock.mock.calls[0]?.[0]?.direction
 
 beforeEach(() => {
 	ingestMock.mockClear()
+	ingestMock.mockImplementation(() => Effect.void)
+})
+
+describe('how far a folder is read when a message will not load', () => {
+	describe('when one message in the batch fails', () => {
+		it('should leave the folder waiting on it rather than reading past', async () => {
+			// GIVEN three new messages, the middle one of which cannot be taken in
+			failingOn(6)
+
+			// WHEN the folder is read
+			const progress = await run(
+				fetchAndIngestNewerThan({
+					client: clientWithAll([5, 6, 7]),
+					organizationId: 'org',
+					inboxId: 'inbox',
+					folder: 'INBOX',
+					direction: 'inbound',
+					uidvalidity: 1,
+					sinceUid: 4,
+					stuckUid: null,
+					attempts: 0,
+				}),
+			)
+
+			// THEN it stops there and says so, so the next pass starts from that
+			// message again. Reading past it would leave mail that landed nowhere
+			// behind, and nothing would ever go looking for it
+			expect(progress.lastUid).toBe(5)
+			expect(progress.stuckUid).toBe(6)
+			expect(progress.attempts).toBe(1)
+		})
+
+		it('should not read the ones behind it either', async () => {
+			// GIVEN the same batch
+			failingOn(6)
+
+			// WHEN the folder is read
+			await run(
+				fetchAndIngestNewerThan({
+					client: clientWithAll([5, 6, 7]),
+					organizationId: 'org',
+					inboxId: 'inbox',
+					folder: 'INBOX',
+					direction: 'inbound',
+					uidvalidity: 1,
+					sinceUid: 4,
+					stuckUid: null,
+					attempts: 0,
+				}),
+			)
+
+			// THEN the message after it waits for the next pass, so the folder is
+			// read in order rather than around the gap
+			expect(ingestMock.mock.calls.map(c => c[0].imapUid)).toEqual([5, 6])
+		})
+	})
+
+	describe('when the same message has already failed several times', () => {
+		it('should move on without it, loudly', async () => {
+			// GIVEN a message that has failed four passes already
+			failingOn(6)
+
+			// WHEN a fifth pass tries it
+			const progress = await run(
+				fetchAndIngestNewerThan({
+					client: clientWithAll([6, 7]),
+					organizationId: 'org',
+					inboxId: 'inbox',
+					folder: 'INBOX',
+					direction: 'inbound',
+					uidvalidity: 1,
+					sinceUid: 5,
+					stuckUid: 6,
+					attempts: 4,
+				}),
+			)
+
+			// THEN the folder gives up on it and carries on, because one message
+			// nobody can read must not hold every message behind it
+			expect(progress.stuckUid).toBeNull()
+			expect(progress.attempts).toBe(0)
+			expect(progress.lastUid).toBe(7)
+			expect(ingestMock.mock.calls.map(c => c[0].imapUid)).toEqual([6, 7])
+		})
+	})
+
+	describe('when a message that had been failing goes through', () => {
+		it('should stop waiting on it', async () => {
+			// GIVEN a message the folder has been waiting on, which now loads
+			const progress = await run(
+				fetchAndIngestNewerThan({
+					client: clientWithAll([6]),
+					organizationId: 'org',
+					inboxId: 'inbox',
+					folder: 'INBOX',
+					direction: 'inbound',
+					uidvalidity: 1,
+					sinceUid: 5,
+					stuckUid: 6,
+					attempts: 3,
+				}),
+			)
+
+			// THEN the count is cleared, so an earlier bad patch does not spend
+			// the allowance of a message that is fine now
+			expect(progress.stuckUid).toBeNull()
+			expect(progress.attempts).toBe(0)
+			expect(progress.lastUid).toBe(6)
+		})
+	})
 })
 
 describe('fetchAndIngestNewerThan', () => {
@@ -77,6 +208,8 @@ describe('fetchAndIngestNewerThan', () => {
 					direction: 'outbound',
 					uidvalidity: 1,
 					sinceUid: 6,
+					stuckUid: null,
+					attempts: 0,
 				}),
 			)
 
@@ -99,6 +232,8 @@ describe('fetchAndIngestNewerThan', () => {
 					direction: 'inbound',
 					uidvalidity: 1,
 					sinceUid: 2,
+					stuckUid: null,
+					attempts: 0,
 				}),
 			)
 

--- a/apps/mail-worker/src/folder-sync.ts
+++ b/apps/mail-worker/src/folder-sync.ts
@@ -9,11 +9,24 @@ import { ingestRawMessage } from './ingest.js'
 // Per-folder sync state stored under inboxes.folder_state JSONB:
 //   { "INBOX": { "uidvalidity": 1234, "lastUid": 9876, "syncedAt": "2026-..." } }
 // Read defensively — folder may not exist yet, fields may be wrong type.
+//
+// `stuckUid` is the message the folder is waiting on, and `attempts` is how
+// many passes have tried it. They are how a message that cannot be taken in is
+// retried instead of skipped, and eventually given up on out loud instead of
+// blocking the folder for good.
 export interface FolderState {
 	readonly uidvalidity: number
 	readonly lastUid: number
 	readonly syncedAt: string | null
+	readonly stuckUid: number | null
+	readonly attempts: number
 }
+
+// How many passes a single message may fail before the folder moves on without
+// it. Low, because each pass is a fresh connection and a fresh transaction: a
+// message that has failed this often is failing on its own contents, not on
+// anything a further wait would settle.
+const MAX_INGEST_ATTEMPTS = 5
 
 export const readFolderState = (
 	state: Record<string, unknown> | null,
@@ -27,7 +40,17 @@ export const readFolderState = (
 	const lu = typeof e['lastUid'] === 'number' ? e['lastUid'] : null
 	if (uv === null || lu === null) return null
 	const sa = typeof e['syncedAt'] === 'string' ? e['syncedAt'] : null
-	return { uidvalidity: uv, lastUid: lu, syncedAt: sa }
+	// Absent on every folder written before these existed, which reads as a
+	// folder that is not waiting on anything.
+	const su = typeof e['stuckUid'] === 'number' ? e['stuckUid'] : null
+	const at = typeof e['attempts'] === 'number' ? e['attempts'] : 0
+	return {
+		uidvalidity: uv,
+		lastUid: lu,
+		syncedAt: sa,
+		stuckUid: su,
+		attempts: at,
+	}
 }
 
 const writeFolderState = (
@@ -70,9 +93,13 @@ export const markExpunged = (args: {
 	})
 
 // Fetch every UID strictly greater than `sinceUid` and ingest each.
-// Returns the highest UID actually persisted so the caller can advance
-// folder_state.lastUid. When no new messages exist, returns sinceUid
-// unchanged.
+// Returns how far the folder has been read, so the caller can carry it into the
+// next pass. When no new messages exist, `lastUid` comes back unchanged.
+//
+// The cursor only moves past a message that was actually taken in. A message
+// that fails stops the pass where it is, so the next one starts again from it
+// rather than leaving it behind — mail that never landed anywhere is not
+// something the folder should walk past quietly.
 export const fetchAndIngestNewerThan = (args: {
 	readonly client: ImapFlow
 	readonly organizationId: string
@@ -81,9 +108,13 @@ export const fetchAndIngestNewerThan = (args: {
 	readonly direction: 'inbound' | 'outbound'
 	readonly uidvalidity: number
 	readonly sinceUid: number
+	readonly stuckUid: number | null
+	readonly attempts: number
 }) =>
 	Effect.gen(function* () {
 		let highest = args.sinceUid
+		let stuckUid = args.stuckUid
+		let attempts = args.attempts
 		// Range `${sinceUid+1}:*` — imapflow accepts `*` for "highest".
 		// `uid: true` means we treat the range as UIDs not seqnums.
 		const messages = yield* Effect.promise(async () => {
@@ -101,7 +132,7 @@ export const fetchAndIngestNewerThan = (args: {
 		})
 
 		for (const m of messages) {
-			yield* ingestRawMessage({
+			const stored = yield* ingestRawMessage({
 				organizationId: args.organizationId,
 				inboxId: args.inboxId,
 				folder: args.folder,
@@ -110,10 +141,7 @@ export const fetchAndIngestNewerThan = (args: {
 				imapUidvalidity: args.uidvalidity,
 				raw: new Uint8Array(m.source),
 			}).pipe(
-				// One bad message must not block the rest of the batch — ingest
-				// failures land in logs and folder_state still advances on
-				// successes. The dedupe index makes a re-fetch on next sync
-				// idempotent if the cause was transient.
+				Effect.as(true),
 				Effect.catchCause(cause =>
 					Effect.logWarning('Ingesting a message failed').pipe(
 						Effect.andThen(Effect.logError(boundedCause(cause))),
@@ -123,21 +151,66 @@ export const fetchAndIngestNewerThan = (args: {
 							folder: args.folder,
 							imapUid: m.uid,
 						}),
+						Effect.as(false),
 					),
 				),
 			)
-			if (m.uid > highest) highest = m.uid
+
+			if (stored) {
+				if (m.uid > highest) highest = m.uid
+				if (stuckUid === m.uid) {
+					stuckUid = null
+					attempts = 0
+				}
+				continue
+			}
+
+			attempts = stuckUid === m.uid ? attempts + 1 : 1
+			stuckUid = m.uid
+
+			// Given up on, and said so at a level somebody is watching. Walking
+			// past it loses one message; refusing to would leave every message
+			// behind it unread for as long as this one keeps failing, which is
+			// the worse of the two.
+			if (attempts >= MAX_INGEST_ATTEMPTS) {
+				yield* Effect.logError(
+					'Giving up on a message that will not load',
+				).pipe(
+					Effect.annotateLogs({
+						event: 'email.ingest_abandoned',
+						inboxId: args.inboxId,
+						folder: args.folder,
+						imapUid: m.uid,
+						attempts,
+					}),
+				)
+				if (m.uid > highest) highest = m.uid
+				stuckUid = null
+				attempts = 0
+				continue
+			}
+
+			// Everything after this one waits for the next pass, so it is read
+			// in order rather than around the gap.
+			break
 		}
 
-		if (highest !== args.sinceUid) {
-			yield* writeFolderState(args.inboxId, args.folder, {
-				uidvalidity: args.uidvalidity,
-				lastUid: highest,
-				syncedAt: new Date().toISOString(),
-			})
+		const progress: FolderState = {
+			uidvalidity: args.uidvalidity,
+			lastUid: highest,
+			syncedAt: new Date().toISOString(),
+			stuckUid,
+			attempts,
+		}
+		if (
+			highest !== args.sinceUid ||
+			stuckUid !== args.stuckUid ||
+			attempts !== args.attempts
+		) {
+			yield* writeFolderState(args.inboxId, args.folder, progress)
 		}
 
-		return highest
+		return progress
 	})
 
 // Persist the (uidvalidity, lastUid) pair after a backfill so the next
@@ -153,4 +226,6 @@ export const recordFolderHead = (args: {
 		uidvalidity: args.uidvalidity,
 		lastUid: args.lastUid,
 		syncedAt: new Date().toISOString(),
+		stuckUid: null,
+		attempts: 0,
 	})

--- a/apps/mail-worker/src/imap-roundtrip.test.ts
+++ b/apps/mail-worker/src/imap-roundtrip.test.ts
@@ -181,6 +181,8 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
+							stuckUid: null,
+							attempts: 0,
 						}).pipe(
 							Effect.provide(RawMessageStorage.layer),
 							Effect.provide(WorkerEnvVars.layer),
@@ -242,6 +244,8 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
+							stuckUid: null,
+							attempts: 0,
 						}).pipe(
 							Effect.provide(RawMessageStorage.layer),
 							Effect.provide(WorkerEnvVars.layer),
@@ -261,6 +265,8 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
+							stuckUid: null,
+							attempts: 0,
 						}).pipe(
 							Effect.provide(RawMessageStorage.layer),
 							Effect.provide(WorkerEnvVars.layer),
@@ -313,6 +319,8 @@ describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
 							direction: 'inbound',
 							uidvalidity,
 							sinceUid: 0,
+							stuckUid: null,
+							attempts: 0,
 						}).pipe(
 							Effect.provide(RawMessageStorage.layer),
 							Effect.provide(WorkerEnvVars.layer),

--- a/apps/mail-worker/src/inbox-session.ts
+++ b/apps/mail-worker/src/inbox-session.ts
@@ -149,7 +149,7 @@ const syncOneFolderTick = (args: {
 		const needsBackfill =
 			known === null || known.uidvalidity !== serverUidvalidity
 
-		const highest = needsBackfill
+		const progress = needsBackfill
 			? yield* backfillSinceDate({
 					client: args.client,
 					organizationId: args.inbox.organizationId,
@@ -169,22 +169,33 @@ const syncOneFolderTick = (args: {
 					direction: args.folder.direction,
 					uidvalidity: serverUidvalidity,
 					sinceUid: known.lastUid,
+					stuckUid: known.stuckUid,
+					attempts: known.attempts,
 				})
+
+		// A backfill answers with a plain uid; the incremental pass answers with
+		// where it got to, including whether it is waiting on a message.
+		const next: FolderState =
+			typeof progress === 'number'
+				? {
+						uidvalidity: serverUidvalidity,
+						lastUid: progress,
+						syncedAt: null,
+						stuckUid: null,
+						attempts: 0,
+					}
+				: { ...progress, syncedAt: null }
 
 		if (needsBackfill) {
 			yield* recordFolderHead({
 				inboxId: args.inbox.id,
 				folder: args.folder.path,
 				uidvalidity: serverUidvalidity,
-				lastUid: highest,
+				lastUid: next.lastUid,
 			})
 		}
 
-		args.progress.set(args.folder.path, {
-			uidvalidity: serverUidvalidity,
-			lastUid: highest,
-			syncedAt: null,
-		})
+		args.progress.set(args.folder.path, next)
 	})
 
 // One inbox = one IMAP connection per tracked folder. We keep things

--- a/apps/mail-worker/src/ingest-replay.integration.test.ts
+++ b/apps/mail-worker/src/ingest-replay.integration.test.ts
@@ -1,0 +1,223 @@
+// Taking the same message in twice must not count it twice.
+//
+// A mailbox whose uid numbering resets is read again from the start, so every
+// message in the window arrives a second time. Storing one is already idempotent
+// — the dedupe index turns the second insert into a no-op — but what a message
+// *means* for the rest of the account is not: a delivery notice moves an
+// address closer to being suppressed, and applying one twice counts a failure
+// that only happened once.
+//
+// Prereq: `pnpm cli services up` and a migrated database.
+
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { ParticipantMatcher } from '@batuda/email/participant-matcher'
+import { TimelineActivityService } from '@batuda/timeline'
+
+import { PgLive } from './db.js'
+import { ingestRawMessage } from './ingest.js'
+import { RawMessageStorage } from './storage.js'
+
+const ORG_ID = `replay-org-${randomUUID()}`
+const DOMAIN = `replay-${randomUUID()}.example`
+const BOUNCED = `gone@${DOMAIN}`
+
+let inboxId = ''
+let contactId = ''
+const originalMessageId = `<replay-original-${randomUUID()}@example>`
+
+// The bytes never leave the test — what is under test is what the database ends
+// up holding, not where the raw message was put.
+const stubStorage = Layer.succeed(RawMessageStorage, {
+	putRaw: () => Effect.void,
+	putAttachment: () => Effect.void,
+} as never)
+
+const sqlOnly = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
+	Effect.runPromise(effect.pipe(Effect.provide(PgLive)))
+
+// One delivery notice, as a mail server writes it: RFC 3464 multipart/report
+// naming the address that failed and quoting the message that did not arrive.
+const deliveryNotice = (): Uint8Array => {
+	const boundary = 'replay-boundary'
+	return new TextEncoder().encode(
+		[
+			`From: MAILER-DAEMON@${DOMAIN}`,
+			`To: desk@${DOMAIN}`,
+			`Message-ID: <replay-dsn-${randomUUID()}@example>`,
+			`Subject: Undelivered Mail Returned to Sender`,
+			`Content-Type: multipart/report; report-type=delivery-status; boundary="${boundary}"`,
+			``,
+			`--${boundary}`,
+			`Content-Type: text/plain; charset=utf-8`,
+			``,
+			`Delivery to the following recipient failed.`,
+			``,
+			`--${boundary}`,
+			`Content-Type: message/delivery-status`,
+			``,
+			`Reporting-MTA: dns; mta.${DOMAIN}`,
+			``,
+			`Final-Recipient: rfc822;${BOUNCED}`,
+			`Action: failed`,
+			`Status: 4.2.2`,
+			``,
+			`--${boundary}`,
+			`Content-Type: message/rfc822`,
+			``,
+			`Message-ID: ${originalMessageId}`,
+			`To: ${BOUNCED}`,
+			`Subject: original`,
+			``,
+			`body bytes`,
+			`--${boundary}--`,
+			``,
+		].join('\r\n'),
+	)
+}
+
+// The same read of the same mailbox, twice — identical uid and uidvalidity, the
+// way a re-read of the window delivers it.
+const ingestOnce = (raw: Uint8Array) =>
+	Effect.runPromise(
+		ingestRawMessage({
+			organizationId: ORG_ID,
+			inboxId,
+			folder: 'INBOX',
+			direction: 'inbound',
+			imapUid: 501,
+			imapUidvalidity: 9,
+			raw,
+		}).pipe(
+			Effect.provide(stubStorage),
+			Effect.provide(ParticipantMatcher.layer),
+			Effect.provide(TimelineActivityService.layer),
+			Effect.provide(PgLive),
+		),
+	)
+
+beforeAll(async () => {
+	await sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`
+				INSERT INTO "organization" (id, name, slug, "createdAt")
+				VALUES (${ORG_ID}, 'Replay Test', ${ORG_ID}, now())`
+			const placeholder = new Uint8Array([0])
+			const inboxes = yield* sql<{ id: string }>`
+				INSERT INTO inboxes (
+					-- A mailbox the whole team shares, which is why it is nobody's
+					-- default: the database refuses a team mailbox that is one.
+					organization_id, email, is_default, is_private, grant_status,
+					imap_host, imap_port, imap_security,
+					smtp_host, smtp_port, smtp_security, username,
+					password_ciphertext, password_nonce, password_tag
+				) VALUES (
+					${ORG_ID}, ${`desk@${DOMAIN}`}, false, false, 'connected',
+					'imap.test', 993, 'tls', 'smtp.test', 465, 'tls', ${`desk@${DOMAIN}`},
+					${placeholder}, ${placeholder}, ${placeholder}
+				) RETURNING id`
+			inboxId = inboxes[0]!.id
+			const companies = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, slug, name)
+				VALUES (${ORG_ID}, ${`replay-co-${randomUUID()}`}, 'Replay Co')
+				RETURNING id`
+			const contacts = yield* sql<{ id: string }>`
+				INSERT INTO contacts (organization_id, company_id, name)
+				VALUES (${ORG_ID}, ${companies[0]!.id}, 'Gone Person')
+				RETURNING id`
+			contactId = contacts[0]!.id
+			yield* sql`
+				INSERT INTO channels (
+					organization_id, subject_table, subject_id, channel, address, is_primary
+				) VALUES (
+					${ORG_ID}, 'contacts', ${contactId}, 'email', ${BOUNCED}, true
+				)`
+			// The message the notice says did not arrive.
+			yield* sql`
+				INSERT INTO email_messages (
+					organization_id, inbox_id, folder, message_id, direction,
+					received_at, status, status_updated_at, raw_rfc822_ref
+				) VALUES (
+					${ORG_ID}, ${inboxId}, 'Sent', ${originalMessageId}, 'outbound',
+					now(), 'normal', now(), ${`raw/${randomUUID()}`}
+				)`
+		}),
+	)
+}, 30_000)
+
+afterAll(async () => {
+	await sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			for (const table of [
+				'timeline_activity',
+				'interactions',
+				'email_messages',
+				'email_thread_links',
+				'channels',
+				'contacts',
+				'companies',
+				'inboxes',
+			]) {
+				yield* sql`DELETE FROM ${sql.literal(table)} WHERE organization_id = ${ORG_ID}`
+			}
+			yield* sql`DELETE FROM "organization" WHERE id = ${ORG_ID}`
+		}),
+	)
+})
+
+const bounceEntries = () =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<{ id: string }>`
+				SELECT id FROM timeline_activity
+				WHERE organization_id = ${ORG_ID} AND kind = 'email_bounced'`
+			return rows.length
+		}),
+	)
+
+const softBounceCount = () =>
+	sqlOnly(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const rows = yield* sql<{ softBounceCount: number }>`
+				SELECT soft_bounce_count FROM channels
+				WHERE organization_id = ${ORG_ID} AND address = ${BOUNCED}`
+			return rows[0]?.softBounceCount ?? 0
+		}),
+	)
+
+describe('taking in a delivery notice that has already been seen', () => {
+	describe('when the same notice arrives a second time', () => {
+		it('should count the failure once, not twice', async () => {
+			// GIVEN a delivery notice for an address we hold a contact for
+			const raw = deliveryNotice()
+
+			// WHEN the same read delivers it twice
+			await ingestOnce(raw)
+			const afterFirst = await softBounceCount()
+			await ingestOnce(raw)
+
+			// THEN the address is no closer to being suppressed than one failure
+			// puts it. Three counted failures suppress an address, so a mailbox
+			// re-read twice would silence somebody who bounced once
+			expect(afterFirst).toBe(1)
+			expect(await softBounceCount()).toBe(1)
+		})
+
+		it('should leave one entry on the history, not one per read', async () => {
+			// GIVEN the notice above, already taken in twice
+			// THEN the account shows the failure once
+			expect(await bounceEntries()).toBe(1)
+		})
+	})
+})

--- a/apps/mail-worker/src/ingest.ts
+++ b/apps/mail-worker/src/ingest.ts
@@ -114,18 +114,18 @@ export const ingestRawMessage = (args: {
 				yield* sql`SET LOCAL ROLE app_service`
 				yield* sql`SELECT set_config('app.current_org_id', ${args.organizationId}, true)`
 
-				// Bounce check first: a DSN both updates the original message
-				// status AND gets persisted as its own inbound row so the user
-				// sees "Mail Delivery Subsystem" in the inbox list.
-				const bounce = parseBounce(mail)
-				if (bounce) {
-					yield* applyBounce({
-						organizationId: args.organizationId,
-						bounce,
-					})
-				}
-
-				yield* persistMessage({
+				// The notice is stored first, and what applying it does to the
+				// rest of the account follows only when storing it was new.
+				//
+				// A delivery notice is a message like any other, so it is kept
+				// as its own inbound row and the user sees "Mail Delivery
+				// Subsystem" in the inbox list. That row is also the only record
+				// that this notice has been seen: a mailbox whose uid numbering
+				// resets is read again from the start, and applying the same
+				// notice twice counts its failures twice — three passes over one
+				// soft bounce is enough to suppress an address that never bounced
+				// three times.
+				const stored = yield* persistMessage({
 					organizationId: args.organizationId,
 					inboxId: args.inboxId,
 					folder: args.folder,
@@ -136,6 +136,16 @@ export const ingestRawMessage = (args: {
 					parsed: withMessageId,
 					attachments: attachmentsMeta,
 				})
+
+				if (stored.messageId !== null) {
+					const bounce = parseBounce(mail)
+					if (bounce) {
+						yield* applyBounce({
+							organizationId: args.organizationId,
+							bounce,
+						})
+					}
+				}
 			}),
 		)
 	})

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -776,6 +776,14 @@ The send path stores the rendered `text` and `html` on the `email_messages` row 
 The worker syncs two folders per inbox, and which one a message came from decides its direction — inbox means it arrived, sent folder means we sent it. Folders are matched on the IMAP special-use flags the server reports (`\Inbox`, `\Sent`) rather than their names, because Gmail calls its sent folder `[Gmail]/Sent Mail` and Outlook `Sent Items`; matching by name syncs no sent mail at all on either. `resolveTrackedFolders` in `apps/mail-worker/src/inbox-session.ts` settles this once per session and hands the answer down, so nothing lower has to re-derive it from a folder name. Only mail that arrived is written to a company's history — what we send is recorded where it is sent from.
 The worker writes it through `@batuda/timeline`, the same recorder the server uses, so an arriving message leaves what a sent one leaves: the history entry, the dates both the company and the contact are read by, and a touchpoint.
 
+How far each folder has been read is kept per folder in `inboxes.folder_state`, and the cursor only moves past a message that was actually taken in.
+A message that fails stops the pass where it is, so the next one starts again from it rather than leaving it behind — a message that landed nowhere is not something to walk past quietly, and nothing would ever go looking for it.
+The same message failing five passes running is given up on at error level (`email.ingest_abandoned`) and the folder moves on, because one message nobody can read must not hold every message behind it.
+
+Applying a delivery notice is gated on storing it being new.
+Storing a message is already idempotent — the dedupe index turns a second insert into a no-op — but what a notice *means* is not: it counts a failure against an address, and three counted failures suppress it.
+A mailbox whose uid numbering resets is read again from the start, so without that gate a re-read would suppress an address that bounced once.
+
 ### Package layout — `packages/email`
 
 Shared Node+browser library, consumed by `apps/server` (render at send time), `apps/internal` (compose + footer editors), and `packages/controllers` (HTTP schema).


### PR DESCRIPTION
## What

Two ways the mail worker could quietly lose or double-count a message. Both predate the change that surfaced them — an audit of PR 587 turned them up — and neither is caused by it.

**A message that fails to load is skipped, permanently.** The ingest loop catches a failure, logs it, and then advances the folder's read cursor past that message anyway. Nothing ever goes back for it. The comment sitting three lines above the bug claims the opposite on both counts: that the cursor "advances on successes", and that "the dedupe index makes a re-fetch on next sync idempotent". There is no re-fetch. A transient database error while taking a customer's email in means that email is gone, and nobody is told.

**A delivery notice taken in twice counts its failure twice.** Storing a message is idempotent — the dedupe index turns the second insert into a no-op — but *applying* a bounce is not. It increments a counter against the address, and three counted failures suppress it. A mailbox whose uid numbering resets is read again from the start, so two re-reads of one soft bounce could stop mail going to an address that bounced once.

This is `apps/mail-worker` only.

## Changes

**Touches:** how far a folder has been read, and when a delivery notice is acted on.

- The cursor now only moves past a message that was actually taken in. A failure stops the pass there, so the next one starts again from it — and the messages behind it wait rather than being read around the gap, so a folder is read in order.
- The same message failing five passes running is given up on at error level (`email.ingest_abandoned`) and the folder moves on. Refusing to would mean one unreadable message holds every message behind it unread, which is the worse of the two failures. That count lives in the per-folder state the worker already keeps, so there is no schema change.
- A delivery notice is applied only the first time it is stored. The message dedupe is the record of "already seen", so the gate is exact: store first, act on it only when storing was new.

## Impact

- **No migration.** The retry state is two more fields in the `inboxes.folder_state` JSONB the worker already writes, and it is read defensively — a folder written before this exists reads as one that is not waiting on anything.
- **A folder can now pause on a bad message** for up to five passes instead of racing past it. That is the intended trade: a stall is visible, repeats in the log every cycle, and self-heals if the cause was transient; a silent loss is none of those.
- **Nothing about which organisation can see what, no new environment variables, no wire-shape change, and nothing the server or web app reads.**
- **`apps/mail-worker` alone** — the server is untouched, so this ships on its own.

## Review guide

- **Start at** `apps/mail-worker/src/folder-sync.ts`. The bug was one line — `if (m.uid > highest) highest = m.uid` sitting outside the `catchCause` — and most of the diff is the bounded-retry state that lets the fix not turn into a permanent stall.
- **The judgement call** is the retry limit. Five passes, then move on loudly. Stopping forever protects every message but lets one poison message silence a mailbox; never stopping is what this PR is fixing. If you would rather it never gives up, it is a one-line change and the test names the behaviour.
- **The bounce gate is a reorder**, and it is worth checking I did not break an ordering dependency: `applyBounce` touches the *original* message's row, its channels, and the history; `persistMessage` inserts the notice itself. Different rows, so which runs first only matters for the idempotency signal.
- **Skip-able:** the `stuckUid`/`attempts` threading through `inbox-session.ts` is mechanical.

## Tests

- Four cases on the cursor: a failure leaves the folder waiting on that message, the ones behind it are not read around it, the fifth failure moves on and clears the count, and a message that recovers stops the count. Mutation-checked — restoring the unconditional advance fails the first.
- Two cases on the replay, driven through the real ingest path against Postgres with the same delivery notice twice: the failure is counted once, and the account shows one entry. Mutation-checked — removing the gate fails both.

## Verification

- `pnpm check-types` (14/14), `pnpm check` (exit 0), `pnpm test` (23/23 packages), `pnpm build` (14/14).
- `pnpm --filter @batuda/mail-worker test:integration` — 5 files, 48 tests.
- `pnpm --filter @batuda/server test:integration` — 105 files, 830 tests, confirming the server is unaffected.
- Not run: the worker against a live IMAP server. `imap-roundtrip.test.ts` covers that path but is skipped unless `MAIL_CATCHER_LIVE` is set, so it does not run here or in CI. The cursor logic is covered by unit tests over a fake client, and the replay gate against real Postgres.
