### PR TITLE
fix(research): accept a reply that says it called no tool with null

### DIFF
--- a/packages/research/src/infrastructure/_reply-shape.test.ts
+++ b/packages/research/src/infrastructure/_reply-shape.test.ts
@@ -205,6 +205,75 @@ describe('normalizeVendorReply', () => {
 		})
 	})
 
+	describe('when a choice says it called no tool by sending null', () => {
+		it('should drop the field rather than put an empty array in its place', () => {
+			// GIVEN a reply whose one choice says it called no tool by sending an
+			// explicit null, which is what some of the configured models send where
+			// the library expects an array
+			const body = replyBody({
+				choices: [
+					{
+						index: 0,
+						finish_reason: 'stop',
+						message: { role: 'assistant', content: 'hi', tool_calls: null },
+					},
+				],
+			})
+
+			// WHEN the reply is normalized
+			const normalized = normalizeVendorReply(body)
+			const choices = parseBody(normalized?.body ?? '')[
+				'choices'
+			] as ReadonlyArray<{ message: Record<string, unknown> }>
+
+			// THEN the field is gone rather than replaced with an empty array —
+			// absent is already how the library reads "called no tool"
+			expect(normalized?.repaired).toContain('tool_calls')
+			expect(choices[0]?.message).not.toHaveProperty('tool_calls')
+		})
+	})
+
+	describe('when a choice sends tool_calls the library already accepts', () => {
+		it('should leave a real tool call untouched', () => {
+			// GIVEN a choice that genuinely called a tool
+			const call = {
+				id: 'c1',
+				type: 'function',
+				function: { name: 'web_search', arguments: '{}' },
+			}
+			const body = replyBody({
+				choices: [
+					{
+						index: 0,
+						finish_reason: 'tool_calls',
+						message: { role: 'assistant', content: null, tool_calls: [call] },
+					},
+				],
+			})
+
+			// THEN nothing is repaired, since an array is the shape the library
+			// already accepts
+			expect(normalizeVendorReply(body)).toBeUndefined()
+		})
+
+		it('should leave an empty array alone rather than drop it too', () => {
+			// GIVEN a choice that said it called no tool the way the library
+			// already understands
+			const body = replyBody({
+				choices: [
+					{
+						index: 0,
+						finish_reason: 'stop',
+						message: { role: 'assistant', content: 'hi', tool_calls: [] },
+					},
+				],
+			})
+
+			// THEN the field stays, because only a null is what decode refuses
+			expect(normalizeVendorReply(body)).toBeUndefined()
+		})
+	})
+
 	describe('when the vendor omits created', () => {
 		it('should fill it with the time the reply arrived', () => {
 			// GIVEN a reply that never carried a created timestamp
@@ -526,11 +595,12 @@ describe('normalizeVendorReply', () => {
 		})
 
 		it('should name every field when several were missing', () => {
-			// GIVEN a reply short its service_tier, created, index and usage total
+			// GIVEN a reply short its service_tier, created, index, tool_calls and
+			// usage total
 			const body = replyBody({
 				service_tier: null,
 				created: undefined,
-				choices: [{ message: { content: 'hi there' } }],
+				choices: [{ message: { content: 'hi there', tool_calls: null } }],
 				usage: { prompt_tokens: 10, completion_tokens: 4 },
 			})
 
@@ -539,6 +609,7 @@ describe('normalizeVendorReply', () => {
 				'service_tier',
 				'created',
 				'index',
+				'tool_calls',
 				'usage',
 			])
 		})

--- a/packages/research/src/infrastructure/_reply-shape.ts
+++ b/packages/research/src/infrastructure/_reply-shape.ts
@@ -3,10 +3,12 @@
  *
  * `@effect/ai-openai-compat` describes a reply more strictly than the vendors
  * behave: `created` and every choice's `index` are required integers, a usage
- * block must carry all three token counters, and `service_tier` is typed as
+ * block must carry all three token counters, `service_tier` is typed as
  * "absent or a string" — never null, which the custom endpoint serving Qwen
- * sends. A reply that is fine in practice is then rejected before any findings
- * are produced, and the run pays a retry against the next configured slot.
+ * sends — and a choice's `tool_calls` the same way: absent or an array, never
+ * the null some models send to say they called no tool. A reply that is fine in
+ * practice is then rejected before any findings are produced, and the run pays a
+ * retry against the next configured slot.
  *
  * The fix lives on the HTTP boundary Batuda already supplies to the client, not
  * in the dependency: `tolerateVendorReplyShape` wraps the `HttpClient` so the
@@ -66,6 +68,25 @@ const repairServiceTier = (
 	// the "absent or a string" shape the library expects.
 	delete reply['service_tier']
 	return 'service_tier'
+}
+
+const repairToolCalls = (
+	choices: ReadonlyArray<unknown>,
+): string | undefined => {
+	let touched = false
+	for (const choice of choices) {
+		if (!isRecord(choice)) continue
+		const message = choice['message']
+		if (!isRecord(message)) continue
+		if (message['tool_calls'] !== null) continue
+		// Dropping the field, rather than putting an empty array in its place, is
+		// what makes the body satisfy the "absent or an array" shape the library
+		// expects — and absent is already how it reads "called no tool", so this
+		// adds nothing the vendor did not say.
+		delete message['tool_calls']
+		touched = true
+	}
+	return touched ? 'tool_calls' : undefined
 }
 
 const repairCreated = (reply: Record<string, unknown>): string | undefined => {
@@ -195,6 +216,7 @@ export const normalizeVendorReply = (
 		repairServiceTier(parsed),
 		repairCreated(parsed),
 		repairChoiceIndexes(choices),
+		repairToolCalls(choices),
 		repairUsage(parsed),
 	].filter((field): field is string => field !== undefined)
 	if (repaired.length === 0) return undefined


### PR DESCRIPTION
## What

Market research runs were sometimes throwing away a perfectly good answer from a language model and paying a second vendor to redo the same work. This stops that. It lives in the research package (`packages/research`), on the thin layer that talks to model vendors — nothing in the CRM, the web app, or the tool surface external assistants connect to (MCP) changes.

When the pipeline asks a model to do something, the reply has to say which tools the model wants to call — and, when it wants none, it has to say that too. The library that reads those replies (`@effect/ai-openai-compat`) accepts two ways of saying "no tools": leave the field out, or send an empty list. Some models say it a third way — they send an empty value, `tool_calls: null` — and the reader refuses the entire reply on the spot. The answer itself was fine; it simply never got read. The run then falls through to the second vendor configured for that step and pays for the same work twice.

## The fix

Touches: the one place where replies from model vendors are tidied up before the library reads them, plus its tests. Nothing about how the pipeline decides what to ask, or what it does with the answer once it has it.

- Batuda already wraps the connection to the model vendors so it can repair replies the library would otherwise refuse: it drops an empty `service_tier`, fills a missing timestamp, numbers unnumbered choices, and works out a missing token count from the two that did arrive. An empty `tool_calls` now joins that list.
- The repair **drops** the field rather than putting an empty list in its place. Leaving it out is already how the library reads "called no tool", so an empty list would put a claim in the model's mouth that it never made. A genuine tool call, and an empty list a model really did send, are both left exactly as they arrived.
- Every repair is logged with the names of the fields it touched, so the first vendor to need one is visible rather than silently patched over.

## Impact

- **Nothing changes for anyone using the product.** No database change, nothing touching which organisation can see what (row-level security), no new settings production must supply at boot (environment variables), and no change to the shape of anything the web app receives from the API.
- **Both ways into the research service get this**, because the repair sits on the connection to the vendor rather than inside either surface — the tools external assistants call (MCP) and the ordinary HTTP routes share it.
- **Spending goes slightly down, not up.** A reply that used to be discarded now counts, so the second vendor gets asked less often. Nothing new is called.
- **Replies that arrive as a live stream are untouched, deliberately.** The pipeline only ever uses the non-streaming path, and buffering a stream in order to repair it would collapse it. The file's own header says so.

## Review guide

- Start at `packages/research/src/infrastructure/_reply-shape.ts:73` — `repairToolCalls` is the entire change; the rest of that file is context for how the existing repairs work.
- The riskiest thing a change like this could do is make a real tool call disappear, which would leave a research run quietly doing less work than it thinks. The guard is the `!== null` test: only an explicit empty value is touched, and every other shape returns early.
- **A decision you might overrule:** a `tool_calls` that is neither a list nor empty — a string, an object, a number — is deliberately left to fail decode, so it still costs a retry. I kept the file's existing stance of only ever restating what the vendor actually said rather than guessing at what it meant. No configured vendor has been seen to do this.
- Not fixed here: the same field on the streaming path (`delta.tool_calls`). Unreachable today, and would need doing if streaming is ever adopted.

## Tests

Unit, in `_reply-shape.test.ts`: the empty value is dropped rather than replaced; a genuine tool call is left alone; an empty list the library already accepts is also left alone; and the repair shows up in the list a reply reports when several were needed at once. I confirmed the new code is load-bearing by deleting the call and re-running — one test fails without it.

## Verification

- `turbo check-types` — 14 of 14 packages clean.
- `pnpm --filter @batuda/research test` — 2,427 passing across 97 files.
- `pnpm build` — 14 of 14.
- `biome check` — no findings on either touched file.
- **Live, against a real vendor.** An eval run over the Spanish and French markets made 8 extraction calls to DeepSeek-V4-Flash that succeeded. Before this change the same model failed every one of them at decode, so the count was 0. (That model is only a candidate; production config is untouched by this PR.)
- Reviewed adversarially: the repair was driven over 15 malformed reply shapes without throwing, and all three forms — field missing, empty list, and repaired empty value — were decoded through the real library and confirmed to produce identical results, including the awkward case of a reply that claims it finished *because* of tool calls while sending none.

## Deferred

The larger question this came out of — whether the extraction step should run a model with a bigger context window at all — stays on #638. One Spanish run on the candidate model came back weak (10 rows and 1 of 5 sectors, against a 20–60 row baseline) and the French run died on the second vendor's timeout, so that swap is unproven and is not in this PR.

Addresses #638
