### PR TITLE
fix(cicd): let the IMAP tests find the mail server themselves

### DIFF
--- a/.github/actions/integration-db/action.yml
+++ b/.github/actions/integration-db/action.yml
@@ -12,10 +12,11 @@ description: >-
 inputs:
   with-mail:
     description: >-
-      Also stand up the mail catcher, so the tests that talk IMAP to a real
-      server run instead of skipping. Off by default: it costs a 320 MB pull and
-      about a minute of start-up, which the pull-request gate cannot spare
-      inside its ten-minute budget. The post-merge backstop turns it on.
+      Also stand up the mail catcher. The tests that need one find it themselves
+      and skip when it is absent, so this is the whole of the switch: bring it
+      up and they run. Off by default, because it costs a 320 MB pull and about
+      a minute of start-up that the pull-request gate cannot spare inside its
+      ten-minute budget. The post-merge backstop turns it on.
     required: false
     default: "false"
 
@@ -125,8 +126,4 @@ runs:
         STORAGE_ACCESS_KEY_ID: batuda
         STORAGE_SECRET_ACCESS_KEY: batuda-secret
         STORAGE_BUCKET: batuda-assets
-        # Set only where the catcher is up. The IMAP tests read this and stay
-        # inert without it, so the gate runs the same suite minus the ones that
-        # need a mail server.
-        MAIL_CATCHER_LIVE: ${{ inputs.with-mail == 'true' && '1' || '' }}
       run: pnpm exec turbo test:integration --concurrency=1

--- a/apps/mail-worker/src/imap-roundtrip.integration.test.ts
+++ b/apps/mail-worker/src/imap-roundtrip.integration.test.ts
@@ -1,11 +1,16 @@
 // Live IMAP-roundtrip test — the only place a real mail server is on the wire.
 //
-// Gated behind MAIL_CATCHER_LIVE because it needs one, which the pull-request
-// gate does not stand up: the image is 320 MB and the server takes about a
-// minute to answer, and that gate has a ten-minute budget to keep. So it runs
-// post-merge, where there is room, and stays inert everywhere else. Locally:
-//   pnpm cli services up && pnpm cli db reset && pnpm cli seed
-//   MAIL_CATCHER_LIVE=1 pnpm --filter @batuda/mail-worker test:integration
+// Runs when there is a mail server to talk to and skips when there is not, by
+// asking one before deciding rather than reading a flag somebody has to set.
+// A flag is one more thing between the server being up and the tests running,
+// and when it goes missing they skip while everything still reports green —
+// which is indistinguishable from passing. Asking cannot go quiet that way:
+// either the server answers and they run, or it does not and they cannot.
+//
+// The pull-request gate stands up no mail server, so they skip there: the image
+// is 320 MB and takes about a minute to answer, and that gate has a ten-minute
+// budget to keep. The post-merge run stands one up, so they run. Locally they
+// follow `pnpm cli services up` with no extra step.
 //
 // What it does: SMTP-inject a message → connect ImapFlow as the seeded
 // admin@taller.cat → open INBOX → call `fetchAndIngestNewerThan` against the
@@ -16,6 +21,9 @@
 
 process.env['DATABASE_URL'] ??=
 	'postgresql://batuda:batuda@localhost:5433/batuda'
+
+// GreenMail's REST port, as docker-compose maps it.
+const MAIL_CATCHER_REST = 'http://localhost:8025'
 
 import { PgClient } from '@effect/sql-pg'
 import { Config, Effect, Redacted } from 'effect'
@@ -100,8 +108,19 @@ const clearCatcher = async () => {
 	}
 }
 
-describe.skipIf(!process.env['MAIL_CATCHER_LIVE'])(
-	'IMAP ingest roundtrip (live; set MAIL_CATCHER_LIVE)',
+// Asked once, before the suite is collected. A short deadline: this answers on
+// a loopback port, so anything slower than a moment is nothing listening.
+const mailServerAnswers = await fetch(
+	`${MAIL_CATCHER_REST}/api/service/readiness`,
+	{
+		signal: AbortSignal.timeout(2000),
+	},
+)
+	.then(res => res.ok)
+	.catch(() => false)
+
+describe.skipIf(!mailServerAnswers)(
+	'IMAP ingest roundtrip (needs the mail catcher)',
 	() => {
 		let pool: pg.Pool
 		let orgId: string


### PR DESCRIPTION
## What

The change I merged an hour ago does not work, and the way it failed is worse than not having shipped it: the tests skipped and the run reported green.

PR 621 set an environment variable to switch the IMAP tests on after a merge. The variable never reached them. Turbo passes through only the variables named in `turbo.json`, so it was stripped between the workflow step and the test process. The post-merge run on `2f9ce3075e` shows it plainly:

```
src/imap-roundtrip.integration.test.ts (3 tests | 3 skipped)
Tests  48 passed | 3 skipped (51)
Integration suite (post-merge): success
```

A skip is a pass, so nothing anywhere went red.

This fixes it by removing the variable rather than declaring it.

## Changes

**Touches:** how the IMAP tests decide to run, and the plumbing that used to tell them.

- The tests now ask the mail server whether it is there, before the suite is collected, and skip when nothing answers. A flag is one more thing between the server being up and the tests running; asking cannot go quiet the way a missing flag can.
- Dropped the flag and everything that carried it. Standing the mail server up is now the whole of the switch, which is the only part that was ever doing work.

## Impact

- **The pull-request gate is unchanged** — it stands up no mail server, so the probe finds nothing and the tests skip exactly as before.
- **The post-merge run will now actually run them**, which PR 621 intended and did not achieve.
- **Locally they run whenever the dev stack is up**, with no extra step. That is a small behaviour change: `pnpm cli services up` and the tests are live, where before you had to know the flag.
- No product code, no schema, nothing that reaches a deployed process.

## Review guide

- **Declaring the variable in `turbo.json` would also have worked**, and it is a one-line change. I did not do that because it leaves the failure mode in place: the next variable somebody adds has the same trap, and a stripped one still shows up as a green run with silent skips. Asking the server removes the class rather than this instance.
- **The probe is a top-level `await` before `describe`**, with a two-second deadline against a loopback port. It runs once per file collection, not per test.
- **What I checked, having got this wrong once**: I reproduced the original bug locally through `turbo` — 3 skipped — then confirmed the fix runs them with no flag set (51 passed), and that stopping the mail catcher makes them skip rather than fail (48 passed / 3 skipped). Running the tests directly under vitest, which is how I verified PR 621, bypasses turbo entirely and is why I missed it.

## Verification

- `pnpm check-types` (14/14), `pnpm check` (exit 0), `pnpm test` (23/23), `pnpm build` (14/14).
- `pnpm exec turbo test:integration --concurrency=1` — the exact command CI runs — with the mail catcher up: mail-worker 6 files / 51 tests, none skipped; server 114 files.
- Same command with the catcher stopped: 48 passed, 3 skipped, no failures.
- Still not verified: that the mail catcher comes up on a GitHub runner. PR 621's post-merge run started the container without erroring, but since the tests skipped anyway, nothing has yet proven the server was actually reachable there. The next post-merge run is the one that tells us — and now a failure to reach it will be visible as tests that did not run, rather than hidden.
