### PR TITLE
fix(research): stop a town page deciding where a firm is

### DIFF
--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -33,6 +33,7 @@ import {
 	ExtractLanguageModel,
 	evalSpanAttributes,
 	evalSummaryAttributes,
+	type FarmReplayScore,
 	type FramingOutcome,
 	type GoldenExpectation,
 	judgeOrganisationKinds,
@@ -52,6 +53,7 @@ import {
 	parseContactGoldenSet,
 	parseFarmCorpus,
 	parseGoldenSet,
+	placeReadOffATownPage,
 	placesNamed,
 	probeModelCapabilities,
 	probeReachability,
@@ -69,6 +71,7 @@ import {
 	scoreContactRun,
 	scoreFarmReplay,
 	scoreRun,
+	townPageJudge,
 	UsageMeter,
 } from '@batuda/research'
 
@@ -1457,30 +1460,49 @@ export const researchFarmReplay = (input: { readonly corpus: string }) =>
 			return
 		}
 
-		const score = scoreFarmReplay(
+		// Two rules, graded apart. They answer the two defects that wear the same
+		// address shape, and one number over both would let a rule that simply
+		// dropped everything look good at exactly the thing this exists to catch.
+		const network = scoreFarmReplay(
 			rows,
 			networkGuardJudge({ drop: dropNetworkRows, placesOf: placesNamed }),
 		)
+		const townPages = scoreFarmReplay(
+			rows,
+			townPageJudge({ reads: placeReadOffATownPage }),
+		)
 		const runs = new Set(rows.map(row => JSON.stringify(row.askedAbout))).size
 
-		yield* Console.log(`${score.rows} rows over ${runs} runs`)
-		yield* Console.log(
-			`operator rows taken off: ${score.networkDropped}/${score.networkTotal}`,
-		)
 		// Printed even at zero, and by name. A count says a rule is a few percent
 		// wrong; a name says which company somebody paid to find would have gone,
 		// and that is the number this exists to protect.
+		const costOf = (score: FarmReplayScore) =>
+			Effect.gen(function* () {
+				yield* Console.log(
+					`  real companies deleted: ${score.companiesDeleted.length}`,
+				)
+				for (const name of score.companiesDeleted) {
+					yield* Console.log(`    deleted: ${name}`)
+				}
+			})
+
+		yield* Console.log(`${network.rows} rows over ${runs} runs`)
+		yield* Console.log('')
 		yield* Console.log(
-			`real companies deleted: ${score.companiesDeleted.length}`,
+			`operator rows taken off: ${network.networkDropped}/${network.networkTotal}`,
 		)
-		for (const name of score.companiesDeleted) {
-			yield* Console.log(`  deleted: ${name}`)
+		yield* costOf(network)
+		yield* Console.log('')
+		yield* Console.log(
+			`per-town landing pages, place refused: ${townPages.placeRefused}/${townPages.placeTotal}`,
+		)
+		yield* costOf(townPages)
+		// The cheaper cost, and only this rule can pay it: an ordinary company left
+		// wearing a doubt about its place that it did not earn.
+		yield* Console.log(
+			`  places refused in error: ${townPages.placesRefusedInError.length}`,
+		)
+		for (const name of townPages.placesRefusedInError) {
+			yield* Console.log(`    refused: ${name}`)
 		}
-		// Always nothing out of however many, because this rule only ever drops a
-		// row or leaves it. It is printed all the same: those rows are a real defect
-		// wearing the same address shape, and a line reading zero is how somebody
-		// finds out nothing yet answers them.
-		yield* Console.log(
-			`per-town landing pages, place refused: ${score.placeRefused}/${score.placeTotal}`,
-		)
 	})

--- a/eval/README.md
+++ b/eval/README.md
@@ -350,6 +350,12 @@ Copy `farm-replay.example.json` to your own `farm-replay.json` and fill it with 
 
 To build a corpus, dump the runs you want (`get_research`, or a query against the runs table) and take each prospect's `name`, its unwrapped `website` and `location`, and the towns the request asked about. `addresses` is every address the row rests on **with the website among them** — the website itself, plus every `source_id` the row cites. One list, not two, so a rule cannot pass a row by forgetting that the website is an address as well.
 
+`placeSource` is separate from all of them: it is the page the row's PLACE was read on, `location.source_id` as the row states it. It is kept apart because the question it answers is not "does this row rest on that host" but "did this very place come off that page", and a rule handed the address list cannot tell one from the other. Leave it `null` where the row stated no place, or stated one written without its source — a run stored before that field was paired with its page keeps the shape it was written in.
+
+**`askedAbout` is a set, not an ordered pair, and nothing in it says which place is the province.** A measurement that reads the last entry as the province gets `Montcada i Reixac (Ripollet)` and `Sant Quirze del Vallès (Sabadell)` — areas that are not places, and a check asked about one of those answers a question nobody meant. If what you are grading needs the area a run was actually held to, read it off the run, and remember the splitter answers a request naming several towns with the widest place containing them all: for most of these that is the province, not any town.
+
+**A corpus is cheaper to rebuild than it looks.** `get_research` dumps are what it is built from, and those survive wherever the tool wrote them — so a corpus lost with its worktree is usually a replay away rather than a re-scan. Pass `include: ['sources']` and the response is large enough to land in a file, which is the affordable way to pull twenty-odd runs.
+
 The `.example` file uses `.example` domains throughout. A corpus names real businesses, and calling a named firm a farm in a shared file is a claim about that firm, so keep yours out of git — `.gitignore` covers `eval/*.json` and spares the `.example` templates.
 
 ### Reading the score
@@ -366,16 +372,22 @@ pnpm cli research farm-replay
 
 It reads `eval/farm-replay.json` (a relative `--corpus` is read from the repo root) and grades the rule that ships, out of the same file the pipeline runs — so a number printed here is a number about production rather than about a copy of the rule that drifted. It fetches nothing and calls no model.
 
-Against the shared template it prints:
+The two rules are graded apart, because they answer the two defects that wear the same address shape. Against the shared template it prints:
 
 ```
 10 rows over 7 runs
+
 operator rows taken off: 3/4
-real companies deleted: 0
-per-town landing pages, place refused: 0/2
+  real companies deleted: 0
+
+per-town landing pages, place refused: 2/2
+  real companies deleted: 0
+  places refused in error: 0
 ```
 
-Three of the four, not four: the fourth cites a finance profile and nothing of the operator's own, so no rule reading hosts can reach it. `0/2` is honest too — nothing yet refuses the place on a per-town landing page.
+Three of the four, not four: the fourth cites a finance profile and nothing of the operator's own, so no rule reading hosts can reach it.
+
+Over twenty-two production scans — 364 rows — the same command reads 9/14 operator rows and 8/13 town pages, with no real company deleted and no ordinary place refused. The five town pages it misses are named in `town-page-guard.ts`, along with why each is out of reach.
 
 ### Handing it a rule of your own
 
@@ -389,5 +401,11 @@ const score = scoreFarmReplay(
 ```
 
 Two things it does that are easy to get wrong on your own. It asks the check **one run at a time** — a rule reads addresses across a whole list, and rows from two scans handed over together would be read against each other in a list no scan ever produced. And it diffs **by id, never by name**: a run repeats a company name across rows far more often than it repeats an id, and joined by name two rows take each other's verdict.
+
+The town-page check is bridged the same way, by `townPageJudge`. That one is smaller — the rule reads one row — but it has its own trap: the place has to go back into the row **paired with the page it was read on**, because reading that pairing is the whole rule. Hand it a bare place and every row comes back `keep`, which looks exactly like a rule that catches nothing:
+
+```ts
+const score = scoreFarmReplay(rows, townPageJudge({ reads: placeReadOffATownPage }))
+```
 
 For a rule of your own, write a `FarmJudge` — handed the whole list, answering by id. A rule that really does read one row at a time is lifted with `rowByRow` and loses nothing. A row your answer leaves out is kept, so a rule that reaches no conclusion is never read as reaching one.

--- a/eval/farm-replay.example.json
+++ b/eval/farm-replay.example.json
@@ -9,6 +9,7 @@
 			"https://www.vkestampacionsmetalurgiquesbarcelona.example",
 			"https://www.vkestampacionsmetalurgiquesbarcelona.example/sant-quirze-del-valles"
 		],
+		"placeSource": "https://www.vkestampacionsmetalurgiquesbarcelona.example/sant-quirze-del-valles",
 		"label": "network"
 	},
 	{
@@ -20,6 +21,7 @@
 		"addresses": [
 			"https://www.vkestampacionsmetalurgiquesbarcelona.example/cerdanyola-del-valles"
 		],
+		"placeSource": "https://www.vkestampacionsmetalurgiquesbarcelona.example/cerdanyola-del-valles",
 		"label": "network"
 	},
 	{
@@ -32,6 +34,7 @@
 			"https://www.vkanoditzatstecnicsbarcelona.example",
 			"https://www.vkanoditzatstecnicsbarcelona.example/vacarisses"
 		],
+		"placeSource": "https://www.vkanoditzatstecnicsbarcelona.example/vacarisses",
 		"label": "network"
 	},
 	{
@@ -41,6 +44,7 @@
 		"website": null,
 		"statedPlace": null,
 		"addresses": ["https://finance-profiles.example"],
+		"placeSource": null,
 		"label": "network"
 	},
 	{
@@ -53,6 +57,7 @@
 			"https://estructuresvalles.example",
 			"https://estructuresvalles.example/estructures-metalliques-castellar-del-valles/"
 		],
+		"placeSource": "https://estructuresvalles.example/estructures-metalliques-castellar-del-valles/",
 		"label": "serves_not_in"
 	},
 	{
@@ -65,6 +70,7 @@
 			"https://estructuresvalles.example",
 			"https://estructuresvalles.example/estructures-metalliques-barbera-del-valles/"
 		],
+		"placeSource": "https://estructuresvalles.example/estructures-metalliques-barbera-del-valles/",
 		"label": "serves_not_in"
 	},
 	{
@@ -74,6 +80,7 @@
 		"website": "https://carinsa.example",
 		"statedPlace": "Sant Quirze del Vallès, Barcelona",
 		"addresses": ["https://carinsa.example"],
+		"placeSource": "https://carinsa.example",
 		"label": "ok"
 	},
 	{
@@ -86,17 +93,19 @@
 			"https://caldereria-sentmenat.example",
 			"https://caldereria-sentmenat.example/"
 		],
+		"placeSource": "https://caldereria-sentmenat.example/caldereria-sentmenat-taller",
 		"label": "ok"
 	},
 	{
 		"id": "example-ordinary-on-a-directory-path",
 		"askedAbout": ["Castellar del Vallès", "Barcelona"],
 		"name": "Delinox Solutions",
-		"website": null,
+		"website": "https://delinox-solutions.example",
 		"statedPlace": "Castellar del Vallès",
 		"addresses": [
 			"https://a-directory.example/castellar-del-valles/fabricante/delinox-solutions"
 		],
+		"placeSource": "https://a-directory.example/castellar-del-valles/fabricante/delinox-solutions",
 		"label": "ok"
 	},
 	{
@@ -106,6 +115,7 @@
 		"website": null,
 		"statedPlace": null,
 		"addresses": [],
+		"placeSource": null,
 		"label": "ok"
 	}
 ]

--- a/packages/research/src/application/eval-farm-replay.test.ts
+++ b/packages/research/src/application/eval-farm-replay.test.ts
@@ -7,7 +7,9 @@ import {
 	parseFarmRow,
 	rowByRow,
 	scoreFarmReplay,
+	townPageJudge,
 } from './eval-farm-replay'
+import { placeReadOffATownPage } from './town-page-guard'
 
 const row = (over: Partial<FarmRow>): FarmRow => ({
 	id: 'r1',
@@ -16,6 +18,7 @@ const row = (over: Partial<FarmRow>): FarmRow => ({
 	website: 'https://acme.example',
 	statedPlace: 'Sant Quirze del Vallès, Barcelona',
 	addresses: ['https://acme.example'],
+	placeSource: null,
 	label: 'ok',
 	...over,
 })
@@ -425,6 +428,7 @@ describe('networkGuardJudge', () => {
 		website: null,
 		statedPlace: null,
 		addresses: [],
+		placeSource: null,
 		label: 'ok',
 		...over,
 	})
@@ -567,6 +571,98 @@ describe('networkGuardJudge', () => {
 			// THEN the key is absent. Sent as null or empty it would read as an
 			//   address, and every check that screens one would have to know better.
 			expect(seen[0]?.prospects[0]).not.toHaveProperty('website')
+		})
+	})
+})
+
+describe('townPageJudge', () => {
+	const row = (
+		over: Partial<FarmRow> & Pick<FarmRow, 'id' | 'name'>,
+	): FarmRow => ({
+		askedAbout: ['Barberà del Vallès', 'Barcelona'],
+		website: 'https://montvalles.com/',
+		statedPlace: 'Barberà del Vallès, Barcelona',
+		addresses: [],
+		placeSource:
+			'https://montvalles.com/estructuras-metalicas-barbera-del-valles/',
+		label: 'serves_not_in',
+		...over,
+	})
+
+	const judge = townPageJudge({ reads: placeReadOffATownPage })
+
+	describe("when a row's place rests on the firm's own page about that town", () => {
+		it('should answer refuse_place, keeping the company on the list', () => {
+			// GIVEN one such row beside an ordinary one
+			const rows = [
+				row({ id: 'a', name: 'Montvalles' }),
+				row({
+					id: 'b',
+					name: 'Metalser SL',
+					website: 'https://metalser.example',
+					statedPlace: 'Barberà del Vallès',
+					placeSource: 'https://metalser.example/contacte',
+					label: 'ok',
+				}),
+			]
+
+			// WHEN the shipped rule is asked
+			const answer = judge(rows)
+
+			// THEN only the town page is refused, and nothing is dropped
+			expect(answer.get('a')).toBe('refuse_place')
+			expect(answer.get('b')).toBe('keep')
+			expect([...answer.values()]).not.toContain('drop')
+		})
+	})
+
+	describe('when a corpus row states a place with no source', () => {
+		it('should keep it, since the rule is handed nothing to grade', () => {
+			// GIVEN a place written without the page it was read on — the shape a
+			// run stored before the field was paired with its source
+			const answer = judge([
+				row({ id: 'a', name: 'ST Empresas', placeSource: null }),
+			])
+
+			// WHEN asked — THEN the honest answer is that this cannot be graded
+			expect(answer.get('a')).toBe('keep')
+		})
+	})
+
+	describe('when a corpus row states no place at all', () => {
+		it('should keep it, since there is no place to refuse', () => {
+			// GIVEN a row whose location never came back
+			const answer = judge([
+				row({ id: 'a', name: 'Stemp', statedPlace: null, placeSource: null }),
+			])
+
+			// WHEN asked — THEN nothing is refused
+			expect(answer.get('a')).toBe('keep')
+		})
+	})
+
+	describe('when the score reads its answers', () => {
+		it('should count a caught row and leave the real companies whole', () => {
+			// GIVEN one town-page row and one ordinary row
+			const rows = [
+				row({ id: 'a', name: 'Montvalles' }),
+				row({
+					id: 'b',
+					name: 'Metalser SL',
+					website: 'https://metalser.example',
+					placeSource: 'https://metalser.example/contacte',
+					label: 'ok',
+				}),
+			]
+
+			// WHEN scored
+			const score = scoreFarmReplay(rows, judge)
+
+			// THEN the catch is counted, and neither cost is paid
+			expect(score.placeRefused).toBe(1)
+			expect(score.placeTotal).toBe(1)
+			expect(score.companiesDeleted).toEqual([])
+			expect(score.placesRefusedInError).toEqual([])
 		})
 	})
 })

--- a/packages/research/src/application/eval-farm-replay.ts
+++ b/packages/research/src/application/eval-farm-replay.ts
@@ -79,6 +79,14 @@ export interface FarmRow {
 	 * which is the same silent miss this file exists to catch.
 	 */
 	readonly addresses: ReadonlyArray<string>
+	/**
+	 * The page the row's PLACE was read on, which a scan row states beside the
+	 * place itself. Kept apart from `addresses` because the question it answers is
+	 * not "does this row rest on that host" but "did this very place come off that
+	 * page" — and a rule handed the whole list cannot tell one from the other.
+	 * Null where the row stated no place, or stated one written without its source.
+	 */
+	readonly placeSource: string | null
 	readonly label: FarmLabel
 }
 
@@ -225,6 +233,10 @@ export const parseFarmRow = (raw: unknown): FarmRowParseResult => {
 	if (!statedPlace.ok) {
 		return { ok: false, error: `${id}: statedPlace must be a string` }
 	}
+	const placeSource = readTextOrNull(row['placeSource'])
+	if (!placeSource.ok) {
+		return { ok: false, error: `${id}: placeSource must be a string` }
+	}
 
 	return {
 		ok: true,
@@ -235,6 +247,7 @@ export const parseFarmRow = (raw: unknown): FarmRowParseResult => {
 			website: website.value,
 			statedPlace: statedPlace.value,
 			addresses: addresses.value,
+			placeSource: placeSource.value,
 			label,
 		},
 	}
@@ -389,3 +402,44 @@ export const networkGuardJudge =
 		}
 		return verdicts
 	}
+
+/**
+ * The shipped town-page check, as a rule this can grade.
+ *
+ * It lives here for the reason the operator bridge above does: a bridge written at
+ * the call site is a bridge nothing tests, and this one decides every number
+ * anybody quotes about the rule.
+ *
+ * The bridging is small but not nothing. The check reads a scan row, so a corpus
+ * row has to be written back into that shape — and the place has to go back
+ * PAIRED with the page it was read on, because reading that pairing is the whole
+ * rule. A corpus row whose place names no source is handed one with none, which is
+ * how the check comes to say the honest "cannot grade this".
+ */
+export const townPageJudge =
+	(check: {
+		readonly reads: (row: Record<string, unknown>) => unknown
+	}): FarmJudge =>
+	rows =>
+		new Map(
+			rows.map(row => [
+				row.id,
+				check.reads({
+					name: row.name,
+					...(row.website === null ? {} : { website: row.website }),
+					...(row.statedPlace === null
+						? {}
+						: {
+								location: {
+									value: row.statedPlace,
+									confidence: null,
+									...(row.placeSource === null
+										? {}
+										: { source_id: row.placeSource }),
+								},
+							}),
+				}) === null
+					? ('keep' as const)
+					: ('refuse_place' as const),
+			]),
+		)

--- a/packages/research/src/application/place-guard.test.ts
+++ b/packages/research/src/application/place-guard.test.ts
@@ -286,6 +286,88 @@ describe('markRowsOutsidePlace', () => {
 		})
 	})
 
+	describe("when a place was read off the firm's own page about that town", () => {
+		it('should take the place off and keep the company, with no judge involved', async () => {
+			// GIVEN a firm that writes one landing page per town it travels to, and
+			// whose place was read off the page for the town this run asked about
+			const findings = scan([
+				prospect('Montvalles', {
+					website: 'https://montvalles.com/',
+					location: {
+						value: 'Barberà del Vallès, Barcelona',
+						source_id:
+							'https://montvalles.com/estructuras-metalicas-barbera-del-valles/',
+						confidence: null,
+					},
+				}),
+			])
+			const judge = vi.fn(silent)
+
+			// WHEN run — THEN the company stays on the list, the place it could not
+			// support is gone, and the row is named so somebody can go and look
+			const result = await run(
+				markRowsOutsidePlace(findings, 'prospects', 'Barcelona', judge),
+			)
+			expect(namesOf(result.findings)).toEqual(['Montvalles'])
+			expect(rowsOf(result.findings)[0]?.['location']).toBeUndefined()
+			expect(result.refusedTownPages).toEqual([
+				{
+					name: 'Montvalles',
+					page: 'montvalles.com/estructuras-metalicas-barbera-del-valles',
+				},
+			])
+			// AND it is counted apart from a value that was never a place at all
+			expect(result.locationsDropped).toBe(0)
+		})
+
+		it('should run even when the request named no area to hold rows to', async () => {
+			// GIVEN the same row, on a run that confined itself to nowhere. The gate
+			// below returns early here, and this one must not: the place is
+			// unsupported whatever was asked for
+			const findings = scan([
+				prospect('Montvalles', {
+					website: 'https://montvalles.com/',
+					location: {
+						value: 'Barberà del Vallès, Barcelona',
+						source_id:
+							'https://montvalles.com/estructuras-metalicas-barbera-del-valles/',
+						confidence: null,
+					},
+				}),
+			])
+
+			// WHEN run with no place — THEN the place still comes off
+			const result = await run(
+				markRowsOutsidePlace(findings, 'prospects', '', silent),
+			)
+			expect(rowsOf(result.findings)[0]?.['location']).toBeUndefined()
+			expect(result.refusedTownPages).toHaveLength(1)
+		})
+
+		it('should leave a place a directory filed under that town alone', async () => {
+			// GIVEN a place read off a business directory's page for the town, which
+			// is a directory stating where a company is rather than a firm naming
+			// somewhere it travels to
+			const findings = scan([
+				prospect('Fadiplast S.L.', {
+					website: 'https://fadiplast.example',
+					location: {
+						value: 'Montcada i Reixac, Barcelona',
+						source_id: 'https://empresite.example/montcada-reixac-barcelona',
+						confidence: null,
+					},
+				}),
+			])
+
+			// WHEN run — THEN nothing is refused
+			const result = await run(
+				markRowsOutsidePlace(findings, 'prospects', 'Barcelona', silent),
+			)
+			expect(rowsOf(result.findings)[0]?.['location']).toBeDefined()
+			expect(result.refusedTownPages).toEqual([])
+		})
+	})
+
 	describe('when an earlier pass already placed a company', () => {
 		it('should stand by an inside even after the row gains evidence', async () => {
 			// GIVEN a company placed inside on an earlier pass, met again with a

--- a/packages/research/src/application/place-guard.ts
+++ b/packages/research/src/application/place-guard.ts
@@ -9,7 +9,7 @@
  * different question — what kind of organisation this is, whether its name can be
  * read, whether it exists at all — and none asks where it is.
  *
- * ## Three answers this gives without asking anybody
+ * ## Four answers this gives without asking anybody
  *
  * The cheap cases are cheap, and they run first so the model is only asked what
  * the model is needed for:
@@ -20,6 +20,10 @@
  *    key is removed. That rule now runs over the field a pass earlier as well,
  *    since the location names the page it was read on; this is what still answers
  *    for a value stored before that, which keeps the shape it was written in.
+ *  - **The page it was read on does not establish it.** A firm writing one landing
+ *    page per town it travels to gets that town recorded as where it is. The
+ *    company is real and stays; the place comes off. See `town-page-guard.ts`,
+ *    which also says why the area comparison below can never answer this one.
  *  - **Nothing was asked.** A run given no place has nothing to hold a row to, so
  *    no row is marked and the count says the check did not run rather than
  *    finding nothing.
@@ -73,6 +77,7 @@ import {
 } from './row-marks'
 import { valueIsRightKind } from './scalar-field-guard'
 import { canonicalizeUrl, hostOf } from './source-key'
+import { placeReadOffATownPage } from './town-page-guard'
 
 /** How much of the judge's reason travels with the row. */
 const REASON_CHARS = 200
@@ -281,6 +286,19 @@ export interface MarkedOutsidePlace {
 	readonly reason: string
 }
 
+/**
+ * One place refused for resting on a page about a town the firm travels to.
+ *
+ * Named rather than counted, the way the operator check next door names what it
+ * takes off: a count says a rule touched two percent of a list, a name says whose
+ * place went and lets somebody open the page and disagree.
+ */
+export interface RefusedTownPagePlace {
+	readonly name: string
+	/** The page that filed it under that town, host and path, so a reader can look. */
+	readonly page: string
+}
+
 export interface PlaceGuardResult {
 	readonly findings: unknown
 	/** Rows marked as outside the area asked for. */
@@ -294,6 +312,12 @@ export interface PlaceGuardResult {
 	readonly cleared: number
 	/** Locations removed for naming a service area rather than a place. */
 	readonly locationsDropped: number
+	/**
+	 * Places removed for resting on a page the firm filed under that very town.
+	 * Counted apart from the line above because the two are different faults: one
+	 * is a value that was never a place, this is a place nothing established.
+	 */
+	readonly refusedTownPages: ReadonlyArray<RefusedTownPagePlace>
 	/** Rows put to the judge, as the scale the marks read against. */
 	readonly asked: number
 	/**
@@ -349,6 +373,7 @@ export const markRowsOutsidePlace = <E, R>(
 			marked: [],
 			cleared: 0,
 			locationsDropped: 0,
+			refusedTownPages: [],
 			asked: 0,
 			ruled: 0,
 			unclear: 0,
@@ -364,6 +389,7 @@ export const markRowsOutsidePlace = <E, R>(
 		// rather than about the area, and a run that named no area still must not
 		// ship a list of towns in the field that says where a company is.
 		let locationsDropped = 0
+		const refusedTownPages: Array<RefusedTownPagePlace> = []
 		const cleaned = list.map(row => {
 			if (!isPlainObject(row)) return row
 			const stated = readTextValue(row['location'])
@@ -372,20 +398,45 @@ export const markRowsOutsidePlace = <E, R>(
 			// that reaches here written bare — findings stored before the field was
 			// paired keep the shape they were written in, and nothing migrates them.
 			if (stated === null) return row
-			if (valueIsRightKind('location', stated)) return row
-			locationsDropped++
 			// Removed rather than emptied, so the row reads as one that never named a
 			// place — the same as any other field a guard takes away.
-			const { location: _taken, ...rest } = row
-			return rest
+			const withoutPlace = () => {
+				const { location: _taken, ...rest } = row
+				return rest
+			}
+			if (!valueIsRightKind('location', stated)) {
+				locationsDropped++
+				return withoutPlace()
+			}
+			// ── Gate 1b: a place the page it was read on does not establish ──
+			// A firm that writes one landing page per town it travels to has its
+			// place read off a page about a town it merely serves. Same field, same
+			// pass, and the same reason as above: this is about the row's own
+			// honesty, so it runs whether or not the run named an area — and it has
+			// to, because a request naming several towns is held to the province
+			// they sit in, which such a row is genuinely inside.
+			const reading = placeReadOffATownPage(row)
+			if (reading === null) return row
+			refusedTownPages.push({
+				name: judgedRowText(row, 'name'),
+				page: `${reading.host}/${reading.filedAs}`,
+			})
+			return withoutPlace()
 		})
 		const afterGateOne =
-			locationsDropped === 0 ? findings : { ...findings, [listField]: cleaned }
+			locationsDropped === 0 && refusedTownPages.length === 0
+				? findings
+				: { ...findings, [listField]: cleaned }
 
 		// ── Gate 2: nothing was asked ──
 		const area = place.trim()
 		if (area === '')
-			return { ...nothing, findings: afterGateOne, locationsDropped }
+			return {
+				...nothing,
+				findings: afterGateOne,
+				locationsDropped,
+				refusedTownPages,
+			}
 
 		// Identity rather than position ties a verdict to a row, because the walk
 		// that writes the marks reads the list again.
@@ -418,7 +469,12 @@ export const markRowsOutsidePlace = <E, R>(
 			row.citedPages.length > 0
 		const judgeable = rows.filter(saysSomething)
 		if (judgeable.length === 0)
-			return { ...nothing, findings: afterGateOne, locationsDropped }
+			return {
+				...nothing,
+				findings: afterGateOne,
+				locationsDropped,
+				refusedTownPages,
+			}
 
 		// The answer this run already holds, where it still speaks for the row. An
 		// "inside" stands whatever a later pass adds; anything else speaks only for
@@ -556,12 +612,16 @@ export const markRowsOutsidePlace = <E, R>(
 
 		return {
 			findings:
-				marked.length === 0 && cleared === 0 && locationsDropped === 0
+				marked.length === 0 &&
+				cleared === 0 &&
+				locationsDropped === 0 &&
+				refusedTownPages.length === 0
 					? findings
 					: { ...findings, [listField]: withMarks },
 			marked,
 			cleared,
 			locationsDropped,
+			refusedTownPages,
 			asked: judgeable.length,
 			ruled,
 			unclear,

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -4449,6 +4449,24 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													}),
 												)
 											}
+											// Named, not merely counted: a place taken off a real company is
+											// something somebody may want to open the page and disagree with,
+											// and a bare number gives them nothing to open.
+											for (const row of check.refusedTownPages.slice(
+												0,
+												MAX_LOGGED_FIELD_DROPS,
+											)) {
+												yield* Effect.logInfo(
+													'research.place.read_off_town_page',
+												).pipe(
+													Effect.annotateLogs({
+														event: 'research.place.read_off_town_page',
+														research_id: researchId,
+														name: row.name,
+														page: row.page,
+													}),
+												)
+											}
 											for (const row of check.marked.slice(
 												0,
 												MAX_LOGGED_FIELD_DROPS,
@@ -4501,6 +4519,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 													'research.place.outside': check.marked.length,
 													'research.place.location_not_a_place':
 														check.locationsDropped,
+													// Apart from the line above: that one is a value that was never a
+													// place, this is a place no page established.
+													'research.place.read_off_town_page':
+														check.refusedTownPages.length,
 												},
 											}
 										}),

--- a/packages/research/src/application/town-page-guard.test.ts
+++ b/packages/research/src/application/town-page-guard.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest'
+
+import { placeReadOffATownPage } from './town-page-guard'
+
+const row = (args: {
+	name?: string
+	website?: string | null
+	place?: string | null
+	readOn?: string | null
+}) => ({
+	name: args.name ?? 'Montvalles',
+	...(args.website === null
+		? {}
+		: { website: args.website ?? 'https://montvalles.com/' }),
+	...(args.place === null
+		? {}
+		: {
+				location: {
+					value: args.place ?? 'Barberà del Vallès, Barcelona',
+					confidence: 1,
+					...(args.readOn === null
+						? {}
+						: {
+								source_id:
+									args.readOn ??
+									'https://montvalles.com/estructuras-metalicas-barbera-del-valles/',
+							}),
+				},
+			}),
+})
+
+describe('placeReadOffATownPage', () => {
+	describe('when the place was read off a page the firm filed under that town', () => {
+		it('should refuse it, since the page says where the firm will go', () => {
+			// GIVEN a landing page on the firm's own site, named for the town
+			// WHEN the place is read against it
+			const reading = placeReadOffATownPage(row({}))
+			// THEN the town is refused, and the reader is told what was read
+			expect(reading).toEqual({
+				host: 'montvalles.com',
+				place: 'barberadelvalles',
+				filedAs: 'estructuras-metalicas-barbera-del-valles',
+			})
+		})
+
+		it('should read the place the row leads with, not the ones around it', () => {
+			// GIVEN a location that leads with its province instead of its town —
+			// the other way round from how a location is normally written
+			// WHEN read against a page filed under the town
+			// THEN nothing is refused. This is a catch given up on purpose: reading
+			// the wider places too is what lets a page named for the province take
+			// a correct town off the row, and that costs more than this misses
+			expect(
+				placeReadOffATownPage(
+					row({ place: 'Barcelona, Barberà del Vallès, España' }),
+				),
+			).toBeNull()
+		})
+
+		it('should read a town spelled without its accents in the path', () => {
+			// GIVEN a path that folds "Barberà" to "barbera", as a path must
+			// WHEN read — THEN the two are the same town
+			expect(placeReadOffATownPage(row({}))?.place).toBe('barberadelvalles')
+		})
+	})
+
+	describe("when the page is not the firm's own", () => {
+		it('should leave it alone, since a directory files a company where it is', () => {
+			// GIVEN a place read off a business directory's page for that town
+			// WHEN read against the firm's own site
+			// THEN nothing is refused — this is how a directory states a place
+			expect(
+				placeReadOffATownPage(
+					row({
+						name: 'Fadiplast S.L.',
+						website: 'https://fadiplast.com',
+						place: 'Montcada i Reixac, Barcelona',
+						readOn:
+							'https://empresite.eleconomista.es/montcada-reixac-barcelona',
+					}),
+				),
+			).toBeNull()
+		})
+	})
+
+	describe('when the path carries nothing but the town', () => {
+		it('should leave it alone, since that is an index of a town', () => {
+			// GIVEN the firm's own site with a bare town path
+			// WHEN read — THEN a page that says only the town is not a page about it
+			expect(
+				placeReadOffATownPage(
+					row({ readOn: 'https://montvalles.com/barbera-del-valles' }),
+				),
+			).toBeNull()
+		})
+	})
+
+	describe("when the town is part of the company's own name", () => {
+		it('should leave it alone, since the path is spelling the name', () => {
+			// GIVEN a firm whose own name carries the town
+			// WHEN its site files a page under that name
+			// THEN the path names the company, not a town it travels to
+			expect(
+				placeReadOffATownPage(
+					row({
+						name: 'SA RUBI INDUSTRIAL',
+						website: 'https://suppliers.catalonia.com',
+						place: 'Rubí, Barcelona',
+						readOn: 'https://suppliers.catalonia.com/sa-rubi-industrial',
+					}),
+				),
+			).toBeNull()
+		})
+	})
+
+	describe('when the path names the province the location also states', () => {
+		it('should leave it alone, or the correct town goes with it', () => {
+			// GIVEN a firm genuinely in Rubí, whose own site has an ordinary page
+			// named for the province rather than for a town
+			// WHEN read against the place it claims
+			// THEN nothing is refused: a page filed under the province says nothing
+			// about which of its towns the firm sits in, and refusing here would
+			// take "Rubí" away too
+			expect(
+				placeReadOffATownPage(
+					row({
+						name: 'Firma Industrial SL',
+						website: 'https://firma.example',
+						place: 'Rubí, Barcelona',
+						readOn: 'https://firma.example/serveis-barcelona',
+					}),
+				),
+			).toBeNull()
+		})
+
+		it('should still refuse when the page names the town itself', () => {
+			// GIVEN the same firm and the same location, but a page written about
+			// the town the row claims
+			// WHEN read — THEN that is the shape this exists for
+			expect(
+				placeReadOffATownPage(
+					row({
+						name: 'Firma Industrial SL',
+						website: 'https://firma.example',
+						place: 'Rubí, Barcelona',
+						readOn: 'https://firma.example/serralleria-rubi',
+					}),
+				)?.place,
+			).toBe('rubi')
+		})
+	})
+
+	describe('when a town of several words is part of the name', () => {
+		it('should read the name a run of words at a time, as it reads a path', () => {
+			// GIVEN a firm named after the town it is in, written as three words —
+			// which is how nearly every town around here is written
+			// WHEN its own site files a page under that name
+			// THEN the path is spelling the company, not filing it under a town
+			expect(
+				placeReadOffATownPage(
+					row({
+						name: 'Estructures Castellar del Vallès',
+						website: 'https://estructures-castellar.example',
+						place: 'Castellar del Vallès, Barcelona',
+						readOn:
+							'https://estructures-castellar.example/estructures-castellar-del-valles',
+					}),
+				),
+			).toBeNull()
+		})
+	})
+
+	describe('when the row cannot be graded', () => {
+		it('should leave alone a location written without the page it was read on', () => {
+			// GIVEN findings stored before the field was paired with its source
+			// WHEN read — THEN there is nothing to grade the place against
+			expect(placeReadOffATownPage(row({ readOn: null }))).toBeNull()
+			expect(
+				placeReadOffATownPage({
+					name: 'Montvalles',
+					website: 'https://montvalles.com/',
+					location: 'Barberà del Vallès, Barcelona',
+				}),
+			).toBeNull()
+		})
+
+		it('should leave alone a row with no website to establish its own site', () => {
+			// GIVEN a row that never stated a website
+			// WHEN read — THEN nothing says the page belongs to the firm
+			expect(placeReadOffATownPage(row({ website: null }))).toBeNull()
+		})
+
+		it('should leave alone a row that states no place', () => {
+			// GIVEN a row with no location at all
+			// WHEN read — THEN there is no place to refuse
+			expect(placeReadOffATownPage(row({ place: null }))).toBeNull()
+			expect(placeReadOffATownPage(row({ place: '   ' }))).toBeNull()
+		})
+
+		it('should leave alone a source that is not a readable web address', () => {
+			// GIVEN a source id a page supplied that does not parse as an address
+			// WHEN read — THEN no host can be established, so nothing is refused
+			expect(
+				placeReadOffATownPage(row({ readOn: 'not an address' })),
+			).toBeNull()
+			expect(
+				placeReadOffATownPage(row({ readOn: 'https://montvalles.com' })),
+			).toBeNull()
+		})
+
+		it('should leave alone a place too short to be read against a path', () => {
+			// GIVEN a two-letter place, which matches far too easily
+			// WHEN read — THEN it is below the floor and nothing is refused
+			expect(
+				placeReadOffATownPage(
+					row({ place: 'BV', readOn: 'https://montvalles.com/taller-bv' }),
+				),
+			).toBeNull()
+		})
+	})
+})

--- a/packages/research/src/application/town-page-guard.ts
+++ b/packages/research/src/application/town-page-guard.ts
@@ -1,0 +1,151 @@
+/**
+ * Refuses a place that was read off a page the firm wrote ABOUT that town.
+ *
+ * ## What it is
+ *
+ * An ordinary business writes one landing page per town it will travel to —
+ * `stemp.es/mecanizados-castellar-del-valles/`, one of a dozen like it. A scan
+ * meeting that page reads the town as where the firm is. It is not: the page says
+ * where the firm will GO. Twenty-two production scans carried thirteen such rows,
+ * and one firm came back placed in three different towns by three of them.
+ *
+ * The firm is real and belongs on the list, so nothing here drops a row. What is
+ * wrong is one field, and one field is what comes off — the same treatment, in the
+ * same pass, as a location that names a service area rather than a place.
+ *
+ * ## Why the place check next door cannot answer this
+ *
+ * That check compares a row's place to the area the request named, and the
+ * splitter is told to answer a request naming several towns with the widest place
+ * containing them all. Eight of those thirteen rows came from requests naming two
+ * to five towns, so the area is the PROVINCE — and a firm in Vacarisses really is
+ * inside Barcelona. Asked that question the check answers "inside" and is right.
+ *
+ * This asks a different question, and one that does not depend on what was asked:
+ * does the page this place was read on establish it? So it runs whether or not the
+ * run named an area.
+ *
+ * ## The page names itself
+ *
+ * A location arrives paired with the page it was read on, and in eleven of the
+ * thirteen that page IS the landing page. So nothing has to be fetched or guessed:
+ * the reading is whether the page a place cites is filed under that same place.
+ *
+ * Three things have to hold, and each keeps an honest row out:
+ *
+ *  - **the page is on the firm's OWN site.** A directory filing a company under
+ *    its town is doing its job — `einforma.com/viladecavalls`,
+ *    `informa.es/localidad-sabadell-barcelona` — and reading a place off one of
+ *    those is good evidence. Without this screen the rule fires on sixteen
+ *    ordinary rows out of three hundred and thirty-seven; with it, on none.
+ *  - **the page says more than the town.** A path that is only the place is an
+ *    index of a town, not a page written about one.
+ *  - **the town is not part of the company's own name.** "SA RUBI INDUSTRIAL"
+ *    filed at `/sa-rubi-industrial` is spelling itself, not filing under Rubí, and
+ *    it is the one false refusal the first two screens leave behind.
+ *
+ * ## What it will not reach
+ *
+ * A row whose website is missing has nothing to establish its own site with, and
+ * loosening that to "the one host it rests on" trades two more catches for
+ * twenty-eight ordinary rows wearing a doubt they did not earn. A location written
+ * bare, without the page it was read on, cannot be graded at all — findings stored
+ * before that field was paired keep the shape they were written in, and nothing
+ * migrates them.
+ *
+ * Measured over those twenty-two scans: eight of the thirteen refused, no ordinary
+ * row touched, no company deleted.
+ */
+
+import { filingWords, namesTheCompany } from './directory-sites'
+import { collapse, foldTokens } from './entity-guard'
+import { isCitedField, readTextValue } from './guard-shapes'
+import { hostOf, isBareWebAddress } from './source-key'
+
+/**
+ * How short a place may be and still be read against a path.
+ *
+ * Three letters, so "Olot" and "Rubí" are read. The same floor the operator check
+ * next door uses, and for the same reason: this asks only whether a path carries a
+ * town, and a town of four letters is as much a town as any other.
+ */
+const SHORTEST_PLACE_READ = 3
+
+/** Why one place was refused, for the log: what was read, and off what. */
+export interface TownPageReading {
+	/** The firm's own site, which is where the page was. */
+	readonly host: string
+	/** The place the row stated, as the path spells it. */
+	readonly place: string
+	/** The path segment that filed the page under it, so a reader can go and look. */
+	readonly filedAs: string
+}
+
+/**
+ * The place a location CLAIMS, as a path would spell it.
+ *
+ * Taken apart on commas and brackets because a location is written "Castellar del
+ * Vallès, Barcelona, España" and the page is filed under one of those parts, never
+ * under the whole string — and then only the FIRST is read, because that is the
+ * place the row is claiming and the rest are the province and country around it.
+ *
+ * Reading the wider ones too was tried and is a trap. A firm in Rubí writes
+ * "Rubí, Barcelona", and its own site names its province in ordinary paths —
+ * `/serveis-barcelona`, `/delegacions/barcelona`, a news post about Barcelona.
+ * Matching on `barcelona` there refuses the whole location and takes the correct
+ * town away with it. A page filed under the province says nothing about which of
+ * its towns the firm sits in. Over three hundred and sixty-four stored rows the
+ * check fires eight times and every one matches this first place, so reading only
+ * it costs no catch at all.
+ */
+const placeClaimed = (stated: string): string | undefined =>
+	stated
+		.split(/[,()]/)
+		.map(part => collapse(part))
+		.find(part => part.length >= SHORTEST_PLACE_READ)
+
+/**
+ * Whether this row's place was read off a page the firm filed under that place.
+ *
+ * Null whenever it cannot be established — a bare location, no website, a page
+ * somewhere else — because saying nothing is what leaves the row alone.
+ */
+export const placeReadOffATownPage = (
+	row: Record<string, unknown>,
+): TownPageReading | null => {
+	const location = row['location']
+	// A location that does not name the page it was read on cannot be graded, and
+	// a value that is not text is not a place.
+	if (!isCitedField(location)) return null
+	const stated = typeof location.value === 'string' ? location.value : ''
+	if (stated.trim() === '') return null
+	const page = location.source_id.trim()
+	if (!isBareWebAddress(page)) return null
+	const host = hostOf(page)
+	if (host === null) return null
+
+	// Only the firm's own site. A directory filing a company under its town is
+	// stating where it is, which is the opposite of what this refuses.
+	const website = readTextValue(row['website'])
+	if (website === null || hostOf(website) !== host) return null
+
+	// The company's name read exactly the way the path above is read — its words
+	// as written. Deliberately NOT the reading that asks which words identify a
+	// firm among many: that one drops a connector, and "Castellar del Vallès"
+	// without its "del" can never spell the town again, which is most towns here.
+	const ownWords = foldTokens(readTextValue(row['name']) ?? '')
+
+	const place = placeClaimed(stated)
+	if (place === undefined) return null
+	// The town is part of the company's own name, so a path carrying it is
+	// spelling the name rather than filing the page under a town.
+	if (namesTheCompany(ownWords, place)) return null
+
+	for (const segment of filingWords(page)) {
+		if (!namesTheCompany(segment, place)) continue
+		// A path that is only the place is an index of a town, not a page about one.
+		if (segment.join('') === place) continue
+		return { host, place, filedAs: segment.join('-') }
+	}
+	return null
+}

--- a/packages/research/src/index.ts
+++ b/packages/research/src/index.ts
@@ -55,6 +55,7 @@ export {
 	parseFarmRow,
 	rowByRow,
 	scoreFarmReplay,
+	townPageJudge,
 } from './application/eval-farm-replay'
 export {
 	type GoldenParseResult,
@@ -185,6 +186,10 @@ export {
 	researchToolkitLayer,
 	researchToolkitWireFormat,
 } from './application/tools'
+export {
+	placeReadOffATownPage,
+	type TownPageReading,
+} from './application/town-page-guard'
 export {
 	makeUsageMeter,
 	UsageMeter,


### PR DESCRIPTION
## What

A firm that writes one landing page per town it will travel to — `stemp.es/mecanizados-castellar-del-valles/`, one of a dozen like it — was having that town recorded as where the firm *is*. It is not: the page says where the firm will **go**. The company is real and belongs on the list; only its place was wrong, so nine of thirteen such rows in a measured sample carried a location nothing supported, and one firm came back placed in three different towns by three different scans.

This lives in the Research context (`packages/research`, with the offline grading tool in `apps/cli`). It takes the unsupported place off the row and leaves the company alone.

## Changes

**Touches:** the check that reads where a company is, the step that already removes a location naming a service area (which now has a sibling beside it), and the offline replay tool that grades both against rows real scans returned.

- A new reading asks one question with no model and no fetch: **is the page a place was read on filed under that very place?** A location arrives paired with the page it came from, and in eleven of the thirteen that page *is* the landing page — so nothing has to be guessed.
- Only the place the row **leads with** is read. A location is written narrowest-first — "Rubí, Barcelona" — and a page filed under the province says nothing about which of its towns the firm sits in, so refusing on `barcelona` would take the correct "Rubí" away with it.
- Three screens keep honest rows out. The page must be on the firm's **own site**, because a business directory filing a company under its town is doing its job and reading a place off one of those is good evidence. The path must say **more than the town**, or it is an index of a town rather than a page about one. And the town must not be **part of the company's own name** — "SA RUBI INDUSTRIAL" at `/sa-rubi-industrial` is spelling itself, not filing under Rubí.
- The offline replay tool (`pnpm cli research farm-replay`) now grades the two rules apart and reports what each costs, so the per-town figure that has stood at `0/13` reads `8/13`.

## Impact

- **A scan row can now come back without a place where it previously carried one.** This is a shape everything downstream already handles — `location` has always been optional — but it is a real change to what a reader sees: a company that used to show a town now shows none, which is the honest answer rather than a wrong town. Nothing is dropped; the company itself always stays.
- **Both ways in get the behaviour.** The check sits inside the research pipeline, which the MCP tools and the HTTP API share, so an assistant reading `get_research` and the web app see the same rows.
- **No new settings, no schema change, no change to which organisation can see what** (row-level security untouched), and **no new spend** — the reading calls no model and fetches no page, so a run costs exactly what it did before.
- **The research eval's `location_fill` check will read lower, and that is this working.** It scores `rowsLocated === rowsReturned` — a strict all-or-nothing flag — so a pass containing even one refused place reports it as failed. Across the twenty-two stored production scans that check already fails in thirteen, but two that pass today (5/5 and 20/20) hold rows this refuses and would flip. Whether the three golden markets the eval actually scores hold such rows is unmeasured, since running it costs money. Read a drop there as the fix rather than a regression; teaching that check to tell a refused place from one never found is separate work.
- **An existing local corpus file still parses.** The new `placeSource` field is optional on read, so an old file grades `0/13` on the new rule rather than erroring — rebuild it (see `eval/README.md`) to get the real figure.

## Review guide

Start with `packages/research/src/application/town-page-guard.ts` — the file header carries the reasoning, including why the check next door cannot answer this. Everything else follows from it.

**The judgement most worth overruling** is that this removes the unsupported place rather than marking the row `outside_requested_place`, which is what issue #625 asked for. I changed it deliberately: the request splitter answers a request naming several towns with **the widest place containing them all**, so for eight of the thirteen the area is the *province* — and a firm in Vacarisses genuinely is inside Barcelona. Marking those "outside the requested place" would be a false statement. Each refusal is instead logged per row as `research.place.read_off_town_page`, with the page named so you can open it and disagree.

**A review of this branch found one real defect and it is fixed here**, folded into the commit that introduced it rather than added on top. Reading every comma-part of the location let a province in a path refuse the whole location: a firm in Rubí with an ordinary `/serveis-barcelona` page on its own site lost its town. It now reads only the place the row leads with. Measured cost: none — across 364 stored rows the check fires eight times and every one already matched that first place. It does give up one shape on purpose, a location written province-first, and the test that used to assert the old behaviour now documents the trade.

**The subtle line** is in `town-page-guard.ts` where the company's own name is read with `foldTokens` rather than `distinctiveWords`. The latter is what the operator check next door uses, and it is wrong here: it drops connectors, so "Castellar del Vallès" loses its "del" and can never spell the town again — which is most towns in this market. A test covers it.

`eval/farm-replay.example.json` is mechanical — skip it.

**I could not verify this against a live production run.** Every stored scan predates the change that made the area readable at all, and no run has happened since, so the evidence is 364 stored rows rather than a fresh scan. The commit that landed in between only made the area readable and does not touch the path this reads, so I do not expect a difference — but it is an assumption, not a measurement.

No UI in this change, so no screenshots. Nothing here touches auth, tenant isolation, or a parser of outside input, so I did not run a security review.

## Tests

New unit tests for the reading itself (each screen, and every way a row cannot be graded — a place written without its source, no website, no place at all, a source that is not a readable address, a place too short to read). New tests through the place check for the end result: the company survives, the place comes off, it runs even when the request named no area, and a place a directory filed under a town is left alone. New tests for the grading bridge.

## Verification

Ran, on this branch:

- `pnpm install` — no lockfile drift.
- `pnpm -w check-types` — 14/14.
- `pnpm -w build` — 14/14.
- Tests — 23/23 packages. The workspace run was killed the first time under concurrency, so I ran the three that matter directly: research 2417 passed, server 1071 passed, internal 180 passed.
- `pnpm cli research farm-replay` against 364 rows from twenty-two production scans: **8/13 town pages refused, 0 real companies deleted, 0 ordinary places refused in error**, with the operator figure unchanged at 9/14. Same command against the shared template: 2/2, no cost.
- Re-ran every gate above after rebasing onto current `main` and folding the review fix in, and re-ran the replay on both corpora: the figures are unchanged.
- Checked out the tree as of the first commit alone and type-checked it, so a bisect landing there still builds.

## Deferred

Five of the thirteen are not reached, each for one reason, all named in the file: three have no website to establish which site is the firm's own, one states no place at all, and one rests on a bare host with no path to read (that last is a different defect — a US company's name attached to a Spanish site). Loosening the own-site test to "the one host it rests on" would buy two of them at the cost of twenty-eight ordinary rows wearing a doubt they did not earn, so I left it.

A location written bare, without the page it was read on, cannot be graded at all — 58 of the 364 stored rows. That is old data from before the field was paired with its source; no run has produced that shape since, and nothing migrates them.

Closes #625

