### PR TITLE
chore: take the newer Unikraft CLI in the dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783689353,
-        "narHash": "sha256-gLPPj83ltHjNXbtOVxiAMmBieTPoZwTQefpCAhXmGaI=",
+        "lastModified": 1787855135,
+        "narHash": "sha256-EcdRVb9a624sy0cI4nK+tw2htA1mTCD5noMQeePcV1s=",
         "owner": "unikraft",
         "repo": "nur",
-        "rev": "e5b33203b32b9b84ff277051934ee05c7ef11e66",
+        "rev": "9c521222a2ad93d2c915fe832de0549a9639e5bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Moves the `unikraft` CLI in the nix dev shell from 0.4.2-staging.16 to 0.5.0-staging.32.

This is what `nix flake update unikraft-nur` produces, and `flake.nix` already names that as the way to bump it. The pin had drifted in a working tree without ever being committed, so this makes it a decision rather than a stray line.

## Changes

**Touches:** the lockfile pinning the Unikraft team's package repo, which is where `nix develop` gets the `unikraft` command. Nothing else — not the workflows that deploy, not the Kraftfiles.

- One input's pin moves forward about five weeks.

## Impact

- **No deploy changes.** The workflows that deploy the API and the mail worker install their own copy of the CLI through `unikraft/setup-action` and stay pinned at `0.4.1`. `flake.nix` says so where the pin is defined. Production cannot be reached by this.
- **What does change is a deploy run by hand.** `flake.nix` describes the dev-shell CLI as being for local spikes and manual deploys, and after this a manual deploy runs 0.5.0 where every automated one runs 0.4.1 — a minor version apart rather than a patch. Worth knowing before reaching for one.
- Nothing touching which organisation can see what (row-level security), no schema change, no new environment variables.

## Review guide

One line to look at. The judgement is whether you want the dev shell a minor version ahead of what CI deploys with. The alternative was bumping both together, which the workflow comment asks for — *"Bump deliberately after verifying a new release against a dry-run deploy"* — and that is a separate piece of work worth doing when 0.5.0 buys something.

## Verification

- `nix develop --command unikraft version` on this branch prints `0.5.0-staging.32`; on `main` it prints `0.4.2-staging.16`. Both shells build.
- Confirmed both deploy workflows still read `UNIKRAFT_CLI_VERSION: "0.4.1"`, so the deploy path is untouched.