### PR TITLE
fix: put a time limit on mailbox checks and hear their errors

### DIFF
--- a/apps/internal/src/routes/emails/inboxes.tsx
+++ b/apps/internal/src/routes/emails/inboxes.tsx
@@ -984,6 +984,8 @@ function InboxFormDialog({
 		(draft.imapHost.trim() === '' || draft.smtpHost.trim() === '')
 	const advancedOpen = showAdvanced || needsManualHosts
 
+	// On a new mailbox, an empty login name means the address itself: that is
+	// what nearly every provider signs in with.
 	const usernameForSubmit = draft.username !== '' ? draft.username : draft.email
 
 	// Create requires email + transport + credentials. Edit lets the user
@@ -1028,7 +1030,10 @@ function InboxFormDialog({
 						smtpHost: draft.smtpHost,
 						smtpPort: draft.smtpPort,
 						smtpSecurity: draft.smtpSecurity,
-						username: usernameForSubmit,
+						// On an edit, an empty login name means nothing to change, so a
+						// mailbox that signs in under a different address keeps the one
+						// it has.
+						...(draft.username !== '' && { username: draft.username }),
 						...(changeCredentials && password !== '' && { password }),
 					})
 				: await onCreate({

--- a/apps/server/src/services/email-harness.ts
+++ b/apps/server/src/services/email-harness.ts
@@ -110,6 +110,7 @@ export const emailDependencies = (options?: HarnessOptions) =>
 							new GrantConnectFailed({
 								inboxId: 'harness-inbox',
 								detail: options.sendFailure,
+								reason: 'unknown',
 							}),
 						),
 			appendToSent: () => Effect.void,

--- a/apps/server/src/services/email-inbox-update.integration.test.ts
+++ b/apps/server/src/services/email-inbox-update.integration.test.ts
@@ -5,7 +5,7 @@ process.env['DATABASE_URL'] ??=
 
 import { randomUUID } from 'node:crypto'
 
-import { Effect, Layer } from 'effect'
+import { Cause, Effect, Exit, Layer } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
@@ -184,7 +184,11 @@ describe('EmailService.updateInbox re-probe', () => {
 					Effect.provide(
 						serviceLayer(creds =>
 							Effect.fail(
-								new GrantAuthFailed({ inboxId: creds.inboxId, detail }),
+								new GrantAuthFailed({
+									inboxId: creds.inboxId,
+									detail,
+									reason: 'invalid_credentials',
+								}),
 							),
 						),
 					),
@@ -436,6 +440,137 @@ describe('EmailService.updateInbox re-probe — real credential round-trip', () 
 		})
 	})
 
+	describe('when a mailbox is connected with whitespace around its details', () => {
+		it('should offer the mail server what was meant, not what was pasted', async () => {
+			// GIVEN details pasted from a provider's page, each carrying a space
+			// or a newline
+			const created = `created-${randomUUID()}@test.local`
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.createInbox({
+						email: ` ${created} `,
+						username: `  ${created}\n`,
+						password: ' pasted-app-pw\n',
+						imapHost: ' imap.test.local\n',
+						imapPort: 993,
+						imapSecurity: 'tls',
+						smtpHost: ' smtp.test.local ',
+						smtpPort: 587,
+						smtpSecurity: 'starttls',
+					})
+				}).pipe(
+					Effect.provide(realServiceLayer),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+					Effect.orDie,
+				),
+			)
+
+			// THEN every one of them reaches the mail server tidied. A hostname
+			// with a newline fails to resolve and reads on screen as correct.
+			expect(probeCalls).toHaveLength(1)
+			expect(probeCalls[0]?.username).toBe(created)
+			expect(probeCalls[0]?.password).toBe('pasted-app-pw')
+			expect(probeCalls[0]?.imapHost).toBe('imap.test.local')
+			expect(probeCalls[0]?.smtpHost).toBe('smtp.test.local')
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					yield* sql`DELETE FROM inboxes WHERE email = ${created}`
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+			)
+		})
+
+		it('should refuse a password that is only blank space', async () => {
+			// GIVEN a password box holding a single space
+			// WHEN the mailbox is connected
+			const exit = await Effect.runPromise(
+				Effect.exit(
+					Effect.gen(function* () {
+						const svc = yield* EmailService
+						yield* svc.createInbox({
+							email: `blank-${randomUUID()}@test.local`,
+							username: 'someone@test.local',
+							password: '   ',
+							imapHost: 'imap.test.local',
+							imapPort: 993,
+							imapSecurity: 'tls',
+							smtpHost: 'smtp.test.local',
+							smtpPort: 587,
+							smtpSecurity: 'starttls',
+						})
+					}).pipe(
+						Effect.provide(realServiceLayer),
+						Effect.provide(orgContext),
+						Effect.provide(sessionContext),
+					),
+				),
+			)
+
+			// THEN it is turned away rather than stored, since stored it could
+			// only ever be refused, and no mail server is troubled with it
+			expect(exit._tag).toBe('Failure')
+			expect(probeCalls).toHaveLength(0)
+		})
+	})
+
+	describe('when a blank password rides along with a handover', () => {
+		it('should refuse before anything is written', async () => {
+			// GIVEN an admin handing the mailbox to somebody who is not a member
+			// of the organization, and a password box holding only blank space
+			const adminContext = Layer.succeed(CurrentOrg, {
+				id: TEST_ORG,
+				role: 'admin',
+			} as never)
+
+			// WHEN the mailbox is saved
+			const exit = await Effect.runPromise(
+				Effect.exit(
+					Effect.gen(function* () {
+						const svc = yield* EmailService
+						yield* svc.updateInbox(inboxId, {
+							ownerUserId: 'not-a-member-of-this-org',
+							password: '   ',
+						})
+					}).pipe(
+						Effect.provide(serviceLayer(() => Effect.void)),
+						Effect.provide(adminContext),
+						Effect.provide(sessionContext),
+					),
+				),
+			)
+
+			// THEN it is turned away for the password, and the handover never ran.
+			// The other way round it would have moved the mailbox first, and a
+			// refusal does not always undo what came before it
+			expect(exit._tag).toBe('Failure')
+			const failure = Exit.isFailure(exit)
+				? [...exit.cause.reasons].find(reason => Cause.isFailReason(reason))
+				: undefined
+			expect(
+				(failure as { error?: { _tag?: string; message?: string } } | undefined)
+					?.error?._tag,
+			).toBe('BadRequest')
+
+			const after = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					const rows = yield* sql<{ ownerUserId: string | null }>`
+						SELECT owner_user_id AS "ownerUserId" FROM inboxes WHERE id = ${inboxId}
+					`
+					return rows[0]?.ownerUserId
+				}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+					string | null | undefined,
+					never,
+					never
+				>,
+			)
+			expect(after).toBe(TEST_USER)
+		})
+	})
+
 	describe('when only the transport changes', () => {
 		it('should probe with the decrypted stored password and the new host', async () => {
 			// [email.ts:1912 — transport change triggers reprobe with the decrypted stored password]
@@ -460,6 +595,56 @@ describe('EmailService.updateInbox re-probe — real credential round-trip', () 
 			expect(probeCalls).toHaveLength(1)
 			expect(probeCalls[0]?.password).toBe(ORIGINAL_PW)
 			expect(probeCalls[0]?.imapHost).toBe('imap.rotated.example')
+		})
+	})
+
+	describe('when the password arrives with blank space around it', () => {
+		it('should probe with the password trimmed', async () => {
+			// GIVEN a password copied from a provider's page, carrying a leading
+			// space and a trailing newline
+			// WHEN it is saved
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.updateInbox(inboxId, {
+						password: ' pasted-app-pw\n',
+					})
+				}).pipe(
+					Effect.provide(realServiceLayer),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+					Effect.orDie,
+				),
+			)
+
+			// THEN the mail server is offered the password itself, not the
+			// whitespace that came with it — which it would reject as wrong
+			expect(probeCalls).toHaveLength(1)
+			expect(probeCalls[0]?.password).toBe('pasted-app-pw')
+		})
+	})
+
+	describe('when the login name arrives with blank space around it', () => {
+		it('should probe with the login name trimmed', async () => {
+			// GIVEN a login name typed with a trailing space
+			// WHEN it is saved
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					yield* svc.updateInbox(inboxId, {
+						username: '  someone@test.local ',
+					})
+				}).pipe(
+					Effect.provide(realServiceLayer),
+					Effect.provide(orgContext),
+					Effect.provide(sessionContext),
+					Effect.orDie,
+				),
+			)
+
+			// THEN the stored login name is the one the server will recognise
+			expect(probeCalls).toHaveLength(1)
+			expect(probeCalls[0]?.username).toBe('someone@test.local')
 		})
 	})
 })

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -23,6 +23,7 @@ import {
 	EmailThreadDetail,
 	EmailThreadList,
 	EmailThreadListItem,
+	type GrantFailureReason,
 	GrantUnavailable,
 	InboxInactive,
 	NoDefaultInbox,
@@ -34,7 +35,7 @@ import { EmailDraft, Inbox, InboxFooter, isOrgManager } from '@batuda/domain'
 import { renderBlocks, type StagedAttachmentRef } from '@batuda/email/render'
 import type { EmailBlocks } from '@batuda/email/schema'
 import { isReplySubject, withReplyPrefix } from '@batuda/email/subject'
-import { boundedCause } from '@batuda/observability'
+import { boundedCause, recordFacts } from '@batuda/observability'
 
 import {
 	type CountMode,
@@ -835,6 +836,7 @@ export class EmailService extends Context.Service<EmailService>()(
 									({
 										status: 'connected' as const,
 										detail: null as string | null,
+										reason: null as GrantFailureReason | null,
 									}) as const,
 								onFailure: err =>
 									({
@@ -843,9 +845,19 @@ export class EmailService extends Context.Service<EmailService>()(
 												? ('auth_failed' as const)
 												: ('connect_failed' as const),
 										detail: err.detail ?? null,
+										reason: err.reason,
 									}) as const,
 							}),
 						)
+
+					// Only the sort of failure travels: the mail server's own words
+					// are about somebody's account.
+					yield* recordFacts({
+						'inbox.probe.outcome': probe.status,
+						...(probe.reason !== null && {
+							'inbox.probe.reason': probe.reason,
+						}),
+					})
 
 					const rows = yield* sql<InboxRow>`
 						UPDATE inboxes
@@ -2351,6 +2363,24 @@ export class EmailService extends Context.Service<EmailService>()(
 						const currentOrg = yield* CurrentOrg
 						const session = yield* SessionContext
 
+						// Pasted from a provider's page, any of these can carry a space or a
+						// newline; the mail server counts that as part of what it was given
+						// and refuses the sign-in.
+						const address = input.email.trim()
+						const username =
+							input.username.trim() === '' ? address : input.username.trim()
+						const password = input.password.trim()
+						const imapHost = input.imapHost.trim()
+						const smtpHost = input.smtpHost.trim()
+
+						// Blank space is not a password: stored, it would only ever be
+						// refused, and the refusals counted against the mailbox.
+						if (password === '') {
+							return yield* new BadRequest({
+								message: 'A password is required to connect a mailbox',
+							})
+						}
+
 						// A mailbox belongs to whoever connects it unless it is being
 						// set up for the whole team.
 						const ownerUserId = input.shared
@@ -2372,7 +2402,7 @@ export class EmailService extends Context.Service<EmailService>()(
 						const alreadyConnected = yield* sql<{ count: number }>`
 							SELECT count(*)::int AS count FROM inboxes
 							WHERE organization_id = ${currentOrg.id}
-							  AND lower(email) = lower(${input.email})
+							  AND lower(email) = lower(${address})
 							  AND active = true
 						`.pipe(Effect.orDie)
 						if ((alreadyConnected[0]?.count ?? 0) > 0) {
@@ -2418,7 +2448,7 @@ export class EmailService extends Context.Service<EmailService>()(
 
 						const encrypted = crypto.encryptPassword({
 							inboxId,
-							plain: input.password,
+							plain: password,
 						})
 
 						// Probe IMAP LOGIN + SMTP EHLO/AUTH against the supplied
@@ -2430,14 +2460,14 @@ export class EmailService extends Context.Service<EmailService>()(
 						const probe = yield* transport
 							.probe({
 								inboxId,
-								imapHost: input.imapHost,
+								imapHost,
 								imapPort: input.imapPort,
 								imapSecurity: input.imapSecurity,
-								smtpHost: input.smtpHost,
+								smtpHost,
 								smtpPort: input.smtpPort,
 								smtpSecurity: input.smtpSecurity,
-								username: input.username,
-								password: input.password,
+								username,
+								password,
 							})
 							.pipe(
 								Effect.match({
@@ -2445,6 +2475,7 @@ export class EmailService extends Context.Service<EmailService>()(
 										({
 											status: 'connected',
 											detail: null,
+											reason: null,
 										}) as const,
 									onFailure: err =>
 										({
@@ -2453,6 +2484,7 @@ export class EmailService extends Context.Service<EmailService>()(
 													? ('auth_failed' as const)
 													: ('connect_failed' as const),
 											detail: err.detail ?? null,
+											reason: err.reason,
 										}) as const,
 								}),
 							)
@@ -2476,20 +2508,20 @@ export class EmailService extends Context.Service<EmailService>()(
 									INSERT INTO inboxes ${sql.insert({
 										id: inboxId,
 										organizationId: currentOrg.id,
-										email: input.email,
+										email: address,
 										displayName: input.displayName ?? null,
 										description: input.description ?? null,
 										ownerUserId,
 										isDefault,
 										isPrivate: input.isPrivate ?? false,
 										active: true,
-										imapHost: input.imapHost,
+										imapHost,
 										imapPort: input.imapPort,
 										imapSecurity: input.imapSecurity,
-										smtpHost: input.smtpHost,
+										smtpHost,
 										smtpPort: input.smtpPort,
 										smtpSecurity: input.smtpSecurity,
-										username: input.username,
+										username,
 										passwordCiphertext: encrypted.ciphertext,
 										passwordNonce: encrypted.nonce,
 										passwordTag: encrypted.tag,
@@ -2519,10 +2551,19 @@ export class EmailService extends Context.Service<EmailService>()(
 						yield* Effect.logInfo('Inbox created').pipe(
 							Effect.annotateLogs({
 								event: 'inbox.created',
-								email: input.email,
+								inboxId,
 								shared: ownerUserId === null,
 							}),
 						)
+
+						// Only the sort of failure travels: the mail server's own words
+						// are about somebody's account.
+						yield* recordFacts({
+							'inbox.probe.outcome': probe.status,
+							...(probe.reason !== null && {
+								'inbox.probe.reason': probe.reason,
+							}),
+						})
 						return yield* decodeInbox(rows[0]!).pipe(Effect.orDie)
 					}),
 
@@ -2616,6 +2657,15 @@ export class EmailService extends Context.Service<EmailService>()(
 							}
 						}
 
+						// Everything that turns a save away is settled before anything is
+						// written, because a refusal raised later can still leave the
+						// surrounding transaction committing what came before it.
+						if (patch.password !== undefined && patch.password.trim() === '') {
+							return yield* new BadRequest({
+								message: 'A password cannot be blank',
+							})
+						}
+
 						// Who a mailbox belongs to is not written from here. The column
 						// is out of this role's reach, so the change goes through a
 						// routine that re-checks the rules for itself — the database
@@ -2648,23 +2698,26 @@ export class EmailService extends Context.Service<EmailService>()(
 						if (patch.active !== undefined)
 							sets.push(sql`active = ${patch.active}`)
 						if (patch.imapHost !== undefined)
-							sets.push(sql`imap_host = ${patch.imapHost}`)
+							sets.push(sql`imap_host = ${patch.imapHost.trim()}`)
 						if (patch.imapPort !== undefined)
 							sets.push(sql`imap_port = ${patch.imapPort}`)
 						if (patch.imapSecurity !== undefined)
 							sets.push(sql`imap_security = ${patch.imapSecurity}`)
 						if (patch.smtpHost !== undefined)
-							sets.push(sql`smtp_host = ${patch.smtpHost}`)
+							sets.push(sql`smtp_host = ${patch.smtpHost.trim()}`)
 						if (patch.smtpPort !== undefined)
 							sets.push(sql`smtp_port = ${patch.smtpPort}`)
 						if (patch.smtpSecurity !== undefined)
 							sets.push(sql`smtp_security = ${patch.smtpSecurity}`)
-						if (patch.username !== undefined)
-							sets.push(sql`username = ${patch.username}`)
+						// Blank space says nothing about what the login name should
+						// become, so the stored one is left alone rather than replaced by
+						// one nothing can sign in with.
+						if (patch.username !== undefined && patch.username.trim() !== '')
+							sets.push(sql`username = ${patch.username.trim()}`)
 						if (patch.password !== undefined) {
 							const encrypted = crypto.encryptPassword({
 								inboxId: id,
-								plain: patch.password,
+								plain: patch.password.trim(),
 							})
 							sets.push(sql`password_ciphertext = ${encrypted.ciphertext}`)
 							sets.push(sql`password_nonce = ${encrypted.nonce}`)
@@ -2692,7 +2745,7 @@ export class EmailService extends Context.Service<EmailService>()(
 						// touches metadata (e.g. display name) skips the probe.
 						const credentialsChanged =
 							patch.password !== undefined ||
-							patch.username !== undefined ||
+							(patch.username !== undefined && patch.username.trim() !== '') ||
 							patch.imapHost !== undefined ||
 							patch.imapPort !== undefined ||
 							patch.imapSecurity !== undefined ||

--- a/apps/server/src/services/inbox-health-probe.integration.test.ts
+++ b/apps/server/src/services/inbox-health-probe.integration.test.ts
@@ -96,11 +96,7 @@ describe('InboxHealthProbe', () => {
 	const readGrant = (id: string) =>
 		Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
-			const rows = yield* sql<{
-				grantStatus: string
-				grantLastError: string | null
-				grantLastSeenAt: Date | null
-			}>`
+			const rows = yield* sql<GrantRow>`
 				SELECT grant_status AS "grantStatus",
 				       grant_last_error AS "grantLastError",
 				       grant_last_seen_at AS "grantLastSeenAt"
@@ -174,7 +170,11 @@ describe('InboxHealthProbe', () => {
 					Effect.provide(
 						provideTestLayers(creds =>
 							Effect.fail(
-								new GrantAuthFailed({ inboxId: creds.inboxId, detail }),
+								new GrantAuthFailed({
+									inboxId: creds.inboxId,
+									detail,
+									reason: 'invalid_credentials',
+								}),
 							),
 						),
 					),
@@ -208,7 +208,11 @@ describe('InboxHealthProbe', () => {
 					Effect.provide(
 						provideTestLayers(creds =>
 							Effect.fail(
-								new GrantConnectFailed({ inboxId: creds.inboxId, detail }),
+								new GrantConnectFailed({
+									inboxId: creds.inboxId,
+									detail,
+									reason: 'unreachable',
+								}),
 							),
 						),
 					),
@@ -275,7 +279,7 @@ describe('InboxHealthProbe', () => {
 
 	describe('over multiple iterations', () => {
 		it('should transition a recovered inbox from auth_failed to connected', async () => {
-			// GIVEN the inbox is on auth_failed (set by an earlier tick)
+			// GIVEN the inbox is on auth_failed, as an earlier tick would leave it
 			await Effect.runPromise(
 				Effect.gen(function* () {
 					const sql = yield* SqlClient.SqlClient

--- a/apps/server/src/services/inbox-health-probe.ts
+++ b/apps/server/src/services/inbox-health-probe.ts
@@ -116,11 +116,13 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 						password,
 					}
 
-					const result = yield* Effect.exit(transport.probe(creds))
-					const { state, detail, reason } =
-						result._tag === 'Success'
-							? ({ state: 'connected', detail: null, reason: null } as const)
-							: failureFacts(result.cause)
+					const { state, detail, reason } = yield* transport.probe(creds).pipe(
+						Effect.matchCause({
+							onSuccess: () =>
+								({ state: 'connected', detail: null, reason: null }) as const,
+							onFailure: failureFacts,
+						}),
+					)
 
 					yield* inServiceTransaction(sql`
 						UPDATE inboxes

--- a/apps/server/src/services/inbox-health-probe.ts
+++ b/apps/server/src/services/inbox-health-probe.ts
@@ -1,6 +1,13 @@
 import { Cause, Config, Context, Effect, Layer, Schedule } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
+import type {
+	GrantAuthFailed,
+	GrantConnectFailed,
+	GrantFailureReason,
+} from '@batuda/controllers'
+import { boundedCause } from '@batuda/observability'
+
 import { CredentialCrypto } from './credential-crypto.js'
 import {
 	type DecryptedCreds,
@@ -20,11 +27,14 @@ interface ActiveInboxRow {
 	readonly passwordCiphertext: Uint8Array
 	readonly passwordNonce: Uint8Array
 	readonly passwordTag: Uint8Array
+	readonly organizationId: string
 }
 
 type GrantState = 'connected' | 'auth_failed' | 'connect_failed'
 
-const stateForFailure = (tag: string): Exclude<GrantState, 'connected'> =>
+const stateForFailure = (
+	tag: GrantAuthFailed['_tag'] | GrantConnectFailed['_tag'],
+): Exclude<GrantState, 'connected'> =>
 	tag === 'GrantAuthFailed' ? 'auth_failed' : 'connect_failed'
 
 export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
@@ -35,6 +45,56 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 			const transport = yield* MailTransport
 			const crypto = yield* CredentialCrypto
 			const intervalSec = yield* Config.int('EMAIL_HEALTH_PROBE_INTERVAL_SEC')
+
+			// A transaction per piece of database work, so no connection is held
+			// open while a mail server takes its time. The role is set inside each
+			// one because it is released with the transaction that set it.
+			const inServiceTransaction = <A, E, R>(work: Effect.Effect<A, E, R>) =>
+				sql.withTransaction(
+					Effect.gen(function* () {
+						yield* sql`SET LOCAL ROLE app_service`
+						return yield* work
+					}),
+				)
+
+			const activeInboxes = inServiceTransaction(sql<ActiveInboxRow>`
+				SELECT
+					id,
+					imap_host          AS "imapHost",
+					imap_port          AS "imapPort",
+					imap_security      AS "imapSecurity",
+					smtp_host          AS "smtpHost",
+					smtp_port          AS "smtpPort",
+					smtp_security      AS "smtpSecurity",
+					username,
+					password_ciphertext AS "passwordCiphertext",
+					password_nonce      AS "passwordNonce",
+					password_tag        AS "passwordTag",
+					organization_id     AS "organizationId"
+				FROM inboxes
+				WHERE active = true
+			`)
+
+			// A defect leaves nothing in the cause to read, so it is reported as a
+			// connection that did not go through rather than guessed at.
+			const failureFacts = (
+				cause: Cause.Cause<GrantAuthFailed | GrantConnectFailed>,
+			): {
+				readonly state: Exclude<GrantState, 'connected'>
+				readonly detail: string | null
+				readonly reason: GrantFailureReason
+			} => {
+				const found = Cause.findErrorOption(cause)
+				if (found._tag === 'None') {
+					return { state: 'connect_failed', detail: null, reason: 'unknown' }
+				}
+				const error = found.value
+				return {
+					state: stateForFailure(error._tag),
+					detail: error.detail,
+					reason: error.reason,
+				}
+			}
 
 			const probeOne = (inbox: ActiveInboxRow) =>
 				Effect.gen(function* () {
@@ -57,62 +117,58 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 					}
 
 					const result = yield* Effect.exit(transport.probe(creds))
-					if (result._tag === 'Success') {
-						yield* sql`
-							UPDATE inboxes
-							SET grant_status = 'connected',
-							    grant_last_error = NULL,
-							    grant_last_seen_at = now()
-							WHERE id = ${inbox.id}
-						`
-						return
-					}
-					const failure = Cause.findErrorOption(result.cause)
-					const tag =
-						failure._tag === 'Some' &&
-						typeof failure.value === 'object' &&
-						failure.value !== null &&
-						'_tag' in failure.value
-							? (failure.value as { _tag: string })._tag
-							: 'GrantConnectFailed'
-					const detail =
-						failure._tag === 'Some' &&
-						typeof failure.value === 'object' &&
-						failure.value !== null &&
-						'detail' in failure.value
-							? ((failure.value as { detail?: string | null }).detail ?? null)
-							: null
-					yield* sql`
+					const { state, detail, reason } =
+						result._tag === 'Success'
+							? ({ state: 'connected', detail: null, reason: null } as const)
+							: failureFacts(result.cause)
+
+					yield* inServiceTransaction(sql`
 						UPDATE inboxes
-						SET grant_status = ${stateForFailure(tag)},
+						SET grant_status = ${state},
 						    grant_last_error = ${detail},
 						    grant_last_seen_at = now()
 						WHERE id = ${inbox.id}
-					`
-				})
+					`)
 
-			const tick = sql.withTransaction(
-				Effect.gen(function* () {
-					yield* sql`SET LOCAL ROLE app_service`
-					const rows = yield* sql<ActiveInboxRow>`
-						SELECT
-							id,
-							imap_host          AS "imapHost",
-							imap_port          AS "imapPort",
-							imap_security      AS "imapSecurity",
-							smtp_host          AS "smtpHost",
-							smtp_port          AS "smtpPort",
-							smtp_security      AS "smtpSecurity",
-							username,
-							password_ciphertext AS "passwordCiphertext",
-							password_nonce      AS "passwordNonce",
-							password_tag        AS "passwordTag"
-						FROM inboxes
-						WHERE active = true
-					`
-					yield* Effect.forEach(rows, probeOne, { concurrency: 4 })
-				}),
-			)
+					// Nobody is waiting on this check, so it gets a line of its own.
+					// Only the sort of failure goes down: never the mailbox address,
+					// and never the words the mail server wrote about somebody's
+					// account. The host names the provider without naming anybody.
+					const facts = {
+						event: 'inbox.probed',
+						inboxId: inbox.id,
+						'org.id': inbox.organizationId,
+						'imap.host': inbox.imapHost,
+						'imap.port': inbox.imapPort,
+						'inbox.probe.outcome': state,
+						...(reason !== null && { 'inbox.probe.reason': reason }),
+					}
+					// A check that passed is only the poller saying it is still
+					// polling; one that did not is for the mailbox owner to fix.
+					yield* state === 'connected'
+						? Effect.logDebug('inbox.probed').pipe(Effect.annotateLogs(facts))
+						: Effect.logWarning('inbox.probed').pipe(Effect.annotateLogs(facts))
+				}).pipe(
+					// One mailbox whose answer cannot be written down must not cost the
+					// others their turn. A lost permission or a key that fails to
+					// decrypt is a fault in the poller rather than in the mailbox, so
+					// it goes down as an error. Shutting down skips this entirely: a
+					// fiber stopped from outside unwinds without running it.
+					Effect.catchCause(cause =>
+						Effect.logError('inbox.probe_unrecorded').pipe(
+							Effect.annotateLogs({
+								event: 'inbox.probe_unrecorded',
+								inboxId: inbox.id,
+								cause: boundedCause(cause),
+							}),
+						),
+					),
+				)
+
+			const tick = Effect.gen(function* () {
+				const rows = yield* activeInboxes
+				yield* Effect.forEach(rows, probeOne, { concurrency: 4 })
+			})
 
 			return { tick, intervalSec } as const
 		}),

