### PR TITLE
perf: read only what a live frame needs from a run

### DIFF
--- a/apps/internal/src/components/research/run-vitals.tsx
+++ b/apps/internal/src/components/research/run-vitals.tsx
@@ -144,7 +144,12 @@ export function vitalsFromRun(run: {
 		Object.keys(run.findings as object).length > 0
 	return {
 		status: run.status,
-		phase: run.phase,
+		// The column counts the phases a run has finished, so the one it is working
+		// on is the next — the same reading the server's frame takes.
+		phase:
+			isTerminalResearchStatus(run.status) || run.phase === null
+				? null
+				: Math.min(run.phase + 1, 3),
 		// Never recorded on the row — see the run's live handler.
 		activeTool: null,
 		sourceCount: run.sourceCount,

--- a/apps/server/src/handlers/research.ts
+++ b/apps/server/src/handlers/research.ts
@@ -12,16 +12,13 @@ import {
 	SessionContext,
 	UnknownStack,
 } from '@batuda/controllers'
-import { isTerminalResearchStatus } from '@batuda/domain'
 import { resolveInstructions, resolveStackRef } from '@batuda/instructions'
 import { type CreateResearchInput, ResearchService } from '@batuda/research'
-import {
-	countFoundRows,
-	countPendingProposals,
-} from '@batuda/research/application/schemas'
+import { foundRowsField } from '@batuda/research/application/schemas'
 import { TimelineActivityService } from '@batuda/timeline'
 
 import { ResearchDefaults } from '../lib/research-defaults'
+import { goneFrame, liveFrame, toolFromEvent } from '../lib/research-live-frame'
 import { detachFromTransaction, resolveSystemOrg } from '../middleware/org'
 import { CompanyService } from '../services/companies'
 import { Geocoder } from '../services/geocoder'
@@ -57,101 +54,6 @@ const LIVE_CONNECTION_LIFETIME = '2 minutes'
 // reading is a database round trip. Waiting for the burst to settle turns a
 // tool call's pair of events — and a whole round's worth — into a single read.
 const LIVE_FRAME_SETTLE = '400 millis'
-
-/**
- * What the run last reached for, as its events report it. A call names the tool;
- * its result means nothing is running just then, so the name is taken back
- * rather than left standing over the phases that follow it.
- */
-const toolFromEvent = (
-	event: unknown,
-): { readonly tool: string | null } | null => {
-	const e = event as { type?: unknown; data?: unknown }
-	if (e.type === 'tool.result') return { tool: null }
-	if (e.type !== 'tool.called') return null
-	const tool = (e.data as { tool?: unknown } | null)?.tool
-	return typeof tool === 'string' ? { tool } : null
-}
-
-/**
- * Which phase a run's event says it is working on. The row cannot answer this:
- * it records the phases a run has *finished*, so reading it there names the one
- * before — a run gathering evidence reads as not started, and one writing the
- * brief reads as still extracting.
- */
-const phaseFromEvent = (event: unknown): number | null => {
-	const phase = (
-		(event as { data?: unknown }).data as { phase?: unknown } | null
-	)?.phase
-	return typeof phase === 'number' ? phase : null
-}
-
-// A number off a run row, or a stand-in when the column has nothing in it yet.
-// The run's own columns are typed, but `get` hands back the row widened by the
-// aggregates it selects alongside them, so each is read back on its own.
-const numberAt = (row: Record<string, unknown>, key: string): number =>
-	typeof row[key] === 'number' ? row[key] : 0
-
-const nullableNumberAt = (
-	row: Record<string, unknown>,
-	key: string,
-): number | null => (typeof row[key] === 'number' ? row[key] : null)
-
-/** Whether a run has written down what it found yet. */
-const hasFindings = (findings: unknown): boolean =>
-	findings !== null &&
-	typeof findings === 'object' &&
-	Object.keys(findings as object).length > 0
-
-/**
- * One frame of the live stream: the whole of where a run is, read off its row.
- *
- * Whole rather than a difference from the last frame, so a watcher that joins
- * partway through a run — or misses a frame — still shows the truth.
- *
- * `activeTool` and `phase` come from the run's own events, because the row does
- * not carry either while the run is working. A watcher that joined late has
- * missed the events that said so, which is why both can be null on a run that
- * is plainly busy — better than the row's answer, which is confidently wrong.
- */
-const liveFrame = (
-	run: unknown,
-	live: { readonly activeTool: string | null; readonly phase: number | null },
-) => {
-	const row = run as Record<string, unknown>
-	const status = typeof row['status'] === 'string' ? row['status'] : 'queued'
-	const findings = row['findings'] ?? null
-	const schemaName =
-		typeof row['schemaName'] === 'string' ? row['schemaName'] : null
-	// Nothing has been written down yet, so there is no count to give. Zero would
-	// be an answer — "it looked and found none" — and this is the other thing.
-	const counted = hasFindings(findings)
-	return {
-		status,
-		phase: live.phase,
-		activeTool: live.activeTool,
-		sourceCount: Array.isArray(row['sources']) ? row['sources'].length : null,
-		progressSteps: nullableNumberAt(row, 'progressSteps'),
-		costCents: numberAt(row, 'costCents'),
-		paidCostCents: numberAt(row, 'paidCostCents'),
-		budgetCents: numberAt(row, 'budgetCents'),
-		paidBudgetCents: numberAt(row, 'paidBudgetCents'),
-		foundCount: counted ? countFoundRows(schemaName, findings) : null,
-		pendingProposalCount: counted ? countPendingProposals(findings) : null,
-		done: isTerminalResearchStatus(status),
-	}
-}
-
-/**
- * The last thing a watcher is told about a run that has gone from under them —
- * soft-deleted, or no longer theirs to read. Marked finished so the page stops
- * waiting and asks the run for itself, which is what says it is gone.
- */
-const goneFrame = (frame: ReturnType<typeof liveFrame>) => ({
-	...frame,
-	status: 'deleted',
-	done: true,
-})
 
 // Same raw-Date handling for the waiting paid lookups.
 const PendingPaidActionRow = Schema.Struct({
@@ -311,36 +213,23 @@ export const ResearchLive = HttpApiBuilder.group(
 				)
 				.handle('live', _ =>
 					Effect.gen(function* () {
-						const run = yield* svc.get(_.params.id)
-						if (!run)
+						// Which organization is watching, and which list this kind of run
+						// fills with what it finds. Both are settled once: the reader was
+						// checked when they asked, and a run's schema never changes.
+						const currentOrg = yield* CurrentOrg
+						const { userId } = yield* SessionContext
+						const schemaName = yield* svc.runSchemaName(_.params.id)
+						if (schemaName === undefined)
 							return yield* new NotFound({
 								entity: 'research',
 								id: _.params.id,
 							})
+						const foundField = foundRowsField(schemaName)
 
-						// What the run is doing right now, as opposed to what it has
-						// finished. Only its events carry either, so both start empty and a
-						// watcher who joined late waits for the next one rather than being
-						// told the row's answer, which names the phase before.
-						const working = yield* Ref.make<{
-							readonly activeTool: string | null
-							readonly phase: number | null
-						}>({ activeTool: null, phase: null })
-
-						const opening = liveFrame(run, {
-							activeTool: null,
-							phase: null,
-						})
-						// Already over: say where it ended and close. Holding the
-						// connection open would leave the page waiting on a run that will
-						// never send anything again.
-						if (opening.done) return Stream.make(opening)
-
-						// Which organization is watching, taken while this handler still
-						// has it. Every later read needs it back (see `nextFrame`), and by
-						// then there is no request left to ask.
-						const currentOrg = yield* CurrentOrg
-						const { userId } = yield* SessionContext
+						// What the run last reached for. Held here because the row does not
+						// keep it; it is only ever said once, in the event announcing the
+						// call, and taken back when that call returns.
+						const activeTool = yield* Ref.make<string | null>(null)
 
 						// Reading the run again happens after this handler has returned:
 						// the frames are sent as the body streams, and the transaction that
@@ -355,16 +244,44 @@ export const ResearchLive = HttpApiBuilder.group(
 						// not a hiccup, and is told apart from a read that simply failed:
 						// without the distinction a deleted run left the connection open
 						// forever, re-reading a row it would never see again.
-						const nextFrame = Effect.gen(function* () {
-							const row = yield* svc
-								.get(_.params.id)
-								.pipe(
-									resolveSystemOrg(sql, currentOrg.id, { userId }),
-									detachFromTransaction(sql),
-								)
-							if (row === null) return goneFrame(opening)
-							return liveFrame(row, yield* Ref.get(working))
-						}).pipe(
+						// `reenter` is the whole difference between the opening read and
+						// every later one. The opening happens inside the request, which
+						// holds the reader's organization already; re-entering there would
+						// look it up a second time and read from outside the transaction it
+						// belongs to.
+						const readRow = (reenter: boolean) => {
+							const read = svc.liveSnapshot(_.params.id, foundField)
+							return reenter
+								? read.pipe(
+										resolveSystemOrg(sql, currentOrg.id, { userId }),
+										detachFromTransaction(sql),
+									)
+								: read
+						}
+
+						const readFrame = Effect.gen(function* () {
+							const row = yield* readRow(true)
+							return row === null
+								? null
+								: liveFrame(row, yield* Ref.get(activeTool))
+						})
+
+						const openingRow = yield* readRow(false)
+						const opening =
+							openingRow === null ? null : liveFrame(openingRow, null)
+						// Gone between the two reads, or over already: either way there is
+						// nothing left to watch, so say so once and close. Holding the
+						// connection open would leave the page waiting on a run that will
+						// never send anything again.
+						if (opening === null)
+							return yield* new NotFound({
+								entity: 'research',
+								id: _.params.id,
+							})
+						if (opening.done) return Stream.make(opening)
+
+						const nextFrame = readFrame.pipe(
+							Effect.map(frame => frame ?? goneFrame(opening)),
 							// A read that fails mid-run must not tear down a watcher's page;
 							// the next beat tries again.
 							Effect.catchCause(() => Effect.succeed(null)),
@@ -379,26 +296,21 @@ export const ResearchLive = HttpApiBuilder.group(
 						// has already said everything that beat would; dropping it saves
 						// a second read of the same row a moment later.
 						const beat = Stream.drop(Stream.tick(LIVE_FRAME_BEAT), 1)
-						// An event's payload goes no further than what the run is doing —
-						// the tool it reached for and the phase it is in, neither of which
-						// the row keeps. Everything else is read off the row afterwards, so
-						// each event becomes a bare nudge of the same shape the beat has.
+						// An event's payload goes no further than the tool it may name —
+						// the one thing the row does not keep. Everything else is read off
+						// the row afterwards, so each event becomes a bare nudge of the
+						// same shape the beat has.
 						const asks =
 							events === null
 								? beat
 								: Stream.merge(
 										beat,
-										Stream.mapEffect(events, event =>
-											Ref.update(working, held => {
-												const tool = toolFromEvent(event)
-												const phase = phaseFromEvent(event)
-												return {
-													activeTool:
-														tool === null ? held.activeTool : tool.tool,
-													phase: phase ?? held.phase,
-												}
-											}),
-										),
+										Stream.mapEffect(events, event => {
+											const named = toolFromEvent(event)
+											return named === null
+												? Effect.void
+												: Ref.set(activeTool, named.tool)
+										}),
 									)
 
 						return Stream.make(opening).pipe(

--- a/apps/server/src/lib/research-live-frame.test.ts
+++ b/apps/server/src/lib/research-live-frame.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import { goneFrame, liveFrame, toolFromEvent } from './research-live-frame'
+
+// A run partway through gathering, as the database holds it: one phase finished,
+// some spend, a few companies written down.
+const row = {
+	status: 'running',
+	phase: 1,
+	progressSteps: 7,
+	costCents: 42,
+	paidCostCents: 8,
+	budgetCents: 300,
+	paidBudgetCents: 100,
+	sourceCount: 12,
+	hasFindings: true,
+	foundCount: 5,
+	pendingProposalCount: 2,
+}
+
+describe('liveFrame', () => {
+	describe('when a run is working', () => {
+		it('should name the phase it is on, not the last one it finished', () => {
+			// GIVEN a running run whose column says one phase is behind it
+			// THEN the frame names the next one, because the column counts what is
+			// done — read straight, it had a run gathering evidence report as not
+			// started, and one writing the brief report as still extracting
+			expect(liveFrame({ ...row, phase: 0 }, null).phase).toBe(1)
+			expect(liveFrame({ ...row, phase: 1 }, null).phase).toBe(2)
+			expect(liveFrame({ ...row, phase: 2 }, null).phase).toBe(3)
+		})
+
+		it('should not count past the last phase there is', () => {
+			// GIVEN a row claiming more finished phases than the run has
+			// THEN the frame still names the final one rather than a fourth
+			expect(liveFrame({ ...row, phase: 3 }, null).phase).toBe(3)
+		})
+	})
+
+	describe('when a run has been asked for but not started', () => {
+		it('should name no phase at all', () => {
+			// GIVEN a queued run: nothing has picked it up, so no phase is finished
+			const frame = liveFrame({ ...row, status: 'queued', phase: 0 }, null)
+
+			// THEN it is on no phase — reading the column as "none done, so it must
+			// be on the first" had the page announce a run was gathering evidence
+			// before the engine had touched it
+			expect(frame.phase).toBeNull()
+			expect(frame.done).toBe(false)
+		})
+	})
+
+	describe('when a run is over', () => {
+		it('should name no phase and mark itself finished', () => {
+			// GIVEN each of the endings a run can reach
+			for (const status of [
+				'succeeded',
+				'succeeded_low_confidence',
+				'failed',
+				'cancelled',
+				'no_reliable_data',
+			]) {
+				const frame = liveFrame({ ...row, status, phase: 3 }, null)
+
+				// THEN there is no phase underway, and the watcher is told to stop
+				expect(frame.phase).toBeNull()
+				expect(frame.done).toBe(true)
+			}
+		})
+	})
+
+	describe('when a run has written nothing down yet', () => {
+		it('should give no counts rather than zero', () => {
+			// GIVEN a run whose findings are still empty, so the counts the database
+			// returned mean nothing
+			const frame = liveFrame(
+				{ ...row, hasFindings: false, foundCount: 0, pendingProposalCount: 0 },
+				null,
+			)
+
+			// THEN neither count is offered: zero would say it looked and found
+			// none, which is a different answer from not having looked yet
+			expect(frame.foundCount).toBeNull()
+			expect(frame.pendingProposalCount).toBeNull()
+		})
+	})
+
+	describe('when the run hunts for no list of its own', () => {
+		it('should pass the absence through rather than inventing a zero', () => {
+			// GIVEN a brief, which has no list of companies for the database to count
+			const frame = liveFrame({ ...row, foundCount: null }, null)
+
+			// THEN there is still nothing to report, even though it has findings
+			expect(frame.foundCount).toBeNull()
+			expect(frame.pendingProposalCount).toBe(2)
+		})
+	})
+
+	describe('when the run named a tool', () => {
+		it('should carry it, since the row does not keep it', () => {
+			// GIVEN the tool the last event announced
+			// THEN it rides along with the figures read off the row
+			expect(liveFrame(row, 'llm.generateText').activeTool).toBe(
+				'llm.generateText',
+			)
+			expect(liveFrame(row, null).activeTool).toBeNull()
+		})
+	})
+})
+
+describe('goneFrame', () => {
+	describe('when a run disappears under somebody watching it', () => {
+		it('should say it is gone and finished, and claim no phase', () => {
+			// GIVEN the last frame a watcher saw before the run was deleted
+			const frame = goneFrame(liveFrame(row, 'llm.generateText'))
+
+			// THEN it is marked gone and over, so the page stops waiting and asks the
+			// run for itself — and it is on no phase, having no work left
+			expect(frame.status).toBe('deleted')
+			expect(frame.done).toBe(true)
+			expect(frame.phase).toBeNull()
+		})
+	})
+})
+
+describe('toolFromEvent', () => {
+	describe('when the run reaches for a tool and finishes with it', () => {
+		it('should name it on the call and take the name back on the result', () => {
+			// GIVEN the pair of events one tool call produces
+			// THEN the call names the tool, and the result says nothing is running —
+			// left unhandled, the last tool stood over every phase that followed
+			expect(
+				toolFromEvent({
+					type: 'tool.called',
+					data: { tool: 'llm.generateText' },
+				}),
+			).toEqual({ tool: 'llm.generateText' })
+			expect(toolFromEvent({ type: 'tool.result', data: {} })).toEqual({
+				tool: null,
+			})
+		})
+	})
+
+	describe('when an event says nothing about a tool', () => {
+		it('should leave whatever is held alone', () => {
+			// GIVEN events of other kinds, and malformed ones
+			// THEN each declines to answer, so the caller keeps what it had
+			expect(toolFromEvent({ type: 'run.started', data: {} })).toBeNull()
+			expect(toolFromEvent({ type: 'tool.called', data: {} })).toBeNull()
+			expect(
+				toolFromEvent({ type: 'tool.called', data: { tool: 7 } }),
+			).toBeNull()
+			expect(toolFromEvent({ type: 'tool.called' })).toBeNull()
+			expect(toolFromEvent(null)).toBeNull()
+		})
+	})
+})

--- a/apps/server/src/lib/research-live-frame.ts
+++ b/apps/server/src/lib/research-live-frame.ts
@@ -1,0 +1,90 @@
+import { isTerminalResearchStatus } from '@batuda/domain'
+import type { ResearchLiveSnapshot } from '@batuda/research'
+
+/**
+ * What a watching page is told about a run, and how each figure is worked out.
+ *
+ * Kept apart from the route that sends it, and free of Effect, the database and
+ * the HTTP layer, because the rules here are the ones easiest to get quietly
+ * wrong — a phase read one behind, a zero standing in for an answer nobody has
+ * yet — and this way they can be read and tested on their own.
+ */
+
+// The one status that means a run is doing something right now. Queued is not
+// it — the run is waiting its turn — and every other status is an ending.
+const RUNNING_STATUS = 'running'
+
+/**
+ * What the run last reached for, as its events report it. A call names the tool;
+ * its result means nothing is running just then, so the name is taken back
+ * rather than left standing over the phases that follow it.
+ */
+export const toolFromEvent = (
+	event: unknown,
+): { readonly tool: string | null } | null => {
+	if (event === null || typeof event !== 'object') return null
+	const e = event as { type?: unknown; data?: unknown }
+	if (e.type === 'tool.result') return { tool: null }
+	if (e.type !== 'tool.called') return null
+	const tool = (e.data as { tool?: unknown } | null)?.tool
+	return typeof tool === 'string' ? { tool } : null
+}
+
+/**
+ * Which phase a run is working on, from the count of those it has finished.
+ *
+ * The column records phases *completed*: it reaches 1 when gathering ends and 2
+ * when extraction does, and only reaches 3 alongside a terminal status. So while
+ * a run is going, the one it is working on is the next one — reading the column
+ * itself named the phase before, and a run gathering evidence read as not
+ * started. Derived rather than carried in the events, so a page that joins a run
+ * halfway through knows it too.
+ */
+const workingPhase = (row: ResearchLiveSnapshot): number | null =>
+	// Only a run that is actually going is on a phase. A queued one has been
+	// asked for and not yet picked up, and reading its column as "none finished,
+	// so it must be on the first" had the page announce it was gathering evidence
+	// before anything had touched it.
+	row.status === RUNNING_STATUS ? Math.min(row.phase + 1, 3) : null
+
+/**
+ * One frame of the live stream: the whole of where a run is.
+ *
+ * Whole rather than a difference from the last frame, so a watcher that joins
+ * partway through a run — or misses a frame — still shows the truth.
+ *
+ * `activeTool` is the one figure the run's row does not keep, so it is carried
+ * from the events and is null on a page that joined after the run last reached
+ * for something. Everything else survives a reload.
+ */
+export const liveFrame = (
+	row: ResearchLiveSnapshot,
+	activeTool: string | null,
+) => ({
+	status: row.status,
+	phase: workingPhase(row),
+	activeTool,
+	sourceCount: row.sourceCount,
+	progressSteps: row.progressSteps,
+	costCents: row.costCents,
+	paidCostCents: row.paidCostCents,
+	budgetCents: row.budgetCents,
+	paidBudgetCents: row.paidBudgetCents,
+	// A run that has written nothing down has no count to give; zero would say
+	// it looked and found none, which is a different answer.
+	foundCount: row.hasFindings ? row.foundCount : null,
+	pendingProposalCount: row.hasFindings ? row.pendingProposalCount : null,
+	done: isTerminalResearchStatus(row.status),
+})
+
+/**
+ * The last thing a watcher is told about a run that has gone from under them —
+ * soft-deleted, or no longer theirs to read. Marked finished so the page stops
+ * waiting and asks the run for itself, which is what says it is gone.
+ */
+export const goneFrame = (frame: ReturnType<typeof liveFrame>) => ({
+	...frame,
+	status: 'deleted',
+	phase: null,
+	done: true,
+})

--- a/apps/server/src/services/research-live-snapshot.integration.test.ts
+++ b/apps/server/src/services/research-live-snapshot.integration.test.ts
@@ -1,0 +1,450 @@
+// The service reads these through Config when its layer is built, so they have
+// to be set before the import below pulls it in. Values are irrelevant here —
+// this suite only reads rows — but the layer refuses to build without them.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+process.env['RESEARCH_MAX_CONCURRENT_FIBERS_TOTAL'] ??= '4'
+process.env['RESEARCH_MAX_AGENT_STEPS'] ??= '6'
+process.env['RESEARCH_MAX_LOOP_PROMPT_TOKENS'] ??= '24000'
+// No run is started here, so keep the background sweep and beat out of the way.
+process.env['RESEARCH_HEARTBEAT_INTERVAL_SEC'] ??= '3600'
+process.env['RESEARCH_ORPHAN_SWEEP_INTERVAL_SEC'] ??= '3600'
+
+import { Effect, Layer } from 'effect'
+import type { LanguageModel } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	AgentLanguageModel,
+	ContactDiscovery,
+	ExtractLanguageModel,
+	MapProvider,
+	RegistryRouter,
+	ResearchEventSink,
+	ResearchService,
+	ScrapeProvider,
+	SearchProvider,
+	WriterLanguageModel,
+} from '@batuda/research'
+
+import { PgLive } from '../db/client.js'
+import { enterOrgScope } from '../middleware/org.js'
+
+// Every collaborator dies if it is reached. Reading where a run is should touch
+// the database and nothing else, so a stub that is called at all is the failure
+// this suite wants to hear about.
+const unreached = 'live snapshot must not reach a provider or a model'
+const dyingLlm: LanguageModel.Service = {
+	generateText: () => Effect.die(unreached) as never,
+	generateObject: () => Effect.die(unreached) as never,
+	streamText: () => Effect.die(unreached) as never,
+}
+
+const ResearchTestLive = ResearchService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			Layer.succeed(AgentLanguageModel)(dyingLlm),
+			Layer.succeed(ExtractLanguageModel)(dyingLlm),
+			Layer.succeed(WriterLanguageModel)(dyingLlm),
+			Layer.succeed(SearchProvider)(
+				SearchProvider.of({ search: () => Effect.die(unreached) }),
+			),
+			Layer.succeed(MapProvider)(
+				MapProvider.of({ map: () => Effect.die(unreached) }),
+			),
+			Layer.succeed(ScrapeProvider)(
+				ScrapeProvider.of({ scrape: () => Effect.die(unreached) }),
+			),
+			Layer.succeed(RegistryRouter)(
+				RegistryRouter.of({ lookup: () => Effect.die(unreached) }),
+			),
+			Layer.succeed(ContactDiscovery)({
+				discover: () => Effect.die(unreached),
+			}),
+			Layer.succeed(ResearchEventSink)(
+				ResearchEventSink.of({ fire: () => Effect.void }),
+			),
+		),
+	),
+	Layer.provideMerge(PgLive),
+)
+
+/**
+ * The one query behind every figure a watching page shows.
+ *
+ * It is worth its own suite because its rules live in SQL, where no type
+ * catches them: whether a run has written anything down yet, which list holds
+ * what it found, and which proposed changes are still waiting. A page reads
+ * this every few seconds for the length of a run, so a wrong answer here is a
+ * wrong answer everywhere.
+ */
+
+type Seeded = { readonly id: string }
+
+// Every row this suite writes carries the same query text, so the clean-up
+// needs no bookkeeping and removes exactly what the suite added.
+const SUITE_QUERY = 'live snapshot suite'
+
+// The organisation the rows belong to, and one they do not. Both are read as
+// whole rows because entering an organisation's scope needs its name and slug,
+// not just its id.
+type OrgRow = {
+	readonly id: string
+	readonly name: string
+	readonly slug: string
+}
+
+let org: OrgRow
+let otherOrg: OrgRow
+let userId: string
+
+const seedRun = (fields: {
+	readonly status: string
+	readonly phase: number
+	readonly schemaName: string | null
+	readonly findings: string
+}) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient
+		const [row] = yield* sql<Seeded>`
+			INSERT INTO research_runs (
+				organization_id, created_by, query, status, kind, mode,
+				schema_name, phase, budget_cents, findings
+			) VALUES (
+				${org.id}, ${userId}, ${SUITE_QUERY}, ${fields.status}, 'leaf', 'deep',
+				${fields.schemaName}, ${fields.phase}, 100, ${fields.findings}::jsonb
+			) RETURNING id
+		`
+		if (!row) throw new Error('seed failed')
+		return row.id
+	})
+
+beforeAll(async () => {
+	const seed = await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const [o] = yield* sql<OrgRow>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'taller' LIMIT 1
+			`
+			const [other] = yield* sql<OrgRow>`
+				SELECT id, name, slug FROM "organization" WHERE slug = 'restaurant' LIMIT 1
+			`
+			const [u] = yield* sql<{ id: string }>`
+				SELECT id FROM "user" WHERE email = 'admin@taller.cat' LIMIT 1
+			`
+			if (!o || !other || !u) {
+				throw new Error(
+					"taller / restaurant orgs or admin@taller.cat missing — run 'pnpm cli db reset && pnpm cli seed' first",
+				)
+			}
+			return { org: o, otherOrg: other, userId: u.id }
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<
+			{ org: OrgRow; otherOrg: OrgRow; userId: string },
+			never,
+			never
+		>,
+	)
+	org = seed.org
+	otherOrg = seed.otherOrg
+	userId = seed.userId
+}, 60_000)
+
+afterAll(async () => {
+	await Effect.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			yield* sql`DELETE FROM research_runs WHERE query = ${SUITE_QUERY}`
+		}).pipe(Effect.provide(PgLive)) as Effect.Effect<void, never, never>,
+	)
+})
+
+describe('ResearchService liveSnapshot', () => {
+	describe('when a run has been asked for but not started', () => {
+		it('should report no phase rather than the first one', async () => {
+			// GIVEN a queued run: nothing has touched it, so it has finished no
+			// phases and its column still reads zero
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const id = yield* seedRun({
+						status: 'queued',
+						phase: 0,
+						schemaName: 'prospect_scan_v1',
+						findings: '{}',
+					})
+					return yield* svc.liveSnapshot(id, 'prospects')
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{ readonly status: string; readonly phase: number } | null,
+					never,
+					never
+				>,
+			)
+
+			// THEN the row says it is waiting, with no phase finished — and reading
+			// that as "on the first one" would have the page announce it was
+			// gathering evidence before the engine had picked it up
+			expect(outcome?.status).toBe('queued')
+			expect(outcome?.phase).toBe(0)
+		}, 30_000)
+	})
+
+	describe('when a run has written nothing down yet', () => {
+		it('should say so rather than counting none', async () => {
+			// GIVEN a running scan whose findings are still empty
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const id = yield* seedRun({
+						status: 'running',
+						phase: 1,
+						schemaName: 'prospect_scan_v1',
+						findings: '{}',
+					})
+					return yield* svc.liveSnapshot(id, 'prospects')
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{ readonly hasFindings: boolean } | null,
+					never,
+					never
+				>,
+			)
+
+			// THEN it reports having written nothing, which the frame turns into an
+			// absent count — zero would claim it looked and found none
+			expect(outcome?.hasFindings).toBe(false)
+		}, 30_000)
+	})
+
+	describe('when a scan has found companies and proposed changes', () => {
+		it('should count the rows and only the changes still waiting', async () => {
+			// GIVEN a scan holding three companies and three proposals, one of them
+			// already decided
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const id = yield* seedRun({
+						status: 'running',
+						phase: 2,
+						schemaName: 'prospect_scan_v1',
+						findings: JSON.stringify({
+							prospects: [{ name: 'A' }, { name: 'B' }, { name: 'C' }],
+							proposed_updates: [
+								{ status: 'pending' },
+								{ status: 'pending' },
+								{ status: 'applied' },
+							],
+						}),
+					})
+					return yield* svc.liveSnapshot(id, 'prospects')
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{
+						readonly hasFindings: boolean
+						readonly foundCount: number | null
+						readonly pendingProposalCount: number
+					} | null,
+					never,
+					never
+				>,
+			)
+
+			// THEN every company is counted, and the decided proposal is not
+			expect(outcome?.hasFindings).toBe(true)
+			expect(outcome?.foundCount).toBe(3)
+			expect(outcome?.pendingProposalCount).toBe(2)
+		}, 30_000)
+	})
+
+	describe('when the run goes looking for no list of its own', () => {
+		it('should give no count rather than zero', async () => {
+			// GIVEN a brief, which is prose — there is no list of companies in it
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const id = yield* seedRun({
+						status: 'running',
+						phase: 1,
+						schemaName: 'freeform',
+						findings: JSON.stringify({ summary: 'prose' }),
+					})
+					return yield* svc.liveSnapshot(id, null)
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{ readonly foundCount: number | null } | null,
+					never,
+					never
+				>,
+			)
+
+			// THEN there is nothing to count, which is not the same as none found
+			expect(outcome?.foundCount).toBeNull()
+		}, 30_000)
+	})
+
+	describe('when the run is gone', () => {
+		it('should answer with nothing at all', async () => {
+			// GIVEN a run that has been deleted, and an id belonging to no run
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const id = yield* seedRun({
+						status: 'deleted',
+						phase: 3,
+						schemaName: 'prospect_scan_v1',
+						findings: '{}',
+					})
+					const deleted = yield* svc.liveSnapshot(id, 'prospects')
+					const missing = yield* svc.liveSnapshot(
+						'00000000-0000-4000-8000-000000000000',
+						'prospects',
+					)
+					// A caller may pass anything; a non-uuid must not reach the database
+					// as a cast error, which surfaces as a 500 rather than a 404.
+					const nonsense = yield* svc.liveSnapshot('not-a-uuid', 'prospects')
+					return { deleted, missing, nonsense }
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{
+						readonly deleted: unknown
+						readonly missing: unknown
+						readonly nonsense: unknown
+					},
+					never,
+					never
+				>,
+			)
+
+			// THEN each reads back as nothing, which is what ends a watcher's stream
+			expect(outcome.deleted).toBeNull()
+			expect(outcome.missing).toBeNull()
+			expect(outcome.nonsense).toBeNull()
+		}, 30_000)
+	})
+})
+
+describe('ResearchService liveSnapshot under an organisation scope', () => {
+	describe('when the organisation watching is not the one that owns the run', () => {
+		it('should answer with nothing', async () => {
+			// GIVEN a run belonging to one organisation, read once under that
+			// organisation and once under another
+			//
+			// Entering a scope is what makes this test mean anything: the query
+			// carries no organisation of its own and leans entirely on the database
+			// to withhold rows (row-level security). The suite's own connection is a
+			// superuser and sails past that, so a plain read here would pass even
+			// with the isolation broken. `enterOrgScope` drops to the ordinary
+			// application role, where the rules actually apply.
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					const svc = yield* ResearchService
+					const id = yield* seedRun({
+						status: 'running',
+						phase: 1,
+						schemaName: 'prospect_scan_v1',
+						findings: JSON.stringify({ prospects: [{ name: 'A' }] }),
+					})
+					const asOwner = yield* enterOrgScope(sql, { org, userId })(
+						svc.liveSnapshot(id, 'prospects'),
+					)
+					const asStranger = yield* enterOrgScope(sql, {
+						org: otherOrg,
+						userId,
+					})(svc.liveSnapshot(id, 'prospects'))
+					return { asOwner, asStranger }
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{
+						readonly asOwner: { readonly foundCount: number | null } | null
+						readonly asStranger: unknown
+					},
+					never,
+					never
+				>,
+			)
+
+			// THEN the organisation that owns the run sees it
+			expect(outcome.asOwner?.foundCount).toBe(1)
+			// AND the other is told nothing at all — not a redacted row, not an
+			// empty one: the same answer a run that does not exist would give
+			expect(outcome.asStranger).toBeNull()
+		}, 30_000)
+	})
+})
+
+describe('ResearchService runSchemaName', () => {
+	describe('when the run exists', () => {
+		it('should give back the schema it was started with', async () => {
+			// GIVEN a scan, and a brief that was stored without one
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const scan = yield* seedRun({
+						status: 'running',
+						phase: 1,
+						schemaName: 'prospect_scan_v1',
+						findings: '{}',
+					})
+					const unschemad = yield* seedRun({
+						status: 'running',
+						phase: 1,
+						schemaName: null,
+						findings: '{}',
+					})
+					return {
+						scan: yield* svc.runSchemaName(scan),
+						unschemad: yield* svc.runSchemaName(unschemad),
+					}
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{
+						readonly scan: string | null | undefined
+						readonly unschemad: string | null | undefined
+					},
+					never,
+					never
+				>,
+			)
+
+			// THEN the scan names its schema, and the one stored without a schema
+			// answers null — which is a run that exists, not a run that is missing
+			expect(outcome.scan).toBe('prospect_scan_v1')
+			expect(outcome.unschemad).toBeNull()
+		}, 30_000)
+	})
+
+	describe('when there is no such run to read', () => {
+		it('should answer with nothing, told apart from a run without a schema', async () => {
+			// GIVEN a deleted run, an id belonging to none, and a string that is not
+			// an id at all
+			const outcome = await Effect.runPromise(
+				Effect.gen(function* () {
+					const svc = yield* ResearchService
+					const deleted = yield* seedRun({
+						status: 'deleted',
+						phase: 3,
+						schemaName: 'prospect_scan_v1',
+						findings: '{}',
+					})
+					return {
+						deleted: yield* svc.runSchemaName(deleted),
+						missing: yield* svc.runSchemaName(
+							'00000000-0000-4000-8000-000000000000',
+						),
+						nonsense: yield* svc.runSchemaName('not-a-uuid'),
+					}
+				}).pipe(Effect.provide(ResearchTestLive)) as Effect.Effect<
+					{
+						readonly deleted: string | null | undefined
+						readonly missing: string | null | undefined
+						readonly nonsense: string | null | undefined
+					},
+					never,
+					never
+				>,
+			)
+
+			// THEN each is undefined rather than null. The route turns exactly that
+			// difference into a 404, so a looser check would start refusing every
+			// run that simply has no schema.
+			expect(outcome.deleted).toBeUndefined()
+			expect(outcome.missing).toBeUndefined()
+			expect(outcome.nonsense).toBeUndefined()
+		}, 30_000)
+	})
+})

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1838,6 +1838,29 @@ export const cloneCacheHitRun = (params: {
 
 // ── ResearchService ──
 
+/**
+ * Where a run is, in the figures a watching page needs — the shape
+ * `liveSnapshot` reads and whatever turns it into a frame consumes.
+ *
+ * Declared once and exported for that reason: the SQL's own type is an
+ * assertion rather than a check, so a column renamed there and nowhere else
+ * arrives as `undefined` wearing the type of a number. Sharing the shape at
+ * least makes the two ends fail together instead of silently disagreeing.
+ */
+export interface ResearchLiveSnapshot {
+	readonly status: string
+	readonly phase: number
+	readonly progressSteps: number | null
+	readonly costCents: number
+	readonly paidCostCents: number
+	readonly budgetCents: number
+	readonly paidBudgetCents: number
+	readonly sourceCount: number
+	readonly hasFindings: boolean
+	readonly foundCount: number | null
+	readonly pendingProposalCount: number
+}
+
 export class ResearchService extends Context.Service<ResearchService>()(
 	'ResearchService',
 	{
@@ -8145,6 +8168,76 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							GROUP BY ${keyFragment}
 							ORDER BY amount_cents DESC
 						`
+					}),
+
+				/**
+				 * Which findings schema a run was started with, or undefined when the
+				 * run is not this reader's to see.
+				 *
+				 * One column, because that is all a watcher needs before it can ask for
+				 * anything else: the schema settles which list holds what the run found,
+				 * and it never changes for the life of a run. Reading the whole run to
+				 * learn it made opening a page the most expensive thing on this route.
+				 */
+				runSchemaName: (researchId: string) =>
+					Effect.gen(function* () {
+						if (!isValidUuid(researchId)) return undefined
+						const [row] = yield* sql<{ schemaName: string | null }>`
+							SELECT r.schema_name
+							FROM research_runs r
+							WHERE r.id = ${researchId} AND r.status != 'deleted'
+						`
+						return row === undefined ? undefined : row.schemaName
+					}),
+
+				/**
+				 * Where a run is, for somebody watching it — the dozen figures a live
+				 * frame carries, and nothing else.
+				 *
+				 * `get` answers the same question, but it answers it with the whole run:
+				 * every page the run has read joined to its source row, every subject
+				 * link, every child of a batch with its own findings and brief, plus the
+				 * transcript and the tool log, which both grow all run. A watcher asks
+				 * this every few seconds for as long as the run lasts, so it reads the
+				 * columns it needs and counts the rest in the database rather than
+				 * carrying a findings blob across the wire to measure its length.
+				 *
+				 * `foundField` names the list this kind of run fills with what it went
+				 * looking for, or null for a kind that hunts for no list. It is settled
+				 * once by the caller from the run's schema, which never changes.
+				 *
+				 * Null when the run is gone — deleted, or never this reader's to see.
+				 */
+				liveSnapshot: (researchId: string, foundField: string | null) =>
+					Effect.gen(function* () {
+						if (!isValidUuid(researchId)) return null
+						const [row] = yield* sql<ResearchLiveSnapshot>`
+							SELECT r.status, r.phase, r.progress_steps,
+								r.cost_cents, r.paid_cost_cents,
+								r.budget_cents, r.paid_budget_cents,
+								(SELECT count(*) FROM research_run_sources rs
+									WHERE rs.research_id = r.id)::int AS source_count,
+								-- A run that has written nothing down yet has no count to
+								-- give, which is not the same as a count of none.
+								(r.findings IS NOT NULL
+									AND jsonb_typeof(r.findings) = 'object'
+									AND r.findings <> '{}'::jsonb) AS has_findings,
+								CASE
+									WHEN ${foundField}::text IS NULL THEN NULL
+									WHEN jsonb_typeof(r.findings -> ${foundField}::text) = 'array'
+										THEN jsonb_array_length(r.findings -> ${foundField}::text)
+									ELSE 0
+								END AS found_count,
+								(SELECT count(*) FROM jsonb_array_elements(
+									CASE WHEN jsonb_typeof(r.findings -> 'proposed_updates') = 'array'
+										THEN r.findings -> 'proposed_updates'
+										ELSE '[]'::jsonb END
+								) pu WHERE pu ->> 'status' = 'pending')::int
+									AS pending_proposal_count
+							FROM research_runs r
+							WHERE r.id = ${researchId} AND r.status != 'deleted'
+						`
+						return row ?? null
 					}),
 
 				/** Subscribe to SSE events for a run. Returns a Stream. */

--- a/packages/research/src/application/schemas/index.ts
+++ b/packages/research/src/application/schemas/index.ts
@@ -186,6 +186,19 @@ const NON_SCAN_FOUND_FIELD = {
 } satisfies Record<SchemaName, string | null>
 
 /**
+ * Which list a kind of run fills with what it went looking for, or null for a
+ * kind that hunts for none. Settled from the run's schema, which never changes,
+ * so a caller reading the same run repeatedly asks once.
+ */
+export const foundRowsField = (schemaName: string | null): string | null => {
+	// A run stored before the schema column existed counts as a brief, and a name
+	// this build no longer has is not one anybody can be told a number for.
+	const name = schemaName ?? 'freeform'
+	if (!isSchemaName(name)) return null
+	return discoveryResultField(name) ?? NON_SCAN_FOUND_FIELD[name]
+}
+
+/**
  * How many rows a run has found so far, or null for a kind that hunts for none.
  *
  * Findings arrive as plain JSON written by a model, so nothing guarantees the
@@ -197,11 +210,7 @@ export const countFoundRows = (
 	schemaName: string | null,
 	findings: unknown,
 ): number | null => {
-	// A run stored before the schema column existed counts as a brief, and a name
-	// this build no longer has is not one anybody can be told a number for.
-	const name = schemaName ?? 'freeform'
-	if (!isSchemaName(name)) return null
-	const field = discoveryResultField(name) ?? NON_SCAN_FOUND_FIELD[name]
+	const field = foundRowsField(schemaName)
 	if (field === null) return null
 	if (!isPlainObject(findings)) return 0
 	const rows = findings[field]

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -155,6 +155,7 @@ export {
 	queryPendingProposals,
 	type ResearchEvent,
 	type ResearchEventType,
+	type ResearchLiveSnapshot,
 	ResearchService,
 	type ResolvedInstructions,
 	stampRunCostFromLedger,


### PR DESCRIPTION
## What

The research run page updates itself while a run works — spend, what it has found, how far along it is. Making it do that put a heavy read on a fast path: to send a dozen numbers every few seconds, the server was fetching the entire run, including everything it had found, its transcript, its tool log, and every page it had read joined to its source. This replaces that with a read of just those numbers, and fixes two things the page was saying that were not true.

This is the research surface: the read behind the live stream in `server` and `research`, and the figures the run page falls back on in `internal`.

## Changes

**Touches:** the read behind each live message, the way the page works out which phase a run is on, and — untouched but worth picturing — the stream that carries them, which landed in the previous PR.

- **A live message now costs a read of what it actually reports.** Measured on a real fifty-source run: the row alone was 8,933 bytes (its findings 4,764, its tool log 1,009) before the joins over sources, links and a batch's children, and before decoding all of it. The replacement is 72 bytes and counts what it needs in the database. The number that matters more than the ratio is how often it happens: every ten seconds, per open page, for as long as a run lasts.
- **The page no longer says a run is doing something it has not started.** The run's phase column counts phases *finished* — it reaches 1 when gathering ends, 2 when extraction does — so reading it directly named the phase before. It is now read as "the next one", which also means a page opened halfway through a run knows the phase, where before it saw nothing until the run next spoke.
- **A run waiting its turn is on no phase at all.** That fell out of the fix above and was caught in review: "none finished, so it must be on the first" had a queued run announcing it was gathering evidence before anything had picked it up.
- **Opening a page no longer fetches the whole run.** The connect path was reading everything to learn one column, and re-entering the reader's organisation for a read that already had it. It is now two small reads — one column to settle which list this kind of run fills, then the figures themselves — where it was one heavy read and one narrow one.

## Impact

- **Nothing about the shape the page and the server agree on** (the typed contract in `packages/controllers`). Same fields, same meanings; only where the server gets them changed.
- **No migration, no new environment variables.** The phase fix deliberately avoids a migration: the column already holds what is needed, once read as a count of what is done rather than a pointer at what is happening.
- **Which organisation can see what is unchanged in policy but tightened in practice.** Reads still run under the reader's own organisation (row-level security); the opening read now does so without re-entering a scope it already holds, which removes a redundant lookup and a second connection. Verified by signing in against a different organisation and asking for this one's run — 404, not its contents.
- **The tools an outside AI calls (MCP) are untouched** — they read a run through a different path, which still returns the whole row.
- **Cheaper per watcher, and the cost no longer grows with the run.** The old read got heavier as a run accumulated sources and tool-log entries; the new one is flat.

## Review guide

- **Start at `packages/research/src/application/research-service.ts`**, `liveSnapshot`. It is the only producer of every figure a watching page shows, and its rules live in SQL where no type catches them.
- **Then `apps/server/src/lib/research-live-frame.ts`** — new file, the frame's own rules, moved out of the route so they could be tested. The phase derivation is the part worth your eye.
- **A decision you might overrule:** counting the found rows and the waiting changes now happens in SQL, while the browser still counts the same things in TypeScript for the figures it shows before the first message arrives. That is duplication, and it is deliberate — the alternative is shipping the findings blob across the wire to measure its length, which is the cost this PR exists to remove. The field name they both read comes from one shared place, so the part that could actually drift does not.
- **Known and not fixed here:** the phase numbering now lives in two places — the engine that writes the column, and this derivation that reads it. A fourth phase, or a change to when the column is written, breaks the reading again. The deeper fix is a column recording the phase underway, which is a migration.
- **Left alone deliberately:** this suite hand-builds its own `ResearchService` layer, which duplicates what the heartbeat suite does. That is the house pattern rather than a slip — nineteen integration suites each build their own — so sharing a factory is a repo-wide change and does not belong here.
- I did not run Snyk — the tool is not available in this session.

## Screenshots

> Screenshots skipped (approved): the only `apps/internal` change is one line in the figures the page falls back on before its first live message, and the progress panel renders from the message rather than from those — so that hunk changes nothing on screen. The visible improvement is server-side, and is verified below at the level the page reads from.

## Tests

- A unit suite over the frame's rules: each phase while running, a queued run, every ending, absent counts before a run has written anything, a kind that hunts for no list, and the event parsing that carries the current tool. It fails on the queued case if the fix is reverted.
- An integration suite over the query itself, against a real database: the same cases plus the three ways a run reads back as nothing — deleted, an id belonging to no run, and a string that is not an id at all. Every collaborator in its layer dies if reached, so the suite also pins that reading a run touches the database and nothing else.
- One of those tests reads the same run under two organisations and expects the second to be told nothing. It has to enter an organisation's scope to mean anything: the query names no organisation and leans on the database to withhold rows, and the suite's own connection is a superuser that sails straight past that. Dropping to the ordinary application role is what makes the rules apply — I checked it fails when the scoping is wrong, rather than trusting that it passes.

## Verification

- Gates run and green: `pnpm install`, `pnpm -w check-types`, `pnpm -w test`, `pnpm -w build`.
- Against the live local stack: a queued run reports no phase, a running run one phase in reports the next, and a scan with five companies and three of four changes still waiting reports exactly that.
- Measured the payload difference on a real run rather than estimating it — the figures in `## Changes` are from `pg_column_size` on that row.
- Confirmed a second organisation asking for this one's run still gets a 404.
- Reviewed the branch at extra-high effort before opening this. Eleven findings: five fixed, one refuted on inspection, five judged correct as written. The queued-phase bug above was one of the five, and it was introduced by this PR's own change — worth knowing when weighing how much of this to trust on a read alone.

## Deferred

A column recording the phase a run is working on, which would remove the derivation described in the review guide.
