### PR TITLE
fix: notice when a machine's clock is wrong

### DIFF
--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -142,6 +142,25 @@ jobs:
             # instances delete/get/logs take a bare name and reject --metro
             # (only run/services create accept it); the login profile spans metros.
             unikraft instances delete batuda-mail-worker 2>&1 | grep -v "not found" || true
+
+            # Confirm the name is really free instead of trusting the delete.
+            # The CLI asks every metro and reports failure when any of them is
+            # unwell, so an outage somewhere else can leave the old instance
+            # standing while the delete still looks like it worked — `run` then
+            # collides on the name and the deploy dies three attempts later
+            # saying nothing about the real cause (2026-08-31). `list` is read
+            # for what it printed, not for how it exited.
+            for _ in 1 2 3 4 5; do
+              unikraft instances list --filter 'name=="batuda-mail-worker"' \
+                -f name -o quiet 2>/dev/null | grep -qx batuda-mail-worker || break
+              sleep 3
+              unikraft instances delete batuda-mail-worker >/dev/null 2>&1 || true
+            done
+            if unikraft instances list --filter 'name=="batuda-mail-worker"' \
+                 -f name -o quiet 2>/dev/null | grep -qx batuda-mail-worker; then
+              echo "::error::batuda-mail-worker is still there after repeated deletes. Check https://status.unikraft.com/ — a metro being down makes every CLI call fail, including ones aimed elsewhere."
+              exit 1
+            fi
             unikraft run \
               --timeout 5m \
               --metro ${{ env.KRAFTCLOUD_METRO }} \

--- a/.github/workflows/deploy_mail_worker.yml
+++ b/.github/workflows/deploy_mail_worker.yml
@@ -75,7 +75,17 @@ jobs:
             --output ${{ env.KRAFTCLOUD_ORG }}/batuda-mail-worker:${{ steps.meta.outputs.version }}
 
       - name: Pre-flight cmdline size guard
+        env:
+          OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
         run: |
+          # The dataset name is appended to the secret, so anything the secret
+          # carries at its end lands in the middle of the value. A stray newline
+          # there truncates everything after it, which is how both instances
+          # ended up holding the team key and no dataset (seen 2026-09-01). Read
+          # from the environment rather than pasted into the command, and
+          # stripped of line breaks before anything is added to it.
+          headers="$(printf '%s' "$OTLP_HEADERS" | tr -d '\r\n'),x-honeycomb-dataset=batuda-mail-worker"
+
           # Unikraft Cloud bakes every -e var into the unikernel kernel command
           # line, which Unikraft caps at 4096 bytes / 60 args: past the byte
           # cap the boot aborts with -E2BIG, past the arg cap argv is silently
@@ -89,7 +99,7 @@ jobs:
             -e SERVICE_VERSION="${{ steps.meta.outputs.version }}"
             -e GIT_SHA="${{ github.sha }}"
             -e REGION="${{ env.KRAFTCLOUD_METRO }}"
-            -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-mail-worker"
+            -e OTEL_EXPORTER_OTLP_HEADERS="$headers"
             -e DATABASE_URL="${{ secrets.DATABASE_URL }}"
             -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}"
             -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}"
@@ -110,6 +120,8 @@ jobs:
 
       - name: Deploy to Unikraft Cloud
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
         with:
           max_attempts: 3
           retry_wait_seconds: 30
@@ -139,6 +151,11 @@ jobs:
           #   Scale-to-zero stays off via the Kraftfile label (baked into the
           #     image), keeping the IDLE-holding worker always-warm.
           command: |
+            # Line breaks stripped before the dataset name is appended: a stray
+            # one at the end of the secret would land mid-value and truncate
+            # everything after it (seen 2026-09-01).
+            headers="$(printf '%s' "$OTLP_HEADERS" | tr -d '\r\n'),x-honeycomb-dataset=batuda-mail-worker"
+
             # instances delete/get/logs take a bare name and reject --metro
             # (only run/services create accept it); the login profile spans metros.
             unikraft instances delete batuda-mail-worker 2>&1 | grep -v "not found" || true
@@ -172,7 +189,7 @@ jobs:
               -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
               -e GIT_SHA="${{ github.sha }}" \
               -e REGION="${{ env.KRAFTCLOUD_METRO }}" \
-              -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-mail-worker" \
+              -e OTEL_EXPORTER_OTLP_HEADERS="$headers" \
               -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
               -e EMAIL_CREDENTIAL_KEY="${{ secrets.EMAIL_CREDENTIAL_KEY }}" \
               -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
@@ -182,6 +199,16 @@ jobs:
         run: |
           sleep 5
           unikraft instances get batuda-mail-worker
