### PR TITLE
feat(research): let the eval see why a run stopped looking

### DIFF
--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -628,9 +628,18 @@ const formatSummary = (summary: EvalSummary): string =>
 // What a pass of market requests got right. Silent for a pass of company profiles,
 // which has no list to judge — the figures are all null there, and printing five
 // "n/a" lines on every ordinary pass buries the ones that mean something.
+//
+// A pass whose market runs all died has no rows either, and it is the one pass
+// that must still say something: the count of runs that never came back is the
+// whole of what happened, and dropping the block would report it as a pass of
+// company profiles with no market in it at all.
 const formatMarketFigures = (summary: EvalSummary): ReadonlyArray<string> =>
 	summary.rowsPerScan === null
-		? []
+		? summary.scansThatNeverAnswered === null
+			? []
+			: [
+					`Market runs lost:       ${count(summary.scansThatNeverAnswered)} — every one of them, so there is nothing else to report`,
+				]
 		: [
 				`Rows per market:        ${decimal(summary.rowsPerScan)}`,
 				`  right kind:           ${pct(summary.organisationKindPrecision)}`,
@@ -645,6 +654,9 @@ const formatMarketFigures = (summary: EvalSummary): ReadonlyArray<string> =>
 				`  never looked for:     ${pct(summary.neverSearchedShare)} of what came back missing`,
 				`  scans that reckoned:  ${count(summary.scansReportingCoverage)}`,
 				`  thought it had them:  ${count(summary.partsThoughtAnswered)} (want nought)`,
+				`Said why they stopped:  ${count(summary.scansSayingWhyTheyStopped)}`,
+				`  of those, cut off:    ${count(summary.scansCutOff)} (their lists were cut short)`,
+				`Market runs lost:       ${count(summary.scansThatNeverAnswered)} (came back with nothing, and store no reason)`,
 			]
 
 // Which models actually did the work. A tier is configured with a first choice

--- a/apps/server/src/services/research-refine-pass-refused.integration.test.ts
+++ b/apps/server/src/services/research-refine-pass-refused.integration.test.ts
@@ -205,7 +205,10 @@ const runRow = (id: string) =>
 			return (yield* svc.get(id).pipe(Effect.orDie)) as {
 				status?: string
 				reason_code?: string | null
-				findings?: { error?: string } | null
+				findings?: {
+					error?: string
+					quality?: { searching_stopped?: string } | null
+				} | null
 			} | null
 		}),
 	)
@@ -261,6 +264,13 @@ describe('a refused extra searching pass', () => {
 			// the refined pass never ran, and an empty list read as a refined one
 			// reads as an empty market
 			expect(row?.findings?.error ?? '').not.toContain('refined retry')
+
+			// AND it says a provider refusal is what stopped it looking. This is the
+			// run's own account of why its list is short, and the first pass having
+			// settled is not that account: the retry was sent because the list was
+			// thin, and it never ran. Reported as finished looking, a short list
+			// here reads as a thin market
+			expect(row?.findings?.quality?.searching_stopped).toBe('provider_refused')
 
 			// AND it really did try to refine — the pass the provider refused
 			expect(firedEvents).toContain('research.refining')

--- a/packages/research/src/application/eval-outcome.test.ts
+++ b/packages/research/src/application/eval-outcome.test.ts
@@ -296,6 +296,50 @@ describe('outcomeFromRun', () => {
 		})
 	})
 
