### PR TITLE
fix: say when telemetry stops leaving the process

### DIFF
--- a/apps/mail-worker/src/observability.ts
+++ b/apps/mail-worker/src/observability.ts
@@ -3,11 +3,15 @@ import { makeOtlpObservability } from '@batuda/observability'
 /**
  * OTLP observability layer for the mail worker. Exports traces, logs, and
  * metrics to the `batuda-mail-worker` Honeycomb dataset when
- * OTEL_EXPORTER_OTLP_ENDPOINT is set; otherwise a no-op (local dev).
+ * OTEL_EXPORTER_OTLP_ENDPOINT is set; otherwise it sends nothing (local dev).
  *
  * Whoever builds this in has to MERGE it, not only provide it: provided alone,
  * the process keeps its own logger and tracer, announces that export is enabled,
  * and sends nothing.
+ *
+ * This process has no HTTP surface, so its console is the only place it can
+ * report on its own export health — which is why that report is a repeating log
+ * line rather than something to be asked for.
  */
 export const OtlpObservability = makeOtlpObservability({
 	serviceName: 'batuda-mail-worker',

--- a/apps/server/src/handlers/health.ts
+++ b/apps/server/src/handlers/health.ts
@@ -1,18 +1,21 @@
-import { Effect } from 'effect'
+import { Clock, Effect } from 'effect'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
 import { BatudaApi } from '@batuda/controllers'
-import { buildMeta } from '@batuda/observability'
+import { buildMeta, exportHealth, exportReport } from '@batuda/observability'
 
 export const HealthLive = HttpApiBuilder.group(BatudaApi, 'health', handlers =>
 	Effect.succeed(
 		handlers.handle('check', () =>
-			Effect.succeed({
+			Effect.map(Clock.currentTimeMillis, now => ({
 				status: 'ok',
 				version: buildMeta.version,
 				commit: buildMeta.commitShort,
 				region: buildMeta.region,
-			}),
+				// Answers "is this instance still reaching Honeycomb?" without
+				// needing the instance console, which only hands back its tail.
+				telemetry: exportReport(exportHealth, now),
+			})),
 		),
 	),
 )

--- a/apps/server/src/lib/observability.ts
+++ b/apps/server/src/lib/observability.ts
@@ -3,7 +3,10 @@ import { makeOtlpObservability } from '@batuda/observability'
 /**
  * OTLP observability layer for the API server. Exports traces, logs, and
  * metrics to the `batuda-server` Honeycomb dataset when
- * OTEL_EXPORTER_OTLP_ENDPOINT is set; otherwise a no-op (local dev).
+ * OTEL_EXPORTER_OTLP_ENDPOINT is set; otherwise it sends nothing (local dev).
+ *
+ * Either way it keeps saying which of the two it is doing, so the question can
+ * be answered from a running process rather than from a line written at boot.
  */
 export const OtlpObservability = makeOtlpObservability({
 	serviceName: 'batuda-server',

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -295,8 +295,9 @@ const program = HttpRouter.serve(AppLive, {
 	// mergeWithExisting). The reverse order would let LoggerLive — which REPLACES
 	// the logger set — drop the OTLP logger, so non-span logs (detached fibers,
 	// boot, Better Auth callbacks) would never reach Honeycomb's /v1/logs. When
-	// OTLP is off, OtlpObservability is Layer.empty and LoggerLive's set shows
-	// through unchanged (no duplicated default logger).
+	// OTLP is off it adds no logger of its own, so LoggerLive's set shows through
+	// unchanged (no duplicated default logger) — the repeating "not exporting"
+	// line goes out on that set.
 	Layer.provide(OtlpObservability),
 	Layer.provide(LoggerLive),
 	// Bottom of the stack so the baked-file ConfigProvider underlies every

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -62,6 +62,11 @@ Timestamps and trace ids are added by the framework.
 | `mcp.tool_called`              | MCP tool invoked by agent                                  |
 | `mcp.auth.rejected`            | An MCP call was refused, and why                           |
 | `mcp.protocol_version.refused` | A call named a protocol revision this server does not know |
+| `otlp.export.failing`          | This process has stopped being able to export, and why     |
+| `otlp.export.recovered`        | Exporting works again                                      |
+| `otlp.export.health`           | Whether this process is exporting, repeated on a timer     |
+
+The three `otlp.export.*` lines are the exception to one record per unit of work: they report on the reporting itself, so they belong to the process rather than to any piece of work it did. See [When export itself fails](#when-export-itself-fails).
 
 A request leaves exactly one of `http.request`, `http.server_error`, `http.defect` or `http.not_found`. "Every request that ended badly" is the middle two: a route that does not exist is the caller's mistake rather than a fault of ours, and it is kept out of the error channel on purpose — recorded as a crash, every bot probing for `/robots.txt` leaves a stack trace at error level and buries the failures that matter.
 
@@ -77,6 +82,8 @@ A request also leaves exactly **one span**, not two. The platform opens that spa
 | `debug` | Development details             |
 
 `MIN_LOG_LEVEL` sets the floor per process. In production it comes from `config.production.json`, which is copied into the image — so changing it means a rebuild and a redeploy, not a live switch. Worth knowing before an incident, when the instinct is to turn the detail up and read more.
+
+That floor is not only ours to spend. A library can report something important at `debug` and have it dropped before any logger sees it — which is how the exporter reports that it has stopped sending anything at all. Anything a library says that we would want during an incident has to be re-said at a level production keeps.
 
 ## Counters: the narrow exception
 
@@ -153,12 +160,15 @@ As a solo operation there is no on-call rotation or war room. Two questions matt
 
 **Start with few, high-signal alerts.** Alert fatigue is worse than no alerts.
 
-| Alert                | Condition                             | Severity |
-| -------------------- | ------------------------------------- | -------- |
-| **API Down**         | Health check fails for > 2 min        | Critical |
-| **High Error Rate**  | > 10% API 5xx responses in 15 min     | High     |
-| **Email Failures**   | > 5 consecutive email send failures   | High     |
-| **Webhook Failures** | > 20% webhook 5xx responses in 15 min | High     |
+| Alert                | Condition                                  | Severity |
+| -------------------- | ------------------------------------------ | -------- |
+| **API Down**         | Health check fails for > 2 min             | Critical |
+| **Telemetry Silent** | No spans from any prod dataset over 15 min | Critical |
+| **High Error Rate**  | > 10% API 5xx responses in 15 min          | High     |
+| **Email Failures**   | > 5 consecutive email send failures        | High     |
+| **Webhook Failures** | > 20% webhook 5xx responses in 15 min      | High     |
+
+**Telemetry Silent is the one alert that cannot be raised from inside.** Every other row above is a question asked of the records, so it needs the records to be arriving. This one has to be evaluated by the vendor, environment-wide, so it still fires when the services are stopped or cut off and cannot report for themselves — the gap that let the 2026-08-31 outage run seven hours unnoticed while `/health` answered 200 throughout. Note the consequence: once it fires it stays fired until export is restored, so it cannot warn about a second outage in the meantime.
 
 1. **Alert on symptoms, not causes** — "API returning errors" > "Database connection failed"
 2. **Include runbook link** — What to do when this fires
@@ -257,7 +267,9 @@ Swapping environments is a pure env-var change:
 | `GIT_SHA`                     | Full commit SHA; short SHA derived at runtime.                                                                |
 | `REGION`                      | Deployment region.                                                                                            |
 
-The endpoint is non-secret, so it lives in each app's `config.production.json` alongside the other endpoints — not a CI secret. It is deliberately left out until a vendor is set up, so export stays dark by default.
+The endpoint is non-secret, so it lives in each app's `config.production.json` alongside the other endpoints — not a CI secret. It is deliberately left out until a vendor is set up, so export stays dark by default — quietly outside production, and at `error` inside it, where its absence means the image was built wrong.
+
+The headers are the half that does not ship in the image: they carry the vendor key, so they arrive as `-e` on the boot command line and live only in whatever the platform kept for that instance. The two halves can therefore disagree — the endpoint is always present, so export always switches itself on, whether or not a key came with it. Export enabled with no key is a 401 on every batch, which now says so rather than going quiet.
 
 **Per-service datasets.** Traces route to a Honeycomb dataset named after `service.name`, so each process separates on its own. Logs and metrics route by the `x-honeycomb-dataset` header instead, so each deploy workflow appends its own dataset name to the shared team-key secret. One environment-scoped API key covers every process.
 
@@ -265,11 +277,29 @@ A process only reports if it **merges** the observability layer into the layer i
 
 Note the consequence: logs and traces from the same request land in different datasets. That is the vendor's routing, not a choice — it is why the per-request record has to be self-sufficient rather than something you assemble by joining a log to a trace.
 
+## When export itself fails
+
+A process that cannot export looks exactly like a healthy one. It serves traffic, writes its lines, and the vendor simply has nothing — which reads as a quiet night rather than a fault. Prod ran that way for seven hours on 2026-08-31 before anyone noticed, and the reason nothing surfaced is worth stating plainly: the exporter reports a refused batch at `debug` and disables itself for sixty seconds, and both deployed services run at `info`, so the runtime discarded the only diagnostic before a logger saw it. That was the entire failure report.
+
+So the export path reports on itself, on the one channel that still works when export does not — the process's own console. It says `otlp.export.failing` once when export breaks and `otlp.export.recovered` once when it comes back, rather than on every attempt, because a backend that is down produces a failure every interval and repeating it buries the console it is trying to reach. And it repeats `otlp.export.health` every few minutes regardless, because the platform hands back the end of an instance's console log rather than the beginning: a line written once at start-up has scrolled away by the time anyone asks, which is what made the 2026-08-31 outage undiagnosable without a restart. A line that comes back is always in the part you can still read.
+
+Deliberately not sent to the backend. A report that export is broken is worth nothing if it goes out the way that is broken.
+
+**Silence is not failure.** The alarm asks whether the last attempt failed and has kept failing — never whether something arrived recently. Logs and traces skip a batch with nothing in it, so a quiet service legitimately posts neither, and a staleness test would call every overnight service broken. What keeps a genuinely dead channel from hiding behind a quiet one is metrics, which posts on every interval whether or not it has anything to say.
+
+**A missing endpoint is loud in production, but never fatal.** In production the endpoint ships inside the image, so its absence is a broken build and is said at `error`. It still does not stop the process: telemetry is not needed to serve a request, and refusing to boot over a monitoring setting would turn being unable to watch production into being unable to run it. Outside production, export being off is ordinary and stays at `info`.
+
+**The three signals are tracked apart.** A backend can take our logs and refuse our traces, so one "is export working" flag would read healthy while traces were being dropped.
+
 ## Health endpoint
 
-`/health` returns build metadata for uptime checks and deploy verification: CalVer version, short commit SHA, region.
+`/health` returns build metadata for uptime checks and deploy verification — CalVer version, short commit SHA, region — plus whether this instance is still reaching the telemetry backend.
 
-**Security note:** only those. No framework or dependency versions, no internal paths, no stack traces. It is also exempt from tracing — an uptime checker polls it constantly and would drown the real traces.
+The telemetry block is there because of the failure above: the console of a deployed instance is not always reachable, and an instance that cannot export cannot report that through the thing it exports to. One unauthenticated request answers it from anywhere, which is the point.
+
+**Security note:** those, and nothing more. No framework or dependency versions, no internal paths, no stack traces — and from the telemetry block, no backend host, no vendor wording and no status line: only a closed set of reasons (`unauthorized`, `rate_limited`, `rejected`, `unreachable`), enough to tell a rejected key from a quota from a dead route. The reason is a fixed set rather than whatever the backend said on purpose: the backend's wording is derived from our request, and our request carries the API key in a header.
+
+It is also exempt from tracing — an uptime checker polls it constantly and would drown the real traces.
 
 ## Where this lives in the code
 
@@ -278,6 +308,7 @@ Pointers, not copies — read the files for detail.
 | Concern                                                       | Where                                              |
 | ------------------------------------------------------------- | -------------------------------------------------- |
 | Shared exporter, sampling, span scrubbing, cause bounding     | `packages/observability`                           |
+| Export health: per-signal outcomes, the watchdog, the report  | `packages/observability/src/export-health.ts`      |
 | Per-request record, route sanitizing, catch-all error logging | `apps/server/src/lib/observability-middleware.ts`  |
 | Logger set and level                                          | `apps/server/src/lib/logger.ts`                    |
 | Tracing exemptions for secret-carrying routes                 | `apps/server/src/main.ts`                          |

--- a/packages/controllers/src/routes/health.test.ts
+++ b/packages/controllers/src/routes/health.test.ts
@@ -1,0 +1,131 @@
+// The health check is the one way to ask a running instance whether it is
+// still reaching its telemetry backend, so what it will and will not carry over
+// the wire is worth pinning. It is served without authentication.
+
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { HealthResponse } from './health'
+
+const encode = (input: unknown) =>
+	Schema.encodeUnknownExit(Schema.toCodecJson(HealthResponse))(input)
+
+const healthy = {
+	status: 'ok',
+	version: '2026.8.30',
+	commit: 'a3cf4f0',
+	region: 'fra',
+	telemetry: {
+		exporting: true,
+		signals: {
+			traces: { failing: false, lastSuccessAt: 1_788_199_862_000 },
+			logs: { failing: false, lastSuccessAt: 1_788_199_862_000 },
+			metrics: { failing: false, lastSuccessAt: 1_788_199_862_000 },
+		},
+	},
+}
+
+describe('the health response', () => {
+	describe('when telemetry is flowing', () => {
+		it('should carry the state of each kind of telemetry', () => {
+			// GIVEN an instance exporting all three signals
+			// WHEN the response is encoded for the wire
+			const exit = encode(healthy)
+
+			// THEN it is accepted
+			expect(exit._tag).toBe('Success')
+		})
+	})
+
+	describe('when a signal has never succeeded', () => {
+		it('should accept the report with no last success to name', () => {
+			// GIVEN traces that have been refused since boot, so there is no
+			//       success to date — the state the 2026-08-31 outage left behind
+			// WHEN the response is encoded
+			const exit = encode({
+				...healthy,
+				telemetry: {
+					exporting: true,
+					signals: {
+						traces: { failing: true, failure: 'unauthorized' },
+						logs: { failing: true, failure: 'unauthorized' },
+						metrics: { failing: true, failure: 'unauthorized' },
+					},
+				},
+			})
+
+			// THEN it is accepted without a `lastSuccessAt`
+			expect(exit._tag).toBe('Success')
+		})
+	})
+
+	describe('when the process exports nothing at all', () => {
+		it('should say so rather than look like a healthy one', () => {
+			// GIVEN local development, with no endpoint configured
+			// WHEN the response is encoded
+			const exit = encode({
+				...healthy,
+				telemetry: {
+					exporting: false,
+					signals: {
+						traces: { failing: false },
+						logs: { failing: false },
+						metrics: { failing: false },
+					},
+				},
+			})
+
+			// THEN it is accepted, and `exporting` is what tells the two apart
+			expect(exit._tag).toBe('Success')
+		})
+	})
+
+	describe('when a reason outside the known set is reported', () => {
+		it('should be rejected', () => {
+			// GIVEN a reason carrying something the backend said, rather than one of
+			//       ours — the shape that would leak wording derived from a request
+			//       whose headers hold the API key
+			// WHEN the response is encoded
+			const exit = encode({
+				...healthy,
+				telemetry: {
+					exporting: true,
+					signals: {
+						traces: { failing: true, failure: 'unknown API key abcd1234' },
+						logs: { failing: false },
+						metrics: { failing: false },
+					},
+				},
+			})
+
+			// THEN the wire format refuses it
+			expect(exit._tag).toBe('Failure')
+		})
+	})
+
+	describe('whatever the state', () => {
+		it('should carry no backend host and no status line', () => {
+			// GIVEN a report that tries to add both
+			// WHEN the response is encoded
+			const exit = encode({
+				...healthy,
+				telemetry: {
+					exporting: true,
+					endpoint: 'api.eu1.honeycomb.io',
+					signals: {
+						traces: { failing: true, failure: 'rejected', status: 500 },
+						logs: { failing: false },
+						metrics: { failing: false },
+					},
+				},
+			})
+
+			// THEN neither survives: an unauthenticated endpoint names no vendor and
+			//      no status
+			expect(exit._tag).toBe('Success')
+			const encoded = JSON.stringify(exit)
+			expect(encoded).not.toContain('honeycomb')
+			expect(encoded).not.toContain('500')
+		})
+	})
+})

--- a/packages/controllers/src/routes/health.ts
+++ b/packages/controllers/src/routes/health.ts
@@ -1,11 +1,50 @@
 import { Schema } from 'effect'
 import { HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
 
-const HealthResponse = Schema.Struct({
+/**
+ * What one kind of telemetry is doing. `failing` means the last batch was
+ * refused or never answered and has stayed that way — not that nothing has been
+ * sent lately, which is the ordinary state of a quiet service.
+ */
+const SignalReport = Schema.Struct({
+	failing: Schema.Boolean,
+	failure: Schema.optional(
+		Schema.Literals([
+			'unauthorized',
+			'rate_limited',
+			'rejected',
+			'unreachable',
+		]),
+	),
+	lastSuccessAt: Schema.optional(Schema.Number),
+})
+
+/**
+ * Whether this process is still reaching its telemetry backend.
+ *
+ * Reported here as well as on the console because a process that cannot export
+ * cannot say so through the thing it exports to — and the console of a deployed
+ * instance is not always reachable. One request answers it from anywhere.
+ *
+ * No backend host, no vendor wording, no status line: this endpoint is served
+ * without authentication, and the reason alone is enough to tell a rejected key
+ * from a quota from a dead route.
+ */
+const TelemetryReport = Schema.Struct({
+	exporting: Schema.Boolean,
+	signals: Schema.Struct({
+		traces: SignalReport,
+		logs: SignalReport,
+		metrics: SignalReport,
+	}),
+})
+
+export const HealthResponse = Schema.Struct({
 	status: Schema.String,
 	version: Schema.String,
 	commit: Schema.String,
 	region: Schema.String,
+	telemetry: TelemetryReport,
 })
 
 export const HealthGroup = HttpApiGroup.make('health').add(

--- a/packages/observability/src/export-health.test.ts
+++ b/packages/observability/src/export-health.test.ts
@@ -1,0 +1,385 @@
+// This record decides whether the process says telemetry is broken, so the
+// cases that matter most are the ones where it must stay quiet: a quiet service
+// exports nothing on two of its three signals, and anything reading "no export
+// lately" as "export is broken" would cry wolf every night.
+
+import { createServer, type Server } from 'node:http'
+
+import { Duration, Effect } from 'effect'
+import {
+	FetchHttpClient,
+	HttpClient,
+	HttpClientRequest,
+} from 'effect/unstable/http'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	type ExportHealth,
+	exportReport,
+	failingSignals,
+	isFailing,
+	makeExportHealth,
+	observingHttpClient,
+} from './export-health'
+
+// A backend under the test's control: `status` picks what it answers with, and
+// a `hang` request is accepted and then left open, which is the failure the
+// exporter cannot see on its own.
+let status = 200
+let server: Server
+let origin: string
+const hungSockets: Array<import('node:net').Socket> = []
+
+const startSink = () =>
+	new Promise<Server>(resolve => {
+		const created = createServer((request, response) => {
+			request.resume()
+			request.on('end', () => {
+				if (request.url?.includes('hang') === true) {
+					hungSockets.push(request.socket)
+					return
+				}
+				response.writeHead(status)
+				response.end('{}')
+			})
+		})
+		created.listen(0, '127.0.0.1', () => resolve(created))
+	})
+
+/** Posts once through the wrapped client and records however it turned out. */
+const post = (url: string, health: ExportHealth, timeout: Duration.Duration) =>
+	Effect.gen(function* () {
+		const inner = yield* HttpClient.HttpClient
+		const client = observingHttpClient(inner, health, timeout)
+		yield* client.execute(HttpClientRequest.post(url))
+	}).pipe(
+		Effect.catchCause(() => Effect.void),
+		Effect.provide(FetchHttpClient.layer),
+		Effect.runPromise,
+	)
+
+const second = Duration.seconds(1)
+
+describe('the export health record', () => {
+	beforeAll(async () => {
+		server = await startSink()
+		const address = server.address()
+		if (address === null || typeof address === 'string')
+			throw new Error('expected a TCP address for the sink')
+		origin = `http://127.0.0.1:${address.port}`
+	}, 30_000)
+
+	afterAll(async () => {
+		for (const socket of hungSockets) socket.destroy()
+		server.closeAllConnections()
+		await new Promise(resolve => server.close(resolve))
+	})
+
+	describe('when the backend accepts a batch', () => {
+		it('should record the success and clear the failing streak', async () => {
+			// GIVEN a signal that has already failed twice
+			const health = makeExportHealth()
+			health.recordFailure('traces', 'rejected', 500, 1_000)
+			health.recordFailure('traces', 'rejected', 500, 2_000)
+
+			// WHEN the next attempt is accepted
+			status = 200
+			await post(`${origin}/v1/traces`, health, second)
+
+			// THEN the streak is gone and the success is dated
+			const traces = health.snapshot().traces
+			expect(traces.failingSince).toBeUndefined()
+			expect(traces.consecutiveFailures).toBe(0)
+			expect(traces.failure).toBeUndefined()
+			expect(traces.lastSuccessAt).toBeTypeOf('number')
+		})
+	})
+
+	describe('when the backend refuses a batch', () => {
+		it('should call a rejected key unauthorized and keep the status', async () => {
+			// GIVEN a backend that answers 401 — a missing or revoked API key
+			const health = makeExportHealth()
+			status = 401
+
+			// WHEN a batch of traces is posted
+			await post(`${origin}/v1/traces`, health, second)
+
+			// THEN the reason names the key, and the status is kept alongside it
+			const traces = health.snapshot().traces
+			expect(traces.failure).toBe('unauthorized')
+			expect(traces.status).toBe(401)
+			expect(traces.consecutiveFailures).toBe(1)
+			expect(traces.failingSince).toBeTypeOf('number')
+		})
+
+		it('should call a forbidden key unauthorized too', async () => {
+			// GIVEN a backend that answers 403 — a key that exists but is not
+			//       allowed to write here
+			const health = makeExportHealth()
+			status = 403
+
+			// WHEN a batch of traces is posted
+			await post(`${origin}/v1/traces`, health, second)
+
+			// THEN it lands in the same bucket as a rejected key: the fix is the
+			//      same either way
+			expect(health.snapshot().traces.failure).toBe('unauthorized')
+		})
+
+		it('should call a 429 rate limited', async () => {
+			// GIVEN a backend that answers 429 — over quota, or too fast
+			const health = makeExportHealth()
+			status = 429
+
+			// WHEN a batch of logs is posted
+			await post(`${origin}/v1/logs`, health, second)
+
+			// THEN the reason says so
+			expect(health.snapshot().logs.failure).toBe('rate_limited')
+		})
+
+		it('should call anything else it refused rejected', async () => {
+			// GIVEN a backend that answers 500
+			const health = makeExportHealth()
+			status = 500
+
+			// WHEN a batch of metrics is posted
+			await post(`${origin}/v1/metrics`, health, second)
+
+			// THEN the reason falls back to a plain refusal, with the status
+			const metrics = health.snapshot().metrics
+			expect(metrics.failure).toBe('rejected')
+			expect(metrics.status).toBe(500)
+		})
+	})
+
+	describe('when the backend cannot be reached at all', () => {
+		it('should record it as unreachable', async () => {
+			// GIVEN nothing listening on the port
+			const health = makeExportHealth()
+
+			// WHEN a batch is posted to it
+			await post('http://127.0.0.1:1/v1/traces', health, second)
+
+			// THEN it is unreachable, with no status to report
+			const traces = health.snapshot().traces
+			expect(traces.failure).toBe('unreachable')
+			expect(traces.status).toBeUndefined()
+		})
+
+		it('should give up on a connection that is accepted and never answered', async () => {
+			// GIVEN a backend that takes the request and then goes quiet — the case
+			//       the exporter waits out for minutes without noticing
+			const health = makeExportHealth()
+
+			// WHEN a batch is posted with a deadline
+			await post(`${origin}/v1/traces?hang=1`, health, Duration.millis(100))
+
+			// THEN the deadline turns the silence into an ordinary failure
+			expect(health.snapshot().traces.failure).toBe('unreachable')
+		}, 15_000)
+	})
+
+	describe('when the configured endpoint already carries a query string', () => {
+		it('should still tell which signal the batch belonged to', async () => {
+			// GIVEN the URL the exporter builds in that case: it appends the signal
+			//       name to the whole configured value, so the name lands inside the
+			//       query rather than at the end of the path
+			const health = makeExportHealth()
+			status = 401
+
+			// WHEN a batch goes out to it
+			await post(`${origin}/otlp?api-key=redacted/v1/traces`, health, second)
+
+			// THEN it is recorded against traces. Reading the parsed path instead
+			//      would find no signal here and record nothing at all, leaving a
+			//      dead backend looking healthy.
+			expect(health.snapshot().traces.failure).toBe('unauthorized')
+		})
+	})
+
+	describe('when one signal fails while another is accepted', () => {
+		it('should report them independently', async () => {
+			// GIVEN a backend that refuses everything
+			const health = makeExportHealth()
+			status = 401
+			await post(`${origin}/v1/traces`, health, second)
+
+			// WHEN it starts accepting, and only logs are posted
+			status = 200
+			await post(`${origin}/v1/logs`, health, second)
+
+			// THEN traces is still failing and logs is not
+			const snapshot = health.snapshot()
+			expect(snapshot.traces.failure).toBe('unauthorized')
+			expect(snapshot.logs.failure).toBeUndefined()
+		})
+	})
+
+	describe('when failures follow one another', () => {
+		it('should date the streak from where it began, not from the last try', () => {
+			// GIVEN a signal failing since the first of three attempts
+			const health = makeExportHealth()
+			health.recordFailure('traces', 'unauthorized', 401, 1_000)
+			health.recordFailure('traces', 'unauthorized', 401, 2_000)
+			health.recordFailure('traces', 'unauthorized', 401, 3_000)
+
+			// THEN the streak is measured from the first, and counts them all
+			const traces = health.snapshot().traces
+			expect(traces.failingSince).toBe(1_000)
+			expect(traces.consecutiveFailures).toBe(3)
+		})
+	})
+})
+
+describe('deciding whether a signal is worth complaining about', () => {
+	describe('when a signal has been failing for longer than the grace period', () => {
+		it('should say so', () => {
+			// GIVEN a signal failing since the start
+			const health = makeExportHealth()
+			health.recordFailure('traces', 'unauthorized', 401, 0)
+
+			// THEN once the grace period has passed it counts as failing
+			expect(
+				isFailing(health.snapshot().traces, 120_000, Duration.minutes(2)),
+			).toBe(true)
+		})
+
+		it('should stay quiet until the grace period has actually passed', () => {
+			// GIVEN the same signal one millisecond short of the grace period
+			const health = makeExportHealth()
+			health.recordFailure('traces', 'unauthorized', 401, 0)
+
+			// THEN it is not yet worth a line
+			expect(
+				isFailing(health.snapshot().traces, 119_999, Duration.minutes(2)),
+			).toBe(false)
+		})
+	})
+
+	describe('when a signal has never been tried', () => {
+		it('should not read as failing', () => {
+			// GIVEN a process that has exported nothing at all yet
+			const health = makeExportHealth()
+
+			// THEN no signal is failing, however long it has been
+			expect(
+				failingSignals(health.snapshot(), 86_400_000, Duration.minutes(2)),
+			).toEqual([])
+		})
+	})
+
+	describe('when a signal is idle after a success', () => {
+		it('should stay healthy however long it has been quiet', () => {
+			// GIVEN a signal that exported once and has had nothing to say since —
+			//       a quiet service, not a broken one
+			const health = makeExportHealth()
+			health.recordSuccess('traces', 1_000)
+
+			// THEN a day later it is still not failing
+			expect(
+				failingSignals(health.snapshot(), 86_400_000, Duration.minutes(2)),
+			).toEqual([])
+		})
+	})
+
+	describe('when a signal recovers', () => {
+		it('should stop reading as failing straight away', () => {
+			// GIVEN a signal that has been failing well past the grace period
+			const health = makeExportHealth()
+			health.recordFailure('traces', 'rate_limited', 429, 0)
+			expect(
+				isFailing(health.snapshot().traces, 300_000, Duration.minutes(2)),
+			).toBe(true)
+
+			// WHEN a batch is accepted
+			health.recordSuccess('traces', 300_000)
+
+			// THEN it is healthy again without waiting anything out
+			expect(
+				isFailing(health.snapshot().traces, 300_001, Duration.minutes(2)),
+			).toBe(false)
+		})
+	})
+
+	describe('when asked what to report from outside', () => {
+		it('should say a process with export switched off is not exporting', () => {
+			// GIVEN a process with no endpoint configured
+			const health = makeExportHealth()
+			health.setExporting(false)
+
+			// THEN it says so, rather than looking like one with nothing to send
+			const report = exportReport(health, 200_000)
+			expect(report.exporting).toBe(false)
+			expect(report.signals.traces.failing).toBe(false)
+		})
+
+		it('should say a process that has sent nothing yet is exporting fine', () => {
+			// GIVEN export configured, and a service quiet since it started
+			const health = makeExportHealth()
+			health.setExporting(true)
+
+			// THEN it is exporting, and nothing is held against any signal
+			const report = exportReport(health, 86_400_000)
+			expect(report.exporting).toBe(true)
+			expect(report.signals.traces.failing).toBe(false)
+			expect(report.signals.logs.failing).toBe(false)
+			expect(report.signals.metrics.failing).toBe(false)
+		})
+
+		it('should name the reason for a signal that has been failing', () => {
+			// GIVEN traces refused since boot, past the grace period
+			const health = makeExportHealth()
+			health.setExporting(true)
+			health.recordFailure('traces', 'unauthorized', 401, 0)
+
+			// THEN that signal is failing and says why, and the others are not
+			const report = exportReport(health, 200_000)
+			expect(report.signals.traces.failing).toBe(true)
+			expect(report.signals.traces.failure).toBe('unauthorized')
+			expect(report.signals.logs.failing).toBe(false)
+		})
+
+		it('should hold back on a signal that has only just started failing', () => {
+			// GIVEN a single refused batch a moment ago — a blip, not an outage
+			const health = makeExportHealth()
+			health.setExporting(true)
+			health.recordFailure('traces', 'rejected', 503, 190_000)
+
+			// THEN it is not called failing yet, though the reason is already there
+			const report = exportReport(health, 200_000)
+			expect(report.signals.traces.failing).toBe(false)
+			expect(report.signals.traces.failure).toBe('rejected')
+		})
+
+		it('should carry no status line and no backend host', () => {
+			// GIVEN a signal refused with a status the backend chose
+			const health = makeExportHealth()
+			health.setExporting(true)
+			health.recordFailure('traces', 'rejected', 503, 0)
+
+			// THEN what goes out names the reason and nothing else about the call
+			const report = exportReport(health, 200_000)
+			expect(Object.keys(report).sort()).toEqual(['exporting', 'signals'])
+			expect(Object.keys(report.signals.traces).sort()).toEqual([
+				'failing',
+				'failure',
+			])
+		})
+	})
+
+	describe('when several signals are failing', () => {
+		it('should name each of them', () => {
+			// GIVEN traces and metrics failing while logs is fine
+			const health = makeExportHealth()
+			health.recordFailure('traces', 'unauthorized', 401, 0)
+			health.recordFailure('metrics', 'unreachable', undefined, 0)
+			health.recordSuccess('logs', 0)
+
+			// THEN both are named, in a stable order
+			expect(
+				failingSignals(health.snapshot(), 200_000, Duration.minutes(2)),
+			).toEqual(['traces', 'metrics'])
+		})
+	})
+})

--- a/packages/observability/src/export-health.ts
+++ b/packages/observability/src/export-health.ts
@@ -1,0 +1,300 @@
+import { Clock, Duration, Effect } from 'effect'
+import { HttpClient, HttpClientError } from 'effect/unstable/http'
+
+/**
+ * The three kinds of telemetry, each posted to its own path under the base URL.
+ * They fail independently — a backend can take our logs and refuse our traces —
+ * so each is tracked on its own rather than behind one "is export working" flag.
+ */
+export type ExportSignal = 'traces' | 'logs' | 'metrics'
+
+export const exportSignals: ReadonlyArray<ExportSignal> = [
+	'traces',
+	'logs',
+	'metrics',
+]
+
+/**
+ * Why a batch did not land, in the few kinds worth telling apart when deciding
+ * what to do about it.
+ *
+ * A closed set on purpose: keeping whatever the backend said would hand back
+ * text derived from our own request, and that request carries the API key in a
+ * header. A fixed set is safe to write anywhere without reading it first.
+ */
+export type ExportFailure =
+	| 'unauthorized'
+	| 'rate_limited'
+	| 'rejected'
+	| 'unreachable'
+
+export interface SignalHealth {
+	readonly lastAttemptAt: number | undefined
+	readonly lastSuccessAt: number | undefined
+	/**
+	 * When the current run of failures started, cleared by any success. Present
+	 * means the last attempt failed — a different question from "how long since
+	 * something arrived".
+	 */
+	readonly failingSince: number | undefined
+	readonly consecutiveFailures: number
+	readonly failure: ExportFailure | undefined
+	readonly status: number | undefined
+}
+
+export type ExportSnapshot = Readonly<Record<ExportSignal, SignalHealth>>
+
+export interface ExportHealth {
+	readonly recordSuccess: (signal: ExportSignal, at: number) => void
+	readonly recordFailure: (
+		signal: ExportSignal,
+		failure: ExportFailure,
+		status: number | undefined,
+		at: number,
+	) => void
+	/**
+	 * Whether this process is set up to export at all. Not something the attempts
+	 * can answer: a process with export switched off and one that simply has
+	 * nothing to send both make no attempts.
+	 */
+	readonly setExporting: (exporting: boolean) => void
+	readonly snapshot: () => ExportSnapshot
+	readonly exporting: () => boolean
+}
+
+const untried: SignalHealth = {
+	lastAttemptAt: undefined,
+	lastSuccessAt: undefined,
+	failingSince: undefined,
+	consecutiveFailures: 0,
+	failure: undefined,
+	status: undefined,
+}
+
+/**
+ * A running tally of how the last export attempt on each signal went.
+ *
+ * Deliberately plain and mutable: it is written from inside the export path,
+ * where anything that allocates or suspends is paid for on every batch.
+ */
+export const makeExportHealth = (): ExportHealth => {
+	const state: Record<ExportSignal, SignalHealth> = {
+		traces: untried,
+		logs: untried,
+		metrics: untried,
+	}
+	let exporting = false
+
+	return {
+		setExporting: next => {
+			exporting = next
+		},
+		exporting: () => exporting,
+		recordSuccess: (signal, at) => {
+			state[signal] = {
+				lastAttemptAt: at,
+				lastSuccessAt: at,
+				failingSince: undefined,
+				consecutiveFailures: 0,
+				failure: undefined,
+				status: undefined,
+			}
+		},
+		recordFailure: (signal, failure, status, at) => {
+			const previous = state[signal]
+			state[signal] = {
+				lastAttemptAt: at,
+				lastSuccessAt: previous.lastSuccessAt,
+				// Kept from the previous failure so the run is measured from where it
+				// began, not from the most recent attempt in it.
+				failingSince: previous.failingSince ?? at,
+				consecutiveFailures: previous.consecutiveFailures + 1,
+				failure,
+				status,
+			}
+		},
+		snapshot: () => ({ ...state }),
+	}
+}
+
+/**
+ * The record for this process, shared by everything that reports on it. A
+ * single value rather than a service, like `buildMeta` beside it: both are
+ * facts about the running process that outlive any one layer, and a service
+ * would have to exist even in the processes that export nothing.
+ */
+export const exportHealth: ExportHealth = makeExportHealth()
+
+/**
+ * Whether a signal has been failing long enough to be worth saying out loud.
+ *
+ * Reads "the last attempt failed and has kept failing", never "nothing has
+ * arrived lately": the exporter skips an empty batch, so a quiet process sends
+ * no logs or traces at all and a staleness test would call it broken. Metrics
+ * posts every interval regardless, so a genuinely dead channel still shows.
+ */
+export const isFailing = (
+	state: SignalHealth,
+	now: number,
+	after: Duration.Duration,
+): boolean =>
+	state.failingSince !== undefined &&
+	now - state.failingSince >= Duration.toMillis(after)
+
+/** Which signals in a snapshot have been failing for longer than `after`. */
+export const failingSignals = (
+	snapshot: ExportSnapshot,
+	now: number,
+	after: Duration.Duration,
+): ReadonlyArray<ExportSignal> =>
+	exportSignals.filter(signal => isFailing(snapshot[signal], now, after))
+
+/**
+ * How long a run of failures has to last before it counts: long enough that one
+ * refused batch during a blip is not news, short enough to hear about it while
+ * it still matters. Keep it comfortably above the slowest signal's export
+ * interval, so a channel has had more than one chance to prove it is down.
+ */
+export const defaultFailingAfter: Duration.Duration = Duration.minutes(2)
+
+export interface SignalReport {
+	readonly failing: boolean
+	readonly failure?: ExportFailure
+	readonly lastSuccessAt?: number
+}
+
+export interface ExportReport {
+	readonly exporting: boolean
+	readonly signals: Readonly<Record<ExportSignal, SignalReport>>
+}
+
+/**
+ * What this process would say about its own telemetry if asked from outside.
+ *
+ * Carries the reason but not the backend's own words, the host, or the status
+ * line: this is read without authentication, and the closed set of reasons is
+ * enough to tell a rejected key from a quota from a dead route.
+ */
+const reportOf = (state: SignalHealth, now: number): SignalReport => ({
+	failing: isFailing(state, now, defaultFailingAfter),
+	...(state.failure === undefined ? {} : { failure: state.failure }),
+	...(state.lastSuccessAt === undefined
+		? {}
+		: { lastSuccessAt: state.lastSuccessAt }),
+})
+
+export const exportReport = (
+	health: ExportHealth,
+	now: number,
+): ExportReport => {
+	const snapshot = health.snapshot()
+	// Written out rather than built from the list of signals: building it needs a
+	// cast to claim all three keys are there, and a cast would let a dropped
+	// signal go out missing from the report with nothing complaining.
+	return {
+		exporting: health.exporting(),
+		signals: {
+			traces: reportOf(snapshot.traces, now),
+			logs: reportOf(snapshot.logs, now),
+			metrics: reportOf(snapshot.metrics, now),
+		},
+	}
+}
+
+const failureOfStatus = (status: number): ExportFailure => {
+	if (status === 401 || status === 403) return 'unauthorized'
+	if (status === 429) return 'rate_limited'
+	return 'rejected'
+}
+
+/**
+ * Whether a URL is the one the exporter posts this signal to.
+ *
+ * Checked against the whole URL as well as against it with any query stripped,
+ * because the signal name can land on either side of a `?`. The exporter
+ * appends the name to whatever the endpoint is configured as, so a base that
+ * already carries a query leaves the name inside that query rather than at the
+ * end of the path. Testing only the path would recognise no signal there and
+ * record nothing at all — a dead backend reading as a healthy one, which is the
+ * outcome this whole file exists to prevent.
+ */
+const posts = (url: string, signalPath: string): boolean =>
+	url.endsWith(signalPath) || (url.split('?')[0] ?? url).endsWith(signalPath)
+
+const signalOfUrl = (url: string): ExportSignal | undefined => {
+	if (posts(url, '/v1/traces')) return 'traces'
+	if (posts(url, '/v1/logs')) return 'logs'
+	if (posts(url, '/v1/metrics')) return 'metrics'
+	return undefined
+}
+
+/**
+ * Wraps the client the OTLP exporter posts through, so every batch leaves a
+ * record of how it went — and so a hung connection cannot pass for a healthy
+ * one.
+ *
+ * The exporter reports a refused batch at debug level and nothing else, which a
+ * process running at info drops before any logger sees it. It also sets no
+ * deadline, so a backend that takes the data and never answers ties the batch
+ * up for the HTTP library's five-minute ceiling — minutes in which the exporter
+ * believes it is still in flight, never trips its back-off and says nothing.
+ * `timeout` turns that silence into an ordinary transport failure.
+ *
+ * Records only, never logs: this runs on every attempt of every retry of all
+ * three signals, so a line written here would arrive several times a second
+ * while a backend is down.
+ */
+export const observingHttpClient = (
+	client: HttpClient.HttpClient,
+	health: ExportHealth,
+	timeout: Duration.Duration,
+): HttpClient.HttpClient =>
+	HttpClient.transform(client, (effect, request) => {
+		const deadlined = effect.pipe(
+			Effect.timeout(timeout),
+			// Back to a transport failure, the shape the caller already has: a
+			// widened error channel here would no longer be an `HttpClient`.
+			Effect.catchTag('TimeoutError', () =>
+				Effect.fail(
+					new HttpClientError.HttpClientError({
+						reason: new HttpClientError.TransportError({
+							request,
+							description: 'timed out waiting for the telemetry backend',
+						}),
+					}),
+				),
+			),
+		)
+
+		// The deadline is applied above whatever this is, so a post that cannot be
+		// tied to a signal still cannot hang; only the recording needs to know
+		// which signal it belongs to.
+		const signal = signalOfUrl(request.url)
+		if (signal === undefined) return deadlined
+
+		return deadlined.pipe(
+			Effect.tap(response =>
+				Effect.map(Clock.currentTimeMillis, at => {
+					// Read below `filterStatusOk`, which the exporter applies on top of
+					// this client — so the real status arrives here, refusals included.
+					if (response.status >= 200 && response.status < 300)
+						health.recordSuccess(signal, at)
+					else
+						health.recordFailure(
+							signal,
+							failureOfStatus(response.status),
+							response.status,
+							at,
+						)
+				}),
+			),
+			// A post cut short by the process shutting down is not recorded as a
+			// failure: an interrupted fiber never runs this handler, so the last
+			// thing a process does on its way out cannot leave it looking broken.
+			Effect.tapCause(() =>
+				Effect.map(Clock.currentTimeMillis, at =>
+					health.recordFailure(signal, 'unreachable', undefined, at),
+				),
+			),
+		)
+	})

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -4,7 +4,28 @@
 
 export { boundedCause } from './bounded-cause'
 export { buildMeta } from './build-meta'
-export { makeOtlpObservability } from './otlp'
+export {
+	defaultFailingAfter,
+	type ExportFailure,
+	type ExportHealth,
+	type ExportReport,
+	type ExportSignal,
+	type ExportSnapshot,
+	exportHealth,
+	exportReport,
+	exportSignals,
+	failingSignals,
+	isFailing,
+	makeExportHealth,
+	observingHttpClient,
+	type SignalHealth,
+	type SignalReport,
+} from './export-health'
+export {
+	type ExportCadence,
+	endpointOf,
+	makeOtlpObservability,
+} from './otlp'
 export {
 	makeWorkRecord,
 	recordFacts,

--- a/packages/observability/src/otlp.test.ts
+++ b/packages/observability/src/otlp.test.ts
@@ -1,5 +1,6 @@
-// Covers the one thing about this layer that can be got wrong without anything
-// failing: how a process composes it.
+// Covers the two things about this layer that can be got wrong without anything
+// failing: how a process composes it, and whether the process notices when what
+// it composed stops working.
 //
 // The exporter installs itself by putting a logger and a tracer into the context
 // it is built into. A process that provides it without merging it back still
@@ -8,18 +9,34 @@
 // already had, so nothing is ever sent. The mail-worker sat like that: alive,
 // logging every few seconds, and absent from the vendor for good.
 //
+// The second is a backend that refuses every batch. The exporter reports that
+// at Debug and both services run at Info, so the runtime drops the line before
+// a logger sees it — a process that exports nothing looks like one exporting
+// fine. These watch for the line that has to be written instead, and for it
+// being written once rather than on every attempt.
+//
 // So this asserts the whole path for real, against a local sink rather than a
 // vendor: compose it the way a process must, write one line, and watch the line
-// leave.
+// leave — or watch the process say why it did not.
 
 import { createServer, type Server } from 'node:http'
 
-import { Effect, Layer, ManagedRuntime } from 'effect'
+import {
+	ConfigProvider,
+	Duration,
+	Effect,
+	Layer,
+	Logger,
+	ManagedRuntime,
+	References,
+} from 'effect'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { makeOtlpObservability } from './otlp'
+import { exportHealth, exportReport, makeExportHealth } from './export-health'
+import { endpointOf, makeOtlpObservability } from './otlp'
 
 const paths: Array<string> = []
+let status = 200
 let server: Server
 let endpoint: string
 
@@ -29,7 +46,7 @@ const sink = () =>
 			request.resume()
 			request.on('end', () => {
 				if (request.url !== undefined) paths.push(request.url)
-				response.writeHead(200, { 'content-type': 'application/json' })
+				response.writeHead(status, { 'content-type': 'application/json' })
 				response.end('{}')
 			})
 		})
@@ -44,6 +61,90 @@ const reached = async (path: string, within: number) => {
 	}
 	return paths.includes(path)
 }
+
+/** Keeps every line the process writes, with the `event` it was tagged with. */
+const recorder = () => {
+	const lines: Array<{
+		readonly event: unknown
+		readonly level: string
+		readonly annotations: Readonly<Record<string, unknown>>
+	}> = []
+	const logger = Logger.make<unknown, void>(options => {
+		const annotations = options.fiber.getRef(References.CurrentLogAnnotations)
+		lines.push({
+			event: annotations['event'],
+			level: options.logLevel,
+			annotations,
+		})
+	})
+	return { lines, layer: Logger.layer([logger]) }
+}
+
+const events = <Line extends { readonly event: unknown }>(
+	lines: ReadonlyArray<Line>,
+	event: string,
+): ReadonlyArray<Line> => lines.filter(line => line.event === event)
+
+const settle = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null
+
+/**
+ * Every value reported about every signal, flattened. A logger is handed its
+ * annotations as `unknown`, so the shape is checked rather than asserted —
+ * anything that is not the nested record this expects flattens to nothing, and
+ * the count the caller checks fails instead of passing on a wrong shape.
+ */
+const reportedValues = (signals: unknown): ReadonlyArray<unknown> =>
+	isRecord(signals)
+		? Object.values(signals).flatMap(detail =>
+				isRecord(detail) ? Object.values(detail) : [detail],
+			)
+		: []
+
+// Short enough that a test does not wait out a real interval. `failingAfter` is
+// zero so the first check after a refused batch is enough; the heartbeat is
+// pushed out of the way except where it is the thing being asserted.
+const brisk = {
+	requestTimeout: Duration.seconds(2),
+	checkEvery: Duration.millis(100),
+	failingAfter: Duration.zero,
+	heartbeatEvery: Duration.minutes(10),
+}
+
+describe('naming the endpoint on a log line', () => {
+	describe('when the endpoint carries a path', () => {
+		it('should keep it, because a wrong path is what this line is for', () => {
+			// GIVEN a backend reached below a path
+			// THEN the path survives, so a wrong one is visible
+			expect(endpointOf('https://api.eu1.honeycomb.io/otlp')).toBe(
+				'https://api.eu1.honeycomb.io/otlp',
+			)
+		})
+	})
+
+	describe('when the endpoint carries a query string', () => {
+		it('should drop it, since that is where a key would hide', () => {
+			// GIVEN a backend that takes its key in the URL rather than a header
+			// THEN nothing after the path is written down
+			expect(
+				endpointOf('https://collector.example.com/v1?api-key=sekrit'),
+			).toBe('https://collector.example.com/v1')
+		})
+	})
+
+	describe('when the endpoint cannot be parsed', () => {
+		it('should say so without repeating it back', () => {
+			// GIVEN a setting that is not a URL at all
+			const named = endpointOf('not a url ?key=sekrit')
+
+			// THEN the line reports the problem and none of the value
+			expect(named).toContain('unparseable')
+			expect(named).not.toContain('sekrit')
+		})
+	})
+})
 
 describe('the OTLP observability layer', () => {
 	beforeAll(async () => {
@@ -75,6 +176,7 @@ describe('the OTLP observability layer', () => {
 			)
 			const runtime = ManagedRuntime.make(Live)
 			paths.length = 0
+			status = 200
 
 			// WHEN the process writes a line
 			await runtime.runPromise(Effect.logInfo('a line worth exporting'))
@@ -84,6 +186,207 @@ describe('the OTLP observability layer', () => {
 
 			// THEN the line reaches the endpoint
 			expect(await reached('/v1/logs', 5_000)).toBe(true)
+			// AND the process's own record says it is exporting, which is what the
+			//     health check reads — this build passed no record of its own, so
+			//     this is the one the deployed processes use
+			expect(exportReport(exportHealth, Date.now()).exporting).toBe(true)
+		}, 30_000)
+	})
+
+	describe('when the backend refuses every batch', () => {
+		it('should say so once, not once per attempt', async () => {
+			// GIVEN a backend answering 401 to everything
+			const log = recorder()
+			const runtime = ManagedRuntime.make(
+				Layer.empty.pipe(
+					Layer.provideMerge(
+						makeOtlpObservability({
+							serviceName: 'observability-test',
+							cadence: brisk,
+							health: makeExportHealth(),
+						}),
+					),
+					Layer.provide(log.layer),
+				),
+			)
+			paths.length = 0
+			status = 401
+
+			try {
+				// WHEN the process writes lines for long enough that batches go out and
+				//      are refused
+				await runtime.runPromise(Effect.logInfo('one'))
+				await settle(1_500)
+				await runtime.runPromise(Effect.logInfo('two'))
+				await settle(1_500)
+
+				// THEN it complained exactly once, however many batches were refused
+				expect(events(log.lines, 'otlp.export.failing')).toHaveLength(1)
+				// AND loudly enough to survive a production log level
+				expect(events(log.lines, 'otlp.export.failing')[0]?.level).toBe('Error')
+				// AND what it says about each signal carries no empty field: the
+				//     console formatter prints those as the word `undefined`, which
+				//     is not something a reader can parse back
+				const values = reportedValues(
+					events(log.lines, 'otlp.export.failing')[0]?.annotations['signals'],
+				)
+				expect(values.length).toBeGreaterThan(0)
+				expect(values).not.toContain(undefined)
+			} finally {
+				await runtime.dispose()
+			}
+		}, 30_000)
+	})
+
+	describe('when export breaks and later comes back', () => {
+		// The health record is driven by hand here rather than through the sink:
+		// the exporter stops trying for a full minute after a refused batch, so a
+		// test that waited for it to retry would have to wait that minute out. What
+		// is under test is the watchdog's reading of the record, which is the part
+		// that decides whether anything gets said at all.
+		it('should say each of those exactly once', async () => {
+			// GIVEN a process whose export health the test drives directly
+			const log = recorder()
+			const health = makeExportHealth()
+			const runtime = ManagedRuntime.make(
+				Layer.empty.pipe(
+					Layer.provideMerge(
+						makeOtlpObservability({
+							serviceName: 'observability-test',
+							cadence: brisk,
+							health,
+						}),
+					),
+					Layer.provide(log.layer),
+				),
+			)
+			paths.length = 0
+			status = 200
+
+			try {
+				await runtime.runPromise(Effect.void)
+
+				// WHEN export starts failing, and keeps failing
+				health.recordFailure('traces', 'unauthorized', 401, Date.now())
+				await settle(400)
+				health.recordFailure('traces', 'unauthorized', 401, Date.now())
+				await settle(400)
+
+				// THEN it was reported once, not once per failure
+				expect(events(log.lines, 'otlp.export.failing')).toHaveLength(1)
+				expect(events(log.lines, 'otlp.export.recovered')).toHaveLength(0)
+
+				// WHEN a batch is accepted again
+				health.recordSuccess('traces', Date.now())
+				await settle(400)
+
+				// THEN the recovery is announced once, and the complaint is not
+				//      repeated
+				expect(events(log.lines, 'otlp.export.recovered')).toHaveLength(1)
+				expect(events(log.lines, 'otlp.export.failing')).toHaveLength(1)
+			} finally {
+				await runtime.dispose()
+			}
+		}, 30_000)
+	})
+
+	describe('when the process has nothing to export', () => {
+		it('should stay quiet rather than report the silence as a failure', async () => {
+			// GIVEN a healthy backend and a process that writes nothing — the state
+			//       every service is in overnight
+			const log = recorder()
+			const runtime = ManagedRuntime.make(
+				Layer.empty.pipe(
+					Layer.provideMerge(
+						makeOtlpObservability({
+							serviceName: 'observability-test',
+							cadence: brisk,
+							health: makeExportHealth(),
+						}),
+					),
+					Layer.provide(log.layer),
+				),
+			)
+			paths.length = 0
+			status = 200
+
+			try {
+				// WHEN it sits idle for longer than several export intervals
+				await settle(2_000)
+
+				// THEN nothing was posted on the signals that skip an empty batch —
+				//      the reason a test for staleness would call this broken
+				expect(paths).not.toContain('/v1/traces')
+				// AND the process did not complain
+				expect(events(log.lines, 'otlp.export.failing')).toHaveLength(0)
+			} finally {
+				await runtime.dispose()
+			}
+		}, 30_000)
+	})
+
+	describe('when no endpoint is configured', () => {
+		// A config provider rather than an edit to `process.env`: the default
+		// provider copies the environment once, the first time anything reads
+		// config, so a variable set part-way through a run is never seen.
+		const withEnv = (
+			env: Record<string, string>,
+			log: ReturnType<typeof recorder>,
+		) =>
+			ManagedRuntime.make(
+				Layer.empty.pipe(
+					Layer.provideMerge(
+						makeOtlpObservability({
+							serviceName: 'observability-test',
+							cadence: { ...brisk, heartbeatEvery: Duration.millis(200) },
+							// Its own record, so building a layer with export off here
+							// cannot leave the process-wide one saying so for whichever
+							// test runs next.
+							health: makeExportHealth(),
+						}),
+					),
+					Layer.provide(log.layer),
+					Layer.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))),
+				),
+			)
+
+		it('should be loud about it in production, and still report its state', async () => {
+			// GIVEN production with the endpoint missing from the baked config
+			const log = recorder()
+			const runtime = withEnv({ NODE_ENV: 'production' }, log)
+
+			try {
+				// WHEN the layer is built and left to run
+				await runtime.runPromise(Effect.void)
+				await settle(500)
+
+				// THEN it said so at a level a production log level keeps
+				expect(log.lines.some(line => line.level === 'Error')).toBe(true)
+				// AND it keeps repeating that it exports nothing, so the answer is
+				//     still there to read later
+				expect(events(log.lines, 'otlp.export.health').length).toBeGreaterThan(
+					0,
+				)
+			} finally {
+				await runtime.dispose()
+			}
+		}, 30_000)
+
+		it('should stay quiet about it outside production', async () => {
+			// GIVEN local development with no endpoint set
+			const log = recorder()
+			const runtime = withEnv({ NODE_ENV: 'development' }, log)
+
+			try {
+				// WHEN the layer is built
+				await runtime.runPromise(Effect.void)
+				await settle(300)
+
+				// THEN export being off is ordinary news, not an error
+				expect(log.lines.some(line => line.level === 'Error')).toBe(false)
+			} finally {
+				await runtime.dispose()
+			}
 		}, 30_000)
 	})
 })

--- a/packages/observability/src/otlp.ts
+++ b/packages/observability/src/otlp.ts
@@ -1,8 +1,18 @@
-import { Config, Duration, Effect, Layer, Tracer } from 'effect'
-import { FetchHttpClient } from 'effect/unstable/http'
+import { Clock, Config, Duration, Effect, Layer, Tracer } from 'effect'
+import { FetchHttpClient, HttpClient } from 'effect/unstable/http'
 import { Otlp } from 'effect/unstable/observability'
 
 import { buildMeta } from './build-meta'
+import {
+	defaultFailingAfter,
+	type ExportHealth,
+	type ExportSignal,
+	type ExportSnapshot,
+	exportHealth,
+	exportSignals,
+	failingSignals,
+	observingHttpClient,
+} from './export-health'
 import { redactingTracer } from './redact-spans'
 import { parseKeepRate, samplingTracer } from './sampling'
 
@@ -22,13 +32,168 @@ const parseOtlpHeaders = (raw: string): Record<string, string> => {
 }
 
 /**
+ * Timings for watching over export. The defaults suit a process that runs for
+ * weeks; a test shortens them so it does not wait out a real interval.
+ */
+export interface ExportCadence {
+	readonly requestTimeout: Duration.Duration
+	readonly checkEvery: Duration.Duration
+	readonly failingAfter: Duration.Duration
+	readonly heartbeatEvery: Duration.Duration
+}
+
+const defaultCadence: ExportCadence = {
+	requestTimeout: Duration.seconds(10),
+	checkEvery: Duration.seconds(60),
+	failingAfter: defaultFailingAfter,
+	heartbeatEvery: Duration.minutes(5),
+}
+
+/**
+ * Where we export to, in a form safe to write down: the path is kept because a
+ * wrong one is the misconfiguration this line exists to catch, and the query
+ * string is dropped because that is where a key tends to hide in a URL.
+ */
+export const endpointOf = (baseUrl: string): string => {
+	try {
+		const url = new URL(baseUrl)
+		return `${url.origin}${url.pathname}`
+	} catch {
+		// Reported rather than thrown: the exporter fails on it soon enough, and a
+		// line naming the problem beats one that hides it. Only the length goes
+		// out, in case an unusable value is a key pasted into the wrong setting.
+		return `unparseable (${baseUrl.length} chars)`
+	}
+}
+
+/**
+ * What to say about each signal named. Fields with nothing to report are left
+ * out rather than written as `undefined`: the console formatter renders them
+ * literally, and `undefined` is not something a reader can parse back.
+ */
+const detailOf = (
+	snapshot: ExportSnapshot,
+	signals: ReadonlyArray<ExportSignal>,
+): Record<string, unknown> =>
+	Object.fromEntries(
+		signals.map(signal => {
+			const state = snapshot[signal]
+			return [
+				signal,
+				{
+					consecutiveFailures: state.consecutiveFailures,
+					...(state.failure === undefined ? {} : { failure: state.failure }),
+					...(state.status === undefined ? {} : { status: state.status }),
+					...(state.lastSuccessAt === undefined
+						? {}
+						: { lastSuccessAt: state.lastSuccessAt }),
+				},
+			]
+		}),
+	)
+
+/**
+ * Says out loud what the export path is doing, on the one channel that still
+ * works when export does not: the process's own console. Not sent to the
+ * backend, because a report that export is broken is worth nothing if it goes
+ * out the way that is broken.
+ *
+ * A failure is said once when export breaks and once when it comes back, since
+ * a backend that is down produces a failure every interval and repeating it
+ * would bury the console it is trying to reach. The heartbeat repeats
+ * regardless, because the platform hands back the end of a console log rather
+ * than the beginning: a line written only at start-up has scrolled away by the
+ * time anyone asks whether this process exports at all.
+ */
+const watchdog = (options: {
+	readonly health: ExportHealth
+	readonly annotations: Record<string, unknown>
+	readonly cadence: ExportCadence
+}) =>
+	Effect.gen(function* () {
+		const { health, annotations, cadence } = options
+		const ticksPerHeartbeat = Math.max(
+			1,
+			Math.round(
+				Duration.toMillis(cadence.heartbeatEvery) /
+					Duration.toMillis(cadence.checkEvery),
+			),
+		)
+		let broken = false
+		let tick = 0
+
+		while (true) {
+			yield* Effect.sleep(cadence.checkEvery)
+			const now = yield* Clock.currentTimeMillis
+			// One reading, used for both the decision and the detail reported with
+			// it. Taking a second one would let a signal recover in between and be
+			// reported as failing with nothing wrong recorded against it.
+			const snapshot = health.snapshot()
+			const failing = failingSignals(snapshot, now, cadence.failingAfter)
+			tick += 1
+
+			if (failing.length > 0 && !broken) {
+				yield* Effect.logError('Telemetry export is failing').pipe(
+					Effect.annotateLogs({
+						...annotations,
+						event: 'otlp.export.failing',
+						signals: detailOf(snapshot, failing),
+					}),
+				)
+			} else if (failing.length === 0 && broken) {
+				yield* Effect.logInfo('Telemetry export recovered').pipe(
+					Effect.annotateLogs({
+						...annotations,
+						event: 'otlp.export.recovered',
+					}),
+				)
+			}
+			broken = failing.length > 0
+
+			if (tick % ticksPerHeartbeat === 0) {
+				yield* Effect.logInfo('Telemetry export health').pipe(
+					Effect.annotateLogs({
+						...annotations,
+						event: 'otlp.export.health',
+						// Same two fields as the line a process with export off writes,
+						// so one search answers the question for every process.
+						exporting: true,
+						failing: failing.length > 0,
+						signals: detailOf(snapshot, exportSignals),
+					}),
+				)
+			}
+		}
+	})
+
+/** Repeats the fact that this process exports nothing, at the same cadence. */
+const exportOffHeartbeat = (options: {
+	readonly annotations: Record<string, unknown>
+	readonly cadence: ExportCadence
+}) =>
+	Effect.gen(function* () {
+		while (true) {
+			yield* Effect.sleep(options.cadence.heartbeatEvery)
+			yield* Effect.logInfo('Telemetry export health').pipe(
+				Effect.annotateLogs({
+					...options.annotations,
+					event: 'otlp.export.health',
+					exporting: false,
+					failing: false,
+				}),
+			)
+		}
+	})
+
+/**
  * OTLP observability layer for a single process — exports traces, logs, and
  * metrics. `serviceName` distinguishes the emitting process in the backend
  * (e.g. `batuda-server`, `batuda-mail-worker`); the Honeycomb dataset is chosen
  * by the `x-honeycomb-dataset` value inside OTEL_EXPORTER_OTLP_HEADERS, not here.
  *
- * Enabled only when OTEL_EXPORTER_OTLP_ENDPOINT is set.
- * When disabled (local dev), returns Layer.empty.
+ * Enabled only when OTEL_EXPORTER_OTLP_ENDPOINT is set. When disabled the
+ * process still says so on a repeating line, so "is this exporting?" has an
+ * answer either way.
  *
  * Config:
  * - OTEL_EXPORTER_OTLP_ENDPOINT — base URL (e.g. https://api.honeycomb.io)
@@ -38,28 +203,58 @@ const parseOtlpHeaders = (raw: string): Record<string, string> => {
  */
 export const makeOtlpObservability = (options: {
 	readonly serviceName: string
+	readonly cadence?: Partial<ExportCadence>
+	readonly health?: ExportHealth
 }) =>
 	Layer.unwrap(
 		Effect.gen(function* () {
+			const cadence = { ...defaultCadence, ...options.cadence }
+			const health = options.health ?? exportHealth
+
 			const baseUrl = yield* Config.string('OTEL_EXPORTER_OTLP_ENDPOINT').pipe(
 				Config.withDefault(''),
 			)
-
-			if (!baseUrl) {
-				yield* Effect.logInfo(
-					'OTLP export disabled (no OTEL_EXPORTER_OTLP_ENDPOINT)',
-				)
-				return Layer.empty
-			}
-
-			// Read below the disable guard so a process with OTLP off (e.g. the
-			// mail-worker run locally, where NODE_ENV is optional) never needs these.
-			const headersRaw = yield* Config.string(
-				'OTEL_EXPORTER_OTLP_HEADERS',
-			).pipe(Config.withDefault(''))
+			// Read above the disable guard, unlike the settings below it: whether
+			// export being off is ordinary or a fault depends on where this runs.
 			const environment = yield* Config.string('NODE_ENV').pipe(
 				Config.withDefault('development'),
 			)
+
+			health.setExporting(Boolean(baseUrl))
+
+			if (!baseUrl) {
+				const annotations = {
+					service: options.serviceName,
+					version: buildMeta.version,
+					commit: buildMeta.commitShort,
+					region: buildMeta.region,
+					environment,
+				}
+				return Layer.effectDiscard(
+					Effect.gen(function* () {
+						// Loud in production, where the endpoint ships inside the image
+						// and its absence means a broken build — but never fatal:
+						// refusing to start over a monitoring setting would turn not
+						// being able to watch production into not being able to run it.
+						yield* environment === 'production'
+							? Effect.logError(
+									'OTLP export is off in production (no OTEL_EXPORTER_OTLP_ENDPOINT)',
+								).pipe(Effect.annotateLogs(annotations))
+							: Effect.logInfo(
+									'OTLP export disabled (no OTEL_EXPORTER_OTLP_ENDPOINT)',
+								).pipe(Effect.annotateLogs(annotations))
+						yield* Effect.forkScoped(
+							exportOffHeartbeat({ annotations, cadence }),
+						)
+					}),
+				)
+			}
+
+			// Read below the disable guard so a process with OTLP off (e.g. the
+			// mail-worker run locally) never needs these.
+			const headersRaw = yield* Config.string(
+				'OTEL_EXPORTER_OTLP_HEADERS',
+			).pipe(Config.withDefault(''))
 			// Read as text and parsed by `parseKeepRate`, which explains why: see
 			// there for what an unusable or out-of-range value does.
 			const keepRate = yield* Config.string('OTEL_TRACES_KEEP_RATE').pipe(
@@ -67,16 +262,17 @@ export const makeOtlpObservability = (options: {
 				Config.map(parseKeepRate),
 			)
 
+			const annotations = {
+				service: options.serviceName,
+				endpoint: endpointOf(baseUrl),
+				version: buildMeta.version,
+				commit: buildMeta.commitShort,
+				region: buildMeta.region,
+				environment,
+			}
+
 			yield* Effect.logInfo('OTLP export enabled').pipe(
-				Effect.annotateLogs({
-					service: options.serviceName,
-					endpoint: baseUrl,
-					version: buildMeta.version,
-					commit: buildMeta.commitShort,
-					region: buildMeta.region,
-					environment,
-					tracesKeepRate: keepRate,
-				}),
+				Effect.annotateLogs({ ...annotations, tracesKeepRate: keepRate }),
 			)
 
 			// The exporter's own tracer, wrapped twice: sampling decides which traces
@@ -88,6 +284,15 @@ export const makeOtlpObservability = (options: {
 					samplingTracer(redactingTracer(inner), keepRate),
 				),
 			)
+
+			// The client every batch goes out through, wrapped so the outcome of
+			// each one is recorded — this is the only place that knows both which
+			// client the exporter uses and what to record into.
+			const ExportClient = Layer.effect(HttpClient.HttpClient)(
+				Effect.map(Effect.service(HttpClient.HttpClient), inner =>
+					observingHttpClient(inner, health, cadence.requestTimeout),
+				),
+			).pipe(Layer.provide(FetchHttpClient.layer))
 
 			return Otlp.layerJson({
 				baseUrl,
@@ -109,10 +314,15 @@ export const makeOtlpObservability = (options: {
 				metricsExportInterval: Duration.seconds(60),
 				metricsTemporality: 'cumulative',
 			}).pipe(
-				Layer.provide(FetchHttpClient.layer),
+				Layer.provide(ExportClient),
 				// Merged, not provided: the exporter's flusher, logger and metrics
 				// still have to reach the process; only the tracer is swapped.
 				layer => ExportTracer.pipe(Layer.provideMerge(layer)),
+				Layer.merge(
+					Layer.effectDiscard(
+						Effect.forkScoped(watchdog({ health, annotations, cadence })),
+					),
+				),
 			)
 		}),
 	)


### PR DESCRIPTION
## What

On 31 August production served traffic normally for about seven hours while sending nothing at all to Honeycomb, the service that stores our logs and traces — and nothing anywhere said so. This makes a process that has stopped reporting say it out loud, so the next time it happens I find out in minutes rather than by noticing an empty dashboard.

The reason it was invisible is worth stating, because it is not a bug in our code. The library that ships telemetry reports a refused batch by writing a `debug` line and nothing else. Both deployed services — the API server (`server`) and the mail worker (`mail-worker`) — run with the log floor set to `info`, and Effect's runtime discards anything below the floor *before any logger sees it*. So the one and only diagnostic was thrown away inside the process. "No export errors in the logs" was not evidence that export was fine; it was the guaranteed output of an exporter that could not send a thing.

## Changes

**Touches:** the shared telemetry layer both deployed processes build on, the health check the API server answers, and the observability guide.

- Every export attempt now leaves a record of how it went — accepted, refused, or never answered — kept separately for each of the three kinds of telemetry, because a backend can accept our logs and refuse our traces.
- A watchdog says `otlp.export.failing` once when export breaks and `otlp.export.recovered` once when it comes back, at a level production keeps. It repeats `otlp.export.health` every few minutes, which is what makes the answer readable later: the platform hands back the *end* of an instance's console log, so a line written once at start-up has scrolled away by the time anyone asks. That is exactly what made the outage impossible to diagnose without restarting the instance.
- These lines go to the process's own console and deliberately **not** to Honeycomb. A report that sending is broken is worth nothing if it goes out the way that is broken. The mail worker has no HTTP surface at all, so the console is the only channel the two processes share.
- Export posts now have a deadline. Without one, a backend that accepts the data and never answers tied a batch up for the HTTP library's five-minute ceiling — five minutes in which the exporter believed it was still in flight, never tripped its own back-off, and said nothing.
- `/health` answers the same question over HTTP, so it can be checked from anywhere without reaching the instance console.
- A missing endpoint in production is now said at error level, but still does not stop the process booting. Telemetry is not needed to serve a request, and refusing to start over a monitoring setting would turn "I cannot watch production" into "I cannot run production".

## Impact

- **No database, tenant-isolation, or authentication change.** Nothing touching which organisation can see what (row-level security), no new environment variables, no migration. Deploy order does not matter.
- **The health check's response shape grew.** `/health` gains a `telemetry` object alongside the existing version, commit and region. Nothing reads that response programmatically today — the deploy gate and the platform's own check both look only at the HTTP status code — but it is a wire-shape change to a public endpoint, so it is worth knowing.
- **That endpoint is unauthenticated**, so the new block deliberately carries no backend host, no status line and none of the vendor's own wording. Only a fixed set of four reasons: `unauthorized`, `rate_limited`, `rejected`, `unreachable`. The backend's text is derived from our request, and our request carries the API key in a header — a fixed set cannot leak one by accident.
- **`status` stays `"ok"` even when telemetry is failing**, on purpose. The deploy gate is `curl -sf .../health`, which reads the status code, so coupling the two would fail releases on a telemetry blip.
- **Both processes get the behaviour**, since it lives in the layer they share.
- **This does not restore production export.** It makes the failure visible and reportable; finding and fixing the actual cause in prod is still to do, which is why the issue stays open below.

## Review guide

Start with `packages/observability/src/export-health.ts` — it holds the whole mechanism, and the two things worth your judgement are both there.

**The one that matters most:** the alarm asks "did the last attempt fail, and has it kept failing" — never "has anything arrived lately". Logs and traces skip a batch with nothing in it, so a quiet service legitimately posts neither, and a staleness test would call every overnight service broken. What keeps a genuinely dead channel from hiding behind a quiet one is metrics, which posts every interval whether or not it has anything to say. My first draft got this wrong and would have paged on healthy idle services; two tests now pin it.

**Decisions you might overrule:**

- A missing endpoint in production is loud but not fatal (reasoning above). There is a real counter-argument from symmetry — `config-provider.ts` already refuses to boot when the baked config file is missing.
- `makeOtlpObservability` gained two options, `cadence` and `health`, that exist only so tests can run fast and stay isolated. They are public API on a shared package with no production caller. Dropping them means testing the watchdog as a pure function and giving up the end-to-end layer test — which is what caught both design bugs here, so I kept them.

**Read this before judging the design.** Since opening this I found what actually caused the outage that prompted it, and **this change would not have caught it**. Both production machines are running with a clock 7 h 25 min behind, so telemetry does arrive at Honeycomb — stamped 7½ hours in the past, leaving every recent window empty. Those batches are *accepted*, and this watchdog reports on batches that are refused or unanswered, so it would have said everything was fine throughout. I still think the change earns its place: a refused key, a quota, and a hung connection had no signal at all before, and each is a real way to go blind. But it is narrower than the title suggests, and noticing a wrong clock needs a different check — the process comparing its own time against a trusted source, or an alarm on the gap between when the backend receives an event and when the event says it happened. Neither is here. Full measurement in [#590](https://github.com/guillempuche/batuda/issues/590#issuecomment-5484291238).

**Not fully closed:** the mail worker's watchdog is not covered by anything running under `pnpm test`. It composes the layer differently from the server, and its only layer test needs a database, so it lives in the integration suite. That is the same shape of gap that let the worker export nothing for months, and it deserves a follow-up.

`packages/observability/src/otlp.ts` is the wiring; the tests and the guide are the bulk of the diff and read quickly.

## Tests

Unit tests for the record and for the decision that drives the alarm, including the two cases that must stay quiet — a signal never tried, and one idle after a success. The layer tests run the real layer against a local HTTP server rather than a vendor: refuse every batch and check it complains exactly once at error level, then drive it broken → recovered and check each is announced once.

One test earns a mention. The endpoint the exporter posts to is built by appending the signal name to whatever the endpoint is configured as, so a configured value that already carries a query string leaves the name *inside* the query rather than at the end of the path. My first version read the parsed path, recognised no signal, and silently recorded nothing — a dead backend reading as a healthy one, which is the exact failure this PR exists to prevent. Found by running it, not by the tests; there is now a test for that URL shape.

## Verification

- `pnpm install`, `pnpm -w check-types`, `pnpm -w test` (all 23 packages), `pnpm -w build` — all green.
- `biome check .` and `dprint check` clean; the 60 warnings reported are pre-existing in `apps/internal` and `apps/cli`, none in changed files.
- Ran against the live local stack, not just the test suite: booted the server pointed at a stand-in backend that refuses every batch, watched `otlp.export.failing` appear at the two-minute mark, flipped the backend to accepting, and watched `otlp.export.recovered` and the heartbeat land on the next check — with `/health` tracking each step. Also confirmed the boot line keeps the endpoint's path (a wrong path is what it exists to catch) and drops any query string.
- Two incidental confirmations from that run: metrics does post every 60 seconds on an otherwise idle server, which is what the alarm relies on; and the library's `debug` line really is the only thing it says when a batch is refused.

No UI change — nothing under `apps/internal` or `packages/ui` — so no screenshots.

## Deferred

- Getting the production clocks back in step: redeploy both services rather than starting them, since a started instance keeps the stale clock. Then confirm the Honeycomb trigger resolves.
- Stopping it recurring — time sync inside the unikernel, or a runbook line saying redeploy and never start.
- Noticing skew on its own, which this change does not do (see the Review guide).
- Reconciling `OTEL_EXPORTER_OTLP_HEADERS`: both instances carry only `x-honeycomb-team`, without the `,x-honeycomb-dataset=<service>` half both deploy workflows append. Traces route by `service.name` so they land anyway, and metrics fall into a default dataset literally named `metrics` — which is why that dataset is called that.
- Covering the mail worker's watchdog in a test that runs under `pnpm test`.

I had a theory here about a research run blowing the Honeycomb event allowance, built on a 10× span burst just before export appeared to stop. Measuring killed it: there was no burst. That was post-restart traffic landing in the past. Trace thinning (`OTEL_TRACES_KEEP_RATE`, unset in both production config files) may still be worth doing, but not for this reason.

Addresses #590 — the issue turned out to be a clock, not an exporter, so this does not close it. It stays open until the production clocks are corrected and the trigger resolves.

