### PR TITLE
fix(research): stop a company search paying for lookups it should not make

### DIFF
--- a/apps/internal/src/components/research/findings/prospect-lead-payload.test.ts
+++ b/apps/internal/src/components/research/findings/prospect-lead-payload.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	buildLeadPayload,
+	type ProspectLeadSource,
+} from './prospect-lead-payload'
+
+// Rows as a real scan wrote them — a Girona industrial-engineering search whose
+// countries came back as words rather than codes, which is what made half of
+// every prospect ever scanned impossible to add.
+const prospect = (over: Partial<ProspectLeadSource>): ProspectLeadSource => ({
+	name: 'Cobra Instalaciones y Servicios, S.A.',
+	...over,
+})
+
+describe('buildLeadPayload', () => {
+	describe('when the run named its country in words', () => {
+		it('should carry it across as the code the CRM stores', () => {
+			// GIVEN the spellings real scans produced
+			const spanish = buildLeadPayload(prospect({ countries: ['España'] }), 's')
+			const english = buildLeadPayload(prospect({ countries: ['Spain'] }), 's')
+
+			// WHEN built — THEN both reach the CRM as the same code, so a person can
+			// filter on it afterwards
+			expect(spanish.payload.country).toBe('ES')
+			expect(english.payload.country).toBe('ES')
+			expect(spanish.dropped).toEqual([])
+		})
+
+		it('should take the first of several, which is where it is registered', () => {
+			// GIVEN a company with a place in more than one country
+			const built = buildLeadPayload(
+				prospect({ countries: ['Portugal', 'Spain'] }),
+				's',
+			)
+
+			// WHEN built — THEN the row holds the one country it can, and it is the
+			// first
+			expect(built.payload.country).toBe('PT')
+		})
+	})
+
+	describe('when the country cannot be turned into a code', () => {
+		it('should add the lead without it and say so', () => {
+			// GIVEN a country the run itself was unsure of
+			const built = buildLeadPayload(
+				prospect({
+					countries: ['Portugal? (uncertain – site uses .br domain)'],
+				}),
+				's',
+			)
+
+			// WHEN built — THEN the lead survives, the country does not, and the
+			// caller is told which field went rather than left to notice
+			expect(built.payload.country).toBeUndefined()
+			expect(built.payload.name).toBe('Cobra Instalaciones y Servicios, S.A.')
+			expect(built.dropped).toEqual(['country'])
+		})
+
+		it('should say nothing when the run named no country at all', () => {
+			// GIVEN a row with no country to begin with
+			const built = buildLeadPayload(prospect({}), 's')
+
+			// WHEN built — THEN nothing was dropped, because nothing was offered:
+			// naming a field the run never filled would read as a fault
+			expect(built.dropped).toEqual([])
+		})
+	})
+
+	describe('when the country is already a code', () => {
+		it('should keep it, whatever case it came in', () => {
+			// GIVEN a code the model wrote in lower case. It passes the CRM's read
+			// but fails its write, and the browser is what writes.
+			expect(
+				buildLeadPayload(prospect({ countries: ['es'] }), 's').payload.country,
+			).toBe('ES')
+			expect(
+				buildLeadPayload(prospect({ countries: ['ES'] }), 's').payload.country,
+			).toBe('ES')
+		})
+	})
+
+	describe('when the web address is not one', () => {
+		it('should add the lead without it and say so', () => {
+			// GIVEN a website field holding something that is not an address
+			const built = buildLeadPayload(
+				prospect({ countries: ['ES'], website: 'not a url' }),
+				's',
+			)
+
+			// WHEN built — THEN the lead lands and only the address is left behind
+			expect(built.payload.website).toBeUndefined()
+			expect(built.dropped).toEqual(['website'])
+		})
+
+		it('should keep a real one', () => {
+			// GIVEN the address this company actually publishes
+			const built = buildLeadPayload(
+				prospect({ website: 'https://www.grupocobra.com' }),
+				's',
+			)
+
+			// WHEN built — THEN it is carried across untouched
+			expect(built.payload.website).toBe('https://www.grupocobra.com')
+			expect(built.dropped).toEqual([])
+		})
+	})
+
+	describe('when a social profile is missing half of itself', () => {
+		it('should leave that one out and keep the rest', () => {
+			// GIVEN a list where one entry says the platform but not the page
+			const built = buildLeadPayload(
+				prospect({
+					social_profiles: [
+						{ kind: 'linkedin', value: 'https://linkedin.com/company/cobra' },
+						{ kind: 'x', value: '  ' },
+					],
+				}),
+				's',
+			)
+
+			// WHEN built — THEN the usable page survives on its own. A footnote is
+			// not worth the lead.
+			expect(built.payload.socialProfiles).toEqual([
+				{ kind: 'linkedin', value: 'https://linkedin.com/company/cobra' },
+			])
+		})
+	})
+
+	describe('when every field the run filled can be stored', () => {
+		it('should carry the whole row and report nothing dropped', () => {
+			// GIVEN a complete row
+			const built = buildLeadPayload(
+				prospect({
+					name: 'EGEIN',
+					industry: 'Ingeniería y construcción industrial',
+					countries: ['ES'],
+					location: 'Celrà, Girona',
+					website: 'https://egein.com',
+				}),
+				'egein-x7f2q',
+			)
+
+			// WHEN built — THEN it arrives whole, at the prospect stage
+			expect(built.payload).toEqual({
+				name: 'EGEIN',
+				slug: 'egein-x7f2q',
+				status: 'prospect',
+				industry: 'Ingeniería y construcción industrial',
+				country: 'ES',
+				location: 'Celrà, Girona',
+				website: 'https://egein.com',
+			})
+			expect(built.dropped).toEqual([])
+		})
+	})
+})