+	describe('when a scan said why it stopped looking', () => {
+		it('should read the reason off the run', () => {
+			// GIVEN a run stopped at its round cap
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				findings: {
+					prospects: [],
+					quality: { searching_stopped: 'round_cap_reached' },
+				},
+				fetchedUrls: [],
+			})
+
+			// THEN the reason is carried through
+			expect(outcome.searchingStopped).toBe('round_cap_reached')
+		})
+
+		it('should refuse a reason it cannot place', () => {
+			// GIVEN a run stored by a later build, naming a reason this one has
+			// never heard of
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				findings: { prospects: [], quality: { searching_stopped: 'gave_up' } },
+				fetchedUrls: [],
+			})
+
+			// THEN nothing is carried: a word this build cannot place must not read
+			// as a reason it can
+			expect(outcome.searchingStopped).toBeNull()
+		})
+
+		it('should refuse a word every object already carries', () => {
+			// GIVEN a run whose stored reason is the name every object answers to
+			// rather than a reason
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				findings: { prospects: [], quality: { searching_stopped: 'toString' } },
+				fetchedUrls: [],
+			})
+
+			// THEN it is refused like any other word this build cannot place
+			expect(outcome.searchingStopped).toBeNull()
+		})
+	})
+
 	describe('when a scan finished before these counts existed', () => {
 		it('should report no reckoning rather than a clean one', () => {
 			// GIVEN a block stored by an older run: it names what came back missing

--- a/packages/research/src/application/eval-outcome.ts
+++ b/packages/research/src/application/eval-outcome.ts
@@ -26,6 +26,7 @@ import {
 import { isConfirmedRow } from './existence-verdict'
 import { contactFill, enrichmentFill } from './extraction-fill'
 import { unwrapValue } from './guard-shapes'
+import { isSearchStopped, type SearchStopped } from './search-stopped'
 import { hostOf } from './source-key'
 
 const TERMINAL_STATUSES: ReadonlySet<string> = new Set<TerminalStatus>([
@@ -117,6 +118,18 @@ export const outcomeFromRun = (input: {
 		missing !== null && neverSearched !== null && thoughtAnswered !== null
 			? { missing, neverSearched, thoughtAnswered }
 			: null
+
+	// Why the run stopped looking for companies, taken off the same block. Read
+	// through `isSearchStopped` because it arrives as plain JSON: a word this
+	// build cannot place is dropped rather than carried, since anything but
+	// `finished_looking` counts as a run that was cut off.
+	const storedStop =
+		quality !== null && typeof quality === 'object'
+			? (quality as { searching_stopped?: unknown }).searching_stopped
+			: undefined
+	const searchingStopped: SearchStopped | null = isSearchStopped(storedStop)
+		? storedStop
+		: null
 
 	// The people the run kept (after the entity + grounding guards), each with the
 	// title it found or null — so the scorer can measure how many known contacts
@@ -221,6 +234,7 @@ export const outcomeFromRun = (input: {
 		companies,
 		registryConfirmed,
 		reportedCoverage,
+		searchingStopped,
 		// Only a run that was asked for a profile is measured on how full it came back.
 		// A search answers with a list and is never given one, so counting it reports
 		// every search as having filled none of a shape nobody asked it for — a failing

--- a/packages/research/src/application/eval-report.test.ts
+++ b/packages/research/src/application/eval-report.test.ts
@@ -13,6 +13,7 @@ const score = (over: Partial<RunScore>): RunScore => ({
 	fields: [],
 	grounded: true,
 	groundable: true,
+	marketWentUnanswered: false,
 	wrongCompany: false,
 	wrongCompanyAutoApplicable: false,
 	lowConfidence: false,
@@ -182,6 +183,9 @@ describe('evalSummaryAttributes', () => {
 				requestCoverage: null,
 				neverSearchedShare: null,
 				scansReportingCoverage: null,
+				scansSayingWhyTheyStopped: null,
+				scansThatNeverAnswered: null,
+				scansCutOff: null,
 				partsThoughtAnswered: null,
 				duplicateRate: null,
 				possibleDuplicateRate: null,
@@ -234,6 +238,9 @@ describe('evalSummaryAttributes', () => {
 				requestCoverage: null,
 				neverSearchedShare: null,
 				scansReportingCoverage: null,
+				scansSayingWhyTheyStopped: null,
+				scansThatNeverAnswered: null,
+				scansCutOff: null,
 				partsThoughtAnswered: null,
 				duplicateRate: null,
 				possibleDuplicateRate: null,
@@ -321,9 +328,32 @@ describe('reporting a pass that held market requests', () => {
 				partsExpected: 5,
 				partsAnswered: 1,
 				reportedCoverage: null,
+				searchingStopped: null,
 				...over,
 			},
 		})
+
+	describe('when a market run said why it stopped looking', () => {
+		it('should chart the reason per run, so a thin row can be read', () => {
+			// GIVEN a run stopped at its round cap
+			const attrs = evalSpanAttributes(
+				marketScore({ searchingStopped: 'round_cap_reached' }),
+			)
+
+			// THEN the reason rides on that run's own span, beside its counts
+			expect(attrs['eval.searching_stopped']).toBe('round_cap_reached')
+		})
+
+		it('should chart nothing for a run that said nothing', () => {
+			// GIVEN a run finished before the reason was recorded
+			const attrs = evalSpanAttributes(marketScore())
+
+			// THEN the key is absent rather than carrying a stand-in: charting one
+			// would say the run finished looking, which is the one thing nobody
+			// knows about it
+			expect('eval.searching_stopped' in attrs).toBe(false)
+		})
+	})
 
 	describe('when a market run carried a reckoning of its own', () => {
 		it('should chart its counts per run, so a moved rate names the run', () => {
@@ -482,6 +512,9 @@ describe('reporting a pass that held market requests', () => {
 			requestCoverage: null,
 			neverSearchedShare: null,
 			scansReportingCoverage: null,
+			scansSayingWhyTheyStopped: null,
+			scansThatNeverAnswered: null,
+			scansCutOff: null,
 			partsThoughtAnswered: null,
 			duplicateRate: null,
 			possibleDuplicateRate: null,
@@ -523,6 +556,9 @@ describe('reporting a pass that held market requests', () => {
 					requestCoverage: 0.2,
 					neverSearchedShare: null,
 					scansReportingCoverage: null,
+					scansSayingWhyTheyStopped: null,
+					scansThatNeverAnswered: null,
+					scansCutOff: null,
 					partsThoughtAnswered: null,
 					duplicateRate: 0.16,
 					locationFill: 0.4,

--- a/packages/research/src/application/eval-report.ts
+++ b/packages/research/src/application/eval-report.ts
@@ -271,6 +271,11 @@ export const evalSpanAttributes = (
 			attributes['eval.reported_never_searched'] = reckoning.neverSearched
 			attributes['eval.reported_thought_answered'] = reckoning.thoughtAnswered
 		}
+		// Absent where the run said nothing, which is not the same as a run that
+		// finished looking.
+		if (market.searchingStopped !== null) {
+			attributes['eval.searching_stopped'] = market.searchingStopped
+		}
 		if (market.partsExpected > 0) {
 			attributes['eval.request_coverage'] =
 				market.partsAnswered / market.partsExpected
@@ -352,8 +357,19 @@ export const evalSummaryAttributes = (
 	if (summary.neverSearchedShare !== null) {
 		attributes['eval.never_searched_share'] = summary.neverSearchedShare
 	}
+	if (summary.scansSayingWhyTheyStopped !== null) {
+		attributes['eval.scans_saying_why_they_stopped'] =
+			summary.scansSayingWhyTheyStopped
+	}
+	if (summary.scansCutOff !== null) {
+		attributes['eval.scans_cut_off'] = summary.scansCutOff
+	}
+	if (summary.scansThatNeverAnswered !== null) {
+		attributes['eval.scans_that_never_answered'] =
+			summary.scansThatNeverAnswered
+	}
 	// Reported whenever any scan ran, including nought — that is the reading that
-	// says the figure above is blind rather than clean.
+	// says the never-searched share above is blind rather than clean.
 	if (summary.scansReportingCoverage !== null) {
 		attributes['eval.scans_reporting_coverage'] = summary.scansReportingCoverage
 	}

--- a/packages/research/src/application/eval-scoring-types.ts
+++ b/packages/research/src/application/eval-scoring-types.ts
@@ -26,6 +26,9 @@
  * measured on — a golden row's `officialDomain` — so scoring it here would report
  * the same success twice and make a change to grounding look twice as large.
  */
+
+import type { SearchStopped } from './search-stopped'
+
 export const SCORABLE_FIELDS = [
 	'industry',
 	'size_range',
@@ -195,9 +198,10 @@ export interface RunOutcome {
 	 */
 	/**
 	 * What the run said about the trades its request named: how many it reported
-	 * nothing for, how many of those it never went looking for, and why it stopped
-	 * looking. Read off the run's own reckoning rather than recomputed, because
-	 * whether it looked is not something its rows can say.
+	 * nothing for, how many of those it never went looking for, and how many it
+	 * finished believing it had already found. Read off the run's own reckoning
+	 * rather than recomputed, because whether it looked is not something its rows
+	 * can say.
 	 *
 	 * Null where the run stored no such reckoning — a run that answers with a
 	 * profile rather than a list, one whose request named a single trade, and every
@@ -212,6 +216,13 @@ export interface RunOutcome {
 		 */
 		readonly thoughtAnswered: number
 	} | null
+	/**
+	 * Why the run stopped looking for companies, in its own words. Null for a run
+	 * that stored none — one that answers with a profile rather than a list, one
+	 * that never went looking, one finished before this was recorded, and one
+	 * whose stored word this build cannot place.
+	 */
+	readonly searchingStopped: SearchStopped | null
 	/**
 	 * What the run removed from its list for not being a company of the trade.
 	 * Empty for a run that removed nothing, and for one that answers with a profile
@@ -375,6 +386,11 @@ export interface MarketScore {
 		readonly neverSearched: number
 		readonly thoughtAnswered: number
 	} | null
+	/**
+	 * Why this run stopped looking, carried through from its own reckoning. Null
+	 * where it stored none.
+	 */
+	readonly searchingStopped: SearchStopped | null
 }
 
 /**
@@ -444,6 +460,20 @@ export interface RunScore {
 	readonly country?: string
 	/** How full the profile came back, independent of the golden answers. */
 	readonly profile?: ProfileFullness
+	/**
+	 * Whether this row asked for a market and the run came back with nothing to
+	 * score at all — it failed, or it was cancelled, so it carries no `market`
+	 * below however much searching it had done.
+	 *
+	 * Counted because those are the runs likeliest to have been stopped: a run
+	 * killed on the run deadline stores no reason, so a pass that lost a third of
+	 * its runs that way would otherwise report that none of them was cut off.
+	 *
+	 * Not every run the stopped-reason figures miss — one that came back with an
+	 * answer can still have stored no reason — but the ones that came back with
+	 * nothing to score at all.
+	 */
+	readonly marketWentUnanswered: boolean
 	/** What the list got right, present only for a row that asked for a market. */
 	readonly market?: MarketScore
 }
@@ -552,6 +582,36 @@ export interface EvalSummary {
 	 * its worst runs are simply absent.
 	 */
 	readonly scansReportingCoverage: number | null
+	/**
+	 * How many scans said why they stopped looking, and how many of those were
+	 * cut off rather than having settled of their own accord.
+	 *
+	 * Settling is a fact about a run's last turn — the model asked for nothing
+	 * further — never a claim that there was nothing left to find. So a short
+	 * list from a settled run is still only that run's answer; what it rules out
+	 * is the reading that the looking was stopped before it got there.
+	 *
+	 * These are what let a thin pass be judged at all: fewer results are fine
+	 * where the run genuinely tried, and no threshold on the figures above
+	 * settles that from the outside.
+	 *
+	 * Counted rather than shared, since a share cannot say whether it rests on
+	 * four scans or on one. The cut-off count is null where no scan said why —
+	 * nought there would read as every one of them having finished looking.
+	 */
+	readonly scansSayingWhyTheyStopped: number | null
+	readonly scansCutOff: number | null
+	/**
+	 * Market runs that came back with nothing to score — failed, or cancelled.
+	 *
+	 * Counted beside the two figures above rather than within them: those speak
+	 * only for runs that came back with something to score, and these came back
+	 * with nothing, so no run is in both. A run killed on the deadline is both
+	 * the likeliest to have been cut off and the one that stores no reason at
+	 * all, so without this a pass reports nothing cut off while a third of it was
+	 * killed mid-search.
+	 */
+	readonly scansThatNeverAnswered: number | null
 	readonly duplicateRate: number | null
 	/**
 	 * The share of rows that may repeat a company, read loosely enough to see the

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -28,6 +28,7 @@ const outcome = (over: Partial<RunOutcome>): RunOutcome => ({
 	contacts: [],
 	companies: [],
 	removed: [],
+	searchingStopped: null,
 	reportedCoverage: null,
 	...over,
 })
@@ -1444,6 +1445,7 @@ describe('scoring a run that answered for a whole market', () => {
 				partsExpected: 2,
 				partsAnswered: 0,
 				reportedCoverage: null,
+				searchingStopped: null,
 			})
 			expect(score.empty).toBe(true)
 		})
@@ -1456,6 +1458,7 @@ describe('summarizeScores', () => {
 		fields: [],
 		grounded: true,
 		groundable: true,
+		marketWentUnanswered: false,
 		wrongCompany: false,
 		wrongCompanyAutoApplicable: false,
 		lowConfidence: false,
@@ -1494,6 +1497,9 @@ describe('summarizeScores', () => {
 				requestCoverage: null,
 				neverSearchedShare: null,
 				scansReportingCoverage: null,
+				scansSayingWhyTheyStopped: null,
+				scansThatNeverAnswered: null,
+				scansCutOff: null,
 				partsThoughtAnswered: null,
 				duplicateRate: null,
 				possibleDuplicateRate: null,
@@ -1752,6 +1758,7 @@ describe('summarizing a pass that held market requests', () => {
 		fields: [],
 		grounded: true,
 		groundable: true,
+		marketWentUnanswered: false,
 		wrongCompany: false,
 		wrongCompanyAutoApplicable: false,
 		lowConfidence: false,
@@ -1897,6 +1904,7 @@ describe('summarizing a pass that held market requests', () => {
 				partsExpected: 5,
 				partsAnswered: 5,
 				reportedCoverage: null,
+				searchingStopped: null,
 				...over,
 			},
 		})
@@ -2128,6 +2136,70 @@ describe('summarizing a pass that held market requests', () => {
 			// every shortfall went unlooked-for
 			expect(summary.neverSearchedShare).toBe(1)
 			expect(summary.scansReportingCoverage).toBe(1)
+		})
+	})
+
+	describe('when a pass held runs that said why they stopped', () => {
+		it('should count both the ones that spoke and the ones cut off', () => {
+			// GIVEN four market runs: three stopped at a limit, one that ran out of
+			// things to try
+			const summary = summarizeScores([
+				marketScore({ searchingStopped: 'round_cap_reached' }),
+				marketScore({ name: 'FR', searchingStopped: 'budget_exhausted' }),
+				marketScore({ name: 'PT', searchingStopped: 'deadline_reached' }),
+				marketScore({ name: 'IT', searchingStopped: 'finished_looking' }),
+			])
+
+			// THEN both halves are reported, the one that ran out of things to try
+			// counting as having spoken but not as cut off
+			expect(summary.scansSayingWhyTheyStopped).toBe(4)
+			expect(summary.scansCutOff).toBe(3)
+		})
+
+		it('should report that no run said why, and no cut-off count at all', () => {
+			// GIVEN a pass whose runs all finished before the reason was recorded
+			const summary = summarizeScores([
+				marketScore(),
+				marketScore({ name: 'FR' }),
+			])
+
+			// THEN the count of runs that spoke is nought and the cut-off count is
+			// absent altogether: nought cut off would say every run finished
+			// looking, which is exactly what nobody knows
+			expect(summary.scansSayingWhyTheyStopped).toBe(0)
+			expect(summary.scansCutOff).toBeNull()
+		})
+	})
+
+	describe('when a pass lost runs before they could answer', () => {
+		it('should count them, so nothing cut off is not read as an all-clear', () => {
+			// GIVEN four market runs that finished having run out of things to try,
+			// and two that died before they came back with anything to score
+			const summary = summarizeScores([
+				marketScore({ searchingStopped: 'finished_looking' }),
+				marketScore({ name: 'FR', searchingStopped: 'finished_looking' }),
+				marketScore({ name: 'PT', searchingStopped: 'finished_looking' }),
+				marketScore({ name: 'IT', searchingStopped: 'finished_looking' }),
+				score({ groundable: false, marketWentUnanswered: true }),
+				score({ groundable: false, marketWentUnanswered: true }),
+			])
+
+			// THEN the two that died are counted. The runs likeliest to have been
+			// stopped are exactly the ones that store no reason, so without this the
+			// pass reports four runs that all finished and nothing cut off — an
+			// all-clear for a pass that lost a third of itself mid-search
+			expect(summary.scansSayingWhyTheyStopped).toBe(4)
+			expect(summary.scansCutOff).toBe(0)
+			expect(summary.scansThatNeverAnswered).toBe(2)
+		})
+
+		it('should say nothing at all for a pass that held no market', () => {
+			// GIVEN a pass of profile runs, none of which asked for a market
+			const summary = summarizeScores([score({}), score({})])
+
+			// THEN the count is absent rather than nought: no market went
+			// unanswered because none was asked for
+			expect(summary.scansThatNeverAnswered).toBeNull()
 		})
 	})
 

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -72,6 +72,7 @@ import {
 	SCORABLE_FIELDS,
 } from './eval-scoring-types'
 import { runWordsOf } from './run-words'
+import { wasCutOff } from './search-stopped'
 
 export { contactNameMatches } from './eval-scoring-company'
 export {
@@ -269,6 +270,11 @@ export const scoreRun = (
 		outcome.companies,
 		runWordsOf(expectedMarket?.parts.flatMap(part => part.terms) ?? []),
 	)
+	// A market row whose run never came back with anything to score. Told apart
+	// from a row that asked for no market at all, because only the first is a
+	// market the pass failed to measure.
+	const marketWentUnanswered =
+		expectedMarket !== undefined && !endedWithAnAnswer(outcome.status)
 	const market: MarketScore | undefined =
 		expectedMarket === undefined || !endedWithAnAnswer(outcome.status)
 			? undefined
@@ -308,12 +314,14 @@ export const scoreRun = (
 					// answered — instead of dropping out of the figure.
 					partsAnswered: partsAnsweredBy(rightKindRows, expectedMarket.parts),
 					reportedCoverage: outcome.reportedCoverage,
+					searchingStopped: outcome.searchingStopped,
 				}
 
 	return {
 		id: expected.id,
 		grounded,
 		groundable: expected.market === undefined,
+		marketWentUnanswered,
 		wrongCompany,
 		wrongCompanyAutoApplicable,
 		lowConfidence,
@@ -360,6 +368,9 @@ export const summarizeScores = (
 			requestCoverage: null,
 			neverSearchedShare: null,
 			scansReportingCoverage: null,
+			scansSayingWhyTheyStopped: null,
+			scansCutOff: null,
+			scansThatNeverAnswered: null,
 			partsThoughtAnswered: null,
 			duplicateRate: null,
 			possibleDuplicateRate: null,
@@ -426,6 +437,11 @@ export const summarizeScores = (
 	// Counted only over the scans that stored a reckoning of their own, so the
 	// share below divides one run's words by the same run's words.
 	let scansReportingCoverage = 0
+	// Counted apart from the coverage reckoning above because a run stores this
+	// one whatever its request named, single trade or five.
+	let scansSayingWhyTheyStopped = 0
+	let scansCutOff = 0
+	let scansThatNeverAnswered = 0
 	let totalReportedMissing = 0
 	let totalReportedNeverSearched = 0
 	let totalReportedThoughtAnswered = 0
@@ -461,6 +477,7 @@ export const summarizeScores = (
 			totalContactsNamed += score.profile.contactsNamed
 			totalContactsTitled += score.profile.contactsTitled
 		}
+		if (score.marketWentUnanswered) scansThatNeverAnswered++
 		if (score.market !== undefined) {
 			scansScored++
 			totalRowsReturned += score.market.rowsReturned
@@ -476,6 +493,11 @@ export const summarizeScores = (
 			totalRowsPossiblyDuplicated += score.market.rowsPossiblyDuplicated
 			totalPartsExpected += score.market.partsExpected
 			totalPartsAnswered += score.market.partsAnswered
+			const stopped = score.market.searchingStopped
+			if (stopped !== null) {
+				scansSayingWhyTheyStopped++
+				if (wasCutOff(stopped)) scansCutOff++
+			}
 			const reckoning = score.market.reportedCoverage
 			if (reckoning !== null) {
 				scansReportingCoverage++
@@ -561,6 +583,13 @@ export const summarizeScores = (
 				? null
 				: totalReportedNeverSearched / totalReportedMissing,
 		scansReportingCoverage: scansScored === 0 ? null : scansReportingCoverage,
+		scansSayingWhyTheyStopped:
+			scansScored === 0 ? null : scansSayingWhyTheyStopped,
+		scansCutOff: scansSayingWhyTheyStopped === 0 ? null : scansCutOff,
+		scansThatNeverAnswered:
+			scansScored + scansThatNeverAnswered === 0
+				? null
+				: scansThatNeverAnswered,
 		partsThoughtAnswered:
 			scansReportingCoverage === 0 ? null : totalReportedThoughtAnswered,
 		duplicateRate: perRow(totalRowsDuplicated),

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -5556,6 +5556,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						// The flag answers for the pass that just ran, so a refused refine
 						// cannot be read as a refused coverage pass later on.
 						let lastPassRefused = false
+						// Whether the thin-list retry was the pass the provider turned
+						// away. Held apart from the covering loop's own record below,
+						// because a request naming a single kind of company never runs that
+						// loop and this is then the only refusal there is.
+						let refinePassRefused = false
 						const searchAgainOrKeep = (instruction: string, soFar: unknown) =>
 							Effect.gen(function* () {
 								lastPassRefused = false
@@ -5619,6 +5624,12 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								// reads an empty list as an empty market, so a pass the
 								// provider refused must not be reported as one that ran.
 								refined = !lastPassRefused
+								// A pass the provider turned away is a pass that did not
+								// happen, so the looking stopped here rather than where the
+								// pass before it ended. Without this the run reports the first
+								// pass's contented ending and a short list reads as a thin
+								// market.
+								if (lastPassRefused) refinePassRefused = true
 							}
 
 							// Then the parts of the request nothing came back for. The retry
@@ -5709,6 +5720,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 									? findings
 									: undefined,
 							refined,
+							refinePassRefused,
 							cheapCents,
 						}
 					}).pipe(
@@ -5731,15 +5743,23 @@ export class ResearchService extends Context.Service<ResearchService>()(
 
 					const loopResult = phaseOutcome.loop
 					runRounds = loopResult.rounds
-					// The chase for a part nothing answered is looking too, and it
-					// stops for reasons of its own: a run whose chase ran out of
-					// passes has not finished looking, however contentedly its last
-					// gathering pass ended.
-					const chaseStopped = coverageStoppedLooking(coverageStopped)
-					searchStopped =
-						chaseStopped === null
-							? loopResult.stopReason
-							: mostBindingStop(loopResult.stopReason, chaseStopped)
+					// Every stretch that went looking, read down to the one that bound
+					// the run hardest. The gathering passes are only the first: the retry
+					// after a thin list and the chase for a part nothing answered each
+					// stop for reasons of their own, and a run whose chase ran out of
+					// passes has not finished looking however contentedly its last
+					// gathering pass ended. A pass the provider turned away is a pass
+					// that never happened, so it counts the same way.
+					searchStopped = [
+						phaseOutcome.refinePassRefused
+							? ('provider_refused' as const)
+							: null,
+						coverageStoppedLooking(coverageStopped),
+					].reduce<SearchStopped>(
+						(sofar, reason) =>
+							reason === null ? sofar : mostBindingStop(sofar, reason),
+						loopResult.stopReason,
+					)
 					// Why the gathering stopped. A run that ran out of room to think,
 					// rather than finishing what it set out to do, had more it wanted
 					// to read — so a thin profile there is a ceiling to raise, not a

--- a/packages/research/src/application/search-stopped.ts
+++ b/packages/research/src/application/search-stopped.ts
@@ -58,6 +58,21 @@ const HOW_BINDING: Record<SearchStopped, number> = {
 }
 
 /**
+ * Whether a value read back off a stored run is one of the reasons above.
+ *
+ * Needed because a finished run's findings are read back as plain JSON, so what
+ * sits there could be anything: nothing at all on a run stored before this was
+ * recorded, or a word a later build knows and this one has never heard of.
+ *
+ * Asked of `HOW_BINDING` rather than of a list of its own, so a reason added
+ * there is recognised here without anyone remembering to add it twice. Own keys
+ * only: every object answers to `toString`, and a run naming that as its reason
+ * must not read as a known one.
+ */
+export const isSearchStopped = (value: unknown): value is SearchStopped =>
+	typeof value === 'string' && Object.hasOwn(HOW_BINDING, value)
+
+/**
  * The reason to report for a run that looked in more than one stretch.
  *
  * Keeps whichever bound the run hardest, so a later stretch settling cannot


### PR DESCRIPTION
## What

A research search that comes back with three companies means one of two things: the market holds three, or the looking was stopped at three. A run has recently started saying which — it stores `searching_stopped` in its findings — but the quality eval, which is how a change to research is judged across a whole set of runs, could not read it. So a market that scored thin scored thin, and nothing said whether its runs had been in any position to answer.

This matters because of how "is this good enough" now gets settled. There is no share of results anyone can agree on from the outside: fewer results are fine where the run genuinely tried. That turns the question into a reporting one — and a reader can only apply it if the numbers say which runs tried.

This lives in the research pipeline (`packages/research`, the part that runs a search and writes up what it found) and its command-line eval.

## Changes

**Touches:** the reason a run stores when it stops looking, the eval's reading of a finished run, the figures a whole pass rolls up to, and the summary the eval prints — plus the thin-list retry, which is where the first commit's bug lived.

**A refused retry no longer reports itself as having finished looking** (first commit). A scan that comes back thin sends one more searching pass out. A pass the provider turns away never runs, but the run kept the first pass's contented ending — so it reported having finished looking and its short list read as a thin market. The covering pass already said so when it was refused; a request naming a single kind of company never runs that loop, so this was the only refusal it had. This changes what a live run stores, unlike the rest of this PR.

**The eval reads the reason** (second commit), carries it on each run's score, and rolls a pass up to two figures: how many runs said why they stopped, and how many of those were cut off.

**Runs that died before returning anything are counted beside those, not within them.** They are the likeliest to have been stopped and the only ones that store no reason at all, so without them a pass reports nothing cut off while a third of it was killed mid-search. A pass whose market runs *all* died prints that count and nothing else, rather than falling silent as if no market had been asked for.

**A stored reason this build cannot place is refused rather than counted**, so a word written by a later build cannot arrive as a finding about the market.

## Impact

- **No change to what any run does**, except the refusal fix in the first commit — that alters `searching_stopped` on a live run whose retry is refused, which is the point of it.
- **No database migration, no new environment variables**, nothing touching which organisation can see what (row-level security), no change to sign-in or which routes are protected, and no cost change: the eval reads what a run already stored.
- **The eval's printed summary gains three lines** and its spans gain four attributes. Anything charting the old ones is unaffected.
- **`RunOutcome`, `MarketScore` and `EvalSummary` each gain fields.** They are internal to the eval — nothing outside `packages/research` and the CLI reads them — but two exhaustive shape assertions in the test suite had to be extended, which is the intended way to notice.

## Review guide

- **Start at** `packages/research/src/application/eval-scoring.ts` where the three counts are kept, and read them against their docs in `eval-scoring-types.ts`. The counts are the whole point; everything else is plumbing.
- **The wording is load-bearing and I got it wrong first time.** `finished_looking` is a fact about a run's last turn — the model asked for nothing more — never a claim that there was nothing left to find. My first draft called it "ran out of things to try", which upgrades it into a claim about the market: the exact inference this whole line of work exists to prevent. If you find another sentence doing that, it is a defect, not a phrasing preference.
- **Riskiest part:** the first commit, because it is the only one that changes a live run. It is covered by an integration case I verified fails without the fix (it stored `finished_looking`).
- **The guard** in `search-stopped.ts` reads the ranking map's own keys rather than a list of its own, so a reason added later is recognised without a second edit — `provider_refused`, added upstream while this was in progress, was picked up with no change. It uses `Object.hasOwn` rather than `in` because `in` walks the prototype chain and would have accepted `"toString"` as a reason; there is a test for that.
- **Skip-able:** the test-fixture lines that just add a null field.

## Tests

- Unit cases for reading the reason off a stored run, including a word from a later build and a word every object already carries.
- Unit cases for the three counts, including a pass that mixes stopped runs with settled ones, and a pass that lost runs — which asserts that "nothing cut off" is not reported as an all-clear.
- The per-run and per-pass span attributes, including that an absent reason charts nothing rather than a stand-in.
- An integration case for the refusal fix, verified to fail without it.

## Verification

On the rebased branch against current `origin/main`: `pnpm check-types` 14/14, `pnpm test` 23/23, `pnpm build` 14/14, `pnpm check` (biome) exit 0. The three affected integration suites pass — refine-pass-refused, coverage-pass-refused, and scan-reporting.

Each commit type-checks on its own, so the trail is bisectable and can be rebase-merged rather than squashed.

**Not run: a live eval pass.** These numbers first appear against real runs in the measurement campaign this PR exists to enable, which is where they get their real test.

## Deferred

- `marketWentUnanswered` is not charted per run, so a died market run's span does not name which market it was.
- The printed block has no explicit count of scored runs. In a live pass every scored run stores a reason, so the first figure is effectively that denominator — but it is not labelled as one.
- The internal app still does not render `searching_stopped` for a person reading a single run.

Addresses #472.
