### PR TITLE
fix: read a Catalan or Spanish name and find it again

### DIFF
--- a/apps/server/src/handlers/documents.ts
+++ b/apps/server/src/handlers/documents.ts
@@ -99,7 +99,7 @@ export const DocumentsLive = HttpApiBuilder.group(
 							conditions.push(
 								// An HTML body is not in the database, so its plain words
 								// are what the search has to match against.
-								sql`(d.title ILIKE ${needle} OR d.content ILIKE ${needle} OR d.search_text ILIKE ${needle})`,
+								sql`(normalize(d.title) ILIKE ${needle} OR d.content ILIKE ${needle} OR d.search_text ILIKE ${needle})`,
 							)
 						}
 						const whereClause =

--- a/apps/server/src/lib/search-text.ts
+++ b/apps/server/src/lib/search-text.ts
@@ -11,12 +11,28 @@
  * nine searches in this codebase did, each in the same way, while three wrote the
  * same escaping out by hand. There is nothing to remember if the finished pattern
  * is what comes back.
+ *
+ * Half of matching an accent lives here and half in the query: the column has to
+ * be read the same way — `normalize(name) ILIKE ${textAnywhere(q)}` — because an
+ * accent already stored can be written either way too, so neither half works
+ * alone. A slug or an email address needs none of it: both are plain letters by
+ * the time they are stored, so there is only one way to write them.
+ *
+ * Names and titles only, never the body of a document. Reading a whole document
+ * that way is seven times slower — measured at 0.37s against 2.6s over twenty
+ * thousand of them — and every search pays it. Finding a body by an accented word
+ * wants a searchable copy kept alongside it.
  */
 
 // The backslash escapes itself first, so a typed backslash cannot turn the
 // character after it into an instruction.
+//
+// An accented letter is put into one form first, because there are two ways to
+// write one and they do not match each other: an é can be a single character, or
+// an e with a mark added after it, and a Mac hands over the second where a browser
+// hands over the first. Somebody pasting "Calderería" from a file found nothing.
 const asPlainText = (typed: string): string =>
-	typed.replace(/[\\%_]/g, match => `\\${match}`)
+	typed.normalize('NFC').replace(/[\\%_]/g, match => `\\${match}`)
 
 /** Rows whose column holds this text anywhere in it. */
 export const textAnywhere = (typed: string): string => `%${asPlainText(typed)}%`