--- a/apps/internal/src/components/research/findings/prospect-lead-payload.ts
+++ b/apps/internal/src/components/research/findings/prospect-lead-payload.ts
@@ -1,0 +1,118 @@
+/**
+ * Turning a scanned prospect into the company row that creates it.
+ *
+ * A scan writes what the pages said, and the CRM only takes what it can store —
+ * a country as two letters, a web address that is one. The two disagree often
+ * enough that half the prospects ever scanned carry a country the CRM refuses,
+ * and the request is checked against its shape in the browser, so a single bad
+ * field used to lose the whole lead before anything left the page.
+ *
+ * So a field that cannot be stored is left out and named, rather than taken
+ * along to be refused. The lead is what the person asked for; the country was a
+ * detail, and one they can type in afterwards.
+ *
+ * Free of JSX and of the translation macros, like the other logic beside these
+ * components: what was dropped comes back as a word the component looks up, so
+ * the sentence a person reads stays where the sentences live.
+ */
+
+import { WEBSITE_ADDRESS_PATTERN } from '@batuda/domain'
+import { mapCountry } from '@batuda/research/application/vocabulary-guard'
+
+/** A field left out because nothing storable could be made of what the run said. */
+export type DroppedLeadField = 'country' | 'website'
+
+/** What a scan row offers up, as far as creating a company needs to know. */
+export interface ProspectLeadSource {
+	readonly name: string
+	readonly industry?: string | undefined
+	readonly countries?: ReadonlyArray<string> | undefined
+	readonly location?: string | undefined
+	readonly website?: string | undefined
+	readonly social_profiles?:
+		| ReadonlyArray<{ readonly kind: string; readonly value: string }>
+		| undefined
+}
+
+export interface LeadPayload {
+	readonly payload: {
+		readonly name: string
+		readonly slug: string
+		readonly status: 'prospect'
+		readonly industry?: string
+		readonly country?: string
+		readonly location?: string
+		readonly website?: string
+		readonly socialProfiles?: ReadonlyArray<{
+			readonly kind: string
+			readonly value: string
+		}>
+	}
+	/** Empty when everything the run said could be carried across. */
+	readonly dropped: ReadonlyArray<DroppedLeadField>
+}
+
+/**
+ * The country a company row can hold, or nothing.
+ *
+ * A scan may name several — every country the company has a place in — and the
+ * row holds the one it is registered in, which is the first. The words the run
+ * used are folded to a code by the same rule the pipeline folds them with, so
+ * "Spain" and "España" reach the CRM as the "ES" a person can then filter on.
+ */
+const storableCountry = (
+	countries: ReadonlyArray<string> | undefined,
+): string | undefined => {
+	const first = countries?.[0]?.trim()
+	if (first === undefined || first === '') return undefined
+	const folded = mapCountry(first)?.toUpperCase()
+	return folded !== undefined && /^[A-Z]{2}$/.test(folded) ? folded : undefined
+}
+
+/** Only pages that say both what platform they are and where. */
+const usableProfiles = (source: ProspectLeadSource) =>
+	(source.social_profiles ?? [])
+		.filter(p => p.kind.trim() !== '' && p.value.trim() !== '')
+		.map(p => ({ kind: p.kind.trim(), value: p.value.trim() }))
+
+/**
+ * The slug is passed in rather than built here because it carries a random
+ * suffix, and a function that answers differently each time cannot be tested by
+ * asking it twice.
+ */
+export const buildLeadPayload = (
+	source: ProspectLeadSource,
+	slug: string,
+): LeadPayload => {
+	const dropped: DroppedLeadField[] = []
+
+	const country = storableCountry(source.countries)
+	if (country === undefined && (source.countries?.[0]?.trim() ?? '') !== '')
+		dropped.push('country')
+
+	const website = source.website?.trim()
+	const storableWebsite =
+		website !== undefined &&
+		website !== '' &&
+		WEBSITE_ADDRESS_PATTERN.test(website)
+			? website
+			: undefined
+	if (storableWebsite === undefined && (website ?? '') !== '')
+		dropped.push('website')
+
+	const profiles = usableProfiles(source)
+
+	return {
+		payload: {
+			name: source.name,
+			slug,
+			status: 'prospect',
+			...(source.industry ? { industry: source.industry } : {}),
+			...(country ? { country } : {}),
+			...(source.location ? { location: source.location } : {}),
+			...(storableWebsite ? { website: storableWebsite } : {}),
+			...(profiles.length > 0 ? { socialProfiles: profiles } : {}),
+		},
+		dropped,
+	}
+}

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -15,6 +15,10 @@ import { PriButton, usePriToast } from '@batuda/ui/pri'
 import { SafeLink } from '#/components/research/safe-link'
 import { BatudaApiAtom } from '#/lib/batuda-api-atom'
 import {
+	buildLeadPayload,
+	type DroppedLeadField,
+} from './prospect-lead-payload'
+import {
 	type Citation,
 	CitationList,
 	type CommonFindings,
@@ -326,33 +330,20 @@ function AddAsLeadButton({
 	)
 	const [busy, setBusy] = useState(false)
 
-	// Only the pages that say both what platform they are and where. These come out
-	// of a model's answer, and one blank entry would otherwise make the whole
-	// request invalid — losing the lead over a footnote, with nothing on screen to
-	// say which row was at fault.
-	const usableProfiles = (prospect.social_profiles ?? [])
-		.filter(p => p.kind.trim() !== '' && p.value.trim() !== '')
-		.map(p => ({ kind: p.kind.trim(), value: p.value.trim() }))
+	// What each field the CRM could not store is called, in words a person reads.
+	// The builder answers with the field, not the sentence, so it can stay clear
+	// of the translation macros the way the other logic beside these components
+	// does.
+	const droppedLabel: Record<DroppedLeadField, MessageDescriptor> = {
+		country: msg`country`,
+		website: msg`website`,
+	}
 
 	const add = async () => {
 		setBusy(true)
 		const slug = toSlug(prospect.name)
-		const exit = await createCompany({
-			payload: {
-				name: prospect.name,
-				slug,
-				status: 'prospect',
-				...(prospect.industry ? { industry: prospect.industry } : {}),
-				// A company row holds one country, and a scan may have named several. The
-				// first is the one it is registered in, which is what the row means.
-				...(prospect.countries?.[0] ? { country: prospect.countries[0] } : {}),
-				...(prospect.location ? { location: prospect.location } : {}),
-				...(prospect.website ? { website: prospect.website } : {}),
-				...(usableProfiles.length > 0
-					? { socialProfiles: usableProfiles }
-					: {}),
-			},
-		})
+		const { payload, dropped } = buildLeadPayload(prospect, slug)
+		const exit = await createCompany({ payload })
 		if (exit._tag !== 'Success') {
 			setBusy(false)
 			toast.add({ title: t`Could not add as a lead`, type: 'error' })
@@ -376,10 +367,22 @@ function AddAsLeadButton({
 		// A wanted vouch that did not land is its own outcome: the company is on
 		// file, and 'unverified' would read as the run's doing rather than as
 		// something to try again.
+		// What the run said but the CRM could not hold. Named on the way past
+		// rather than left to be noticed: the lead is on file either way, and a
+		// company that quietly arrived without its country reads as a company that
+		// never had one.
+		const left = dropped.map(field => t(droppedLabel[field])).join(', ')
 		if (vouchWanted && !verified) {
 			toast.add({
 				title: t`Added, but could not be marked verified`,
 				type: 'error',
+			})
+		} else if (left !== '') {
+			toast.add({
+				title: verified
+					? t`Added as a verified lead, without its ${left}`
+					: t`Added as an unverified lead, without its ${left}`,
+				type: 'success',
 			})
 		} else {
 			toast.add({

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -373,15 +373,23 @@ function AddAsLeadButton({
 		// something to try again. It comes first because it is the one thing here
 		// worth trying again, and a dropped field is not.
 		if (vouchWanted && !verified) {
+			// The dropped fields are named here too. A lead that lost both its
+			// country and its vouch would otherwise only hear about the vouch, which
+			// is the one case this message exists for.
 			toast.add({
-				title: t`Added, but could not be marked verified`,
+				title:
+					left === ''
+						? t`Added, but could not be marked verified`
+						: t`Added, but could not be marked verified, leaving out: ${left}`,
 				type: 'error',
 			})
 		} else if (left !== '') {
+			// Written as a list rather than "without its X", which reads as one
+			// thing and has to agree with it in languages that give words a gender.
 			toast.add({
 				title: verified
-					? t`Added as a verified lead, without its ${left}`
-					: t`Added as an unverified lead, without its ${left}`,
+					? t`Added as a verified lead, leaving out: ${left}`
+					: t`Added as an unverified lead, leaving out: ${left}`,
 				type: 'success',
 			})
 		} else {

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -364,14 +364,14 @@ function AddAsLeadButton({
 					payload: { verified: true },
 				})
 			)._tag === 'Success'
-		// A wanted vouch that did not land is its own outcome: the company is on
-		// file, and 'unverified' would read as the run's doing rather than as
-		// something to try again.
-		// What the run said but the CRM could not hold. Named on the way past
-		// rather than left to be noticed: the lead is on file either way, and a
+		// What the run said but the CRM could not hold, named on the way past: a
 		// company that quietly arrived without its country reads as a company that
 		// never had one.
 		const left = dropped.map(field => t(droppedLabel[field])).join(', ')
+		// A wanted vouch that did not land is its own outcome: the company is on
+		// file, and 'unverified' would read as the run's doing rather than as
+		// something to try again. It comes first because it is the one thing here
+		// worth trying again, and a dropped field is not.
 		if (vouchWanted && !verified) {
 			toast.add({
 				title: t`Added, but could not be marked verified`,

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -512,8 +512,16 @@ msgid "Added as a verified lead"
 msgstr "Afegit com a oportunitat verificada"
 
 #: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added as a verified lead, without its {left}"
+msgstr "Afegit com a oportunitat verificada, sense el seu {left}"
+
+#: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added as an unverified lead"
 msgstr "Afegit com a oportunitat sense verificar"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added as an unverified lead, without its {left}"
+msgstr "Afegit com a oportunitat sense verificar, sense el seu {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added, but could not be marked verified"
@@ -1871,6 +1879,10 @@ msgstr "carregant el recompte"
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Countries"
 msgstr "Països"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "country"
+msgstr "país"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
@@ -6499,6 +6511,10 @@ msgstr "Encaix feble"
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Weaknesses"
 msgstr "Punts febles"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "website"
+msgstr "lloc web"
 
 #: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/run-labels.ts

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -512,20 +512,24 @@ msgid "Added as a verified lead"
 msgstr "Afegit com a oportunitat verificada"
 
 #: src/components/research/findings/prospect-scan-view.tsx
-msgid "Added as a verified lead, without its {left}"
-msgstr "Afegit com a oportunitat verificada, sense el seu {left}"
+msgid "Added as a verified lead, leaving out: {left}"
+msgstr "Afegit com a oportunitat verificada; s'ha deixat fora: {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added as an unverified lead"
 msgstr "Afegit com a oportunitat sense verificar"
 
 #: src/components/research/findings/prospect-scan-view.tsx
-msgid "Added as an unverified lead, without its {left}"
-msgstr "Afegit com a oportunitat sense verificar, sense el seu {left}"
+msgid "Added as an unverified lead, leaving out: {left}"
+msgstr "Afegit com a oportunitat sense verificar; s'ha deixat fora: {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added, but could not be marked verified"
 msgstr "Afegit, però no s'ha pogut marcar com a verificat"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added, but could not be marked verified, leaving out: {left}"
+msgstr "Afegit, però no s'ha pogut marcar com a verificat; s'ha deixat fora: {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/routes/settings/organization/members.tsx

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -512,8 +512,16 @@ msgid "Added as a verified lead"
 msgstr "Added as a verified lead"
 
 #: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added as a verified lead, without its {left}"
+msgstr "Added as a verified lead, without its {left}"
+
+#: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added as an unverified lead"
 msgstr "Added as an unverified lead"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added as an unverified lead, without its {left}"
+msgstr "Added as an unverified lead, without its {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added, but could not be marked verified"
@@ -1871,6 +1879,10 @@ msgstr "count loading"
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Countries"
 msgstr "Countries"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "country"
+msgstr "country"
 
 #: src/components/companies/about-section.tsx
 #: src/components/research/findings/company-enrichment-view.tsx
@@ -6499,6 +6511,10 @@ msgstr "Weak fit"
 #: src/components/research/findings/competitor-scan-view.tsx
 msgid "Weaknesses"
 msgstr "Weaknesses"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "website"
+msgstr "website"
 
 #: src/components/contacts/channel-kind-label.tsx
 #: src/components/research/run-labels.ts

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -512,20 +512,24 @@ msgid "Added as a verified lead"
 msgstr "Added as a verified lead"
 
 #: src/components/research/findings/prospect-scan-view.tsx
-msgid "Added as a verified lead, without its {left}"
-msgstr "Added as a verified lead, without its {left}"
+msgid "Added as a verified lead, leaving out: {left}"
+msgstr "Added as a verified lead, leaving out: {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added as an unverified lead"
 msgstr "Added as an unverified lead"
 
 #: src/components/research/findings/prospect-scan-view.tsx
-msgid "Added as an unverified lead, without its {left}"
-msgstr "Added as an unverified lead, without its {left}"
+msgid "Added as an unverified lead, leaving out: {left}"
+msgstr "Added as an unverified lead, leaving out: {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 msgid "Added, but could not be marked verified"
 msgstr "Added, but could not be marked verified"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Added, but could not be marked verified, leaving out: {left}"
+msgstr "Added, but could not be marked verified, leaving out: {left}"
 
 #: src/components/research/findings/prospect-scan-view.tsx
 #: src/routes/settings/organization/members.tsx

--- a/apps/server/src/services/research-discover-no-domain.integration.test.ts
+++ b/apps/server/src/services/research-discover-no-domain.integration.test.ts
@@ -112,6 +112,7 @@ const budget: BudgetService = {
 			charges.push(`${provider}:${idempotencyKey}`)
 			return { _tag: 'bought' as const, value: yield* Effect.suspend(call) }
 		}),
+	vendorsRefused: () => Effect.succeed([]),
 	snapshot: () => Effect.succeed({} as never),
 }
 

--- a/apps/server/src/services/research-paid-followup.integration.test.ts
+++ b/apps/server/src/services/research-paid-followup.integration.test.ts
@@ -486,6 +486,35 @@ describe('paid-action follow-up', () => {
 		})
 	})
 
+	describe('when a discover_contacts action says the company has no website', () => {
+		it('should run it, because that is a statement and not a gap', async () => {
+			// GIVEN an action whose domain is written as an explicit null — what a
+			// search records for a company with no site of its own, which is the
+			// kind it turns up most
+			const user = `u-nulldom-${randomUUID()}`
+			const before = discoverCalls.length
+			const origin = await seedOrigin(user, [
+				{
+					id: 'pa1',
+					status: 'pending',
+					tool: 'discover_contacts',
+					args: { company_name: 'Acme', domain: null },
+				},
+			])
+
+			// WHEN it is approved and the follow-up runs
+			const result = await approve(origin, 'pa1', user)
+			const followupId =
+				result.status === 'approved' ? result.followup_run_id : ''
+
+			// THEN it runs. Refusing it would dead-end the approval the moment
+			// somebody gave it — discovery takes a null domain on purpose and
+			// answers with names off the register rather than guessed addresses.
+			expect(await pollRun(followupId)).toBe('succeeded')
+			expect(discoverCalls.length).toBe(before + 1)
+		})
+	})
+
 	describe('when a discover_contacts action carries no company at all', () => {
 		it('should backfill it from the origin run single company subject', async () => {
 			// GIVEN a run about one company and a gate whose args are empty

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -454,7 +454,7 @@ Three safety invariants hold regardless of budget: the agent never mutates a CRM
 
 ### Surfaces
 
-The same loop is reached three ways. External agents call the MCP tools (`start_research`, `get_research`, and the in-loop `web_search` / `scrape_page` / `registry_lookup` / `discover_contacts` and the propose-update family) and read a run as an MCP resource. The web app drives the HTTP API — create a run, stream it over SSE, approve a paid action, apply or reject a proposed update. And the research page renders the findings, the human brief, the source list, with a snapshot for each page the run opened, and the proposals panel where a human applies changes.
+The same loop is reached three ways. External agents call the MCP tools (`start_research`, `get_research`, and the in-loop `web_search` / `scrape_page` / `registry_lookup` / `discover_contacts` and the propose-update family) and read a run as an MCP resource. The two that spend money — `registry_lookup` and `discover_contacts` — are withheld from a discovery scan's own agent: a scan is asked for a list of companies, while buying a register record or a set of contacts is work about one of them, and a scan that wants either proposes it under `pending_paid_actions` for a person to approve. The web app drives the HTTP API — create a run, stream it over SSE, approve a paid action, apply or reject a proposed update. And the research page renders the findings, the human brief, the source list, with a snapshot for each page the run opened, and the proposals panel where a human applies changes.
 
 ### Data model
 

--- a/packages/research/package.json
+++ b/packages/research/package.json
@@ -45,6 +45,10 @@
 		"./application/schemas": {
 			"types": "./src/application/schemas/index.ts",
 			"import": "./src/application/schemas/index.ts"
+		},
+		"./application/vocabulary-guard": {
+			"types": "./src/application/vocabulary-guard.ts",
+			"import": "./src/application/vocabulary-guard.ts"
 		}
 	},
 	"scripts": {

--- a/packages/research/src/application/budget.test.ts
+++ b/packages/research/src/application/budget.test.ts
@@ -356,6 +356,115 @@ describe('paying for a vendor call that then fails', () => {
 		})
 	})
 
+	describe('when a vendor says its paid allowance is spent', () => {
+		// A refusal for want of credit, which is what a register with no money on
+		// the account answers every lookup with.
+		const outOfCredit = Effect.fail(
+			new ProviderError({
+				provider: 'librebor',
+				message: 'registry lookup failed: HTTP 402',
+				recoverable: false,
+				quotaExhausted: true,
+			}),
+		)
+
+		it('should turn the next call to that vendor away without charging', async () => {
+			// GIVEN a run whose first registry lookup was refused for want of credit
+			const [outcome, left] = await withBudget(budget =>
+				Effect.gen(function* () {
+					yield* budget
+						.withPaidCharge(
+							'registry',
+							29,
+							'registry_lookup',
+							'k1',
+						)(() => outOfCredit)
+						.pipe(Effect.ignore)
+
+					// WHEN a second, different lookup goes to the same vendor
+					const second = yield* budget.withPaidCharge(
+						'registry',
+						29,
+						'registry_lookup',
+						'k2',
+					)(() => outOfCredit)
+					const snapshot = yield* budget.snapshot()
+					return [second, snapshot.paidRemaining] as const
+				}),
+			)
+
+			// THEN it is told the vendor refused rather than charged again, and the
+			// run's allowance is whole
+			expect(outcome).toEqual({ _tag: 'vendor_refused', provider: 'registry' })
+			expect(left).toBe(100)
+		})
+
+		it('should still let a different vendor be paid', async () => {
+			// GIVEN the same refused register
+			const outcome = await withBudget(budget =>
+				Effect.gen(function* () {
+					yield* budget
+						.withPaidCharge(
+							'registry',
+							29,
+							'registry_lookup',
+							'k1',
+						)(() => outOfCredit)
+						.pipe(Effect.ignore)
+
+					// WHEN another vendor is asked for something
+					return yield* budget.withPaidCharge(
+						'hunter-verify',
+						1,
+						'discover_contacts',
+						'k2',
+					)(() => Effect.succeed('checked'))
+				}),
+			)
+
+			// THEN one vendor running dry does not shut the others off
+			expect(outcome).toEqual({ _tag: 'bought', value: 'checked' })
+		})
+	})
+
+	describe('when a vendor fails for a reason other than credit', () => {
+		it('should keep asking it, since the next call may well answer', async () => {
+			// GIVEN a vendor that failed once with a plain upstream error
+			const outcome = await withBudget(budget =>
+				Effect.gen(function* () {
+					yield* budget
+						.withPaidCharge(
+							'hunter',
+							20,
+							'discover_contacts',
+							'k1',
+						)(() =>
+							Effect.fail(
+								new ProviderError({
+									provider: 'hunter',
+									message: 'upstream 503',
+									recoverable: true,
+								}),
+							),
+						)
+						.pipe(Effect.ignore)
+
+					// WHEN it is asked again
+					return yield* budget.withPaidCharge(
+						'hunter',
+						20,
+						'discover_contacts',
+						'k2',
+					)(() => Effect.succeed('people'))
+				}),
+			)
+
+			// THEN the call goes through — a vendor that was merely down is not a
+			// vendor that has run out of money
+			expect(outcome).toEqual({ _tag: 'bought', value: 'people' })
+		})
+	})
+
 	describe('when the vendor call succeeds', () => {
 		it('should keep the money spent and hand back what was bought', async () => {
 			// GIVEN the same run

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Layer, Ref } from 'effect'
+import { Cause, Effect, Exit, Layer, Option, Ref } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
@@ -8,6 +8,28 @@ import {
 } from '../domain/errors'
 import type { BudgetSnapshot, ResolvedPolicy } from '../domain/types'
 import { Budget } from './ports'
+
+/**
+ * Whether a failed vendor call failed because the account's paid allowance is
+ * spent, rather than because the vendor had nothing to say.
+ *
+ * Read off the value rather than with `instanceof`, so an error crossing a
+ * package boundary is still recognised. A vendor that does not set the flag
+ * never trips the refusal, which is the safe way round: the run keeps paying.
+ */
+const isQuotaRefusal = (error: unknown): boolean =>
+	typeof error === 'object' &&
+	error !== null &&
+	'_tag' in error &&
+	error._tag === 'ProviderError' &&
+	'quotaExhausted' in error &&
+	error.quotaExhausted === true
+
+/** The same question of a whole cause: did this call fail for want of credit? */
+const causeIsQuotaRefusal = <E>(cause: Cause.Cause<E>): boolean => {
+	const error = Cause.findErrorOption(cause)
+	return Option.isSome(error) && isQuotaRefusal(error.value)
+}
 
 // ── Monthly paid spend: check-and-debit serialized per organization ──
 
@@ -185,6 +207,13 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 				spent: 0,
 				remaining: config.policy.paidBudgetCents,
 			})
+			// Vendors that have told this run their paid allowance is spent. A
+			// register with no credit refuses every lookup identically, so the
+			// second call buys exactly what the first did — nothing — and the run
+			// pays the flat price again to be told so. Remembered per run rather
+			// than globally: an allowance topped up between two runs should be
+			// found by the next one rather than waited out.
+			const refusedRef = yield* Ref.make<ReadonlySet<string>>(new Set())
 
 			// Give this run back the room it set aside for a call that did not
 			// happen. This is the run's own allowance — how much more work it may
@@ -346,6 +375,10 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 					) =>
 					<A, E, R>(vendorCall: () => Effect.Effect<A, E, R>) =>
 						Effect.gen(function* () {
+							// A vendor that already ran dry is not asked again — the answer
+							// would be the same and the price would not.
+							if ((yield* Ref.get(refusedRef)).has(provider))
+								return { _tag: 'vendor_refused' as const, provider }
 							const charged = yield* chargePaidImpl(
 								provider,
 								cents,
@@ -359,7 +392,18 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 								Effect.onExit(exit =>
 									Exit.isSuccess(exit)
 										? Effect.void
-										: releaseRunAllowance(cents),
+										: Effect.andThen(
+												// A refusal is remembered, so the next call to
+												// this vendor is turned away rather than charged
+												// a second time.
+												causeIsQuotaRefusal(exit.cause)
+													? Ref.update(
+															refusedRef,
+															seen => new Set([...seen, provider]),
+														)
+													: Effect.void,
+												releaseRunAllowance(cents),
+											),
 								),
 							)
 							return { _tag: 'bought' as const, value }

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit, Layer, Option, Ref } from 'effect'
+import { Cause, Effect, Exit, Layer, Ref } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 
 import {
@@ -25,11 +25,18 @@ const isQuotaRefusal = (error: unknown): boolean =>
 	'quotaExhausted' in error &&
 	error.quotaExhausted === true
 
-/** The same question of a whole cause: did this call fail for want of credit? */
-const causeIsQuotaRefusal = <E>(cause: Cause.Cause<E>): boolean => {
-	const error = Cause.findErrorOption(cause)
-	return Option.isSome(error) && isQuotaRefusal(error.value)
-}
+/**
+ * The same question of a whole cause: did this call fail for want of credit?
+ *
+ * Every failure in it is read, not just the first. A call that cascades across
+ * two vendors keeps both, and the one that ran out of credit is as likely to be
+ * the earlier as the later — reading only the first would leave the vendor
+ * unremembered and every later lookup paying again.
+ */
+const causeIsQuotaRefusal = <E>(cause: Cause.Cause<E>): boolean =>
+	cause.reasons.some(
+		reason => Cause.isFailReason(reason) && isQuotaRefusal(reason.error),
+	)
 
 // ── Monthly paid spend: check-and-debit serialized per organization ──
 

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -409,6 +409,9 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 							return { _tag: 'bought' as const, value }
 						}),
 
+				vendorsRefused: () =>
+					Effect.map(Ref.get(refusedRef), seen => [...seen].sort()),
+
 				snapshot: () =>
 					Effect.gen(function* () {
 						const cheap = yield* Ref.get(cheapRef)

--- a/packages/research/src/application/contact-discovery.test.ts
+++ b/packages/research/src/application/contact-discovery.test.ts
@@ -502,7 +502,7 @@ const anInput = { domain: 'acme.example' }
 const recordCharge =
 	(charged: string[]) =>
 	(label: string) =>
-	<A>(call: () => Effect.Effect<A>) =>
+	<A, E>(call: () => Effect.Effect<A, E>) =>
 		Effect.gen(function* () {
 			charged.push(label)
 			return { _tag: 'bought' as const, value: yield* Effect.suspend(call) }
@@ -718,6 +718,93 @@ describe('runEnrichmentChain', () => {
 			// the charge is taken before the paid call
 			expect(Exit.isFailure(exit)).toBe(true)
 			expect(calls).toEqual([])
+		})
+	})
+})
+
+describe('runEnrichmentChain and the budget it buys through', () => {
+	// A charge whose vendor call is allowed to fail, recording which labels the
+	// failure actually reached. The real budget uses that failure to remember a
+	// vendor with no credit left; a stand-in that swallows it inside the call
+	// would let this pass while production quietly paid twice.
+	const chargeSeeingFailures =
+		(sawFailure: string[]) =>
+		(label: string) =>
+		<A, E>(call: () => Effect.Effect<A, E>) =>
+			Effect.suspend(call).pipe(
+				Effect.tapError(() => Effect.sync(() => sawFailure.push(label))),
+				Effect.map(value => ({ _tag: 'bought' as const, value })),
+			)
+
+	describe('when a vendor refuses because its allowance is spent', () => {
+		it('should let the failure reach the budget rather than swallow it', async () => {
+			// GIVEN a vendor out of credit, and a budget watching for that failure
+			const sawFailure: string[] = []
+			const outcome = await Effect.runPromise(
+				runEnrichmentChain(
+					{
+						mode: 'fallback',
+						attempts: [
+							{
+								label: 'hunter',
+								findPeople: () =>
+									Effect.fail(
+										new ProviderError({
+											provider: 'hunter',
+											message: 'HTTP 429',
+											recoverable: false,
+											quotaExhausted: true,
+										}),
+									),
+							},
+						],
+					},
+					anInput,
+					chargeSeeingFailures(sawFailure),
+				),
+			)
+
+			// THEN the budget saw it — which is what lets it stop paying that vendor
+			// for the rest of the run — and the chain still reports the shortfall
+			// rather than failing the whole discovery
+			expect(sawFailure).toEqual(['hunter'])
+			expect(outcome.quotaExhausted).toBe(true)
+			expect(outcome.people).toEqual([])
+		})
+	})
+
+	describe('when the budget turns a vendor away it already knows is dry', () => {
+		it('should count it as the same shortfall, without calling the vendor', async () => {
+			// GIVEN a budget answering that this vendor already ran dry this run
+			let called = false
+			const outcome = await Effect.runPromise(
+				runEnrichmentChain(
+					{
+						mode: 'fallback',
+						attempts: [
+							{
+								label: 'hunter',
+								findPeople: () => {
+									called = true
+									return Effect.succeed(
+										new EnrichmentResult({ people: [], units: 0 }),
+									)
+								},
+							},
+						],
+					},
+					anInput,
+					() => () =>
+						Effect.succeed({
+							_tag: 'vendor_refused' as const,
+							provider: 'hunter-enrich',
+						}),
+				),
+			)
+
+			// THEN nothing was asked, and the missing people are reported as ours
+			expect(called).toBe(false)
+			expect(outcome.quotaExhausted).toBe(true)
 		})
 	})
 })

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -137,11 +137,15 @@ export const runEnrichmentChain = (
 	// which case the vendor is not called again — the answer would be bought a
 	// second time for real money that this run's record deliberately will not
 	// count twice.
+	// The vendor's own failure is left in the error channel rather than swallowed
+	// inside the call, so the budget sees it: that is what tells a vendor which
+	// ran out of credit apart from one that simply found nobody, and it is what
+	// stops the next company in the same run paying to be refused again.
 	buy: (
 		label: string,
-	) => <A>(
-		call: () => Effect.Effect<A>,
-	) => Effect.Effect<PaidCall<A>, PaidRail>,
+	) => <A, E>(
+		call: () => Effect.Effect<A, E>,
+	) => Effect.Effect<PaidCall<A>, PaidRail | E>,
 ): Effect.Effect<EnrichmentChainOutcome, PaidRail> =>
 	Effect.gen(function* () {
 		const collected: SourcePerson[] = []
@@ -153,17 +157,24 @@ export const runEnrichmentChain = (
 			// resumed after a deploy — is not called again, and the shortfall is
 			// reported instead.
 			const outcome = yield* buy(attempt.label)(() =>
-				attempt.findPeople(input).pipe(
-					// A vendor that could not answer is remembered, not just swallowed.
-					// "Nobody works here" and "we are out of credit" produce the same
-					// empty list, and only one of them is an answer about the company.
-					Effect.catchTag('ProviderError', error =>
-						Effect.sync(() => {
-							if (error.quotaExhausted === true) quotaExhausted = true
-							else vendorFailed = true
-							return new EnrichmentResult({ people: [], units: 0 })
-						}),
-					),
+				attempt.findPeople(input),
+			).pipe(
+				// A vendor that could not answer is remembered, not just swallowed.
+				// "Nobody works here" and "we are out of credit" produce the same empty
+				// list, and only one of them is an answer about the company.
+				//
+				// Caught out here rather than around the call itself: inside, the
+				// failure never reaches the budget, so a vendor with no credit left is
+				// paid again for every company that follows.
+				Effect.catchTag('ProviderError', error =>
+					Effect.sync(() => {
+						if (error.quotaExhausted === true) quotaExhausted = true
+						else vendorFailed = true
+						return {
+							_tag: 'bought' as const,
+							value: new EnrichmentResult({ people: [], units: 0 }),
+						}
+					}),
 				),
 			)
 			if (outcome._tag === 'already_charged') {
@@ -571,26 +582,32 @@ export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 							// agent's own registry_lookup tool. Left uncharged, a discovery
 							// spent real money that neither the run's budget nor the
 							// month's total ever saw.
-							const looked = yield* budget.withPaidCharge(
-								'registry',
-								REGISTRY_LOOKUP_COST_CENTS,
-								'discover_contacts',
-								`${researchId}:registry:${countryWithRegistry}:${input.companyName}`,
-							)(() =>
-								registry
-									.lookup({
+							const looked = yield* budget
+								.withPaidCharge(
+									'registry',
+									REGISTRY_LOOKUP_COST_CENTS,
+									'discover_contacts',
+									`${researchId}:registry:${countryWithRegistry}:${input.companyName}`,
+								)(() =>
+									registry.lookup({
 										country: countryWithRegistry,
 										query: input.companyName,
-									})
-									.pipe(
-										// Registry is best-effort here; any miss (provider failure
-										// or a country with no registry) falls through to enrichment.
-										Effect.catchTags({
-											ProviderError: () => Effect.succeed(null),
-											NoRegistry: () => Effect.succeed(null),
-										}),
-									),
-							)
+									}),
+								)
+								.pipe(
+									// Registry is best-effort here; any miss (provider failure or a
+									// country with no registry) falls through to enrichment.
+									//
+									// Caught out here rather than around the lookup: inside, the
+									// failure never reaches the budget, so a register with no credit
+									// is paid again for every company in the same run.
+									Effect.catchTags({
+										ProviderError: () =>
+											Effect.succeed({ _tag: 'bought' as const, value: null }),
+										NoRegistry: () =>
+											Effect.succeed({ _tag: 'bought' as const, value: null }),
+									}),
+								)
 							// Only a lookup this run actually bought carries directors.
 							// Already paid for on an earlier attempt — what a resume after a
 							// deploy looks like — the register is not asked again: it bills

--- a/packages/research/src/application/contact-discovery.ts
+++ b/packages/research/src/application/contact-discovery.ts
@@ -170,6 +170,13 @@ export const runEnrichmentChain = (
 				alreadyPaid = true
 				continue
 			}
+			// This vendor ran dry earlier in the run, so nothing was called and
+			// nothing charged. The same shortfall as the refusal caught above,
+			// without paying to be told again.
+			if (outcome._tag === 'vendor_refused') {
+				quotaExhausted = true
+				continue
+			}
 			collected.push(...outcome.value.people)
 			if (chain.mode === 'fallback' && collected.length > 0) break
 		}
@@ -584,15 +591,15 @@ export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 										}),
 									),
 							)
-							// Already paid for on an earlier attempt at this run, which is
-							// what a resume after a deploy looks like. The register is not
-							// asked again — it bills per call, and this run's record of
-							// what it spent deliberately will not count the same key twice,
-							// so a second call would be money nothing recorded. The cost is
-							// that the paid finders below are reached instead, which is
-							// dearer than the register would have been.
-							const record =
-								looked._tag === 'already_charged' ? null : looked.value
+							// Only a lookup this run actually bought carries directors.
+							// Already paid for on an earlier attempt — what a resume after a
+							// deploy looks like — the register is not asked again: it bills
+							// per call, and this run's record of what it spent deliberately
+							// will not count the same key twice, so a second call would be
+							// money nothing recorded. Out of credit, it has nothing left to
+							// answer with. Either way the paid finders below are reached
+							// instead, which is dearer than the register would have been.
+							const record = looked._tag === 'bought' ? looked.value : null
 							people = (record?.directors ?? []).map(d => {
 								const { firstName, lastName } = splitPersonName(
 									d.name,
@@ -660,6 +667,15 @@ export class ContactDiscovery extends Context.Service<ContactDiscovery>()(
 								)(() => verifier.verify({ email }))
 								if (checked._tag === 'already_charged') {
 									yield* Ref.set(verifierAlreadyPaid, true)
+									return {
+										verdict: 'unknown' as VerificationVerdict,
+										confidence: undefined as number | undefined,
+									}
+								}
+								// The verifier ran dry earlier in this run, and the refusal that
+								// ran it dry already recorded why below. Unchecked, then — not
+								// checked and found wanting.
+								if (checked._tag === 'vendor_refused') {
 									return {
 										verdict: 'unknown' as VerificationVerdict,
 										confidence: undefined as number | undefined,

--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -350,6 +350,13 @@ export interface BudgetService {
 		R
 	>
 	readonly snapshot: () => Effect.Effect<BudgetSnapshot>
+	/**
+	 * The vendors that refused this run for want of credit, so the finished run
+	 * can say which of its gaps are ours rather than the company's. Kept apart
+	 * from the money snapshot because it is not a sum: a run that stopped asking
+	 * a vendor spent nothing more on it, and the figure alone cannot say why.
+	 */
+	readonly vendorsRefused: () => Effect.Effect<ReadonlyArray<string>>
 }
 
 export class Budget extends Context.Service<Budget, BudgetService>()(

--- a/packages/research/src/application/ports.ts
+++ b/packages/research/src/application/ports.ts
@@ -34,6 +34,12 @@ export class ResearchRunContext extends Context.Service<
 		// company, and that alone turns the re-anchoring off.
 		readonly entityTargets?: EntityTargets | null | undefined
 		readonly entityName?: string | undefined
+		// What kind of run this is, so a handler that spends money can refuse a run
+		// that is not allowed to. The tools a scan may call are already narrowed
+		// where the request is built, but that narrowing is the provider honouring
+		// what it was sent, and a paid call is the wrong place to find out that one
+		// did not.
+		readonly schemaName?: string | undefined
 	}
 >()('research/ResearchRunContext') {}
 
@@ -277,14 +283,21 @@ export class ResearchEventSink extends Context.Service<
 // ── Budget ──
 
 /**
- * What came of paying for a vendor call: the answer that was bought, or word
- * that this run already paid for the same call and holds the answer somewhere
- * — never a bare value, so a caller cannot spend twice by mistaking the second
- * for the first.
+ * What came of paying for a vendor call: the answer that was bought, word that
+ * this run already paid for the same call and holds the answer somewhere, or
+ * word that the vendor's own allowance is spent — never a bare value, so a
+ * caller cannot spend twice by mistaking one for another.
  */
 export type PaidCall<A> =
 	| { readonly _tag: 'bought'; readonly value: A }
 	| { readonly _tag: 'already_charged' }
+	/**
+	 * This vendor already told the run its paid allowance is spent, so nothing
+	 * was charged and nothing was called. An outcome rather than a failure: the
+	 * caller carries on with what it can do without that vendor, exactly as it
+	 * would for a vendor that had nothing to say.
+	 */
+	| { readonly _tag: 'vendor_refused'; readonly provider: string }
 
 export interface BudgetService {
 	readonly chargeCheap: (
@@ -311,6 +324,11 @@ export interface BudgetService {
 	 * answer it never got. A call that fails hands the run's own allowance back;
 	 * a repeat of one already paid for in this run comes back as
 	 * `already_charged` and the vendor is not called again.
+	 *
+	 * Once a vendor has said its allowance is spent, every later call to that
+	 * same vendor in this run comes back as `vendor_refused` without charging.
+	 * A register with no credit answers every lookup the same way, and paying
+	 * the flat price each time buys a run nothing but a smaller allowance.
 	 *
 	 * The call is passed as a function, not as a ready-made effect, so nothing
 	 * of it is built until the money is actually set aside.

--- a/packages/research/src/application/research-quality.test.ts
+++ b/packages/research/src/application/research-quality.test.ts
@@ -29,6 +29,7 @@ const scanInput = {
 	coverageLastMissing: [],
 	existence: null,
 	place: null,
+	vendorsUnavailable: [],
 } as const
 
 describe('computeRunQuality', () => {
@@ -105,6 +106,7 @@ describe('computeRunQuality', () => {
 			coverageLastMissing: [],
 			existence: null,
 			place: null,
+			vendorsUnavailable: [],
 		} as const
 
 		it('should not flag a strong, well-grounded run', () => {
@@ -198,6 +200,7 @@ describe('computeRunQuality', () => {
 			coverageLastMissing: [],
 			existence: null,
 			place: null,
+			vendorsUnavailable: [],
 		} as const
 
 		it('should flag a scan vetted against a single source', () => {
@@ -309,6 +312,7 @@ describe('computeRunQuality', () => {
 			coverageLastMissing: [],
 			existence: null,
 			place: null,
+			vendorsUnavailable: [],
 		} as const
 
 		it('should flag a well-sourced scan that still found only a handful', () => {
@@ -365,6 +369,7 @@ describe('computeRunQuality', () => {
 				coverageLastMissing: [],
 				existence: null,
 				place: null,
+				vendorsUnavailable: [],
 			})
 			// THEN the thin-list signal stays quiet — a missing list is "does not
 			// apply", not "found nothing"
@@ -397,6 +402,7 @@ describe('computeRunQuality', () => {
 			coverageLastMissing: [],
 			existence: null,
 			place: null,
+			vendorsUnavailable: [],
 		} as const
 
 		it('should flag a long list that answered one of the trades asked about', () => {
@@ -531,6 +537,7 @@ describe('computeRunQuality', () => {
 			coverageLastMissing: [],
 			existence: null,
 			place: null,
+			vendorsUnavailable: [],
 		} as const
 
 		it('should flag a run whose citations were all rejected', () => {
@@ -599,6 +606,7 @@ describe('computeRunQuality', () => {
 				coverageLastMissing: [],
 				existence: null,
 				place: null,
+				vendorsUnavailable: [],
 			}).low_confidence
 
 		it('should flag one that never clearly reached that company', () => {
@@ -640,6 +648,7 @@ describe('computeRunQuality', () => {
 				coverageLastMissing: [],
 				existence: null,
 				place: null,
+				vendorsUnavailable: [],
 			})
 			// THEN the count still stands: 'absent' is a verdict on what the evidence
 			// showed, not the run having no company to be about
@@ -670,6 +679,7 @@ describe('computeRunQuality', () => {
 			coverageLastMissing: [],
 			existence: null,
 			place: null,
+			vendorsUnavailable: [],
 		} as const
 
 		it('should leave out the profile numbers a brief never fills', () => {
@@ -745,6 +755,7 @@ describe('computeRunQuality', () => {
 			coverageLastMissing: [],
 			existence: null,
 			place: null,
+			vendorsUnavailable: [],
 		} as const
 
 		it('should report each phase of rounds as its own number', () => {
@@ -785,6 +796,7 @@ describe('computeRunQuality', () => {
 				coverageLastMissing: [],
 				existence: null,
 				place: null,
+				vendorsUnavailable: [],
 			})
 			// THEN zero is reported rather than left out: a run that went back for
 			// nothing is a run that needed nothing, which is worth knowing
@@ -848,6 +860,7 @@ describe('computeRunQuality — how the list split', () => {
 		coverageStopped: null,
 		coverageLastMissing: [],
 		place: null,
+		vendorsUnavailable: [],
 	} as const
 
 	describe('when a scan verified its list', () => {
@@ -857,6 +870,7 @@ describe('computeRunQuality — how the list split', () => {
 				...scan,
 				existence: { confirmed: 4, candidates: 8 },
 				place: null,
+				vendorsUnavailable: [],
 			})
 
 			// THEN a reader can see what the run stands behind without opening it
@@ -869,6 +883,7 @@ describe('computeRunQuality — how the list split', () => {
 				...scan,
 				existence: { confirmed: 0, candidates: 12 },
 				place: null,
+				vendorsUnavailable: [],
 			})
 
 			// THEN the run is reported, not flagged. What to do about a list of
@@ -917,6 +932,7 @@ describe('computeRunQuality — when the run could not read its own subject', ()
 		coverageLastMissing: [],
 		existence: null,
 		place: null,
+		vendorsUnavailable: [],
 	} as const
 
 	describe('when the subject name yielded no key', () => {
@@ -1264,6 +1280,37 @@ describe('computeRunQuality — how the list stands against the place asked for'
 
 			// THEN the signal has nothing to say about it
 			expect(quality.low_confidence).toBe(false)
+		})
+	})
+})
+
+describe('computeRunQuality when a paid source turned the run away', () => {
+	describe('when a vendor refused for want of credit', () => {
+		it('should name it, so a gap on our side is not read as one in the world', () => {
+			// GIVEN a search the national register would not answer, because our own
+			// allowance with it is spent
+			const quality = computeRunQuality({
+				...scanInput,
+				notCompanies: [],
+				vendorsUnavailable: ['registry'],
+			})
+
+			// WHEN the run writes down how it went
+			// THEN the refusal is on the record. Nothing else on a finished run says
+			// the register was shut, and a reader who cannot see that concludes the
+			// companies are not on it.
+			expect(quality.vendors_unavailable).toEqual(['registry'])
+		})
+	})
+
+	describe('when every vendor answered', () => {
+		it('should say nothing at all', () => {
+			// GIVEN a run where nothing refused — including one that asked nobody
+			const quality = computeRunQuality({ ...scanInput, notCompanies: [] })
+
+			// WHEN written down — THEN the field is absent rather than empty, so its
+			// presence alone is the signal and it can be counted off finished runs
+			expect(quality.vendors_unavailable).toBeUndefined()
 		})
 	})
 })

--- a/packages/research/src/application/research-quality.ts
+++ b/packages/research/src/application/research-quality.ts
@@ -91,6 +91,12 @@ export interface RunQualityInput {
 	 * out. Empty for a run that removed nothing, and for every run that is not a
 	 * scan.
 	 */
+	/**
+	 * Paid vendors that refused this run because our allowance with them is
+	 * spent. Empty for a run where every vendor answered, and for one that asked
+	 * none.
+	 */
+	readonly vendorsUnavailable: ReadonlyArray<string>
 	readonly notCompanies: ReadonlyArray<DroppedOrganisation>
 	/** Citations the run offered for its findings. */
 	readonly citationsSeen: number
@@ -299,6 +305,17 @@ export interface RunQuality {
 	 * signal, and how often it happens can be counted off finished runs.
 	 */
 	readonly subject_unreadable?: true
+	/**
+	 * The paid vendors that turned this run away because our own allowance with
+	 * them is spent — the national register, the contact finders.
+	 *
+	 * Present only when one did, because its presence is the whole signal. What a
+	 * run could not buy it also could not report, and a thin answer then reads as
+	 * a fact about the company rather than about us: nothing else on a finished
+	 * run says the register was shut, so a reader is left to conclude the company
+	 * is not on it.
+	 */
+	readonly vendors_unavailable?: ReadonlyArray<string>
 	/** True when the result is thin enough that an automation should not act on it unreviewed. */
 	readonly low_confidence: boolean
 }
@@ -401,6 +418,9 @@ export const computeRunQuality = (input: RunQualityInput): RunQuality => {
 		...(input.existence !== null ? { existence: input.existence } : {}),
 		...(input.place !== null ? { place: input.place } : {}),
 		...(subjectWentUnchecked ? { subject_unreadable: true as const } : {}),
+		...(input.vendorsUnavailable.length > 0
+			? { vendors_unavailable: input.vendorsUnavailable }
+			: {}),
 		low_confidence: lowConfidence,
 	}
 }

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -2392,20 +2392,24 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							typeof args.company_name === 'string'
 								? args.company_name
 								: undefined
-						const domain =
-							typeof args.domain === 'string' ? args.domain : undefined
+						// A domain nobody wrote is not the same as one written as "there
+						// is none". An absent key is ambiguous — whoever proposed the
+						// action may simply have left it out — and guessing addresses off
+						// a bare name is the one thing this must never do, so it fails
+						// closed below. An explicit null is a statement: this company has
+						// no website, which discover_contacts takes on purpose, and
+						// answers with names and titles off the register instead of
+						// guessed addresses.
+						const domainArg = 'domain' in args ? args.domain : undefined
+						const domainStated =
+							(typeof domainArg === 'string' && domainArg !== '') ||
+							domainArg === null
+						const domain = typeof domainArg === 'string' ? domainArg : null
 						const country =
 							typeof args.country === 'string' ? args.country : undefined
-						// The name is the only thing this cannot do without. A company
-						// with no website of its own is exactly what discover_contacts
-						// takes `domain: null` for — it comes back with names and titles
-						// off the register instead of guessed addresses — and a search
-						// that hands work back for approval finds those constantly, so
-						// refusing them here would dead-end the approval the moment
-						// somebody gave it.
-						if (!companyName)
+						if (!companyName || !domainStated)
 							return yield* finishFailed(
-								'discover_contacts requires company_name',
+								'discover_contacts requires company_name, and a domain — write it as null when the company has no website',
 							)
 
 						// Reuse this follow-up's id + budget so the enrichment/verify spend
@@ -2415,7 +2419,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							const budget = yield* Budget
 							return yield* contactDiscovery.discover({
 								companyName,
-								domain: domain ?? null,
+								domain,
 								country,
 								runContext: { researchId, budget },
 							})

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -223,6 +223,7 @@ import {
 	SEARCH_COST_CENTS,
 } from './tool-costs'
 import {
+	agentToolChoice,
 	isUnsupportedScrapeUrl,
 	researchToolkit,
 	researchToolkitLayer,
@@ -431,9 +432,17 @@ export const isValidUuid = (id: string): boolean =>
 const MAX_GROUNDING_RETRIES = 1
 
 // Appended after such a premature finish: push the model to reach the company's
-// own site (or its registry) rather than answering from look-alike pages.
-const GROUNDING_RETRY_INSTRUCTION =
-	'You have not yet confirmed this is the right company from its own website. Before giving a final answer, use web_search to find the official website (try the company name together with its city or country), then scrape_page that site — or look up the company in the official registry. Do not answer from the pages you already have if none of them is its own official site.'
+// own site (or its registry) rather than answering from look-alike pages. The
+// register is named only where the run may actually reach it — an anchored scan
+// meets the same "not confirmed yet" test as an enrichment run, but its agent is
+// handed a shorter tool list, so pointing it at the register sends it after
+// something that is not on the wire.
+const groundingRetryInstruction = (schemaName: string): string =>
+	`You have not yet confirmed this is the right company from its own website. Before giving a final answer, use web_search to find the official website (try the company name together with its city or country), then scrape_page that site${
+		isDiscoveryScan(schemaName)
+			? ''
+			: ' — or look up the company in the official registry'
+	}. Do not answer from the pages you already have if none of them is its own official site.`
 
 // When an enrichment run finishes without having gathered any employee-count
 // signal, it gets this many nudges to search for the headcount before ending — the
@@ -1284,7 +1293,11 @@ export const buildResearchSystemPrompt = (args: {
 		'The employee headcount is rarely on a company\'s own homepage. If the site does not state it, search for it (the company name with "number of employees", or its LinkedIn / ZoomInfo profile) before finishing — do not conclude the size is unknown without having searched.',
 		"The company's own site rarely tells the whole story. Vary your searches across the open web — recent news and trade press (roughly the last 12 months), industry blogs, magazines, and event or conference pages — for funding, leadership changes, tooling, and growth signals the site omits.",
 		'For a citation to a page you scraped, set source_id to the exact URL you scraped with scrape_page. Never invent an identifier — a made-up source is dropped.',
-		'Name the people who run the company — each with the exact title they are given — and treat that as part of the job, not an extra. They are listed on a team, leadership, management or "equipo" page, almost never on the homepage, so open one when the site has it. When reading the pages turns up nobody with a title, discover_contacts is the tool that finds them.',
+		`Name the people who run the company — each with the exact title they are given — and treat that as part of the job, not an extra. They are listed on a team, leadership, management or "equipo" page, almost never on the homepage, so open one when the site has it. ${
+			isDiscoveryScan(args.schemaName)
+				? 'When reading the pages turns up nobody with a title, the tools that would buy you names are not yours to call on a list of companies: add a `pending_paid_actions` entry naming discover_contacts and the company, and a person decides whether to spend it.'
+				: 'When reading the pages turns up nobody with a title, discover_contacts is the tool that finds them.'
+		}`,
 		'A search result quotes only the one sentence of a page that matched your query. When a page looks like it holds more than that sentence, open it with scrape_page rather than settling for the snippet.',
 		'For discovery or prospecting queries, prefer authoritative sources — business directories, industry association member lists, and sector registries — over social media, forums, or glossary pages. Treat such a page as somewhere to find candidates, not as the answer: a "top N" or "largest" ranking lists the biggest firms in a sector, which is the opposite of what most prospecting asks for. Carry every qualifier in the request — size, place, and niche — into each search, and check each candidate against all of them before returning it; leave out one that fails any, however prominently a directory listed it.',
 		...(isDiscoveryScan(args.schemaName) ? [DISCOVERY_PLAN_DIRECTIVE] : []),
@@ -5421,7 +5434,11 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										query: registryQuery,
 									}),
 								)
-								if (looked._tag === 'already_charged') return
+								// Nothing to seed: either this run already bought the same
+								// lookup, or the register has no credit left to answer it.
+								// The run carries on with what the web tells it, exactly as it
+								// does when the register does not list the company.
+								if (looked._tag !== 'bought') return
 								const record = looked.value
 								const hash = urlHashForScrape(record.sourceUrl)
 								// A record read from a national register sits in `sources`
@@ -5510,11 +5527,10 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										const response = yield* agentLlm.generateText({
 											prompt,
 											toolkit,
-											// Force a tool on the first round so the model can't
-											// answer from memory without gathering evidence (which
-											// would leave zero sources and fail the grounding gate
-											// on a legitimate company); reflect freely after.
-											toolChoice: round === 1 ? 'required' : 'auto',
+											// A scan is offered a shorter list than the toolkit
+											// holds, and round one must call a tool either way —
+											// the helper says why.
+											toolChoice: agentToolChoice(schemaName, round),
 										})
 										prompt = Prompt.concat(
 											prompt,
@@ -5713,7 +5729,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											groundingRetries++
 											prompt = Prompt.concat(
 												prompt,
-												Prompt.make(GROUNDING_RETRY_INSTRUCTION),
+												Prompt.make(groundingRetryInstruction(schemaName)),
 											)
 											return true
 										}
@@ -5986,6 +6002,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								place: hints?.place,
 								entityTargets,
 								entityName,
+								schemaName,
 							}),
 						),
 						Effect.withSpan('research.phase1', {

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1584,6 +1584,11 @@ export const buildBriefPrompt = (args: {
 	readonly existence?:
 		| { readonly confirmed: number; readonly candidates: number }
 		| undefined
+	/**
+	 * Paid sources that refused this run because our allowance with them is
+	 * spent. Absent for a run every source answered.
+	 */
+	readonly vendorsUnavailable?: ReadonlyArray<string> | undefined
 }): string => {
 	const subject = briefSubject(args.subjectName)
 	const heading =
@@ -1650,6 +1655,17 @@ export const buildBriefPrompt = (args: {
 			: [
 					`A company the run could not establish as real carries \`existence_unconfirmed\` in its \`marks\`, with \`existence_reason\` saying what was missing; a company without that mark is one the run stopped doubting, because two independent websites named it and one is established as its own. ${args.existence.candidates} of the ${args.existence.candidates + args.existence.confirmed} carry the mark. Say so near the top, in ${args.language}, and wherever you name companies make clear which are which. Never present a marked company as an established one. The mark is not the run judging that a company does not exist — it is the run unable to settle it either way, and \`budget_exhausted\`, \`deadline_reached\` or \`checker_unavailable\` mean it never got to check at all.`,
 				]
+	// A paid source that turned the run away leaves gaps that look exactly like
+	// gaps in the world. Nothing else in the material says the difference, so
+	// without this the brief reports our unpaid bill as a fact about the
+	// companies — that the register does not list them, that nobody works there.
+	const vendorsShut =
+		args.vendorsUnavailable === undefined ||
+		args.vendorsUnavailable.length === 0
+			? []
+			: [
+					`One or more paid sources this run relies on turned it away because our own allowance with them is spent: ${args.vendorsUnavailable.join(', ')}. Say so in ${args.language}, in a sentence of its own, and say plainly that what is missing because of it is missing on our side. Never write that a company is absent from a source the run could not open.`,
+				]
 	return [
 		`Write a concise human-readable research brief in ${args.language}, summarizing ONLY the material below.`,
 		heading,
@@ -1661,6 +1677,7 @@ export const buildBriefPrompt = (args: {
 		// prohibition without sending the model hunting for something.
 		'Write the brief and nothing else. Never add a note about these instructions, about what you did or did not include, or about what the material does not contain.',
 		...standing,
+		...vendorsShut,
 		'`proposed_updates`, `pending_paid_actions` and `discovered_existing` are how the run hands work back to the CRM, not things it found out. Never report one as a finding, and never let one be the whole brief.',
 		'When the material carries news or dated events, give recent developments (roughly the last 12 months) a short section of their own.',
 		...shortfall,
@@ -3069,6 +3086,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					// so every terminal path can say so, rather than leaving the retry —
 					// the main lever on a thin list — to be reconstructed from logs.
 					let refinedRetry = false
+					// The paid vendors that turned this run away for want of credit.
+					// Carried out of phase 1 for the same reason as the flag above: the
+					// budget that knows goes out of scope long before the run writes
+					// down how it went, and a gap nobody could pay to fill is a fact
+					// about us that the answer otherwise reports as one about the
+					// company.
+					let vendorsUnavailable: ReadonlyArray<string> = []
 					// The kinds of company the request asked for, split out before any
 					// searching started. Carried out of phase 1 because what came back is
 					// held against it once more at the end, over the findings phase 2
@@ -5990,6 +6014,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							refined,
 							refinePassRefused,
 							cheapCents,
+							vendorsRefused: yield* budget.vendorsRefused(),
 						}
 					}).pipe(
 						Effect.provide(researchToolkitLayer),
@@ -6049,6 +6074,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 					retryFindings = phaseOutcome.findings
 					refinedRetry = phaseOutcome.refined
 					cheapSpentCents = phaseOutcome.cheapCents
+					vendorsUnavailable = phaseOutcome.vendorsRefused
 
 					// Entity grounding gate: from the fetched evidence alone (never the
 					// model's prose), classify how strongly the pages concern the
@@ -7156,6 +7182,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 								unsearchedParts: requestCoverage?.unsearched ?? [],
 								searchStopped,
 								existence: existenceCounts,
+								vendorsUnavailable,
 							}),
 						})
 
@@ -7229,6 +7256,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						coverageLastMissing,
 						existence: null,
 						place: null,
+						vendorsUnavailable,
 					})
 
 					if ((sources?.n ?? 0) < MIN_GROUNDED_SOURCES) {
@@ -7342,6 +7370,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 						coverageLastMissing,
 						existence: existenceCounts ?? null,
 						place: placeStanding,
+						vendorsUnavailable,
 					})
 					const findingsWithQuality = {
 						...withRegistryFlag(findings as Record<string, unknown>),

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1560,6 +1560,16 @@ const briefSubject = (name: string | undefined): string =>
  * a machine-readable block would still leave them unable to tell a market with no
  * lift installers from a search that stopped before it looked for any.
  */
+// A paid source in words a person reads. The budget keys these by the slug it
+// charges under — `hunter-verify`, `fullenrich-enrich` — which names our billing
+// arrangement rather than anything the reader of a brief could place.
+const vendorInWords = (slug: string): string => {
+	if (slug === 'registry') return 'the national business register'
+	if (slug.endsWith('-enrich')) return 'the contact finder'
+	if (slug.endsWith('-verify')) return 'the email address checker'
+	return 'a paid source'
+}
+
 export const buildBriefPrompt = (args: {
 	readonly schemaName: string
 	readonly language: string
@@ -1659,12 +1669,14 @@ export const buildBriefPrompt = (args: {
 	// gaps in the world. Nothing else in the material says the difference, so
 	// without this the brief reports our unpaid bill as a fact about the
 	// companies — that the register does not list them, that nobody works there.
+	const shutInWords = [
+		...new Set((args.vendorsUnavailable ?? []).map(vendorInWords)),
+	]
 	const vendorsShut =
-		args.vendorsUnavailable === undefined ||
-		args.vendorsUnavailable.length === 0
+		shutInWords.length === 0
 			? []
 			: [
-					`One or more paid sources this run relies on turned it away because our own allowance with them is spent: ${args.vendorsUnavailable.join(', ')}. Say so in ${args.language}, in a sentence of its own, and say plainly that what is missing because of it is missing on our side. Never write that a company is absent from a source the run could not open.`,
+					`One or more paid sources this run relies on turned it away because our own allowance with them is spent: ${shutInWords.join(', ')}. Say so in ${args.language}, in a sentence of its own, and say plainly that what is missing because of it is missing on our side. Never write that a company is absent from a source the run could not open.`,
 				]
 	return [
 		`Write a concise human-readable research brief in ${args.language}, summarizing ONLY the material below.`,
@@ -2384,9 +2396,16 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							typeof args.domain === 'string' ? args.domain : undefined
 						const country =
 							typeof args.country === 'string' ? args.country : undefined
-						if (!companyName || !domain)
+						// The name is the only thing this cannot do without. A company
+						// with no website of its own is exactly what discover_contacts
+						// takes `domain: null` for — it comes back with names and titles
+						// off the register instead of guessed addresses — and a search
+						// that hands work back for approval finds those constantly, so
+						// refusing them here would dead-end the approval the moment
+						// somebody gave it.
+						if (!companyName)
 							return yield* finishFailed(
-								'discover_contacts requires company_name and domain',
+								'discover_contacts requires company_name',
 							)
 
 						// Reuse this follow-up's id + budget so the enrichment/verify spend
@@ -2396,7 +2415,7 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							const budget = yield* Budget
 							return yield* contactDiscovery.discover({
 								companyName,
-								domain,
+								domain: domain ?? null,
 								country,
 								runContext: { researchId, budget },
 							})

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+
 import { Effect, Layer, Logger, Schema, Stream } from 'effect'
 import { describe, expect, it } from 'vitest'
 
@@ -1158,6 +1160,33 @@ describe('agentToolChoice', () => {
 			// form, because narrowing a run nobody classified would silently take
 			// tools away from it
 			expect(agentToolChoice('freeform_v1', 2)).toBe('auto')
+		})
+	})
+})
+
+describe('the tool choice the agent loop actually sends', () => {
+	// The helper being right is half of it. This reads the real call site's
+	// source and asserts it passes the helper rather than a hand-written choice —
+	// reverting that one line otherwise breaks nothing anywhere in the suite,
+	// which is exactly how the narrowing would be lost.
+	const callSite = readFileSync(
+		new URL('./research-service.ts', import.meta.url),
+		'utf8',
+	)
+
+	describe('when the loop asks the model for a round', () => {
+		it('should hand it the choice this module decides, not one of its own', () => {
+			// GIVEN the generateText call the reflect loop makes
+			const call = callSite.slice(
+				callSite.indexOf('agentLlm.generateText({'),
+				callSite.indexOf('agentLlm.generateText({') + 600,
+			)
+
+			// WHEN its toolChoice is read
+			// THEN it defers to the helper. A literal 'required'/'auto' here is the
+			// narrowing silently gone for every discovery scan.
+			expect(call).toContain('toolChoice: agentToolChoice(schemaName, round)')
+			expect(call).not.toMatch(/toolChoice:\s*round === 1/)
 		})
 	})
 })

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -52,6 +52,7 @@ const stubBudget = Layer.succeed(Budget)(
 				_tag: 'bought' as const,
 				value,
 			})),
+		vendorsRefused: () => Effect.succeed([]),
 		snapshot: () =>
 			Effect.succeed({
 				cheapBudget: 1000,
@@ -1241,6 +1242,7 @@ describe('what a tool call charges the run', () => {
 						_tag: 'bought' as const,
 						value,
 					})),
+				vendorsRefused: () => Effect.succeed([]),
 				snapshot: () =>
 					Effect.succeed({
 						cheapBudget: 1000,
@@ -1319,6 +1321,7 @@ describe('looking the same company up twice in one run', () => {
 				// Already paid for in this run, so the vendor is never called.
 				withPaidCharge: () => () =>
 					Effect.succeed({ _tag: 'already_charged' as const }),
+				vendorsRefused: () => Effect.succeed([]),
 				snapshot: () =>
 					Effect.succeed({
 						cheapBudget: 1000,
@@ -1405,6 +1408,7 @@ describe('looking up a country Batuda has no register for', () => {
 							value: yield* Effect.suspend(call),
 						}
 					}),
+				vendorsRefused: () => Effect.succeed([]),
 				snapshot: () =>
 					Effect.succeed({
 						cheapBudget: 1000,
@@ -1502,6 +1506,7 @@ describe('a run that spends its budget', () => {
 							remaining,
 						}),
 					),
+				vendorsRefused: () => Effect.succeed([]),
 				snapshot: () =>
 					Effect.succeed({
 						cheapBudget: 1000,
@@ -1647,6 +1652,7 @@ describe('a run that spends its budget', () => {
 						Effect.fail(
 							new MonthlyCapExceeded({ capCents: 5000, spentCents: 5000 }),
 						),
+					vendorsRefused: () => Effect.succeed([]),
 					snapshot: () =>
 						Effect.succeed({
 							cheapBudget: 1000,

--- a/packages/research/src/application/tools.test.ts
+++ b/packages/research/src/application/tools.test.ts
@@ -28,6 +28,7 @@ import {
 	SearchProvider,
 } from './ports'
 import {
+	agentToolChoice,
 	isUnsupportedScrapeUrl,
 	RegistryLookupTool,
 	researchToolkit,
@@ -1078,6 +1079,88 @@ describe('stripPlaceholderSiteFilters', () => {
 	})
 })
 
+describe('agentToolChoice', () => {
+	// The tools that charge the organisation. Listed once so a new paid tool
+	// only has to be added here to be held to the same test.
+	const paidTools = ['registry_lookup', 'discover_contacts']
+	const oneOfFor = (schema: string, round: number): ReadonlyArray<string> => {
+		const choice = agentToolChoice(schema, round)
+		// Only a scan gets the object form; anything else names no list at all.
+		return typeof choice === 'object' && 'oneOf' in choice ? choice.oneOf : []
+	}
+
+	describe('when the run is a discovery scan', () => {
+		it('should offer the free tools only, for either kind of scan', () => {
+			// GIVEN both schemas that are discovery scans
+			// WHEN each is asked what a later round may call
+			// THEN both get searching and reading, and nothing that spends
+			expect(oneOfFor('prospect_scan_v1', 2)).toEqual([
+				'web_search',
+				'scrape_page',
+			])
+			expect(oneOfFor('competitor_scan_v1', 2)).toEqual([
+				'web_search',
+				'scrape_page',
+			])
+		})
+
+		it('should keep every paid tool out of reach', () => {
+			// GIVEN a scan on its first and a later round
+			// WHEN the offered lists are read
+			// THEN neither carries a tool that charges the organisation
+			for (const round of [1, 2]) {
+				for (const paid of paidTools) {
+					expect(oneOfFor('prospect_scan_v1', round)).not.toContain(paid)
+				}
+			}
+		})
+
+		it('should still force a tool call on the first round', () => {
+			// GIVEN the first round of a scan, where answering from memory would
+			// leave no sources behind
+			const first = agentToolChoice('prospect_scan_v1', 1)
+			const later = agentToolChoice('prospect_scan_v1', 2)
+
+			// WHEN the mode is read — THEN round one must call something and a
+			// later round may reflect instead
+			expect(first).toEqual({
+				mode: 'required',
+				oneOf: ['web_search', 'scrape_page'],
+			})
+			expect(later).toEqual({
+				mode: 'auto',
+				oneOf: ['web_search', 'scrape_page'],
+			})
+		})
+	})
+
+	describe('when the run is about one named company', () => {
+		it('should leave the whole toolkit reachable', () => {
+			// GIVEN the two schemas whose whole job is a single company
+			// WHEN each is asked what it may call
+			// THEN no list is named at all, so every tool stays on the wire
+			expect(agentToolChoice('company_enrichment_v1', 2)).toBe('auto')
+			expect(agentToolChoice('contact_discovery_v1', 2)).toBe('auto')
+		})
+
+		it('should still force a tool call on the first round', () => {
+			// GIVEN the first round of an enrichment run
+			// WHEN the choice is read — THEN it is the bare forcing, unchanged
+			expect(agentToolChoice('company_enrichment_v1', 1)).toBe('required')
+		})
+	})
+
+	describe('when the schema is one nothing recognises', () => {
+		it('should leave the whole toolkit reachable rather than guess', () => {
+			// GIVEN a schema name that is not a discovery scan
+			// WHEN the choice is read — THEN it falls through to the unrestricted
+			// form, because narrowing a run nobody classified would silently take
+			// tools away from it
+			expect(agentToolChoice('freeform_v1', 2)).toBe('auto')
+		})
+	})
+})
+
 describe('researchToolkitWireFormat', () => {
 	describe('when serialising the toolkit for a provider', () => {
 		it('should carry every research tool in the shape sent to a provider', () => {
@@ -1638,6 +1721,163 @@ describe('a run that spends its budget', () => {
 				level: 'Error',
 				message: 'research.tool.failed',
 			})
+		})
+	})
+})
+
+describe('the paid tools when the run is a discovery scan', () => {
+	// The handlers reached directly, so the answer is the handler's own and not
+	// the provider's narrowing — which is the whole point of the check.
+	const handleOnScan = async (
+		tool: 'registry_lookup' | 'discover_contacts',
+		params: Record<string, unknown>,
+	) => {
+		let vendorCalled = false
+		const ports = Layer.mergeAll(
+			StubSearchProvider,
+			StubScrapeProvider,
+			Layer.succeed(RegistryRouter)(
+				RegistryRouter.of({
+					lookup: () => {
+						vendorCalled = true
+						return Effect.succeed(
+							new RegistryRecord({
+								legalName: 'Acme SL',
+								sourceUrl: 'https://registry.example/acme',
+								units: 1,
+							}),
+						)
+					},
+				}),
+			),
+		)
+		const infra = Layer.mergeAll(
+			stubBudget,
+			Layer.succeed(ResearchRunContext)({
+				researchId: 'test-run',
+				schemaName: 'prospect_scan_v1',
+			}),
+			Layer.succeed(ContactDiscovery)({
+				discover: () => {
+					vendorCalled = true
+					return Effect.succeed({
+						status: 'no_reliable_contact' as const,
+						researchId: 'test-run',
+					})
+				},
+			}),
+		)
+		const results: unknown[] = []
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const toolkit = yield* researchToolkit
+				const stream = yield* toolkit.handle(tool, params as never)
+				yield* Stream.runForEach(stream, part =>
+					Effect.sync(() => results.push(part)),
+				)
+			}).pipe(
+				Effect.provide(
+					researchToolkitLayer.pipe(
+						Layer.provide(Layer.mergeAll(ports, infra)),
+					),
+				),
+			),
+		)
+		return { vendorCalled, results }
+	}
+
+	describe('when a scan calls the register anyway', () => {
+		it('should refuse without reaching the vendor', async () => {
+			// GIVEN a scan whose model asked for a registry lookup regardless of
+			// what it was offered — a provider that ignores the narrowing, say
+			const { vendorCalled, results } = await handleOnScan('registry_lookup', {
+				country: 'ES',
+				query: 'Acme SL',
+				tax_id: null,
+			})
+
+			// THEN nothing was bought, and the model is told where the request
+			// belongs instead of being handed a bare refusal
+			expect(vendorCalled).toBe(false)
+			expect(JSON.stringify(results)).toContain('pending_paid_actions')
+		})
+	})
+
+	describe('when a scan calls contact discovery anyway', () => {
+		it('should refuse without reaching the vendor', async () => {
+			// GIVEN the same, for the other tool that spends
+			const { vendorCalled, results } = await handleOnScan(
+				'discover_contacts',
+				{
+					company_name: 'Acme SL',
+					domain: 'acme.example',
+					country: 'ES',
+				},
+			)
+
+			// THEN the same answer: nothing bought, and a route to take instead
+			expect(vendorCalled).toBe(false)
+			expect(JSON.stringify(results)).toContain('pending_paid_actions')
+		})
+	})
+
+	describe('when the run is not a scan', () => {
+		it('should let the register through', async () => {
+			// GIVEN an enrichment run, which is what the register is for
+			let vendorCalled = false
+			const ports = Layer.mergeAll(
+				StubSearchProvider,
+				StubScrapeProvider,
+				Layer.succeed(RegistryRouter)(
+					RegistryRouter.of({
+						lookup: () => {
+							vendorCalled = true
+							return Effect.succeed(
+								new RegistryRecord({
+									legalName: 'Acme SL',
+									sourceUrl: 'https://registry.example/acme',
+									units: 1,
+								}),
+							)
+						},
+					}),
+				),
+			)
+			const infra = Layer.mergeAll(
+				stubBudget,
+				Layer.succeed(ResearchRunContext)({
+					researchId: 'test-run',
+					schemaName: 'company_enrichment_v1',
+				}),
+				Layer.succeed(ContactDiscovery)({
+					discover: () =>
+						Effect.succeed({
+							status: 'no_reliable_contact' as const,
+							researchId: 'test-run',
+						}),
+				}),
+			)
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const toolkit = yield* researchToolkit
+					const stream = yield* toolkit.handle('registry_lookup', {
+						country: 'ES',
+						query: 'Acme SL',
+						tax_id: null,
+					})
+					yield* Stream.runDrain(stream)
+				}).pipe(
+					Effect.provide(
+						researchToolkitLayer.pipe(
+							Layer.provide(Layer.mergeAll(ports, infra)),
+						),
+					),
+				),
+			)
+
+			// THEN the lookup happens, because barring it everywhere would be a
+			// different change from barring it on a list
+			expect(vendorCalled).toBe(true)
 		})
 	})
 })

--- a/packages/research/src/application/tools.ts
+++ b/packages/research/src/application/tools.ts
@@ -20,6 +20,7 @@
 import { Cause, Effect, Schema } from 'effect'
 import {
 	AiError,
+	type LanguageModel,
 	OpenAiStructuredOutput,
 	Tool,
 	Toolkit,
@@ -31,9 +32,12 @@ import {
 	approvalRequiredResult,
 	BudgetExceeded,
 	noRegistryResult,
+	paidToolBarredResult,
+	registryUnavailableResult,
 } from '../domain/errors'
 import { ScrapedPage } from '../domain/types'
 import { ContactDiscovery } from './contact-discovery'
+import { isDiscoveryScan } from './discovery-scan'
 import {
 	Budget,
 	RegistryRouter,
@@ -170,12 +174,46 @@ export const researchToolkit = Toolkit.make(
 	DiscoverContactsTool,
 )
 
+/** Every tool name the toolkit above holds, for anything that names a subset. */
+type ResearchToolName =
+	(typeof researchToolkit.tools)[keyof typeof researchToolkit.tools]['name']
+
+// What a discovery scan may reach for. The two paid tools are left out because a
+// scan is asked for a list of companies, while buying a register record or a set
+// of contacts is work about ONE of them — the register seeding step already
+// refuses to do it for a scan, and leaving the tools on the wire lets the model
+// do by hand what that step declines to do for it. A scan that wants either says
+// so under `pending_paid_actions` and a person decides.
+const SCAN_TOOLS: ReadonlyArray<ResearchToolName> = [
+	'web_search',
+	'scrape_page',
+]
+
+/**
+ * Which tools this round may call, and whether it must call one.
+ *
+ * Round one is forced either way: a model that answers from memory leaves no
+ * sources behind and fails the grounding gate on a company that is perfectly
+ * real. Later rounds are free to reflect instead.
+ */
+export const agentToolChoice = (
+	schemaName: string,
+	round: number,
+): LanguageModel.ToolChoice<ResearchToolName> => {
+	const mode = round === 1 ? ('required' as const) : ('auto' as const)
+	return isDiscoveryScan(schemaName) ? { mode, oneOf: SCAN_TOOLS } : mode
+}
+
 /**
  * The tool list written out exactly as it is sent to a provider.
  *
  * A provider can accept a simple made-up tool and still reject these over a
  * detail of how one argument is described, so anything asking "would you accept
  * our tools?" has to ask with the real ones.
+ *
+ * Every tool, including the two a scan is not offered: a scan narrows what the
+ * model may CALL, while this asks whether a provider will accept the definitions
+ * at all, and only the widest set answers that for every run.
  */
 export const researchToolkitWireFormat = (): ReadonlyArray<
 	Record<string, unknown>
@@ -305,7 +343,16 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 			country: hintCountry,
 			entityTargets,
 			entityName,
+			schemaName,
 		} = yield* ResearchRunContext
+
+		// A scan is not offered the paid tools, and this is where that is true
+		// rather than merely asked for: the narrowing sent with the request is the
+		// provider being told what to allow, and a paid call is the wrong place to
+		// discover that one did not listen. Costs nothing when the narrowing works,
+		// which is every time it does.
+		const paidToolBarred =
+			schemaName !== undefined && isDiscoveryScan(schemaName)
 
 		// Each tool below reports a failure in three steps, in this order: log an
 		// unexpected one, turn an expected stop into the sentence the model should
@@ -474,6 +521,7 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 
 			registry_lookup: params =>
 				Effect.gen(function* () {
+					if (paidToolBarred) return paidToolBarredResult('registry_lookup')
 					const country = params.country.toUpperCase()
 					// Find out whether there is a register to ask before paying to ask
 					// it. Charging first meant a country Batuda has no register for
@@ -497,11 +545,16 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 					)
 					// The register charges per lookup, so a repeat of one this run
 					// already bought would be paid for twice for the same answer.
-					return outcome._tag === 'already_charged'
-						? alreadyLookedUpResult(
-								`${params.tax_id ?? params.query ?? ''} (${country})`,
-							)
-						: outcome.value
+					if (outcome._tag === 'already_charged')
+						return alreadyLookedUpResult(
+							`${params.tax_id ?? params.query ?? ''} (${country})`,
+						)
+					// Told as a result rather than a failure, and named as OUR shortfall:
+					// a model handed a bare error about a register tends to read it as
+					// something about the company it asked after.
+					if (outcome._tag === 'vendor_refused')
+						return registryUnavailableResult(country)
+					return outcome.value
 				}).pipe(
 					// A registry-less country is a routing answer, not a failure:
 					// hand it back as data so the model can switch to discover_contacts.
@@ -532,25 +585,24 @@ export const researchToolkitLayer = researchToolkit.toLayer(
 			// Reuses this run's id + budget so paid enrichment/verification lands on
 			// the run and its cap applies — no separate anchor run or allowance.
 			discover_contacts: params =>
-				contactDiscovery
-					.discover({
+				Effect.gen(function* () {
+					if (paidToolBarred) return paidToolBarredResult('discover_contacts')
+					return yield* contactDiscovery.discover({
 						companyName: params.company_name,
 						domain: params.domain,
 						country: params.country ?? undefined,
 						runContext: { researchId, budget },
 					})
-					.pipe(
-						Effect.catchCause(cause =>
-							mapToolError('discover_contacts')(cause),
-						),
-						Effect.withSpan('research.tool.discover_contacts', {
-							attributes: {
-								'research.tool': 'discover_contacts',
-								'research.run_id': researchId,
-								domain: params.domain,
-							},
-						}),
-					),
+				}).pipe(
+					Effect.catchCause(cause => mapToolError('discover_contacts')(cause)),
+					Effect.withSpan('research.tool.discover_contacts', {
+						attributes: {
+							'research.tool': 'discover_contacts',
+							'research.run_id': researchId,
+							domain: params.domain,
+						},
+					}),
+				),
 		})
 	}),
 )

--- a/packages/research/src/application/vocabulary-guard.test.ts
+++ b/packages/research/src/application/vocabulary-guard.test.ts
@@ -163,6 +163,25 @@ describe('mapCountry', () => {
 			expect(mapCountry('')).toBeNull()
 		})
 	})
+
+	describe('when the value names a country and then says something about it', () => {
+		it('should read the country and ignore the aside', () => {
+			// GIVEN the shapes real scans have written, where the country is stated
+			// plainly and the bracket only says how far the company reaches
+			expect(mapCountry('Spain (global)')).toBe('ES')
+			expect(mapCountry('United States (global)')).toBe('US')
+		})
+
+		it('should leave a country the run was unsure of alone', () => {
+			// GIVEN a value where the question mark is the run saying it does not
+			// know which country this is
+			const hedged = 'Portugal? (uncertain – site uses .br domain)'
+
+			// WHEN folded — THEN it stays as written, because answering "PT" would
+			// state as fact something the run explicitly did not settle
+			expect(mapCountry(hedged)).toBe(hedged)
+		})
+	})
 })
 
 describe('constrainVocabulary', () => {
@@ -417,6 +436,73 @@ describe('a country named in its own writing', () => {
 			// THEN it survives as written. Refusing what cannot be mapped would throw
 			// away real countries simply for being absent from a hand-written list
 			expect(mapCountry('Freedonia')).toBe('Freedonia')
+		})
+	})
+})
+
+describe('constrainVocabulary on a scan row', () => {
+	const prospects = (countries: unknown) => ({
+		prospects: [{ name: 'Acme', countries }],
+	})
+	const countriesOf = (result: { findings: unknown }): unknown =>
+		(
+			(result.findings as { prospects: ReadonlyArray<Record<string, unknown>> })
+				.prospects[0] as Record<string, unknown>
+		)['countries']
+
+	describe('when a scan names its countries in words', () => {
+		it('should fold every one of them to a code', () => {
+			// GIVEN the spellings real scans have written into the list
+			const result = constrainVocabulary(
+				prospects(['Spain', 'España', 'Portugal', 'United States']),
+			)
+
+			// WHEN folded — THEN each is a code, and the two spellings of Spain
+			// become one entry rather than the same country listed twice
+			expect(countriesOf(result)).toEqual(['ES', 'PT', 'US'])
+			expect(result.mapped).toBe(4)
+		})
+
+		it('should leave a list already written as codes alone', () => {
+			// GIVEN a list the model wrote correctly
+			const result = constrainVocabulary(prospects(['ES', 'FR']))
+
+			// WHEN folded — THEN nothing is rewritten and nothing is counted
+			expect(countriesOf(result)).toEqual(['ES', 'FR'])
+			expect(result.mapped).toBe(0)
+		})
+	})
+
+	describe('when the list holds junk beside a real country', () => {
+		it('should drop the junk and keep the country', () => {
+			// GIVEN a list where the model filled one slot with a placeholder
+			const result = constrainVocabulary(
+				prospects(['Spain', 'N/A', 'https://acme.example']),
+			)
+
+			// WHEN folded — THEN the country survives and the two placeholders go
+			expect(countriesOf(result)).toEqual(['ES'])
+			expect(result.blanked).toBe(2)
+		})
+
+		it('should drop the field when nothing in it was usable', () => {
+			// GIVEN a list of nothing but placeholders
+			const result = constrainVocabulary(prospects(['N/A', '']))
+
+			// WHEN folded — THEN the key is gone rather than left as an empty list,
+			// which would read as a run that looked and found no country
+			expect(countriesOf(result)).toBeUndefined()
+		})
+	})
+
+	describe('when the list is not a list of countries at all', () => {
+		it('should leave a shape it cannot read where it is', () => {
+			// GIVEN an entry that is not a value this mapper understands
+			const result = constrainVocabulary(prospects([{ odd: 'shape' }, 'Spain']))
+
+			// WHEN folded — THEN the country is folded and the odd entry survives,
+			// because one unreadable entry is not a reason to lose the list
+			expect(countriesOf(result)).toEqual([{ odd: 'shape' }, 'ES'])
 		})
 	})
 })

--- a/packages/research/src/application/vocabulary-guard.test.ts
+++ b/packages/research/src/application/vocabulary-guard.test.ts
@@ -495,6 +495,30 @@ describe('constrainVocabulary on a scan row', () => {
 		})
 	})
 
+	describe('when a field is named after something every object already has', () => {
+		it('should leave it alone rather than treat a built-in as a rule', () => {
+			// GIVEN a row carrying keys that every JavaScript object answers to, which
+			// a plain lookup finds on the prototype and mistakes for a mapping rule.
+			// `toString` used to come back rewritten as "[object Undefined]".
+			const result = constrainVocabulary({
+				prospects: [{ constructor: 'x', toString: 'y', countries: ['Spain'] }],
+			})
+
+			// WHEN folded — THEN both survive as written, and the real field beside
+			// them is still folded
+			expect(result.findings).toEqual({
+				prospects: [{ constructor: 'x', toString: 'y', countries: ['ES'] }],
+			})
+		})
+
+		it('should not read a country name off the prototype either', () => {
+			// GIVEN a country whose name matches a built-in. Looked up plainly this
+			// answered with a function, which then travelled on as the country.
+			expect(mapCountry('constructor')).toBe('constructor')
+			expect(mapCountry('valueOf')).toBe('valueOf')
+		})
+	})
+
 	describe('when the list is not a list of countries at all', () => {
 		it('should leave a shape it cannot read where it is', () => {
 			// GIVEN an entry that is not a value this mapper understands

--- a/packages/research/src/application/vocabulary-guard.test.ts
+++ b/packages/research/src/application/vocabulary-guard.test.ts
@@ -164,12 +164,16 @@ describe('mapCountry', () => {
 		})
 	})
 
-	describe('when the value names a country and then says something about it', () => {
-		it('should read the country and ignore the aside', () => {
-			// GIVEN the shapes real scans have written, where the country is stated
-			// plainly and the bracket only says how far the company reaches
-			expect(mapCountry('Spain (global)')).toBe('ES')
-			expect(mapCountry('United States (global)')).toBe('US')
+	describe('when the value names a country and then qualifies it', () => {
+		it('should leave it alone rather than read past the bracket', () => {
+			// GIVEN values where the bracket is what says WHICH country. Reading the
+			// name off the front answers confidently and wrongly.
+			expect(mapCountry('Korea (North)')).toBe('Korea (North)')
+			expect(mapCountry('China (Taiwan)')).toBe('China (Taiwan)')
+			expect(mapCountry('Ireland (Northern)')).toBe('Ireland (Northern)')
+			// AND one where reading past it would have been right — kept as written
+			// all the same, because nothing here can tell the two kinds apart
+			expect(mapCountry('Spain (global)')).toBe('Spain (global)')
 		})
 
 		it('should leave a country the run was unsure of alone', () => {
@@ -519,14 +523,19 @@ describe('constrainVocabulary on a scan row', () => {
 		})
 	})
 
-	describe('when the list is not a list of countries at all', () => {
-		it('should leave a shape it cannot read where it is', () => {
-			// GIVEN an entry that is not a value this mapper understands
-			const result = constrainVocabulary(prospects([{ odd: 'shape' }, 'Spain']))
+	describe('when the list holds something that is not a country at all', () => {
+		it('should drop it rather than leave it looking like one', () => {
+			// GIVEN entries that are not values this mapper can read — an object
+			// where a name belongs, a number, a null
+			const result = constrainVocabulary(
+				prospects([{ odd: 'shape' }, 'Spain', 5, null]),
+			)
 
-			// WHEN folded — THEN the country is folded and the odd entry survives,
-			// because one unreadable entry is not a reason to lose the list
-			expect(countriesOf(result)).toEqual([{ odd: 'shape' }, 'ES'])
+			// WHEN folded — THEN only the country survives. Carrying the rest along
+			// would leave a list that reads as countries and holds something else,
+			// which every later reader would take at face value.
+			expect(countriesOf(result)).toEqual(['ES'])
+			expect(result.blanked).toBe(3)
 		})
 	})
 })

--- a/packages/research/src/application/vocabulary-guard.ts
+++ b/packages/research/src/application/vocabulary-guard.ts
@@ -226,11 +226,17 @@ const COUNTRY_NAME_TO_ALPHA2: Record<string, string> = {
 // map a known country name, and leave anything else untouched (never dropping a real
 // value we simply don't have a code for). Hard junk — a URL, an email, a placeholder —
 // is blanked like the other fields.
+// A value that names a country and then adds something in brackets is left
+// alone. It is tempting to read the country off the front — "Spain (global)"
+// plainly means ES — but the bracket is just as often the part that says WHICH
+// country: "Korea (North)" is not KR, "China (Taiwan)" is not CN, and
+// "Ireland (Northern)" is not IE. Reading past it turns three of those into a
+// confident wrong answer, which is worse than the handful of rows it rescues.
 export const mapCountry = (raw: string): string | null => {
 	const n = normalize(raw)
 	if (isHardJunk(n)) return null
 	if (/^[a-z]{2}$/.test(n)) return n.toUpperCase()
-	const iso = alpha2For(n) ?? alpha2For(named(n))
+	const iso = alpha2For(n)
 	return iso ?? raw
 }
 
@@ -243,17 +249,6 @@ const own = <T>(table: Record<string, T>, key: string): T | undefined =>
 
 const alpha2For = (key: string): string | undefined =>
 	own(COUNTRY_NAME_TO_ALPHA2, key)
-
-// The country out of a value that names one and then says something about it —
-// "Spain (global)". The aside is about how far the company reaches, and the
-// country in front of it was stated plainly, so losing the whole value over the
-// bracket would throw away a fact the run really did establish.
-//
-// A question mark is the exception, and the reason this is not a plain strip: it
-// is the run saying it does not know which country, and reading a code out of
-// that would turn a doubt into a fact nobody checked.
-const named = (n: string): string =>
-	n.includes('?') ? n : n.replace(/\([^)]*\)/g, '').trim()
 
 // The words a model reaches for when naming somebody's part in a purchase, and
 // the part each one means. Written as fragments so "Economic Buyer", "the
@@ -396,11 +391,13 @@ export const constrainVocabulary = (findings: unknown): VocabularyResult => {
 				const seen = new Set<string>()
 				for (const entry of v) {
 					const raw = rawOf(entry)
-					// A shape this mapper cannot read is passed along untouched. Not
-					// every entry has to be a value it understands, and losing the list
-					// over one would cost more than the folding is worth.
+					// An entry that is not a value at all — a number, a null, an object
+					// where a country name belongs — is dropped rather than carried
+					// along. Keeping it would leave a list that reads as countries and
+					// holds something else, which every later reader would take at face
+					// value.
 					if (raw === null) {
-						kept.push(walk(entry))
+						blanked++
 						continue
 					}
 					const code = listMapper(raw)

--- a/packages/research/src/application/vocabulary-guard.ts
+++ b/packages/research/src/application/vocabulary-guard.ts
@@ -230,9 +230,20 @@ export const mapCountry = (raw: string): string | null => {
 	const n = normalize(raw)
 	if (isHardJunk(n)) return null
 	if (/^[a-z]{2}$/.test(n)) return n.toUpperCase()
-	const iso = COUNTRY_NAME_TO_ALPHA2[n]
+	const iso = COUNTRY_NAME_TO_ALPHA2[n] ?? COUNTRY_NAME_TO_ALPHA2[named(n)]
 	return iso ?? raw
 }
+
+// The country out of a value that names one and then says something about it —
+// "Spain (global)". The aside is about how far the company reaches, and the
+// country in front of it was stated plainly, so losing the whole value over the
+// bracket would throw away a fact the run really did establish.
+//
+// A question mark is the exception, and the reason this is not a plain strip: it
+// is the run saying it does not know which country, and reading a code out of
+// that would turn a doubt into a fact nobody checked.
+const named = (n: string): string =>
+	n.includes('?') ? n : n.replace(/\([^)]*\)/g, '').trim()
 
 // The words a model reaches for when naming somebody's part in a purchase, and
 // the part each one means. Written as fragments so "Economic Buyer", "the
@@ -324,6 +335,16 @@ const MAPPERS: Record<string, (raw: string) => string | null> = {
 	buyingRole: mapBuyingRole,
 }
 
+// Fields holding a list of values rather than one. A scan names every country a
+// company has a place in, and each entry answers the same question the single
+// `country` above does, so it is folded to a code the same way. Kept in its own
+// table because the walk has to read a list where the others read a string, and
+// a mapper that guessed which it had would fold a two-letter country name to a
+// code letter by letter.
+const LIST_MAPPERS: Record<string, (raw: string) => string | null> = {
+	countries: mapCountry,
+}
+
 export interface VocabularyResult {
 	readonly findings: unknown
 	/** Values rewritten to a different code. */
@@ -359,6 +380,38 @@ export const constrainVocabulary = (findings: unknown): VocabularyResult => {
 		if (value === null || typeof value !== 'object') return value
 		const out: Record<string, unknown> = {}
 		for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+			const listMapper = LIST_MAPPERS[key]
+			if (listMapper && Array.isArray(v)) {
+				const kept: unknown[] = []
+				const seen = new Set<string>()
+				for (const entry of v) {
+					const raw = rawOf(entry)
+					// A shape this mapper cannot read is passed along untouched. Not
+					// every entry has to be a value it understands, and losing the list
+					// over one would cost more than the folding is worth.
+					if (raw === null) {
+						kept.push(walk(entry))
+						continue
+					}
+					const code = listMapper(raw)
+					if (code === null) {
+						blanked++
+						continue
+					}
+					if (code !== raw) mapped++
+					// The same country twice says nothing the once did not, and two
+					// spellings of it — "Spain" beside "ES" — is exactly what folding
+					// them produces.
+					if (seen.has(code)) continue
+					seen.add(code)
+					kept.push(withValue(entry, code))
+				}
+				// A list emptied of everything usable is dropped whole: an empty list
+				// reads as a run that looked and found no country, which is not what
+				// happened.
+				if (kept.length > 0) out[key] = kept
+				continue
+			}
 			const mapper = MAPPERS[key]
 			const raw = mapper ? rawOf(v) : null
 			if (mapper && raw !== null) {

--- a/packages/research/src/application/vocabulary-guard.ts
+++ b/packages/research/src/application/vocabulary-guard.ts
@@ -230,9 +230,19 @@ export const mapCountry = (raw: string): string | null => {
 	const n = normalize(raw)
 	if (isHardJunk(n)) return null
 	if (/^[a-z]{2}$/.test(n)) return n.toUpperCase()
-	const iso = COUNTRY_NAME_TO_ALPHA2[n] ?? COUNTRY_NAME_TO_ALPHA2[named(n)]
+	const iso = alpha2For(n) ?? alpha2For(named(n))
 	return iso ?? raw
 }
+
+// Every one of these tables is looked up by words a model wrote, and a plain
+// object answers for the whole prototype chain as well as its own entries — so
+// "constructor" comes back as a function and "toString" as a method, which the
+// walk below would then call and store. Own entries only, always.
+const own = <T>(table: Record<string, T>, key: string): T | undefined =>
+	Object.hasOwn(table, key) ? table[key] : undefined
+
+const alpha2For = (key: string): string | undefined =>
+	own(COUNTRY_NAME_TO_ALPHA2, key)
 
 // The country out of a value that names one and then says something about it —
 // "Spain (global)". The aside is about how far the company reaches, and the
@@ -380,7 +390,7 @@ export const constrainVocabulary = (findings: unknown): VocabularyResult => {
 		if (value === null || typeof value !== 'object') return value
 		const out: Record<string, unknown> = {}
 		for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-			const listMapper = LIST_MAPPERS[key]
+			const listMapper = own(LIST_MAPPERS, key)
 			if (listMapper && Array.isArray(v)) {
 				const kept: unknown[] = []
 				const seen = new Set<string>()
@@ -412,7 +422,7 @@ export const constrainVocabulary = (findings: unknown): VocabularyResult => {
 				if (kept.length > 0) out[key] = kept
 				continue
 			}
-			const mapper = MAPPERS[key]
+			const mapper = own(MAPPERS, key)
 			const raw = mapper ? rawOf(v) : null
 			if (mapper && raw !== null) {
 				const code = mapper(raw)

--- a/packages/research/src/domain/errors.ts
+++ b/packages/research/src/domain/errors.ts
@@ -120,7 +120,7 @@ export const noRegistryResult = (country: string) => ({
 export const paidToolBarredResult = (tool: string) => ({
 	status: 'not_available_here' as const,
 	tool,
-	message: `${tool} is not available on a list-of-companies search, because it spends money on one company at a time. Record it under pending_paid_actions with the company it is for, and a person decides whether to run it.`,
+	message: `${tool} is not available on a list-of-companies search, because it spends money on one company at a time. Record it under pending_paid_actions with the company it is for — and for discover_contacts, its web domain, written as null when the company has no website — and a person decides whether to run it.`,
 })
 
 /**

--- a/packages/research/src/domain/errors.ts
+++ b/packages/research/src/domain/errors.ts
@@ -112,6 +112,30 @@ export const noRegistryResult = (country: string) => ({
 })
 
 /**
+ * A tool that spends money, reached by a run that may not spend it. A scan is
+ * handed a list of companies to work through, so buying a record about one of
+ * them is work for a run about that one company — which a person starts, from
+ * what the scan proposes.
+ */
+export const paidToolBarredResult = (tool: string) => ({
+	status: 'not_available_here' as const,
+	tool,
+	message: `${tool} is not available on a list-of-companies search, because it spends money on one company at a time. Record it under pending_paid_actions with the company it is for, and a person decides whether to run it.`,
+})
+
+/**
+ * The register exists but our account has no credit left to ask it, so no lookup
+ * in this run will be answered. Kept apart from `no_registry`, which says the
+ * country has no register at all: this one is a fact about us, and a run that
+ * confuses the two reports a gap in our billing as a gap in the record.
+ */
+export const registryUnavailableResult = (country: string) => ({
+	status: 'registry_unavailable' as const,
+	country,
+	message: `The ${country} business registry cannot be reached this run — our paid allowance for it is spent, which is about us and not about the company. Do not look it up again; carry on with the open web, and say plainly that the register went unchecked rather than that the company is not on it.`,
+})
+
+/**
  * The scrape provider flatly refuses this site — Firecrawl answers a page fetch
  * with "we do not support this site" (LinkedIn and other people directories).
  * A routing outcome, not a failure: the page can never be fetched no matter the

--- a/packages/research/src/infrastructure/librebor/registry.test.ts
+++ b/packages/research/src/infrastructure/librebor/registry.test.ts
@@ -300,6 +300,36 @@ describe('makeLibreborRegistry', () => {
 		expect(log.count).toBe(1)
 	})
 
+	it('should say a 402 is the paid allowance running out, not a bad answer', async () => {
+		// GIVEN the register refuses because the account has no credit left
+		const { exit, log } = runLookup(
+			{ country: 'ES', taxId: 'A46103834' },
+			() => ({
+				status: 402,
+				body: { error: { code: 'PAYMENT_REQUIRED' } },
+			}),
+		)
+
+		// THEN it fails fast and says why, so the budget can stop asking a register
+		// that will answer every later lookup the same way
+		const resolved = await exit
+		expect(errorOf(resolved)?.recoverable).toBe(false)
+		expect(errorOf(resolved)?.quotaExhausted).toBe(true)
+		expect(log.count).toBe(1)
+	})
+
+	it('should not read a bad credential as an allowance running out', async () => {
+		// GIVEN a dead key rather than an empty account
+		const { exit } = runLookup({ country: 'ES', taxId: 'A46103834' }, () => ({
+			status: 401,
+			body: { error: { code: 'UNAUTHORIZED' } },
+		}))
+
+		// THEN the flag stays off — it means an allowance running out, which a
+		// dead key is not
+		expect(errorOf(await exit)?.quotaExhausted).toBe(false)
+	})
+
 	it('should treat 404 (company not found) as non-recoverable', async () => {
 		// GIVEN the company is not in the registry
 		const { exit } = runLookup({ country: 'ES', taxId: 'A00000000' }, () => ({

--- a/packages/research/src/infrastructure/librebor/registry.ts
+++ b/packages/research/src/infrastructure/librebor/registry.ts
@@ -67,12 +67,18 @@ const SearchResponse = Schema.Struct({
 const statusRecoverable = (status: number): boolean =>
 	status === 429 || status >= 500
 
+// Only 402 (no credit) means the same answer awaits every later lookup this run
+// makes, which is what the budget needs to hear. 401 is a dead key: terminal
+// too, but not an allowance running out.
+const isQuotaExhausted = (status: number): boolean => status === 402
+
 const failStatus = (status: number) =>
 	Effect.fail(
 		new ProviderError({
 			provider: 'librebor',
 			message: `registry lookup failed: HTTP ${status}`,
 			recoverable: statusRecoverable(status),
+			quotaExhausted: isQuotaExhausted(status),
 		}),
 	)
 


### PR DESCRIPTION
## What

Two separate faults, both found while investigating why one research run
(`fae56de6`, industrial engineering around Girona) came back with most of its
fields empty and its companies impossible to add.

**A search for a list of companies was paying for lookups about single ones.**
The step that seeds a company's record from the national business register is
already gated — it checks the run's schema and its comment says "never a scan
that happens to be anchored". That gate holds and never fired. But
`researchToolkit` is one static toolkit handed to every run, so the search's
model still saw `registry_lookup` and `discover_contacts` in its tool list and
called them by hand. Lifetime register spend by kind of run: contact discovery
€11.60, **company search €4.35**, company enrichment €0.29.

Worse, the Spanish register has had no credit since about 30 August, so every
one of those calls came back HTTP 402:

```
day         kind of run        attempts  failed  charged
2026-08-30  prospect_scan_v1      3        3      87¢
2026-09-09  prospect_scan_v1      7        3      87¢
```

€1.74 for six calls that returned nothing — and **nothing anywhere said the
register was refusing**. A run has no way to report that a paid source turned it
away, so its brief reported our unpaid bill as a fact about the companies.

**Half of every company a search has ever returned cannot be added as a lead.**
The list of countries each row carries is documented as two-letter codes, but it
is a plain array of strings with nothing checking it, and the model writes
"Spain" or "España" about half the time. The button feeds the first entry
straight to the CRM, whose country field is `/^[A-Za-z]{2}$/` — and the request
is checked against that shape *in the browser*, so it never left the page.
Across all 960 companies ever returned:

```
no country   366  (38%)  addable — the field is simply absent
valid code   116  (12%)  addable
free text    478  (50%)  BLOCKED
```

Confirmed by reproduction before any of this was written: encoding the real
payloads for all 11 rows of that run failed on 9 and passed on 2, and the
country was the only difference between them.

## The fix

**Touches:** which tools a company search may call, what the budget does after a
vendor refuses, how a search's countries are folded, and how the internal app
builds the create-company request. No change to what an enrichment or
contact-discovery run does.

- **A search gets neither paid tool**, narrowed on the wire through Effect's own
  `toolChoice.oneOf` and refused again in the handlers. Two barriers rather than
  one because `oneOf` is the provider being *told* what to allow, and a paid call
  is the wrong place to find out it did not listen.
- **The instructions stopped naming tools the search cannot call.** Two lines
  still did. A search is now told to record what it wants under
  `pending_paid_actions` for a person to approve — which matters more than it
  sounds: the sentence inside the paid tools' approval gate is the *only* text
  that ever taught a run to fill that field, so removing the tools without this
  would have silently taken away the way to opt back in.
- **A vendor that says its allowance is spent is not asked again.** Per run, per
  vendor, and only on HTTP 402 — 401 is a dead key, and the one place that flag
  is ever shown to a person says "no paid allowance left this month", which would
  be a lie about a bad key.
- **A finished run says which paid sources refused it**, and its brief is told to
  say plainly that what is missing for that reason is missing on our side.
  Contact discovery has carried that distinction on its own results for a while;
  this is the run-level counterpart, in the same words.
- **A search's countries are folded to codes** by the same table that already
  folds the single `country` field — it was skipped only because the folding step
  reads one value and could not read a list. 475 of the 478 stray values fold
  cleanly.
- **The lead button drops a field it cannot store instead of losing the lead**,
  and names what it dropped. The principle was already written down one field
  over, for half-written social profiles; it just was not applied to the rest.

## Impact

No database migration, nothing touching which organisation can see what
(row-level security), no new settings the server needs to start, and no change to
what the web app or the tool surface reads back.

Four behaviour changes worth stating plainly:

- **A company search will no longer buy register records or contacts.** It can
  still ask, under `pending_paid_actions`, and the approved-follow-up path that
  spends on your say-so is untouched.
- **A country requirement in a search will start actually filtering.** The check
  runs each stated country through the same code parser and keeps the row when it
  yields nothing — so for the ~50% of rows carrying free text it has never once
  fired. Expect fewer rows back, and check they are the right ones.
- **`toolChoice` is inside the model-response cache key**, so this invalidates
  cached agent rounds for searches. First run after deploy costs full price.
- **An anchored search can no longer set `registry_confirmed`.** Nothing in the
  product reads it — the eval counts it toward grounding — so it moves a
  measurement without moving behaviour. Worth knowing before reading the next
  eval as a regression.

## Review guide

Start at `agentToolChoice` in `packages/research/src/application/tools.ts`. It is
six lines, and the comment above `SCAN_TOOLS` carries the reasoning. Then the one
call site, `research-service.ts:5554` — there is exactly one place the toolkit
reaches a model, which is why this did not need a second toolkit or a second
handler layer. Re-providing the handler layer on a narrower scope would have
reset the per-run spend, which an existing comment warns about.

Then `withPaidCharge` in `budget.ts`. The load-bearing choice is that a refusal
comes back as an *outcome* (`vendor_refused`) rather than an error: making it an
error would have had to be a member of `PaidRail`, and the email verifier turns a
budget failure into "unchecked", so one register 402 would have silently stripped
every guessed address run-wide. The type checker found all five call sites.

Three judgement calls I would rather flag than bury:

- **I did not reverse the 29¢ ledger row for a refused call.** It is tempting —
  the vendor definitely did not bill for a 402 — but `docs/architecture.md:453`
  makes idempotent metering a stated safety invariant and `:629` calls that table
  an audit log, and deleting a row frees the idempotency key. With the circuit
  breaker in place the mis-accounting is capped at one row per vendor per run.
  Small prize, real rule. Happy to be overruled.
- **A hedged country is left alone rather than folded.** `Spain (global)` reads
  as `ES`, but `Portugal? (uncertain – site uses .br domain)` stays as written —
  the question mark is the run saying it does not know, and answering `PT` would
  state as fact something nobody settled. One row in 960, and the button then
  drops the field and says so, which I think is the honest outcome.
- **The last commit is a bug I did not go looking for.** Reviewing the country
  change, I found the folding step looks each field up in a plain object, which
  answers for everything every JavaScript object inherits — so a field named
  `toString` found a built-in, called it, and stored `"[object Undefined]"` in
  place of the value. Pre-existing, and my change had just extended the same
  lookup to lists, so it folded in rather than waiting.

## Tests

Unit, beside each module. The ones that carry weight:

- `tools.test.ts` — both kinds of search get the narrowed list; enrichment and
  contact discovery keep everything; round one still forces a call through the
  narrowing; and the two paid handlers are driven directly with a scan in context
  to prove they refuse **without reaching the vendor**, which is the half
  `oneOf` cannot promise.
- `budget.test.ts` — a second call to a refused vendor comes back untouched and
  uncharged; a *different* vendor is still payable; a vendor that merely failed is
  still retried.
- `vocabulary-guard.test.ts` — the real distinct values pulled from production,
  the hedged case, and a regression for the prototype bug above.
- `prospect-lead-payload.test.ts` — the real rows from the run, including the
  lower-case `es` that passes the CRM's read and fails its write.

Verified end to end against the live stack, not only in tests. I loaded that
exact run into a worktree database and clicked the button that used to fail:

| | before | after |
| --- | --- | --- |
| `ENGINYERIA ENERGÈTICA GIRONINA` (`España`) | "Could not add as a lead" | created, `country = ES` |
| a row with a hedged country and a broken web address | no company at all | created, both fields dropped |
| `POST /v1/companies` in the server log | never appeared | appears |

The unverified row landed unverified, which is the other thing that had to stay
true.

## Deferred

- The waste I first blamed on the agent loop is **#632** — a prompt-token ceiling
  set for a 32K model and never raised after the 4 September swap to a 262K one.
  There is already a worktree on it. **#605** owns the room-to-read work and
  states that using up rounds is a legitimate way for a search to stop, which is
  what talked me out of the framing I started with.
- Duplicate rows are **#568**. Measured across the 960: 14 groups share a website
  host, 1 does not. The three-spelling case from this run has no website at all,
  so it is evidence for that issue rather than a competing fix — I will add it
  there.
- Two things with no issue yet: a page fetch retried the same dead hostname in
  five separate passes with nothing remembering the DNS failure (3 of 141 runs in
  30 days), and one row cited a *different company's* page as the evidence for its
  own address and headcount.