--- a/apps/server/src/services/mail-transport-probe.test.ts
+++ b/apps/server/src/services/mail-transport-probe.test.ts
@@ -1,0 +1,443 @@
+import { EventEmitter } from 'node:events'
+
+import { Cause, Effect, Exit, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GrantAuthFailed, GrantConnectFailed } from '@batuda/controllers'
+
+import type { DecryptedCreds } from './mail-transport'
+
+// The two mail libraries stand in for real servers here, because the things
+// worth testing are the ones a real server cannot be asked for on demand: a
+// connection that never answers, a sign-in that is refused, a socket that
+// fails long after anybody was waiting for it.
+
+interface Behaviour {
+	imapConnect: () => Promise<unknown>
+	imapLogout: () => Promise<unknown>
+	imapClose: () => void
+	smtpVerify: () => Promise<unknown>
+	smtpClose: () => void
+}
+
+interface Budget {
+	readonly connectionTimeout: number
+	readonly greetingTimeout: number
+	readonly socketTimeout: number
+}
+
+let behaviour: Behaviour
+let imapClients: Array<FakeImapFlow>
+let smtpTransports: Array<FakeSmtpTransport>
+let closed: Array<'imap' | 'smtp'>
+// What each library was actually constructed with. Without this the timeouts
+// are invisible to every test here, and dropping them would stay green.
+let imapOptions: Array<Budget>
+let smtpOptions: Array<Budget>
+
+// A real EventEmitter, not a stand-in with a no-op `on`: the crash this
+// guards against is Node throwing when 'error' is emitted and nothing is
+// listening, so a fake that cannot throw would assert nothing.
+class FakeImapFlow extends EventEmitter {
+	readonly connect = vi.fn(() => behaviour.imapConnect())
+	readonly logout = vi.fn(() => behaviour.imapLogout())
+	readonly close = vi.fn(() => {
+		closed.push('imap')
+		behaviour.imapClose()
+	})
+
+	constructor(options: Budget) {
+		super()
+		imapOptions.push(options)
+		imapClients.push(this)
+	}
+}
+
+class FakeSmtpTransport {
+	readonly verify = vi.fn(() => behaviour.smtpVerify())
+	readonly sendMail = vi.fn(() =>
+		Promise.resolve({
+			message: Buffer.from('compiled message'),
+			messageId: '<sent@test.local>',
+		}),
+	)
+	readonly close = vi.fn(() => {
+		closed.push('smtp')
+		behaviour.smtpClose()
+	})
+}
+
+vi.mock('imapflow', () => ({ ImapFlow: FakeImapFlow }))
+
+vi.mock('nodemailer', () => ({
+	default: {
+		createTransport: (options: Budget & { streamTransport?: boolean }) => {
+			// The compiler that turns a message into bytes opens no connection,
+			// so it carries no budget and does not belong in this list.
+			if (options.streamTransport !== true) smtpOptions.push(options)
+			const transport = new FakeSmtpTransport()
+			smtpTransports.push(transport)
+			return transport
+		},
+	},
+}))
+
+const { MailTransport } = await import('./mail-transport')
+
+const creds: DecryptedCreds = {
+	inboxId: 'inbox-under-test',
+	imapHost: 'imap.test.local',
+	imapPort: 993,
+	imapSecurity: 'tls',
+	smtpHost: 'smtp.test.local',
+	smtpPort: 465,
+	smtpSecurity: 'tls',
+	username: 'someone@test.local',
+	password: 'app-pw',
+}
+
+const probe = () => Effect.runSync(MailTransport.make).probe(creds)
+
+const send = () =>
+	Effect.runSync(MailTransport.make).send(creds, {
+		from: 'someone@test.local',
+		to: ['somebody@example.test'],
+		subject: 'a message',
+		text: 'hello',
+	})
+
+const extractFailure = <E>(cause: Cause.Cause<E>): E | null => {
+	for (const reason of cause.reasons) {
+		if (Cause.isFailReason(reason)) return reason.error
+	}
+	return null
+}
+
+const failureOf = async (): Promise<GrantAuthFailed | GrantConnectFailed> => {
+	const exit = await Effect.runPromise(Effect.exit(probe()))
+	if (Exit.isSuccess(exit)) throw new Error('expected the probe to fail')
+	const failure = extractFailure(exit.cause)
+	if (failure === null) throw new Error('expected a typed failure')
+	return failure
+}
+
+const rejectWith = (fields: Record<string, unknown>) => () =>
+	Promise.reject(Object.assign(new Error('probe fixture'), fields))
+
+beforeEach(() => {
+	imapClients = []
+	smtpTransports = []
+	imapOptions = []
+	smtpOptions = []
+	closed = []
+	behaviour = {
+		imapConnect: () => Promise.resolve(),
+		imapLogout: () => Promise.resolve(),
+		imapClose: () => {},
+		smtpVerify: () => Promise.resolve(),
+		smtpClose: () => {},
+	}
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe('MailTransport.probe', () => {
+	describe('when a caller is waiting on the answer', () => {
+		it('should bound both legs without cutting a slow server short', async () => {
+			// GIVEN a mailbox being probed, which somebody is waiting on
+			// WHEN both legs are opened
+			await Effect.runPromise(probe())
+
+			// THEN no timer is left at the library's own generous default, or a
+			// probe could outlast the person watching for it
+			const budgets = [...imapOptions, ...smtpOptions]
+			expect(budgets).toHaveLength(2)
+			for (const budget of budgets) {
+				expect(budget.connectionTimeout).toBeLessThanOrEqual(15_000)
+				expect(budget.greetingTimeout).toBeLessThanOrEqual(16_000)
+				expect(budget.socketTimeout).toBeLessThanOrEqual(15_000)
+
+				// AND the timer that decides a server is dead rather than merely
+				// busy is not cut below what the mail libraries chose for
+				// themselves: an unreachable verdict refuses the mailbox every
+				// send until a later check clears it
+				expect(budget.greetingTimeout).toBeGreaterThanOrEqual(10_000)
+			}
+		})
+	})
+
+	describe('when a message goes out', () => {
+		it('should not give the send the room an upload gets', async () => {
+			// GIVEN a mailbox with a message to send
+			// WHEN the message goes out
+			await Effect.runPromise(send())
+
+			// THEN the connection that carried it is held to the send's own
+			// budget. A socket timer as loose as the one filing a sent copy
+			// gets would let a server keep a message the client had given up
+			// waiting for, and the retry above would send it a second time
+			expect(smtpOptions).toHaveLength(1)
+			expect(smtpOptions[0]?.socketTimeout).toBeLessThanOrEqual(15_000)
+		})
+	})
+
+	describe('when both legs answer', () => {
+		it('should succeed, and close what it opened', async () => {
+			// GIVEN a mail server that accepts the credentials on both protocols
+			// WHEN the mailbox is probed
+			await Effect.runPromise(probe())
+
+			// THEN the IMAP session is ended politely before the socket is
+			// dropped, and neither connection is left open
+			expect(imapClients[0]?.logout).toHaveBeenCalledTimes(1)
+			expect(closed).toEqual(['imap', 'smtp'])
+		})
+	})
+
+	describe('when IMAP refuses the credentials', () => {
+		beforeEach(() => {
+			behaviour.imapConnect = rejectWith({
+				authenticationFailed: true,
+				response: 'NO [AUTHENTICATIONFAILED] Invalid login or password',
+			})
+		})
+
+		it('should fail as a credential problem', async () => {
+			// GIVEN a mailbox whose password the server rejects
+			// WHEN it is probed
+			const failure = await failureOf()
+
+			// THEN the failure says the credentials were wrong, not that the
+			// server was unreachable
+			expect(failure._tag).toBe('GrantAuthFailed')
+			expect(failure.reason).toBe('invalid_credentials')
+			expect(failure.detail).toContain('Invalid login or password')
+		})
+
+		it('should read the status word the server sent, not only the flag', async () => {
+			// GIVEN a refusal carrying only the server's status word. imapflow
+			// sets both this and the flag above, so a test that goes in through
+			// the flag alone would pass with this branch deleted.
+			behaviour.imapConnect = rejectWith({
+				serverResponseCode: 'AUTHENTICATIONFAILED',
+				response: 'NO [AUTHENTICATIONFAILED] Invalid login or password',
+			})
+
+			// WHEN the mailbox is probed
+			const failure = await failureOf()
+
+			// THEN it is still read as the credentials being wrong
+			expect(failure._tag).toBe('GrantAuthFailed')
+			expect(failure.reason).toBe('invalid_credentials')
+		})
+
+		it('should close the IMAP connection and never open an SMTP one', async () => {
+			// GIVEN the same refusal
+			// WHEN it is probed
+			await failureOf()
+
+			// THEN the refused connection is handed back, and the second leg is
+			// never reached — so there is nothing there to close
+			expect(closed).toEqual(['imap'])
+			expect(smtpTransports).toHaveLength(0)
+		})
+	})
+
+	describe('when IMAP accepts and SMTP refuses the credentials', () => {
+		beforeEach(() => {
+			behaviour.smtpVerify = rejectWith({ code: 'EAUTH' })
+		})
+
+		it('should fail as a credential problem and close both connections', async () => {
+			// GIVEN a server that signs the mailbox in over IMAP but not SMTP
+			// WHEN it is probed
+			const failure = await failureOf()
+
+			// THEN the credentials are blamed, and both connections are closed
+			expect(failure._tag).toBe('GrantAuthFailed')
+			expect(failure.reason).toBe('invalid_credentials')
+			expect(closed).toEqual(['imap', 'smtp'])
+		})
+	})
+
+	describe('when SMTP answers a bare 535 with no code', () => {
+		it('should still read it as a credential problem', async () => {
+			// GIVEN a server that reports a refused sign-in only by its number
+			behaviour.smtpVerify = rejectWith({ responseCode: 535 })
+
+			// WHEN the mailbox is probed
+			const failure = await failureOf()
+
+			// THEN it is read the same way as a named refusal
+			expect(failure._tag).toBe('GrantAuthFailed')
+			expect(failure.reason).toBe('invalid_credentials')
+		})
+	})
+
+	describe('when the connection fails rather than the sign-in', () => {
+		// One row per group the code actually tells apart. The other members of
+		// each group take the same branch, so they would test nothing further.
+		it.each([
+			['ETIMEDOUT', 'timeout'],
+			['ENOTFOUND', 'dns'],
+			['ECONNREFUSED', 'unreachable'],
+			['ESOCKET', 'tls'],
+			['ERR_SSL_WRONG_VERSION_NUMBER', 'tls'],
+			['DEPTH_ZERO_SELF_SIGNED_CERT', 'tls'],
+			['SOMETHING_NEW', 'unknown'],
+		])('should read %s as %s', async (code, reason) => {
+			// GIVEN a connection that fails before any sign-in is attempted
+			behaviour.imapConnect = rejectWith({ code })
+
+			// WHEN the mailbox is probed
+			const failure = await failureOf()
+
+			// THEN the failure carries a reason that can be counted later,
+			// rather than only the sentence the library happened to use
+			expect(failure._tag).toBe('GrantConnectFailed')
+			expect(failure.reason).toBe(reason)
+		})
+
+		it('should read an error with no code at all as unknown', async () => {
+			// GIVEN a failure that says nothing about why
+			behaviour.imapConnect = () => Promise.reject(new Error('no code here'))
+
+			// WHEN the mailbox is probed
+			const failure = await failureOf()
+
+			// THEN it is recorded as unknown rather than guessed at
+			expect(failure.reason).toBe('unknown')
+		})
+	})
+
+	describe('when the server accepts the connection but never answers', () => {
+		it('should give up at the deadline and hand the connection back', async () => {
+			// GIVEN a server that holds the connection open and says nothing
+			behaviour.imapConnect = () => new Promise<never>(() => {})
+
+			// WHEN the mailbox is probed and the wait runs past the deadline
+			const exit = await Effect.runPromise(
+				Effect.gen(function* () {
+					const fiber = yield* Effect.forkChild(Effect.exit(probe()))
+					yield* TestClock.adjust('45 seconds')
+					return yield* Fiber.join(fiber)
+				}).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+			)
+
+			// THEN the probe gives up rather than waiting on a silent server
+			// forever
+			expect(Exit.isFailure(exit)).toBe(true)
+			const failure = Exit.isFailure(exit) ? extractFailure(exit.cause) : null
+			expect(failure?._tag).toBe('GrantConnectFailed')
+			expect(failure?.reason).toBe('timeout')
+
+			// AND the connection it was waiting on is closed, not orphaned
+			expect(closed).toEqual(['imap'])
+		})
+	})
+
+	describe('when closing a connection fails', () => {
+		it('should still report why the probe itself failed', async () => {
+			// GIVEN a probe that cannot reach SMTP, and a close that throws
+			behaviour.smtpVerify = rejectWith({ code: 'ECONNREFUSED' })
+			behaviour.smtpClose = () => {
+				throw new Error('close blew up')
+			}
+
+			// WHEN the mailbox is probed
+			const failure = await failureOf()
+
+			// THEN the reason the caller gets is the one that matters, not the
+			// trouble met while tidying up after it
+			expect(failure._tag).toBe('GrantConnectFailed')
+			expect(failure.reason).toBe('unreachable')
+		})
+
+		it('should still succeed when the probe itself went through', async () => {
+			// GIVEN a healthy mailbox whose IMAP connection throws on close
+			behaviour.imapClose = () => {
+				throw new Error('close blew up')
+			}
+
+			// WHEN it is probed
+			// THEN the mailbox is reported as working
+			await Effect.runPromise(probe())
+		})
+	})
+
+	describe('when the library closes the connection before reporting why', () => {
+		it('should blame what actually happened, not the closing', async () => {
+			// GIVEN a socket that dies mid-connect. imapflow tears the connection
+			// down first and rejects the call with its own "Unexpected close", so
+			// the reason is only ever delivered to the error listener.
+			behaviour.imapConnect = () =>
+				new Promise((_resolve, reject) => {
+					const client = imapClients[0]
+					client?.emit(
+						'error',
+						Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+					)
+					reject(
+						Object.assign(new Error('Unexpected close'), {
+							code: 'ClosedAfterConnectTLS',
+						}),
+					)
+				})
+			vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+			// WHEN the mailbox is probed
+			const failure = await failureOf()
+
+			// THEN the mailbox is reported as unreachable rather than as an
+			// unexplained close, which is the difference between a reason
+			// somebody can act on and one nobody can
+			expect(failure._tag).toBe('GrantConnectFailed')
+			expect(failure.reason).toBe('unreachable')
+		})
+	})
+
+	describe('when a connection fails after the probe has walked away', () => {
+		it('should not bring the process down', async () => {
+			// GIVEN a mailbox that has already been probed
+			const written = vi.spyOn(console, 'warn').mockImplementation(() => {})
+			await Effect.runPromise(probe())
+			const client = imapClients[0]
+
+			// WHEN the socket dies later and the client reports it the only way
+			// it can — by emitting 'error', which Node turns into a throw when
+			// nothing is listening
+			const emit = () =>
+				client?.emit(
+					'error',
+					Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+				)
+
+			// THEN nothing escapes, so the crash guard never sees it
+			expect(emit).not.toThrow()
+
+			// AND what gets written down is the sort of failure it was, not the
+			// words the server used about somebody's account
+			expect(written).toHaveBeenCalledTimes(1)
+			const line = String(written.mock.calls[0]?.[0])
+			const parsed = JSON.parse(line) as {
+				level: string
+				timestamp: string
+				annotations: Record<string, unknown>
+			}
+			expect(parsed.level).toBe('WARN')
+			expect(parsed.timestamp).toEqual(expect.any(String))
+			// Under `annotations`, the way the process's own logger writes every
+			// other event — loose at the top level it would be invisible to the
+			// queries that find them.
+			expect(parsed.annotations).toMatchObject({
+				event: 'inbox.imap_client_error',
+				inboxId: 'inbox-under-test',
+				reason: 'unreachable',
+			})
+			expect(line).not.toContain('socket hang up')
+		})
+	})
+})

--- a/apps/server/src/services/mail-transport.ts
+++ b/apps/server/src/services/mail-transport.ts
@@ -1,10 +1,14 @@
 import { Buffer } from 'node:buffer'
 
-import { Context, Effect, Layer } from 'effect'
+import { Context, DateTime, Effect, Layer } from 'effect'
 import { ImapFlow } from 'imapflow'
 import nodemailer from 'nodemailer'
 
-import { GrantAuthFailed, GrantConnectFailed } from '@batuda/controllers'
+import {
+	GrantAuthFailed,
+	GrantConnectFailed,
+	type GrantFailureReason,
+} from '@batuda/controllers'
 
 // ── Types the transport speaks in ─────────────────────────────
 
@@ -57,10 +61,8 @@ export interface SentResult {
 // ── Error-classification helpers ──────────────────────────────
 
 // nodemailer surfaces SMTP failures as Error objects with a numeric or
-// 5-char code on `.responseCode` / `.code`. We treat anything in the
-// 5xx auth family as auth_failed; anything that didn't get past the
-// socket as connect_failed; the rest as connect_failed too (caller can
-// differentiate via `detail`).
+// 5-char code on `.responseCode` / `.code`. `EAUTH` and 535 are the whole of
+// what counts as a refused sign-in; everything else did not get through.
 //
 // `detail` aggregates every nodemailer field we've seen carry useful
 // information so the persisted error string (and the test error
@@ -85,6 +87,58 @@ const formatSmtpDetail = (err: unknown): string | null => {
 	return parts.length === 0 ? null : parts.join(' ')
 }
 
+const TIMEOUT_CODES = new Set([
+	// Not a typo for each other: the mail sender spells it the first way, the
+	// mailbox reader the second.
+	'ETIMEDOUT',
+	'ETIMEOUT',
+	'CONNECT_TIMEOUT',
+	'GREETING_TIMEOUT',
+	// A server that stalls partway through securing a STARTTLS connection.
+	'UPGRADE_TIMEOUT',
+])
+const DNS_CODES = new Set(['ENOTFOUND', 'EAI_AGAIN'])
+const UNREACHABLE_CODES = new Set([
+	'ECONNREFUSED',
+	'ECONNRESET',
+	'ECONNECTION',
+	'EConnectionClosed',
+	'EHOSTUNREACH',
+	'ENETUNREACH',
+])
+// A refused certificate and a port that does not speak TLS read as a wrong
+// password unless they are named, and they arrive under several names:
+// nodemailer wraps its own as `ESOCKET`, Node's TLS layer reports its own.
+const TLS_CODES = new Set([
+	'ESOCKET',
+	'EPROTO',
+	'CERT_HAS_EXPIRED',
+	'DEPTH_ZERO_SELF_SIGNED_CERT',
+	'SELF_SIGNED_CERT_IN_CHAIN',
+	'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+	'ERR_TLS_CERT_ALTNAME_INVALID',
+])
+const isTlsCode = (code: string): boolean =>
+	TLS_CODES.has(code) ||
+	code.startsWith('ERR_TLS_') ||
+	code.startsWith('ERR_SSL_')
+
+// Only this fixed set is safe to count and write down anywhere; the mail
+// server's own words stay in `detail`.
+const reasonForCode = (code: string | undefined): GrantFailureReason => {
+	if (code === undefined) return 'unknown'
+	if (TIMEOUT_CODES.has(code)) return 'timeout'
+	if (DNS_CODES.has(code)) return 'dns'
+	if (UNREACHABLE_CODES.has(code)) return 'unreachable'
+	if (isTlsCode(code)) return 'tls'
+	return 'unknown'
+}
+
+const codeOf = (err: unknown): string | undefined =>
+	typeof err === 'object' && err !== null
+		? (err as { code?: string }).code
+		: undefined
+
 const classifySmtpError = (
 	err: unknown,
 	inboxId: string,
@@ -92,44 +146,141 @@ const classifySmtpError = (
 	const e = err as { code?: string; responseCode?: number }
 	const detail = formatSmtpDetail(err)
 	if (e?.code === 'EAUTH' || e?.responseCode === 535) {
-		return new GrantAuthFailed({ inboxId, detail })
+		return new GrantAuthFailed({
+			inboxId,
+			detail,
+			reason: 'invalid_credentials',
+		})
 	}
-	return new GrantConnectFailed({ inboxId, detail })
+	return new GrantConnectFailed({
+		inboxId,
+		detail,
+		reason: reasonForCode(e?.code),
+	})
 }
 
 const classifyImapError = (
 	err: unknown,
 	inboxId: string,
 ): GrantAuthFailed | GrantConnectFailed => {
+	// imapflow keeps the server's status word on `serverResponseCode`; `code`
+	// is where it puts what stopped the connection.
 	const e = err as {
 		authenticationFailed?: boolean
+		serverResponseCode?: string
 		code?: string
 	}
 	const detail = formatSmtpDetail(err)
-	if (e?.authenticationFailed === true || e?.code === 'AUTHENTICATIONFAILED') {
-		return new GrantAuthFailed({ inboxId, detail })
+	if (
+		e?.authenticationFailed === true ||
+		e?.serverResponseCode === 'AUTHENTICATIONFAILED'
+	) {
+		return new GrantAuthFailed({
+			inboxId,
+			detail,
+			reason: 'invalid_credentials',
+		})
 	}
-	return new GrantConnectFailed({ inboxId, detail })
+	return new GrantConnectFailed({
+		inboxId,
+		detail,
+		reason: reasonForCode(e?.code),
+	})
 }
 
 // ── Wire builders ─────────────────────────────────────────────
 
-const buildSmtpTransport = (creds: DecryptedCreds) =>
+// How long a send may wait. Short, because a send is retried three times on
+// top of this. The socket timer is looser: cutting a send short can leave the
+// server accepting a message the client stopped listening for, which the retry
+// then sends again.
+const SEND_BUDGET = {
+	connectionTimeout: 5_000,
+	greetingTimeout: 5_000,
+	socketTimeout: 15_000,
+} as const
+
+// A probe is more patient than a send, because failing one is expensive: a
+// mailbox that comes back unreachable is refused every send until a later
+// check clears it. So the wait for a server to say hello is no shorter than
+// the mail libraries allow themselves, since a busy server is slow at exactly
+// that and must not be read as a dead one. Getting the connection up is held
+// far tighter than they would: a handshake that slow is a host nobody reaches.
+const PROBE_BUDGET = {
+	connectionTimeout: 10_000,
+	greetingTimeout: 10_000,
+	socketTimeout: 15_000,
+} as const
+
+// Filing the copy of a message that has already gone out carries the whole
+// message, so it is given room to finish.
+const UPLOAD_BUDGET = {
+	connectionTimeout: 30_000,
+	greetingTimeout: 30_000,
+	socketTimeout: 300_000,
+} as const
+
+// The longest a probe may take, and the only bound on it: the timers above
+// fail a dead host in seconds, but the socket one measures silence and starts
+// again on every byte, so a server that dribbles out a reply forever is held
+// by nothing else. One slow leg can spend all of it and leave the other none.
+const PROBE_DEADLINE = '45 seconds'
+
+const buildSmtpTransport = (
+	creds: DecryptedCreds,
+	budget: typeof SEND_BUDGET | typeof PROBE_BUDGET | typeof UPLOAD_BUDGET,
+) =>
 	nodemailer.createTransport({
 		host: creds.smtpHost,
 		port: creds.smtpPort,
 		secure: creds.smtpSecurity === 'tls',
 		requireTLS: creds.smtpSecurity === 'starttls',
 		auth: { user: creds.username, pass: creds.password },
-		// 5s socket-level guard so a dead host fails the probe fast
-		// instead of hanging the request thread.
-		connectionTimeout: 5_000,
-		greetingTimeout: 5_000,
-		socketTimeout: 15_000,
+		...budget,
 	})
 
-const openImapClient = (creds: DecryptedCreds): ImapFlow =>
-	new ImapFlow({
+// imapflow tears the connection down before reporting why, and tearing down
+// rejects the call in flight with its own "Unexpected close", so the reason
+// only ever reaches the 'error' listener. Held weakly, so a dropped client
+// takes its entry with it.
+const lastClientError = new WeakMap<ImapFlow, unknown>()
+
+// imapflow's own name for "something closed this while you were waiting".
+const isClosedDuringCall = (err: unknown): boolean =>
+	(codeOf(err) ?? '').startsWith('ClosedAfterConnect')
+
+// Node throws when a client emits 'error' and nothing is listening, which
+// would take the whole process down long after whoever opened the client
+// walked away.
+const onImapClientError =
+	(client: ImapFlow, inboxId: string) =>
+	(error: unknown): void => {
+		lastClientError.set(client, error)
+		// Outside any fiber the logger is out of reach, so this goes straight to
+		// the process's error stream and no further — it is a last resort for a
+		// connection nobody is waiting on any more. A failure that happens while
+		// somebody is waiting travels back through the record above instead, and
+		// is the one that reaches the traces. Only the sort of failure goes down:
+		// the server's words are about somebody's account.
+		console.warn(
+			JSON.stringify({
+				level: 'WARN',
+				message: 'imap client error',
+				timestamp: DateTime.formatIso(DateTime.nowUnsafe()),
+				annotations: {
+					event: 'inbox.imap_client_error',
+					inboxId,
+					reason: reasonForCode(codeOf(error)),
+				},
+			}),
+		)
+	}
+
+const openImapClient = (
+	creds: DecryptedCreds,
+	budget: typeof SEND_BUDGET | typeof PROBE_BUDGET | typeof UPLOAD_BUDGET,
+): ImapFlow => {
+	const client = new ImapFlow({
 		host: creds.imapHost,
 		port: creds.imapPort,
 		secure: creds.imapSecurity === 'tls',
@@ -137,7 +288,14 @@ const openImapClient = (creds: DecryptedCreds): ImapFlow =>
 		// imapflow logs every protocol line at info — silence in prod
 		// so the structured Effect log isn't drowned in low-level chatter.
 		logger: false,
+		...budget,
 	})
+	client.on('error', onImapClientError(client, creds.inboxId))
+	return client
+}
+
+const realImapFailure = (client: ImapFlow, thrown: unknown): unknown =>
+	isClosedDuringCall(thrown) ? (lastClientError.get(client) ?? thrown) : thrown
 
 // ── Tag ───────────────────────────────────────────────────────
 
@@ -145,26 +303,60 @@ export class MailTransport extends Context.Service<MailTransport>()(
 	'MailTransport',
 	{
 		make: Effect.sync(() => {
+			// Closing is paired with opening, so a leg that fails — or one the
+			// deadline cuts short — still hands its connection back, and a close
+			// that raises cannot stand in for the reason the probe failed.
 			const probe = (creds: DecryptedCreds) =>
 				Effect.gen(function* () {
 					// IMAP first because IMAP rejects credentials more loudly
 					// than SMTP (some providers accept SMTP without auth probes).
-					const imap = openImapClient(creds)
-					yield* Effect.tryPromise({
-						try: () => imap.connect(),
-						catch: err => classifyImapError(err, creds.inboxId),
-					})
-					yield* Effect.promise(() => imap.logout()).pipe(
-						Effect.catchCause(() => Effect.void),
+					yield* Effect.acquireUseRelease(
+						Effect.sync(() => openImapClient(creds, PROBE_BUDGET)),
+						imap =>
+							Effect.gen(function* () {
+								yield* Effect.tryPromise({
+									try: () => imap.connect(),
+									catch: err =>
+										classifyImapError(
+											realImapFailure(imap, err),
+											creds.inboxId,
+										),
+								})
+								yield* Effect.promise(() => imap.logout()).pipe(
+									Effect.catchCause(() => Effect.void),
+								)
+							}),
+						imap =>
+							Effect.sync(() => imap.close()).pipe(
+								Effect.catchCause(() => Effect.void),
+							),
 					)
 
-					const smtp = buildSmtpTransport(creds)
-					yield* Effect.tryPromise({
-						try: () => smtp.verify(),
-						catch: err => classifySmtpError(err, creds.inboxId),
-					})
-					smtp.close()
-				})
+					yield* Effect.acquireUseRelease(
+						Effect.sync(() => buildSmtpTransport(creds, PROBE_BUDGET)),
+						smtp =>
+							Effect.tryPromise({
+								try: () => smtp.verify(),
+								catch: err => classifySmtpError(err, creds.inboxId),
+							}),
+						smtp =>
+							Effect.sync(() => smtp.close()).pipe(
+								Effect.catchCause(() => Effect.void),
+							),
+					)
+				}).pipe(
+					Effect.timeoutOrElse({
+						duration: PROBE_DEADLINE,
+						orElse: () =>
+							Effect.fail(
+								new GrantConnectFailed({
+									inboxId: creds.inboxId,
+									detail: null,
+									reason: 'timeout',
+								}),
+							),
+					}),
+				)
 
 			const send = (creds: DecryptedCreds, message: OutboundMessage) =>
 				Effect.gen(function* () {
@@ -212,7 +404,7 @@ export class MailTransport extends Context.Service<MailTransport>()(
 					const raw = compiled.message as Buffer
 					const messageId = compiled.messageId ?? ''
 
-					const transport = buildSmtpTransport(creds)
+					const transport = buildSmtpTransport(creds, SEND_BUDGET)
 					yield* Effect.tryPromise({
 						try: () =>
 							transport.sendMail({
@@ -235,39 +427,54 @@ export class MailTransport extends Context.Service<MailTransport>()(
 					} satisfies SentResult
 				})
 
+			// Paired the same way as in the probe, and the message has already gone
+			// out over SMTP by the time this runs — a fault raised while filing the
+			// copy would report a send that worked as one that did not.
 			const appendToSent = (creds: DecryptedCreds, raw: Uint8Array) =>
-				Effect.gen(function* () {
-					const imap = openImapClient(creds)
-					yield* Effect.tryPromise({
-						try: () => imap.connect(),
-						catch: err => classifyImapError(err, creds.inboxId),
-					})
-					yield* Effect.tryPromise({
-						try: async () => {
-							// Ask the server which of its folders holds sent mail rather
-							// than guessing at the name: Gmail calls it
-							// "[Gmail]/Sent Mail" and Outlook "Sent Items". Dev mail
-							// catchers (GreenMail) and providers without one have no
-							// answer; skip the APPEND (the message already went out over
-							// SMTP) instead of erroring.
-							const boxes = await imap.list().catch(() => [])
-							const sentPath =
-								boxes.find(entry => entry.specialUse === '\\Sent')?.path ??
-								boxes.find(entry => entry.path === 'Sent')?.path
-							if (sentPath === undefined) return
-							const box = await imap
-								.getMailboxLock(sentPath, { readOnly: false })
-								.catch(() => null)
-							if (!box) return
-							try {
-								await imap.append(sentPath, Buffer.from(raw), ['\\Seen'])
-							} finally {
-								box.release()
-							}
-						},
-						catch: err => classifyImapError(err, creds.inboxId),
-					}).pipe(Effect.ensuring(Effect.promise(() => imap.logout())))
-				})
+				Effect.acquireUseRelease(
+					Effect.sync(() => openImapClient(creds, UPLOAD_BUDGET)),
+					imap =>
+						Effect.gen(function* () {
+							yield* Effect.tryPromise({
+								try: () => imap.connect(),
+								catch: err =>
+									classifyImapError(realImapFailure(imap, err), creds.inboxId),
+							})
+							yield* Effect.tryPromise({
+								try: async () => {
+									// Ask the server which of its folders holds sent mail rather
+									// than guessing at the name: Gmail calls it
+									// "[Gmail]/Sent Mail" and Outlook "Sent Items". Dev mail
+									// catchers (GreenMail) and providers without one have no
+									// answer; skip the APPEND (the message already went out over
+									// SMTP) instead of erroring.
+									const boxes = await imap.list().catch(() => [])
+									const sentPath =
+										boxes.find(entry => entry.specialUse === '\\Sent')?.path ??
+										boxes.find(entry => entry.path === 'Sent')?.path
+									if (sentPath === undefined) return
+									const box = await imap
+										.getMailboxLock(sentPath, { readOnly: false })
+										.catch(() => null)
+									if (!box) return
+									try {
+										await imap.append(sentPath, Buffer.from(raw), ['\\Seen'])
+									} finally {
+										box.release()
+									}
+								},
+								catch: err =>
+									classifyImapError(realImapFailure(imap, err), creds.inboxId),
+							})
+							yield* Effect.promise(() => imap.logout()).pipe(
+								Effect.catchCause(() => Effect.void),
+							)
+						}),
+					imap =>
+						Effect.sync(() => imap.close()).pipe(
+							Effect.catchCause(() => Effect.void),
+						),
+				)
 
 			return { probe, send, appendToSent } as const
 		}),

--- a/apps/server/src/services/mail-transport.ts
+++ b/apps/server/src/services/mail-transport.ts
@@ -323,13 +323,10 @@ export class MailTransport extends Context.Service<MailTransport>()(
 										),
 								})
 								yield* Effect.promise(() => imap.logout()).pipe(
-									Effect.catchCause(() => Effect.void),
+									Effect.ignoreCause,
 								)
 							}),
-						imap =>
-							Effect.sync(() => imap.close()).pipe(
-								Effect.catchCause(() => Effect.void),
-							),
+						imap => Effect.sync(() => imap.close()).pipe(Effect.ignoreCause),
 					)
 
 					yield* Effect.acquireUseRelease(
@@ -339,10 +336,7 @@ export class MailTransport extends Context.Service<MailTransport>()(
 								try: () => smtp.verify(),
 								catch: err => classifySmtpError(err, creds.inboxId),
 							}),
-						smtp =>
-							Effect.sync(() => smtp.close()).pipe(
-								Effect.catchCause(() => Effect.void),
-							),
+						smtp => Effect.sync(() => smtp.close()).pipe(Effect.ignoreCause),
 					)
 				}).pipe(
 					Effect.timeoutOrElse({
@@ -467,13 +461,10 @@ export class MailTransport extends Context.Service<MailTransport>()(
 									classifyImapError(realImapFailure(imap, err), creds.inboxId),
 							})
 							yield* Effect.promise(() => imap.logout()).pipe(
-								Effect.catchCause(() => Effect.void),
+								Effect.ignoreCause,
 							)
 						}),
-					imap =>
-						Effect.sync(() => imap.close()).pipe(
-							Effect.catchCause(() => Effect.void),
-						),
+					imap => Effect.sync(() => imap.close()).pipe(Effect.ignoreCause),
 				)
 
 			return { probe, send, appendToSent } as const

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -53,6 +53,9 @@ Timestamps and trace ids are added by the framework.
 | `email.sent`                   | Outbound email                                             |
 | `email.received`               | Inbound reply                                              |
 | `email.failed`                 | Email delivery failed                                      |
+| `inbox.created`                | A mailbox was connected                                    |
+| `inbox.probed`                 | A mailbox check that did not pass (a clean one is `debug`) |
+| `inbox.probe_unrecorded`       | A mailbox was checked but the answer could not be stored   |
 | `webhook.fired`                | Webhook fan-out triggered                                  |
 | `webhook.failed`               | Webhook delivery failed                                    |
 | `page.published`               | Sales page made public                                     |

--- a/packages/controllers/src/errors.ts
+++ b/packages/controllers/src/errors.ts
@@ -103,16 +103,39 @@ export class InboxInactive extends Schema.TaggedErrorClass<InboxInactive>()(
 	{ inboxId: Schema.String },
 ) {}
 
+/**
+ * Why a probe did not go through, as a fixed set rather than the words the
+ * mail server used. Safe to count and to write down anywhere, since it carries
+ * nothing the server said about the account — `detail` keeps those words.
+ */
+export const GrantFailureReason = Schema.Literals([
+	'invalid_credentials',
+	'timeout',
+	'dns',
+	'tls',
+	'unreachable',
+	'unknown',
+])
+export type GrantFailureReason = typeof GrantFailureReason.Type
+
 /** IMAP/SMTP probe rejected the credentials. Returned as 409. */
 export class GrantAuthFailed extends Schema.TaggedErrorClass<GrantAuthFailed>()(
 	'GrantAuthFailed',
-	{ inboxId: Schema.String, detail: Schema.NullOr(Schema.String) },
+	{
+		inboxId: Schema.String,
+		detail: Schema.NullOr(Schema.String),
+		reason: GrantFailureReason,
+	},
 ) {}
 
 /** IMAP/SMTP probe could not reach the server. Returned as 409. */
 export class GrantConnectFailed extends Schema.TaggedErrorClass<GrantConnectFailed>()(
 	'GrantConnectFailed',
-	{ inboxId: Schema.String, detail: Schema.NullOr(Schema.String) },
+	{
+		inboxId: Schema.String,
+		detail: Schema.NullOr(Schema.String),
+		reason: GrantFailureReason,
+	},
 ) {}
 
 /** Inbox grant is in a non-`connected` state. Returned as 409. */

--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -11,6 +11,7 @@ export {
 	Forbidden,
 	GrantAuthFailed,
 	GrantConnectFailed,
+	GrantFailureReason,
 	GrantUnavailable,
 	InboxInactive,
 	InsufficientBudget,


### PR DESCRIPTION
## What

Connecting a mailbox to Infomaniak kept failing with "invalid login or password" even though the password was right. The cause turned out to be invisible whitespace: a password copied from a provider's page brings a trailing space or newline with it, and the mail server counts that as part of what it was given. Nothing on the path trimmed it, and nothing recorded why the sign-in was refused — I only found the real error by reading it out of the database by hand.

This fixes that, and hardens the rest of the path I found while chasing it. It lives in the email side of the server (`server`), with one small change in the internal web app (`internal`).

## Changes

Touches: the mailbox connection check itself, the two service calls that connect and edit a mailbox, the recurring background health check that re-tests every mailbox, and the shared error types those all answer with.

- **Whitespace is trimmed off every credential** before it is stored or sent, so a pasted password works. I reproduced the original failure against a real mail server: `"secret-pw\n  "` gives exactly the `invalid_credentials` the production mailbox shows, and the trimmed form connects.
- **The check can no longer run unbounded.** The reading half (IMAP) was left on the library's own defaults — up to 90 seconds to give up on a host that goes nowhere. It now has its own time limits and an overall deadline, and closes both connections when it runs out. Measured against an unroutable address: 90s worst case becomes 10s.
- **A connection that fails on its own is now heard.** Node turns an unheard connection error into a crash, and this file attached no listener at all, so a mailbox checked minutes earlier could take the server down. The mail worker already learned this; the server never had.
- **Every reason to refuse a save is settled before anything is written.** A save that was turned away could still have handed the mailbox to a different owner first — see the Review guide, this is the subtle one.
- **The background health check no longer holds a database connection** while it waits on somebody else's mail server. It reads, contacts, and writes in separate short transactions.
- **A refused sign-in is now told apart from an unreachable server.** The old check read a field the mail library never fills in, so a wrong password looked like a dead host.

## Impact

- **The shape of an error changes.** Both mailbox errors — the one for a refused sign-in and the one for an unreachable server — now carry a fixed `reason` code (one of six words like `invalid_credentials` or `timeout`) alongside the mail server's own wording, which was already there. These are returned as HTTP 409 and as tool results over MCP, and `packages/controllers` is consumed by the internal app's typed client, so the new field reaches the frontend. Nothing was removed or renamed.
- **Both surfaces get the behaviour.** The changes are in the shared service, so the web app and MCP tool callers behave identically.
- **No database change.** No migration, no new column, so nothing has to be applied before the server tag.
- **Nothing touching which organisation can see what (row-level security).** The background check runs under the same database role as before (`app_service`), just in several short transactions instead of one long one; the role is re-set inside each, since it is released along with the transaction that set it.
- **No new environment variables**, so production needs no config change to boot.
- **Timing.** A mailbox pointed at a dead host now fails in about 10 seconds instead of up to 90. In the other direction, the check is deliberately *more* patient about a slow greeting than my first draft was — see the Review guide.

## Review guide

Start with `apps/server/src/services/mail-transport.ts`; it carries most of the change. The rest follows from it.

**The subtle one — read this before the diff.** In `updateInbox` I moved a refusal above the mailbox handover. It looks unnecessary, because a failed request rolls its transaction back. On the web path that is true. On the MCP path it is not: the tool layer turns the refusal into a defect, and `safe-toolkit` catches that defect and answers with an ordinary "this is an error" tool result — which is a *success* as far as the surrounding transaction is concerned, so it commits what came before. The transaction is opened outermost in `apps/server/src/mcp/http.ts:320` and the defect-catch sits inside it at `apps/server/src/mcp/safe-toolkit.ts:199`. My own security review pass got this wrong by reading `withTransaction` in isolation, so it is worth a careful look; if you read it differently, say so.

**A decision you might overrule.** I gave the check its own timeout budget, more patient than the one a send uses: 10 seconds to connect and 10 to greet, against a send's 5 and 5. The reason is that failing a check is expensive — a mailbox marked unreachable is refused every send until a later check clears it (`email.ts:968`) — and both mail libraries pick 10–16 seconds for the greeting themselves. My first draft used 5 and would have written off a busy server. A test now pins the floor as well as the ceiling.

**Two things I could not close.** One integration file failed once in the first of four full runs and I could not name it; three later full runs and three targeted runs of the suites I touched were all clean, so I have no evidence it is mine and none that it isn't. And the Snyk scanning tool is not available in this session, so the new code has not been through it.

Skip-able: the test files are mechanical, `docs/observability.md` is four table rows, and the third commit is a pure idiom swap — five hand-rolled "swallow whatever went wrong" handlers become Effect's own `ignoreCause`, and one `Exit` fold becomes `matchCause`. One detail in it is worth a glance though: plain `ignore` would have been wrong, because it lets a thrown error through and closing a connection throws rather than failing.

## Screenshots

> Screenshots skipped (approved): the only change in the web app is which fields the edit form submits. Nothing renders differently, so a screenshot would show a dialog identical to the one on `main`. Both the create and the edit path are covered by integration tests instead.

## Tests

Twenty-one new unit tests for the connection check (`mail-transport-probe.test.ts`), driving the two mail libraries through stand-ins so the cases a real server cannot be asked for on demand — a connection that never answers, a socket that fails after everyone stopped waiting — are actually exercised. Integration cases for the trimming on both the create and edit paths, and for the refusal-before-write ordering. Four of the new assertions were mutation-checked: I broke the code each one covers and confirmed the test fails.

## Verification

Everything below I ran on this branch, rebased onto current `main`:

- `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test` (1060 passing), `pnpm test:integration` (114 server files / 897 tests, plus the mail-worker suites), `pnpm -w build` — all green, run again after the rebase.
- **Against the live local mail server**, driving the changed code directly: correct credentials connect in 305 ms; an unroutable address fails in 10.0 s as `timeout`; a closed port fails in 2 ms as `unreachable`; and a password with a trailing newline reproduces the original `invalid_credentials`.
- All of the above re-run after the idiom swap in the third commit, including the live probe — same four results.
- The real IMAP round-trip suite (`MAIL_CATCHER_LIVE=1`) against the same mail server — 3 tests, all passing.
- `/code-review` at max effort plus an independent audit agent, a readability pass, and `/security-review`, which reported no findings.

## Deferred

A back-off, so a mailbox that keeps rejecting its credentials stops being retried every fifteen minutes. I built it and pulled it back out: it had fifteen unresolved findings across three writers and two readers, and it wants its own pass rather than riding along here. I will file it separately.

Also still true after this merges: the mailbox that started all this is still broken. This makes the path say why and stops it hanging or crashing; it does not fix the credential.
