### PR TITLE
feat: say how much of a measurement pass was lost before its rates

### DIFF
--- a/apps/cli/src/commands/research.ts
+++ b/apps/cli/src/commands/research.ts
@@ -606,10 +606,30 @@ const count = (value: number | null): string =>
 const decimal = (value: number | null): string =>
 	value === null ? 'n/a' : value.toFixed(1)
 
+/**
+ * What the pass lost, printed directly under the run count and above the rates it
+ * qualifies.
+ *
+ * Silent when nothing was lost, so its presence is the warning. Every rate below
+ * is taken over the runs that came back, and a pass measured through a model
+ * vendor having a bad hour reports worse rates over fewer runs — which reads
+ * exactly like research having got worse. These two lines are what tell the
+ * reader which of the two they are looking at.
+ */
+const formatRunsLost = (summary: EvalSummary): ReadonlyArray<string> => [
+	...(summary.runsThatNeverAnswered > 0
+		? [`  never answered:       ${summary.runsThatNeverAnswered}`]
+		: []),
+	...(summary.runsStoppedByProvider > 0
+		? [`  cut short by vendor:  ${summary.runsStoppedByProvider}`]
+		: []),
+]
+
 const formatSummary = (summary: EvalSummary): string =>
 	[
 		'',
 		`Runs:                   ${summary.runs}`,
+		...formatRunsLost(summary),
 		`Grounding accuracy:     ${pct(summary.groundingAccuracy)}`,
 		`Field precision:        ${pct(summary.fieldPrecision)}`,
 		`Field recall:           ${pct(summary.fieldRecall)}`,

--- a/packages/research/src/application/eval-report.test.ts
+++ b/packages/research/src/application/eval-report.test.ts
@@ -14,6 +14,8 @@ const score = (over: Partial<RunScore>): RunScore => ({
 	grounded: true,
 	groundable: true,
 	marketWentUnanswered: false,
+	wentUnanswered: false,
+	searchingStopped: null,
 	wrongCompany: false,
 	wrongCompanyAutoApplicable: false,
 	lowConfidence: false,
@@ -185,6 +187,8 @@ describe('evalSummaryAttributes', () => {
 				scansReportingCoverage: null,
 				scansSayingWhyTheyStopped: null,
 				scansThatNeverAnswered: null,
+				runsThatNeverAnswered: 0,
+				runsStoppedByProvider: 0,
 				scansCutOff: null,
 				partsThoughtAnswered: null,
 				duplicateRate: null,
@@ -240,6 +244,8 @@ describe('evalSummaryAttributes', () => {
 				scansReportingCoverage: null,
 				scansSayingWhyTheyStopped: null,
 				scansThatNeverAnswered: null,
+				runsThatNeverAnswered: 0,
+				runsStoppedByProvider: 0,
 				scansCutOff: null,
 				partsThoughtAnswered: null,
 				duplicateRate: null,
@@ -514,6 +520,8 @@ describe('reporting a pass that held market requests', () => {
 			scansReportingCoverage: null,
 			scansSayingWhyTheyStopped: null,
 			scansThatNeverAnswered: null,
+			runsThatNeverAnswered: 0,
+			runsStoppedByProvider: 0,
 			scansCutOff: null,
 			partsThoughtAnswered: null,
 			duplicateRate: null,
@@ -543,6 +551,30 @@ describe('reporting a pass that held market requests', () => {
 			expect('eval.grounding_accuracy' in attrs).toBe(false)
 		})
 
+		it('should always say how much of the pass was lost, nought included', () => {
+			// GIVEN a clean pass, where nothing was lost
+			const attrs = evalSummaryAttributes(
+				summary({ runsThatNeverAnswered: 0, runsStoppedByProvider: 0 }),
+			)
+
+			// WHEN charted — THEN both still appear. Nought is the reading that says
+			// the rates beside them were taken over the whole pass, so leaving it out
+			// would make a clean pass and an unmeasured one look the same.
+			expect(attrs['eval.runs_that_never_answered']).toBe(0)
+			expect(attrs['eval.runs_stopped_by_provider']).toBe(0)
+		})
+
+		it('should carry what a degraded pass lost', () => {
+			// GIVEN a pass where a vendor killed three runs and cut two more short
+			const attrs = evalSummaryAttributes(
+				summary({ runsThatNeverAnswered: 3, runsStoppedByProvider: 2 }),
+			)
+
+			// WHEN charted — THEN both counts ride along with the rates
+			expect(attrs['eval.runs_that_never_answered']).toBe(3)
+			expect(attrs['eval.runs_stopped_by_provider']).toBe(2)
+		})
+
 		it('should carry each market rate that has a reading', () => {
 			// GIVEN a market pass with figures
 			const attrs = evalSummaryAttributes(
@@ -558,6 +590,8 @@ describe('reporting a pass that held market requests', () => {
 					scansReportingCoverage: null,
 					scansSayingWhyTheyStopped: null,
 					scansThatNeverAnswered: null,
+					runsThatNeverAnswered: 0,
+					runsStoppedByProvider: 0,
 					scansCutOff: null,
 					partsThoughtAnswered: null,
 					duplicateRate: 0.16,

--- a/packages/research/src/application/eval-report.ts
+++ b/packages/research/src/application/eval-report.ts
@@ -368,6 +368,10 @@ export const evalSummaryAttributes = (
 		attributes['eval.scans_that_never_answered'] =
 			summary.scansThatNeverAnswered
 	}
+	// Always charted, nought included: nought is the reading that says the rates
+	// beside them were taken over the whole pass rather than over what survived it.
+	attributes['eval.runs_that_never_answered'] = summary.runsThatNeverAnswered
+	attributes['eval.runs_stopped_by_provider'] = summary.runsStoppedByProvider
 	// Reported whenever any scan ran, including nought — that is the reading that
 	// says the never-searched share above is blind rather than clean.
 	if (summary.scansReportingCoverage !== null) {

--- a/packages/research/src/application/eval-scoring-types.ts
+++ b/packages/research/src/application/eval-scoring-types.ts
@@ -474,6 +474,24 @@ export interface RunScore {
 	 * nothing to score at all.
 	 */
 	readonly marketWentUnanswered: boolean
+	/**
+	 * The same fact about any row, market or not: the run came back with nothing
+	 * to score.
+	 *
+	 * The figure above says it for market rows, because it is read beside the
+	 * other market ones. This one is read beside the pass, where a run that died
+	 * is otherwise indistinguishable from a run that worked and found nothing —
+	 * both land in `empty`, and only one of them says anything about quality.
+	 */
+	readonly wentUnanswered: boolean
+	/**
+	 * Why the run stopped looking, for any row rather than only a market one.
+	 *
+	 * Carried up so a pass can say how many of its runs a vendor cut short. That
+	 * is the difference between a pass that measured worse and a pass that was
+	 * measured through an outage.
+	 */
+	readonly searchingStopped: SearchStopped | null
 	/** What the list got right, present only for a row that asked for a market. */
 	readonly market?: MarketScore
 }
@@ -612,6 +630,24 @@ export interface EvalSummary {
 	 * killed mid-search.
 	 */
 	readonly scansThatNeverAnswered: number | null
+	/**
+	 * How much of the pass never answered at all, and how much of it a vendor cut
+	 * short — across every run, not only the market ones. Cut short means a vendor
+	 * turned the run away; a run that ran out of time or money hit a limit of our
+	 * own and is not counted here.
+	 *
+	 * Every rate above is taken over the runs that came back. When a model vendor
+	 * has a bad hour, a pass finishes with fewer of those and reports its rates
+	 * over what survived, which reads exactly like research having got worse. It
+	 * is not the same thing, and nothing else here tells them apart: a run that
+	 * died and a run that worked and found nothing both land in `emptyRate`.
+	 *
+	 * Counted rather than shared, for the same reason as the scan figures above —
+	 * a share cannot say whether it rests on forty runs or on four. Nought is the
+	 * healthy reading for both.
+	 */
+	readonly runsThatNeverAnswered: number
+	readonly runsStoppedByProvider: number
 	readonly duplicateRate: number | null
 	/**
 	 * The share of rows that may repeat a company, read loosely enough to see the

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -1459,6 +1459,8 @@ describe('summarizeScores', () => {
 		grounded: true,
 		groundable: true,
 		marketWentUnanswered: false,
+		wentUnanswered: false,
+		searchingStopped: null,
 		wrongCompany: false,
 		wrongCompanyAutoApplicable: false,
 		lowConfidence: false,
@@ -1499,6 +1501,8 @@ describe('summarizeScores', () => {
 				scansReportingCoverage: null,
 				scansSayingWhyTheyStopped: null,
 				scansThatNeverAnswered: null,
+				runsThatNeverAnswered: 0,
+				runsStoppedByProvider: 0,
 				scansCutOff: null,
 				partsThoughtAnswered: null,
 				duplicateRate: null,
@@ -1550,6 +1554,55 @@ describe('summarizeScores', () => {
 			expect(summary.profileFieldsTotal).toBe(6)
 			expect(summary.contactsNamedPerRun).toBe(2)
 			expect(summary.contactsTitledPerRun).toBe(1.5)
+		})
+	})
+
+	describe('when some runs never came back with anything', () => {
+		it('should count them, so the rates are not read as the whole pass', () => {
+			// GIVEN a pass of four runs, two of which never answered — the shape a
+			// pass takes when a model vendor has a bad hour
+			const summary = summarizeScores([
+				score({}),
+				score({}),
+				score({ wentUnanswered: true, empty: true }),
+				score({ wentUnanswered: true, empty: true }),
+			])
+
+			// WHEN summarized — THEN how much of the pass was lost is reported
+			expect(summary.runsThatNeverAnswered).toBe(2)
+
+			// AND the run count still covers every row that was asked for, so the
+			// two read together as "half of these answered"
+			expect(summary.runs).toBe(4)
+		})
+	})
+
+	describe('when a vendor cut a run short but it still answered', () => {
+		it('should count it apart from the runs that never answered', () => {
+			// GIVEN one run stopped early because a vendor refused, and one that
+			// stopped of its own accord
+			const summary = summarizeScores([
+				score({ searchingStopped: 'provider_refused' }),
+				score({ searchingStopped: 'finished_looking' }),
+			])
+
+			// WHEN summarized — THEN only the refused one counts
+			expect(summary.runsStoppedByProvider).toBe(1)
+
+			// AND it is not counted as never having answered, because it did
+			expect(summary.runsThatNeverAnswered).toBe(0)
+		})
+	})
+
+	describe('when every run answered', () => {
+		it('should report nothing lost rather than leaving it unsaid', () => {
+			// GIVEN a clean pass
+			const summary = summarizeScores([score({}), score({})])
+
+			// WHEN summarized — THEN both counts read nought, which is what says the
+			// rates were taken over the whole pass
+			expect(summary.runsThatNeverAnswered).toBe(0)
+			expect(summary.runsStoppedByProvider).toBe(0)
 		})
 	})
 
@@ -1759,6 +1812,8 @@ describe('summarizing a pass that held market requests', () => {
 		grounded: true,
 		groundable: true,
 		marketWentUnanswered: false,
+		wentUnanswered: false,
+		searchingStopped: null,
 		wrongCompany: false,
 		wrongCompanyAutoApplicable: false,
 		lowConfidence: false,
@@ -2439,6 +2494,37 @@ describe('scoring a run that answered with a list of companies', () => {
 			// the wrong-company measure, so the shape returning the most companies
 			// could never be measured at all
 			expect(score.empty).toBe(false)
+		})
+	})
+
+	describe('when a company run died before it answered', () => {
+		it('should say it never answered, not merely that it found nothing', () => {
+			// GIVEN a company row — not a market one — whose run failed
+			const score = scoreRun(acme, outcome({ status: 'failed' }))
+
+			// WHEN scored — THEN it is marked as never having answered, which is
+			// what separates a vendor outage from research that found nothing
+			expect(score.wentUnanswered).toBe(true)
+
+			// AND the market-only figure stays silent, because no market was asked
+			// for and it speaks only for the ones that were
+			expect(score.marketWentUnanswered).toBe(false)
+		})
+	})
+
+	describe('when a company run was cut short by a vendor', () => {
+		it('should carry that up, not only for market rows', () => {
+			// GIVEN a company run that answered but stopped early because a vendor
+			// refused
+			const score = scoreRun(
+				acme,
+				outcome({ status: 'succeeded', searchingStopped: 'provider_refused' }),
+			)
+
+			// WHEN scored — THEN the reason is carried, so a pass can say how many
+			// of its runs a vendor cut short
+			expect(score.searchingStopped).toBe('provider_refused')
+			expect(score.wentUnanswered).toBe(false)
 		})
 	})
 

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -322,6 +322,8 @@ export const scoreRun = (
 		grounded,
 		groundable: expected.market === undefined,
 		marketWentUnanswered,
+		wentUnanswered: !endedWithAnAnswer(outcome.status),
+		searchingStopped: outcome.searchingStopped,
 		wrongCompany,
 		wrongCompanyAutoApplicable,
 		lowConfidence,
@@ -371,6 +373,8 @@ export const summarizeScores = (
 			scansSayingWhyTheyStopped: null,
 			scansCutOff: null,
 			scansThatNeverAnswered: null,
+			runsThatNeverAnswered: 0,
+			runsStoppedByProvider: 0,
 			partsThoughtAnswered: null,
 			duplicateRate: null,
 			possibleDuplicateRate: null,
@@ -442,6 +446,8 @@ export const summarizeScores = (
 	let scansSayingWhyTheyStopped = 0
 	let scansCutOff = 0
 	let scansThatNeverAnswered = 0
+	let runsThatNeverAnswered = 0
+	let runsStoppedByProvider = 0
 	let totalReportedMissing = 0
 	let totalReportedNeverSearched = 0
 	let totalReportedThoughtAnswered = 0
@@ -478,6 +484,8 @@ export const summarizeScores = (
 			totalContactsTitled += score.profile.contactsTitled
 		}
 		if (score.marketWentUnanswered) scansThatNeverAnswered++
+		if (score.wentUnanswered) runsThatNeverAnswered++
+		if (score.searchingStopped === 'provider_refused') runsStoppedByProvider++
 		if (score.market !== undefined) {
 			scansScored++
 			totalRowsReturned += score.market.rowsReturned
@@ -590,6 +598,8 @@ export const summarizeScores = (
 			scansScored + scansThatNeverAnswered === 0
 				? null
 				: scansThatNeverAnswered,
+		runsThatNeverAnswered,
+		runsStoppedByProvider,
 		partsThoughtAnswered:
 			scansReportingCoverage === 0 ? null : totalReportedThoughtAnswered,
 		duplicateRate: perRow(totalRowsDuplicated),


### PR DESCRIPTION
## What

The research eval harness reports quality rates — grounding accuracy, field precision, how often a run came back with the wrong company. Every one of those is worked out over the runs that came back with something to score.

So when a model vendor has a bad hour, a pass finishes with fewer of those runs and reports its rates over the survivors. That looks identical to research quality having dropped. Issue #575 opens on exactly this: "two of three results turned out to be readings of degraded runs", and "every number this repo takes about research quality is measured through this vendor".

This adds the two counts that tell those apart — how many runs never answered at all, and how many a vendor cut short — and prints them above the rates they qualify. Nothing a customer's research run does changes; this is the measuring instrument reporting on itself.

Lives in `packages/research` (the scorer) and `apps/cli` (the printed report).

## Changes

**Touches:** the per-run score, the pass summary rolled up from it, the span attributes charted from that summary, and the block the runner prints at the end. The research pipeline itself, and what a run does when a vendor fails mid-run, are untouched.

- Carried two facts up for every row that were previously kept only for market ones. The scorer already worked out whether a run never answered and why it stopped looking; for a company row it computed both and threw them away, so a company run that died was indistinguishable in the summary from one that ran fine and found nothing. Both land in `emptyRate`, and only one of them says anything about quality.
- Counted them across the pass as `runsThatNeverAnswered` and `runsStoppedByProvider`, reported as counts rather than shares — the same choice the neighbouring scan figures make, since a share cannot say whether it rests on forty runs or four.
- Printed them directly under the run count and above the rates, and only when something was lost, so their presence is the warning and an ordinary pass reads exactly as short as before.

## Impact

Nothing in production changes behaviour: no database migration, nothing touching which organisation can see what (row-level security), no new settings the server needs at start-up, no change to the shape of anything the web app or the tool surface reads, and no change to what a research run costs or does.

Two things worth knowing:

- **Two new charted attributes**, `eval.runs_that_never_answered` and `eval.runs_stopped_by_provider`. Both are always sent, nought included — nought is the reading that says the rates beside them were taken over the whole pass rather than over what survived it, and omitting it would make a clean pass and an unmeasured one look the same.
- **Stored reports gain two fields.** A report written by this build has them; one written by an older build does not. Nothing reads old reports back except a person, so this needs no migration — but a before/after comparison across the change will show the fields appearing.

## Review guide

Start at `scoreRun` in `eval-scoring.ts` — the two added lines are the whole behavioural change, and everything else follows from them. `wentUnanswered` deliberately uses `endedWithAnAnswer`, which treats "looked and found nothing" as an answer: that is real information about a market, and counting it as a loss would blame the vendor for an honest empty result.

`runsStoppedByProvider` counts only `provider_refused`, not every stop reason. That is narrower than the `scansCutOff` field just above it, which counts every non-settling reason including our own round cap and deadline — a reader coming from that field would reasonably expect the same breadth, so the type says so explicitly and a test pins it.

One limitation I did not fix, because it is structural and pre-existing: the per-market breakdown is built from scores that *have* a market, and a run that died carries none — so `runsThatNeverAnswered` reads nought in every per-market summary. The existing `scansThatNeverAnswered` behaves the same way there. The whole-pass summary, and the by-bucket and by-country breakdowns, do include them.

Skip-able: the fifteen mechanical `runsThatNeverAnswered: 0, runsStoppedByProvider: 0` additions to existing test fixtures, required by the interface.

## Tests

Five new cases. Two on the scorer, that a company run which died is marked as never having answered and that a vendor's refusal is carried up for a non-market row — these are the ones covering what was previously discarded. Two on the summariser, that the counts add up and that a refusal is counted apart from a death. One on the charted attributes, that both appear even at nought.

I checked each can actually fail, by putting the bug back and confirming only the intended test broke:

| Bug reintroduced | Result |
| --- | --- |
| Company rows discard both signals again (the old behaviour) | 2 failed |
| Count every stop reason, not only a vendor's refusal | 1 failed |
| Chart the counts only when non-zero | 1 failed |

The seam below this was already covered: `outcomeFromRun` reading `searching_stopped` out of a real run's stored findings has its own tests, so the chain from stored data through to the reported number is complete.

The printed CLI lines themselves have no test, per this repo's rule against testing CLI code — the summary they render is what is tested.

## Verification

- `pnpm install` (no lockfile drift), `pnpm -w check-types`, `pnpm -w test` (23 tasks), `pnpm -w build` — all green. `packages/research` on its own: 2410 passing.
- Repo-wide `biome check` clean.
- Four mutation runs, each failing only its intended test.

I did **not** run a live measurement pass: that costs real vendor credits and needs keys I do not have. The change is pure computation over scores the harness already produces, and the chain from stored findings to reported number is covered by tests end to end.

## What this does and does not close

Addresses #575. It closes the third acceptance criterion (a pass reports how many calls failed alongside its rates). The other two I investigated rather than coded, and posted the evidence on the issue:

- **Attribution (AC1)** is answered from production telemetry. Of 115 failed model calls across 1856, 94% are the first vendor — a chronic `StructuredOutputError` on the extract tier plus a one-day outage. But dead runs tell a different story: 8 of the 9 runs that died were the *second* vendor rejecting our own tool schema, and every one of those causes has since been fixed.
- **Not dying on a bad shape (AC2)** looks met by work already on main, but on thin evidence — only 8 runs have happened since the last fix deployed.

I have left both boxes unticked for you to judge.