--- a/apps/server/src/mcp/tools/documents.ts
+++ b/apps/server/src/mcp/tools/documents.ts
@@ -211,7 +211,7 @@ export const DocumentHandlersLive = DocumentTools.toLayer(
 					if (params.q) {
 						const needle = textAnywhere(params.q)
 						conditions.push(
-							sql`(d.title ILIKE ${needle} OR d.content ILIKE ${needle})`,
+							sql`(normalize(d.title) ILIKE ${needle} OR d.content ILIKE ${needle})`,
 						)
 					}
 					const whereClause =

--- a/apps/server/src/mcp/tools/members.ts
+++ b/apps/server/src/mcp/tools/members.ts
@@ -51,7 +51,7 @@ export const MemberHandlersLive = MemberTools.toLayer(
 					if (query !== undefined) {
 						const like = textAnywhere(query)
 						conditions.push(
-							sql`(u.name ILIKE ${like} OR u.email ILIKE ${like})`,
+							sql`(normalize(u.name) ILIKE ${like} OR u.email ILIKE ${like})`,
 						)
 					}
 					// Read back camelCase whatever the column is called — the SQL client

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -131,7 +131,7 @@ const companyConditions = (
 				sql`EXISTS (
 					SELECT 1 FROM jsonb_array_elements(COALESCE(fit_checks, '[]'::jsonb)) fc
 					WHERE fc->>'result' = 'pass'
-						AND fc->>'criterion' ILIKE ${textAnywhere(filters.fitCriterionPassed)}
+						AND normalize(fc->>'criterion') ILIKE ${textAnywhere(filters.fitCriterionPassed)}
 				)`,
 			)
 		if (filters.attention)
@@ -139,7 +139,7 @@ const companyConditions = (
 				attentionCondition(sql, filters.attention, filters.staleDays),
 			)
 		if (filters.query)
-			conditions.push(sql`name ILIKE ${textAnywhere(filters.query)}`)
+			conditions.push(sql`normalize(name) ILIKE ${textAnywhere(filters.query)}`)
 		// A rectangle on the map matches a company when the company's own pin is
 		// inside it, or when any of its branches is. Without the second half, a
 		// chain registered in one city is invisible to somebody drawing a box

--- a/apps/server/src/services/company-search-accents.integration.test.ts
+++ b/apps/server/src/services/company-search-accents.integration.test.ts
@@ -1,0 +1,129 @@
+// Live-DB integration test for finding a company whose name carries an accent.
+//
+// An accented letter can be written two ways and the two do not match each other:
+// é is either one character, or an e with a mark added after it. A browser hands
+// over the first, a Mac hands over the second, and a name scraped off a page can be
+// either. So the same word typed twice found a company once and nothing the other
+// time, with no way for the person searching to tell why.
+//
+// A live database on purpose: what is pinned down is how Postgres compares the
+// two forms, which is the half no unit test can reach.
+//
+// Prereq: `pnpm cli services up` — the integration runner's globalSetup builds,
+// migrates and seeds the disposable database this suite runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../db/client'
+import { applyTestEnv } from '../test-env'
+import { CompanyService } from './companies'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+const TAG = `accents-${randomUUID().slice(0, 8)}`
+
+// The same name written both ways: the accent joined onto the letter, and the
+// accent left as a mark of its own after the letter.
+const JOINED = 'Calderería Sentmenat'.normalize('NFC')
+const APART = 'Calderería Sentmenat'.normalize('NFD')
+
+let pool: pg.Pool
+let orgId: string
+
+const deps = CompanyService.layer.pipe(Layer.provideMerge(PgLive))
+
+// Read the way a request does: role app_user, scoped to this org, so row-level
+// security applies exactly as it would in production.
+const searchFor = (query: string): Promise<ReadonlyArray<string>> =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const companies = yield* CompanyService
+		return yield* sql.withTransaction(
+			Effect.gen(function* () {
+				yield* sql`SET LOCAL ROLE app_user`
+				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+				const page = yield* companies.search({ query, limit: 50 }).pipe(
+					Effect.provideService(CurrentOrg, {
+						id: orgId,
+						name: 'fixture',
+						slug: 'fixture',
+						role: 'member' as const,
+					}),
+				)
+				return page.items
+					.map(row => row.name)
+					.filter(name => name.includes(TAG))
+			}),
+		)
+	}).pipe(Effect.provide(deps), Effect.orDie, Effect.runPromise)
+
+const insertCompany = async (name: string, slug: string): Promise<void> => {
+	await pool.query(
+		`INSERT INTO companies (organization_id, slug, name, status)
+		 VALUES ($1, $2, $3, 'prospect')`,
+		[orgId, slug, name],
+	)
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	const orgs = await pool.query<{ id: string }>(
+		`SELECT id FROM organization ORDER BY id LIMIT 1`,
+	)
+	const first = orgs.rows[0]?.id
+	if (first === undefined)
+		throw new Error('an organization must be seeded — run the setup')
+	orgId = first
+	// One company stored with the accent joined on, one with it written apart —
+	// both shapes really do arrive, so both have to be findable.
+	await insertCompany(`${JOINED} ${TAG} joined`, `${TAG}-joined`)
+	await insertCompany(`${APART} ${TAG} apart`, `${TAG}-apart`)
+})
+
+afterAll(async () => {
+	await pool.query('DELETE FROM companies WHERE slug LIKE $1', [`${TAG}%`])
+	await pool.end()
+})
+
+describe('searching for a company whose name carries an accent', () => {
+	describe('when the search is typed with the accent joined on', () => {
+		it('should find it however the stored name was written', async () => {
+			// GIVEN two companies, one stored each way
+			// WHEN the accented word is typed the joined way, as a browser sends it
+			// THEN both come back — a company stored the other way is not a miss
+			const found = await searchFor('Calderería'.normalize('NFC'))
+			expect(found).toHaveLength(2)
+		})
+	})
+
+	describe('when the search is typed with the accent written apart', () => {
+		it('should find it however the stored name was written', async () => {
+			// GIVEN the same two companies
+			// WHEN the word is pasted the way a Mac writes it
+			// THEN both still come back — this is the direction somebody hit while
+			// pasting a name out of a file
+			const found = await searchFor('Calderería'.normalize('NFD'))
+			expect(found).toHaveLength(2)
+		})
+	})
+
+	describe('when the search names a different company', () => {
+		it('should still find nothing', async () => {
+			// GIVEN a word neither company is called
+			// WHEN searched
+			// THEN nothing. Reading the two forms alike must not make everything alike
+			const found = await searchFor(`Fusteria ${TAG}`)
+			expect(found).toEqual([])
+		})
+	})
+})

