### PR TITLE
docs: say who may write a company fit verdict

### DIFF
--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -74,7 +74,7 @@ export const CompanyFilterOptions = Schema.Struct({
 
 const SearchCompanies = Tool.make('search_companies', {
 	description:
-		'Filter companies by status, country (ISO 3166-1 alpha-2, e.g. US/ES/DE), industry, priority, search query, the research fit verdict (strong_fit / possible_fit / weak_fit / no_fit), a fit criterion the company passed (matched loosely against the criterion text), a tag or tags the company carries (every one named has to be on it, so a second tag narrows the list), one thing written under `metadata` given as `metadata_key` plus `metadata_value`, or a geographic bounding box. The box is any subset of min_lat/max_lat/min_lng/max_lng (decimal degrees); each bound is applied independently and only matches companies with stored coordinates. Returns summaries (including latitude/longitude) — call get_company for full details. Set `include_filter_options` to be told which countries and trades actually narrow this list, rather than guessing a value and getting nothing back. `hasMore` says whether more matched than were returned — read it before saying how many there are, and ask again with a larger `offset` if it is true.',
+		'Filter companies by status, country (ISO 3166-1 alpha-2, e.g. US/ES/DE), industry, priority, search query, the research fit verdict (strong_fit / possible_fit / weak_fit / no_fit) — what a research run concluded, which nothing but a run writes, so a view of your own lives under `metadata` and is found with the pair below — a fit criterion the company passed (matched loosely against the criterion text), a tag or tags the company carries (every one named has to be on it, so a second tag narrows the list), one thing written under `metadata` given as `metadata_key` plus `metadata_value`, or a geographic bounding box. The box is any subset of min_lat/max_lat/min_lng/max_lng (decimal degrees); each bound is applied independently and only matches companies with stored coordinates. Returns summaries (including latitude/longitude) — call get_company for full details. Set `include_filter_options` to be told which countries and trades actually narrow this list, rather than guessing a value and getting nothing back. `hasMore` says whether more matched than were returned — read it before saying how many there are, and ask again with a larger `offset` if it is true.',
 	parameters: Schema.Struct({
 		status: Schema.optional(Schema.String),
 		country: Schema.optional(Schema.String),
@@ -175,7 +175,10 @@ const companyInputFields = {
 	longitude: Schema.optional(CompanyLongitude),
 	geocodedAt: Schema.optional(Schema.String),
 	geocodeSource: Schema.optional(Schema.String),
-	metadata: Schema.optional(Schema.Unknown),
+	metadata: Schema.optional(Schema.Unknown).annotate({
+		description:
+			'Anything else worth keeping on this company, as a JSON object of your own shape. Searchable later through search_companies with metadata_key + metadata_value. Your own view of whether a company is worth selling to belongs here, by convention as `fitVerdict`: the separate fit_verdict field is what a research run concluded and nothing but a run writes it, so a judgement of your own has nowhere else to live.',
+	}),
 }
 const CompanyInput = Schema.Struct(companyInputFields)
 
@@ -283,7 +286,10 @@ const UpdateCompany = Tool.make('update_company', {
 					"The account's running notes, in markdown. One shared page — what you send replaces what is there and no earlier version is kept, so read it first and carry over anything still worth keeping.",
 			}),
 		),
-		metadata: Schema.optional(Schema.Unknown),
+		metadata: Schema.optional(Schema.Unknown).annotate({
+			description:
+				'Anything else worth keeping on this company, as a JSON object of your own shape. Searchable later through search_companies with metadata_key + metadata_value. Your own view of whether a company is worth selling to belongs here, by convention as `fitVerdict`: the separate fit_verdict field is what a research run concluded and nothing but a run writes it, so a judgement of your own has nowhere else to live.',
+		}),
 	}),
 	success: Schema.NullOr(Company.json),
 	dependencies: REQUEST_DEPENDENCIES,

--- a/apps/server/src/mcp/tools/company-fit-ownership.test.ts
+++ b/apps/server/src/mcp/tools/company-fit-ownership.test.ts
@@ -1,0 +1,121 @@
+import { Tool } from 'effect/unstable/ai'
+import { describe, expect, it } from 'vitest'
+
+import { CompanyTools } from './companies'
+
+// The research engine owns a company's fit fields: a run writes them when its
+// findings are applied, and nothing a person or an assistant calls sets them.
+// The rule is written down beside the columns, but a rule only written down is
+// one somebody adds a parameter past without noticing — so it is checked here,
+// against the surface the server actually serves.
+//
+// Somebody's own view of whether a company is worth selling to lives under
+// `metadata`; that is the field the write tools do offer.
+
+// Every field name the tool accepts, at whatever depth it sits. Read as names
+// rather than by searching the schema text, because the descriptions mention
+// these fields on purpose and would match a text search.
+const acceptedFieldNames = (toolName: string): ReadonlySet<string> => {
+	// Reached by name so the check reads the served surface rather than a second
+	// list kept beside it; the toolkit types its tools one by one, so the lookup
+	// goes through `unknown` rather than asserting a shape it does not have.
+	const tools = CompanyTools.tools as unknown as Record<string, Tool.Any>
+	const tool = tools[toolName]
+	if (tool === undefined) throw new Error(`no company tool named ${toolName}`)
+	const names = new Set<string>()
+	const walk = (node: unknown): void => {
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child)
+			return
+		}
+		if (typeof node !== 'object' || node === null) return
+		const record = node as Record<string, unknown>
+		const properties = record['properties']
+		if (typeof properties === 'object' && properties !== null)
+			for (const key of Object.keys(properties)) names.add(key)
+		for (const value of Object.values(record)) walk(value)
+	}
+	walk(Tool.getJsonSchema(tool))
+	return names
+}
+
+// What a client is actually told about one field, as published rather than as
+// written in the source — a description that never reaches the schema helps
+// nobody.
+const fieldDescription = (toolName: string, field: string): string => {
+	const tools = CompanyTools.tools as unknown as Record<string, Tool.Any>
+	const tool = tools[toolName]
+	if (tool === undefined) throw new Error(`no company tool named ${toolName}`)
+	let found = ''
+	const walk = (node: unknown): void => {
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child)
+			return
+		}
+		if (typeof node !== 'object' || node === null) return
+		const record = node as Record<string, unknown>
+		const properties = record['properties']
+		if (typeof properties === 'object' && properties !== null) {
+			const entry = (properties as Record<string, unknown>)[field]
+			if (typeof entry === 'object' && entry !== null) {
+				const described = (entry as { description?: unknown }).description
+				if (typeof described === 'string' && described !== '') found = described
+			}
+		}
+		for (const value of Object.values(record)) walk(value)
+	}
+	walk(Tool.getJsonSchema(tool))
+	return found
+}
+
+const FIT_FIELDS = ['fit_verdict', 'fitVerdict', 'fit_checks', 'fitChecks']
+
+describe('who may write a company fit verdict', () => {
+	describe.each([
+		'create_companies',
+		'update_company',
+	])('the %s tool', toolName => {
+		it('should accept no fit field, so a run stays the only writer', () => {
+			// GIVEN the parameters the tool really publishes
+			const accepted = acceptedFieldNames(toolName)
+
+			// THEN none of the fit fields is among them. A caller that could set
+			// the verdict would leave nobody able to tell what a run concluded
+			// from somebody disagreeing with it
+			for (const field of FIT_FIELDS)
+				expect(Array.from(accepted)).not.toContain(field)
+		})
+
+		it('should accept metadata, which is where a view of your own goes', () => {
+			// GIVEN the same parameters
+			// THEN metadata is offered, so the rule above leaves somewhere to put
+			// a judgement rather than simply refusing one
+			expect(Array.from(acceptedFieldNames(toolName))).toContain('metadata')
+		})
+
+		it('should tell a caller where its own verdict goes', () => {
+			// GIVEN the description a client actually receives for metadata
+			const described = fieldDescription(toolName, 'metadata')
+
+			// THEN it names the convention, because a caller that cannot find
+			// fit_verdict among these parameters is otherwise left to invent a place
+			// for its own judgement — which is how a second field came to exist
+			expect(described).toContain('fitVerdict')
+			expect(described).toContain('metadata_key')
+		})
+	})
+
+	describe('the search_companies tool', () => {
+		it('should still filter on the verdict a run reached', () => {
+			// GIVEN the search parameters
+			// AND the metadata pair added for a view of your own
+			const accepted = acceptedFieldNames('search_companies')
+
+			// THEN both routes are searchable: the run's verdict as its own filter,
+			// and yours through the metadata pair
+			expect(Array.from(accepted)).toContain('fit_verdict')
+			expect(Array.from(accepted)).toContain('metadata_key')
+			expect(Array.from(accepted)).toContain('metadata_value')
+		})
+	})
+})

