### PR TITLE
feat: narrow a company list by several values, from the app or an agent

### DIFF
--- a/apps/internal/src/atoms/companies-atoms.test.ts
+++ b/apps/internal/src/atoms/companies-atoms.test.ts
@@ -6,7 +6,7 @@ describe('canonicalSearchKey', () => {
 	describe('when the search carries an owner and a sort', () => {
 		it('should include both fields and their values in the key', () => {
 			// GIVEN a "my leads, sorted by name" search
-			const key = canonicalSearchKey({ owner: 'user-1', sort: 'name' })
+			const key = canonicalSearchKey({ owner: ['user-1'], sort: 'name' })
 			// THEN the key encodes both filter and value
 			expect(key).toContain('owner')
 			expect(key).toContain('user-1')
@@ -17,18 +17,34 @@ describe('canonicalSearchKey', () => {
 		it('should give different owners different keys (so the atoms differ)', () => {
 			// GIVEN two searches that differ only by owner
 			// THEN their cache keys differ
-			expect(canonicalSearchKey({ owner: 'a' })).not.toBe(
-				canonicalSearchKey({ owner: 'b' }),
+			expect(canonicalSearchKey({ owner: ['a'] })).not.toBe(
+				canonicalSearchKey({ owner: ['b'] }),
 			)
 		})
 	})
 
-	describe('when owner or sort is an empty string', () => {
-		it('should drop them, matching an unset search', () => {
-			// GIVEN empty owner/sort (a cleared filter)
+	describe('when a filter is empty', () => {
+		it('should drop a blank string, matching an unset search', () => {
+			// GIVEN a cleared free-text filter
 			// THEN the key equals the no-filter key
-			expect(canonicalSearchKey({ owner: '', sort: '' })).toBe(
+			expect(canonicalSearchKey({ query: '' })).toBe(canonicalSearchKey({}))
+		})
+
+		it('should drop an empty list, matching an unset search', () => {
+			// GIVEN a caller that read no stages from its form and sent the empty
+			// list — which the server also reads as nobody asking
+			// THEN the key must agree, or the same list answers to two entries and
+			// is fetched twice
+			expect(canonicalSearchKey({ status: [], tags: [] })).toBe(
 				canonicalSearchKey({}),
+			)
+		})
+
+		it('should drop a blank among real values', () => {
+			// GIVEN a trailing comma in the link, which decodes to a blank
+			// THEN it changes nothing about which list this is
+			expect(canonicalSearchKey({ tags: ['pilot', ''] })).toBe(
+				canonicalSearchKey({ tags: ['pilot'] }),
 			)
 		})
 	})
@@ -37,8 +53,41 @@ describe('canonicalSearchKey', () => {
 		it('should produce a stable, order-independent key', () => {
 			// GIVEN the same owner + status in two orders
 			// THEN the canonical key is identical
-			expect(canonicalSearchKey({ owner: 'user-1', status: 'meeting' })).toBe(
-				canonicalSearchKey({ status: 'meeting', owner: 'user-1' }),
+			expect(
+				canonicalSearchKey({ owner: ['user-1'], status: ['meeting'] }),
+			).toBe(canonicalSearchKey({ status: ['meeting'], owner: ['user-1'] }))
+		})
+	})
+
+	describe('when one filter holds the same values in a different order', () => {
+		it('should produce one key, not two', () => {
+			// GIVEN two links naming the same two tags the other way round
+			// WHEN each is turned into a cache key
+			// THEN they are the same list. Left unsorted they would be two atoms
+			// fetching identical rows, and a saved view would stop reading as active
+			// the moment its tags came back reordered
+			expect(canonicalSearchKey({ tags: ['b', 'a'] })).toBe(
+				canonicalSearchKey({ tags: ['a', 'b'] }),
+			)
+		})
+
+		it('should still tell different sets apart', () => {
+			// GIVEN one link naming a second tag
+			// THEN it is a different, narrower list
+			expect(canonicalSearchKey({ tags: ['a', 'b'] })).not.toBe(
+				canonicalSearchKey({ tags: ['a'] }),
+			)
+		})
+	})
+
+	describe('when a filter nobody listed by hand is set', () => {
+		it('should still reach the key', () => {
+			// GIVEN the fit verdict, which no hand-written list of fields names
+			// THEN it separates the two lists. The key reads whatever the search
+			// holds rather than a list of names kept in step by hand, which is what
+			// stops a new filter from sharing another one's entry
+			expect(canonicalSearchKey({ fitVerdict: ['strong_fit'] })).not.toBe(
+				canonicalSearchKey({}),
 			)
 		})
 	})

--- a/apps/internal/src/atoms/companies-atoms.ts
+++ b/apps/internal/src/atoms/companies-atoms.ts
@@ -1,6 +1,6 @@
 import { Atom } from 'effect/unstable/reactivity'
 
-import type { AttentionFilter } from '@batuda/domain'
+import type { AttentionFilter, CompanySort } from '@batuda/domain'
 
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import {
@@ -18,21 +18,29 @@ import {
  * that key too or two different searches will answer to one entry.
  */
 export type CompaniesSearch = {
-	readonly status?: string
-	readonly country?: string
+	// Four of these hold a list and match any of the values in it, while
+	// different filters still narrow one another. `tags` is the exception and
+	// reads the other way round: every tag has to be on the company.
+	readonly status?: ReadonlyArray<string>
+	readonly country?: ReadonlyArray<string>
 	readonly industry?: string
 	readonly priority?: number
-	readonly owner?: string
-	readonly sort?: string
+	// User ids, and/or the word 'none' for the companies nobody has taken.
+	readonly owner?: ReadonlyArray<string>
+	// What a research run concluded about whether the company is worth selling
+	// to. Free text on the row, so the menu comes from what is actually stored.
+	readonly fitVerdict?: ReadonlyArray<string>
+	readonly tags?: ReadonlyArray<string>
+	readonly sort?: CompanySort
 	readonly query?: string
 	// What needs doing, in the dashboard's own words: a missed follow-up, a
 	// company gone quiet, or one with nothing planned. Arriving here from a
 	// dashboard heading sets this, and the threshold it was showing rides along.
 	readonly attention?: AttentionFilter
 	readonly staleDays?: number
-	// 'only' asks for the companies taken out of view, which is how one is found
-	// again to be put back. Absent means the ones in use.
-	readonly deleted?: 'only' | 'include'
+	// The companies taken out of view, which is how one is found again to be put
+	// back. Absent means the ones in use.
+	readonly deleted?: 'only'
 }
 
 /**
@@ -99,46 +107,31 @@ export function companiesSearchAtom(
 /**
  * Produce a stable cache key from a search object. Normalizes away:
  *   - key order (`{a,b}` vs `{b,a}`) via sorted keys
- *   - empty-string values (treated as absent, same as undefined)
+ *   - the order of the values inside one filter, and any blanks among them
+ *   - empty-string and empty-list values (treated as absent, same as undefined)
  *   - nullish values
  *
- * Using `JSON.stringify` on a sorted plain object gives identical keys
- * for identical searches without pulling in a stable-stringify dep.
+ * Every field the search holds is read, rather than a list kept in step by
+ * hand: a filter left out of that list would answer to another filter's key, and
+ * two different searches would quietly share one entry.
+ *
+ * Sorting the values inside a filter is what makes `?tags=a,b` and `?tags=b,a`
+ * one list rather than two atoms fetching the same rows twice.
  */
 export function canonicalSearchKey(search: CompaniesSearch): string {
 	const entries: Array<[string, string | number]> = []
-	if (search.status !== undefined && search.status !== '') {
-		entries.push(['status', search.status])
-	}
-	if (search.country !== undefined && search.country !== '') {
-		entries.push(['country', search.country])
-	}
-	if (search.industry !== undefined && search.industry !== '') {
-		entries.push(['industry', search.industry])
-	}
-	if (search.priority !== undefined) {
-		entries.push(['priority', search.priority])
-	}
-	if (search.owner !== undefined && search.owner !== '') {
-		entries.push(['owner', search.owner])
-	}
-	if (search.sort !== undefined && search.sort !== '') {
-		entries.push(['sort', search.sort])
-	}
-	if (search.query !== undefined && search.query !== '') {
-		entries.push(['query', search.query])
-	}
-	if (search.attention !== undefined) {
-		entries.push(['attention', search.attention])
-	}
-	if (search.staleDays !== undefined) {
-		entries.push(['staleDays', search.staleDays])
-	}
-	// Part of the key, not just the query: the deleted companies and the ones in
-	// use are two different lists. Left out, both answer to the same key and
-	// asking for one serves whatever the other last fetched.
-	if (search.deleted !== undefined) {
-		entries.push(['deleted', search.deleted])
+	for (const [key, raw] of Object.entries(search)) {
+		if (raw === undefined || raw === null || raw === '') continue
+		if (Array.isArray(raw)) {
+			const values = (raw as ReadonlyArray<string>)
+				.filter(value => value !== '')
+				.slice()
+				.sort()
+			if (values.length === 0) continue
+			entries.push([key, values.join(',')])
+			continue
+		}
+		entries.push([key, raw as string | number])
 	}
 	entries.sort(([a], [b]) => a.localeCompare(b))
 	return JSON.stringify(Object.fromEntries(entries))

--- a/apps/internal/src/components/companies/about-section.tsx
+++ b/apps/internal/src/components/companies/about-section.tsx
@@ -153,6 +153,7 @@ export function AboutSection({
 								values={company.tags}
 								onSave={next => onSave('tags', next)}
 								emptyHint={t`No tags yet`}
+								splitOnComma
 							/>
 							<EditableChips
 								label={t`Products fit`}

--- a/apps/internal/src/components/companies/company-fit-section.tsx
+++ b/apps/internal/src/components/companies/company-fit-section.tsx
@@ -1,5 +1,3 @@
-import type { MessageDescriptor } from '@lingui/core'
-import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { Link } from '@tanstack/react-router'
 import {
@@ -16,6 +14,7 @@ import { PriCollapsible } from '@batuda/ui/pri'
 
 import { normalizeConfidence } from '#/components/research/proposal-logic'
 import { RelativeDate } from '#/components/shared/relative-date'
+import { verdictLabel } from '#/lib/company-fit-verdict'
 import { agedPaperSurface, stenciledTitle } from '#/lib/workshop-mixins'
 
 export type FitCheck = {
@@ -111,7 +110,7 @@ export function CompanyFitSection({
 							$verdict={company.fitVerdict}
 							data-testid='company-fit-verdict'
 						>
-							{verdictOf(i18n, company.fitVerdict)}
+							{verdictLabel(i18n, company.fitVerdict)}
 						</Verdict>
 					) : null}
 				</PriCollapsible.Trigger>
@@ -243,24 +242,6 @@ export function CompanyFitSection({
 			</PriCollapsible.Panel>
 		</PriCollapsible.Root>
 	)
-}
-
-// The verdict is stored as the research vocabulary wrote it; the reader sees it
-// in their own language, and a value the vocabulary does not know is shown
-// as-is rather than hidden.
-const VERDICT_LABEL: Record<string, MessageDescriptor> = {
-	strong_fit: msg`Strong fit`,
-	possible_fit: msg`Possible fit`,
-	weak_fit: msg`Weak fit`,
-	no_fit: msg`Not a fit`,
-}
-
-function verdictOf(
-	i18n: { _: (descriptor: MessageDescriptor) => string },
-	verdict: string,
-): string {
-	const label = VERDICT_LABEL[verdict]
-	return label === undefined ? verdict : i18n._(label)
 }
 
 function hostOf(url: string): string {

--- a/apps/internal/src/components/companies/pipeline-board.tsx
+++ b/apps/internal/src/components/companies/pipeline-board.tsx
@@ -311,7 +311,7 @@ function BoardColumn({
 }) {
 	const { t } = useLingui()
 	const columnSearch = useMemo<CompaniesSearch>(
-		() => ({ ...search, status }),
+		() => ({ ...search, status: [status] }),
 		[search, status],
 	)
 	const list = useInfiniteList({

--- a/apps/internal/src/components/companies/saved-views.tsx
+++ b/apps/internal/src/components/companies/saved-views.tsx
@@ -3,7 +3,10 @@ import { Bookmark, BookmarkPlus, X } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import type { CompaniesSearch } from '#/atoms/companies-atoms'
+import {
+	type CompaniesSearch,
+	canonicalSearchKey,
+} from '#/atoms/companies-atoms'
 import { stenciledTitle } from '#/lib/workshop-mixins'
 
 const STORAGE_KEY = 'batuda.companies.savedViews'
@@ -45,8 +48,12 @@ export function SavedViews({
 	}, [])
 
 	const hasFilters = Object.keys(current).length > 0
+	// The list's own way of spelling a search, rather than a second one here: it
+	// ignores the order of the filters and of the values inside each one, so a
+	// saved view still reads as the one in force when its two tags come back the
+	// other way round.
 	const activeName = views.find(
-		v => canonical(v.search) === canonical(current),
+		v => canonicalSearchKey(v.search) === canonicalSearchKey(current),
 	)?.name
 
 	const save = () => {
@@ -93,15 +100,6 @@ export function SavedViews({
 				</Chip>
 			)}
 		</Wrap>
-	)
-}
-
-/** Order-independent, so the same filters chosen in a different order match. */
-function canonical(search: CompaniesSearch): string {
-	return JSON.stringify(
-		Object.fromEntries(
-			Object.entries(search).sort(([a], [b]) => (a < b ? -1 : 1)),
-		),
 	)
 }
 

--- a/apps/internal/src/components/shared/editable-field.tsx
+++ b/apps/internal/src/components/shared/editable-field.tsx
@@ -404,6 +404,10 @@ export interface EditableChipsProps {
 	readonly onSave: (next: ReadonlyArray<string>) => Promise<void>
 	readonly placeholder?: string
 	readonly emptyHint?: ReactNode
+	// Whether a typed comma starts the next chip. Only for values that may not
+	// contain one themselves — a tag, whose list travels as a single
+	// comma-separated value — and never where a comma is ordinary text.
+	readonly splitOnComma?: boolean
 }
 
 /**
@@ -416,6 +420,7 @@ export function EditableChips({
 	onSave,
 	placeholder,
 	emptyHint,
+	splitOnComma = false,
 }: EditableChipsProps) {
 	const { t } = useLingui()
 	const [draft, setDraft] = useState('')
@@ -430,15 +435,18 @@ export function EditableChips({
 		}
 	}
 
+	// A comma separates one chip from the next rather than living inside one.
+	// It has to: several of these travel to the server as a single
+	// comma-separated value, so a chip holding a comma would be split back into
+	// pieces nobody carries and the companies under it would stop being findable.
+	// Splitting here is also what somebody typing or pasting "a, b" means.
 	const addChip = async () => {
-		const next = draft.trim()
-		if (next.length === 0) return
-		if (values.includes(next)) {
-			setDraft('')
-			return
-		}
+		const added = (splitOnComma ? draft.split(',') : [draft])
+			.map(part => part.trim())
+			.filter(part => part.length > 0 && !values.includes(part))
 		setDraft('')
-		await mutate([...values, next])
+		if (added.length === 0) return
+		await mutate([...values, ...new Set(added)])
 	}
 
 	const removeChip = (chip: string) => mutate(values.filter(v => v !== chip))

--- a/apps/internal/src/components/shared/multi-select-filter.tsx
+++ b/apps/internal/src/components/shared/multi-select-filter.tsx
@@ -1,0 +1,402 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { Check, ChevronsUpDown, Search } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+import { PriCheckbox, PriInput, PriPopover } from '@batuda/ui/pri'
+
+import { SrOnly } from '#/components/shared/sr-only'
+
+export type MultiSelectOption = {
+	readonly value: string
+	readonly label: string
+	// Absent where nothing counts the values — a list of colleagues, say, rather
+	// than a menu built from the companies themselves.
+	readonly count?: number
+}
+
+/**
+ * A filter whose values are picked several at a time, from a list the server
+ * counted.
+ *
+ * A dropdown could not do this — it gives back one value — and the stage strip
+ * could not either: nine stages are a fixed vocabulary that fits on a line,
+ * while tags are written by the organisation and there is no number of them
+ * that is too many. So the list lives in a popover, with a box to narrow it once
+ * there are more than a screenful.
+ *
+ * `countsStandAlone` says whether a number still means anything once its value is
+ * ticked. For tags it does not — a ticked tag reports the whole current list,
+ * every time — so those are hidden rather than shown as noise.
+ */
+export function MultiSelectFilter({
+	label,
+	options,
+	selected,
+	onToggle,
+	onClear,
+	testId,
+	describeCount,
+	countsStandAlone = false,
+}: {
+	readonly label: string
+	readonly options: ReadonlyArray<MultiSelectOption>
+	readonly selected: ReadonlyArray<string>
+	// The value that was ticked, not the list it produces. Working out the next
+	// list here would read the current one from this render, and two ticks inside
+	// one navigation window would then both be built on the same stale list, so
+	// the second would quietly undo the first.
+	readonly onToggle: (value: string) => void
+	readonly onClear: () => void
+	readonly testId: string
+	// The row's label names the checkbox, so the number beside it is read out
+	// as part of that name, and a loose digit lands there attached to nothing.
+	// The caller says what its numbers count, in one piece a translator can
+	// reorder.
+	readonly describeCount: (count: number) => string
+	readonly countsStandAlone?: boolean
+}) {
+	const { t } = useLingui()
+	const [filterText, setFilterText] = useState('')
+	const [open, setOpen] = useState(false)
+
+	// Which rows are shown, and in what order, is held still for as long as the
+	// panel is open: ticking one value re-counts the rest, and under "all of them
+	// have to match" most of those counts fall to zero, so the list would lose
+	// most of itself and reorder the survivors under the reader's hand.
+	//
+	// Only the order is held, never the numbers — those are read from the live
+	// list every render. Freezing them too would leave a reader ticking a tag
+	// that says 3 and landing on 2, which is the one thing the counts are for.
+	const frozenOrder = useRef<ReadonlyArray<string> | undefined>(undefined)
+	// Written after the render is committed, never during it, so a render React
+	// throws away cannot leave an order behind that nobody ever saw. An empty
+	// list is not worth holding: the counts simply have not arrived yet, and
+	// holding that would show "nothing matches" until the panel was reopened.
+	useEffect(() => {
+		if (!open) {
+			setFilterText('')
+			frozenOrder.current = undefined
+			return
+		}
+		if (frozenOrder.current === undefined && options.length > 0)
+			frozenOrder.current = options.map(option => option.value)
+	}, [open, options])
+
+	// The single chosen value, if there is exactly one, named as its menu names
+	// it rather than as it is stored — a country code is not a country.
+	const onlyChosen = useMemo(() => {
+		if (selected.length !== 1) return undefined
+		const value = selected[0] as string
+		return (
+			options.find(option => option.value === value) ?? { value, label: value }
+		)
+	}, [options, selected])
+
+	const heldOptions = useMemo(() => {
+		const order = open ? frozenOrder.current : undefined
+		if (order === undefined) return options
+		const live = new Map(options.map(option => [option.value, option]))
+		// A value that has since gone from the counts keeps its place, reading
+		// zero, rather than leaving a gap where the reader last saw it.
+		return order.map(
+			value => live.get(value) ?? { value, label: value, count: 0 },
+		)
+	}, [open, options])
+
+	// A box to narrow the list is worth its own row only once the list is long
+	// enough to scroll; below that it is one more thing between the reader and
+	// the tag they can already see.
+	const searchable = heldOptions.length > 8
+	const visibleOptions = useMemo(() => {
+		const term = filterText.trim().toLowerCase()
+		if (term === '') return heldOptions
+		return heldOptions.filter(option =>
+			option.label.toLowerCase().includes(term),
+		)
+	}, [heldOptions, filterText])
+
+	return (
+		<PriPopover.Root open={open} onOpenChange={setOpen}>
+			<Trigger data-testid={testId}>
+				<TriggerLabel>
+					{/* One value takes the control's place, several are counted beside it.
+					 * These sit several to a line, so there is room for the name of the
+					 * control or the name of one value but not both — and which value is
+					 * narrowing the list is the more useful of the two. The control keeps
+					 * its own name for anyone listening. */}
+					{onlyChosen !== undefined ? (
+						<>
+							<SrOnly>{label}</SrOnly>
+							<TriggerValue>{onlyChosen.label}</TriggerValue>
+						</>
+					) : (
+						<>
+							{label}
+							{selected.length > 1 ? (
+								<>
+									{/* A bare digit beside a word reads as nothing at all when
+									 * spoken; the sentence beside it is what a listener gets. */}
+									<Badge aria-hidden>{selected.length}</Badge>
+									<SrOnly>{t`${selected.length} selected`}</SrOnly>
+								</>
+							) : null}
+						</>
+					)}
+				</TriggerLabel>
+				<ChevronsUpDown size={14} aria-hidden />
+			</Trigger>
+			<PriPopover.Portal>
+				<PriPopover.Positioner sideOffset={6}>
+					{/* Named, because the panel is a dialog and would otherwise be
+					 * announced as an unlabelled one. */}
+					<PriPopover.Popup aria-label={label}>
+						<Panel>
+							{searchable ? (
+								<SearchWrap>
+									<SearchIcon>
+										<Search size={14} aria-hidden />
+									</SearchIcon>
+									{/* Deliberately not a search box: Escape in one of those
+									 * clears the field and closes the panel in the same press,
+									 * so the key would mean two things at once. */}
+									<PriInput
+										type='text'
+										value={filterText}
+										onChange={event => setFilterText(event.target.value)}
+										placeholder={t`Narrow this list…`}
+										// Not "narrow the list of ${label}": the panel around it already
+										// carries that name, and dropping a translated noun into an
+										// English frame leaves a translator no room for gender or order.
+										aria-label={t`Narrow this list`}
+										style={{
+											paddingLeft: 'calc(var(--space-xs) * 2 + 14px)',
+										}}
+										data-testid={`${testId}-search`}
+									/>
+								</SearchWrap>
+							) : null}
+							{visibleOptions.length === 0 ? (
+								<Empty>{t`Nothing matches`}</Empty>
+							) : (
+								<List>
+									{visibleOptions.map(option => {
+										const isChosen = selected.includes(option.value)
+										return (
+											// One control per row, not a checkbox beside a button:
+											// the checkbox draws its name from this label, and a
+											// second control would be a nameless tab stop next to a
+											// stateless one — twice the keys, half the meaning.
+											<Row key={option.value}>
+												<PriCheckbox.Root
+													checked={isChosen}
+													onCheckedChange={() => onToggle(option.value)}
+													data-testid={`${testId}-option-${option.value}`}
+												>
+													<PriCheckbox.Indicator>
+														<Check size={12} aria-hidden />
+													</PriCheckbox.Indicator>
+												</PriCheckbox.Root>
+												<RowName>{option.label}</RowName>
+												{option.count !== undefined &&
+												(countsStandAlone || !isChosen) ? (
+													<>
+														{/* The label names the checkbox, so every word inside
+														 * it is read out as part of that name. A loose "14"
+														 * lands there as a number with nothing attached;
+														 * these words say what it counts. */}
+														<RowCount aria-hidden>{option.count}</RowCount>
+														<SrOnly>{describeCount(option.count)}</SrOnly>
+													</>
+												) : null}
+											</Row>
+										)
+									})}
+								</List>
+							)}
+							{selected.length > 0 ? (
+								<ClearRow>
+									<ClearButton
+										type='button'
+										onClick={onClear}
+										data-testid={`${testId}-clear`}
+									>
+										<Trans>Clear</Trans>
+									</ClearButton>
+								</ClearRow>
+							) : null}
+						</Panel>
+					</PriPopover.Popup>
+				</PriPopover.Positioner>
+			</PriPopover.Portal>
+		</PriPopover.Root>
+	)
+}
+
+// ── Styles ───────────────────────────────────────────────────────
+
+// Shaped after PriSelect's trigger so the filter bar reads as one row of
+// controls rather than a dropdown next to something else.
+const Trigger = styled(PriPopover.Trigger).withConfig({
+	displayName: 'MultiSelectFilterTrigger',
+})`
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-2xs);
+	padding: var(--space-2xs) var(--space-sm);
+	background: linear-gradient(
+		145deg,
+		var(--color-metal-light) 0%,
+		var(--color-metal) 50%,
+		var(--color-metal-dark) 100%
+	);
+	border: 1px solid var(--color-metal-edge);
+	border-radius: var(--shape-2xs);
+	box-shadow: var(--elevation-workshop-sm);
+	font-family: var(--font-display);
+	font-size: var(--typescale-label-large-size);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-on-surface);
+	text-shadow: var(--text-shadow-emboss);
+	cursor: pointer;
+
+	&:hover:not(:disabled) {
+		box-shadow: var(--elevation-workshop-md);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+const TriggerLabel = styled.span`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+`
+
+// The chosen value, standing where the control's name would be.
+const TriggerValue = styled.span.withConfig({
+	displayName: 'MultiSelectFilterTriggerValue',
+})`
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--color-primary);
+`
+
+const Badge = styled.span`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 1.25rem;
+	padding: 0 var(--space-3xs);
+	background: var(--color-primary);
+	color: var(--color-on-primary);
+	border-radius: var(--shape-full);
+	font-size: var(--typescale-label-small-size);
+`
+
+const Panel = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	min-width: 14rem;
+	max-width: 20rem;
+`
+
+const SearchWrap = styled.div`
+	position: relative;
+	display: flex;
+	align-items: center;
+`
+
+const SearchIcon = styled.span`
+	position: absolute;
+	left: var(--space-xs);
+	display: inline-flex;
+	color: var(--color-on-surface-variant);
+	pointer-events: none;
+	z-index: 2;
+`
+
+const List = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3xs);
+	max-height: 16rem;
+	overflow-y: auto;
+`
+
+// A real <label> wrapping the checkbox: that is where the checkbox takes its
+// name from, and it makes the whole row the target rather than a 20px square.
+const Row = styled.label`
+	display: flex;
+	align-items: center;
+	gap: var(--space-xs);
+	padding: var(--space-3xs) 0;
+	min-height: 1.5rem;
+	cursor: pointer;
+`
+
+const RowName = styled.span`
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font: var(--type-body-medium);
+	color: var(--color-on-surface);
+`
+
+// Full-strength ink, not the muted variant: at this size, against the darkest
+// corner of the panel's metal gradient, the muted one measures 3.6:1 and misses
+// the 4.5:1 a small label has to meet.
+const RowCount = styled.span`
+	flex: 0 0 auto;
+	font-size: var(--typescale-label-small-size);
+	color: var(--color-on-surface);
+	font-variant-numeric: tabular-nums;
+`
+
+const ClearRow = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	padding-top: var(--space-3xs);
+	border-top: 1px solid var(--color-outline-variant);
+`
+
+// Undoing five tags one at a time is five toggles, each re-counting the rest.
+const ClearButton = styled.button`
+	padding: var(--space-3xs) var(--space-2xs);
+	background: none;
+	border: none;
+	font-size: var(--typescale-label-small-size);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-primary);
+	cursor: pointer;
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: var(--glow-active);
+	}
+`
+
+const Empty = styled.p`
+	margin: 0;
+	padding: var(--space-2xs) 0;
+	font: var(--type-body-small);
+	color: var(--color-on-surface-variant);
+`

--- a/apps/internal/src/hooks/use-company-filter-options.ts
+++ b/apps/internal/src/hooks/use-company-filter-options.ts
@@ -1,10 +1,12 @@
 import { useAtomValue } from '@effect/atom-react'
+import type { I18n } from '@lingui/core'
 import { useLingui } from '@lingui/react'
 import { AsyncResult } from 'effect/unstable/reactivity'
 import { useEffect, useMemo, useRef } from 'react'
 
 import type { CompaniesSearch } from '#/atoms/companies-atoms'
 import { companyFacetsAtom } from '#/atoms/company-facets-atoms'
+import { verdictLabel } from '#/lib/company-fit-verdict'
 import { countryName } from '#/lib/country-name'
 import { useCompanyIndustries } from './use-company-industries'
 
@@ -17,17 +19,53 @@ type FilterOption = {
 type FilterOptions = {
 	readonly countries: ReadonlyArray<FilterOption>
 	readonly industries: ReadonlyArray<FilterOption>
+	// Picked several at a time, so there is no single chosen value to spell the
+	// menu's way — the entries carry what was counted and whatever is already
+	// ticked, and the control matches them by value.
+	readonly tags: ReadonlyArray<FilterOption>
+	readonly fitVerdicts: ReadonlyArray<FilterOption>
 	// The entry the filter in force corresponds to, spelled the menu's way. A
 	// filter can be written more than one way — a trade by its stored form or
 	// its name, a country code in either casing — and a selector can only point
 	// at a value its own list holds.
-	readonly countryValue: string | undefined
 	readonly industryValue: string | undefined
 }
 
 const NOTHING_YET = {
 	countries: [] as ReadonlyArray<FilterOption>,
 	industries: [] as ReadonlyArray<FilterOption>,
+	tags: [] as ReadonlyArray<FilterOption>,
+	fitVerdicts: [] as ReadonlyArray<FilterOption>,
+}
+
+/**
+ * The same two halves as `menuFor`, for a filter that holds several values at
+ * once: whatever would find something, plus whatever is already ticked.
+ *
+ * The order is the server's — commonest first — because a list of tags has no
+ * natural order the reader already knows, unlike a country or a trade name.
+ */
+const multiMenuFor = (
+	counted: ReadonlyArray<FilterOption>,
+	chosen: ReadonlyArray<string> | undefined,
+	// How to name a value the counts do not mention. Without it such a row falls
+	// back to the stored value, and the one moment a reader most needs to
+	// recognise the filter in force is the moment it reads `strong_fit`.
+	labelOf: (value: string) => string = value => value,
+): ReadonlyArray<FilterOption> => {
+	const picked = new Set(chosen ?? [])
+	const offered = counted.filter(
+		option => option.count > 0 || picked.has(option.value),
+	)
+	// A value in force that the count no longer mentions still belongs on the
+	// list, or there is no way to untick it.
+	const missing = [...picked].filter(
+		value => !offered.some(option => option.value === value),
+	)
+	return [
+		...offered,
+		...missing.map(value => ({ value, label: labelOf(value), count: 0 })),
+	]
 }
 
 /**
@@ -71,10 +109,6 @@ const menuFor = (
 	}
 }
 
-/** Two ways of writing one country: the stored code, in any casing. */
-const sameCountry = (option: FilterOption, chosen: string): boolean =>
-	option.value.toUpperCase() === chosen.toUpperCase()
-
 /**
  * The countries and trades to offer beside a filtered list of companies.
  *
@@ -101,16 +135,16 @@ export function useCompanyFilterOptions(
 	const shown = useMemo(() => {
 		if (!AsyncResult.isSuccess(result)) return undefined
 		const facets = result.value
-		const countries = menuFor(
-			facets.country.map(c => ({
-				value: c.value,
-				label: countryName(c.value, locale) ?? c.value,
-				count: c.count,
-			})),
+		const countries = multiMenuFor(
+			facets.country
+				.map(c => ({
+					value: c.value,
+					label: countryName(c.value, locale) ?? c.value,
+					count: c.count,
+				}))
+				.sort((a, b) => a.label.localeCompare(b.label, locale)),
 			search.country,
 			code => countryName(code, locale) ?? code,
-			sameCountry,
-			locale,
 		)
 		const industries = menuFor(
 			facets.industry.map(i => ({
@@ -129,12 +163,37 @@ export function useCompanyFilterOptions(
 			locale,
 		)
 		return {
-			countries: countries.entries,
+			countries,
 			industries: industries.entries,
-			countryValue: countries.chosenValue,
+			tags: multiMenuFor(
+				facets.tags.map(t => ({
+					value: t.value,
+					label: t.value,
+					count: t.count,
+				})),
+				search.tags,
+			),
+			fitVerdicts: multiMenuFor(
+				facets.fitVerdict.map(v => ({
+					value: v.value,
+					label: verdictLabel(i18n, v.value),
+					count: v.count,
+				})),
+				search.fitVerdict,
+				value => verdictLabel(i18n, value),
+			),
 			industryValue: industries.chosenValue,
 		}
-	}, [result, locale, search.country, search.industry, labelFor])
+	}, [
+		result,
+		locale,
+		i18n,
+		search.country,
+		search.industry,
+		search.tags,
+		search.fitVerdict,
+		labelFor,
+	])
 
 	// Kept after the render is committed, never during it: a render React throws
 	// away must not leave these menus behind for filters nobody ever saw.
@@ -143,13 +202,15 @@ export function useCompanyFilterOptions(
 			lastShown.current = {
 				countries: shown.countries,
 				industries: shown.industries,
+				tags: shown.tags,
+				fitVerdicts: shown.fitVerdicts,
 			}
 	}, [shown])
 
 	if (shown !== undefined) return shown
 	// Nothing has arrived yet, or the count failed. Either way the filters in
 	// force still belong on screen, so they can be read and lifted.
-	return keepChosen(lastShown.current, search, labelFor, locale)
+	return keepChosen(lastShown.current, search, labelFor, locale, i18n)
 }
 
 /**
@@ -162,17 +223,18 @@ const keepChosen = (
 	shown: {
 		readonly countries: ReadonlyArray<FilterOption>
 		readonly industries: ReadonlyArray<FilterOption>
+		readonly tags: ReadonlyArray<FilterOption>
+		readonly fitVerdicts: ReadonlyArray<FilterOption>
 	},
 	search: CompaniesSearch,
 	labelFor: (slug: string) => string | null,
 	locale: string,
+	i18n: I18n,
 ): FilterOptions => {
-	const countries = menuFor(
+	const countries = multiMenuFor(
 		shown.countries,
 		search.country,
 		code => countryName(code, locale) ?? code,
-		sameCountry,
-		locale,
 	)
 	const industries = menuFor(
 		shown.industries,
@@ -184,9 +246,12 @@ const keepChosen = (
 		locale,
 	)
 	return {
-		countries: countries.entries,
+		countries,
 		industries: industries.entries,
-		countryValue: countries.chosenValue,
+		tags: multiMenuFor(shown.tags, search.tags),
+		fitVerdicts: multiMenuFor(shown.fitVerdicts, search.fitVerdict, value =>
+			verdictLabel(i18n, value),
+		),
 		industryValue: industries.chosenValue,
 	}
 }

--- a/apps/internal/src/lib/companies-search-params.ts
+++ b/apps/internal/src/lib/companies-search-params.ts
@@ -1,0 +1,30 @@
+import type { CompaniesSearch } from '#/atoms/companies-atoms'
+
+/**
+ * The filters as a query string, for a link built by hand.
+ *
+ * Every field the search holds is written out, rather than a list of names kept
+ * in step by hand: a filter left off that list is dropped from the link, so
+ * arriving from a dashboard heading and switching view would silently widen the
+ * list, and switching back would not put it right.
+ *
+ * A filter holding several values travels comma-separated — the form the server
+ * reads, and the one a person can type.
+ */
+export function companiesSearchToQuery(search: CompaniesSearch): string {
+	const params = new URLSearchParams()
+	for (const [key, raw] of Object.entries(search)) {
+		if (raw === undefined || raw === null || raw === '') continue
+		if (Array.isArray(raw)) {
+			const values = (raw as ReadonlyArray<string>).filter(
+				value => value !== '',
+			)
+			if (values.length === 0) continue
+			params.set(key, values.join(','))
+			continue
+		}
+		params.set(key, String(raw))
+	}
+	const query = params.toString()
+	return query === '' ? '' : `?${query}`
+}

--- a/apps/internal/src/lib/company-fit-verdict.ts
+++ b/apps/internal/src/lib/company-fit-verdict.ts
@@ -1,0 +1,25 @@
+import type { MessageDescriptor } from '@lingui/core'
+import { msg } from '@lingui/core/macro'
+
+// The verdict is stored as the research vocabulary wrote it; the reader sees it
+// in their own language, and a value the vocabulary does not know is shown
+// as-is rather than hidden — nothing enforces the four words, so a run may write
+// a fifth and the company carrying it still has to be readable and findable.
+//
+// One copy, read by the company page and by the filter that narrows a list to a
+// verdict: two lists of these would name the same verdict differently on two
+// screens.
+const VERDICT_LABEL: Record<string, MessageDescriptor> = {
+	strong_fit: msg`Strong fit`,
+	possible_fit: msg`Possible fit`,
+	weak_fit: msg`Weak fit`,
+	no_fit: msg`Not a fit`,
+}
+
+export function verdictLabel(
+	i18n: { _: (descriptor: MessageDescriptor) => string },
+	verdict: string,
+): string {
+	const label = VERDICT_LABEL[verdict]
+	return label === undefined ? verdict : i18n._(label)
+}

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -167,8 +167,10 @@ msgstr "{0} a punt d’aplicar, {1} per llegir, {attentionTotal} execucions requ
 msgid "{0} reported a message as spam, so it is blocked."
 msgstr "{0} ha marcat un missatge com a brossa, així que està bloquejada."
 
+#. placeholder {0}: selected.length
 #. placeholder {0}: selection.selectedCount
 #: src/components/companies/pipeline-board.tsx
+#: src/components/shared/multi-select-filter.tsx
 msgid "{0} selected"
 msgstr "{0} seleccionats"
 
@@ -191,6 +193,13 @@ msgstr "{addedEmail} ja és membre. Se li ha enviat un correu."
 #: src/routes/settings/mcp/connections.tsx
 msgid "{confirmLabel}'s assistant stops reaching this organization on its next request. It keeps working in any other organization they belong to, and they can't undo this themselves."
 msgstr "L'assistent de {confirmLabel} deixarà d'accedir a aquesta organització a la següent petició. Continuarà funcionant a qualsevol altra organització de la qual formi part, i no ho podrà desfer pel seu compte."
+
+#: src/routes/companies/index.tsx
+#: src/routes/companies/index.tsx
+#: src/routes/companies/index.tsx
+#: src/routes/companies/index.tsx
+msgid "{count} companies"
+msgstr "{count} empreses"
 
 #: src/routes/companies/$slug.tsx
 msgid "{count} people went with it"
@@ -534,10 +543,6 @@ msgstr "Assistents d'IA que has connectat per MCP. Cadascun treballa a les organ
 msgid "All"
 msgstr "Tots"
 
-#: src/routes/companies/index.tsx
-msgid "All countries"
-msgstr "Tots els països"
-
 #: src/routes/emails/index.tsx
 #: src/routes/emails/index.tsx
 msgid "All inboxes"
@@ -547,13 +552,13 @@ msgstr "Totes les safates"
 msgid "All industries"
 msgstr "Tots els sectors"
 
-#: src/routes/companies/index.tsx
-msgid "All owners"
-msgstr "Tots els responsables"
-
 #: src/components/research/inbox/research-inbox.tsx
 msgid "All runs"
 msgstr "Totes les execucions"
+
+#: src/routes/companies/index.tsx
+msgid "All stages"
+msgstr "Totes les etapes"
 
 #: src/routes/pages/index.tsx
 msgid "All statuses"
@@ -645,6 +650,10 @@ msgstr "Qualsevol confiança"
 #: src/routes/companies/index.tsx
 msgid "Any priority"
 msgstr "Qualsevol prioritat"
+
+#: src/routes/companies/index.tsx
+msgid "Anything"
+msgstr "Qualsevol"
 
 #: src/routes/settings/api-keys/index.tsx
 #: src/routes/settings/profile/index.tsx
@@ -789,6 +798,10 @@ msgstr "Adjunta"
 #: src/routes/emails/$threadId.tsx
 msgid "attachment"
 msgstr "adjunt"
+
+#: src/routes/companies/index.tsx
+msgid "Attention"
+msgstr "Atenció"
 
 #: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/inbox/research-inbox.tsx
@@ -940,6 +953,22 @@ msgstr "Llista de punts"
 #: src/routes/settings/api-keys/index.tsx
 msgid "by {creatorName}"
 msgstr "per {creatorName}"
+
+#: src/routes/companies/index.tsx
+msgid "By last contact"
+msgstr "Per últim contacte"
+
+#: src/routes/companies/index.tsx
+msgid "By last update"
+msgstr "Per última actualització"
+
+#: src/routes/companies/index.tsx
+msgid "By name"
+msgstr "Per nom"
+
+#: src/routes/companies/index.tsx
+msgid "By priority"
+msgstr "Per prioritat"
 
 #: src/routes/settings/organization/spend.tsx
 msgid "By provider"
@@ -1101,6 +1130,7 @@ msgid "Claude Desktop can't reach a remote server directly, so this bridges thro
 msgstr "Claude Desktop no es pot connectar directament a un servidor remot, així que això fa de pont amb <0>mcp-remote</0> (cal tenir Node instal·lat). O afegeix-lo com a connector OAuth."
 
 #: src/components/companies/pipeline-board.tsx
+#: src/components/shared/multi-select-filter.tsx
 #: src/components/shared/task-item.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/index.tsx
@@ -2555,6 +2585,7 @@ msgstr "Primer contacte enviat"
 #: src/components/companies/company-fit-section.tsx
 #: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/routes/companies/index.tsx
 msgid "Fit"
 msgstr "Encaix"
 
@@ -2670,6 +2701,15 @@ msgstr "Ves a connexions"
 #: src/routes/reset-password.tsx
 msgid "Go to sign in"
 msgstr "Ves a iniciar sessió"
+
+#: src/routes/companies/index.tsx
+msgid "Gone quiet"
+msgstr "En silenci"
+
+#. placeholder {0}: search.staleDays
+#: src/routes/companies/index.tsx
+msgid "Gone quiet · {0}+ days"
+msgstr "En silenci · {0}+ dies"
 
 #: src/components/instructions/template-transfer-dialog.tsx
 msgid "Hand it over"
@@ -3456,7 +3496,6 @@ msgstr "Les meves piles"
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/stack-editor.tsx
 #: src/components/instructions/template-dialog.tsx
-#: src/routes/companies/index.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Name"
@@ -3473,6 +3512,14 @@ msgstr "nom@empresa.com"
 #: src/components/emails/compose-form.tsx
 msgid "name@example.com, another@example.com"
 msgstr "nom@exemple.cat, altre@exemple.cat"
+
+#: src/components/shared/multi-select-filter.tsx
+msgid "Narrow this list"
+msgstr "Filtra aquesta llista"
+
+#: src/components/shared/multi-select-filter.tsx
+msgid "Narrow this list…"
+msgstr "Filtra aquesta llista…"
 
 #: src/routes/index.tsx
 #: src/routes/index.tsx
@@ -3885,7 +3932,7 @@ msgstr "Prioritat normal"
 msgid "Not a contact on file yet"
 msgstr "Encara no és un contacte registrat"
 
-#: src/components/companies/company-fit-section.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Not a fit"
 msgstr "No encaixa"
 
@@ -3953,6 +4000,10 @@ msgstr "Encara no hi ha res connectat a aquesta organització."
 msgid "Nothing later in the queue"
 msgstr "Res més endavant a la cua"
 
+#: src/components/shared/multi-select-filter.tsx
+msgid "Nothing matches"
+msgstr "Cap coincidència"
+
 #: src/components/research/inbox/research-inbox.tsx
 msgid "nothing on file, would add"
 msgstr "no hi ha res, s'afegiria"
@@ -3960,6 +4011,10 @@ msgstr "no hi ha res, s'afegiria"
 #: src/routes/tasks/index.tsx
 msgid "Nothing overdue"
 msgstr "Res endarrerit"
+
+#: src/routes/companies/index.tsx
+msgid "Nothing planned"
+msgstr "Sense res programat"
 
 #: src/routes/tasks/index.tsx
 msgid "Nothing snoozed"
@@ -4230,6 +4285,7 @@ msgid "Outside the area searched:"
 msgstr "Fora de la zona cercada:"
 
 #: src/components/companies/next-action-card.tsx
+#: src/routes/companies/index.tsx
 #: src/routes/index.tsx
 #: src/routes/index.tsx
 #: src/routes/tasks/index.tsx
@@ -4468,8 +4524,8 @@ msgstr "Sense xifrar"
 msgid "Please try again."
 msgstr "Torna-ho a provar."
 
-#: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Possible fit"
 msgstr "Encaix possible"
 
@@ -4511,7 +4567,6 @@ msgstr "Bústia principal establerta"
 msgid "Primary navigation"
 msgstr "Navegació principal"
 
-#: src/routes/companies/index.tsx
 #: src/routes/companies/index.tsx
 #: src/routes/tasks/index.tsx
 msgid "Priority"
@@ -4692,14 +4747,6 @@ msgstr "Execucions recents"
 #: src/components/companies/research-summary-card.tsx
 msgid "recently"
 msgstr "fa poc"
-
-#: src/routes/companies/index.tsx
-msgid "Recently contacted"
-msgstr "Contactats recentment"
-
-#: src/routes/companies/index.tsx
-msgid "Recently updated"
-msgstr "Actualitzats recentment"
 
 #: src/routes/companies/$slug.tsx
 msgid "Recipient marked as spam"
@@ -5581,8 +5628,8 @@ msgstr "Punts forts"
 msgid "Strikethrough"
 msgstr "Ratllat"
 
-#: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Strong fit"
 msgstr "Encaix fort"
 
@@ -5618,6 +5665,7 @@ msgstr "Sistema"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/run-labels.ts
+#: src/routes/companies/index.tsx
 msgid "Tags"
 msgstr "Etiquetes"
 
@@ -6371,8 +6419,8 @@ msgstr "No reconeixem aquest correu. Demana a un administrador que t'inviti."
 msgid "We sent a sign-in link to"
 msgstr "S'ha enviat un enllaç d'inici de sessió a"
 
-#: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Weak fit"
 msgstr "Encaix feble"
 

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -167,8 +167,10 @@ msgstr "{0} ready to apply, {1} need reading, {attentionTotal} runs need attenti
 msgid "{0} reported a message as spam, so it is blocked."
 msgstr "{0} reported a message as spam, so it is blocked."
 
+#. placeholder {0}: selected.length
 #. placeholder {0}: selection.selectedCount
 #: src/components/companies/pipeline-board.tsx
+#: src/components/shared/multi-select-filter.tsx
 msgid "{0} selected"
 msgstr "{0} selected"
 
@@ -191,6 +193,13 @@ msgstr "{addedEmail} is now a member. They've been emailed."
 #: src/routes/settings/mcp/connections.tsx
 msgid "{confirmLabel}'s assistant stops reaching this organization on its next request. It keeps working in any other organization they belong to, and they can't undo this themselves."
 msgstr "{confirmLabel}'s assistant stops reaching this organization on its next request. It keeps working in any other organization they belong to, and they can't undo this themselves."
+
+#: src/routes/companies/index.tsx
+#: src/routes/companies/index.tsx
+#: src/routes/companies/index.tsx
+#: src/routes/companies/index.tsx
+msgid "{count} companies"
+msgstr "{count} companies"
 
 #: src/routes/companies/$slug.tsx
 msgid "{count} people went with it"
@@ -534,10 +543,6 @@ msgstr "AI assistants you've connected over MCP. Each works in the organizations
 msgid "All"
 msgstr "All"
 
-#: src/routes/companies/index.tsx
-msgid "All countries"
-msgstr "All countries"
-
 #: src/routes/emails/index.tsx
 #: src/routes/emails/index.tsx
 msgid "All inboxes"
@@ -547,13 +552,13 @@ msgstr "All inboxes"
 msgid "All industries"
 msgstr "All industries"
 
-#: src/routes/companies/index.tsx
-msgid "All owners"
-msgstr "All owners"
-
 #: src/components/research/inbox/research-inbox.tsx
 msgid "All runs"
 msgstr "All runs"
+
+#: src/routes/companies/index.tsx
+msgid "All stages"
+msgstr "All stages"
 
 #: src/routes/pages/index.tsx
 msgid "All statuses"
@@ -645,6 +650,10 @@ msgstr "Any confidence"
 #: src/routes/companies/index.tsx
 msgid "Any priority"
 msgstr "Any priority"
+
+#: src/routes/companies/index.tsx
+msgid "Anything"
+msgstr "Anything"
 
 #: src/routes/settings/api-keys/index.tsx
 #: src/routes/settings/profile/index.tsx
@@ -789,6 +798,10 @@ msgstr "Attach"
 #: src/routes/emails/$threadId.tsx
 msgid "attachment"
 msgstr "attachment"
+
+#: src/routes/companies/index.tsx
+msgid "Attention"
+msgstr "Attention"
 
 #: src/components/research/inbox/research-inbox.tsx
 #: src/components/research/inbox/research-inbox.tsx
@@ -940,6 +953,22 @@ msgstr "Bullet list"
 #: src/routes/settings/api-keys/index.tsx
 msgid "by {creatorName}"
 msgstr "by {creatorName}"
+
+#: src/routes/companies/index.tsx
+msgid "By last contact"
+msgstr "By last contact"
+
+#: src/routes/companies/index.tsx
+msgid "By last update"
+msgstr "By last update"
+
+#: src/routes/companies/index.tsx
+msgid "By name"
+msgstr "By name"
+
+#: src/routes/companies/index.tsx
+msgid "By priority"
+msgstr "By priority"
 
 #: src/routes/settings/organization/spend.tsx
 msgid "By provider"
@@ -1101,6 +1130,7 @@ msgid "Claude Desktop can't reach a remote server directly, so this bridges thro
 msgstr "Claude Desktop can't reach a remote server directly, so this bridges through <0>mcp-remote</0> (needs Node installed). Or add it as an OAuth connector instead."
 
 #: src/components/companies/pipeline-board.tsx
+#: src/components/shared/multi-select-filter.tsx
 #: src/components/shared/task-item.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/emails/index.tsx
@@ -2555,6 +2585,7 @@ msgstr "First outreach sent"
 #: src/components/companies/company-fit-section.tsx
 #: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/routes/companies/index.tsx
 msgid "Fit"
 msgstr "Fit"
 
@@ -2670,6 +2701,15 @@ msgstr "Go to connections"
 #: src/routes/reset-password.tsx
 msgid "Go to sign in"
 msgstr "Go to sign in"
+
+#: src/routes/companies/index.tsx
+msgid "Gone quiet"
+msgstr "Gone quiet"
+
+#. placeholder {0}: search.staleDays
+#: src/routes/companies/index.tsx
+msgid "Gone quiet · {0}+ days"
+msgstr "Gone quiet · {0}+ days"
 
 #: src/components/instructions/template-transfer-dialog.tsx
 msgid "Hand it over"
@@ -3456,7 +3496,6 @@ msgstr "My stacks"
 #: src/components/contacts/manage-channels-dialog.tsx
 #: src/components/instructions/stack-editor.tsx
 #: src/components/instructions/template-dialog.tsx
-#: src/routes/companies/index.tsx
 #: src/routes/emails/inboxes.tsx
 #: src/routes/settings/api-keys/index.tsx
 msgid "Name"
@@ -3473,6 +3512,14 @@ msgstr "name@company.com"
 #: src/components/emails/compose-form.tsx
 msgid "name@example.com, another@example.com"
 msgstr "name@example.com, another@example.com"
+
+#: src/components/shared/multi-select-filter.tsx
+msgid "Narrow this list"
+msgstr "Narrow this list"
+
+#: src/components/shared/multi-select-filter.tsx
+msgid "Narrow this list…"
+msgstr "Narrow this list…"
 
 #: src/routes/index.tsx
 #: src/routes/index.tsx
@@ -3885,7 +3932,7 @@ msgstr "Normal priority"
 msgid "Not a contact on file yet"
 msgstr "Not a contact on file yet"
 
-#: src/components/companies/company-fit-section.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Not a fit"
 msgstr "Not a fit"
 
@@ -3953,6 +4000,10 @@ msgstr "Nothing is connected to this organization yet."
 msgid "Nothing later in the queue"
 msgstr "Nothing later in the queue"
 
+#: src/components/shared/multi-select-filter.tsx
+msgid "Nothing matches"
+msgstr "Nothing matches"
+
 #: src/components/research/inbox/research-inbox.tsx
 msgid "nothing on file, would add"
 msgstr "nothing on file, would add"
@@ -3960,6 +4011,10 @@ msgstr "nothing on file, would add"
 #: src/routes/tasks/index.tsx
 msgid "Nothing overdue"
 msgstr "Nothing overdue"
+
+#: src/routes/companies/index.tsx
+msgid "Nothing planned"
+msgstr "Nothing planned"
 
 #: src/routes/tasks/index.tsx
 msgid "Nothing snoozed"
@@ -4230,6 +4285,7 @@ msgid "Outside the area searched:"
 msgstr "Outside the area searched:"
 
 #: src/components/companies/next-action-card.tsx
+#: src/routes/companies/index.tsx
 #: src/routes/index.tsx
 #: src/routes/index.tsx
 #: src/routes/tasks/index.tsx
@@ -4468,8 +4524,8 @@ msgstr "Plain"
 msgid "Please try again."
 msgstr "Please try again."
 
-#: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Possible fit"
 msgstr "Possible fit"
 
@@ -4511,7 +4567,6 @@ msgstr "Primary inbox set"
 msgid "Primary navigation"
 msgstr "Primary navigation"
 
-#: src/routes/companies/index.tsx
 #: src/routes/companies/index.tsx
 #: src/routes/tasks/index.tsx
 msgid "Priority"
@@ -4692,14 +4747,6 @@ msgstr "Recent runs"
 #: src/components/companies/research-summary-card.tsx
 msgid "recently"
 msgstr "recently"
-
-#: src/routes/companies/index.tsx
-msgid "Recently contacted"
-msgstr "Recently contacted"
-
-#: src/routes/companies/index.tsx
-msgid "Recently updated"
-msgstr "Recently updated"
 
 #: src/routes/companies/$slug.tsx
 msgid "Recipient marked as spam"
@@ -5581,8 +5628,8 @@ msgstr "Strengths"
 msgid "Strikethrough"
 msgstr "Strikethrough"
 
-#: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Strong fit"
 msgstr "Strong fit"
 
@@ -5618,6 +5665,7 @@ msgstr "System"
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
 #: src/components/research/run-labels.ts
+#: src/routes/companies/index.tsx
 msgid "Tags"
 msgstr "Tags"
 
@@ -6371,8 +6419,8 @@ msgstr "We don't recognize that email. Ask an admin to invite you."
 msgid "We sent a sign-in link to"
 msgstr "We sent a sign-in link to"
 
-#: src/components/companies/company-fit-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
+#: src/lib/company-fit-verdict.ts
 msgid "Weak fit"
 msgstr "Weak fit"
 

--- a/apps/internal/src/router.tsx
+++ b/apps/internal/src/router.tsx
@@ -1,10 +1,35 @@
-import { createRouter } from '@tanstack/react-router'
+import { createRouter, stringifySearchWith } from '@tanstack/react-router'
 
 import { routeTree } from './routeTree.gen'
 
 function NotFound() {
 	return <p>Pàgina no trobada</p>
 }
+
+/**
+ * A filter holding several values is written into the address as one
+ * comma-separated value, not as JSON.
+ *
+ * The router would otherwise write `?status=["contacted","responded"]`, and the
+ * API reads `?status=contacted,responded` — the same list in two spellings, one
+ * of which nobody can type. Writing the form the server already reads keeps a
+ * link people share, hand-edit and paste into a terminal working everywhere.
+ *
+ * Only the array case is ours; everything else is handed to the router's own
+ * encoder unchanged, and the companies list and its board are the only routes
+ * with a list-valued filter today.
+ */
+const stringifySearch = stringifySearchWith(
+	value =>
+		Array.isArray(value) && value.every(entry => typeof entry === 'string')
+			? (value as ReadonlyArray<string>).join(',')
+			: JSON.stringify(value),
+	// Without this second half a value that merely looks like JSON is written
+	// bare: the text `2024` comes back as the number 2024, and every field typed
+	// as text then drops it. Searching for a year, a phone number or the word
+	// `true` silently cleared the box — on every screen, not just this one.
+	JSON.parse,
+)
 
 export const getRouter = () => {
 	const router = createRouter({
@@ -13,6 +38,7 @@ export const getRouter = () => {
 		defaultPreloadStaleTime: 0,
 		defaultNotFoundComponent: NotFound,
 		defaultHashScrollIntoView: { behavior: 'smooth' },
+		stringifySearch,
 	})
 	return router
 }

--- a/apps/internal/src/routes/companies/board.tsx
+++ b/apps/internal/src/routes/companies/board.tsx
@@ -3,20 +3,42 @@ import { ClientOnly, createFileRoute } from '@tanstack/react-router'
 import { Schema } from 'effect'
 import styled from 'styled-components'
 
-import type { CompaniesSearch } from '#/atoms/companies-atoms'
+import { CommaList } from '@batuda/controllers'
+import {
+	AttentionFilter as AttentionFilterSchema,
+	CompanySort as CompanySortSchema,
+} from '@batuda/domain'
+
 import { CompaniesHeader } from '#/components/companies/companies-header'
 import { PipelineBoard } from '#/components/companies/pipeline-board'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
+import { companiesSearchToQuery } from '#/lib/companies-search-params'
 import { validateSearchWith } from '#/lib/search-schema'
 
+// Either comma-separated text from a link somebody wrote, or the list the router
+// hands back from what it last put in the address.
+const ValueList = Schema.Union([Schema.Array(Schema.NonEmptyString), CommaList])
+
 // Same filters as the list minus `status` — the board's columns are the statuses.
+//
+// Every one of the others is named here, including what needs doing: a filter
+// left out is not merely unshown, it is dropped, so arriving from a dashboard
+// heading and switching to the board would silently widen the list.
 const validateSearch = validateSearchWith({
-	country: Schema.NonEmptyString,
+	country: ValueList,
 	industry: Schema.NonEmptyString,
 	priority: Schema.Union([Schema.Number, Schema.NumberFromString]),
-	owner: Schema.NonEmptyString,
-	sort: Schema.NonEmptyString,
+	owner: ValueList,
+	fitVerdict: ValueList,
+	tags: ValueList,
+	sort: CompanySortSchema,
 	query: Schema.NonEmptyString,
+	attention: AttentionFilterSchema,
+	staleDays: Schema.Union([Schema.Number, Schema.NumberFromString]),
+	// Carried like the rest: the list hands over whatever it holds, and a filter
+	// this route does not name is not merely unshown, it is dropped — so going
+	// from the bin to the board would quietly show the live pipeline instead.
+	deleted: Schema.Literals(['only']),
 })
 
 export const Route = createFileRoute('/companies/board')({
@@ -29,19 +51,9 @@ function BoardPage() {
 	const { t } = useLingui()
 	const search = Route.useSearch()
 
-	// Carry the active filters back to the list view.
-	const listHref = (() => {
-		const params = new URLSearchParams()
-		if (search.country) params.set('country', search.country)
-		if (search.industry) params.set('industry', search.industry)
-		if (search.priority !== undefined)
-			params.set('priority', String(search.priority))
-		if (search.owner) params.set('owner', search.owner)
-		if (search.sort) params.set('sort', search.sort)
-		if (search.query) params.set('query', search.query)
-		const qs = params.toString()
-		return qs ? `/companies?${qs}` : '/companies'
-	})()
+	// Carry the active filters back to the list view — all of them, through the
+	// one place that knows how to write them.
+	const listHref = `/companies${companiesSearchToQuery(search)}`
 
 	return (
 		<Page>
@@ -54,7 +66,7 @@ function BoardPage() {
 			/>
 
 			<ClientOnly fallback={<LoadingSpinner label={t`Loading board…`} />}>
-				<PipelineBoard search={search as CompaniesSearch} />
+				<PipelineBoard search={search} />
 			</ClientOnly>
 		</Page>
 	)

--- a/apps/internal/src/routes/companies/index.tsx
+++ b/apps/internal/src/routes/companies/index.tsx
@@ -8,9 +8,14 @@ import { LayoutGroup, motion } from 'motion/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
+import { CommaList } from '@batuda/controllers'
 import {
+	ATTENTION_FILTERS,
 	type AttentionFilter,
 	AttentionFilter as AttentionFilterSchema,
+	COMPANY_SORTS,
+	type CompanySort,
+	CompanySort as CompanySortSchema,
 } from '@batuda/domain'
 import { PriButton, PriInput, PriSelect, usePriToast } from '@batuda/ui/pri'
 
@@ -30,10 +35,12 @@ import { EmptyState } from '#/components/shared/empty-state'
 import { ErrorState } from '#/components/shared/error-state'
 import { InfiniteListFooter } from '#/components/shared/infinite-list-footer'
 import { LoadingSpinner } from '#/components/shared/loading-spinner'
+import { MultiSelectFilter } from '#/components/shared/multi-select-filter'
 import {
 	PRIORITY_LEVELS,
 	priorityShortLabels,
 } from '#/components/shared/priority-dot'
+import { SrOnly } from '#/components/shared/sr-only'
 import {
 	type CompanyStatus,
 	STATUS_ORDER,
@@ -43,6 +50,7 @@ import { useQuickCapture } from '#/context/quick-capture-context'
 import { useCompanyFilterOptions } from '#/hooks/use-company-filter-options'
 import { useInfiniteList } from '#/hooks/use-infinite-list'
 import { dehydrateAtom } from '#/lib/atom-hydration'
+import { companiesSearchToQuery } from '#/lib/companies-search-params'
 import { useOrgMembers } from '#/lib/org-members'
 import { validateSearchWith } from '#/lib/search-schema'
 import { getServerCookieHeader } from '#/lib/server-cookie'
@@ -66,6 +74,12 @@ type CompanyRow = {
 	readonly ownerId: string | null
 }
 
+// A filter holding several values arrives one of two ways, and both have to
+// decode: comma-separated from a link somebody wrote or a link this page built,
+// and as a list from the router's own round-trip of what it last put in the URL.
+// The same two cases `priority` already had, for the same reason.
+const ValueList = Schema.Union([Schema.Array(Schema.NonEmptyString), CommaList])
+
 /**
  * TanStack Router `validateSearch` — runs on every search-param change
  * and produces the canonical `CompaniesSearch` shape. Empty strings and
@@ -77,22 +91,27 @@ type CompanyRow = {
  * first hit). Both decode to `number`.
  */
 const validateSearch = validateSearchWith({
-	status: Schema.NonEmptyString,
-	country: Schema.NonEmptyString,
+	status: ValueList,
+	country: ValueList,
 	industry: Schema.NonEmptyString,
 	priority: Schema.Union([Schema.Number, Schema.NumberFromString]),
-	owner: Schema.NonEmptyString,
-	sort: Schema.NonEmptyString,
+	owner: ValueList,
+	// What a research run concluded. Not a closed set: nothing stops a run
+	// writing a word nobody listed, and a company carrying one still has to be
+	// findable.
+	fitVerdict: ValueList,
+	tags: ValueList,
+	sort: CompanySortSchema,
 	query: Schema.NonEmptyString,
 	// Set when arriving from a dashboard heading, so the list opens on exactly
 	// what that heading was counting rather than on everything.
 	attention: AttentionFilterSchema,
 	staleDays: Schema.Union([Schema.Number, Schema.NumberFromString]),
-	// 'only' shows the ones taken out of view, so somebody can put one back.
-	// Absent means the companies in use, which is the page's ordinary job. A URL
+	// Shows the ones taken out of view, so somebody can put one back. Absent
+	// means the companies in use, which is the page's ordinary job. A URL
 	// carrying anything else is dropped rather than passed on as a filter the
 	// server would not recognise.
-	deleted: Schema.Literals(['only', 'include']),
+	deleted: Schema.Literals(['only']),
 })
 
 /**
@@ -194,7 +213,10 @@ const SEARCH_DEBOUNCE_MS = 300
 const ALL = '__all__'
 
 /** Strip `status` from the search when linking to the board — its columns are
- * the statuses, so a status filter there makes no sense. */
+ * the statuses, so a status filter there makes no sense. Everything else goes
+ * across, including what needs attention: a heading on the dashboard opens a
+ * narrowed list, and dropping a filter on the way would quietly widen it
+ * again. */
 function boardSearch(search: CompaniesSearch): CompaniesSearch {
 	const { status: _status, ...rest } = search
 	return rest
@@ -262,12 +284,42 @@ function CompaniesListPage() {
 		},
 		[navigate],
 	)
-	const handleStatusFilter = useCallback(
-		(status: CompanyStatus | undefined) => {
-			applyPatch({ status })
+	// Ticking a value works off the search the router is about to hand back, not
+	// the one this render captured: two ticks land inside one navigation window
+	// often enough — that is what the popover is for — and building both on the
+	// same captured list would let the second quietly undo the first.
+	const toggleValue = useCallback(
+		(
+			key: 'status' | 'tags' | 'fitVerdict' | 'country' | 'owner',
+			value: string,
+		) => {
+			void navigate({
+				to: '/companies',
+				search: prev => {
+					const chosen = prev[key] ?? []
+					const next = chosen.includes(value)
+						? chosen.filter(other => other !== value)
+						: [...chosen, value]
+					return mergeSearch(prev, {
+						[key]: next.length === 0 ? undefined : next,
+					})
+				},
+			})
 		},
-		[applyPatch],
+		[navigate],
 	)
+	// Stages are alternatives, so picking a second widens rather than narrows:
+	// "everything mid-conversation" is one question, asked of one control.
+	const chosenStatuses = search.status ?? []
+	const toggleStatus = useCallback(
+		(status: CompanyStatus) => {
+			toggleValue('status', status)
+		},
+		[toggleValue],
+	)
+	const clearStatus = useCallback(() => {
+		applyPatch({ status: undefined })
+	}, [applyPatch])
 	const toast = usePriToast()
 	const restoreCompany = useAtomSet(restoreCompanyAtom, { mode: 'promiseExit' })
 	// The menus are counted from the same companies the list holds, so putting
@@ -313,7 +365,7 @@ function CompaniesListPage() {
 	// Counted against the filters already set, and asked for in the same words as
 	// the list itself: a menu offers a narrowing that finds something, plus
 	// whatever is already chosen so it can be taken off again.
-	const { countries, industries, countryValue, industryValue } =
+	const { countries, industries, tags, fitVerdicts, industryValue } =
 		useCompanyFilterOptions(search)
 
 	const activeFilters = hasActiveFilters(search)
@@ -327,10 +379,7 @@ function CompaniesListPage() {
 			? t`1 company`
 			: t`${total} companies`
 
-	const countryItems = [
-		{ value: ALL, label: t`All countries` },
-		...countries.map(c => ({ value: c.value, label: c.label })),
-	]
+	const countryOptions = countries
 	// Filtered by the web-address form, which is what the row carries and what a
 	// shared link keeps working with; the name is what the reader picks from.
 	const industryItems = [
@@ -344,19 +393,49 @@ function CompaniesListPage() {
 			label: i18n._(priorityShortLabels[p]),
 		})),
 	]
-	const ownerItems = [
-		{ value: ALL, label: t`All owners` },
+	// No counts: the colleagues come from the organisation's own list, not from a
+	// tally of the companies, so there is no number to put beside a name.
+	const ownerOptions = [
 		...(meUserId ? [{ value: meUserId, label: t`My leads` }] : []),
 		{ value: 'none', label: t`Unassigned` },
 		...members
 			.filter(m => m.userId !== meUserId)
 			.map(m => ({ value: m.userId, label: m.name })),
 	]
-	const sortItems = [
-		{ value: 'priority', label: t`Priority` },
-		{ value: 'name', label: t`Name` },
-		{ value: 'recent_contact', label: t`Recently contacted` },
-		{ value: 'recent_update', label: t`Recently updated` },
+	// Read off the orders the server actually holds, so a new one cannot be
+	// offered here and quietly ignored there — nor added there and missed here,
+	// since a word without a label below fails to compile.
+	// Each one names the order rather than the field, because the trigger shows
+	// only the value it is set to: a bare "Priority" would sit beside the priority
+	// filter's own "Any priority" and the two would read as the same control.
+	const sortLabels: Record<CompanySort, string> = {
+		priority: t`By priority`,
+		name: t`By name`,
+		recent_contact: t`By last contact`,
+		recent_update: t`By last update`,
+	}
+	const sortItems = COMPANY_SORTS.map(value => ({
+		value,
+		label: sortLabels[value],
+	}))
+	// The threshold rides in the label rather than getting a control of its own:
+	// it only qualifies "gone quiet" and means nothing beside it, but it changes
+	// what the words are worth, so a reader arriving from a heading counted at
+	// sixty days should not read them as the usual fortnight.
+	const attentionLabels: Record<AttentionFilter, string> = {
+		overdue: t`Overdue`,
+		stale:
+			search.staleDays === undefined
+				? t`Gone quiet`
+				: t`Gone quiet · ${search.staleDays}+ days`,
+		'no-next-action': t`Nothing planned`,
+	}
+	const attentionItems = [
+		{ value: ALL, label: t`Anything` },
+		...ATTENTION_FILTERS.map(value => ({
+			value,
+			label: attentionLabels[value],
+		})),
 	]
 
 	return (
@@ -368,6 +447,20 @@ function CompaniesListPage() {
 				boardHref={boardHref(boardSearch(search))}
 				{...(hasResult && total !== undefined ? { subtitle: countLabel } : {})}
 			/>
+
+			{/* Every control in the bar below changes the list without the keyboard
+			 * moving anywhere, so anyone not looking at the screen gets no sign of
+			 * it — including when a control quietly lifts another filter, as the
+			 * bin and what-needs-doing do to each other. This line sits outside the
+			 * block that swaps, because a spoken message that disappears with the
+			 * list it describes is often never read out. */}
+			<SrOnly
+				role='status'
+				aria-live='polite'
+				data-testid='companies-count-announcement'
+			>
+				{hasResult && total !== undefined ? countLabel : ''}
+			</SrOnly>
 
 			<Filters role='group' aria-label={t`Filter companies`}>
 				<SearchWrap>
@@ -388,8 +481,14 @@ function CompaniesListPage() {
 				<StatusFilters role='group' aria-label={t`Filter by status`}>
 					<StatusFilterButton
 						type='button'
-						$active={search.status === undefined}
-						onClick={() => handleStatusFilter(undefined)}
+						$active={chosenStatuses.length === 0}
+						onClick={clearStatus}
+						// It is the one chip that lights up while carrying no state a
+						// listener can hear, so the strip reads as eight toggles and one
+						// plain button with no way to tell which is on. And "All" alone
+						// says nothing about what it is all of.
+						aria-pressed={chosenStatuses.length === 0}
+						aria-label={t`All stages`}
 						data-testid='companies-status-all'
 					>
 						{t`All`}
@@ -398,13 +497,9 @@ function CompaniesListPage() {
 						<StatusFilterButton
 							key={status}
 							type='button'
-							$active={search.status === status}
-							onClick={() =>
-								handleStatusFilter(
-									search.status === status ? undefined : status,
-								)
-							}
-							aria-pressed={search.status === status}
+							$active={chosenStatuses.includes(status)}
+							onClick={() => toggleStatus(status)}
+							aria-pressed={chosenStatuses.includes(status)}
 							data-testid={`companies-status-${status}`}
 						>
 							<StatusBadge status={status} />
@@ -421,6 +516,10 @@ function CompaniesListPage() {
 								// A stage filter would narrow the deleted ones by a stage
 								// nobody is working, which reads as "none of them".
 								status: undefined,
+								// What needs doing is worse: a deleted company is on none of
+								// those lists by definition, so the two together find nothing
+								// at all, every time, with nothing on screen to say why.
+								attention: undefined,
 							})
 						}
 						aria-pressed={search.deleted === 'only'}
@@ -439,11 +538,13 @@ function CompaniesListPage() {
 				/>
 
 				<DropdownRow>
-					<FilterSelect
+					<MultiSelectFilter
 						label={t`Country`}
-						value={countryValue ?? ALL}
-						options={countryItems}
-						onChange={v => applyPatch({ country: v === ALL ? undefined : v })}
+						options={countryOptions}
+						selected={search.country ?? []}
+						onToggle={value => toggleValue('country', value)}
+						onClear={() => applyPatch({ country: undefined })}
+						describeCount={count => t`${count} companies`}
 						testId='companies-filter-country'
 					/>
 					<FilterSelect
@@ -464,18 +565,56 @@ function CompaniesListPage() {
 						}
 						testId='companies-filter-priority'
 					/>
-					<FilterSelect
+					<MultiSelectFilter
 						label={t`Owner`}
-						value={search.owner ?? ALL}
-						options={ownerItems}
-						onChange={v => applyPatch({ owner: v === ALL ? undefined : v })}
+						options={ownerOptions}
+						selected={search.owner ?? []}
+						onToggle={value => toggleValue('owner', value)}
+						onClear={() => applyPatch({ owner: undefined })}
+						describeCount={count => t`${count} companies`}
 						testId='companies-filter-owner'
+					/>
+					<FilterSelect
+						label={t`Attention`}
+						value={search.attention ?? ALL}
+						options={attentionItems}
+						onChange={v =>
+							applyPatch({
+								attention: v === ALL ? undefined : (v as AttentionFilter),
+								// The threshold only qualifies "gone quiet"; left behind on
+								// any other choice it would sit in the link meaning nothing.
+								...(v === 'stale' ? {} : { staleDays: undefined }),
+								// Nothing on these lists is deleted, so asking for both finds
+								// nothing — put the bin down rather than empty the list.
+								...(v === ALL ? {} : { deleted: undefined }),
+							})
+						}
+						testId='companies-filter-attention'
+					/>
+					<MultiSelectFilter
+						label={t`Tags`}
+						options={tags}
+						selected={search.tags ?? []}
+						onToggle={value => toggleValue('tags', value)}
+						onClear={() => applyPatch({ tags: undefined })}
+						describeCount={count => t`${count} companies`}
+						testId='companies-filter-tags'
+					/>
+					<MultiSelectFilter
+						label={t`Fit`}
+						options={fitVerdicts}
+						selected={search.fitVerdict ?? []}
+						onToggle={value => toggleValue('fitVerdict', value)}
+						onClear={() => applyPatch({ fitVerdict: undefined })}
+						describeCount={count => t`${count} companies`}
+						testId='companies-filter-fit'
+						countsStandAlone
 					/>
 					<FilterSelect
 						label={t`Sort`}
 						value={search.sort ?? 'priority'}
 						options={sortItems}
-						onChange={v => applyPatch({ sort: v })}
+						onChange={v => applyPatch({ sort: v as CompanySort })}
 						testId='companies-filter-sort'
 					/>
 					{activeFilters && (
@@ -603,16 +742,7 @@ function CompaniesListPage() {
 
 /** Build the /companies/board URL, carrying the shared filters as query params. */
 function boardHref(search: CompaniesSearch): string {
-	const params = new URLSearchParams()
-	if (search.country) params.set('country', search.country)
-	if (search.industry) params.set('industry', search.industry)
-	if (search.priority !== undefined)
-		params.set('priority', String(search.priority))
-	if (search.owner) params.set('owner', search.owner)
-	if (search.sort) params.set('sort', search.sort)
-	if (search.query) params.set('query', search.query)
-	const qs = params.toString()
-	return qs ? `/companies/board?${qs}` : '/companies/board'
+	return `/companies/board${companiesSearchToQuery(search)}`
 }
 
 function FilterSelect({
@@ -654,83 +784,55 @@ function FilterSelect({
 // ── Helpers ──────────────────────────────────────────────────────
 
 /**
- * Produce the next `CompaniesSearch` from a partial patch while keeping
- * the result strict: any field in `next` that's undefined or empty is
- * *dropped* from the result instead of set to undefined. This is the
- * only way to clear a search param under `exactOptionalPropertyTypes`
- * — assigning `undefined` to an optional field is a TS error.
+ * Produce the next `CompaniesSearch` from a partial patch while keeping the
+ * result strict: any value in `next` that is undefined, blank, or an empty list
+ * is *dropped* from the result instead of set to undefined. That is the only way
+ * to clear a search param under `exactOptionalPropertyTypes` — assigning
+ * `undefined` to an optional field is a TS error.
+ *
+ * Written once over whatever the search holds, rather than a block per field: a
+ * block per field has to be extended for every new filter, and a filter that is
+ * missed simply never clears.
  */
 function mergeSearch(
 	prev: CompaniesSearch,
 	next: Partial<{
-		status: string | undefined
-		country: string | undefined
-		industry: string | undefined
-		priority: number | undefined
-		owner: string | undefined
-		sort: string | undefined
-		query: string | undefined
-		attention: AttentionFilter | undefined
-		staleDays: number | undefined
-		deleted: 'only' | 'include' | undefined
+		[K in keyof CompaniesSearch]: CompaniesSearch[K] | undefined
 	}>,
 ): CompaniesSearch {
-	const result: {
-		status?: string
-		country?: string
-		industry?: string
-		priority?: number
-		owner?: string
-		sort?: string
-		query?: string
-		attention?: AttentionFilter
-		staleDays?: number
-		deleted?: 'only' | 'include'
-	} = {}
-
-	const status = 'status' in next ? next.status : prev.status
-	if (status !== undefined && status !== '') result.status = status
-
-	const country = 'country' in next ? next.country : prev.country
-	if (country !== undefined && country !== '') result.country = country
-
-	const industry = 'industry' in next ? next.industry : prev.industry
-	if (industry !== undefined && industry !== '') result.industry = industry
-
-	const priority = 'priority' in next ? next.priority : prev.priority
-	if (priority !== undefined) result.priority = priority
-
-	const query = 'query' in next ? next.query : prev.query
-	if (query !== undefined && query !== '') result.query = query
-
-	const owner = 'owner' in next ? next.owner : prev.owner
-	if (owner !== undefined && owner !== '') result.owner = owner
-
-	const sort = 'sort' in next ? next.sort : prev.sort
-	if (sort !== undefined && sort !== '') result.sort = sort
-
-	const attention = 'attention' in next ? next.attention : prev.attention
-	if (attention !== undefined) result.attention = attention
-
-	const staleDays = 'staleDays' in next ? next.staleDays : prev.staleDays
-	if (staleDays !== undefined) result.staleDays = staleDays
-
-	const deleted = 'deleted' in next ? next.deleted : prev.deleted
-	if (deleted !== undefined) result.deleted = deleted
-
-	return result
+	const merged: Record<string, unknown> = { ...prev, ...next }
+	const result: Record<string, unknown> = {}
+	for (const [key, value] of Object.entries(merged)) {
+		if (value === undefined || value === null || value === '') continue
+		if (Array.isArray(value)) {
+			const values = (value as ReadonlyArray<string>).filter(v => v !== '')
+			if (values.length === 0) continue
+			result[key] = values
+			continue
+		}
+		result[key] = value
+	}
+	return result as CompaniesSearch
 }
 
+// The two the search holds that do not narrow it: the order to read it in, and
+// how long counts as quiet, which only qualifies the attention filter and means
+// nothing on its own.
+const NON_NARROWING_KEYS = new Set(['sort', 'staleDays'])
+
+/**
+ * Whether anything is narrowing the list.
+ *
+ * Asking the object rather than naming the filters is what stops a new filter
+ * from narrowing the list with nothing on screen offering to clear it.
+ */
 function hasActiveFilters(search: CompaniesSearch): boolean {
-	return (
-		search.status !== undefined ||
-		search.country !== undefined ||
-		search.industry !== undefined ||
-		search.priority !== undefined ||
-		search.owner !== undefined ||
-		search.attention !== undefined ||
-		search.query !== undefined
-	)
+	return Object.entries(search).some(([key, value]) => {
+		if (NON_NARROWING_KEYS.has(key)) return false
+		if (value === undefined || value === null || value === '') return false
+		if (Array.isArray(value)) return value.length > 0
+		return true
+	})
 }
 
 // Typed date fields decode to DateTime.Utc on the wire; fall back to their
@@ -943,7 +1045,12 @@ const DropdownRow = styled.div.withConfig({
 })`
 	display: flex;
 	flex-wrap: wrap;
-	align-items: center;
+	/* Stretch, not centre: one control carries a longer label than the rest —
+	 * "Gone quiet · 30+ days" — and on a narrow row it takes two lines. Centred,
+	 * it would stand taller than its neighbours and the row would read as broken;
+	 * stretched, every control on a line is the same height whatever its label
+	 * does. */
+	align-items: stretch;
 	gap: var(--space-2xs);
 
 	/* Each dropdown takes a share of the line and stops shrinking once it is

--- a/apps/internal/src/routes/index.tsx
+++ b/apps/internal/src/routes/index.tsx
@@ -353,7 +353,11 @@ function PipelinePage() {
 			<StatusStrip>
 				{STATUS_ORDER.map(status => (
 					<StatusChip key={status} data-testid={`pipeline-column-${status}`}>
-						<Link to='/companies' search={{ status }} aria-label={status} />
+						<Link
+							to='/companies'
+							search={{ status: [status] }}
+							aria-label={status}
+						/>
 						<StatusBadge status={status} size='lg' />
 						<StatusCount>{countFor(status)}</StatusCount>
 					</StatusChip>

--- a/apps/internal/tests/e2e/company-filter-options.test.ts
+++ b/apps/internal/tests/e2e/company-filter-options.test.ts
@@ -103,8 +103,10 @@ test.describe('company filter options', () => {
 			await page.goto('/companies?industry=ceramica', {
 				waitUntil: 'networkidle',
 			})
+			// The header's own line, not the spoken one beside it: the count is
+			// deliberately in the page twice, visible and announced.
 			await expect(
-				page.getByText('1 company with filters applied'),
+				page.locator('p', { hasText: '1 company with filters applied' }),
 			).toBeVisible({ timeout: 10_000 })
 
 			// WHEN the list is also narrowed to clients, which that trade has none of
@@ -144,4 +146,250 @@ test.describe('company filter options', () => {
 			await expect(page.getByTestId(SPAIN)).toBeVisible({ timeout: 10_000 })
 		})
 	})
+
+	test.describe('when a second stage is picked', () => {
+		test('should widen to either, and say so in the address', async ({
+			page,
+		}) => {
+			// GIVEN the list narrowed to one stage
+			await page.goto('/companies', { waitUntil: 'networkidle' })
+			await page.getByTestId('companies-status-contacted').click()
+			await expect(page).toHaveURL(/status=contacted/)
+			const oneStage = await countShown(page)
+
+			// WHEN a second stage is picked rather than swapping the first
+			await page.getByTestId('companies-status-responded').click()
+
+			// THEN both are in force and the list has grown. A company has one
+			// stage, so naming a second can only widen — which is the question
+			// ("everything mid-conversation") the board view existed to answer
+			await expect(page).toHaveURL(
+				/status=contacted%2Cresponded|status=contacted,responded/,
+			)
+			await expect(
+				page.getByTestId('companies-status-contacted'),
+			).toHaveAttribute('aria-pressed', 'true')
+			await expect(
+				page.getByTestId('companies-status-responded'),
+			).toHaveAttribute('aria-pressed', 'true')
+			expect(await countShown(page)).toBeGreaterThan(oneStage)
+		})
+	})
+
+	test.describe('when the list is opened from a dashboard heading', () => {
+		test('should name what needs doing, not only carry it in the address', async ({
+			page,
+		}) => {
+			// GIVEN a link of the kind the dashboard's headings produce
+			await page.goto('/companies?attention=overdue', {
+				waitUntil: 'networkidle',
+			})
+
+			// THEN the control says which one is filtering. Unnamed, it would narrow
+			// the list with nothing on screen saying so, leaving the address bar as
+			// the only way to find out what "companies with filters applied" meant
+			await expect(page.getByTestId('companies-filter-attention')).toHaveText(
+				/overdue/i,
+			)
+		})
+
+		test('should put it down when the bin is opened, rather than show nothing', async ({
+			page,
+		}) => {
+			// GIVEN the list narrowed to what is overdue
+			await page.goto('/companies?attention=overdue', {
+				waitUntil: 'networkidle',
+			})
+
+			// WHEN the deleted companies are asked for
+			await page.getByTestId('companies-filter-deleted').click()
+
+			// THEN what needs doing is lifted. A deleted company is on none of those
+			// lists by definition, so the two together match nothing at all — an
+			// empty screen with no way to tell why
+			await expect(page).toHaveURL(/deleted=only/)
+			await expect(page).not.toHaveURL(/attention=/)
+		})
+	})
+
+	test.describe('when a tag is picked', () => {
+		test('should narrow by it and keep it visible on the control', async ({
+			page,
+		}) => {
+			// GIVEN the companies list, whose tag menu is counted from the same
+			// companies the list holds
+			await page.goto('/companies', { waitUntil: 'networkidle' })
+			const tags = page.getByTestId('companies-filter-tags')
+			await tags.click()
+
+			// WHEN the first tag on offer is ticked
+			const option = page
+				.locator('[data-testid^="companies-filter-tags-option-"]')
+				.first()
+			await expect(option).toBeVisible({ timeout: 10_000 })
+			const picked = ((await option.getAttribute('data-testid')) ?? '').replace(
+				'companies-filter-tags-option-',
+				'',
+			)
+			await option.click()
+
+			// THEN the list is narrowed by it, and the control names it, so the reader
+			// sees what is in force without opening it again
+			await expect(page).toHaveURL(
+				new RegExp(`tags=${encodeURIComponent(picked)}`, 'i'),
+			)
+			await expect(tags).toHaveText(new RegExp(picked, 'i'))
+		})
+	})
+
+	test.describe('when a fit verdict is picked', () => {
+		test('should narrow by what the research runs concluded', async ({
+			page,
+		}) => {
+			// GIVEN the companies list
+			await page.goto('/companies', { waitUntil: 'networkidle' })
+			await page.getByTestId('companies-filter-fit').click()
+
+			// WHEN a verdict on offer is ticked
+			const option = page.getByTestId('companies-filter-fit-option-strong_fit')
+			await expect(option).toBeVisible({ timeout: 10_000 })
+			await option.click()
+
+			// THEN it filters the list. The menu is built from what runs actually
+			// wrote rather than a fixed list of four words, so a verdict nobody
+			// listed is still offered instead of hiding the companies carrying it
+			await expect(page).toHaveURL(/fitVerdict=strong_fit/)
+		})
+	})
 })
+
+test.describe('when the filters are used without looking at the screen', () => {
+	test('should name each option, so the choices are told apart', async ({
+		page,
+	}) => {
+		// GIVEN the tag menu open
+		await page.goto('/companies', { waitUntil: 'networkidle' })
+		await page.getByTestId('companies-filter-tags').click()
+		const first = page
+			.locator('[data-testid^="companies-filter-tags-option-"]')
+			.first()
+		await expect(first).toBeVisible({ timeout: 10_000 })
+		const tag = ((await first.getAttribute('data-testid')) ?? '').replace(
+			'companies-filter-tags-option-',
+			'',
+		)
+
+		// THEN the option is a checkbox that carries the tag as its name. Named
+		// by nothing, every row announces as "unchecked checkbox" and a listener
+		// has no way to tell one from the next
+		// The name carries the tag and what its number counts. Base UI's own
+		// hidden input sits beside it carrying `aria-hidden`, so it is not a
+		// second checkbox as far as anyone listening is concerned
+		await expect(
+			page.getByRole('checkbox', { name: new RegExp(`^${tag} `) }),
+		).toHaveCount(1)
+
+		// AND there is one control per row, not a nameless checkbox beside a
+		// stateless button — which was two tab stops for one choice
+		await expect(
+			page.getByRole('button', { name: tag, exact: true }),
+		).toHaveCount(0)
+	})
+
+	test('should say what is chosen, not only show a badge', async ({ page }) => {
+		// GIVEN two tags chosen, which is where the control stops naming them and
+		// starts counting them
+		await page.goto('/companies', { waitUntil: 'networkidle' })
+		const tags = page.getByTestId('companies-filter-tags')
+		await tags.click()
+		const options = page.locator(
+			'[data-testid^="companies-filter-tags-option-"]',
+		)
+		await expect(options.first()).toBeVisible({ timeout: 10_000 })
+		await options.first().click()
+		await expect(options.nth(1)).toBeVisible()
+		await options.nth(1).click()
+		await page.keyboard.press('Escape')
+
+		// THEN the trigger's own name carries the number in words. A bare digit
+		// beside the label is silence to a listener, which is the one thing the
+		// badge exists to say
+		await expect(tags).toHaveAccessibleName(/2 selected/i)
+	})
+
+	test('should name a single choice rather than count it', async ({ page }) => {
+		// GIVEN one tag chosen
+		await page.goto('/companies', { waitUntil: 'networkidle' })
+		const tags = page.getByTestId('companies-filter-tags')
+		await tags.click()
+		const first = page
+			.locator('[data-testid^="companies-filter-tags-option-"]')
+			.first()
+		await expect(first).toBeVisible({ timeout: 10_000 })
+		const picked = ((await first.getAttribute('data-testid')) ?? '').replace(
+			'companies-filter-tags-option-',
+			'',
+		)
+		await first.click()
+		await page.keyboard.press('Escape')
+
+		// THEN it is named, spoken as well as shown — "1" would tell a reader that
+		// something is in force while withholding which
+		await expect(tags).toHaveAccessibleName(new RegExp(picked, 'i'))
+	})
+
+	test('should say which stage filter is in force, including none', async ({
+		page,
+	}) => {
+		// GIVEN nothing narrowed by stage
+		await page.goto('/companies', { waitUntil: 'networkidle' })
+
+		// THEN the chip that is lit says so. It is the only one that lights up
+		// while carrying no state a listener can hear
+		const all = page.getByTestId('companies-status-all')
+		await expect(all).toHaveAttribute('aria-pressed', 'true')
+
+		// WHEN a stage is picked
+		await page.getByTestId('companies-status-client').click()
+		await expect(page).toHaveURL(/status=client/)
+
+		// THEN the two swap, and both say which they are
+		await expect(all).toHaveAttribute('aria-pressed', 'false')
+		await expect(page.getByTestId('companies-status-client')).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		)
+	})
+
+	test('should announce the count when a filter changes it', async ({
+		page,
+	}) => {
+		// GIVEN the list unfiltered
+		await page.goto('/companies', { waitUntil: 'networkidle' })
+
+		// WHEN a stage is picked, which changes the list without the keyboard
+		// moving anywhere
+		await page.getByTestId('companies-status-client').click()
+		await expect(page).toHaveURL(/status=client/)
+
+		// THEN the change is spoken. Without it a listener gets silence, and the
+		// two controls that quietly lift another filter are invisible entirely
+		await expect(
+			page.getByTestId('companies-count-announcement'),
+		).toContainText(/compan(y|ies) with filters applied/, {
+			timeout: 10_000,
+		})
+	})
+})
+
+// The total the header states, which is what a filter is judged by — the grid
+// only holds the page loaded so far.
+async function countShown(
+	page: import('@playwright/test').Page,
+): Promise<number> {
+	const text = await page
+		.locator('p', { hasText: /companies? with filters applied/ })
+		.first()
+		.textContent()
+	return Number((text ?? '').match(/\d+/)?.[0] ?? '0')
+}

--- a/apps/internal/tests/e2e/company-industries.test.ts
+++ b/apps/internal/tests/e2e/company-industries.test.ts
@@ -223,8 +223,10 @@ test.describe('company industries', () => {
 			// THEN the list narrows to that trade, and the count reads in the
 			// singular rather than "1 companies"
 			await expect(page).toHaveURL(/industry=serralleria/)
+			// The header's own line, not the spoken one beside it: the count is
+			// deliberately in the page twice, visible and announced
 			await expect(
-				page.getByText('1 company with filters applied'),
+				page.locator('p', { hasText: '1 company with filters applied' }),
 			).toBeVisible({ timeout: 10_000 })
 		})
 	})

--- a/apps/server/src/db/migrations-company-filters.integration.test.ts
+++ b/apps/server/src/db/migrations-company-filters.integration.test.ts
@@ -1,0 +1,183 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PgLive } from './client.js'
+import putFiltersRight from './migrations/0068_company_country_case_and_tag_index'
+
+// Putting the rows already stored in step with two rules the filters lean on.
+//
+// Both rules turn a value away where it is written from now on, so the only way
+// a bad one exists is that it was written before — which means the repair itself
+// is the only thing standing between those companies and a filter that cannot
+// find them. It cannot be shown without a real database: the point is what the
+// UPDATE does to rows, and the suite runs after the migration has already been
+// applied, so every fixture here is written the way the old rules allowed.
+
+const run = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
+	Effect.runPromise(
+		effect.pipe(Effect.provide(PgLive), Effect.orDie) as Effect.Effect<A>,
+	)
+
+const withSql = <A, E>(
+	f: (sql: SqlClient.SqlClient) => Effect.Effect<A, E, SqlClient.SqlClient>,
+) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		return yield* f(sql)
+	})
+
+const orgs: Array<string> = []
+
+// Written straight in, past the schemas: these are the shapes the rules now
+// refuse, and the whole question is what happens to them.
+const seedCompany = (
+	orgId: string,
+	country: string | null,
+	tags: ReadonlyArray<string> | null,
+) =>
+	withSql(sql =>
+		Effect.gen(function* () {
+			const rows = yield* sql<{ id: string }>`
+				INSERT INTO companies (organization_id, slug, name, country, tags)
+				VALUES (${orgId}, ${`co-${randomUUID()}`}, 'Seeded', ${country},
+					${tags}::text[])
+				RETURNING id
+			`
+			return rows[0]?.id as string
+		}),
+	)
+
+const readCompany = (id: string) =>
+	withSql(
+		sql => sql<{ country: string | null; tags: ReadonlyArray<string> | null }>`
+			SELECT country, tags FROM companies WHERE id = ${id}
+		`,
+	)
+
+afterEach(async () => {
+	for (const orgId of orgs.splice(0))
+		await run(
+			withSql(
+				sql => sql`DELETE FROM companies WHERE organization_id = ${orgId}`,
+			),
+		)
+})
+
+describe('putting company countries and tags in step with the filters', () => {
+	describe('when a country was stored in lower case', () => {
+		it('should raise it, so the one spelling the filter asks for finds it', async () => {
+			// GIVEN a company written before the rule raised what it was given
+			const org = `filters-${randomUUID()}`
+			orgs.push(org)
+			const id = await run(seedCompany(org, 'es', null))
+
+			// WHEN the rows are put in step
+			await run(putFiltersRight)
+
+			// THEN it carries the spelling every reader compares against
+			const [row] = await run(readCompany(id))
+			expect(row?.country).toBe('ES')
+		})
+	})
+
+	describe('when the stored country is not a code at all', () => {
+		it('should leave it alone rather than shout it back', async () => {
+			// GIVEN somebody typed a country name into a field that wanted a code
+			const org = `filters-${randomUUID()}`
+			orgs.push(org)
+			const id = await run(seedCompany(org, 'Spain', null))
+
+			// WHEN the rows are put in step
+			await run(putFiltersRight)
+
+			// THEN it reads as it was written. Raising it cannot be undone and
+			// would not make it findable either, so it is left for a person
+			const [row] = await run(readCompany(id))
+			expect(row?.country).toBe('Spain')
+		})
+	})
+
+	describe('when a tag holds a comma', () => {
+		it('should split it into the tags it was meant to be', async () => {
+			// GIVEN a tag written as one value, back when a comma was allowed —
+			// several tags travel as one comma-separated value, so this one comes
+			// back as two tags nobody carries and the company stops being findable
+			const org = `filters-${randomUUID()}`
+			orgs.push(org)
+			const id = await run(seedCompany(org, null, ['Barcelona, Sants', 'hvac']))
+
+			// WHEN the rows are put in step
+			await run(putFiltersRight)
+
+			// THEN it is the two tags it plainly meant, and the others are untouched
+			const [row] = await run(readCompany(id))
+			expect([...(row?.tags ?? [])].sort()).toStrictEqual([
+				'Barcelona',
+				'Sants',
+				'hvac',
+			])
+		})
+
+		it('should drop the blank ends and any duplicate the split creates', async () => {
+			// GIVEN a comma tag whose halves are padded, and one of which the
+			// company already carries on its own
+			const org = `filters-${randomUUID()}`
+			orgs.push(org)
+			const id = await run(seedCompany(org, null, [' hvac , olot ', 'hvac']))
+
+			// WHEN the rows are put in step
+			await run(putFiltersRight)
+
+			// THEN each tag appears once, with nothing hanging off its ends
+			const [row] = await run(readCompany(id))
+			expect([...(row?.tags ?? [])].sort()).toStrictEqual(['hvac', 'olot'])
+		})
+	})
+
+	describe('when there was nothing wrong with the row', () => {
+		it('should leave it exactly as it was', async () => {
+			// GIVEN a company already written the way the rules now require
+			const org = `filters-${randomUUID()}`
+			orgs.push(org)
+			const id = await run(seedCompany(org, 'FR', ['hvac', 'olot']))
+
+			// WHEN the rows are put in step
+			await run(putFiltersRight)
+
+			// THEN nothing about it moves
+			const [row] = await run(readCompany(id))
+			expect(row?.country).toBe('FR')
+			expect([...(row?.tags ?? [])].sort()).toStrictEqual(['hvac', 'olot'])
+		})
+	})
+
+	describe('when it is run a second time', () => {
+		it('should change nothing it changed the first time', async () => {
+			// GIVEN rows that needed both repairs, already repaired once
+			const org = `filters-${randomUUID()}`
+			orgs.push(org)
+			const id = await run(seedCompany(org, 'pt', ['a, b']))
+			await run(putFiltersRight)
+			const [afterOnce] = await run(readCompany(id))
+
+			// WHEN it runs again
+			await run(putFiltersRight)
+
+			// THEN the row reads the same. A repair that moved on every run would
+			// keep splitting values that were never meant to be split
+			const [afterTwice] = await run(readCompany(id))
+			expect(afterTwice?.country).toBe(afterOnce?.country)
+			expect([...(afterTwice?.tags ?? [])].sort()).toStrictEqual(
+				[...(afterOnce?.tags ?? [])].sort(),
+			)
+		})
+	})
+})

--- a/apps/server/src/db/migrations/0068_company_country_case_and_tag_index.ts
+++ b/apps/server/src/db/migrations/0068_company_country_case_and_tag_index.ts
@@ -1,0 +1,58 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+// Three things a company list needs before its filters can be trusted.
+//
+// First, one spelling per country. The shape a country has to have — two
+// letters — never said which case, and it is written in as free text, so `es`
+// was as storable as `ES`. Both the filter and the per-value counts compare the
+// stored text exactly, so a company saved lowercase was missed by anyone asking
+// for the capitals, and was offered as a second Spain with a count of its own.
+// Only rows that are actually a two-letter code are touched: a hand-typed
+// `Spain` is left alone rather than shouted back as `SPAIN`, since raising it
+// cannot be undone and would not make it findable either.
+//
+// Second, tags that can survive a round trip. Several tags travel to and from a
+// screen as one comma-separated value, so a tag holding a comma comes back as
+// two tags nobody carries: the menu offers it, and picking it finds nothing.
+// New ones are turned away where they are written; these are the ones already
+// stored, split on the comma into the tags they were plainly meant to be, with
+// blank ends trimmed and any duplicate the split creates dropped. Irreversible,
+// and deliberately so — the single tag it came from could never be asked for.
+//
+// Third, an index for tags. Narrowing by a tag is `tags @> …`, which a GIN index
+// serves. Offering the tags worth narrowing by expands every company's array,
+// which no index can serve — that one stays a scan.
+//
+// All three change nothing on a second run.
+
+export default Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient
+
+	yield* sql`
+		UPDATE companies
+		SET country = upper(country)
+		WHERE country IS NOT NULL
+			AND country ~ '^[A-Za-z]{2}$'
+			AND country <> upper(country)
+	`
+
+	yield* sql`
+		UPDATE companies
+		SET tags = cleaned.tags
+		FROM (
+			SELECT c.id,
+				array_agg(DISTINCT btrim(part)) FILTER (WHERE btrim(part) <> '') AS tags
+			FROM companies c, unnest(c.tags) AS tag, unnest(string_to_array(tag, ',')) AS part
+			WHERE c.tags IS NOT NULL
+			GROUP BY c.id
+		) AS cleaned
+		WHERE companies.id = cleaned.id
+			AND companies.tags IS DISTINCT FROM cleaned.tags
+	`
+
+	yield* sql`
+		CREATE INDEX IF NOT EXISTS idx_companies_tags
+			ON companies USING GIN (tags)
+	`
+})

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -2,8 +2,13 @@ import { DateTime, Effect, Schema } from 'effect'
 import { Tool, Toolkit } from 'effect/unstable/ai'
 import { SqlClient } from 'effect/unstable/sql'
 
-import { CompanyDetail, CurrentOrg } from '@batuda/controllers'
 import {
+	CompanyDetail,
+	CurrentOrg,
+	STALE_DAYS_BOUNDS,
+} from '@batuda/controllers'
+import {
+	AttentionFilter,
 	COMPANY_PRIORITIES,
 	COMPANY_STATUSES,
 	Company,
@@ -19,7 +24,9 @@ import {
 	CompanySizeRange,
 	CompanySlug,
 	CompanySocialProfile,
+	CompanySort,
 	CompanyStatus,
+	CompanyTag,
 	CompanyWebsite,
 	companySlugFromName,
 	HandSetVerificationVerdict,
@@ -71,19 +78,53 @@ export const CompanyFilterOptions = Schema.Struct({
 			company_count: Schema.Number,
 		}),
 	),
+	// The tags actually in use, so a caller stops guessing at free text. The count
+	// is how many are left if this tag is added to the ones already asked for, so
+	// a tag already asked for reports the whole current list.
+	tags: Schema.Array(
+		Schema.Struct({ tag: Schema.String, company_count: Schema.Number }),
+	),
+	// The verdicts runs have actually written, which need not be the four expected
+	// words — the column is free text, so counting is the only honest menu.
+	fit_verdicts: Schema.Array(
+		Schema.Struct({ verdict: Schema.String, company_count: Schema.Number }),
+	),
 })
 
 const SearchCompanies = Tool.make('search_companies', {
 	description:
-		'Filter companies by status, country (ISO 3166-1 alpha-2, e.g. US/ES/DE), industry, priority, search query, the research fit verdict (strong_fit / possible_fit / weak_fit / no_fit) — what a research run concluded, which nothing but a run writes, so a view of your own lives under `metadata` and is found with the pair below — a fit criterion the company passed (matched loosely against the criterion text), a tag or tags the company carries (every one named has to be on it, so a second tag narrows the list), one thing written under `metadata` given as `metadata_key` plus `metadata_value`, or a geographic bounding box. The box is any subset of min_lat/max_lat/min_lng/max_lng (decimal degrees); each bound is applied independently and only matches companies with stored coordinates. Returns summaries (including latitude/longitude) — call get_company for full details. Set `include_filter_options` to be told which countries and trades actually narrow this list, rather than guessing a value and getting nothing back. `hasMore` says whether more matched than were returned — read it before saying how many there are, and ask again with a larger `offset` if it is true.',
+		'Filter companies by status, country (ISO 3166-1 alpha-2, e.g. US/ES/DE), industry, priority, owner, search query, what needs attention, the research fit verdict, a fit criterion the company passed, tags, one thing written under `metadata`, or a geographic bounding box. `status`, `country`, `owner` and `fit_verdict` each take a list and match ANY of the values in it, while different filters narrow one another — so status ["contacted","responded"] with country ["ES"] is those two stages in Spain. `tags` reads the other way round: every tag named has to be on the company, so a second tag narrows the list. `owner` takes user ids from list_members and/or the word "none" for companies nobody has taken; pass both to ask for yours plus the unclaimed. `attention` is what needs doing, in the same words the daily lists use: "overdue" missed its follow-up date, "stale" is mid-chase and unheard from for `stale_days` (default 14), "no-next-action" has nothing written down at all — a deleted company counts as none of these, so `attention` with `deleted: "only"` finds nothing at all, and with `deleted: "include"` simply leaves the deleted ones out. `fit_verdict` is what a research run concluded (strong_fit / possible_fit / weak_fit / no_fit), which nothing but a run writes, so a view of your own lives under `metadata` and is found with the pair below — a fit criterion is matched loosely against the criterion text. One thing under `metadata` is given as `metadata_key` plus `metadata_value`. The box is any subset of min_lat/max_lat/min_lng/max_lng (decimal degrees); each bound is applied independently and only matches companies with stored coordinates. `sort` picks the order: priority (the default), name, recent_contact, recent_update. Returns summaries (including latitude/longitude) — call get_company for full details. Set `include_filter_options` to be told which countries, trades, tags and fit verdicts are worth asking for, rather than guessing a value and getting nothing back. Each count is how many companies carry that value under the OTHER filters in force — for `status`, `country` and `fit_verdict` that is what adding it would bring in, not the size of the list you would end up with, since a second value there widens. For `tags` it is both, because every tag named has to be on the company, so a tag already chosen just reports the whole current list. `hasMore` says whether more matched than were returned — read it before saying how many there are, and ask again with a larger `offset` if it is true.',
 	parameters: Schema.Struct({
-		status: Schema.optionalKey(Schema.String),
-		country: Schema.optionalKey(Schema.String),
+		// The same closed word lists the write tools below use. A stage the model
+		// invented used to come back as an empty list, which reads as "you have
+		// none of those" rather than "that is not a stage".
+		status: Schema.optionalKey(Schema.Array(CompanyStatus)),
+		country: Schema.optionalKey(Schema.Array(CompanyCountry)),
 		industry: Schema.optionalKey(Schema.String),
-		priority: Schema.optionalKey(Schema.Number),
-		fit_verdict: Schema.optionalKey(Schema.String),
+		priority: Schema.optionalKey(CompanyPriority),
+		owner: Schema.optionalKey(Schema.Array(Schema.String)).annotate({
+			description:
+				'User ids from list_members, and/or the literal "none" for companies nobody has taken. Several values match any of them, so ["none", "<my id>"] is what I am working plus what is going spare.',
+		}),
+		attention: Schema.optionalKey(AttentionFilter).annotate({
+			description:
+				'What needs doing. Narrows to the same companies the daily lists report, so a count there and a list here agree. A deleted company is on none of these lists, so pairing this with `deleted: "only"` finds nothing.',
+		}),
+		stale_days: Schema.optionalKey(
+			Schema.Number.pipe(
+				Schema.check(Schema.isInt(), Schema.isBetween(STALE_DAYS_BOUNDS)),
+			),
+		).annotate({
+			description:
+				'How long a company may go quiet before `attention: "stale"` counts it, in days (default 14). Raise it for long sales cycles. Means nothing on its own.',
+		}),
+		sort: Schema.optionalKey(CompanySort).annotate({
+			description:
+				'The order to read the list in. Defaults to priority, so ask for recent_contact or recent_update when the question is about what happened lately — a page of the default order cannot be re-sorted after the fact.',
+		}),
+		fit_verdict: Schema.optionalKey(Schema.Array(Schema.String)),
 		fit_criterion_passed: Schema.optionalKey(Schema.String),
-		tags: Schema.optionalKey(Schema.Array(Schema.String)).annotate({
+		tags: Schema.optionalKey(Schema.Array(CompanyTag)).annotate({
 			description:
 				'Tags the company must carry — every one of them, not any of them. Tags are free text set when the company was written, so ask for one you know was used rather than guessing.',
 		}),
@@ -108,7 +149,7 @@ const SearchCompanies = Tool.make('search_companies', {
 		offset: Schema.optionalKey(McpPageOffset),
 		include_filter_options: Schema.optionalKey(Schema.Boolean).annotate({
 			description:
-				'Also return which countries and trades are worth narrowing by, each with how many companies it would find under the filters already given. Ask for this instead of guessing a value: a `company_count` of 0 means that value exists but finds nothing here, and a value absent from the list finds nothing at all.',
+				'Also return which countries, trades, tags and fit verdicts are worth narrowing by, each with how many companies carry it under the other filters already given. Ask for this instead of guessing a value: a `company_count` of 0 means that value exists but finds nothing here, and a value absent from the list finds nothing at all.',
 		}),
 	}),
 	success: Schema.Struct({
@@ -170,7 +211,7 @@ const companyInputFields = {
 	}),
 	googleMapsUrl: Schema.optionalKey(CompanyGoogleMapsUrl),
 	productsFit: Schema.optionalKey(Schema.Array(Schema.String)),
-	tags: Schema.optionalKey(Schema.Array(Schema.String)),
+	tags: Schema.optionalKey(Schema.Array(CompanyTag)),
 	painPoints: Schema.optionalKey(Schema.String),
 	currentTools: Schema.optionalKey(Schema.String),
 	nextAction: Schema.optionalKey(Schema.String),
@@ -277,7 +318,7 @@ const UpdateCompany = Tool.make('update_company', {
 		linkedin: Schema.optionalKey(CompanyLinkedin),
 		googleMapsUrl: Schema.optionalKey(CompanyGoogleMapsUrl),
 		productsFit: Schema.optionalKey(Schema.Array(Schema.String)),
-		tags: Schema.optionalKey(Schema.Array(Schema.String)),
+		tags: Schema.optionalKey(Schema.Array(CompanyTag)),
 		painPoints: Schema.optionalKey(Schema.String),
 		currentTools: Schema.optionalKey(Schema.String),
 		nextAction: Schema.optionalKey(Schema.String),
@@ -513,6 +554,10 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 						country: params.country,
 						industry: params.industry,
 						priority: params.priority,
+						owner: params.owner,
+						attention: params.attention,
+						staleDays: params.stale_days,
+						sort: params.sort,
 						fitVerdict: params.fit_verdict,
 						fitCriterionPassed: params.fit_criterion_passed,
 						tags: params.tags,
@@ -544,6 +589,14 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 								slug: i.slug,
 								label: i.label,
 								company_count: i.count,
+							})),
+							tags: facets.tags.map(t => ({
+								tag: t.value,
+								company_count: t.count,
+							})),
+							fit_verdicts: facets.fitVerdict.map(v => ({
+								verdict: v.value,
+								company_count: v.count,
 							})),
 						},
 					}

--- a/apps/server/src/mcp/tools/company-filter-options.integration.test.ts
+++ b/apps/server/src/mcp/tools/company-filter-options.integration.test.ts
@@ -181,7 +181,7 @@ describe('search_companies filter options', () => {
 			// GIVEN an ordinary search
 
 			// WHEN it is run without asking for the filter values
-			const result = await search({ status: 'client', limit: 5 })
+			const result = await search({ status: ['client'], limit: 5 })
 
 			// THEN no options come back — an assistant that did not ask pays neither
 			// the extra query nor the tokens
@@ -196,7 +196,7 @@ describe('search_companies filter options', () => {
 
 			// WHEN the search asks for the filter values
 			const result = await search({
-				status: 'client',
+				status: ['client'],
 				limit: 5,
 				include_filter_options: true,
 			})
@@ -212,7 +212,7 @@ describe('search_companies filter options', () => {
 
 			// WHEN the filter values are asked for at a stage neither company is in
 			const result = await search({
-				status: 'prospect',
+				status: ['prospect'],
 				limit: 5,
 				include_filter_options: true,
 			})

--- a/apps/server/src/services/companies-attention-filter.integration.test.ts
+++ b/apps/server/src/services/companies-attention-filter.integration.test.ts
@@ -136,7 +136,12 @@ const stalePlusStatus = (status: string) =>
 				yield* sql`SET LOCAL ROLE app_user`
 				yield* sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
 				return yield* companies
-					.search({ attention: 'stale', status, limit: 500, count: 'exact' })
+					.search({
+						attention: 'stale',
+						status: [status],
+						limit: 500,
+						count: 'exact',
+					})
 					.pipe(Effect.provideService(CurrentOrg, { ...asMember, id: orgId }))
 			}),
 		)

--- a/apps/server/src/services/companies-detail.integration.test.ts
+++ b/apps/server/src/services/companies-detail.integration.test.ts
@@ -216,7 +216,7 @@ describe('filtering companies by how well they fit', () => {
 			])
 
 			// WHEN the strong fits are asked for
-			const rows = await searchWith({ fitVerdict: 'strong_fit' })
+			const rows = await searchWith({ fitVerdict: ['strong_fit'] })
 
 			// THEN only the strong one comes back
 			const ids = rows.map(r => r['id'])

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -8,7 +8,13 @@ import {
 	CurrentOrg,
 	NotFound,
 } from '@batuda/controllers'
-import { Company, Contact, Interaction } from '@batuda/domain'
+import {
+	Company,
+	type CompanySort,
+	Contact,
+	Interaction,
+	normalizeCountry,
+} from '@batuda/domain'
 
 import { textAnywhere } from '../lib/search-text'
 import {
@@ -27,6 +33,7 @@ import {
 import { type AttentionFilter, attentionCondition } from './company-attention'
 import {
 	findIndustryByName,
+	type Industry,
 	industryForWrite,
 	withIndustry,
 } from './company-industries'
@@ -34,12 +41,15 @@ import { requireOrgMembers } from './org-members'
 import { researchProvenance } from './research-provenance'
 
 export interface CompanyFilters {
-	readonly status?: string | undefined
-	readonly country?: string | undefined
+	// Several values mean any of them. An empty list means nobody asked, not a
+	// condition nothing can meet — which is what a caller sends when it read the
+	// filter off a form and the reader had cleared it.
+	readonly status?: ReadonlyArray<string> | undefined
+	readonly country?: ReadonlyArray<string> | undefined
 	readonly industry?: string | undefined
 	readonly priority?: number | undefined
 	// The run's overall judgement of whether this company is worth selling to.
-	readonly fitVerdict?: string | undefined
+	readonly fitVerdict?: ReadonlyArray<string> | undefined
 	// Narrows to companies whose fit checks marked a matching rule passed, so a
 	// salesperson can ask "who actually meets this criterion?" rather than
 	// trusting the one-word verdict alone.
@@ -52,8 +62,10 @@ export interface CompanyFilters {
 	// which is not a question anybody has asked for.
 	readonly metadataKey?: string | undefined
 	readonly metadataValue?: string | undefined
-	// Owner id to match, or the literal 'none' to match only unassigned companies.
-	readonly owner?: string | undefined
+	// Owner ids to match, and/or the literal 'none' for the companies nobody has
+	// taken. Both together is a real question — what I am working, plus what is
+	// going spare.
+	readonly owner?: ReadonlyArray<string> | undefined
 	// Narrows to what needs doing: a missed follow-up, a company gone quiet, or
 	// one with nothing written down as the next step. Same rules the dashboard
 	// counts by, so a heading there opens a list of the same size here.
@@ -64,8 +76,9 @@ export interface CompanyFilters {
 	// Which companies to look at: the live ones by default, 'only' for the ones
 	// taken out of view (how somebody finds one to put back), 'include' for both.
 	readonly deleted?: 'only' | 'include' | undefined
-	// One of the whitelisted sort keys below; anything else falls back to priority.
-	readonly sort?: string | undefined
+	// Which order to read the list in. A closed set, so an order the server does
+	// not hold is turned away at the door rather than quietly ignored here.
+	readonly sort?: CompanySort | undefined
 	readonly query?: string | undefined
 	// Bounding box on the geocoded coordinates. Each bound is applied
 	// independently, so a partial box (e.g. only a southern edge) still narrows.
@@ -90,23 +103,65 @@ export interface CompanyFilters {
 export const normalizeTaxId = (taxId: string): string =>
 	taxId.replace(/[^A-Za-z0-9]/g, '').toUpperCase()
 
+/** A filter that offers a menu of its values, each with how many it would find. */
+export type CompanyFacetKey = 'country' | 'industry' | 'tags' | 'fitVerdict'
+
+/**
+ * The filters whose values are requirements rather than alternatives.
+ *
+ * This one fact decides how a menu is counted, so it is written here instead of
+ * being remembered at each call. Naming a second country swaps the first, so
+ * every country has to be counted with the country filter lifted — otherwise the
+ * one already chosen is the only entry above zero and there is no way to change
+ * it. Naming a second tag adds to the first, so a tag is counted with the tags
+ * already chosen still in force: the number then says what is left if you add it,
+ * which is what adding it will actually do.
+ *
+ */
+const FILTERS_NEEDING_EVERY_VALUE = new Set<CompanyFacetKey>(['tags'])
+
+/**
+ * The values actually being asked for, with the blanks dropped.
+ *
+ * Blanks, and an empty list once they are gone, are what a caller sends when it
+ * read the filter off a form the reader had cleared — or off a link with a
+ * trailing comma. Left in, `IN ('')` matches nothing and the screen reports the
+ * organisation as empty; treated as nobody asking, the list is simply unfiltered,
+ * which is what was meant.
+ */
+const asked = (
+	values: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> | undefined => {
+	if (values === undefined) return undefined
+	const kept = values.filter(value => value.trim() !== '')
+	return kept.length === 0 ? undefined : kept
+}
+
 /**
  * The conditions a company search is narrowed by.
  *
  * The per-value counts are built from these same conditions, so what a count
  * promises about a value and what a search does with it cannot drift apart.
  *
- * `omit` leaves one filter out. A value is counted under every filter except
- * its own: counted under the chosen country, every other country would read
- * zero and there would be no way to swap one for another.
+ * `facetFor` says which menu is being counted, not which condition to skip —
+ * whether the filter is lifted follows from the rule above, so a caller cannot
+ * get it wrong by guessing.
  */
 const companyConditions = (
 	sql: SqlClient.SqlClient,
 	orgId: string,
 	filters: CompanyFilters,
-	omit?: 'country' | 'industry',
+	facetFor?: CompanyFacetKey,
+	// The trade the filter names, already looked up. Several condition sets are
+	// built for one request and all but one of them keep the trade filter, so
+	// without this each would ask the database for the same trade again.
+	trade?: Industry | undefined,
 ) =>
 	Effect.gen(function* () {
+		const lifted =
+			facetFor !== undefined && !FILTERS_NEEDING_EVERY_VALUE.has(facetFor)
+				? facetFor
+				: undefined
 		const conditions: Array<Statement.Fragment> = [
 			sql`organization_id = ${orgId}`,
 		]
@@ -116,22 +171,38 @@ const companyConditions = (
 		if (filters.deleted === 'only') conditions.push(sql`deleted_at IS NOT NULL`)
 		else if (filters.deleted !== 'include')
 			conditions.push(sql`deleted_at IS NULL`)
-		if (filters.status) conditions.push(sql`status = ${filters.status}`)
-		if (filters.country && omit !== 'country')
-			conditions.push(sql`country = ${filters.country}`)
-		if (filters.industry && omit !== 'industry') {
-			const trade = yield* findIndustryByName(sql, orgId, filters.industry)
+		const statuses = asked(filters.status)
+		if (statuses !== undefined)
+			conditions.push(sql`status IN ${sql.in(statuses)}`)
+		// Raised to capitals to match how they are stored, so a link written by
+		// hand with a lowercase code still finds the companies it names.
+		const countries = asked(filters.country)?.map(normalizeCountry)
+		if (countries !== undefined && lifted !== 'country')
+			conditions.push(sql`country IN ${sql.in(countries)}`)
+		if (filters.industry && lifted !== 'industry') {
+			const found =
+				trade ?? (yield* findIndustryByName(sql, orgId, filters.industry))
 			conditions.push(
-				trade === undefined ? sql`false` : sql`industry_id = ${trade.id}`,
+				found === undefined ? sql`false` : sql`industry_id = ${found.id}`,
 			)
 		}
 		if (filters.priority !== undefined)
 			conditions.push(sql`priority = ${filters.priority}`)
-		// 'none' narrows to unassigned leads; any other value matches one owner.
-		if (filters.owner === 'none') conditions.push(sql`owner_id IS NULL`)
-		else if (filters.owner) conditions.push(sql`owner_id = ${filters.owner}`)
-		if (filters.fitVerdict)
-			conditions.push(sql`fit_verdict = ${filters.fitVerdict}`)
+		// 'none' is the companies nobody has taken, and it sits beside the ids
+		// rather than replacing them: "mine or going spare" is one question, and
+		// an owner column has no value standing for nobody to match against.
+		const owners = asked(filters.owner)
+		if (owners !== undefined) {
+			const unassigned = owners.includes('none')
+			const ids = owners.filter(id => id !== 'none')
+			if (ids.length === 0) conditions.push(sql`owner_id IS NULL`)
+			else if (!unassigned) conditions.push(sql`owner_id IN ${sql.in(ids)}`)
+			else
+				conditions.push(sql`(owner_id IS NULL OR owner_id IN ${sql.in(ids)})`)
+		}
+		const verdicts = asked(filters.fitVerdict)
+		if (verdicts !== undefined && lifted !== 'fitVerdict')
+			conditions.push(sql`fit_verdict IN ${sql.in(verdicts)}`)
 		// A missing or empty fit_checks simply matches nothing, rather than
 		// tripping the element expansion on a null.
 		if (filters.fitCriterionPassed)
@@ -142,13 +213,10 @@ const companyConditions = (
 						AND normalize(fc->>'criterion') ILIKE ${textAnywhere(filters.fitCriterionPassed)}
 				)`,
 			)
-		// Blanks are dropped before the list is judged empty, and an empty list is
-		// the same as not asking rather than a condition nothing can satisfy. Both
-		// are what a caller sends when it read its tags from a form: asking for a
-		// tag no company carries would answer "there are none of those", which is
-		// true of the blank and false of what was meant.
-		const tags = filters.tags?.filter(tag => tag.trim() !== '')
-		if (tags !== undefined && tags.length > 0)
+		// Every tag named has to be on the company, which is the one filter here
+		// whose values narrow rather than widen.
+		const tags = asked(filters.tags)
+		if (tags !== undefined && lifted !== 'tags')
 			conditions.push(sql`tags @> ${tags}::text[]`)
 		if (
 			filters.metadataKey !== undefined &&
@@ -279,20 +347,39 @@ export class CompanyService extends Context.Service<CompanyService>()(
 						const onOffer = yield* companyConditions(sql, currentOrg.id, {
 							deleted: filters.deleted,
 						})
-						const countryMatches = yield* companyConditions(
-							sql,
-							currentOrg.id,
-							filters,
-							'country',
-						)
-						const industryMatches = yield* companyConditions(
-							sql,
-							currentOrg.id,
-							filters,
-							'industry',
-						)
+						const trade = filters.industry
+							? yield* findIndustryByName(sql, currentOrg.id, filters.industry)
+							: undefined
+						const [countryMatches, industryMatches, tagMatches, fitMatches] =
+							yield* Effect.all(
+								[
+									companyConditions(
+										sql,
+										currentOrg.id,
+										filters,
+										'country',
+										trade,
+									),
+									companyConditions(
+										sql,
+										currentOrg.id,
+										filters,
+										'industry',
+										trade,
+									),
+									companyConditions(sql, currentOrg.id, filters, 'tags', trade),
+									companyConditions(
+										sql,
+										currentOrg.id,
+										filters,
+										'fitVerdict',
+										trade,
+									),
+								],
+								{ concurrency: 'unbounded' },
+							)
 
-						const country = yield* sql<{
+						const countryQuery = sql<{
 							readonly value: string
 							readonly count: number
 						}>`
@@ -313,7 +400,7 @@ export class CompanyService extends Context.Service<CompanyService>()(
 						// The join is also what puts a trade on offer: somebody has to be
 						// on it, since a trade nothing can match is only a way to empty the
 						// list.
-						const industry = yield* sql<{
+						const industryQuery = sql<{
 							readonly slug: string
 							readonly label: string
 							readonly count: number
@@ -331,7 +418,51 @@ export class CompanyService extends Context.Service<CompanyService>()(
 							ORDER BY i.label
 						`
 
-						return { country, industry }
+						// Counted per distinct company, not per row: expanding the array
+						// gives one row per tag a company carries, and nothing stops the
+						// same tag being written onto a company twice — which would then
+						// count it twice. The expansion is named `tag`, deliberately not
+						// `tags`: an alias of that name shadows the column, and the
+						// `tags @> …` condition above would quietly bind to it instead.
+						const tagsQuery = sql<{
+							readonly value: string
+							readonly count: number
+						}>`
+							SELECT tag AS value,
+								count(DISTINCT companies.id) FILTER (
+									WHERE ${sql.and(tagMatches)}
+								)::int AS count
+							FROM companies, unnest(tags) AS tag
+							WHERE ${sql.and(onOffer)}
+								AND tag <> ''
+							GROUP BY tag
+							ORDER BY count DESC, value ASC
+						`
+						// Whatever a run actually wrote, not the four words expected of it.
+						// The column is free text on purpose, so a fifth verdict has to be
+						// offered rather than hide every company carrying it.
+						const fitVerdictQuery = sql<{
+							readonly value: string
+							readonly count: number
+						}>`
+							SELECT fit_verdict AS value,
+								count(*) FILTER (WHERE ${sql.and(fitMatches)})::int AS count
+							FROM companies
+							WHERE ${sql.and(onOffer)}
+								AND fit_verdict IS NOT NULL
+								AND fit_verdict <> ''
+							GROUP BY fit_verdict
+							ORDER BY count DESC, value ASC
+						`
+
+						// Asked side by side: four counts of the same companies, none of
+						// which needs another's answer, and a filter bar re-asks for all of
+						// them every time somebody ticks anything.
+						const [country, industry, tags, fitVerdict] = yield* Effect.all(
+							[countryQuery, industryQuery, tagsQuery, fitVerdictQuery],
+							{ concurrency: 'unbounded' },
+						)
+						return { country, industry, tags, fitVerdict }
 					}),
 
 				findBySlug: (slug: string) =>

--- a/apps/server/src/services/company-facets.integration.test.ts
+++ b/apps/server/src/services/company-facets.integration.test.ts
@@ -59,12 +59,16 @@ const insertCompany = async (options: {
 	readonly tradeId: string
 	readonly deleted?: boolean
 	readonly organizationId?: string
+	readonly tags?: ReadonlyArray<string>
+	readonly fitVerdict?: string | null
 }): Promise<void> => {
 	const slug = `${TAG}-${options.name}`
 	await pool.query(
 		`INSERT INTO companies (
-			organization_id, slug, name, status, country, industry_id, deleted_at
-		 ) VALUES ($1, $2, $2, $3, $4, $5, CASE WHEN $6 THEN now() ELSE NULL END)`,
+			organization_id, slug, name, status, country, industry_id, deleted_at,
+			tags, fit_verdict
+		 ) VALUES ($1, $2, $2, $3, $4, $5, CASE WHEN $6 THEN now() ELSE NULL END,
+			$7, $8)`,
 		[
 			options.organizationId ?? orgId,
 			slug,
@@ -72,6 +76,8 @@ const insertCompany = async (options: {
 			options.country,
 			options.tradeId,
 			options.deleted ?? false,
+			options.tags ?? [],
+			options.fitVerdict ?? null,
 		],
 	)
 }
@@ -142,18 +148,28 @@ beforeAll(async () => {
 		country: 'PT',
 		tradeId: binTrade,
 		deleted: true,
+		// Only the deleted company carries this tag and this verdict, so both must
+		// be absent from the menus that describe the companies in use.
+		tags: [`${TAG}-gone`],
+		fitVerdict: `${TAG}-buried`,
 	})
 	await insertCompany({
 		name: 'client',
 		status: 'client',
 		country: 'IT',
 		tradeId: quietTrade,
+		tags: [`${TAG}-beta`],
+		fitVerdict: `${TAG}-strong`,
 	})
 	await insertCompany({
 		name: 'prospect',
 		status: 'prospect',
 		country: 'FR',
 		tradeId: busyTrade,
+		// The only one on both tags, so asking for one has something to keep and
+		// something to drop.
+		tags: [`${TAG}-alpha`, `${TAG}-beta`],
+		fitVerdict: `${TAG}-strong`,
 	})
 	// Live, and in a country nothing in this organisation is in — so only the
 	// organisation boundary can keep it out of these counts.
@@ -171,6 +187,8 @@ beforeAll(async () => {
 		status: 'prospect',
 		country: 'FR',
 		tradeId: busyTrade,
+		tags: [`${TAG}-alpha`],
+		fitVerdict: `${TAG}-possible`,
 	})
 	// One with no country and one with an empty string: both are absences that
 	// must never be offered as something to narrow by.
@@ -179,12 +197,20 @@ beforeAll(async () => {
 		status: 'prospect',
 		country: null,
 		tradeId: busyTrade,
+		// The same tag written twice, which nothing prevents. Expanding the array
+		// gives this company two rows for it, so a naive count would say two
+		// companies carry it.
+		tags: [`${TAG}-dupe`, `${TAG}-dupe`],
 	})
 	await insertCompany({
 		name: 'blank',
 		status: 'prospect',
 		country: '',
 		tradeId: busyTrade,
+		// A blank tag and a blank verdict are absences too, and must not be
+		// offered as something to narrow by.
+		tags: [''],
+		fitVerdict: '',
 	})
 }, 60_000)
 
@@ -260,7 +286,7 @@ describe('company filter options', () => {
 			// GIVEN one prospect in France and one client in Italy
 
 			// WHEN the options are read for prospects
-			const facets = await facetsFor({ status: 'prospect' })
+			const facets = await facetsFor({ status: ['prospect'] })
 
 			// THEN both countries are still returned, and only France has anything
 			// behind it — a zero says the value exists but finds nothing here, which
@@ -296,7 +322,7 @@ describe('company filter options', () => {
 			// GIVEN France is the chosen country
 
 			// WHEN the options are read
-			const facets = await facetsFor({ country: 'FR' })
+			const facets = await facetsFor({ country: ['FR'] })
 
 			// THEN the countries are counted as though nothing were chosen — counting
 			// them under their own filter would leave every other one reading zero
@@ -330,6 +356,104 @@ describe('company filter options', () => {
 			expect(mine(facets.country, c => c.value)).toEqual([
 				['FR', 2],
 				['IT', 0],
+			])
+		})
+	})
+
+	describe('when tags are offered', () => {
+		it('should count each tag once per company, however often it was written', async () => {
+			// GIVEN one company carries the same tag twice, and none of the tags on
+			// the deleted company belong to a company in use
+
+			// WHEN the tags are read with nothing filtered
+			const facets = await facetsFor({})
+
+			// THEN each tag names the companies carrying it, the doubly-written one
+			// counting for the single company it is on, and the deleted company's own
+			// tag is not offered at all
+			expect(mine(facets.tags, t => t.value)).toEqual([
+				[`${TAG}-alpha`, 2],
+				[`${TAG}-beta`, 2],
+				[`${TAG}-dupe`, 1],
+			])
+		})
+
+		it('should not offer a blank tag as something to narrow by', async () => {
+			// GIVEN a company was written with an empty string among its tags
+
+			// WHEN the tags are read
+			const facets = await facetsFor({})
+
+			// THEN nothing empty is on offer — it is an absence, not a value
+			expect(facets.tags.map(t => t.value)).not.toContain('')
+		})
+	})
+
+	describe('when a tag is already chosen', () => {
+		it('should count the others as what adding them would leave', async () => {
+			// GIVEN alpha is chosen, and only one of its two companies also has beta
+
+			// WHEN the tags are read
+			const facets = await facetsFor({ tags: [`${TAG}-alpha`] })
+
+			// THEN each tag says what would be left if it were added to alpha, which
+			// is the opposite of how a country is counted: naming a second country
+			// swaps the first, naming a second tag narrows what the first found
+			expect(mine(facets.tags, t => t.value)).toEqual([
+				[`${TAG}-alpha`, 2],
+				[`${TAG}-beta`, 1],
+				[`${TAG}-dupe`, 0],
+			])
+		})
+
+		it('should narrow the other menus by it, since they are not its own', async () => {
+			// GIVEN alpha is chosen, and both its companies are French
+
+			// WHEN the countries are read
+			const facets = await facetsFor({ tags: [`${TAG}-alpha`] })
+
+			// THEN Italy finds nothing under it
+			expect(mine(facets.country, c => c.value)).toEqual([
+				['FR', 2],
+				['IT', 0],
+			])
+		})
+	})
+
+	describe('when fit verdicts are offered', () => {
+		it('should count whatever a run wrote, not only the words expected of it', async () => {
+			// GIVEN the verdicts on file are none of strong_fit / possible_fit /
+			// weak_fit / no_fit — the column is free text, so a run may write a word
+			// nobody listed
+
+			// WHEN the verdicts are read
+			const facets = await facetsFor({})
+
+			// THEN each one is offered with its count, and neither the blank nor the
+			// deleted company's verdict appears
+			expect(mine(facets.fitVerdict, v => v.value)).toEqual([
+				[`${TAG}-strong`, 2],
+				[`${TAG}-possible`, 1],
+			])
+		})
+
+		it('should keep offering the others once one is chosen', async () => {
+			// GIVEN one verdict is chosen
+
+			// WHEN the verdicts are read
+			const facets = await facetsFor({ fitVerdict: [`${TAG}-strong`] })
+
+			// THEN they are counted as though nothing were chosen, so a different one
+			// can be picked — the same rule the countries follow
+			expect(mine(facets.fitVerdict, v => v.value)).toEqual([
+				[`${TAG}-strong`, 2],
+				[`${TAG}-possible`, 1],
+			])
+
+			// AND the countries respect it, since that filter is not their own
+			expect(mine(facets.country, c => c.value)).toEqual([
+				['FR', 1],
+				['IT', 1],
 			])
 		})
 	})

--- a/apps/server/src/services/company-multi-value-filters.integration.test.ts
+++ b/apps/server/src/services/company-multi-value-filters.integration.test.ts
@@ -1,0 +1,275 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { enterOrgScope } from '../middleware/org'
+import { type CompanyFilters, CompanyService } from './companies'
+
+// Narrowing a company list by several values at once.
+//
+// Four filters take a list and match any of the values in it, while different
+// filters still narrow one another — "everything mid-conversation in Spain" is
+// two stages and one country, not a choice between them. Tags are the exception
+// and have their own suite; what is pinned here is the four that widen, the
+// owner's "nobody has taken this" sentinel, and the rule that an empty list is
+// nobody asking rather than a condition nothing can meet.
+//
+// Country is here too, because it is the one filter whose stored form and asked
+// form could differ: the shape says two letters and never said which case.
+//
+// Prereq: `pnpm cli services up` so Postgres is reachable.
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+let org: { readonly id: string; readonly name: string; readonly slug: string }
+const suffix = randomUUID().slice(0, 8)
+
+const ANA = `owner-ana-${suffix}`
+const BRUNO = `owner-bruno-${suffix}`
+
+const runtime = ManagedRuntime.make(
+	CompanyService.layer.pipe(Layer.provideMerge(PgLive)),
+)
+
+// Typed as the service's own filters, so a change to what a filter accepts
+// fails here rather than passing through as an untyped bag.
+const search = (filters: CompanyFilters) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const service = yield* CompanyService
+			return yield* enterOrgScope(sql, { org })(service.search(filters))
+		}).pipe(Effect.orDie),
+	)
+
+const seedCompany = (options: {
+	readonly name: string
+	readonly status: string
+	readonly country: string
+	readonly ownerId?: string | null
+	readonly fitVerdict?: string | null
+}) =>
+	pool.query(
+		`INSERT INTO companies (
+			organization_id, slug, name, status, country, owner_id, fit_verdict
+		 ) VALUES ($1, $2, $2, $3, $4, $5, $6)`,
+		[
+			org.id,
+			`${options.name}-${suffix}`,
+			options.status,
+			options.country,
+			options.ownerId ?? null,
+			options.fitVerdict ?? null,
+		],
+	)
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	const orgs = await pool.query<{ id: string; name: string; slug: string }>(
+		`SELECT id, name, slug FROM organization WHERE slug = 'taller' LIMIT 1`,
+	)
+	const row = orgs.rows[0]
+	if (!row) throw new Error("taller org missing — run 'pnpm cli seed' first")
+	org = row
+
+	// One company per stage the tests ask about, plus one at a stage they never
+	// ask about, so a filter that widened too far has something to catch it on.
+	await seedCompany({
+		name: 'contacted',
+		status: 'contacted',
+		country: 'ES',
+		ownerId: ANA,
+		fitVerdict: 'strong_fit',
+	})
+	await seedCompany({
+		name: 'responded',
+		status: 'responded',
+		country: 'FR',
+		ownerId: BRUNO,
+		fitVerdict: 'possible_fit',
+	})
+	await seedCompany({
+		name: 'client',
+		status: 'client',
+		country: 'ES',
+		ownerId: null,
+		fitVerdict: 'no_fit',
+	})
+	await seedCompany({
+		name: 'unclaimed',
+		status: 'contacted',
+		country: 'PT',
+		ownerId: null,
+		fitVerdict: null,
+	})
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query(
+		`DELETE FROM companies WHERE organization_id = $1 AND slug LIKE $2`,
+		[org.id, `%-${suffix}`],
+	)
+	await pool.end()
+	await runtime.dispose()
+})
+
+const mine = (result: { items: ReadonlyArray<{ slug: string }> }) =>
+	result.items
+		.map(c => c.slug)
+		.filter(s => s.endsWith(suffix))
+		.sort()
+
+describe('narrowing a company list by several values', () => {
+	describe('when two stages are named', () => {
+		it('should return companies at either, and none at a third', async () => {
+			// GIVEN one company at each of three stages
+			// WHEN the search names two of them
+			const found = await search({
+				status: ['contacted', 'responded'],
+				limit: 200,
+			})
+
+			// THEN both are returned — naming a second stage widens, unlike naming a
+			// second tag, because a company has one stage and cannot be at both
+			// AND the third stage stays out
+			expect(mine(found)).toEqual([
+				`contacted-${suffix}`,
+				`responded-${suffix}`,
+				`unclaimed-${suffix}`,
+			])
+		})
+	})
+
+	describe('when a stage and a country are named together', () => {
+		it('should narrow by both rather than widen to either', async () => {
+			// GIVEN two companies at the contacted stage, in different countries
+			// WHEN the search names that stage and one of the countries
+			const found = await search({
+				status: ['contacted'],
+				country: ['ES'],
+				limit: 200,
+			})
+
+			// THEN only the one meeting both comes back. Values inside one filter are
+			// alternatives; separate filters are requirements
+			expect(mine(found)).toEqual([`contacted-${suffix}`])
+		})
+	})
+
+	describe('when the list for a filter is empty', () => {
+		it('should filter nothing, the same as not asking', async () => {
+			// GIVEN a caller whose form had no stage chosen and sent the empty list
+			// WHEN the search is run
+			const found = await search({ status: [], limit: 200 })
+
+			// THEN every company is returned. An empty list has to read as "nobody
+			// asked": treated as a condition, it would match nothing and the screen
+			// would say the organisation has no companies
+			expect(mine(found)).toHaveLength(4)
+		})
+	})
+
+	describe('when a filter holds nothing but blanks', () => {
+		it('should filter nothing, rather than match nothing', async () => {
+			// GIVEN a link with a trailing comma, or a form field the reader emptied
+			// WHEN the search is run
+			const found = await search({ status: [''], limit: 200 })
+
+			// THEN every company is returned. A blank left in would become `IN ('')`,
+			// which matches nothing and reports the organisation as empty — an answer
+			// that looks like data rather than like a filter nobody set
+			expect(mine(found)).toHaveLength(4)
+		})
+
+		it('should still apply the values beside a blank', async () => {
+			// GIVEN one real stage and one blank
+			const found = await search({ status: ['client', ''], limit: 200 })
+
+			// THEN the blank is dropped and the stage still narrows
+			expect(mine(found)).toEqual([`client-${suffix}`])
+		})
+	})
+
+	describe('when a country is written in lower case', () => {
+		it('should find the companies stored under the capitals', async () => {
+			// GIVEN two companies stored with country ES
+			// WHEN a hand-written link asks for es
+			const found = await search({ country: ['es'], limit: 200 })
+
+			// THEN both are found. The two-letter shape never said which case, so the
+			// filter raises what it is given to match how the column is written
+			expect(mine(found)).toEqual([`client-${suffix}`, `contacted-${suffix}`])
+		})
+	})
+
+	describe('when the owner asked for is nobody', () => {
+		it('should return only the companies no one has taken', async () => {
+			// GIVEN two companies with an owner and two without
+			// WHEN the search asks for none
+			const found = await search({ owner: ['none'], limit: 200 })
+
+			// THEN only the unowned ones come back
+			expect(mine(found)).toEqual([`client-${suffix}`, `unclaimed-${suffix}`])
+		})
+	})
+
+	describe('when an owner and nobody are asked for together', () => {
+		it('should return that owner’s companies and the unclaimed ones', async () => {
+			// GIVEN Ana owns one company, Bruno owns another, and two are unowned
+			// WHEN the search asks for Ana or nobody
+			const found = await search({ owner: ['none', ANA], limit: 200 })
+
+			// THEN Ana's company and both unowned ones come back, and Bruno's does
+			// not. "What I am working plus what is going spare" is one question, and
+			// an owner column holds no value standing for nobody to be matched against
+			expect(mine(found)).toEqual([
+				`client-${suffix}`,
+				`contacted-${suffix}`,
+				`unclaimed-${suffix}`,
+			])
+		})
+	})
+
+	describe('when two owners are named', () => {
+		it('should return both their companies and leave the unclaimed out', async () => {
+			// GIVEN Ana and Bruno own one company each
+			// WHEN the search names both
+			const found = await search({ owner: [ANA, BRUNO], limit: 200 })
+
+			// THEN only their companies come back — asking for owners is not asking
+			// for the ones nobody has
+			expect(mine(found)).toEqual([
+				`contacted-${suffix}`,
+				`responded-${suffix}`,
+			])
+		})
+	})
+
+	describe('when two fit verdicts are named', () => {
+		it('should return companies carrying either', async () => {
+			// GIVEN three companies with a verdict and one without
+			// WHEN the search names two of the verdicts
+			const found = await search({
+				fitVerdict: ['strong_fit', 'possible_fit'],
+				limit: 200,
+			})
+
+			// THEN both are returned, and the third verdict and the blank stay out
+			expect(mine(found)).toEqual([
+				`contacted-${suffix}`,
+				`responded-${suffix}`,
+			])
+		})
+	})
+})

--- a/apps/server/src/services/company-tag-metadata-search.integration.test.ts
+++ b/apps/server/src/services/company-tag-metadata-search.integration.test.ts
@@ -12,7 +12,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { PgLive } from '../db/client'
 import { enterOrgScope } from '../middleware/org'
-import { CompanyService } from './companies'
+import { type CompanyFilters, CompanyService } from './companies'
 
 // Finding a company by a tag it carries, or by something written under its
 // `metadata`.
@@ -34,7 +34,7 @@ const runtime = ManagedRuntime.make(
 	CompanyService.layer.pipe(Layer.provideMerge(PgLive)),
 )
 
-const search = (filters: Record<string, unknown>) =>
+const search = (filters: CompanyFilters) =>
 	runtime.runPromise(
 		Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
@@ -43,7 +43,7 @@ const search = (filters: Record<string, unknown>) =>
 		}).pipe(Effect.orDie),
 	)
 
-const facets = (filters: Record<string, unknown>) =>
+const facets = (filters: CompanyFilters) =>
 	runtime.runPromise(
 		Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -1,4 +1,4 @@
-import { Cause, DateTime, Effect } from 'effect'
+import { Cause, DateTime, Effect, Schema } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { CurrentOrg } from '@batuda/controllers'
@@ -7,6 +7,8 @@ import {
 	COMPANY_PRIORITIES,
 	COMPANY_SIZE_RANGES,
 	COMPANY_STATUSES,
+	CompanyCountry,
+	CompanyTag,
 	channelAddressIsValid,
 	isVerificationVerdict,
 	MAPS_ADDRESS_PATTERN,
@@ -271,6 +273,28 @@ const COMPANY_FIELD_SHAPES: ReadonlyArray<{
 		ok: value => MAPS_ADDRESS_PATTERN.test(value),
 		wanted: 'a Google Maps link',
 	},
+	{
+		field: 'country',
+		ok: value => Schema.is(CompanyCountry)(value.toUpperCase()),
+		wanted: 'a two-letter country code',
+	},
+]
+
+// Fields holding a list, whose every entry has to look like something. A model
+// writing a label list will happily put a comma inside one entry, and several
+// tags travel to and from a screen as a single comma-separated value — so a tag
+// holding one is split on the way back into tags nobody carries, and the company
+// stops being findable under the tag it is actually wearing.
+const COMPANY_LIST_FIELD_SHAPES: ReadonlyArray<{
+	readonly field: string
+	readonly ok: (value: string) => boolean
+	readonly wanted: string
+}> = [
+	{
+		field: 'tags',
+		ok: value => Schema.is(CompanyTag)(value),
+		wanted: 'a tag with no comma in it and no blank ends',
+	},
 ]
 
 const COMPANY_FIELD_VOCABULARIES: ReadonlyArray<FieldVocabulary> = [
@@ -323,6 +347,17 @@ export const checkFieldValues = (
 			if (raw === null || raw === undefined) continue
 			if (typeof raw === 'string' && ok(raw)) continue
 			return `${field} must be ${wanted} — got ${JSON.stringify(raw)}`
+		}
+	if (table === 'companies')
+		for (const { field, ok, wanted } of COMPANY_LIST_FIELD_SHAPES) {
+			if (!(field in fields)) continue
+			const raw = fields[field]
+			if (raw === null || raw === undefined) continue
+			if (!Array.isArray(raw))
+				return `${field} must be a list — got ${JSON.stringify(raw)}`
+			const bad = raw.find(entry => typeof entry !== 'string' || !ok(entry))
+			if (bad !== undefined)
+				return `every ${field} entry must be ${wanted} — got ${JSON.stringify(bad)}`
 		}
 	return null
 }

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -830,10 +830,16 @@ Every list on this page is decided by the server, not assembled in the browser. 
 
 ### Company list (`/companies`)
 
-- Filter bar: status (pills), then country, industry, priority, owner and sort (dropdowns)
+- Filter bar: stage (pills, several at once), then country, industry, priority, owner, what needs doing, tags, fit verdict and sort (dropdowns)
 - Search input (name)
 - Company cards: name, location, status chip, industry, last contacted date, priority dot
 - Sorted by priority ASC, then last_contacted_at DESC
+
+Several values inside one filter match any of them; different filters narrow each other. Tags read the other way round — every tag named has to be on the company — so the menu counts what would be left if that tag were added, and a tag already chosen shows no count because it would always report the whole list. The menus themselves are counted by the server against the filters already set, so a value that finds nothing is not offered unless it is the one in force, which has to stay on offer so it can be taken off again.
+
+Every filter the list can be narrowed by is reachable from this bar except two, deliberately: the free-form `metadata` key/value pair, whose control would be a query builder, and the map bounding box, which is a viewport's language. Both remain available to agents and to a hand-written link.
+
+The bar announces the resulting count through a live region, because every control here changes the list without moving the keyboard — including the two that quietly lift another filter (opening the bin puts down a stage or attention filter, since a deleted company is on none of those lists and the two together would always find nothing).
 
 ### Company detail (`/companies/$slug`)
 

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -30,12 +30,14 @@ export {
 	PaginatedList,
 	pageQuery,
 } from './pagination'
+export { CommaList } from './query-list'
 export { AuthGroup } from './routes/auth'
 export { CalcomWebhookGroup } from './routes/calcom-webhook'
 export { CalendarGroup, Slot } from './routes/calendar'
 export {
 	CompaniesGroup,
 	CompanyDetail,
+	CompanyFacets,
 	CompanyResearchRun,
 } from './routes/companies'
 export { CompanyIndustriesGroup } from './routes/company-industries'

--- a/packages/controllers/src/query-list.ts
+++ b/packages/controllers/src/query-list.ts
@@ -1,0 +1,28 @@
+import { Schema, SchemaGetter } from 'effect'
+
+/**
+ * Several values for one filter, written as a single comma-separated value on
+ * the link.
+ *
+ * A query string has no way of its own to carry a list, and a repeated key is
+ * read differently by each client, so the list travels as text and is split
+ * here. Blanks are dropped, so a trailing comma or a value somebody cleared
+ * costs nothing.
+ *
+ * One codec, used by the routes and by the browser that builds their links: two
+ * copies of a splitting rule are two rules, and they disagree the first time one
+ * of them trims differently.
+ */
+export const CommaList = Schema.String.pipe(
+	Schema.decodeTo(Schema.Array(Schema.String), {
+		decode: SchemaGetter.transform((raw: string) =>
+			raw
+				.split(',')
+				.map(value => value.trim())
+				.filter(value => value.length > 0),
+		),
+		encode: SchemaGetter.transform((values: ReadonlyArray<string>) =>
+			values.join(','),
+		),
+	}),
+)

--- a/packages/controllers/src/routes/companies.ts
+++ b/packages/controllers/src/routes/companies.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaGetter } from 'effect'
+import { Schema } from 'effect'
 import {
 	HttpApiEndpoint,
 	HttpApiGroup,
@@ -20,7 +20,9 @@ import {
 	CompanySizeRange,
 	CompanySlug,
 	CompanySocialProfile,
+	CompanySort,
 	CompanyStatus,
+	CompanyTag,
 	CompanyWebsite,
 	Contact,
 	Interaction,
@@ -30,6 +32,7 @@ import { BadRequest, NotFound } from '../errors'
 import { OrgMiddleware } from '../middleware/org'
 import { SessionMiddleware } from '../middleware/session'
 import { PaginatedList, pageQuery } from '../pagination'
+import { CommaList } from '../query-list'
 import { StaleDays } from './pipeline'
 
 // One research run whose findings were applied to a company, with the pages its
@@ -104,7 +107,7 @@ export const CreateCompanyInput = Schema.Struct({
 	socialProfiles: Schema.optional(Schema.Array(CompanySocialProfile)),
 	googleMapsUrl: Schema.optional(CompanyGoogleMapsUrl),
 	productsFit: Schema.optional(Schema.Array(Schema.String)),
-	tags: Schema.optional(Schema.Array(Schema.String)),
+	tags: Schema.optional(Schema.Array(CompanyTag)),
 	painPoints: Schema.optional(Schema.String),
 	currentTools: Schema.optional(Schema.String),
 	nextAction: Schema.optional(Schema.String),
@@ -149,7 +152,7 @@ export const UpdateCompanyInput = Schema.Struct({
 	socialProfiles: Schema.optional(Schema.Array(CompanySocialProfile)),
 	googleMapsUrl: Schema.optional(Schema.NullOr(CompanyGoogleMapsUrl)),
 	productsFit: Schema.optional(Schema.NullOr(Schema.Array(Schema.String))),
-	tags: Schema.optional(Schema.NullOr(Schema.Array(Schema.String))),
+	tags: Schema.optional(Schema.NullOr(Schema.Array(CompanyTag))),
 	painPoints: Schema.optional(Schema.NullOr(Schema.String)),
 	currentTools: Schema.optional(Schema.NullOr(Schema.String)),
 	nextAction: Schema.optional(Schema.NullOr(Schema.String)),
@@ -167,32 +170,19 @@ export const UpdateCompanyInput = Schema.Struct({
  * The per-value counts are asked for in exactly these words too, so the values
  * a caller is offered and the list it gets back answer the same question.
  */
-/**
- * Tags to narrow by, written as one comma-separated value on the link.
- *
- * A query string has no way of its own to carry a list, and a repeated key is
- * read differently by each client, so the list travels as text and is split here.
- */
-const TagList = Schema.String.pipe(
-	Schema.decodeTo(Schema.Array(Schema.String), {
-		decode: SchemaGetter.transform((raw: string) =>
-			raw
-				.split(',')
-				.map(tag => tag.trim())
-				.filter(tag => tag.length > 0),
-		),
-		encode: SchemaGetter.transform((tags: ReadonlyArray<string>) =>
-			tags.join(','),
-		),
-	}),
-)
-
 const companyFilterQuery = {
-	status: Schema.optional(Schema.String),
-	country: Schema.optional(Schema.String),
+	// Four of these take several values, comma-separated, and match any of them —
+	// "everything mid-conversation", "mine or nobody's". Different filters still
+	// narrow one another, so a country and two stages means those stages in that
+	// country. `tags` is the one exception and reads the other way round; its own
+	// note below says why.
+	status: Schema.optional(CommaList),
+	country: Schema.optional(CommaList),
 	industry: Schema.optional(Schema.String),
 	priority: Schema.optional(Schema.NumberFromString),
-	owner: Schema.optional(Schema.String),
+	// A user id, or the word `none` for the companies nobody has taken. Both at
+	// once is a real question — what I am working plus what is going spare.
+	owner: Schema.optional(CommaList),
 	// Narrows to what needs doing, in the same words the dashboard uses:
 	// `overdue` missed its follow-up date, `stale` is mid-chase and has
 	// gone quiet, `no-next-action` has nothing written down at all. The
@@ -202,11 +192,12 @@ const companyFilterQuery = {
 	// How long counts as quiet, for `attention=stale`. Rides along on the
 	// link so the list matches whatever the dashboard was showing.
 	staleDays: Schema.optional(StaleDays),
-	fitVerdict: Schema.optional(Schema.String),
+	fitVerdict: Schema.optional(CommaList),
 	fitCriterionPassed: Schema.optional(Schema.String),
 	// Every tag has to be on the company, not just one of them: naming a second
-	// tag is how somebody narrows a list, and matching either would widen it.
-	tags: Schema.optional(TagList),
+	// tag is how somebody narrows a list, and matching either would widen it. That
+	// is the opposite of the four above, and it is what a tag means.
+	tags: Schema.optional(CommaList),
 	// One thing written under `metadata`, named and matched as a pair. The
 	// research engine files its own judgements there and callers file their own
 	// notes, none of which could be searched for before.
@@ -232,6 +223,15 @@ const companyFilterQuery = {
  * a choice already made rather than stranding it. Countries come back as the
  * stored code and trades as the name the organisation wrote; putting either
  * into a reader's own language is the caller's job.
+ *
+ * Each count is how many companies carry that value under the OTHER filters in
+ * force — so for a filter whose values are alternatives it is what the value
+ * would bring in, not the size of the list you would end up with, since a second
+ * alternative widens. Tags are the one exception and read both ways at once.
+ *
+ * Fit verdicts come back as whatever a research run wrote. The four expected
+ * words are not enforced anywhere, so counting them is the only way to offer a
+ * fifth rather than hide the companies carrying it.
  */
 export const CompanyFacets = Schema.Struct({
 	country: Schema.Array(
@@ -244,6 +244,12 @@ export const CompanyFacets = Schema.Struct({
 			count: Schema.Number,
 		}),
 	),
+	tags: Schema.Array(
+		Schema.Struct({ value: Schema.String, count: Schema.Number }),
+	),
+	fitVerdict: Schema.Array(
+		Schema.Struct({ value: Schema.String, count: Schema.Number }),
+	),
 })
 
 export const CompaniesGroup = HttpApiGroup.make('companies')
@@ -251,7 +257,10 @@ export const CompaniesGroup = HttpApiGroup.make('companies')
 		HttpApiEndpoint.get('list', '/companies', {
 			query: {
 				...companyFilterQuery,
-				sort: Schema.optional(Schema.String),
+				// Refused rather than ignored when it is not one of these: the server
+				// holds one fixed order per word, so anything else would quietly be
+				// served in priority order with nothing saying so.
+				sort: Schema.optional(CompanySort),
 				...pageQuery,
 			},
 			success: PaginatedList(Company.json),

--- a/packages/domain/src/schema/companies.ts
+++ b/packages/domain/src/schema/companies.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Schema, SchemaGetter } from 'effect'
 import { Model } from 'effect/unstable/schema'
 
 import { DbNumberOrNull } from './_common'
@@ -76,6 +76,19 @@ export const ATTENTION_FILTERS = ['overdue', 'stale', 'no-next-action'] as const
 export const AttentionFilter = Schema.Literals(ATTENTION_FILTERS)
 export type AttentionFilter = typeof AttentionFilter.Type
 
+// The orders a company list can be read in. A closed set, because each word
+// stands for one fixed ordering held elsewhere: a word that is not on the list
+// would be taken and then ignored, and the caller would be handed priority order
+// believing it had asked for something else.
+export const COMPANY_SORTS = [
+	'priority',
+	'name',
+	'recent_contact',
+	'recent_update',
+] as const
+export const CompanySort = Schema.Literals(COMPANY_SORTS)
+export type CompanySort = typeof CompanySort.Type
+
 // The shape each written-in value has to have. They live beside the vocabularies
 // above so every way into a company row checks the same thing, and something that
 // could never be a real address or phone number is turned away where it is typed
@@ -87,9 +100,48 @@ export type AttentionFilter = typeof AttentionFilter.Type
 export const CompanySlug = Schema.String.pipe(
 	Schema.check(Schema.isPattern(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)),
 )
+
+// A label somebody groups companies by. Anything except a comma, because a
+// query string has no list of its own and several tags travel as one
+// comma-separated value — so a tag holding a comma would be split back into two
+// tags nobody carries, and the companies under it would quietly stop being
+// findable. Refused where it is typed rather than mangled where it is read.
+export const CompanyTag = Schema.String.pipe(
+	Schema.check(
+		Schema.isMinLength(1),
+		Schema.isPattern(/^[^,]+$/),
+		// No leading or trailing blanks, and not blank all through. Several tags
+		// travel as one comma-separated value and each is trimmed on the way back,
+		// so a padded tag is offered in the menu under one spelling and asked for
+		// under another, and a blank one asks for nothing at all.
+		Schema.isPattern(/^\S(.*\S)?$/s),
+	),
+)
+// Raised to capitals as it comes in, because narrowing by a country and counting
+// how many carry it both compare the stored text exactly: a company written `es`
+// would be missed by anyone asking for `ES`, and would be offered as a second
+// Spain with a count of its own. Only what a caller sends passes through here —
+// a row already stored is read as written, by the plain string on the row below.
 export const CompanyCountry = Schema.String.pipe(
 	Schema.check(Schema.isPattern(/^[A-Za-z]{2}$/)),
+	// The same shape on the far side of the raising, not only before it. A check
+	// that sits only on the way in leaves the finished type a plain string, and
+	// anything asking "is this a country code?" of a finished value — a guard on
+	// a paid lookup, most of all — quietly answers yes to every word there is.
+	Schema.decodeTo(
+		Schema.String.pipe(Schema.check(Schema.isPattern(/^[A-Z]{2}$/))),
+		{
+			decode: SchemaGetter.transform((code: string) => code.toUpperCase()),
+			encode: SchemaGetter.transform((code: string) => code),
+		},
+	),
 )
+
+/**
+ * The same raising, for a country arriving anywhere a schema does not decode it —
+ * a filter value, most of all, which has to compare against what was stored.
+ */
+export const normalizeCountry = (code: string): string => code.toUpperCase()
 // The four ways of reaching a company are the same shapes a person's channels
 // use, read from one place — a company's email and a contact's email are the same
 // question, and answering it twice is how the two doors start disagreeing.

--- a/packages/domain/src/schema/company-filter-values.test.ts
+++ b/packages/domain/src/schema/company-filter-values.test.ts
@@ -1,0 +1,110 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { CompanyCountry, CompanySort, CompanyTag } from './companies'
+
+// The shapes a company filter compares against, and the write rules that keep
+// what is stored comparable with what is asked for.
+
+const decode = <A, I>(schema: Schema.Codec<A, I>, input: I) =>
+	Schema.decodeUnknownExit(schema)(input)
+
+describe('a company country', () => {
+	describe('when a caller writes one in lower case', () => {
+		it('should be raised to capitals before it is stored', () => {
+			// GIVEN a country typed in as free text, which is what a caller sends
+			// WHEN it is decoded on the way in
+			const result = decode(CompanyCountry, 'es')
+
+			// THEN it is stored the way the filter and the counts compare it. Left as
+			// typed, the company would be missed by anyone asking for ES and would be
+			// offered as a second Spain with a count of its own
+			expect(result._tag).toBe('Success')
+			if (result._tag === 'Success') expect(result.value).toBe('ES')
+		})
+
+		it('should leave one already in capitals alone', () => {
+			// GIVEN the form nearly every caller already sends
+			const result = decode(CompanyCountry, 'ES')
+
+			// THEN nothing changes, so the rule is safe to apply everywhere
+			expect(result._tag).toBe('Success')
+			if (result._tag === 'Success') expect(result.value).toBe('ES')
+		})
+	})
+
+	describe('when it is not two letters', () => {
+		it('should be refused rather than stored', () => {
+			// GIVEN values that are the wrong shape for a country code
+			// THEN each is turned away where it is typed
+			expect(decode(CompanyCountry, 'ESP')._tag).toBe('Failure')
+			expect(decode(CompanyCountry, 'E')._tag).toBe('Failure')
+			expect(decode(CompanyCountry, '')._tag).toBe('Failure')
+			expect(decode(CompanyCountry, '12')._tag).toBe('Failure')
+		})
+	})
+})
+
+describe('a company tag', () => {
+	describe('when it holds a comma', () => {
+		it('should be refused, because several tags travel as one comma list', () => {
+			// GIVEN a label somebody might reasonably type
+			// WHEN it is written
+			const result = decode(CompanyTag, 'Barcelona, Sants')
+
+			// THEN it is refused. Stored, it would be split back into two tags no
+			// company carries the moment anyone filtered by it, and every company
+			// under it would quietly stop being findable
+			expect(result._tag).toBe('Failure')
+		})
+	})
+
+	describe('when it is ordinary text', () => {
+		it('should be accepted as written, accents and spaces included', () => {
+			// GIVEN the labels an organisation actually uses
+			// THEN each is kept exactly as typed — a tag is free text, and only the
+			// separator is out of bounds
+			for (const tag of ['pilot', 'Q1 2026', 'Calderería', 'shortlist']) {
+				const result = decode(CompanyTag, tag)
+				expect(result._tag).toBe('Success')
+				if (result._tag === 'Success') expect(result.value).toBe(tag)
+			}
+		})
+	})
+
+	describe('when it is empty', () => {
+		it('should be refused rather than stored as a blank chip', () => {
+			// GIVEN nothing typed
+			// THEN there is no tag to write
+			expect(decode(CompanyTag, '')._tag).toBe('Failure')
+		})
+	})
+})
+
+describe('a company sort order', () => {
+	describe('when it is one the server holds', () => {
+		it('should be accepted', () => {
+			// GIVEN each order the list can be read in
+			for (const sort of [
+				'priority',
+				'name',
+				'recent_contact',
+				'recent_update',
+			]) {
+				expect(decode(CompanySort, sort)._tag).toBe('Success')
+			}
+		})
+	})
+
+	describe('when it is a word the server does not know', () => {
+		it('should be refused rather than quietly ignored', () => {
+			// GIVEN an order nobody implements
+			// THEN it is turned away at the door. Accepted, the caller would be sent
+			// a list in priority order believing it had asked for something else,
+			// with nothing in the answer to say otherwise
+			expect(decode(CompanySort, 'newest')._tag).toBe('Failure')
+			expect(decode(CompanySort, 'name_desc')._tag).toBe('Failure')
+			expect(decode(CompanySort, '')._tag).toBe('Failure')
+		})
+	})
+})

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -40,6 +40,7 @@ export {
 	AttentionFilter,
 	COMPANY_PRIORITIES,
 	COMPANY_SIZE_RANGES,
+	COMPANY_SORTS,
 	COMPANY_STATUSES,
 	Company,
 	CompanyCountry,
@@ -55,8 +56,11 @@ export {
 	CompanySizeRange,
 	CompanySlug,
 	CompanySocialProfile,
+	CompanySort,
 	CompanyStatus,
+	CompanyTag,
 	CompanyWebsite,
+	normalizeCountry,
 } from './companies'
 export {
 	ContactChannel,

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -7525,7 +7525,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							if (filter.status) conds.push(sql`status = ${filter.status}`)
 							if (filter.industry)
 								conds.push(sql`industry = ${filter.industry}`)
-							if (filter.country) conds.push(sql`country = ${filter.country}`)
+							// Raised the same way the rows are, or a selector written in
+							// lower case matches nothing at all.
+							if (filter.country)
+								conds.push(sql`country = ${filter.country.toUpperCase()}`)
 							if (filter.tags && filter.tags.length > 0)
 								conds.push(sql`tags && ${filter.tags}`)
 

--- a/packages/research/src/domain/country.test.ts
+++ b/packages/research/src/domain/country.test.ts
@@ -29,12 +29,14 @@ describe('AcceptedCountry', () => {
 			expect(decodeCountry('FR')).toBe('FR')
 		})
 
-		it('should accept any case and preserve it (the handler normalizes)', () => {
+		it('should accept any case and raise it to capitals', () => {
 			// GIVEN a lower- or mixed-case code
 			// WHEN it is decoded
-			// THEN the boundary leaves case untouched — upper-casing is the handler's job
-			expect(decodeCountry('gb')).toBe('gb')
-			expect(decodeCountry('Us')).toBe('Us')
+			// THEN it comes back in capitals, the one spelling everything downstream
+			// compares against — a company stored lower-case is missed by anyone
+			// asking for the capitals, and counted as a country of its own
+			expect(decodeCountry('gb')).toBe('GB')
+			expect(decodeCountry('Us')).toBe('US')
 		})
 	})
 


### PR DESCRIPTION
## What

A company list can be narrowed eighteen different ways. Before this, the web app offered eight of them and the tools an AI assistant calls (MCP) offered fifteen — and they were missing *different* ones, so a question you could answer by clicking could not be asked by an assistant, and the other way round. Three of the eight the web app did offer also answered confidently and wrongly in particular cases.

This makes every filter reachable from both doors and fixes the cases that lied. It lives in the CRM context across three surfaces: the shared contract (`packages/domain`, `packages/controllers`), the server (`apps/server`, including its agent tools), and the web app (`apps/internal`).

## Changes

**Touches:** the rules about what a country and a tag may look like, the query that narrows a company list and the per-value counts built from the same rules, the agent tool that searches companies, and the company list screen with its filter bar — plus the pipeline board it hands filters to, which was dropping some of them, and the app-wide address encoder, which turned out to be dropping search terms on every screen.

- **Four filters take several values now** — stage, country, owner, and the verdict a research run reached about whether a company is worth selling to. Several values inside one filter mean *any of them*; different filters still narrow each other. Tags stay the exception, where every tag named has to be on the company. "Everything mid-conversation" was the question the board view existed to answer, and it is now one click on the list.
- **Two filters the server has always answered had no menu**, so anyone using them was guessing a value and getting an empty list when they guessed wrong. The counts beside the list now include tags and fit verdicts.
- **Whether a menu leaves its own filter out follows from one written-down rule** rather than being remembered at each call site. Values that are alternatives (pick a second country, the first is replaced) leave it out; values that are requirements (pick a second tag, the list gets smaller) keep it.
- **Two rules about a value moved into `packages/domain`** and are read at all three write doors, the research apply path included: a country is raised to capitals, and a tag may not hold a comma or lean on a blank. Several tags travel as one comma-separated value, so one holding a comma splits into tags nobody carries.
- **Cases that answered wrongly:** a country typed in lower case was invisible to anyone filtering for the capitals; an order the server did not recognise was silently swapped for priority order; asking for deleted companies together with "what needs doing" always found nothing; and switching from the bin to the board quietly widened the list.
- **Eight filters were unreachable from the web app** — not merely unrendered. The address is validated against a fixed list of names, so a hand-written link carrying one was dropped before the request was built and the list came back unfiltered with no error.

## Impact

- **A migration must run, and it rewrites stored data.** `0068_company_country_case_and_tag_index` raises stored country codes to capitals, splits tags that hold a comma into the tags they meant, and adds an index for tag lookups. `deploy_server.yml` runs `migrate` behind the `production-db` reviewer gate and `deploy` declares `needs: [detect-migrations, migrate]`, so the server cannot ship ahead of it. Both rewrites are irreversible — a country's original case and a comma tag's single-value form cannot be recovered — and both are written so a second run changes nothing. Only rows that are actually a two-letter code are touched, so a hand-typed `Spain` is left for a person rather than shouted back as `SPAIN`.
- **The web app must not ship ahead of the server.** `deploy_web.yml` has no dependency on the server deploy, and the new UI writes `?country=ES,FR`, which today's server reads as one string and matches nothing — silently, with no error. Release `server` before `internal`.
- **The shape sent over the wire changed for four filters.** `status`, `country`, `owner` and `fitVerdict` travel as a comma-separated list rather than a single value, and `sort` is a closed set of four words that returns 400 for anything else. `packages/controllers` is read by both the server and the web app's typed client, so this ripples to both — no shim, matching the pre-production convention.
- **Both doors get the behaviour.** The HTTP endpoints and the agent tool share one service, so the multi-value filters, the new counts and the country fix reach the web app and MCP alike. `search_companies` additionally gained owner, what-needs-doing and sort, which it never had, and its filters now take the same closed word lists its write tools use — an invented stage is refused with a reason instead of answered with an empty list.
- **The address encoder changed for every route, not just this one.** A search value that merely looks like JSON is now written back quoted. Without that the text `2024` returned as the number `2024` and every field typed as text dropped it, so searching for a year or a phone number silently cleared the box on companies, emails, documents and pages.
- **Nothing touching which organisation can see what** (row-level security, the `organization_id` scope, and the Postgres role each path runs under) changed, no new environment variables, no change to the public/protected boundary, and no webhook or paid-provider behaviour. Every new filter value reaches SQL as a bound parameter.

## Review guide

Read in this order:

1. `apps/server/src/services/companies.ts` — the heart of it. `FILTERS_NEEDING_EVERY_VALUE` and the `lifted` line below it are the one rule the whole counting story rests on; if that is wrong, every menu number is wrong. The two new count queries are at the end of `facets`.
2. `packages/domain/src/schema/companies.ts` — the value rules, and `packages/controllers/src/routes/companies.ts` for the contract.
3. `apps/internal/src/routes/companies/index.tsx` — the filter bar. `mergeSearch` and `hasActiveFilters` read whatever the search holds instead of naming each filter by hand, which is how a filter got left out before.

**The riskiest part** is the tags count. It expands every company's tag array into one row per tag, so it counts per distinct company — a company with the same tag written twice would otherwise count twice, and nothing prevents that. It also must not alias the expansion as `tags`, which would shadow the column the filter condition reads. Both are commented at the query and covered by tests.

**Decisions you might overrule.** A chosen tag reports the whole current list as its count, every time, so I hide the number on chosen tags rather than show a figure that says nothing. A control shows the name of a single chosen value in place of its own name — these sit several to a line and there is room for one or the other, and which value is narrowing the list seemed the more useful; the control keeps its own name for anyone listening. And `deleted=include` is gone from the web app's accepted parameters, so a bookmarked link carrying it now shows only live companies.

**What I could not verify.** Snyk is not available in this session, so no dependency or code scan was run. I have not checked production for country codes stored in mixed case or tags holding a comma — `SELECT DISTINCT country FROM companies` and a tag scan before the migration would tell you how much data it actually rewrites.

**Skip-able:** the `.po` translation catalogs are generated by `i18n:extract` plus the Catalan I filled in.

## Screenshots

Two stages in force at once, a country, and what needs doing carried in from a dashboard heading — the chosen value takes the control's place, in the accent colour:

![pr-filters-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-617/pr-filters-desktop.webp)

The tag menu with one tag already chosen. The others show what would be left if you added them, which is what adding them does; the chosen one carries no number, because it would always report the whole list:

![pr-filters-tags](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-617/pr-filters-tags.webp)

Mobile — the stage strip slides rather than wrapping, and the controls fall two per row:

![pr-filters-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-617/pr-filters-mobile.webp)

## Tests

- **Unit** — the value rules (country raised to capitals and refused when it is not a code, a tag refusing a comma or a blank, an unknown sort order refused) and the browser's cache key, including that two links naming the same tags in a different order are one list.
- **Integration, against live Postgres** — the multi-value filters including the "mine or nobody's" owner case, blanks reading as nobody asking, the lower-case country, and the counting rules for tags and fit verdicts. The migration has its own suite: the case fix, the comma split, padding and duplicates, a row needing nothing, and a second run changing nothing.
- **End-to-end** — twenty Playwright cases on the real page, including four for what a screen reader gets: every option named, the count spoken as words, the stage strip's state, and the list announcing itself when a filter changes it.

## Verification

I ran, on this branch rebased onto current `main`: `pnpm install` (no lockfile drift), `tsc --noEmit` in all eight packages, `pnpm turbo test` (23 packages), the full server integration suite (892 tests), `pnpm -w build`, and the full Playwright suite (163 passing). I also drove the running API by hand: `?status=contacted,responded` returns 40 where one stage returns 22, `?country=es` and `?country=ES` both return 120, `?sort=newest` returns 400 while `?sort=name` returns 200, and the counts endpoint returns all four menus with the tag counts narrowing correctly as a tag is added.

Two flaky suites are worth knowing about, both unrelated to this change and both passing repeatedly in isolation: `email-threading` and `mcp-connections` each failed once in a full run and neither is touched here.

## Deferred

Nothing from either issue. Two filters are deliberately left without a control: the free-form `metadata` key/value pair, because a control for an open store of arbitrary keys is a query builder and that is a different product; and the map bounding box, which is a viewport's language rather than something anybody clicks. Both remain available to agents and to a hand-written link.

An accessibility review also flagged two things I did not take: the unselected stage chip's dashed border measures 2.45:1 against the plate, which is a design-system token used app-wide rather than something this change introduced; and adding `@axe-core/playwright` to the e2e suite, which is a new dependency and a scope decision of its own.

Closes #602
Closes #603