+
+          # Confirm the dataset name survived into the running instance. Only
+          # the count is read: this API hands back the whole environment in
+          # clear text, so nothing from it is ever printed. A warning rather
+          # than a failure — traces route by service name and land either way;
+          # what goes astray without it is where metrics are filed.
+          if [ "$(unikraft instances get batuda-mail-worker -o json 2>/dev/null \
+                    | grep -c 'x-honeycomb-dataset')" -eq 0 ]; then
+            echo "::warning::x-honeycomb-dataset is missing from the running instance; metrics will be filed under a shared default dataset"
+          fi
           # claimAvailableInboxes runs every 5 s, so an IDLE-established
           # log line should appear within ~10 s if any inbox is provisioned.
           unikraft instances logs batuda-mail-worker --tail 100 || echo "::warning::No logs yet"

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -205,16 +205,32 @@ jobs:
       # this is an idempotent safety net for a from-scratch environment.
       - name: Ensure Unikraft Cloud service exists
         run: |
-          if unikraft services get batuda-server >/dev/null 2>&1; then
+          # Read for what the CLI printed, not for how it exited: it asks every
+          # metro and reports failure when any of them is unwell, even though
+          # the one being deployed to answered perfectly. Going by the exit
+          # code, an outage in another metro sends this down the else branch
+          # and the deploy dies creating a service that already exists
+          # (2026-08-31). The filter keeps the answer to this metro, so a
+          # service of the same name elsewhere cannot stand in for it.
+          if unikraft services list \
+               --filter 'metro=="${{ env.KRAFTCLOUD_METRO }}"' \
+               -f name -o quiet 2>/dev/null | grep -qx batuda-server; then
             echo "Service batuda-server already exists"
           else
             echo "Creating service batuda-server"
-            unikraft services create \
-              --name batuda-server \
-              --metro ${{ env.KRAFTCLOUD_METRO }} \
-              --domains api.batuda.co \
-              --services 443:3000/tls+http \
-              --services 80:443/http+redirect
+            # "Already exists" is the state we want, so it is not a failure —
+            # which keeps this step safe to rerun even when the check above got
+            # no answer at all and sent us here. Any other failure still stops
+            # the deploy.
+            if ! unikraft services create \
+                   --name batuda-server \
+                   --metro ${{ env.KRAFTCLOUD_METRO }} \
+                   --domains api.batuda.co \
+                   --services 443:3000/tls+http \
+                   --services 80:443/http+redirect >/tmp/svc-create.log 2>&1; then
+              cat /tmp/svc-create.log
+              grep -q "already exists" /tmp/svc-create.log
+            fi
           fi
 
       - name: Pre-flight cmdline size guard

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -234,7 +234,17 @@ jobs:
           fi
 
       - name: Pre-flight cmdline size guard
+        env:
+          OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
         run: |
+          # The dataset name is appended to the secret, so anything the secret
+          # carries at its end lands in the middle of the value. A stray newline
+          # there truncates everything after it, which is how both instances
+          # ended up holding the team key and no dataset (seen 2026-09-01). Read
+          # from the environment rather than pasted into the command, and
+          # stripped of line breaks before anything is added to it.
+          headers="$(printf '%s' "$OTLP_HEADERS" | tr -d '\r\n'),x-honeycomb-dataset=batuda-server"
+
           # Unikraft Cloud bakes every -e var into the unikernel kernel command
           # line, which Unikraft caps at 4096 bytes / 60 args: past the byte
           # cap the boot aborts with -E2BIG, past the arg cap argv is silently
@@ -249,7 +259,7 @@ jobs:
             -e SERVICE_VERSION="${{ steps.meta.outputs.version }}"
             -e GIT_SHA="${{ github.sha }}"
             -e REGION="${{ env.KRAFTCLOUD_METRO }}"
-            -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-server"
+            -e OTEL_EXPORTER_OTLP_HEADERS="$headers"
             -e DATABASE_URL="${{ secrets.DATABASE_URL }}"
             -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}"
             -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}"
@@ -288,6 +298,8 @@ jobs:
 
       - name: Deploy to Unikraft Cloud
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
         with:
           max_attempts: 3
           retry_wait_seconds: 30
@@ -311,6 +323,11 @@ jobs:
           #     with the process crash-guards in main.ts.
           #   Scale-to-zero stays off via the Kraftfile label (baked in).
           command: |
+            # Line breaks stripped before the dataset name is appended: a stray
+            # one at the end of the secret would land mid-value and truncate
+            # everything after it (seen 2026-09-01).
+            headers="$(printf '%s' "$OTLP_HEADERS" | tr -d '\r\n'),x-honeycomb-dataset=batuda-server"
+
             # No users yet, so a brief gap is fine: remove every current
             # batuda-server instance (the old release, plus any half-created one
             # from a failed retry) so the new instance is the sole member of the
@@ -335,7 +352,7 @@ jobs:
               -e SERVICE_VERSION="${{ steps.meta.outputs.version }}" \
               -e GIT_SHA="${{ github.sha }}" \
               -e REGION="${{ env.KRAFTCLOUD_METRO }}" \
