### PR TITLE
cicd: run the IMAP round-trip after a merge instead of never

### DIFF
--- a/.github/actions/integration-db/action.yml
+++ b/.github/actions/integration-db/action.yml
@@ -9,6 +9,16 @@ description: >-
   database up the same way. Two copies drift, and a backstop that drifts from
   the gate reports breaks the gate never had.
 
+inputs:
+  with-mail:
+    description: >-
+      Also stand up the mail catcher, so the tests that talk IMAP to a real
+      server run instead of skipping. Off by default: it costs a 320 MB pull and
+      about a minute of start-up, which the pull-request gate cannot spare
+      inside its ten-minute budget. The post-merge backstop turns it on.
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
@@ -38,6 +48,35 @@ runs:
         done
         docker compose -f docker/docker-compose.yml up -d --wait db storage
         docker compose -f docker/docker-compose.yml run --rm --no-deps storage-init
+
+    # Only where the caller asked for it — see the input's description for why
+    # this is not on by default.
+    - name: Start the mail catcher
+      if: inputs.with-mail == 'true'
+      shell: bash
+      run: |
+        pull_attempt=1
+        until docker compose -f docker/docker-compose.yml pull --quiet mail-catcher; do
+          if [ "$pull_attempt" -ge 3 ]; then
+            echo "Could not fetch the mail catcher image after 3 tries." >&2
+            exit 1
+          fi
+          echo "Image pull failed (attempt $pull_attempt) — retrying shortly."
+          sleep $((pull_attempt * 10))
+          pull_attempt=$((pull_attempt + 1))
+        done
+        docker compose -f docker/docker-compose.yml up -d mail-catcher
+        # GreenMail answers on its REST port well after the container is up, and
+        # a test that connects too early fails on a refused socket rather than
+        # on anything it meant to check.
+        for _ in $(seq 1 90); do
+          if curl -sf -o /dev/null --max-time 2 http://localhost:8025/api/service/readiness; then
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "The mail catcher never became ready." >&2
+        exit 1
 
     # The local container above. Its `batuda` superuser owns the schema, and
     # integration tests SET ROLE into the app_user / app_service roles that the
@@ -86,4 +125,8 @@ runs:
         STORAGE_ACCESS_KEY_ID: batuda
         STORAGE_SECRET_ACCESS_KEY: batuda-secret
         STORAGE_BUCKET: batuda-assets
+        # Set only where the catcher is up. The IMAP tests read this and stay
+        # inert without it, so the gate runs the same suite minus the ones that
+        # need a mail server.
+        MAIL_CATCHER_LIVE: ${{ inputs.with-mail == 'true' && '1' || '' }}
       run: pnpm exec turbo test:integration --concurrency=1

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -81,5 +81,10 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # with-mail here and not on the pull-request gate: the IMAP tests need a
+      # real mail server, which costs a pull and about a minute of start-up. This
+      # job is a backstop with room for it; the gate is not.
       - name: Integration suite against a local Postgres
         uses: ./.github/actions/integration-db
+        with:
+          with-mail: "true"

--- a/apps/mail-worker/src/imap-roundtrip.integration.test.ts
+++ b/apps/mail-worker/src/imap-roundtrip.integration.test.ts
@@ -1,9 +1,11 @@
-// Live IMAP-roundtrip integration test. Gated behind MAIL_CATCHER_LIVE: it
-// needs the running dev stack (GreenMail IMAP on :1143, Postgres, MinIO),
-// none of which exist in the unit-test CI job, so it stays inert there and
-// runs only when explicitly enabled:
+// Live IMAP-roundtrip test — the only place a real mail server is on the wire.
+//
+// Gated behind MAIL_CATCHER_LIVE because it needs one, which the pull-request
+// gate does not stand up: the image is 320 MB and the server takes about a
+// minute to answer, and that gate has a ten-minute budget to keep. So it runs
+// post-merge, where there is room, and stays inert everywhere else. Locally:
 //   pnpm cli services up && pnpm cli db reset && pnpm cli seed
-//   MAIL_CATCHER_LIVE=1 pnpm --filter @batuda/mail-worker vitest run src/imap-roundtrip
+//   MAIL_CATCHER_LIVE=1 pnpm --filter @batuda/mail-worker test:integration
 //
 // What it does: SMTP-inject a message → connect ImapFlow as the seeded
 // admin@taller.cat → open INBOX → call `fetchAndIngestNewerThan` against the


### PR DESCRIPTION
## What

The one test that puts a real mail server on the wire has never run anywhere — not in CI, and not locally unless somebody happened to know a flag. This makes it run after a merge.

It covers the path the last two PRs changed: an SMTP-injected message arrives, the worker runs one fetch tick through `fetchAndIngestNewerThan`, and a row lands; running the same tick twice does not duplicate it; an `EXPUNGE` marks the row deleted. Real IMAP, real Postgres — the only coverage of the wire protocol, uid semantics, and expunge handling that exists.

`apps/mail-worker` and CI config only. No product code changes.

## Changes

**Touches:** which suite the round-trip belongs to, and what the post-merge run stands up.

- Filed the round-trip with the other tests that need a database. It was named as a unit test, so the unit runner picked it up and nothing stood its dependencies up — which is *why* it needed a flag to stay quiet. Renaming it is most of the fix.
- Gave the shared database action an opt-in for the mail catcher, mirroring the `with-mail` input `e2e-stack` already has, and turned it on for the post-merge backstop only.

## Impact

- **The pull-request gate is untouched** and takes the default (off), so its ten-minute budget is unchanged. Verified: without the flag the suite reports 48 passing and 3 skipped; with it, 51 passing.
- **The post-merge backstop grows by a 320 MB pull and about a minute of start-up**, inside a fifteen-minute budget where the work currently takes about half that.
- **Nothing ships differently.** No product code, no schema, no environment variable that reaches a deployed process.

## Review guide

- **The decision worth checking is placement**, and I would rather you overrule it than not see it. These tests run *after* a merge, so a break in the IMAP path is named on main rather than blocked before it. I put them there because I measured the alternative: GreenMail is a 320 MB image and took 61 seconds to answer from an already-warm image on this machine, against a gate that currently runs 7m24s of a 10m budget. That is too tight to spend on it. Moving them to the gate is a one-line change to `ci.yml` if you would rather pay it.
- **What these tests do not cover**, so the coverage is not overstated: I checked by reverting the cursor fix from the previous PR and running them — all three still passed. They only exercise the path where ingest succeeds, so the failure and retry logic is not among what they protect. That stays covered by the unit tests over a fake client, which is the right tool for it. What these add is the wire itself.
- **Skip-able:** the test file's diff is a rename plus a rewritten header comment.

## Verification

- `pnpm check-types` (14/14), `pnpm check` (exit 0), `pnpm test` (23/23 packages), `pnpm build` (14/14).
- `pnpm --filter @batuda/mail-worker test:integration` both ways: 48 passed / 3 skipped without the flag, 51 passed with it.
- `pnpm --filter @batuda/server test:integration` — 114 files, 892 tests, confirming the rename does not disturb the shared runner.
- Not run: the workflow itself. The action's YAML parses and the wiring is a default-off input, but whether the mail catcher comes up on a GitHub runner is only proven by the first post-merge run.
