### PR TITLE
test(mail-worker): cover mail that will not load, and what it counts as

### DIFF
--- a/apps/mail-worker/src/imap-roundtrip.integration.test.ts
+++ b/apps/mail-worker/src/imap-roundtrip.integration.test.ts
@@ -14,10 +14,12 @@
 //
 // What it does: SMTP-inject a message → connect ImapFlow as the seeded
 // admin@taller.cat → open INBOX → call `fetchAndIngestNewerThan` against the
-// same SqlClient layer the worker uses → assert that an `email_messages` row
-// with the test subject lands. The IMAP + SMTP connections are real wire
-// interactions; the only thing we mock is the `Effect.never` outer loop in
-// `runInboxSession` so the test terminates.
+// same SqlClient layer the worker uses → assert what lands: the message row,
+// one touchpoint per message no matter how many people are copied in, and —
+// when a message will not store — that the folder waits on it rather than
+// reading past it. The IMAP + SMTP connections are real wire interactions;
+// the only thing we mock is the `Effect.never` outer loop in `runInboxSession`
+// so the test terminates.
 
 process.env['DATABASE_URL'] ??=
 	'postgresql://batuda:batuda@localhost:5433/batuda'
@@ -26,7 +28,7 @@ process.env['DATABASE_URL'] ??=
 const MAIL_CATCHER_REST = 'http://localhost:8025'
 
 import { PgClient } from '@effect/sql-pg'
-import { Config, Effect, Redacted } from 'effect'
+import { Config, Effect, Layer, Redacted } from 'effect'
 import { ImapFlow } from 'imapflow'
 import nodemailer from 'nodemailer'
 import pg from 'pg'