-              -e OTEL_EXPORTER_OTLP_HEADERS="${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }},x-honeycomb-dataset=batuda-server" \
+              -e OTEL_EXPORTER_OTLP_HEADERS="$headers" \
               -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
               -e BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
               -e STORAGE_ACCESS_KEY_ID="${{ secrets.STORAGE_ACCESS_KEY_ID }}" \
@@ -366,6 +383,16 @@ jobs:
           # Gate the deploy on /health actually serving. curl already retries
           # to absorb cold-boot latency; fail the job if it never comes up so a
           # broken release doesn't pass with only a warning.
+          # Confirm the dataset name survived into the running instance. Only
+          # the count is read: this API hands back the whole environment in
+          # clear text, so nothing from it is ever printed. A warning rather
+          # than a failure — traces route by service name and land either way;
+          # what goes astray without it is where metrics are filed.
+          if [ "$(unikraft instances get batuda-server -o json 2>/dev/null \
+                    | grep -c 'x-honeycomb-dataset')" -eq 0 ]; then
+            echo "::warning::x-honeycomb-dataset is missing from the running instance; metrics will be filed under a shared default dataset"
+          fi
+
           if curl --retry 5 --retry-delay 5 --retry-all-errors -sf https://api.batuda.co/health -o /dev/null; then
             echo "Health check passed"
           else

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -65,8 +65,10 @@ Timestamps and trace ids are added by the framework.
 | `otlp.export.failing`          | This process has stopped being able to export, and why     |
 | `otlp.export.recovered`        | Exporting works again                                      |
 | `otlp.export.health`           | Whether this process is exporting, repeated on a timer     |
+| `otlp.clock.skewed`            | This process and the backend disagree about the time       |
+| `otlp.clock.agreed`            | This process and the backend agree again                   |
 
-The three `otlp.export.*` lines are the exception to one record per unit of work: they report on the reporting itself, so they belong to the process rather than to any piece of work it did. See [When export itself fails](#when-export-itself-fails).
+The `otlp.*` lines are the exception to one record per unit of work: they report on the reporting itself, so they belong to the process rather than to any piece of work it did. See [When export itself fails](#when-export-itself-fails).
 
 A request leaves exactly one of `http.request`, `http.server_error`, `http.defect` or `http.not_found`. "Every request that ended badly" is the middle two: a route that does not exist is the caller's mistake rather than a fault of ours, and it is kept out of the error channel on purpose — recorded as a crash, every bot probing for `/robots.txt` leaves a stack trace at error level and buries the failures that matter.
 
@@ -291,11 +293,21 @@ Deliberately not sent to the backend. A report that export is broken is worth no
 
 **The three signals are tracked apart.** A backend can take our logs and refuse our traces, so one "is export working" flag would read healthy while traces were being dropped.
 
+### A wrong clock is the failure none of that catches
+
+Everything above asks whether a batch was refused. A machine with a wrong clock refuses nothing: every span and log is sent, accepted, and stored — at the wrong moment. Nothing fails, nothing retries, and the only symptom is that questions about a recent window come back empty, which reads as a quiet service rather than a broken one. Production spent a day like that on 2026-08-31, and the export watchdog would have called it healthy throughout.
+
+So the export path also compares its own clock against the backend's. Every HTTP reply carries a `Date`, and we are already talking to that backend constantly, so this costs no extra request and no extra dependency — the difference is read off replies we were making anyway. Only off accepted ones: a proxy or an error page is not the backend, and its idea of the time proves nothing. `otlp.clock.skewed` is said the first time the difference passes a two-minute tolerance — generous, because a reply's clock has one-second resolution and the round trip adds more. What it is looking for is not drift but a clock that stopped.
+
+The cause worth knowing: a stopped machine keeps the time it went to sleep with. Restarting a stopped instance resumes it hours behind, while **deploying a fresh one gets a correct clock** — so redeploy, do not start.
+
 ## Health endpoint
 
 `/health` returns build metadata for uptime checks and deploy verification — CalVer version, short commit SHA, region — plus whether this instance is still reaching the telemetry backend.
 
 The telemetry block is there because of the failure above: the console of a deployed instance is not always reachable, and an instance that cannot export cannot report that through the thing it exports to. One unauthenticated request answers it from anywhere, which is the point.
+
+It also carries how far the instance's clock sits from the backend's, in seconds, negative when behind — absent until a reply has been read, because absent means unknown rather than zero.
 
 **Security note:** those, and nothing more. No framework or dependency versions, no internal paths, no stack traces — and from the telemetry block, no backend host, no vendor wording and no status line: only a closed set of reasons (`unauthorized`, `rate_limited`, `rejected`, `unreachable`), enough to tell a rejected key from a quota from a dead route. The reason is a fixed set rather than whatever the backend said on purpose: the backend's wording is derived from our request, and our request carries the API key in a header.
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -61,6 +61,16 @@ A few vendors want an unusual shape:
 - Set the jwt plugin's `rotationInterval` so keys expire and regenerate on a schedule, or
 - weigh `jwks.disablePrivateKeyEncryption` — removes the secret↔key coupling but stores the signing private key **unencrypted** in the DB.
 
+## Restarting a stopped production instance
+
+**Redeploy it. Never start it.**
+
+A unikernel's clock does not advance while the instance is stopped, and nothing re-syncs it when the instance comes back. Start one that has been down for seven hours and it resumes seven hours behind, and stays there. Deploying creates a fresh instance, which gets a correct clock.
+
+The damage is quiet. A machine with a wrong clock serves traffic normally and exports telemetry normally — every span and log is accepted and stored, just stamped at the wrong moment. Nothing fails and nothing retries, so the only symptom is that any question about a recent window comes back empty, which reads as a quiet service rather than a broken one. Production ran a day like that on 2026-08-31 before anyone worked out why.
+
+Two things now say so within a minute: the process writes `otlp.clock.skewed` at error level, and `/health` carries `clockOffsetSeconds` — how far the instance sits from the telemetry backend, negative when behind. To check by hand, send a request to any traced route at a noted time and find its span; `/health` itself is exempt from tracing, so it will not appear.
+
 ## Applying database migrations
 
 Where migrations run depends on the environment, and the boundary is deliberate.

--- a/packages/controllers/src/routes/health.test.ts
+++ b/packages/controllers/src/routes/health.test.ts
@@ -80,6 +80,31 @@ describe('the health response', () => {
 		})
 	})
 
