### PR TITLE
docs(research): make the prompt-budget comments say what the code does

### DIFF
--- a/packages/research/src/application/agent-loop.test.ts
+++ b/packages/research/src/application/agent-loop.test.ts
@@ -130,6 +130,27 @@ describe('runAgentResearchLoop', () => {
 		})
 	})
 
+	describe('when both budgets are set and the chars run out first', () => {
+		it('should halt on chars even though the provider reported usage', async () => {
+			// GIVEN rounds reporting real usage, well inside a 1000-token budget that
+			// therefore cannot fire, each adding 100 chars against a 150-char one
+			const result = await Effect.runPromise(
+				runAgentResearchLoop({
+					maxSteps: 100,
+					maxPromptChars: 150,
+					maxPromptTokens: 1000,
+					runRound: scriptedRounds([toolRound(1), toolRound(2), toolRound(3)]),
+					budgetSnapshot: Effect.succeed(snapshot(100, 100)),
+				}),
+			)
+
+			// THEN the char budget ends it at round 2, so it is not something that
+			// stands aside once the provider says what the prompt really occupies
+			expect(result.stopReason).toBe('context_full')
+			expect(result.rounds).toBe(2)
+		})
+	})
+
 	describe('when the model finishes but the target is not yet grounded', () => {
 		it('should run another round when the continue hook asks to keep going', async () => {
 			// GIVEN the model finishes each round, and the grounding hook asks to
@@ -267,9 +288,9 @@ describe('runAgentResearchLoop — token budget', () => {
 	})
 
 	describe('when usage is absent but a char budget is set', () => {
-		it('should still halt on the char backstop', async () => {
+		it('should still halt on the char budget', async () => {
 			// GIVEN 0-token rounds that each add 100 prompt chars, a 100-token budget
-			// and a 150-char backstop
+			// and a 150-char one
 			const charRound: LoopRound = {
 				...toolRound(1),
 				inputTokens: 0,

--- a/packages/research/src/application/agent-loop.ts
+++ b/packages/research/src/application/agent-loop.ts
@@ -63,15 +63,22 @@ export const canAffordAnotherRound = (snapshot: BudgetSnapshot): boolean =>
 
 export interface RunAgentResearchLoopParams<E, R> {
 	readonly maxSteps: number
-	/** Character budget for the accumulated prompt; stops the loop before the
-	 * agent model's context window overflows. Omitted = unbounded. */
+	/**
+	 * Character budget for the accumulated prompt, summed over what each round
+	 * adds. Checked before the token budget below, and never conditional on the
+	 * provider reporting usage — it is live on every run, not a fallback for when
+	 * usage is missing, so it can be the cap that ends the loop even where a token
+	 * budget is set too. Omitted = unbounded.
+	 */
 	readonly maxPromptChars?: number | undefined
 	/**
 	 * Token budget compared against the LATEST round's inputTokens — the
 	 * provider-reported occupancy of the whole current prompt, so it is NOT
-	 * accumulated like promptChars. This is the primary depth stop; the char cap
-	 * is the provider-independent backstop for when usage is unavailable (then
-	 * inputTokens is 0 and this never fires). Omitted = no token stop.
+	 * accumulated like promptChars. It counts the real prompt instead of
+	 * estimating it, but it is checked second, and a provider that omits usage
+	 * leaves inputTokens at 0 so it never fires at all. Both caps stop with the
+	 * same reason, so which of the two ended a loop is not visible afterwards.
+	 * Omitted = no token stop.
 	 */
 	readonly maxPromptTokens?: number | undefined
 	readonly runRound: (round: number) => Effect.Effect<LoopRound, E, R>
@@ -118,9 +125,8 @@ export const runAgentResearchLoop = <E, R>(
 
 			// The stop conditions are independent: the model finishing (unless the
 			// grounding-retry hook asks for one more round), the step cap, the prompt
-			// outgrowing the context window (a token budget on the latest round's
-			// occupancy, with the char cap as a provider-independent backstop), and
-			// the budget each end the loop on their own.
+			// outgrowing the context window (the char budget or the token budget,
+			// whichever is met first), and the budget each end the loop on their own.
 
 			// The hook below can send a finished model back out, and a ceiling met on
 			// a round the model had already finished stopped the hook's errand rather

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -317,10 +317,14 @@ const boundedToolResult = (value: unknown, maxChars = 4000): string => {
 // success with fabricated findings.
 const MIN_GROUNDED_SOURCES = 1
 
-// Provider-independent backstop for the reflect-loop depth: a rough character
-// budget on the accumulated prompt (which re-sends every round's tool results),
-// used when the model provider omits token usage so the token budget below can't
-// fire. Scrapes are capped per page but many of them still add up.
+// Character ceiling on how deep the reflect loop may go. Each round's tool
+// results stay in the prompt for every round after it, so summing what each
+// round adds tracks how large the prompt has grown. Checked before the token
+// budget and never conditional on the provider reporting usage: it is live on
+// every run, not a fallback for when usage is missing. At roughly four
+// characters to the token it lands near the 24k tokens that budget runs at in
+// production, so raising either of the two on its own barely moves where a
+// search stops. Scrapes are capped per page but many still add up.
 const MAX_LOOP_PROMPT_CHARS = 90000
 
 // How much full fetched-page text phase-2 extraction may read on top of the
@@ -1951,8 +1955,13 @@ export class ResearchService extends Context.Service<ResearchService>()(
 			// search, so it is required with no default — like the concurrency cap.
 			const maxAgentSteps = yield* Config.int('RESEARCH_MAX_AGENT_STEPS')
 			// How many prompt tokens the reflect loop may reach before it stops
-			// searching, so a bigger-context model can look further. Required with no
-			// default — set per the chosen agent model's context window.
+			// searching. Required with no default — sized to the smallest context
+			// window that has to hold the transcript afterwards, which today is the
+			// extract tier's model and not the agent model that runs the loop;
+			// MAX_EXTRACTION_PAGE_CHARS above carries the arithmetic. It bounds one
+			// pass, so a run that searches again stacks a further pass's transcript on
+			// top of it. Raising this without raising MAX_LOOP_PROMPT_CHARS too leaves
+			// the search stopping in the same place.
 			const maxLoopPromptTokens = yield* Config.int(
 				'RESEARCH_MAX_LOOP_PROMPT_TOKENS',
 			)


### PR DESCRIPTION
## What

Three comments in the research engine described one budget, and two of them stated a rule the code does not follow. Nobody can see this from the outside — nothing about how a search runs changes here — but acting on either comment has already cost real money and real runs, mine included. This corrects them, in the research package (`packages/research`).

The part of the pipeline that searches, reads what it found, and decides whether to search again is stopped by two ceilings. One counts tokens, the unit a language model charges and thinks in; the other counts plain characters. Both report the same thing when they fire: the search ran out of room. The comment sitting on the token one said it should be set against the window of the model doing the searching. It should not — it is sized against the model that has to *read the transcript afterwards*, which is a different, smaller model. The comment on the character one called it a fallback for when a vendor forgets to report usage. It is not a fallback: it is checked first and applies always.

## The fix

Touches: the two ceilings that stop the search loop, the comments describing them in the loop itself and at the two places they are configured, and one new test. No runtime behaviour, and no configured value, changes.

- The rule on the token value now names the constraint that actually governs it — the smallest context window that has to hold the transcript afterwards, which today is the extraction step's model and not the agent model running the loop — and points at where the arithmetic is already written down.
- The character ceiling is no longer described as a fallback. It is checked before the token one and never depends on a vendor reporting usage, so it is frequently the thing that actually stops a search.
- The pairing between the two is written down, because raising one and leaving the other is a silent no-op. That is not hypothetical: it is what I measured and misread as "the change did nothing".
- The same wrong sentence lived in a fourth place, inside the loop body. It is gone too.

## Impact

- **Nothing changes for anyone using the product**, and nothing changes for the machines running it. No database change, no change to which organisation can see what (row-level security), no new settings production must supply at boot (environment variables), no change to the shape of anything the web app receives from the API. The two files carrying the corrected comments change **zero** executable lines — I checked by filtering the diff.
- **No configured value moves.** Choosing better values is deliberately not this PR; it needs the extraction step to be able to read more first, which is #638.
- **The one behavioural guard added is a test**, not production code.

## Review guide

- The whole change is four comment blocks and one test. If you read one thing, read the comment on `RESEARCH_MAX_LOOP_PROMPT_TOKENS` in `research-service.ts` — that is the sentence that misled me into a change which killed every run.
- The risk in a change like this is not a crash; it is shipping *another* untrue sentence. So I had every factual claim in the new wording verified line by line against the source, independently, and fixed the two that did not hold: I had called the two ceilings "the same ceiling" when one of them is an environment value and so only equal in today's deployment, and I had written that the character cap "wins" when both are met, which implies a distinction that does not exist — both stop with the identical reason, which is exactly why a failed raise looks like nothing happened.
- **One claim you might still want to weaken.** "Which today is the extract tier's model" is true of the current configuration but is not provable from code, since every tier's model is set by environment variable. I hedged it with "today" rather than dropping it, because the correction is the whole point of the issue. Say the word if you would rather it were vaguer.
- **A decision I made:** I did not move the token value from an environment variable to a constant beside its character sibling, even though the pairing comment is only strictly true while production is set to 24k. That is a design change, and it belongs with the re-derivation on #638.

## Tests

One added, in `agent-loop.test.ts`. It pins the character ceiling firing while the vendor *is* reporting usage and the token budget is unmet — the situation production actually runs in, which nothing covered: one existing test has usage but no token budget, the other has a token budget but no usage.

I checked it earns its place rather than assuming it. Two obvious mutations of the character check were caught by existing tests as well, which would have made it redundant. The third — making the character cap stand aside whenever the token cap *can* do its job, which is the most faithful implementation of what the old comment claimed — is caught by **this test alone**, 15 of 16 passing without it.

## Verification

- `turbo check-types` — 14 of 14 packages clean.
- `pnpm --filter @batuda/research test` — 2,428 passing across 97 files.
- `pnpm build` — 14 of 14.
- `biome check` — no findings on any of the three files.
- Code review at high effort — no findings.
- Not run: a live research run. Nothing executable changed in production code, so there is no runtime behaviour here for a live run to exercise.

## Deferred

Choosing new values for either ceiling, and giving the extraction step a model that can read more, are #638. The measurement taken so far is not a green light: freed of these ceilings the Spanish market returned 119 rows instead of 20–56, but the share of them anyone could locate fell from 70–92% to 5%. That is a quality trade, not a win, and it needs more than one run per market before anything ships.

Closes #632