@@ -83,6 +85,7 @@ const runWith = <A, E>(eff: Effect.Effect<A, E, never>) =>
 const smtpInject = async (msg: {
 	to: string
 	from: string
+	cc?: string
 	subject: string
 	text: string
 }) => {
@@ -304,6 +307,185 @@ describe.skipIf(!mailServerAnswers)(
 						[subject, orgId],
 					)
 					expect(rows.rows[0]!.count).toBe('1')
+				} finally {
+					await client.logout().catch(() => undefined)
+				}
+			})
+		})
+
+		describe('when a known contact writes in with colleagues copied', () => {
+			it('should file one touchpoint for the message, not one per person', async () => {
+				// Read the addresses out of the seed rather than naming them, so
+				// the test still means the same thing when the seed data changes.
+				const people = await pool.query<{
+					address: string
+					companyId: string
+				}>(
+					`SELECT lower(ch.address) AS address,
+					        min(c.company_id::text) AS "companyId"
+					 FROM channels ch
+					 JOIN contacts c
+					   ON c.id = ch.subject_id AND ch.subject_table = 'contacts'
+					 WHERE ch.channel = 'email'
+					   AND ch.organization_id = $1
+					   AND c.deleted_at IS NULL
+					   AND c.company_id IS NOT NULL
+					 GROUP BY lower(ch.address)
+					 -- One contact each: an address shared by two of them is
+					 -- ambiguous, and the matcher declines to pick a winner.
+					 HAVING count(DISTINCT c.id) = 1
+					 ORDER BY 1
+					 LIMIT 3`,
+					[orgId],
+				)
+				expect(people.rows.length).toBe(3)
+				const [sender, ...copied] = people.rows
+
+				const subject = `roundtrip-cc ${Date.now()}`
+				await clearCatcher()
+
+				const countInteractions = async () =>
+					(
+						await pool.query<{ n: number }>(
+							`SELECT count(*)::int AS n FROM interactions WHERE organization_id = $1`,
+							[orgId],
+						)
+					).rows[0]?.n ?? 0
+
+				const interactionsBefore = await countInteractions()
+
+				// GIVEN mail from someone we know, with two more people we know
+				// copied in
+				await smtpInject({
+					to: 'admin@taller.cat',
+					from: sender!.address,
+					cc: copied.map(p => p.address).join(', '),
+					subject,
+					text: 'three people we know are on this message',
+				})
+
+				const client = await openImap()
+				try {
+					const opened = await client.mailboxOpen('INBOX')
+
+					// WHEN one tick reads the folder
+					await runWith(
+						fetchAndIngestNewerThan({
+							client,
+							organizationId: orgId,
+							inboxId,
+							folder: 'INBOX',
+							direction: 'inbound',
+							uidvalidity: Number(opened.uidValidity),
+							sinceUid: 0,
+							stuckUid: null,
+							attempts: 0,
+						}).pipe(
+							Effect.provide(RawMessageStorage.layer),
+							Effect.provide(WorkerEnvVars.layer),
+							Effect.provide(ParticipantMatcher.layer),
+							Effect.provide(TimelineActivityService.layer),
+							Effect.provide(PgLive),
+						),
+					)
+
+					// THEN the message is filed against the sender's company
+					const stored = await pool.query<{ id: string; companyId: string }>(
+						`SELECT id, company_id AS "companyId" FROM email_messages
+						 WHERE organization_id = $1 AND subject = $2`,
+						[orgId, subject],
+					)
+					expect(stored.rows.length).toBe(1)
+					expect(stored.rows[0]?.companyId).toBe(sender!.companyId)
+
+					// AND it counts once — what is recorded is the message, not each
+					// person on it.
+					const history = await pool.query<{ n: number }>(
+						`SELECT count(*)::int AS n FROM timeline_activity
+						 WHERE organization_id = $1 AND entity_id = $2`,
+						[orgId, stored.rows[0]!.id],
+					)
+					expect(history.rows[0]?.n).toBe(1)
+					expect((await countInteractions()) - interactionsBefore).toBe(1)
+				} finally {
+					await client.logout().catch(() => undefined)
+				}
+			})
+		})
+
+		describe('when one of the messages cannot be taken in', () => {
+			it('should stop there rather than reading past it', async () => {
+				const badSubject = `roundtrip-bad ${Date.now()}`
+				const nextSubject = `roundtrip-next ${Date.now()}`
+
+				await clearCatcher()
+
+				// GIVEN two messages waiting, the first of which cannot be
+				// stored — what a short object-store outage looks like
+				await smtpInject({
+					to: 'admin@taller.cat',
+					from: 'roundtrip-sender@example.com',
+					subject: badSubject,
+					text: 'this one will not store',
+				})
+				await smtpInject({
+					to: 'admin@taller.cat',
+					from: 'roundtrip-sender@example.com',
+					subject: nextSubject,
+					text: 'this one is behind it',
+				})
+
+				// Refuses exactly the first message and stores the rest, so one
+				// message fails rather than the whole pass.
+				const refusingStorage = Layer.succeed(RawMessageStorage, {
+					putRaw: (_key: string, body: Uint8Array) =>
+						new TextDecoder().decode(body).includes(badSubject)
+							? Effect.fail(new Error('object store refused the bytes'))
+							: Effect.void,
+					putAttachment: () => Effect.void,
+				} as never)
+
+				const client = await openImap()
+				try {
+					const opened = await client.mailboxOpen('INBOX')
+					const uidvalidity = Number(opened.uidValidity)
+
+					// WHEN one tick reads the folder
+					const progress = await runWith(
+						fetchAndIngestNewerThan({
+							client,
+							organizationId: orgId,
+							inboxId,
+							folder: 'INBOX',
+							direction: 'inbound',
+							uidvalidity,
+							sinceUid: 0,
+							stuckUid: null,
+							attempts: 0,
+						}).pipe(
+							Effect.provide(refusingStorage),
+							Effect.provide(WorkerEnvVars.layer),
+							Effect.provide(ParticipantMatcher.layer),
+							Effect.provide(TimelineActivityService.layer),
+							Effect.provide(PgLive),
+						),
+					)
+
+					// THEN the folder is left waiting on the message it could not
+					// take in, so the next tick starts from it again
+					expect(progress.lastUid).toBe(0)
+					expect(progress.stuckUid).not.toBeNull()
+					expect(progress.attempts).toBe(1)
+
+					// AND neither message is on file: the first because it failed,
+					// the one behind it because the folder is read in order rather
+					// than around the gap
+					const stored = await pool.query<{ subject: string }>(
+						`SELECT subject FROM email_messages
+						 WHERE organization_id = $1 AND subject = ANY($2)`,
+						[orgId, [badSubject, nextSubject]],
+					)
+					expect(stored.rows).toEqual([])
 				} finally {
 					await client.logout().catch(() => undefined)
 				}


### PR DESCRIPTION
## What

Mail arrives from a customer's mailbox through the mail worker, which reads each message and files it against the right company. Two things about that were untested, and this adds a test for each.

The first is what happens when a message will not load — the object store having a bad minute, say. The worker is supposed to wait on that message and try again, rather than skip it and lose it. Nothing checked that against a real mail server.

The second is how much a message counts as. When mail arrives from a company we know, the worker records a touchpoint — one line saying "these people talked". I wanted to know whether copying more people we know into the same message records more of them, because that is the difference between a handful of new rows a day and a flood of them.

No production code changed. This is `apps/mail-worker` only.

## Changes

**Touches:** the live mail round-trip test — the one place a real mail server is on the wire — and nothing else.

- Added a case where the first of two waiting messages cannot be stored, checking that the folder stops there instead of reading past it. The cases already here only covered mail that loads, which I proved by putting the skipping-past bug back: all three still passed, so the branch that this suite exists to protect had no cover at all.
- Added a case where someone we know writes in with two more people we know copied, checking the message is filed against the sender's company and counts exactly once.

## Impact

None on the running system — no production code, no database changes, nothing touching which organisation can see what (row-level security), no new settings the server needs at start-up, and no change to the shape of anything the web app reads.

One thing worth knowing, which is the answer to the volume question and not visible in the diff: **one touchpoint per message that reaches a company we know, and none for a message that does not.** Copying two more known people into a message still produces one, not three. I measured this against a real mailbox rather than reasoning about it. So when an inbox is first connected and the worker reads back through the last 30 days (`EMAIL_WORKER_BACKFILL_DAYS`), the number of new rows is the number of messages from companies already in the CRM in that window — it does not multiply by the people on each message.

These two cases run after a merge, not on the pull request itself: the mail server image is 320 MB and takes about a minute to answer, and the pull-request gate has a ten-minute budget to keep. Locally they follow `pnpm cli services up` with no extra step.

## Review guide

Read the second case first (`when one of the messages cannot be taken in`) — it is the one carrying real risk, because a test that cannot fail is worse than no test. I checked it can, twice, by breaking the code on purpose:

| Bug put back | What happened |
| --- | --- |
| Folder moves on even when a message failed | `expected 33 to be +0` — only the new case failed |
| Reads past the gap instead of stopping | `expected 39 to be +0` — only the new case failed |
| Records one touchpoint per person copied in | `expected 3 to be 1` — only the other new case failed |

Two decisions you might overrule:

- The failing message is forced by handing the worker a stand-in object store that refuses exactly one message and stores the rest. That keeps the failure to one message rather than the whole pass, but it does mean the test trusts the stand-in — which the mutation runs above confirm, since the second message did get stored when I removed the stop.
- The addresses come out of the seed at run time rather than being written into the test, so it keeps meaning the same thing when the seed data changes. It asks for three contacts whose address belongs to exactly one person; if the seed ever has fewer, the test fails on that check rather than misreporting.

## Tests

`apps/mail-worker` integration: 53 passing, up from 51.

## Verification

Ran against the live local stack — a real mail server over IMAP and SMTP, real Postgres, real object store:

- `pnpm install` — no lockfile drift
- `pnpm -w check-types` — clean
- `pnpm -w test` — 23 tasks, all passing
- `pnpm -w build` — clean
- `pnpm --filter @batuda/mail-worker test:integration` — 53 passing
- Three mutation runs, each confirming exactly one case fails and the rest stay green

I also restarted the local mail-catcher container during this work: a throwaway measurement script called the mail server's full service reset, which clears its user accounts, where the suite uses the message purge. That wedged IMAP logins until the restart. The throwaway script is deleted and nothing in this PR calls that endpoint.

## Deferred

Nothing. The measurement that motivated the second case is now the case itself, so it cannot quietly stop being true.