+	describe('when the clocks have been compared', () => {
+		it('should carry how far apart they are', () => {
+			// GIVEN an instance whose clock sits 7h25m behind the backend's — the
+			//       state the production machines came back in on 2026-08-31, where
+			//       everything is sent and accepted but stamped at the wrong moment
+			// WHEN the response is encoded
+			const exit = encode({
+				...healthy,
+				telemetry: { ...healthy.telemetry, clockOffsetSeconds: -26_700 },
+			})
+
+			// THEN the wire format carries it, negative meaning behind
+			expect(exit._tag).toBe('Success')
+		})
+
+		it('should accept a report from a process that has not compared yet', () => {
+			// GIVEN a process that has had no reply back to read a time from
+			// WHEN the response is encoded without the field
+			const exit = encode(healthy)
+
+			// THEN it is accepted: absent means unknown, not zero
+			expect(exit._tag).toBe('Success')
+		})
+	})
+
 	describe('when a reason outside the known set is reported', () => {
 		it('should be rejected', () => {
 			// GIVEN a reason carrying something the backend said, rather than one of

--- a/packages/controllers/src/routes/health.ts
+++ b/packages/controllers/src/routes/health.ts
@@ -32,6 +32,13 @@ const SignalReport = Schema.Struct({
  */
 const TelemetryReport = Schema.Struct({
 	exporting: Schema.Boolean,
+	/**
+	 * Seconds this instance's clock sits ahead of the telemetry backend's;
+	 * negative means behind. Absent until a reply has been read. A large figure
+	 * means the data is arriving stamped at the wrong moment, which reads as a
+	 * silent service rather than a broken one.
+	 */
+	clockOffsetSeconds: Schema.optional(Schema.Number),
 	signals: Schema.Struct({
 		traces: SignalReport,
 		logs: SignalReport,

--- a/packages/observability/src/export-health.test.ts
+++ b/packages/observability/src/export-health.test.ts
@@ -11,12 +11,14 @@ import {
 	HttpClient,
 	HttpClientRequest,
 } from 'effect/unstable/http'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import {
+	defaultClockTolerance,
 	type ExportHealth,
 	exportReport,
 	failingSignals,
+	isClockSkewed,
 	isFailing,
 	makeExportHealth,
 	observingHttpClient,
@@ -26,6 +28,9 @@ import {
 // a `hang` request is accepted and then left open, which is the failure the
 // exporter cannot see on its own.
 let status = 200
+// Lets a test put a specific time on the backend's reply, which is where the
+// clock comparison reads from.
+let replyDate: string | undefined
 let server: Server
 let origin: string
 const hungSockets: Array<import('node:net').Socket> = []
@@ -39,7 +44,10 @@ const startSink = () =>
 					hungSockets.push(request.socket)
 					return
 				}
-				response.writeHead(status)
+				response.writeHead(
+					status,
+					replyDate === undefined ? undefined : { date: replyDate },
+				)
 				response.end('{}')
 			})
 		})
@@ -68,6 +76,14 @@ describe('the export health record', () => {
 			throw new Error('expected a TCP address for the sink')
 		origin = `http://127.0.0.1:${address.port}`
 	}, 30_000)
+
+	// Put the fake backend back to plain, agreeable answers between cases, so a
+	// test that fails part-way cannot leave a refusal or a wrong time behind for
+	// whatever runs next.
+	afterEach(() => {
+		status = 200
+		replyDate = undefined
+	})
 
 	afterAll(async () => {
 		for (const socket of hungSockets) socket.destroy()
@@ -198,6 +214,69 @@ describe('the export health record', () => {
 		})
 	})
 
+	describe('comparing our clock against the backend', () => {
+		it('should read the time off the reply and keep the difference', async () => {
+			// GIVEN a backend that says it is an hour later than we think it is —
+			//       the shape of a machine resumed with the clock it went to sleep on
+			const health = makeExportHealth()
+			status = 200
+			replyDate = new Date(Date.now() + 3_600_000).toUTCString()
+
+			// WHEN a batch is accepted
+			await post(`${origin}/v1/traces`, health, second)
+
+			// THEN we know we are roughly an hour behind, and say so as a negative
+			const offset = health.clockOffset()
+			expect(offset).toBeTypeOf('number')
+			expect(offset ?? 0).toBeLessThan(-3_500_000)
+		})
+
+		it('should stay quiet about the ordinary difference of a healthy process', async () => {
+			// GIVEN a backend whose clock agrees with ours, give or take the round
+			//       trip and the one-second resolution of the reply's own clock
+			const health = makeExportHealth()
+			status = 200
+
+			// WHEN a batch is accepted
+			await post(`${origin}/v1/logs`, health, second)
+
+			// THEN an offset was read, and it is not worth telling anyone about
+			expect(health.clockOffset()).toBeTypeOf('number')
+			expect(isClockSkewed(health.clockOffset(), defaultClockTolerance)).toBe(
+				false,
+			)
+		})
+
+		it('should ignore a reply whose time cannot be read', async () => {
+			// GIVEN a backend sending something that is not a date — this value
+			//       comes from outside, so it is checked rather than trusted
+			const health = makeExportHealth()
+			status = 200
+			replyDate = 'not a date at all'
+
+			// WHEN a batch is accepted
+			await post(`${origin}/v1/traces`, health, second)
+
+			// THEN nothing is claimed about the clock
+			expect(health.clockOffset()).toBeUndefined()
+		})
+
+		it('should not read a clock off a reply that refused the batch', async () => {
+			// GIVEN a backend refusing the batch, whatever time it puts on the reply
+			const health = makeExportHealth()
+			status = 401
+			replyDate = new Date(Date.now() + 3_600_000).toUTCString()
+
+			// WHEN a batch is posted
+			await post(`${origin}/v1/traces`, health, second)
+
+			// THEN the refusal is recorded and the clock is left alone: a proxy or
+			//      an error page is not the backend, and its time proves nothing
+			expect(health.snapshot().traces.failure).toBe('unauthorized')
+			expect(health.clockOffset()).toBeUndefined()
+		})
+	})
+
 	describe('when one signal fails while another is accepted', () => {
 		it('should report them independently', async () => {
 			// GIVEN a backend that refuses everything
@@ -299,6 +378,28 @@ describe('deciding whether a signal is worth complaining about', () => {
 			expect(
 				isFailing(health.snapshot().traces, 300_001, Duration.minutes(2)),
 			).toBe(false)
+		})
+	})
+
+	describe('deciding whether the clocks disagree enough to say so', () => {
+		it('should say nothing before any reply has been read', () => {
+			// GIVEN a process that has not yet had a batch accepted
+			// THEN there is nothing to compare, so nothing is claimed
+			expect(isClockSkewed(undefined, defaultClockTolerance)).toBe(false)
+		})
+
+		it('should ignore a difference inside the tolerance', () => {
+			// GIVEN a minute of difference, which a round trip and a coarse clock
+			//       can account for
+			expect(isClockSkewed(60_000, defaultClockTolerance)).toBe(false)
+		})
+
+		it('should catch a clock that stopped, in either direction', () => {
+			// GIVEN the 7h25m the production machines came back with on 2026-08-31
+			const stopped = 7 * 3_600_000 + 25 * 60_000
+			expect(isClockSkewed(-stopped, defaultClockTolerance)).toBe(true)
+			// AND the same distance the other way, which is just as wrong
+			expect(isClockSkewed(stopped, defaultClockTolerance)).toBe(true)
 		})
 	})
 

--- a/packages/observability/src/export-health.ts
+++ b/packages/observability/src/export-health.ts
@@ -60,6 +60,12 @@ export interface ExportHealth {
 	readonly setExporting: (exporting: boolean) => void
 	readonly snapshot: () => ExportSnapshot
 	readonly exporting: () => boolean
+	/**
+	 * How far this process's clock sits from the backend's, in milliseconds,
+	 * positive when we are ahead. `undefined` until a reply has been read.
+	 */
+	readonly recordClockOffset: (offsetMs: number) => void
+	readonly clockOffset: () => number | undefined
 }
 
 const untried: SignalHealth = {
@@ -84,12 +90,17 @@ export const makeExportHealth = (): ExportHealth => {
 		metrics: untried,
 	}
 	let exporting = false
+	let clockOffset: number | undefined
 
 	return {
 		setExporting: next => {
 			exporting = next
 		},
 		exporting: () => exporting,
+		recordClockOffset: offsetMs => {
+			clockOffset = offsetMs
+		},
+		clockOffset: () => clockOffset,
 		recordSuccess: (signal, at) => {
 			state[signal] = {
 				lastAttemptAt: at,
@@ -157,6 +168,32 @@ export const failingSignals = (
  */
 export const defaultFailingAfter: Duration.Duration = Duration.minutes(2)
 
+/**
+ * How far our clock may sit from the backend's before it is worth saying so.
+ *
+ * Generous on purpose. The reply's clock has one-second resolution and the
+ * round trip adds more, so a healthy process is always off by a little. What
+ * this is looking for is not drift but a clock that stopped: a machine paused
+ * and resumed keeps the time it went to sleep with, and comes back hours out.
+ */
+export const defaultClockTolerance: Duration.Duration = Duration.minutes(2)
+
+/**
+ * Whether this process and the backend disagree about the time by more than
+ * they should.
+ *
+ * Worth its own check because a wrong clock is invisible to everything else
+ * here: the batches are accepted, so nothing fails and nothing is retried. What
+ * breaks is the reading — every span arrives stamped at the wrong moment, so
+ * any question about a recent window comes back empty and the process looks
+ * idle rather than misconfigured. That is what happened on 2026-08-31.
+ */
+export const isClockSkewed = (
+	offsetMs: number | undefined,
+	tolerance: Duration.Duration,
+): boolean =>
+	offsetMs !== undefined && Math.abs(offsetMs) > Duration.toMillis(tolerance)
+
 export interface SignalReport {
 	readonly failing: boolean
 	readonly failure?: ExportFailure
@@ -165,6 +202,8 @@ export interface SignalReport {
 
 export interface ExportReport {
 	readonly exporting: boolean
+	/** Seconds this process's clock sits ahead of the backend's; negative behind. */
+	readonly clockOffsetSeconds?: number
 	readonly signals: Readonly<Record<ExportSignal, SignalReport>>
 }
 
@@ -188,17 +227,44 @@ export const exportReport = (
 	now: number,
 ): ExportReport => {
 	const snapshot = health.snapshot()
+	const offsetMs = health.clockOffset()
+
 	// Written out rather than built from the list of signals: building it needs a
 	// cast to claim all three keys are there, and a cast would let a dropped
 	// signal go out missing from the report with nothing complaining.
 	return {
 		exporting: health.exporting(),
+		// Rounded to seconds: the reply's clock has no finer resolution, and a
+		// millisecond figure would read as precision that is not there.
+		...(offsetMs === undefined
+			? {}
+			: { clockOffsetSeconds: Math.round(offsetMs / 1000) }),
 		signals: {
 			traces: reportOf(snapshot.traces, now),
 			logs: reportOf(snapshot.logs, now),
 			metrics: reportOf(snapshot.metrics, now),
 		},
 	}
+}
+
+/**
+ * Reads the backend's own clock off its reply and keeps how far ours sits from
+ * it.
+ *
+ * Every HTTP reply carries a `Date`, so this costs no extra request and no
+ * extra dependency — the one thing we already do constantly is talk to a
+ * machine that knows the time. Treated as a number and nothing else: it is a
+ * value from outside, so an unreadable one is ignored rather than trusted.
+ */
+const readClock = (
+	dateHeader: string | undefined,
+	ourTime: number,
+	health: ExportHealth,
+): void => {
+	if (dateHeader === undefined) return
+	const theirTime = Date.parse(dateHeader)
+	if (Number.isNaN(theirTime)) return
+	health.recordClockOffset(ourTime - theirTime)
 }
 
 const failureOfStatus = (status: number): ExportFailure => {
@@ -277,9 +343,10 @@ export const observingHttpClient = (
 				Effect.map(Clock.currentTimeMillis, at => {
 					// Read below `filterStatusOk`, which the exporter applies on top of
 					// this client — so the real status arrives here, refusals included.
-					if (response.status >= 200 && response.status < 300)
+					if (response.status >= 200 && response.status < 300) {
 						health.recordSuccess(signal, at)
-					else
+						readClock(response.headers['date'], at, health)
+					} else
 						health.recordFailure(
 							signal,
 							failureOfStatus(response.status),

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -5,6 +5,7 @@
 export { boundedCause } from './bounded-cause'
 export { buildMeta } from './build-meta'
 export {
+	defaultClockTolerance,
 	defaultFailingAfter,
 	type ExportFailure,
 	type ExportHealth,
@@ -15,6 +16,7 @@ export {
 	exportReport,
 	exportSignals,
 	failingSignals,
+	isClockSkewed,
 	isFailing,
 	makeExportHealth,
 	observingHttpClient,

--- a/packages/observability/src/otlp.ts
+++ b/packages/observability/src/otlp.ts
@@ -4,6 +4,7 @@ import { Otlp } from 'effect/unstable/observability'
 
 import { buildMeta } from './build-meta'
 import {
+	defaultClockTolerance,
 	defaultFailingAfter,
 	type ExportHealth,
 	type ExportSignal,
@@ -11,6 +12,7 @@ import {
 	exportHealth,
 	exportSignals,
 	failingSignals,
+	isClockSkewed,
 	observingHttpClient,
 } from './export-health'
 import { redactingTracer } from './redact-spans'
@@ -40,6 +42,7 @@ export interface ExportCadence {
 	readonly checkEvery: Duration.Duration
 	readonly failingAfter: Duration.Duration
 	readonly heartbeatEvery: Duration.Duration
+	readonly clockTolerance: Duration.Duration
 }
 
 const defaultCadence: ExportCadence = {
@@ -47,6 +50,7 @@ const defaultCadence: ExportCadence = {
 	checkEvery: Duration.seconds(60),
 	failingAfter: defaultFailingAfter,
 	heartbeatEvery: Duration.minutes(5),
+	clockTolerance: defaultClockTolerance,
 }
 
 /**
@@ -120,6 +124,7 @@ const watchdog = (options: {
 			),
 		)
 		let broken = false
+		let wasSkewed = false
 		let tick = 0
 
 		while (true) {
@@ -150,6 +155,27 @@ const watchdog = (options: {
 			}
 			broken = failing.length > 0
 
+			const offsetMs = health.clockOffset()
+			const skewed = isClockSkewed(offsetMs, cadence.clockTolerance)
+			// `skewed` is never true without an offset; the check is repeated so
+			// the number itself can be reported below.
+			if (skewed && !wasSkewed && offsetMs !== undefined) {
+				yield* Effect.logError(
+					'This process and the backend disagree about the time',
+				).pipe(
+					Effect.annotateLogs({
+						...annotations,
+						event: 'otlp.clock.skewed',
+						clockOffsetSeconds: Math.round(offsetMs / 1000),
+					}),
+				)
+			} else if (!skewed && wasSkewed) {
+				yield* Effect.logInfo('Clocks agree again').pipe(
+					Effect.annotateLogs({ ...annotations, event: 'otlp.clock.agreed' }),
+				)
+			}
+			wasSkewed = skewed
+
 			if (tick % ticksPerHeartbeat === 0) {
 				yield* Effect.logInfo('Telemetry export health').pipe(
 					Effect.annotateLogs({
@@ -159,6 +185,11 @@ const watchdog = (options: {
 						// so one search answers the question for every process.
 						exporting: true,
 						failing: failing.length > 0,
+						// Left out entirely until a reply has been read: the console
+						// formatter writes an absent value as the word `undefined`.
+						...(offsetMs === undefined
+							? {}
+							: { clockOffsetSeconds: Math.round(offsetMs / 1000) }),
 						signals: detailOf(snapshot, exportSignals),
 					}),
 				)


### PR DESCRIPTION
## What

Two follow-ups to the outage in #590, where production ran a full day with telemetry that looked fine and was not.

The cause turned out to be a clock. Both machines came back from a restart keeping the time they went to sleep with, so everything they sent was accepted and stored 7½ hours in the past. Nothing failed, nothing retried — and the watchdog added in #591 reported everything healthy throughout, because it asks whether a batch was refused and none were. The only symptom was that any question about a recent window came back empty, which reads as a quiet service rather than a broken one.

This makes that specific failure visible, in the API server (`server`) and the mail worker (`mail-worker`) alike. It also fixes the reason the fix itself could not be deployed on the first attempt: an outage in one Unikraft region blocked deploying to a different, healthy one.

## Changes

**Touches:** the shared telemetry layer both deployed processes build on, the health check the API server answers, and the two deploy workflows.

- Compares this process's clock against the telemetry backend's. Every HTTP reply carries a `Date`, and we already talk to that backend constantly, so the difference is read off replies we were making anyway — no extra request, no new dependency, no new setting.
- Read only from accepted replies. A proxy or an error page is not the backend, and its idea of the time proves nothing.
- Says `otlp.clock.skewed` once past a two-minute tolerance, and `otlp.clock.agreed` once on the way back. Generous on purpose: a reply's clock has one-second resolution and the round trip adds more, so what this looks for is not drift but a clock that stopped.
- Reports the offset on `/health` in seconds, negative when behind, absent until a reply has been read — absent means unknown, not zero.
- Keeps the dataset name on the telemetry header. It is appended to a secret, so a stray line break at the end of that secret lands mid-value and truncates everything after it — which is why both instances were running with the team key and no dataset, filing every metric under one shared default rather than one per service. The secret is now read from the step environment instead of being pasted into the command, and each deploy checks the name reached the instance (counting matches only, since that API returns the whole environment in clear text).
- Writes down that a stopped instance must be redeployed rather than started, since its clock stops with it.
- Both deploy workflows now read what the `unikraft` CLI printed rather than how it exited. It asks every region and reports failure when any one cannot answer, which is what broke both deploys on 2026-08-31 while an unrelated region was down. Creating a service that already exists is also treated as the state we wanted, so that step is safe to rerun.

## Impact

- **No database, tenant-isolation, or authentication change.** Nothing touching which organisation can see what (row-level security), no migration, no new environment variables. Deploy order does not matter.
- **The health check's response shape grew again**, by one optional number (`clockOffsetSeconds`) inside the `telemetry` object added in #591. Nothing reads that response programmatically — the deploy gate and the platform's own check both look only at the HTTP status code.
- **That endpoint is unauthenticated**, so the new field is a plain integer and nothing else: no backend host, no vendor wording. It does reveal roughly how wrong an instance's clock is, which is the point of publishing it.
- **Both processes get the behaviour**, since it lives in the layer they share.
- **The deploy workflow changes cannot be exercised by CI** — they only run on a `server-v*` / `mail-worker-v*` tag. They are shell, reviewed by reading; see the Review guide.
- **This detects rather than prevents.** A stopped-and-started instance will still come back with a stale clock; it will now say so within a minute instead of hiding for a day. Preventing it needs time sync in the unikernel or a runbook rule, which #590 still tracks.

## Review guide

Start with `packages/observability/src/export-health.ts` — `readClock` and `isClockSkewed` are the whole idea, and both are small.

**The judgement call worth checking:** the two-minute tolerance. Too tight and every process complains about ordinary round-trip delay; too loose and a real problem hides. Two minutes is far above any plausible latency and far below the hours a stopped machine comes back with, but it is a guess at a boundary rather than a measured one.

**The shell is the riskiest part of this diff**, because CI cannot run it — those workflows only fire on a release tag. I verified the CLI invocations by hand against the live account (`services list --filter 'metro=="fra"' -f name -o quiet` and the equivalent for instances both return clean name-per-line output and exit 0), and checked both files still parse as YAML. The logic around them is a careful read, not a tested path. One shape I got wrong on the first pass and fixed: piping `services create` through `tee` made the step's exit status `tee`'s, which always succeeds — so a genuine failure would have passed silently.

**Two gaps I left, deliberately.** The clock offset is only refreshed by an accepted export, so it goes stale while export is failing — the export-failing alarm covers that window, and the last known offset beats none. And if the CLI cannot answer at all, the worker's deletion check reads that as "the instance is gone" and lets the create collide as before; distinguishing "absent" from "cannot tell" needs a health probe that step has no business owning. The common case — one region down while others answer — is fixed.

**A correction to something I wrote in #591.** I listed the mail worker's watchdog as uncovered by tests. Checking rather than assuming, it is covered, across two suites: that the worker builds the exporting layer and hands its tracer and logger out is asserted by `live-layer.integration.test.ts` in the pre-push suite, and that such a layer runs a watchdog is asserted by `otlp.test.ts` under `pnpm test`. The worker's layer differs from the server's only in its service name, so there is no worker-specific behaviour left untested. I have not added a redundant test.

`packages/observability/src/otlp.ts` is the wiring, and the tests and guide are most of the line count.

## Tests

Unit tests for reading the backend's clock off a reply: the offset is kept, an unreadable date is ignored rather than trusted, and a refused reply is not read from at all. Separate tests for the decision itself — nothing claimed before a first reply, an ordinary difference ignored, and the 7 h 25 m production displacement caught in both directions. Plus the wire format, including a report from a process that has not compared yet.

I checked the clock tests are not vacuous by removing the call that reads the header: two of them fail, as they should.

## Verification

- `pnpm install`, `pnpm -w check-types`, `pnpm -w test` (all 23 packages), `pnpm -w build` — all green. Biome and dprint clean.
- Ran it against the live local stack rather than only the suite: a stand-in backend that **accepts every batch** but reports a clock 7 h 25 m ahead — the exact production displacement. `/health` returned `clockOffsetSeconds: -26700` while all three signals read `failing: false`, which is the outage reproduced and now visible. `otlp.clock.skewed` fired at error level on the first check, once, carrying the same number.
- Both workflow files parse as YAML; the CLI commands they use were run by hand against the live account.

No UI change, so no screenshots.

## Deferred

- Time sync inside the unikernel. The runbook rule is now written down, so a stopped instance gets redeployed rather than started, but nothing enforces it.

Addresses #590 — it detects the failure rather than preventing it, so the issue stays open for the recurrence work.