--- a/packages/domain/src/schema/companies.ts
+++ b/packages/domain/src/schema/companies.ts
@@ -219,6 +219,15 @@ export class Company extends Model.Class<Company>('Company')({
 	// fitVerdict values: strong_fit | possible_fit | weak_fit | no_fit
 	// fitChecks[].result values: pass | fail | unknown
 	//
+	// These three are the research engine's own: a run writes them when its
+	// findings are applied, and no tool a person or an assistant can call sets
+	// them. That is deliberate — the field answers "what did the run conclude",
+	// and letting anything else write it would leave nobody able to tell a run's
+	// reading from somebody's disagreement with it. A view of your own about
+	// whether a company is worth selling to belongs under `metadata`, by
+	// convention as `fitVerdict` there, which search_companies can filter on with
+	// its metadata_key / metadata_value pair.
+	//
 	// The fit checks and conflicts are kept word for word as the research run
 	// wrote them, so their inner names are the ones the research schema defines.
 	// The provenance map is built entry by entry instead, so it carries this


### PR DESCRIPTION
## What

A company carries a verdict on whether it is worth selling to. That verdict is the research engine's: a run writes it when its findings are applied, and no tool a person or an assistant can call sets it. Nothing said so anywhere, so a caller that went looking for it, found it missing from the write tools, and needed somewhere to record its own view invented a second place — `metadata.fitVerdict` — and an instruction template written by hand had to warn people the two existed.

This keeps the split, because it is the right one: `fit_verdict` answers "what did the run conclude", and letting anything else write it would leave nobody able to tell a run's reading from somebody disagreeing with it. What changes is that the surface now says so, in the places a caller actually looks, and a test holds it there.

Surface: the CRM's company tools (`server`) and the shared company shape (`domain`).

## Changes

**Touches:** the two tools that write a company, the one that searches for companies, the company shape both of them read — and a test that checks the rule against the surface the server really serves, rather than against the sentence describing it.

- The `metadata` parameter on `create_companies` and `update_company` now says what it is for, that it is searchable, and that a view of your own about fit belongs there under the name `fitVerdict` — with the reason: the separate `fit_verdict` field is a run's conclusion and nothing but a run writes it.
- `search_companies` distinguishes the two: the run's verdict has its own filter, and yours is found with the `metadata_key` / `metadata_value` pair.
- The rule is recorded beside the columns in the shared company shape, so someone adding a parameter later reads it before adding one.

## Impact

- **No behaviour changes and no new capability.** Nothing that could be written before can be written now, and nothing that could be read before reads differently. The whole change is what a client is told.
- **Callers do see different tool descriptions**, which is the point: an assistant reading `update_company` is now told where its own judgement goes instead of having to work it out.
- Nothing touching which organisation can see what (row-level security), no database migration, no new settings, and no change to the shape of any answer.

## Review guide

- **The judgement to check is the direction, not the code.** I kept `fit_verdict` closed and documented the split rather than opening it up or collapsing the two fields. If you would rather a person could overrule a run's verdict, this is the PR to say so on — it would be a small change to make, and everything here would need rewording.
- The test is the part worth reading: it reads the published JSON schema rather than the source, so it catches both a fit field being added to a write tool and the explanation quietly disappearing. I checked it bites by adding `fit_verdict` to `update_company` and watching it fail.
- The wording avoids apostrophes in one place for a dull reason — the description is a single-quoted string and an apostrophe broke the build the first time.

## Tests

A new unit test over the served company tools: the fit fields must stay absent from what `create_companies` and `update_company` accept, `metadata` must stay present so the rule leaves somewhere to put a judgement, `search_companies` must still filter on both routes, and the published description must carry the convention.

## Verification

- Gates run on this branch: `pnpm install`, `pnpm check-types` (14/14), `pnpm test` (23/23), `pnpm build` (14/14).
- The guard was checked by breaking it on purpose: adding `fit_verdict` back to `update_company` fails the test with `expected [ 'id', …(32) ] to not include 'fit_verdict'`.
- `check-types` caught an unsound cast in my first version of the test that the test runner had happily executed — worth knowing that the test suite alone would not have.

## Deferred

- **Checkpointing a research run so a deploy cannot destroy it**, whose first slice is storing what a paid answer said rather than only that it was paid.
