### PR TITLE
fix(research): stop condemning a model on one bad answer

### DIFF
--- a/packages/research/src/infrastructure/capability-probe.test.ts
+++ b/packages/research/src/infrastructure/capability-probe.test.ts
@@ -1,12 +1,81 @@
+import { Effect, Redacted } from 'effect'
+import {
+	HttpClient,
+	type HttpClientError,
+	type HttpClientRequest,
+	HttpClientResponse,
+} from 'effect/unstable/http'
 import { describe, expect, it } from 'vitest'
 
 import {
 	classifyJsonSchemaResponse,
 	classifyToolChoiceResponse,
 	jsonSchemaProbeBody,
+	probeModelCapabilities,
 	toolChoiceProbeBody,
 	verdictForStatus,
 } from './capability-probe'
+
+// The body groq returns when the model called the tool but filled its arguments
+// in wrongly — copied from a real run, because the exact wording is what tells
+// this apart from a vendor saying the model cannot call tools at all.
+const TOOL_CALL_DID_NOT_VALIDATE = JSON.stringify({
+	error: {
+		message:
+			"Tool call validation failed: parameters for tool web_search did not match schema: errors: [missing properties: 'limit', additionalProperties 'topn' not allowed]",
+		type: 'invalid_request_error',
+		code: 'tool_use_failed',
+	},
+})
+
+const CALLED_A_TOOL = JSON.stringify({
+	choices: [
+		{ message: { tool_calls: [{ function: { name: 'web_search' } }] } },
+	],
+})
+
+const RETURNED_JSON = JSON.stringify({
+	choices: [{ message: { content: '{"title":"a","year":1}' } }],
+})
+
+/**
+ * A client that answers with the given replies in order, counting how many times
+ * it was asked. The last reply repeats once the script runs out, so a test only
+ * has to write the answers it cares about.
+ */
+const scriptedClient = (
+	replies: ReadonlyArray<{ status: number; body: string }>,
+	asked: { count: number },
+): HttpClient.HttpClient =>
+	HttpClient.makeWith<
+		HttpClientError.HttpClientError,
+		never,
+		HttpClientError.HttpClientError,
+		never
+	>(
+		effect =>
+			Effect.flatMap(effect, (request: HttpClientRequest.HttpClientRequest) => {
+				const reply = replies[asked.count] ?? replies[replies.length - 1]!
+				asked.count += 1
+				return Effect.succeed(
+					HttpClientResponse.fromWeb(
+						request,
+						new Response(reply.body, { status: reply.status }),
+					),
+				)
+			}),
+		Effect.succeed,
+	)
+
+const probeWith = (client: HttpClient.HttpClient) =>
+	Effect.runPromise(
+		probeModelCapabilities({
+			baseUrl: 'https://api.example.test/v1',
+			apiKey: Redacted.make('test-key'),
+			model: 'openai/gpt-oss-120b',
+			tools: [{ type: 'function', function: { name: 'web_search' } }],
+		}).pipe(Effect.provideService(HttpClient.HttpClient, client)),
+	)
 
 describe('classifyToolChoiceResponse', () => {
 	describe('when the model emitted a tool call', () => {
@@ -172,6 +241,17 @@ describe('probe request bodies', () => {
 				expect(verdict).toBe('unknown')
 			})
 
+			it('should not blame the model when a tool call did not validate', () => {
+				// GIVEN a refusal about the arguments this one answer chose — the
+				// model did call the tool, it just filled it in wrongly, and the
+				// next answer may well be right
+				const verdict = verdictForStatus(400, TOOL_CALL_DID_NOT_VALIDATE)
+
+				// WHEN classified — THEN it is held back for a person, because
+				// nothing here says the model cannot do the work
+				expect(verdict).toBe('unknown')
+			})
+
 			it('should blame the model when it is no longer served', () => {
 				// GIVEN a model the vendor has retired
 				// WHEN classified — THEN it counts against the model: gone is as good a
@@ -225,6 +305,93 @@ describe('probe request bodies', () => {
 			}
 			expect(responseFormat.type).toBe('json_schema')
 			expect(responseFormat.json_schema.strict).toBe(true)
+		})
+	})
+})
+
+describe('probeModelCapabilities', () => {
+	describe('when one answer fails and the next one works', () => {
+		it('should report the capability as met', async () => {
+			// GIVEN a model whose first tool call did not validate and whose
+			// second one did — the same model answering twice, differently
+			const asked = { count: 0 }
+			const client = scriptedClient(
+				[
+					{ status: 400, body: TOOL_CALL_DID_NOT_VALIDATE },
+					{ status: 200, body: CALLED_A_TOOL },
+					{ status: 200, body: RETURNED_JSON },
+				],
+				asked,
+			)
+
+			// WHEN probed
+			const result = await probeWith(client)
+
+			// THEN the model is not blamed for the answer that went wrong
+			expect(result.toolChoice.ok).toBe(true)
+			expect(result.passed).toBe(true)
+		})
+	})
+
+	describe('when every answer fails the same way', () => {
+		it('should report the failure and say how many times it asked', async () => {
+			// GIVEN a model that never produces a usable tool call
+			const asked = { count: 0 }
+			const client = scriptedClient(
+				[{ status: 400, body: TOOL_CALL_DID_NOT_VALIDATE }],
+				asked,
+			)
+
+			// WHEN probed
+			const result = await probeWith(client)
+
+			// THEN it is reported as failed, and the report says how hard we tried
+			// so a reader can weigh it
+			expect(result.toolChoice.ok).toBe(false)
+			expect(result.toolChoice.detail).toContain('3 attempts')
+
+			// AND it is still held back rather than counted against the model,
+			// because the refusal never said the model cannot do the work
+			expect(result.toolChoice.verdict).toBe('unknown')
+		})
+	})
+
+	describe('when the vendor never gives a usable answer', () => {
+		it('should ask once rather than spending the run on a slow vendor', async () => {
+			// GIVEN the vendor's own side failing, which says nothing about the
+			// model and is the slowest kind of answer to come back
+			const asked = { count: 0 }
+			const client = scriptedClient(
+				[{ status: 503, body: '{"error":"upstream unavailable"}' }],
+				asked,
+			)
+
+			// WHEN probed
+			const result = await probeWith(client)
+
+			// THEN each of the two capabilities was asked exactly once. Asking
+			// again would multiply the slowest case by three, and the scheduled
+			// check has a fixed slot of time to finish in.
+			expect(asked.count).toBe(2)
+			expect(result.toolChoice.verdict).toBe('transport')
+		})
+	})
+
+	describe('when the key is refused', () => {
+		it('should take that at its word rather than asking again', async () => {
+			// GIVEN a vendor rejecting the key, which no amount of retrying fixes
+			const asked = { count: 0 }
+			const client = scriptedClient(
+				[{ status: 401, body: '{"error":"invalid api key"}' }],
+				asked,
+			)
+
+			// WHEN probed
+			const result = await probeWith(client)
+
+			// THEN each of the two capabilities was asked exactly once
+			expect(asked.count).toBe(2)
+			expect(result.toolChoice.verdict).toBe('auth')
 		})
 	})
 })

--- a/packages/research/src/infrastructure/capability-probe.ts
+++ b/packages/research/src/infrastructure/capability-probe.ts
@@ -88,9 +88,12 @@ const fail = (
  *
  * A 404 is the model being gone, which is as good a reason to stop trusting it
  * as a refusal. A 401 or 403 is about the key. A 429 is about how fast we asked.
- * Anything from the vendor's own side says nothing at all. A plain 400 usually
- * is the model declining the request, but not always — a model that needs terms
- * accepted answers exactly the same way — so the body decides.
+ * Anything from the vendor's own side says nothing at all.
+ *
+ * A 400 only counts against the model when the vendor says so in as many words:
+ * it can just as easily be terms waiting to be accepted, or one answer whose tool
+ * arguments came out wrong while the next one would have been fine. A refusal
+ * nobody can read is held back for a person rather than blamed on the model.
  */
 export const verdictForStatus = (
 	status: number,
@@ -106,9 +109,7 @@ export const verdictForStatus = (
 			lower.includes('does not support') ||
 			lower.includes('not supported') ||
 			lower.includes('unsupported')
-		if (aboutTheModel) return 'capability'
-		if (lower.includes('terms') || lower.includes('quota')) return 'unknown'
-		return 'capability'
+		return aboutTheModel ? 'capability' : 'unknown'
 	}
 	return 'unknown'
 }
@@ -268,6 +269,50 @@ const runCheck = (
 	)
 
 /**
+ * How many times one capability is asked for before a failure is believed.
+ *
+ * The same request can come back a good answer one time and a bad one the next,
+ * so concluding from a single bad answer reads a model that mostly works as one
+ * that never does — which is how a working spare gets reported as broken. Only a
+ * model that fails every time has said something that still holds tomorrow.
+ */
+const MAX_ATTEMPTS = 3
+
+/**
+ * One capability check, asked again while a failure could still be luck.
+ *
+ * Only what the model itself said is worth asking twice. A rejected key or a rate
+ * limit is not the model choosing badly, and will answer the same way however
+ * often we ask.
+ */
+const runCheckUntilSettled = (
+	client: HttpClient.HttpClient,
+	url: string,
+	apiKey: Redacted.Redacted<string>,
+	body: Record<string, unknown>,
+	classify: (json: unknown) => ProbeCheck,
+): Effect.Effect<ProbeCheck> =>
+	Effect.gen(function* () {
+		let attemptsMade = 1
+		let check = yield* runCheck(client, url, apiKey, body, classify)
+		while (
+			!check.ok &&
+			attemptsMade < MAX_ATTEMPTS &&
+			// Only the model's own answers are asked again: asking a slow or broken
+			// vendor three times over runs the check out of the time it is given.
+			(check.verdict === 'capability' || check.verdict === 'unknown')
+		) {
+			attemptsMade += 1
+			check = yield* runCheck(client, url, apiKey, body, classify)
+		}
+		// Say how hard we tried, so a reader can weigh the verdict rather than
+		// take it on trust.
+		return check.ok || attemptsMade === 1
+			? check
+			: { ...check, detail: `${check.detail} (${attemptsMade} attempts)` }
+	})
+
+/**
  * Probe one model's two required capabilities against an OpenAI-compatible endpoint.
  * Requires an `HttpClient`; never fails — each capability is reported as a check.
  */
@@ -280,14 +325,14 @@ export const probeModelCapabilities = (input: {
 	Effect.gen(function* () {
 		const client = yield* HttpClient.HttpClient
 		const url = `${input.baseUrl.replace(/\/$/, '')}/chat/completions`
-		const toolChoice = yield* runCheck(
+		const toolChoice = yield* runCheckUntilSettled(
 			client,
 			url,
 			input.apiKey,
 			toolChoiceProbeBody(input.model, input.tools),
 			classifyToolChoiceResponse,
 		)
-		const jsonSchema = yield* runCheck(
+		const jsonSchema = yield* runCheckUntilSettled(
 			client,
 			url,
 			input.apiKey,


### PR DESCRIPTION
## What

Every morning a scheduled check asks each AI model the research pipeline is configured to use whether it can still do its job — call a tool when told to, and answer in a fixed shape. Models get withdrawn or change behaviour without anything in this repo changing, and the check exists so we find out before a customer's research run does.

Yesterday it accused a working model and opened an issue. This fixes the check, not the model.

The evidence is in the check's own output. It probed `openai/gpt-oss-120b` on groq twice in the same run — once for the agent tier, once for the writer tier, the same model at the same vendor with the same request — and got a pass one time and a failure the other. That can only happen if the answer is not the same every time, which for these models it is not: they pick their words rather than look them up. The failure was a tool call whose arguments did not validate — the model did call the tool, it just named one of the fields wrongly, and the next answer was fine.

This lives in `packages/research`, in the check the daily job runs. No part of a live research run changed.

## The fix

**Touches:** how the check reads a refusal it cannot make sense of, and how many times it asks before believing a failure. The research pipeline itself, and what a run does when a model actually fails mid-run, are untouched.

- A refusal nobody can read no longer counts against the model. It used to: any rejection the check could not match to a known phrase fell through to the one verdict that means "this model is finished, and it will still be finished tomorrow" — so the case we understand *least* produced the most confident conclusion. Now only a vendor saying so in as many words counts against a model; anything else is reported for a person to look at, without raising an alarm.
- A failure is asked again before it is believed, up to three times, stopping at the first pass. One answer from a model that picks its words is not evidence about the model.
- Only the model's own answers are asked again. A rejected key, a rate limit, or a request that never came back is not the model choosing badly — and retrying a timeout in particular would have been costly: three attempts at a 45-second ceiling across six configured slots is about 27 minutes against the 15 the scheduled job is allowed, so a vendor outage would have killed the job mid-step and reported nothing at all. That is the failure this check exists to prevent, so it would have been an unusually bad one to introduce.

## Impact

Nothing in production changes behaviour: no database migration, nothing touching which organisation can see what (row-level security), no new settings the server needs in order to start, no change to the shape of anything the web app or the tool surface reads, and no change to what a research run costs or does. The only code that changed is reached by one command, `pnpm cli research probe-config`, which the daily job runs.

What does change is the daily job's verdict. Tomorrow morning it will **pass** where it has been failing, and this case moves into the list it prints under "could not tell — nothing here says a model went bad". A model that genuinely cannot do the work still fails the job, and now says `(3 attempts)` beside the reason, which is a far stronger claim than one refusal.

Worth being deliberate about: the check is now harder to set off. A real capability loss whose error message we do not recognise will be *reported* rather than *alarmed*. I think that is the right trade — the alternative is what produced this issue — but it is a judgement, and it is yours to overrule.

## Review guide

Start at `verdictForStatus` in `packages/research/src/infrastructure/capability-probe.ts`. The whole first half of this PR is the last line of its 400 branch changing from `capability` to `unknown`; everything else there is the comment explaining why.

Then `runCheckUntilSettled` just below it. The condition on its loop is the load-bearing part and the place I got it wrong first time round: retrying `transport` failures is what blows the job's time budget, so the loop deliberately retries only `capability` and `unknown` — the two verdicts that come from something the model actually said. A test pins that, because the cost of widening it is invisible until a vendor has a bad night.

Two things I would flag rather than bury:

- I removed the explicit `terms` / `quota` branch. Its behaviour is unchanged — both now reach the same `unknown` through the new default — and the existing test for terms acceptance still passes untouched, which is what convinced me the branch was redundant rather than load-bearing.
- I did **not** touch the model configuration in `apps/server/config.production.json`, which is what the issue asks for. See Deferred.

## Tests

Unit, in `capability-probe.test.ts`. The four new cases drive `probeModelCapabilities` through a stand-in HTTP client that answers from a script and counts what it was asked, following the pattern the sibling reachability test already uses: a failure then a pass reports the capability as met; an always-failing check reports how many times it asked; a slow vendor and a rejected key are each asked exactly once.

I checked every one of them can actually fail, by putting each bug back and confirming only the intended test broke:

| Bug reintroduced | Result |
| --- | --- |
| Unreadable refusal blames the model | 3 failed |
| Ask once and conclude from it | 2 failed |
| Retry slow vendors too | 1 failed |

I re-ran all three after the readability pass, since edits made late are the least reviewed.

## Verification

- Reproduced the bug first: fed the exact groq refusal from the issue to `verdictForStatus` and watched it return `capability`.
- Ran the real command end-to-end against a stand-in vendor on localhost — `pnpm cli research probe --base-url … --api-key-env …` — scripted to refuse the first tool call the way groq did and accept the second. The vendor logged `tool_choice #1, tool_choice #2, json_schema` and the CLI printed `✓ openai/gpt-oss-120b … Gate: 1/1 passed`. That is the issue's own scenario, passing, through the real CLI and the real package code.
- `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test` (23 tasks), `pnpm -w build` — all green. `packages/research` on its own: 2402 passing.
- Repo-wide `biome check` clean.

I could **not** run the probe against groq itself: it needs `RESEARCH_LLM_AGENT_API_KEY_2`, which is not in my environment and there is no Infisical CLI on this machine.

## Deferred

Whether `openai/gpt-oss-120b` is actually a good enough fallback for the agent tier. This PR proves it is not *permanently* broken — it passed the same check three times out of four in the run that filed the issue — but that does not say whether it gets the tool arguments wrong 5% of the time or 40%, and only the second is worth swapping the model over. Running `pnpm cli research probe --api-key-env RESEARCH_LLM_AGENT_API_KEY_2 --models openai/gpt-oss-120b` a dozen times with that key set would settle it.

Addresses #629.

I chose `Addresses` rather than `Closes` because merging this stops the false alarm but does not answer the question above, which is what the issue was originally about. Say the word if you would rather it close on merge and the model question be tracked separately.
