### PR TITLE
fix: say who every mail line is about, and name every one of them

### DIFF
--- a/apps/mail-worker/src/persist.ts
+++ b/apps/mail-worker/src/persist.ts
@@ -373,6 +373,8 @@ export const persistMessage = (args: {
 			yield* Effect.logInfo('Email received').pipe(
 				Effect.annotateLogs({
 					event: 'email.received',
+					// No request to inherit the tenant from here, so the line names it.
+					'org.id': args.organizationId,
 					inboxId: args.inboxId,
 					folder: args.folder,
 					companyId,

--- a/apps/server/src/mcp/http.ts
+++ b/apps/server/src/mcp/http.ts
@@ -271,7 +271,9 @@ const McpAuthMiddleware = HttpRouter.middleware(
 					// is registered ahead of this one and has already opened the record.
 					recordFacts({
 						'mcp.auth_method': authMethod,
-						'mcp.org_id': org.id,
+						// Named here as well as in `enterOrgScope`, because a call that
+						// dies between the two still resolved to a tenant.
+						'org.id': org.id,
 						'mcp.principal_is_agent': principal.isAgent,
 					}).pipe(
 						Effect.andThen(

--- a/apps/server/src/middleware/enter-org-scope.integration.test.ts
+++ b/apps/server/src/middleware/enter-org-scope.integration.test.ts
@@ -5,7 +5,7 @@ process.env['DATABASE_URL'] ??=
 
 import { randomUUID } from 'node:crypto'
 
-import { Effect } from 'effect'
+import { Effect, Layer, Logger, References } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -72,6 +72,25 @@ const countVisiblePolicies: Effect.Effect<number, never, SqlClient.SqlClient> =
 		`.pipe(Effect.orDie)
 		return rows[0]?.n ?? 0
 	})
+
+// Reads back the annotations on every line an effect writes; they sit on the
+// fiber, not on the log options.
+const captureLines = () => {
+	const lines: Array<Record<string, unknown>> = []
+	const layer = Logger.layer([
+		Logger.make(options => {
+			lines.push({
+				...(options.fiber.getRef(References.CurrentLogAnnotations) as Record<
+					string,
+					unknown
+				>),
+			})
+		}),
+	]).pipe(
+		Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
+	)
+	return { lines, layer }
+}
 
 const ctx = {} as { org: Org }
 const seededUsers: string[] = []
@@ -157,6 +176,34 @@ describe('enterOrgScope', () => {
 			expect(result.role).toBe('app_user')
 			expect(result.orgGuc).toBe(ctx.org.id)
 			expect(result.userGuc).toBeNull()
+		})
+	})
+
+	describe('when work inside the scope writes a line of its own', () => {
+		it('should name the tenant on that line, not only on the closing record', async () => {
+			// GIVEN a business event logged from inside the scope
+			// WHEN enterOrgScope wraps it
+			// THEN the line itself carries org.id — the request's record is only
+			//      read when the work ends, so it cannot name the tenant on a line
+			//      written halfway through
+			const { lines, layer } = captureLines()
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient
+					yield* enterOrgScope(sql, { org: ctx.org })(
+						Effect.logInfo('Inbox created').pipe(
+							Effect.annotateLogs({ event: 'inbox.created' }),
+						),
+					)
+				}).pipe(Effect.provide(PgLive), Effect.provide(layer)) as Effect.Effect<
+					void,
+					never,
+					never
+				>,
+			)
+
+			const created = lines.find(line => line['event'] === 'inbox.created')
+			expect(created?.['org.id']).toBe(ctx.org.id)
 		})
 	})
 

--- a/apps/server/src/middleware/org.ts
+++ b/apps/server/src/middleware/org.ts
@@ -68,6 +68,10 @@ export const detachFromTransaction =
  * member behind it manages nothing, so leaving it out grants no authority
  * rather than borrowing someone else's.
  */
+// One spelling of the tenant, so the record and the log lines can never end up
+// disagreeing about which one it was.
+const tenantFact = (orgId: string) => ({ 'org.id': orgId })
+
 export const enterOrgScope =
 	(
 		// Passed in (not pulled from context) so the wrapped effect's R stays
@@ -81,18 +85,29 @@ export const enterOrgScope =
 		},
 	) =>
 	<A, E, R>(effect: Effect.Effect<A, E, R>) =>
-		sql
-			.withTransaction(
-				Effect.gen(function* () {
-					yield* sql`SET LOCAL ROLE app_user`
-					yield* sql`SELECT set_config('app.current_org_id', ${scope.org.id}, true)`
-					if (scope.userId !== undefined)
-						yield* sql`SELECT set_config('app.current_user_id', ${scope.userId}, true)`
-					return yield* Effect.provideService(effect, CurrentOrg, {
-						...scope.org,
-						role: scope.role ?? null,
-					})
-				}),
+		// Which tenant this is, said once for every transport that enters a scope
+		// here. The record is only read when the work ends, so the annotation is
+		// what names the tenant on lines written midway through.
+		recordFacts(tenantFact(scope.org.id))
+			.pipe(
+				Effect.andThen(
+					sql.withTransaction(
+						Effect.gen(function* () {
+							yield* sql`SET LOCAL ROLE app_user`
+							yield* sql`SELECT set_config('app.current_org_id', ${scope.org.id}, true)`
+							if (scope.userId !== undefined)
+								yield* sql`SELECT set_config('app.current_user_id', ${scope.userId}, true)`
+							return yield* Effect.provideService(
+								Effect.annotateLogs(effect, tenantFact(scope.org.id)),
+								CurrentOrg,
+								{
+									...scope.org,
+									role: scope.role ?? null,
+								},
+							)
+						}),
+					),
+				),
 			)
 			// Die only on SqlError: the role/GUC prologue and the commit are
 			// infrastructure, so they must not surface to callers. The wrapped
@@ -247,12 +262,6 @@ export const OrgMiddlewareLive = Layer.effect(
 						message: `Active organization ${activeOrgId} not found`,
 					})
 				}
-
-				// Put the resolved org on the request's span and row so errors and
-				// traces can be filtered to one tenant. ObservabilityMiddleware runs
-				// before this and already set request id + route on the same span,
-				// and opened the row this joins.
-				yield* recordFacts({ 'org.id': row.id })
 
 				// Enter the org scope (role + both GUCs + CurrentOrg) for the
 				// rest of the request via the shared combinator, keeping the

--- a/apps/server/src/services/email-threading.integration.test.ts
+++ b/apps/server/src/services/email-threading.integration.test.ts
@@ -71,6 +71,35 @@ const runExit = <A, E>(
 const sqlOnly = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
 	Effect.runPromise(effect.pipe(Effect.provide(PgLive)))
 
+// A conversation's own id is a uuid; the provider's Message-ID is an address.
+// Telling them apart is the whole point of the assertions that use this.
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// Reads back every line an effect writes. Annotations sit on the fiber rather
+// than on the log options, so they are read the way the built-in formatters
+// read them.
+const captureLines = () => {
+	const lines: Array<{
+		level: string
+		message: string
+		annotations: Record<string, unknown>
+	}> = []
+	const layer = Logger.layer([
+		Logger.make(options => {
+			lines.push({
+				level: String(options.logLevel),
+				message: String(options.message),
+				annotations: options.fiber.getRef(
+					References.CurrentLogAnnotations,
+				) as Record<string, unknown>,
+			})
+		}),
+	]).pipe(
+		Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
+	)
+	return { lines, layer }
+}
+
 // Why the send was turned away, so a test that expects a refusal can't be
 // satisfied by some unrelated failure earlier in the call. A refusal carries a
 // tag of its own and names its reason; anything else answers with neither.
@@ -1155,24 +1184,7 @@ describe('the record a send that never got through leaves', () => {
 			messages: [{ messageId: ROOT_ID, subject: 'your pallet pools' }],
 		})
 
-		const lines: Array<{
-			level: string
-			message: string
-			annotations: Record<string, unknown>
-		}> = []
-		const capture = Logger.layer([
-			Logger.make(options => {
-				lines.push({
-					level: String(options.logLevel),
-					message: String(options.message),
-					annotations: options.fiber.getRef(
-						References.CurrentLogAnnotations,
-					) as Record<string, unknown>,
-				})
-			}),
-		]).pipe(
-			Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
-		)
+		const { lines, layer: capture } = captureLines()
 
 		// WHEN the send is attempted
 		const exit = await failingSend.runPromiseExit(
@@ -1250,22 +1262,7 @@ describe('the record a failed clean-up leaves', () => {
 			messages: [{ messageId: ROOT_ID, subject: 'your pallet pools' }],
 		})
 
-		const lines: Array<{
-			level: string
-			annotations: Record<string, unknown>
-		}> = []
-		const capture = Logger.layer([
-			Logger.make(options => {
-				lines.push({
-					level: String(options.logLevel),
-					annotations: options.fiber.getRef(
-						References.CurrentLogAnnotations,
-					) as Record<string, unknown>,
-				})
-			}),
-		]).pipe(
-			Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
-		)
+		const { lines, layer: capture } = captureLines()
 
 		// WHEN it is sent
 		const exit = await failingPurge.runPromiseExit(
@@ -1300,22 +1297,7 @@ describe('the record a refused send leaves', () => {
 	// went through does. Without it, "how often are we refusing sends, and
 	// over what" cannot be answered at all.
 	const runCapturingLogs = async (effect: Parameters<typeof runExit>[0]) => {
-		const lines: Array<{
-			level: string
-			annotations: Record<string, unknown>
-		}> = []
-		const capture = Logger.layer([
-			Logger.make(options => {
-				lines.push({
-					level: String(options.logLevel),
-					annotations: options.fiber.getRef(
-						References.CurrentLogAnnotations,
-					) as Record<string, unknown>,
-				})
-			}),
-		]).pipe(
-			Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
-		)
+		const { lines, layer: capture } = captureLines()
 		await runtime.runPromiseExit(
 			scopedAsOrg(asOrg, effect).pipe(Effect.provide(capture)) as Effect.Effect<
 				unknown,
@@ -1488,6 +1470,98 @@ describe('a draft answering a conversation in another mailbox', () => {
 			// conversation belonging to another
 			expect(lastOutbound).not.toBeNull()
 			expect(lastOutbound?.inReplyTo).toBeUndefined()
+		})
+	})
+})
+
+describe('the record a send that went through leaves', () => {
+	// The line has to join back to the CRM, and the provider's Message-ID cannot:
+	// it joins to nothing we hold, and it is an address, so naming a conversation
+	// by it files a tenant's mail domain into telemetry.
+
+	// Takes the id as a uuid or not at all: handed 'null' or 'undefined', the
+	// comparison below raises a Postgres type error, which reads as broken test
+	// plumbing rather than as the regression it would actually be.
+	const linkExists = (id: unknown) => {
+		if (typeof id !== 'string' || !UUID.test(id)) return Promise.resolve(0)
+		return sqlOnly(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient
+				const rows = yield* sql<{ n: number }>`
+					SELECT count(*)::int AS n FROM email_thread_links
+					WHERE id = ${id}
+				`
+				return rows[0]!.n
+			}),
+		)
+	}
+
+	describe('when the send opens a new conversation', () => {
+		it('should name that conversation by its own id, and the mailbox it left from', async () => {
+			// GIVEN a first message to a company
+			const { lines, layer } = captureLines()
+
+			// WHEN it is sent
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.send(
+						inboxId,
+						'client@example.com',
+						'your pallet pools',
+						body,
+						companyId,
+						undefined,
+						{ actor: null },
+					)
+				}).pipe(Effect.provide(layer)),
+			)
+
+			// THEN the line names the conversation row this send created, so the
+			// send can be joined to the thread, the company and the tenant
+			const sent = lines.find(l => l.annotations['event'] === 'email.sent')
+			expect(sent).toBeDefined()
+			expect(await linkExists(sent?.annotations['threadId'])).toBe(1)
+
+			// AND it names the mailbox it went out from, which is what ties a send
+			// to the inbox whose credentials carried it
+			expect(sent?.annotations['inboxId']).toBe(inboxId)
+
+			// AND it names the tenant, which reaches the line from the org scope
+			// the send runs in rather than from the line itself
+			expect(sent?.annotations['org.id']).toBe(ORG)
+
+			// AND nothing on it carries a mail domain: a Message-ID is an address,
+			// and addresses must never reach telemetry
+			expect(String(sent?.annotations['threadId'])).not.toContain('@')
+		})
+	})
+
+	describe('when the send answers an existing conversation', () => {
+		it('should name the conversation it joined, not the message that opened it', async () => {
+			// GIVEN a conversation already on file
+			const threadId = await seedThread({
+				linkSubject: 'your pallet pools',
+				messages: [{ messageId: ROOT_ID, subject: 'your pallet pools' }],
+			})
+			const { lines, layer } = captureLines()
+
+			// WHEN a reply goes out on it
+			await run(
+				Effect.gen(function* () {
+					const svc = yield* EmailService
+					return yield* svc.reply(threadId, body, { actor: null })
+				}).pipe(Effect.provide(layer)),
+			)
+
+			// THEN the line names that same conversation and its mailbox
+			const replied = lines.find(
+				l => l.annotations['event'] === 'email.replied',
+			)
+			expect(replied).toBeDefined()
+			expect(replied?.annotations['threadId']).toBe(threadId)
+			expect(replied?.annotations['inboxId']).toBe(inboxId)
+			expect(replied?.annotations['org.id']).toBe(ORG)
 		})
 	})
 })

--- a/apps/server/src/services/email.ts
+++ b/apps/server/src/services/email.ts
@@ -1139,15 +1139,22 @@ export class EmailService extends Context.Service<EmailService>()(
 								),
 							),
 						)
-					yield* transport
-						.appendToSent(creds, sent.raw)
-						.pipe(
-							Effect.catchCause(cause =>
-								Effect.logWarning(
-									`appendToSent failed inbox=${inbox.id} (provider may auto-copy)`,
-								).pipe(Effect.andThen(Effect.logError(cause))),
+					yield* transport.appendToSent(creds, sent.raw).pipe(
+						Effect.catchCause(cause =>
+							Effect.logWarning(
+								'Filing a copy in the Sent folder failed (the provider may file it itself)',
+							).pipe(
+								// The failing call was handed the whole message, so an
+								// unbounded cause could carry the customer's own words
+								// into the logs.
+								Effect.andThen(Effect.logError(boundedCause(cause))),
+								Effect.annotateLogs({
+									event: 'email.sent_append_failed',
+									inboxId: inbox.id,
+								}),
 							),
-						)
+						),
+					)
 					return { messageId, rawRef: key }
 				})
 
@@ -1187,7 +1194,7 @@ export class EmailService extends Context.Service<EmailService>()(
 				Effect.gen(function* () {
 					const currentOrg = yield* CurrentOrg
 
-					yield* sql.withTransaction(
+					return yield* sql.withTransaction(
 						Effect.gen(function* () {
 							let externalThreadId: string
 							let inReplyTo: string | null
@@ -1317,6 +1324,11 @@ export class EmailService extends Context.Service<EmailService>()(
 									Effect.provideService(TimelineActivityService, timeline),
 								)
 							}
+
+							// Handed back so the send's line can name the conversation by
+							// our own id: the provider's Message-ID joins to nothing we
+							// hold and carries the mailbox's domain.
+							return threadLinkId
 						}),
 					)
 				})
@@ -1415,7 +1427,7 @@ export class EmailService extends Context.Service<EmailService>()(
 							threadId: dispatched.messageId,
 						}
 
-						yield* recordOutbound({
+						const threadLinkId = yield* recordOutbound({
 							result,
 							inbox,
 							companyId,
@@ -1455,7 +1467,8 @@ export class EmailService extends Context.Service<EmailService>()(
 							Effect.annotateLogs({
 								event: 'email.sent',
 								companyId,
-								threadId: result.threadId,
+								inboxId: inbox.id,
+								threadId: threadLinkId,
 							}),
 						)
 
@@ -1700,6 +1713,7 @@ export class EmailService extends Context.Service<EmailService>()(
 						yield* Effect.logInfo('Email reply sent').pipe(
 							Effect.annotateLogs({
 								event: 'email.replied',
+								inboxId: inbox.id,
 								threadId,
 							}),
 						)
@@ -3439,7 +3453,9 @@ export class EmailService extends Context.Service<EmailService>()(
 								: dispatched.messageId,
 						}
 
-						yield* recordOutbound({
+						// The conversation the message landed in: the same one for a
+						// reply, a fresh one when this send opened it.
+						threadLinkId = yield* recordOutbound({
 							result,
 							inbox,
 							companyId: ctx.companyId,
@@ -3489,7 +3505,8 @@ export class EmailService extends Context.Service<EmailService>()(
 							Effect.annotateLogs({
 								event: 'email.draft_sent',
 								draftId,
-								threadId: result.threadId,
+								inboxId: inbox.id,
+								threadId: threadLinkId,
 							}),
 						)
 

--- a/apps/server/src/services/inbox-health-probe.ts
+++ b/apps/server/src/services/inbox-health-probe.ts
@@ -148,8 +148,12 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 					// A check that passed is only the poller saying it is still
 					// polling; one that did not is for the mailbox owner to fix.
 					yield* state === 'connected'
-						? Effect.logDebug('inbox.probed').pipe(Effect.annotateLogs(facts))
-						: Effect.logWarning('inbox.probed').pipe(Effect.annotateLogs(facts))
+						? Effect.logDebug('Mailbox check passed').pipe(
+								Effect.annotateLogs(facts),
+							)
+						: Effect.logWarning('Mailbox check did not pass').pipe(
+								Effect.annotateLogs(facts),
+							)
 				}).pipe(
 					// One mailbox whose answer cannot be written down must not cost the
 					// others their turn. A lost permission or a key that fails to
@@ -157,7 +161,7 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 					// it goes down as an error. Shutting down skips this entirely: a
 					// fiber stopped from outside unwinds without running it.
 					Effect.catchCause(cause =>
-						Effect.logError('inbox.probe_unrecorded').pipe(
+						Effect.logError('Storing a mailbox check failed').pipe(
 							Effect.annotateLogs({
 								event: 'inbox.probe_unrecorded',
 								inboxId: inbox.id,
@@ -185,10 +189,20 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 	static readonly daemonLayer = Layer.effectDiscard(
 		Effect.gen(function* () {
 			const probe = yield* InboxHealthProbe
-			yield* Effect.logInfo(`inbox health probe: every ${probe.intervalSec}s`)
+			yield* Effect.logInfo('Mailbox checks started').pipe(
+				Effect.annotateLogs({
+					event: 'inbox.probe_started',
+					'inbox.probe.interval_sec': probe.intervalSec,
+				}),
+			)
 			yield* probe.tick.pipe(
 				Effect.catchCause(cause =>
-					Effect.logError('inbox health probe tick failed', cause),
+					// A whole round failing is the poller itself broken, not one
+					// mailbox, so it gets a name of its own.
+					Effect.logError('A round of mailbox checks failed').pipe(
+						Effect.andThen(Effect.logError(boundedCause(cause))),
+						Effect.annotateLogs({ event: 'inbox.probe_round_failed' }),
+					),
 				),
 				Effect.repeat(Schedule.spaced(`${probe.intervalSec} seconds`)),
 				Effect.forkScoped,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -32,9 +32,17 @@ So the rule is: when work learns something, it puts that fact on the work's reco
 | `event`             | Dot-notation name, so records filter by kind      |
 | `http.path_pattern` | The route, with ids collapsed — never the raw URL |
 | `org.id`            | Which tenant, once resolved                       |
-| `service`           | Which process emitted it                          |
+| `service.name`      | Which process emitted it                          |
 
-Timestamps and trace ids are added by the framework.
+Timestamps and trace ids are added by the framework, and `service.name` comes from the process's own resource rather than from a line — so it is the exported column, not something a caller writes.
+The `otlp.*` lines are the exception: they never reach the backend, so they spell it `service` on the console themselves.
+
+`org.id` comes from `enterOrgScope`, which every transport passes through when it settles who the work is for — HTTP, MCP, the cal.com webhook.
+It rides two ways on purpose: onto the request's record, which lands on the closing line, and as a log annotation, which reaches every line written *inside* the scope.
+The record alone is not enough, because it is only read when the work ends: a business event written halfway through a request would name no tenant.
+Two places say it a second time on purpose, and neither is redundant.
+The MCP transport records it before entering the scope, because a call can fail on the way there — reading its body, or writing down which client it came from — and a request that got as far as resolving a tenant should say which one.
+The mail worker has no request and no scope at all, so `email.received` names the tenant itself.
 
 ### Event names
 
@@ -50,12 +58,21 @@ Timestamps and trace ids are added by the framework.
 | `company.status_changed`       | Pipeline status transition                                 |
 | `interaction.logged`           | Interaction recorded                                       |
 | `document.created`             | Research/notes document added                              |
-| `email.sent`                   | Outbound email                                             |
+| `email.sent`                   | Outbound email starting a conversation                     |
+| `email.replied`                | Outbound email answering one                               |
+| `email.draft_sent`             | A saved draft went out                                     |
 | `email.received`               | Inbound reply                                              |
 | `email.failed`                 | Email delivery failed                                      |
+| `email.refused`                | A message was turned away before it was sent, and why      |
+| `email.sent_copy_failed`       | The message went out; keeping our own copy did not         |
+| `email.sent_append_failed`     | The message went out; filing it in Sent did not            |
+| `email.staging_purge_failed`   | Attachments outlived the message they went with            |
 | `inbox.created`                | A mailbox was connected                                    |
 | `inbox.probed`                 | A mailbox check that did not pass (a clean one is `debug`) |
 | `inbox.probe_unrecorded`       | A mailbox was checked but the answer could not be stored   |
+| `inbox.probe_started`          | The recurring mailbox check began, and how often it runs   |
+| `inbox.probe_round_failed`     | A whole round of checks failed — the poller, not a mailbox |
+| `mail_worker.heartbeat`        | The mail worker is still running, repeated on a timer      |
 | `webhook.fired`                | Webhook fan-out triggered                                  |
 | `webhook.failed`               | Webhook delivery failed                                    |
 | `page.published`               | Sales page made public                                     |
@@ -77,6 +94,16 @@ A request leaves exactly one of `http.request`, `http.server_error`, `http.defec
 A refused MCP tool call is the case that makes the rule concrete: the refusal travels as a JSON-RPC error inside a perfectly successful HTTP response, so the request's own line reads `http.status: 200` and a tool that turned the caller away is indistinguishable from one that answered. So the tool's name and how the call went ride on that same record as `mcp.tool` and `mcp.tool.outcome` (`ok` / `refused` / `failed`) rather than on a line of their own — recorded once, where every tool call already funnels through `apps/server/src/mcp/safe-toolkit.ts`. A refusal is the tool answering and a fault is nobody's intention, which is why the two are told apart rather than counted together. This matters more here than elsewhere because an MCP client shows a refusal as a silent retry rather than a visible error, so the record is the only place it surfaces at all.
 
 A request also leaves exactly **one span**, not two. The platform opens that span itself, so the server passes no tracer of its own when it starts serving; passing one as well used to open a second span per request, and every count taken from the traces read double until 2026-08-18. A trace older than that carries the twins.
+
+### What the mail lines carry
+
+An email line names the conversation by `threadId` — the `email_thread_links` row, our own id — and the mailbox it went out from by `inboxId`.
+Never the provider's Message-ID: it joins to nothing we hold, and it is an address, so naming the conversation by it filed a tenant's mail domain into telemetry on every send.
+
+A mailbox check carries `inbox.probe.outcome` (`connected`, `auth_failed`, `connect_failed`) and, when it did not pass, `inbox.probe.reason` — one of `invalid_credentials`, `timeout`, `dns`, `tls`, `unreachable`, `unknown`.
+It also carries `imap.host` and `imap.port`, which name the provider without naming anybody.
+What the mail server itself said never travels: those words are about somebody's account, so they stay on the mailbox row where its owner can read them.
+A check that passed is only the poller saying it is still polling, so it is written at `debug` and production keeps none of them.
 
 ### Levels
 
@@ -121,8 +148,9 @@ Routes whose URL itself carries a secret are exempt from tracing entirely rather
 | ------------------------ | --------------------------------------------------------------------- | -------------------------- |
 | **Pipeline Progression** | `company.status_changed`                                              | Core business flow         |
 | **Interaction Logging**  | `interaction.logged`, `task.created`                                  | Drives daily work          |
-| **Email Outbound**       | `email.sent`, `email.failed`                                          | Primary outreach channel   |
+| **Email Outbound**       | `email.sent`, `email.replied`, `email.draft_sent`, `email.failed`     | Primary outreach channel   |
 | **Email Inbound**        | `email.received`, `interaction.logged`                                | Reply tracking             |
+| **Mailbox Health**       | `inbox.created`, `inbox.probed`                                       | A dead mailbox stops both  |
 | **Webhook Fan-out**      | `webhook.fired`, `webhook.failed`                                     | Integration reliability    |
 | **Page Publishing**      | `page.published`, `page.viewed`                                       | Sales page effectiveness   |
 | **MCP Tool Calls**       | `mcp.auth.rejected`; the tool and its outcome on the request's record | Agent workflow reliability |
@@ -166,13 +194,18 @@ As a solo operation there is no on-call rotation or war room. Two questions matt
 
 **Start with few, high-signal alerts.** Alert fatigue is worse than no alerts.
 
-| Alert                | Condition                                  | Severity |
-| -------------------- | ------------------------------------------ | -------- |
-| **API Down**         | Health check fails for > 2 min             | Critical |
-| **Telemetry Silent** | No spans from any prod dataset over 15 min | Critical |
-| **High Error Rate**  | > 10% API 5xx responses in 15 min          | High     |
-| **Email Failures**   | > 5 consecutive email send failures        | High     |
-| **Webhook Failures** | > 20% webhook 5xx responses in 15 min      | High     |
+| Alert                | Condition                                     | Severity |
+| -------------------- | --------------------------------------------- | -------- |
+| **API Down**         | Health check fails for > 2 min                | Critical |
+| **Telemetry Silent** | No spans from any prod dataset over 15 min    | Critical |
+| **High Error Rate**  | > 10% API 5xx responses in 15 min             | High     |
+| **Email Failures**   | > 5 consecutive email send failures           | High     |
+| **Mailbox Refused**  | The same mailbox fails its check for > 30 min | High     |
+| **Webhook Failures** | > 20% webhook 5xx responses in 15 min         | High     |
+
+Mailbox Refused is the one that says a tenant is cut off rather than that a request went wrong.
+A mailbox whose credentials stop working stops that tenant's mail in both directions, and it is silent by construction: nobody is waiting on the check, so the only place it surfaces is `inbox.probed`.
+It is held to one mailbox failing repeatedly rather than to a count across all of them, because a provider having a bad minute and a password that has actually been revoked look identical in a single check.
 
 **Telemetry Silent is the one alert that cannot be raised from inside.** Every other row above is a question asked of the records, so it needs the records to be arriving. This one has to be evaluated by the vendor, environment-wide, so it still fires when the services are stopped or cut off and cannot report for themselves — the gap that let the 2026-08-31 outage run seven hours unnoticed while `/health` answered 200 throughout. Note the consequence: once it fires it stays fired until export is restored, so it cannot warn about a second outage in the meantime.
 
@@ -327,6 +360,8 @@ Pointers, not copies — read the files for detail.
 | Export health: per-signal outcomes, the watchdog, the report  | `packages/observability/src/export-health.ts`      |
 | Per-request record, route sanitizing, catch-all error logging | `apps/server/src/lib/observability-middleware.ts`  |
 | Logger set and level                                          | `apps/server/src/lib/logger.ts`                    |
+| Tenant on every line inside a request                         | `apps/server/src/middleware/org.ts`                |
+| Mailbox checks and the lines they leave                       | `apps/server/src/services/inbox-health-probe.ts`   |
 | Tracing exemptions for secret-carrying routes                 | `apps/server/src/main.ts`                          |
 | Spend counters                                                | `packages/research/src/application/usage-meter.ts` |
 

--- a/packages/observability/src/redact-spans.test.ts
+++ b/packages/observability/src/redact-spans.test.ts
@@ -90,13 +90,13 @@ describe('redactingTracer', () => {
 
 			// WHEN they are recorded
 			span.attribute('tool', 'manage_email_inbox')
-			span.attribute('mcp.org_id', 'org_123')
+			span.attribute('org.id', 'org_123')
 			span.attribute('mcp.auth_method', 'api_key')
 
 			// THEN every one survives — scrubbing everything would leave nothing to
 			// debug from, so only the catch-all argument bag is emptied
 			expect(recorded.get('tool')).toBe('manage_email_inbox')
-			expect(recorded.get('mcp.org_id')).toBe('org_123')
+			expect(recorded.get('org.id')).toBe('org_123')
 			expect(recorded.get('mcp.auth_method')).toBe('api_key')
 		})
 	})


### PR DESCRIPTION
## What

When a customer's email breaks — a mailbox that stops accepting its password, a message that never goes out — the records the system keeps have to say *whose* mailbox it was and *which* conversation it belonged to. They didn't. I found this reading production telemetry in Honeycomb after the recent mailbox-password fix: every mailbox and email line was there, but a person could not get from one to the organisation it belonged to, and the line for a sent message named the conversation by a value that joins to nothing we store.

This makes every email and mailbox line name its organisation, its mailbox and its conversation, and gives a name to two lines that had none. It touches the CRM's email surface — the API server (`server`) and the background process that takes in arriving mail (`mail-worker`) — plus the observability guide. **No user-facing behaviour changes**: this is about the records the system leaves behind, not what it does.

## Changes

**Touches:** the shared organisation scope that every request passes through when it settles which customer it is acting for, the three paths that send a message (a first message, a reply, a saved draft), the recurring mailbox check, and the mail worker's line for an arriving message — plus the guide that is supposed to list every one of these lines.

- **Named the organisation on lines written *during* a request, not only on the one line a request leaves when it finishes.** Facts gathered mid-request are collected and written out together at the end, so an event logged halfway through had no organisation on it at all. Said once in `enterOrgScope`, which HTTP, MCP and the cal.com webhook all pass through, so no transport can be forgotten. The mail worker has no request to inherit from, so its line names the organisation itself.
- **Named the conversation a sent message belongs to by our own database id, not the mail provider's Message-ID.** That value joins to nothing we hold — you cannot get from it back to the conversation in the CRM — and it is an address (`<abc@customer-domain.com>`), so every send filed a customer's mail domain into the records we keep. All three send paths now also name the mailbox the message left from.
- **Gave the two lines that had no name one, and bounded the error text they carry.** A failure to file a copy in the Sent folder was an unnamed warning with the mailbox id glued into its message text, followed by the whole untrimmed failure of a call that had just been handed the entire message — so the customer's own words could reach the logs. The recurring check's whole-round failure had the same shape.
- **Wrote down the six lines the code already emitted but the guide never mentioned**, what the mail and mailbox lines carry, and an alert for a mailbox that stops signing in. Corrected `service` to `service.name`, which is the column that actually exists.

## Impact

- **Nothing changes about which organisation can see what (row-level security).** This is the one thing worth checking closely, because the change wraps `enterOrgScope` — the piece that decides, for each request, which customer's rows are visible. The body of that function is untouched: the same `SET LOCAL ROLE app_user`, the same two settings that the visibility rules read (`app.current_org_id`, `app.current_user_id`), in the same order, inside the same transaction, around the same effect. What is new sits outside it and only writes log fields. `/security-review` found nothing.
- **Both ways in get the fix.** Because it lives in the shared scope, requests over the web API and over MCP (the interface the AI assistant connects through) both get the organisation on their lines. In production the MCP path had *no* organisation on any line at all; now it does.
- **One telemetry field is renamed: `mcp.org_id` becomes `org.id`.** No code reads either name, so nothing breaks — but any saved Honeycomb query or board filtering on `mcp.org_id` will go blind when this deploys. That was the point: one field name now reaches a customer's work whichever way it arrived, instead of MCP having a private spelling.
- **One log message's wording changed**, so a grep habit changes with it: the mailbox check's start line was `inbox health probe: every 900s` and is now `Mailbox checks started` with the interval in a field. The greppable token is the event name, `inbox.probe_started`.
- **No migration, no new environment variables, no change to the API's shape, no change to authentication or route protection, nothing needing a coordinated deploy.** The value the send API *returns* to callers is unchanged — only what gets logged changed.

## Review guide

- **Start here:** `apps/server/src/middleware/org.ts`. It is the only load-bearing change and the only one with any risk; everything else is fields on log lines.
- **The riskiest part, and why:** it wraps the tenant-isolation combinator. I checked the restructuring keeps the role, both settings, the transaction boundary and what runs inside the scope identical, and `/security-review` agreed. If you only read one hunk, read that one.
- **A decision you might overrule:** the MCP path records `org.id` twice — once before entering the scope, once inside it. I kept the early one because a call can fail between the two (reading its body, writing down which client it came from), and a request that got as far as resolving a customer should say which one. If you'd rather have one write, the early one is the one to drop.
- **Skip-able:** the test files. Most of that diff is mechanical — four copies of the same log-capture block in one file folded into one helper (−45 lines).
- **Couldn't verify:** Snyk isn't available in this session, so no dependency/code scan ran. There are no new dependencies.
- **Left alone, deliberately:** the thread-link insert tolerates a missing returned row with `?? null` while the insert twelve lines below it explicitly fails on the same condition. Unreachable in practice — Postgres returns the row or raises — so fixing the asymmetry is a behaviour change that doesn't belong in this PR.

## Tests

- **Integration, against real Postgres:** a business event logged inside an organisation scope carries `org.id` — the mechanism the whole change rests on; and both send paths (a first message and a reply) name the conversation by an id that exists in `email_thread_links`, name the mailbox, name the organisation, and carry no `@` anywhere.
- I checked the new assertions actually bite: removing the log-annotation half of `enterOrgScope` fails the send test, and putting the Message-ID back fails it too. A test that cannot fail is not coverage.

## Verification

Everything below I ran on this branch, rebased onto current `origin/main`:

- **Gates:** `pnpm install` (no lockfile drift) → `pnpm -w check-types` + `pnpm -w test` → `pnpm -w build`. All four green.
- **Suites:** server 1061 unit + 900 integration, mail-worker 48 unit + 48 integration, observability 64, controllers 69.
- **Against a live server**, booted in this worktree with its own database and the local mail server:
  - Created a mailbox over MCP. The line it left reads `event=inbox.created org.id=uEDWcjag… inboxId=ef83eb1b… shared=false` — the organisation is on a line written *during* the request, which is the bug this fixes, and the mailbox address is not on it.
  - The same request's closing line now carries `org.id` on the `/mcp` route, which in production carried none.
  - The mailbox check's start line came out as `event=inbox.probe_started inbox.probe.interval_sec=900`.
- **Not verified live:** a real `email.sent` line — the dev API key hit its own rate limit before I could send one. That path is covered by the integration tests above, against the real database and the real organisation scope.
- Not a UI change, so no screenshots.

## Deferred

- **The "Mailbox Refused" alert is documented but not created** in Honeycomb. Creating a live alert is a change to a running system, so it is yours to make — say the word and I'll add it. Until then a mailbox that stops signing in is still silent unless someone looks. Two mailboxes are failing that check in production right now, including one created *after* the password-trim fix, which points at the credentials rather than at our code.