--- a/apps/server/src/services/tasks.ts
+++ b/apps/server/src/services/tasks.ts
@@ -219,13 +219,13 @@ export class TaskService extends Context.Service<TaskService>()('TaskService', {
 				// They are documents now, so a search that only read the row would
 				// quietly stop finding half of what it used to.
 				conditions.push(sql`(
-					title ILIKE ${needle}
+					normalize(title) ILIKE ${needle}
 					OR EXISTS (
 						SELECT 1 FROM document_links dl
 						JOIN documents d ON d.id = dl.document_id
 						WHERE dl.subject_table = 'tasks' AND dl.subject_id = tasks.id
 							AND (
-								d.title ILIKE ${needle}
+								normalize(d.title) ILIKE ${needle}
 								OR d.content ILIKE ${needle}
 								OR d.search_text ILIKE ${needle}
 							)

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -594,7 +594,10 @@ export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 							const record =
 								looked._tag === 'already_charged' ? null : looked.value
 							people = (record?.directors ?? []).map(d => {
-								const { firstName, lastName } = splitPersonName(d.name)
+								const { firstName, lastName } = splitPersonName(
+									d.name,
+									input.country,
+								)
 								return { firstName, lastName, position: d.role }
 							})
 						}

--- a/packages/research/src/application/email-guess.test.ts
+++ b/packages/research/src/application/email-guess.test.ts
@@ -246,3 +246,177 @@ describe('splitPersonName', () => {
 		})
 	})
 })
+
+describe('splitting a name that may carry two surnames', () => {
+	describe('when the company is in a Spanish-speaking country', () => {
+		it('should use the surname the person is actually called by', () => {
+			// GIVEN ordinary names from this market, where the father's surname comes
+			// first and the mother's second
+			// WHEN split
+			// THEN the first of the two is what comes back. Taking the last word gives
+			// the mother's surname, which is neither what the person is called nor how
+			// their address is built
+			expect(splitPersonName('María García López', 'ES')).toEqual({
+				firstName: 'María',
+				lastName: 'García',
+			})
+			expect(splitPersonName('Guillem Puche Sanz', 'ES')).toEqual({
+				firstName: 'Guillem',
+				lastName: 'Puche',
+			})
+			expect(splitPersonName('Carlos Ruiz Mendoza', 'MX')).toEqual({
+				firstName: 'Carlos',
+				lastName: 'Ruiz',
+			})
+		})
+
+		it('should read a name whose two surnames are joined by a little word', () => {
+			// GIVEN the Catalan shape, where "i" sits between the two surnames
+			// WHEN split
+			// THEN the joining word belongs to neither and the first surname stands
+			expect(splitPersonName('Jordi Pujol i Soley', 'ES')).toEqual({
+				firstName: 'Jordi',
+				lastName: 'Pujol',
+			})
+		})
+
+		it('should keep a surname whole when it opens with a little word', () => {
+			// GIVEN a surname of several words, as many here are
+			// WHEN split
+			// THEN it comes back whole rather than cut at its first word
+			expect(splitPersonName('Ana de la Torre Ruiz', 'ES')).toEqual({
+				firstName: 'Ana',
+				lastName: 'de la Torre',
+			})
+		})
+
+		it('should not be fooled by a given name of two words', () => {
+			// GIVEN a compound given name, which is ordinary here
+			// WHEN split
+			// THEN still the first surname. The two surnames sit at the end whatever
+			// the given name is, so nothing has to count the words in front of them
+			expect(splitPersonName('José María García López', 'ES')).toEqual({
+				firstName: 'José',
+				lastName: 'García',
+			})
+		})
+
+		it('should leave a name carrying only one surname alone', () => {
+			// GIVEN a two-word name
+			// WHEN split
+			// THEN the one surname it has. Two surnames is the norm, not a rule
+			expect(splitPersonName('Ada Lovelace', 'ES')).toEqual({
+				firstName: 'Ada',
+				lastName: 'Lovelace',
+			})
+		})
+	})
+
+	describe('when the country reads its surnames the other way round', () => {
+		it('should take the last word as the surname', () => {
+			// GIVEN Portugal and Brazil, which also carry two surnames but put the
+			// mother's first and the father's last, and a country with one surname
+			// WHEN split
+			// THEN the last word, which is right for all three
+			expect(splitPersonName('João Silva Santos', 'PT')).toEqual({
+				firstName: 'João',
+				lastName: 'Santos',
+			})
+			expect(splitPersonName('Mary Jane Watson', 'US')).toEqual({
+				firstName: 'Mary',
+				lastName: 'Watson',
+			})
+		})
+	})
+
+	describe('when no country is known', () => {
+		it('should fall back to the last word', () => {
+			// GIVEN no country to settle it. "María García López" and "Mary Jane
+			// Watson" are the same shape, and nothing in either says which it is
+			// WHEN split
+			// THEN the last word — a guess at the country would be a guess at the
+			// answer
+			expect(splitPersonName('María García López')).toEqual({
+				firstName: 'María',
+				lastName: 'López',
+			})
+			expect(splitPersonName('Mary Jane Watson')).toEqual({
+				firstName: 'Mary',
+				lastName: 'Watson',
+			})
+		})
+	})
+
+	describe('when the name arrives the way a register writes it', () => {
+		it('should pick the same surname as it would from the plain shape', () => {
+			// GIVEN the "SURNAME, Forename" shape a register hands back. It says which
+			// words are surnames, but not which of them the person goes by
+			const fromRegister = splitPersonName('GARCÍA LÓPEZ, María', 'ES')
+			const fromPlain = splitPersonName('María García López', 'ES')
+
+			// WHEN both are read
+			// THEN the same woman comes back the same way. She was arriving as
+			// garcialopez@ from the register and garcia@ from a page, and only one of
+			// those reaches her
+			expect(fromRegister.lastName).toBe('GARCÍA')
+			expect(guessEmails({ ...fromRegister, domain: 'acme.es' })[0]).toBe(
+				guessEmails({ ...fromPlain, domain: 'acme.es' })[0],
+			)
+		})
+
+		it('should leave the surnames whole where they are read the other way', () => {
+			// GIVEN the same shape from countries that do not put the father's
+			// surname first
+			// WHEN read
+			// THEN what the register gave stands, as it always did
+			expect(splitPersonName('SMITH, John', 'GB').lastName).toBe('SMITH')
+			expect(splitPersonName('SILVA SANTOS, João', 'PT').lastName).toBe(
+				'SILVA SANTOS',
+			)
+			expect(splitPersonName('VAN DEN BERG, Jan', 'NL').lastName).toBe(
+				'VAN DEN BERG',
+			)
+		})
+	})
+
+	describe('when a little word carries a surname', () => {
+		it('should keep the surname whole rather than cut off its opening', () => {
+			// GIVEN names whose surname opens with a little word
+			// WHEN split
+			// THEN the whole surname. Taking the last word alone addressed Jan van den
+			// Berg as jan.berg@, which is not his name
+			expect(splitPersonName('Jan van den Berg').lastName).toBe('van den Berg')
+			expect(splitPersonName('Ludwig von Mises').lastName).toBe('von Mises')
+		})
+
+		it('should treat the same word as a first name when it opens one', () => {
+			// GIVEN people whose given name is spelled like one of those little words
+			// WHEN split
+			// THEN it is their first name. Carried onto what follows, Van Morrison
+			// became one long first name with no surname at all, and no address could
+			// be built for him
+			expect(splitPersonName('Van Morrison')).toEqual({
+				firstName: 'Van',
+				lastName: 'Morrison',
+			})
+			expect(splitPersonName('Do Kim')).toEqual({
+				firstName: 'Do',
+				lastName: 'Kim',
+			})
+		})
+	})
+
+	describe('when the addresses are guessed from it', () => {
+		it('should build them on the surname the person goes by', () => {
+			// GIVEN a Spanish name at a Spanish company
+			const name = splitPersonName('María García López', 'ES')
+
+			// WHEN addresses are guessed
+			// THEN they are built on García. Only the first guess is ever tried, and a
+			// wrong one fails its check and leaves the person with no address at all
+			expect(guessEmails({ ...name, domain: 'acme.es' })[0]).toBe(
+				'maria.garcia@acme.es',
+			)
+		})
+	})
+})

--- a/packages/research/src/application/email-guess.ts
+++ b/packages/research/src/application/email-guess.ts
@@ -70,28 +70,146 @@ export interface PersonName {
 	readonly lastName: string
 }
 
+// Countries where a person carries two surnames and the FIRST of them is the one
+// they go by — the father's. "María García López" is Señora García, and her
+// address is maria.garcia@, never maria.lopez@.
+//
+// Portugal and Brazil are deliberately absent though they also carry two: there
+// the order is the other way round, mother's then father's, so the LAST surname
+// is the one they go by and the ordinary reading below is already right.
+const FATHERS_SURNAME_COMES_FIRST = new Set([
+	'ES',
+	'MX',
+	'AR',
+	'CL',
+	'CO',
+	'PE',
+	'VE',
+	'EC',
+	'BO',
+	'PY',
+	'UY',
+	'CR',
+	'CU',
+	'DO',
+	'GT',
+	'HN',
+	'NI',
+	'PA',
+	'SV',
+])
+
+// Little words that are part of the surname following them rather than a name of
+// their own — "de la Torre" is one surname. `i` and `y` are the other shape: they
+// sit BETWEEN two surnames ("Pujol i Soley") and belong to neither.
+const CARRIED_INTO_THE_NEXT_WORD = new Set([
+	'de',
+	'del',
+	'la',
+	'las',
+	'los',
+	'da',
+	'das',
+	'do',
+	'dos',
+	'van',
+	'von',
+	'der',
+	'den',
+])
+const JOINS_TWO_SURNAMES = new Set(['i', 'y'])
+
+// The words of a name, with each little word joined onto the one it belongs to,
+// so "Ana de la Torre Ruiz" reads as three names and not five.
+//
+// A little word is only little when a name comes before it. Opening a name, the
+// same spelling is somebody's actual first name — Van Morrison, and Do and Da as
+// Korean and Vietnamese given names — and joining it to what follows leaves the
+// person with one long first name and no surname at all.
+const nameParts = (tokens: ReadonlyArray<string>): ReadonlyArray<string> => {
+	const parts: string[] = []
+	let carried = ''
+	for (const token of tokens) {
+		const lower = token.toLowerCase()
+		const opensTheName = parts.length === 0 && carried === ''
+		if (!opensTheName && JOINS_TWO_SURNAMES.has(lower)) continue
+		if (!opensTheName && CARRIED_INTO_THE_NEXT_WORD.has(lower)) {
+			carried = carried === '' ? token : `${carried} ${token}`
+			continue
+		}
+		parts.push(carried === '' ? token : `${carried} ${token}`)
+		carried = ''
+	}
+	// A little word with nothing after it is a name's last word, not a carry.
+	if (carried !== '') parts.push(carried)
+	return parts
+}
+
+// Which of a person's surnames they go by, given every surname they carry.
+// Two of them and a country that puts the father's first means the first one;
+// anything else means the whole of what was given.
+const surnameGoneBy = (
+	surnames: ReadonlyArray<string>,
+	country: string | undefined,
+): string | null => {
+	if (surnames.length < 2) return null
+	if (country === undefined) return null
+	return FATHERS_SURNAME_COMES_FIRST.has(country.trim().toUpperCase())
+		? (surnames[0] ?? null)
+		: null
+}
+
 /**
- * Split a single display name into first + last. Handles the
- * "SURNAME, Forename" shape registries like Companies House return, as well as
- * plain "First Last". A one-word name becomes the first name with no surname.
+ * Split a single display name into the given name and the surname somebody is
+ * actually addressed by.
+ *
+ * Handles the "SURNAME, Forename" shape registries like Companies House return, as
+ * well as plain "First Last". A one-word name becomes the first name with no
+ * surname.
+ *
+ * `country` is where the company is, which is the only thing that can settle a
+ * name of three or more words. "María García López" and "Mary Jane Watson" are the
+ * same shape, and taking the last word — which is right for Mary — gives López,
+ * the mother's surname, which is not what a Spanish or Latin American person is
+ * called or how their address is built. Nothing in the name itself says which of
+ * the two it is, so with no country given the ordinary reading stands.
  */
-export const splitPersonName = (name: string): PersonName => {
+export const splitPersonName = (
+	name: string,
+	country?: string | undefined,
+): PersonName => {
 	const trimmed = name.trim()
 	if (trimmed.includes(',')) {
 		const comma = trimmed.indexOf(',')
-		const last = trimmed.slice(0, comma).trim()
+		const surnames = trimmed.slice(0, comma).trim()
 		const first =
 			trimmed
 				.slice(comma + 1)
 				.trim()
 				.split(/\s+/)[0] ?? ''
-		return { firstName: first, lastName: last }
+		// This shape says which words are surnames but not which of them the person
+		// goes by, so the same reading applies: a register handing back "GARCÍA
+		// LÓPEZ, María" means the same woman as "María García López", and she was
+		// coming back as garcialopez@ from one and garcia@ from the other.
+		const parts = nameParts(surnames.split(/\s+/).filter(t => t.length > 0))
+		return {
+			firstName: first,
+			lastName: surnameGoneBy(parts, country) ?? surnames,
+		}
 	}
-	const tokens = trimmed.split(/\s+/).filter(t => t.length > 0)
-	return {
-		firstName: tokens[0] ?? '',
-		lastName: tokens.length > 1 ? (tokens[tokens.length - 1] ?? '') : '',
-	}
+	const parts = nameParts(trimmed.split(/\s+/).filter(t => t.length > 0))
+	const first = parts[0] ?? ''
+	if (parts.length < 2) return { firstName: first, lastName: '' }
+
+	// Two surnames sit at the end whatever the given name is, so a compound given
+	// name like "José María" needs no counting: it is the last two that are
+	// surnames, and which of those the person goes by is read the same way.
+	const surnames = parts.slice(-2)
+	const last =
+		(parts.length > 2 ? surnameGoneBy(surnames, country) : null) ??
+		parts[parts.length - 1] ??
+		''
+	return { firstName: first, lastName: last }
 }
 
 /** Ordered, de-duplicated candidate emails for a name at a domain. */


### PR DESCRIPTION
## What

Two bugs on ordinary Catalan and Spanish input — the market this product actually serves. Both surfaced while auditing `#534`, which had filed them as problems with alphabets other than Latin; they are not, and measuring them is what showed it.

The first quietly stops decision-maker email discovery working for most contacts here. The second makes a company impossible to find by its own name depending on where the search text was pasted from. Research bounded context (`packages/research`) and the CRM's searches (`server`).

## Changes

**Touches:** the reading that turns a person's display name into a first name and a surname, and the six searches that match typed text against a name somebody wrote — company, colleague, task, document title, fit criterion.

- **A person's surname is read from the country the company is in.** A name was split as first word given, last word family. In Spain and Latin America a person carries two surnames and the **first** is the one they go by: `María García López` is Señora García. The old reading returned `López`, her mother's surname. This applies to both shapes a name arrives in — plain, and the `SURNAME, Forename` a register hands back — which previously disagreed with each other.
- **A surname opening with a little word is kept whole**, whatever the country: `Jan van den Berg` was being addressed as `jan.berg@`, which is not his name. The same word opening a name is left alone as a first name, since `Van` and `Do` are given names too.
- **An accented letter is put into one form on both sides of a search.** There are two ways to write é — one character, or an e with a mark added after it — and they do not match each other.

## Impact

- **This changes which address is guessed for a contact in a Spanish-speaking market**, which is the point, but it also means contacts discovered *before* this runs may hold an address built on the wrong surname. Nothing rewrites them; a fresh scan of the same company would now guess correctly.
- **Only the first guessed address is ever tried**, and one that fails its check is dropped rather than sent — so what this fixes is not wrong addresses going out, it is contacts coming back with **no address at all**. That makes it invisible in the data today: the failure looks like "no email found", not like a mistake.
- **Nothing touching which organisation can see what (row-level security)**, authentication, or route protection. No schema change, no migration, no new environment variables, no change to the assistant-facing tool surface (MCP) or the typed client the web app uses.
- **Search reads a little more per row.** Measured on a short name column at 50,000 rows: 29ms against 70ms. Document **bodies** are deliberately excluded — there the same change measured 0.37s against 2.6s over 20,000 documents, a sevenfold cost every search would pay.
- **Independent of `#593`.** Different files, no shared commits; either can merge first.

## Review guide

Start with `splitPersonName` in `packages/research/src/application/email-guess.ts`. The decision worth checking is that the country is doing the work for *which of two surnames* to use: nothing in a name says which shape it is — `María García López` and `Mary Jane Watson` are identical in structure — so a rule read off the name alone would have to guess.

Note one thing that is **not** country-gated, deliberately: joining a little word onto the surname it belongs to. `Jan van den Berg` now gives `van den Berg` where it used to give `Berg`, with or without a country, because `jan.berg@` is wrong in every country that writes such a name. It is covered by tests.

Two calls you might overrule:

- **The country list has 19 entries.** Portugal and Brazil are deliberately absent although they also carry two surnames: there the order is reversed, so the existing reading is already right for them. If you would rather ship `ES` alone and widen later, that is a one-line change.
- **Document bodies are left out of the accent fix.** That is a performance call with numbers behind it, not an oversight, and it leaves one real gap: a document body containing an accented word is still only findable if the search is typed the same way the body was stored. Doing it properly wants a searchable copy kept beside the body, which lines up with the full-text work already deferred on `#534`.

I left `likeNeedle` in `apps/server/src/handlers/documents.ts:64` alone — a one-use alias for `textAnywhere` that makes the changed line read differently from its five siblings. It sits outside this change, so tidying it here would be scope creep; worth a follow-up.

## Tests

- Unit tests for the name reading, covering what must change (three-word Spanish and Mexican names, the Catalan `Pujol i Soley` shape, a compound given name, a multi-word surname like `de la Torre`, and the register shape agreeing with the plain one) and what must not (Portugal, the Netherlands, the UK, the US, a two-word name, and a name whose *first* word is spelled like a little word — `Van Morrison`, `Do Kim`).
- A live-database test for the accented search: two companies stored with the accent written each way, found by the word typed each way, with an unrelated name still matching nothing.
- Both were confirmed to **fail without their fix** — the search one finds 1 of 2 companies with the change reverted — so they guard rather than decorate.

## Verification

Run on this branch after rebasing onto current `main`:

- `pnpm -w check-types` (14/14), `pnpm -w test` (23/23), `pnpm -w build` (14/14).
- `pnpm check` — no errors; the 60 warnings match `main` exactly.
- Server integration suite against the live stack: 106 files, 836 tests.
- The cost figures above were measured against a real Postgres with generated data at the stated row counts, not estimated.

Addresses #534, which stays open for the items that genuinely are about other alphabets.
