### PR TITLE
fix: stop a cut through the middle of a character failing a write

### DIFF
--- a/apps/mail-worker/src/bounces.ts
+++ b/apps/mail-worker/src/bounces.ts
@@ -2,6 +2,7 @@ import { DateTime, Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import type { ParsedMail } from 'mailparser'
 
+import { clipText } from '@batuda/domain'
 import { EmailBounced, TimelineActivityService } from '@batuda/timeline'
 
 import { asOrg } from './lib/as-org.js'
@@ -80,7 +81,7 @@ const parseDeliveryStatus = (
 		} else if (name === 'status' && status === null) {
 			status = value
 		} else if (name === 'diagnostic-code' && diagnostic === null) {
-			diagnostic = value.slice(0, 500)
+			diagnostic = clipText(value, 500)
 		}
 	}
 	return { recipients, status, diagnostic }

--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import type { ParsedMail } from 'mailparser'
 
+import { clipText } from '@batuda/domain'
 import { NoMatch, ParticipantMatcher } from '@batuda/email/participant-matcher'
 import { EmailReceived, TimelineActivityService } from '@batuda/timeline'
 
@@ -83,7 +84,7 @@ export const fromParsedMail = (mail: ParsedMail): ParsedInbound => {
 				? [inReplyTo]
 				: []
 	const text = typeof mail.text === 'string' ? mail.text : null
-	const preview = text ? text.slice(0, 200) : null
+	const preview = text ? clipText(text, 200) : null
 	return {
 		messageId,
 		inReplyTo,

--- a/packages/domain/src/clip-text.test.ts
+++ b/packages/domain/src/clip-text.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import { clipText } from './clip-text'
+
+// Cutting text nobody controls — a scraped page, an email, a model's answer — down
+// to a length it can be stored at. What matters is that the cut never lands inside
+// a character, because half a character written out as JSON is refused by the
+// database and the whole write fails.
+
+describe('clipText', () => {
+	describe('when the value is already short enough', () => {
+		it('should hand it back exactly as it came', () => {
+			// GIVEN values at and under the limit
+			// WHEN clipped
+			// THEN unchanged — nothing to cut
+			expect(clipText('hello', 10)).toBe('hello')
+			expect(clipText('hello', 5)).toBe('hello')
+			expect(clipText('', 5)).toBe('')
+		})
+	})
+
+	describe('when the cut lands between the two halves of one character', () => {
+		it('should leave the whole character out rather than half of it', () => {
+			// GIVEN text whose fourth character is an emoji, cut to four
+			const clipped = clipText('abc🚀def', 4)
+
+			// WHEN the result is inspected
+			// THEN the emoji is either whole or absent, never half. Half of one is
+			// what the database refuses, failing a write that had nothing else wrong
+			// with it
+			expect(clipped.isWellFormed()).toBe(true)
+			expect(clipped).toBe('abc🚀')
+		})
+
+		it('should keep the result usable as JSON', () => {
+			// GIVEN the shape that broke a real write: a scraped line with an emoji
+			// straddling the cut
+			const line = `${'x'.repeat(199)}🚀 and more text`
+			const clipped = clipText(line, 200)
+
+			// WHEN written out as JSON, the way findings and citations are stored
+			// THEN nothing in it needs escaping into something the database will
+			// refuse. Cut by storage units instead, this produced `\\ud83d` — six
+			// plain characters that reach Postgres and are rejected there
+			expect(clipped.isWellFormed()).toBe(true)
+			expect(JSON.stringify({ quote: clipped })).not.toContain('\\ud8')
+		})
+	})
+
+	describe('when the text is written in characters that each take two units', () => {
+		it('should count them as a reader would, not as storage does', () => {
+			// GIVEN four emoji, which occupy eight units between them
+			const clipped = clipText('🚀🚀🚀🚀', 3)
+
+			// WHEN clipped to three
+			// THEN three come back. Counting units gave one and a half, so text in
+			// such characters was being cut to half the length asked for
+			expect([...clipped]).toHaveLength(3)
+			expect(clipped.isWellFormed()).toBe(true)
+		})
+	})
+
+	describe('when the text is ordinary', () => {
+		it('should cut at exactly the length asked for', () => {
+			// GIVEN plain and accented Latin, and Chinese
+			// WHEN clipped
+			// THEN the same answer the old reading gave, so nothing already stored
+			// changes meaning
+			expect(clipText('abcdefgh', 3)).toBe('abc')
+			expect(clipText('Calderería Sentmenat', 10)).toBe('Calderería')
+			expect(clipText('北京物流有限公司', 4)).toBe('北京物流')
+		})
+	})
+
+	describe('when a caller marks what it shortened', () => {
+		it('should let the caller tell whether anything came off', () => {
+			// GIVEN text of few characters stored in many units, and genuinely long
+			// text. A caller that asks "is this long?" one way and cuts it another
+			// puts an ellipsis on a value it never shortened
+			const dense = '🚀'.repeat(70)
+			const long = 'a'.repeat(300)
+
+			// WHEN each is clipped
+			// THEN comparing the result against what went in answers it exactly,
+			// which asking `.length` beforehand does not
+			expect(clipText(dense, 120)).toBe(dense)
+			expect(clipText(long, 120)).not.toBe(long)
+		})
+	})
+
+	describe('when the limit is nothing or less', () => {
+		it('should give nothing back', () => {
+			// GIVEN a limit of zero, and a negative one
+			// WHEN clipped
+			// THEN empty rather than a slice read from the far end, which is what a
+			// negative count does to `slice`
+			expect(clipText('hello', 0)).toBe('')
+			expect(clipText('hello', -1)).toBe('')
+		})
+	})
+})

--- a/packages/domain/src/clip-text.ts
+++ b/packages/domain/src/clip-text.ts
@@ -1,0 +1,47 @@
+/**
+ * Cutting a piece of text down to a length, without cutting a character in half.
+ *
+ * JavaScript measures a string in UTF-16 units rather than in characters, and
+ * anything outside the everyday range — an emoji, and the rarer Chinese and
+ * Japanese characters — takes two of them. `slice` counts those units, so a cut
+ * landing between the two halves of one character keeps half a character: a piece
+ * of a letter that is not a letter, and not text at all.
+ *
+ * That half-character is not merely ugly. Written out as JSON it becomes the six
+ * plain characters `\ud83d`, which travel to Postgres perfectly well and are then
+ * refused by its JSON reader — `invalid input syntax for type json` — so the whole
+ * write fails. A run that scraped a page with an emoji at the wrong offset could
+ * not file what it had found. Reproduced against a real database; the same text in
+ * an ordinary text column is accepted, with the half character replaced by `�`.
+ *
+ * So every cut of text nobody controls goes through here. The text that arrives is
+ * whatever a web page, an email or a model produced, and none of them owe us
+ * characters that survive being cut in the middle.
+ */
+
+// Whole characters rather than the units they are stored in. Anything above the
+// everyday range takes two units, and spreading the string hands back the
+// characters themselves — which is what a length should have been counting all
+// along.
+const charactersOf = (value: string): ReadonlyArray<string> => [...value]
+
+/**
+ * The first `maxCharacters` characters of a value, counted as a reader would count
+ * them. A value already that short comes back untouched, so the common case
+ * allocates nothing.
+ *
+ * Counting characters rather than storage units also means the result is at most
+ * `maxCharacters` characters wherever the text comes from, instead of shrinking to
+ * half that for a language whose characters happen to take two units each.
+ */
+export const clipText = (value: string, maxCharacters: number): string => {
+	if (maxCharacters <= 0) return ''
+	// `length` is the storage count, so it is never smaller than the character
+	// count — a value under the limit by that measure is under it by any measure,
+	// and there is nothing to cut.
+	if (value.length <= maxCharacters) return value
+	const characters = charactersOf(value)
+	return characters.length <= maxCharacters
+		? value
+		: characters.slice(0, maxCharacters).join('')
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,3 +1,4 @@
+export * from './clip-text'
 export * from './current-org'
 export * from './letter-equivalences.generated'
 export * from './schema/index'

--- a/packages/research/src/application/citation-guard.ts
+++ b/packages/research/src/application/citation-guard.ts
@@ -13,6 +13,8 @@
  * in every findings schema, so it filters wherever it finds a `citations` array.
  */
 
+import { clipText } from '@batuda/domain'
+
 import { isCitedField } from './guard-shapes'
 import { canonicalizeUrl, hostOf } from './source-key'
 
@@ -37,9 +39,15 @@ export interface CitationValidation {
 }
 
 // Bound a dropped value so a long string in the value slot can't bloat a log line.
+//
+// The mark goes on only when something was actually taken off. Asking whether the
+// text is long and then cutting it are two readings of "long", and where they
+// disagree — text of few characters stored in many units — a value that was never
+// shortened wears a mark saying it was.
 const boundDropValue = (value: unknown): string => {
 	const text = typeof value === 'string' ? value : JSON.stringify(value)
-	return text.length > 120 ? `${text.slice(0, 120)}…` : text
+	const bounded = clipText(text, 120)
+	return bounded === text ? text : `${bounded}…`
 }
 
 /**

--- a/packages/research/src/application/generic-emails.ts
+++ b/packages/research/src/application/generic-emails.ts
@@ -17,6 +17,8 @@
  *    kept as the quote, so it is grounded by construction.
  */
 
+import { clipText } from '@batuda/domain'
+
 // Role / department local parts across the languages the pipeline researches in.
 // A person's name is never in this list, so only shared mailboxes are captured.
 const ROLE_LOCALPARTS = new Set([
@@ -117,7 +119,7 @@ export const harvestGenericEmails = (
 				found.push({
 					value: email,
 					source_id: page.sourceId,
-					quote: line.trim().slice(0, 200),
+					quote: clipText(line.trim(), 200),
 					rank: rankOf(localPart),
 				})
 			}

--- a/packages/research/src/application/scalar-field-guard.ts
+++ b/packages/research/src/application/scalar-field-guard.ts
@@ -26,6 +26,8 @@
  * mistaken for a scalar field.
  */
 
+import { clipText } from '@batuda/domain'
+
 import { isSourcedField } from './guard-shapes'
 import { writtenWithoutWordSpaces } from './term-match'
 
@@ -310,9 +312,13 @@ export interface ScalarFieldGuardResult {
 }
 
 // A dropped value is short (a place, an industry code); cap it anyway so a runaway
-// string in the value slot can never bloat the per-drop log the guard emits.
-const truncateDropValue = (value: string): string =>
-	value.length > 120 ? `${value.slice(0, 120)}…` : value
+// string in the value slot can never bloat the per-drop log the guard emits. The
+// mark goes on only when something was actually taken off, since a value that was
+// never shortened must not wear one saying it was.
+const truncateDropValue = (value: string): string => {
+	const bounded = clipText(value, 120)
+	return bounded === value ? value : `${bounded}…`
+}
 
 /**
  * Enforce the grounded-or-absent contract on every per-field `Sourced` scalar in a

--- a/packages/research/src/infrastructure/brave/llm-context.ts
+++ b/packages/research/src/infrastructure/brave/llm-context.ts
@@ -23,6 +23,8 @@
 import { Config, Effect, Redacted, Schema } from 'effect'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
+import { clipText } from '@batuda/domain'
+
 import { type SearchInput, SearchProvider } from '../../application/ports'
 import { parseCountryAlpha2 } from '../../domain/country'
 import { ProviderError } from '../../domain/errors'
@@ -155,7 +157,7 @@ export const makeBraveLlmContextSearch = (slot: number) =>
 									new SearchResultItem({
 										url,
 										title: item.title ?? url,
-										snippet: content.slice(0, 300),
+										snippet: clipText(content, 300),
 										content,
 									}),
 								]

--- a/packages/research/src/infrastructure/firecrawl/search.ts
+++ b/packages/research/src/infrastructure/firecrawl/search.ts
@@ -22,6 +22,8 @@ import {
 	HttpClientResponse,
 } from 'effect/unstable/http'
 
+import { clipText } from '@batuda/domain'
+
 import { type SearchInput, SearchProvider } from '../../application/ports'
 import { parseCountryAlpha2 } from '../../domain/country'
 import { ProviderError } from '../../domain/errors'
@@ -161,7 +163,7 @@ export const makeFirecrawlSearch = (slot: number) =>
 									title: r.title ?? '',
 									// A preview at the same cut-off the Brave context adapter
 									// uses; the whole passage goes in `content` below.
-									snippet: passage.slice(0, 300),
+									snippet: clipText(passage, 300),
 									...(passage.length > 0 ? { content: passage } : {}),
 								})
 							}),


### PR DESCRIPTION
## What

A research run could fail to file what it had found, because of where a piece of text happened to be cut.

JavaScript counts a string in storage units rather than in characters, and anything outside the everyday range — an emoji, the rarer Chinese and Japanese characters — takes two units. Cutting text to a length by those units can keep **half a character**. Written out as JSON that half becomes six plain characters, which travel to Postgres perfectly well and are then refused by its JSON reader, so the write fails with `invalid input syntax for type json`.

This came out of investigating the items deferred on `#534`. It was not one of them — it is what the investigation found instead, and it is worth more than any of them. Research bounded context (`packages/research`), the mail worker, and a shared helper in `packages/domain`.

## Changes

**Touches:** one shared way to cut text down to a length, and the six places that cut text nobody controls — a line quoted beside an email address on a scraped page, a search result's preview from two vendors, a dropped field's value, a bounce's reason, and an email's preview.

- **The cut now counts characters rather than storage units**, so it never lands in the middle of one.
- **A length now means the same thing in every language.** Counting units quietly halved the limit for text whose characters take two units each, so a Chinese quote kept 100 characters where a Spanish one kept 200.

## Impact

- **This is a live failure, not a hardening exercise.** Reproduced against a real database on the path that files a run's citations: the same insert fails before the change and succeeds after it. The trigger is an emoji straddling the cut in a scraped line that also carries an email address — and a contact page with an emoji beside its address is an ordinary thing on the web.
- **Text whose characters each take one storage unit reads exactly as before** — every Latin, Cyrillic, Greek, Arabic and everyday Chinese name, checked at all three cut lengths in use.
- **Text built from characters that take two units does change, deliberately.** It now keeps the number of characters asked for instead of half that, so a 200-character limit means 200 characters whatever language wrote the text. An earlier draft of this description claimed only already-broken text changes; that was wrong, and this is the case it missed.
- **The equivalent cut into an ordinary text column was never a failure** — Postgres accepts it and stores one `�`. Those sites are changed too, because it is the same cut done the same way, but that half is cosmetic.
- **No schema change, no migration, no new environment variables.** Nothing touching which organisation can see what (row-level security), authentication, or the assistant-facing tool surface (MCP).

## Review guide

`packages/domain/src/clip-text.ts` is the whole idea; everything else is six call sites swapping one call for another.

The judgement worth checking is **where this belongs**. I fixed the cause — the cut — rather than the symptom at the database boundary, because a half character is wrong wherever it ends up, and a boundary guard would have left the broken text in place while hiding the failure. The alternative was sanitising at the JSON write, which would catch future sites this does not. If you would rather have both, the boundary guard is a separate small change.

One thing I did **not** do: there are other cuts on text in the codebase — a cached prompt key, a capability probe's error snippet — that do not carry untrusted page text into storage. I left them, rather than sweeping every `slice` in the repo.

## Tests

- Unit tests for the helper: a cut landing between the two halves of a character, the exact shape that broke the real write, a length counted in characters rather than units, ordinary Latin and Chinese text cut unchanged, a limit of zero or less, and the case behind the ellipsis fix below.
- Two guards mark a shortened value with an ellipsis. They asked whether the text was long by one measure and cut it by another, so text of few characters stored in many units came back untouched wearing a mark saying it had been shortened. They now ask whether anything actually came off.
- The reproduction itself is not a committed test — it needs a live database and an insert into a jsonb column. Recorded here instead: before, `invalid input syntax for type json`; after, the row writes.

## Verification

- `pnpm -w check-types` (14/14), `pnpm -w test` (23/23), `pnpm -w build` (14/14), `pnpm check` — no errors, 60 warnings matching `main`.
- Research suite specifically: 89 files, 2190 tests.
- Server integration suite against the live stack: 105 files, 833 tests.
- Old-versus-new insert run side by side against a real Postgres, and an equivalence check over Latin, Cyrillic, Greek, Arabic and CJK samples confirming identical output.

Addresses #534.
